### PR TITLE
fix(dashboard): stabilize skills catalog identity

### DIFF
--- a/platform/daemon/src/routes/skills.test.ts
+++ b/platform/daemon/src/routes/skills.test.ts
@@ -547,9 +547,14 @@ This is a test skill.`,
 			const signetSkills = body.results.filter((s: { provider: string }) => s.provider === "signet");
 			expect(signetSkills.length).toBeGreaterThan(0);
 
-			// Verify signet skills use repo path as fullName, not signet@ prefix
+			// Verify signet skills keep repo path as the install source but expose
+			// per-skill catalog keys for keyed UI rendering and compare state.
+			const catalogKeys = new Set<string>();
 			for (const skill of signetSkills) {
 				expect(skill.fullName).toBe("Signet-AI/signetai");
+				expect(skill.catalogKey).toBe(`signet:Signet-AI/signetai:${skill.name}`);
+				expect(catalogKeys.has(skill.catalogKey)).toBe(false);
+				catalogKeys.add(skill.catalogKey);
 				expect(skill.official).toBe(true);
 			}
 

--- a/platform/daemon/src/routes/skills.ts
+++ b/platform/daemon/src/routes/skills.ts
@@ -91,6 +91,7 @@ type ClawhubItem = {
 type SkillBrowseResult = {
 	name: string;
 	fullName: string;
+	catalogKey: string;
 	installs: string;
 	installsRaw: number;
 	popularityScore: number;
@@ -233,6 +234,24 @@ function calculateSkillPopularity(input: {
 	return input.installsRaw + stars * 200 + verifiedBoost;
 }
 
+function createSkillBrowseResult(input: Omit<SkillBrowseResult, "catalogKey">): SkillBrowseResult {
+	return {
+		...input,
+		catalogKey: `${input.provider}:${input.fullName}:${input.name}`,
+	};
+}
+
+function dedupeSkillBrowseResults(results: SkillBrowseResult[]): SkillBrowseResult[] {
+	const byKey = new Map<string, SkillBrowseResult>();
+	for (const result of results) {
+		const existing = byKey.get(result.catalogKey);
+		if (!existing || result.popularityScore > existing.popularityScore) {
+			byKey.set(result.catalogKey, result);
+		}
+	}
+	return Array.from(byKey.values());
+}
+
 async function fetchCatalog(): Promise<CatalogEntry[]> {
 	const now = Date.now();
 	if (catalogCache.length > 0 && now - catalogFetchedAt < CATALOG_TTL) {
@@ -343,7 +362,7 @@ function listSignetOfficialSkills(): SkillBrowseResult[] {
 				const meta = parseSkillFrontmatter(content);
 				const isBuiltin = /^builtin:\s*true$/m.test(content);
 				return [
-					{
+					createSkillBrowseResult({
 						name: d.name,
 						fullName: "Signet-AI/signetai",
 						installs: isBuiltin ? "built-in" : "--",
@@ -359,7 +378,7 @@ function listSignetOfficialSkills(): SkillBrowseResult[] {
 						permissions: meta.permissions,
 						official: true,
 						builtin: isBuiltin,
-					},
+					}),
 				];
 			} catch {
 				return [];
@@ -917,43 +936,51 @@ export function mountSkillsRoutes(app: Hono, _authMode: AuthMode = "local"): voi
 		const installed = listInstalledSkills().map((s) => s.name);
 		const signetNames = new Set(signetSkills.map((s) => s.name));
 
-		const skillsShResults: SkillBrowseResult[] = skillsShCatalog.map((s) => ({
-			name: s.name,
-			fullName: `${s.source}@${s.skillId}`,
-			installs: formatInstalls(s.installs),
-			installsRaw: s.installs,
-			popularityScore: calculateSkillPopularity({ installsRaw: s.installs }),
-			description: "",
-			installed: installed.includes(s.name),
-			provider: "skills.sh" as const,
-			category: inferSkillCategory(`${s.name} ${s.skillId} ${s.source}`),
-			downloads: s.installs,
-			maintainer: s.source.split("/")[0] || undefined,
-		}));
-
-		const clawhubResults: SkillBrowseResult[] = clawhubItems.map((s) => ({
-			name: s.slug,
-			fullName: `clawhub@${s.slug}`,
-			installs: formatInstalls(s.stats.installsAllTime),
-			installsRaw: s.stats.installsAllTime,
-			popularityScore: calculateSkillPopularity({
-				installsRaw: s.stats.installsAllTime,
-				stars: s.stats.stars,
+		const skillsShResults: SkillBrowseResult[] = skillsShCatalog.map((s) =>
+			createSkillBrowseResult({
+				name: s.name,
+				fullName: `${s.source}@${s.skillId}`,
+				installs: formatInstalls(s.installs),
+				installsRaw: s.installs,
+				popularityScore: calculateSkillPopularity({ installsRaw: s.installs }),
+				description: "",
+				installed: installed.includes(s.name),
+				provider: "skills.sh" as const,
+				category: inferSkillCategory(`${s.name} ${s.skillId} ${s.source}`),
+				downloads: s.installs,
+				maintainer: s.source.split("/")[0] || undefined,
 			}),
-			description: s.summary,
-			installed: installed.includes(s.slug),
-			provider: "clawhub" as const,
-			category: inferSkillCategory(`${s.slug} ${s.summary} ${s.tags.latest}`),
-			stars: s.stats.stars,
-			downloads: s.stats.downloads,
-			versions: s.stats.versions,
-			author: s.displayName,
-			maintainer: s.displayName,
-		}));
+		);
+
+		const clawhubResults: SkillBrowseResult[] = clawhubItems.map((s) =>
+			createSkillBrowseResult({
+				name: s.slug,
+				fullName: `clawhub@${s.slug}`,
+				installs: formatInstalls(s.stats.installsAllTime),
+				installsRaw: s.stats.installsAllTime,
+				popularityScore: calculateSkillPopularity({
+					installsRaw: s.stats.installsAllTime,
+					stars: s.stats.stars,
+				}),
+				description: s.summary,
+				installed: installed.includes(s.slug),
+				provider: "clawhub" as const,
+				category: inferSkillCategory(`${s.slug} ${s.summary} ${s.tags.latest}`),
+				stars: s.stats.stars,
+				downloads: s.stats.downloads,
+				versions: s.stats.versions,
+				author: s.displayName,
+				maintainer: s.displayName,
+			}),
+		);
 
 		// Deduplicate: prefer signet provider when a skill exists in multiple sources
-		const external = [...skillsShResults, ...clawhubResults].filter((s) => !signetNames.has(s.name));
-		const results = [...signetSkills, ...external].sort((a, b) => b.popularityScore - a.popularityScore);
+		const external = dedupeSkillBrowseResults([...skillsShResults, ...clawhubResults]).filter(
+			(s) => !signetNames.has(s.name),
+		);
+		const results = dedupeSkillBrowseResults([...signetSkills, ...external]).sort(
+			(a, b) => b.popularityScore - a.popularityScore,
+		);
 		return c.json({ results, total: results.length });
 	});
 
@@ -985,19 +1012,21 @@ export function mountSkillsRoutes(app: Hono, _authMode: AuthMode = "local"): voi
 							source: string;
 						}>;
 					};
-					return (data.skills ?? []).map((s) => ({
-						name: s.name,
-						fullName: `${s.source}@${s.skillId}`,
-						installs: formatInstalls(s.installs),
-						installsRaw: s.installs,
-						popularityScore: calculateSkillPopularity({ installsRaw: s.installs }),
-						description: "",
-						installed: installed.includes(s.name),
-						provider: "skills.sh" as const,
-						category: inferSkillCategory(`${s.name} ${s.skillId} ${s.source}`),
-						downloads: s.installs,
-						maintainer: s.source.split("/")[0] || undefined,
-					}));
+					return (data.skills ?? []).map((s) =>
+						createSkillBrowseResult({
+							name: s.name,
+							fullName: `${s.source}@${s.skillId}`,
+							installs: formatInstalls(s.installs),
+							installsRaw: s.installs,
+							popularityScore: calculateSkillPopularity({ installsRaw: s.installs }),
+							description: "",
+							installed: installed.includes(s.name),
+							provider: "skills.sh" as const,
+							category: inferSkillCategory(`${s.name} ${s.skillId} ${s.source}`),
+							downloads: s.installs,
+							maintainer: s.source.split("/")[0] || undefined,
+						}),
+					);
 				} catch (err) {
 					logger.error("skills", "skills.sh search failed", err as Error);
 					return [];
@@ -1012,25 +1041,27 @@ export function mountSkillsRoutes(app: Hono, _authMode: AuthMode = "local"): voi
 							s.displayName.toLowerCase().includes(lowerQuery) ||
 							s.summary.toLowerCase().includes(lowerQuery),
 					)
-					.map((s) => ({
-						name: s.slug,
-						fullName: `clawhub@${s.slug}`,
-						installs: formatInstalls(s.stats.installsAllTime),
-						installsRaw: s.stats.installsAllTime,
-						popularityScore: calculateSkillPopularity({
+					.map((s) =>
+						createSkillBrowseResult({
+							name: s.slug,
+							fullName: `clawhub@${s.slug}`,
+							installs: formatInstalls(s.stats.installsAllTime),
 							installsRaw: s.stats.installsAllTime,
+							popularityScore: calculateSkillPopularity({
+								installsRaw: s.stats.installsAllTime,
+								stars: s.stats.stars,
+							}),
+							description: s.summary,
+							installed: installed.includes(s.slug),
+							provider: "clawhub" as const,
+							category: inferSkillCategory(`${s.slug} ${s.summary} ${s.tags.latest}`),
 							stars: s.stats.stars,
+							downloads: s.stats.downloads,
+							versions: s.stats.versions,
+							author: s.displayName,
+							maintainer: s.displayName,
 						}),
-						description: s.summary,
-						installed: installed.includes(s.slug),
-						provider: "clawhub" as const,
-						category: inferSkillCategory(`${s.slug} ${s.summary} ${s.tags.latest}`),
-						stars: s.stats.stars,
-						downloads: s.stats.downloads,
-						versions: s.stats.versions,
-						author: s.displayName,
-						maintainer: s.displayName,
-					}));
+					);
 			})(),
 		]);
 
@@ -1039,8 +1070,12 @@ export function mountSkillsRoutes(app: Hono, _authMode: AuthMode = "local"): voi
 			(s) => s.name.toLowerCase().includes(lowerQuery) || s.description.toLowerCase().includes(lowerQuery),
 		);
 		const signetNames = new Set(signetFiltered.map((s) => s.name));
-		const external = [...skillsShResults, ...clawhubFiltered].filter((s) => !signetNames.has(s.name));
-		const results = [...signetFiltered, ...external].sort((a, b) => b.popularityScore - a.popularityScore);
+		const external = dedupeSkillBrowseResults([...skillsShResults, ...clawhubFiltered]).filter(
+			(s) => !signetNames.has(s.name),
+		);
+		const results = dedupeSkillBrowseResults([...signetFiltered, ...external]).sort(
+			(a, b) => b.popularityScore - a.popularityScore,
+		);
 		return c.json({ results });
 	});
 

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -1844,6 +1844,7 @@ export interface Skill {
 export interface SkillSearchResult {
 	name: string;
 	fullName: string;
+	catalogKey?: string;
 	installs: string;
 	installsRaw?: number;
 	popularityScore?: number;

--- a/surfaces/dashboard/src/lib/components/skills/SkillGrid.svelte
+++ b/surfaces/dashboard/src/lib/components/skills/SkillGrid.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Skill, SkillSearchResult } from "$lib/api";
+import { skillIdentityKey, skillRenderKey, skillSource } from "$lib/skills/skill-identity";
 import SkillCard from "./SkillCard.svelte";
 import SkillsEmptyState from "./SkillsEmptyState.svelte";
 
@@ -12,8 +13,8 @@ type Props = {
 	selectedName?: string | null;
 	installing?: string | null;
 	uninstalling?: string | null;
-	onitemclick?: (name: string) => void;
-	oninstall?: (name: string) => void;
+	onitemclick?: (name: string, source?: string) => void;
+	oninstall?: (name: string, source?: string) => void;
 	onuninstall?: (name: string) => void;
 	emptyState?: EmptyStateKind | null;
 	onemptyaction?: (action: "primary" | "secondary") => void;
@@ -43,12 +44,8 @@ const {
 	onreviewrequest,
 }: Props = $props();
 
-function isSearchResult(i: Skill | SkillSearchResult): i is SkillSearchResult {
-	return "installed" in i && "fullName" in i;
-}
-
 function skillKey(i: Skill | SkillSearchResult): string {
-	return isSearchResult(i) ? i.fullName : i.name;
+	return skillIdentityKey(i);
 }
 
 const emptyActions = $derived.by(() => {
@@ -98,7 +95,7 @@ const remainingCount = $derived(items.length - visibleCount);
 				<div class="featured-count">{featuredItems.length} featured</div>
 			</div>
 			<div class="grid featured-grid">
-				{#each featuredItems as item (skillKey(item))}
+				{#each featuredItems as item, index (skillRenderKey(item, index))}
 					<SkillCard
 						{item}
 						{mode}
@@ -107,8 +104,8 @@ const remainingCount = $derived(items.length - visibleCount);
 						installing={installing === item.name}
 						uninstalling={uninstalling === item.name}
 						compareSelected={compareSelectedKeys.includes(skillKey(item))}
-						onclick={() => onitemclick?.(item.name)}
-						oninstall={() => oninstall?.(item.name)}
+						onclick={() => onitemclick?.(item.name, skillSource(item))}
+						oninstall={() => oninstall?.(item.name, skillSource(item))}
 						onuninstall={() => onuninstall?.(item.name)}
 						oncomparetoggle={() => oncomparetoggle?.(skillKey(item))}
 					/>
@@ -120,7 +117,7 @@ const remainingCount = $derived(items.length - visibleCount);
 	{#if items.length > 0}
 		<!-- Main grid -->
 		<div class="grid">
-			{#each visibleItems as item (skillKey(item))}
+			{#each visibleItems as item, index (skillRenderKey(item, index))}
 				<SkillCard
 					{item}
 					{mode}
@@ -128,8 +125,8 @@ const remainingCount = $derived(items.length - visibleCount);
 					installing={installing === item.name}
 					uninstalling={uninstalling === item.name}
 					compareSelected={compareSelectedKeys.includes(skillKey(item))}
-					onclick={() => onitemclick?.(item.name)}
-					oninstall={() => oninstall?.(item.name)}
+					onclick={() => onitemclick?.(item.name, skillSource(item))}
+					oninstall={() => oninstall?.(item.name, skillSource(item))}
 					onuninstall={() => onuninstall?.(item.name)}
 					oncomparetoggle={() => oncomparetoggle?.(skillKey(item))}
 				/>

--- a/surfaces/dashboard/src/lib/components/skills/SkillsComparePanel.svelte
+++ b/surfaces/dashboard/src/lib/components/skills/SkillsComparePanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { SkillSearchResult } from "$lib/api";
 import { computePermissionFootprint } from "$lib/skills/risk-profile";
+import { skillIdentityKey } from "$lib/skills/skill-identity";
 
 type Props = {
 	items: SkillSearchResult[];
@@ -8,10 +9,15 @@ type Props = {
 	onClear: () => void;
 };
 
+// biome-ignore lint/style/useConst: Svelte updates destructured $props bindings when parents pass new values.
 let { items, onRemove, onClear }: Props = $props();
 
 function itemKey(item: SkillSearchResult): string {
-	return item.fullName;
+	return skillIdentityKey(item);
+}
+
+function itemRenderKey(item: SkillSearchResult, index: number): string {
+	return `${itemKey(item)}:${index}`;
 }
 
 function formatCount(value: number | undefined): string {
@@ -52,7 +58,7 @@ function verifiedLabel(item: SkillSearchResult): string {
 				</tr>
 			</thead>
 			<tbody>
-				{#each items as item (itemKey(item))}
+				{#each items as item, index (itemRenderKey(item, index))}
 					<tr>
 						<td>{item.name}</td>
 						<td>{maintainerLabel(item)}</td>

--- a/surfaces/dashboard/src/lib/components/tabs/MarketplaceTab.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/MarketplaceTab.svelte
@@ -10,6 +10,7 @@ import { Button } from "$lib/components/ui/button/index.js";
 import * as Collapsible from "$lib/components/ui/collapsible/index.js";
 import * as Select from "$lib/components/ui/select/index.js";
 import { ChevronDown } from "$lib/icons";
+import { skillIdentityKey } from "$lib/skills/skill-identity";
 import { returnToSidebar } from "$lib/stores/focus.svelte";
 import {
 	fetchMarketplaceMcpCatalog,
@@ -266,7 +267,7 @@ function getMarketplaceSkillEmptyState(): "installed" | "browse" | "search" | nu
 function getMarketplaceCompareItems(): SkillSearchResult[] {
 	return getMarketplaceSkillItems()
 		.filter((item): item is SkillSearchResult => "fullName" in item)
-		.filter((item) => sk.compareSelected.includes(item.fullName));
+		.filter((item) => sk.compareSelected.includes(skillIdentityKey(item)));
 }
 
 function handleMarketplaceSkillEmptyAction(action: "primary" | "secondary"): void {
@@ -898,8 +899,8 @@ $effect(() => {
 							selectedName={sk.selectedName}
 							installing={sk.installing}
 							uninstalling={sk.uninstalling}
-							onitemclick={(name) => openDetail(name)}
-							oninstall={(name) => doInstall(name)}
+							onitemclick={(name, source) => openDetail(name, source)}
+							oninstall={(name, source) => doInstall(name, source)}
 							onuninstall={(name) => doUninstall(name)}
 							emptyState={getMarketplaceSkillEmptyState()}
 							onemptyaction={handleMarketplaceSkillEmptyAction}

--- a/surfaces/dashboard/src/lib/components/tabs/SkillsTab.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/SkillsTab.svelte
@@ -6,6 +6,7 @@ import SkillsComparePanel from "$lib/components/skills/SkillsComparePanel.svelte
 import { getFeaturedOfficialSkills, omitFeaturedSkills } from "$lib/components/skills/featured-skills";
 import * as Select from "$lib/components/ui/select/index.js";
 import * as Tabs from "$lib/components/ui/tabs/index.js";
+import { skillIdentityKey } from "$lib/skills/skill-identity";
 import {
 	type ProviderFilter,
 	type SkillsView,
@@ -144,7 +145,7 @@ const emptyState = $derived<"installed" | "browse" | "search" | null>(
 
 const compareItems = $derived.by(() => {
 	const available = displayItems.filter((item): item is SkillSearchResult => "fullName" in item);
-	return available.filter((item) => sk.compareSelected.includes(item.fullName));
+	return available.filter((item) => sk.compareSelected.includes(skillIdentityKey(item)));
 });
 
 const showLoading = $derived.by(() => {
@@ -344,8 +345,8 @@ onMount(() => {
 			selectedName={sk.selectedName}
 			installing={sk.installing}
 			uninstalling={sk.uninstalling}
-			onitemclick={(name) => openDetail(name)}
-			oninstall={(name) => doInstall(name)}
+			onitemclick={(name, source) => openDetail(name, source)}
+			oninstall={(name, source) => doInstall(name, source)}
 			onuninstall={(name) => doUninstall(name)}
 			emptyState={emptyState}
 			onemptyaction={handleEmptyAction}

--- a/surfaces/dashboard/src/lib/skills/skill-identity.test.ts
+++ b/surfaces/dashboard/src/lib/skills/skill-identity.test.ts
@@ -1,0 +1,47 @@
+// @ts-nocheck
+import { describe, expect, it } from "bun:test";
+import { skillIdentityKey, skillRenderKey } from "./skill-identity";
+
+describe("skill identity keys", () => {
+	it("uses server catalog keys when present", () => {
+		expect(
+			skillIdentityKey({
+				name: "remember",
+				fullName: "Signet-AI/signetai",
+				catalogKey: "signet:Signet-AI/signetai:remember",
+				installs: "built-in",
+				description: "Save memories",
+				installed: true,
+				provider: "signet",
+			}),
+		).toBe("signet:Signet-AI/signetai:remember");
+	});
+
+	it("separates cached official skills that share the same install source", () => {
+		const recall = {
+			name: "recall",
+			fullName: "Signet-AI/signetai",
+			installs: "built-in",
+			description: "Recall memories",
+			installed: true,
+			provider: "signet" as const,
+		};
+		const remember = { ...recall, name: "remember", description: "Save memories" };
+
+		expect(skillIdentityKey(recall)).toBe("signet:Signet-AI/signetai:recall");
+		expect(skillIdentityKey(remember)).toBe("signet:Signet-AI/signetai:remember");
+	});
+
+	it("adds the render index so exact duplicate rows cannot crash keyed each blocks", () => {
+		const duplicate = {
+			name: "web-search",
+			fullName: "someone/skills@web-search",
+			installs: "10",
+			description: "Search",
+			installed: false,
+			provider: "skills.sh" as const,
+		};
+
+		expect(skillRenderKey(duplicate, 0)).not.toBe(skillRenderKey(duplicate, 1));
+	});
+});

--- a/surfaces/dashboard/src/lib/skills/skill-identity.ts
+++ b/surfaces/dashboard/src/lib/skills/skill-identity.ts
@@ -1,0 +1,21 @@
+import type { Skill, SkillSearchResult } from "$lib/api";
+
+export function isSkillSearchResult(item: Skill | SkillSearchResult): item is SkillSearchResult {
+	return "installed" in item && "fullName" in item;
+}
+
+export function skillIdentityKey(item: Skill | SkillSearchResult): string {
+	if (isSkillSearchResult(item)) {
+		if (item.catalogKey) return item.catalogKey;
+		return `${item.provider ?? "external"}:${item.fullName}:${item.name}`;
+	}
+	return `installed:${item.name}`;
+}
+
+export function skillRenderKey(item: Skill | SkillSearchResult, index: number): string {
+	return `${skillIdentityKey(item)}:${index}`;
+}
+
+export function skillSource(item: Skill | SkillSearchResult): string | undefined {
+	return isSkillSearchResult(item) ? item.fullName : undefined;
+}

--- a/surfaces/dashboard/src/lib/stores/skills.svelte.ts
+++ b/surfaces/dashboard/src/lib/stores/skills.svelte.ts
@@ -282,7 +282,13 @@ export async function doSearch(): Promise<void> {
 	sk.searching = false;
 }
 
-export async function openDetail(name: string): Promise<void> {
+function findCatalogMatch(name: string, source?: string): SkillSearchResult | undefined {
+	const matches = [...sk.results, ...sk.catalog].filter((s) => s.name === name);
+	if (source) return matches.find((s) => s.fullName === source) ?? matches[0];
+	return matches[0];
+}
+
+export async function openDetail(name: string, source?: string): Promise<void> {
 	sk.selectedName = name;
 	sk.detailOpen = true;
 	sk.detailLoading = true;
@@ -290,11 +296,11 @@ export async function openDetail(name: string): Promise<void> {
 	sk.detailMeta = null;
 
 	// Find source from search results or catalog for remote fetch
-	const match = sk.results.find((s) => s.name === name) || sk.catalog.find((s) => s.name === name);
+	const match = findCatalogMatch(name, source);
 	sk.detailSource = match ?? null;
-	const source = match?.fullName || undefined;
+	const detailSource = source ?? match?.fullName;
 
-	const detail = await getSkill(name, source);
+	const detail = await getSkill(name, detailSource);
 	if (detail) {
 		sk.detailMeta = detail;
 		sk.detailContent = (detail as SkillDetail).content ?? "";
@@ -310,12 +316,14 @@ export function closeDetail(): void {
 	sk.detailSource = null;
 }
 
-export async function doInstall(name: string): Promise<void> {
+export async function doInstall(name: string, source?: string): Promise<void> {
 	sk.installing = name;
-	// Look up fullName from search results or catalog
-	const match = sk.results.find((s) => s.name === name) || sk.catalog.find((s) => s.name === name);
-	const source = match?.fullName || undefined;
-	const result = await installSkill(name, source);
+	// Look up fullName from search results, the active detail pane, or catalog.
+	const detailSource = sk.detailOpen && sk.selectedName === name ? sk.detailSource?.fullName : undefined;
+	const requestedSource = source ?? detailSource;
+	const match = findCatalogMatch(name, requestedSource);
+	const installSource = requestedSource ?? match?.fullName;
+	const result = await installSkill(name, installSource);
 	if (result.success) {
 		toast(`Skill ${name} installed`, "success");
 		await fetchInstalled({ force: true });


### PR DESCRIPTION
## Summary

Fixes #868 by separating skill install source identity from dashboard render identity.

- adds backend `catalogKey` values for skills browse/search results
- keeps `fullName` as the install/detail source while giving Svelte unique UI keys
- uses a shared dashboard identity helper for grid and compare rows, including stale cached rows
- routes card/detail install actions with the selected catalog source so duplicate skill names do not install the wrong provider
- adds regression coverage for official Signet skills that share `fullName` and exact duplicate cached rows

## Verification

- `bun test platform/daemon/src/routes/skills.test.ts surfaces/dashboard/src/lib/skills/skill-identity.test.ts surfaces/dashboard/src/lib/components/skills/featured-skills.test.ts`
- `bunx biome check platform/daemon/src/routes/skills.ts platform/daemon/src/routes/skills.test.ts surfaces/dashboard/src/lib/skills/skill-identity.ts surfaces/dashboard/src/lib/skills/skill-identity.test.ts surfaces/dashboard/src/lib/components/skills/SkillGrid.svelte surfaces/dashboard/src/lib/components/skills/SkillsComparePanel.svelte surfaces/dashboard/src/lib/components/tabs/SkillsTab.svelte surfaces/dashboard/src/lib/components/tabs/MarketplaceTab.svelte surfaces/dashboard/src/lib/stores/skills.svelte.ts surfaces/dashboard/src/lib/api.ts`
- `bun run --filter '@signet/daemon' build`
- `autoreview` returned no findings

## Notes

`cd surfaces/dashboard && bun run check` still reports pre-existing unrelated errors in `api.ts` login result typing and `bun:test` type resolution for test files; no touched skills files were reported by the targeted check output.
