### PR TITLE
fix(dashboard): generate daily brief gaps from saved memories

### DIFF
--- a/platform/daemon-rs/crates/signet-pipeline/src/reflection_worker.rs
+++ b/platform/daemon-rs/crates/signet-pipeline/src/reflection_worker.rs
@@ -12,7 +12,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use chrono::{DateTime, Utc};
 use rusqlite::{OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use signet_core::db::{DbPool, Priority};
@@ -24,6 +24,7 @@ use uuid::Uuid;
 const POLL_INTERVAL_MS: i64 = 300_000;
 const MINUTE_MS: i64 = 60_000;
 const DAY_MS: i64 = 24 * 60 * MINUTE_MS;
+const DAILY_BRIEF_MEMORY_BATCH_SIZE: usize = 50;
 
 #[derive(Debug, Error)]
 pub enum ReflectionWorkerError {
@@ -222,6 +223,53 @@ fn trim_line(text: &str, max: usize) -> String {
     }
 }
 
+fn is_question_led_insight(text: &str) -> bool {
+    let normalized = text
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase();
+    if normalized.ends_with('?') {
+        return true;
+    }
+    let first = normalized.split_whitespace().next().unwrap_or_default();
+    if !matches!(
+        first,
+        "has"
+            | "have"
+            | "does"
+            | "did"
+            | "do"
+            | "is"
+            | "are"
+            | "was"
+            | "were"
+            | "can"
+            | "could"
+            | "will"
+            | "would"
+            | "should"
+            | "what"
+            | "which"
+            | "who"
+            | "when"
+            | "where"
+            | "why"
+            | "how"
+    ) {
+        return false;
+    }
+    normalized
+        .chars()
+        .take_while(|ch| !matches!(ch, '.' | '!' | '?'))
+        .count()
+        < normalized.chars().count()
+        && normalized
+            .chars()
+            .take_while(|ch| !matches!(ch, '.' | '!'))
+            .any(|ch| ch == '?')
+}
+
 pub fn parse_daily_brief_insights(text: &str, limit: usize) -> Vec<DailyBriefInsight> {
     let mut insights = Vec::new();
     let mut pending: Option<String> = None;
@@ -234,11 +282,15 @@ pub fn parse_daily_brief_insights(text: &str, limit: usize) -> Vec<DailyBriefIns
     ) {
         let Some(raw) = pending.take() else { return };
         let summary = trim_line(&raw, 420);
-        insights.push(DailyBriefInsight {
-            question: summary.contains('?').then_some(summary.clone()),
-            summary,
-            patterns: std::mem::take(patterns),
-        });
+        if !summary.is_empty() && !is_question_led_insight(&summary) {
+            insights.push(DailyBriefInsight {
+                question: None,
+                summary,
+                patterns: std::mem::take(patterns),
+            });
+        } else {
+            patterns.clear();
+        }
     }
 
     for raw_line in text.lines() {
@@ -246,27 +298,22 @@ pub fn parse_daily_brief_insights(text: &str, limit: usize) -> Vec<DailyBriefIns
         if line.is_empty() {
             continue;
         }
-        let upper = line.to_ascii_uppercase();
         let cleaned = line
             .strip_prefix("- ")
             .or_else(|| line.strip_prefix("* "))
             .unwrap_or(line)
             .trim();
-        let cleaned_upper = cleaned.to_ascii_uppercase();
-        if let Some((_, value)) = cleaned.split_once(':') {
-            if cleaned_upper.starts_with("INSIGHT:")
-                || cleaned_upper.starts_with("QUESTION:")
-                || cleaned_upper.starts_with("BRIEF:")
-            {
+        if let Some((label, value)) = cleaned.split_once(':') {
+            let label_upper = label.trim().to_ascii_uppercase();
+            if matches!(
+                label_upper.as_str(),
+                "BRIEF" | "GAP" | "INSIGHT" | "SUMMARY"
+            ) {
                 flush(&mut insights, &mut pending, &mut patterns);
                 pending = Some(value.trim().to_string());
                 continue;
             }
-            if pending.is_some()
-                && (upper.starts_with("FOCUS:")
-                    || upper.starts_with("PATTERNS:")
-                    || upper.starts_with("TAGS:"))
-            {
+            if pending.is_some() && matches!(label_upper.as_str(), "FOCUS" | "PATTERNS" | "TAGS") {
                 patterns = value
                     .split(',')
                     .map(str::trim)
@@ -280,10 +327,32 @@ pub fn parse_daily_brief_insights(text: &str, limit: usize) -> Vec<DailyBriefIns
     flush(&mut insights, &mut pending, &mut patterns);
 
     if insights.is_empty() {
+        let has_structured_label = text.lines().any(|line| {
+            let cleaned = line
+                .trim()
+                .strip_prefix("- ")
+                .or_else(|| line.trim().strip_prefix("* "))
+                .unwrap_or(line.trim());
+            let Some((label, _)) = cleaned.split_once(':') else {
+                return false;
+            };
+            matches!(
+                label.trim().to_ascii_uppercase().as_str(),
+                "ASK"
+                    | "BRIEF"
+                    | "FOCUS"
+                    | "GAP"
+                    | "INSIGHT"
+                    | "PATTERNS"
+                    | "QUESTION"
+                    | "SUMMARY"
+                    | "TAGS"
+            )
+        });
         let fallback = trim_line(text, 420);
-        if !fallback.is_empty() {
+        if !has_structured_label && !fallback.is_empty() && !is_question_led_insight(&fallback) {
             insights.push(DailyBriefInsight {
-                question: fallback.contains('?').then_some(fallback.clone()),
+                question: None,
                 summary: fallback,
                 patterns: Vec::new(),
             });
@@ -294,7 +363,7 @@ pub fn parse_daily_brief_insights(text: &str, limit: usize) -> Vec<DailyBriefIns
     insights
         .into_iter()
         .filter(|item| {
-            let key = normalize_insight(item.question.as_deref().unwrap_or(&item.summary));
+            let key = normalize_insight(&item.summary);
             !key.is_empty() && seen.insert(key)
         })
         .take(limit)
@@ -304,14 +373,16 @@ pub fn parse_daily_brief_insights(text: &str, limit: usize) -> Vec<DailyBriefIns
 pub fn build_reflection_prompt(context: &ReflectionSourceContext, count: usize) -> String {
     let mut lines = vec![
         "You are Signet's Daily Brief generator.".to_string(),
-        "Reason over recent transcripts, memory, and the knowledge graph like a helpful assistant searching its memory for what is unclear or worth resolving.".to_string(),
-        "Generate fresh, concrete, non-redundant insights for the dashboard. Do not write a daily report. Do not summarize the last 24 hours.".to_string(),
-        format!("Return exactly {count} items. Each item should be one short useful question or observation, ideally one sentence and never more than two."),
-        "Prefer open loops, contradictions, unresolved decisions, repeated blockers, or connections the user has not explicitly closed.".to_string(),
-        "Avoid repeating existing brief items. Avoid generic productivity advice.".to_string(),
+        format!(
+            "Given the following {} saved memories, observe the gaps.",
+            context.memories.len()
+        ),
+        "Find missing decisions, contradictions, unresolved loops, stale assumptions, or next checks implied by the memories.".to_string(),
+        format!("Return exactly {count} concrete insights. Each insight should be declarative, useful, and grounded in the memories."),
+        "Do not quiz the user. Do not turn implementation checks into yes/no questions. Do not summarize the batch.".to_string(),
         String::new(),
         "Output only lines in this format:".to_string(),
-        "INSIGHT: <short useful question or insight>".to_string(),
+        "INSIGHT: <observed gap or useful next-check insight>".to_string(),
         "FOCUS: <2-5 comma-separated concrete tags>".to_string(),
         String::new(),
     ];
@@ -319,74 +390,37 @@ pub fn build_reflection_prompt(context: &ReflectionSourceContext, count: usize) 
     if !context.existing_reflections.is_empty() {
         lines.push("Existing brief items to avoid repeating:".to_string());
         for reflection in context.existing_reflections.iter().take(12) {
-            let text = reflection.question.as_ref().unwrap_or(&reflection.summary);
             lines.push(format!(
                 "  [{}] {}",
                 &reflection.created_at[..reflection.created_at.len().min(10)],
-                trim_line(text, 220)
+                trim_line(&reflection.summary, 220)
             ));
+            if let Some(question) = &reflection.question {
+                if normalize_insight(question) != normalize_insight(&reflection.summary) {
+                    lines.push(format!(
+                        "  [{}] {}",
+                        &reflection.created_at[..reflection.created_at.len().min(10)],
+                        trim_line(question, 220)
+                    ));
+                }
+            }
         }
         lines.push(String::new());
     }
 
-    if !context.transcripts.is_empty() {
-        lines.push("Recent transcript excerpts:".to_string());
-        for transcript in &context.transcripts {
-            let project = transcript
-                .project
-                .as_ref()
-                .map(|p| format!(" project={p}"))
-                .unwrap_or_default();
-            lines.push(format!(
-                "  [{}{}] {}",
-                &transcript.created_at[..transcript.created_at.len().min(10)],
-                project,
-                trim_line(&transcript.content, 900)
-            ));
-        }
-        lines.push(String::new());
-    }
-
-    if !context.summaries.is_empty() {
-        lines.push("Recent session summaries:".to_string());
-        for summary in &context.summaries {
-            lines.push(format!(
-                "  [{}] {}",
-                &summary.created_at[..summary.created_at.len().min(10)],
-                trim_line(&summary.content, 650)
-            ));
-        }
-        lines.push(String::new());
-    }
-
-    if !context.memories.is_empty() {
-        lines.push("Relevant memories:".to_string());
-        for memory in &context.memories {
-            let date = &memory.created_at[..memory.created_at.len().min(10)];
-            let tags = if memory.tags.is_empty() {
-                String::new()
-            } else {
-                format!("[{}] ", memory.tags)
-            };
-            lines.push(format!(
-                "  [{date}] ({}) {tags}{}",
-                memory.memory_type,
-                trim_line(&memory.content, 500)
-            ));
-        }
-        lines.push(String::new());
-    }
-
-    if !context.graph_facts.is_empty() {
-        lines.push("Knowledge graph facts:".to_string());
-        for fact in &context.graph_facts {
-            lines.push(format!(
-                "  {} ({}): {}",
-                fact.entity,
-                fact.kind,
-                trim_line(&fact.detail, 360)
-            ));
-        }
+    lines.push("Last saved memories:".to_string());
+    for memory in &context.memories {
+        let date = &memory.created_at[..memory.created_at.len().min(10)];
+        let tags = if memory.tags.is_empty() {
+            String::new()
+        } else {
+            format!("[{}] ", memory.tags)
+        };
+        lines.push(format!(
+            "  [{date}] ({}) {tags}{}",
+            memory.memory_type,
+            trim_line(&memory.content, 500)
+        ));
     }
 
     lines.join("\n")
@@ -395,93 +429,29 @@ pub fn build_reflection_prompt(context: &ReflectionSourceContext, count: usize) 
 pub async fn collect_reflection_context(
     pool: &DbPool,
     agent_id: &str,
-    config: &ReflectionConfig,
+    _config: &ReflectionConfig,
 ) -> Result<ReflectionSourceContext, ReflectionWorkerError> {
     let agent_id = agent_id.to_string();
-    let max_memories = config.max_memories.max(24);
-    let max_summaries = config.max_summaries.max(12);
-    let hours = config.time_window_hours.max(1);
-    let cutoff = (Utc::now() - ChronoDuration::hours(hours)).to_rfc3339();
 
     pool.read(move |conn| {
         let memories = {
             let mut stmt = conn.prepare_cached(
                 "SELECT id, content, type, tags, created_at FROM memories
-                 WHERE agent_id = ?1 AND is_deleted = 0 AND (created_at >= ?2 OR pinned = 1)
-                 ORDER BY pinned DESC, importance DESC, created_at DESC LIMIT ?3",
+                 WHERE agent_id = ?1 AND is_deleted = 0
+                 ORDER BY created_at DESC LIMIT ?2",
             )?;
-            stmt.query_map(params![agent_id, cutoff, max_memories as i64], |row| {
-                Ok(ReflectionMemory {
-                    id: row.get(0)?,
-                    content: row.get(1)?,
-                    memory_type: row.get(2)?,
-                    tags: row.get::<_, Option<String>>(3)?.unwrap_or_default(),
-                    created_at: row.get(4)?,
-                })
-            })?
-            .collect::<rusqlite::Result<Vec<_>>>()?
-        };
-
-        let summaries = {
-            let mut stmt = conn.prepare_cached(
-                "SELECT id, content, created_at, latest_at, session_key FROM session_summaries
-                 WHERE agent_id = ?1 AND COALESCE(latest_at, created_at) >= ?2
-                 ORDER BY COALESCE(latest_at, created_at) DESC LIMIT ?3",
-            )?;
-            stmt.query_map(params![agent_id, cutoff, max_summaries as i64], |row| {
-                Ok(ReflectionSummary {
-                    id: row.get(0)?,
-                    content: row.get(1)?,
-                    created_at: row.get(2)?,
-                    latest_at: row.get(3)?,
-                    session_key: row.get(4)?,
-                })
-            })?
-            .collect::<rusqlite::Result<Vec<_>>>()?
-        };
-
-        let transcripts = {
-            let mut stmt = conn.prepare_cached(
-                "SELECT session_key, content, project, created_at FROM session_transcripts
-                 WHERE agent_id = ?1 AND COALESCE(updated_at, created_at) >= ?2
-                 ORDER BY COALESCE(updated_at, created_at) DESC LIMIT 4",
-            )?;
-            stmt.query_map(params![agent_id, cutoff], |row| {
-                Ok(ReflectionTranscript {
-                    session_key: row.get(0)?,
-                    content: row.get(1)?,
-                    project: row.get(2)?,
-                    created_at: row.get(3)?,
-                })
-            })?
-            .collect::<rusqlite::Result<Vec<_>>>()?
-        };
-
-        let graph_facts = {
-            let mut stmt = conn.prepare_cached(
-                "SELECT e.name AS entity, e.entity_type AS kind, ea.name AS aspect,
-                        attr.content AS content, attr.updated_at AS updated_at
-                 FROM entity_attributes attr
-                 LEFT JOIN entity_aspects ea ON ea.id = attr.aspect_id
-                 LEFT JOIN entities e ON e.id = ea.entity_id
-                 WHERE attr.agent_id = ?1 AND attr.status = 'active' AND e.name IS NOT NULL
-                   AND COALESCE(attr.updated_at, attr.created_at) >= ?2
-                 ORDER BY attr.importance DESC, attr.updated_at DESC LIMIT 28",
-            )?;
-            stmt.query_map(params![agent_id, cutoff], |row| {
-                let aspect = row.get::<_, Option<String>>(2)?.unwrap_or_default();
-                let content: String = row.get(3)?;
-                Ok(ReflectionGraphFact {
-                    entity: row.get(0)?,
-                    kind: row.get(1)?,
-                    detail: if aspect.is_empty() {
-                        content
-                    } else {
-                        format!("{aspect}: {content}")
-                    },
-                    updated_at: row.get(4)?,
-                })
-            })?
+            stmt.query_map(
+                params![agent_id, DAILY_BRIEF_MEMORY_BATCH_SIZE as i64],
+                |row| {
+                    Ok(ReflectionMemory {
+                        id: row.get(0)?,
+                        content: row.get(1)?,
+                        memory_type: row.get(2)?,
+                        tags: row.get::<_, Option<String>>(3)?.unwrap_or_default(),
+                        created_at: row.get(4)?,
+                    })
+                },
+            )?
             .collect::<rusqlite::Result<Vec<_>>>()?
         };
 
@@ -504,9 +474,9 @@ pub async fn collect_reflection_context(
 
         Ok(ReflectionSourceContext {
             memories,
-            summaries,
-            transcripts,
-            graph_facts,
+            summaries: Vec::new(),
+            transcripts: Vec::new(),
+            graph_facts: Vec::new(),
             existing_reflections,
         })
     })
@@ -522,11 +492,7 @@ pub async fn generate_daily_brief_insights(
     count: usize,
 ) -> Result<Vec<String>, ReflectionWorkerError> {
     let context = collect_reflection_context(pool, agent_id, config).await?;
-    if context.memories.is_empty()
-        && context.summaries.is_empty()
-        && context.transcripts.is_empty()
-        && context.graph_facts.is_empty()
-    {
+    if context.memories.is_empty() {
         return Ok(Vec::new());
     }
 
@@ -539,14 +505,16 @@ pub async fn generate_daily_brief_insights(
     let mut existing = context
         .existing_reflections
         .iter()
-        .map(|r| normalize_insight(r.question.as_deref().unwrap_or(&r.summary)))
+        .flat_map(|r| [Some(r.summary.as_str()), r.question.as_deref()])
+        .flatten()
+        .map(normalize_insight)
         .filter(|key| !key.is_empty())
         .collect::<HashSet<_>>();
 
     let insights = parse_daily_brief_insights(&raw, (count * 2).max(count))
         .into_iter()
         .filter(|insight| {
-            let key = normalize_insight(insight.question.as_deref().unwrap_or(&insight.summary));
+            let key = normalize_insight(&insight.summary);
             !key.is_empty() && existing.insert(key)
         })
         .take(count)
@@ -582,8 +550,7 @@ pub async fn generate_daily_brief_insights(
             let mut ids = Vec::new();
             for insight in insights {
                 let id = Uuid::new_v4().to_string();
-                let content_key =
-                    normalize_insight(insight.question.as_deref().unwrap_or(&insight.summary));
+                let content_key = normalize_insight(&insight.summary);
                 let patterns =
                     serde_json::to_string(&insight.patterns).unwrap_or_else(|_| "[]".to_string());
                 let changes = conn.execute(
@@ -755,25 +722,19 @@ impl ReflectionWorkerHandle {
 
 pub async fn list_active_agent_ids(
     pool: &DbPool,
-    config: &ReflectionConfig,
+    _config: &ReflectionConfig,
 ) -> Result<Vec<String>, ReflectionWorkerError> {
-    let cutoff = (Utc::now() - ChronoDuration::hours(config.time_window_hours.max(1))).to_rfc3339();
     let ids = pool
         .read(move |conn| {
             let mut stmt = conn.prepare_cached(
                 "SELECT DISTINCT agent_id FROM memories
-                 WHERE created_at >= ?1 AND is_deleted = 0
-                 UNION
-                 SELECT DISTINCT agent_id FROM session_summaries
-                 WHERE created_at >= ?2",
+                 WHERE is_deleted = 0",
             )?;
-            stmt.query_map(params![cutoff, cutoff], |row| {
-                row.get::<_, Option<String>>(0)
-            })?
-            .filter_map(Result::ok)
-            .flatten()
-            .collect::<Vec<_>>()
-            .pipe(Ok)
+            stmt.query_map([], |row| row.get::<_, Option<String>>(0))?
+                .filter_map(Result::ok)
+                .flatten()
+                .collect::<Vec<_>>()
+                .pipe(Ok)
         })
         .await
         .map_err(|e| ReflectionWorkerError::Database(e.to_string()))?;

--- a/platform/daemon/src/pipeline/reflection-worker.test.ts
+++ b/platform/daemon/src/pipeline/reflection-worker.test.ts
@@ -8,9 +8,11 @@ import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 import { logger } from "../logger";
 import { txIngestEnvelope } from "../transactions";
 import {
+	buildReflectionPrompt,
 	collectReflectionContext,
 	generateDailyBriefInsights,
 	nextReflectionDelayMs,
+	parseDailyBriefInsights,
 	startReflectionWorker,
 } from "./reflection-worker";
 
@@ -124,29 +126,96 @@ describe("reflection worker", () => {
 		expect(existsSync(join(dir, ".daemon", "last-reflection.default.json"))).toBe(false);
 	});
 
-	it("collects recent source context and only lets pinned old memories bypass the cutoff", () => {
-		const old = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
-		const recentId = seedMemory("default", { content: "Recent source", hash: "recent-source" });
-		const pinnedId = seedMemory("default", {
-			content: "Pinned durable source",
-			createdAt: old,
-			pinned: 1,
-			hash: "pinned-source",
-		});
-		seedMemory("default", { content: "Stale unpinned source", createdAt: old, hash: "stale-source" });
+	it("collects the last 50 saved memories as the daily brief source batch", () => {
+		const ids: string[] = [];
+		const base = Date.now() - 60_000;
+		for (let i = 0; i < 55; i += 1) {
+			ids.push(
+				seedMemory("default", {
+					content: `Saved memory ${i}`,
+					createdAt: new Date(base + i * 1000).toISOString(),
+					hash: `saved-memory-${i}`,
+				}),
+			);
+		}
 
 		const context = collectReflectionContext("default", config);
 
-		expect(context.memories.map((m) => m.id)).toEqual([pinnedId, recentId]);
-		expect(context.memories.map((m) => m.content)).not.toContain("Stale unpinned source");
+		expect(context.memories).toHaveLength(50);
+		expect(context.memories.map((m) => m.id)).toEqual(ids.slice(5).reverse());
+		expect(context.summaries).toEqual([]);
+		expect(context.transcripts).toEqual([]);
+		expect(context.graphFacts).toEqual([]);
+	});
+
+	it("builds a simple gap-observation prompt over saved memories", () => {
+		const prompt = buildReflectionPrompt(
+			{
+				memories: [
+					{
+						id: "memory-1",
+						content: "Issue #868 likely involves compare/install catalog key routing.",
+						type: "fact",
+						tags: "issue868,backend",
+						createdAt: "2026-06-28T00:00:00.000Z",
+					},
+				],
+				summaries: [],
+				transcripts: [],
+				graphFacts: [],
+				existingReflections: [],
+			},
+			1,
+		);
+
+		expect(prompt).toContain("Given the following 1 saved memories, observe the gaps.");
+		expect(prompt).toContain("Last saved memories:");
+		expect(prompt).toContain("Do not turn implementation checks into yes/no questions");
+		expect(prompt).toContain("INSIGHT: <observed gap or useful next-check insight>");
+	});
+
+	it("parses declarative gap insights and drops quiz-style questions", () => {
+		const insights = parseDailyBriefInsights(
+			[
+				"INSIGHT: Rust parity test ports are the release bottleneck; group the remaining work by harness surface before opening more feature threads.",
+				"FOCUS: rust-parity, release",
+				"INSIGHT: Has the backend compare/install logic been updated to route by catalogKey?",
+				"FOCUS: rejected",
+				"INSIGHT: Has the backend path been verified? Verify it before release.",
+				"FOCUS: rejected",
+				"GAP: Issue #868 likely hinges on compare/install catalog-key routing; verify the backend path before touching UI behavior.",
+				"FOCUS: issue868, backend",
+				"INSIGHT: The open loop \"Why does install fail?\" needs an owner before release.",
+				"FOCUS: install, owner",
+			].join("\n"),
+			3,
+		);
+
+		expect(insights).toEqual([
+			{
+				summary:
+					"Rust parity test ports are the release bottleneck; group the remaining work by harness surface before opening more feature threads.",
+				patterns: ["rust-parity", "release"],
+			},
+			{
+				summary:
+					"Issue #868 likely hinges on compare/install catalog-key routing; verify the backend path before touching UI behavior.",
+				patterns: ["issue868", "backend"],
+			},
+			{
+				summary: "The open loop \"Why does install fail?\" needs an owner before release.",
+				patterns: ["install", "owner"],
+			},
+		]);
+		expect(parseDailyBriefInsights("QUESTION: Has the backend path been verified?\nFOCUS: backend", 1)).toEqual([]);
+		expect(parseDailyBriefInsights("  QUESTION: Has the backend path been verified?\n  FOCUS: backend", 1)).toEqual([]);
 	});
 
 	it("persists generated brief insights", async () => {
 		const memoryId = seedMemory("default");
 		const worker = startReflectionWorker(config, {
 			getDbAccessor,
-			getInferenceProvider: () =>
-				provider("SUMMARY: Worker persisted.\nPATTERNS: persistence\nQUESTION: Should we keep it?"),
+			getInferenceProvider: () => provider("BRIEF: Worker persisted the daily brief row.\nFOCUS: persistence"),
 			logger,
 		});
 
@@ -165,7 +234,7 @@ describe("reflection worker", () => {
 				},
 		);
 		expect(reflection).toEqual({
-			summary: "Should we keep it?",
+			summary: "Worker persisted the daily brief row.",
 			model: "test-model",
 			memory_ids: JSON.stringify([memoryId]),
 		});
@@ -227,7 +296,7 @@ describe("reflection worker", () => {
 				waiting += 1;
 				if (waiting === 2) release?.();
 				await barrier;
-				return "INSIGHT: Should this duplicate be inserted once?\nFOCUS: race, dedupe";
+				return "INSIGHT: Duplicate dashboard-open generations should insert one row.\nFOCUS: race, dedupe";
 			},
 		};
 		await Promise.all([
@@ -251,8 +320,8 @@ describe("reflection worker", () => {
 		});
 		expect(rows).toEqual([
 			{
-				summary: "Should this duplicate be inserted once?",
-				content_key: "should this duplicate be inserted once",
+				summary: "Duplicate dashboard-open generations should insert one row.",
+				content_key: "duplicate dashboard open generations should insert one row",
 			},
 		]);
 	});

--- a/platform/daemon/src/pipeline/reflection-worker.ts
+++ b/platform/daemon/src/pipeline/reflection-worker.ts
@@ -22,6 +22,7 @@ const DEFAULT_DEPS: ReflectionDeps = {
 const POLL_INTERVAL_MS = 300_000;
 const MINUTE_MS = 60_000;
 const DAY_MS = 24 * 60 * MINUTE_MS;
+const DAILY_BRIEF_MEMORY_BATCH_SIZE = 50;
 
 function getAgentsDir(): string {
 	return resolveDefaultBasePath();
@@ -121,17 +122,24 @@ function trimLine(text: string, max = 260): string {
 	return single.length > max ? `${single.slice(0, max - 1).trim()}…` : single;
 }
 
+function isQuestionLedInsight(text: string): boolean {
+	const normalized = text.replace(/\s+/g, " ").trim().toLowerCase();
+	if (normalized.endsWith("?")) return true;
+	return /^(?:has|have|does|did|do|is|are|was|were|can|could|will|would|should|what|which|who|when|where|why|how)\b[^.!?]*\?/.test(
+		normalized,
+	);
+}
+
 export function buildReflectionPrompt(context: ReflectionSourceContext, count = 3): string {
 	const lines: string[] = [
 		"You are Signet's Daily Brief generator.",
-		"Reason over recent transcripts, memory, and the knowledge graph like a helpful assistant searching its memory for what is unclear or worth resolving.",
-		"Generate fresh, concrete, non-redundant insights for the dashboard. Do not write a daily report. Do not summarize the last 24 hours.",
-		`Return exactly ${count} items. Each item should be one short useful question or observation, ideally one sentence and never more than two.`,
-		"Prefer open loops, contradictions, unresolved decisions, repeated blockers, or connections the user has not explicitly closed.",
-		"Avoid repeating existing brief items. Avoid generic productivity advice.",
+		`Given the following ${context.memories.length} saved memories, observe the gaps.`,
+		"Find missing decisions, contradictions, unresolved loops, stale assumptions, or next checks implied by the memories.",
+		`Return exactly ${count} concrete insights. Each insight should be declarative, useful, and grounded in the memories.`,
+		"Do not quiz the user. Do not turn implementation checks into yes/no questions. Do not summarize the batch.",
 		"",
 		"Output only lines in this format:",
-		"INSIGHT: <short useful question or insight>",
+		"INSIGHT: <observed gap or useful next-check insight>",
 		"FOCUS: <2-5 comma-separated concrete tags>",
 		"",
 	];
@@ -139,42 +147,18 @@ export function buildReflectionPrompt(context: ReflectionSourceContext, count = 
 	if (context.existingReflections.length > 0) {
 		lines.push("Existing brief items to avoid repeating:");
 		for (const r of context.existingReflections.slice(0, 12)) {
-			lines.push(`  [${r.createdAt.slice(0, 10)}] ${trimLine(r.question ?? r.summary, 220)}`);
+			lines.push(`  [${r.createdAt.slice(0, 10)}] ${trimLine(r.summary, 220)}`);
+			if (r.question && normalizeInsight(r.question) !== normalizeInsight(r.summary)) {
+				lines.push(`  [${r.createdAt.slice(0, 10)}] ${trimLine(r.question, 220)}`);
+			}
 		}
 		lines.push("");
 	}
 
-	if (context.transcripts.length > 0) {
-		lines.push("Recent transcript excerpts:");
-		for (const t of context.transcripts) {
-			const project = t.project ? ` project=${t.project}` : "";
-			lines.push(`  [${t.createdAt.slice(0, 10)}${project}] ${trimLine(t.content, 900)}`);
-		}
-		lines.push("");
-	}
-
-	if (context.summaries.length > 0) {
-		lines.push("Recent session summaries:");
-		for (const s of context.summaries) {
-			lines.push(`  [${s.createdAt.slice(0, 10)}] ${trimLine(s.content, 650)}`);
-		}
-		lines.push("");
-	}
-
-	if (context.memories.length > 0) {
-		lines.push("Relevant memories:");
-		for (const m of context.memories) {
-			const date = m.createdAt.slice(0, 10);
-			lines.push(`  [${date}] (${m.type}) ${m.tags ? `[${m.tags}] ` : ""}${trimLine(m.content, 500)}`);
-		}
-		lines.push("");
-	}
-
-	if (context.graphFacts.length > 0) {
-		lines.push("Knowledge graph facts:");
-		for (const g of context.graphFacts) {
-			lines.push(`  ${g.entity} (${g.kind}): ${trimLine(g.detail, 360)}`);
-		}
+	lines.push("Last saved memories:");
+	for (const m of context.memories) {
+		const date = m.createdAt.slice(0, 10);
+		lines.push(`  [${date}] (${m.type}) ${m.tags ? `[${m.tags}] ` : ""}${trimLine(m.content, 500)}`);
 	}
 
 	return lines.join("\n");
@@ -202,7 +186,7 @@ export function parseDailyBriefInsights(text: string, limit = 3): DailyBriefInsi
 	function flush(): void {
 		if (!pending) return;
 		const summary = trimLine(pending, 420);
-		insights.push({ summary, question: summary.includes("?") ? summary : undefined, patterns });
+		if (summary && !isQuestionLedInsight(summary)) insights.push({ summary, patterns });
 		pending = null;
 		patterns = [];
 	}
@@ -210,13 +194,13 @@ export function parseDailyBriefInsights(text: string, limit = 3): DailyBriefInsi
 	for (const rawLine of text.split(/\r?\n/)) {
 		const line = rawLine.trim();
 		if (!line) continue;
-		const insight = line.match(/^(?:[-*]\s*)?(?:INSIGHT|QUESTION|BRIEF)\s*:\s*(.+)$/i)?.[1];
-		if (insight) {
+		const brief = line.match(/^(?:[-*]\s*)?(?:BRIEF|GAP|INSIGHT|SUMMARY)\s*:\s*(.+)$/i)?.[1];
+		if (brief) {
 			flush();
-			pending = insight.trim();
+			pending = brief.trim();
 			continue;
 		}
-		const focus = line.match(/^(?:FOCUS|PATTERNS|TAGS)\s*:\s*(.+)$/i)?.[1];
+		const focus = line.match(/^(?:[-*]\s*)?(?:FOCUS|PATTERNS|TAGS)\s*:\s*(.+)$/i)?.[1];
 		if (focus && pending) {
 			patterns = focus
 				.split(",")
@@ -228,15 +212,17 @@ export function parseDailyBriefInsights(text: string, limit = 3): DailyBriefInsi
 	flush();
 
 	if (insights.length === 0) {
+		const hasStructuredLabel = /^\s*(?:[-*]\s*)?(?:ASK|BRIEF|FOCUS|GAP|INSIGHT|PATTERNS|QUESTION|SUMMARY|TAGS)\s*:/im.test(
+			text,
+		);
 		const fallback = trimLine(text, 420);
-		if (fallback)
-			insights.push({ summary: fallback, question: fallback.includes("?") ? fallback : undefined, patterns: [] });
+		if (!hasStructuredLabel && fallback && !isQuestionLedInsight(fallback)) insights.push({ summary: fallback, patterns: [] });
 	}
 
 	const seen = new Set<string>();
 	return insights
 		.filter((item) => {
-			const key = normalizeInsight(item.question ?? item.summary);
+			const key = normalizeInsight(item.summary);
 			if (!key || seen.has(key)) return false;
 			seen.add(key);
 			return true;
@@ -246,22 +232,19 @@ export function parseDailyBriefInsights(text: string, limit = 3): DailyBriefInsi
 
 export function collectReflectionContext(
 	agentId: string,
-	config: PipelineReflectionsConfig,
+	_config: PipelineReflectionsConfig,
 	deps: Pick<ReflectionDeps, "getDbAccessor"> = DEFAULT_DEPS,
 ): ReflectionSourceContext {
-	const maxMemories = Math.max(config.maxMemories, 24);
-	const maxSummaries = Math.max(config.maxSummaries, 12);
-	const cutoff = new Date(Date.now() - Math.max(config.timeWindowHours, 1) * 60 * 60 * 1000).toISOString();
 	const dbAccessor = deps.getDbAccessor();
 
 	const memories = dbAccessor.withReadDb((db) => {
 		const rows = db
 			.prepare(
 				`SELECT id, content, type, tags, created_at FROM memories
-				 WHERE agent_id = ? AND is_deleted = 0 AND (created_at >= ? OR pinned = 1)
-				 ORDER BY pinned DESC, importance DESC, created_at DESC LIMIT ?`,
+				 WHERE agent_id = ? AND is_deleted = 0
+				 ORDER BY created_at DESC LIMIT ?`,
 			)
-			.all(agentId, cutoff, maxMemories) as {
+			.all(agentId, DAILY_BRIEF_MEMORY_BATCH_SIZE) as {
 			id: string;
 			content: string;
 			type: string;
@@ -277,71 +260,6 @@ export function collectReflectionContext(
 		}));
 	});
 
-	const summaries = dbAccessor.withReadDb((db) => {
-		const rows = db
-			.prepare(
-				`SELECT id, content, created_at, latest_at, session_key FROM session_summaries
-				 WHERE agent_id = ? AND COALESCE(latest_at, created_at) >= ?
-				 ORDER BY COALESCE(latest_at, created_at) DESC LIMIT ?`,
-			)
-			.all(agentId, cutoff, maxSummaries) as {
-			id: string;
-			content: string;
-			created_at: string;
-			latest_at: string | null;
-			session_key: string | null;
-		}[];
-		return rows.map((r) => ({
-			id: r.id,
-			content: r.content,
-			createdAt: r.created_at,
-			latestAt: r.latest_at,
-			sessionKey: r.session_key,
-		}));
-	});
-
-	const transcripts = dbAccessor.withReadDb((db) => {
-		const rows = db
-			.prepare(
-				`SELECT session_key, content, project, created_at FROM session_transcripts
-				 WHERE agent_id = ? AND COALESCE(updated_at, created_at) >= ?
-				 ORDER BY COALESCE(updated_at, created_at) DESC LIMIT 4`,
-			)
-			.all(agentId, cutoff) as { session_key: string; content: string; project: string | null; created_at: string }[];
-		return rows.map((r) => ({
-			sessionKey: r.session_key,
-			content: r.content,
-			project: r.project,
-			createdAt: r.created_at,
-		}));
-	});
-
-	const graphFacts = dbAccessor.withReadDb((db) => {
-		const attributes = db
-			.prepare(
-				`SELECT e.name AS entity, e.entity_type AS kind, ea.name AS aspect, attr.content AS content, attr.updated_at AS updated_at
-				 FROM entity_attributes attr
-				 LEFT JOIN entity_aspects ea ON ea.id = attr.aspect_id
-				 LEFT JOIN entities e ON e.id = ea.entity_id
-				 WHERE attr.agent_id = ? AND attr.status = 'active' AND e.name IS NOT NULL
-				   AND COALESCE(attr.updated_at, attr.created_at) >= ?
-				 ORDER BY attr.importance DESC, attr.updated_at DESC LIMIT 28`,
-			)
-			.all(agentId, cutoff) as {
-			entity: string;
-			kind: string;
-			aspect: string | null;
-			content: string;
-			updated_at: string | null;
-		}[];
-		return attributes.map((r) => ({
-			entity: r.entity,
-			kind: r.kind,
-			detail: `${r.aspect ? `${r.aspect}: ` : ""}${r.content}`,
-			updatedAt: r.updated_at,
-		}));
-	});
-
 	const existingReflections = dbAccessor.withReadDb((db) => {
 		const rows = db
 			.prepare(
@@ -353,7 +271,7 @@ export function collectReflectionContext(
 		return rows.map((r) => ({ id: r.id, question: r.question, summary: r.summary, createdAt: r.created_at }));
 	});
 
-	return { memories, summaries, transcripts, graphFacts, existingReflections };
+	return { memories, summaries: [], transcripts: [], graphFacts: [], existingReflections };
 }
 
 export async function generateDailyBriefInsights(
@@ -363,24 +281,20 @@ export async function generateDailyBriefInsights(
 	deps: ReflectionDeps = DEFAULT_DEPS,
 ): Promise<string[]> {
 	const context = collectReflectionContext(agentId, config, deps);
-	if (
-		context.memories.length === 0 &&
-		context.summaries.length === 0 &&
-		context.transcripts.length === 0 &&
-		context.graphFacts.length === 0
-	) {
-		return [];
-	}
+	if (context.memories.length === 0) return [];
 
 	const prompt = buildReflectionPrompt(context, count);
 	const provider = deps.getInferenceProvider("default");
 	const raw = await provider.generate(prompt, { timeoutMs: config.timeout, maxTokens: config.maxTokens });
 	const existing = new Set(
-		context.existingReflections.map((r) => normalizeInsight(r.question ?? r.summary)).filter(Boolean),
+		context.existingReflections
+			.flatMap((r) => [r.summary, r.question ?? ""])
+			.map((text) => normalizeInsight(text))
+			.filter(Boolean),
 	);
 	const insights = parseDailyBriefInsights(raw, Math.max(count * 2, count))
 		.filter((insight) => {
-			const key = normalizeInsight(insight.question ?? insight.summary);
+			const key = normalizeInsight(insight.summary);
 			if (!key || existing.has(key)) return false;
 			existing.add(key);
 			return true;
@@ -398,7 +312,7 @@ export async function generateDailyBriefInsights(
 	deps.getDbAccessor().withWriteTx((db) => {
 		for (const insight of insights) {
 			const id = randomUUID();
-			const contentKey = normalizeInsight(insight.question ?? insight.summary);
+			const contentKey = normalizeInsight(insight.summary);
 			const result = db
 				.prepare(
 					`INSERT OR IGNORE INTO daily_reflections
@@ -458,17 +372,13 @@ export function startReflectionWorker(
 	}
 
 	function listActiveAgentIds(): string[] {
-		const cutoff = new Date(Date.now() - config.timeWindowHours * 60 * 60 * 1000).toISOString();
 		const rows = deps.getDbAccessor().withReadDb((db) => {
 			return db
 				.prepare(
 					`SELECT DISTINCT agent_id FROM memories
-					 WHERE created_at >= ? AND is_deleted = 0
-					 UNION
-					 SELECT DISTINCT agent_id FROM session_summaries
-					 WHERE created_at >= ?`,
+					 WHERE is_deleted = 0`,
 				)
-				.all(cutoff, cutoff) as { agent_id: string | null }[];
+				.all() as { agent_id: string | null }[];
 		});
 		const agentIds = rows.map((row) => row.agent_id).filter((agentId): agentId is string => !!agentId);
 		return agentIds.length > 0 ? agentIds : ["default"];

--- a/platform/daemon/src/routes/reflection-routes.test.ts
+++ b/platform/daemon/src/routes/reflection-routes.test.ts
@@ -72,7 +72,7 @@ function app(): Hono {
 		agentsDir: dir,
 		getDbAccessor: () => dbAccessor,
 		getInferenceProvider: () =>
-			makeProvider("SUMMARY: We fixed reflections.\nPATTERNS: persistence, scoping\nQUESTION: Keep it?"),
+			makeProvider("INSIGHT: Reflection generation now persists declarative gap observations.\nFOCUS: persistence, scoping"),
 	});
 	return next;
 }
@@ -119,8 +119,8 @@ describe("reflection routes", () => {
 		const res = await app().request("/api/reflections/generate?agentId=agent-a", { method: "POST" });
 		expect(res.status).toBe(200);
 		const body = await res.json();
-		expect(body.reflection.summary).toBe("Keep it?");
-		expect(body.reflection.patterns).toEqual([]);
+		expect(body.reflection.summary).toBe("Reflection generation now persists declarative gap observations.");
+		expect(body.reflection.patterns).toEqual(["persistence", "scoping"]);
 
 		const row = dbAccessor.withReadDb(
 			(db) =>


### PR DESCRIPTION
## Summary
- generate Daily Brief insights from the last 50 saved memories instead of mixed transcript/summary/graph context
- simplify the prompt around observing gaps in those memories
- filter quiz-style question output and keep TypeScript/Rust reflection-worker parity
- align scheduled agent selection with memory-backed brief generation

## Verification
- `bun test platform/daemon/src/pipeline/reflection-worker.test.ts platform/daemon/src/routes/reflection-routes.test.ts`
- `cargo fmt --check --manifest-path platform/daemon-rs/crates/signet-pipeline/Cargo.toml`
- `cargo test --manifest-path platform/daemon-rs/Cargo.toml -p signet-pipeline reflection_worker_schedules_and_collects_sources`
- local autoreview clean
