### PR TITLE
fix(memory): prevent recursive aggregate recall evidence

### DIFF
--- a/platform/daemon-rs/crates/signet-pipeline/src/aggregate_recall.rs
+++ b/platform/daemon-rs/crates/signet-pipeline/src/aggregate_recall.rs
@@ -569,8 +569,17 @@ fn parse_planner_queries(raw: &str) -> Vec<String> {
         .collect()
 }
 
+fn is_aggregate_recall_row(row: &RecallResult) -> bool {
+    row.source == "aggregate-recall"
+        || row
+            .source_id
+            .as_deref()
+            .is_some_and(|source_id| source_id.starts_with("aggregate-recall:"))
+}
+
 fn is_source_memory_row(row: &RecallResult) -> bool {
     row.source != "llm_summary"
+        && !is_aggregate_recall_row(row)
         && !row.id.starts_with("constructed:")
         && !row.id.starts_with("summary:")
         && !row.id.starts_with("source-chunk:")
@@ -1164,6 +1173,11 @@ pub async fn aggregate_recall(
     let save_aggregate = deps.router.is_some() && params.save_aggregate != Some(false);
     let mut timings = TimingCollector::new();
     let mut usage_stages: Vec<AggregateRecallUsageStage> = Vec::new();
+    let now = deps
+        .now
+        .map(|now| now())
+        .unwrap_or_else(Utc::now)
+        .to_rfc3339();
 
     let first = timings
         .time_async("aggregate_initial_recall", || {
@@ -1194,9 +1208,16 @@ pub async fn aggregate_recall(
         ));
     };
 
+    let first_planning_evidence = unique_evidence(&first.results);
     let (planned_queries, planning_usage) = timings
         .time_async("aggregate_planning", || {
-            plan_queries(router, &params, budget, max_queries, &first.results)
+            plan_queries(
+                router,
+                &params,
+                budget,
+                max_queries,
+                &first_planning_evidence,
+            )
         })
         .await;
     if let Some(usage) = planning_usage {
@@ -1275,11 +1296,6 @@ pub async fn aggregate_recall(
         budget,
         &source_memory_ids,
     );
-    let now = deps
-        .now
-        .map(|now| now())
-        .unwrap_or_else(Utc::now)
-        .to_rfc3339();
     let mut row: Option<RecallResult>;
     let mut deduped = false;
     let mut saved = false;

--- a/platform/daemon-rs/crates/signet-pipeline/tests/aggregate_recall_parity.rs
+++ b/platform/daemon-rs/crates/signet-pipeline/tests/aggregate_recall_parity.rs
@@ -581,3 +581,53 @@ async fn synthesized_recall_rows_are_not_evidence_sources() {
         .expect("read links");
     assert_eq!(links, vec!["mem-1"]);
 }
+
+#[tokio::test]
+async fn saved_aggregate_recall_rows_are_not_recursive_evidence_sources() {
+    let conn = setup_conn();
+    let mut aggregate_row = row(
+        "aggregate-memory",
+        "Stale synthesized aggregate should not be recursive evidence",
+    );
+    aggregate_row.source_id = Some("aggregate-recall:old-key".to_string());
+    aggregate_row.tags = Some("aggregate,recall".to_string());
+    let recall = StaticRecall::default().with(
+        "what happened",
+        vec![aggregate_row, row("mem-1", "Real evidence")],
+    );
+    let router = StaticRouter::default();
+    let now = || Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap();
+    let id = || "aggregate-source-filter".to_string();
+
+    let result = aggregate_recall(
+        &conn,
+        AggregateRecallParams {
+            query: "what happened".to_string(),
+            aggregate: true,
+            agent_id: Some("agent-a".to_string()),
+            ..AggregateRecallParams::default()
+        },
+        AggregateRecallDeps {
+            recall: Some(&recall),
+            router: Some(&router),
+            now: Some(&now),
+            id_factory: Some(&id),
+            ..AggregateRecallDeps::default()
+        },
+    )
+    .await
+    .expect("aggregate result");
+
+    assert_eq!(
+        result
+            .aggregate
+            .expect("aggregate metadata")
+            .source_memory_ids,
+        vec!["mem-1"]
+    );
+    let prompts = router.prompts.borrow();
+    assert!(prompts[0].contains("Real evidence"));
+    assert!(!prompts[0].contains("Stale synthesized aggregate"));
+    assert!(prompts[1].contains("Real evidence"));
+    assert!(!prompts[1].contains("Stale synthesized aggregate"));
+}

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -710,6 +710,40 @@ memory:
 		expect(links.map((link) => link.source_memory_id)).toEqual(["mem-1"]);
 	});
 
+	it("does not use saved aggregate recall rows as aggregate evidence", async () => {
+		const router = new StaticRouter();
+		const result = await aggregateRecall(
+			{
+				query: "what happened",
+				aggregate: true,
+				agentId: "agent-a",
+			},
+			loadMemoryConfig(dir),
+			{
+				router,
+				embedFn: async () => null,
+				logger: quietLogger(),
+				now: () => new Date("2026-05-20T12:00:00.000Z"),
+				idFactory: () => "aggregate-source-filter",
+				hybridRecall: async (params: RecallParams) =>
+					response(params.query, [
+						{
+							...row("aggregate-memory", "Stale synthesized aggregate should not be recursive evidence"),
+							source_id: "aggregate-recall:old-key",
+							tags: "aggregate,recall",
+						},
+						row("mem-1", "Real evidence"),
+					]),
+			},
+		);
+
+		expect(result.aggregate?.sourceMemoryIds).toEqual(["mem-1"]);
+		expect(router.prompts[0]).toContain("Real evidence");
+		expect(router.prompts[0]).not.toContain("Stale synthesized aggregate");
+		expect(router.prompts[1]).toContain("Real evidence");
+		expect(router.prompts[1]).not.toContain("Stale synthesized aggregate");
+	});
+
 	it("returns unsaved aggregate when content hash conflicts with an inaccessible memory", async () => {
 		const answer = "Aggregate answer from memory evidence.";
 		const normalized = normalizeAndHashContent(answer);

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -286,9 +286,14 @@ function parsePlannerQueries(raw: string): string[] {
 		.filter((line) => line.length > 0);
 }
 
+function isAggregateRecallRow(row: RecallResult): boolean {
+	return row.source === "aggregate-recall" || row.source_id?.startsWith("aggregate-recall:") === true;
+}
+
 function isSourceMemoryRow(row: RecallResult): boolean {
 	return (
 		row.source !== "llm_summary" &&
+		!isAggregateRecallRow(row) &&
 		!row.id.startsWith("constructed:") &&
 		!row.id.startsWith("summary:") &&
 		!row.id.startsWith("source-chunk:") &&
@@ -638,6 +643,7 @@ export async function aggregateRecall(
 	const ingestEnvelope = deps.ingestEnvelope ?? txIngestEnvelope;
 	const timings = createAggregateTimingCollector();
 	const usageStages: AggregateRecallUsageStage[] = [];
+	const now = (deps.now?.() ?? new Date()).toISOString();
 	const finish = (response: RecallResponse): RecallResponse => {
 		const recallTimings = timings.finish();
 		const usage = buildAggregateUsage(usageStages);
@@ -694,7 +700,7 @@ export async function aggregateRecall(
 			params,
 			budget,
 			maxQueries,
-			initialRows: first.results,
+			initialRows: uniqueEvidence(first.results),
 		}),
 	);
 	const queries = uniqueQueries(params.query, planned.queries, maxQueries);
@@ -738,7 +744,6 @@ export async function aggregateRecall(
 	const agentId = params.agentId ?? "default";
 	const project = sourceProject(params);
 	const key = aggregateKey({ agentId, project, query: params.query, budget, sourceMemoryIds });
-	const now = (deps.now?.() ?? new Date()).toISOString();
 
 	let row: RecallResult | null;
 	let deduped = false;


### PR DESCRIPTION
## Summary

- exclude saved `aggregate-recall:*` rows from aggregate recall planning/synthesis evidence
- keep aggregate provenance links limited to real source memory rows
- mirror the filtering behavior in the Rust pipeline parity implementation
- add TS and Rust regression coverage for recursive aggregate evidence

## Validation

- `bunx biome check platform/daemon/src/aggregate-recall.ts platform/daemon/src/aggregate-recall.test.ts`
- `bun test platform/daemon/src/aggregate-recall.test.ts`
- `rustfmt --edition 2024 --check platform/daemon-rs/crates/signet-pipeline/src/aggregate_recall.rs platform/daemon-rs/crates/signet-pipeline/tests/aggregate_recall_parity.rs`
- `cd platform/daemon-rs && cargo test -p signet-pipeline --test aggregate_recall_parity`
- `autoreview` final pass: no findings

## Notes

This fixes the recursive contamination path that caused a saved aggregate answer to become evidence for later aggregate recalls. The existing bad saved aggregate rows still need cleanup/forgetting in the live workspace, but new aggregate runs will not use those rows as source evidence after this lands.
