### PR TITLE
fix(memory): exclude aggregate memories from aggregate recall

### DIFF
--- a/platform/core/src/search.ts
+++ b/platform/core/src/search.ts
@@ -32,6 +32,7 @@ export interface SearchOptions {
 export interface VectorSearchOptions {
 	limit?: number;
 	type?: "fact" | "preference" | "decision";
+	excludeAggregateRecall?: boolean;
 }
 
 export interface HybridSearchOptions {
@@ -134,20 +135,26 @@ export function vectorSearch(
 		// sqlite-vec uses MATCH syntax for vector search
 		// The query vector must be serialized as a blob
 		const queryBlob = new Float32Array(queryVector);
+		const maxK = options?.excludeAggregateRecall ? Math.max(limit, Math.min(limit * 8, 1000)) : limit;
+		let k = limit;
 
-		// vec0 KNN queries require `k = ?` in the WHERE clause
-		const params: unknown[] = [queryBlob, limit];
+		while (true) {
+			// vec0 KNN queries require `k = ?` in the WHERE clause
+			const params: unknown[] = [queryBlob, k];
 
-		// Build type filter if specified
-		let typeFilter = "";
-		if (options?.type) {
-			typeFilter = " AND m.type = ?";
-			params.push(options.type);
-		}
+			// Build type filter if specified
+			let typeFilter = "";
+			if (options?.type) {
+				typeFilter = " AND m.type = ?";
+				params.push(options.type);
+			}
+			if (options?.excludeAggregateRecall) {
+				typeFilter += " AND COALESCE(m.source_type, '') != 'aggregate-recall'";
+			}
 
-		// Query vec_embeddings virtual table, join with embeddings to get source_id
-		const rows = db
-			.prepare(`
+			// Query vec_embeddings virtual table, join with embeddings to get source_id
+			const rows = db
+				.prepare(`
       SELECT
         e.source_id,
         v.distance
@@ -157,14 +164,18 @@ export function vectorSearch(
       WHERE v.embedding MATCH ? AND k = ?${typeFilter}
       ORDER BY v.distance
     `)
-			.all(...params) as Array<{ source_id: string; distance: number }>;
+				.all(...params) as Array<{ source_id: string; distance: number }>;
 
-		// Convert cosine distance to similarity score
-		// sqlite-vec with distance_metric=cosine returns (1 - similarity)
-		// So similarity = 1 - distance
-		for (const row of rows) {
-			const similarity = 1 - row.distance;
-			results.push({ id: row.source_id, score: Math.max(0, similarity) });
+			results.length = 0;
+			// Convert cosine distance to similarity score
+			// sqlite-vec with distance_metric=cosine returns (1 - similarity)
+			// So similarity = 1 - distance
+			for (const row of rows.slice(0, limit)) {
+				const similarity = 1 - row.distance;
+				results.push({ id: row.source_id, score: Math.max(0, similarity) });
+			}
+			if (results.length >= limit || k >= maxK || (!options?.excludeAggregateRecall && rows.length < k)) break;
+			k = Math.min(k * 2, maxK);
 		}
 	} catch (e) {
 		// Vector search may fail if no embeddings exist or vec table unavailable

--- a/platform/daemon-rs/crates/signet-core/src/search.rs
+++ b/platform/daemon-rs/crates/signet-core/src/search.rs
@@ -92,6 +92,7 @@ pub struct SearchOptions {
     pub min_score: f64,
     pub top_k: usize,
     pub memory_type: Option<String>,
+    pub exclude_aggregate_recall: bool,
 }
 
 impl Default for SearchOptions {
@@ -104,6 +105,7 @@ impl Default for SearchOptions {
             min_score: 0.1,
             top_k: 50,
             memory_type: None,
+            exclude_aggregate_recall: false,
         }
     }
 }
@@ -127,6 +129,7 @@ pub struct RecallFilter<'a> {
     pub agent_id: Option<&'a str>,
     pub read_policy: Option<&'a str>,
     pub policy_group: Option<&'a str>,
+    pub exclude_aggregate_recall: bool,
 }
 
 struct FilterClause {
@@ -177,6 +180,9 @@ fn build_filter(f: &RecallFilter) -> FilterClause {
     if let Some(project) = f.project {
         parts.push("m.project = ?".to_string());
         args.push(Box::new(project.to_string()));
+    }
+    if f.exclude_aggregate_recall {
+        parts.push("COALESCE(m.source_type, '') != 'aggregate-recall'".to_string());
     }
     if let Some(agent_id) = f.agent_id {
         match f.read_policy.unwrap_or("isolated") {
@@ -349,49 +355,67 @@ pub fn vector_search(
     query_vec: &[f32],
     limit: usize,
     memory_type: Option<&str>,
+    exclude_aggregate_recall: bool,
 ) -> Vec<(String, f64)> {
     let blob: Vec<u8> = query_vec.iter().flat_map(|f| f.to_le_bytes()).collect();
 
-    let sql = if memory_type.is_some() {
-        "SELECT e.source_id, v.distance
-         FROM vec_embeddings v
-         JOIN embeddings e ON v.id = e.id
-         JOIN memories m ON e.source_id = m.id
-         WHERE v.embedding MATCH ?1 AND k = ?2 AND m.type = ?3
-         ORDER BY v.distance"
+    let mut filters = Vec::new();
+    if memory_type.is_some() {
+        filters.push("m.type = ?".to_string());
+    }
+    if exclude_aggregate_recall {
+        filters.push("COALESCE(m.source_type, '') != 'aggregate-recall'".to_string());
+    }
+    let filter_sql = if filters.is_empty() {
+        String::new()
     } else {
+        format!(" AND {}", filters.join(" AND "))
+    };
+    let sql = format!(
         "SELECT e.source_id, v.distance
          FROM vec_embeddings v
          JOIN embeddings e ON v.id = e.id
          JOIN memories m ON e.source_id = m.id
-         WHERE v.embedding MATCH ?1 AND k = ?2
+         WHERE v.embedding MATCH ?1 AND k = ?2{filter_sql}
          ORDER BY v.distance"
-    };
+    );
 
     let result = (|| -> Result<Vec<(String, f64)>, rusqlite::Error> {
-        let mut stmt = conn.prepare(sql)?;
-
-        let collect = |row: &rusqlite::Row| -> rusqlite::Result<(String, f64)> {
-            Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?))
-        };
-
-        let raw: Vec<(String, f64)> = if let Some(t) = memory_type {
-            stmt.query_map(params![blob, limit, t], collect)?
-                .filter_map(|r| r.ok())
-                .collect()
+        let max_k = if exclude_aggregate_recall {
+            limit.max((limit * 8).min(1000))
         } else {
-            stmt.query_map(params![blob, limit], collect)?
-                .filter_map(|r| r.ok())
-                .collect()
+            limit
         };
+        let mut k = limit;
+        let out = loop {
+            let mut stmt = conn.prepare(&sql)?;
+            let collect = |row: &rusqlite::Row| -> rusqlite::Result<(String, f64)> {
+                Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?))
+            };
+            let raw: Vec<(String, f64)> = if let Some(t) = memory_type {
+                stmt.query_map(params![blob.clone(), k, t], collect)?
+                    .filter_map(|r| r.ok())
+                    .collect()
+            } else {
+                stmt.query_map(params![blob.clone(), k], collect)?
+                    .filter_map(|r| r.ok())
+                    .collect()
+            };
 
-        Ok(raw
-            .into_iter()
-            .map(|(id, dist)| {
-                let sim = (1.0 - dist).max(0.0);
-                (id, sim)
-            })
-            .collect())
+            let out = raw
+                .into_iter()
+                .take(limit)
+                .map(|(id, dist)| {
+                    let sim = (1.0 - dist).max(0.0);
+                    (id, sim)
+                })
+                .collect::<Vec<_>>();
+            if out.len() >= limit || k >= max_k || !exclude_aggregate_recall {
+                break out;
+            }
+            k = (k * 2).min(max_k);
+        };
+        Ok(out)
     })();
 
     match result {
@@ -411,34 +435,48 @@ pub fn vec_search_scored(
     filter: &RecallFilter,
 ) -> Vec<ScoredHit> {
     let blob: Vec<u8> = query_vec.iter().flat_map(|f| f.to_le_bytes()).collect();
-    let fc = build_filter(filter);
-    let sql = format!(
-        "SELECT e.source_id, v.distance
-         FROM vec_embeddings v
-         JOIN embeddings e ON v.id = e.id
-         JOIN memories m ON e.source_id = m.id
-         WHERE v.embedding MATCH ? AND k = ?{filter_sql}
-         ORDER BY v.distance",
-        filter_sql = fc.sql,
-    );
 
     let result = (|| -> Result<Vec<ScoredHit>, rusqlite::Error> {
-        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-        params.push(Box::new(blob));
-        params.push(Box::new(top_k as i64));
-        params.extend(fc.args);
-        let refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|b| b.as_ref()).collect();
+        let max_k = if filter.exclude_aggregate_recall {
+            top_k.max((top_k * 8).min(1000))
+        } else {
+            top_k
+        };
+        let mut k = top_k;
+        let out = loop {
+            let fc = build_filter(filter);
+            let sql = format!(
+                "SELECT e.source_id, v.distance
+                 FROM vec_embeddings v
+                 JOIN embeddings e ON v.id = e.id
+                 JOIN memories m ON e.source_id = m.id
+                 WHERE v.embedding MATCH ? AND k = ?{filter_sql}
+                 ORDER BY v.distance",
+                filter_sql = fc.sql,
+            );
+            let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+            params.push(Box::new(blob.clone()));
+            params.push(Box::new(k as i64));
+            params.extend(fc.args);
+            let refs: Vec<&dyn rusqlite::types::ToSql> =
+                params.iter().map(|b| b.as_ref()).collect();
 
-        let mut stmt = conn.prepare(&sql)?;
-        let rows = stmt.query_map(refs.as_slice(), |row| {
-            let dist = row.get::<_, f64>(1)?;
-            Ok(ScoredHit {
-                id: row.get(0)?,
-                score: (1.0 - dist).max(0.0),
-                source: SearchSource::Vector,
-            })
-        })?;
-        Ok(rows.filter_map(|r| r.ok()).collect())
+            let mut stmt = conn.prepare(&sql)?;
+            let rows = stmt.query_map(refs.as_slice(), |row| {
+                let dist = row.get::<_, f64>(1)?;
+                Ok(ScoredHit {
+                    id: row.get(0)?,
+                    score: (1.0 - dist).max(0.0),
+                    source: SearchSource::Vector,
+                })
+            })?;
+            let out = rows.filter_map(|r| r.ok()).take(top_k).collect::<Vec<_>>();
+            if out.len() >= top_k || k >= max_k || !filter.exclude_aggregate_recall {
+                break out;
+            }
+            k = (k * 2).min(max_k);
+        };
+        Ok(out)
     })();
 
     match result {
@@ -1803,12 +1841,34 @@ pub fn hybrid_search(conn: &Connection, opts: &SearchOptions) -> Result<Vec<Sear
 
     // Vector search
     let vec_results = match &opts.vector {
-        Some(v) => vector_search(conn, v, top_k, opts.memory_type.as_deref()),
+        Some(v) => vector_search(
+            conn,
+            v,
+            top_k,
+            opts.memory_type.as_deref(),
+            opts.exclude_aggregate_recall,
+        ),
         None => Vec::new(),
     };
 
     // Keyword search
-    let kw_results = keyword_search(conn, &opts.query, top_k);
+    let kw_results = if opts.exclude_aggregate_recall {
+        fts_search(
+            conn,
+            &opts.query,
+            top_k,
+            &RecallFilter {
+                memory_type: opts.memory_type.as_deref(),
+                exclude_aggregate_recall: true,
+                ..RecallFilter::default()
+            },
+        )?
+        .into_iter()
+        .map(|hit| (hit.id, hit.score))
+        .collect()
+    } else {
+        keyword_search(conn, &opts.query, top_k)
+    };
 
     // Build score maps
     let vec_map: HashMap<&str, f64> = vec_results
@@ -2409,7 +2469,7 @@ mod tests {
 
         // Search with a very similar vector
         let query: Vec<f32> = (0..768).map(|i| (i as f32) / 768.0 + 0.001).collect();
-        let results = vector_search(&conn, &query, 10, None);
+        let results = vector_search(&conn, &query, 10, None, false);
 
         assert!(!results.is_empty());
         assert_eq!(results[0].0, "m1");

--- a/platform/daemon-rs/crates/signet-core/tests/embedding_upsert.rs
+++ b/platform/daemon-rs/crates/signet-core/tests/embedding_upsert.rs
@@ -63,7 +63,7 @@ fn upsert_embedding_stamps_agent_and_syncs_vec_index() {
         .expect("read vec count");
     assert_eq!(vec_count, 1);
 
-    let results = vector_search(&conn, &vector, 5, None);
+    let results = vector_search(&conn, &vector, 5, None, false);
     assert_eq!(
         results.first().map(|(id, _)| id.as_str()),
         Some("mem-agent")

--- a/platform/daemon-rs/crates/signet-daemon/src/routes/search.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes/search.rs
@@ -650,6 +650,7 @@ pub async fn recall(
                 agent_id: Some(agent_id.as_str()),
                 read_policy: Some(read_policy.as_str()),
                 policy_group: policy_group.as_deref(),
+                exclude_aggregate_recall: false,
             };
 
             // Candidate collection order follows TS memory-search.ts:997/1162/1203/1261/1290/1333/1378.

--- a/platform/daemon-rs/crates/signet-pipeline/src/aggregate_recall.rs
+++ b/platform/daemon-rs/crates/signet-pipeline/src/aggregate_recall.rs
@@ -155,6 +155,8 @@ pub struct AggregateRecallParams {
     pub read_policy: Option<String>,
     #[serde(default)]
     pub project: Option<String>,
+    #[serde(default)]
+    pub exclude_aggregate_recall_memories: bool,
 }
 
 impl AggregateRecallParams {
@@ -1193,6 +1195,7 @@ fn default_hybrid_recall(
             query: params.query.clone(),
             vector: None,
             limit: 10,
+            exclude_aggregate_recall: true,
             ..SearchOptions::default()
         },
     )?;
@@ -1200,7 +1203,7 @@ fn default_hybrid_recall(
     for hit in hits {
         let row = conn
             .query_row(
-                "SELECT source_id, tags, pinned, importance, who, project, created_at, visibility, scope
+                "SELECT source_id, tags, pinned, importance, who, project, created_at, visibility, scope, source_type
                  FROM memories WHERE id = ?1",
                 params![hit.id],
                 |row| {
@@ -1214,22 +1217,37 @@ fn default_hybrid_recall(
                         row.get::<_, String>(6)?,
                         row.get::<_, Option<String>>(7)?,
                         row.get::<_, Option<String>>(8)?,
+                        row.get::<_, Option<String>>(9)?,
                     ))
                 },
             )
             .optional()?;
-        let (source_id, tags, pinned, importance, who, project, created_at, visibility, scope) =
-            row.unwrap_or((
-                None,
-                None,
-                0,
-                hit.confidence,
-                None,
-                None,
-                Utc::now().to_rfc3339(),
-                Some("global".to_string()),
-                None,
-            ));
+        let (
+            source_id,
+            tags,
+            pinned,
+            importance,
+            who,
+            project,
+            created_at,
+            visibility,
+            scope,
+            source_type,
+        ) = row.unwrap_or((
+            None,
+            None,
+            0,
+            hit.confidence,
+            None,
+            None,
+            Utc::now().to_rfc3339(),
+            Some("global".to_string()),
+            None,
+            None,
+        ));
+        if source_type.as_deref() == Some("aggregate-recall") {
+            continue;
+        }
         results.push(RecallResult {
             id: hit.id,
             content_length: hit.content.len(),
@@ -1249,6 +1267,9 @@ fn default_hybrid_recall(
             visibility,
             scope,
         });
+        if results.len() >= 10 {
+            break;
+        }
     }
     let total_returned = results.len();
     Ok(RecallResponse {
@@ -1281,9 +1302,11 @@ pub async fn aggregate_recall(
         .unwrap_or_else(Utc::now)
         .to_rfc3339();
 
+    let mut initial_recall_params = params.clone();
+    initial_recall_params.exclude_aggregate_recall_memories = true;
     let first = timings
         .time_async("aggregate_initial_recall", || {
-            run_recall(conn, deps.recall, params.clone())
+            run_recall(conn, deps.recall, initial_recall_params.clone())
         })
         .await?;
 
@@ -1334,6 +1357,7 @@ pub async fn aggregate_recall(
                     let mut followup = params.clone();
                     followup.query = query;
                     followup.aggregate = false;
+                    followup.exclude_aggregate_recall_memories = true;
                     responses.push(run_recall(conn, deps.recall, followup).await?);
                 }
                 Ok::<_, AggregateRecallError>(responses)

--- a/platform/daemon-rs/crates/signet-pipeline/tests/aggregate_recall_parity.rs
+++ b/platform/daemon-rs/crates/signet-pipeline/tests/aggregate_recall_parity.rs
@@ -77,6 +77,7 @@ fn response(query: &str, results: Vec<RecallResult>) -> RecallResponse {
 #[derive(Default)]
 struct StaticRecall {
     calls: RefCell<Vec<String>>,
+    exclude_flags: RefCell<Vec<bool>>,
     by_query: HashMap<String, Vec<RecallResult>>,
 }
 
@@ -89,6 +90,10 @@ impl StaticRecall {
     fn calls(&self) -> Vec<String> {
         self.calls.borrow().clone()
     }
+
+    fn exclude_flags(&self) -> Vec<bool> {
+        self.exclude_flags.borrow().clone()
+    }
 }
 
 impl AggregateRecallProvider for StaticRecall {
@@ -99,6 +104,9 @@ impl AggregateRecallProvider for StaticRecall {
     ) -> BoxAggregateFuture<'a, Result<RecallResponse, AggregateRecallError>> {
         Box::pin(async move {
             self.calls.borrow_mut().push(params.query.clone());
+            self.exclude_flags
+                .borrow_mut()
+                .push(params.exclude_aggregate_recall_memories);
             let rows = self
                 .by_query
                 .get(&params.query)
@@ -249,6 +257,93 @@ async fn rejects_invalid_aggregate_budget() {
     .await
     .expect_err("invalid budgets should reject");
     assert!(matches!(err, AggregateRecallError::InvalidBudget));
+}
+
+#[tokio::test]
+async fn provider_recalls_are_marked_to_exclude_aggregate_created_memories() {
+    let conn = setup_conn();
+    let recall = StaticRecall::default()
+        .with("what happened", vec![row("mem-1", "First evidence")])
+        .with("follow up one", vec![row("mem-2", "Second evidence")])
+        .with("follow up two", vec![row("mem-3", "Third evidence")]);
+    let router = StaticRouter::default();
+
+    aggregate_recall(
+        &conn,
+        AggregateRecallParams {
+            query: "what happened".to_string(),
+            aggregate: true,
+            agent_id: Some("agent-a".to_string()),
+            ..AggregateRecallParams::default()
+        },
+        AggregateRecallDeps {
+            recall: Some(&recall),
+            router: Some(&router),
+            ..AggregateRecallDeps::default()
+        },
+    )
+    .await
+    .expect("aggregate result");
+
+    let flags = recall.exclude_flags();
+    assert!(!flags.is_empty());
+    assert!(flags.iter().all(|flag| *flag));
+}
+
+#[tokio::test]
+async fn default_aggregate_recall_excludes_aggregate_created_memories() {
+    let conn = setup_conn();
+    conn.execute(
+        "INSERT INTO memories (
+            id, content, type, source_type, source_id, agent_id, visibility, created_at, updated_at, updated_by, importance
+        ) VALUES (?1, ?2, 'fact', 'aggregate-recall', 'aggregate-recall:old', 'agent-a', 'global', datetime('now'), datetime('now'), 'test', 0.9)",
+        params!["aggregate-created-memory", "alpha stale aggregate-created summary"],
+    )
+    .expect("insert aggregate memory");
+    conn.execute(
+        "INSERT INTO memories (
+            id, content, type, agent_id, visibility, created_at, updated_at, updated_by, importance
+        ) VALUES (?1, ?2, 'fact', 'agent-a', 'global', datetime('now'), datetime('now'), 'test', 0.9)",
+        params!["ordinary-memory", "alpha ordinary source evidence"],
+    )
+    .expect("insert ordinary memory");
+
+    let router = StaticRouter::default();
+    let result = aggregate_recall(
+        &conn,
+        AggregateRecallParams {
+            query: "alpha".to_string(),
+            aggregate: true,
+            agent_id: Some("agent-a".to_string()),
+            read_policy: Some("isolated".to_string()),
+            ..AggregateRecallParams::default()
+        },
+        AggregateRecallDeps {
+            router: Some(&router),
+            ..AggregateRecallDeps::default()
+        },
+    )
+    .await
+    .expect("aggregate result");
+
+    assert_eq!(
+        result
+            .aggregate
+            .expect("aggregate metadata")
+            .source_memory_ids,
+        vec!["ordinary-memory"]
+    );
+    let prompts = router.prompts.borrow();
+    assert!(
+        prompts
+            .iter()
+            .any(|prompt| prompt.contains("ordinary source evidence"))
+    );
+    assert!(
+        !prompts
+            .iter()
+            .any(|prompt| prompt.contains("stale aggregate-created"))
+    );
 }
 
 #[tokio::test]

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -785,6 +785,30 @@ memory:
 		expect(links.map((link) => link.source_memory_id)).toEqual(["mem-1"]);
 	});
 
+	it("marks every recall during aggregate synthesis to exclude aggregate-created memories", async () => {
+		const seen: Array<boolean | undefined> = [];
+		await aggregateRecall(
+			{
+				query: "what happened",
+				aggregate: true,
+				agentId: "agent-a",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: new StaticRouter(),
+				embedFn: async () => null,
+				logger: quietLogger(),
+				hybridRecall: async (params: RecallParams) => {
+					seen.push(params.excludeAggregateRecallMemories);
+					return response(params.query, [row(`mem-${seen.length}`, "Real evidence")]);
+				},
+			},
+		);
+
+		expect(seen.length).toBeGreaterThan(0);
+		expect(seen.every((value) => value === true)).toBe(true);
+	});
+
 	it("does not use saved aggregate recall rows as aggregate evidence", async () => {
 		const router = new StaticRouter();
 		const result = await aggregateRecall(

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -751,7 +751,10 @@ export async function aggregateRecall(
 				: response.aggregate,
 		};
 	};
-	const first = await timings.timeAsync("aggregate_initial_recall", () => recall(params, cfg, deps.embedFn));
+	const aggregateRecallParams: RecallParams = { ...params, excludeAggregateRecallMemories: true };
+	const first = await timings.timeAsync("aggregate_initial_recall", () =>
+		recall(aggregateRecallParams, cfg, deps.embedFn),
+	);
 
 	if (!deps.router) {
 		const firstEvidence = uniqueEvidence(first.results);
@@ -790,6 +793,7 @@ export async function aggregateRecall(
 									...params,
 									query,
 									aggregate: false,
+									excludeAggregateRecallMemories: true,
 								},
 								cfg,
 								deps.embedFn,

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -115,6 +115,58 @@ describe("hybridRecall", () => {
 		});
 	}
 
+	it("keeps aggregate-created memories out of aggregate recall only", async () => {
+		const now = new Date().toISOString();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, source_type, source_id, agent_id, visibility, created_at, updated_at, updated_by
+				) VALUES (?, ?, 'fact', ?, ?, ?, 'global', ?, ?, 'test')`,
+			).run(
+				"aggregate-created-memory",
+				"alpha aggregate-created stale summary",
+				"aggregate-recall",
+				"aggregate-recall:old-key",
+				"agent-a",
+				now,
+				now,
+			);
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, visibility, created_at, updated_at, updated_by
+				) VALUES (?, ?, 'fact', ?, 'global', ?, ?, 'test')`,
+			).run("ordinary-memory", "alpha ordinary source evidence", "agent-a", now, now);
+		});
+
+		const normal = await hybridRecall(
+			{
+				query: "alpha",
+				keywordQuery: "alpha",
+				limit: 5,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			async () => null,
+		);
+		expect(normal.results.map((row) => row.id)).toContain("aggregate-created-memory");
+
+		const aggregate = await hybridRecall(
+			{
+				query: "alpha",
+				keywordQuery: "alpha",
+				limit: 5,
+				aggregate: true,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			async () => null,
+		);
+		expect(aggregate.results.map((row) => row.id)).not.toContain("aggregate-created-memory");
+		expect(aggregate.results.map((row) => row.id)).toContain("ordinary-memory");
+	});
+
 	it("keeps recall memory-only even when legacy expand is requested", async () => {
 		const now = new Date().toISOString();
 		getDbAccessor().withWriteTx((db) => {

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -90,6 +90,8 @@ export interface RecallParams {
 	recallMode?: string;
 	/** Internal escape hatch for hooks that must claim only injected rows. */
 	claimRecallResults?: boolean;
+	/** Internal aggregate-recall guard: derived aggregate memories may be returned by normal recall, but never as aggregate evidence. */
+	excludeAggregateRecallMemories?: boolean;
 	/** Internal escape hatch for hooks that must track only injected rows elsewhere. */
 	trackRecallAccess?: boolean;
 }
@@ -271,6 +273,9 @@ function buildFilterClause(params: RecallParams): FilterClause {
 	if (typeof params.importance_min === "number") {
 		parts.push("m.importance >= ?");
 		args.push(params.importance_min);
+	}
+	if (params.aggregate === true || params.excludeAggregateRecallMemories === true) {
+		parts.push("COALESCE(m.source_type, '') != 'aggregate-recall'");
 	}
 	if (params.since) {
 		parts.push("m.created_at >= ?");
@@ -1362,13 +1367,15 @@ export async function hybridRecall(
 	const vectorMap = new Map<string, number>();
 	if (queryVecF32) {
 		const queryVector = queryVecF32;
-		const vecLimit = needsPostFilter ? cfg.search.top_k * 2 : cfg.search.top_k;
+		const excludeAggregateRecall = params.aggregate === true || params.excludeAggregateRecallMemories === true;
+		const vecLimit = needsPostFilter || excludeAggregateRecall ? cfg.search.top_k * 2 : cfg.search.top_k;
 		try {
 			timings.time("vector_search", () => {
 				getDbAccessor().withReadDb((db) => {
 					const vecResults = vectorSearch(db as any, queryVector, {
 						limit: vecLimit,
 						type: params.type as "fact" | "preference" | "decision" | undefined,
+						excludeAggregateRecall,
 					});
 					for (const r of vecResults) {
 						vectorMap.set(r.id, r.score);


### PR DESCRIPTION
## Summary
- Exclude memories created by `aggregate-recall` from aggregate recall candidate collection/evidence.
- Preserve normal non-aggregate recall behavior so those saved aggregate memories can still be returned directly.
- Thread an internal `excludeAggregateRecallMemories` / Rust parity flag through initial and follow-up aggregate recalls.
- Apply the exclusion in TS keyword/vector filters and Rust core search/default aggregate recall, including bounded vector retry/over-fetch so aggregate rows cannot consume the KNN budget.

## Readiness checklist
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Validation
- `bun run --filter '@signet/core' build`
- `bun test platform/daemon/src/memory-search.test.ts platform/daemon/src/aggregate-recall.test.ts`
- `cd platform/daemon-rs && cargo test -p signet-pipeline --test aggregate_recall_parity`
- `cd platform/daemon-rs && cargo test -p signet-core search::tests::vector_search_basic`
- `bunx biome check platform/core/src/search.ts platform/daemon/src/memory-search.ts platform/daemon/src/memory-search.test.ts platform/daemon/src/aggregate-recall.ts platform/daemon/src/aggregate-recall.test.ts` (only existing `noExplicitAny` warnings in `memory-search.ts`)
- `rustfmt --edition 2024 --check platform/daemon-rs/crates/signet-core/src/search.rs platform/daemon-rs/crates/signet-core/tests/embedding_upsert.rs platform/daemon-rs/crates/signet-daemon/src/routes/search.rs platform/daemon-rs/crates/signet-pipeline/src/aggregate_recall.rs platform/daemon-rs/crates/signet-pipeline/tests/aggregate_recall_parity.rs`
- `autoreview` final pass: no findings
