### PR TITLE
fix(hooks): queue rendered Codex transcripts

### DIFF
--- a/platform/daemon/src/transcript-normalization.test.ts
+++ b/platform/daemon/src/transcript-normalization.test.ts
@@ -20,6 +20,11 @@ describe("transcript normalization", () => {
 		expect(normalizeSessionTranscript("test", "User: plain text")).toBe("User: plain text");
 	});
 
+	it("falls back to raw text for rendered Codex transcripts", () => {
+		const raw = "User: plain Codex transcript\nAssistant: queued";
+		expect(normalizeSessionTranscript("codex", raw)).toBe(raw);
+	});
+
 	it("normalizes generic JSON-line conversations", () => {
 		const raw = [
 			JSON.stringify({ role: "user", content: "question" }),

--- a/platform/daemon/src/transcript-normalization.test.ts
+++ b/platform/daemon/src/transcript-normalization.test.ts
@@ -25,6 +25,15 @@ describe("transcript normalization", () => {
 		expect(normalizeSessionTranscript("codex", raw)).toBe(raw);
 	});
 
+	it("uses generic JSONL turns when Codex-specific events are absent", () => {
+		const raw = [
+			JSON.stringify({ role: "user", content: "generic question" }),
+			JSON.stringify({ role: "assistant", content: "generic answer" }),
+		].join("\n");
+
+		expect(normalizeSessionTranscript("codex", raw)).toBe("User: generic question\nAssistant: generic answer");
+	});
+
 	it("normalizes generic JSON-line conversations", () => {
 		const raw = [
 			JSON.stringify({ role: "user", content: "question" }),

--- a/platform/daemon/src/transcript-normalization.ts
+++ b/platform/daemon/src/transcript-normalization.ts
@@ -12,7 +12,9 @@ export function normalizeSessionTranscript(
 ): string {
 	if (harness.trim().toLowerCase() === "codex") {
 		const codex = normalizeCodexTranscript(raw);
-		if (codex || normalizeJsonConversationTranscript(raw) !== null) return codex;
+		if (codex) return codex;
+		const generic = normalizeJsonConversationTranscript(raw);
+		if (generic !== null) return generic;
 		return raw;
 	}
 

--- a/platform/daemon/src/transcript-normalization.ts
+++ b/platform/daemon/src/transcript-normalization.ts
@@ -11,7 +11,9 @@ export function normalizeSessionTranscript(
 	onEmptyJsonConversation?: EmptyJsonConversationReporter,
 ): string {
 	if (harness.trim().toLowerCase() === "codex") {
-		return normalizeCodexTranscript(raw);
+		const codex = normalizeCodexTranscript(raw);
+		if (codex || normalizeJsonConversationTranscript(raw) !== null) return codex;
+		return raw;
 	}
 
 	const result = normalizeJsonConversationTranscript(raw);


### PR DESCRIPTION
## Summary
- Treat Codex plain-text rendered transcripts as valid session-end transcript input.
- Keep JSONL normalization for raw Codex event logs, but fall back to raw text when payload is already rendered conversation text.

## Verification
- `bun test platform/daemon/src/transcript-normalization.test.ts` -> 6 pass, 0 fail.
- Live mac differential: `claude-code` and `codex` both returned `queued: true` for prefix `codex-queue-66fc395a`; both appeared in `summary_jobs` and `transcript_capture_jobs` with `transcript_len=2220`.

## Context
- Fixes the Codex session-end rejection observed during Signet memory lifecycle repair.
