### PR TITLE
fix(migrations): repair memory lifecycle lineage

### DIFF
--- a/platform/core/src/migrations/083-memory-lifecycle-repair.ts
+++ b/platform/core/src/migrations/083-memory-lifecycle-repair.ts
@@ -1,0 +1,170 @@
+import { up as transcriptCaptureJobs } from "./079-transcript-capture-jobs";
+import { up as documentScopeColumns } from "./080-document-scope-columns";
+import { up as aggregateEvidenceSources } from "./081-aggregate-evidence-sources";
+import type { MigrationDb } from "./index";
+
+const DEPENDENCY_TYPES = new Set([
+	"uses",
+	"requires",
+	"owned_by",
+	"owns",
+	"blocks",
+	"informs",
+	"maintains",
+	"implements",
+	"built",
+	"depends_on",
+	"related_to",
+	"learned_from",
+	"teaches",
+	"knows",
+	"assumes",
+	"supports_claim",
+	"authored_by",
+	"links_to",
+	"contains",
+	"contains_note",
+	"contradicts",
+	"supersedes",
+	"part_of",
+	"produced_artifact",
+	"precedes",
+	"follows",
+	"triggers",
+	"may_execute",
+	"requires_approval_from",
+	"impacts",
+	"produces",
+	"consumes",
+]);
+
+function sqlStringList(values: ReadonlySet<string>): string {
+	return [...values].map((value) => `'${value}'`).join(", ");
+}
+
+function hasTable(db: MigrationDb, table: string): boolean {
+	return Boolean(db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(table));
+}
+
+function hasColumn(db: MigrationDb, table: string, column: string): boolean {
+	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;
+	return rows.some((row) => row.name === column);
+}
+
+function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
+	if (!hasColumn(db, table, column)) db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+}
+
+function documentScopeColumnsPreservingExisting(db: MigrationDb): void {
+	const preserveAgentId = hasColumn(db, "documents", "agent_id");
+	const preserveProject = hasColumn(db, "documents", "project");
+	if (preserveAgentId) {
+		db.exec(`
+			CREATE TEMP TABLE __signet_doc_agent_guard AS
+			SELECT id, agent_id FROM documents
+			WHERE NULLIF(TRIM(agent_id), '') IS NOT NULL
+			  AND NULLIF(TRIM(agent_id), '') <> 'default'
+		`);
+	}
+	if (preserveProject) {
+		db.exec(`
+			CREATE TEMP TABLE __signet_doc_project_guard AS
+			SELECT id, project FROM documents
+			WHERE NULLIF(TRIM(project), '') IS NOT NULL
+		`);
+	}
+	try {
+		documentScopeColumns(db);
+		if (preserveAgentId) {
+			db.exec(`
+				UPDATE documents
+				SET agent_id = (SELECT agent_id FROM __signet_doc_agent_guard WHERE __signet_doc_agent_guard.id = documents.id)
+				WHERE EXISTS (SELECT 1 FROM __signet_doc_agent_guard WHERE __signet_doc_agent_guard.id = documents.id)
+			`);
+		}
+		if (preserveProject) {
+			db.exec(`
+				UPDATE documents
+				SET project = (SELECT project FROM __signet_doc_project_guard WHERE __signet_doc_project_guard.id = documents.id)
+				WHERE EXISTS (SELECT 1 FROM __signet_doc_project_guard WHERE __signet_doc_project_guard.id = documents.id)
+			`);
+		}
+	} finally {
+		db.exec("DROP TABLE IF EXISTS temp.__signet_doc_agent_guard");
+		db.exec("DROP TABLE IF EXISTS temp.__signet_doc_project_guard");
+	}
+}
+
+export function up(db: MigrationDb): void {
+	// Long-lived mac DBs used versions 79-81 for local memory lifecycle patches
+	// before upstream assigned those versions. Re-run upstream's idempotent 79-81
+	// migrations here so collided DBs get the upstream artifacts too.
+	transcriptCaptureJobs(db);
+	if (hasTable(db, "documents")) {
+		documentScopeColumnsPreservingExisting(db);
+	}
+	aggregateEvidenceSources(db);
+
+	addColumnIfMissing(db, "memories", "superseded_by", "TEXT");
+	addColumnIfMissing(db, "memories", "superseded_at", "TEXT");
+	addColumnIfMissing(db, "memories", "superseded_reason", "TEXT");
+	db.exec("CREATE INDEX IF NOT EXISTS idx_memories_superseded_by ON memories(superseded_by)");
+	db.exec("CREATE INDEX IF NOT EXISTS idx_memories_active_supersession ON memories(is_deleted, superseded_by)");
+
+	if (!hasTable(db, "relations") || !hasTable(db, "entity_dependencies")) return;
+
+	addColumnIfMissing(db, "entity_dependencies", "confidence", "REAL");
+	addColumnIfMissing(db, "entity_dependencies", "reason", "TEXT");
+	addColumnIfMissing(db, "entity_dependencies", "source_id", "TEXT");
+	addColumnIfMissing(db, "entity_dependencies", "source_kind", "TEXT");
+	addColumnIfMissing(db, "entity_dependencies", "proposal_evidence", "TEXT NOT NULL DEFAULT '[]'");
+	addColumnIfMissing(db, "entity_dependencies", "status", "TEXT NOT NULL DEFAULT 'active'");
+
+	const relationConfidence = hasColumn(db, "relations", "confidence") ? "r.confidence" : "NULL";
+	const relationUpdatedAt = hasColumn(db, "relations", "updated_at") ? "r.updated_at" : "r.created_at";
+	const sourceAgentId = hasColumn(db, "entities", "agent_id")
+		? "COALESCE(NULLIF(TRIM(src.agent_id), ''), 'default')"
+		: "'default'";
+	const targetAgentId = hasColumn(db, "entities", "agent_id")
+		? "COALESCE(NULLIF(TRIM(dst.agent_id), ''), 'default')"
+		: "'default'";
+
+	db.exec(`
+		INSERT OR IGNORE INTO entity_dependencies (
+			id,
+			source_entity_id,
+			target_entity_id,
+			agent_id,
+			dependency_type,
+			strength,
+			confidence,
+			reason,
+			created_at,
+			updated_at,
+			source_id,
+			source_kind,
+			proposal_evidence,
+			status
+		)
+		SELECT
+			'relation:' || r.id,
+			r.source_entity_id,
+			r.target_entity_id,
+			COALESCE(${sourceAgentId}, ${targetAgentId}, 'default'),
+			CASE WHEN r.relation_type IN (${sqlStringList(DEPENDENCY_TYPES)}) THEN r.relation_type ELSE 'related_to' END,
+			MAX(0.1, MIN(1.0, COALESCE(r.strength, 0.5))),
+			MAX(0.1, MIN(1.0, COALESCE(${relationConfidence}, 0.7))),
+			'legacy relation backfill: ' || r.relation_type,
+			COALESCE(r.created_at, datetime('now')),
+			COALESCE(${relationUpdatedAt}, r.created_at, datetime('now')),
+			r.id,
+			'relation',
+			'[]',
+			'active'
+		FROM relations r
+		JOIN entities src ON src.id = r.source_entity_id
+		JOIN entities dst ON dst.id = r.target_entity_id
+		WHERE r.source_entity_id <> r.target_entity_id
+		  AND ${sourceAgentId} = ${targetAgentId}
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -88,6 +88,7 @@ import { up as transcriptCaptureJobs } from "./079-transcript-capture-jobs";
 import { up as documentScopeColumns } from "./080-document-scope-columns";
 import { up as aggregateEvidenceSources } from "./081-aggregate-evidence-sources";
 import { up as skillInvocationsHarness } from "./082-skill-invocations-harness";
+import { up as memoryLifecycleRepair } from "./083-memory-lifecycle-repair";
 
 // -- Public interface consumed by Database.init() --
 
@@ -783,6 +784,21 @@ export const MIGRATIONS: readonly Migration[] = [
 			columns: [
 				{ table: "skill_invocations", column: "harness" },
 				{ table: "skill_invocations", column: "tool_use_id" },
+			],
+		},
+	},
+	{
+		version: 83,
+		name: "memory-lifecycle-repair",
+		up: memoryLifecycleRepair,
+		artifacts: {
+			tables: ["transcript_capture_jobs", "aggregate_evidence_sources", "entity_dependencies"],
+			columns: [
+				{ table: "documents", column: "agent_id" },
+				{ table: "documents", column: "project" },
+				{ table: "memories", column: "superseded_by" },
+				{ table: "memories", column: "superseded_at" },
+				{ table: "memories", column: "superseded_reason" },
 			],
 		},
 	},

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -14,6 +14,7 @@ import { up as agentScopedTemporalUniqueness } from "./047-agent-scoped-temporal
 import { up as threadHeadsMigration } from "./048-thread-heads";
 import { up as ontologyControlPlaneState } from "./070-ontology-control-plane-state";
 import { up as documentScopeColumns } from "./080-document-scope-columns";
+import { up as memoryLifecycleRepair } from "./083-memory-lifecycle-repair";
 import { MIGRATIONS, hasPendingMigrations, runMigrations } from "./index";
 
 function createFreshDb(): Database {
@@ -1048,6 +1049,130 @@ describe("migration framework", () => {
 		expect(colNames).toContain("success");
 		expect(colNames).toContain("error_text");
 		expect(colNames).toContain("created_at");
+	});
+
+	test("migration 083 backfills legacy relations idempotently", () => {
+		db = createFreshDb();
+		runMigrations(db);
+
+		db.query(
+			`INSERT INTO entities (id, name, canonical_name, entity_type, agent_id, created_at, updated_at)
+			 VALUES ('entity-source', 'Source', 'source', 'concept', 'agent-a', '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z')`,
+		).run();
+		db.query(
+			`INSERT INTO entities (id, name, canonical_name, entity_type, agent_id, created_at, updated_at)
+			 VALUES ('entity-target', 'Target', 'target', 'concept', 'agent-a', '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z')`,
+		).run();
+		db.query(
+			`INSERT INTO entities (id, name, canonical_name, entity_type, agent_id, created_at, updated_at)
+			 VALUES ('entity-other-agent', 'Other', 'other', 'concept', 'agent-b', '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z')`,
+		).run();
+		db.query(
+			`INSERT INTO relations (id, source_entity_id, target_entity_id, relation_type, strength, created_at)
+			 VALUES ('legacy-rel', 'entity-source', 'entity-target', 'unknown_local_type', 0.8, '2026-07-01T00:00:01.000Z')`,
+		).run();
+		db.query(
+			`INSERT INTO relations (id, source_entity_id, target_entity_id, relation_type, strength, created_at)
+			 VALUES ('cross-agent-rel', 'entity-source', 'entity-other-agent', 'related_to', 0.9, '2026-07-01T00:00:02.000Z')`,
+		).run();
+		db.query(
+			`INSERT INTO documents (id, source_type, metadata_json, agent_id, project, created_at, updated_at)
+			 VALUES ('doc-guard', 'obsidian', '{"signet":{"agentId":"metadata-agent","project":"/old"}}', 'corrected-agent', '/corrected', '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z')`,
+		).run();
+		db.query(
+			`INSERT INTO memories (id, content, content_hash, type, source_type, visibility, agent_id, created_at, updated_at, updated_by)
+			 VALUES ('doc-memory-guard', 'chunk', 'doc-hash-guard', 'document_chunk', 'document', 'global', 'corrected-agent', '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z', 'test')`,
+		).run();
+		db.query("INSERT INTO document_memories (document_id, memory_id) VALUES ('doc-guard', 'doc-memory-guard')").run();
+		db.query(
+			`INSERT INTO documents (id, source_type, metadata_json, agent_id, project, created_at, updated_at)
+			 VALUES ('doc-placeholder', 'obsidian', '{"signet":{"agentId":"metadata-agent","project":"/metadata"}}', 'default', NULL, '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z')`,
+		).run();
+		db.exec("DROP INDEX IF EXISTS idx_documents_agent_project");
+		db.exec("DROP INDEX IF EXISTS idx_documents_source_scope");
+
+		memoryLifecycleRepair(db);
+		memoryLifecycleRepair(db);
+
+		const row = db
+			.query(
+				`SELECT id, agent_id, dependency_type, strength, confidence, reason, source_id, source_kind, status, created_at, updated_at
+				 FROM entity_dependencies WHERE id = 'relation:legacy-rel'`,
+			)
+			.get() as {
+			id: string;
+			agent_id: string;
+			dependency_type: string;
+			strength: number;
+			confidence: number;
+			reason: string;
+			source_id: string;
+			source_kind: string;
+			status: string;
+			created_at: string;
+			updated_at: string;
+		};
+		expect(row).toEqual({
+			id: "relation:legacy-rel",
+			agent_id: "agent-a",
+			dependency_type: "related_to",
+			strength: 0.8,
+			confidence: 0.5,
+			reason: "legacy relation backfill: unknown_local_type",
+			source_id: "legacy-rel",
+			source_kind: "relation",
+			status: "active",
+			created_at: "2026-07-01T00:00:01.000Z",
+			updated_at: "2026-07-01T00:00:01.000Z",
+		});
+		const { count } = db
+			.query("SELECT COUNT(*) AS count FROM entity_dependencies WHERE id = 'relation:legacy-rel'")
+			.get() as { count: number };
+		expect(count).toBe(1);
+		const crossAgent = db.query("SELECT id FROM entity_dependencies WHERE id = 'relation:cross-agent-rel'").get();
+		expect(crossAgent).toBeNull();
+		const guardedDocument = db.query("SELECT agent_id, project FROM documents WHERE id = 'doc-guard'").get() as {
+			agent_id: string;
+			project: string;
+		};
+		expect(guardedDocument).toEqual({ agent_id: "corrected-agent", project: "/corrected" });
+		const repairedDocumentIndexes = db
+			.query(
+				"SELECT name FROM sqlite_master WHERE type = 'index' AND name IN ('idx_documents_agent_project', 'idx_documents_source_scope')",
+			)
+			.all();
+		expect(repairedDocumentIndexes.length).toBe(2);
+		const documentMemory = db.query("SELECT visibility FROM memories WHERE id = 'doc-memory-guard'").get() as {
+			visibility: string;
+		};
+		expect(documentMemory.visibility).toBe("private");
+		const placeholderDocument = db
+			.query("SELECT agent_id, project FROM documents WHERE id = 'doc-placeholder'")
+			.get() as {
+			agent_id: string;
+			project: string;
+		};
+		expect(placeholderDocument).toEqual({ agent_id: "metadata-agent", project: "/metadata" });
+	});
+
+	test("migration 083 preserves existing document scope when one column is missing", () => {
+		db = createFreshDb();
+		runMigrations(db);
+		db.query(
+			`INSERT INTO documents (id, source_type, metadata_json, agent_id, project, created_at, updated_at)
+			 VALUES ('doc-partial', 'obsidian', '{"signet":{"agentId":"metadata-agent","project":"/metadata"}}', 'corrected-agent', '/corrected', '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z')`,
+		).run();
+		db.exec("DROP INDEX IF EXISTS idx_documents_agent_project");
+		db.exec("DROP INDEX IF EXISTS idx_documents_source_scope");
+		db.exec("ALTER TABLE documents DROP COLUMN project");
+
+		memoryLifecycleRepair(db);
+
+		const row = db.query("SELECT agent_id, project FROM documents WHERE id = 'doc-partial'").get() as {
+			agent_id: string;
+			project: string;
+		};
+		expect(row).toEqual({ agent_id: "corrected-agent", project: "/metadata" });
 	});
 
 	test("entities table has graph-extended columns after migration", () => {

--- a/platform/daemon-rs/crates/signet-core/src/migrations.rs
+++ b/platform/daemon-rs/crates/signet-core/src/migrations.rs
@@ -109,10 +109,16 @@ const TS_ARTIFACT_SOURCE_PROVENANCE_VERSION: u32 = 75;
 const TS_ARTIFACT_SOURCE_PROVENANCE_NAME: &str = "memory-artifact-source-provenance";
 const TS_TEMPORAL_EDGES_VERSION: u32 = 76;
 const TS_TEMPORAL_EDGES_NAME: &str = "temporal-edges";
+const TS_TRANSCRIPT_CAPTURE_JOBS_VERSION: u32 = 79;
+const TS_TRANSCRIPT_CAPTURE_JOBS_NAME: &str = "transcript-capture-jobs";
 const TS_DOCUMENT_SCOPE_COLUMNS_VERSION: u32 = 80;
 const TS_DOCUMENT_SCOPE_COLUMNS_NAME: &str = "document-scope-columns";
+const TS_AGGREGATE_EVIDENCE_SOURCES_VERSION: u32 = 81;
+const TS_AGGREGATE_EVIDENCE_SOURCES_NAME: &str = "aggregate-evidence-sources";
 const TS_SKILL_INVOCATIONS_HARNESS_VERSION: u32 = 82;
 const TS_SKILL_INVOCATIONS_HARNESS_NAME: &str = "skill-invocations-harness";
+const TS_MEMORY_LIFECYCLE_REPAIR_VERSION: u32 = 83;
+const TS_MEMORY_LIFECYCLE_REPAIR_NAME: &str = "memory-lifecycle-repair";
 
 /// Simple checksum matching the TS implementation (hash of "version:name").
 fn checksum(version: u32, name: &str) -> String {
@@ -148,6 +154,16 @@ fn add_column_if_missing(
     }
 
     Ok(())
+}
+
+fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool, CoreError> {
+    conn.prepare(&format!("PRAGMA table_info(\"{table}\")"))
+        .and_then(|mut stmt| {
+            let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+            let names: Vec<String> = rows.filter_map(|r| r.ok()).collect();
+            Ok(names.iter().any(|n| n == column))
+        })
+        .map_err(CoreError::from)
 }
 
 fn table_exists(conn: &Connection, table: &str) -> Result<bool, CoreError> {
@@ -733,6 +749,319 @@ fn ensure_cross_daemon_parity_tables(conn: &Connection) -> Result<(), CoreError>
     Ok(())
 }
 
+fn ensure_transcript_capture_jobs(conn: &Connection) -> Result<(), CoreError> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS transcript_capture_jobs (
+            id TEXT PRIMARY KEY,
+            agent_id TEXT NOT NULL DEFAULT 'default',
+            harness TEXT NOT NULL,
+            session_key TEXT,
+            session_id TEXT NOT NULL,
+            project TEXT,
+            transcript TEXT NOT NULL,
+            raw_transcript TEXT,
+            transcript_path TEXT,
+            captured_at TEXT NOT NULL,
+            ended_at TEXT,
+            summary_status TEXT NOT NULL DEFAULT 'not_requested',
+            status TEXT NOT NULL DEFAULT 'pending',
+            attempts INTEGER NOT NULL DEFAULT 0,
+            max_attempts INTEGER NOT NULL DEFAULT 5,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            completed_at TEXT,
+            error TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_transcript_capture_jobs_status
+            ON transcript_capture_jobs(status, created_at);
+        CREATE INDEX IF NOT EXISTS idx_transcript_capture_jobs_agent_session
+            ON transcript_capture_jobs(agent_id, session_key, created_at);",
+    )?;
+    Ok(())
+}
+
+fn repair_document_scope_columns(conn: &Connection) -> Result<(), CoreError> {
+    add_column_if_missing(
+        conn,
+        "documents",
+        "agent_id",
+        "TEXT NOT NULL DEFAULT 'default'",
+    )?;
+    add_column_if_missing(conn, "documents", "project", "TEXT")?;
+    conn.execute_batch(
+        "UPDATE documents
+            SET agent_id = NULLIF(TRIM(json_extract(metadata_json, '$.signet.agentId')), '')
+          WHERE metadata_json IS NOT NULL
+            AND json_valid(metadata_json)
+            AND json_type(metadata_json, '$.signet.agentId') = 'text'
+            AND NULLIF(TRIM(json_extract(metadata_json, '$.signet.agentId')), '') IS NOT NULL;
+         UPDATE documents
+            SET project = NULLIF(TRIM(json_extract(metadata_json, '$.signet.project')), '')
+          WHERE metadata_json IS NOT NULL
+            AND json_valid(metadata_json)
+            AND json_type(metadata_json, '$.signet.project') = 'text';
+         WITH linked_scope AS (
+            SELECT
+                dm.document_id,
+                m.agent_id,
+                m.project,
+                ROW_NUMBER() OVER (
+                    PARTITION BY dm.document_id
+                    ORDER BY COUNT(*) DESC, m.agent_id, COALESCE(m.project, '')
+                ) AS rank
+            FROM document_memories dm
+            JOIN memories m ON m.id = dm.memory_id
+            WHERE m.agent_id IS NOT NULL
+              AND NULLIF(TRIM(m.agent_id), '') IS NOT NULL
+            GROUP BY dm.document_id, m.agent_id, m.project
+         )
+         UPDATE documents
+            SET agent_id = COALESCE((
+                    SELECT agent_id FROM linked_scope
+                    WHERE linked_scope.document_id = documents.id AND rank = 1
+                ), agent_id),
+                project = (
+                    SELECT project FROM linked_scope
+                    WHERE linked_scope.document_id = documents.id AND rank = 1
+                )
+          WHERE EXISTS (
+                SELECT 1 FROM linked_scope
+                WHERE linked_scope.document_id = documents.id AND rank = 1
+            )
+            AND NOT (
+                metadata_json IS NOT NULL
+                AND json_valid(metadata_json)
+                AND json_type(metadata_json, '$.signet.agentId') = 'text'
+                AND NULLIF(TRIM(json_extract(metadata_json, '$.signet.agentId')), '') IS NOT NULL
+            );
+         UPDATE memories
+            SET visibility = 'private'
+          WHERE id IN (SELECT memory_id FROM document_memories)
+            AND type = 'document_chunk'
+            AND source_type = 'document'
+            AND (visibility IS NULL OR visibility = 'global');
+         DROP INDEX IF EXISTS idx_memories_content_hash_unique;
+         CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_content_hash_unique
+            ON memories(
+                content_hash,
+                COALESCE(NULLIF(agent_id, ''), 'default'),
+                COALESCE(project, ''),
+                COALESCE(scope, '__NULL__'),
+                COALESCE(visibility, 'global')
+            )
+            WHERE content_hash IS NOT NULL AND is_deleted = 0;
+         CREATE INDEX IF NOT EXISTS idx_documents_agent_project
+            ON documents(agent_id, project);
+         CREATE INDEX IF NOT EXISTS idx_documents_source_scope
+            ON documents(source_url, agent_id, project);",
+    )?;
+    Ok(())
+}
+
+fn repair_document_scope_columns_preserving_existing(conn: &Connection) -> Result<(), CoreError> {
+    let preserve_agent_id = column_exists(conn, "documents", "agent_id")?;
+    let preserve_project = column_exists(conn, "documents", "project")?;
+    if preserve_agent_id {
+        conn.execute_batch(
+            "CREATE TEMP TABLE __signet_doc_agent_guard AS
+             SELECT id, agent_id FROM documents
+             WHERE NULLIF(TRIM(agent_id), '') IS NOT NULL
+               AND NULLIF(TRIM(agent_id), '') <> 'default';",
+        )?;
+    }
+    if preserve_project {
+        conn.execute_batch(
+            "CREATE TEMP TABLE __signet_doc_project_guard AS
+             SELECT id, project FROM documents
+             WHERE NULLIF(TRIM(project), '') IS NOT NULL;",
+        )?;
+    }
+
+    let result = (|| -> Result<(), CoreError> {
+        repair_document_scope_columns(conn)?;
+        if preserve_agent_id {
+            conn.execute_batch(
+                "UPDATE documents
+                    SET agent_id = (
+                        SELECT agent_id FROM __signet_doc_agent_guard
+                        WHERE __signet_doc_agent_guard.id = documents.id
+                    )
+                  WHERE EXISTS (
+                        SELECT 1 FROM __signet_doc_agent_guard
+                        WHERE __signet_doc_agent_guard.id = documents.id
+                    );",
+            )?;
+        }
+        if preserve_project {
+            conn.execute_batch(
+                "UPDATE documents
+                    SET project = (
+                        SELECT project FROM __signet_doc_project_guard
+                        WHERE __signet_doc_project_guard.id = documents.id
+                    )
+                  WHERE EXISTS (
+                        SELECT 1 FROM __signet_doc_project_guard
+                        WHERE __signet_doc_project_guard.id = documents.id
+                    );",
+            )?;
+        }
+        Ok(())
+    })();
+
+    let _ = conn.execute_batch("DROP TABLE IF EXISTS temp.__signet_doc_agent_guard;");
+    let _ = conn.execute_batch("DROP TABLE IF EXISTS temp.__signet_doc_project_guard;");
+    result
+}
+
+fn run_memory_lifecycle_repair(
+    conn: &Connection,
+    backfill_legacy_relations: bool,
+) -> Result<(), CoreError> {
+    ensure_transcript_capture_jobs(conn)?;
+    if table_exists(conn, "documents")? {
+        if backfill_legacy_relations
+            || !column_exists(conn, "documents", "agent_id")?
+            || !column_exists(conn, "documents", "project")?
+        {
+            repair_document_scope_columns_preserving_existing(conn)?;
+        } else {
+            if table_exists(conn, "document_memories")?
+                && column_exists(conn, "memories", "visibility")?
+                && column_exists(conn, "memories", "type")?
+                && column_exists(conn, "memories", "source_type")?
+            {
+                conn.execute_batch(
+                    "UPDATE memories
+                        SET visibility = 'private'
+                      WHERE id IN (SELECT memory_id FROM document_memories)
+                        AND type = 'document_chunk'
+                        AND source_type = 'document'
+                        AND (visibility IS NULL OR visibility = 'global');",
+                )?;
+            }
+            if column_exists(conn, "memories", "content_hash")?
+                && column_exists(conn, "memories", "agent_id")?
+                && column_exists(conn, "memories", "project")?
+                && column_exists(conn, "memories", "scope")?
+                && column_exists(conn, "memories", "visibility")?
+                && column_exists(conn, "memories", "is_deleted")?
+            {
+                conn.execute_batch(
+                    "DROP INDEX IF EXISTS idx_memories_content_hash_unique;
+                     CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_content_hash_unique
+                        ON memories(
+                            content_hash,
+                            COALESCE(NULLIF(agent_id, ''), 'default'),
+                            COALESCE(project, ''),
+                            COALESCE(scope, '__NULL__'),
+                            COALESCE(visibility, 'global')
+                        )
+                        WHERE content_hash IS NOT NULL AND is_deleted = 0;",
+                )?;
+            }
+            conn.execute_batch(
+                "CREATE INDEX IF NOT EXISTS idx_documents_agent_project
+                    ON documents(agent_id, project);
+                 CREATE INDEX IF NOT EXISTS idx_documents_source_scope
+                    ON documents(source_url, agent_id, project);",
+            )?;
+        }
+    }
+    conn.execute_batch(include_str!("sql/058-aggregate-evidence-sources.sql"))?;
+
+    add_column_if_missing(conn, "memories", "superseded_by", "TEXT")?;
+    add_column_if_missing(conn, "memories", "superseded_at", "TEXT")?;
+    add_column_if_missing(conn, "memories", "superseded_reason", "TEXT")?;
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_memories_superseded_by ON memories(superseded_by);
+         CREATE INDEX IF NOT EXISTS idx_memories_active_supersession ON memories(is_deleted, superseded_by);",
+    )?;
+
+    if !table_exists(conn, "relations")? || !table_exists(conn, "entity_dependencies")? {
+        return Ok(());
+    }
+
+    add_column_if_missing(conn, "entity_dependencies", "confidence", "REAL")?;
+    add_column_if_missing(conn, "entity_dependencies", "reason", "TEXT")?;
+    add_column_if_missing(conn, "entity_dependencies", "source_id", "TEXT")?;
+    add_column_if_missing(conn, "entity_dependencies", "source_kind", "TEXT")?;
+    add_column_if_missing(
+        conn,
+        "entity_dependencies",
+        "proposal_evidence",
+        "TEXT NOT NULL DEFAULT '[]'",
+    )?;
+    add_column_if_missing(
+        conn,
+        "entity_dependencies",
+        "status",
+        "TEXT NOT NULL DEFAULT 'active'",
+    )?;
+
+    if !backfill_legacy_relations {
+        return Ok(());
+    }
+
+    let relation_confidence = if column_exists(conn, "relations", "confidence")? {
+        "r.confidence"
+    } else {
+        "NULL"
+    };
+    let relation_updated_at = if column_exists(conn, "relations", "updated_at")? {
+        "r.updated_at"
+    } else {
+        "r.created_at"
+    };
+    let source_agent_id = if column_exists(conn, "entities", "agent_id")? {
+        "COALESCE(NULLIF(TRIM(src.agent_id), ''), 'default')"
+    } else {
+        "'default'"
+    };
+    let target_agent_id = if column_exists(conn, "entities", "agent_id")? {
+        "COALESCE(NULLIF(TRIM(dst.agent_id), ''), 'default')"
+    } else {
+        "'default'"
+    };
+
+    let sql = format!(
+        "INSERT OR IGNORE INTO entity_dependencies (
+            id, source_entity_id, target_entity_id, agent_id, dependency_type,
+            strength, confidence, reason, created_at, updated_at, source_id,
+            source_kind, proposal_evidence, status
+        )
+        SELECT
+            'relation:' || r.id,
+            r.source_entity_id,
+            r.target_entity_id,
+            COALESCE({source_agent_id}, {target_agent_id}, 'default'),
+            CASE WHEN r.relation_type IN (
+                'uses', 'requires', 'owned_by', 'owns', 'blocks', 'informs',
+                'maintains', 'implements', 'built', 'depends_on', 'related_to',
+                'learned_from', 'teaches', 'knows', 'assumes', 'supports_claim',
+                'authored_by', 'links_to', 'contains', 'contains_note',
+                'contradicts', 'supersedes', 'part_of', 'produced_artifact',
+                'precedes', 'follows', 'triggers', 'may_execute',
+                'requires_approval_from', 'impacts', 'produces', 'consumes'
+            ) THEN r.relation_type ELSE 'related_to' END,
+            MAX(0.1, MIN(1.0, COALESCE(r.strength, 0.5))),
+            MAX(0.1, MIN(1.0, COALESCE({relation_confidence}, 0.7))),
+            'legacy relation backfill: ' || r.relation_type,
+            COALESCE(r.created_at, datetime('now')),
+            COALESCE({relation_updated_at}, r.created_at, datetime('now')),
+            r.id,
+            'relation',
+            '[]',
+            'active'
+        FROM relations r
+        JOIN entities src ON src.id = r.source_entity_id
+        JOIN entities dst ON dst.id = r.target_entity_id
+        WHERE r.source_entity_id <> r.target_entity_id
+          AND {source_agent_id} = {target_agent_id}"
+    );
+    conn.execute_batch(&sql)?;
+    Ok(())
+}
+
 fn ensure_cross_daemon_parity_columns(conn: &Connection) -> Result<(), CoreError> {
     ensure_summary_jobs_required_columns(conn)?;
 
@@ -761,8 +1090,33 @@ fn ensure_cross_daemon_parity_columns(conn: &Connection) -> Result<(), CoreError
     )?;
     add_column_if_missing(conn, "connectors", "enabled", "INTEGER NOT NULL DEFAULT 1")?;
 
-    let should_backfill_document_scope =
-        !typescript_parity_migration_stamped(conn, TS_DOCUMENT_SCOPE_COLUMNS_VERSION)?;
+    ensure_transcript_capture_jobs(conn)?;
+    stamp_typescript_parity_migration(
+        conn,
+        TS_TRANSCRIPT_CAPTURE_JOBS_VERSION,
+        TS_TRANSCRIPT_CAPTURE_JOBS_NAME,
+    )?;
+
+    let document_agent_id_exists = column_exists(conn, "documents", "agent_id")?;
+    let document_project_exists = column_exists(conn, "documents", "project")?;
+    let document_scope_columns_missing = !document_agent_id_exists || !document_project_exists;
+    let should_backfill_document_scope = document_scope_columns_missing
+        || !typescript_parity_migration_stamped(conn, TS_DOCUMENT_SCOPE_COLUMNS_VERSION)?;
+    if should_backfill_document_scope && document_agent_id_exists {
+        conn.execute_batch(
+            "CREATE TEMP TABLE __signet_doc_agent_guard AS
+             SELECT id, agent_id FROM documents
+             WHERE NULLIF(TRIM(agent_id), '') IS NOT NULL
+               AND NULLIF(TRIM(agent_id), '') <> 'default';",
+        )?;
+    }
+    if should_backfill_document_scope && document_project_exists {
+        conn.execute_batch(
+            "CREATE TEMP TABLE __signet_doc_project_guard AS
+             SELECT id, project FROM documents
+             WHERE NULLIF(TRIM(project), '') IS NOT NULL;",
+        )?;
+    }
     add_column_if_missing(
         conn,
         "documents",
@@ -824,7 +1178,35 @@ fn ensure_cross_daemon_parity_columns(conn: &Connection) -> Result<(), CoreError
                 AND source_type = 'document'
                 AND (visibility IS NULL OR visibility = 'global');",
         )?;
+        if document_agent_id_exists {
+            conn.execute_batch(
+                "UPDATE documents
+                    SET agent_id = (
+                        SELECT agent_id FROM __signet_doc_agent_guard
+                        WHERE __signet_doc_agent_guard.id = documents.id
+                    )
+                  WHERE EXISTS (
+                        SELECT 1 FROM __signet_doc_agent_guard
+                        WHERE __signet_doc_agent_guard.id = documents.id
+                    );",
+            )?;
+        }
+        if document_project_exists {
+            conn.execute_batch(
+                "UPDATE documents
+                    SET project = (
+                        SELECT project FROM __signet_doc_project_guard
+                        WHERE __signet_doc_project_guard.id = documents.id
+                    )
+                  WHERE EXISTS (
+                        SELECT 1 FROM __signet_doc_project_guard
+                        WHERE __signet_doc_project_guard.id = documents.id
+                    );",
+            )?;
+        }
     }
+    let _ = conn.execute_batch("DROP TABLE IF EXISTS temp.__signet_doc_agent_guard;");
+    let _ = conn.execute_batch("DROP TABLE IF EXISTS temp.__signet_doc_project_guard;");
     conn.execute_batch(
         "DROP INDEX IF EXISTS idx_memories_content_hash_unique;
          CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_content_hash_unique
@@ -846,6 +1228,11 @@ fn ensure_cross_daemon_parity_columns(conn: &Connection) -> Result<(), CoreError
         TS_DOCUMENT_SCOPE_COLUMNS_VERSION,
         TS_DOCUMENT_SCOPE_COLUMNS_NAME,
     )?;
+    stamp_typescript_parity_migration(
+        conn,
+        TS_AGGREGATE_EVIDENCE_SOURCES_VERSION,
+        TS_AGGREGATE_EVIDENCE_SOURCES_NAME,
+    )?;
 
     // Harness skill-invocation columns (parity with TS 082). Add columns first,
     // then the indexes that reference them (059 sql), then stamp.
@@ -860,6 +1247,15 @@ fn ensure_cross_daemon_parity_columns(conn: &Connection) -> Result<(), CoreError
         conn,
         TS_SKILL_INVOCATIONS_HARNESS_VERSION,
         TS_SKILL_INVOCATIONS_HARNESS_NAME,
+    )?;
+
+    let should_backfill_legacy_relations =
+        !typescript_parity_migration_stamped(conn, TS_MEMORY_LIFECYCLE_REPAIR_VERSION)?;
+    run_memory_lifecycle_repair(conn, should_backfill_legacy_relations)?;
+    stamp_typescript_parity_migration(
+        conn,
+        TS_MEMORY_LIFECYCLE_REPAIR_VERSION,
+        TS_MEMORY_LIFECYCLE_REPAIR_NAME,
     )?;
 
     add_column_if_missing(

--- a/platform/daemon-rs/crates/signet-core/tests/migrations.rs
+++ b/platform/daemon-rs/crates/signet-core/tests/migrations.rs
@@ -128,3 +128,278 @@ fn adds_harness_columns_and_dedupe_index_to_skill_invocations() {
         "dedupe should drop repeated harness invocations per agent"
     );
 }
+
+#[test]
+fn backfills_document_scope_when_stamped_columns_were_missing() {
+    let conn = Connection::open_in_memory().expect("open in-memory db");
+    signet_core::migrations::run(&conn).expect("migrations run");
+    conn.execute(
+        "INSERT INTO documents (id, source_type, metadata_json, created_at, updated_at)
+         VALUES ('doc-collision', 'obsidian', '{\"signet\":{\"agentId\":\"agent-meta\",\"project\":\"/meta\"}}', '2026-07-01T00:00:00Z', '2026-07-01T00:00:00Z')",
+        [],
+    )
+    .expect("insert collision document");
+    conn.execute_batch(
+        "DROP INDEX IF EXISTS idx_documents_agent_project;
+         DROP INDEX IF EXISTS idx_documents_source_scope;
+         ALTER TABLE documents DROP COLUMN agent_id;
+         ALTER TABLE documents DROP COLUMN project;",
+    )
+    .expect("simulate stamped TS v80 without document scope columns");
+
+    signet_core::migrations::run(&conn)
+        .expect("rerun migrations repairs missing document scope columns");
+
+    let scope = conn
+        .query_row(
+            "SELECT agent_id, project FROM documents WHERE id = 'doc-collision'",
+            [],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .expect("read repaired document scope");
+    assert_eq!(scope.0, "agent-meta");
+    assert_eq!(scope.1, "/meta");
+}
+
+#[test]
+fn preserves_existing_document_scope_when_one_column_was_missing() {
+    let conn = Connection::open_in_memory().expect("open in-memory db");
+    signet_core::migrations::run(&conn).expect("migrations run");
+    conn.execute(
+        "INSERT INTO documents (id, source_type, metadata_json, agent_id, project, created_at, updated_at)
+         VALUES ('doc-partial', 'obsidian', '{\"signet\":{\"agentId\":\"metadata-agent\",\"project\":\"/metadata\"}}', 'corrected-agent', '/corrected', '2026-07-01T00:00:00Z', '2026-07-01T00:00:00Z')",
+        [],
+    )
+    .expect("insert partial document");
+    conn.execute_batch(
+        "DROP INDEX IF EXISTS idx_documents_agent_project;
+         DROP INDEX IF EXISTS idx_documents_source_scope;
+         ALTER TABLE documents DROP COLUMN project;",
+    )
+    .expect("simulate partial document scope repair");
+
+    signet_core::migrations::run(&conn).expect("rerun migrations repairs missing project only");
+
+    let scope = conn
+        .query_row(
+            "SELECT agent_id, project FROM documents WHERE id = 'doc-partial'",
+            [],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .expect("read repaired partial document scope");
+    assert_eq!(scope.0, "corrected-agent");
+    assert_eq!(scope.1, "/metadata");
+}
+
+#[test]
+fn repairs_memory_lifecycle_lineage_and_stamps_ts_versions() {
+    let conn = Connection::open_in_memory().expect("open in-memory db");
+    signet_core::migrations::run(&conn).expect("migrations run");
+
+    for version in [79_i64, 81, 83] {
+        let stamped: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE version = ?1)",
+                [version],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|n| n != 0)
+            .expect("query stamped TS version");
+        assert!(
+            stamped,
+            "TS migration {version} should be stamped after parity repair"
+        );
+    }
+
+    let transcript_jobs_exists: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='transcript_capture_jobs')",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map(|n| n != 0)
+        .expect("query transcript capture table");
+    assert!(
+        transcript_jobs_exists,
+        "transcript_capture_jobs should exist"
+    );
+
+    for column in ["superseded_by", "superseded_at", "superseded_reason"] {
+        let exists: bool = conn
+            .prepare("PRAGMA table_info(memories)")
+            .expect("prepare table_info")
+            .query_map([], |row| row.get::<_, String>(1))
+            .expect("query table_info")
+            .filter_map(Result::ok)
+            .any(|name| name == column);
+        assert!(exists, "memories missing {column}");
+    }
+
+    conn.execute(
+        "INSERT INTO entities (id, name, canonical_name, entity_type, agent_id, created_at, updated_at)
+         VALUES ('entity-source', 'Source', 'source', 'concept', 'agent-a', '2026-07-01T00:00:00Z', '2026-07-01T00:00:00Z')",
+        [],
+    )
+    .expect("insert source entity");
+    conn.execute(
+        "INSERT INTO entities (id, name, canonical_name, entity_type, agent_id, created_at, updated_at)
+         VALUES ('entity-target', 'Target', 'target', 'concept', 'agent-a', '2026-07-01T00:00:00Z', '2026-07-01T00:00:00Z')",
+        [],
+    )
+    .expect("insert target entity");
+    conn.execute(
+        "INSERT INTO entities (id, name, canonical_name, entity_type, agent_id, created_at, updated_at)
+         VALUES ('entity-other-agent', 'Other', 'other', 'concept', 'agent-b', '2026-07-01T00:00:00Z', '2026-07-01T00:00:00Z')",
+        [],
+    )
+    .expect("insert other-agent entity");
+    conn.execute(
+        "INSERT INTO relations (id, source_entity_id, target_entity_id, relation_type, strength, created_at)
+         VALUES ('legacy-rel', 'entity-source', 'entity-target', 'unknown_local_type', 0.8, '2026-07-01T00:00:01Z')",
+        [],
+    )
+    .expect("insert legacy relation");
+    conn.execute(
+        "INSERT INTO relations (id, source_entity_id, target_entity_id, relation_type, strength, created_at)
+         VALUES ('cross-agent-rel', 'entity-source', 'entity-other-agent', 'related_to', 0.9, '2026-07-01T00:00:02Z')",
+        [],
+    )
+    .expect("insert cross-agent relation");
+    conn.execute(
+        "INSERT INTO documents (id, source_type, metadata_json, agent_id, project, created_at, updated_at)
+         VALUES ('doc-guard', 'obsidian', '{\"signet\":{\"agentId\":\"metadata-agent\",\"project\":\"/old\"}}', 'corrected-agent', '/corrected', '2026-07-01T00:00:00Z', '2026-07-01T00:00:00Z')",
+        [],
+    )
+    .expect("insert guarded document");
+    conn.execute(
+        "INSERT INTO memories (id, content, content_hash, type, source_type, visibility, agent_id, created_at, updated_at, updated_by)
+         VALUES ('doc-memory-guard', 'chunk', 'doc-hash-guard', 'document_chunk', 'document', 'global', 'corrected-agent', '2026-07-01T00:00:00Z', '2026-07-01T00:00:00Z', 'test')",
+        [],
+    )
+    .expect("insert guarded document memory");
+    conn.execute(
+        "INSERT INTO document_memories (document_id, memory_id)
+         VALUES ('doc-guard', 'doc-memory-guard')",
+        [],
+    )
+    .expect("link guarded document memory");
+    conn.execute(
+        "INSERT INTO documents (id, source_type, metadata_json, agent_id, project, created_at, updated_at)
+         VALUES ('doc-placeholder', 'obsidian', '{\"signet\":{\"agentId\":\"metadata-agent\",\"project\":\"/metadata\"}}', 'default', NULL, '2026-07-01T00:00:00Z', '2026-07-01T00:00:00Z')",
+        [],
+    )
+    .expect("insert placeholder document scope");
+    conn.execute_batch(
+        "DROP INDEX IF EXISTS idx_documents_agent_project;
+         DROP INDEX IF EXISTS idx_documents_source_scope;
+         DELETE FROM schema_migrations WHERE version = 83;",
+    )
+    .expect("drop document indexes and mark v83 pending for repair");
+
+    signet_core::migrations::run(&conn).expect("rerun migrations backfills legacy relation");
+    signet_core::migrations::run(&conn).expect("relation backfill remains idempotent");
+
+    let row = conn
+        .query_row(
+            "SELECT agent_id, dependency_type, strength, reason, source_id, source_kind, status
+             FROM entity_dependencies WHERE id = 'relation:legacy-rel'",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, f64>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, String>(6)?,
+                ))
+            },
+        )
+        .expect("read backfilled dependency");
+    assert_eq!(row.0, "agent-a");
+    assert_eq!(row.1, "related_to");
+    assert_eq!(row.2, 0.8);
+    assert_eq!(row.3, "legacy relation backfill: unknown_local_type");
+    assert_eq!(row.4, "legacy-rel");
+    assert_eq!(row.5, "relation");
+    assert_eq!(row.6, "active");
+
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM entity_dependencies WHERE id = 'relation:legacy-rel'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count backfilled dependency rows");
+    assert_eq!(count, 1, "legacy relation backfill should be idempotent");
+
+    let cross_agent_exists: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM entity_dependencies WHERE id = 'relation:cross-agent-rel')",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map(|n| n != 0)
+        .expect("query skipped cross-agent relation");
+    assert!(
+        !cross_agent_exists,
+        "cross-agent relation should not be backfilled"
+    );
+
+    let guarded_document = conn
+        .query_row(
+            "SELECT agent_id, project FROM documents WHERE id = 'doc-guard'",
+            [],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .expect("read guarded document");
+    assert_eq!(guarded_document.0, "corrected-agent");
+    assert_eq!(guarded_document.1, "/corrected");
+
+    let repaired_document_indexes: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master
+             WHERE type = 'index'
+               AND name IN ('idx_documents_agent_project', 'idx_documents_source_scope')",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count repaired document indexes");
+    assert_eq!(repaired_document_indexes, 2);
+
+    let document_memory_visibility: String = conn
+        .query_row(
+            "SELECT visibility FROM memories WHERE id = 'doc-memory-guard'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read guarded document memory visibility");
+    assert_eq!(document_memory_visibility, "private");
+
+    let placeholder_document = conn
+        .query_row(
+            "SELECT agent_id, project FROM documents WHERE id = 'doc-placeholder'",
+            [],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .expect("read repaired placeholder document scope");
+    assert_eq!(placeholder_document.0, "metadata-agent");
+    assert_eq!(placeholder_document.1, "/metadata");
+
+    conn.execute(
+        "DELETE FROM entity_dependencies WHERE id = 'relation:legacy-rel'",
+        [],
+    )
+    .expect("delete backfilled dependency after v83 stamp");
+    signet_core::migrations::run(&conn)
+        .expect("rerun migrations should not repeat v83 data backfill");
+    let recreated_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM entity_dependencies WHERE id = 'relation:legacy-rel'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count deleted backfilled dependency rows");
+    assert_eq!(recreated_count, 0, "v83 data backfill should be one-shot");
+}


### PR DESCRIPTION
## Summary
- Add migration 083 as an idempotent lifecycle repair for long-lived mac DBs that used local 079-081 patches before upstream assigned those versions.
- Replays upstream 079-081 artifacts idempotently:
  - `transcript_capture_jobs`
  - `documents.agent_id` / `documents.project`
  - `aggregate_evidence_sources`
- Adds memory supersession columns and indexes:
  - `memories.superseded_by`
  - `memories.superseded_at`
  - `memories.superseded_reason`
- Backfills legacy same-agent `relations` rows into `entity_dependencies` so traversal sees graph edges.
- Mirrors the repair in Rust daemon parity and keeps the relation data backfill one-shot after v83 is stamped.

## Context
- References #883.
- This is separated from the observed feedback loop PR so reviewers can inspect DB lineage repair independently.

## Live mac verification
- Before repair: `entity_dependencies` was 0 and diagnostics reported healthy graph with `edgeCount=0`.
- After repair: `entity_dependencies=9802`, diagnostics graph `status=healthy`, `edgeCount=9802`.
- Container-side DB check with sqlite-vec loaded: `PRAGMA quick_check` -> `ok`; `PRAGMA integrity_check` -> `ok`.

## Tests / build
- `bunx biome check platform/core/src/migrations/index.ts platform/core/src/migrations/083-memory-lifecycle-repair.ts platform/core/src/migrations/migrations.test.ts`
- `bun run --filter '@signet/core' build`
- `bun test platform/core/src/migrations/migrations.test.ts --timeout 30000`
- `cargo test -p signet-core --test migrations`
- `bun scripts/check-rust-daemon-parity.ts`
- `autoreview` -> `[]`

## Migration Notes (if applicable)
- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Migration 083 uses `CREATE TABLE IF NOT EXISTS`, add-column-if-missing guards, and `INSERT OR IGNORE` for same-agent legacy relation backfill. It preserves explicit document scope values, repairs missing/default document scope artifacts, and skips cross-agent relation backfills. Rollback compatibility: no memory rows are hard-deleted; newly added supersession columns/indexes are additive, and older daemons ignore unknown columns.

## PR Readiness Checklist
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally