### PR TITLE
fix(pi): support pi-mono session lifecycle events

### DIFF
--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -38,6 +38,22 @@ The connector package exposes programmatic cleanup that removes the extension fi
 | Package | `@signetai/connector-pi` |
 | License | Apache-2.0 |
 
+## Compatibility
+
+The extension works with both **pi** (`@earendil-works/pi-coding-agent`) and
+**pi-mono** (`@mariozechner/pi-coding-agent`, the older monorepo fork, e.g.
+v0.66.x). Both resolve the agent dir the same way (`~/.pi/agent`, overridable
+via `PI_CODING_AGENT_DIR`), so the connector writes the managed extension to the
+same location either variant scans.
+
+The only difference is the session-lifecycle event vocabulary: current pi emits
+both the cancellable `session_before_fork` / `session_before_switch` events and
+the post-action `session_fork` / `session_switch` events, while pi-mono only
+emits the `before` variants. The extension ends the previous session on the
+`before` events (fires exactly once per action under either variant) and
+refreshes the new session on the post events — falling back to `session_start`
+under pi-mono. See [#887](https://github.com/Signet-AI/signetai/issues/887).
+
 ## Architecture
 
 ```

--- a/integrations/pi/connector/index.test.ts
+++ b/integrations/pi/connector/index.test.ts
@@ -165,6 +165,13 @@ describe("EXTENSION_BUNDLE integrity", () => {
 		expect(EXTENSION_BUNDLE).not.toContain("session.compacting");
 	});
 
+	it("wires pi-mono compat events (session_before_fork/session_before_switch)", () => {
+		// pi-mono (older monorepo fork) only emits the before-variants; the bundle
+		// must register handlers for them so fork/switch tracking works under it.
+		expect(EXTENSION_BUNDLE).toContain("session_before_fork");
+		expect(EXTENSION_BUNDLE).toContain("session_before_switch");
+	});
+
 	it("includes harness field in remember request body", () => {
 		expect(EXTENSION_BUNDLE).toMatch(/hooks\/remember[\s\S]{0,200}harness:/);
 	});

--- a/integrations/pi/extension/index.test.ts
+++ b/integrations/pi/extension/index.test.ts
@@ -458,6 +458,197 @@ describe("SignetPiExtension", () => {
 		expect(registered.has("before_agent_start")).toBe(true);
 		expect(registered.has("context")).toBe(true);
 		expect(registered.has("session_before_compact")).toBe(true);
+		// pi-mono compat: the before-events must be registered so fork/switch
+		// tracking works under pi-mono (which only emits the before-variants).
+		expect(registered.has("session_before_switch")).toBe(true);
+		expect(registered.has("session_before_fork")).toBe(true);
+		expect(registered.has("session_switch")).toBe(true);
+		expect(registered.has("session_fork")).toBe(true);
+	});
+
+	it("session_before_switch ends the previous session; session_switch only refreshes (no double session-end)", async () => {
+		const requests: Array<{ method: string; path: string; body: unknown }> = [];
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				const path = new URL(req.url).pathname;
+				const body = req.method === "POST" ? ((await req.json().catch(() => undefined)) as unknown) : undefined;
+				requests.push({ method: req.method, path, body });
+				if (path === "/health") return new Response(null, { status: 200 });
+				if (path === "/api/hooks/session-start") return Response.json({ inject: "session-context" });
+				if (path === "/api/hooks/session-end") return Response.json({ ok: true });
+				return new Response("not found", { status: 404 });
+			},
+		});
+		servers.push(server);
+		process.env.SIGNET_DAEMON_URL = `http://127.0.0.1:${server.port}`;
+
+		const handlers: HandlerMap = {};
+		const pi = {
+			on(event: string, handler: (event: unknown, ctx: unknown) => unknown) {
+				(handlers[event] ??= []).push(handler);
+			},
+			registerCommand(_name: string, _opts: unknown) {},
+			registerTool(_opts: unknown) {},
+		};
+		SignetPiExtension(pi as never);
+
+		const ctx = {
+			cwd: "/tmp/pi-project",
+			sessionManager: {
+				getBranch: () => [],
+				getEntries: () => [],
+				getHeader: () => ({ id: "session-pi-switch-1", cwd: "/tmp/pi-project" }),
+				getSessionFile: () => undefined,
+				getSessionId: () => "session-pi-switch-1",
+			},
+			ui: {
+				notify: () => {},
+				setStatus: () => {},
+				theme: { fg: (_color: string, text: string) => text },
+			},
+		};
+
+		// Establish the active session so endPreviousSession has a session to end.
+		await handlers.session_start[0]?.({}, ctx);
+		// before-event (emitted by both current pi and pi-mono): end previous session.
+		await handlers.session_before_switch[0]?.({ type: "session_before_switch", reason: "new" }, ctx);
+		// post-event (current pi only): refresh the new session. pi-mono refreshes
+		// via session_start (reason fork/new/resume) instead.
+		await handlers.session_switch[0]?.({ type: "session_switch", reason: "new" }, ctx);
+
+		const posts = requests.filter((r) => r.method === "POST");
+		expect(posts.map((r) => r.path)).toEqual([
+			"/api/hooks/session-start",
+			"/api/hooks/session-end",
+			"/api/hooks/session-start",
+		]);
+		// Exactly one session-end across before + post events — no double post.
+		expect(posts.filter((r) => r.path === "/api/hooks/session-end")).toHaveLength(1);
+		const end = posts.find((r) => r.path === "/api/hooks/session-end");
+		expect(end?.body).toMatchObject({
+			harness: "pi",
+			reason: "session_switch",
+			sessionKey: "session-pi-switch-1",
+		});
+		expect(end?.body).not.toHaveProperty("transcript");
+	});
+
+	it("session_before_fork ends the previous session with the fork reason", async () => {
+		const requests: Array<{ method: string; path: string; body: unknown }> = [];
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				const path = new URL(req.url).pathname;
+				const body = req.method === "POST" ? ((await req.json().catch(() => undefined)) as unknown) : undefined;
+				requests.push({ method: req.method, path, body });
+				if (path === "/health") return new Response(null, { status: 200 });
+				if (path === "/api/hooks/session-start") return Response.json({ inject: "session-context" });
+				if (path === "/api/hooks/session-end") return Response.json({ ok: true });
+				return new Response("not found", { status: 404 });
+			},
+		});
+		servers.push(server);
+		process.env.SIGNET_DAEMON_URL = `http://127.0.0.1:${server.port}`;
+
+		const handlers: HandlerMap = {};
+		const pi = {
+			on(event: string, handler: (event: unknown, ctx: unknown) => unknown) {
+				(handlers[event] ??= []).push(handler);
+			},
+			registerCommand(_name: string, _opts: unknown) {},
+			registerTool(_opts: unknown) {},
+		};
+		SignetPiExtension(pi as never);
+
+		const ctx = {
+			cwd: "/tmp/pi-project",
+			sessionManager: {
+				getBranch: () => [],
+				getEntries: () => [],
+				getHeader: () => ({ id: "session-pi-fork-1", cwd: "/tmp/pi-project" }),
+				getSessionFile: () => undefined,
+				getSessionId: () => "session-pi-fork-1",
+			},
+			ui: {
+				notify: () => {},
+				setStatus: () => {},
+				theme: { fg: (_color: string, text: string) => text },
+			},
+		};
+
+		await handlers.session_start[0]?.({}, ctx);
+		await handlers.session_before_fork[0]?.({ type: "session_before_fork", entryId: "entry-42" }, ctx);
+
+		const end = requests.find((r) => r.method === "POST" && r.path === "/api/hooks/session-end");
+		expect(end).toBeDefined();
+		expect(end?.body).toMatchObject({
+			harness: "pi",
+			reason: "session_fork",
+			sessionKey: "session-pi-fork-1",
+		});
+	});
+
+	it("pi-mono flow: before-event ends the old session, then session_start establishes the new one", async () => {
+		// pi-mono only emits session_before_switch (no session_switch post-event) and
+		// follows it with session_start (reason new/resume) carrying the NEW session.
+		const requests: Array<{ method: string; path: string; body: unknown }> = [];
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				const path = new URL(req.url).pathname;
+				const body = req.method === "POST" ? ((await req.json().catch(() => undefined)) as unknown) : undefined;
+				requests.push({ method: req.method, path, body });
+				if (path === "/health") return new Response(null, { status: 200 });
+				if (path === "/api/hooks/session-start") return Response.json({ inject: "session-context" });
+				if (path === "/api/hooks/session-end") return Response.json({ ok: true });
+				return new Response("not found", { status: 404 });
+			},
+		});
+		servers.push(server);
+		process.env.SIGNET_DAEMON_URL = `http://127.0.0.1:${server.port}`;
+
+		const handlers: HandlerMap = {};
+		const pi = {
+			on(event: string, handler: (event: unknown, ctx: unknown) => unknown) {
+				(handlers[event] ??= []).push(handler);
+			},
+			registerCommand(_name: string, _opts: unknown) {},
+			registerTool(_opts: unknown) {},
+		};
+		SignetPiExtension(pi as never);
+
+		const ctxFor = (id: string) => ({
+			cwd: "/tmp/pi-project",
+			sessionManager: {
+				getBranch: () => [],
+				getEntries: () => [],
+				getHeader: () => ({ id, cwd: "/tmp/pi-project" }),
+				getSessionFile: () => undefined,
+				getSessionId: () => id,
+			},
+			ui: {
+				notify: () => {},
+				setStatus: () => {},
+				theme: { fg: (_color: string, text: string) => text },
+			},
+		});
+
+		// 1) Old session A is active.
+		await handlers.session_start[0]?.({}, ctxFor("session-A"));
+		// 2) pi-mono before-event fires while A is still the active session.
+		await handlers.session_before_switch[0]?.({ type: "session_before_switch", reason: "new" }, ctxFor("session-A"));
+		// 3) pi-mono follows with session_start for the NEW session B (no session_switch).
+		await handlers.session_start[0]?.({}, ctxFor("session-B"));
+
+		const posts = requests.filter((r) => r.method === "POST");
+		const ends = posts.filter((r) => r.path === "/api/hooks/session-end");
+		const starts = posts.filter((r) => r.path === "/api/hooks/session-start");
+		// Exactly one session-end, targeting the old session A.
+		expect(ends).toHaveLength(1);
+		expect(ends[0]?.body).toMatchObject({ harness: "pi", reason: "session_switch", sessionKey: "session-A" });
+		// session-start fired for both A (initial) and B (after switch).
+		expect(starts.map((r) => (r.body as { sessionKey?: string }).sessionKey)).toEqual(["session-A", "session-B"]);
 	});
 
 	it("bypass mode skips automatic hooks but keeps commands and tools", () => {

--- a/integrations/pi/extension/src/index.ts
+++ b/integrations/pi/extension/src/index.ts
@@ -301,13 +301,38 @@ function registerSessionLifecycleHandlers(pi: PiExtensionApi, deps: LifecycleDep
 		await refreshSessionStart(deps, ctx);
 	});
 
-	pi.on("session_switch", async (event, ctx) => {
-		await endPreviousSession(deps, event, event.type);
-		await refreshSessionStart(deps, ctx);
+	// Session switches/forks are split across the before- and post-events so the
+	// same handlers work under both current pi and pi-mono (the older monorepo
+	// fork, v0.66.x). See https://github.com/Signet-AI/signetai/issues/887.
+	//
+	// - `endPreviousSession` runs on the BEFORE-events. Both variants emit these
+	//   while the previous session is still the active one (its file is on disk and
+	//   most up to date), the most reliable point to capture its transcript.
+	// - `refreshSessionStart` runs on the POST-events, which only current pi
+	//   emits; pi-mono establishes the new-session context via `session_start`
+	//   (reason fork/new/resume) instead, so exactly one path refreshes.
+	//
+	// endPreviousSession is deliberately on ONLY the before-events (not also the
+	// post-events): current pi emits the before-event only once an extension
+	// registers a handler for it (hasHandlers guard), so registering here activates
+	// it under current pi too, and the not-loaded branch of endPreviousSession is
+	// not idempotent — wiring it to both events would double-call it for the same
+	// switch/fork. (The separate, pre-existing pending-queue re-POST behavior of
+	// endPreviousSession is unchanged by this split.) The before-event is awaited
+	// by pi, so the end POST runs as part of the pre-switch step; like session_start
+	// it is a bounded local-daemon call. Reason is normalized to the post-event
+	// names so the daemon records the same value per variant.
+	pi.on("session_before_switch", async () => {
+		await endPreviousSession(deps, {}, "session_switch");
+	});
+	pi.on("session_before_fork", async () => {
+		await endPreviousSession(deps, {}, "session_fork");
 	});
 
-	pi.on("session_fork", async (event, ctx) => {
-		await endPreviousSession(deps, event, event.type);
+	pi.on("session_switch", async (_event, ctx) => {
+		await refreshSessionStart(deps, ctx);
+	});
+	pi.on("session_fork", async (_event, ctx) => {
 		await refreshSessionStart(deps, ctx);
 	});
 
@@ -528,8 +553,7 @@ function registerCommandsAndTools(pi: PiExtensionApi, daemonUrl: string, agentId
 		label: "Signet Recall",
 		description:
 			"Search SignetAI persistent memory for relevant context from previous sessions. Use aggregate=true for multi-query synthesis that consolidates scattered memories into a single summary.",
-		promptSnippet:
-			"Search past memories when user asks about previous decisions, preferences, or project context",
+		promptSnippet: "Search past memories when user asks about previous decisions, preferences, or project context",
 		promptGuidelines: [
 			"Use aggregate=true when the user asks a broad question that likely spans many memories (e.g. 'who is X', 'what happened with Y', 'summarize the history of Z')",
 			"Use aggregate=false (default) for targeted lookups of specific facts or single memories",
@@ -554,7 +578,8 @@ function registerCommandsAndTools(pi: PiExtensionApi, daemonUrl: string, agentId
 			),
 			aggregateBudget: Type.Optional(
 				Type.String({
-					description: "Aggregate synthesis budget: 'small', 'medium', or 'large'. Controls depth of multi-query recall and synthesis. (default: medium)",
+					description:
+						"Aggregate synthesis budget: 'small', 'medium', or 'large'. Controls depth of multi-query recall and synthesis. (default: medium)",
 				}),
 			),
 		}),
@@ -572,8 +597,7 @@ function registerCommandsAndTools(pi: PiExtensionApi, daemonUrl: string, agentId
 				const limit = typeof params.limit === "number" ? params.limit : 5;
 				const isAggregate = params.aggregate === true;
 				const aggregateBudget =
-					typeof params.aggregateBudget === "string" &&
-					["small", "medium", "large"].includes(params.aggregateBudget)
+					typeof params.aggregateBudget === "string" && ["small", "medium", "large"].includes(params.aggregateBudget)
 						? (params.aggregateBudget as "small" | "medium" | "large")
 						: undefined;
 
@@ -857,7 +881,6 @@ function registerCommandsAndTools(pi: PiExtensionApi, daemonUrl: string, agentId
 			}
 		},
 	});
-
 }
 
 // ============================================================================

--- a/integrations/pi/extension/src/types.ts
+++ b/integrations/pi/extension/src/types.ts
@@ -73,6 +73,31 @@ export interface PiSessionSwitchEvent {
 	readonly previousSessionFile?: string;
 }
 
+/**
+ * `session_before_switch` — fired before switching to another session.
+ *
+ * pi-mono (the older monorepo fork of pi, v0.66.x) emits this INSTEAD of the
+ * post-event `session_switch`; current pi emits both. The payload carries the
+ * session being switched TO (`targetSessionFile`), not the previous one, so the
+ * handler relies on `endPreviousSession`'s active-session-file fallback.
+ */
+export interface PiSessionBeforeSwitchEvent {
+	readonly type: "session_before_switch";
+	readonly reason?: "new" | "resume";
+	readonly targetSessionFile?: string;
+}
+
+/**
+ * `session_before_fork` — fired before forking a session.
+ *
+ * pi-mono emits this INSTEAD of the post-event `session_fork`; current pi emits
+ * both. Same end-previous-only handling as `session_before_switch`.
+ */
+export interface PiSessionBeforeForkEvent {
+	readonly type: "session_before_fork";
+	readonly entryId?: string;
+}
+
 // UI and notification types
 export interface PiTheme {
 	fg(color: string, text: string): string;
@@ -131,6 +156,14 @@ export interface PiExtensionApi {
 	on(event: "session_start", handler: (event: unknown, ctx: PiExtensionContext) => unknown): void;
 	on(event: "session_switch", handler: (event: PiSessionSwitchEvent, ctx: PiExtensionContext) => unknown): void;
 	on(event: "session_fork", handler: (event: PiSessionSwitchEvent, ctx: PiExtensionContext) => unknown): void;
+	on(
+		event: "session_before_switch",
+		handler: (event: PiSessionBeforeSwitchEvent, ctx: PiExtensionContext) => unknown,
+	): void;
+	on(
+		event: "session_before_fork",
+		handler: (event: PiSessionBeforeForkEvent, ctx: PiExtensionContext) => unknown,
+	): void;
 	on(event: "session_shutdown", handler: (event: unknown, ctx: PiExtensionContext) => unknown): void;
 	on(event: "input", handler: (event: PiInputEvent, ctx: PiExtensionContext) => unknown): void;
 	on(


### PR DESCRIPTION
## Summary

The pi connector's session lifecycle didn't work under **pi-mono** (the older monorepo fork, `@mariozechner/pi-coding-agent` v0.66.x). pi-mono only emits `session_before_fork` / `session_before_switch`; the extension only listened for the post-action `session_fork` / `session_switch`, so forking or switching sessions never reported the previous session as ended to the daemon. Agent dir and config already match between variants, so pi-mono loaded the extension but the lifecycle hooks never fired.

Closes #887.

## Changes

- `integrations/pi/extension/src/index.ts` — register `session_before_fork` / `session_before_switch` handlers that end the previous session; reduce the `session_switch` / `session_fork` post-events to refresh-only. `endPreviousSession` is kept on the before-events only because its not-loaded branch isn't idempotent, so wiring both events would double-call it. Reason is normalized to the post-event names so the daemon records the same value per variant.
- `integrations/pi/extension/src/types.ts` — add `PiSessionBeforeSwitchEvent` / `PiSessionBeforeForkEvent` plus `on()` overloads.
- `integrations/pi/extension/index.test.ts` — 3 regression tests (before-event registration; a single session-end across before+post; the pi-mono flow `A → session_before_switch → session_start B`).
- `integrations/pi/connector/index.test.ts` — bundle-integrity guard asserting the shipped extension wires the before-events.
- `integrations/pi/README.md` — Compatibility section.
- Drive-by: `biome check --write` on `index.ts` for two pre-existing formatting findings in the `signet_recall` tool definition (present on `main`, unrelated to this fix, but in a touched file).

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/connector-*`

## Screenshots

N/A — no UI changes (connector / runtime extension only).

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — checked both; no spec entry governs the pi connector's session-event wiring, so nothing to align against.
- [x] Agent scoping verified on all new/changed data queries — N/A: no daemon data queries changed; this is client-side event handling only.
- [x] Input/config validation and bounds checks added — N/A: no new inputs or config; the before-events pass `{}` to the existing `endPreviousSession`, which already falls back to the active session.
- [x] Error handling and fallback paths tested (no silent swallow) — `endPreviousSession`'s idempotency guard and active-session fallback are exercised by the new tests; the split is designed so it fires once per action under either variant.
- [x] Security checks applied to admin/mutation endpoints — N/A: no admin/mutation endpoints touched.
- [x] Docs updated for API/spec/status changes — `integrations/pi/README.md` Compatibility section added.
- [x] Regression tests added for each bug fix — 3 behavioral tests + 1 bundle-integrity guard.
- [x] Lint/typecheck/tests pass locally — `tsc --noEmit` clean; `bun test` green for the affected packages (extension 30, connector 14); `biome check` clean on all changed files.

## Migration Notes (if applicable)

N/A — no migrations touched.

## Testing

- [x] `bun test` passes (affected packages: pi extension + connector)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (changed files)
- [x] Tested against running daemon
- [ ] N/A

Runtime verification: cloned real pi-mono (`sysid/pi-mono` v0.66.0), built it, configured the GLM (`zai` / `glm-5.2`) provider, and installed this fixed extension into an isolated agent dir pointed at the local daemon (`127.0.0.1:3850`):
- `pi --print` under pi-mono loaded the extension with no errors; `session_start` fired and the daemon injected 45 memories; `session_shutdown` released the session.
- A harness using pi-mono's real `discoverAndLoadExtensions` confirmed the extension registers `session_before_fork` / `session_before_switch` handlers on pi-mono's real API, and firing `session_start` then `session_before_fork` produced the expected `Session claimed → Session start completed → Session released/ended` sequence in the daemon log (the release 19 ms after start is `session_before_fork → endPreviousSession`).

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Behavior under current pi is unchanged in effect: current pi emits both the before- and post-events, so end-previous runs on the before-event and refresh runs on the post-event (one of each per action). The before-event is awaited by pi, so the session-end POST now runs in the pre-switch step — a bounded local-daemon call, consistent with the existing `session_start` HTTP. The pre-existing pending-queue re-POST behavior of `endPreviousSession` is untouched.
