### PR TITLE
fix(hermes): embed connector assets in native releases

### DIFF
--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -21,6 +21,7 @@ const originalEnv = {
 	SIGNET_AGENT_POLICY_GROUP: process.env.SIGNET_AGENT_POLICY_GROUP,
 	SIGNET_SKIP_AGENT_REGISTER: process.env.SIGNET_SKIP_AGENT_REGISTER,
 	SIGNET_DIR: process.env.SIGNET_DIR,
+	SIGNET_CONNECTOR_ASSETS_DIR: process.env.SIGNET_CONNECTOR_ASSETS_DIR,
 };
 
 let tmpRoot = "";
@@ -174,6 +175,8 @@ beforeEach(() => {
 	process.env.SIGNET_SKIP_AGENT_REGISTER = "1";
 	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_DIR;
+	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
+	delete process.env.SIGNET_CONNECTOR_ASSETS_DIR;
 });
 
 afterEach(() => {
@@ -190,6 +193,7 @@ afterEach(() => {
 	restoreEnv("SIGNET_AGENT_POLICY_GROUP");
 	restoreEnv("SIGNET_SKIP_AGENT_REGISTER");
 	restoreEnv("SIGNET_DIR");
+	restoreEnv("SIGNET_CONNECTOR_ASSETS_DIR");
 	if (tmpRoot) {
 		rmSync(tmpRoot, { recursive: true, force: true });
 	}
@@ -729,6 +733,7 @@ describe("HermesAgentConnector.install()", () => {
 			process.env.HERMES_REPO = hermesRepo;
 			process.env.HERMES_HOME = hermesHome;
 			process.env.SIGNET_AGENT_ID = "dot";
+			// biome-ignore lint/performance/noDelete: exercise the SIGNET_TOKEN fallback without a stale API key
 			delete process.env.SIGNET_API_KEY;
 			process.env.SIGNET_TOKEN = " test-token \n";
 			process.env.SIGNET_AGENT_READ_POLICY = "isolated";
@@ -1000,15 +1005,15 @@ describe("Hermes Agent bundled plugin", () => {
 					"assert manager.has_tool('signet_session_search')",
 					"print(','.join(sorted(names)))",
 				].join("\n"),
-				],
-				{ env: { ...process.env, PYTHONPATH: fixture }, encoding: "utf-8" },
-				);
+			],
+			{ env: { ...process.env, PYTHONPATH: fixture }, encoding: "utf-8" },
+		);
 
-				expect(result.status).toBe(0);
-				expect(result.stdout).toContain("memory_search");
-				expect(result.stdout).toContain("signet_session_search");
-				expect(result.stdout).not.toContain(",session_search,");
-				expect(result.stdout).toContain("remember");
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("memory_search");
+		expect(result.stdout).toContain("signet_session_search");
+		expect(result.stdout).not.toContain(",session_search,");
+		expect(result.stdout).toContain("remember");
 	});
 
 	it("imports the client from a Hermes user-installed provider namespace", () => {
@@ -1388,6 +1393,61 @@ describe("HermesAgentConnector — AGENTS.md legacy block migration", () => {
 });
 
 describe("HermesAgentConnector — native bundle (SIGNET_DIR) plugin resolution", () => {
+	it("installs from a materialized embedded connector asset tree", async () => {
+		const connectorAssetsDir = join(tmpRoot, "embedded-connectors");
+		const pluginDir = join(connectorAssetsDir, "hermes-agent", "hermes-plugin");
+		cpSync(join(import.meta.dir, "hermes-plugin"), pluginDir, { recursive: true });
+
+		process.env.SIGNET_CONNECTOR_ASSETS_DIR = connectorAssetsDir;
+		process.env.HERMES_HOME = join(tmpRoot, ".hermes");
+		const isolatedRoot = mkdtempSync(join(import.meta.dir, "isolated-embedded-connector-"));
+		const isolatedDistDir = join(isolatedRoot, "runtime", "cli", "dist");
+		mkdirSync(isolatedDistDir, { recursive: true });
+		cpSync(join(import.meta.dir, "src", "index.ts"), join(isolatedDistDir, "index.ts"));
+
+		try {
+			const isolatedModule = await import(
+				`${pathToFileURL(join(isolatedDistDir, "index.ts")).href}?embedded=${Date.now()}`
+			);
+			const result = await new isolatedModule.HermesAgentConnector().install(tmpRoot);
+
+			expect(result.success).toBe(true);
+			expect(existsSync(join(process.env.HERMES_HOME, "plugins", "signet", "__init__.py"))).toBe(true);
+		} finally {
+			rmSync(isolatedRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("returns structured doctor diagnostics when bundled assets are absent", async () => {
+		process.env.HERMES_HOME = join(tmpRoot, ".hermes");
+		const isolatedRoot = mkdtempSync(join(import.meta.dir, "isolated-missing-connector-"));
+		const isolatedDistDir = join(isolatedRoot, "runtime", "cli", "dist");
+		mkdirSync(isolatedDistDir, { recursive: true });
+		cpSync(join(import.meta.dir, "src", "index.ts"), join(isolatedDistDir, "index.ts"));
+
+		try {
+			const isolatedModule = await import(
+				`${pathToFileURL(join(isolatedDistDir, "index.ts")).href}?missing=${Date.now()}`
+			);
+			const report = await isolatedModule.diagnoseHermesIntegration({
+				hermesHome: process.env.HERMES_HOME,
+				hermesRepo: null,
+				daemonUrl: "http://127.0.0.1:1",
+			});
+
+			expect(report.ok).toBe(false);
+			expect(report.checks).toContainEqual(
+				expect.objectContaining({
+					id: "plugin-source",
+					ok: false,
+					detail: expect.stringContaining("Cannot find hermes-plugin directory"),
+				}),
+			);
+		} finally {
+			rmSync(isolatedRoot, { recursive: true, force: true });
+		}
+	});
+
 	it("installs successfully when hermes-plugin is in SIGNET_DIR runtime connectors layout", async () => {
 		const signetDir = join(tmpRoot, "signet-bundle");
 		const hermesPluginSource = join(import.meta.dir, "hermes-plugin");

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -21,6 +21,13 @@ function getPluginSourceDir(): string {
 	// In development, hermes-plugin/ is at package root
 	const fromSrc = join(__dirname, "..", "..", "hermes-plugin");
 	if (existsSync(fromSrc)) return fromSrc;
+	// Native binaries materialize embedded connector assets into a stable,
+	// content-addressed tree before loading the CLI.
+	const connectorAssetsDir = process.env.SIGNET_CONNECTOR_ASSETS_DIR?.trim();
+	if (connectorAssetsDir) {
+		const fromEmbeddedAssets = join(connectorAssetsDir, "hermes-agent", "hermes-plugin");
+		if (existsSync(fromEmbeddedAssets)) return fromEmbeddedAssets;
+	}
 	// In the native bundle (SIGNET_DIR), hermes-plugin/ lives inside the
 	// connectors directory alongside the connector JS output.
 	const signetDir = process.env.SIGNET_DIR?.trim();
@@ -480,6 +487,8 @@ function getConnectorPackageJsonPath(): string | null {
 }
 
 function getConnectorVersion(): string {
+	const runtimeVersion = process.env.SIGNET_VERSION?.trim();
+	if (runtimeVersion) return runtimeVersion;
 	const packageJsonPath = getConnectorPackageJsonPath();
 	if (!packageJsonPath) return "unknown";
 	try {
@@ -991,8 +1000,15 @@ export async function diagnoseHermesIntegration(opts?: {
 	const repoPluginDir = hermesRepo ? getRepoPluginTargetDir(hermesRepo) : null;
 	const checks: HermesDiagnosticCheck[] = [];
 	const warnings: string[] = [];
-	const userPluginCurrent = pluginLooksCurrent(userPluginDir);
-	const repoPluginCurrent = repoPluginDir ? pluginLooksCurrent(repoPluginDir) : false;
+	let pluginSourceDir: string | null = null;
+	let pluginSourceError: string | null = null;
+	try {
+		pluginSourceDir = getPluginSourceDir();
+	} catch (error) {
+		pluginSourceError = error instanceof Error ? error.message : String(error);
+	}
+	const userPluginCurrent = pluginSourceDir !== null && pluginLooksCurrent(userPluginDir);
+	const repoPluginCurrent = pluginSourceDir !== null && repoPluginDir ? pluginLooksCurrent(repoPluginDir) : false;
 	const probe = hermesRepo
 		? probeHermesProvider(hermesRepo)
 		: userPluginCurrent
@@ -1000,6 +1016,13 @@ export async function diagnoseHermesIntegration(opts?: {
 			: { ok: false, toolNames: [], error: "Hermes repo not found and user plugin is missing or stale" };
 	const daemon = await checkDaemon(daemonUrl);
 
+	checks.push({
+		id: "plugin-source",
+		label: "Bundled Hermes plugin source",
+		ok: pluginSourceDir !== null,
+		detail: pluginSourceDir ?? pluginSourceError ?? "Cannot find hermes-plugin directory in connector package",
+		fix: pluginSourceDir ? undefined : "Reinstall Signet from a release that includes Hermes connector assets.",
+	});
 	checks.push({
 		id: "daemon-health",
 		label: "Signet daemon",

--- a/platform/daemon/src/native-runtime-assets.test.ts
+++ b/platform/daemon/src/native-runtime-assets.test.ts
@@ -78,6 +78,31 @@ describe("native-runtime-assets", () => {
 		expect(skillsDir ? readFileSync(`${skillsDir}/signet/SKILL.md`, "utf8") : "").toContain("Signet");
 	});
 
+	test("materializes connector assets under a deterministic hash with a content marker", () => {
+		registerNativeAssets({
+			connectors: [
+				{
+					path: "hermes-agent/hermes-plugin/__init__.py",
+					contentBase64: Buffer.from("# signet provider\n").toString("base64"),
+					mode: 0o644,
+				},
+			],
+		});
+
+		const first = materializeEmbeddedAssetTree("connectors");
+		const second = materializeEmbeddedAssetTree("connectors");
+		expect(first).toBe(second);
+		expect(first ? readFileSync(`${first}/hermes-agent/hermes-plugin/__init__.py`, "utf8") : "").toBe(
+			"# signet provider\n",
+		);
+		const marker = JSON.parse(first ? readFileSync(`${first}/.signet-assets.json`, "utf8") : "{}") as {
+			kind?: unknown;
+			sourceHash?: unknown;
+		};
+		expect(marker.kind).toBe("connectors");
+		expect(marker.sourceHash).toMatch(/^[a-f0-9]{64}$/);
+	});
+
 	test("stores pre-resolved transformers bindings for compiled runtime", () => {
 		const bindings = { env: {}, pipeline: () => undefined };
 		registerNativeTransformersBindings(bindings);

--- a/platform/daemon/src/native-runtime-assets.ts
+++ b/platform/daemon/src/native-runtime-assets.ts
@@ -26,6 +26,7 @@ export interface EmbeddedFileAsset {
 }
 
 export interface NativeRuntimeAssets {
+	readonly connectors?: readonly EmbeddedFileAsset[];
 	readonly dashboard?: readonly EmbeddedDashboardAsset[];
 	readonly skills?: readonly EmbeddedFileAsset[];
 	readonly templates?: readonly EmbeddedFileAsset[];
@@ -99,15 +100,14 @@ export function materializeEmbeddedWasmAssets(): string | null {
 	return dir;
 }
 
-export function materializeEmbeddedAssetTree(kind: "skills" | "templates"): string | null {
+export function materializeEmbeddedAssetTree(kind: "connectors" | "skills" | "templates"): string | null {
 	const assets = nativeRuntimeAssets()[kind] ?? [];
 	if (assets.length === 0) return null;
 
-	const hash = createHash("sha256")
+	const sourceHash = createHash("sha256")
 		.update(assets.map((asset) => `${asset.path}:${asset.contentBase64}:${asset.mode ?? ""}`).join("\n"))
-		.digest("hex")
-		.slice(0, 16);
-	const root = join(tmpdir(), `signet-native-${kind}`, hash);
+		.digest("hex");
+	const root = join(tmpdir(), `signet-native-${kind}`, sourceHash.slice(0, 16));
 	mkdirSync(root, { recursive: true });
 	for (const asset of assets) {
 		const parts = asset.path.split(/[\\/]+/).filter(Boolean);
@@ -118,6 +118,9 @@ export function materializeEmbeddedAssetTree(kind: "skills" | "templates"): stri
 			writeFileSync(path, Buffer.from(asset.contentBase64, "base64"));
 			if (asset.mode !== undefined) chmodSync(path, asset.mode);
 		}
+	}
+	if (kind === "connectors") {
+		writeFileSync(join(root, ".signet-assets.json"), `${JSON.stringify({ kind, sourceHash }, null, 2)}\n`);
 	}
 	return root;
 }

--- a/scripts/build-native-bun.ts
+++ b/scripts/build-native-bun.ts
@@ -91,6 +91,7 @@ if (!existsSync(join(dashboardDir, "index.html"))) {
 }
 const templatesDir = join(root, "surfaces", "cli", "templates");
 const skillsDir = join(root, "skills");
+const hermesPluginDir = join(root, "integrations", "hermes-agent", "connector", "hermes-plugin");
 
 const workerEntries = [
 	["synthesis-render-worker", "platform/daemon/src/synthesis-render-worker.ts"],
@@ -117,17 +118,19 @@ const dashboardAssets = walkFiles(dashboardDir).map((path) => {
 		contentBase64: readFileSync(path).toString("base64"),
 	};
 });
-const fileAssetsFor = (dir: string) =>
+const fileAssetsFor = (dir: string, prefix = "") =>
 	walkFiles(dir).map((path) => {
 		const relative = path.slice(dir.length).replaceAll("\\", "/");
+		const normalized = relative.startsWith("/") ? relative.slice(1) : relative;
 		return {
-			path: relative.startsWith("/") ? relative.slice(1) : relative,
+			path: prefix ? `${prefix}/${normalized}` : normalized,
 			contentBase64: readFileSync(path).toString("base64"),
 			mode: statSync(path).mode & 0o777,
 		};
 	});
 const templateAssets = fileAssetsFor(templatesDir);
 const skillAssets = fileAssetsFor(skillsDir);
+const connectorAssets = fileAssetsFor(hermesPluginDir, "hermes-agent/hermes-plugin");
 
 const workerAssets = workerEntries.map(([name]) => ({
 	name,
@@ -188,6 +191,7 @@ const wasmAssets = ["ort-wasm-simd-threaded.mjs", "ort-wasm-simd-threaded.wasm"]
 writeFileSync(
 	join(buildDir, "native-assets.ts"),
 	`export const dashboardAssets = ${JSON.stringify(dashboardAssets)} as const;\n` +
+		`export const connectorAssets = ${JSON.stringify(connectorAssets)} as const;\n` +
 		`export const skillAssets = ${JSON.stringify(skillAssets)} as const;\n` +
 		`export const templateAssets = ${JSON.stringify(templateAssets)} as const;\n` +
 		`export const workerAssets = ${JSON.stringify(workerAssets)} as const;\n` +
@@ -206,16 +210,17 @@ export const { env, pipeline } = transformers;
 writeFileSync(
 	join(buildDir, "cli-native.ts"),
 	`import { materializeEmbeddedAssetTree, registerNativeAssets, registerNativeTransformersBindings } from "../platform/daemon/src/native-runtime-assets";
-import { dashboardAssets, skillAssets, templateAssets, wasmAssets, workerAssets } from "./native-assets";
+import { connectorAssets, dashboardAssets, skillAssets, templateAssets, wasmAssets, workerAssets } from "./native-assets";
 import * as transformersWebRuntime from "./transformers-web-runtime";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-registerNativeAssets({ dashboard: dashboardAssets, skills: skillAssets, templates: templateAssets, workers: workerAssets, wasm: wasmAssets });
+registerNativeAssets({ connectors: connectorAssets, dashboard: dashboardAssets, skills: skillAssets, templates: templateAssets, workers: workerAssets, wasm: wasmAssets });
 registerNativeTransformersBindings(transformersWebRuntime);
 process.env.SIGNET_VERSION = process.env.SIGNET_VERSION?.trim() || ${JSON.stringify(nativeVersion)};
 process.env.SIGNET_TEMPLATES_DIR ??= materializeEmbeddedAssetTree("templates") ?? "";
 process.env.SIGNET_SKILLS_SOURCE ??= materializeEmbeddedAssetTree("skills") ?? "";
+process.env.SIGNET_CONNECTOR_ASSETS_DIR ??= materializeEmbeddedAssetTree("connectors") ?? "";
 
 // When the binary is invoked directly (curl-install + signet install,
 // raw binary from PATH) without a parent process setting SIGNET_DIR,

--- a/scripts/check-publish-manifests.test.ts
+++ b/scripts/check-publish-manifests.test.ts
@@ -107,10 +107,12 @@ describe("check-publish-manifests", () => {
 		expect(buildScript).toContain('join(root, "skills")');
 		expect(buildScript).toContain("templateAssets");
 		expect(buildScript).toContain("skillAssets");
+		expect(buildScript).toContain("connectorAssets");
 		expect(buildScript).toContain("process.env.SIGNET_VERSION");
 		expect(buildScript).toContain("process.env.SIGNET_VERSION?.trim()");
 		expect(buildScript).toContain("SIGNET_TEMPLATES_DIR");
 		expect(buildScript).toContain("SIGNET_SKILLS_SOURCE");
+		expect(buildScript).toContain("SIGNET_CONNECTOR_ASSETS_DIR");
 		expect(buildScript).not.toContain('"@1password/sdk"');
 		expect(workflow).toContain("build-native:");
 		expect(workflow).toContain("platform: linux-x64");

--- a/scripts/native-hermes-release-smoke.test.ts
+++ b/scripts/native-hermes-release-smoke.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+
+const tempDirs: string[] = [];
+
+function tempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "signet-native-hermes-smoke-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function run(binary: string, args: readonly string[], env: NodeJS.ProcessEnv, cwd: string) {
+	return spawnSync(binary, args, {
+		cwd,
+		env,
+		encoding: "utf8",
+		timeout: 30_000,
+	});
+}
+
+function parseJsonOutput(stdout: string): Record<string, unknown> {
+	const start = stdout.indexOf("{");
+	if (start < 0) throw new Error(`command did not emit JSON: ${stdout}`);
+	return JSON.parse(stdout.slice(start)) as Record<string, unknown>;
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("native Hermes release smoke", () => {
+	const binary = process.env.SIGNET_NATIVE_SMOKE_BINARY?.trim();
+	const hermesFixture = process.env.SIGNET_HERMES_SMOKE_REPO?.trim();
+	const smoke = binary && hermesFixture ? test : test.skip;
+
+	smoke(
+		"sync and doctor materialize the current Hermes provider from a binary-only package",
+		() => {
+			if (!binary || !hermesFixture) throw new Error("native Hermes smoke environment is incomplete");
+			expect(existsSync(binary)).toBe(true);
+			expect(existsSync(join(hermesFixture, "plugins", "memory", "__init__.py"))).toBe(true);
+
+			const root = tempDir();
+			const home = join(root, "home");
+			const workspace = join(home, ".agents");
+			const hermesHome = join(home, ".hermes");
+			const hermesRepo = join(root, "hermes-agent");
+			mkdirSync(workspace, { recursive: true });
+			cpSync(hermesFixture, hermesRepo, { recursive: true });
+			writeFileSync(join(workspace, "agent.yaml"), "harnesses:\n  - hermes-agent\nembedding:\n  provider: none\n");
+
+			const env: NodeJS.ProcessEnv = {
+				...process.env,
+				HOME: home,
+				SIGNET_PATH: workspace,
+				HERMES_HOME: hermesHome,
+				HERMES_REPO: hermesRepo,
+				PYTHON: process.env.PYTHON?.trim() || "python3",
+				SIGNET_SKIP_AGENT_REGISTER: "1",
+			};
+			// biome-ignore lint/performance/noDelete: clean-home smoke must not inherit source/runtime fallbacks
+			delete env.SIGNET_DIR;
+			// biome-ignore lint/performance/noDelete: prove the binary materializes and sets its own embedded asset tree
+			delete env.SIGNET_CONNECTOR_ASSETS_DIR;
+
+			const sync = run(binary, ["sync"], env, root);
+			expect(sync.status, `${sync.stdout}\n${sync.stderr}`).toBe(0);
+			expect(sync.stdout).not.toContain("Hermes Agent integration setup failed");
+
+			const userPluginDir = join(hermesHome, "plugins", "signet");
+			const repoPluginDir = join(hermesRepo, "plugins", "memory", "signet");
+			for (const pluginDir of [userPluginDir, repoPluginDir]) {
+				for (const name of ["__init__.py", "client.py", "plugin.yaml", "README.md", "signet.install.json"]) {
+					expect(existsSync(join(pluginDir, name)), `${pluginDir}/${name}`).toBe(true);
+				}
+			}
+
+			const marker = JSON.parse(readFileSync(join(userPluginDir, "signet.install.json"), "utf8")) as {
+				connectorVersion?: unknown;
+				sourceHash?: unknown;
+			};
+			const expectedVersion = process.env.SIGNET_NATIVE_SMOKE_VERSION?.trim();
+			if (expectedVersion) expect(marker.connectorVersion).toBe(expectedVersion);
+			expect(marker.sourceHash).toMatch(/^[a-f0-9]{64}$/);
+
+			const doctor = run(binary, ["doctor", "hermes", "--json"], env, root);
+			expect(doctor.status, `${doctor.stdout}\n${doctor.stderr}`).toBe(0);
+			const report = parseJsonOutput(doctor.stdout) as {
+				checks?: Array<{ id?: string; ok?: boolean }>;
+				toolNames?: string[];
+			};
+			expect(report.checks?.find((check) => check.id === "plugin-source")?.ok).toBe(true);
+			expect(report.checks?.find((check) => check.id === "user-plugin")?.ok).toBe(true);
+			expect(report.checks?.find((check) => check.id === "repo-plugin")?.ok).toBe(true);
+			expect(report.checks?.find((check) => check.id === "tool-routing")?.ok).toBe(true);
+			expect(report.toolNames).toEqual(
+				expect.arrayContaining([
+					"memory_search",
+					"memory_store",
+					"memory_get",
+					"memory_list",
+					"memory_modify",
+					"memory_forget",
+					"signet_session_search",
+					"recall",
+					"remember",
+				]),
+			);
+			expect(report.toolNames).not.toContain("session_search");
+
+			const providerProbe = spawnSync(
+				env.PYTHON || "python3",
+				[
+					"-c",
+					[
+						"import json",
+						"from plugins.memory import load_memory_provider",
+						"provider = load_memory_provider('signet')",
+						"print(json.dumps(sorted(schema['name'] for schema in provider.get_tool_schemas())))",
+					].join("\n"),
+				],
+				{ cwd: hermesRepo, env: { ...env, PYTHONPATH: hermesRepo }, encoding: "utf8", timeout: 10_000 },
+			);
+			expect(providerProbe.status, `${providerProbe.stdout}\n${providerProbe.stderr}`).toBe(0);
+			const toolNames = JSON.parse(providerProbe.stdout) as string[];
+			expect(toolNames).toContain("signet_session_search");
+			expect(toolNames).not.toContain("session_search");
+
+			// The package under test intentionally needs no Signet source checkout or
+			// sibling runtime directory: its only required release payload is the binary.
+			expect(basename(binary)).toMatch(/^signet(?:-|$)/);
+		},
+		120_000,
+	);
+});


### PR DESCRIPTION
## Summary

- embed the Hermes Python provider assets into Bun-compiled native Signet binaries
- materialize embedded connector assets into a deterministic content-addressed runtime tree
- let the Hermes connector resolve that tree through `SIGNET_CONNECTOR_ASSETS_DIR`
- expose missing connector assets as a structured `doctor hermes` check instead of throwing
- add unit, manifest, and real binary-only regression coverage

## Root cause

The Hermes connector package contains `hermes-plugin/`, but Bun's compiled native executable only embedded JavaScript and the existing dashboard/skill/template assets. A binary-only install therefore had no filesystem copy of the Python provider where `signet sync` and `signet doctor hermes` expected it.

## Validation

- `bun run --filter '@signet/connector-hermes-agent' build`
- `bun run build:native-bun`
- `SIGNET_NATIVE_SMOKE_BINARY=$PWD/dist/native/signet-linux-x64 SIGNET_HERMES_SMOKE_REPO=$PWD/references/hermes-agent SIGNET_NATIVE_SMOKE_VERSION=0.147.1 bun test scripts/native-hermes-release-smoke.test.ts`
  - 1 test passed, 27 assertions
  - validates binary-only `sync`, `doctor hermes --json`, both plugin destinations, provider import, release marker/hash, and all nine Signet tools
- focused connector regressions: 3 passed
- native asset and publish-manifest tests: 28 passed
- `bunx biome check` on all changed TypeScript files: passed
- native dashboard/Bun build: passed

### Existing baseline exception

The full connector file has eight failures on this host on both `origin/main` and this branch: seven tests spawn literal `python` while only `python3` is installed, and one existing install-warning assertion fails unchanged. The newly added/modified #894 tests pass independently and the branch introduces no additional full-file failures.

## Readiness checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Fixes #894
