### PR TITLE
fix(pipeline): cancel extraction for forgotten memories

### DIFF
--- a/platform/daemon/src/pipeline/extraction-queue.ts
+++ b/platform/daemon/src/pipeline/extraction-queue.ts
@@ -1,5 +1,31 @@
 import type { DbAccessor, WriteDb } from "../db-accessor";
 
+export const FORGOTTEN_MEMORY_JOB_ERROR = "Source memory forgotten";
+export const FORGOTTEN_MEMORY_JOB_RESULT = JSON.stringify({ cancelled: "memory_forgotten" });
+
+export function cancelExtractionJobsForForgottenMemory(db: WriteDb, memoryId: string, changedAt: string): number {
+	const result = db
+		.prepare(
+			`UPDATE memory_jobs
+			 SET status = 'dead', result = ?, error = ?, failed_at = ?, updated_at = ?
+			 WHERE memory_id = ?
+			   AND job_type = 'extract'
+			   AND status IN ('pending', 'leased')`,
+		)
+		.run(FORGOTTEN_MEMORY_JOB_RESULT, FORGOTTEN_MEMORY_JOB_ERROR, changedAt, changedAt, memoryId);
+	return result.changes;
+}
+
+export function cancelExtractionJobForForgottenMemory(db: WriteDb, jobId: string): void {
+	const now = new Date().toISOString();
+	db.prepare(
+		`UPDATE memory_jobs
+		 SET status = 'dead', result = ?, error = ?, failed_at = ?, updated_at = ?
+		 WHERE id = ?
+		   AND status IN ('pending', 'leased')`,
+	).run(FORGOTTEN_MEMORY_JOB_RESULT, FORGOTTEN_MEMORY_JOB_ERROR, now, now, jobId);
+}
+
 // ---------------------------------------------------------------------------
 // Job enqueue (called by daemon remember endpoint and other write surfaces)
 // ---------------------------------------------------------------------------
@@ -8,9 +34,10 @@ export function enqueueExtractionJobInTx(db: WriteDb, memoryId: string): void {
 	// Skip if memory extraction is already complete (structured passthrough
 	// or prior pipeline run). This prevents re-processing memories that
 	// were ingested with pre-extracted data.
-	const mem = db.prepare("SELECT extraction_status FROM memories WHERE id = ? LIMIT 1").get(memoryId) as
-		| { extraction_status: string | null }
+	const mem = db.prepare("SELECT extraction_status, is_deleted FROM memories WHERE id = ? LIMIT 1").get(memoryId) as
+		| { extraction_status: string | null; is_deleted: number }
 		| undefined;
+	if (!mem || mem.is_deleted === 1) return;
 	if (mem?.extraction_status === "complete" || mem?.extraction_status === "completed") return;
 
 	// Dedup: skip if a pending/leased job already exists

--- a/platform/daemon/src/pipeline/worker.integration.test.ts
+++ b/platform/daemon/src/pipeline/worker.integration.test.ts
@@ -16,6 +16,7 @@ import type { LlmProvider, PipelineV2Config } from "@signet/core";
 import { runMigrations } from "../../../core/src/migrations";
 import { normalizeAndHashContent } from "../content-normalization";
 import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
+import { txForgetMemory } from "../transactions";
 import type { DecisionConfig } from "./decision";
 import { startHintsWorker } from "./prospective-index";
 import { enqueueExtractionJob, startWorker } from "./worker";
@@ -617,6 +618,68 @@ describe("pipeline integration", () => {
 		// Search for relocation-related hint
 		const relocationResults = getHintsFts(db, '"Nicholai" "Seattle"');
 		expect(relocationResults.length).toBeGreaterThan(0);
+	});
+
+	it("forgetting a leased source before Phase C blocks fact and graph writes", async () => {
+		const sourceId = crypto.randomUUID();
+		insertMemory(db, sourceId, "Nicholai moved from Portland to Seattle in 2019 for a new engineering role");
+
+		let signalExtractionStarted!: () => void;
+		const extractionStarted = new Promise<void>((resolve) => {
+			signalExtractionStarted = resolve;
+		});
+		let releaseExtraction!: () => void;
+		const extractionBarrier = new Promise<void>((resolve) => {
+			releaseExtraction = resolve;
+		});
+		let providerCalls = 0;
+		const provider: LlmProvider = {
+			name: "mock-race",
+			async generate() {
+				providerCalls++;
+				if (providerCalls === 1) {
+					signalExtractionStarted();
+					await extractionBarrier;
+					return EXTRACTION_RESPONSE;
+				}
+				return DECISION_ADD_RESPONSE;
+			},
+			async available() {
+				return true;
+			},
+		};
+
+		enqueueExtractionJob(accessor, sourceId);
+		const worker = startWorker(accessor, provider, testPipelineCfg(), testDecisionCfg());
+		await extractionStarted;
+
+		const forgottenAt = new Date().toISOString();
+		const forgotten = accessor.withWriteTx((writeDb) =>
+			txForgetMemory(writeDb, {
+				memoryId: sourceId,
+				reason: "privacy request during extraction",
+				changedBy: "operator",
+				changedAt: forgottenAt,
+				force: false,
+			}),
+		);
+		expect(forgotten.status).toBe("deleted");
+
+		releaseExtraction();
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		await worker.stop();
+
+		const job = getJob(db, sourceId, "extract");
+		expect(job?.status).toBe("dead");
+		expect(job?.error).toBe("Source memory forgotten");
+		expect(JSON.parse(job?.result ?? "{}")).toEqual({ cancelled: "memory_forgotten" });
+		expect(getWrittenFacts(db, sourceId)).toEqual([]);
+		expect(getEntities(db, "Nicholai")).toBeNull();
+		expect(getEntities(db, "Seattle")).toBeNull();
+		expect(getEntities(db, "Portland")).toBeNull();
+		expect(getMentions(db, sourceId)).toEqual([]);
+		const relationCount = db.prepare("SELECT COUNT(*) AS count FROM relations").get() as { count: number };
+		expect(relationCount.count).toBe(0);
 	});
 
 	it("shadow mode: extracts and decides but writes nothing", async () => {

--- a/platform/daemon/src/pipeline/worker.test.ts
+++ b/platform/daemon/src/pipeline/worker.test.ts
@@ -537,6 +537,38 @@ describe("Worker processing", () => {
 		expect(result.skipped).toBe("memory_not_found");
 	});
 
+	it("skips a deleted source before invoking the provider", async () => {
+		let generateCalls = 0;
+		const provider: LlmProvider = {
+			name: "must-not-run",
+			async generate() {
+				generateCalls++;
+				return JSON.stringify({ facts: [], entities: [] });
+			},
+			async available() {
+				return true;
+			},
+		};
+
+		insertMemory(db, "mem-deleted-before-extract", "User prefers a private editor configuration");
+		enqueueExtractionJob(accessor, "mem-deleted-before-extract");
+		const deletedAt = new Date().toISOString();
+		db.prepare(
+			`UPDATE memories
+			 SET is_deleted = 1, deleted_at = ?, updated_at = ?
+			 WHERE id = ?`,
+		).run(deletedAt, deletedAt, "mem-deleted-before-extract");
+
+		const worker = startWorker(accessor, provider, PIPELINE_CFG, DECISION_CFG);
+		await Bun.sleep(200);
+		await worker.stop();
+
+		expect(generateCalls).toBe(0);
+		const job = getJob(db, "mem-deleted-before-extract");
+		expect(job?.status).toBe("completed");
+		expect(JSON.parse(job?.result ?? "{}")).toEqual({ skipped: "memory_forgotten" });
+	});
+
 	it("fails job with retry when LLM provider throws", async () => {
 		// When the LLM throws, extraction now propagates the error so the
 		// worker's failJob() path handles it with exponential backoff retry.

--- a/platform/daemon/src/pipeline/worker.ts
+++ b/platform/daemon/src/pipeline/worker.ts
@@ -22,11 +22,7 @@ import type { DecisionConfig, FactDecisionProposal } from "./decision";
 import { runShadowDecisions } from "./decision";
 import { extractFactsAndEntities } from "./extraction";
 import { escalate } from "./extraction-escalation";
-import {
-	cancelExtractionJobForForgottenMemory,
-	enqueueExtractionJob,
-	enqueueExtractionJobInTx,
-} from "./extraction-queue";
+import { cancelExtractionJobForForgottenMemory } from "./extraction-queue";
 import { txPersistEntities } from "./graph-transactions";
 import { invalidateTraversalCache } from "./graph-traversal";
 import { enqueueHintsJob } from "./prospective-index";

--- a/platform/daemon/src/pipeline/worker.ts
+++ b/platform/daemon/src/pipeline/worker.ts
@@ -22,7 +22,11 @@ import type { DecisionConfig, FactDecisionProposal } from "./decision";
 import { runShadowDecisions } from "./decision";
 import { extractFactsAndEntities } from "./extraction";
 import { escalate } from "./extraction-escalation";
-import { enqueueExtractionJob, enqueueExtractionJobInTx } from "./extraction-queue";
+import {
+	cancelExtractionJobForForgottenMemory,
+	enqueueExtractionJob,
+	enqueueExtractionJobInTx,
+} from "./extraction-queue";
 import { txPersistEntities } from "./graph-transactions";
 import { invalidateTraversalCache } from "./graph-traversal";
 import { enqueueHintsJob } from "./prospective-index";
@@ -71,6 +75,7 @@ interface JobRow {
 interface MemoryContentRow {
 	content: string;
 	extraction_status: string | null;
+	is_deleted: number;
 	agent_id: string | null;
 	project: string | null;
 	scope: string | null;
@@ -205,7 +210,8 @@ function completeJob(db: WriteDb, jobId: string, result: string | null): void {
 	db.prepare(
 		`UPDATE memory_jobs
 		 SET status = 'completed', result = ?, completed_at = ?, updated_at = ?
-		 WHERE id = ?`,
+		 WHERE id = ?
+		   AND status IN ('pending', 'leased')`,
 	).run(result, now, now, jobId);
 }
 
@@ -219,7 +225,8 @@ function failJob(db: WriteDb, jobId: string, error: string, attempts: number, ma
 	db.prepare(
 		`UPDATE memory_jobs
 		 SET status = ?, error = ?, failed_at = ?, updated_at = ?
-		 WHERE id = ?`,
+		 WHERE id = ?
+		   AND status IN ('pending', 'leased')`,
 	).run(nextStatus, error, now, now, jobId);
 }
 
@@ -233,8 +240,13 @@ function deadLetterJob(db: WriteDb, jobId: string, error: string): void {
 	db.prepare(
 		`UPDATE memory_jobs
 		 SET status = 'dead', error = ?, failed_at = ?, updated_at = ?
-		 WHERE id = ?`,
+		 WHERE id = ?
+		   AND status IN ('pending', 'leased')`,
 	).run(error, now, now, jobId);
+}
+
+function memoryIsActive(db: WriteDb, memoryId: string): boolean {
+	return Boolean(db.prepare("SELECT 1 FROM memories WHERE id = ? AND is_deleted = 0 LIMIT 1").get(memoryId));
 }
 
 function updateExtractionStatus(db: WriteDb, memoryId: string, status: string, extractionModel?: string): void {
@@ -1022,7 +1034,7 @@ export function startWorker(
 			(db) =>
 				db
 					.prepare(
-						`SELECT content, extraction_status, agent_id, project, scope, visibility, source_type, source_id
+						`SELECT content, extraction_status, is_deleted, agent_id, project, scope, visibility, source_type, source_id
 						 FROM memories
 						 WHERE id = ?`,
 					)
@@ -1032,6 +1044,12 @@ export function startWorker(
 		if (!row) {
 			accessor.withWriteTx((db) => {
 				completeJob(db, job.id, JSON.stringify({ skipped: "memory_not_found" }));
+			});
+			return;
+		}
+		if (row.is_deleted === 1) {
+			accessor.withWriteTx((db) => {
+				completeJob(db, job.id, JSON.stringify({ skipped: "memory_forgotten" }));
 			});
 			return;
 		}
@@ -1287,8 +1305,15 @@ export function startWorker(
 
 		let writeStats = zeroWriteStats();
 
-		// Record everything atomically.
+		// Record everything atomically. Re-check source liveness inside the
+		// write transaction so a concurrent forget cannot race Phase C writes.
+		let sourceForgotten = false;
 		accessor.withWriteTx((db) => {
+			if (!memoryIsActive(db, job.memory_id)) {
+				cancelExtractionJobForForgottenMemory(db, job.id);
+				sourceForgotten = true;
+				return;
+			}
 			if (controlledWritesEnabled) {
 				writeStats = applyPhaseCWrites(
 					db,
@@ -1334,6 +1359,13 @@ export function startWorker(
 			completeJob(db, job.id, resultPayload);
 			updateExtractionStatus(db, job.memory_id, "completed", extractionCfg.model);
 		});
+		if (sourceForgotten) {
+			log.info("pipeline", "Source memory forgotten before extraction persistence", {
+				jobId: job.id,
+				memoryId: job.memory_id,
+			});
+			return;
+		}
 
 		if (controlledWritesEnabled && writeStats.writeGateConsidered > 0) {
 			const blockRate = writeStats.writeGateBlocked / writeStats.writeGateConsidered;
@@ -1369,14 +1401,20 @@ export function startWorker(
 		};
 		if (shouldPersistExtractionGraph(pipelineCfg, extraction.entities.length)) {
 			try {
-				graphStats = accessor.withWriteTx((db) =>
-					txPersistEntities(db, {
+				let sourceForgottenBeforeGraph = false;
+				graphStats = accessor.withWriteTx((db) => {
+					if (!memoryIsActive(db, job.memory_id)) {
+						sourceForgottenBeforeGraph = true;
+						return graphStats;
+					}
+					return txPersistEntities(db, {
 						entities: extraction.entities,
 						sourceMemoryId: job.memory_id,
 						extractedAt: new Date().toISOString(),
 						agentId,
-					}),
-				);
+					});
+				});
+				if (sourceForgottenBeforeGraph) return;
 				// New entities/relations invalidate traversal table cache
 				invalidateTraversalCache();
 			} catch (e) {

--- a/platform/daemon/src/transactions.test.ts
+++ b/platform/daemon/src/transactions.test.ts
@@ -285,6 +285,91 @@ describe("transactions: txModifyMemory + txForgetMemory + txRecoverMemory", () =
 		expect(history.reason).toBe("cleanup with force");
 	});
 
+	it("dead-letters pending and leased jobs for a forgotten memory without touching other jobs", () => {
+		insertMemory(db, {
+			id: "mem-forget-jobs",
+			content: "Forget jobs source",
+			contentHash: "hash-forget-jobs",
+		});
+		insertMemory(db, {
+			id: "mem-keep-jobs",
+			content: "Keep jobs source",
+			contentHash: "hash-keep-jobs",
+		});
+
+		const createdAt = "2026-07-09T10:00:00.000Z";
+		const insertJob = db.prepare(
+			`INSERT INTO memory_jobs
+			 (id, memory_id, job_type, status, attempts, max_attempts, created_at, updated_at)
+			 VALUES (?, ?, 'extract', ?, 0, 3, ?, ?)`,
+		);
+		insertJob.run("job-forget-pending", "mem-forget-jobs", "pending", createdAt, createdAt);
+		insertJob.run("job-forget-leased", "mem-forget-jobs", "leased", createdAt, createdAt);
+		insertJob.run("job-forget-completed", "mem-forget-jobs", "completed", createdAt, createdAt);
+		insertJob.run("job-keep-leased", "mem-keep-jobs", "leased", createdAt, createdAt);
+
+		const changedAt = "2026-07-09T10:05:00.000Z";
+		const result = txForgetMemory(asWriteDb(db), {
+			memoryId: "mem-forget-jobs",
+			reason: "privacy request",
+			changedBy: "operator",
+			changedAt,
+			force: false,
+		});
+
+		expect(result.status).toBe("deleted");
+		const cancelled = db
+			.prepare(
+				`SELECT id, status, result, error, failed_at, updated_at
+				 FROM memory_jobs
+				 WHERE id IN ('job-forget-pending', 'job-forget-leased')
+				 ORDER BY id`,
+			)
+			.all() as Array<{
+			id: string;
+			status: string;
+			result: string | null;
+			error: string | null;
+			failed_at: string | null;
+			updated_at: string;
+		}>;
+		expect(cancelled).toHaveLength(2);
+		for (const job of cancelled) {
+			expect(job.status).toBe("dead");
+			expect(JSON.parse(job.result ?? "{}")).toEqual({ cancelled: "memory_forgotten" });
+			expect(job.error).toBe("Source memory forgotten");
+			expect(job.failed_at).toBe(changedAt);
+			expect(job.updated_at).toBe(changedAt);
+		}
+
+		const untouched = db
+			.prepare(
+				`SELECT id, status, result, error, failed_at, updated_at
+				 FROM memory_jobs
+				 WHERE id IN ('job-forget-completed', 'job-keep-leased')
+				 ORDER BY id`,
+			)
+			.all();
+		expect(untouched).toEqual([
+			{
+				id: "job-forget-completed",
+				status: "completed",
+				result: null,
+				error: null,
+				failed_at: null,
+				updated_at: createdAt,
+			},
+			{
+				id: "job-keep-leased",
+				status: "leased",
+				result: null,
+				error: null,
+				failed_at: null,
+				updated_at: createdAt,
+			},
+		]);
+	});
+
 	it("removes aggregate provenance links when a linked memory is forgotten", () => {
 		insertMemory(db, {
 			id: "mem-aggregate",

--- a/platform/daemon/src/transactions.ts
+++ b/platform/daemon/src/transactions.ts
@@ -8,6 +8,7 @@
 
 import type { WriteDb } from "./db-accessor";
 import { syncVecDeleteBySourceExceptHash, syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "./db-helpers";
+import { cancelExtractionJobsForForgottenMemory } from "./pipeline/extraction-queue";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -562,6 +563,7 @@ export function txForgetMemory(db: WriteDb, input: ForgetMemoryTxInput): ForgetM
 		     version = version + 1
 		 WHERE id = ?`,
 	).run(input.changedAt, input.changedAt, input.changedBy, input.memoryId);
+	cancelExtractionJobsForForgottenMemory(db, input.memoryId, input.changedAt);
 	deleteAggregateMemorySourceLinks(db, input.memoryId);
 
 	insertHistoryEvent(db, {


### PR DESCRIPTION
## Summary

- cancel pending and leased extraction jobs in the same transaction that forgets their source memory
- prevent terminal worker updates from resurrecting a cancelled job
- skip deleted sources before provider invocation and reject Phase C / graph persistence if the source is forgotten while extraction is in flight
- avoid enqueueing extraction work for missing or already deleted memories
- add transaction, worker, and full pipeline race regression coverage

## Root cause

`txForgetMemory` soft-deleted the memory but left `memory_jobs` untouched. A leased extraction could therefore finish after deletion and persist derived fact memories and graph entities from forgotten content. Worker completion/failure updates were also unconditional, so an in-flight worker could overwrite a cancellation state.

## Validation

- `bun test platform/daemon/src/transactions.test.ts platform/daemon/src/pipeline/worker.test.ts platform/daemon/src/pipeline/worker.integration.test.ts` — 71 pass, 0 fail
- `bunx biome check ... --diagnostic-level=error` on all changed files — no errors
- `git diff --check` — clean

The daemon's standalone `tsc -p platform/daemon/tsconfig.json --noEmit` is not a clean project gate on `main`; it currently emits the existing cross-workspace `rootDir` and broader typing backlog. This patch does not add a new package-level typecheck script.

## Checklist

- [x] Linked issue: Fixes #895
- [x] Targeted tests added and passing
- [x] Integration race covered with a barrier-controlled in-flight provider
- [x] No new dependencies
- [x] No schema/API changes
- [x] Branch is scoped to one bug

Fixes #895
