### PR TITLE
fix(native): initialize ONNX WASM embeddings in compiled binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,6 +212,13 @@ jobs:
         shell: bash
         run: test -s ./dist/native/"$RELEASE_ASSET"
 
+      - name: Native embedding smoke
+        shell: bash
+        env:
+          SIGNET_NATIVE_EMBEDDING_SMOKE: "1"
+          SIGNET_NATIVE_SMOKE_BINARY: ./dist/native/${{ matrix.asset }}
+        run: bun test scripts/native-embedding-runtime-smoke.test.ts
+
       - name: Upload to release
         shell: bash
         run: |

--- a/platform/daemon/src/native-embedding.test.ts
+++ b/platform/daemon/src/native-embedding.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 
 // Mock @huggingface/transformers to avoid real model downloads
 const mockEmbedFn = mock(async (text: string, _opts: unknown) => ({
@@ -87,7 +87,11 @@ describe("native-embedding", () => {
 
 		const status1 = await checkNativeProvider();
 		expect(status1.available).toBe(false);
-		expect(status1.error).toContain("network timeout");
+		expect(status1.error).toContain("runtime=bundled runtime");
+		expect(status1.error).toContain("backend=onnx-wasm");
+		expect(status1.error).toContain("cachePath=");
+		expect(status1.error).toContain("wasmPath=unavailable");
+		expect(status1.error).toContain("cause=network timeout");
 
 		await shutdownNativeProvider();
 

--- a/platform/daemon/src/native-embedding.ts
+++ b/platform/daemon/src/native-embedding.ts
@@ -62,6 +62,11 @@ interface TransformersBindings {
 	) => Promise<unknown>;
 }
 
+interface LoadedTransformersBindings {
+	readonly bindings: TransformersBindings;
+	readonly source: string;
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -84,7 +89,7 @@ function readTransformersBindings(value: unknown): TransformersBindings | null {
 	};
 }
 
-async function loadTransformersBindings(): Promise<TransformersBindings> {
+async function loadTransformersBindings(): Promise<LoadedTransformersBindings> {
 	const importBySpecifier = (specifier: string): Promise<unknown> => {
 		return import(specifier);
 	};
@@ -139,11 +144,11 @@ async function loadTransformersBindings(): Promise<TransformersBindings> {
 		}
 
 		const direct = readTransformersBindings(mod);
-		if (direct !== null) return direct;
+		if (direct !== null) return { bindings: direct, source: candidate.source };
 
 		if (isRecord(mod) && "default" in mod) {
 			const fromDefault = readTransformersBindings(mod.default);
-			if (fromDefault !== null) return fromDefault;
+			if (fromDefault !== null) return { bindings: fromDefault, source: candidate.source };
 		}
 
 		failures.push(`${candidate.source}: unsupported export shape (missing env/pipeline)`);
@@ -216,19 +221,24 @@ async function ensureInitialized(): Promise<void> {
 }
 
 async function doInit(): Promise<void> {
+	let runtimeSource = "unresolved";
+	let cacheDir = "unresolved";
+	let wasmDir: string | null = null;
 	try {
 		initError = null;
 
-		const cacheDir = getCacheDir();
+		cacheDir = getCacheDir();
 		mkdirSync(cacheDir, { recursive: true });
 
 		// Dynamic import to avoid top-level WASM load
-		const transformers = await loadTransformersBindings();
+		const loaded = await loadTransformersBindings();
+		const transformers = loaded.bindings;
+		runtimeSource = loaded.source;
 
 		// Configure cache directory
 		transformers.env.cacheDir = cacheDir;
 		transformers.env.allowLocalModels = true;
-		const wasmDir = materializeEmbeddedWasmAssets();
+		wasmDir = materializeEmbeddedWasmAssets();
 		if (wasmDir) {
 			const backends = transformers.env.backends;
 			const onnx = isRecord(backends) ? backends.onnx : null;
@@ -238,8 +248,12 @@ async function doInit(): Promise<void> {
 			}
 		}
 
-		logger.info("native-embedding", `Initializing ${MODEL_ID} (q8 quantization)`);
-		logger.info("native-embedding", `Model cache: ${cacheDir}`);
+		logger.info("native-embedding", `Initializing ${MODEL_ID} (q8 quantization)`, {
+			runtime: runtimeSource,
+			backend: "onnx-wasm",
+			cachePath: cacheDir,
+			wasmPath: wasmDir ?? "unavailable",
+		});
 
 		const pipe = await transformers.pipeline("feature-extraction", MODEL_ID, {
 			dtype: "q8" as const,
@@ -267,11 +281,13 @@ async function doInit(): Promise<void> {
 		modelCached = true;
 		logger.info("native-embedding", `Ready — ${EXPECTED_DIMS}-dim embeddings`);
 	} catch (err) {
-		initError = err instanceof Error ? err.message : String(err);
+		const cause = err instanceof Error ? err.message : String(err);
+		initError = `runtime=${runtimeSource}; backend=onnx-wasm; cachePath=${cacheDir}; wasmPath=${wasmDir ?? "unavailable"}; cause=${cause}`;
 		initPromise = null;
 		lastInitFailure = Date.now();
-		logger.error("native-embedding", `Init failed: ${initError}`);
-		throw err;
+		const wrapped = new Error(initError, { cause: err });
+		logger.error("native-embedding", `Init failed: ${initError}`, wrapped);
+		throw wrapped;
 	}
 }
 

--- a/scripts/build-native-bun.ts
+++ b/scripts/build-native-bun.ts
@@ -135,10 +135,54 @@ const workerAssets = workerEntries.map(([name]) => ({
 }));
 const transformersPackageJson = daemonRequire.resolve("@huggingface/transformers/package.json");
 const transformersDir = dirname(transformersPackageJson);
+const transformersRequire = createRequire(transformersPackageJson);
+const onnxRuntimeWebPackageJson = transformersRequire.resolve("onnxruntime-web/package.json");
+const onnxRuntimeWebDir = dirname(onnxRuntimeWebPackageJson);
+const onnxRuntimeWebWasmPath = join(onnxRuntimeWebDir, "dist", "ort.wasm.bundle.min.mjs");
+const onnxRuntimeWebRequire = createRequire(onnxRuntimeWebPackageJson);
+const onnxRuntimeCommonPackageJson = onnxRuntimeWebRequire.resolve("onnxruntime-common/package.json");
+const onnxRuntimeCommonEsmPath = join(dirname(onnxRuntimeCommonPackageJson), "dist", "esm", "index.js");
 const transformersWebRuntimePath = join(transformersDir, "dist", "transformers.web.js");
-const wasmAssets = ["ort-wasm-simd-threaded.jsep.wasm"].map((name) => ({
+
+// Bun's compiled executable reports a Node-like environment, so Transformers.js
+// selects its native ONNX branch even though this release embeds the web/WASM
+// runtime. Patch only the generated build copy, with unique-anchor guards so a
+// dependency upgrade fails loudly instead of silently producing a broken binary.
+let patchedTransformersWebRuntimeSource = readFileSync(transformersWebRuntimePath, "utf8");
+for (const [specifier, resolved] of [
+	["onnxruntime-common", onnxRuntimeCommonEsmPath],
+	["onnxruntime-web", onnxRuntimeWebWasmPath],
+] as const) {
+	const externalImport = `from ${JSON.stringify(specifier)};`;
+	if (patchedTransformersWebRuntimeSource.split(externalImport).length !== 2) {
+		throw new Error(`Unsupported @huggingface/transformers web runtime: ${specifier} import changed`);
+	}
+	patchedTransformersWebRuntimeSource = patchedTransformersWebRuntimeSource.replace(
+		externalImport,
+		`from ${JSON.stringify(resolved)};`,
+	);
+}
+const customRuntimeAnchor = "    ONNX = globalThis[ORT_SYMBOL];\n";
+if (patchedTransformersWebRuntimeSource.split(customRuntimeAnchor).length !== 2) {
+	throw new Error("Unsupported @huggingface/transformers web runtime: custom ONNX runtime anchor changed");
+}
+patchedTransformersWebRuntimeSource = patchedTransformersWebRuntimeSource.replace(
+	customRuntimeAnchor,
+	`${customRuntimeAnchor}\n    // Transformers.js 3.8.1 does not populate device defaults for a custom runtime.\n    supportedDevices.push('wasm');\n    defaultDevices = ['wasm'];\n`,
+);
+const nodeDeviceDefault = /device \?\? \([^\n)]+\.apis\.IS_NODE_ENV \? 'cpu' : 'wasm'\)/g;
+if ((patchedTransformersWebRuntimeSource.match(nodeDeviceDefault) ?? []).length !== 1) {
+	throw new Error("Unsupported @huggingface/transformers web runtime: Node device default changed");
+}
+patchedTransformersWebRuntimeSource = patchedTransformersWebRuntimeSource.replace(
+	nodeDeviceDefault,
+	"device ?? 'wasm'",
+);
+const patchedTransformersWebRuntimePath = join(buildDir, "transformers.web.js");
+writeFileSync(patchedTransformersWebRuntimePath, patchedTransformersWebRuntimeSource);
+const wasmAssets = ["ort-wasm-simd-threaded.mjs", "ort-wasm-simd-threaded.wasm"].map((name) => ({
 	name,
-	contentBase64: readFileSync(join(transformersDir, "dist", name)).toString("base64"),
+	contentBase64: readFileSync(join(onnxRuntimeWebDir, "dist", name)).toString("base64"),
 }));
 
 writeFileSync(
@@ -152,7 +196,11 @@ writeFileSync(
 
 writeFileSync(
 	join(buildDir, "transformers-web-runtime.ts"),
-	`export { env, pipeline } from ${JSON.stringify(transformersWebRuntimePath)};\n`,
+	`import * as onnxRuntime from ${JSON.stringify(onnxRuntimeWebWasmPath)};
+globalThis[Symbol.for("onnxruntime")] = onnxRuntime.default ?? onnxRuntime;
+const transformers = await import(${JSON.stringify(patchedTransformersWebRuntimePath)});
+export const { env, pipeline } = transformers;
+`,
 );
 
 writeFileSync(

--- a/scripts/native-embedding-runtime-smoke.test.ts
+++ b/scripts/native-embedding-runtime-smoke.test.ts
@@ -1,0 +1,143 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const enabled = process.env.SIGNET_NATIVE_EMBEDDING_SMOKE === "1";
+const tempDirs: string[] = [];
+const children: ChildProcessWithoutNullStreams[] = [];
+
+function tempDir(): string {
+	const path = mkdtempSync(join(tmpdir(), "signet-native-embedding-smoke-"));
+	tempDirs.push(path);
+	return path;
+}
+
+async function freePort(): Promise<number> {
+	const server = createServer();
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	const address = server.address();
+	if (address === null || typeof address === "string") throw new Error("failed to allocate smoke-test port");
+	const port = address.port;
+	await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+	return port;
+}
+
+async function waitForHealth(origin: string, child: ChildProcessWithoutNullStreams): Promise<void> {
+	const deadline = Date.now() + 30_000;
+	while (Date.now() < deadline) {
+		if (child.exitCode !== null) throw new Error(`native daemon exited before health check (status ${child.exitCode})`);
+		try {
+			const response = await fetch(`${origin}/health`, { signal: AbortSignal.timeout(1_000) });
+			if (response.ok) return;
+		} catch {}
+		await Bun.sleep(100);
+	}
+	throw new Error("native daemon did not become healthy within 30 seconds");
+}
+
+function floatVector(value: unknown): Float32Array {
+	if (!(value instanceof Uint8Array)) throw new Error("embedding vector was not stored as bytes");
+	return new Float32Array(value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength));
+}
+
+async function stopChild(child: ChildProcessWithoutNullStreams): Promise<void> {
+	if (child.exitCode !== null) return;
+	child.kill("SIGTERM");
+	await Promise.race([
+		new Promise<void>((resolve) => child.once("close", () => resolve())),
+		Bun.sleep(5_000).then(() => {
+			if (child.exitCode === null) child.kill("SIGKILL");
+		}),
+	]);
+}
+
+afterEach(async () => {
+	for (const child of children.splice(0)) await stopChild(child);
+	for (const path of tempDirs.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe("compiled native embedding runtime", () => {
+	const smoke = enabled ? test : test.skip;
+
+	smoke(
+		"embeds and recalls a fixed sentence through the compiled Linux binary",
+		async () => {
+			if (process.platform !== "linux" || process.arch !== "x64") return;
+
+			const binary = join(root, "dist", "native", "signet-linux-x64");
+			const workspace = tempDir();
+			writeFileSync(
+				join(workspace, "agent.yaml"),
+				"version: 1\nschema: signet/v1\nagent:\n  name: Native Embedding Smoke\nmemory:\n  database: memory/memories.db\n  pipelineV2:\n    enabled: false\nembedding:\n  provider: native\n  model: nomic-embed-text-v1.5\n  dimensions: 768\n",
+			);
+
+			const port = await freePort();
+			const origin = `http://127.0.0.1:${port}`;
+			const child = spawn(binary, [], {
+				env: {
+					...process.env,
+					SIGNET_DAEMON_ENTRYPOINT: "1",
+					SIGNET_PATH: workspace,
+					SIGNET_PORT: String(port),
+					SIGNET_BIND: "127.0.0.1",
+					OLLAMA_HOST: "http://127.0.0.1:1",
+				},
+				stdio: ["ignore", "pipe", "pipe"],
+			});
+			children.push(child);
+			const output: Buffer[] = [];
+			child.stdout.on("data", (chunk) => output.push(Buffer.from(chunk)));
+			child.stderr.on("data", (chunk) => output.push(Buffer.from(chunk)));
+
+			try {
+				await waitForHealth(origin, child);
+				const sentence = "Issue 898 native packaging probe remembers the cobalt lighthouse.";
+				const rememberResponse = await fetch(`${origin}/api/memory/remember`, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ content: sentence, who: "runtime-smoke", importance: 0.9 }),
+					signal: AbortSignal.timeout(10 * 60_000),
+				});
+				const remember = (await rememberResponse.json()) as { id?: unknown; embedded?: unknown; error?: unknown };
+				expect(rememberResponse.ok).toBe(true);
+				expect(remember.error).toBeUndefined();
+				expect(remember.embedded).toBe(true);
+				expect(typeof remember.id).toBe("string");
+
+				const db = new Database(join(workspace, "memory", "memories.db"), { readonly: true });
+				const row = db
+					.query("SELECT dimensions, vector FROM embeddings WHERE source_type = 'memory' AND source_id = ?")
+					.get(String(remember.id)) as { dimensions?: unknown; vector?: unknown } | null;
+				db.close();
+				expect(row?.dimensions).toBe(768);
+				const vector = floatVector(row?.vector);
+				expect(vector).toHaveLength(768);
+				expect(Array.from(vector).every(Number.isFinite)).toBe(true);
+
+				const recallResponse = await fetch(`${origin}/api/memory/recall`, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ query: "cobalt lighthouse packaging probe", limit: 5 }),
+					signal: AbortSignal.timeout(30_000),
+				});
+				const recallText = await recallResponse.text();
+				expect(recallResponse.ok).toBe(true);
+				expect(recallText).toContain(sentence);
+			} catch (error) {
+				const logs = Buffer.concat(output).toString("utf8");
+				throw new Error(`${error instanceof Error ? error.message : String(error)}\n\nNative daemon output:\n${logs}`, {
+					cause: error,
+				});
+			}
+		},
+		12 * 60_000,
+	);
+});

--- a/scripts/native-embedding-runtime-smoke.test.ts
+++ b/scripts/native-embedding-runtime-smoke.test.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -10,6 +10,18 @@ const root = join(import.meta.dir, "..");
 const enabled = process.env.SIGNET_NATIVE_EMBEDDING_SMOKE === "1";
 const tempDirs: string[] = [];
 const children: ChildProcessWithoutNullStreams[] = [];
+
+/** Resolve the compiled native binary to smoke-test.
+ *  Honors an explicit SIGNET_NATIVE_SMOKE_BINARY override (release CI builds to
+ *  dist/native/$RELEASE_ASSET); otherwise derives the asset name for the current
+ *  platform so one test covers every release leg. */
+function nativeSmokeBinary(): string {
+	const override = process.env.SIGNET_NATIVE_SMOKE_BINARY;
+	if (override) return override;
+	const key = `${process.platform}-${process.arch}`;
+	const name = `signet-${key}`;
+	return join(root, "dist", "native", key.startsWith("win32-") ? `${name}.exe` : name);
+}
 
 function tempDir(): string {
 	const path = mkdtempSync(join(tmpdir(), "signet-native-embedding-smoke-"));
@@ -68,11 +80,12 @@ describe("compiled native embedding runtime", () => {
 	const smoke = enabled ? test : test.skip;
 
 	smoke(
-		"embeds and recalls a fixed sentence through the compiled Linux binary",
+		"embeds and recalls a fixed sentence through the compiled native binary",
 		async () => {
-			if (process.platform !== "linux" || process.arch !== "x64") return;
-
-			const binary = join(root, "dist", "native", "signet-linux-x64");
+			const binary = nativeSmokeBinary();
+			if (!existsSync(binary)) {
+				throw new Error(`native binary not found at ${binary}; build it first (bun run build:native-bun)`);
+			}
 			const workspace = tempDir();
 			writeFileSync(
 				join(workspace, "agent.yaml"),


### PR DESCRIPTION
## Summary

- register the exact `onnxruntime-web/wasm` runtime before evaluating the Transformers.js web bundle in Bun-compiled executables
- patch only the generated Transformers.js build copy so its custom runtime supports/defaults to WASM under Bun's Node-like environment
- embed the matching `ort-wasm-simd-threaded.mjs` + `.wasm` pair from the pinned ONNX Runtime Web package
- preserve runtime source, backend, cache/model path, WASM path, and the original causal error in native-provider diagnostics
- add a fail-closed compiled-binary smoke that performs a real embed, verifies a finite 768-dimensional stored vector, and recalls the sentence

## Root cause

Bun compilation evaluates the Transformers.js web bundle in a Node-like environment. The bundle selected its native branch, but the compiled runtime did not expose a usable native `InferenceSession`, producing `undefined is not an object (evaluating 'InferenceSession5.create')`.

Registering ONNX Runtime Web alone exposed two additional package-contract requirements:

1. Transformers.js 3.8.1 does not populate supported/default devices for a custom global runtime.
2. The selected WASM entry dynamically imports a matching `.mjs` loader beside its `.wasm` payload; the release previously embedded only a mismatched JSEP WASM file.

The build now resolves all ONNX files from Transformers.js's own pinned dependency graph and uses guarded source anchors so dependency upgrades fail loudly instead of silently emitting a broken executable.

## Validation

- `bun run build:native-bun` — compiled `dist/native/signet-linux-x64`
- `SIGNET_NATIVE_EMBEDDING_SMOKE=1 bun test platform/daemon/src/native-embedding.test.ts platform/daemon/src/native-runtime-assets.test.ts scripts/native-embedding-runtime-smoke.test.ts` — 14 passed, 52 assertions
  - real model initialization through the compiled binary
  - `embedded:true`
  - stored vector dimensions = 768
  - every vector value finite
  - recall returns the stored sentence
- `bun test platform/daemon/src/embedding-fetch.test.ts platform/daemon/src/embedding-health.test.ts` — 15 passed, 36 assertions
- `bunx biome check platform/daemon/src/native-embedding.ts platform/daemon/src/native-embedding.test.ts scripts/build-native-bun.ts scripts/native-embedding-runtime-smoke.test.ts` — clean
- `git diff --check` — clean

## Checklist

- [x] Read and understood `AGENT.md`
- [x] Relevant tests pass locally
- [x] Formatter/linter passes for changed files
- [x] No generated binaries or build directories included
- [x] No secrets or unrelated changes included
- [x] Tested the compiled Linux x64 executable, not only mocked imports

Fixes #898
