### PR TITLE
fix: gate summary jobs on runnable synthesis

### DIFF
--- a/platform/daemon-rs/crates/signet-core/src/config.rs
+++ b/platform/daemon-rs/crates/signet-core/src/config.rs
@@ -787,6 +787,20 @@ memory:
 
         assert_eq!(pipeline.synthesis.provider, "none");
         assert!(!pipeline.synthesis.enabled);
+        assert!(!pipeline.summary_workload_enabled());
+    }
+
+    #[test]
+    fn summary_workload_requires_enabled_non_none_provider() {
+        let mut pipeline = PipelineV2Config::default();
+        assert!(pipeline.summary_workload_enabled());
+
+        pipeline.synthesis.enabled = false;
+        assert!(!pipeline.summary_workload_enabled());
+
+        pipeline.synthesis.enabled = true;
+        pipeline.synthesis.provider = "NONE".to_string();
+        assert!(!pipeline.summary_workload_enabled());
     }
 
     #[test]
@@ -1413,6 +1427,12 @@ pub struct PipelineV2Config {
     /// round-tripping them so older documented manifests do not fall back.
     pub predictor_pipeline: PredictorPipelineConfig,
     pub model_registry: ModelRegistryConfig,
+}
+
+impl PipelineV2Config {
+    pub fn summary_workload_enabled(&self) -> bool {
+        self.synthesis.enabled && !self.synthesis.provider.eq_ignore_ascii_case("none")
+    }
 }
 
 impl Default for PipelineV2Config {

--- a/platform/daemon-rs/crates/signet-daemon/src/main.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/main.rs
@@ -1653,10 +1653,9 @@ pub(crate) async fn start_summary_worker(state: &AppState) -> bool {
     if (!pipeline.enabled && !pipeline.shadow_mode) || pipeline.paused || state.pipeline_paused() {
         return false;
     }
-    // Summary worker gates only on pipeline being active — session-end always
-    // enqueues summary jobs and they must be consumed to write canonical
-    // --summary.md artifacts. When no explicit provider is configured,
-    // from_config falls back to Ollama so jobs are never stranded.
+    if !pipeline.summary_workload_enabled() {
+        return false;
+    }
 
     let provider =
         signet_pipeline::provider::from_config(&signet_pipeline::provider::LlmProviderConfig {

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -60,6 +60,7 @@ import { resolveEmbeddedWorkerPath } from "./native-runtime-assets";
 import {
 	DEFAULT_RETENTION,
 	ensureRetentionWorker,
+	ensureSummaryRecovery,
 	ensureSummaryWorker,
 	setDreamingWorker,
 	startPipeline,
@@ -1347,7 +1348,7 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 	const routerStatus = await router.status(false);
 	const statusValue = routerStatus.ok ? routerStatus.value : null;
 	const explicitInference = statusValue?.source === "explicit";
-	const commandExtractionMode = memoryCfg.pipelineV2.extraction.provider === "command";
+	const commandExtractionMode = memoryCfg.pipelineV2.enabled && memoryCfg.pipelineV2.extraction.provider === "command";
 	const extractionWorkloadConfigured =
 		!pipelinePaused && (commandExtractionMode || (await router.hasWorkload("memory_extraction")));
 	const synthesisWorkloadConfigured = !pipelinePaused && (await router.hasWorkload("session_synthesis"));
@@ -1434,9 +1435,29 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 	});
 
 	// Summary worker — shared infrastructure, owned here not by startPipeline.
-	// Both pipelineV2 and dreaming consume session summaries.
-	if ((memoryCfg.pipelineV2.enabled || memoryCfg.dreaming.enabled) && !pipelinePaused) {
-		ensureSummaryWorker(getDbAccessor());
+	// Both pipelineV2 and dreaming consume session summaries. Command-mode
+	// extraction also checkpoints through summary_jobs and remains runnable
+	// without synthesis; all other queued work requires an effective route.
+	const isSummarySynthesisAvailable = async (): Promise<boolean> =>
+		(await router.explain({ agentId: defaultAgentId, operation: "session_synthesis" }, true)).ok;
+	const hasSummaryConsumers = memoryCfg.pipelineV2.enabled || memoryCfg.dreaming.enabled;
+	const summarySynthesisAvailable = hasSummaryConsumers ? await isSummarySynthesisAvailable() : false;
+	if (hasSummaryConsumers && !pipelinePaused && (commandExtractionMode || summarySynthesisAvailable)) {
+		ensureSummaryWorker(getDbAccessor(), {
+			isSynthesisAvailable: isSummarySynthesisAvailable,
+		});
+	} else if (hasSummaryConsumers) {
+		ensureSummaryRecovery(getDbAccessor(), {
+			workerOptions: { isSynthesisAvailable: isSummarySynthesisAvailable },
+			shouldStartWorker: async () => {
+				const liveCfg = loadMemoryConfig(AGENTS_DIR);
+				if ((!liveCfg.pipelineV2.enabled && !liveCfg.dreaming.enabled) || liveCfg.pipelineV2.paused) return false;
+				return (
+					(liveCfg.pipelineV2.enabled && liveCfg.pipelineV2.extraction.provider === "command") ||
+					(await isSummarySynthesisAvailable())
+				);
+			},
+		});
 	}
 
 	if (memoryCfg.pipelineV2.enabled && !pipelinePaused && extractionAvailable) {

--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -3572,7 +3572,7 @@ describe("summary worker tick gate", () => {
 			const jobId = enq.jobId;
 
 			const { startSummaryWorker } = await import("./pipeline/summary-worker");
-			const handle = startSummaryWorker(getDbAccessor());
+			const handle = startSummaryWorker(getDbAccessor(), { isSynthesisAvailable: async () => true });
 
 			// First tick fires after POLL_INTERVAL_MS (5s)
 			await new Promise((resolve) => setTimeout(resolve, 5500));
@@ -3588,6 +3588,216 @@ describe("summary worker tick gate", () => {
 			// Gate allowed tick through → job was leased → attempts incremented.
 			// Without LLM the processing will fail, but that doesn't matter.
 			expect(job?.attempts).toBeGreaterThan(0);
+		},
+		15_000,
+	);
+
+	test.serial(
+		"leaves jobs unchanged when direct worker startup has no route check",
+		async () => {
+			writeAgentYaml(`memory:
+  pipelineV2:
+    enabled: false
+  dreaming:
+    enabled: true
+`);
+			createMemoryDb([]);
+			const enq = handleCheckpointExtract({
+				harness: "test",
+				sessionKey: "ckpt-worker-no-route",
+				transcript: "x".repeat(600),
+			});
+			if (!enq.jobId) throw new Error("expected checkpoint enqueue to return a job id");
+
+			const { startSummaryWorker } = await import("./pipeline/summary-worker");
+			const handle = startSummaryWorker(getDbAccessor());
+			await new Promise((resolve) => setTimeout(resolve, 5500));
+			handle.stop();
+
+			const db = openTestDb();
+			const job = db.prepare("SELECT status, attempts FROM summary_jobs WHERE id = ?").get(enq.jobId) as {
+				status: string;
+				attempts: number;
+			};
+			db.close();
+			expect(job).toEqual({ status: "pending", attempts: 0 });
+		},
+		15_000,
+	);
+
+	test.serial(
+		"does not activate retained command config when pipeline V2 is disabled",
+		async () => {
+			const marker = join(TEST_DIR, "disabled-pipeline-command-ran");
+			writeAgentYaml(`memory:
+  pipelineV2:
+    enabled: false
+    allowRemoteProviders: true
+    extraction:
+      provider: command
+      command:
+        bin: node
+        args:
+          - -e
+          - "require('node:fs').writeFileSync('${marker}', 'unexpected')"
+    synthesis:
+      enabled: false
+      provider: none
+  dreaming:
+    enabled: true
+`);
+			createMemoryDb([]);
+			const enq = handleCheckpointExtract({
+				harness: "test",
+				sessionKey: "ckpt-worker-disabled-command",
+				transcript: "x".repeat(600),
+			});
+			if (!enq.jobId) throw new Error("expected checkpoint enqueue to return a job id");
+
+			const { startSummaryWorker } = await import("./pipeline/summary-worker");
+			const handle = startSummaryWorker(getDbAccessor(), { isSynthesisAvailable: async () => false });
+			try {
+				await new Promise((resolve) => setTimeout(resolve, 5500));
+			} finally {
+				handle.stop();
+			}
+
+			const db = openTestDb();
+			const job = db.prepare("SELECT status, attempts FROM summary_jobs WHERE id = ?").get(enq.jobId) as {
+				status: string;
+				attempts: number;
+			};
+			db.close();
+			expect(existsSync(marker)).toBe(false);
+			expect(job).toEqual({ status: "pending", attempts: 0 });
+		},
+		15_000,
+	);
+
+	test.serial(
+		"uses synthesis instead of retained command config when pipeline V2 is disabled",
+		async () => {
+			const marker = join(TEST_DIR, "disabled-pipeline-available-command-ran");
+			writeAgentYaml(`memory:
+  pipelineV2:
+    enabled: false
+    allowRemoteProviders: true
+    extraction:
+      provider: command
+      command:
+        bin: node
+        args:
+          - -e
+          - "require('node:fs').writeFileSync('${marker}', 'unexpected')"
+  dreaming:
+    enabled: true
+`);
+			createMemoryDb([]);
+			const schemaDb = openTestDb();
+			schemaDb.exec("ALTER TABLE summary_jobs ADD COLUMN error TEXT");
+			schemaDb.close();
+			const enq = handleCheckpointExtract({
+				harness: "test",
+				sessionKey: "ckpt-worker-disabled-command-with-synthesis",
+				transcript: "x".repeat(600),
+			});
+			if (!enq.jobId) throw new Error("expected checkpoint enqueue to return a job id");
+
+			let resolverCalls = 0;
+			let generateCalls = 0;
+			const { initInferenceProviderResolver, closeInferenceProviderResolver } = await import("./llm");
+			initInferenceProviderResolver(() => {
+				resolverCalls += 1;
+				return {
+					name: "test-synthesis",
+					async available() {
+						return true;
+					},
+					async generate() {
+						generateCalls += 1;
+						throw new Error("expected synthesis attempt");
+					},
+				};
+			});
+			const { startSummaryWorker } = await import("./pipeline/summary-worker");
+			const handle = startSummaryWorker(getDbAccessor(), { isSynthesisAvailable: async () => true });
+			try {
+				await new Promise((resolve) => setTimeout(resolve, 5500));
+			} finally {
+				handle.stop();
+				closeInferenceProviderResolver();
+			}
+
+			const db = openTestDb();
+			const job = db.prepare("SELECT status, attempts FROM summary_jobs WHERE id = ?").get(enq.jobId) as {
+				status: string;
+				attempts: number;
+			};
+			db.close();
+			expect(existsSync(marker)).toBe(false);
+			expect(resolverCalls).toBe(1);
+			expect(generateCalls).toBe(1);
+			expect(job).toEqual({ status: "pending", attempts: 1 });
+		},
+		15_000,
+	);
+
+	test.serial(
+		"completes command-only extraction without resolving synthesis",
+		async () => {
+			const marker = join(TEST_DIR, "command-only-ran");
+			writeAgentYaml(`memory:
+  pipelineV2:
+    enabled: true
+    allowRemoteProviders: true
+    significance:
+      enabled: false
+    extraction:
+      provider: command
+      command:
+        bin: node
+        args:
+          - -e
+          - "require('node:fs').writeFileSync('${marker}', 'ok')"
+    synthesis:
+      enabled: false
+      provider: none
+`);
+			createMemoryDb([]);
+			const schemaDb = openTestDb();
+			schemaDb.exec("ALTER TABLE summary_jobs ADD COLUMN result TEXT");
+			schemaDb.close();
+			const enq = handleCheckpointExtract({
+				harness: "test",
+				sessionKey: "ckpt-worker-command-only",
+				transcript: "x".repeat(600),
+			});
+			if (!enq.jobId) throw new Error("expected checkpoint enqueue to return a job id");
+
+			let resolverCalls = 0;
+			const { initInferenceProviderResolver, closeInferenceProviderResolver } = await import("./llm");
+			initInferenceProviderResolver(() => {
+				resolverCalls += 1;
+				throw new Error("synthesis resolver must not be called");
+			});
+			const { startSummaryWorker } = await import("./pipeline/summary-worker");
+			const handle = startSummaryWorker(getDbAccessor(), { isSynthesisAvailable: async () => false });
+			try {
+				await new Promise((resolve) => setTimeout(resolve, 5500));
+			} finally {
+				handle.stop();
+				closeInferenceProviderResolver();
+			}
+
+			const db = openTestDb();
+			const job = db.prepare("SELECT status, attempts FROM summary_jobs WHERE id = ?").get(enq.jobId) as {
+				status: string;
+				attempts: number;
+			};
+			db.close();
+			expect(existsSync(marker)).toBe(true);
+			expect(resolverCalls).toBe(0);
+			expect(job).toEqual({ status: "completed", attempts: 1 });
 		},
 		15_000,
 	);
@@ -3808,10 +4018,12 @@ describe("queryAnchorsMissingFromRecall", () => {
 	});
 });
 
-
 test.serial("session-end queues stored transcript and content-hash summary job", async () => {
 	createMemoryDb([]);
-	const transcript = "User: session end should store transcript and queue summary job.\nAssistant: summary queue should receive session_end trigger.\n".repeat(8);
+	const transcript =
+		"User: session end should store transcript and queue summary job.\nAssistant: summary queue should receive session_end trigger.\n".repeat(
+			8,
+		);
 
 	const result = await handleSessionEnd({
 		harness: "test",
@@ -3842,7 +4054,10 @@ test.serial("session-end queues stored transcript and content-hash summary job",
 
 test.serial("session-end skips duplicate summary job for identical content hash", async () => {
 	createMemoryDb([]);
-	const transcript = "User: identical transcript should dedupe summary queue.\nAssistant: same content should not queue twice.\n".repeat(8);
+	const transcript =
+		"User: identical transcript should dedupe summary queue.\nAssistant: same content should not queue twice.\n".repeat(
+			8,
+		);
 	const req = {
 		harness: "test",
 		transcript,
@@ -3859,10 +4074,9 @@ test.serial("session-end skips duplicate summary job for identical content hash"
 	expect(second.queued).toBe(false);
 	const db = openTestDb();
 	try {
-		const row = db.prepare("SELECT COUNT(*) count FROM summary_jobs WHERE session_key = ? AND agent_id = ?").get(
-			"sess-dedupe-hash",
-			"noam",
-		) as { count: number };
+		const row = db
+			.prepare("SELECT COUNT(*) count FROM summary_jobs WHERE session_key = ? AND agent_id = ?")
+			.get("sess-dedupe-hash", "noam") as { count: number };
 		expect(row.count).toBe(1);
 	} finally {
 		db.close();
@@ -4028,7 +4242,6 @@ describe("applyTokenBudget", () => {
 		}
 	});
 });
-
 
 afterAll(() => {
 	if (PREV_SIGNET_AGENT_ID_FOR_HOOKS === undefined) {

--- a/platform/daemon/src/pipeline/index.test.ts
+++ b/platform/daemon/src/pipeline/index.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { promoteSummaryWorkerIfAvailable } from "./index";
+
+describe("promoteSummaryWorkerIfAvailable", () => {
+	it("does not promote when shutdown occurs during the availability check", async () => {
+		let resolveAvailability: ((available: boolean) => void) | undefined;
+		const availability = new Promise<boolean>((resolve) => {
+			resolveAvailability = resolve;
+		});
+		let stopped = false;
+		let promotions = 0;
+
+		const pending = promoteSummaryWorkerIfAvailable(
+			() => availability,
+			() => stopped,
+			() => {
+				promotions += 1;
+			},
+		);
+		stopped = true;
+		resolveAvailability?.(true);
+
+		expect(await pending).toBe(false);
+		expect(promotions).toBe(0);
+	});
+
+	it("promotes once when availability succeeds and recovery is active", async () => {
+		let promotions = 0;
+		const promoted = await promoteSummaryWorkerIfAvailable(
+			async () => true,
+			() => false,
+			() => {
+				promotions += 1;
+			},
+		);
+
+		expect(promoted).toBe(true);
+		expect(promotions).toBe(1);
+	});
+});

--- a/platform/daemon/src/pipeline/index.ts
+++ b/platform/daemon/src/pipeline/index.ts
@@ -27,7 +27,12 @@ import {
 } from "./retention-worker";
 import { type StructuralClassifyHandle, startStructuralClassifyWorker } from "./structural-classify";
 import { type StructuralDependencyHandle, startStructuralDependencyWorker } from "./structural-dependency";
-import { type SummaryWorkerHandle, startSummaryWorker } from "./summary-worker";
+import {
+	type SummaryWorkerHandle,
+	type SummaryWorkerOptions,
+	startSummaryRecovery,
+	startSummaryWorker,
+} from "./summary-worker";
 import { type SynthesisWorkerHandle, startSynthesisWorker } from "./synthesis-worker";
 import { type WorkerHandle, type WorkerProgressStats, type WorkerStats, startWorker } from "./worker";
 
@@ -68,10 +73,53 @@ export function setDreamingWorker(handle: DreamingWorkerHandle | null): void {
 
 /** Start the summary worker if not already running (used when dreaming
  *  is enabled but pipelineV2 is disabled — dreaming needs summaries). */
-export function ensureSummaryWorker(accessor: DbAccessor): void {
+export function ensureSummaryWorker(accessor: DbAccessor, options: SummaryWorkerOptions = {}): void {
 	if (!summaryWorkerHandle) {
-		summaryWorkerHandle = startSummaryWorker(accessor);
+		summaryRecoveryStop?.();
+		summaryRecoveryStop = null;
+		summaryWorkerHandle = startSummaryWorker(accessor, options);
 	}
+}
+
+/** Recover stale summary leases without starting the polling worker. */
+export function ensureSummaryRecovery(
+	accessor: DbAccessor,
+	options: {
+		readonly workerOptions?: SummaryWorkerOptions;
+		readonly shouldStartWorker?: () => Promise<boolean>;
+	} = {},
+): void {
+	if (summaryWorkerHandle || summaryRecoveryStop) return;
+
+	const stopRecovery = startSummaryRecovery(accessor);
+	let stopped = false;
+	let monitorTimer: ReturnType<typeof setTimeout> | null = null;
+	const stop = (): void => {
+		stopped = true;
+		stopRecovery();
+		if (monitorTimer) clearTimeout(monitorTimer);
+	};
+	summaryRecoveryStop = stop;
+
+	const shouldStartWorker = options.shouldStartWorker;
+	if (!shouldStartWorker) return;
+	const monitor = async (): Promise<void> => {
+		if (stopped) return;
+		try {
+			const promoted = await promoteSummaryWorkerIfAvailable(
+				shouldStartWorker,
+				() => stopped,
+				() => ensureSummaryWorker(accessor, options.workerOptions),
+			);
+			if (promoted || stopped) return;
+		} catch (error) {
+			logger.warn("pipeline", "Summary workload monitor failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+		if (!stopped) monitorTimer = setTimeout(() => void monitor(), 5_000);
+	};
+	monitorTimer = setTimeout(() => void monitor(), 5_000);
 }
 
 // ---------------------------------------------------------------------------
@@ -83,6 +131,22 @@ let retentionHandle: RetentionHandle | null = null;
 let maintenanceHandle: MaintenanceHandle | null = null;
 let documentWorkerHandle: DocumentWorkerHandle | null = null;
 let summaryWorkerHandle: SummaryWorkerHandle | null = null;
+let summaryRecoveryStop: (() => void) | null = null;
+
+/**
+ * Promote recovery-only mode after an asynchronous availability check, unless
+ * shutdown occurred while the check was in flight.
+ */
+export async function promoteSummaryWorkerIfAvailable(
+	shouldStartWorker: () => Promise<boolean>,
+	isStopped: () => boolean,
+	promote: () => void,
+): Promise<boolean> {
+	const shouldStart = await shouldStartWorker();
+	if (isStopped() || !shouldStart) return false;
+	promote();
+	return true;
+}
 let synthesisWorkerHandle: SynthesisWorkerHandle | null = null;
 let structuralClassifyHandle: StructuralClassifyHandle | null = null;
 let structuralDependencyHandle: StructuralDependencyHandle | null = null;
@@ -329,6 +393,10 @@ export async function stopPipeline(): Promise<void> {
 	if (summaryWorkerHandle) {
 		summaryWorkerHandle.stop();
 		summaryWorkerHandle = null;
+	}
+	if (summaryRecoveryStop) {
+		summaryRecoveryStop();
+		summaryRecoveryStop = null;
 	}
 	if (documentWorkerHandle) {
 		await documentWorkerHandle.stop();

--- a/platform/daemon/src/pipeline/summary-worker.test.ts
+++ b/platform/daemon/src/pipeline/summary-worker.test.ts
@@ -11,11 +11,13 @@ import { RateLimitExceededError } from "./provider";
 import {
 	SUMMARY_WORKER_UPDATED_BY,
 	type SummaryWorkerHandle,
+	canProcessSummaryJobs,
 	clearCommandStageRunning,
 	getCommandStageStatus,
 	hasCommandStageCompleted,
 	insertSummaryFacts,
 	isTerminalSummaryJobError,
+	leaseSummaryJobWhenAvailable,
 	markCommandStageCompleted,
 	markCommandStageRunning,
 	recoverSummaryJobs,
@@ -23,8 +25,25 @@ import {
 	resolveSummaryHeadingDate,
 	runSummaryCommandProvider,
 	shouldRunSignificanceGateForJob,
+	startSummaryRecovery,
 	startSummaryWorker,
 } from "./summary-worker";
+
+describe("canProcessSummaryJobs", () => {
+	it("preserves command extraction when synthesis is unavailable", () => {
+		expect(canProcessSummaryJobs(true, false)).toBe(true);
+	});
+
+	it("requires synthesis for non-command summary work", () => {
+		expect(canProcessSummaryJobs(false, true)).toBe(true);
+		expect(canProcessSummaryJobs(false, false)).toBe(false);
+	});
+
+	it("does not let command extraction bypass a pipeline pause", () => {
+		expect(canProcessSummaryJobs(true, false, true)).toBe(false);
+		expect(canProcessSummaryJobs(true, true, true)).toBe(false);
+	});
+});
 
 function makeAccessor(db: Database): DbAccessor {
 	return {
@@ -321,6 +340,98 @@ describe("insertSummaryFacts", () => {
 	});
 });
 
+describe("leaseSummaryJobWhenAvailable", () => {
+	let db: Database;
+	let accessor: DbAccessor;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		accessor = makeAccessor(db);
+		db.prepare(
+			`INSERT INTO summary_jobs
+			 (id, session_key, session_id, harness, project, agent_id, transcript,
+			  trigger, status, attempts, max_attempts, created_at)
+			 VALUES ('job-gated', 'session-gated', 'session-gated', 'hermes', NULL,
+			         'default', 'User: hello', 'session_end', 'pending', 0, 3, ?)`,
+		).run(new Date().toISOString());
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("leaves pending jobs unchanged when synthesis is unavailable", async () => {
+		const job = await leaseSummaryJobWhenAvailable(accessor, async () => false);
+
+		expect(job).toBeNull();
+		const row = db.prepare("SELECT status, attempts FROM summary_jobs WHERE id = 'job-gated'").get() as {
+			status: string;
+			attempts: number;
+		};
+		expect(row).toEqual({ status: "pending", attempts: 0 });
+	});
+
+	it("restores an unchanged pending job when synthesis becomes unavailable after lease", async () => {
+		let checks = 0;
+		const job = await leaseSummaryJobWhenAvailable(accessor, async () => {
+			checks += 1;
+			return checks === 1;
+		});
+
+		expect(job).toBeNull();
+		expect(checks).toBe(2);
+		const row = db.prepare("SELECT status, attempts FROM summary_jobs WHERE id = 'job-gated'").get() as {
+			status: string;
+			attempts: number;
+		};
+		expect(row).toEqual({ status: "pending", attempts: 0 });
+	});
+
+	it("restores an unchanged pending job when the post-lease availability check errors", async () => {
+		let checks = 0;
+		await expect(
+			leaseSummaryJobWhenAvailable(accessor, async () => {
+				checks += 1;
+				if (checks === 2) throw new Error("routing refresh failed");
+				return true;
+			}),
+		).rejects.toThrow("routing refresh failed");
+
+		const row = db.prepare("SELECT status, attempts FROM summary_jobs WHERE id = 'job-gated'").get() as {
+			status: string;
+			attempts: number;
+		};
+		expect(row).toEqual({ status: "pending", attempts: 0 });
+	});
+
+	it("surfaces a failed lease restoration instead of silently stranding work", async () => {
+		let checks = 0;
+		await expect(
+			leaseSummaryJobWhenAvailable(accessor, async () => {
+				checks += 1;
+				if (checks === 2) {
+					db.prepare("UPDATE summary_jobs SET status = 'dead' WHERE id = 'job-gated'").run();
+					return false;
+				}
+				return true;
+			}),
+		).rejects.toThrow("Failed to restore unprocessed summary lease for job job-gated");
+	});
+
+	it("leases a pending job only while synthesis remains available", async () => {
+		const job = await leaseSummaryJobWhenAvailable(accessor, async () => true);
+
+		expect(job?.id).toBe("job-gated");
+		expect(job?.attempts).toBe(1);
+		const row = db.prepare("SELECT status, attempts FROM summary_jobs WHERE id = 'job-gated'").get() as {
+			status: string;
+			attempts: number;
+		};
+		expect(row).toEqual({ status: "processing", attempts: 1 });
+	});
+});
+
 describe("recoverSummaryJobs", () => {
 	let db: Database;
 	let accessor: DbAccessor;
@@ -437,6 +548,27 @@ describe("recoverSummaryJobs", () => {
 
 		const after = db.prepare("SELECT status FROM summary_jobs WHERE id = 'job-startup'").get() as { status: string };
 		expect(after.status).toBe("pending");
+	});
+
+	it("recovers stale leases without leasing pending work", async () => {
+		const now = new Date().toISOString();
+		const stmt = db.prepare(
+			`INSERT INTO summary_jobs
+			 (id, session_key, harness, project, transcript, status, attempts, max_attempts, created_at)
+			 VALUES (?, NULL, 'codex', NULL, 'transcript', ?, ?, 3, ?)`,
+		);
+		stmt.run("job-stale", "leased", 1, now);
+		stmt.run("job-pending", "pending", 0, now);
+
+		const stopRecovery = startSummaryRecovery(accessor);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		stopRecovery();
+
+		const rows = db.prepare("SELECT id, status, attempts FROM summary_jobs ORDER BY id").all();
+		expect(rows).toEqual([
+			{ id: "job-pending", status: "pending", attempts: 0 },
+			{ id: "job-stale", status: "pending", attempts: 1 },
+		]);
 	});
 });
 

--- a/platform/daemon/src/pipeline/summary-worker.ts
+++ b/platform/daemon/src/pipeline/summary-worker.ts
@@ -23,7 +23,7 @@ import { countChanges } from "../db-helpers";
 import { getInferenceProvider } from "../llm";
 import { logger } from "../logger";
 import { inferType, isDuplicate } from "../memory-classification";
-import { loadMemoryConfig, type ResolvedMemoryConfig } from "../memory-config";
+import { type ResolvedMemoryConfig, loadMemoryConfig } from "../memory-config";
 import {
 	IMMUTABLE_ARTIFACT_ERROR_PREFIX,
 	ensureCanonicalManifest,
@@ -47,6 +47,19 @@ import { countTokens } from "./tokenizer";
 export interface SummaryWorkerHandle {
 	stop(): void;
 	readonly running: boolean;
+}
+
+export interface SummaryWorkerOptions {
+	/** Must perform a live route check. Omitted means synthesis is unavailable. */
+	readonly isSynthesisAvailable?: () => Promise<boolean>;
+}
+
+export function canProcessSummaryJobs(
+	commandExtractionMode: boolean,
+	synthesisAvailable: boolean,
+	paused = false,
+): boolean {
+	return !paused && (commandExtractionMode || synthesisAvailable);
 }
 
 const RECOVER_BATCH = 100;
@@ -346,11 +359,7 @@ function parseLlmResponse(raw: string): LlmSummaryResult | null {
 // Core processing
 // ---------------------------------------------------------------------------
 
-function passesSignificanceGate(
-	accessor: DbAccessor,
-	job: SummaryJobRow,
-	memoryCfg: ResolvedMemoryConfig,
-): boolean {
+function passesSignificanceGate(accessor: DbAccessor, job: SummaryJobRow, memoryCfg: ResolvedMemoryConfig): boolean {
 	const significanceCfg: SignificanceConfig = memoryCfg.pipelineV2.significance ?? {
 		enabled: true,
 		minTurns: 5,
@@ -384,10 +393,7 @@ function substituteCommandTokens(input: string, replacements: Record<string, str
 	return output;
 }
 
-export async function runSummaryCommandProvider(
-	job: SummaryJobRow,
-	cfg: ResolvedMemoryConfig,
-): Promise<void> {
+export async function runSummaryCommandProvider(job: SummaryJobRow, cfg: ResolvedMemoryConfig): Promise<void> {
 	const command = cfg.pipelineV2.extraction.command;
 	if (!command) {
 		throw new Error("pipelineV2.extraction.command is required when extraction.provider is 'command'");
@@ -597,7 +603,7 @@ async function processJob(
 	job: SummaryJobRow,
 	memoryCfg: ResolvedMemoryConfig,
 ): Promise<void> {
-	const commandMode = memoryCfg.pipelineV2.extraction.provider === "command";
+	const commandMode = memoryCfg.pipelineV2.enabled && memoryCfg.pipelineV2.extraction.provider === "command";
 	const commandStageStatus: CommandStageStatus = commandMode ? getCommandStageStatus(accessor, job.id) : "none";
 
 	if (
@@ -652,6 +658,7 @@ async function processJob(
 	const genOpts = {
 		timeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
 		maxTokens: memoryCfg.pipelineV2.synthesis.maxTokens,
+		refresh: true,
 	};
 	const result =
 		job.transcript.length > CHUNK_TARGET_CHARS
@@ -1434,10 +1441,117 @@ export function recoverSummaryJobs(accessor: DbAccessor, limit: number = RECOVER
 	return result;
 }
 
-export function startSummaryWorker(accessor: DbAccessor): SummaryWorkerHandle {
+export async function leaseSummaryJobWhenAvailable(
+	accessor: DbAccessor,
+	isWorkloadAvailable: () => Promise<boolean>,
+): Promise<SummaryJobRow | null> {
+	if (!(await isWorkloadAvailable())) return null;
+
+	const job = accessor.withWriteTx((db) => {
+		let row: SummaryJobRow | undefined;
+		try {
+			row = db
+				.prepare(
+					`SELECT id, session_key, session_id, harness, project, transcript,
+					        agent_id, trigger, captured_at, started_at, ended_at,
+					        attempts, max_attempts, created_at
+					 FROM summary_jobs
+					 WHERE status = 'pending' AND attempts < max_attempts
+					 ORDER BY created_at ASC
+					 LIMIT 1`,
+				)
+				.get() as SummaryJobRow | undefined;
+		} catch {
+			row = db
+				.prepare(
+					`SELECT id, session_key, session_key AS session_id, harness, project, transcript,
+					        'default' AS agent_id, 'session_end' AS trigger,
+					        created_at AS captured_at, NULL AS started_at, completed_at AS ended_at,
+					        attempts, max_attempts, created_at
+					 FROM summary_jobs
+					 WHERE status = 'pending' AND attempts < max_attempts
+					 ORDER BY created_at ASC
+					 LIMIT 1`,
+				)
+				.get() as SummaryJobRow | undefined;
+		}
+
+		if (!row) return null;
+
+		const updated = countChanges(
+			db
+				.prepare(
+					`UPDATE summary_jobs
+					 SET status = 'processing', attempts = attempts + 1
+					 WHERE id = ? AND status = 'pending' AND attempts = ?`,
+				)
+				.run(row.id, row.attempts),
+		);
+		return updated === 1 ? { ...row, attempts: row.attempts + 1 } : null;
+	});
+
+	if (!job) return null;
+
+	try {
+		if (await isWorkloadAvailable()) return job;
+	} catch (error) {
+		restoreUnprocessedSummaryLease(accessor, job);
+		throw error;
+	}
+
+	restoreUnprocessedSummaryLease(accessor, job);
+	return null;
+}
+
+function restoreUnprocessedSummaryLease(accessor: DbAccessor, job: SummaryJobRow): void {
+	const restored = accessor.withWriteTx((db) =>
+		countChanges(
+			db
+				.prepare(
+					`UPDATE summary_jobs
+					 SET status = 'pending', attempts = attempts - 1
+					 WHERE id = ? AND status = 'processing' AND attempts = ?`,
+				)
+				.run(job.id, job.attempts),
+		),
+	);
+	if (restored !== 1) {
+		throw new Error(`Failed to restore unprocessed summary lease for job ${job.id}`);
+	}
+}
+
+export function startSummaryRecovery(accessor: DbAccessor): () => void {
 	let timer: ReturnType<typeof setTimeout> | null = null;
-	let recoverTimer: ReturnType<typeof setTimeout> | null = null;
 	let stopped = false;
+
+	function schedule(delay: number): void {
+		if (stopped) return;
+		timer = setTimeout(() => {
+			try {
+				const batch = recoverSummaryJobs(accessor);
+				if (batch.updated > 0) {
+					logger.info("summary-worker", `Crash recovery: reset ${batch.updated} stuck job(s) to pending/dead`);
+				}
+				if (batch.selected >= RECOVER_BATCH) schedule(0);
+			} catch (e) {
+				logger.warn("summary-worker", "Crash recovery failed (non-fatal)", {
+					error: e instanceof Error ? e.message : String(e),
+				});
+			}
+		}, delay);
+	}
+
+	schedule(0);
+	return () => {
+		stopped = true;
+		if (timer) clearTimeout(timer);
+	};
+}
+
+export function startSummaryWorker(accessor: DbAccessor, options: SummaryWorkerOptions = {}): SummaryWorkerHandle {
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let stopped = false;
+	const stopRecovery = startSummaryRecovery(accessor);
 
 	let cachedProvider: LlmProvider | null = null;
 
@@ -1454,46 +1568,16 @@ export function startSummaryWorker(accessor: DbAccessor): SummaryWorkerHandle {
 		let jobId: string | null = null;
 
 		try {
-			// Lease a pending job
-			const job = accessor.withWriteTx((db) => {
-				let row: SummaryJobRow | undefined;
-				try {
-					row = db
-						.prepare(
-							`SELECT id, session_key, session_id, harness, project, transcript,
-							        agent_id, trigger, captured_at, started_at, ended_at,
-							        attempts, max_attempts, created_at
-							 FROM summary_jobs
-							 WHERE status = 'pending' AND attempts < max_attempts
-							 ORDER BY created_at ASC
-							 LIMIT 1`,
-						)
-						.get() as SummaryJobRow | undefined;
-				} catch {
-					row = db
-						.prepare(
-							`SELECT id, session_key, session_key AS session_id, harness, project, transcript,
-							        'default' AS agent_id, 'session_end' AS trigger,
-							        created_at AS captured_at, NULL AS started_at, completed_at AS ended_at,
-							        attempts, max_attempts, created_at
-							 FROM summary_jobs
-							 WHERE status = 'pending' AND attempts < max_attempts
-							 ORDER BY created_at ASC
-							 LIMIT 1`,
-						)
-						.get() as SummaryJobRow | undefined;
-				}
-
-				if (!row) return null;
-
-				db.prepare(
-					`UPDATE summary_jobs
-					 SET status = 'processing', attempts = attempts + 1
-					 WHERE id = ?`,
-				).run(row.id);
-
-				return { ...row, attempts: row.attempts + 1 };
-			});
+			const isSynthesisAvailable = options.isSynthesisAvailable ?? (async () => false);
+			const isWorkloadAvailable = async (): Promise<boolean> => {
+				const latest = loadMemoryConfig(AGENTS_DIR);
+				return canProcessSummaryJobs(
+					latest.pipelineV2.enabled && latest.pipelineV2.extraction.provider === "command",
+					await isSynthesisAvailable(),
+					latest.pipelineV2.paused,
+				);
+			};
+			const job = await leaseSummaryJobWhenAvailable(accessor, isWorkloadAvailable);
 
 			if (!job) {
 				scheduleTick(POLL_INTERVAL_MS);
@@ -1501,6 +1585,20 @@ export function startSummaryWorker(accessor: DbAccessor): SummaryWorkerHandle {
 			}
 
 			jobId = job.id;
+			const memoryCfg = loadMemoryConfig(AGENTS_DIR);
+			const commandMode = memoryCfg.pipelineV2.enabled && memoryCfg.pipelineV2.extraction.provider === "command";
+			let synthesisAvailable = false;
+			try {
+				synthesisAvailable = await isSynthesisAvailable();
+			} catch (error) {
+				if (!commandMode) restoreUnprocessedSummaryLease(accessor, job);
+				throw error;
+			}
+			if (!commandMode && !synthesisAvailable) {
+				restoreUnprocessedSummaryLease(accessor, job);
+				scheduleTick(POLL_INTERVAL_MS);
+				return;
+			}
 
 			logger.info("summary-worker", "Processing session summary", {
 				jobId: job.id,
@@ -1510,10 +1608,15 @@ export function startSummaryWorker(accessor: DbAccessor): SummaryWorkerHandle {
 				project: job.project,
 			});
 
-			if (!cachedProvider) {
-				cachedProvider = getInferenceProvider("sessionSynthesis");
+			// Command-only extraction must not resolve or call session synthesis.
+			if (synthesisAvailable && !cachedProvider) {
+				try {
+					cachedProvider = getInferenceProvider("sessionSynthesis");
+				} catch (error) {
+					if (!commandMode) throw error;
+				}
 			}
-			await processJob(accessor, cachedProvider, job, cfg);
+			await processJob(accessor, synthesisAvailable ? cachedProvider : null, job, memoryCfg);
 
 			// Mark complete
 			accessor.withWriteTx((db) => {
@@ -1577,29 +1680,6 @@ export function startSummaryWorker(accessor: DbAccessor): SummaryWorkerHandle {
 		}, delay);
 	}
 
-	function scheduleRecovery(delay: number): void {
-		if (stopped) return;
-		recoverTimer = setTimeout(() => {
-			try {
-				const batch = recoverSummaryJobs(accessor);
-				if (batch.updated > 0) {
-					logger.info("summary-worker", `Crash recovery: reset ${batch.updated} stuck job(s) to pending/dead`);
-				}
-				if (batch.selected >= RECOVER_BATCH) {
-					scheduleRecovery(0);
-				}
-			} catch (e) {
-				logger.warn("summary-worker", "Crash recovery failed (non-fatal)", {
-					error: e instanceof Error ? e.message : String(e),
-				});
-			}
-		}, delay);
-	}
-
-	// Crash recovery runs in small async batches so daemon startup and HTTP
-	// readiness are not blocked by large summary_jobs tables.
-	scheduleRecovery(0);
-
 	// Start polling
 	scheduleTick(POLL_INTERVAL_MS);
 
@@ -1607,7 +1687,7 @@ export function startSummaryWorker(accessor: DbAccessor): SummaryWorkerHandle {
 		stop() {
 			stopped = true;
 			if (timer) clearTimeout(timer);
-			if (recoverTimer) clearTimeout(recoverTimer);
+			stopRecovery();
 		},
 		get running() {
 			return !stopped;


### PR DESCRIPTION
1|## Summary
2|
3|Stops session-summary jobs from consuming retries when no effective synthesis workload exists, without stranding command-provider extraction or stale crash leases.
4|
5|TypeScript now gates each lease on a forced-refresh `session_synthesis` route check and rolls back the lease without consuming an attempt if availability changes across the lease transition. Rust no longer starts the summary worker when synthesis is disabled or configured as `none`.
6|
7|Closes #899
8|
9|## Changes
10|
11|- gate TypeScript summary-worker startup and each lease on the effective inference-router workload
12|- preserve active command-provider extraction, which shares `summary_jobs`, when synthesis is disabled
13|- require pipeline V2 to be enabled before retained command-provider configuration can bypass synthesis gating
14|- make TypeScript leasing compare-and-set safe and restore `pending` plus the original attempt count after a post-lease availability loss/error
15|- recover stale TypeScript `processing`/`leased` jobs independently when the polling worker is disabled
16|- monitor an unavailable startup route and promote recovery-only mode to polling when the workload becomes healthy
17|- gate Rust summary-worker startup on enabled, non-`none` synthesis instead of hidden Ollama fallback
18|- add regression coverage for disabled, disappearing, errored, command-mode, recovery-only, and available workloads
19|
20|## Type
21|
22|- [ ] `feat` — new user-facing feature (bumps minor)
23|- [x] `fix` — bug fix
24|- [ ] `refactor` — restructure without behavior change
25|- [ ] `chore` — build, deps, config, docs
26|- [ ] `perf` — performance improvement
27|- [ ] `test` — test coverage
28|
29|## Packages affected
30|
31|- [ ] `@signet/core`
32|- [x] `@signet/daemon`
33|- [ ] `@signet/cli` / dashboard
34|- [ ] `@signet/sdk`
35|- [ ] `@signet/connector-*`
36|- [ ] `@signet/web`
37|- [ ] `predictor`
38|- [x] Other: Rust `signet-core` and `signet-daemon`
39|
40|## Screenshots
41|
42|N/A. No UI changes.
43|
44|## PR Readiness (MANDATORY)
45|
46|- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
47|- [x] Agent scoping verified on all new/changed data queries
48|- [x] Input/config validation and bounds checks added
49|- [x] Error handling and fallback paths tested (no silent swallow)
50|- [x] Security checks applied to admin/mutation endpoints
51|- [x] Docs updated for API/spec/status changes
52|- [x] Regression tests added for each bug fix
53|- [ ] Lint/typecheck/tests pass locally
54|
55|The final readiness item remains unchecked while this PR is a draft: focused TypeScript/Rust tests, Biome, rustfmt, the daemon production build, Cargo check, and the Rust route-parity manifest generator pass. The route-parity test fails identically on current `origin/main` because `GET /api/repair/integrity-check` and `POST /api/repair/rebuild-indexes` are already marked missing; this PR does not change either route or the parity manifest. Broader daemon tests/typechecking also report unrelated baseline or environment failures; none are in the new regression cases.
56|
57|No API/spec/status contract changed, so no documentation update was required. No admin/mutation endpoint was added or changed.
58|
59|## Migration Notes (if applicable)
60|
61|- [ ] Migration is idempotent
62|- [x] Daemon Rust parity reviewed or explicitly N/A
63|- [x] Rollback / compatibility note included in PR description
64|
65|No schema migration. Rollback is a normal code revert. Pending jobs remain untouched while synthesis is disabled; stale in-flight jobs are recovered separately.
66|
67|## Testing
68|
69|- [ ] `bun test` passes
70|- [ ] `bun run typecheck` passes
71|- [x] `bun run lint` passes
72|- [ ] Tested against running daemon
73|- [ ] N/A
74|
75|Verified:
76|
77|- `bun test platform/daemon/src/pipeline/index.test.ts platform/daemon/src/pipeline/summary-worker.test.ts` — 37 pass
78|- `bun test platform/daemon/src/hooks.test.ts -t "summary worker tick gate"` — 5 pass
79|- daemon production `bun run build`
80|- `bunx biome check <changed TypeScript files>`
81|- `bun run check:rust-parity` — manifest generator passes (`328 routes`)
82|- `bun test scripts/check-rust-daemon-parity.test.ts` — baseline failure reproduced on `origin/main`: two existing missing repair routes
83|- `rustfmt --edition 2024 --check <changed Rust files>`
84|- `cargo test -p signet-core summary_workload -- --nocapture`
85|- `cargo check -p signet-daemon`
86|- broader daemon suite/typecheck — unrelated baseline or environment failures remain
87|
88|## AI disclosure
89|
90|- [ ] No AI tools were used in this PR
91|- [x] AI tools were used (see `Assisted-by` tags in commits)
92|
93|## Notes
94|
95|This PR fixes queue safety and worker startup in both daemon implementations. Broader canonical paused/blocked status rendering remains tracked separately by #908.
96|