### PR TITLE
fix(daemon): isolate native embedding in a worker so it cannot block /health

### DIFF
--- a/.github/workflows/embedding-health-isolation.yml
+++ b/.github/workflows/embedding-health-isolation.yml
@@ -1,0 +1,57 @@
+name: Embedding Health Isolation
+
+# Permanent CI invariant: the daemon's HTTP server (incl. /health) must stay
+# responsive regardless of native embedding state — init, model download, or
+# inference. The guard that would have caught the event-loop wedge fixed in
+# this change. Runs the worker-handle unit tests (bounded RPC, crash/exit
+# handling, sync status) and the end-to-end isolation test (real daemon over
+# HTTP, model fetch stalled at a local blackhole, /health SLA asserted).
+#
+# Mirrors rust-daemon-parity.yml (path-scoped pull_request + push-to-main).
+
+on:
+  pull_request:
+    paths:
+      - "platform/daemon/src/native-embedding*.ts"
+      - "platform/daemon/src/embedding-worker*.ts"
+      - "platform/daemon/src/embedding-fetch.ts"
+      - "platform/daemon/src/embedding-health.ts"
+      - "platform/daemon/src/routes/utils.ts"
+      - "platform/daemon/src/daemon.ts"
+      - "scripts/native-embedding-runtime-smoke.test.ts"
+      - "scripts/build-native-bun.ts"
+      - ".github/workflows/embedding-health-isolation.yml"
+  push:
+    branches: [main]
+    paths:
+      - "platform/daemon/src/native-embedding*.ts"
+      - "platform/daemon/src/embedding-worker*.ts"
+      - "platform/daemon/src/embedding-fetch.ts"
+      - "platform/daemon/src/embedding-health.ts"
+      - "platform/daemon/src/routes/utils.ts"
+      - "platform/daemon/src/daemon.ts"
+      - ".github/workflows/embedding-health-isolation.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  isolation:
+    name: Native embedding cannot block /health
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Worker-handle unit tests (RPC bounds, crash/exit, sync status)
+        working-directory: platform/daemon
+        run: bun test src/embedding-worker-handle.test.ts src/native-embedding.test.ts
+
+      - name: End-to-end /health SLA while embedding download is stalled
+        working-directory: platform/daemon
+        run: bun test src/native-embedding-eventloop-isolation.test.ts

--- a/.github/workflows/embedding-health-isolation.yml
+++ b/.github/workflows/embedding-health-isolation.yml
@@ -48,10 +48,13 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Worker-handle unit tests (RPC bounds, crash/exit, sync status)
+      - name: Build @signet/core (workspace dep the daemon imports)
+        run: bun run build:core
+      # Unit guard: proves the main-thread adapter never blocks while the
+      # embedding worker is stuck (the ★ non-blocking invariant), plus RPC
+      # bounds, crash/exit handling, and sync status. Needs only @signet/core.
+      # The end-to-end /health-SLA test (real daemon spawn) and the compiled-
+      # binary smoke run in release.yml, where the full workspace is built.
+      - name: Worker-handle unit + facade contract tests
         working-directory: platform/daemon
         run: bun test src/embedding-worker-handle.test.ts src/native-embedding.test.ts
-
-      - name: End-to-end /health SLA while embedding download is stalled
-        working-directory: platform/daemon
-        run: bun test src/native-embedding-eventloop-isolation.test.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,10 @@ jobs:
       - name: Build workspace dependencies
         run: bun run build
 
+      - name: Native embedding /health isolation (source daemon)
+        working-directory: platform/daemon
+        run: bun test src/native-embedding-eventloop-isolation.test.ts
+
       - name: Build dashboard assets
         run: bun run build:dashboard
 

--- a/platform/daemon/src/embedding-worker-handle.test.ts
+++ b/platform/daemon/src/embedding-worker-handle.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { WorkerOptions } from "node:worker_threads";
+import {
+	type EmbeddingWorkerFactory,
+	type EmbeddingWorkerLike,
+	createEmbeddingWorkerHandle,
+} from "./embedding-worker-handle";
+import type { EmbeddingWorkerInit, MainToWorkerMessage, WorkerToMainMessage } from "./embedding-worker-protocol";
+
+// Flush the microtask queue so an async RPC method (which posts its message
+// via a resolved-promise continuation) has actually written to worker.posted
+// before the test inspects it.
+const flush = (): Promise<void> => Bun.sleep(0);
+
+// ---------------------------------------------------------------------------
+// Fake worker that speaks the IPC protocol. The test drives it by calling
+// emit()/emitError()/emitExit() and inspects posted[] to respond. This lets
+// us exercise every adapter path — including a worker that *never*
+// responds (simulating a stuck model download) — deterministically, without
+// a real ONNX runtime or network.
+// ---------------------------------------------------------------------------
+
+interface FakeWorkerListeners {
+	message: Array<(msg: WorkerToMainMessage) => void>;
+	error: Array<(err: Error) => void>;
+	exit: Array<(code: number) => void>;
+}
+
+class FakeWorker implements EmbeddingWorkerLike {
+	readonly posted: MainToWorkerMessage[] = [];
+	private readonly listeners: FakeWorkerListeners = { message: [], error: [], exit: [] };
+	terminated = false;
+
+	on(event: "message" | "error" | "exit", listener: (...a: never[]) => void): this {
+		this.listeners[event].push(listener as never);
+		return this;
+	}
+
+	postMessage(msg: MainToWorkerMessage): void {
+		this.posted.push(msg);
+	}
+
+	terminate(): number {
+		this.terminated = true;
+		return 0;
+	}
+
+	emit(msg: WorkerToMainMessage): void {
+		for (const cb of this.listeners.message) cb(msg);
+	}
+
+	emitError(err: Error): void {
+		for (const cb of this.listeners.error) cb(err);
+	}
+
+	emitExit(code: number): void {
+		for (const cb of this.listeners.exit) cb(code);
+	}
+}
+
+function fakePair(): { worker: FakeWorker; factory: EmbeddingWorkerFactory } {
+	const worker = new FakeWorker();
+	const factory: EmbeddingWorkerFactory = (
+		_path: string,
+		_init: EmbeddingWorkerInit,
+		_options: WorkerOptions,
+	): EmbeddingWorkerLike => worker;
+	return { worker, factory };
+}
+
+const DIM = 768;
+const vec = (n = 1 / Math.sqrt(DIM)): number[] => Array<number>(DIM).fill(n);
+
+const handles: Array<{ stop: () => Promise<void> }> = [];
+
+async function makeHandle(worker: FakeWorker, factory: EmbeddingWorkerFactory, opts: Record<string, number> = {}) {
+	const handle = await createEmbeddingWorkerHandle({ workerFactory: factory, expectedDimensions: DIM, ...opts });
+	worker.emit({ type: "ready" }); // complete the ready handshake AFTER the listener is registered
+	handles.push(handle);
+	return handle;
+}
+
+afterEach(async () => {
+	for (const h of handles.splice(0)) {
+		try {
+			await h.stop();
+		} catch {
+			/* best-effort teardown */
+		}
+	}
+});
+
+function lastEmbedId(worker: FakeWorker): number {
+	const req = [...worker.posted].reverse().find((m) => m.type === "embed");
+	return req?.type === "embed" ? req.id : -1;
+}
+
+function lastCheckId(worker: FakeWorker): number {
+	const req = [...worker.posted].reverse().find((m) => m.type === "checkAvailable");
+	return req?.type === "checkAvailable" ? req.id : -1;
+}
+
+describe("embedding-worker-handle", () => {
+	it("embeds via RPC", async () => {
+		const { worker, factory } = fakePair();
+		const handle = await makeHandle(worker, factory);
+
+		const p = handle.embed("hello");
+		await flush();
+		expect(worker.posted.some((m) => m.type === "embed" && m.text === "hello")).toBe(true);
+
+		worker.emit({ type: "embed_result", id: lastEmbedId(worker), vector: vec() });
+		await expect(p).resolves.toHaveLength(DIM);
+	});
+
+	it("checkAvailable reports available when the worker inits", async () => {
+		const { worker, factory } = fakePair();
+		const handle = await makeHandle(worker, factory);
+
+		const p = handle.checkAvailable();
+		await flush();
+		worker.emit({ type: "status", status: { initialized: true, initializing: false, modelCached: true, error: null } });
+		worker.emit({ type: "check_result", id: lastCheckId(worker), available: true });
+
+		const status = await p;
+		expect(status.available).toBe(true);
+		expect(status.modelCached).toBe(true);
+	});
+
+	it("getStatus() is synchronous and reflects the latest worker status push — even while init is pending", async () => {
+		const { worker, factory } = fakePair();
+		const handle = await makeHandle(worker, factory);
+
+		void handle.checkAvailable().catch(() => {}); // init in flight; do NOT await
+		// getStatus must NOT await the RPC — it reads the push-driven cache.
+		expect(handle.getStatus().initialized).toBe(false);
+
+		worker.emit({
+			type: "status",
+			status: { initialized: false, initializing: true, modelCached: false, error: null },
+		});
+		expect(handle.getStatus().initializing).toBe(true);
+
+		worker.emit({ type: "status", status: { initialized: true, initializing: false, modelCached: true, error: null } });
+		expect(handle.getStatus().initialized).toBe(true);
+		expect(handle.getStatus().modelCached).toBe(true);
+	});
+
+	it("★ main event loop stays responsive while an RPC is stuck (the regression this fixes)", async () => {
+		// Simulate an unreachable model CDN: the worker accepts the
+		// checkAvailable RPC but NEVER responds. The handle's main-thread
+		// work must not block — heartbeat ticks must stay on schedule and
+		// getStatus() must remain instant. (Under the old in-process
+		// implementation, the synchronous WASM/download work froze the loop.)
+		const { worker, factory } = fakePair();
+		const handle = await makeHandle(worker, factory, { initTimeoutMs: 10_000 });
+
+		const pending = handle.checkAvailable(); // worker will not respond
+		void pending.catch(() => {});
+
+		const intervals: number[] = [];
+		const start = Date.now();
+		for (let i = 0; i < 5; i++) {
+			await Bun.sleep(25);
+			intervals.push(Date.now() - start);
+			// getStatus stays synchronous and instant on every tick
+			expect(typeof handle.getStatus().initialized).toBe("boolean");
+		}
+
+		// Each ~25ms tick landed on schedule (generous jitter, but the loop
+		// never stalled). If the main thread had blocked, these would balloon
+		// toward the 10s init timeout.
+		for (let i = 0; i < intervals.length; i++) {
+			expect(intervals[i]).toBeLessThan(500 * (i + 1));
+		}
+		expect(intervals.at(-1) ?? 0).toBeLessThan(1_000);
+	});
+
+	it("embed fails fast when the worker never responds (bounded RPC timeout)", async () => {
+		const { worker, factory } = fakePair();
+		const handle = await makeHandle(worker, factory, { embedTimeoutMs: 60, cooldownMs: 5_000 });
+
+		await expect(handle.embed("stuck")).rejects.toThrow(/timed out/);
+		// Cooldown gates an immediate retry without re-posting
+		const before = worker.posted.length;
+		await expect(handle.embed("again")).rejects.toThrow(/cooldown|timed out/);
+		expect(worker.posted.length).toBe(before); // no new RPC sent during cooldown
+	});
+
+	it("checkAvailable fails fast on timeout and marks the provider unavailable", async () => {
+		const { worker, factory } = fakePair();
+		const handle = await makeHandle(worker, factory, { initTimeoutMs: 60, cooldownMs: 5_000 });
+
+		const status = await handle.checkAvailable();
+		expect(status.available).toBe(false);
+		expect(status.error).toMatch(/timed out/);
+	});
+
+	it("a worker crash rejects pending RPCs and marks the provider unavailable", async () => {
+		const { worker, factory } = fakePair();
+		const handle = await makeHandle(worker, factory);
+
+		const p = handle.embed("doomed");
+		await flush();
+		worker.emitError(new Error("wasm segfault"));
+		await expect(p).rejects.toThrow(/crashed/);
+		expect(handle.getStatus().initialized).toBe(false);
+		expect(handle.getLastError()).toMatch(/segfault/);
+	});
+
+	it("a non-zero worker exit rejects pending RPCs", async () => {
+		const { worker, factory } = fakePair();
+		const handle = await makeHandle(worker, factory);
+
+		const p = handle.embed("doomed");
+		await flush();
+		worker.emitExit(137);
+		await expect(p).rejects.toThrow(/exited/);
+	});
+
+	it("concurrent embeds get distinct RPC ids and resolve independently", async () => {
+		const { worker, factory } = fakePair();
+		const handle = await makeHandle(worker, factory);
+
+		const a = handle.embed("a");
+		const b = handle.embed("b");
+		await flush();
+		const ids = worker.posted.filter((m) => m.type === "embed").map((m) => (m.type === "embed" ? m.id : -1));
+		expect(new Set(ids).size).toBe(2);
+
+		worker.emit({ type: "embed_result", id: ids[0], vector: vec(0.01) });
+		worker.emit({ type: "embed_result", id: ids[1], vector: vec(0.02) });
+		const [ra, rb] = await Promise.all([a, b]);
+		expect(ra[0]).toBeCloseTo(0.01, 5);
+		expect(rb[0]).toBeCloseTo(0.02, 5);
+	});
+
+	it("stop() posts shutdown, terminates the worker, and rejects further embeds", async () => {
+		const { worker, factory } = fakePair();
+		const handle = await makeHandle(worker, factory);
+
+		await handle.stop();
+		expect(worker.posted.some((m) => m.type === "shutdown")).toBe(true);
+		expect(worker.terminated).toBe(true);
+		await expect(handle.embed("after")).rejects.toThrow(/shut down/);
+	});
+
+	it("retries after the cooldown window elapses", async () => {
+		const { worker, factory } = fakePair();
+		const handle = await makeHandle(worker, factory, { embedTimeoutMs: 40, cooldownMs: 80 });
+
+		await expect(handle.embed("first")).rejects.toThrow(/timed out/); // -> cooldown
+		await Bun.sleep(120); // past cooldown
+		const p = handle.embed("retry");
+		await flush();
+		worker.emit({ type: "embed_result", id: lastEmbedId(worker), vector: vec() });
+		await expect(p).resolves.toHaveLength(DIM);
+	});
+});

--- a/platform/daemon/src/embedding-worker-handle.ts
+++ b/platform/daemon/src/embedding-worker-handle.ts
@@ -1,0 +1,368 @@
+/**
+ * Main-thread adapter for the native embedding worker.
+ *
+ * Spawns a node:worker_threads Worker running embedding-worker.ts and
+ * exposes the embedding provider contract used by the rest of the daemon
+ * (native-embedding.ts facade). All potentially-long work happens in the
+ * worker; this handle never blocks the main event loop:
+ *
+ *   - getStatus() is synchronous — it returns a cache fed by proactive
+ *     "status" pushes from the worker, so /health and status endpoints
+ *     never await the worker.
+ *   - embed()/checkAvailable() are RPC calls, each bounded by a
+ *     Promise.race timeout. If the worker is grinding (e.g. stuck on an
+ *     unreachable model CDN), these fail fast and mark the provider
+ *     unavailable instead of hanging — but crucially the main loop keeps
+ *     serving other requests the entire time, because the grinding happens
+ *     in the worker, not here.
+ *
+ * Mirrors the established worker pattern (see pipeline/extraction-thread-handle.ts):
+ * embedded-worker-asset fallback for the compiled binary, workerData init,
+ * ready handshake with timeout, injectable workerFactory for tests.
+ */
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker, type WorkerOptions } from "node:worker_threads";
+import { resolveDefaultBasePath } from "@signet/core";
+import type {
+	EmbeddingWorkerInit,
+	EmbeddingWorkerStatus,
+	MainToWorkerMessage,
+	WorkerToMainMessage,
+} from "./embedding-worker-protocol";
+import { logger } from "./logger";
+import { materializeEmbeddedWasmAssets, resolveEmbeddedWorkerPath } from "./native-runtime-assets";
+
+// ---------------------------------------------------------------------------
+// Constants (overridable via options for deterministic tests)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MODEL_ID = "nomic-ai/nomic-embed-text-v1.5";
+const DEFAULT_DIMENSIONS = 768;
+const READY_TIMEOUT_MS = 30_000;
+const INIT_TIMEOUT_MS = 90_000; // first-run model download can take a while
+const EMBED_TIMEOUT_MS = 15_000;
+const COOLDOWN_MS = 300_000; // match prior in-process behaviour
+
+// ---------------------------------------------------------------------------
+// Injectable worker surface (for tests)
+// ---------------------------------------------------------------------------
+
+export interface EmbeddingWorkerLike {
+	on(event: "message", listener: (msg: WorkerToMainMessage) => void): unknown;
+	on(event: "error", listener: (err: Error) => void): unknown;
+	on(event: "exit", listener: (code: number) => void): unknown;
+	postMessage(msg: MainToWorkerMessage): void;
+	terminate(): Promise<number> | number;
+}
+
+export type EmbeddingWorkerFactory = (
+	workerPath: string,
+	init: EmbeddingWorkerInit,
+	options: WorkerOptions,
+) => EmbeddingWorkerLike;
+
+export interface EmbeddingHandleOptions {
+	readonly modelId?: string;
+	readonly expectedDimensions?: number;
+	readonly cacheDir?: string;
+	/** Test seam: point transformers env.remoteHost at a local blackhole. */
+	readonly remoteHostOverride?: string;
+	readonly workerFactory?: EmbeddingWorkerFactory;
+	readonly readyTimeoutMs?: number;
+	readonly initTimeoutMs?: number;
+	readonly embedTimeoutMs?: number;
+	readonly cooldownMs?: number;
+}
+
+interface PendingRpc {
+	readonly resolve: (value: unknown) => void;
+	readonly reject: (err: Error) => void;
+	readonly timer: ReturnType<typeof setTimeout>;
+}
+
+export interface EmbeddingProviderStatus {
+	readonly available: boolean;
+	readonly error?: string;
+	readonly dimensions: number;
+	readonly modelCached: boolean;
+}
+
+export interface EmbeddingProviderSnapshot {
+	readonly initialized: boolean;
+	readonly initializing: boolean;
+	readonly modelCached: boolean;
+}
+
+export interface EmbeddingWorkerHandle {
+	embed(text: string): Promise<number[]>;
+	checkAvailable(): Promise<EmbeddingProviderStatus>;
+	getStatus(): EmbeddingProviderSnapshot;
+	getLastError(): string | null;
+	stop(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export async function createEmbeddingWorkerHandle(opts: EmbeddingHandleOptions = {}): Promise<EmbeddingWorkerHandle> {
+	const modelId = opts.modelId ?? DEFAULT_MODEL_ID;
+	const dimensions = opts.expectedDimensions ?? DEFAULT_DIMENSIONS;
+	const readyTimeoutMs = opts.readyTimeoutMs ?? READY_TIMEOUT_MS;
+	const initTimeoutMs = opts.initTimeoutMs ?? INIT_TIMEOUT_MS;
+	const embedTimeoutMs = opts.embedTimeoutMs ?? EMBED_TIMEOUT_MS;
+	const cooldownMs = opts.cooldownMs ?? COOLDOWN_MS;
+
+	const cacheDir = opts.cacheDir ?? join(resolveDefaultBasePath(), ".models");
+	// Main thread owns the compiled-binary asset globals; materialize WASM
+	// here and hand the directory to the worker (which has an isolated
+	// globalThis and cannot read them itself). Null in source mode, where
+	// onnxruntime-wasm resolves its .wasm from node_modules.
+	const wasmDir = materializeEmbeddedWasmAssets();
+
+	const init: EmbeddingWorkerInit = {
+		cacheDir,
+		wasmDir,
+		modelId,
+		expectedDimensions: dimensions,
+		...(opts.remoteHostOverride ? { remoteHostOverride: opts.remoteHostOverride } : {}),
+	};
+
+	const __dirname = dirname(fileURLToPath(import.meta.url));
+	const bundled = join(__dirname, "embedding-worker.js");
+	const workerPath = existsSync(bundled)
+		? bundled
+		: (resolveEmbeddedWorkerPath("embedding-worker") ?? join(__dirname, "embedding-worker.ts"));
+	const workerOptions = { workerData: init, type: "module" } as const;
+	const worker = (opts.workerFactory ?? createNodeWorker)(workerPath, init, workerOptions);
+
+	let nextId = 1;
+	const pending = new Map<number, PendingRpc>();
+	let status: EmbeddingWorkerStatus = { initialized: false, initializing: false, modelCached: false, error: null };
+	let lastError: string | null = null;
+	let lastFailureAt = 0;
+	let stopped = false;
+
+	let resolveReady: () => void = () => {};
+	const ready = new Promise<void>((resolve) => {
+		resolveReady = resolve;
+	});
+	const readyTimer = setTimeout(() => {
+		// If the worker never signals ready, unblock anyway so callers fail
+		// fast via RPC (the worker may have crashed before its first post).
+		resolveReady();
+	}, readyTimeoutMs);
+	readyTimer.unref?.();
+
+	function clearPending(id: number): PendingRpc | undefined {
+		const entry = pending.get(id);
+		if (entry) {
+			clearTimeout(entry.timer);
+			pending.delete(id);
+		}
+		return entry;
+	}
+
+	function failAllPending(err: Error): void {
+		for (const entry of pending.values()) {
+			clearTimeout(entry.timer);
+			entry.reject(err);
+		}
+		pending.clear();
+	}
+
+	function sendRpc(kind: "embed" | "checkAvailable", timeoutMs: number, extra?: { text: string }): number {
+		const id = nextId++;
+		const msg: MainToWorkerMessage =
+			kind === "embed" ? { type: "embed", id, text: extra?.text ?? "" } : { type: "checkAvailable", id };
+		worker.postMessage(msg);
+		return id;
+	}
+
+	function rpc<T>(kind: "embed" | "checkAvailable", timeoutMs: number, extra?: { text: string }): Promise<T> {
+		return ready.then(
+			() =>
+				new Promise<T>((resolve, reject) => {
+					const id = sendRpc(kind, timeoutMs, extra);
+					const timer = setTimeout(() => {
+						if (pending.has(id)) {
+							clearPending(id);
+							const message = `${kind} timed out after ${timeoutMs}ms (worker isolated; provider marked unavailable)`;
+							lastError = message;
+							lastFailureAt = Date.now();
+							status = { ...status, initialized: false, initializing: false, error: message };
+							logger.warn("native-embedding", message);
+							reject(new Error(message));
+						}
+					}, timeoutMs);
+					pending.set(id, { resolve: resolve as (v: unknown) => void, reject, timer });
+				}),
+		);
+	}
+
+	// Single message listener: resolves the ready handshake on first "ready",
+	// then dispatches everything else.
+	worker.on("message", (msg: WorkerToMainMessage) => {
+		switch (msg.type) {
+			case "ready":
+				clearTimeout(readyTimer);
+				resolveReady();
+				break;
+			case "status":
+				status = msg.status;
+				if (msg.status.error) lastError = msg.status.error;
+				break;
+			case "embed_result": {
+				const entry = clearPending(msg.id);
+				entry?.resolve(msg.vector);
+				break;
+			}
+			case "embed_error": {
+				const entry = clearPending(msg.id);
+				if (entry) {
+					lastError = msg.error;
+					entry.reject(new Error(msg.error));
+				}
+				break;
+			}
+			case "check_result": {
+				const entry = clearPending(msg.id);
+				if (entry) {
+					if (!msg.available) {
+						lastError = msg.error ?? "native embedding unavailable";
+						lastFailureAt = Date.now();
+					}
+					entry.resolve({
+						available: msg.available,
+						error: msg.error ?? undefined,
+						dimensions,
+						modelCached: status.modelCached,
+					});
+				}
+				break;
+			}
+			case "log": {
+				const message = msg.message;
+				if (msg.level === "error") {
+					logger.error("native-embedding", message, undefined, msg.data);
+				} else if (msg.level === "warn") {
+					logger.warn("native-embedding", message, msg.data);
+				} else {
+					logger.info("native-embedding", message, msg.data);
+				}
+				break;
+			}
+			case "error":
+				logger.error("native-embedding", "Embedding worker error", undefined, { error: msg.error, stack: msg.stack });
+				lastError = msg.error;
+				break;
+		}
+	});
+
+	worker.on("error", (err: Error) => {
+		logger.error("native-embedding", "Embedding worker crashed", err);
+		lastError = err.message;
+		lastFailureAt = Date.now();
+		status = { initialized: false, initializing: false, modelCached: false, error: err.message };
+		failAllPending(new Error(`Embedding worker crashed: ${err.message}`));
+	});
+
+	worker.on("exit", (code: number) => {
+		if (!stopped && code !== 0) {
+			logger.warn("native-embedding", "Embedding worker exited unexpectedly", { code });
+		}
+		status = {
+			initialized: false,
+			initializing: false,
+			modelCached: false,
+			error: lastError ?? `worker exited (${code})`,
+		};
+		failAllPending(new Error(`Embedding worker exited (code ${code})`));
+	});
+
+	function inCooldown(): boolean {
+		return lastFailureAt > 0 && Date.now() - lastFailureAt < cooldownMs;
+	}
+
+	const handle: EmbeddingWorkerHandle = {
+		async embed(text: string): Promise<number[]> {
+			if (stopped) throw new Error("Native embedding provider shut down");
+			if (inCooldown()) throw new Error(lastError ?? "Native embedding init on cooldown");
+			return rpc<number[]>("embed", embedTimeoutMs, { text });
+		},
+
+		async checkAvailable(): Promise<EmbeddingProviderStatus> {
+			if (stopped) {
+				return { available: false, error: "Native embedding provider shut down", dimensions, modelCached: false };
+			}
+			if (inCooldown()) {
+				return {
+					available: false,
+					error: lastError ?? "Native embedding init on cooldown",
+					dimensions,
+					modelCached: false,
+				};
+			}
+			// checkAvailable triggers init (model download), so it gets the init budget.
+			// Resolves with {available:false} on timeout/failure to preserve the
+			// checkNativeProvider contract (callers like /api/embeddings/health do
+			// not catch). Only embed() rejects.
+			try {
+				return await rpc<EmbeddingProviderStatus>("checkAvailable", initTimeoutMs);
+			} catch (err) {
+				return {
+					available: false,
+					error: err instanceof Error ? err.message : String(err),
+					dimensions,
+					modelCached: false,
+				};
+			}
+		},
+
+		getStatus(): EmbeddingProviderSnapshot {
+			return {
+				initialized: status.initialized,
+				initializing: status.initializing,
+				modelCached: status.modelCached,
+			};
+		},
+
+		getLastError(): string | null {
+			return lastError;
+		},
+
+		async stop(): Promise<void> {
+			if (stopped) return;
+			stopped = true;
+			try {
+				worker.postMessage({ type: "shutdown" });
+			} catch {
+				// worker may already be gone
+			}
+			failAllPending(new Error("Native embedding provider shut down"));
+			// A real Worker.terminate() resolves once the thread is gone; a fake
+			// returns a sync number. Either way this bounds teardown without
+			// waiting on an "exit" event the peer may never emit.
+			try {
+				const result = worker.terminate();
+				if (result && typeof (result as Promise<unknown>).then === "function") {
+					await result;
+				}
+			} catch {
+				// best-effort
+			}
+			logger.info("native-embedding", "Provider shut down");
+		},
+	};
+
+	return handle;
+}
+
+function createNodeWorker(workerPath: string, _init: EmbeddingWorkerInit, options: WorkerOptions): EmbeddingWorkerLike {
+	// node:worker_threads Worker structurally satisfies EmbeddingWorkerLike
+	// (on/postMessage/terminate). Exposed as a factory so tests inject a fake.
+	return new Worker(workerPath, options) as unknown as EmbeddingWorkerLike;
+}

--- a/platform/daemon/src/embedding-worker-protocol.ts
+++ b/platform/daemon/src/embedding-worker-protocol.ts
@@ -1,0 +1,79 @@
+/**
+ * IPC protocol for the native embedding worker thread.
+ *
+ * Why a worker exists (see native-embedding.ts / embedding-worker.ts):
+ * the ONNX-WASM embedding runtime performs long, partly-synchronous
+ * work — first-run model download, WASM compile, and per-call forward
+ * passes. Running that on the daemon's main event loop starves every
+ * HTTP handler including /health (the bug fixed by this change). A
+ * worker_threads Worker cannot block the main loop, so isolation is the
+ * structural guarantee; the main-thread handle adds bounded RPC
+ * timeouts on top for fail-fast.
+ *
+ * Main thread spawns a node:worker_threads Worker with EmbeddingWorkerInit
+ * as workerData. Communication uses postMessage only — no MessageChannel,
+ * BroadcastChannel, or receiveMessageOnPort (mirrors extraction-thread-protocol.ts).
+ */
+
+// ---------------------------------------------------------------------------
+// Serializable init config (passed via workerData)
+// ---------------------------------------------------------------------------
+
+/**
+ * Everything the worker needs to self-initialize. Computed on the main
+ * thread (which owns the compiled-binary asset globals) and passed in,
+ * because a worker has an isolated globalThis and cannot itself read
+ * `__SIGNET_NATIVE_RUNTIME_ASSETS__` / call materializeEmbeddedWasmAssets().
+ */
+export interface EmbeddingWorkerInit {
+	/** Cache directory for the transformers model (<agentsDir>/.models). */
+	readonly cacheDir: string;
+	/**
+	 * Directory holding the materialized ONNX WASM assets, or null in
+	 * source mode where onnxruntime-wasm resolves its .wasm from node_modules.
+	 * Main thread obtains this via materializeEmbeddedWasmAssets().
+	 */
+	readonly wasmDir: string | null;
+	readonly modelId: string;
+	readonly expectedDimensions: number;
+	/**
+	 * Optional override for transformers `env.remoteHost` — test seam used
+	 * by the event-loop isolation test to point the model fetch at a local
+	 * blackhole so download "hangs" hermetically (no real network in CI).
+	 */
+	readonly remoteHostOverride?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Main → Worker messages
+// ---------------------------------------------------------------------------
+
+export type MainToWorkerMessage =
+	| { readonly type: "embed"; readonly id: number; readonly text: string }
+	| { readonly type: "checkAvailable"; readonly id: number }
+	| { readonly type: "shutdown" };
+
+// ---------------------------------------------------------------------------
+// Worker → Main messages
+// ---------------------------------------------------------------------------
+
+/**
+ * Proactive status snapshots pushed whenever the worker's init state
+ * transitions, so the main thread can answer getNativeProviderStatus()
+ * synchronously without awaiting an RPC round-trip.
+ */
+export interface EmbeddingWorkerStatus {
+	readonly initialized: boolean;
+	readonly initializing: boolean;
+	readonly modelCached: boolean;
+	readonly error: string | null;
+}
+
+export type WorkerToMainMessage =
+	| { readonly type: "ready" }
+	| { readonly type: "status"; readonly status: EmbeddingWorkerStatus }
+	| { readonly type: "embed_result"; readonly id: number; readonly vector: number[] }
+	| { readonly type: "embed_error"; readonly id: number; readonly error: string }
+	| { readonly type: "check_result"; readonly id: number; readonly available: boolean; readonly error: string | null }
+	| { readonly type: "log"; readonly level: string; readonly message: string; readonly data?: Record<string, unknown> }
+	| { readonly type: "error"; readonly error: string; readonly stack?: string };

--- a/platform/daemon/src/embedding-worker.ts
+++ b/platform/daemon/src/embedding-worker.ts
@@ -1,0 +1,268 @@
+/**
+ * Native embedding worker — runs nomic-embed-text ONNX (via
+ * @huggingface/transformers WASM runtime) inside a worker_threads Worker.
+ *
+ * This is the thread that performs the long, partly-synchronous work:
+ * first-run model download, WASM compile, and per-call forward passes.
+ * Keeping it off the daemon's main event loop is what guarantees that
+ * /health and every HTTP handler stay responsive regardless of embedding
+ * state. The main-thread adapter (embedding-worker-handle.ts) bounds each
+ * RPC with a timeout so callers fail fast even if this worker is grinding.
+ *
+ * Loaded in the worker via:
+ *   - source mode: `new Worker(new URL("./embedding-worker.ts", import.meta.url))`
+ *     → resolves @huggingface/transformers from node_modules.
+ *   - compiled binary: the worker is bun-bundled into an embedded worker
+ *     asset (see scripts/build-native-bun.ts workerEntries) with transformers
+ *     inlined, and the main thread passes the materialized wasmDir via
+ *     workerData (the worker cannot read the main-thread asset globals).
+ */
+
+import { mkdirSync } from "node:fs";
+import { isMainThread, parentPort, workerData } from "node:worker_threads";
+import type { EmbeddingWorkerInit, MainToWorkerMessage, WorkerToMainMessage } from "./embedding-worker-protocol";
+
+// Lazy, narrow transformers typing — keeps the contract we use without
+// dragging in the library's complex generics (same approach as the prior
+// in-process implementation).
+interface TransformersEnv {
+	cacheDir?: string;
+	localModelPath?: string;
+	allowLocalModels?: boolean;
+	remoteHost?: string;
+	backends?: {
+		onnx?: {
+			wasm?: { wasmPaths?: string };
+		};
+	};
+}
+interface TransformersBindings {
+	readonly env: TransformersEnv;
+	readonly pipeline: (
+		task: string,
+		model: string,
+		opts: {
+			dtype: "q8";
+			progress_callback?: (progress: { status: string; progress?: number; file?: string }) => void;
+		},
+	) => Promise<unknown>;
+}
+interface EmbedCallable {
+	(text: string, opts?: { pooling?: string; normalize?: boolean }): Promise<{ data: Float32Array }>;
+	dispose?: () => Promise<void>;
+}
+
+const workerInit = workerData as EmbeddingWorkerInit | undefined;
+
+if (isMainThread || !parentPort || !workerInit) {
+	// Defensive: should never be imported on the main thread. Bail loudly
+	// rather than silently no-op'ing.
+	throw new Error("embedding-worker.ts must run as a worker_threads Worker with EmbeddingWorkerInit workerData");
+}
+
+const init: EmbeddingWorkerInit = workerInit;
+
+const port = parentPort;
+
+function post(msg: WorkerToMainMessage): void {
+	port.postMessage(msg);
+}
+
+function log(level: string, message: string, data?: Record<string, unknown>): void {
+	post({ type: "log", level, message, data });
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+let transformers: TransformersBindings | null = null;
+let embedFn: EmbedCallable | null = null;
+let initPromise: Promise<void> | null = null;
+let initError: string | null = null;
+let modelCached = false;
+
+function snapshot() {
+	return {
+		initialized: embedFn !== null,
+		initializing: initPromise !== null && embedFn === null,
+		modelCached,
+		error: initError,
+	};
+}
+
+function pushStatus(): void {
+	post({ type: "status", status: snapshot() });
+}
+
+// ---------------------------------------------------------------------------
+// Transformers loading + init
+// ---------------------------------------------------------------------------
+
+async function loadTransformers(): Promise<TransformersBindings> {
+	// The worker cannot use the compiled binary's main-thread
+	// __SIGNET_NATIVE_TRANSFORMERS_BINDINGS__ global (isolated globalThis),
+	// so load via the bundled runtime entry. In source mode this resolves
+	// @huggingface/transformers from node_modules; in the compiled binary
+	// the worker .mjs has transformers inlined by the bun build.
+	const mod = (await import("./transformers-runtime")) as {
+		env: TransformersEnv;
+		pipeline: TransformersBindings["pipeline"];
+	};
+	return { env: mod.env, pipeline: mod.pipeline };
+}
+
+async function ensureInitialized(): Promise<void> {
+	if (embedFn) return;
+	if (initPromise) return initPromise;
+	initPromise = doInit();
+	try {
+		await initPromise;
+	} finally {
+		// Keep initPromise around only while in-flight; clear on settle so
+		// retries (after cooldown, controlled by the main thread) can re-init.
+		initPromise = null;
+	}
+	return;
+}
+
+async function doInit(): Promise<void> {
+	try {
+		initError = null;
+		pushStatus();
+
+		mkdirSync(init.cacheDir, { recursive: true });
+		transformers = await loadTransformers();
+
+		// Configure cache + LOCAL load path. Setting localModelPath to the
+		// same cacheDir is the fix for the "Unable to load from local path
+		// /models/…" noise: without it transformers defaults localModelPath
+		// to a root "/models" that never exists, so every load pointlessly
+		// probes-and-fails locally before hitting the network. With this, a
+		// cached model loads straight from disk on subsequent starts.
+		transformers.env.cacheDir = init.cacheDir;
+		transformers.env.localModelPath = init.cacheDir;
+		transformers.env.allowLocalModels = true;
+		if (init.remoteHostOverride) {
+			transformers.env.remoteHost = init.remoteHostOverride;
+		}
+		if (init.wasmDir) {
+			const wasm = transformers.env.backends?.onnx?.wasm;
+			if (wasm) wasm.wasmPaths = `${init.wasmDir}/`;
+		}
+
+		log("info", `Initializing ${init.modelId} (q8 quantization)`, {
+			cachePath: init.cacheDir,
+			wasmPath: init.wasmDir ?? "node_modules",
+			remoteHost: transformers.env.remoteHost,
+		});
+
+		const pipe = await transformers.pipeline("feature-extraction", init.modelId, {
+			dtype: "q8",
+			progress_callback: (progress) => {
+				if (progress.status === "download" && typeof progress.progress === "number") {
+					log("info", `Downloading ${progress.file ?? "model"}: ${Math.round(progress.progress)}%`);
+				} else if (progress.status === "ready") {
+					log("info", "Model ready");
+				}
+			},
+		});
+
+		const embed = toEmbedCallable(pipe);
+		// Warm-up to verify output shape before declaring readiness.
+		const warmup = await embed("test", { pooling: "mean", normalize: true });
+		if (warmup.data.length !== init.expectedDimensions) {
+			throw new Error(`Expected ${init.expectedDimensions} dimensions but got ${warmup.data.length}`);
+		}
+
+		embedFn = embed;
+		modelCached = true;
+		log("info", `Ready — ${init.expectedDimensions}-dim embeddings`);
+		pushStatus();
+	} catch (err) {
+		initError = err instanceof Error ? err.message : String(err);
+		embedFn = null;
+		modelCached = false;
+		log("error", `Init failed: ${initError}`);
+		pushStatus();
+		throw err;
+	}
+}
+
+function toEmbedCallable(value: unknown): EmbedCallable {
+	if (typeof value !== "function") throw new Error("Transformers pipeline is not callable");
+	const callable = value as (
+		text: string,
+		opts?: { pooling?: string; normalize?: boolean },
+	) => Promise<{
+		data: Float32Array;
+	}>;
+	const embed: EmbedCallable = async (text, opts) => {
+		const output = await Promise.resolve(callable(text, opts));
+		if (!(output?.data instanceof Float32Array)) {
+			throw new Error("Transformers pipeline returned non-Float32Array data");
+		}
+		return { data: output.data };
+	};
+	const dispose = (value as { dispose?: () => Promise<void> }).dispose;
+	if (typeof dispose === "function") embed.dispose = dispose;
+	return embed;
+}
+
+// ---------------------------------------------------------------------------
+// RPC
+// ---------------------------------------------------------------------------
+
+async function handleEmbed(id: number, text: string): Promise<void> {
+	try {
+		await ensureInitialized();
+		if (!embedFn) throw new Error(initError ?? "Native embedding pipeline not initialized");
+		const output = await embedFn(text, { pooling: "mean", normalize: true });
+		post({ type: "embed_result", id, vector: Array.from(output.data) });
+	} catch (err) {
+		post({ type: "embed_error", id, error: err instanceof Error ? err.message : String(err) });
+	}
+}
+
+async function handleCheckAvailable(id: number): Promise<void> {
+	try {
+		await ensureInitialized();
+		post({ type: "check_result", id, available: embedFn !== null, error: embedFn ? null : (initError ?? "not ready") });
+	} catch (err) {
+		post({ type: "check_result", id, available: false, error: err instanceof Error ? err.message : String(err) });
+	}
+}
+
+async function handleShutdown(): Promise<void> {
+	if (embedFn?.dispose) {
+		try {
+			await embedFn.dispose();
+		} catch {
+			// best-effort
+		}
+	}
+	embedFn = null;
+	modelCached = false;
+	initPromise = null;
+	initError = null;
+}
+
+port.on("message", (msg: MainToWorkerMessage) => {
+	switch (msg.type) {
+		case "embed":
+			void handleEmbed(msg.id, msg.text);
+			break;
+		case "checkAvailable":
+			void handleCheckAvailable(msg.id);
+			break;
+		case "shutdown":
+			void handleShutdown();
+			break;
+	}
+});
+
+port.on("error", (err: Error) => {
+	post({ type: "error", error: err.message, stack: err.stack });
+});
+
+post({ type: "ready" });

--- a/platform/daemon/src/native-embedding-eventloop-isolation.test.ts
+++ b/platform/daemon/src/native-embedding-eventloop-isolation.test.ts
@@ -1,0 +1,184 @@
+/**
+ * End-to-end regression: the daemon's HTTP server (incl. /health) must stay
+ * responsive while the native embedding provider is stuck on its first-run
+ * model download.
+ *
+ * This is the test the bug class escaped. The prior in-process implementation
+ * ran ONNX-WASM init + model fetch on the main event loop, so an unreachable
+ * model CDN wedged the whole daemon — /health timed out even though the
+ * process was alive and the port was bound. The unit tests mocked
+ * @huggingface/transformers and so never exercised any of that.
+ *
+ * Here we spawn the REAL daemon (source mode) configured for native
+ * embeddings, point the model fetch at a local TCP blackhole (accepts the
+ * connection, never responds — simulates a stalled CDN, fully hermetic, no
+ * real network), and poll /health through the window where the embedding
+ * worker is grinding. Every response must return within the SLA. The main
+ * event loop can't be starved because the grinding now happens in a worker.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { type Server, createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const daemonScript = join(import.meta.dir, "daemon.ts");
+const tempDirs: string[] = [];
+const children: ChildProcessWithoutNullStreams[] = [];
+const servers: Server[] = [];
+
+afterEach(async () => {
+	for (const child of children.splice(0)) {
+		if (child.exitCode === null) {
+			child.kill("SIGTERM");
+			await new Promise<void>((resolve) => {
+				const t = setTimeout(() => {
+					child.kill("SIGKILL");
+					resolve();
+				}, 2_000);
+				child.once("close", () => {
+					clearTimeout(t);
+					resolve();
+				});
+			});
+		}
+	}
+	for (const server of servers.splice(0)) server.close();
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function tempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "signet-embedding-isolation-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+async function freePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (address === null || typeof address === "string") return reject(new Error("no port"));
+			const port = address.port;
+			server.close((err) => (err ? reject(err) : resolve(port)));
+		});
+	});
+}
+
+/** A TCP server that accepts connections but never responds — makes an HTTP
+ *  fetch hang indefinitely on response headers (a stalled CDN), hermetically. */
+async function blackholeOrigin(): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const server = createServer((socket) => {
+			// Hold the connection open without ever writing a response.
+			socket.on("error", () => {});
+		});
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (address === null || typeof address === "string") return reject(new Error("no port"));
+			servers.push(server);
+			resolve(`http://127.0.0.1:${address.port}`);
+		});
+	});
+}
+
+async function waitForHealth(
+	origin: string,
+	child: ChildProcessWithoutNullStreams,
+	deadlineMs = 30_000,
+): Promise<void> {
+	const deadline = Date.now() + deadlineMs;
+	while (Date.now() < deadline) {
+		if (child.exitCode !== null) throw new Error(`daemon exited before health (status ${child.exitCode})`);
+		try {
+			const res = await fetch(`${origin}/health`, { signal: AbortSignal.timeout(1_000) });
+			if (res.ok) return;
+		} catch {}
+		await Bun.sleep(100);
+	}
+	throw new Error("daemon did not become healthy in time");
+}
+
+describe("native embedding event-loop isolation (e2e)", () => {
+	// Generous timeout: daemon startup + a 5s probe window.
+	it("/health stays within SLA while the embedding worker is stuck on a model download", async () => {
+		const agentsDir = tempDir();
+		writeFileSync(
+			join(agentsDir, "agent.yaml"),
+			[
+				"memory:",
+				"  pipelineV2:",
+				"    enabled: false",
+				"  embedding:",
+				"    provider: native",
+				"    model: nomic-ai/nomic-embed-text-v1.5",
+				"    dimensions: 768",
+				"",
+			].join("\n"),
+		);
+
+		const [port, blackhole] = await Promise.all([freePort(), blackholeOrigin()]);
+		const origin = `http://127.0.0.1:${port}`;
+
+		const child = spawn(process.execPath, [daemonScript], {
+			env: {
+				...process.env,
+				SIGNET_PORT: String(port),
+				SIGNET_PATH: agentsDir,
+				SIGNET_BIND: "127.0.0.1",
+				// Redirect the transformers model fetch to the blackhole so the
+				// embedding worker's first-run download hangs for the whole probe.
+				SIGNET_EMBEDDING_REMOTE_HOST: blackhole,
+				// Avoid crosstalk with the user's real daemon/services.
+				SIGNET_DAEMON_ENTRYPOINT: "1",
+			},
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		children.push(child);
+
+		// Surface daemon failures fast.
+		child.stderr.on("data", () => {});
+		child.stdout.on("data", () => {});
+
+		await waitForHealth(origin, child);
+
+		// The daemon's startup probe (daemon.ts) fires checkEmbeddingProvider
+		// at boot, so the embedding worker is now grinding against the
+		// blackhole. Poll /health through the window and assert the SLA.
+		const samples: number[] = [];
+		const probeDeadline = Date.now() + 5_000;
+		while (Date.now() < probeDeadline) {
+			const t0 = Date.now();
+			const res = await fetch(`${origin}/health`, { signal: AbortSignal.timeout(2_000) });
+			samples.push(Date.now() - t0);
+			expect(res.ok).toBe(true);
+			await Bun.sleep(250);
+		}
+
+		expect(samples.length).toBeGreaterThan(5);
+		// /health is a cheap SELECT 1; it must return well under a second even
+		// while the embedding worker is hung. (Before the fix this timed out.)
+		const max = Math.max(...samples);
+		expect(max).toBeLessThan(1_000);
+
+		// Prove the embedding worker actually started its (stuck) init against
+		// the blackhole — otherwise this test could pass trivially with the
+		// provider idle. The handle forwards worker logs through the daemon
+		// logger, which writes to the agents-dir log.
+		const logDir = join(agentsDir, ".daemon", "logs");
+		let logText = "";
+		try {
+			for (const name of readdirSync(logDir)) {
+				if (name.endsWith(".log")) logText += readFileSync(join(logDir, name), "utf8");
+			}
+		} catch {
+			// logs may live elsewhere on some platforms; the SLA assertion above
+			// is the load-bearing guard.
+		}
+		expect(logText).toMatch(/nomic-embed|Initializing.*nomic|embedding/i);
+	}, 60_000);
+});

--- a/platform/daemon/src/native-embedding.test.ts
+++ b/platform/daemon/src/native-embedding.test.ts
@@ -1,117 +1,140 @@
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { WorkerOptions } from "node:worker_threads";
+import type { EmbeddingWorkerFactory, EmbeddingWorkerLike } from "./embedding-worker-handle";
+import type { EmbeddingWorkerInit, MainToWorkerMessage, WorkerToMainMessage } from "./embedding-worker-protocol";
+import {
+	__resetEmbeddingProviderForTests,
+	__setEmbeddingWorkerFactoryForTests,
+	checkNativeProvider,
+	getNativeProviderStatus,
+	nativeEmbed,
+	shutdownNativeProvider,
+} from "./native-embedding";
 
-// Mock @huggingface/transformers to avoid real model downloads
-const mockEmbedFn = mock(async (text: string, _opts: unknown) => ({
-	data: new Float32Array(768).fill(1 / Math.sqrt(768)),
-}));
+const flush = (): Promise<void> => Bun.sleep(0);
 
-const mockPipeline = mock(async () => mockEmbedFn);
+const DIM = 768;
+const vec = (n = 1 / Math.sqrt(DIM)): number[] => Array<number>(DIM).fill(n);
 
-mock.module("@huggingface/transformers", () => ({
-	pipeline: mockPipeline,
-	env: { cacheDir: "", allowLocalModels: false },
-}));
+class FakeWorker implements EmbeddingWorkerLike {
+	readonly posted: MainToWorkerMessage[] = [];
+	private readonly listeners = { message: [], error: [], exit: [] } as Record<
+		"message" | "error" | "exit",
+		Array<(arg: never) => void>
+	>;
+	ready = false;
 
-// Must import after mocking
-const { nativeEmbed, checkNativeProvider, shutdownNativeProvider, getNativeProviderStatus } = await import(
-	"./native-embedding"
-);
+	on(event: "message" | "error" | "exit", listener: (...a: never[]) => void): this {
+		this.listeners[event].push(listener as never);
+		return this;
+	}
 
-describe("native-embedding", () => {
+	postMessage(msg: MainToWorkerMessage): void {
+		this.posted.push(msg);
+	}
+
+	terminate(): number {
+		return 0;
+	}
+
+	emit(msg: WorkerToMainMessage): void {
+		for (const cb of this.listeners.message) cb(msg as never);
+	}
+}
+
+// Facade contract: the public API the rest of the daemon imports must keep
+// working now that the implementation lives behind a worker. These tests go
+// through native-embedding.ts (the singleton facade) using the test-only
+// worker-factory seam, asserting delegation, sync status, singleton reuse,
+// and reset — the properties callers rely on.
+describe("native-embedding facade (worker-backed)", () => {
+	let worker: FakeWorker;
+
+	beforeEach(() => {
+		worker = new FakeWorker();
+		const factory: EmbeddingWorkerFactory = (
+			_path: string,
+			_init: EmbeddingWorkerInit,
+			_options: WorkerOptions,
+		): EmbeddingWorkerLike => worker;
+		__setEmbeddingWorkerFactoryForTests(factory);
+	});
+
 	afterEach(async () => {
-		await shutdownNativeProvider();
-		mockPipeline.mockClear();
-		mockEmbedFn.mockClear();
+		await __resetEmbeddingProviderForTests();
 	});
 
-	it("nativeEmbed returns 768-dim vector", async () => {
-		const vec = await nativeEmbed("hello world");
-		expect(vec).toHaveLength(768);
-		expect(Array.isArray(vec)).toBe(true);
-	});
-
-	it("output is approximately L2-normalized", async () => {
-		const vec = await nativeEmbed("test normalization");
-		const norm = Math.sqrt(vec.reduce((sum, v) => sum + v * v, 0));
-		expect(Math.abs(norm - 1.0)).toBeLessThan(0.01);
-	});
-
-	it("singleton: second call reuses pipeline", async () => {
-		await nativeEmbed("first");
-		await nativeEmbed("second");
-		// pipeline() should only be called once (singleton init)
-		expect(mockPipeline).toHaveBeenCalledTimes(1);
-		// embed fn: 1 warm-up + 2 actual calls = 3
-		expect(mockEmbedFn).toHaveBeenCalledTimes(3);
-	});
-
-	it("concurrent init calls share the same promise", async () => {
-		const results = await Promise.all([nativeEmbed("a"), nativeEmbed("b"), nativeEmbed("c")]);
-		expect(results).toHaveLength(3);
-		for (const vec of results) {
-			expect(vec).toHaveLength(768);
-		}
-		// pipeline() still only called once
-		expect(mockPipeline).toHaveBeenCalledTimes(1);
-	});
-
-	it("checkNativeProvider reports status correctly", async () => {
-		const status = await checkNativeProvider();
-		expect(status.available).toBe(true);
-		expect(status.dimensions).toBe(768);
-		expect(status.modelCached).toBe(true);
-	});
-
-	it("shutdownNativeProvider disposes pipeline", async () => {
-		await nativeEmbed("init");
-		expect(getNativeProviderStatus().initialized).toBe(true);
-
-		await shutdownNativeProvider();
-		expect(getNativeProviderStatus().initialized).toBe(false);
-
-		// Next call should re-initialize
-		await nativeEmbed("after shutdown");
-		expect(mockPipeline).toHaveBeenCalledTimes(2);
-	});
-
-	it("getNativeProviderStatus shows correct state before init", async () => {
+	it("getNativeProviderStatus is synchronous and returns a default snapshot before init", () => {
 		const status = getNativeProviderStatus();
 		expect(status.initialized).toBe(false);
-		expect(status.initializing).toBe(false);
+		expect(status.modelCached).toBe(false);
+		expect(typeof status.initializing).toBe("boolean");
 	});
 
-	it("init failure resets promise for retry after shutdown", async () => {
-		mockPipeline.mockImplementationOnce(async () => {
-			throw new Error("network timeout");
+	it("nativeEmbed delegates to the worker and returns a 768-dim vector", async () => {
+		const p = nativeEmbed("hello world");
+		await flush(); // handle created, message listener registered, awaiting ready
+		worker.emit({ type: "ready" });
+		await flush(); // ready resolves -> embed RPC posted
+		const req = worker.posted.find((m) => m.type === "embed");
+		worker.emit({ type: "embed_result", id: req?.type === "embed" ? req.id : -1, vector: vec() });
+		const result = await p;
+		expect(result).toHaveLength(DIM);
+	});
+
+	it("checkNativeProvider resolves with available:false on init failure (does not reject)", async () => {
+		// Preserves the contract: /api/embeddings/health and the startup
+		// probe await this without try/catch.
+		const p = checkNativeProvider();
+		await flush();
+		worker.emit({ type: "ready" });
+		await flush();
+		const req = worker.posted.find((m) => m.type === "checkAvailable");
+		worker.emit({
+			type: "check_result",
+			id: req?.type === "checkAvailable" ? req.id : -1,
+			available: false,
+			error: "model download failed",
 		});
+		const status = await p;
+		expect(status.available).toBe(false);
+		expect(status.error).toMatch(/model download failed/);
+		expect(status.dimensions).toBe(DIM);
+	});
 
-		const status1 = await checkNativeProvider();
-		expect(status1.available).toBe(false);
-		expect(status1.error).toContain("runtime=bundled runtime");
-		expect(status1.error).toContain("backend=onnx-wasm");
-		expect(status1.error).toContain("cachePath=");
-		expect(status1.error).toContain("wasmPath=unavailable");
-		expect(status1.error).toContain("cause=network timeout");
+	it("singleton: the facade reuses one worker handle across calls", async () => {
+		const first = nativeEmbed("a");
+		await flush();
+		worker.emit({ type: "ready" });
+		await flush();
+		const r1 = worker.posted.find((m) => m.type === "embed");
+		worker.emit({ type: "embed_result", id: r1?.type === "embed" ? r1.id : -1, vector: vec() });
+		await first;
 
+		// Second call must NOT spawn another worker — it reuses the handle.
+		const spawnsBefore = worker.posted.length;
+		const second = nativeEmbed("b");
+		await flush();
+		const r2 = [...worker.posted].reverse().find((m) => m.type === "embed");
+		worker.emit({ type: "embed_result", id: r2?.type === "embed" ? r2.id : -1, vector: vec() });
+		await second;
+		// Only one "ready" handshake ever happened (singleton).
+		expect(worker.posted.filter((m) => m.type === "shutdown").length).toBe(0);
+		expect(spawnsBefore).toBeGreaterThan(0);
+	});
+
+	it("shutdownNativeProvider resets the singleton so a later call re-initializes", async () => {
+		const first = nativeEmbed("a");
+		await flush();
+		worker.emit({ type: "ready" });
+		await flush();
+		const r1 = worker.posted.find((m) => m.type === "embed");
+		worker.emit({ type: "embed_result", id: r1?.type === "embed" ? r1.id : -1, vector: vec() });
+		await first;
+
+		const shutdownsBefore = worker.posted.filter((m) => m.type === "shutdown").length;
 		await shutdownNativeProvider();
-
-		const status2 = await checkNativeProvider();
-		expect(status2.available).toBe(true);
-		expect(mockPipeline).toHaveBeenCalledTimes(2);
-	});
-
-	it("init failure enforces cooldown before retry", async () => {
-		mockPipeline.mockImplementationOnce(async () => {
-			throw new Error("network timeout");
-		});
-
-		const status1 = await checkNativeProvider();
-		expect(status1.available).toBe(false);
-		expect(status1.error).toContain("network timeout");
-
-		const status2 = await checkNativeProvider();
-		expect(status2.available).toBe(false);
-		expect(status2.error).toContain("network timeout");
-		expect(mockPipeline).toHaveBeenCalledTimes(1);
+		expect(worker.posted.filter((m) => m.type === "shutdown").length).toBeGreaterThan(shutdownsBefore);
+		expect(getNativeProviderStatus().initialized).toBe(false);
 	});
 });

--- a/platform/daemon/src/native-embedding.ts
+++ b/platform/daemon/src/native-embedding.ts
@@ -1,349 +1,112 @@
 /**
- * Native embedding provider — runs nomic-embed-text ONNX directly
- * via @huggingface/transformers (WASM runtime).
+ * Native embedding provider — public facade.
  *
- * Lazy-initialized singleton with mutex-based init to handle
- * concurrent callers during model download.
+ * The ONNX (nomic-embed-text) runtime now lives in a worker_threads Worker
+ * (see embedding-worker.ts / embedding-worker-handle.ts). Running download,
+ * WASM compile, and per-call inference off the daemon's main event loop is
+ * what keeps /health and every HTTP handler responsive regardless of
+ * embedding state — the bug this file previously hosted ran all of that
+ * in-process on the main thread and could wedge the whole daemon during a
+ * first-run model download.
+ *
+ * This module preserves the exact public API the rest of the daemon depends
+ * on (`embedding-fetch.ts`, `routes/utils.ts`, `daemon.ts`), delegating to a
+ * lazily-created singleton worker handle. `getNativeProviderStatus()` stays
+ * synchronous (it reads a cache the worker pushes to), so status/health
+ * paths never await the worker.
  */
 
-import { mkdirSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
-import { resolveDefaultBasePath } from "@signet/core";
-import { logger } from "./logger";
-import { getNativeTransformersBindings, materializeEmbeddedWasmAssets } from "./native-runtime-assets";
+import {
+	type EmbeddingProviderSnapshot,
+	type EmbeddingProviderStatus,
+	type EmbeddingWorkerFactory,
+	type EmbeddingWorkerHandle,
+	createEmbeddingWorkerHandle,
+} from "./embedding-worker-handle";
+
+export type NativeProviderStatus = EmbeddingProviderStatus;
+export type NativeProviderSnapshot = EmbeddingProviderSnapshot;
 
 // ---------------------------------------------------------------------------
-// Types
+// Singleton handle
 // ---------------------------------------------------------------------------
 
-interface NativeProviderStatus {
-	readonly available: boolean;
-	readonly error?: string;
-	readonly dimensions: number;
-	readonly modelCached: boolean;
-}
+let handlePromise: Promise<EmbeddingWorkerHandle> | null = null;
+let resolvedHandle: EmbeddingWorkerHandle | null = null;
+let workerFactoryOverride: EmbeddingWorkerFactory | null = null;
 
-interface NativeProviderSnapshot {
-	readonly initialized: boolean;
-	readonly initializing: boolean;
-	readonly modelCached: boolean;
-}
-
-// We keep a narrow callable type for the pipeline return.
-// transformers.js FeatureExtractionPipeline is callable but its
-// full type drags in complex generics — this captures the contract
-// we actually use and avoids `as unknown as` casts.
-interface EmbedFn {
-	(
-		text: string,
-		opts?: { pooling?: string; normalize?: boolean },
-	): Promise<{
-		data: Float32Array;
-	}>;
-	dispose?: () => Promise<void>;
-}
-
-interface ProgressInfo {
-	readonly status: string;
-	readonly progress?: number;
-	readonly file?: string;
-}
-
-interface TransformersBindings {
-	readonly env: Record<string, unknown>;
-	readonly pipeline: (
-		task: string,
-		model: string,
-		opts: {
-			dtype: "q8";
-			progress_callback?: (progress: ProgressInfo) => void;
-		},
-	) => Promise<unknown>;
-}
-
-interface LoadedTransformersBindings {
-	readonly bindings: TransformersBindings;
-	readonly source: string;
-}
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const MODEL_ID = "nomic-ai/nomic-embed-text-v1.5";
-const EXPECTED_DIMS = 768;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
-}
-
-function readTransformersBindings(value: unknown): TransformersBindings | null {
-	if (!isRecord(value)) return null;
-	const env = value.env;
-	const pipeline = value.pipeline;
-	if (!isRecord(env) || typeof pipeline !== "function") return null;
-	return {
-		env,
-		pipeline: (task, model, opts) => Promise.resolve(Reflect.apply(pipeline, undefined, [task, model, opts])),
-	};
-}
-
-async function loadTransformersBindings(): Promise<LoadedTransformersBindings> {
-	const importBySpecifier = (specifier: string): Promise<unknown> => {
-		return import(specifier);
-	};
-
-	const resolveImportMetaSpecifier = (specifier: string): string => {
-		const resolver = Reflect.get(import.meta, "resolve");
-		if (typeof resolver !== "function") {
-			throw new Error("import.meta.resolve is not available");
-		}
-		return String(Reflect.apply(resolver, import.meta, [specifier]));
-	};
-
-	const loadTransformersWebRuntime = async (): Promise<unknown> => {
-		const packageJsonUrl = resolveImportMetaSpecifier("@huggingface/transformers/package.json");
-		const packageJsonPath = fileURLToPath(packageJsonUrl);
-		const webRuntimePath = join(dirname(packageJsonPath), "dist", "transformers.web.js");
-		return import(pathToFileURL(webRuntimePath).href);
-	};
-
-	const importCandidates: ReadonlyArray<{
-		readonly source: string;
-		readonly load: () => Promise<unknown>;
-	}> = [
-		{
-			source: "compiled native runtime",
-			load: () => Promise.resolve(getNativeTransformersBindings()),
-		},
-		{
-			source: "bundled runtime",
-			load: () => import("./transformers-runtime"),
-		},
-		{
-			source: "@huggingface/transformers",
-			load: () => importBySpecifier("@huggingface/transformers"),
-		},
-		{
-			source: "@huggingface/transformers dist web runtime",
-			load: () => loadTransformersWebRuntime(),
-		},
-	];
-
-	const failures: string[] = [];
-
-	for (const candidate of importCandidates) {
-		let mod: unknown;
-		try {
-			mod = await candidate.load();
-		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
-			failures.push(`${candidate.source}: ${message}`);
-			continue;
-		}
-
-		const direct = readTransformersBindings(mod);
-		if (direct !== null) return { bindings: direct, source: candidate.source };
-
-		if (isRecord(mod) && "default" in mod) {
-			const fromDefault = readTransformersBindings(mod.default);
-			if (fromDefault !== null) return { bindings: fromDefault, source: candidate.source };
-		}
-
-		failures.push(`${candidate.source}: unsupported export shape (missing env/pipeline)`);
-	}
-
-	throw new Error(`Failed to load @huggingface/transformers: ${failures.join("; ")}`);
-}
-
-function toEmbedFn(value: unknown): EmbedFn {
-	if (typeof value !== "function") {
-		throw new Error("Transformers pipeline is not callable");
-	}
-
-	const callable = value;
-	const embed: EmbedFn = async (text, opts) => {
-		const output = await Promise.resolve(Reflect.apply(callable, undefined, [text, opts]));
-		if (!isRecord(output)) {
-			throw new Error("Transformers pipeline returned invalid output");
-		}
-		const data = output.data;
-		if (!(data instanceof Float32Array)) {
-			throw new Error("Transformers pipeline returned non-Float32Array data");
-		}
-		return { data };
-	};
-
-	const dispose = Reflect.get(callable, "dispose");
-	if (typeof dispose === "function") {
-		embed.dispose = async () => {
-			await Promise.resolve(Reflect.apply(dispose, callable, []));
-		};
-	}
-
-	return embed;
-}
-
-// ---------------------------------------------------------------------------
-// Singleton state
-// ---------------------------------------------------------------------------
-
-let embedFn: EmbedFn | null = null;
-let initPromise: Promise<void> | null = null;
-let initError: string | null = null;
-let modelCached = false;
-let lastInitFailure = 0;
-
-const INIT_RETRY_COOLDOWN_MS = 300_000;
-
-// ---------------------------------------------------------------------------
-// Cache directory
-// ---------------------------------------------------------------------------
-
-function getCacheDir(): string {
-	const agentsDir = resolveDefaultBasePath();
-	return join(agentsDir, ".models");
-}
-
-// ---------------------------------------------------------------------------
-// Lazy init
-// ---------------------------------------------------------------------------
-
-async function ensureInitialized(): Promise<void> {
-	if (embedFn) return;
-	if (initPromise) return initPromise;
-	if (lastInitFailure > 0 && Date.now() - lastInitFailure < INIT_RETRY_COOLDOWN_MS) {
-		throw new Error(initError ?? "Native embedding init on cooldown");
-	}
-	initPromise = doInit();
-	return initPromise;
-}
-
-async function doInit(): Promise<void> {
-	let runtimeSource = "unresolved";
-	let cacheDir = "unresolved";
-	let wasmDir: string | null = null;
-	try {
-		initError = null;
-
-		cacheDir = getCacheDir();
-		mkdirSync(cacheDir, { recursive: true });
-
-		// Dynamic import to avoid top-level WASM load
-		const loaded = await loadTransformersBindings();
-		const transformers = loaded.bindings;
-		runtimeSource = loaded.source;
-
-		// Configure cache directory
-		transformers.env.cacheDir = cacheDir;
-		transformers.env.allowLocalModels = true;
-		wasmDir = materializeEmbeddedWasmAssets();
-		if (wasmDir) {
-			const backends = transformers.env.backends;
-			const onnx = isRecord(backends) ? backends.onnx : null;
-			const wasm = isRecord(onnx) ? onnx.wasm : null;
-			if (isRecord(wasm)) {
-				wasm.wasmPaths = `${wasmDir}/`;
-			}
-		}
-
-		logger.info("native-embedding", `Initializing ${MODEL_ID} (q8 quantization)`, {
-			runtime: runtimeSource,
-			backend: "onnx-wasm",
-			cachePath: cacheDir,
-			wasmPath: wasmDir ?? "unavailable",
+function getHandle(): Promise<EmbeddingWorkerHandle> {
+	if (!handlePromise) {
+		// SIGNET_EMBEDDING_REMOTE_HOST: test/debug seam that redirects the
+		// transformers model fetch (env.remoteHost). The event-loop isolation
+		// test points it at a local blackhole so first-run download "hangs"
+		// hermetically, without real network.
+		const remoteHostOverride = process.env.SIGNET_EMBEDDING_REMOTE_HOST?.trim() || undefined;
+		handlePromise = createEmbeddingWorkerHandle(
+			workerFactoryOverride
+				? { workerFactory: workerFactoryOverride }
+				: remoteHostOverride
+					? { remoteHostOverride }
+					: {},
+		).then((h) => {
+			resolvedHandle = h;
+			return h;
 		});
-
-		const pipe = await transformers.pipeline("feature-extraction", MODEL_ID, {
-			dtype: "q8" as const,
-			progress_callback: (progress: ProgressInfo) => {
-				if (progress.status === "download" && typeof progress.progress === "number") {
-					logger.info("native-embedding", `Downloading ${progress.file ?? "model"}: ${Math.round(progress.progress)}%`);
-				} else if (progress.status === "ready") {
-					logger.info("native-embedding", "Model ready");
-				}
-			},
-		});
-
-		// Warm-up to verify output shape
-		const embed = toEmbedFn(pipe);
-		const warmup = await embed("test", { pooling: "mean", normalize: true });
-		const dims = warmup.data.length;
-		if (dims !== EXPECTED_DIMS) {
-			throw new Error(`Expected ${EXPECTED_DIMS} dimensions but got ${dims}`);
-		}
-
-		// The pipeline return is callable — assign to our narrow interface.
-		// We verify the contract via the warmup call above rather than
-		// relying on type assertions.
-		embedFn = embed;
-		modelCached = true;
-		logger.info("native-embedding", `Ready — ${EXPECTED_DIMS}-dim embeddings`);
-	} catch (err) {
-		const cause = err instanceof Error ? err.message : String(err);
-		initError = `runtime=${runtimeSource}; backend=onnx-wasm; cachePath=${cacheDir}; wasmPath=${wasmDir ?? "unavailable"}; cause=${cause}`;
-		initPromise = null;
-		lastInitFailure = Date.now();
-		const wrapped = new Error(initError, { cause: err });
-		logger.error("native-embedding", `Init failed: ${initError}`, wrapped);
-		throw wrapped;
 	}
+	return handlePromise;
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Public API (unchanged signatures)
 // ---------------------------------------------------------------------------
 
 export async function nativeEmbed(text: string): Promise<number[]> {
-	await ensureInitialized();
-	if (embedFn === null) {
-		throw new Error("Native embedding pipeline failed to initialize");
-	}
-	const output = await embedFn(text, { pooling: "mean", normalize: true });
-	return Array.from(output.data);
+	const handle = await getHandle();
+	return handle.embed(text);
 }
 
 export async function checkNativeProvider(): Promise<NativeProviderStatus> {
-	try {
-		await ensureInitialized();
-		return {
-			available: true,
-			dimensions: EXPECTED_DIMS,
-			modelCached,
-		};
-	} catch {
-		return {
-			available: false,
-			error: initError ?? "Native embedding provider not ready",
-			dimensions: EXPECTED_DIMS,
-			modelCached: false,
-		};
-	}
-}
-
-export async function shutdownNativeProvider(): Promise<void> {
-	if (embedFn) {
-		if (typeof embedFn.dispose === "function") {
-			try {
-				await embedFn.dispose();
-			} catch {
-				// best-effort
-			}
-		}
-		logger.info("native-embedding", "Provider shut down");
-	}
-	embedFn = null;
-	initPromise = null;
-	initError = null;
-	modelCached = false;
-	lastInitFailure = 0;
+	const handle = await getHandle();
+	return handle.checkAvailable();
 }
 
 export function getNativeProviderStatus(): NativeProviderSnapshot {
-	return {
-		initialized: embedFn !== null,
-		initializing: initPromise !== null && embedFn === null,
-		modelCached,
-	};
+	if (resolvedHandle) return resolvedHandle.getStatus();
+	// No handle resolved yet: report "initializing" if creation is in flight,
+	// otherwise the default pre-init snapshot. Never awaits.
+	return { initialized: false, initializing: handlePromise !== null, modelCached: false };
+}
+
+export async function shutdownNativeProvider(): Promise<void> {
+	const pending = handlePromise;
+	handlePromise = null;
+	const h = resolvedHandle;
+	resolvedHandle = null;
+	if (h) {
+		await h.stop();
+	} else if (pending) {
+		// Handle was still coming up; await then stop it.
+		try {
+			await (await pending).stop();
+		} catch {
+			// best-effort during teardown
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test-only seams
+// ---------------------------------------------------------------------------
+
+/** @internal Inject a worker factory (e.g. a fake that speaks the IPC
+ *  protocol) BEFORE the first call. Call __resetEmbeddingProviderForTests()
+ *  to clear the singleton between tests. */
+export function __setEmbeddingWorkerFactoryForTests(factory: EmbeddingWorkerFactory | null): void {
+	workerFactoryOverride = factory;
+}
+
+/** @internal Reset the singleton handle between tests. */
+export async function __resetEmbeddingProviderForTests(): Promise<void> {
+	await shutdownNativeProvider();
+	workerFactoryOverride = null;
 }

--- a/scripts/build-native-bun.ts
+++ b/scripts/build-native-bun.ts
@@ -96,6 +96,12 @@ const hermesPluginDir = join(root, "integrations", "hermes-agent", "connector", 
 const workerEntries = [
 	["synthesis-render-worker", "platform/daemon/src/synthesis-render-worker.ts"],
 	["extraction-thread", "platform/daemon/src/pipeline/extraction-thread.ts"],
+	// Native ONNX embedding runs in a worker so model download / WASM compile /
+	// inference can never block the daemon's main event loop (see
+	// embedding-worker.ts). Transformers is bundled into this asset; the ONNX
+	// .wasm is embedded separately (wasmAssets) and the main thread passes the
+	// materialized wasmDir to the worker via workerData.
+	["embedding-worker", "platform/daemon/src/embedding-worker.ts"],
 ] as const;
 const nativeExternalArgs = ["--external", "better-sqlite3"] as const;
 

--- a/scripts/native-embedding-runtime-smoke.test.ts
+++ b/scripts/native-embedding-runtime-smoke.test.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { createServer } from "node:net";
+import { type Server, createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -71,8 +71,28 @@ async function stopChild(child: ChildProcessWithoutNullStreams): Promise<void> {
 	]);
 }
 
+const blackholeServers: Server[] = [];
+
+/** TCP server that accepts a connection but never responds — makes an HTTP
+ *  model fetch hang on response headers (a stalled CDN), hermetically. */
+async function blackholeOrigin(): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const server = createServer((socket) => {
+			socket.on("error", () => {});
+		});
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (address === null || typeof address === "string") return reject(new Error("blackhole did not bind"));
+			blackholeServers.push(server);
+			resolve(`http://127.0.0.1:${address.port}`);
+		});
+	});
+}
+
 afterEach(async () => {
 	for (const child of children.splice(0)) await stopChild(child);
+	for (const server of blackholeServers.splice(0)) server.close();
 	for (const path of tempDirs.splice(0)) rmSync(path, { recursive: true, force: true });
 });
 
@@ -152,5 +172,65 @@ describe("compiled native embedding runtime", () => {
 			}
 		},
 		12 * 60_000,
+	);
+
+	smoke(
+		"keeps /health within SLA while the native embedding download is stalled (event-loop isolation)",
+		async () => {
+			// Regression guard for the shipped binary: the daemon's HTTP server
+			// must stay responsive while the native embedding worker is stuck on
+			// its first-run model download. We stall the fetch hermetically with
+			// a local blackhole and assert /health latency through the window.
+			const binary = nativeSmokeBinary();
+			if (!existsSync(binary)) {
+				throw new Error(`native binary not found at ${binary}; build it first (bun run build:native-bun)`);
+			}
+			const workspace = tempDir();
+			writeFileSync(
+				join(workspace, "agent.yaml"),
+				"version: 1\nschema: signet/v1\nagent:\n  name: Native Embedding Isolation Smoke\nmemory:\n  database: memory/memories.db\n  pipelineV2:\n    enabled: false\nembedding:\n  provider: native\n  model: nomic-embed-text-v1.5\n  dimensions: 768\n",
+			);
+			const [port, blackhole] = await Promise.all([freePort(), blackholeOrigin()]);
+			const origin = `http://127.0.0.1:${port}`;
+			const child = spawn(binary, [], {
+				env: {
+					...process.env,
+					SIGNET_DAEMON_ENTRYPOINT: "1",
+					SIGNET_PATH: workspace,
+					SIGNET_PORT: String(port),
+					SIGNET_BIND: "127.0.0.1",
+					// Redirect the transformers model fetch at the blackhole so the
+					// embedding worker's first-run download hangs for the window.
+					SIGNET_EMBEDDING_REMOTE_HOST: blackhole,
+					OLLAMA_HOST: "http://127.0.0.1:1",
+				},
+				stdio: ["ignore", "pipe", "pipe"],
+			});
+			children.push(child);
+			const output: Buffer[] = [];
+			child.stdout.on("data", (chunk) => output.push(Buffer.from(chunk)));
+			child.stderr.on("data", (chunk) => output.push(Buffer.from(chunk)));
+
+			try {
+				await waitForHealth(origin, child);
+				const samples: number[] = [];
+				const deadline = Date.now() + 5_000;
+				while (Date.now() < deadline) {
+					const t0 = Date.now();
+					const res = await fetch(`${origin}/health`, { signal: AbortSignal.timeout(2_000) });
+					samples.push(Date.now() - t0);
+					expect(res.ok).toBe(true);
+					await Bun.sleep(250);
+				}
+				expect(samples.length).toBeGreaterThan(5);
+				expect(Math.max(...samples)).toBeLessThan(1_000);
+			} catch (error) {
+				const logs = Buffer.concat(output).toString("utf8");
+				throw new Error(`${error instanceof Error ? error.message : String(error)}\n\nNative daemon output:\n${logs}`, {
+					cause: error,
+				});
+			}
+		},
+		2 * 60_000,
 	);
 });


### PR DESCRIPTION
## Problem

Native ONNX (`nomic-embed-text`) init, model download, and per-call inference ran on the daemon's **main event loop**. A slow or unreachable first-run model download (e.g. the embedding CDN not resolving) starved the loop and took down the whole HTTP server — `/health` timed out while the process stayed alive and the port stayed bound, so the daemon reported as **stopped**. Per-memory inference carried the same latent stall on every embed.

The unit tests mocked `@huggingface/transformers`, so none of this (real download, real blocking, real event-loop impact) was ever exercised — which is why the bug class escaped.

## Fix

Move the entire native provider into a `worker_threads` Worker — the same isolation pattern the daemon already uses for extraction / dreaming / summary. A worker **cannot block** the main event loop, so `/health` and every handler stay responsive regardless of embedding state. The public API of `native-embedding.ts` is unchanged, so `embedding-fetch`, `routes/utils`, and the startup probe are untouched.

- **`embedding-worker.ts`** owns transformers (pipeline, download, inference).
- **`embedding-worker-handle.ts`** — lazy worker, ready handshake, **synchronous** `getNativeProviderStatus()` (fed by worker status pushes, never awaits), bounded RPC timeouts (`embed` rejects; `checkAvailable` resolves `available:false` to preserve the `checkNativeProvider` contract), cooldown, crash/exit handling.
- **`localModelPath = cacheDir`** — cached models load without the pointless `"/models/…"` probe-and-fail before every fetch.
- Worker loads transformers via `./transformers-runtime` (the main-thread `__SIGNET_NATIVE_TRANSFORMERS_BINDINGS__` global is not visible in the worker); main thread materializes the ONNX wasm dir and passes it via `workerData`. Registered as an embedded worker asset in `build-native-bun.ts`.

## Regression coverage (the guardrail)

| Layer | Test | Runs |
|---|---|---|
| Unit | `embedding-worker-handle.test.ts` — RPC bounds, concurrent ids, sync status, cooldown, crash/exit, **main-thread non-blocking invariant** | every PR |
| Contract | `native-embedding.test.ts` — facade through the public API | every PR |
| **E2E isolation** | `native-embedding-eventloop-isolation.test.ts` — spawns the real daemon over HTTP, stalls the model fetch at a local blackhole, asserts `/health` stays within SLA while the worker is stuck | every PR |
| Release smoke | `native-embedding-runtime-smoke.test.ts` — same `/health`-SLA guard against the **compiled** native binary, every release platform | release CI |
| CI invariant | `.github/workflows/embedding-health-isolation.yml` | PR + push |

The e2e test is the one the bug class escaped: it proves the worker actually started its stuck download **and** that `/health` stayed responsive throughout.

## Verification

- Embedding suite: **37 pass / 0 fail** (run per-file, as the repo does).
- `autoreview` (branch mode, focused on isolation / concurrency / contract): **no actionable findings**.
- Consumers (`embedding-fetch`, `routes/utils`, daemon startup) unchanged and green.
- Native-binary build path wires the worker as an embedded asset; full compiled-binary verification runs in release CI via the smoke above.

## Notes

- The pre-existing `daemon.ts:1743` `WorkerOptions` `type` tsc warning is untouched (not introduced here; repo doesn't gate on full `tsc`).
- Draft until the readiness checklist is confirmed against `INDEX.md` / `dependencies.yaml` (no spec, data-query, or endpoint changes in this fix).

## Checklist

- [x] Regression tests added for each bug fix
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Lint/typecheck/tests pass locally
