### PR TITLE
fix(embedding): await in-flight init before first embed to prevent warm-up race

### DIFF
--- a/platform/daemon/src/native-embedding.test.ts
+++ b/platform/daemon/src/native-embedding.test.ts
@@ -137,4 +137,106 @@ describe("native-embedding facade (worker-backed)", () => {
 		expect(worker.posted.filter((m) => m.type === "shutdown").length).toBeGreaterThan(shutdownsBefore);
 		expect(getNativeProviderStatus().initialized).toBe(false);
 	});
+
+	it("★ nativeEmbed awaits in-flight init before embedding (warm-up race #920)", async () => {
+		// Simulate the daemon startup probe: checkNativeProvider() fires
+		// and starts init. Before it completes, nativeEmbed() is called.
+		// nativeEmbed should await the init promise, then send the embed
+		// RPC — NOT race the embed timeout against the still-initializing
+		// worker.
+		const checkP = checkNativeProvider();
+		await flush();
+		worker.emit({ type: "ready" });
+		await flush();
+
+		// At this point, checkAvailable RPC has been posted and is pending.
+		expect(worker.posted.some((m) => m.type === "checkAvailable")).toBe(true);
+		expect(worker.posted.some((m) => m.type === "embed")).toBe(false);
+
+		// While check is still in flight, start an embed.
+		const embedP = nativeEmbed("warm-start test");
+		await flush();
+
+		// The embed RPC should NOT have been posted yet — we're waiting
+		// for the check (init) to complete first.
+		expect(worker.posted.some((m) => m.type === "embed")).toBe(false);
+
+		// Now complete the init check.
+		const checkReq = worker.posted.find((m) => m.type === "checkAvailable");
+		worker.emit({
+			type: "status",
+			status: { initialized: true, initializing: false, modelCached: true, error: null },
+		});
+		worker.emit({
+			type: "check_result",
+			id: checkReq?.type === "checkAvailable" ? checkReq.id : -1,
+			available: true,
+		});
+		await checkP;
+		await flush();
+
+		// NOW the embed RPC should be posted (init is done).
+		expect(worker.posted.some((m) => m.type === "embed")).toBe(true);
+
+		// Respond to the embed RPC.
+		const embedReq = [...worker.posted].reverse().find((m) => m.type === "embed");
+		worker.emit({
+			type: "embed_result",
+			id: embedReq?.type === "embed" ? embedReq.id : -1,
+			vector: vec(),
+		});
+		const result = await embedP;
+		expect(result).toHaveLength(DIM);
+	});
+
+	it("nativeEmbed proceeds without waiting when no init is in flight", async () => {
+		// No checkNativeProvider() has been called, so initPromise is null.
+		// nativeEmbed should go straight to embed without waiting.
+		const p = nativeEmbed("direct");
+		await flush();
+		worker.emit({ type: "ready" });
+		await flush();
+
+		// Embed RPC is posted immediately — no checkAvailable sent first.
+		expect(worker.posted.some((m) => m.type === "checkAvailable")).toBe(false);
+		expect(worker.posted.some((m) => m.type === "embed")).toBe(true);
+
+		const req = worker.posted.find((m) => m.type === "embed");
+		worker.emit({ type: "embed_result", id: req?.type === "embed" ? req.id : -1, vector: vec() });
+		await expect(p).resolves.toHaveLength(DIM);
+	});
+
+	it("nativeEmbed still embeds when init check returns unavailable (graceful degradation)", async () => {
+		// The startup probe fires and the worker reports unavailable (e.g.,
+		// model not downloaded yet, but the daemon is running). nativeEmbed
+		// should still proceed to attempt the embed after the init promise
+		// settles, rather than hanging indefinitely. The embed may succeed
+		// (worker recovered between probe and embed) or fail (propagated).
+		const checkP = checkNativeProvider();
+		await flush();
+		worker.emit({ type: "ready" });
+		await flush();
+
+		// Worker responds as unavailable.
+		const checkReq = worker.posted.find((m) => m.type === "checkAvailable");
+		worker.emit({
+			type: "check_result",
+			id: checkReq?.type === "checkAvailable" ? checkReq.id : -1,
+			available: false,
+			error: "not ready yet",
+		});
+		await checkP;
+
+		// The init promise has settled (not rejected — checkAvailable
+		// resolves with {available:false}). nativeEmbed should not hang
+		// waiting for it. The embed may be in cooldown from the failed
+		// check, so we verify the promise settles (not that it hangs).
+		const embedP = nativeEmbed("after-unavailable");
+		// Race with a timeout to prove it doesn't hang.
+		const result = await Promise.race([
+			embedP.then(() => "settled").catch(() => "rejected"),
+			Bun.sleep(2000).then(() => "hung"),
+		]);
+		expect(result).not.toBe("hung");
+	});
 });

--- a/platform/daemon/src/native-embedding.ts
+++ b/platform/daemon/src/native-embedding.ts
@@ -35,6 +35,14 @@ let handlePromise: Promise<EmbeddingWorkerHandle> | null = null;
 let resolvedHandle: EmbeddingWorkerHandle | null = null;
 let workerFactoryOverride: EmbeddingWorkerFactory | null = null;
 
+// Tracks the most recent init/warm-up attempt. When the daemon's startup
+// probe calls checkNativeProvider(), this promise is set. nativeEmbed()
+// awaits it before calling embed() so the first `signet remember` after a
+// daemon restart waits for the native worker to finish initializing (model
+// load + WASM compile) instead of racing the 15 s embed timeout and losing
+// (#920).
+let initPromise: Promise<unknown> | null = null;
+
 function getHandle(): Promise<EmbeddingWorkerHandle> {
 	if (!handlePromise) {
 		// SIGNET_EMBEDDING_REMOTE_HOST: test/debug seam that redirects the
@@ -62,12 +70,27 @@ function getHandle(): Promise<EmbeddingWorkerHandle> {
 
 export async function nativeEmbed(text: string): Promise<number[]> {
 	const handle = await getHandle();
+	// If an init/warm-up is in flight (e.g., the startup probe hasn't
+	// completed yet), await it before embedding. This ensures the first
+	// `signet remember` after a daemon restart waits for the native worker
+	// to finish initializing instead of racing the 15 s embed timeout and
+	// silently saving without an embedding (#920).
+	if (initPromise && !resolvedHandle?.getStatus().initialized) {
+		await initPromise.catch(() => {});
+		initPromise = null;
+	}
 	return handle.embed(text);
 }
 
 export async function checkNativeProvider(): Promise<NativeProviderStatus> {
 	const handle = await getHandle();
-	return handle.checkAvailable();
+	const p = handle.checkAvailable();
+	initPromise = p;
+	// Clear once settled so subsequent nativeEmbed calls don't await a stale promise.
+	p.finally(() => {
+		if (initPromise === p) initPromise = null;
+	});
+	return p;
 }
 
 export function getNativeProviderStatus(): NativeProviderSnapshot {
@@ -80,6 +103,7 @@ export function getNativeProviderStatus(): NativeProviderSnapshot {
 export async function shutdownNativeProvider(): Promise<void> {
 	const pending = handlePromise;
 	handlePromise = null;
+	initPromise = null;
 	const h = resolvedHandle;
 	resolvedHandle = null;
 	if (h) {


### PR DESCRIPTION
## Summary

The first `signet remember` after a daemon restart could save a memory without an embedding (`(no embedding)` in the CLI) because `nativeEmbed()` raced the 15s embed timeout against the worker's first-run model load + WASM compile. When the embed RPC timed out, the embedding tracker backfilled asynchronously, leaving a window where the memory was not vector-searchable.

## Changes

- `platform/daemon/src/native-embedding.ts`: track the init promise from `checkNativeProvider()`. `nativeEmbed()` now awaits the in-flight init before sending the embed RPC, so the first embed uses the full 90s init budget instead of the 15s embed budget. The init promise is cleared once settled so subsequent embeds proceed immediately.
- `platform/daemon/src/native-embedding.test.ts`: three regression tests covering the warm-up race, the no-init-in-flight path, and graceful degradation when init fails.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`

## Screenshots

N/A

## Testing

- [x] `bun test` passes (8/8 in native-embedding.test.ts, 11/11 in embedding-worker-handle.test.ts)
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Co-authored-by` tag in commits)

## Notes

Fixes #920. The bot (@ant) identified the root cause during triage and wrote the initial implementation. I cleaned up the init promise lifecycle and fixed one failing test.

Closes #920.
