### PR TITLE
fix(recall): unify recall request semantics

### DIFF
--- a/integrations/pi/extension/index.test.ts
+++ b/integrations/pi/extension/index.test.ts
@@ -701,6 +701,198 @@ describe("SignetPiExtension", () => {
 		expect(toolNames).not.toContain("signet_memory_feedback");
 	});
 
+	it("signet_recall tool forwards canonical recall context with default limit 10", async () => {
+		let capturedBody: Record<string, unknown> = {};
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				const path = new URL(req.url).pathname;
+				if (path === "/health") return new Response(null, { status: 200 });
+				if (path === "/api/memory/recall") {
+					capturedBody = (await req.json()) as Record<string, unknown>;
+					return Response.json({
+						method: "hybrid",
+						results: [{ id: "mem-1", content: "session memory", source: "hybrid", type: "fact" }],
+						meta: { totalReturned: 1, hasSupplementary: false, noHits: false },
+					});
+				}
+				return new Response("not found", { status: 404 });
+			},
+		});
+		servers.push(server);
+		process.env.SIGNET_DAEMON_URL = `http://127.0.0.1:${server.port}`;
+		process.env.SIGNET_AGENT_ID = "context-agent";
+
+		let recallTool:
+			| {
+					parameters?: { properties?: Record<string, unknown> };
+					execute: (
+						toolCallId: string,
+						params: Record<string, unknown>,
+						signal: AbortSignal,
+						onUpdate: unknown,
+						ctx: unknown,
+					) => Promise<unknown>;
+			  }
+			| undefined;
+		const pi = {
+			on(_event: string, _handler: unknown) {},
+			registerCommand(_name: string, _opts: unknown) {},
+			registerTool(opts: { name: string; parameters?: { properties?: Record<string, unknown> }; execute: never }) {
+				if (opts.name === "signet_recall") recallTool = opts as typeof recallTool;
+			},
+		};
+
+		SignetPiExtension(pi as never);
+
+		expect(recallTool?.parameters?.properties).toHaveProperty("sessionKey");
+		expect(recallTool?.parameters?.properties).toHaveProperty("includeRecalled");
+		expect(recallTool?.parameters?.properties).toHaveProperty("scope");
+
+		const ctx = {
+			sessionManager: {
+				getHeader: () => ({ id: "ctx-session", cwd: "/tmp/pi-project" }),
+				getSessionId: () => "ctx-session",
+			},
+			ui: {
+				setStatus: () => {},
+				theme: { fg: (_color: string, text: string) => text },
+			},
+		};
+
+		await recallTool?.execute(
+			"tool-call-1",
+			{
+				query: "session memory",
+				sessionKey: "explicit-session",
+				includeRecalled: true,
+				scope: "session",
+			},
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+
+		expect(capturedBody).toMatchObject({
+			query: "session memory",
+			limit: 10,
+			agentId: "context-agent",
+			sessionKey: "explicit-session",
+			includeRecalled: true,
+			scope: "session",
+		});
+	});
+
+	it("signet_recall tool labels degraded aggregate evidence honestly", async () => {
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				const path = new URL(req.url).pathname;
+				if (path === "/health") return new Response(null, { status: 200 });
+				if (path === "/api/memory/recall") {
+					return Response.json({
+						method: "hybrid",
+						results: [{ id: "mem-1", content: "First evidence", source: "hybrid", type: "semantic" }],
+						meta: { totalReturned: 1, hasSupplementary: false, noHits: false },
+						aggregate: {
+							savedMemoryId: null,
+							saved: false,
+							deduped: false,
+							budget: "small",
+							queries: ["what happened"],
+							sourceMemoryIds: ["mem-1"],
+							stoppedReason: "synthesis_failed",
+							partial: true,
+							message: "Aggregate recall synthesis failed; returning retrieved evidence.",
+						},
+					});
+				}
+				return new Response("not found", { status: 404 });
+			},
+		});
+		servers.push(server);
+		process.env.SIGNET_DAEMON_URL = `http://127.0.0.1:${server.port}`;
+
+		let recallTool:
+			| {
+					execute: (
+						toolCallId: string,
+						params: Record<string, unknown>,
+						signal: AbortSignal,
+						onUpdate: unknown,
+						ctx: unknown,
+					) => Promise<{ content?: Array<{ text?: string }>; details?: Record<string, unknown> }>;
+			  }
+			| undefined;
+		const pi = {
+			on(_event: string, _handler: unknown) {},
+			registerCommand(_name: string, _opts: unknown) {},
+			registerTool(opts: { name: string; execute: never }) {
+				if (opts.name === "signet_recall") recallTool = opts as typeof recallTool;
+			},
+		};
+
+		SignetPiExtension(pi as never);
+
+		const result = await recallTool?.execute(
+			"tool-call-1",
+			{ query: "what happened", aggregate: true },
+			new AbortController().signal,
+			undefined,
+			{
+				sessionManager: { getHeader: () => ({ id: "ctx-session" }), getSessionId: () => "ctx-session" },
+				ui: { setStatus: () => {}, theme: { fg: (_color: string, text: string) => text } },
+			},
+		);
+
+		expect(result?.content?.[0]?.text).toContain("[Aggregate Recall degraded]");
+		expect(result?.content?.[0]?.text).toContain("Aggregate recall synthesis failed");
+		expect(result?.content?.[0]?.text).toContain("First evidence");
+		expect(result?.details?.aggregate).toMatchObject({ partial: true, stoppedReason: "synthesis_failed" });
+	});
+
+	it("/recall command uses the canonical default recall limit", async () => {
+		let capturedBody: Record<string, unknown> = {};
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				const path = new URL(req.url).pathname;
+				if (path === "/health") return new Response(null, { status: 200 });
+				if (path === "/api/memory/recall") {
+					capturedBody = (await req.json()) as Record<string, unknown>;
+					return Response.json({
+						method: "hybrid",
+						results: [{ id: "mem-1", content: "command memory", source: "hybrid", type: "fact" }],
+						meta: { totalReturned: 1, hasSupplementary: false, noHits: false },
+					});
+				}
+				return new Response("not found", { status: 404 });
+			},
+		});
+		servers.push(server);
+		process.env.SIGNET_DAEMON_URL = `http://127.0.0.1:${server.port}`;
+
+		let recallCommand: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
+		const pi = {
+			on(_event: string, _handler: unknown) {},
+			registerCommand(name: string, opts: { handler: (args: string, ctx: unknown) => Promise<void> }) {
+				if (name === "recall") recallCommand = opts;
+			},
+			registerTool(_opts: unknown) {},
+		};
+
+		SignetPiExtension(pi as never);
+		await recallCommand?.handler("command memory", {
+			ui: {
+				notify: () => {},
+				setStatus: () => {},
+				theme: { fg: (_color: string, text: string) => text },
+			},
+		});
+
+		expect(capturedBody.limit).toBe(10);
+	});
+
 	it("context injection end-to-end: session context and recall are delivered via context event", async () => {
 		const server = Bun.serve({
 			port: 0,

--- a/integrations/pi/extension/src/index.ts
+++ b/integrations/pi/extension/src/index.ts
@@ -140,33 +140,15 @@ export async function recallMemories(
 		saveAggregate?: boolean;
 	} = {},
 ): Promise<RecallPayload> {
-	const {
-		limit = 10,
-		agentId,
-		sessionKey,
-		includeRecalled,
-		scope,
-		aggregate,
-		aggregateBudget,
-		saveAggregate,
-	} = options;
-
 	const response = await fetch(`${daemonUrl}/api/memory/recall`, {
 		method: "POST",
 		headers: daemonHeaders({ "Content-Type": "application/json" }),
 		body: JSON.stringify(
 			buildRecallRequestBody(query, {
-				limit,
-				agentId,
-				sessionKey,
-				includeRecalled,
-				scope,
-				aggregate,
-				aggregateBudget,
-				saveAggregate,
+				...options,
 			}),
 		),
-		signal: AbortSignal.timeout(aggregate ? Math.max(READ_TIMEOUT * 6, 30_000) : READ_TIMEOUT),
+		signal: AbortSignal.timeout(options.aggregate ? Math.max(READ_TIMEOUT * 6, 30_000) : READ_TIMEOUT),
 	});
 
 	if (!response.ok) {
@@ -219,7 +201,7 @@ export async function searchSourceArtifacts(
 		project?: string;
 	} = {},
 ): Promise<RecallPayload> {
-	const { limit = 10, agentId, sessionKey, includeRecalled, project } = options;
+	const { limit, agentId, sessionKey, includeRecalled, project } = options;
 
 	const response = await fetch(`${daemonUrl}/api/memory/recall`, {
 		method: "POST",
@@ -465,7 +447,7 @@ function registerCommandsAndTools(pi: PiExtensionApi, daemonUrl: string, agentId
 			ctx.ui.notify(`Recalling: "${args}"...`, "info");
 
 			try {
-				const recall = await recallMemories(daemonUrl, args, { limit: 5, agentId });
+				const recall = await recallMemories(daemonUrl, args, { agentId });
 				const parsed = parseRecallPayload(recall);
 
 				if (parsed.rows.length === 0) {
@@ -565,8 +547,24 @@ function registerCommandsAndTools(pi: PiExtensionApi, daemonUrl: string, agentId
 			}),
 			limit: Type.Optional(
 				Type.Number({
-					description: "Maximum number of memories to return (default: 5)",
-					default: 5,
+					description: "Maximum number of memories to return (default: 10)",
+					default: 10,
+				}),
+			),
+			sessionKey: Type.Optional(
+				Type.String({
+					description: "Session key for per-context recall dedupe",
+				}),
+			),
+			includeRecalled: Type.Optional(
+				Type.Boolean({
+					description: "Include rows already recalled in this context",
+					default: false,
+				}),
+			),
+			scope: Type.Optional(
+				Type.Union([Type.Literal("global"), Type.Literal("agent"), Type.Literal("session")], {
+					description: "Recall scope constraint",
 				}),
 			),
 			aggregate: Type.Optional(
@@ -594,7 +592,12 @@ function registerCommandsAndTools(pi: PiExtensionApi, daemonUrl: string, agentId
 
 			try {
 				const query = String(params.query || "");
-				const limit = typeof params.limit === "number" ? params.limit : 5;
+				const limit = typeof params.limit === "number" ? params.limit : undefined;
+				const sessionKey = typeof params.sessionKey === "string" ? params.sessionKey : undefined;
+				const scope =
+					typeof params.scope === "string" && ["global", "agent", "session"].includes(params.scope)
+						? (params.scope as "global" | "agent" | "session")
+						: undefined;
 				const isAggregate = params.aggregate === true;
 				const aggregateBudget =
 					typeof params.aggregateBudget === "string" && ["small", "medium", "large"].includes(params.aggregateBudget)
@@ -604,6 +607,9 @@ function registerCommandsAndTools(pi: PiExtensionApi, daemonUrl: string, agentId
 				const recall = await recallMemories(daemonUrl, query, {
 					limit,
 					agentId,
+					sessionKey,
+					includeRecalled: params.includeRecalled === true,
+					scope,
 					aggregate: isAggregate,
 					aggregateBudget,
 				});
@@ -623,7 +629,11 @@ function registerCommandsAndTools(pi: PiExtensionApi, daemonUrl: string, agentId
 					state.memoryCount = aggregateRows.length;
 					updateStatus(ctx);
 
-					const parts = [`[Aggregate Recall] Query: ${query}`];
+					const degraded = recall.aggregate.partial === true;
+					const parts = [
+						degraded ? `[Aggregate Recall degraded] Query: ${query}` : `[Aggregate Recall] Query: ${query}`,
+					];
+					if (degraded && typeof recall.aggregate.message === "string") parts.push(recall.aggregate.message);
 					for (const row of aggregateRows) {
 						if (typeof row.content === "string") parts.push(row.content);
 					}

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -152,6 +152,7 @@ export {
 	withHookRecallCompat,
 } from "./recall";
 export type {
+	AggregateRecallMeta,
 	AggregateRecallUsage,
 	AggregateRecallUsageStage,
 	RecallMeta,
@@ -160,7 +161,10 @@ export type {
 	RecallRequestOptions,
 	RecallRow,
 	RecallScoreFilterRow,
+	RecallTemporalMeta,
+	RecallTimeOptions,
 	RememberRequestOptions,
+	TemporalFacet,
 } from "./recall";
 export {
 	createMemoriesFts,

--- a/platform/core/src/recall.test.ts
+++ b/platform/core/src/recall.test.ts
@@ -42,6 +42,38 @@ describe("recall surface helpers", () => {
 		expect(text).toContain("id: ctx-1; SEC adds supporting evidence.");
 	});
 
+	it("formats degraded aggregate recall as evidence with a clear partial message", () => {
+		const text = formatRecallText({
+			method: "hybrid",
+			results: [
+				{
+					id: "mem-1",
+					content: "First evidence",
+					source: "hybrid",
+					type: "semantic",
+					created_at: "2026-05-20T12:00:00.000Z",
+				},
+			],
+			meta: { totalReturned: 1, hasSupplementary: false, noHits: false },
+			aggregate: {
+				savedMemoryId: null,
+				saved: false,
+				deduped: false,
+				budget: "small",
+				queries: ["what happened"],
+				sourceMemoryIds: ["mem-1"],
+				stoppedReason: "router_unavailable",
+				partial: true,
+				message: "Aggregate recall could not synthesize; returning retrieved evidence.",
+			},
+		});
+
+		expect(text).toContain("Aggregate recall could not synthesize; returning retrieved evidence.");
+		expect(text).toContain("Found 1 memory (hybrid).");
+		expect(text).toContain("First evidence");
+		expect(text).not.toContain("No matching memories found.");
+	});
+
 	it("builds recall request bodies without forwarding client-side score thresholds", () => {
 		expect(
 			buildRecallRequestBody("graph", {
@@ -63,6 +95,97 @@ describe("recall surface helpers", () => {
 		});
 	});
 
+	it("owns the canonical recall default limit", () => {
+		expect(buildRecallRequestBody("graph")).toEqual({
+			query: "graph",
+			limit: 10,
+		});
+	});
+
+	it("uses explicit agent ids before contextual agent ids", () => {
+		expect(
+			buildRecallRequestBody("graph", {
+				agentId: "explicit-agent",
+				contextAgentId: "context-agent",
+			}),
+		).toMatchObject({
+			agentId: "explicit-agent",
+		});
+
+		expect(
+			buildRecallRequestBody("graph", {
+				contextAgentId: "context-agent",
+			}),
+		).toMatchObject({
+			agentId: "context-agent",
+		});
+	});
+
+	it("normalizes standard recall aliases without losing valid options", () => {
+		expect(
+			buildRecallRequestBody("graph", {
+				keyword_query: "graph OR entity",
+				limit: 2,
+				agent_id: "agent-a",
+				session_key: "session-a",
+				include_recalled: true,
+				source_only: true,
+				aggregate: true,
+				aggregate_budget: "large",
+				save_aggregate: false,
+				scope: "session",
+				project: "/tmp/project",
+				type: "decision",
+				tags: "architecture",
+				who: "codex",
+				pinned: true,
+				importance_min: 0.8,
+				since: "2026-01-01",
+				until: "2026-02-01",
+				time: {
+					start: "2026-01-01T00:00:00.000Z",
+					end: "2026-02-01T00:00:00.000Z",
+					facets: ["captured", "source"],
+					mode: "filter",
+				},
+				expand: true,
+			}),
+		).toEqual({
+			query: "graph",
+			keywordQuery: "graph OR entity",
+			limit: 2,
+			agentId: "agent-a",
+			sessionKey: "session-a",
+			includeRecalled: true,
+			sourceOnly: true,
+			aggregate: true,
+			aggregateBudget: "large",
+			saveAggregate: false,
+			scope: "session",
+			project: "/tmp/project",
+			type: "decision",
+			tags: "architecture",
+			who: "codex",
+			pinned: true,
+			importance_min: 0.8,
+			since: "2026-01-01",
+			until: "2026-02-01",
+			time: {
+				start: "2026-01-01T00:00:00.000Z",
+				end: "2026-02-01T00:00:00.000Z",
+				facets: ["captured", "source"],
+				mode: "filter",
+			},
+			expand: true,
+		});
+	});
+
+	it("bounds recall limits to a positive canonical range", () => {
+		expect(buildRecallRequestBody("graph", { limit: 0 }).limit).toBe(1);
+		expect(buildRecallRequestBody("graph", { limit: -5 }).limit).toBe(1);
+		expect(buildRecallRequestBody("graph", { limit: 5000 }).limit).toBe(100);
+	});
+
 	it("forwards temporal recall request options", () => {
 		expect(
 			buildRecallRequestBody("2026/05/13", {
@@ -75,6 +198,7 @@ describe("recall surface helpers", () => {
 			}),
 		).toEqual({
 			query: "2026/05/13",
+			limit: 10,
 			time: {
 				start: "2026-05-13T00:00:00.000Z",
 				end: "2026-05-14T00:00:00.000Z",
@@ -128,6 +252,7 @@ describe("recall surface helpers", () => {
 			}),
 		).toEqual({
 			query: "graph",
+			limit: 10,
 			aggregate: true,
 			aggregateBudget: "medium",
 			saveAggregate: false,
@@ -137,9 +262,10 @@ describe("recall surface helpers", () => {
 	it("forwards source-only recall constraints only when callers set them", () => {
 		expect(buildRecallRequestBody("graph", { sourceOnly: true })).toEqual({
 			query: "graph",
+			limit: 10,
 			sourceOnly: true,
 		});
-		expect(buildRecallRequestBody("graph", { sourceOnly: false })).toEqual({ query: "graph" });
+		expect(buildRecallRequestBody("graph", { sourceOnly: false })).toEqual({ query: "graph", limit: 10 });
 	});
 
 	it("normalizes legacy structured aspect tuples for remember callers", () => {

--- a/platform/core/src/recall.ts
+++ b/platform/core/src/recall.ts
@@ -71,6 +71,8 @@ export interface AggregateRecallMeta {
 	readonly queries: readonly string[];
 	readonly sourceMemoryIds: readonly string[];
 	readonly stoppedReason: "complete" | "no_evidence" | "router_unavailable" | "synthesis_failed";
+	readonly partial?: boolean;
+	readonly message?: string;
 	readonly usage?: AggregateRecallUsage;
 }
 
@@ -128,10 +130,15 @@ export interface RecallRequestOptions {
 	readonly time?: RecallTimeOptions;
 	readonly expand?: boolean;
 	readonly agentId?: string;
+	readonly agent_id?: string;
+	readonly contextAgentId?: string;
 	readonly sessionKey?: string;
+	readonly session_key?: string;
 	readonly includeRecalled?: boolean;
+	readonly include_recalled?: boolean;
 	readonly scope?: "global" | "agent" | "session";
 	readonly sourceOnly?: boolean;
+	readonly source_only?: boolean;
 	readonly aggregate?: boolean;
 	readonly aggregateBudget?: AggregateRecallBudget;
 	readonly aggregate_budget?: AggregateRecallBudget;
@@ -193,6 +200,11 @@ function normalizeRememberTags(tags: string | readonly string[] | undefined): st
 	}
 
 	return undefined;
+}
+
+function normalizeRecallLimit(limit: number | undefined): number {
+	if (typeof limit !== "number" || !Number.isFinite(limit)) return 10;
+	return Math.min(100, Math.max(1, Math.trunc(limit)));
 }
 
 export function partitionRecallRows<T extends RecallPartitionableRow>(
@@ -348,7 +360,14 @@ export function formatRecallText(raw: unknown): string {
 	const { primary, supporting } = partitionRecallRows(parsed.rows);
 	if (parsed.meta.temporal?.mode === "timeline") return formatTemporalRecallText(primary, parsed.meta.temporal);
 	const noun = parsed.meta.totalReturned === 1 ? "memory" : "memories";
-	const parts = [`Found ${parsed.meta.totalReturned} ${noun}${parsed.method ? ` (${parsed.method})` : ""}.`];
+	const parts =
+		payload.aggregate?.partial === true && typeof payload.aggregate.message === "string"
+			? [
+					payload.aggregate.message,
+					"",
+					`Found ${parsed.meta.totalReturned} ${noun}${parsed.method ? ` (${parsed.method})` : ""}.`,
+				]
+			: [`Found ${parsed.meta.totalReturned} ${noun}${parsed.method ? ` (${parsed.method})` : ""}.`];
 
 	if (primary.length > 0) {
 		parts.push("", "Primary matches:", ...primary.map((row) => formatRecallRow(row)));
@@ -365,7 +384,7 @@ export function buildRecallRequestBody(query: string, options: RecallRequestOpti
 	return withDefined({
 		query,
 		keywordQuery: options.keywordQuery ?? options.keyword_query,
-		limit: options.limit,
+		limit: normalizeRecallLimit(options.limit),
 		project: options.project,
 		type: options.type,
 		tags: options.tags,
@@ -376,11 +395,11 @@ export function buildRecallRequestBody(query: string, options: RecallRequestOpti
 		until: options.until,
 		time: options.time,
 		expand: options.expand === true ? true : undefined,
-		agentId: options.agentId,
-		sessionKey: options.sessionKey,
-		includeRecalled: options.includeRecalled === true ? true : undefined,
+		agentId: options.agentId ?? options.agent_id ?? options.contextAgentId,
+		sessionKey: options.sessionKey ?? options.session_key,
+		includeRecalled: options.includeRecalled === true || options.include_recalled === true ? true : undefined,
 		scope: options.scope,
-		sourceOnly: options.sourceOnly === true ? true : undefined,
+		sourceOnly: options.sourceOnly === true || options.source_only === true ? true : undefined,
 		aggregate: options.aggregate === true ? true : undefined,
 		aggregateBudget: options.aggregateBudget ?? options.aggregate_budget,
 		saveAggregate:

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -134,6 +134,27 @@ class StaticRouter implements AggregateInferenceRouter {
 	}
 }
 
+class SynthesisFailingRouter extends StaticRouter {
+	override async execute(
+		request: RouteRequest,
+		prompt: string,
+		opts?: {
+			readonly timeoutMs?: number;
+			readonly maxTokens?: number;
+			readonly refresh?: boolean;
+			readonly acpxHooks?: "disabled" | "inherit";
+		},
+	): ReturnType<AggregateInferenceRouter["execute"]> {
+		if (this.calls.length === 1) {
+			this.calls.push(request);
+			this.prompts.push(prompt);
+			this.opts.push(opts ?? {});
+			return { ok: false, error: new Error("synthesis unavailable") };
+		}
+		return super.execute(request, prompt, opts);
+	}
+}
+
 function quietLogger(): { readonly warn: ReturnType<typeof mock> } {
 	return {
 		warn: mock((_category: string, _message: string, _data?: Record<string, unknown>) => {}),
@@ -364,6 +385,69 @@ memory:
 			"https://gateway.example.test/v1/chat/completions",
 			"https://gateway.example.test/v1/chat/completions",
 		]);
+	});
+
+	it("returns evidence with partial aggregate metadata when the router is unavailable", async () => {
+		const result = await aggregateRecall(
+			{
+				query: "what evidence exists",
+				aggregate: true,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			{
+				embedFn: async () => null,
+				logger: quietLogger(),
+				hybridRecall: async (params: RecallParams) =>
+					response(params.query, [row("mem-1", "First evidence"), row("mem-2", "Second evidence")]),
+			},
+		);
+
+		expect(result.results.map((entry) => entry.id)).toEqual(["mem-1", "mem-2"]);
+		expect(result.meta.noHits).toBe(false);
+		expect(result.meta.totalReturned).toBe(2);
+		expect(result.aggregate).toMatchObject({
+			savedMemoryId: null,
+			saved: false,
+			deduped: false,
+			sourceMemoryIds: ["mem-1", "mem-2"],
+			stoppedReason: "router_unavailable",
+			partial: true,
+		});
+		expect(result.aggregate?.message).toContain("router");
+	});
+
+	it("returns evidence with partial aggregate metadata when synthesis fails", async () => {
+		const result = await aggregateRecall(
+			{
+				query: "what evidence exists",
+				aggregate: true,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: new SynthesisFailingRouter(),
+				embedFn: async () => null,
+				logger: quietLogger(),
+				hybridRecall: async (params: RecallParams) =>
+					response(params.query, [row("mem-1", "First evidence"), row("mem-2", "Second evidence")]),
+			},
+		);
+
+		expect(result.results.map((entry) => entry.id)).toEqual(["mem-1", "mem-2"]);
+		expect(result.meta.noHits).toBe(false);
+		expect(result.meta.totalReturned).toBe(2);
+		expect(result.aggregate).toMatchObject({
+			savedMemoryId: null,
+			saved: false,
+			deduped: false,
+			sourceMemoryIds: ["mem-1", "mem-2"],
+			stoppedReason: "synthesis_failed",
+			partial: true,
+		});
+		expect(result.aggregate?.message).toContain("synthesis");
 	});
 
 	it("dedupes repeated aggregate runs for the same evidence set", async () => {
@@ -1095,7 +1179,7 @@ memory:
 		expect(rows.pending_extract_count).toBe(1);
 	});
 
-	it("returns structured no-hit metadata when synthesis is unavailable", async () => {
+	it("returns structured no-hit metadata when aggregate recall has no evidence", async () => {
 		const result = await aggregateRecall(
 			{
 				query: "what happened",
@@ -1107,7 +1191,7 @@ memory:
 			{
 				router: null,
 				embedFn: async () => null,
-				hybridRecall: async (input: RecallParams) => response(input.query, [row("mem-1", "First evidence")]),
+				hybridRecall: async (input: RecallParams) => response(input.query, []),
 			},
 		);
 
@@ -1116,8 +1200,8 @@ memory:
 		expect(result.aggregate).toMatchObject({
 			saved: false,
 			savedMemoryId: null,
-			stoppedReason: "router_unavailable",
-			sourceMemoryIds: ["mem-1"],
+			stoppedReason: "no_evidence",
+			sourceMemoryIds: [],
 		});
 		expect(result.meta.timings.stages.map((stage) => stage.name)).toEqual(["aggregate_initial_recall"]);
 	});

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -245,6 +245,42 @@ function emptyAggregateResponse(
 	};
 }
 
+function degradedAggregateResponse(
+	params: RecallParams,
+	budget: AggregateRecallBudget,
+	queries: readonly string[],
+	evidence: readonly RecallResult[],
+	sourceMemoryIds: readonly string[],
+	stoppedReason: "router_unavailable" | "synthesis_failed",
+): RecallResponse {
+	const message =
+		stoppedReason === "router_unavailable"
+			? "Aggregate recall could not synthesize because the inference router is unavailable; returning retrieved evidence."
+			: "Aggregate recall synthesis failed; returning retrieved evidence.";
+	return {
+		results: [...evidence],
+		query: params.query,
+		method: "hybrid",
+		meta: {
+			totalReturned: evidence.length,
+			hasSupplementary: evidence.some((row) => row.supplementary === true),
+			noHits: evidence.length === 0,
+			timings: { totalMs: 0, stages: [] },
+		},
+		aggregate: {
+			savedMemoryId: null,
+			saved: false,
+			deduped: false,
+			budget,
+			queries,
+			sourceMemoryIds,
+			stoppedReason,
+			partial: true,
+			message,
+		},
+	};
+}
+
 function normalizeQuery(value: string): string {
 	return value.trim().replace(/\s+/g, " ").toLowerCase();
 }
@@ -759,6 +795,11 @@ export async function aggregateRecall(
 	if (!deps.router) {
 		const firstEvidence = uniqueEvidence(first.results);
 		const sourceMemoryIds = linkableSourceMemoryIds(firstEvidence);
+		if (firstEvidence.length > 0) {
+			return finish(
+				degradedAggregateResponse(params, budget, [params.query], firstEvidence, sourceMemoryIds, "router_unavailable"),
+			);
+		}
 		return finish(
 			emptyAggregateResponse(
 				params,
@@ -818,7 +859,7 @@ export async function aggregateRecall(
 	if (synthesized.usage) usageStages.push(synthesized.usage);
 	const answer = synthesized.answer;
 	if (!answer) {
-		return finish(emptyAggregateResponse(params, budget, queries, sourceMemoryIds, "synthesis_failed"));
+		return finish(degradedAggregateResponse(params, budget, queries, evidence, sourceMemoryIds, "synthesis_failed"));
 	}
 
 	const agentId = params.agentId ?? "default";

--- a/platform/daemon/src/mcp/tools.test.ts
+++ b/platform/daemon/src/mcp/tools.test.ts
@@ -720,6 +720,37 @@ describe("createMcpServer", () => {
 			expect(result.isError).toBeUndefined();
 			expect(result.content[0]?.text).toContain("Signet recall result");
 		});
+
+		it("forwards canonical recall context fields through signet_recall", async () => {
+			const cap: { body?: string } = {};
+			mockFetch(
+				200,
+				{
+					method: "hybrid",
+					results: [],
+					meta: { totalReturned: 0, hasSupplementary: false, noHits: true },
+				},
+				cap,
+			);
+
+			await callTool(server, "signet_recall", {
+				query: "What happened in this session?",
+				session_key: "session-b",
+				agent_id: "agent-b",
+				include_recalled: true,
+				scope: "session",
+			});
+
+			const body = JSON.parse(cap.body ?? "{}");
+			expect(body).toMatchObject({
+				query: "What happened in this session?",
+				limit: 10,
+				sessionKey: "session-b",
+				agentId: "agent-b",
+				includeRecalled: true,
+				scope: "session",
+			});
+		});
 	});
 
 	describe("signet_source_search", () => {

--- a/platform/daemon/src/mcp/tools.ts
+++ b/platform/daemon/src/mcp/tools.ts
@@ -857,6 +857,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 				session_key: z.string().optional().describe("Session key for per-context recall dedupe"),
 				agent_id: z.string().optional().describe("Agent ID for scoped recall"),
 				include_recalled: z.boolean().optional().describe("Include rows already recalled in this context"),
+				scope: z.enum(["global", "agent", "session"]).optional().describe("Recall scope constraint"),
 			}),
 		},
 		async ({
@@ -880,12 +881,13 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			session_key,
 			agent_id,
 			include_recalled,
+			scope,
 		}) => {
 			const result = await fetchDaemon<unknown>(baseUrl, "/api/memory/recall", {
 				method: "POST",
 				body: buildRecallRequestBody(query, {
 					keyword_query,
-					limit: limit ?? 10,
+					limit,
 					project,
 					type,
 					tags,
@@ -901,6 +903,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					sessionKey: session_key,
 					agentId: agent_id,
 					includeRecalled: include_recalled,
+					scope,
 				}),
 			});
 
@@ -945,6 +948,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 				session_key: z.string().optional().describe("Session key for per-context recall dedupe"),
 				agent_id: z.string().optional().describe("Agent ID for scoped recall"),
 				include_recalled: z.boolean().optional().describe("Include rows already recalled in this context"),
+				scope: z.enum(["global", "agent", "session"]).optional().describe("Recall scope constraint"),
 			}),
 		},
 		async ({
@@ -965,12 +969,13 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			session_key,
 			agent_id,
 			include_recalled,
+			scope,
 		}) => {
 			const result = await fetchDaemon<unknown>(baseUrl, "/api/memory/recall", {
 				method: "POST",
 				body: buildRecallRequestBody(query, {
 					keyword_query,
-					limit: limit ?? 10,
+					limit,
 					project,
 					type,
 					tags,
@@ -984,6 +989,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					sessionKey: session_key,
 					agentId: agent_id,
 					includeRecalled: include_recalled,
+					scope,
 				}),
 			});
 
@@ -1012,7 +1018,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 				method: "POST",
 				body: {
 					...buildRecallRequestBody(query, {
-						limit: limit ?? 10,
+						limit,
 						project,
 						sessionKey: session_key,
 						agentId: agent_id,

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -139,6 +139,8 @@ export interface RecallResponse {
 		queries: readonly string[];
 		sourceMemoryIds: readonly string[];
 		stoppedReason: "complete" | "no_evidence" | "router_unavailable" | "synthesis_failed";
+		partial?: boolean;
+		message?: string;
 		usage?: AggregateRecallUsage;
 	};
 	entities?: Array<{

--- a/surfaces/cli/src/commands/memory.ts
+++ b/surfaces/cli/src/commands/memory.ts
@@ -94,7 +94,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 	program
 		.command("recall <query>")
 		.description("Search memories using hybrid (vector + keyword) search")
-		.option("-l, --limit <n>", "Max results", Number.parseInt, 10)
+		.option("-l, --limit <n>", "Max results", Number.parseInt)
 		.option("--project <project>", "Filter by project")
 		.option("-t, --type <type>", "Filter by type")
 		.option("--tags <tags>", "Filter by tags (comma-separated)")


### PR DESCRIPTION
## Summary

Fixes #929 by moving recall request policy out of the CLI, MCP, and Pi connectors into the shared core recall module.

- Makes `@signet/core` the canonical owner of recall defaults, limit bounds, request aliases, context-agent precedence, and daemon request serialization.
- Aligns CLI, MCP, and Pi on the default limit of `10`; wires Pi `sessionKey`, `includeRecalled`, and `scope` through its tool contract.
- Preserves retrieved evidence when aggregate planning/synthesis cannot complete, returning explicit partial aggregate metadata rather than a false `noHits` result.
- Keeps genuine no-evidence aggregate recall empty and avoids saving any failed/degraded aggregate.
- Adds cross-surface request and aggregate-degradation regression coverage.

## Verification

- `platform/core`: recall tests (**13 passed**) and production build
- `platform/daemon`: aggregate-recall tests (**24 passed**), MCP recall tests (**71 passed**); one unrelated GraphIQ test fails identically on `origin/main`
- `surfaces/cli`: memory command tests (**7 passed**) and workspace build
- `integrations/pi/extension`: suite (**41 passed**), build, and typecheck
- Real pinned Pi runtime load: `@mariozechner/pi-coding-agent@0.54.1` loaded the built extension with `pi --extension … --help` without a daemon or model call
- Daemon production/dashboard build and Rust route parity check passed
- Changed-file Biome passed; existing `memory-search.ts` formatter/lint diagnostics reproduce unchanged on `origin/main`
- `git diff --check` passed

## Notes

The aggregate response includes `partial: true` and a user-visible explanation whenever evidence was found but aggregate synthesis was unavailable or failed. Consumers therefore retain usable evidence while knowing it is not a synthesized aggregate.
