### PR TITLE
fix(daemon-rs): add missing repair routes for rust daemon parity

### DIFF
--- a/platform/daemon-rs/crates/signet-daemon/src/routes/repair.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes/repair.rs
@@ -1337,24 +1337,16 @@ pub async fn re_embed(
 async fn pragma_integrity_check(
     state: &AppState,
 ) -> Result<(bool, Vec<String>), signet_core::CoreError> {
-    let value = state
+    let messages = state
         .pool
         .read(|conn| {
             let mut stmt = conn.prepare("PRAGMA integrity_check")?;
             let messages = stmt
                 .query_map([], |row| row.get::<_, String>(0))?
                 .collect::<rusqlite::Result<Vec<String>>>()?;
-            Ok(serde_json::json!(messages))
+            Ok(messages)
         })
         .await?;
-    let messages = value
-        .as_array()
-        .map(|rows| {
-            rows.iter()
-                .filter_map(|row| row.as_str().map(str::to_string))
-                .collect::<Vec<String>>()
-        })
-        .unwrap_or_default();
     let ok = messages.len() == 1 && messages[0] == "ok";
     Ok((ok, if ok { Vec::new() } else { messages }))
 }


### PR DESCRIPTION
## Summary

The rust daemon parity check fails on `main`: `bun test scripts/check-rust-daemon-parity.test.ts` reports 2 routes with status `missing` — `GET /api/repair/integrity-check` and `POST /api/repair/rebuild-indexes` — added to the TS daemon in c83b2fac (#893) but never ported to the Rust daemon. This PR implements both in `signet-daemon`, mounts them, and adds contract replay coverage so they classify as `native-rust-replay-proven` (same as sibling repair routes).

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] Other: `platform/daemon-rs` (Rust daemon)

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — N/A, no spec/dependency changes; route contract mirrors existing TS daemon behavior
- [x] Agent scoping verified on all new/changed data queries — handlers reuse existing scoped read-pool/access patterns of sibling repair routes
- [x] Input/config validation and bounds checks added — re-embed batch bounded at 200, matching TS
- [x] Error handling and fallback paths tested (no silent swallow) — errors surface as messages in the response contract, as in TS
- [x] Security checks applied to admin/mutation endpoints — same auth/mount context as existing `/api/repair/*` mutation routes
- [x] Docs updated for API/spec/status changes — parity manifest regenerated; no doc-facing API change (contract already existed in TS daemon)
- [x] Regression tests added for each bug fix — contract replay assertions for both endpoints
- [x] Lint/typecheck/tests pass locally

## Changes

- `platform/daemon-rs/crates/signet-daemon/src/routes/repair.rs` — new `integrity_check` handler (`PRAGMA integrity_check`, `{ok, messages}`) and `rebuild_indexes` handler (integrity check → FTS consistency check/rebuild → re-embed up to 200 missing embeddings; returns `{integrity, fts, embeddings, summary}`), matching the TS response shapes in `platform/daemon/src/repair-actions.ts`.
- `platform/daemon-rs/crates/signet-daemon/src/main.rs` — mounted both routes alongside the other `/api/repair/*` routes.
- `platform/daemon-rs/crates/signet-daemon/tests/contract_replay.rs` — replay coverage asserting 200 + full response shape for both endpoints.
- `platform/daemon-rs/contracts/route-parity.json` — regenerated via `--write`; missing routes now 0 (328 routes, all classified).

## Testing

- [x] `bun test scripts/check-rust-daemon-parity.test.ts` passes (5 pass, 0 fail — was 1 failing on main)
- [x] `bun scripts/check-rust-daemon-parity.ts` exits 0 (manifest current, 328 routes)
- [x] `cargo test -p signet-daemon --test contract_replay remaining_public_routes_have_contract_replay_coverage -- --include-ignored` passes (spawns the built daemon binary and exercises both endpoints over HTTP)
- [x] `cargo check -p signet-daemon --tests`, `cargo clippy -p signet-daemon --tests`, `cargo fmt` clean
- [x] Tested against running daemon (via contract replay harness)

## AI disclosure

- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- `cargo test -p signet-daemon --bin signet-daemon` has 5 pre-existing failures in `routes::pipeline::tests` that exist on `main` independently of this change (untouched module, no shared code/state).
- Minor intentional deviation, consistent with all existing Rust repair routes: the TS repair policy/audit-log gate is not ported (matches the established `repair.rs` pattern, e.g. `check_fts`).
