### PR TITLE
refactor(db): extract shared tableExists and add cross-daemon constant parity test

### DIFF
--- a/platform/daemon-rs/crates/signet-daemon/src/main.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/main.rs
@@ -2256,6 +2256,7 @@ async fn health(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
 
 // Queue backlog thresholds, mirroring the TS daemon's diagnostics constants
 // (platform/daemon/src/diagnostics.ts) so /health/ready gates on the same limits.
+// Cross-daemon parity is asserted by constants-parity.test.ts — update both sides.
 const QUEUE_MAX_DEPTH: i64 = 50;
 const QUEUE_MAX_DEAD_RATE: f64 = 0.01;
 const QUEUE_MAX_OLDEST_AGE_SEC: f64 = 300.0;

--- a/platform/daemon/src/constants-parity.test.ts
+++ b/platform/daemon/src/constants-parity.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Cross-daemon constant parity check.
+ *
+ * The Rust daemon re-declares queue threshold constants that originate in
+ * diagnostics.ts. This test asserts they stay in sync. If someone changes
+ * one side without the other, this test fails.
+ */
+
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	QUEUE_MAX_DEAD_RATE,
+	QUEUE_MAX_DEPTH,
+	QUEUE_MAX_OLDEST_AGE_SEC,
+} from "./diagnostics";
+
+const RUST_MAIN_RS = join(import.meta.dir, "..", "..", "daemon-rs", "crates", "signet-daemon", "src", "main.rs");
+const rustSource = readFileSync(RUST_MAIN_RS, "utf-8");
+
+function extractRustConst(type: "i64" | "f64", name: string): number {
+	const pattern = new RegExp(`const ${name}: ${type} = ([0-9.]+)`);
+	const match = rustSource.match(pattern);
+	if (!match?.[1]) throw new Error(`Rust constant ${name} not found in main.rs`);
+	return type === "i64" ? parseInt(match[1], 10) : parseFloat(match[1]);
+}
+
+test("QUEUE_MAX_DEPTH matches between TS and Rust", () => {
+	const rust = extractRustConst("i64", "QUEUE_MAX_DEPTH");
+	expect(QUEUE_MAX_DEPTH).toBe(rust);
+});
+
+test("QUEUE_MAX_DEAD_RATE matches between TS and Rust", () => {
+	const rust = extractRustConst("f64", "QUEUE_MAX_DEAD_RATE");
+	expect(QUEUE_MAX_DEAD_RATE).toBe(rust);
+});
+
+test("QUEUE_MAX_OLDEST_AGE_SEC matches between TS and Rust", () => {
+	const rust = extractRustConst("f64", "QUEUE_MAX_OLDEST_AGE_SEC");
+	expect(QUEUE_MAX_OLDEST_AGE_SEC).toBe(rust);
+});

--- a/platform/daemon/src/db-helpers.ts
+++ b/platform/daemon/src/db-helpers.ts
@@ -144,3 +144,14 @@ export function syncVecDeleteBySourceExceptHash(
 		// non-fatal
 	}
 }
+
+/**
+ * Check whether a table exists in the SQLite database.
+ * Replaces 8+ local copies across the daemon codebase.
+ */
+export function tableExists(
+	db: { prepare(sql: string): { get(...args: unknown[]): unknown } },
+	name: string,
+): boolean {
+	return db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(name) !== undefined;
+}

--- a/platform/daemon/src/graph-impact.ts
+++ b/platform/daemon/src/graph-impact.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ReadDb } from "./db-accessor";
+import { tableExists } from "./db-helpers";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -41,12 +42,7 @@ interface ImpactResult {
 // Table detection
 // ---------------------------------------------------------------------------
 
-function tableExists(db: ReadDb, name: string): boolean {
-	const row = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(name) as
-		| { name: string }
-		| undefined;
-	return row !== undefined;
-}
+
 
 // ---------------------------------------------------------------------------
 // Walk

--- a/platform/daemon/src/ontology-evidence.ts
+++ b/platform/daemon/src/ontology-evidence.ts
@@ -1,4 +1,5 @@
 import type { ReadDb } from "./db-accessor";
+import { tableExists } from "./db-helpers";
 
 export interface OntologyEvidenceRef {
 	readonly sourceKind: string | null;
@@ -66,10 +67,6 @@ function readString(record: Readonly<Record<string, unknown>>, key: string): str
 	if (typeof value !== "string") return null;
 	const trimmed = value.trim();
 	return trimmed.length > 0 ? trimmed : null;
-}
-
-function tableExists(db: ReadDb, name: string): boolean {
-	return db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(name) !== undefined;
 }
 
 function columnExists(db: ReadDb, table: string, column: string): boolean {

--- a/platform/daemon/src/session-transcripts.ts
+++ b/platform/daemon/src/session-transcripts.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 
 import { dirname, join } from "node:path";
 import { extractAnchorTerms } from "./anchor-terms";
 import { getDbAccessor } from "./db-accessor";
+import { tableExists as tableExistsIn } from "./db-helpers";
 import { logger } from "./logger";
 import { sanitizeFtsQuery } from "./memory-search";
 import {
@@ -90,10 +91,7 @@ function markBackfillCanonical(classification: TranscriptSessionKeyClassificatio
 
 function tableExists(name: string): boolean {
 	try {
-		return getDbAccessor().withReadDb((db) => {
-			const row = db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`).get(name);
-			return row !== undefined;
-		});
+		return getDbAccessor().withReadDb((db) => tableExistsIn(db, name));
 	} catch {
 		return false;
 	}

--- a/platform/daemon/src/subagent-context.ts
+++ b/platform/daemon/src/subagent-context.ts
@@ -1,4 +1,5 @@
 import type { ReadDb } from "./db-accessor";
+import { tableExists } from "./db-helpers";
 import { sanitizeFtsQuery } from "./memory-search";
 import { redactSecrets } from "./session-checkpoints";
 
@@ -45,11 +46,6 @@ function cleanString(value: unknown): string | undefined {
 	if (typeof value !== "string") return undefined;
 	const trimmed = value.trim();
 	return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function tableExists(db: ReadDb, name: string): boolean {
-	const row = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(name);
-	return row !== undefined && row !== null;
 }
 
 function columnExists(db: ReadDb, table: string, column: string): boolean {

--- a/platform/daemon/src/temporal-fallback.ts
+++ b/platform/daemon/src/temporal-fallback.ts
@@ -1,5 +1,6 @@
 import { extractAnchorTerms } from "./anchor-terms";
 import { getDbAccessor } from "./db-accessor";
+import { tableExists as tableExistsIn } from "./db-helpers";
 import { logger } from "./logger";
 import { escapeLike } from "./sql-utils";
 import { deriveThreadKey, deriveThreadLabel } from "./thread-heads";
@@ -30,10 +31,7 @@ export interface TemporalHit {
 
 function tableExists(name: string): boolean {
 	try {
-		return getDbAccessor().withReadDb((db) => {
-			const row = db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`).get(name);
-			return row !== undefined;
-		});
+		return getDbAccessor().withReadDb((db) => tableExistsIn(db, name));
 	} catch (err) {
 		logger.warn("temporal-fallback", "tableExists failed", {
 			table: name,

--- a/platform/daemon/src/temporal-recall.ts
+++ b/platform/daemon/src/temporal-recall.ts
@@ -1,5 +1,6 @@
 import type { AgentRosterReadPolicy, RecallTemporalMeta, TemporalFacet } from "@signet/core";
 import { getDbAccessor } from "./db-accessor";
+import { tableExists } from "./db-helpers";
 import { buildAgentScopeClause } from "./memory-access-scope";
 
 const DEFAULT_TEMPORAL_FACETS: readonly TemporalFacet[] = [
@@ -283,10 +284,6 @@ export function parseTemporalRecallIntent(params: {
 		mode: resolveTemporalMode(params.time?.mode, contentQuery),
 		facets: normalizeFacets(params.time?.facets),
 	};
-}
-
-function tableExists(db: { prepare(sql: string): { get(...args: unknown[]): unknown } }, name: string): boolean {
-	return db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(name) !== undefined;
 }
 
 function columnExists(

--- a/platform/daemon/src/transactions.ts
+++ b/platform/daemon/src/transactions.ts
@@ -7,7 +7,7 @@
  */
 
 import type { WriteDb } from "./db-accessor";
-import { syncVecDeleteBySourceExceptHash, syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "./db-helpers";
+import { syncVecDeleteBySourceExceptHash, syncVecDeleteBySourceId, syncVecInsert, tableExists, vectorToBlob } from "./db-helpers";
 import { cancelExtractionJobsForForgottenMemory } from "./pipeline/extraction-queue";
 
 // ---------------------------------------------------------------------------
@@ -237,11 +237,6 @@ export function insertHistoryEvent(
 		args.sessionId ?? null,
 		args.requestId ?? null,
 	);
-}
-
-function tableExists(db: WriteDb, name: string): boolean {
-	const row = db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(name);
-	return row !== null && row !== undefined;
 }
 
 function deleteAggregateMemorySourceLinks(db: WriteDb, memoryId: string): void {


### PR DESCRIPTION
## Summary

Replace 7 local `tableExists` copies with a shared utility in `db-helpers.ts`. Add a cross-daemon constant parity test that asserts TS and Rust queue threshold constants stay in sync.

AGENTS.md lines 139-147 explicitly require this: "Do not duplicate constants, maps, dependency types, config defaults across files. Extract a shared source of truth when duplication would create drift."

## Changes

- `db-helpers.ts`: add shared `tableExists(db, name)` function
- `graph-impact.ts`, `transactions.ts`, `ontology-evidence.ts`, `subagent-context.ts`, `temporal-recall.ts`: replace local function with import
- `session-transcripts.ts`, `temporal-fallback.ts`: delegate to shared function from `getDbAccessor()` wrapper
- `constants-parity.test.ts` (new): asserts `QUEUE_MAX_DEPTH`, `QUEUE_MAX_DEAD_RATE`, `QUEUE_MAX_OLDEST_AGE_SEC` match between TS `diagnostics.ts` and Rust `main.rs`
- `main.rs`: comment documenting the parity test link

## Type

- [x] `refactor`

## Packages affected

- [x] `@signet/daemon`
- [x] Other: `platform/daemon-rs` (comment only)

## PR Readiness

- [x] `bun run build` passes
- [x] `bun test platform/daemon/src/constants-parity.test.ts` passes (3/3)
- [x] `bun test platform/daemon/src/session-transcripts.test.ts` passes (2/2)
- [x] No behavior change; pure refactor + test addition

## AI disclosure

- [x] AI tools were used