### PR TITLE
fix(openclaw): restore plugin discovery and lifecycle hooks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -186,7 +186,7 @@
         "@types/node": "^22.0.0",
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.22",
+        "openclaw": ">=2026.7.1",
       },
       "optionalPeers": [
         "openclaw",

--- a/integrations/openclaw/connector/README.md
+++ b/integrations/openclaw/connector/README.md
@@ -1,4 +1,4 @@
-# @signetai/connector-openclaw
+# @signet/connector-openclaw
 
 Signet connector for OpenClaw (and its earlier names: clawdbot, moltbot).
 
@@ -6,20 +6,21 @@ Signet connector for OpenClaw (and its earlier names: clawdbot, moltbot).
 
 Unlike other harnesses, OpenClaw reads `~/.agents/AGENTS.md` directly, so no
 generated output file is needed. Instead, this connector patches the JSON
-config to point OpenClaw at the Signet workspace and enables memory hooks.
+config to point OpenClaw at the Signet workspace and configures the Signet
+memory plugin.
 
 ## Installation
 
 ```bash
-npm install @signetai/connector-openclaw
+npm install @signet/connector-openclaw
 # or
-bun add @signetai/connector-openclaw
+bun add @signet/connector-openclaw
 ```
 
 ## Usage
 
 ```typescript
-import { OpenClawConnector } from '@signetai/connector-openclaw';
+import { OpenClawConnector } from '@signet/connector-openclaw';
 
 const connector = new OpenClawConnector();
 await connector.install('~/.agents');
@@ -40,16 +41,22 @@ await connector.install('~/.agents');
   `OPENCLAW_HOME`, `CLAWDBOT_HOME`, `MOLDBOT_HOME`, `MOLTBOT_HOME`,
   `OPENCLAW_STATE_HOME`
 - Sets `agents.defaults.workspace` to point at `~/.agents`
-- Enables the `signet-memory` internal hook entry
+- Selects `signet-memory-openclaw` as the memory plugin and adds it to
+  `plugins.allow`
+- Grants the plugin the explicit `hooks.allowConversationAccess` permission
+  required for `agent_end` transcript capture
+- Disables OpenClaw's built-in memory search and the legacy `signet-memory`
+  internal hook to prevent duplicate memory paths
 - Creates hook handler files in `~/.agents/hooks/agent-memory/` for
-  `/remember`, `/recall`, and `/context` commands
+  legacy `/remember`, `/recall`, and `/context` command compatibility
 
 ## API
 
-### `install(basePath: string): Promise<InstallResult>`
+### `install(basePath: string, options?: OpenClawInstallOptions): Promise<InstallResult>`
 
 Install the connector. Patches all found OpenClaw config files and installs
-hook handler files.
+hook handler files. The plugin runtime is the default; pass
+`{ runtimePath: "legacy" }` only for an older OpenClaw runtime.
 
 ### `uninstall(basePath?: string): Promise<UninstallResult>`
 

--- a/integrations/openclaw/connector/src/index.ts
+++ b/integrations/openclaw/connector/src/index.ts
@@ -49,7 +49,19 @@ interface OpenClawConfigShape {
 		slots?: {
 			memory?: string;
 		};
-		entries?: Record<string, { enabled?: boolean; config?: Record<string, unknown> }>;
+		entries?: Record<
+			string,
+			{
+				enabled?: boolean;
+				config?: Record<string, unknown>;
+				hooks?: {
+					allowPromptInjection?: boolean;
+					allowConversationAccess?: boolean;
+					timeoutMs?: number;
+					timeouts?: Record<string, number>;
+				};
+			}
+		>;
 		load?: {
 			paths?: string[];
 		};
@@ -381,6 +393,12 @@ export class OpenClawConnector extends BaseConnector {
 					entries: {
 						"signet-memory-openclaw": {
 							enabled: true,
+							// OpenClaw 2026.7.1+ blocks raw-conversation hooks for
+							// non-bundled plugins unless the operator opts in. The
+							// plugin needs agent_end to persist the session transcript.
+							hooks: {
+								allowConversationAccess: true,
+							},
 							config: {
 								daemonUrl: "http://localhost:3850",
 							},
@@ -882,7 +900,7 @@ export class OpenClawConnector extends BaseConnector {
 
 	/**
 	 * Patch configs with plugin entry using the object format:
-	 * plugins.entries["signet-memory-openclaw"] = { enabled, config }
+	 * plugins.entries["signet-memory-openclaw"] = { enabled, hooks, config }
 	 *
 	 * Migrates:
 	 * - Legacy array-style plugins (["signet-memory"] -> { entries: {...} })

--- a/integrations/openclaw/connector/test/index.test.ts
+++ b/integrations/openclaw/connector/test/index.test.ts
@@ -94,6 +94,7 @@ describe("OpenClawConnector config patching", () => {
 		expect(patched.agents.defaults.workspace).toBe("/home/other/.agents");
 		expect(patched.hooks.internal.entries["signet-memory"].enabled).toBe(false);
 		expect(patched.plugins.entries["signet-memory-openclaw"].enabled).toBe(true);
+		expect(patched.plugins.entries["signet-memory-openclaw"].hooks.allowConversationAccess).toBe(true);
 
 		await connector.configureWorkspace(workspacePath);
 		const workspacePatched = JSON.parse(readFileSync(configPath, "utf-8"));
@@ -136,6 +137,59 @@ describe("OpenClawConnector config patching", () => {
 		expect(patched.agents.defaults.workspace).toBe("/home/old/.agents");
 		expect(patched.hooks.internal.entries["signet-memory"].enabled).toBe(false);
 		expect(patched.plugins.entries["signet-memory-openclaw"].enabled).toBe(true);
+		expect(patched.plugins.entries["signet-memory-openclaw"].hooks.allowConversationAccess).toBe(true);
+	});
+
+	it("grants required conversation access while preserving existing hook policy", async () => {
+		const configPath = join(tmpRoot, "openclaw.json");
+		const hookBasePath = join(tmpRoot, "agents");
+
+		writeFileSync(
+			configPath,
+			JSON.stringify(
+				{
+					plugins: {
+						entries: {
+							"signet-memory-openclaw": {
+								enabled: true,
+								hooks: {
+									allowPromptInjection: false,
+									allowConversationAccess: false,
+									timeoutMs: 45_000,
+									timeouts: { before_prompt_build: 12_000 },
+								},
+								config: {
+									daemonUrl: "http://localhost:9999",
+									customSetting: "preserved",
+								},
+							},
+						},
+					},
+				},
+				null,
+				2,
+			),
+		);
+		process.env.OPENCLAW_CONFIG_PATH = configPath;
+
+		await new OpenClawConnector().install(hookBasePath, {
+			configureWorkspace: false,
+			configureHooks: false,
+			runtimePath: "plugin",
+		});
+
+		const patched = JSON.parse(readFileSync(configPath, "utf-8"));
+		const entry = patched.plugins.entries["signet-memory-openclaw"];
+		expect(entry.hooks).toEqual({
+			allowPromptInjection: false,
+			allowConversationAccess: true,
+			timeoutMs: 45_000,
+			timeouts: { before_prompt_build: 12_000 },
+		});
+		expect(entry.config).toEqual({
+			daemonUrl: "http://localhost:3850",
+			customSetting: "preserved",
+		});
 	});
 
 	it("does not execute non-JSON expressions while parsing configs", async () => {

--- a/integrations/openclaw/memory-adapter/openclaw.plugin.json
+++ b/integrations/openclaw/memory-adapter/openclaw.plugin.json
@@ -1,6 +1,19 @@
 {
 	"id": "signet-memory-openclaw",
 	"kind": "memory",
+	"contracts": {
+		"tools": [
+			"memory_search",
+			"memory_get",
+			"memory_store",
+			"memory_list",
+			"memory_modify",
+			"memory_forget",
+			"session_search",
+			"mcp_server_list",
+			"mcp_server_call"
+		]
+	},
 	"uiHints": {
 		"daemonUrl": {
 			"label": "Daemon URL",

--- a/integrations/openclaw/memory-adapter/package.json
+++ b/integrations/openclaw/memory-adapter/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^22.0.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.22"
+    "openclaw": ">=2026.7.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/integrations/openclaw/memory-adapter/src/index.test.ts
+++ b/integrations/openclaw/memory-adapter/src/index.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { OpenClawPluginApi, OpenClawToolDefinition } from "./openclaw-types";
+import type { OpenClawMemoryCapability, OpenClawPluginApi, OpenClawToolDefinition } from "./openclaw-types";
 
 // Import directly; tests seed a real temporary SIGNET_PATH instead of
 // mocking @signet/core globally, which otherwise leaks into later suites.
@@ -79,10 +79,12 @@ function createMockApi(overrides?: Partial<OpenClawPluginApi>): {
 	hooks: Map<string, HookHandler>;
 	hookOptions: Map<string, unknown>;
 	tools: Array<ToolRegistration>;
+	memoryCapabilities: Array<OpenClawMemoryCapability>;
 } {
 	const hooks = new Map<string, HookHandler>();
 	const hookOptions = new Map<string, unknown>();
 	const tools: Array<ToolRegistration> = [];
+	const memoryCapabilities: Array<OpenClawMemoryCapability> = [];
 
 	const api: OpenClawPluginApi = {
 		pluginConfig: {
@@ -104,6 +106,9 @@ function createMockApi(overrides?: Partial<OpenClawPluginApi>): {
 		registerTool(tool) {
 			tools.push(tool);
 		},
+		registerMemoryCapability(capability) {
+			memoryCapabilities.push(capability);
+		},
 		registerCli() {
 			// no-op
 		},
@@ -122,7 +127,7 @@ function createMockApi(overrides?: Partial<OpenClawPluginApi>): {
 		...overrides,
 	};
 
-	return { api, hooks, hookOptions, tools };
+	return { api, hooks, hookOptions, tools, memoryCapabilities };
 }
 
 beforeEach(() => {
@@ -1791,43 +1796,99 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 		expect(getHits("/api/hooks/session-checkpoint-extract")).toBe(1);
 	});
 
-	it("does not reregister marketplace proxy tools on refresh", async () => {
+	it("keeps marketplace access behind the manifest-declared static tools", async () => {
 		const { api, tools } = createMockApi();
 		signetPlugin.register(api);
 		await Bun.sleep(0);
 
-		const firstNames = tools.map((tool) => tool.name);
-		const proxyNames = firstNames.filter((name) => name.startsWith("signet_server_a_"));
-		expect(proxyNames).toEqual(["signet_server_a_alpha", "signet_server_a_beta"]);
+		expect(tools.some((tool) => tool.name.startsWith("signet_server_a_"))).toBeFalse();
+		expect(getHits("/api/marketplace/mcp/tools")).toBe(0);
+		expect(getHits("/api/marketplace/mcp/policy")).toBe(0);
 
-		await flushIntervals();
-		await Bun.sleep(0);
-
-		const refreshedNames = tools.map((tool) => tool.name);
-		expect(refreshedNames.filter((name) => name === "signet_server_a_alpha").length).toBe(1);
-		expect(refreshedNames.filter((name) => name === "signet_server_a_beta").length).toBe(1);
-		expect(refreshedNames.some((name) => name === "signet_server_a_alpha_2")).toBeFalse();
-		expect(refreshedNames.some((name) => name === "signet_server_a_beta_2")).toBeFalse();
+		const listTool = tools.find((tool) => tool.name === "mcp_server_list");
+		expect(listTool).toBeDefined();
+		await listTool?.execute("tool-call-1", {});
+		expect(getHits("/api/marketplace/mcp/tools")).toBe(1);
 	});
 });
 
 describe("registration guard (#422)", () => {
+	it("registers a side-effect-free memory capability in discovery mode", async () => {
+		const { api, hooks, tools, memoryCapabilities } = createMockApi({ registrationMode: "discovery" });
+		signetPlugin.register(api);
+		await Bun.sleep(0);
+
+		expect(memoryCapabilities).toHaveLength(1);
+		expect(tools).toHaveLength(0);
+		expect(hooks.size).toBe(0);
+		expect(registeredServices).toHaveLength(0);
+		expect(intervalCallbacks).toHaveLength(0);
+		expect(getHits("/health")).toBe(0);
+
+		const promptBuilder = memoryCapabilities[0]?.promptBuilder;
+		expect(promptBuilder).toBeDefined();
+		expect(
+			promptBuilder?.({ availableTools: new Set(["memory_search", "memory_get"]), citationsMode: "auto" }),
+		).toContain("## Signet Memory");
+		expect(promptBuilder?.({ availableTools: new Set(), citationsMode: "auto" })).toEqual([]);
+	});
+
+	it("registers static tools without runtime side effects in tool-discovery mode", async () => {
+		const { api, hooks, tools, memoryCapabilities } = createMockApi({ registrationMode: "tool-discovery" });
+		signetPlugin.register(api);
+		await Bun.sleep(0);
+
+		expect(tools.map((tool) => tool.name)).toEqual([
+			"memory_search",
+			"memory_store",
+			"session_search",
+			"memory_get",
+			"memory_list",
+			"memory_modify",
+			"memory_forget",
+			"mcp_server_list",
+			"mcp_server_call",
+		]);
+		expect(memoryCapabilities).toHaveLength(0);
+		expect(hooks.size).toBe(0);
+		expect(registeredServices).toHaveLength(0);
+		expect(intervalCallbacks).toHaveLength(0);
+		expect(getHits("/health")).toBe(0);
+	});
+
 	it("skips tools, hooks, and services when registrationMode is cli-metadata", () => {
-		const { api, hooks, tools } = createMockApi({ registrationMode: "cli-metadata" });
+		const { api, hooks, tools, memoryCapabilities } = createMockApi({ registrationMode: "cli-metadata" });
 		signetPlugin.register(api);
 
 		expect(tools.length).toBe(0);
 		expect(hooks.size).toBe(0);
 		expect(registeredServices.length).toBe(0);
+		expect(memoryCapabilities).toHaveLength(0);
 	});
 
 	it("registers normally when registrationMode is full", () => {
-		const { api, hooks, tools } = createMockApi({ registrationMode: "full" });
+		const { api, hooks, tools, memoryCapabilities } = createMockApi({ registrationMode: "full" });
 		signetPlugin.register(api);
 
 		expect(tools.length).toBeGreaterThan(0);
 		expect(hooks.size).toBeGreaterThan(0);
 		expect(registeredServices.length).toBeGreaterThan(0);
+		expect(memoryCapabilities).toHaveLength(1);
+	});
+
+	it("supports discovery, tool discovery, then full registration in one process", () => {
+		const discovery = createMockApi({ registrationMode: "discovery" });
+		signetPlugin.register(discovery.api);
+		const toolDiscovery = createMockApi({ registrationMode: "tool-discovery" });
+		signetPlugin.register(toolDiscovery.api);
+		const full = createMockApi({ registrationMode: "full" });
+		signetPlugin.register(full.api);
+
+		expect(discovery.memoryCapabilities).toHaveLength(1);
+		expect(toolDiscovery.tools.length).toBeGreaterThan(0);
+		expect(full.memoryCapabilities).toHaveLength(1);
+		expect(full.tools.length).toBeGreaterThan(0);
+		expect(full.hooks.size).toBeGreaterThan(0);
 	});
 
 	it("publishes an OpenClaw diagnostics heartbeat after startup health succeeds", async () => {
@@ -1837,7 +1898,13 @@ describe("registration guard (#422)", () => {
 
 		expect(lastHeartbeatBody).toMatchObject({
 			pluginVersion: "test-plugin",
-			hooksRegistered: ["before_prompt_build", "before_agent_start", "agent_end", "before_compaction", "after_compaction"],
+			hooksRegistered: [
+				"before_prompt_build",
+				"before_agent_start",
+				"agent_end",
+				"before_compaction",
+				"after_compaction",
+			],
 		});
 	});
 

--- a/integrations/openclaw/memory-adapter/src/index.ts
+++ b/integrations/openclaw/memory-adapter/src/index.ts
@@ -327,38 +327,6 @@ interface MarketplaceContextOptions {
 	readonly channel?: string;
 }
 
-interface MarketplaceExposurePolicy {
-	readonly mode: "compact" | "hybrid" | "expanded";
-	readonly maxExpandedTools: number;
-	readonly maxSearchResults: number;
-	readonly updatedAt: string;
-}
-
-function sanitizeToolSegment(value: string): string {
-	const normalized = value
-		.trim()
-		.toLowerCase()
-		.replace(/[^a-z0-9]+/g, "_")
-		.replace(/^_+|_+$/g, "");
-	return normalized.length > 0 ? normalized : "tool";
-}
-
-function buildProxyToolName(used: Set<string>, serverId: string, toolName: string): string {
-	const base = `signet_${sanitizeToolSegment(serverId)}_${sanitizeToolSegment(toolName)}`;
-	if (!used.has(base)) {
-		used.add(base);
-		return base;
-	}
-
-	let suffix = 2;
-	while (used.has(`${base}_${suffix}`)) {
-		suffix += 1;
-	}
-	const uniqueName = `${base}_${suffix}`;
-	used.add(uniqueName);
-	return uniqueName;
-}
-
 // ============================================================================
 // Shared fetch helper
 // ============================================================================
@@ -854,19 +822,6 @@ export async function marketplaceToolCall(
 		},
 		timeout: WRITE_TIMEOUT,
 	});
-}
-
-async function getMarketplaceExposurePolicy(
-	options: MarketplaceContextOptions = {},
-): Promise<MarketplaceExposurePolicy | null> {
-	const daemonUrl = options.daemonUrl || DEFAULT_DAEMON_URL;
-	const result = await daemonFetch<{ policy?: MarketplaceExposurePolicy }>(daemonUrl, "/api/marketplace/mcp/policy", {
-		timeout: READ_TIMEOUT,
-	});
-	if (!result?.policy) {
-		return null;
-	}
-	return result.policy;
 }
 
 // ============================================================================
@@ -1392,99 +1347,6 @@ function buildCompactionEventKey(
 	return parts.join("|");
 }
 
-async function registerMarketplaceProxyTools(
-	api: OpenClawPluginApi,
-	options: MarketplaceContextOptions,
-	knownNames: Set<string>,
-	proxyNameByToolKey: Map<string, string>,
-): Promise<{ registeredNow: number; total: number }> {
-	const [catalog, policy] = await Promise.all([
-		marketplaceToolList({ ...options, refresh: true }),
-		getMarketplaceExposurePolicy(options),
-	]);
-	if (!catalog || catalog.tools.length === 0) {
-		return { registeredNow: 0, total: knownNames.size };
-	}
-
-	const mode = policy?.mode ?? "hybrid";
-	const maxExpandedTools =
-		typeof policy?.maxExpandedTools === "number" && Number.isFinite(policy.maxExpandedTools)
-			? Math.max(0, Math.min(100, Math.round(policy.maxExpandedTools)))
-			: 12;
-
-	const sortedTools = [...catalog.tools].sort((a, b) =>
-		`${a.serverId}:${a.toolName}`.localeCompare(`${b.serverId}:${b.toolName}`),
-	);
-
-	const candidates =
-		mode === "expanded" ? sortedTools : mode === "hybrid" ? sortedTools.slice(0, maxExpandedTools) : [];
-
-	const usedNames = new Set<string>([
-		"memory_search",
-		"memory_store",
-		"memory_get",
-		"memory_list",
-		"memory_modify",
-		"memory_forget",
-		"mcp_server_list",
-		"mcp_server_call",
-	]);
-	for (const name of knownNames) {
-		usedNames.add(name);
-	}
-
-	let registeredNow = 0;
-	for (const tool of candidates) {
-		const toolKey = `${tool.serverId}\0${tool.toolName}`;
-		let proxyName = proxyNameByToolKey.get(toolKey);
-		if (!proxyName) {
-			proxyName = buildProxyToolName(usedNames, tool.serverId, tool.toolName);
-			proxyNameByToolKey.set(toolKey, proxyName);
-		} else {
-			usedNames.add(proxyName);
-		}
-		if (knownNames.has(proxyName)) {
-			continue;
-		}
-
-		api.registerTool(
-			{
-				name: proxyName,
-				label: `Signet ${tool.serverName} • ${tool.toolName}`,
-				description:
-					tool.description && tool.description.trim().length > 0
-						? tool.description
-						: `Proxy tool ${tool.toolName} from MCP server ${tool.serverName}`,
-				parameters: Type.Object({}, { additionalProperties: true }),
-				async execute(_toolCallId, params) {
-					const args = typeof params === "object" && params !== null ? (params as Record<string, unknown>) : {};
-
-					try {
-						const result = await marketplaceToolCall(tool.serverId, tool.toolName, args, options);
-						if (!result?.success) {
-							return textResult(`Tool server call failed: ${result?.error ?? "unknown error"}`, {
-								error: result?.error ?? "unknown",
-							});
-						}
-
-						const text = typeof result.result === "string" ? result.result : JSON.stringify(result.result, null, 2);
-						return textResult(text, { result: result.result });
-					} catch (err) {
-						return textResult(`Tool server call failed: ${String(err)}`, {
-							error: String(err),
-						});
-					}
-				},
-			},
-			{ name: proxyName },
-		);
-		knownNames.add(proxyName);
-		registeredNow += 1;
-	}
-
-	return { registeredNow, total: knownNames.size };
-}
-
 // ============================================================================
 // Plugin definition (OpenClaw register(api) pattern)
 // ============================================================================
@@ -1505,6 +1367,33 @@ function writeRegistered(value: boolean): void {
 	Reflect.set(globalThis, REG_KEY, value);
 }
 
+function buildMemoryPromptSection({
+	availableTools,
+	citationsMode,
+}: {
+	availableTools: Set<string>;
+	citationsMode?: "auto" | "on" | "off";
+}): string[] {
+	const hasSearch = availableTools.has("memory_search");
+	const hasGet = availableTools.has("memory_get");
+	if (!hasSearch && !hasGet) return [];
+
+	const guidance = hasSearch
+		? `Before answering about prior work, decisions, dates, people, preferences, or todos, use memory_search${
+				hasGet ? "; then use memory_get when an exact memory must be inspected" : ""
+			}. Signet results are scoped and provenance-backed; if recall is inconclusive, say that you checked.`
+		: "When a request points to a specific remembered item, use memory_get before answering. Signet results are scoped and provenance-backed; if the lookup is inconclusive, say that you checked.";
+
+	const lines = ["## Signet Memory", guidance];
+	if (citationsMode === "off") {
+		lines.push("Do not expose source identifiers or provenance in the reply unless the user asks for them.");
+	} else {
+		lines.push("Include provenance when it materially helps the user verify a recalled claim.");
+	}
+	lines.push("");
+	return lines;
+}
+
 const signetPlugin = {
 	id: "signet-memory-openclaw",
 	name: "Signet Memory",
@@ -1514,16 +1403,23 @@ const signetPlugin = {
 
 	register(api: OpenClawPluginApi): void {
 		const mode = api.registrationMode ?? "full";
-		// Only "full" should register runtime behavior. setup-only,
-		// setup-runtime, and cli-metadata are metadata/setup passes.
-		if (mode !== "full") {
-			if (!["cli-metadata", "setup-only", "setup-runtime"].includes(mode)) {
-				api.logger.warn(`signet-memory: skipping runtime registration for unknown mode=${mode}`);
-			}
+
+		// Discovery must remain side-effect free: OpenClaw runs it while
+		// inspecting plugin capabilities, before a live runtime exists.
+		if (mode === "discovery") {
+			api.registerMemoryCapability({ promptBuilder: buildMemoryPromptSection });
 			return;
 		}
 
-		if (readRegistered()) {
+		if (["cli-metadata", "setup-only", "setup-runtime"].includes(mode)) {
+			return;
+		}
+		if (mode !== "full" && mode !== "tool-discovery") {
+			api.logger.warn(`signet-memory: skipping runtime registration for unknown mode=${mode}`);
+			return;
+		}
+
+		if (mode === "full" && readRegistered()) {
 			api.logger.warn("signet-memory: register() called twice with non-cli mode, skipping duplicate");
 			return;
 		}
@@ -1537,20 +1433,21 @@ const signetPlugin = {
 				workspace: process.env.SIGNET_WORKSPACE ?? process.cwd(),
 				channel: process.env.SIGNET_CHANNEL,
 			};
-			writeRegistered(true);
-			claimed = true;
+			if (mode === "full") {
+				api.registerMemoryCapability({ promptBuilder: buildMemoryPromptSection });
+				writeRegistered(true);
+				claimed = true;
+			}
 
 			// Request normalization — two layers for coverage: fetch wrapper +
-			// SDK prototype patch.
-			const removeFetchSanitizer = installFetchSanitizer();
-			const removeSdkSanitizer = installSdkSanitizer();
+			// SDK prototype patch. Tool discovery is deliberately side-effect free.
+			const removeFetchSanitizer = mode === "full" ? installFetchSanitizer() : () => {};
+			const removeSdkSanitizer = mode === "full" ? installSdkSanitizer() : () => {};
 
 			// Instance-scoped health state (safe for multi-register)
 			let daemonReachable = true;
 			let knownPid: number | null = null;
 			let healthTimer: ReturnType<typeof setInterval> | null = null;
-			let marketplaceProxyTimer: ReturnType<typeof setInterval> | null = null;
-			const marketplaceProxyNames = new Set<string>();
 			const hooksRegistered = [
 				"before_prompt_build",
 				"before_agent_start",
@@ -1584,22 +1481,26 @@ const signetPlugin = {
 				}
 			};
 
-			api.logger.info(`signet-memory: registered (daemon: ${daemonUrl})`);
+			if (mode === "full") {
+				api.logger.info(`signet-memory: registered (daemon: ${daemonUrl})`);
+			}
 
 			// Fire-and-forget startup health check (also captures initial PID)
-			getDaemonPid(daemonUrl).then((pid) => {
-				daemonReachable = pid !== null;
-				knownPid = pid;
-				if (!daemonReachable) {
-					healthError = `daemon unreachable at ${daemonUrl}; memory hooks are disabled until Signet is healthy`;
-					api.logger.warn(
-						`signet-memory: daemon unreachable at ${daemonUrl}. Memory hooks are disabled until daemon health recovers; run \`signet status\` or \`signet doctor\` for diagnostics.`,
-					);
-				} else {
-					healthError = null;
-					void sendHeartbeat();
-				}
-			});
+			if (mode === "full") {
+				getDaemonPid(daemonUrl).then((pid) => {
+					daemonReachable = pid !== null;
+					knownPid = pid;
+					if (!daemonReachable) {
+						healthError = `daemon unreachable at ${daemonUrl}; memory hooks are disabled until Signet is healthy`;
+						api.logger.warn(
+							`signet-memory: daemon unreachable at ${daemonUrl}. Memory hooks are disabled until daemon health recovers; run \`signet status\` or \`signet doctor\` for diagnostics.`,
+						);
+					} else {
+						healthError = null;
+						void sendHeartbeat();
+					}
+				});
+			}
 
 			// ==================================================================
 			// Tools
@@ -2078,25 +1979,10 @@ const signetPlugin = {
 				{ name: "mcp_server_call" },
 			);
 
-			const marketplaceProxyNameByToolKey = new Map<string, string>();
-
-			const refreshMarketplaceProxyTools = (): Promise<void> =>
-				registerMarketplaceProxyTools(api, opts, marketplaceProxyNames, marketplaceProxyNameByToolKey)
-					.then((result) => {
-						if (result.registeredNow > 0) {
-							api.logger.info(
-								`signet-memory: registered ${result.registeredNow} marketplace proxy tools (${result.total} total)`,
-							);
-						}
-					})
-					.catch((error) => {
-						api.logger.warn(`signet-memory: failed to register marketplace proxy tools: ${String(error)}`);
-					});
-
-			void refreshMarketplaceProxyTools();
-			marketplaceProxyTimer = setInterval(() => {
-				void refreshMarketplaceProxyTools();
-			}, 15_000);
+			// OpenClaw uses this pass to build the tool registry exposed to a
+			// harness such as Codex. Static tools are enough; hooks, services,
+			// timers, marketplace refreshes, and daemon probes belong to full mode.
+			if (mode === "tool-discovery") return;
 
 			// ==================================================================
 			// Lifecycle hooks
@@ -2552,7 +2438,9 @@ const signetPlugin = {
 								void sendHeartbeat();
 							} else {
 								healthError = `daemon became unreachable at ${daemonUrl}; memory hooks are disabled`;
-								api.logger.warn("signet-memory: daemon became unreachable; memory hooks are disabled until health recovers");
+								api.logger.warn(
+									"signet-memory: daemon became unreachable; memory hooks are disabled until health recovers",
+								);
 							}
 						} else if (ok) {
 							void sendHeartbeat();
@@ -2575,10 +2463,6 @@ const signetPlugin = {
 						if (healthTimer) {
 							clearInterval(healthTimer);
 							healthTimer = null;
-						}
-						if (marketplaceProxyTimer) {
-							clearInterval(marketplaceProxyTimer);
-							marketplaceProxyTimer = null;
 						}
 					} finally {
 						// Always release the process-level registration guard so a

--- a/integrations/openclaw/memory-adapter/src/openclaw-types.ts
+++ b/integrations/openclaw/memory-adapter/src/openclaw-types.ts
@@ -70,7 +70,23 @@ export type PluginHookAfterCompactionEvent = {
 // Plugin API
 // ============================================================================
 
-export type PluginRegistrationMode = "full" | "setup-only" | "setup-runtime" | "cli-metadata";
+export type PluginRegistrationMode =
+	| "full"
+	| "discovery"
+	| "tool-discovery"
+	| "setup-only"
+	| "setup-runtime"
+	| "cli-metadata";
+
+export interface OpenClawMemoryCapability {
+	promptBuilder?: (params: {
+		availableTools: Set<string>;
+		citationsMode?: "auto" | "on" | "off";
+		agentId?: string;
+		agentSessionKey?: string;
+		sandboxed?: boolean;
+	}) => string[];
+}
 
 export interface OpenClawPluginApi {
 	readonly pluginConfig?: Record<string, unknown>;
@@ -90,6 +106,7 @@ export interface OpenClawPluginApi {
 			optional?: boolean;
 		},
 	): void;
+	registerMemoryCapability(capability: OpenClawMemoryCapability): void;
 	registerCli(fn: (ctx: { program: unknown }) => void, opts?: { commands?: readonly string[] }): void;
 	registerService(service: {
 		id: string;

--- a/scripts/check-publish-manifests.test.ts
+++ b/scripts/check-publish-manifests.test.ts
@@ -635,7 +635,7 @@ describe("check-publish-manifests", () => {
 		expect(rootPackage.scripts?.["build:deps"]).toStartWith("bun run --filter '@signet/sdk' build && ");
 		expect(adapter.dependencies?.["@signet/sdk"]).toBeUndefined();
 		expect(adapter.devDependencies?.["@signet/sdk"]).toBeDefined();
-		expect(adapter.peerDependencies?.openclaw).toBe(">=2026.5.22");
+		expect(adapter.peerDependencies?.openclaw).toBe(">=2026.7.1");
 		expect(adapter.peerDependenciesMeta?.openclaw?.optional).toBe(true);
 
 		const workspacePackages = collectWorkspacePackages([adapterFile, sdkFile, coreFile]);

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -683,7 +683,10 @@ For each config found, verify:
    OpenClaw's native memory is still active alongside Signet.
 2. **`signet-memory-openclaw` plugin is registered** — Check
    `plugins.entries["signet-memory-openclaw"].enabled` is `true`.
-3. **No dual runtime paths** — Either the plugin path OR legacy
+3. **Conversation access is explicitly allowed** — Check
+   `plugins.entries["signet-memory-openclaw"].hooks.allowConversationAccess`
+   is `true`; OpenClaw otherwise blocks Signet's `agent_end` capture hook.
+4. **No dual runtime paths** — Either the plugin path OR legacy
    hooks should be active, not both.
 
 If any check fails, fix with:
@@ -695,6 +698,7 @@ Report the OpenClaw integration status in the audit summary:
 ```
 openclaw integration: [healthy/dual-system detected/not installed]
 memorySearch disabled: [yes/no/n/a]
+conversation access allowed: [yes/no/n/a]
 runtime path: [plugin/legacy/n/a]
 ```
 

--- a/surfaces/cli/src/features/sync.test.ts
+++ b/surfaces/cli/src/features/sync.test.ts
@@ -270,12 +270,19 @@ describe("syncTemplates openclaw migration", () => {
 				hooks?: { internal?: { entries?: Record<string, { enabled?: boolean }> } };
 				plugins?: {
 					slots?: { memory?: string };
-					entries?: Record<string, { enabled?: boolean }>;
+					entries?: Record<
+						string,
+						{
+							enabled?: boolean;
+							hooks?: { allowConversationAccess?: boolean };
+						}
+					>;
 				};
 			};
 			expect(patched.hooks?.internal?.entries?.["signet-memory"]?.enabled).toBe(false);
 			expect(patched.plugins?.slots?.memory).toBe("signet-memory-openclaw");
 			expect(patched.plugins?.entries?.["signet-memory-openclaw"]?.enabled).toBe(true);
+			expect(patched.plugins?.entries?.["signet-memory-openclaw"]?.hooks?.allowConversationAccess).toBe(true);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/web/marketing/public/skill.md
+++ b/web/marketing/public/skill.md
@@ -518,6 +518,7 @@ of what Signet is supposed to fix.
        "entries": {
          "signet-memory-openclaw": {
            "enabled": true,
+           "hooks": { "allowConversationAccess": true },
            "config": { "daemonUrl": "http://localhost:3850" }
          }
        }
@@ -531,10 +532,14 @@ of what Signet is supposed to fix.
    }
    ```
 
-3. Sets `memorySearch.enabled: false` — this is the critical line
+3. Sets `hooks.allowConversationAccess: true` for the Signet plugin.
+   OpenClaw requires this explicit opt-in before a non-bundled plugin
+   can receive the `agent_end` transcript used for session extraction.
+
+4. Sets `memorySearch.enabled: false` — this is the critical line
    that disables OpenClaw's built-in memory search.
 
-4. Sets the workspace to `~/.agents/` so OpenClaw reads identity
+5. Sets the workspace to `~/.agents/` so OpenClaw reads identity
    files directly (no generated output file needed).
 
 **Two runtime paths:**
@@ -574,14 +579,18 @@ cat <config_path> | grep -A1 memorySearch
 # 3. Check if the plugin is registered
 cat <config_path> | grep -A3 signet-memory-openclaw
 
-# 4. If either check fails, re-run setup
+# 4. Check conversation access for the session-end capture hook
+cat <config_path> | grep -A4 allowConversationAccess
+
+# 5. If any check fails, re-run setup
 signet setup --harness openclaw
 ```
 
 If `signet setup` can't find the config, you may need to manually
 patch `openclaw.json` with the JSON shown above. The critical fields
 are `plugins.entries["signet-memory-openclaw"].enabled: true` and
-`agents.defaults.memorySearch.enabled: false`.
+`plugins.entries["signet-memory-openclaw"].hooks.allowConversationAccess:
+true`, plus `agents.defaults.memorySearch.enabled: false`.
 
 ---
 


### PR DESCRIPTION
## Summary

Restore Signet plugin discovery, static tool exposure, and lifecycle capture
with OpenClaw 2026.7.1+.

OpenClaw now performs side-effect-free discovery passes, requires exact tool
contracts, and blocks conversation-aware hooks for non-bundled plugins unless
the operator explicitly grants access. Without those contracts, Signet's tools
and `agent_end` transcript capture were absent from the active runtime.

## Changes

- handle OpenClaw `discovery` and `tool-discovery` registration modes without runtime side effects
- declare the exact static tool contract required by OpenClaw
- expose marketplace integrations through `mcp_server_list` and `mcp_server_call`
- remove asynchronous dynamic tool registration that OpenClaw could not activate
- grant the explicit conversation-access permission required by `agent_end`
- preserve existing OpenClaw hook policy while patching configuration
- bump the optional OpenClaw peer dependency to `>=2026.7.1`
- update connector, onboarding, and marketing documentation
- add regression coverage for discovery, lifecycle registration, configuration migration, and tool contracts

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [x] `@signet/web`
- [ ] `predictor`
- [x] Other: `@signetai/signet-memory-openclaw`

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

The unchecked readiness item is due only to the repository-wide
`bun run lint` baseline. Typecheck, focused tests, builds, and scoped Biome
checks all pass. This change adds no data queries, admin routes, or mutation
endpoints; the corresponding scoping and security checks are N/A after review.

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

The configuration patch is idempotent and preserves existing hook policy.
Rust parity is N/A because this change is limited to the OpenClaw integration.
Rollback consists of reverting this commit; older OpenClaw runtimes remain
supported through the explicit legacy runtime path.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Additional validation:

- 157 focused tests pass across the adapter, connector, CLI sync, and publish-manifest suites
- `@signetai/signet-memory-openclaw` build passes
- `@signet/connector-openclaw` build passes
- scoped Biome check passes on all seven touched TypeScript files
- real OpenClaw 2026.7.2 runtime validation confirms all 9 declared tools, all 5 lifecycle hooks, the Signet service, and `allowConversationAccess: true`
- `bun run lint` reports 2,329 pre-existing repository-wide formatting errors
- a live Signet daemon was not required because this regression concerns OpenClaw plugin registration

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

OpenClaw requires exact `contracts.tools` declarations and blocks
conversation-aware hooks for non-bundled plugins unless
`plugins.entries.signet-memory-openclaw.hooks.allowConversationAccess` is
explicitly enabled.

The previous asynchronous marketplace expansion logged tools as registered,
but those tools were absent from OpenClaw's runtime registry. Marketplace
access now remains behind the declared `mcp_server_list` and
`mcp_server_call` tools.
