### PR TITLE
refactor(recall): align runtime request contracts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -274,6 +274,7 @@
       "name": "@signet/sdk",
       "version": "0.147.23",
       "devDependencies": {
+        "@signet/core": "workspace:*",
         "@types/react": "^19.0.0",
         "react": "^19.0.0",
       },

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -96,7 +96,10 @@ const { results, query, method, meta } = await signet.recall("language preferenc
   limit: 10,
   time: { start: "2026-05-13T00:00:00Z", end: "2026-05-14T00:00:00Z" },
   expand: true,
+  scope: "world:alpha",
 });
+// Omitted limits are sent as 10; request limits are bounded to 1..100
+// scope is an exact daemon memory-scope string; use agentId/sessionKey for isolation
 // meta.timings?.stages — daemon-side recall stages and durations
 // meta.temporal — resolved temporal window when date recall is active
 ```
@@ -122,8 +125,11 @@ const result = await signet.recall("language preferences", {
 // result.meta.timings — present when the daemon returns recall stage timings
 ```
 
-`minScore` is applied client-side by the SDK after the daemon returns recall
-results. This keeps the API contract honest while preserving compatibility for
+`recall()` and `recallOrThrow()` use the canonical Signet request builder, so
+they share default, bound, alias, omission, session, agent, scope, and aggregate
+semantics with runtime integrations. `minScore` is applied client-side by the
+SDK after the daemon returns recall results and is never included in daemon
+JSON. This keeps the API contract honest while preserving compatibility for
 existing SDK callers that already rely on score thresholding.
 
 Explicit aggregate recall is available through the same method:
@@ -1806,7 +1812,8 @@ try {
   const { results, meta } = await signet.recallOrThrow("user preferences", {
     type: "preference",
     limit: 5,
-    minScore: 0.5,
+    minScore: 0.5, // applied locally; never sent to the daemon
+    agentId: "my-agent",
   });
   // Guaranteed to have at least one result
   // meta.totalReturned matches the filtered result count

--- a/docs/api/memory.md
+++ b/docs/api/memory.md
@@ -585,11 +585,21 @@ permission. For the full execution model, see [Hybrid Recall](../MEMORY.md#hybri
   "saveAggregate": true,
   "agentId": "alice",
   "sessionKey": "session-uuid",
-  "includeRecalled": false
+  "includeRecalled": false,
+  "scope": "world:alpha"
 }
 ```
 
-Only `query` is required.
+Only `query` is required. Canonical clients serialize an omitted `limit` as
+`10` and bound request values to `1..100`. The search backend currently applies
+a separate execution cap of 50. `scope` is an exact daemon memory-scope string,
+not a selector for agent or session isolation. Use `agentId` and `sessionKey`
+for those behaviors. Domain clients may use namespaced values such as
+`world:alpha`.
+
+Canonical clients also accept snake-case aliases for compatibility but emit the
+camel-case wire fields shown above. False opt-in flags are omitted, except an
+explicit `saveAggregate: false`, which is significant for recall-only callers.
 
 Exact date phrases in `query`, such as `2026/05/13`, `2026-05-13`, or
 `May 13 2026`, activate temporal recall automatically. A date-only query
@@ -701,9 +711,11 @@ can still use aggregate mode by sending `saveAggregate: false`. Repeating the
 same agent/query/project/budget/source-memory set returns the same saved memory
 through the aggregate idempotency key.
 
-When aggregate synthesis cannot complete, the response is a no-hit recall
-shape with `results: []` and `aggregate.stoppedReason` set to `no_evidence`,
-`router_unavailable`, or `synthesis_failed`.
+When no evidence exists, aggregate recall returns a no-hit shape with
+`results: []` and `aggregate.stoppedReason: "no_evidence"`. When planning or
+synthesis is unavailable after evidence was retrieved, recall returns that
+evidence with `aggregate.partial: true`, a diagnostic message, and
+`aggregate.stoppedReason` set to `router_unavailable` or `synthesis_failed`.
 
 When the routed inference provider reports token or billing metadata,
 `aggregate.usage` includes planning/synthesis totals plus per-stage target,
@@ -770,6 +782,19 @@ auth:
 ```
 
 No additional permission level is required beyond `recall`.
+
+#### Client request compatibility
+
+| Client | Canonical default/bounds | Scope surface | Score threshold | Intentional override |
+|---|---|---|---|---|
+| Core, SDK | `10`, `1..100` | Any daemon scope string | SDK `minScore` is local | None |
+| OpenClaw | `10`, `1..100` | Not exposed by its tool schema | `min_score` is local | Product schema exposes a focused subset |
+| OpenCode | `10`, `1..100` | Exact daemon scope string | `min_score` is local | None |
+| Hermes Agent | `10`, `1..100` | Agent opt-in through `agent_scoped` | `score_min` is local | Product schema exposes a focused subset |
+| Unreal | NPC default `6`, `1..20` | World/player namespace | Not exposed | Always sets `includeRecalled: true` |
+
+The versioned cross-runtime request vectors live in
+`platform/core/contracts/recall-request-v1.json`.
 
 ### GET /api/memory/search
 

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -10,6 +10,8 @@ Integrates Signet's memory system into Hermes Agent as a native plugin.
 - Registers memory tools: `memory_search`, `memory_store`, `memory_get`, `memory_list`, `memory_modify`, `memory_forget`, `signet_session_search`, `recall`, and `remember`
 - Backs up existing provider configuration for safe uninstallation
 - Uses content hashing to detect when the plugin needs updating
+- Uses Signet's canonical recall request defaults and bounds (`10`, `1..100`); `score_min` remains a client-side filter
+- Preserves Hermes's explicit `agent_scoped` opt-in instead of silently restricting shared recall
 
 ## Installation
 

--- a/integrations/hermes-agent/connector/hermes-plugin/__init__.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/__init__.py
@@ -61,7 +61,7 @@ MEMORY_SEARCH_SCHEMA = {
                     "and timeframe when known; avoid diagnostic keyword soup."
                 ),
             },
-            "limit": {"type": "integer", "description": "Max results to return (default 10, max 50)."},
+            "limit": {"type": "integer", "description": "Max results to request (default 10, request max 100)."},
             "project": {"type": "string", "description": "Optional project path filter."},
             "type": {"type": "string", "description": "Filter by memory type."},
             "tags": {"type": "string", "description": "Filter by tags, comma-separated."},
@@ -910,7 +910,7 @@ class SignetMemoryProvider(MemoryProvider):
 
             result = self._client.recall(
                 query,
-                limit=_as_int(search_args.get("limit"), 10, minimum=1, maximum=50),
+                limit=search_args.get("limit"),
                 project=str(search_args.get("project", "") or ""),
                 memory_type=str(search_args.get("type", "") or ""),
                 tags=str(search_args.get("tags", "") or ""),

--- a/integrations/hermes-agent/connector/hermes-plugin/client.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/client.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import ipaddress
 import urllib.error
@@ -33,6 +34,59 @@ _TRUSTED_ORIGINS_ENV = "SIGNET_TRUSTED_DAEMON_ORIGINS"
 def _sanitize(value: str) -> str:
     """Strip leading/trailing whitespace and embedded newlines from env values."""
     return value.strip().replace("\r", "").replace("\n", "")
+
+
+def _normalize_recall_limit(value: Any) -> int:
+    """Match the versioned Signet recall request contract."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 10
+    if isinstance(value, float) and not math.isfinite(value):
+        return 10
+    return min(100, max(1, math.trunc(value)))
+
+
+def _build_recall_request_body(
+    query: str,
+    *,
+    limit: Any = None,
+    project: str = "",
+    memory_type: str = "",
+    tags: str = "",
+    who: str = "",
+    pinned: Optional[bool] = None,
+    importance_min: Optional[float] = None,
+    since: str = "",
+    until: str = "",
+    keyword_query: str = "",
+    aggregate: bool = False,
+    aggregate_budget: str = "",
+    save_aggregate: Optional[bool] = None,
+    agent_id: str = "",
+) -> Dict[str, Any]:
+    """Build canonical daemon JSON for the options exposed by Hermes."""
+    body: Dict[str, Any] = {"query": query, "limit": _normalize_recall_limit(limit)}
+    optional_strings = {
+        "project": project,
+        "type": memory_type,
+        "tags": tags,
+        "who": who,
+        "since": since,
+        "until": until,
+        "keywordQuery": keyword_query,
+        "agentId": agent_id,
+    }
+    body.update({key: value for key, value in optional_strings.items() if value})
+    if pinned is True:
+        body["pinned"] = True
+    if importance_min is not None:
+        body["importance_min"] = importance_min
+    if aggregate is True:
+        body["aggregate"] = True
+    if aggregate_budget in ("small", "medium", "large"):
+        body["aggregateBudget"] = aggregate_budget
+    if isinstance(save_aggregate, bool):
+        body["saveAggregate"] = save_aggregate
+    return body
 
 
 def _normalize_base_url(raw: str, source: str) -> str:
@@ -397,7 +451,7 @@ class SignetClient:
         self,
         query: str,
         *,
-        limit: int = 10,
+        limit: Any = None,
         project: str = "",
         memory_type: str = "",
         tags: str = "",
@@ -414,36 +468,23 @@ class SignetClient:
         agent_scoped: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """Search memories via hybrid recall."""
-        body: Dict[str, Any] = {
-            "query": query,
-            "limit": limit,
-        }
-        if project:
-            body["project"] = project
-        if memory_type:
-            body["type"] = memory_type
-        if tags:
-            body["tags"] = tags
-        if who:
-            body["who"] = who
-        if pinned is not None:
-            body["pinned"] = pinned
-        if importance_min is not None:
-            body["importance_min"] = importance_min
-        if since:
-            body["since"] = since
-        if until:
-            body["until"] = until
-        if keyword_query:
-            body["keywordQuery"] = keyword_query
-        if aggregate:
-            body["aggregate"] = True
-            if aggregate_budget in ("small", "medium", "large"):
-                body["aggregateBudget"] = aggregate_budget
-            if save_aggregate is not None:
-                body["saveAggregate"] = save_aggregate
-        if agent_scoped and self._agent_id:
-            body["agentId"] = self._agent_id
+        body = _build_recall_request_body(
+            query,
+            limit=limit,
+            project=project,
+            memory_type=memory_type,
+            tags=tags,
+            who=who,
+            pinned=pinned,
+            importance_min=importance_min,
+            since=since,
+            until=until,
+            keyword_query=keyword_query,
+            aggregate=aggregate,
+            aggregate_budget=aggregate_budget,
+            save_aggregate=save_aggregate,
+            agent_id=self._agent_id if agent_scoped else "",
+        )
 
         result = self._post("/api/memory/recall", body, timeout=_RECALL_TIMEOUT_SECS)
         if (

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -805,6 +805,51 @@ describe("Hermes Agent bundled plugin", () => {
 		expect(plugin).toContain('if tool_name == "signet_session_search"');
 	});
 
+	it("matches the shared recall request vectors exposed by Hermes", () => {
+		const clientPath = join(import.meta.dir, "hermes-plugin", "client.py");
+		const contractPath = join(import.meta.dir, "../../../platform/core/contracts/recall-request-v1.json");
+		const script = String.raw`
+import importlib.util
+import json
+import sys
+
+spec = importlib.util.spec_from_file_location("signet_client", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+with open(sys.argv[2], encoding="utf-8") as handle:
+    contract = json.load(handle)
+
+mapping = {
+    "project": "project",
+    "type": "memory_type",
+    "tags": "tags",
+    "who": "who",
+    "pinned": "pinned",
+    "importance_min": "importance_min",
+    "since": "since",
+    "until": "until",
+    "keywordQuery": "keyword_query",
+    "aggregate": "aggregate",
+    "aggregateBudget": "aggregate_budget",
+    "saveAggregate": "save_aggregate",
+}
+for vector in contract["vectors"]:
+    if "hermes" not in vector["clients"]:
+        continue
+    options = vector["options"]
+    kwargs = {"limit": options.get("limit")}
+    kwargs.update({target: options[source] for source, target in mapping.items() if source in options})
+    actual = module._build_recall_request_body(vector["query"], **kwargs)
+    if actual != vector["expected"]:
+        raise AssertionError(f"{vector['name']}: {actual!r} != {vector['expected']!r}")
+`;
+		const result = spawnSync(process.env.PYTHON?.trim() || "python3", ["-c", script, clientPath, contractPath], {
+			encoding: "utf-8",
+		});
+
+		expect(result.status, result.stderr || result.stdout).toBe(0);
+	});
+
 	it("returns Signet tool schemas before daemon initialization", () => {
 		const plugin = readFileSync(join(import.meta.dir, "hermes-plugin", "__init__.py"), "utf-8");
 		const schemasFn = plugin.slice(plugin.indexOf("def get_tool_schemas"), plugin.indexOf("def handle_tool_call"));
@@ -1061,8 +1106,8 @@ describe("Hermes Agent bundled plugin", () => {
 	it("does not force agentId into explicit recall requests", () => {
 		const client = readFileSync(join(import.meta.dir, "hermes-plugin", "client.py"), "utf-8");
 
-		expect(client).toContain("if agent_scoped and self._agent_id:");
-		expect(client).toContain('body["agentId"] = self._agent_id');
+		expect(client).toContain('agent_id=self._agent_id if agent_scoped else ""');
+		expect(client).toContain('"agentId": agent_id');
 		expect(client).not.toContain('"agentId": self._agent_id,\\n        }\\n        if min_score');
 	});
 

--- a/integrations/openclaw/memory-adapter/src/index.test.ts
+++ b/integrations/openclaw/memory-adapter/src/index.test.ts
@@ -8,7 +8,7 @@ import type { OpenClawMemoryCapability, OpenClawPluginApi, OpenClawToolDefinitio
 // mocking @signet/core globally, which otherwise leaks into later suites.
 const signet = await import("./index");
 const signetPlugin = signet.default;
-const { memoryStore, sessionSearch, _resetRegistration, _sanitization, cleanupTimedMap } = signet;
+const { memoryRecall, memoryStore, sessionSearch, _resetRegistration, _sanitization, cleanupTimedMap } = signet;
 
 type HookHandler = (event: Record<string, unknown>, ctx: unknown) => Promise<unknown> | unknown;
 type ToolRegistration = OpenClawToolDefinition;
@@ -323,6 +323,14 @@ afterEach(async () => {
 });
 
 describe("signet-memory-openclaw lifecycle hooks", () => {
+	it("delegates recall defaults and bounds to the canonical request builder", async () => {
+		await memoryRecall("default recall", { daemonUrl: "http://daemon.test" });
+		expect(lastMemoryRecallBody).toEqual({ query: "default recall", limit: 10 });
+
+		await memoryRecall("bounded recall", { daemonUrl: "http://daemon.test", limit: 5000 });
+		expect(lastMemoryRecallBody).toEqual({ query: "bounded recall", limit: 100 });
+	});
+
 	it("forwards session_search requests to the transcript search endpoint", async () => {
 		const result = await sessionSearch("Juniper trunk ports", {
 			daemonUrl: "http://daemon.test",

--- a/integrations/openclaw/memory-adapter/src/index.ts
+++ b/integrations/openclaw/memory-adapter/src/index.ts
@@ -632,7 +632,7 @@ export async function memoryRecall(
 	const result = await daemonFetch<unknown>(daemonUrl, "/api/memory/recall", {
 		method: "POST",
 		body: buildRecallRequestBody(query, {
-			limit: options.limit ?? 10,
+			limit: options.limit,
 			type: options.type,
 			aggregate: options.aggregate,
 			aggregateBudget: options.aggregateBudget,

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -1,6 +1,6 @@
 # OpenCode Integration
 
-Signet connector for [OpenCode](https://github.com/opencode-ai/opencode).
+Signet connector for [OpenCode](https://github.com/anomalyco/opencode).
 
 ## What It Does
 
@@ -13,6 +13,7 @@ Integrates Signet's memory system with OpenCode via its plugin system.
 - Migrates away from the legacy `memory.mjs` approach on install/uninstall
 - Preserves JSONC comments and formatting while applying targeted config updates
 - Uses the daemon's authenticated remote MCP endpoint for remote-only installs
+- Normalizes `memory_search` requests through Signet's canonical recall contract; `scope` accepts an exact daemon memory scope such as `world:alpha`
 
 ## Installation
 

--- a/integrations/opencode/plugin/src/tools.test.ts
+++ b/integrations/opencode/plugin/src/tools.test.ts
@@ -3,6 +3,28 @@ import type { DaemonClient } from "./daemon-client.js";
 import { createTools } from "./tools.js";
 
 describe("createTools", () => {
+	test("memory_search uses canonical defaults, bounds, and scope serialization", async () => {
+		const captured: unknown[] = [];
+		const client = {
+			post: async (_path: string, body: unknown) => {
+				captured.push(body);
+				return { results: [], meta: { totalReturned: 0, hasSupplementary: false, noHits: true } };
+			},
+		} as unknown as DaemonClient;
+		const tools = createTools(client);
+
+		await tools.memory_search.execute({ query: "default recall" }, {} as never);
+		await tools.memory_search.execute(
+			{ query: "bounded recall", limit: 5000, scope: "world:alpha", include_recalled: true },
+			{} as never,
+		);
+
+		expect(captured).toEqual([
+			{ query: "default recall", limit: 10 },
+			{ query: "bounded recall", limit: 100, scope: "world:alpha", includeRecalled: true },
+		]);
+	});
+
 	test("session_search posts to the transcript search endpoint", async () => {
 		let capturedPath = "";
 		let capturedBody: unknown;

--- a/integrations/opencode/plugin/src/tools.ts
+++ b/integrations/opencode/plugin/src/tools.ts
@@ -26,28 +26,26 @@ async function searchMemory(
 		readonly type?: string;
 		readonly min_score?: number;
 		readonly aggregate?: boolean;
-		readonly aggregate_budget?: string;
+		readonly aggregate_budget?: "small" | "medium" | "large";
 		readonly save_aggregate?: boolean;
 		readonly session_key?: string;
 		readonly agent_id?: string;
 		readonly include_recalled?: boolean;
+		readonly scope?: string;
 	},
 ): Promise<string> {
-	const aggregateBudget =
-		args.aggregate_budget === "medium" || args.aggregate_budget === "large" || args.aggregate_budget === "small"
-			? args.aggregate_budget
-			: undefined;
 	const result = await client.post<unknown>(
 		"/api/memory/recall",
 		buildRecallRequestBody(args.query, {
-			limit: args.limit ?? 10,
+			limit: args.limit,
 			type: args.type,
 			aggregate: args.aggregate,
-			aggregate_budget: aggregateBudget,
+			aggregate_budget: args.aggregate_budget,
 			save_aggregate: args.save_aggregate,
 			sessionKey: args.session_key,
 			agentId: args.agent_id,
 			includeRecalled: args.include_recalled,
+			scope: args.scope,
 		}),
 		READ_TIMEOUT,
 	);
@@ -123,11 +121,12 @@ export function createTools(client: DaemonClient): Record<string, ReturnType<typ
 				type: tool.schema.string().optional().describe("Filter by memory type"),
 				min_score: tool.schema.number().optional().describe("Minimum relevance score threshold"),
 				aggregate: tool.schema.boolean().optional().describe("Synthesize an aggregate answer from recall evidence"),
-				aggregate_budget: tool.schema.string().optional().describe("Aggregate recall budget: small, medium, or large"),
+				aggregate_budget: tool.schema.enum(["small", "medium", "large"]).optional().describe("Aggregate recall budget"),
 				save_aggregate: tool.schema.boolean().optional().describe("Save aggregate answers as memories"),
 				session_key: tool.schema.string().optional().describe("Session key for per-context recall dedupe"),
 				agent_id: tool.schema.string().optional().describe("Agent ID for scoped recall"),
 				include_recalled: tool.schema.boolean().optional().describe("Include rows already recalled in this context"),
+				scope: tool.schema.string().optional().describe("Exact daemon memory scope to recall"),
 			},
 			async execute(args): Promise<string> {
 				return searchMemory(client, args);

--- a/integrations/unreal/plugin/SignetUnreal/README.md
+++ b/integrations/unreal/plugin/SignetUnreal/README.md
@@ -45,7 +45,10 @@ scope = world:{WorldId}:player:{PlayerId}
 ```
 
 World-scoped memories are recalled for the NPC in that world. Player-scoped
-memories are recalled only when a `PlayerId` is provided.
+memories are recalled only when a `PlayerId` is provided. NPC recall deliberately
+overrides the generic client policy: it defaults to 6 results, clamps requests
+to 1-20, and sets `includeRecalled: true` because repeated context can remain
+relevant across gameplay turns.
 
 ## Event IDs
 

--- a/integrations/unreal/plugin/SignetUnreal/Source/SignetUnrealRuntime/Private/SignetAsyncActions.cpp
+++ b/integrations/unreal/plugin/SignetUnreal/Source/SignetUnrealRuntime/Private/SignetAsyncActions.cpp
@@ -2,11 +2,11 @@
 
 #include "Json.h"
 #include "Misc/Guid.h"
+#include "SignetRecallRequest.h"
 #include "SignetUnrealClient.h"
 
 namespace
 {
-constexpr int32 DefaultRecallLimit = 6;
 
 FString BuildNpcIdentitySourceId(const FSignetNpcIdentity& Identity)
 {
@@ -87,17 +87,6 @@ TSharedRef<FJsonObject> MakeRememberBody(
 	Body->SetStringField(TEXT("visibility"), TEXT("global"));
 	Body->SetNumberField(TEXT("importance"), FMath::Clamp(Importance, 0.0f, 1.0f));
 	Body->SetBoolField(TEXT("pinned"), bPinned);
-	return Body;
-}
-
-TSharedRef<FJsonObject> MakeRecallBody(const FString& AgentId, const FString& Scope, const FString& Query, int32 Limit)
-{
-	TSharedRef<FJsonObject> Body = MakeShared<FJsonObject>();
-	Body->SetStringField(TEXT("query"), Query);
-	Body->SetStringField(TEXT("agentId"), AgentId);
-	Body->SetStringField(TEXT("scope"), Scope);
-	Body->SetNumberField(TEXT("limit"), FMath::Clamp(Limit, 1, 20));
-	Body->SetBoolField(TEXT("includeRecalled"), true);
 	return Body;
 }
 
@@ -275,7 +264,7 @@ USignetRecallNpcContextAsync* USignetRecallNpcContextAsync::RecallNpcContext(
 	Action->WorldId = InWorldId;
 	Action->PlayerId = InPlayerId;
 	Action->Situation = InSituation;
-	Action->Limit = InLimit > 0 ? InLimit : DefaultRecallLimit;
+	Action->Limit = InLimit > 0 ? InLimit : SignetRecallRequest::DefaultNpcLimit;
 	Action->RegisterWithGameInstance(WorldContextObject);
 	return Action;
 }
@@ -318,7 +307,7 @@ void USignetRecallNpcContextAsync::RecallScope(const FString& Scope, TFunction<v
 		*AgentId,
 		*Situation
 	);
-	TSharedRef<FJsonObject> Body = MakeRecallBody(AgentId, Scope, Query, Limit);
+	TSharedRef<FJsonObject> Body = SignetRecallRequest::BuildNpcBody(AgentId, Scope, Query, Limit);
 
 	FSignetUnrealClient::PostJson(
 		TEXT("/api/memory/recall"),

--- a/integrations/unreal/plugin/SignetUnreal/Source/SignetUnrealRuntime/Private/SignetRecallRequest.cpp
+++ b/integrations/unreal/plugin/SignetUnreal/Source/SignetUnrealRuntime/Private/SignetRecallRequest.cpp
@@ -1,0 +1,20 @@
+#include "SignetRecallRequest.h"
+
+namespace SignetRecallRequest
+{
+TSharedRef<FJsonObject> BuildNpcBody(
+	const FString& AgentId,
+	const FString& Scope,
+	const FString& Query,
+	int32 Limit
+)
+{
+	TSharedRef<FJsonObject> Body = MakeShared<FJsonObject>();
+	Body->SetStringField(TEXT("query"), Query);
+	Body->SetStringField(TEXT("agentId"), AgentId);
+	Body->SetStringField(TEXT("scope"), Scope);
+	Body->SetNumberField(TEXT("limit"), FMath::Clamp(Limit, MinimumNpcLimit, MaximumNpcLimit));
+	Body->SetBoolField(TEXT("includeRecalled"), true);
+	return Body;
+}
+}

--- a/integrations/unreal/plugin/SignetUnreal/Source/SignetUnrealRuntime/Private/SignetRecallRequest.h
+++ b/integrations/unreal/plugin/SignetUnreal/Source/SignetUnrealRuntime/Private/SignetRecallRequest.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+
+namespace SignetRecallRequest
+{
+inline constexpr int32 DefaultNpcLimit = 6;
+inline constexpr int32 MinimumNpcLimit = 1;
+inline constexpr int32 MaximumNpcLimit = 20;
+
+TSharedRef<FJsonObject> BuildNpcBody(
+	const FString& AgentId,
+	const FString& Scope,
+	const FString& Query,
+	int32 Limit
+);
+}

--- a/integrations/unreal/plugin/SignetUnreal/Source/SignetUnrealRuntime/Private/Tests/SignetRecallRequestTest.cpp
+++ b/integrations/unreal/plugin/SignetUnreal/Source/SignetUnrealRuntime/Private/Tests/SignetRecallRequestTest.cpp
@@ -1,0 +1,63 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "SignetRecallRequest.h"
+
+#include "HAL/PlatformMisc.h"
+#include "Json.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FSignetRecallRequestContractTest,
+	"Signet.Recall.RequestContract",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter
+)
+
+bool FSignetRecallRequestContractTest::RunTest(const FString& Parameters)
+{
+	(void)Parameters;
+	const FString ContractPath = FPlatformMisc::GetEnvironmentVariable(TEXT("SIGNET_RECALL_CONTRACT_VECTORS"));
+	if (ContractPath.IsEmpty())
+	{
+		AddWarning(TEXT("Skipping Signet recall contract test because SIGNET_RECALL_CONTRACT_VECTORS is not set"));
+		return true;
+	}
+
+	FString ContractJson;
+	if (!FFileHelper::LoadFileToString(ContractJson, *ContractPath))
+	{
+		AddError(FString::Printf(TEXT("Unable to read recall contract: %s"), *ContractPath));
+		return false;
+	}
+
+	TSharedPtr<FJsonObject> Contract;
+	const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(ContractJson);
+	if (!FJsonSerializer::Deserialize(Reader, Contract) || !Contract.IsValid())
+	{
+		AddError(TEXT("Recall contract is not valid JSON"));
+		return false;
+	}
+
+	const TSharedPtr<FJsonObject> Overrides = Contract->GetObjectField(TEXT("overrides"));
+	const TSharedPtr<FJsonObject> Unreal = Overrides->GetObjectField(TEXT("unreal"));
+	TestEqual(TEXT("Default NPC limit matches the shared contract"), SignetRecallRequest::DefaultNpcLimit, static_cast<int32>(Unreal->GetNumberField(TEXT("defaultLimit"))));
+	TestEqual(TEXT("Minimum NPC limit matches the shared contract"), SignetRecallRequest::MinimumNpcLimit, static_cast<int32>(Unreal->GetNumberField(TEXT("minimumLimit"))));
+	TestEqual(TEXT("Maximum NPC limit matches the shared contract"), SignetRecallRequest::MaximumNpcLimit, static_cast<int32>(Unreal->GetNumberField(TEXT("maximumLimit"))));
+	TestTrue(TEXT("NPC recalls include rows recalled earlier in the context"), Unreal->GetBoolField(TEXT("includeRecalled")));
+
+	const TSharedRef<FJsonObject> Body = SignetRecallRequest::BuildNpcBody(
+		TEXT("npc-1"),
+		TEXT("world:alpha"),
+		TEXT("What happened here?"),
+		5000
+	);
+	TestEqual(TEXT("Query is serialized"), Body->GetStringField(TEXT("query")), FString(TEXT("What happened here?")));
+	TestEqual(TEXT("Agent is serialized"), Body->GetStringField(TEXT("agentId")), FString(TEXT("npc-1")));
+	TestEqual(TEXT("Custom world scope is preserved"), Body->GetStringField(TEXT("scope")), FString(TEXT("world:alpha")));
+	TestEqual(TEXT("NPC limit is clamped"), static_cast<int32>(Body->GetNumberField(TEXT("limit"))), SignetRecallRequest::MaximumNpcLimit);
+	TestTrue(TEXT("includeRecalled is serialized"), Body->GetBoolField(TEXT("includeRecalled")));
+	return true;
+}
+
+#endif

--- a/integrations/unreal/plugin/SignetUnreal/Source/SignetUnrealRuntime/Public/SignetAsyncActions.h
+++ b/integrations/unreal/plugin/SignetUnreal/Source/SignetUnrealRuntime/Public/SignetAsyncActions.h
@@ -115,7 +115,7 @@ private:
 	FString Situation;
 
 	UPROPERTY()
-	int32 Limit = 6;
+	int32 Limit = 0;
 
 	TArray<FSignetMemoryBlock> PendingMemories;
 	void RecallScope(const FString& Scope, TFunction<void(const FSignetOperationResult&)> Done);

--- a/integrations/unreal/plugin/__tests__/manifest.test.ts
+++ b/integrations/unreal/plugin/__tests__/manifest.test.ts
@@ -4,6 +4,9 @@ import { join } from "node:path";
 
 const root = join(import.meta.dir, "..");
 const pluginRoot = join(root, "SignetUnreal");
+const recallContract = JSON.parse(
+	readFileSync(join(root, "../../../platform/core/contracts/recall-request-v1.json"), "utf8"),
+);
 
 function read(relativePath: string): string {
 	return readFileSync(join(pluginRoot, relativePath), "utf8");
@@ -31,11 +34,25 @@ describe("Signet Unreal plugin", () => {
 			"Source/SignetUnrealRuntime/Public/SignetUnrealTypes.h",
 			"Source/SignetUnrealRuntime/Private/SignetAgentComponent.cpp",
 			"Source/SignetUnrealRuntime/Private/SignetAsyncActions.cpp",
+			"Source/SignetUnrealRuntime/Private/SignetRecallRequest.cpp",
+			"Source/SignetUnrealRuntime/Private/SignetRecallRequest.h",
+			"Source/SignetUnrealRuntime/Private/Tests/SignetRecallRequestTest.cpp",
 			"Source/SignetUnrealRuntime/Private/SignetUnrealClient.cpp",
 			"Source/SignetUnrealRuntime/Private/SignetUnrealRuntimeModule.cpp",
 		]) {
 			expect(existsSync(join(pluginRoot, relativePath))).toBe(true);
 		}
+	});
+
+	it("keeps intentional NPC recall overrides aligned with the shared contract", () => {
+		const requestHeader = read("Source/SignetUnrealRuntime/Private/SignetRecallRequest.h");
+		const unreal = recallContract.overrides.unreal;
+		expect(requestHeader).toContain(`DefaultNpcLimit = ${unreal.defaultLimit}`);
+		expect(requestHeader).toContain(`MinimumNpcLimit = ${unreal.minimumLimit}`);
+		expect(requestHeader).toContain(`MaximumNpcLimit = ${unreal.maximumLimit}`);
+		expect(read("Source/SignetUnrealRuntime/Private/SignetRecallRequest.cpp")).toContain(
+			'Body->SetBoolField(TEXT("includeRecalled"), true)',
+		);
 	});
 
 	it("uses the existing Signet daemon API surface", () => {

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -33,6 +33,7 @@
     "test": "bun test"
   },
   "devDependencies": {
+    "@signet/core": "workspace:*",
     "@types/react": "^19.0.0",
     "react": "^19.0.0"
   },

--- a/libs/sdk/src/__tests__/client.test.ts
+++ b/libs/sdk/src/__tests__/client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { Server } from "bun";
 import { SignetClient } from "../index.js";
+import type { SdkRecallOptions } from "../types.js";
 
 interface RecordedRequest {
 	readonly method: string;
@@ -80,6 +81,19 @@ describe("SignetClient", () => {
 			type: "preference",
 			importance: 0.9,
 		});
+	});
+
+	test("recall() matches the shared request vectors exposed by the SDK", async () => {
+		const contract = await Bun.file(
+			new URL("../../../../platform/core/contracts/recall-request-v1.json", import.meta.url),
+		).json();
+		const { client } = mockDaemon();
+
+		for (const vector of contract.vectors) {
+			if (!vector.clients.includes("sdk")) continue;
+			await client.recall(vector.query, vector.options as SdkRecallOptions);
+			expect(lastRequest().body, vector.name).toEqual(vector.expected);
+		}
 	});
 
 	test("recall() sends POST /api/memory/recall with query", async () => {
@@ -184,7 +198,6 @@ describe("SignetClient", () => {
 		expect(req.body).toEqual({
 			query: "confidence",
 			limit: 5,
-			minScore: 0.8,
 			until: "2026-04-03T00:00:00Z",
 			project: "proj-a",
 			keywordQuery: "confidence",

--- a/libs/sdk/src/__tests__/helpers.test.ts
+++ b/libs/sdk/src/__tests__/helpers.test.ts
@@ -199,6 +199,7 @@ describe("SignetClientHelpers", () => {
 		await expect(client.recallOrThrow("nonexistent", { minScore: 0.5 })).rejects.toThrow(
 			'No memories found for query: "nonexistent"',
 		);
+		expect(lastRequest().body).toEqual({ query: "nonexistent", limit: 10 });
 	});
 
 	test("getMemoryOrThrow() returns memory when found", async () => {

--- a/libs/sdk/src/helpers.ts
+++ b/libs/sdk/src/helpers.ts
@@ -8,9 +8,10 @@
  * - Error shortcuts
  */
 
+import { applyRecallScoreThreshold, buildRecallRequestBody } from "@signet/core/recall";
 import { SignetApiError } from "./errors.js";
 import type { SignetTransport } from "./transport.js";
-import type { DocumentRecord, JobStatus, MemoryRecord, RecallResponse } from "./types.js";
+import type { DocumentRecord, JobStatus, MemoryRecord, RecallResponse, SdkRecallOptions } from "./types.js";
 
 export interface WaitForJobOptions {
 	/** Maximum time to wait in milliseconds (default: 30_000) */
@@ -27,21 +28,7 @@ export interface BatchModifyProgress {
 }
 
 export function applyRecallMinScore(result: RecallResponse, minScore?: number): RecallResponse {
-	if (typeof minScore !== "number") {
-		return result;
-	}
-
-	const filtered = result.results.filter((row) => row.score >= minScore);
-	return {
-		...result,
-		results: filtered,
-		meta: {
-			...result.meta,
-			totalReturned: filtered.length,
-			hasSupplementary: filtered.some((row) => row.supplementary === true),
-			noHits: filtered.length === 0,
-		},
-	};
+	return applyRecallScoreThreshold(result, minScore) as RecallResponse;
 }
 
 export class SignetClientHelpers {
@@ -143,41 +130,11 @@ export class SignetClientHelpers {
 	 * });
 	 * ```
 	 */
-	async recallOrThrow(
-		query: string,
-		opts?: {
-			readonly keywordQuery?: string;
-			readonly limit?: number;
-			readonly project?: string;
-			readonly type?: string;
-			readonly tags?: string;
-			readonly who?: string;
-			readonly pinned?: boolean;
-			readonly importance_min?: number;
-			readonly since?: string;
-			readonly until?: string;
-			readonly time?: {
-				readonly start?: string;
-				readonly end?: string;
-				readonly facets?: readonly string[];
-				readonly mode?: "auto" | "timeline" | "filter";
-			};
-			readonly expand?: boolean;
-			readonly minScore?: number;
-			readonly agentId?: string;
-			readonly aggregate?: boolean;
-			readonly aggregateBudget?: "small" | "medium" | "large";
-			readonly saveAggregate?: boolean;
-			readonly sessionKey?: string;
-			readonly includeRecalled?: boolean;
-		},
-	): Promise<RecallResponse> {
+	async recallOrThrow(query: string, opts?: SdkRecallOptions): Promise<RecallResponse> {
+		const { minScore, ...requestOptions } = opts ?? {};
 		const result = applyRecallMinScore(
-			await this.transport.post<RecallResponse>("/api/memory/recall", {
-				query,
-				...opts,
-			}),
-			opts?.minScore,
+			await this.transport.post<RecallResponse>("/api/memory/recall", buildRecallRequestBody(query, requestOptions)),
+			minScore,
 		);
 
 		if (!result.results || result.results.length === 0) {

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -1,8 +1,9 @@
 /**
  * @signet/sdk — HTTP client for the Signet daemon API.
- * No native dependencies (no SQLite, no @signet/core).
+ * No native dependencies (no SQLite).
  */
 
+import { buildRecallRequestBody } from "@signet/core/recall";
 import { SignetClientP2 } from "./client-p2.js";
 import { SignetClientHelpers, applyRecallMinScore } from "./helpers.js";
 import { SignetTransport } from "./transport.js";
@@ -56,6 +57,7 @@ import type {
 	RecallResponse,
 	RecoverResult,
 	RememberResult,
+	SdkRecallOptions,
 	SecretExecJob,
 	SecretExecOptions,
 	SecretExecResult,
@@ -145,41 +147,11 @@ export class SignetClient extends SignetClientHelpers {
 		});
 	}
 
-	async recall(
-		query: string,
-		opts?: {
-			readonly keywordQuery?: string;
-			readonly limit?: number;
-			readonly project?: string;
-			readonly type?: string;
-			readonly tags?: string;
-			readonly who?: string;
-			readonly pinned?: boolean;
-			readonly importance_min?: number;
-			readonly since?: string;
-			readonly until?: string;
-			readonly time?: {
-				readonly start?: string;
-				readonly end?: string;
-				readonly facets?: readonly string[];
-				readonly mode?: "auto" | "timeline" | "filter";
-			};
-			readonly minScore?: number;
-			readonly expand?: boolean;
-			readonly agentId?: string;
-			readonly aggregate?: boolean;
-			readonly aggregateBudget?: "small" | "medium" | "large";
-			readonly saveAggregate?: boolean;
-			readonly sessionKey?: string;
-			readonly includeRecalled?: boolean;
-		},
-	): Promise<RecallResponse> {
+	async recall(query: string, opts?: SdkRecallOptions): Promise<RecallResponse> {
+		const { minScore, ...requestOptions } = opts ?? {};
 		return applyRecallMinScore(
-			await this.transport.post<RecallResponse>("/api/memory/recall", {
-				query,
-				...opts,
-			}),
-			opts?.minScore,
+			await this.transport.post<RecallResponse>("/api/memory/recall", buildRecallRequestBody(query, requestOptions)),
+			minScore,
 		);
 	}
 
@@ -1405,6 +1377,7 @@ export type {
 	RecallResponse,
 	RecallResult,
 	RecoverResult,
+	SdkRecallOptions,
 	RememberResult,
 	SecretExecJob,
 	SecretExecOptions,

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -1,5 +1,4 @@
 // Response types for the Signet daemon HTTP API.
-// Standalone — no dependency on @signet/core.
 
 export interface MemoryRecord {
 	readonly id: string;
@@ -115,6 +114,44 @@ export interface RecallEntity {
 	readonly name: string;
 	readonly type: string;
 	readonly aspects: readonly RecallEntityAspect[];
+}
+
+export interface SdkRecallOptions {
+	readonly keywordQuery?: string;
+	readonly keyword_query?: string;
+	readonly limit?: number;
+	readonly project?: string;
+	readonly type?: string;
+	readonly tags?: string;
+	readonly who?: string;
+	readonly pinned?: boolean;
+	readonly importance_min?: number;
+	readonly since?: string;
+	readonly until?: string;
+	readonly time?: {
+		readonly start?: string;
+		readonly end?: string;
+		readonly facets?: readonly ("captured" | "session" | "source" | "observed" | "occurred" | "valid")[];
+		readonly mode?: "auto" | "timeline" | "filter";
+	};
+	readonly expand?: boolean;
+	readonly agentId?: string;
+	readonly agent_id?: string;
+	readonly contextAgentId?: string;
+	readonly sessionKey?: string;
+	readonly session_key?: string;
+	readonly includeRecalled?: boolean;
+	readonly include_recalled?: boolean;
+	readonly scope?: string;
+	readonly sourceOnly?: boolean;
+	readonly source_only?: boolean;
+	readonly aggregate?: boolean;
+	readonly aggregateBudget?: "small" | "medium" | "large";
+	readonly aggregate_budget?: "small" | "medium" | "large";
+	readonly saveAggregate?: boolean;
+	readonly save_aggregate?: boolean;
+	/** Applied to returned rows by the SDK; never sent to the daemon. */
+	readonly minScore?: number;
 }
 
 export interface RecallResponse {

--- a/platform/core/contracts/README.md
+++ b/platform/core/contracts/README.md
@@ -1,0 +1,24 @@
+# Recall request contract
+
+`recall-request-v1.json` is the transport-neutral contract for turning a recall
+intent into the JSON body sent to `POST /api/memory/recall`.
+
+`buildRecallRequestBody()` in `platform/core/src/recall.ts` is the sole
+TypeScript implementation. TypeScript clients call it directly. Native clients
+implement only the subset exposed by their harness and consume the applicable
+vectors in tests so defaults, bounds, field names, and omission rules cannot
+drift silently.
+
+The request contract bounds `limit` to `1..100`. The daemon currently applies a
+separate execution cap of 50 while searching; that backend safeguard does not
+change the client request contract.
+
+The `unreal` entry records deliberate gameplay policy rather than a second
+generic contract: NPC recall defaults to 6, is capped at 20, always includes
+previously recalled rows, and uses world/player scope strings. Repository-native
+Unreal automation receives this file through `SIGNET_RECALL_CONTRACT_VECTORS`;
+installed plugins skip that repository-only vector assertion when the variable
+is unset.
+
+When the wire contract changes, add a new version instead of rewriting vectors
+that released native clients may still use.

--- a/platform/core/contracts/recall-request-v1.json
+++ b/platform/core/contracts/recall-request-v1.json
@@ -1,0 +1,180 @@
+{
+	"version": 1,
+	"description": "Transport-neutral recall intent to daemon request contract.",
+	"vectors": [
+		{
+			"name": "canonical-defaults",
+			"clients": ["core", "openclaw", "opencode", "sdk", "hermes"],
+			"query": "graph",
+			"options": {},
+			"expected": {
+				"query": "graph",
+				"limit": 10
+			}
+		},
+		{
+			"name": "lower-limit-bound",
+			"clients": ["core", "openclaw", "opencode", "sdk", "hermes"],
+			"query": "graph",
+			"options": {
+				"limit": 0
+			},
+			"expected": {
+				"query": "graph",
+				"limit": 1
+			}
+		},
+		{
+			"name": "fractional-limit",
+			"clients": ["core", "openclaw", "opencode", "sdk", "hermes"],
+			"query": "graph",
+			"options": {
+				"limit": 12.9
+			},
+			"expected": {
+				"query": "graph",
+				"limit": 12
+			}
+		},
+		{
+			"name": "upper-limit-bound",
+			"clients": ["core", "openclaw", "opencode", "sdk", "hermes"],
+			"query": "graph",
+			"options": {
+				"limit": 5000
+			},
+			"expected": {
+				"query": "graph",
+				"limit": 100
+			}
+		},
+		{
+			"name": "huge-integer-limit",
+			"clients": ["core", "sdk", "hermes"],
+			"query": "graph",
+			"options": {
+				"limit": 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+			},
+			"expected": {
+				"query": "graph",
+				"limit": 100
+			}
+		},
+		{
+			"name": "canonical-options",
+			"clients": ["core", "sdk"],
+			"query": "architecture",
+			"options": {
+				"keywordQuery": "architecture OR design",
+				"limit": 5,
+				"project": "/tmp/project",
+				"type": "decision",
+				"tags": "architecture",
+				"who": "codex",
+				"pinned": true,
+				"importance_min": 0.8,
+				"since": "2026-01-01",
+				"until": "2026-02-01",
+				"expand": true,
+				"agentId": "explicit-agent",
+				"contextAgentId": "context-agent",
+				"sessionKey": "session-a",
+				"includeRecalled": true,
+				"scope": "world:alpha",
+				"sourceOnly": true,
+				"aggregate": true,
+				"aggregateBudget": "large",
+				"saveAggregate": false
+			},
+			"expected": {
+				"query": "architecture",
+				"keywordQuery": "architecture OR design",
+				"limit": 5,
+				"project": "/tmp/project",
+				"type": "decision",
+				"tags": "architecture",
+				"who": "codex",
+				"pinned": true,
+				"importance_min": 0.8,
+				"since": "2026-01-01",
+				"until": "2026-02-01",
+				"expand": true,
+				"agentId": "explicit-agent",
+				"sessionKey": "session-a",
+				"includeRecalled": true,
+				"scope": "world:alpha",
+				"sourceOnly": true,
+				"aggregate": true,
+				"aggregateBudget": "large",
+				"saveAggregate": false
+			}
+		},
+		{
+			"name": "snake-case-aliases",
+			"clients": ["core"],
+			"query": "aliases",
+			"options": {
+				"keyword_query": "aliases OR normalization",
+				"agent_id": "agent-a",
+				"session_key": "session-a",
+				"include_recalled": true,
+				"source_only": true,
+				"aggregate_budget": "medium",
+				"save_aggregate": false
+			},
+			"expected": {
+				"query": "aliases",
+				"keywordQuery": "aliases OR normalization",
+				"limit": 10,
+				"agentId": "agent-a",
+				"sessionKey": "session-a",
+				"includeRecalled": true,
+				"sourceOnly": true,
+				"aggregateBudget": "medium",
+				"saveAggregate": false
+			}
+		},
+		{
+			"name": "false-flags-are-omitted",
+			"clients": ["core", "sdk", "hermes"],
+			"query": "flags",
+			"options": {
+				"pinned": false,
+				"expand": false,
+				"includeRecalled": false,
+				"sourceOnly": false,
+				"aggregate": false
+			},
+			"expected": {
+				"query": "flags",
+				"limit": 10
+			}
+		},
+		{
+			"name": "aggregate-save-false-is-preserved",
+			"clients": ["core", "openclaw", "opencode", "sdk", "hermes"],
+			"query": "history",
+			"options": {
+				"aggregate": true,
+				"aggregateBudget": "small",
+				"saveAggregate": false
+			},
+			"expected": {
+				"query": "history",
+				"limit": 10,
+				"aggregate": true,
+				"aggregateBudget": "small",
+				"saveAggregate": false
+			}
+		}
+	],
+	"overrides": {
+		"unreal": {
+			"defaultLimit": 6,
+			"minimumLimit": 1,
+			"maximumLimit": 20,
+			"includeRecalled": true,
+			"scope": "world-or-player"
+		}
+	}
+}

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -18,11 +18,15 @@
 		"./llm-model-catalog": {
 			"import": "./dist/llm-model-catalog.js",
 			"types": "./dist/llm-model-catalog.d.ts"
+		},
+		"./recall": {
+			"import": "./dist/recall.js",
+			"types": "./dist/recall.d.ts"
 		}
 	},
 	"files": ["dist", "!dist/**/*.test.*", "!dist/**/__tests__/**"],
 	"scripts": {
-		"build": "bun build ./src/index.ts ./src/pipeline-providers.ts ./src/llm-model-catalog.ts --outdir ./dist --target node --external better-sqlite3 && bun run build:types",
+		"build": "bun build ./src/index.ts ./src/pipeline-providers.ts ./src/llm-model-catalog.ts ./src/recall.ts --outdir ./dist --target node --external better-sqlite3 && bun run build:types",
 		"build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
 		"dev": "bun --watch src/index.ts",
 		"test": "bun test",

--- a/platform/core/src/recall.test.ts
+++ b/platform/core/src/recall.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import type { RecallRequestOptions } from "./recall";
 import {
 	applyRecallScoreThreshold,
 	buildRecallRequestBody,
@@ -8,7 +9,31 @@ import {
 	withHookRecallCompat,
 } from "./recall";
 
+interface RecallContractVector {
+	readonly name: string;
+	readonly query: string;
+	readonly options: RecallRequestOptions;
+	readonly expected: Record<string, unknown>;
+}
+
+interface RecallContract {
+	readonly version: number;
+	readonly vectors: readonly RecallContractVector[];
+}
+
+async function readRecallContract(): Promise<RecallContract> {
+	return Bun.file(new URL("../contracts/recall-request-v1.json", import.meta.url)).json();
+}
+
 describe("recall surface helpers", () => {
+	it("matches the versioned transport-neutral request contract", async () => {
+		const contract = await readRecallContract();
+		expect(contract.version).toBe(1);
+		for (const vector of contract.vectors) {
+			expect(buildRecallRequestBody(vector.query, vector.options), vector.name).toEqual(vector.expected);
+		}
+	});
+
 	it("formats daemon recall payloads with primary and supporting context", () => {
 		const text = formatRecallText({
 			method: "hybrid",

--- a/platform/core/src/recall.ts
+++ b/platform/core/src/recall.ts
@@ -136,7 +136,8 @@ export interface RecallRequestOptions {
 	readonly session_key?: string;
 	readonly includeRecalled?: boolean;
 	readonly include_recalled?: boolean;
-	readonly scope?: "global" | "agent" | "session";
+	/** Exact daemon memory-scope string; agent/session isolation use their dedicated fields. */
+	readonly scope?: string;
 	readonly sourceOnly?: boolean;
 	readonly source_only?: boolean;
 	readonly aggregate?: boolean;
@@ -288,11 +289,10 @@ export function applyRecallScoreThreshold(raw: unknown, minScore?: number): unkn
 		...payload,
 		results: filtered,
 		meta: {
+			...(isRecord(payload.meta) ? payload.meta : {}),
 			totalReturned: filtered.length,
 			hasSupplementary: filtered.some((row) => row.supplementary === true),
 			noHits: filtered.length === 0,
-			...(isRecord(payload.meta) && isRecord(payload.meta.dedupe) ? { dedupe: payload.meta.dedupe } : {}),
-			...(isRecord(payload.meta) && isRecord(payload.meta.temporal) ? { temporal: payload.meta.temporal } : {}),
 		},
 	};
 }


### PR DESCRIPTION
## Summary

Extends the canonical recall request policy from `@signet/core` to the remaining direct runtime clients audited in #931 while preserving each harness's intentional product behavior.

Sequencing: land #928 / PR #952, then #927 / PR #951, before finalizing this PR and its OpenCode changes.

Closes #931

## Changes

- adds versioned, transport-neutral recall request vectors under `platform/core/contracts/`
- exports the canonical core recall builder as `@signet/core/recall`
- routes SDK, OpenClaw, and OpenCode request shaping through the canonical TypeScript builder
- keeps SDK `minScore` client-side and preserves recall metadata after filtering
- adds OpenCode exact daemon scope-string support and exact endpoint-payload tests
- adds a Python canonical request normalizer for Hermes with shared-vector coverage
- extracts Unreal NPC recall serialization into a testable native helper while preserving its explicit `6`, `1..20`, `includeRecalled: true`, and world/player-scope policy
- documents the compatibility matrix, client-side filtering, request bounds, daemon execution cap, and native overrides

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [x] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: OpenClaw and OpenCode runtime plugins; Unreal native plugin

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
  - N/A: no admin or mutation endpoint changes.
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally
  - Focused affected checks and the full workspace typecheck pass. Repository-wide lint/tests retain unrelated baseline failures documented under Testing.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused verification:

- core recall: 14 passed
- SDK: 78 passed
- OpenClaw adapter: 101 passed
- OpenCode plugin: 16 passed
- Hermes connector/provider: 69 passed
- Unreal manifest/contract checks: 4 passed
- affected package builds and declaration generation pass
- SDK built output imports successfully and contains no `@signet/core`, SQLite, or native dependency references
- `git diff --check` passes
- two final structured reviews completed; the final review reported no findings

Current upstream harness verification:

- current OpenCode loaded the installed Signet plugin through its real `PluginLoader`, registered `memory_search`, accepted an arbitrary string scope, and emitted `{ query, limit: 100, scope }`
- current Hermes discovered and loaded the installed Signet memory provider through `plugins.memory`, registered `memory_search`, and emitted the expected canonical request with explicit opt-in agent scope
- current OpenClaw installed the packed adapter, selected it as `plugins.slots.memory`, and reported it active/loaded with no diagnostics

Broader-command notes:

- `bun run typecheck` passes after generating the repository's ignored connector bundles through their normal build scripts
- `bun run test` reached 2,241 passing daemon tests and 49 failures outside the changed surfaces (including existing auth, timing, and package-artifact-sensitive tests); all affected suites above pass independently
- `bun run lint` reports 1,787 repository-wide diagnostics, primarily existing formatting drift in package JSON and other untouched files; changed TypeScript/JSON surfaces pass focused Biome checks apart from the pre-existing formatting of `libs/sdk/package.json`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Land this after #928 / PR #952 and #927 / PR #951 establish the intended OpenCode install and lifecycle baseline.
- The daemon's execution clamp remains `1..50`; this PR preserves the existing canonical client request contract of `1..100` and documents the distinction.
- Unreal Editor 5.4-5.6 was not installed on the validation machine, so native automation could not be executed. Repository checks validate the manifest/source wiring, and the automation test is included for a UE-equipped runner.


