### PR TITLE
fix(opencode): retain memory across turn transforms

### DIFF
--- a/integrations/opencode/plugin/src/index.test.ts
+++ b/integrations/opencode/plugin/src/index.test.ts
@@ -104,7 +104,7 @@ describe("SignetPlugin OpenCode lifecycle", () => {
 		});
 	});
 
-	test("keeps session-start context available for the same prompt when chat.message runs first", async () => {
+	test("keeps turn context available for title and primary transforms", async () => {
 		process.env.SIGNET_AGENT_ID = undefined;
 		installFetch();
 		const hooks = await createHooks();
@@ -116,11 +116,137 @@ describe("SignetPlugin OpenCode lifecycle", () => {
 			{ sessionID: "child-chat-first" },
 			{ parts: [{ type: "text", text: "start the delegated task" }] },
 		);
-		const output = { system: [] };
-		await hooks["experimental.chat.system.transform"]({ sessionID: "child-chat-first" }, output);
+		const titleOutput = { system: [] };
+		const primaryOutput = { system: [] };
+		await hooks["experimental.chat.system.transform"]({ sessionID: "child-chat-first" }, titleOutput);
+		await hooks["experimental.chat.system.transform"]({ sessionID: "child-chat-first" }, primaryOutput);
 
-		expect(output.system.join("\n")).toContain("session-start:child-chat-first");
-		expect(output.system.join("\n")).toContain("prompt-submit-context");
+		for (const output of [titleOutput, primaryOutput]) {
+			expect(output.system.join("\n")).toContain("session-start:child-chat-first");
+			expect(output.system.join("\n")).toContain("prompt-submit-context");
+		}
+	});
+
+	test("clears prior turn context when the next message has no text", async () => {
+		process.env.SIGNET_AGENT_ID = undefined;
+		installFetch();
+		const hooks = await createHooks();
+
+		await hooks["chat.message"](
+			{ sessionID: "non-text-next-turn" },
+			{ parts: [{ type: "text", text: "recall this turn" }] },
+		);
+		await hooks["chat.message"]({ sessionID: "non-text-next-turn" }, { parts: [{ type: "text", text: "" }] });
+		const output = { system: [] };
+		await hooks["experimental.chat.system.transform"]({ sessionID: "non-text-next-turn" }, output);
+
+		expect(output.system.join("\n")).not.toContain("session-start:non-text-next-turn");
+		expect(output.system.join("\n")).not.toContain("prompt-submit-context");
+	});
+
+	test("does not let an older prompt response overwrite a newer turn", async () => {
+		process.env.SIGNET_AGENT_ID = undefined;
+		let releaseSessionStart: (() => void) | undefined;
+		let markSessionStartStarted: (() => void) | undefined;
+		let releaseOlderPrompt: (() => void) | undefined;
+		let markOlderPromptStarted: (() => void) | undefined;
+		const sessionStartGate = new Promise<void>((resolve) => {
+			releaseSessionStart = resolve;
+		});
+		const sessionStartStarted = new Promise<void>((resolve) => {
+			markSessionStartStarted = resolve;
+		});
+		const olderPromptGate = new Promise<void>((resolve) => {
+			releaseOlderPrompt = resolve;
+		});
+		const olderPromptStarted = new Promise<void>((resolve) => {
+			markOlderPromptStarted = resolve;
+		});
+		globalThis.fetch = Object.assign(
+			async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+				const url = new URL(String(input));
+				const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+				if (url.pathname === "/api/hooks/session-start") {
+					if (body.sessionKey) {
+						markSessionStartStarted?.();
+						await sessionStartGate;
+						return Response.json({ inject: "session-start-context" });
+					}
+					return Response.json({ inject: "workspace-start" });
+				}
+				if (url.pathname === "/api/hooks/user-prompt-submit") {
+					if (body.userMessage === "older prompt") {
+						markOlderPromptStarted?.();
+						await olderPromptGate;
+						return Response.json({ inject: "older-prompt-context" });
+					}
+					return Response.json({ inject: "newer-prompt-context" });
+				}
+				return Response.json({});
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+		const hooks = await createHooks();
+
+		const olderChat = hooks["chat.message"](
+			{ sessionID: "overlapping-turns" },
+			{ parts: [{ type: "text", text: "older prompt" }] },
+		);
+		await sessionStartStarted;
+		const newerChat = hooks["chat.message"](
+			{ sessionID: "overlapping-turns" },
+			{ parts: [{ type: "text", text: "newer prompt" }] },
+		);
+		releaseSessionStart?.();
+		await olderPromptStarted;
+		await newerChat;
+		releaseOlderPrompt?.();
+		await olderChat;
+
+		const output = { system: [] };
+		await hooks["experimental.chat.system.transform"]({ sessionID: "overlapping-turns" }, output);
+		expect(output.system.join("\n")).toContain("session-start-context");
+		expect(output.system.join("\n")).toContain("newer-prompt-context");
+		expect(output.system.join("\n")).not.toContain("older-prompt-context");
+	});
+
+	test("does not restore turn context after session end", async () => {
+		process.env.SIGNET_AGENT_ID = undefined;
+		let releasePrompt: (() => void) | undefined;
+		let markPromptStarted: (() => void) | undefined;
+		const promptGate = new Promise<void>((resolve) => {
+			releasePrompt = resolve;
+		});
+		const promptStarted = new Promise<void>((resolve) => {
+			markPromptStarted = resolve;
+		});
+		globalThis.fetch = Object.assign(
+			async (input: RequestInfo | URL): Promise<Response> => {
+				const url = new URL(String(input));
+				if (url.pathname === "/api/hooks/session-start") return Response.json({ inject: "session-start-context" });
+				if (url.pathname === "/api/hooks/user-prompt-submit") {
+					markPromptStarted?.();
+					await promptGate;
+					return Response.json({ inject: "late-prompt-context" });
+				}
+				return Response.json({});
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+		const hooks = await createHooks();
+
+		const chat = hooks["chat.message"](
+			{ sessionID: "ending-turn" },
+			{ parts: [{ type: "text", text: "ending prompt" }] },
+		);
+		await promptStarted;
+		await hooks.event({ event: { type: "session.deleted", properties: { id: "ending-turn" } } });
+		releasePrompt?.();
+		await chat;
+
+		const output = { system: [] };
+		await hooks["experimental.chat.system.transform"]({ sessionID: "ending-turn" }, output);
+		expect(output.system.join("\n")).not.toContain("late-prompt-context");
 	});
 
 	test("single-flights concurrent per-session start hooks", async () => {

--- a/integrations/opencode/plugin/src/index.ts
+++ b/integrations/opencode/plugin/src/index.ts
@@ -52,18 +52,29 @@ interface UserPromptSubmitResult {
 	readonly memoryCount?: number;
 }
 
-// Per-prompt inject cache: consumed once by system.transform after chat.message populates it.
-// Capped to prevent unbounded growth if sessions die between the two hooks.
-const MAX_PENDING = 64;
-const pendingInject = new Map<string, string>();
+// Per-turn inject cache: every LLM transform for a prompt receives the same context.
+// The next chat.message replaces it, and session end removes it. The cap prevents
+// unbounded growth if OpenCode never emits either lifecycle hook for a session.
+const MAX_ACTIVE_TURNS = 64;
+interface ActiveTurn {
+	inject: string;
+}
+const activeTurns = new Map<string, ActiveTurn>();
 
-function pendingInjectSet(sessionID: string, inject: string): void {
-	if (!pendingInject.has(sessionID) && pendingInject.size >= MAX_PENDING) {
-		const oldest = pendingInject.keys().next().value;
-		if (oldest !== undefined) pendingInject.delete(oldest);
+function beginTurn(sessionID: string): ActiveTurn {
+	if (activeTurns.size >= MAX_ACTIVE_TURNS) {
+		const oldest = activeTurns.keys().next().value;
+		if (oldest !== undefined) activeTurns.delete(oldest);
 	}
-	const existing = pendingInject.get(sessionID);
-	pendingInject.set(sessionID, existing ? `${existing}\n${inject}` : inject);
+	const turn = { inject: "" };
+	activeTurns.set(sessionID, turn);
+	return turn;
+}
+
+function appendTurnInject(sessionID: string, turn: ActiveTurn, inject: string): void {
+	const active = activeTurns.get(sessionID);
+	if (active !== turn) return;
+	active.inject = active.inject ? `${active.inject}\n${inject}` : inject;
 }
 
 function readRuntimeEnv(name: string): string | undefined {
@@ -214,10 +225,7 @@ export const SignetPlugin: Plugin = async ({ directory, client: oc }) => {
 	async function ensureSessionStarted(sessionID: string): Promise<string> {
 		if (startedSessions.has(sessionID)) return "";
 		const existing = startingSessions.get(sessionID);
-		if (existing) {
-			await existing;
-			return "";
-		}
+		if (existing) return await existing;
 
 		const startSession = client
 			.post<SessionStartResult>(
@@ -280,20 +288,21 @@ export const SignetPlugin: Plugin = async ({ directory, client: oc }) => {
 		// ------------------------------------------------------------------
 
 		"chat.message": async (input, output): Promise<void> => {
+			// Every message starts a new turn, including prompts without text parts.
+			activeTurns.delete(input.sessionID);
+
 			const userText = output.parts
 				.map((part) => readPartText(part))
 				.filter((text): text is string => text !== null)
 				.join("\n")
 				.trim();
 			if (!userText) return;
-
-			// Clear any unconsumed inject from a prior prompt for this session
-			pendingInject.delete(input.sessionID);
+			const turn = beginTurn(input.sessionID);
 
 			try {
 				try {
 					const startInject = await ensureSessionStarted(input.sessionID);
-					if (startInject) pendingInjectSet(input.sessionID, startInject);
+					if (startInject) appendTurnInject(input.sessionID, turn, startInject);
 				} catch {
 					// Session-start context is optional; still run prompt-submit so
 					// recall and transcript capture stay fail-open independently.
@@ -312,7 +321,7 @@ export const SignetPlugin: Plugin = async ({ directory, client: oc }) => {
 					promptSubmitTimeout(),
 				);
 				if (result?.inject) {
-					pendingInjectSet(input.sessionID, result.inject);
+					appendTurnInject(input.sessionID, turn, result.inject);
 				}
 			} catch {
 				// never block the user's message
@@ -320,7 +329,7 @@ export const SignetPlugin: Plugin = async ({ directory, client: oc }) => {
 		},
 
 		// ------------------------------------------------------------------
-		// Inject per-prompt context into the system prompt
+		// Inject per-turn context into every LLM request for the prompt
 		// ------------------------------------------------------------------
 		"experimental.chat.system.transform": async (input, output): Promise<void> => {
 			if (!input.sessionID) return;
@@ -330,13 +339,10 @@ export const SignetPlugin: Plugin = async ({ directory, client: oc }) => {
 			} catch {
 				// Signet context is optional; never break OpenCode prompt rendering.
 			}
-			const inject = pendingInject.get(input.sessionID);
-			const parts = [startInject, inject].filter((part) => part?.trim());
+			const inject = activeTurns.get(input.sessionID)?.inject;
+			const parts = [...new Set([startInject, inject].filter((part) => part?.trim()))];
 			if (parts.length > 0) {
 				output.system.push(parts.join("\n"));
-			}
-			if (inject) {
-				pendingInject.delete(input.sessionID);
 			}
 		},
 
@@ -416,7 +422,7 @@ export const SignetPlugin: Plugin = async ({ directory, client: oc }) => {
 					if (sid) {
 						startedSessions.delete(sid);
 						parentBySession.delete(sid);
-						pendingInject.delete(sid);
+						activeTurns.delete(sid);
 					}
 				}
 


### PR DESCRIPTION
## Summary

Keeps OpenCode automatic-memory context available for every LLM transform in a user turn, so title generation can no longer consume the one-shot injection before the primary agent request.

Sequencing: land #928 / PR #952 before this lifecycle fix. PR #950 remains sequenced after both issues.

Closes #927

## Changes

- replaces the one-shot pending injection with a bounded per-turn context cache
- reuses session-start and prompt-submit context across title, primary, retry, and tool-loop transforms for the same turn
- clears/replaces context on every next `chat.message`, including messages without text, and removes it at session end
- guards asynchronous session-start and prompt-submit completions with active-turn identity so older responses cannot repopulate a newer or ended turn
- adds regressions for title-then-primary transforms, non-text turn boundaries, overlapping prompt responses, session-end invalidation, and session-start single-flight behavior

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `@signet/opencode-plugin`

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
  - N/A: no spec or dependency change.
- [x] Agent scoping verified on all new/changed data queries
  - No query shape changed; configured `agentId` remains threaded through lifecycle calls.
- [x] Input/config validation and bounds checks added
  - N/A: no new external input or bound.
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
  - N/A: no endpoint or mutation change.
- [x] Docs updated for API/spec/status changes
  - N/A: public API and documented setup are unchanged.
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally
  - Affected tests, typecheck, build, Biome, and diff checks pass; repository-wide commands are not claimed.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon — upstream E2E used an isolated mock daemon
- [ ] N/A

Focused verification:

- `bun test ./integrations/opencode/plugin/src` — 18 passed
- `bun run --cwd integrations/opencode/plugin typecheck`
- `bun run --cwd integrations/opencode/plugin build`
- `bunx biome check integrations/opencode/plugin/src/index.ts integrations/opencode/plugin/src/index.test.ts`
- `git diff --check`
- final structured review reported no findings

Regression proof:

- the title/primary regression test fails against the pre-fix implementation because the second transform receives an empty system context
- current upstream OpenCode 1.18.4 was installed in isolated temporary state and run through its real `opencode run` path with a mock OpenAI-compatible provider and mock Signet daemon
- OpenCode emitted exactly two LLM requests: one title request and one primary request
- both requests contained the session-start memory and prompt-submit context, and the primary response completed successfully

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Current upstream source was inspected at `anomalyco/opencode@0a601cf334b9a83cc2854108a2b860f25e6e7e8e`: `chat.message` runs while creating the user message; title generation then forks before the primary request; both LLM paths invoke `experimental.chat.system.transform` with the same session ID.
- Land this after #928 / PR #952, matching the requested OpenCode sequencing.



