### PR TITLE
fix(opencode): support remote-only connector installs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -201,6 +201,7 @@
       "dependencies": {
         "@signet/connector-base": "0.142.4",
         "@signet/core": "0.142.4",
+        "jsonc-parser": "3.3.1",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -2718,6 +2719,8 @@
     "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
 

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -349,21 +349,20 @@ it during install by deleting the old file and scrubbing any
 
 ### Config File Detection
 
-The connector searches for an OpenCode config file in this order:
+The connector writes the highest-precedence global OpenCode config file:
 
-1. `~/.config/opencode/opencode.json`
-2. `~/.config/opencode/opencode.jsonc`
+1. `~/.config/opencode/opencode.jsonc`
+2. `~/.config/opencode/opencode.json`
 3. `~/.config/opencode/config.json`
 
-The first one found is used. If none exist, `opencode.json` is created
-as the default. JSONC files (with `//` comments and trailing commas)
-are parsed correctly — the connector strips comments and trailing
-commas before parsing.
+This matches OpenCode's load order, where `opencode.jsonc` is merged last. If
+none exist, `opencode.jsonc` is created. Config updates are targeted JSONC
+edits, so comments, trailing commas, and unrelated settings are preserved.
 
 ### MCP Tools
 
-OpenCode also gets MCP tool access via a local server entry registered
-in the config file during install:
+The plugin handles lifecycle hooks; MCP provides on-demand Signet tools. A
+local install without an explicit daemon URL uses the packaged stdio command:
 
 ```json
 {
@@ -377,7 +376,12 @@ in the config file during install:
 }
 ```
 
-The plugin handles lifecycle hooks; MCP provides on-demand memory tools.
+A standalone remote install with `--url` uses OpenCode's remote MCP transport
+instead, pointing at `<daemon-origin>/mcp`, setting `oauth: false`, and adding
+the supplied API key as a bearer header. The key is kept in a mode-0600 managed
+file referenced through OpenCode's `{file:}` substitution, not embedded in the
+config or plugin. This path does not require or create a local Signet identity
+workspace.
 
 ### Supported hooks
 

--- a/docs/REMOTE-CONNECTORS.md
+++ b/docs/REMOTE-CONNECTORS.md
@@ -339,6 +339,12 @@ npx -y @signetai/connector-opencode install \
   --agent-id opencode-mini-pc
 ```
 
+No local Signet workspace or identity files are required on the OpenCode
+machine. The installer registers the bundled lifecycle plugin in the effective
+OpenCode config and configures `http://signet-home.tailnet:3850/mcp` as a
+remote MCP server with bearer authentication. The API key is stored in a
+mode-0600 connector-managed file rather than embedded in the config or plugin.
+
 Start a new OpenCode session so it picks up the new plugin/config.
 
 ### Remote Pi connector

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -11,7 +11,8 @@ Integrates Signet's memory system with OpenCode via its plugin system.
 - Registers the plugin in OpenCode's configuration (`opencode.json` / `opencode.jsonc` / `config.json`)
 - Symlinks the skills directory for tool access
 - Migrates away from the legacy `memory.mjs` approach on install/uninstall
-- Supports JSONC configuration files (strips comments before parsing)
+- Preserves JSONC comments and formatting while applying targeted config updates
+- Uses the daemon's authenticated remote MCP endpoint for remote-only installs
 
 ## Installation
 
@@ -25,8 +26,18 @@ machine where you only want to install the OpenCode integration, use the
 standalone npm installer:
 
 ```bash
-npx -y @signetai/connector-opencode install --url http://signet-home.tailnet:3850 --api-key sig_sk_...
+npx -y @signetai/connector-opencode install \
+  --url http://signet-home.tailnet:3850 \
+  --api-key sig_sk_... \
+  --agent-id personal
 ```
+
+This remote-only path does not require or create a local Signet workspace. It
+installs the lifecycle plugin and configures `<daemon-origin>/mcp` as an
+OpenCode remote MCP server with bearer authentication. The API key is stored in
+a mode-0600 connector-managed file and referenced through OpenCode's `{file:}`
+substitution rather than written into the config or plugin. Local installs
+without `--url` continue to use the `signet-mcp` stdio command.
 
 ## Uninstallation
 
@@ -42,10 +53,11 @@ The connector package exposes programmatic cleanup that removes the plugin file 
 ## Architecture
 
 ```
-~/.config/opencode/plugins/signet.mjs  <-- bundled plugin
-~/.config/opencode/opencode.json       <-- plugin registered here
-~/.config/opencode/AGENTS.md           <-- generated identity file
-~/.agents/                             <-- agent workspace
+~/.config/opencode/plugins/signet.mjs       <-- bundled plugin
+~/.config/opencode/plugins/.signet-api-key  <-- protected key file when configured
+~/.config/opencode/opencode.jsonc           <-- plugin and MCP registered here by default
+~/.config/opencode/AGENTS.md           <-- generated only for a local managed identity
+~/.agents/                             <-- optional for remote-only installs
 ```
 
 The connector extends `BaseConnector` from `@signet/connector-base` and ships a self-contained plugin bundle that OpenCode auto-discovers from its plugins directory.

--- a/integrations/opencode/connector/index.test.ts
+++ b/integrations/opencode/connector/index.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { parse } from "jsonc-parser/lib/esm/main.js";
 import { OpenCodeConnector } from "./src/index.js";
 
 const origHome = process.env.HOME;
@@ -15,6 +16,26 @@ function writeIdentity(dir: string): void {
 	for (const file of ["AGENTS.md", "SOUL.md", "IDENTITY.md", "USER.md"]) {
 		writeFileSync(join(dir, file), `# ${file}\n`, "utf-8");
 	}
+}
+
+interface TestMcpEntry {
+	readonly type?: string;
+	readonly command?: string[];
+	readonly url?: string;
+	readonly headers?: Record<string, string>;
+	readonly oauth?: boolean;
+	readonly enabled?: boolean;
+}
+
+interface TestConfig {
+	readonly agent: Record<string, unknown>;
+	readonly mcp: Record<string, TestMcpEntry>;
+	readonly plugin: unknown[];
+	readonly provider?: unknown;
+}
+
+function readConfig(path: string): TestConfig {
+	return parse(readFileSync(path, "utf-8"), undefined, { allowTrailingComma: true }) as TestConfig;
 }
 
 class TestableConnector extends OpenCodeConnector {
@@ -31,19 +52,23 @@ class TestableConnector extends OpenCodeConnector {
 beforeEach(() => {
 	tmpRoot = mkdtempSync(join(tmpdir(), "signet-opencode-test-"));
 	process.env.HOME = tmpRoot;
+	Reflect.deleteProperty(process.env, "SIGNET_DAEMON_URL");
+	Reflect.deleteProperty(process.env, "SIGNET_API_KEY");
+	Reflect.deleteProperty(process.env, "SIGNET_TOKEN");
+	Reflect.deleteProperty(process.env, "SIGNET_AGENT_ID");
 	mkdirSync(join(tmpRoot, ".config", "opencode"), { recursive: true });
 });
 
 afterEach(() => {
 	if (origHome !== undefined) process.env.HOME = origHome;
-	else delete process.env.HOME;
+	else Reflect.deleteProperty(process.env, "HOME");
 	for (const [key, value] of Object.entries({
 		SIGNET_DAEMON_URL: origDaemonUrl,
 		SIGNET_API_KEY: origApiKey,
 		SIGNET_TOKEN: origToken,
 		SIGNET_AGENT_ID: origAgentId,
 	})) {
-		if (value === undefined) delete process.env[key];
+		if (value === undefined) Reflect.deleteProperty(process.env, key);
 		else process.env[key] = value;
 	}
 	if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
@@ -53,11 +78,7 @@ describe("OpenCodeConnector.install — legacy SIGNET block migration", () => {
 	it("strips legacy block from AGENTS.md and reports path in filesWritten", async () => {
 		writeIdentity(tmpRoot);
 		const agentsPath = join(tmpRoot, "AGENTS.md");
-		writeFileSync(
-			agentsPath,
-			`before\n<!-- SIGNET:START -->\nmanaged block\n<!-- SIGNET:END -->\nafter\n`,
-			"utf-8",
-		);
+		writeFileSync(agentsPath, "before\n<!-- SIGNET:START -->\nmanaged block\n<!-- SIGNET:END -->\nafter\n", "utf-8");
 		const result = await new OpenCodeConnector().install(tmpRoot);
 		expect(readFileSync(agentsPath, "utf-8")).toBe("before\nafter\n");
 		expect(result.filesWritten).toContain(agentsPath);
@@ -73,11 +94,7 @@ describe("OpenCodeConnector.install — legacy SIGNET block migration", () => {
 
 	it("does not strip AGENTS.md when identity check fails", async () => {
 		const agentsPath = join(tmpRoot, "AGENTS.md");
-		writeFileSync(
-			agentsPath,
-			`before\n<!-- SIGNET:START -->\nmanaged block\n<!-- SIGNET:END -->\nafter\n`,
-			"utf-8",
-		);
+		writeFileSync(agentsPath, "before\n<!-- SIGNET:START -->\nmanaged block\n<!-- SIGNET:END -->\nafter\n", "utf-8");
 		const result = await new OpenCodeConnector().install(tmpRoot);
 		expect(result.success).toBe(false);
 		expect(readFileSync(agentsPath, "utf-8")).toContain("<!-- SIGNET:START -->");
@@ -200,57 +217,151 @@ describe("OpenCodeConnector — pipeline agent registration", () => {
 		expect(config.agent).toBeUndefined();
 	});
 
-	it("install works with JSONC config files", async () => {
+	it("continues uninstall cleanup when another config candidate is malformed", async () => {
+		const jsonPath = join(ocPath(), "opencode.json");
+		const jsoncPath = join(ocPath(), "opencode.jsonc");
+		writeFileSync(
+			jsonPath,
+			JSON.stringify({
+				plugin: ["./plugins/signet.mjs", "./keep.mjs"],
+				mcp: { signet: { type: "remote" }, keep: { type: "remote" } },
+				agent: { "signet-pipeline": EXPECTED_AGENT, keep: { prompt: "keep" } },
+			}),
+			"utf-8",
+		);
+		writeFileSync(jsoncPath, "{ invalid", "utf-8");
+		mkdirSync(join(ocPath(), "plugins"), { recursive: true });
+		writeFileSync(join(ocPath(), "plugins", "signet.mjs"), "plugin", "utf-8");
+		writeFileSync(join(ocPath(), "plugins", ".signet-api-key"), "secret", "utf-8");
+		const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+		try {
+			await new TestableConnector(ocPath()).uninstall();
+		} finally {
+			warn.mockRestore();
+		}
+
+		const config = readConfig(jsonPath);
+		expect(config.plugin).toEqual(["./keep.mjs"]);
+		expect(config.mcp).toEqual({ keep: { type: "remote" } });
+		expect(config.agent).toEqual({ keep: { prompt: "keep" } });
+		expect(readFileSync(jsoncPath, "utf-8")).toBe("{ invalid");
+		expect(existsSync(join(ocPath(), "plugins", "signet.mjs"))).toBe(false);
+		expect(existsSync(join(ocPath(), "plugins", ".signet-api-key"))).toBe(false);
+	});
+
+	it("preserves JSONC comments while updating unrelated configuration", async () => {
 		writeIdentity(tmpRoot);
 		const configPath = join(ocPath(), "opencode.jsonc");
-		writeFileSync(configPath, '{\n  // comment\n  "provider": {}\n}\n', "utf-8");
+		writeFileSync(configPath, '{\n  // keep this provider comment\n  "provider": {},\n}\n', "utf-8");
 
 		await new TestableConnector(ocPath()).install(tmpRoot);
 
-		const config = JSON.parse(readFileSync(configPath, "utf-8"));
+		const raw = readFileSync(configPath, "utf-8");
+		const config = readConfig(configPath);
+		expect(raw).toContain("// keep this provider comment");
+		expect(raw).toContain('"provider": {}');
 		expect(config.agent["signet-pipeline"]).toEqual(EXPECTED_AGENT);
 	});
 
-	it("install persists remote Signet env into MCP config and plugin bootstrap", async () => {
-		writeIdentity(tmpRoot);
-		process.env.SIGNET_DAEMON_URL = "https://daemon.example.test:3850";
+	it("installs remotely without identity and patches the highest-precedence config", async () => {
+		process.env.SIGNET_DAEMON_URL = "https://daemon.example.test:3850/";
 		process.env.SIGNET_API_KEY = "sig_sk_opencode_test_secret";
 		process.env.SIGNET_AGENT_ID = "opencode-remote";
-		const configPath = join(ocPath(), "opencode.json");
-		writeFileSync(configPath, JSON.stringify({ provider: {} }), "utf-8");
+		const jsonPath = join(ocPath(), "opencode.json");
+		const jsoncPath = join(ocPath(), "opencode.jsonc");
+		writeFileSync(
+			jsonPath,
+			JSON.stringify({
+				plugin: ["./lower-precedence.mjs"],
+				mcp: { signet: { type: "local", command: ["signet-mcp"], enabled: true } },
+			}),
+			"utf-8",
+		);
+		writeFileSync(
+			jsoncPath,
+			'{\n  // highest-precedence user config\n  "plugin": ["./existing.mjs", ["package-plugin", { "option": true }]],\n  "provider": { "custom": {} },\n}\n',
+			"utf-8",
+		);
 
-		await new TestableConnector(ocPath()).install(tmpRoot);
+		const connector = new TestableConnector(ocPath());
+		const result = await connector.install(join(tmpRoot, "missing-workspace"));
 
-		const config = JSON.parse(readFileSync(configPath, "utf-8"));
-		expect(config.mcp.signet.environment).toEqual({
-			SIGNET_DAEMON_URL: "https://daemon.example.test:3850",
-			SIGNET_API_KEY: "sig_sk_opencode_test_secret",
-			SIGNET_AGENT_ID: "opencode-remote",
+		expect(result.success).toBe(true);
+		expect(connector.getConfigPath()).toBe(jsoncPath);
+		const raw = readFileSync(jsoncPath, "utf-8");
+		const config = readConfig(jsoncPath);
+		expect(raw).toContain("// highest-precedence user config");
+		expect(config.provider).toEqual({ custom: {} });
+		expect(config.plugin).toEqual(["./existing.mjs", ["package-plugin", { option: true }], "./plugins/signet.mjs"]);
+		expect(config.mcp.signet).toEqual({
+			type: "remote",
+			url: "https://daemon.example.test:3850/mcp",
+			headers: { Authorization: "Bearer {file:./plugins/.signet-api-key}" },
+			oauth: false,
+			enabled: true,
 		});
+		expect(readConfig(jsonPath).mcp).toBeUndefined();
+		expect(config.agent["signet-pipeline"]).toEqual(EXPECTED_AGENT);
+		expect(existsSync(join(ocPath(), "AGENTS.md"))).toBe(false);
+
 		const plugin = readFileSync(join(ocPath(), "plugins", "signet.mjs"), "utf-8");
 		expect(plugin).toContain('process.env["SIGNET_DAEMON_URL"] = "https://daemon.example.test:3850";');
-		expect(plugin).toContain('process.env["SIGNET_API_KEY"] = "sig_sk_opencode_test_secret";');
+		expect(plugin).toContain('__signetReadFileSync');
+		expect(plugin).not.toContain("sig_sk_opencode_test_secret");
 		expect(plugin).toContain('process.env["SIGNET_AGENT_ID"] = "opencode-remote";');
+		const apiKeyFile = join(ocPath(), "plugins", ".signet-api-key");
+		expect(readFileSync(apiKeyFile, "utf-8")).toBe("sig_sk_opencode_test_secret\n");
+		if (process.platform !== "win32") expect(statSync(apiKeyFile).mode & 0o777).toBe(0o600);
 	});
 
-	it("install creates opencode.json when no config file exists", async () => {
+	it("rejects invalid remote daemon URLs before writing connector files", async () => {
+		process.env.SIGNET_DAEMON_URL = "https://daemon.example.test:3850/not-an-origin";
+		const connector = new TestableConnector(ocPath());
+
+		await expect(connector.install(join(tmpRoot, "missing-workspace"))).rejects.toThrow(
+			"SIGNET_DAEMON_URL must point at the daemon origin",
+		);
+		expect(existsSync(join(ocPath(), "plugins", "signet.mjs"))).toBe(false);
+	});
+
+	it("rejects malformed lower-precedence config before writing any artifacts", async () => {
+		process.env.SIGNET_DAEMON_URL = "https://daemon.example.test:3850";
+		writeIdentity(tmpRoot);
+		const agentsPath = join(tmpRoot, "AGENTS.md");
+		const agents = "before\n<!-- SIGNET:START -->\nmanaged block\n<!-- SIGNET:END -->\nafter\n";
+		writeFileSync(agentsPath, agents, "utf-8");
+		const jsoncPath = join(ocPath(), "opencode.jsonc");
+		const legacyPath = join(ocPath(), "config.json");
+		writeFileSync(jsoncPath, '{ "provider": {} }\n', "utf-8");
+		writeFileSync(legacyPath, "{ invalid", "utf-8");
+		const connector = new TestableConnector(ocPath());
+
+		await expect(connector.install(tmpRoot)).rejects.toThrow(
+			`Cannot update OpenCode config ${legacyPath}`,
+		);
+		expect(readFileSync(jsoncPath, "utf-8")).toBe('{ "provider": {} }\n');
+		expect(readFileSync(legacyPath, "utf-8")).toBe("{ invalid");
+		expect(readFileSync(agentsPath, "utf-8")).toBe(agents);
+		expect(existsSync(join(ocPath(), "plugins"))).toBe(false);
+	});
+
+	it("install creates opencode.jsonc when no config file exists", async () => {
 		writeIdentity(tmpRoot);
 		const freshOcPath = join(tmpRoot, ".config", "opencode-fresh");
 		mkdirSync(freshOcPath, { recursive: true });
 
 		await new TestableConnector(freshOcPath).install(tmpRoot);
 
-		const configPath = join(freshOcPath, "opencode.json");
-		const config = JSON.parse(readFileSync(configPath, "utf-8"));
+		const configPath = join(freshOcPath, "opencode.jsonc");
+		const config = readConfig(configPath);
 		// ensureConfigFile creates the empty file before registerPlugin,
 		// registerMcpServer, and registerPipelineAgent — all three entries
 		// must be present to prove the ordering fix works.
 		expect(config.agent["signet-pipeline"]).toEqual(EXPECTED_AGENT);
-		expect(config.mcp).toBeDefined();
-		expect(config.mcp.signet).toBeDefined();
 		expect(config.mcp.signet.type).toBe("local");
+		expect(config.mcp.signet.command).toEqual(["signet-mcp"]);
 		expect(config.mcp.signet.enabled).toBe(true);
-		expect(Array.isArray(config.plugin)).toBe(true);
-		expect(config.plugin.length).toBeGreaterThan(0);
+		expect(config.plugin).toEqual(["./plugins/signet.mjs"]);
 	});
 });

--- a/integrations/opencode/connector/package.json
+++ b/integrations/opencode/connector/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "@signet/connector-base": "0.147.21",
-    "@signet/core": "0.147.21"
+    "@signet/core": "0.147.21",
+    "jsonc-parser": "3.3.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/opencode/connector/src/index.ts
+++ b/integrations/opencode/connector/src/index.ts
@@ -22,8 +22,23 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, relative } from "node:path";
-import { BaseConnector, type InstallResult, type UninstallResult, atomicWriteJson, isSignetGeneratedFile } from "@signet/connector-base";
-import { OPENCODE_PIPELINE_AGENT, OPENCODE_PIPELINE_SYSTEM_PROMPT, expandHome, hasValidIdentity, loadIdentityMode } from "@signet/core";
+import {
+	BaseConnector,
+	type InstallResult,
+	type UninstallResult,
+	atomicWriteJson,
+	atomicWriteText,
+	isSignetGeneratedFile,
+} from "@signet/connector-base";
+import {
+	OPENCODE_PIPELINE_AGENT,
+	OPENCODE_PIPELINE_SYSTEM_PROMPT,
+	expandHome,
+	hasValidIdentity,
+	loadIdentityMode,
+	resolveSignetDaemonUrl,
+} from "@signet/core";
+import { type ParseError, applyEdits, modify, parse } from "jsonc-parser/lib/esm/main.js";
 import { PLUGIN_BUNDLE } from "./plugin-bundle.js";
 
 // ============================================================================
@@ -31,6 +46,8 @@ import { PLUGIN_BUNDLE } from "./plugin-bundle.js";
 // ============================================================================
 
 type JsonObject = Record<string, unknown>;
+
+const API_KEY_FILE_NAME = ".signet-api-key";
 
 function isJsonObject(value: unknown): value is JsonObject {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -43,7 +60,7 @@ function readTrimmedEnv(name: string): string | undefined {
 
 function signetRuntimeEnv(): Record<string, string> {
 	const env: Record<string, string> = {};
-	const daemonUrl = readTrimmedEnv("SIGNET_DAEMON_URL");
+	const daemonUrl = configuredDaemonUrl();
 	const apiKey = readTrimmedEnv("SIGNET_API_KEY") ?? readTrimmedEnv("SIGNET_TOKEN");
 	const agentId = readTrimmedEnv("SIGNET_AGENT_ID");
 	if (daemonUrl) env.SIGNET_DAEMON_URL = daemonUrl;
@@ -52,159 +69,59 @@ function signetRuntimeEnv(): Record<string, string> {
 	return env;
 }
 
-function buildPluginBundle(): string {
+function buildPluginBundle(apiKeyFilePath?: string): string {
 	const env = signetRuntimeEnv();
-	const entries = Object.entries(env);
-	if (entries.length === 0) return PLUGIN_BUNDLE;
-	const bootstrap = entries
-		.map(([key, value]) => `process.env[${JSON.stringify(key)}] = ${JSON.stringify(value)};`)
-		.join("\n");
-	return `${bootstrap}\n${PLUGIN_BUNDLE}`;
-}
-
-function toStringArray(value: unknown): string[] {
-	if (!Array.isArray(value)) return [];
-
-	const strings: string[] = [];
-	for (const item of value) {
-		if (typeof item === "string") {
-			strings.push(item);
-		}
+	if (apiKeyFilePath) delete env.SIGNET_API_KEY;
+	const assignments = Object.entries(env).map(
+		([key, value]) => `process.env[${JSON.stringify(key)}] = ${JSON.stringify(value)};`,
+	);
+	if (apiKeyFilePath) {
+		assignments.unshift('import { readFileSync as __signetReadFileSync } from "node:fs";');
+		assignments.push(
+			`process.env["SIGNET_API_KEY"] = __signetReadFileSync(${JSON.stringify(apiKeyFilePath)}, "utf-8").trim();`,
+		);
 	}
-
-	return strings;
-}
-
-function stripJsonComments(source: string): string {
-	let result = "";
-	let inString = false;
-	let quote = '"';
-	let escaped = false;
-	let inSingleLineComment = false;
-	let inMultiLineComment = false;
-
-	for (let i = 0; i < source.length; i++) {
-		const ch = source[i];
-		const next = source[i + 1];
-
-		if (inSingleLineComment) {
-			if (ch === "\n") {
-				inSingleLineComment = false;
-				result += ch;
-			}
-			continue;
-		}
-
-		if (inMultiLineComment) {
-			if (ch === "*" && next === "/") {
-				inMultiLineComment = false;
-				i++;
-			}
-			continue;
-		}
-
-		if (inString) {
-			result += ch;
-			if (escaped) {
-				escaped = false;
-			} else if (ch === "\\") {
-				escaped = true;
-			} else if (ch === quote) {
-				inString = false;
-			}
-			continue;
-		}
-
-		if (ch === '"' || ch === "'") {
-			inString = true;
-			quote = ch;
-			result += ch;
-			continue;
-		}
-
-		if (ch === "/" && next === "/") {
-			inSingleLineComment = true;
-			i++;
-			continue;
-		}
-
-		if (ch === "/" && next === "*") {
-			inMultiLineComment = true;
-			i++;
-			continue;
-		}
-
-		result += ch;
-	}
-
-	return result;
-}
-
-function stripTrailingCommas(source: string): string {
-	let result = "";
-	let inString = false;
-	let quote = '"';
-	let escaped = false;
-
-	for (let i = 0; i < source.length; i++) {
-		const ch = source[i];
-
-		if (inString) {
-			result += ch;
-			if (escaped) {
-				escaped = false;
-			} else if (ch === "\\") {
-				escaped = true;
-			} else if (ch === quote) {
-				inString = false;
-			}
-			continue;
-		}
-
-		if (ch === '"' || ch === "'") {
-			inString = true;
-			quote = ch;
-			result += ch;
-			continue;
-		}
-
-		if (ch === ",") {
-			let j = i + 1;
-			while (j < source.length && /\s/.test(source[j])) {
-				j++;
-			}
-			if (source[j] === "}" || source[j] === "]") {
-				continue;
-			}
-		}
-
-		result += ch;
-	}
-
-	return result;
+	if (assignments.length === 0) return PLUGIN_BUNDLE;
+	return `${assignments.join("\n")}\n${PLUGIN_BUNDLE}`;
 }
 
 function parseJsonOrJsonc(raw: string): JsonObject {
-	const content = raw.replace(/^\uFEFF/, "");
-
-	try {
-		const parsed: unknown = JSON.parse(content);
-		if (isJsonObject(parsed)) {
-			return parsed;
-		}
-	} catch {
-		// Fall through to JSONC-compatible parse.
+	const errors: ParseError[] = [];
+	const parsed: unknown = parse(raw.replace(/^\uFEFF/, ""), errors, {
+		allowTrailingComma: true,
+		disallowComments: false,
+	});
+	if (errors.length > 0) {
+		const first = errors[0];
+		throw new Error(`Invalid OpenCode JSONC at offset ${first.offset} (code ${first.error})`);
 	}
-
-	const withoutComments = stripJsonComments(content);
-	const withoutTrailingCommas = stripTrailingCommas(withoutComments);
-	const parsed: unknown = JSON.parse(withoutTrailingCommas);
-
-	if (!isJsonObject(parsed)) {
-		throw new Error("OpenCode config must be a top-level object");
-	}
-
+	if (!isJsonObject(parsed)) throw new Error("OpenCode config must be a top-level object");
 	return parsed;
+}
+
+function formattingOptions(source: string): { insertSpaces: boolean; tabSize: number; eol: string } {
+	const indent = source.match(/(?:^|\r?\n)([\t ]+)"/)?.[1];
+	return {
+		insertSpaces: !indent?.includes("\t"),
+		tabSize: indent && !indent.includes("\t") ? indent.length : 2,
+		eol: source.includes("\r\n") ? "\r\n" : "\n",
+	};
+}
+
+function writeConfigValue(configPath: string, path: readonly (string | number)[], value: unknown): void {
+	const raw = readFileSync(configPath, "utf-8");
+	const hasBom = raw.startsWith("\uFEFF");
+	const source = hasBom ? raw.slice(1) : raw;
+	const edits = modify(source, [...path], value, { formattingOptions: formattingOptions(source) });
+	if (edits.length === 0) return;
+	const updated = applyEdits(source, edits);
+	atomicWriteText(configPath, hasBom ? `\uFEFF${updated}` : updated);
+}
+
+function configuredDaemonUrl(): string | undefined {
+	const daemonUrl = readTrimmedEnv("SIGNET_DAEMON_URL");
+	if (!daemonUrl) return undefined;
+	return resolveSignetDaemonUrl({ env: { SIGNET_DAEMON_URL: daemonUrl } });
 }
 
 // ============================================================================
@@ -232,7 +149,7 @@ export class OpenCodeConnector extends BaseConnector {
 				return candidate;
 			}
 		}
-		return join(opencodePath, "opencode.json");
+		return join(opencodePath, "opencode.jsonc");
 	}
 
 	private getPluginsPath(opencodePath: string): string {
@@ -241,6 +158,10 @@ export class OpenCodeConnector extends BaseConnector {
 
 	private getPluginFilePath(opencodePath: string): string {
 		return join(this.getPluginsPath(opencodePath), "signet.mjs");
+	}
+
+	private getApiKeyFilePath(opencodePath: string): string {
+		return join(this.getPluginsPath(opencodePath), API_KEY_FILE_NAME);
 	}
 
 	private getPluginConfigEntry(opencodePath: string): string {
@@ -259,10 +180,11 @@ export class OpenCodeConnector extends BaseConnector {
 	async install(basePath: string): Promise<InstallResult> {
 		const filesWritten: string[] = [];
 		const expandedBasePath = expandHome(basePath || join(homedir(), ".agents"));
+		const daemonUrl = configuredDaemonUrl();
+		const identityAvailable = hasValidIdentity(expandedBasePath);
+		const identityMode = identityAvailable ? loadIdentityMode(expandedBasePath) : undefined;
 
-		const identityMode = loadIdentityMode(expandedBasePath);
-
-		if (!hasValidIdentity(expandedBasePath)) {
+		if (!identityAvailable && !daemonUrl) {
 			return {
 				success: false,
 				message: `No valid Signet identity found at ${expandedBasePath}`,
@@ -270,13 +192,20 @@ export class OpenCodeConnector extends BaseConnector {
 			};
 		}
 
-		const strippedAgentsPath = this.stripLegacySignetBlock(expandedBasePath);
-		if (strippedAgentsPath !== null) {
-			filesWritten.push(strippedAgentsPath);
-		}
-
 		const opencodePath = this.getOpenCodePath();
 		const pluginsPath = this.getPluginsPath(opencodePath);
+
+		// OpenCode parses every global config layer. Validate all of them before
+		// mutating anything so a malformed lower-precedence file cannot leave a
+		// partial install or make the effective integration unloadable.
+		this.validateConfigCandidates(opencodePath);
+
+		if (identityAvailable) {
+			const strippedAgentsPath = this.stripLegacySignetBlock(expandedBasePath);
+			if (strippedAgentsPath !== null) {
+				filesWritten.push(strippedAgentsPath);
+			}
+		}
 
 		if (!existsSync(opencodePath)) {
 			mkdirSync(opencodePath, { recursive: true });
@@ -289,22 +218,36 @@ export class OpenCodeConnector extends BaseConnector {
 		// Migrate away from legacy memory.mjs before writing new plugin
 		this.migrateFromLegacy(opencodePath);
 
+		// Keep remote credentials out of the world-readable config and plugin.
+		// OpenCode expands the file token while loading config, and the lifecycle
+		// plugin reads the same mode-0600 file at runtime.
+		const apiKey = readTrimmedEnv("SIGNET_API_KEY") ?? readTrimmedEnv("SIGNET_TOKEN");
+		const apiKeyFilePath = this.getApiKeyFilePath(opencodePath);
+		if (apiKey) {
+			atomicWriteText(apiKeyFilePath, `${apiKey}\n`, 0o600);
+			filesWritten.push(apiKeyFilePath);
+		} else if (existsSync(apiKeyFilePath)) {
+			rmSync(apiKeyFilePath);
+		}
+
 		// Write bundled plugin and register it in config so runtime loading
 		// does not depend on undocumented auto-discovery behavior.
 		const pluginFilePath = this.getPluginFilePath(opencodePath);
-		writeFileSync(pluginFilePath, buildPluginBundle());
+		writeFileSync(pluginFilePath, buildPluginBundle(apiKey ? apiKeyFilePath : undefined));
 		filesWritten.push(pluginFilePath);
 		this.ensureConfigFile(opencodePath);
 		this.registerPlugin(opencodePath);
 
-		// Generate AGENTS.md from identity files only when identity is managed
+		// Generate AGENTS.md only from an available managed identity. Remote-only
+		// installs do not synthesize a local workspace or identity files.
 		if (identityMode === "managed") {
 			const agentsMdPath = await this.generateAgentsMd(expandedBasePath);
 			if (agentsMdPath) {
 				filesWritten.push(agentsMdPath);
 			}
 		} else {
-			// Clean up any previously Signet-generated AGENTS.md when identity is off/passthrough
+			// Clean up any previously Signet-generated AGENTS.md when identity is
+			// unavailable, off, or passthrough. User-owned files are untouched.
 			const staleAgentsMd = join(this.getOpenCodePath(), "AGENTS.md");
 			if (existsSync(staleAgentsMd)) {
 				try {
@@ -318,8 +261,9 @@ export class OpenCodeConnector extends BaseConnector {
 			}
 		}
 
-		// Register Signet MCP server in OpenCode config
-		this.registerMcpServer(opencodePath);
+		// Explicit daemon URLs use OpenCode's remote Streamable HTTP MCP client.
+		// Local installs retain the packaged signet-mcp stdio behavior.
+		this.registerMcpServer(opencodePath, daemonUrl, apiKey ? `./plugins/${API_KEY_FILE_NAME}` : undefined);
 
 		// Register pipeline agent for lightweight extraction sessions
 		this.registerPipelineAgent(opencodePath);
@@ -327,7 +271,7 @@ export class OpenCodeConnector extends BaseConnector {
 		// Symlink skills directory
 		const skillsSource = join(expandedBasePath, "skills");
 		const skillsDest = join(opencodePath, "skills");
-		if (existsSync(skillsSource)) {
+		if (identityAvailable && existsSync(skillsSource)) {
 			this.symlinkSkills(skillsSource, skillsDest);
 		}
 
@@ -349,6 +293,12 @@ export class OpenCodeConnector extends BaseConnector {
 		if (existsSync(pluginFilePath)) {
 			rmSync(pluginFilePath);
 			filesRemoved.push(pluginFilePath);
+		}
+
+		const apiKeyFilePath = this.getApiKeyFilePath(opencodePath);
+		if (existsSync(apiKeyFilePath)) {
+			rmSync(apiKeyFilePath);
+			filesRemoved.push(apiKeyFilePath);
 		}
 
 		const agentsMdPath = join(opencodePath, "AGENTS.md");
@@ -404,179 +354,149 @@ export class OpenCodeConnector extends BaseConnector {
 	// ============================================================================
 
 	/**
-	 * Remove legacy memory.mjs installation artifacts
-	 *
-	 * Deletes the old memory.mjs from the OpenCode root directory and scrubs
-	 * any file:// URL or path referencing it from all known config candidates.
+	 * Remove legacy memory.mjs installation artifacts.
 	 */
 	private migrateFromLegacy(opencodePath: string): void {
 		const legacyPluginPath = join(opencodePath, "memory.mjs");
-
-		if (existsSync(legacyPluginPath)) {
-			rmSync(legacyPluginPath);
-		}
+		if (existsSync(legacyPluginPath)) rmSync(legacyPluginPath);
 
 		for (const configPath of this.getConfigCandidates(opencodePath)) {
 			if (!existsSync(configPath)) continue;
-
-			let config: JsonObject;
-			try {
-				config = parseJsonOrJsonc(readFileSync(configPath, "utf-8"));
-			} catch {
-				continue;
-			}
-
-			const changed = this.removeMemoryMjsEntries(config);
-			if (changed) {
-				atomicWriteJson(configPath, config);
+			const config = this.readConfigForCleanup(configPath);
+			if (!config) continue;
+			for (const key of ["plugin", "plugins"] as const) {
+				const entries = Array.isArray(config[key]) ? config[key] : [];
+				this.removeArrayEntries(configPath, key, entries, (entry) => this.isLegacyPluginEntry(entry));
 			}
 		}
-	}
-
-	/**
-	 * Scrub any plugin entry that references memory.mjs from the config object.
-	 * Returns true if the config was modified.
-	 */
-	private removeMemoryMjsEntries(config: JsonObject): boolean {
-		const isLegacyEntry = (entry: string): boolean => {
-			const t = entry.trim();
-			if (t === "./memory.mjs" || t === "memory.mjs") return true;
-			if (t.endsWith("/memory.mjs")) return true;
-			return false;
-		};
-
-		let changed = false;
-
-		for (const key of ["plugin", "plugins"] as const) {
-			if (!(key in config)) continue;
-
-			const current = toStringArray(config[key]);
-			const filtered = current.filter((e) => !isLegacyEntry(e));
-
-			if (filtered.length !== current.length) {
-				config[key] = filtered;
-				changed = true;
-			}
-		}
-
-		return changed;
 	}
 
 	// ============================================================================
 	// Internal helpers
 	// ============================================================================
 
-	/**
-	 * Register Signet MCP server in OpenCode config file
-	 */
+	private readConfig(configPath: string): JsonObject {
+		try {
+			return parseJsonOrJsonc(readFileSync(configPath, "utf-8"));
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new Error(`Cannot update OpenCode config ${configPath}: ${message}`);
+		}
+	}
+
+	private validateConfigCandidates(opencodePath: string): void {
+		for (const configPath of this.getConfigCandidates(opencodePath)) {
+			if (existsSync(configPath)) this.readConfig(configPath);
+		}
+	}
+
+	private readConfigForCleanup(configPath: string): JsonObject | undefined {
+		try {
+			return this.readConfig(configPath);
+		} catch (error) {
+			console.warn(`[signet] Warning: ${error instanceof Error ? error.message : String(error)}`);
+			return undefined;
+		}
+	}
+
+	private isLegacyPluginEntry(entry: unknown): boolean {
+		if (typeof entry !== "string") return false;
+		const trimmed = entry.trim();
+		return trimmed === "./memory.mjs" || trimmed === "memory.mjs" || trimmed.endsWith("/memory.mjs");
+	}
+
+	private pluginSpecifier(entry: unknown): string | undefined {
+		if (typeof entry === "string") return entry;
+		if (Array.isArray(entry) && typeof entry[0] === "string") return entry[0];
+		return undefined;
+	}
+
+	private removeArrayEntries(
+		configPath: string,
+		key: string,
+		entries: readonly unknown[],
+		shouldRemove: (entry: unknown) => boolean,
+	): void {
+		for (let index = entries.length - 1; index >= 0; index--) {
+			if (shouldRemove(entries[index])) writeConfigValue(configPath, [key, index], undefined);
+		}
+	}
+
 	private registerPlugin(opencodePath: string): void {
 		const pluginEntry = this.getPluginConfigEntry(opencodePath);
-
-		for (const configPath of this.getConfigCandidates(opencodePath)) {
-			if (!existsSync(configPath)) continue;
-
-			let config: JsonObject;
-			try {
-				config = parseJsonOrJsonc(readFileSync(configPath, "utf-8"));
-			} catch {
-				continue;
-			}
-
-			const existing = toStringArray(config.plugin);
-			if (!existing.includes(pluginEntry)) {
-				config.plugin = [...existing, pluginEntry];
-				atomicWriteJson(configPath, config);
-			}
-			return;
+		this.removePlugin(opencodePath);
+		const configPath = this.getConfigPath();
+		const config = this.readConfig(configPath);
+		const entries = Array.isArray(config.plugin) ? config.plugin : [];
+		if (Array.isArray(config.plugin)) {
+			writeConfigValue(configPath, ["plugin", entries.length], pluginEntry);
+		} else {
+			writeConfigValue(configPath, ["plugin"], [pluginEntry]);
 		}
 	}
 
 	private removePlugin(opencodePath: string): void {
 		const pluginEntry = this.getPluginConfigEntry(opencodePath);
-
 		for (const configPath of this.getConfigCandidates(opencodePath)) {
 			if (!existsSync(configPath)) continue;
+			const config = this.readConfigForCleanup(configPath);
+			if (!config) continue;
+			const entries = Array.isArray(config.plugin) ? config.plugin : [];
+			this.removeArrayEntries(configPath, "plugin", entries, (entry) => this.pluginSpecifier(entry) === pluginEntry);
+		}
+	}
 
-			let config: JsonObject;
-			try {
-				config = parseJsonOrJsonc(readFileSync(configPath, "utf-8"));
-			} catch {
-				continue;
-			}
+	private registerMcpServer(opencodePath: string, daemonUrl?: string, apiKeyFile?: string): void {
+		// Remove old local/remote Signet entries from every precedence layer first.
+		// Otherwise OpenCode's deep merge can retain incompatible local fields.
+		this.removeMcpServer(opencodePath);
+		const configPath = this.getConfigPath();
+		this.readConfig(configPath);
 
-			const existing = toStringArray(config.plugin);
-			const filtered = existing.filter((entry) => entry !== pluginEntry);
-			if (filtered.length !== existing.length) {
-				config.plugin = filtered;
-				atomicWriteJson(configPath, config);
-			}
+		if (daemonUrl) {
+			writeConfigValue(configPath, ["mcp", "signet"], {
+				type: "remote",
+				url: `${daemonUrl}/mcp`,
+				...(apiKeyFile ? { headers: { Authorization: `Bearer {file:${apiKeyFile}}` } } : {}),
+				oauth: false,
+				enabled: true,
+			});
 			return;
 		}
-	}
 
-	private registerMcpServer(opencodePath: string): void {
-		for (const configPath of this.getConfigCandidates(opencodePath)) {
-			if (!existsSync(configPath)) continue;
-
-			let config: JsonObject;
-			try {
-				config = parseJsonOrJsonc(readFileSync(configPath, "utf-8"));
-			} catch {
-				continue;
+		// On Windows, spawn() without shell:true cannot resolve .cmd wrappers,
+		// so use "node" + mcp-stdio.js path instead.
+		let mcpCommand: string[] = ["signet-mcp"];
+		if (process.platform === "win32") {
+			const cliEntry = process.argv[1] || "";
+			const mcpJs = join(cliEntry, "..", "..", "dist", "mcp-stdio.js");
+			if (existsSync(mcpJs)) {
+				mcpCommand = [process.execPath, mcpJs];
+			} else {
+				console.warn(
+					`[signet] Warning: could not resolve mcp-stdio.js from argv[1]="${cliEntry}". MCP server config will use "signet-mcp" which may fail on Windows without shell:true.`,
+				);
 			}
-
-			const existingMcp = isJsonObject(config.mcp) ? (config.mcp as JsonObject) : {};
-			// On Windows, spawn() without shell:true cannot resolve .cmd
-			// wrappers, so use "node" + mcp-stdio.js path instead.
-			let mcpCommand: string[] = ["signet-mcp"];
-			if (process.platform === "win32") {
-				const cliEntry = process.argv[1] || "";
-				const mcpJs = join(cliEntry, "..", "..", "dist", "mcp-stdio.js");
-				if (existsSync(mcpJs)) {
-					mcpCommand = [process.execPath, mcpJs];
-				} else {
-					console.warn(
-						`[signet] Warning: could not resolve mcp-stdio.js from argv[1]="${cliEntry}". ` +
-							`MCP server config will use "signet-mcp" which may fail on Windows without shell:true.`,
-					);
-				}
-			}
-			const environment = signetRuntimeEnv();
-			config.mcp = {
-				...existingMcp,
-				signet: {
-					type: "local",
-					command: mcpCommand,
-					...(Object.keys(environment).length > 0 ? { environment } : {}),
-					enabled: true,
-				},
-			};
-			atomicWriteJson(configPath, config);
-			return; // Only update first found config
 		}
+		const environment = signetRuntimeEnv();
+		if (apiKeyFile) environment.SIGNET_API_KEY = `{file:${apiKeyFile}}`;
+		writeConfigValue(configPath, ["mcp", "signet"], {
+			type: "local",
+			command: mcpCommand,
+			...(Object.keys(environment).length > 0 ? { environment } : {}),
+			enabled: true,
+		});
 	}
 
-	/**
-	 * Remove Signet MCP server from OpenCode config file
-	 */
 	private removeMcpServer(opencodePath: string): void {
 		for (const configPath of this.getConfigCandidates(opencodePath)) {
 			if (!existsSync(configPath)) continue;
-
-			let config: JsonObject;
-			try {
-				config = parseJsonOrJsonc(readFileSync(configPath, "utf-8"));
-			} catch {
-				continue;
-			}
-
-			if (isJsonObject(config.mcp)) {
-				const mcp = config.mcp as JsonObject;
-				delete mcp.signet;
-				if (Object.keys(mcp).length === 0) {
-					delete config.mcp;
-				}
-				atomicWriteJson(configPath, config);
+			const config = this.readConfigForCleanup(configPath);
+			if (!config || !isJsonObject(config.mcp) || !("signet" in config.mcp)) continue;
+			if (Object.keys(config.mcp).length === 1) {
+				writeConfigValue(configPath, ["mcp"], undefined);
+			} else {
+				writeConfigValue(configPath, ["mcp", "signet"], undefined);
 			}
 		}
 	}
@@ -590,49 +510,24 @@ export class OpenCodeConnector extends BaseConnector {
 	};
 
 	private registerPipelineAgent(opencodePath: string): void {
-		for (const configPath of this.getConfigCandidates(opencodePath)) {
-			if (!existsSync(configPath)) continue;
-
-			let config: JsonObject;
-			try {
-				config = parseJsonOrJsonc(readFileSync(configPath, "utf-8"));
-			} catch {
-				continue;
-			}
-
-			const agents = isJsonObject(config.agent) ? { ...(config.agent as JsonObject) } : {};
-			agents[OPENCODE_PIPELINE_AGENT] = { ...OpenCodeConnector.PIPELINE_AGENT_CONFIG };
-			config.agent = agents;
-			atomicWriteJson(configPath, config);
-			return;
-		}
+		this.removePipelineAgent(opencodePath);
+		const configPath = this.getConfigPath();
+		this.readConfig(configPath);
+		writeConfigValue(configPath, ["agent", OPENCODE_PIPELINE_AGENT], {
+			...OpenCodeConnector.PIPELINE_AGENT_CONFIG,
+		});
 	}
 
 	private removePipelineAgent(opencodePath: string): void {
 		for (const configPath of this.getConfigCandidates(opencodePath)) {
 			if (!existsSync(configPath)) continue;
-
-			let config: JsonObject;
-			try {
-				config = parseJsonOrJsonc(readFileSync(configPath, "utf-8"));
-			} catch {
-				continue;
-			}
-
-			if (!isJsonObject(config.agent)) continue;
-
-			const agents = config.agent as JsonObject;
-			if (!(OPENCODE_PIPELINE_AGENT in agents)) continue;
-
-			const { [OPENCODE_PIPELINE_AGENT]: _, ...rest } = agents;
-			if (Object.keys(rest).length === 0) {
-				const { agent: __, ...configWithoutAgent } = config;
-				atomicWriteJson(configPath, configWithoutAgent);
+			const config = this.readConfigForCleanup(configPath);
+			if (!config || !isJsonObject(config.agent) || !(OPENCODE_PIPELINE_AGENT in config.agent)) continue;
+			if (Object.keys(config.agent).length === 1) {
+				writeConfigValue(configPath, ["agent"], undefined);
 			} else {
-				config.agent = rest;
-				atomicWriteJson(configPath, config);
+				writeConfigValue(configPath, ["agent", OPENCODE_PIPELINE_AGENT], undefined);
 			}
-			return;
 		}
 	}
 
@@ -641,13 +536,16 @@ export class OpenCodeConnector extends BaseConnector {
 			if (existsSync(candidate)) return;
 		}
 		mkdirSync(opencodePath, { recursive: true });
-		atomicWriteJson(join(opencodePath, "opencode.json"), {});
+		atomicWriteJson(join(opencodePath, "opencode.jsonc"), {});
 	}
 
 	private getConfigCandidates(opencodePath: string): string[] {
+		// OpenCode loads config.json, opencode.json, then opencode.jsonc in
+		// increasing precedence. List candidates highest-first so a later file
+		// cannot replace Signet's plugin array.
 		return [
-			join(opencodePath, "opencode.json"),
 			join(opencodePath, "opencode.jsonc"),
+			join(opencodePath, "opencode.json"),
 			join(opencodePath, "config.json"),
 		];
 	}

--- a/libs/connector-base/index.test.ts
+++ b/libs/connector-base/index.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, relative, resolve } from "node:path";
 import {
 	BaseConnector,
 	type InstallResult,
 	type UninstallResult,
+	atomicWriteText,
 	removeManagedExtensionFile,
 	resolveSignetDaemonUrl,
 	resolveSignetWorkspacePath,
@@ -87,6 +88,20 @@ describe("BaseConnector.stripLegacySignetBlock", () => {
 		const strippedPath = connector.cleanup(dir);
 		expect(strippedPath).toBeNull();
 		expect(existsSync(join(dir, "AGENTS.md"))).toBe(false);
+	});
+});
+
+describe("atomicWriteText", () => {
+	it("replaces text without changing its contents", () => {
+		dir = mkdtempSync(join(tmpdir(), "signet-connector-base-atomic-"));
+		const file = join(dir, "config.jsonc");
+		writeFileSync(file, "old\n", "utf-8");
+		if (process.platform !== "win32") chmodSync(file, 0o600);
+
+		atomicWriteText(file, "{\n  // preserved\n}\n");
+
+		expect(readFileSync(file, "utf-8")).toBe("{\n  // preserved\n}\n");
+		if (process.platform !== "win32") expect(statSync(file).mode & 0o777).toBe(0o600);
 	});
 });
 

--- a/libs/connector-base/src/index.ts
+++ b/libs/connector-base/src/index.ts
@@ -33,7 +33,7 @@
  */
 
 import { randomBytes } from "node:crypto";
-import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import {
@@ -254,11 +254,18 @@ export function isSignetGeneratedFile(raw: string): boolean {
 // then renames (atomic on POSIX, near-atomic on Windows).
 // ============================================================================
 
-export function atomicWriteJson(path: string, data: unknown, indent: number | string = 2): void {
-	const content = `${JSON.stringify(data, null, indent)}\n`;
+export function atomicWriteText(path: string, content: string, mode?: number): void {
 	const tmp = join(dirname(path), `.${randomBytes(6).toString("hex")}.tmp`);
+	let writeMode = mode;
+	if (writeMode === undefined) {
+		try {
+			writeMode = statSync(path).mode & 0o777;
+		} catch {
+			// New files use the process umask.
+		}
+	}
 	try {
-		writeFileSync(tmp, content, "utf-8");
+		writeFileSync(tmp, content, { encoding: "utf-8", mode: writeMode });
 		renameSync(tmp, path);
 	} catch (err) {
 		try {
@@ -266,6 +273,10 @@ export function atomicWriteJson(path: string, data: unknown, indent: number | st
 		} catch {}
 		throw err;
 	}
+}
+
+export function atomicWriteJson(path: string, data: unknown, indent: number | string = 2): void {
+	atomicWriteText(path, `${JSON.stringify(data, null, indent)}\n`);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes #928 by making the documented standalone OpenCode connector work on a remote-only client with no local Signet identity. Remote installs now register the daemon's authenticated Streamable HTTP MCP endpoint, update the effective OpenCode config without destroying JSONC, and protect the persisted API key.

This is the sequencing prerequisite for #927 / PR #951 and the OpenCode portion of #931 / PR #950.

## Changes

- allow `--url` / `SIGNET_DAEMON_URL` installs without a local identity or workspace
- configure `<daemon-origin>/mcp` as an OpenCode `remote` MCP server with bearer auth and `oauth: false`; preserve local `signet-mcp` stdio behavior when no explicit daemon URL is set
- store the API key in a connector-managed mode-0600 file and reference it through OpenCode's `{file:}` substitution instead of embedding it in config or plugin source
- follow OpenCode's global config precedence (`opencode.jsonc`, then `opencode.json`, then `config.json` when selecting the write target)
- apply targeted `jsonc-parser` edits that preserve comments, trailing commas, tuple plugin entries, unrelated settings, and existing file permissions
- remove stale Signet entries from lower-precedence configs, while making uninstall best-effort around malformed candidates
- preflight every existing config before any install mutation to prevent partial installs
- default new OpenCode configs to `opencode.jsonc`
- document remote-only behavior and add regression coverage

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: OpenCode integration docs

`@signet/core` is consumed for canonical daemon URL validation; its package source is unchanged.

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
  - No issue-specific spec entry; reviewed for conflicts.
- [x] Agent scoping verified on all new/changed data queries (no data query changed; existing `SIGNET_AGENT_ID` propagation is preserved)
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints (N/A for endpoints; bearer credential persistence was reviewed and hardened)
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally (focused Biome/tests plus full workspace typecheck)

## Migration Notes (if applicable)

N/A — no database migration. Reinstalling removes stale Signet plugin/MCP/agent entries from lower-precedence OpenCode configs before registering the effective entry.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused validation:

- `bun test ./integrations/opencode/connector/index.test.ts` — 15 passed
- `env -u SIGNET_PATH bun test ./libs/connector-base/index.test.ts` — 18 passed
- `bun test ./scripts/check-publish-manifests.test.ts ./scripts/stage-npm-publish.test.ts` — 25 passed
- `bun run --cwd integrations/opencode/connector typecheck`
- `bun run --cwd integrations/opencode/connector build`
- `bun run --cwd libs/connector-base build`
- `bun run typecheck` — full workspace passed after the normal Pi connector bundle-generation prerequisites
- focused Biome checks and `git diff --check`
- final structured review after fixes — no findings

Staged-package runtime verification:

- staged the publish tree with `scripts/stage-npm-publish.ts`
- packed and installed only the staged `@signetai/core`, `@signetai/connector-base`, and `@signetai/connector-opencode` tarballs under `/Volumes/AverySSD/tmp`
- installed upstream OpenCode 1.18.4 in the same isolated temporary runtime
- installed against an absent workspace while both `opencode.json` and `opencode.jsonc` existed
- verified comment preservation, highest-precedence plugin/MCP registration, stale lower-precedence cleanup, no identity creation, mode-0600 credential storage, and no plaintext key in config/plugin
- `opencode debug config` resolved the plugin and `{file:}` bearer value
- `opencode mcp list` reported `signet` connected to the remote HTTP MCP endpoint
- the bundled lifecycle plugin and remote MCP client both reached an isolated mock daemon with the expected bearer header
- packed uninstall removed the plugin, credential, MCP entry, and pipeline agent while preserving unrelated JSONC

The runtime check used an isolated mock Signet daemon, not a real daemon. Full repository-wide `bun test` and `bun run lint` were not run; focused affected checks and the full workspace typecheck are green.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

OpenCode upstream config precedence, `{file:}` substitution, plugin loading, and authenticated remote MCP behavior were inspected directly from upstream source before implementation. PR #951 and PR #950 should rebase after this lands.

