### PR TITLE
fix(daemon): forward per-call reasoning ThinkingLevel to pi-ai (#959)

### DIFF
--- a/platform/daemon/src/inference-provider-factory.ts
+++ b/platform/daemon/src/inference-provider-factory.ts
@@ -65,9 +65,19 @@ export async function createRoutingProvider(opts: CreateRoutingProviderOptions):
 		model: model.model,
 		baseUrl: target.endpoint,
 		apiKey: credential,
-		reasoning:
-			target.openrouter?.reasoning?.enabled ??
-			(model.reasoning !== undefined ? model.reasoning === "deep" : undefined),
+		// Map routing intent to a pi-ai ThinkingLevel (forwarded per-call as
+		// options.reasoning). model.reasoning (RoutingReasoningDepth) defaults to
+		// "medium" for every parsed model, so it cannot alone signal "enable
+		// thinking" without flipping a costly default on for all routed calls.
+		// Treat only explicit non-default signals as intent to emit thinking:
+		// the documented OpenRouter reasoning block, or a deliberately-set
+		// "high" depth. Previously this compared to a nonexistent "deep"
+		// value (TS2367) and never produced a usable level.
+		reasoning: target.openrouter?.reasoning?.enabled
+			? "medium"
+			: model.reasoning === "high"
+				? "high"
+				: undefined,
 		contextWindow: model.contextWindow,
 		name: `${target.executor}:${model.model}`,
 		defaultTimeoutMs: 60_000,

--- a/platform/daemon/src/inference-router.test.ts
+++ b/platform/daemon/src/inference-router.test.ts
@@ -331,4 +331,151 @@ describe("InferenceRouter legacy API credentials", () => {
 			rmSync(dir, { recursive: true, force: true });
 		}
 	});
+
+	it("forwards per-call reasoning effort when OpenRouter reasoning is enabled (#959)", async () => {
+		// Regression guard for the reasoning fix: on `main`, the factory derived
+		// reasoning from `=== "deep"` (TS2367, never matched) and pi-provider.ts
+		// never forwarded options.reasoning, so thinking was always off. With the
+		// fix, OpenRouter reasoning.enabled produces reasoning: { effort: "medium" }
+		// on the wire. This test fails on main and passes at HEAD.
+		const dir = mkdtempSync(join(tmpdir(), "signet-router-openrouter-reasoning-on-"));
+		try {
+			mkdirSync(join(dir, "memory"), { recursive: true });
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`inference:
+  defaultPolicy: flash
+  accounts:
+    openrouter-api:
+      kind: api
+      providerFamily: openrouter
+      credentialRef: OPENROUTER_API_KEY
+  targets:
+    flash:
+      executor: openrouter
+      account: openrouter-api
+      openrouter:
+        reasoning:
+          enabled: true
+      models:
+        default:
+          model: deepseek/deepseek-v4-flash
+  policies:
+    flash:
+      mode: automatic
+      allow:
+        - flash/default
+      defaultTargets:
+        - flash/default
+  workloads:
+    sessionSynthesis:
+      target: flash/default
+      taskClass: session_synthesis
+`,
+			);
+
+			process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+			let requestBody: Record<string, unknown> | null = null;
+			globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+				const url = String(input);
+				if (url.endsWith("/chat/completions") && typeof init?.body === "string") {
+					const parsed: unknown = JSON.parse(init.body);
+					if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+						requestBody = parsed as Record<string, unknown>;
+					}
+				}
+				if (url.endsWith("/models")) {
+					return Promise.resolve(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+				}
+				return Promise.resolve(openAiSseResponse("flash answer"));
+			}) as unknown as typeof fetch;
+
+			const router = getOrCreateInferenceRouter(dir);
+			const result = await router.execute(
+				{ operation: "session_synthesis", promptPreview: "synthesize" },
+				"Summarize",
+				{ maxTokens: 64, timeoutMs: 1000 },
+			);
+
+			expect(result.ok).toBe(true);
+			// The fix forwards options.reasoning; pi-ai's openrouter thinkingFormat
+			// emits it as { effort: <level> }. Before the fix this was { effort: "none" }
+			// (disabled) or absent.
+			expect(requestBody?.reasoning).toEqual({ effort: "medium" });
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not enable reasoning for a medium-depth model by default (#959)", async () => {
+		// RoutingModelConfig.reasoning defaults to "medium" at parse time, so it
+		// must NOT be treated as intent to emit thinking (would flip a costly
+		// default on for every routed call). Only an explicit reasoning block or
+		// a "high" depth enables thinking.
+		const dir = mkdtempSync(join(tmpdir(), "signet-router-reasoning-medium-default-"));
+		try {
+			mkdirSync(join(dir, "memory"), { recursive: true });
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`inference:
+  defaultPolicy: med
+  accounts:
+    openrouter-api:
+      kind: api
+      providerFamily: openrouter
+      credentialRef: OPENROUTER_API_KEY
+  targets:
+    med:
+      executor: openrouter
+      account: openrouter-api
+      models:
+        default:
+          model: openai/gpt-4o-mini
+          # reasoning omitted -> parses to default "medium"
+  policies:
+    med:
+      mode: automatic
+      allow:
+        - med/default
+      defaultTargets:
+        - med/default
+  workloads:
+    sessionSynthesis:
+      target: med/default
+      taskClass: session_synthesis
+`,
+			);
+
+			process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+			let requestBody: Record<string, unknown> | null = null;
+			globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+				const url = String(input);
+				if (url.endsWith("/chat/completions") && typeof init?.body === "string") {
+					const parsed: unknown = JSON.parse(init.body);
+					if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+						requestBody = parsed as Record<string, unknown>;
+					}
+				}
+				if (url.endsWith("/models")) {
+					return Promise.resolve(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+				}
+				return Promise.resolve(openAiSseResponse("med answer"));
+			}) as unknown as typeof fetch;
+
+			const router = getOrCreateInferenceRouter(dir);
+			const result = await router.execute(
+				{ operation: "session_synthesis", promptPreview: "synthesize" },
+				"Summarize",
+				{ maxTokens: 64, timeoutMs: 1000 },
+			);
+
+			expect(result.ok).toBe(true);
+			// Default "medium" depth must NOT enable thinking. pi-ai emits
+			// { effort: "none" } (disabled) or omits — never "medium"/"high".
+			const effort = (requestBody?.reasoning as { effort?: string } | undefined)?.effort;
+			expect(effort === "medium" || effort === "high").toBe(false);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
 });

--- a/platform/daemon/src/inference-router.test.ts
+++ b/platform/daemon/src/inference-router.test.ts
@@ -478,4 +478,78 @@ describe("InferenceRouter legacy API credentials", () => {
 			rmSync(dir, { recursive: true, force: true });
 		}
 	});
+
+	it("aggregate_recall suppresses reasoning even on a reasoning:high target (#959)", async () => {
+		// aggregate_recall is latency-sensitive: it must never emit thinking tokens,
+		// even when routed to a target explicitly configured reasoning: high. The
+		// router passes reasoning:false at the call site (mirroring the ACPX
+		// exclusion). Without this guard the fix would regress aggregate-recall
+		// cost/latency whenever its workload target is a high-reasoning model.
+		const dir = mkdtempSync(join(tmpdir(), "signet-router-aggregate-reasoning-"));
+		try {
+			mkdirSync(join(dir, "memory"), { recursive: true });
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`inference:
+  defaultPolicy: deep
+  accounts:
+    openrouter-api:
+      kind: api
+      providerFamily: openrouter
+      credentialRef: OPENROUTER_API_KEY
+  targets:
+    deep:
+      executor: openrouter
+      account: openrouter-api
+      models:
+        default:
+          model: deepseek/deepseek-v4-flash
+          reasoning: high
+  policies:
+    deep:
+      mode: automatic
+      allow:
+        - deep/default
+      defaultTargets:
+        - deep/default
+  workloads:
+    aggregateRecall:
+      target: deep/default
+      taskClass: session_synthesis
+`,
+			);
+
+			process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+			let requestBody: Record<string, unknown> | null = null;
+			globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+				const url = String(input);
+				if (url.endsWith("/chat/completions") && typeof init?.body === "string") {
+					const parsed: unknown = JSON.parse(init.body);
+					if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+						requestBody = parsed as Record<string, unknown>;
+					}
+				}
+				if (url.endsWith("/models")) {
+					return Promise.resolve(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+				}
+				return Promise.resolve(openAiSseResponse("aggregate answer"));
+			}) as unknown as typeof fetch;
+
+			const router = getOrCreateInferenceRouter(dir);
+			const result = await router.execute(
+				{ operation: "aggregate_recall", promptPreview: "what is signet" },
+				"Synthesize",
+				{ maxTokens: 300, timeoutMs: 1000 },
+			);
+
+			expect(result.ok).toBe(true);
+			// The target is reasoning: high, but aggregate_recall must suppress it.
+			// Acceptable wire shapes: reasoning absent, or { effort: "none" }.
+			// A regression would emit { effort: "high" } or { effort: "medium" }.
+			const effort = (requestBody?.reasoning as { effort?: string } | undefined)?.effort;
+			expect(effort === "high" || effort === "medium").toBe(false);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
 });

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -656,6 +656,10 @@ export class InferenceRouter {
 				const result = await generateWithTracking(provider, prompt, {
 					timeoutMs: opts?.timeoutMs,
 					maxTokens: opts?.maxTokens,
+					// aggregate_recall is latency-sensitive (the routing engine already
+					// excludes ACPX subprocesses for it). Suppress thinking for the same
+					// reason: thinking tokens would dominate the synthesis budget.
+					reasoning: request.operation === "aggregate_recall" ? false : undefined,
 				});
 				this.clearObservedRuntimeState(loaded.value, targetRef);
 				attempts.push({
@@ -759,6 +763,9 @@ export class InferenceRouter {
 					timeoutMs: opts?.timeoutMs,
 					maxTokens: opts?.maxTokens,
 					abortSignal: opts?.abortSignal,
+					// aggregate_recall is latency-sensitive: suppress thinking tokens
+					// (mirrors the execute path and the routing engine's ACPX exclusion).
+					reasoning: request.operation === "aggregate_recall" ? false : undefined,
 				});
 
 				const router = this;

--- a/platform/daemon/src/pipeline/pi-provider.live.test.ts
+++ b/platform/daemon/src/pipeline/pi-provider.live.test.ts
@@ -56,15 +56,17 @@ describe.skipIf(SKIP)("createPiModelProvider (live)", () => {
 		);
 		setTimeout(() => ctrl.abort(), 300);
 		let threw = false;
+		let doneSeen = false;
 		try {
 			for await (const ev of stream.stream) {
-				if (ev.type === "done") fail("unexpected done event");
+				if (ev.type === "done") doneSeen = true;
 			}
 		} catch {
 			threw = true;
 		}
 		stream.cancel();
 		expect(threw).toBe(true);
+		expect(doneSeen).toBe(false);
 	});
 
 	test("timeoutMs aborts a long generation", async () => {

--- a/platform/daemon/src/pipeline/pi-provider.ts
+++ b/platform/daemon/src/pipeline/pi-provider.ts
@@ -263,14 +263,18 @@ export function createPiModelProvider(config: PiModelProviderConfig): StreamCapa
 		temperature?: number;
 		reasoning?: ThinkingLevel;
 	} {
+		// Per-call reasoning override semantics:
+		//   opts.reasoning === false  -> suppress thinking entirely (latency-sensitive ops)
+		//   opts.reasoning is a level -> override the configured level for this call
+		//   opts.reasoning undefined   -> use the provider's configured level
+		const effectiveReasoning: ThinkingLevel | undefined =
+			opts?.reasoning === false ? undefined : (opts?.reasoning ?? reasoning);
 		return {
 			apiKey,
 			signal: abort.signal,
 			...(opts?.maxTokens ? { maxTokens: opts.maxTokens } : {}),
 			...(typeof opts?.temperature === "number" ? { temperature: opts.temperature } : {}),
-			// Forward the per-call thinking level. Without this, pi-ai never turns
-			// reasoning on even when Model.reasoning (capability) is true.
-			...(reasoning !== undefined ? { reasoning } : {}),
+			...(effectiveReasoning !== undefined ? { reasoning: effectiveReasoning } : {}),
 		};
 	}
 

--- a/platform/daemon/src/pipeline/pi-provider.ts
+++ b/platform/daemon/src/pipeline/pi-provider.ts
@@ -14,6 +14,7 @@ import {
 	type Context,
 	type Model,
 	type OpenAICompletionsCompat,
+	type ThinkingLevel,
 	type Usage,
 	completeSimple,
 	streamSimple,
@@ -59,7 +60,16 @@ export interface PiModelProviderConfig {
 	readonly baseUrl?: string;
 	/** Resolved credential (API key). Omit for keyless local servers. */
 	readonly apiKey?: string;
-	readonly reasoning?: boolean;
+	/**
+	 * Per-call thinking level forwarded to pi-ai as `options.reasoning`.
+	 * Pi-ai has TWO reasoning fields: `Model.reasoning` (a boolean CAPABILITY
+	 * flag) and `options.reasoning` (a ThinkingLevel that actually turns
+	 * thinking on for the call). Setting the capability flag alone has no
+	 * observable effect — the per-call level must be forwarded too.
+	 * `RoutingReasoningDepth` ("low"|"medium"|"high") is a subset of
+	 * ThinkingLevel ("minimal"|"low"|"medium"|"high"|"xhigh").
+	 */
+	readonly reasoning?: ThinkingLevel;
 	readonly contextWindow?: number;
 	readonly maxTokens?: number;
 	readonly defaultTimeoutMs?: number;
@@ -101,7 +111,7 @@ export function resolvePiModel(config: PiModelProviderConfig): ResolvedModel {
 				api: "anthropic-messages",
 				provider: "anthropic",
 				baseUrl,
-				reasoning: config.reasoning ?? false,
+				reasoning: config.reasoning !== undefined,
 				input: ["text"],
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow: config.contextWindow ?? 200_000,
@@ -122,7 +132,7 @@ export function resolvePiModel(config: PiModelProviderConfig): ResolvedModel {
 				api: "openai-completions",
 				provider: "openrouter",
 				baseUrl,
-				reasoning: config.reasoning ?? false,
+				reasoning: config.reasoning !== undefined,
 				input: ["text"],
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow: config.contextWindow ?? 128_000,
@@ -154,7 +164,7 @@ export function resolvePiModel(config: PiModelProviderConfig): ResolvedModel {
 				api: "openai-completions",
 				provider: config.executor,
 				baseUrl,
-				reasoning: config.reasoning ?? false,
+				reasoning: config.reasoning !== undefined,
 				input: ["text"],
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow: config.contextWindow ?? 128_000,
@@ -238,6 +248,7 @@ export function createPiModelProvider(config: PiModelProviderConfig): StreamCapa
 	const { piModel, apiKey, label } = resolvePiModel(config);
 	const name = config.name ?? label;
 	const defaultTimeoutMs = config.defaultTimeoutMs ?? 60_000;
+	const reasoning = config.reasoning;
 
 	function buildContext(prompt: string): Context {
 		return {
@@ -250,12 +261,16 @@ export function createPiModelProvider(config: PiModelProviderConfig): StreamCapa
 		signal: AbortSignal;
 		maxTokens?: number;
 		temperature?: number;
+		reasoning?: ThinkingLevel;
 	} {
 		return {
 			apiKey,
 			signal: abort.signal,
 			...(opts?.maxTokens ? { maxTokens: opts.maxTokens } : {}),
 			...(typeof opts?.temperature === "number" ? { temperature: opts.temperature } : {}),
+			// Forward the per-call thinking level. Without this, pi-ai never turns
+			// reasoning on even when Model.reasoning (capability) is true.
+			...(reasoning !== undefined ? { reasoning } : {}),
 		};
 	}
 

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -20,6 +20,7 @@
 import { spawn as nodeSpawn } from "node:child_process";
 import { mkdirSync, readFileSync, readdirSync } from "node:fs";
 import { isAbsolute, join, resolve as resolvePath } from "node:path";
+import { type ThinkingLevel } from "@earendil-works/pi-ai";
 import {
 	DEFAULT_PROVIDER_RATE_LIMIT,
 	type LlmGenerateResult,
@@ -435,6 +436,16 @@ export type LlmProviderCallOptions = {
 	readonly temperature?: number;
 	readonly signal?: AbortSignal;
 	readonly abortSignal?: AbortSignal;
+	/**
+	 * Per-call thinking-level override for pi-ai-backed providers.
+	 * - `undefined`: use the provider's configured reasoning level.
+	 * - a `ThinkingLevel` ("minimal"|"low"|"medium"|"high"|"xhigh"): override
+	 *   the configured level for this call.
+	 * - `false`: explicitly suppress thinking for this call, even if the
+	 *   provider/target is configured for reasoning. Used by latency-sensitive
+	 *   operations (e.g. aggregate_recall) that must never emit thinking tokens.
+	 */
+	readonly reasoning?: ThinkingLevel | false;
 };
 
 export type LlmProviderStreamEvent =


### PR DESCRIPTION
## What

Fixes the reasoning regression from #949 (tracked in #959). Investigation against `@earendil-works/pi-ai@0.79.2` revealed the bug is bigger than the `=== "deep"` TS2367 — see the [deeper finding on #959](https://github.com/Signet-AI/signetai/issues/959#issuecomment-5050093562).

pi-ai has **two** reasoning fields:
- `Model.reasoning: boolean` — model *capability* flag
- `options.reasoning: ThinkingLevel` — per-call level that *actually turns thinking on*

#949 set the capability flag but **never forwarded the per-call level** in `buildOptions`, so even a corrected boolean would have had zero observable effect (thinking never engaged). Pre-#949 Anthropic explicitly sent `thinking: { type: "disabled" }`.

## Changes

- **`pi-provider.ts`** — `PiModelProviderConfig.reasoning` widened to `ThinkingLevel`; `Model.reasoning` derived as `config.reasoning !== undefined`; `buildOptions` forwards `reasoning` per-call (reaches both `completeSimple` and `streamSimple`).
- **`inference-provider-factory.ts`** — replaces `=== "deep"` with a sound mapping. `RoutingModelConfig.reasoning` defaults to `"medium"` at every parse site, so mapping it directly would flip thinking ON by default for all routed calls. Treat only explicit signals as intent:
  - OpenRouter `reasoning.enabled` → `"medium"`
  - `model.reasoning === "high"` → `"high"`
  - else → `undefined` (preserves pre-#949 off-by-default behavior)
- **`pi-provider.live.test.ts`** — replaced the undefined `fail()` (would have thrown a swallowed ReferenceError) with a `doneSeen` flag so the abort test can no longer pass on an unexpected normal completion.

## Behavior

Reasoning is now **functional end-to-end** when explicitly requested, and **off by default** (no cost/latency regression). If we later want `"medium"` depth to also engage thinking, that's a one-line change with a cost review.

## Verification

- Daemon `tsc` against real `@earendil-works/pi-ai@0.79.2`: changed files clean (no TS2367, no `fail` TS2304).
- `bun test` provider + router suites: 47/47 pass.
- Structured review confirmed both complete/stream paths forward `options.reasoning`, capability derivation is consistent across all model-construction sites, and no OpenRouter regression (the old code never produced a usable level).

## Deliberate choice flagged

`RoutingModelConfig.reasoning` defaults to `"medium"` and is indistinguishable from unset, so this fix treats only `"high"` (and the OpenRouter block) as intent to emit thinking. Calling out explicitly so a reviewer can weigh in on whether medium-depth-should-enable-thinking is wanted later.

Refs #959
