### PR TITLE
fix(daemon): restore provider-status contract after #949 (#960)

### DIFF
--- a/platform/daemon/src/daemon-status.test.ts
+++ b/platform/daemon/src/daemon-status.test.ts
@@ -114,11 +114,13 @@ describe("daemon status contract", () => {
 		expect(extraction).toBeDefined();
 		expect(typeof extraction?.resolved).toBe("string");
 		expect(typeof extraction?.effective).toBe("string");
-		expect(
-			extraction?.fallbackProvider === "ollama" ||
-				extraction?.fallbackProvider === "llama-cpp" ||
-				extraction?.fallbackProvider === "none",
-		).toBe(true);
+		// fallbackProvider must always be present as a string. #949 dropped this field
+		// from the status object (it was sourcing from the retired flat config field),
+		// which made `signet status` print "fallback: unknown". The type was widened
+		// from the narrow "llama-cpp"|"ollama"|"none" enum to RuntimeProviderName
+		// because the routing registry's fallbackTargetRefs can resolve to any
+		// executor. Asserting presence + string type is the real regression guard.
+		expect(typeof extraction?.fallbackProvider).toBe("string");
 		expect(
 			extraction?.status === "active" ||
 				extraction?.status === "degraded" ||
@@ -175,11 +177,17 @@ describe("daemon status contract", () => {
 				providerResolution?: {
 					extraction?: {
 						effective?: unknown;
+						fallbackProvider?: unknown;
 						status?: unknown;
 					};
 				};
 			};
 			expect(body.providerResolution?.extraction?.effective).toBe("llama-cpp");
+			// #960: the routing cutover dropped fallbackProvider from the status object.
+			// With a legacy fallbackProvider: llama-cpp config (migrated to a routing
+			// fallback target), the field must report the fallback executor — not be
+			// undefined, which made `signet status` print "fallback: unknown".
+			expect(body.providerResolution?.extraction?.fallbackProvider).toBe("llama-cpp");
 			expect(["active", "degraded"]).toContain(body.providerResolution?.extraction?.status);
 		} finally {
 			globalThis.fetch = originalFetch;

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1395,16 +1395,31 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 				synthesisDecision?.ok ? synthesisDecision.value.targetRef : undefined,
 			) as RuntimeSynthesisProviderName | null)) ??
 		(synthesisAvailable ? "inference" : null);
+	// After #949, the retired flat pipelineV2.extraction.fallbackProvider field
+	// was dropped from this status object, which made `signet status` print
+	// "fallback: unknown". Restore the field with runtime-derived semantics:
+	// when a fallback is in use (fallbackApplied), `effective` is the fallback
+	// executor; otherwise report "none". (The decision's fallbackTargetRefs is
+	// NOT the right source — it holds candidates remaining AFTER selection, so
+	// it is empty when the fallback became the selected target.) NOTE: this is
+	// an applied-vs-configured semantic shift from pre-#949 — in the "blocked"
+	// case the field reports "none" even if a fallback was configured but also
+	// failed, because the decision carries no candidates when blocked. The
+	// `reason` field carries the failure detail in that case.
+	const extractionFallbackProvider: RuntimeProviderName = extractionFallbackApplied
+		? extractionEffective
+		: "none";
 	providerRuntimeResolution.extraction = {
 		// Configured/resolved now derive from the routing registry (the workload
 		// binding's target executor), not the retired legacy flat fields.
 		configured: commandExtractionMode
 			? "command"
-			: (executorForTargetRef(statusValue, extractionBinding) as RuntimeExtractionProviderName | null),
-		resolved: commandExtractionMode
-			? "command"
-			: (extractionEffective as RuntimeExtractionProviderName | null),
+			: statusValue
+				? executorForTargetRef(statusValue, extractionBinding)
+				: null,
+		resolved: commandExtractionMode ? "command" : extractionEffective,
 		effective: extractionEffective,
+		fallbackProvider: commandExtractionMode ? "none" : extractionFallbackProvider,
 		status: extractionStatus,
 		degraded: extractionDegraded,
 		fallbackApplied: extractionFallbackApplied,
@@ -1424,11 +1439,14 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 	};
 	providerRuntimeResolution.synthesis = {
 		configured: synthesisAvailable
-			? ((executorForTargetRef(statusValue, synthesisDecision?.ok ? synthesisDecision.value.targetRef : undefined) as RuntimeSynthesisProviderName | null))
+			? statusValue
+				? executorForTargetRef(
+						statusValue,
+						synthesisDecision?.ok ? synthesisDecision.value.targetRef : undefined,
+					) ?? null
+				: null
 			: null,
-		resolved: synthesisAvailable
-			? (synthesisEffective as RuntimeSynthesisProviderName | null)
-			: null,
+		resolved: synthesisAvailable ? (synthesisEffective as RuntimeSynthesisProviderName | null) : null,
 		effective: synthesisEffective,
 	};
 

--- a/platform/daemon/src/routes/state.ts
+++ b/platform/daemon/src/routes/state.ts
@@ -244,7 +244,10 @@ export interface ProviderRuntimeResolution {
 		configured: string | null;
 		resolved: RuntimeProviderName;
 		effective: RuntimeProviderName;
-		fallbackProvider: "llama-cpp" | "ollama" | "none";
+		// Widened from "llama-cpp" | "ollama" | "none" after #949: the routing
+		// registry expresses fallback via fallbackTargetRefs, whose executor can be
+		// any RuntimeProviderName. Defaults to "none" when no fallback is configured.
+		fallbackProvider: RuntimeProviderName;
 		status: "active" | "degraded" | "blocked" | "disabled" | "paused";
 		degraded: boolean;
 		fallbackApplied: boolean;


### PR DESCRIPTION
## What

Fixes #960 — the daemon provider-runtime status contract drift from #949. The status block in `startPipelineRuntime` (which feeds `/api/status`, the dashboard, and `signet status`) had **5 dormant tsc errors** that were invisible because the daemon has no tsc gate (#961).

## Root causes

| # | Error | What happened |
|---|---|---|
| 1 | `RuntimeExtractionProviderName` undefined (TS2304) | Cast to (`as`) at daemon.ts:1403/1406 but the type was never defined. Its sibling `RuntimeSynthesisProviderName` is correctly defined in `routes/state.ts`. `executorForTargetRef` already returns `RuntimeProviderName|null`, so the casts were bogus *and* unnecessary. |
| 2 | `fallbackProvider` missing (TS2741) | #949 dropped it (it had sourced from the retired flat `pipelineV2.extraction.fallbackProvider` field) but the type still required it. **User-visible regression:** the CLI `signet status` reads this field (`health.ts`: `fallback: ${fallbackProvider ?? "unknown"}`), so it silently printed "unknown". |
| 3 | `statusValue` (InferenceStatusSummary\|null) unguarded (TS2345) | Passed to `executorForTargetRef` on the extraction/synthesis `configured` paths without the null guard already used elsewhere. |

## Fixes

- **Removed the bogus `as RuntimeExtractionProviderName` casts** — `executorForTargetRef` returns the correct type already.
- **Restored `fallbackProvider`** with runtime-derived semantics: `extractionFallbackApplied ? extractionEffective : "none"`. The decision's `fallbackTargetRefs` is *not* the source — it holds candidates remaining *after* selection, so it's empty when the fallback became the selected target (verified empirically: `effective` was `"llama-cpp"` but `fallbackTargetRefs[0]` was undefined).
- **Null-guarded** all `executorForTargetRef` calls against `statusValue` (the `statusValue ? ... : null` pattern already used in the file).
- **Widened the type** from `"llama-cpp"|"ollama"|"none"` to `RuntimeProviderName` — the routing registry's fallback can be any executor. Backward-compatible: the CLI already types it `string|null`, and the common migration case still yields `ollama`/`llama-cpp`.

## Semantic shift (flagged for awareness)

Pre-#949, `fallbackProvider` was the statically-*configured* flat value. Post-fix, it's runtime-*applied* (the executor in use when `fallbackApplied`). In the **blocked** case it now reports `"none"` even if a fallback was configured but also failed, because the decision carries no candidates when blocked (and the configured fallback isn't cleanly resolvable from the status summary). The `reason` field carries the failure detail in that case. Documented inline.

## Verification

- Daemon `tsc` against changed files: **clean** — all 5 #960 errors resolved (the only remaining daemon tsc noise is pre-existing #961: `daemon.ts:1781` WorkerOptions, `daemon-status.test.ts:191` toContain overload).
- `daemon-status.test.ts` + `inference-router.test.ts` + `provider.test.ts`: **39/39 pass**.
- CLI `health.test.ts`: **17/17 pass** (the field's consumer).
- **Regression proof:** the extended `daemon-status` test asserts `fallbackProvider === "llama-cpp"` on the wire. Verified to **FAIL on main** (`Received: undefined`) and **PASS with the fix**.
- Live wire check: confirmed the stale daemon emits `fallbackProvider` on `/api/status` (the field is a real consumed contract, not dead code).

## Structured review

Ran autoreview — verdict: sound, type-clean, backward-compatible with all CLI consumers. The one info-level finding (the applied-vs-configured semantic shift in the blocked case) is documented inline; the configured-but-failed fallback isn't cleanly resolvable from the status summary, and `reason` already carries the detail.

Closes #960
