### PR TITLE
fix(daemon): integrate pi-ai OAuth providers

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -369,6 +369,9 @@ inference:
       kind: api
       providerFamily: openrouter
       credentialRef: OPENROUTER_API_KEY
+    codex-subscription:
+      kind: subscription_session
+      providerFamily: openai-codex
 
   targets:
     opus:
@@ -402,6 +405,13 @@ inference:
           reasoning: medium
           streaming: true
           costTier: low
+    codex-direct:
+      executor: openai-codex
+      account: codex-subscription
+      models:
+        default:
+          model: gpt-5.4
+          reasoning: high
 
   policies:
     auto:
@@ -455,11 +465,19 @@ Named account or credential identities used by targets.
 | Field | Type | Description |
 |-------|------|-------------|
 | `kind` | string | `subscription_session` or `api` |
-| `providerFamily` | string | Provider family label, for example `anthropic`, `openai`, `openrouter` |
+| `providerFamily` | string | pi-ai provider id, for example `anthropic`, `openai-codex`, `github-copilot`, or `openrouter` |
 | `label` | string | Human-readable account label |
 | `credentialRef` | string | Secret name or env var name for API-backed targets |
 | `sessionRef` | string | Session identifier for subscription-backed targets |
 | `usageTier` | string | Optional account tier label |
+
+For an OAuth subscription, set `kind: subscription_session`, use the pi-ai
+OAuth provider id as `providerFamily`, and omit `credentialRef`. Connect the
+account through `/api/inference/oauth/login/:id`. Signet stores the resulting
+OAuth credential in its encrypted secret store and asks pi-ai to refresh it at
+request time. For a conventional API-key account, use `kind: api` and set
+`credentialRef`; environment variables continue to take precedence over the
+encrypted secret with the same name.
 
 ### inference.targets
 
@@ -468,7 +486,7 @@ subscription-backed CLI session, or gateway.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `executor` | string | `acpx`, `claude-code`, `codex`, `opencode`, `anthropic`, `openrouter`, `ollama`, `llama-cpp`, `openai-compatible`, or `command` |
+| `executor` | string | `acpx`, a local compatibility executor, or a provider id returned by `/api/inference/catalog` |
 | `kind` | string | Optional explicit target kind. Inferred when omitted |
 | `account` | string | Account id from `inference.accounts` |
 | `endpoint` | string | Optional base URL override |

--- a/docs/api/inference.md
+++ b/docs/api/inference.md
@@ -76,6 +76,51 @@ Inference concurrency limits can be tuned with:
 - `SIGNET_INFERENCE_MAX_CONCURRENT_GATEWAY_STREAMS`
 - `SIGNET_INFERENCE_MAX_CONCURRENT_TOTAL`
 
+### GET /api/inference/catalog
+
+Requires `diagnostics` permission in authenticated modes. Returns the provider
+and model registry from pi-ai, the OAuth provider registry, and ACPX agent
+names. `modelErrors` reports provider-specific catalog failures; failures are
+never represented as a silent empty model list.
+
+### GET /api/inference/oauth/providers
+
+Requires `diagnostics` permission in authenticated modes. Returns the OAuth
+providers registered by pi-ai and whether Signet has encrypted credentials for
+each provider. Access and refresh tokens are never returned.
+
+### POST /api/inference/oauth/login/:id
+
+Requires `admin` permission. Starts a bounded, daemon-owned OAuth login and
+returns a Server-Sent Events stream. The response's
+`X-Signet-OAuth-Session-Id` header identifies the login session.
+
+Events include `session`, `auth`, `device_code`, `prompt`, `select`, `manual_code`,
+`progress`, `connected`, `error`, and `done`. Interactive events include a
+`responseId` that must be answered through the completion route. The daemon
+stores credentials returned by pi-ai; clients never submit or receive OAuth
+credentials.
+
+### POST /api/inference/oauth/complete
+
+Requires `admin` permission. Answers one pending login interaction.
+
+```json
+{
+  "sessionId": "a login session UUID",
+  "responseId": "the event response UUID",
+  "value": "the prompt response, selected option id, or manual callback URL"
+}
+```
+
+Sessions and responses are single-use, expire after ten minutes, and reject
+empty values unless the provider explicitly allows them.
+
+### POST /api/inference/oauth/disconnect/:id
+
+Requires `admin` permission. Deletes the provider's encrypted OAuth credential.
+Subsequent inference requests treat the account as disconnected.
+
 ### GET /api/inference/history
 
 Requires `diagnostics` permission in authenticated modes.

--- a/docs/specs/approved/model-provider-router.md
+++ b/docs/specs/approved/model-provider-router.md
@@ -257,6 +257,10 @@ OAuth provider discovery, interactive login, encrypted credential storage,
 disconnect, and request-time token refresh are delivered by #966 using pi-ai's
 provider registry. The daemon preserves the existing account/target/workload
 routing model while accepting pi-ai provider ids dynamically.
+Dynamic provider ids therefore pass config parsing before registry/model
+resolution; unsupported executors or models fail explicitly during provider
+construction. The provider resolver's default error remains the exhaustiveness
+safeguard for ids that are not statically known.
 
 These items remain intentionally deferred because the phase 2 hardening wave
 focused on making the daemon-owned router safe enough for broader harness

--- a/docs/specs/approved/model-provider-router.md
+++ b/docs/specs/approved/model-provider-router.md
@@ -253,6 +253,11 @@ the spec stays useful as both contract and progress tracker.
 
 ### Deferred / phase 3
 
+OAuth provider discovery, interactive login, encrypted credential storage,
+disconnect, and request-time token refresh are delivered by #966 using pi-ai's
+provider registry. The daemon preserves the existing account/target/workload
+routing model while accepting pi-ai provider ids dynamically.
+
 These items remain intentionally deferred because the phase 2 hardening wave
 focused on making the daemon-owned router safe enough for broader harness
 adoption. They should become follow-up specs or sprint briefs rather than
@@ -262,7 +267,6 @@ blocking the current router foundation.
   - persisted account health records
   - persisted quota/cost ledgers
   - durable expiry / invalidation state transitions
-  - refresh or revalidation flows where supported
 - Schema and provider-abstraction parity with the full target design:
   - canonical top-level `models:` map with reusable capability metadata
   - richer `RouteRequest` metadata for harness, subtask, tool, and runtime

--- a/platform/core/src/routing.test.ts
+++ b/platform/core/src/routing.test.ts
@@ -642,6 +642,28 @@ describe("inference config + decision engine", () => {
 		});
 	});
 
+	it("accepts pi-ai provider ids without duplicating its dynamic catalog", () => {
+		const parsed = parseRoutingConfig({
+			inference: {
+				accounts: {
+					codex: { kind: "subscription_session", providerFamily: "openai-codex" },
+				},
+				targets: {
+					codex: {
+						executor: "openai-codex",
+						account: "codex",
+						models: { default: { model: "gpt-5.4" } },
+					},
+				},
+			},
+		});
+
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok) return;
+		expect(parsed.value.targets.codex?.executor).toBe("openai-codex");
+		expect(parsed.value.targets.codex?.kind).toBe("api");
+	});
+
 	it("does not allow explicit target overrides outside the agent roster", () => {
 		const parsed = parseRoutingConfig({
 			inference: {

--- a/platform/core/src/routing.ts
+++ b/platform/core/src/routing.ts
@@ -1,5 +1,5 @@
-import type { PipelineCommandConfig, PipelineExtractionConfig, PipelineSynthesisConfig } from "./types";
 import { defaultPipelineModel } from "./pipeline-providers";
+import type { PipelineCommandConfig, PipelineExtractionConfig, PipelineSynthesisConfig } from "./types";
 
 export const ROUTING_ACCOUNT_KINDS = ["subscription_session", "api"] as const;
 export const ROUTING_TARGET_KINDS = ["subscription_session", "api", "local", "gateway"] as const;
@@ -15,6 +15,7 @@ export const ROUTING_EXECUTOR_KINDS = [
 	"openai-compatible",
 	"command",
 ] as const;
+const ROUTING_EXECUTOR_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/;
 export const ROUTING_POLICY_MODES = ["strict", "automatic", "hybrid"] as const;
 export const ROUTING_PRIVACY_TIERS = ["remote_ok", "restricted_remote", "local_only"] as const;
 export const ROUTING_REASONING_DEPTHS = ["low", "medium", "high"] as const;
@@ -34,7 +35,7 @@ export const ROUTING_OPERATION_KINDS = [
 
 export type RoutingAccountKind = (typeof ROUTING_ACCOUNT_KINDS)[number];
 export type RoutingTargetKind = (typeof ROUTING_TARGET_KINDS)[number];
-export type RoutingExecutorKind = (typeof ROUTING_EXECUTOR_KINDS)[number];
+export type RoutingExecutorKind = (typeof ROUTING_EXECUTOR_KINDS)[number] | (string & {});
 export type RoutingPolicyMode = (typeof ROUTING_POLICY_MODES)[number];
 export type RoutingPrivacyTier = (typeof ROUTING_PRIVACY_TIERS)[number];
 export type RoutingReasoningDepth = (typeof ROUTING_REASONING_DEPTHS)[number];
@@ -366,8 +367,10 @@ function inferTargetKind(executor: string): RoutingTargetKind {
 	if (executor === "ollama" || executor === "llama-cpp" || executor === "openai-compatible" || executor === "command") {
 		return executor === "openai-compatible" ? "gateway" : "local";
 	}
-	if (executor === "anthropic" || executor === "openrouter") return "api";
-	return "subscription_session";
+	if (executor === "acpx" || executor === "claude-code" || executor === "codex" || executor === "opencode") {
+		return "subscription_session";
+	}
+	return "api";
 }
 
 function inferLegacyTargetKind(executor: string, endpoint: string | undefined): RoutingTargetKind {
@@ -588,7 +591,7 @@ function parseOpenRouterConfig(raw: unknown): RoutingOpenRouterConfig | undefine
 function parseTargetConfig(raw: unknown): RoutingTargetConfig | null {
 	if (!isRecord(raw)) return null;
 	const executor = asString(raw.executor);
-	if (!executor || !(ROUTING_EXECUTOR_KINDS as readonly string[]).includes(executor)) return null;
+	if (!executor || !ROUTING_EXECUTOR_PATTERN.test(executor)) return null;
 	const modelsRaw = isRecord(raw.models) ? raw.models : null;
 	if (!modelsRaw) return null;
 	const models: Record<string, RoutingModelConfig> = {};

--- a/platform/daemon/src/inference-api.test.ts
+++ b/platform/daemon/src/inference-api.test.ts
@@ -630,6 +630,57 @@ describe("inference routing api", () => {
 		expect(body.policies).toContain("auto");
 	});
 
+	it("exposes the pi-ai provider, OAuth, and model catalog without hiding resolver failures", async () => {
+		const res = await app.request(
+			new Request("http://localhost/api/inference/catalog", {
+				headers: { Authorization: `Bearer ${auth}` },
+			}),
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			providers: string[];
+			oauthProviders: Array<{ id: string; name: string }>;
+			models: Record<string, Array<{ id: string }>>;
+			modelErrors: Record<string, string>;
+		};
+		expect(body.providers).toContain("openrouter");
+		expect(body.oauthProviders.some((provider) => provider.id === "anthropic")).toBe(true);
+		expect(body.models.openrouter?.length).toBeGreaterThan(0);
+		expect(body.modelErrors).toEqual({});
+	});
+
+	it("validates OAuth route inputs and never returns credential fields", async () => {
+		const providersRes = await app.request(
+			new Request("http://localhost/api/inference/oauth/providers", {
+				headers: { Authorization: `Bearer ${auth}` },
+			}),
+		);
+		expect(providersRes.status).toBe(200);
+		const providersText = await providersRes.text();
+		expect(providersText).not.toContain('"access"');
+		expect(providersText).not.toContain('"refresh"');
+
+		const unknownLogin = await app.request(
+			new Request("http://localhost/api/inference/oauth/login/missing-provider", {
+				method: "POST",
+				headers: { Authorization: `Bearer ${auth}` },
+			}),
+		);
+		expect(unknownLogin.status).toBe(404);
+
+		const invalidComplete = await app.request(
+			new Request("http://localhost/api/inference/oauth/complete", {
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${auth}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({ sessionId: "missing" }),
+			}),
+		);
+		expect(invalidComplete.status).toBe(400);
+	});
+
 	it("lists gateway models including automatic routing alias", async () => {
 		const res = await app.request(
 			new Request("http://localhost/v1/models", {
@@ -673,6 +724,21 @@ describe("inference route hardening", () => {
 				}),
 			);
 			expect(executeRes.status).toBe(403);
+
+			const providersRes = await app.request(
+				new Request("http://localhost/api/inference/oauth/providers", {
+					headers: { Authorization: `Bearer ${operatorToken}` },
+				}),
+			);
+			expect(providersRes.status).toBe(200);
+
+			const disconnectRes = await app.request(
+				new Request("http://localhost/api/inference/oauth/disconnect/anthropic", {
+					method: "POST",
+					headers: { Authorization: `Bearer ${operatorToken}` },
+				}),
+			);
+			expect(disconnectRes.status).toBe(403);
 		} finally {
 			resetInferenceRouterForTests();
 			rmSync(root, { recursive: true, force: true });

--- a/platform/daemon/src/inference-oauth.test.ts
+++ b/platform/daemon/src/inference-oauth.test.ts
@@ -122,6 +122,22 @@ describe("inference OAuth", () => {
 		expect((await loadOAuthCredentials(PROVIDER_ID))?.access).toBe("access-refreshed");
 	});
 
+	test("treats a rejected token refresh as an unavailable credential", async () => {
+		const refreshToken = mock(async () => {
+			throw new Error("revoked refresh token");
+		});
+		registerOAuthProvider(provider({ refreshToken }));
+		await storeOAuthCredentials(PROVIDER_ID, {
+			refresh: "refresh-revoked",
+			access: "access-expired",
+			expires: Date.now() - 1,
+		});
+
+		expect(await resolveOAuthCredential(PROVIDER_ID)).toBeNull();
+		expect(refreshToken).toHaveBeenCalledTimes(1);
+		expect((await loadOAuthCredentials(PROVIDER_ID))?.access).toBe("access-expired");
+	});
+
 	test("rejects invalid provider ids before touching secret storage", async () => {
 		await expect(loadOAuthCredentials("../../escape")).rejects.toThrow("Invalid OAuth provider id");
 		expect(() => startOAuthLogin("missing-provider")).toThrow("Unknown OAuth provider");

--- a/platform/daemon/src/inference-oauth.test.ts
+++ b/platform/daemon/src/inference-oauth.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import type { OAuthProviderInterface } from "@earendil-works/pi-ai";
+import { registerOAuthProvider, unregisterOAuthProvider } from "@earendil-works/pi-ai/oauth";
+import {
+	completeOAuthInteraction,
+	disconnectOAuthProvider,
+	listOAuthProviderMetadata,
+	loadOAuthCredentials,
+	resetOAuthStateForTests,
+	resolveOAuthCredential,
+	startOAuthLogin,
+	storeOAuthCredentials,
+} from "./inference-oauth";
+import { invalidateSecretsCache } from "./secrets";
+
+const PROVIDER_ID = "signet-test-oauth-966";
+const originalSignetPath = process.env.SIGNET_PATH;
+let agentsDir = "";
+
+function provider(overrides: Partial<OAuthProviderInterface> = {}): OAuthProviderInterface {
+	return {
+		id: PROVIDER_ID,
+		name: "Signet test OAuth",
+		async login(callbacks) {
+			callbacks.onAuth({ url: "https://example.test/login", instructions: "Sign in" });
+			const answer = await callbacks.onPrompt({ message: "Account", placeholder: "name" });
+			return { refresh: `refresh-${answer}`, access: "access-login", expires: Date.now() + 60_000 };
+		},
+		async refreshToken(credentials) {
+			return { ...credentials, access: "access-refreshed", expires: Date.now() + 60_000 };
+		},
+		getApiKey(credentials) {
+			return credentials.access;
+		},
+		...overrides,
+	};
+}
+
+async function readUntil(
+	reader: ReadableStreamDefaultReader<Uint8Array>,
+	predicate: (text: string) => boolean,
+): Promise<string> {
+	const decoder = new TextDecoder();
+	let text = "";
+	while (!predicate(text)) {
+		const next = await reader.read();
+		if (next.done) break;
+		text += decoder.decode(next.value, { stream: true });
+	}
+	return text;
+}
+
+describe("inference OAuth", () => {
+	beforeEach(() => {
+		agentsDir = mkdtempSync(`${tmpdir()}/signet-oauth-`);
+		mkdirSync(agentsDir, { recursive: true });
+		process.env.SIGNET_PATH = agentsDir;
+		registerOAuthProvider(provider());
+	});
+
+	afterEach(() => {
+		resetOAuthStateForTests();
+		unregisterOAuthProvider(PROVIDER_ID);
+		invalidateSecretsCache();
+		if (originalSignetPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
+		else process.env.SIGNET_PATH = originalSignetPath;
+		rmSync(agentsDir, { recursive: true, force: true });
+	});
+
+	test("streams interactive login events and stores credentials only in the daemon", async () => {
+		expect(listOAuthProviderMetadata()).toContainEqual({
+			id: PROVIDER_ID,
+			name: "Signet test OAuth",
+			usesCallbackServer: false,
+		});
+
+		const login = startOAuthLogin(PROVIDER_ID);
+		const reader = login.stream.getReader();
+		const initial = await readUntil(reader, (text) => text.includes('"type":"prompt"'));
+		expect(initial).toContain("https://example.test/login");
+		const promptData = initial
+			.split("\n")
+			.find((line) => line.startsWith("data: ") && line.includes('"type":"prompt"'));
+		expect(promptData).toBeDefined();
+		if (!promptData) throw new Error("prompt event missing");
+		const prompt = JSON.parse(promptData.slice(6)) as { responseId: string };
+
+		completeOAuthInteraction(login.sessionId, prompt.responseId, "avery");
+		const completed = await readUntil(reader, (text) => text.includes('"type":"done"'));
+		expect(completed).toContain('"type":"connected"');
+		expect(await loadOAuthCredentials(PROVIDER_ID)).toMatchObject({
+			refresh: "refresh-avery",
+			access: "access-login",
+		});
+		expect(await disconnectOAuthProvider(PROVIDER_ID)).toBe(true);
+		expect(await loadOAuthCredentials(PROVIDER_ID)).toBeNull();
+	});
+
+	test("refreshes an expired token once and persists the replacement", async () => {
+		const refreshToken = mock(async () => ({
+			refresh: "refresh-old",
+			access: "access-refreshed",
+			expires: Date.now() + 60_000,
+		}));
+		registerOAuthProvider(provider({ refreshToken }));
+		await storeOAuthCredentials(PROVIDER_ID, {
+			refresh: "refresh-old",
+			access: "access-expired",
+			expires: Date.now() - 1,
+		});
+
+		const [first, second] = await Promise.all([
+			resolveOAuthCredential(PROVIDER_ID),
+			resolveOAuthCredential(PROVIDER_ID),
+		]);
+
+		expect(refreshToken).toHaveBeenCalledTimes(1);
+		expect(first?.apiKey).toBe("access-refreshed");
+		expect(second?.apiKey).toBe("access-refreshed");
+		expect((await loadOAuthCredentials(PROVIDER_ID))?.access).toBe("access-refreshed");
+	});
+
+	test("rejects invalid provider ids before touching secret storage", async () => {
+		await expect(loadOAuthCredentials("../../escape")).rejects.toThrow("Invalid OAuth provider id");
+		expect(() => startOAuthLogin("missing-provider")).toThrow("Unknown OAuth provider");
+	});
+
+	test("accepts only selection values offered by the OAuth provider", async () => {
+		registerOAuthProvider(
+			provider({
+				async login(callbacks) {
+					const selected = await callbacks.onSelect({
+						message: "Choose a flow",
+						options: [{ id: "device_code", label: "Device code" }],
+					});
+					return { refresh: "refresh", access: selected ?? "none", expires: Date.now() + 60_000 };
+				},
+			}),
+		);
+		const login = startOAuthLogin(PROVIDER_ID);
+		const reader = login.stream.getReader();
+		const initial = await readUntil(reader, (text) => text.includes('"type":"select"'));
+		const selectData = initial
+			.split("\n")
+			.find((line) => line.startsWith("data: ") && line.includes('"type":"select"'));
+		if (!selectData) throw new Error("select event missing");
+		const select = JSON.parse(selectData.slice(6)) as { responseId: string };
+
+		expect(() => completeOAuthInteraction(login.sessionId, select.responseId, "browser")).toThrow(
+			"not one of the offered options",
+		);
+		completeOAuthInteraction(login.sessionId, select.responseId, "device_code");
+		await readUntil(reader, (text) => text.includes('"type":"done"'));
+	});
+});

--- a/platform/daemon/src/inference-oauth.ts
+++ b/platform/daemon/src/inference-oauth.ts
@@ -1,0 +1,313 @@
+import { randomUUID } from "node:crypto";
+import {
+	type OAuthCredentials,
+	type OAuthLoginCallbacks,
+	type OAuthPrompt,
+	type OAuthSelectPrompt,
+	getOAuthApiKey,
+	getOAuthProvider,
+	getOAuthProviders,
+} from "@earendil-works/pi-ai/oauth";
+import { deleteSecretFromActiveProvider, getSecret, putSecret } from "./secrets";
+
+const OAUTH_SECRET_PREFIX = "SIGNET_OAUTH_";
+const OAUTH_SESSION_TTL_MS = 10 * 60_000;
+const MAX_ACTIVE_OAUTH_SESSIONS = 8;
+const PROVIDER_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/;
+
+export type OAuthLoginEvent =
+	| { readonly type: "session"; readonly sessionId: string; readonly providerId: string }
+	| { readonly type: "auth"; readonly url: string; readonly instructions?: string }
+	| {
+			readonly type: "device_code";
+			readonly userCode: string;
+			readonly verificationUri: string;
+			readonly intervalSeconds?: number;
+			readonly expiresInSeconds?: number;
+	  }
+	| ({ readonly type: "prompt"; readonly responseId: string } & OAuthPrompt)
+	| ({ readonly type: "select"; readonly responseId: string } & OAuthSelectPrompt)
+	| { readonly type: "manual_code"; readonly responseId: string; readonly message: string }
+	| { readonly type: "progress"; readonly message: string }
+	| { readonly type: "connected"; readonly providerId: string }
+	| { readonly type: "error"; readonly error: string }
+	| { readonly type: "done" };
+
+export interface ResolvedOAuthCredential {
+	readonly apiKey: string;
+	readonly credentials: OAuthCredentials;
+}
+
+interface PendingInteraction {
+	readonly responseId: string;
+	readonly allowEmpty: boolean;
+	readonly allowedValues?: ReadonlySet<string>;
+	resolve(value: string | undefined): void;
+	reject(error: Error): void;
+}
+
+interface OAuthLoginSession {
+	readonly id: string;
+	readonly providerId: string;
+	readonly controller: AbortController;
+	readonly pending: Map<string, PendingInteraction>;
+	readonly expiresAt: number;
+	emit(event: OAuthLoginEvent): void;
+	close(): void;
+}
+
+const activeSessions = new Map<string, OAuthLoginSession>();
+const refreshes = new Map<string, Promise<ResolvedOAuthCredential | null>>();
+
+function validateProviderId(providerId: string): string {
+	const normalized = providerId.trim();
+	if (!PROVIDER_ID_PATTERN.test(normalized)) throw new Error("Invalid OAuth provider id");
+	return normalized;
+}
+
+function secretName(providerId: string): string {
+	const normalized = validateProviderId(providerId);
+	return `${OAUTH_SECRET_PREFIX}${Buffer.from(normalized, "utf8").toString("hex").toUpperCase()}`;
+}
+
+function isOAuthCredentials(value: unknown): value is OAuthCredentials {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const candidate = value as Record<string, unknown>;
+	return (
+		typeof candidate.refresh === "string" &&
+		candidate.refresh.length > 0 &&
+		typeof candidate.access === "string" &&
+		candidate.access.length > 0 &&
+		typeof candidate.expires === "number" &&
+		Number.isFinite(candidate.expires) &&
+		candidate.expires >= 0
+	);
+}
+
+function safeError(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	return message
+		.replace(/\bBearer\s+[^\s,}]+/gi, "Bearer [redacted]")
+		.replace(/([?&](?:code|token|access_token|refresh_token)=)[^&\s]+/gi, "$1[redacted]")
+		.slice(0, 500);
+}
+
+export function listOAuthProviderMetadata(): Array<{
+	readonly id: string;
+	readonly name: string;
+	readonly usesCallbackServer: boolean;
+}> {
+	return getOAuthProviders().map((provider) => ({
+		id: provider.id,
+		name: provider.name,
+		usesCallbackServer: provider.usesCallbackServer === true,
+	}));
+}
+
+export function isOAuthProvider(providerId: string): boolean {
+	return getOAuthProvider(providerId) !== undefined;
+}
+
+export async function loadOAuthCredentials(providerId: string): Promise<OAuthCredentials | null> {
+	const name = secretName(providerId);
+	let raw: string;
+	try {
+		raw = await getSecret(name);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		if (/not found|does not exist|no such/i.test(message)) return null;
+		throw error;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		throw new Error(`Stored OAuth credentials for ${providerId} are invalid JSON`);
+	}
+	if (!isOAuthCredentials(parsed)) {
+		throw new Error(`Stored OAuth credentials for ${providerId} have an invalid shape`);
+	}
+	return parsed;
+}
+
+export async function storeOAuthCredentials(providerId: string, credentials: OAuthCredentials): Promise<void> {
+	if (!getOAuthProvider(validateProviderId(providerId))) throw new Error(`Unknown OAuth provider: ${providerId}`);
+	if (!isOAuthCredentials(credentials)) throw new Error(`Invalid OAuth credentials for ${providerId}`);
+	await putSecret(secretName(providerId), JSON.stringify(credentials));
+}
+
+export async function disconnectOAuthProvider(providerId: string): Promise<boolean> {
+	if (!getOAuthProvider(validateProviderId(providerId))) throw new Error(`Unknown OAuth provider: ${providerId}`);
+	return deleteSecretFromActiveProvider(secretName(providerId));
+}
+
+export async function isOAuthProviderConnected(providerId: string): Promise<boolean> {
+	return (await loadOAuthCredentials(providerId)) !== null;
+}
+
+export async function resolveOAuthCredential(providerId: string): Promise<ResolvedOAuthCredential | null> {
+	const normalized = validateProviderId(providerId);
+	const existing = refreshes.get(normalized);
+	if (existing) return existing;
+
+	const pending = (async () => {
+		const credentials = await loadOAuthCredentials(normalized);
+		if (!credentials) return null;
+		const result = await getOAuthApiKey(normalized, { [normalized]: credentials });
+		if (!result) return null;
+		if (JSON.stringify(result.newCredentials) !== JSON.stringify(credentials)) {
+			await storeOAuthCredentials(normalized, result.newCredentials);
+		}
+		return { apiKey: result.apiKey, credentials: result.newCredentials };
+	})();
+	refreshes.set(normalized, pending);
+	try {
+		return await pending;
+	} finally {
+		refreshes.delete(normalized);
+	}
+}
+
+function createInteraction(
+	session: OAuthLoginSession,
+	event: Omit<Extract<OAuthLoginEvent, { type: "prompt" | "select" | "manual_code" }>, "responseId">,
+	allowEmpty: boolean,
+	allowedValues?: ReadonlySet<string>,
+): Promise<string | undefined> {
+	if (session.controller.signal.aborted) return Promise.reject(new Error("Login cancelled"));
+	const responseId = randomUUID();
+	return new Promise<string | undefined>((resolve, reject) => {
+		session.pending.set(responseId, { responseId, allowEmpty, allowedValues, resolve, reject });
+		session.emit({ ...event, responseId } as OAuthLoginEvent);
+	});
+}
+
+function cleanupSession(session: OAuthLoginSession, reason?: string): void {
+	activeSessions.delete(session.id);
+	for (const interaction of session.pending.values()) {
+		interaction.reject(new Error(reason ?? "Login session closed"));
+	}
+	session.pending.clear();
+}
+
+export function startOAuthLogin(
+	providerId: string,
+	onCredentialsChanged?: () => void,
+): {
+	readonly sessionId: string;
+	readonly stream: ReadableStream<Uint8Array>;
+} {
+	const normalized = validateProviderId(providerId);
+	const provider = getOAuthProvider(normalized);
+	if (!provider) throw new Error(`Unknown OAuth provider: ${normalized}`);
+	if (activeSessions.size >= MAX_ACTIVE_OAUTH_SESSIONS) throw new Error("Too many active OAuth login sessions");
+
+	const sessionId = randomUUID();
+	const encoder = new TextEncoder();
+	let controllerRef: ReadableStreamDefaultController<Uint8Array> | null = null;
+	let closed = false;
+	const abortController = new AbortController();
+	const session: OAuthLoginSession = {
+		id: sessionId,
+		providerId: normalized,
+		controller: abortController,
+		pending: new Map(),
+		expiresAt: Date.now() + OAUTH_SESSION_TTL_MS,
+		emit(event) {
+			if (closed || !controllerRef) return;
+			controllerRef.enqueue(encoder.encode(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`));
+		},
+		close() {
+			if (closed) return;
+			closed = true;
+			try {
+				controllerRef?.close();
+			} catch {
+				// The consumer may already have cancelled the stream.
+			}
+		},
+	};
+
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controllerRef = controller;
+			activeSessions.set(sessionId, session);
+			session.emit({ type: "session", sessionId, providerId: normalized });
+			const timeout = setTimeout(() => abortOAuthLogin(sessionId, "Login session expired"), OAUTH_SESSION_TTL_MS);
+			timeout.unref?.();
+
+			const callbacks: OAuthLoginCallbacks = {
+				onAuth: (info) => session.emit({ type: "auth", ...info }),
+				onDeviceCode: (info) => session.emit({ type: "device_code", ...info }),
+				onPrompt: async (prompt) =>
+					(await createInteraction(session, { type: "prompt", ...prompt }, prompt.allowEmpty === true)) ?? "",
+				onSelect: async (prompt) =>
+					createInteraction(
+						session,
+						{ type: "select", ...prompt },
+						false,
+						new Set(prompt.options.map((option) => option.id)),
+					),
+				onProgress: (message) => session.emit({ type: "progress", message }),
+				onManualCodeInput: async () =>
+					(await createInteraction(
+						session,
+						{ type: "manual_code", message: "Paste the final redirect URL or authorization code" },
+						false,
+					)) ?? "",
+				signal: abortController.signal,
+			};
+
+			void provider
+				.login(callbacks)
+				.then(async (credentials) => {
+					if (abortController.signal.aborted) throw new Error("Login cancelled");
+					await storeOAuthCredentials(normalized, credentials);
+					onCredentialsChanged?.();
+					session.emit({ type: "connected", providerId: normalized });
+					session.emit({ type: "done" });
+				})
+				.catch((error) => {
+					session.emit({ type: "error", error: safeError(error) });
+					session.emit({ type: "done" });
+				})
+				.finally(() => {
+					clearTimeout(timeout);
+					cleanupSession(session);
+					session.close();
+				});
+		},
+		cancel() {
+			abortOAuthLogin(sessionId, "Client disconnected");
+		},
+	});
+
+	return { sessionId, stream };
+}
+
+export function completeOAuthInteraction(sessionId: string, responseId: string, value: string): void {
+	const session = activeSessions.get(sessionId);
+	if (!session || session.expiresAt <= Date.now()) throw new Error("OAuth login session not found or expired");
+	const interaction = session.pending.get(responseId);
+	if (!interaction) throw new Error("OAuth login response not found or already completed");
+	if (!interaction.allowEmpty && value.trim().length === 0) throw new Error("OAuth login response may not be empty");
+	if (interaction.allowedValues && !interaction.allowedValues.has(value)) {
+		throw new Error("OAuth login selection is not one of the offered options");
+	}
+	session.pending.delete(responseId);
+	interaction.resolve(value);
+}
+
+export function abortOAuthLogin(sessionId: string, reason = "Login cancelled"): boolean {
+	const session = activeSessions.get(sessionId);
+	if (!session) return false;
+	session.controller.abort(reason);
+	cleanupSession(session, reason);
+	session.close();
+	return true;
+}
+
+export function resetOAuthStateForTests(): void {
+	for (const sessionId of activeSessions.keys()) abortOAuthLogin(sessionId, "Test reset");
+	refreshes.clear();
+}

--- a/platform/daemon/src/inference-oauth.ts
+++ b/platform/daemon/src/inference-oauth.ts
@@ -8,6 +8,7 @@ import {
 	getOAuthProvider,
 	getOAuthProviders,
 } from "@earendil-works/pi-ai/oauth";
+import { logger } from "./logger";
 import { deleteSecretFromActiveProvider, getSecret, putSecret } from "./secrets";
 
 const OAUTH_SECRET_PREFIX = "SIGNET_OAUTH_";
@@ -153,7 +154,19 @@ export async function resolveOAuthCredential(providerId: string): Promise<Resolv
 	const pending = (async () => {
 		const credentials = await loadOAuthCredentials(normalized);
 		if (!credentials) return null;
-		const result = await getOAuthApiKey(normalized, { [normalized]: credentials });
+		let result: Awaited<ReturnType<typeof getOAuthApiKey>>;
+		try {
+			result = await getOAuthApiKey(normalized, { [normalized]: credentials });
+		} catch (error) {
+			if (!(error instanceof Error) || error.message !== `Failed to refresh OAuth token for ${normalized}`) {
+				throw error;
+			}
+			logger.warn("inference", "OAuth credential refresh failed", {
+				providerId: normalized,
+				error: safeError(error),
+			});
+			return null;
+		}
 		if (!result) return null;
 		if (JSON.stringify(result.newCredentials) !== JSON.stringify(credentials)) {
 			await storeOAuthCredentials(normalized, result.newCredentials);

--- a/platform/daemon/src/inference-provider-factory.test.ts
+++ b/platform/daemon/src/inference-provider-factory.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { parseRoutingConfig } from "@signet/core";
+import { createRoutingProvider } from "./inference-provider-factory";
+
+function codexConfig(model = "gpt-5.4") {
+	const parsed = parseRoutingConfig({
+		inference: {
+			accounts: {
+				codex: { kind: "subscription_session", providerFamily: "openai-codex" },
+			},
+			targets: {
+				codex: {
+					executor: "openai-codex",
+					account: "codex",
+					models: { default: { model } },
+				},
+			},
+		},
+	});
+	if (!parsed.ok) throw new Error(parsed.error.message);
+	return parsed.value;
+}
+
+describe("inference provider factory", () => {
+	test("constructs native pi-ai OAuth providers from catalog model metadata", async () => {
+		const provider = await createRoutingProvider({
+			config: codexConfig(),
+			targetId: "codex",
+			modelId: "default",
+			async resolveCredential() {
+				return {
+					apiKey: "oauth-access",
+					oauthCredentials: { refresh: "oauth-refresh", access: "oauth-access", expires: Date.now() + 60_000 },
+				};
+			},
+		});
+
+		expect(provider.name).toBe("openai-codex:gpt-5.4");
+		expect(await provider.available()).toBe(true);
+	});
+
+	test("fails clearly when a dynamic provider model is absent from pi-ai", async () => {
+		await expect(
+			createRoutingProvider({
+				config: codexConfig("not-a-real-model"),
+				targetId: "codex",
+				modelId: "default",
+				async resolveCredential() {
+					return { apiKey: "oauth-access" };
+				},
+			}),
+		).rejects.toThrow('Unknown pi-ai model "not-a-real-model" for provider "openai-codex"');
+	});
+});

--- a/platform/daemon/src/inference-provider-factory.ts
+++ b/platform/daemon/src/inference-provider-factory.ts
@@ -1,7 +1,9 @@
-import type { PipelineClaudeCodeConfig, RoutingConfig } from "@signet/core";
+import { type Api, type Model, type OAuthCredentials, getModels, getProviders } from "@earendil-works/pi-ai";
+import { getOAuthProvider } from "@earendil-works/pi-ai/oauth";
+import type { PipelineClaudeCodeConfig, RoutingAccountConfig, RoutingConfig } from "@signet/core";
+import { type PiExecutorKind, createPiModelProvider } from "./pipeline/pi-provider";
 import type { AcpxHooksMode, StreamCapableLlmProvider } from "./pipeline/provider";
 import { createAcpxProvider } from "./pipeline/provider";
-import { createPiModelProvider, type PiExecutorKind } from "./pipeline/pi-provider";
 
 export interface CreateRoutingProviderOptions {
 	readonly config: RoutingConfig;
@@ -9,7 +11,12 @@ export interface CreateRoutingProviderOptions {
 	readonly modelId: string;
 	readonly acpxHooks?: AcpxHooksMode;
 	readonly claudeCode?: PipelineClaudeCodeConfig;
-	resolveCredential(credentialRef: string | undefined): Promise<string | undefined>;
+	resolveCredential(account: RoutingAccountConfig | undefined): Promise<ResolvedInferenceCredential | undefined>;
+}
+
+export interface ResolvedInferenceCredential {
+	readonly apiKey: string;
+	readonly oauthCredentials?: OAuthCredentials;
 }
 
 /**
@@ -19,14 +26,21 @@ export interface CreateRoutingProviderOptions {
  */
 const FOLDED_EXECUTORS = new Set(["claude-code", "codex", "opencode", "command"]);
 
-/** Executors routed through the Pi (pi-ai) backend. */
-const PI_EXECUTORS = new Set<PiExecutorKind>([
-	"anthropic",
-	"openrouter",
-	"ollama",
-	"llama-cpp",
-	"openai-compatible",
-]);
+const CUSTOM_PI_EXECUTORS = new Set(["anthropic", "openrouter", "ollama", "llama-cpp", "openai-compatible"]);
+
+function catalogModel(
+	providerFamily: string,
+	modelId: string,
+	credential: ResolvedInferenceCredential | undefined,
+): Model<Api> | undefined {
+	if (!(getProviders() as readonly string[]).includes(providerFamily)) return undefined;
+	let models = (getModels as (provider: string) => Model<Api>[])(providerFamily);
+	const oauthProvider = getOAuthProvider(providerFamily);
+	if (oauthProvider?.modifyModels && credential?.oauthCredentials) {
+		models = oauthProvider.modifyModels(models, credential.oauthCredentials);
+	}
+	return models.find((candidate) => candidate.id === modelId);
+}
 
 export async function createRoutingProvider(opts: CreateRoutingProviderOptions): Promise<StreamCapableLlmProvider> {
 	const target = opts.config.targets[opts.targetId];
@@ -46,25 +60,32 @@ export async function createRoutingProvider(opts: CreateRoutingProviderOptions):
 
 	if (FOLDED_EXECUTORS.has(target.executor)) {
 		throw new Error(
-			`Routing executor "${target.executor}" has been folded into the Pi + ACPX backends (#947). ` +
-				`Reconfigure target "${opts.targetId}" to use one of: anthropic, openrouter, ollama, llama-cpp, openai-compatible, acpx. ` +
-				`For claude-code/codex/opencode use 'executor: acpx' with an 'acpx: { agent: <name> }' block; ` +
-				`see docs/UPGRADING.md. Restart the daemon to re-run the automatic one-time config migration.`,
+			`Routing executor "${target.executor}" has been folded into the Pi + ACPX backends (#947). Reconfigure target "${opts.targetId}" to use one of: anthropic, openrouter, ollama, llama-cpp, openai-compatible, acpx. For claude-code/codex/opencode use 'executor: acpx' with an 'acpx: { agent: <name> }' block; see docs/UPGRADING.md. Restart the daemon to re-run the automatic one-time config migration.`,
 		);
 	}
 
-	if (!PI_EXECUTORS.has(target.executor as PiExecutorKind)) {
+	const account = target.account ? opts.config.accounts[target.account] : undefined;
+	const providerFamily = account?.providerFamily ?? target.executor;
+	if (!CUSTOM_PI_EXECUTORS.has(target.executor) && !(getProviders() as readonly string[]).includes(providerFamily)) {
 		throw new Error(`Unsupported routing executor "${target.executor}" for target ${opts.targetId}`);
 	}
 
-	const account = target.account ? opts.config.accounts[target.account] : undefined;
-	const credential = await opts.resolveCredential(account?.credentialRef);
+	const credential = await opts.resolveCredential(account);
+	const piModel = CUSTOM_PI_EXECUTORS.has(target.executor)
+		? undefined
+		: catalogModel(providerFamily, model.model, credential);
+	if (!piModel && !CUSTOM_PI_EXECUTORS.has(target.executor)) {
+		throw new Error(`Unknown pi-ai model "${model.model}" for provider "${providerFamily}"`);
+	}
 
 	return createPiModelProvider({
 		executor: target.executor as PiExecutorKind,
+		providerFamily,
 		model: model.model,
+		piModel,
+		skipAvailabilityProbe: piModel !== undefined,
 		baseUrl: target.endpoint,
-		apiKey: credential,
+		apiKey: credential?.apiKey,
 		// Map routing intent to a pi-ai ThinkingLevel (forwarded per-call as
 		// options.reasoning). model.reasoning (RoutingReasoningDepth) defaults to
 		// "medium" for every parsed model, so it cannot alone signal "enable
@@ -73,11 +94,7 @@ export async function createRoutingProvider(opts: CreateRoutingProviderOptions):
 		// the documented OpenRouter reasoning block, or a deliberately-set
 		// "high" depth. Previously this compared to a nonexistent "deep"
 		// value (TS2367) and never produced a usable level.
-		reasoning: target.openrouter?.reasoning?.enabled
-			? "medium"
-			: model.reasoning === "high"
-				? "high"
-				: undefined,
+		reasoning: target.openrouter?.reasoning?.enabled ? "medium" : model.reasoning === "high" ? "high" : undefined,
 		contextWindow: model.contextWindow,
 		name: `${target.executor}:${model.model}`,
 		defaultTimeoutMs: 60_000,

--- a/platform/daemon/src/inference-router.test.ts
+++ b/platform/daemon/src/inference-router.test.ts
@@ -2,11 +2,16 @@ import { afterEach, describe, expect, it, mock } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { registerOAuthProvider, unregisterOAuthProvider } from "@earendil-works/pi-ai/oauth";
+import { resetOAuthStateForTests, storeOAuthCredentials } from "./inference-oauth";
 import { getOrCreateInferenceRouter, resetInferenceRouterForTests } from "./inference-router";
+import { invalidateSecretsCache } from "./secrets";
 
 const originalFetch = globalThis.fetch;
 const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
 const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
+const originalSignetPath = process.env.SIGNET_PATH;
+const REVOKED_OAUTH_PROVIDER_ID = "signet-router-review-oauth";
 
 /** Build an OpenAI-compatible SSE streaming response (pi-ai's openai-completions transport streams). */
 function openAiSseResponse(
@@ -23,6 +28,11 @@ function openAiSseResponse(
 
 afterEach(() => {
 	globalThis.fetch = originalFetch;
+	resetOAuthStateForTests();
+	unregisterOAuthProvider(REVOKED_OAUTH_PROVIDER_ID);
+	invalidateSecretsCache();
+	if (originalSignetPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
+	else process.env.SIGNET_PATH = originalSignetPath;
 	if (originalOpenRouterApiKey === undefined) {
 		process.env.OPENROUTER_API_KEY = undefined;
 	} else {
@@ -37,6 +47,94 @@ afterEach(() => {
 });
 
 describe("InferenceRouter legacy API credentials", () => {
+	it("isolates a rejected OAuth refresh from healthy fallback targets", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-router-oauth-refresh-"));
+		try {
+			mkdirSync(join(dir, "memory"), { recursive: true });
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`inference:
+  defaultPolicy: auto
+  accounts:
+    revoked:
+      kind: subscription_session
+      providerFamily: ${REVOKED_OAUTH_PROVIDER_ID}
+  targets:
+    revoked:
+      kind: subscription_session
+      executor: ${REVOKED_OAUTH_PROVIDER_ID}
+      account: revoked
+      models:
+        default:
+          model: unavailable
+    healthy:
+      executor: openai-compatible
+      endpoint: http://127.0.0.1:1234/v1
+      models:
+        default:
+          model: healthy-local
+  policies:
+    auto:
+      mode: automatic
+      defaultTargets:
+        - revoked/default
+        - healthy/default
+  workloads:
+    interactive:
+      policy: auto
+`,
+			);
+
+			process.env.SIGNET_PATH = dir;
+			invalidateSecretsCache();
+			registerOAuthProvider({
+				id: REVOKED_OAUTH_PROVIDER_ID,
+				name: "Revoked review OAuth",
+				async login() {
+					throw new Error("login not used");
+				},
+				async refreshToken() {
+					throw new Error("revoked refresh token");
+				},
+				getApiKey(credentials) {
+					return credentials.access;
+				},
+			});
+			await storeOAuthCredentials(REVOKED_OAUTH_PROVIDER_ID, {
+				refresh: "refresh-revoked",
+				access: "access-expired",
+				expires: Date.now() - 1,
+			});
+
+			globalThis.fetch = mock((input: string | URL | Request) => {
+				const url = String(input);
+				if (url.endsWith("/models")) {
+					return Promise.resolve(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+				}
+				return Promise.resolve(openAiSseResponse("healthy fallback answer"));
+			}) as unknown as typeof fetch;
+
+			const router = getOrCreateInferenceRouter(dir);
+			const status = await router.status(true);
+			expect(status.ok).toBe(true);
+			if (!status.ok) return;
+			expect(status.value.runtimeSnapshot.targets["revoked/default"]?.accountState).toBe("expired");
+			expect(status.value.runtimeSnapshot.targets["healthy/default"]?.accountState).toBe("ready");
+
+			const result = await router.execute(
+				{ operation: "interactive", promptPreview: "fallback after revoked OAuth" },
+				"Answer through the healthy target",
+				{ maxTokens: 64, timeoutMs: 1000 },
+			);
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.text).toBe("healthy fallback answer");
+			expect(result.value.decision.targetRef).toBe("healthy/default");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("uses OPENROUTER_API_KEY for legacy pipeline OpenRouter synthesis targets", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "signet-router-openrouter-"));
 		try {

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -7,6 +7,7 @@ import type {
 	RouteDecision,
 	RouteRequest,
 	RouterResult,
+	RoutingAccountConfig,
 	RoutingConfig,
 	RoutingOperationKind,
 	RoutingRuntimeSnapshot,
@@ -21,7 +22,8 @@ import {
 	parseYamlDocument,
 	resolveRoutingDecision,
 } from "@signet/core";
-import { createRoutingProvider } from "./inference-provider-factory";
+import { isOAuthProvider, resolveOAuthCredential } from "./inference-oauth";
+import { type ResolvedInferenceCredential, createRoutingProvider } from "./inference-provider-factory";
 import { logger } from "./logger";
 import { loadMemoryConfig } from "./memory-config";
 import {
@@ -459,14 +461,25 @@ export class InferenceRouter {
 		}
 	}
 
-	private async resolveCredential(credentialRef: string | undefined): Promise<string | undefined> {
+	private async resolveCredential(
+		account: RoutingAccountConfig | undefined,
+	): Promise<ResolvedInferenceCredential | undefined> {
+		if (
+			account &&
+			isOAuthProvider(account.providerFamily) &&
+			(account.kind === "subscription_session" || !account.credentialRef)
+		) {
+			const oauth = await resolveOAuthCredential(account.providerFamily);
+			if (oauth) return { apiKey: oauth.apiKey, oauthCredentials: oauth.credentials };
+		}
+		const credentialRef = account?.credentialRef;
 		if (!credentialRef) return undefined;
 		const envValue = process.env[credentialRef];
 		if (typeof envValue === "string" && envValue.trim().length > 0) {
-			return envValue.trim();
+			return { apiKey: envValue.trim() };
 		}
 		try {
-			return await getSecret(credentialRef);
+			return { apiKey: await getSecret(credentialRef) };
 		} catch {
 			return undefined;
 		}
@@ -479,8 +492,16 @@ export class InferenceRouter {
 		acpxHooks?: AcpxHooksMode,
 	): Promise<StreamCapableLlmProvider> {
 		const cacheKey = `${loaded.signature}:${targetId}/${modelId}:${acpxHooks ?? "configured-hooks"}`;
-		const cached = this.providerCache.get(cacheKey);
-		if (cached) return cached;
+		const target = loaded.config.targets[targetId];
+		const account = target?.account ? loaded.config.accounts[target.account] : undefined;
+		const oauthBacked =
+			account !== undefined &&
+			isOAuthProvider(account.providerFamily) &&
+			(account.kind === "subscription_session" || !account.credentialRef);
+		if (!oauthBacked) {
+			const cached = this.providerCache.get(cacheKey);
+			if (cached) return cached;
+		}
 
 		const build = (async (): Promise<StreamCapableLlmProvider> => {
 			return createRoutingProvider({
@@ -489,11 +510,11 @@ export class InferenceRouter {
 				modelId,
 				acpxHooks,
 				claudeCode: loadMemoryConfig(this.agentsDir).pipelineV2.claudeCode,
-				resolveCredential: (credentialRef) => this.resolveCredential(credentialRef),
+				resolveCredential: (candidateAccount) => this.resolveCredential(candidateAccount),
 			});
 		})();
 
-		this.providerCache.set(cacheKey, build);
+		if (!oauthBacked) this.providerCache.set(cacheKey, build);
 		return build;
 	}
 
@@ -522,7 +543,12 @@ export class InferenceRouter {
 			};
 		}
 		const account = target.account ? loaded.config.accounts[target.account] : undefined;
+		const oauthCredentialAccount =
+			account !== undefined &&
+			isOAuthProvider(account.providerFamily) &&
+			(account.kind === "subscription_session" || !account.credentialRef);
 		const needsCredential =
+			oauthCredentialAccount ||
 			target.executor === "anthropic" ||
 			target.executor === "openrouter" ||
 			(target.executor === "openai-compatible" && !isLocalInferenceEndpoint(target.endpoint));
@@ -536,7 +562,7 @@ export class InferenceRouter {
 			};
 		}
 		if (needsCredential) {
-			const credential = await this.resolveCredential(account?.credentialRef);
+			const credential = await this.resolveCredential(account);
 			if (!credential) {
 				return {
 					available: false,
@@ -567,6 +593,13 @@ export class InferenceRouter {
 				unavailableReason: formatExecutionError(error),
 			};
 		}
+	}
+
+	invalidateCredentialState(): void {
+		this.providerCache.clear();
+		this.observedTargetState.clear();
+		this.observedAccountState.clear();
+		this.resetRuntimeCaches();
 	}
 
 	private async runtimeSnapshot(loaded: LoadedRoutingConfig, refresh = false): Promise<RoutingRuntimeSnapshot> {

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -227,6 +227,14 @@ function isRuntimeBlocked(state: RoutingRuntimeState): boolean {
 	);
 }
 
+function isOAuthBackedAccount(account: RoutingAccountConfig | undefined): account is RoutingAccountConfig {
+	return (
+		account !== undefined &&
+		isOAuthProvider(account.providerFamily) &&
+		(account.kind === "subscription_session" || !account.credentialRef)
+	);
+}
+
 function buildPromptFromMessages(messages: ReadonlyArray<{ readonly role: string; readonly content: string }>): string {
 	return messages.map((message) => `${message.role.toUpperCase()}:\n${message.content}`).join("\n\n");
 }
@@ -464,11 +472,7 @@ export class InferenceRouter {
 	private async resolveCredential(
 		account: RoutingAccountConfig | undefined,
 	): Promise<ResolvedInferenceCredential | undefined> {
-		if (
-			account &&
-			isOAuthProvider(account.providerFamily) &&
-			(account.kind === "subscription_session" || !account.credentialRef)
-		) {
+		if (isOAuthBackedAccount(account)) {
 			const oauth = await resolveOAuthCredential(account.providerFamily);
 			if (oauth) return { apiKey: oauth.apiKey, oauthCredentials: oauth.credentials };
 		}
@@ -494,10 +498,7 @@ export class InferenceRouter {
 		const cacheKey = `${loaded.signature}:${targetId}/${modelId}:${acpxHooks ?? "configured-hooks"}`;
 		const target = loaded.config.targets[targetId];
 		const account = target?.account ? loaded.config.accounts[target.account] : undefined;
-		const oauthBacked =
-			account !== undefined &&
-			isOAuthProvider(account.providerFamily) &&
-			(account.kind === "subscription_session" || !account.credentialRef);
+		const oauthBacked = isOAuthBackedAccount(account);
 		if (!oauthBacked) {
 			const cached = this.providerCache.get(cacheKey);
 			if (cached) return cached;
@@ -543,10 +544,7 @@ export class InferenceRouter {
 			};
 		}
 		const account = target.account ? loaded.config.accounts[target.account] : undefined;
-		const oauthCredentialAccount =
-			account !== undefined &&
-			isOAuthProvider(account.providerFamily) &&
-			(account.kind === "subscription_session" || !account.credentialRef);
+		const oauthCredentialAccount = isOAuthBackedAccount(account);
 		const needsCredential =
 			oauthCredentialAccount ||
 			target.executor === "anthropic" ||
@@ -568,7 +566,7 @@ export class InferenceRouter {
 					available: false,
 					health: "blocked",
 					circuitOpen: false,
-					accountState: "missing",
+					accountState: target.kind === "subscription_session" ? "expired" : "missing",
 					unavailableReason: `missing credential${target.account ? ` for ${target.account}` : ""}`,
 				};
 			}

--- a/platform/daemon/src/pipeline/pi-provider.test.ts
+++ b/platform/daemon/src/pipeline/pi-provider.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { type Api, type Model, getModels } from "@earendil-works/pi-ai";
+import { githubCopilotOAuthProvider } from "@earendil-works/pi-ai/oauth";
+import { resolvePiModel } from "./pi-provider";
+
+describe("pi provider catalog models", () => {
+	test("preserves the Codex responses API and registry metadata", () => {
+		const model = getModels("openai-codex").find((candidate) => candidate.id === "gpt-5.4");
+		expect(model).toBeDefined();
+		const resolved = resolvePiModel({
+			executor: "openai-codex",
+			providerFamily: "openai-codex",
+			model: "gpt-5.4",
+			piModel: model as Model<Api>,
+			apiKey: "oauth-access",
+		});
+
+		expect(resolved.piModel.api).toBe("openai-codex-responses");
+		expect(resolved.piModel.baseUrl).toBe("https://chatgpt.com/backend-api");
+		expect(resolved.apiKey).toBe("oauth-access");
+	});
+
+	test("preserves Copilot headers and applies credential-dependent model changes", () => {
+		const models = getModels("github-copilot") as Model<Api>[];
+		const modified = githubCopilotOAuthProvider.modifyModels?.(models, {
+			refresh: "refresh",
+			access: "tid=1;proxy-ep=proxy.enterprise.example.com;exp=9999999999",
+			expires: Date.now() + 60_000,
+		});
+		const model = modified?.[0];
+		expect(model).toBeDefined();
+		if (!model) throw new Error("Copilot catalog model missing");
+		const resolved = resolvePiModel({
+			executor: "github-copilot",
+			providerFamily: "github-copilot",
+			model: model.id,
+			piModel: model,
+			apiKey: "copilot-access",
+		});
+
+		expect(resolved.piModel.baseUrl).toBe("https://api.enterprise.example.com");
+		expect(resolved.piModel.headers?.["Copilot-Integration-Id"]).toBe("vscode-chat");
+	});
+});

--- a/platform/daemon/src/pipeline/pi-provider.ts
+++ b/platform/daemon/src/pipeline/pi-provider.ts
@@ -29,12 +29,7 @@ import type {
 } from "./provider";
 
 /** Executors that route through pi-ai. `acpx` is handled separately. */
-export type PiExecutorKind =
-	| "anthropic"
-	| "openrouter"
-	| "ollama"
-	| "llama-cpp"
-	| "openai-compatible";
+export type PiExecutorKind = "anthropic" | "openrouter" | "ollama" | "llama-cpp" | "openai-compatible" | (string & {});
 
 const DEFAULT_ANTHROPIC_BASE_URL = "https://api.anthropic.com";
 const DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
@@ -56,7 +51,12 @@ const LOCAL_COMPAT: OpenAICompletionsCompat = {
 
 export interface PiModelProviderConfig {
 	readonly executor: PiExecutorKind;
+	readonly providerFamily?: string;
 	readonly model: string;
+	/** Model metadata supplied by pi-ai for native providers. */
+	readonly piModel?: Model<Api>;
+	/** Native pi-ai providers do not share a portable unauthenticated health endpoint. */
+	readonly skipAvailabilityProbe?: boolean;
 	readonly baseUrl?: string;
 	/** Resolved credential (API key). Omit for keyless local servers. */
 	readonly apiKey?: string;
@@ -96,6 +96,19 @@ function withVersionPath(baseUrl: string): string {
 export function resolvePiModel(config: PiModelProviderConfig): ResolvedModel {
 	const timeoutMs = config.defaultTimeoutMs ?? 60_000;
 	void timeoutMs;
+	if (config.piModel) {
+		const piModel: Model<Api> = {
+			...config.piModel,
+			...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
+			...(config.contextWindow ? { contextWindow: config.contextWindow } : {}),
+			...(config.maxTokens ? { maxTokens: config.maxTokens } : {}),
+		};
+		return {
+			piModel,
+			apiKey: config.apiKey,
+			label: `${config.providerFamily ?? config.executor}:${config.model}`,
+		};
+	}
 	switch (config.executor) {
 		case "anthropic": {
 			const baseUrl = config.baseUrl ?? DEFAULT_ANTHROPIC_BASE_URL;
@@ -153,8 +166,7 @@ export function resolvePiModel(config: PiModelProviderConfig): ResolvedModel {
 						: DEFAULT_OPENAI_COMPATIBLE_BASE_URL;
 			const rawBase = config.baseUrl ?? defaultBase;
 			// ollama/llama-cpp always get /v1; openai-compatible respects a provided path.
-			const baseUrl =
-				config.executor === "openai-compatible" ? withVersionPath(rawBase) : withVersionPath(rawBase);
+			const baseUrl = config.executor === "openai-compatible" ? withVersionPath(rawBase) : withVersionPath(rawBase);
 			// Keyless only when the server is local AND no explicit key was provided.
 			// A local gateway/proxy that requires a bearer token keeps its real key.
 			const keyless = !config.apiKey && isLocalBaseUrl(rawBase);
@@ -178,6 +190,8 @@ export function resolvePiModel(config: PiModelProviderConfig): ResolvedModel {
 				label: `${config.executor}:${config.model}`,
 			};
 		}
+		default:
+			throw new Error(`Provider ${config.providerFamily ?? config.executor} requires a model from the pi-ai catalog`);
 	}
 }
 
@@ -217,7 +231,10 @@ function toError(label: string, message: { stopReason: string; errorMessage?: st
 }
 
 /** Create an AbortController that fires on caller signal OR timeout. */
-function callerAbort(opts: LlmProviderCallOptions | undefined, defaultTimeoutMs: number): {
+function callerAbort(
+	opts: LlmProviderCallOptions | undefined,
+	defaultTimeoutMs: number,
+): {
 	signal: AbortSignal;
 	abort: () => void;
 	cleanup: () => void;
@@ -256,7 +273,10 @@ export function createPiModelProvider(config: PiModelProviderConfig): StreamCapa
 		};
 	}
 
-	function buildOptions(opts: LlmProviderCallOptions | undefined, abort: { signal: AbortSignal }): {
+	function buildOptions(
+		opts: LlmProviderCallOptions | undefined,
+		abort: { signal: AbortSignal },
+	): {
 		apiKey: string | undefined;
 		signal: AbortSignal;
 		maxTokens?: number;
@@ -310,12 +330,14 @@ export function createPiModelProvider(config: PiModelProviderConfig): StreamCapa
 			return callOnce(prompt, opts);
 		},
 		async available() {
+			if (config.skipAvailabilityProbe) return true;
 			// Reachability check: ping the OpenAI-compatible /models endpoint (or
 			// Anthropic /v1/models) so the router can skip unreachable targets before
 			// attempting a real call. Mirrors the legacy providers' availability probe.
-			const probeUrl = piModel.api === "anthropic-messages"
-				? `${piModel.baseUrl.replace(/\/+$/, "")}/v1/models`
-				: `${piModel.baseUrl.replace(/\/+$/, "")}/models`;
+			const probeUrl =
+				piModel.api === "anthropic-messages"
+					? `${piModel.baseUrl.replace(/\/+$/, "")}/v1/models`
+					: `${piModel.baseUrl.replace(/\/+$/, "")}/models`;
 			try {
 				const res = await fetch(probeUrl, {
 					method: "GET",

--- a/platform/daemon/src/routes/inference.ts
+++ b/platform/daemon/src/routes/inference.ts
@@ -1,3 +1,4 @@
+import { getModels, getProviders } from "@earendil-works/pi-ai";
 import {
 	ROUTING_COST_TIERS,
 	ROUTING_OPERATION_KINDS,
@@ -5,11 +6,17 @@ import {
 	type RouteRequest,
 	parseRoutingTargetRef,
 } from "@signet/core";
-import { getModels, getProviders } from "@earendil-works/pi-ai";
 import type { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { AuthMode, TokenClaims } from "../auth/index.js";
 import { checkScope } from "../auth/index.js";
+import {
+	completeOAuthInteraction,
+	disconnectOAuthProvider,
+	isOAuthProviderConnected,
+	listOAuthProviderMetadata,
+	startOAuthLogin,
+} from "../inference-oauth.js";
 import { getInferenceRouterOrNull } from "../inference-router.js";
 import type { TelemetryCollector, TelemetryEvent, TelemetryProperties } from "../telemetry.js";
 
@@ -784,6 +791,28 @@ function buildUsagePayload(
 	};
 }
 
+async function oauthProviderStatus(provider: {
+	readonly id: string;
+	readonly name: string;
+	readonly usesCallbackServer: boolean;
+}): Promise<{
+	readonly id: string;
+	readonly name: string;
+	readonly usesCallbackServer: boolean;
+	readonly connected: boolean;
+	readonly error?: string;
+}> {
+	try {
+		return { ...provider, connected: await isOAuthProviderConnected(provider.id) };
+	} catch (error) {
+		return {
+			...provider,
+			connected: false,
+			error: error instanceof Error ? error.message.slice(0, 300) : "OAuth credential status failed",
+		};
+	}
+}
+
 export function mountInferenceRoutes(app: Hono, opts: InferenceRouteOptions = {}): void {
 	app.get("/api/inference/status", async (c) => {
 		const router = getInferenceRouterOrNull();
@@ -797,17 +826,22 @@ export function mountInferenceRoutes(app: Hono, opts: InferenceRouteOptions = {}
 	});
 
 	// Catalog of providers + models (pi-ai) and ACPX agents. Backs the dashboard
-	// inference settings redesign (#947). Pure read from the pi-ai catalog; does
-	// not touch credentials or make network calls.
-	app.get("/api/inference/catalog", (c) => {
+	// inference settings redesign (#947). Reads only provider/model metadata and
+	// encrypted credential presence; it never returns credential values or makes
+	// provider network calls.
+	app.get("/api/inference/catalog", async (c) => {
 		const providers = getProviders();
-		const models: Record<string, Array<{
-			id: string;
-			name: string;
-			contextWindow: number;
-			input: readonly string[];
-			reasoning: boolean;
-		}>> = {};
+		const models: Record<
+			string,
+			Array<{
+				id: string;
+				name: string;
+				contextWindow: number;
+				input: readonly string[];
+				reasoning: boolean;
+			}>
+		> = {};
+		const modelErrors: Record<string, string> = {};
 		for (const provider of providers) {
 			try {
 				models[provider] = getModels(provider).map((m) => ({
@@ -817,19 +851,70 @@ export function mountInferenceRoutes(app: Hono, opts: InferenceRouteOptions = {}
 					input: m.input,
 					reasoning: m.reasoning,
 				}));
-			} catch {
-				// A provider whose catalog fails to resolve yields no models; the
-			// picker just shows none for it. Never fail the whole catalog.
-				models[provider] = [];
+			} catch (error) {
+				modelErrors[provider] = error instanceof Error ? error.message : "model catalog resolution failed";
 			}
 		}
+		const oauthProviders = await Promise.all(listOAuthProviderMetadata().map(oauthProviderStatus));
 		return c.json({
 			providers,
 			models,
+			modelErrors,
+			oauthProviders,
 			// ACPX agent subcommands (acpx <agent> ...). Static — matches the
 			// agents createAcpxProvider drives. Mirrors `acpx --help` subcommands.
 			acpxAgents: ["claude", "codex", "opencode", "gemini", "pi", "openclaw"],
 		});
+	});
+
+	app.get("/api/inference/oauth/providers", async (c) => {
+		const providers = await Promise.all(listOAuthProviderMetadata().map(oauthProviderStatus));
+		return c.json({ providers });
+	});
+
+	app.post("/api/inference/oauth/login/:id", (c) => {
+		try {
+			const login = startOAuthLogin(c.req.param("id"), () => getInferenceRouterOrNull()?.invalidateCredentialState());
+			return new Response(login.stream, {
+				headers: {
+					"Content-Type": "text/event-stream",
+					"Cache-Control": "no-cache, no-transform",
+					Connection: "keep-alive",
+					"X-Signet-OAuth-Session-Id": login.sessionId,
+				},
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Failed to start OAuth login";
+			return c.json({ error: message }, /unknown|invalid/i.test(message) ? 404 : 429);
+		}
+	});
+
+	app.post("/api/inference/oauth/complete", async (c) => {
+		const body = await readJsonObject(c, 16 * 1024);
+		if (!body.ok) return c.json({ error: body.message, details: body.details ?? null }, body.status);
+		const sessionId = parseTrimmedString(body.value.sessionId);
+		const responseId = parseTrimmedString(body.value.responseId);
+		const value = typeof body.value.value === "string" ? body.value.value : undefined;
+		if (!sessionId || !responseId || value === undefined) {
+			return c.json({ error: "sessionId, responseId, and string value are required" }, 400);
+		}
+		try {
+			completeOAuthInteraction(sessionId, responseId, value);
+			return c.json({ success: true });
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : "OAuth response failed" }, 400);
+		}
+	});
+
+	app.post("/api/inference/oauth/disconnect/:id", async (c) => {
+		try {
+			const disconnected = await disconnectOAuthProvider(c.req.param("id"));
+			getInferenceRouterOrNull()?.invalidateCredentialState();
+			return c.json({ success: true, disconnected });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "OAuth disconnect failed";
+			return c.json({ error: message }, /unknown|invalid/i.test(message) ? 404 : 500);
+		}
 	});
 
 	app.get("/api/inference/history", (c) => {

--- a/surfaces/dashboard/src/lib/api.inference.test.ts
+++ b/surfaces/dashboard/src/lib/api.inference.test.ts
@@ -22,10 +22,12 @@ describe("api key validation", () => {
 	});
 
 	test("falls back leniently for providers without a known prefix", () => {
-		// A provider we have no strict pattern for: trust length, don't pretend
-		// to know the format.
+		// A provider we have no strict pattern for: never disable Connect on a
+		// non-empty key (legitimate short keys for custom gateways / some Bedrock
+		// shapes). Surface "unsure" so the hint shows and the button stays on.
 		expect(validateApiKey("amazon-bedrock", "a".repeat(24))).toBe("unsure");
-		expect(validateApiKey("amazon-bedrock", "short")).toBe("empty");
+		expect(validateApiKey("amazon-bedrock", "short")).toBe("unsure");
+		expect(validateApiKey("amazon-bedrock", "")).toBe("empty");
 		expect(apiKeyFormat("amazon-bedrock")).toBeNull();
 		// Providers with a lenient length-only pattern still validate honestly.
 		expect(validateApiKey("together", "a".repeat(24))).toBe("valid");

--- a/surfaces/dashboard/src/lib/api.inference.test.ts
+++ b/surfaces/dashboard/src/lib/api.inference.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { apiKeyFormat, providerKeySecretName, validateApiKey } from "./inference-keys";
+
+// The connect dialog's instant key feedback (#966/#968 UI half). Validation is
+// advisory — a non-match never blocks save, it only nudges with a format hint.
+describe("api key validation", () => {
+	test("recognizes known provider key shapes", () => {
+		expect(validateApiKey("anthropic", "sk-ant-api03-xxxxxxxx")).toBe("valid");
+		expect(validateApiKey("openai", "sk-proj-deadbeef")).toBe("valid");
+		expect(validateApiKey("openrouter", "sk-or-v1-abc")).toBe("valid");
+		expect(validateApiKey("google", "AIzaSyXXXXXXXX")).toBe("valid");
+		expect(validateApiKey("xai", "xai-abcdef")).toBe("valid");
+		expect(validateApiKey("groq", "gsk_abc123")).toBe("valid");
+	});
+
+	test("flags format mismatches as unsure, never blocks", () => {
+		// A real-looking key that doesn't match the usual prefix.
+		expect(validateApiKey("anthropic", "not-an-anthropic-key")).toBe("unsure");
+		// Empty is the only state that disables the connect button.
+		expect(validateApiKey("anthropic", "   ")).toBe("empty");
+		expect(validateApiKey("anthropic", "")).toBe("empty");
+	});
+
+	test("falls back leniently for providers without a known prefix", () => {
+		// A provider we have no strict pattern for: trust length, don't pretend
+		// to know the format.
+		expect(validateApiKey("amazon-bedrock", "a".repeat(24))).toBe("unsure");
+		expect(validateApiKey("amazon-bedrock", "short")).toBe("empty");
+		expect(apiKeyFormat("amazon-bedrock")).toBeNull();
+		// Providers with a lenient length-only pattern still validate honestly.
+		expect(validateApiKey("together", "a".repeat(24))).toBe("valid");
+		expect(apiKeyFormat("together")?.hint).toBe("a Together API key");
+	});
+
+	test("trims whitespace before checking", () => {
+		// Paste often includes a trailing newline/space.
+		expect(validateApiKey("openrouter", "  sk-or-v1-abc\n")).toBe("valid");
+	});
+});
+
+describe("provider key secret naming", () => {
+	test("produces stable, human-meaningful, uppercase secret names", () => {
+		expect(providerKeySecretName("anthropic")).toBe("SIGNET_KEY_ANTHROPIC");
+		expect(providerKeySecretName("openrouter")).toBe("SIGNET_KEY_OPENROUTER");
+	});
+
+	test("sanitizes non-alphanumeric families", () => {
+		// google-vertex → GOOGLE_VERTEX so the secret name stays a valid env/secret key.
+		expect(providerKeySecretName("google-vertex")).toBe("SIGNET_KEY_GOOGLE_VERTEX");
+	});
+});

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -3721,7 +3721,17 @@ export interface InferenceCatalog {
 export async function getInferenceCatalog(): Promise<InferenceCatalog> {
 	const response = await authFetch(`${API_BASE}/api/inference/catalog`);
 	if (!response.ok) throw new Error("Failed to fetch inference catalog");
-	return response.json();
+	const raw = await response.json();
+	// Default #968 fields so a pre-#968 daemon (which omits oauthProviders/
+	// modelErrors) doesn't break direct callers — the type declares them
+	// required, so honor that contract here rather than at every call site.
+	return {
+		providers: raw.providers ?? [],
+		models: raw.models ?? {},
+		modelErrors: raw.modelErrors ?? {},
+		oauthProviders: raw.oauthProviders ?? [],
+		acpxAgents: raw.acpxAgents ?? [],
+	};
 }
 
 // Bounded live OAuth login stream. The daemon runs the provider's interactive

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -3702,9 +3702,20 @@ export interface CatalogModel {
 	input: readonly string[];
 	reasoning: boolean;
 }
+export interface OAuthProviderMeta {
+	readonly id: string;
+	readonly name: string;
+	readonly usesCallbackServer: boolean;
+}
+export interface OAuthProviderStatus extends OAuthProviderMeta {
+	readonly connected: boolean;
+	readonly error?: string;
+}
 export interface InferenceCatalog {
 	providers: readonly string[];
 	models: Record<string, CatalogModel[]>;
+	modelErrors: Record<string, string>;
+	oauthProviders: readonly OAuthProviderStatus[];
 	acpxAgents: readonly string[];
 }
 export async function getInferenceCatalog(): Promise<InferenceCatalog> {
@@ -3712,3 +3723,192 @@ export async function getInferenceCatalog(): Promise<InferenceCatalog> {
 	if (!response.ok) throw new Error("Failed to fetch inference catalog");
 	return response.json();
 }
+
+// Bounded live OAuth login stream. The daemon runs the provider's interactive
+// flow and emits events (auth url, device code, prompts, select, connected,
+// error, done). Mirrors the SSE shape from inference-oauth.ts. POST-based
+// because the login route mutates daemon state; browsers cannot attach the
+// dashboard auth header to a native EventSource.
+export type OAuthLoginEvent =
+	| { readonly type: "session"; readonly sessionId: string; readonly providerId: string }
+	| { readonly type: "auth"; readonly url: string; readonly instructions?: string }
+	| {
+			readonly type: "device_code";
+			readonly userCode: string;
+			readonly verificationUri: string;
+			readonly intervalSeconds?: number;
+			readonly expiresInSeconds?: number;
+	  }
+	| ({ readonly type: "prompt"; readonly responseId: string } & {
+			readonly message: string;
+			readonly placeholder?: string;
+			readonly allowEmpty?: boolean;
+	  })
+	| ({ readonly type: "select"; readonly responseId: string } & {
+			readonly message: string;
+			options: ReadonlyArray<{ readonly id: string; readonly label: string }>;
+	  })
+	| { readonly type: "manual_code"; readonly responseId: string; readonly message: string }
+	| { readonly type: "progress"; readonly message: string }
+	| { readonly type: "connected"; readonly providerId: string }
+	| { readonly type: "error"; readonly error: string }
+	| { readonly type: "done" };
+
+export interface OAuthLoginHandle {
+	readonly sessionId: string | null;
+	onEvent(handler: (event: OAuthLoginEvent) => void): void;
+	onError(handler: (message: string) => void): void;
+	close(): void;
+}
+
+export async function startOAuthLogin(
+	providerId: string,
+	onConnected?: () => void,
+): Promise<OAuthLoginHandle> {
+	const handlers: Array<(event: OAuthLoginEvent) => void> = [];
+	const errorHandlers: Array<(message: string) => void> = [];
+	const controller = new AbortController();
+	let closed = false;
+	let capturedSessionId: string | null = null;
+	let sawDone = false;
+
+	const pump = authFetch(`${API_BASE}/api/inference/oauth/login/${encodeURIComponent(providerId)}`, {
+		method: "POST",
+		headers: { Accept: "text/event-stream" },
+		signal: controller.signal,
+	})
+		.then(async (response) => {
+			if (!response.ok || !response.body) {
+				let message = `OAuth login failed (HTTP ${response.status})`;
+				try {
+					const body = await response.json();
+					if (body?.error) message = body.error;
+				} catch {
+					/* keep status message */
+				}
+				throw new Error(message);
+			}
+			if (response.headers.get("X-Signet-OAuth-Session-Id")) {
+				capturedSessionId = response.headers.get("X-Signet-OAuth-Session-Id");
+			}
+			const reader = response.body.getReader();
+			const decoder = new TextDecoder();
+			let buffer = "";
+			while (!closed) {
+				const { value, done } = await reader.read();
+				if (done) break;
+				buffer += decoder.decode(value, { stream: true });
+				buffer = buffer.replace(/\r\n/g, "\n");
+				let boundary = buffer.indexOf("\n\n");
+				while (boundary !== -1) {
+					const rawEvent = buffer.slice(0, boundary);
+					buffer = buffer.slice(boundary + 2);
+					const data = rawEvent
+						.split(/\r?\n/)
+						.filter((line) => line.startsWith("data:"))
+						.map((line) => line.slice(5).trimStart())
+						.join("\n");
+					if (data) {
+						try {
+							const event = JSON.parse(data) as OAuthLoginEvent;
+							if (event.type === "session") capturedSessionId = event.sessionId;
+							if (event.type === "connected") onConnected?.();
+							if (event.type === "done") sawDone = true;
+							for (const handler of handlers) handler(event);
+						} catch {
+							/* skip malformed frame */
+						}
+					}
+					boundary = buffer.indexOf("\n\n");
+				}
+			}
+			if (!closed && !sawDone) {
+				for (const handler of errorHandlers) handler("OAuth login stream ended unexpectedly");
+			}
+		})
+		.catch((error) => {
+			if (closed || controller.signal.aborted) return;
+			const message = error instanceof Error ? error.message : "OAuth login failed";
+			for (const handler of errorHandlers) handler(message);
+		});
+
+	void pump;
+	return {
+		get sessionId() {
+			return capturedSessionId;
+		},
+		onEvent(handler) {
+			handlers.push(handler);
+		},
+		onError(handler) {
+			errorHandlers.push(handler);
+		},
+		close() {
+			if (closed) return;
+			closed = true;
+			controller.abort();
+		},
+	};
+}
+
+export async function completeOAuthInteraction(
+	sessionId: string,
+	responseId: string,
+	value: string,
+): Promise<boolean> {
+	const response = await authFetch(`${API_BASE}/api/inference/oauth/complete`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ sessionId, responseId, value }),
+	});
+	return response.ok;
+}
+
+export async function disconnectOAuthProvider(providerId: string): Promise<boolean> {
+	const response = await authFetch(`${API_BASE}/api/inference/oauth/disconnect/${encodeURIComponent(providerId)}`, {
+		method: "POST",
+	});
+	return response.ok;
+}
+
+// Inference router runtime status. refresh=1 forces a fresh availability probe
+// per target (used by the "verify connection" button after saving a key).
+export interface InferenceRuntimeTarget {
+	readonly available: boolean;
+	readonly health: "healthy" | "blocked" | "degraded" | "unknown" | string;
+	readonly circuitOpen: boolean;
+	readonly accountState: "ready" | "missing" | "expired" | "unknown" | string;
+	readonly unavailableReason?: string;
+}
+export interface InferenceStatus {
+	readonly enabled: boolean;
+	readonly source?: string;
+	readonly defaultPolicy?: string;
+	readonly defaultAgentId?: string;
+	readonly policies?: readonly string[];
+	readonly targetRefs?: readonly string[];
+	readonly runtimeSnapshot?: { readonly targets: Record<string, InferenceRuntimeTarget> };
+	readonly concurrency?: unknown;
+	readonly error?: string;
+}
+export async function getInferenceStatus(refresh = false): Promise<InferenceStatus | null> {
+	try {
+		const query = refresh ? "?refresh=1" : "";
+		const response = await authFetch(`${API_BASE}/api/inference/status${query}`);
+		if (!response.ok) return null;
+		return response.json();
+	} catch {
+		return null;
+	}
+}
+
+// Per-provider API-key format hints + validation. Re-exported from the
+// dependency-free inference-keys module so the logic is unit-testable outside
+// the SvelteKit runtime (this file pulls in $app/environment via auth.ts).
+export {
+	apiKeyFormat,
+	providerKeySecretName,
+	validateApiKey,
+	type ApiKeyFormat,
+	type KeyValidationState,
+} from "./inference-keys";

--- a/surfaces/dashboard/src/lib/components/tabs/settings/ConnectProviderDialog.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/ConnectProviderDialog.svelte
@@ -1,0 +1,773 @@
+<script lang="ts">
+import type { OAuthProviderStatus } from "$lib/api";
+import { apiKeyFormat, deleteSecret, getInferenceStatus, providerKeySecretName } from "$lib/api";
+import { CheckCircle, ExternalLink, Eye, EyeOff, KeyRound, Loader, RefreshCw, TriangleAlertIcon, Unlink, X } from "$lib/icons";
+import { st } from "$lib/stores/settings.svelte";
+import { onDestroy, onMount } from "svelte";
+import { ConnectProviderController } from "./connect-provider.svelte";
+
+interface Props {
+	provider: OAuthProviderStatus | { readonly id: string; readonly name: string; readonly connected: boolean };
+	supportsOAuth: boolean;
+	supportsApiKey: boolean;
+	onclose: () => void;
+	onsaved: () => void;
+}
+
+let {
+	provider,
+	supportsOAuth,
+	supportsApiKey,
+	onclose,
+	onsaved,
+}: Props = $props();
+
+// Controller owns all flow state. The component is a thin render over phase.
+let controller = $state(
+	new ConnectProviderController({
+		provider,
+		supportsOAuth,
+		supportsApiKey,
+		onSaved: onsaved,
+		linkOAuthAccount: linkOAuthAccountForProvider,
+	}),
+);
+
+let verifying = $state(false);
+let verifyResult = $state<{ ok: boolean; message: string } | null>(null);
+let otp = $state("");
+let promptInput = $state("");
+let closeTimer: ReturnType<typeof setTimeout> | null = null;
+let hasSavedKey = $state(false);
+
+const format = apiKeyFormat(provider.id);
+const phase = $derived(controller.phase);
+
+onMount(() => {
+	// Auto-start when there's exactly one path (no method screen needed).
+	const path = controller.singlePath;
+	if (path === "oauth") controller.startOAuth();
+	else if (path === "key") controller.enterKeyMode();
+});
+
+onDestroy(() => {
+	controller.dispose();
+	if (closeTimer) clearTimeout(closeTimer);
+});
+
+function handleKeydown(e: KeyboardEvent): void {
+	if (e.key === "Escape") handleClose();
+}
+
+function handleClose(): void {
+	controller.dispose();
+	if (closeTimer) clearTimeout(closeTimer);
+	onclose();
+}
+
+// After a successful connect, linger on the success state briefly, then close.
+function scheduleClose(): void {
+	if (closeTimer) clearTimeout(closeTimer);
+	closeTimer = setTimeout(handleClose, 1400);
+}
+
+// React to phase reaching "connected" — linger then close.
+$effect(() => {
+	if (phase.kind === "connected") scheduleClose();
+});
+
+function linkAccountForApiKey(): void {
+	// Wire inference.accounts.<provider> as a key-bearing API account so the
+	// router resolves credentialRef → stored secret. Matches the shape
+	// parseAccountConfig requires (kind + providerFamily) and the router's
+	// resolveCredential precedence (env, then secret).
+	const base = ["inference", "accounts", provider.id];
+	st.aSetStr([...base, "kind"], "api");
+	st.aSetStr([...base, "providerFamily"], provider.id);
+	st.aSetStr([...base, "credentialRef"], `SIGNET_KEY_${provider.id.replace(/[^A-Z0-9_]/gi, "_").toUpperCase()}`);
+}
+
+function linkOAuthAccountForProvider(): void {
+	// OAuth providers connect as a subscription_session account. The router's
+	// isOAuthBackedAccount() recognizes kind: subscription_session (or a missing
+	// credentialRef) and resolves the OAuth credential daemon-side. No
+	// credentialRef — creds live in the SIGNET_OAUTH_* secret the login wrote.
+	const base = ["inference", "accounts", provider.id];
+	st.aSetStr([...base, "kind"], "subscription_session");
+	st.aSetStr([...base, "providerFamily"], provider.id);
+	st.aDel([...base, "credentialRef"]);
+}
+
+async function handleSaveKey(): Promise<void> {
+	await controller.saveKey(linkAccountForApiKey);
+	if (controller.phase.kind === "connected") hasSavedKey = true;
+}
+
+async function handleVerify(): Promise<void> {
+	// There is no dedicated "test this key" route; the router probes *targets*
+	// (keyed `targetId/modelId`, not provider family). Only verify once a key is
+	// actually saved — otherwise we'd falsely claim success.
+	if (!hasSavedKey) {
+		verifyResult = { ok: false, message: "Save the key first, then verify." };
+		return;
+	}
+	verifying = true;
+	verifyResult = null;
+	const status = await getInferenceStatus(true);
+	verifying = false;
+	// Find targets whose config account resolves to this provider (the only
+	// honest cross-reference available client-side: config-side account family).
+	const family = provider.id;
+	const boundRefs: string[] = [];
+	for (const targetName of ["background", "aggregation"]) {
+		const acct = st.aStr(["inference", "targets", targetName, "account"]);
+		const acctFamily = acct ? st.aStr(["inference", "accounts", acct, "providerFamily"]) : "";
+		if (acctFamily === family) boundRefs.push(`${targetName}/default`);
+	}
+	const targets = status?.runtimeSnapshot?.targets ?? {};
+	let okSeen = false;
+	let failReason: string | null = null;
+	for (const ref of boundRefs) {
+		const state = targets[ref];
+		if (state?.available) okSeen = true;
+		else if (state && !failReason) failReason = state.unavailableReason ?? "not reachable yet";
+	}
+	if (okSeen) {
+		verifyResult = { ok: true, message: "Connection verified — provider is reachable." };
+	} else if (boundRefs.length === 0) {
+		verifyResult = {
+			ok: true,
+			message: "Key saved and encrypted. Assign this provider to a target below to use it.",
+		};
+	} else if (failReason) {
+		verifyResult = { ok: false, message: failReason };
+	} else {
+		// Bound to a target that isn't probeable yet (usually no model selected).
+		verifyResult = {
+			ok: false,
+			message: "Provider is assigned but not probeable yet — pick a model for the target.",
+		};
+	}
+}
+
+async function handleDisconnect(): Promise<void> {
+	await controller.disconnect();
+	// Also drop the stored API key (OAuth disconnect only clears creds daemon-side;
+	// the API-key secret would otherwise orphan in the vault).
+	await deleteSecret(providerKeySecretName(provider.id));
+	const base = ["inference", "accounts", provider.id];
+	st.aDel([...base, "kind"]);
+	st.aDel([...base, "providerFamily"]);
+	st.aDel([...base, "credentialRef"]);
+	st.aDel(base);
+	handleClose();
+}
+
+function submitPrompt(): void {
+	const value = promptInput.trim();
+	if (!value) return;
+	void controller.answerPrompt(value);
+	promptInput = "";
+}
+
+// Select an offered OAuth option (device flow choice etc.)
+function selectOption(id: string): void {
+	void controller.answerPrompt(id);
+}
+
+// Safely extract a hostname for the device-code link label; never throws in render.
+function hostnameOf(uri: string): string {
+	try {
+		return new URL(uri).hostname || uri;
+	} catch {
+		return uri;
+	}
+}
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<div
+	class="dialog-backdrop"
+	role="presentation"
+	onclick={(e) => {
+		if (e.target === e.currentTarget) handleClose();
+	}}
+>
+	<div class="dialog-panel" role="dialog" aria-modal="true" aria-label="Connect {provider.name}">
+		<header class="dialog-header">
+			<div class="title-wrap">
+				{#if phase.kind === "key-entry" || phase.kind === "saving"}
+					<KeyRound class="size-4" />
+				{:else}
+					<div class="provider-dot" aria-hidden="true"></div>
+				{/if}
+				<h2 class="dialog-title">{provider.name}</h2>
+			</div>
+			<button class="dialog-close" onclick={handleClose} aria-label="Close">
+				<X class="size-4" />
+			</button>
+		</header>
+
+		<div class="dialog-body">
+			{#if phase.kind === "method"}
+				<p class="lede">Choose how to connect {provider.name}.</p>
+				<div class="method-list">
+					{#if supportsOAuth}
+						<button class="method-card" onclick={() => controller.startOAuth()}>
+							<div class="method-icon"><RefreshCw class="size-4" /></div>
+							<div class="method-text">
+								<span class="method-label">Sign in</span>
+								<span class="method-hint">Open a secure login in your browser</span>
+							</div>
+						</button>
+					{/if}
+					{#if supportsApiKey}
+						<button class="method-card" onclick={() => controller.enterKeyMode()}>
+							<div class="method-icon"><KeyRound class="size-4" /></div>
+							<div class="method-text">
+								<span class="method-label">Use an API key</span>
+								<span class="method-hint">Paste a key from your provider dashboard</span>
+							</div>
+						</button>
+					{/if}
+				</div>
+			{:else if phase.kind === "oauth-running"}
+				{#if phase.prompt}
+					<div class="prompt-block">
+						<p class="prompt-message">{phase.prompt.message}</p>
+						{#if phase.prompt.kind === "select" && phase.prompt.options}
+							<div class="option-list">
+								{#each phase.prompt.options as opt (opt.id)}
+									<button class="option-card" onclick={() => selectOption(opt.id)}>
+										<span>{opt.label}</span>
+									</button>
+								{/each}
+							</div>
+						{:else}
+							<form
+								onsubmit={(e) => {
+									e.preventDefault();
+									submitPrompt();
+								}}
+							>
+								<div class="key-row">
+									<input
+										class="text-input"
+										type="text"
+										placeholder={phase.prompt.placeholder ?? ""}
+										bind:value={promptInput}
+										autocomplete="off"
+										spellcheck="false"
+									/>
+									<button class="btn btn--primary" type="submit" disabled={!promptInput.trim()}>
+										Continue
+									</button>
+								</div>
+							</form>
+						{/if}
+						<button class="link-btn" onclick={() => controller.cancelOAuth()}>Cancel</button>
+					</div>
+				{:else if phase.url}
+					<div class="auth-block">
+						<p class="lede">A login page should have opened in your browser.</p>
+						<a class="btn btn--primary auth-link" href={phase.url} target="_blank" rel="noopener noreferrer">
+							<ExternalLink class="size-3.5" /> Open login page
+						</a>
+						<div class="waiting">
+							<Loader class="size-3.5 spin" />
+							<span>Waiting for you to finish signing in…</span>
+						</div>
+						{#if phase.progress}<p class="progress-note">{phase.progress}</p>{/if}
+						<button class="link-btn" onclick={() => controller.cancelOAuth()}>Cancel</button>
+					</div>
+				{:else if phase.deviceCode}
+					<div class="device-block">
+						<p class="lede">Enter this code, then approve the login:</p>
+						<div class="device-code" role="textbox" aria-label="Device code" tabindex="-1">{phase.deviceCode.userCode}</div>
+						<a class="btn btn--secondary auth-link" href={phase.deviceCode.verificationUri} target="_blank" rel="noopener noreferrer">
+							<ExternalLink class="size-3.5" /> Open {hostnameOf(phase.deviceCode.verificationUri)}
+						</a>
+						<div class="waiting">
+							<Loader class="size-3.5 spin" />
+							<span>Waiting for approval…</span>
+						</div>
+						<button class="link-btn" onclick={() => controller.cancelOAuth()}>Cancel</button>
+					</div>
+				{:else}
+					<div class="waiting-block">
+						<Loader class="size-4 spin" />
+						<p>Starting secure login…</p>
+					</div>
+				{/if}
+			{:else if phase.kind === "key-entry"}
+				<form
+					onsubmit={(e) => {
+						e.preventDefault();
+						if (phase.validation !== "empty") handleSaveKey();
+					}}
+				>
+					<p class="lede">Paste your {provider.name} API key. It's stored encrypted and never shown again.</p>
+					{#if format}
+						<p class="format-hint">Keys for this provider usually {format.hint}.</p>
+					{/if}
+					<div class="key-row">
+						<input
+							class="text-input"
+							type={phase.reveal ? "text" : "password"}
+							placeholder="Paste API key"
+							value={phase.key}
+							oninput={(e) => controller.setKey(e.currentTarget.value)}
+							autocomplete="off"
+							spellcheck="false"
+						/>
+						<button
+							class="reveal-btn"
+							type="button"
+							onclick={() => controller.toggleReveal()}
+							aria-label={phase.reveal ? "Hide key" : "Show key"}
+						>
+							{#if phase.reveal}<EyeOff class="size-3.5" />{:else}<Eye class="size-3.5" />{/if}
+						</button>
+					</div>
+					{#if phase.validation === "valid"}
+						<p class="key-status key-status--ok"><CheckCircle class="size-3.5" /> Looks like a valid {provider.name} key.</p>
+					{:else if phase.validation === "unsure" && phase.key.trim()}
+						<p class="key-status key-status--unsure"><TriangleAlertIcon class="size-3.5" /> That doesn't match the usual format. Double-check it — it may still work.</p>
+					{/if}
+					{#if verifyResult}
+						<p class="key-status {verifyResult.ok ? "key-status--ok" : "key-status--unsure"}">
+							{#if verifyResult.ok}<CheckCircle class="size-3.5" />{:else}<TriangleAlertIcon class="size-3.5" />{/if}
+							{verifyResult.message}
+						</p>
+					{/if}
+					<div class="key-actions">
+						<button class="btn btn--primary" type="submit" disabled={phase.validation === "empty"}>
+							Connect
+						</button>
+						<button class="btn btn--ghost" type="button" onclick={handleVerify} disabled={verifying || phase.validation === "empty"}>
+							{#if verifying}<Loader class="size-3.5 spin" />{:else}<RefreshCw class="size-3.5" />{/if}
+							Verify
+						</button>
+					</div>
+				</form>
+			{:else if phase.kind === "saving"}
+				<div class="waiting-block">
+					<Loader class="size-4 spin" />
+					<p>Saving key…</p>
+				</div>
+			{:else if phase.kind === "connected"}
+				<div class="success-block">
+					<CheckCircle class="size-6" />
+					<p>{provider.name} is connected.</p>
+				</div>
+			{:else if phase.kind === "error"}
+				<div class="error-block">
+					<TriangleAlertIcon class="size-5" />
+					<p class="error-message">{phase.message}</p>
+					<div class="error-actions">
+						<button class="btn btn--primary" onclick={() => controller.reset()}>Try again</button>
+						{#if provider.connected}
+							<button class="btn btn--ghost" onclick={handleDisconnect}>
+								<Unlink class="size-3.5" /> Disconnect
+							</button>
+						{/if}
+					</div>
+				</div>
+			{/if}
+
+			{#if provider.connected && phase.kind === "method"}
+				<div class="manage-block">
+					<p class="manage-note">{provider.name} is currently connected.</p>
+					<button class="btn btn--ghost danger" onclick={handleDisconnect}>
+						<Unlink class="size-3.5" /> Disconnect
+					</button>
+				</div>
+			{/if}
+		</div>
+	</div>
+</div>
+
+<style>
+	.dialog-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 100;
+		background: rgba(0, 0, 0, 0.6);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 16px;
+	}
+
+	.dialog-panel {
+		background: var(--sig-surface);
+		border: 1px solid var(--sig-border-strong);
+		border-radius: 12px;
+		width: 100%;
+		max-width: 460px;
+		max-height: 85vh;
+		overflow: hidden;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.dialog-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 14px 18px 12px;
+		border-bottom: 1px solid var(--sig-border);
+	}
+
+	.title-wrap {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.provider-dot {
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		background: var(--sig-accent);
+	}
+
+	.dialog-title {
+		font-family: var(--font-mono);
+		font-size: 14px;
+		font-weight: 600;
+		color: var(--sig-text);
+		margin: 0;
+	}
+
+	.dialog-close {
+		background: none;
+		border: none;
+		color: var(--sig-text-muted);
+		cursor: pointer;
+		padding: 4px;
+		border-radius: 6px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+	.dialog-close:hover {
+		color: var(--sig-text);
+		background: var(--sig-surface-raised);
+	}
+
+	.dialog-body {
+		padding: 18px;
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+		overflow-y: auto;
+	}
+
+	.lede {
+		font-family: var(--font-body);
+		font-size: 12px;
+		line-height: 1.55;
+		color: var(--sig-text-muted);
+		margin: 0;
+	}
+
+	.method-list {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+	.method-card {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		padding: 12px;
+		border: 1px solid var(--sig-border);
+		border-radius: 9px;
+		background: var(--sig-bg);
+		cursor: pointer;
+		text-align: left;
+		transition: border-color 0.12s, background 0.12s;
+	}
+	.method-card:hover {
+		border-color: var(--sig-accent);
+		background: var(--sig-surface-raised);
+	}
+	.method-icon {
+		color: var(--sig-accent);
+		display: flex;
+	}
+	.method-text {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+	.method-label {
+		font-family: var(--font-body);
+		font-size: 12.5px;
+		font-weight: 600;
+		color: var(--sig-text);
+	}
+	.method-hint {
+		font-family: var(--font-body);
+		font-size: 11px;
+		color: var(--sig-text-muted);
+	}
+
+	.key-row {
+		display: flex;
+		gap: 6px;
+		align-items: stretch;
+	}
+	.text-input {
+		flex: 1;
+		font-family: var(--font-mono);
+		font-size: 12px;
+		padding: 8px 10px;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: 8px;
+		background: var(--sig-bg);
+		color: var(--sig-text);
+		outline: none;
+		min-width: 0;
+	}
+	.text-input:focus {
+		border-color: var(--sig-accent);
+	}
+	.reveal-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0 10px;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: 8px;
+		background: var(--sig-bg);
+		color: var(--sig-text-muted);
+		cursor: pointer;
+	}
+	.reveal-btn:hover {
+		color: var(--sig-text);
+	}
+
+	.format-hint {
+		font-family: var(--font-body);
+		font-size: 10.5px;
+		color: var(--sig-text-muted);
+		margin: -8px 0 0 0;
+		opacity: 0.8;
+	}
+
+	.key-status {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		font-family: var(--font-body);
+		font-size: 11px;
+		margin: 0;
+	}
+	.key-status--ok {
+		color: #4ade80;
+	}
+	.key-status--unsure {
+		color: #fbbf24;
+	}
+
+	.key-actions {
+		display: flex;
+		gap: 8px;
+	}
+
+	.btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 6px;
+		font-family: var(--font-body);
+		font-size: 11.5px;
+		font-weight: 500;
+		padding: 7px 14px;
+		border-radius: 8px;
+		cursor: pointer;
+		border: 1px solid transparent;
+		transition: background 0.12s, border-color 0.12s, opacity 0.12s;
+	}
+	.btn:disabled {
+		opacity: 0.45;
+		cursor: not-allowed;
+	}
+	.btn--primary {
+		background: var(--sig-accent);
+		color: var(--sig-bg);
+	}
+	.btn--primary:not(:disabled):hover {
+		opacity: 0.9;
+	}
+	.btn--secondary {
+		background: var(--sig-surface-raised);
+		color: var(--sig-text);
+		border-color: var(--sig-border-strong);
+	}
+	.btn--ghost {
+		background: transparent;
+		color: var(--sig-text-muted);
+		border-color: var(--sig-border);
+	}
+	.btn--ghost:not(:disabled):hover {
+		color: var(--sig-text);
+		background: var(--sig-surface-raised);
+	}
+	.btn.danger {
+		color: #f87171;
+		border-color: rgba(248, 113, 113, 0.3);
+	}
+	.btn.danger:hover {
+		background: rgba(248, 113, 113, 0.1);
+	}
+
+	.auth-link,
+	.auth-link:visited {
+		text-decoration: none;
+		align-self: flex-start;
+	}
+
+	.waiting {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		font-family: var(--font-body);
+		font-size: 11px;
+		color: var(--sig-text-muted);
+	}
+
+	.waiting-block,
+	.success-block,
+	.error-block {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 10px;
+		padding: 16px 0;
+		text-align: center;
+	}
+	.waiting-block p,
+	.success-block p {
+		font-family: var(--font-body);
+		font-size: 12px;
+		color: var(--sig-text-muted);
+		margin: 0;
+	}
+	.success-block {
+		color: #4ade80;
+	}
+
+	.device-block,
+	.auth-block,
+	.prompt-block {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+	.device-code {
+		font-family: var(--font-mono);
+		font-size: 22px;
+		font-weight: 700;
+		letter-spacing: 0.18em;
+		text-align: center;
+		padding: 14px;
+		border: 1px dashed var(--sig-border-strong);
+		border-radius: 9px;
+		background: var(--sig-bg);
+		color: var(--sig-text);
+		user-select: all;
+	}
+
+	.prompt-message {
+		font-family: var(--font-body);
+		font-size: 12px;
+		color: var(--sig-text);
+		margin: 0;
+	}
+	.option-list {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+	.option-card {
+		text-align: left;
+		padding: 10px 12px;
+		border: 1px solid var(--sig-border);
+		border-radius: 8px;
+		background: var(--sig-bg);
+		color: var(--sig-text);
+		font-family: var(--font-body);
+		font-size: 12px;
+		cursor: pointer;
+	}
+	.option-card:hover {
+		border-color: var(--sig-accent);
+		background: var(--sig-surface-raised);
+	}
+
+	.link-btn {
+		align-self: flex-start;
+		background: none;
+		border: none;
+		color: var(--sig-text-muted);
+		font-family: var(--font-body);
+		font-size: 11px;
+		cursor: pointer;
+		padding: 0;
+		text-decoration: underline;
+	}
+	.link-btn:hover {
+		color: var(--sig-text);
+	}
+
+	.progress-note {
+		font-family: var(--font-body);
+		font-size: 11px;
+		color: var(--sig-text-muted);
+		margin: 0;
+		opacity: 0.7;
+	}
+
+	.error-block {
+		color: #f87171;
+	}
+	.error-message {
+		font-family: var(--font-body);
+		font-size: 12px;
+		color: var(--sig-text);
+		margin: 0;
+		word-break: break-word;
+	}
+	.error-actions {
+		display: flex;
+		gap: 8px;
+	}
+
+	.manage-block {
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+		padding-top: 12px;
+		border-top: 1px solid var(--sig-border);
+		align-items: flex-start;
+	}
+	.manage-note {
+		font-family: var(--font-body);
+		font-size: 11px;
+		color: var(--sig-text-muted);
+		margin: 0;
+	}
+
+	:global(.spin) {
+		animation: spin 0.9s linear infinite;
+	}
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+</style>

--- a/surfaces/dashboard/src/lib/components/tabs/settings/ConnectProviderDialog.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/ConnectProviderDialog.svelte
@@ -11,7 +11,7 @@ interface Props {
 	supportsOAuth: boolean;
 	supportsApiKey: boolean;
 	onclose: () => void;
-	onsaved: () => void;
+	onsaved: () => void | Promise<void>;
 }
 
 let {
@@ -37,8 +37,6 @@ let verifying = $state(false);
 let verifyResult = $state<{ ok: boolean; message: string } | null>(null);
 let otp = $state("");
 let promptInput = $state("");
-let closeTimer: ReturnType<typeof setTimeout> | null = null;
-let hasSavedKey = $state(false);
 
 const format = apiKeyFormat(provider.id);
 const phase = $derived(controller.phase);
@@ -52,39 +50,30 @@ onMount(() => {
 
 onDestroy(() => {
 	controller.dispose();
-	if (closeTimer) clearTimeout(closeTimer);
 });
 
+// The connected phase lingers (no auto-close) so the user can verify the
+// connection and dismiss deliberately.
 function handleKeydown(e: KeyboardEvent): void {
 	if (e.key === "Escape") handleClose();
 }
 
 function handleClose(): void {
 	controller.dispose();
-	if (closeTimer) clearTimeout(closeTimer);
 	onclose();
 }
-
-// After a successful connect, linger on the success state briefly, then close.
-function scheduleClose(): void {
-	if (closeTimer) clearTimeout(closeTimer);
-	closeTimer = setTimeout(handleClose, 1400);
-}
-
-// React to phase reaching "connected" — linger then close.
-$effect(() => {
-	if (phase.kind === "connected") scheduleClose();
-});
 
 function linkAccountForApiKey(): void {
 	// Wire inference.accounts.<provider> as a key-bearing API account so the
 	// router resolves credentialRef → stored secret. Matches the shape
 	// parseAccountConfig requires (kind + providerFamily) and the router's
-	// resolveCredential precedence (env, then secret).
+	// resolveCredential precedence (env, then secret). The secret name MUST
+	// match what saveKey stored (providerKeySecretName) — reuse the helper so
+	// the two can never drift.
 	const base = ["inference", "accounts", provider.id];
 	st.aSetStr([...base, "kind"], "api");
 	st.aSetStr([...base, "providerFamily"], provider.id);
-	st.aSetStr([...base, "credentialRef"], `SIGNET_KEY_${provider.id.replace(/[^A-Z0-9_]/gi, "_").toUpperCase()}`);
+	st.aSetStr([...base, "credentialRef"], providerKeySecretName(provider.id));
 }
 
 function linkOAuthAccountForProvider(): void {
@@ -100,17 +89,9 @@ function linkOAuthAccountForProvider(): void {
 
 async function handleSaveKey(): Promise<void> {
 	await controller.saveKey(linkAccountForApiKey);
-	if (controller.phase.kind === "connected") hasSavedKey = true;
 }
 
 async function handleVerify(): Promise<void> {
-	// There is no dedicated "test this key" route; the router probes *targets*
-	// (keyed `targetId/modelId`, not provider family). Only verify once a key is
-	// actually saved — otherwise we'd falsely claim success.
-	if (!hasSavedKey) {
-		verifyResult = { ok: false, message: "Save the key first, then verify." };
-		return;
-	}
 	verifying = true;
 	verifyResult = null;
 	const status = await getInferenceStatus(true);
@@ -151,21 +132,25 @@ async function handleVerify(): Promise<void> {
 }
 
 async function handleDisconnect(): Promise<void> {
-	await controller.disconnect();
-	// Also drop the stored API key (OAuth disconnect only clears creds daemon-side;
-	// the API-key secret would otherwise orphan in the vault).
+	// daemon-side: clear OAuth creds + delete the stored API key (persist now).
 	await deleteSecret(providerKeySecretName(provider.id));
+	await controller.disconnect();
+	// config-side: remove the account entry, THEN persist + refresh. The aDel
+	// must be saved (not just in-memory) or agent.yaml keeps a credentialRef
+	// pointing at the now-deleted secret — a broken "Connected" card on reload.
 	const base = ["inference", "accounts", provider.id];
 	st.aDel([...base, "kind"]);
 	st.aDel([...base, "providerFamily"]);
 	st.aDel([...base, "credentialRef"]);
 	st.aDel(base);
+	await onsaved();
 	handleClose();
 }
 
 function submitPrompt(): void {
+	const allowEmpty = phase.kind === "oauth-running" && phase.prompt?.allowEmpty === true;
 	const value = promptInput.trim();
-	if (!value) return;
+	if (!value && !allowEmpty) return;
 	void controller.answerPrompt(value);
 	promptInput = "";
 }
@@ -182,6 +167,14 @@ function hostnameOf(uri: string): string {
 	} catch {
 		return uri;
 	}
+}
+
+// Allowlist http(s) for any daemon-sourced URL we bind to href. Svelte escapes
+// attribute text but does not block javascript:/data: schemes; a poisoned OAuth
+// stream could otherwise inject a click-to-execute link. Defense-in-depth.
+function safeHref(uri: string | undefined): string | null {
+	if (!uri) return null;
+	return /^https?:\/\//i.test(uri) ? uri : null;
 }
 </script>
 
@@ -260,7 +253,7 @@ function hostnameOf(uri: string): string {
 										autocomplete="off"
 										spellcheck="false"
 									/>
-									<button class="btn btn--primary" type="submit" disabled={!promptInput.trim()}>
+									<button class="btn btn--primary" type="submit" disabled={!promptInput.trim() && !(phase.prompt?.allowEmpty === true)}>
 										Continue
 									</button>
 								</div>
@@ -271,9 +264,13 @@ function hostnameOf(uri: string): string {
 				{:else if phase.url}
 					<div class="auth-block">
 						<p class="lede">A login page should have opened in your browser.</p>
-						<a class="btn btn--primary auth-link" href={phase.url} target="_blank" rel="noopener noreferrer">
-							<ExternalLink class="size-3.5" /> Open login page
-						</a>
+						{#if safeHref(phase.url)}
+							<a class="btn btn--primary auth-link" href={safeHref(phase.url)} target="_blank" rel="noopener noreferrer">
+								<ExternalLink class="size-3.5" /> Open login page
+							</a>
+						{:else}
+							<p class="format-hint">Login URL: {phase.url}</p>
+						{/if}
 						<div class="waiting">
 							<Loader class="size-3.5 spin" />
 							<span>Waiting for you to finish signing in…</span>
@@ -285,9 +282,13 @@ function hostnameOf(uri: string): string {
 					<div class="device-block">
 						<p class="lede">Enter this code, then approve the login:</p>
 						<div class="device-code" role="textbox" aria-label="Device code" tabindex="-1">{phase.deviceCode.userCode}</div>
-						<a class="btn btn--secondary auth-link" href={phase.deviceCode.verificationUri} target="_blank" rel="noopener noreferrer">
-							<ExternalLink class="size-3.5" /> Open {hostnameOf(phase.deviceCode.verificationUri)}
-						</a>
+						{#if safeHref(phase.deviceCode.verificationUri)}
+							<a class="btn btn--secondary auth-link" href={safeHref(phase.deviceCode.verificationUri)} target="_blank" rel="noopener noreferrer">
+								<ExternalLink class="size-3.5" /> Open {hostnameOf(phase.deviceCode.verificationUri)}
+							</a>
+						{:else}
+							<p class="format-hint">Verification URL: {phase.deviceCode.verificationUri}</p>
+						{/if}
 						<div class="waiting">
 							<Loader class="size-3.5 spin" />
 							<span>Waiting for approval…</span>
@@ -360,6 +361,19 @@ function hostnameOf(uri: string): string {
 				<div class="success-block">
 					<CheckCircle class="size-6" />
 					<p>{provider.name} is connected.</p>
+					{#if verifyResult}
+						<p class="key-status {verifyResult.ok ? "key-status--ok" : "key-status--unsure"}">
+							{#if verifyResult.ok}<CheckCircle class="size-3.5" />{:else}<TriangleAlertIcon class="size-3.5" />{/if}
+							{verifyResult.message}
+						</p>
+					{/if}
+					<div class="key-actions">
+						<button class="btn btn--ghost" onclick={handleVerify} disabled={verifying}>
+							{#if verifying}<Loader class="size-3.5 spin" />{:else}<RefreshCw class="size-3.5" />{/if}
+							Verify
+						</button>
+						<button class="btn btn--primary" onclick={handleClose}>Done</button>
+					</div>
 				</div>
 			{:else if phase.kind === "error"}
 				<div class="error-block">

--- a/surfaces/dashboard/src/lib/components/tabs/settings/InferenceSection.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/InferenceSection.svelte
@@ -110,9 +110,12 @@ function closeConnect(): void {
 	connecting = null;
 }
 
-// After a connect/disconnect, re-read the catalog (OAuth connected state lives
-// daemon-side) and refresh settings so account writes are reflected.
+// After a connect/disconnect, persist any config writes (account entries are
+// in-memory until st.save()), then re-read the catalog + refresh. Order matters:
+// save() writes agent.yaml, then invalidateAll() re-reads it — so the account
+// wiring survives the refresh instead of being clobbered by st.init() from disk.
 async function onProviderChanged(): Promise<void> {
+	if (st.isDirty) await st.save();
 	catalog = await loadCatalog();
 	try {
 		await invalidateAll();

--- a/surfaces/dashboard/src/lib/components/tabs/settings/InferenceSection.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/InferenceSection.svelte
@@ -5,17 +5,15 @@ import FormSection from "$lib/components/config/FormSection.svelte";
 import SettingList from "$lib/components/config/SettingList.svelte";
 import SettingRow from "$lib/components/config/SettingRow.svelte";
 import { type InferenceCatalog, getInferenceCatalog } from "$lib/api";
+import { CheckCircle, KeyRound, Plus, TriangleAlertIcon } from "$lib/icons";
 import { st } from "$lib/stores/settings.svelte";
+import { invalidateAll } from "$app/navigation";
+import ConnectProviderDialog from "./ConnectProviderDialog.svelte";
 
-// Inference settings (#947). Rebuilt to match the OpenCode settings-v2 rhythm:
-// SettingList containers with SettingRows (title+description left, control
-// right). Three concerns, each its own list:
-//   1. Background executor — which backend runs Pipeline V2 extraction.
-//   2. Model — which model that executor uses.
-//   3. Embeddings — provider/model/endpoint for the vector store.
-//
-// Writes the routing registry (inference.*) so Pipeline V2 reads it directly,
-// plus the workload binding (inference.workloads.memoryExtraction.target).
+// Inference settings (#947/#966/#968). A provider connect wall sits above the
+// target pickers: connect Claude Max / ChatGPT / Copilot via OAuth, or any API
+// provider via a pasted key (stored encrypted, never surfaced as a "secret
+// name"). Background + aggregation targets then draw from connected providers.
 
 const selectTriggerClass =
 	"font-mono text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-lg w-full h-auto min-h-[30px] px-2 py-[5px] box-border focus-visible:border-[var(--sig-accent)]";
@@ -25,15 +23,107 @@ const selectItemClass = "font-mono text-[11px] rounded-lg";
 const inputClass =
 	"font-mono text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-lg w-full h-auto min-h-[30px] px-2 py-[5px] box-border focus-visible:border-[var(--sig-accent)]";
 
-// pi-ai catalog
+// pi-ai catalog (providers + OAuth providers + models)
 let catalog = $state<InferenceCatalog | null>(null);
+let catalogFailed = $state(false);
+// Defensive: a daemon predating #968 omits oauthProviders/modelErrors. Default
+// them so an older runtime doesn't break the panel — it just shows fewer cards.
+async function loadCatalog(): Promise<InferenceCatalog | null> {
+	try {
+		const c = await getInferenceCatalog();
+		catalogFailed = false;
+		return {
+			providers: c.providers ?? [],
+			models: c.models ?? {},
+			modelErrors: c.modelErrors ?? {},
+			oauthProviders: c.oauthProviders ?? [],
+			acpxAgents: c.acpxAgents ?? [],
+		};
+	} catch {
+		catalogFailed = true;
+		return null;
+	}
+}
 $effect(() => {
-	void getInferenceCatalog().then(
-		(c) => (catalog = c),
-		() => (catalog = null),
-	);
+	void loadCatalog().then((c) => (catalog = c));
 });
 
+// ---------------------------------------------------------------------------
+// Provider connect wall
+// ---------------------------------------------------------------------------
+// OAuth-only subscription providers (no direct API key path). pi-ai reaches
+// these only through their OAuth login.
+const OAUTH_ONLY_PROVIDERS = new Set(["openai-codex", "github-copilot"]);
+
+// Curated featured set shown in the wall, in display order. Intersected with
+// the live catalog so a provider missing from the installed pi-ai build never
+// appears. Each entry maps the pi-ai provider family to a friendly name.
+const FEATURED: ReadonlyArray<{ id: string; name: string }> = [
+	{ id: "anthropic", name: "Anthropic (Claude)" },
+	{ id: "openai-codex", name: "ChatGPT / Codex" },
+	{ id: "github-copilot", name: "GitHub Copilot" },
+	{ id: "openrouter", name: "OpenRouter" },
+	{ id: "openai", name: "OpenAI" },
+	{ id: "google", name: "Google (Gemini)" },
+	{ id: "xai", name: "xAI (Grok)" },
+	{ id: "groq", name: "Groq" },
+	{ id: "mistral", name: "Mistral" },
+	{ id: "deepseek", name: "DeepSeek" },
+];
+
+interface ConnectableProvider {
+	id: string;
+	name: string;
+	supportsOAuth: boolean;
+	supportsApiKey: boolean;
+	connected: boolean;
+	isOAuth: boolean;
+}
+
+let connecting = $state<{ provider: ConnectableProvider } | null>(null);
+
+function connectableProviders(): ConnectableProvider[] {
+	if (!catalog) return [];
+	const oauthIds = new Set(catalog.oauthProviders.map((p) => p.id));
+	const catalogIds = new Set(catalog.providers);
+	const oauthStatus = new Map(catalog.oauthProviders.map((p) => [p.id, p] as const));
+	return FEATURED.filter((f) => oauthIds.has(f.id) || catalogIds.has(f.id)).map((f) => {
+		const supportsOAuth = oauthIds.has(f.id);
+		const isOAuthOnly = OAUTH_ONLY_PROVIDERS.has(f.id);
+		const supportsApiKey = catalogIds.has(f.id) && !isOAuthOnly;
+		const connected = supportsOAuth
+			? (oauthStatus.get(f.id)?.connected ?? false) || hasApiKeyAccount(f.id)
+			: hasApiKeyAccount(f.id);
+		return { id: f.id, name: f.name, supportsOAuth, supportsApiKey, connected, isOAuth: supportsOAuth };
+	});
+}
+
+function hasApiKeyAccount(providerFamily: string): boolean {
+	return !!st.aStr(["inference", "accounts", providerFamily, "credentialRef"]);
+}
+
+function openConnect(provider: ConnectableProvider): void {
+	connecting = { provider };
+}
+
+function closeConnect(): void {
+	connecting = null;
+}
+
+// After a connect/disconnect, re-read the catalog (OAuth connected state lives
+// daemon-side) and refresh settings so account writes are reflected.
+async function onProviderChanged(): Promise<void> {
+	catalog = await loadCatalog();
+	try {
+		await invalidateAll();
+	} catch {
+		/* navigation may not be ready in all contexts */
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Background / aggregation target helpers (unchanged logic)
+// ---------------------------------------------------------------------------
 const TARGET_NAME = "background";
 const ACCOUNT_NAME = "background";
 
@@ -49,8 +139,6 @@ const EXECUTOR_OPTIONS = [
 
 const ACPX_AGENTS = ["claude", "codex", "opencode", "gemini", "pi", "openclaw"];
 
-// Aggregation executor options EXCLUDE acpx — aggregate recall is latency-
-// sensitive and pi-ai-only (subprocess spawn latency would dominate).
 const AGGREGATION_EXECUTOR_OPTIONS = EXECUTOR_OPTIONS.filter((o) => o.value !== "acpx");
 
 function bgExecutor(): string {
@@ -66,12 +154,6 @@ function providerFamilyForExecutor(exec: string): string {
 	return "openai";
 }
 
-// Mirror the router's needsCredential (inference-router.ts): anthropic and
-// openrouter always need a credential; openai-compatible needs one only when
-// the endpoint is remote; ollama/llama-cpp/acpx never do. isLocalEndpoint is
-// inlined here (not imported from @signet/core) because the dashboard is a
-// browser bundle and cannot pull core's Node-only runtime (better-sqlite3).
-// Keep this in sync with platform/core/src/routing.ts isLocalInferenceEndpoint.
 function isLocalEndpoint(endpoint: string): boolean {
 	if (!endpoint) return true;
 	try {
@@ -86,17 +168,11 @@ function targetNeedsAccount(exec: string, endpoint: string): boolean {
 	return false;
 }
 
-// Ensure the account has the shape parseAccountConfig accepts: it returns null
-// (silently dropping the account) if `kind` or `providerFamily` is absent, which
-// would block every API target with "account ... not found".
 function ensureAccount(accountName: string, executor: string): void {
 	st.aSetStr(["inference", "accounts", accountName, "kind"], "api");
 	st.aSetStr(["inference", "accounts", accountName, "providerFamily"], providerFamilyForExecutor(executor));
 }
 
-// Write the complete, routing-valid target + account shape for an executor.
-// Local/acpx targets get NO account; API targets get a linked account with the
-// valid { kind, providerFamily, credentialRef } shape.
 function writeTarget(opts: {
 	targetName: string;
 	accountName: string;
@@ -108,9 +184,6 @@ function writeTarget(opts: {
 	const accountBase = ["inference", "accounts", accountName];
 	const workloadBase = ["inference", "workloads", workloadKey];
 	if (!executor) {
-		// Reset the whole target: clear every field so allTargetRefs (which
-		// enumerates via targets.*.models) does not surface an orphaned ref that
-		// would block with "account ... not found". aDel prunes empty parents.
 		st.aDel([...targetBase, "executor"]);
 		st.aDel([...targetBase, "account"]);
 		st.aDel([...targetBase, "models"]);
@@ -167,12 +240,6 @@ function bgModelOptions(): Array<{ value: string; label: string }> {
 	return (catalog.models[family] ?? []).map((m) => ({ value: m.id, label: `${m.name} (${m.id})` }));
 }
 
-// ---------------------------------------------------------------------------
-// Aggregation (separate latency-optimized path, pi-ai-only — no ACPX).
-// Aggregate recall is query-time evidence synthesis; it depends on inference
-// speed, not raw intelligence or cost, so it gets its own target bound to the
-// aggregate_recall workload. The router enforces no-ACPX at the routing layer.
-// ---------------------------------------------------------------------------
 const AGG_TARGET_NAME = "aggregation";
 const AGG_ACCOUNT_NAME = "aggregation";
 
@@ -213,7 +280,6 @@ const aggNeedsApiKey = $derived(
 	(aggExecutor() === "openai-compatible" && !isLocalEndpoint(aggEndpoint())),
 );
 
-// Embeddings (folded in)
 const EMBEDDING_PROVIDER_OPTIONS = [
 	{ value: "", label: "— select —" },
 	{ value: "native", label: "native (built-in nomic)" },
@@ -253,9 +319,61 @@ const needsApiKey = $derived(
 const embNonNative = $derived(embProvider() && embProvider() !== "native" && embProvider() !== "");
 </script>
 
-<FormSection description="Inference backends. Pick the backend + model that runs background memory work, and configure embeddings. Everything here saves with the Save bar.">
+<FormSection description="Connect AI providers, then choose which one runs background memory work. Connect once; keys live encrypted and never leave the daemon.">
+
 	<!-- ============================================================ -->
-	<!-- Background executor + model + endpoint + key                 -->
+	<!-- Provider connect wall                                         -->
+	<!-- ============================================================ -->
+	<SettingList title="Providers">
+		<div class="provider-grid">
+			{#each connectableProviders() as provider (provider.id)}
+				<button
+					class="provider-card {provider.connected ? "provider-card--connected" : ""}"
+					onclick={() => openConnect(provider)}
+				>
+					<div class="provider-card-head">
+						<span class="provider-name">{provider.name}</span>
+						{#if provider.connected}
+							<span class="status-badge status-badge--ok"><CheckCircle class="size-3" /> Connected</span>
+						{:else}
+							<span class="status-badge status-badge--off"><Plus class="size-3" /> Connect</span>
+						{/if}
+					</div>
+					<div class="provider-card-meta">
+						{#if provider.supportsOAuth && provider.supportsApiKey}
+							<span class="meta-pill">Sign in or API key</span>
+						{:else if provider.supportsOAuth}
+							<span class="meta-pill"><KeyRound class="size-2.5" /> Sign in</span>
+						{:else}
+							<span class="meta-pill"><KeyRound class="size-2.5" /> API key</span>
+						{/if}
+						{#if catalog?.models[provider.id]?.length}
+							<span class="meta-count">{catalog.models[provider.id].length} models</span>
+						{/if}
+					</div>
+				</button>
+			{:else}
+				{#if catalogFailed}
+					<div class="provider-empty">Couldn't load the provider catalog. Update the daemon and retry.</div>
+				{:else}
+					<div class="provider-empty">Loading providers…</div>
+				{/if}
+			{/each}
+		</div>
+		{#if catalog?.modelErrors && Object.keys(catalog.modelErrors).length > 0}
+			<div class="catalog-warnings">
+				{#each Object.entries(catalog.modelErrors) as [providerId, message] (providerId)}
+					<div class="catalog-warning">
+						<TriangleAlertIcon class="size-3" />
+						<span>{providerId}: {message}</span>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</SettingList>
+
+	<!-- ============================================================ -->
+	<!-- Background executor + model + endpoint + key                  -->
 	<!-- ============================================================ -->
 	<SettingList title="Background inference">
 		<SettingRow
@@ -332,7 +450,7 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 			{#if needsApiKey}
 				<SettingRow
 					title="API key (secret name)"
-					description="The Signet secret holding the key, e.g. ANTHROPIC_API_KEY. The key value is never shown."
+					description="The Signet secret holding the key, e.g. ANTHROPIC_API_KEY. Or connect via the Providers panel above to skip this. The key value is never shown."
 				>
 					<Input
 						class={inputClass}
@@ -464,8 +582,114 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 	</SettingList>
 </FormSection>
 
+{#if connecting}
+	<ConnectProviderDialog
+		provider={connecting.provider}
+		supportsOAuth={connecting.provider.supportsOAuth}
+		supportsApiKey={connecting.provider.supportsApiKey}
+		onclose={closeConnect}
+		onsaved={() => onProviderChanged()}
+	/>
+{/if}
+
 <style>
 	:global(.setting-list-wrap + .setting-list-wrap) {
 		margin-top: var(--space-lg);
+	}
+	.provider-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+		gap: 10px;
+		width: 100%;
+	}
+	.provider-card {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		padding: 11px 12px;
+		border: 1px solid var(--sig-border);
+		border-radius: 9px;
+		background: var(--sig-bg);
+		cursor: pointer;
+		text-align: left;
+		transition: border-color 0.12s, background 0.12s;
+	}
+	.provider-card:hover {
+		border-color: var(--sig-accent);
+		background: var(--sig-surface-raised);
+	}
+	.provider-card--connected {
+		border-color: rgba(74, 222, 128, 0.35);
+	}
+	.provider-card-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+	}
+	.provider-name {
+		font-family: var(--font-body);
+		font-size: 12px;
+		font-weight: 600;
+		color: var(--sig-text);
+	}
+	.status-badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 3px;
+		font-family: var(--font-body);
+		font-size: 9.5px;
+		font-weight: 500;
+		padding: 2px 6px;
+		border-radius: 999px;
+		white-space: nowrap;
+	}
+	.status-badge--ok {
+		color: #4ade80;
+		background: rgba(74, 222, 128, 0.12);
+	}
+	.status-badge--off {
+		color: var(--sig-text-muted);
+		background: var(--sig-surface-raised);
+	}
+	.provider-card-meta {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+	.meta-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 3px;
+		font-family: var(--font-body);
+		font-size: 9.5px;
+		color: var(--sig-text-muted);
+	}
+	.meta-count {
+		font-family: var(--font-mono);
+		font-size: 9.5px;
+		color: var(--sig-text-muted);
+		opacity: 0.7;
+	}
+	.provider-empty {
+		font-family: var(--font-body);
+		font-size: 11px;
+		color: var(--sig-text-muted);
+		padding: 12px;
+		grid-column: 1 / -1;
+	}
+	.catalog-warnings {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		margin-top: 4px;
+	}
+	.catalog-warning {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		font-family: var(--font-body);
+		font-size: 10.5px;
+		color: #fbbf24;
 	}
 </style>

--- a/surfaces/dashboard/src/lib/components/tabs/settings/connect-provider.svelte.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/connect-provider.svelte.ts
@@ -1,0 +1,243 @@
+/**
+ * Connect-provider controller — the state machine behind ConnectProviderDialog.
+ *
+ * Two flows share one reducer:
+ *   1. OAuth login (Claude Max / ChatGPT Codex / GitHub Copilot) — driven by
+ *      the daemon's SSE login stream. Events advance a finite state machine.
+ *   2. API-key connect — paste a key, validate, save to the vault, link.
+ *
+ * States are an exhaustive union so impossible states are unrepresentable
+ * (you can't be "connected" and "awaiting prompt" at once). Mirrors the
+ * dispatch/Match structure OpenCode's dialog-connect-provider uses, adapted to
+ * pi-ai's streaming event model.
+ */
+import {
+	type KeyValidationState,
+	type OAuthLoginEvent,
+	type OAuthProviderStatus,
+	completeOAuthInteraction,
+	disconnectOAuthProvider,
+	providerKeySecretName,
+	putSecret,
+	startOAuthLogin,
+	validateApiKey,
+} from "$lib/api";
+
+export type ConnectPhase =
+	| { kind: "method" }
+	| { kind: "oauth-running"; url?: string; deviceCode?: { userCode: string; verificationUri: string }; prompt?: PendingPrompt; progress?: string }
+	| { kind: "key-entry"; key: string; reveal: boolean; validation: KeyValidationState; testing: boolean }
+	| { kind: "saving" }
+	| { kind: "connected" }
+	| { kind: "error"; message: string };
+
+export interface PendingPrompt {
+	readonly responseId: string;
+	readonly kind: "text" | "select" | "manual_code";
+	readonly message: string;
+	readonly placeholder?: string;
+	readonly options?: ReadonlyArray<{ readonly id: string; readonly label: string }>;
+}
+
+export interface ConnectOptions {
+	readonly provider: OAuthProviderStatus | { readonly id: string; readonly name: string; readonly connected: boolean };
+	readonly supportsOAuth: boolean;
+	readonly supportsApiKey: boolean;
+	readonly onSaved?: () => void;
+	/** Called when an OAuth login completes so the caller can write the
+	 * `subscription_session` account entry the router resolves against. */
+	readonly linkOAuthAccount?: () => void;
+}
+
+export class ConnectProviderController {
+	readonly providerId: string;
+	readonly providerName: string;
+	phase = $state<ConnectPhase>({ kind: "method" });
+
+	private readonly supportsOAuth: boolean;
+	private readonly supportsApiKey: boolean;
+	private readonly onSaved?: () => void;
+	private readonly linkOAuthAccount?: () => void;
+	private login: Awaited<ReturnType<typeof startOAuthLogin>> | null = null;
+
+	constructor(opts: ConnectOptions) {
+		this.providerId = opts.provider.id;
+		this.providerName = opts.provider.name;
+		this.supportsOAuth = opts.supportsOAuth;
+		this.supportsApiKey = opts.supportsApiKey;
+		this.onSaved = opts.onSaved;
+		this.linkOAuthAccount = opts.linkOAuthAccount;
+	}
+
+	/** True when only one path exists — the dialog can auto-start it. */
+	get singlePath(): "oauth" | "key" | "choice" | null {
+		if (this.supportsOAuth && !this.supportsApiKey) return "oauth";
+		if (this.supportsApiKey && !this.supportsOAuth) return "key";
+		if (this.supportsOAuth && this.supportsApiKey) return "choice";
+		return null;
+	}
+
+	// ---- OAuth flow ------------------------------------------------------
+
+	startOAuth(): void {
+		if (this.phase.kind !== "method" && this.phase.kind !== "error") return;
+		this.phase = { kind: "oauth-running" };
+		void this.runOAuth();
+	}
+
+	private async runOAuth(): Promise<void> {
+		let url: string | undefined;
+		let deviceCode: { userCode: string; verificationUri: string } | undefined;
+		let progress: string | undefined;
+		let prompt: PendingPrompt | undefined;
+		const handle = await startOAuthLogin(this.providerId, () => {
+			// OAuth login stored the credential daemon-side; now wire the
+			// account entry so the router resolves it as subscription_session.
+			this.linkOAuthAccount?.();
+			this.onSaved?.();
+		});
+		this.login = handle;
+		handle.onEvent((event) => {
+			switch (event.type) {
+				case "auth":
+					url = event.url;
+					this.phase = { kind: "oauth-running", url, deviceCode, progress, prompt };
+					break;
+				case "device_code":
+					deviceCode = { userCode: event.userCode, verificationUri: event.verificationUri };
+					this.phase = { kind: "oauth-running", url, deviceCode, progress, prompt };
+					break;
+				case "prompt":
+					prompt = {
+						responseId: event.responseId,
+						kind: "text",
+						message: event.message,
+						placeholder: event.placeholder,
+					};
+					this.phase = { kind: "oauth-running", url, deviceCode, progress, prompt };
+					break;
+				case "select":
+					prompt = {
+						responseId: event.responseId,
+						kind: "select",
+						message: event.message,
+						options: event.options,
+					};
+					this.phase = { kind: "oauth-running", url, deviceCode, progress, prompt };
+					break;
+				case "manual_code":
+					prompt = {
+						responseId: event.responseId,
+						kind: "manual_code",
+						message: event.message,
+					};
+					this.phase = { kind: "oauth-running", url, deviceCode, progress, prompt };
+					break;
+				case "progress":
+					progress = event.message;
+					this.phase = { kind: "oauth-running", url, deviceCode, progress, prompt };
+					break;
+				case "connected":
+					this.phase = { kind: "connected" };
+					break;
+				case "error":
+					this.phase = { kind: "error", message: event.error };
+					break;
+				case "session":
+				case "done":
+					break;
+			}
+		});
+		this.login.onError((message) => {
+			if (this.phase.kind === "oauth-running") this.phase = { kind: "error", message };
+		});
+	}
+
+	async answerPrompt(value: string): Promise<void> {
+		const sessionId = this.login?.sessionId;
+		const prompt = this.phase.kind === "oauth-running" ? this.phase.prompt : undefined;
+		if (!sessionId || !prompt) return;
+		let ok: boolean;
+		try {
+			ok = await completeOAuthInteraction(sessionId, prompt.responseId, value);
+		} catch (error) {
+			// Network-level failure (daemon gone, connection drop): the HTTP !ok path
+			// is covered by `ok === false`; this catches transport rejection so the
+			// prompt doesn't hang with no feedback.
+			const message = error instanceof Error ? error.message : "Could not reach the daemon.";
+			this.phase = { kind: "error", message };
+			return;
+		}
+		if (!ok) {
+			this.phase = { kind: "error", message: "The provider rejected that response. Try again." };
+			return;
+		}
+		// Clear the prompt; the stream emits the next event (progress/connected).
+		if (this.phase.kind === "oauth-running") {
+			this.phase = { ...this.phase, prompt: undefined };
+		}
+	}
+
+	cancelOAuth(): void {
+		this.login?.close();
+		this.login = null;
+		this.phase = { kind: "method" };
+	}
+
+	async disconnect(): Promise<boolean> {
+		const ok = await disconnectOAuthProvider(this.providerId);
+		if (ok) this.onSaved?.();
+		return ok;
+	}
+
+	// ---- API-key flow ----------------------------------------------------
+
+	enterKeyMode(): void {
+		this.phase = { kind: "key-entry", key: "", reveal: false, validation: "empty", testing: false };
+	}
+
+	setKey(value: string): void {
+		if (this.phase.kind !== "key-entry") return;
+		this.phase = {
+			...this.phase,
+			key: value,
+			validation: validateApiKey(this.providerId, value),
+			testing: false,
+		};
+	}
+
+	toggleReveal(): void {
+		if (this.phase.kind !== "key-entry") return;
+		this.phase = { ...this.phase, reveal: !this.phase.reveal };
+	}
+
+	/** Save the key into the encrypted vault + link the account. The caller
+	 * (dialog) wires the account/credentialRef into agent.yaml via the settings
+	 * store; this only handles the secret write and final status. */
+	async saveKey(linkAccount: () => void): Promise<void> {
+		if (this.phase.kind !== "key-entry") return;
+		const value = this.phase.key.trim();
+		if (!value) return;
+		this.phase = { kind: "saving" };
+		const name = providerKeySecretName(this.providerId);
+		const stored = await putSecret(name, value);
+		if (!stored) {
+			this.phase = { kind: "error", message: "Could not save the key to the encrypted vault." };
+			return;
+		}
+		linkAccount();
+		this.onSaved?.();
+		this.phase = { kind: "connected" };
+	}
+
+	reset(): void {
+		this.login?.close();
+		this.login = null;
+		this.phase = { kind: "method" };
+	}
+
+	dispose(): void {
+		this.login?.close();
+		this.login = null;
+	}
+}

--- a/surfaces/dashboard/src/lib/components/tabs/settings/connect-provider.svelte.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/connect-provider.svelte.ts
@@ -36,6 +36,7 @@ export interface PendingPrompt {
 	readonly kind: "text" | "select" | "manual_code";
 	readonly message: string;
 	readonly placeholder?: string;
+	readonly allowEmpty?: boolean;
 	readonly options?: ReadonlyArray<{ readonly id: string; readonly label: string }>;
 }
 
@@ -43,7 +44,7 @@ export interface ConnectOptions {
 	readonly provider: OAuthProviderStatus | { readonly id: string; readonly name: string; readonly connected: boolean };
 	readonly supportsOAuth: boolean;
 	readonly supportsApiKey: boolean;
-	readonly onSaved?: () => void;
+	readonly onSaved?: () => void | Promise<void>;
 	/** Called when an OAuth login completes so the caller can write the
 	 * `subscription_session` account entry the router resolves against. */
 	readonly linkOAuthAccount?: () => void;
@@ -56,7 +57,7 @@ export class ConnectProviderController {
 
 	private readonly supportsOAuth: boolean;
 	private readonly supportsApiKey: boolean;
-	private readonly onSaved?: () => void;
+	private readonly onSaved?: () => void | Promise<void>;
 	private readonly linkOAuthAccount?: () => void;
 	private login: Awaited<ReturnType<typeof startOAuthLogin>> | null = null;
 
@@ -113,6 +114,7 @@ export class ConnectProviderController {
 						kind: "text",
 						message: event.message,
 						placeholder: event.placeholder,
+						allowEmpty: event.allowEmpty === true,
 					};
 					this.phase = { kind: "oauth-running", url, deviceCode, progress, prompt };
 					break;
@@ -185,9 +187,11 @@ export class ConnectProviderController {
 	}
 
 	async disconnect(): Promise<boolean> {
-		const ok = await disconnectOAuthProvider(this.providerId);
-		if (ok) this.onSaved?.();
-		return ok;
+		// Daemon-side disconnect only. The caller (dialog) owns the single
+		// onSaved notification so it can persist the account-entry removal in
+		// the same refresh — firing onSaved here would save the pre-removal state
+		// first and double the refresh.
+		return disconnectOAuthProvider(this.providerId);
 	}
 
 	// ---- API-key flow ----------------------------------------------------

--- a/surfaces/dashboard/src/lib/inference-keys.ts
+++ b/surfaces/dashboard/src/lib/inference-keys.ts
@@ -1,0 +1,51 @@
+/**
+ * Per-provider API-key format hints + validation. Dependency-free so it is
+ * unit-testable outside the SvelteKit runtime (api.ts pulls in $app/environment).
+ *
+ * Used by the connect dialog for instant client-side feedback — no network
+ * round-trip. Validation is advisory: a non-match never blocks save (providers
+ * change formats and custom gateways accept arbitrary keys); it only nudges.
+ * Patterns reflect the common shipped key shapes as of mid-2026.
+ */
+export interface ApiKeyFormat {
+	readonly hint: string;
+	readonly pattern: RegExp;
+}
+
+const STRICT_KEY_FORMATS: Record<string, ApiKeyFormat> = {
+	anthropic: { hint: "starts with sk-ant-", pattern: /^sk-ant-/i },
+	openai: { hint: "starts with sk-", pattern: /^sk-/i },
+	openrouter: { hint: "starts with sk-or-", pattern: /^sk-or-/i },
+	google: { hint: "starts with AIza", pattern: /^AIza/i },
+	"google-vertex": { hint: "starts with AIza", pattern: /^AIza/i },
+	xai: { hint: "starts with xai-", pattern: /^xai-/i },
+	groq: { hint: "starts with gsk_", pattern: /^gsk_/i },
+	mistral: { hint: "a Mistral platform key", pattern: /^[A-Za-z0-9_-]{20,}$/ },
+	deepseek: { hint: "starts with sk-", pattern: /^sk-/i },
+	together: { hint: "a Together API key", pattern: /^[A-Za-z0-9_-]{20,}$/ },
+	fireworks: { hint: "a Fireworks API key", pattern: /^[A-Za-z0-9_-]{20,}$/ },
+	nvidia: { hint: "starts with nvapi-", pattern: /^nvapi-/i },
+};
+
+export function apiKeyFormat(providerFamily: string): ApiKeyFormat | null {
+	return STRICT_KEY_FORMATS[providerFamily] ?? null;
+}
+
+export type KeyValidationState = "empty" | "valid" | "unsure";
+
+export function validateApiKey(providerFamily: string, value: string): KeyValidationState {
+	const trimmed = value.trim();
+	if (!trimmed) return "empty";
+	const format = apiKeyFormat(providerFamily);
+	if (!format) return trimmed.length >= 12 ? "unsure" : "empty";
+	return format.pattern.test(trimmed) ? "valid" : "unsure";
+}
+
+/**
+ * Stable secret name for a stored provider API key. Kept provider-keyed so a
+ * user can hold one key per provider and the name is human-meaningful in the
+ * secrets list. Collisions with real env vars are implausible for this prefix.
+ */
+export function providerKeySecretName(providerFamily: string): string {
+	return `SIGNET_KEY_${providerFamily.replace(/[^A-Z0-9_]/gi, "_").toUpperCase()}`;
+}

--- a/surfaces/dashboard/src/lib/inference-keys.ts
+++ b/surfaces/dashboard/src/lib/inference-keys.ts
@@ -37,7 +37,12 @@ export function validateApiKey(providerFamily: string, value: string): KeyValida
 	const trimmed = value.trim();
 	if (!trimmed) return "empty";
 	const format = apiKeyFormat(providerFamily);
-	if (!format) return trimmed.length >= 12 ? "unsure" : "empty";
+	if (!format) {
+		// No known format: never disable Connect for a non-empty key (that would
+		// silently block legitimate short keys for custom gateways / some Bedrock
+		// shapes). Surface it as "unsure" so the hint shows and the button stays on.
+		return "unsure";
+	}
 	return format.pattern.test(trimmed) ? "valid" : "unsure";
 }
 


### PR DESCRIPTION
## Summary

Completes the framework-independent backend half of #966 by integrating pi-ai's OAuth and dynamic provider registries into the daemon. OAuth credentials remain daemon-owned in Signet's encrypted secrets store, refresh through pi-ai at request time, and never cross the inference API boundary.

Fixes #966. The React dashboard work remains scoped to #948 as requested.

## Changes

- Add bounded SSE OAuth login, interactive completion, provider status, and disconnect routes.
- Store provider-keyed OAuth credentials in Signet Secrets and single-flight token refresh through `getOAuthApiKey()`.
- Resolve OAuth accounts by `providerFamily` while preserving env/secret API-key precedence for conventional accounts.
- Build native pi-ai providers/models dynamically, including credential-dependent Copilot model metadata.
- Return real pi-ai/OAuth catalog metadata and explicit per-provider model errors instead of silent empty lists.
- Accept safe dynamic pi-ai executor ids without changing target/account/workload semantics or ACPX behavior.
- Document the API, configuration, security boundary, session TTL, and approved router-spec delivery status.
- Add regression coverage for OAuth lifecycle, refresh persistence, catalog routing, provider model fidelity, validation, and authorization.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A — no UI files changed. The UI half remains in #948.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no database migration or Rust surface changes.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Passed locally:

- `bunx biome check` on all changed TypeScript files
- `bun run build:core`
- `cd platform/core && bun run typecheck`
- `cd platform/daemon && bun build.ts`
- 33 focused core/router/OAuth/provider tests
- 3 focused inference route, validation, and permission tests
- `bun scripts/doc-drift.ts` confirms the new OAuth routes are documented

Full `platform/daemon/src/inference-api.test.ts` result is 14 pass / 12 fail. A pristine `origin/main` worktree reproduces the same 12 failures at 12 pass / 12 fail; they are existing command-executor folding and OpenAI-compatible availability-probe expectations. This PR adds two passing cases and no new failures to that file.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

OAuth login sessions are capped at 8 concurrent sessions, expire after 10 minutes, validate offered selections, and clear pending interactions on timeout or disconnect. Credential-bearing providers bypass the fixed provider cache so refreshed tokens and provider-specific model mutations are applied per request.
