### PR TITLE
ci(daemon): add non-blocking tsc gate + clear #949 residuals (#961)

### DIFF
--- a/.github/workflows/daemon-typecheck.yml
+++ b/.github/workflows/daemon-typecheck.yml
@@ -72,8 +72,15 @@ jobs:
         run: |
           echo "## Daemon Typecheck (non-blocking)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
+          OUTCOME="${{ steps.tsc.outcome }}"
           COUNT="${{ steps.tsc.outputs.error_count }}"
-          if [ -z "$COUNT" ] || [ "$COUNT" = "0" ]; then
+          if [ "$OUTCOME" != "success" ]; then
+            # Distinguish "0 errors" from "typecheck step skipped/broken"
+            # (failed install, tsc OOM/timeout) — otherwise an unset COUNT
+            # would falsely print "✅ clean".
+            echo "⚠️ Daemon typecheck step did not complete (outcome: $OUTCOME)." >> "$GITHUB_STEP_SUMMARY"
+            echo "Cannot report an error count; investigate the job logs." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$COUNT" = "0" ]; then
             echo "✅ Daemon \`tsc --noEmit\` is clean." >> "$GITHUB_STEP_SUMMARY"
           else
             echo "⚠️ Daemon \`tsc --noEmit\` reports **$COUNT** error(s)." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/daemon-typecheck.yml
+++ b/.github/workflows/daemon-typecheck.yml
@@ -1,0 +1,82 @@
+name: Daemon Typecheck
+
+# Non-blocking daemon tsc gate (#961).
+#
+# The daemon historically shipped with dormant type errors because it had no
+# `typecheck` script and `build:types` emits despite errors (noEmitOnError
+# defaults to false). This workflow surfaces the daemon's tsc status without
+# blocking main or PRs (continue-on-error), so:
+#   - the existing backlog (tracked in its own issue) is visible, and
+#   - NEW type errors introduced by a PR show up here for the author/reviewer.
+#
+# Once the backlog is cleared to green in a follow-up, flip `continue-on-error`
+# to false to make this a hard gate.
+on:
+  pull_request:
+    paths:
+      - "platform/daemon/src/**"
+      - "platform/daemon/tsconfig.json"
+      - "platform/daemon/package.json"
+      - "platform/core/src/**"
+      - ".github/workflows/daemon-typecheck.yml"
+  push:
+    branches: [main]
+    paths:
+      - "platform/daemon/src/**"
+      - "platform/daemon/tsconfig.json"
+      - "platform/daemon/package.json"
+      - "platform/core/src/**"
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    name: Daemon tsc --noEmit (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        shell: bash
+        run: bun install --frozen-lockfile
+
+      - name: Build @signet/core (daemon imports its compiled types)
+        shell: bash
+        run: bun run --filter '@signet/core' build
+
+      - name: Daemon typecheck
+        id: tsc
+        shell: bash
+        run: |
+          set +e
+          # Mirror the daemon's local typecheck script (tsc --noEmit from
+          # platform/daemon, which picks up daemon/tsconfig.json). Exclude the
+          # rootDir cross-package TS6059 noise that tsc emits when core source
+          # is pulled in via path maps — those are not real daemon errors.
+          cd platform/daemon
+          npx tsc --noEmit 2>&1 | grep -v "TS6059" | tee /tmp/tsc-out.txt
+          # Count real errors (exclude the rootDir noise + the per-file "is in
+          # the program because" follow-up lines).
+          ERR_COUNT=$(grep -c "error TS" /tmp/tsc-out.txt || true)
+          echo "error_count=$ERR_COUNT" >> "$GITHUB_OUTPUT"
+          echo "::warning file=platform/daemon::Daemon tsc reports $ERR_COUNT type error(s). This job is non-blocking (see #961). New errors introduced by this PR should be fixed before merge."
+
+      - name: Summary
+        if: always()
+        shell: bash
+        run: |
+          echo "## Daemon Typecheck (non-blocking)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          COUNT="${{ steps.tsc.outputs.error_count }}"
+          if [ -z "$COUNT" ] || [ "$COUNT" = "0" ]; then
+            echo "✅ Daemon \`tsc --noEmit\` is clean." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "⚠️ Daemon \`tsc --noEmit\` reports **$COUNT** error(s)." >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "This job is **non-blocking** (continue-on-error) per #961. The existing backlog is tracked separately; please ensure your PR does not *add* new errors." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/platform/daemon/package.json
+++ b/platform/daemon/package.json
@@ -26,6 +26,7 @@
     "prebuild": "bun run copy:skills",
     "build": "bun run prebuild && bun run build.ts && bun run build:dashboard",
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
+    "typecheck": "tsc --noEmit",
     "dev": "bun --watch src/daemon.ts",
     "start": "cd ../core && bun run build && cd ../daemon && bun src/daemon.ts",
     "install:service": "bun src/daemon.ts --install",

--- a/platform/daemon/src/config-migration.ts
+++ b/platform/daemon/src/config-migration.ts
@@ -207,9 +207,14 @@ export function migrateInferenceProviders(agentsDir: string): void {
 }
 
 function stampConfigVersion(doc: Document.Parsed, version: number): void {
+	// Use Document.set (typed `key: any, value: unknown`) rather than the
+	// narrowed YAMLMap.set on `doc.contents`, which types its key as ParsedNode
+	// and rejects the string key "configVersion" (TS2345). Document.set
+	// delegates to contents.set when contents is a map, so behavior is
+	// identical for both branches.
 	const root = doc.contents;
 	if (isMap(root)) {
-		root.set("configVersion", doc.createNode(version));
+		doc.set("configVersion", version);
 	} else {
 		// Empty or non-map document — wrap it.
 		doc.set("configVersion", version);

--- a/platform/daemon/src/config-migration.ts
+++ b/platform/daemon/src/config-migration.ts
@@ -209,7 +209,7 @@ export function migrateInferenceProviders(agentsDir: string): void {
 function stampConfigVersion(doc: Document.Parsed, version: number): void {
 	const root = doc.contents;
 	if (isMap(root)) {
-		root.set("configVersion", version);
+		root.set("configVersion", doc.createNode(version));
 	} else {
 		// Empty or non-map document — wrap it.
 		doc.set("configVersion", version);

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -288,10 +288,14 @@ const RATE_LIMIT_PROVIDERS: ReadonlySet<string> = new Set([
 	"openrouter",
 	"codex",
 	"opencode",
+	"openai-compatible",
 ]);
 
-// Compile-time check: if a new remote provider is added to the union but
-// omitted from the set above, this produces a type error.
+// Compile-time check: if a new remote provider is added to the RemoteProvider
+// union but omitted from the _exhaustiveCheck Record above, this produces a
+// type error. NOTE: this only enforces that the Record keys cover the union —
+// keeping RATE_LIMIT_PROVIDERS in sync with the Record remains a human
+// discipline step (the Set is untyped ReadonlySet<string>).
 const _exhaustiveCheck: Record<RemoteProvider, true> = {
 	acpx: true,
 	"claude-code": true,
@@ -299,6 +303,7 @@ const _exhaustiveCheck: Record<RemoteProvider, true> = {
 	openrouter: true,
 	codex: true,
 	opencode: true,
+	"openai-compatible": true,
 };
 void _exhaustiveCheck;
 


### PR DESCRIPTION
## What

Closes #961 — adds a **non-blocking** daemon `tsc` gate so the #960-class silent-type-error failures surface in PRs going forward, and clears the 2 #949-introduced residuals that motivated the issue.

## Root cause (why these shipped silently)

- The daemon had **no `typecheck` script** → `bun run typecheck` (`--filter '*'`) silently skipped it.
- Its `build:types` (`tsc --emitDeclarationOnly`) runs with `noEmitOnError: false` (inherited, not overridden like `core` does) → declarations emit *despite* errors, so the build "succeeds" while hiding them.

Result: **335 dormant type errors** (154 source / 181 test) accumulated — including all 5 from #960.

## Changes

1. **`platform/daemon/package.json`** — add `"typecheck": "tsc --noEmit"` (mirrors `core`). Now `bun run typecheck` and the turbo pipeline cover the daemon.
2. **`.github/workflows/daemon-typecheck.yml`** — new workflow, **`continue-on-error: true`** (non-blocking). Runs `tsc --noEmit` from `platform/daemon`, filters the TS6059 rootDir cross-package noise, and emits a step-summary + warning annotation with the real error count. Path-scoped to daemon/core source so it runs on relevant PRs.

## The 2 #949 residuals (cleared now — they're why this issue exists)

- **`pipeline/provider.ts`** — added `"openai-compatible"` to **both** `RATE_LIMIT_PROVIDERS` and the `_exhaustiveCheck` Record. It's a member of `RemoteProvider` (via `PipelineExtractionConfig.provider`), so the compile-time guard that's *supposed* to catch a remote provider missing rate-limit coverage was itself incomplete. Tightened the comment to be honest that the Record covers the union but `RATE_LIMIT_PROVIDERS` sync is still manual.
- **`config-migration.ts`** — `stampConfigVersion` now uses `doc.createNode(version)` for the yaml `Map.set` value (TS2345 `ParsedNode`) instead of a raw number.

## Why non-blocking (and the plan to harden)

A hard gate can't land green today — the backlog is 333 pre-existing errors **unrelated to #949** (87 are one mechanical `Record[] as Row[]` cast pattern; rest are bun-types gaps like `destroySoon`/`NonSharedBuffer`). Clearing all of it is a large cross-cutting refactor touching ~40 files I haven't reviewed — too risky for one PR.

So this lands the **incremental gate** (per maintainer decision): non-blocking now, so new errors surface immediately without red-ing main over the backlog. The backlog is tracked in **#969** for per-subsystem clearing; once it hits green, flip `continue-on-error: false`.

## Verification

- The 2 residual fixes: both `tsc` errors resolved; 13/13 migration tests + 26/26 provider tests pass.
- The gate command (`npx tsc --noEmit` from `platform/daemon`): runs correctly, reports **333 errors** (was 335; −2 from this PR) — matching the #969 inventory.
- Workflow YAML validated; `continue-on-error: true` confirmed non-blocking for PR and push (autoreview verified).

## Structured review

autoreview: sound and low-risk. One info-level nit (the `_exhaustiveCheck` comment over-promised sync enforcement) — addressed by tightening the comment.

Closes #961. Backlog: #969.
