### PR TITLE
fix(memory): stop session-start injection from advancing access tracking

### DIFF
--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -858,6 +858,44 @@ creature: digital assistant
 		expect(result.inject).toContain("Relevant Memories");
 	});
 
+	// Regression for #971: session-start injects ~50 memories into the system
+	// prompt for context, but the agent never recalled them. Bumping
+	// access_count/last_accessed here permanently inflates rehearsal boost for
+	// the injection set and resets last_accessed so the half-life never decays
+	// it. Those columns must only advance on genuine recall (CLI/MCP/harness
+	// prompt-submit recall via hybridRecall).
+	test.serial("session-start injection does not advance access_count/last_accessed", async () => {
+		createMemoryDb([{ content: "Injected startup memory", importance: 0.9 }]);
+		const injectedId = getDbAccessor().withReadDb(
+			(db) =>
+				(db.prepare("SELECT id FROM memories WHERE content = ?").get("Injected startup memory") as { id: string }).id,
+		);
+
+		const before = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT access_count, last_accessed FROM memories WHERE id = ?").get(injectedId) as {
+					access_count: number;
+					last_accessed: string | null;
+				},
+		);
+		expect(before.access_count).toBe(0);
+		expect(before.last_accessed).toBeNull();
+
+		const result = await handleSessionStart({ harness: "claude-code", sessionKey: "access-tracking-971" });
+		expect(result.memories.length).toBe(1);
+		expect(result.inject).toContain("Injected startup memory");
+
+		const after = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT access_count, last_accessed FROM memories WHERE id = ?").get(injectedId) as {
+					access_count: number;
+					last_accessed: string | null;
+				},
+		);
+		expect(after.access_count).toBe(0);
+		expect(after.last_accessed).toBeNull();
+	});
+
 	test.serial("includes MEMORY.md as working memory", async () => {
 		writeMemoryMd("# Working Memory\n\nCurrently working on hooks migration.");
 

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -501,10 +501,6 @@ function getPredictedContextMemories(
 	);
 }
 
-function updateAccessTracking(ids: string[]): void {
-	memoryCandidates.updateAccessTracking(getMemoryDbPath(), ids);
-}
-
 // ============================================================================
 // Config Loading
 // ============================================================================
@@ -940,9 +936,14 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 
 	const exploredId: string | null = null;
 
-	// Update access tracking for served memories
-	const servedIds = memories.map((m) => m.id);
-	updateAccessTracking(servedIds);
+	// Do NOT bump access_count/last_accessed for session-start injected memories.
+	// Those columns drive rehearsal boost and retention decay, which must reflect
+	// genuine recall operations (CLI, MCP, or harness prompt-submit recall via
+	// hybridRecall), not the ~50-60 memories injected into the system prompt at
+	// session start. Bumping them here permanently inflates the boost for the
+	// injection set and resets last_accessed so the half-life never decays it.
+	// Injected rows are still recorded for the predictive scorer below via
+	// session_memories, so no telemetry is lost. See #971.
 
 	// Record all candidates + which were injected for predictive scorer
 	const injectedSet = new Set(memories.map((m) => m.id));

--- a/platform/daemon/src/memory-candidates.ts
+++ b/platform/daemon/src/memory-candidates.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import type { AgentRosterReadPolicy } from "@signet/core";
-import { type WriteDb, getDbAccessor } from "./db-accessor";
+import { getDbAccessor } from "./db-accessor";
 import { logger } from "./logger";
 import { effectiveScore } from "./memory-classification";
 import { buildAgentScopeClause } from "./memory-search";
@@ -346,26 +346,6 @@ export function getPredictedContextMemories(
 			error: e instanceof Error ? e.message : String(e),
 		});
 		return [];
-	}
-}
-
-export function updateAccessTracking(memoryDbPath: string, ids: string[]): void {
-	if (ids.length === 0 || !existsSync(memoryDbPath)) return;
-
-	try {
-		getDbAccessor().withWriteTx((db: WriteDb) => {
-			const now = new Date().toISOString();
-			const stmt = db.prepare(
-				`UPDATE memories SET access_count = access_count + 1,
-				 last_accessed = ? WHERE id = ?`,
-			);
-
-			for (const id of ids) {
-				stmt.run(now, id);
-			}
-		});
-	} catch (e) {
-		logger.error("hooks", "Failed to update access tracking", e as Error);
 	}
 }
 


### PR DESCRIPTION
Fixes #971.

## Summary

Session-start injects ~50-60 memories into the system prompt for context, but the agent never recalled them. `handleSessionStart` was bumping `memories.access_count` and `last_accessed` for that entire injected set via a direct write (`updateAccessTracking(servedIds)`) that bypassed the `hybridRecall` access-tracking path.

Those columns drive **rehearsal boost** (`memory-search.ts` `applyRehearsalBoost`), **retention decay** (`maintenance-worker.ts`), and the **repair queue** (`repair-actions.ts`). Bumping them at session start:

1. permanently inflated rehearsal boost for the injection set, and
2. reset `last_accessed` every session so the half-life decay never bit (recencyFactor ≈ 1.0 forever), and
3. fed a feedback loop — session-start candidate selection itself reads `access_count` as a feature (`memory-candidates.ts`), so the inflation compounded.

## Root cause

`platform/daemon/src/hooks.ts:943-945` (main):

```ts
// Update access tracking for served memories
const servedIds = memories.map((m) => m.id);
updateAccessTracking(servedIds);  // bumps access_count + last_accessed for the injected set
```

`servedIds` is the full injected set (up to 50 scored candidates + up to 10 predicted-context memories) — none of them recalls.

## Fix

Remove the stray `updateAccessTracking(servedIds)` call, plus the now-orphaned wrapper in `hooks.ts` and the orphaned export in `memory-candidates.ts`.

Genuine recall surfaces already advance these columns correctly via `hybridRecall`'s `finish()` (`memory-search.ts:1201-1213`, gated by `trackRecallAccess !== false`):

- CLI / `/api/memory/*`
- harness prompt-submit recall `/api/hooks/recall` (sets `recallSurface: "api.hooks.recall"`)
- MCP
- aggregate-recall

So only the stray write is removed — no recall path changes.

## Behavior change to flag

Because `access_count` was a session-start candidate-selection feature (impact #4 above), session-start candidate ordering will shift slightly as the feedback loop unwinds. That is the intended behavior, but it is a visible change to candidate ranking. Pre-compaction `getRecentMemories` (`hooks.ts:1242`) is unaffected — it only builds a summary string and never wrote `access_count`.

Telemetry is preserved: injected rows are still recorded for the predictive scorer via `session_memories` (`claimRecallItems`), which is independent of `access_count`.

## Validation

- `bun test platform/daemon/src/hooks.test.ts` — 177 pass / 0 fail (incl. new regression test)
- `bun test platform/daemon/src/memory-search.test.ts` — 49 pass / 0 fail
- `bunx tsc --noEmit` — no new errors (425 pre-existing errors unchanged; none in changed files)
- `bunx biome check` — clean
- Regression test verified to **fail on old code, pass with fix** (temporarily reverted the source to confirm)
- `autoreview` — 0 findings

## Type

- [x] `fix`

## Packages affected

- [x] `@signet/daemon`

## AI disclosure

- [x] AI tools were used (this PR was prepared with an AI coding assistant)