### PR TITLE
fix(acpx): prevent recursive background hooks

### DIFF
--- a/docs/ACP-INTEGRATION.md
+++ b/docs/ACP-INTEGRATION.md
@@ -179,7 +179,7 @@ ACPX target config lives under `inference.targets.<name>.acpx`.
 | `mode` | `exec` or `session` | `exec` is the default. `session` only adds `-s <session>` before `exec --file -`. |
 | `session` | string | Named ACPX session used when `mode: session`. |
 | `permissions` | `inherit`, `deny-all`, `approve-reads`, or `approve-all` | Maps to ACPX permission flags. |
-| `hooks` | `inherit`, `disabled`, or `enabled` | `disabled` sets `SIGNET_NO_HOOKS=1`; `enabled` removes it; `inherit` leaves the environment alone. |
+| `hooks` | `inherit`, `disabled`, or `enabled` | `disabled` sets `SIGNET_NO_HOOKS=1` and `SIGNET_ENABLED=false`; `enabled` removes the no-hooks sentinel; `inherit` leaves the environment alone. |
 | `terminal` | boolean or string | `false` or `disabled` passes `--no-terminal`; `true` maps to `enabled`; string modes `inherit`, `disabled`, `enabled` are accepted. |
 | `allowedTools` | string[] | Passed as comma-separated `--allowed-tools`. |
 | `timeoutMs` | number | Per-call subprocess deadline in milliseconds. Also converted to ACPX `--timeout` seconds. |
@@ -196,8 +196,10 @@ background targets use:
 hooks: disabled
 ```
 
-That maps to `SIGNET_NO_HOOKS=1`, which prevents Signet harness hooks from
-injecting session-start context into the ACPX subprocess.
+That maps to `SIGNET_NO_HOOKS=1` and `SIGNET_ENABLED=false`, which prevents
+Signet harness plugins from registering hooks or injecting session-start
+context inside the ACPX subprocess. Plugins also honor the no-hooks sentinel
+for compatibility with existing sterile subprocess launchers.
 
 This is intentionally configurable, not global:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -479,7 +479,7 @@ subscription-backed CLI session, or gateway.
 | `cwd` | string | Optional working directory for harness execution |
 | `session` | string | Optional ACPX session identifier when a persistent session is desired |
 | `permissions` | string | Optional ACPX permission policy passed through to the harness |
-| `hooks` | string | Set to `disabled` for sterile/background execution (`SIGNET_NO_HOOKS=1`) |
+| `hooks` | string | Set to `disabled` for sterile/background execution (`SIGNET_NO_HOOKS=1` and `SIGNET_ENABLED=false`) |
 | `terminal` | boolean | For ACPX, set `false` to pass `--no-terminal` |
 | `allowedTools` | array | Optional ACPX allowed-tool list |
 | `format` / `outputFormat` | string | ACPX output format. `quiet` is the default; `json` parses ACPX JSON events and extracts the final response |

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -453,6 +453,9 @@ session-end) and exposes `/remember` and `/recall` as native tools.
 
 Install is handled automatically by `signet setup` or `signet connect opencode`.
 
+Set `SIGNET_ENABLED=false` or `SIGNET_NO_HOOKS=1` to prevent the plugin from
+registering hooks for a sterile background process.
+
 > **Legacy:** Earlier installations placed a fetch-based `memory.mjs` at
 > `~/.config/opencode/memory.mjs`. This path is deprecated. Running
 > `signet connect opencode` migrates the installation to the current

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -102,8 +102,8 @@ immediately with a `"CLI binary not found on PATH"` error.
 Spawned processes inherit the daemon's environment with two modifications:
 
 - `CLAUDECODE` is stripped to avoid nested-session detection
-- `SIGNET_NO_HOOKS` is set to `"1"` to prevent hook loops (the spawned
-  agent shouldn't trigger Signet hooks back into the daemon)
+- `SIGNET_NO_HOOKS` is set to `"1"` to prevent hook loops (Signet harness
+  integrations treat the spawned agent as a sterile background process)
 
 ### Timeout Behavior
 

--- a/integrations/opencode/plugin/src/index.test.ts
+++ b/integrations/opencode/plugin/src/index.test.ts
@@ -4,6 +4,8 @@ import { SignetPlugin } from "./index.js";
 const originalFetch = globalThis.fetch;
 const originalDaemonUrl = process.env.SIGNET_DAEMON_URL;
 const originalAgentId = process.env.SIGNET_AGENT_ID;
+const originalEnabled = process.env.SIGNET_ENABLED;
+const originalNoHooks = process.env.SIGNET_NO_HOOKS;
 
 interface RequestRecord {
 	readonly path: string;
@@ -77,9 +79,34 @@ afterEach(() => {
 	} else {
 		process.env.SIGNET_AGENT_ID = originalAgentId;
 	}
+	if (originalEnabled === undefined) {
+		process.env.SIGNET_ENABLED = undefined;
+	} else {
+		process.env.SIGNET_ENABLED = originalEnabled;
+	}
+	if (originalNoHooks === undefined) {
+		process.env.SIGNET_NO_HOOKS = undefined;
+	} else {
+		process.env.SIGNET_NO_HOOKS = originalNoHooks;
+	}
 });
 
 describe("SignetPlugin OpenCode lifecycle", () => {
+	test.each([
+		["SIGNET_ENABLED=false", "SIGNET_ENABLED", "false"],
+		["SIGNET_NO_HOOKS=1", "SIGNET_NO_HOOKS", "1"],
+	] as const)("does not register hooks or contact the daemon when %s", async (_label, name, value) => {
+		process.env.SIGNET_ENABLED = "true";
+		process.env.SIGNET_NO_HOOKS = undefined;
+		process.env[name] = value;
+		const records = installFetch();
+
+		const plugin = await SignetPlugin({ directory: "/repo" } as never);
+
+		expect(plugin).toEqual({});
+		expect(records).toEqual([]);
+	});
+
 	test("injects per-session start context when system transform runs before chat.message", async () => {
 		process.env.SIGNET_AGENT_ID = undefined;
 		const records = installFetch();

--- a/integrations/opencode/plugin/src/index.ts
+++ b/integrations/opencode/plugin/src/index.ts
@@ -191,7 +191,7 @@ function readPartText(part: unknown): string | null {
 // ============================================================================
 
 export const SignetPlugin: Plugin = async ({ directory, client: oc }) => {
-	const enabled = readRuntimeEnv("SIGNET_ENABLED") !== "false";
+	const enabled = readRuntimeEnv("SIGNET_ENABLED") !== "false" && readRuntimeEnv("SIGNET_NO_HOOKS") !== "1";
 	if (!enabled) return {};
 
 	const daemonUrl = readRuntimeEnv("SIGNET_DAEMON_URL") ?? DAEMON_URL_DEFAULT;

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, expect, it } from "bun:test";
 import { spawn as nodeSpawn } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -76,7 +76,7 @@ describe("createAcpxProvider", () => {
 printf '%s\n' "$@" > ${JSON.stringify(argsPath)}
 printf '%s' "$PWD" > ${JSON.stringify(cwdPath)}
 cat > ${JSON.stringify(promptPath)}
-printf '%s' "\${SIGNET_NO_HOOKS:-}" > ${JSON.stringify(hooksPath)}
+printf '%s|%s' "\${SIGNET_NO_HOOKS:-}" "\${SIGNET_ENABLED:-}" > ${JSON.stringify(hooksPath)}
 printf '  acpx answer  \\n'
 `,
 		);
@@ -107,8 +107,8 @@ printf '  acpx answer  \\n'
 			const agentIndex = args.indexOf("codex");
 			expect(args.slice(agentIndex)).toEqual(["codex", "-s", "background", "exec", "--file", "-"]);
 			expect(readFileSync(promptPath, "utf-8")).toBe("hello acpx");
-			expect(readFileSync(hooksPath, "utf-8")).toBe("1");
-			expect(readFileSync(cwdPath, "utf-8")).toBe(join(root, ".daemon", "acpx-background"));
+			expect(readFileSync(hooksPath, "utf-8")).toBe("1|false");
+			expect(readFileSync(cwdPath, "utf-8")).toBe(realpathSync(join(root, ".daemon", "acpx-background")));
 		} finally {
 			if (previousSignetPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
 			else process.env.SIGNET_PATH = previousSignetPath;

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -20,7 +20,7 @@
 import { spawn as nodeSpawn } from "node:child_process";
 import { mkdirSync, readFileSync, readdirSync } from "node:fs";
 import { isAbsolute, join, resolve as resolvePath } from "node:path";
-import { type ThinkingLevel } from "@earendil-works/pi-ai";
+import type { ThinkingLevel } from "@earendil-works/pi-ai";
 import {
 	DEFAULT_PROVIDER_RATE_LIMIT,
 	type LlmGenerateResult,
@@ -685,6 +685,7 @@ function acpxEnv(hooks: AcpxHooksMode | undefined, runId?: string): NodeJS.Proce
 	const env: NodeJS.ProcessEnv = { ...process.env };
 	if (hooks === "disabled") {
 		env.SIGNET_NO_HOOKS = "1";
+		env.SIGNET_ENABLED = "false";
 	} else if (hooks === "enabled") {
 		env.SIGNET_NO_HOOKS = undefined;
 	}


### PR DESCRIPTION
## Summary

Prevent Signet's sterile ACPX/OpenCode background workers from registering Signet hooks and recursively capturing their own extraction and synthesis sessions. Closes #973.

## Changes

- Set both `SIGNET_NO_HOOKS=1` and `SIGNET_ENABLED=false` when an ACPX target uses `hooks: disabled`.
- Make the OpenCode plugin return before daemon contact or hook registration when either disable signal is present.
- Add provider and OpenCode plugin regressions for the shared disable contract.
- Document the sterile ACPX/OpenCode hook behavior.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `@signet/opencode-plugin`

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Daemon Rust parity reviewed or explicitly N/A
- [ ] Rollback / compatibility note included in PR description

No migration or persisted schema change.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Scoped validation:

- `bun test integrations/opencode/plugin/src/index.test.ts` — 12 passed.
- Focused ACPX provider regression — 1 passed.
- `bun run --filter '@signet/opencode-plugin' typecheck` — passed.
- `bun run --filter '@signet/opencode-plugin' build` — passed.
- `bun run --filter '@signet/daemon' build` — passed.
- Biome check on all changed TypeScript files — passed.
- Controlled OpenCode 1.18.4 / ACPX 0.12.0 A/B test — enabled baseline emitted lifecycle hook requests; `SIGNET_NO_HOOKS=1` emitted none and completed successfully.
- Running daemon v0.147.10 route test at `2026-07-22T23:09:21Z` — `opencode-background/default` completed `memory_extraction` successfully in 15.4 seconds with no fallback. The daemon log contained zero matching `.agents/.daemon/acpx-background` hook events or inference failures after the probe began.

The repository-wide daemon typecheck still reports pre-existing `origin/main` cross-package `rootDir` and SQLite typing diagnostics; the affected plugin typecheck, daemon build, focused tests, and changed-file lint all pass.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- `docs/specs/INDEX.md` and `docs/specs/dependencies.yaml` were reviewed; this preserves the existing `signet-runtime` lifecycle contract and does not change spec dependencies.
- No data queries, agent-scoped storage, new external inputs, admin/mutation endpoints, Rust parity surface, or migration files are changed; the corresponding readiness checks are verified N/A for this patch.
- ACPX 0.12.0 source confirms it forwards its process environment into the spawned agent. OpenCode source confirms external plugins initialize inside that process, so both disable signals reach the plugin boundary.

