### PR TITLE
fix(web): enable Astro ClientRouter for client-side navigation

### DIFF
--- a/web/marketing/src/layouts/Base.astro
+++ b/web/marketing/src/layouts/Base.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/global.css";
 import "../styles/tailwind.css";
+import { ClientRouter } from "astro:transitions";
 
 interface Props {
 	title?: string;
@@ -32,6 +33,7 @@ const imageUrl = new URL(image, Astro.site ?? "https://signetai.sh");
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="generator" content={Astro.generator} />
+    <ClientRouter />
     <script>if(typeof crypto!=="undefined"&&!crypto.randomUUID){crypto.randomUUID=function(){return([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g,function(c){return(c^crypto.getRandomValues(new Uint8Array(1))[0]&15>>c/4).toString(16)})};}</script>
     <!-- Meta Pixel Code -->
     <script>
@@ -129,7 +131,7 @@ const imageUrl = new URL(image, Astro.site ?? "https://signetai.sh");
 
     <!-- Reddit Pixel Conversion Events -->
     <script>
-    document.addEventListener('DOMContentLoaded', function() {
+    document.addEventListener('astro:page-load', function() {
       function trackReddit(event, selectors) {
         selectors.forEach(function(sel) {
           document.querySelectorAll(sel).forEach(function(el) {


### PR DESCRIPTION
## Problem

Clicking between pages on the marketing/docs site triggered a **full page reload** instead of a client-side swap. Astro 5's router was never enabled.

## Root cause

Astro 5 ships in **MPA mode** by default (every link = full document reload). Enabling SPA-style navigation requires adding the `<ClientRouter />` component (renamed from `ViewTransitions` in Astro 5) to the `<head>` — and it was never added to `Base.astro`.

**Evidence the site was built *expecting* the router:** 10 files already listen for `astro:page-load` / `astro:before-swap`, which **only fire when ClientRouter is active**:

- `src/components/Nav.astro`
- `src/components/ShareButtons.astro`
- `src/layouts/Base.astro`, `Blog.astro`, `Docs.astro`
- `src/scripts/canvas-animations.ts`, `canvas-text-overlays.ts`, `docs-toc.ts`, `interactions.ts`, `masonry-layout.ts`

So before this fix, the sidebar TOC, masonry layout, nav interactions, and canvas overlays were likely **silently not initializing** on the live site, because their init events never fired.

## Fix (3 lines in `web/marketing/src/layouts/Base.astro`)

1. `import { ClientRouter } from "astro:transitions";`
2. `<ClientRouter />` in `<head>` — `Base.astro` is the single `<head>` root (`Blog.astro` and `Docs.astro` both wrap it), so this covers all page types.
3. Reddit conversion-tracking script: `DOMContentLoaded` → `astro:page-load`, so click listeners re-attach after each navigation (otherwise enabling the router would silently break conversion tracking on every page after the first).

`ClientRouter` is the correct component for the installed version — verified against `node_modules/astro` (v5.18.1), not guessed.

## Verification

- ✅ `bun run build` green — 109 pages built
- ✅ ClientRouter runtime bundle present in built `<head>` of `/`, `/docs`, and `/blog`
- ✅ All inline `<script>` blocks parse cleanly
- ✅ No remaining `DOMContentLoaded` listeners anywhere in `src/`