### PR TITLE
fix(acpx): harden sterile OpenCode inference

### DIFF
--- a/docs/ACP-INTEGRATION.md
+++ b/docs/ACP-INTEGRATION.md
@@ -135,6 +135,7 @@ inference:
         format: json
         captureEvents: true
         maxCapturedEvents: 200
+        emptyResponseRetries: 1
       models:
         default:
           model: gpt-5.4-mini
@@ -150,6 +151,14 @@ API.
 to JSON when `format` is omitted. Provider-level callers can also attach an
 event callback; Signet limits callback delivery with `maxCapturedEvents`
 (default `200`) while still scanning the full stream for the final response.
+
+ACPX agents can occasionally finish with `end_turn` but no assistant message
+chunks. Signet retries that empty completion in a fresh one-shot session only
+when the target is sterile (`deny-all`, hooks disabled, and an empty tool
+catalog). `emptyResponseRetries` defaults to `1`, is capped at `3`, and can be
+set to `0` to disable the retry. Repeated empties report the output format,
+byte counts, stop metadata when JSON is available, retry count, and duration.
+Tool or permission activity is never retried as an empty completion.
 
 This is intentionally the first Zed-inspired step, not the whole session model:
 Signet now has a typed ACPX event parsing seam, but durable dashboard-visible

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -485,6 +485,7 @@ subscription-backed CLI session, or gateway.
 | `format` / `outputFormat` | string | ACPX output format. `quiet` is the default; `json` parses ACPX JSON events and extracts the final response |
 | `captureEvents` | boolean | When true, defaults ACPX to JSON output and enables the provider event-capture path |
 | `maxCapturedEvents` | number | Maximum number of JSON events delivered to the provider-side event callback; defaults to 200 |
+| `emptyResponseRetries` | number | Fresh-session retries after an exit-0 empty response. Defaults to 1 and is capped at 3; retries run only for sterile deny-all targets with hooks and tools disabled |
 | `timeoutMs` | number | Per-call ACPX subprocess deadline |
 | `extraArgs` | array | Additional ACPX CLI args appended after Signet-managed args |
 | `privacy` | string | `remote_ok`, `restricted_remote`, or `local_only` |

--- a/platform/core/src/routing.test.ts
+++ b/platform/core/src/routing.test.ts
@@ -478,6 +478,7 @@ describe("inference config + decision engine", () => {
 							format: "json",
 							captureEvents: true,
 							maxCapturedEvents: 128,
+							emptyResponseRetries: 9,
 						},
 						models: { default: { model: "gpt-5.4-mini" } },
 					},
@@ -490,6 +491,7 @@ describe("inference config + decision engine", () => {
 			format: "json",
 			captureEvents: true,
 			maxCapturedEvents: 128,
+			emptyResponseRetries: 3,
 		});
 	});
 

--- a/platform/core/src/routing.ts
+++ b/platform/core/src/routing.ts
@@ -1,5 +1,5 @@
-import type { PipelineCommandConfig, PipelineExtractionConfig, PipelineSynthesisConfig } from "./types";
 import { defaultPipelineModel } from "./pipeline-providers";
+import type { PipelineCommandConfig, PipelineExtractionConfig, PipelineSynthesisConfig } from "./types";
 
 export const ROUTING_ACCOUNT_KINDS = ["subscription_session", "api"] as const;
 export const ROUTING_TARGET_KINDS = ["subscription_session", "api", "local", "gateway"] as const;
@@ -112,6 +112,7 @@ export interface RoutingAcpxConfig {
 	readonly format?: RoutingAcpxOutputFormat;
 	readonly captureEvents?: boolean;
 	readonly maxCapturedEvents?: number;
+	readonly emptyResponseRetries?: number;
 	readonly timeoutMs?: number;
 	readonly extraArgs?: readonly string[];
 }
@@ -566,6 +567,10 @@ function parseAcpxConfig(raw: unknown): RoutingAcpxConfig | undefined {
 		format: asAcpxOutputFormat(nested.format ?? nested.outputFormat ?? nested.output_format),
 		captureEvents: asBool(nested.captureEvents ?? nested.capture_events),
 		maxCapturedEvents: asPositiveInt(nested.maxCapturedEvents ?? nested.max_captured_events),
+		emptyResponseRetries: Math.min(
+			3,
+			asNonNegativeInt(nested.emptyResponseRetries ?? nested.empty_response_retries) ?? 1,
+		),
 		timeoutMs: asPositiveInt(nested.timeoutMs ?? nested.timeout_ms),
 		extraArgs: extraArgs.length > 0 ? extraArgs : undefined,
 	};

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -154,6 +154,211 @@ printf 'ok\\n'
 		}
 	});
 
+	it("retries a sterile quiet-mode empty completion in a fresh one-shot session", async () => {
+		const root = join(tmpdir(), `signet-acpx-empty-retry-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const bin = join(root, "fake-acpx-empty-then-valid.sh");
+		const countPath = join(root, "count.txt");
+		const argsPath = join(root, "args.txt");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+count=0
+[[ -f ${JSON.stringify(countPath)} ]] && count=$(cat ${JSON.stringify(countPath)})
+count=$((count + 1))
+printf '%s' "$count" > ${JSON.stringify(countPath)}
+printf '%s\n' "$@" >> ${JSON.stringify(argsPath)}
+cat >/dev/null
+if [[ "$count" -eq 1 ]]; then
+  printf '  \n'
+else
+  printf 'recovered answer\n'
+fi
+`,
+		);
+		chmodSync(bin, 0o755);
+		try {
+			const provider = createAcpxProvider({
+				agent: "codex",
+				bin,
+				mode: "session",
+				session: "persistent-background",
+				permissions: "deny-all",
+				hooks: "disabled",
+				allowedTools: [],
+				emptyResponseRetries: 1,
+			});
+
+			await expect(provider.generate("retry me", { timeoutMs: 2000 })).resolves.toBe("recovered answer");
+			expect(readFileSync(countPath, "utf8")).toBe("2");
+			const args = readFileSync(argsPath, "utf8").trim().split("\n");
+			expect(args.filter((arg) => arg === "persistent-background")).toHaveLength(1);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("reports structured diagnostics after repeated empty completions", async () => {
+		const root = join(tmpdir(), `signet-acpx-empty-terminal-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const bin = join(root, "fake-acpx-always-empty.sh");
+		const countPath = join(root, "count.txt");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+count=0
+[[ -f ${JSON.stringify(countPath)} ]] && count=$(cat ${JSON.stringify(countPath)})
+printf '%s' "$((count + 1))" > ${JSON.stringify(countPath)}
+cat >/dev/null
+printf '\n'
+printf '%s\n' '[acpx] tokens: input=20 output=1 total=21' >&2
+`,
+		);
+		chmodSync(bin, 0o755);
+		try {
+			const provider = createAcpxProvider({
+				agent: "codex",
+				bin,
+				permissions: "deny-all",
+				hooks: "disabled",
+				allowedTools: [],
+				emptyResponseRetries: 1,
+			});
+
+			await expect(provider.generate("retry me", { timeoutMs: 2000 })).rejects.toThrow(
+				/exitCode=0, stdoutBytes=1, stderrBytes=42, format=quiet, sessionId=unknown, stopReason=unknown, usage=input=20 output=1 total=21, retryCount=1, durationMs=\d+/,
+			);
+			expect(readFileSync(countPath, "utf8")).toBe("2");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("retries JSON end_turn with zero assistant chunks and preserves ACP diagnostics", async () => {
+		const root = join(tmpdir(), `signet-acpx-json-empty-retry-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const bin = join(root, "fake-acpx-json-empty-then-valid.sh");
+		const countPath = join(root, "count.txt");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+count=0
+[[ -f ${JSON.stringify(countPath)} ]] && count=$(cat ${JSON.stringify(countPath)})
+count=$((count + 1))
+printf '%s' "$count" > ${JSON.stringify(countPath)}
+cat >/dev/null
+printf '%s\n' '{"jsonrpc":"2.0","id":0,"result":{"sessionId":"ses-empty"}}'
+if [[ "$count" -eq 1 ]]; then
+  printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn","usage":{"inputTokens":20,"outputTokens":1}}}'
+else
+  printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"json recovered"}}}}'
+  printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
+fi
+`,
+		);
+		chmodSync(bin, 0o755);
+		try {
+			const provider = createAcpxProvider({
+				agent: "codex",
+				bin,
+				format: "json",
+				permissions: "deny-all",
+				hooks: "disabled",
+				allowedTools: [],
+			});
+
+			await expect(provider.generate("retry json", { timeoutMs: 2000 })).resolves.toBe("json recovered");
+			expect(readFileSync(countPath, "utf8")).toBe("2");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("does not retry JSON output after observable tool activity", async () => {
+		const root = join(tmpdir(), `signet-acpx-json-side-effect-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const bin = join(root, "fake-acpx-json-tool.sh");
+		const countPath = join(root, "count.txt");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+printf '1' >> ${JSON.stringify(countPath)}
+cat >/dev/null
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"tool_call","toolCallId":"call-1","title":"shell"}}}'
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
+`,
+		);
+		chmodSync(bin, 0o755);
+		try {
+			const provider = createAcpxProvider({
+				agent: "codex",
+				bin,
+				format: "json",
+				permissions: "deny-all",
+				hooks: "disabled",
+				allowedTools: [],
+			});
+
+			await expect(provider.generate("do not retry", { timeoutMs: 2000 })).rejects.toThrow(
+				"codex via ACPX JSON output did not include a final response",
+			);
+			expect(readFileSync(countPath, "utf8")).toBe("1");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("injects a tool-denying OpenCode profile and defaults sterile runs to JSON", async () => {
+		const root = join(tmpdir(), `signet-acpx-opencode-profile-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const bin = join(root, "fake-opencode-acpx.sh");
+		const argsPath = join(root, "args.txt");
+		const configPath = join(root, "opencode-config.json");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+printf '%s\n' "$@" > ${JSON.stringify(argsPath)}
+printf '%s' "$OPENCODE_CONFIG_CONTENT" > ${JSON.stringify(configPath)}
+cat >/dev/null
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"sterile answer"}}}}'
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
+`,
+		);
+		chmodSync(bin, 0o755);
+		const previousConfig = process.env.OPENCODE_CONFIG_CONTENT;
+		process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({ model: "provider/model" });
+		try {
+			const provider = createAcpxProvider({
+				agent: "opencode",
+				bin,
+				model: "routed/model",
+				permissions: "deny-all",
+				hooks: "disabled",
+				allowedTools: [],
+			});
+			await expect(provider.generate("sterile", { timeoutMs: 2000 })).resolves.toBe("sterile answer");
+			const args = readFileSync(argsPath, "utf8").trim().split("\n");
+			expect(args[args.indexOf("--format") + 1]).toBe("json");
+			expect(args).not.toContain("--model");
+			const overlay = JSON.parse(readFileSync(configPath, "utf8")) as {
+				model?: string;
+				tools?: Record<string, boolean>;
+				permission?: Record<string, string>;
+				agent?: { build?: { tools?: Record<string, boolean>; permission?: Record<string, string> } };
+			};
+			expect(overlay.model).toBe("routed/model");
+			expect(overlay.tools?.["*"]).toBe(false);
+			expect(overlay.permission?.["*"]).toBe("deny");
+			expect(overlay.agent?.build?.tools?.["*"]).toBe(false);
+			expect(overlay.agent?.build?.permission?.["*"]).toBe("deny");
+			expect(overlay.agent?.build).toMatchObject({ model: "routed/model" });
+		} finally {
+			if (previousConfig === undefined) Reflect.deleteProperty(process.env, "OPENCODE_CONFIG_CONTENT");
+			else process.env.OPENCODE_CONFIG_CONTENT = previousConfig;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("cleans up detached Codex ACP agent processes after successful ACPX exec", async () => {
 		if (process.platform !== "linux") return;
 		const root = join(tmpdir(), `signet-acpx-success-cleanup-${Date.now()}-${Math.random().toString(36).slice(2)}`);

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -657,12 +657,15 @@ export interface AcpxProviderConfig {
 	readonly format?: AcpxOutputFormat;
 	readonly captureEvents?: boolean;
 	readonly maxCapturedEvents?: number;
+	readonly emptyResponseRetries?: number;
 	readonly onEvent?: (event: AcpxJsonEvent) => void;
 	readonly timeoutMs?: number;
 	readonly extraArgs?: readonly string[];
 }
 
 const DEFAULT_ACPX_VERSION = "0.12.0";
+const DEFAULT_ACPX_EMPTY_RESPONSE_RETRIES = 1;
+const MAX_ACPX_EMPTY_RESPONSE_RETRIES = 3;
 
 function normalizeAcpxAgent(agent: string): string {
 	return agent === "claude-code" ? "claude" : agent;
@@ -681,13 +684,64 @@ function acpxPermissionArgs(mode: AcpxPermissionMode | undefined): string[] {
 	}
 }
 
-function acpxEnv(hooks: AcpxHooksMode | undefined, runId?: string): NodeJS.ProcessEnv {
+function isSterileAcpxTarget(config: AcpxProviderConfig): boolean {
+	return (
+		config.hooks === "disabled" &&
+		config.permissions === "deny-all" &&
+		(resolveAcpxAllowedTools(config)?.length ?? 0) === 0
+	);
+}
+
+function mergeSterileOpenCodeConfig(raw: string | undefined, model: string | undefined): string {
+	let existing: Record<string, unknown> = {};
+	if (raw?.trim()) {
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(raw);
+		} catch (error) {
+			throw new Error(
+				`Cannot secure OpenCode ACPX target: OPENCODE_CONFIG_CONTENT is invalid JSON (${error instanceof Error ? error.message : String(error)})`,
+			);
+		}
+		if (!isJsonRecord(parsed)) {
+			throw new Error("Cannot secure OpenCode ACPX target: OPENCODE_CONFIG_CONTENT must contain a JSON object");
+		}
+		existing = { ...parsed };
+	}
+	const existingTools = isJsonRecord(existing.tools) ? existing.tools : {};
+	const existingPermission = isJsonRecord(existing.permission) ? existing.permission : {};
+	const existingAgents = isJsonRecord(existing.agent) ? existing.agent : {};
+	const existingBuild = isJsonRecord(existingAgents.build) ? existingAgents.build : {};
+	return JSON.stringify({
+		...existing,
+		...(model ? { model } : {}),
+		tools: { ...existingTools, "*": false },
+		permission: { ...existingPermission, "*": "deny" },
+		agent: {
+			...existingAgents,
+			build: {
+				...existingBuild,
+				...(model ? { model } : {}),
+				tools: { ...(isJsonRecord(existingBuild.tools) ? existingBuild.tools : {}), "*": false },
+				permission: {
+					...(isJsonRecord(existingBuild.permission) ? existingBuild.permission : {}),
+					"*": "deny",
+				},
+			},
+		},
+	});
+}
+
+function acpxEnv(config: AcpxProviderConfig, runId?: string): NodeJS.ProcessEnv {
 	const env: NodeJS.ProcessEnv = { ...process.env };
-	if (hooks === "disabled") {
+	if (config.hooks === "disabled") {
 		env.SIGNET_NO_HOOKS = "1";
 		env.SIGNET_ENABLED = "false";
-	} else if (hooks === "enabled") {
+	} else if (config.hooks === "enabled") {
 		env.SIGNET_NO_HOOKS = undefined;
+	}
+	if (normalizeAcpxAgent(config.agent).toLowerCase() === "opencode" && isSterileAcpxTarget(config)) {
+		env.OPENCODE_CONFIG_CONTENT = mergeSterileOpenCodeConfig(env.OPENCODE_CONFIG_CONTENT, config.model);
 	}
 	if (runId) env.SIGNET_ACPX_RUN_ID = runId;
 	return env;
@@ -712,8 +766,12 @@ function resolveAcpxAllowedTools(
 	return config.hooks === "disabled" ? [] : undefined;
 }
 
-function resolveAcpxFormat(config: Pick<AcpxProviderConfig, "format" | "captureEvents">): AcpxOutputFormat {
-	return config.format ?? (config.captureEvents ? "json" : "quiet");
+function resolveAcpxFormat(config: AcpxProviderConfig): AcpxOutputFormat {
+	if (config.format) return config.format;
+	if (config.captureEvents) return "json";
+	return normalizeAcpxAgent(config.agent).toLowerCase() === "opencode" && isSterileAcpxTarget(config)
+		? "json"
+		: "quiet";
 }
 
 function buildAcpxCommand(
@@ -732,7 +790,9 @@ function buildAcpxCommand(
 	args.push("--format", resolveAcpxFormat(config));
 	args.push("--timeout", String(Math.max(1, Math.ceil(timeoutMs / 1000))));
 	if (cwd) args.push("--cwd", cwd);
-	if (config.model) args.push("--model", config.model);
+	const openCodeProfileOwnsModel =
+		normalizeAcpxAgent(config.agent).toLowerCase() === "opencode" && isSterileAcpxTarget(config);
+	if (config.model && !openCodeProfileOwnsModel) args.push("--model", config.model);
 	args.push(...acpxPermissionArgs(config.permissions));
 	if (config.terminal === "disabled") args.push("--no-terminal");
 	if (allowedTools) args.push("--allowed-tools", allowedTools.join(","));
@@ -884,14 +944,94 @@ function cleanupAcpxAgentProcesses(agent: string, runId: string): void {
 	}
 }
 
+interface AcpxParsedJsonOutput {
+	readonly text?: string;
+	readonly finalSeen: boolean;
+	readonly messageChunks: number;
+	readonly sideEffects: boolean;
+	readonly sessionId?: string;
+	readonly stopReason?: string;
+	readonly usage?: string;
+}
+
+interface AcpxAttemptDiagnostics {
+	readonly exitCode: number;
+	readonly stdoutBytes: number;
+	readonly stderrBytes: number;
+	readonly format: AcpxOutputFormat;
+	readonly durationMs: number;
+	readonly sideEffects: boolean;
+	readonly sessionId?: string;
+	readonly stopReason?: string;
+	readonly usage?: string;
+}
+
+class AcpxEmptyResponseError extends Error {
+	readonly diagnostics: AcpxAttemptDiagnostics;
+
+	constructor(agent: string, diagnostics: AcpxAttemptDiagnostics) {
+		super(`${agent} via ACPX returned empty response`);
+		this.name = "AcpxEmptyResponseError";
+		this.diagnostics = diagnostics;
+	}
+}
+
+function nestedAcpxRecord(event: AcpxJsonEvent, key: "result" | "params"): AcpxJsonEvent | undefined {
+	const value = event[key];
+	return isJsonRecord(value) ? value : undefined;
+}
+
+function extractAcpxSessionId(event: AcpxJsonEvent): string | undefined {
+	return (
+		acpxStringField(event, "sessionId") ??
+		acpxStringField(event, "session_id") ??
+		acpxStringField(nestedAcpxRecord(event, "result") ?? {}, "sessionId") ??
+		acpxStringField(nestedAcpxRecord(event, "result") ?? {}, "session_id") ??
+		acpxStringField(nestedAcpxRecord(event, "params") ?? {}, "sessionId") ??
+		acpxStringField(nestedAcpxRecord(event, "params") ?? {}, "session_id")
+	);
+}
+
+function extractAcpxStopReason(event: AcpxJsonEvent): string | undefined {
+	return (
+		acpxStringField(event, "stopReason") ??
+		acpxStringField(event, "stop_reason") ??
+		acpxStringField(nestedAcpxRecord(event, "result") ?? {}, "stopReason") ??
+		acpxStringField(nestedAcpxRecord(event, "result") ?? {}, "stop_reason")
+	);
+}
+
+function extractAcpxUsage(event: AcpxJsonEvent): string | undefined {
+	const result = nestedAcpxRecord(event, "result");
+	const usage = (result ?? event).usage;
+	if (!isJsonRecord(usage)) return undefined;
+	return JSON.stringify(usage).slice(0, 300);
+}
+
+function isAcpxSideEffectEvent(event: AcpxJsonEvent): boolean {
+	const method = acpxStringField(event, "method")?.toLowerCase();
+	if (method?.includes("permission") || method === "session/request_permission") return true;
+	if (method !== "session/update") return false;
+	const params = nestedAcpxRecord(event, "params");
+	const update = params && isJsonRecord(params.update) ? params.update : undefined;
+	const kind = update ? acpxStringField(update, "sessionUpdate")?.toLowerCase() : undefined;
+	return kind === "tool_call" || kind === "tool_call_update";
+}
+
 function parseAcpxJsonOutput(
 	stdout: string,
 	config: Pick<AcpxProviderConfig, "agent" | "captureEvents" | "maxCapturedEvents" | "onEvent">,
-): string {
+): AcpxParsedJsonOutput {
 	const maxCapturedEvents = Math.max(0, config.maxCapturedEvents ?? 200);
 	let emittedEvents = 0;
 	let finalText: string | undefined;
 	let streamedText = "";
+	let finalSeen = false;
+	let messageChunks = 0;
+	let sideEffects = false;
+	let sessionId: string | undefined;
+	let stopReason: string | undefined;
+	let usage: string | undefined;
 	const lines = stdout
 		.split(/\r?\n/)
 		.map((line) => line.trim())
@@ -911,8 +1051,16 @@ function parseAcpxJsonOutput(
 			throw new Error(`${config.agent} via ACPX emitted non-object JSON event on line ${index + 1}`);
 		}
 		const chunk = extractAcpxMessageChunk(parsed);
-		if (chunk !== undefined) streamedText += chunk;
+		if (chunk !== undefined) {
+			messageChunks += 1;
+			streamedText += chunk;
+		}
+		sideEffects ||= isAcpxSideEffectEvent(parsed);
+		sessionId ??= extractAcpxSessionId(parsed);
 		if (isAcpxFinalEvent(parsed)) {
+			finalSeen = true;
+			stopReason ??= extractAcpxStopReason(parsed);
+			usage ??= extractAcpxUsage(parsed);
 			const candidate = extractAcpxTextCandidate(parsed);
 			if (candidate?.trim()) {
 				finalText = candidate;
@@ -926,8 +1074,143 @@ function parseAcpxJsonOutput(
 		}
 	}
 
-	if (finalText?.trim()) return finalText.trim();
-	throw new Error(`${config.agent} via ACPX JSON output did not include a final response`);
+	return {
+		...(finalText?.trim() ? { text: finalText.trim() } : {}),
+		finalSeen,
+		messageChunks,
+		sideEffects,
+		...(sessionId ? { sessionId } : {}),
+		...(stopReason ? { stopReason } : {}),
+		...(usage ? { usage } : {}),
+	};
+}
+
+function resolveEmptyResponseRetries(config: AcpxProviderConfig): number {
+	const configured = config.emptyResponseRetries ?? DEFAULT_ACPX_EMPTY_RESPONSE_RETRIES;
+	return Math.min(MAX_ACPX_EMPTY_RESPONSE_RETRIES, Math.max(0, Math.floor(configured)));
+}
+
+function quietUsage(stderr: string): string | undefined {
+	return stderr.match(/^\[acpx\] tokens: (.+)$/m)?.[1]?.slice(0, 300);
+}
+
+function formatEmptyResponseError(
+	agent: string,
+	diagnostics: AcpxAttemptDiagnostics,
+	retryCount: number,
+	totalDurationMs: number,
+): Error {
+	const fields = [
+		`exitCode=${diagnostics.exitCode}`,
+		`stdoutBytes=${diagnostics.stdoutBytes}`,
+		`stderrBytes=${diagnostics.stderrBytes}`,
+		`format=${diagnostics.format}`,
+		`sessionId=${diagnostics.sessionId ?? "unknown"}`,
+		`stopReason=${diagnostics.stopReason ?? "unknown"}`,
+		`usage=${diagnostics.usage ?? "unknown"}`,
+		`retryCount=${retryCount}`,
+		`durationMs=${Math.round(totalDurationMs)}`,
+	];
+	return new Error(`${agent} via ACPX returned empty response (${fields.join(", ")})`);
+}
+
+function runAcpxAttempt(
+	config: AcpxProviderConfig,
+	prompt: string,
+	remainingMs: number,
+	signal: AbortSignal | undefined,
+): Promise<string> {
+	const { bin, args, cwd } = buildAcpxCommand(config, remainingMs);
+	const outputFormat = resolveAcpxFormat(config);
+	const runId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+	const startedAt = performance.now();
+	return new Promise<string>((resolve, reject) => {
+		let stdout = "";
+		let stderr = "";
+		let settled = false;
+		let aborted = false;
+		const child = nodeSpawn(bin, args, {
+			cwd,
+			env: acpxEnv(config, runId),
+			stdio: ["pipe", "pipe", "pipe"],
+			detached: process.platform !== "win32",
+			windowsHide: true,
+		});
+		const finish = (fn: () => void): void => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			signal?.removeEventListener("abort", onAbort);
+			cleanupAcpxAgentProcesses(config.agent, runId);
+			fn();
+		};
+		const onAbort = (): void => {
+			aborted = true;
+			terminateChildProcessTreeWithEscalation(child);
+		};
+		if (signal?.aborted) onAbort();
+		else signal?.addEventListener("abort", onAbort, { once: true });
+		const timer = setTimeout(() => {
+			terminateChildProcessTreeWithEscalation(child);
+			finish(() => reject(new Error(`${config.agent} via ACPX timeout after ${Math.ceil(remainingMs)}ms`)));
+		}, remainingMs);
+		child.stdout?.setEncoding("utf8");
+		child.stderr?.setEncoding("utf8");
+		child.stdout?.on("data", (chunk) => {
+			stdout += String(chunk);
+		});
+		child.stderr?.on("data", (chunk) => {
+			stderr += String(chunk);
+		});
+		child.on("error", (error) => finish(() => reject(error)));
+		child.on("close", (code) =>
+			finish(() => {
+				if (aborted) {
+					reject(new Error(`${config.agent} via ACPX aborted`));
+					return;
+				}
+				if (code !== 0) {
+					reject(new Error(`${config.agent} via ACPX exited ${code}: ${stderr.slice(0, 300)}`));
+					return;
+				}
+				let text: string | undefined;
+				let parsed: AcpxParsedJsonOutput | undefined;
+				try {
+					if (outputFormat === "json") {
+						parsed = parseAcpxJsonOutput(stdout, config);
+						text = parsed.text;
+					} else {
+						text = stdout.trim();
+					}
+				} catch (error) {
+					reject(error);
+					return;
+				}
+				if (!text) {
+					if (parsed && (!parsed.finalSeen || parsed.sideEffects)) {
+						reject(new Error(`${config.agent} via ACPX JSON output did not include a final response`));
+						return;
+					}
+					reject(
+						new AcpxEmptyResponseError(config.agent, {
+							exitCode: 0,
+							stdoutBytes: Buffer.byteLength(stdout),
+							stderrBytes: Buffer.byteLength(stderr),
+							format: outputFormat,
+							durationMs: performance.now() - startedAt,
+							sideEffects: parsed?.sideEffects ?? false,
+							...(parsed?.sessionId ? { sessionId: parsed.sessionId } : {}),
+							...(parsed?.stopReason ? { stopReason: parsed.stopReason } : {}),
+							...(parsed?.usage || quietUsage(stderr) ? { usage: parsed?.usage ?? quietUsage(stderr) } : {}),
+						}),
+					);
+					return;
+				}
+				resolve(text);
+			}),
+		);
+		child.stdin?.end(prompt);
+	});
 }
 
 export function createAcpxProvider(config: AcpxProviderConfig): LlmProvider {
@@ -939,83 +1222,43 @@ export function createAcpxProvider(config: AcpxProviderConfig): LlmProvider {
 			const signal = generateSignal(opts);
 			return withLlmConcurrency(
 				async () => {
-					const remainingMs = deadline - performance.now();
-					if (remainingMs <= 0) {
-						throw new Error(
-							`${config.agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`,
-						);
-					}
-					const { bin, args, cwd } = buildAcpxCommand(config, remainingMs);
-					const outputFormat = resolveAcpxFormat(config);
-					const runId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
-					return new Promise<string>((resolve, reject) => {
-						let stdout = "";
-						let stderr = "";
-						let settled = false;
-						let aborted = false;
-						const child = nodeSpawn(bin, args, {
-							cwd,
-							env: acpxEnv(config.hooks, runId),
-							stdio: ["pipe", "pipe", "pipe"],
-							detached: process.platform !== "win32",
-							windowsHide: true,
-						});
-						const finish = (fn: () => void): void => {
-							if (settled) return;
-							settled = true;
-							clearTimeout(timer);
-							signal?.removeEventListener("abort", onAbort);
-							cleanupAcpxAgentProcesses(config.agent, runId);
-							fn();
-						};
-						const onAbort = (): void => {
-							aborted = true;
-							terminateChildProcessTreeWithEscalation(child);
-						};
-						if (signal?.aborted) {
-							onAbort();
-						} else {
-							signal?.addEventListener("abort", onAbort, { once: true });
+					const retries = isSterileAcpxTarget(config) ? resolveEmptyResponseRetries(config) : 0;
+					const startedAt = performance.now();
+					let lastEmpty: AcpxEmptyResponseError | undefined;
+					for (let attempt = 0; attempt <= retries; attempt += 1) {
+						const remainingMs = deadline - performance.now();
+						if (remainingMs <= 0) {
+							if (lastEmpty) {
+								throw formatEmptyResponseError(
+									config.agent,
+									lastEmpty.diagnostics,
+									attempt - 1,
+									performance.now() - startedAt,
+								);
+							}
+							throw new Error(
+								`${config.agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`,
+							);
 						}
-						const timer = setTimeout(() => {
-							terminateChildProcessTreeWithEscalation(child);
-							finish(() => reject(new Error(`${config.agent} via ACPX timeout after ${timeoutMs}ms`)));
-						}, remainingMs);
-						child.stdout?.setEncoding("utf8");
-						child.stderr?.setEncoding("utf8");
-						child.stdout?.on("data", (chunk) => {
-							stdout += String(chunk);
-						});
-						child.stderr?.on("data", (chunk) => {
-							stderr += String(chunk);
-						});
-						child.on("error", (error) => finish(() => reject(error)));
-						child.on("close", (code) =>
-							finish(() => {
-								if (aborted) {
-									reject(new Error(`${config.agent} via ACPX aborted`));
-									return;
-								}
-								if (code !== 0) {
-									reject(new Error(`${config.agent} via ACPX exited ${code}: ${stderr.slice(0, 300)}`));
-									return;
-								}
-								let text: string;
-								try {
-									text = outputFormat === "json" ? parseAcpxJsonOutput(stdout, config) : stdout.trim();
-								} catch (error) {
-									reject(error);
-									return;
-								}
-								if (!text) {
-									reject(new Error(`${config.agent} via ACPX returned empty response`));
-									return;
-								}
-								resolve(text);
-							}),
-						);
-						child.stdin?.end(prompt);
-					});
+						const attemptConfig = attempt === 0 ? config : { ...config, mode: "exec" as const, session: undefined };
+						try {
+							return await runAcpxAttempt(attemptConfig, prompt, remainingMs, signal);
+						} catch (error) {
+							if (!(error instanceof AcpxEmptyResponseError)) throw error;
+							lastEmpty = error;
+							if (attempt >= retries) {
+								throw formatEmptyResponseError(config.agent, error.diagnostics, attempt, performance.now() - startedAt);
+							}
+							logger.warn("inference", "Retrying sterile ACPX empty response", {
+								agent: config.agent,
+								attempt: attempt + 1,
+								format: error.diagnostics.format,
+								sessionId: error.diagnostics.sessionId ?? "unknown",
+								stopReason: error.diagnostics.stopReason ?? "unknown",
+							});
+						}
+					}
+					throw new Error(`${config.agent} via ACPX retry loop exhausted`);
 				},
 				timeoutMs,
 				"acpx",


### PR DESCRIPTION
## Summary

Hardens sterile OpenCode background inference through ACPX so deny-all targets honor the empty tool policy and recover once from an exit-0, end-turn response with no assistant text. Closes #979.

## Changes

- Inject a native OpenCode config overlay that denies all tools/permissions and selects the routed model without ACPX's unsupported generic `--model` flag.
- Parse ACP JSON completion metadata and retry only sterile, side-effect-free empty completions in a fresh one-shot session under the original deadline.
- Add bounded `emptyResponseRetries` configuration, structured terminal diagnostics, regression coverage, and ACP integration docs.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: ACP integration/configuration docs

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Agent scoping and admin/mutation endpoint checks are N/A: this change adds no data queries or HTTP endpoints. The readiness result is scoped to changed files and affected packages; repository-wide baseline failures are documented below.

## Migration Notes (if applicable)

No migration or persisted schema change.

- [ ] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Rust parity is N/A because the ACPX provider is TypeScript-only. Rollback is a normal commit revert; `emptyResponseRetries: 0` disables the new retry behavior independently.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Passing scoped verification:

- `bun test platform/core/src/routing.test.ts` — 16 pass, 0 fail
- Focused ACPX provider regressions — 5 pass, 0 fail
- Full provider file — 28 pass; 3 existing macOS fixture failures reproduced before this change (`/var` vs `/private/var`, Linux process-group fixture)
- Biome check on all four changed TypeScript files
- `bun run --filter '@signet/core' typecheck`
- `bun run --filter '@signet/daemon' build`
- Real ACPX 0.12.0 → OpenCode 1.18.0 → `minimax-coding-plan/MiniMax-M3` inference returned `PONG`
- Isolated daemon health, inference status, and execution all returned 200; execution returned `PONG` with no permission, empty-response, or retry warnings

Repository-wide baseline state:

- `bun run lint` reports 1,773 pre-existing errors outside this diff.
- `bun run typecheck` fails in unrelated daemon test files; affected core typecheck and daemon production build pass.
- The root test run encountered unrelated existing packaging, SQLite extension, shared-state, and legacy-config failures; it was stopped after the failures were established. No issue-specific test failed.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Retries are deliberately limited to sterile targets (`deny-all`, hooks disabled, empty tools), exit-0 completion, and no observed tool or permission activity. Retry attempts use a fresh one-shot ACPX session and share the original request deadline.
