### PR TITLE
fix(acpx): support agent-managed models

### DIFF
--- a/docs/ACP-INTEGRATION.md
+++ b/docs/ACP-INTEGRATION.md
@@ -121,6 +121,14 @@ npx -y acpx@0.7.0 \
 The prompt is written to stdin. The final text response is read from stdout and
 returned to the current `LlmProvider` abstraction.
 
+`modelSelection` controls who applies the routed model. `acp` passes
+`--model` to ACPX and requires the agent to advertise compatible ACP model
+selection. `agent` omits the flag and relies on the harness's native model
+configuration; `signet route doctor` warns operators to verify that external
+configuration. OpenCode defaults to `agent` because installations may not
+advertise ACP model negotiation, while other agents default to `acp`. Set the
+mode explicitly to override either default.
+
 ### JSON event capture
 
 Signet can also ask ACPX for JSON output:
@@ -132,6 +140,7 @@ inference:
       executor: acpx
       acpx:
         agent: codex
+        modelSelection: acp
         format: json
         captureEvents: true
         maxCapturedEvents: 200
@@ -173,6 +182,7 @@ ACPX target config lives under `inference.targets.<name>.acpx`.
 | Field | Type | Description |
 |---|---|---|
 | `agent` | string | ACPX agent command, for example `codex`, `claude` for Claude Code, or `opencode`. Legacy `claude-code` values are normalized to `claude` before spawning ACPX. |
+| `modelSelection` | `acp` or `agent` | `acp` passes the routed model through ACPX negotiation. `agent` omits `--model` and relies on the agent's native configuration. Defaults to `agent` for OpenCode and `acp` otherwise. |
 | `version` / `acpxVersion` | string | ACPX npm package version. Defaults to Signet's pinned `0.7.0`. |
 | `bin` | string | Optional executable override. If omitted, Signet runs `npx -y acpx@<version>`. |
 | `cwd` | string | Working directory for ACPX and the harness. |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -485,6 +485,7 @@ subscription-backed CLI session, or gateway.
 | `format` / `outputFormat` | string | ACPX output format. `quiet` is the default; `json` parses ACPX JSON events and extracts the final response |
 | `captureEvents` | boolean | When true, defaults ACPX to JSON output and enables the provider event-capture path |
 | `maxCapturedEvents` | number | Maximum number of JSON events delivered to the provider-side event callback; defaults to 200 |
+| `modelSelection` | string | `acp` passes the routed model through ACPX negotiation; `agent` lets the ACP agent's native configuration choose it. Defaults to `agent` for OpenCode and `acp` for other agents |
 | `timeoutMs` | number | Per-call ACPX subprocess deadline |
 | `extraArgs` | array | Additional ACPX CLI args appended after Signet-managed args |
 | `privacy` | string | `remote_ok`, `restricted_remote`, or `local_only` |

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -445,9 +445,11 @@ export {
 	compileLegacyRoutingConfig,
 	parseRoutingConfig,
 	allTargetRefs,
+	resolveAcpxModelSelection,
 	resolveRoutingDecision,
 } from "./routing";
 export type {
+	AcpxModelSelection,
 	RoutingAccountKind,
 	RoutingTargetKind,
 	RoutingExecutorKind,

--- a/platform/core/src/routing.test.ts
+++ b/platform/core/src/routing.test.ts
@@ -467,6 +467,35 @@ describe("inference config + decision engine", () => {
 		expect(parsed.value.targets.background?.acpx?.terminal).toBe("disabled");
 	});
 
+	it("defaults OpenCode to agent-managed models and preserves explicit ACP model selection", () => {
+		const parsed = parseRoutingConfig({
+			inference: {
+				targets: {
+					opencode: {
+						executor: "acpx",
+						acpx: { agent: "OpenCode" },
+						models: { default: { model: "minimax-coding-plan/MiniMax-M3" } },
+					},
+					codex: {
+						executor: "acpx",
+						acpx: { agent: "codex" },
+						models: { default: { model: "gpt-5.4-mini" } },
+					},
+					opencodeExplicit: {
+						executor: "acpx",
+						acpx: { agent: "opencode", model_selection: "acp" },
+						models: { default: { model: "minimax-coding-plan/MiniMax-M3" } },
+					},
+				},
+			},
+		});
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok) return;
+		expect(parsed.value.targets.opencode?.acpx?.modelSelection).toBe("agent");
+		expect(parsed.value.targets.codex?.acpx?.modelSelection).toBe("acp");
+		expect(parsed.value.targets.opencodeExplicit?.acpx?.modelSelection).toBe("acp");
+	});
+
 	it("parses ACPX event capture configuration", () => {
 		const parsed = parseRoutingConfig({
 			inference: {

--- a/platform/core/src/routing.ts
+++ b/platform/core/src/routing.ts
@@ -1,5 +1,5 @@
-import type { PipelineCommandConfig, PipelineExtractionConfig, PipelineSynthesisConfig } from "./types";
 import { defaultPipelineModel } from "./pipeline-providers";
+import type { PipelineCommandConfig, PipelineExtractionConfig, PipelineSynthesisConfig } from "./types";
 
 export const ROUTING_ACCOUNT_KINDS = ["subscription_session", "api"] as const;
 export const ROUTING_TARGET_KINDS = ["subscription_session", "api", "local", "gateway"] as const;
@@ -96,9 +96,16 @@ export type RoutingAcpxHooksMode = "inherit" | "disabled" | "enabled";
 export type RoutingAcpxTerminalMode = "inherit" | "disabled" | "enabled";
 export type RoutingAcpxSessionMode = "exec" | "session";
 export type RoutingAcpxOutputFormat = "quiet" | "json";
+export type AcpxModelSelection = "acp" | "agent";
+
+export function resolveAcpxModelSelection(agent: string, configured?: AcpxModelSelection): AcpxModelSelection {
+	if (configured) return configured;
+	return agent.trim().toLowerCase() === "opencode" ? "agent" : "acp";
+}
 
 export interface RoutingAcpxConfig {
 	readonly agent: string;
+	readonly modelSelection?: AcpxModelSelection;
 	readonly version?: string;
 	readonly bin?: string;
 	readonly package?: string;
@@ -544,6 +551,10 @@ function asAcpxOutputFormat(value: unknown): RoutingAcpxOutputFormat | undefined
 		: undefined;
 }
 
+function asAcpxModelSelection(value: unknown): AcpxModelSelection | undefined {
+	return typeof value === "string" && ["acp", "agent"].includes(value) ? (value as AcpxModelSelection) : undefined;
+}
+
 function parseAcpxConfig(raw: unknown): RoutingAcpxConfig | undefined {
 	if (!isRecord(raw)) return undefined;
 	const nested = isRecord(raw.acpx) ? raw.acpx : raw;
@@ -553,6 +564,10 @@ function parseAcpxConfig(raw: unknown): RoutingAcpxConfig | undefined {
 	const extraArgs = asStringArray(nested.extraArgs ?? nested.extra_args);
 	return {
 		agent,
+		modelSelection: resolveAcpxModelSelection(
+			agent,
+			asAcpxModelSelection(nested.modelSelection ?? nested.model_selection),
+		),
 		version: asString(nested.version ?? nested.acpxVersion ?? nested.acpx_version),
 		bin: asString(nested.bin ?? nested.command),
 		package: asString(nested.package ?? nested.packageRef ?? nested.package_ref),

--- a/platform/daemon/src/inference-api.test.ts
+++ b/platform/daemon/src/inference-api.test.ts
@@ -839,6 +839,23 @@ describe("inference route hardening", () => {
 			expect(args).toContain("--deny-all");
 			expect(args).toContain("--no-terminal");
 			expect(args.slice(-4)).toEqual(["codex", "exec", "--file", "-"]);
+
+			const statusRes = await app.request(
+				new Request("http://localhost/api/inference/status", {
+					headers: { Authorization: `Bearer ${adminToken}` },
+				}),
+			);
+			expect(statusRes.status).toBe(200);
+			const statusBody = (await statusRes.json()) as {
+				readonly targets?: Record<
+					string,
+					{ readonly acpx?: { readonly agent?: string; readonly modelSelection?: string } }
+				>;
+			};
+			expect(statusBody.targets?.["background-acpx"]?.acpx).toEqual({
+				agent: "codex",
+				modelSelection: "acp",
+			});
 		} finally {
 			resetInferenceRouterForTests();
 			rmSync(root, { recursive: true, force: true });

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type {
+	AcpxModelSelection,
 	LlmGenerateResult,
 	LlmProvider,
 	LlmUsage,
@@ -19,6 +20,7 @@ import {
 	parseRoutingConfig,
 	parseRoutingTargetRef,
 	parseYamlDocument,
+	resolveAcpxModelSelection,
 	resolveRoutingDecision,
 } from "@signet/core";
 import { createRoutingProvider } from "./inference-provider-factory";
@@ -98,6 +100,10 @@ export interface InferenceTargetSummary {
 	readonly account?: string;
 	readonly privacy?: string;
 	readonly models: Readonly<Record<string, { readonly model: string; readonly label?: string }>>;
+	readonly acpx?: {
+		readonly agent: string;
+		readonly modelSelection: AcpxModelSelection;
+	};
 }
 
 export interface InferenceStatusSummary {
@@ -970,6 +976,14 @@ export class InferenceRouter {
 				{
 					kind: target.kind,
 					executor: target.executor,
+					...(target.acpx
+						? {
+								acpx: {
+									agent: target.acpx.agent,
+									modelSelection: resolveAcpxModelSelection(target.acpx.agent, target.acpx.modelSelection),
+								},
+							}
+						: {}),
 					...(target.account ? { account: target.account } : {}),
 					...(target.privacy ? { privacy: target.privacy } : {}),
 					models: Object.fromEntries(

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -99,6 +99,8 @@ printf '  acpx answer  \\n'
 			const args = readFileSync(argsPath, "utf-8").trim().split("\n");
 			expect(args).toContain("--format");
 			expect(args).toContain("quiet");
+			expect(args).toContain("--model");
+			expect(args[args.indexOf("--model") + 1]).toBe("gpt-5.4-mini");
 			expect(args).toContain("--deny-all");
 			expect(args).toContain("--no-terminal");
 			expect(args).toContain("--allowed-tools");
@@ -112,6 +114,45 @@ printf '  acpx answer  \\n'
 		} finally {
 			if (previousSignetPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
 			else process.env.SIGNET_PATH = previousSignetPath;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("lets OpenCode use its native model config unless ACP selection is explicit", async () => {
+		const root = join(tmpdir(), `signet-acpx-opencode-model-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const bin = join(root, "fake-acpx.sh");
+		const argsPath = join(root, "args.txt");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+printf '%s\n' "$@" > ${JSON.stringify(argsPath)}
+cat >/dev/null
+printf 'ok\n'
+`,
+		);
+		chmodSync(bin, 0o755);
+		try {
+			const agentManaged = createAcpxProvider({
+				agent: "opencode",
+				model: "minimax-coding-plan/MiniMax-M3",
+				bin,
+			});
+			await expect(agentManaged.generate("hello", { timeoutMs: 1000 })).resolves.toBe("ok");
+			let args = readFileSync(argsPath, "utf-8").trim().split("\n");
+			expect(args).not.toContain("--model");
+
+			const acpManaged = createAcpxProvider({
+				agent: "opencode",
+				model: "minimax-coding-plan/MiniMax-M3",
+				modelSelection: "acp",
+				bin,
+			});
+			await expect(acpManaged.generate("hello", { timeoutMs: 1000 })).resolves.toBe("ok");
+			args = readFileSync(argsPath, "utf-8").trim().split("\n");
+			expect(args).toContain("--model");
+			expect(args[args.indexOf("--model") + 1]).toBe("minimax-coding-plan/MiniMax-M3");
+		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}
 	});

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -22,12 +22,14 @@ import { mkdirSync, readFileSync, readdirSync } from "node:fs";
 import { isAbsolute, join, resolve as resolvePath } from "node:path";
 import type { ThinkingLevel } from "@earendil-works/pi-ai";
 import {
+	type AcpxModelSelection,
 	DEFAULT_PROVIDER_RATE_LIMIT,
 	type LlmGenerateResult,
 	type LlmProvider,
 	type LlmUsage,
 	type PipelineExtractionConfig,
 	type ProviderRateLimitConfig,
+	resolveAcpxModelSelection,
 	resolveDefaultBasePath,
 } from "@signet/core";
 import { logger } from "../logger";
@@ -644,6 +646,7 @@ export type AcpxJsonEvent = Readonly<Record<string, unknown>>;
 export interface AcpxProviderConfig {
 	readonly agent: string;
 	readonly model?: string;
+	readonly modelSelection?: AcpxModelSelection;
 	readonly version?: string;
 	readonly bin?: string;
 	readonly package?: string;
@@ -732,7 +735,9 @@ function buildAcpxCommand(
 	args.push("--format", resolveAcpxFormat(config));
 	args.push("--timeout", String(Math.max(1, Math.ceil(timeoutMs / 1000))));
 	if (cwd) args.push("--cwd", cwd);
-	if (config.model) args.push("--model", config.model);
+	if (config.model && resolveAcpxModelSelection(config.agent, config.modelSelection) === "acp") {
+		args.push("--model", config.model);
+	}
 	args.push(...acpxPermissionArgs(config.permissions));
 	if (config.terminal === "disabled") args.push("--no-terminal");
 	if (allowedTools) args.push("--allowed-tools", allowedTools.join(","));

--- a/surfaces/cli/src/commands/route.test.ts
+++ b/surfaces/cli/src/commands/route.test.ts
@@ -237,4 +237,58 @@ describe("registerRouteCommands", () => {
 		expect(yaml).toContain("pinnedTargets:");
 		expect(yaml).toContain("default: primary/fast");
 	});
+
+	test("route doctor warns when an ACPX target relies on agent-managed model selection", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-route-command-"));
+		tempDirs.push(dir);
+		const lines: string[] = [];
+		const previousExitCode = process.exitCode;
+		process.exitCode = undefined;
+		console.log = (line?: unknown) => {
+			lines.push(String(line ?? ""));
+		};
+		const program = new Command();
+		registerRouteCommands(program, {
+			AGENTS_DIR: dir,
+			fetchFromDaemon: async () => ({
+				enabled: true,
+				source: "explicit",
+				defaultAgentId: "default",
+				policies: [],
+				taskClasses: [],
+				targetRefs: ["opencode-background/default"],
+				workloadBindings: {},
+				accounts: {},
+				targets: {
+					"opencode-background": {
+						kind: "subscription_session",
+						executor: "acpx",
+						models: { default: { model: "minimax-coding-plan/MiniMax-M3" } },
+						acpx: { agent: "opencode", modelSelection: "agent" },
+					},
+				},
+				agents: ["default"],
+				runtimeSnapshot: {
+					targets: {
+						"opencode-background/default": {
+							available: true,
+							health: "healthy",
+							accountState: "ready",
+						},
+					},
+				},
+			}),
+			secretApiCall: async () => ({ ok: false, data: null }),
+		});
+
+		try {
+			await program.parseAsync(["node", "test", "route", "doctor"]);
+
+			expect(lines.join("\n")).toContain("model selection is agent-managed for opencode");
+			expect(lines.join("\n")).toContain("verify the agent's native configuration");
+			expect(process.exitCode).toBeUndefined();
+		} finally {
+			process.exitCode = previousExitCode;
+		}
+	});
 });

--- a/surfaces/cli/src/commands/route.ts
+++ b/surfaces/cli/src/commands/route.ts
@@ -43,6 +43,7 @@ interface RouteStatusResponse {
 			readonly account?: string;
 			readonly privacy?: string;
 			readonly models: Record<string, { readonly model: string; readonly label?: string }>;
+			readonly acpx?: { readonly agent: string; readonly modelSelection: "acp" | "agent" };
 		}
 	>;
 	readonly agents: readonly string[];
@@ -256,12 +257,19 @@ export function registerRouteCommands(program: Command, deps: RouteDeps): void {
 				if (!runtime || runtime.available) return [];
 				return [`${targetRef}: ${runtime.unavailableReason ?? runtime.health}`];
 			});
+			const warnings = Object.entries(status.targets).flatMap(([targetId, target]) => {
+				if (target.executor !== "acpx" || target.acpx?.modelSelection !== "agent") return [];
+				return [
+					`${targetId}: ACPX model selection is agent-managed for ${target.acpx.agent}; verify the agent's native configuration matches the routed model`,
+				];
+			});
 			const summary = {
 				enabled: status.enabled,
 				source: status.source,
 				defaultPolicy: status.defaultPolicy ?? null,
 				defaultAgentId: status.defaultAgentId,
 				issues,
+				warnings,
 			};
 			if ((options as { json?: boolean }).json) {
 				console.log(JSON.stringify(summary, null, 2));
@@ -271,15 +279,18 @@ export function registerRouteCommands(program: Command, deps: RouteDeps): void {
 			console.log(chalk.dim(`  Enabled:        ${status.enabled ? "yes" : "no"}`));
 			console.log(chalk.dim(`  Source:         ${status.source}`));
 			console.log(chalk.dim(`  Default policy: ${status.defaultPolicy ?? "-"}`));
-			if (issues.length === 0) {
+			if (issues.length === 0 && warnings.length === 0) {
 				console.log(chalk.green("\n  No broken route targets detected.\n"));
 				return;
+			}
+			for (const warning of warnings) {
+				console.log(chalk.yellow(`  - ${warning}`));
 			}
 			for (const issue of issues) {
 				console.log(chalk.red(`  - ${issue}`));
 			}
 			console.log();
-			process.exitCode = 1;
+			if (issues.length > 0) process.exitCode = 1;
 		});
 	withJson(doctorCmd);
 


### PR DESCRIPTION
## Summary

Adds explicit ACPX model-selection ownership so OpenCode can use its native configured model without Signet forcing unsupported ACP `--model` negotiation. OpenCode defaults to agent-managed selection; other ACP agents retain the existing ACP-managed behavior. Closes #974.

## Changes

- Add validated `modelSelection: acp | agent` routing configuration with one shared resolver and backward-compatible optional typing.
- Default OpenCode to `agent`, omit `--model` in that mode, and preserve explicit `acp` overrides plus existing Codex/Claude behavior.
- Expose effective selection in inference status and add a non-failing route-doctor warning when native agent configuration owns the model.
- Document the behavior and add parser, argv, status API, and CLI doctor regressions.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: ACP integration/configuration docs

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Agent scoping and admin/mutation security are N/A because this change adds no data queries or mutation endpoints. Readiness validation is scoped to changed files and affected packages.

## Migration Notes (if applicable)

No migration or persisted schema change.

- [ ] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Rust parity is N/A because ACPX routing is currently TypeScript-only. Rollback is a normal commit revert; operators can explicitly select either mode in configuration.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Passing scoped verification:

- `bun test platform/core/src/routing.test.ts` — 17 pass, 0 fail
- Focused ACPX provider tests — 2 pass, 0 fail
- `bun test surfaces/cli/src/commands/route.test.ts` — 9 pass, 0 fail
- Focused inference API test — 1 pass, 0 fail
- Biome check on all nine changed TypeScript files
- `bun run --filter '@signet/core' typecheck`
- `bun run --filter '@signet/daemon' build`
- `bun run --filter '@signet/cli' build:workspace-deps` and `build:cli`
- Real ACPX 0.12.0 → OpenCode 1.18.0 → `minimax-coding-plan/MiniMax-M3` returned exactly `PONG` with agent-managed selection

Broader file state:

- Full provider tests: 24 pass, with 3 unrelated macOS fixture failures (`/var` vs `/private/var` and a Linux process-group fixture).
- Full inference API tests include environment-dependent unrelated failures; the changed ACPX execution/status case passes.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Root cause: ACPX 0.12.0 rejects `--model` when the agent does not expose compatible session model metadata. In `agent` mode Signet keeps the routed model in status/provider telemetry but deliberately omits the negotiation flag, leaving model choice to the agent's native configuration. Route doctor warns about that external dependency without marking an otherwise healthy target broken.
