### PR TITLE
fix(embedding): bound llama.cpp inputs

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -93,6 +93,8 @@ embedding:
   dimensions: 768
   base_url: http://localhost:11434
   promptSubmitTimeoutMs: 1000
+  # llama.cpp only: truncate inputs to stay below its physical batch limit
+  llamaCppMaxInputTokens: 1400
 
 search:
   alpha: 0.7

--- a/platform/daemon/src/embedding-fetch.test.ts
+++ b/platform/daemon/src/embedding-fetch.test.ts
@@ -5,6 +5,7 @@ import {
 	setNativeEmbeddingProviderForTest,
 	setNativeFallbackProvider,
 } from "./embedding-fetch";
+import { countTokens } from "./pipeline/tokenizer";
 
 const originalFetch = globalThis.fetch;
 const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
@@ -152,6 +153,26 @@ describe("fetchEmbedding", () => {
 		expect(capturedBody).toContain("nomic-embed-text");
 	});
 
+	it("bounds cached llama.cpp fallback inputs with the configured limit", async () => {
+		let capturedInput = "";
+		globalThis.fetch = mock((_url: string | URL | Request, init?: RequestInit) => {
+			capturedInput = (JSON.parse(String(init?.body)) as { input: string }).input;
+			return Promise.resolve(Response.json({ data: [{ embedding: [0.8, 0.9] }] }));
+		}) as unknown as typeof fetch;
+
+		setNativeFallbackProvider("llama-cpp");
+		const result = await fetchEmbedding("token ".repeat(1000), {
+			provider: "native",
+			model: "nomic-embed-text",
+			dimensions: 2,
+			base_url: "",
+			llamaCppMaxInputTokens: 256,
+		});
+
+		expect(result).toEqual([0.8, 0.9]);
+		expect(countTokens(capturedInput)).toBeLessThanOrEqual(256);
+	});
+
 	it("returns null when llama.cpp fallback provider is set but server unreachable", async () => {
 		globalThis.fetch = mock(() => {
 			return Promise.resolve(new Response("not found", { status: 500 }));
@@ -170,6 +191,7 @@ describe("fetchEmbedding", () => {
 
 	it("falls back to llama.cpp when native fails, skipping ollama", async () => {
 		let capturedUrl: string | undefined;
+		let capturedInput = "";
 		globalThis.fetch = mock((url: string | URL | Request, init?: RequestInit) => {
 			const urlStr = url.toString();
 			if (urlStr.includes("localhost:8080")) {
@@ -177,6 +199,7 @@ describe("fetchEmbedding", () => {
 					return Promise.resolve(Response.json({ data: [{ id: "nomic-embed-text" }] }));
 				}
 				capturedUrl = urlStr;
+				capturedInput = (JSON.parse(String(init?.body)) as { input: string }).input;
 				return Promise.resolve(Response.json({ data: [{ embedding: [0.1, 0.2] }] }));
 			}
 			return Promise.resolve(new Response("unreachable", { status: 503 }));
@@ -186,15 +209,38 @@ describe("fetchEmbedding", () => {
 		setNativeEmbeddingProviderForTest(async () => {
 			throw new Error("native unavailable");
 		});
-		const result = await fetchEmbedding("test", {
+		const result = await fetchEmbedding("token ".repeat(1000), {
 			provider: "native",
 			model: "nomic-embed-text-v1.5",
 			dimensions: 2,
 			base_url: "",
+			llamaCppMaxInputTokens: 300,
 		});
 
 		expect(result).toEqual([0.1, 0.2]);
 		expect(capturedUrl).toContain("localhost:8080");
+		expect(countTokens(capturedInput)).toBeLessThanOrEqual(300);
+	});
+
+	it("bounds configured llama.cpp inputs while preserving short inputs", async () => {
+		const capturedInputs: string[] = [];
+		globalThis.fetch = mock((_url: string | URL | Request, init?: RequestInit) => {
+			capturedInputs.push((JSON.parse(String(init?.body)) as { input: string }).input);
+			return Promise.resolve(Response.json({ data: [{ embedding: [0.1, 0.2] }] }));
+		}) as unknown as typeof fetch;
+		const cfg = {
+			provider: "llama-cpp" as const,
+			model: "nomic-embed-text",
+			dimensions: 2,
+			base_url: "http://localhost:8080",
+			llamaCppMaxInputTokens: 256,
+		};
+
+		await fetchEmbedding("short input", cfg);
+		await fetchEmbedding("token ".repeat(1000), cfg);
+
+		expect(capturedInputs[0]).toBe("short input");
+		expect(countTokens(capturedInputs[1] ?? "")).toBeLessThanOrEqual(256);
 	});
 
 	it("falls back to ollama when both native and llama.cpp fail", async () => {

--- a/platform/daemon/src/embedding-fetch.ts
+++ b/platform/daemon/src/embedding-fetch.ts
@@ -1,6 +1,12 @@
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
-import { DEFAULT_LLAMACPP_BASE_URL, DEFAULT_OLLAMA_BASE_URL, DEFAULT_OPENAI_BASE_URL } from "./memory-config";
+import {
+	DEFAULT_LLAMACPP_BASE_URL,
+	DEFAULT_LLAMACPP_MAX_INPUT_TOKENS,
+	DEFAULT_OLLAMA_BASE_URL,
+	DEFAULT_OPENAI_BASE_URL,
+} from "./memory-config";
+import { countTokens, truncateToTokens } from "./pipeline/tokenizer";
 import { getSecret } from "./secrets.js";
 
 export function resolveOllamaUrl(): string {
@@ -130,6 +136,45 @@ async function fetchOllamaEmbedding(
 	return data.embedding ?? null;
 }
 
+function boundLlamaCppEmbeddingInput(text: string, maxInputTokens: number): string {
+	const tokenCount = countTokens(text);
+	if (tokenCount <= maxInputTokens) return text;
+	logger.warn("embedding", "Truncating llama.cpp embedding input to physical-batch safety limit", {
+		inputTokens: tokenCount,
+		maxInputTokens,
+	});
+	return truncateToTokens(text, maxInputTokens);
+}
+
+async function fetchLlamaCppEmbedding(
+	text: string,
+	baseUrl: string,
+	model: string,
+	opts: EmbeddingFetchOptions,
+	timeoutMs: number,
+	maxInputTokens = DEFAULT_LLAMACPP_MAX_INPUT_TOKENS,
+): Promise<number[] | null> {
+	const res = await fetchWithEmbeddingTimeout(
+		`${baseUrl.replace(/\/$/, "")}/v1/embeddings`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ input: boundLlamaCppEmbeddingInput(text, maxInputTokens), model }),
+		},
+		opts,
+		resolveEmbeddingTimeoutMs(opts, timeoutMs),
+	);
+	if (!res.ok) {
+		logger.warn("embedding", "llama.cpp embedding request failed", {
+			status: res.status,
+			model,
+		});
+		return null;
+	}
+	const data = (await res.json()) as { data?: Array<{ embedding: number[] }> };
+	return data.data?.[0]?.embedding ?? null;
+}
+
 export function resolveEmbeddingBaseUrl(cfg: EmbeddingConfig): string {
 	if (cfg.provider === "openai") {
 		return cfg.base_url.trim() || DEFAULT_OPENAI_BASE_URL;
@@ -174,21 +219,14 @@ export async function fetchEmbedding(
 			}
 			if (nativeFallbackProvider === "llama-cpp") {
 				const fallbackModel = nativeFallbackModel ?? "nomic-embed-text";
-				const llamaCppRes = await fetchWithEmbeddingTimeout(
-					`${DEFAULT_LLAMACPP_BASE_URL.replace(/\/$/, "")}/v1/embeddings`,
-					{
-						method: "POST",
-						headers: { "Content-Type": "application/json" },
-						body: JSON.stringify({ input: text, model: fallbackModel }),
-					},
+				return fetchLlamaCppEmbedding(
+					text,
+					DEFAULT_LLAMACPP_BASE_URL,
+					fallbackModel,
 					opts,
-					resolveEmbeddingTimeoutMs(opts, 5000),
+					5000,
+					cfg.llamaCppMaxInputTokens,
 				);
-				if (llamaCppRes.ok) {
-					const data = (await llamaCppRes.json()) as { data?: Array<{ embedding: number[] }> };
-					if (data.data?.[0]?.embedding) return data.data[0].embedding;
-				}
-				return null;
 			}
 			try {
 				if (!cachedNativeEmbed) {
@@ -208,27 +246,22 @@ export async function fetchEmbedding(
 					if (!discoveredModel) {
 						logger.warn("embedding", "llama.cpp server reachable but no supported embedding model loaded");
 					} else {
-						const llamaCppRes = await fetchWithEmbeddingTimeout(
-							`${DEFAULT_LLAMACPP_BASE_URL.replace(/\/$/, "")}/v1/embeddings`,
-							{
-								method: "POST",
-								headers: { "Content-Type": "application/json" },
-								body: JSON.stringify({ input: text, model: discoveredModel }),
-							},
+						const embedding = await fetchLlamaCppEmbedding(
+							text,
+							DEFAULT_LLAMACPP_BASE_URL,
+							discoveredModel,
 							opts,
-							resolveEmbeddingTimeoutMs(opts, 5000),
+							5000,
+							cfg.llamaCppMaxInputTokens,
 						);
-						if (llamaCppRes.ok) {
+						if (embedding) {
 							nativeFallbackProvider = "llama-cpp";
 							nativeFallbackModel = discoveredModel;
-							const data = (await llamaCppRes.json()) as { data?: Array<{ embedding: number[] }> };
-							if (data.data?.[0]?.embedding) {
-								logger.info(
-									"embedding",
-									`llama.cpp fallback succeeded (model: ${discoveredModel}) — will use llama.cpp for remaining embeddings this session`,
-								);
-								return data.data[0].embedding;
-							}
+							logger.info(
+								"embedding",
+								`llama.cpp fallback succeeded (model: ${discoveredModel}) — will use llama.cpp for remaining embeddings this session`,
+							);
+							return embedding;
 						}
 					}
 				} catch {
@@ -257,25 +290,7 @@ export async function fetchEmbedding(
 
 		if (cfg.provider === "llama-cpp") {
 			const baseUrl = cfg.base_url.trim() || DEFAULT_LLAMACPP_BASE_URL;
-			const res = await fetchWithEmbeddingTimeout(
-				`${baseUrl.replace(/\/$/, "")}/v1/embeddings`,
-				{
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ model: cfg.model, input: text }),
-				},
-				opts,
-				resolveEmbeddingTimeoutMs(opts, 30000),
-			);
-			if (!res.ok) {
-				logger.warn("embedding", "llama.cpp embedding request failed", {
-					status: res.status,
-					model: cfg.model,
-				});
-				return null;
-			}
-			const data = (await res.json()) as { data: Array<{ embedding: number[] }> };
-			return data.data?.[0]?.embedding ?? null;
+			return fetchLlamaCppEmbedding(text, baseUrl, cfg.model, opts, 30000, cfg.llamaCppMaxInputTokens);
 		}
 
 		const apiKey = await resolveEmbeddingApiKey(cfg.api_key);

--- a/platform/daemon/src/memory-config.test.ts
+++ b/platform/daemon/src/memory-config.test.ts
@@ -3,8 +3,11 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	DEFAULT_LLAMACPP_MAX_INPUT_TOKENS,
 	DEFAULT_PIPELINE_V2,
+	MAX_LLAMACPP_MAX_INPUT_TOKENS,
 	MAX_PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS,
+	MIN_LLAMACPP_MAX_INPUT_TOKENS,
 	MIN_PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS,
 	loadMemoryConfig,
 	loadPipelineConfig,
@@ -95,6 +98,7 @@ describe("loadMemoryConfig", () => {
 		expect(cfg.embedding.model).toBe("nomic-embed-text-v1.5");
 		expect(cfg.embedding.dimensions).toBe(768);
 		expect(cfg.embedding.promptSubmitTimeoutMs).toBe(MIN_PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS);
+		expect(cfg.embedding.llamaCppMaxInputTokens).toBe(DEFAULT_LLAMACPP_MAX_INPUT_TOKENS);
 	});
 
 	it("deliberately enables the bounded freshness prior by default and allows opt-out", () => {
@@ -179,6 +183,23 @@ describe("loadMemoryConfig", () => {
 		const highDir = makeTempAgentsDir();
 		writeFileSync(join(highDir, "agent.yaml"), "embedding:\n  provider: ollama\n  promptSubmitTimeoutMs: 999999\n");
 		expect(loadMemoryConfig(highDir).embedding.promptSubmitTimeoutMs).toBe(MAX_PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS);
+	});
+
+	it("loads and clamps the llama.cpp input token limit", () => {
+		const configuredDir = makeTempAgentsDir();
+		writeFileSync(
+			join(configuredDir, "agent.yaml"),
+			"embedding:\n  provider: llama-cpp\n  llamaCppMaxInputTokens: 1800\n",
+		);
+		expect(loadMemoryConfig(configuredDir).embedding.llamaCppMaxInputTokens).toBe(1800);
+
+		const lowDir = makeTempAgentsDir();
+		writeFileSync(join(lowDir, "agent.yaml"), "embedding:\n  llamaCppMaxInputTokens: 1\n");
+		expect(loadMemoryConfig(lowDir).embedding.llamaCppMaxInputTokens).toBe(MIN_LLAMACPP_MAX_INPUT_TOKENS);
+
+		const highDir = makeTempAgentsDir();
+		writeFileSync(join(highDir, "agent.yaml"), "embedding:\n  llamaCppMaxInputTokens: 999999\n");
+		expect(loadMemoryConfig(highDir).embedding.llamaCppMaxInputTokens).toBe(MAX_LLAMACPP_MAX_INPUT_TOKENS);
 	});
 
 	it("respects ollama+nomic-embed-text config without overriding", () => {

--- a/platform/daemon/src/memory-config.ts
+++ b/platform/daemon/src/memory-config.ts
@@ -22,6 +22,7 @@ export interface EmbeddingConfig {
 	base_url: string;
 	api_key?: string;
 	promptSubmitTimeoutMs?: number;
+	llamaCppMaxInputTokens?: number;
 }
 
 export interface MemorySearchConfig {
@@ -271,6 +272,9 @@ export const DEFAULT_PIPELINE_V2: ResolvedPipelineV2Config = {
 
 export const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434";
 export const DEFAULT_LLAMACPP_BASE_URL = "http://localhost:8080";
+export const DEFAULT_LLAMACPP_MAX_INPUT_TOKENS = 1400;
+export const MIN_LLAMACPP_MAX_INPUT_TOKENS = 128;
+export const MAX_LLAMACPP_MAX_INPUT_TOKENS = 131072;
 export const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 export const DEFAULT_PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS = 1000;
 export const MIN_PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS = 1000;
@@ -1122,6 +1126,7 @@ export function loadMemoryConfig(agentsDir: string): ResolvedMemoryConfig {
 			dimensions: 768,
 			base_url: "",
 			promptSubmitTimeoutMs: DEFAULT_PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS,
+			llamaCppMaxInputTokens: DEFAULT_LLAMACPP_MAX_INPUT_TOKENS,
 		},
 		search: {
 			alpha: 0.7,
@@ -1159,6 +1164,12 @@ export function loadMemoryConfig(agentsDir: string): ResolvedMemoryConfig {
 				MIN_PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS,
 				MAX_PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS,
 				defaults.embedding.promptSubmitTimeoutMs ?? DEFAULT_PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS,
+			);
+			defaults.embedding.llamaCppMaxInputTokens = clampPositive(
+				emb.llamaCppMaxInputTokens,
+				MIN_LLAMACPP_MAX_INPUT_TOKENS,
+				MAX_LLAMACPP_MAX_INPUT_TOKENS,
+				defaults.embedding.llamaCppMaxInputTokens ?? DEFAULT_LLAMACPP_MAX_INPUT_TOKENS,
 			);
 
 			if (emb.provider === "none") {


### PR DESCRIPTION
## Summary

Bounds text sent to llama.cpp embeddings so oversized memories cannot exceed the server physical batch or context. The conservative default is configurable and applies consistently to configured, cached-fallback, and newly discovered llama.cpp endpoints. Closes #975.

## Changes

- Route every llama.cpp embedding request through one shared bounded helper while preserving native, Ollama, and OpenAI behavior.
- Add validated `embedding.llamaCppMaxInputTokens` configuration with a conservative 1,400-token default.
- Add direct, cached-fallback, discovery-fallback, short-input, default, and config-bound regressions.
- Document the llama.cpp-specific setting.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: configuration docs

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Agent scoping and admin/mutation security are N/A because this change adds no data queries or endpoints. Changed-file lint, daemon build, focused regressions, the full daemon source suite, live llama.cpp inference, and a running-daemon readiness check pass. The standalone daemon typecheck remains red on existing repository-wide `rootDir` and database typing errors unrelated to this diff.

## Migration Notes (if applicable)

No migration or persisted schema change.

- [ ] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Rust parity is N/A because this provider request path exists only in the TypeScript daemon. The new field is optional and defaults safely, so rollback is a normal commit revert.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Passing verification:

- `bun test platform/daemon/src/embedding-fetch.test.ts platform/daemon/src/memory-config.test.ts` — 113 pass, 0 fail
- `bun test platform/daemon/src` — pass
- Biome check on all changed TypeScript and documentation files
- `bun run --cwd platform/daemon build` — pass
- Live llama.cpp test: 3,001 estimated tokens bounded to 1,400; `nomic-embed-text` returned a 768-dimensional vector
- Temporary clean daemon: `/health/ready` reported llama.cpp available and ready, followed by a clean shutdown

Known baseline:

- `bun run --cwd platform/daemon typecheck` fails on existing repository-wide `rootDir` and database typing errors; no reported error targets the changed files.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Upstream llama.cpp requires pooled embedding inputs without a memory module to fit within one physical micro-batch. Signet now truncates only llama.cpp requests using the shared tokenizer, logs the original token count and applied bound without logging content, and leaves short inputs unchanged.
