### PR TITLE
fix(dreaming): parse JSON after model preambles

### DIFF
--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -500,6 +500,47 @@ describe("dreaming", () => {
 			expect(passes[0]?.status).toBe("failed");
 		});
 
+		it("accepts valid JSON after a reasoning preamble and resets the token counter", async () => {
+			addDreamingTokens(accessor, AGENT, 120_000);
+			seedEntity(db, "ent-1", "Test", "concept");
+			const response = JSON.stringify({ mutations: [], summary: "Reviewed graph after reasoning" });
+			const generate = async () => `Looking at {graph} before deciding...\n${response}\nDone.`;
+
+			const result = await runDreamingPass(accessor, generate, defaultCfg(), "/tmp", AGENT, "incremental");
+
+			expect(result.summary).toBe("Reviewed graph after reasoning");
+			expect(getDreamingState(accessor, AGENT).tokensSinceLastPass).toBe(0);
+		});
+
+		it("accepts fenced JSON after a reasoning preamble", async () => {
+			seedEntity(db, "ent-1", "Test", "concept");
+			const response = JSON.stringify({ mutations: [], summary: "Reviewed fenced result" });
+			const generate = async () => `Looking at the graph...\n\`\`\`json\n${response}\n\`\`\``;
+
+			const result = await runDreamingPass(accessor, generate, defaultCfg(), "/tmp", AGENT, "incremental");
+
+			expect(result.summary).toBe("Reviewed fenced result");
+		});
+
+		it("keeps braces, escaped quotes, and backslashes inside JSON strings balanced", async () => {
+			seedEntity(db, "ent-1", "Test", "concept");
+			const summary = 'Reviewed {draft}, the "quoted" value, and C:\\temp';
+			const response = JSON.stringify({ mutations: [], summary });
+			const generate = async () => `Reasoning first.\n${response}`;
+
+			const result = await runDreamingPass(accessor, generate, defaultCfg(), "/tmp", AGENT, "incremental");
+
+			expect(result.summary).toBe(summary);
+		});
+
+		it("rejects malformed balanced output after a preamble", async () => {
+			seedEntity(db, "ent-1", "Test", "concept");
+			const generate = async () => 'Looking...\n{"mutations": nope, "summary": "broken"}';
+
+			await expect(runDreamingPass(accessor, generate, defaultCfg(), "/tmp", AGENT, "incremental")).rejects.toThrow();
+			expect(getDreamingPasses(accessor, AGENT)[0]?.status).toBe("failed");
+		});
+
 		it("resets token counter after successful pass", async () => {
 			addDreamingTokens(accessor, AGENT, 120_000);
 			seedEntity(db, "ent-1", "Test", "concept");

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -19,6 +19,7 @@ import {
 } from "@signet/core";
 import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
 import { logger } from "../logger";
+import { extractBalancedJsonObjects } from "./extraction";
 import { countTokens } from "./tokenizer";
 
 // ---------------------------------------------------------------------------
@@ -646,21 +647,27 @@ function insertAttr(
 }
 
 function parseDreamingResult(raw: string): DreamingResult {
-	// Strip markdown code fences if present
-	let cleaned = raw.trim();
-	if (cleaned.startsWith("```")) {
-		const first = cleaned.indexOf("\n");
-		const last = cleaned.lastIndexOf("```");
-		if (first > 0 && last > first) {
-			cleaned = cleaned.slice(first + 1, last).trim();
+	const cleaned = raw.trim();
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(cleaned);
+	} catch (rawParseError) {
+		for (const candidate of extractBalancedJsonObjects(cleaned)) {
+			try {
+				parsed = JSON.parse(candidate);
+				break;
+			} catch {
+				// Keep scanning: prose may contain braces before the response object.
+			}
 		}
+		if (parsed === undefined) throw rawParseError;
 	}
 
-	const parsed = JSON.parse(cleaned) as {
+	const result = parsed as {
 		mutations?: unknown[];
 		summary?: string;
 	};
-	const all = Array.isArray(parsed.mutations) ? parsed.mutations : [];
+	const all = Array.isArray(result.mutations) ? result.mutations : [];
 	const mutations = all.filter(isValidMutation);
 	const invalidMutations = all.length - mutations.length;
 	if (invalidMutations > 0) {
@@ -674,7 +681,7 @@ function parseDreamingResult(raw: string): DreamingResult {
 	}
 	return {
 		mutations,
-		summary: typeof parsed.summary === "string" ? parsed.summary : "No summary provided",
+		summary: typeof result.summary === "string" ? result.summary : "No summary provided",
 		tokensConsumed: countTokens(raw),
 		invalidMutations,
 	};


### PR DESCRIPTION
## Summary

Preserves successful dreaming passes when a model emits reasoning prose or a markdown fence before its structured JSON response. Dreaming now finds the first strictly valid balanced JSON object, while malformed output continues to fail and record the pass as failed. Closes #976.

## Changes

- Keep direct `JSON.parse` as the fast path for normal raw JSON responses.
- Reuse the shared string-aware balanced-object scanner after a raw parse failure and strictly parse candidates in response order.
- Preserve existing mutation-shape validation, transactional application, failure recording, and token accounting.
- Add regressions for prose, fenced JSON, decoy braces, escaped strings, malformed payloads, and successful token-counter reset.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Agent scoping, config bounds, admin/mutation security, and API/spec documentation changes are N/A because this is an internal response-parser correction with no new queries, inputs, endpoints, config, or contract changes. Changed-file lint, the focused suite, full daemon source suite, production build, and running-daemon validation pass. Standalone daemon typecheck remains red on existing repository-wide `rootDir` and database typing errors unrelated to this diff.

## Migration Notes (if applicable)

No migration or persisted schema change.

- [ ] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Rust parity is N/A because dreaming consolidation is implemented in the TypeScript daemon. The behavior is backward compatible for raw and fenced JSON; rollback is a normal commit revert.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Passing verification:

- `bun test platform/daemon/src/pipeline/dreaming.test.ts` — 32 pass, 0 fail
- `bun test platform/daemon/src` — pass
- Biome check on both changed TypeScript files
- `bun run --cwd platform/daemon build` — pass
- Temporary clean daemon: `/health/ready` reported ready, followed by a clean shutdown

Known baseline:

- `bun run --cwd platform/daemon typecheck` fails on existing repository-wide `rootDir` and database typing errors; no reported error targets the changed files.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Root cause: `parseDreamingResult()` only removed a markdown fence when it began at character zero, then passed the entire remaining response to `JSON.parse`. Model reasoning such as `Looking...` therefore discarded an otherwise valid and potentially expensive pass. The fallback remains strict JSON parsing and does not repair malformed payloads.