### PR TITLE
fix(pipeline): make maintenance supersession sweep non-fatal without a provider

### DIFF
--- a/platform/daemon/src/pipeline/maintenance-worker.test.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.test.ts
@@ -257,4 +257,34 @@ describe("maintenance-worker", () => {
 		expect(sweepCalled).toBe(true);
 		db.close();
 	});
+
+	it("does not abort the cycle when the inference provider is not initialised", async () => {
+		// Regression: the retroactive supersession sweep called getLlmProvider()
+		// unguarded, which throws when no resolver is set. With the defaults
+		// (graph + feedback + supersession all enabled) this aborted the entire
+		// maintenance cycle, skipping retention, dedup, dead-memory scan, and
+		// feedback telemetry. The sweep must be best-effort/non-fatal.
+		const db = freshDb();
+		const accessor = asAccessor(db);
+		const tracker = createProviderTracker();
+
+		// Dead jobs → non-empty recommendations → exercises the execute branch
+		// where the supersession sweep runs after repairs.
+		for (let i = 0; i < 2; i++) {
+			db.prepare(
+				`INSERT INTO memory_jobs (id, memory_id, job_type, status, attempts, max_attempts, failed_at, created_at, updated_at)
+				 VALUES (?, ?, 'extract', 'dead', 3, 3, ?, ?, ?)`,
+			).run(`dead-noprovider-${i}`, `mem-noprovider-${i}`, now, now, now);
+		}
+
+		const handle = startMaintenanceWorker(accessor, BASE_CFG, tracker, null);
+		handle.stop();
+
+		// No initInferenceProviderResolver() call — emulates a boot where the
+		// provider is not yet wired up. tick() must resolve, not reject.
+		const result = await handle.tick();
+		expect(result.recommendations.length).toBeGreaterThan(0);
+		expect(result.executed.length).toBeGreaterThan(0);
+		db.close();
+	});
 });

--- a/platform/daemon/src/pipeline/maintenance-worker.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.ts
@@ -125,6 +125,35 @@ function getGraphAgentIds(accessor: DbAccessor): readonly string[] {
 	});
 }
 
+/**
+ * Retroactive supersession sweep for a single agent.
+ *
+ * Opportunistic and best-effort: it must never abort the maintenance
+ * cycle. If no inference provider is configured (e.g. the resolver has
+ * not been initialised yet) or the sweep itself fails, the error is
+ * logged and skipped — consistent with the summary-condensation block
+ * below, which is also a non-fatal retroactive LLM pass.
+ */
+async function runSupersessionSweep(accessor: DbAccessor, agentId: string, cfg: PipelineV2Config): Promise<void> {
+	if (!cfg.structural.supersessionSweepEnabled) return;
+	try {
+		const { sweepRetroactiveSupersession } = await import("./supersession");
+		const sweep = await sweepRetroactiveSupersession(accessor, agentId, cfg, getLlmProvider());
+		if (sweep.candidates.length > 0) {
+			logger.info("maintenance", "Supersession sweep", {
+				agentId,
+				superseded: sweep.superseded,
+				proposals: sweep.candidates.length,
+			});
+		}
+	} catch (e) {
+		logger.warn("maintenance", "Supersession sweep skipped (non-fatal)", {
+			agentId,
+			error: e instanceof Error ? e.message : String(e),
+		});
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Execution
 // ---------------------------------------------------------------------------
@@ -236,18 +265,7 @@ export function startMaintenanceWorker(
 					}
 					feedbackPropagatedAttributes += propagateMemoryStatus(accessor, agentId);
 
-					// Retroactive supersession sweep — runs regardless of maintenance health
-					if (cfg.structural.supersessionSweepEnabled) {
-						const { sweepRetroactiveSupersession } = await import("./supersession");
-						const sweep = await sweepRetroactiveSupersession(accessor, agentId, cfg, getLlmProvider());
-						if (sweep.candidates.length > 0) {
-							logger.info("maintenance", "Supersession sweep", {
-								agentId,
-								superseded: sweep.superseded,
-								proposals: sweep.candidates.length,
-							});
-						}
-					}
+					await runSupersessionSweep(accessor, agentId, cfg);
 				}
 				recordFeedbackTelemetry({
 					feedbackDecayedAspects,
@@ -328,19 +346,7 @@ export function startMaintenanceWorker(
 				}
 				feedbackPropagatedAttributes += propagateMemoryStatus(accessor, agentId);
 
-				// Retroactive supersession sweep
-				if (cfg.structural.supersessionSweepEnabled) {
-					const { sweepRetroactiveSupersession } = await import("./supersession");
-					const provider = getLlmProvider();
-					const sweep = await sweepRetroactiveSupersession(accessor, agentId, cfg, provider);
-					if (sweep.candidates.length > 0) {
-						logger.info("maintenance", "Supersession sweep", {
-							agentId,
-							superseded: sweep.superseded,
-							proposals: sweep.candidates.length,
-						});
-					}
-				}
+				await runSupersessionSweep(accessor, agentId, cfg);
 			}
 			recordFeedbackTelemetry({
 				feedbackDecayedAspects,


### PR DESCRIPTION
## Summary

The autonomous maintenance worker aborted its entire cycle whenever the inference provider resolver was not initialised, because two duplicated supersession-sweep blocks called `getLlmProvider()` unguarded. `getLlmProvider()` throws *"Inference provider resolver not initialised"* when no resolver is set.

With the defaults (`graph.enabled` + `feedback.enabled` + `structural.supersessionSweepEnabled` all `true`), this threw on every tick that reached the feedback/supersession section — breaking **6 of 7** `maintenance-worker` tests on `main`, and in production skipping retention, dedup, dead-memory scan, and feedback telemetry whenever the provider was unavailable.

## Changes

- `platform/daemon/src/pipeline/maintenance-worker.ts`
  - Extract a single module-level helper `runSupersessionSweep(accessor, agentId, cfg)` that wraps the sweep in `try/catch` and logs a non-fatal `warn`.
  - Replaces the two duplicated, unguarded supersession blocks (empty-recommendations branch + execute branch) with calls to the helper.
  - Consistent with the adjacent **summary-condensation** block, which is already `try/catch (non-fatal)`. The supersession blocks were the inconsistency.
- `platform/daemon/src/pipeline/maintenance-worker.test.ts`
  - Add regression test *"does not abort the cycle when the inference provider is not initialised"* — exercises the execute branch without an initialised resolver. Fails before the fix (unguarded throw), passes after.

The sweep is opportunistic/retroactive, and `sweepRetroactiveSupersession` already treats the provider as optional (`?: LlmProvider`, used only for the optional semantic-contradiction fallback). Deterministic contradiction detection still runs, so skipping when no provider is configured only defers semantic detection to the next tick — no data loss, no silent swallow (logs `agentId` + error at `warn`).

## Type
- [x] `fix` — bug fix

## Packages affected
- [x] `@signet/daemon`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec touched; N/A beyond confirming no spec describes this sweep as fatal
- [x] Agent scoping verified on all new/changed data queries — no new queries; existing `getGraphAgentIds` threading unchanged
- [x] Input/config validation and bounds checks added — N/A; no new inputs/bounds
- [x] Error handling and fallback paths tested (no silent swallow) — error is logged at `warn` with `agentId` + message, matching the condensation block's pattern
- [x] Security checks applied to admin/mutation endpoints — N/A; no endpoints touched
- [x] Docs updated for API/spec/status changes — N/A; no API/spec/status change
- [x] Regression tests added for each bug fix — added
- [x] Lint/typecheck/tests pass locally — verified (8/8 maintenance-worker; 139 sibling worker tests; 0 new typecheck errors)

## Testing
- [x] `bun test` passes — `maintenance-worker.test.ts` 8/8; sibling pipeline worker tests 139/139
- [x] `bun run typecheck` passes — 0 new errors (423-error pre-existing baseline unchanged on `origin/main`)
- [x] `bun run lint` passes — no new errors (only pre-existing `organizeImports` findings on the import blocks, present on `origin/main`)
- [ ] Tested against running daemon — not required; pure unit-tested pipeline module

## AI disclosure
- [x] AI tools were used (see `Assisted-by: pi:zai/glm-5.2` in commit)

## Notes
Root-cause blame: the supersession sweep + `getLlmProvider()` calls were added in `08787c51` (2026-03-19) without the non-fatal guard the sibling condensation block already had. Pre-existing since release `0.148.5`. Unrelated to the most recent `main` commit (the Astro ClientRouter web fix).