### PR TITLE
fix(pipeline): quiesce background inference on pause

### DIFF
--- a/docs/api/operations.md
+++ b/docs/api/operations.md
@@ -513,9 +513,20 @@ Returns `409` if another pause/resume transition is already running.
   "changed": true,
   "paused": true,
   "file": "/home/user/.agents/agent.yaml",
-  "mode": "paused"
+  "mode": "paused",
+  "quiescence": {
+    "activeAtStart": 1,
+    "aborted": 1,
+    "remaining": 0,
+    "timedOut": false
+  }
 }
 ```
+
+After a successful pause, background extraction, session synthesis (including
+dreaming), and repair inference admission is closed. Active provider calls are
+aborted and boundedly drained before this response. `remaining: 0` confirms
+that no tracked background inference call remains active.
 
 ### POST /api/pipeline/resume
 

--- a/docs/specs/complete/pipeline-pause-control.md
+++ b/docs/specs/complete/pipeline-pause-control.md
@@ -5,6 +5,7 @@ informed_by:
 success_criteria:
   - "Operators can pause extraction work from the CLI or dashboard without losing later backlog processing"
   - "While paused, new memories still persist and queue for later extraction instead of being dropped"
+  - "A successful pause closes background inference admission and aborts or drains every active background provider call"
   - "Resuming restores normal worker startup and backlog draining with no schema migration"
 scope_boundary: "Temporary operator control for background pipeline activity only; does not add schedules, per-stage pausing, or new memory semantics"
 ---
@@ -67,6 +68,12 @@ When `enabled = true` and `paused = true`:
 - do keep retention-only startup behavior
 - do report pipeline mode as `paused`
 
+The live pause transition first closes router admission for extraction,
+summary/synthesis, repair, and dreaming inference. Active calls receive an
+abort signal (including ACPX subprocess trees), and the endpoint does not
+report success until they settle or the bounded quiescence wait expires. The
+response reports the active, aborted, remaining, and timeout counts.
+
 ### C) CLI control
 
 Add:
@@ -123,6 +130,8 @@ pipeline is paused, then drain after resume.
 - `/api/pipeline/status` reports `mode = "paused"` when applicable
 - `/api/pipeline/pause` and `/api/pipeline/resume` expose live operator control
   with structured mutation responses
+- successful pause responses include a `quiescence` result; `remaining = 0`
+  is the observable completion contract
 
 ## 6) Validation and tests
 
@@ -133,3 +142,5 @@ pipeline is paused, then drain after resume.
 - Paused mode reports correctly in status/observability
 - Resume clears the flag and restores normal startup path
 - Dashboard pause/resume helpers surface structured success and error results
+- Router quiescence aborts active background inference, blocks new admission,
+  and prevents an aborted target from spawning a fallback provider

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -46,7 +46,11 @@ import { initFeatureFlags } from "./feature-flags";
 import { writeFileIfChangedAsync } from "./file-sync";
 import { createSignetHttpServer } from "./http-server";
 import { syncAgentWorkspaces } from "./identity-sync";
-import { type InferenceStatusSummary, getOrCreateInferenceRouter } from "./inference-router.js";
+import {
+	type BackgroundInferenceQuiescence,
+	type InferenceStatusSummary,
+	getOrCreateInferenceRouter,
+} from "./inference-router.js";
 import { closeInferenceProviderResolver, getInferenceProvider, initInferenceProviderResolver } from "./llm";
 import { logger } from "./logger";
 import { type ResolvedMemoryConfig, loadMemoryConfig, shouldWarnGraphExtractionWritesDisabled } from "./memory-config";
@@ -1172,8 +1176,9 @@ function clearStructuralBackfillTimer(): void {
 	structuralBackfillTimer = null;
 }
 
-async function stopPipelineRuntime(): Promise<void> {
+async function stopPipelineRuntime(): Promise<BackgroundInferenceQuiescence> {
 	clearStructuralBackfillTimer();
+	const quiescence = await getOrCreateInferenceRouter(AGENTS_DIR).quiesceBackgroundInference();
 
 	if (skillReconcilerHandle) {
 		try {
@@ -1234,11 +1239,16 @@ async function stopPipelineRuntime(): Promise<void> {
 	closeInferenceProviderResolver();
 	stopModelRegistry();
 	invalidateDiagnosticsCache();
+	return quiescence;
 }
 
-async function restartPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?: TelemetryCollector): Promise<void> {
-	await stopPipelineRuntime();
+async function restartPipelineRuntime(
+	memoryCfg: ResolvedMemoryConfig,
+	telemetry?: TelemetryCollector,
+): Promise<BackgroundInferenceQuiescence> {
+	const quiescence = await stopPipelineRuntime();
 	await startPipelineRuntime(memoryCfg, telemetry);
+	return quiescence;
 }
 
 export async function stopDaemonRuntimeForTests(): Promise<void> {
@@ -1327,6 +1337,11 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 	}
 
 	const router = getOrCreateInferenceRouter(AGENTS_DIR);
+	if (pipelinePaused) {
+		await router.quiesceBackgroundInference(0);
+	} else {
+		router.resumeBackgroundInference();
+	}
 	const defaultAgentId = resolveDaemonAgentId();
 	initInferenceProviderResolver((workload) => {
 		switch (workload) {

--- a/platform/daemon/src/inference-router.test.ts
+++ b/platform/daemon/src/inference-router.test.ts
@@ -553,3 +553,99 @@ describe("InferenceRouter legacy API credentials", () => {
 		}
 	});
 });
+
+describe("InferenceRouter background quiescence", () => {
+	it("aborts active routed inference and rejects new work until resumed", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-router-quiescence-"));
+		try {
+			mkdirSync(join(dir, "memory"), { recursive: true });
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`inference:
+  defaultPolicy: background
+  accounts:
+    openrouter-api:
+      kind: api
+      providerFamily: openrouter
+      credentialRef: OPENROUTER_API_KEY
+  targets:
+    background:
+      executor: openrouter
+      account: openrouter-api
+      models:
+        default:
+          model: openai/gpt-4o-mini
+    fallback:
+      executor: openrouter
+      account: openrouter-api
+      models:
+        default:
+          model: openai/gpt-4o-mini
+  policies:
+    background:
+      mode: automatic
+      allow: [background/default, fallback/default]
+      defaultTargets: [background/default, fallback/default]
+  workloads:
+    memoryExtraction:
+      policy: background
+      taskClass: memory_extraction
+`,
+			);
+
+			process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+			let chatRequests = 0;
+			let completeChat = false;
+			let markStarted: (() => void) | undefined;
+			const started = new Promise<void>((resolve) => {
+				markStarted = resolve;
+			});
+			globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+				if (String(input).endsWith("/models")) {
+					return Promise.resolve(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+				}
+				chatRequests += 1;
+				markStarted?.();
+				if (completeChat) return Promise.resolve(openAiSseResponse("resumed answer"));
+				return new Promise<Response>((_resolve, reject) => {
+					if (init?.signal?.aborted) {
+						reject(new DOMException("aborted", "AbortError"));
+						return;
+					}
+					init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), {
+						once: true,
+					});
+				});
+			}) as unknown as typeof fetch;
+
+			const router = getOrCreateInferenceRouter(dir);
+			const active = router.execute({ operation: "memory_extraction", promptPreview: "extract" }, "Extract facts", {
+				timeoutMs: 30_000,
+			});
+			await started;
+
+			expect(await router.quiesceBackgroundInference(1_000)).toEqual({
+				activeAtStart: 1,
+				aborted: 1,
+				remaining: 0,
+				timedOut: false,
+			});
+			expect((await active).ok).toBe(false);
+			expect((await router.execute({ operation: "memory_extraction", promptPreview: "blocked" }, "Must not start")).ok).toBe(
+				false,
+			);
+			expect(chatRequests).toBe(1);
+
+			completeChat = true;
+			router.resumeBackgroundInference();
+			const resumed = await router.execute(
+				{ operation: "memory_extraction", promptPreview: "resumed" },
+				"Start after resume",
+			);
+			expect(resumed.ok).toBe(true);
+			expect(chatRequests).toBe(2);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -38,6 +38,14 @@ const OBSERVED_RATE_LIMIT_TTL_MS = 60_000;
 const OBSERVED_AUTH_TTL_MS = 5 * 60_000;
 const OBSERVED_MISSING_TTL_MS = 60_000;
 const REDACTED_UPSTREAM_DETAIL = "[redacted upstream detail]";
+const BACKGROUND_OPERATIONS = new Set<RoutingOperationKind>(["memory_extraction", "session_synthesis", "repair"]);
+
+export interface BackgroundInferenceQuiescence {
+	readonly activeAtStart: number;
+	readonly aborted: number;
+	readonly remaining: number;
+	readonly timedOut: boolean;
+}
 
 export interface InferenceExecutionAttempt {
 	readonly targetRef: string;
@@ -235,8 +243,63 @@ export class InferenceRouter {
 	private readonly observedTargetState = new Map<string, ObservedRuntimeOverride>();
 	private readonly observedAccountState = new Map<string, ObservedRuntimeOverride>();
 	private providerCacheSignature: string | null = null;
+	private backgroundAdmissionsOpen = true;
+	private readonly activeBackgroundExecutions = new Map<number, AbortController>();
+	private readonly backgroundSettledWaiters = new Set<() => void>();
+	private nextBackgroundExecutionId = 1;
 
 	constructor(private readonly agentsDir: string) {}
+
+	resumeBackgroundInference(): void {
+		this.backgroundAdmissionsOpen = true;
+	}
+
+	async quiesceBackgroundInference(timeoutMs = 5_000): Promise<BackgroundInferenceQuiescence> {
+		this.backgroundAdmissionsOpen = false;
+		const activeAtStart = this.activeBackgroundExecutions.size;
+		for (const controller of this.activeBackgroundExecutions.values()) controller.abort();
+		if (this.activeBackgroundExecutions.size === 0) {
+			return { activeAtStart, aborted: activeAtStart, remaining: 0, timedOut: false };
+		}
+
+		let timeout: ReturnType<typeof setTimeout> | null = null;
+		let timedOut = false;
+		let settledWaiter: (() => void) | null = null;
+		await Promise.race([
+			new Promise<void>((resolve) => {
+				settledWaiter = resolve;
+				this.backgroundSettledWaiters.add(resolve);
+			}),
+			new Promise<void>((resolve) => {
+				timeout = setTimeout(() => {
+					timedOut = true;
+					resolve();
+				}, timeoutMs);
+			}),
+		]);
+		if (timeout) clearTimeout(timeout);
+		if (settledWaiter) this.backgroundSettledWaiters.delete(settledWaiter);
+		return { activeAtStart, aborted: activeAtStart, remaining: this.activeBackgroundExecutions.size, timedOut };
+	}
+
+	private beginBackgroundExecution(
+		operation: RoutingOperationKind,
+	): { readonly id: number; readonly signal: AbortSignal } | null | undefined {
+		if (!BACKGROUND_OPERATIONS.has(operation)) return undefined;
+		if (!this.backgroundAdmissionsOpen) return null;
+		const id = this.nextBackgroundExecutionId++;
+		const controller = new AbortController();
+		this.activeBackgroundExecutions.set(id, controller);
+		return { id, signal: controller.signal };
+	}
+
+	private finishBackgroundExecution(id: number | undefined): void {
+		if (id === undefined) return;
+		this.activeBackgroundExecutions.delete(id);
+		if (this.activeBackgroundExecutions.size !== 0) return;
+		for (const resolve of this.backgroundSettledWaiters) resolve();
+		this.backgroundSettledWaiters.clear();
+	}
 
 	private async loadConfig(): Promise<RouterResult<LoadedRoutingConfig>> {
 		let raw: unknown = {};
@@ -617,6 +680,39 @@ export class InferenceRouter {
 			readonly maxTokens?: number;
 			readonly refresh?: boolean;
 			readonly acpxHooks?: AcpxHooksMode;
+			readonly signal?: AbortSignal;
+			readonly abortSignal?: AbortSignal;
+		},
+	): Promise<RouterResult<InferenceExecutionResult>> {
+		const background = this.beginBackgroundExecution(request.operation);
+		if (background === null) {
+			return {
+				ok: false,
+				error: { code: "execution-failed", message: "Background inference is paused." },
+			};
+		}
+		const callerSignal = opts?.signal ?? opts?.abortSignal;
+		const signal = background
+			? callerSignal
+				? AbortSignal.any([background.signal, callerSignal])
+				: background.signal
+			: callerSignal;
+		try {
+			return await this.executeRouted(request, prompt, { ...opts, signal });
+		} finally {
+			this.finishBackgroundExecution(background?.id);
+		}
+	}
+
+	private async executeRouted(
+		request: RouteRequest,
+		prompt: string,
+		opts?: {
+			readonly timeoutMs?: number;
+			readonly maxTokens?: number;
+			readonly refresh?: boolean;
+			readonly acpxHooks?: AcpxHooksMode;
+			readonly signal?: AbortSignal;
 		},
 	): Promise<RouterResult<InferenceExecutionResult>> {
 		const loaded = await this.loadConfig();
@@ -625,6 +721,7 @@ export class InferenceRouter {
 		if (!decision.ok) return decision;
 		const attempts: InferenceExecutionAttempt[] = [];
 		for (const targetRef of [decision.value.targetRef, ...decision.value.fallbackTargetRefs]) {
+			if (opts?.signal?.aborted) break;
 			const parsed = parseRoutingTargetRef(targetRef);
 			if (!parsed.ok) {
 				attempts.push({
@@ -656,6 +753,7 @@ export class InferenceRouter {
 				const result = await generateWithTracking(provider, prompt, {
 					timeoutMs: opts?.timeoutMs,
 					maxTokens: opts?.maxTokens,
+					signal: opts?.signal,
 					// aggregate_recall is latency-sensitive (the routing engine already
 					// excludes ACPX subprocesses for it). Suppress thinking for the same
 					// reason: thinking tokens would dominate the synthesis budget.
@@ -690,6 +788,7 @@ export class InferenceRouter {
 					durationMs: Date.now() - startedAt,
 					error: message,
 				});
+				if (opts?.signal?.aborted) break;
 			}
 		}
 		return {

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -118,11 +118,15 @@ async function togglePipelinePause(c: Context, paused: boolean): Promise<Respons
 	try {
 		const changed = prev.paused !== paused;
 		const next = changed ? setPipelinePaused(AGENTS_DIR, paused) : prev;
+		let quiescence: Awaited<ReturnType<NonNullable<typeof restartPipelineRuntimeRef>>> | undefined;
 		if (changed) {
 			if (!restartPipelineRuntimeRef) {
 				throw new Error("Pipeline runtime not initialized");
 			}
-			await restartPipelineRuntimeRef(loadMemoryConfig(AGENTS_DIR), telemetryRef);
+			quiescence = await restartPipelineRuntimeRef(loadMemoryConfig(AGENTS_DIR), telemetryRef);
+			if (paused && quiescence.remaining > 0) {
+				throw new Error(`Pipeline pause timed out with ${quiescence.remaining} background inference call(s) still active`);
+			}
 		}
 		const liveCfg = loadMemoryConfig(AGENTS_DIR);
 		return c.json({
@@ -131,6 +135,7 @@ async function togglePipelinePause(c: Context, paused: boolean): Promise<Respons
 			paused: next.paused,
 			file: next.file,
 			mode: readPipelineMode(liveCfg.pipelineV2),
+			...(quiescence ? { quiescence } : {}),
 		});
 	} catch (err) {
 		const { logger } = await import("../logger.js");

--- a/platform/daemon/src/routes/state.ts
+++ b/platform/daemon/src/routes/state.ts
@@ -13,6 +13,7 @@ import { type AuthConfig, AuthRateLimiter, loadOrCreateSecret, parseAuthConfig }
 import { getDbAccessor } from "../db-accessor";
 import { type DiagnosticsOptions, type DiagnosticsReport, createProviderTracker, getDiagnostics } from "../diagnostics";
 import type { EmbeddingTrackerHandle } from "../embedding-tracker";
+import type { BackgroundInferenceQuiescence } from "../inference-router";
 import { logger } from "../logger";
 import { type ResolvedMemoryConfig, loadMemoryConfig } from "../memory-config";
 import { enqueueExtractionJob as enqueueExtractionJobBase } from "../pipeline";
@@ -22,7 +23,7 @@ import type { TelemetryCollector } from "../telemetry";
 import { getUpdateState } from "../update-system";
 
 export let restartPipelineRuntimeRef:
-	| ((memoryCfg: ResolvedMemoryConfig, telemetry?: TelemetryCollector) => Promise<void>)
+	| ((memoryCfg: ResolvedMemoryConfig, telemetry?: TelemetryCollector) => Promise<BackgroundInferenceQuiescence>)
 	| null = null;
 
 // Paths
@@ -518,7 +519,7 @@ function readPipelineMode(cfg: ResolvedMemoryConfig["pipelineV2"]): string {
 export { readPipelineMode };
 
 export function setRestartPipelineRuntime(
-	fn: (memoryCfg: ResolvedMemoryConfig, telemetry?: TelemetryCollector) => Promise<void>,
+	fn: (memoryCfg: ResolvedMemoryConfig, telemetry?: TelemetryCollector) => Promise<BackgroundInferenceQuiescence>,
 ): void {
 	restartPipelineRuntimeRef = fn;
 }


### PR DESCRIPTION
## Summary

Closes #977.

Makes `signet daemon pause` an observable quiescence barrier for background inference. A successful pause now closes background router admission, aborts active extraction/session-synthesis/repair provider calls (including ACPX process trees), waits for bounded settlement, and reports active/aborted/remaining counts.

Root cause: workers supplied cancellation signals, but `InferenceRouter.execute()` discarded them before invoking routed providers. Runtime shutdown also had no shared admission gate, so callbacks could enter new inference while individual workers were stopping; dreaming could wait 30 seconds and then drop its handle while ACPX remained alive.

## Changes

- Add router-wide background inference admission control and active-call tracking.
- Compose worker cancellation with the runtime quiescence signal and stop fallback routing after abort.
- Quiesce the router before worker shutdown; reopen admission only for an unpaused runtime.
- Return bounded quiescence counts from live pause/resume transitions and fail pause success if calls remain active.
- Preserve idempotent pause behavior so repeated pause requests do not restart the runtime.
- Document the pause completion contract and add a regression covering abort, fallback suppression, admission rejection, and resume.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: documentation

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries (N/A: no data queries changed)
- [x] Input/config validation and bounds checks added (bounded 5-second quiescence wait)
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints (existing admin guard retained)
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally (repository-wide baseline is red; details below)

## Migration Notes (if applicable)

N/A — no schema or data migration.

- [ ] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A (JS runtime lifecycle only; Rust daemon has no matching routed-provider lifecycle)
- [x] Rollback / compatibility note included in PR description (removing the commit restores the prior response shape and shutdown behavior; added JSON fields are backward-compatible)

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Passing validation:

- `bun test src/inference-router.test.ts` — 9 passed
- `bun test src/daemon-status.test.ts` — 5 passed
- `bun test src/daemon-refactor.test.ts` — 3 passed
- `bun test src/pipeline/index.test.ts` — 2 passed
- `bun test src/pipeline/dreaming-worker.test.ts` — 2 passed
- `bunx biome lint` on all changed TypeScript files — passed
- `bun run build` in `platform/daemon` — passed (daemon bundles + dashboard production build; existing Svelte accessibility warnings only)
- Running built daemon — first pause returned `remaining: 0`, worker status showed inference workers stopped, idempotent pause did not restart, resume restored controlled-write mode, and SIGINT shutdown exited 0

Repository baseline findings:

- Full daemon suite: 2,144 passed / 7 skipped / 60 failed, then Bun 1.3.14 crashed with exit 133. Failures are unrelated shared-global/environment baseline failures (including `/tmp` vs `/private/tmp` path expectations, package fixture state, and cross-file DB/config contamination). The new quiescence regression passed in this run and all lifecycle-adjacent files pass in isolated processes.
- Standalone daemon typecheck remains red on pre-existing monorepo `rootDir` leakage and broad Bun SQLite typing errors; filtering diagnostics for changed files found no new errors attributable to this change.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

ACPX 0.12 source/distribution behavior was reviewed: it handles termination and escalates child cleanup. Signet's ACPX provider already terminates detached process groups; this fix supplies the cancellation signal that the router previously dropped.
