### PR TITLE
fix(codex): remove invalid hook ownership markers

### DIFF
--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -212,6 +212,11 @@ patching.
 | `~/.codex/hooks.json` | Compatibility lifecycle hooks — SessionStart, UserPromptSubmit, Stop |
 | `~/.codex/skills` | Compatibility symlink to `$SIGNET_WORKSPACE/skills` when plugin support is unavailable |
 
+Generated Codex hook manifests contain only fields from Codex's hook schema.
+Signet identifies its entries by their hook command when reinstalling or
+uninstalling, so unrelated hook groups remain untouched without private metadata
+inside Codex-owned configuration.
+
 ### Native memory bridge
 
 Signet indexes Codex-owned memory artifacts without rewriting them or turning

--- a/integrations/codex/connector/src/config-toml.test.ts
+++ b/integrations/codex/connector/src/config-toml.test.ts
@@ -319,7 +319,7 @@ describe("CodexConnector.install — config.toml MCP registration", () => {
 		expect(content).toContain("[mcp_servers.signet.http_headers]");
 		expect(content).toContain("Authorization = 'Bearer sig_sk_codex_old_secret'");
 
-		delete process.env.SIGNET_API_KEY;
+		Reflect.deleteProperty(process.env, "SIGNET_API_KEY");
 		await connector().install(tempHome);
 
 		content = readFileSync(configPath, "utf-8");
@@ -393,9 +393,19 @@ describe("CodexConnector.install — native plugin bundle", () => {
 			"plugin.json",
 		);
 		const mcpPath = join(codexDir, ".tmp", "signet-plugin-marketplace", "plugins", "signet", ".mcp.json");
+		const pluginHooksPath = join(
+			codexDir,
+			".tmp",
+			"signet-plugin-marketplace",
+			"plugins",
+			"signet",
+			"hooks",
+			"hooks.json",
+		);
 		expect(existsSync(marketplacePath)).toBe(true);
 		expect(existsSync(pluginManifestPath)).toBe(true);
 		expect(existsSync(mcpPath)).toBe(true);
+		expect(codexHookContractErrors(JSON.parse(readFileSync(pluginHooksPath, "utf-8")))).toEqual([]);
 		expect(result.filesWritten).toContain(pluginManifestPath);
 
 		const config = readFileSync(configPath, "utf-8");
@@ -635,10 +645,69 @@ function readHooksJson(): Record<string, unknown> {
 	return JSON.parse(readFileSync(hooksPath, "utf-8"));
 }
 
+const CODEX_HOOK_EVENTS = new Set([
+	"PreToolUse",
+	"PermissionRequest",
+	"PostToolUse",
+	"PreCompact",
+	"PostCompact",
+	"SessionStart",
+	"SessionEnd",
+	"UserPromptSubmit",
+	"SubagentStart",
+	"SubagentStop",
+	"Stop",
+]);
+
+function codexHookContractErrors(value: unknown): string[] {
+	const errors: string[] = [];
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return ["root must be an object"];
+	const root = value as Record<string, unknown>;
+	for (const key of Object.keys(root)) {
+		if (key !== "description" && key !== "hooks") errors.push(`unknown root field: ${key}`);
+	}
+	if (root.description !== undefined && typeof root.description !== "string")
+		errors.push("description must be a string");
+	if (typeof root.hooks !== "object" || root.hooks === null || Array.isArray(root.hooks)) {
+		errors.push("hooks must be an object");
+		return errors;
+	}
+	for (const [event, groups] of Object.entries(root.hooks as Record<string, unknown>)) {
+		if (!CODEX_HOOK_EVENTS.has(event)) errors.push(`unknown hook event: ${event}`);
+		if (!Array.isArray(groups)) {
+			errors.push(`${event} must be an array`);
+			continue;
+		}
+		for (const [groupIndex, group] of groups.entries()) {
+			if (typeof group !== "object" || group === null || Array.isArray(group)) {
+				errors.push(`${event}[${groupIndex}] must be an object`);
+				continue;
+			}
+			const matcherGroup = group as Record<string, unknown>;
+			for (const key of Object.keys(matcherGroup)) {
+				if (key !== "matcher" && key !== "hooks") errors.push(`unknown matcher field: ${event}[${groupIndex}].${key}`);
+			}
+			if (!Array.isArray(matcherGroup.hooks)) errors.push(`${event}[${groupIndex}].hooks must be an array`);
+		}
+	}
+	return errors;
+}
+
 describe("CodexConnector.install — hooks.json schema", () => {
+	test("contract fixture rejects private ownership fields", () => {
+		const errors = codexHookContractErrors({
+			_signet: true,
+			hooks: { SessionStart: [{ _signet: true, hooks: [] }] },
+		});
+
+		expect(errors).toContain("unknown root field: _signet");
+		expect(errors).toContain("unknown matcher field: SessionStart[0]._signet");
+	});
+
 	test("writes hooks under a top-level 'hooks' key with PascalCase event names", async () => {
 		await connector().install(tempHome);
 		const json = readHooksJson();
+		expect(codexHookContractErrors(json)).toEqual([]);
 
 		expect(json.hooks).toBeDefined();
 		expect(typeof json.hooks).toBe("object");
@@ -743,16 +812,16 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		const hooks = json.hooks as Record<string, Record<string, unknown>[]>;
 		const startHandler = ((hooks.SessionStart[0] as Record<string, unknown>).hooks as Record<string, unknown>[])[0];
 
+		expect(codexHookContractErrors(json)).toEqual([]);
 		expect(startHandler.timeout).toBe(20);
 	});
 
-	test("preserves unrelated top-level keys when refreshing only Signet hooks", async () => {
+	test("preserves the schema-supported description when refreshing Signet hooks", async () => {
 		writeFileSync(
 			hooksPath,
 			JSON.stringify({
 				_signet: true,
-				version: 1,
-				metadata: { owner: "third-party" },
+				description: "third-party hooks",
 				hooks: {
 					SessionStart: [
 						{ _signet: true, hooks: [{ type: "command", command: "signet hook session-start -H codex", timeout: 10 }] },
@@ -766,8 +835,9 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		const hooks = json.hooks as Record<string, Record<string, unknown>[]>;
 		const startHandler = ((hooks.SessionStart[0] as Record<string, unknown>).hooks as Record<string, unknown>[])[0];
 
-		expect(json.version).toBe(1);
-		expect(json.metadata).toEqual({ owner: "third-party" });
+		expect(json.description).toBe("third-party hooks");
+		expect(json._signet).toBeUndefined();
+		expect(codexHookContractErrors(json)).toEqual([]);
 		expect(startHandler.timeout).toBe(20);
 	});
 
@@ -793,6 +863,7 @@ describe("CodexConnector.install — hooks.json schema", () => {
 
 		await connector().install(tempHome);
 		const json = readHooksJson();
+		expect(JSON.stringify(json)).not.toContain('"_signet"');
 		const hooks = json.hooks as Record<string, Record<string, unknown>[]>;
 		const startGroups = hooks.SessionStart;
 		const signetHandlers = startGroups.flatMap((group) =>
@@ -862,10 +933,17 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		expect(json.stop).toBeUndefined();
 	});
 
-	test("sets _signet marker", async () => {
+	test("does not serialize private ownership markers", async () => {
 		await connector().install(tempHome);
 		const json = readHooksJson();
-		expect(json._signet).toBe(true);
+		expect(JSON.stringify(json)).not.toContain('"_signet"');
+	});
+
+	test("bundled plugin hooks satisfy the Codex contract", () => {
+		const bundledPath = join(import.meta.dir, "..", "..", "plugin", "plugins", "signet", "hooks", "hooks.json");
+		const bundled = JSON.parse(readFileSync(bundledPath, "utf-8"));
+
+		expect(codexHookContractErrors(bundled)).toEqual([]);
 	});
 
 	test("idempotent: re-running install produces identical hooks.json", async () => {
@@ -900,6 +978,7 @@ describe("CodexConnector.install — hooks.json schema", () => {
 
 		expect(c.isInstalled()).toBe(true);
 		const json = readHooksJson();
+		expect(json._signet).toBeUndefined();
 		const hooks = json.hooks as Record<string, unknown>;
 		expect(hooks.SessionStart).toBeDefined();
 		expect(hooks.UserPromptSubmit).toBeDefined();
@@ -924,6 +1003,7 @@ describe("CodexConnector.install — hooks.json legacy migration", () => {
 		await connector().install(tempHome);
 		const json = readHooksJson();
 
+		expect(codexHookContractErrors(json)).toEqual([]);
 		expect(json.hooks).toBeDefined();
 		expect(json.sessionStart).toBeUndefined();
 		expect(json.userPromptSubmit).toBeUndefined();
@@ -977,7 +1057,7 @@ describe("CodexConnector.uninstall — hooks.json cleanup", () => {
 		const json = readHooksJson();
 		const hooks = json.hooks as Record<string, unknown[]>;
 		(hooks as Record<string, unknown>).PreToolUse = [
-			{ hooks: [{ type: "command", command: "echo pre-tool", timeout: 5 }] },
+			{ _signet: true, hooks: [{ type: "command", command: "echo pre-tool", timeout: 5 }] },
 		];
 		writeFileSync(hooksPath, JSON.stringify(json));
 
@@ -987,6 +1067,7 @@ describe("CodexConnector.uninstall — hooks.json cleanup", () => {
 		const remaining = JSON.parse(readFileSync(hooksPath, "utf-8"));
 		const remHooks = remaining.hooks as Record<string, unknown[]>;
 		expect(remHooks.PreToolUse).toBeDefined();
+		expect(JSON.stringify(remaining)).not.toContain('"_signet"');
 		expect(remHooks.SessionStart).toBeUndefined();
 		expect(remHooks.UserPromptSubmit).toBeUndefined();
 		expect(remHooks.Stop).toBeUndefined();
@@ -994,6 +1075,21 @@ describe("CodexConnector.uninstall — hooks.json cleanup", () => {
 });
 
 describe("CodexConnector.isInstalled", () => {
+	test("does not treat legacy markers on third-party hooks as ownership", () => {
+		writeFileSync(
+			hooksPath,
+			JSON.stringify({
+				hooks: {
+					SessionStart: [
+						{ _signet: true, hooks: [{ type: "command", command: "echo third-party", timeout: 5 }] },
+					],
+				},
+			}),
+		);
+
+		expect(connector().isInstalled()).toBe(false);
+	});
+
 	test("returns true after install", async () => {
 		const c = connector();
 		expect(c.isInstalled()).toBe(false);

--- a/integrations/codex/connector/src/index.ts
+++ b/integrations/codex/connector/src/index.ts
@@ -278,7 +278,6 @@ const CODEX_PROMPT_SUBMIT_GRACE_SECONDS = 2;
 const SESSION_END_TIMEOUT_SECONDS = 30;
 
 interface MatcherGroup {
-	_signet?: boolean;
 	matcher?: string;
 	hooks: HandlerConfig[];
 }
@@ -290,7 +289,7 @@ interface HandlerConfig {
 }
 
 interface HooksFile {
-	_signet?: boolean;
+	description?: string;
 	hooks?: Record<string, MatcherGroup[]>;
 	[key: string]: unknown;
 }
@@ -348,7 +347,6 @@ function withRemoteDaemonEnv(command: string, remoteDaemonUrl: string | null): s
 
 function buildHooksFile(signetArgs: string[], remoteDaemonUrl: string | null = resolveRemoteDaemonUrl()): HooksFile {
 	const cmd = (subcommand: string, secs: number, codexJson = true): MatcherGroup => ({
-		_signet: true,
 		hooks: [
 			{
 				type: "command",
@@ -361,7 +359,6 @@ function buildHooksFile(signetArgs: string[], remoteDaemonUrl: string | null = r
 		],
 	});
 	return {
-		_signet: true,
 		hooks: {
 			SessionStart: [cmd("session-start", resolveCodexSessionStartTimeoutSeconds())],
 			UserPromptSubmit: [cmd("user-prompt-submit", resolveCodexPromptSubmitTimeoutSeconds())],
@@ -382,8 +379,8 @@ function readHooksFile(path: string): HooksFile | null {
 	}
 }
 
-function isSignetOwned(file: HooksFile): boolean {
-	return file._signet === true;
+function hasLegacySignetMarker(file: HooksFile): boolean {
+	return Object.hasOwn(file, "_signet");
 }
 
 function writeHooksFile(path: string, file: HooksFile): void {
@@ -421,7 +418,6 @@ function isSignetHookCommand(cmd: string): boolean {
 
 function isSignetMatcherGroup(group: unknown): boolean {
 	if (typeof group !== "object" || group === null) return false;
-	if ((group as Record<string, unknown>)._signet === true) return true;
 	const hooksArr = (group as Record<string, unknown>).hooks;
 	if (!Array.isArray(hooksArr)) return false;
 	for (const handler of hooksArr) {
@@ -449,14 +445,21 @@ function isLegacySignetMatcherGroup(group: unknown): boolean {
 }
 
 function removeSignetEntries(file: HooksFile): HooksFile {
-	const cleaned: HooksFile = { ...file, hooks: file.hooks ? structuredClone(file.hooks) : undefined };
+	const { _signet: _legacyMarker, ...withoutMarker } = file;
+	const cleaned: HooksFile = { ...withoutMarker, hooks: file.hooks ? structuredClone(file.hooks) : undefined };
 	const events = cleaned.hooks;
 	if (!events || typeof events !== "object") return cleaned;
 
 	for (const key of Object.keys(events)) {
 		const groups = events[key];
 		if (!Array.isArray(groups)) continue;
-		const filtered = groups.filter((g) => !isSignetMatcherGroup(g) && !isLegacySignetMatcherGroup(g));
+		const filtered = groups
+			.filter((g) => !isSignetMatcherGroup(g) && !isLegacySignetMatcherGroup(g))
+			.map((group) => {
+				if (typeof group !== "object" || group === null) return group;
+				const { _signet: _legacyGroupMarker, ...preserved } = group as MatcherGroup & Record<string, unknown>;
+				return preserved as MatcherGroup;
+			});
 		if (filtered.length === 0) {
 			delete events[key];
 		} else {
@@ -465,13 +468,6 @@ function removeSignetEntries(file: HooksFile): HooksFile {
 	}
 
 	if (Object.keys(events).length === 0) cleaned.hooks = undefined;
-
-	const hasSignet = cleaned.hooks
-		? Object.values(cleaned.hooks as Record<string, unknown[]>).some(
-				(groups) => Array.isArray(groups) && groups.some(isSignetMatcherGroup),
-			)
-		: false;
-	if (!hasSignet) cleaned._signet = undefined;
 	return cleaned;
 }
 
@@ -604,9 +600,7 @@ function removeHookTrustState(path: string, entries: readonly HookTrustEntry[]):
 	return true;
 }
 
-function migrateLegacyHooksFile(file: HooksFile, signetArgs: string[]): HooksFile {
-	if (isSignetOwned(file) && file.hooks && Object.keys(file.hooks).length > 0) return file;
-
+function migrateLegacyHooksFile(file: HooksFile): HooksFile {
 	const legacyKeys = ["sessionStart", "userPromptSubmit", "stop"] as const;
 	const hasLegacy = legacyKeys.some(
 		(k) =>
@@ -615,20 +609,9 @@ function migrateLegacyHooksFile(file: HooksFile, signetArgs: string[]): HooksFil
 	);
 	if (!hasLegacy) return file;
 
-	const fresh = buildHooksFile(signetArgs);
-	if (!file.hooks || typeof file.hooks !== "object") {
-		fresh.hooks = { ...fresh.hooks };
-	} else {
-		for (const key of HOOK_EVENT_KEYS) {
-			const existing = (file.hooks as Record<string, unknown[]>)[key];
-			if (!Array.isArray(existing)) continue;
-			const kept = existing.filter((g) => !isSignetMatcherGroup(g) && !isLegacySignetMatcherGroup(g));
-			const ours = fresh.hooks?.[key] ?? [];
-			(fresh.hooks as Record<string, unknown>)[key] = [...kept, ...ours];
-		}
-	}
-	for (const k of legacyKeys) delete (fresh as Record<string, unknown>)[k];
-	return fresh;
+	const migrated = structuredClone(file);
+	for (const key of legacyKeys) delete migrated[key];
+	return migrated;
 }
 
 // ---------------------------------------------------------------------------
@@ -860,12 +843,12 @@ export class CodexConnector extends BaseConnector {
 		const existing = readHooksFile(hooksPath);
 
 		if (existing) {
-			const migrated = migrateLegacyHooksFile(existing, signetArgs);
+			const migrated = migrateLegacyHooksFile(existing);
 			const cleaned = removeSignetEntries(migrated);
 			const hasHooks = cleaned.hooks && Object.keys(cleaned.hooks).length > 0;
 			if (hasHooks) {
 				const signet = buildHooksFile(signetArgs);
-				const merged: HooksFile = { ...cleaned, _signet: true };
+				const merged: HooksFile = { ...cleaned };
 				merged.hooks = { ...(cleaned.hooks as Record<string, MatcherGroup[]>) };
 				for (const key of HOOK_EVENT_KEYS) {
 					const current = merged.hooks[key] ?? [];
@@ -876,7 +859,7 @@ export class CodexConnector extends BaseConnector {
 				warnings.push("Merged Signet hooks into existing hooks.json — existing hooks preserved");
 			} else {
 				const signet = buildHooksFile(signetArgs);
-				writeHooksFile(hooksPath, { ...cleaned, _signet: true, hooks: signet.hooks });
+				writeHooksFile(hooksPath, { ...cleaned, hooks: signet.hooks });
 			}
 		} else {
 			writeHooksFile(hooksPath, buildHooksFile(signetArgs));
@@ -899,7 +882,7 @@ export class CodexConnector extends BaseConnector {
 		const existing = readHooksFile(hooksPath);
 		const hookTrustEntries = existing ? buildHookTrustEntries(hooksPath, existing) : [];
 		if (existing) {
-			const hasMarker = isSignetOwned(existing);
+			const hasMarker = hasLegacySignetMarker(existing);
 			const events = existing.hooks;
 			const hasHandlers =
 				events &&
@@ -909,7 +892,7 @@ export class CodexConnector extends BaseConnector {
 				);
 			if (hasMarker || hasHandlers) {
 				const cleaned = removeSignetEntries(existing);
-				const remaining = Object.keys(cleaned).filter((k) => k !== "_signet" && k !== "hooks");
+				const remaining = Object.keys(cleaned).filter((k) => k !== "hooks");
 				const hooksRemain = cleaned.hooks && Object.keys(cleaned.hooks as Record<string, unknown>).length > 0;
 				if (remaining.length === 0 && !hooksRemain) {
 					rmSync(hooksPath, { force: true });
@@ -1029,7 +1012,7 @@ export class CodexConnector extends BaseConnector {
 		const existing = readHooksFile(hooksPath);
 		const hookTrustEntries = existing ? buildHookTrustEntries(hooksPath, existing) : [];
 		if (existing) {
-			const hasMarker = isSignetOwned(existing);
+			const hasMarker = hasLegacySignetMarker(existing);
 			const events = existing.hooks;
 			const hasHandlers =
 				events &&
@@ -1039,7 +1022,7 @@ export class CodexConnector extends BaseConnector {
 				);
 			if (hasMarker || hasHandlers) {
 				const cleaned = removeSignetEntries(existing);
-				const remaining = Object.keys(cleaned).filter((k) => k !== "_signet" && k !== "hooks");
+				const remaining = Object.keys(cleaned).filter((k) => k !== "hooks");
 				const hooksRemain = cleaned.hooks && Object.keys(cleaned.hooks as Record<string, unknown>).length > 0;
 				if (remaining.length === 0 && !hooksRemain) {
 					rmSync(hooksPath, { force: true });

--- a/integrations/codex/plugin/plugins/signet/hooks/hooks.json
+++ b/integrations/codex/plugin/plugins/signet/hooks/hooks.json
@@ -1,9 +1,7 @@
 {
-  "_signet": true,
   "hooks": {
     "SessionStart": [
       {
-        "_signet": true,
         "hooks": [
           {
             "type": "command",
@@ -15,7 +13,6 @@
     ],
     "UserPromptSubmit": [
       {
-        "_signet": true,
         "hooks": [
           {
             "type": "command",
@@ -27,7 +24,6 @@
     ],
     "Stop": [
       {
-        "_signet": true,
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

Closes #978.

Stops the Codex connector and bundled Signet plugin from writing private `_signet` ownership fields into Codex hook manifests. Codex 0.145.0 rejects the top-level field because its Rust `HooksFile` schema uses `deny_unknown_fields`, which prevents every Signet lifecycle hook from loading.

Ownership is now determined from the existing Signet lifecycle command signatures. Reinstall and uninstall strip legacy marker debris while preserving unrelated hook groups and schema-supported metadata.

## Changes

- Remove `_signet` from generated compatibility hooks, generated native-plugin bundles, and the committed plugin manifest.
- Detect Signet groups structurally from `signet hook session-start`, `user-prompt-submit`, and `session-end` commands, including supported node/shim variants.
- Migrate old marked and lowercase hook files without retaining invalid fields or discarding unrelated schema-valid hooks.
- Add a Codex-derived contract fixture covering generated and bundled manifests, idempotent reinstall, legacy cleanup, structural installed-state detection, and third-party-safe uninstall.
- Document the schema-safe ownership contract for Codex hook manifests.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: Codex bundled plugin and harness documentation

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) (no feature/spec dependency change)
- [x] Agent scoping verified on all new/changed data queries (N/A: no data queries)
- [x] Input/config validation and bounds checks added (N/A: serialized schema fields are narrowed instead)
- [x] Error handling and fallback paths tested (no silent swallow) (legacy migration, reinstall, and uninstall paths)
- [x] Security checks applied to admin/mutation endpoints (N/A: no endpoint changes)
- [x] Docs updated for API/spec/status changes (Codex harness contract documented)
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally (repository-wide baseline is red; scoped checks pass)

## Migration Notes (if applicable)

N/A — no database or persistent application-state migration. Connector reinstall rewrites legacy Codex hook manifests in place.

- [ ] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A (Codex install-time connector/plugin only)
- [x] Rollback / compatibility note included in PR description (reverting restores marker serialization; reinstalling this version removes legacy markers without removing third-party hooks)

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Passing validation:

- `bun test integrations/codex/connector/src/config-toml.test.ts` — 58 passed
- `bun run --cwd integrations/codex/connector typecheck` — passed
- `bun run --cwd integrations/codex/connector build` — passed
- `bunx biome lint` on all changed code/config files — passed
- Codex CLI 0.145.0 isolated smoke — generated marketplace installed successfully; `SessionStart`, `UserPromptSubmit`, and `Stop` each registered and completed in a real `codex exec` session

Repository baseline findings:

- Full `bun test`: 3,145 passed / 47 skipped / 110 failed / 15 errors across 3,302 tests. Failures are unrelated existing cross-suite/environment issues, including stale Rust parity and web-content fixtures, unavailable SQLite vector extension support, global config/database contamination, package fixture assumptions, and one 120-second synthesis timeout. The Codex connector suite passed within the run; the final added ownership regression also passes in the isolated 58-test run.
- Root `bun run typecheck` remains red on existing daemon/core SQLite and monorepo typing errors. The Codex connector package typecheck passes.
- Root `bun run lint` remains red on existing repository formatting drift across untouched package manifests and assets. All changed source/config files pass Biome lint.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Dependency contract proof was checked directly against OpenAI Codex tag `rust-v0.145.0` and current upstream in `codex-rs/config/src/hook_config.rs` plus the plugin loader. `HooksFile` accepts only `description` and `hooks`; matcher groups expose `matcher` and `hooks`. The installed local CLI reports `codex-cli 0.145.0`.

