### PR TITLE
fix(test): stop native embedding smoke child within bun's afterEach budget

### DIFF
--- a/scripts/native-embedding-runtime-smoke.test.ts
+++ b/scripts/native-embedding-runtime-smoke.test.ts
@@ -63,9 +63,16 @@ function floatVector(value: unknown): Float32Array {
 async function stopChild(child: ChildProcessWithoutNullStreams): Promise<void> {
 	if (child.exitCode !== null) return;
 	child.kill("SIGTERM");
+	// Keep the SIGTERM grace window well under bun's default afterEach timeout
+	// (5s). A healthy daemon honors SIGTERM in milliseconds; only a deliberately
+	// wedged child (the isolation test pins it on a blackhole fetch) holds out,
+	// and SIGKILL at 2s is safe on a throwaway process. At 5s the grace window
+	// collided with the hook timeout, so the slowest runner (darwin-arm64)
+	// deterministically reported "a beforeEach/afterEach hook timed out" even
+	// though the test body passed.
 	await Promise.race([
 		new Promise<void>((resolve) => child.once("close", () => resolve())),
-		Bun.sleep(5_000).then(() => {
+		Bun.sleep(2_000).then(() => {
 			if (child.exitCode === null) child.kill("SIGKILL");
 		}),
 	]);


### PR DESCRIPTION
## Summary

The release-gate **Native embedding smoke** job (`darwin-arm64`) failed **deterministically across three consecutive re-runs** with:

> `(fail) compiled native embedding runtime > keeps /health within SLA while the native embedding download is stalled (event-loop isolation)`
> `^ a beforeEach/afterEach hook timed out for this test.`

The test **body passed** — `/health` stayed within SLA. What timed out was the cleanup hook.

## Root cause

`stopChild()` gave the spawned daemon a **5-second SIGTERM grace window** before `SIGKILL`. That collides with **bun's default per-hook timeout (5000ms)**, confirmed via `bun test --help`:

```
--timeout=<val>  Set the per-test timeout in milliseconds, default is 5000.
```

The isolation test deliberately wedges the daemon on a blackhole network fetch, so the child ignores `SIGTERM` for the full 5s grace window. On the slowest runner (`darwin-arm64`) the grace window lost the race against the hook budget every time → reported as a hook timeout even though the product behavior was correct.

## Fix

Lower the SIGTERM grace from `5_000` → `2_000` ms. A healthy daemon honors `SIGTERM` in milliseconds; only the deliberately-wedged child holds out, and `SIGKILL` after 2s is safe on a throwaway process. This leaves 3s of headroom under the 5s hook budget.

```diff
- Bun.sleep(5_000).then(() => { … SIGKILL … })
+ Bun.sleep(2_000).then(() => { … SIGKILL … })
```

## Why this PR, why now

Unrelated to #968 / #990 — neither touches the native binary or this smoke test. The flake **predates both merges**: seen on `main` 2026-07-22T23:27 (run 29966180960) and intermittently before that (it passed once on 29967243885). Surfacing now because the merges kicked off a fresh Nightly Release run that re-tripped it. This makes the release gate reliable rather than requiring re-rolls.

## Type

- [x] `fix`

## Testing

- [x] `bun test scripts/native-embedding-runtime-smoke.test.ts` — compiles, both cases skip cleanly without `SIGNET_NATIVE_EMBEDDING_SMOKE` (no local native binary)
- [x] daemon `typecheck` clean for the file
- [ ] Confirmed green on `darwin-arm64` in CI (this is the actual proof — pending)

## Migration notes

N/A — test-only.

## AI disclosure

- [x] AI tools used (`Assisted-by: pi:claude`)