### PR TITLE
fix(dashboard): provider wall completeness, optional keys, OAuth window

### DIFF
--- a/surfaces/dashboard/src/lib/components/tabs/settings/ConnectProviderDialog.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/ConnectProviderDialog.svelte
@@ -30,6 +30,7 @@ let controller = $state(
 		supportsApiKey,
 		onSaved: onsaved,
 		linkOAuthAccount: linkOAuthAccountForProvider,
+		onNavigate: navigateOAuthWindow,
 	}),
 );
 
@@ -37,18 +38,62 @@ let verifying = $state(false);
 let verifyResult = $state<{ ok: boolean; message: string } | null>(null);
 let otp = $state("");
 let promptInput = $state("");
+// OAuth popup handle. Opened SYNCHRONOUSLY inside the sign-in click (the only
+// way browsers permit window.open), then navigated once the daemon emits the
+// auth URL. The daemon runs a local callback server (e.g. localhost:53692 for
+// Claude, localhost:1455 for Codex); the provider redirects there after login,
+// the daemon captures the code, and the SSE stream emits `connected`.
+let oauthWindow: Window | null = null;
+
+function openOAuthWindow(): boolean {
+	if (oauthWindow && !oauthWindow.closed) return true;
+	// NOTE: do NOT pass noopener — that makes window.open return null (spec),
+	// which would discard the handle and leave the popup stranded on about:blank.
+	// We need the handle to navigate the popup to the auth URL once it arrives.
+	oauthWindow = window.open("about:blank", "signet-oauth", "width=640,height=760");
+	if (!oauthWindow) {
+		// Popup blocker prevented the window. The UI still renders a clickable
+		// link when the URL arrives, so the user can open it manually.
+		oauthWindow = null;
+		return false;
+	}
+	return true;
+}
+
+function navigateOAuthWindow(url: string): void {
+	if (!oauthWindow || oauthWindow.closed) return;
+	try {
+		oauthWindow.location.href = url;
+	} catch {
+		// Cross-origin guard — can happen briefly on some browsers; the clickable
+		// link in the dialog is the fallback.
+	}
+}
+
+function closeOAuthWindow(): void {
+	if (oauthWindow && !oauthWindow.closed) {
+		try {
+			oauthWindow.close();
+		} catch {
+			/* ignore */
+		}
+	}
+	oauthWindow = null;
+}
 
 const format = apiKeyFormat(provider.id);
 const phase = $derived(controller.phase);
 
 onMount(() => {
-	// Auto-start when there's exactly one path (no method screen needed).
+	// Only auto-enter API-key mode (no window needed). OAuth is NEVER auto-
+	// started: window.open must run inside a real user gesture (the Sign in
+	// click), which onMount is not, so the popup would be blocked.
 	const path = controller.singlePath;
-	if (path === "oauth") controller.startOAuth();
-	else if (path === "key") controller.enterKeyMode();
+	if (path === "key") controller.enterKeyMode();
 });
 
 onDestroy(() => {
+	closeOAuthWindow();
 	controller.dispose();
 });
 
@@ -59,9 +104,24 @@ function handleKeydown(e: KeyboardEvent): void {
 }
 
 function handleClose(): void {
+	closeOAuthWindow();
 	controller.dispose();
 	onclose();
 }
+
+// Sign-in entry point: open the browser window FIRST (synchronously, inside
+// the click) so the popup is allowed, then start the daemon-side OAuth flow;
+// when the auth URL arrives it navigates the already-open window.
+function beginSignIn(): void {
+	openOAuthWindow();
+	controller.startOAuth();
+}
+
+// Close the popup once OAuth resolves (connected/error/cancel). Kept as an
+// effect so every exit path is covered without scattering closeOAuthWindow().
+$effect(() => {
+	if (phase.kind !== "oauth-running") closeOAuthWindow();
+});
 
 function linkAccountForApiKey(): void {
 	// Wire inference.accounts.<provider> as a key-bearing API account so the
@@ -207,7 +267,7 @@ function safeHref(uri: string | undefined): string | null {
 				<p class="lede">Choose how to connect {provider.name}.</p>
 				<div class="method-list">
 					{#if supportsOAuth}
-						<button class="method-card" onclick={() => controller.startOAuth()}>
+						<button class="method-card" onclick={() => beginSignIn()}>
 							<div class="method-icon"><RefreshCw class="size-4" /></div>
 							<div class="method-text">
 								<span class="method-label">Sign in</span>

--- a/surfaces/dashboard/src/lib/components/tabs/settings/InferenceSection.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/InferenceSection.svelte
@@ -55,20 +55,38 @@ $effect(() => {
 // these only through their OAuth login.
 const OAUTH_ONLY_PROVIDERS = new Set(["openai-codex", "github-copilot"]);
 
-// Curated featured set shown in the wall, in display order. Intersected with
-// the live catalog so a provider missing from the installed pi-ai build never
-// appears. Each entry maps the pi-ai provider family to a friendly name.
-const FEATURED: ReadonlyArray<{ id: string; name: string }> = [
-	{ id: "anthropic", name: "Anthropic (Claude)" },
-	{ id: "openai-codex", name: "ChatGPT / Codex" },
-	{ id: "github-copilot", name: "GitHub Copilot" },
-	{ id: "openrouter", name: "OpenRouter" },
-	{ id: "openai", name: "OpenAI" },
-	{ id: "google", name: "Google (Gemini)" },
-	{ id: "xai", name: "xAI (Grok)" },
-	{ id: "groq", name: "Groq" },
-	{ id: "mistral", name: "Mistral" },
-	{ id: "deepseek", name: "DeepSeek" },
+// Friendly names for known provider families. Anything not listed falls back to
+// a title-cased id. The wall is built from the LIVE catalog, not this list, so a
+// provider added upstream (e.g. zai, kimi-coding) shows up without a dashboard
+// change — this map only controls display name + ordering.
+const PROVIDER_NAMES: Record<string, string> = {
+	anthropic: "Anthropic (Claude)",
+	"openai-codex": "ChatGPT / Codex",
+	"github-copilot": "GitHub Copilot",
+	openrouter: "OpenRouter",
+	openai: "OpenAI",
+	google: "Google (Gemini)",
+	xai: "xAI (Grok)",
+	groq: "Groq",
+	mistral: "Mistral",
+	deepseek: "DeepSeek",
+	zai: "ZAI",
+	"zai-coding-cn": "ZAI Coding (CN)",
+};
+// Known providers float to the top in this order; everything else sorts after.
+const FEATURED_ORDER = [
+	"anthropic",
+	"openai-codex",
+	"github-copilot",
+	"openrouter",
+	"openai",
+	"google",
+	"xai",
+	"groq",
+	"mistral",
+	"deepseek",
+	"zai",
+	"zai-coding-cn",
 ];
 
 interface ConnectableProvider {
@@ -82,19 +100,44 @@ interface ConnectableProvider {
 
 let connecting = $state<{ provider: ConnectableProvider } | null>(null);
 
+function titleCase(id: string): string {
+	return id
+		.replace(/[-_]/g, " ")
+		.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 function connectableProviders(): ConnectableProvider[] {
 	if (!catalog) return [];
-	const oauthIds = new Set(catalog.oauthProviders.map((p) => p.id));
-	const catalogIds = new Set(catalog.providers);
-	const oauthStatus = new Map(catalog.oauthProviders.map((p) => [p.id, p] as const));
-	return FEATURED.filter((f) => oauthIds.has(f.id) || catalogIds.has(f.id)).map((f) => {
-		const supportsOAuth = oauthIds.has(f.id);
-		const isOAuthOnly = OAUTH_ONLY_PROVIDERS.has(f.id);
-		const supportsApiKey = catalogIds.has(f.id) && !isOAuthOnly;
+	const cat = catalog;
+	const oauthIds = new Set(cat.oauthProviders.map((p) => p.id));
+	const oauthStatus = new Map(cat.oauthProviders.map((p) => [p.id, p] as const));
+	// Every provider the catalog knows about is connectable — no hand-picked allowlist.
+	// A provider is "connectable" if it's in the model catalog OR it's an OAuth provider.
+	const allIds = new Set<string>([...cat.providers, ...oauthIds]);
+	const sortedIds = [...allIds].sort((a, b) => {
+		const ia = FEATURED_ORDER.indexOf(a);
+		const ib = FEATURED_ORDER.indexOf(b);
+		if (ia !== -1 && ib !== -1) return ia - ib;
+		if (ia !== -1) return -1;
+		if (ib !== -1) return 1;
+		return a.localeCompare(b);
+	});
+	return sortedIds.map((id) => {
+		const supportsOAuth = oauthIds.has(id);
+		const isOAuthOnly = OAUTH_ONLY_PROVIDERS.has(id);
+		// API-key path needs model entries (the catalog maps provider→models).
+		const supportsApiKey = cat.providers.includes(id) && !isOAuthOnly;
 		const connected = supportsOAuth
-			? (oauthStatus.get(f.id)?.connected ?? false) || hasApiKeyAccount(f.id)
-			: hasApiKeyAccount(f.id);
-		return { id: f.id, name: f.name, supportsOAuth, supportsApiKey, connected, isOAuth: supportsOAuth };
+			? (oauthStatus.get(id)?.connected ?? false) || hasApiKeyAccount(id)
+			: hasApiKeyAccount(id);
+		return {
+			id,
+			name: PROVIDER_NAMES[id] ?? titleCase(id),
+			supportsOAuth,
+			supportsApiKey,
+			connected,
+			isOAuth: supportsOAuth,
+		};
 	});
 }
 
@@ -157,18 +200,21 @@ function providerFamilyForExecutor(exec: string): string {
 	return "openai";
 }
 
-function isLocalEndpoint(endpoint: string): boolean {
-	if (!endpoint) return true;
-	try {
-		return ["127.0.0.1", "localhost", "::1", "[::1]"].includes(new URL(endpoint).hostname);
-	} catch {
-		return false;
-	}
+// Executors that REQUIRE an API key / account to function at all.
+function executorRequiresAccount(exec: string): boolean {
+	return exec === "anthropic" || exec === "openrouter";
 }
-function targetNeedsAccount(exec: string, endpoint: string): boolean {
-	if (exec === "anthropic" || exec === "openrouter") return true;
-	if (exec === "openai-compatible") return !isLocalEndpoint(endpoint);
-	return false;
+// openai-compatible MAY take an optional key (local servers are keyless by
+// default; remote gateways may want one but it's not enforced).
+function executorAllowsOptionalKey(exec: string): boolean {
+	return exec === "openai-compatible";
+}
+
+// Conventional secret name for a provider family (used only as the placeholder
+// hint — never hardcode ANTHROPIC_API_KEY for every provider).
+function secretNameFor(exec: string): string {
+	const family = providerFamilyForExecutor(exec);
+	return `${family.replace(/-/g, "_").toUpperCase()}_API_KEY`;
 }
 
 function ensureAccount(accountName: string, executor: string): void {
@@ -198,8 +244,17 @@ function writeTarget(opts: {
 	}
 	st.aSetStr([...targetBase, "executor"], executor);
 	st.aSetStr([...workloadBase, "target"], `${targetName}/default`);
-	const endpoint = st.aStr([...targetBase, "endpoint"]);
-	if (!targetNeedsAccount(executor, endpoint)) {
+	const hasKey = !!st.aStr([...accountBase, "credentialRef"]);
+	// Account linkage rule:
+	//  - anthropic/openrouter: always need an account (key required).
+	//  - openai-compatible: link an account only when a key is present (optional
+	//    key — keyless local servers stay account-free).
+	//  - ollama/llama-cpp/acpx: never need an account — drop it even if a stale
+	//    key lingers from a prior executor, so a key isn't injected into a
+	//    keyless provider. executorAllowsOptionalKey gates the keep-on-hasKey
+	//    behavior so only the optional-key executor honors a leftover key.
+	const needsAccount = executorRequiresAccount(executor) || (executorAllowsOptionalKey(executor) && hasKey);
+	if (!needsAccount) {
 		st.aDel([...targetBase, "account"]);
 		st.aDel(accountBase);
 	} else {
@@ -233,8 +288,19 @@ function bgApiKey(): string {
 	return st.aStr(["inference", "accounts", ACCOUNT_NAME, "credentialRef"]);
 }
 function bgSetApiKey(v: string): void {
-	st.aSetStr(["inference", "accounts", ACCOUNT_NAME, "credentialRef"], v);
-	if (v) ensureAccount(ACCOUNT_NAME, bgExecutor());
+	const targetBase = ["inference", "targets", TARGET_NAME];
+	const accountBase = ["inference", "accounts", ACCOUNT_NAME];
+	st.aSetStr([...accountBase, "credentialRef"], v);
+	if (v) {
+		// A key was provided: ensure the account shape + link it to the target
+		// (even for local openai-compatible, which is otherwise keyless).
+		ensureAccount(ACCOUNT_NAME, bgExecutor());
+		st.aSetStr([...targetBase, "account"], ACCOUNT_NAME);
+	} else if (bgExecutor() === "openai-compatible") {
+		// Optional key removed on a keyless-capable executor: drop the account.
+		st.aDel([...targetBase, "account"]);
+		st.aDel(accountBase);
+	}
 }
 
 function bgModelOptions(): Array<{ value: string; label: string }> {
@@ -268,8 +334,16 @@ function aggApiKey(): string {
 	return st.aStr(["inference", "accounts", AGG_ACCOUNT_NAME, "credentialRef"]);
 }
 function aggSetApiKey(v: string): void {
-	st.aSetStr(["inference", "accounts", AGG_ACCOUNT_NAME, "credentialRef"], v);
-	if (v) ensureAccount(AGG_ACCOUNT_NAME, aggExecutor());
+	const targetBase = ["inference", "targets", AGG_TARGET_NAME];
+	const accountBase = ["inference", "accounts", AGG_ACCOUNT_NAME];
+	st.aSetStr([...accountBase, "credentialRef"], v);
+	if (v) {
+		ensureAccount(AGG_ACCOUNT_NAME, aggExecutor());
+		st.aSetStr([...targetBase, "account"], AGG_ACCOUNT_NAME);
+	} else if (aggExecutor() === "openai-compatible") {
+		st.aDel([...targetBase, "account"]);
+		st.aDel(accountBase);
+	}
 }
 function aggModelOptions(): Array<{ value: string; label: string }> {
 	if (!catalog) return [];
@@ -277,10 +351,12 @@ function aggModelOptions(): Array<{ value: string; label: string }> {
 	return (catalog.models[family] ?? []).map((m) => ({ value: m.id, label: `${m.name} (${m.id})` }));
 }
 const aggIsLocal = $derived(["openai-compatible", "ollama", "llama-cpp"].includes(aggExecutor()));
+// #3: openai-compatible aggregation shows an OPTIONAL key field always (local
+// servers stay keyless, but the field is there for gateways that need auth).
 const aggNeedsApiKey = $derived(
 	aggExecutor() === "anthropic" ||
 	aggExecutor() === "openrouter" ||
-	(aggExecutor() === "openai-compatible" && !isLocalEndpoint(aggEndpoint())),
+	aggExecutor() === "openai-compatible",
 );
 
 const EMBEDDING_PROVIDER_OPTIONS = [
@@ -314,10 +390,11 @@ function embSetEndpoint(v: string): void {
 }
 
 const isLocalExecutor = $derived(["openai-compatible", "ollama", "llama-cpp"].includes(bgExecutor()));
+// #3: openai-compatible background also shows an optional key field always.
 const needsApiKey = $derived(
 	bgExecutor() === "anthropic" ||
 	bgExecutor() === "openrouter" ||
-	(bgExecutor() === "openai-compatible" && !isLocalEndpoint(bgEndpoint())),
+	bgExecutor() === "openai-compatible",
 );
 const embNonNative = $derived(embProvider() && embProvider() !== "native" && embProvider() !== "");
 </script>
@@ -453,12 +530,12 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 			{#if needsApiKey}
 				<SettingRow
 					title="API key (secret name)"
-					description="The Signet secret holding the key, e.g. ANTHROPIC_API_KEY. Or connect via the Providers panel above to skip this. The key value is never shown."
+				description="The Signet secret holding the key. Or connect via the Providers panel above to skip this. The key value is never shown."
 				>
 					<Input
 						class={inputClass}
 						value={bgApiKey()}
-						placeholder="ANTHROPIC_API_KEY"
+						placeholder={secretNameFor(bgExecutor())}
 						oninput={(e) => bgSetApiKey(e.currentTarget.value)}
 					/>
 				</SettingRow>
@@ -536,7 +613,7 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 					<Input
 						class={inputClass}
 						value={aggApiKey()}
-						placeholder="ANTHROPIC_API_KEY"
+						placeholder={secretNameFor(aggExecutor())}
 						oninput={(e) => aggSetApiKey(e.currentTarget.value)}
 					/>
 				</SettingRow>

--- a/surfaces/dashboard/src/lib/components/tabs/settings/connect-provider.svelte.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/connect-provider.svelte.ts
@@ -48,6 +48,12 @@ export interface ConnectOptions {
 	/** Called when an OAuth login completes so the caller can write the
 	 * `subscription_session` account entry the router resolves against. */
 	readonly linkOAuthAccount?: () => void;
+	/** Fired when the daemon emits a URL the user must open in their browser
+	 * (the OAuth auth URL, OR a device-code verification URL). The caller uses it
+	 * to navigate a popup window it opened synchronously in the user gesture —
+	 * browsers block window.open outside a click, so the window must already
+	 * exist when this (async) URL arrives. */
+	onNavigate?: (url: string) => void;
 }
 
 export class ConnectProviderController {
@@ -59,6 +65,7 @@ export class ConnectProviderController {
 	private readonly supportsApiKey: boolean;
 	private readonly onSaved?: () => void | Promise<void>;
 	private readonly linkOAuthAccount?: () => void;
+	private readonly onNavigate?: (url: string) => void;
 	private login: Awaited<ReturnType<typeof startOAuthLogin>> | null = null;
 
 	constructor(opts: ConnectOptions) {
@@ -68,6 +75,7 @@ export class ConnectProviderController {
 		this.supportsApiKey = opts.supportsApiKey;
 		this.onSaved = opts.onSaved;
 		this.linkOAuthAccount = opts.linkOAuthAccount;
+		this.onNavigate = opts.onNavigate;
 	}
 
 	/** True when only one path exists — the dialog can auto-start it. */
@@ -102,10 +110,12 @@ export class ConnectProviderController {
 			switch (event.type) {
 				case "auth":
 					url = event.url;
+					this.onNavigate?.(event.url);
 					this.phase = { kind: "oauth-running", url, deviceCode, progress, prompt };
 					break;
 				case "device_code":
 					deviceCode = { userCode: event.userCode, verificationUri: event.verificationUri };
+					this.onNavigate?.(event.verificationUri);
 					this.phase = { kind: "oauth-running", url, deviceCode, progress, prompt };
 					break;
 				case "prompt":


### PR DESCRIPTION
## Summary

Four issues surfaced during live testing of the connect UI (#968).

1. **zai missing from the provider wall.** The wall was a hardcoded list; any provider the daemon's catalog knew about but the dashboard didn't list was invisible. Now built from the **live catalog** (every provider), with a name map only controlling display name + ordering. zai, zai-coding-cn, and any future provider appear automatically.

2. **Aggregation OpenRouter showed "ANTHROPIC_API_KEY".** Hardcoded placeholder/description for every provider. Now derives from the chosen executor (`OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, etc.).

3. **openai-compatible aggregation key was hidden for local endpoints.** Now always shown (optional) for both background and aggregation. Account-linking rewritten with a clean rule: anthropic/openrouter always need an account; openai-compatible links one only when a key is present; ollama/llama-cpp/acpx never. Fixes an orphan where switching a keyed local openai-compatible target to ollama left a bogus `credentialRef`.

4. **OAuth login never opened a browser window** — only rendered a clickable link. Now opens the popup **synchronously in the click** (browsers require a user gesture for `window.open`), then navigates it when the daemon emits the auth/device-code URL. Verified the daemon's OAuth stream emits the real provider URL end-to-end.

## What's verified

- Dashboard `build` + `svelte-check` clean for all changed files
- 6 key-validation tests pass
- Daemon OAuth stream traced against the running instance: `session` → `auth` (real Claude URL with `localhost:53692/callback`) → `manual_code`
- Adversarial review caught a critical bug (window.open with `noopener` returns null per spec → handle discarded → popup stranded); fixed before push

## What needs your eyes

#4's backend is proven working and the window-open fix is spec-correct, but I have no browser binary in this environment to do a real click-through. The remaining proof is: click Sign in on Claude/Codex/Copilot and confirm the browser window opens to the provider login.

## Type

- [x] `fix`

## AI disclosure

- [x] AI tools used (`Assisted-by: pi:claude`)