### PR TITLE
fix(embedding): harden native WASM inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Surface summary of the most recent release dates. See the release ledger below f
 
 ### 2026-07-23
 - Features: inference settings density + hierarchy refactor; select connected providers as backends + compact rows.
-- Bug fixes: quiesce background inference on pause; harden sterile OpenCode inference; provider wall completeness, optional keys, OAuth window; support agent-managed models; parse JSON after model preambles; bound llama.cpp inputs; remove invalid hook ownership markers; stop native embedding smoke child within bun's afterEach budget; integrate pi-ai OAuth providers; make maintenance supersession sweep non-fatal without a provider; enable Astro ClientRouter for client-side navigation.
+- Bug fixes: prevent native ONNX embedding hangs and repeated fallback probes; quiesce background inference on pause; harden sterile OpenCode inference; provider wall completeness, optional keys, OAuth window; support agent-managed models; parse JSON after model preambles; bound llama.cpp inputs; remove invalid hook ownership markers; stop native embedding smoke child within bun's afterEach budget; integrate pi-ai OAuth providers; make maintenance supersession sweep non-fatal without a provider; enable Astro ClientRouter for client-side navigation.
 - Docs: update roadmap to reflect current priorities (dashboard, desktop, config UX).
 
 ### 2026-07-22

--- a/docs/api/memory.md
+++ b/docs/api/memory.md
@@ -943,6 +943,10 @@ Check the configured embedding provider's availability. Results are cached for
 ```
 
 On failure, `available` is `false` and `error` contains a description.
+If a native inference call times out, Signet disables that native worker for
+the rest of the daemon session and reports it unavailable here. Signet probes
+local llama.cpp and Ollama fallbacks once; when neither is ready, later
+embedding requests degrade without repeating those probes.
 
 ### GET /api/embeddings/health
 

--- a/platform/daemon/src/embedding-fetch.test.ts
+++ b/platform/daemon/src/embedding-fetch.test.ts
@@ -272,6 +272,40 @@ describe("fetchEmbedding", () => {
 		expect(capturedUrl).toContain("localhost:11434");
 	});
 
+	it("single-flights failed local fallback discovery and negative-caches the result", async () => {
+		let nativeCalls = 0;
+		let llamaModelProbes = 0;
+		let ollamaProbes = 0;
+		globalThis.fetch = mock((url: string | URL | Request) => {
+			const value = url.toString();
+			if (value.includes("/v1/models")) llamaModelProbes++;
+			if (value.includes("/api/embeddings")) ollamaProbes++;
+			return Promise.resolve(new Response("unreachable", { status: 503 }));
+		}) as unknown as typeof fetch;
+
+		setNativeEmbeddingProviderForTest(async () => {
+			nativeCalls++;
+			throw new Error("native worker timed out");
+		});
+		const cfg = {
+			provider: "native" as const,
+			model: "nomic-embed-text-v1.5",
+			dimensions: 768,
+			base_url: "",
+		};
+
+		const results = await Promise.all(Array.from({ length: 20 }, (_, index) => fetchEmbedding(`text-${index}`, cfg)));
+		expect(results.every((result) => result === null)).toBe(true);
+		expect(nativeCalls).toBe(20);
+		expect(llamaModelProbes).toBe(1);
+		expect(ollamaProbes).toBe(1);
+
+		await expect(fetchEmbedding("after-negative-cache", cfg)).resolves.toBeNull();
+		expect(nativeCalls).toBe(20);
+		expect(llamaModelProbes).toBe(1);
+		expect(ollamaProbes).toBe(1);
+	});
+
 	it("returns null when native provider is 'none'", async () => {
 		const result = await fetchEmbedding("test", {
 			provider: "none",

--- a/platform/daemon/src/embedding-fetch.ts
+++ b/platform/daemon/src/embedding-fetch.ts
@@ -45,10 +45,18 @@ export async function findLlamaCppEmbeddingModel(
 let cachedNativeEmbed: ((text: string) => Promise<number[]>) | null = null;
 type NativeFallbackProvider = "llama-cpp" | "ollama";
 type NativeFallbackState = NativeFallbackProvider | "unavailable" | null;
+type NativeFallbackProbeResult = {
+	readonly provider: NativeFallbackProvider | "unavailable";
+	readonly model: LlamaCppEmbeddingModel | null;
+	readonly embedding: number[] | null;
+};
+type NativeFallbackProbe = {
+	readonly promise: Promise<NativeFallbackProbeResult>;
+};
 
 let nativeFallbackProvider: NativeFallbackState = null;
 let nativeFallbackModel: LlamaCppEmbeddingModel | null = null;
-let nativeFallbackProbe: Promise<number[] | null> | null = null;
+let nativeFallbackProbe: NativeFallbackProbe | null = null;
 
 export function setNativeFallbackProvider(provider: NativeFallbackState, model?: LlamaCppEmbeddingModel | null): void {
 	nativeFallbackProvider = provider;
@@ -182,6 +190,7 @@ async function fetchNativeFallback(
 	text: string,
 	cfg: EmbeddingConfig,
 	opts: EmbeddingFetchOptions,
+	model: LlamaCppEmbeddingModel | null = nativeFallbackModel,
 ): Promise<number[] | null> {
 	if (provider === "ollama") {
 		return fetchOllamaEmbedding(text, resolveOllamaUrl(), "nomic-embed-text", opts);
@@ -189,7 +198,7 @@ async function fetchNativeFallback(
 	return fetchLlamaCppEmbedding(
 		text,
 		DEFAULT_LLAMACPP_BASE_URL,
-		nativeFallbackModel ?? "nomic-embed-text",
+		model ?? "nomic-embed-text",
 		opts,
 		5000,
 		cfg.llamaCppMaxInputTokens,
@@ -200,8 +209,7 @@ async function probeNativeFallback(
 	text: string,
 	cfg: EmbeddingConfig,
 	opts: EmbeddingFetchOptions,
-	nativeError: string,
-): Promise<number[] | null> {
+): Promise<NativeFallbackProbeResult> {
 	const discoveredModel = await findLlamaCppEmbeddingModel();
 	if (discoveredModel) {
 		const embedding = await fetchLlamaCppEmbedding(
@@ -213,33 +221,20 @@ async function probeNativeFallback(
 			cfg.llamaCppMaxInputTokens,
 		);
 		if (embedding) {
-			nativeFallbackProvider = "llama-cpp";
-			nativeFallbackModel = discoveredModel;
-			logger.info(
-				"embedding",
-				`llama.cpp fallback succeeded (model: ${discoveredModel}) — will use llama.cpp for remaining embeddings this session`,
-			);
-			return embedding;
+			return { provider: "llama-cpp", model: discoveredModel, embedding };
 		}
 	}
 
 	try {
 		const embedding = await fetchOllamaEmbedding(text, resolveOllamaUrl(), "nomic-embed-text", opts);
 		if (embedding) {
-			nativeFallbackProvider = "ollama";
-			logger.info("embedding", "Ollama fallback succeeded — will use ollama for remaining embeddings this session");
-			return embedding;
+			return { provider: "ollama", model: null, embedding };
 		}
 	} catch {
 		// The aggregate warning below is the single actionable diagnostic.
 	}
 
-	nativeFallbackProvider = "unavailable";
-	nativeFallbackModel = null;
-	logger.warn("embedding", "Native embedding disabled for this daemon session; no local fallback is ready", {
-		error: nativeError,
-	});
-	return null;
+	return { provider: "unavailable", model: null, embedding: null };
 }
 
 async function resolveNativeFallback(
@@ -252,17 +247,36 @@ async function resolveNativeFallback(
 	if (nativeFallbackProvider) return fetchNativeFallback(nativeFallbackProvider, text, cfg, opts);
 
 	if (nativeFallbackProbe) {
-		await nativeFallbackProbe;
-		return nativeFallbackProvider && nativeFallbackProvider !== "unavailable"
-			? fetchNativeFallback(nativeFallbackProvider, text, cfg, opts)
+		const result = await nativeFallbackProbe.promise;
+		return result.provider !== "unavailable"
+			? fetchNativeFallback(result.provider, text, cfg, opts, result.model)
 			: null;
 	}
 
 	logger.warn("embedding", `Native embedding failed, probing local fallbacks: ${nativeError}`);
-	const probe = probeNativeFallback(text, cfg, opts, nativeError);
+	const probe: NativeFallbackProbe = {
+		promise: probeNativeFallback(text, cfg, opts),
+	};
 	nativeFallbackProbe = probe;
 	try {
-		return await probe;
+		const result = await probe.promise;
+		if (nativeFallbackProbe === probe) {
+			nativeFallbackProvider = result.provider;
+			nativeFallbackModel = result.model;
+			if (result.provider === "llama-cpp") {
+				logger.info(
+					"embedding",
+					`llama.cpp fallback succeeded (model: ${result.model}) — will use llama.cpp for remaining embeddings this session`,
+				);
+			} else if (result.provider === "ollama") {
+				logger.info("embedding", "Ollama fallback succeeded — will use ollama for remaining embeddings this session");
+			} else {
+				logger.warn("embedding", "Native embedding disabled for this daemon session; no local fallback is ready", {
+					error: nativeError,
+				});
+			}
+		}
+		return result.embedding;
 	} finally {
 		if (nativeFallbackProbe === probe) nativeFallbackProbe = null;
 	}

--- a/platform/daemon/src/embedding-fetch.ts
+++ b/platform/daemon/src/embedding-fetch.ts
@@ -43,15 +43,17 @@ export async function findLlamaCppEmbeddingModel(
 }
 
 let cachedNativeEmbed: ((text: string) => Promise<number[]>) | null = null;
-let nativeFallbackProvider: "llama-cpp" | "ollama" | null = null;
-let nativeFallbackModel: LlamaCppEmbeddingModel | null = null;
+type NativeFallbackProvider = "llama-cpp" | "ollama";
+type NativeFallbackState = NativeFallbackProvider | "unavailable" | null;
 
-export function setNativeFallbackProvider(
-	provider: "llama-cpp" | "ollama" | null,
-	model?: LlamaCppEmbeddingModel | null,
-): void {
+let nativeFallbackProvider: NativeFallbackState = null;
+let nativeFallbackModel: LlamaCppEmbeddingModel | null = null;
+let nativeFallbackProbe: Promise<number[] | null> | null = null;
+
+export function setNativeFallbackProvider(provider: NativeFallbackState, model?: LlamaCppEmbeddingModel | null): void {
 	nativeFallbackProvider = provider;
 	nativeFallbackModel = model ?? null;
+	nativeFallbackProbe = null;
 }
 
 export function setNativeEmbeddingProviderForTest(provider: ((text: string) => Promise<number[]>) | null): void {
@@ -175,6 +177,97 @@ async function fetchLlamaCppEmbedding(
 	return data.data?.[0]?.embedding ?? null;
 }
 
+async function fetchNativeFallback(
+	provider: NativeFallbackProvider,
+	text: string,
+	cfg: EmbeddingConfig,
+	opts: EmbeddingFetchOptions,
+): Promise<number[] | null> {
+	if (provider === "ollama") {
+		return fetchOllamaEmbedding(text, resolveOllamaUrl(), "nomic-embed-text", opts);
+	}
+	return fetchLlamaCppEmbedding(
+		text,
+		DEFAULT_LLAMACPP_BASE_URL,
+		nativeFallbackModel ?? "nomic-embed-text",
+		opts,
+		5000,
+		cfg.llamaCppMaxInputTokens,
+	);
+}
+
+async function probeNativeFallback(
+	text: string,
+	cfg: EmbeddingConfig,
+	opts: EmbeddingFetchOptions,
+	nativeError: string,
+): Promise<number[] | null> {
+	const discoveredModel = await findLlamaCppEmbeddingModel();
+	if (discoveredModel) {
+		const embedding = await fetchLlamaCppEmbedding(
+			text,
+			DEFAULT_LLAMACPP_BASE_URL,
+			discoveredModel,
+			opts,
+			5000,
+			cfg.llamaCppMaxInputTokens,
+		);
+		if (embedding) {
+			nativeFallbackProvider = "llama-cpp";
+			nativeFallbackModel = discoveredModel;
+			logger.info(
+				"embedding",
+				`llama.cpp fallback succeeded (model: ${discoveredModel}) — will use llama.cpp for remaining embeddings this session`,
+			);
+			return embedding;
+		}
+	}
+
+	try {
+		const embedding = await fetchOllamaEmbedding(text, resolveOllamaUrl(), "nomic-embed-text", opts);
+		if (embedding) {
+			nativeFallbackProvider = "ollama";
+			logger.info("embedding", "Ollama fallback succeeded — will use ollama for remaining embeddings this session");
+			return embedding;
+		}
+	} catch {
+		// The aggregate warning below is the single actionable diagnostic.
+	}
+
+	nativeFallbackProvider = "unavailable";
+	nativeFallbackModel = null;
+	logger.warn("embedding", "Native embedding disabled for this daemon session; no local fallback is ready", {
+		error: nativeError,
+	});
+	return null;
+}
+
+async function resolveNativeFallback(
+	text: string,
+	cfg: EmbeddingConfig,
+	opts: EmbeddingFetchOptions,
+	nativeError: string,
+): Promise<number[] | null> {
+	if (nativeFallbackProvider === "unavailable") return null;
+	if (nativeFallbackProvider) return fetchNativeFallback(nativeFallbackProvider, text, cfg, opts);
+
+	if (nativeFallbackProbe) {
+		await nativeFallbackProbe;
+		return nativeFallbackProvider && nativeFallbackProvider !== "unavailable"
+			? fetchNativeFallback(nativeFallbackProvider, text, cfg, opts)
+			: null;
+	}
+
+	logger.warn("embedding", `Native embedding failed, probing local fallbacks: ${nativeError}`);
+	const probe = probeNativeFallback(text, cfg, opts, nativeError);
+	nativeFallbackProbe = probe;
+	try {
+		return await probe;
+	} finally {
+		if (nativeFallbackProbe === probe) nativeFallbackProbe = null;
+	}
+}
+
 export function resolveEmbeddingBaseUrl(cfg: EmbeddingConfig): string {
 	if (cfg.provider === "openai") {
 		return cfg.base_url.trim() || DEFAULT_OPENAI_BASE_URL;
@@ -214,20 +307,8 @@ export async function fetchEmbedding(
 	if (cfg.provider === "none") return null;
 	try {
 		if (cfg.provider === "native") {
-			if (nativeFallbackProvider === "ollama") {
-				return await fetchOllamaEmbedding(text, resolveOllamaUrl(), "nomic-embed-text", opts);
-			}
-			if (nativeFallbackProvider === "llama-cpp") {
-				const fallbackModel = nativeFallbackModel ?? "nomic-embed-text";
-				return fetchLlamaCppEmbedding(
-					text,
-					DEFAULT_LLAMACPP_BASE_URL,
-					fallbackModel,
-					opts,
-					5000,
-					cfg.llamaCppMaxInputTokens,
-				);
-			}
+			if (nativeFallbackProvider === "unavailable") return null;
+			if (nativeFallbackProvider) return fetchNativeFallback(nativeFallbackProvider, text, cfg, opts);
 			try {
 				if (!cachedNativeEmbed) {
 					const mod = await import("./native-embedding");
@@ -235,53 +316,12 @@ export async function fetchEmbedding(
 				}
 				return await cachedNativeEmbed(text);
 			} catch (nativeErr) {
-				logger.warn(
-					"embedding",
-					`Native embedding failed, attempting local fallback: ${
-						nativeErr instanceof Error ? nativeErr.message : String(nativeErr)
-					}`,
+				return resolveNativeFallback(
+					text,
+					cfg,
+					opts,
+					nativeErr instanceof Error ? nativeErr.message : String(nativeErr),
 				);
-				try {
-					const discoveredModel = await findLlamaCppEmbeddingModel();
-					if (!discoveredModel) {
-						logger.warn("embedding", "llama.cpp server reachable but no supported embedding model loaded");
-					} else {
-						const embedding = await fetchLlamaCppEmbedding(
-							text,
-							DEFAULT_LLAMACPP_BASE_URL,
-							discoveredModel,
-							opts,
-							5000,
-							cfg.llamaCppMaxInputTokens,
-						);
-						if (embedding) {
-							nativeFallbackProvider = "llama-cpp";
-							nativeFallbackModel = discoveredModel;
-							logger.info(
-								"embedding",
-								`llama.cpp fallback succeeded (model: ${discoveredModel}) — will use llama.cpp for remaining embeddings this session`,
-							);
-							return embedding;
-						}
-					}
-				} catch {
-					logger.warn("embedding", "llama.cpp fallback not reachable");
-				}
-				try {
-					const result = await fetchOllamaEmbedding(text, resolveOllamaUrl(), "nomic-embed-text", opts);
-					if (result !== null) {
-						nativeFallbackProvider = "ollama";
-						logger.info(
-							"embedding",
-							"Ollama fallback succeeded — will use ollama for remaining embeddings this session",
-						);
-						return result;
-					}
-					logger.warn("embedding", "Ollama fallback also failed");
-				} catch {
-					logger.warn("embedding", "Ollama fallback not reachable");
-				}
-				return null;
 			}
 		}
 		if (cfg.provider === "ollama") {

--- a/platform/daemon/src/embedding-wasm-config.test.ts
+++ b/platform/daemon/src/embedding-wasm-config.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import { configureEmbeddingWasm } from "./embedding-wasm-config";
+
+describe("configureEmbeddingWasm", () => {
+	it("disables the ONNX WASM worker pool before inference", () => {
+		const wasm = { numThreads: 4, wasmPaths: "https://cdn.example.invalid/" };
+
+		configureEmbeddingWasm(wasm, "/tmp/signet-native-wasm");
+
+		expect(wasm).toEqual({
+			numThreads: 1,
+			wasmPaths: "/tmp/signet-native-wasm/",
+		});
+	});
+
+	it("is a no-op when the selected backend has no WASM environment", () => {
+		expect(() => configureEmbeddingWasm(undefined, null)).not.toThrow();
+	});
+});

--- a/platform/daemon/src/embedding-wasm-config.ts
+++ b/platform/daemon/src/embedding-wasm-config.ts
@@ -1,0 +1,15 @@
+export interface EmbeddingWasmConfig {
+	numThreads?: number;
+	wasmPaths?: string;
+}
+
+export function configureEmbeddingWasm(wasm: EmbeddingWasmConfig | undefined, wasmDir: string | null): void {
+	if (!wasm) return;
+	// ONNX Runtime defaults Node-like environments to up to four WASM
+	// threads. Bun's compiled worker runtime has exhibited thread-pool hangs
+	// on both Intel and Apple Silicon Macs, so keep SIMD but disable the
+	// auxiliary Emscripten worker pool. ONNX Runtime documents numThreads=1
+	// as the no-worker configuration.
+	wasm.numThreads = 1;
+	if (wasmDir) wasm.wasmPaths = `${wasmDir}/`;
+}

--- a/platform/daemon/src/embedding-worker-handle.test.ts
+++ b/platform/daemon/src/embedding-worker-handle.test.ts
@@ -218,21 +218,46 @@ describe("embedding-worker-handle", () => {
 		await expect(p).rejects.toThrow(/exited/);
 	});
 
-	it("concurrent embeds get distinct RPC ids and resolve independently", async () => {
+	it("serializes concurrent embeds so ONNX never runs the shared session concurrently", async () => {
 		const { worker, factory } = fakePair();
 		const handle = await makeHandle(worker, factory);
 
 		const a = handle.embed("a");
 		const b = handle.embed("b");
 		await flush();
-		const ids = worker.posted.filter((m) => m.type === "embed").map((m) => (m.type === "embed" ? m.id : -1));
-		expect(new Set(ids).size).toBe(2);
+		let requests = worker.posted.filter((m) => m.type === "embed");
+		expect(requests).toHaveLength(1);
+		const firstId = requests[0]?.type === "embed" ? requests[0].id : -1;
 
-		worker.emit({ type: "embed_result", id: ids[0], vector: vec(0.01) });
-		worker.emit({ type: "embed_result", id: ids[1], vector: vec(0.02) });
+		worker.emit({ type: "embed_result", id: firstId, vector: vec(0.01) });
+		await flush();
+		requests = worker.posted.filter((m) => m.type === "embed");
+		expect(requests).toHaveLength(2);
+		const secondId = requests[1]?.type === "embed" ? requests[1].id : -1;
+		expect(secondId).not.toBe(firstId);
+
+		worker.emit({ type: "embed_result", id: secondId, vector: vec(0.02) });
 		const [ra, rb] = await Promise.all([a, b]);
 		expect(ra[0]).toBeCloseTo(0.01, 5);
 		expect(rb[0]).toBeCloseTo(0.02, 5);
+	});
+
+	it("does not post queued embeds after an earlier inference times out", async () => {
+		const { worker, factory } = fakePair();
+		const handle = await makeHandle(worker, factory, { embedTimeoutMs: 40, cooldownMs: 5_000 });
+
+		const first = handle.embed("stuck");
+		const queued = handle.embed("queued");
+		const outcomes = Promise.allSettled([first, queued]);
+		await flush();
+		expect(worker.posted.filter((m) => m.type === "embed")).toHaveLength(1);
+
+		const [firstResult, queuedResult] = await outcomes;
+		expect(firstResult.status).toBe("rejected");
+		expect(String(firstResult.status === "rejected" ? firstResult.reason : "")).toMatch(/timed out/);
+		expect(queuedResult.status).toBe("rejected");
+		expect(String(queuedResult.status === "rejected" ? queuedResult.reason : "")).toMatch(/timed out|disabled/);
+		expect(worker.posted.filter((m) => m.type === "embed")).toHaveLength(1);
 	});
 
 	it("stop() posts shutdown, terminates the worker, and rejects further embeds", async () => {
@@ -245,16 +270,16 @@ describe("embedding-worker-handle", () => {
 		await expect(handle.embed("after")).rejects.toThrow(/shut down/);
 	});
 
-	it("retries after the cooldown window elapses", async () => {
+	it("keeps a timed-out inference worker disabled after the cooldown window", async () => {
 		const { worker, factory } = fakePair();
 		const handle = await makeHandle(worker, factory, { embedTimeoutMs: 40, cooldownMs: 80 });
 
-		await expect(handle.embed("first")).rejects.toThrow(/timed out/); // -> cooldown
+		await expect(handle.embed("first")).rejects.toThrow(/timed out/);
+		const posted = worker.posted.length;
 		await Bun.sleep(120); // past cooldown
-		const p = handle.embed("retry");
-		await flush();
-		worker.emit({ type: "embed_result", id: lastEmbedId(worker), vector: vec() });
-		await expect(p).resolves.toHaveLength(DIM);
+		await expect(handle.embed("retry")).rejects.toThrow(/timed out|disabled/);
+		expect(worker.posted).toHaveLength(posted);
+		expect(worker.terminated).toBe(true);
 	});
 
 	// Regression test for #922: when the embedding worker handle is created

--- a/platform/daemon/src/embedding-worker-handle.ts
+++ b/platform/daemon/src/embedding-worker-handle.ts
@@ -189,6 +189,8 @@ export async function createEmbeddingWorkerHandle(opts: EmbeddingHandleOptions =
 	let lastError: string | null = null;
 	let lastFailureAt = 0;
 	let stopped = false;
+	let disabled = false;
+	let embedQueue: Promise<void> = Promise.resolve();
 
 	let resolveReady: () => void = () => {};
 	const ready = new Promise<void>((resolve) => {
@@ -234,12 +236,29 @@ export async function createEmbeddingWorkerHandle(opts: EmbeddingHandleOptions =
 					const timer = setTimeout(() => {
 						if (pending.has(id)) {
 							clearPending(id);
-							const message = `${kind} timed out after ${timeoutMs}ms (worker isolated; provider marked unavailable)`;
+							const message =
+								kind === "embed"
+									? `embed timed out after ${timeoutMs}ms (worker isolated; provider disabled until daemon restart)`
+									: `checkAvailable timed out after ${timeoutMs}ms (worker isolated; provider marked unavailable)`;
 							lastError = message;
 							lastFailureAt = Date.now();
 							status = { ...status, initialized: false, initializing: false, error: message };
 							logger.warn("native-embedding", message);
 							reject(new Error(message));
+							if (kind === "embed") {
+								disabled = true;
+								// A timed-out inference has left the worker unable to
+								// service further RPCs. Terminate it so the stuck WASM
+								// runtime cannot retain threads or memory indefinitely.
+								try {
+									const result = worker.terminate();
+									if (result && typeof (result as Promise<unknown>).then === "function") {
+										void Promise.resolve(result).catch(() => {});
+									}
+								} catch {
+									// best-effort
+								}
+							}
 						}
 					}, timeoutMs);
 					pending.set(id, { resolve: resolve as (v: unknown) => void, reject, timer });
@@ -315,7 +334,7 @@ export async function createEmbeddingWorkerHandle(opts: EmbeddingHandleOptions =
 	});
 
 	worker.on("exit", (code: number) => {
-		if (!stopped && code !== 0) {
+		if (!stopped && !disabled && code !== 0) {
 			logger.warn("native-embedding", "Embedding worker exited unexpectedly", { code });
 		}
 		status = {
@@ -333,14 +352,34 @@ export async function createEmbeddingWorkerHandle(opts: EmbeddingHandleOptions =
 
 	const handle: EmbeddingWorkerHandle = {
 		async embed(text: string): Promise<number[]> {
-			if (stopped) throw new Error("Native embedding provider shut down");
-			if (inCooldown()) throw new Error(lastError ?? "Native embedding init on cooldown");
-			return rpc<number[]>("embed", embedTimeoutMs, { text });
+			const run = embedQueue.then(() => {
+				if (stopped) throw new Error("Native embedding provider shut down");
+				if (disabled) throw new Error(lastError ?? "Native embedding provider disabled until daemon restart");
+				if (inCooldown()) throw new Error(lastError ?? "Native embedding init on cooldown");
+				return rpc<number[]>("embed", embedTimeoutMs, { text });
+			});
+			// ONNX Runtime's WASM session is process-global and has shown
+			// non-reentrant hangs under concurrent inference. Preserve caller
+			// concurrency while serializing the worker RPCs; failures do not
+			// poison the tail, and queued calls observe cooldown before posting.
+			embedQueue = run.then(
+				() => {},
+				() => {},
+			);
+			return run;
 		},
 
 		async checkAvailable(): Promise<EmbeddingProviderStatus> {
 			if (stopped) {
 				return { available: false, error: "Native embedding provider shut down", dimensions, modelCached: false };
+			}
+			if (disabled) {
+				return {
+					available: false,
+					error: lastError ?? "Native embedding provider disabled until daemon restart",
+					dimensions,
+					modelCached: false,
+				};
 			}
 			if (inCooldown()) {
 				return {

--- a/platform/daemon/src/embedding-worker.ts
+++ b/platform/daemon/src/embedding-worker.ts
@@ -20,6 +20,7 @@
 
 import { mkdirSync } from "node:fs";
 import { isMainThread, parentPort, workerData } from "node:worker_threads";
+import { type EmbeddingWasmConfig, configureEmbeddingWasm } from "./embedding-wasm-config";
 import type { EmbeddingWorkerInit, MainToWorkerMessage, WorkerToMainMessage } from "./embedding-worker-protocol";
 
 // Lazy, narrow transformers typing — keeps the contract we use without
@@ -32,7 +33,7 @@ interface TransformersEnv {
 	remoteHost?: string;
 	backends?: {
 		onnx?: {
-			wasm?: { wasmPaths?: string };
+			wasm?: EmbeddingWasmConfig;
 		};
 	};
 }
@@ -164,10 +165,7 @@ async function doInit(): Promise<void> {
 		if (init.remoteHostOverride) {
 			transformers.env.remoteHost = init.remoteHostOverride;
 		}
-		if (init.wasmDir) {
-			const wasm = transformers.env.backends?.onnx?.wasm;
-			if (wasm) wasm.wasmPaths = `${init.wasmDir}/`;
-		}
+		configureEmbeddingWasm(transformers.env.backends?.onnx?.wasm, init.wasmDir);
 
 		log("info", `Initializing ${init.modelId} (q8 quantization)`, {
 			cachePath: init.cacheDir,

--- a/platform/daemon/src/routes/utils.ts
+++ b/platform/daemon/src/routes/utils.ts
@@ -924,6 +924,7 @@ export async function checkEmbeddingProvider(cfg: EmbeddingConfig): Promise<Embe
 			if (nativeStatus.available) {
 				status.available = true;
 				status.dimensions = nativeStatus.dimensions;
+				setNativeFallbackProvider(null);
 			} else {
 				logger.warn("embedding", `Native provider unavailable: ${nativeStatus.error ?? "unknown"}`);
 				try {
@@ -964,6 +965,7 @@ export async function checkEmbeddingProvider(cfg: EmbeddingConfig): Promise<Embe
 				} catch {
 					status.error = `Native: ${nativeStatus.error ?? "not ready"}. Local providers not reachable.`;
 				}
+				if (!status.available) setNativeFallbackProvider("unavailable");
 			}
 		} else if (cfg.provider === "llama-cpp") {
 			const res = await fetch(`${cfg.base_url.replace(/\/$/, "")}/v1/models`, {


### PR DESCRIPTION
## Summary

Fixes the native ONNX embedding hang reported in #991. ONNX Runtime was allowed to create its default WASM thread pool inside the embedding worker, while callers could also dispatch concurrent inference against the shared session. Once an inference wedged, each memory write retried native and re-probed local fallbacks, producing a sustained warning storm.

This keeps SIMD enabled but sets ONNX WASM `numThreads = 1`, serializes native inference RPCs, permanently disables and terminates a worker after an inference timeout, and single-flights/negative-caches fallback discovery for the daemon session.

Closes #991.

## Changes

- Configure the Transformers ONNX WASM backend before pipeline creation so it does not create auxiliary Emscripten workers.
- Serialize embed RPCs against the shared native session.
- Terminate and mark the native provider unavailable after a timed-out inference until daemon restart.
- Probe llama.cpp and Ollama fallbacks once, then cache the unavailable state instead of retrying and logging per request.
- Surface the degraded provider state through the existing embedding status path.
- Add regression coverage, API documentation, and a changelog entry.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

No data queries or endpoints changed, so agent-scoping and endpoint-security checks are N/A after review. The only backend setting is constrained to the documented no-worker value (`numThreads = 1`). Scoped lint, tests, production build, and native runtime checks pass. The repository-wide daemon typecheck still reports its documented pre-existing backlog (including a pre-existing error in `embedding-worker-handle.test.ts:123`); no errors originate from the changed implementation lines.

## Migration Notes (if applicable)

N/A — no schema or data migration.

## Testing

- [x] `bun test` passes (59 embedding-related tests; post-rebase focused run: 41 tests)
- [x] `bun run typecheck` passes (pre-existing daemon backlog; non-blocking workflow #961)
- [x] `bun run lint` passes (changed files; three pre-existing `routes/utils.ts` warnings only)
- [x] Tested against running daemon
- [ ] N/A

Additional validation:

- `bun run --filter '@signet/daemon' build`
- `bun run build:native-bun`
- Compiled arm64 native embed-and-recall smoke
- Cross-compiled x86_64 native embed-and-recall smoke under Rosetta
- Compiled worker bundle inspection confirms `numThreads = 1`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The x86_64 runtime smoke ran under Rosetta on Apple Silicon, not on physical Intel hardware. The fix is intentionally architecture-neutral because the same hang has also been observed on Apple Silicon.
