### PR TITLE
feat(dashboard): inference settings density + hierarchy refactor

### DIFF
--- a/surfaces/dashboard/src/lib/components/config/SettingRow.svelte
+++ b/surfaces/dashboard/src/lib/components/config/SettingRow.svelte
@@ -1,31 +1,65 @@
 <script lang="ts">
 import type { Snippet } from "svelte";
+import { InfoIcon } from "$lib/icons";
+import * as Tooltip from "$lib/components/ui/tooltip/index.js";
 
-// Shared settings row, matching the OpenCode settings-v2 rhythm:
-// title + description on the left, control on the right. Used inside a
-// SettingList for the bordered "list with divider rows" look. See
-// docs/research/2026-07-22-dashboard-inference-settings-design.md.
+// Shared settings row. Default = OpenCode settings-v2 rhythm (title+desc left,
+// control right). Pass `compact` for a dense vertical stack: label on top (with
+// the description moved into an info-icon tooltip so it no longer eats a
+// column), control directly below. Compact is opt-in so existing tabs are
+// unaffected; the Inference section uses it to raise density and kill the
+// far-left-label / far-right-control jump.
 
 interface Props {
 	title: string;
 	description?: string;
+	/** Dense vertical stack: label on top, control below; description → tooltip. */
+	compact?: boolean;
 	children: Snippet;
 }
 
-let { title, description, children }: Props = $props();
+let { title, description, compact = false, children }: Props = $props();
 </script>
 
-<div class="setting-row" data-component="settings-row">
-	<div class="row-copy">
-		<div class="row-title">{title}</div>
-		{#if description}
-			<div class="row-description">{description}</div>
-		{/if}
+{#if compact}
+	<div class="setting-row compact" data-component="settings-row">
+		<div class="row-head">
+			<span class="row-title">{title}</span>
+			{#if description}
+				<Tooltip.Provider>
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<span {...props} class="info-icon" role="button" tabindex="0" aria-label={title}>
+									<InfoIcon class="size-3" />
+								</span>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content class="tooltip-content">
+							<div class="tip-title">{title}</div>
+							<div class="tip-body">{description}</div>
+						</Tooltip.Content>
+					</Tooltip.Root>
+				</Tooltip.Provider>
+			{/if}
+		</div>
+		<div class="row-control">
+			{@render children()}
+		</div>
 	</div>
-	<div class="row-control">
-		{@render children()}
+{:else}
+	<div class="setting-row" data-component="settings-row">
+		<div class="row-copy">
+			<div class="row-title">{title}</div>
+			{#if description}
+				<div class="row-description">{description}</div>
+			{/if}
+		</div>
+		<div class="row-control">
+			{@render children()}
+		</div>
 	</div>
-</div>
+{/if}
 
 <style>
 	.setting-row {
@@ -44,6 +78,13 @@ let { title, description, children }: Props = $props();
 			flex-wrap: nowrap;
 		}
 	}
+	/* Compact: vertical stack, tight padding, label above control. */
+	.setting-row.compact {
+		flex-direction: column;
+		align-items: stretch;
+		gap: 5px;
+		padding-block: 8px;
+	}
 	.row-copy {
 		display: flex;
 		min-width: 0;
@@ -51,12 +92,25 @@ let { title, description, children }: Props = $props();
 		flex-direction: column;
 		gap: 6px;
 	}
+	.row-head {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		min-height: 16px;
+	}
 	.row-title {
 		font-family: var(--font-display);
 		font-size: 12px;
 		font-weight: 500;
 		color: var(--sig-text-bright);
 		line-height: 1.3;
+	}
+	.setting-row.compact .row-title {
+		font-size: 10px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--sig-text-muted);
 	}
 	.row-description {
 		font-family: var(--font-body);
@@ -74,5 +128,38 @@ let { title, description, children }: Props = $props();
 			width: auto;
 			flex-shrink: 0;
 		}
+	}
+	.setting-row.compact .row-control {
+		width: 100%;
+		justify-content: flex-start;
+	}
+	.info-icon {
+		display: inline-flex;
+		align-items: center;
+		color: var(--sig-text-muted);
+		opacity: 0.6;
+		cursor: help;
+	}
+	.info-icon:hover {
+		opacity: 1;
+		color: var(--sig-text);
+	}
+	:global(.tooltip-content) {
+		max-width: 280px;
+		padding: 8px 10px;
+		font-family: var(--font-body);
+		font-size: 11px;
+		line-height: 1.5;
+		color: var(--sig-text);
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border-strong);
+		border-radius: 6px;
+	}
+	:global(.tooltip-content .tip-title) {
+		font-weight: 600;
+		margin-bottom: 2px;
+	}
+	:global(.tooltip-content .tip-body) {
+		color: var(--sig-text-muted);
 	}
 </style>

--- a/surfaces/dashboard/src/lib/components/tabs/settings/InferenceSection.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/InferenceSection.svelte
@@ -99,6 +99,32 @@ interface ConnectableProvider {
 }
 
 let connecting = $state<{ provider: ConnectableProvider } | null>(null);
+let showPicker = $state(false);
+
+// Picker modal focus management: autofocus into the panel on open, restore
+// focus to the Add button on close, and listen for Escape at window level (a
+// backdrop-only listener misses when focus is outside the modal subtree).
+let pickerCloseBtn: HTMLButtonElement | null = $state(null);
+let lastFocused: HTMLElement | null = null;
+
+$effect(() => {
+	if (!showPicker) return;
+	lastFocused = document.activeElement as HTMLElement | null;
+	// Defer until the panel renders.
+	const id = requestAnimationFrame(() => pickerCloseBtn?.focus());
+	const onKey = (e: KeyboardEvent) => {
+		if (e.key === "Escape") {
+			e.preventDefault();
+			showPicker = false;
+		}
+	};
+	window.addEventListener("keydown", onKey);
+	return () => {
+		cancelAnimationFrame(id);
+		window.removeEventListener("keydown", onKey);
+		lastFocused?.focus?.();
+	};
+});
 
 function titleCase(id: string): string {
 	return id
@@ -177,11 +203,21 @@ function accountForFamily(family: string): string | null {
 }
 
 function openConnect(provider: ConnectableProvider): void {
+	showPicker = false;
 	connecting = { provider };
 }
 
 function closeConnect(): void {
 	connecting = null;
+}
+
+// Connected providers shown in the compact list; the rest are reachable via
+// the "+ Add provider" picker so the section doesn't balloon to 30+ rows.
+function connectedList(): ConnectableProvider[] {
+	return connectableProviders().filter((p) => p.connected);
+}
+function availableList(): ConnectableProvider[] {
+	return connectableProviders().filter((p) => !p.connected);
 }
 
 // After a connect/disconnect, persist any config writes (account entries are
@@ -449,16 +485,16 @@ const needsApiKey = $derived(bgExecutor() === "openai-compatible");
 const embNonNative = $derived(embProvider() && embProvider() !== "native" && embProvider() !== "");
 </script>
 
-<FormSection description="Connect AI providers, then choose which one runs background memory work. Connect once; keys live encrypted and never leave the daemon.">
+<FormSection>
 
 	<!-- ============================================================ -->
-	<!-- Provider connect wall                                         -->
+	<!-- Providers (connected only + Add picker)                       -->
 	<!-- ============================================================ -->
 	<SettingList title="Providers">
 		<div class="provider-list">
-			{#each connectableProviders() as provider (provider.id)}
+			{#each connectedList() as provider (provider.id)}
 				<button
-					class="provider-row {provider.connected ? "provider-row--connected" : ""}"
+					class="provider-row provider-row--connected"
 					onclick={() => openConnect(provider)}
 				>
 					<span class="provider-row-name">{provider.name}</span>
@@ -466,20 +502,21 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 						{#if provider.supportsOAuth && provider.supportsApiKey}Sign in or key{:else if provider.supportsOAuth}Sign in{:else}API key{/if}
 						{#if catalog?.models[provider.id]?.length}· {catalog.models[provider.id].length} models{/if}
 					</span>
-					{#if provider.connected}
-						<span class="status-badge status-badge--ok"><CheckCircle class="size-3" /> Connected</span>
-					{:else}
-						<span class="status-badge status-badge--off"><Plus class="size-3" /> Connect</span>
-					{/if}
+					<span class="status-badge status-badge--ok"><CheckCircle class="size-3" /> Connected</span>
 				</button>
 			{:else}
 				{#if catalogFailed}
 					<div class="provider-empty">Couldn't load the provider catalog. Update the daemon and retry.</div>
-				{:else}
+				{:else if !catalog}
 					<div class="provider-empty">Loading providers…</div>
+				{:else}
+					<div class="provider-empty">No providers connected yet.</div>
 				{/if}
 			{/each}
 		</div>
+		<button class="add-provider-btn" onclick={() => (showPicker = true)}>
+			<Plus class="size-3.5" /> Add provider
+		</button>
 		{#if catalog?.modelErrors && Object.keys(catalog.modelErrors).length > 0}
 			<div class="catalog-warnings">
 				{#each Object.entries(catalog.modelErrors) as [providerId, message] (providerId)}
@@ -493,10 +530,11 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 	</SettingList>
 
 	<!-- ============================================================ -->
-	<!-- Background executor + model + endpoint + key                  -->
+	<!-- Background + Aggregation (two-column)                         -->
 	<!-- ============================================================ -->
+	<div class="workload-grid">
 	<SettingList title="Background inference">
-		<SettingRow
+		<SettingRow compact
 			title="Backend"
 			description="Which backend runs memory extraction and synthesis. Direct API providers (Anthropic/OpenRouter) are powered by pi-ai; local servers (LM Studio/Ollama/llama.cpp) connect via an OpenAI-compatible endpoint; ACPX drives a harness subprocess (Claude/Codex/OpenCode)."
 		>
@@ -514,7 +552,7 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 
 		{#if bgExecutor() && bgExecutor() !== ""}
 			{#if bgExecutor() === "acpx"}
-				<SettingRow title="ACPX agent" description="The harness ACPX drives.">
+				<SettingRow compact title="ACPX agent" description="The harness ACPX drives.">
 					<Select.Root type="single" value={bgAcpxAgent()} onValueChange={(v) => bgSetAcpxAgent(v)}>
 						<Select.Trigger class={selectTriggerClass}>{bgAcpxAgent()}</Select.Trigger>
 						<Select.Content class={selectContentClass}>
@@ -525,7 +563,7 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 					</Select.Root>
 				</SettingRow>
 			{:else}
-				<SettingRow
+				<SettingRow compact
 					title="Model"
 					description="From the pi-ai catalog. For local servers, type the model id your server exposes."
 				>
@@ -554,7 +592,7 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 			{/if}
 
 			{#if isLocalExecutor}
-				<SettingRow
+				<SettingRow compact
 					title="Endpoint"
 					description="Base URL of the OpenAI-compatible server. LM Studio: http://localhost:1234/v1 · Ollama: http://localhost:11434 · llama.cpp: http://localhost:8080/v1"
 				>
@@ -568,7 +606,7 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 			{/if}
 
 			{#if needsApiKey}
-				<SettingRow
+				<SettingRow compact
 					title="API key (secret name)"
 				description="The Signet secret holding the key. Or connect via the Providers panel above to skip this. The key value is never shown."
 				>
@@ -587,7 +625,7 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 	<!-- Aggregation (separate latency-optimized path, pi-ai-only)    -->
 	<!-- ============================================================ -->
 	<SettingList title="Aggregation">
-		<SettingRow
+		<SettingRow compact
 			title="Backend"
 			description="Which backend runs aggregate recall (query-time evidence synthesis). Latency-sensitive and pi-ai-only — ACPX subprocesses are excluded because spawn latency would dominate."
 		>
@@ -604,7 +642,7 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 		</SettingRow>
 
 		{#if aggExecutor() && aggExecutor() !== ""}
-			<SettingRow
+			<SettingRow compact
 				title="Model"
 				description="From the pi-ai catalog. Favor a fast/cheap model — aggregation is latency-bound, not intelligence-bound."
 			>
@@ -632,7 +670,7 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 			</SettingRow>
 
 			{#if aggIsLocal}
-				<SettingRow
+				<SettingRow compact
 					title="Endpoint"
 					description="Base URL of the OpenAI-compatible server."
 				>
@@ -646,7 +684,7 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 			{/if}
 
 			{#if aggNeedsApiKey}
-				<SettingRow
+				<SettingRow compact
 					title="API key (secret name)"
 					description="The Signet secret holding the key."
 				>
@@ -660,12 +698,13 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 			{/if}
 		{/if}
 	</SettingList>
+	</div><!-- /workload-grid -->
 
 	<!-- ============================================================ -->
 	<!-- Embeddings                                                   -->
 	<!-- ============================================================ -->
 	<SettingList title="Embeddings">
-		<SettingRow
+		<SettingRow compact
 			title="Provider"
 			description="Changing provider or model will re-embed your entire memory database."
 		>
@@ -682,7 +721,7 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 		</SettingRow>
 
 		{#if embNonNative}
-			<SettingRow title="Model" description="The model id your embedding provider exposes.">
+			<SettingRow compact title="Model" description="The model id your embedding provider exposes.">
 				<Input
 					class={inputClass}
 					value={embModel()}
@@ -690,7 +729,7 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 					oninput={(e) => embSetModel(e.currentTarget.value)}
 				/>
 			</SettingRow>
-			<SettingRow title="Endpoint" description="Base URL of the embedding server.">
+			<SettingRow compact title="Endpoint" description="Base URL of the embedding server.">
 				<Input
 					class={inputClass}
 					value={embEndpoint()}
@@ -701,6 +740,37 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 		{/if}
 	</SettingList>
 </FormSection>
+
+{#if showPicker}
+	<div
+		class="dialog-backdrop"
+		role="presentation"
+		onclick={(e) => {
+			if (e.target === e.currentTarget) showPicker = false;
+		}}
+	>
+		<div class="picker-panel" role="dialog" aria-modal="true" aria-label="Add a provider">
+			<header class="picker-head">
+				<h2 class="picker-title">Add a provider</h2>
+				<button bind:this={pickerCloseBtn} class="picker-close" onclick={() => (showPicker = false)} aria-label="Close">✕</button>
+			</header>
+			<div class="picker-list">
+				{#each availableList() as provider (provider.id)}
+					<button class="picker-row" onclick={() => openConnect(provider)}>
+						<span class="picker-row-name">{provider.name}</span>
+						<span class="picker-row-meta">
+							{#if provider.supportsOAuth && provider.supportsApiKey}Sign in or key{:else if provider.supportsOAuth}Sign in{:else}API key{/if}
+							{#if catalog?.models[provider.id]?.length}· {catalog.models[provider.id].length} models{/if}
+						</span>
+						<Plus class="size-3" />
+					</button>
+				{:else}
+					<div class="provider-empty">No more providers available.</div>
+				{/each}
+			</div>
+		</div>
+	</div>
+{/if}
 
 {#if connecting}
 	<ConnectProviderDialog
@@ -774,10 +844,6 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 		color: #4ade80;
 		background: rgba(74, 222, 128, 0.12);
 	}
-	.status-badge--off {
-		color: var(--sig-text-muted);
-		background: var(--sig-surface-raised);
-	}
 	.provider-empty {
 		font-family: var(--font-body);
 		font-size: 11px;
@@ -797,5 +863,128 @@ const embNonNative = $derived(embProvider() && embProvider() !== "native" && emb
 		font-family: var(--font-body);
 		font-size: 10.5px;
 		color: #fbbf24;
+	}
+
+	/* Two-column workload grid: background + aggregation side by side.
+	   Stacks on narrow viewports. Embeddings stays full-width below. */
+	.workload-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: var(--space-lg);
+		align-items: start;
+	}
+	@media (max-width: 900px) {
+		.workload-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.add-provider-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 5px;
+		margin-top: 6px;
+		padding: 5px 10px;
+		border: 1px dashed var(--sig-border-strong);
+		border-radius: 7px;
+		background: transparent;
+		color: var(--sig-text-muted);
+		font-family: var(--font-body);
+		font-size: 11px;
+		font-weight: 500;
+		cursor: pointer;
+		transition: border-color 0.12s, color 0.12s;
+	}
+	.add-provider-btn:hover {
+		border-color: var(--sig-accent);
+		color: var(--sig-text);
+	}
+
+	/* Add-provider picker modal */
+	.dialog-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 100;
+		background: rgba(0, 0, 0, 0.6);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 16px;
+	}
+	.picker-panel {
+		background: var(--sig-surface);
+		border: 1px solid var(--sig-border-strong);
+		border-radius: 12px;
+		width: 100%;
+		max-width: 480px;
+		max-height: 70vh;
+		overflow: hidden;
+		display: flex;
+		flex-direction: column;
+	}
+	.picker-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 12px 16px;
+		border-bottom: 1px solid var(--sig-border);
+	}
+	.picker-title {
+		font-family: var(--font-mono);
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--sig-text);
+		margin: 0;
+	}
+	.picker-close {
+		background: none;
+		border: none;
+		color: var(--sig-text-muted);
+		cursor: pointer;
+		font-size: 14px;
+		padding: 4px;
+		border-radius: 4px;
+	}
+	.picker-close:hover {
+		color: var(--sig-text);
+		background: var(--sig-surface-raised);
+	}
+	.picker-list {
+		overflow-y: auto;
+		padding: 6px;
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+	}
+	.picker-row {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 6px 9px;
+		border: 1px solid var(--sig-border);
+		border-radius: 7px;
+		background: var(--sig-bg);
+		cursor: pointer;
+		text-align: left;
+		color: var(--sig-text);
+	}
+	.picker-row:hover {
+		border-color: var(--sig-accent);
+		background: var(--sig-surface-raised);
+	}
+	.picker-row-name {
+		font-family: var(--font-body);
+		font-size: 11.5px;
+		font-weight: 600;
+		white-space: nowrap;
+	}
+	.picker-row-meta {
+		flex: 1 1 auto;
+		font-family: var(--font-body);
+		font-size: 10px;
+		color: var(--sig-text-muted);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 </style>


### PR DESCRIPTION
## Summary

Five UX issues from live testing of the inference settings, addressed together.

1. **Provider wall → connected-only + picker.** The 30+ row provider list ate vertical space. Now shows connected providers as compact rows + a single **"+ Add provider"** button that opens a focus-managed modal listing only unconnected providers.
2. **Two-column workloads.** Background inference + Aggregation now sit side by side (stacks under 900px); Embeddings spans full-width below.
3. **Tighter label/control grouping.** `SettingRow` gained an opt-in `compact` mode (vertical stack: label on top, description as an info-icon tooltip, control directly below). Kills the far-left-label / far-right-control eye jump. **Default behavior is byte-identical — the other settings tabs are unaffected.**
4. **Long descriptions → tooltips.** Multi-line descriptions now render as a hover/focus info-icon tooltip on each compact row.
5. **Higher density overall** (compact rows at 8px padding vs 20px, two-column grid, condensed provider section).

## What's verified (agent-browser, against the running daemon)

- Two-column grid renders side by side (260px columns, confirmed via element metrics)
- Compact rows at 8px padding (was 20px); 7 per inference section
- Provider list shows only the 6 connected providers + Add button
- Add-provider picker opens, lists only unconnected providers, opens the connect flow on click
- Workload backends reflect live config
- Adversarial review clean; fixed a picker-modal focus/Escape defect (window-level Escape + autofocus + focus restore) and removed the resulting dead CSS
- Build + `svelte-check` clean; 6 key-validation tests pass

## Type

- [x] `feat`

## AI disclosure

- [x] AI tools used (`Assisted-by: pi:claude`)