### PR TITLE
refactor(connector-base): centralize MCP command resolution

### DIFF
--- a/integrations/claude-code/connector/src/index.ts
+++ b/integrations/claude-code/connector/src/index.ts
@@ -16,7 +16,14 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { BaseConnector, type InstallResult, type UninstallResult, atomicWriteJson, isSignetGeneratedFile } from "@signet/connector-base";
+import {
+	BaseConnector,
+	type InstallResult,
+	type UninstallResult,
+	atomicWriteJson,
+	isSignetGeneratedFile,
+	resolveSignetMcpCommand,
+} from "@signet/connector-base";
 import { expandHome, resolvePromptSubmitTimeoutMs, resolveSessionStartTimeoutMs } from "@signet/core";
 
 // ============================================================================
@@ -448,33 +455,15 @@ export class ClaudeCodeConnector extends BaseConnector {
 			}
 		}
 
-		// On Windows, Node.js spawn() without shell:true cannot resolve .cmd
-		// wrappers, so "signet-mcp" fails with ENOENT. Use "node" as the
-		// command and pass the mcp-stdio.js entry point as an argument instead.
-		let mcpCommand = "signet-mcp";
-		let mcpArgs: string[] = [];
-		if (process.platform === "win32") {
-			const cliEntry = process.argv[1] || "";
-			// cliEntry is e.g. .../signetai/bin/signet.js
-			// mcp-stdio.js lives at .../signetai/dist/mcp-stdio.js
-			const mcpJs = join(cliEntry, "..", "..", "dist", "mcp-stdio.js");
-			if (existsSync(mcpJs)) {
-				mcpCommand = process.execPath;
-				mcpArgs = [mcpJs];
-			} else {
-				console.warn(
-					`[signet] Warning: could not resolve mcp-stdio.js from argv[1]="${cliEntry}". MCP server config will use "signet-mcp" which may fail on Windows without shell:true.`,
-				);
-			}
-		}
+		const mcp = resolveSignetMcpCommand();
 
 		const existingMcp = (config.mcpServers as Record<string, unknown> | undefined) ?? {};
 		config.mcpServers = {
 			...existingMcp,
 			signet: {
 				type: "stdio",
-				command: mcpCommand,
-				args: mcpArgs,
+				command: mcp.command,
+				args: mcp.args,
 				env: {},
 			},
 		};

--- a/integrations/codex/connector/src/index.ts
+++ b/integrations/codex/connector/src/index.ts
@@ -3,7 +3,14 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { BaseConnector, type InstallResult, type UninstallResult, atomicWriteJson } from "@signet/connector-base";
+import {
+	BaseConnector,
+	type InstallResult,
+	type UninstallResult,
+	atomicWriteJson,
+	resolveSignetCliCommand,
+	resolveSignetMcpCommand,
+} from "@signet/connector-base";
 import {
 	expandHome,
 	resolvePromptSubmitTimeoutMs,
@@ -49,11 +56,8 @@ interface NativePluginCommandResult {
  *  Windows: navigates from argv[1] (e.g. <pkg>/bin/signet.js) up two levels to find
  *  the bin directory. Falls back to bare "signet" if the layout doesn't match (shims, junctions). */
 function resolveSignetArgs(): string[] {
-	if (process.platform !== "win32") return ["signet"];
-	const entry = process.argv[1] || "";
-	const signetJs = join(entry, "..", "..", "bin", "signet.js");
-	if (existsSync(signetJs)) return [process.execPath, signetJs];
-	return ["signet"];
+	const resolved = resolveSignetCliCommand();
+	return [resolved.command, ...resolved.args];
 }
 
 /** Resolve signet-mcp as { command, args } for Codex config.toml.
@@ -69,11 +73,7 @@ function resolveSignetMcp(): SignetMcpConfig {
 			...(apiKey ? { httpHeaders: { Authorization: `Bearer ${apiKey}` } } : {}),
 		};
 	}
-	if (process.platform !== "win32") return { command: "signet-mcp", args: [] };
-	const entry = process.argv[1] || "";
-	const mcpJs = join(entry, "..", "..", "bin", "mcp-stdio.js");
-	if (existsSync(mcpJs)) return { command: process.execPath, args: [mcpJs] };
-	return { command: "signet-mcp", args: [] };
+	return resolveSignetMcpCommand();
 }
 
 function readEnv(name: string): string | undefined {

--- a/integrations/forge/connector/src/index.ts
+++ b/integrations/forge/connector/src/index.ts
@@ -18,6 +18,7 @@ import {
 	atomicWriteJson,
 	isSignetGeneratedFile,
 	resolveSignetApiKey,
+	resolveSignetMcpCommand,
 	resolveSignetWorkspacePath,
 } from "@signet/connector-base";
 import { expandHome, hasValidIdentity, loadIdentityMode, resolveSignetDaemonUrl } from "@signet/core";
@@ -85,18 +86,6 @@ function resolveRemoteDaemonUrl(): string | null {
 	return readTrimmedEnv("SIGNET_DAEMON_URL") ? resolveSignetDaemonUrl() : null;
 }
 
-function resolveSignetMcp(): ForgeMcpStdioServer {
-	if (process.platform !== "win32") return { command: "signet-mcp", args: [] };
-	const cliEntry = process.argv[1] || "";
-	const mcpJs = join(cliEntry, "..", "..", "dist", "mcp-stdio.js");
-	if (existsSync(mcpJs)) return { command: process.execPath, args: [mcpJs] };
-	console.warn(
-		`[signet] Warning: could not resolve mcp-stdio.js from argv[1]="${cliEntry}". ` +
-			`MCP server config will use "signet-mcp" which may fail on Windows without shell:true.`,
-	);
-	return { command: "signet-mcp", args: [] };
-}
-
 function buildMcpServer(basePath: string): ForgeMcpServer {
 	const remoteDaemonUrl = resolveRemoteDaemonUrl();
 	if (remoteDaemonUrl) {
@@ -106,7 +95,7 @@ function buildMcpServer(basePath: string): ForgeMcpServer {
 			...(apiKey ? { headers: { Authorization: `Bearer ${apiKey}` } } : {}),
 		};
 	}
-	const mcp = resolveSignetMcp();
+	const mcp = resolveSignetMcpCommand();
 	return {
 		command: mcp.command,
 		...(mcp.args && mcp.args.length > 0 ? { args: mcp.args } : {}),
@@ -319,7 +308,7 @@ export class ForgeConnector extends BaseConnector {
 		if (!("signet" in servers)) return false;
 		const { signet: _, ...rest } = servers;
 		if (Object.keys(rest).length === 0) {
-			delete config.mcpServers;
+			Reflect.deleteProperty(config, "mcpServers");
 		} else {
 			config.mcpServers = rest;
 		}

--- a/integrations/opencode/connector/src/index.ts
+++ b/integrations/opencode/connector/src/index.ts
@@ -29,6 +29,7 @@ import {
 	atomicWriteJson,
 	atomicWriteText,
 	isSignetGeneratedFile,
+	resolveSignetMcpCommand,
 } from "@signet/connector-base";
 import {
 	OPENCODE_PIPELINE_AGENT,
@@ -71,7 +72,7 @@ function signetRuntimeEnv(): Record<string, string> {
 
 function buildPluginBundle(apiKeyFilePath?: string): string {
 	const env = signetRuntimeEnv();
-	if (apiKeyFilePath) delete env.SIGNET_API_KEY;
+	if (apiKeyFilePath) Reflect.deleteProperty(env, "SIGNET_API_KEY");
 	const assignments = Object.entries(env).map(
 		([key, value]) => `process.env[${JSON.stringify(key)}] = ${JSON.stringify(value)};`,
 	);
@@ -464,20 +465,8 @@ export class OpenCodeConnector extends BaseConnector {
 			return;
 		}
 
-		// On Windows, spawn() without shell:true cannot resolve .cmd wrappers,
-		// so use "node" + mcp-stdio.js path instead.
-		let mcpCommand: string[] = ["signet-mcp"];
-		if (process.platform === "win32") {
-			const cliEntry = process.argv[1] || "";
-			const mcpJs = join(cliEntry, "..", "..", "dist", "mcp-stdio.js");
-			if (existsSync(mcpJs)) {
-				mcpCommand = [process.execPath, mcpJs];
-			} else {
-				console.warn(
-					`[signet] Warning: could not resolve mcp-stdio.js from argv[1]="${cliEntry}". MCP server config will use "signet-mcp" which may fail on Windows without shell:true.`,
-				);
-			}
-		}
+		const resolvedMcp = resolveSignetMcpCommand();
+		const mcpCommand = [resolvedMcp.command, ...resolvedMcp.args];
 		const environment = signetRuntimeEnv();
 		if (apiKeyFile) environment.SIGNET_API_KEY = `{file:${apiKeyFile}}`;
 		writeConfigValue(configPath, ["mcp", "signet"], {

--- a/libs/connector-base/index.test.ts
+++ b/libs/connector-base/index.test.ts
@@ -8,7 +8,9 @@ import {
 	type UninstallResult,
 	atomicWriteText,
 	removeManagedExtensionFile,
+	resolveSignetCliCommand,
 	resolveSignetDaemonUrl,
+	resolveSignetMcpCommand,
 	resolveSignetWorkspacePath,
 } from "./src/index";
 
@@ -102,6 +104,55 @@ describe("atomicWriteText", () => {
 
 		expect(readFileSync(file, "utf-8")).toBe("{\n  // preserved\n}\n");
 		if (process.platform !== "win32") expect(statSync(file).mode & 0o777).toBe(0o600);
+	});
+});
+
+describe("packaged Signet command resolution", () => {
+	const originalPlatform = process.platform;
+	const originalArgv = process.argv;
+	const originalExecPath = process.execPath;
+	const originalWarn = console.warn;
+
+	afterEach(() => {
+		process.platform = originalPlatform;
+		process.argv = originalArgv;
+		process.execPath = originalExecPath;
+		console.warn = originalWarn;
+	});
+
+	it("uses bare commands outside Windows", () => {
+		process.platform = "darwin";
+
+		expect(resolveSignetMcpCommand()).toEqual({ command: "signet-mcp", args: [] });
+		expect(resolveSignetCliCommand()).toEqual({ command: "signet", args: [] });
+	});
+
+	it("resolves packaged Windows entry points from the Signet CLI path", () => {
+		dir = mkdtempSync(join(tmpdir(), "signet-command-resolution-"));
+		const cliEntry = join(dir, "bin", "signet.js");
+		const mcpEntry = join(dir, "dist", "mcp-stdio.js");
+		mkdirSync(join(dir, "bin"), { recursive: true });
+		mkdirSync(join(dir, "dist"), { recursive: true });
+		writeFileSync(cliEntry, "", "utf8");
+		writeFileSync(mcpEntry, "", "utf8");
+		process.platform = "win32";
+		process.argv = ["node", cliEntry];
+		process.execPath = "C:\\Program Files\\nodejs\\node.exe";
+
+		expect(resolveSignetMcpCommand()).toEqual({ command: process.execPath, args: [mcpEntry] });
+		expect(resolveSignetCliCommand()).toEqual({ command: process.execPath, args: [cliEntry] });
+	});
+
+	it("warns once and returns the bare MCP command when the Windows entry point is missing", () => {
+		const warnings: string[] = [];
+		process.platform = "win32";
+		process.argv = ["node", "C:\\missing\\signetai\\bin\\signet.js"];
+		console.warn = (message?: unknown) => warnings.push(String(message));
+
+		expect(resolveSignetMcpCommand()).toEqual({ command: "signet-mcp", args: [] });
+		expect(warnings).toEqual([
+			'[signet] Warning: could not resolve mcp-stdio.js from argv[1]="C:\\missing\\signetai\\bin\\signet.js". MCP server config will use "signet-mcp" which may fail on Windows without shell:true.',
+		]);
 	});
 });
 

--- a/libs/connector-base/src/index.ts
+++ b/libs/connector-base/src/index.ts
@@ -242,9 +242,7 @@ export function isSignetGeneratedFile(raw: string): boolean {
 			// Daemon-generated: "# AUTO-GENERATED from <path> by Signet"
 			/^#\s+AUTO-GENERATED\s+from\s+.*\s+by\s+Signet/i.test(line) ||
 			// Connector-generated: "# Auto-generated from <path>" followed by "# Source: <path>" on the next line
-			(/^#\s+Auto-generated\s+from\s+/.test(line) &&
-				i + 1 < lines.length &&
-				/^#\s+Source:\s+/.test(lines[i + 1])),
+			(/^#\s+Auto-generated\s+from\s+/.test(line) && i + 1 < lines.length && /^#\s+Source:\s+/.test(lines[i + 1])),
 	);
 }
 
@@ -277,6 +275,39 @@ export function atomicWriteText(path: string, content: string, mode?: number): v
 
 export function atomicWriteJson(path: string, data: unknown, indent: number | string = 2): void {
 	atomicWriteText(path, `${JSON.stringify(data, null, indent)}\n`);
+}
+
+export type ResolvedCommand = { readonly command: string; readonly args: readonly string[] };
+
+function resolvePackagedSignetCommand(
+	bareCommand: string,
+	scriptDirectory: "bin" | "dist",
+	scriptName: string,
+	warnOnFallback: boolean,
+): ResolvedCommand {
+	if (process.platform !== "win32") return { command: bareCommand, args: [] };
+
+	const cliEntry = process.argv[1] ?? "";
+	const scriptPath = join(cliEntry, "..", "..", scriptDirectory, scriptName);
+	if (cliEntry && existsSync(scriptPath)) return { command: process.execPath, args: [scriptPath] };
+
+	if (warnOnFallback) {
+		console.warn(
+			`[signet] Warning: could not resolve ${scriptName} from argv[1]="${cliEntry}". ` +
+				`MCP server config will use "${bareCommand}" which may fail on Windows without shell:true.`,
+		);
+	}
+	return { command: bareCommand, args: [] };
+}
+
+/** Resolve the signet-mcp stdio command, including the packaged Windows entry point. */
+export function resolveSignetMcpCommand(): ResolvedCommand {
+	return resolvePackagedSignetCommand("signet-mcp", "dist", "mcp-stdio.js", true);
+}
+
+/** Resolve the Signet CLI command for hook invocation. */
+export function resolveSignetCliCommand(): ResolvedCommand {
+	return resolvePackagedSignetCommand("signet", "bin", "signet.js", false);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Centralizes packaged Signet CLI and MCP command resolution in `@signet/connector-base`, removing connector-specific Windows path probing and fixing Codex's stale `bin/mcp-stdio.js` lookup.


## Changes

- Add shared `resolveSignetMcpCommand()` and `resolveSignetCliCommand()` helpers with Windows packaged-path fallback coverage.
- Adapt Codex, Forge, OpenCode, and Claude Code to their native MCP configuration shapes.
- Preserve Codex remote HTTP MCP configuration and clean up pre-existing Biome diagnostics in touched connector files.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `@signet/connector-base`

## Screenshots

N/A — no UI changes.


## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec or dependency changes
- [x] Agent scoping verified on all new/changed data queries — N/A, no data queries
- [x] Input/config validation and bounds checks added — packaged path existence and fallback behavior covered
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints — N/A, no endpoints
- [x] Docs updated for API/spec/status changes — N/A, internal connector API only
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally — all affected files and packages pass; repository-wide baseline failures are pre-existing on `main`


## Migration Notes (if applicable)

- [x] Migration is idempotent — N/A, no migration
- [x] Daemon Rust parity reviewed or explicitly N/A — N/A, connector-only refactor
- [x] Rollback / compatibility note included in PR description — existing bare-command fallback and remote MCP behavior are preserved

## Testing

- [x] `bun test` passes — 109/109 affected tests pass; the full command was also run and its unrelated failures reproduce on clean `main`
- [x] `bun run typecheck` passes — all five affected packages pass; full-repo daemon/Bun SQLite typing failures reproduce on clean `main`
- [x] `bun run lint` passes — all six touched files pass Biome; full-repo formatting diagnostics reproduce on clean `main`
- [x] Tested against running daemon — Codex, OpenCode, Claude Code, and a locally built current Forge all report Signet connected through their real MCP harness commands
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Full-suite failures are outside the six changed files and pre-date this branch. A fresh `origin/main` worktree independently fails `bun test`, `bun run typecheck`, and `bun run lint`; the focused tests, builds, typechecks, and lint checks for this change are green.
- The shared resolver uses the published package layout: `bin/signet.js` for CLI hooks and `dist/mcp-stdio.js` for MCP stdio.

Closes #953
