### PR TITLE
fix(daemon): clean legacy config and honor repair dry runs

### DIFF
--- a/docs/api/operations.md
+++ b/docs/api/operations.md
@@ -468,6 +468,44 @@ top of hash-based dedup.
 }
 ```
 
+### POST /api/repair/relink-entities
+
+Attach unlinked memories to existing entities whose names appear in the memory
+content. The operation is agent-scoped and never creates new entities.
+
+**Request body**
+
+```json
+{
+  "agentId": "default",
+  "batchSize": 500,
+  "dryRun": true
+}
+```
+
+`batchSize` defaults to and is capped at `500`. The default remains
+`dryRun: false` for compatibility. With `dryRun: true`, Signet performs the
+same entity matching without changing mention rows or entity counters.
+`remaining` is the current persisted count, while `projectedRemaining` is the
+count that would remain if the preview were applied.
+
+**Dry-run response**
+
+```json
+{
+  "action": "relink-entities",
+  "dryRun": true,
+  "processed": 500,
+  "linked": 398,
+  "entities": 398,
+  "aspects": 0,
+  "attributes": 0,
+  "remaining": 7267,
+  "projectedRemaining": 6869,
+  "message": "dry run: 398 link(s) would be added across 398 memories; 6869 would remain unlinked"
+}
+```
+
 
 ## Pipeline
 

--- a/platform/daemon/src/config-migration.ts
+++ b/platform/daemon/src/config-migration.ts
@@ -11,7 +11,7 @@
  */
 import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { isMap, isPair, parseDocument, type Document } from "yaml";
+import { type Document, isMap, isPair, parseDocument } from "yaml";
 import { logger } from "./logger";
 
 // Flat keys: flip false → true
@@ -178,8 +178,9 @@ export function migrateInferenceProviders(agentsDir: string): void {
 			if (!isMap(target)) continue;
 			const execNode = target.get("executor", true);
 			const executor = execNode ? String(execNode) : undefined;
-			if (!executor || !(executor in EXECUTOR_AGENT_MAP)) continue;
-			const agent = EXECUTOR_AGENT_MAP[executor]!;
+			if (!executor) continue;
+			const agent = EXECUTOR_AGENT_MAP[executor];
+			if (!agent) continue;
 			// Only insert an acpx block if one isn't already present (avoid duplicates).
 			if (!target.has("acpx")) {
 				target.set("acpx", doc.createNode({ agent }));
@@ -228,7 +229,7 @@ function writeAtomic(path: string, contents: string): void {
 }
 
 // ---------------------------------------------------------------------------
-// v4: retire legacy pipelineV2 routing fields -> inference registry
+// v4/v5: retire legacy pipelineV2 routing fields -> inference registry
 // ---------------------------------------------------------------------------
 // Compiles memory.pipelineV2.extraction/synthesis routing fields into the
 // inference.accounts/targets/workloads registry (mirroring the daemon's
@@ -236,7 +237,11 @@ function writeAtomic(path: string, contents: string): void {
 // model, endpoint, fallbackProvider, command) so the registry is the single
 // source of truth. Tuning fields (timeout, maxTokens, enabled) are preserved.
 //
-// Guarded by configVersion: 4. Idempotent: a file already at v4+ is skipped.
+// v5 completes the v4 cleanup by removing legacy flat routing keys. It must
+// rerun for v4 configs because the incomplete migration shipped to users.
+// Idempotent: a file already at v5+ is skipped.
+
+const LEGACY_FLAT_KEYS = ["extractionProvider", "extractionModel", "extractionStrength"] as const;
 
 /** Map a legacy provider to the account name/id this migration creates. */
 function legacyAccountFor(provider: string): { name: string; family: string; cred: string } | null {
@@ -257,7 +262,7 @@ export function migrateLegacyRoutingToRegistry(agentsDir: string): void {
 	}
 
 	const vMatch = /^configVersion:\s*(\d+)/m.exec(text);
-	if (vMatch && Number(vMatch[1]) >= 4) return;
+	if (vMatch && Number(vMatch[1]) >= 5) return;
 
 	const doc = parseDocument(text);
 	if (doc.errors.length > 0) {
@@ -268,37 +273,39 @@ export function migrateLegacyRoutingToRegistry(agentsDir: string): void {
 		return;
 	}
 
+	const pipeline = doc.getIn(["memory", "pipelineV2"], true);
 	const extraction = doc.getIn(["memory", "pipelineV2", "extraction"], true);
 	const synthesis = doc.getIn(["memory", "pipelineV2", "synthesis"], true);
-	const hasLegacyRouting =
+	const hasLegacyFlatKeys = isMap(pipeline) && LEGACY_FLAT_KEYS.some((key) => pipeline.has(key));
+	const hasNestedLegacyRouting =
 		(isMap(extraction) && (extraction.has("provider") || extraction.has("model") || extraction.has("endpoint"))) ||
 		(isMap(synthesis) && (synthesis.has("provider") || synthesis.has("model") || synthesis.has("endpoint")));
 
-	if (!hasLegacyRouting) {
-		// Nothing to migrate; still stamp v4 so we don't re-parse every startup.
-		stampConfigVersion(doc, 4);
+	if (!hasNestedLegacyRouting && !hasLegacyFlatKeys) {
+		// Nothing to migrate; still stamp v5 so we don't re-parse every startup.
+		stampConfigVersion(doc, 5);
 		writeAtomic(path, doc.toString());
 		return;
 	}
 
 	const mutations: string[] = [];
 
-	// Ensure inference/accounts and inference/targets maps exist.
-	const inference =
-		doc.getIn(["inference"], true) ??
-		doc.setIn(["inference"], doc.createNode({})) ??
-		doc.getIn(["inference"], true);
-	if (!isMap(inference)) {
-		doc.setIn(["inference"], doc.createNode({}));
-	}
-	if (!doc.getIn(["inference", "targets"], true)) {
-		doc.setIn(["inference", "targets"], doc.createNode({}));
-	}
-	if (!doc.getIn(["inference", "accounts"], true)) {
-		doc.setIn(["inference", "accounts"], doc.createNode({}));
-	}
-	if (!doc.getIn(["inference", "workloads"], true)) {
-		doc.setIn(["inference", "workloads"], doc.createNode({}));
+	if (hasNestedLegacyRouting) {
+		// Ensure inference/accounts and inference/targets maps exist.
+		const inference =
+			doc.getIn(["inference"], true) ?? doc.setIn(["inference"], doc.createNode({})) ?? doc.getIn(["inference"], true);
+		if (!isMap(inference)) {
+			doc.setIn(["inference"], doc.createNode({}));
+		}
+		if (!doc.getIn(["inference", "targets"], true)) {
+			doc.setIn(["inference", "targets"], doc.createNode({}));
+		}
+		if (!doc.getIn(["inference", "accounts"], true)) {
+			doc.setIn(["inference", "accounts"], doc.createNode({}));
+		}
+		if (!doc.getIn(["inference", "workloads"], true)) {
+			doc.setIn(["inference", "workloads"], doc.createNode({}));
+		}
 	}
 
 	function compileTarget(
@@ -322,11 +329,14 @@ export function migrateLegacyRoutingToRegistry(agentsDir: string): void {
 		// Create the account if the provider needs one.
 		const acct = legacyAccountFor(provider);
 		if (acct) {
-			doc.setIn(["inference", "accounts", acct.name], doc.createNode({
-				kind: "api",
-				providerFamily: acct.family,
-				credentialRef: acct.cred,
-			}));
+			doc.setIn(
+				["inference", "accounts", acct.name],
+				doc.createNode({
+					kind: "api",
+					providerFamily: acct.family,
+					credentialRef: acct.cred,
+				}),
+			);
 		}
 		// Create/update the target.
 		const targetNode = doc.createNode({
@@ -337,14 +347,19 @@ export function migrateLegacyRoutingToRegistry(agentsDir: string): void {
 		});
 		doc.setIn(["inference", "targets", targetName], targetNode);
 		// Bind the workload to it.
-		doc.setIn(["inference", "workloads", workloadKey], doc.createNode({
-			target: `${targetName}/default`,
-		}));
+		doc.setIn(
+			["inference", "workloads", workloadKey],
+			doc.createNode({
+				target: `${targetName}/default`,
+			}),
+		);
 		mutations.push(`${workloadKey} -> inference.targets.${targetName} (executor: ${provider})`);
 	}
 
-	compileTarget(extraction, "legacy-extraction", "memoryExtraction");
-	compileTarget(synthesis, "legacy-synthesis", "sessionSynthesis");
+	if (hasNestedLegacyRouting) {
+		compileTarget(extraction, "legacy-extraction", "memoryExtraction");
+		compileTarget(synthesis, "legacy-synthesis", "sessionSynthesis");
+	}
 
 	// Null the legacy ROUTING keys (keep tuning: timeout, maxTokens, enabled).
 	function nullRoutingKeys(node: ReturnType<typeof doc.getIn>, label: string): void {
@@ -362,7 +377,26 @@ export function migrateLegacyRoutingToRegistry(agentsDir: string): void {
 	nullRoutingKeys(extraction, "extraction");
 	nullRoutingKeys(synthesis, "synthesis");
 
-	stampConfigVersion(doc, 4);
+	if (isMap(pipeline)) {
+		const flatStrength = pipeline.get("extractionStrength");
+		if (flatStrength !== undefined && flatStrength !== null) {
+			const canonicalExtraction = isMap(extraction) ? extraction : doc.createNode({ strength: flatStrength });
+			if (!isMap(extraction)) {
+				pipeline.set("extraction", canonicalExtraction);
+			} else {
+				canonicalExtraction.set("strength", flatStrength);
+			}
+			mutations.push("moved memory.pipelineV2.extractionStrength -> extraction.strength");
+		}
+		for (const key of LEGACY_FLAT_KEYS) {
+			if (pipeline.has(key)) {
+				pipeline.delete(key);
+				mutations.push(`removed memory.pipelineV2.${key}`);
+			}
+		}
+	}
+
+	stampConfigVersion(doc, 5);
 	writeAtomic(path, doc.toString());
 
 	if (mutations.length > 0) {

--- a/platform/daemon/src/inline-entity-linker.ts
+++ b/platform/daemon/src/inline-entity-linker.ts
@@ -8,7 +8,8 @@
  * intent, or reviewed repair/normalization passes.
  */
 
-import type { WriteDb } from "./db-accessor";
+import type { ReadDb, WriteDb } from "./db-accessor";
+import { countChanges } from "./db-helpers";
 
 // ---------------------------------------------------------------------------
 // Decision pattern detection
@@ -256,7 +257,7 @@ export function extractCandidateNames(text: string): string[] {
 // Existing entity resolution
 // ---------------------------------------------------------------------------
 
-function resolveKnownEntity(db: WriteDb, name: string, agentId: string, now: string): string {
+function findKnownEntityId(db: ReadDb, name: string, agentId: string): string {
 	const canonical = name.trim().toLowerCase().replace(/\s+/g, " ");
 	if (canonical.length < 3) return "";
 
@@ -268,12 +269,14 @@ function resolveKnownEntity(db: WriteDb, name: string, agentId: string, now: str
 		)
 		.get(canonical, name, agentId) as { id: string } | undefined;
 
-	if (existing) {
-		db.prepare("UPDATE entities SET mentions = mentions + 1, updated_at = ? WHERE id = ?").run(now, existing.id);
-		return existing.id;
-	}
+	return existing?.id ?? "";
+}
 
-	return "";
+function resolveKnownEntity(db: WriteDb, name: string, agentId: string, now: string): string {
+	const entityId = findKnownEntityId(db, name, agentId);
+	if (!entityId) return "";
+	db.prepare("UPDATE entities SET mentions = mentions + 1, updated_at = ? WHERE id = ?").run(now, entityId);
+	return entityId;
 }
 
 // ---------------------------------------------------------------------------
@@ -285,6 +288,26 @@ export interface LinkResult {
 	readonly entityIds: string[];
 	readonly aspects: number;
 	readonly attributes: number;
+}
+
+/** Preview the links `linkMemoryToEntities` would create without mutating graph state. */
+export function previewMemoryEntityLinks(db: ReadDb, memoryId: string, content: string, agentId: string): LinkResult {
+	const names = extractCandidateNames(content);
+	if (names.length === 0) return { linked: 0, entityIds: [], aspects: 0, attributes: 0 };
+
+	let linked = 0;
+	const entityIds: string[] = [];
+	for (const name of names) {
+		const entityId = findKnownEntityId(db, name, agentId);
+		if (!entityId) continue;
+		entityIds.push(entityId);
+		const existingMention = db
+			.prepare("SELECT 1 FROM memory_entity_mentions WHERE memory_id = ? AND entity_id = ? LIMIT 1")
+			.get(memoryId, entityId);
+		if (!existingMention) linked++;
+	}
+
+	return { linked, entityIds, aspects: 0, attributes: 0 };
 }
 
 /**
@@ -316,7 +339,7 @@ export function linkMemoryToEntities(db: WriteDb, memoryId: string, content: str
 			 VALUES (?, ?, ?, 0.8, ?)`,
 			)
 			.run(memoryId, entityId, name, now);
-		if (ins.changes > 0) linked++;
+		if (countChanges(ins) > 0) linked++;
 	}
 
 	return { linked, entityIds, aspects: 0, attributes: 0 };

--- a/platform/daemon/src/legacy-routing-migration.test.ts
+++ b/platform/daemon/src/legacy-routing-migration.test.ts
@@ -10,7 +10,7 @@ function setupDir(): string {
 	return dir;
 }
 
-describe("migrateLegacyRoutingToRegistry (#947 v4)", () => {
+describe("migrateLegacyRoutingToRegistry (#947 v4, #1004 v5 cleanup)", () => {
 	it("compiles legacy extraction + synthesis into inference registry and nulls routing keys", () => {
 		const dir = setupDir();
 		try {
@@ -59,7 +59,7 @@ describe("migrateLegacyRoutingToRegistry (#947 v4)", () => {
 			expect(after).toContain("maxTokens: 1024");
 
 			// Version stamped.
-			expect(after).toMatch(/^configVersion: 4/m);
+			expect(after).toMatch(/^configVersion: 5/m);
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -134,7 +134,7 @@ describe("migrateLegacyRoutingToRegistry (#947 v4)", () => {
 		}
 	});
 
-	it("stamps v4 even when there is no legacy routing to migrate", () => {
+	it("stamps v5 even when there is no legacy routing to migrate", () => {
 		const dir = setupDir();
 		try {
 			writeFileSync(
@@ -150,9 +150,79 @@ inference:
 			);
 			migrateLegacyRoutingToRegistry(dir);
 			const after = readFileSync(join(dir, "agent.yaml"), "utf-8");
-			expect(after).toMatch(/^configVersion: 4/m);
+			expect(after).toMatch(/^configVersion: 5/m);
 			// Existing inference block untouched.
 			expect(after).toContain("background:");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("cleans flat routing keys from already-migrated v4 configs while preserving tuning", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`configVersion: 4
+memory:
+  pipelineV2:
+    enabled: true
+    extractionProvider: acpx
+    extractionModel: gpt-5.3-codex-spark
+    extractionStrength: medium
+    extractionTimeout: 45000
+    extraction:
+      harness: codex
+      timeout: 90000
+      strength: low
+inference:
+  targets:
+    background-acpx:
+      executor: acpx
+      models:
+        default:
+          model: gpt-5.3-codex-spark
+  workloads:
+    memoryExtraction:
+      target: background-acpx/default
+`,
+			);
+
+			migrateLegacyRoutingToRegistry(dir);
+			const after = readFileSync(join(dir, "agent.yaml"), "utf-8");
+
+			expect(after).toMatch(/^configVersion: 5/m);
+			expect(after).not.toContain("extractionProvider:");
+			expect(after).not.toContain("extractionModel:");
+			expect(after).not.toContain("extractionStrength:");
+			expect(after).toMatch(/extraction:\s*\n\s+harness: codex\s*\n\s+timeout: 90000\s*\n\s+strength: medium/);
+			expect(after).toContain("extractionTimeout: 45000");
+			expect(after).toContain("enabled: true");
+			expect(after).toContain("target: background-acpx/default");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps canonical strength when the legacy flat value is null", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`configVersion: 4
+memory:
+  pipelineV2:
+    extractionStrength: null
+    extraction:
+      strength: high
+`,
+			);
+
+			migrateLegacyRoutingToRegistry(dir);
+			const after = readFileSync(join(dir, "agent.yaml"), "utf-8");
+
+			expect(after).not.toContain("extractionStrength:");
+			expect(after).toContain("strength: high");
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}

--- a/platform/daemon/src/routes/repair-routes.test.ts
+++ b/platform/daemon/src/routes/repair-routes.test.ts
@@ -1,0 +1,149 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import { parseAuthConfig } from "../auth";
+import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
+import { registerRepairRoutes } from "./repair-routes";
+
+let db: Database;
+let accessor: DbAccessor;
+
+function makeAccessor(database: Database): DbAccessor {
+	return {
+		withReadDb<T>(fn: (readDb: ReadDb) => T): T {
+			return fn(database as unknown as ReadDb);
+		},
+		withWriteTx<T>(fn: (writeDb: WriteDb) => T): T {
+			database.exec("BEGIN IMMEDIATE");
+			try {
+				const result = fn(database as unknown as WriteDb);
+				database.exec("COMMIT");
+				return result;
+			} catch (error) {
+				database.exec("ROLLBACK");
+				throw error;
+			}
+		},
+		close(): void {},
+	};
+}
+
+function makeApp(): Hono {
+	const app = new Hono();
+	registerRepairRoutes(app, {
+		authConfig: parseAuthConfig(undefined, "/tmp/signet-repair-routes-test"),
+		getDbAccessor: () => accessor,
+	});
+	return app;
+}
+
+function requestHeaders(): Record<string, string> {
+	return { "Content-Type": "application/json" };
+}
+
+function seedRelinkCandidate(): void {
+	const now = new Date().toISOString();
+	accessor.withWriteTx((db) => {
+		db.prepare(
+			`INSERT INTO memories (id, content, type, agent_id, created_at, updated_at, updated_by)
+			 VALUES (?, ?, 'fact', ?, ?, ?, 'test')`,
+		).run("memory-relink", "Nicholai maintains Signet.", "agent-relink", now, now);
+		db.prepare(
+			`INSERT INTO entities (
+				id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at
+			) VALUES (?, ?, ?, 'person', ?, 0, ?, ?)`,
+		).run("entity-nicholai", "Nicholai", "nicholai", "agent-relink", now, now);
+	});
+}
+
+function readMutationState(): { mentions: number; entityMentions: number } {
+	return accessor.withReadDb((db) => {
+		const mentionRow = db.prepare("SELECT COUNT(*) AS count FROM memory_entity_mentions").get() as { count: number };
+		const entityRow = db.prepare("SELECT mentions FROM entities WHERE id = ?").get("entity-nicholai") as {
+			mentions: number;
+		};
+		return { mentions: mentionRow.count, entityMentions: entityRow.mentions };
+	});
+}
+
+beforeEach(() => {
+	db = new Database(":memory:");
+	db.exec(`
+		CREATE TABLE memories (
+			id TEXT PRIMARY KEY,
+			content TEXT NOT NULL,
+			type TEXT,
+			agent_id TEXT,
+			is_deleted INTEGER DEFAULT 0,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			updated_by TEXT
+		);
+		CREATE TABLE entities (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			canonical_name TEXT,
+			entity_type TEXT,
+			agent_id TEXT NOT NULL,
+			mentions INTEGER DEFAULT 0,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+		CREATE TABLE memory_entity_mentions (
+			memory_id TEXT NOT NULL,
+			entity_id TEXT NOT NULL,
+			mention_text TEXT,
+			confidence REAL,
+			created_at TEXT,
+			PRIMARY KEY (memory_id, entity_id)
+		);
+	`);
+	accessor = makeAccessor(db);
+	seedRelinkCandidate();
+});
+
+afterEach(() => {
+	db.close();
+});
+
+describe("POST /api/repair/relink-entities", () => {
+	it("previews relinking without persisting mentions when dryRun is true", async () => {
+		const before = readMutationState();
+		const response = await makeApp().request("/api/repair/relink-entities", {
+			method: "POST",
+			headers: requestHeaders(),
+			body: JSON.stringify({ agentId: "agent-relink", batchSize: 1, dryRun: true }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({
+			action: "relink-entities",
+			dryRun: true,
+			processed: 1,
+			linked: 1,
+			entities: 1,
+			remaining: 1,
+			projectedRemaining: 0,
+		});
+		expect(readMutationState()).toEqual(before);
+	});
+
+	it("still persists the same links when dryRun is false", async () => {
+		const response = await makeApp().request("/api/repair/relink-entities", {
+			method: "POST",
+			headers: requestHeaders(),
+			body: JSON.stringify({ agentId: "agent-relink", batchSize: 1, dryRun: false }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({
+			action: "relink-entities",
+			dryRun: false,
+			processed: 1,
+			linked: 1,
+			entities: 1,
+			remaining: 0,
+		});
+		expect(readMutationState()).toEqual({ mentions: 1, entityMentions: 1 });
+	});
+});

--- a/platform/daemon/src/routes/repair-routes.ts
+++ b/platform/daemon/src/routes/repair-routes.ts
@@ -1,9 +1,9 @@
 import type { Context, Hono } from "hono";
 import { resolveAgentId, resolveDaemonAgentId } from "../agent-id";
-import { requirePermission } from "../auth";
-import { getDbAccessor } from "../db-accessor.js";
+import { type AuthConfig, requirePermission } from "../auth";
+import { type DbAccessor, getDbAccessor } from "../db-accessor.js";
 import { fetchEmbedding } from "../embedding-fetch.js";
-import { linkMemoryToEntities } from "../inline-entity-linker.js";
+import { linkMemoryToEntities, previewMemoryEntityLinks } from "../inline-entity-linker.js";
 import { getLlmProvider } from "../llm.js";
 import { loadMemoryConfig } from "../memory-config.js";
 import { clusterEntities } from "../pipeline/community-detection.js";
@@ -23,8 +23,8 @@ import {
 	pruneChunkGroupEntities,
 	pruneGenericEntities,
 	pruneSingletonExtractedEntities,
-	reclassifyEntities,
 	rebuildDerivedIndexes,
+	reclassifyEntities,
 	reembedMissingMemories,
 	releaseStaleLeases,
 	requeueDeadJobs,
@@ -78,13 +78,19 @@ function resolveRepairAgentId(c: Context, body: Readonly<Record<string, unknown>
 	});
 }
 
-export function registerRepairRoutes(app: Hono): void {
+export function registerRepairRoutes(
+	app: Hono,
+	deps: {
+		readonly authConfig?: AuthConfig;
+		readonly getDbAccessor?: () => DbAccessor;
+	} = {},
+): void {
 	// Permission guards
 	app.use("/api/repair/*", async (c, next) => {
-		return requirePermission("admin", authConfig)(c, next);
+		return requirePermission("admin", deps.authConfig ?? authConfig)(c, next);
 	});
 	app.use("/api/troubleshoot/*", async (c, next) => {
-		return requirePermission("admin", authConfig)(c, next);
+		return requirePermission("admin", deps.authConfig ?? authConfig)(c, next);
 	});
 
 	app.post("/api/repair/requeue-dead", (c) => {
@@ -390,15 +396,19 @@ export function registerRepairRoutes(app: Hono): void {
 
 	app.post("/api/repair/relink-entities", async (c) => {
 		let batchSize = 500;
+		let dryRun = false;
 		let body: Record<string, unknown> = {};
 		try {
 			body = asRecord(await c.req.json());
-			if (typeof body?.batchSize === "number") batchSize = body.batchSize;
+			if (typeof body.batchSize === "number" && Number.isFinite(body.batchSize) && body.batchSize > 0) {
+				batchSize = Math.min(Math.floor(body.batchSize), 500);
+			}
+			if (typeof body.dryRun === "boolean") dryRun = body.dryRun;
 		} catch {
 			// defaults
 		}
 		const agentId = resolveRepairAgentId(c, body);
-		const accessor = getDbAccessor();
+		const accessor = deps.getDbAccessor?.() ?? getDbAccessor();
 
 		const unlinked = accessor.withReadDb(
 			(db) =>
@@ -414,7 +424,63 @@ export function registerRepairRoutes(app: Hono): void {
 		);
 
 		if (unlinked.length === 0) {
-			return c.json({ action: "relink-entities", linked: 0, remaining: 0, message: "all memories linked" });
+			return c.json({
+				action: "relink-entities",
+				dryRun,
+				processed: 0,
+				linked: 0,
+				entities: 0,
+				aspects: 0,
+				attributes: 0,
+				remaining: 0,
+				...(dryRun ? { projectedRemaining: 0 } : {}),
+				message: "all memories linked",
+			});
+		}
+
+		if (dryRun) {
+			const preview = accessor.withReadDb((db) => {
+				let linked = 0;
+				let entities = 0;
+				let aspects = 0;
+				let attributes = 0;
+				let linkedMemories = 0;
+
+				for (const mem of unlinked) {
+					const result = previewMemoryEntityLinks(db, mem.id, mem.content, agentId);
+					linked += result.linked;
+					entities += result.entityIds.length;
+					aspects += result.aspects;
+					attributes += result.attributes;
+					if (result.linked > 0) linkedMemories++;
+				}
+
+				const remaining = (
+					db
+						.prepare(
+							`SELECT COUNT(*) as cnt FROM memories
+			 WHERE is_deleted = 0
+			   AND COALESCE(NULLIF(agent_id, ''), 'default') = ?
+			   AND id NOT IN (SELECT DISTINCT memory_id FROM memory_entity_mentions)`,
+						)
+						.get(agentId) as { cnt: number }
+				).cnt;
+
+				return { linked, entities, aspects, attributes, linkedMemories, remaining };
+			});
+			const projectedRemaining = Math.max(0, preview.remaining - preview.linkedMemories);
+			return c.json({
+				action: "relink-entities",
+				dryRun: true,
+				processed: unlinked.length,
+				linked: preview.linked,
+				entities: preview.entities,
+				aspects: preview.aspects,
+				attributes: preview.attributes,
+				remaining: preview.remaining,
+				projectedRemaining,
+				message: `dry run: ${preview.linked} link(s) would be added across ${preview.linkedMemories} memories; ${projectedRemaining} would remain unlinked`,
+			});
 		}
 
 		let linked = 0;
@@ -446,6 +512,7 @@ export function registerRepairRoutes(app: Hono): void {
 
 		return c.json({
 			action: "relink-entities",
+			dryRun: false,
 			processed: unlinked.length,
 			linked,
 			entities,


### PR DESCRIPTION
## Summary

Complete the v4 legacy routing migration by removing obsolete flat `pipelineV2` routing keys from configs that have already migrated. Also fix the unrelated repair UX finding from #1006 so `POST /api/repair/relink-entities` honors `dryRun: true` without persisting graph changes.

Closes #1004
Addresses the `relink-entities` secondary finding in #1006.

## Changes

- Detect `extractionProvider`, `extractionModel`, and `extractionStrength` as legacy migration work.
- Rerun the config cleanup once for shipped v4 configs, then stamp v5 for idempotency.
- Preserve flat strength precedence in `pipelineV2.extraction.strength` while leaving timeout, max-token, enabled, and other nested tuning fields intact.
- Avoid creating empty inference registry maps when a config only needs flat-key cleanup.
- Preview entity relinking through read-only matching when `dryRun: true`; mention rows and entity counters remain unchanged.
- Return explicit dry-run mode, current `remaining`, and `projectedRemaining` counts, while preserving the existing applied behavior.
- Bound relink batches to 500 items and document the repair request/response contract.
- Add isolated route regressions for both preview and applied relinking, alongside the v5 migration regressions.

## Type

<!-- Check one. -->

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

<!-- Check all that apply. -->

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

<!-- Derived from AGENTS.md recurring review failures. These checks are
     required and enforced by CI. -->

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec dependency is affected.
- [x] Agent scoping verified on all new/changed data queries — relink selection, entity matching, and remaining counts all use the resolved agent ID.
- [x] Input/config validation and bounds checks added — YAML mapping guards remain in place; relink batch input must be finite and positive and is capped at 500.
- [x] Error handling and fallback paths tested (no silent swallow) — malformed YAML and null strength fallbacks remain covered; dry-run and applied route paths are both covered.
- [x] Security checks applied to admin/mutation endpoints — the existing admin permission guard remains active and is exercised by the auth guard suite.
- [x] Docs updated for API/spec/status changes — the relink dry-run contract is documented in `docs/api/operations.md`.
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally — changed files and focused tests pass; repository-wide baseline failures are detailed below and reproduce on clean `origin/main`.

## Migration Notes (if applicable)

<!-- Fill this section only when migrations are touched. -->

- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A — N/A; the startup config-file migration and this TypeScript repair route have no Rust counterpart.
- [x] Rollback / compatibility note included in PR description — v4 configs migrate forward once to v5; non-null flat strength is preserved in the canonical nested field. Relink remains mutating by default for compatibility and only previews when `dryRun: true`.

## Testing

<!-- How did you verify this works? -->

- [x] `bun test` passes — changed migration/linking/route suites: 19 passed, 0 failed (74 assertions). The required repository-wide run completed with 3,019 passed / 108 failed / 20 errors; clean `origin/main` reproduced the pre-existing baseline with 3,014 passed / 109 failed / 20 errors. Both new relink route tests pass in the full run.
- [x] `bun run typecheck` passes — no changed file reports an error. The required repository-wide run has 456 pre-existing errors versus 457 on clean `origin/main`.
- [x] `bun run lint` passes — all changed TypeScript files pass Biome. The required repository-wide run reports 1,812 errors / 142 warnings versus 1,815 errors / 143 warnings on clean `origin/main`.
- [x] Tested against running daemon — built the daemon and verified both runtime paths: v4-to-v5 config migration through healthy startup, and a real authenticated repair route dry run that returned the preview while direct SQLite inspection remained at zero mention rows and zero entity counter increments.
- [ ] N/A

Additional focused verification:

- `bun run build:core`
- `bun run --filter '@signet/daemon' build`
- `bunx biome check platform/daemon/src/config-migration.ts platform/daemon/src/legacy-routing-migration.test.ts platform/daemon/src/inline-entity-linker.ts platform/daemon/src/routes/repair-routes.ts platform/daemon/src/routes/repair-routes.test.ts`
- `bun test platform/daemon/src/config-migration.test.ts platform/daemon/src/legacy-routing-migration.test.ts platform/daemon/src/inline-entity-linker.test.ts platform/daemon/src/routes/repair-routes.test.ts`
- Concurrent auth/isolation regression run: 37 passed, 0 failed

## AI disclosure

<!-- See AI_POLICY.md for the full policy. The short version:

  Use AI freely, but understand everything you ship. AI is your hands,
  not your brain. Unreviewed AI output will be closed.

  If AI was used, include Assisted-by tags in your commit messages:

    Assisted-by: Claude-Code:claude-opus-4-6
    Assisted-by: Cursor:claude-sonnet-4-5 biome

  If no AI was used, check the box and move on.
-->

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The v4 migration shipped in v0.150.2, so extending a migration guarded at `configVersion >= 4` would not repair existing users. Advancing this cleanup to v5 ensures those configs are repaired on their next daemon start.

This PR addresses only the explicitly unrelated `relink-entities` secondary finding in #1006. It does not claim to resolve or close the macOS IOAccelerator memory investigation.
