### PR TITLE
fix(test): await native smoke child teardown

### DIFF
--- a/scripts/native-embedding-runtime-smoke.test.ts
+++ b/scripts/native-embedding-runtime-smoke.test.ts
@@ -10,6 +10,29 @@ const root = join(import.meta.dir, "..");
 const enabled = process.env.SIGNET_NATIVE_EMBEDDING_SMOKE === "1";
 const tempDirs: string[] = [];
 const children: ChildProcessWithoutNullStreams[] = [];
+const CHILD_KILL_REAP_MS = 2_000;
+const CHILD_TERM_GRACE_MS = 2_000;
+
+interface StoppableChild {
+	readonly exitCode: number | null;
+	kill(signal: "SIGTERM" | "SIGKILL"): void;
+	once(event: "close", listener: () => void): void;
+}
+
+interface StopTimings {
+	readonly termGraceMs: number;
+	readonly killReapMs: number;
+}
+
+function closesWithin(closed: Promise<true>, timeoutMs: number): Promise<boolean> {
+	return new Promise((resolve) => {
+		const timer = setTimeout(() => resolve(false), timeoutMs);
+		void closed.then(() => {
+			clearTimeout(timer);
+			resolve(true);
+		});
+	});
+}
 
 /** Resolve the compiled native binary to smoke-test.
  *  Honors an explicit SIGNET_NATIVE_SMOKE_BINARY override (release CI builds to
@@ -60,22 +83,19 @@ function floatVector(value: unknown): Float32Array {
 	return new Float32Array(value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength));
 }
 
-async function stopChild(child: ChildProcessWithoutNullStreams): Promise<void> {
+async function stopChild(
+	child: StoppableChild,
+	timings: StopTimings = { termGraceMs: CHILD_TERM_GRACE_MS, killReapMs: CHILD_KILL_REAP_MS },
+): Promise<void> {
 	if (child.exitCode !== null) return;
+	const closed = new Promise<true>((resolve) => child.once("close", () => resolve(true)));
 	child.kill("SIGTERM");
-	// Keep the SIGTERM grace window well under bun's default afterEach timeout
-	// (5s). A healthy daemon honors SIGTERM in milliseconds; only a deliberately
-	// wedged child (the isolation test pins it on a blackhole fetch) holds out,
-	// and SIGKILL at 2s is safe on a throwaway process. At 5s the grace window
-	// collided with the hook timeout, so the slowest runner (darwin-arm64)
-	// deterministically reported "a beforeEach/afterEach hook timed out" even
-	// though the test body passed.
-	await Promise.race([
-		new Promise<void>((resolve) => child.once("close", () => resolve())),
-		Bun.sleep(2_000).then(() => {
-			if (child.exitCode === null) child.kill("SIGKILL");
-		}),
-	]);
+	if (await closesWithin(closed, timings.termGraceMs)) return;
+
+	if (child.exitCode === null) child.kill("SIGKILL");
+	if (!(await closesWithin(closed, timings.killReapMs))) {
+		throw new Error(`native smoke child did not close within ${timings.killReapMs}ms after SIGKILL`);
+	}
 }
 
 const blackholeServers: Server[] = [];
@@ -101,6 +121,46 @@ afterEach(async () => {
 	for (const child of children.splice(0)) await stopChild(child);
 	for (const server of blackholeServers.splice(0)) server.close();
 	for (const path of tempDirs.splice(0)) rmSync(path, { recursive: true, force: true });
+}, 30_000);
+
+describe("native embedding smoke teardown", () => {
+	test("waits for close after escalating a SIGTERM-resistant child", async () => {
+		const signals: string[] = [];
+		let closed = false;
+		let onClose: (() => void) | undefined;
+		const child: StoppableChild = {
+			exitCode: null,
+			kill(signal) {
+				signals.push(signal);
+				if (signal === "SIGKILL") {
+					setTimeout(() => {
+						closed = true;
+						onClose?.();
+					}, 10);
+				}
+			},
+			once(_event, listener) {
+				onClose = listener;
+			},
+		};
+
+		await stopChild(child, { termGraceMs: 1, killReapMs: 100 });
+
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+		expect(closed).toBe(true);
+	});
+
+	test("fails within the reap bound when a killed child never closes", async () => {
+		const child: StoppableChild = {
+			exitCode: null,
+			kill() {},
+			once() {},
+		};
+
+		await expect(stopChild(child, { termGraceMs: 1, killReapMs: 5 })).rejects.toThrow(
+			"native smoke child did not close within 5ms after SIGKILL",
+		);
+	});
 });
 
 describe("compiled native embedding runtime", () => {


### PR DESCRIPTION
## Summary

Completes the native embedding smoke teardown hardening from #994 so the release gate waits for the spawned daemon to actually close after escalation and cannot collide with Bun's default hook timeout.

Closes #964

## Changes

- Reuse one `close` promise across the SIGTERM grace period and the SIGKILL reap period.
- Bound post-SIGKILL reaping at 2 seconds and report a diagnostic failure if the child never closes.
- Give the cleanup hook an explicit 30-second timeout.
- Add always-on regression tests for a SIGTERM-resistant child and a missing `close` event.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: native release smoke harness

## Screenshots

N/A — test-harness-only change.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — N/A; no product/spec behavior changed.
- [x] Agent scoping verified on all new/changed data queries — N/A; no data queries changed.
- [x] Input/config validation and bounds checks added — teardown now has explicit grace, reap, and hook bounds.
- [x] Error handling and fallback paths tested (no silent swallow) — missing `close` now fails with a bounded diagnostic.
- [x] Security checks applied to admin/mutation endpoints — N/A; no endpoint changes.
- [x] Docs updated for API/spec/status changes — N/A; no API/spec/status changes.
- [x] Regression tests added for each bug fix — escalation/reap and missing-close cases covered.
- [x] Lint/typecheck/tests pass locally — changed file passes focused tests and Biome; mandatory broad commands were run and their unrelated failures reproduce on clean `main` as detailed below.

## Migration Notes (if applicable)

- [x] Migration is idempotent — N/A; no migration.
- [x] Daemon Rust parity reviewed or explicitly N/A — N/A; test harness only.
- [x] Rollback / compatibility note included in PR description — N/A; no runtime compatibility change.

## Testing

- [x] `bun test` passes — changed file and runtime pass. Broad branch: 3428 pass, 101 fail, 4 errors; identically built clean `main`: 3426 pass, the same 101 fail and 4 errors. The branch delta is the two new passing regression tests; broad failures are pre-existing and do not involve the changed file.
- [x] `bun run typecheck` passes — changed smoke file compiles in focused and native-runtime tests. The mandatory broad command was run; its daemon `rootDir`/SQLite typing failures reproduce unchanged on clean `main` and do not reference the changed file.
- [x] `bun run lint` passes — `bunx biome check scripts/native-embedding-runtime-smoke.test.ts` passes. The mandatory broad command was run; existing repository formatting diagnostics reproduce on clean `main` and do not include the changed file.
- [x] Tested against running daemon — built the full workspace/dashboard/native executable and ran the compiled native embedding smoke: 4 pass, including the stalled-download `/health` case.
- [x] N/A — UI/migration testing is not applicable; runtime proof is included above.

Additional focused proof:

- `bun test --rerun-each 100 scripts/native-embedding-runtime-smoke.test.ts` — 200 pass, 0 fail (compiled-native cases intentionally skipped without the opt-in env).
- `SIGNET_NATIVE_EMBEDDING_SMOKE=1 SIGNET_NATIVE_SMOKE_BINARY=./dist/native/signet-darwin-arm64 bun test scripts/native-embedding-runtime-smoke.test.ts` — 4 pass, 0 fail.
- `bun run build`, `bun run build:dashboard`, and `bun run build:native-bun` — pass.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

#994 shortened the SIGTERM grace window but still resolved immediately after sending SIGKILL. This PR completes issue #964's recommended action by awaiting `close` under a second hard bound and setting an explicit cleanup-hook budget.
