### PR TITLE
refactor(connector-base): share lenient JSON parsing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -167,7 +167,6 @@
       "dependencies": {
         "@signet/connector-base": "0.142.4",
         "@signet/core": "0.142.4",
-        "json5": "^2.2.3",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -264,6 +263,8 @@
       "version": "0.154.0",
       "dependencies": {
         "@signet/core": "0.142.4",
+        "json5": "^2.2.3",
+        "jsonc-parser": "3.3.1",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/integrations/openclaw/connector/package.json
+++ b/integrations/openclaw/connector/package.json
@@ -26,8 +26,7 @@
   },
   "dependencies": {
     "@signet/connector-base": "0.154.0",
-    "@signet/core": "0.154.0",
-    "json5": "^2.2.3"
+    "@signet/core": "0.154.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/openclaw/connector/src/index.ts
+++ b/integrations/openclaw/connector/src/index.ts
@@ -25,14 +25,15 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { homedir, tmpdir } from "node:os";
 import { delimiter, join, resolve } from "node:path";
 import { BaseConnector, type InstallResult, type UninstallResult, atomicWriteJson } from "@signet/connector-base";
+import { parseLenientJsonObject } from "@signet/connector-base/lenient-json";
 import { expandHome } from "@signet/core";
-import { parse as parseJson5 } from "json5";
 
 // ============================================================================
 // Deep merge helper
 // ============================================================================
 
 type JsonObject = Record<string, unknown>;
+const OPENCLAW_PARSE_OPTIONS = { label: "OpenClaw config" } as const;
 
 function isJsonObject(value: unknown): value is JsonObject {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -110,71 +111,6 @@ function deepMerge(target: JsonObject, source: JsonObject): JsonObject {
 	return target;
 }
 
-function stripJsonComments(source: string): string {
-	let result = "";
-	let inString = false;
-	let quote = '"';
-	let escaped = false;
-	let inSingleLineComment = false;
-	let inMultiLineComment = false;
-
-	for (let i = 0; i < source.length; i++) {
-		const ch = source[i];
-		const next = source[i + 1];
-
-		if (inSingleLineComment) {
-			if (ch === "\n") {
-				inSingleLineComment = false;
-				result += ch;
-			}
-			continue;
-		}
-
-		if (inMultiLineComment) {
-			if (ch === "*" && next === "/") {
-				inMultiLineComment = false;
-				i++;
-			}
-			continue;
-		}
-
-		if (inString) {
-			result += ch;
-			if (escaped) {
-				escaped = false;
-			} else if (ch === "\\") {
-				escaped = true;
-			} else if (ch === quote) {
-				inString = false;
-			}
-			continue;
-		}
-
-		if (ch === '"' || ch === "'") {
-			inString = true;
-			quote = ch;
-			result += ch;
-			continue;
-		}
-
-		if (ch === "/" && next === "/") {
-			inSingleLineComment = true;
-			i++;
-			continue;
-		}
-
-		if (ch === "/" && next === "*") {
-			inMultiLineComment = true;
-			i++;
-			continue;
-		}
-
-		result += ch;
-	}
-
-	return result;
-}
-
 function mergePluginAllow(pluginsObj: JsonObject, pluginName: string): { changed: boolean; warning?: string } {
 	const rawAllow = pluginsObj.allow;
 	if (rawAllow === undefined) {
@@ -221,89 +157,6 @@ function removePluginAllow(pluginsObj: JsonObject, pluginName: string): { change
 		pluginsObj.allow = next;
 	}
 	return { changed: !unchanged };
-}
-
-function stripTrailingCommas(source: string): string {
-	let result = "";
-	let inString = false;
-	let quote = '"';
-	let escaped = false;
-
-	for (let i = 0; i < source.length; i++) {
-		const ch = source[i];
-
-		if (inString) {
-			result += ch;
-			if (escaped) {
-				escaped = false;
-			} else if (ch === "\\") {
-				escaped = true;
-			} else if (ch === quote) {
-				inString = false;
-			}
-			continue;
-		}
-
-		if (ch === '"' || ch === "'") {
-			inString = true;
-			quote = ch;
-			result += ch;
-			continue;
-		}
-
-		if (ch === ",") {
-			let j = i + 1;
-			while (j < source.length && /\s/.test(source[j])) j++;
-			if (source[j] === "}" || source[j] === "]") {
-				continue;
-			}
-		}
-
-		result += ch;
-	}
-
-	return result;
-}
-
-function parseJsonOrJson5(raw: string): JsonObject {
-	const content = raw.replace(/^\uFEFF/, "");
-	let lastError: Error | null = null;
-
-	try {
-		const parsed: unknown = JSON.parse(content);
-		if (!isJsonObject(parsed)) {
-			throw new Error("Top-level config must be an object");
-		}
-		return parsed;
-	} catch (error) {
-		lastError = error instanceof Error ? error : new Error(String(error));
-		// Fallback to JSON5-like parsing.
-	}
-
-	const withoutComments = stripJsonComments(content);
-	const withoutTrailingCommas = stripTrailingCommas(withoutComments);
-
-	try {
-		const parsed: unknown = JSON.parse(withoutTrailingCommas);
-		if (!isJsonObject(parsed)) {
-			throw new Error("Top-level config must be an object");
-		}
-		return parsed;
-	} catch (error) {
-		lastError = error instanceof Error ? error : new Error(String(error));
-	}
-
-	try {
-		const parsed: unknown = parseJson5(withoutComments);
-		if (!isJsonObject(parsed)) {
-			throw new Error("Top-level config must be an object");
-		}
-		return parsed;
-	} catch (error) {
-		const json5Error = error instanceof Error ? error : new Error(String(error));
-		const priorError = lastError ? `; prior parse error: ${lastError.message}` : "";
-		throw new Error(`could not parse JSON/JSON5 config (${json5Error.message}${priorError})`);
-	}
 }
 
 /**
@@ -494,7 +347,7 @@ export class OpenClawConnector extends BaseConnector {
 		for (const configPath of this.getDiscoveredConfigPaths()) {
 			try {
 				const raw = readFileSync(configPath, "utf-8");
-				const config = parseJsonOrJson5(raw);
+				const config = parseLenientJsonObject(raw, OPENCLAW_PARSE_OPTIONS);
 				const indent = this.detectIndent(raw);
 
 				// Preserve pre-existing OpenClaw agents not managed by Signet.
@@ -543,7 +396,10 @@ export class OpenClawConnector extends BaseConnector {
 
 		for (const configPath of this.getDiscoveredConfigPaths()) {
 			try {
-				const config = parseJsonOrJson5(readFileSync(configPath, "utf-8")) as OpenClawConfigShape;
+				const config = parseLenientJsonObject(
+					readFileSync(configPath, "utf-8"),
+					OPENCLAW_PARSE_OPTIONS,
+				) as OpenClawConfigShape;
 				const rawWorkspace = config.agents?.defaults?.workspace;
 				if (typeof rawWorkspace !== "string") {
 					continue;
@@ -635,7 +491,7 @@ export class OpenClawConnector extends BaseConnector {
 		for (const configPath of this.getDiscoveredConfigPaths()) {
 			try {
 				const raw = readFileSync(configPath, "utf-8");
-				const config = parseJsonOrJson5(raw);
+				const config = parseLenientJsonObject(raw, OPENCLAW_PARSE_OPTIONS);
 				const indent = this.detectIndent(raw);
 
 				if (Array.isArray(config.plugins)) {
@@ -678,7 +534,10 @@ export class OpenClawConnector extends BaseConnector {
 	isInstalled(): boolean {
 		for (const configPath of this.getDiscoveredConfigPaths()) {
 			try {
-				const config = parseJsonOrJson5(readFileSync(configPath, "utf-8")) as OpenClawConfigShape;
+				const config = parseLenientJsonObject(
+					readFileSync(configPath, "utf-8"),
+					OPENCLAW_PARSE_OPTIONS,
+				) as OpenClawConfigShape;
 				// Legacy hook system
 				if (config.hooks?.internal?.entries?.["signet-memory"]?.enabled === true) {
 					return true;
@@ -704,7 +563,10 @@ export class OpenClawConnector extends BaseConnector {
 
 		for (const configPath of this.getDiscoveredConfigPaths()) {
 			try {
-				const config = parseJsonOrJson5(readFileSync(configPath, "utf-8")) as OpenClawConfigShape;
+				const config = parseLenientJsonObject(
+					readFileSync(configPath, "utf-8"),
+					OPENCLAW_PARSE_OPTIONS,
+				) as OpenClawConfigShape;
 
 				const pluginEntry =
 					config.plugins?.entries?.["signet-memory-openclaw"]?.enabled === true ||
@@ -922,7 +784,7 @@ export class OpenClawConnector extends BaseConnector {
 		for (const configPath of this.getDiscoveredConfigPaths()) {
 			try {
 				const raw = readFileSync(configPath, "utf-8");
-				const config = parseJsonOrJson5(raw);
+				const config = parseLenientJsonObject(raw, OPENCLAW_PARSE_OPTIONS);
 				const indent = this.detectIndent(raw);
 
 				// Migrate legacy array-style plugins to object format
@@ -1020,12 +882,7 @@ export class OpenClawConnector extends BaseConnector {
 
 	private patchConfig(configPath: string, patch: JsonObject): void {
 		const raw = readFileSync(configPath, "utf-8");
-		let config: JsonObject;
-		try {
-			config = parseJsonOrJson5(raw);
-		} catch (e) {
-			throw new Error(`could not parse JSON/JSON5 config (${(e as Error).message})`);
-		}
+		const config = parseLenientJsonObject(raw, OPENCLAW_PARSE_OPTIONS);
 
 		const indent = this.detectIndent(raw);
 		backupConfig(configPath, raw);
@@ -1050,7 +907,7 @@ export class OpenClawConnector extends BaseConnector {
 		for (const configPath of this.getDiscoveredConfigPaths()) {
 			try {
 				const raw = readFileSync(configPath, "utf-8");
-				const config = parseJsonOrJson5(raw);
+				const config = parseLenientJsonObject(raw, OPENCLAW_PARSE_OPTIONS);
 				const indent = this.detectIndent(raw);
 
 				// Legacy configs store plugins as an array of strings. The

--- a/integrations/openclaw/connector/test/index.test.ts
+++ b/integrations/openclaw/connector/test/index.test.ts
@@ -210,7 +210,7 @@ describe("OpenClawConnector config patching", () => {
 		});
 
 		expect(result.configsPatched).not.toContain(configPath);
-		expect(result.warnings?.some((w) => w.includes("could not parse JSON/JSON5 config"))).toBe(true);
+		expect(result.warnings?.some((w) => w.includes("Invalid OpenClaw config at offset"))).toBe(true);
 		expect(connector.getDiscoveredWorkspacePaths()).toHaveLength(0);
 	});
 

--- a/integrations/opencode/connector/index.test.ts
+++ b/integrations/opencode/connector/index.test.ts
@@ -338,7 +338,7 @@ describe("OpenCodeConnector — pipeline agent registration", () => {
 		const connector = new TestableConnector(ocPath());
 
 		await expect(connector.install(tmpRoot)).rejects.toThrow(
-			`Cannot update OpenCode config ${legacyPath}`,
+			`Cannot update OpenCode config ${legacyPath}: Invalid OpenCode config at offset`,
 		);
 		expect(readFileSync(jsoncPath, "utf-8")).toBe('{ "provider": {} }\n');
 		expect(readFileSync(legacyPath, "utf-8")).toBe("{ invalid");

--- a/integrations/opencode/connector/src/index.ts
+++ b/integrations/opencode/connector/src/index.ts
@@ -31,6 +31,7 @@ import {
 	isSignetGeneratedFile,
 	resolveSignetMcpCommand,
 } from "@signet/connector-base";
+import { parseLenientJsonObject } from "@signet/connector-base/lenient-json";
 import {
 	OPENCODE_PIPELINE_AGENT,
 	OPENCODE_PIPELINE_SYSTEM_PROMPT,
@@ -39,7 +40,7 @@ import {
 	loadIdentityMode,
 	resolveSignetDaemonUrl,
 } from "@signet/core";
-import { type ParseError, applyEdits, modify, parse } from "jsonc-parser/lib/esm/main.js";
+import { applyEdits, modify } from "jsonc-parser/lib/esm/main.js";
 import { PLUGIN_BUNDLE } from "./plugin-bundle.js";
 
 // ============================================================================
@@ -84,20 +85,6 @@ function buildPluginBundle(apiKeyFilePath?: string): string {
 	}
 	if (assignments.length === 0) return PLUGIN_BUNDLE;
 	return `${assignments.join("\n")}\n${PLUGIN_BUNDLE}`;
-}
-
-function parseJsonOrJsonc(raw: string): JsonObject {
-	const errors: ParseError[] = [];
-	const parsed: unknown = parse(raw.replace(/^\uFEFF/, ""), errors, {
-		allowTrailingComma: true,
-		disallowComments: false,
-	});
-	if (errors.length > 0) {
-		const first = errors[0];
-		throw new Error(`Invalid OpenCode JSONC at offset ${first.offset} (code ${first.error})`);
-	}
-	if (!isJsonObject(parsed)) throw new Error("OpenCode config must be a top-level object");
-	return parsed;
 }
 
 function formattingOptions(source: string): { insertSpaces: boolean; tabSize: number; eol: string } {
@@ -378,7 +365,7 @@ export class OpenCodeConnector extends BaseConnector {
 
 	private readConfig(configPath: string): JsonObject {
 		try {
-			return parseJsonOrJsonc(readFileSync(configPath, "utf-8"));
+			return parseLenientJsonObject(readFileSync(configPath, "utf-8"), { label: "OpenCode config" });
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			throw new Error(`Cannot update OpenCode config ${configPath}: ${message}`);

--- a/libs/connector-base/index.test.ts
+++ b/libs/connector-base/index.test.ts
@@ -13,6 +13,7 @@ import {
 	resolveSignetMcpCommand,
 	resolveSignetWorkspacePath,
 } from "./src/index";
+import { parseLenientJsonObject } from "./src/lenient-json";
 
 class TestConnector extends BaseConnector {
 	readonly name = "Test";
@@ -153,6 +154,37 @@ describe("packaged Signet command resolution", () => {
 		expect(warnings).toEqual([
 			'[signet] Warning: could not resolve mcp-stdio.js from argv[1]="C:\\missing\\signetai\\bin\\signet.js". MCP server config will use "signet-mcp" which may fail on Windows without shell:true.',
 		]);
+	});
+});
+
+describe("parseLenientJsonObject", () => {
+	it("parses BOM-prefixed JSONC with line and block comments and trailing commas", () => {
+		const parsed = parseLenientJsonObject(
+			'\uFEFF{\n  // line comment\n  "nested": {\n    /* block comment */\n    "enabled": true,\n  },\n}\n',
+			{ label: "Test config" },
+		);
+
+		expect(parsed).toEqual({ nested: { enabled: true } });
+	});
+
+	it("preserves OpenClaw JSON5 compatibility for unquoted keys and single-quoted strings", () => {
+		const parsed = parseLenientJsonObject("{ gateway: { mode: 'local' } }", {
+			label: "OpenClaw config",
+		});
+
+		expect(parsed).toEqual({ gateway: { mode: "local" } });
+	});
+
+	it.each(["[]", "null", '"value"', "42"])("rejects a non-object top level: %s", (raw) => {
+		expect(() => parseLenientJsonObject(raw, { label: "Test config" })).toThrow(
+			"Invalid Test config: expected a top-level object",
+		);
+	});
+
+	it("reports malformed input with the caller label, offset, and parse code", () => {
+		expect(() => parseLenientJsonObject("{ invalid", { label: "OpenCode config" })).toThrow(
+			/^Invalid OpenCode config at offset \d+ \([A-Za-z]+\)$/,
+		);
 	});
 });
 

--- a/libs/connector-base/package.json
+++ b/libs/connector-base/package.json
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./lenient-json": {
+      "import": "./dist/lenient-json.js",
+      "types": "./dist/lenient-json.d.ts"
     }
   },
   "files": [
@@ -17,12 +21,14 @@
     "!dist/**/__tests__/**"
   ],
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir ./dist --target node --external better-sqlite3 && bun run build:types",
+    "build": "bun build ./src/index.ts ./src/lenient-json.ts --outdir ./dist --target node --external better-sqlite3 && bun run build:types",
     "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/core": "0.154.0"
+    "@signet/core": "0.154.0",
+    "json5": "^2.2.3",
+    "jsonc-parser": "3.3.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/libs/connector-base/src/lenient-json.ts
+++ b/libs/connector-base/src/lenient-json.ts
@@ -1,0 +1,26 @@
+import { parse as parseJson5 } from "json5";
+import { type ParseError, parse as parseJsonc, printParseErrorCode } from "jsonc-parser/lib/esm/main.js";
+
+/** Parse a connector config as JSONC or JSON5 and require an object root. */
+export function parseLenientJsonObject(raw: string, options: { readonly label: string }): Record<string, unknown> {
+	const source = raw.replace(/^\uFEFF/, "");
+	const errors: ParseError[] = [];
+	let parsed: unknown = parseJsonc(source, errors, {
+		allowTrailingComma: true,
+		disallowComments: false,
+	});
+
+	if (errors.length > 0) {
+		try {
+			parsed = parseJson5(source);
+		} catch {
+			const first = errors[0];
+			throw new Error(`Invalid ${options.label} at offset ${first.offset} (${printParseErrorCode(first.error)})`);
+		}
+	}
+
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new Error(`Invalid ${options.label}: expected a top-level object`);
+	}
+	return parsed as Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary

Extracts OpenClaw and OpenCode's duplicate lenient config parsing into a typed connector-base entrypoint with consistent object-root validation and parse errors.

Closes #954.

## Changes

- add `@signet/connector-base/lenient-json` with checked JSONC parsing and the JSON5 fallback required by OpenClaw
- migrate every OpenClaw config read and OpenCode's config validation to the shared parser
- move parser dependencies into connector-base while keeping them out of unrelated connector bundles
- cover BOMs, comments, trailing commas, JSON5 syntax, invalid roots, and labeled errors

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `@signet/connector-base`

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — N/A; no ontology/spec dependency changed
- [x] Agent scoping verified on all new/changed data queries — N/A; no data queries changed
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints — N/A; no endpoint changed
- [x] Docs updated for API/spec/status changes — N/A; no public API/spec/status documentation changed
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally — affected packages/files pass; broad pre-existing failures are detailed below and reproduce on clean `main`

## Migration Notes (if applicable)

- [x] Migration is idempotent — N/A; no migration
- [x] Daemon Rust parity reviewed or explicitly N/A — N/A; no daemon route change
- [x] Rollback / compatibility note included in PR description — removing the shared import restores the prior local parsers; OpenClaw JSON5 compatibility is retained

## Testing

- [x] `bun test` passes — 66/66 focused tests pass. Broad branch: 3,433 pass, 101 fail, 4 errors; clean `main`: 3,426 pass, 101 fail, 4 errors. The seven added tests pass and the unchanged failures are pre-existing.
- [x] `bun run typecheck` passes — connector-base, OpenClaw, and OpenCode pass; the broad daemon rootDir/SQLite typing failures reproduce on clean `main`.
- [x] `bun run lint` passes — changed files add no diagnostics; branch and clean `main` both report the same pre-existing 1,861 errors and 143 warnings.
- [x] Tested against running daemon — N/A for this connector-only change; tested the built connectors against the published OpenClaw and OpenCode CLIs instead.
- [x] N/A — no daemon or UI runtime path changed.

Additional proof:

- `bun run build`
- OpenClaw connector install from JSON5 followed by `openclaw config validate`
- OpenCode connector install from JSONC followed by `opencode debug config`
- public `@signet/connector-base/lenient-json` subpath import smoke test

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

OpenClaw's current parser tests require single-quoted strings and unquoted keys, so the JSON5 fallback remains intentional. OpenCode continues to use JSONC edits to preserve comments; only its object parsing/validation is shared.
