### PR TITLE
fix(daemon): surface extraction route blockers

### DIFF
--- a/docs/api/health-status.md
+++ b/docs/api/health-status.md
@@ -230,6 +230,7 @@ silent fallback or hard-blocked extraction after boot.
       "degraded": false,
       "fallbackApplied": false,
       "reason": null,
+      "blockedBy": [],
       "since": null
     }
   },
@@ -268,6 +269,9 @@ bypass enabled (see [Sessions and hooks API](./sessions-hooks.md#sessions)).
 Monitor `providerResolution.extraction.status` for `degraded` or `blocked`
 states when the configured extraction provider is unavailable or routed to a
 fallback target.
+When extraction is blocked, `providerResolution.extraction.blockedBy` contains
+the first routing candidate's policy and runtime gate reasons in evaluation
+order. The array is empty for non-blocked states.
 When `pipeline.extraction.overloaded` is `true`, the extraction worker is
 intentionally backing off for `overloadBackoffMs` between polls.
 `transcripts.capture` exposes compact durable transcript-capture queue counts;

--- a/platform/daemon-rs/crates/signet-daemon/src/main.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/main.rs
@@ -2618,6 +2618,9 @@ async fn status(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
                 "degraded": es.degraded,
                 "fallbackApplied": es.fallback_applied,
                 "reason": es.reason,
+                // daemon-rs uses direct provider preflight rather than the shared
+                // inference router, so it has no candidate gate trace to expose.
+                "blockedBy": [],
                 "since": es.since,
             })
         })
@@ -3426,6 +3429,10 @@ mod tests {
         assert_eq!(
             body["providerResolution"]["extraction"]["reason"],
             serde_json::Value::Null
+        );
+        assert_eq!(
+            body["providerResolution"]["extraction"]["blockedBy"],
+            serde_json::json!([])
         );
     }
 

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -42,6 +42,7 @@ import { clearAllPresence } from "./cross-agent";
 import { closeDbAccessor, getDbAccessor, getVectorRuntimeStatus, initDbAccessorAsync } from "./db-accessor";
 import { fetchEmbedding } from "./embedding-fetch";
 import { type EmbeddingTrackerHandle, startEmbeddingTracker } from "./embedding-tracker";
+import { firstCandidateBlockedBy } from "./extraction-status";
 import { initFeatureFlags } from "./feature-flags";
 import { writeFileIfChangedAsync } from "./file-sync";
 import { createSignetHttpServer } from "./http-server";
@@ -1408,9 +1409,7 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 	// case the field reports "none" even if a fallback was configured but also
 	// failed, because the decision carries no candidates when blocked. The
 	// `reason` field carries the failure detail in that case.
-	const extractionFallbackProvider: RuntimeProviderName = extractionFallbackApplied
-		? extractionEffective
-		: "none";
+	const extractionFallbackProvider: RuntimeProviderName = extractionFallbackApplied ? extractionEffective : "none";
 	providerRuntimeResolution.extraction = {
 		// Configured/resolved now derive from the routing registry (the workload
 		// binding's target executor), not the retired legacy flat fields.
@@ -1437,15 +1436,17 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 						? (runtimeReasonForTarget(extractionDecision, extractionBinding) ??
 							`Configured extraction provider unavailable; using ${extractionEffective} fallback`)
 						: (extractionSelectedRuntime?.unavailableReason ?? null),
+		blockedBy:
+			extractionStatus === "blocked" && extractionDecision && !extractionDecision.ok
+				? firstCandidateBlockedBy(extractionDecision.error.details)
+				: [],
 		since: statusSince,
 	};
 	providerRuntimeResolution.synthesis = {
 		configured: synthesisAvailable
 			? statusValue
-				? executorForTargetRef(
-						statusValue,
-						synthesisDecision?.ok ? synthesisDecision.value.targetRef : undefined,
-					) ?? null
+				? (executorForTargetRef(statusValue, synthesisDecision?.ok ? synthesisDecision.value.targetRef : undefined) ??
+					null)
 				: null
 			: null,
 		resolved: synthesisAvailable ? (synthesisEffective as RuntimeSynthesisProviderName | null) : null,

--- a/platform/daemon/src/extraction-status.test.ts
+++ b/platform/daemon/src/extraction-status.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { firstCandidateBlockedBy } from "./extraction-status";
+
+describe("firstCandidateBlockedBy", () => {
+	it("returns the first routing candidate's valid gate reasons in order", () => {
+		expect(
+			firstCandidateBlockedBy({
+				trace: {
+					candidates: [
+						{
+							blockedBy: [
+								"privacy gate (restricted_remote)",
+								"missing credential for issue-1003",
+								42,
+								"",
+								"account state missing",
+							],
+						},
+						{ blockedBy: ["second candidate reason"] },
+					],
+				},
+			}),
+		).toEqual(["privacy gate (restricted_remote)", "missing credential for issue-1003", "account state missing"]);
+	});
+
+	it("returns an empty array when the router failure has no candidate trace", () => {
+		expect(firstCandidateBlockedBy(undefined)).toEqual([]);
+		expect(firstCandidateBlockedBy({ trace: { candidates: [] } })).toEqual([]);
+		expect(firstCandidateBlockedBy({ trace: { candidates: [{ blockedBy: "not-an-array" }] } })).toEqual([]);
+	});
+});

--- a/platform/daemon/src/extraction-status.ts
+++ b/platform/daemon/src/extraction-status.ts
@@ -1,0 +1,19 @@
+export function firstCandidateBlockedBy(details: unknown): readonly string[] {
+	if (!details || typeof details !== "object" || !("trace" in details)) return [];
+	const trace = details.trace;
+	if (!trace || typeof trace !== "object" || !("candidates" in trace) || !Array.isArray(trace.candidates)) {
+		return [];
+	}
+	const firstCandidate = trace.candidates[0];
+	if (
+		!firstCandidate ||
+		typeof firstCandidate !== "object" ||
+		!("blockedBy" in firstCandidate) ||
+		!Array.isArray(firstCandidate.blockedBy)
+	) {
+		return [];
+	}
+	return firstCandidate.blockedBy.filter(
+		(reason: unknown): reason is string => typeof reason === "string" && reason.trim().length > 0,
+	);
+}

--- a/platform/daemon/src/routes/state.ts
+++ b/platform/daemon/src/routes/state.ts
@@ -253,6 +253,7 @@ export interface ProviderRuntimeResolution {
 		degraded: boolean;
 		fallbackApplied: boolean;
 		reason: string | null;
+		blockedBy: readonly string[];
 		since: string | null;
 	};
 	synthesis: {
@@ -273,6 +274,7 @@ export const providerRuntimeResolution: ProviderRuntimeResolution = {
 		degraded: false,
 		fallbackApplied: false,
 		reason: null,
+		blockedBy: [],
 		since: null,
 	},
 	synthesis: {

--- a/surfaces/cli/src/features/health.test.ts
+++ b/surfaces/cli/src/features/health.test.ts
@@ -656,6 +656,7 @@ describe("getExtractionStatusNotice", () => {
 				status: "blocked",
 				degraded: true,
 				reason: "Claude Code CLI not found during extraction startup preflight; fallbackProvider is none",
+				blockedBy: ["missing credential for extraction", "account state missing"],
 				since: "2026-03-26T00:00:00.000Z",
 			},
 			extractionWorker: null,
@@ -663,7 +664,9 @@ describe("getExtractionStatusNotice", () => {
 
 		expect(notice?.level).toBe("error");
 		expect(notice?.title).toBe("Extraction blocked");
-		expect(notice?.detail).toContain("fallback: none");
+		expect(notice?.detail).toBe(
+			"configured: claude-code, fallback: none — Claude Code CLI not found during extraction startup preflight; fallbackProvider is none — blocked by: missing credential for extraction; account state missing",
+		);
 	});
 
 	it("returns a warning when extraction worker is load-shedding", () => {

--- a/surfaces/cli/src/features/health.ts
+++ b/surfaces/cli/src/features/health.ts
@@ -40,6 +40,7 @@ interface DaemonStatus {
 		readonly status: string | null;
 		readonly degraded: boolean;
 		readonly reason: string | null;
+		readonly blockedBy?: readonly string[];
 		readonly since: string | null;
 	} | null;
 	readonly extractionWorker: {
@@ -416,10 +417,14 @@ export function getExtractionStatusNotice(
 ): { level: "warn" | "error"; title: string; detail: string } | null {
 	const extraction = daemon.extraction;
 	if (extraction && daemon.running && extraction.status === "blocked") {
+		const blockedBy =
+			extraction.blockedBy && extraction.blockedBy.length > 0
+				? ` — blocked by: ${extraction.blockedBy.join("; ")}`
+				: "";
 		return {
 			level: "error",
 			title: "Extraction blocked",
-			detail: `configured: ${extraction.configured ?? "unknown"}, fallback: ${extraction.fallbackProvider ?? "unknown"}${extraction.reason ? ` — ${extraction.reason}` : ""}`,
+			detail: `configured: ${extraction.configured ?? "unknown"}, fallback: ${extraction.fallbackProvider ?? "unknown"}${extraction.reason ? ` — ${extraction.reason}` : ""}${blockedBy}`,
 		};
 	}
 

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -406,6 +406,7 @@ describe("getDaemonStatus", () => {
 							status: "degraded",
 							degraded: true,
 							reason: "Claude Code CLI not found during extraction startup preflight",
+							blockedBy: ["missing credential", 42, "", "account state missing"],
 							since: "2026-03-26T00:00:00.000Z",
 						},
 					},
@@ -437,6 +438,7 @@ describe("getDaemonStatus", () => {
 			status: "degraded",
 			degraded: true,
 			reason: "Claude Code CLI not found during extraction startup preflight",
+			blockedBy: ["missing credential", "account state missing"],
 			since: "2026-03-26T00:00:00.000Z",
 		});
 		expect(status.extractionWorker).toEqual({

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -70,6 +70,7 @@ interface DaemonInstance {
 		readonly status: string | null;
 		readonly degraded: boolean;
 		readonly reason: string | null;
+		readonly blockedBy: readonly string[];
 		readonly since: string | null;
 	} | null;
 	readonly extractionWorker: {
@@ -364,6 +365,7 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 								status?: string | null;
 								degraded?: boolean;
 								reason?: string | null;
+								blockedBy?: unknown;
 								since?: string | null;
 							};
 						};
@@ -418,6 +420,11 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 									status: extraction.status ?? null,
 									degraded: extraction.degraded === true,
 									reason: extraction.reason ?? null,
+									blockedBy: Array.isArray(extraction.blockedBy)
+										? extraction.blockedBy.filter(
+												(reason): reason is string => typeof reason === "string" && reason.trim().length > 0,
+											)
+										: [],
 									since: extraction.since ?? null,
 								}
 							: null,


### PR DESCRIPTION
## Summary

Surfaces the router's first candidate `blockedBy` reasons in daemon extraction status so operators can diagnose policy and runtime gates directly from `signet status` without calling the internal explain API.

Closes #1003.

## Changes

- Extract the first routing candidate's ordered, valid `blockedBy` reasons when extraction has no available route.
- Expose those reasons as structured `providerResolution.extraction.blockedBy` data from `/api/status`.
- Normalize the optional field at the CLI boundary for compatibility with older daemons and malformed responses.
- Append privacy, capability, credential, account, and other gate reasons to the `Extraction blocked` status detail.
- Keep the Rust daemon status schema aligned with an empty array because its extraction worker uses direct provider preflight rather than the shared inference router.
- Document the status contract and add daemon-helper, CLI parsing, CLI rendering, and Rust parity regressions.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: Rust daemon status parity

## Screenshots

N/A — terminal/API status output only; no graphical UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — aligns with the approved `model-provider-router` criterion that operators can inspect routing decisions and health from CLI/daemon status surfaces.
- [x] Agent scoping verified on all new/changed data queries — N/A; no data query or persisted state changed.
- [x] Input/config validation and bounds checks added — the CLI accepts only non-empty string reasons and safely defaults missing/malformed arrays to empty.
- [x] Error handling and fallback paths tested (no silent swallow) — missing traces, empty candidates, malformed reasons, and older-daemon responses retain the existing generic status safely.
- [x] Security checks applied to admin/mutation endpoints — N/A; no endpoint or permission change. Router runtime errors pass through the existing inline-secret sanitization before reaching candidate traces.
- [x] Docs updated for API/spec/status changes — `/api/status` documents `blockedBy` semantics.
- [x] Regression tests added for each bug fix — ordered trace extraction, response normalization, terminal rendering, and Rust schema parity are covered.
- [x] Lint/typecheck/tests pass locally — changed files and focused/runtime checks pass; mandatory broad failures reproduce on clean `main` and are detailed below.

## Migration Notes (if applicable)

- [x] Migration is idempotent — N/A; no migration or persisted schema change.
- [x] Daemon Rust parity reviewed or explicitly N/A — Rust `/api/status` now emits `blockedBy: []`; its direct provider-preflight `reason` remains the diagnostic source.
- [x] Rollback / compatibility note included in PR description — older daemons that omit `blockedBy` remain compatible because the CLI normalizes it to an empty array.

## Testing

- [x] `bun test` passes — 45 focused tests pass. Broad branch: 3,428 pass / 101 fail / 4 errors; clean `main`: 3,426 pass / 101 fail / 4 errors. The two added tests pass and the unchanged failures are pre-existing.
- [x] `bun run typecheck` passes — branch and clean `main` produce the same 423 pre-existing diagnostics (daemon `rootDir`/SQLite typing and related debt). No diagnostic originates from the new helper or changed hunks.
- [x] `bun run lint` passes — all eight changed TypeScript files pass Biome. Broad branch reports 1,860 errors / 143 warnings versus clean `main` at 1,861 errors / 143 warnings; remaining diagnostics are pre-existing.
- [x] Tested against running daemon — an isolated daemon on port 39503 returned blocked extraction plus ordered `privacy gate`, `tool-use required`, `missing credential`, and `account state missing` reasons from `/api/status`.
- [x] N/A — screenshots and migration runtime testing do not apply.

Additional focused proof:

- `bun run build`
- `bun run --filter '@signet/daemon' build`
- `bun run --cwd surfaces/cli build:cli`
- `bun test platform/daemon/src/extraction-status.test.ts surfaces/cli/src/lib/runtime.test.ts surfaces/cli/src/features/health.test.ts`
- `bunx biome check` across all changed TypeScript files
- `cargo fmt --all -- --check`
- `cargo test -p signet-daemon preflight_persists_disabled_resolution_when_provider_is_none`
- `git diff --check`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The status keeps the existing generic route error for compatibility and adds structured gate reasons alongside it. The CLI renders the reasons only when present, so older daemon versions keep their prior output. Rust extraction does not currently consume the shared inference router, so its direct preflight reason remains specific while `blockedBy` is empty for schema parity.
