### PR TITLE
fix(core): infer openai-compatible privacy from endpoint

### DIFF
--- a/platform/core/src/routing.test.ts
+++ b/platform/core/src/routing.test.ts
@@ -14,6 +14,38 @@ const ready = {
 	accountState: "ready",
 } as const;
 
+const compatibleTargetRef = makeRoutingTargetRef("compatible", "default");
+
+function parseRestrictedCompatibleRouting(endpoint: string) {
+	return parseRoutingConfig({
+		inference: {
+			defaultPolicy: "auto",
+			targets: {
+				compatible: {
+					executor: "openai-compatible",
+					endpoint,
+					models: {
+						default: {
+							model: "compatible-model",
+						},
+					},
+				},
+			},
+			policies: {
+				auto: {
+					mode: "automatic",
+					defaultTargets: [compatibleTargetRef],
+				},
+			},
+			taskClasses: {
+				memory_extraction: {
+					privacy: "restricted_remote",
+				},
+			},
+		},
+	});
+}
+
 describe("inference config + decision engine", () => {
 	it("classifies loopback inference endpoints as local", () => {
 		expect(isLocalInferenceEndpoint(undefined)).toBe(true);
@@ -21,6 +53,97 @@ describe("inference config + decision engine", () => {
 		expect(isLocalInferenceEndpoint("http://localhost:1234/v1")).toBe(true);
 		expect(isLocalInferenceEndpoint("http://[::1]:1234/v1")).toBe(true);
 		expect(isLocalInferenceEndpoint("https://gateway.example.test/v1")).toBe(false);
+	});
+
+	it("allows local openai-compatible targets for restricted_remote task classes", () => {
+		const parsed = parseRestrictedCompatibleRouting("http://127.0.0.1:1234/v1");
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok) return;
+		expect(parsed.value.targets.compatible?.privacy).toBe("local_only");
+
+		const decision = resolveRoutingDecision(
+			parsed.value,
+			{ operation: "memory_extraction" },
+			{ targets: { [compatibleTargetRef]: ready } },
+		);
+		expect(decision.ok).toBe(true);
+		if (!decision.ok) return;
+		expect(decision.value.targetRef).toBe(compatibleTargetRef);
+
+		const parsedTarget = parsed.value.targets.compatible;
+		expect(parsedTarget).toBeDefined();
+		if (!parsedTarget) return;
+		const targetWithoutParsedPrivacy = {
+			...parsedTarget,
+			privacy: undefined,
+		};
+		const directConfigDecision = resolveRoutingDecision(
+			{
+				...parsed.value,
+				targets: {
+					...parsed.value.targets,
+					compatible: targetWithoutParsedPrivacy,
+				},
+			},
+			{ operation: "memory_extraction" },
+			{ targets: { [compatibleTargetRef]: ready } },
+		);
+		expect(directConfigDecision.ok).toBe(true);
+	});
+
+	it("keeps remote openai-compatible targets behind the restricted_remote privacy gate", () => {
+		const parsed = parseRestrictedCompatibleRouting("https://gateway.example.test/v1");
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok) return;
+		expect(parsed.value.targets.compatible?.privacy).toBe("remote_ok");
+
+		const decision = resolveRoutingDecision(
+			parsed.value,
+			{ operation: "memory_extraction" },
+			{ targets: { [compatibleTargetRef]: ready } },
+		);
+		expect(decision.ok).toBe(false);
+		if (!("error" in decision)) return;
+		expect(decision.error.code).toBe("no-candidates");
+		const trace = decision.error.details?.trace as
+			| { readonly candidates: readonly { readonly blockedBy: readonly string[] }[] }
+			| undefined;
+		expect(trace?.candidates[0]?.blockedBy).toContain("privacy gate (restricted_remote)");
+	});
+
+	it("honors an explicit privacy override on a loopback endpoint (no proxy-to-cloud leak)", () => {
+		// Regression for the safety valve: endpoint-based privacy is a default,
+		// not a forced classification. A user can explicitly mark a loopback
+		// target as `remote_ok` (e.g. a local reverse-proxy forwarding to a real
+		// cloud API). The privacy gate must honor that override and keep the
+		// target gated for `restricted_remote` tasks — it must NOT auto-relax to
+		// `local_only` just because the address is 127.0.0.1.
+		const parsed = parseRestrictedCompatibleRouting("http://127.0.0.1:1234/v1");
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok) return;
+		const baseTarget = parsed.value.targets.compatible;
+		expect(baseTarget).toBeDefined();
+		if (!baseTarget) return;
+
+		const overridden = {
+			...parsed.value,
+			targets: {
+				...parsed.value.targets,
+				compatible: { ...baseTarget, privacy: "remote_ok" as const },
+			},
+		};
+		const decision = resolveRoutingDecision(
+			overridden,
+			{ operation: "memory_extraction" },
+			{ targets: { [compatibleTargetRef]: ready } },
+		);
+		expect(decision.ok).toBe(false);
+		if (!("error" in decision)) return;
+		expect(decision.error.code).toBe("no-candidates");
+		const trace = decision.error.details?.trace as
+			| { readonly candidates: readonly { readonly blockedBy: readonly string[] }[] }
+			| undefined;
+		expect(trace?.candidates[0]?.blockedBy).toContain("privacy gate (restricted_remote)");
 	});
 
 	it("prefers local targets for local_only task classes", () => {

--- a/platform/core/src/routing.ts
+++ b/platform/core/src/routing.ts
@@ -386,16 +386,12 @@ function inferLegacyTargetKind(executor: string, endpoint: string | undefined): 
 	return inferTargetKind(executor);
 }
 
-function inferTargetPrivacy(executor: string): RoutingPrivacyTier {
+function inferTargetPrivacy(executor: string, endpoint?: string): RoutingPrivacyTier {
+	if (executor === "openai-compatible" && isLocalInferenceEndpoint(endpoint)) return "local_only";
 	if (executor === "ollama" || executor === "llama-cpp") return "local_only";
 	if (executor === "acpx" || executor === "claude-code" || executor === "codex" || executor === "opencode")
 		return "restricted_remote";
 	return "remote_ok";
-}
-
-function inferLegacyTargetPrivacy(executor: string, endpoint: string | undefined): RoutingPrivacyTier {
-	if (executor === "openai-compatible" && isLocalInferenceEndpoint(endpoint)) return "local_only";
-	return inferTargetPrivacy(executor);
 }
 
 function mergeUnique(base: readonly string[], extra: readonly string[]): readonly string[] {
@@ -623,6 +619,7 @@ function parseTargetConfig(raw: unknown): RoutingTargetConfig | null {
 	const acpx = executor === "acpx" ? parseAcpxConfig(raw) : undefined;
 	if (executor === "acpx" && !acpx) return null;
 	const openrouter = executor === "openrouter" ? parseOpenRouterConfig(raw) : undefined;
+	const endpoint = asString(raw.endpoint ?? raw.baseUrl ?? raw.base_url);
 	return {
 		kind: (() => {
 			const parsed = asString(raw.kind);
@@ -633,11 +630,11 @@ function parseTargetConfig(raw: unknown): RoutingTargetConfig | null {
 		})(),
 		executor: executor as RoutingExecutorKind,
 		account: asString(raw.account),
-		endpoint: asString(raw.endpoint ?? raw.baseUrl ?? raw.base_url),
+		endpoint,
 		command: parseCommandConfig(raw.command),
 		acpx,
 		openrouter,
-		privacy: asRoutingPrivacyTier(raw.privacy, inferTargetPrivacy(executor)),
+		privacy: asRoutingPrivacyTier(raw.privacy, inferTargetPrivacy(executor, endpoint)),
 		models,
 	};
 }
@@ -774,7 +771,7 @@ export function compileLegacyRoutingConfig(opts: {
 			account: legacyAccountForProvider(opts.extraction.provider, opts.extraction.endpoint),
 			endpoint: opts.extraction.endpoint,
 			command: opts.extraction.command,
-			privacy: inferLegacyTargetPrivacy(opts.extraction.provider, opts.extraction.endpoint),
+			privacy: inferTargetPrivacy(opts.extraction.provider, opts.extraction.endpoint),
 			models: {
 				default: {
 					model: opts.extraction.model,
@@ -818,7 +815,7 @@ export function compileLegacyRoutingConfig(opts: {
 			executor: opts.synthesis.provider,
 			account: legacyAccountForProvider(opts.synthesis.provider, opts.synthesis.endpoint),
 			endpoint: opts.synthesis.endpoint,
-			privacy: inferLegacyTargetPrivacy(opts.synthesis.provider, opts.synthesis.endpoint),
+			privacy: inferTargetPrivacy(opts.synthesis.provider, opts.synthesis.endpoint),
 			models: {
 				default: {
 					model: opts.synthesis.model,
@@ -1242,7 +1239,7 @@ function buildCandidateTrace(
 	const reasons: string[] = [];
 	let score = 0;
 	const requiredPrivacy = request.privacy ?? config.taskClasses[classification.taskClass]?.privacy ?? "remote_ok";
-	const targetPrivacy = target.privacy ?? inferTargetPrivacy(target.executor);
+	const targetPrivacy = target.privacy ?? inferTargetPrivacy(target.executor, target.endpoint);
 	if (privacyRank(targetPrivacy) < privacyRank(requiredPrivacy)) {
 		blockedBy.push(`privacy gate (${requiredPrivacy})`);
 	}


### PR DESCRIPTION
## Summary

Fix endpoint-aware privacy inference for `openai-compatible` routing targets so loopback servers are eligible for `restricted_remote` workloads while remote gateways remain blocked.

## Changes

- Infer default `openai-compatible` privacy from the configured endpoint during target parsing and candidate evaluation.
- Consolidate legacy and explicit target privacy inference into one canonical path.
- Add regressions for parsed loopback targets, direct configs with omitted privacy, and remote endpoints that must remain behind the privacy gate.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: N/A

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — behavior now matches the approved model-provider-router privacy gate; no contract change.
- [x] Agent scoping verified on all new/changed data queries — N/A; no data queries or scope changes.
- [x] Input/config validation and bounds checks added — N/A; the existing normalized endpoint and local-endpoint validator are reused.
- [x] Error handling and fallback paths tested (no silent swallow) — remote endpoints retain the explicit privacy-gate block trace.
- [x] Security checks applied to admin/mutation endpoints — N/A; no endpoint or permission changes. Privacy policy remains fail-closed for remote gateways.
- [x] Docs updated for API/spec/status changes — N/A; public schema and documented intended behavior are unchanged.
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally — changed files and affected package pass; repository-wide baseline failures are documented below.

## Migration Notes (if applicable)

- [x] Migration is idempotent — N/A; no migration.
- [x] Daemon Rust parity reviewed or explicitly N/A — N/A; Rust inference routes do not implement the TypeScript candidate decision engine and currently return router-not-initialized.
- [x] Rollback / compatibility note included in PR description — no schema or compatibility change; reverting restores the previous incorrect loopback classification.

## Testing

- [x] `bun test` passes — changed router suite: 20 passed, 0 failed. Repository-wide branch: 3,017 pass / 108 fail / 20 errors; clean `main` at `4b486522`: 3,015 pass / 108 fail / 20 errors. The broad failures are pre-existing on `main`, and this PR adds two passing regressions without affecting them.
- [x] `bun run typecheck` passes — `@signet/core` passes. Repository-wide branch and clean `main` both report the same 457 pre-existing TypeScript diagnostics; neither changed file contributes a diagnostic.
- [x] `bun run lint` passes — both changed files pass Biome. Repository-wide branch and clean `main` both report the same 1,815 pre-existing errors and 143 warnings; this PR does not affect them.
- [ ] Tested against running daemon
- [x] N/A — this is a pure core routing decision fix; the exact configured-target reproduction was exercised directly through `parseRoutingConfig` and `resolveRoutingDecision`.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Closes #1002

The original one-line recommendation covered only candidate fallback. The configured-target reproduction also required endpoint-aware inference during parsing because parsed targets eagerly store their default privacy. This PR fixes both entry paths while preserving explicit privacy overrides and remote fail-closed behavior.
