### PR TITLE
fix(dashboard): sync legacy extraction label with routing target

### DIFF
--- a/platform/daemon/src/memory-config.test.ts
+++ b/platform/daemon/src/memory-config.test.ts
@@ -789,6 +789,21 @@ describe("loadPipelineConfig", () => {
 		expect(result.extraction.model).toBe("qwen3:8b");
 	});
 
+	it("preserves the extraction model label for a provider family outside the legacy vocab (#1017)", () => {
+		// The dashboard writes the routing target (inference.targets.background)
+		// and mirrors only the model into the legacy label when the executor is a
+		// provider family (e.g. minimax) the narrower pipeline vocab can't express.
+		// The model — the only field logs/telemetry/DB read — must propagate.
+		const result = loadPipelineConfig({
+			memory: {
+				pipelineV2: {
+					extractionModel: "MiniMax-M2.7",
+				},
+			},
+		});
+		expect(result.extraction.model).toBe("MiniMax-M2.7");
+	});
+
 	it("nested provider used when no flat key is set", () => {
 		const result = loadPipelineConfig({
 			memory: {

--- a/surfaces/dashboard/src/lib/components/tabs/settings/InferenceSection.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/InferenceSection.svelte
@@ -8,6 +8,7 @@ import { type InferenceCatalog, getInferenceCatalog } from "$lib/api";
 import { CheckCircle, Plus, TriangleAlertIcon } from "$lib/icons";
 import { st } from "$lib/stores/settings.svelte";
 import { invalidateAll } from "$app/navigation";
+import { extractionLabelForRoutingTarget } from "./pipeline-settings";
 import ConnectProviderDialog from "./ConnectProviderDialog.svelte";
 
 // Inference settings (#947/#966/#968). A provider connect wall sits above the
@@ -247,6 +248,7 @@ function bgExecutor(): string {
 }
 function bgSetExecutor(v: string): void {
 	writeTarget({ targetName: TARGET_NAME, accountName: ACCOUNT_NAME, workloadKey: "memoryExtraction", executor: v });
+	syncExtractionLabel();
 }
 
 // Backend taxonomy. After #947/#968 the daemon accepts any catalog provider
@@ -328,6 +330,15 @@ function writeTarget(opts: {
 		st.aDel(workloadBase);
 		return;
 	}
+	// A model is only valid for its own provider family, so a backend switch
+	// must clear the stale model (and its legacy label) to force a re-pick —
+	// otherwise switching ollama:gemma3 -> anthropic would leave the routing
+	// target and the extraction_model DB label on a model the new backend never
+	// serves (#1017).
+	const priorExecutor = st.aStr([...targetBase, "executor"]);
+	if (priorExecutor && priorExecutor !== executor) {
+		st.aDel([...targetBase, "models"]);
+	}
 	st.aSetStr([...targetBase, "executor"], executor);
 	st.aSetStr([...workloadBase, "target"], `${targetName}/default`);
 	const kind = backendKind(executor);
@@ -367,6 +378,23 @@ function bgModelId(): string {
 }
 function bgSetModelId(v: string): void {
 	st.aSetStr(["inference", "targets", TARGET_NAME, "models", "default", "model"], v);
+	syncExtractionLabel();
+}
+
+// Keep the legacy extraction label (memory.pipelineV2.extraction{Provider,Model})
+// in sync with the background routing target so pipeline logs, telemetry, and
+// the extraction_model DB column report the model actually in use instead of
+// the qwen3:4b default (#1017). Routing stays authoritative post-#947; this
+// label is purely informational. Mirrors applyAcpxDashboardSetup for the non-ACPX
+// path. InferenceSection is the sole live writer of this label; PipelineSection's
+// extraction provider/model setters are retained but currently unbound.
+function syncExtractionLabel(): void {
+	const { provider, model } = extractionLabelForRoutingTarget(bgExecutor(), bgModelId());
+	const base = ["memory", "pipelineV2"];
+	if (provider) st.aSetStr([...base, "extractionProvider"], provider);
+	else st.aDel([...base, "extractionProvider"]);
+	if (model) st.aSetStr([...base, "extractionModel"], model);
+	else st.aDel([...base, "extractionModel"]);
 }
 
 function bgEndpoint(): string {
@@ -380,7 +408,14 @@ function bgAcpxAgent(): string {
 	return st.aStr(["inference", "targets", TARGET_NAME, "acpx", "agent"]) || "claude";
 }
 function bgSetAcpxAgent(v: string): void {
+	const prior = bgAcpxAgent();
 	st.aSetStr(["inference", "targets", TARGET_NAME, "acpx", "agent"], v);
+	// An ACPX agent switch changes which models can run (claude:haiku vs codex:gpt),
+	// so clear the stale model and re-sync the label exactly like a backend switch.
+	if (prior && prior !== v) {
+		st.aDel(["inference", "targets", TARGET_NAME, "models"]);
+		syncExtractionLabel();
+	}
 }
 
 function bgApiKey(): string {

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
@@ -5,6 +5,7 @@ import {
 	DEFAULT_OPENAI_COMPATIBLE_ENDPOINT,
 	applyAcpxDashboardSetup,
 	defaultAcpxDashboardAgent,
+	extractionLabelForRoutingTarget,
 	hasExplicitSynthesisConfig,
 	hasExplicitSynthesisProvider,
 	resolveExtractionEndpoint,
@@ -242,5 +243,41 @@ describe("pipeline-settings ACPX dashboard setup", () => {
 				sessionSynthesis: { target: "background-acpx/default", taskClass: "session_synthesis" },
 			},
 		});
+	});
+});
+
+describe("extraction label sync for routing targets (#1017)", () => {
+	it("mirrors an in-vocabulary executor and its model into the legacy label", () => {
+		expect(extractionLabelForRoutingTarget("ollama", "gemma3:4b")).toEqual({
+			provider: "ollama",
+			model: "gemma3:4b",
+		});
+		expect(extractionLabelForRoutingTarget("acpx", "haiku")).toEqual({
+			provider: "acpx",
+			model: "haiku",
+		});
+		expect(extractionLabelForRoutingTarget("openai-compatible", "lmstudio-model")).toEqual({
+			provider: "openai-compatible",
+			model: "lmstudio-model",
+		});
+	});
+
+	it("keeps the model label for a provider family the legacy vocab cannot represent", () => {
+		// minimax/google-style provider backends aren't in PIPELINE_PROVIDER_CHOICES;
+		// the model label (the only field logs/telemetry/DB read) must still sync.
+		expect(extractionLabelForRoutingTarget("minimax", "MiniMax-M2.7")).toEqual({
+			provider: undefined,
+			model: "MiniMax-M2.7",
+		});
+	});
+
+	it("resets the label when the backend is cleared", () => {
+		expect(extractionLabelForRoutingTarget("", "gemma3:4b")).toEqual({ provider: undefined, model: undefined });
+		expect(extractionLabelForRoutingTarget("", "")).toEqual({ provider: undefined, model: undefined });
+	});
+
+	it("drops an empty model rather than writing a blank label", () => {
+		expect(extractionLabelForRoutingTarget("ollama", "")).toEqual({ provider: "ollama", model: undefined });
+		expect(extractionLabelForRoutingTarget("ollama", "   ")).toEqual({ provider: "ollama", model: undefined });
 	});
 });

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
@@ -84,6 +84,28 @@ export function resolveExtractionEndpoint(agent: unknown): string {
 	return provider === "openai-compatible" ? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT : "";
 }
 
+/**
+ * Compute the legacy extraction label (`memory.pipelineV2.extraction{Provider,Model}`)
+ * that should mirror a routing target so pipeline logs, telemetry, and the
+ * `extraction_model` DB column report the model actually in use instead of the
+ * `qwen3:4b` default (#1017). Routing is authoritative post-#947; this label is
+ * purely informational and feeds `compileLegacyRoutingConfig`.
+ *
+ * Returns the value to write for each key, or `undefined` to delete it (e.g.
+ * when the backend is cleared, or when the executor is a provider family the
+ * narrower legacy vocabulary can't represent — the model label is still kept).
+ */
+export function extractionLabelForRoutingTarget(
+	executor: string,
+	model: string,
+): { readonly provider: string | undefined; readonly model: string | undefined } {
+	if (!executor) return { provider: undefined, model: undefined };
+	return {
+		provider: isPipelineProvider(executor) ? executor : undefined,
+		model: model.trim() || undefined,
+	};
+}
+
 export function resolveSynthesisProvider(agent: unknown): PipelineProviderChoice {
 	const pipeline = readPipeline(agent);
 	const explicit = readString(pipeline, "synthesis", "provider");


### PR DESCRIPTION
## Summary

Closes #1017.

When a user set the extraction model via the dashboard, the setting was written to the routing path (`inference.workloads.memoryExtraction.target` + `inference.targets.background`) so inference **actually** ran the right model — but the dashboard never wrote the legacy label (`memory.pipelineV2.extraction{Provider,Model}`). That label is what the pipeline "Worker started" log, telemetry events, and the `extraction_model` DB column read, so they kept showing the `qwen3:4b` default. It also generated an orphaned, always-blocked `legacy-extraction/default` target in `/api/inference/status`.

### Fix
Mirrors the **existing** label-write pattern in `applyAcpxDashboardSetup` for the non-ACPX path (which had never been ported when the ACPX flow was added):

- **`extractionLabelForRoutingTarget(executor, model)`** — a pure, unit-tested helper in `pipeline-settings.ts` that maps the routing executor into the narrower legacy provider vocab. For provider families the legacy vocab can't represent (e.g. minimax), it drops `provider` but keeps `model`, which `loadPipelineConfig`'s `flatModelOnly` path still recovers — so the model label propagates regardless.
- **`syncExtractionLabel()`** wired into all three background write paths in `InferenceSection` (`bgSetExecutor`, `bgSetModelId`, `bgSetAcpxAgent`) to write/delete the label to match the routing target.

### Latent bug the sync exposed (also fixed)
`writeTarget` only cleared `models.default.model` when the backend was *emptied*, so a backend switch (ollama→anthropic) left a stale cross-provider model on the routing target — which the sync would then faithfully mirror into the very DB-facing label #1017 sets out to fix. `writeTarget` now clears `models` on an executor change (and `bgSetAcpxAgent` mirrors the same on an ACPX agent switch), so no stale model reaches the label.

### Soundness (verified in review)
- The legacy label is **informational at runtime**: `parseRoutingConfig` lets the explicit `inference.workloads.memoryExtraction` override the label-synthesized `legacy-extraction` target, so the `llama-cpp` default applied to out-of-vocab families never misroutes execution.
- `st.aStr` is always string-safe (used with `.trim()`); clearing the backend deletes both label fields.
- `InferenceSection` is the sole live writer of this label (PipelineSection's extraction setters are currently unbound dead code).

## Test plan
- [x] New `extraction label sync for routing targets (#1017)` suite (4 tests): legacy-vocab mapping, out-of-vocab families, clear path, empty-model handling.
- [x] New daemon-level guard: `loadPipelineConfig` preserves the extraction model for a provider family outside the legacy vocab.
- [x] `bun test` for both `pipeline-settings.test.ts` (14) and `memory-config.test.ts` (99) — all pass.
- [x] `svelte-check` — no new errors (same 8 pre-existing).
- [x] `@signet/daemon` build (bundles dashboard) — clean.
- [x] Three `autoreview` rounds; all findings addressed (stale-model-on-switch root cause, ACPX-agent staleness, stale comment).

The separate, low-impact "orphaned `legacy-extraction/default` target" symptom is intentionally **out of scope** — it's a different root cause (the legacy compile synthesizes a target nothing references) and would warrant its own "flag unreferenced targets" validator rule rather than a label sync.
