### PR TITLE
refactor(core): consolidate workspace path resolution (#956)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -464,6 +464,7 @@
       "name": "@signet/desktop",
       "version": "0.154.6",
       "dependencies": {
+        "@signet/core": "workspace:*",
         "@signet/tray": "workspace:*",
         "electron-updater": "^6.8.3",
       },

--- a/libs/connector-base/index.test.ts
+++ b/libs/connector-base/index.test.ts
@@ -247,10 +247,12 @@ describe("resolveSignetDaemonUrl", () => {
 
 describe("resolveSignetWorkspacePath", () => {
 	// Config/default-path tests below rely on SIGNET_PATH being absent so the
-	// config-file and homedir fallbacks are exercised; clear it up front so the
+	// config-file and homedir fallbacks are exercised; clear both workspace env
+	// vars (the resolver now honors SIGNET_PATH then SIGNET_WORKSPACE) so the
 	// suite is deterministic regardless of the host environment.
 	beforeEach(() => {
 		Reflect.deleteProperty(process.env, "SIGNET_PATH");
+		Reflect.deleteProperty(process.env, "SIGNET_WORKSPACE");
 	});
 
 	it("trusts and normalizes SIGNET_PATH when it points to an existing directory", () => {

--- a/libs/connector-base/src/index.ts
+++ b/libs/connector-base/src/index.ts
@@ -35,12 +35,12 @@
 import { randomBytes } from "node:crypto";
 import { existsSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join } from "node:path";
 import {
 	type SymlinkOptions,
 	type SymlinkResult,
-	expandHome,
 	resolveSignetDaemonUrl as resolveCoreSignetDaemonUrl,
+	resolveWorkspacePath,
 	stripSignetBlock,
 	symlinkSkills,
 } from "@signet/core";
@@ -333,52 +333,15 @@ function isExistingDirectory(path: string): boolean {
 }
 
 export function resolveSignetWorkspacePath(home = homedir()): string {
-	const configured = readManagedTrimmedEnv("SIGNET_PATH");
-	if (configured) {
-		const resolved = resolve(expandHome(configured));
-		if (isExistingDirectory(resolved)) return resolved;
-		// Defense-in-depth against the managed-extension feedback loop (issue
-		// #1016): a stale SIGNET_PATH baked into a migrated/legacy extension
-		// points at a directory that no longer exists on this machine. Trusting
-		// it would re-embed the wrong path on the next sync, so fall through to
-		// the homedir/config resolution, which can always re-derive a valid
-		// default workspace. Warn so the override being ignored is diagnosable.
-		console.warn(
-			`[signet] SIGNET_PATH="${configured}" does not point to an existing workspace directory; using the default workspace resolution instead.`,
-		);
-	}
-
-	const defaultWorkspace = join(home, ".agents");
-	const configHome = readManagedTrimmedEnv("XDG_CONFIG_HOME") ?? join(home, ".config");
-	const workspaceConfigPath = join(configHome, "signet", "workspace.json");
-	if (!existsSync(workspaceConfigPath)) return defaultWorkspace;
-
-	let raw: unknown;
-	try {
-		raw = JSON.parse(readFileSync(workspaceConfigPath, "utf8"));
-	} catch (err) {
-		const detail = err instanceof Error ? err.message : String(err);
-		throw new Error(`Invalid Signet workspace config at ${workspaceConfigPath}: ${detail}`);
-	}
-
-	if (typeof raw !== "object" || raw === null || !("workspace" in raw)) {
-		throw new Error(`Invalid Signet workspace config at ${workspaceConfigPath}: missing workspace`);
-	}
-
-	const workspace = raw.workspace;
-	if (typeof workspace !== "string" || workspace.trim().length === 0) {
-		throw new Error(`Invalid Signet workspace config at ${workspaceConfigPath}: workspace must be a non-empty string`);
-	}
-
-	return resolve(expandHome(workspace.trim()));
+	// Delegates to the canonical resolver in @signet/core (issue #956). Connectors
+	// are install-time operations, so they fail loud on a malformed workspace.json
+	// (strict) and treat a stale env override as unset so it is not re-embedded
+	// into a managed extension (requireExistingEnvPath, issue #1016). A persisted
+	// workspace.json value is still trusted verbatim: it is an explicit,
+	// admin-authored override, and buildManagedExtensionEnvBootstrap re-checks
+	// existence before baking any path into an extension.
+	return resolveWorkspacePath({ home, strict: true, requireExistingEnvPath: true }).path;
 }
-
-// NOTE: unlike the SIGNET_PATH env branch above, the persisted workspace.json
-// value is intentionally trusted without an existence check. It is an explicit,
-// admin-authored override (written by `signet workspace set`), not a value that
-// can be silently injected by a migrated/legacy extension. buildManagedExtensionEnvBootstrap
-// additionally re-checks existence before baking any path into an extension, so a
-// stale config value still cannot be re-embedded via the feedback loop.
 
 export function resolveSignetDaemonUrl(): string {
 	return resolveCoreSignetDaemonUrl();

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -128,6 +128,18 @@ export { loadConfiguredHarnesses, parseHarnessList } from "./harness-config";
 export { resolveSignetDaemonUrl } from "./daemon-url";
 export type { SignetDaemonUrlOptions } from "./daemon-url";
 export {
+	type WorkspaceSource,
+	type WorkspaceResolution,
+	type ResolveWorkspacePathOptions,
+	WORKSPACE_ENV_KEYS,
+	normalizeWorkspacePath,
+	getWorkspaceConfigPath,
+	readConfiguredWorkspacePath,
+	writeConfiguredWorkspacePath,
+	clearConfiguredWorkspacePath,
+	resolveWorkspacePath,
+} from "./workspace";
+export {
 	search,
 	vectorSearch,
 	keywordSearch,

--- a/platform/core/src/workspace.test.ts
+++ b/platform/core/src/workspace.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	type WorkspaceResolution,
+	clearConfiguredWorkspacePath,
+	getWorkspaceConfigPath,
+	normalizeWorkspacePath,
+	readConfiguredWorkspacePath,
+	resolveWorkspacePath,
+	writeConfiguredWorkspacePath,
+} from "./workspace";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function makeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+	return {
+		// Strip host env so precedence tests are deterministic.
+		SIGNET_PATH: undefined,
+		SIGNET_WORKSPACE: undefined,
+		XDG_CONFIG_HOME: undefined,
+		...overrides,
+	};
+}
+
+describe("normalizeWorkspacePath", () => {
+	it("trims, expands ~, and resolves the path", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-norm-"));
+		try {
+			expect(normalizeWorkspacePath("  ~/x  ", home)).toBe(join(home, "x"));
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("resolveWorkspacePath precedence", () => {
+	it("prefers SIGNET_PATH over stored config and SIGNET_WORKSPACE", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-env-"));
+		try {
+			const configHome = join(home, "config");
+			const fromEnv = join(home, "env");
+			const fromWorkspaceAlias = join(home, "env-alias");
+			const fromConfig = join(home, "configured");
+			mkdirSync(join(configHome, "signet"), { recursive: true });
+			writeFileSync(
+				join(configHome, "signet", "workspace.json"),
+				JSON.stringify({ version: 1, workspace: fromConfig }),
+			);
+
+			const resolved = resolveWorkspacePath({
+				env: makeEnv({ SIGNET_PATH: fromEnv, SIGNET_WORKSPACE: fromWorkspaceAlias, XDG_CONFIG_HOME: configHome }),
+				home,
+			});
+
+			expect(resolved.path).toBe(fromEnv);
+			expect(resolved.source).toBe("env");
+			expect(resolved.configuredPath).toBe(fromConfig);
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	it("falls back to SIGNET_WORKSPACE when SIGNET_PATH is absent", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-alias-"));
+		try {
+			const workspace = join(home, "env-alias");
+			const resolved = resolveWorkspacePath({ env: makeEnv({ SIGNET_WORKSPACE: workspace }), home });
+
+			expect(resolved.path).toBe(workspace);
+			expect(resolved.source).toBe("env");
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	it("uses persisted config when no env override is present", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-config-"));
+		try {
+			const configHome = join(home, "config");
+			const configured = join(home, "configured");
+			mkdirSync(join(configHome, "signet"), { recursive: true });
+			writeFileSync(
+				join(configHome, "signet", "workspace.json"),
+				JSON.stringify({ version: 1, workspace: configured }),
+			);
+
+			const resolved = resolveWorkspacePath({ env: makeEnv({ XDG_CONFIG_HOME: configHome }), home });
+
+			expect(resolved.path).toBe(configured);
+			expect(resolved.source).toBe("config");
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	it("falls back to ~/.agents when nothing is configured", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-default-"));
+		try {
+			const resolved = resolveWorkspacePath({ env: makeEnv(), home });
+
+			expect(resolved.path).toBe(join(home, ".agents"));
+			expect(resolved.source).toBe("default");
+			expect(resolved.configuredPath).toBeNull();
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("resolveWorkspacePath malformed config", () => {
+	it("falls back gracefully by default", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-lenient-"));
+		try {
+			const configHome = join(home, "config");
+			mkdirSync(join(configHome, "signet"), { recursive: true });
+			writeFileSync(join(configHome, "signet", "workspace.json"), "{not json");
+
+			const resolved = resolveWorkspacePath({ env: makeEnv({ XDG_CONFIG_HOME: configHome }), home });
+
+			expect(resolved.source).toBe("default");
+			expect(resolved.path).toBe(join(home, ".agents"));
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	it("throws in strict mode on malformed JSON", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-strict-"));
+		try {
+			const configHome = join(home, "config");
+			mkdirSync(join(configHome, "signet"), { recursive: true });
+			writeFileSync(join(configHome, "signet", "workspace.json"), "{not json");
+
+			expect(() => resolveWorkspacePath({ env: makeEnv({ XDG_CONFIG_HOME: configHome }), home, strict: true })).toThrow(
+				"Invalid Signet workspace config",
+			);
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	it("throws in strict mode when workspace is missing or blank", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-strict-missing-"));
+		try {
+			const configHome = join(home, "config");
+			mkdirSync(join(configHome, "signet"), { recursive: true });
+			writeFileSync(join(configHome, "signet", "workspace.json"), JSON.stringify({ version: 1, workspace: "  " }));
+
+			expect(() => resolveWorkspacePath({ env: makeEnv({ XDG_CONFIG_HOME: configHome }), home, strict: true })).toThrow(
+				"workspace must be a non-empty string",
+			);
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	it("a valid env override masks a malformed config even in strict mode", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-strict-masked-"));
+		try {
+			const configHome = join(home, "config");
+			const envWorkspace = join(home, "env-wins");
+			mkdirSync(envWorkspace, { recursive: true });
+			mkdirSync(join(configHome, "signet"), { recursive: true });
+			// Corrupt config that WOULD throw in strict mode if reached.
+			writeFileSync(join(configHome, "signet", "workspace.json"), "{not json");
+
+			// A valid env override short-circuits the malformed config instead of
+			// throwing — preserving the historical contract that a connector install
+			// with a valid SIGNET_PATH succeeds even when workspace.json is corrupt.
+			const resolved = resolveWorkspacePath({
+				env: makeEnv({ SIGNET_PATH: envWorkspace, XDG_CONFIG_HOME: configHome }),
+				home,
+				strict: true,
+			});
+			expect(resolved.source).toBe("env");
+			expect(resolved.path).toBe(envWorkspace);
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("resolveWorkspacePath requireExistingEnvPath", () => {
+	it("trusts a non-existing env path by default", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-trust-"));
+		try {
+			const resolved = resolveWorkspacePath({ env: makeEnv({ SIGNET_PATH: "/nonexistent/stale/.agents" }), home });
+			expect(resolved.source).toBe("env");
+			expect(resolved.path).toBe("/nonexistent/stale/.agents");
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	it("drops a stale env path and warns when requireExistingEnvPath is set (#1016)", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-stale-"));
+		try {
+			const warnings: string[] = [];
+			const originalWarn = console.warn;
+			console.warn = (message?: unknown) => warnings.push(String(message));
+			try {
+				const resolved = resolveWorkspacePath({
+					env: makeEnv({ SIGNET_PATH: "/nonexistent/stale/.agents" }),
+					home,
+					requireExistingEnvPath: true,
+				});
+				expect(resolved.source).toBe("default");
+				expect(resolved.path).toBe(join(home, ".agents"));
+			} finally {
+				console.warn = originalWarn;
+			}
+			expect(warnings.join("\n")).toContain("does not point to an existing workspace directory");
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	it("accepts an existing env path when requireExistingEnvPath is set", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-existing-"));
+		try {
+			const existing = join(home, "real-workspace");
+			mkdirSync(existing, { recursive: true });
+			const resolved = resolveWorkspacePath({
+				env: makeEnv({ SIGNET_PATH: existing }),
+				home,
+				requireExistingEnvPath: true,
+			});
+			expect(resolved.source).toBe("env");
+			expect(resolved.path).toBe(existing);
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("workspace config read/write/clear", () => {
+	it("writes, reads, and clears the persisted workspace payload", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-io-"));
+		try {
+			const env = makeEnv({ XDG_CONFIG_HOME: join(home, "config") });
+			const target = join(home, "target-workspace");
+			const cfgPath = writeConfiguredWorkspacePath(target, env, home);
+			expect(cfgPath).toBe(getWorkspaceConfigPath(env, home));
+			expect(readConfiguredWorkspacePath(env, home)).toBe(target);
+
+			const raw: unknown = JSON.parse(readFileSync(cfgPath, "utf-8"));
+			if (!isRecord(raw) || !("workspace" in raw) || !("version" in raw)) throw new Error("bad payload");
+			expect(raw.workspace).toBe(target);
+			expect(raw.version).toBe(1);
+
+			clearConfiguredWorkspacePath(env);
+			expect(readConfiguredWorkspacePath(env, home)).toBeNull();
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	it("readConfiguredWorkspacePath is null when config is absent", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-absent-"));
+		try {
+			expect(readConfiguredWorkspacePath(makeEnv({ XDG_CONFIG_HOME: join(home, "config") }), home)).toBeNull();
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("resolveWorkspacePath respects the real host default", () => {
+	it("uses process.env and homedir() when no options are given", () => {
+		const resolved: WorkspaceResolution = resolveWorkspacePath({ env: makeEnv() });
+		expect(resolved.path).toBe(join(homedir(), ".agents"));
+		expect(resolved.source).toBe("default");
+	});
+});

--- a/platform/core/src/workspace.ts
+++ b/platform/core/src/workspace.ts
@@ -1,0 +1,247 @@
+/**
+ * Canonical Signet workspace path resolution.
+ *
+ * One owner for the "resolve `SIGNET_PATH` → `SIGNET_WORKSPACE` →
+ * `$XDG_CONFIG_HOME/signet/workspace.json` → `~/.agents` default" chain that
+ * is shared by connector-base, the CLI, and the desktop shell (issue #956).
+ *
+ * Resolution precedence:
+ *   1. `SIGNET_PATH` env var
+ *   2. `SIGNET_WORKSPACE` env var (alias, lower precedence)
+ *   3. persisted `$XDG_CONFIG_HOME/signet/workspace.json` `{ workspace }`
+ *   4. `~/.agents` default
+ *
+ * Env var precedence is defined once here and applied everywhere, so a synced
+ * or cloned agents directory resolves consistently regardless of which surface
+ * performs the resolution.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { expandHome } from "./constants";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type WorkspaceSource = "env" | "config" | "default";
+
+export interface WorkspaceResolution {
+	readonly path: string;
+	readonly source: WorkspaceSource;
+	readonly configPath: string;
+	readonly configuredPath: string | null;
+}
+
+export interface ResolveWorkspacePathOptions {
+	readonly env?: NodeJS.ProcessEnv;
+	readonly home?: string;
+	/**
+	 * Throw on a malformed persisted workspace.json instead of falling back to
+	 * the default. Default `false` (graceful), which is required for surfaces
+	 * that resolve at import time and must never crash on a corrupt config.
+	 * Explicit install operations pass `true` to fail loud.
+	 */
+	readonly strict?: boolean;
+	/**
+	 * Require an env-derived workspace path to point at an existing directory.
+	 * When `false` (default) an env override is trusted verbatim. When `true`,
+	 * a stale env override is treated as unset (with a warning) and resolution
+	 * falls through to the config/default, which prevents a migrated/legacy
+	 * managed extension from re-embedding a path that no longer exists
+	 * (issue #1016).
+	 */
+	readonly requireExistingEnvPath?: boolean;
+}
+
+interface WorkspaceConfigFile {
+	readonly version: 1;
+	readonly workspace: string;
+	readonly updatedAt: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Env vars honored as workspace overrides, in precedence order. */
+export const WORKSPACE_ENV_KEYS = ["SIGNET_PATH", "SIGNET_WORKSPACE"] as const;
+
+const DEFAULT_AGENTS_DIRNAME = ".agents";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+export function normalizeWorkspacePath(pathValue: string, home = homedir()): string {
+	return resolve(expandHome(pathValue.trim(), home));
+}
+
+function readTrimmedEnv(env: NodeJS.ProcessEnv, name: string): string | undefined {
+	const value = env[name];
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readConfigHome(env: NodeJS.ProcessEnv, home: string): string {
+	const raw = env.XDG_CONFIG_HOME;
+	if (typeof raw !== "string") return join(home, ".config");
+	const trimmed = raw.trim();
+	return trimmed.length > 0 ? normalizeWorkspacePath(trimmed, home) : join(home, ".config");
+}
+
+function isExistingDirectory(path: string): boolean {
+	try {
+		return statSync(path).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// ============================================================================
+// Config path + read/write
+// ============================================================================
+
+export function getWorkspaceConfigPath(env: NodeJS.ProcessEnv = process.env, home = homedir()): string {
+	return join(readConfigHome(env, home), "signet", "workspace.json");
+}
+
+/**
+ * Read the persisted `workspace` value from `workspace.json`.
+ *
+ * Returns `null` when the file is absent or (in non-strict mode) malformed.
+ * In strict mode a malformed file throws, preserving the historical contract
+ * of explicit install operations.
+ */
+export function readConfiguredWorkspacePath(
+	env: NodeJS.ProcessEnv = process.env,
+	home = homedir(),
+	options: { readonly strict?: boolean } = {},
+): string | null {
+	const strict = options.strict ?? false;
+	const configPath = getWorkspaceConfigPath(env, home);
+	if (!existsSync(configPath)) return null;
+
+	let raw: unknown;
+	try {
+		raw = JSON.parse(readFileSync(configPath, "utf-8"));
+	} catch (err) {
+		if (strict) {
+			const detail = err instanceof Error ? err.message : String(err);
+			throw new Error(`Invalid Signet workspace config at ${configPath}: ${detail}`);
+		}
+		return null;
+	}
+
+	if (!isRecord(raw) || !("workspace" in raw)) {
+		if (strict) throw new Error(`Invalid Signet workspace config at ${configPath}: missing workspace`);
+		return null;
+	}
+
+	const workspace = raw.workspace;
+	if (typeof workspace !== "string" || workspace.trim().length === 0) {
+		if (strict)
+			throw new Error(`Invalid Signet workspace config at ${configPath}: workspace must be a non-empty string`);
+		return null;
+	}
+
+	return normalizeWorkspacePath(workspace, home);
+}
+
+export function writeConfiguredWorkspacePath(
+	pathValue: string,
+	env: NodeJS.ProcessEnv = process.env,
+	home = homedir(),
+): string {
+	const path = normalizeWorkspacePath(pathValue, home);
+	const configPath = getWorkspaceConfigPath(env, home);
+	const configDir = dirname(configPath);
+	mkdirSync(configDir, { recursive: true });
+
+	const payload: WorkspaceConfigFile = {
+		version: 1,
+		workspace: path,
+		updatedAt: new Date().toISOString(),
+	};
+	writeFileSync(configPath, `${JSON.stringify(payload, null, 2)}\n`);
+	return configPath;
+}
+
+export function clearConfiguredWorkspacePath(env: NodeJS.ProcessEnv = process.env): void {
+	const configPath = getWorkspaceConfigPath(env);
+	if (!existsSync(configPath)) return;
+	rmSync(configPath, { force: true });
+}
+
+// ============================================================================
+// Resolution
+// ============================================================================
+
+/**
+ * Resolve the active Signet workspace path from env, persisted config, and
+ * default, returning a structured result describing which source won.
+ */
+export function resolveWorkspacePath(options: ResolveWorkspacePathOptions = {}): WorkspaceResolution {
+	const env = options.env ?? process.env;
+	const home = options.home ?? homedir();
+	const strict = options.strict ?? false;
+	const requireExistingEnvPath = options.requireExistingEnvPath ?? false;
+
+	const configPath = getWorkspaceConfigPath(env, home);
+	// Resolve the env override first: if it wins, a malformed persisted config is
+	// irrelevant (only the `configuredPath` report field needs it, so read it
+	// leniently). Only propagate `strict` to the config read when the env override
+	// did not win, preserving the historical contract that a valid env override
+	// short-circuits a corrupt workspace.json rather than throwing.
+	const envPath = resolveEnvWorkspace(env, home, requireExistingEnvPath);
+	const configValue = readConfiguredWorkspacePath(env, home, { strict: envPath ? false : strict });
+
+	if (envPath) {
+		return {
+			path: envPath,
+			source: "env",
+			configPath,
+			configuredPath: configValue,
+		};
+	}
+
+	if (configValue) {
+		return {
+			path: configValue,
+			source: "config",
+			configPath,
+			configuredPath: configValue,
+		};
+	}
+
+	return {
+		path: join(home, DEFAULT_AGENTS_DIRNAME),
+		source: "default",
+		configPath,
+		configuredPath: configValue,
+	};
+}
+
+function resolveEnvWorkspace(env: NodeJS.ProcessEnv, home: string, requireExisting: boolean): string | null {
+	for (const key of WORKSPACE_ENV_KEYS) {
+		const raw = readTrimmedEnv(env, key);
+		if (!raw) continue;
+		const normalized = normalizeWorkspacePath(raw, home);
+		if (!requireExisting || isExistingDirectory(normalized)) return normalized;
+		// A stale env override (from a migrated/legacy managed extension) points
+		// at a directory that no longer exists on this machine. Treat it as
+		// unset and fall through to config/default resolution so the wrong path
+		// is not re-embedded (issue #1016). Warn so the dropped override is
+		// diagnosable.
+		console.warn(
+			`[signet] ${key}="${raw}" does not point to an existing workspace directory; using the default workspace resolution instead.`,
+		);
+	}
+	return null;
+}

--- a/surfaces/cli/src/lib/workspace.test.ts
+++ b/surfaces/cli/src/lib/workspace.test.ts
@@ -8,14 +8,20 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
 }
 
+// Strip both workspace env vars from the host so precedence/fallback tests are
+// deterministic regardless of the developer shell (the resolver honors
+// SIGNET_PATH then SIGNET_WORKSPACE).
+function cleanEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+	return { ...process.env, SIGNET_PATH: "", SIGNET_WORKSPACE: "", ...overrides };
+}
+
 describe("workspace path resolution", () => {
 	it("prefers SIGNET_PATH over stored config", () => {
 		const root = mkdtempSync(join(tmpdir(), "signet-workspace-env-"));
-		const env = {
-			...process.env,
+		const env = cleanEnv({
 			XDG_CONFIG_HOME: root,
 			SIGNET_PATH: join(root, "from-env"),
-		};
+		});
 		writeConfiguredWorkspacePath(join(root, "from-config"), env);
 
 		const resolved = resolveAgentsDir(env);
@@ -25,11 +31,10 @@ describe("workspace path resolution", () => {
 
 	it("uses stored config when env override is absent", () => {
 		const root = mkdtempSync(join(tmpdir(), "signet-workspace-config-"));
-		const env = {
-			...process.env,
+		const env = cleanEnv({
 			XDG_CONFIG_HOME: root,
 			SIGNET_PATH: "",
-		};
+		});
 		writeConfiguredWorkspacePath(join(root, "agent-home"), env);
 
 		const resolved = resolveAgentsDir(env);
@@ -39,11 +44,10 @@ describe("workspace path resolution", () => {
 
 	it("falls back to ~/.agents when no env or config is present", () => {
 		const root = mkdtempSync(join(tmpdir(), "signet-workspace-default-"));
-		const env = {
-			...process.env,
+		const env = cleanEnv({
 			XDG_CONFIG_HOME: root,
 			SIGNET_PATH: "",
-		};
+		});
 
 		const resolved = resolveAgentsDir(env);
 		expect(resolved.source).toBe("default");
@@ -52,10 +56,9 @@ describe("workspace path resolution", () => {
 
 	it("writes workspace config payload to expected file", () => {
 		const root = mkdtempSync(join(tmpdir(), "signet-workspace-write-"));
-		const env = {
-			...process.env,
+		const env = cleanEnv({
 			XDG_CONFIG_HOME: root,
-		};
+		});
 		const target = join(root, "target-workspace");
 		const cfgPath = writeConfiguredWorkspacePath(target, env);
 		const expected = getWorkspaceConfigPath(env);

--- a/surfaces/cli/src/lib/workspace.ts
+++ b/surfaces/cli/src/lib/workspace.ts
@@ -1,145 +1,42 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
-import { expandHome } from "@signet/core";
+import {
+	type WorkspaceResolution,
+	type WorkspaceSource,
+	clearConfiguredWorkspacePath as clearCore,
+	getWorkspaceConfigPath as getCore,
+	normalizeWorkspacePath as normalizeCore,
+	readConfiguredWorkspacePath as readCore,
+	resolveWorkspacePath,
+	writeConfiguredWorkspacePath as writeCore,
+} from "@signet/core";
 
-export type WorkspaceSource = "env" | "config" | "default";
+// Canonical Signet workspace resolution lives in @signet/core (issue #956).
+// These thin wrappers preserve the CLI's historical default-argument shape
+// (resolving against process.env at call time) while delegating to the single
+// shared implementation, so the CLI, desktop shell, and connectors can no
+// longer drift on env-var precedence or the workspace.json schema.
 
-export interface WorkspaceResolution {
-	readonly path: string;
-	readonly source: WorkspaceSource;
-	readonly configPath: string;
-	readonly configuredPath: string | null;
-}
-
-interface WorkspaceConfigFile {
-	readonly version: 1;
-	readonly workspace: string;
-	readonly updatedAt: string;
-}
+export type { WorkspaceSource, WorkspaceResolution };
 
 export function normalizeWorkspacePath(pathValue: string): string {
-	return resolve(expandHome(pathValue.trim()));
-}
-
-function readEnvPath(env: NodeJS.ProcessEnv): string | null {
-	const raw = env.SIGNET_PATH;
-	if (typeof raw !== "string") {
-		return null;
-	}
-
-	const trimmed = raw.trim();
-	if (trimmed.length === 0) {
-		return null;
-	}
-
-	return normalizeWorkspacePath(trimmed);
-}
-
-function readConfigHome(env: NodeJS.ProcessEnv): string {
-	const raw = env.XDG_CONFIG_HOME;
-	if (typeof raw !== "string") {
-		return join(homedir(), ".config");
-	}
-
-	const trimmed = raw.trim();
-	if (trimmed.length === 0) {
-		return join(homedir(), ".config");
-	}
-
-	return normalizeWorkspacePath(trimmed);
+	return normalizeCore(pathValue);
 }
 
 export function getWorkspaceConfigPath(env: NodeJS.ProcessEnv = process.env): string {
-	return join(readConfigHome(env), "signet", "workspace.json");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
-}
-
-function readWorkspaceFromConfig(path: string): string | null {
-	if (!existsSync(path)) {
-		return null;
-	}
-
-	try {
-		const raw: unknown = JSON.parse(readFileSync(path, "utf-8"));
-		if (!isRecord(raw)) {
-			return null;
-		}
-
-		const workspace = raw.workspace;
-		if (typeof workspace !== "string") {
-			return null;
-		}
-
-		const trimmed = workspace.trim();
-		if (trimmed.length === 0) {
-			return null;
-		}
-
-		return normalizeWorkspacePath(trimmed);
-	} catch {
-		return null;
-	}
+	return getCore(env);
 }
 
 export function readConfiguredWorkspacePath(env: NodeJS.ProcessEnv = process.env): string | null {
-	const cfgPath = getWorkspaceConfigPath(env);
-	return readWorkspaceFromConfig(cfgPath);
+	return readCore(env);
 }
 
 export function resolveAgentsDir(env: NodeJS.ProcessEnv = process.env): WorkspaceResolution {
-	const cfgPath = getWorkspaceConfigPath(env);
-	const envPath = readEnvPath(env);
-	const cfgValue = readWorkspaceFromConfig(cfgPath);
-	if (envPath) {
-		return {
-			path: envPath,
-			source: "env",
-			configPath: cfgPath,
-			configuredPath: cfgValue,
-		};
-	}
-
-	if (cfgValue) {
-		return {
-			path: cfgValue,
-			source: "config",
-			configPath: cfgPath,
-			configuredPath: cfgValue,
-		};
-	}
-
-	return {
-		path: join(homedir(), ".agents"),
-		source: "default",
-		configPath: cfgPath,
-		configuredPath: null,
-	};
+	return resolveWorkspacePath({ env });
 }
 
 export function writeConfiguredWorkspacePath(pathValue: string, env: NodeJS.ProcessEnv = process.env): string {
-	const path = normalizeWorkspacePath(pathValue);
-	const cfgPath = getWorkspaceConfigPath(env);
-	const cfgDir = dirname(cfgPath);
-	mkdirSync(cfgDir, { recursive: true });
-
-	const payload: WorkspaceConfigFile = {
-		version: 1,
-		workspace: path,
-		updatedAt: new Date().toISOString(),
-	};
-	writeFileSync(cfgPath, `${JSON.stringify(payload, null, 2)}\n`);
-	return cfgPath;
+	return writeCore(pathValue, env);
 }
 
 export function clearConfiguredWorkspacePath(env: NodeJS.ProcessEnv = process.env): void {
-	const cfgPath = getWorkspaceConfigPath(env);
-	if (!existsSync(cfgPath)) {
-		return;
-	}
-
-	rmSync(cfgPath, { force: true });
+	clearCore(env);
 }

--- a/surfaces/desktop/package.json
+++ b/surfaces/desktop/package.json
@@ -20,6 +20,7 @@
 		"test": "bun test"
 	},
 	"dependencies": {
+		"@signet/core": "workspace:*",
 		"@signet/tray": "workspace:*",
 		"electron-updater": "^6.8.3"
 	},

--- a/surfaces/desktop/src/workspace.ts
+++ b/surfaces/desktop/src/workspace.ts
@@ -1,52 +1,19 @@
-import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { type WorkspaceResolution, type WorkspaceSource, resolveWorkspacePath } from "@signet/core";
 
-export type DesktopWorkspaceSource = "env" | "config" | "default";
+// Canonical Signet workspace resolution lives in @signet/core (issue #956).
+// The desktop shell delegates to the single shared implementation so env-var
+// precedence (SIGNET_PATH then SIGNET_WORKSPACE) and the workspace.json schema
+// can no longer drift from the CLI and connectors.
 
-export interface DesktopWorkspaceResolution {
-	readonly path: string;
-	readonly source: DesktopWorkspaceSource;
-	readonly configPath: string;
-	readonly configuredPath: string | null;
-}
-
-export function normalizeWorkspacePath(pathValue: string, home = homedir()): string {
-	return resolve(expandHome(pathValue.trim(), home));
-}
+export type DesktopWorkspaceSource = WorkspaceSource;
+export type DesktopWorkspaceResolution = WorkspaceResolution;
 
 export function resolveDesktopWorkspace(
 	env: NodeJS.ProcessEnv = process.env,
 	home = homedir(),
 ): DesktopWorkspaceResolution {
-	const configPath = getWorkspaceConfigPath(env, home);
-	const envPath = readEnvPath(env, home);
-	const configPathValue = readWorkspaceFromConfig(configPath, home);
-
-	if (envPath) {
-		return {
-			path: envPath,
-			source: "env",
-			configPath,
-			configuredPath: configPathValue,
-		};
-	}
-
-	if (configPathValue) {
-		return {
-			path: configPathValue,
-			source: "config",
-			configPath,
-			configuredPath: configPathValue,
-		};
-	}
-
-	return {
-		path: join(home, ".agents"),
-		source: "default",
-		configPath,
-		configuredPath: null,
-	};
+	return resolveWorkspacePath({ env, home });
 }
 
 export function applyDesktopWorkspaceEnv(
@@ -56,41 +23,4 @@ export function applyDesktopWorkspaceEnv(
 	env.SIGNET_PATH = resolution.path;
 	env.SIGNET_WORKSPACE = resolution.path;
 	return resolution;
-}
-
-function readEnvPath(env: NodeJS.ProcessEnv, home: string): string | null {
-	for (const key of ["SIGNET_PATH", "SIGNET_WORKSPACE"] as const) {
-		const raw = env[key];
-		if (typeof raw !== "string") continue;
-		const trimmed = raw.trim();
-		if (trimmed.length > 0) return normalizeWorkspacePath(trimmed, home);
-	}
-	return null;
-}
-
-function getWorkspaceConfigPath(env: NodeJS.ProcessEnv, home: string): string {
-	const raw = env.XDG_CONFIG_HOME;
-	if (typeof raw !== "string") return join(home, ".config", "signet", "workspace.json");
-	const trimmed = raw.trim();
-	const configHome = trimmed.length > 0 ? normalizeWorkspacePath(trimmed, home) : join(home, ".config");
-	return join(configHome, "signet", "workspace.json");
-}
-
-function readWorkspaceFromConfig(path: string, home: string): string | null {
-	if (!existsSync(path)) return null;
-	try {
-		const raw: unknown = JSON.parse(readFileSync(path, "utf8"));
-		if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
-		const workspace = Reflect.get(raw, "workspace");
-		if (typeof workspace !== "string") return null;
-		const trimmed = workspace.trim();
-		return trimmed.length > 0 ? normalizeWorkspacePath(trimmed, home) : null;
-	} catch {
-		return null;
-	}
-}
-
-function expandHome(pathValue: string, home: string): string {
-	if (pathValue === "~") return home;
-	return pathValue.startsWith("~/") || pathValue.startsWith("~\\") ? join(home, pathValue.slice(2)) : pathValue;
 }


### PR DESCRIPTION
## Summary

Closes #956.

The "resolve `SIGNET_PATH` → `SIGNET_WORKSPACE` → `$XDG_CONFIG_HOME/signet/workspace.json` → `~/.agents`" chain was implemented in three drifted places (connector-base, CLI, desktop). The desktop copy honored `SIGNET_WORKSPACE` while connector-base and the CLI did **not** — so a user setting `SIGNET_WORKSPACE` could resolve a different workspace depending on which surface performed the resolution (a real wrong-workspace bug).

## Changes

- **NEW `platform/core/src/workspace.ts`** — one canonical `resolveWorkspacePath({ env, home, strict?, requireExistingEnvPath? })` returning `{ path, source, configPath, configuredPath }`. Honors `SIGNET_PATH` → `SIGNET_WORKSPACE` → `workspace.json` → `~/.agents` in that order. Two option flags preserve each surface's historical behavior:
  - `strict` — throw vs graceful on a malformed `workspace.json`
  - `requireExistingEnvPath` — treat a stale env override as unset (#1016 stale-path guard)
- Also moves the `workspace.json` read/write/clear helpers (`writeConfiguredWorkspacePath`, `clearConfiguredWorkspacePath`, `readConfiguredWorkspacePath`) into the same core owner.
- **connector-base**: `resolveSignetWorkspacePath` delegates with `strict: true, requireExistingEnvPath: true` (preserves its throw + existence-validation). The env path is resolved before the strict config read, so a valid env override still masks a corrupt config.
- **CLI** (`surfaces/cli/src/lib/workspace.ts`): thin re-export wrappers delegating to core (default graceful). Was 151 lines, now thin.
- **desktop** (`surfaces/desktop/src/workspace.ts`): delegates to core; removed local `expandHome`/config-reader copies. Gains `@signet/core` as a workspace dep.
- **Test scaffolding** hardened: clears `SIGNET_WORKSPACE` in addition to `SIGNET_PATH` so suites are deterministic regardless of the host shell.

## Why the desktop dep is safe

`@signet/core`'s native modules (`better-sqlite3`, `sqlite-vec-*`) are all `optionalDependencies` / lazy-loaded — core's `database.ts` loads them via dynamic `await import()` inside the `Database` constructor, which the desktop never invokes. The desktop's `build:desktop` script already builds core. The `@signet/tray` workspace dep already establishes this pattern. `sqlite-vec` and `yaml` (small, non-native) land in the asar but are never eagerly executed.

## Verification

- New core suite (15 cases): precedence, malformed config (strict + graceful), `requireExistingEnvPath`, env-masks-config regression.
- Full sweep: **94 tests pass** across core, connector-base, pi/oh-my-pi/forge/gemini connectors, CLI, desktop.
- `biome check` + `tsc --noEmit` clean for all changed packages. Net **−191 LOC**.
- Adversarial review (2 passes): all findings addressed; no correctness/security defects.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations touched. The desktop gains a `@signet/core` workspace dependency; `bun install` / `bun.lock` updated.

- [ ] Migration is idempotent
- [ ] Daemon Rust parity reviewed or explicitly N/A
- [ ] Rollback / compatibility note included in PR description

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Resolves the drift flagged in #956: all three surfaces now honor the same env-var precedence. Out of scope: `platform/core/src/constants.ts`'s `resolveDefaultBasePath()` (a simpler `SIGNET_PATH || ~/.agents` resolver with 31 daemon-runtime callers) — left untouched to avoid changing daemon behavior; it could be migrated separately if XDG-config awareness is wanted there.
