### PR TITLE
fix(codex): migrate stale desktop runtimes

### DIFF
--- a/dist/signetai/bin/launch.js
+++ b/dist/signetai/bin/launch.js
@@ -48,7 +48,7 @@ export function launchSignet() {
 	// doesn't carry inline. The env is only set when the wrapper actually
 	// has a runtime tree to share; the binary's own bootstrap can derive
 	// its own path otherwise.
-	const env = { ...process.env };
+	const env = { ...process.env, SIGNET_WRAPPER_DIR: packageDir };
 	if (!env.SIGNET_DIR && existsSync(join(packageDir, "runtime", "connectors"))) {
 		env.SIGNET_DIR = packageDir;
 	}

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -18,6 +18,9 @@ available, with a compatibility path for older Codex installs.
   Codex-generated `MEMORY.md` or `memory_summary.md`
 - Configurable timeout grace periods (5 s for SessionStart, 2 s for UserPromptSubmit)
 - Supports remote daemon URL via `SIGNET_DAEMON_URL` environment variable
+- On macOS, discovers and validates the bundled Codex Desktop Node runtime on
+  install and refreshes only stale Signet-owned hook and MCP commands after a
+  Codex Desktop packaging update
 
 ## Installation
 

--- a/integrations/codex/connector/src/config-toml.test.ts
+++ b/integrations/codex/connector/src/config-toml.test.ts
@@ -87,6 +87,7 @@ let previousDaemonUrl: string | undefined;
 let previousApiKey: string | undefined;
 let previousToken: string | undefined;
 let previousForceCompatHooks: string | undefined;
+let previousWrapperDir: string | undefined;
 let previousArgvEntry: string | undefined;
 let previousExecPath: string;
 
@@ -106,6 +107,7 @@ beforeEach(() => {
 	previousApiKey = process.env.SIGNET_API_KEY;
 	previousToken = process.env.SIGNET_TOKEN;
 	previousForceCompatHooks = process.env.SIGNET_CODEX_FORCE_COMPAT_HOOKS;
+	previousWrapperDir = process.env.SIGNET_WRAPPER_DIR;
 	previousArgvEntry = process.argv[1];
 	previousExecPath = process.execPath;
 	Reflect.deleteProperty(process.env, "SIGNET_SESSION_START_TIMEOUT");
@@ -115,6 +117,7 @@ beforeEach(() => {
 	Reflect.deleteProperty(process.env, "SIGNET_API_KEY");
 	Reflect.deleteProperty(process.env, "SIGNET_TOKEN");
 	Reflect.deleteProperty(process.env, "SIGNET_CODEX_FORCE_COMPAT_HOOKS");
+	Reflect.deleteProperty(process.env, "SIGNET_WRAPPER_DIR");
 	tempHome = join(tmpdir(), `signet-codex-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	codexDir = join(tempHome, ".codex");
 	configPath = join(codexDir, "config.toml");
@@ -130,6 +133,7 @@ afterEach(() => {
 	restoreEnv("SIGNET_API_KEY", previousApiKey);
 	restoreEnv("SIGNET_TOKEN", previousToken);
 	restoreEnv("SIGNET_CODEX_FORCE_COMPAT_HOOKS", previousForceCompatHooks);
+	restoreEnv("SIGNET_WRAPPER_DIR", previousWrapperDir);
 	if (previousArgvEntry === undefined) process.argv.splice(1, 1);
 	else process.argv[1] = previousArgvEntry;
 	process.execPath = previousExecPath;
@@ -899,7 +903,7 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		expect(signetHandlers[0]?.timeout).toBe(20);
 	});
 
-	test("migrates stale Codex Desktop node paths after a packaging update", async () => {
+	test("migrates a stale Codex Desktop MCP runtime path after a packaging update", async () => {
 		const appPath = join(tempHome, "Applications", "Codex.app");
 		const runtime = join(appPath, "Contents", "Resources", "runtime", "node", "bin", "node");
 		mkdirSync(join(runtime, ".."), { recursive: true });
@@ -919,23 +923,9 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		process.argv[1] = "/$bunfs/root/signet";
 
 		writeFileSync(
-			hooksPath,
-			JSON.stringify({
-				hooks: {
-					SessionStart: [
-						{
-							hooks: [
-								{
-									type: "command",
-									command: "/old/Codex.app/Contents/Resources/node /old/signet.js hook session-start -H codex",
-								},
-							],
-						},
-					],
-				},
-			}),
+			configPath,
+			"[mcp_servers.signet]\ncommand = '/old/Codex.app/Contents/Resources/node'\nargs = ['/old/mcp-stdio.js']\n",
 		);
-		writeFileSync(configPath, "[mcp_servers.signet]\ncommand = '/old/Codex.app/Contents/Resources/node'\n");
 
 		const result = await desktopRuntimeConnector(appPath).install(tempHome);
 		const hooks = readHooksJson().hooks as Record<string, Record<string, unknown>[]>;
@@ -948,6 +938,38 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		expect(result.warnings).toContain(
 			"Detected a missing Signet Codex runtime path; refreshed only Signet-owned hooks and MCP configuration.",
 		);
+	});
+
+	test("uses the wrapper entry when an optional native binary runs without postinstall", async () => {
+		const appPath = join(tempHome, "Applications", "Codex.app");
+		const runtime = join(appPath, "Contents", "Resources", "runtime", "node", "bin", "node");
+		mkdirSync(join(runtime, ".."), { recursive: true });
+		writeFileSync(runtime, "#!/bin/sh\necho v22.14.0\n", "utf-8");
+		chmodSync(runtime, 0o755);
+
+		const packageRoot = join(tempHome, "signetai");
+		const signetEntry = join(packageRoot, "bin", "signet.js");
+		const mcpEntry = join(packageRoot, "dist", "mcp-stdio.js");
+		const optionalNative = join(packageRoot, "node_modules", "signetai-darwin-arm64", "bin", "signet");
+		mkdirSync(join(signetEntry, ".."), { recursive: true });
+		mkdirSync(join(mcpEntry, ".."), { recursive: true });
+		mkdirSync(join(optionalNative, ".."), { recursive: true });
+		writeFileSync(signetEntry, "// fixture\n", "utf-8");
+		writeFileSync(mcpEntry, "// fixture\n", "utf-8");
+		writeFileSync(optionalNative, "binary fixture\n", "utf-8");
+		process.execPath = optionalNative;
+		process.argv[1] = "/$bunfs/root/signet";
+		process.env.SIGNET_WRAPPER_DIR = packageRoot;
+
+		await desktopRuntimeConnector(appPath).install(tempHome);
+		const hooks = readHooksJson().hooks as Record<string, Record<string, unknown>[]>;
+		for (const event of ["SessionStart", "UserPromptSubmit", "Stop"]) {
+			const handler = ((hooks[event]?.[0]?.hooks as Record<string, unknown>[]) ?? [])[0];
+			expect(handler?.command).toContain(`${runtime} ${signetEntry}`);
+		}
+		const config = readFileSync(configPath, "utf-8");
+		expect(config).toContain(`command = '${runtime}'`);
+		expect(config).toContain(`args = ['${mcpEntry}']`);
 	});
 
 	test("discovers symlinked Codex Desktop runtimes", async () => {

--- a/integrations/codex/connector/src/config-toml.test.ts
+++ b/integrations/codex/connector/src/config-toml.test.ts
@@ -6,10 +6,10 @@
  * temp directory so the real ~/.codex is never touched.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { CodexConnector, buildMcpBlock } from "./index.js";
+import { CodexConnector, buildMcpBlock, resolveCodexDesktopNode } from "./index.js";
 
 class TempConnector extends CodexConnector {
 	constructor(private home: string) {
@@ -88,6 +88,7 @@ let previousApiKey: string | undefined;
 let previousToken: string | undefined;
 let previousForceCompatHooks: string | undefined;
 let previousArgvEntry: string | undefined;
+let previousExecPath: string;
 
 function restoreEnv(name: string, value: string | undefined): void {
 	if (value === undefined) {
@@ -106,6 +107,7 @@ beforeEach(() => {
 	previousToken = process.env.SIGNET_TOKEN;
 	previousForceCompatHooks = process.env.SIGNET_CODEX_FORCE_COMPAT_HOOKS;
 	previousArgvEntry = process.argv[1];
+	previousExecPath = process.execPath;
 	Reflect.deleteProperty(process.env, "SIGNET_SESSION_START_TIMEOUT");
 	Reflect.deleteProperty(process.env, "SIGNET_FETCH_TIMEOUT");
 	Reflect.deleteProperty(process.env, "SIGNET_PROMPT_SUBMIT_TIMEOUT");
@@ -130,6 +132,7 @@ afterEach(() => {
 	restoreEnv("SIGNET_CODEX_FORCE_COMPAT_HOOKS", previousForceCompatHooks);
 	if (previousArgvEntry === undefined) process.argv.splice(1, 1);
 	else process.argv[1] = previousArgvEntry;
+	process.execPath = previousExecPath;
 	rmSync(tempHome, { recursive: true, force: true });
 });
 
@@ -910,7 +913,10 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		mkdirSync(join(mcpEntry, ".."), { recursive: true });
 		writeFileSync(signetEntry, "// fixture\n", "utf-8");
 		writeFileSync(mcpEntry, "// fixture\n", "utf-8");
-		process.argv[1] = signetEntry;
+		const signetBinary = join(packageRoot, "bin", "signet");
+		writeFileSync(signetBinary, "binary fixture\n", "utf-8");
+		process.execPath = signetBinary;
+		process.argv[1] = "/$bunfs/root/signet";
 
 		writeFileSync(
 			hooksPath,
@@ -942,6 +948,35 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		expect(result.warnings).toContain(
 			"Detected a missing Signet Codex runtime path; refreshed only Signet-owned hooks and MCP configuration.",
 		);
+	});
+
+	test("discovers symlinked Codex Desktop runtimes", async () => {
+		const appPath = join(tempHome, "Applications", "Codex.app");
+		const resourcesDir = join(appPath, "Contents", "Resources");
+		const runtimeDir = join(tempHome, "node-runtime");
+		const versionedNode = join(runtimeDir, "node-v22.14.0");
+		const runtime = join(runtimeDir, "node");
+		mkdirSync(runtimeDir, { recursive: true });
+		writeFileSync(versionedNode, "#!/bin/sh\necho v22.14.0\n", "utf-8");
+		chmodSync(versionedNode, 0o755);
+		symlinkSync("node-v22.14.0", runtime);
+		mkdirSync(resourcesDir, { recursive: true });
+		symlinkSync(runtimeDir, join(resourcesDir, "runtime"));
+
+		expect(resolveCodexDesktopNode([appPath], (path) => path === join(resourcesDir, "runtime", "node"))).toBe(
+			join(resourcesDir, "runtime", "node"),
+		);
+	});
+
+	test("installs with malformed but valid hooks.json", async () => {
+		for (const hooks of [
+			{ SessionStart: "x" },
+			{ SessionStart: [{ hooks: "x" }] },
+			{ SessionStart: [{ hooks: [null] }] },
+		]) {
+			writeFileSync(hooksPath, JSON.stringify({ hooks }));
+			await expect(connector().install(tempHome)).resolves.toMatchObject({ success: true });
+		}
 	});
 
 	test("preserves third-party commands that only mention hook subcommands", async () => {

--- a/integrations/codex/connector/src/config-toml.test.ts
+++ b/integrations/codex/connector/src/config-toml.test.ts
@@ -6,7 +6,7 @@
  * temp directory so the real ~/.codex is never touched.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CodexConnector, buildMcpBlock } from "./index.js";
@@ -20,6 +20,18 @@ class TempConnector extends CodexConnector {
 	}
 	protected override supportsNativePluginInstall(): boolean {
 		return false;
+	}
+}
+
+class DesktopRuntimeTempConnector extends TempConnector {
+	constructor(
+		home: string,
+		private appPath: string,
+	) {
+		super(home);
+	}
+	protected override getCodexDesktopAppPaths(): readonly string[] {
+		return [this.appPath];
 	}
 }
 
@@ -75,6 +87,7 @@ let previousDaemonUrl: string | undefined;
 let previousApiKey: string | undefined;
 let previousToken: string | undefined;
 let previousForceCompatHooks: string | undefined;
+let previousArgvEntry: string | undefined;
 
 function restoreEnv(name: string, value: string | undefined): void {
 	if (value === undefined) {
@@ -92,6 +105,7 @@ beforeEach(() => {
 	previousApiKey = process.env.SIGNET_API_KEY;
 	previousToken = process.env.SIGNET_TOKEN;
 	previousForceCompatHooks = process.env.SIGNET_CODEX_FORCE_COMPAT_HOOKS;
+	previousArgvEntry = process.argv[1];
 	Reflect.deleteProperty(process.env, "SIGNET_SESSION_START_TIMEOUT");
 	Reflect.deleteProperty(process.env, "SIGNET_FETCH_TIMEOUT");
 	Reflect.deleteProperty(process.env, "SIGNET_PROMPT_SUBMIT_TIMEOUT");
@@ -114,11 +128,17 @@ afterEach(() => {
 	restoreEnv("SIGNET_API_KEY", previousApiKey);
 	restoreEnv("SIGNET_TOKEN", previousToken);
 	restoreEnv("SIGNET_CODEX_FORCE_COMPAT_HOOKS", previousForceCompatHooks);
+	if (previousArgvEntry === undefined) process.argv.splice(1, 1);
+	else process.argv[1] = previousArgvEntry;
 	rmSync(tempHome, { recursive: true, force: true });
 });
 
 function connector(): TempConnector {
 	return new TempConnector(tempHome);
+}
+
+function desktopRuntimeConnector(appPath: string): TempConnector {
+	return new DesktopRuntimeTempConnector(tempHome, appPath);
 }
 
 function nativePluginConnector(): TempConnector {
@@ -876,6 +896,54 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		expect(signetHandlers[0]?.timeout).toBe(20);
 	});
 
+	test("migrates stale Codex Desktop node paths after a packaging update", async () => {
+		const appPath = join(tempHome, "Applications", "Codex.app");
+		const runtime = join(appPath, "Contents", "Resources", "runtime", "node", "bin", "node");
+		mkdirSync(join(runtime, ".."), { recursive: true });
+		writeFileSync(runtime, "#!/bin/sh\necho v22.14.0\n", "utf-8");
+		chmodSync(runtime, 0o755);
+
+		const packageRoot = join(tempHome, "signetai");
+		const signetEntry = join(packageRoot, "bin", "signet.js");
+		const mcpEntry = join(packageRoot, "dist", "mcp-stdio.js");
+		mkdirSync(join(signetEntry, ".."), { recursive: true });
+		mkdirSync(join(mcpEntry, ".."), { recursive: true });
+		writeFileSync(signetEntry, "// fixture\n", "utf-8");
+		writeFileSync(mcpEntry, "// fixture\n", "utf-8");
+		process.argv[1] = signetEntry;
+
+		writeFileSync(
+			hooksPath,
+			JSON.stringify({
+				hooks: {
+					SessionStart: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: "/old/Codex.app/Contents/Resources/node /old/signet.js hook session-start -H codex",
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+		writeFileSync(configPath, "[mcp_servers.signet]\ncommand = '/old/Codex.app/Contents/Resources/node'\n");
+
+		const result = await desktopRuntimeConnector(appPath).install(tempHome);
+		const hooks = readHooksJson().hooks as Record<string, Record<string, unknown>[]>;
+		for (const event of ["SessionStart", "UserPromptSubmit", "Stop"]) {
+			const handler = ((hooks[event]?.[0]?.hooks as Record<string, unknown>[]) ?? [])[0];
+			expect(handler?.command).toContain(`${runtime} ${signetEntry}`);
+		}
+		expect(readFileSync(configPath, "utf-8")).toContain(`command = '${runtime}'`);
+		expect(readFileSync(configPath, "utf-8")).toContain(`args = ['${mcpEntry}']`);
+		expect(result.warnings).toContain(
+			"Detected a missing Signet Codex runtime path; refreshed only Signet-owned hooks and MCP configuration.",
+		);
+	});
+
 	test("preserves third-party commands that only mention hook subcommands", async () => {
 		writeFileSync(
 			hooksPath,
@@ -1080,9 +1148,7 @@ describe("CodexConnector.isInstalled", () => {
 			hooksPath,
 			JSON.stringify({
 				hooks: {
-					SessionStart: [
-						{ _signet: true, hooks: [{ type: "command", command: "echo third-party", timeout: 5 }] },
-					],
+					SessionStart: [{ _signet: true, hooks: [{ type: "command", command: "echo third-party", timeout: 5 }] }],
 				},
 			}),
 		);

--- a/integrations/codex/connector/src/index.ts
+++ b/integrations/codex/connector/src/index.ts
@@ -52,13 +52,17 @@ interface NativePluginCommandResult {
 // Signet command resolution
 // ---------------------------------------------------------------------------
 
-/** Resolve signet command for hook invocation. Returns array form for hooks.json command field.
- *  Windows: navigates from argv[1] (e.g. <pkg>/bin/signet.js) up two levels to find
- *  the bin directory. Falls back to bare "signet" if the layout doesn't match (shims, junctions). */
+/** Resolve the packaged Signet entry used by the compiled CLI.
+ *
+ * Bun-compiled binaries expose a virtual bunfs path in argv[1], so it cannot be
+ * used to locate the installed package. The binary itself remains on disk at
+ * <package>/bin/signet, making its sibling signet.js entry reliable instead. */
 function resolveSignetEntry(): string | null {
-	const entry = process.argv[1];
-	if (!entry || basename(entry) !== "signet.js" || !existsSync(entry)) return null;
-	return entry;
+	const candidates = [join(dirname(process.execPath), "..", "bin", "signet.js"), process.argv[1]];
+	for (const entry of candidates) {
+		if (entry && basename(entry) === "signet.js" && existsSync(entry)) return entry;
+	}
+	return null;
 }
 
 function resolveSignetArgs(runtime: string | null = null): string[] {
@@ -108,9 +112,13 @@ function codexDesktopNodeCandidates(root: string, depth = 0): string[] {
 	const candidates: string[] = [];
 	for (const entry of readdirSync(root, { withFileTypes: true })) {
 		const path = join(root, entry.name);
-		if (entry.isFile() && entry.name === "node") candidates.push(path);
-		if (entry.isDirectory() && entry.name !== "app.asar")
+		if ((entry.isFile() || entry.isSymbolicLink()) && entry.name === "node") candidates.push(path);
+		try {
+			if (!statSync(path).isDirectory()) continue;
 			candidates.push(...codexDesktopNodeCandidates(path, depth + 1));
+		} catch {
+			// Ignore broken symlinks and files that disappear while scanning.
+		}
 	}
 	return candidates;
 }
@@ -479,9 +487,16 @@ function isSignetMatcherGroup(group: unknown): boolean {
 }
 
 function hasMissingSignetRuntime(file: HooksFile | null, configPath: string): boolean {
-	const hookCommands = Object.values(file?.hooks ?? {}).flatMap((groups) =>
-		groups.flatMap((group) => group.hooks.map((handler) => handler.command)),
-	);
+	const hookCommands: string[] = [];
+	for (const groups of Object.values(file?.hooks ?? {})) {
+		if (!Array.isArray(groups)) continue;
+		for (const group of groups) {
+			if (typeof group !== "object" || group === null || !Array.isArray(group.hooks)) continue;
+			for (const handler of group.hooks) {
+				if (typeof handler?.command === "string") hookCommands.push(handler.command);
+			}
+		}
+	}
 	const config = existsSync(configPath) ? readFileSync(configPath, "utf-8") : "";
 	const commands = [
 		...hookCommands,
@@ -1005,7 +1020,9 @@ export class CodexConnector extends BaseConnector {
 		const mcp = resolveSignetMcp(runtime);
 		if (staleRuntime) {
 			warnings.push(
-				"Detected a missing Signet Codex runtime path; refreshed only Signet-owned hooks and MCP configuration.",
+				runtime
+					? "Detected a missing Signet Codex runtime path; refreshed only Signet-owned hooks and MCP configuration."
+					: "Detected a missing Signet Codex runtime path; no replacement Codex runtime was found, so Signet commands use the PATH fallback.",
 			);
 		}
 		const nativePluginSupported = this.supportsNativePluginInstall();

--- a/integrations/codex/connector/src/index.ts
+++ b/integrations/codex/connector/src/index.ts
@@ -1,8 +1,8 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import {
 	BaseConnector,
 	type InstallResult,
@@ -55,14 +55,22 @@ interface NativePluginCommandResult {
 /** Resolve signet command for hook invocation. Returns array form for hooks.json command field.
  *  Windows: navigates from argv[1] (e.g. <pkg>/bin/signet.js) up two levels to find
  *  the bin directory. Falls back to bare "signet" if the layout doesn't match (shims, junctions). */
-function resolveSignetArgs(): string[] {
+function resolveSignetEntry(): string | null {
+	const entry = process.argv[1];
+	if (!entry || basename(entry) !== "signet.js" || !existsSync(entry)) return null;
+	return entry;
+}
+
+function resolveSignetArgs(runtime: string | null = null): string[] {
+	const entry = resolveSignetEntry();
+	if (runtime && entry) return [runtime, entry];
 	const resolved = resolveSignetCliCommand();
 	return [resolved.command, ...resolved.args];
 }
 
 /** Resolve signet-mcp as { command, args } for Codex config.toml.
  *  Codex expects `command` as a string and `args` as a separate array. */
-function resolveSignetMcp(): SignetMcpConfig {
+function resolveSignetMcp(runtime: string | null = null): SignetMcpConfig {
 	const remoteDaemonUrl = resolveRemoteDaemonUrl();
 	if (remoteDaemonUrl) {
 		const apiKey = readAuthTokenEnv();
@@ -73,6 +81,9 @@ function resolveSignetMcp(): SignetMcpConfig {
 			...(apiKey ? { httpHeaders: { Authorization: `Bearer ${apiKey}` } } : {}),
 		};
 	}
+	const entry = resolveSignetEntry();
+	const mcpEntry = entry ? join(dirname(entry), "..", "dist", "mcp-stdio.js") : null;
+	if (runtime && mcpEntry && existsSync(mcpEntry)) return { command: runtime, args: [mcpEntry] };
 	return resolveSignetMcpCommand();
 }
 
@@ -87,6 +98,44 @@ function resolveRemoteDaemonUrl(): string | null {
 	const explicit = readEnv("SIGNET_DAEMON_URL");
 	if (!explicit) return null;
 	return resolveSignetDaemonUrl();
+}
+
+const CODEX_DESKTOP_APP_PATHS = [join(homedir(), "Applications", "Codex.app"), "/Applications/Codex.app"];
+const CODEX_RUNTIME_SCAN_DEPTH = 8;
+
+function codexDesktopNodeCandidates(root: string, depth = 0): string[] {
+	if (depth > CODEX_RUNTIME_SCAN_DEPTH || !existsSync(root)) return [];
+	const candidates: string[] = [];
+	for (const entry of readdirSync(root, { withFileTypes: true })) {
+		const path = join(root, entry.name);
+		if (entry.isFile() && entry.name === "node") candidates.push(path);
+		if (entry.isDirectory() && entry.name !== "app.asar")
+			candidates.push(...codexDesktopNodeCandidates(path, depth + 1));
+	}
+	return candidates;
+}
+
+function isUsableNodeRuntime(path: string): boolean {
+	try {
+		if (!statSync(path).isFile()) return false;
+		const result = spawnSync(path, ["--version"], { encoding: "utf-8", timeout: 5_000 });
+		return result.status === 0 && /^v\d+\.\d+\.\d+/.test(result.stdout.trim());
+	} catch {
+		return false;
+	}
+}
+
+export function resolveCodexDesktopNode(
+	appPaths: readonly string[] = CODEX_DESKTOP_APP_PATHS,
+	validate: (path: string) => boolean = isUsableNodeRuntime,
+): string | null {
+	for (const appPath of appPaths) {
+		const candidates = codexDesktopNodeCandidates(join(appPath, "Contents", "Resources"));
+		for (const candidate of candidates) {
+			if (validate(candidate)) return candidate;
+		}
+	}
+	return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -427,6 +476,23 @@ function isSignetMatcherGroup(group: unknown): boolean {
 		if (isSignetHookCommand(cmd)) return true;
 	}
 	return false;
+}
+
+function hasMissingSignetRuntime(file: HooksFile | null, configPath: string): boolean {
+	const hookCommands = Object.values(file?.hooks ?? {}).flatMap((groups) =>
+		groups.flatMap((group) => group.hooks.map((handler) => handler.command)),
+	);
+	const config = existsSync(configPath) ? readFileSync(configPath, "utf-8") : "";
+	const commands = [
+		...hookCommands,
+		...[...config.matchAll(/^command\s*=\s*['\"]([^'\"]+)['\"]/gm)].map((match) => match[1] ?? ""),
+	];
+	return commands.some((command) => {
+		if (!isSignetHookCommand(command) && !command.includes("signet-mcp") && !command.includes("mcp-stdio.js"))
+			return false;
+		const node = command.match(/(?:^|\s)(['\"]?)([^'\"\s]*[\\/]node(?:\.exe)?)(?:\1)(?=\s|$)/i)?.[2];
+		return Boolean(node && !existsSync(node));
+	});
 }
 
 function isLegacySignetMatcherGroup(group: unknown): boolean {
@@ -785,6 +851,14 @@ export class CodexConnector extends BaseConnector {
 		return join(homedir(), ".codex");
 	}
 
+	protected getCodexDesktopAppPaths(): readonly string[] {
+		return CODEX_DESKTOP_APP_PATHS;
+	}
+
+	protected resolveCodexDesktopNode(): string | null {
+		return resolveCodexDesktopNode(this.getCodexDesktopAppPaths());
+	}
+
 	protected supportsNativePluginInstall(): boolean {
 		if (readEnv("SIGNET_CODEX_DISABLE_NATIVE_PLUGIN") === "1") return false;
 		const result = spawnSync("codex", ["plugin", "--help"], {
@@ -924,8 +998,16 @@ export class CodexConnector extends BaseConnector {
 		const codexHome = this.getCodexHome();
 		mkdirSync(codexHome, { recursive: true });
 
-		const signetArgs = resolveSignetArgs();
-		const mcp = resolveSignetMcp();
+		const configPath = this.getConfigPath();
+		const staleRuntime = hasMissingSignetRuntime(readHooksFile(this.getHooksJsonPath()), configPath);
+		const runtime = this.resolveCodexDesktopNode();
+		const signetArgs = resolveSignetArgs(runtime);
+		const mcp = resolveSignetMcp(runtime);
+		if (staleRuntime) {
+			warnings.push(
+				"Detected a missing Signet Codex runtime path; refreshed only Signet-owned hooks and MCP configuration.",
+			);
+		}
 		const nativePluginSupported = this.supportsNativePluginInstall();
 
 		if (nativePluginSupported) {
@@ -981,7 +1063,6 @@ export class CodexConnector extends BaseConnector {
 		}
 
 		// 3. Register MCP server in config.toml
-		const configPath = this.getConfigPath();
 		if (patchConfigToml(configPath, mcp)) {
 			configsPatched.push(configPath);
 		}

--- a/integrations/codex/connector/src/index.ts
+++ b/integrations/codex/connector/src/index.ts
@@ -55,10 +55,16 @@ interface NativePluginCommandResult {
 /** Resolve the packaged Signet entry used by the compiled CLI.
  *
  * Bun-compiled binaries expose a virtual bunfs path in argv[1], so it cannot be
- * used to locate the installed package. The binary itself remains on disk at
- * <package>/bin/signet, making its sibling signet.js entry reliable instead. */
+ * used to locate the installed package. The npm wrapper passes its package root
+ * explicitly because it can launch an optional-dependency binary outside that
+ * package when postinstall did not link a local native binary. */
 function resolveSignetEntry(): string | null {
-	const candidates = [join(dirname(process.execPath), "..", "bin", "signet.js"), process.argv[1]];
+	const wrapperDir = readEnv("SIGNET_WRAPPER_DIR") ?? readEnv("SIGNET_DIR");
+	const candidates = [
+		wrapperDir ? join(wrapperDir, "bin", "signet.js") : null,
+		join(dirname(process.execPath), "..", "bin", "signet.js"),
+		process.argv[1],
+	];
 	for (const entry of candidates) {
 		if (entry && basename(entry) === "signet.js" && existsSync(entry)) return entry;
 	}
@@ -486,28 +492,42 @@ function isSignetMatcherGroup(group: unknown): boolean {
 	return false;
 }
 
+function hasMissingNodeRuntime(command: string): boolean {
+	const node = command.match(/(?:^|\s)(['\"]?)([^'\"\s]*[\\/]node(?:\.exe)?)(?:\1)(?=\s|$)/i)?.[2];
+	return Boolean(node && !existsSync(node));
+}
+
 function hasMissingSignetRuntime(file: HooksFile | null, configPath: string): boolean {
-	const hookCommands: string[] = [];
 	for (const groups of Object.values(file?.hooks ?? {})) {
 		if (!Array.isArray(groups)) continue;
 		for (const group of groups) {
 			if (typeof group !== "object" || group === null || !Array.isArray(group.hooks)) continue;
 			for (const handler of group.hooks) {
-				if (typeof handler?.command === "string") hookCommands.push(handler.command);
+				if (
+					typeof handler?.command === "string" &&
+					isSignetHookCommand(handler.command) &&
+					hasMissingNodeRuntime(handler.command)
+				) {
+					return true;
+				}
 			}
 		}
 	}
-	const config = existsSync(configPath) ? readFileSync(configPath, "utf-8") : "";
-	const commands = [
-		...hookCommands,
-		...[...config.matchAll(/^command\s*=\s*['\"]([^'\"]+)['\"]/gm)].map((match) => match[1] ?? ""),
-	];
-	return commands.some((command) => {
-		if (!isSignetHookCommand(command) && !command.includes("signet-mcp") && !command.includes("mcp-stdio.js"))
-			return false;
-		const node = command.match(/(?:^|\s)(['\"]?)([^'\"\s]*[\\/]node(?:\.exe)?)(?:\1)(?=\s|$)/i)?.[2];
-		return Boolean(node && !existsSync(node));
-	});
+
+	if (!existsSync(configPath)) return false;
+	let inSignetMcpSection = false;
+	for (const line of readFileSync(configPath, "utf-8").split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed === "[mcp_servers.signet]") {
+			inSignetMcpSection = true;
+			continue;
+		}
+		if (inSignetMcpSection && trimmed.startsWith("[")) break;
+		if (!inSignetMcpSection) continue;
+		const command = trimmed.match(/^command\s*=\s*['\"]([^'\"]+)['\"]/)?.[1];
+		if (typeof command === "string") return hasMissingNodeRuntime(command);
+	}
+	return false;
 }
 
 function isLegacySignetMatcherGroup(group: unknown): boolean {

--- a/scripts/native-install-smoke.test.ts
+++ b/scripts/native-install-smoke.test.ts
@@ -54,6 +54,9 @@ if [ "\${1:-}" = "install" ]; then
 	echo '{"installed":true}'
 	exit 0
 fi
+if [ "\${SIGNET_PRINT_WRAPPER_DIR:-}" = "1" ]; then
+	echo "signet wrapper \${SIGNET_WRAPPER_DIR:-}"
+fi
 echo "fake native signet $*"
 `);
 }
@@ -546,8 +549,12 @@ describe("native install smoke", () => {
 		writeFileSync(nativePackageBin, fakeNativeBinary());
 		chmodSync(nativePackageBin, 0o755);
 
-		const directWrapper = await runCommand("node", [join(packageDir, "bin", "signet.js"), "--version"], process.env);
+		const directWrapper = await runCommand("node", [join(packageDir, "bin", "signet.js"), "--version"], {
+			...process.env,
+			SIGNET_PRINT_WRAPPER_DIR: "1",
+		});
 		expect(directWrapper.status).toBe(0);
+		expect(directWrapper.stdout).toContain(`signet wrapper ${packageDir}`);
 		expect(directWrapper.stdout).toContain("fake native signet --version");
 
 		const install = await runCommand("node", [join(packageDir, "scripts", "install-native.js")], process.env);


### PR DESCRIPTION
## Summary

Fixes #1024. Codex Desktop packaging updates can move its bundled Node executable, leaving Signet-owned lifecycle hooks and MCP stdio configured with a dead absolute path. The connector now discovers and validates the current bundled runtime before rewriting those Signet-owned commands.

## Changes

- Scan supported macOS Codex.app resource layouts for an executable Node runtime and validate it with `--version`.
- Use the validated runtime for Signet hook commands and local MCP stdio when the installed Signet entry points are available.
- Detect a missing prior Signet runtime and emit a focused migration warning while preserving unrelated hooks.
- Add the Codex Desktop packaging-update regression test and document refresh behavior.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — connector-install behavior only; no product spec dependency changed.
- [x] Agent scoping verified on all new/changed data queries — N/A; no data queries.
- [x] Input/config validation and bounds checks added — runtime must be a regular executable file and pass `node --version`; scanning is depth bounded.
- [x] Error handling and fallback paths tested (no silent swallow) — unusable candidates are skipped; existing Signet command resolution remains the fallback.
- [x] Security checks applied to admin/mutation endpoints — N/A; no endpoint changes.
- [x] Docs updated for API/spec/status changes — Codex integration guide documents runtime discovery and migration.
- [x] Regression tests added for each bug fix — macOS packaging-update fixture covers hooks, MCP, and the migration diagnostic.
- [x] Lint/typecheck/tests pass locally — affected-file Biome check, connector typecheck, and 59/59 connector tests pass. Repository-wide lint/typecheck/test failures reproduce on untouched `main` (existing format/type drift, stale generated route/content guards, and local SQLite extension loading).

## Migration Notes (if applicable)

- [x] Migration is idempotent — reconnect rewrites only the Signet hook and MCP registrations.
- [x] Daemon Rust parity reviewed or explicitly N/A — N/A; this is an install-time TypeScript connector change.
- [x] Rollback / compatibility note included in PR description — reinstalling older Signet restores its previous command strategy; non-Signet hooks are preserved.

## Testing

- [x] `bun test` passes — `bun test integrations/codex/connector/src/config-toml.test.ts`: 59 pass, 0 fail. Full `bun test` has only failures reproduced on untouched `main`: three Rust route-parity guard failures, one generated web-content-index guard failure, and this macOS hosts SQLite build cannot load `vec_version()`.
- [x] `bun run typecheck` passes — connector package passes. Root typecheck failures are pre-existing daemon type errors reproduced on untouched `main`.
- [x] `bun run lint` passes — touched files pass Biome. Root lint has 726 pre-existing diagnostics reproduced on untouched `main`.
- [x] Tested against running daemon — N/A; no daemon runtime behavior changed.
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tag in commit)

## Notes

The connector uses the current Codex Desktop runtime only when the installed Signet JS entry points can be identified. Otherwise it retains the existing portable Signet command fallback.
