### PR TITLE
fix(status): separate extraction workload state

### DIFF
--- a/docs/api/health-status.md
+++ b/docs/api/health-status.md
@@ -231,7 +231,12 @@ silent fallback or hard-blocked extraction after boot.
       "fallbackApplied": false,
       "reason": null,
       "blockedBy": [],
-      "since": null
+      "since": null,
+      "enabled": true,
+      "paused": false,
+      "workerRunning": true,
+      "ready": true,
+      "blockedReason": null
     }
   },
   "logging": {
@@ -266,9 +271,13 @@ silent fallback or hard-blocked extraction after boot.
 
 The `bypassedSessions` field reports how many active sessions currently have
 bypass enabled (see [Sessions and hooks API](./sessions-hooks.md#sessions)).
-Monitor `providerResolution.extraction.status` for `degraded` or `blocked`
-states when the configured extraction provider is unavailable or routed to a
-fallback target.
+`providerResolution.extraction` is the canonical workload-state object. Its
+`configured`, `resolved`, and `effective` labels describe provider selection;
+they do not imply that jobs are being serviced. Use `enabled`, `paused`,
+`workerRunning`, and `ready` to determine whether extraction is actually
+available for work. `blockedReason` is populated only for a blocked route.
+Monitor `status` for `degraded` or `blocked` states when the configured
+extraction provider is unavailable or routed to a fallback target.
 When extraction is blocked, `providerResolution.extraction.blockedBy` contains
 the first routing candidate's policy and runtime gate reasons in evaluation
 order. The array is empty for non-blocked states.

--- a/platform/daemon/src/daemon-status.test.ts
+++ b/platform/daemon/src/daemon-status.test.ts
@@ -241,6 +241,31 @@ describe("daemon status contract", () => {
 
 		expect(state.restartPipelineRuntimeRef).toBeDefined();
 		await state.restartPipelineRuntimeRef?.(loadMemoryConfig(dir));
+		const res = await app.request("http://localhost/api/status");
+		const body = (await res.json()) as {
+			providerResolution?: {
+				extraction?: {
+					configured?: unknown;
+					resolved?: unknown;
+					effective?: unknown;
+					status?: unknown;
+					enabled?: unknown;
+					paused?: unknown;
+					workerRunning?: unknown;
+					ready?: unknown;
+					blockedReason?: unknown;
+				};
+			};
+		};
+		expect(res.status).toBe(200);
+		expect(body.providerResolution?.extraction).toMatchObject({
+			status: "disabled",
+			enabled: false,
+			paused: false,
+			workerRunning: false,
+			ready: false,
+			blockedReason: null,
+		});
 
 		expect(getLlmConcurrencyStatus().limit).toBe(1);
 	});

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1356,20 +1356,20 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 	const routerStatus = await router.status(false);
 	const statusValue = routerStatus.ok ? routerStatus.value : null;
 	const explicitInference = statusValue?.source === "explicit";
-	const commandExtractionMode = memoryCfg.pipelineV2.enabled && memoryCfg.pipelineV2.extraction.provider === "command";
-	const extractionWorkloadConfigured =
-		!pipelinePaused && (commandExtractionMode || (await router.hasWorkload("memory_extraction")));
-	const synthesisWorkloadConfigured = !pipelinePaused && (await router.hasWorkload("session_synthesis"));
+	const commandExtractionConfigured = memoryCfg.pipelineV2.extraction.provider === "command";
+	const commandExtractionMode = memoryCfg.pipelineV2.enabled && commandExtractionConfigured;
+	const extractionWorkloadConfigured = commandExtractionConfigured || (await router.hasWorkload("memory_extraction"));
+	const synthesisWorkloadConfigured = await router.hasWorkload("session_synthesis");
 	const extractionDecision =
-		!pipelinePaused && !commandExtractionMode && extractionWorkloadConfigured
+		!commandExtractionConfigured && extractionWorkloadConfigured
 			? await router.explain({ agentId: defaultAgentId, operation: "memory_extraction" })
 			: null;
 	const synthesisDecision =
 		!pipelinePaused && synthesisWorkloadConfigured
 			? await router.explain({ agentId: defaultAgentId, operation: "session_synthesis" })
 			: null;
-	const extractionAvailable = !pipelinePaused && (commandExtractionMode || Boolean(extractionDecision?.ok));
-	const synthesisAvailable = !pipelinePaused && Boolean(synthesisDecision?.ok);
+	const extractionAvailable = commandExtractionConfigured || Boolean(extractionDecision?.ok);
+	const synthesisAvailable = Boolean(synthesisDecision?.ok);
 	const extractionBinding = statusValue?.workloadBindings.memoryExtraction;
 	const extractionSelectedRef = extractionDecision?.ok ? extractionDecision.value.targetRef : undefined;
 	const extractionSelectedRuntime = extractionSelectedRef
@@ -1379,21 +1379,25 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 		extractionSelectedRef && extractionBinding?.includes("/") && extractionSelectedRef !== extractionBinding,
 	);
 	const extractionDegraded = extractionFallbackApplied || extractionSelectedRuntime?.health === "degraded";
-	const extractionStatus = pipelinePaused
-		? "paused"
-		: !extractionWorkloadConfigured
-			? "disabled"
-			: extractionDecision?.ok
-				? extractionDegraded
-					? "degraded"
-					: "active"
-				: "blocked";
+	const extractionStatus = !memoryCfg.pipelineV2.enabled
+		? "disabled"
+		: pipelinePaused
+			? "paused"
+			: !extractionWorkloadConfigured
+				? "disabled"
+				: extractionDecision?.ok
+					? extractionDegraded
+						? "degraded"
+						: "active"
+					: "blocked";
 	const statusSince =
 		extractionStatus === "active" || extractionStatus === "disabled" ? null : new Date().toISOString();
-	const extractionEffective = commandExtractionMode
+	const extractionResolved = commandExtractionConfigured
 		? "command"
 		: ((statusValue && executorForTargetRef(statusValue, extractionSelectedRef)) ??
-			(extractionAvailable ? "inference" : "none"));
+			(statusValue && executorForTargetRef(statusValue, extractionBinding)) ??
+			"none");
+	const extractionEffective = extractionAvailable ? extractionResolved : "none";
 	const synthesisEffective =
 		(statusValue &&
 			(executorForTargetRef(
@@ -1416,29 +1420,31 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 	providerRuntimeResolution.extraction = {
 		// Configured/resolved now derive from the routing registry (the workload
 		// binding's target executor), not the retired legacy flat fields.
-		configured: commandExtractionMode
+		configured: commandExtractionConfigured
 			? "command"
 			: statusValue
 				? executorForTargetRef(statusValue, extractionBinding)
 				: null,
-		resolved: commandExtractionMode ? "command" : extractionEffective,
+		resolved: extractionResolved,
 		effective: extractionEffective,
-		fallbackProvider: commandExtractionMode ? "none" : extractionFallbackProvider,
+		fallbackProvider: commandExtractionConfigured ? "none" : extractionFallbackProvider,
 		status: extractionStatus,
 		degraded: extractionDegraded,
 		fallbackApplied: extractionFallbackApplied,
-		reason: pipelinePaused
-			? "Pipeline paused"
-			: extractionStatus === "disabled"
-				? "No inference workload is configured for memoryExtraction"
-				: extractionStatus === "blocked"
-					? extractionDecision && !extractionDecision.ok
-						? extractionDecision.error.message
-						: "No memoryExtraction route available"
-					: extractionFallbackApplied
-						? (runtimeReasonForTarget(extractionDecision, extractionBinding) ??
-							`Configured extraction provider unavailable; using ${extractionEffective} fallback`)
-						: (extractionSelectedRuntime?.unavailableReason ?? null),
+		reason: !memoryCfg.pipelineV2.enabled
+			? "Pipeline disabled"
+			: pipelinePaused
+				? "Pipeline paused"
+				: extractionStatus === "disabled"
+					? "No inference workload is configured for memoryExtraction"
+					: extractionStatus === "blocked"
+						? extractionDecision && !extractionDecision.ok
+							? extractionDecision.error.message
+							: "No memoryExtraction route available"
+						: extractionFallbackApplied
+							? (runtimeReasonForTarget(extractionDecision, extractionBinding) ??
+								`Configured extraction provider unavailable; using ${extractionEffective} fallback`)
+							: (extractionSelectedRuntime?.unavailableReason ?? null),
 		blockedBy:
 			extractionStatus === "blocked" && extractionDecision && !extractionDecision.ok
 				? firstCandidateBlockedBy(extractionDecision.error.details)

--- a/platform/daemon/src/routes/health.test.ts
+++ b/platform/daemon/src/routes/health.test.ts
@@ -149,6 +149,34 @@ describe("GET /health/ready", () => {
 			expect(typeof reason).toBe("string");
 		}
 	});
+
+	test("returns a structured 503 (not a 500) when loadMemoryConfig throws on a misconfigured agent.yaml", async () => {
+		// Regression guard: checkInference calls loadMemoryConfig on every probe.
+		// A misconfigured pipeline (extraction.provider='command' with no command
+		// block) throws PipelineConfigValidationError; without a try/catch this
+		// turned /health/ready into an unhandled 500. It must stay a structured 503.
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			"memory:\n  pipelineV2:\n    enabled: true\n    extraction:\n      provider: command\n",
+		);
+
+		const app = makeApp();
+		const res = await app.request("http://localhost/health/ready");
+
+		expect(res.status).toBe(503);
+		const body = (await res.json()) as {
+			status: string;
+			reasons: string[];
+			checks: { inference: { status: string } };
+		};
+		expect(body.status).toBe("not_ready");
+		expect(Array.isArray(body.reasons)).toBe(true);
+		// The misconfig is caught by whichever of checkEmbedding/checkInference runs
+		// first (both call loadMemoryConfig); either way the endpoint must return a
+		// structured 503 with a config-unavailable reason, never an unhandled 500.
+		expect(body.reasons.some((r) => /config unavailable/i.test(r))).toBe(true);
+		expect(body.checks.inference.status).toBe("unknown");
+	});
 });
 
 describe("GET /health (back-compat)", () => {

--- a/platform/daemon/src/routes/health.ts
+++ b/platform/daemon/src/routes/health.ts
@@ -144,7 +144,17 @@ interface InferenceCheck {
 
 /** Inference gates readiness only when the extraction route is fully blocked; degraded still serves. */
 function checkInference(): { ok: boolean; detail: InferenceCheck; reason: string | null } {
-	const cfg = loadMemoryConfig(AGENTS_DIR);
+	let cfg: ReturnType<typeof loadMemoryConfig>;
+	try {
+		cfg = loadMemoryConfig(getCurrentAgentsDir());
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		return {
+			ok: false,
+			detail: { status: "unknown", configured: null, effective: "none", reason: msg },
+			reason: `inference config unavailable: ${msg}`,
+		};
+	}
 	const extraction = getExtractionWorkloadState({
 		enabled: cfg.pipelineV2.enabled,
 		paused: cfg.pipelineV2.paused,

--- a/platform/daemon/src/routes/health.ts
+++ b/platform/daemon/src/routes/health.ts
@@ -19,6 +19,7 @@ import {
 	CURRENT_VERSION,
 	PORT,
 	getCurrentAgentsDir,
+	getExtractionWorkloadState,
 	providerRuntimeResolution,
 	shuttingDown,
 } from "./state.js";
@@ -143,7 +144,12 @@ interface InferenceCheck {
 
 /** Inference gates readiness only when the extraction route is fully blocked; degraded still serves. */
 function checkInference(): { ok: boolean; detail: InferenceCheck; reason: string | null } {
-	const extraction = providerRuntimeResolution.extraction;
+	const cfg = loadMemoryConfig(AGENTS_DIR);
+	const extraction = getExtractionWorkloadState({
+		enabled: cfg.pipelineV2.enabled,
+		paused: cfg.pipelineV2.paused,
+		workerRunning: getPipelineWorkerStatus().extraction.running,
+	});
 	const detail: InferenceCheck = {
 		status: extraction.status,
 		configured: extraction.configured,

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -44,6 +44,7 @@ import {
 	authConfig,
 	buildOpenClawHealth,
 	getCachedDiagnosticsReport,
+	getExtractionWorkloadState,
 	getUpdateState,
 	invalidateDiagnosticsCache,
 	openClawHeartbeat,
@@ -208,6 +209,11 @@ export function registerPipelineRoutes(app: Hono): void {
 		const config = loadMemoryConfig(AGENTS_DIR);
 		const workerStatus = getPipelineWorkerStatus();
 		const extractionWorker = workerStatus.extraction;
+		const extractionWorkload = getExtractionWorkloadState({
+			enabled: config.pipelineV2.enabled,
+			paused: config.pipelineV2.paused,
+			workerRunning: extractionWorker.running,
+		});
 		const configuredLogFile = readEnvTrimmed("SIGNET_LOG_FILE");
 		const configuredLogDir = readEnvTrimmed("SIGNET_LOG_DIR") ?? LOG_DIR;
 		const datedLogFile = join(configuredLogDir, `signet-${new Date().toISOString().slice(0, 10)}.log`);
@@ -285,7 +291,7 @@ export function registerPipelineRoutes(app: Hono): void {
 				},
 				queue: pipelineQueueBlock(),
 			},
-			providerResolution: providerRuntimeResolution,
+			providerResolution: { ...providerRuntimeResolution, extraction: extractionWorkload },
 			logging: {
 				logDir: configuredLogFile ? dirname(configuredLogFile) : configuredLogDir,
 				logFile: configuredLogFile ?? datedLogFile,
@@ -458,10 +464,19 @@ export function registerPipelineRoutes(app: Hono): void {
 		const diagnostics = getCachedDiagnosticsReport();
 
 		const pipelineV2 = cfg.pipelineV2;
+		const workers = getPipelineWorkerStatus();
 		const mode = readPipelineMode(pipelineV2);
 
 		return c.json({
-			workers: getPipelineWorkerStatus(),
+			workers,
+			providerResolution: {
+				...providerRuntimeResolution,
+				extraction: getExtractionWorkloadState({
+					enabled: pipelineV2.enabled,
+					paused: pipelineV2.paused,
+					workerRunning: workers.extraction.running,
+				}),
+			},
 			queues: dbData.queues,
 			diagnostics,
 			latency: analyticsCollector.getLatency(),

--- a/platform/daemon/src/routes/state.ts
+++ b/platform/daemon/src/routes/state.ts
@@ -263,6 +263,37 @@ export interface ProviderRuntimeResolution {
 	};
 }
 
+export type ExtractionWorkloadState = ProviderRuntimeResolution["extraction"] & {
+	readonly enabled: boolean;
+	readonly paused: boolean;
+	readonly workerRunning: boolean;
+	readonly ready: boolean;
+	readonly blockedReason: string | null;
+};
+
+/**
+ * Canonical extraction workload state shared by status, health, diagnostics,
+ * and CLI consumers. A resolved provider alone never means that jobs run.
+ */
+export function getExtractionWorkloadState(input: {
+	readonly enabled: boolean;
+	readonly paused: boolean;
+	readonly workerRunning: boolean;
+}): ExtractionWorkloadState {
+	const base = providerRuntimeResolution.extraction;
+	const status = !input.enabled ? "disabled" : input.paused ? "paused" : base.status;
+	const blockedReason = status === "blocked" ? base.reason : null;
+	return {
+		...base,
+		status,
+		enabled: input.enabled,
+		paused: input.paused,
+		workerRunning: input.workerRunning,
+		ready: (status === "active" || status === "degraded") && input.workerRunning,
+		blockedReason,
+	};
+}
+
 // Runtime state singletons
 export const providerRuntimeResolution: ProviderRuntimeResolution = {
 	extraction: {

--- a/surfaces/cli/src/features/health.ts
+++ b/surfaces/cli/src/features/health.ts
@@ -35,6 +35,7 @@ interface DaemonStatus {
 	readonly resources?: DaemonResourceUsage | null;
 	readonly extraction: {
 		readonly configured: string | null;
+		readonly resolved: string | null;
 		readonly effective: string | null;
 		readonly fallbackProvider: string | null;
 		readonly status: string | null;
@@ -42,6 +43,12 @@ interface DaemonStatus {
 		readonly reason: string | null;
 		readonly blockedBy?: readonly string[];
 		readonly since: string | null;
+		readonly enabled: boolean;
+		readonly paused: boolean;
+		readonly workerRunning: boolean;
+		readonly ready: boolean;
+		readonly blockedReason: string | null;
+		readonly hasWorkloadState: boolean;
 	} | null;
 	readonly extractionWorker: {
 		readonly running: boolean;
@@ -416,6 +423,20 @@ export function getExtractionStatusNotice(
 	daemon: DaemonStatus,
 ): { level: "warn" | "error"; title: string; detail: string } | null {
 	const extraction = daemon.extraction;
+	if (extraction && daemon.running && extraction.hasWorkloadState && !extraction.ready) {
+		const title = !extraction.enabled
+			? "Pipeline disabled"
+			: extraction.paused
+				? "Pipeline paused"
+				: extraction.status === "blocked"
+					? "Extraction blocked"
+					: "Extraction worker stopped";
+		return {
+			level: extraction.status === "blocked" ? "error" : "warn",
+			title,
+			detail: `configured: ${extraction.configured ?? "none"}, resolved: ${extraction.resolved ?? "none"}, effective: ${extraction.effective ?? "none"}, worker running: ${extraction.workerRunning}${extraction.blockedReason ? ` — ${extraction.blockedReason}` : ""}`,
+		};
+	}
 	if (extraction && daemon.running && extraction.status === "blocked") {
 		const blockedBy =
 			extraction.blockedBy && extraction.blockedBy.length > 0

--- a/surfaces/cli/src/features/health.ts
+++ b/surfaces/cli/src/features/health.ts
@@ -434,7 +434,11 @@ export function getExtractionStatusNotice(
 		return {
 			level: extraction.status === "blocked" ? "error" : "warn",
 			title,
-			detail: `configured: ${extraction.configured ?? "none"}, resolved: ${extraction.resolved ?? "none"}, effective: ${extraction.effective ?? "none"}, worker running: ${extraction.workerRunning}${extraction.blockedReason ? ` — ${extraction.blockedReason}` : ""}`,
+			detail: `configured: ${extraction.configured ?? "none"}, resolved: ${extraction.resolved ?? "none"}, effective: ${extraction.effective ?? "none"}, worker running: ${extraction.workerRunning}${extraction.blockedReason ? ` — ${extraction.blockedReason}` : ""}${
+				extraction.status === "blocked" && extraction.blockedBy && extraction.blockedBy.length > 0
+					? ` — blocked by: ${extraction.blockedBy.join("; ")}`
+					: ""
+			}`,
 		};
 	}
 	if (extraction && daemon.running && extraction.status === "blocked") {

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -401,6 +401,7 @@ describe("getDaemonStatus", () => {
 					providerResolution: {
 						extraction: {
 							configured: "claude-code",
+							resolved: "claude-code",
 							effective: "ollama",
 							fallbackProvider: "ollama",
 							status: "degraded",
@@ -408,6 +409,11 @@ describe("getDaemonStatus", () => {
 							reason: "Claude Code CLI not found during extraction startup preflight",
 							blockedBy: ["missing credential", 42, "", "account state missing"],
 							since: "2026-03-26T00:00:00.000Z",
+							enabled: true,
+							paused: false,
+							workerRunning: true,
+							ready: true,
+							blockedReason: null,
 						},
 					},
 					pipeline: {
@@ -433,6 +439,7 @@ describe("getDaemonStatus", () => {
 		expect(status.probe.readinessReasons).toBeUndefined();
 		expect(status.extraction).toEqual({
 			configured: "claude-code",
+			resolved: "claude-code",
 			effective: "ollama",
 			fallbackProvider: "ollama",
 			status: "degraded",
@@ -440,6 +447,11 @@ describe("getDaemonStatus", () => {
 			reason: "Claude Code CLI not found during extraction startup preflight",
 			blockedBy: ["missing credential", "account state missing"],
 			since: "2026-03-26T00:00:00.000Z",
+			enabled: true,
+			paused: false,
+			workerRunning: true,
+			ready: true,
+			blockedReason: null,
 		});
 		expect(status.extractionWorker).toEqual({
 			running: true,

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -452,6 +452,7 @@ describe("getDaemonStatus", () => {
 			workerRunning: true,
 			ready: true,
 			blockedReason: null,
+			hasWorkloadState: true,
 		});
 		expect(status.extractionWorker).toEqual({
 			running: true,

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -65,6 +65,7 @@ interface DaemonInstance {
 	readonly resources: DaemonResourceUsage | null;
 	readonly extraction: {
 		readonly configured: string | null;
+		readonly resolved: string | null;
 		readonly effective: string | null;
 		readonly fallbackProvider: string | null;
 		readonly status: string | null;
@@ -72,6 +73,12 @@ interface DaemonInstance {
 		readonly reason: string | null;
 		readonly blockedBy: readonly string[];
 		readonly since: string | null;
+		readonly enabled: boolean;
+		readonly paused: boolean;
+		readonly workerRunning: boolean;
+		readonly ready: boolean;
+		readonly blockedReason: string | null;
+		readonly hasWorkloadState: boolean;
 	} | null;
 	readonly extractionWorker: {
 		readonly running: boolean;
@@ -360,6 +367,7 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 						providerResolution?: {
 							extraction?: {
 								configured?: string | null;
+								resolved?: string | null;
 								effective?: string | null;
 								fallbackProvider?: string | null;
 								status?: string | null;
@@ -367,6 +375,11 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 								reason?: string | null;
 								blockedBy?: unknown;
 								since?: string | null;
+								enabled?: boolean;
+								paused?: boolean;
+								workerRunning?: boolean;
+								ready?: boolean;
+								blockedReason?: string | null;
 							};
 						};
 						pipeline?: {
@@ -415,6 +428,7 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 						extraction: extraction
 							? {
 									configured: extraction.configured ?? null,
+									resolved: extraction.resolved ?? null,
 									effective: extraction.effective ?? null,
 									fallbackProvider: extraction.fallbackProvider ?? null,
 									status: extraction.status ?? null,
@@ -426,6 +440,12 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 											)
 										: [],
 									since: extraction.since ?? null,
+									enabled: extraction.enabled === true,
+									paused: extraction.paused === true,
+									workerRunning: extraction.workerRunning === true,
+									ready: extraction.ready === true,
+									blockedReason: extraction.blockedReason ?? null,
+									hasWorkloadState: typeof extraction.ready === "boolean",
 								}
 							: null,
 						extractionWorker: extractionWorker


### PR DESCRIPTION
## Summary

Fixes stale extraction-state reporting so the daemon, API, diagnostics, health surface, and CLI report the current effective workload state, including disabled, paused, blocked, and worker-not-running conditions.

Fixes #908

## Changes

- Introduce one canonical extraction workload-state calculation in the daemon.
- Make `/api/status`, `/api/diagnostics`, and health readiness use the canonical state.
- Update CLI health rendering to clearly explain unavailable extraction work.
- Preserve compatibility with older daemon status payloads.
- Add regression tests for configuration and runtime state transitions.

## Testing

- [x] `bun test platform/daemon/src/routes/status.test.ts surfaces/cli/src/features/health.test.ts`
- [x] `bun run build:core`
- [x] Focused daemon and CLI tests pass.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Notes: agent data queries and admin/mutation endpoints are not part of this read-only status change. Older-daemon fallback payloads are covered by the CLI health tests.

## Validation

- Status and diagnostics responses reflect enabled, paused, worker-running, and blocked conditions.
- CLI health output describes why extraction work is unavailable.
- Existing status payloads without the new workload state remain usable.