### PR TITLE
refactor(cli): show ASCII brand banner on bare signet invocation

### DIFF
--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -101,6 +101,7 @@ import { importFromGitHub } from "./features/import.js";
 import { installNativeBinary, printNativeInstallResult } from "./features/native-install.js";
 import { setupWizard } from "./features/setup.js";
 import { copyDirRecursive, syncBuiltinSkills, syncTemplates } from "./features/sync.js";
+import { signetBanner } from "./lib/banner.js";
 import { createDaemonClient, ensureDaemonRunning } from "./lib/daemon.js";
 import { gitAddAndCommit, gitInit, isGitRepo } from "./lib/git.js";
 import {
@@ -876,7 +877,7 @@ function createExtensionSymlink(stateDir: string, globalPath: string, silent?: b
 // CLI Definition
 // ============================================================================
 
-program.name("signet").description("Own your agent. Bring it anywhere.").version(VERSION);
+program.name("signet").version(VERSION);
 program.showHelpAfterError();
 program.addHelpText(
 	"after",
@@ -1187,6 +1188,9 @@ registerBrowseCommand(program);
 
 // Default action when no command specified
 program.action(async () => {
+	if (process.stdout.isTTY) {
+		console.log(signetBanner({ version: VERSION }));
+	}
 	program.outputHelp();
 	const report = await getStatusReport(AGENTS_DIR, healthDeps);
 	console.log();

--- a/surfaces/cli/src/lib/banner.test.ts
+++ b/surfaces/cli/src/lib/banner.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { signetBanner } from "./banner.js";
+
+const DOT = "●";
+const CRESCENTS = ["◐", "◑"];
+
+function stripAnsi(text: string): string {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally matches ANSI escape introducer
+	return text.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+describe("signetBanner", () => {
+	it("renders the dot-grid mark at 9x7 with 28 dots", () => {
+		const plain = stripAnsi(signetBanner({ version: "1.2.3" }));
+		const rows = plain
+			.trim()
+			.split("\n")
+			.map((line) => line.trimEnd());
+		expect(rows).toHaveLength(7);
+
+		const markOnly = rows.map((line) => line.slice(0, 20));
+		const dots = markOnly
+			.join("")
+			.split("")
+			.filter((ch) => ch === DOT);
+		const crescents = markOnly
+			.join("")
+			.split("")
+			.filter((ch) => CRESCENTS.includes(ch));
+		expect(dots).toHaveLength(26);
+		expect(crescents).toHaveLength(2);
+	});
+
+	it("includes name, tagline, and version on aligned side rows", () => {
+		const plain = stripAnsi(signetBanner({ version: "1.2.3" }));
+		expect(plain).toContain("Signet CLI");
+		expect(plain).toContain("Own your agent. Bring it anywhere.");
+		expect(plain).toContain("v1.2.3");
+
+		const rows = plain.trim().split("\n");
+		const sideStarts = rows
+			.filter((line) => /Signet CLI|Own your agent|v1\.2\.3/.test(line))
+			.map((line) => line.search(/Signet CLI|Own your agent|v1\.2\.3/));
+		expect(sideStarts).toHaveLength(3);
+		expect(new Set(sideStarts).size).toBe(1);
+	});
+});

--- a/surfaces/cli/src/lib/banner.ts
+++ b/surfaces/cli/src/lib/banner.ts
@@ -1,0 +1,42 @@
+import chalk from "chalk";
+
+const BRAND_ORANGE = "#FF4D00";
+
+/**
+ * Dot-grid "S" mark, derived from web/marketing/public/Signet-Logo-White.png
+ * via connected-component extraction (26 full circles plus 2 half-filled
+ * eclipse dots on a 9x7 grid). Side-text alignment assumes narrow glyph
+ * rendering (width 1 per mark cell); CJK-wide locales may misalign.
+ */
+const MARK_GRID = `
+..●●●●...
+.◐..●●●●.
+●●●..●●..
+..●●.....
+......●●●
+.●●●●..◑.
+..●●●●...
+`;
+const MARK_ROWS = MARK_GRID.trim().split("\n");
+
+function renderMark(): string[] {
+	const orange = chalk.hex(BRAND_ORANGE);
+	return MARK_ROWS.map((row) => [...row].map((cell) => (cell === "." ? "  " : orange(`${cell} `))).join(""));
+}
+
+/**
+ * Full CLI banner for the bare `signet` invocation: ASCII brand mark on the
+ * left, name / tagline / version vertically centered on the right.
+ * Callers should gate on process.stdout.isTTY so piped/agent consumers get
+ * plain help output without decorative art.
+ */
+export function signetBanner(options: { readonly version: string }): string {
+	const mark = renderMark();
+	const side: Record<number, string> = {
+		2: chalk.bold("Signet CLI"),
+		3: chalk.dim("Own your agent. Bring it anywhere."),
+		4: chalk.dim(`v${options.version}`),
+	};
+	const lines = mark.map((row, i) => (side[i] ? `${row}  ${side[i]}` : row.trimEnd()));
+	return `\n${lines.map((line) => `  ${line}`).join("\n")}\n`;
+}


### PR DESCRIPTION
## Summary

Running bare `signet` in a TTY now prints an ASCII brand banner — the dot-grid **S** mark in signal orange `#FF4D00`, with **Signet CLI** in bold, the tagline, and version — above the help output, in the style of the `higgsfield` CLI.

```
      ● ● ● ●
    ◐     ● ● ● ●
  ● ● ●     ● ●       Signet CLI
      ● ●             Own your agent. Bring it anywhere.
              ● ● ●   v0.154.10
    ● ● ● ●     ◑
      ● ● ● ●
```

The mark is not hand-drawn: it was derived from `web/marketing/public/Signet-Logo-White.png` via connected-component extraction — 26 full circles plus 2 half-filled eclipse dots on a 9×7 grid — so the ASCII version preserves the real logo geometry (including the two eclipse dots, rendered `◐`/`◑`).

## Details

- New `surfaces/cli/src/lib/banner.ts` + tests; wired into the bare-`signet` program action.
- **TTY-gated**: piped/agent consumers keep plain help output with no decorative art or color.
- Root program description removed so the tagline appears once (in the banner) instead of being duplicated in help output. Deliberate side effect: `signet --help` and error help no longer print the tagline.
- Brand color switched from the CLI's legacy gold to signal orange `#FF4D00` per review.

## Verification

- `bun test surfaces/cli` — banner tests pass; suite shows only the same 14 pre-existing failures as clean `origin/main` (sources/route/sync pollution, verified by stash-and-rerun).
- `biome check` clean on touched files; `build:cli` bundle builds.
- Live PTY run verified with real escape output (`script -qec "bun surfaces/cli/src/cli.ts"`).

## Review notes

Autoreview ran on the diff. Two findings addressed (doc-comment dot count, CJK-width alignment assumption documented). One info-level finding intentionally kept: the tagline no longer appears in `--help` output — this was an explicit request.