### PR TITLE
feat(setup): plan-driven redesign of `signet setup` (#967)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -50,8 +50,8 @@
         "signet-connector-claude-code": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.142.4",
-        "@signet/core": "0.142.4",
+        "@signet/connector-base": "0.155.0",
+        "@signet/core": "0.155.0",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -65,8 +65,8 @@
         "signet-connector-codex": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.142.4",
-        "@signet/core": "0.142.4",
+        "@signet/connector-base": "0.155.0",
+        "@signet/core": "0.155.0",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -91,8 +91,8 @@
         "signet-connector-forge": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.142.4",
-        "@signet/core": "0.142.4",
+        "@signet/connector-base": "0.155.0",
+        "@signet/core": "0.155.0",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -106,8 +106,8 @@
         "signet-connector-gemini": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.142.4",
-        "@signet/core": "0.142.4",
+        "@signet/connector-base": "0.155.0",
+        "@signet/core": "0.155.0",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -121,8 +121,8 @@
         "signet-connector-hermes-agent": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.142.4",
-        "@signet/core": "0.142.4",
+        "@signet/connector-base": "0.155.0",
+        "@signet/core": "0.155.0",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -136,8 +136,8 @@
         "signet-connector-oh-my-pi": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.142.4",
-        "@signet/core": "0.142.4",
+        "@signet/connector-base": "0.155.0",
+        "@signet/core": "0.155.0",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -165,8 +165,8 @@
         "signet-connector-openclaw": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.142.4",
-        "@signet/core": "0.142.4",
+        "@signet/connector-base": "0.155.0",
+        "@signet/core": "0.155.0",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -198,8 +198,8 @@
         "signet-connector-opencode": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.142.4",
-        "@signet/core": "0.142.4",
+        "@signet/connector-base": "0.155.0",
+        "@signet/core": "0.155.0",
         "jsonc-parser": "3.3.1",
       },
       "devDependencies": {
@@ -224,8 +224,8 @@
         "signet-connector-pi": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.142.4",
-        "@signet/core": "0.142.4",
+        "@signet/connector-base": "0.155.0",
+        "@signet/core": "0.155.0",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -262,7 +262,7 @@
       "name": "@signet/connector-base",
       "version": "0.155.3",
       "dependencies": {
-        "@signet/core": "0.142.4",
+        "@signet/core": "0.155.0",
         "json5": "^2.2.3",
         "jsonc-parser": "3.3.1",
       },
@@ -409,6 +409,7 @@
         "commander": "^12.0.0",
         "open": "^10.0.0",
         "ora": "^8.0.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.0",
@@ -3881,7 +3882,7 @@
 
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
@@ -3892,6 +3893,10 @@
     "@anthropic-ai/tokenizer/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "@astrojs/react/vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
+
+    "@astrojs/rss/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@astrojs/sitemap/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@aws-sdk/core/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
 
@@ -4029,6 +4034,8 @@
 
     "@langchain/core/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
+    "@langchain/core/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
     "@mariozechner/pi-ai/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.73.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw=="],
@@ -4047,6 +4054,10 @@
 
     "@mariozechner/pi-tui/marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
+    "@mistralai/mistralai/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "@napi-rs/cli/@inquirer/prompts": ["@inquirer/prompts@8.4.2", "", { "dependencies": { "@inquirer/checkbox": "^5.1.4", "@inquirer/confirm": "^6.0.12", "@inquirer/editor": "^5.1.1", "@inquirer/expand": "^5.0.13", "@inquirer/input": "^5.0.12", "@inquirer/number": "^4.0.12", "@inquirer/password": "^5.0.12", "@inquirer/rawlist": "^5.2.8", "@inquirer/search": "^4.1.8", "@inquirer/select": "^5.1.4" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q=="],
 
     "@npmcli/agent/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
@@ -4063,7 +4074,11 @@
 
     "@oh-my-pi/pi-ai/openai": ["openai@6.34.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw=="],
 
+    "@oh-my-pi/pi-ai/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "@oh-my-pi/pi-coding-agent/@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.16.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw=="],
+
+    "@oh-my-pi/pi-coding-agent/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
 
@@ -4120,6 +4135,8 @@
     "@signet/core/better-sqlite3": ["better-sqlite3@11.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ=="],
 
     "@signet/daemon/better-sqlite3": ["better-sqlite3@11.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ=="],
+
+    "@signet/daemon/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@signet/oh-my-pi-extension/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
@@ -4254,8 +4271,6 @@
     "@types/yauzl/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "acpx/commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
-
-    "acpx/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "ajv-keywords/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -394,6 +394,7 @@
       "version": "0.155.3",
       "bin": "./dist/cli.js",
       "dependencies": {
+        "@earendil-works/pi-ai": "0.79.2",
         "@inquirer/prompts": "^7.0.0",
         "@signet/connector-claude-code": "workspace:*",
         "@signet/connector-codex": "workspace:*",

--- a/docs/specs/drafts/setup-redesign-plan.md
+++ b/docs/specs/drafts/setup-redesign-plan.md
@@ -196,10 +196,25 @@ moves to small section modules. Net non-test LOC should drop.
 
 - No Signet Cloud branch (product doesn't exist).
 - No identity interview engine (stubs + `/onboarding` pointer).
-- No new config semantics yet — `skills.selected`, `dreaming.enabled`,
-  `secrets.backend`, `synthesis.*` are written to `agent.yaml` but runtime
-  honoring lands in phase 2 alongside the daemon/core changes.
 - `setup-migrate.ts` (existing-identity path) untouched.
+
+## Phase 2 findings (code-verified)
+
+Implemented (config-driven, runtime-honored):
+- **Distinct synthesis route** — `synthesisProvider/Model/Endpoint`; daemon
+  routes a separate `session_synthesis` workload (`routing.ts`, verified).
+- **dreaming toggle** — `dreamingEnabled` → `memory.dreaming.enabled`;
+  `loadDreamingConfig` reads it (`DEFAULT_DREAMING.enabled=false`, verified).
+
+Deferred with rationale (NOT setup config keys):
+- **secrets.backend** — the active provider is RUNTIME state, not config:
+  `setActiveSecretProvider` writes `SIGNET_SECRETS_ACTIVE_PROVIDER` to the
+  secrets store; 1Password uses a stored service-account token. There is no
+  `agent.yaml` key the daemon reads to select the backend, so it is not a
+  SetupPlan field. Backend selection stays a post-setup dashboard/API action.
+- **skills.selected** — the `skills` allowlist lives on `AgentDefinition`
+  (per roster entry, `agents.ts`), not the flat top-level config. It belongs
+  in phase 3 (multi-agent roster), not the single-agent fresh plan.
 
 ## Open questions
 

--- a/docs/specs/drafts/setup-redesign-plan.md
+++ b/docs/specs/drafts/setup-redesign-plan.md
@@ -11,7 +11,7 @@ success_criteria:
   - "`signet setup --dry-run` prints the plan and the files it would write without mutating anything"
   - "Non-TTY invocation never blocks on a prompt; incomplete input fails with a structured error"
   - "The wizard can add roster agents via the same code path as `signet agent add`, reconciled into the agents table at daemon boot"
-  - "Setup can write a distinct synthesis provider route and a secrets backend selection that the daemon already supports"
+  - "Setup can write an optional aggregate-recall route for supported fresh-setup providers"
 scope_boundary: "CLI onboarding UX and headless setup payload only; does not specify Signet Cloud onboarding, dashboard onboarding UI (#948 consumes the same plan shape), an in-CLI identity interview engine, or runtime semantics for new config keys (phase 2)"
 ---
 
@@ -62,7 +62,7 @@ interface SetupPlan {
   }>;
 
   identity: {
-    mode: "managed" | "passthrough" | "off";
+    mode: "managed" | "off";
     preset: "minimal" | "hermes" | "openclaw" | "custom";
     // No interview engine in CLI. Stubs are written; output points to
     // the /onboarding skill for the guided identity interview.
@@ -76,7 +76,7 @@ interface SetupPlan {
 
   pipeline: {
     extraction: { provider: ExtractionProviderChoice; model: string; endpoint?: string };
-    synthesis: { mode: "same" } | { mode: "custom"; provider: string; model: string; endpoint?: string };
+    aggregateRecall?: { provider: "openrouter" | "ollama" | "llama-cpp" | "openai-compatible"; model: string; endpoint?: string };
     dreaming: { enabled: boolean }; // default true
   };
 
@@ -142,8 +142,8 @@ Grouped sections, each a small pure-ish async fn `plan -> plan`:
    Then loop: "Add another agent?" → name/description/preset/read-policy.
 3. **Harness detection**: scan PATH for harness CLIs, multi-select with
    detected ones pre-checked ("We see Claude Code and OpenCode...").
-4. **Provider & pipeline**: extraction provider+model → synthesis
-   (same-as-extraction default) → dreaming confirm (default on).
+4. **Provider & pipeline**: extraction provider+model → optional aggregate
+   recall override → dreaming confirm (default on).
 5. **Embeddings**: native default; ollama/llama-cpp/openai model prompts.
 6. **Skills**: checkbox of builtins, all on, dreaming locked on.
 7. **Sources**: optional Obsidian path / ChatGPT export path / skip
@@ -203,11 +203,13 @@ moves to small section modules. Net non-test LOC should drop.
 Implemented (config-driven, runtime-honored):
 - **Distinct aggregate-recall provider** — `aggregateRecallProvider/Model/Endpoint`.
   Aggregate recall is query-time evidence synthesis; it is the only per-operation
-  override over the extraction provider (the dashboard's main selector reads "memory
-  extraction and synthesis" — session synthesis is NOT a separate provider).
+  override over the extraction provider. Fresh setup offers keyless local servers
+  plus OpenRouter, which uses the router's established `OPENROUTER_API_KEY`
+  contract. Other cloud providers must be connected in the dashboard first.
+  A model is required for every aggregate-recall route.
   Setup writes a modern `inference.targets.aggregation` target bound to
   `workloads.aggregateRecall`; the daemon merges `inference.*` atop the legacy
-  `pipeline.*` base, so extraction/session-synthesis are unaffected
+  `pipeline.*` base, so extraction is unaffected
   (`parseRoutingConfig`, `inference-router.ts`, verified). pi-ai-only
   (no harness subprocess — spawn latency would dominate).
 - **dreaming toggle** — `dreamingEnabled` → `memory.dreaming.enabled`;
@@ -250,14 +252,7 @@ Deferred with rationale (NOT setup config keys):
    URL into agent.yaml (e.g. `daemon.url`) and teach
    `resolveSignetDaemonUrl` a config fallback, install connectors with
    `--url`, skip local daemon start.
-4. **Synthesis provider — runtime already supports it.** Two independent
-   mechanisms: (a) `PipelineSynthesisConfig` has its own
-   `provider/model/endpoint` separate from extraction
-   (`platform/core/src/types.ts` L438); (b) the daemon routes synthesis as
-   a distinct workload — `session_synthesis` vs `memory_extraction` —
-   through the inference routing layer (`platform/daemon/src/daemon.ts`
-   ~L1342-1471), and setup already writes per-workload routes
-   (`applySetupInferenceRoute` in `setup-pipeline.ts` handles both
-   `workloads.memoryExtraction` and `workloads.sessionSynthesis`). The
-   wizard just needs to ask, and write a second route/config block when
-   the user picks a distinct synthesis provider.
+4. **Session synthesis routing is obsolete.** The daemon routes internal
+   session work through `memoryExtraction`/the default policy. Setup must not
+   add a separate session-synthesis target; `aggregateRecall` is the only
+   optional distinct workload route in this plan.

--- a/docs/specs/drafts/setup-redesign-plan.md
+++ b/docs/specs/drafts/setup-redesign-plan.md
@@ -201,8 +201,15 @@ moves to small section modules. Net non-test LOC should drop.
 ## Phase 2 findings (code-verified)
 
 Implemented (config-driven, runtime-honored):
-- **Distinct synthesis route** — `synthesisProvider/Model/Endpoint`; daemon
-  routes a separate `session_synthesis` workload (`routing.ts`, verified).
+- **Distinct aggregate-recall provider** — `aggregateRecallProvider/Model/Endpoint`.
+  Aggregate recall is query-time evidence synthesis; it is the only per-operation
+  override over the extraction provider (the dashboard's main selector reads "memory
+  extraction and synthesis" — session synthesis is NOT a separate provider).
+  Setup writes a modern `inference.targets.aggregation` target bound to
+  `workloads.aggregateRecall`; the daemon merges `inference.*` atop the legacy
+  `pipeline.*` base, so extraction/session-synthesis are unaffected
+  (`parseRoutingConfig`, `inference-router.ts`, verified). pi-ai-only
+  (no harness subprocess — spawn latency would dominate).
 - **dreaming toggle** — `dreamingEnabled` → `memory.dreaming.enabled`;
   `loadDreamingConfig` reads it (`DEFAULT_DREAMING.enabled=false`, verified).
 

--- a/docs/specs/drafts/setup-redesign-plan.md
+++ b/docs/specs/drafts/setup-redesign-plan.md
@@ -204,8 +204,11 @@ Implemented (config-driven, runtime-honored):
 - **Distinct aggregate-recall provider** — `aggregateRecallProvider/Model/Endpoint`.
   Aggregate recall is query-time evidence synthesis; it is the only per-operation
   override over the extraction provider. Fresh setup offers keyless local servers
-  plus OpenRouter, which uses the router's established `OPENROUTER_API_KEY`
-  contract. Other cloud providers must be connected in the dashboard first.
+  plus OpenRouter. An unconnected OpenRouter route uses the router's established
+  `OPENROUTER_API_KEY` contract; when the setup connect flow configured
+  OpenRouter extraction, aggregate recall reuses that connected account and its
+  stored `SIGNET_KEY_OPENROUTER` credential. Other cloud providers must be
+  connected in the dashboard first.
   A model is required for every aggregate-recall route.
   Setup writes a modern `inference.targets.aggregation` target bound to
   `workloads.aggregateRecall`; the daemon merges `inference.*` atop the legacy
@@ -216,6 +219,10 @@ Implemented (config-driven, runtime-honored):
   `loadDreamingConfig` reads it (`DEFAULT_DREAMING.enabled=false`, verified).
 
 Deferred with rationale (NOT setup config keys):
+- **Legacy `passthrough` identity** — no longer offered or written for new
+  setup plans, but existing workspaces keep its read-without-stewardship
+  behavior until an operator explicitly reconfigures identity. This avoids a
+  silent identity-injection behavior change on upgrade.
 - **secrets.backend** — the active provider is RUNTIME state, not config:
   `setActiveSecretProvider` writes `SIGNET_SECRETS_ACTIVE_PROVIDER` to the
   secrets store; 1Password uses a stored service-account token. There is no

--- a/integrations/forge/connector/dist/index.js
+++ b/integrations/forge/connector/dist/index.js
@@ -6,48 +6,65 @@ import {
   readFileSync as readFileSync2,
   readdirSync,
   readlinkSync,
-  rmSync,
+  rmSync as rmSync2,
   unlinkSync as unlinkSync3,
-  writeFileSync as writeFileSync2
+  writeFileSync as writeFileSync3
 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
+import { homedir as homedir5 } from "node:os";
 import { isAbsolute, join as join6, relative, resolve as resolve2, sep } from "node:path";
 
 // ../../../libs/connector-base/dist/index.js
 import { randomBytes } from "node:crypto";
-import { existsSync, readFileSync, renameSync, unlinkSync as unlinkSync2, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, statSync as statSync2, unlinkSync as unlinkSync2, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname as dirname2, join as join3, resolve } from "node:path";
+import { dirname as dirname3, join as join3 } from "node:path";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir as homedir2 } from "os";
 import { join as join2 } from "path";
+import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync3, rmSync, statSync, writeFileSync as writeFileSync2 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { dirname as dirname2, join as join5, resolve } from "node:path";
 import { createRequire as createRequire2 } from "node:module";
-import { homedir as homedir3, platform as platform2 } from "node:os";
-import { basename, dirname as dirname3, resolve as resolve3 } from "node:path";
-import { homedir as homedir7 } from "node:os";
-import { existsSync as existsSync12, lstatSync, mkdirSync as mkdirSync8, readdirSync as readdirSync6, symlinkSync, unlinkSync } from "node:fs";
-import { join as join12 } from "node:path";
-var __create = Object.create;
-var __getProtoOf = Object.getPrototypeOf;
-var __defProp = Object.defineProperty;
-var __getOwnPropNames = Object.getOwnPropertyNames;
-var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __toESM = (mod, isNodeMode, target) => {
-  target = mod != null ? __create(__getProtoOf(mod)) : {};
-  const to = isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target;
-  for (let key of __getOwnPropNames(mod))
-    if (!__hasOwnProp.call(to, key))
-      __defProp(to, key, {
-        get: () => mod[key],
+import { homedir as homedir4, platform as platform2 } from "node:os";
+import { basename, dirname as dirname4, resolve as resolve4 } from "node:path";
+import { homedir as homedir8 } from "node:os";
+import { existsSync as existsSync13, lstatSync, mkdirSync as mkdirSync9, readdirSync as readdirSync6, symlinkSync, unlinkSync } from "node:fs";
+import { join as join13 } from "node:path";
+var __create2 = Object.create;
+var __getProtoOf2 = Object.getPrototypeOf;
+var __defProp2 = Object.defineProperty;
+var __getOwnPropNames2 = Object.getOwnPropertyNames;
+var __hasOwnProp2 = Object.prototype.hasOwnProperty;
+function __accessProp2(key) {
+  return this[key];
+}
+var __toESMCache_node2;
+var __toESMCache_esm2;
+var __toESM2 = (mod, isNodeMode, target) => {
+  var canCache = mod != null && typeof mod === "object";
+  if (canCache) {
+    var cache = isNodeMode ? __toESMCache_node2 ??= new WeakMap : __toESMCache_esm2 ??= new WeakMap;
+    var cached = cache.get(mod);
+    if (cached)
+      return cached;
+  }
+  target = mod != null ? __create2(__getProtoOf2(mod)) : {};
+  const to = isNodeMode || !mod || !mod.__esModule ? __defProp2(target, "default", { value: mod, enumerable: true }) : target;
+  for (let key of __getOwnPropNames2(mod))
+    if (!__hasOwnProp2.call(to, key))
+      __defProp2(to, key, {
+        get: __accessProp2.bind(mod, key),
         enumerable: true
       });
+  if (canCache)
+    cache.set(mod, to);
   return to;
 };
-var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+var __commonJS2 = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
 var __require = /* @__PURE__ */ createRequire(import.meta.url);
-var require_identity = __commonJS((exports) => {
+var require_identity = __commonJS2((exports) => {
   var ALIAS = Symbol.for("yaml.alias");
   var DOC = Symbol.for("yaml.document");
   var MAP = Symbol.for("yaml.map");
@@ -99,7 +116,7 @@ var require_identity = __commonJS((exports) => {
   exports.isScalar = isScalar;
   exports.isSeq = isSeq;
 });
-var require_visit = __commonJS((exports) => {
+var require_visit = __commonJS2((exports) => {
   var identity = require_identity();
   var BREAK = Symbol("break visit");
   var SKIP = Symbol("skip children");
@@ -252,7 +269,7 @@ var require_visit = __commonJS((exports) => {
   exports.visit = visit;
   exports.visitAsync = visitAsync;
 });
-var require_directives = __commonJS((exports) => {
+var require_directives = __commonJS2((exports) => {
   var identity = require_identity();
   var visit = require_visit();
   var escapeChars = {
@@ -402,7 +419,7 @@ var require_directives = __commonJS((exports) => {
   Directives.defaultTags = { "!!": "tag:yaml.org,2002:" };
   exports.Directives = Directives;
 });
-var require_anchors = __commonJS((exports) => {
+var require_anchors = __commonJS2((exports) => {
   var identity = require_identity();
   var visit = require_visit();
   function anchorIsValid(anchor) {
@@ -462,7 +479,7 @@ var require_anchors = __commonJS((exports) => {
   exports.createNodeAnchors = createNodeAnchors;
   exports.findNewAnchor = findNewAnchor;
 });
-var require_applyReviver = __commonJS((exports) => {
+var require_applyReviver = __commonJS2((exports) => {
   function applyReviver(reviver, obj, key, val) {
     if (val && typeof val === "object") {
       if (Array.isArray(val)) {
@@ -507,7 +524,7 @@ var require_applyReviver = __commonJS((exports) => {
   }
   exports.applyReviver = applyReviver;
 });
-var require_toJS = __commonJS((exports) => {
+var require_toJS = __commonJS2((exports) => {
   var identity = require_identity();
   function toJS(value, arg, ctx) {
     if (Array.isArray(value))
@@ -532,7 +549,7 @@ var require_toJS = __commonJS((exports) => {
   }
   exports.toJS = toJS;
 });
-var require_Node = __commonJS((exports) => {
+var require_Node = __commonJS2((exports) => {
   var applyReviver = require_applyReviver();
   var identity = require_identity();
   var toJS = require_toJS();
@@ -567,7 +584,7 @@ var require_Node = __commonJS((exports) => {
   }
   exports.NodeBase = NodeBase;
 });
-var require_Alias = __commonJS((exports) => {
+var require_Alias = __commonJS2((exports) => {
   var anchors = require_anchors();
   var visit = require_visit();
   var identity = require_identity();
@@ -673,7 +690,7 @@ var require_Alias = __commonJS((exports) => {
   }
   exports.Alias = Alias;
 });
-var require_Scalar = __commonJS((exports) => {
+var require_Scalar = __commonJS2((exports) => {
   var identity = require_identity();
   var Node = require_Node();
   var toJS = require_toJS();
@@ -699,7 +716,7 @@ var require_Scalar = __commonJS((exports) => {
   exports.Scalar = Scalar;
   exports.isScalarValue = isScalarValue;
 });
-var require_createNode = __commonJS((exports) => {
+var require_createNode = __commonJS2((exports) => {
   var Alias = require_Alias();
   var identity = require_identity();
   var Scalar = require_Scalar();
@@ -769,7 +786,7 @@ var require_createNode = __commonJS((exports) => {
   }
   exports.createNode = createNode;
 });
-var require_Collection = __commonJS((exports) => {
+var require_Collection = __commonJS2((exports) => {
   var createNode = require_createNode();
   var identity = require_identity();
   var Node = require_Node();
@@ -882,7 +899,7 @@ var require_Collection = __commonJS((exports) => {
   exports.collectionFromPath = collectionFromPath;
   exports.isEmptyPath = isEmptyPath;
 });
-var require_stringifyComment = __commonJS((exports) => {
+var require_stringifyComment = __commonJS2((exports) => {
   var stringifyComment = (str) => str.replace(/^(?!$)(?: $)?/gm, "#");
   function indentComment(comment, indent) {
     if (/^\n+$/.test(comment))
@@ -897,7 +914,7 @@ var require_stringifyComment = __commonJS((exports) => {
   exports.lineComment = lineComment;
   exports.stringifyComment = stringifyComment;
 });
-var require_foldFlowLines = __commonJS((exports) => {
+var require_foldFlowLines = __commonJS2((exports) => {
   var FOLD_FLOW = "flow";
   var FOLD_BLOCK = "block";
   var FOLD_QUOTED = "quoted";
@@ -1032,7 +1049,7 @@ ${indent}${text.slice(fold + 1, end2)}`;
   exports.FOLD_QUOTED = FOLD_QUOTED;
   exports.foldFlowLines = foldFlowLines;
 });
-var require_stringifyString = __commonJS((exports) => {
+var require_stringifyString = __commonJS2((exports) => {
   var Scalar = require_Scalar();
   var foldFlowLines = require_foldFlowLines();
   var getFoldOptions = (ctx, isBlock) => ({
@@ -1328,7 +1345,7 @@ ${indent}`);
   }
   exports.stringifyString = stringifyString;
 });
-var require_stringify = __commonJS((exports) => {
+var require_stringify = __commonJS2((exports) => {
   var anchors = require_anchors();
   var identity = require_identity();
   var stringifyComment = require_stringifyComment();
@@ -1447,7 +1464,7 @@ ${ctx.indent}${str}`;
   exports.createStringifyContext = createStringifyContext;
   exports.stringify = stringify;
 });
-var require_stringifyPair = __commonJS((exports) => {
+var require_stringifyPair = __commonJS2((exports) => {
   var identity = require_identity();
   var Scalar = require_Scalar();
   var stringify = require_stringify();
@@ -1581,7 +1598,7 @@ ${ctx.indent}`;
   }
   exports.stringifyPair = stringifyPair;
 });
-var require_log = __commonJS((exports) => {
+var require_log = __commonJS2((exports) => {
   var node_process = __require("process");
   function debug(logLevel, ...messages) {
     if (logLevel === "debug")
@@ -1598,7 +1615,7 @@ var require_log = __commonJS((exports) => {
   exports.debug = debug;
   exports.warn = warn;
 });
-var require_merge = __commonJS((exports) => {
+var require_merge = __commonJS2((exports) => {
   var identity = require_identity();
   var Scalar = require_Scalar();
   var MERGE_KEY = "<<";
@@ -1650,7 +1667,7 @@ var require_merge = __commonJS((exports) => {
   exports.isMergeKey = isMergeKey;
   exports.merge = merge;
 });
-var require_addPairToJSMap = __commonJS((exports) => {
+var require_addPairToJSMap = __commonJS2((exports) => {
   var log = require_log();
   var merge = require_merge();
   var stringify = require_stringify();
@@ -1709,7 +1726,7 @@ var require_addPairToJSMap = __commonJS((exports) => {
   }
   exports.addPairToJSMap = addPairToJSMap;
 });
-var require_Pair = __commonJS((exports) => {
+var require_Pair = __commonJS2((exports) => {
   var createNode = require_createNode();
   var stringifyPair = require_stringifyPair();
   var addPairToJSMap = require_addPairToJSMap();
@@ -1745,7 +1762,7 @@ var require_Pair = __commonJS((exports) => {
   exports.Pair = Pair;
   exports.createPair = createPair;
 });
-var require_stringifyCollection = __commonJS((exports) => {
+var require_stringifyCollection = __commonJS2((exports) => {
   var identity = require_identity();
   var stringify = require_stringify();
   var stringifyComment = require_stringifyComment();
@@ -1895,7 +1912,7 @@ ${indent}${end}`;
   }
   exports.stringifyCollection = stringifyCollection;
 });
-var require_YAMLMap = __commonJS((exports) => {
+var require_YAMLMap = __commonJS2((exports) => {
   var stringifyCollection = require_stringifyCollection();
   var addPairToJSMap = require_addPairToJSMap();
   var Collection = require_Collection();
@@ -2020,7 +2037,7 @@ var require_YAMLMap = __commonJS((exports) => {
   exports.YAMLMap = YAMLMap;
   exports.findPair = findPair;
 });
-var require_map = __commonJS((exports) => {
+var require_map = __commonJS2((exports) => {
   var identity = require_identity();
   var YAMLMap = require_YAMLMap();
   var map = {
@@ -2037,7 +2054,7 @@ var require_map = __commonJS((exports) => {
   };
   exports.map = map;
 });
-var require_YAMLSeq = __commonJS((exports) => {
+var require_YAMLSeq = __commonJS2((exports) => {
   var createNode = require_createNode();
   var stringifyCollection = require_stringifyCollection();
   var Collection = require_Collection();
@@ -2128,7 +2145,7 @@ var require_YAMLSeq = __commonJS((exports) => {
   }
   exports.YAMLSeq = YAMLSeq;
 });
-var require_seq = __commonJS((exports) => {
+var require_seq = __commonJS2((exports) => {
   var identity = require_identity();
   var YAMLSeq = require_YAMLSeq();
   var seq = {
@@ -2145,7 +2162,7 @@ var require_seq = __commonJS((exports) => {
   };
   exports.seq = seq;
 });
-var require_string = __commonJS((exports) => {
+var require_string = __commonJS2((exports) => {
   var stringifyString = require_stringifyString();
   var string = {
     identify: (value) => typeof value === "string",
@@ -2159,7 +2176,7 @@ var require_string = __commonJS((exports) => {
   };
   exports.string = string;
 });
-var require_null = __commonJS((exports) => {
+var require_null = __commonJS2((exports) => {
   var Scalar = require_Scalar();
   var nullTag = {
     identify: (value) => value == null,
@@ -2172,7 +2189,7 @@ var require_null = __commonJS((exports) => {
   };
   exports.nullTag = nullTag;
 });
-var require_bool = __commonJS((exports) => {
+var require_bool = __commonJS2((exports) => {
   var Scalar = require_Scalar();
   var boolTag = {
     identify: (value) => typeof value === "boolean",
@@ -2191,7 +2208,7 @@ var require_bool = __commonJS((exports) => {
   };
   exports.boolTag = boolTag;
 });
-var require_stringifyNumber = __commonJS((exports) => {
+var require_stringifyNumber = __commonJS2((exports) => {
   function stringifyNumber({ format, minFractionDigits, tag, value }) {
     if (typeof value === "bigint")
       return String(value);
@@ -2213,7 +2230,7 @@ var require_stringifyNumber = __commonJS((exports) => {
   }
   exports.stringifyNumber = stringifyNumber;
 });
-var require_float = __commonJS((exports) => {
+var require_float = __commonJS2((exports) => {
   var Scalar = require_Scalar();
   var stringifyNumber = require_stringifyNumber();
   var floatNaN = {
@@ -2254,7 +2271,7 @@ var require_float = __commonJS((exports) => {
   exports.floatExp = floatExp;
   exports.floatNaN = floatNaN;
 });
-var require_int = __commonJS((exports) => {
+var require_int = __commonJS2((exports) => {
   var stringifyNumber = require_stringifyNumber();
   var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
   var intResolve = (str, offset, radix, { intAsBigInt }) => intAsBigInt ? BigInt(str) : parseInt(str.substring(offset), radix);
@@ -2294,7 +2311,7 @@ var require_int = __commonJS((exports) => {
   exports.intHex = intHex;
   exports.intOct = intOct;
 });
-var require_schema = __commonJS((exports) => {
+var require_schema = __commonJS2((exports) => {
   var map = require_map();
   var _null = require_null();
   var seq = require_seq();
@@ -2317,7 +2334,7 @@ var require_schema = __commonJS((exports) => {
   ];
   exports.schema = schema;
 });
-var require_schema2 = __commonJS((exports) => {
+var require_schema2 = __commonJS2((exports) => {
   var Scalar = require_Scalar();
   var map = require_map();
   var seq = require_seq();
@@ -2379,7 +2396,7 @@ var require_schema2 = __commonJS((exports) => {
   var schema = [map.map, seq.seq].concat(jsonScalars, jsonError);
   exports.schema = schema;
 });
-var require_binary = __commonJS((exports) => {
+var require_binary = __commonJS2((exports) => {
   var node_buffer = __require("buffer");
   var Scalar = require_Scalar();
   var stringifyString = require_stringifyString();
@@ -2432,7 +2449,7 @@ var require_binary = __commonJS((exports) => {
   };
   exports.binary = binary;
 });
-var require_pairs = __commonJS((exports) => {
+var require_pairs = __commonJS2((exports) => {
   var identity = require_identity();
   var Pair = require_Pair();
   var Scalar = require_Scalar();
@@ -2505,7 +2522,7 @@ ${cn.comment}` : item.comment;
   exports.pairs = pairs;
   exports.resolvePairs = resolvePairs;
 });
-var require_omap = __commonJS((exports) => {
+var require_omap = __commonJS2((exports) => {
   var identity = require_identity();
   var toJS = require_toJS();
   var YAMLMap = require_YAMLMap();
@@ -2575,7 +2592,7 @@ var require_omap = __commonJS((exports) => {
   exports.YAMLOMap = YAMLOMap;
   exports.omap = omap;
 });
-var require_bool2 = __commonJS((exports) => {
+var require_bool2 = __commonJS2((exports) => {
   var Scalar = require_Scalar();
   function boolStringify({ value, source }, ctx) {
     const boolObj = value ? trueTag : falseTag;
@@ -2602,7 +2619,7 @@ var require_bool2 = __commonJS((exports) => {
   exports.falseTag = falseTag;
   exports.trueTag = trueTag;
 });
-var require_float2 = __commonJS((exports) => {
+var require_float2 = __commonJS2((exports) => {
   var Scalar = require_Scalar();
   var stringifyNumber = require_stringifyNumber();
   var floatNaN = {
@@ -2646,7 +2663,7 @@ var require_float2 = __commonJS((exports) => {
   exports.floatExp = floatExp;
   exports.floatNaN = floatNaN;
 });
-var require_int2 = __commonJS((exports) => {
+var require_int2 = __commonJS2((exports) => {
   var stringifyNumber = require_stringifyNumber();
   var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
   function intResolve(str, offset, radix, { intAsBigInt }) {
@@ -2720,7 +2737,7 @@ var require_int2 = __commonJS((exports) => {
   exports.intHex = intHex;
   exports.intOct = intOct;
 });
-var require_set = __commonJS((exports) => {
+var require_set = __commonJS2((exports) => {
   var identity = require_identity();
   var Pair = require_Pair();
   var YAMLMap = require_YAMLMap();
@@ -2801,7 +2818,7 @@ var require_set = __commonJS((exports) => {
   exports.YAMLSet = YAMLSet;
   exports.set = set;
 });
-var require_timestamp = __commonJS((exports) => {
+var require_timestamp = __commonJS2((exports) => {
   var stringifyNumber = require_stringifyNumber();
   function parseSexagesimal(str, asBigInt) {
     const sign = str[0];
@@ -2881,7 +2898,7 @@ var require_timestamp = __commonJS((exports) => {
   exports.intTime = intTime;
   exports.timestamp = timestamp;
 });
-var require_schema3 = __commonJS((exports) => {
+var require_schema3 = __commonJS2((exports) => {
   var map = require_map();
   var _null = require_null();
   var seq = require_seq();
@@ -2920,7 +2937,7 @@ var require_schema3 = __commonJS((exports) => {
   ];
   exports.schema = schema;
 });
-var require_tags = __commonJS((exports) => {
+var require_tags = __commonJS2((exports) => {
   var map = require_map();
   var _null = require_null();
   var seq = require_seq();
@@ -3009,7 +3026,7 @@ var require_tags = __commonJS((exports) => {
   exports.coreKnownTags = coreKnownTags;
   exports.getTags = getTags;
 });
-var require_Schema = __commonJS((exports) => {
+var require_Schema = __commonJS2((exports) => {
   var identity = require_identity();
   var map = require_map();
   var seq = require_seq();
@@ -3037,7 +3054,7 @@ var require_Schema = __commonJS((exports) => {
   }
   exports.Schema = Schema;
 });
-var require_stringifyDocument = __commonJS((exports) => {
+var require_stringifyDocument = __commonJS2((exports) => {
   var identity = require_identity();
   var stringify = require_stringify();
   var stringifyComment = require_stringifyComment();
@@ -3115,7 +3132,7 @@ var require_stringifyDocument = __commonJS((exports) => {
   }
   exports.stringifyDocument = stringifyDocument;
 });
-var require_Document = __commonJS((exports) => {
+var require_Document = __commonJS2((exports) => {
   var Alias = require_Alias();
   var Collection = require_Collection();
   var identity = require_identity();
@@ -3348,7 +3365,7 @@ var require_Document = __commonJS((exports) => {
   }
   exports.Document = Document;
 });
-var require_errors = __commonJS((exports) => {
+var require_errors = __commonJS2((exports) => {
 
   class YAMLError extends Error {
     constructor(name, pos, code, message) {
@@ -3412,7 +3429,7 @@ ${pointer}
   exports.YAMLWarning = YAMLWarning;
   exports.prettifyError = prettifyError;
 });
-var require_resolve_props = __commonJS((exports) => {
+var require_resolve_props = __commonJS2((exports) => {
   function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIndent, startOnNewline }) {
     let spaceBefore = false;
     let atNewline = startOnNewline;
@@ -3540,7 +3557,7 @@ var require_resolve_props = __commonJS((exports) => {
   }
   exports.resolveProps = resolveProps;
 });
-var require_util_contains_newline = __commonJS((exports) => {
+var require_util_contains_newline = __commonJS2((exports) => {
   function containsNewline(key) {
     if (!key)
       return null;
@@ -3578,7 +3595,7 @@ var require_util_contains_newline = __commonJS((exports) => {
   }
   exports.containsNewline = containsNewline;
 });
-var require_util_flow_indent_check = __commonJS((exports) => {
+var require_util_flow_indent_check = __commonJS2((exports) => {
   var utilContainsNewline = require_util_contains_newline();
   function flowIndentCheck(indent, fc, onError) {
     if (fc?.type === "flow-collection") {
@@ -3591,7 +3608,7 @@ var require_util_flow_indent_check = __commonJS((exports) => {
   }
   exports.flowIndentCheck = flowIndentCheck;
 });
-var require_util_map_includes = __commonJS((exports) => {
+var require_util_map_includes = __commonJS2((exports) => {
   var identity = require_identity();
   function mapIncludes(ctx, items, search) {
     const { uniqueKeys } = ctx.options;
@@ -3602,7 +3619,7 @@ var require_util_map_includes = __commonJS((exports) => {
   }
   exports.mapIncludes = mapIncludes;
 });
-var require_resolve_block_map = __commonJS((exports) => {
+var require_resolve_block_map = __commonJS2((exports) => {
   var Pair = require_Pair();
   var YAMLMap = require_YAMLMap();
   var resolveProps = require_resolve_props();
@@ -3707,7 +3724,7 @@ var require_resolve_block_map = __commonJS((exports) => {
   }
   exports.resolveBlockMap = resolveBlockMap;
 });
-var require_resolve_block_seq = __commonJS((exports) => {
+var require_resolve_block_seq = __commonJS2((exports) => {
   var YAMLSeq = require_YAMLSeq();
   var resolveProps = require_resolve_props();
   var utilFlowIndentCheck = require_util_flow_indent_check();
@@ -3753,7 +3770,7 @@ var require_resolve_block_seq = __commonJS((exports) => {
   }
   exports.resolveBlockSeq = resolveBlockSeq;
 });
-var require_resolve_end = __commonJS((exports) => {
+var require_resolve_end = __commonJS2((exports) => {
   function resolveEnd(end, offset, reqSpace, onError) {
     let comment = "";
     if (end) {
@@ -3791,7 +3808,7 @@ var require_resolve_end = __commonJS((exports) => {
   }
   exports.resolveEnd = resolveEnd;
 });
-var require_resolve_flow_collection = __commonJS((exports) => {
+var require_resolve_flow_collection = __commonJS2((exports) => {
   var identity = require_identity();
   var Pair = require_Pair();
   var YAMLMap = require_YAMLMap();
@@ -3980,7 +3997,7 @@ var require_resolve_flow_collection = __commonJS((exports) => {
   }
   exports.resolveFlowCollection = resolveFlowCollection;
 });
-var require_compose_collection = __commonJS((exports) => {
+var require_compose_collection = __commonJS2((exports) => {
   var identity = require_identity();
   var Scalar = require_Scalar();
   var YAMLMap = require_YAMLMap();
@@ -4040,7 +4057,7 @@ var require_compose_collection = __commonJS((exports) => {
   }
   exports.composeCollection = composeCollection;
 });
-var require_resolve_block_scalar = __commonJS((exports) => {
+var require_resolve_block_scalar = __commonJS2((exports) => {
   var Scalar = require_Scalar();
   function resolveBlockScalar(ctx, scalar, onError) {
     const start = scalar.offset;
@@ -4231,7 +4248,7 @@ var require_resolve_block_scalar = __commonJS((exports) => {
   }
   exports.resolveBlockScalar = resolveBlockScalar;
 });
-var require_resolve_flow_scalar = __commonJS((exports) => {
+var require_resolve_flow_scalar = __commonJS2((exports) => {
   var Scalar = require_Scalar();
   var resolveEnd = require_resolve_end();
   function resolveFlowScalar(scalar, strict, onError) {
@@ -4445,7 +4462,7 @@ var require_resolve_flow_scalar = __commonJS((exports) => {
   }
   exports.resolveFlowScalar = resolveFlowScalar;
 });
-var require_compose_scalar = __commonJS((exports) => {
+var require_compose_scalar = __commonJS2((exports) => {
   var identity = require_identity();
   var Scalar = require_Scalar();
   var resolveBlockScalar = require_resolve_block_scalar();
@@ -4521,7 +4538,7 @@ var require_compose_scalar = __commonJS((exports) => {
   }
   exports.composeScalar = composeScalar;
 });
-var require_util_empty_scalar_position = __commonJS((exports) => {
+var require_util_empty_scalar_position = __commonJS2((exports) => {
   function emptyScalarPosition(offset, before, pos) {
     if (before) {
       pos ?? (pos = before.length);
@@ -4546,7 +4563,7 @@ var require_util_empty_scalar_position = __commonJS((exports) => {
   }
   exports.emptyScalarPosition = emptyScalarPosition;
 });
-var require_compose_node = __commonJS((exports) => {
+var require_compose_node = __commonJS2((exports) => {
   var Alias = require_Alias();
   var identity = require_identity();
   var composeCollection = require_compose_collection();
@@ -4647,7 +4664,7 @@ var require_compose_node = __commonJS((exports) => {
   exports.composeEmptyNode = composeEmptyNode;
   exports.composeNode = composeNode;
 });
-var require_compose_doc = __commonJS((exports) => {
+var require_compose_doc = __commonJS2((exports) => {
   var Document = require_Document();
   var composeNode = require_compose_node();
   var resolveEnd = require_resolve_end();
@@ -4685,7 +4702,7 @@ var require_compose_doc = __commonJS((exports) => {
   }
   exports.composeDoc = composeDoc;
 });
-var require_composer = __commonJS((exports) => {
+var require_composer = __commonJS2((exports) => {
   var node_process = __require("process");
   var directives = require_directives();
   var Document = require_Document();
@@ -4872,7 +4889,7 @@ ${end.comment}` : end.comment;
   }
   exports.Composer = Composer;
 });
-var require_cst_scalar = __commonJS((exports) => {
+var require_cst_scalar = __commonJS2((exports) => {
   var resolveBlockScalar = require_resolve_block_scalar();
   var resolveFlowScalar = require_resolve_flow_scalar();
   var errors = require_errors();
@@ -5060,7 +5077,7 @@ var require_cst_scalar = __commonJS((exports) => {
   exports.resolveAsScalar = resolveAsScalar;
   exports.setScalarValue = setScalarValue;
 });
-var require_cst_stringify = __commonJS((exports) => {
+var require_cst_stringify = __commonJS2((exports) => {
   var stringify = (cst) => ("type" in cst) ? stringifyToken(cst) : stringifyItem(cst);
   function stringifyToken(token) {
     switch (token.type) {
@@ -5116,7 +5133,7 @@ var require_cst_stringify = __commonJS((exports) => {
   }
   exports.stringify = stringify;
 });
-var require_cst_visit = __commonJS((exports) => {
+var require_cst_visit = __commonJS2((exports) => {
   var BREAK = Symbol("break visit");
   var SKIP = Symbol("skip children");
   var REMOVE = Symbol("remove item");
@@ -5173,7 +5190,7 @@ var require_cst_visit = __commonJS((exports) => {
   }
   exports.visit = visit;
 });
-var require_cst = __commonJS((exports) => {
+var require_cst = __commonJS2((exports) => {
   var cstScalar = require_cst_scalar();
   var cstStringify = require_cst_stringify();
   var cstVisit = require_cst_visit();
@@ -5272,7 +5289,7 @@ var require_cst = __commonJS((exports) => {
   exports.prettyToken = prettyToken;
   exports.tokenType = tokenType;
 });
-var require_lexer = __commonJS((exports) => {
+var require_lexer = __commonJS2((exports) => {
   var cst = require_cst();
   function isEmpty(ch) {
     switch (ch) {
@@ -5856,7 +5873,7 @@ var require_lexer = __commonJS((exports) => {
   }
   exports.Lexer = Lexer;
 });
-var require_line_counter = __commonJS((exports) => {
+var require_line_counter = __commonJS2((exports) => {
 
   class LineCounter {
     constructor() {
@@ -5883,7 +5900,7 @@ var require_line_counter = __commonJS((exports) => {
   }
   exports.LineCounter = LineCounter;
 });
-var require_parser = __commonJS((exports) => {
+var require_parser = __commonJS2((exports) => {
   var node_process = __require("process");
   var cst = require_cst();
   var lexer = require_lexer();
@@ -6730,7 +6747,7 @@ var require_parser = __commonJS((exports) => {
   }
   exports.Parser = Parser;
 });
-var require_public_api = __commonJS((exports) => {
+var require_public_api = __commonJS2((exports) => {
   var composer = require_composer();
   var Document = require_Document();
   var errors = require_errors();
@@ -6822,7 +6839,7 @@ var require_public_api = __commonJS((exports) => {
   exports.parseDocument = parseDocument;
   exports.stringify = stringify;
 });
-var require_dist = __commonJS((exports) => {
+var require_dist = __commonJS2((exports) => {
   var composer = require_composer();
   var Document = require_Document();
   var Schema = require_Schema();
@@ -9462,6 +9479,494 @@ function up78(db) {
 			ON api_keys(connector, harness);
 	`);
 }
+function up79(db) {
+  db.exec(`
+		CREATE TABLE IF NOT EXISTS transcript_capture_jobs (
+			id TEXT PRIMARY KEY,
+			agent_id TEXT NOT NULL DEFAULT 'default',
+			harness TEXT NOT NULL,
+			session_key TEXT,
+			session_id TEXT NOT NULL,
+			project TEXT,
+			transcript TEXT NOT NULL,
+			raw_transcript TEXT,
+			transcript_path TEXT,
+			captured_at TEXT NOT NULL,
+			ended_at TEXT,
+			summary_status TEXT NOT NULL DEFAULT 'not_requested',
+			status TEXT NOT NULL DEFAULT 'pending',
+			attempts INTEGER NOT NULL DEFAULT 0,
+			max_attempts INTEGER NOT NULL DEFAULT 5,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			completed_at TEXT,
+			error TEXT
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_transcript_capture_jobs_status
+			ON transcript_capture_jobs(status, created_at);
+
+		CREATE INDEX IF NOT EXISTS idx_transcript_capture_jobs_agent_session
+			ON transcript_capture_jobs(agent_id, session_key, created_at);
+	`);
+}
+function hasColumn10(db, table, column) {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all();
+  return rows.some((row) => row.name === column);
+}
+function up80(db) {
+  if (!hasColumn10(db, "documents", "agent_id")) {
+    db.exec("ALTER TABLE documents ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'default'");
+  }
+  if (!hasColumn10(db, "documents", "project")) {
+    db.exec("ALTER TABLE documents ADD COLUMN project TEXT");
+  }
+  db.exec(`
+		UPDATE documents
+		SET agent_id = NULLIF(TRIM(json_extract(metadata_json, '$.signet.agentId')), '')
+		WHERE metadata_json IS NOT NULL
+		  AND json_valid(metadata_json)
+		  AND json_type(metadata_json, '$.signet.agentId') = 'text'
+		  AND NULLIF(TRIM(json_extract(metadata_json, '$.signet.agentId')), '') IS NOT NULL
+	`);
+  db.exec(`
+		UPDATE documents
+		SET project = NULLIF(TRIM(json_extract(metadata_json, '$.signet.project')), '')
+		WHERE metadata_json IS NOT NULL
+		  AND json_valid(metadata_json)
+		  AND json_type(metadata_json, '$.signet.project') = 'text'
+	`);
+  db.exec(`
+		WITH linked_scope AS (
+			SELECT
+				dm.document_id,
+				m.agent_id,
+				m.project,
+				ROW_NUMBER() OVER (
+					PARTITION BY dm.document_id
+					ORDER BY COUNT(*) DESC, m.agent_id, COALESCE(m.project, '')
+				) AS rank
+			FROM document_memories dm
+			JOIN memories m ON m.id = dm.memory_id
+			WHERE m.agent_id IS NOT NULL
+			  AND NULLIF(TRIM(m.agent_id), '') IS NOT NULL
+			GROUP BY dm.document_id, m.agent_id, m.project
+		)
+		UPDATE documents
+		SET
+			agent_id = COALESCE((
+				SELECT agent_id FROM linked_scope
+				WHERE linked_scope.document_id = documents.id AND rank = 1
+			), agent_id),
+			project = (
+				SELECT project FROM linked_scope
+				WHERE linked_scope.document_id = documents.id AND rank = 1
+			)
+		WHERE EXISTS (
+			SELECT 1 FROM linked_scope
+			WHERE linked_scope.document_id = documents.id AND rank = 1
+		)
+		AND NOT (
+			metadata_json IS NOT NULL
+			AND json_valid(metadata_json)
+			AND json_type(metadata_json, '$.signet.agentId') = 'text'
+			AND NULLIF(TRIM(json_extract(metadata_json, '$.signet.agentId')), '') IS NOT NULL
+		)
+	`);
+  if (hasColumn10(db, "memories", "visibility") && hasColumn10(db, "memories", "type") && hasColumn10(db, "memories", "source_type")) {
+    db.exec(`
+			UPDATE memories
+			SET visibility = 'private'
+			WHERE id IN (SELECT memory_id FROM document_memories)
+			  AND type = 'document_chunk'
+			  AND source_type = 'document'
+			  AND (visibility IS NULL OR visibility = 'global')
+		`);
+  }
+  if (hasColumn10(db, "memories", "content_hash") && hasColumn10(db, "memories", "agent_id") && hasColumn10(db, "memories", "project") && hasColumn10(db, "memories", "scope") && hasColumn10(db, "memories", "visibility") && hasColumn10(db, "memories", "is_deleted")) {
+    db.exec("DROP INDEX IF EXISTS idx_memories_content_hash_unique");
+    db.exec(`
+			CREATE UNIQUE INDEX idx_memories_content_hash_unique
+			ON memories(
+				content_hash,
+				COALESCE(NULLIF(agent_id, ''), 'default'),
+				COALESCE(project, ''),
+				COALESCE(scope, '__NULL__'),
+				COALESCE(visibility, 'global')
+			)
+			WHERE content_hash IS NOT NULL AND is_deleted = 0
+		`);
+  }
+  db.exec("CREATE INDEX IF NOT EXISTS idx_documents_agent_project ON documents(agent_id, project)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_documents_source_scope ON documents(source_url, agent_id, project)");
+}
+function up81(db) {
+  db.exec(`
+		CREATE TABLE IF NOT EXISTS aggregate_evidence_sources (
+			aggregate_memory_id TEXT NOT NULL,
+			source_kind TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			source_path TEXT,
+			agent_id TEXT NOT NULL DEFAULT 'default',
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (aggregate_memory_id, source_kind, source_id)
+		);
+		CREATE INDEX IF NOT EXISTS idx_aggregate_evidence_sources_agent
+			ON aggregate_evidence_sources(agent_id, aggregate_memory_id);
+		CREATE INDEX IF NOT EXISTS idx_aggregate_evidence_sources_source
+			ON aggregate_evidence_sources(source_kind, source_id);
+	`);
+}
+function hasColumn11(db, table, column) {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all();
+  return rows.some((row) => row.name === column);
+}
+var COLUMNS = ["harness", "session_id", "tool_use_id", "cwd", "origin", "args"];
+function up82(db) {
+  for (const column of COLUMNS) {
+    if (!hasColumn11(db, "skill_invocations", column)) {
+      db.exec(`ALTER TABLE skill_invocations ADD COLUMN ${column} TEXT`);
+    }
+  }
+  db.exec("DROP INDEX IF EXISTS idx_skill_inv_dedupe");
+  db.exec(`
+		CREATE UNIQUE INDEX idx_skill_inv_dedupe
+		ON skill_invocations(agent_id, harness, session_id, tool_use_id)
+		WHERE harness IS NOT NULL AND session_id IS NOT NULL AND tool_use_id IS NOT NULL
+	`);
+  db.exec("CREATE INDEX IF NOT EXISTS idx_skill_inv_harness ON skill_invocations(harness, created_at)");
+}
+var DEPENDENCY_TYPES = new Set([
+  "uses",
+  "requires",
+  "owned_by",
+  "owns",
+  "blocks",
+  "informs",
+  "maintains",
+  "implements",
+  "built",
+  "depends_on",
+  "related_to",
+  "learned_from",
+  "teaches",
+  "knows",
+  "assumes",
+  "supports_claim",
+  "authored_by",
+  "links_to",
+  "contains",
+  "contains_note",
+  "contradicts",
+  "supersedes",
+  "part_of",
+  "produced_artifact",
+  "precedes",
+  "follows",
+  "triggers",
+  "may_execute",
+  "requires_approval_from",
+  "impacts",
+  "produces",
+  "consumes"
+]);
+function sqlStringList(values) {
+  return [...values].map((value) => `'${value}'`).join(", ");
+}
+function hasTable3(db, table) {
+  return Boolean(db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(table));
+}
+function hasColumn12(db, table, column) {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all();
+  return rows.some((row) => row.name === column);
+}
+function addColumnIfMissing20(db, table, column, definition) {
+  if (!hasColumn12(db, table, column))
+    db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+}
+function documentScopeColumnsPreservingExisting(db) {
+  const preserveAgentId = hasColumn12(db, "documents", "agent_id");
+  const preserveProject = hasColumn12(db, "documents", "project");
+  if (preserveAgentId) {
+    db.exec(`
+			CREATE TEMP TABLE __signet_doc_agent_guard AS
+			SELECT id, agent_id FROM documents
+			WHERE NULLIF(TRIM(agent_id), '') IS NOT NULL
+			  AND NULLIF(TRIM(agent_id), '') <> 'default'
+		`);
+  }
+  if (preserveProject) {
+    db.exec(`
+			CREATE TEMP TABLE __signet_doc_project_guard AS
+			SELECT id, project FROM documents
+			WHERE NULLIF(TRIM(project), '') IS NOT NULL
+		`);
+  }
+  try {
+    up80(db);
+    if (preserveAgentId) {
+      db.exec(`
+				UPDATE documents
+				SET agent_id = (SELECT agent_id FROM __signet_doc_agent_guard WHERE __signet_doc_agent_guard.id = documents.id)
+				WHERE EXISTS (SELECT 1 FROM __signet_doc_agent_guard WHERE __signet_doc_agent_guard.id = documents.id)
+			`);
+    }
+    if (preserveProject) {
+      db.exec(`
+				UPDATE documents
+				SET project = (SELECT project FROM __signet_doc_project_guard WHERE __signet_doc_project_guard.id = documents.id)
+				WHERE EXISTS (SELECT 1 FROM __signet_doc_project_guard WHERE __signet_doc_project_guard.id = documents.id)
+			`);
+    }
+  } finally {
+    db.exec("DROP TABLE IF EXISTS temp.__signet_doc_agent_guard");
+    db.exec("DROP TABLE IF EXISTS temp.__signet_doc_project_guard");
+  }
+}
+function up83(db) {
+  up79(db);
+  if (hasTable3(db, "documents")) {
+    documentScopeColumnsPreservingExisting(db);
+  }
+  up81(db);
+  addColumnIfMissing20(db, "memories", "superseded_by", "TEXT");
+  addColumnIfMissing20(db, "memories", "superseded_at", "TEXT");
+  addColumnIfMissing20(db, "memories", "superseded_reason", "TEXT");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_memories_superseded_by ON memories(superseded_by)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_memories_active_supersession ON memories(is_deleted, superseded_by)");
+  if (!hasTable3(db, "relations") || !hasTable3(db, "entity_dependencies"))
+    return;
+  addColumnIfMissing20(db, "entity_dependencies", "confidence", "REAL");
+  addColumnIfMissing20(db, "entity_dependencies", "reason", "TEXT");
+  addColumnIfMissing20(db, "entity_dependencies", "source_id", "TEXT");
+  addColumnIfMissing20(db, "entity_dependencies", "source_kind", "TEXT");
+  addColumnIfMissing20(db, "entity_dependencies", "proposal_evidence", "TEXT NOT NULL DEFAULT '[]'");
+  addColumnIfMissing20(db, "entity_dependencies", "status", "TEXT NOT NULL DEFAULT 'active'");
+  const relationConfidence = hasColumn12(db, "relations", "confidence") ? "r.confidence" : "NULL";
+  const relationUpdatedAt = hasColumn12(db, "relations", "updated_at") ? "r.updated_at" : "r.created_at";
+  const sourceAgentId = hasColumn12(db, "entities", "agent_id") ? "COALESCE(NULLIF(TRIM(src.agent_id), ''), 'default')" : "'default'";
+  const targetAgentId = hasColumn12(db, "entities", "agent_id") ? "COALESCE(NULLIF(TRIM(dst.agent_id), ''), 'default')" : "'default'";
+  db.exec(`
+		INSERT OR IGNORE INTO entity_dependencies (
+			id,
+			source_entity_id,
+			target_entity_id,
+			agent_id,
+			dependency_type,
+			strength,
+			confidence,
+			reason,
+			created_at,
+			updated_at,
+			source_id,
+			source_kind,
+			proposal_evidence,
+			status
+		)
+		SELECT
+			'relation:' || r.id,
+			r.source_entity_id,
+			r.target_entity_id,
+			COALESCE(${sourceAgentId}, ${targetAgentId}, 'default'),
+			CASE WHEN r.relation_type IN (${sqlStringList(DEPENDENCY_TYPES)}) THEN r.relation_type ELSE 'related_to' END,
+			MAX(0.1, MIN(1.0, COALESCE(r.strength, 0.5))),
+			MAX(0.1, MIN(1.0, COALESCE(${relationConfidence}, 0.7))),
+			'legacy relation backfill: ' || r.relation_type,
+			COALESCE(r.created_at, datetime('now')),
+			COALESCE(${relationUpdatedAt}, r.created_at, datetime('now')),
+			r.id,
+			'relation',
+			'[]',
+			'active'
+		FROM relations r
+		JOIN entities src ON src.id = r.source_entity_id
+		JOIN entities dst ON dst.id = r.target_entity_id
+		WHERE r.source_entity_id <> r.target_entity_id
+		  AND ${sourceAgentId} = ${targetAgentId}
+	`);
+}
+function up84(db) {
+  db.exec(`
+		CREATE TABLE IF NOT EXISTS legacy_markdown_imports (
+			path TEXT PRIMARY KEY,
+			mtime_ms INTEGER NOT NULL,
+			ctime_ms INTEGER NOT NULL,
+			size INTEGER NOT NULL,
+			content_hash TEXT NOT NULL,
+			importer_version INTEGER NOT NULL,
+			chunk_count INTEGER NOT NULL DEFAULT 0,
+			last_imported_at TEXT NOT NULL,
+			last_seen_at TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'imported',
+			error TEXT
+		);
+
+		CREATE TABLE IF NOT EXISTS legacy_markdown_chunks (
+			file_path TEXT NOT NULL,
+			chunk_hash TEXT NOT NULL,
+			chunk_index INTEGER NOT NULL,
+			memory_id TEXT,
+			source_id TEXT,
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (file_path, chunk_hash)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_legacy_markdown_chunks_memory_id
+			ON legacy_markdown_chunks(memory_id);
+	`);
+}
+function up85(db) {
+  const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name IN ('relations', 'entity_dependencies')").all();
+  const tableNames = new Set(tables.map((r) => String(r.name)));
+  if (!tableNames.has("relations") || !tableNames.has("entity_dependencies"))
+    return;
+  const relCols = db.prepare("PRAGMA table_info(relations)").all();
+  const depCols = db.prepare("PRAGMA table_info(entity_dependencies)").all();
+  const rel = new Set(relCols.map((c) => String(c.name)));
+  const dep = new Set(depCols.map((c) => String(c.name)));
+  if (!rel.has("source_entity_id") || !rel.has("relation_type"))
+    return;
+  if (!dep.has("source_entity_id") || !dep.has("dependency_type") || !dep.has("agent_id"))
+    return;
+  const hasRelConfidence = rel.has("confidence");
+  const hasRelUpdated = rel.has("updated_at");
+  const hasDepConfidence = dep.has("confidence");
+  const hasDepReason = dep.has("reason");
+  const hasDepStatus = dep.has("status");
+  const selectParts = ["id", "source_entity_id", "target_entity_id"];
+  const colParts = ["id", "source_entity_id", "target_entity_id"];
+  selectParts.push("relation_type");
+  colParts.push("dependency_type");
+  selectParts.push("strength", "created_at");
+  colParts.push("strength", "created_at");
+  selectParts.push("'default'");
+  colParts.push("agent_id");
+  selectParts.push("NULL");
+  colParts.push("aspect_id");
+  if (hasRelConfidence && hasDepConfidence) {
+    selectParts.push("confidence");
+    colParts.push("confidence");
+  }
+  if (hasDepReason) {
+    selectParts.push("'extracted'");
+    colParts.push("reason");
+  }
+  if (hasDepStatus) {
+    selectParts.push("'active'");
+    colParts.push("status");
+  }
+  if (hasRelUpdated && dep.has("updated_at")) {
+    selectParts.push("updated_at");
+    colParts.push("updated_at");
+  }
+  const selectClause = selectParts.join(", ");
+  const colsClause = colParts.join(", ");
+  db.exec(`INSERT OR IGNORE INTO entity_dependencies (${colsClause})
+		 SELECT ${selectClause}
+		 FROM relations
+		 WHERE source_entity_id IS NOT NULL
+		   AND target_entity_id IS NOT NULL
+		   AND relation_type IS NOT NULL`);
+}
+function addColumnIfMissing21(db, table, column, definition) {
+  const cols = db.prepare(`PRAGMA table_info(${table})`).all();
+  if (cols.some((col) => col.name === column))
+    return;
+  db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+}
+function up86(db) {
+  addColumnIfMissing21(db, "summary_jobs", "content_hash", "TEXT");
+  db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_summary_jobs_agent_session_content_hash
+		ON summary_jobs(agent_id, session_key, content_hash)
+	`);
+}
+function addColumnIfMissing22(db, table, column, definition) {
+  const cols = db.prepare(`PRAGMA table_info(${table})`).all();
+  if (cols.some((col) => col.name === column))
+    return;
+  db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+}
+function up87(db) {
+  addColumnIfMissing22(db, "summary_jobs", "boundary_reason", "TEXT");
+  db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_summary_jobs_boundary_reason
+		ON summary_jobs(agent_id, session_key, boundary_reason)
+	`);
+}
+function up88(db) {
+  db.exec(`
+		CREATE TABLE IF NOT EXISTS transcript_recovery_files (
+			agent_id TEXT NOT NULL,
+			source_path TEXT NOT NULL,
+			harness TEXT NOT NULL,
+			size_bytes INTEGER NOT NULL,
+			mtime_ms INTEGER NOT NULL,
+			content_sha256 TEXT NOT NULL,
+			session_id TEXT NOT NULL,
+			last_scanned_at TEXT NOT NULL,
+			PRIMARY KEY (agent_id, source_path)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_transcript_capture_jobs_agent_session_id
+			ON transcript_capture_jobs(agent_id, session_id, status);
+	`);
+}
+function up89(db) {
+  db.exec(`
+		CREATE TABLE IF NOT EXISTS job_cancellations (
+			id TEXT PRIMARY KEY,
+			source_table TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			status_before TEXT NOT NULL,
+			payload_json TEXT NOT NULL,
+			reason TEXT,
+			actor TEXT NOT NULL,
+			actor_type TEXT NOT NULL,
+			request_id TEXT,
+			created_at TEXT NOT NULL
+		)
+	`);
+  if (!indexExists(db, "job_cancellations", "idx_job_cancellations_source")) {
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_job_cancellations_source
+			 ON job_cancellations(source_table, source_id)`);
+  }
+  if (!indexExists(db, "job_cancellations", "idx_job_cancellations_created_at")) {
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_job_cancellations_created_at
+			 ON job_cancellations(created_at)`);
+  }
+}
+function indexExists(db, table, indexName) {
+  const rows = db.prepare(`PRAGMA index_list(${table})`).all();
+  return rows.some((row) => row.name === indexName);
+}
+function up90(db) {
+  db.exec(`
+		CREATE TABLE IF NOT EXISTS job_archive (
+			id TEXT PRIMARY KEY,
+			source_table TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			status TEXT NOT NULL,
+			payload_json TEXT NOT NULL,
+			archived_at TEXT NOT NULL,
+			archived_by TEXT NOT NULL,
+			reason TEXT,
+			created_at TEXT NOT NULL
+		)
+	`);
+  if (!indexExists2(db, "job_archive", "idx_job_archive_source")) {
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_job_archive_source
+			 ON job_archive(source_table, source_id)`);
+  }
+  if (!indexExists2(db, "job_archive", "idx_job_archive_archived_at")) {
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_job_archive_archived_at
+			 ON job_archive(archived_at)`);
+  }
+}
+function indexExists2(db, table, indexName) {
+  const rows = db.prepare(`PRAGMA index_list(${table})`).all();
+  return rows.some((row) => row.name === indexName);
+}
 var MIGRATIONS = [
   {
     version: 1,
@@ -10088,12 +10593,121 @@ var MIGRATIONS = [
     artifacts: {
       tables: ["api_keys"]
     }
+  },
+  {
+    version: 79,
+    name: "transcript-capture-jobs",
+    up: up79,
+    artifacts: {
+      tables: ["transcript_capture_jobs"]
+    }
+  },
+  {
+    version: 80,
+    name: "document-scope-columns",
+    up: up80,
+    artifacts: {
+      columns: [
+        { table: "documents", column: "agent_id" },
+        { table: "documents", column: "project" }
+      ]
+    }
+  },
+  {
+    version: 81,
+    name: "aggregate-evidence-sources",
+    up: up81,
+    artifacts: {
+      tables: ["aggregate_evidence_sources"]
+    }
+  },
+  {
+    version: 82,
+    name: "skill-invocations-harness",
+    up: up82,
+    artifacts: {
+      columns: [
+        { table: "skill_invocations", column: "harness" },
+        { table: "skill_invocations", column: "tool_use_id" }
+      ]
+    }
+  },
+  {
+    version: 83,
+    name: "memory-lifecycle-repair",
+    up: up83,
+    artifacts: {
+      tables: ["transcript_capture_jobs", "aggregate_evidence_sources", "entity_dependencies"],
+      columns: [
+        { table: "documents", column: "agent_id" },
+        { table: "documents", column: "project" },
+        { table: "memories", column: "superseded_by" },
+        { table: "memories", column: "superseded_at" },
+        { table: "memories", column: "superseded_reason" }
+      ]
+    }
+  },
+  {
+    version: 84,
+    name: "legacy-markdown-import-state",
+    up: up84,
+    artifacts: {
+      tables: ["legacy_markdown_imports", "legacy_markdown_chunks"]
+    }
+  },
+  {
+    version: 85,
+    name: "backfill-relations-to-dependencies",
+    up: up85,
+    artifacts: {
+      tables: ["entity_dependencies"]
+    }
+  },
+  {
+    version: 86,
+    name: "summary-jobs-content-hash",
+    up: up86,
+    artifacts: {
+      columns: [{ table: "summary_jobs", column: "content_hash" }]
+    }
+  },
+  {
+    version: 87,
+    name: "summary-jobs-boundary-reason",
+    up: up87,
+    artifacts: {
+      columns: [{ table: "summary_jobs", column: "boundary_reason" }]
+    }
+  },
+  {
+    version: 88,
+    name: "transcript-recovery-files",
+    up: up88,
+    artifacts: {
+      tables: ["transcript_recovery_files"]
+    }
+  },
+  {
+    version: 89,
+    name: "job-cancellations",
+    up: up89,
+    artifacts: {
+      tables: ["job_cancellations"]
+    }
+  },
+  {
+    version: 90,
+    name: "job-archive",
+    up: up90,
+    artifacts: {
+      tables: ["job_archive"]
+    }
   }
 ];
 var LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1]?.version ?? 0;
 var __filename2 = fileURLToPath(import.meta.url);
 var __dirname2 = dirname(__filename2);
-var import_yaml = __toESM(require_dist(), 1);
+var import_yaml = __toESM2(require_dist(), 1);
 function expandHome(p, home = homedir2()) {
   if (p === "~")
     return home;
@@ -10102,19 +10716,177 @@ function expandHome(p, home = homedir2()) {
   return p;
 }
 var LOCAL_BINDS = new Set(["127.0.0.1", "localhost", "::1", "::ffff:127.0.0.1"]);
-var import_yaml2 = __toESM(require_dist(), 1);
+var import_yaml2 = __toESM2(require_dist(), 1);
+var WORKSPACE_ENV_KEYS = ["SIGNET_PATH", "SIGNET_WORKSPACE"];
+var DEFAULT_AGENTS_DIRNAME = ".agents";
+function normalizeWorkspacePath(pathValue, home = homedir3()) {
+  return resolve(expandHome(pathValue.trim(), home));
+}
+function readTrimmedEnv(env, name) {
+  const value = env[name];
+  if (typeof value !== "string")
+    return;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+function readConfigHome(env, home) {
+  const raw = env.XDG_CONFIG_HOME;
+  if (typeof raw !== "string")
+    return join5(home, ".config");
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? normalizeWorkspacePath(trimmed, home) : join5(home, ".config");
+}
+function isExistingDirectory(path) {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+function isRecord4(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function getWorkspaceConfigPath(env = process.env, home = homedir3()) {
+  return join5(readConfigHome(env, home), "signet", "workspace.json");
+}
+function readConfiguredWorkspacePath(env = process.env, home = homedir3(), options = {}) {
+  const strict = options.strict ?? false;
+  const configPath = getWorkspaceConfigPath(env, home);
+  if (!existsSync4(configPath))
+    return null;
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync3(configPath, "utf-8"));
+  } catch (err) {
+    if (strict) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(`Invalid Signet workspace config at ${configPath}: ${detail}`);
+    }
+    return null;
+  }
+  if (!isRecord4(raw) || !("workspace" in raw)) {
+    if (strict)
+      throw new Error(`Invalid Signet workspace config at ${configPath}: missing workspace`);
+    return null;
+  }
+  const workspace = raw.workspace;
+  if (typeof workspace !== "string" || workspace.trim().length === 0) {
+    if (strict)
+      throw new Error(`Invalid Signet workspace config at ${configPath}: workspace must be a non-empty string`);
+    return null;
+  }
+  return normalizeWorkspacePath(workspace, home);
+}
+function resolveWorkspacePath(options = {}) {
+  const env = options.env ?? process.env;
+  const home = options.home ?? homedir3();
+  const strict = options.strict ?? false;
+  const requireExistingEnvPath = options.requireExistingEnvPath ?? false;
+  const configPath = getWorkspaceConfigPath(env, home);
+  const envPath = resolveEnvWorkspace(env, home, requireExistingEnvPath);
+  const configValue = readConfiguredWorkspacePath(env, home, { strict: envPath ? false : strict });
+  if (envPath) {
+    return {
+      path: envPath,
+      source: "env",
+      configPath,
+      configuredPath: configValue
+    };
+  }
+  if (configValue) {
+    return {
+      path: configValue,
+      source: "config",
+      configPath,
+      configuredPath: configValue
+    };
+  }
+  return {
+    path: join5(home, DEFAULT_AGENTS_DIRNAME),
+    source: "default",
+    configPath,
+    configuredPath: configValue
+  };
+}
+function resolveEnvWorkspace(env, home, requireExisting) {
+  for (const key of WORKSPACE_ENV_KEYS) {
+    const raw = readTrimmedEnv(env, key);
+    if (!raw)
+      continue;
+    const normalized = normalizeWorkspacePath(raw, home);
+    if (!requireExisting || isExistingDirectory(normalized))
+      return normalized;
+    console.warn(`[signet] ${key}="${raw}" does not point to an existing workspace directory; using the default workspace resolution instead.`);
+  }
+  return null;
+}
 var native = null;
 try {
   const esmRequire = createRequire2(import.meta.url);
   native = esmRequire("@signet/native");
 } catch {}
 var SIGNET_SOURCE_CHECKOUT_DIRNAME = "signetai";
+var SIGNET_GIT_ALLOWED_DIRECTORIES = ["skills", "tools", "dreaming"];
 var SIGNET_GIT_PROTECTED_PATHS = [
+  ".daemon",
+  ".shadow",
+  "node_modules",
+  ":(glob)**/node_modules/**",
+  `${SIGNET_SOURCE_CHECKOUT_DIRNAME}`,
+  "memory/backups",
   "memory/memories.db",
-  "memory/memories.db-wal",
-  "memory/memories.db-shm",
-  "memory/memories.db-journal",
-  `${SIGNET_SOURCE_CHECKOUT_DIRNAME}/`
+  ":(glob)memory/memories.db*",
+  ":(glob)memory/**/*.db",
+  ":(glob)memory/**/*.db-*",
+  ":(glob)memory/**/*.db-journal",
+  ":(glob)memory/**/*.db-shm",
+  ":(glob)memory/**/*.db-wal",
+  ":(glob)memory/**/*.sqlite",
+  ":(glob)memory/**/*.sqlite3",
+  ":(glob)**/*.db",
+  ":(glob)**/*.db-*",
+  ":(glob)**/*.db-journal",
+  ":(glob)**/*.db-shm",
+  ":(glob)**/*.db-wal",
+  ":(glob)**/*.sqlite",
+  ":(glob)**/*.sqlite3"
+];
+var SIGNET_GIT_TRACKED_PATHS = [
+  "*.md",
+  ":(glob)**/*.md",
+  "*.json",
+  ":(glob)**/*.json",
+  "*.jsonl",
+  ":(glob)**/*.jsonl",
+  "*.html",
+  ":(glob)**/*.html",
+  "*.yaml",
+  ":(glob)**/*.yaml",
+  "*.yml",
+  ":(glob)**/*.yml",
+  ...SIGNET_GIT_ALLOWED_DIRECTORIES
+];
+var SIGNET_GITIGNORE_PROTECTED_PATTERNS = [
+  ".daemon/",
+  ".shadow/",
+  "node_modules/",
+  `${SIGNET_SOURCE_CHECKOUT_DIRNAME}/`,
+  "memory/memories.db*",
+  "memory/**/*.db",
+  "memory/**/*.db-*",
+  "memory/**/*.db-journal",
+  "memory/**/*.db-shm",
+  "memory/**/*.db-wal",
+  "memory/**/*.sqlite",
+  "memory/**/*.sqlite3",
+  "memory/backups/",
+  "*.db",
+  "*.db-*",
+  "*.db-journal",
+  "*.db-shm",
+  "*.db-wal",
+  "*.sqlite",
+  "*.sqlite3"
 ];
 var DEFAULT_DISCORD_DESKTOP_CACHE_PATH = defaultDiscordDesktopCachePath();
 var DEFAULT_GITHUB_RESOURCE_TYPES = ["issues", "pulls", "discussions", "docs"];
@@ -10122,11 +10894,11 @@ var VALID_GITHUB_RESOURCE_TYPES = new Set(DEFAULT_GITHUB_RESOURCE_TYPES);
 function defaultDiscordDesktopCachePath() {
   switch (platform2()) {
     case "darwin":
-      return resolve3(homedir3(), "Library", "Application Support", "discord");
+      return resolve4(homedir4(), "Library", "Application Support", "discord");
     case "win32":
-      return resolve3(process.env.APPDATA || resolve3(homedir3(), "AppData", "Roaming"), "discord");
+      return resolve4(process.env.APPDATA || resolve4(homedir4(), "AppData", "Roaming"), "discord");
     default:
-      return resolve3(process.env.XDG_CONFIG_HOME || resolve3(homedir3(), ".config"), "discord");
+      return resolve4(process.env.XDG_CONFIG_HOME || resolve4(homedir4(), ".config"), "discord");
   }
 }
 var IDENTITY_FILES = {
@@ -10194,15 +10966,15 @@ function symlinkSkills(sourceDir, targetDir, options = {}) {
     skipped: [],
     errors: []
   };
-  if (!existsSync12(sourceDir)) {
+  if (!existsSync13(sourceDir)) {
     return result;
   }
-  const targetParent = join12(targetDir, "..");
-  if (!existsSync12(targetParent)) {
-    mkdirSync8(targetParent, { recursive: true });
+  const targetParent = join13(targetDir, "..");
+  if (!existsSync13(targetParent)) {
+    mkdirSync9(targetParent, { recursive: true });
   }
-  if (!existsSync12(targetDir)) {
-    mkdirSync8(targetDir, { recursive: true });
+  if (!existsSync13(targetDir)) {
+    mkdirSync9(targetDir, { recursive: true });
   }
   let entries;
   try {
@@ -10215,8 +10987,8 @@ function symlinkSkills(sourceDir, targetDir, options = {}) {
     return result;
   }
   for (const entry of entries) {
-    const srcPath = join12(sourceDir, entry);
-    const destPath = join12(targetDir, entry);
+    const srcPath = join13(sourceDir, entry);
+    const destPath = join13(targetDir, entry);
     try {
       const src = lstatSync(srcPath);
       if (src.isSymbolicLink() || !src.isDirectory()) {
@@ -10257,7 +11029,7 @@ function symlinkSkills(sourceDir, targetDir, options = {}) {
   }
   return result;
 }
-var home = homedir7();
+var home = homedir8();
 var SIGNET_BLOCK_START = "<!-- SIGNET:START -->";
 var SIGNET_BLOCK_END = "<!-- SIGNET:END -->";
 function stripSignetBlock(content) {
@@ -10414,7 +11186,7 @@ class BaseConnector {
   generateHeader(sourcePath, targetName) {
     const name = targetName || this.name;
     const safe = (p) => p.replace(/[\n\r]/g, "");
-    const root = dirname2(sourcePath);
+    const root = dirname3(sourcePath);
     return `# Auto-generated from ${safe(sourcePath)}
 # Source: ${safe(sourcePath)}
 # Generated: ${new Date().toISOString()}
@@ -10450,12 +11222,16 @@ function isSignetGeneratedFile(raw) {
 `).slice(0, 6);
   return lines.some((line, i) => /^#\s+AUTO-GENERATED\s+from\s+.*\s+by\s+Signet/i.test(line) || /^#\s+Auto-generated\s+from\s+/.test(line) && i + 1 < lines.length && /^#\s+Source:\s+/.test(lines[i + 1]));
 }
-function atomicWriteJson(path, data, indent = 2) {
-  const content = `${JSON.stringify(data, null, indent)}
-`;
-  const tmp = join3(dirname2(path), `.${randomBytes(6).toString("hex")}.tmp`);
+function atomicWriteText(path, content, mode) {
+  const tmp = join3(dirname3(path), `.${randomBytes(6).toString("hex")}.tmp`);
+  let writeMode = mode;
+  if (writeMode === undefined) {
+    try {
+      writeMode = statSync2(path).mode & 511;
+    } catch {}
+  }
   try {
-    writeFileSync(tmp, content, "utf-8");
+    writeFileSync(tmp, content, { encoding: "utf-8", mode: writeMode });
     renameSync(tmp, path);
   } catch (err) {
     try {
@@ -10463,6 +11239,25 @@ function atomicWriteJson(path, data, indent = 2) {
     } catch {}
     throw err;
   }
+}
+function atomicWriteJson(path, data, indent = 2) {
+  atomicWriteText(path, `${JSON.stringify(data, null, indent)}
+`);
+}
+function resolvePackagedSignetCommand(bareCommand, scriptDirectory, scriptName, warnOnFallback) {
+  if (process.platform !== "win32")
+    return { command: bareCommand, args: [] };
+  const cliEntry = process.argv[1] ?? "";
+  const scriptPath = join3(cliEntry, "..", "..", scriptDirectory, scriptName);
+  if (cliEntry && existsSync(scriptPath))
+    return { command: process.execPath, args: [scriptPath] };
+  if (warnOnFallback) {
+    console.warn(`[signet] Warning: could not resolve ${scriptName} from argv[1]="${cliEntry}". ` + `MCP server config will use "${bareCommand}" which may fail on Windows without shell:true.`);
+  }
+  return { command: bareCommand, args: [] };
+}
+function resolveSignetMcpCommand() {
+  return resolvePackagedSignetCommand("signet-mcp", "dist", "mcp-stdio.js", true);
 }
 function readManagedTrimmedEnv(name) {
   const value = process.env[name];
@@ -10472,29 +11267,7 @@ function readManagedTrimmedEnv(name) {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 function resolveSignetWorkspacePath(home2 = homedir()) {
-  const configured = readManagedTrimmedEnv("SIGNET_PATH");
-  if (configured)
-    return resolve(expandHome(configured));
-  const defaultWorkspace = join3(home2, ".agents");
-  const configHome = readManagedTrimmedEnv("XDG_CONFIG_HOME") ?? join3(home2, ".config");
-  const workspaceConfigPath = join3(configHome, "signet", "workspace.json");
-  if (!existsSync(workspaceConfigPath))
-    return defaultWorkspace;
-  let raw;
-  try {
-    raw = JSON.parse(readFileSync(workspaceConfigPath, "utf8"));
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    throw new Error(`Invalid Signet workspace config at ${workspaceConfigPath}: ${detail}`);
-  }
-  if (typeof raw !== "object" || raw === null || !("workspace" in raw)) {
-    throw new Error(`Invalid Signet workspace config at ${workspaceConfigPath}: missing workspace`);
-  }
-  const workspace = raw.workspace;
-  if (typeof workspace !== "string" || workspace.trim().length === 0) {
-    throw new Error(`Invalid Signet workspace config at ${workspaceConfigPath}: workspace must be a non-empty string`);
-  }
-  return resolve(expandHome(workspace.trim()));
+  return resolveWorkspacePath({ home: home2, strict: true, requireExistingEnvPath: true }).path;
 }
 function resolveSignetApiKey() {
   return readManagedTrimmedEnv("SIGNET_API_KEY") ?? readManagedTrimmedEnv("SIGNET_TOKEN");
@@ -10502,35 +11275,49 @@ function resolveSignetApiKey() {
 
 // ../../../platform/core/dist/index.js
 import { createRequire as createRequire3 } from "node:module";
-import { dirname as dirname4, join as join4 } from "node:path";
+import { dirname as dirname5, join as join4 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 import { homedir as homedir22 } from "os";
 import { join as join22 } from "path";
 import { createRequire as createRequire22 } from "node:module";
-import { homedir as homedir32, platform as platform22 } from "node:os";
-import { basename as basename2, dirname as dirname32, resolve as resolve32 } from "node:path";
-import { existsSync as existsSync10, readFileSync as readFileSync8, readdirSync as readdirSync4, realpathSync, statSync as statSync4 } from "node:fs";
-import { dirname as dirname6, join as join10 } from "node:path";
-import { homedir as homedir72 } from "node:os";
-var __create2 = Object.create;
-var __getProtoOf2 = Object.getPrototypeOf;
-var __defProp2 = Object.defineProperty;
-var __getOwnPropNames2 = Object.getOwnPropertyNames;
-var __hasOwnProp2 = Object.prototype.hasOwnProperty;
-var __toESM2 = (mod, isNodeMode, target) => {
-  target = mod != null ? __create2(__getProtoOf2(mod)) : {};
-  const to = isNodeMode || !mod || !mod.__esModule ? __defProp2(target, "default", { value: mod, enumerable: true }) : target;
-  for (let key of __getOwnPropNames2(mod))
-    if (!__hasOwnProp2.call(to, key))
-      __defProp2(to, key, {
-        get: () => mod[key],
+import { homedir as homedir42, platform as platform22 } from "node:os";
+import { basename as basename2, dirname as dirname42, resolve as resolve42 } from "node:path";
+import { existsSync as existsSync11, readFileSync as readFileSync9, readdirSync as readdirSync4, realpathSync, statSync as statSync5 } from "node:fs";
+import { dirname as dirname7, join as join11 } from "node:path";
+import { homedir as homedir82 } from "node:os";
+var __create = Object.create;
+var __getProtoOf = Object.getPrototypeOf;
+var __defProp = Object.defineProperty;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+function __accessProp(key) {
+  return this[key];
+}
+var __toESMCache_node;
+var __toESMCache_esm;
+var __toESM = (mod, isNodeMode, target) => {
+  var canCache = mod != null && typeof mod === "object";
+  if (canCache) {
+    var cache = isNodeMode ? __toESMCache_node ??= new WeakMap : __toESMCache_esm ??= new WeakMap;
+    var cached = cache.get(mod);
+    if (cached)
+      return cached;
+  }
+  target = mod != null ? __create(__getProtoOf(mod)) : {};
+  const to = isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target;
+  for (let key of __getOwnPropNames(mod))
+    if (!__hasOwnProp.call(to, key))
+      __defProp(to, key, {
+        get: __accessProp.bind(mod, key),
         enumerable: true
       });
+  if (canCache)
+    cache.set(mod, to);
   return to;
 };
-var __commonJS2 = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
 var __require2 = /* @__PURE__ */ createRequire3(import.meta.url);
-var require_identity2 = __commonJS2((exports) => {
+var require_identity2 = __commonJS((exports) => {
   var ALIAS = Symbol.for("yaml.alias");
   var DOC = Symbol.for("yaml.document");
   var MAP = Symbol.for("yaml.map");
@@ -10582,7 +11369,7 @@ var require_identity2 = __commonJS2((exports) => {
   exports.isScalar = isScalar;
   exports.isSeq = isSeq;
 });
-var require_visit2 = __commonJS2((exports) => {
+var require_visit2 = __commonJS((exports) => {
   var identity = require_identity2();
   var BREAK = Symbol("break visit");
   var SKIP = Symbol("skip children");
@@ -10735,7 +11522,7 @@ var require_visit2 = __commonJS2((exports) => {
   exports.visit = visit;
   exports.visitAsync = visitAsync;
 });
-var require_directives2 = __commonJS2((exports) => {
+var require_directives2 = __commonJS((exports) => {
   var identity = require_identity2();
   var visit = require_visit2();
   var escapeChars = {
@@ -10885,7 +11672,7 @@ var require_directives2 = __commonJS2((exports) => {
   Directives.defaultTags = { "!!": "tag:yaml.org,2002:" };
   exports.Directives = Directives;
 });
-var require_anchors2 = __commonJS2((exports) => {
+var require_anchors2 = __commonJS((exports) => {
   var identity = require_identity2();
   var visit = require_visit2();
   function anchorIsValid(anchor) {
@@ -10945,7 +11732,7 @@ var require_anchors2 = __commonJS2((exports) => {
   exports.createNodeAnchors = createNodeAnchors;
   exports.findNewAnchor = findNewAnchor;
 });
-var require_applyReviver2 = __commonJS2((exports) => {
+var require_applyReviver2 = __commonJS((exports) => {
   function applyReviver(reviver, obj, key, val) {
     if (val && typeof val === "object") {
       if (Array.isArray(val)) {
@@ -10990,7 +11777,7 @@ var require_applyReviver2 = __commonJS2((exports) => {
   }
   exports.applyReviver = applyReviver;
 });
-var require_toJS2 = __commonJS2((exports) => {
+var require_toJS2 = __commonJS((exports) => {
   var identity = require_identity2();
   function toJS(value, arg, ctx) {
     if (Array.isArray(value))
@@ -11015,7 +11802,7 @@ var require_toJS2 = __commonJS2((exports) => {
   }
   exports.toJS = toJS;
 });
-var require_Node2 = __commonJS2((exports) => {
+var require_Node2 = __commonJS((exports) => {
   var applyReviver = require_applyReviver2();
   var identity = require_identity2();
   var toJS = require_toJS2();
@@ -11050,7 +11837,7 @@ var require_Node2 = __commonJS2((exports) => {
   }
   exports.NodeBase = NodeBase;
 });
-var require_Alias2 = __commonJS2((exports) => {
+var require_Alias2 = __commonJS((exports) => {
   var anchors = require_anchors2();
   var visit = require_visit2();
   var identity = require_identity2();
@@ -11156,7 +11943,7 @@ var require_Alias2 = __commonJS2((exports) => {
   }
   exports.Alias = Alias;
 });
-var require_Scalar2 = __commonJS2((exports) => {
+var require_Scalar2 = __commonJS((exports) => {
   var identity = require_identity2();
   var Node = require_Node2();
   var toJS = require_toJS2();
@@ -11182,7 +11969,7 @@ var require_Scalar2 = __commonJS2((exports) => {
   exports.Scalar = Scalar;
   exports.isScalarValue = isScalarValue;
 });
-var require_createNode2 = __commonJS2((exports) => {
+var require_createNode2 = __commonJS((exports) => {
   var Alias = require_Alias2();
   var identity = require_identity2();
   var Scalar = require_Scalar2();
@@ -11252,7 +12039,7 @@ var require_createNode2 = __commonJS2((exports) => {
   }
   exports.createNode = createNode;
 });
-var require_Collection2 = __commonJS2((exports) => {
+var require_Collection2 = __commonJS((exports) => {
   var createNode = require_createNode2();
   var identity = require_identity2();
   var Node = require_Node2();
@@ -11365,7 +12152,7 @@ var require_Collection2 = __commonJS2((exports) => {
   exports.collectionFromPath = collectionFromPath;
   exports.isEmptyPath = isEmptyPath;
 });
-var require_stringifyComment2 = __commonJS2((exports) => {
+var require_stringifyComment2 = __commonJS((exports) => {
   var stringifyComment = (str) => str.replace(/^(?!$)(?: $)?/gm, "#");
   function indentComment(comment, indent) {
     if (/^\n+$/.test(comment))
@@ -11380,7 +12167,7 @@ var require_stringifyComment2 = __commonJS2((exports) => {
   exports.lineComment = lineComment;
   exports.stringifyComment = stringifyComment;
 });
-var require_foldFlowLines2 = __commonJS2((exports) => {
+var require_foldFlowLines2 = __commonJS((exports) => {
   var FOLD_FLOW = "flow";
   var FOLD_BLOCK = "block";
   var FOLD_QUOTED = "quoted";
@@ -11515,7 +12302,7 @@ ${indent}${text.slice(fold + 1, end2)}`;
   exports.FOLD_QUOTED = FOLD_QUOTED;
   exports.foldFlowLines = foldFlowLines;
 });
-var require_stringifyString2 = __commonJS2((exports) => {
+var require_stringifyString2 = __commonJS((exports) => {
   var Scalar = require_Scalar2();
   var foldFlowLines = require_foldFlowLines2();
   var getFoldOptions = (ctx, isBlock) => ({
@@ -11811,7 +12598,7 @@ ${indent}`);
   }
   exports.stringifyString = stringifyString;
 });
-var require_stringify2 = __commonJS2((exports) => {
+var require_stringify2 = __commonJS((exports) => {
   var anchors = require_anchors2();
   var identity = require_identity2();
   var stringifyComment = require_stringifyComment2();
@@ -11930,7 +12717,7 @@ ${ctx.indent}${str}`;
   exports.createStringifyContext = createStringifyContext;
   exports.stringify = stringify;
 });
-var require_stringifyPair2 = __commonJS2((exports) => {
+var require_stringifyPair2 = __commonJS((exports) => {
   var identity = require_identity2();
   var Scalar = require_Scalar2();
   var stringify = require_stringify2();
@@ -12064,7 +12851,7 @@ ${ctx.indent}`;
   }
   exports.stringifyPair = stringifyPair;
 });
-var require_log2 = __commonJS2((exports) => {
+var require_log2 = __commonJS((exports) => {
   var node_process = __require2("process");
   function debug(logLevel, ...messages) {
     if (logLevel === "debug")
@@ -12081,7 +12868,7 @@ var require_log2 = __commonJS2((exports) => {
   exports.debug = debug;
   exports.warn = warn;
 });
-var require_merge2 = __commonJS2((exports) => {
+var require_merge2 = __commonJS((exports) => {
   var identity = require_identity2();
   var Scalar = require_Scalar2();
   var MERGE_KEY = "<<";
@@ -12133,7 +12920,7 @@ var require_merge2 = __commonJS2((exports) => {
   exports.isMergeKey = isMergeKey;
   exports.merge = merge;
 });
-var require_addPairToJSMap2 = __commonJS2((exports) => {
+var require_addPairToJSMap2 = __commonJS((exports) => {
   var log = require_log2();
   var merge = require_merge2();
   var stringify = require_stringify2();
@@ -12192,7 +12979,7 @@ var require_addPairToJSMap2 = __commonJS2((exports) => {
   }
   exports.addPairToJSMap = addPairToJSMap;
 });
-var require_Pair2 = __commonJS2((exports) => {
+var require_Pair2 = __commonJS((exports) => {
   var createNode = require_createNode2();
   var stringifyPair = require_stringifyPair2();
   var addPairToJSMap = require_addPairToJSMap2();
@@ -12228,7 +13015,7 @@ var require_Pair2 = __commonJS2((exports) => {
   exports.Pair = Pair;
   exports.createPair = createPair;
 });
-var require_stringifyCollection2 = __commonJS2((exports) => {
+var require_stringifyCollection2 = __commonJS((exports) => {
   var identity = require_identity2();
   var stringify = require_stringify2();
   var stringifyComment = require_stringifyComment2();
@@ -12378,7 +13165,7 @@ ${indent}${end}`;
   }
   exports.stringifyCollection = stringifyCollection;
 });
-var require_YAMLMap2 = __commonJS2((exports) => {
+var require_YAMLMap2 = __commonJS((exports) => {
   var stringifyCollection = require_stringifyCollection2();
   var addPairToJSMap = require_addPairToJSMap2();
   var Collection = require_Collection2();
@@ -12503,7 +13290,7 @@ var require_YAMLMap2 = __commonJS2((exports) => {
   exports.YAMLMap = YAMLMap;
   exports.findPair = findPair;
 });
-var require_map2 = __commonJS2((exports) => {
+var require_map2 = __commonJS((exports) => {
   var identity = require_identity2();
   var YAMLMap = require_YAMLMap2();
   var map = {
@@ -12520,7 +13307,7 @@ var require_map2 = __commonJS2((exports) => {
   };
   exports.map = map;
 });
-var require_YAMLSeq2 = __commonJS2((exports) => {
+var require_YAMLSeq2 = __commonJS((exports) => {
   var createNode = require_createNode2();
   var stringifyCollection = require_stringifyCollection2();
   var Collection = require_Collection2();
@@ -12611,7 +13398,7 @@ var require_YAMLSeq2 = __commonJS2((exports) => {
   }
   exports.YAMLSeq = YAMLSeq;
 });
-var require_seq2 = __commonJS2((exports) => {
+var require_seq2 = __commonJS((exports) => {
   var identity = require_identity2();
   var YAMLSeq = require_YAMLSeq2();
   var seq = {
@@ -12628,7 +13415,7 @@ var require_seq2 = __commonJS2((exports) => {
   };
   exports.seq = seq;
 });
-var require_string2 = __commonJS2((exports) => {
+var require_string2 = __commonJS((exports) => {
   var stringifyString = require_stringifyString2();
   var string = {
     identify: (value) => typeof value === "string",
@@ -12642,7 +13429,7 @@ var require_string2 = __commonJS2((exports) => {
   };
   exports.string = string;
 });
-var require_null2 = __commonJS2((exports) => {
+var require_null2 = __commonJS((exports) => {
   var Scalar = require_Scalar2();
   var nullTag = {
     identify: (value) => value == null,
@@ -12655,7 +13442,7 @@ var require_null2 = __commonJS2((exports) => {
   };
   exports.nullTag = nullTag;
 });
-var require_bool3 = __commonJS2((exports) => {
+var require_bool3 = __commonJS((exports) => {
   var Scalar = require_Scalar2();
   var boolTag = {
     identify: (value) => typeof value === "boolean",
@@ -12674,7 +13461,7 @@ var require_bool3 = __commonJS2((exports) => {
   };
   exports.boolTag = boolTag;
 });
-var require_stringifyNumber2 = __commonJS2((exports) => {
+var require_stringifyNumber2 = __commonJS((exports) => {
   function stringifyNumber({ format, minFractionDigits, tag, value }) {
     if (typeof value === "bigint")
       return String(value);
@@ -12696,7 +13483,7 @@ var require_stringifyNumber2 = __commonJS2((exports) => {
   }
   exports.stringifyNumber = stringifyNumber;
 });
-var require_float3 = __commonJS2((exports) => {
+var require_float3 = __commonJS((exports) => {
   var Scalar = require_Scalar2();
   var stringifyNumber = require_stringifyNumber2();
   var floatNaN = {
@@ -12737,7 +13524,7 @@ var require_float3 = __commonJS2((exports) => {
   exports.floatExp = floatExp;
   exports.floatNaN = floatNaN;
 });
-var require_int3 = __commonJS2((exports) => {
+var require_int3 = __commonJS((exports) => {
   var stringifyNumber = require_stringifyNumber2();
   var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
   var intResolve = (str, offset, radix, { intAsBigInt }) => intAsBigInt ? BigInt(str) : parseInt(str.substring(offset), radix);
@@ -12777,7 +13564,7 @@ var require_int3 = __commonJS2((exports) => {
   exports.intHex = intHex;
   exports.intOct = intOct;
 });
-var require_schema4 = __commonJS2((exports) => {
+var require_schema4 = __commonJS((exports) => {
   var map = require_map2();
   var _null = require_null2();
   var seq = require_seq2();
@@ -12800,7 +13587,7 @@ var require_schema4 = __commonJS2((exports) => {
   ];
   exports.schema = schema;
 });
-var require_schema22 = __commonJS2((exports) => {
+var require_schema22 = __commonJS((exports) => {
   var Scalar = require_Scalar2();
   var map = require_map2();
   var seq = require_seq2();
@@ -12862,7 +13649,7 @@ var require_schema22 = __commonJS2((exports) => {
   var schema = [map.map, seq.seq].concat(jsonScalars, jsonError);
   exports.schema = schema;
 });
-var require_binary2 = __commonJS2((exports) => {
+var require_binary2 = __commonJS((exports) => {
   var node_buffer = __require2("buffer");
   var Scalar = require_Scalar2();
   var stringifyString = require_stringifyString2();
@@ -12915,7 +13702,7 @@ var require_binary2 = __commonJS2((exports) => {
   };
   exports.binary = binary;
 });
-var require_pairs2 = __commonJS2((exports) => {
+var require_pairs2 = __commonJS((exports) => {
   var identity = require_identity2();
   var Pair = require_Pair2();
   var Scalar = require_Scalar2();
@@ -12988,7 +13775,7 @@ ${cn.comment}` : item.comment;
   exports.pairs = pairs;
   exports.resolvePairs = resolvePairs;
 });
-var require_omap2 = __commonJS2((exports) => {
+var require_omap2 = __commonJS((exports) => {
   var identity = require_identity2();
   var toJS = require_toJS2();
   var YAMLMap = require_YAMLMap2();
@@ -13058,7 +13845,7 @@ var require_omap2 = __commonJS2((exports) => {
   exports.YAMLOMap = YAMLOMap;
   exports.omap = omap;
 });
-var require_bool22 = __commonJS2((exports) => {
+var require_bool22 = __commonJS((exports) => {
   var Scalar = require_Scalar2();
   function boolStringify({ value, source }, ctx) {
     const boolObj = value ? trueTag : falseTag;
@@ -13085,7 +13872,7 @@ var require_bool22 = __commonJS2((exports) => {
   exports.falseTag = falseTag;
   exports.trueTag = trueTag;
 });
-var require_float22 = __commonJS2((exports) => {
+var require_float22 = __commonJS((exports) => {
   var Scalar = require_Scalar2();
   var stringifyNumber = require_stringifyNumber2();
   var floatNaN = {
@@ -13129,7 +13916,7 @@ var require_float22 = __commonJS2((exports) => {
   exports.floatExp = floatExp;
   exports.floatNaN = floatNaN;
 });
-var require_int22 = __commonJS2((exports) => {
+var require_int22 = __commonJS((exports) => {
   var stringifyNumber = require_stringifyNumber2();
   var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
   function intResolve(str, offset, radix, { intAsBigInt }) {
@@ -13203,7 +13990,7 @@ var require_int22 = __commonJS2((exports) => {
   exports.intHex = intHex;
   exports.intOct = intOct;
 });
-var require_set2 = __commonJS2((exports) => {
+var require_set2 = __commonJS((exports) => {
   var identity = require_identity2();
   var Pair = require_Pair2();
   var YAMLMap = require_YAMLMap2();
@@ -13284,7 +14071,7 @@ var require_set2 = __commonJS2((exports) => {
   exports.YAMLSet = YAMLSet;
   exports.set = set;
 });
-var require_timestamp2 = __commonJS2((exports) => {
+var require_timestamp2 = __commonJS((exports) => {
   var stringifyNumber = require_stringifyNumber2();
   function parseSexagesimal(str, asBigInt) {
     const sign = str[0];
@@ -13364,7 +14151,7 @@ var require_timestamp2 = __commonJS2((exports) => {
   exports.intTime = intTime;
   exports.timestamp = timestamp;
 });
-var require_schema32 = __commonJS2((exports) => {
+var require_schema32 = __commonJS((exports) => {
   var map = require_map2();
   var _null = require_null2();
   var seq = require_seq2();
@@ -13403,7 +14190,7 @@ var require_schema32 = __commonJS2((exports) => {
   ];
   exports.schema = schema;
 });
-var require_tags2 = __commonJS2((exports) => {
+var require_tags2 = __commonJS((exports) => {
   var map = require_map2();
   var _null = require_null2();
   var seq = require_seq2();
@@ -13492,7 +14279,7 @@ var require_tags2 = __commonJS2((exports) => {
   exports.coreKnownTags = coreKnownTags;
   exports.getTags = getTags;
 });
-var require_Schema2 = __commonJS2((exports) => {
+var require_Schema2 = __commonJS((exports) => {
   var identity = require_identity2();
   var map = require_map2();
   var seq = require_seq2();
@@ -13520,7 +14307,7 @@ var require_Schema2 = __commonJS2((exports) => {
   }
   exports.Schema = Schema;
 });
-var require_stringifyDocument2 = __commonJS2((exports) => {
+var require_stringifyDocument2 = __commonJS((exports) => {
   var identity = require_identity2();
   var stringify = require_stringify2();
   var stringifyComment = require_stringifyComment2();
@@ -13598,7 +14385,7 @@ var require_stringifyDocument2 = __commonJS2((exports) => {
   }
   exports.stringifyDocument = stringifyDocument;
 });
-var require_Document2 = __commonJS2((exports) => {
+var require_Document2 = __commonJS((exports) => {
   var Alias = require_Alias2();
   var Collection = require_Collection2();
   var identity = require_identity2();
@@ -13831,7 +14618,7 @@ var require_Document2 = __commonJS2((exports) => {
   }
   exports.Document = Document;
 });
-var require_errors2 = __commonJS2((exports) => {
+var require_errors2 = __commonJS((exports) => {
 
   class YAMLError extends Error {
     constructor(name, pos, code, message) {
@@ -13895,7 +14682,7 @@ ${pointer}
   exports.YAMLWarning = YAMLWarning;
   exports.prettifyError = prettifyError;
 });
-var require_resolve_props2 = __commonJS2((exports) => {
+var require_resolve_props2 = __commonJS((exports) => {
   function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIndent, startOnNewline }) {
     let spaceBefore = false;
     let atNewline = startOnNewline;
@@ -14023,7 +14810,7 @@ var require_resolve_props2 = __commonJS2((exports) => {
   }
   exports.resolveProps = resolveProps;
 });
-var require_util_contains_newline2 = __commonJS2((exports) => {
+var require_util_contains_newline2 = __commonJS((exports) => {
   function containsNewline(key) {
     if (!key)
       return null;
@@ -14061,7 +14848,7 @@ var require_util_contains_newline2 = __commonJS2((exports) => {
   }
   exports.containsNewline = containsNewline;
 });
-var require_util_flow_indent_check2 = __commonJS2((exports) => {
+var require_util_flow_indent_check2 = __commonJS((exports) => {
   var utilContainsNewline = require_util_contains_newline2();
   function flowIndentCheck(indent, fc, onError) {
     if (fc?.type === "flow-collection") {
@@ -14074,7 +14861,7 @@ var require_util_flow_indent_check2 = __commonJS2((exports) => {
   }
   exports.flowIndentCheck = flowIndentCheck;
 });
-var require_util_map_includes2 = __commonJS2((exports) => {
+var require_util_map_includes2 = __commonJS((exports) => {
   var identity = require_identity2();
   function mapIncludes(ctx, items, search) {
     const { uniqueKeys } = ctx.options;
@@ -14085,7 +14872,7 @@ var require_util_map_includes2 = __commonJS2((exports) => {
   }
   exports.mapIncludes = mapIncludes;
 });
-var require_resolve_block_map2 = __commonJS2((exports) => {
+var require_resolve_block_map2 = __commonJS((exports) => {
   var Pair = require_Pair2();
   var YAMLMap = require_YAMLMap2();
   var resolveProps = require_resolve_props2();
@@ -14190,7 +14977,7 @@ var require_resolve_block_map2 = __commonJS2((exports) => {
   }
   exports.resolveBlockMap = resolveBlockMap;
 });
-var require_resolve_block_seq2 = __commonJS2((exports) => {
+var require_resolve_block_seq2 = __commonJS((exports) => {
   var YAMLSeq = require_YAMLSeq2();
   var resolveProps = require_resolve_props2();
   var utilFlowIndentCheck = require_util_flow_indent_check2();
@@ -14236,7 +15023,7 @@ var require_resolve_block_seq2 = __commonJS2((exports) => {
   }
   exports.resolveBlockSeq = resolveBlockSeq;
 });
-var require_resolve_end2 = __commonJS2((exports) => {
+var require_resolve_end2 = __commonJS((exports) => {
   function resolveEnd(end, offset, reqSpace, onError) {
     let comment = "";
     if (end) {
@@ -14274,7 +15061,7 @@ var require_resolve_end2 = __commonJS2((exports) => {
   }
   exports.resolveEnd = resolveEnd;
 });
-var require_resolve_flow_collection2 = __commonJS2((exports) => {
+var require_resolve_flow_collection2 = __commonJS((exports) => {
   var identity = require_identity2();
   var Pair = require_Pair2();
   var YAMLMap = require_YAMLMap2();
@@ -14463,7 +15250,7 @@ var require_resolve_flow_collection2 = __commonJS2((exports) => {
   }
   exports.resolveFlowCollection = resolveFlowCollection;
 });
-var require_compose_collection2 = __commonJS2((exports) => {
+var require_compose_collection2 = __commonJS((exports) => {
   var identity = require_identity2();
   var Scalar = require_Scalar2();
   var YAMLMap = require_YAMLMap2();
@@ -14523,7 +15310,7 @@ var require_compose_collection2 = __commonJS2((exports) => {
   }
   exports.composeCollection = composeCollection;
 });
-var require_resolve_block_scalar2 = __commonJS2((exports) => {
+var require_resolve_block_scalar2 = __commonJS((exports) => {
   var Scalar = require_Scalar2();
   function resolveBlockScalar(ctx, scalar, onError) {
     const start = scalar.offset;
@@ -14714,7 +15501,7 @@ var require_resolve_block_scalar2 = __commonJS2((exports) => {
   }
   exports.resolveBlockScalar = resolveBlockScalar;
 });
-var require_resolve_flow_scalar2 = __commonJS2((exports) => {
+var require_resolve_flow_scalar2 = __commonJS((exports) => {
   var Scalar = require_Scalar2();
   var resolveEnd = require_resolve_end2();
   function resolveFlowScalar(scalar, strict, onError) {
@@ -14928,7 +15715,7 @@ var require_resolve_flow_scalar2 = __commonJS2((exports) => {
   }
   exports.resolveFlowScalar = resolveFlowScalar;
 });
-var require_compose_scalar2 = __commonJS2((exports) => {
+var require_compose_scalar2 = __commonJS((exports) => {
   var identity = require_identity2();
   var Scalar = require_Scalar2();
   var resolveBlockScalar = require_resolve_block_scalar2();
@@ -15004,7 +15791,7 @@ var require_compose_scalar2 = __commonJS2((exports) => {
   }
   exports.composeScalar = composeScalar;
 });
-var require_util_empty_scalar_position2 = __commonJS2((exports) => {
+var require_util_empty_scalar_position2 = __commonJS((exports) => {
   function emptyScalarPosition(offset, before, pos) {
     if (before) {
       pos ?? (pos = before.length);
@@ -15029,7 +15816,7 @@ var require_util_empty_scalar_position2 = __commonJS2((exports) => {
   }
   exports.emptyScalarPosition = emptyScalarPosition;
 });
-var require_compose_node2 = __commonJS2((exports) => {
+var require_compose_node2 = __commonJS((exports) => {
   var Alias = require_Alias2();
   var identity = require_identity2();
   var composeCollection = require_compose_collection2();
@@ -15130,7 +15917,7 @@ var require_compose_node2 = __commonJS2((exports) => {
   exports.composeEmptyNode = composeEmptyNode;
   exports.composeNode = composeNode;
 });
-var require_compose_doc2 = __commonJS2((exports) => {
+var require_compose_doc2 = __commonJS((exports) => {
   var Document = require_Document2();
   var composeNode = require_compose_node2();
   var resolveEnd = require_resolve_end2();
@@ -15168,7 +15955,7 @@ var require_compose_doc2 = __commonJS2((exports) => {
   }
   exports.composeDoc = composeDoc;
 });
-var require_composer2 = __commonJS2((exports) => {
+var require_composer2 = __commonJS((exports) => {
   var node_process = __require2("process");
   var directives = require_directives2();
   var Document = require_Document2();
@@ -15355,7 +16142,7 @@ ${end.comment}` : end.comment;
   }
   exports.Composer = Composer;
 });
-var require_cst_scalar2 = __commonJS2((exports) => {
+var require_cst_scalar2 = __commonJS((exports) => {
   var resolveBlockScalar = require_resolve_block_scalar2();
   var resolveFlowScalar = require_resolve_flow_scalar2();
   var errors = require_errors2();
@@ -15543,7 +16330,7 @@ var require_cst_scalar2 = __commonJS2((exports) => {
   exports.resolveAsScalar = resolveAsScalar;
   exports.setScalarValue = setScalarValue;
 });
-var require_cst_stringify2 = __commonJS2((exports) => {
+var require_cst_stringify2 = __commonJS((exports) => {
   var stringify = (cst) => ("type" in cst) ? stringifyToken(cst) : stringifyItem(cst);
   function stringifyToken(token) {
     switch (token.type) {
@@ -15599,7 +16386,7 @@ var require_cst_stringify2 = __commonJS2((exports) => {
   }
   exports.stringify = stringify;
 });
-var require_cst_visit2 = __commonJS2((exports) => {
+var require_cst_visit2 = __commonJS((exports) => {
   var BREAK = Symbol("break visit");
   var SKIP = Symbol("skip children");
   var REMOVE = Symbol("remove item");
@@ -15656,7 +16443,7 @@ var require_cst_visit2 = __commonJS2((exports) => {
   }
   exports.visit = visit;
 });
-var require_cst2 = __commonJS2((exports) => {
+var require_cst2 = __commonJS((exports) => {
   var cstScalar = require_cst_scalar2();
   var cstStringify = require_cst_stringify2();
   var cstVisit = require_cst_visit2();
@@ -15755,7 +16542,7 @@ var require_cst2 = __commonJS2((exports) => {
   exports.prettyToken = prettyToken;
   exports.tokenType = tokenType;
 });
-var require_lexer2 = __commonJS2((exports) => {
+var require_lexer2 = __commonJS((exports) => {
   var cst = require_cst2();
   function isEmpty(ch) {
     switch (ch) {
@@ -16339,7 +17126,7 @@ var require_lexer2 = __commonJS2((exports) => {
   }
   exports.Lexer = Lexer;
 });
-var require_line_counter2 = __commonJS2((exports) => {
+var require_line_counter2 = __commonJS((exports) => {
 
   class LineCounter {
     constructor() {
@@ -16366,7 +17153,7 @@ var require_line_counter2 = __commonJS2((exports) => {
   }
   exports.LineCounter = LineCounter;
 });
-var require_parser2 = __commonJS2((exports) => {
+var require_parser2 = __commonJS((exports) => {
   var node_process = __require2("process");
   var cst = require_cst2();
   var lexer = require_lexer2();
@@ -17213,7 +18000,7 @@ var require_parser2 = __commonJS2((exports) => {
   }
   exports.Parser = Parser;
 });
-var require_public_api2 = __commonJS2((exports) => {
+var require_public_api2 = __commonJS((exports) => {
   var composer = require_composer2();
   var Document = require_Document2();
   var errors = require_errors2();
@@ -17305,7 +18092,7 @@ var require_public_api2 = __commonJS2((exports) => {
   exports.parseDocument = parseDocument;
   exports.stringify = stringify;
 });
-var require_dist2 = __commonJS2((exports) => {
+var require_dist2 = __commonJS((exports) => {
   var composer = require_composer2();
   var Document = require_Document2();
   var Schema = require_Schema2();
@@ -17418,7 +18205,7 @@ function memoriesFtsNeedsTokenizerRepair2(sql) {
     return true;
   return !normalized.includes(`tokenize='${MEMORIES_FTS_TOKENIZER2}'`);
 }
-function up79(db) {
+function up91(db) {
   db.exec(`
 		CREATE TABLE IF NOT EXISTS schema_migrations (
 			version INTEGER PRIMARY KEY,
@@ -17507,31 +18294,31 @@ function up79(db) {
   } catch {}
   createMemoriesFts2(db);
 }
-function hasColumn10(db, table, column) {
+function hasColumn13(db, table, column) {
   const rows = db.prepare(`PRAGMA table_info(${table})`).all();
   return rows.some((r) => r.name === column);
 }
-function addColumnIfMissing20(db, table, column, definition) {
-  if (!hasColumn10(db, table, column)) {
+function addColumnIfMissing23(db, table, column, definition) {
+  if (!hasColumn13(db, table, column)) {
     db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
   }
 }
 function up210(db) {
-  addColumnIfMissing20(db, "memories", "content_hash", "TEXT");
-  addColumnIfMissing20(db, "memories", "normalized_content", "TEXT");
-  addColumnIfMissing20(db, "memories", "is_deleted", "INTEGER DEFAULT 0");
-  addColumnIfMissing20(db, "memories", "deleted_at", "TEXT");
-  addColumnIfMissing20(db, "memories", "extraction_status", "TEXT DEFAULT 'none'");
-  addColumnIfMissing20(db, "memories", "embedding_model", "TEXT");
-  addColumnIfMissing20(db, "memories", "extraction_model", "TEXT");
-  addColumnIfMissing20(db, "memories", "update_count", "INTEGER DEFAULT 0");
-  addColumnIfMissing20(db, "memories", "who", "TEXT");
-  addColumnIfMissing20(db, "memories", "why", "TEXT");
-  addColumnIfMissing20(db, "memories", "project", "TEXT");
-  addColumnIfMissing20(db, "memories", "pinned", "INTEGER DEFAULT 0");
-  addColumnIfMissing20(db, "memories", "importance", "REAL DEFAULT 0.5");
-  addColumnIfMissing20(db, "memories", "last_accessed", "TEXT");
-  addColumnIfMissing20(db, "memories", "access_count", "INTEGER DEFAULT 0");
+  addColumnIfMissing23(db, "memories", "content_hash", "TEXT");
+  addColumnIfMissing23(db, "memories", "normalized_content", "TEXT");
+  addColumnIfMissing23(db, "memories", "is_deleted", "INTEGER DEFAULT 0");
+  addColumnIfMissing23(db, "memories", "deleted_at", "TEXT");
+  addColumnIfMissing23(db, "memories", "extraction_status", "TEXT DEFAULT 'none'");
+  addColumnIfMissing23(db, "memories", "embedding_model", "TEXT");
+  addColumnIfMissing23(db, "memories", "extraction_model", "TEXT");
+  addColumnIfMissing23(db, "memories", "update_count", "INTEGER DEFAULT 0");
+  addColumnIfMissing23(db, "memories", "who", "TEXT");
+  addColumnIfMissing23(db, "memories", "why", "TEXT");
+  addColumnIfMissing23(db, "memories", "project", "TEXT");
+  addColumnIfMissing23(db, "memories", "pinned", "INTEGER DEFAULT 0");
+  addColumnIfMissing23(db, "memories", "importance", "REAL DEFAULT 0.5");
+  addColumnIfMissing23(db, "memories", "last_accessed", "TEXT");
+  addColumnIfMissing23(db, "memories", "access_count", "INTEGER DEFAULT 0");
   db.exec(`
 		CREATE TABLE IF NOT EXISTS memory_history (
 			id TEXT PRIMARY KEY,
@@ -17627,7 +18414,7 @@ function up210(db) {
 			ON memory_entity_mentions(entity_id);
 	`);
 }
-function addColumnIfMissing22(db, table, column, definition) {
+function addColumnIfMissing24(db, table, column, definition) {
   const rows = db.prepare(`PRAGMA table_info(${table})`).all();
   if (rows.some((r) => r.name === column))
     return false;
@@ -17635,8 +18422,8 @@ function addColumnIfMissing22(db, table, column, definition) {
   return true;
 }
 function up310(db) {
-  addColumnIfMissing22(db, "memories", "why", "TEXT");
-  addColumnIfMissing22(db, "memories", "project", "TEXT");
+  addColumnIfMissing24(db, "memories", "why", "TEXT");
+  addColumnIfMissing24(db, "memories", "project", "TEXT");
   db.exec(`DROP INDEX IF EXISTS idx_memories_content_hash`);
   db.exec(`
 		UPDATE memories
@@ -17793,7 +18580,7 @@ function up710(db) {
     db.exec("ALTER TABLE memory_jobs ADD COLUMN document_id TEXT");
   }
 }
-function up82(db) {
+function up810(db) {
   const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='embeddings'").all();
   if (tables.length === 0)
     return;
@@ -19062,7 +19849,7 @@ function up492(db) {
 		);
 	`);
 }
-function hasTable3(db, name) {
+function hasTable4(db, name) {
   return db.prepare(`SELECT name
 			 FROM sqlite_master
 			 WHERE type = 'table' AND name = ?
@@ -19092,7 +19879,7 @@ function up502(db) {
 		CREATE INDEX IF NOT EXISTS idx_entity_dependency_history_created
 			ON entity_dependency_history(created_at DESC);
 	`);
-  if (!hasTable3(db, "entity_dependencies"))
+  if (!hasTable4(db, "entity_dependencies"))
     return;
   db.exec("DROP TRIGGER IF EXISTS trg_entity_dependencies_related_to_reason_insert");
   db.exec("DROP TRIGGER IF EXISTS trg_entity_dependencies_related_to_reason_update");
@@ -19945,11 +20732,499 @@ function up782(db) {
 			ON api_keys(connector, harness);
 	`);
 }
+function up792(db) {
+  db.exec(`
+		CREATE TABLE IF NOT EXISTS transcript_capture_jobs (
+			id TEXT PRIMARY KEY,
+			agent_id TEXT NOT NULL DEFAULT 'default',
+			harness TEXT NOT NULL,
+			session_key TEXT,
+			session_id TEXT NOT NULL,
+			project TEXT,
+			transcript TEXT NOT NULL,
+			raw_transcript TEXT,
+			transcript_path TEXT,
+			captured_at TEXT NOT NULL,
+			ended_at TEXT,
+			summary_status TEXT NOT NULL DEFAULT 'not_requested',
+			status TEXT NOT NULL DEFAULT 'pending',
+			attempts INTEGER NOT NULL DEFAULT 0,
+			max_attempts INTEGER NOT NULL DEFAULT 5,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			completed_at TEXT,
+			error TEXT
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_transcript_capture_jobs_status
+			ON transcript_capture_jobs(status, created_at);
+
+		CREATE INDEX IF NOT EXISTS idx_transcript_capture_jobs_agent_session
+			ON transcript_capture_jobs(agent_id, session_key, created_at);
+	`);
+}
+function hasColumn102(db, table, column) {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all();
+  return rows.some((row) => row.name === column);
+}
+function up802(db) {
+  if (!hasColumn102(db, "documents", "agent_id")) {
+    db.exec("ALTER TABLE documents ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'default'");
+  }
+  if (!hasColumn102(db, "documents", "project")) {
+    db.exec("ALTER TABLE documents ADD COLUMN project TEXT");
+  }
+  db.exec(`
+		UPDATE documents
+		SET agent_id = NULLIF(TRIM(json_extract(metadata_json, '$.signet.agentId')), '')
+		WHERE metadata_json IS NOT NULL
+		  AND json_valid(metadata_json)
+		  AND json_type(metadata_json, '$.signet.agentId') = 'text'
+		  AND NULLIF(TRIM(json_extract(metadata_json, '$.signet.agentId')), '') IS NOT NULL
+	`);
+  db.exec(`
+		UPDATE documents
+		SET project = NULLIF(TRIM(json_extract(metadata_json, '$.signet.project')), '')
+		WHERE metadata_json IS NOT NULL
+		  AND json_valid(metadata_json)
+		  AND json_type(metadata_json, '$.signet.project') = 'text'
+	`);
+  db.exec(`
+		WITH linked_scope AS (
+			SELECT
+				dm.document_id,
+				m.agent_id,
+				m.project,
+				ROW_NUMBER() OVER (
+					PARTITION BY dm.document_id
+					ORDER BY COUNT(*) DESC, m.agent_id, COALESCE(m.project, '')
+				) AS rank
+			FROM document_memories dm
+			JOIN memories m ON m.id = dm.memory_id
+			WHERE m.agent_id IS NOT NULL
+			  AND NULLIF(TRIM(m.agent_id), '') IS NOT NULL
+			GROUP BY dm.document_id, m.agent_id, m.project
+		)
+		UPDATE documents
+		SET
+			agent_id = COALESCE((
+				SELECT agent_id FROM linked_scope
+				WHERE linked_scope.document_id = documents.id AND rank = 1
+			), agent_id),
+			project = (
+				SELECT project FROM linked_scope
+				WHERE linked_scope.document_id = documents.id AND rank = 1
+			)
+		WHERE EXISTS (
+			SELECT 1 FROM linked_scope
+			WHERE linked_scope.document_id = documents.id AND rank = 1
+		)
+		AND NOT (
+			metadata_json IS NOT NULL
+			AND json_valid(metadata_json)
+			AND json_type(metadata_json, '$.signet.agentId') = 'text'
+			AND NULLIF(TRIM(json_extract(metadata_json, '$.signet.agentId')), '') IS NOT NULL
+		)
+	`);
+  if (hasColumn102(db, "memories", "visibility") && hasColumn102(db, "memories", "type") && hasColumn102(db, "memories", "source_type")) {
+    db.exec(`
+			UPDATE memories
+			SET visibility = 'private'
+			WHERE id IN (SELECT memory_id FROM document_memories)
+			  AND type = 'document_chunk'
+			  AND source_type = 'document'
+			  AND (visibility IS NULL OR visibility = 'global')
+		`);
+  }
+  if (hasColumn102(db, "memories", "content_hash") && hasColumn102(db, "memories", "agent_id") && hasColumn102(db, "memories", "project") && hasColumn102(db, "memories", "scope") && hasColumn102(db, "memories", "visibility") && hasColumn102(db, "memories", "is_deleted")) {
+    db.exec("DROP INDEX IF EXISTS idx_memories_content_hash_unique");
+    db.exec(`
+			CREATE UNIQUE INDEX idx_memories_content_hash_unique
+			ON memories(
+				content_hash,
+				COALESCE(NULLIF(agent_id, ''), 'default'),
+				COALESCE(project, ''),
+				COALESCE(scope, '__NULL__'),
+				COALESCE(visibility, 'global')
+			)
+			WHERE content_hash IS NOT NULL AND is_deleted = 0
+		`);
+  }
+  db.exec("CREATE INDEX IF NOT EXISTS idx_documents_agent_project ON documents(agent_id, project)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_documents_source_scope ON documents(source_url, agent_id, project)");
+}
+function up812(db) {
+  db.exec(`
+		CREATE TABLE IF NOT EXISTS aggregate_evidence_sources (
+			aggregate_memory_id TEXT NOT NULL,
+			source_kind TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			source_path TEXT,
+			agent_id TEXT NOT NULL DEFAULT 'default',
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (aggregate_memory_id, source_kind, source_id)
+		);
+		CREATE INDEX IF NOT EXISTS idx_aggregate_evidence_sources_agent
+			ON aggregate_evidence_sources(agent_id, aggregate_memory_id);
+		CREATE INDEX IF NOT EXISTS idx_aggregate_evidence_sources_source
+			ON aggregate_evidence_sources(source_kind, source_id);
+	`);
+}
+function hasColumn112(db, table, column) {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all();
+  return rows.some((row) => row.name === column);
+}
+var COLUMNS2 = ["harness", "session_id", "tool_use_id", "cwd", "origin", "args"];
+function up822(db) {
+  for (const column of COLUMNS2) {
+    if (!hasColumn112(db, "skill_invocations", column)) {
+      db.exec(`ALTER TABLE skill_invocations ADD COLUMN ${column} TEXT`);
+    }
+  }
+  db.exec("DROP INDEX IF EXISTS idx_skill_inv_dedupe");
+  db.exec(`
+		CREATE UNIQUE INDEX idx_skill_inv_dedupe
+		ON skill_invocations(agent_id, harness, session_id, tool_use_id)
+		WHERE harness IS NOT NULL AND session_id IS NOT NULL AND tool_use_id IS NOT NULL
+	`);
+  db.exec("CREATE INDEX IF NOT EXISTS idx_skill_inv_harness ON skill_invocations(harness, created_at)");
+}
+var DEPENDENCY_TYPES2 = new Set([
+  "uses",
+  "requires",
+  "owned_by",
+  "owns",
+  "blocks",
+  "informs",
+  "maintains",
+  "implements",
+  "built",
+  "depends_on",
+  "related_to",
+  "learned_from",
+  "teaches",
+  "knows",
+  "assumes",
+  "supports_claim",
+  "authored_by",
+  "links_to",
+  "contains",
+  "contains_note",
+  "contradicts",
+  "supersedes",
+  "part_of",
+  "produced_artifact",
+  "precedes",
+  "follows",
+  "triggers",
+  "may_execute",
+  "requires_approval_from",
+  "impacts",
+  "produces",
+  "consumes"
+]);
+function sqlStringList2(values) {
+  return [...values].map((value) => `'${value}'`).join(", ");
+}
+function hasTable32(db, table) {
+  return Boolean(db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(table));
+}
+function hasColumn122(db, table, column) {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all();
+  return rows.some((row) => row.name === column);
+}
+function addColumnIfMissing202(db, table, column, definition) {
+  if (!hasColumn122(db, table, column))
+    db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+}
+function documentScopeColumnsPreservingExisting2(db) {
+  const preserveAgentId = hasColumn122(db, "documents", "agent_id");
+  const preserveProject = hasColumn122(db, "documents", "project");
+  if (preserveAgentId) {
+    db.exec(`
+			CREATE TEMP TABLE __signet_doc_agent_guard AS
+			SELECT id, agent_id FROM documents
+			WHERE NULLIF(TRIM(agent_id), '') IS NOT NULL
+			  AND NULLIF(TRIM(agent_id), '') <> 'default'
+		`);
+  }
+  if (preserveProject) {
+    db.exec(`
+			CREATE TEMP TABLE __signet_doc_project_guard AS
+			SELECT id, project FROM documents
+			WHERE NULLIF(TRIM(project), '') IS NOT NULL
+		`);
+  }
+  try {
+    up802(db);
+    if (preserveAgentId) {
+      db.exec(`
+				UPDATE documents
+				SET agent_id = (SELECT agent_id FROM __signet_doc_agent_guard WHERE __signet_doc_agent_guard.id = documents.id)
+				WHERE EXISTS (SELECT 1 FROM __signet_doc_agent_guard WHERE __signet_doc_agent_guard.id = documents.id)
+			`);
+    }
+    if (preserveProject) {
+      db.exec(`
+				UPDATE documents
+				SET project = (SELECT project FROM __signet_doc_project_guard WHERE __signet_doc_project_guard.id = documents.id)
+				WHERE EXISTS (SELECT 1 FROM __signet_doc_project_guard WHERE __signet_doc_project_guard.id = documents.id)
+			`);
+    }
+  } finally {
+    db.exec("DROP TABLE IF EXISTS temp.__signet_doc_agent_guard");
+    db.exec("DROP TABLE IF EXISTS temp.__signet_doc_project_guard");
+  }
+}
+function up832(db) {
+  up792(db);
+  if (hasTable32(db, "documents")) {
+    documentScopeColumnsPreservingExisting2(db);
+  }
+  up812(db);
+  addColumnIfMissing202(db, "memories", "superseded_by", "TEXT");
+  addColumnIfMissing202(db, "memories", "superseded_at", "TEXT");
+  addColumnIfMissing202(db, "memories", "superseded_reason", "TEXT");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_memories_superseded_by ON memories(superseded_by)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_memories_active_supersession ON memories(is_deleted, superseded_by)");
+  if (!hasTable32(db, "relations") || !hasTable32(db, "entity_dependencies"))
+    return;
+  addColumnIfMissing202(db, "entity_dependencies", "confidence", "REAL");
+  addColumnIfMissing202(db, "entity_dependencies", "reason", "TEXT");
+  addColumnIfMissing202(db, "entity_dependencies", "source_id", "TEXT");
+  addColumnIfMissing202(db, "entity_dependencies", "source_kind", "TEXT");
+  addColumnIfMissing202(db, "entity_dependencies", "proposal_evidence", "TEXT NOT NULL DEFAULT '[]'");
+  addColumnIfMissing202(db, "entity_dependencies", "status", "TEXT NOT NULL DEFAULT 'active'");
+  const relationConfidence = hasColumn122(db, "relations", "confidence") ? "r.confidence" : "NULL";
+  const relationUpdatedAt = hasColumn122(db, "relations", "updated_at") ? "r.updated_at" : "r.created_at";
+  const sourceAgentId = hasColumn122(db, "entities", "agent_id") ? "COALESCE(NULLIF(TRIM(src.agent_id), ''), 'default')" : "'default'";
+  const targetAgentId = hasColumn122(db, "entities", "agent_id") ? "COALESCE(NULLIF(TRIM(dst.agent_id), ''), 'default')" : "'default'";
+  db.exec(`
+		INSERT OR IGNORE INTO entity_dependencies (
+			id,
+			source_entity_id,
+			target_entity_id,
+			agent_id,
+			dependency_type,
+			strength,
+			confidence,
+			reason,
+			created_at,
+			updated_at,
+			source_id,
+			source_kind,
+			proposal_evidence,
+			status
+		)
+		SELECT
+			'relation:' || r.id,
+			r.source_entity_id,
+			r.target_entity_id,
+			COALESCE(${sourceAgentId}, ${targetAgentId}, 'default'),
+			CASE WHEN r.relation_type IN (${sqlStringList2(DEPENDENCY_TYPES2)}) THEN r.relation_type ELSE 'related_to' END,
+			MAX(0.1, MIN(1.0, COALESCE(r.strength, 0.5))),
+			MAX(0.1, MIN(1.0, COALESCE(${relationConfidence}, 0.7))),
+			'legacy relation backfill: ' || r.relation_type,
+			COALESCE(r.created_at, datetime('now')),
+			COALESCE(${relationUpdatedAt}, r.created_at, datetime('now')),
+			r.id,
+			'relation',
+			'[]',
+			'active'
+		FROM relations r
+		JOIN entities src ON src.id = r.source_entity_id
+		JOIN entities dst ON dst.id = r.target_entity_id
+		WHERE r.source_entity_id <> r.target_entity_id
+		  AND ${sourceAgentId} = ${targetAgentId}
+	`);
+}
+function up842(db) {
+  db.exec(`
+		CREATE TABLE IF NOT EXISTS legacy_markdown_imports (
+			path TEXT PRIMARY KEY,
+			mtime_ms INTEGER NOT NULL,
+			ctime_ms INTEGER NOT NULL,
+			size INTEGER NOT NULL,
+			content_hash TEXT NOT NULL,
+			importer_version INTEGER NOT NULL,
+			chunk_count INTEGER NOT NULL DEFAULT 0,
+			last_imported_at TEXT NOT NULL,
+			last_seen_at TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'imported',
+			error TEXT
+		);
+
+		CREATE TABLE IF NOT EXISTS legacy_markdown_chunks (
+			file_path TEXT NOT NULL,
+			chunk_hash TEXT NOT NULL,
+			chunk_index INTEGER NOT NULL,
+			memory_id TEXT,
+			source_id TEXT,
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (file_path, chunk_hash)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_legacy_markdown_chunks_memory_id
+			ON legacy_markdown_chunks(memory_id);
+	`);
+}
+function up852(db) {
+  const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name IN ('relations', 'entity_dependencies')").all();
+  const tableNames = new Set(tables.map((r) => String(r.name)));
+  if (!tableNames.has("relations") || !tableNames.has("entity_dependencies"))
+    return;
+  const relCols = db.prepare("PRAGMA table_info(relations)").all();
+  const depCols = db.prepare("PRAGMA table_info(entity_dependencies)").all();
+  const rel = new Set(relCols.map((c) => String(c.name)));
+  const dep = new Set(depCols.map((c) => String(c.name)));
+  if (!rel.has("source_entity_id") || !rel.has("relation_type"))
+    return;
+  if (!dep.has("source_entity_id") || !dep.has("dependency_type") || !dep.has("agent_id"))
+    return;
+  const hasRelConfidence = rel.has("confidence");
+  const hasRelUpdated = rel.has("updated_at");
+  const hasDepConfidence = dep.has("confidence");
+  const hasDepReason = dep.has("reason");
+  const hasDepStatus = dep.has("status");
+  const selectParts = ["id", "source_entity_id", "target_entity_id"];
+  const colParts = ["id", "source_entity_id", "target_entity_id"];
+  selectParts.push("relation_type");
+  colParts.push("dependency_type");
+  selectParts.push("strength", "created_at");
+  colParts.push("strength", "created_at");
+  selectParts.push("'default'");
+  colParts.push("agent_id");
+  selectParts.push("NULL");
+  colParts.push("aspect_id");
+  if (hasRelConfidence && hasDepConfidence) {
+    selectParts.push("confidence");
+    colParts.push("confidence");
+  }
+  if (hasDepReason) {
+    selectParts.push("'extracted'");
+    colParts.push("reason");
+  }
+  if (hasDepStatus) {
+    selectParts.push("'active'");
+    colParts.push("status");
+  }
+  if (hasRelUpdated && dep.has("updated_at")) {
+    selectParts.push("updated_at");
+    colParts.push("updated_at");
+  }
+  const selectClause = selectParts.join(", ");
+  const colsClause = colParts.join(", ");
+  db.exec(`INSERT OR IGNORE INTO entity_dependencies (${colsClause})
+		 SELECT ${selectClause}
+		 FROM relations
+		 WHERE source_entity_id IS NOT NULL
+		   AND target_entity_id IS NOT NULL
+		   AND relation_type IS NOT NULL`);
+}
+function addColumnIfMissing212(db, table, column, definition) {
+  const cols = db.prepare(`PRAGMA table_info(${table})`).all();
+  if (cols.some((col) => col.name === column))
+    return;
+  db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+}
+function up862(db) {
+  addColumnIfMissing212(db, "summary_jobs", "content_hash", "TEXT");
+  db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_summary_jobs_agent_session_content_hash
+		ON summary_jobs(agent_id, session_key, content_hash)
+	`);
+}
+function addColumnIfMissing222(db, table, column, definition) {
+  const cols = db.prepare(`PRAGMA table_info(${table})`).all();
+  if (cols.some((col) => col.name === column))
+    return;
+  db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+}
+function up872(db) {
+  addColumnIfMissing222(db, "summary_jobs", "boundary_reason", "TEXT");
+  db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_summary_jobs_boundary_reason
+		ON summary_jobs(agent_id, session_key, boundary_reason)
+	`);
+}
+function up882(db) {
+  db.exec(`
+		CREATE TABLE IF NOT EXISTS transcript_recovery_files (
+			agent_id TEXT NOT NULL,
+			source_path TEXT NOT NULL,
+			harness TEXT NOT NULL,
+			size_bytes INTEGER NOT NULL,
+			mtime_ms INTEGER NOT NULL,
+			content_sha256 TEXT NOT NULL,
+			session_id TEXT NOT NULL,
+			last_scanned_at TEXT NOT NULL,
+			PRIMARY KEY (agent_id, source_path)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_transcript_capture_jobs_agent_session_id
+			ON transcript_capture_jobs(agent_id, session_id, status);
+	`);
+}
+function up892(db) {
+  db.exec(`
+		CREATE TABLE IF NOT EXISTS job_cancellations (
+			id TEXT PRIMARY KEY,
+			source_table TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			status_before TEXT NOT NULL,
+			payload_json TEXT NOT NULL,
+			reason TEXT,
+			actor TEXT NOT NULL,
+			actor_type TEXT NOT NULL,
+			request_id TEXT,
+			created_at TEXT NOT NULL
+		)
+	`);
+  if (!indexExists3(db, "job_cancellations", "idx_job_cancellations_source")) {
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_job_cancellations_source
+			 ON job_cancellations(source_table, source_id)`);
+  }
+  if (!indexExists3(db, "job_cancellations", "idx_job_cancellations_created_at")) {
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_job_cancellations_created_at
+			 ON job_cancellations(created_at)`);
+  }
+}
+function indexExists3(db, table, indexName) {
+  const rows = db.prepare(`PRAGMA index_list(${table})`).all();
+  return rows.some((row) => row.name === indexName);
+}
+function up902(db) {
+  db.exec(`
+		CREATE TABLE IF NOT EXISTS job_archive (
+			id TEXT PRIMARY KEY,
+			source_table TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			status TEXT NOT NULL,
+			payload_json TEXT NOT NULL,
+			archived_at TEXT NOT NULL,
+			archived_by TEXT NOT NULL,
+			reason TEXT,
+			created_at TEXT NOT NULL
+		)
+	`);
+  if (!indexExists22(db, "job_archive", "idx_job_archive_source")) {
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_job_archive_source
+			 ON job_archive(source_table, source_id)`);
+  }
+  if (!indexExists22(db, "job_archive", "idx_job_archive_archived_at")) {
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_job_archive_archived_at
+			 ON job_archive(archived_at)`);
+  }
+}
+function indexExists22(db, table, indexName) {
+  const rows = db.prepare(`PRAGMA index_list(${table})`).all();
+  return rows.some((row) => row.name === indexName);
+}
 var MIGRATIONS2 = [
   {
     version: 1,
     name: "baseline",
-    up: up79,
+    up: up91,
     artifacts: { tables: ["memories", "conversations", "embeddings"] }
   },
   {
@@ -19998,7 +21273,7 @@ var MIGRATIONS2 = [
   {
     version: 8,
     name: "embeddings-unique-hash",
-    up: up82
+    up: up810
   },
   {
     version: 9,
@@ -20571,12 +21846,121 @@ var MIGRATIONS2 = [
     artifacts: {
       tables: ["api_keys"]
     }
+  },
+  {
+    version: 79,
+    name: "transcript-capture-jobs",
+    up: up792,
+    artifacts: {
+      tables: ["transcript_capture_jobs"]
+    }
+  },
+  {
+    version: 80,
+    name: "document-scope-columns",
+    up: up802,
+    artifacts: {
+      columns: [
+        { table: "documents", column: "agent_id" },
+        { table: "documents", column: "project" }
+      ]
+    }
+  },
+  {
+    version: 81,
+    name: "aggregate-evidence-sources",
+    up: up812,
+    artifacts: {
+      tables: ["aggregate_evidence_sources"]
+    }
+  },
+  {
+    version: 82,
+    name: "skill-invocations-harness",
+    up: up822,
+    artifacts: {
+      columns: [
+        { table: "skill_invocations", column: "harness" },
+        { table: "skill_invocations", column: "tool_use_id" }
+      ]
+    }
+  },
+  {
+    version: 83,
+    name: "memory-lifecycle-repair",
+    up: up832,
+    artifacts: {
+      tables: ["transcript_capture_jobs", "aggregate_evidence_sources", "entity_dependencies"],
+      columns: [
+        { table: "documents", column: "agent_id" },
+        { table: "documents", column: "project" },
+        { table: "memories", column: "superseded_by" },
+        { table: "memories", column: "superseded_at" },
+        { table: "memories", column: "superseded_reason" }
+      ]
+    }
+  },
+  {
+    version: 84,
+    name: "legacy-markdown-import-state",
+    up: up842,
+    artifacts: {
+      tables: ["legacy_markdown_imports", "legacy_markdown_chunks"]
+    }
+  },
+  {
+    version: 85,
+    name: "backfill-relations-to-dependencies",
+    up: up852,
+    artifacts: {
+      tables: ["entity_dependencies"]
+    }
+  },
+  {
+    version: 86,
+    name: "summary-jobs-content-hash",
+    up: up862,
+    artifacts: {
+      columns: [{ table: "summary_jobs", column: "content_hash" }]
+    }
+  },
+  {
+    version: 87,
+    name: "summary-jobs-boundary-reason",
+    up: up872,
+    artifacts: {
+      columns: [{ table: "summary_jobs", column: "boundary_reason" }]
+    }
+  },
+  {
+    version: 88,
+    name: "transcript-recovery-files",
+    up: up882,
+    artifacts: {
+      tables: ["transcript_recovery_files"]
+    }
+  },
+  {
+    version: 89,
+    name: "job-cancellations",
+    up: up892,
+    artifacts: {
+      tables: ["job_cancellations"]
+    }
+  },
+  {
+    version: 90,
+    name: "job-archive",
+    up: up902,
+    artifacts: {
+      tables: ["job_archive"]
+    }
   }
 ];
 var LATEST_SCHEMA_VERSION2 = MIGRATIONS2[MIGRATIONS2.length - 1]?.version ?? 0;
 var __filename22 = fileURLToPath2(import.meta.url);
-var __dirname22 = dirname4(__filename22);
-var import_yaml3 = __toESM2(require_dist2(), 1);
+var __dirname22 = dirname5(__filename22);
+var import_yaml3 = __toESM(require_dist2(), 1);
 function expandHome2(p, home2 = homedir22()) {
   if (p === "~")
     return home2;
@@ -20585,7 +21969,7 @@ function expandHome2(p, home2 = homedir22()) {
   return p;
 }
 var LOCAL_BINDS2 = new Set(["127.0.0.1", "localhost", "::1", "::ffff:127.0.0.1"]);
-var import_yaml22 = __toESM2(require_dist2(), 1);
+var import_yaml22 = __toESM(require_dist2(), 1);
 function parseSimpleYaml(text) {
   try {
     const parsed = import_yaml22.default.parse(text);
@@ -20660,6 +22044,8 @@ function resolveSignetDaemonUrl(opts = {}) {
   const explicit = readEnv(env, "SIGNET_DAEMON_URL");
   if (explicit)
     return normalizeDaemonUrl(explicit, "SIGNET_DAEMON_URL");
+  if (opts.configUrl)
+    return normalizeDaemonUrl(opts.configUrl, "daemon.url");
   const host = readEnv(env, "SIGNET_HOST") ?? fallbackHost;
   assertPlainHost(host);
   const port = normalizePort(readEnv(env, "SIGNET_PORT"), fallbackPort);
@@ -20671,12 +22057,67 @@ try {
   native2 = esmRequire("@signet/native");
 } catch {}
 var SIGNET_SOURCE_CHECKOUT_DIRNAME2 = "signetai";
+var SIGNET_GIT_ALLOWED_DIRECTORIES2 = ["skills", "tools", "dreaming"];
 var SIGNET_GIT_PROTECTED_PATHS2 = [
+  ".daemon",
+  ".shadow",
+  "node_modules",
+  ":(glob)**/node_modules/**",
+  `${SIGNET_SOURCE_CHECKOUT_DIRNAME2}`,
+  "memory/backups",
   "memory/memories.db",
-  "memory/memories.db-wal",
-  "memory/memories.db-shm",
-  "memory/memories.db-journal",
-  `${SIGNET_SOURCE_CHECKOUT_DIRNAME2}/`
+  ":(glob)memory/memories.db*",
+  ":(glob)memory/**/*.db",
+  ":(glob)memory/**/*.db-*",
+  ":(glob)memory/**/*.db-journal",
+  ":(glob)memory/**/*.db-shm",
+  ":(glob)memory/**/*.db-wal",
+  ":(glob)memory/**/*.sqlite",
+  ":(glob)memory/**/*.sqlite3",
+  ":(glob)**/*.db",
+  ":(glob)**/*.db-*",
+  ":(glob)**/*.db-journal",
+  ":(glob)**/*.db-shm",
+  ":(glob)**/*.db-wal",
+  ":(glob)**/*.sqlite",
+  ":(glob)**/*.sqlite3"
+];
+var SIGNET_GIT_TRACKED_PATHS2 = [
+  "*.md",
+  ":(glob)**/*.md",
+  "*.json",
+  ":(glob)**/*.json",
+  "*.jsonl",
+  ":(glob)**/*.jsonl",
+  "*.html",
+  ":(glob)**/*.html",
+  "*.yaml",
+  ":(glob)**/*.yaml",
+  "*.yml",
+  ":(glob)**/*.yml",
+  ...SIGNET_GIT_ALLOWED_DIRECTORIES2
+];
+var SIGNET_GITIGNORE_PROTECTED_PATTERNS2 = [
+  ".daemon/",
+  ".shadow/",
+  "node_modules/",
+  `${SIGNET_SOURCE_CHECKOUT_DIRNAME2}/`,
+  "memory/memories.db*",
+  "memory/**/*.db",
+  "memory/**/*.db-*",
+  "memory/**/*.db-journal",
+  "memory/**/*.db-shm",
+  "memory/**/*.db-wal",
+  "memory/**/*.sqlite",
+  "memory/**/*.sqlite3",
+  "memory/backups/",
+  "*.db",
+  "*.db-*",
+  "*.db-journal",
+  "*.db-shm",
+  "*.db-wal",
+  "*.sqlite",
+  "*.sqlite3"
 ];
 var DEFAULT_DISCORD_DESKTOP_CACHE_PATH2 = defaultDiscordDesktopCachePath2();
 var DEFAULT_GITHUB_RESOURCE_TYPES2 = ["issues", "pulls", "discussions", "docs"];
@@ -20684,14 +22125,14 @@ var VALID_GITHUB_RESOURCE_TYPES2 = new Set(DEFAULT_GITHUB_RESOURCE_TYPES2);
 function defaultDiscordDesktopCachePath2() {
   switch (platform22()) {
     case "darwin":
-      return resolve32(homedir32(), "Library", "Application Support", "discord");
+      return resolve42(homedir42(), "Library", "Application Support", "discord");
     case "win32":
-      return resolve32(process.env.APPDATA || resolve32(homedir32(), "AppData", "Roaming"), "discord");
+      return resolve42(process.env.APPDATA || resolve42(homedir42(), "AppData", "Roaming"), "discord");
     default:
-      return resolve32(process.env.XDG_CONFIG_HOME || resolve32(homedir32(), ".config"), "discord");
+      return resolve42(process.env.XDG_CONFIG_HOME || resolve42(homedir42(), ".config"), "discord");
   }
 }
-var IDENTITY_MODES = ["managed", "passthrough", "off"];
+var IDENTITY_MODES = ["managed", "off"];
 var IDENTITY_FILES2 = {
   agents: {
     path: "AGENTS.md",
@@ -20753,7 +22194,7 @@ function hasValidIdentity(basePath) {
     return true;
   for (const key of REQUIRED_IDENTITY_KEYS2) {
     const spec = IDENTITY_FILES2[key];
-    if (!existsSync10(join10(basePath, spec.path))) {
+    if (!existsSync11(join11(basePath, spec.path))) {
       return false;
     }
   }
@@ -20771,24 +22212,28 @@ function resolveIdentityModeFromConfig(config) {
   const capabilityIdentity = readRecord(capabilities.identity);
   if (isIdentityMode(capabilityIdentity.mode))
     return capabilityIdentity.mode;
+  if (capabilityIdentity.mode === "passthrough")
+    return "off";
   const identity = readRecord(root.identity);
   if (isIdentityMode(identity.mode))
     return identity.mode;
+  if (identity.mode === "passthrough")
+    return "off";
   if (identity.enabled === false)
     return "off";
   return "managed";
 }
 function loadIdentityMode(agentsDir) {
-  const agentYaml = join10(agentsDir, "agent.yaml");
-  if (!existsSync10(agentYaml))
+  const agentYaml = join11(agentsDir, "agent.yaml");
+  if (!existsSync11(agentYaml))
     return "managed";
   try {
-    return resolveIdentityModeFromConfig(parseSimpleYaml(readFileSync8(agentYaml, "utf-8")));
+    return resolveIdentityModeFromConfig(parseSimpleYaml(readFileSync9(agentYaml, "utf-8")));
   } catch {
     return "managed";
   }
 }
-var home2 = homedir72();
+var home2 = homedir82();
 var SKIP_SUBTYPES2 = new Set([
   "channel_join",
   "channel_leave",
@@ -20911,7 +22356,7 @@ var SIGNET_FORGE_MARKER = "Managed by Signet (@signet/connector-forge)";
 function isJsonObject(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
-function readTrimmedEnv(name) {
+function readTrimmedEnv2(name) {
   const value = process.env[name];
   if (typeof value !== "string")
     return;
@@ -20919,8 +22364,8 @@ function readTrimmedEnv(name) {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 function getHomeDir() {
-  const home3 = readTrimmedEnv("HOME");
-  return home3 ?? homedir4();
+  const home3 = readTrimmedEnv2("HOME");
+  return home3 ?? homedir5();
 }
 function readJsonObject(path) {
   if (!existsSync2(path))
@@ -20940,9 +22385,9 @@ function readMcpServers(config) {
 }
 function signetRuntimeEnv(basePath) {
   const env = { SIGNET_PATH: basePath };
-  const daemonUrl = readTrimmedEnv("SIGNET_DAEMON_URL");
-  const apiKey = readTrimmedEnv("SIGNET_API_KEY") ?? readTrimmedEnv("SIGNET_TOKEN");
-  const agentId = readTrimmedEnv("SIGNET_AGENT_ID");
+  const daemonUrl = readTrimmedEnv2("SIGNET_DAEMON_URL");
+  const apiKey = readTrimmedEnv2("SIGNET_API_KEY") ?? readTrimmedEnv2("SIGNET_TOKEN");
+  const agentId = readTrimmedEnv2("SIGNET_AGENT_ID");
   if (daemonUrl)
     env.SIGNET_DAEMON_URL = daemonUrl;
   if (apiKey)
@@ -20952,17 +22397,7 @@ function signetRuntimeEnv(basePath) {
   return env;
 }
 function resolveRemoteDaemonUrl() {
-  return readTrimmedEnv("SIGNET_DAEMON_URL") ? resolveSignetDaemonUrl() : null;
-}
-function resolveSignetMcp() {
-  if (process.platform !== "win32")
-    return { command: "signet-mcp", args: [] };
-  const cliEntry = process.argv[1] || "";
-  const mcpJs = join6(cliEntry, "..", "..", "dist", "mcp-stdio.js");
-  if (existsSync2(mcpJs))
-    return { command: process.execPath, args: [mcpJs] };
-  console.warn(`[signet] Warning: could not resolve mcp-stdio.js from argv[1]="${cliEntry}". ` + `MCP server config will use "signet-mcp" which may fail on Windows without shell:true.`);
-  return { command: "signet-mcp", args: [] };
+  return readTrimmedEnv2("SIGNET_DAEMON_URL") ? resolveSignetDaemonUrl() : null;
 }
 function buildMcpServer(basePath) {
   const remoteDaemonUrl = resolveRemoteDaemonUrl();
@@ -20973,7 +22408,7 @@ function buildMcpServer(basePath) {
       ...apiKey ? { headers: { Authorization: `Bearer ${apiKey}` } } : {}
     };
   }
-  const mcp = resolveSignetMcp();
+  const mcp = resolveSignetMcpCommand();
   return {
     command: mcp.command,
     ...mcp.args && mcp.args.length > 0 ? { args: mcp.args } : {},
@@ -20989,7 +22424,7 @@ class ForgeConnector extends BaseConnector {
   name = "ForgeCode";
   harnessId = "forge";
   getForgeHome() {
-    const configured = readTrimmedEnv("FORGE_CONFIG");
+    const configured = readTrimmedEnv2("FORGE_CONFIG");
     if (configured)
       return resolve2(expandHome2(configured));
     const legacyPath = join6(getHomeDir(), "forge");
@@ -21040,7 +22475,7 @@ class ForgeConnector extends BaseConnector {
         try {
           const raw = readFileSync2(staleAgentsPath, "utf-8");
           if (isSignetGeneratedFile(raw) || raw.includes(SIGNET_FORGE_MARKER))
-            rmSync(staleAgentsPath);
+            rmSync2(staleAgentsPath);
         } catch {}
       }
     }
@@ -21076,7 +22511,7 @@ class ForgeConnector extends BaseConnector {
       try {
         const raw = readFileSync2(agentsPath, "utf-8");
         if (isSignetGeneratedFile(raw) || raw.includes(SIGNET_FORGE_MARKER)) {
-          rmSync(agentsPath, { force: true });
+          rmSync2(agentsPath, { force: true });
           filesRemoved.push(agentsPath);
         }
       } catch {}
@@ -21096,7 +22531,7 @@ class ForgeConnector extends BaseConnector {
         const patched = this.removeMcpServer(config);
         if (patched) {
           if (Object.keys(config).length === 0) {
-            rmSync(this.getMcpConfigPath(), { force: true });
+            rmSync2(this.getMcpConfigPath(), { force: true });
             filesRemoved.push(this.getMcpConfigPath());
           } else {
             atomicWriteJson(this.getMcpConfigPath(), config);
@@ -21117,7 +22552,7 @@ class ForgeConnector extends BaseConnector {
   }
   static isHarnessInstalled() {
     const home3 = getHomeDir();
-    return existsSync2(readTrimmedEnv("FORGE_CONFIG") ?? "") || existsSync2(join6(home3, "forge", ".mcp.json")) || existsSync2(join6(home3, ".forge", ".mcp.json")) || existsSync2(join6(home3, "forge")) || existsSync2(join6(home3, ".forge"));
+    return existsSync2(readTrimmedEnv2("FORGE_CONFIG") ?? "") || existsSync2(join6(home3, "forge", ".mcp.json")) || existsSync2(join6(home3, ".forge", ".mcp.json")) || existsSync2(join6(home3, "forge")) || existsSync2(join6(home3, ".forge"));
   }
   getAgentsPath() {
     return join6(this.getForgeHome(), "AGENTS.md");
@@ -21138,7 +22573,7 @@ class ForgeConnector extends BaseConnector {
     const body = extras ? `${userContent}${extras}` : userContent;
     const header = this.generateHeader(sourcePath, this.name);
     const targetPath = this.getAgentsPath();
-    writeFileSync2(targetPath, `# ${SIGNET_FORGE_MARKER}
+    writeFileSync3(targetPath, `# ${SIGNET_FORGE_MARKER}
 ${header}${body}
 `, "utf-8");
     return targetPath;
@@ -21154,7 +22589,7 @@ ${header}${body}
       return false;
     const { signet: _, ...rest } = servers;
     if (Object.keys(rest).length === 0) {
-      delete config.mcpServers;
+      Reflect.deleteProperty(config, "mcpServers");
     } else {
       config.mcpServers = rest;
     }
@@ -21199,7 +22634,7 @@ ${header}${body}
     }
     try {
       if (readdirSync(skillsDir).length === 0)
-        rmSync(skillsDir, { recursive: true, force: true });
+        rmSync2(skillsDir, { recursive: true, force: true });
     } catch {}
   }
 }

--- a/integrations/forge/connector/dist/index.js
+++ b/integrations/forge/connector/dist/index.js
@@ -22206,19 +22206,18 @@ function readRecord(value) {
 function isIdentityMode(value) {
   return typeof value === "string" && IDENTITY_MODES.includes(value);
 }
+function isResolvedIdentityMode(value) {
+  return isIdentityMode(value) || value === "passthrough";
+}
 function resolveIdentityModeFromConfig(config) {
   const root = readRecord(config);
   const capabilities = readRecord(root.capabilities);
   const capabilityIdentity = readRecord(capabilities.identity);
-  if (isIdentityMode(capabilityIdentity.mode))
+  if (isResolvedIdentityMode(capabilityIdentity.mode))
     return capabilityIdentity.mode;
-  if (capabilityIdentity.mode === "passthrough")
-    return "off";
   const identity = readRecord(root.identity);
-  if (isIdentityMode(identity.mode))
+  if (isResolvedIdentityMode(identity.mode))
     return identity.mode;
-  if (identity.mode === "passthrough")
-    return "off";
   if (identity.enabled === false)
     return "off";
   return "managed";

--- a/platform/core/src/__tests__/identity.test.ts
+++ b/platform/core/src/__tests__/identity.test.ts
@@ -158,17 +158,16 @@ describe("readStaticIdentity", () => {
 		expect(readStaticIdentity(TMP)).toBeNull();
 	});
 
-	test("legacy passthrough mode collapses to off (ignores identity files)", () => {
+	test("legacy passthrough mode reads existing startup identity without managing it", () => {
 		writeFileSync(
 			join(TMP, "agent.yaml"),
 			"capabilities:\n  identity:\n    mode: passthrough\nidentity:\n  preset: minimal\n  startup:\n    load:\n      - path: AGENTS.md\n        role: operating_instructions\n",
 		);
 		writeFileSync(join(TMP, "AGENTS.md"), "agents");
 
-		// passthrough was collapsed into off — it no longer reads identity files.
-		expect(loadIdentityMode(TMP)).toBe("off");
-		expect(resolveStartupIdentityFiles(TMP)).toEqual([]);
-		expect(readStaticIdentity(TMP)).toBeNull();
+		expect(loadIdentityMode(TMP)).toBe("passthrough");
+		expect(resolveStartupIdentityFiles(TMP).map((entry) => entry.path)).toEqual(["AGENTS.md"]);
+		expect(readStaticIdentity(TMP)).toContain("agents");
 	});
 
 	test("respects configured startup identity file order", () => {

--- a/platform/core/src/__tests__/identity.test.ts
+++ b/platform/core/src/__tests__/identity.test.ts
@@ -158,16 +158,17 @@ describe("readStaticIdentity", () => {
 		expect(readStaticIdentity(TMP)).toBeNull();
 	});
 
-	test("identity passthrough mode reads existing startup identity without managing it", () => {
+	test("legacy passthrough mode collapses to off (ignores identity files)", () => {
 		writeFileSync(
 			join(TMP, "agent.yaml"),
 			"capabilities:\n  identity:\n    mode: passthrough\nidentity:\n  preset: minimal\n  startup:\n    load:\n      - path: AGENTS.md\n        role: operating_instructions\n",
 		);
 		writeFileSync(join(TMP, "AGENTS.md"), "agents");
 
-		expect(loadIdentityMode(TMP)).toBe("passthrough");
-		expect(resolveStartupIdentityFiles(TMP).map((entry) => entry.path)).toEqual(["AGENTS.md"]);
-		expect(readStaticIdentity(TMP)).toContain("agents");
+		// passthrough was collapsed into off — it no longer reads identity files.
+		expect(loadIdentityMode(TMP)).toBe("off");
+		expect(resolveStartupIdentityFiles(TMP)).toEqual([]);
+		expect(readStaticIdentity(TMP)).toBeNull();
 	});
 
 	test("respects configured startup identity file order", () => {

--- a/platform/core/src/daemon-url.test.ts
+++ b/platform/core/src/daemon-url.test.ts
@@ -51,4 +51,30 @@ describe("resolveSignetDaemonUrl", () => {
 		);
 		expect(() => resolveSignetDaemonUrl({ env: { SIGNET_PORT: "70000" } })).toThrow("SIGNET_PORT must be an integer");
 	});
+
+	test("honors a persisted configUrl below the env override", () => {
+		expect(resolveSignetDaemonUrl({ configUrl: "https://remote.signet.example:8443" })).toBe(
+			"https://remote.signet.example:8443",
+		);
+		// SIGNET_DAEMON_URL wins over configUrl.
+		expect(
+			resolveSignetDaemonUrl({
+				env: { SIGNET_DAEMON_URL: "http://127.0.0.1:3850" },
+				configUrl: "https://remote.signet.example:8443",
+			}),
+		).toBe("http://127.0.0.1:3850");
+	});
+
+	test("configUrl beats SIGNET_HOST/PORT env", () => {
+		expect(
+			resolveSignetDaemonUrl({
+				env: { SIGNET_HOST: "127.0.0.1", SIGNET_PORT: "3850" },
+				configUrl: "http://10.0.0.5:4000",
+			}),
+		).toBe("http://10.0.0.5:4000");
+	});
+
+	test("rejects an invalid configUrl", () => {
+		expect(() => resolveSignetDaemonUrl({ configUrl: "ftp://x" })).toThrow("daemon.url must use http or https");
+	});
 });

--- a/platform/core/src/daemon-url.ts
+++ b/platform/core/src/daemon-url.ts
@@ -2,6 +2,14 @@ export interface SignetDaemonUrlOptions {
 	readonly env?: Record<string, string | undefined>;
 	readonly defaultHost?: string;
 	readonly defaultPort?: number;
+	/**
+	 * Persisted daemon URL from config (e.g. agent.yaml `daemon.url`). Used only
+	 * when no SIGNET_DAEMON_URL env override is present; still below the env
+	 * override but above SIGNET_HOST/PORT. Keeping the resolver pure (no fs)
+	 * means the caller loads config once and threads it in — one resolution
+	 * path, no parallel reader.
+	 */
+	readonly configUrl?: string;
 }
 
 function readEnv(env: Record<string, string | undefined>, name: string): string | undefined {
@@ -70,6 +78,7 @@ export function resolveSignetDaemonUrl(opts: SignetDaemonUrlOptions = {}): strin
 	const fallbackPort = opts.defaultPort ?? 3850;
 	const explicit = readEnv(env, "SIGNET_DAEMON_URL");
 	if (explicit) return normalizeDaemonUrl(explicit, "SIGNET_DAEMON_URL");
+	if (opts.configUrl) return normalizeDaemonUrl(opts.configUrl, "daemon.url");
 
 	const host = readEnv(env, "SIGNET_HOST") ?? fallbackHost;
 	assertPlainHost(host);

--- a/platform/core/src/identity.ts
+++ b/platform/core/src/identity.ts
@@ -38,6 +38,10 @@ export type IdentityPresetName = "minimal" | "hermes" | "openclaw" | "custom";
 
 export type IdentityMode = "managed" | "off";
 
+/** Runtime-only compatibility mode for workspaces created before setup removed
+ * the passthrough choice. New setup plans must use {@link IdentityMode}. */
+export type ResolvedIdentityMode = IdentityMode | "passthrough";
+
 export const IDENTITY_MODES = ["managed", "off"] as const;
 
 export type IdentityFileContext = "startup" | "session";
@@ -575,18 +579,18 @@ function isIdentityMode(value: unknown): value is IdentityMode {
 	return typeof value === "string" && (IDENTITY_MODES as readonly string[]).includes(value);
 }
 
-export function resolveIdentityModeFromConfig(config: unknown): IdentityMode {
+function isResolvedIdentityMode(value: unknown): value is ResolvedIdentityMode {
+	return isIdentityMode(value) || value === "passthrough";
+}
+
+export function resolveIdentityModeFromConfig(config: unknown): ResolvedIdentityMode {
 	const root = readRecord(config);
 	const capabilities = readRecord(root.capabilities);
 	const capabilityIdentity = readRecord(capabilities.identity);
-	if (isIdentityMode(capabilityIdentity.mode)) return capabilityIdentity.mode;
-	// Legacy configs may still carry "passthrough" (collapsed into "off" — the two
-	// were redundant: passthrough only read existing files, off ignores them).
-	if (capabilityIdentity.mode === "passthrough") return "off";
+	if (isResolvedIdentityMode(capabilityIdentity.mode)) return capabilityIdentity.mode;
 
 	const identity = readRecord(root.identity);
-	if (isIdentityMode(identity.mode)) return identity.mode;
-	if (identity.mode === "passthrough") return "off";
+	if (isResolvedIdentityMode(identity.mode)) return identity.mode;
 	if (identity.enabled === false) return "off";
 
 	// Existing installs predate capability modules and should keep the current
@@ -594,7 +598,7 @@ export function resolveIdentityModeFromConfig(config: unknown): IdentityMode {
 	return "managed";
 }
 
-export function loadIdentityMode(agentsDir: string): IdentityMode {
+export function loadIdentityMode(agentsDir: string): ResolvedIdentityMode {
 	const agentYaml = join(agentsDir, "agent.yaml");
 	if (!existsSync(agentYaml)) return "managed";
 	try {
@@ -604,11 +608,11 @@ export function loadIdentityMode(agentsDir: string): IdentityMode {
 	}
 }
 
-export function identityModeManagesFiles(mode: IdentityMode): boolean {
+export function identityModeManagesFiles(mode: ResolvedIdentityMode): boolean {
 	return mode === "managed";
 }
 
-export function identityModeReadsFiles(mode: IdentityMode): boolean {
+export function identityModeReadsFiles(mode: ResolvedIdentityMode): boolean {
 	return mode !== "off";
 }
 

--- a/platform/core/src/identity.ts
+++ b/platform/core/src/identity.ts
@@ -36,9 +36,9 @@ export function resolveAgentBasePath(agentName: string, workspaceDir: string): s
  */
 export type IdentityPresetName = "minimal" | "hermes" | "openclaw" | "custom";
 
-export type IdentityMode = "managed" | "passthrough" | "off";
+export type IdentityMode = "managed" | "off";
 
-export const IDENTITY_MODES = ["managed", "passthrough", "off"] as const;
+export const IDENTITY_MODES = ["managed", "off"] as const;
 
 export type IdentityFileContext = "startup" | "session";
 
@@ -506,7 +506,7 @@ export function loadIdentityFilesSync(basePath: string): IdentityMap {
 
 /**
  * Check if a directory has the minimum required identity files.
- * Returns false when identity mode is off or passthrough — those modes
+ * Returns false when identity mode is off — that mode
  * intentionally omit identity files.
  */
 export function hasValidIdentity(basePath: string): boolean {
@@ -523,7 +523,7 @@ export function hasValidIdentity(basePath: string): boolean {
 
 /**
  * Get list of missing required identity files.
- * Returns an empty list when identity mode is off or passthrough.
+ * Returns an empty list when identity mode is off.
  */
 export function getMissingIdentityFiles(basePath: string): string[] {
 	const mode = loadIdentityMode(basePath);
@@ -580,9 +580,13 @@ export function resolveIdentityModeFromConfig(config: unknown): IdentityMode {
 	const capabilities = readRecord(root.capabilities);
 	const capabilityIdentity = readRecord(capabilities.identity);
 	if (isIdentityMode(capabilityIdentity.mode)) return capabilityIdentity.mode;
+	// Legacy configs may still carry "passthrough" (collapsed into "off" — the two
+	// were redundant: passthrough only read existing files, off ignores them).
+	if (capabilityIdentity.mode === "passthrough") return "off";
 
 	const identity = readRecord(root.identity);
 	if (isIdentityMode(identity.mode)) return identity.mode;
+	if (identity.mode === "passthrough") return "off";
 	if (identity.enabled === false) return "off";
 
 	// Existing installs predate capability modules and should keep the current

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -356,6 +356,7 @@ export type {
 	IdentityFileSpec,
 	IdentityPresetName,
 	IdentityMode,
+	ResolvedIdentityMode,
 	IdentityFileContext,
 	IdentitySessionKind,
 	IdentityContextFileEntry,

--- a/platform/core/src/types.ts
+++ b/platform/core/src/types.ts
@@ -166,7 +166,7 @@ export interface AgentManifest {
 					enabled?: boolean;
 				};
 				identity?: {
-					mode?: "managed" | "passthrough" | "off";
+					mode?: "managed" | "off";
 				};
 		  };
 	harnessCompatibility?: string[];

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -291,7 +291,7 @@ const SYNC_DEBOUNCE_MS = 2000;
 async function syncHarnessConfigs() {
 	const identityMode = loadIdentityMode(AGENTS_DIR);
 	if (!identityModeManagesFiles(identityMode)) {
-		// Clean up stale generated harness identity files when mode is off/passthrough
+		// Clean up stale generated harness identity files when mode is off
 		await cleanupStaleHarnessIdentity();
 		await ensureArchitectureDoc();
 		return;
@@ -384,7 +384,7 @@ ${fileList}
 }
 
 /**
- * Remove Signet-generated harness identity files when identity mode is off/passthrough.
+ * Remove Signet-generated harness identity files when identity mode is off.
  * Only deletes files whose first lines match Signet-generated markers.
  */
 async function cleanupStaleHarnessIdentity(): Promise<void> {

--- a/surfaces/cli/package.json
+++ b/surfaces/cli/package.json
@@ -43,6 +43,7 @@
   "homepage": "https://signetai.sh",
   "dependencies": {
     "@signet/core": "workspace:*",
+    "@earendil-works/pi-ai": "0.79.2",
     "@signet/connector-claude-code": "workspace:*",
     "@signet/connector-codex": "workspace:*",
     "@signet/connector-forge": "workspace:*",

--- a/surfaces/cli/package.json
+++ b/surfaces/cli/package.json
@@ -56,7 +56,8 @@
     "commander": "^12.0.0",
     "chalk": "^5.3.0",
     "ora": "^8.0.0",
-    "open": "^10.0.0"
+    "open": "^10.0.0",
+    "zod": "^4.3.6"
   },
   "optionalDependencies": {
     "better-sqlite3": "^12.0.0"

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -1049,7 +1049,7 @@ async function ensureDaemonForSecrets(): Promise<boolean> {
 	return ensureDaemonRunning(isDaemonRunning);
 }
 
-const { fetchFromDaemon, fetchDaemonResult, secretApiCall } = createDaemonClient(DEFAULT_PORT);
+const { fetchFromDaemon, fetchDaemonResult, secretApiCall } = createDaemonClient(DEFAULT_PORT, AGENTS_DIR);
 const SKILLS_DIR = join(AGENTS_DIR, "skills");
 
 registerRepairQueueCommands(program, {

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -1004,6 +1004,7 @@ registerAppCommands(program, {
 			parseSearchBalanceValue,
 			showStatus: (statusOptions) => showStatus(statusOptions, healthDeps),
 			signetLogo,
+			signetBanner: () => signetBanner({ version: VERSION }),
 			startDaemon,
 			syncBuiltinSkills,
 			syncNativeEmbeddingModel,

--- a/surfaces/cli/src/commands/agent.ts
+++ b/surfaces/cli/src/commands/agent.ts
@@ -72,7 +72,7 @@ function removeFromRoster(dir: string, name: string): void {
 }
 
 /** Validate agent name: lowercase alphanumeric + hyphens, not 'default'. */
-function validateName(name: string): string | null {
+export function validateName(name: string): string | null {
 	if (name === "default") return "Cannot use reserved name 'default'";
 	if (!/^[a-z0-9][a-z0-9-]*$/.test(name)) return "Name must be lowercase alphanumeric + hyphens only";
 	return null;

--- a/surfaces/cli/src/commands/app.ts
+++ b/surfaces/cli/src/commands/app.ts
@@ -32,6 +32,7 @@ interface SetupOptions {
 	json?: string;
 	dryRun?: boolean;
 	enableDreaming?: boolean;
+	agent?: string[];
 }
 
 interface PathOptions {
@@ -134,6 +135,12 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 		.option("--json <plan>", "Apply an inline setup plan JSON string (headless, no prompts)")
 		.option("--dry-run", "Resolve and print the setup plan, then exit without applying")
 		.option("--enable-dreaming", "Enable background memory consolidation (dreaming)")
+		.option(
+			"--agent <name:policy[:group]>",
+			"Add a named agent to the roster (repeatable). policy: isolated|shared|group",
+			deps.collectListOption,
+			[],
+		)
 		.option(
 			"--identity-preset <preset>",
 			"Identity preset for startup/special prompt files (minimal, hermes, openclaw, custom)",

--- a/surfaces/cli/src/commands/app.ts
+++ b/surfaces/cli/src/commands/app.ts
@@ -34,6 +34,7 @@ interface SetupOptions {
 	enableDreaming?: boolean;
 	agent?: string[];
 	remoteUrl?: string;
+	obsidianSource?: string[];
 }
 
 interface PathOptions {
@@ -137,6 +138,12 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 		.option("--dry-run", "Resolve and print the setup plan, then exit without applying")
 		.option("--enable-dreaming", "Enable background memory consolidation (dreaming)")
 		.option("--remote-url <url>", "Point this workspace at a remote daemon instead of starting a local one")
+		.option(
+			"--obsidian-source <path[::name]>",
+			"Connect an Obsidian vault source (repeatable). Optionally name it with path::name",
+			deps.collectListOption,
+			[],
+		)
 		.option(
 			"--agent <name:policy[:group]>",
 			"Add a named agent to the roster (repeatable). policy: isolated|shared|group",

--- a/surfaces/cli/src/commands/app.ts
+++ b/surfaces/cli/src/commands/app.ts
@@ -154,7 +154,7 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 			"--identity-preset <preset>",
 			"Identity preset for startup/special prompt files (minimal, hermes, openclaw, custom)",
 		)
-		.option("--identity-mode <mode>", "Identity management mode in non-interactive mode (managed, passthrough, off)")
+		.option("--identity-mode <mode>", "Identity management mode in non-interactive mode (managed, off)")
 		.action(deps.setupWizard);
 
 	const dashboard = program

--- a/surfaces/cli/src/commands/app.ts
+++ b/surfaces/cli/src/commands/app.ts
@@ -31,6 +31,7 @@ interface SetupOptions {
 	file?: string;
 	json?: string;
 	dryRun?: boolean;
+	enableDreaming?: boolean;
 }
 
 interface PathOptions {
@@ -132,6 +133,7 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 		.option("--file <path>", "Apply a setup plan from a JSON file (headless, no prompts)")
 		.option("--json <plan>", "Apply an inline setup plan JSON string (headless, no prompts)")
 		.option("--dry-run", "Resolve and print the setup plan, then exit without applying")
+		.option("--enable-dreaming", "Enable background memory consolidation (dreaming)")
 		.option(
 			"--identity-preset <preset>",
 			"Identity preset for startup/special prompt files (minimal, hermes, openclaw, custom)",

--- a/surfaces/cli/src/commands/app.ts
+++ b/surfaces/cli/src/commands/app.ts
@@ -14,6 +14,9 @@ interface SetupOptions {
 	extractionProvider?: string;
 	extractionModel?: string;
 	extractionEndpoint?: string;
+	synthesisProvider?: string;
+	synthesisModel?: string;
+	synthesisEndpoint?: string;
 	searchBalance?: string;
 	openclawRuntimePath?: string;
 	configureOpenclawWorkspace?: boolean;
@@ -100,6 +103,9 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 		)
 		.option("--extraction-model <model>", "Extraction model in non-interactive mode")
 		.option("--extraction-endpoint <url>", "OpenAI-compatible extraction endpoint in non-interactive mode")
+		.option("--synthesis-provider <provider>", "Distinct synthesis provider (non-interactive mode)")
+		.option("--synthesis-model <model>", "Distinct synthesis model (non-interactive mode)")
+		.option("--synthesis-endpoint <url>", "OpenAI-compatible synthesis endpoint (non-interactive mode)")
 		.option("--search-balance <alpha>", "Search balance alpha in non-interactive mode (0-1)")
 		.option("--openclaw-runtime-path <mode>", "OpenClaw runtime path in non-interactive mode (plugin, legacy)")
 		.option(

--- a/surfaces/cli/src/commands/app.ts
+++ b/surfaces/cli/src/commands/app.ts
@@ -33,6 +33,7 @@ interface SetupOptions {
 	dryRun?: boolean;
 	enableDreaming?: boolean;
 	agent?: string[];
+	remoteUrl?: string;
 }
 
 interface PathOptions {
@@ -135,6 +136,7 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 		.option("--json <plan>", "Apply an inline setup plan JSON string (headless, no prompts)")
 		.option("--dry-run", "Resolve and print the setup plan, then exit without applying")
 		.option("--enable-dreaming", "Enable background memory consolidation (dreaming)")
+		.option("--remote-url <url>", "Point this workspace at a remote daemon instead of starting a local one")
 		.option(
 			"--agent <name:policy[:group]>",
 			"Add a named agent to the roster (repeatable). policy: isolated|shared|group",

--- a/surfaces/cli/src/commands/app.ts
+++ b/surfaces/cli/src/commands/app.ts
@@ -14,9 +14,9 @@ interface SetupOptions {
 	extractionProvider?: string;
 	extractionModel?: string;
 	extractionEndpoint?: string;
-	synthesisProvider?: string;
-	synthesisModel?: string;
-	synthesisEndpoint?: string;
+	aggregateRecallProvider?: string;
+	aggregateRecallModel?: string;
+	aggregateRecallEndpoint?: string;
 	searchBalance?: string;
 	openclawRuntimePath?: string;
 	configureOpenclawWorkspace?: boolean;
@@ -107,9 +107,9 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 		)
 		.option("--extraction-model <model>", "Extraction model in non-interactive mode")
 		.option("--extraction-endpoint <url>", "OpenAI-compatible extraction endpoint in non-interactive mode")
-		.option("--synthesis-provider <provider>", "Distinct synthesis provider (non-interactive mode)")
-		.option("--synthesis-model <model>", "Distinct synthesis model (non-interactive mode)")
-		.option("--synthesis-endpoint <url>", "OpenAI-compatible synthesis endpoint (non-interactive mode)")
+		.option("--aggregate-recall-provider <provider>", "Distinct provider for aggregate recall (non-interactive mode)")
+		.option("--aggregate-recall-model <model>", "Model for aggregate recall (non-interactive mode)")
+		.option("--aggregate-recall-endpoint <url>", "OpenAI-compatible aggregate-recall endpoint (non-interactive mode)")
 		.option("--search-balance <alpha>", "Search balance alpha in non-interactive mode (0-1)")
 		.option("--openclaw-runtime-path <mode>", "OpenClaw runtime path in non-interactive mode (plugin, legacy)")
 		.option(

--- a/surfaces/cli/src/commands/app.ts
+++ b/surfaces/cli/src/commands/app.ts
@@ -24,6 +24,7 @@ interface SetupOptions {
 	disableSignetSecrets?: boolean;
 	withGraphiq?: boolean;
 	disableGraphiq?: boolean;
+	schema?: boolean;
 }
 
 interface PathOptions {
@@ -118,14 +119,12 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 		)
 		.option("--with-graphiq", "Install and enable the optional GraphIQ code retrieval plugin")
 		.option("--disable-graphiq", "Leave the optional GraphIQ plugin disabled during setup")
+		.option("--schema", "Print the JSON Schema for the setup plan (for --json/--file payloads) and exit")
 		.option(
 			"--identity-preset <preset>",
 			"Identity preset for startup/special prompt files (minimal, hermes, openclaw, custom)",
 		)
-		.option(
-			"--identity-mode <mode>",
-			"Identity management mode in non-interactive mode (managed, passthrough, off)",
-		)
+		.option("--identity-mode <mode>", "Identity management mode in non-interactive mode (managed, passthrough, off)")
 		.action(deps.setupWizard);
 
 	const dashboard = program

--- a/surfaces/cli/src/commands/app.ts
+++ b/surfaces/cli/src/commands/app.ts
@@ -25,6 +25,9 @@ interface SetupOptions {
 	withGraphiq?: boolean;
 	disableGraphiq?: boolean;
 	schema?: boolean;
+	file?: string;
+	json?: string;
+	dryRun?: boolean;
 }
 
 interface PathOptions {
@@ -120,6 +123,9 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 		.option("--with-graphiq", "Install and enable the optional GraphIQ code retrieval plugin")
 		.option("--disable-graphiq", "Leave the optional GraphIQ plugin disabled during setup")
 		.option("--schema", "Print the JSON Schema for the setup plan (for --json/--file payloads) and exit")
+		.option("--file <path>", "Apply a setup plan from a JSON file (headless, no prompts)")
+		.option("--json <plan>", "Apply an inline setup plan JSON string (headless, no prompts)")
+		.option("--dry-run", "Resolve and print the setup plan, then exit without applying")
 		.option(
 			"--identity-preset <preset>",
 			"Identity preset for startup/special prompt files (minimal, hermes, openclaw, custom)",

--- a/surfaces/cli/src/features/setup-connect.test.ts
+++ b/surfaces/cli/src/features/setup-connect.test.ts
@@ -6,14 +6,6 @@ function mockHttp(overrides: Partial<ConnectHttp> = {}): ConnectHttp {
 	return {
 		postJson: mock(async () => ({ ok: true })),
 		getJson: mock(async () => ({ ok: true })),
-		postStream: mock(
-			async () =>
-				new ReadableStream({
-					start(c) {
-						c.close();
-					},
-				}),
-		),
 		...overrides,
 	};
 }
@@ -26,18 +18,6 @@ function mockUi(overrides: Partial<ConnectUi> = {}): ConnectUi {
 		promptSelect: mock(async () => ""),
 		...overrides,
 	};
-}
-
-/** Build a SSE stream from framed events (matches the daemon's emit format). */
-function sseStream(events: Array<{ type: string; data: Record<string, unknown> }>): ReadableStream<Uint8Array> {
-	const encoder = new TextEncoder();
-	const frames = events.map((e) => `event: ${e.type}\ndata: ${JSON.stringify(e.data)}\n\n`).join("");
-	return new ReadableStream({
-		start(controller) {
-			controller.enqueue(encoder.encode(frames));
-			controller.close();
-		},
-	});
 }
 
 describe("connectApiKey", () => {
@@ -59,91 +39,78 @@ describe("connectApiKey", () => {
 });
 
 describe("connectOAuth", () => {
-	it("opens the auth URL and completes on connected", async () => {
+	// A fake pi-ai login() that drives the UI callbacks, then returns creds.
+	const fakeLogin =
+		(events: Array<(cb: Record<string, (...a: unknown[]) => unknown>) => void>) =>
+		async (callbacks: Record<string, (...a: unknown[]) => unknown>) => {
+			for (const e of events) e(callbacks);
+			return { refresh: "r", access: "a", expires: 0 } as never;
+		};
+
+	it("opens the auth URL via the onAuth callback and stores the credential", async () => {
 		const openUrl = mock(() => {});
+		const stored: Array<{ name: string; value: string }> = [];
 		const http = mockHttp({
-			postStream: mock(async () =>
-				sseStream([
-					{ type: "session", data: { sessionId: "s1", providerId: "anthropic" } },
-					{ type: "auth", data: { url: "https://claude.ai/oauth/authorize?..." } },
-					{ type: "connected", data: { providerId: "anthropic" } },
-					{ type: "done", data: {} },
-				]),
-			),
+			postJson: mock(async (path: string, body: unknown) => {
+				if (path.startsWith("/api/secrets/")) stored.push({ name: path, value: (body as { value: string }).value });
+				return { ok: true };
+			}) as ConnectHttp["postJson"],
 		});
-		const res = await connectOAuth(http, mockUi({ openUrl }), "anthropic");
+		const login = fakeLogin([(cb) => cb.onAuth({ url: "https://claude.ai/oauth/authorize" })]);
+		const res = await connectOAuth(http, mockUi({ openUrl }), "anthropic", { login });
 		expect(res).toEqual({ ok: true, method: "oauth" });
-		expect(openUrl).toHaveBeenCalledWith("https://claude.ai/oauth/authorize?...");
+		expect(openUrl).toHaveBeenCalledWith("https://claude.ai/oauth/authorize");
+		// Stored under the canonical SIGNET_OAUTH_<hex> secret, JSON-encoded.
+		expect(stored[0]?.name).toMatch(/^\/api\/secrets\/SIGNET_OAUTH_/);
+		expect(stored[0]?.value).toContain('"refresh":"r"');
 	});
 
 	it("shows a device code for device-flow providers", async () => {
 		const showDeviceCode = mock(() => {});
-		const http = mockHttp({
-			postStream: mock(async () =>
-				sseStream([
-					{ type: "device_code", data: { userCode: "ABCD-WXYZ", verificationUri: "https://github.com/login/device" } },
-					{ type: "connected", data: { providerId: "github-copilot" } },
-				]),
-			),
-		});
-		const res = await connectOAuth(http, mockUi({ showDeviceCode }), "github-copilot");
-		expect(res.ok).toBe(true);
+		const login = fakeLogin([
+			(cb) => cb.onDeviceCode({ userCode: "ABCD-WXYZ", verificationUri: "https://github.com/login/device" }),
+		]);
+		await connectOAuth(mockHttp(), mockUi({ showDeviceCode }), "github-copilot", { login });
 		expect(showDeviceCode).toHaveBeenCalledWith("ABCD-WXYZ", "https://github.com/login/device");
 	});
 
-	it("answers a prompt by POSTing to /complete with the sessionId", async () => {
-		const completeCalls: Array<Record<string, unknown>> = [];
-		const http = mockHttp({
-			postStream: mock(async () =>
-				sseStream([
-					{ type: "session", data: { sessionId: "s9" } },
-					{ type: "prompt", data: { responseId: "r1", message: "Paste code", allowEmpty: false } },
-					{ type: "connected", data: {} },
-				]),
-			),
-			postJson: mock(async (_path: string, body: unknown) => {
-				completeCalls.push(body as Record<string, unknown>);
-				return { ok: true };
-			}) as ConnectHttp["postJson"],
-		});
-		await connectOAuth(http, mockUi({ promptText: mock(async () => "the-code") }), "anthropic");
-		expect(completeCalls).toContainEqual({ sessionId: "s9", responseId: "r1", value: "the-code" });
+	it("answers a prompt via the UI and forwards progress", async () => {
+		const progress = mock(() => {});
+		const login = fakeLogin([
+			(cb) => cb.onProgress("exchanging"),
+			async (cb) => {
+				const v = await cb.onPrompt({ message: "Paste code" });
+				expect(v).toBe("the-code");
+			},
+		]);
+		await connectOAuth(
+			mockHttp(),
+			mockUi({ promptText: mock(async () => "the-code"), onProgress: progress }),
+			"anthropic",
+			{
+				login,
+			},
+		);
+		expect(progress).toHaveBeenCalledWith("exchanging");
 	});
 
-	it("answers a select prompt", async () => {
-		const completeCalls: Array<Record<string, unknown>> = [];
-		const http = mockHttp({
-			postStream: mock(async () =>
-				sseStream([
-					{
-						type: "select",
-						data: {
-							responseId: "r2",
-							message: "pick",
-							options: [
-								{ id: "a", label: "A" },
-								{ id: "b", label: "B" },
-							],
-						},
-					},
-					{ type: "connected", data: {} },
-				]),
-			),
-			postJson: mock(async (_p: string, body: unknown) => {
-				completeCalls.push(body as Record<string, unknown>);
-				return { ok: true };
-			}) as ConnectHttp["postJson"],
-		});
-		await connectOAuth(http, mockUi({ promptSelect: mock(async () => "b") }), "x");
-		expect(completeCalls).toContainEqual({ sessionId: undefined, responseId: "r2", value: "b" });
-	});
-
-	it("surfaces a daemon error", async () => {
-		const http = mockHttp({
-			postStream: mock(async () => sseStream([{ type: "error", data: { error: "bad token" } }])),
-		});
-		const res = await connectOAuth(http, mockUi(), "anthropic");
+	it("surfaces a login failure", async () => {
+		const login = async () => {
+			throw new Error("bad token");
+		};
+		const res = await connectOAuth(mockHttp(), mockUi(), "anthropic", { login });
 		expect(res).toEqual({ ok: false, error: "bad token" });
+	});
+
+	it("reports a store failure", async () => {
+		const login = fakeLogin([]);
+		const res = await connectOAuth(
+			mockHttp({ postJson: mock(async () => ({ ok: false, error: "vault locked" })) }),
+			mockUi(),
+			"anthropic",
+			{ login },
+		);
+		expect(res).toEqual({ ok: false, error: "vault locked" });
 	});
 });
 

--- a/surfaces/cli/src/features/setup-connect.test.ts
+++ b/surfaces/cli/src/features/setup-connect.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, mock } from "bun:test";
+import { connectApiKey, connectChoice, connectOAuth, fetchModels } from "./setup-connect";
+import type { ConnectHttp, ConnectUi } from "./setup-connect";
+import type { ConnectableProvider } from "./setup-providers";
+
+function mockHttp(overrides: Partial<ConnectHttp> = {}): ConnectHttp {
+	return {
+		postJson: mock(async () => ({ ok: true })),
+		postStream: mock(
+			async () =>
+				new ReadableStream({
+					start(c) {
+						c.close();
+					},
+				}),
+		),
+		...overrides,
+	};
+}
+
+function mockUi(overrides: Partial<ConnectUi> = {}): ConnectUi {
+	return {
+		openUrl: mock(() => {}),
+		showDeviceCode: mock(() => {}),
+		promptText: mock(async () => ""),
+		promptSelect: mock(async () => ""),
+		...overrides,
+	};
+}
+
+/** Build a SSE stream from framed events (matches the daemon's emit format). */
+function sseStream(events: Array<{ type: string; data: Record<string, unknown> }>): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder();
+	const frames = events.map((e) => `event: ${e.type}\ndata: ${JSON.stringify(e.data)}\n\n`).join("");
+	return new ReadableStream({
+		start(controller) {
+			controller.enqueue(encoder.encode(frames));
+			controller.close();
+		},
+	});
+}
+
+describe("connectApiKey", () => {
+	it("stores the key under the canonical secret name", async () => {
+		const postJson = mock(async () => ({ ok: true }));
+		const res = await connectApiKey({ postJson } as ConnectHttp, "openrouter", "sk-or-x");
+		expect(res).toEqual({ ok: true, method: "api" });
+		expect(postJson).toHaveBeenCalledWith("/api/secrets/SIGNET_KEY_OPENROUTER", { value: "sk-or-x" });
+	});
+
+	it("reports failure", async () => {
+		const res = await connectApiKey(
+			mockHttp({ postJson: mock(async () => ({ ok: false, error: "nope" })) }),
+			"openrouter",
+			"k",
+		);
+		expect(res.ok).toBe(false);
+	});
+});
+
+describe("connectOAuth", () => {
+	it("opens the auth URL and completes on connected", async () => {
+		const openUrl = mock(() => {});
+		const http = mockHttp({
+			postStream: mock(async () =>
+				sseStream([
+					{ type: "session", data: { sessionId: "s1", providerId: "anthropic" } },
+					{ type: "auth", data: { url: "https://claude.ai/oauth/authorize?..." } },
+					{ type: "connected", data: { providerId: "anthropic" } },
+					{ type: "done", data: {} },
+				]),
+			),
+		});
+		const res = await connectOAuth(http, mockUi({ openUrl }), "anthropic");
+		expect(res).toEqual({ ok: true, method: "oauth" });
+		expect(openUrl).toHaveBeenCalledWith("https://claude.ai/oauth/authorize?...");
+	});
+
+	it("shows a device code for device-flow providers", async () => {
+		const showDeviceCode = mock(() => {});
+		const http = mockHttp({
+			postStream: mock(async () =>
+				sseStream([
+					{ type: "device_code", data: { userCode: "ABCD-WXYZ", verificationUri: "https://github.com/login/device" } },
+					{ type: "connected", data: { providerId: "github-copilot" } },
+				]),
+			),
+		});
+		const res = await connectOAuth(http, mockUi({ showDeviceCode }), "github-copilot");
+		expect(res.ok).toBe(true);
+		expect(showDeviceCode).toHaveBeenCalledWith("ABCD-WXYZ", "https://github.com/login/device");
+	});
+
+	it("answers a prompt by POSTing to /complete with the sessionId", async () => {
+		const completeCalls: Array<Record<string, unknown>> = [];
+		const http = mockHttp({
+			postStream: mock(async () =>
+				sseStream([
+					{ type: "session", data: { sessionId: "s9" } },
+					{ type: "prompt", data: { responseId: "r1", message: "Paste code", allowEmpty: false } },
+					{ type: "connected", data: {} },
+				]),
+			),
+			postJson: mock(async (_path: string, body: unknown) => {
+				completeCalls.push(body as Record<string, unknown>);
+				return { ok: true };
+			}) as ConnectHttp["postJson"],
+		});
+		await connectOAuth(http, mockUi({ promptText: mock(async () => "the-code") }), "anthropic");
+		expect(completeCalls).toContainEqual({ sessionId: "s9", responseId: "r1", value: "the-code" });
+	});
+
+	it("answers a select prompt", async () => {
+		const completeCalls: Array<Record<string, unknown>> = [];
+		const http = mockHttp({
+			postStream: mock(async () =>
+				sseStream([
+					{
+						type: "select",
+						data: {
+							responseId: "r2",
+							message: "pick",
+							options: [
+								{ id: "a", label: "A" },
+								{ id: "b", label: "B" },
+							],
+						},
+					},
+					{ type: "connected", data: {} },
+				]),
+			),
+			postJson: mock(async (_p: string, body: unknown) => {
+				completeCalls.push(body as Record<string, unknown>);
+				return { ok: true };
+			}) as ConnectHttp["postJson"],
+		});
+		await connectOAuth(http, mockUi({ promptSelect: mock(async () => "b") }), "x");
+		expect(completeCalls).toContainEqual({ sessionId: undefined, responseId: "r2", value: "b" });
+	});
+
+	it("surfaces a daemon error", async () => {
+		const http = mockHttp({
+			postStream: mock(async () => sseStream([{ type: "error", data: { error: "bad token" } }])),
+		});
+		const res = await connectOAuth(http, mockUi(), "anthropic");
+		expect(res).toEqual({ ok: false, error: "bad token" });
+	});
+});
+
+describe("fetchModels", () => {
+	it("returns the model list for a family", async () => {
+		const http = mockHttp({
+			postJson: mock(async () => ({ ok: true, data: { models: { openrouter: [{ id: "m1", name: "M1" }] } } })),
+		});
+		expect(await fetchModels(http, "openrouter")).toEqual([{ id: "m1", name: "M1" }]);
+	});
+
+	it("returns [] when the family is absent", async () => {
+		const http = mockHttp({ postJson: mock(async () => ({ ok: true, data: { models: {} } })) });
+		expect(await fetchModels(http, "nope")).toEqual([]);
+	});
+});
+
+describe("connectChoice", () => {
+	const mk = (id: string, oauth: boolean, key: boolean): ConnectableProvider => ({
+		id,
+		name: id,
+		supportsOAuth: oauth,
+		supportsApiKey: key,
+	});
+	it("classifies oauth-only, key-only, and choice providers", () => {
+		expect(connectChoice(mk("openai-codex", true, false))).toBe("oauth");
+		expect(connectChoice(mk("openrouter", false, true))).toBe("key");
+		expect(connectChoice(mk("anthropic", true, true))).toBe("choice");
+		expect(connectChoice(mk("none", false, false))).toBeNull();
+	});
+});

--- a/surfaces/cli/src/features/setup-connect.test.ts
+++ b/surfaces/cli/src/features/setup-connect.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it, mock } from "bun:test";
-import { connectApiKey, connectOAuth, fetchModels } from "./setup-connect";
+import { runOAuthLogin, storeApiKey, storeOAuthCredentials } from "./setup-connect";
 import type { ConnectHttp, ConnectUi } from "./setup-connect";
 
 function mockHttp(overrides: Partial<ConnectHttp> = {}): ConnectHttp {
 	return {
 		postJson: mock(async () => ({ ok: true })),
-		getJson: mock(async () => ({ ok: true })),
 		...overrides,
 	};
 }
@@ -20,25 +19,37 @@ function mockUi(overrides: Partial<ConnectUi> = {}): ConnectUi {
 	};
 }
 
-describe("connectApiKey", () => {
+describe("storeApiKey", () => {
 	it("stores the key under the canonical secret name", async () => {
 		const postJson = mock(async () => ({ ok: true }));
-		const res = await connectApiKey({ postJson } as ConnectHttp, "openrouter", "sk-or-x");
-		expect(res).toEqual({ ok: true, method: "api" });
+		const res = await storeApiKey({ postJson } as ConnectHttp, "openrouter", "sk-or-x");
+		expect(res.ok).toBe(true);
 		expect(postJson).toHaveBeenCalledWith("/api/secrets/SIGNET_KEY_OPENROUTER", { value: "sk-or-x" });
 	});
 
-	it("reports failure", async () => {
-		const res = await connectApiKey(
-			mockHttp({ postJson: mock(async () => ({ ok: false, error: "nope" })) }),
+	it("reports a store failure with the nested daemon error", async () => {
+		const res = await storeApiKey(
+			mockHttp({ postJson: mock(async () => ({ ok: false, data: { error: "vault locked" } })) }),
 			"openrouter",
 			"k",
 		);
-		expect(res.ok).toBe(false);
+		expect(res).toEqual({ ok: false, error: "vault locked" });
 	});
 });
 
-describe("connectOAuth", () => {
+describe("storeOAuthCredentials", () => {
+	it("JSON-encodes the credential under the SIGNET_OAUTH_* secret", async () => {
+		const postJson = mock(async () => ({ ok: true }));
+		const creds = { refresh: "r", access: "a", expires: 0 };
+		const res = await storeOAuthCredentials({ postJson } as ConnectHttp, "anthropic", creds as never);
+		expect(res.ok).toBe(true);
+		const [path, body] = (postJson as ReturnType<typeof mock>).mock.calls[0];
+		expect(path).toMatch(/^\/api\/secrets\/SIGNET_OAUTH_/);
+		expect((body as { value: string }).value).toContain('"refresh":"r"');
+	});
+});
+
+describe("runOAuthLogin", () => {
 	// A fake pi-ai login() that drives the UI callbacks, then returns creds.
 	const fakeLogin =
 		(events: Array<(cb: Record<string, (...a: unknown[]) => unknown>) => void>) =>
@@ -47,22 +58,12 @@ describe("connectOAuth", () => {
 			return { refresh: "r", access: "a", expires: 0 } as never;
 		};
 
-	it("opens the auth URL via the onAuth callback and stores the credential", async () => {
+	it("opens the auth URL via the onAuth callback", async () => {
 		const openUrl = mock(() => {});
-		const stored: Array<{ name: string; value: string }> = [];
-		const http = mockHttp({
-			postJson: mock(async (path: string, body: unknown) => {
-				if (path.startsWith("/api/secrets/")) stored.push({ name: path, value: (body as { value: string }).value });
-				return { ok: true };
-			}) as ConnectHttp["postJson"],
-		});
 		const login = fakeLogin([(cb) => cb.onAuth({ url: "https://claude.ai/oauth/authorize" })]);
-		const res = await connectOAuth(http, mockUi({ openUrl }), "anthropic", { login });
-		expect(res).toEqual({ ok: true, method: "oauth" });
+		const creds = await runOAuthLogin(mockUi({ openUrl }), "anthropic", { login });
+		expect(creds).toEqual({ refresh: "r", access: "a", expires: 0 });
 		expect(openUrl).toHaveBeenCalledWith("https://claude.ai/oauth/authorize");
-		// Stored under the canonical SIGNET_OAUTH_<hex> secret, JSON-encoded.
-		expect(stored[0]?.name).toMatch(/^\/api\/secrets\/SIGNET_OAUTH_/);
-		expect(stored[0]?.value).toContain('"refresh":"r"');
 	});
 
 	it("shows a device code for device-flow providers", async () => {
@@ -70,7 +71,7 @@ describe("connectOAuth", () => {
 		const login = fakeLogin([
 			(cb) => cb.onDeviceCode({ userCode: "ABCD-WXYZ", verificationUri: "https://github.com/login/device" }),
 		]);
-		await connectOAuth(mockHttp(), mockUi({ showDeviceCode }), "github-copilot", { login });
+		await runOAuthLogin(mockUi({ showDeviceCode }), "github-copilot", { login });
 		expect(showDeviceCode).toHaveBeenCalledWith("ABCD-WXYZ", "https://github.com/login/device");
 	});
 
@@ -83,47 +84,16 @@ describe("connectOAuth", () => {
 				expect(v).toBe("the-code");
 			},
 		]);
-		await connectOAuth(
-			mockHttp(),
-			mockUi({ promptText: mock(async () => "the-code"), onProgress: progress }),
-			"anthropic",
-			{
-				login,
-			},
-		);
+		await runOAuthLogin(mockUi({ promptText: mock(async () => "the-code"), onProgress: progress }), "anthropic", {
+			login,
+		});
 		expect(progress).toHaveBeenCalledWith("exchanging");
 	});
 
-	it("surfaces a login failure", async () => {
+	it("throws on login failure (the wizard surfaces the error)", async () => {
 		const login = async () => {
 			throw new Error("bad token");
 		};
-		const res = await connectOAuth(mockHttp(), mockUi(), "anthropic", { login });
-		expect(res).toEqual({ ok: false, error: "bad token" });
-	});
-
-	it("reports a store failure", async () => {
-		const login = fakeLogin([]);
-		const res = await connectOAuth(
-			mockHttp({ postJson: mock(async () => ({ ok: false, error: "vault locked" })) }),
-			mockUi(),
-			"anthropic",
-			{ login },
-		);
-		expect(res).toEqual({ ok: false, error: "vault locked" });
-	});
-});
-
-describe("fetchModels", () => {
-	it("returns the model list for a family", async () => {
-		const http = mockHttp({
-			getJson: mock(async () => ({ ok: true, data: { models: { openrouter: [{ id: "m1", name: "M1" }] } } })),
-		});
-		expect(await fetchModels(http, "openrouter")).toEqual([{ id: "m1", name: "M1" }]);
-	});
-
-	it("returns [] when the family is absent", async () => {
-		const http = mockHttp({ getJson: mock(async () => ({ ok: true, data: { models: {} } })) });
-		expect(await fetchModels(http, "nope")).toEqual([]);
+		await expect(runOAuthLogin(mockUi(), "anthropic", { login })).rejects.toThrow("bad token");
 	});
 });

--- a/surfaces/cli/src/features/setup-connect.test.ts
+++ b/surfaces/cli/src/features/setup-connect.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, mock } from "bun:test";
-import { connectApiKey, connectChoice, connectOAuth, fetchModels } from "./setup-connect";
+import { connectApiKey, connectOAuth, fetchModels } from "./setup-connect";
 import type { ConnectHttp, ConnectUi } from "./setup-connect";
-import type { ConnectableProvider } from "./setup-providers";
 
 function mockHttp(overrides: Partial<ConnectHttp> = {}): ConnectHttp {
 	return {
@@ -159,20 +158,5 @@ describe("fetchModels", () => {
 	it("returns [] when the family is absent", async () => {
 		const http = mockHttp({ getJson: mock(async () => ({ ok: true, data: { models: {} } })) });
 		expect(await fetchModels(http, "nope")).toEqual([]);
-	});
-});
-
-describe("connectChoice", () => {
-	const mk = (id: string, oauth: boolean, key: boolean): ConnectableProvider => ({
-		id,
-		name: id,
-		supportsOAuth: oauth,
-		supportsApiKey: key,
-	});
-	it("classifies oauth-only, key-only, and choice providers", () => {
-		expect(connectChoice(mk("openai-codex", true, false))).toBe("oauth");
-		expect(connectChoice(mk("openrouter", false, true))).toBe("key");
-		expect(connectChoice(mk("anthropic", true, true))).toBe("choice");
-		expect(connectChoice(mk("none", false, false))).toBeNull();
 	});
 });

--- a/surfaces/cli/src/features/setup-connect.test.ts
+++ b/surfaces/cli/src/features/setup-connect.test.ts
@@ -6,6 +6,7 @@ import type { ConnectableProvider } from "./setup-providers";
 function mockHttp(overrides: Partial<ConnectHttp> = {}): ConnectHttp {
 	return {
 		postJson: mock(async () => ({ ok: true })),
+		getJson: mock(async () => ({ ok: true })),
 		postStream: mock(
 			async () =>
 				new ReadableStream({
@@ -150,13 +151,13 @@ describe("connectOAuth", () => {
 describe("fetchModels", () => {
 	it("returns the model list for a family", async () => {
 		const http = mockHttp({
-			postJson: mock(async () => ({ ok: true, data: { models: { openrouter: [{ id: "m1", name: "M1" }] } } })),
+			getJson: mock(async () => ({ ok: true, data: { models: { openrouter: [{ id: "m1", name: "M1" }] } } })),
 		});
 		expect(await fetchModels(http, "openrouter")).toEqual([{ id: "m1", name: "M1" }]);
 	});
 
 	it("returns [] when the family is absent", async () => {
-		const http = mockHttp({ postJson: mock(async () => ({ ok: true, data: { models: {} } })) });
+		const http = mockHttp({ getJson: mock(async () => ({ ok: true, data: { models: {} } })) });
 		expect(await fetchModels(http, "nope")).toEqual([]);
 	});
 });

--- a/surfaces/cli/src/features/setup-connect.ts
+++ b/surfaces/cli/src/features/setup-connect.ts
@@ -12,7 +12,6 @@
  * HTTP + UI are injected so the state machine is unit-testable without a live
  * daemon or TTY.
  */
-import type { ConnectableProvider } from "./setup-inference-connect.js";
 import { oauthSecretName, providerKeySecretName } from "./setup-inference-connect.js";
 
 export interface ConnectHttp {
@@ -172,14 +171,6 @@ export async function fetchModels(http: ConnectHttp, family: string): Promise<Ca
 	if (!res.ok || !res.data) return [];
 	const models = (res.data as { models?: Record<string, CatalogModel[]> }).models?.[family];
 	return Array.isArray(models) ? models : [];
-}
-
-/** Whether a provider offers a choice between OAuth and API key. */
-export function connectChoice(provider: ConnectableProvider): "oauth" | "key" | "choice" | null {
-	if (provider.supportsOAuth && !provider.supportsApiKey) return "oauth";
-	if (provider.supportsApiKey && !provider.supportsOAuth) return "key";
-	if (provider.supportsOAuth && provider.supportsApiKey) return "choice";
-	return null;
 }
 
 export { oauthSecretName };

--- a/surfaces/cli/src/features/setup-connect.ts
+++ b/surfaces/cli/src/features/setup-connect.ts
@@ -12,6 +12,7 @@
  * HTTP + UI are injected so the state machine is unit-testable without a live
  * daemon or TTY.
  */
+import { type OAuthCredentials, type OAuthLoginCallbacks, getOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import { oauthSecretName, providerKeySecretName } from "./setup-inference-connect.js";
 
 export interface ConnectHttp {
@@ -24,8 +25,6 @@ export interface ConnectHttp {
 	readonly getJson: (
 		path: string,
 	) => Promise<{ readonly ok: boolean; readonly data?: unknown; readonly error?: string }>;
-	/** POST that returns the raw SSE body stream for OAuth login. */
-	readonly postStream: (path: string, body: unknown) => Promise<ReadableStream<Uint8Array>>;
 }
 
 export interface ConnectUi {
@@ -64,100 +63,63 @@ export async function connectApiKey(http: ConnectHttp, family: string, key: stri
 	return { ok: true, method: "api" };
 }
 
-interface SseEvent {
-	readonly type: string;
-	readonly data: Record<string, unknown>;
-}
+/** Acquire OAuth credentials via pi-ai's login() — injectable for tests. */
+export type OAuthLoginFn = (callbacks: OAuthLoginCallbacks) => Promise<OAuthCredentials>;
 
-/** Parse one SSE frame (`event: t\ndata: {...}\n\n`) into { type, data }. */
-function parseSseFrame(chunk: string): SseEvent | null {
-	let type = "message";
-	let dataLine = "";
-	for (const line of chunk.split("\n")) {
-		const trimmed = line.trim();
-		if (trimmed.startsWith("event:")) type = trimmed.slice(6).trim();
-		else if (trimmed.startsWith("data:")) dataLine += trimmed.slice(5).trim();
-	}
-	if (!dataLine) return null;
-	try {
-		return { type, data: JSON.parse(dataLine) as Record<string, unknown> };
-	} catch {
-		return null;
-	}
+function defaultLogin(providerId: string): OAuthLoginFn {
+	return (callbacks) => {
+		const provider = getOAuthProvider(providerId);
+		if (!provider) throw new Error(`Unknown OAuth provider: ${providerId}`);
+		return provider.login(callbacks);
+	};
 }
 
 /**
- * Drive an OAuth login to completion via the daemon's SSE stream. Mirrors the
- * dashboard's ConnectProviderController.runOAuth: opens the auth/device URL,
- * answers prompt/select/manual_code via inquirer-style callbacks, and POSTs
- * each answer to /api/inference/oauth/complete. The daemon stores the
- * resulting credential in the SIGNET_OAUTH_* secret.
+ * Drive an OAuth login to completion using pi-ai's own login() — the same
+ * self-contained flow the SDK ships (it spins its own localhost callback
+ * server for browser-callback providers and handles device codes for the
+ * rest). The dashboard proxies this through the daemon only because a browser
+ * can't run node:http; the CLI calls the SDK directly. The resulting
+ * credential is stored under the canonical SIGNET_OAUTH_* secret so the
+ * daemon resolves it at call time.
  */
-export async function connectOAuth(http: ConnectHttp, ui: ConnectUi, providerId: string): Promise<ConnectResult> {
-	let stream: ReadableStream<Uint8Array>;
+export async function connectOAuth(
+	http: ConnectHttp,
+	ui: ConnectUi,
+	providerId: string,
+	deps?: { readonly login: OAuthLoginFn },
+): Promise<ConnectResult> {
+	const login = deps?.login ?? defaultLogin(providerId);
+
+	let credentials: OAuthCredentials;
 	try {
-		stream = await http.postStream(`/api/inference/oauth/login/${encodeURIComponent(providerId)}`, {});
+		credentials = await login({
+			onAuth: (info) => ui.openUrl(info.url),
+			onDeviceCode: (info) => ui.showDeviceCode(info.userCode, info.verificationUri),
+			onPrompt: async (prompt) => ui.promptText(prompt.message),
+			onSelect: async (prompt) =>
+				ui.promptSelect(
+					prompt.message,
+					prompt.options.map((o) => ({ id: o.id, label: o.label })),
+				),
+			onProgress: (message) => ui.onProgress?.(message),
+			onManualCodeInput: async () => ui.promptText("Paste the final redirect URL or authorization code"),
+		});
 	} catch (err) {
-		return { ok: false, error: err instanceof Error ? err.message : "OAuth login request failed" };
+		const msg = err instanceof Error ? err.message : "OAuth login failed";
+		ui.onError?.(msg);
+		return { ok: false, error: msg };
 	}
 
-	const reader = stream.getReader();
-	const decoder = new TextDecoder();
-	let buffer = "";
-	let sessionId: string | undefined;
-
-	// Outstanding prompt the daemon is waiting on; resolved when the UI answers.
-	let pending: { readonly responseId: string; readonly kind: "text" | "select" | "manual_code" } | undefined;
-
-	const answer = async (responseId: string, value: string): Promise<void> => {
-		await http.postJson("/api/inference/oauth/complete", { sessionId, responseId, value });
-	};
-
-	for (;;) {
-		const { done, value } = await reader.read();
-		if (done) break;
-		buffer += decoder.decode(value, { stream: true });
-
-		let nl: number;
-		// Frames are separated by a blank line (\n\n).
-		while ((nl = buffer.indexOf("\n\n")) >= 0) {
-			const frame = buffer.slice(0, nl);
-			buffer = buffer.slice(nl + 2);
-			const event = parseSseFrame(frame);
-			if (!event) continue;
-			const d = event.data;
-
-			if (event.type === "session") sessionId = typeof d.sessionId === "string" ? d.sessionId : sessionId;
-			else if (event.type === "auth" && typeof d.url === "string") ui.openUrl(d.url);
-			else if (event.type === "device_code" && typeof d.userCode === "string" && typeof d.verificationUri === "string")
-				ui.showDeviceCode(d.userCode, d.verificationUri);
-			else if (event.type === "progress" && typeof d.message === "string") ui.onProgress?.(d.message);
-			else if (event.type === "connected") return { ok: true, method: "oauth" };
-			else if (event.type === "error" && typeof d.error === "string") {
-				ui.onError?.(d.error);
-				return { ok: false, error: d.error };
-			} else if (event.type === "prompt" && typeof d.responseId === "string") {
-				pending = { responseId: d.responseId, kind: "text" };
-				const msg = typeof d.message === "string" ? d.message : "Enter a value";
-				const val = await ui.promptText(msg);
-				await answer(d.responseId, val);
-				pending = undefined;
-			} else if (event.type === "select" && typeof d.responseId === "string" && Array.isArray(d.options)) {
-				const options = (d.options as ReadonlyArray<Record<string, unknown>>).map((o) => ({
-					id: String(o.id),
-					label: String(o.label ?? o.id),
-				}));
-				const chosen = await ui.promptSelect(typeof d.message === "string" ? d.message : "Select an option", options);
-				await answer(d.responseId, chosen);
-			} else if (event.type === "manual_code" && typeof d.responseId === "string") {
-				const val = await ui.promptText("Paste the final redirect URL or authorization code");
-				await answer(d.responseId, val);
-			}
-		}
+	const name = oauthSecretName(providerId);
+	const res = await http.postJson(`/api/secrets/${encodeURIComponent(name)}`, {
+		value: JSON.stringify(credentials),
+	});
+	if (!res.ok) {
+		const nested = (res.data as { error?: string } | undefined)?.error;
+		return { ok: false, error: res.error ?? nested ?? "Failed to store OAuth credentials" };
 	}
-	return pending
-		? { ok: false, error: "OAuth login ended with a pending prompt" }
-		: { ok: false, error: "OAuth login ended unexpectedly" };
+	return { ok: true, method: "oauth" };
 }
 
 export interface CatalogModel {

--- a/surfaces/cli/src/features/setup-connect.ts
+++ b/surfaces/cli/src/features/setup-connect.ts
@@ -1,0 +1,177 @@
+/**
+ * Daemon-driven provider connect for `signet setup` — the CLI counterpart of
+ * the dashboard's ConnectProviderController. Talks to the SAME daemon endpoints
+ * the dashboard uses, so a provider connected here is identical to one
+ * connected in the browser:
+ *
+ *   - POST /api/secrets/:name            (API-key store)
+ *   - POST /api/inference/oauth/login/:id (SSE login stream)
+ *   - POST /api/inference/oauth/complete  (answer a login prompt)
+ *   - GET  /api/inference/catalog         (live model list)
+ *
+ * HTTP + UI are injected so the state machine is unit-testable without a live
+ * daemon or TTY.
+ */
+import type { ConnectableProvider } from "./setup-inference-connect.js";
+import { oauthSecretName, providerKeySecretName } from "./setup-inference-connect.js";
+
+export interface ConnectHttp {
+	/** JSON POST to the daemon; returns { ok, data?, error? }. */
+	readonly postJson: (
+		path: string,
+		body: unknown,
+	) => Promise<{ readonly ok: boolean; readonly data?: unknown; readonly error?: string }>;
+	/** POST that returns the raw SSE body stream for OAuth login. */
+	readonly postStream: (path: string, body: unknown) => Promise<ReadableStream<Uint8Array>>;
+}
+
+export interface ConnectUi {
+	/** Open/Show a URL the user must visit in a browser. */
+	readonly openUrl: (url: string) => void;
+	/** Print a device code + verification URI (no browser needed). */
+	readonly showDeviceCode: (userCode: string, verificationUri: string) => void;
+	/** Free-text prompt (manual code / OAuth text prompt). */
+	readonly promptText: (message: string) => Promise<string>;
+	/** Multiple-choice prompt. */
+	readonly promptSelect: (
+		message: string,
+		options: ReadonlyArray<{ readonly id: string; readonly label: string }>,
+	) => Promise<string>;
+	readonly onProgress?: (message: string) => void;
+	readonly onError?: (message: string) => void;
+}
+
+export type ConnectResult =
+	| { readonly ok: true; readonly method: "api" | "oauth" }
+	| { readonly ok: false; readonly error: string };
+
+/**
+ * Connect an API-key provider: store the key under the canonical secret name
+ * the router resolves (mirrors the dashboard's putSecret + linkAccountForApiKey).
+ */
+export async function connectApiKey(http: ConnectHttp, family: string, key: string): Promise<ConnectResult> {
+	const name = providerKeySecretName(family);
+	const res = await http.postJson(`/api/secrets/${encodeURIComponent(name)}`, { value: key });
+	if (!res.ok) return { ok: false, error: res.error ?? "Failed to store API key" };
+	return { ok: true, method: "api" };
+}
+
+interface SseEvent {
+	readonly type: string;
+	readonly data: Record<string, unknown>;
+}
+
+/** Parse one SSE frame (`event: t\ndata: {...}\n\n`) into { type, data }. */
+function parseSseFrame(chunk: string): SseEvent | null {
+	let type = "message";
+	let dataLine = "";
+	for (const line of chunk.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed.startsWith("event:")) type = trimmed.slice(6).trim();
+		else if (trimmed.startsWith("data:")) dataLine += trimmed.slice(5).trim();
+	}
+	if (!dataLine) return null;
+	try {
+		return { type, data: JSON.parse(dataLine) as Record<string, unknown> };
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Drive an OAuth login to completion via the daemon's SSE stream. Mirrors the
+ * dashboard's ConnectProviderController.runOAuth: opens the auth/device URL,
+ * answers prompt/select/manual_code via inquirer-style callbacks, and POSTs
+ * each answer to /api/inference/oauth/complete. The daemon stores the
+ * resulting credential in the SIGNET_OAUTH_* secret.
+ */
+export async function connectOAuth(http: ConnectHttp, ui: ConnectUi, providerId: string): Promise<ConnectResult> {
+	let stream: ReadableStream<Uint8Array>;
+	try {
+		stream = await http.postStream(`/api/inference/oauth/login/${encodeURIComponent(providerId)}`, {});
+	} catch (err) {
+		return { ok: false, error: err instanceof Error ? err.message : "OAuth login request failed" };
+	}
+
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+	let sessionId: string | undefined;
+
+	// Outstanding prompt the daemon is waiting on; resolved when the UI answers.
+	let pending: { readonly responseId: string; readonly kind: "text" | "select" | "manual_code" } | undefined;
+
+	const answer = async (responseId: string, value: string): Promise<void> => {
+		await http.postJson("/api/inference/oauth/complete", { sessionId, responseId, value });
+	};
+
+	for (;;) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		buffer += decoder.decode(value, { stream: true });
+
+		let nl: number;
+		// Frames are separated by a blank line (\n\n).
+		while ((nl = buffer.indexOf("\n\n")) >= 0) {
+			const frame = buffer.slice(0, nl);
+			buffer = buffer.slice(nl + 2);
+			const event = parseSseFrame(frame);
+			if (!event) continue;
+			const d = event.data;
+
+			if (event.type === "session") sessionId = typeof d.sessionId === "string" ? d.sessionId : sessionId;
+			else if (event.type === "auth" && typeof d.url === "string") ui.openUrl(d.url);
+			else if (event.type === "device_code" && typeof d.userCode === "string" && typeof d.verificationUri === "string")
+				ui.showDeviceCode(d.userCode, d.verificationUri);
+			else if (event.type === "progress" && typeof d.message === "string") ui.onProgress?.(d.message);
+			else if (event.type === "connected") return { ok: true, method: "oauth" };
+			else if (event.type === "error" && typeof d.error === "string") {
+				ui.onError?.(d.error);
+				return { ok: false, error: d.error };
+			} else if (event.type === "prompt" && typeof d.responseId === "string") {
+				pending = { responseId: d.responseId, kind: "text" };
+				const msg = typeof d.message === "string" ? d.message : "Enter a value";
+				const val = await ui.promptText(msg);
+				await answer(d.responseId, val);
+				pending = undefined;
+			} else if (event.type === "select" && typeof d.responseId === "string" && Array.isArray(d.options)) {
+				const options = (d.options as ReadonlyArray<Record<string, unknown>>).map((o) => ({
+					id: String(o.id),
+					label: String(o.label ?? o.id),
+				}));
+				const chosen = await ui.promptSelect(typeof d.message === "string" ? d.message : "Select an option", options);
+				await answer(d.responseId, chosen);
+			} else if (event.type === "manual_code" && typeof d.responseId === "string") {
+				const val = await ui.promptText("Paste the final redirect URL or authorization code");
+				await answer(d.responseId, val);
+			}
+		}
+	}
+	return pending
+		? { ok: false, error: "OAuth login ended with a pending prompt" }
+		: { ok: false, error: "OAuth login ended unexpectedly" };
+}
+
+export interface CatalogModel {
+	readonly id: string;
+	readonly name: string;
+}
+
+/** Fetch the live model list for a provider family from the daemon catalog. */
+export async function fetchModels(http: ConnectHttp, family: string): Promise<CatalogModel[]> {
+	// Reuse postJson against the GET catalog endpoint (body ignored).
+	const res = await http.postJson("/api/inference/catalog", {});
+	if (!res.ok || !res.data) return [];
+	const models = (res.data as { models?: Record<string, CatalogModel[]> }).models?.[family];
+	return Array.isArray(models) ? models : [];
+}
+
+/** Whether a provider offers a choice between OAuth and API key. */
+export function connectChoice(provider: ConnectableProvider): "oauth" | "key" | "choice" | null {
+	if (provider.supportsOAuth && !provider.supportsApiKey) return "oauth";
+	if (provider.supportsApiKey && !provider.supportsOAuth) return "key";
+	if (provider.supportsOAuth && provider.supportsApiKey) return "choice";
+	return null;
+}
+
+export { oauthSecretName };

--- a/surfaces/cli/src/features/setup-connect.ts
+++ b/surfaces/cli/src/features/setup-connect.ts
@@ -21,6 +21,10 @@ export interface ConnectHttp {
 		path: string,
 		body: unknown,
 	) => Promise<{ readonly ok: boolean; readonly data?: unknown; readonly error?: string }>;
+	/** JSON GET to the daemon (e.g. the catalog). */
+	readonly getJson: (
+		path: string,
+	) => Promise<{ readonly ok: boolean; readonly data?: unknown; readonly error?: string }>;
 	/** POST that returns the raw SSE body stream for OAuth login. */
 	readonly postStream: (path: string, body: unknown) => Promise<ReadableStream<Uint8Array>>;
 }
@@ -52,7 +56,12 @@ export type ConnectResult =
 export async function connectApiKey(http: ConnectHttp, family: string, key: string): Promise<ConnectResult> {
 	const name = providerKeySecretName(family);
 	const res = await http.postJson(`/api/secrets/${encodeURIComponent(name)}`, { value: key });
-	if (!res.ok) return { ok: false, error: res.error ?? "Failed to store API key" };
+	if (!res.ok) {
+		// secretApiCall nests the daemon error at res.data.error; fall back to the
+		// top-level error field, then a generic message.
+		const nested = (res.data as { error?: string } | undefined)?.error;
+		return { ok: false, error: res.error ?? nested ?? "Failed to store API key" };
+	}
 	return { ok: true, method: "api" };
 }
 
@@ -159,8 +168,7 @@ export interface CatalogModel {
 
 /** Fetch the live model list for a provider family from the daemon catalog. */
 export async function fetchModels(http: ConnectHttp, family: string): Promise<CatalogModel[]> {
-	// Reuse postJson against the GET catalog endpoint (body ignored).
-	const res = await http.postJson("/api/inference/catalog", {});
+	const res = await http.getJson("/api/inference/catalog");
 	if (!res.ok || !res.data) return [];
 	const models = (res.data as { models?: Record<string, CatalogModel[]> }).models?.[family];
 	return Array.isArray(models) ? models : [];

--- a/surfaces/cli/src/features/setup-connect.ts
+++ b/surfaces/cli/src/features/setup-connect.ts
@@ -1,29 +1,19 @@
 /**
- * Daemon-driven provider connect for `signet setup` — the CLI counterpart of
- * the dashboard's ConnectProviderController. Talks to the SAME daemon endpoints
- * the dashboard uses, so a provider connected here is identical to one
- * connected in the browser:
- *
- *   - POST /api/secrets/:name            (API-key store)
- *   - POST /api/inference/oauth/login/:id (SSE login stream)
- *   - POST /api/inference/oauth/complete  (answer a login prompt)
- *   - GET  /api/inference/catalog         (live model list)
- *
- * HTTP + UI are injected so the state machine is unit-testable without a live
- * daemon or TTY.
+ * Provider connect for `signet setup` — runs the OAuth flow via pi-ai's own
+ * SDK (self-contained: it spins its own localhost callback server, so no daemon
+ * is needed for the login itself) and stores the resulting credential via the
+ * daemon secrets API. The dashboard proxies login through the daemon only
+ * because a browser can't run node:http; the CLI calls the SDK directly during
+ * the wizard, before listing models.
  */
 import { type OAuthCredentials, type OAuthLoginCallbacks, getOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import { oauthSecretName, providerKeySecretName } from "./setup-inference-connect.js";
 
 export interface ConnectHttp {
-	/** JSON POST to the daemon; returns { ok, data?, error? }. */
+	/** JSON POST to the daemon secrets store; returns { ok, data?, error? }. */
 	readonly postJson: (
 		path: string,
 		body: unknown,
-	) => Promise<{ readonly ok: boolean; readonly data?: unknown; readonly error?: string }>;
-	/** JSON GET to the daemon (e.g. the catalog). */
-	readonly getJson: (
-		path: string,
 	) => Promise<{ readonly ok: boolean; readonly data?: unknown; readonly error?: string }>;
 }
 
@@ -43,25 +33,7 @@ export interface ConnectUi {
 	readonly onError?: (message: string) => void;
 }
 
-export type ConnectResult =
-	| { readonly ok: true; readonly method: "api" | "oauth" }
-	| { readonly ok: false; readonly error: string };
-
-/**
- * Connect an API-key provider: store the key under the canonical secret name
- * the router resolves (mirrors the dashboard's putSecret + linkAccountForApiKey).
- */
-export async function connectApiKey(http: ConnectHttp, family: string, key: string): Promise<ConnectResult> {
-	const name = providerKeySecretName(family);
-	const res = await http.postJson(`/api/secrets/${encodeURIComponent(name)}`, { value: key });
-	if (!res.ok) {
-		// secretApiCall nests the daemon error at res.data.error; fall back to the
-		// top-level error field, then a generic message.
-		const nested = (res.data as { error?: string } | undefined)?.error;
-		return { ok: false, error: res.error ?? nested ?? "Failed to store API key" };
-	}
-	return { ok: true, method: "api" };
-}
+export type ConnectResult = { readonly ok: true } | { readonly ok: false; readonly error: string };
 
 /** Acquire OAuth credentials via pi-ai's login() — injectable for tests. */
 export type OAuthLoginFn = (callbacks: OAuthLoginCallbacks) => Promise<OAuthCredentials>;
@@ -75,64 +47,57 @@ function defaultLogin(providerId: string): OAuthLoginFn {
 }
 
 /**
- * Drive an OAuth login to completion using pi-ai's own login() — the same
- * self-contained flow the SDK ships (it spins its own localhost callback
- * server for browser-callback providers and handles device codes for the
- * rest). The dashboard proxies this through the daemon only because a browser
- * can't run node:http; the CLI calls the SDK directly. The resulting
- * credential is stored under the canonical SIGNET_OAUTH_* secret so the
- * daemon resolves it at call time.
+ * Run the OAuth login NOW (during the wizard) using pi-ai's self-contained
+ * login() — the browser opens / a device code is shown, and the user
+ * authenticates. Returns the credential to persist (storage happens later via
+ * storeOAuthCredentials, once the daemon is running). Throws on failure.
  */
-export async function connectOAuth(
-	http: ConnectHttp,
+export async function runOAuthLogin(
 	ui: ConnectUi,
 	providerId: string,
 	deps?: { readonly login: OAuthLoginFn },
-): Promise<ConnectResult> {
+): Promise<OAuthCredentials> {
 	const login = deps?.login ?? defaultLogin(providerId);
+	return login({
+		onAuth: (info) => ui.openUrl(info.url),
+		onDeviceCode: (info) => ui.showDeviceCode(info.userCode, info.verificationUri),
+		onPrompt: async (prompt) => ui.promptText(prompt.message),
+		onSelect: async (prompt) =>
+			ui.promptSelect(
+				prompt.message,
+				prompt.options.map((o) => ({ id: o.id, label: o.label })),
+			),
+		onProgress: (message) => ui.onProgress?.(message),
+		onManualCodeInput: async () => ui.promptText("Paste the final redirect URL or authorization code"),
+	});
+}
 
-	let credentials: OAuthCredentials;
-	try {
-		credentials = await login({
-			onAuth: (info) => ui.openUrl(info.url),
-			onDeviceCode: (info) => ui.showDeviceCode(info.userCode, info.verificationUri),
-			onPrompt: async (prompt) => ui.promptText(prompt.message),
-			onSelect: async (prompt) =>
-				ui.promptSelect(
-					prompt.message,
-					prompt.options.map((o) => ({ id: o.id, label: o.label })),
-				),
-			onProgress: (message) => ui.onProgress?.(message),
-			onManualCodeInput: async () => ui.promptText("Paste the final redirect URL or authorization code"),
-		});
-	} catch (err) {
-		const msg = err instanceof Error ? err.message : "OAuth login failed";
-		ui.onError?.(msg);
-		return { ok: false, error: msg };
-	}
-
-	const name = oauthSecretName(providerId);
-	const res = await http.postJson(`/api/secrets/${encodeURIComponent(name)}`, {
+/** Store an OAuth credential under the canonical SIGNET_OAUTH_* secret (post-start). */
+export async function storeOAuthCredentials(
+	http: ConnectHttp,
+	providerId: string,
+	credentials: OAuthCredentials,
+): Promise<ConnectResult> {
+	const res = await http.postJson(`/api/secrets/${encodeURIComponent(oauthSecretName(providerId))}`, {
 		value: JSON.stringify(credentials),
 	});
 	if (!res.ok) {
 		const nested = (res.data as { error?: string } | undefined)?.error;
 		return { ok: false, error: res.error ?? nested ?? "Failed to store OAuth credentials" };
 	}
-	return { ok: true, method: "oauth" };
+	return { ok: true };
 }
 
-export interface CatalogModel {
-	readonly id: string;
-	readonly name: string;
-}
-
-/** Fetch the live model list for a provider family from the daemon catalog. */
-export async function fetchModels(http: ConnectHttp, family: string): Promise<CatalogModel[]> {
-	const res = await http.getJson("/api/inference/catalog");
-	if (!res.ok || !res.data) return [];
-	const models = (res.data as { models?: Record<string, CatalogModel[]> }).models?.[family];
-	return Array.isArray(models) ? models : [];
+/** Store an API key under the canonical SIGNET_KEY_* secret (post-start). */
+export async function storeApiKey(http: ConnectHttp, family: string, key: string): Promise<ConnectResult> {
+	const res = await http.postJson(`/api/secrets/${encodeURIComponent(providerKeySecretName(family))}`, {
+		value: key,
+	});
+	if (!res.ok) {
+		const nested = (res.data as { error?: string } | undefined)?.error;
+		return { ok: false, error: res.error ?? nested ?? "Failed to store API key" };
+	}
+	return { ok: true };
 }
 
 export { oauthSecretName };

--- a/surfaces/cli/src/features/setup-connect.ts
+++ b/surfaces/cli/src/features/setup-connect.ts
@@ -50,7 +50,13 @@ function defaultLogin(providerId: string): OAuthLoginFn {
  * Run the OAuth login NOW (during the wizard) using pi-ai's self-contained
  * login() — the browser opens / a device code is shown, and the user
  * authenticates. Returns the credential to persist (storage happens later via
- * storeOAuthCredentials, once the daemon is running). Throws on failure.
+ * storeOAuthCredentials, once the daemon is running). Rejects on failure.
+ *
+ * pi-ai's login races a local callback server against manual input and can
+ * emit unhandled rejections from its internal async ops (e.g. a bind or fetch
+ * failure on the callback race) that would otherwise kill the process
+ * silently. Those are captured here and surfaced as a normal rejection so the
+ * wizard can fail gracefully (message + return to menu) instead of quitting.
  */
 export async function runOAuthLogin(
 	ui: ConnectUi,
@@ -58,7 +64,7 @@ export async function runOAuthLogin(
 	deps?: { readonly login: OAuthLoginFn },
 ): Promise<OAuthCredentials> {
 	const login = deps?.login ?? defaultLogin(providerId);
-	return login({
+	const callbacks: OAuthLoginCallbacks = {
 		onAuth: (info) => ui.openUrl(info.url),
 		onDeviceCode: (info) => ui.showDeviceCode(info.userCode, info.verificationUri),
 		onPrompt: async (prompt) => ui.promptText(prompt.message),
@@ -69,6 +75,26 @@ export async function runOAuthLogin(
 			),
 		onProgress: (message) => ui.onProgress?.(message),
 		onManualCodeInput: async () => ui.promptText("Paste the final redirect URL or authorization code"),
+	};
+	return new Promise<OAuthCredentials>((resolve, reject) => {
+		const cleanup = () => process.off("unhandledRejection", onUnhandled);
+		const onUnhandled = (reason: unknown) => {
+			cleanup();
+			const msg = reason instanceof Error ? reason.message : String(reason);
+			ui.onError?.(msg);
+			reject(reason instanceof Error ? reason : new Error(msg));
+		};
+		process.on("unhandledRejection", onUnhandled);
+		login(callbacks).then(
+			(creds) => {
+				cleanup();
+				resolve(creds);
+			},
+			(err) => {
+				cleanup();
+				reject(err);
+			},
+		);
 	});
 }
 

--- a/surfaces/cli/src/features/setup-connect.ts
+++ b/surfaces/cli/src/features/setup-connect.ts
@@ -77,7 +77,15 @@ export async function runOAuthLogin(
 		onManualCodeInput: async () => ui.promptText("Paste the final redirect URL or authorization code"),
 	};
 	return new Promise<OAuthCredentials>((resolve, reject) => {
-		const cleanup = () => process.off("unhandledRejection", onUnhandled);
+		const cleanup = () => {
+			clearInterval(keepalive);
+			process.off("unhandledRejection", onUnhandled);
+		};
+		// Hold the event loop open for the duration of the interactive login. pi-ai's
+		// callback server + browser race are async and may not ref the loop (the
+		// browser is a detached process), so without this bun can exit cleanly
+		// mid-login after the last inquirer prompt resolves.
+		const keepalive = setInterval(() => {}, 1000);
 		const onUnhandled = (reason: unknown) => {
 			cleanup();
 			const msg = reason instanceof Error ? reason.message : String(reason);

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -2,6 +2,7 @@ import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from
 import { join } from "node:path";
 import { OpenClawConnector } from "@signet/connector-openclaw";
 import {
+	addObsidianSource,
 	buildAgentMemoryConfig,
 	disableGraphiqState,
 	ensureUnifiedSchema,
@@ -189,6 +190,20 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 		}
 
 		writeFileSync(join(context.basePath, "agent.yaml"), formatYaml(config));
+
+		// Connect configured sources (config files the daemon indexes at boot).
+		if (plan.sources && plan.sources.length > 0) {
+			for (const src of plan.sources) {
+				if (src.type === "obsidian") {
+					const result = addObsidianSource({ root: src.path, name: src.name }, context.basePath);
+					if (result.ok) {
+						console.log(chalk.dim(`  ✓ Obsidian source: ${result.source.name}`));
+					} else {
+						console.warn(chalk.yellow(`  ⚠ Could not add Obsidian source ${src.path}: ${result.error}`));
+					}
+				}
+			}
+		}
 
 		writeSetupCorePluginRegistry(context.basePath, {
 			signetSecretsEnabled: plan.signetSecretsEnabled,

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -2,6 +2,7 @@ import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from
 import { join } from "node:path";
 import { OpenClawConnector } from "@signet/connector-openclaw";
 import {
+	buildAgentMemoryConfig,
 	disableGraphiqState,
 	ensureUnifiedSchema,
 	formatYaml,
@@ -173,6 +174,15 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 			context.acpxBin,
 		);
 		applySetupInferenceRoute(config, inference);
+
+		if (plan.agents && plan.agents.length > 0) {
+			config.agents = {
+				roster: plan.agents.map((agent) => ({
+					name: agent.name,
+					memory: buildAgentMemoryConfig(agent.memoryPolicy, agent.memoryGroup),
+				})),
+			};
+		}
 
 		writeFileSync(join(context.basePath, "agent.yaml"), formatYaml(config));
 

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -16,7 +16,7 @@ import ora from "ora";
 import { daemonAccessLines } from "../lib/network.js";
 import Database from "../sqlite.js";
 import { installGraphiqPlugin } from "./graphiq.js";
-import { applyInferenceRoute, buildExtractionRoute } from "./setup-inference-connect.js";
+import { CONNECT_MODEL_DEFAULTS, applyInferenceRoute, buildExtractionRoute } from "./setup-inference-connect.js";
 import {
 	applyAggregateRecallRoute,
 	applySetupInferenceRoute,
@@ -184,7 +184,9 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 					executor: plan.extractionConnect.family,
 					family: plan.extractionConnect.family,
 					connectMethod: plan.extractionConnect.connectMethod,
-					model: plan.extractionModel || "default",
+					// extractionModel is validated non-empty for connect plans (superRefine);
+					// fall back to a per-family default rather than a literal placeholder.
+					model: plan.extractionModel || CONNECT_MODEL_DEFAULTS[plan.extractionConnect.family] || "haiku",
 				}),
 			);
 		}

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -149,7 +149,18 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 		}
 
 		const memory = readRecord(config.memory);
-		memory.pipelineV2 = buildSetupPipeline(plan.extractionProvider, plan.extractionModel, plan.extractionEndpoint);
+		memory.pipelineV2 = buildSetupPipeline(
+			plan.extractionProvider,
+			plan.extractionModel,
+			plan.extractionEndpoint,
+			plan.synthesisProvider || plan.synthesisModel || plan.synthesisEndpoint
+				? {
+						provider: plan.synthesisProvider,
+						model: plan.synthesisModel,
+						endpoint: plan.synthesisEndpoint,
+					}
+				: undefined,
+		);
 		config.memory = memory;
 		const inference = buildSetupInference(
 			plan.extractionProvider,

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -16,6 +16,7 @@ import ora from "ora";
 import { daemonAccessLines } from "../lib/network.js";
 import Database from "../sqlite.js";
 import { installGraphiqPlugin } from "./graphiq.js";
+import { applyInferenceRoute, buildExtractionRoute } from "./setup-inference-connect.js";
 import {
 	applyAggregateRecallRoute,
 	applySetupInferenceRoute,
@@ -170,6 +171,23 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 			context.acpxBin,
 		);
 		applySetupInferenceRoute(config, inference);
+
+		// Dashboard-style connected cloud provider: the modern inference.* route is
+		// the source of truth (target + connected account). pipelineV2 stays enabled
+		// so the extraction worker runs; the daemon merges inference.* atop the
+		// legacy base, so this target overrides the legacy extraction target.
+		if (plan.extractionConnect) {
+			applyInferenceRoute(
+				config,
+				buildExtractionRoute({
+					kind: "cloud",
+					executor: plan.extractionConnect.family,
+					family: plan.extractionConnect.family,
+					connectMethod: plan.extractionConnect.connectMethod,
+					model: plan.extractionModel || "default",
+				}),
+			);
+		}
 
 		// Optional distinct provider for aggregate recall (query-time evidence
 		// synthesis). Overlaid on config.inference; the daemon merges it atop the
@@ -373,6 +391,22 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 				for (const line of daemonAccessLines(deps.DEFAULT_PORT, plan.networkMode)) {
 					console.log(chalk.dim(`    ${line}`));
 				}
+			}
+		}
+
+		// Connect the chosen cloud provider now that the daemon is running (the
+		// daemon owns the secrets store + OAuth endpoints, like the dashboard).
+		if (plan.extractionConnect && context.connectExtraction && !remoteDaemon) {
+			spinner.text = `Connecting ${plan.extractionConnect.family}...`;
+			const ok = await context.connectExtraction(plan.extractionConnect.family, plan.extractionConnect.connectMethod);
+			if (ok) {
+				console.log(chalk.green(`  ✓ Connected ${plan.extractionConnect.family}`));
+			} else {
+				console.log(
+					chalk.yellow(
+						`  ⚠ Could not connect ${plan.extractionConnect.family} now — finish connecting via the dashboard.`,
+					),
+				);
 			}
 		}
 

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -16,7 +16,7 @@ import ora from "ora";
 import { daemonAccessLines } from "../lib/network.js";
 import Database from "../sqlite.js";
 import { installGraphiqPlugin } from "./graphiq.js";
-import { CONNECT_MODEL_DEFAULTS, applyInferenceRoute, buildExtractionRoute } from "./setup-inference-connect.js";
+import { applyInferenceRoute, buildExtractionRoute, modelOptions } from "./setup-inference-connect.js";
 import {
 	applyAggregateRecallRoute,
 	applySetupInferenceRoute,
@@ -184,9 +184,9 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 					executor: plan.extractionConnect.family,
 					family: plan.extractionConnect.family,
 					connectMethod: plan.extractionConnect.connectMethod,
-					// extractionModel is validated non-empty for connect plans (superRefine);
-					// fall back to a per-family default rather than a literal placeholder.
-					model: plan.extractionModel || CONNECT_MODEL_DEFAULTS[plan.extractionConnect.family] || "haiku",
+					// extractionModel comes from the pi-ai model dropdown (non-empty for
+					// connect plans); fall back to the family's first catalog model.
+					model: plan.extractionModel || modelOptions(plan.extractionConnect.family)[0]?.id || "haiku",
 				}),
 			);
 		}

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -16,7 +16,13 @@ import ora from "ora";
 import { daemonAccessLines } from "../lib/network.js";
 import Database from "../sqlite.js";
 import { installGraphiqPlugin } from "./graphiq.js";
-import { applySetupInferenceRoute, buildSetupInference, buildSetupPipeline } from "./setup-pipeline.js";
+import {
+	applyAggregateRecallRoute,
+	applySetupInferenceRoute,
+	buildSetupAggregateRecall,
+	buildSetupInference,
+	buildSetupPipeline,
+} from "./setup-pipeline.js";
 import type { SetupApplyContext, SetupPlan } from "./setup-plan.js";
 import { writeSetupCorePluginRegistry } from "./setup-plugins.js";
 import { enforceSetupProtection, printSetupProtectionSummary, refreshSnapshotProtection } from "./setup-protection.js";
@@ -151,18 +157,7 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 		}
 
 		const memory = readRecord(config.memory);
-		memory.pipelineV2 = buildSetupPipeline(
-			plan.extractionProvider,
-			plan.extractionModel,
-			plan.extractionEndpoint,
-			plan.synthesisProvider || plan.synthesisModel || plan.synthesisEndpoint
-				? {
-						provider: plan.synthesisProvider,
-						model: plan.synthesisModel,
-						endpoint: plan.synthesisEndpoint,
-					}
-				: undefined,
-		);
+		memory.pipelineV2 = buildSetupPipeline(plan.extractionProvider, plan.extractionModel, plan.extractionEndpoint);
 		if (plan.dreamingEnabled) {
 			memory.dreaming = { enabled: true };
 		}
@@ -175,6 +170,20 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 			context.acpxBin,
 		);
 		applySetupInferenceRoute(config, inference);
+
+		// Optional distinct provider for aggregate recall (query-time evidence
+		// synthesis). Overlaid on config.inference; the daemon merges it atop the
+		// legacy pipeline.* base, so extraction/session-synthesis are unaffected.
+		if (plan.aggregateRecallProvider) {
+			applyAggregateRecallRoute(
+				config,
+				buildSetupAggregateRecall(
+					plan.aggregateRecallProvider,
+					plan.aggregateRecallModel,
+					plan.aggregateRecallEndpoint,
+				),
+			);
+		}
 
 		if (plan.agents && plan.agents.length > 0) {
 			config.agents = {

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -199,7 +199,7 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 				config,
 				buildSetupAggregateRecall(
 					plan.aggregateRecallProvider,
-					plan.aggregateRecallModel,
+					plan.aggregateRecallModel ?? "",
 					plan.aggregateRecallEndpoint,
 				),
 			);
@@ -398,7 +398,7 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 
 		// Connect the chosen cloud provider now that the daemon is running (the
 		// daemon owns the secrets store + OAuth endpoints, like the dashboard).
-		if (plan.extractionConnect && context.connectExtraction && !remoteDaemon) {
+		if (plan.extractionConnect && context.connectExtraction) {
 			spinner.text = `Connecting ${plan.extractionConnect.family}...`;
 			const ok = await context.connectExtraction();
 			if (ok) {

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -161,6 +161,9 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 					}
 				: undefined,
 		);
+		if (plan.dreamingEnabled) {
+			memory.dreaming = { enabled: true };
+		}
 		config.memory = memory;
 		const inference = buildSetupInference(
 			plan.extractionProvider,

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -201,6 +201,7 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 					plan.aggregateRecallProvider,
 					plan.aggregateRecallModel ?? "",
 					plan.aggregateRecallEndpoint,
+					plan.extractionConnect?.family === "openrouter" && plan.aggregateRecallProvider === "openrouter",
 				),
 			);
 		}

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -15,185 +15,186 @@ import { daemonAccessLines } from "../lib/network.js";
 import Database from "../sqlite.js";
 import { installGraphiqPlugin } from "./graphiq.js";
 import { applySetupInferenceRoute, buildSetupInference, buildSetupPipeline } from "./setup-pipeline.js";
+import type { SetupApplyContext, SetupPlan } from "./setup-plan.js";
 import { writeSetupCorePluginRegistry } from "./setup-plugins.js";
 import { enforceSetupProtection, printSetupProtectionSummary, refreshSnapshotProtection } from "./setup-protection.js";
 import { formatWorkspaceSourceRepoSync, readErr, readRecord } from "./setup-shared.js";
-import type { FreshSetupConfig, SetupDeps } from "./setup-types.js";
+import type { SetupDeps } from "./setup-types.js";
 
-export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Promise<void> {
+export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext, deps: SetupDeps): Promise<void> {
 	const spinner = ora("Setting up Signet...").start();
 	let graphiqInstalled = false;
 
 	try {
-		if (cfg.nonInteractive && !cfg.allowUnprotectedWorkspace && !cfg.createLocalBackup) {
+		if (context.nonInteractive && !context.allowUnprotectedWorkspace && !context.createLocalBackup) {
 			await enforceSetupProtection({
-				basePath: cfg.basePath,
+				basePath: context.basePath,
 				nonInteractive: true,
 				allowUnprotectedWorkspace: false,
 				createLocalBackup: false,
-				assumeOpenClawLinked: cfg.configureOpenClawWs && cfg.openclawConfigCount > 0,
+				assumeOpenClawLinked: plan.configureOpenClawWs && context.openclawConfigCount > 0,
 			});
 		}
 
 		const templatesDir = deps.getTemplatesDir();
-		mkdirSync(cfg.basePath, { recursive: true });
+		mkdirSync(context.basePath, { recursive: true });
 
 		const gitignoreSource = join(templatesDir, "gitignore.template");
 		if (existsSync(gitignoreSource)) {
-			copyFileSync(gitignoreSource, join(cfg.basePath, ".gitignore"));
+			copyFileSync(gitignoreSource, join(context.basePath, ".gitignore"));
 		}
 
-		if (cfg.gitEnabled && !deps.isGitRepo(cfg.basePath)) {
+		if (plan.gitEnabled && !deps.isGitRepo(context.basePath)) {
 			spinner.text = "Initializing git...";
-			await deps.gitInit(cfg.basePath);
+			await deps.gitInit(context.basePath);
 		}
 
-		if (cfg.gitEnabled && cfg.existingAgentsDir) {
+		if (plan.gitEnabled && context.existingAgentsDir) {
 			spinner.text = "Creating backup commit...";
 			const date = new Date().toISOString().split("T")[0];
-			await deps.gitAddAndCommit(cfg.basePath, `${date}_pre-signet-backup`);
+			await deps.gitAddAndCommit(context.basePath, `${date}_pre-signet-backup`);
 		}
 
-		mkdirSync(join(cfg.basePath, "memory", "scripts"), { recursive: true });
-		mkdirSync(join(cfg.basePath, "harnesses"), { recursive: true });
+		mkdirSync(join(context.basePath, "memory", "scripts"), { recursive: true });
+		mkdirSync(join(context.basePath, "harnesses"), { recursive: true });
 
 		spinner.text = "Installing memory system...";
 		const scriptsSource = join(templatesDir, "memory", "scripts");
 		if (existsSync(scriptsSource)) {
-			deps.copyDirRecursive(scriptsSource, join(cfg.basePath, "memory", "scripts"));
+			deps.copyDirRecursive(scriptsSource, join(context.basePath, "memory", "scripts"));
 		}
 
 		const requirementsSource = join(templatesDir, "memory", "requirements.txt");
 		if (existsSync(requirementsSource)) {
-			copyFileSync(requirementsSource, join(cfg.basePath, "memory", "requirements.txt"));
+			copyFileSync(requirementsSource, join(context.basePath, "memory", "requirements.txt"));
 		}
 
 		const utilScriptsSource = join(templatesDir, "scripts");
 		if (existsSync(utilScriptsSource)) {
-			mkdirSync(join(cfg.basePath, "scripts"), { recursive: true });
-			deps.copyDirRecursive(utilScriptsSource, join(cfg.basePath, "scripts"));
+			mkdirSync(join(context.basePath, "scripts"), { recursive: true });
+			deps.copyDirRecursive(utilScriptsSource, join(context.basePath, "scripts"));
 		}
 
 		spinner.text = "Installing built-in skills...";
-		deps.syncBuiltinSkills(deps.getSkillsSourceDir(), cfg.basePath);
+		deps.syncBuiltinSkills(deps.getSkillsSourceDir(), context.basePath);
 
 		spinner.text = "Cloning Signet source checkout...";
-		const sourceRepoSync = await deps.syncWorkspaceSourceRepo(cfg.basePath);
+		const sourceRepoSync = await deps.syncWorkspaceSourceRepo(context.basePath);
 
-		if (cfg.identityMode === "managed") {
+		if (plan.identityMode === "managed") {
 			spinner.text = "Creating agent identity...";
 			const agentsTemplate = join(templatesDir, "AGENTS.md.template");
 			let agentsMd: string;
 			if (existsSync(agentsTemplate)) {
-				agentsMd = readFileSync(agentsTemplate, "utf-8").replace(/\{\{AGENT_NAME\}\}/g, cfg.agentName);
+				agentsMd = readFileSync(agentsTemplate, "utf-8").replace(/\{\{AGENT_NAME\}\}/g, plan.agentName);
 			} else {
-				agentsMd = `# ${cfg.agentName}\n\nThis is your agent identity file. Define your agent's personality, capabilities,\nand behaviors here. This file is shared across all your AI tools.\n\n## Personality\n\n${cfg.agentName} is a helpful assistant.\n\n## Instructions\n\n- Be concise and direct\n- Ask clarifying questions when needed\n- Remember user preferences\n`;
+				agentsMd = `# ${plan.agentName}\n\nThis is your agent identity file. Define your agent's personality, capabilities,\nand behaviors here. This file is shared across all your AI tools.\n\n## Personality\n\n${plan.agentName} is a helpful assistant.\n\n## Instructions\n\n- Be concise and direct\n- Ask clarifying questions when needed\n- Remember user preferences\n`;
 			}
-			writeFileSync(join(cfg.basePath, "AGENTS.md"), agentsMd);
+			writeFileSync(join(context.basePath, "AGENTS.md"), agentsMd);
 		}
 
 		spinner.text = "Writing configuration...";
 		const now = new Date().toISOString();
-		const packageManager = resolvePrimaryPackageManager({ agentsDir: cfg.basePath, env: process.env });
+		const packageManager = resolvePrimaryPackageManager({ agentsDir: context.basePath, env: process.env });
 		const config: Record<string, unknown> = {
 			version: 1,
 			schema: "signet/v1",
 			capabilities: {
 				memory: { enabled: true, autoInject: true, memoryHead: true },
-				secrets: { enabled: cfg.signetSecretsEnabled },
-				identity: { mode: cfg.identityMode },
+				secrets: { enabled: plan.signetSecretsEnabled },
+				identity: { mode: plan.identityMode },
 			},
 			agent: {
-				name: cfg.agentName,
-				description: cfg.agentDescription,
+				name: plan.agentName,
+				description: plan.agentDescription,
 				created: now,
 				updated: now,
 			},
 			network: {
-				mode: cfg.networkMode,
+				mode: plan.networkMode,
 			},
-			harnesses: cfg.harnesses,
+			harnesses: plan.harnesses,
 			install: {
 				primary_package_manager: packageManager.family,
 				source: packageManager.source,
 			},
 			memory: {
 				database: "memory/memories.db",
-				session_budget: cfg.memorySessionBudget,
-				decay_rate: cfg.memoryDecayRate,
+				session_budget: plan.memorySessionBudget,
+				decay_rate: plan.memoryDecayRate,
 			},
 			search: {
-				alpha: cfg.searchBalance,
-				top_k: cfg.searchTopK,
-				min_score: cfg.searchMinScore,
+				alpha: plan.searchBalance,
+				top_k: plan.searchTopK,
+				min_score: plan.searchMinScore,
 			},
 		};
 
-		if (cfg.identityMode === "managed") {
+		if (plan.identityMode === "managed") {
 			config.identity = {
-				preset: cfg.identityPreset,
+				preset: plan.identityPreset,
 				startup: {
-					load: cfg.startupIdentityFiles,
+					load: plan.startupIdentityFiles,
 				},
-				special: cfg.specialIdentityFiles,
+				special: plan.specialIdentityFiles,
 			};
 		}
 
-		if (cfg.embeddingProvider !== "none") {
+		if (plan.embeddingProvider !== "none") {
 			config.embedding = {
-				provider: cfg.embeddingProvider,
-				model: cfg.embeddingModel,
-				dimensions: cfg.embeddingDimensions,
+				provider: plan.embeddingProvider,
+				model: plan.embeddingModel,
+				dimensions: plan.embeddingDimensions,
 			};
 		}
 
 		const memory = readRecord(config.memory);
-		memory.pipelineV2 = buildSetupPipeline(cfg.extractionProvider, cfg.extractionModel, cfg.extractionEndpoint);
+		memory.pipelineV2 = buildSetupPipeline(plan.extractionProvider, plan.extractionModel, plan.extractionEndpoint);
 		config.memory = memory;
 		const inference = buildSetupInference(
-			cfg.extractionProvider,
-			cfg.extractionModel,
-			cfg.harnesses,
-			cfg.availableExtractionProviders,
-			cfg.acpxBin,
+			plan.extractionProvider,
+			plan.extractionModel,
+			plan.harnesses,
+			context.availableExtractionProviders,
+			context.acpxBin,
 		);
 		applySetupInferenceRoute(config, inference);
 
-		writeFileSync(join(cfg.basePath, "agent.yaml"), formatYaml(config));
+		writeFileSync(join(context.basePath, "agent.yaml"), formatYaml(config));
 
-		writeSetupCorePluginRegistry(cfg.basePath, {
-			signetSecretsEnabled: cfg.signetSecretsEnabled,
-			graphiqEnabled: cfg.graphiqEnabled,
+		writeSetupCorePluginRegistry(context.basePath, {
+			signetSecretsEnabled: plan.signetSecretsEnabled,
+			graphiqEnabled: plan.graphiqEnabled,
 		});
-		if (cfg.graphiqEnabled) {
+		if (plan.graphiqEnabled) {
 			spinner.stop();
-			graphiqInstalled = await installGraphiqPlugin({ agentsDir: cfg.basePath });
+			graphiqInstalled = await installGraphiqPlugin({ agentsDir: context.basePath });
 			spinner.start("Continuing Signet setup...");
 		} else {
-			disableGraphiqState(cfg.basePath);
+			disableGraphiqState(context.basePath);
 		}
 
 		const docFiles = Array.from(
 			new Set([
-				...cfg.startupIdentityFiles.map((entry) => entry.path),
-				...cfg.specialIdentityFiles.map((entry) => entry.path),
+				...plan.startupIdentityFiles.map((entry) => entry.path),
+				...plan.specialIdentityFiles.map((entry) => entry.path),
 			]),
 		).map((name) => ({ name, template: `${name}.template` }));
 
 		for (const doc of docFiles) {
 			const templatePath = join(templatesDir, doc.template);
-			const destPath = join(cfg.basePath, doc.name);
+			const destPath = join(context.basePath, doc.name);
 			if (existsSync(destPath)) {
 				continue;
 			}
 			if (existsSync(templatePath)) {
-				const content = readFileSync(templatePath, "utf-8").replace(/\{\{AGENT_NAME\}\}/g, cfg.agentName);
+				const content = readFileSync(templatePath, "utf-8").replace(/\{\{AGENT_NAME\}\}/g, plan.agentName);
 				writeFileSync(destPath, content);
 			}
 		}
 
 		spinner.text = "Initializing database...";
-		const dbPath = join(cfg.basePath, "memory", "memories.db");
+		const dbPath = join(context.basePath, "memory", "memories.db");
 		const db = Database(dbPath);
 		try {
 			ensureUnifiedSchema(db);
@@ -203,11 +204,11 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 		}
 
 		let protection = await enforceSetupProtection({
-			basePath: cfg.basePath,
-			nonInteractive: cfg.nonInteractive,
-			allowUnprotectedWorkspace: cfg.allowUnprotectedWorkspace,
-			createLocalBackup: cfg.createLocalBackup,
-			assumeOpenClawLinked: cfg.configureOpenClawWs && cfg.openclawConfigCount > 0,
+			basePath: context.basePath,
+			nonInteractive: context.nonInteractive,
+			allowUnprotectedWorkspace: context.allowUnprotectedWorkspace,
+			createLocalBackup: context.createLocalBackup,
+			assumeOpenClawLinked: plan.configureOpenClawWs && context.openclawConfigCount > 0,
 		});
 
 		spinner.text = "Configuring harness hooks...";
@@ -217,40 +218,40 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 		// actual daemon address at runtime via SIGNET_DAEMON_URL, falling back
 		// to the baked default — no live daemon connection is needed here.
 		const configuredHarnesses: string[] = [];
-		for (const harness of cfg.harnesses) {
+		for (const harness of plan.harnesses) {
 			try {
-				await deps.configureHarnessHooks(harness, cfg.basePath, { openclawRuntimePath: cfg.openclawRuntimePath });
+				await deps.configureHarnessHooks(harness, context.basePath, { openclawRuntimePath: plan.openclawRuntimePath });
 				configuredHarnesses.push(harness);
 			} catch (err) {
 				console.warn(`\n  ⚠ Could not configure ${harness}: ${readErr(err)}`);
 			}
 		}
 
-		if (cfg.configureOpenClawWs) {
+		if (plan.configureOpenClawWs) {
 			spinner.text = "Configuring OpenClaw workspace...";
-			const patched = await new OpenClawConnector().configureWorkspace(cfg.basePath);
+			const patched = await new OpenClawConnector().configureWorkspace(context.basePath);
 			if (patched.length > 0) {
-				console.log(chalk.dim(`\n  ✓ OpenClaw workspace set to ${cfg.basePath}`));
+				console.log(chalk.dim(`\n  ✓ OpenClaw workspace set to ${context.basePath}`));
 			}
 		}
 
 		if (protection.state === "snapshot") {
 			spinner.text = "Refreshing workspace snapshot...";
-			protection = refreshSnapshotProtection(cfg.basePath, protection);
+			protection = refreshSnapshotProtection(context.basePath, protection);
 		}
 
 		let committed = false;
-		if (cfg.gitEnabled) {
+		if (plan.gitEnabled) {
 			const date = new Date().toISOString().split("T")[0];
-			committed = await deps.gitAddAndCommit(cfg.basePath, `${date}_signet-setup`);
+			committed = await deps.gitAddAndCommit(context.basePath, `${date}_signet-setup`);
 		}
 
 		spinner.text = "Starting daemon...";
-		const daemonStarted = await deps.startDaemon(cfg.basePath);
+		const daemonStarted = await deps.startDaemon(context.basePath);
 
-		if (daemonStarted && cfg.embeddingProvider === "native") {
+		if (daemonStarted && plan.embeddingProvider === "native") {
 			spinner.text = "Warming native embedding model...";
-			const nativeResult = await deps.syncNativeEmbeddingModel(cfg.basePath);
+			const nativeResult = await deps.syncNativeEmbeddingModel(context.basePath);
 			if (nativeResult.status === "error") {
 				console.log(chalk.yellow(`\n  ⚠ Native embedding model warmup failed: ${nativeResult.message}`));
 				console.log(chalk.dim("    Embeddings will be unavailable until this is resolved."));
@@ -262,17 +263,17 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 
 		console.log();
 		console.log(chalk.dim("  Files created:"));
-		console.log(chalk.dim(`    ${cfg.basePath}/`));
+		console.log(chalk.dim(`    ${context.basePath}/`));
 		console.log(chalk.dim("    ├── agent.yaml    manifest & config"));
 		const reportedDocs = Array.from(
 			new Set([
 				"AGENTS.md",
-				...cfg.startupIdentityFiles.map((entry) => entry.path),
-				...cfg.specialIdentityFiles.map((entry) => entry.path),
+				...plan.startupIdentityFiles.map((entry) => entry.path),
+				...plan.specialIdentityFiles.map((entry) => entry.path),
 			]),
-		).filter((name) => existsSync(join(cfg.basePath, name)));
+		).filter((name) => existsSync(join(context.basePath, name)));
 		for (const name of reportedDocs) {
-			const special = cfg.specialIdentityFiles.some((entry) => entry.path === name) ? " (special session)" : "";
+			const special = plan.specialIdentityFiles.some((entry) => entry.path === name) ? " (special session)" : "";
 			console.log(chalk.dim(`    ├── ${name.padEnd(12)}${special}`));
 		}
 		console.log(chalk.dim("    ├── signetai/     Signet source checkout"));
@@ -282,7 +283,7 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 		console.log(chalk.dim("  Core plugins:"));
 		console.log(
 			chalk.dim(
-				`    ${cfg.signetSecretsEnabled ? "✓" : "○"} Signet Secrets ${cfg.signetSecretsEnabled ? "enabled" : "installed but disabled"}`,
+				`    ${plan.signetSecretsEnabled ? "✓" : "○"} Signet Secrets ${plan.signetSecretsEnabled ? "enabled" : "installed but disabled"}`,
 			),
 		);
 		console.log(
@@ -306,7 +307,7 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 		if (daemonStarted) {
 			console.log();
 			console.log(chalk.green("  ● Daemon running"));
-			for (const line of daemonAccessLines(deps.DEFAULT_PORT, cfg.networkMode)) {
+			for (const line of daemonAccessLines(deps.DEFAULT_PORT, plan.networkMode)) {
 				console.log(chalk.dim(`    ${line}`));
 			}
 		}
@@ -316,8 +317,8 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 			console.log(chalk.dim("  ✓ Changes committed to git"));
 		}
 
-		if (cfg.nonInteractive) {
-			if (cfg.openDashboard) {
+		if (context.nonInteractive) {
+			if (context.openDashboard) {
 				await open(`http://localhost:${deps.DEFAULT_PORT}`);
 			}
 		} else {
@@ -332,7 +333,7 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 		console.log();
 		printSetupProtectionSummary(protection);
 		console.log();
-		if (cfg.identityMode === "managed") {
+		if (plan.identityMode === "managed") {
 			console.log(chalk.cyan("  → Next step: Say '/onboarding' to personalize your agent"));
 			console.log(chalk.dim("    This will walk you through setting up your agent's personality,"));
 			console.log(chalk.dim("    communication style, and your preferences."));

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -184,6 +184,10 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 			};
 		}
 
+		if (plan.daemonUrl) {
+			config.daemon = { url: plan.daemonUrl };
+		}
+
 		writeFileSync(join(context.basePath, "agent.yaml"), formatYaml(config));
 
 		writeSetupCorePluginRegistry(context.basePath, {
@@ -270,10 +274,18 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 			committed = await deps.gitAddAndCommit(context.basePath, `${date}_signet-setup`);
 		}
 
-		spinner.text = "Starting daemon...";
-		const daemonStarted = await deps.startDaemon(context.basePath);
+		const remoteDaemon = Boolean(plan.daemonUrl);
+		let daemonStarted: boolean;
+		if (remoteDaemon) {
+			// Remote instance: no local daemon to start; the CLI/connector clients
+			// resolve daemon.url from config at runtime.
+			daemonStarted = true;
+		} else {
+			spinner.text = "Starting daemon...";
+			daemonStarted = await deps.startDaemon(context.basePath);
+		}
 
-		if (daemonStarted && plan.embeddingProvider === "native") {
+		if (!remoteDaemon && daemonStarted && plan.embeddingProvider === "native") {
 			spinner.text = "Warming native embedding model...";
 			const nativeResult = await deps.syncNativeEmbeddingModel(context.basePath);
 			if (nativeResult.status === "error") {
@@ -330,9 +342,13 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 
 		if (daemonStarted) {
 			console.log();
-			console.log(chalk.green("  ● Daemon running"));
-			for (const line of daemonAccessLines(deps.DEFAULT_PORT, plan.networkMode)) {
-				console.log(chalk.dim(`    ${line}`));
+			if (remoteDaemon) {
+				console.log(chalk.green(`  ● Using remote daemon: ${plan.daemonUrl}`));
+			} else {
+				console.log(chalk.green("  ● Daemon running"));
+				for (const line of daemonAccessLines(deps.DEFAULT_PORT, plan.networkMode)) {
+					console.log(chalk.dim(`    ${line}`));
+				}
 			}
 		}
 

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -400,7 +400,7 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 		// daemon owns the secrets store + OAuth endpoints, like the dashboard).
 		if (plan.extractionConnect && context.connectExtraction && !remoteDaemon) {
 			spinner.text = `Connecting ${plan.extractionConnect.family}...`;
-			const ok = await context.connectExtraction(plan.extractionConnect.family, plan.extractionConnect.connectMethod);
+			const ok = await context.connectExtraction();
 			if (ok) {
 				console.log(chalk.green(`  ✓ Connected ${plan.extractionConnect.family}`));
 			} else {

--- a/surfaces/cli/src/features/setup-inference-connect.test.ts
+++ b/surfaces/cli/src/features/setup-inference-connect.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "bun:test";
+import {
+	CONNECTABLE_PROVIDERS,
+	apiAccountEntry,
+	buildExtractionRoute,
+	findConnectableProvider,
+	oauthAccountEntry,
+	oauthSecretName,
+	providerKeySecretName,
+} from "./setup-inference-connect";
+
+describe("provider catalog", () => {
+	it("marks the three pi-ai OAuth providers", () => {
+		const oauth = CONNECTABLE_PROVIDERS.filter((p) => p.supportsOAuth).map((p) => p.id);
+		expect(oauth.sort()).toEqual(["anthropic", "github-copilot", "openai-codex"]);
+	});
+
+	it("lets anthropic choose between OAuth and API key", () => {
+		const anthropic = findConnectableProvider("anthropic");
+		expect(anthropic?.supportsOAuth).toBe(true);
+		expect(anthropic?.supportsApiKey).toBe(true);
+	});
+
+	it("findConnectableProvider returns undefined for unknown ids", () => {
+		expect(findConnectableProvider("nope")).toBeUndefined();
+	});
+});
+
+describe("secret naming (mirrors dashboard/daemon)", () => {
+	it("providerKeySecretName matches the dashboard formula", () => {
+		expect(providerKeySecretName("anthropic")).toBe("SIGNET_KEY_ANTHROPIC");
+		expect(providerKeySecretName("openrouter")).toBe("SIGNET_KEY_OPENROUTER");
+		expect(providerKeySecretName("google-vertex")).toBe("SIGNET_KEY_GOOGLE_VERTEX");
+	});
+
+	it("oauthSecretName matches the daemon formula (SIGNET_OAUTH_<upperhex>)", () => {
+		expect(oauthSecretName("anthropic")).toBe(
+			`SIGNET_OAUTH_${Buffer.from("anthropic", "utf8").toString("hex").toUpperCase()}`,
+		);
+		// daemon resolves the same name, so the credential round-trips.
+		expect(oauthSecretName("anthropic")).not.toBe(oauthSecretName("openai-codex"));
+	});
+});
+
+describe("account entries", () => {
+	it("api account references the key secret", () => {
+		expect(apiAccountEntry("openrouter")).toEqual({
+			kind: "api",
+			providerFamily: "openrouter",
+			credentialRef: "SIGNET_KEY_OPENROUTER",
+		});
+	});
+
+	it("oauth account omits credentialRef (subscription_session)", () => {
+		expect(oauthAccountEntry("anthropic")).toEqual({
+			kind: "subscription_session",
+			providerFamily: "anthropic",
+		});
+		expect(oauthAccountEntry("anthropic")).not.toHaveProperty("credentialRef");
+	});
+});
+
+describe("buildExtractionRoute", () => {
+	it("binds an API-key cloud provider to memoryExtraction with an account", () => {
+		const route = buildExtractionRoute({
+			kind: "cloud",
+			executor: "openrouter",
+			family: "openrouter",
+			connectMethod: "api",
+			model: "anthropic/claude-3.5-sonnet",
+		});
+		expect(route.targets.background).toMatchObject({
+			executor: "openrouter",
+			account: "openrouter",
+			models: { default: { model: "anthropic/claude-3.5-sonnet", reasoning: "medium" } },
+		});
+		expect(route.accounts?.openrouter).toEqual({
+			kind: "api",
+			providerFamily: "openrouter",
+			credentialRef: "SIGNET_KEY_OPENROUTER",
+		});
+		expect(route.workloads.memoryExtraction).toEqual({ target: "background/default" });
+	});
+
+	it("binds an OAuth cloud provider as subscription_session", () => {
+		const route = buildExtractionRoute({
+			kind: "cloud",
+			executor: "anthropic",
+			family: "anthropic",
+			connectMethod: "oauth",
+			model: "claude-3-5-sonnet-20241022",
+		});
+		expect(route.accounts?.anthropic).toEqual({ kind: "subscription_session", providerFamily: "anthropic" });
+	});
+
+	it("local ollama is keyless with no account", () => {
+		const route = buildExtractionRoute({ kind: "local", executor: "ollama", model: "qwen3:4b" });
+		expect(route.targets.background).toMatchObject({ executor: "ollama" });
+		expect(route.targets.background).not.toHaveProperty("account");
+		expect(route.accounts).toBeUndefined();
+	});
+
+	it("local openai-compatible carries an endpoint", () => {
+		const route = buildExtractionRoute({
+			kind: "local",
+			executor: "openai-compatible",
+			model: "m",
+			endpoint: "http://gw:8000/v1",
+		});
+		expect(route.targets.background).toMatchObject({ executor: "openai-compatible", endpoint: "http://gw:8000/v1" });
+	});
+
+	it("acpx carries the agent block", () => {
+		const route = buildExtractionRoute({
+			kind: "acpx",
+			executor: "acpx",
+			model: "haiku",
+			acpx: { agent: "claude", bin: "/usr/bin/bunx" },
+		});
+		expect(route.targets.background).toMatchObject({ executor: "acpx", acpx: { agent: "claude" } });
+	});
+});

--- a/surfaces/cli/src/features/setup-inference-connect.test.ts
+++ b/surfaces/cli/src/features/setup-inference-connect.test.ts
@@ -1,28 +1,37 @@
 import { describe, expect, it } from "bun:test";
 import {
-	CONNECTABLE_PROVIDERS,
 	apiAccountEntry,
+	apiKeyProviderOptions,
 	buildExtractionRoute,
-	findConnectableProvider,
+	modelOptions,
 	oauthAccountEntry,
+	oauthProviderOptions,
 	oauthSecretName,
 	providerKeySecretName,
 } from "./setup-inference-connect";
 
-describe("provider catalog", () => {
-	it("marks the three pi-ai OAuth providers", () => {
-		const oauth = CONNECTABLE_PROVIDERS.filter((p) => p.supportsOAuth).map((p) => p.id);
-		expect(oauth.sort()).toEqual(["anthropic", "github-copilot", "openai-codex"]);
+describe("provider catalog (sourced from pi-ai)", () => {
+	it("lists the OAuth-login providers from pi-ai", () => {
+		const ids = oauthProviderOptions()
+			.map((p) => p.id)
+			.sort();
+		// pi-ai's OAuth registry: anthropic, openai-codex, github-copilot.
+		expect(ids).toEqual(["anthropic", "github-copilot", "openai-codex"]);
 	});
 
-	it("lets anthropic choose between OAuth and API key", () => {
-		const anthropic = findConnectableProvider("anthropic");
-		expect(anthropic?.supportsOAuth).toBe(true);
-		expect(anthropic?.supportsApiKey).toBe(true);
+	it("excludes OAuth-only providers from the API-key list but keeps anthropic", () => {
+		const ids = apiKeyProviderOptions().map((p) => p.id);
+		expect(ids).toContain("anthropic");
+		expect(ids).toContain("openrouter");
+		// openai-codex / github-copilot are subscription-only (no API key).
+		expect(ids).not.toContain("openai-codex");
+		expect(ids).not.toContain("github-copilot");
 	});
 
-	it("findConnectableProvider returns undefined for unknown ids", () => {
-		expect(findConnectableProvider("nope")).toBeUndefined();
+	it("returns the real model list for a family (no guesses)", () => {
+		const models = modelOptions("anthropic");
+		expect(models.length).toBeGreaterThan(0);
+		expect(models.some((m) => m.id.includes("claude"))).toBe(true);
 	});
 });
 
@@ -37,7 +46,6 @@ describe("secret naming (mirrors dashboard/daemon)", () => {
 		expect(oauthSecretName("anthropic")).toBe(
 			`SIGNET_OAUTH_${Buffer.from("anthropic", "utf8").toString("hex").toUpperCase()}`,
 		);
-		// daemon resolves the same name, so the credential round-trips.
 		expect(oauthSecretName("anthropic")).not.toBe(oauthSecretName("openai-codex"));
 	});
 });
@@ -93,13 +101,6 @@ describe("buildExtractionRoute", () => {
 		expect(route.accounts?.anthropic).toEqual({ kind: "subscription_session", providerFamily: "anthropic" });
 	});
 
-	it("local ollama is keyless with no account", () => {
-		const route = buildExtractionRoute({ kind: "local", executor: "ollama", model: "qwen3:4b" });
-		expect(route.targets.background).toMatchObject({ executor: "ollama" });
-		expect(route.targets.background).not.toHaveProperty("account");
-		expect(route.accounts).toBeUndefined();
-	});
-
 	it("local openai-compatible carries an endpoint", () => {
 		const route = buildExtractionRoute({
 			kind: "local",
@@ -108,15 +109,5 @@ describe("buildExtractionRoute", () => {
 			endpoint: "http://gw:8000/v1",
 		});
 		expect(route.targets.background).toMatchObject({ executor: "openai-compatible", endpoint: "http://gw:8000/v1" });
-	});
-
-	it("acpx carries the agent block", () => {
-		const route = buildExtractionRoute({
-			kind: "acpx",
-			executor: "acpx",
-			model: "haiku",
-			acpx: { agent: "claude", bin: "/usr/bin/bunx" },
-		});
-		expect(route.targets.background).toMatchObject({ executor: "acpx", acpx: { agent: "claude" } });
 	});
 });

--- a/surfaces/cli/src/features/setup-inference-connect.ts
+++ b/surfaces/cli/src/features/setup-inference-connect.ts
@@ -64,6 +64,12 @@ export function connectableProviderIds(): readonly string[] {
 	return [...new Set([...getProviders(), ...getOAuthProviders().map((p) => p.id)])];
 }
 
+/** Provider ids valid for aggregate recall — pi-ai families plus local servers
+ * (ollama/llama-cpp/openai-compatible). ACPX is excluded (latency-sensitive). */
+export function aggregateRecallProviderIds(): readonly string[] {
+	return [...new Set([...connectableProviderIds(), ...LOCAL_SERVERS.map((s) => s.id)])];
+}
+
 /** Local keyless servers offered as extraction backends. */
 export const LOCAL_SERVERS = [
 	{ id: "ollama", name: "Ollama (local)" },

--- a/surfaces/cli/src/features/setup-inference-connect.ts
+++ b/surfaces/cli/src/features/setup-inference-connect.ts
@@ -1,45 +1,68 @@
 /**
- * Provider-connect model for `signet setup` — mirrors the dashboard's
- * InferenceSection so the CLI offers the same provider/login UX.
+ * Provider-connect model for `signet setup` — sources providers and models
+ * directly from pi-ai (the SAME catalog the dashboard and daemon use), so
+ * there is a single source of truth and no hand-maintained list to drift.
  *
- * The dashboard drives everything through the daemon HTTP API against a live
- * daemon. This module holds the PURE pieces (catalog, naming, config shapes)
- * so they are unit-testable; the imperative connect steps (OAuth SSE, secret
- * writes) live in setup-connect.ts and talk to the daemon the same way the
- * dashboard does. Nothing here touches the network or filesystem.
+ * The dashboard drives connect through the daemon HTTP API; this module holds
+ * the PURE pieces (catalog lookups, naming, config shapes) for unit testing.
+ * The imperative connect steps (OAuth SSE, secret writes) live in
+ * setup-connect.ts and talk to the daemon the same way the dashboard does.
  *
  * Config shapes are verified against:
  *  - dashboard `InferenceSection.writeTarget` / `ensureAccount`
  *  - dashboard `ConnectProviderDialog.linkAccountForApiKey` / `linkOAuthAccountForProvider`
  *  - daemon `inference-oauth.secretName` (SIGNET_OAUTH_<hex>) and `secrets.putSecret`
  */
+import { getModels, getProviders } from "@earendil-works/pi-ai";
+import { getOAuthProviders } from "@earendil-works/pi-ai/oauth";
 
-/** A cloud provider the user can connect via API key and/or OAuth login. */
-export interface ConnectableProvider {
-	readonly id: string; // pi-ai family id; also the routing executor
+export interface ProviderOption {
+	readonly id: string;
 	readonly name: string;
-	readonly supportsOAuth: boolean;
-	readonly supportsApiKey: boolean;
+}
+
+function titleCase(id: string): string {
+	return id
+		.split(/[-_]/)
+		.map((w) => (w.length > 0 ? w[0].toUpperCase() + w.slice(1) : w))
+		.join(" ");
 }
 
 /**
- * Curated connectable providers. Mirrors the dashboard's featured list +
- * auth capabilities (pi-ai OAuth providers: anthropic, openai-codex,
- * github-copilot). The live model catalog is fetched from the daemon after it
- * starts; this list only drives the selection menu.
+ * Providers that accept a login (OAuth subscription) — from pi-ai's OAuth
+ * registry (Claude Max / ChatGPT / GitHub Copilot). These are the only ids the
+ * daemon's `/api/inference/oauth/login/:id` will accept.
  */
-export const CONNECTABLE_PROVIDERS: readonly ConnectableProvider[] = [
-	{ id: "anthropic", name: "Anthropic (Claude)", supportsOAuth: true, supportsApiKey: true },
-	{ id: "openai-codex", name: "ChatGPT / Codex (subscription)", supportsOAuth: true, supportsApiKey: false },
-	{ id: "github-copilot", name: "GitHub Copilot", supportsOAuth: true, supportsApiKey: false },
-	{ id: "openrouter", name: "OpenRouter", supportsOAuth: false, supportsApiKey: true },
-	{ id: "openai", name: "OpenAI", supportsOAuth: false, supportsApiKey: true },
-	{ id: "google", name: "Google (Gemini)", supportsOAuth: false, supportsApiKey: true },
-	{ id: "xai", name: "xAI (Grok)", supportsOAuth: false, supportsApiKey: true },
-	{ id: "groq", name: "Groq", supportsOAuth: false, supportsApiKey: true },
-	{ id: "deepseek", name: "DeepSeek", supportsOAuth: false, supportsApiKey: true },
-	{ id: "mistral", name: "Mistral", supportsOAuth: false, supportsApiKey: true },
-];
+export function oauthProviderOptions(): ProviderOption[] {
+	return getOAuthProviders().map((p) => ({ id: p.id, name: p.name }));
+}
+
+/**
+ * Providers that accept a pasted API key — the pi-ai catalog families, minus the
+ * OAuth-only subscription providers (which have no API-key surface). anthropic
+ * is kept because it accepts BOTH OAuth and an API key.
+ */
+export function apiKeyProviderOptions(): ProviderOption[] {
+	const oauthOnly = getOAuthProviders()
+		.map((p) => p.id)
+		.filter((id) => id !== "anthropic");
+	return getProviders()
+		.filter((id) => !oauthOnly.includes(id))
+		.map((id) => ({ id, name: titleCase(id) }));
+}
+
+/**
+ * The real model list for a provider family — from pi-ai's model registry, the
+ * same data the dashboard's model picker uses. Never a guess.
+ */
+export function modelOptions(family: string): ProviderOption[] {
+	return getModels(family).map((m) => ({ id: m.id, name: m.name || m.id }));
+}
+
+/** All connectable provider ids (OAuth + API-key families). */
+export function connectableProviderIds(): readonly string[] {
+	return [...new Set([...getProviders(), ...getOAuthProviders().map((p) => p.id)])];
+}
 
 /** Local keyless servers offered as extraction backends. */
 export const LOCAL_SERVERS = [
@@ -47,22 +70,6 @@ export const LOCAL_SERVERS = [
 	{ id: "llama-cpp", name: "llama.cpp (local)" },
 	{ id: "openai-compatible", name: "OpenAI-compatible (LM Studio / gateway)" },
 ] as const;
-
-/** Per-family extraction model defaults (small/fast/cheap, extraction-grade).
- * The dashboard picks from the live catalog; the CLI wizard runs before the
- * daemon, so we suggest a known-good id and let the user override. */
-export const CONNECT_MODEL_DEFAULTS: Record<string, string> = {
-	anthropic: "claude-3-5-haiku-20241022",
-	openrouter: "anthropic/claude-3.5-haiku",
-	openai: "gpt-4o-mini",
-	"openai-codex": "gpt-4o-mini",
-	"github-copilot": "gpt-4o-mini",
-	google: "gemini-2.0-flash",
-	xai: "grok-2-latest",
-	groq: "llama-3.1-8b-instant",
-	deepseek: "deepseek-chat",
-	mistral: "mistral-small-latest",
-};
 
 export type ExtractionBackendKind = "cloud" | "local" | "acpx" | "none";
 
@@ -157,11 +164,6 @@ export function buildExtractionRoute(opts: ExtractionRouteOptions): ExtractionRo
 		...(accounts ? { accounts } : {}),
 		workloads: { memoryExtraction: { target: `${targetName}/default` } },
 	};
-}
-
-/** Find a connectable provider by id (OAuth/API-key menu uses this). */
-export function findConnectableProvider(id: string): ConnectableProvider | undefined {
-	return CONNECTABLE_PROVIDERS.find((p) => p.id === id);
 }
 
 /** Merge an inference route fragment (targets/accounts/workloads) into

--- a/surfaces/cli/src/features/setup-inference-connect.ts
+++ b/surfaces/cli/src/features/setup-inference-connect.ts
@@ -48,6 +48,22 @@ export const LOCAL_SERVERS = [
 	{ id: "openai-compatible", name: "OpenAI-compatible (LM Studio / gateway)" },
 ] as const;
 
+/** Per-family extraction model defaults (small/fast/cheap, extraction-grade).
+ * The dashboard picks from the live catalog; the CLI wizard runs before the
+ * daemon, so we suggest a known-good id and let the user override. */
+export const CONNECT_MODEL_DEFAULTS: Record<string, string> = {
+	anthropic: "claude-3-5-haiku-20241022",
+	openrouter: "anthropic/claude-3.5-haiku",
+	openai: "gpt-4o-mini",
+	"openai-codex": "gpt-4o-mini",
+	"github-copilot": "gpt-4o-mini",
+	google: "gemini-2.0-flash",
+	xai: "grok-2-latest",
+	groq: "llama-3.1-8b-instant",
+	deepseek: "deepseek-chat",
+	mistral: "mistral-small-latest",
+};
+
 export type ExtractionBackendKind = "cloud" | "local" | "acpx" | "none";
 
 /**

--- a/surfaces/cli/src/features/setup-inference-connect.ts
+++ b/surfaces/cli/src/features/setup-inference-connect.ts
@@ -14,7 +14,7 @@
  *  - daemon `inference-oauth.secretName` (SIGNET_OAUTH_<hex>) and `secrets.putSecret`
  */
 import { getModels, getProviders } from "@earendil-works/pi-ai";
-import { getOAuthProviders } from "@earendil-works/pi-ai/oauth";
+import { type OAuthCredentials, getOAuthProvider, getOAuthProviders } from "@earendil-works/pi-ai/oauth";
 
 export interface ProviderOption {
 	readonly id: string;
@@ -53,10 +53,17 @@ export function apiKeyProviderOptions(): ProviderOption[] {
 
 /**
  * The real model list for a provider family — from pi-ai's model registry, the
- * same data the dashboard's model picker uses. Never a guess.
+ * same data the dashboard's model picker uses. When OAuth credentials are
+ * supplied, the provider's modifyModels() is applied (e.g. GitHub Copilot
+ * adjusts its model set based on the authenticated account). Never a guess.
  */
-export function modelOptions(family: string): ProviderOption[] {
-	return getModels(family).map((m) => ({ id: m.id, name: m.name || m.id }));
+export function modelOptions(family: string, credentials?: OAuthCredentials): ProviderOption[] {
+	let models = getModels(family);
+	if (credentials) {
+		const provider = getOAuthProvider(family);
+		if (provider?.modifyModels) models = provider.modifyModels(models, credentials);
+	}
+	return models.map((m) => ({ id: m.id, name: m.name || m.id }));
 }
 
 /** All connectable provider ids (OAuth + API-key families). */

--- a/surfaces/cli/src/features/setup-inference-connect.ts
+++ b/surfaces/cli/src/features/setup-inference-connect.ts
@@ -1,0 +1,150 @@
+/**
+ * Provider-connect model for `signet setup` — mirrors the dashboard's
+ * InferenceSection so the CLI offers the same provider/login UX.
+ *
+ * The dashboard drives everything through the daemon HTTP API against a live
+ * daemon. This module holds the PURE pieces (catalog, naming, config shapes)
+ * so they are unit-testable; the imperative connect steps (OAuth SSE, secret
+ * writes) live in setup-connect.ts and talk to the daemon the same way the
+ * dashboard does. Nothing here touches the network or filesystem.
+ *
+ * Config shapes are verified against:
+ *  - dashboard `InferenceSection.writeTarget` / `ensureAccount`
+ *  - dashboard `ConnectProviderDialog.linkAccountForApiKey` / `linkOAuthAccountForProvider`
+ *  - daemon `inference-oauth.secretName` (SIGNET_OAUTH_<hex>) and `secrets.putSecret`
+ */
+
+/** A cloud provider the user can connect via API key and/or OAuth login. */
+export interface ConnectableProvider {
+	readonly id: string; // pi-ai family id; also the routing executor
+	readonly name: string;
+	readonly supportsOAuth: boolean;
+	readonly supportsApiKey: boolean;
+}
+
+/**
+ * Curated connectable providers. Mirrors the dashboard's featured list +
+ * auth capabilities (pi-ai OAuth providers: anthropic, openai-codex,
+ * github-copilot). The live model catalog is fetched from the daemon after it
+ * starts; this list only drives the selection menu.
+ */
+export const CONNECTABLE_PROVIDERS: readonly ConnectableProvider[] = [
+	{ id: "anthropic", name: "Anthropic (Claude)", supportsOAuth: true, supportsApiKey: true },
+	{ id: "openai-codex", name: "ChatGPT / Codex (subscription)", supportsOAuth: true, supportsApiKey: false },
+	{ id: "github-copilot", name: "GitHub Copilot", supportsOAuth: true, supportsApiKey: false },
+	{ id: "openrouter", name: "OpenRouter", supportsOAuth: false, supportsApiKey: true },
+	{ id: "openai", name: "OpenAI", supportsOAuth: false, supportsApiKey: true },
+	{ id: "google", name: "Google (Gemini)", supportsOAuth: false, supportsApiKey: true },
+	{ id: "xai", name: "xAI (Grok)", supportsOAuth: false, supportsApiKey: true },
+	{ id: "groq", name: "Groq", supportsOAuth: false, supportsApiKey: true },
+	{ id: "deepseek", name: "DeepSeek", supportsOAuth: false, supportsApiKey: true },
+	{ id: "mistral", name: "Mistral", supportsOAuth: false, supportsApiKey: true },
+];
+
+/** Local keyless servers offered as extraction backends. */
+export const LOCAL_SERVERS = [
+	{ id: "ollama", name: "Ollama (local)" },
+	{ id: "llama-cpp", name: "llama.cpp (local)" },
+	{ id: "openai-compatible", name: "OpenAI-compatible (LM Studio / gateway)" },
+] as const;
+
+export type ExtractionBackendKind = "cloud" | "local" | "acpx" | "none";
+
+/**
+ * Stable secret name for a stored provider API key. Mirrors the dashboard's
+ * `providerKeySecretName` so the daemon resolves the same credential the
+ * dashboard would write.
+ */
+export function providerKeySecretName(family: string): string {
+	return `SIGNET_KEY_${family.replace(/[^A-Z0-9_]/gi, "_").toUpperCase()}`;
+}
+
+/**
+ * Stable secret name for stored OAuth credentials. Mirrors the daemon's
+ * `inference-oauth.secretName` (SIGNET_OAUTH_<UPPERHEX>) so the daemon's
+ * `loadOAuthCredentials` finds what setup wrote.
+ */
+export function oauthSecretName(providerId: string): string {
+	return `SIGNET_OAUTH_${Buffer.from(providerId, "utf8").toString("hex").toUpperCase()}`;
+}
+
+/** Routing account entry for an API-key-connected provider. */
+export function apiAccountEntry(family: string): Record<string, unknown> {
+	return { kind: "api", providerFamily: family, credentialRef: providerKeySecretName(family) };
+}
+
+/** Routing account entry for an OAuth-connected (subscription) provider. */
+export function oauthAccountEntry(family: string): Record<string, unknown> {
+	// No credentialRef — the daemon resolves the OAuth credential from the
+	// SIGNET_OAUTH_* secret at call time (isOAuthBackedAccount recognizes
+	// kind: subscription_session).
+	return { kind: "subscription_session", providerFamily: family };
+}
+
+export interface ExtractionRouteOptions {
+	/** Backend kind: determines target shape. */
+	readonly kind: ExtractionBackendKind;
+	/** pi-ai family / executor id (cloud provider, local server, or "acpx"). */
+	readonly executor: string;
+	readonly model: string;
+	/** Cloud provider family; used to name + author the account entry. */
+	readonly family?: string;
+	/** "api" | "oauth" — how a cloud provider was connected. */
+	readonly connectMethod?: "api" | "oauth";
+	/** openai-compatible gateway URL. */
+	readonly endpoint?: string;
+	/** ACPX agent block (agent/bin/...). */
+	readonly acpx?: Record<string, unknown>;
+	/** Target name in inference.targets (default "background"). */
+	readonly targetName?: string;
+}
+
+export interface ExtractionRoute {
+	readonly targets: Record<string, unknown>;
+	readonly accounts?: Record<string, unknown>;
+	readonly workloads: Record<string, unknown>;
+}
+
+/**
+ * Build the modern routing-config fragment that binds an extraction backend to
+ * the memoryExtraction workload. Mirrors the dashboard's writeTarget +
+ * ensureAccount + linkAccount* so the resulting agent.yaml is identical to what
+ * the dashboard produces for the same selection.
+ */
+export function buildExtractionRoute(opts: ExtractionRouteOptions): ExtractionRoute {
+	const targetName = opts.targetName ?? "background";
+	const target: Record<string, unknown> = {
+		executor: opts.executor,
+		models: { default: { model: opts.model, reasoning: "medium" } },
+	};
+	let accounts: Record<string, unknown> | undefined;
+
+	if (opts.kind === "cloud") {
+		const family = opts.family ?? opts.executor;
+		// Provider backends reference an account by family; the credential is
+		// resolved from the secret the connect step wrote.
+		target.account = family;
+		accounts = {
+			[family]:
+				opts.connectMethod === "oauth" ? oauthAccountEntry(family) : apiAccountEntry(family),
+		};
+	} else if (opts.kind === "local") {
+		if (opts.executor === "openai-compatible") {
+			target.endpoint = opts.endpoint ?? "http://localhost:1234/v1";
+		}
+		// ollama / llama-cpp / openai-compatible(localhost) are keyless.
+	} else if (opts.kind === "acpx") {
+		if (opts.acpx) target.acpx = opts.acpx;
+	}
+
+	return {
+		targets: { [targetName]: target },
+		...(accounts ? { accounts } : {}),
+		workloads: { memoryExtraction: { target: `${targetName}/default` } },
+	};
+}
+
+/** Find a connectable provider by id (OAuth/API-key menu uses this). */
+export function findConnectableProvider(id: string): ConnectableProvider | undefined {
+	return CONNECTABLE_PROVIDERS.find((p) => p.id === id);
+}

--- a/surfaces/cli/src/features/setup-inference-connect.ts
+++ b/surfaces/cli/src/features/setup-inference-connect.ts
@@ -125,8 +125,7 @@ export function buildExtractionRoute(opts: ExtractionRouteOptions): ExtractionRo
 		// resolved from the secret the connect step wrote.
 		target.account = family;
 		accounts = {
-			[family]:
-				opts.connectMethod === "oauth" ? oauthAccountEntry(family) : apiAccountEntry(family),
+			[family]: opts.connectMethod === "oauth" ? oauthAccountEntry(family) : apiAccountEntry(family),
 		};
 	} else if (opts.kind === "local") {
 		if (opts.executor === "openai-compatible") {
@@ -147,4 +146,20 @@ export function buildExtractionRoute(opts: ExtractionRouteOptions): ExtractionRo
 /** Find a connectable provider by id (OAuth/API-key menu uses this). */
 export function findConnectableProvider(id: string): ConnectableProvider | undefined {
 	return CONNECTABLE_PROVIDERS.find((p) => p.id === id);
+}
+
+/** Merge an inference route fragment (targets/accounts/workloads) into
+ * config.inference, creating it if absent. Used for the extraction target and
+ * (via buildSetupAggregateRecall) the aggregate-recall target. */
+export function applyInferenceRoute(
+	config: Record<string, unknown>,
+	route: { targets: Record<string, unknown>; accounts?: Record<string, unknown>; workloads: Record<string, unknown> },
+): void {
+	const existing = (config.inference ?? {}) as Record<string, unknown>;
+	const targets = { ...((existing.targets as Record<string, unknown>) ?? {}), ...route.targets };
+	const workloads = { ...((existing.workloads as Record<string, unknown>) ?? {}), ...route.workloads };
+	const accounts = route.accounts
+		? { ...((existing.accounts as Record<string, unknown>) ?? {}), ...route.accounts }
+		: (existing.accounts as Record<string, unknown> | undefined);
+	config.inference = { ...existing, targets, workloads, ...(accounts ? { accounts } : {}) };
 }

--- a/surfaces/cli/src/features/setup-inference-connect.ts
+++ b/surfaces/cli/src/features/setup-inference-connect.ts
@@ -71,10 +71,16 @@ export function connectableProviderIds(): readonly string[] {
 	return [...new Set([...getProviders(), ...getOAuthProviders().map((p) => p.id)])];
 }
 
-/** Provider ids valid for aggregate recall — pi-ai families plus local servers
- * (ollama/llama-cpp/openai-compatible). ACPX is excluded (latency-sensitive). */
+/**
+ * Provider ids valid for aggregate recall during fresh setup.
+ *
+ * The dashboard can route any provider that is already connected. Fresh setup
+ * cannot safely serialize a second provider credential into a headless plan,
+ * so it only offers the keyless local servers plus OpenRouter, whose existing
+ * `OPENROUTER_API_KEY` environment contract is understood by the router.
+ */
 export function aggregateRecallProviderIds(): readonly string[] {
-	return [...new Set([...connectableProviderIds(), ...LOCAL_SERVERS.map((s) => s.id)])];
+	return ["openrouter", ...LOCAL_SERVERS.map((server) => server.id)];
 }
 
 /** Local keyless servers offered as extraction backends. */

--- a/surfaces/cli/src/features/setup-pipeline.test.ts
+++ b/surfaces/cli/src/features/setup-pipeline.test.ts
@@ -84,6 +84,26 @@ describe("buildSetupPipeline", () => {
 		});
 	});
 
+	it("decouples synthesis from extraction when an override provider is given", () => {
+		const pipeline = buildSetupPipeline("claude-code", "haiku", undefined, {
+			provider: "openrouter",
+			model: "anthropic/claude-3.5-sonnet",
+		});
+		expect(pipeline.extraction).toMatchObject({ provider: "claude-code", model: "haiku" });
+		expect(pipeline.synthesis).toMatchObject({
+			enabled: true,
+			provider: "openrouter",
+			model: "anthropic/claude-3.5-sonnet",
+		});
+	});
+
+	it("defaults a distinct synthesis model when only the provider is overridden", () => {
+		const pipeline = buildSetupPipeline("claude-code", "haiku", undefined, { provider: "codex" });
+		expect(pipeline.synthesis.provider).toBe("codex");
+		expect(pipeline.synthesis.model).not.toBe("haiku");
+		expect(pipeline.synthesis.model.length).toBeGreaterThan(0);
+	});
+
 	it("does not invent a generic ACPX model when no harness agent is known", () => {
 		expect(buildSetupPipeline("acpx").extraction.model).toBe("");
 		expect(buildSetupPipeline("acpx").synthesis?.model).toBe("");

--- a/surfaces/cli/src/features/setup-pipeline.test.ts
+++ b/surfaces/cli/src/features/setup-pipeline.test.ts
@@ -237,10 +237,10 @@ describe("buildSetupAggregateRecall", () => {
 			executor: "ollama",
 			models: { default: { model: "qwen3:4b", reasoning: "medium" } },
 		});
-		expect(ar.workloads.aggregateRecall).toEqual({
-			target: "aggregation/default",
-			taskClass: "aggregate_recall",
-		});
+		// No taskClass — the daemon validates taskClasses and 'aggregate_recall' is
+		// not declared; mirror the dashboard writer (target only).
+		expect(ar.workloads.aggregateRecall).toEqual({ target: "aggregation/default" });
+		expect(ar.accounts).toBeUndefined();
 	});
 
 	it("defaults the model when none is given", () => {
@@ -250,14 +250,18 @@ describe("buildSetupAggregateRecall", () => {
 		).toBeGreaterThan(0);
 	});
 
-	it("requires an endpoint for openai-compatible and references an account for openrouter", () => {
+	it("requires an endpoint for openai-compatible and backs openrouter with a resolvable account", () => {
 		expect(buildSetupAggregateRecall("openai-compatible", "m", "http://gw:8000/v1").targets.aggregation).toMatchObject({
 			executor: "openai-compatible",
 			endpoint: "http://gw:8000/v1",
 		});
-		expect(buildSetupAggregateRecall("openrouter", "m").targets.aggregation).toMatchObject({
-			executor: "openrouter",
-			account: "openrouter",
+		const or = buildSetupAggregateRecall("openrouter", "m");
+		expect(or.targets.aggregation).toMatchObject({ executor: "openrouter", account: "aggregation" });
+		// The account must exist or the daemon hard-blocks the target as 'missing'.
+		expect(or.accounts?.aggregation).toMatchObject({
+			kind: "api",
+			providerFamily: "openrouter",
+			credentialRef: "OPENROUTER_API_KEY",
 		});
 	});
 });

--- a/surfaces/cli/src/features/setup-pipeline.test.ts
+++ b/surfaces/cli/src/features/setup-pipeline.test.ts
@@ -243,13 +243,6 @@ describe("buildSetupAggregateRecall", () => {
 		expect(ar.accounts).toBeUndefined();
 	});
 
-	it("defaults the model when none is given", () => {
-		const ar = buildSetupAggregateRecall("openrouter");
-		expect(
-			(ar.targets.aggregation as { models: { default: { model: string } } }).models.default.model.length,
-		).toBeGreaterThan(0);
-	});
-
 	it("requires an endpoint for openai-compatible and backs openrouter with a resolvable account", () => {
 		expect(buildSetupAggregateRecall("openai-compatible", "m", "http://gw:8000/v1").targets.aggregation).toMatchObject({
 			executor: "openai-compatible",

--- a/surfaces/cli/src/features/setup-pipeline.test.ts
+++ b/surfaces/cli/src/features/setup-pipeline.test.ts
@@ -243,7 +243,7 @@ describe("buildSetupAggregateRecall", () => {
 		expect(ar.accounts).toBeUndefined();
 	});
 
-	it("requires an endpoint for openai-compatible and backs openrouter with a resolvable account", () => {
+	it("requires an endpoint for openai-compatible and backs unconnected openrouter with a resolvable account", () => {
 		expect(buildSetupAggregateRecall("openai-compatible", "m", "http://gw:8000/v1").targets.aggregation).toMatchObject({
 			executor: "openai-compatible",
 			endpoint: "http://gw:8000/v1",
@@ -256,6 +256,12 @@ describe("buildSetupAggregateRecall", () => {
 			providerFamily: "openrouter",
 			credentialRef: "OPENROUTER_API_KEY",
 		});
+	});
+
+	it("reuses the interactive OpenRouter extraction account", () => {
+		const or = buildSetupAggregateRecall("openrouter", "m", undefined, true);
+		expect(or.targets.aggregation).toMatchObject({ executor: "openrouter", account: "openrouter" });
+		expect(or.accounts).toBeUndefined();
 	});
 });
 

--- a/surfaces/cli/src/features/setup-pipeline.test.ts
+++ b/surfaces/cli/src/features/setup-pipeline.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import {
+	applyAggregateRecallRoute,
 	applySetupInferenceRoute,
+	buildSetupAggregateRecall,
 	buildSetupInference,
 	buildSetupPipeline,
 	defaultAcpxModel,
@@ -84,29 +86,9 @@ describe("buildSetupPipeline", () => {
 		});
 	});
 
-	it("decouples synthesis from extraction when an override provider is given", () => {
-		const pipeline = buildSetupPipeline("claude-code", "haiku", undefined, {
-			provider: "openrouter",
-			model: "anthropic/claude-3.5-sonnet",
-		});
-		expect(pipeline.extraction).toMatchObject({ provider: "claude-code", model: "haiku" });
-		expect(pipeline.synthesis).toMatchObject({
-			enabled: true,
-			provider: "openrouter",
-			model: "anthropic/claude-3.5-sonnet",
-		});
-	});
-
-	it("defaults a distinct synthesis model when only the provider is overridden", () => {
-		const pipeline = buildSetupPipeline("claude-code", "haiku", undefined, { provider: "codex" });
-		expect(pipeline.synthesis.provider).toBe("codex");
-		expect(pipeline.synthesis.model).not.toBe("haiku");
-		expect(pipeline.synthesis.model.length).toBeGreaterThan(0);
-	});
-
 	it("does not invent a generic ACPX model when no harness agent is known", () => {
 		expect(buildSetupPipeline("acpx").extraction.model).toBe("");
-		expect(buildSetupPipeline("acpx").synthesis?.model).toBe("");
+		expect(buildSetupPipeline("acpx").synthesis.model).toBe("");
 	});
 });
 
@@ -245,5 +227,65 @@ describe("buildSetupInference", () => {
 				custom_review: { reasoning: "high", toolsRequired: true, privacy: "local" },
 			},
 		});
+	});
+});
+
+describe("buildSetupAggregateRecall", () => {
+	it("binds a local ollama target to the aggregateRecall workload", () => {
+		const ar = buildSetupAggregateRecall("ollama", "qwen3:4b");
+		expect(ar.targets.aggregation).toMatchObject({
+			executor: "ollama",
+			models: { default: { model: "qwen3:4b", reasoning: "medium" } },
+		});
+		expect(ar.workloads.aggregateRecall).toEqual({
+			target: "aggregation/default",
+			taskClass: "aggregate_recall",
+		});
+	});
+
+	it("defaults the model when none is given", () => {
+		const ar = buildSetupAggregateRecall("openrouter");
+		expect(
+			(ar.targets.aggregation as { models: { default: { model: string } } }).models.default.model.length,
+		).toBeGreaterThan(0);
+	});
+
+	it("requires an endpoint for openai-compatible and references an account for openrouter", () => {
+		expect(buildSetupAggregateRecall("openai-compatible", "m", "http://gw:8000/v1").targets.aggregation).toMatchObject({
+			executor: "openai-compatible",
+			endpoint: "http://gw:8000/v1",
+		});
+		expect(buildSetupAggregateRecall("openrouter", "m").targets.aggregation).toMatchObject({
+			executor: "openrouter",
+			account: "openrouter",
+		});
+	});
+});
+
+describe("applyAggregateRecallRoute", () => {
+	it("creates config.inference when absent", () => {
+		const config: Record<string, unknown> = {};
+		applyAggregateRecallRoute(config, buildSetupAggregateRecall("ollama", "qwen3:4b"));
+		expect(
+			(config.inference as { workloads: { aggregateRecall: { target: string } } }).workloads.aggregateRecall.target,
+		).toBe("aggregation/default");
+	});
+
+	it("merges into an existing inference block without clobbering other targets", () => {
+		const config: Record<string, unknown> = {
+			inference: {
+				targets: { "background-acpx": { executor: "acpx" } },
+				workloads: { memoryExtraction: { target: "background-acpx/default" } },
+			},
+		};
+		applyAggregateRecallRoute(config, buildSetupAggregateRecall("ollama", "qwen3:4b"));
+		const inference = config.inference as {
+			targets: Record<string, unknown>;
+			workloads: Record<string, unknown>;
+		};
+		expect(inference.targets["background-acpx"]).toBeDefined();
+		expect(inference.targets.aggregation).toBeDefined();
+		expect(inference.workloads.memoryExtraction).toBeDefined();
+		expect(inference.workloads.aggregateRecall).toBeDefined();
 	});
 });

--- a/surfaces/cli/src/features/setup-pipeline.ts
+++ b/surfaces/cli/src/features/setup-pipeline.ts
@@ -4,6 +4,16 @@ import type { ExtractionProviderChoice, HarnessChoice } from "./setup-shared.js"
 export const EXTRACTION_SAFETY_WARNING =
 	"Extraction is intended for Claude Code (haiku), Codex CLI (gpt-5.4-mini) on a Pro/Max subscription, or local llama.cpp / Ollama with qwen3:4b or larger. Remote API extraction can rack up extreme usage fees fast. On a VPS, set the provider to none unless you explicitly want background extraction.";
 
+/**
+ * Providers eligible for the distinct aggregate-recall workload. Aggregate
+ * recall is latency-sensitive and pi-ai-only — harness subprocesss (acpx /
+ * claude-code / codex / opencode) are excluded because spawn latency would
+ * dominate (see dashboard InferenceSection). Setup offers the non-subprocess
+ * providers it already knows how to configure.
+ */
+export const AGGREGATE_RECALL_PROVIDER_CHOICES = ["openrouter", "openai-compatible", "ollama", "llama-cpp"] as const;
+export type AggregateRecallProviderChoice = (typeof AGGREGATE_RECALL_PROVIDER_CHOICES)[number];
+
 export interface SetupPipelineConfig {
 	readonly enabled: boolean;
 	readonly extraction: {
@@ -11,7 +21,7 @@ export interface SetupPipelineConfig {
 		readonly model: string;
 		readonly endpoint?: string;
 	};
-	readonly synthesis?: {
+	readonly synthesis: {
 		readonly enabled: boolean;
 		readonly provider: ExtractionProviderChoice;
 		readonly model: string;
@@ -38,21 +48,14 @@ export function defaultExtractionModel(provider: DirectExtractionProviderChoice)
 	return defaultPipelineModel(provider);
 }
 
-export interface SetupSynthesisOverride {
-	readonly provider?: ExtractionProviderChoice;
-	readonly model?: string;
-	readonly endpoint?: string;
-}
-
 export function buildSetupPipeline(
 	provider: ExtractionProviderChoice,
 	model?: string,
 	endpoint?: string,
-	synthesis?: SetupSynthesisOverride,
 ): SetupPipelineConfig {
 	const resolved = model?.trim() || (provider === "acpx" ? "" : defaultExtractionModel(provider));
 	const resolvedEndpoint = endpoint?.trim() || undefined;
-	if (provider === "none" && (!synthesis || !synthesis.provider || synthesis.provider === "none")) {
+	if (provider === "none") {
 		return {
 			enabled: false,
 			extraction: {
@@ -68,14 +71,9 @@ export function buildSetupPipeline(
 		};
 	}
 
-	// Synthesis provider: an explicit override decouples session summaries from
-	// the extraction model. When absent, synthesis mirrors extraction (legacy).
-	const synthProvider = synthesis?.provider ?? provider;
-	const synthModel = synthesis?.provider
-		? synthesis.model?.trim() || (synthProvider === "acpx" ? "" : defaultExtractionModel(synthProvider))
-		: resolved;
-	const synthEndpoint = synthesis?.provider ? synthesis.endpoint?.trim() || undefined : resolvedEndpoint;
-
+	// Session synthesis runs on the same provider as extraction — there is no
+	// distinct "synthesis provider". The only per-operation override is
+	// aggregate recall, configured separately via the routing config.
 	return {
 		enabled: provider !== "none",
 		extraction: {
@@ -84,10 +82,10 @@ export function buildSetupPipeline(
 			...(resolvedEndpoint ? { endpoint: resolvedEndpoint } : {}),
 		},
 		synthesis: {
-			enabled: synthProvider !== "none",
-			provider: synthProvider,
-			model: synthModel,
-			...(synthEndpoint ? { endpoint: synthEndpoint } : {}),
+			enabled: provider !== "none",
+			provider,
+			model: resolved,
+			...(resolvedEndpoint ? { endpoint: resolvedEndpoint } : {}),
 			timeout: 120000,
 		},
 		semanticContradictionEnabled: true,
@@ -256,4 +254,48 @@ function isGeneratedAcpxWorkload(value: unknown): boolean {
 		!Array.isArray(value) &&
 		(value as { target?: unknown }).target === "background-acpx/default"
 	);
+}
+
+/**
+ * Build the modern routing-config fragment that binds a distinct provider to
+ * the aggregate-recall workload. Merged into config.inference by the daemon
+ * (parseRoutingConfig overlays inference.* atop the legacy pipeline.* base),
+ * so extraction/session-synthesis keep working from the extraction provider.
+ *
+ * Credentials are not wired inline — provider backends reference an account
+ * by family that the user connects separately (same model as extraction).
+ */
+export function buildSetupAggregateRecall(
+	provider: AggregateRecallProviderChoice,
+	model?: string,
+	endpoint?: string,
+): { targets: Record<string, unknown>; workloads: Record<string, unknown> } {
+	const resolvedModel = model?.trim() || defaultPipelineModel(provider);
+	const target: Record<string, unknown> = {
+		executor: provider,
+		models: { default: { model: resolvedModel, reasoning: "medium" } },
+	};
+	if (provider === "openai-compatible") {
+		target.endpoint = endpoint?.trim() || "http://localhost:1234/v1";
+	} else if (provider === "openrouter") {
+		// Reference a connected account by family; the credential is connected
+		// separately (connect wall / secrets), exactly like extraction.
+		target.account = "openrouter";
+	}
+	return {
+		targets: { aggregation: target },
+		workloads: { aggregateRecall: { target: "aggregation/default", taskClass: "aggregate_recall" } },
+	};
+}
+
+/** Merge an aggregate-recall fragment into config.inference (creating it if the
+ * acpx route did not). */
+export function applyAggregateRecallRoute(
+	config: Record<string, unknown>,
+	aggregateRecall: { targets: Record<string, unknown>; workloads: Record<string, unknown> },
+): void {
+	const existing = (config.inference ?? {}) as Record<string, unknown>;
+	const targets = { ...((existing.targets as Record<string, unknown>) ?? {}), ...aggregateRecall.targets };
+	const workloads = { ...((existing.workloads as Record<string, unknown>) ?? {}), ...aggregateRecall.workloads };
+	config.inference = { ...existing, targets, workloads };
 }

--- a/surfaces/cli/src/features/setup-pipeline.ts
+++ b/surfaces/cli/src/features/setup-pipeline.ts
@@ -262,14 +262,15 @@ function isGeneratedAcpxWorkload(value: unknown): boolean {
  * Mirrors the dashboard's InferenceSection writer: a target bound to
  * workloads.aggregateRecall (target only, no taskClass — the daemon validates
  * taskClasses and 'aggregate_recall' is not declared). For the openrouter
- * family we also create the account block (credentialRef OPENROUTER_API_KEY)
- * the way compileLegacyRoutingConfig does for extraction, so the daemon can
- * resolve the credential instead of hard-blocking the target as 'missing'.
+ * family we either reuse the connected extraction account or create the
+ * established OPENROUTER_API_KEY-backed account. Both shapes ensure the daemon
+ * can resolve the credential instead of hard-blocking the target as 'missing'.
  */
 export function buildSetupAggregateRecall(
 	provider: string,
 	model: string,
 	endpoint?: string,
+	reuseConnectedOpenRouterAccount = false,
 ): { targets: Record<string, unknown>; accounts?: Record<string, unknown>; workloads: Record<string, unknown> } {
 	const resolvedModel = model.trim();
 	const target: Record<string, unknown> = {
@@ -280,10 +281,15 @@ export function buildSetupAggregateRecall(
 	if (provider === "openai-compatible") {
 		target.endpoint = endpoint?.trim() || "http://localhost:1234/v1";
 	} else if (provider === "openrouter") {
-		// Reference an account backed by the same env key extraction uses, so the
-		// daemon resolves the credential at call time instead of blocking the target.
-		target.account = "aggregation";
-		accounts = { aggregation: { kind: "api", providerFamily: "openrouter", credentialRef: "OPENROUTER_API_KEY" } };
+		// The interactive connect flow stores its API key as SIGNET_KEY_OPENROUTER
+		// on the extraction account. Reuse that account rather than creating an
+		// aggregation account that points at the unrelated legacy env variable.
+		if (reuseConnectedOpenRouterAccount) {
+			target.account = "openrouter";
+		} else {
+			target.account = "aggregation";
+			accounts = { aggregation: { kind: "api", providerFamily: "openrouter", credentialRef: "OPENROUTER_API_KEY" } };
+		}
 	}
 	return {
 		targets: { aggregation: target },

--- a/surfaces/cli/src/features/setup-pipeline.ts
+++ b/surfaces/cli/src/features/setup-pipeline.ts
@@ -5,14 +5,11 @@ export const EXTRACTION_SAFETY_WARNING =
 	"Extraction is intended for Claude Code (haiku), Codex CLI (gpt-5.4-mini) on a Pro/Max subscription, or local llama.cpp / Ollama with qwen3:4b or larger. Remote API extraction can rack up extreme usage fees fast. On a VPS, set the provider to none unless you explicitly want background extraction.";
 
 /**
- * Providers eligible for the distinct aggregate-recall workload. Aggregate
- * recall is latency-sensitive and pi-ai-only — harness subprocesss (acpx /
- * claude-code / codex / opencode) are excluded because spawn latency would
- * dominate (see dashboard InferenceSection). Setup offers the non-subprocess
- * providers it already knows how to configure.
+ * Providers eligible for the distinct aggregate-recall workload are sourced
+ * from pi-ai via aggregateRecallProviderIds() in setup-inference-connect
+ * (pi-ai families + local servers; ACPX is excluded — aggregate recall is
+ * latency-sensitive, and spawn latency would dominate).
  */
-export const AGGREGATE_RECALL_PROVIDER_CHOICES = ["openrouter", "openai-compatible", "ollama", "llama-cpp"] as const;
-export type AggregateRecallProviderChoice = (typeof AGGREGATE_RECALL_PROVIDER_CHOICES)[number];
 
 export interface SetupPipelineConfig {
 	readonly enabled: boolean;
@@ -270,7 +267,7 @@ function isGeneratedAcpxWorkload(value: unknown): boolean {
  * resolve the credential instead of hard-blocking the target as 'missing'.
  */
 export function buildSetupAggregateRecall(
-	provider: AggregateRecallProviderChoice,
+	provider: string,
 	model?: string,
 	endpoint?: string,
 ): { targets: Record<string, unknown>; accounts?: Record<string, unknown>; workloads: Record<string, unknown> } {

--- a/surfaces/cli/src/features/setup-pipeline.ts
+++ b/surfaces/cli/src/features/setup-pipeline.ts
@@ -75,14 +75,14 @@ export function buildSetupPipeline(
 	// distinct "synthesis provider". The only per-operation override is
 	// aggregate recall, configured separately via the routing config.
 	return {
-		enabled: provider !== "none",
+		enabled: true,
 		extraction: {
 			provider,
 			model: resolved,
 			...(resolvedEndpoint ? { endpoint: resolvedEndpoint } : {}),
 		},
 		synthesis: {
-			enabled: provider !== "none",
+			enabled: true,
 			provider,
 			model: resolved,
 			...(resolvedEndpoint ? { endpoint: resolvedEndpoint } : {}),

--- a/surfaces/cli/src/features/setup-pipeline.ts
+++ b/surfaces/cli/src/features/setup-pipeline.ts
@@ -262,29 +262,36 @@ function isGeneratedAcpxWorkload(value: unknown): boolean {
  * (parseRoutingConfig overlays inference.* atop the legacy pipeline.* base),
  * so extraction/session-synthesis keep working from the extraction provider.
  *
- * Credentials are not wired inline — provider backends reference an account
- * by family that the user connects separately (same model as extraction).
+ * Mirrors the dashboard's InferenceSection writer: a target bound to
+ * workloads.aggregateRecall (target only, no taskClass — the daemon validates
+ * taskClasses and 'aggregate_recall' is not declared). For the openrouter
+ * family we also create the account block (credentialRef OPENROUTER_API_KEY)
+ * the way compileLegacyRoutingConfig does for extraction, so the daemon can
+ * resolve the credential instead of hard-blocking the target as 'missing'.
  */
 export function buildSetupAggregateRecall(
 	provider: AggregateRecallProviderChoice,
 	model?: string,
 	endpoint?: string,
-): { targets: Record<string, unknown>; workloads: Record<string, unknown> } {
+): { targets: Record<string, unknown>; accounts?: Record<string, unknown>; workloads: Record<string, unknown> } {
 	const resolvedModel = model?.trim() || defaultPipelineModel(provider);
 	const target: Record<string, unknown> = {
 		executor: provider,
 		models: { default: { model: resolvedModel, reasoning: "medium" } },
 	};
+	let accounts: Record<string, unknown> | undefined;
 	if (provider === "openai-compatible") {
 		target.endpoint = endpoint?.trim() || "http://localhost:1234/v1";
 	} else if (provider === "openrouter") {
-		// Reference a connected account by family; the credential is connected
-		// separately (connect wall / secrets), exactly like extraction.
-		target.account = "openrouter";
+		// Reference an account backed by the same env key extraction uses, so the
+		// daemon resolves the credential at call time instead of blocking the target.
+		target.account = "aggregation";
+		accounts = { aggregation: { kind: "api", providerFamily: "openrouter", credentialRef: "OPENROUTER_API_KEY" } };
 	}
 	return {
 		targets: { aggregation: target },
-		workloads: { aggregateRecall: { target: "aggregation/default", taskClass: "aggregate_recall" } },
+		...(accounts ? { accounts } : {}),
+		workloads: { aggregateRecall: { target: "aggregation/default" } },
 	};
 }
 
@@ -292,10 +299,17 @@ export function buildSetupAggregateRecall(
  * acpx route did not). */
 export function applyAggregateRecallRoute(
 	config: Record<string, unknown>,
-	aggregateRecall: { targets: Record<string, unknown>; workloads: Record<string, unknown> },
+	aggregateRecall: {
+		targets: Record<string, unknown>;
+		accounts?: Record<string, unknown>;
+		workloads: Record<string, unknown>;
+	},
 ): void {
 	const existing = (config.inference ?? {}) as Record<string, unknown>;
 	const targets = { ...((existing.targets as Record<string, unknown>) ?? {}), ...aggregateRecall.targets };
 	const workloads = { ...((existing.workloads as Record<string, unknown>) ?? {}), ...aggregateRecall.workloads };
-	config.inference = { ...existing, targets, workloads };
+	const accounts = aggregateRecall.accounts
+		? { ...((existing.accounts as Record<string, unknown>) ?? {}), ...aggregateRecall.accounts }
+		: (existing.accounts as Record<string, unknown> | undefined);
+	config.inference = { ...existing, targets, workloads, ...(accounts ? { accounts } : {}) };
 }

--- a/surfaces/cli/src/features/setup-pipeline.ts
+++ b/surfaces/cli/src/features/setup-pipeline.ts
@@ -38,14 +38,21 @@ export function defaultExtractionModel(provider: DirectExtractionProviderChoice)
 	return defaultPipelineModel(provider);
 }
 
+export interface SetupSynthesisOverride {
+	readonly provider?: ExtractionProviderChoice;
+	readonly model?: string;
+	readonly endpoint?: string;
+}
+
 export function buildSetupPipeline(
 	provider: ExtractionProviderChoice,
 	model?: string,
 	endpoint?: string,
+	synthesis?: SetupSynthesisOverride,
 ): SetupPipelineConfig {
 	const resolved = model?.trim() || (provider === "acpx" ? "" : defaultExtractionModel(provider));
 	const resolvedEndpoint = endpoint?.trim() || undefined;
-	if (provider === "none") {
+	if (provider === "none" && (!synthesis || !synthesis.provider || synthesis.provider === "none")) {
 		return {
 			enabled: false,
 			extraction: {
@@ -61,18 +68,26 @@ export function buildSetupPipeline(
 		};
 	}
 
+	// Synthesis provider: an explicit override decouples session summaries from
+	// the extraction model. When absent, synthesis mirrors extraction (legacy).
+	const synthProvider = synthesis?.provider ?? provider;
+	const synthModel = synthesis?.provider
+		? synthesis.model?.trim() || (synthProvider === "acpx" ? "" : defaultExtractionModel(synthProvider))
+		: resolved;
+	const synthEndpoint = synthesis?.provider ? synthesis.endpoint?.trim() || undefined : resolvedEndpoint;
+
 	return {
-		enabled: true,
+		enabled: provider !== "none",
 		extraction: {
 			provider,
 			model: resolved,
 			...(resolvedEndpoint ? { endpoint: resolvedEndpoint } : {}),
 		},
 		synthesis: {
-			enabled: true,
-			provider,
-			model: resolved,
-			...(resolvedEndpoint ? { endpoint: resolvedEndpoint } : {}),
+			enabled: synthProvider !== "none",
+			provider: synthProvider,
+			model: synthModel,
+			...(synthEndpoint ? { endpoint: synthEndpoint } : {}),
 			timeout: 120000,
 		},
 		semanticContradictionEnabled: true,

--- a/surfaces/cli/src/features/setup-pipeline.ts
+++ b/surfaces/cli/src/features/setup-pipeline.ts
@@ -268,10 +268,10 @@ function isGeneratedAcpxWorkload(value: unknown): boolean {
  */
 export function buildSetupAggregateRecall(
 	provider: string,
-	model?: string,
+	model: string,
 	endpoint?: string,
 ): { targets: Record<string, unknown>; accounts?: Record<string, unknown>; workloads: Record<string, unknown> } {
-	const resolvedModel = model?.trim() || defaultPipelineModel(provider);
+	const resolvedModel = model.trim();
 	const target: Record<string, unknown> = {
 		executor: provider,
 		models: { default: { model: resolvedModel, reasoning: "medium" } },

--- a/surfaces/cli/src/features/setup-plan.test.ts
+++ b/surfaces/cli/src/features/setup-plan.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "bun:test";
+import { IDENTITY_PRESETS } from "@signet/core";
+import { type SetupPlan, parseSetupPlan, setupPlanJsonSchema } from "./setup-plan.js";
+
+function basePlan(overrides: Partial<SetupPlan> = {}): SetupPlan {
+	return {
+		agentName: "My Agent",
+		agentDescription: "Personal AI assistant",
+		networkMode: "localhost",
+		harnesses: ["claude-code"],
+		openclawRuntimePath: "plugin",
+		configureOpenClawWs: false,
+		embeddingProvider: "native",
+		embeddingModel: "nomic-embed-text-v1.5",
+		embeddingDimensions: 768,
+		extractionProvider: "claude-code",
+		extractionModel: "haiku",
+		extractionEndpoint: undefined,
+		searchBalance: 0.7,
+		searchTopK: 20,
+		searchMinScore: 0.3,
+		memorySessionBudget: 2000,
+		memoryDecayRate: 0.95,
+		gitEnabled: false,
+		signetSecretsEnabled: true,
+		graphiqEnabled: false,
+		identityMode: "managed",
+		identityPreset: "minimal",
+		startupIdentityFiles: [...IDENTITY_PRESETS.minimal.startup],
+		specialIdentityFiles: [...IDENTITY_PRESETS.minimal.special],
+		...overrides,
+	};
+}
+
+describe("setupPlanSchema", () => {
+	it("accepts a well-formed plan", () => {
+		const plan = basePlan();
+		expect(parseSetupPlan(plan)).toEqual(plan);
+	});
+
+	it("accepts a plan with an http openai-compatible endpoint", () => {
+		const plan = basePlan({
+			extractionProvider: "openai-compatible",
+			extractionEndpoint: "http://127.0.0.1:1234/v1",
+		});
+		expect(parseSetupPlan(plan).extractionEndpoint).toBe("http://127.0.0.1:1234/v1");
+	});
+
+	it("accepts identity mode off with empty identity file lists", () => {
+		const plan = basePlan({
+			identityMode: "off",
+			startupIdentityFiles: [],
+			specialIdentityFiles: [],
+		});
+		expect(parseSetupPlan(plan).identityMode).toBe("off");
+	});
+
+	it("rejects an out-of-range search balance", () => {
+		expect(() => parseSetupPlan(basePlan({ searchBalance: 1.5 }))).toThrow("searchBalance");
+	});
+
+	it("rejects a non-positive top_k", () => {
+		expect(() => parseSetupPlan(basePlan({ searchTopK: 0 }))).toThrow("searchTopK");
+	});
+
+	it("rejects an unknown harness", () => {
+		expect(() => parseSetupPlan(basePlan({ harnesses: ["unknown-harness" as never] }))).toThrow();
+	});
+
+	it("rejects an unknown identity mode", () => {
+		expect(() => parseSetupPlan(basePlan({ identityMode: "ghost" as never }))).toThrow("identityMode");
+	});
+
+	it("rejects an unknown extraction provider", () => {
+		expect(() => parseSetupPlan(basePlan({ extractionProvider: "bedrock" as never }))).toThrow();
+	});
+
+	it("rejects an unknown embedding provider", () => {
+		expect(() => parseSetupPlan(basePlan({ embeddingProvider: "voyage" as never }))).toThrow();
+	});
+
+	it("rejects a non-integer or negative embedding dimension", () => {
+		expect(() => parseSetupPlan(basePlan({ embeddingDimensions: 768.5 }))).toThrow("embeddingDimensions");
+		expect(() => parseSetupPlan(basePlan({ embeddingDimensions: -1 }))).toThrow("embeddingDimensions");
+	});
+
+	it("rejects a non-positive memory session budget", () => {
+		expect(() => parseSetupPlan(basePlan({ memorySessionBudget: 0 }))).toThrow("memorySessionBudget");
+	});
+
+	it("rejects an out-of-range search min score", () => {
+		expect(() => parseSetupPlan(basePlan({ searchMinScore: 2 }))).toThrow("searchMinScore");
+	});
+
+	it("rejects an invalid special-identity session kind", () => {
+		const bad = basePlan({
+			specialIdentityFiles: [{ path: "DREAMING.md", kind: "naptime" as never }],
+		});
+		expect(() => parseSetupPlan(bad)).toThrow("kind");
+	});
+
+	it("rejects a non-http extraction endpoint", () => {
+		expect(() => parseSetupPlan(basePlan({ extractionEndpoint: "ftp://example.test/v1" }))).toThrow(
+			"extractionEndpoint",
+		);
+	});
+
+	it("lists every invalid field when multiple are wrong", () => {
+		const bad = basePlan({ searchBalance: 5, memoryDecayRate: -1, identityMode: "ghost" as never });
+		try {
+			parseSetupPlan(bad);
+			throw new Error("should have thrown");
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			expect(message).toContain("searchBalance");
+			expect(message).toContain("memoryDecayRate");
+			expect(message).toContain("identityMode");
+		}
+	});
+
+	it("accepts the startup files the openclaw preset produces", () => {
+		const plan = basePlan({
+			identityPreset: "openclaw",
+			startupIdentityFiles: [...IDENTITY_PRESETS.openclaw.startup],
+			specialIdentityFiles: [...IDENTITY_PRESETS.openclaw.special],
+		});
+		const parsed = parseSetupPlan(plan);
+		expect(parsed.specialIdentityFiles.some((entry) => entry.kind === "dreaming")).toBe(true);
+	});
+});
+
+describe("setupPlanJsonSchema", () => {
+	it("emits a JSON Schema document with the plan properties", () => {
+		const schema = setupPlanJsonSchema() as { properties: Record<string, unknown> };
+		expect(schema.properties).toBeDefined();
+		for (const key of [
+			"agentName",
+			"networkMode",
+			"harnesses",
+			"embeddingProvider",
+			"searchBalance",
+			"identityPreset",
+		]) {
+			expect(schema.properties[key]).toBeDefined();
+		}
+	});
+
+	it("keeps the zod schema and its inferred type in sync", () => {
+		// parseSetupPlan returns the same shape setupPlanSchema infers; a
+		// round-trip through JSON must stay valid (plan is serializable).
+		const plan = basePlan();
+		const roundTrip = parseSetupPlan(JSON.parse(JSON.stringify(plan)));
+		expect(roundTrip).toEqual(plan);
+	});
+});

--- a/surfaces/cli/src/features/setup-plan.test.ts
+++ b/surfaces/cli/src/features/setup-plan.test.ts
@@ -159,6 +159,15 @@ describe("setupPlanSchema", () => {
 		expect(() => parseSetupPlan(basePlan({ synthesisModel: "x" }))).toThrow("synthesisProvider");
 	});
 
+	it("accepts a remote daemon URL", () => {
+		const plan = basePlan({ daemonUrl: "https://signet.remote.example:8443" });
+		expect(parseSetupPlan(plan).daemonUrl).toBe("https://signet.remote.example:8443");
+	});
+
+	it("rejects a non-http daemon URL", () => {
+		expect(() => parseSetupPlan(basePlan({ daemonUrl: "ftp://x" }))).toThrow("daemonUrl");
+	});
+
 	it("rejects openai-compatible synthesis without an endpoint", () => {
 		expect(() => parseSetupPlan(basePlan({ synthesisProvider: "openai-compatible" }))).toThrow("synthesisEndpoint");
 	});

--- a/surfaces/cli/src/features/setup-plan.test.ts
+++ b/surfaces/cli/src/features/setup-plan.test.ts
@@ -198,6 +198,15 @@ describe("setupPlanSchema", () => {
 		expect(parseSetupPlan(plan).daemonUrl).toBe("https://signet.remote.example:8443");
 	});
 
+	it("accepts a bracketed IPv6 remote daemon URL", () => {
+		const plan = basePlan({ daemonUrl: "http://[fd00:dead:beef::1]:3850" });
+		expect(parseSetupPlan(plan).daemonUrl).toBe("http://[fd00:dead:beef::1]:3850");
+	});
+
+	it("rejects a malformed bracketed IPv6 remote daemon URL", () => {
+		expect(() => parseSetupPlan(basePlan({ daemonUrl: "http://[:::1]" }))).toThrow("daemonUrl");
+	});
+
 	it("rejects a non-http daemon URL", () => {
 		expect(() => parseSetupPlan(basePlan({ daemonUrl: "ftp://x" }))).toThrow("daemonUrl");
 	});

--- a/surfaces/cli/src/features/setup-plan.test.ts
+++ b/surfaces/cli/src/features/setup-plan.test.ts
@@ -99,6 +99,30 @@ describe("setupPlanSchema", () => {
 		expect(() => parseSetupPlan(bad)).toThrow("kind");
 	});
 
+	it("rejects openai-compatible extraction without an endpoint", () => {
+		expect(() => parseSetupPlan(basePlan({ extractionProvider: "openai-compatible" }))).toThrow("extractionEndpoint");
+	});
+
+	it("accepts openai-compatible extraction with an endpoint", () => {
+		const plan = basePlan({
+			extractionProvider: "openai-compatible",
+			extractionEndpoint: "http://127.0.0.1:1234/v1",
+		});
+		expect(parseSetupPlan(plan).extractionProvider).toBe("openai-compatible");
+	});
+
+	it("rejects unknown top-level keys (strict contract)", () => {
+		const plan = { ...basePlan(), typoField: true };
+		expect(() => parseSetupPlan(plan)).toThrow();
+	});
+
+	it("rejects unknown keys in identity file entries", () => {
+		const plan = basePlan({
+			startupIdentityFiles: [{ path: "AGENTS.md", bogus: true } as never],
+		});
+		expect(() => parseSetupPlan(plan)).toThrow();
+	});
+
 	it("rejects a non-http extraction endpoint", () => {
 		expect(() => parseSetupPlan(basePlan({ extractionEndpoint: "ftp://example.test/v1" }))).toThrow(
 			"extractionEndpoint",

--- a/surfaces/cli/src/features/setup-plan.test.ts
+++ b/surfaces/cli/src/features/setup-plan.test.ts
@@ -168,6 +168,11 @@ describe("setupPlanSchema", () => {
 		expect(() => parseSetupPlan(basePlan({ daemonUrl: "ftp://x" }))).toThrow("daemonUrl");
 	});
 
+	it("accepts obsidian sources", () => {
+		const plan = basePlan({ sources: [{ type: "obsidian", path: "/tmp/vault", name: "vault" }] });
+		expect(parseSetupPlan(plan).sources?.[0].path).toBe("/tmp/vault");
+	});
+
 	it("rejects openai-compatible synthesis without an endpoint", () => {
 		expect(() => parseSetupPlan(basePlan({ synthesisProvider: "openai-compatible" }))).toThrow("synthesisEndpoint");
 	});

--- a/surfaces/cli/src/features/setup-plan.test.ts
+++ b/surfaces/cli/src/features/setup-plan.test.ts
@@ -120,7 +120,10 @@ describe("setupPlanSchema", () => {
 	});
 
 	it("accepts a connected extraction provider decision", () => {
-		const plan = basePlan({ extractionConnect: { family: "anthropic", connectMethod: "oauth" } });
+		const plan = basePlan({
+			extractionProvider: "anthropic",
+			extractionConnect: { family: "anthropic", connectMethod: "oauth" },
+		});
 		expect(parseSetupPlan(plan).extractionConnect).toEqual({ family: "anthropic", connectMethod: "oauth" });
 	});
 
@@ -173,6 +176,21 @@ describe("setupPlanSchema", () => {
 
 	it("rejects aggregate-recall model without a provider", () => {
 		expect(() => parseSetupPlan(basePlan({ aggregateRecallModel: "x" }))).toThrow("aggregateRecallProvider");
+	});
+
+	it("rejects aggregate-recall provider without a model", () => {
+		expect(() => parseSetupPlan(basePlan({ aggregateRecallProvider: "openrouter" }))).toThrow("aggregateRecallModel");
+	});
+
+	it("rejects a connected provider whose family differs from extractionProvider", () => {
+		expect(() =>
+			parseSetupPlan(
+				basePlan({
+					extractionProvider: "anthropic",
+					extractionConnect: { family: "openrouter", connectMethod: "api" },
+				}),
+			),
+		).toThrow("extractionConnect.family");
 	});
 
 	it("accepts a remote daemon URL", () => {

--- a/surfaces/cli/src/features/setup-plan.test.ts
+++ b/surfaces/cli/src/features/setup-plan.test.ts
@@ -116,6 +116,22 @@ describe("setupPlanSchema", () => {
 		expect(parseSetupPlan(plan).synthesisProvider).toBe("openrouter");
 	});
 
+	it("accepts a multi-agent roster", () => {
+		const plan = basePlan({
+			agents: [
+				{ name: "researcher", memoryPolicy: "isolated" },
+				{ name: "writer", memoryPolicy: "group", memoryGroup: "docs" },
+			],
+		});
+		const parsed = parseSetupPlan(plan);
+		expect(parsed.agents).toHaveLength(2);
+		expect(parsed.agents?.[1].memoryGroup).toBe("docs");
+	});
+
+	it("rejects an invalid agent memory policy", () => {
+		expect(() => parseSetupPlan(basePlan({ agents: [{ name: "x", memoryPolicy: "open" as never }] }))).toThrow();
+	});
+
 	it("rejects openai-compatible synthesis without an endpoint", () => {
 		expect(() => parseSetupPlan(basePlan({ synthesisProvider: "openai-compatible" }))).toThrow("synthesisEndpoint");
 	});

--- a/surfaces/cli/src/features/setup-plan.test.ts
+++ b/surfaces/cli/src/features/setup-plan.test.ts
@@ -124,6 +124,20 @@ describe("setupPlanSchema", () => {
 		expect(parseSetupPlan(plan).extractionConnect).toEqual({ family: "anthropic", connectMethod: "oauth" });
 	});
 
+	it("rejects a model key on extractionConnect (the model lives in extractionModel)", () => {
+		// Regression: the wizard used to assign the whole {family,connectMethod,model}
+		// object, which the strict schema rejected with 'Unrecognized key: model'.
+		expect(() =>
+			parseSetupPlan(
+				basePlan({
+					extractionProvider: "openai-codex",
+					extractionModel: "gpt-5.5",
+					extractionConnect: { family: "openai-codex", connectMethod: "oauth", model: "gpt-5.5" } as never,
+				}),
+			),
+		).toThrow("model");
+	});
+
 	it("accepts a multi-agent roster", () => {
 		const plan = basePlan({
 			agents: [

--- a/surfaces/cli/src/features/setup-plan.test.ts
+++ b/surfaces/cli/src/features/setup-plan.test.ts
@@ -132,6 +132,33 @@ describe("setupPlanSchema", () => {
 		expect(() => parseSetupPlan(basePlan({ agents: [{ name: "x", memoryPolicy: "open" as never }] }))).toThrow();
 	});
 
+	it("rejects group policy without a group", () => {
+		expect(() => parseSetupPlan(basePlan({ agents: [{ name: "x", memoryPolicy: "group" }] }))).toThrow("memoryGroup");
+	});
+
+	it("rejects duplicate agent names", () => {
+		expect(() =>
+			parseSetupPlan(
+				basePlan({
+					agents: [
+						{ name: "x", memoryPolicy: "isolated" },
+						{ name: "x", memoryPolicy: "shared" },
+					],
+				}),
+			),
+		).toThrow("duplicate");
+	});
+
+	it("rejects synthesis without extraction (dead config)", () => {
+		expect(() =>
+			parseSetupPlan(basePlan({ extractionProvider: "none", synthesisProvider: "openrouter", synthesisModel: "x" })),
+		).toThrow("synthesis");
+	});
+
+	it("rejects synthesis model without a provider", () => {
+		expect(() => parseSetupPlan(basePlan({ synthesisModel: "x" }))).toThrow("synthesisProvider");
+	});
+
 	it("rejects openai-compatible synthesis without an endpoint", () => {
 		expect(() => parseSetupPlan(basePlan({ synthesisProvider: "openai-compatible" }))).toThrow("synthesisEndpoint");
 	});

--- a/surfaces/cli/src/features/setup-plan.test.ts
+++ b/surfaces/cli/src/features/setup-plan.test.ts
@@ -168,6 +168,11 @@ describe("setupPlanSchema", () => {
 		expect(() => parseSetupPlan(basePlan({ daemonUrl: "ftp://x" }))).toThrow("daemonUrl");
 	});
 
+	it("rejects a daemon URL with a path or query (must be a bare origin)", () => {
+		expect(() => parseSetupPlan(basePlan({ daemonUrl: "https://host/signet" }))).toThrow("daemonUrl");
+		expect(() => parseSetupPlan(basePlan({ daemonUrl: "https://host?token=1" }))).toThrow("daemonUrl");
+	});
+
 	it("accepts obsidian sources", () => {
 		const plan = basePlan({ sources: [{ type: "obsidian", path: "/tmp/vault", name: "vault" }] });
 		expect(parseSetupPlan(plan).sources?.[0].path).toBe("/tmp/vault");

--- a/surfaces/cli/src/features/setup-plan.test.ts
+++ b/surfaces/cli/src/features/setup-plan.test.ts
@@ -111,9 +111,12 @@ describe("setupPlanSchema", () => {
 		expect(parseSetupPlan(plan).extractionProvider).toBe("openai-compatible");
 	});
 
-	it("accepts a distinct synthesis provider", () => {
-		const plan = basePlan({ synthesisProvider: "openrouter", synthesisModel: "anthropic/claude-3.5-sonnet" });
-		expect(parseSetupPlan(plan).synthesisProvider).toBe("openrouter");
+	it("accepts a distinct aggregate-recall provider", () => {
+		const plan = basePlan({
+			aggregateRecallProvider: "openrouter",
+			aggregateRecallModel: "anthropic/claude-3.5-sonnet",
+		});
+		expect(parseSetupPlan(plan).aggregateRecallProvider).toBe("openrouter");
 	});
 
 	it("accepts a multi-agent roster", () => {
@@ -149,14 +152,8 @@ describe("setupPlanSchema", () => {
 		).toThrow("duplicate");
 	});
 
-	it("rejects synthesis without extraction (dead config)", () => {
-		expect(() =>
-			parseSetupPlan(basePlan({ extractionProvider: "none", synthesisProvider: "openrouter", synthesisModel: "x" })),
-		).toThrow("synthesis");
-	});
-
-	it("rejects synthesis model without a provider", () => {
-		expect(() => parseSetupPlan(basePlan({ synthesisModel: "x" }))).toThrow("synthesisProvider");
+	it("rejects aggregate-recall model without a provider", () => {
+		expect(() => parseSetupPlan(basePlan({ aggregateRecallModel: "x" }))).toThrow("aggregateRecallProvider");
 	});
 
 	it("accepts a remote daemon URL", () => {
@@ -178,8 +175,10 @@ describe("setupPlanSchema", () => {
 		expect(parseSetupPlan(plan).sources?.[0].path).toBe("/tmp/vault");
 	});
 
-	it("rejects openai-compatible synthesis without an endpoint", () => {
-		expect(() => parseSetupPlan(basePlan({ synthesisProvider: "openai-compatible" }))).toThrow("synthesisEndpoint");
+	it("rejects openai-compatible aggregate recall without an endpoint", () => {
+		expect(() => parseSetupPlan(basePlan({ aggregateRecallProvider: "openai-compatible" }))).toThrow(
+			"aggregateRecallEndpoint",
+		);
 	});
 
 	it("rejects unknown top-level keys (strict contract)", () => {

--- a/surfaces/cli/src/features/setup-plan.test.ts
+++ b/surfaces/cli/src/features/setup-plan.test.ts
@@ -181,6 +181,12 @@ describe("setupPlanSchema", () => {
 		);
 	});
 
+	it("rejects aggregate recall when extraction is disabled (nothing to synthesize)", () => {
+		expect(() =>
+			parseSetupPlan(basePlan({ extractionProvider: "none", aggregateRecallProvider: "ollama", aggregateRecallModel: "qwen3:4b" })),
+		).toThrow("aggregateRecallProvider");
+	});
+
 	it("rejects unknown top-level keys (strict contract)", () => {
 		const plan = { ...basePlan(), typoField: true };
 		expect(() => parseSetupPlan(plan)).toThrow();

--- a/surfaces/cli/src/features/setup-plan.test.ts
+++ b/surfaces/cli/src/features/setup-plan.test.ts
@@ -111,6 +111,15 @@ describe("setupPlanSchema", () => {
 		expect(parseSetupPlan(plan).extractionProvider).toBe("openai-compatible");
 	});
 
+	it("accepts a distinct synthesis provider", () => {
+		const plan = basePlan({ synthesisProvider: "openrouter", synthesisModel: "anthropic/claude-3.5-sonnet" });
+		expect(parseSetupPlan(plan).synthesisProvider).toBe("openrouter");
+	});
+
+	it("rejects openai-compatible synthesis without an endpoint", () => {
+		expect(() => parseSetupPlan(basePlan({ synthesisProvider: "openai-compatible" }))).toThrow("synthesisEndpoint");
+	});
+
 	it("rejects unknown top-level keys (strict contract)", () => {
 		const plan = { ...basePlan(), typoField: true };
 		expect(() => parseSetupPlan(plan)).toThrow();

--- a/surfaces/cli/src/features/setup-plan.test.ts
+++ b/surfaces/cli/src/features/setup-plan.test.ts
@@ -119,6 +119,11 @@ describe("setupPlanSchema", () => {
 		expect(parseSetupPlan(plan).aggregateRecallProvider).toBe("openrouter");
 	});
 
+	it("accepts a connected extraction provider decision", () => {
+		const plan = basePlan({ extractionConnect: { family: "anthropic", connectMethod: "oauth" } });
+		expect(parseSetupPlan(plan).extractionConnect).toEqual({ family: "anthropic", connectMethod: "oauth" });
+	});
+
 	it("accepts a multi-agent roster", () => {
 		const plan = basePlan({
 			agents: [
@@ -183,7 +188,9 @@ describe("setupPlanSchema", () => {
 
 	it("rejects aggregate recall when extraction is disabled (nothing to synthesize)", () => {
 		expect(() =>
-			parseSetupPlan(basePlan({ extractionProvider: "none", aggregateRecallProvider: "ollama", aggregateRecallModel: "qwen3:4b" })),
+			parseSetupPlan(
+				basePlan({ extractionProvider: "none", aggregateRecallProvider: "ollama", aggregateRecallModel: "qwen3:4b" }),
+			),
 		).toThrow("aggregateRecallProvider");
 	});
 

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -214,7 +214,7 @@ export interface SetupApplyContext {
 	/** Run the provider connect (API-key entry / OAuth) against the now-running
 	 * daemon. Provided by the interactive wizard; undefined for headless plans
 	 * (the provider is connected later via the dashboard). */
-	readonly connectExtraction?: (family: string, method: "api" | "oauth") => Promise<boolean>;
+	readonly connectExtraction?: () => Promise<boolean>;
 }
 
 /**

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -94,6 +94,15 @@ export const setupPlanSchema = z
 		startupIdentityFiles: z.array(identityContextFileSchema),
 		specialIdentityFiles: z.array(identitySpecialFileSchema),
 		dreamingEnabled: z.boolean().optional(),
+		// Dashboard-style provider connect: when set, extraction runs on a connected
+		// cloud provider (API key or OAuth). The modern inference.* route is the
+		// source of truth; pipelineV2 stays enabled so the extraction worker runs.
+		extractionConnect: z
+			.strictObject({
+				family: z.string(),
+				connectMethod: z.enum(["api", "oauth"]),
+			})
+			.optional(),
 		daemonUrl: z
 			.string()
 			// Match normalizeDaemonUrl's rules: a bare origin (no path, query,
@@ -197,6 +206,10 @@ export interface SetupApplyContext {
 	readonly acpxBin?: string;
 	readonly openclawConfigCount: number;
 	readonly openDashboard: boolean;
+	/** Run the provider connect (API-key entry / OAuth) against the now-running
+	 * daemon. Provided by the interactive wizard; undefined for headless plans
+	 * (the provider is connected later via the dashboard). */
+	readonly connectExtraction?: (family: string, method: "api" | "oauth") => Promise<boolean>;
 }
 
 /**

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -94,7 +94,10 @@ export const setupPlanSchema = z
 		dreamingEnabled: z.boolean().optional(),
 		daemonUrl: z
 			.string()
-			.regex(/^https?:\/\/\S+$/, "must be an http:// or https:// URL")
+			// Match normalizeDaemonUrl's rules: a bare origin (no path, query,
+			// fragment, or credentials) so a persisted daemon.url cannot brick the
+			// module-load daemon client.
+			.regex(/^https?:\/\/[\w.:-]+\/?$/, "must be a bare http(s) origin (no path, query, or credentials)")
 			.optional(),
 		sources: z
 			.array(

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -92,6 +92,15 @@ export const setupPlanSchema = z
 		startupIdentityFiles: z.array(identityContextFileSchema),
 		specialIdentityFiles: z.array(identitySpecialFileSchema),
 		dreamingEnabled: z.boolean().optional(),
+		agents: z
+			.array(
+				z.strictObject({
+					name: z.string(),
+					memoryPolicy: z.enum(["isolated", "shared", "group"]),
+					memoryGroup: z.string().optional(),
+				}),
+			)
+			.optional(),
 	})
 	.superRefine((plan, ctx) => {
 		// openai-compatible extraction has no implicit endpoint; the interactive

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -69,6 +69,26 @@ const httpEndpointSchema = z
 	.describe("Required when extractionProvider is 'openai-compatible'")
 	.optional();
 
+/** A daemon URL is a bare origin, not an API path or credential-bearing URL. */
+export const BARE_DAEMON_ORIGIN_PATTERN = /^https?:\/\/(?:[\w.-]+|\[[0-9A-Fa-f:.]+\])(?::\d+)?\/?$/;
+
+export function isBareDaemonOrigin(value: string): boolean {
+	if (!BARE_DAEMON_ORIGIN_PATTERN.test(value)) return false;
+	try {
+		const parsed = new URL(value);
+		return (
+			(parsed.protocol === "http:" || parsed.protocol === "https:") &&
+			!parsed.username &&
+			!parsed.password &&
+			!parsed.search &&
+			!parsed.hash &&
+			(parsed.pathname === "/" || parsed.pathname === "")
+		);
+	} catch {
+		return false;
+	}
+}
+
 export const setupPlanSchema = z
 	.strictObject({
 		agentName: z.string(),
@@ -113,7 +133,7 @@ export const setupPlanSchema = z
 			// Match normalizeDaemonUrl's rules: a bare origin (no path, query,
 			// fragment, or credentials) so a persisted daemon.url cannot brick the
 			// module-load daemon client.
-			.regex(/^https?:\/\/[\w.:-]+\/?$/, "must be a bare http(s) origin (no path, query, or credentials)")
+			.regex(BARE_DAEMON_ORIGIN_PATTERN, "must be a bare http(s) origin (no path, query, or credentials)")
 			.optional(),
 		sources: z
 			.array(
@@ -135,6 +155,17 @@ export const setupPlanSchema = z
 			.optional(),
 	})
 	.superRefine((plan, ctx) => {
+		// The published regex admits bracketed IPv6 origins but cannot fully encode
+		// IPv6 grammar. Apply URL parsing at the plan boundary too, so --file and
+		// --json match the interactive/flag path rather than persisting a daemon
+		// URL the runtime will reject.
+		if (plan.daemonUrl && BARE_DAEMON_ORIGIN_PATTERN.test(plan.daemonUrl) && !isBareDaemonOrigin(plan.daemonUrl)) {
+			ctx.addIssue({
+				code: "custom",
+				message: "must be a valid bare http(s) origin",
+				path: ["daemonUrl"],
+			});
+		}
 		// openai-compatible extraction has no implicit endpoint; the interactive
 		// wizard defaults one, but a headless --file plan must state it.
 		if (plan.extractionProvider === "openai-compatible" && !plan.extractionEndpoint) {

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -91,6 +91,7 @@ export const setupPlanSchema = z
 		identityPreset: identityPresetSchema,
 		startupIdentityFiles: z.array(identityContextFileSchema),
 		specialIdentityFiles: z.array(identitySpecialFileSchema),
+		dreamingEnabled: z.boolean().optional(),
 	})
 	.superRefine((plan, ctx) => {
 		// openai-compatible extraction has no implicit endpoint; the interactive

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -7,6 +7,7 @@ import {
 	NETWORK_MODES,
 } from "@signet/core";
 import { z } from "zod";
+import { AGGREGATE_RECALL_PROVIDER_CHOICES } from "./setup-pipeline.js";
 import {
 	EMBEDDING_PROVIDER_CHOICES,
 	EXTRACTION_PROVIDER_CHOICES,
@@ -33,6 +34,7 @@ const networkModeSchema = z.enum(NETWORK_MODES);
 const harnessSchema = z.enum(SETUP_HARNESS_CHOICES);
 const embeddingProviderSchema = z.enum(EMBEDDING_PROVIDER_CHOICES);
 const extractionProviderSchema = z.enum(EXTRACTION_PROVIDER_CHOICES);
+const aggregateRecallProviderSchema = z.enum(AGGREGATE_RECALL_PROVIDER_CHOICES);
 const openclawRuntimeSchema = z.enum(OPENCLAW_RUNTIME_CHOICES);
 
 const identityModeSchema = z.enum(IDENTITY_MODES);
@@ -76,9 +78,9 @@ export const setupPlanSchema = z
 		extractionProvider: extractionProviderSchema,
 		extractionModel: z.string(),
 		extractionEndpoint: httpEndpointSchema,
-		synthesisProvider: extractionProviderSchema.optional(),
-		synthesisModel: z.string().optional(),
-		synthesisEndpoint: httpEndpointSchema,
+		aggregateRecallProvider: aggregateRecallProviderSchema.optional(),
+		aggregateRecallModel: z.string().optional(),
+		aggregateRecallEndpoint: httpEndpointSchema,
 		searchBalance: z.number().min(0).max(1),
 		searchTopK: z.number().int().positive(),
 		searchMinScore: z.number().min(0).max(1),
@@ -128,28 +130,21 @@ export const setupPlanSchema = z
 				path: ["extractionEndpoint"],
 			});
 		}
-		if (plan.synthesisProvider === "openai-compatible" && !plan.synthesisEndpoint) {
+		// Aggregate recall is a distinct provider for query-time evidence
+		// synthesis. It is pi-ai-only (no harness subprocess) and optional —
+		// when unset it falls through to the default policy (extraction).
+		if (plan.aggregateRecallProvider === "openai-compatible" && !plan.aggregateRecallEndpoint) {
 			ctx.addIssue({
 				code: "custom",
-				message: "openai-compatible synthesis requires synthesisEndpoint",
-				path: ["synthesisEndpoint"],
+				message: "openai-compatible aggregate recall requires aggregateRecallEndpoint",
+				path: ["aggregateRecallEndpoint"],
 			});
 		}
-		// synthesisModel/Endpoint are meaningless without a provider to apply them to.
-		if ((plan.synthesisModel || plan.synthesisEndpoint) && !plan.synthesisProvider) {
+		if ((plan.aggregateRecallModel || plan.aggregateRecallEndpoint) && !plan.aggregateRecallProvider) {
 			ctx.addIssue({
 				code: "custom",
-				message: "synthesisModel/synthesisEndpoint require synthesisProvider",
-				path: ["synthesisProvider"],
-			});
-		}
-		// The daemon gates the synthesis worker on pipelineV2.enabled, so a
-		// synthesis provider without extraction is dead config.
-		if (plan.extractionProvider === "none" && plan.synthesisProvider && plan.synthesisProvider !== "none") {
-			ctx.addIssue({
-				code: "custom",
-				message: "synthesis requires extraction to be enabled (the daemon gates synthesis on the extraction pipeline)",
-				path: ["synthesisProvider"],
+				message: "aggregateRecallModel/aggregateRecallEndpoint require aggregateRecallProvider",
+				path: ["aggregateRecallProvider"],
 			});
 		}
 		if (plan.agents) {

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -92,6 +92,10 @@ export const setupPlanSchema = z
 		startupIdentityFiles: z.array(identityContextFileSchema),
 		specialIdentityFiles: z.array(identitySpecialFileSchema),
 		dreamingEnabled: z.boolean().optional(),
+		daemonUrl: z
+			.string()
+			.regex(/^https?:\/\/\S+$/, "must be an http:// or https:// URL")
+			.optional(),
 		agents: z
 			.array(
 				z.strictObject({

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -76,6 +76,9 @@ export const setupPlanSchema = z
 		extractionProvider: extractionProviderSchema,
 		extractionModel: z.string(),
 		extractionEndpoint: httpEndpointSchema,
+		synthesisProvider: extractionProviderSchema.optional(),
+		synthesisModel: z.string().optional(),
+		synthesisEndpoint: httpEndpointSchema,
 		searchBalance: z.number().min(0).max(1),
 		searchTopK: z.number().int().positive(),
 		searchMinScore: z.number().min(0).max(1),
@@ -97,6 +100,13 @@ export const setupPlanSchema = z
 				code: "custom",
 				message: "openai-compatible extraction requires extractionEndpoint",
 				path: ["extractionEndpoint"],
+			});
+		}
+		if (plan.synthesisProvider === "openai-compatible" && !plan.synthesisEndpoint) {
+			ctx.addIssue({
+				code: "custom",
+				message: "openai-compatible synthesis requires synthesisEndpoint",
+				path: ["synthesisEndpoint"],
 			});
 		}
 	});

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -96,6 +96,15 @@ export const setupPlanSchema = z
 			.string()
 			.regex(/^https?:\/\/\S+$/, "must be an http:// or https:// URL")
 			.optional(),
+		sources: z
+			.array(
+				z.strictObject({
+					type: z.literal("obsidian"),
+					path: z.string(),
+					name: z.string().optional(),
+				}),
+			)
+			.optional(),
 		agents: z
 			.array(
 				z.strictObject({

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -161,6 +161,13 @@ export const setupPlanSchema = z
 				path: ["aggregateRecallProvider"],
 			});
 		}
+		if (plan.aggregateRecallProvider && !plan.aggregateRecallModel?.trim()) {
+			ctx.addIssue({
+				code: "custom",
+				message: "aggregateRecallProvider requires aggregateRecallModel",
+				path: ["aggregateRecallModel"],
+			});
+		}
 		// Aggregate recall synthesizes extracted memories at query time. With the
 		// pipeline disabled (extraction none) there is nothing to synthesize, so a
 		// distinct aggregate-recall provider would be dead config.
@@ -171,6 +178,22 @@ export const setupPlanSchema = z
 					"aggregateRecallProvider requires extraction to be enabled (nothing to synthesize without the extraction pipeline)",
 				path: ["aggregateRecallProvider"],
 			});
+		}
+		if (plan.extractionConnect) {
+			if (!connectableProviderIds().includes(plan.extractionConnect.family)) {
+				ctx.addIssue({
+					code: "custom",
+					message: `unknown connected provider "${plan.extractionConnect.family}"`,
+					path: ["extractionConnect", "family"],
+				});
+			}
+			if (plan.extractionConnect.family !== plan.extractionProvider) {
+				ctx.addIssue({
+					code: "custom",
+					message: "extractionConnect.family must match extractionProvider",
+					path: ["extractionConnect", "family"],
+				});
+			}
 		}
 		if (plan.agents) {
 			const seen = new Set<string>();

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -7,7 +7,7 @@ import {
 	NETWORK_MODES,
 } from "@signet/core";
 import { z } from "zod";
-import { CONNECTABLE_PROVIDERS } from "./setup-inference-connect.js";
+import { connectableProviderIds } from "./setup-inference-connect.js";
 import { AGGREGATE_RECALL_PROVIDER_CHOICES } from "./setup-pipeline.js";
 import {
 	EMBEDDING_PROVIDER_CHOICES,
@@ -35,11 +35,9 @@ const networkModeSchema = z.enum(NETWORK_MODES);
 const harnessSchema = z.enum(SETUP_HARNESS_CHOICES);
 const embeddingProviderSchema = z.enum(EMBEDDING_PROVIDER_CHOICES);
 // Extraction provider accepts both the legacy CLI choices and the dashboard
-// connect families (anthropic, openai-codex, github-copilot, …) — all are
-// valid routing executors the daemon's routing compiler handles.
-const EXTRACTION_PROVIDER_IDS = [
-	...new Set([...EXTRACTION_PROVIDER_CHOICES, ...CONNECTABLE_PROVIDERS.map((p) => p.id)]),
-] as const;
+// connect families (anthropic, openai-codex, github-copilot, …) — sourced from
+// pi-ai's catalog, all valid routing executors the daemon handles.
+const EXTRACTION_PROVIDER_IDS = [...new Set([...EXTRACTION_PROVIDER_CHOICES, ...connectableProviderIds()])] as const;
 const extractionProviderSchema = z.enum(EXTRACTION_PROVIDER_IDS);
 const aggregateRecallProviderSchema = z.enum(AGGREGATE_RECALL_PROVIDER_CHOICES);
 const openclawRuntimeSchema = z.enum(OPENCLAW_RUNTIME_CHOICES);

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -147,6 +147,17 @@ export const setupPlanSchema = z
 				path: ["aggregateRecallProvider"],
 			});
 		}
+		// Aggregate recall synthesizes extracted memories at query time. With the
+		// pipeline disabled (extraction none) there is nothing to synthesize, so a
+		// distinct aggregate-recall provider would be dead config.
+		if (plan.extractionProvider === "none" && plan.aggregateRecallProvider) {
+			ctx.addIssue({
+				code: "custom",
+				message:
+					"aggregateRecallProvider requires extraction to be enabled (nothing to synthesize without the extraction pipeline)",
+				path: ["aggregateRecallProvider"],
+			});
+		}
 		if (plan.agents) {
 			const seen = new Set<string>();
 			plan.agents.forEach((agent, i) => {

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -7,8 +7,7 @@ import {
 	NETWORK_MODES,
 } from "@signet/core";
 import { z } from "zod";
-import { connectableProviderIds } from "./setup-inference-connect.js";
-import { AGGREGATE_RECALL_PROVIDER_CHOICES } from "./setup-pipeline.js";
+import { aggregateRecallProviderIds, connectableProviderIds } from "./setup-inference-connect.js";
 import {
 	EMBEDDING_PROVIDER_CHOICES,
 	EXTRACTION_PROVIDER_CHOICES,
@@ -39,7 +38,8 @@ const embeddingProviderSchema = z.enum(EMBEDDING_PROVIDER_CHOICES);
 // pi-ai's catalog, all valid routing executors the daemon handles.
 const EXTRACTION_PROVIDER_IDS = [...new Set([...EXTRACTION_PROVIDER_CHOICES, ...connectableProviderIds()])] as const;
 const extractionProviderSchema = z.enum(EXTRACTION_PROVIDER_IDS);
-const aggregateRecallProviderSchema = z.enum(AGGREGATE_RECALL_PROVIDER_CHOICES);
+// Aggregate recall is pi-ai-only; accept any connectable pi-ai family + local servers.
+const aggregateRecallProviderSchema = z.enum(aggregateRecallProviderIds());
 const openclawRuntimeSchema = z.enum(OPENCLAW_RUNTIME_CHOICES);
 
 const identityModeSchema = z.enum(IDENTITY_MODES);

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -1,0 +1,132 @@
+import {
+	IDENTITY_MODES,
+	IDENTITY_PRESETS,
+	type IdentityContextFileEntry,
+	type IdentityPresetName,
+	type IdentitySpecialFileEntry,
+	NETWORK_MODES,
+} from "@signet/core";
+import { z } from "zod";
+import {
+	EMBEDDING_PROVIDER_CHOICES,
+	EXTRACTION_PROVIDER_CHOICES,
+	type ExtractionProviderChoice,
+	OPENCLAW_RUNTIME_CHOICES,
+	SETUP_HARNESS_CHOICES,
+} from "./setup-shared.js";
+
+/**
+ * `SetupPlan` is the single typed, serializable seam for `signet setup`.
+ *
+ * It captures every decision the fresh-setup wizard makes — no prompts, no
+ * side effects, no environment-derived values. Three frontends converge on it:
+ * the interactive wizard, a headless `--json`/`--file` payload, and the plain
+ * CLI flags. A validated plan is handed to {@link runFreshSetup} together with
+ * a {@link SetupApplyContext} that carries the runtime/detected bits.
+ *
+ * Design note: the choice enums are derived from the existing readonly choice
+ * arrays in `setup-shared.ts` so there is a single source of truth for the
+ * allowed harness/provider values.
+ */
+
+const networkModeSchema = z.enum(NETWORK_MODES);
+const harnessSchema = z.enum(SETUP_HARNESS_CHOICES);
+const embeddingProviderSchema = z.enum(EMBEDDING_PROVIDER_CHOICES);
+const extractionProviderSchema = z.enum(EXTRACTION_PROVIDER_CHOICES);
+const openclawRuntimeSchema = z.enum(OPENCLAW_RUNTIME_CHOICES);
+
+const identityModeSchema = z.enum(IDENTITY_MODES);
+const identityPresetSchema = z.enum(
+	// IDENTITY_PRESETS is Record<IdentityPresetName, ...>, so its keys are exactly the preset names.
+	Object.keys(IDENTITY_PRESETS) as [IdentityPresetName, ...IdentityPresetName[]],
+);
+const identitySessionKindSchema = z.enum(["dreaming", "heartbeat", "bootstrap"]);
+
+const identityContextFileSchema = z.object({
+	path: z.string(),
+	role: z.string().optional(),
+	budget: z.number().optional(),
+	enabled: z.boolean().optional(),
+});
+
+const identitySpecialFileSchema = identityContextFileSchema.extend({
+	kind: identitySessionKindSchema,
+});
+
+const httpEndpointSchema = z
+	.string()
+	.url()
+	.regex(/^https?:\/\//, "must be an http:// or https:// URL")
+	.optional();
+
+export const setupPlanSchema = z.object({
+	agentName: z.string(),
+	agentDescription: z.string(),
+	networkMode: networkModeSchema,
+	harnesses: z.array(harnessSchema),
+	openclawRuntimePath: openclawRuntimeSchema,
+	configureOpenClawWs: z.boolean(),
+	embeddingProvider: embeddingProviderSchema,
+	embeddingModel: z.string(),
+	embeddingDimensions: z.number().int().nonnegative(),
+	extractionProvider: extractionProviderSchema,
+	extractionModel: z.string(),
+	extractionEndpoint: httpEndpointSchema,
+	searchBalance: z.number().min(0).max(1),
+	searchTopK: z.number().int().positive(),
+	searchMinScore: z.number().min(0).max(1),
+	memorySessionBudget: z.number().int().positive(),
+	memoryDecayRate: z.number().min(0).max(1),
+	gitEnabled: z.boolean(),
+	signetSecretsEnabled: z.boolean(),
+	graphiqEnabled: z.boolean(),
+	identityMode: identityModeSchema,
+	identityPreset: identityPresetSchema,
+	startupIdentityFiles: z.array(identityContextFileSchema),
+	specialIdentityFiles: z.array(identitySpecialFileSchema),
+});
+
+export type SetupPlan = z.infer<typeof setupPlanSchema>;
+
+/**
+ * Runtime/detected context that is NOT a user decision and therefore not part
+ * of the serializable plan: where to apply, what was detected on disk, and how
+ * the invocation should behave (interactive vs. headless, protection policy).
+ */
+export interface SetupApplyContext {
+	readonly basePath: string;
+	readonly existingAgentsDir: boolean;
+	readonly nonInteractive: boolean;
+	readonly allowUnprotectedWorkspace: boolean;
+	readonly createLocalBackup: boolean;
+	readonly availableExtractionProviders: readonly ExtractionProviderChoice[];
+	readonly acpxBin?: string;
+	readonly openclawConfigCount: number;
+	readonly openDashboard: boolean;
+}
+
+/**
+ * Parse and validate a raw (e.g. JSON-decoded) setup plan. Throws a structured
+ * error listing every invalid field, so headless/agent callers get actionable
+ * feedback instead of a raw zod stack.
+ */
+export function parseSetupPlan(json: unknown): SetupPlan {
+	const result = setupPlanSchema.safeParse(json);
+	if (result.success) {
+		return result.data;
+	}
+	const issues = result.error.issues.map((issue) => {
+		const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+		return `  - ${path}: ${issue.message}`;
+	});
+	throw new Error(`Invalid setup plan:\n${issues.join("\n")}`);
+}
+
+/** JSON Schema (draft 2020-12) for the setup plan, for `signet setup --schema`. */
+export function setupPlanJsonSchema(): unknown {
+	return z.toJSONSchema(setupPlanSchema);
+}
+
+// Re-export the entry types so callers of the plan API do not need a second
+// import surface; the zod schemas mirror these core types exactly.
+export type { IdentityContextFileEntry, IdentitySpecialFileEntry };

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -119,6 +119,43 @@ export const setupPlanSchema = z
 				path: ["synthesisEndpoint"],
 			});
 		}
+		// synthesisModel/Endpoint are meaningless without a provider to apply them to.
+		if ((plan.synthesisModel || plan.synthesisEndpoint) && !plan.synthesisProvider) {
+			ctx.addIssue({
+				code: "custom",
+				message: "synthesisModel/synthesisEndpoint require synthesisProvider",
+				path: ["synthesisProvider"],
+			});
+		}
+		// The daemon gates the synthesis worker on pipelineV2.enabled, so a
+		// synthesis provider without extraction is dead config.
+		if (plan.extractionProvider === "none" && plan.synthesisProvider && plan.synthesisProvider !== "none") {
+			ctx.addIssue({
+				code: "custom",
+				message: "synthesis requires extraction to be enabled (the daemon gates synthesis on the extraction pipeline)",
+				path: ["synthesisProvider"],
+			});
+		}
+		if (plan.agents) {
+			const seen = new Set<string>();
+			plan.agents.forEach((agent, i) => {
+				if (agent.memoryPolicy === "group" && !agent.memoryGroup) {
+					ctx.addIssue({
+						code: "custom",
+						message: "group memory policy requires memoryGroup",
+						path: ["agents", i, "memoryGroup"],
+					});
+				}
+				if (seen.has(agent.name)) {
+					ctx.addIssue({
+						code: "custom",
+						message: `duplicate agent name "${agent.name}"`,
+						path: ["agents", i, "name"],
+					});
+				}
+				seen.add(agent.name);
+			});
+		}
 	});
 
 export type SetupPlan = z.infer<typeof setupPlanSchema>;

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -7,6 +7,7 @@ import {
 	NETWORK_MODES,
 } from "@signet/core";
 import { z } from "zod";
+import { CONNECTABLE_PROVIDERS } from "./setup-inference-connect.js";
 import { AGGREGATE_RECALL_PROVIDER_CHOICES } from "./setup-pipeline.js";
 import {
 	EMBEDDING_PROVIDER_CHOICES,
@@ -33,7 +34,13 @@ import {
 const networkModeSchema = z.enum(NETWORK_MODES);
 const harnessSchema = z.enum(SETUP_HARNESS_CHOICES);
 const embeddingProviderSchema = z.enum(EMBEDDING_PROVIDER_CHOICES);
-const extractionProviderSchema = z.enum(EXTRACTION_PROVIDER_CHOICES);
+// Extraction provider accepts both the legacy CLI choices and the dashboard
+// connect families (anthropic, openai-codex, github-copilot, …) — all are
+// valid routing executors the daemon's routing compiler handles.
+const EXTRACTION_PROVIDER_IDS = [
+	...new Set([...EXTRACTION_PROVIDER_CHOICES, ...CONNECTABLE_PROVIDERS.map((p) => p.id)]),
+] as const;
+const extractionProviderSchema = z.enum(EXTRACTION_PROVIDER_IDS);
 const aggregateRecallProviderSchema = z.enum(AGGREGATE_RECALL_PROVIDER_CHOICES);
 const openclawRuntimeSchema = z.enum(OPENCLAW_RUNTIME_CHOICES);
 

--- a/surfaces/cli/src/features/setup-plan.ts
+++ b/surfaces/cli/src/features/setup-plan.ts
@@ -42,7 +42,7 @@ const identityPresetSchema = z.enum(
 );
 const identitySessionKindSchema = z.enum(["dreaming", "heartbeat", "bootstrap"]);
 
-const identityContextFileSchema = z.object({
+const identityContextFileSchema = z.strictObject({
 	path: z.string(),
 	role: z.string().optional(),
 	budget: z.number().optional(),
@@ -53,38 +53,53 @@ const identitySpecialFileSchema = identityContextFileSchema.extend({
 	kind: identitySessionKindSchema,
 });
 
+// Single regex enforced identically by both parseSetupPlan (runtime) and the
+// published --schema (pattern). Avoids zod .url(), whose constraint does not
+// round-trip into z.toJSONSchema.
 const httpEndpointSchema = z
 	.string()
-	.url()
-	.regex(/^https?:\/\//, "must be an http:// or https:// URL")
+	.regex(/^https?:\/\/\S+$/, "must be an http:// or https:// URL")
+	.describe("Required when extractionProvider is 'openai-compatible'")
 	.optional();
 
-export const setupPlanSchema = z.object({
-	agentName: z.string(),
-	agentDescription: z.string(),
-	networkMode: networkModeSchema,
-	harnesses: z.array(harnessSchema),
-	openclawRuntimePath: openclawRuntimeSchema,
-	configureOpenClawWs: z.boolean(),
-	embeddingProvider: embeddingProviderSchema,
-	embeddingModel: z.string(),
-	embeddingDimensions: z.number().int().nonnegative(),
-	extractionProvider: extractionProviderSchema,
-	extractionModel: z.string(),
-	extractionEndpoint: httpEndpointSchema,
-	searchBalance: z.number().min(0).max(1),
-	searchTopK: z.number().int().positive(),
-	searchMinScore: z.number().min(0).max(1),
-	memorySessionBudget: z.number().int().positive(),
-	memoryDecayRate: z.number().min(0).max(1),
-	gitEnabled: z.boolean(),
-	signetSecretsEnabled: z.boolean(),
-	graphiqEnabled: z.boolean(),
-	identityMode: identityModeSchema,
-	identityPreset: identityPresetSchema,
-	startupIdentityFiles: z.array(identityContextFileSchema),
-	specialIdentityFiles: z.array(identitySpecialFileSchema),
-});
+export const setupPlanSchema = z
+	.strictObject({
+		agentName: z.string(),
+		agentDescription: z.string(),
+		networkMode: networkModeSchema,
+		harnesses: z.array(harnessSchema),
+		openclawRuntimePath: openclawRuntimeSchema,
+		configureOpenClawWs: z.boolean(),
+		embeddingProvider: embeddingProviderSchema,
+		embeddingModel: z.string(),
+		embeddingDimensions: z.number().int().nonnegative(),
+		extractionProvider: extractionProviderSchema,
+		extractionModel: z.string(),
+		extractionEndpoint: httpEndpointSchema,
+		searchBalance: z.number().min(0).max(1),
+		searchTopK: z.number().int().positive(),
+		searchMinScore: z.number().min(0).max(1),
+		memorySessionBudget: z.number().int().positive(),
+		memoryDecayRate: z.number().min(0).max(1),
+		gitEnabled: z.boolean(),
+		signetSecretsEnabled: z.boolean(),
+		graphiqEnabled: z.boolean(),
+		identityMode: identityModeSchema,
+		identityPreset: identityPresetSchema,
+		startupIdentityFiles: z.array(identityContextFileSchema),
+		specialIdentityFiles: z.array(identitySpecialFileSchema),
+	})
+	.superRefine((plan, ctx) => {
+		// openai-compatible extraction has no implicit endpoint; the interactive
+		// wizard defaults one, but a headless --file plan must state it.
+		if (plan.extractionProvider === "openai-compatible" && !plan.extractionEndpoint) {
+			ctx.addIssue({
+				code: "custom",
+				message: "openai-compatible extraction requires extractionEndpoint",
+				path: ["extractionEndpoint"],
+			});
+		}
+	});
 
 export type SetupPlan = z.infer<typeof setupPlanSchema>;
 

--- a/surfaces/cli/src/features/setup-shared.ts
+++ b/surfaces/cli/src/features/setup-shared.ts
@@ -12,7 +12,7 @@ export type HarnessChoice =
 	| "codex"
 	| "hermes-agent"
 	| "gemini";
-export type EmbeddingProviderChoice = "native" | "llama-cpp" | "ollama" | "openai" | "none";
+export type EmbeddingProviderChoice = "native" | "ollama" | "openai" | "none";
 export type ExtractionProviderChoice =
 	| "acpx"
 	| "claude-code"
@@ -46,7 +46,7 @@ export const SETUP_HARNESS_CHOICES: readonly HarnessChoice[] = [
 	"hermes-agent",
 	"gemini",
 ];
-export const EMBEDDING_PROVIDER_CHOICES: readonly EmbeddingProviderChoice[] = ["native", "llama-cpp", "ollama", "openai", "none"];
+export const EMBEDDING_PROVIDER_CHOICES: readonly EmbeddingProviderChoice[] = ["native", "ollama", "openai", "none"];
 export const EXTRACTION_PROVIDER_CHOICES: readonly ExtractionProviderChoice[] = [
 	"acpx",
 	"claude-code",
@@ -60,7 +60,12 @@ export const EXTRACTION_PROVIDER_CHOICES: readonly ExtractionProviderChoice[] = 
 ];
 export const OPENCLAW_RUNTIME_CHOICES: readonly OpenClawRuntimeChoice[] = ["plugin", "legacy"];
 export const DEPLOYMENT_TYPE_CHOICES: readonly DeploymentTypeChoice[] = ["local", "vps", "server"];
-const VPS_NON_LOCAL_EXTRACTION_PROVIDERS: readonly ExtractionProviderChoice[] = ["acpx", "claude-code", "codex", "opencode"];
+const VPS_NON_LOCAL_EXTRACTION_PROVIDERS: readonly ExtractionProviderChoice[] = [
+	"acpx",
+	"claude-code",
+	"codex",
+	"opencode",
+];
 const DETECTED_EXTRACTION_PROVIDER_ORDER: readonly ExtractionProviderChoice[] = [
 	"acpx",
 	"llama-cpp",

--- a/surfaces/cli/src/features/setup-types.ts
+++ b/surfaces/cli/src/features/setup-types.ts
@@ -14,6 +14,9 @@ export interface SetupWizardOptions {
 	extractionProvider?: string;
 	extractionModel?: string;
 	extractionEndpoint?: string;
+	synthesisProvider?: string;
+	synthesisModel?: string;
+	synthesisEndpoint?: string;
 	searchBalance?: string;
 	skipGit?: boolean;
 	openDashboard?: boolean;

--- a/surfaces/cli/src/features/setup-types.ts
+++ b/surfaces/cli/src/features/setup-types.ts
@@ -14,9 +14,9 @@ export interface SetupWizardOptions {
 	extractionProvider?: string;
 	extractionModel?: string;
 	extractionEndpoint?: string;
-	synthesisProvider?: string;
-	synthesisModel?: string;
-	synthesisEndpoint?: string;
+	aggregateRecallProvider?: string;
+	aggregateRecallModel?: string;
+	aggregateRecallEndpoint?: string;
 	searchBalance?: string;
 	skipGit?: boolean;
 	openDashboard?: boolean;

--- a/surfaces/cli/src/features/setup-types.ts
+++ b/surfaces/cli/src/features/setup-types.ts
@@ -66,6 +66,7 @@ export interface SetupDeps {
 	readonly parseSearchBalanceValue: (value: unknown) => number | null;
 	readonly showStatus: (options: { path?: string; json?: boolean }) => Promise<void>;
 	readonly signetLogo: () => string;
+	readonly signetBanner: () => string;
 	readonly startDaemon: (agentsDir?: string) => Promise<boolean>;
 	readonly getSkillsSourceDir: () => string;
 	readonly syncBuiltinSkills: (

--- a/surfaces/cli/src/features/setup-types.ts
+++ b/surfaces/cli/src/features/setup-types.ts
@@ -33,6 +33,7 @@ export interface SetupWizardOptions {
 	file?: string;
 	json?: string;
 	dryRun?: boolean;
+	enableDreaming?: boolean;
 }
 
 export interface SetupDeps {

--- a/surfaces/cli/src/features/setup-types.ts
+++ b/surfaces/cli/src/features/setup-types.ts
@@ -27,6 +27,9 @@ export interface SetupWizardOptions {
 	identityPreset?: string;
 	identityMode?: string;
 	schema?: boolean;
+	file?: string;
+	json?: string;
+	dryRun?: boolean;
 }
 
 export interface SetupDeps {

--- a/surfaces/cli/src/features/setup-types.ts
+++ b/surfaces/cli/src/features/setup-types.ts
@@ -1,11 +1,5 @@
-import type {
-	IdentityContextFileEntry,
-	IdentityPresetName,
-	IdentitySpecialFileEntry,
-	SetupDetection,
-	WorkspaceSourceRepoSyncResult,
-} from "@signet/core";
-import type { EmbeddingProviderChoice, ExtractionProviderChoice, OpenClawRuntimeChoice } from "./setup-shared.js";
+import type { SetupDetection, WorkspaceSourceRepoSyncResult } from "@signet/core";
+import type { OpenClawRuntimeChoice } from "./setup-shared.js";
 
 export interface SetupWizardOptions {
 	path?: string;
@@ -32,6 +26,7 @@ export interface SetupWizardOptions {
 	disableGraphiq?: boolean;
 	identityPreset?: string;
 	identityMode?: string;
+	schema?: boolean;
 }
 
 export interface SetupDeps {
@@ -72,40 +67,4 @@ export interface SetupDeps {
 		basePath: string,
 	) => Promise<{ readonly status: "updated" | "current" | "skipped" | "error"; readonly message: string }>;
 	readonly loadConfiguredHarnesses?: (basePath: string) => readonly string[];
-}
-
-export interface FreshSetupConfig {
-	readonly basePath: string;
-	readonly agentName: string;
-	readonly agentDescription: string;
-	readonly networkMode: "localhost" | "tailscale";
-	readonly harnesses: string[];
-	readonly openclawRuntimePath: OpenClawRuntimeChoice;
-	readonly configureOpenClawWs: boolean;
-	readonly openclawConfigCount: number;
-	readonly embeddingProvider: EmbeddingProviderChoice;
-	readonly embeddingModel: string;
-	readonly embeddingDimensions: number;
-	readonly extractionProvider: ExtractionProviderChoice;
-	readonly extractionModel: string;
-	readonly extractionEndpoint?: string;
-	readonly availableExtractionProviders: readonly ExtractionProviderChoice[];
-	readonly acpxBin?: string;
-	readonly searchBalance: number;
-	readonly searchTopK: number;
-	readonly searchMinScore: number;
-	readonly memorySessionBudget: number;
-	readonly memoryDecayRate: number;
-	readonly gitEnabled: boolean;
-	readonly existingAgentsDir: boolean;
-	readonly nonInteractive: boolean;
-	readonly openDashboard: boolean;
-	readonly allowUnprotectedWorkspace: boolean;
-	readonly createLocalBackup: boolean;
-	readonly signetSecretsEnabled: boolean;
-	readonly graphiqEnabled: boolean;
-	readonly identityMode: "managed" | "passthrough" | "off";
-	readonly identityPreset: IdentityPresetName;
-	readonly startupIdentityFiles: readonly IdentityContextFileEntry[];
-	readonly specialIdentityFiles: readonly IdentitySpecialFileEntry[];
 }

--- a/surfaces/cli/src/features/setup-types.ts
+++ b/surfaces/cli/src/features/setup-types.ts
@@ -34,6 +34,7 @@ export interface SetupWizardOptions {
 	json?: string;
 	dryRun?: boolean;
 	enableDreaming?: boolean;
+	agent?: string[];
 }
 
 export interface SetupDeps {

--- a/surfaces/cli/src/features/setup-types.ts
+++ b/surfaces/cli/src/features/setup-types.ts
@@ -36,6 +36,7 @@ export interface SetupWizardOptions {
 	enableDreaming?: boolean;
 	agent?: string[];
 	remoteUrl?: string;
+	obsidianSource?: string[];
 }
 
 export interface SetupDeps {

--- a/surfaces/cli/src/features/setup-types.ts
+++ b/surfaces/cli/src/features/setup-types.ts
@@ -35,6 +35,7 @@ export interface SetupWizardOptions {
 	dryRun?: boolean;
 	enableDreaming?: boolean;
 	agent?: string[];
+	remoteUrl?: string;
 }
 
 export interface SetupDeps {

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -802,6 +802,34 @@ describe("setupWizard headless plan path", () => {
 		}
 	});
 
+	it("refuses to overwrite an existing installation", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-headless-existing-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		writeIdentityTemplates(templatesPath);
+		const planPath = writePlanFile(root);
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			getTemplatesDir: mock(() => templatesPath),
+			normalizeAgentPath: mock((p: string) => p),
+			detectExistingSetup: mock(() => fakeDetection(basePath)),
+		});
+
+		const exitSpy = spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+			throw new Error(`process.exit:${code ?? ""}`);
+		}) as never);
+		const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			await expect(setupWizard({ file: planPath }, deps)).rejects.toThrow("process.exit:1");
+			expect(String(errorSpy.mock.calls[0]?.[0] ?? "")).toContain("existing Signet installation");
+			// Nothing was written.
+			expect(existsSync(join(basePath, "agent.yaml"))).toBe(false);
+		} finally {
+			exitSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
+	});
+
 	it("rejects a plan that fails validation", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-headless-invalid-"));
 		const basePath = join(root, "agents");
@@ -831,8 +859,8 @@ describe("setupWizard headless plan path", () => {
 			detectExistingSetup: mock(() => fakeDetection(basePath)),
 		});
 
-		const originalTty = process.stdout.isTTY;
-		Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+		const originalTty = process.stdin.isTTY;
+		Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
 		const exitSpy = spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
 			throw new Error(`process.exit:${code ?? ""}`);
 		}) as never);
@@ -843,7 +871,7 @@ describe("setupWizard headless plan path", () => {
 		} finally {
 			exitSpy.mockRestore();
 			errorSpy.mockRestore();
-			Object.defineProperty(process.stdout, "isTTY", { value: originalTty, configurable: true });
+			Object.defineProperty(process.stdin, "isTTY", { value: originalTty, configurable: true });
 		}
 	});
 });

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -631,4 +631,27 @@ describe("setupWizard non-interactive harness hooks", () => {
 		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
 		expect(agentYaml).toContain("mode: off");
 	});
+
+	it("prints the setup plan JSON Schema and exits before any wizard work when --schema is set", async () => {
+		const logSpy = spyOn(console, "log").mockImplementation(() => {});
+		try {
+			const signetLogo = mock(() => "SHOULD-NOT-APPEAR");
+			const detectExistingSetup = mock(() => fakeDetection());
+			const deps = stubDeps({ signetLogo, detectExistingSetup });
+
+			await setupWizard({ schema: true }, deps);
+
+			// Emits a JSON Schema document.
+			const printed = logSpy.mock.calls[0]?.[0] as string;
+			const parsed = JSON.parse(printed);
+			expect(parsed.$schema).toContain("json-schema.org");
+			expect(parsed.properties.agentName).toBeDefined();
+			expect(parsed.properties.networkMode.enum).toEqual(["localhost", "tailscale"]);
+			// Wizard body never ran.
+			expect(signetLogo).not.toHaveBeenCalled();
+			expect(detectExistingSetup).not.toHaveBeenCalled();
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
 });

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -747,8 +747,8 @@ describe("setupWizard headless plan path", () => {
 		}
 	});
 
-	it("enforces synthesis-requires-extraction on the flag path too", async () => {
-		root = mkdtempSync(join(tmpdir(), "setup-flag-deadconfig-"));
+	it("runs flag-path plans through parseSetupPlan (aggregate-recall model without provider)", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-flag-aggrecall-"));
 		const basePath = join(root, "agents");
 		mkdirSync(basePath, { recursive: true });
 		const deps = stubDeps({
@@ -762,13 +762,10 @@ describe("setupWizard headless plan path", () => {
 		}) as never);
 		const errorSpy = spyOn(console, "error").mockImplementation(() => {});
 		try {
-			await expect(
-				setupWizard(
-					{ nonInteractive: true, extractionProvider: "none", synthesisProvider: "openrouter", synthesisModel: "x" },
-					deps,
-				),
-			).rejects.toThrow("process.exit:1");
-			expect(String(errorSpy.mock.calls[0]?.[0] ?? "")).toContain("synthesis");
+			await expect(setupWizard({ nonInteractive: true, aggregateRecallModel: "x" }, deps)).rejects.toThrow(
+				"process.exit:1",
+			);
+			expect(String(errorSpy.mock.calls[0]?.[0] ?? "")).toContain("aggregateRecallProvider");
 		} finally {
 			exitSpy.mockRestore();
 			errorSpy.mockRestore();
@@ -846,25 +843,25 @@ describe("setupWizard headless plan path", () => {
 		expect(agentYaml).toContain("enabled: true");
 	});
 
-	it("writes a distinct synthesis provider from a plan file", async () => {
-		root = mkdtempSync(join(tmpdir(), "setup-headless-synthesis-"));
+	it("writes a distinct aggregate-recall target from a plan file", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-headless-aggrecall-"));
 		const basePath = join(root, "agents");
 		const templatesPath = join(root, "templates");
 		writeIdentityTemplates(templatesPath);
 		const planPath = writePlanFile(root, {
 			extractionProvider: "claude-code",
 			extractionModel: "haiku",
-			synthesisProvider: "openrouter",
-			synthesisModel: "anthropic/claude-3.5-sonnet",
+			aggregateRecallProvider: "openrouter",
+			aggregateRecallModel: "anthropic/claude-3.5-sonnet",
 		});
 		const deps = freshDeps(basePath, templatesPath);
 
 		await setupWizard({ file: planPath }, deps);
 
 		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
-		expect(agentYaml).toContain("provider: openrouter");
+		expect(agentYaml).toContain("aggregateRecall:");
+		expect(agentYaml).toContain("target: aggregation/default");
 		expect(agentYaml).toContain("anthropic/claude-3.5-sonnet");
-		expect(agentYaml).toContain("provider: claude-code");
 	});
 
 	it("applies a plan from an inline --json string", async () => {

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -721,6 +721,21 @@ describe("setupWizard headless plan path", () => {
 		expect(existsSync(join(basePath, "memory", "memories.db"))).toBe(true);
 	});
 
+	it("enables dreaming when the plan sets dreamingEnabled", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-headless-dreaming-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		writeIdentityTemplates(templatesPath);
+		const planPath = writePlanFile(root, { dreamingEnabled: true });
+		const deps = freshDeps(basePath, templatesPath);
+
+		await setupWizard({ file: planPath }, deps);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).toContain("dreaming:");
+		expect(agentYaml).toContain("enabled: true");
+	});
+
 	it("writes a distinct synthesis provider from a plan file", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-headless-synthesis-"));
 		const basePath = join(root, "agents");

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -850,7 +850,7 @@ describe("setupWizard headless plan path", () => {
 		writeIdentityTemplates(templatesPath);
 		const planPath = writePlanFile(root, {
 			extractionProvider: "openrouter",
-			extractionModel: "anthropic/claude-3.5-sonnet",
+			extractionModel: "anthropic/claude-3.5-haiku",
 			extractionConnect: { family: "openrouter", connectMethod: "api" },
 		});
 		const deps = freshDeps(basePath, templatesPath);
@@ -864,6 +864,25 @@ describe("setupWizard headless plan path", () => {
 		expect(agentYaml).toContain("executor: openrouter");
 		// API-key connect writes an api account referencing the key secret.
 		expect(agentYaml).toContain("SIGNET_KEY_OPENROUTER");
+	});
+
+	it("accepts a non-legacy connect family (anthropic OAuth) and writes a subscription_session account", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-headless-connect-anthropic-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		writeIdentityTemplates(templatesPath);
+		const planPath = writePlanFile(root, {
+			extractionProvider: "anthropic",
+			extractionModel: "claude-3-5-haiku-20241022",
+			extractionConnect: { family: "anthropic", connectMethod: "oauth" },
+		});
+		const deps = freshDeps(basePath, templatesPath);
+
+		await setupWizard({ file: planPath }, deps);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).toContain("executor: anthropic");
+		expect(agentYaml).toContain("subscription_session");
 	});
 
 	it("writes a distinct aggregate-recall target from a plan file", async () => {

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -70,6 +70,7 @@ function stubDeps(overrides: Partial<SetupDeps> = {}): SetupDeps {
 		parseSearchBalanceValue: mock(() => null),
 		showStatus: mock(async () => {}),
 		signetLogo: mock(() => ""),
+		signetBanner: mock(() => ""),
 		startDaemon: mock(async () => true),
 		getSkillsSourceDir: mock(() => "/tmp/skills"),
 		syncBuiltinSkills: mock(() => ({ installed: [], updated: [], skipped: [] })),

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -843,6 +843,29 @@ describe("setupWizard headless plan path", () => {
 		expect(agentYaml).toContain("enabled: true");
 	});
 
+	it("writes a connected cloud extraction target from a plan file", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-headless-connect-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		writeIdentityTemplates(templatesPath);
+		const planPath = writePlanFile(root, {
+			extractionProvider: "openrouter",
+			extractionModel: "anthropic/claude-3.5-sonnet",
+			extractionConnect: { family: "openrouter", connectMethod: "api" },
+		});
+		const deps = freshDeps(basePath, templatesPath);
+
+		await setupWizard({ file: planPath }, deps);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		// Modern inference.* route is the source of truth for the connected target.
+		expect(agentYaml).toContain("memoryExtraction:");
+		expect(agentYaml).toContain("target: background/default");
+		expect(agentYaml).toContain("executor: openrouter");
+		// API-key connect writes an api account referencing the key secret.
+		expect(agentYaml).toContain("SIGNET_KEY_OPENROUTER");
+	});
+
 	it("writes a distinct aggregate-recall target from a plan file", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-headless-aggrecall-"));
 		const basePath = join(root, "agents");

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -746,6 +746,22 @@ describe("setupWizard headless plan path", () => {
 		}
 	});
 
+	it("writes a remote daemon URL and skips local daemon start", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-headless-remote-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		writeIdentityTemplates(templatesPath);
+		const planPath = writePlanFile(root, { daemonUrl: "https://signet.remote.example:8443" });
+		const startDaemon = mock(async () => true);
+		const deps = { ...freshDeps(basePath, templatesPath), startDaemon };
+
+		await setupWizard({ file: planPath }, deps);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).toContain("url: https://signet.remote.example:8443");
+		expect(startDaemon).not.toHaveBeenCalled();
+	});
+
 	it("writes a multi-agent roster from a plan file", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-headless-roster-"));
 		const basePath = join(root, "agents");

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -721,6 +721,31 @@ describe("setupWizard headless plan path", () => {
 		expect(existsSync(join(basePath, "memory", "memories.db"))).toBe(true);
 	});
 
+	it("rejects a malformed --agent flag instead of silently dropping it", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-headless-badagent-"));
+		const basePath = join(root, "agents");
+		mkdirSync(basePath, { recursive: true });
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			normalizeAgentPath: mock((p: string) => p),
+			detectExistingSetup: mock(() => ({ ...fakeDetection(basePath), agentsDir: false, memoryDb: false })),
+		});
+
+		const exitSpy = spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+			throw new Error(`process.exit:${code ?? ""}`);
+		}) as never);
+		const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			await expect(setupWizard({ nonInteractive: true, agent: ["researcher"] }, deps)).rejects.toThrow(
+				"process.exit:1",
+			);
+			expect(String(errorSpy.mock.calls[0]?.[0] ?? "")).toContain("Expected name:policy");
+		} finally {
+			exitSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
+	});
+
 	it("writes a multi-agent roster from a plan file", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-headless-roster-"));
 		const basePath = join(root, "agents");

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -11,7 +11,7 @@ import {
 } from "@signet/core";
 import { detectedHarnessesForExistingSetup, runExistingSetupWizard } from "./setup-migrate.js";
 import type { SetupDeps } from "./setup-types.js";
-import { setupWizard } from "./setup.js";
+import { renderSetupPlanSummary, setupWizard } from "./setup.js";
 
 const NO_HARNESSES = {
 	claudeCode: false,
@@ -845,5 +845,60 @@ describe("setupWizard headless plan path", () => {
 			errorSpy.mockRestore();
 			Object.defineProperty(process.stdout, "isTTY", { value: originalTty, configurable: true });
 		}
+	});
+});
+
+describe("renderSetupPlanSummary", () => {
+	const plan = {
+		agentName: "My Agent",
+		agentDescription: "Personal AI assistant",
+		networkMode: "localhost" as const,
+		harnesses: ["claude-code", "codex"],
+		openclawRuntimePath: "plugin" as const,
+		configureOpenClawWs: false,
+		embeddingProvider: "native",
+		embeddingModel: "nomic-embed-text-v1.5",
+		embeddingDimensions: 768,
+		extractionProvider: "claude-code",
+		extractionModel: "haiku",
+		extractionEndpoint: undefined,
+		searchBalance: 0.7,
+		searchTopK: 20,
+		searchMinScore: 0.3,
+		memorySessionBudget: 2000,
+		memoryDecayRate: 0.95,
+		gitEnabled: true,
+		signetSecretsEnabled: true,
+		graphiqEnabled: false,
+		identityMode: "managed" as const,
+		identityPreset: "minimal" as const,
+		startupIdentityFiles: [{ path: "AGENTS.md" }],
+		specialIdentityFiles: [{ path: "DREAMING.md", kind: "dreaming" as const }],
+	};
+
+	it("groups plan fields into labeled sections", () => {
+		const summary = renderSetupPlanSummary(plan);
+		expect(summary).toContain("Identity");
+		expect(summary).toContain("Harnesses");
+		expect(summary).toContain("Memory & search");
+		expect(summary).toContain("Extraction");
+		expect(summary).toContain("Plugins & network");
+	});
+
+	it("includes the agent name, preset, and harness list", () => {
+		const summary = renderSetupPlanSummary(plan);
+		expect(summary).toContain("My Agent");
+		expect(summary).toContain("managed (minimal)");
+		expect(summary).toContain("claude-code, codex");
+	});
+
+	it("shows disabled state for none providers", () => {
+		const summary = renderSetupPlanSummary({
+			...plan,
+			embeddingProvider: "none",
+			extractionProvider: "none",
+		});
+		expect(summary).toContain("Embeddings:");
+		expect(summary).toContain("disabled");
 	});
 });

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -721,6 +721,28 @@ describe("setupWizard headless plan path", () => {
 		expect(existsSync(join(basePath, "memory", "memories.db"))).toBe(true);
 	});
 
+	it("writes a multi-agent roster from a plan file", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-headless-roster-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		writeIdentityTemplates(templatesPath);
+		const planPath = writePlanFile(root, {
+			agents: [
+				{ name: "researcher", memoryPolicy: "isolated" },
+				{ name: "writer", memoryPolicy: "group", memoryGroup: "docs" },
+			],
+		});
+		const deps = freshDeps(basePath, templatesPath);
+
+		await setupWizard({ file: planPath }, deps);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).toContain("roster:");
+		expect(agentYaml).toContain("name: researcher");
+		expect(agentYaml).toContain("name: writer");
+		expect(agentYaml).toContain("group: docs");
+	});
+
 	it("enables dreaming when the plan sets dreamingEnabled", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-headless-dreaming-"));
 		const basePath = join(root, "agents");

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -808,6 +808,30 @@ describe("setupWizard headless plan path", () => {
 		expect(startDaemon).not.toHaveBeenCalled();
 	});
 
+	it("rejects a remote daemon URL with a path before building a setup plan", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-remote-url-"));
+		const basePath = join(root, "agents");
+		mkdirSync(basePath, { recursive: true });
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			normalizeAgentPath: mock((p: string) => p),
+			detectExistingSetup: mock(() => ({ ...fakeDetection(basePath), agentsDir: false, memoryDb: false })),
+		});
+		const exitSpy = spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+			throw new Error(`process.exit:${code ?? ""}`);
+		}) as never);
+		const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			await expect(
+				setupWizard({ nonInteractive: true, remoteUrl: "https://signet.remote.example/api" }, deps),
+			).rejects.toThrow("process.exit:1");
+			expect(String(errorSpy.mock.calls[0]?.[0] ?? "")).toContain("bare http:// or https:// origin");
+		} finally {
+			exitSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
+	});
+
 	it("stores an interactive provider credential on the configured remote daemon", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-remote-connect-"));
 		const basePath = join(root, "agents");
@@ -817,6 +841,8 @@ describe("setupWizard headless plan path", () => {
 			extractionProvider: "openrouter",
 			extractionModel: "anthropic/claude-3.5-haiku",
 			extractionConnect: { family: "openrouter", connectMethod: "api" },
+			aggregateRecallProvider: "openrouter",
+			aggregateRecallModel: "anthropic/claude-3.5-sonnet",
 			daemonUrl: "https://signet.remote.example:8443",
 		});
 		const connectExtraction = mock(async () => true);
@@ -842,6 +868,10 @@ describe("setupWizard headless plan path", () => {
 
 		expect(startDaemon).not.toHaveBeenCalled();
 		expect(connectExtraction).toHaveBeenCalledTimes(1);
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).toContain("aggregateRecall:");
+		expect(agentYaml).toContain("account: openrouter");
+		expect(agentYaml).not.toContain("credentialRef: OPENROUTER_API_KEY");
 	});
 
 	it("writes a multi-agent roster from a plan file", async () => {

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -746,6 +746,34 @@ describe("setupWizard headless plan path", () => {
 		}
 	});
 
+	it("enforces synthesis-requires-extraction on the flag path too", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-flag-deadconfig-"));
+		const basePath = join(root, "agents");
+		mkdirSync(basePath, { recursive: true });
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			normalizeAgentPath: mock((p: string) => p),
+			detectExistingSetup: mock(() => ({ ...fakeDetection(basePath), agentsDir: false, memoryDb: false })),
+		});
+
+		const exitSpy = spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+			throw new Error(`process.exit:${code ?? ""}`);
+		}) as never);
+		const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			await expect(
+				setupWizard(
+					{ nonInteractive: true, extractionProvider: "none", synthesisProvider: "openrouter", synthesisModel: "x" },
+					deps,
+				),
+			).rejects.toThrow("process.exit:1");
+			expect(String(errorSpy.mock.calls[0]?.[0] ?? "")).toContain("synthesis");
+		} finally {
+			exitSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
+	});
+
 	it("connects an obsidian vault source from a plan file", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-headless-obsidian-"));
 		const basePath = join(root, "agents");

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -655,3 +655,195 @@ describe("setupWizard non-interactive harness hooks", () => {
 		}
 	});
 });
+
+describe("setupWizard headless plan path", () => {
+	let root: string;
+
+	function writePlanFile(dir: string, overrides: Record<string, unknown> = {}): string {
+		const planPath = join(dir, "plan.json");
+		const plan = {
+			agentName: "Headless Agent",
+			agentDescription: "From a plan file",
+			networkMode: "localhost",
+			harnesses: ["claude-code"],
+			openclawRuntimePath: "plugin",
+			configureOpenClawWs: false,
+			embeddingProvider: "native",
+			embeddingModel: "nomic-embed-text-v1.5",
+			embeddingDimensions: 768,
+			extractionProvider: "none",
+			extractionModel: "",
+			searchBalance: 0.7,
+			searchTopK: 20,
+			searchMinScore: 0.3,
+			memorySessionBudget: 2000,
+			memoryDecayRate: 0.95,
+			gitEnabled: false,
+			signetSecretsEnabled: true,
+			graphiqEnabled: false,
+			identityMode: "managed",
+			identityPreset: "minimal",
+			startupIdentityFiles: [{ path: "AGENTS.md" }],
+			specialIdentityFiles: [{ path: "DREAMING.md", kind: "dreaming" }],
+			...overrides,
+		};
+		writeFileSync(planPath, JSON.stringify(plan));
+		return planPath;
+	}
+
+	function freshDeps(basePath: string, templatesPath: string): SetupDeps {
+		const freshDetection: SetupDetection = { ...fakeDetection(basePath), agentsDir: false, memoryDb: false };
+		return stubDeps({
+			AGENTS_DIR: basePath,
+			getTemplatesDir: mock(() => templatesPath),
+			normalizeAgentPath: mock((p: string) => p),
+			detectExistingSetup: mock(() => freshDetection),
+		});
+	}
+
+	afterEach(() => {
+		if (root) rmSync(root, { recursive: true, force: true });
+	});
+
+	it("applies a plan from --file without prompts", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-headless-file-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		writeIdentityTemplates(templatesPath);
+		const planPath = writePlanFile(root);
+		const deps = freshDeps(basePath, templatesPath);
+
+		await setupWizard({ file: planPath }, deps);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).toContain("name: Headless Agent");
+		expect(agentYaml).toContain("mode: localhost");
+		expect(existsSync(join(basePath, "memory", "memories.db"))).toBe(true);
+	});
+
+	it("applies a plan from an inline --json string", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-headless-json-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		writeIdentityTemplates(templatesPath);
+		const deps = freshDeps(basePath, templatesPath);
+		const planJson = JSON.stringify({
+			agentName: "Inline Agent",
+			agentDescription: "d",
+			networkMode: "localhost",
+			harnesses: [],
+			openclawRuntimePath: "plugin",
+			configureOpenClawWs: false,
+			embeddingProvider: "none",
+			embeddingModel: "",
+			embeddingDimensions: 768,
+			extractionProvider: "none",
+			extractionModel: "",
+			searchBalance: 0.7,
+			searchTopK: 20,
+			searchMinScore: 0.3,
+			memorySessionBudget: 2000,
+			memoryDecayRate: 0.95,
+			gitEnabled: false,
+			signetSecretsEnabled: false,
+			graphiqEnabled: false,
+			identityMode: "off",
+			identityPreset: "minimal",
+			startupIdentityFiles: [],
+			specialIdentityFiles: [],
+		});
+
+		await setupWizard({ json: planJson }, deps);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).toContain("name: Inline Agent");
+		expect(agentYaml).toContain("mode: off");
+	});
+
+	it("--dry-run prints the plan and applies nothing", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-headless-dryrun-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		writeIdentityTemplates(templatesPath);
+		const planPath = writePlanFile(root, { agentName: "Dry Run Agent" });
+		const deps = freshDeps(basePath, templatesPath);
+
+		const logSpy = spyOn(console, "log").mockImplementation(() => {});
+		try {
+			await setupWizard({ file: planPath, dryRun: true }, deps);
+
+			const printed = logSpy.mock.calls[0]?.[0] as string;
+			const parsed = JSON.parse(printed);
+			expect(parsed.agentName).toBe("Dry Run Agent");
+			// Nothing was applied.
+			expect(existsSync(join(basePath, "agent.yaml"))).toBe(false);
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
+	it("rejects an invalid plan JSON with a structured error", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-headless-bad-"));
+		const basePath = join(root, "agents");
+		const badPath = join(root, "bad.json");
+		writeFileSync(badPath, "{not valid json");
+		const deps = freshDeps(basePath, root);
+
+		const exitSpy = spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+			throw new Error(`process.exit:${code ?? ""}`);
+		}) as never);
+		const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			await expect(setupWizard({ file: badPath }, deps)).rejects.toThrow("process.exit:1");
+			expect(String(errorSpy.mock.calls[0]?.[0] ?? "")).toContain("not valid JSON");
+		} finally {
+			exitSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
+	});
+
+	it("rejects a plan that fails validation", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-headless-invalid-"));
+		const basePath = join(root, "agents");
+		const planPath = writePlanFile(root, { searchBalance: 5 });
+		const deps = freshDeps(basePath, root);
+
+		const exitSpy = spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+			throw new Error(`process.exit:${code ?? ""}`);
+		}) as never);
+		const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			await expect(setupWizard({ file: planPath }, deps)).rejects.toThrow("process.exit:1");
+			expect(String(errorSpy.mock.calls[0]?.[0] ?? "")).toContain("searchBalance");
+		} finally {
+			exitSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
+	});
+
+	it("fails closed when invoked interactively without a TTY", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-notty-"));
+		const basePath = join(root, "agents");
+		mkdirSync(basePath, { recursive: true });
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			normalizeAgentPath: mock((p: string) => p),
+			detectExistingSetup: mock(() => fakeDetection(basePath)),
+		});
+
+		const originalTty = process.stdout.isTTY;
+		Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+		const exitSpy = spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+			throw new Error(`process.exit:${code ?? ""}`);
+		}) as never);
+		const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			await expect(setupWizard({}, deps)).rejects.toThrow("process.exit:1");
+			expect(String(errorSpy.mock.calls[0]?.[0] ?? "")).toContain("requires a TTY");
+		} finally {
+			exitSpy.mockRestore();
+			errorSpy.mockRestore();
+			Object.defineProperty(process.stdout, "isTTY", { value: originalTty, configurable: true });
+		}
+	});
+});

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -862,6 +862,8 @@ describe("setupWizard headless plan path", () => {
 		expect(agentYaml).toContain("aggregateRecall:");
 		expect(agentYaml).toContain("target: aggregation/default");
 		expect(agentYaml).toContain("anthropic/claude-3.5-sonnet");
+		// openrouter must be backed by a resolvable account or the daemon blocks it.
+		expect(agentYaml).toContain("credentialRef: OPENROUTER_API_KEY");
 	});
 
 	it("applies a plan from an inline --json string", async () => {

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -9,7 +9,9 @@ import {
 	readGraphiqState,
 	updateGraphiqActiveProject,
 } from "@signet/core";
+import { runFreshSetup } from "./setup-fresh.js";
 import { detectedHarnessesForExistingSetup, runExistingSetupWizard } from "./setup-migrate.js";
+import { parseSetupPlan } from "./setup-plan.js";
 import type { SetupDeps } from "./setup-types.js";
 import { renderSetupPlanSummary, setupWizard } from "./setup.js";
 
@@ -806,6 +808,42 @@ describe("setupWizard headless plan path", () => {
 		expect(startDaemon).not.toHaveBeenCalled();
 	});
 
+	it("stores an interactive provider credential on the configured remote daemon", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-remote-connect-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		writeIdentityTemplates(templatesPath);
+		const planPath = writePlanFile(root, {
+			extractionProvider: "openrouter",
+			extractionModel: "anthropic/claude-3.5-haiku",
+			extractionConnect: { family: "openrouter", connectMethod: "api" },
+			daemonUrl: "https://signet.remote.example:8443",
+		});
+		const connectExtraction = mock(async () => true);
+		const startDaemon = mock(async () => true);
+		const deps = { ...freshDeps(basePath, templatesPath), startDaemon };
+		const plan = parseSetupPlan(JSON.parse(readFileSync(planPath, "utf-8")));
+
+		await runFreshSetup(
+			plan,
+			{
+				basePath,
+				existingAgentsDir: false,
+				nonInteractive: true,
+				allowUnprotectedWorkspace: true,
+				createLocalBackup: false,
+				availableExtractionProviders: [],
+				openclawConfigCount: 0,
+				openDashboard: false,
+				connectExtraction,
+			},
+			deps,
+		);
+
+		expect(startDaemon).not.toHaveBeenCalled();
+		expect(connectExtraction).toHaveBeenCalledTimes(1);
+	});
+
 	it("writes a multi-agent roster from a plan file", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-headless-roster-"));
 		const basePath = join(root, "agents");
@@ -843,7 +881,7 @@ describe("setupWizard headless plan path", () => {
 		expect(agentYaml).toContain("enabled: true");
 	});
 
-	it("writes a connected cloud extraction target from a plan file", async () => {
+	it("rejects a connected cloud extraction target from a headless plan", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-headless-connect-"));
 		const basePath = join(root, "agents");
 		const templatesPath = join(root, "templates");
@@ -855,18 +893,20 @@ describe("setupWizard headless plan path", () => {
 		});
 		const deps = freshDeps(basePath, templatesPath);
 
-		await setupWizard({ file: planPath }, deps);
-
-		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
-		// Modern inference.* route is the source of truth for the connected target.
-		expect(agentYaml).toContain("memoryExtraction:");
-		expect(agentYaml).toContain("target: background/default");
-		expect(agentYaml).toContain("executor: openrouter");
-		// API-key connect writes an api account referencing the key secret.
-		expect(agentYaml).toContain("SIGNET_KEY_OPENROUTER");
+		const exitSpy = spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+			throw new Error(`process.exit:${code ?? ""}`);
+		}) as never);
+		const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			await expect(setupWizard({ file: planPath }, deps)).rejects.toThrow("process.exit:1");
+			expect(String(errorSpy.mock.calls[0]?.[0] ?? "")).toContain("cannot use extractionConnect");
+		} finally {
+			exitSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
 	});
 
-	it("accepts a non-legacy connect family (anthropic OAuth) and writes a subscription_session account", async () => {
+	it("rejects a non-legacy connected provider from a headless plan", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-headless-connect-anthropic-"));
 		const basePath = join(root, "agents");
 		const templatesPath = join(root, "templates");
@@ -878,11 +918,17 @@ describe("setupWizard headless plan path", () => {
 		});
 		const deps = freshDeps(basePath, templatesPath);
 
-		await setupWizard({ file: planPath }, deps);
-
-		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
-		expect(agentYaml).toContain("executor: anthropic");
-		expect(agentYaml).toContain("subscription_session");
+		const exitSpy = spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+			throw new Error(`process.exit:${code ?? ""}`);
+		}) as never);
+		const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			await expect(setupWizard({ file: planPath }, deps)).rejects.toThrow("process.exit:1");
+			expect(String(errorSpy.mock.calls[0]?.[0] ?? "")).toContain("cannot use extractionConnect");
+		} finally {
+			exitSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
 	});
 
 	it("writes a distinct aggregate-recall target from a plan file", async () => {

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -721,6 +721,27 @@ describe("setupWizard headless plan path", () => {
 		expect(existsSync(join(basePath, "memory", "memories.db"))).toBe(true);
 	});
 
+	it("writes a distinct synthesis provider from a plan file", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-headless-synthesis-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		writeIdentityTemplates(templatesPath);
+		const planPath = writePlanFile(root, {
+			extractionProvider: "claude-code",
+			extractionModel: "haiku",
+			synthesisProvider: "openrouter",
+			synthesisModel: "anthropic/claude-3.5-sonnet",
+		});
+		const deps = freshDeps(basePath, templatesPath);
+
+		await setupWizard({ file: planPath }, deps);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).toContain("provider: openrouter");
+		expect(agentYaml).toContain("anthropic/claude-3.5-sonnet");
+		expect(agentYaml).toContain("provider: claude-code");
+	});
+
 	it("applies a plan from an inline --json string", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-headless-json-"));
 		const basePath = join(root, "agents");

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -746,6 +746,24 @@ describe("setupWizard headless plan path", () => {
 		}
 	});
 
+	it("connects an obsidian vault source from a plan file", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-headless-obsidian-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		const vaultPath = join(root, "vault");
+		writeIdentityTemplates(templatesPath);
+		mkdirSync(vaultPath, { recursive: true });
+		writeFileSync(join(vaultPath, "note.md"), "# note");
+		const planPath = writePlanFile(root, { sources: [{ type: "obsidian", path: vaultPath, name: "my-vault" }] });
+		const deps = freshDeps(basePath, templatesPath);
+
+		await setupWizard({ file: planPath }, deps);
+
+		const sourcesConfig = readFileSync(join(basePath, "sources.json"), "utf-8");
+		expect(sourcesConfig).toContain("my-vault");
+		expect(sourcesConfig).toContain(vaultPath);
+	});
+
 	it("writes a remote daemon URL and skips local daemon start", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-headless-remote-"));
 		const basePath = join(root, "agents");

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -27,7 +27,7 @@ import { installGraphiqPlugin } from "./graphiq.js";
 import { connectApiKey, connectChoice, connectOAuth } from "./setup-connect.js";
 import type { ConnectHttp, ConnectUi } from "./setup-connect.js";
 import { runFreshSetup } from "./setup-fresh.js";
-import { CONNECTABLE_PROVIDERS } from "./setup-inference-connect.js";
+import { CONNECTABLE_PROVIDERS, CONNECT_MODEL_DEFAULTS } from "./setup-inference-connect.js";
 import { runExistingSetupWizard } from "./setup-migrate.js";
 import {
 	AGGREGATE_RECALL_PROVIDER_CHOICES,
@@ -83,22 +83,6 @@ import type { SetupDeps, SetupWizardOptions } from "./setup-types.js";
 function modelChoices(provider: ExtractionProviderChoice): Array<{ value: string; name: string }> {
 	return modelPresetsForProvider(provider).map((preset) => ({ value: preset.value, name: preset.label }));
 }
-
-/** Per-family extraction model defaults (small/fast/cheap, extraction-grade).
- * The dashboard picks from the live catalog; the CLI wizard runs before the
- * daemon, so we suggest a known-good id and let the user override. */
-const CONNECT_MODEL_DEFAULTS: Record<string, string> = {
-	anthropic: "claude-3-5-haiku-20241022",
-	openrouter: "anthropic/claude-3.5-haiku",
-	openai: "gpt-4o-mini",
-	"openai-codex": "gpt-4o-mini",
-	"github-copilot": "gpt-4o-mini",
-	google: "gemini-2.0-flash",
-	xai: "grok-2-latest",
-	groq: "llama-3.1-8b-instant",
-	deepseek: "deepseek-chat",
-	mistral: "mistral-small-latest",
-};
 
 /**
  * Interactive sub-flow matching the dashboard's connect-provider wall: pick a
@@ -1309,6 +1293,10 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		deps.normalizeChoice(existingExtraction.provider, EXTRACTION_PROVIDER_CHOICES);
 	let extractionProvider: ExtractionProviderChoice;
 	let extractionConnect: { family: string; connectMethod: "api" | "oauth" } | undefined;
+	// Declared before the provider-selection block so the connect sub-flow can
+	// assign it (avoids a temporal-dead-zone ReferenceError); the per-provider
+	// model branches below overwrite it for non-connect providers.
+	let extractionModel = "haiku";
 	if (nonInteractive) {
 		extractionProvider = resolveSetupExtractionProvider({
 			deploymentType,
@@ -1397,7 +1385,6 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		}
 	}
 
-	let extractionModel = "haiku";
 	if (extractionConnect) {
 		// Model was chosen in the connect sub-flow; skip the legacy per-provider
 		// model branches (they don't cover the connect families).
@@ -1534,8 +1521,8 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 			(aggregateRecallProvider === "openai-compatible" ? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT : undefined);
 	} else if (extractionProvider !== "none") {
 		const distinctAggregateRecall = await confirm({
-			message: "Use a different provider for aggregate recall?",
-			description: "Query-time evidence synthesis. Latency-sensitive; defaults to your extraction provider.",
+			message:
+				"Use a different provider for aggregate recall? (query-time evidence synthesis — defaults to your extraction provider)",
 			default: false,
 		});
 		if (distinctAggregateRecall) {

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -191,6 +191,23 @@ interface ExtractionEnvironment {
 }
 
 /**
+ * Parse a non-interactive --agent flag: "name:policy" or "name:policy:group".
+ * policy is isolated|shared|group. Returns null on a malformed value.
+ */
+function parseAgentFlag(
+	raw: string,
+): { name: string; memoryPolicy: "isolated" | "shared" | "group"; memoryGroup?: string } | null {
+	const parts = raw
+		.split(":")
+		.map((p) => p.trim())
+		.filter(Boolean);
+	if (parts.length < 2) return null;
+	const [name, policyRaw, group] = parts;
+	if (policyRaw !== "isolated" && policyRaw !== "shared" && policyRaw !== "group") return null;
+	return { name, memoryPolicy: policyRaw, memoryGroup: group || undefined };
+}
+
+/**
  * Probe the local machine for extraction-capable tools (claude/codex/ollama/
  * opencode CLIs, llama.cpp server, acpx runner). Shared by the interactive
  * wizard and the headless plan path so detection never diverges.
@@ -326,6 +343,9 @@ export function renderSetupPlanSummary(plan: SetupPlan): string {
 	row("Network:", plan.networkMode);
 	row("Git:", plan.gitEnabled ? "enabled" : "disabled");
 	if (plan.dreamingEnabled) row("Dreaming:", "enabled");
+	if (plan.agents && plan.agents.length > 0) {
+		row("Agents:", `${plan.agents.length} (${plan.agents.map((a) => a.name).join(", ")})`);
+	}
 
 	return lines.join("\n");
 }
@@ -1408,6 +1428,38 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		gitEnabled = initGit;
 	}
 
+	// Multi-agent roster: additional named agents beyond the default. Each gets
+	// a memory read-policy; the daemon reconciles agents.roster into the
+	// `agents` table at boot (syncAgentRoster).
+	const agents: { name: string; memoryPolicy: "isolated" | "shared" | "group"; memoryGroup?: string }[] = [];
+	if (nonInteractive) {
+		for (const raw of options.agent ?? []) {
+			const parsed = parseAgentFlag(raw);
+			if (parsed) agents.push(parsed);
+		}
+	} else {
+		let adding = await confirm({ message: "Add a named agent to the roster?", default: false });
+		while (adding) {
+			const name = await input({ message: "Agent name:" });
+			if (!name.trim()) break;
+			const memoryPolicy = await select({
+				message: `Memory policy for ${name}:`,
+				choices: [
+					{ value: "isolated", name: "Isolated — private memory scope" },
+					{ value: "shared", name: "Shared — reads the default agent's memory" },
+					{ value: "group", name: "Group — shared memory scope with a group" },
+				],
+				default: "isolated",
+			});
+			let memoryGroup: string | undefined;
+			if (memoryPolicy === "group") {
+				memoryGroup = (await input({ message: "Group name:", default: name })) || name;
+			}
+			agents.push({ name: name.trim(), memoryPolicy, memoryGroup });
+			adding = await confirm({ message: "Add another agent?", default: false });
+		}
+	}
+
 	const plan: SetupPlan = {
 		agentName,
 		agentDescription,
@@ -1437,6 +1489,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		startupIdentityFiles,
 		specialIdentityFiles,
 		dreamingEnabled,
+		agents: agents.length > 0 ? agents : undefined,
 	};
 
 	const context: SetupApplyContext = {

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -316,6 +316,9 @@ export function renderSetupPlanSummary(plan: SetupPlan): string {
 		row("Model:", plan.extractionModel || chalk.dim("(default)"));
 		if (plan.extractionEndpoint) row("Endpoint:", plan.extractionEndpoint);
 	}
+	if (plan.synthesisProvider && plan.synthesisProvider !== plan.extractionProvider) {
+		row("Synthesis:", `${plan.synthesisProvider}${plan.synthesisModel ? ` (${plan.synthesisModel})` : ""}`);
+	}
 
 	section("Plugins & network");
 	row("Secrets:", plan.signetSecretsEnabled ? "enabled" : "disabled");
@@ -433,6 +436,13 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	const requestedExtractionProvider = deps.normalizeChoice(rawExtractionProvider, EXTRACTION_PROVIDER_CHOICES);
 	const rawExtractionEndpoint = deps.normalizeStringValue(options.extractionEndpoint);
 	const requestedExtractionEndpoint = normalizeHttpEndpoint(rawExtractionEndpoint);
+	const requestedSynthesisProvider = deps.normalizeChoice(options.synthesisProvider, EXTRACTION_PROVIDER_CHOICES);
+	const requestedSynthesisEndpoint = normalizeHttpEndpoint(deps.normalizeStringValue(options.synthesisEndpoint));
+	if (options.synthesisProvider && !requestedSynthesisProvider) {
+		failSetupValidation(
+			`Unknown --synthesis-provider value: ${options.synthesisProvider}. Valid choices: ${EXTRACTION_PROVIDER_CHOICES.join(", ")}.`,
+		);
+	}
 	const existingName = readString(existingConfig.name) ?? readString(existingAgent.name) ?? "My Agent";
 	const existingDesc =
 		readString(existingConfig.description) ?? readString(existingAgent.description) ?? "Personal AI assistant";
@@ -1287,6 +1297,45 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		extractionEndpoint = normalizeHttpEndpoint(endpointInput) ?? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT;
 	}
 
+	// Optional distinct synthesis provider (session summaries). When unset,
+	// synthesis mirrors extraction.
+	let synthesisProvider: ExtractionProviderChoice | undefined;
+	let synthesisModel: string | undefined;
+	let synthesisEndpoint: string | undefined;
+	if (nonInteractive) {
+		synthesisProvider = requestedSynthesisProvider ?? undefined;
+		synthesisModel = deps.normalizeStringValue(options.synthesisModel) ?? undefined;
+		synthesisEndpoint = requestedSynthesisEndpoint ?? undefined;
+	} else if (extractionProvider !== "none") {
+		const distinctSynthesis = await confirm({
+			message: "Use a different provider for session summaries (synthesis)?",
+			default: false,
+		});
+		if (distinctSynthesis) {
+			console.log();
+			synthesisProvider = await select({
+				message: "Synthesis provider:",
+				choices: EXTRACTION_PROVIDER_CHOICES.filter((p) => p !== "none").map((p) => ({
+					value: p,
+					name: p,
+				})),
+			});
+			console.log();
+			synthesisModel = await select({
+				message: "Which model for synthesis?",
+				choices: modelChoices(synthesisProvider),
+			});
+			if (synthesisProvider === "openai-compatible") {
+				const epInput = await input({
+					message: "Synthesis endpoint:",
+					default: synthesisEndpoint ?? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT,
+					validate: (value) => normalizeHttpEndpoint(value) !== undefined || "Enter an http:// or https:// URL.",
+				});
+				synthesisEndpoint = normalizeHttpEndpoint(epInput) ?? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT;
+			}
+		}
+	}
+
 	const wantAdvanced = nonInteractive
 		? false
 		: await confirm({
@@ -1364,6 +1413,9 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		extractionProvider,
 		extractionModel,
 		extractionEndpoint,
+		synthesisProvider,
+		synthesisModel,
+		synthesisEndpoint,
 		searchBalance,
 		searchTopK,
 		searchMinScore,

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -364,6 +364,9 @@ export function renderSetupPlanSummary(plan: SetupPlan): string {
 	if (plan.agents && plan.agents.length > 0) {
 		row("Agents:", `${plan.agents.length} (${plan.agents.map((a) => a.name).join(", ")})`);
 	}
+	if (plan.sources && plan.sources.length > 0) {
+		row("Sources:", `${plan.sources.length} obsidian vault(s)`);
+	}
 
 	return lines.join("\n");
 }
@@ -1515,6 +1518,24 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		}
 	}
 
+	// Obsidian vault sources (config files the daemon indexes at boot).
+	const sources: { type: "obsidian"; path: string; name?: string }[] = [];
+	if (nonInteractive) {
+		for (const raw of options.obsidianSource ?? []) {
+			const [path, name] = raw.split("::").map((p) => p.trim());
+			if (path) sources.push({ type: "obsidian", path, name: name || undefined });
+		}
+	} else {
+		let addingSource = await confirm({ message: "Connect an Obsidian vault?", default: false });
+		while (addingSource) {
+			const path = await input({ message: "Vault path:", default: basePath });
+			if (!path.trim()) break;
+			const name = (await input({ message: "Source name (optional):" })).trim() || undefined;
+			sources.push({ type: "obsidian", path: path.trim(), name });
+			addingSource = await confirm({ message: "Connect another vault?", default: false });
+		}
+	}
+
 	const plan: SetupPlan = {
 		agentName,
 		agentDescription,
@@ -1546,6 +1567,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		dreamingEnabled,
 		daemonUrl,
 		agents: agents.length > 0 ? agents : undefined,
+		sources: sources.length > 0 ? sources : undefined,
 	};
 
 	const context: SetupApplyContext = {

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -254,8 +254,8 @@ async function buildHeadlessApplyContext(
 	basePath: string,
 	plan: SetupPlan,
 	deps: SetupDeps,
+	existingAgentsDir: boolean,
 ): Promise<SetupApplyContext> {
-	const existing = deps.detectExistingSetup(basePath);
 	const { availableExtractionProviders, acpxBin } = await probeExtractionEnvironment();
 	let openclawConfigCount = 0;
 	if (plan.harnesses.includes("openclaw")) {
@@ -263,7 +263,7 @@ async function buildHeadlessApplyContext(
 	}
 	return {
 		basePath,
-		existingAgentsDir: existing.agentsDir,
+		existingAgentsDir,
 		nonInteractive: true,
 		allowUnprotectedWorkspace: options.allowUnprotectedWorkspace === true,
 		createLocalBackup: options.createLocalBackup === true,
@@ -342,15 +342,23 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 			console.log(JSON.stringify(plan, null, 2));
 			return;
 		}
-		const context = await buildHeadlessApplyContext(options, basePath, plan, deps);
+		const existing = deps.detectExistingSetup(basePath);
+		if (hasExistingAgentState(existing)) {
+			failSetupValidation(
+				`An existing Signet installation was found at ${basePath}.`,
+				"--file/--json performs a fresh setup. To reconfigure an existing install, run the interactive wizard or use --non-interactive with flags.",
+			);
+		}
+		const context = await buildHeadlessApplyContext(options, basePath, plan, deps, existing.agentsDir);
 		await runFreshSetup(plan, context, deps);
 		return;
 	}
 
-	// Fail closed: never block on an interactive prompt when stdin/stdout is not a
-	// TTY (piped, agent, CI). Headless callers must opt in via --non-interactive
-	// (flags) or --file/--json (plan).
-	if (!options.nonInteractive && !process.stdout.isTTY) {
+	// Fail closed: never block on an interactive prompt when stdin is not a TTY
+	// (piped, agent, CI). Headless callers must opt in via --non-interactive
+	// (flags) or --file/--json (plan). Checking stdin (not stdout) still allows
+	// `signet setup | tee log` where stdin remains interactive.
+	if (!options.nonInteractive && !process.stdin.isTTY) {
 		failSetupValidation(
 			"signet setup is interactive and requires a TTY.",
 			"For headless use, pass --non-interactive with explicit flags, or --file/--json with a setup plan (see --schema).",

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -1,6 +1,6 @@
 import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { checkbox, confirm, input, password, select } from "@inquirer/prompts";
+import { checkbox, confirm, input, password, search, select } from "@inquirer/prompts";
 import { OpenClawConnector } from "@signet/connector-openclaw";
 import {
 	IDENTITY_MODES,
@@ -27,14 +27,15 @@ import { installGraphiqPlugin } from "./graphiq.js";
 import { connectApiKey, connectOAuth } from "./setup-connect.js";
 import type { ConnectHttp, ConnectUi } from "./setup-connect.js";
 import { runFreshSetup } from "./setup-fresh.js";
-import { apiKeyProviderOptions, modelOptions, oauthProviderOptions } from "./setup-inference-connect.js";
-import { runExistingSetupWizard } from "./setup-migrate.js";
 import {
-	AGGREGATE_RECALL_PROVIDER_CHOICES,
-	type AggregateRecallProviderChoice,
-	defaultAcpxModel,
-	defaultExtractionModel,
-} from "./setup-pipeline.js";
+	LOCAL_SERVERS,
+	aggregateRecallProviderIds,
+	apiKeyProviderOptions,
+	modelOptions,
+	oauthProviderOptions,
+} from "./setup-inference-connect.js";
+import { runExistingSetupWizard } from "./setup-migrate.js";
+import { defaultAcpxModel, defaultExtractionModel } from "./setup-pipeline.js";
 import { parseSetupPlan, setupPlanJsonSchema } from "./setup-plan.js";
 import type { SetupApplyContext, SetupPlan } from "./setup-plan.js";
 import { readSetupCorePluginEnabled, writeSetupCorePluginRegistry } from "./setup-plugins.js";
@@ -83,6 +84,42 @@ function modelChoices(provider: ExtractionProviderChoice): Array<{ value: string
 }
 
 /**
+ * Pick a model from pi-ai's real catalog for a provider family. Uses a plain
+ * select for short lists and a searchable `search` prompt for large ones
+ * (e.g. openrouter's 253 models) so the user can type to find what they want.
+ * Falls back to free text only if the catalog has no models for the family.
+ */
+async function pickModel(
+	family: string,
+	prompts: {
+		readonly select: typeof import("@inquirer/prompts").select;
+		readonly search: typeof import("@inquirer/prompts").search;
+		readonly input: typeof import("@inquirer/prompts").input;
+	},
+): Promise<string> {
+	const models = modelOptions(family);
+	if (models.length === 0) {
+		return (
+			await prompts.input({ message: "Model:", validate: (v) => v.trim().length > 0 || "Enter a model id" })
+		).trim();
+	}
+	const choices = models.map((m) => ({ value: m.id, name: `${m.name} (${m.id})` }));
+	if (models.length <= 12) {
+		return prompts.select({ message: "Model:", choices });
+	}
+	return prompts.search({
+		message: "Model (type to search):",
+		source: (term) => {
+			const t = (term ?? "").trim().toLowerCase();
+			const filtered = t
+				? choices.filter((c) => c.value.toLowerCase().includes(t) || c.name.toLowerCase().includes(t))
+				: choices;
+			return filtered.slice(0, 50);
+		},
+	});
+}
+
+/**
  * Connect sub-flows for background inference. The METHOD (OAuth vs API key)
  * is chosen by the top-level menu, so each helper just picks a provider from
  * the matching capability set and a model. Credential entry happens after the
@@ -94,6 +131,7 @@ async function pickConnectedProvider(
 	connectMethod: "api" | "oauth",
 	prompts: {
 		readonly select: typeof import("@inquirer/prompts").select;
+		readonly search: typeof import("@inquirer/prompts").search;
 		readonly input: typeof import("@inquirer/prompts").input;
 	},
 ): Promise<{ family: string; connectMethod: "api" | "oauth"; model: string } | undefined> {
@@ -102,20 +140,7 @@ async function pickConnectedProvider(
 		choices: [...providers.map((p) => ({ value: p.id, name: p.name })), { value: "__back__", name: "← back" }],
 	});
 	if (provider === "__back__") return undefined;
-	// Real model list from pi-ai (same as the dashboard) — never a guess.
-	const models = modelOptions(provider);
-	const model =
-		models.length > 0
-			? await prompts.select({
-					message: "Model:",
-					choices: models.map((m) => ({ value: m.id, name: `${m.name} (${m.id})` })),
-				})
-			: (
-					await prompts.input({
-						message: "Model:",
-						validate: (v) => v.trim().length > 0 || "Enter a model id",
-					})
-				).trim();
+	const model = await pickModel(provider, prompts);
 	return { family: provider, connectMethod, model };
 }
 
@@ -576,11 +601,11 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	const requestedExtractionEndpoint = normalizeHttpEndpoint(rawExtractionEndpoint);
 	const requestedAggregateRecallProvider = deps.normalizeChoice(
 		options.aggregateRecallProvider,
-		AGGREGATE_RECALL_PROVIDER_CHOICES,
+		aggregateRecallProviderIds(),
 	);
 	if (options.aggregateRecallProvider && !requestedAggregateRecallProvider) {
 		failSetupValidation(
-			`Unknown --aggregate-recall-provider value: ${options.aggregateRecallProvider}. Valid choices: ${AGGREGATE_RECALL_PROVIDER_CHOICES.join(", ")}.`,
+			`Unknown --aggregate-recall-provider value: ${options.aggregateRecallProvider}. Valid choices: ${aggregateRecallProviderIds().join(", ")}.`,
 		);
 	}
 	const existingName = readString(existingConfig.name) ?? readString(existingAgent.name) ?? "My Agent";
@@ -1287,7 +1312,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				],
 			});
 			if (chosen === "__oauth__") {
-				const connected = await pickConnectedProvider(oauthProviderOptions(), "oauth", { select, input });
+				const connected = await pickConnectedProvider(oauthProviderOptions(), "oauth", { select, search, input });
 				if (connected) {
 					extractionConnect = connected;
 					extractionModel = connected.model;
@@ -1295,7 +1320,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 					break;
 				}
 			} else if (chosen === "__apikey__") {
-				const connected = await pickConnectedProvider(apiKeyProviderOptions(), "api", { select, input });
+				const connected = await pickConnectedProvider(apiKeyProviderOptions(), "api", { select, search, input });
 				if (connected) {
 					extractionConnect = connected;
 					extractionModel = connected.model;
@@ -1431,14 +1456,12 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	// Optional distinct provider for aggregate recall (query-time evidence
 	// synthesis). pi-ai-only (no harness subprocess). When unset, aggregate
 	// recall falls through to the default policy (the extraction provider).
-	let aggregateRecallProvider: AggregateRecallProviderChoice | undefined;
+	let aggregateRecallProvider: string | undefined;
 	let aggregateRecallModel: string | undefined;
 	let aggregateRecallEndpoint: string | undefined;
 	if (nonInteractive) {
-		aggregateRecallProvider = (deps.normalizeChoice(
-			options.aggregateRecallProvider,
-			AGGREGATE_RECALL_PROVIDER_CHOICES,
-		) ?? undefined) as AggregateRecallProviderChoice | undefined;
+		aggregateRecallProvider =
+			deps.normalizeChoice(options.aggregateRecallProvider, aggregateRecallProviderIds()) ?? undefined ?? undefined;
 		aggregateRecallModel = deps.normalizeStringValue(options.aggregateRecallModel) ?? undefined;
 		aggregateRecallEndpoint =
 			normalizeHttpEndpoint(deps.normalizeStringValue(options.aggregateRecallEndpoint)) ??
@@ -1451,15 +1474,17 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		});
 		if (distinctAggregateRecall) {
 			console.log();
+			// Same pi-ai catalog as the connect flow (pi-ai-only — no ACPX, since
+			// aggregate recall is latency-sensitive), plus local servers.
+			const aggProviders = [...oauthProviderOptions(), ...apiKeyProviderOptions(), ...LOCAL_SERVERS].filter(
+				(p, i, arr) => arr.findIndex((q) => q.id === p.id) === i,
+			);
 			aggregateRecallProvider = await select({
 				message: "Aggregate-recall provider:",
-				choices: AGGREGATE_RECALL_PROVIDER_CHOICES.map((p) => ({ value: p, name: p })),
+				choices: aggProviders.map((p) => ({ value: p.id, name: p.name })),
 			});
 			console.log();
-			aggregateRecallModel = await select({
-				message: "Which model for aggregate recall?",
-				choices: modelChoices(aggregateRecallProvider),
-			});
+			aggregateRecallModel = await pickModel(aggregateRecallProvider, { select, search, input });
 			if (aggregateRecallProvider === "openai-compatible") {
 				const epInput = await input({
 					message: "Aggregate-recall endpoint:",

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -410,10 +410,13 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		);
 	}
 
-	console.log(deps.signetLogo());
-	console.log();
-
 	const nonInteractive = options.nonInteractive === true;
+	if (!nonInteractive) {
+		console.log(deps.signetBanner());
+	} else {
+		console.log(deps.signetLogo());
+	}
+	console.log();
 	const explicitPath = deps.normalizeStringValue(options.path);
 	let basePath = deps.normalizeAgentPath(explicitPath ?? deps.AGENTS_DIR);
 

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -24,7 +24,7 @@ import ora from "ora";
 import { validateName } from "../commands/agent.js";
 import { createDaemonClient } from "../lib/daemon.js";
 import { installGraphiqPlugin } from "./graphiq.js";
-import { connectApiKey, connectChoice, connectOAuth } from "./setup-connect.js";
+import { connectApiKey, connectOAuth } from "./setup-connect.js";
 import type { ConnectHttp, ConnectUi } from "./setup-connect.js";
 import { runFreshSetup } from "./setup-fresh.js";
 import { CONNECTABLE_PROVIDERS, CONNECT_MODEL_DEFAULTS } from "./setup-inference-connect.js";
@@ -32,7 +32,6 @@ import { runExistingSetupWizard } from "./setup-migrate.js";
 import {
 	AGGREGATE_RECALL_PROVIDER_CHOICES,
 	type AggregateRecallProviderChoice,
-	EXTRACTION_SAFETY_WARNING,
 	defaultAcpxModel,
 	defaultExtractionModel,
 } from "./setup-pipeline.js";
@@ -60,7 +59,6 @@ import {
 	type OpenClawRuntimeChoice,
 	SETUP_HARNESS_CHOICES,
 	defaultEmbeddingProviderForDeployment,
-	defaultExtractionProviderForDeployment,
 	detectExtractionProviderFromAvailable,
 	detectPreferredOpenClawWorkspace,
 	failNonInteractiveSetup,
@@ -85,49 +83,32 @@ function modelChoices(provider: ExtractionProviderChoice): Array<{ value: string
 }
 
 /**
- * Interactive sub-flow matching the dashboard's connect-provider wall: pick a
- * cloud provider, choose API-key vs OAuth login (when both are offered), and
- * pick a model. Returns the connect decision, or undefined if the user backs
- * out. Credential entry happens after the daemon starts (the daemon owns the
- * secrets store + OAuth endpoints, exactly like the browser dashboard).
+ * Connect sub-flows for background inference. The METHOD (OAuth vs API key)
+ * is chosen by the top-level menu, so each helper just picks a provider from
+ * the matching capability set and a model. Credential entry happens after the
+ * daemon starts (the daemon owns the secrets store + OAuth endpoints, like the
+ * browser dashboard). Returns undefined if the user backs out.
  */
-async function connectExtractionProvider(prompts: {
-	readonly select: typeof import("@inquirer/prompts").select;
-	readonly confirm: typeof import("@inquirer/prompts").confirm;
-	readonly input: typeof import("@inquirer/prompts").input;
-}): Promise<{ family: string; connectMethod: "api" | "oauth"; model: string } | undefined> {
-	const provider = await prompts.select<{
-		id: string;
-		name: string;
-		supportsOAuth: boolean;
-		supportsApiKey: boolean;
-	}>({
-		message: "Connect a cloud provider for memory extraction:",
+async function pickConnectedProvider(
+	providers: readonly { id: string; name: string }[],
+	connectMethod: "api" | "oauth",
+	prompts: {
+		readonly select: typeof import("@inquirer/prompts").select;
+		readonly input: typeof import("@inquirer/prompts").input;
+	},
+): Promise<{ family: string; connectMethod: "api" | "oauth"; model: string } | undefined> {
+	const provider = await prompts.select<{ id: string; name: string }>({
+		message: connectMethod === "oauth" ? "Log in with:" : "Provider:",
 		choices: [
-			...CONNECTABLE_PROVIDERS.map((p) => ({ value: p, name: p.name })),
-			{ value: { id: "__back__", name: "← back", supportsOAuth: false, supportsApiKey: false }, name: "← back" },
+			...providers.map((p) => ({ value: p, name: p.name })),
+			{ value: { id: "__back__", name: "← back" }, name: "← back" },
 		],
 	});
 	if (provider.id === "__back__") return undefined;
-
-	const choice = connectChoice(provider);
-	let connectMethod: "api" | "oauth";
-	if (choice === "choice") {
-		connectMethod = await prompts.select<"api" | "oauth">({
-			message: `How do you want to connect ${provider.name}?`,
-			choices: [
-				{ value: "oauth", name: "Log in (subscription / OAuth)" },
-				{ value: "api", name: "Paste an API key" },
-			],
-		});
-	} else {
-		connectMethod = choice === "oauth" ? "oauth" : "api";
-	}
-	const modelDefault = CONNECT_MODEL_DEFAULTS[provider.id] ?? "";
 	const model = (
 		await prompts.input({
-			message: `Model for ${provider.name} (extraction):`,
-			default: modelDefault,
+			message: "Model:",
+			default: CONNECT_MODEL_DEFAULTS[provider.id] ?? "",
 			validate: (v) => v.trim().length > 0 || "Enter a model id",
 		})
 	).trim();
@@ -1309,79 +1290,50 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		});
 	} else {
 		console.log();
-		console.log(chalk.cyan("  Deployment guidance:"));
-		for (const line of getDeploymentExtractionGuidance(deploymentType)) {
-			console.log(chalk.dim(`    ${line}`));
-		}
+		console.log(chalk.yellow("  Background inference runs continuously — remote APIs can incur usage costs."));
 		console.log();
-		console.log(chalk.yellow(`  Warning: ${EXTRACTION_SAFETY_WARNING}`));
-		console.log();
-		const choices: Array<{ value: ExtractionProviderChoice; name: string }> = [
-			{
-				value: "acpx",
-				name: `ACPX (recommended default, uses your selected Codex/Claude/OpenCode harness with pinned acpx@0.7.0)${detectedProvider === "acpx" ? " — detected" : ""}`,
-			},
-			{
-				value: "llama-cpp",
-				name: `llama.cpp (local, recommended — qwen3:4b minimum)${detectedProvider === "llama-cpp" ? " — detected" : ""}`,
-			},
-			{
-				value: "claude-code",
-				name: `Claude Code (Haiku, recommended if you already have Pro/Max)${detectedProvider === "claude-code" ? " — detected" : ""}`,
-			},
-			{
-				value: "codex",
-				name: `Codex (gpt-5.4-mini, recommended if you already have Pro/Max)${detectedProvider === "codex" ? " — detected" : ""}`,
-			},
-			{
-				value: "ollama",
-				name: `Ollama (local, qwen3:4b minimum)${detectedProvider === "ollama" ? " — detected" : ""}`,
-			},
-			{ value: "none", name: "Disable extraction pipeline" },
-			{
-				value: "opencode",
-				name: `OpenCode (advanced, can route to paid APIs)${detectedProvider === "opencode" ? " — detected" : ""}`,
-			},
-			{
-				value: "openrouter",
-				name: "OpenRouter (cloud API, billed usage, expensive if left running)",
-			},
-			{
-				value: "openai-compatible",
-				name: "OpenAI-compatible endpoint (advanced, uses OPENAI_API_KEY and extraction endpoint config)",
-			},
-		];
-		// Dashboard-style connect option: cloud provider via API key or OAuth.
-		choices.unshift({
-			value: "__connect__" as ExtractionProviderChoice,
-			name: "Connect a cloud provider (API key or login — Anthropic, OpenRouter, OpenAI, …)",
-		});
-		const chosen = await select<ExtractionProviderChoice>({
-			message: "Memory extraction provider (analyzes conversations):",
-			choices,
-			default: defaultExtractionProviderForDeployment(
-				deploymentType,
-				detectedProvider,
-				availableToolExtractionProviders,
-				harnesses,
-			),
-		});
-		if (chosen === ("__connect__" as ExtractionProviderChoice)) {
-			const connected = await connectExtractionProvider({ select, confirm, input });
-			if (connected) {
-				extractionConnect = connected;
-				extractionModel = connected.model;
-				// pipelineV2 must stay enabled for the worker; the modern inference.*
-				// route (written in apply) overrides the actual target/credential.
-				extractionProvider = connected.family as ExtractionProviderChoice;
+		// Loop so a connect sub-flow can return to this menu on "← back".
+		for (;;) {
+			const chosen = await select<string>({
+				message: "Background inference provider:",
+				choices: [
+					{ value: "__oauth__", name: "Log in (Claude Max, ChatGPT, GitHub Copilot)" },
+					{ value: "__apikey__", name: "API key (Anthropic, OpenRouter, OpenAI, …)" },
+					{
+						value: "acpx",
+						name: `ACPX (harness subprocess)${detectedProvider === "acpx" ? " — detected" : ""}`,
+					},
+					{ value: "openai-compatible", name: "Custom endpoint (OpenAI-compatible URL)" },
+				],
+			});
+			if (chosen === "__oauth__") {
+				const connected = await pickConnectedProvider(
+					CONNECTABLE_PROVIDERS.filter((p) => p.supportsOAuth),
+					"oauth",
+					{ select, input },
+				);
+				if (connected) {
+					extractionConnect = connected;
+					extractionModel = connected.model;
+					extractionProvider = connected.family as ExtractionProviderChoice;
+					break;
+				}
+			} else if (chosen === "__apikey__") {
+				const connected = await pickConnectedProvider(
+					CONNECTABLE_PROVIDERS.filter((p) => p.supportsApiKey),
+					"api",
+					{ select, input },
+				);
+				if (connected) {
+					extractionConnect = connected;
+					extractionModel = connected.model;
+					extractionProvider = connected.family as ExtractionProviderChoice;
+					break;
+				}
 			} else {
-				extractionProvider = await select({
-					message: "Memory extraction provider:",
-					choices: choices.filter((c) => c.value !== ("__connect__" as ExtractionProviderChoice)),
-				});
+				extractionProvider = chosen as ExtractionProviderChoice;
+				break;
 			}
-		} else {
-			extractionProvider = chosen;
 		}
 	}
 

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -1279,7 +1279,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 			if (chosen === "__oauth__") {
 				const connected = await pickConnectedProvider(oauthProviderOptions(), "oauth", { select, search, input });
 				if (connected) {
-					extractionConnect = connected;
+					extractionConnect = { family: connected.family, connectMethod: connected.connectMethod };
 					extractionModel = connected.model;
 					extractionProvider = connected.family as ExtractionProviderChoice;
 					break;
@@ -1287,7 +1287,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 			} else if (chosen === "__apikey__") {
 				const connected = await pickConnectedProvider(apiKeyProviderOptions(), "api", { select, search, input });
 				if (connected) {
-					extractionConnect = connected;
+					extractionConnect = { family: connected.family, connectMethod: connected.connectMethod };
 					extractionModel = connected.model;
 					extractionProvider = connected.family as ExtractionProviderChoice;
 					break;

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -1304,6 +1304,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 						name: `ACPX (harness subprocess)${detectedProvider === "acpx" ? " — detected" : ""}`,
 					},
 					{ value: "openai-compatible", name: "Custom endpoint (OpenAI-compatible URL)" },
+					{ value: "none", name: "Disable background inference" },
 				],
 			});
 			if (chosen === "__oauth__") {

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -1137,25 +1137,11 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		}
 	}
 
-	let deploymentType: DeploymentTypeChoice;
-	if (nonInteractive) {
-		deploymentType = requestedDeploymentType ?? "local";
-	} else if (requestedDeploymentType) {
-		deploymentType = requestedDeploymentType;
-		console.log();
-		console.log(chalk.dim(`  Using deployment type from CLI: ${requestedDeploymentType}`));
-	} else {
-		console.log();
-		deploymentType = await select({
-			message: "Where is Signet running?",
-			choices: [
-				{ value: "local", name: "Local machine (dev / personal)" },
-				{ value: "vps", name: "VPS or cloud server (shared / constrained resources)" },
-				{ value: "server", name: "Self-hosted server (dedicated hardware)" },
-			],
-			default: "local",
-		});
-	}
+	// Deployment type only tailors non-interactive/reconfigure defaults (e.g.
+	// VPS prefers non-local extraction providers). It has no effect in the
+	// interactive fresh-setup flow, so we don't prompt for it — the flag still
+	// works for non-interactive use.
+	const deploymentType: DeploymentTypeChoice = requestedDeploymentType ?? "local";
 
 	let embeddingProvider: EmbeddingProviderChoice;
 	if (nonInteractive) {

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -274,6 +274,58 @@ async function buildHeadlessApplyContext(
 	};
 }
 
+/**
+ * Render a SetupPlan as a human-readable, sectioned summary for the interactive
+ * review screen. Pure (no side effects); returns a plain string.
+ */
+export function renderSetupPlanSummary(plan: SetupPlan): string {
+	const lines: string[] = [
+		chalk.bold("  Setup plan"),
+		chalk.dim(
+			"  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+		),
+	];
+	const section = (title: string) => {
+		lines.push("");
+		lines.push(chalk.cyan(`  ${title}`));
+	};
+	const row = (label: string, value: string) => lines.push(`    ${label.padEnd(13)}${value}`);
+
+	section("Identity");
+	row("Agent:", plan.agentName);
+	row("Description:", plan.agentDescription);
+	row("Mode:", plan.identityMode === "managed" ? `managed (${plan.identityPreset})` : plan.identityMode);
+
+	section("Harnesses");
+	lines.push(`    ${plan.harnesses.length > 0 ? plan.harnesses.join(", ") : chalk.dim("(none)")}`);
+
+	section("Memory & search");
+	if (plan.embeddingProvider === "none") {
+		row("Embeddings:", chalk.dim("disabled"));
+	} else {
+		row("Embeddings:", `${plan.embeddingProvider} (${plan.embeddingModel}, ${plan.embeddingDimensions}d)`);
+	}
+	row("Search:", `balance ${plan.searchBalance}, top_k ${plan.searchTopK}, min_score ${plan.searchMinScore}`);
+	row("Memory:", `budget ${plan.memorySessionBudget}, decay ${plan.memoryDecayRate}`);
+
+	section("Extraction");
+	if (plan.extractionProvider === "none") {
+		row("Provider:", chalk.dim("disabled"));
+	} else {
+		row("Provider:", plan.extractionProvider);
+		row("Model:", plan.extractionModel || chalk.dim("(default)"));
+		if (plan.extractionEndpoint) row("Endpoint:", plan.extractionEndpoint);
+	}
+
+	section("Plugins & network");
+	row("Secrets:", plan.signetSecretsEnabled ? "enabled" : "disabled");
+	row("GraphIQ:", plan.graphiqEnabled ? "enabled" : "disabled");
+	row("Network:", plan.networkMode);
+	row("Git:", plan.gitEnabled ? "enabled" : "disabled");
+
+	return lines.join("\n");
+}
+
 export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps): Promise<void> {
 	if (options.schema) {
 		console.log(JSON.stringify(setupPlanJsonSchema(), null, 2));
@@ -1333,6 +1385,17 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	if (options.dryRun) {
 		console.log(JSON.stringify(plan, null, 2));
 		return;
+	}
+
+	if (!nonInteractive) {
+		console.log();
+		console.log(renderSetupPlanSummary(plan));
+		console.log();
+		const applyNow = await confirm({ message: "Apply this plan?", default: true });
+		if (!applyNow) {
+			console.log(chalk.dim("  Setup cancelled. No changes were made."));
+			return;
+		}
 	}
 
 	await runFreshSetup(plan, context, deps);

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -97,22 +97,26 @@ async function pickConnectedProvider(
 		readonly input: typeof import("@inquirer/prompts").input;
 	},
 ): Promise<{ family: string; connectMethod: "api" | "oauth"; model: string } | undefined> {
-	const provider = await prompts.select<{ id: string; name: string }>({
+	const provider = await prompts.select<string>({
 		message: connectMethod === "oauth" ? "Log in with:" : "Provider:",
-		choices: [
-			...providers.map((p) => ({ value: p, name: p.name })),
-			{ value: { id: "__back__", name: "← back" }, name: "← back" },
-		],
+		choices: [...providers.map((p) => ({ value: p.id, name: p.name })), { value: "__back__", name: "← back" }],
 	});
-	if (provider.id === "__back__") return undefined;
-	const model = (
-		await prompts.input({
-			message: "Model:",
-			default: CONNECT_MODEL_DEFAULTS[provider.id] ?? "",
-			validate: (v) => v.trim().length > 0 || "Enter a model id",
-		})
-	).trim();
-	return { family: provider.id, connectMethod, model };
+	if (provider === "__back__") return undefined;
+	// Real model list from pi-ai (same as the dashboard) — never a guess.
+	const models = modelOptions(provider);
+	const model =
+		models.length > 0
+			? await prompts.select({
+					message: "Model:",
+					choices: models.map((m) => ({ value: m.id, name: `${m.name} (${m.id})` })),
+				})
+			: (
+					await prompts.input({
+						message: "Model:",
+						validate: (v) => v.trim().length > 0 || "Enter a model id",
+					})
+				).trim();
+	return { family: provider, connectMethod, model };
 }
 
 /**
@@ -1283,11 +1287,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				],
 			});
 			if (chosen === "__oauth__") {
-				const connected = await pickConnectedProvider(
-					CONNECTABLE_PROVIDERS.filter((p) => p.supportsOAuth),
-					"oauth",
-					{ select, input },
-				);
+				const connected = await pickConnectedProvider(oauthProviderOptions(), "oauth", { select, input });
 				if (connected) {
 					extractionConnect = connected;
 					extractionModel = connected.model;
@@ -1295,11 +1295,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 					break;
 				}
 			} else if (chosen === "__apikey__") {
-				const connected = await pickConnectedProvider(
-					CONNECTABLE_PROVIDERS.filter((p) => p.supportsApiKey),
-					"api",
-					{ select, input },
-				);
+				const connected = await pickConnectedProvider(apiKeyProviderOptions(), "api", { select, input });
 				if (connected) {
 					extractionConnect = connected;
 					extractionModel = connected.model;

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -27,7 +27,7 @@ import { installGraphiqPlugin } from "./graphiq.js";
 import { connectApiKey, connectOAuth } from "./setup-connect.js";
 import type { ConnectHttp, ConnectUi } from "./setup-connect.js";
 import { runFreshSetup } from "./setup-fresh.js";
-import { CONNECTABLE_PROVIDERS, CONNECT_MODEL_DEFAULTS } from "./setup-inference-connect.js";
+import { apiKeyProviderOptions, modelOptions, oauthProviderOptions } from "./setup-inference-connect.js";
 import { runExistingSetupWizard } from "./setup-migrate.js";
 import {
 	AGGREGATE_RECALL_PROVIDER_CHOICES,

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -1482,7 +1482,10 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		const seen = new Set<string>();
 		for (const raw of options.agent ?? []) {
 			const parsed = parseAgentFlag(raw);
-			if (seen.has(parsed.name)) continue;
+			if (seen.has(parsed.name)) {
+				console.warn(chalk.yellow(`  ⚠ duplicate --agent "${parsed.name}" ignored`));
+				continue;
+			}
 			seen.add(parsed.name);
 			agents.push(parsed);
 		}
@@ -1581,6 +1584,14 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		openclawConfigCount,
 		openDashboard: options.openDashboard === true,
 	};
+
+	// Enforce the same cross-field invariants the headless --file path gets via
+	// parseSetupPlan (e.g. synthesis requires extraction; group needs a group).
+	try {
+		parseSetupPlan(plan);
+	} catch (err) {
+		failSetupValidation(err instanceof Error ? err.message : String(err));
+	}
 
 	if (options.dryRun) {
 		console.log(JSON.stringify(plan, null, 2));

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -25,7 +25,7 @@ import { installGraphiqPlugin } from "./graphiq.js";
 import { runFreshSetup } from "./setup-fresh.js";
 import { runExistingSetupWizard } from "./setup-migrate.js";
 import { EXTRACTION_SAFETY_WARNING, defaultAcpxModel, defaultExtractionModel } from "./setup-pipeline.js";
-import { setupPlanJsonSchema } from "./setup-plan.js";
+import { parseSetupPlan, setupPlanJsonSchema } from "./setup-plan.js";
 import type { SetupApplyContext, SetupPlan } from "./setup-plan.js";
 import { readSetupCorePluginEnabled, writeSetupCorePluginRegistry } from "./setup-plugins.js";
 import { enforceSetupProtection, printSetupProtectionSummary } from "./setup-protection.js";
@@ -61,6 +61,7 @@ import {
 	hasExistingAgentState,
 	hasExistingIdentityFiles,
 	normalizeHarnessList,
+	readErr,
 	readHarnesses,
 	readRecord,
 	readString,
@@ -182,10 +183,126 @@ async function promptIdentityMode(defaultIdentityMode: IdentityMode): Promise<Id
 	});
 }
 
+interface ExtractionEnvironment {
+	readonly availableExtractionProviders: ExtractionProviderChoice[];
+	readonly acpxBin: string | undefined;
+	readonly detectedProvider: ExtractionProviderChoice;
+	readonly llamaCppServerAvailable: boolean;
+}
+
+/**
+ * Probe the local machine for extraction-capable tools (claude/codex/ollama/
+ * opencode CLIs, llama.cpp server, acpx runner). Shared by the interactive
+ * wizard and the headless plan path so detection never diverges.
+ */
+async function probeExtractionEnvironment(): Promise<ExtractionEnvironment> {
+	const hasClaudeCommand = hasCommand("claude");
+	const hasCodexCommand = hasCommand("codex");
+	const hasOllamaCommand = hasCommand("ollama");
+	const hasOpenCodeCommand = hasCommand("opencode");
+	const acpxBin = resolveCommandPath("bunx") ?? resolveCommandPath("npx");
+	const llamaCppServerAvailable = await hasLlamaCppServer();
+	const availableExtractionProviders: ExtractionProviderChoice[] = [];
+	if (acpxBin && (hasClaudeCommand || hasCodexCommand || hasOpenCodeCommand)) availableExtractionProviders.push("acpx");
+	if (llamaCppServerAvailable) availableExtractionProviders.push("llama-cpp");
+	if (hasClaudeCommand) availableExtractionProviders.push("claude-code");
+	if (hasCodexCommand) availableExtractionProviders.push("codex");
+	if (hasOllamaCommand) availableExtractionProviders.push("ollama");
+	if (hasOpenCodeCommand) availableExtractionProviders.push("opencode");
+	const detectedProvider = detectExtractionProviderFromAvailable(availableExtractionProviders);
+	return { availableExtractionProviders, acpxBin, detectedProvider, llamaCppServerAvailable };
+}
+
+/**
+ * Load and validate a {@link SetupPlan} from `--file` or `--json`. Headless only —
+ * the returned plan carries no runtime context, which is built separately by
+ * {@link buildHeadlessApplyContext}.
+ */
+function loadPlanFromOptions(options: SetupWizardOptions): SetupPlan {
+	if (options.file && options.json) {
+		failSetupValidation("Pass either --file or --json, not both.");
+	}
+	let raw: string;
+	if (options.file) {
+		try {
+			raw = readFileSync(options.file, "utf-8");
+		} catch (err) {
+			failSetupValidation(`Could not read plan file ${options.file}: ${readErr(err)}`);
+		}
+	} else {
+		raw = options.json ?? "";
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (err) {
+		failSetupValidation(`Setup plan is not valid JSON: ${readErr(err)}`);
+	}
+	try {
+		return parseSetupPlan(parsed);
+	} catch (err) {
+		failSetupValidation(err instanceof Error ? err.message : String(err));
+	}
+}
+
+/**
+ * Build the runtime {@link SetupApplyContext} for a headless plan by probing the
+ * environment (tool detection, OpenClaw configs) the same way the wizard does.
+ */
+async function buildHeadlessApplyContext(
+	options: SetupWizardOptions,
+	basePath: string,
+	plan: SetupPlan,
+	deps: SetupDeps,
+): Promise<SetupApplyContext> {
+	const existing = deps.detectExistingSetup(basePath);
+	const { availableExtractionProviders, acpxBin } = await probeExtractionEnvironment();
+	let openclawConfigCount = 0;
+	if (plan.harnesses.includes("openclaw")) {
+		openclawConfigCount = new OpenClawConnector().getDiscoveredConfigPaths().length;
+	}
+	return {
+		basePath,
+		existingAgentsDir: existing.agentsDir,
+		nonInteractive: true,
+		allowUnprotectedWorkspace: options.allowUnprotectedWorkspace === true,
+		createLocalBackup: options.createLocalBackup === true,
+		availableExtractionProviders,
+		acpxBin,
+		openclawConfigCount,
+		openDashboard: options.openDashboard === true,
+	};
+}
+
 export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps): Promise<void> {
 	if (options.schema) {
 		console.log(JSON.stringify(setupPlanJsonSchema(), null, 2));
 		return;
+	}
+
+	// Headless plan path: apply a validated plan from --file/--json with no
+	// prompts. The runtime context is probed from the environment.
+	if (options.file || options.json) {
+		const explicitPath = deps.normalizeStringValue(options.path);
+		const basePath = deps.normalizeAgentPath(explicitPath ?? deps.AGENTS_DIR);
+		const plan = loadPlanFromOptions(options);
+		if (options.dryRun) {
+			console.log(JSON.stringify(plan, null, 2));
+			return;
+		}
+		const context = await buildHeadlessApplyContext(options, basePath, plan, deps);
+		await runFreshSetup(plan, context, deps);
+		return;
+	}
+
+	// Fail closed: never block on an interactive prompt when stdin/stdout is not a
+	// TTY (piped, agent, CI). Headless callers must opt in via --non-interactive
+	// (flags) or --file/--json (plan).
+	if (!options.nonInteractive && !process.stdout.isTTY) {
+		failSetupValidation(
+			"signet setup is interactive and requires a TTY.",
+			"For headless use, pass --non-interactive with explicit flags, or --file/--json with a setup plan (see --schema).",
+		);
 	}
 
 	console.log(deps.signetLogo());
@@ -277,21 +394,12 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 			`Unknown --identity-preset value: ${options.identityPreset}. Valid choices: ${IDENTITY_PRESET_CHOICES.join(", ")}.`,
 		);
 	}
-	const hasClaudeCommand = hasCommand("claude");
-	const hasCodexCommand = hasCommand("codex");
-	const hasOllamaCommand = hasCommand("ollama");
-	const hasOpenCodeCommand = hasCommand("opencode");
-	const acpxBin = resolveCommandPath("bunx") ?? resolveCommandPath("npx");
-	const llamaCppServerAvailable = await hasLlamaCppServer();
-	const availableToolExtractionProviders: ExtractionProviderChoice[] = [];
-	if (acpxBin && (hasClaudeCommand || hasCodexCommand || hasOpenCodeCommand))
-		availableToolExtractionProviders.push("acpx");
-	if (llamaCppServerAvailable) availableToolExtractionProviders.push("llama-cpp");
-	if (hasClaudeCommand) availableToolExtractionProviders.push("claude-code");
-	if (hasCodexCommand) availableToolExtractionProviders.push("codex");
-	if (hasOllamaCommand) availableToolExtractionProviders.push("ollama");
-	if (hasOpenCodeCommand) availableToolExtractionProviders.push("opencode");
-	const detectedProvider = detectExtractionProviderFromAvailable(availableToolExtractionProviders);
+	const {
+		availableExtractionProviders: availableToolExtractionProviders,
+		acpxBin,
+		detectedProvider,
+		llamaCppServerAvailable,
+	} = await probeExtractionEnvironment();
 
 	if (rawDeploymentType && !requestedDeploymentType) {
 		failSetupValidation(
@@ -1221,6 +1329,11 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		openclawConfigCount,
 		openDashboard: options.openDashboard === true,
 	};
+
+	if (options.dryRun) {
+		console.log(JSON.stringify(plan, null, 2));
+		return;
+	}
 
 	await runFreshSetup(plan, context, deps);
 }

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -1091,49 +1091,38 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	const signetSecretsEnabled = await resolveSignetSecretsCorePluginSelection(basePath, nonInteractive, options);
 	const graphiqEnabled = await resolveGraphiqPluginSelection(basePath, nonInteractive, options);
 
+	// One question covers both how a local daemon binds AND whether to skip a
+	// local daemon entirely in favor of a remote one. (networkMode is irrelevant
+	// when remote — no local daemon is started.)
 	let networkMode: NetworkMode;
-	if (nonInteractive) {
-		networkMode = deps.normalizeChoice(options.networkMode, NETWORK_MODES) ?? existingNetworkMode;
-	} else {
-		console.log();
-		networkMode = await select({
-			message: "How should the daemon be hosted?",
-			choices: [
-				{
-					value: "localhost",
-					name: "localhost only (default)",
-					description: "Bind to 127.0.0.1 only",
-				},
-				{
-					value: "tailscale",
-					name: "Tailscale / remote",
-					description: "Keep localhost working and also bind 0.0.0.0",
-				},
-			],
-			default: existingNetworkMode,
-		});
-	}
-
-	// Remote instance: point this workspace at a daemon running elsewhere
-	// instead of starting a local one. Persisted as daemon.url in agent.yaml.
 	let daemonUrl: string | undefined;
 	const requestedRemoteUrl = normalizeHttpEndpoint(deps.normalizeStringValue(options.remoteUrl));
 	if (options.remoteUrl && !requestedRemoteUrl) {
 		failSetupValidation("--remote-url must be an http:// or https:// URL.");
 	}
 	if (nonInteractive) {
+		networkMode = deps.normalizeChoice(options.networkMode, NETWORK_MODES) ?? existingNetworkMode;
 		daemonUrl = requestedRemoteUrl ?? undefined;
 	} else {
-		const useRemote = await confirm({
-			message: "Use a remote daemon instead of starting a local one?",
-			default: false,
+		console.log();
+		const hosting = await select({
+			message: "How should the daemon run?",
+			choices: [
+				{ value: "local", name: "Local — this machine (localhost only)" },
+				{ value: "tailscale", name: "Local — this machine (Tailscale / network)" },
+				{ value: "remote", name: "Remote — connect to a daemon elsewhere" },
+			],
+			default: existingNetworkMode === "tailscale" ? "tailscale" : "local",
 		});
-		if (useRemote) {
+		if (hosting === "remote") {
 			const urlInput = await input({
 				message: "Remote daemon URL:",
 				validate: (value) => normalizeHttpEndpoint(value) !== undefined || "Enter an http:// or https:// URL.",
 			});
 			daemonUrl = normalizeHttpEndpoint(urlInput) ?? undefined;
+			networkMode = "localhost"; // no local daemon to bind
+		} else {
+			networkMode = hosting === "tailscale" ? "tailscale" : "localhost";
 		}
 	}
 

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -21,6 +21,7 @@ import {
 import chalk from "chalk";
 import open from "open";
 import ora from "ora";
+import { validateName } from "../commands/agent.js";
 import { installGraphiqPlugin } from "./graphiq.js";
 import { runFreshSetup } from "./setup-fresh.js";
 import { runExistingSetupWizard } from "./setup-migrate.js";
@@ -192,18 +193,34 @@ interface ExtractionEnvironment {
 
 /**
  * Parse a non-interactive --agent flag: "name:policy" or "name:policy:group".
- * policy is isolated|shared|group. Returns null on a malformed value.
+ * policy is isolated|shared|group. Fails loudly on malformed input rather than
+ * silently dropping it.
  */
-function parseAgentFlag(
-	raw: string,
-): { name: string; memoryPolicy: "isolated" | "shared" | "group"; memoryGroup?: string } | null {
+function parseAgentFlag(raw: string): {
+	name: string;
+	memoryPolicy: "isolated" | "shared" | "group";
+	memoryGroup?: string;
+} {
 	const parts = raw
 		.split(":")
 		.map((p) => p.trim())
 		.filter(Boolean);
-	if (parts.length < 2) return null;
+	if (parts.length < 2) {
+		failSetupValidation(
+			`Invalid --agent value: "${raw}". Expected name:policy[:group] (policy: isolated|shared|group).`,
+		);
+	}
 	const [name, policyRaw, group] = parts;
-	if (policyRaw !== "isolated" && policyRaw !== "shared" && policyRaw !== "group") return null;
+	const nameErr = validateName(name);
+	if (nameErr) {
+		failSetupValidation(`Invalid --agent name "${name}": ${nameErr}`);
+	}
+	if (policyRaw !== "isolated" && policyRaw !== "shared" && policyRaw !== "group") {
+		failSetupValidation(`Invalid --agent policy "${policyRaw}" in "${raw}". Expected isolated|shared|group.`);
+	}
+	if (policyRaw === "group" && !group) {
+		failSetupValidation(`--agent "${name}:group" requires a group name: "${name}:group:<group>".`);
+	}
 	return { name, memoryPolicy: policyRaw, memoryGroup: group || undefined };
 }
 
@@ -1326,7 +1343,9 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	if (nonInteractive) {
 		synthesisProvider = requestedSynthesisProvider ?? undefined;
 		synthesisModel = deps.normalizeStringValue(options.synthesisModel) ?? undefined;
-		synthesisEndpoint = requestedSynthesisEndpoint ?? undefined;
+		synthesisEndpoint =
+			requestedSynthesisEndpoint ??
+			(requestedSynthesisProvider === "openai-compatible" ? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT : undefined);
 	} else if (extractionProvider !== "none") {
 		const distinctSynthesis = await confirm({
 			message: "Use a different provider for session summaries (synthesis)?",
@@ -1433,15 +1452,27 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	// `agents` table at boot (syncAgentRoster).
 	const agents: { name: string; memoryPolicy: "isolated" | "shared" | "group"; memoryGroup?: string }[] = [];
 	if (nonInteractive) {
+		const seen = new Set<string>();
 		for (const raw of options.agent ?? []) {
 			const parsed = parseAgentFlag(raw);
-			if (parsed) agents.push(parsed);
+			if (seen.has(parsed.name)) continue;
+			seen.add(parsed.name);
+			agents.push(parsed);
 		}
 	} else {
 		let adding = await confirm({ message: "Add a named agent to the roster?", default: false });
 		while (adding) {
 			const name = await input({ message: "Agent name:" });
 			if (!name.trim()) break;
+			const nameErr = validateName(name.trim());
+			if (nameErr) {
+				console.log(chalk.yellow(`  ⚠ ${nameErr}`));
+				continue;
+			}
+			if (agents.some((a) => a.name === name.trim())) {
+				console.log(chalk.yellow(`  ⚠ An agent named "${name.trim()}" is already in the roster.`));
+				continue;
+			}
 			const memoryPolicy = await select({
 				message: `Memory policy for ${name}:`,
 				choices: [

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -1395,7 +1395,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 			if (synthesisProvider === "openai-compatible") {
 				const epInput = await input({
 					message: "Synthesis endpoint:",
-					default: synthesisEndpoint ?? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT,
+					default: DEFAULT_OPENAI_COMPATIBLE_ENDPOINT,
 					validate: (value) => normalizeHttpEndpoint(value) !== undefined || "Enter an http:// or https:// URL.",
 				});
 				synthesisEndpoint = normalizeHttpEndpoint(epInput) ?? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT;

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -325,6 +325,7 @@ export function renderSetupPlanSummary(plan: SetupPlan): string {
 	row("GraphIQ:", plan.graphiqEnabled ? "enabled" : "disabled");
 	row("Network:", plan.networkMode);
 	row("Git:", plan.gitEnabled ? "enabled" : "disabled");
+	if (plan.dreamingEnabled) row("Dreaming:", "enabled");
 
 	return lines.join("\n");
 }
@@ -1365,6 +1366,13 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		memoryDecayRate = Number.parseFloat(decayInput) || 0.95;
 	}
 
+	const dreamingEnabled = nonInteractive
+		? options.enableDreaming === true
+		: await confirm({
+				message: "Enable dreaming (background memory consolidation)?",
+				default: false,
+			});
+
 	let gitEnabled = false;
 	const shouldSkipGit = nonInteractive && options.skipGit === true;
 
@@ -1428,6 +1436,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		identityPreset,
 		startupIdentityFiles,
 		specialIdentityFiles,
+		dreamingEnabled,
 	};
 
 	const context: SetupApplyContext = {

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -24,8 +24,8 @@ import ora from "ora";
 import { validateName } from "../commands/agent.js";
 import { createDaemonClient } from "../lib/daemon.js";
 import { installGraphiqPlugin } from "./graphiq.js";
-import { connectApiKey, connectOAuth } from "./setup-connect.js";
-import type { ConnectHttp, ConnectUi } from "./setup-connect.js";
+import { runOAuthLogin, storeApiKey, storeOAuthCredentials } from "./setup-connect.js";
+import type { ConnectUi } from "./setup-connect.js";
 import { runFreshSetup } from "./setup-fresh.js";
 import {
 	LOCAL_SERVERS,
@@ -84,20 +84,18 @@ function modelChoices(provider: ExtractionProviderChoice): Array<{ value: string
 }
 
 /**
- * Pick a model from pi-ai's real catalog for a provider family. Uses a plain
- * select for short lists and a searchable `search` prompt for large ones
- * (e.g. openrouter's 253 models) so the user can type to find what they want.
- * Falls back to free text only if the catalog has no models for the family.
+ * Pick a model from a list of pi-ai model options. Plain select for short
+ * lists, searchable `search` prompt for large ones (e.g. openrouter's 253) so
+ * the user can type to find what they want — all results are shown, not capped.
  */
 async function pickModel(
-	family: string,
+	models: readonly { id: string; name: string }[],
 	prompts: {
 		readonly select: typeof import("@inquirer/prompts").select;
 		readonly search: typeof import("@inquirer/prompts").search;
 		readonly input: typeof import("@inquirer/prompts").input;
 	},
 ): Promise<string> {
-	const models = modelOptions(family);
 	if (models.length === 0) {
 		return (
 			await prompts.input({ message: "Model:", validate: (v) => v.trim().length > 0 || "Enter a model id" })
@@ -111,20 +109,44 @@ async function pickModel(
 		message: "Model (type to search):",
 		source: (term) => {
 			const t = (term ?? "").trim().toLowerCase();
-			const filtered = t
-				? choices.filter((c) => c.value.toLowerCase().includes(t) || c.name.toLowerCase().includes(t))
-				: choices;
-			return filtered.slice(0, 50);
+			return t ? choices.filter((c) => c.value.toLowerCase().includes(t) || c.name.toLowerCase().includes(t)) : choices;
 		},
 	});
 }
 
+/** Terminal UI for the OAuth dance (pi-ai login callbacks). */
+function connectUi(): ConnectUi {
+	return {
+		openUrl: (url) => {
+			console.log(chalk.cyan(`  Opening browser: ${url}`));
+			void open(url).catch(() => {});
+		},
+		showDeviceCode: (userCode, verificationUri) => {
+			console.log(chalk.cyan(`  Enter this code at ${verificationUri}:`));
+			console.log(chalk.bold(`    ${userCode}`));
+		},
+		promptText: (message) => input({ message }),
+		promptSelect: (message, options) =>
+			select({ message, choices: options.map((o) => ({ value: o.id, name: o.label })) }),
+		onProgress: (m) => console.log(chalk.dim(`    ${m}`)),
+	};
+}
+
+/** A captured provider credential (held in the wizard, stored after the daemon starts). */
+interface CapturedCredential {
+	readonly family: string;
+	readonly connectMethod: "api" | "oauth";
+	readonly apiKey?: string;
+	readonly oauthCredentials?: unknown;
+}
+
 /**
- * Connect sub-flows for background inference. The METHOD (OAuth vs API key)
- * is chosen by the top-level menu, so each helper just picks a provider from
- * the matching capability set and a model. Credential entry happens after the
- * daemon starts (the daemon owns the secrets store + OAuth endpoints, like the
- * browser dashboard). Returns undefined if the user backs out.
+ * Connect sub-flow: the user authenticates FIRST (OAuth login via pi-ai, or an
+ * API-key prompt), THEN picks a model from the authenticated catalog. pi-ai's
+ * login() is self-contained (spins its own callback server), so the OAuth
+ * dance runs here in the wizard — no daemon needed. The captured credential
+ * is stored after the daemon starts. Returns the decision + credential, or
+ * undefined if the user backs out.
  */
 async function pickConnectedProvider(
 	providers: readonly { id: string; name: string }[],
@@ -134,54 +156,61 @@ async function pickConnectedProvider(
 		readonly search: typeof import("@inquirer/prompts").search;
 		readonly input: typeof import("@inquirer/prompts").input;
 	},
-): Promise<{ family: string; connectMethod: "api" | "oauth"; model: string } | undefined> {
+): Promise<({ family: string; connectMethod: "api" | "oauth"; model: string } & CapturedCredential) | undefined> {
 	const provider = await prompts.select<string>({
 		message: connectMethod === "oauth" ? "Log in with:" : "Provider:",
 		choices: [...providers.map((p) => ({ value: p.id, name: p.name })), { value: "__back__", name: "← back" }],
 	});
 	if (provider === "__back__") return undefined;
-	const model = await pickModel(provider, prompts);
-	return { family: provider, connectMethod, model };
+
+	let credential: CapturedCredential;
+	if (connectMethod === "oauth") {
+		console.log();
+		console.log(chalk.cyan(`  Starting ${provider} login…`));
+		try {
+			const oauthCredentials = await runOAuthLogin(connectUi(), provider);
+			credential = { family: provider, connectMethod: "oauth", oauthCredentials };
+			console.log(chalk.green(`  ✓ Logged in to ${provider}`));
+		} catch (err) {
+			console.log(chalk.red(`  ✗ Login failed: ${err instanceof Error ? err.message : err}`));
+			return undefined;
+		}
+	} else {
+		const apiKey = (await password({ message: `Paste your ${provider} API key:`, mask: "*" })).trim();
+		if (!apiKey) return undefined;
+		credential = { family: provider, connectMethod: "api", apiKey };
+	}
+
+	console.log();
+	// Authenticated model list (pi-ai; modifyModels applied for OAuth providers).
+	const model = await pickModel(modelOptions(provider, credential.oauthCredentials as never), prompts);
+	return { family: provider, connectMethod, model, ...credential };
 }
 
 /**
- * Build the post-daemon-start connect callback. Talks to the daemon the same
- * way the dashboard does (the daemon owns the secrets store + OAuth SSE
- * endpoints), with terminal UI: a password prompt for API keys, `open()` +
- * inquirer for the OAuth dance. Returns true on success.
+ * Build the post-daemon-start store callback. The login already happened in
+ * the wizard (pi-ai's login() captured the credential); this just persists it
+ * to the daemon secrets store once the daemon is running. Returns true on
+ * success. If no credential was captured (e.g. back-out), it's a no-op true.
  */
 function buildConnectExtraction(
 	basePath: string,
 	port: number,
-): (family: string, method: "api" | "oauth") => Promise<boolean> {
-	return async (family, method) => {
+	credential: CapturedCredential | undefined,
+): () => Promise<boolean> {
+	return async () => {
+		if (!credential) return true;
 		const client = createDaemonClient(port, basePath);
-		const http: ConnectHttp = {
-			postJson: (path, body) => client.secretApiCall("POST", path, body),
-			getJson: (path) => client.secretApiCall("GET", path),
-		};
-		if (method === "api") {
-			const key = (await password({ message: `Paste your ${family} API key:`, mask: "*" })).trim();
-			if (!key) return false;
-			const res = await connectApiKey(http, family, key);
+		const http = { postJson: (path: string, body: unknown) => client.secretApiCall("POST", path, body) };
+		if (credential.connectMethod === "oauth" && credential.oauthCredentials) {
+			const res = await storeOAuthCredentials(http, credential.family, credential.oauthCredentials as never);
 			return res.ok;
 		}
-		const ui: ConnectUi = {
-			openUrl: (url) => {
-				console.log(chalk.cyan(`  Opening browser: ${url}`));
-				void open(url).catch(() => {});
-			},
-			showDeviceCode: (userCode, verificationUri) => {
-				console.log(chalk.cyan(`  Enter this code at ${verificationUri}:`));
-				console.log(chalk.bold(`    ${userCode}`));
-			},
-			promptText: (message) => input({ message }),
-			promptSelect: (message, options) =>
-				select({ message, choices: options.map((o) => ({ value: o.id, name: o.label })) }),
-			onProgress: (m) => console.log(chalk.dim(`    ${m}`)),
-		};
-		const res = await connectOAuth(http, ui, family);
-		return res.ok;
+		if (credential.connectMethod === "api" && credential.apiKey) {
+			const res = await storeApiKey(http, credential.family, credential.apiKey);
+			return res.ok;
+		}
+		return true;
 	};
 }
 
@@ -1243,6 +1272,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		deps.normalizeChoice(existingExtraction.provider, EXTRACTION_PROVIDER_CHOICES);
 	let extractionProvider: ExtractionProviderChoice;
 	let extractionConnect: { family: string; connectMethod: "api" | "oauth" } | undefined;
+	let extractionCredential: CapturedCredential | undefined;
 	// Declared before the provider-selection block so the connect sub-flow can
 	// assign it (avoids a temporal-dead-zone ReferenceError); the per-provider
 	// model branches below overwrite it for non-connect providers.
@@ -1280,6 +1310,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				const connected = await pickConnectedProvider(oauthProviderOptions(), "oauth", { select, search, input });
 				if (connected) {
 					extractionConnect = { family: connected.family, connectMethod: connected.connectMethod };
+					extractionCredential = connected;
 					extractionModel = connected.model;
 					extractionProvider = connected.family as ExtractionProviderChoice;
 					break;
@@ -1288,6 +1319,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				const connected = await pickConnectedProvider(apiKeyProviderOptions(), "api", { select, search, input });
 				if (connected) {
 					extractionConnect = { family: connected.family, connectMethod: connected.connectMethod };
+					extractionCredential = connected;
 					extractionModel = connected.model;
 					extractionProvider = connected.family as ExtractionProviderChoice;
 					break;
@@ -1642,7 +1674,9 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		acpxBin,
 		openclawConfigCount,
 		openDashboard: options.openDashboard === true,
-		connectExtraction: nonInteractive ? undefined : buildConnectExtraction(basePath, deps.DEFAULT_PORT),
+		connectExtraction: nonInteractive
+			? undefined
+			: buildConnectExtraction(basePath, deps.DEFAULT_PORT, extractionCredential),
 	};
 
 	// Enforce the same cross-field invariants the headless --file path gets via

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -25,6 +25,8 @@ import { installGraphiqPlugin } from "./graphiq.js";
 import { runFreshSetup } from "./setup-fresh.js";
 import { runExistingSetupWizard } from "./setup-migrate.js";
 import { EXTRACTION_SAFETY_WARNING, defaultAcpxModel, defaultExtractionModel } from "./setup-pipeline.js";
+import { setupPlanJsonSchema } from "./setup-plan.js";
+import type { SetupApplyContext, SetupPlan } from "./setup-plan.js";
 import { readSetupCorePluginEnabled, writeSetupCorePluginRegistry } from "./setup-plugins.js";
 import { enforceSetupProtection, printSetupProtectionSummary } from "./setup-protection.js";
 import {
@@ -64,7 +66,7 @@ import {
 	readString,
 	resolveSetupExtractionProvider,
 } from "./setup-shared.js";
-import type { FreshSetupConfig, SetupDeps, SetupWizardOptions } from "./setup-types.js";
+import type { SetupDeps, SetupWizardOptions } from "./setup-types.js";
 
 function modelChoices(provider: ExtractionProviderChoice): Array<{ value: string; name: string }> {
 	return modelPresetsForProvider(provider).map((preset) => ({ value: preset.value, name: preset.label }));
@@ -181,6 +183,11 @@ async function promptIdentityMode(defaultIdentityMode: IdentityMode): Promise<Id
 }
 
 export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps): Promise<void> {
+	if (options.schema) {
+		console.log(JSON.stringify(setupPlanJsonSchema(), null, 2));
+		return;
+	}
+
 	console.log(deps.signetLogo());
 	console.log();
 
@@ -1176,34 +1183,25 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		gitEnabled = initGit;
 	}
 
-	const cfg: FreshSetupConfig = {
-		basePath,
+	const plan: SetupPlan = {
 		agentName,
 		agentDescription,
 		networkMode,
 		harnesses,
 		openclawRuntimePath,
 		configureOpenClawWs,
-		openclawConfigCount,
 		embeddingProvider,
 		embeddingModel,
 		embeddingDimensions,
 		extractionProvider,
 		extractionModel,
 		extractionEndpoint,
-		availableExtractionProviders: availableToolExtractionProviders,
-		acpxBin,
 		searchBalance,
 		searchTopK,
 		searchMinScore,
 		memorySessionBudget,
 		memoryDecayRate,
 		gitEnabled,
-		existingAgentsDir: existing.agentsDir,
-		nonInteractive,
-		openDashboard: options.openDashboard === true,
-		allowUnprotectedWorkspace: options.allowUnprotectedWorkspace === true,
-		createLocalBackup: options.createLocalBackup === true,
 		signetSecretsEnabled,
 		graphiqEnabled,
 		identityMode,
@@ -1212,7 +1210,19 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		specialIdentityFiles,
 	};
 
-	await runFreshSetup(cfg, deps);
+	const context: SetupApplyContext = {
+		basePath,
+		existingAgentsDir: existing.agentsDir,
+		nonInteractive,
+		allowUnprotectedWorkspace: options.allowUnprotectedWorkspace === true,
+		createLocalBackup: options.createLocalBackup === true,
+		availableExtractionProviders: availableToolExtractionProviders,
+		acpxBin,
+		openclawConfigCount,
+		openDashboard: options.openDashboard === true,
+	};
+
+	await runFreshSetup(plan, context, deps);
 }
 
 async function resolveGraphiqPluginSelection(

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -25,7 +25,13 @@ import { validateName } from "../commands/agent.js";
 import { installGraphiqPlugin } from "./graphiq.js";
 import { runFreshSetup } from "./setup-fresh.js";
 import { runExistingSetupWizard } from "./setup-migrate.js";
-import { EXTRACTION_SAFETY_WARNING, defaultAcpxModel, defaultExtractionModel } from "./setup-pipeline.js";
+import {
+	AGGREGATE_RECALL_PROVIDER_CHOICES,
+	type AggregateRecallProviderChoice,
+	EXTRACTION_SAFETY_WARNING,
+	defaultAcpxModel,
+	defaultExtractionModel,
+} from "./setup-pipeline.js";
 import { parseSetupPlan, setupPlanJsonSchema } from "./setup-plan.js";
 import type { SetupApplyContext, SetupPlan } from "./setup-plan.js";
 import { readSetupCorePluginEnabled, writeSetupCorePluginRegistry } from "./setup-plugins.js";
@@ -350,8 +356,11 @@ export function renderSetupPlanSummary(plan: SetupPlan): string {
 		row("Model:", plan.extractionModel || chalk.dim("(default)"));
 		if (plan.extractionEndpoint) row("Endpoint:", plan.extractionEndpoint);
 	}
-	if (plan.synthesisProvider && plan.synthesisProvider !== plan.extractionProvider) {
-		row("Synthesis:", `${plan.synthesisProvider}${plan.synthesisModel ? ` (${plan.synthesisModel})` : ""}`);
+	if (plan.aggregateRecallProvider && plan.aggregateRecallProvider !== plan.extractionProvider) {
+		row(
+			"Aggregate recall:",
+			`${plan.aggregateRecallProvider}${plan.aggregateRecallModel ? ` (${plan.aggregateRecallModel})` : ""}`,
+		);
 	}
 
 	section("Plugins & network");
@@ -481,11 +490,13 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	const requestedExtractionProvider = deps.normalizeChoice(rawExtractionProvider, EXTRACTION_PROVIDER_CHOICES);
 	const rawExtractionEndpoint = deps.normalizeStringValue(options.extractionEndpoint);
 	const requestedExtractionEndpoint = normalizeHttpEndpoint(rawExtractionEndpoint);
-	const requestedSynthesisProvider = deps.normalizeChoice(options.synthesisProvider, EXTRACTION_PROVIDER_CHOICES);
-	const requestedSynthesisEndpoint = normalizeHttpEndpoint(deps.normalizeStringValue(options.synthesisEndpoint));
-	if (options.synthesisProvider && !requestedSynthesisProvider) {
+	const requestedAggregateRecallProvider = deps.normalizeChoice(
+		options.aggregateRecallProvider,
+		AGGREGATE_RECALL_PROVIDER_CHOICES,
+	);
+	if (options.aggregateRecallProvider && !requestedAggregateRecallProvider) {
 		failSetupValidation(
-			`Unknown --synthesis-provider value: ${options.synthesisProvider}. Valid choices: ${EXTRACTION_PROVIDER_CHOICES.join(", ")}.`,
+			`Unknown --aggregate-recall-provider value: ${options.aggregateRecallProvider}. Valid choices: ${AGGREGATE_RECALL_PROVIDER_CHOICES.join(", ")}.`,
 		);
 	}
 	const existingName = readString(existingConfig.name) ?? readString(existingAgent.name) ?? "My Agent";
@@ -1365,43 +1376,45 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		extractionEndpoint = normalizeHttpEndpoint(endpointInput) ?? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT;
 	}
 
-	// Optional distinct synthesis provider (session summaries). When unset,
-	// synthesis mirrors extraction.
-	let synthesisProvider: ExtractionProviderChoice | undefined;
-	let synthesisModel: string | undefined;
-	let synthesisEndpoint: string | undefined;
+	// Optional distinct provider for aggregate recall (query-time evidence
+	// synthesis). pi-ai-only (no harness subprocess). When unset, aggregate
+	// recall falls through to the default policy (the extraction provider).
+	let aggregateRecallProvider: AggregateRecallProviderChoice | undefined;
+	let aggregateRecallModel: string | undefined;
+	let aggregateRecallEndpoint: string | undefined;
 	if (nonInteractive) {
-		synthesisProvider = requestedSynthesisProvider ?? undefined;
-		synthesisModel = deps.normalizeStringValue(options.synthesisModel) ?? undefined;
-		synthesisEndpoint =
-			requestedSynthesisEndpoint ??
-			(requestedSynthesisProvider === "openai-compatible" ? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT : undefined);
+		aggregateRecallProvider = (deps.normalizeChoice(
+			options.aggregateRecallProvider,
+			AGGREGATE_RECALL_PROVIDER_CHOICES,
+		) ?? undefined) as AggregateRecallProviderChoice | undefined;
+		aggregateRecallModel = deps.normalizeStringValue(options.aggregateRecallModel) ?? undefined;
+		aggregateRecallEndpoint =
+			normalizeHttpEndpoint(deps.normalizeStringValue(options.aggregateRecallEndpoint)) ??
+			(aggregateRecallProvider === "openai-compatible" ? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT : undefined);
 	} else if (extractionProvider !== "none") {
-		const distinctSynthesis = await confirm({
-			message: "Use a different provider for session summaries (synthesis)?",
+		const distinctAggregateRecall = await confirm({
+			message: "Use a different provider for aggregate recall?",
+			description: "Query-time evidence synthesis. Latency-sensitive; defaults to your extraction provider.",
 			default: false,
 		});
-		if (distinctSynthesis) {
+		if (distinctAggregateRecall) {
 			console.log();
-			synthesisProvider = await select({
-				message: "Synthesis provider:",
-				choices: EXTRACTION_PROVIDER_CHOICES.filter((p) => p !== "none").map((p) => ({
-					value: p,
-					name: p,
-				})),
+			aggregateRecallProvider = await select({
+				message: "Aggregate-recall provider:",
+				choices: AGGREGATE_RECALL_PROVIDER_CHOICES.map((p) => ({ value: p, name: p })),
 			});
 			console.log();
-			synthesisModel = await select({
-				message: "Which model for synthesis?",
-				choices: modelChoices(synthesisProvider),
+			aggregateRecallModel = await select({
+				message: "Which model for aggregate recall?",
+				choices: modelChoices(aggregateRecallProvider),
 			});
-			if (synthesisProvider === "openai-compatible") {
+			if (aggregateRecallProvider === "openai-compatible") {
 				const epInput = await input({
-					message: "Synthesis endpoint:",
+					message: "Aggregate-recall endpoint:",
 					default: DEFAULT_OPENAI_COMPATIBLE_ENDPOINT,
 					validate: (value) => normalizeHttpEndpoint(value) !== undefined || "Enter an http:// or https:// URL.",
 				});
-				synthesisEndpoint = normalizeHttpEndpoint(epInput) ?? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT;
+				aggregateRecallEndpoint = normalizeHttpEndpoint(epInput) ?? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT;
 			}
 		}
 	}
@@ -1555,9 +1568,9 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		extractionProvider,
 		extractionModel,
 		extractionEndpoint,
-		synthesisProvider,
-		synthesisModel,
-		synthesisEndpoint,
+		aggregateRecallProvider,
+		aggregateRecallModel,
+		aggregateRecallEndpoint,
 		searchBalance,
 		searchTopK,
 		searchMinScore,

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -84,18 +84,34 @@ function modelChoices(provider: ExtractionProviderChoice): Array<{ value: string
 	return modelPresetsForProvider(provider).map((preset) => ({ value: preset.value, name: preset.label }));
 }
 
+/** Per-family extraction model defaults (small/fast/cheap, extraction-grade).
+ * The dashboard picks from the live catalog; the CLI wizard runs before the
+ * daemon, so we suggest a known-good id and let the user override. */
+const CONNECT_MODEL_DEFAULTS: Record<string, string> = {
+	anthropic: "claude-3-5-haiku-20241022",
+	openrouter: "anthropic/claude-3.5-haiku",
+	openai: "gpt-4o-mini",
+	"openai-codex": "gpt-4o-mini",
+	"github-copilot": "gpt-4o-mini",
+	google: "gemini-2.0-flash",
+	xai: "grok-2-latest",
+	groq: "llama-3.1-8b-instant",
+	deepseek: "deepseek-chat",
+	mistral: "mistral-small-latest",
+};
+
 /**
  * Interactive sub-flow matching the dashboard's connect-provider wall: pick a
- * cloud provider, then choose API-key vs OAuth login (when both are offered).
- * Returns the connect decision, or undefined if the user backs out. Credential
- * entry happens after the daemon starts (the daemon owns the secrets store +
- * OAuth endpoints, exactly like the browser dashboard).
+ * cloud provider, choose API-key vs OAuth login (when both are offered), and
+ * pick a model. Returns the connect decision, or undefined if the user backs
+ * out. Credential entry happens after the daemon starts (the daemon owns the
+ * secrets store + OAuth endpoints, exactly like the browser dashboard).
  */
 async function connectExtractionProvider(prompts: {
 	readonly select: typeof import("@inquirer/prompts").select;
 	readonly confirm: typeof import("@inquirer/prompts").confirm;
 	readonly input: typeof import("@inquirer/prompts").input;
-}): Promise<{ family: string; connectMethod: "api" | "oauth" } | undefined> {
+}): Promise<{ family: string; connectMethod: "api" | "oauth"; model: string } | undefined> {
 	const provider = await prompts.select<{
 		id: string;
 		name: string;
@@ -123,7 +139,15 @@ async function connectExtractionProvider(prompts: {
 	} else {
 		connectMethod = choice === "oauth" ? "oauth" : "api";
 	}
-	return { family: provider.id, connectMethod };
+	const modelDefault = CONNECT_MODEL_DEFAULTS[provider.id] ?? "";
+	const model = (
+		await prompts.input({
+			message: `Model for ${provider.name} (extraction):`,
+			default: modelDefault,
+			validate: (v) => v.trim().length > 0 || "Enter a model id",
+		})
+	).trim();
+	return { family: provider.id, connectMethod, model };
 }
 
 /**
@@ -140,6 +164,7 @@ function buildConnectExtraction(
 		const client = createDaemonClient(port, basePath);
 		const http: ConnectHttp = {
 			postJson: (path, body) => client.secretApiCall("POST", path, body),
+			getJson: (path) => client.secretApiCall("GET", path),
 			postStream: async (path, body) => {
 				const res = await fetch(`${client.url}${path}`, {
 					method: "POST",
@@ -1357,9 +1382,10 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 			const connected = await connectExtractionProvider({ select, confirm, input });
 			if (connected) {
 				extractionConnect = connected;
+				extractionModel = connected.model;
 				// pipelineV2 must stay enabled for the worker; the modern inference.*
 				// route (written in apply) overrides the actual target/credential.
-				extractionProvider = (connected.family as ExtractionProviderChoice) ?? "openrouter";
+				extractionProvider = connected.family as ExtractionProviderChoice;
 			} else {
 				extractionProvider = await select({
 					message: "Memory extraction provider:",
@@ -1372,7 +1398,10 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	}
 
 	let extractionModel = "haiku";
-	if (extractionProvider === "acpx") {
+	if (extractionConnect) {
+		// Model was chosen in the connect sub-flow; skip the legacy per-provider
+		// model branches (they don't cover the connect families).
+	} else if (extractionProvider === "acpx") {
 		if (nonInteractive) {
 			extractionModel =
 				deps.normalizeStringValue(options.extractionModel) ||

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -147,7 +147,7 @@ function writeCapabilitySelection(
 }
 
 /**
- * Scaffold minimal identity files when switching from off/passthrough to managed.
+ * Scaffold minimal identity files when switching from off to managed.
  * Only creates files that do not already exist.
  */
 function scaffoldIdentityIfNeeded(basePath: string, identityMode: IdentityMode, previousMode: IdentityMode): void {
@@ -179,11 +179,6 @@ async function promptIdentityMode(defaultIdentityMode: IdentityMode): Promise<Id
 				value: "off",
 				name: "Off — use Signet only for memory, recall, sources, and secrets",
 				description: "Best when your harness already owns personality and instructions.",
-			},
-			{
-				value: "passthrough",
-				name: "Passthrough — reserve identity for existing harness files",
-				description: "Signet will not author or sync identity files.",
 			},
 		],
 		default: defaultIdentityMode,
@@ -584,7 +579,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 
 			const resolvedIdentityMode = configuredIdentityMode ?? existingIdentityMode;
 
-			// When identity mode changes to off/passthrough, run stale identity cleanup
+			// When identity mode changes to off, run stale identity cleanup
 			// for all detected and configured harnesses even if --harness was not passed.
 			if (resolvedIdentityMode !== "managed" && existingIdentityMode === "managed") {
 				const h = existing.harnesses;

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -159,15 +159,6 @@ function buildConnectExtraction(
 		const http: ConnectHttp = {
 			postJson: (path, body) => client.secretApiCall("POST", path, body),
 			getJson: (path) => client.secretApiCall("GET", path),
-			postStream: async (path, body) => {
-				const res = await fetch(`${client.url}${path}`, {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify(body),
-				});
-				if (!res.ok || !res.body) throw new Error(`daemon ${path} returned ${res.status}`);
-				return res.body;
-			},
 		};
 		if (method === "api") {
 			const key = (await password({ message: `Paste your ${family} API key:`, mask: "*" })).trim();
@@ -1172,7 +1163,6 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 			message: "How should memories be embedded for search?",
 			choices: [
 				{ value: "native", name: "Built-in (recommended, no setup required)" },
-				{ value: "llama-cpp", name: "llama.cpp (local — nomic-embed-text)" },
 				{ value: "ollama", name: "Ollama (local, requires ollama install)" },
 				{ value: "openai", name: "OpenAI API" },
 				{ value: "none", name: "Skip embeddings for now" },
@@ -1186,31 +1176,6 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	if (embeddingProvider === "native") {
 		embeddingModel = "nomic-embed-text-v1.5";
 		embeddingDimensions = 768;
-	} else if (embeddingProvider === "llama-cpp") {
-		if (nonInteractive) {
-			const configuredModel =
-				deps.normalizeStringValue(options.embeddingModel) ||
-				deps.normalizeStringValue(existingEmbedding.model) ||
-				"nomic-embed-text";
-			embeddingModel = configuredModel;
-			embeddingDimensions = getEmbeddingDimensions(configuredModel);
-		} else {
-			console.log();
-			const model = await select({
-				message: "Which embedding model?",
-				choices: [
-					{ value: "nomic-embed-text", name: "nomic-embed-text (768d, recommended)" },
-					{ value: "all-minilm", name: "all-minilm (384d, faster)" },
-					{ value: "mxbai-embed-large", name: "mxbai-embed-large (1024d, better quality)" },
-				],
-			});
-			embeddingModel = model;
-			embeddingDimensions = getEmbeddingDimensions(model);
-			if (!llamaCppServerAvailable) {
-				console.log(chalk.yellow("  No llama.cpp server detected on http://localhost:8080."));
-				console.log(chalk.yellow("  Embeddings will fail until llama.cpp is running."));
-			}
-		}
 	} else if (embeddingProvider === "ollama") {
 		if (nonInteractive) {
 			const configuredModel =

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -521,6 +521,12 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		const explicitPath = deps.normalizeStringValue(options.path);
 		const basePath = deps.normalizeAgentPath(explicitPath ?? deps.AGENTS_DIR);
 		const plan = loadPlanFromOptions(options);
+		if (plan.extractionConnect) {
+			failSetupValidation(
+				"A headless setup plan cannot use extractionConnect because credentials are not part of SetupPlan.",
+				"Use a supported non-interactive extraction provider with its configured credential, or run interactive setup to connect the provider.",
+			);
+		}
 		if (options.dryRun) {
 			console.log(JSON.stringify(plan, null, 2));
 			return;
@@ -1471,17 +1477,16 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		});
 		if (distinctAggregateRecall) {
 			console.log();
-			// Same pi-ai catalog as the connect flow (pi-ai-only — no ACPX, since
-			// aggregate recall is latency-sensitive), plus local servers.
-			const aggProviders = [...oauthProviderOptions(), ...apiKeyProviderOptions(), ...LOCAL_SERVERS].filter(
-				(p, i, arr) => arr.findIndex((q) => q.id === p.id) === i,
-			);
+			// Fresh setup can safely configure keyless local servers and OpenRouter,
+			// whose existing OPENROUTER_API_KEY environment contract the router uses.
+			// Other cloud families must be connected in the dashboard first.
+			const aggProviders = [{ id: "openrouter", name: "OpenRouter" }, ...LOCAL_SERVERS];
 			aggregateRecallProvider = await select({
 				message: "Aggregate-recall provider:",
 				choices: aggProviders.map((p) => ({ value: p.id, name: p.name })),
 			});
 			console.log();
-			aggregateRecallModel = await pickModel(aggregateRecallProvider, { select, search, input });
+			aggregateRecallModel = await pickModel(modelOptions(aggregateRecallProvider), { select, search, input });
 			if (aggregateRecallProvider === "openai-compatible") {
 				const epInput = await input({
 					message: "Aggregate-recall endpoint:",

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -36,7 +36,7 @@ import {
 } from "./setup-inference-connect.js";
 import { runExistingSetupWizard } from "./setup-migrate.js";
 import { defaultAcpxModel, defaultExtractionModel } from "./setup-pipeline.js";
-import { parseSetupPlan, setupPlanJsonSchema } from "./setup-plan.js";
+import { isBareDaemonOrigin, parseSetupPlan, setupPlanJsonSchema } from "./setup-plan.js";
 import type { SetupApplyContext, SetupPlan } from "./setup-plan.js";
 import { readSetupCorePluginEnabled, writeSetupCorePluginRegistry } from "./setup-plugins.js";
 import { enforceSetupProtection, printSetupProtectionSummary } from "./setup-protection.js";
@@ -226,6 +226,11 @@ function normalizeHttpEndpoint(value: string | null | undefined): string | undef
 	} catch {
 		return undefined;
 	}
+}
+
+function normalizeDaemonOrigin(value: string | null | undefined): string | undefined {
+	const endpoint = normalizeHttpEndpoint(value);
+	return endpoint && isBareDaemonOrigin(endpoint) ? endpoint : undefined;
 }
 
 function resolveSetupExtractionEndpoint(options: {
@@ -643,6 +648,9 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	const existingIdentity = readRecord(existingConfig.identity);
 	const configuredIdentityMode = deps.normalizeChoice(options.identityMode, IDENTITY_MODE_CHOICES);
 	const existingIdentityMode = resolveIdentityModeFromConfig(existingConfig);
+	// Passthrough remains readable for existing installs, but fresh setup no
+	// longer writes or offers it. Reconfiguring explicitly selects a current mode.
+	const existingSetupIdentityMode: IdentityMode = existingIdentityMode === "passthrough" ? "off" : existingIdentityMode;
 	const configuredIdentityPreset = deps.normalizeChoice(options.identityPreset, IDENTITY_PRESET_CHOICES);
 	const existingIdentityPreset = deps.normalizeChoice(existingIdentity.preset, IDENTITY_PRESET_CHOICES);
 	if (options.identityMode && !configuredIdentityMode) {
@@ -705,10 +713,14 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				writeCapabilitySelection(
 					basePath,
 					existingConfig,
-					configuredIdentityMode ?? existingIdentityMode,
+					configuredIdentityMode ?? existingSetupIdentityMode,
 					signetSecretsEnabled,
 				);
-				scaffoldIdentityIfNeeded(basePath, configuredIdentityMode ?? existingIdentityMode, existingIdentityMode);
+				scaffoldIdentityIfNeeded(
+					basePath,
+					configuredIdentityMode ?? existingSetupIdentityMode,
+					existingSetupIdentityMode,
+				);
 			}
 			writeSetupCorePluginRegistry(basePath, { signetSecretsEnabled, graphiqEnabled });
 			if (graphiqEnabled) {
@@ -717,7 +729,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				disableGraphiqState(basePath);
 			}
 
-			const resolvedIdentityMode = configuredIdentityMode ?? existingIdentityMode;
+			const resolvedIdentityMode = configuredIdentityMode ?? existingSetupIdentityMode;
 
 			// When identity mode changes to off, run stale identity cleanup
 			// for all detected and configured harnesses even if --harness was not passed.
@@ -871,7 +883,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 
 			await runExistingSetupWizard(basePath, existing, existingConfig, deps, {
 				nonInteractive: true,
-				identityMode: configuredIdentityMode ?? existingIdentityMode,
+				identityMode: configuredIdentityMode ?? existingSetupIdentityMode,
 				openDashboard: options.openDashboard === true,
 				skipGit: options.skipGit === true,
 				allowUnprotectedWorkspace: options.allowUnprotectedWorkspace === true,
@@ -963,7 +975,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 
 			const signetSecretsEnabled = await resolveSignetSecretsCorePluginSelection(basePath, false, options);
 			const graphiqEnabled = await resolveGraphiqPluginSelection(basePath, false, options);
-			const migrationIdentityMode = configuredIdentityMode ?? (await promptIdentityMode(existingIdentityMode));
+			const migrationIdentityMode = configuredIdentityMode ?? (await promptIdentityMode(existingSetupIdentityMode));
 
 			await runExistingSetupWizard(basePath, existing, existingConfig, deps, {
 				identityMode: migrationIdentityMode,
@@ -1006,7 +1018,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		console.log();
 	}
 
-	const defaultIdentityMode: IdentityMode = configuredIdentityMode ?? existingIdentityMode ?? "managed";
+	const defaultIdentityMode: IdentityMode = configuredIdentityMode ?? existingSetupIdentityMode;
 	const identityMode: IdentityMode = nonInteractive
 		? defaultIdentityMode
 		: await promptIdentityMode(defaultIdentityMode);
@@ -1151,9 +1163,9 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	// when remote — no local daemon is started.)
 	let networkMode: NetworkMode;
 	let daemonUrl: string | undefined;
-	const requestedRemoteUrl = normalizeHttpEndpoint(deps.normalizeStringValue(options.remoteUrl));
+	const requestedRemoteUrl = normalizeDaemonOrigin(deps.normalizeStringValue(options.remoteUrl));
 	if (options.remoteUrl && !requestedRemoteUrl) {
-		failSetupValidation("--remote-url must be an http:// or https:// URL.");
+		failSetupValidation("--remote-url must be a bare http:// or https:// origin (no path, query, or credentials).");
 	}
 	if (nonInteractive) {
 		networkMode = deps.normalizeChoice(options.networkMode, NETWORK_MODES) ?? existingNetworkMode;
@@ -1172,9 +1184,11 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		if (hosting === "remote") {
 			const urlInput = await input({
 				message: "Remote daemon URL:",
-				validate: (value) => normalizeHttpEndpoint(value) !== undefined || "Enter an http:// or https:// URL.",
+				validate: (value) =>
+					normalizeDaemonOrigin(value) !== undefined ||
+					"Enter a bare http:// or https:// origin (no path, query, or credentials).",
 			});
-			daemonUrl = normalizeHttpEndpoint(urlInput) ?? undefined;
+			daemonUrl = normalizeDaemonOrigin(urlInput) ?? undefined;
 			networkMode = "localhost"; // no local daemon to bind
 		} else {
 			networkMode = hosting === "tailscale" ? "tailscale" : "localhost";

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -1,6 +1,6 @@
 import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { checkbox, confirm, input, select } from "@inquirer/prompts";
+import { checkbox, confirm, input, password, select } from "@inquirer/prompts";
 import { OpenClawConnector } from "@signet/connector-openclaw";
 import {
 	IDENTITY_MODES,
@@ -22,8 +22,12 @@ import chalk from "chalk";
 import open from "open";
 import ora from "ora";
 import { validateName } from "../commands/agent.js";
+import { createDaemonClient } from "../lib/daemon.js";
 import { installGraphiqPlugin } from "./graphiq.js";
+import { connectApiKey, connectChoice, connectOAuth } from "./setup-connect.js";
+import type { ConnectHttp, ConnectUi } from "./setup-connect.js";
 import { runFreshSetup } from "./setup-fresh.js";
+import { CONNECTABLE_PROVIDERS } from "./setup-inference-connect.js";
 import { runExistingSetupWizard } from "./setup-migrate.js";
 import {
 	AGGREGATE_RECALL_PROVIDER_CHOICES,
@@ -78,6 +82,97 @@ import type { SetupDeps, SetupWizardOptions } from "./setup-types.js";
 
 function modelChoices(provider: ExtractionProviderChoice): Array<{ value: string; name: string }> {
 	return modelPresetsForProvider(provider).map((preset) => ({ value: preset.value, name: preset.label }));
+}
+
+/**
+ * Interactive sub-flow matching the dashboard's connect-provider wall: pick a
+ * cloud provider, then choose API-key vs OAuth login (when both are offered).
+ * Returns the connect decision, or undefined if the user backs out. Credential
+ * entry happens after the daemon starts (the daemon owns the secrets store +
+ * OAuth endpoints, exactly like the browser dashboard).
+ */
+async function connectExtractionProvider(prompts: {
+	readonly select: typeof import("@inquirer/prompts").select;
+	readonly confirm: typeof import("@inquirer/prompts").confirm;
+	readonly input: typeof import("@inquirer/prompts").input;
+}): Promise<{ family: string; connectMethod: "api" | "oauth" } | undefined> {
+	const provider = await prompts.select<{
+		id: string;
+		name: string;
+		supportsOAuth: boolean;
+		supportsApiKey: boolean;
+	}>({
+		message: "Connect a cloud provider for memory extraction:",
+		choices: [
+			...CONNECTABLE_PROVIDERS.map((p) => ({ value: p, name: p.name })),
+			{ value: { id: "__back__", name: "← back", supportsOAuth: false, supportsApiKey: false }, name: "← back" },
+		],
+	});
+	if (provider.id === "__back__") return undefined;
+
+	const choice = connectChoice(provider);
+	let connectMethod: "api" | "oauth";
+	if (choice === "choice") {
+		connectMethod = await prompts.select<"api" | "oauth">({
+			message: `How do you want to connect ${provider.name}?`,
+			choices: [
+				{ value: "oauth", name: "Log in (subscription / OAuth)" },
+				{ value: "api", name: "Paste an API key" },
+			],
+		});
+	} else {
+		connectMethod = choice === "oauth" ? "oauth" : "api";
+	}
+	return { family: provider.id, connectMethod };
+}
+
+/**
+ * Build the post-daemon-start connect callback. Talks to the daemon the same
+ * way the dashboard does (the daemon owns the secrets store + OAuth SSE
+ * endpoints), with terminal UI: a password prompt for API keys, `open()` +
+ * inquirer for the OAuth dance. Returns true on success.
+ */
+function buildConnectExtraction(
+	basePath: string,
+	port: number,
+): (family: string, method: "api" | "oauth") => Promise<boolean> {
+	return async (family, method) => {
+		const client = createDaemonClient(port, basePath);
+		const http: ConnectHttp = {
+			postJson: (path, body) => client.secretApiCall("POST", path, body),
+			postStream: async (path, body) => {
+				const res = await fetch(`${client.url}${path}`, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(body),
+				});
+				if (!res.ok || !res.body) throw new Error(`daemon ${path} returned ${res.status}`);
+				return res.body;
+			},
+		};
+		if (method === "api") {
+			const key = (await password({ message: `Paste your ${family} API key:`, mask: "*" })).trim();
+			if (!key) return false;
+			const res = await connectApiKey(http, family, key);
+			return res.ok;
+		}
+		const ui: ConnectUi = {
+			openUrl: (url) => {
+				console.log(chalk.cyan(`  Opening browser: ${url}`));
+				void open(url).catch(() => {});
+			},
+			showDeviceCode: (userCode, verificationUri) => {
+				console.log(chalk.cyan(`  Enter this code at ${verificationUri}:`));
+				console.log(chalk.bold(`    ${userCode}`));
+			},
+			promptText: (message) => input({ message }),
+			promptSelect: (message, options) =>
+				select({ message, choices: options.map((o) => ({ value: o.id, name: o.label })) }),
+			onProgress: (m) => console.log(chalk.dim(`    ${m}`)),
+		};
+		const res = await connectOAuth(http, ui, family);
+		return res.ok;
+	};
 }
 
 const DEFAULT_OPENAI_COMPATIBLE_ENDPOINT = "http://127.0.0.1:1234/v1";
@@ -1188,6 +1283,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		deps.normalizeChoice(existingPipeline.extractionProvider, EXTRACTION_PROVIDER_CHOICES) ||
 		deps.normalizeChoice(existingExtraction.provider, EXTRACTION_PROVIDER_CHOICES);
 	let extractionProvider: ExtractionProviderChoice;
+	let extractionConnect: { family: string; connectMethod: "api" | "oauth" } | undefined;
 	if (nonInteractive) {
 		extractionProvider = resolveSetupExtractionProvider({
 			deploymentType,
@@ -1242,7 +1338,12 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				name: "OpenAI-compatible endpoint (advanced, uses OPENAI_API_KEY and extraction endpoint config)",
 			},
 		];
-		extractionProvider = await select({
+		// Dashboard-style connect option: cloud provider via API key or OAuth.
+		choices.unshift({
+			value: "__connect__" as ExtractionProviderChoice,
+			name: "Connect a cloud provider (API key or login — Anthropic, OpenRouter, OpenAI, …)",
+		});
+		const chosen = await select<ExtractionProviderChoice>({
 			message: "Memory extraction provider (analyzes conversations):",
 			choices,
 			default: defaultExtractionProviderForDeployment(
@@ -1252,6 +1353,22 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				harnesses,
 			),
 		});
+		if (chosen === ("__connect__" as ExtractionProviderChoice)) {
+			const connected = await connectExtractionProvider({ select, confirm, input });
+			if (connected) {
+				extractionConnect = connected;
+				// pipelineV2 must stay enabled for the worker; the modern inference.*
+				// route (written in apply) overrides the actual target/credential.
+				extractionProvider = (connected.family as ExtractionProviderChoice) ?? "openrouter";
+			} else {
+				extractionProvider = await select({
+					message: "Memory extraction provider:",
+					choices: choices.filter((c) => c.value !== ("__connect__" as ExtractionProviderChoice)),
+				});
+			}
+		} else {
+			extractionProvider = chosen;
+		}
 	}
 
 	let extractionModel = "haiku";
@@ -1563,6 +1680,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		extractionProvider,
 		extractionModel,
 		extractionEndpoint,
+		extractionConnect,
 		aggregateRecallProvider,
 		aggregateRecallModel,
 		aggregateRecallEndpoint,
@@ -1594,6 +1712,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		acpxBin,
 		openclawConfigCount,
 		openDashboard: options.openDashboard === true,
+		connectExtraction: nonInteractive ? undefined : buildConnectExtraction(basePath, deps.DEFAULT_PORT),
 	};
 
 	// Enforce the same cross-field invariants the headless --file path gets via

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -359,6 +359,7 @@ export function renderSetupPlanSummary(plan: SetupPlan): string {
 	row("GraphIQ:", plan.graphiqEnabled ? "enabled" : "disabled");
 	row("Network:", plan.networkMode);
 	row("Git:", plan.gitEnabled ? "enabled" : "disabled");
+	if (plan.daemonUrl) row("Daemon:", `remote (${plan.daemonUrl})`);
 	if (plan.dreamingEnabled) row("Dreaming:", "enabled");
 	if (plan.agents && plan.agents.length > 0) {
 		row("Agents:", `${plan.agents.length} (${plan.agents.map((a) => a.name).join(", ")})`);
@@ -1016,6 +1017,29 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		});
 	}
 
+	// Remote instance: point this workspace at a daemon running elsewhere
+	// instead of starting a local one. Persisted as daemon.url in agent.yaml.
+	let daemonUrl: string | undefined;
+	const requestedRemoteUrl = normalizeHttpEndpoint(deps.normalizeStringValue(options.remoteUrl));
+	if (options.remoteUrl && !requestedRemoteUrl) {
+		failSetupValidation("--remote-url must be an http:// or https:// URL.");
+	}
+	if (nonInteractive) {
+		daemonUrl = requestedRemoteUrl ?? undefined;
+	} else {
+		const useRemote = await confirm({
+			message: "Use a remote daemon instead of starting a local one?",
+			default: false,
+		});
+		if (useRemote) {
+			const urlInput = await input({
+				message: "Remote daemon URL:",
+				validate: (value) => normalizeHttpEndpoint(value) !== undefined || "Enter an http:// or https:// URL.",
+			});
+			daemonUrl = normalizeHttpEndpoint(urlInput) ?? undefined;
+		}
+	}
+
 	let deploymentType: DeploymentTypeChoice;
 	if (nonInteractive) {
 		deploymentType = requestedDeploymentType ?? "local";
@@ -1520,6 +1544,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		startupIdentityFiles,
 		specialIdentityFiles,
 		dreamingEnabled,
+		daemonUrl,
 		agents: agents.length > 0 ? agents : undefined,
 	};
 

--- a/surfaces/cli/src/lib/daemon.test.ts
+++ b/surfaces/cli/src/lib/daemon.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createDaemonClient } from "./daemon.js";
 
 const originalFetch = globalThis.fetch;
@@ -60,6 +63,25 @@ describe("createDaemonClient", () => {
 		} finally {
 			if (previous === undefined) Reflect.deleteProperty(process.env, "SIGNET_DAEMON_URL");
 			else process.env.SIGNET_DAEMON_URL = previous;
+		}
+	});
+
+	test("a malformed persisted daemon.url falls back gracefully instead of bricking the client", () => {
+		const dir = join(tmpdir(), `daemon-badurl-${Date.now()}`);
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "agent.yaml"), "daemon:\n  url: https://host.example/signet\n");
+		const previousUrl = process.env.SIGNET_DAEMON_URL;
+		Reflect.deleteProperty(process.env, "SIGNET_DAEMON_URL");
+		const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const client = createDaemonClient(3850, dir);
+			expect(client.url).toBe("http://localhost:3850");
+			expect(String(warnSpy.mock.calls[0]?.[0] ?? "")).toContain("Ignoring invalid daemon.url");
+		} finally {
+			warnSpy.mockRestore();
+			if (previousUrl === undefined) Reflect.deleteProperty(process.env, "SIGNET_DAEMON_URL");
+			else process.env.SIGNET_DAEMON_URL = previousUrl;
+			rmSync(dir, { recursive: true, force: true });
 		}
 	});
 

--- a/surfaces/cli/src/lib/daemon.ts
+++ b/surfaces/cli/src/lib/daemon.ts
@@ -1,4 +1,6 @@
-import { resolveSignetDaemonUrl } from "@signet/core";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseSimpleYaml, resolveSignetDaemonUrl } from "@signet/core";
 import chalk from "chalk";
 
 export type DaemonFetch = <T>(path: string, opts?: RequestInit & { timeout?: number }) => Promise<T | null>;
@@ -49,7 +51,10 @@ function withAuthHeaders(headers?: HeadersInit): Headers {
 	return merged;
 }
 
-export function createDaemonClient(port: number): {
+export function createDaemonClient(
+	port: number,
+	agentsDir?: string,
+): {
 	readonly url: string;
 	readonly fetchFromDaemon: DaemonFetch;
 	readonly fetchDaemonResult: <T>(
@@ -58,7 +63,7 @@ export function createDaemonClient(port: number): {
 	) => Promise<DaemonFetchResult<T>>;
 	readonly secretApiCall: DaemonApiCall;
 } {
-	const url = resolveDaemonClientUrl(port);
+	const url = resolveDaemonClientUrl(port, agentsDir);
 
 	const fetchDaemonResult = async <T>(
 		path: string,
@@ -140,8 +145,26 @@ export function createDaemonClient(port: number): {
 	};
 }
 
-function resolveDaemonClientUrl(port: number): string {
-	return resolveSignetDaemonUrl({ defaultHost: "localhost", defaultPort: port });
+function resolveDaemonClientUrl(port: number, agentsDir?: string): string {
+	return resolveSignetDaemonUrl({
+		defaultHost: "localhost",
+		defaultPort: port,
+		configUrl: agentsDir ? readDaemonUrlConfig(agentsDir) : undefined,
+	});
+}
+
+/** Read the persisted `daemon.url` from agent.yaml, if any. */
+function readDaemonUrlConfig(agentsDir: string): string | undefined {
+	const file = join(agentsDir, "agent.yaml");
+	if (!existsSync(file)) return undefined;
+	try {
+		const cfg = parseSimpleYaml(readFileSync(file, "utf-8")) as Record<string, unknown>;
+		const daemon = cfg.daemon as Record<string, unknown> | undefined;
+		const url = daemon?.url;
+		return typeof url === "string" && url.trim() ? url.trim() : undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 export async function ensureDaemonRunning(

--- a/surfaces/cli/src/lib/daemon.ts
+++ b/surfaces/cli/src/lib/daemon.ts
@@ -146,11 +146,19 @@ export function createDaemonClient(
 }
 
 function resolveDaemonClientUrl(port: number, agentsDir?: string): string {
-	return resolveSignetDaemonUrl({
-		defaultHost: "localhost",
-		defaultPort: port,
-		configUrl: agentsDir ? readDaemonUrlConfig(agentsDir) : undefined,
-	});
+	const configUrl = agentsDir ? readDaemonUrlConfig(agentsDir) : undefined;
+	try {
+		return resolveSignetDaemonUrl({ defaultHost: "localhost", defaultPort: port, configUrl });
+	} catch (err) {
+		// A malformed daemon.url must never brick every CLI command (the client is
+		// built at module load). Fall back to env/default resolution and warn.
+		if (configUrl) {
+			console.warn(
+				chalk.yellow(`Ignoring invalid daemon.url "${configUrl}": ${err instanceof Error ? err.message : err}`),
+			);
+		}
+		return resolveSignetDaemonUrl({ defaultHost: "localhost", defaultPort: port });
+	}
 }
 
 /** Read the persisted `daemon.url` from agent.yaml, if any. */


### PR DESCRIPTION
## Summary

Reworks fresh `signet setup` around a validated, serializable `SetupPlan`, so the interactive wizard, flags, and `--file` / `--json` headless paths share one apply engine. Closes #967.

## Changes

- Adds strict SetupPlan validation, JSON Schema output, headless plan application, dry-run, and non-TTY protection.
- Adds reviewable setup summaries, dreaming, roster, remote-daemon, and Obsidian-source setup options.
- Adds provider connection during interactive setup. Headless plans reject `extractionConnect` because credentials are not serializable.
- Restricts fresh-setup aggregate recall to local backends and OpenRouter, requires a model, and preserves the remote daemon credential write.
- Rebases on current `main` and updates the setup design draft for the removed session-synthesis route.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: setup design documentation

## Screenshots

Not applicable. This is a CLI flow.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No database or config migration is added.

## Testing

- [x] Focused setup, daemon URL, and identity suite: 165 passing tests.
- [x] `bun run --filter '@signet/cli' build:workspace-deps && bun run --filter '@signet/cli' build:cli`
- [x] `biome check` on changed setup and spec files.
- [x] Built CLI runtime: `setup --schema`, valid `--file --dry-run`, and rejection of a credential-bearing headless plan.
- [ ] `bun run typecheck` is blocked by existing daemon rootDir and aggregate-recall errors in untouched `platform/daemon` files. Changed core and connector package typechecks pass during the build.
- [ ] Live OAuth login was not run because it requires a real provider account/credential.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tag in the rehabilitation commit)

## Notes

The final gpt-5.6-terra autoreview attempt was blocked before review by the local Codex refresh-token error. No reviewer findings were produced.
