### PR TITLE
fix(release): absolutize native smoke binary override path

### DIFF
--- a/scripts/native-embedding-runtime-smoke.test.ts
+++ b/scripts/native-embedding-runtime-smoke.test.ts
@@ -4,7 +4,7 @@ import { type ChildProcessWithoutNullStreams, spawn, spawnSync } from "node:chil
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { type Server, createServer } from "node:net";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import { MIGRATIONS } from "../platform/core/src/migrations";
 
 const root = join(import.meta.dir, "..");
@@ -38,10 +38,16 @@ function closesWithin(closed: Promise<true>, timeoutMs: number): Promise<boolean
 /** Resolve the compiled native binary to smoke-test.
  *  Honors an explicit SIGNET_NATIVE_SMOKE_BINARY override (release CI builds to
  *  dist/native/$RELEASE_ASSET); otherwise derives the asset name for the current
- *  platform so one test covers every release leg. */
-function nativeSmokeBinary(): string {
+ *  platform so one test covers every release leg.
+ *
+ *  The override is resolved against the repo root and returned as an absolute
+ *  path. Release CI sets a relative value (`./dist/native/$RELEASE_ASSET`);
+ *  without absolutizing, the `signet sync` spawnSync below fails with ENOENT
+ *  because it runs with `cwd: <tempdir>`, and Node resolves a relative command
+ *  path against that cwd rather than the repo root. */
+export function nativeSmokeBinary(): string {
 	const override = process.env.SIGNET_NATIVE_SMOKE_BINARY;
-	if (override) return override;
+	if (override) return resolve(root, override);
 	const key = `${process.platform}-${process.arch}`;
 	const name = `signet-${key}`;
 	return join(root, "dist", "native", key.startsWith("win32-") ? `${name}.exe` : name);
@@ -123,6 +129,33 @@ afterEach(async () => {
 	for (const server of blackholeServers.splice(0)) server.close();
 	for (const path of tempDirs.splice(0)) rmSync(path, { recursive: true, force: true });
 }, 30_000);
+
+describe("native smoke binary path", () => {
+	test("resolves a relative SIGNET_NATIVE_SMOKE_BINARY override to an absolute path", () => {
+		const prev = process.env.SIGNET_NATIVE_SMOKE_BINARY;
+		process.env.SIGNET_NATIVE_SMOKE_BINARY = join(".", "dist", "native", "signet-test-binary");
+		try {
+			const binary = nativeSmokeBinary();
+			expect(isAbsolute(binary), binary).toBe(true);
+			expect(binary).toBe(join(root, "dist", "native", "signet-test-binary"));
+		} finally {
+			if (prev === undefined) delete process.env.SIGNET_NATIVE_SMOKE_BINARY;
+			else process.env.SIGNET_NATIVE_SMOKE_BINARY = prev;
+		}
+	});
+
+	test("respects an absolute SIGNET_NATIVE_SMOKE_BINARY override unchanged", () => {
+		const prev = process.env.SIGNET_NATIVE_SMOKE_BINARY;
+		const abs = join(root, "dist", "native", "signet-abs-binary");
+		process.env.SIGNET_NATIVE_SMOKE_BINARY = abs;
+		try {
+			expect(nativeSmokeBinary()).toBe(abs);
+		} finally {
+			if (prev === undefined) delete process.env.SIGNET_NATIVE_SMOKE_BINARY;
+			else process.env.SIGNET_NATIVE_SMOKE_BINARY = prev;
+		}
+	});
+});
 
 describe("native embedding smoke teardown", () => {
 	test("waits for close after escalating a SIGTERM-resistant child", async () => {


### PR DESCRIPTION
## Problem

`main`'s **Nightly Release** workflow has failed on every push since `7f1da9fcd` (landed between v0.154.7 and v0.154.8), at the **Native release runtime smoke** step. As a result native binary assets stopped uploading: v0.154.8 → v0.155.0 each shipped with only **15 release assets** (no native binaries) instead of the expected **32**. The last accessible nightly with native binaries is **v0.154.7**.

## Root cause

The smoke test added in `7f1da9fcd` runs `signet sync` via:

```ts
spawnSync(binary, ["sync"], { cwd: <tempdir>, ... })
```

CI sets `SIGNET_NATIVE_SMOKE_BINARY=./dist/native/$RELEASE_ASSET` — a **relative** path. Node resolves a relative command path against `options.cwd` (the tempdir), not the repo root, so the spawn throws `ENOENT`:

```
ENOENT: no such file or directory, posix_spawn './dist/native/signet-linux-x64'
```

The daemon `spawn(binary, [])` earlier in the same test worked only because it omits `cwd`. The non-override path in `nativeSmokeBinary()` already returned an absolute path (`join(root, …)`); the override branch returned the raw value — an inconsistency.

## Fix

`nativeSmokeBinary()` resolves the override against the repo root and returns an absolute path, matching the non-override path. Two cheap regression unit tests (no native build required) guard both the relative- and absolute-override cases.

## Verification

- Reproduced the exact CI failure locally, then confirmed all **7 tests pass** with the exact CI override form `./dist/native/signet-linux-x64`.
- Adversarial review: 0 findings; the reviewer independently reproduced the ENOENT and verified `resolve(root, override)` under both Node and Bun.

Once this lands, the next Nightly Release on `main` will publish native binaries for the new version. The existing v0.154.8–v0.155.0 tags remain without native assets; backfilling those is out of scope here.


## Readiness checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec change; CI/release test fix only
- [x] Agent scoping verified on all new/changed data queries — no data queries changed
- [x] Input/config validation and bounds checks added — `nativeSmokeBinary()` now absolutizes the override input
- [x] Error handling and fallback paths tested (no silent swallow) — regression tests assert absolute resolution for relative + absolute overrides
- [x] Security checks applied to admin/mutation endpoints — no endpoints changed
- [x] Docs updated for API/spec/status changes — no API/spec/user-facing change; commit message documents the release-pipeline behavior fix
- [x] Regression tests added for each bug fix — two new unit tests in the same file (run without native build)
- [x] Lint/typecheck/tests pass locally — `bun test scripts/native-embedding-runtime-smoke.test.ts` → 7 pass / 0 fail with the CI override form
