### PR TITLE
fix(inference): remove session synthesis routing

### DIFF
--- a/docs/ACP-INTEGRATION.md
+++ b/docs/ACP-INTEGRATION.md
@@ -91,18 +91,11 @@ inference:
       reasoning: medium
       toolsRequired: true
       privacy: restricted_remote
-    session_synthesis:
-      reasoning: medium
-      toolsRequired: true
-      privacy: restricted_remote
 
   workloads:
     memoryExtraction:
       target: background-acpx/default
       taskClass: memory_extraction
-    sessionSynthesis:
-      target: background-acpx/default
-      taskClass: session_synthesis
 ```
 
 When a routed workload uses that target, the daemon builds a command equivalent

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -445,9 +445,6 @@ inference:
     memoryExtraction:
       policy: auto
       taskClass: casual_chat
-    sessionSynthesis:
-      policy: auto
-      taskClass: casual_chat
 
   agents:
     rose:
@@ -549,9 +546,9 @@ inference:
           model: gpt-5.4-mini
           reasoning: medium
   workloads:
-    sessionSynthesis:
+    memoryExtraction:
       target: codex-cli/default
-      taskClass: session_synthesis
+      taskClass: memory_extraction
 ```
 
 Signet marks the target unavailable unless `codex --version` works and either `CODEX_HOME/auth.json`
@@ -613,7 +610,6 @@ Supported workload keys:
 
 - `interactive`
 - `memoryExtraction`
-- `sessionSynthesis`
 
 Each workload can define:
 
@@ -643,9 +639,10 @@ LLM-based fact extraction against incoming conversation text, then decides
 whether to write new memories, update existing ones, or skip. Config lives
 under `memory.pipelineV2` in `agent.yaml`.
 
-Inference selection for extraction and session synthesis can also be routed
-through the top-level `inference.workloads` bindings. When explicit routing is
-enabled for `default`, `memoryExtraction`, `sessionSynthesis`, `widgetGeneration`, or `repair`, those workloads use the
+Inference selection for extraction can be routed through the top-level
+`inference.workloads` bindings. Session processing follows the
+`memoryExtraction` route and is not independently configurable. When explicit routing is
+enabled for `default`, `memoryExtraction`, `widgetGeneration`, or `repair`, those workloads use the
 shared inference control plane. Legacy extraction and synthesis fields are treated as load-time compatibility input, not separate runtime providers.
 
 The config uses a nested structure with grouped sub-objects. Legacy flat
@@ -1374,7 +1371,7 @@ signet context compile --profile coding --max-chars 2200
 ```
 
 The compiler reads `AGENTS.md`, `USER.md`, `IDENTITY.md`, and `SOUL.md`,
-runs the configured inference `session_synthesis` route, hard-caps the
+runs the configured inference `memoryExtraction` route, hard-caps the
 result, and writes `context-profiles/coding/AGENTS.md`. Session-start
 hooks only read that artifact; they do not perform model synthesis at
 runtime.

--- a/docs/api/inference.md
+++ b/docs/api/inference.md
@@ -39,8 +39,7 @@ current runtime snapshot for each route target.
   "targetRefs": ["sonnet/default", "gpt/gpt54", "local/gemma4"],
   "workloadBindings": {
     "interactive": "auto",
-    "memoryExtraction": "memory-pipeline",
-    "sessionSynthesis": "memory-pipeline"
+    "memoryExtraction": "memory-pipeline"
   },
   "configIssues": [
     {

--- a/platform/core/src/routing.test.ts
+++ b/platform/core/src/routing.test.ts
@@ -666,7 +666,7 @@ describe("inference config + decision engine", () => {
 
 		expect(commandLegacy.targets["legacy-extraction"]).toBeUndefined();
 		expect(commandLegacy.workloads?.memoryExtraction).toBeUndefined();
-		expect(commandLegacy.targets["legacy-synthesis"]?.executor).toBe("ollama");
+		expect(commandLegacy.targets["legacy-synthesis"]).toBeUndefined();
 
 		const acpxLegacy = compileLegacyRoutingConfig({
 			extraction: {
@@ -686,7 +686,6 @@ describe("inference config + decision engine", () => {
 		expect(acpxLegacy.targets["legacy-extraction"]).toBeUndefined();
 		expect(acpxLegacy.targets["legacy-synthesis"]).toBeUndefined();
 		expect(acpxLegacy.workloads?.memoryExtraction).toBeUndefined();
-		expect(acpxLegacy.workloads?.sessionSynthesis).toBeUndefined();
 		expect(acpxLegacy.enabled).toBe(false);
 	});
 
@@ -711,13 +710,8 @@ describe("inference config + decision engine", () => {
 			providerFamily: "anthropic",
 			credentialRef: "ANTHROPIC_API_KEY",
 		});
-		expect(legacy.accounts["legacy-openrouter"]).toMatchObject({
-			kind: "api",
-			providerFamily: "openrouter",
-			credentialRef: "OPENROUTER_API_KEY",
-		});
 		expect(legacy.targets["legacy-extraction"]?.account).toBe("legacy-anthropic");
-		expect(legacy.targets["legacy-synthesis"]?.account).toBe("legacy-openrouter");
+		expect(legacy.targets["legacy-synthesis"]).toBeUndefined();
 
 		const compatible = compileLegacyRoutingConfig({
 			extraction: {
@@ -760,10 +754,7 @@ describe("inference config + decision engine", () => {
 		expect(localCompatible.targets["legacy-extraction"]?.kind).toBe("local");
 		expect(localCompatible.targets["legacy-extraction"]?.privacy).toBe("local_only");
 		expect(localCompatible.targets["legacy-extraction"]?.account).toBeUndefined();
-		expect(localCompatible.targets["legacy-synthesis"]?.executor).toBe("openai-compatible");
-		expect(localCompatible.targets["legacy-synthesis"]?.kind).toBe("local");
-		expect(localCompatible.targets["legacy-synthesis"]?.privacy).toBe("local_only");
-		expect(localCompatible.targets["legacy-synthesis"]?.account).toBeUndefined();
+		expect(localCompatible.targets["legacy-synthesis"]).toBeUndefined();
 	});
 
 	it("parses OpenRouter reasoning controls on explicit targets", () => {
@@ -885,6 +876,31 @@ describe("inference config + decision engine", () => {
 		}
 		expect(decision.error.code).toBe("no-candidates");
 	});
+});
+
+it("ignores obsolete sessionSynthesis bindings and routes internal session work through memoryExtraction", () => {
+	const parsed = parseRoutingConfig({
+		inference: {
+			targets: {
+				memory: { executor: "ollama", models: { default: { model: "qwen3:4b" } } },
+				legacy: { executor: "llama-cpp", models: { default: { model: "qwen3:4b" } } },
+			},
+			policies: { auto: { mode: "automatic", defaultTargets: ["memory/default"] } },
+			workloads: {
+				memoryExtraction: { target: "memory/default" },
+				sessionSynthesis: { target: "legacy/default" },
+			},
+			defaultPolicy: "auto",
+		},
+	});
+	expect(parsed.ok).toBe(true);
+	if (!parsed.ok) return;
+	expect("sessionSynthesis" in (parsed.value.workloads ?? {})).toBe(false);
+	const decision = resolveRoutingDecision(parsed.value, { operation: "session_synthesis" }, {
+		targets: { "memory/default": ready, "legacy/default": ready },
+	});
+	expect(decision.ok).toBe(true);
+	if (decision.ok) expect(decision.value.targetRef).toBe("memory/default");
 });
 
 describe("routing reference validation (#1005)", () => {
@@ -1046,7 +1062,7 @@ describe("routing reference validation (#1005)", () => {
 			workloads: {
 				...parsed.value.workloads!,
 				memoryExtraction: { target: "ghost-a/default" },
-				sessionSynthesis: { target: "ghost-b/default" },
+				aggregateRecall: { target: "ghost-b/default" },
 			},
 			defaultPolicy: "ghost-policy",
 		};

--- a/platform/core/src/routing.ts
+++ b/platform/core/src/routing.ts
@@ -207,7 +207,6 @@ export interface RoutingConfig {
 		readonly default?: RoutingWorkloadBinding;
 		readonly interactive?: RoutingWorkloadBinding;
 		readonly memoryExtraction?: RoutingWorkloadBinding;
-		readonly sessionSynthesis?: RoutingWorkloadBinding;
 		readonly aggregateRecall?: RoutingWorkloadBinding;
 		readonly widgetGeneration?: RoutingWorkloadBinding;
 		readonly repair?: RoutingWorkloadBinding;
@@ -717,7 +716,8 @@ export function compileLegacyRoutingConfig(opts: {
 		PipelineExtractionConfig,
 		"provider" | "model" | "endpoint" | "command" | "fallbackProvider"
 	>;
-	readonly synthesis: Pick<PipelineSynthesisConfig, "enabled" | "provider" | "model" | "endpoint">;
+	/** Accepted only for legacy callers; it never creates a route. */
+	readonly synthesis?: Pick<PipelineSynthesisConfig, "enabled" | "provider" | "model" | "endpoint">;
 }): RoutingConfig {
 	const accounts: Record<string, RoutingAccountConfig> = {};
 	const targets: Record<string, RoutingTargetConfig> = {};
@@ -732,15 +732,11 @@ export function compileLegacyRoutingConfig(opts: {
 		memory_extraction: {
 			reasoning: "medium",
 		},
-		session_synthesis: {
-			reasoning: "medium",
-		},
 	};
 	const workloads: {
 		default?: RoutingWorkloadBinding;
 		interactive?: RoutingWorkloadBinding;
 		memoryExtraction?: RoutingWorkloadBinding;
-		sessionSynthesis?: RoutingWorkloadBinding;
 		widgetGeneration?: RoutingWorkloadBinding;
 		repair?: RoutingWorkloadBinding;
 	} = {};
@@ -828,29 +824,6 @@ export function compileLegacyRoutingConfig(opts: {
 		}
 	}
 
-	if (opts.synthesis.enabled && opts.synthesis.provider !== "none" && opts.synthesis.provider !== "acpx") {
-		targets["legacy-synthesis"] = {
-			kind: inferLegacyTargetKind(opts.synthesis.provider, opts.synthesis.endpoint),
-			executor: opts.synthesis.provider,
-			account: legacyAccountForProvider(opts.synthesis.provider, opts.synthesis.endpoint),
-			endpoint: opts.synthesis.endpoint,
-			privacy: inferTargetPrivacy(opts.synthesis.provider, opts.synthesis.endpoint),
-			models: {
-				default: {
-					model: opts.synthesis.model,
-					label: opts.synthesis.model,
-					reasoning: "medium",
-				},
-			},
-		};
-		const ref = makeRoutingTargetRef("legacy-synthesis", "default");
-		workloads.sessionSynthesis = {
-			target: ref,
-			taskClass: "session_synthesis",
-		};
-		defaultTargets = [ref, ...defaultTargets];
-	}
-
 	policies["legacy-default"] = {
 		mode: "automatic",
 		defaultTargets,
@@ -866,7 +839,7 @@ export function compileLegacyRoutingConfig(opts: {
 	};
 	workloads.widgetGeneration = {
 		policy: "legacy-default",
-		taskClass: "session_synthesis",
+		taskClass: "memory_extraction",
 	};
 	workloads.repair = {
 		policy: "legacy-default",
@@ -1076,9 +1049,6 @@ export function parseRoutingConfig(raw: unknown, legacyConfig?: RoutingConfig): 
 		const memoryExtraction = parseWorkloadBinding(
 			routingRaw.workloads.memoryExtraction ?? routingRaw.workloads.memory_extraction,
 		);
-		const sessionSynthesis = parseWorkloadBinding(
-			routingRaw.workloads.sessionSynthesis ?? routingRaw.workloads.session_synthesis,
-		);
 		const aggregateRecall = parseWorkloadBinding(
 			routingRaw.workloads.aggregateRecall ?? routingRaw.workloads.aggregate_recall,
 		);
@@ -1089,7 +1059,6 @@ export function parseRoutingConfig(raw: unknown, legacyConfig?: RoutingConfig): 
 		if (defaultBinding) workloads.default = defaultBinding;
 		if (interactive) workloads.interactive = interactive;
 		if (memoryExtraction) workloads.memoryExtraction = memoryExtraction;
-		if (sessionSynthesis) workloads.sessionSynthesis = sessionSynthesis;
 		if (aggregateRecall) workloads.aggregateRecall = aggregateRecall;
 		if (widgetGeneration) workloads.widgetGeneration = widgetGeneration;
 		if (repair) workloads.repair = repair;
@@ -1139,11 +1108,11 @@ function workloadBindingForOperation(
 		case "memory_extraction":
 			return config.workloads?.memoryExtraction ?? config.workloads?.default;
 		case "session_synthesis":
-			return config.workloads?.sessionSynthesis ?? config.workloads?.default;
+			return config.workloads?.memoryExtraction ?? config.workloads?.default;
 		case "aggregate_recall":
-			return config.workloads?.aggregateRecall ?? config.workloads?.sessionSynthesis ?? config.workloads?.default;
+			return config.workloads?.aggregateRecall ?? config.workloads?.memoryExtraction ?? config.workloads?.default;
 		case "widget_generation":
-			return config.workloads?.widgetGeneration ?? config.workloads?.sessionSynthesis ?? config.workloads?.default;
+			return config.workloads?.widgetGeneration ?? config.workloads?.memoryExtraction ?? config.workloads?.default;
 		case "repair":
 			return config.workloads?.repair ?? config.workloads?.memoryExtraction ?? config.workloads?.default;
 	}

--- a/platform/daemon/src/config-migration.ts
+++ b/platform/daemon/src/config-migration.ts
@@ -311,21 +311,13 @@ export function migrateLegacyRoutingToRegistry(agentsDir: string): void {
 	function compileTarget(
 		source: ReturnType<typeof doc.getIn>,
 		targetName: string,
-		workloadKey: "memoryExtraction" | "sessionSynthesis",
+		workloadKey: "memoryExtraction",
 	): void {
 		if (!isMap(source)) return;
 		const provider = String(source.get("provider", true) ?? "");
 		const model = source.get("model", true);
 		const endpoint = source.get("endpoint", true);
 		if (!provider || provider === "none" || provider === "command") return;
-		// Read `enabled` as a real boolean (defaulting to true when absent, matching
-		// the runtime default). The raw YAML node's String() returns the source text
-		// (e.g. "false"), which would never short-circuit and silently re-enable a
-		// disabled synthesis — destructive for a migration that nulls routing keys.
-		const enabled = source.get("enabled");
-		if (workloadKey === "sessionSynthesis" && enabled === false) return;
-		if (workloadKey === "sessionSynthesis" && provider === "acpx") return;
-
 		// Create the account if the provider needs one.
 		const acct = legacyAccountFor(provider);
 		if (acct) {
@@ -358,7 +350,6 @@ export function migrateLegacyRoutingToRegistry(agentsDir: string): void {
 
 	if (hasNestedLegacyRouting) {
 		compileTarget(extraction, "legacy-extraction", "memoryExtraction");
-		compileTarget(synthesis, "legacy-synthesis", "sessionSynthesis");
 	}
 
 	// Null the legacy ROUTING keys (keep tuning: timeout, maxTokens, enabled).
@@ -405,5 +396,58 @@ export function migrateLegacyRoutingToRegistry(agentsDir: string): void {
 			file: path,
 			note: "Routing now flows through inference.*; pipelineV2 tuning fields (timeout, maxTokens, enabled) preserved.",
 		});
+	}
+}
+
+// ---------------------------------------------------------------------------
+// v6: remove the obsolete session-synthesis inference route
+// ---------------------------------------------------------------------------
+// Session processing is internal and follows memoryExtraction/default routing.
+// Older migrations created workloads.sessionSynthesis -> legacy-synthesis/default,
+// which permanently preserved an unavailable local target after upgrades.
+export function migrateSessionSynthesisRoute(agentsDir: string): void {
+	const path = findConfigPath(agentsDir);
+	if (!path) return;
+
+	let text: string;
+	try {
+		text = readFileSync(path, "utf-8");
+	} catch {
+		return;
+	}
+
+	const vMatch = /^configVersion:\s*(\d+)/m.exec(text);
+	if (vMatch && Number(vMatch[1]) >= 6) return;
+
+	const doc = parseDocument(text);
+	if (doc.errors.length > 0) {
+		logger.warn("config-migration", "Skipping session-route migration: agent.yaml has parse errors", {
+			file: path,
+			errors: doc.errors.map((error) => error.message).slice(0, 3),
+		});
+		return;
+	}
+
+	const mutations: string[] = [];
+	const workloads = doc.getIn(["inference", "workloads"], true);
+	if (isMap(workloads) && workloads.has("sessionSynthesis")) {
+		workloads.delete("sessionSynthesis");
+		mutations.push("removed inference.workloads.sessionSynthesis");
+	}
+	const targets = doc.getIn(["inference", "targets"], true);
+	if (isMap(targets) && targets.has("legacy-synthesis")) {
+		targets.delete("legacy-synthesis");
+		mutations.push("removed inference.targets.legacy-synthesis");
+	}
+	const taskClasses = doc.getIn(["inference", "taskClasses"], true);
+	if (isMap(taskClasses) && taskClasses.has("session_synthesis")) {
+		taskClasses.delete("session_synthesis");
+		mutations.push("removed inference.taskClasses.session_synthesis");
+	}
+
+	stampConfigVersion(doc, 6);
+	writeAtomic(path, doc.toString());
+	if (mutations.length > 0) {
+		logger.info("config-migration", "Removed obsolete session synthesis route", { mutations, file: path });
 	}
 }

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -36,7 +36,12 @@ import { resolveDaemonAgentId } from "./agent-id";
 import { yieldEvery } from "./async-yield";
 import { requirePermission } from "./auth";
 import { bindWithRetry } from "./bind-with-retry";
-import { migrateConfig, migrateInferenceProviders, migrateLegacyRoutingToRegistry } from "./config-migration";
+import {
+	migrateConfig,
+	migrateInferenceProviders,
+	migrateLegacyRoutingToRegistry,
+	migrateSessionSynthesisRoute,
+} from "./config-migration";
 import { listConnectors } from "./connectors/registry";
 import { clearAllPresence } from "./cross-agent";
 import { closeDbAccessor, getDbAccessor, getVectorRuntimeStatus, initDbAccessorAsync } from "./db-accessor";
@@ -1866,6 +1871,7 @@ async function main() {
 		migrateConfig(AGENTS_DIR);
 		migrateInferenceProviders(AGENTS_DIR);
 		migrateLegacyRoutingToRegistry(AGENTS_DIR);
+		migrateSessionSynthesisRoute(AGENTS_DIR);
 	} catch (err) {
 		logger.warn("config-migration", "Config migration failed; continuing startup", {
 			error: err instanceof Error ? err.message : String(err),

--- a/platform/daemon/src/inference-router.test.ts
+++ b/platform/daemon/src/inference-router.test.ts
@@ -135,7 +135,7 @@ describe("InferenceRouter legacy API credentials", () => {
 		}
 	});
 
-	it("uses OPENROUTER_API_KEY for legacy pipeline OpenRouter synthesis targets", async () => {
+	it("uses OPENROUTER_API_KEY for legacy pipeline OpenRouter extraction targets", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "signet-router-openrouter-"));
 		try {
 			mkdirSync(join(dir, "memory"), { recursive: true });
@@ -144,9 +144,6 @@ describe("InferenceRouter legacy API credentials", () => {
 				`memory:
   pipelineV2:
     extraction:
-      provider: none
-    synthesis:
-      enabled: true
       provider: openrouter
       model: openai/gpt-4o-mini
       endpoint: https://openrouter.ai/api/v1
@@ -179,7 +176,7 @@ describe("InferenceRouter legacy API credentials", () => {
 			expect(result.ok).toBe(true);
 			if (!result.ok) return;
 			expect(result.value.text).toBe("aggregate recall answer");
-			expect(result.value.decision.targetRef).toBe("legacy-synthesis/default");
+			expect(result.value.decision.targetRef).toBe("legacy-extraction/default");
 			expect(seen.every((entry) => entry.authorization === "Bearer test-openrouter-key")).toBe(true);
 			expect(seen.map((entry) => entry.url)).toContain("https://openrouter.ai/api/v1/models");
 			expect(seen.map((entry) => entry.url)).toContain("https://openrouter.ai/api/v1/chat/completions");
@@ -384,9 +381,9 @@ describe("InferenceRouter legacy API credentials", () => {
       defaultTargets:
         - mercury/default
   workloads:
-    sessionSynthesis:
+    memoryExtraction:
       target: mercury/default
-      taskClass: session_synthesis
+      taskClass: memory_extraction
 `,
 			);
 
@@ -466,9 +463,9 @@ describe("InferenceRouter legacy API credentials", () => {
       defaultTargets:
         - flash/default
   workloads:
-    sessionSynthesis:
+    memoryExtraction:
       target: flash/default
-      taskClass: session_synthesis
+      taskClass: memory_extraction
 `,
 			);
 
@@ -538,9 +535,9 @@ describe("InferenceRouter legacy API credentials", () => {
       defaultTargets:
         - med/default
   workloads:
-    sessionSynthesis:
+    memoryExtraction:
       target: med/default
-      taskClass: session_synthesis
+      taskClass: memory_extraction
 `,
 			);
 

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -130,7 +130,6 @@ export interface InferenceStatusSummary {
 		readonly default?: string;
 		readonly interactive?: string;
 		readonly memoryExtraction?: string;
-		readonly sessionSynthesis?: string;
 		readonly widgetGeneration?: string;
 		readonly repair?: string;
 	};
@@ -360,10 +359,7 @@ export class InferenceRouter {
 		let legacy: RoutingConfig;
 		try {
 			const memoryCfg = loadMemoryConfig(this.agentsDir);
-			legacy = compileLegacyRoutingConfig({
-				extraction: memoryCfg.pipelineV2.extraction,
-				synthesis: memoryCfg.pipelineV2.synthesis,
-			});
+			legacy = compileLegacyRoutingConfig({ extraction: memoryCfg.pipelineV2.extraction });
 		} catch (error) {
 			return {
 				ok: false,
@@ -567,11 +563,11 @@ export class InferenceRouter {
 			case "memory_extraction":
 				return Boolean(config.workloads?.memoryExtraction ?? config.workloads?.default ?? config.defaultPolicy);
 			case "session_synthesis":
-				return Boolean(config.workloads?.sessionSynthesis ?? config.workloads?.default ?? config.defaultPolicy);
+				return Boolean(config.workloads?.memoryExtraction ?? config.workloads?.default ?? config.defaultPolicy);
 			case "widget_generation":
 				return Boolean(
 					config.workloads?.widgetGeneration ??
-						config.workloads?.sessionSynthesis ??
+						config.workloads?.memoryExtraction ??
 						config.workloads?.default ??
 						config.defaultPolicy,
 				);
@@ -1193,9 +1189,6 @@ export class InferenceRouter {
 					memoryExtraction:
 						loaded.value.config.workloads?.memoryExtraction?.policy ??
 						loaded.value.config.workloads?.memoryExtraction?.target,
-					sessionSynthesis:
-						loaded.value.config.workloads?.sessionSynthesis?.policy ??
-						loaded.value.config.workloads?.sessionSynthesis?.target,
 					widgetGeneration:
 						loaded.value.config.workloads?.widgetGeneration?.policy ??
 						loaded.value.config.workloads?.widgetGeneration?.target,

--- a/platform/daemon/src/legacy-routing-migration.test.ts
+++ b/platform/daemon/src/legacy-routing-migration.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { migrateLegacyRoutingToRegistry } from "./config-migration";
+import { migrateLegacyRoutingToRegistry, migrateSessionSynthesisRoute } from "./config-migration";
 
 function setupDir(): string {
 	const dir = mkdtempSync(join(tmpdir(), "signet-legacy-routing-migration-"));
@@ -40,7 +40,6 @@ describe("migrateLegacyRoutingToRegistry (#947 v4, #1004 v5 cleanup)", () => {
 			expect(after).toMatch(/accounts:\s*\n\s+legacy-openrouter:/);
 			expect(after).toMatch(/providerFamily: openrouter/);
 			expect(after).toMatch(/credentialRef: OPENROUTER_API_KEY/);
-			expect(after).toMatch(/legacy-anthropic:/);
 
 			// Targets carry executor + model + account.
 			expect(after).toMatch(/legacy-extraction:/);
@@ -48,9 +47,10 @@ describe("migrateLegacyRoutingToRegistry (#947 v4, #1004 v5 cleanup)", () => {
 			expect(after).toMatch(/account: legacy-openrouter/);
 			expect(after).toMatch(/model: anthropic\/claude-haiku/);
 
-			// Workloads bound to the targets.
+			// Only extraction has a configurable workload; session processing follows it.
 			expect(after).toMatch(/memoryExtraction:\s*\n\s+target: legacy-extraction\/default/);
-			expect(after).toMatch(/sessionSynthesis:\s*\n\s+target: legacy-synthesis\/default/);
+			expect(after).not.toContain("sessionSynthesis");
+			expect(after).not.toContain("legacy-synthesis");
 
 			// Legacy ROUTING keys gone, tuning preserved.
 			expect(after).not.toMatch(/provider: openrouter/);
@@ -233,6 +233,50 @@ memory:
 		try {
 			writeFileSync(join(dir, "agent.yaml"), "memory:\n  [unterminated");
 			expect(() => migrateLegacyRoutingToRegistry(dir)).not.toThrow();
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("removes stale session synthesis routing in v6 and is idempotent", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`configVersion: 5
+inference:
+  targets:
+    legacy-synthesis:
+      executor: llama-cpp
+      models:
+        default:
+          model: qwen3:4b
+    aggregation:
+      executor: openrouter
+      models:
+        default:
+          model: deepseek/deepseek-v4-flash
+  workloads:
+    memoryExtraction:
+      target: background/default
+    sessionSynthesis:
+      target: legacy-synthesis/default
+    aggregateRecall:
+      target: aggregation/default
+  taskClasses:
+    session_synthesis:
+      reasoning: medium
+`,
+			);
+			migrateSessionSynthesisRoute(dir);
+			const after = readFileSync(join(dir, "agent.yaml"), "utf-8");
+			expect(after).toMatch(/^configVersion: 6/m);
+			expect(after).not.toContain("sessionSynthesis");
+			expect(after).not.toContain("legacy-synthesis");
+			expect(after).not.toContain("session_synthesis");
+			expect(after).toContain("target: aggregation/default");
+			migrateSessionSynthesisRoute(dir);
+			expect(readFileSync(join(dir, "agent.yaml"), "utf-8")).toBe(after);
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}

--- a/surfaces/cli/src/commands/route.ts
+++ b/surfaces/cli/src/commands/route.ts
@@ -29,7 +29,6 @@ interface RouteStatusResponse {
 	readonly workloadBindings: {
 		readonly interactive?: string;
 		readonly memoryExtraction?: string;
-		readonly sessionSynthesis?: string;
 	};
 	readonly accounts: Record<
 		string,
@@ -175,7 +174,7 @@ function printStatus(status: RouteStatusResponse): void {
 	console.log(chalk.dim(`  Task classes:   ${status.taskClasses.join(", ") || "-"}`));
 	console.log(
 		chalk.dim(
-			`  Workloads:      interactive=${status.workloadBindings.interactive ?? "-"}, extraction=${status.workloadBindings.memoryExtraction ?? "-"}, synthesis=${status.workloadBindings.sessionSynthesis ?? "-"}`,
+			`  Workloads:      interactive=${status.workloadBindings.interactive ?? "-"}, extraction=${status.workloadBindings.memoryExtraction ?? "-"}`,
 		),
 	);
 	console.log();

--- a/surfaces/cli/src/features/setup-pipeline.test.ts
+++ b/surfaces/cli/src/features/setup-pipeline.test.ts
@@ -190,7 +190,6 @@ describe("buildSetupInference", () => {
 				...buildSetupInference("acpx", "haiku", ["codex"], ["acpx"], "/usr/local/bin/bunx"),
 				taskClasses: {
 					memory_extraction: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
-					session_synthesis: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
 					custom_review: { reasoning: "high", toolsRequired: true, privacy: "local" },
 				},
 			},
@@ -211,11 +210,9 @@ describe("buildSetupInference", () => {
 				...buildSetupInference("acpx", "haiku", ["codex"], ["acpx"], "/usr/local/bin/bunx"),
 				workloads: {
 					memoryExtraction: { target: "background-acpx/default" },
-					sessionSynthesis: { target: "background-acpx/default" },
 				},
 				taskClasses: {
 					memory_extraction: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
-					session_synthesis: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
 					custom_review: { reasoning: "high", toolsRequired: true, privacy: "local" },
 				},
 			},

--- a/surfaces/cli/src/features/setup-pipeline.ts
+++ b/surfaces/cli/src/features/setup-pipeline.ts
@@ -175,11 +175,9 @@ export function buildSetupInference(
 		},
 		taskClasses: {
 			memory_extraction: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
-			session_synthesis: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
 		},
 		workloads: {
 			memoryExtraction: { target: targetRef, taskClass: "memory_extraction" },
-			sessionSynthesis: { target: targetRef, taskClass: "session_synthesis" },
 		},
 	};
 }
@@ -210,10 +208,6 @@ export function applySetupInferenceRoute(
 		generatedTaskClasses.add(getAcpxWorkloadTaskClass(route.workloads.memoryExtraction, "memory_extraction"));
 		Reflect.deleteProperty(route.workloads, "memoryExtraction");
 	}
-	if (route.workloads?.sessionSynthesis && isGeneratedAcpxWorkload(route.workloads.sessionSynthesis)) {
-		generatedTaskClasses.add(getAcpxWorkloadTaskClass(route.workloads.sessionSynthesis, "session_synthesis"));
-		Reflect.deleteProperty(route.workloads, "sessionSynthesis");
-	}
 	for (const taskClass of generatedTaskClasses) {
 		if (isGeneratedAcpxTaskClass(taskClass, route.taskClasses?.[taskClass])) {
 			Reflect.deleteProperty(route.taskClasses, taskClass);
@@ -234,7 +228,7 @@ function getAcpxWorkloadTaskClass(value: unknown, fallback: string): string {
 }
 
 function isGeneratedAcpxTaskClass(taskClass: string, value: unknown): boolean {
-	if (taskClass !== "memory_extraction" && taskClass !== "session_synthesis") return false;
+	if (taskClass !== "memory_extraction") return false;
 	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
 	const record = value as { reasoning?: unknown; toolsRequired?: unknown; privacy?: unknown };
 	return record.reasoning === "medium" && record.toolsRequired === true && record.privacy === "restricted_remote";

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
@@ -240,7 +240,6 @@ describe("pipeline-settings ACPX dashboard setup", () => {
 			},
 			workloads: {
 				memoryExtraction: { target: "background-acpx/default", taskClass: "memory_extraction" },
-				sessionSynthesis: { target: "background-acpx/default", taskClass: "session_synthesis" },
 			},
 		});
 	});

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
@@ -247,8 +247,6 @@ export function applyAcpxDashboardSetup(
 	};
 	const taskClasses = ensureRecord(inference, "taskClasses");
 	taskClasses.memory_extraction = { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" };
-	taskClasses.session_synthesis = { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" };
 	const workloads = ensureRecord(inference, "workloads");
 	workloads.memoryExtraction = { target: "background-acpx/default", taskClass: "memory_extraction" };
-	workloads.sessionSynthesis = { target: "background-acpx/default", taskClass: "session_synthesis" };
 }


### PR DESCRIPTION
## Summary
- remove the obsolete `sessionSynthesis` inference workload from setup, routing config, status output, and documentation
- add a v6 migration that removes stale `legacy-synthesis` targets and session-synthesis bindings from upgraded workspaces
- route internal session processing through `memoryExtraction`, while retaining `aggregateRecall` as its own workload

## Verification
- `bun test platform/core/src/routing.test.ts platform/daemon/src/legacy-routing-migration.test.ts platform/daemon/src/inference-router.test.ts surfaces/cli/src/features/setup-pipeline.test.ts surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts` (87 passing)
- `bun run --filter @signet/core build`
- Biome lint on touched code
- structured final review: no actionable findings
