### PR TITLE
feat(daemon): migrate embeddings without recall downtime

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -221,6 +221,14 @@ Increase the embedding timeout when local embedding models are slow to
 cold-load. For example, Ollama with `mxbai-embed-large` may need `10000` ms
 to avoid aborted explicit recall embeddings.
 
+Changing the embedding provider, model, dimensions, or base URL starts a
+background index migration. Existing semantic recall remains on the active
+index until Signet has re-embedded every active memory and source chunk with
+the new profile; only then is the new index promoted. Check
+`GET /api/embeddings/status` for the active/staging profile and migration
+coverage. If the daemon restarts, the incomplete staged build resumes; a
+failed build leaves the active index unchanged.
+
 Recommended Ollama models:
 
 | Model | Dimensions | Notes |

--- a/platform/core/src/migrations/091-embedding-index-generations.ts
+++ b/platform/core/src/migrations/091-embedding-index-generations.ts
@@ -1,0 +1,22 @@
+import type { MigrationDb } from "./index";
+
+/**
+ * Persist active/staging embedding generations separately from mutable config.
+ *
+ * The daemon creates the physical staging tables only after it can verify the
+ * vector extension is available. Keeping this migration extension-free makes
+ * upgrades safe on installs without sqlite-vec.
+ */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS embedding_index_state (
+			id INTEGER PRIMARY KEY CHECK (id = 1),
+			active_profile_json TEXT NOT NULL,
+			staging_profile_json TEXT,
+			state TEXT NOT NULL CHECK (state IN ('ready', 'building', 'failed')) DEFAULT 'ready',
+			last_error TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		)
+	`);
+}

--- a/platform/core/src/migrations/092-embedding-staging-store.ts
+++ b/platform/core/src/migrations/092-embedding-staging-store.ts
@@ -1,0 +1,26 @@
+import type { MigrationDb } from "./index";
+
+/**
+ * The inactive half of a rolling embedding migration. sqlite-vec's matching
+ * virtual table is created by the daemon only when its extension is loaded;
+ * keeping the durable BLOB store here makes migration safe everywhere else.
+ */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS embeddings_staging (
+			id TEXT PRIMARY KEY,
+			content_hash TEXT NOT NULL UNIQUE,
+			vector BLOB NOT NULL,
+			dimensions INTEGER NOT NULL,
+			source_type TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			chunk_text TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			agent_id TEXT
+		);
+		CREATE INDEX IF NOT EXISTS idx_embeddings_staging_source
+			ON embeddings_staging(source_type, source_id);
+		CREATE INDEX IF NOT EXISTS idx_embeddings_staging_agent_source
+			ON embeddings_staging(agent_id, source_type, source_id);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -96,6 +96,8 @@ import { up as summaryJobsBoundaryReason } from "./087-summary-jobs-boundary-rea
 import { up as transcriptRecoveryFiles } from "./088-transcript-recovery-files";
 import { up as jobCancellations } from "./089-job-cancellations";
 import { up as jobArchive } from "./090-job-archive";
+import { up as embeddingIndexGenerations } from "./091-embedding-index-generations";
+import { up as embeddingStagingStore } from "./092-embedding-staging-store";
 
 // -- Public interface consumed by Database.init() --
 
@@ -864,6 +866,18 @@ export const MIGRATIONS: readonly Migration[] = [
 		artifacts: {
 			tables: ["job_archive"],
 		},
+	},
+	{
+		version: 91,
+		name: "embedding-index-generations",
+		up: embeddingIndexGenerations,
+		artifacts: { tables: ["embedding_index_state"] },
+	},
+	{
+		version: 92,
+		name: "embedding-staging-store",
+		up: embeddingStagingStore,
+		artifacts: { tables: ["embeddings_staging"] },
 	},
 ];
 

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -3,6 +3,7 @@ import type { LlmUsage, RouteRequest, RouterResult } from "@signet/core";
 import { normalizeAndHashContent } from "./content-normalization";
 import { type WriteDb, getDbAccessor } from "./db-accessor";
 import { syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "./db-helpers";
+import { isActiveEmbeddingConfig, resolveActiveEmbeddingConfig } from "./embedding-index-state";
 import { logger } from "./logger";
 import type { EmbeddingConfig, ResolvedMemoryConfig } from "./memory-config";
 import {
@@ -627,9 +628,17 @@ async function embedAggregateMemory(
 	cfg: EmbeddingConfig,
 	embedFn: EmbedFn,
 ): Promise<boolean> {
-	const vec = await embedFn(content, cfg);
-	if (!vec || vec.length !== cfg.dimensions) return false;
-	getDbAccessor().withWriteTx((db) => {
+	// Aggregate saves can originate from hooks with the desired config while a
+	// new index is staging. They must stay in the active vector space until
+	// promotion; the staging worker independently copies every active row.
+	const activeCfg = getDbAccessor().withReadDb((db) => resolveActiveEmbeddingConfig(db, cfg));
+	const vec = await embedFn(content, activeCfg, "document");
+	if (!vec || vec.length !== activeCfg.dimensions) return false;
+	const written = getDbAccessor().withWriteTx((db) => {
+		// Promotion can commit while the provider call above is in flight. Do
+		// not contaminate the new generation with an old-space vector; the
+		// normal tracker will enqueue this memory against the new active model.
+		if (!isActiveEmbeddingConfig(db, activeCfg)) return false;
 		const embId = randomUUID();
 		syncVecDeleteBySourceId(db, "memory", memoryId);
 		db.prepare("DELETE FROM embeddings WHERE source_type = 'memory' AND source_id = ?").run(memoryId);
@@ -639,9 +648,10 @@ async function embedAggregateMemory(
 			VALUES (?, ?, ?, ?, 'memory', ?, ?, ?)
 		`).run(embId, contentHash, vectorToBlob(vec), vec.length, memoryId, content, createdAt);
 		syncVecInsert(db, embId, vec);
-		db.prepare("UPDATE memories SET embedding_model = ? WHERE id = ?").run(cfg.model, memoryId);
+		db.prepare("UPDATE memories SET embedding_model = ? WHERE id = ?").run(activeCfg.model, memoryId);
+		return true;
 	});
-	return true;
+	return written;
 }
 
 function unsavedAggregateResult(content: string, key: string, project: string | null): RecallResult {

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -802,7 +802,8 @@ export async function aggregateRecall(
 		recall(aggregateRecallParams, cfg, deps.embedFn),
 	);
 
-	if (!deps.router) {
+	const router = deps.router;
+	if (!router) {
 		const firstEvidence = uniqueEvidence(first.results);
 		const sourceMemoryIds = linkableSourceMemoryIds(firstEvidence);
 		if (firstEvidence.length > 0) {
@@ -823,7 +824,7 @@ export async function aggregateRecall(
 
 	const planned = await timings.timeAsync("aggregate_planning", () =>
 		planQueries({
-			router: deps.router,
+			router,
 			params,
 			budget,
 			maxQueries,
@@ -863,9 +864,7 @@ export async function aggregateRecall(
 		return finish(emptyAggregateResponse(params, budget, queries, [], "no_evidence"));
 	}
 
-	const synthesized = await timings.timeAsync("aggregate_synthesis", () =>
-		synthesize({ router: deps.router, params, evidence }),
-	);
+	const synthesized = await timings.timeAsync("aggregate_synthesis", () => synthesize({ router, params, evidence }));
 	if (synthesized.usage) usageStages.push(synthesized.usage);
 	const answer = synthesized.answer;
 	if (!answer) {
@@ -962,18 +961,19 @@ export async function aggregateRecall(
 			}),
 		);
 		if (row && !deduped) {
+			const savedRow = row;
 			let embedded = false;
 			let embeddingError: unknown;
 			try {
 				embedded = await timings.timeAsync("aggregate_embedding", () =>
-					embedAggregateMemory(row.id, row.content, normalized.contentHash, now, cfg.embedding, deps.embedFn),
+					embedAggregateMemory(savedRow.id, savedRow.content, normalized.contentHash, now, cfg.embedding, deps.embedFn),
 				);
 			} catch (err) {
 				embeddingError = err;
 			}
 			if (!embedded) {
 				log.warn("memory", "Aggregate recall memory saved without embedding", {
-					memoryId: row.id,
+					memoryId: savedRow.id,
 					agentId,
 					project,
 					sourceId: key,

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -46,6 +46,8 @@ import { listConnectors } from "./connectors/registry";
 import { clearAllPresence } from "./cross-agent";
 import { closeDbAccessor, getDbAccessor, getVectorRuntimeStatus, initDbAccessorAsync } from "./db-accessor";
 import { fetchEmbedding } from "./embedding-fetch";
+import { resolveActiveEmbeddingConfig } from "./embedding-index-state";
+import { type EmbeddingIndexMigrationHandle, startEmbeddingIndexMigration } from "./embedding-index-migration";
 import { type EmbeddingTrackerHandle, startEmbeddingTracker } from "./embedding-tracker";
 import { firstCandidateBlockedBy } from "./extraction-status";
 import { initFeatureFlags } from "./feature-flags";
@@ -188,6 +190,7 @@ let httpServer: import("node:net").Server | null = null;
 let dreamingWorkerHandle: DreamingWorkerHandle | null = null;
 let shadowProcess: ChildProcess | null = null;
 let embeddingTrackerHandle: EmbeddingTrackerHandle | null = null;
+let embeddingIndexMigrationHandle: EmbeddingIndexMigrationHandle | null = null;
 let skillReconcilerHandle: ReturnType<typeof startReconciler> | null = null;
 let schedulerHandle: { stop(): Promise<void> } | null = null;
 let transcriptCaptureWorkerHandle: TranscriptCaptureWorkerHandle | null = null;
@@ -1204,6 +1207,12 @@ async function stopPipelineRuntime(): Promise<void> {
 		embeddingTrackerHandle = null;
 		setEmbeddingTrackerHandle(null);
 	}
+	if (embeddingIndexMigrationHandle) {
+		try {
+			await embeddingIndexMigrationHandle.stop();
+		} catch {}
+		embeddingIndexMigrationHandle = null;
+	}
 	if (sharedEmbeddingTrackerHandle) {
 		try {
 			await sharedEmbeddingTrackerHandle.stop();
@@ -1314,6 +1323,7 @@ function syncAgentRoster(agentsDir: string): void {
 
 async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?: TelemetryCollector): Promise<void> {
 	const pipelinePaused = memoryCfg.pipelineV2.paused;
+	const activeEmbeddingCfg = getDbAccessor().withReadDb((db) => resolveActiveEmbeddingConfig(db, memoryCfg.embedding));
 	configureLlmConcurrency(memoryCfg.pipelineV2.worker.maxLlmConcurrency);
 	clearStructuralBackfillTimer();
 	if (shouldWarnGraphExtractionWritesDisabled(memoryCfg)) {
@@ -1508,11 +1518,11 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 					agentsDir: AGENTS_DIR,
 					agentId: defaultAgentId,
 					embeddingConfig: {
-						provider: memoryCfg.embedding.provider,
-						model: memoryCfg.embedding.model,
-						dimensions: memoryCfg.embedding.dimensions ?? 768,
-						base_url: memoryCfg.embedding.base_url,
-						api_key: memoryCfg.embedding.api_key,
+						provider: activeEmbeddingCfg.provider,
+						model: activeEmbeddingCfg.model,
+						dimensions: activeEmbeddingCfg.dimensions ?? 768,
+						base_url: activeEmbeddingCfg.base_url,
+						api_key: activeEmbeddingCfg.api_key,
 					},
 					pipelineConfig: memoryCfg.pipelineV2 as unknown as Record<string, unknown>,
 					searchConfig: memoryCfg.search as unknown as Record<string, unknown>,
@@ -1529,7 +1539,7 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 		startPipeline(
 			getDbAccessor(),
 			memoryCfg.pipelineV2,
-			memoryCfg.embedding,
+			activeEmbeddingCfg,
 			fetchEmbedding,
 			memoryCfg.search,
 			defaultAgentId,
@@ -1554,15 +1564,36 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 		ensureRetentionWorker(getDbAccessor(), DEFAULT_RETENTION);
 	}
 
-	if (memoryCfg.embedding.provider !== "none" && memoryCfg.pipelineV2.embeddingTracker.enabled && !pipelinePaused) {
+	if (activeEmbeddingCfg.provider !== "none" && memoryCfg.pipelineV2.embeddingTracker.enabled && !pipelinePaused) {
 		embeddingTrackerHandle = startEmbeddingTracker(
 			getDbAccessor(),
-			memoryCfg.embedding,
+			activeEmbeddingCfg,
 			memoryCfg.pipelineV2.embeddingTracker,
 			fetchEmbedding,
 			checkEmbeddingProvider,
 		);
 		setEmbeddingTrackerHandle(embeddingTrackerHandle);
+	}
+
+	if (!pipelinePaused) {
+		embeddingIndexMigrationHandle = startEmbeddingIndexMigration({
+			accessor: getDbAccessor(),
+			configured: memoryCfg.embedding,
+			fetchEmbedding,
+			checkProvider: checkEmbeddingProvider,
+			pollMs: memoryCfg.pipelineV2.embeddingTracker.pollMs,
+			batchSize: memoryCfg.pipelineV2.embeddingTracker.batchSize,
+			onPromoted: () => {
+				// The tracker and extraction worker hold their embedding config at
+				// construction time. Recreate them only after the new generation is
+				// committed, never while the active slot is still serving recall.
+				void restartPipelineRuntime(loadMemoryConfig(AGENTS_DIR), telemetry).catch((error) => {
+					logger.error("embedding", "Promoted index but could not restart embedding workers", undefined, {
+						error: error instanceof Error ? error.message : String(error),
+					});
+				});
+			},
+		});
 	}
 
 	if (memoryCfg.dreaming.enabled && !pipelinePaused && !memoryCfg.pipelineV2.mutationsFrozen) {

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -31,6 +31,7 @@ import {
 	runMigrations,
 } from "@signet/core";
 import { loadMemoryConfig } from "./memory-config";
+import { ensureEmbeddingIndexState } from "./embedding-index-state";
 
 const isBun = typeof (globalThis as Record<string, unknown>).Bun !== "undefined";
 const require = createRequire(import.meta.url);
@@ -716,11 +717,20 @@ function finishDbAccessorInit(writeConn: SqliteDatabase, opts?: { readonly agent
 	// Ensure FTS5 virtual table exists — may be missing on upgrades from
 	// older installs where the table was dropped or never created.
 	ensureFtsTable(writeConn);
+	const configuredEmbedding = loadMemoryConfig(opts?.agentsDir ?? resolveSqliteAgentsDir()).embedding;
+	const legacyVecSql = writeConn.prepare("SELECT sql FROM sqlite_master WHERE name = 'vec_embeddings' AND type = 'table'").get() as
+		| { sql?: string }
+		| undefined;
+	const legacyDimensions = readVecEmbeddingDimensions(legacyVecSql?.sql);
+	const embeddingIndexState = ensureEmbeddingIndexState(
+		writeConn,
+		legacyDimensions === null ? configuredEmbedding : { ...configuredEmbedding, dimensions: legacyDimensions },
+	);
 
 	// Ensure vec_embeddings virtual table exists with the configured dimensions.
 	// Older tables may lack the TEXT id column or carry stale FLOAT[N] dims.
 	if (vecExtPath) {
-		const vecDimensions = resolveVecEmbeddingDimensions(opts?.agentsDir);
+		const vecDimensions = embeddingIndexState.active.dimensions;
 		try {
 			ensureVecTable(writeConn, vecDimensions);
 		} catch (err) {

--- a/platform/daemon/src/embedding-fetch.test.ts
+++ b/platform/daemon/src/embedding-fetch.test.ts
@@ -56,6 +56,28 @@ describe("fetchEmbedding", () => {
 		});
 	});
 
+	it("uses the query formatter when role is passed before request options", async () => {
+		let capturedInput = "";
+		globalThis.fetch = mock((_url: string | URL | Request, init?: RequestInit) => {
+			capturedInput = (JSON.parse(String(init?.body)) as { input: string }).input;
+			return Promise.resolve(Response.json({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
+		}) as unknown as typeof fetch;
+
+		await fetchEmbedding(
+			"where is my note?",
+			{
+				provider: "openai",
+				model: "nomic-embed-text-v1.5",
+				dimensions: 3,
+				base_url: "http://localhost:1234/v1",
+				profile: "nomic-embed-text-v1.5",
+			},
+			"query",
+		);
+
+		expect(capturedInput).toBe("search_query: where is my note?");
+	});
+
 	it("composes caller abort signals with provider timeouts", async () => {
 		const controller = new AbortController();
 		let capturedSignal: AbortSignal | null | undefined;

--- a/platform/daemon/src/embedding-fetch.ts
+++ b/platform/daemon/src/embedding-fetch.ts
@@ -1,4 +1,7 @@
 import { logger } from "./logger";
+import { getDbAccessor, hasDbAccessor } from "./db-accessor";
+import { resolveActiveEmbeddingConfig } from "./embedding-index-state";
+import { formatEmbeddingInput, type EmbeddingRole } from "./embedding-profile";
 import type { EmbeddingConfig } from "./memory-config";
 import {
 	DEFAULT_LLAMACPP_BASE_URL,
@@ -313,42 +316,74 @@ export async function resolveEmbeddingApiKey(rawApiKey: string | undefined): Pro
 	return configured || process.env.OPENAI_API_KEY || "";
 }
 
+export function fetchEmbedding(
+	text: string,
+	cfg: EmbeddingConfig,
+	role?: EmbeddingRole,
+	opts?: EmbeddingFetchOptions,
+): Promise<number[] | null>;
+/** @deprecated Pass the role before options. Kept for callers using the former options position. */
+export function fetchEmbedding(
+	text: string,
+	cfg: EmbeddingConfig,
+	opts?: EmbeddingFetchOptions,
+	role?: EmbeddingRole,
+): Promise<number[] | null>;
 export async function fetchEmbedding(
 	text: string,
 	cfg: EmbeddingConfig,
-	opts: EmbeddingFetchOptions = {},
+	roleOrOpts: EmbeddingRole | EmbeddingFetchOptions = "document",
+	optsOrRole: EmbeddingFetchOptions | EmbeddingRole = {},
 ): Promise<number[] | null> {
-	if (cfg.provider === "none") return null;
+	// Ordinary callers always resolve the generation at request time. This
+	// prevents an in-flight writer that captured yesterday's active config from
+	// inserting old-space vectors after an atomic promotion. Only the isolated
+	// migration worker is allowed to address its staging generation directly.
+	const effectiveCfg =
+		cfg.indexGeneration === "staging" || !hasDbAccessor()
+			? cfg
+			: getDbAccessor().withReadDb((db) => resolveActiveEmbeddingConfig(db, cfg));
+	if (effectiveCfg.provider === "none") return null;
+	const role = typeof roleOrOpts === "string" ? roleOrOpts : typeof optsOrRole === "string" ? optsOrRole : "document";
+	const opts = typeof roleOrOpts === "string" ? (typeof optsOrRole === "string" ? {} : optsOrRole) : roleOrOpts;
+	const formattedText = formatEmbeddingInput(text, effectiveCfg, role);
 	try {
-		if (cfg.provider === "native") {
+		if (effectiveCfg.provider === "native") {
 			if (nativeFallbackProvider === "unavailable") return null;
-			if (nativeFallbackProvider) return fetchNativeFallback(nativeFallbackProvider, text, cfg, opts);
+			if (nativeFallbackProvider) return fetchNativeFallback(nativeFallbackProvider, formattedText, effectiveCfg, opts);
 			try {
 				if (!cachedNativeEmbed) {
 					const mod = await import("./native-embedding");
 					cachedNativeEmbed = mod.nativeEmbed;
 				}
-				return await cachedNativeEmbed(text);
+				return await cachedNativeEmbed(formattedText);
 			} catch (nativeErr) {
 				return resolveNativeFallback(
-					text,
-					cfg,
+					formattedText,
+					effectiveCfg,
 					opts,
 					nativeErr instanceof Error ? nativeErr.message : String(nativeErr),
 				);
 			}
 		}
-		if (cfg.provider === "ollama") {
-			return await fetchOllamaEmbedding(text, cfg.base_url, cfg.model, opts);
+		if (effectiveCfg.provider === "ollama") {
+			return await fetchOllamaEmbedding(formattedText, effectiveCfg.base_url, effectiveCfg.model, opts);
 		}
 
-		if (cfg.provider === "llama-cpp") {
-			const baseUrl = cfg.base_url.trim() || DEFAULT_LLAMACPP_BASE_URL;
-			return fetchLlamaCppEmbedding(text, baseUrl, cfg.model, opts, 30000, cfg.llamaCppMaxInputTokens);
+		if (effectiveCfg.provider === "llama-cpp") {
+			const baseUrl = effectiveCfg.base_url.trim() || DEFAULT_LLAMACPP_BASE_URL;
+			return fetchLlamaCppEmbedding(
+				formattedText,
+				baseUrl,
+				effectiveCfg.model,
+				opts,
+				30000,
+				effectiveCfg.llamaCppMaxInputTokens,
+			);
 		}
 
-		const apiKey = await resolveEmbeddingApiKey(cfg.api_key);
-		const baseUrl = resolveEmbeddingBaseUrl(cfg);
+		const apiKey = await resolveEmbeddingApiKey(effectiveCfg.api_key);
+		const baseUrl = resolveEmbeddingBaseUrl(effectiveCfg);
 		if (!apiKey && requiresOpenAiApiKey(baseUrl)) {
 			logger.warn("embedding", "No API key configured for OpenAI embeddings, skipping request to api.openai.com");
 			return null;
@@ -361,7 +396,7 @@ export async function fetchEmbedding(
 					"Content-Type": "application/json",
 					...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
 				},
-				body: JSON.stringify({ model: cfg.model, input: text }),
+				body: JSON.stringify({ model: effectiveCfg.model, input: formattedText }),
 			},
 			opts,
 			resolveEmbeddingTimeoutMs(opts, 30000),
@@ -369,8 +404,8 @@ export async function fetchEmbedding(
 		if (!res.ok) {
 			logger.warn("embedding", "Embedding API request failed", {
 				status: res.status,
-				provider: cfg.provider,
-				model: cfg.model,
+				provider: effectiveCfg.provider,
+				model: effectiveCfg.model,
 			});
 			return null;
 		}
@@ -380,8 +415,8 @@ export async function fetchEmbedding(
 		return data.data?.[0]?.embedding ?? null;
 	} catch (e) {
 		logger.warn("embedding", "Embedding fetch error", {
-			provider: cfg.provider,
-			model: cfg.model,
+			provider: effectiveCfg.provider,
+			model: effectiveCfg.model,
 			error: e instanceof Error ? e.message : String(e),
 		});
 		return null;

--- a/platform/daemon/src/embedding-index-migration.test.ts
+++ b/platform/daemon/src/embedding-index-migration.test.ts
@@ -1,0 +1,261 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it } from "bun:test";
+import { findSqliteVecExtension } from "@signet/core";
+import {
+	promoteStagingIndex,
+	stageEmbeddingBatch,
+	stagingCoverage,
+	startEmbeddingIndexMigration,
+} from "./embedding-index-migration";
+import { beginEmbeddingIndexBuild, ensureEmbeddingIndexState } from "./embedding-index-state";
+import { up as embeddingIndexGenerations } from "../../core/src/migrations/091-embedding-index-generations";
+import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
+
+const VEC_EXTENSION = findSqliteVecExtension();
+
+describe("staging embedding coverage", () => {
+	it("requires every active row, including source chunks, at the staged dimensions", () => {
+		const raw = new Database(":memory:");
+		raw.exec(`
+			CREATE TABLE memories (id TEXT PRIMARY KEY, embedding_model TEXT);
+			CREATE TABLE embeddings (id TEXT, content_hash TEXT, dimensions INTEGER, created_at TEXT);
+			CREATE TABLE embeddings_staging (id TEXT, content_hash TEXT, dimensions INTEGER);
+			INSERT INTO embeddings VALUES ('m1', 'memory-hash', 768, '2026-01-01');
+			INSERT INTO embeddings VALUES ('s1', 'source-hash', 768, '2026-01-02');
+			INSERT INTO embeddings_staging VALUES ('m2', 'memory-hash', 1024);
+		`);
+		const db = raw as unknown as ReadDb;
+		expect(stagingCoverage(db, 1024)).toEqual({ active: 2, staged: 1, missing: 1, wrongDimensions: 0, ready: false });
+
+		raw.exec("INSERT INTO embeddings_staging VALUES ('s2', 'source-hash', 768)");
+		expect(stagingCoverage(db, 1024)).toEqual({ active: 2, staged: 2, missing: 0, wrongDimensions: 1, ready: false });
+
+		raw.exec("UPDATE embeddings_staging SET dimensions = 1024 WHERE id = 's2'");
+		expect(stagingCoverage(db, 1024)).toEqual({ active: 2, staged: 2, missing: 0, wrongDimensions: 0, ready: true });
+	});
+
+	it("prunes obsolete staged rows while active writes and purges continue", async () => {
+		const raw = new Database(":memory:");
+		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);
+		raw.exec(`
+			CREATE TABLE embeddings (
+				id TEXT PRIMARY KEY, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER,
+				source_type TEXT, source_id TEXT, chunk_text TEXT, created_at TEXT, agent_id TEXT
+			);
+			CREATE TABLE embeddings_staging (
+				id TEXT PRIMARY KEY, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER,
+				source_type TEXT, source_id TEXT, chunk_text TEXT, created_at TEXT, agent_id TEXT
+			);
+			CREATE TABLE vec_embeddings_staging (id TEXT PRIMARY KEY, embedding BLOB);
+			INSERT INTO embeddings VALUES
+				('memory-embedding', 'memory-hash', X'00', 768, 'memory', 'memory-1', 'memory text', '2026-01-01', 'agent-a'),
+				('source-embedding', 'source-hash', X'00', 768, 'source_chunk', 'chunk-1', 'source text', '2026-01-01', 'agent-a');
+		`);
+		const db = raw as unknown as WriteDb;
+		const config = {
+			provider: "ollama",
+			model: "nomic-embed-text",
+			dimensions: 768,
+			base_url: "http://127.0.0.1:11434",
+		} as const;
+		ensureEmbeddingIndexState(db, config);
+		beginEmbeddingIndexBuild(db, { ...config, model: "qwen3-embedding:0.6b", dimensions: 4 });
+		const accessor: DbAccessor = {
+			withWriteTx: (fn) => fn(db),
+			withReadDb: (fn) => fn(raw as unknown as ReadDb),
+			close: () => undefined,
+		};
+
+		const first = await stageEmbeddingBatch({
+			accessor,
+			configured: { ...config, model: "qwen3-embedding:0.6b", dimensions: 4 },
+			fetchEmbedding: async (text) => [text.length, 0, 0, 1],
+			batchSize: 10,
+		});
+		expect(first.coverage).toEqual({ active: 2, staged: 2, missing: 0, wrongDimensions: 0, ready: true });
+		expect(raw.prepare("SELECT COUNT(*) AS count FROM vec_embeddings_staging").get()).toEqual({ count: 2 });
+
+		// A source purge during an asynchronous build must not strand an orphan
+		// in staging and indefinitely block the count-based promotion gate.
+		raw.exec("DELETE FROM embeddings WHERE id = 'source-embedding'");
+		const second = await stageEmbeddingBatch({
+			accessor,
+			configured: { ...config, model: "qwen3-embedding:0.6b", dimensions: 4 },
+			fetchEmbedding: async () => [0, 0, 0, 0],
+			batchSize: 10,
+		});
+		expect(second.coverage).toEqual({ active: 1, staged: 1, missing: 0, wrongDimensions: 0, ready: true });
+		expect(raw.prepare("SELECT id FROM vec_embeddings_staging").all()).toHaveLength(1);
+	});
+
+	it("fails closed when the target provider returns the wrong vector dimension", async () => {
+		const raw = new Database(":memory:");
+		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);
+		raw.exec(`
+			CREATE TABLE embeddings (id TEXT PRIMARY KEY, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER, source_type TEXT, source_id TEXT, chunk_text TEXT, created_at TEXT, agent_id TEXT);
+			CREATE TABLE embeddings_staging (id TEXT PRIMARY KEY, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER, source_type TEXT, source_id TEXT, chunk_text TEXT, created_at TEXT, agent_id TEXT);
+			CREATE TABLE vec_embeddings_staging (id TEXT PRIMARY KEY, embedding BLOB);
+			INSERT INTO embeddings VALUES ('memory-embedding', 'memory-hash', X'00', 768, 'memory', 'memory-1', 'memory text', '2026-01-01', NULL);
+		`);
+		const db = raw as unknown as WriteDb;
+		const config = {
+			provider: "ollama",
+			model: "nomic-embed-text",
+			dimensions: 768,
+			base_url: "http://127.0.0.1:11434",
+		} as const;
+		ensureEmbeddingIndexState(db, config);
+		beginEmbeddingIndexBuild(db, { ...config, model: "qwen3-embedding:0.6b", dimensions: 4 });
+		const accessor: DbAccessor = {
+			withWriteTx: (fn) => fn(db),
+			withReadDb: (fn) => fn(raw as unknown as ReadDb),
+			close: () => undefined,
+		};
+
+		await expect(
+			stageEmbeddingBatch({
+				accessor,
+				configured: { ...config, model: "qwen3-embedding:0.6b", dimensions: 4 },
+				fetchEmbedding: async () => [1, 2, 3],
+				batchSize: 10,
+			}),
+		).rejects.toThrow("expected 4");
+		expect(stagingCoverage(raw as unknown as ReadDb, 4).ready).toBe(false);
+	});
+});
+
+describe("staging promotion", () => {
+	it("swaps full index slots while retaining the previous active slot", () => {
+		const raw = new Database(":memory:");
+		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);
+		raw.exec(`
+				CREATE TABLE memories (id TEXT PRIMARY KEY, embedding_model TEXT);
+				CREATE TABLE embeddings (id TEXT, content_hash TEXT, dimensions INTEGER, source_type TEXT, source_id TEXT, created_at TEXT);
+			CREATE TABLE embeddings_staging (id TEXT, content_hash TEXT UNIQUE, dimensions INTEGER, source_type TEXT, source_id TEXT, created_at TEXT);
+			CREATE TABLE vec_embeddings (id TEXT, embedding BLOB);
+			CREATE TABLE vec_embeddings_staging (id TEXT, embedding BLOB);
+			`);
+		const db = raw as unknown as WriteDb;
+		const config = {
+			provider: "ollama",
+			model: "nomic-embed-text",
+			dimensions: 768,
+			base_url: "http://127.0.0.1:11434",
+		} as const;
+		ensureEmbeddingIndexState(db, config);
+		beginEmbeddingIndexBuild(db, { ...config, model: "qwen3-embedding:0.6b", dimensions: 1024 });
+		raw.exec(`
+				INSERT INTO memories VALUES ('memory-1', 'nomic-embed-text');
+			INSERT INTO embeddings VALUES ('old', 'content', 768, 'memory', 'memory-1', '2026-01-01');
+			INSERT INTO embeddings_staging VALUES ('new', 'content', 1024, 'memory', 'memory-1', '2026-01-01');
+			INSERT INTO vec_embeddings VALUES ('old', X'00');
+			INSERT INTO vec_embeddings_staging VALUES ('new', X'01');
+		`);
+		const accessor: DbAccessor = {
+			withWriteTx: (fn) => fn(db),
+			withReadDb: (fn) => fn(raw as unknown as ReadDb),
+			close: () => undefined,
+		};
+
+		expect(promoteStagingIndex(accessor)).toBe(true);
+		expect(raw.prepare("SELECT id, dimensions FROM embeddings").get()).toEqual({ id: "new", dimensions: 1024 });
+		expect(raw.prepare("SELECT id, dimensions FROM embeddings_staging").get()).toEqual({ id: "old", dimensions: 768 });
+		expect(raw.prepare("SELECT id FROM vec_embeddings").get()).toEqual({ id: "new" });
+		expect(raw.prepare("SELECT id FROM vec_embeddings_staging").get()).toEqual({ id: "old" });
+	});
+
+	it("keeps the promoted sqlite-vec virtual table queryable", () => {
+		if (!VEC_EXTENSION) return;
+		const raw = new Database(":memory:");
+		raw.loadExtension(VEC_EXTENSION);
+		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);
+		raw.exec(`
+			CREATE TABLE memories (id TEXT PRIMARY KEY, embedding_model TEXT);
+			CREATE TABLE embeddings (id TEXT, content_hash TEXT, vector BLOB, dimensions INTEGER, source_type TEXT, source_id TEXT, created_at TEXT);
+			CREATE TABLE embeddings_staging (id TEXT, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER, source_type TEXT, source_id TEXT, created_at TEXT);
+			CREATE VIRTUAL TABLE vec_embeddings USING vec0(id TEXT PRIMARY KEY, embedding FLOAT[3] distance_metric=cosine);
+			CREATE VIRTUAL TABLE vec_embeddings_staging USING vec0(id TEXT PRIMARY KEY, embedding FLOAT[3] distance_metric=cosine);
+		`);
+		const db = raw as unknown as WriteDb;
+		const config = {
+			provider: "ollama",
+			model: "nomic-embed-text",
+			dimensions: 3,
+			base_url: "http://127.0.0.1:11434",
+		} as const;
+		ensureEmbeddingIndexState(db, config);
+		beginEmbeddingIndexBuild(db, { ...config, model: "qwen3-embedding:0.6b" });
+		raw.exec(`
+			INSERT INTO memories VALUES ('memory-1', 'nomic-embed-text');
+			INSERT INTO embeddings VALUES ('old', 'content', X'0000803F0000000000000000', 3, 'memory', 'memory-1', '2026-01-01');
+			INSERT INTO embeddings_staging VALUES ('new', 'content', X'000000000000803F00000000', 3, 'memory', 'memory-1', '2026-01-01');
+		`);
+		raw.prepare("INSERT INTO vec_embeddings (id, embedding) VALUES (?, ?)").run("old", new Float32Array([1, 0, 0]));
+		raw
+			.prepare("INSERT INTO vec_embeddings_staging (id, embedding) VALUES (?, ?)")
+			.run("new", new Float32Array([0, 1, 0]));
+		const accessor: DbAccessor = {
+			withWriteTx: (fn) => {
+				raw.exec("BEGIN IMMEDIATE");
+				try {
+					const result = fn(db);
+					raw.exec("COMMIT");
+					return result;
+				} catch (error) {
+					raw.exec("ROLLBACK");
+					throw error;
+				}
+			},
+			withReadDb: (fn) => fn(raw as unknown as ReadDb),
+			close: () => undefined,
+		};
+
+		expect(promoteStagingIndex(accessor)).toBe(true);
+		const nearest = raw
+			.prepare("SELECT id FROM vec_embeddings WHERE embedding MATCH ? AND k = 1")
+			.get(new Float32Array([0, 1, 0]));
+		expect(nearest).toEqual({ id: "new" });
+	});
+});
+
+describe("staging migration lifecycle", () => {
+	it("resumes an interrupted build without clearing its inactive vector slot", async () => {
+		const raw = new Database(":memory:");
+		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);
+		raw.exec(`
+			CREATE TABLE embeddings (id TEXT, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER, source_type TEXT, source_id TEXT, chunk_text TEXT, created_at TEXT, agent_id TEXT);
+			CREATE TABLE embeddings_staging (id TEXT, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER, source_type TEXT, source_id TEXT, chunk_text TEXT, created_at TEXT, agent_id TEXT);
+			CREATE TABLE vec_embeddings (id TEXT PRIMARY KEY, embedding BLOB);
+			CREATE TABLE vec_embeddings_staging (id TEXT PRIMARY KEY, embedding BLOB);
+			INSERT INTO vec_embeddings_staging VALUES ('preserved', X'01');
+		`);
+		const db = raw as unknown as WriteDb;
+		const active = {
+			provider: "ollama",
+			model: "custom-a",
+			dimensions: 3,
+			base_url: "http://127.0.0.1:11434",
+		} as const;
+		const desired = { ...active, model: "custom-b" };
+		ensureEmbeddingIndexState(db, active);
+		beginEmbeddingIndexBuild(db, desired);
+		const accessor: DbAccessor = {
+			withWriteTx: (fn) => fn(db),
+			withReadDb: (fn) => fn(raw as unknown as ReadDb),
+			close: () => undefined,
+		};
+
+		const handle = startEmbeddingIndexMigration({
+			accessor,
+			configured: desired,
+			fetchEmbedding: async () => [0, 0, 0],
+			checkProvider: async () => ({ available: false }),
+			pollMs: 60_000,
+			batchSize: 10,
+		});
+		expect(handle).not.toBeNull();
+		await Promise.resolve();
+		expect(raw.prepare("SELECT id FROM vec_embeddings_staging").get()).toEqual({ id: "preserved" });
+		await handle?.stop();
+	});
+});

--- a/platform/daemon/src/embedding-index-migration.ts
+++ b/platform/daemon/src/embedding-index-migration.ts
@@ -1,0 +1,352 @@
+import { randomUUID } from "node:crypto";
+import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
+import { vectorToBlob } from "./db-helpers";
+import {
+	type PersistedEmbeddingProfile,
+	type EmbeddingIndexState,
+	readEmbeddingIndexState,
+} from "./embedding-index-state";
+import { beginEmbeddingIndexBuild, failEmbeddingIndexBuild } from "./embedding-index-state";
+import type { EmbeddingConfig } from "./memory-config";
+
+const STAGING_VECTOR_TABLE = "vec_embeddings_staging";
+
+interface ActiveEmbeddingRow {
+	readonly content_hash: string;
+	readonly source_type: string;
+	readonly source_id: string;
+	readonly chunk_text: string;
+	readonly agent_id: string | null;
+}
+
+export interface EmbeddingMigrationCoverage {
+	readonly active: number;
+	readonly staged: number;
+	readonly missing: number;
+	readonly wrongDimensions: number;
+	readonly ready: boolean;
+}
+
+export interface EmbeddingIndexMigrationStats {
+	readonly running: boolean;
+	readonly staged: number;
+	readonly failed: number;
+	readonly coverage: EmbeddingMigrationCoverage | null;
+}
+
+export interface EmbeddingIndexMigrationHandle {
+	stop(): Promise<void>;
+	getStats(): EmbeddingIndexMigrationStats;
+}
+
+function assertDimensions(dimensions: number): number {
+	if (!Number.isInteger(dimensions) || dimensions <= 0) throw new Error("Invalid staging embedding dimensions");
+	return dimensions;
+}
+
+function configForProfile(profile: PersistedEmbeddingProfile, configured: EmbeddingConfig): EmbeddingConfig {
+	return {
+		...configured,
+		provider: profile.provider,
+		model: profile.model,
+		dimensions: profile.dimensions,
+		base_url: profile.baseUrl,
+		// `legacy-raw` is deliberately truthy so the migration can encode an
+		// unknown model without being redirected to the active generation.
+		profile: profile.profile ?? "legacy-raw",
+		indexGeneration: "staging",
+	};
+}
+
+function tableExists(db: ReadDb, name: string): boolean {
+	return db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(name) !== undefined;
+}
+
+function isVecVirtualTable(db: ReadDb, name: string): boolean {
+	const row = db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?").get(name) as
+		| { sql?: string }
+		| undefined;
+	return typeof row?.sql === "string" && /^CREATE\s+VIRTUAL\s+TABLE/i.test(row.sql);
+}
+
+function createVectorIndex(db: WriteDb, table: string, dimensions: number): void {
+	db.exec(`
+		CREATE VIRTUAL TABLE ${table} USING vec0(
+			id TEXT PRIMARY KEY,
+			embedding FLOAT[${assertDimensions(dimensions)}] distance_metric=cosine
+		)
+	`);
+}
+
+/** Creates a dimension-safe inactive vec0 table without touching active recall. */
+export function resetStagingVectorIndex(db: WriteDb, dimensions: number): void {
+	db.exec(`DROP TABLE IF EXISTS ${STAGING_VECTOR_TABLE}`);
+	createVectorIndex(db, STAGING_VECTOR_TABLE, dimensions);
+}
+
+/** Rebuild the active sqlite-vec projection from its durable BLOB rows. */
+function rebuildActiveVectorIndex(db: WriteDb, dimensions: number): void {
+	db.exec("DROP TABLE IF EXISTS vec_embeddings_staging");
+	db.exec("DROP TABLE vec_embeddings");
+	createVectorIndex(db, "vec_embeddings", dimensions);
+	const rows = db.prepare("SELECT id, vector FROM embeddings ORDER BY id").all() as Array<{
+		id: string;
+		vector: Buffer;
+	}>;
+	const insert = db.prepare("INSERT INTO vec_embeddings (id, embedding) VALUES (?, ?)");
+	for (const row of rows) {
+		const vector = new Float32Array(
+			row.vector.buffer,
+			row.vector.byteOffset,
+			row.vector.byteLength / Float32Array.BYTES_PER_ELEMENT,
+		);
+		if (vector.length !== dimensions)
+			throw new Error(`Staged embedding ${row.id} has ${vector.length} dimensions, expected ${dimensions}`);
+		insert.run(row.id, vector);
+	}
+}
+
+export function stagingCoverage(db: ReadDb, dimensions: number): EmbeddingMigrationCoverage {
+	const active = (db.prepare("SELECT COUNT(*) AS n FROM embeddings").get() as { n: number } | undefined)?.n ?? 0;
+	const staged =
+		(db.prepare("SELECT COUNT(*) AS n FROM embeddings_staging").get() as { n: number } | undefined)?.n ?? 0;
+	const missing =
+		(
+			db
+				.prepare(
+					`SELECT COUNT(*) AS n FROM embeddings e
+				 LEFT JOIN embeddings_staging s ON s.content_hash = e.content_hash
+				 WHERE s.id IS NULL`,
+				)
+				.get() as { n: number } | undefined
+		)?.n ?? 0;
+	const wrongDimensions =
+		(
+			db.prepare("SELECT COUNT(*) AS n FROM embeddings_staging WHERE dimensions != ?").get(dimensions) as
+				| { n: number }
+				| undefined
+		)?.n ?? 0;
+	return {
+		active,
+		staged,
+		missing,
+		wrongDimensions,
+		ready: missing === 0 && wrongDimensions === 0 && active === staged,
+	};
+}
+
+/** Remove rows whose active source was deleted or changed while staging ran. */
+function pruneStagingRows(accessor: DbAccessor): void {
+	accessor.withWriteTx((db) => {
+		const stale = db
+			.prepare(
+				`SELECT s.id FROM embeddings_staging s
+				 LEFT JOIN embeddings e ON e.content_hash = s.content_hash
+				 WHERE e.id IS NULL`,
+			)
+			.all() as Array<{ id: string }>;
+		if (stale.length === 0) return;
+		const deleteVector = db.prepare(`DELETE FROM ${STAGING_VECTOR_TABLE} WHERE id = ?`);
+		const deleteEmbedding = db.prepare("DELETE FROM embeddings_staging WHERE id = ?");
+		for (const { id } of stale) {
+			deleteVector.run(id);
+			deleteEmbedding.run(id);
+		}
+	});
+}
+
+export async function stageEmbeddingBatch(input: {
+	readonly accessor: DbAccessor;
+	readonly configured: EmbeddingConfig;
+	readonly fetchEmbedding: (text: string, cfg: EmbeddingConfig, role?: "document") => Promise<number[] | null>;
+	readonly batchSize: number;
+}): Promise<{ staged: number; coverage: EmbeddingMigrationCoverage | null }> {
+	const state = input.accessor.withReadDb((db) => readEmbeddingIndexState(db));
+	if (state?.state !== "building" || !state.staging) return { staged: 0, coverage: null };
+	const profile = state.staging;
+	// Writes and source purges continue against the active slot during a build.
+	// Without this cleanup, an obsolete staging row would keep the count-based
+	// readiness gate false forever after its active counterpart disappears.
+	pruneStagingRows(input.accessor);
+	const rows = input.accessor.withReadDb((db) => {
+		if (!tableExists(db, STAGING_VECTOR_TABLE)) throw new Error("Staging vector index is unavailable");
+		return db
+			.prepare(
+				`SELECT e.content_hash, e.source_type, e.source_id, e.chunk_text, e.agent_id
+				 FROM embeddings e
+				 LEFT JOIN embeddings_staging s ON s.content_hash = e.content_hash
+				 WHERE s.id IS NULL OR s.dimensions != ?
+				 ORDER BY e.created_at ASC
+				 LIMIT ?`,
+			)
+			.all(profile.dimensions, input.batchSize) as ActiveEmbeddingRow[];
+	});
+
+	let staged = 0;
+	for (const row of rows) {
+		const vector = await input.fetchEmbedding(row.chunk_text, configForProfile(profile, input.configured), "document");
+		if (!vector) continue;
+		if (vector.length !== profile.dimensions) {
+			throw new Error(
+				`Staging provider returned ${vector.length} dimensions for ${profile.model}; expected ${profile.dimensions}`,
+			);
+		}
+		input.accessor.withWriteTx((db) => {
+			const id = randomUUID();
+			db.prepare(
+				`INSERT INTO embeddings_staging
+				 (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), ?)
+				 ON CONFLICT(content_hash) DO UPDATE SET
+				   vector = excluded.vector, dimensions = excluded.dimensions, source_type = excluded.source_type,
+				   source_id = excluded.source_id, chunk_text = excluded.chunk_text, created_at = excluded.created_at,
+				   agent_id = excluded.agent_id`,
+			).run(
+				id,
+				row.content_hash,
+				vectorToBlob(vector),
+				vector.length,
+				row.source_type,
+				row.source_id,
+				row.chunk_text,
+				row.agent_id,
+			);
+			const stored = db.prepare("SELECT id FROM embeddings_staging WHERE content_hash = ?").get(row.content_hash) as
+				| { id: string }
+				| undefined;
+			if (stored)
+				db.prepare(`INSERT OR REPLACE INTO ${STAGING_VECTOR_TABLE} (id, embedding) VALUES (?, ?)`).run(
+					stored.id,
+					new Float32Array(vector),
+				);
+		});
+		staged++;
+	}
+
+	const coverage = input.accessor.withReadDb((db) => stagingCoverage(db, profile.dimensions));
+	return { staged, coverage };
+}
+
+/**
+ * Promotion runs in one IMMEDIATE transaction. The coverage recheck closes the
+ * gap between an asynchronous batch and a concurrent memory/source write.
+ */
+export function promoteStagingIndex(accessor: DbAccessor): boolean {
+	return accessor.withWriteTx((db) => {
+		const state = readEmbeddingIndexState(db);
+		if (state?.state !== "building" || !state.staging) return false;
+		if (!stagingCoverage(db, state.staging.dimensions).ready) return false;
+		if (!tableExists(db, STAGING_VECTOR_TABLE)) return false;
+		db.prepare(
+			`UPDATE memories SET embedding_model = ?
+			 WHERE id IN (SELECT source_id FROM embeddings_staging WHERE source_type = 'memory')`,
+		).run(state.staging.model);
+
+		// Keep exactly two slots: after the swap the former active index becomes
+		// the inactive/rollback slot, ready to be cleared only for the next build.
+		db.exec("ALTER TABLE embeddings_staging RENAME TO embeddings_next");
+		db.exec("ALTER TABLE embeddings RENAME TO embeddings_staging");
+		db.exec("ALTER TABLE embeddings_next RENAME TO embeddings");
+		// sqlite-vec virtual-table renames leave its backing tables associated
+		// with the old table name. Rebuild the projection after swapping the
+		// durable slots instead; the transaction keeps old recall visible until
+		// the complete new vec0 index is committed. Plain tables remain useful
+		// test doubles and retain the inexpensive rename path.
+		if (isVecVirtualTable(db, "vec_embeddings") && isVecVirtualTable(db, STAGING_VECTOR_TABLE)) {
+			rebuildActiveVectorIndex(db, state.staging.dimensions);
+		} else {
+			db.exec(`ALTER TABLE ${STAGING_VECTOR_TABLE} RENAME TO vec_embeddings_next`);
+			db.exec("ALTER TABLE vec_embeddings RENAME TO vec_embeddings_staging");
+			db.exec("ALTER TABLE vec_embeddings_next RENAME TO vec_embeddings");
+		}
+		db.prepare(
+			`UPDATE embedding_index_state
+			 SET active_profile_json = staging_profile_json, staging_profile_json = NULL,
+			     state = 'ready', last_error = NULL, updated_at = ?
+			 WHERE id = 1`,
+		).run(new Date().toISOString());
+		return true;
+	});
+}
+
+/**
+ * Rebuild the inactive slot without ever querying it. Active/staging coverage
+ * is rechecked in the promotion transaction, so a write arriving during the
+ * final batch simply postpones promotion until the next pass.
+ */
+export function startEmbeddingIndexMigration(input: {
+	readonly accessor: DbAccessor;
+	readonly configured: EmbeddingConfig;
+	readonly fetchEmbedding: (text: string, cfg: EmbeddingConfig, role?: "document") => Promise<number[] | null>;
+	readonly checkProvider: (cfg: EmbeddingConfig) => Promise<{ available: boolean }>;
+	readonly pollMs: number;
+	readonly batchSize: number;
+	/** Recreate active-model workers after an atomic promotion. */
+	readonly onPromoted?: () => void;
+}): EmbeddingIndexMigrationHandle | null {
+	// Unknown models still need an isolated rebuild. They use the identity
+	// formatter rather than being rejected solely because Signet does not know
+	// a model-specific retrieval prefix.
+	if (input.configured.provider === "none") return null;
+
+	let running = true;
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let staged = 0;
+	let failed = 0;
+	let coverage: EmbeddingMigrationCoverage | null = null;
+
+	const before = input.accessor.withReadDb((db) => readEmbeddingIndexState(db));
+	const initial = input.accessor.withWriteTx((db) => beginEmbeddingIndexBuild(db, input.configured));
+	if (initial.state !== "building" || !initial.staging) return null;
+	const resumeExistingBuild =
+		before?.state === "building" && before.staging?.fingerprint === initial.staging.fingerprint;
+	try {
+		if (resumeExistingBuild) {
+			const hasStagingVectorIndex = input.accessor.withReadDb((db) => tableExists(db, STAGING_VECTOR_TABLE));
+			if (!hasStagingVectorIndex) throw new Error("Staging vector index is unavailable while resuming a build");
+		} else {
+			input.accessor.withWriteTx((db) => resetStagingVectorIndex(db, initial.staging.dimensions));
+		}
+	} catch (error) {
+		input.accessor.withWriteTx((db) =>
+			failEmbeddingIndexBuild(db, error instanceof Error ? error.message : String(error)),
+		);
+		return null;
+	}
+
+	const tick = async (): Promise<void> => {
+		if (!running) return;
+		try {
+			const state = input.accessor.withReadDb((db) => readEmbeddingIndexState(db));
+			if (state?.state !== "building" || !state.staging) return;
+			const providerCfg = configForProfile(state.staging, input.configured);
+			if (!(await input.checkProvider(providerCfg)).available) {
+				failed++;
+				return;
+			}
+			const result = await stageEmbeddingBatch(input);
+			staged += result.staged;
+			coverage = result.coverage;
+			if (coverage?.ready && promoteStagingIndex(input.accessor)) {
+				running = false;
+				input.onPromoted?.();
+			}
+		} catch (error) {
+			failed++;
+			input.accessor.withWriteTx((db) =>
+				failEmbeddingIndexBuild(db, error instanceof Error ? error.message : String(error)),
+			);
+		} finally {
+			if (running) timer = setTimeout(() => void tick(), input.pollMs);
+		}
+	};
+	void tick();
+
+	return {
+		async stop(): Promise<void> {
+			running = false;
+			if (timer) clearTimeout(timer);
+		},
+		getStats: () => ({ running, staged, failed, coverage }),
+	};
+}

--- a/platform/daemon/src/embedding-index-migration.ts
+++ b/platform/daemon/src/embedding-index-migration.ts
@@ -2,8 +2,8 @@ import { randomUUID } from "node:crypto";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import { vectorToBlob } from "./db-helpers";
 import {
-	type PersistedEmbeddingProfile,
 	type EmbeddingIndexState,
+	type PersistedEmbeddingProfile,
 	readEmbeddingIndexState,
 } from "./embedding-index-state";
 import { beginEmbeddingIndexBuild, failEmbeddingIndexBuild } from "./embedding-index-state";
@@ -297,15 +297,15 @@ export function startEmbeddingIndexMigration(input: {
 
 	const before = input.accessor.withReadDb((db) => readEmbeddingIndexState(db));
 	const initial = input.accessor.withWriteTx((db) => beginEmbeddingIndexBuild(db, input.configured));
-	if (initial.state !== "building" || !initial.staging) return null;
-	const resumeExistingBuild =
-		before?.state === "building" && before.staging?.fingerprint === initial.staging.fingerprint;
+	const staging = initial.staging;
+	if (initial.state !== "building" || !staging) return null;
+	const resumeExistingBuild = before?.state === "building" && before.staging?.fingerprint === staging.fingerprint;
 	try {
 		if (resumeExistingBuild) {
 			const hasStagingVectorIndex = input.accessor.withReadDb((db) => tableExists(db, STAGING_VECTOR_TABLE));
 			if (!hasStagingVectorIndex) throw new Error("Staging vector index is unavailable while resuming a build");
 		} else {
-			input.accessor.withWriteTx((db) => resetStagingVectorIndex(db, initial.staging.dimensions));
+			input.accessor.withWriteTx((db) => resetStagingVectorIndex(db, staging.dimensions));
 		}
 	} catch (error) {
 		input.accessor.withWriteTx((db) =>

--- a/platform/daemon/src/embedding-index-state.test.ts
+++ b/platform/daemon/src/embedding-index-state.test.ts
@@ -1,0 +1,113 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it } from "bun:test";
+import { up as embeddingIndexGenerations } from "../../core/src/migrations/091-embedding-index-generations";
+import {
+	beginEmbeddingIndexBuild,
+	ensureEmbeddingIndexState,
+	failEmbeddingIndexBuild,
+	isActiveEmbeddingConfig,
+	readEmbeddingIndexState,
+	resolveActiveEmbeddingConfig,
+} from "./embedding-index-state";
+import type { WriteDb } from "./db-accessor";
+import type { EmbeddingConfig } from "./memory-config";
+
+const config: EmbeddingConfig = {
+	provider: "native",
+	model: "nomic-embed-text-v1.5",
+	dimensions: 768,
+	base_url: "",
+};
+
+describe("embedding index state", () => {
+	it("seeds one legacy raw active profile and preserves it on later starts", () => {
+		const raw = new Database(":memory:");
+		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);
+		const db = raw as unknown as WriteDb;
+
+		const initial = ensureEmbeddingIndexState(db, config, "2026-01-01T00:00:00.000Z");
+		expect(initial.state).toBe("ready");
+		expect(initial.active.profile).toBeUndefined();
+		expect(initial.active.model).toBe("nomic-embed-text-v1.5");
+		expect(readEmbeddingIndexState(db)).toEqual(initial);
+
+		const changedConfig = { ...config, model: "qwen3-embedding:0.6b", dimensions: 1024 };
+		const later = ensureEmbeddingIndexState(db, changedConfig, "2026-01-02T00:00:00.000Z");
+		expect(later.active).toEqual(initial.active);
+		expect(resolveActiveEmbeddingConfig(db, changedConfig)).toMatchObject({
+			provider: "native",
+			model: "nomic-embed-text-v1.5",
+			dimensions: 768,
+			profile: undefined,
+		});
+		expect(raw.prepare("SELECT COUNT(*) AS count FROM embedding_index_state").get() as { count: number }).toEqual({
+			count: 1,
+		});
+	});
+
+	it("builds Qwen in staging without changing the legacy active profile", () => {
+		const raw = new Database(":memory:");
+		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);
+		raw.exec(
+			`CREATE TABLE embeddings_staging (id TEXT PRIMARY KEY, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER, source_type TEXT, source_id TEXT, chunk_text TEXT, created_at TEXT, agent_id TEXT)`,
+		);
+		const db = raw as unknown as WriteDb;
+		const active = ensureEmbeddingIndexState(db, config);
+		const staged = beginEmbeddingIndexBuild(db, {
+			...config,
+			provider: "ollama",
+			model: "qwen3-embedding:0.6b",
+			dimensions: 1024,
+		});
+
+		expect(staged.state).toBe("building");
+		expect(staged.active).toEqual(active.active);
+		expect(staged.staging?.profile).toBe("qwen3-embedding");
+		failEmbeddingIndexBuild(db, "provider unavailable");
+		expect(ensureEmbeddingIndexState(db, config).state).toBe("failed");
+		expect(ensureEmbeddingIndexState(db, config).active).toEqual(active.active);
+	});
+
+	it("stages unknown model changes with identity formatting instead of silently skipping them", () => {
+		const raw = new Database(":memory:");
+		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);
+		raw.exec(
+			`CREATE TABLE embeddings_staging (id TEXT PRIMARY KEY, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER, source_type TEXT, source_id TEXT, chunk_text TEXT, created_at TEXT, agent_id TEXT)`,
+		);
+		const db = raw as unknown as WriteDb;
+		ensureEmbeddingIndexState(db, { ...config, model: "custom-a" });
+		const staging = beginEmbeddingIndexBuild(db, { ...config, model: "custom-b" });
+		expect(staging.state).toBe("building");
+		expect(staging.staging?.profile).toBeUndefined();
+		expect(staging.staging?.model).toBe("custom-b");
+	});
+
+	it("rejects writes that captured a superseded active generation", () => {
+		const raw = new Database(":memory:");
+		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);
+		raw.exec(
+			`CREATE TABLE embeddings_staging (id TEXT PRIMARY KEY, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER, source_type TEXT, source_id TEXT, chunk_text TEXT, created_at TEXT, agent_id TEXT)`,
+		);
+		const db = raw as unknown as WriteDb;
+		ensureEmbeddingIndexState(db, config);
+		expect(isActiveEmbeddingConfig(db, config)).toBe(true);
+		beginEmbeddingIndexBuild(db, { ...config, model: "qwen3-embedding:0.6b", dimensions: 1024 });
+		raw
+			.prepare(
+				"UPDATE embedding_index_state SET active_profile_json = staging_profile_json, staging_profile_json = NULL, state = 'ready' WHERE id = 1",
+			)
+			.run();
+		expect(isActiveEmbeddingConfig(db, config)).toBe(false);
+	});
+
+	it("normalizes malformed config before it becomes durable state", () => {
+		const raw = new Database(":memory:");
+		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);
+		const db = raw as unknown as WriteDb;
+		const malformed = { ...config, provider: "not-a-provider", dimensions: 0 } as unknown as EmbeddingConfig;
+		const initial = ensureEmbeddingIndexState(db, malformed);
+		expect(initial.active.provider).toBe("native");
+		expect(initial.active.dimensions).toBe(768);
+		expect(ensureEmbeddingIndexState(db, malformed)).toEqual(initial);
+	});
+});

--- a/platform/daemon/src/embedding-index-state.ts
+++ b/platform/daemon/src/embedding-index-state.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_EMBEDDING_DIMENSIONS } from "@signet/core";
-import { embeddingProfileFingerprint, recommendedEmbeddingProfileId } from "./embedding-profile";
 import type { ReadDb, WriteDb } from "./db-accessor";
+import { embeddingProfileFingerprint, recommendedEmbeddingProfileId } from "./embedding-profile";
 import type { EmbeddingConfig } from "./memory-config";
 
 export type EmbeddingIndexBuildState = "ready" | "building" | "failed";
@@ -70,12 +70,15 @@ export function isActiveEmbeddingConfig(db: ReadDb, cfg: EmbeddingConfig): boole
 function parseProfile(value: string): PersistedEmbeddingProfile | null {
 	try {
 		const parsed = JSON.parse(value) as Partial<PersistedEmbeddingProfile>;
+		const dimensions = parsed.dimensions;
 		if (
 			typeof parsed.fingerprint !== "string" ||
 			typeof parsed.model !== "string" ||
 			typeof parsed.baseUrl !== "string" ||
-			!Number.isInteger(parsed.dimensions) ||
-			parsed.dimensions <= 0 ||
+			!Number.isInteger(dimensions) ||
+			// `Number.isInteger` does not narrow `number | undefined` for TypeScript.
+			dimensions === undefined ||
+			dimensions <= 0 ||
 			!isEmbeddingProvider(parsed.provider)
 		)
 			return null;
@@ -83,7 +86,7 @@ function parseProfile(value: string): PersistedEmbeddingProfile | null {
 			fingerprint: parsed.fingerprint,
 			provider: parsed.provider,
 			model: parsed.model,
-			dimensions: parsed.dimensions,
+			dimensions,
 			baseUrl: parsed.baseUrl,
 			...(typeof parsed.profile === "string" ? { profile: parsed.profile } : {}),
 		};

--- a/platform/daemon/src/embedding-index-state.ts
+++ b/platform/daemon/src/embedding-index-state.ts
@@ -1,0 +1,174 @@
+import { DEFAULT_EMBEDDING_DIMENSIONS } from "@signet/core";
+import { embeddingProfileFingerprint, recommendedEmbeddingProfileId } from "./embedding-profile";
+import type { ReadDb, WriteDb } from "./db-accessor";
+import type { EmbeddingConfig } from "./memory-config";
+
+export type EmbeddingIndexBuildState = "ready" | "building" | "failed";
+
+export interface PersistedEmbeddingProfile {
+	readonly fingerprint: string;
+	readonly provider: EmbeddingConfig["provider"];
+	readonly model: string;
+	readonly dimensions: number;
+	readonly baseUrl: string;
+	readonly profile?: string;
+}
+
+export interface EmbeddingIndexState {
+	readonly active: PersistedEmbeddingProfile;
+	readonly staging: PersistedEmbeddingProfile | null;
+	readonly state: EmbeddingIndexBuildState;
+	readonly lastError: string | null;
+}
+
+interface StateRow {
+	readonly active_profile_json: string;
+	readonly staging_profile_json: string | null;
+	readonly state: EmbeddingIndexBuildState;
+	readonly last_error: string | null;
+}
+
+function profileForStorage(cfg: EmbeddingConfig): PersistedEmbeddingProfile {
+	const provider = isEmbeddingProvider(cfg.provider) ? cfg.provider : "native";
+	const dimensions =
+		Number.isInteger(cfg.dimensions) && cfg.dimensions > 0 ? cfg.dimensions : DEFAULT_EMBEDDING_DIMENSIONS;
+	const normalized: EmbeddingConfig = { ...cfg, provider, dimensions };
+	return {
+		fingerprint: embeddingProfileFingerprint(normalized),
+		provider,
+		model: normalized.model,
+		dimensions,
+		baseUrl: normalized.base_url,
+		...(normalized.profile ? { profile: normalized.profile } : {}),
+	};
+}
+
+export function resolveActiveEmbeddingConfig(db: ReadDb, configured: EmbeddingConfig): EmbeddingConfig {
+	if (configured.profile) return configured;
+	const active = readEmbeddingIndexState(db)?.active;
+	if (!active) return configured;
+	return {
+		...configured,
+		provider: active.provider,
+		model: active.model,
+		dimensions: active.dimensions,
+		base_url: active.baseUrl,
+		...(active.profile ? { profile: active.profile } : { profile: undefined }),
+	};
+}
+
+/** True only while `cfg` still describes the generation that owns active recall. */
+export function isActiveEmbeddingConfig(db: ReadDb, cfg: EmbeddingConfig): boolean {
+	const state = readEmbeddingIndexState(db);
+	// Lightweight/test databases that have run schema migrations but not daemon
+	// initialization cannot be mid-promotion. Preserve their legacy behavior;
+	// a running daemon always seeds this singleton before any worker starts.
+	if (!state) return true;
+	return embeddingProfileFingerprint(cfg) === state.active.fingerprint;
+}
+
+function parseProfile(value: string): PersistedEmbeddingProfile | null {
+	try {
+		const parsed = JSON.parse(value) as Partial<PersistedEmbeddingProfile>;
+		if (
+			typeof parsed.fingerprint !== "string" ||
+			typeof parsed.model !== "string" ||
+			typeof parsed.baseUrl !== "string" ||
+			!Number.isInteger(parsed.dimensions) ||
+			parsed.dimensions <= 0 ||
+			!isEmbeddingProvider(parsed.provider)
+		)
+			return null;
+		return {
+			fingerprint: parsed.fingerprint,
+			provider: parsed.provider,
+			model: parsed.model,
+			dimensions: parsed.dimensions,
+			baseUrl: parsed.baseUrl,
+			...(typeof parsed.profile === "string" ? { profile: parsed.profile } : {}),
+		};
+	} catch {
+		return null;
+	}
+}
+
+function isEmbeddingProvider(value: unknown): value is EmbeddingConfig["provider"] {
+	return value === "native" || value === "llama-cpp" || value === "ollama" || value === "openai" || value === "none";
+}
+
+function parseState(row: StateRow): EmbeddingIndexState | null {
+	const active = parseProfile(row.active_profile_json);
+	const staging = row.staging_profile_json === null ? null : parseProfile(row.staging_profile_json);
+	if (!active || (row.staging_profile_json !== null && !staging)) return null;
+	if (row.state !== "ready" && row.state !== "building" && row.state !== "failed") return null;
+	return { active, staging, state: row.state, lastError: row.last_error };
+}
+
+export function readEmbeddingIndexState(db: ReadDb): EmbeddingIndexState | null {
+	const row = db
+		.prepare(
+			"SELECT active_profile_json, staging_profile_json, state, last_error FROM embedding_index_state WHERE id = 1",
+		)
+		.get() as StateRow | undefined;
+	return row ? parseState(row) : null;
+}
+
+/**
+ * Initialise the singleton with the legacy raw-text profile. This deliberately
+ * does not infer a new formatter from the model name: existing vectors were
+ * created from raw input and must keep their matching query transform until a
+ * staged generation has rebuilt them.
+ */
+export function ensureEmbeddingIndexState(
+	db: WriteDb,
+	cfg: EmbeddingConfig,
+	now = new Date().toISOString(),
+): EmbeddingIndexState {
+	const existing = readEmbeddingIndexState(db);
+	if (existing) {
+		const parsed = existing;
+		if (parsed) return parsed;
+	}
+	const rawState = db.prepare("SELECT 1 FROM embedding_index_state WHERE id = 1").get();
+	if (rawState) throw new Error("Invalid embedding index state; refusing to guess an active vector space");
+
+	const legacyConfig: EmbeddingConfig = { ...cfg, profile: undefined };
+	const active = profileForStorage(legacyConfig);
+	db.prepare(
+		`INSERT INTO embedding_index_state
+		 (id, active_profile_json, staging_profile_json, state, last_error, created_at, updated_at)
+		 VALUES (1, ?, NULL, 'ready', NULL, ?, ?)`,
+	).run(JSON.stringify(active), now, now);
+	return { active, staging: null, state: "ready", lastError: null };
+}
+
+/** Start (or resume) the inactive generation without changing active recall. */
+export function beginEmbeddingIndexBuild(
+	db: WriteDb,
+	cfg: EmbeddingConfig,
+	now = new Date().toISOString(),
+): EmbeddingIndexState {
+	const current = ensureEmbeddingIndexState(db, cfg, now);
+	const stagingConfig: EmbeddingConfig = {
+		...cfg,
+		profile: recommendedEmbeddingProfileId(cfg),
+	};
+	const staging = profileForStorage(stagingConfig);
+	if (current.state === "building" && current.staging?.fingerprint === staging.fingerprint) return current;
+	if (current.active.fingerprint === staging.fingerprint) return current;
+
+	db.exec("DELETE FROM embeddings_staging");
+	db.prepare(
+		`UPDATE embedding_index_state
+		 SET staging_profile_json = ?, state = 'building', last_error = NULL, updated_at = ?
+		 WHERE id = 1`,
+	).run(JSON.stringify(staging), now);
+	return { active: current.active, staging, state: "building", lastError: null };
+}
+
+export function failEmbeddingIndexBuild(db: WriteDb, error: string, now = new Date().toISOString()): void {
+	db.prepare("UPDATE embedding_index_state SET state = 'failed', last_error = ?, updated_at = ? WHERE id = 1").run(
+		error,
+		now,
+	);
+}

--- a/platform/daemon/src/embedding-profile.test.ts
+++ b/platform/daemon/src/embedding-profile.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import { embeddingProfileFingerprint, formatEmbeddingInput, resolveEmbeddingProfile } from "./embedding-profile";
+import type { EmbeddingConfig } from "./memory-config";
+
+function config(overrides: Partial<EmbeddingConfig> = {}): EmbeddingConfig {
+	return {
+		provider: "ollama",
+		model: "nomic-embed-text",
+		dimensions: 768,
+		base_url: "http://127.0.0.1:11434",
+		profile: "nomic-embed-text-v1.5",
+		...overrides,
+	};
+}
+
+describe("embedding profiles", () => {
+	it("uses Nomic's documented asymmetric retrieval prefixes", () => {
+		const cfg = config();
+		expect(resolveEmbeddingProfile(cfg).id).toBe("nomic-embed-text-v1.5");
+		expect(formatEmbeddingInput("a note", cfg, "document")).toBe("search_document: a note");
+		expect(formatEmbeddingInput("find it", cfg, "query")).toBe("search_query: find it");
+	});
+
+	it("formats Qwen retrieval queries but not passages", () => {
+		const cfg = config({ model: "qwen3-embedding:0.6b", dimensions: 1024, profile: "qwen3-embedding" });
+		expect(resolveEmbeddingProfile(cfg).id).toBe("qwen3-embedding");
+		expect(formatEmbeddingInput("passage", cfg, "document")).toBe("passage");
+		expect(formatEmbeddingInput("question", cfg, "query")).toBe(
+			"Instruct: Given a web search query, retrieve relevant passages that answer the query\nQuery: question",
+		);
+	});
+
+	it("does not include secrets in the vector-space fingerprint", () => {
+		const cfg = config({ api_key: "secret" });
+		const withoutSecret = config();
+		expect(embeddingProfileFingerprint(cfg)).toBe(embeddingProfileFingerprint(withoutSecret));
+	});
+
+	it("keeps legacy vectors raw until their generation is migrated", () => {
+		const cfg = config({ profile: undefined });
+		expect(formatEmbeddingInput("existing text", cfg, "document")).toBe("existing text");
+		expect(formatEmbeddingInput("existing text", cfg, "query")).toBe("existing text");
+	});
+});

--- a/platform/daemon/src/embedding-profile.ts
+++ b/platform/daemon/src/embedding-profile.ts
@@ -1,0 +1,70 @@
+import type { EmbeddingConfig } from "./memory-config";
+
+/** The semantic role determines the model's documented retrieval formatting. */
+export type EmbeddingRole = "document" | "query";
+
+export interface EmbeddingProfile {
+	readonly id: string;
+	readonly dimensions: number;
+	readonly format: (text: string, role: EmbeddingRole) => string;
+}
+
+const QWEN_RETRIEVAL_INSTRUCTION = "Given a web search query, retrieve relevant passages that answer the query";
+
+const identityProfile = (cfg: EmbeddingConfig): EmbeddingProfile => ({
+	id: `custom:${cfg.provider}:${cfg.model}`,
+	dimensions: cfg.dimensions,
+	format: (text) => text,
+});
+
+const nomicProfile = (cfg: EmbeddingConfig): EmbeddingProfile => ({
+	id: "nomic-embed-text-v1.5",
+	dimensions: cfg.dimensions,
+	format: (text, role) => `${role === "query" ? "search_query" : "search_document"}: ${text}`,
+});
+
+const qwenProfile = (cfg: EmbeddingConfig): EmbeddingProfile => ({
+	id: "qwen3-embedding",
+	dimensions: cfg.dimensions,
+	format: (text, role) => (role === "query" ? `Instruct: ${QWEN_RETRIEVAL_INSTRUCTION}\nQuery: ${text}` : text),
+});
+
+/**
+ * Resolve only formats that the daemon can prove from the configured model.
+ * Unknown models remain identity-formatted rather than receiving an invented
+ * prefix that could silently harm recall.
+ */
+export function resolveEmbeddingProfile(cfg: EmbeddingConfig): EmbeddingProfile {
+	if (!cfg.profile || cfg.profile === "legacy-raw") return identityProfile(cfg);
+	const model = cfg.model.trim().toLowerCase();
+	if (cfg.profile === "nomic-embed-text-v1.5" && model.includes("nomic-embed-text")) return nomicProfile(cfg);
+	if (cfg.profile === "qwen3-embedding" && model.includes("qwen3-embedding")) return qwenProfile(cfg);
+	return identityProfile(cfg);
+}
+
+/** The profile a new generation should use for a known configured model. */
+export function recommendedEmbeddingProfileId(cfg: EmbeddingConfig): string | undefined {
+	const model = cfg.model.trim().toLowerCase();
+	if (model.includes("nomic-embed-text")) return "nomic-embed-text-v1.5";
+	if (model.includes("qwen3-embedding")) return "qwen3-embedding";
+	return undefined;
+}
+
+export function formatEmbeddingInput(text: string, cfg: EmbeddingConfig, role: EmbeddingRole): string {
+	return resolveEmbeddingProfile(cfg).format(text, role);
+}
+
+/**
+ * Stable, secret-free identity for a vector space. A change means existing
+ * vectors cannot be queried with new query embeddings and must be rebuilt.
+ */
+export function embeddingProfileFingerprint(cfg: EmbeddingConfig): string {
+	const profile = resolveEmbeddingProfile(cfg);
+	return JSON.stringify({
+		profile: profile.id,
+		provider: cfg.provider,
+		model: cfg.model,
+		dimensions: profile.dimensions,
+		baseUrl: cfg.base_url,
+	});
+}

--- a/platform/daemon/src/embedding-tracker.ts
+++ b/platform/daemon/src/embedding-tracker.ts
@@ -11,6 +11,7 @@ import type { PipelineEmbeddingTrackerConfig } from "@signet/core";
 import type { DbAccessor } from "./db-accessor";
 import { syncVecDeleteBySourceExceptHash, syncVecInsert, vectorToBlob } from "./db-helpers";
 import { listStaleEmbeddingRows } from "./embedding-coverage";
+import { isActiveEmbeddingConfig } from "./embedding-index-state";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
 
@@ -179,6 +180,9 @@ export function startEmbeddingTracker(
 
 			// 4. Batch write in a single write transaction
 			accessor.withWriteTx((db) => {
+				// A promotion may commit while this batch is encoding. Never let a
+				// tracker closed over the previous generation overwrite its vectors.
+				if (!isActiveEmbeddingConfig(db, embeddingCfg)) return;
 				for (const { row, vector, contentHash } of cycle.results) {
 					// Delete stale embeddings for this source
 					syncVecDeleteBySourceExceptHash(db, "memory", row.id, contentHash);

--- a/platform/daemon/src/memory-config.ts
+++ b/platform/daemon/src/memory-config.ts
@@ -20,6 +20,10 @@ export interface EmbeddingConfig {
 	model: string;
 	dimensions: number;
 	base_url: string;
+	/** Internal retrieval formatting contract. Omitted means legacy raw text until a generation migration promotes a profile. */
+	profile?: string;
+	/** Internal marker: only the migration worker may bypass active resolution. */
+	indexGeneration?: "staging";
 	api_key?: string;
 	promptSubmitTimeoutMs?: number;
 	llamaCppMaxInputTokens?: number;

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -26,6 +26,7 @@ import { getLlmProvider } from "./llm";
 import { logger } from "./logger";
 import { buildAgentScopeClause } from "./memory-access-scope";
 import type { EmbeddingConfig, MemorySearchConfig, ResolvedMemoryConfig } from "./memory-config";
+import type { EmbeddingRole } from "./embedding-profile";
 import { NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID } from "./native-memory-constants";
 import { constructContextBlocks } from "./pipeline/context-construction";
 import { DEFAULT_DAMPENING, type ScoredRow, applyDampening } from "./pipeline/dampening";
@@ -165,7 +166,7 @@ export interface AggregateRecallUsageStage extends LlmUsage {
 	readonly fallbackCount: number;
 }
 
-export type EmbedFn = (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>;
+export type EmbedFn = (text: string, cfg: EmbeddingConfig, role?: EmbeddingRole) => Promise<number[] | null>;
 
 export interface RecallStageTiming {
 	name: string;
@@ -1291,7 +1292,7 @@ export async function hybridRecall(
 		const embeddingStart = performance.now();
 		let promise: Promise<number[] | null>;
 		try {
-			promise = Promise.resolve(embedFn(query, cfg.embedding));
+			promise = Promise.resolve(embedFn(query, cfg.embedding, "query"));
 		} catch (e) {
 			promise = Promise.reject(e);
 		}

--- a/platform/daemon/src/obsidian-source-embeddings.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.ts
@@ -4,6 +4,7 @@ import { LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE, SOURCE_CHUNK_SOURCE_TYPE } from "@si
 import { yieldEvery } from "./async-yield";
 import { getDbAccessor } from "./db-accessor";
 import { syncVecDeleteByEmbeddingIds, syncVecInsert, vectorToBlob } from "./db-helpers";
+import { isActiveEmbeddingConfig, resolveActiveEmbeddingConfig } from "./embedding-index-state";
 import type { EmbeddingConfig } from "./memory-config";
 
 export const OBSIDIAN_CHUNK_SOURCE_TYPE = SOURCE_CHUNK_SOURCE_TYPE;
@@ -227,7 +228,10 @@ export function buildObsidianSourceChunks(input: {
 export async function indexObsidianSourceEmbeddings(
 	input: IndexObsidianSourceEmbeddingsInput,
 ): Promise<IndexObsidianSourceEmbeddingsResult> {
-	if (input.embeddingConfig.provider === "none") return { chunks: 0, embedded: 0, skipped: 0 };
+	// Source watchers outlive a config edit. Keep their writes compatible with
+	// active recall while the requested profile is built in the inactive slot.
+	const embeddingConfig = getDbAccessor().withReadDb((db) => resolveActiveEmbeddingConfig(db, input.embeddingConfig));
+	if (embeddingConfig.provider === "none") return { chunks: 0, embedded: 0, skipped: 0 };
 	const chunks = buildObsidianSourceChunks(input);
 	const currentHashes = new Set<string>();
 	const yielder = yieldEvery(1);
@@ -244,24 +248,25 @@ export async function indexObsidianSourceEmbeddings(
 			await sleep(OBSIDIAN_SOURCE_CHUNK_DELAY_MS);
 			continue;
 		}
-		const vector = await input.fetchEmbedding(chunk.chunkText, input.embeddingConfig);
-		if (!vector || vector.length === 0) {
-			skipped++;
-			await yielder();
-			await sleep(OBSIDIAN_SOURCE_CHUNK_DELAY_MS);
-			continue;
-		}
-		getDbAccessor().withWriteTx((db) => {
-			const embId = hash(`${OBSIDIAN_CHUNK_SOURCE_TYPE}:${input.agentId}:${chunk.id}`).slice(0, 32);
-			const existingForId = db.prepare("SELECT content_hash FROM embeddings WHERE id = ?").get(embId) as
-				| { content_hash: string }
-				| undefined;
-			if (existingForId && existingForId.content_hash !== contentHash) {
-				syncVecDeleteByEmbeddingIds(db, [embId]);
-				db.prepare("DELETE FROM embeddings WHERE id = ?").run(embId);
-			}
-			db.prepare(
-				`INSERT INTO embeddings
+		let stored = false;
+		for (let attempt = 0; attempt < 2 && !stored; attempt += 1) {
+			const writeConfig = getDbAccessor().withReadDb((db) => resolveActiveEmbeddingConfig(db, input.embeddingConfig));
+			const vector = await input.fetchEmbedding(chunk.chunkText, writeConfig);
+			if (!vector || vector.length === 0) break;
+			stored = getDbAccessor().withWriteTx((db) => {
+				// Recheck after the asynchronous provider call: promotion may have
+				// committed a new active space while this chunk was encoding.
+				if (!isActiveEmbeddingConfig(db, writeConfig)) return false;
+				const embId = hash(`${OBSIDIAN_CHUNK_SOURCE_TYPE}:${input.agentId}:${chunk.id}`).slice(0, 32);
+				const existingForId = db.prepare("SELECT content_hash FROM embeddings WHERE id = ?").get(embId) as
+					| { content_hash: string }
+					| undefined;
+				if (existingForId && existingForId.content_hash !== contentHash) {
+					syncVecDeleteByEmbeddingIds(db, [embId]);
+					db.prepare("DELETE FROM embeddings WHERE id = ?").run(embId);
+				}
+				db.prepare(
+					`INSERT INTO embeddings
 				 (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
 				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 				 ON CONFLICT(content_hash) DO UPDATE SET
@@ -272,22 +277,30 @@ export async function indexObsidianSourceEmbeddings(
 				   chunk_text = excluded.chunk_text,
 				   created_at = excluded.created_at,
 				   agent_id = excluded.agent_id`,
-			).run(
-				embId,
-				contentHash,
-				vectorToBlob(vector),
-				vector.length,
-				OBSIDIAN_CHUNK_SOURCE_TYPE,
-				chunk.id,
-				chunk.chunkText,
-				now,
-				input.agentId,
-			);
-			const stored = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(contentHash) as
-				| { id: string }
-				| undefined;
-			syncVecInsert(db, stored?.id ?? embId, vector);
-		});
+				).run(
+					embId,
+					contentHash,
+					vectorToBlob(vector),
+					vector.length,
+					OBSIDIAN_CHUNK_SOURCE_TYPE,
+					chunk.id,
+					chunk.chunkText,
+					now,
+					input.agentId,
+				);
+				const stored = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(contentHash) as
+					| { id: string }
+					| undefined;
+				syncVecInsert(db, stored?.id ?? embId, vector);
+				return true;
+			});
+		}
+		if (!stored) {
+			skipped++;
+			await yielder();
+			await sleep(OBSIDIAN_SOURCE_CHUNK_DELAY_MS);
+			continue;
+		}
 		embedded++;
 		await yielder();
 		await sleep(OBSIDIAN_SOURCE_CHUNK_DELAY_MS);
@@ -295,16 +308,17 @@ export async function indexObsidianSourceEmbeddings(
 
 	getDbAccessor().withWriteTx((db) => {
 		const prefix = `${input.sourceId}:${relPath(normalizePath(input.root).replace(/\/$/, ""), normalizePath(input.filePath))}#`;
-		const stale = OBSIDIAN_CHUNK_SOURCE_TYPES.flatMap((sourceType) =>
-			db
-				.prepare(
-					"SELECT id, source_type, content_hash FROM embeddings WHERE source_type = ? AND source_id >= ? AND source_id < ? AND agent_id = ?",
-				)
-				.all(sourceType, prefix, prefixUpperBound(prefix), input.agentId) as Array<{
-				id: string;
-				source_type: string;
-				content_hash: string;
-			}>,
+		const stale = OBSIDIAN_CHUNK_SOURCE_TYPES.flatMap(
+			(sourceType) =>
+				db
+					.prepare(
+						"SELECT id, source_type, content_hash FROM embeddings WHERE source_type = ? AND source_id >= ? AND source_id < ? AND agent_id = ?",
+					)
+					.all(sourceType, prefix, prefixUpperBound(prefix), input.agentId) as Array<{
+					id: string;
+					source_type: string;
+					content_hash: string;
+				}>,
 		);
 		const staleIds = stale
 			.filter((row) => row.source_type === LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE || !currentHashes.has(row.content_hash))

--- a/platform/daemon/src/pipeline/decision.ts
+++ b/platform/daemon/src/pipeline/decision.ts
@@ -11,6 +11,7 @@ import { DECISION_ACTIONS, buildFtsMatchQuery, type DecisionAction, type Extract
 import { type DbAccessor, isVectorRuntimeUsable } from "../db-accessor";
 import { logger } from "../logger";
 import type { EmbeddingConfig, MemorySearchConfig } from "../memory-config";
+import type { EmbeddingRole } from "../embedding-profile";
 import type { LlmProvider } from "./provider";
 
 // ---------------------------------------------------------------------------
@@ -34,7 +35,7 @@ export interface DecisionConfig {
 	readonly embedding: EmbeddingConfig;
 	readonly search: MemorySearchConfig;
 	readonly timeoutMs?: number;
-	readonly fetchEmbedding: (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>;
+	readonly fetchEmbedding: (text: string, cfg: EmbeddingConfig, role?: EmbeddingRole) => Promise<number[] | null>;
 }
 
 export interface FactDecisionProposal {
@@ -112,7 +113,7 @@ async function findCandidatesVector(
 	const vectorLimit =
 		scope.scope !== null || scope.visibility !== "global" ? limit * VECTOR_OVERFETCH_MULTIPLIER : limit;
 	try {
-		const queryVec = await cfg.fetchEmbedding(query, cfg.embedding);
+		const queryVec = await cfg.fetchEmbedding(query, cfg.embedding, "query");
 		if (queryVec) {
 			const qf32 = new Float32Array(queryVec);
 			accessor.withReadDb((db) => {

--- a/platform/daemon/src/pipeline/document-worker.ts
+++ b/platform/daemon/src/pipeline/document-worker.ts
@@ -12,6 +12,7 @@
 import { normalizeAndHashContent } from "../content-normalization";
 import type { DbAccessor, WriteDb } from "../db-accessor";
 import { syncVecInsert, vectorToBlob } from "../db-helpers";
+import { isActiveEmbeddingConfig } from "../embedding-index-state";
 import { logger } from "../logger";
 import type { EmbeddingConfig, PipelineV2Config } from "../memory-config";
 import { txIngestEnvelope } from "../transactions";
@@ -308,6 +309,7 @@ async function processDocument(deps: DocumentWorkerDeps, job: DocumentJobRow): P
 				return;
 			}
 			const normalized = normalizeAndHashContent(chunkText);
+			const canStoreVector = vector !== null && isActiveEmbeddingConfig(db, embeddingCfg);
 
 			// Dedup: skip if exact content already linked to this document
 			const existingLink = db
@@ -353,7 +355,7 @@ async function processDocument(deps: DocumentWorkerDeps, job: DocumentJobRow): P
 					pinned: 0,
 					isDeleted: 0,
 					extractionStatus: "none",
-					embeddingModel: vector ? embeddingCfg.model : null,
+					embeddingModel: canStoreVector ? embeddingCfg.model : null,
 					extractionModel: null,
 					updatedBy: "document-worker",
 					sourceType: "document",
@@ -372,7 +374,7 @@ async function processDocument(deps: DocumentWorkerDeps, job: DocumentJobRow): P
 			).run(docId, memId, i);
 
 			// Store embedding if we got one (with dimension validation)
-			if (vector) {
+			if (canStoreVector && vector) {
 				if (vector.length !== embeddingCfg.dimensions) {
 					logger.warn("document-worker", "Embedding dimension mismatch, skipping vector insert", {
 						got: vector.length,

--- a/platform/daemon/src/pipeline/extraction-thread.ts
+++ b/platform/daemon/src/pipeline/extraction-thread.ts
@@ -184,7 +184,7 @@ async function bootstrap(): Promise<void> {
 			embedding: embeddingCfg,
 			search: searchCfg,
 			timeoutMs: pipelineCfg.extraction.timeout,
-			fetchEmbedding: (text: string, cfg: EmbeddingConfig) => fetchEmbedding(text, cfg),
+			fetchEmbedding: (text: string, cfg: EmbeddingConfig, role) => fetchEmbedding(text, cfg, role),
 		};
 
 		// 4. Start extraction worker with IPC-backed instrumentation

--- a/platform/daemon/src/pipeline/index.ts
+++ b/platform/daemon/src/pipeline/index.ts
@@ -7,6 +7,7 @@ import type { DbAccessor } from "../db-accessor";
 import type { ProviderTracker } from "../diagnostics";
 import { getLlmProvider } from "../llm";
 import { logger } from "../logger";
+import type { EmbeddingRole } from "../embedding-profile";
 import type { EmbeddingConfig, MemorySearchConfig, PipelineV2Config } from "../memory-config";
 import type { TelemetryCollector } from "../telemetry";
 import type { DecisionConfig } from "./decision";
@@ -236,7 +237,7 @@ export function startPipeline(
 	accessor: DbAccessor,
 	pipelineCfg: PipelineV2Config,
 	embeddingCfg: EmbeddingConfig,
-	fetchEmbedding: (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>,
+	fetchEmbedding: (text: string, cfg: EmbeddingConfig, role?: EmbeddingRole) => Promise<number[] | null>,
 	searchCfg: MemorySearchConfig,
 	agentId: string,
 	providerTracker?: ProviderTracker,

--- a/platform/daemon/src/pipeline/skill-graph.ts
+++ b/platform/daemon/src/pipeline/skill-graph.ts
@@ -12,6 +12,7 @@
 import { createHash } from "node:crypto";
 import type { DbAccessor, WriteDb } from "../db-accessor";
 import { syncVecDeleteByEmbeddingIds, syncVecInsert, vectorToBlob } from "../db-helpers";
+import { isActiveEmbeddingConfig, resolveActiveEmbeddingConfig } from "../embedding-index-state";
 import { logger } from "../logger";
 import type { EmbeddingConfig, PipelineV2Config } from "../memory-config";
 import { extractFactsAndEntities } from "./extraction";
@@ -277,14 +278,16 @@ export async function installSkillNode(
 	// Step 3: Generate embedding from enriched frontmatter
 	let embeddingCreated = false;
 	const embeddingText = buildEmbeddingText(fm);
-	const embVec = await fetchEmbedding(embeddingText, embeddingCfg);
+	const writeConfig = accessor.withReadDb((db) => resolveActiveEmbeddingConfig(db, embeddingCfg));
+	const embVec = await fetchEmbedding(embeddingText, writeConfig);
 
 	if (embVec && embVec.length > 0) {
 		const embId = crypto.randomUUID();
 		const blob = vectorToBlob(embVec);
 		const embHash = skillEmbeddingHash(entityId, input.frontmatter);
 
-		accessor.withWriteTx((db) => {
+		embeddingCreated = accessor.withWriteTx((db) => {
+			if (!isActiveEmbeddingConfig(db, writeConfig)) return false;
 			// Remove any old skill embeddings
 			const oldEmbs = db
 				.prepare(`SELECT id FROM embeddings WHERE source_type = 'skill' AND source_id = ?`)
@@ -314,9 +317,8 @@ export async function installSkillNode(
 			// existing id, not the one we generated above.
 			const actualRow = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(embHash) as { id: string };
 			syncVecInsert(db, actualRow.id, embVec);
+			return true;
 		});
-
-		embeddingCreated = true;
 	}
 
 	// Step 4: Extract entities from SKILL.md body for graph relations

--- a/platform/daemon/src/pipeline/worker.ts
+++ b/platform/daemon/src/pipeline/worker.ts
@@ -12,8 +12,9 @@ import type { AnalyticsCollector } from "../analytics";
 import { normalizeAndHashContent } from "../content-normalization";
 import type { DbAccessor, WriteDb } from "../db-accessor";
 import { countChanges, syncVecDeleteBySourceExceptHash, syncVecInsert, vectorToBlob } from "../db-helpers";
+import { isActiveEmbeddingConfig } from "../embedding-index-state";
 import { logger } from "../logger";
-import type { PipelineV2Config } from "../memory-config";
+import type { EmbeddingConfig, PipelineV2Config } from "../memory-config";
 import type { TelemetryCollector } from "../telemetry";
 import { txForgetMemory, txIngestEnvelope, txModifyMemory } from "../transactions";
 import { PROSPECTIVE_ANTONYM_PAIRS, hasAntonymConflict, hasNegation, overlapCount, tokenize } from "./antonyms";
@@ -364,8 +365,10 @@ function insertMemoryEmbedding(
 	content: string,
 	vector: readonly number[],
 	now: string,
+	embeddingConfig: EmbeddingConfig,
 	expectedDimensions?: number,
 ): boolean {
+	if (!isActiveEmbeddingConfig(db, embeddingConfig)) return false;
 	if (expectedDimensions !== undefined && vector.length !== expectedDimensions) {
 		logger.warn("pipeline", "Embedding dimension mismatch, skipping vector insert", {
 			got: vector.length,
@@ -416,6 +419,7 @@ function applyPhaseCWrites(
 		readonly minFactConfidenceForWrite: number;
 		readonly allowUpdateDelete: boolean;
 		readonly expectedEmbeddingDimensions: number;
+		readonly embeddingConfig: EmbeddingConfig;
 		readonly sourceAgentId: string;
 		readonly sourceProject: string | null;
 		readonly sourceScope: string | null;
@@ -630,6 +634,7 @@ function applyPhaseCWrites(
 					storageContent,
 					vector,
 					now,
+					meta.embeddingConfig,
 					meta.expectedEmbeddingDimensions,
 				);
 				if (insertedEmbedding) {
@@ -727,6 +732,7 @@ function applyPhaseCWrites(
 					extractionModelOnContentChange: meta.extractionModel,
 					embeddingModelOnContentChange: vector ? meta.embeddingModel : null,
 					embeddingVector: vector,
+					embeddingConfig: meta.embeddingConfig,
 					ctx: { actorType: "pipeline" },
 				});
 
@@ -1361,6 +1367,7 @@ export function startWorker(
 						minFactConfidenceForWrite: extractionCfg.minConfidence,
 						allowUpdateDelete: autonomousCfg.allowUpdateDelete,
 						expectedEmbeddingDimensions: decisionCfg.embedding.dimensions,
+						embeddingConfig: decisionCfg.embedding,
 						sourceAgentId: agentId,
 						sourceProject,
 						sourceScope,

--- a/platform/daemon/src/prompt-entity-context.ts
+++ b/platform/daemon/src/prompt-entity-context.ts
@@ -4,9 +4,10 @@ import { selectWithBudgetSkippingOversized } from "./context-budget";
 import { type ReadDb, getDbAccessor, hasDbAccessor } from "./db-accessor";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
+import type { EmbeddingRole } from "./embedding-profile";
 import { countPromptTermOverlap, extractSubstantiveWords, stripUntrustedMetadata } from "./prompt-text";
 
-type FetchEmbedding = (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>;
+type FetchEmbedding = (text: string, cfg: EmbeddingConfig, role?: EmbeddingRole) => Promise<number[] | null>;
 
 type PromptEntityMatch = {
 	readonly entityId: string;
@@ -665,7 +666,7 @@ export async function buildEntityPromptContext({
 		if (!semanticQuery) continue;
 		let queryVector: Float32Array | null = null;
 		try {
-			const vector = await fetchEmbedding(semanticQuery, embedding);
+			const vector = await fetchEmbedding(semanticQuery, embedding, "query");
 			if (vector) queryVector = new Float32Array(vector);
 		} catch (error) {
 			logger.warn("hooks", "Entity attribute semantic scoring failed; using lexical attribute scoring", {

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -12,6 +12,12 @@ import { type ReadDb, type WriteDb, getDbAccessor, prepareTypedStatement } from 
 import { syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "../db-helpers";
 import { fetchEmbedding } from "../embedding-fetch";
 import { buildEmbeddingHealth } from "../embedding-health";
+import {
+	isActiveEmbeddingConfig,
+	readEmbeddingIndexState,
+	resolveActiveEmbeddingConfig,
+} from "../embedding-index-state";
+import { stagingCoverage } from "../embedding-index-migration";
 import { getInferenceRouterOrNull } from "../inference-router";
 import { linkMemoryToEntities } from "../inline-entity-linker";
 import { logger } from "../logger";
@@ -43,6 +49,7 @@ import {
 	projectionInFlight,
 	queueExtractionJob,
 } from "./state";
+
 import {
 	type FilterParams,
 	type ForgetCandidatesRequest,
@@ -77,6 +84,10 @@ import {
 	toRecord,
 	validateSessionAgentBinding,
 } from "./utils";
+
+function withActiveEmbeddingConfig(cfg: ResolvedMemoryConfig): ResolvedMemoryConfig {
+	return { ...cfg, embedding: getDbAccessor().withReadDb((db) => resolveActiveEmbeddingConfig(db, cfg.embedding)) };
+}
 
 const MAX_MUTATION_BATCH = 200;
 const FORGET_CONFIRM_THRESHOLD = 25;
@@ -1197,7 +1208,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		}
 
 		// Pipeline v2 kill switch: refuse writes when mutations are frozen
-		const fullCfg = loadMemoryConfig(AGENTS_DIR);
+		const fullCfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		const pipelineCfg = fullCfg.pipelineV2;
 		if (pipelineCfg.mutationsFrozen) {
 			return c.json({ error: "Mutations are frozen (kill switch active)" }, 503);
@@ -1424,6 +1435,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 								const blob = vectorToBlob(vec);
 								const embHash = scope ? `${plan.normalized.contentHash}:${scope}` : plan.normalized.contentHash;
 								getDbAccessor().withWriteTx((db) => {
+									if (!isActiveEmbeddingConfig(db, fullCfg.embedding)) return;
 									syncVecDeleteBySourceId(db, "memory", chunkId);
 									db.prepare(`DELETE FROM embeddings WHERE source_type = 'memory' AND source_id = ?`).run(chunkId);
 									db.prepare(`
@@ -1647,7 +1659,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		// Generate embedding asynchronously
 		let embedded = false;
 		try {
-			const cfg = loadMemoryConfig(AGENTS_DIR);
+			const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 			const vec = await fetchEmbedding(normalizedContent.storageContent, cfg.embedding);
 			if (vec) {
 				if (vec.length !== cfg.embedding.dimensions) {
@@ -1662,6 +1674,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					const embId = crypto.randomUUID();
 
 					getDbAccessor().withWriteTx((db) => {
+						if (!isActiveEmbeddingConfig(db, cfg.embedding)) return;
 						syncVecDeleteBySourceId(db, "memory", id);
 						db.prepare(`DELETE FROM embeddings WHERE source_type = 'memory' AND source_id = ?`).run(id);
 						db.prepare(`
@@ -2124,7 +2137,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		}
 		const ifVersion = ifVersionBody ?? ifVersionQuery;
 
-		const cfg = loadMemoryConfig(AGENTS_DIR);
+		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		if (cfg.pipelineV2.mutationsFrozen) {
 			return c.json({ error: "Mutations are frozen (kill switch active)" }, 503);
 		}
@@ -2219,7 +2232,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			return c.json({ error: parsedPatch.error }, 400);
 		}
 
-		const cfg = loadMemoryConfig(AGENTS_DIR);
+		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		if (cfg.pipelineV2.mutationsFrozen) {
 			return c.json({ error: "Mutations are frozen (kill switch active)" }, 503);
 		}
@@ -2243,6 +2256,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				extractionModelOnContentChange: null,
 				embeddingModelOnContentChange: cfg.embedding.model,
 				embeddingVector,
+				embeddingConfig: cfg.embedding,
 				ctx: actor,
 			}),
 		);
@@ -2341,7 +2355,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		}
 		const ifVersion = ifVersionBody ?? ifVersionQuery;
 
-		const cfg = loadMemoryConfig(AGENTS_DIR);
+		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		if (cfg.pipelineV2.mutationsFrozen) {
 			return c.json({ error: "Mutations are frozen (kill switch active)" }, 503);
 		}
@@ -2423,7 +2437,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const memoryId = c.req.param("id")?.trim();
 		if (!memoryId) return c.json({ error: "memory id is required" }, 400);
 
-		const cfg = loadMemoryConfig(AGENTS_DIR);
+		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		if (cfg.pipelineV2.mutationsFrozen) return c.json({ error: "Mutations are frozen (kill switch active)" }, 503);
 		const scopeDecision = authorizeMemoryMutationScope(c, [memoryId]);
 		if (scopeDecision.error) return c.json({ error: scopeDecision.error }, 403);
@@ -2684,7 +2698,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			}
 		}
 
-		const cfg = loadMemoryConfig(AGENTS_DIR);
+		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		if (cfg.pipelineV2.mutationsFrozen) {
 			return c.json({ error: "Mutations are frozen (kill switch active)" }, 503);
 		}
@@ -2746,7 +2760,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			);
 		}
 
-		const cfg = loadMemoryConfig(AGENTS_DIR);
+		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		if (cfg.pipelineV2.mutationsFrozen) {
 			return c.json({ error: "Mutations are frozen (kill switch active)" }, 503);
 		}
@@ -2835,6 +2849,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					extractionModelOnContentChange: null,
 					embeddingModelOnContentChange: cfg.embedding.model,
 					embeddingVector,
+					embeddingConfig: cfg.embedding,
 					ctx: actor,
 				}),
 			);
@@ -2885,7 +2900,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			if (denied) return denied;
 		}
 
-		const cfg = loadMemoryConfig(AGENTS_DIR);
+		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		if (
 			((cfg.pipelineV2.reranker.enabled && cfg.pipelineV2.reranker.useExtractionModel) || body.aggregate === true) &&
 			authConfig.mode !== "local"
@@ -2983,7 +2998,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const project = c.req.query("project");
 		const includeRecalled = c.req.query("includeRecalled") ?? c.req.query("include_recalled");
 
-		const cfg = loadMemoryConfig(AGENTS_DIR);
+		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		const scopeProject = c.get("auth")?.claims?.scope?.project;
 		try {
 			const sessionKeyRaw =
@@ -3241,10 +3256,14 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	// GET /api/embeddings/status
 	// =========================================================================
 	app.get("/api/embeddings/status", async (c) => {
-		const config = loadMemoryConfig(AGENTS_DIR);
+		const config = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		const status = await checkEmbeddingProvider(config.embedding);
 		const tracker = embeddingTrackerHandle?.getStats() ?? null;
-		return c.json({ ...status, tracker });
+		const index = getDbAccessor().withReadDb((db) => {
+			const state = readEmbeddingIndexState(db);
+			return state?.staging ? { ...state, coverage: stagingCoverage(db, state.staging.dimensions) } : state;
+		});
+		return c.json({ ...status, tracker, index });
 	});
 
 	// =========================================================================

--- a/platform/daemon/src/routes/utils.ts
+++ b/platform/daemon/src/routes/utils.ts
@@ -892,12 +892,28 @@ export function parseModifyPatch(
 export let cachedEmbeddingStatus: EmbeddingStatus | null = null;
 export let statusCacheTime = 0;
 export const STATUS_CACHE_TTL = 30000;
+const embeddingStatusCache = new Map<string, { readonly status: EmbeddingStatus; readonly checkedAt: number }>();
+
+function embeddingStatusCacheKey(cfg: EmbeddingConfig): string {
+	return `${cfg.provider}\u0000${cfg.model}\u0000${resolveEmbeddingBaseUrl(cfg)}`;
+}
+
+function cacheEmbeddingStatus(key: string, status: EmbeddingStatus, now: number): void {
+	embeddingStatusCache.set(key, { status, checkedAt: now });
+	// Preserve the existing exported latest-status diagnostics surface.
+	cachedEmbeddingStatus = status;
+	statusCacheTime = now;
+}
 
 export async function checkEmbeddingProvider(cfg: EmbeddingConfig): Promise<EmbeddingStatus> {
 	const now = Date.now();
+	const cacheKey = embeddingStatusCacheKey(cfg);
+	const cached = embeddingStatusCache.get(cacheKey);
 
-	if (cachedEmbeddingStatus && now - statusCacheTime < STATUS_CACHE_TTL) {
-		return cachedEmbeddingStatus;
+	if (cached && now - cached.checkedAt < STATUS_CACHE_TTL) {
+		cachedEmbeddingStatus = cached.status;
+		statusCacheTime = cached.checkedAt;
+		return cached.status;
 	}
 
 	const status: EmbeddingStatus = {
@@ -911,8 +927,7 @@ export async function checkEmbeddingProvider(cfg: EmbeddingConfig): Promise<Embe
 	if (cfg.provider === "none") {
 		status.available = false;
 		status.error = "Embedding provider set to 'none' — vector search disabled";
-		cachedEmbeddingStatus = status;
-		statusCacheTime = now;
+		cacheEmbeddingStatus(cacheKey, status, now);
 		return status;
 	}
 
@@ -1008,8 +1023,7 @@ export async function checkEmbeddingProvider(cfg: EmbeddingConfig): Promise<Embe
 			const apiKey = await resolveEmbeddingApiKey(cfg.api_key);
 			if (!apiKey) {
 				status.error = "Missing OpenAI API key";
-				cachedEmbeddingStatus = status;
-				statusCacheTime = now;
+				cacheEmbeddingStatus(cacheKey, status, now);
 				return status;
 			}
 			const testResult = await fetchEmbedding("test", cfg);
@@ -1024,8 +1038,7 @@ export async function checkEmbeddingProvider(cfg: EmbeddingConfig): Promise<Embe
 		status.error = err instanceof Error ? err.message : "Unknown error";
 	}
 
-	cachedEmbeddingStatus = status;
-	statusCacheTime = now;
+	cacheEmbeddingStatus(cacheKey, status, now);
 	return status;
 }
 

--- a/platform/daemon/src/transactions.ts
+++ b/platform/daemon/src/transactions.ts
@@ -7,7 +7,15 @@
  */
 
 import type { WriteDb } from "./db-accessor";
-import { syncVecDeleteBySourceExceptHash, syncVecDeleteBySourceId, syncVecInsert, tableExists, vectorToBlob } from "./db-helpers";
+import {
+	syncVecDeleteBySourceExceptHash,
+	syncVecDeleteBySourceId,
+	syncVecInsert,
+	tableExists,
+	vectorToBlob,
+} from "./db-helpers";
+import { isActiveEmbeddingConfig } from "./embedding-index-state";
+import type { EmbeddingConfig } from "./memory-config";
 import { cancelExtractionJobsForForgottenMemory } from "./pipeline/extraction-queue";
 
 // ---------------------------------------------------------------------------
@@ -89,6 +97,8 @@ export interface ModifyMemoryTxInput {
 	extractionModelOnContentChange?: string | null;
 	embeddingModelOnContentChange?: string | null;
 	embeddingVector?: readonly number[] | null;
+	/** Generation that produced embeddingVector, when the caller has one. */
+	embeddingConfig?: EmbeddingConfig;
 	ctx?: MutationContext;
 }
 
@@ -337,6 +347,9 @@ export function txModifyMemory(db: WriteDb, input: ModifyMemoryTxInput): ModifyM
 	let contentChanged = false;
 	let finalContent = existing.content;
 
+	const embeddingGenerationActive =
+		!input.embeddingVector || input.embeddingConfig === undefined || isActiveEmbeddingConfig(db, input.embeddingConfig);
+
 	if (input.patch.content !== undefined && input.patch.content !== existing.content) {
 		contentChanged = true;
 		finalContent = input.patch.content;
@@ -384,7 +397,9 @@ export function txModifyMemory(db: WriteDb, input: ModifyMemoryTxInput): ModifyM
 		args.push(input.extractionModelOnContentChange ?? null);
 		updates.push("embedding_model = ?");
 		args.push(
-			input.embeddingVector && input.embeddingVector.length > 0 ? (input.embeddingModelOnContentChange ?? null) : null,
+			input.embeddingVector && input.embeddingVector.length > 0 && embeddingGenerationActive
+				? (input.embeddingModelOnContentChange ?? null)
+				: null,
 		);
 		changedFields.push("content");
 	}
@@ -447,7 +462,7 @@ export function txModifyMemory(db: WriteDb, input: ModifyMemoryTxInput): ModifyM
 			).run(input.memoryId);
 		}
 
-		if (newHash && input.embeddingVector && input.embeddingVector.length > 0) {
+		if (newHash && input.embeddingVector && input.embeddingVector.length > 0 && embeddingGenerationActive) {
 			const embId = crypto.randomUUID();
 			const blob = vectorToBlob(input.embeddingVector);
 			db.prepare(


### PR DESCRIPTION
## Summary

Adds automatic, zero-downtime embedding-index migrations. Signet keeps the active vector space online while it re-embeds a complete inactive generation, then atomically promotes it only after coverage validation.

## Changes

- Add active/staging embedding generation state and durable staging storage migrations.
- Apply role-aware document/query formatting for known Nomic and Qwen retrieval profiles.
- Re-embed every active embedding row, including source chunks, into a dimension-safe staging vec0 index.
- Promote only complete staging coverage, rebuild sqlite-vec atomically, and preserve active recall on failure.
- Guard concurrent embedding writers against generation changes and expose migration coverage in embedding status.
- Document the background migration lifecycle and repair production TypeScript narrowing in aggregate recall and embedding state/migration startup.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

The status route remains the existing recall-permission GET endpoint; this PR adds no admin or mutation endpoint. `docs/specs/INDEX.md` and `docs/specs/dependencies.yaml` were reviewed; this is not an ontology schema change.

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

The active index remains readable until staging has complete, correctly dimensioned coverage. Failed staging work records its error and leaves the active generation untouched. The former active durable rows occupy the inactive slot after promotion; sqlite-vec is rebuilt from promoted BLOB rows because virtual-table renames do not preserve sqlite-vec backing-table bindings.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused verification passed: production daemon `npx tsc --noEmit`; Biome check for all changed daemon files; `embedding-index-state`, `embedding-index-migration`, `aggregate-recall`, and `memory-search` suites (83 tests); plus the earlier focused migration/write-path suite. `@signet/core` builds successfully.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Default embedding model and retrieval scoring calibration are unchanged.
