### PR TITLE
fix(daemon): persist memory embeddings across startup index promotion

### DIFF
--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -1208,7 +1208,8 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		}
 
 		// Pipeline v2 kill switch: refuse writes when mutations are frozen
-		const fullCfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
+		const fullCfgBase = loadMemoryConfig(AGENTS_DIR);
+		const fullCfg = withActiveEmbeddingConfig(fullCfgBase);
 		const pipelineCfg = fullCfg.pipelineV2;
 		if (pipelineCfg.mutationsFrozen) {
 			return c.json({ error: "Mutations are frozen (kill switch active)" }, 503);
@@ -1435,7 +1436,8 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 								const blob = vectorToBlob(vec);
 								const embHash = scope ? `${plan.normalized.contentHash}:${scope}` : plan.normalized.contentHash;
 								getDbAccessor().withWriteTx((db) => {
-									if (!isActiveEmbeddingConfig(db, fullCfg.embedding)) return;
+									const activeCfg = resolveActiveEmbeddingConfig(db, fullCfgBase.embedding);
+									if (!isActiveEmbeddingConfig(db, activeCfg)) return;
 									syncVecDeleteBySourceId(db, "memory", chunkId);
 									db.prepare(`DELETE FROM embeddings WHERE source_type = 'memory' AND source_id = ?`).run(chunkId);
 									db.prepare(`
@@ -1659,7 +1661,8 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		// Generate embedding asynchronously
 		let embedded = false;
 		try {
-			const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
+			const baseCfg = loadMemoryConfig(AGENTS_DIR);
+			const cfg = withActiveEmbeddingConfig(baseCfg);
 			const vec = await fetchEmbedding(normalizedContent.storageContent, cfg.embedding);
 			if (vec) {
 				if (vec.length !== cfg.embedding.dimensions) {
@@ -1673,8 +1676,14 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					const blob = vectorToBlob(vec);
 					const embId = crypto.randomUUID();
 
-					getDbAccessor().withWriteTx((db) => {
-						if (!isActiveEmbeddingConfig(db, cfg.embedding)) return;
+					// Re-resolve the active embedding config and gate on it inside the same
+					// transaction. Previously the config was resolved once (before the model
+					// call) and re-checked later, so a startup building->ready promotion
+					// between the two could skip the insert while still reporting
+					// embedded=true. `embedded` now reflects whether the vector was written.
+					embedded = getDbAccessor().withWriteTx((db) => {
+						const activeCfg = resolveActiveEmbeddingConfig(db, baseCfg.embedding);
+						if (!isActiveEmbeddingConfig(db, activeCfg)) return false;
 						syncVecDeleteBySourceId(db, "memory", id);
 						db.prepare(`DELETE FROM embeddings WHERE source_type = 'memory' AND source_id = ?`).run(id);
 						db.prepare(`
@@ -1684,8 +1693,8 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						`).run(embId, embHash, blob, vec.length, id, normalizedContent.storageContent, now);
 						syncVecInsert(db, embId, vec);
 						db.prepare("UPDATE memories SET embedding_model = ? WHERE id = ?").run(cfg.embedding.model, id);
+						return true;
 					});
-					embedded = true;
 				}
 			}
 		} catch (e) {

--- a/platform/daemon/src/transactions.test.ts
+++ b/platform/daemon/src/transactions.test.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { runMigrations } from "../../core/src/migrations";
 import type { WriteDb } from "./db-accessor";
+import { beginEmbeddingIndexBuild, ensureEmbeddingIndexState } from "./embedding-index-state";
 import { txApplyDecision, txForgetMemory, txIngestEnvelope, txModifyMemory, txRecoverMemory } from "./transactions";
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
@@ -503,6 +504,59 @@ describe("transactions: txModifyMemory + txForgetMemory + txRecoverMemory", () =
 
 		const row = db.prepare("SELECT is_deleted FROM memories WHERE id = ?").get("mem-expired") as { is_deleted: number };
 		expect(row.is_deleted).toBe(1);
+	});
+
+	it("writes the embedding even when the caller's resolved config raced a building->ready promotion", () => {
+		// Regression: txModifyMemory re-resolves the active embedding config inside
+		// the transaction. Previously it checked the caller-supplied (already
+		// resolved) config, so a startup building->ready promotion between the
+		// caller's resolve and this write skipped the insert and silently dropped
+		// the vector (the API still reported embedded=true).
+		const embeddingConfig = {
+			provider: "native" as const,
+			model: "nomic-embed-text-v1.5",
+			dimensions: 768,
+			base_url: "",
+		};
+		ensureEmbeddingIndexState(asWriteDb(db), embeddingConfig);
+		db.exec(
+			"CREATE TABLE IF NOT EXISTS embeddings_staging (id TEXT PRIMARY KEY, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER, source_type TEXT, source_id TEXT, chunk_text TEXT, created_at TEXT, agent_id TEXT)",
+		);
+		beginEmbeddingIndexBuild(asWriteDb(db), embeddingConfig);
+		// Promote staging -> active, simulating the startup build completing so
+		// the active profile becomes the recommended nomic profile.
+		db.prepare(
+			"UPDATE embedding_index_state SET active_profile_json = staging_profile_json, staging_profile_json = NULL, state = 'ready' WHERE id = 1",
+		).run();
+
+		insertMemory(db, { id: "mem-race", content: "original content", contentHash: "hash-race-old" });
+
+		const result = txModifyMemory(asWriteDb(db), {
+			memoryId: "mem-race",
+			patch: {
+				content: "updated content",
+				normalizedContent: "updated content",
+				contentHash: "hash-race-new",
+			},
+			reason: "race regression",
+			changedBy: "test",
+			changedAt: new Date().toISOString(),
+			embeddingVector: new Array(768).fill(0.1),
+			embeddingModelOnContentChange: "nomic-embed-text-v1.5",
+			extractionStatusOnContentChange: "none",
+			extractionModelOnContentChange: null,
+			// Stale: caller resolved this during building (no profile -> identity),
+			// but active is now the promoted nomic profile. Without the in-tx
+			// re-resolve this write would be skipped.
+			embeddingConfig: { ...embeddingConfig, profile: undefined },
+		});
+
+		expect(result.status).toBe("updated");
+		expect(result.contentChanged).toBe(true);
+		const row = db
+			.prepare("SELECT dimensions FROM embeddings WHERE source_type = 'memory' AND source_id = ?")
+			.get("mem-race") as { dimensions?: number } | undefined;
+		expect(row?.dimensions).toBe(768);
 	});
 });
 

--- a/platform/daemon/src/transactions.ts
+++ b/platform/daemon/src/transactions.ts
@@ -14,7 +14,7 @@ import {
 	tableExists,
 	vectorToBlob,
 } from "./db-helpers";
-import { isActiveEmbeddingConfig } from "./embedding-index-state";
+import { isActiveEmbeddingConfig, resolveActiveEmbeddingConfig } from "./embedding-index-state";
 import type { EmbeddingConfig } from "./memory-config";
 import { cancelExtractionJobsForForgottenMemory } from "./pipeline/extraction-queue";
 
@@ -347,8 +347,17 @@ export function txModifyMemory(db: WriteDb, input: ModifyMemoryTxInput): ModifyM
 	let contentChanged = false;
 	let finalContent = existing.content;
 
+	// Re-resolve the active embedding config inside this transaction so the
+	// active-config check cannot race a startup building->ready promotion: the
+	// caller resolves the config before the (slow) model call, and the index can
+	// promote before this write. Strip the pre-resolved profile so it re-reads
+	// the current active state.
+	const activeEmbeddingCfg =
+		input.embeddingConfig === undefined
+			? undefined
+			: resolveActiveEmbeddingConfig(db, { ...input.embeddingConfig, profile: undefined });
 	const embeddingGenerationActive =
-		!input.embeddingVector || input.embeddingConfig === undefined || isActiveEmbeddingConfig(db, input.embeddingConfig);
+		!input.embeddingVector || activeEmbeddingCfg === undefined || isActiveEmbeddingConfig(db, activeEmbeddingCfg);
 
 	if (input.patch.content !== undefined && input.patch.content !== existing.content) {
 		contentChanged = true;


### PR DESCRIPTION
## Summary

Fixes a race that silently dropped memory embeddings during daemon startup, breaking semantic recall for any memory saved in the startup window. This is the **pre-existing `build-native` smoke failure** that surfaced on the daemon-rs removal merge (it's unrelated to that merge — see "Why now" below).

## Root cause

A TOCTOU (time-of-check-time-of-use) race in the embedding write path.

On startup the embedding index is seeded in state **`building`** (active profile = identity `custom:native:…`) and asynchronously **promoted to `ready`** (active profile = `nomic-embed-text-v1.5`) once the model loads. The `remember` handler did:

1. `cfg = withActiveEmbeddingConfig(loadMemoryConfig(...))` — resolved `cfg.embedding.profile` from the active state.
2. `await fetchEmbedding(...)` — the slow model call (several seconds).
3. inside `withWriteTx`: `if (!isActiveEmbeddingConfig(db, cfg.embedding)) return;` — re-checked against the active state.

If the `building→ready` promotion happened between steps 1 and 3, the cfg fingerprint (locked at step 1) no longer matched the active fingerprint → the `INSERT INTO embeddings` was **skipped**. Worse, `embedded = true` was set *after* `withWriteTx` regardless of whether the callback early-returned, so the API reported `embedded:true` while **no vector row existed**.

The same `resolve-once / check-later` split existed in the auto-chunk handler and in `txModifyMemory` (which backs both `/modify` routes).

## Reproduction

Posting `remember` immediately after `/health` (the smoke test's timing):
```
RESULT embedded=true row=null          ← bug
STATE=ready  ACTIVE profile="nomic-embed-text-v1.5"   (promotion already completed by the time we observe)
```
Waiting for the index to settle before `remember` → row present (dimensions 768). So it's purely the startup promotion window.

## The fix (belt and suspenders)

1. **Eliminate the TOCTOU** — re-resolve the active embedding config *inside* each write transaction, so resolution and the `isActiveEmbeddingConfig` check read the same state. Applied to:
   - `routes/memory-routes.ts` — `remember` handler + auto-chunk handler
   - `transactions.ts` — `txModifyMemory` (covers both modify routes)
2. **Stop the lie** — `embedded` now reflects whether the vector was actually written (the `remember` handler returns the boolean from `withWriteTx`).

## Verification

- ✅ The previously-failing smoke test **`compiled native embedding runtime > embeds and recalls a fixed sentence through the compiled native binary`** now **passes** (7/7) against a rebuilt native binary.
- ✅ New regression test in `transactions.test.ts` promotes the index `building→ready` between resolve and write — **fails without the fix** (`Expected: 768, Received: undefined`), **passes with it**.
- ✅ `bun run typecheck` green; `bun run lint` introduces zero new errors vs `main`.
- ✅ Daemon `transactions` + `embedding-index-state` suites: 22 pass / 0 fail.

## Why now

`build-native` is gated on `if: needs.release.outputs.version != ''`. Recent docs-only pushes skipped it; the daemon-rs removal touched real code → produced a version → `build-native` ran → exposed this latent race. Reproduces on `d61e2ff7a` (pre-removal). Independent of the daemon-rs work.

## Notes

- The `embedded = true`-regardless lie is fixed at the `remember` site; the dedup fast-paths that also set `embedded: true` are out of scope (they assume the existing memory already has a vector — a separate assumption, not this race).
- The `building→ready` transition is normal daemon startup behavior; this fix ensures writes that straddle it are persisted rather than silently dropped.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec changes; bug fix only.
- [x] Agent scoping verified on all new/changed data queries — no new queries; existing scoping unchanged.
- [x] Input/config validation and bounds checks added — N/A (no new inputs; fixes a write-path race).
- [x] Error handling and fallback paths tested (no silent swallow) — this fix removes a silent drop; `embedded` now reflects the actual write.
- [x] Security checks applied to admin/mutation endpoints — no endpoint surface change.
- [x] Docs updated for API/spec/status changes — N/A (internal fix, no API/behavior contract change).
- [x] Regression tests added for each bug fix — yes: `transactions.test.ts` race test + the existing native smoke test (now green).
- [x] Lint/typecheck/tests pass locally.

## AI disclosure

- [x] AI tools were used (see `Assisted-by: pi:glm-5.2` tag in the commit)
