### PR TITLE
fix(cli): close hook stdin after read timeout

### DIFF
--- a/surfaces/cli/src/commands/hook.test.ts
+++ b/surfaces/cli/src/commands/hook.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Readable } from "node:stream";
 import { Command } from "commander";
 import {
 	buildCodexHookOutput,
@@ -8,6 +9,7 @@ import {
 	buildSessionStartFallback,
 	buildUserPromptSubmitBody,
 	pickSessionKey,
+	readJson,
 	registerHookCommands,
 	resolvePromptSubmitTimeout,
 	resolveSessionStartTimeout,
@@ -658,6 +660,16 @@ describe("shouldReadCompactionInput", () => {
 				sessionKey: "sess-1",
 			}),
 		).toBeFalse();
+	});
+});
+
+describe("readJson cleanup", () => {
+	test("closes stdin after the timeout so an abandoned hook cannot keep running", async () => {
+		const input = new Readable({ read() {} });
+
+		expect(await readJson(input)).toBeNull();
+		expect(input.destroyed).toBe(true);
+		expect(input.listenerCount("end")).toBe(0);
 	});
 });
 

--- a/surfaces/cli/src/commands/hook.ts
+++ b/surfaces/cli/src/commands/hook.ts
@@ -1,3 +1,4 @@
+import type { Readable } from "node:stream";
 import {
 	STATIC_IDENTITY_SESSION_START_TIMEOUT_STATUS,
 	resolvePromptSubmitTimeoutMs,
@@ -20,6 +21,11 @@ const SESSION_START_TIMEOUT_MS = resolveSessionStartTimeout();
 const PROMPT_SUBMIT_TIMEOUT_MS = resolvePromptSubmitTimeout();
 const LEGACY_RUNTIME_PATH = "legacy" as const;
 const STDIN_TIMEOUT_MS = 2000;
+
+type HookInput = Readable & {
+	readonly isTTY?: boolean;
+	unref?: () => void;
+};
 
 function legacyHookHeaders(headers?: HeadersInit): Headers {
 	const merged = new Headers(headers);
@@ -418,26 +424,35 @@ export function shouldReadCompactionInput(
 	return true;
 }
 
-async function readJson(): Promise<Record<string, unknown> | null> {
+export async function readJson(input: HookInput = process.stdin): Promise<Record<string, unknown> | null> {
+	if (input.isTTY) return null;
+	const chunks: Buffer[] = [];
+	const stdinDone = (async (): Promise<void> => {
+		for await (const chunk of input) {
+			chunks.push(chunk);
+		}
+	})();
 	try {
-		if (process.stdin.isTTY) return null;
-		const chunks: Buffer[] = [];
-		const stdinDone = (async (): Promise<void> => {
-			for await (const chunk of process.stdin) {
-				chunks.push(chunk);
-			}
-		})();
 		const timedOut = new Promise<never>((_, reject) => {
 			const timer = setTimeout(() => reject(new Error("stdin timeout")), STDIN_TIMEOUT_MS);
 			timer.unref();
 		});
 		await Promise.race([stdinDone, timedOut]);
-		const input = Buffer.concat(chunks).toString("utf-8").trim();
-		if (!input) return null;
-		const parsed = JSON.parse(input);
+		const rawInput = Buffer.concat(chunks).toString("utf-8").trim();
+		if (!rawInput) return null;
+		const parsed = JSON.parse(rawInput);
 		return toRecord(parsed);
 	} catch {
 		return null;
+	} finally {
+		// The stdin iterator survives a timeout unless the stream is explicitly
+		// closed. Hook processes are one-shot, so destroy it after consuming the
+		// available input and before waiting for the daemon.
+		input.pause();
+		input.destroy();
+		await stdinDone.catch(() => undefined);
+		input.removeAllListeners();
+		input.unref?.();
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #1061.

Hook commands now close their stdin stream after the bounded input read finishes. This prevents the async stdin iterator from surviving when a harness stops waiting or disappears.

## Changes

- Added deterministic stdin cleanup in `surfaces/cli/src/commands/hook.ts`.
- Destroyed the one-shot hook input stream, waited for the iterator to settle, then removed its listeners.
- Added a regression test that verifies timeout cleanup destroys the stream and removes the iterator listener.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A — CLI lifecycle fix; no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — N/A; no spec or data contract changed.
- [x] Agent scoping verified on all new/changed data queries — N/A; no data queries changed.
- [x] Input/config validation and bounds checks added — existing 2-second stdin bound is preserved.
- [x] Error handling and fallback paths tested (no silent swallow) — stream cleanup errors are isolated from hook results.
- [x] Security checks applied to admin/mutation endpoints — N/A; no endpoints changed.
- [x] Docs updated for API/spec/status changes — N/A; internal lifecycle behavior only.
- [x] Regression tests added for each bug fix.
- [x] Lint/typecheck/tests pass locally — focused test, build, and lint checks pass; baseline full-suite failures are documented below.

## Migration Notes (if applicable)

- [x] Migration is idempotent — N/A; no migration touched.
- [x] Rollback / compatibility note included in PR description — N/A; no schema or compatibility contract changed.

## Testing

- [x] `bun test surfaces/cli/src/commands/hook.test.ts` — 41 passed.
- [x] `biome check surfaces/cli/src/commands/hook.ts surfaces/cli/src/commands/hook.test.ts` — passed.
- [x] `bun build ./src/commands/hook.ts --outfile /tmp/signet-issue-1061-hook.js --target node --external better-sqlite3` — passed.
- [ ] `bun test` — the full CLI package has 21 pre-existing failures and 8 module-load errors; the parent revision has the same failures.
- [ ] `bun run typecheck` — not used as the focused check; the changed module builds successfully.
- [ ] Tested against running daemon.
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The new regression test fails against the parent revision because the timed-out input stream remains open. Two independent adversarial reviews using `gpt-5.6-luna` found no blockers.
