### PR TITLE
fix(update): prefer native install over wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,10 +180,12 @@ the native binary into place; if scripts are disabled, the wrapper resolves the
 native package directly. They do not install Bun, rebuild Signet, or install
 daemon dependencies.
 
-Choose one installation method per machine. `signet update install` preserves
-the active method, and `signet doctor` warns when an inactive package-manager
-wrapper coexists with a direct native install. Duplicate installs are never
-removed automatically.
+Choose one installation method per machine. `signet update install` uses a
+direct native install when it coexists with a package-manager wrapper, and
+`signet doctor` warns about the inactive wrapper. If a daemon is still running
+from another install, the native CLI rebinds it before starting or updating.
+Doctor's cleanup command removes only the duplicate launcher, not the package
+that may also provide `signet-mcp`.
 
 Published native binaries currently cover Linux x64, Linux arm64, macOS x64,
 macOS arm64, and Windows x64. Windows direct installs should use

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1017,11 +1017,12 @@ Subcommands:
 | `-i, --interval <seconds>` | Check interval in seconds (default: 21600; range: 300-604800) |
 
 After `signet update install` completes, a daemon restart is required to
-run the new version: `signet daemon restart`. The command updates the active
-install method rather than selecting another package manager from PATH. If a
-direct native install and an inactive npm/Bun/pnpm/Yarn wrapper coexist, the
-CLI prints the exact manual uninstall command after the update; `signet
-doctor` reports the same conflict. Signet never removes the duplicate
+run the new version: `signet daemon restart`. When a direct native install
+coexists with an npm/Bun/pnpm/Yarn wrapper, the updater uses the native binary
+instead of selecting a package manager from PATH. The CLI prints an exact
+command that removes only the duplicate launcher after the update; `signet
+doctor` reports the same conflict. Do not uninstall the whole package, because
+it may also provide `signet-mcp`. Signet never removes the duplicate
 automatically.
 
 ---

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -134,10 +134,12 @@ place; if scripts are disabled, the wrapper resolves the native package
 directly. They do not install Bun, rebuild Signet, or install daemon
 dependencies.
 
-Choose one installation method per machine. `signet update install` preserves
-the active method, and `signet doctor` warns when an inactive package-manager
-wrapper coexists with a direct native install. Duplicate installs are never
-removed automatically.
+Choose one installation method per machine. `signet update install` uses a
+direct native install when it coexists with a package-manager wrapper, and
+`signet doctor` warns about the inactive wrapper. If a daemon is still running
+from another install, the native CLI rebinds it before starting or updating.
+Doctor's cleanup command removes only the duplicate launcher, not the package
+that may also provide `signet-mcp`.
 
 Published native binaries currently cover Linux x64, Linux arm64, macOS x64,
 macOS arm64, and Windows x64. Windows direct installs should use

--- a/platform/core/src/signet-installation.test.ts
+++ b/platform/core/src/signet-installation.test.ts
@@ -36,7 +36,7 @@ describe("detectSignetInstallations", () => {
 				executablePath: npmBin,
 				packagePath: npmPackage,
 				active: false,
-				removalCommand: "npm uninstall -g signetai",
+				removalCommand: `rm -f -- '${npmBin}'`,
 			},
 		]);
 	});
@@ -100,7 +100,13 @@ describe("detectSignetInstallations", () => {
 		});
 
 		expect(report.target.kind).toBe("native");
-		expect(report.inactive).toMatchObject([{ method: "npm", executablePath: npmBin }]);
+		expect(report.inactive).toMatchObject([
+			{
+				method: "npm",
+				executablePath: npmBin,
+				removalCommand: `del /f /q "${npmBin}"`,
+			},
+		]);
 	});
 
 	it("recognizes the native package binary launched by a default Windows npm wrapper", () => {

--- a/platform/core/src/signet-installation.ts
+++ b/platform/core/src/signet-installation.ts
@@ -113,6 +113,17 @@ export function packageManagerRemovalCommand(family: PackageManagerFamily): stri
 	}
 }
 
+function quotePosix(value: string): string {
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function packageManagerEntryPointRemovalCommand(path: string, platform: NodeJS.Platform): string {
+	if (platform === "win32") {
+		return `del /f /q "${path.replaceAll('"', '""')}"`;
+	}
+	return `rm -f -- ${quotePosix(path)}`;
+}
+
 export function detectSignetInstallations(options: SignetInstallationDetectionOptions = {}): SignetInstallationReport {
 	const env = options.env ?? process.env;
 	const home = options.home ?? homedir();
@@ -172,7 +183,9 @@ export function detectSignetInstallations(options: SignetInstallationDetectionOp
 				executablePath: candidate.executablePath,
 				...(candidate.packagePath ? { packagePath: candidate.packagePath } : {}),
 				active: false,
-				...(method !== "native" ? { removalCommand: packageManagerRemovalCommand(method) } : {}),
+				...(method !== "native"
+					? { removalCommand: packageManagerEntryPointRemovalCommand(candidate.executablePath, platform) }
+					: {}),
 			},
 		];
 	});

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -45,8 +45,8 @@ import { listConnectors } from "./connectors/registry";
 import { clearAllPresence } from "./cross-agent";
 import { closeDbAccessor, getDbAccessor, getVectorRuntimeStatus, initDbAccessorAsync } from "./db-accessor";
 import { fetchEmbedding } from "./embedding-fetch";
-import { resolveActiveEmbeddingConfig } from "./embedding-index-state";
 import { type EmbeddingIndexMigrationHandle, startEmbeddingIndexMigration } from "./embedding-index-migration";
+import { resolveActiveEmbeddingConfig } from "./embedding-index-state";
 import { type EmbeddingTrackerHandle, startEmbeddingTracker } from "./embedding-tracker";
 import { firstCandidateBlockedBy } from "./extraction-status";
 import { initFeatureFlags } from "./feature-flags";
@@ -1916,7 +1916,7 @@ async function main() {
 	setCheckpointPruneTimer(checkpointPruneTimer);
 
 	startGitSyncTimer();
-	initUpdateSystem(CURRENT_VERSION, AGENTS_DIR, () => {
+	initUpdateSystem(CURRENT_VERSION, AGENTS_DIR, (preferredExecutablePath) => {
 		const daemonScript = process.argv[1] ?? "";
 		if (!daemonScript) {
 			logger.warn("daemon", "Cannot self-restart: process.argv[1] is empty, falling back to clean exit");
@@ -1927,11 +1927,11 @@ async function main() {
 		}
 
 		logger.info("daemon", "Spawning replacement daemon process", {
-			execPath: process.execPath,
+			execPath: preferredExecutablePath ?? process.execPath,
 			script: daemonScript,
 		});
 
-		const replacement = spawn(process.execPath, [daemonScript], {
+		const replacement = spawn(preferredExecutablePath ?? process.execPath, [daemonScript], {
 			detached: true,
 			stdio: "ignore",
 			windowsHide: true,

--- a/platform/daemon/src/update-system.test.ts
+++ b/platform/daemon/src/update-system.test.ts
@@ -27,6 +27,7 @@ import {
 	parseUpdateChannel,
 	parseUpdateInterval,
 	runUpdate,
+	selectUpdateTarget,
 	updateDesktopInstallAfterUpdate,
 } from "./update-system";
 
@@ -55,6 +56,26 @@ describe("Bug 5: pendingRestartVersion is set only after successful verification
 });
 
 describe("Issue 322: verify installed version after update install", () => {
+	it("prefers the direct native install when an npm daemon coexists with it", () => {
+		expect(
+			selectUpdateTarget({
+				target: {
+					kind: "package-manager",
+					family: "npm",
+					executablePath: "/opt/homebrew/lib/node_modules/signetai/native/signet",
+				},
+				installations: [],
+				inactive: [
+					{
+						method: "native",
+						executablePath: "/Users/test/.local/bin/signet",
+						active: false,
+					},
+				],
+			}),
+		).toEqual({ kind: "native", executablePath: "/Users/test/.local/bin/signet" });
+	});
+
 	it("pins install command to targetVersion when provided", () => {
 		expect(UPDATE_INSTALL_SRC).toContain("const installPackage = `${settings.packageName}@${version}`");
 		expect(UPDATE_SYSTEM_SRC).toContain("detectSignetInstallations()");
@@ -332,7 +353,7 @@ describe("active executable update targeting", () => {
 						executablePath: "/home/test/.npm-global/bin/signet",
 						packagePath: "/home/test/.npm-global/lib/node_modules/signetai",
 						active: false,
-						removalCommand: "npm uninstall -g signetai",
+						removalCommand: "rm -f -- '/home/test/.npm-global/bin/signet'",
 					},
 				],
 				inactive: [],

--- a/platform/daemon/src/update-system.ts
+++ b/platform/daemon/src/update-system.ts
@@ -12,6 +12,7 @@ import {
 	type PackageManagerFamily,
 	type SignetInstallMethod,
 	type SignetInstallationReport,
+	type SignetUpdateTarget,
 	type WorkspaceSourceRepoSyncResult,
 	detectSignetInstallations,
 	parseSimpleYaml,
@@ -166,13 +167,17 @@ let updateConfig: UpdateConfig = {
 	checkInterval: DEFAULT_UPDATE_INTERVAL_SECONDS,
 	channel: "stable" as const,
 };
-let restartCallback: (() => void) | null = null;
+let restartCallback: ((preferredExecutablePath?: string) => void) | null = null;
 
 // ---------------------------------------------------------------------------
 // Init / accessors
 // ---------------------------------------------------------------------------
 
-export function initUpdateSystem(version: string, dir: string, onRestartNeeded?: () => void): void {
+export function initUpdateSystem(
+	version: string,
+	dir: string,
+	onRestartNeeded?: (preferredExecutablePath?: string) => void,
+): void {
 	currentVersion = version;
 	agentsDir = dir;
 	updateConfig = loadUpdateConfig();
@@ -557,6 +562,18 @@ function updateFailure(
 	};
 }
 
+/**
+ * When a package-manager daemon coexists with a direct native install, keep
+ * the native installation authoritative. This is the common mixed-install
+ * shape where npm is needed for `signet-mcp` but should not own Signet updates.
+ */
+export function selectUpdateTarget(report: SignetInstallationReport): SignetUpdateTarget {
+	if (report.target.kind !== "package-manager") return report.target;
+
+	const native = report.inactive.find((installation) => installation.method === "native");
+	return native ? { kind: "native", executablePath: native.executablePath } : report.target;
+}
+
 interface DesktopInstallDetectionDeps {
 	readonly existsSync: (path: string) => boolean;
 	readonly readFileSync: (path: string, encoding: BufferEncoding) => string;
@@ -827,7 +844,7 @@ export async function runUpdate(targetVersion?: string, deps: RunUpdateDeps = {}
 		}
 
 		const report = (deps.detectInstallations ?? (() => detectSignetInstallations()))();
-		const target = report.target;
+		const target = selectUpdateTarget(report);
 		if (target.kind === "unsupported") {
 			return updateFailure(
 				"unsupported_installation",
@@ -992,7 +1009,7 @@ async function runAutoUpdateCycle(): Promise<void> {
 
 			if (restartCallback) {
 				logger.info("update", "Invoking restart callback to spawn replacement daemon");
-				restartCallback();
+				restartCallback(installResult.success ? installResult.activeExecutablePath : undefined);
 			} else {
 				// Fallback: clean exit — systemd/launchd Restart=always will respawn.
 				// Without a restart callback, the daemon simply exits.

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -973,7 +973,14 @@ registerAppCommands(program, {
 			signetLogo,
 		}),
 	installNative: async (options) => {
-		printNativeInstallResult(installNativeBinary(options), options.json);
+		const result = installNativeBinary(options);
+		printNativeInstallResult(result, options.json);
+		if (await isDaemonRunning()) {
+			const rebound = await startDaemon(AGENTS_DIR, result.target);
+			if (!rebound) {
+				console.error("Signet binary installed, but the running daemon could not be switched to it.");
+			}
+		}
 	},
 	launchDashboard: (options) => launchDashboard(options, daemonDeps),
 	migrateSchema: (options) => migrateSchema(options, daemonDeps),
@@ -1136,6 +1143,11 @@ registerHookCommands(program, {
 
 const MIN_AUTO_UPDATE_INTERVAL = 300;
 const MAX_AUTO_UPDATE_INTERVAL = 604800;
+const reconcileDaemonInstallation = async (): Promise<boolean> => {
+	if (!(await isDaemonRunning())) return true;
+	return await startDaemon(AGENTS_DIR);
+};
+
 registerUpdateCommands(program, {
 	AGENTS_DIR,
 	MAX_AUTO_UPDATE_INTERVAL,
@@ -1147,6 +1159,7 @@ registerUpdateCommands(program, {
 	isOpenClawInstalled: () => new OpenClawConnector().isInstalled(),
 	isOhMyPiInstalled: () => new OhMyPiConnector().isInstalled(),
 	isPiInstalled: () => new PiConnector().isInstalled(),
+	reconcileDaemon: reconcileDaemonInstallation,
 	syncBuiltinSkills,
 	syncWorkspaceSourceRepo,
 });

--- a/surfaces/cli/src/commands/update.ts
+++ b/surfaces/cli/src/commands/update.ts
@@ -17,6 +17,7 @@ interface UpdateDeps {
 	readonly isOpenClawInstalled: () => boolean;
 	readonly isOhMyPiInstalled: () => boolean;
 	readonly isPiInstalled: () => boolean;
+	readonly reconcileDaemon?: () => Promise<boolean>;
 	readonly getSkillsSourceDir: () => string;
 	readonly syncBuiltinSkills: (
 		skillsSourceDir: string,
@@ -105,6 +106,10 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 		.command("install")
 		.description("Install the latest update")
 		.action(async () => {
+			if (deps.reconcileDaemon && !(await deps.reconcileDaemon())) {
+				console.error(chalk.red("Could not switch the daemon to the current Signet installation"));
+				process.exit(1);
+			}
 			const printInstallationWarning = (): void => {
 				printConcurrentInstallationWarning((deps.detectInstallations ?? detectSignetInstallations)());
 			};
@@ -300,6 +305,10 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 			"21600",
 		)
 		.action(async (options) => {
+			if (deps.reconcileDaemon && !(await deps.reconcileDaemon())) {
+				console.error(chalk.red("Could not switch the daemon to the current Signet installation"));
+				process.exit(1);
+			}
 			const interval = Number.parseInt(options.interval, 10);
 			if (
 				!Number.isFinite(interval) ||

--- a/surfaces/cli/src/features/daemon.test.ts
+++ b/surfaces/cli/src/features/daemon.test.ts
@@ -87,6 +87,21 @@ function makeDeps(overrides?: Partial<Parameters<typeof doRestart>[1]>): Paramet
 }
 
 describe("daemon lifecycle recovery", () => {
+	it("lets an already-running daemon reconcile its installation owner", async () => {
+		let started = false;
+		const deps = makeDeps({
+			isDaemonRunning: async () => true,
+			startDaemon: async () => {
+				started = true;
+				return true;
+			},
+		});
+
+		await doStart({}, deps);
+
+		expect(started).toBe(true);
+	});
+
 	it("restart stops a stale daemon process even when health checks say stopped", async () => {
 		const calls: string[] = [];
 		const deps = makeDeps({

--- a/surfaces/cli/src/features/daemon.ts
+++ b/surfaces/cli/src/features/daemon.ts
@@ -192,15 +192,11 @@ export async function doStart(options: PathOptions, deps: Deps): Promise<void> {
 	console.log(deps.signetLogo());
 	const basePath = readPath(options, deps);
 	const running = await deps.isDaemonRunning();
-	if (running) {
-		console.log(chalk.yellow("  Daemon is already running"));
-		return;
-	}
 
 	const spinner = ora("Starting daemon...").start();
 	const started = await deps.startDaemon(basePath);
 	if (started) {
-		spinner.succeed("Daemon started");
+		spinner.succeed(running ? "Daemon ready" : "Daemon started");
 		const status = await deps.getDaemonStatus();
 		for (const line of daemonAccessLines(deps.defaultPort, status)) {
 			console.log(chalk.dim(`  ${line}`));

--- a/surfaces/cli/src/features/health.test.ts
+++ b/surfaces/cli/src/features/health.test.ts
@@ -515,7 +515,7 @@ describe("doctor concurrent Signet installations", () => {
 								executablePath: join(root, ".npm-global", "bin", "signet"),
 								packagePath: join(root, ".npm-global", "lib", "node_modules", "signetai"),
 								active: false,
-								removalCommand: "npm uninstall -g signetai",
+								removalCommand: `rm -f -- '${join(root, ".npm-global", "bin", "signet")}'`,
 							},
 						],
 					}),
@@ -533,7 +533,7 @@ describe("doctor concurrent Signet installations", () => {
 			expect(output.findings).toContainEqual(
 				expect.objectContaining({
 					code: "duplicate_signet_installation",
-					fix: expect.stringContaining("npm uninstall -g signetai"),
+					fix: expect.stringContaining("rm -f --"),
 				}),
 			);
 		} finally {

--- a/surfaces/cli/src/features/health.ts
+++ b/surfaces/cli/src/features/health.ts
@@ -671,7 +671,7 @@ function addConcurrentInstallationFindings(report: SignetInstallationReport, fin
 			code: "duplicate_signet_installation",
 			message: `Another Signet installation is inactive: ${duplicate.executablePath} (${duplicate.method}). Active: ${report.target.executablePath} (native).`,
 			fix: duplicate.removalCommand
-				? `After verifying the active installation, remove the duplicate manually: ${duplicate.removalCommand}`
+				? `After verifying the active installation, remove only the duplicate launcher (this keeps signet-mcp available): ${duplicate.removalCommand}`
 				: undefined,
 		});
 	}

--- a/surfaces/cli/src/features/installation-warning.test.ts
+++ b/surfaces/cli/src/features/installation-warning.test.ts
@@ -16,7 +16,7 @@ describe("concurrentInstallationWarningLines", () => {
 						executablePath: "/home/test/.npm-global/bin/signet",
 						packagePath: "/home/test/.npm-global/lib/node_modules/signetai",
 						active: false,
-						removalCommand: "npm uninstall -g signetai",
+						removalCommand: "rm -f -- '/home/test/.npm-global/bin/signet'",
 					},
 				],
 			},
@@ -25,8 +25,8 @@ describe("concurrentInstallationWarningLines", () => {
 
 		expect(lines.join("\n")).toContain("Active:   ~/.local/bin/signet (native)");
 		expect(lines.join("\n")).toContain("Inactive: ~/.npm-global/bin/signet (npm)");
-		expect(lines.join("\n")).toContain("npm uninstall -g signetai");
-		expect(lines.join("\n")).not.toContain("deprecated");
+		expect(lines.join("\n")).toContain("rm -f -- '/home/test/.npm-global/bin/signet'");
+		expect(lines.join("\n")).toContain("keeps signet-mcp available");
 	});
 
 	it("stays silent for a package-manager-only installation", () => {

--- a/surfaces/cli/src/features/installation-warning.ts
+++ b/surfaces/cli/src/features/installation-warning.ts
@@ -24,7 +24,10 @@ export function concurrentInstallationWarningLines(
 	for (const duplicate of duplicates) {
 		lines.push(`Inactive: ${displayPath(duplicate.executablePath, home)} (${duplicate.method})`);
 	}
-	lines.push("", "After verifying the active installation, remove the duplicate manually:");
+	lines.push(
+		"",
+		"After verifying the active installation, remove only the duplicate launcher (this keeps signet-mcp available):",
+	);
 	for (const command of new Set(
 		duplicates.flatMap((duplicate) => (duplicate.removalCommand ? [duplicate.removalCommand] : [])),
 	)) {

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -14,9 +14,11 @@ import {
 	macOSLaunchAgentAttributionNotice,
 	readDaemonStartFailureDiagnostics,
 	readManagedDaemonPid,
+	rebindDaemonIfNeeded,
 	resolveDaemonLaunchCommand,
 	resolveDaemonPaths,
 	resolveDaemonRuntimeCommand,
+	shouldRebindDaemon,
 } from "./runtime.js";
 
 const originalFetch = globalThis.fetch;
@@ -29,6 +31,46 @@ describe("resolveDaemonPaths", () => {
 	it("keeps the JavaScript daemon bundle as the default when SIGNET_DIR is set", () => {
 		const paths = resolveDaemonPaths({ SIGNET_DIR: "/opt/signet" });
 		expect(paths[0]).toBe("/opt/signet/runtime/daemon-js/daemon.js");
+	});
+});
+
+describe("daemon installation ownership", () => {
+	it("rebinds an npm-launched daemon when the native CLI is now active", () => {
+		const nativeExecutable = "/Users/test/.local/bin/signet";
+		const npmExecutable = "/opt/homebrew/lib/node_modules/signetai/native/signet";
+
+		expect(shouldRebindDaemon(`${npmExecutable} daemon`, nativeExecutable)).toBe(true);
+		expect(shouldRebindDaemon(`${nativeExecutable} daemon`, nativeExecutable)).toBe(false);
+	});
+
+	it("restarts a mismatched healthy daemon instead of leaving the old install in charge", async () => {
+		const calls: string[] = [];
+		const result = await rebindDaemonIfNeeded("/Users/test/.local/bin/signet", {
+			getDaemonStatus: async () => ({ running: true, pid: 42 }),
+			readCommand: () => "/opt/homebrew/lib/node_modules/signetai/native/signet daemon",
+			stopDaemon: async (pid) => {
+				calls.push(`stop:${pid}`);
+				return true;
+			},
+		});
+
+		expect(result).toBe("restarted");
+		expect(calls).toEqual(["stop:42"]);
+	});
+
+	it("does not restart a daemon already using the current executable", async () => {
+		let stopped = false;
+		const result = await rebindDaemonIfNeeded("/Users/test/.local/bin/signet", {
+			getDaemonStatus: async () => ({ running: true, pid: 42 }),
+			readCommand: () => "/Users/test/.local/bin/signet daemon",
+			stopDaemon: async () => {
+				stopped = true;
+				return true;
+			},
+		});
+
+		expect(result).toBe("already-current");
+		expect(stopped).toBe(false);
 	});
 });
 
@@ -47,9 +89,7 @@ describe("resolveDaemonRuntimeCommand", () => {
 
 describe("resolveDaemonLaunchCommand", () => {
 	it("launches native daemon binaries directly", () => {
-		expect(resolveDaemonLaunchCommand("/opt/signet/bin/signet")).toEqual([
-			"/opt/signet/bin/signet",
-		]);
+		expect(resolveDaemonLaunchCommand("/opt/signet/bin/signet")).toEqual(["/opt/signet/bin/signet"]);
 	});
 
 	it("launches JavaScript daemon scripts through the runtime command", () => {
@@ -185,7 +225,6 @@ describe("buildLaunchdDaemonPlist", () => {
 			"/Users/user/Library/LaunchAgents/ai.signet.daemon.plist",
 		);
 	});
-
 
 	it("uses launchctl bootstrap against the current user launchd domain", () => {
 		const args = buildLaunchdDaemonStartArgs("/Users/user/Library/LaunchAgents/ai.signet.daemon.plist");

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -7,6 +7,7 @@ import {
 	mkdirSync,
 	openSync,
 	readFileSync,
+	realpathSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
@@ -130,6 +131,11 @@ export function resolveDaemonPaths(env: NodeJS.ProcessEnv = process.env): string
 	]
 		.filter((path): path is string => path !== null)
 		.filter((path, index, items) => items.indexOf(path) === index);
+}
+
+/** Resolve the daemon executable that the current CLI would launch. */
+export function resolveDaemonPath(env: NodeJS.ProcessEnv = process.env): string | null {
+	return resolveDaemonPaths(env).find((path) => existsSync(path)) ?? null;
 }
 
 function daemonPaths(): string[] {
@@ -496,6 +502,32 @@ function normalizeCmd(value: string): string {
 	return normalize(value).replaceAll("\\", "/").toLowerCase();
 }
 
+function executablePathVariants(executablePath: string): readonly string[] {
+	const variants = [executablePath];
+	try {
+		variants.push(realpathSync(executablePath));
+	} catch {
+		// The executable may have been replaced during an update. The command
+		// line still gives us the best available ownership signal in that case.
+	}
+	return [...new Set(variants.map(normalizeCmd))];
+}
+
+/** Return whether a daemon command line contains the requested executable. */
+export function daemonCommandUsesExecutable(command: string, executablePath: string): boolean {
+	const normalizedCommand = normalizeCmd(command);
+	return executablePathVariants(executablePath).some((candidate) => normalizedCommand.includes(candidate));
+}
+
+/**
+ * A running daemon may outlive the CLI installation that started it. Rebind
+ * only when its command line is known and points at a different executable;
+ * an unreadable command line is left alone for safety.
+ */
+export function shouldRebindDaemon(currentCommand: string | null, desiredExecutablePath: string): boolean {
+	return currentCommand !== null && !daemonCommandUsesExecutable(currentCommand, desiredExecutablePath);
+}
+
 function matchesDaemon(cmd: string, paths: readonly string[]): boolean {
 	const normalizedCmd = normalizeCmd(cmd);
 	return daemonMarks(paths).some((path) => normalizedCmd.includes(normalizeCmd(path)));
@@ -510,6 +542,22 @@ function readCmd(pid: number): string | null {
 		}
 	} catch {
 		// Fall through.
+	}
+
+	if (process.platform === "win32") {
+		const script = `$process = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"; if ($process) { $process.CommandLine }`;
+		for (const command of ["powershell.exe", "pwsh"]) {
+			try {
+				const proc = spawnSync(command, ["-NoProfile", "-NonInteractive", "-Command", script], {
+					encoding: "utf-8",
+					windowsHide: true,
+					timeout: 3000,
+				});
+				if (proc.status === 0 && proc.stdout.trim()) return proc.stdout.trim();
+			} catch {
+				// Try the next available PowerShell command.
+			}
+		}
 	}
 
 	try {
@@ -638,6 +686,35 @@ export async function getDaemonStatus(): Promise<{
 		probe,
 		openclaw: null,
 	};
+}
+
+interface DaemonOwnershipStatus {
+	readonly running: boolean;
+	readonly pid: number | null;
+}
+
+export type DaemonRebindResult = "not-running" | "already-current" | "unknown" | "restarted" | "failed";
+
+/**
+ * Switch a healthy daemon to the executable selected by the current CLI when
+ * an older daemon was started from another Signet installation.
+ */
+export async function rebindDaemonIfNeeded(
+	desiredExecutablePath: string,
+	deps: {
+		readonly getDaemonStatus: () => Promise<DaemonOwnershipStatus>;
+		readonly readCommand: (pid: number) => string | null;
+		readonly stopDaemon: (pid: number) => Promise<boolean>;
+	},
+): Promise<DaemonRebindResult> {
+	const status = await deps.getDaemonStatus();
+	if (!status.running) return "not-running";
+	if (status.pid === null) return "unknown";
+
+	const currentCommand = deps.readCommand(status.pid);
+	if (!shouldRebindDaemon(currentCommand, desiredExecutablePath)) return currentCommand ? "already-current" : "unknown";
+
+	return (await deps.stopDaemon(status.pid)) ? "restarted" : "failed";
 }
 
 export interface DaemonStartArgsInput {
@@ -903,9 +980,26 @@ export function didSystemdDaemonStart(result: Pick<SpawnSyncReturns<Buffer>, "st
 
 export const didLaunchdDaemonStart = didSystemdDaemonStart;
 
-export async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boolean> {
-	if (await isDaemonRunning()) {
+export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemonPath?: string): Promise<boolean> {
+	const daemonPath = preferredDaemonPath ?? resolveDaemonPath();
+	if (!daemonPath) {
+		console.error(chalk.red("Daemon not found. Try reinstalling signet."));
+		return false;
+	}
+
+	const rebindResult = await rebindDaemonIfNeeded(daemonPath, {
+		getDaemonStatus,
+		readCommand: (pid) => readCmd(pid),
+		stopDaemon: (pid) => stopDaemon(agentsDir, pid),
+	});
+	if (rebindResult === "already-current" || rebindResult === "unknown") {
 		return true;
+	}
+	if (rebindResult === "failed") {
+		return false;
+	}
+	if (rebindResult === "restarted") {
+		console.error(chalk.dim("  Existing daemon uses another Signet installation; switching to the current one."));
 	}
 
 	if (await hasDaemonProcess(agentsDir)) {
@@ -921,23 +1015,6 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boole
 	const logDir = join(daemonDir, "logs");
 	mkdirSync(daemonDir, { recursive: true });
 	mkdirSync(logDir, { recursive: true });
-
-	// In dev, runtime.ts lives in lib/ so cliDir (dirname(__dirname)) = src/.
-	// In the published bundle, everything flattens into dist/cli.js so
-	// __dirname already points at dist/ — check it first to handle the
-	// bundled layout where cliDir overshoots to the package root.
-	let daemonPath: string | null = null;
-	for (const loc of daemonPaths()) {
-		if (existsSync(loc)) {
-			daemonPath = loc;
-			break;
-		}
-	}
-
-	if (!daemonPath) {
-		console.error(chalk.red("Daemon not found. Try reinstalling signet."));
-		return false;
-	}
 
 	const attributionNotice = macOSLaunchAgentAttributionNotice(daemonPath);
 	if (attributionNotice) {
@@ -1118,7 +1195,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boole
 	return false;
 }
 
-export async function stopDaemon(agentsDir: string = AGENTS_DIR): Promise<boolean> {
+export async function stopDaemon(agentsDir: string = AGENTS_DIR, preferredPid?: number): Promise<boolean> {
 	if (process.platform === "darwin") {
 		spawnSync("launchctl", buildLaunchdDaemonStopArgs(), {
 			stdio: "ignore",
@@ -1127,7 +1204,7 @@ export async function stopDaemon(agentsDir: string = AGENTS_DIR): Promise<boolea
 		});
 	}
 
-	const pids = new Set<number>();
+	const pids = new Set<number>(preferredPid === undefined ? [] : [preferredPid]);
 	const managed = readManagedDaemonPid(agentsDir);
 	if (managed !== null) {
 		pids.add(managed);

--- a/web/marketing/public/skill.md
+++ b/web/marketing/public/skill.md
@@ -302,10 +302,12 @@ These are the supported install methods. Do not use:
 - `sudo npm install` — never use sudo
 - Cloning the repository — that is for contributors, not users
 
-Choose one install method. `signet update install` updates the active method,
-and `signet doctor` reports inactive npm/Bun/pnpm/Yarn duplicates with a
-manual uninstall command. Signet never removes another installation
-automatically.
+Choose one install method. `signet update install` prefers a direct native
+install over an inactive package-manager wrapper, and `signet doctor` reports
+inactive npm/Bun/pnpm/Yarn duplicates with a command that removes only the
+duplicate launcher. Do not uninstall the whole package, because it may also
+provide `signet-mcp`. Signet never removes
+another installation automatically.
 
 > GATE: After the install command completes, verify it worked:
 > ```bash


### PR DESCRIPTION
## Summary

Fixes #1060. The updater no longer recreates an npm/Bun/pnpm/Yarn signet launcher when a direct native installation is present. The native installation becomes authoritative, while the package-manager installation remains available for tools such as signet-mcp.

The CLI also detects and replaces a running daemon that was started from the wrong installation.

## Changes

- Prefer an inactive direct native binary over a package-manager wrapper for updates.
- Rebind stale daemons before daemon start, update install, update enable, and native installation.
- Remove only duplicate package-manager launchers from doctor guidance, preserving the package and signet-mcp.
- Add regression coverage for target selection, daemon ownership, launcher cleanup, and already-running daemon reconciliation.
- Update README, CLI, quickstart, and skill documentation.

## Type

- [x] fix — bug fix
- [ ] feat — new user-facing feature (bumps minor)
- [ ] refactor — restructure without behavior change
- [ ] chore — build, deps, config, docs
- [ ] perf — performance improvement
- [ ] test — test coverage

## Packages affected

- [x] @signet/core
- [x] @signet/daemon
- [x] @signet/cli / dashboard
- [ ] @signet/sdk
- [ ] @signet/connector-*
- [ ] @signet/web
- [ ] predictor
- [ ] Other: <!-- specify -->

## Screenshots

N/A — no UI changes.

## PR Readiness

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec or dependency manifest changes are required.
- [x] Agent scoping verified on all new/changed data queries — this change adds no data queries.
- [x] Input/config validation and bounds checks added — existing update bounds and safe PID handling are preserved.
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints — no admin or mutation endpoints changed.
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally — focused checks pass; unrelated full-suite baseline failures are documented below.

## Testing

Focused verification passed:

- bun test surfaces/cli/src/lib/runtime.test.ts surfaces/cli/src/features/daemon.test.ts surfaces/cli/src/features/installation-warning.test.ts surfaces/cli/src/commands/app.test.ts — 48 passed
- bun test platform/core/src/signet-installation.test.ts platform/daemon/src/update-system.test.ts — 47 passed
- bun test surfaces/cli/src/features/health.test.ts — 18 passed
- Biome check on all changed code and test files
- Core build and full CLI bundle build passed

The full surfaces/cli suite currently reports 407 passed and 13 failures in unrelated route/source tests involving pre-existing process.exitCode contamination. The daemon package typecheck also has pre-existing missing-dependency/type errors outside this change.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see Assisted-by tags in commits)

Two independent adversarial reviews were run with gpt-5.6-luna; the final review found no blockers and approved the change.

## Notes

The direct native install wins only when it coexists with a package-manager installation. Doctor now suggests deleting the duplicate launcher path instead of uninstalling the whole package, so packages that provide signet-mcp are preserved.