### PR TITLE
fix(cli): stop surfacing the retired extraction pipeline in status output

### DIFF
--- a/surfaces/cli/src/features/health.test.ts
+++ b/surfaces/cli/src/features/health.test.ts
@@ -723,7 +723,7 @@ describe("getExtractionStatusNotice", () => {
 		expect(notice).toBeNull();
 	});
 
-	it("warns that the pipeline is disabled under the Dreaming cutover", () => {
+	it("does not surface a pipeline notice when the extraction pipeline is retired", () => {
 		const notice = getExtractionStatusNotice({
 			running: true,
 			pid: 1,
@@ -740,6 +740,37 @@ describe("getExtractionStatusNotice", () => {
 				status: "disabled",
 				degraded: false,
 				reason: "Dreaming cutover owns semantic writes",
+				blockedBy: [],
+				since: null,
+				enabled: false,
+				paused: false,
+				workerRunning: false,
+				ready: false,
+				blockedReason: null,
+				hasWorkloadState: true,
+			},
+		});
+
+		expect(notice).toBeNull();
+	});
+
+	it("still warns that the pipeline is disabled when no retirement reason is present", () => {
+		const notice = getExtractionStatusNotice({
+			running: true,
+			pid: 1,
+			uptime: 10,
+			version: "0.0.1",
+			host: "127.0.0.1",
+			bindHost: "127.0.0.1",
+			networkMode: "local",
+			extraction: {
+				configured: null,
+				resolved: null,
+				effective: null,
+				fallbackProvider: "none",
+				status: "disabled",
+				degraded: false,
+				reason: null,
 				blockedBy: [],
 				since: null,
 				enabled: false,

--- a/surfaces/cli/src/features/health.ts
+++ b/surfaces/cli/src/features/health.ts
@@ -410,6 +410,12 @@ export function getExtractionStatusNotice(
 ): { level: "warn" | "error"; title: string; detail: string } | null {
 	const extraction = daemon.extraction;
 	if (extraction && daemon.running && extraction.hasWorkloadState && !extraction.ready) {
+		// The legacy auto-extraction pipeline was deliberately retired in favor
+		// of Dreaming, which owns all semantic writes. Retired states are not a
+		// fault and are not surfaced as a pipeline notice at all.
+		if (!extraction.enabled && extraction.status === "disabled" && extraction.reason) {
+			return null;
+		}
 		const title = !extraction.enabled
 			? "Pipeline disabled"
 			: extraction.paused


### PR DESCRIPTION
## Summary

`signet status` prints `⚠ Pipeline disabled` (warn level) even though the state is deliberate: the legacy auto-extraction pipeline was retired and Dreaming owns all semantic writes. The renderer treated every `!enabled` extraction state as a fault and dropped the daemon's `reason` field, so the actual explanation ("Dreaming owns semantic writes") never reached the operator. Same misleading-diagnostics class as #1074.

## Changes

- `health.ts` (`getExtractionStatusNotice`): when extraction is disabled with a retirement reason (the Dreaming cutover), the pipeline notice is suppressed entirely — retired extraction is not a pipeline state worth reporting.
- Disabled states **without** a reason still render as the existing `⚠ Pipeline disabled` warn, so genuinely unexplained disablement is not silently hidden.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/cli` / dashboard

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [ ] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Testing

- [x] `bun test` passes (20/20 in health.test.ts; 1 test updated to assert the retired case emits no notice + 1 added for the reason-less warn path)
- [x] `bun run typecheck` passes (`@signet/cli` build passes; daemon unaffected)
- [x] `bun run lint` passes (biome clean)
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

AI tools were used (see `Assisted-by` tags in commits).

## Notes

No migration impact. The status output no longer mentions the pipeline at all on current daemons; the `⚠ Pipeline disabled` line only appears if extraction is disabled without a retirement reason.
