### PR TITLE
fix(dreaming): accept redundant selectors that name the flagged entity in hygiene archives

### DIFF
--- a/platform/daemon/src/pipeline/dreaming-operations.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.test.ts
@@ -161,6 +161,47 @@ describe("dreaming operations", () => {
 		).toContain(`attention:${attentionId}`);
 	});
 
+	it("accepts an attention-cited archive that echoes the flagged name alongside entity_id", () => {
+		// Regression: the Dreaming agent submitted archive_entity payloads with
+		// both `entity: <name>` (echoed from attention details) and the required
+		// `entity_id`. The id match pins the flagged target, so the redundant
+		// selector must not reject the op.
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES ('legacy-husk', 'Legacy Husk', 'legacy husk', 'project', 'agent-a', 5, datetime('now'), datetime('now'))`,
+			).run();
+			enqueueDreamingAttentionInTx(db, {
+				agentId: "agent-a",
+				kind: "hygiene",
+				subjectRef: "entity:legacy-husk",
+				details: { entityId: "legacy-husk", name: "Legacy Husk", reason: "zero_active_attributes" },
+				priority: 90,
+			});
+		});
+		const attentionId = getDbAccessor().withReadDb(
+			(db) => db.prepare("SELECT id FROM dreaming_attention WHERE agent_id = ?").get("agent-a") as { id: string },
+		).id;
+		const result = applyDreamingOperations({
+			accessor: getDbAccessor(),
+			agentId: "agent-a",
+			actor: "dreaming",
+			operations: [
+				{
+					operation: "archive_entity",
+					payload: { entity: "Legacy Husk", entity_id: "legacy-husk", force: false },
+					provenance: `attention:${attentionId}`,
+					confidence: 1,
+				},
+			],
+		});
+		expect(result.ok).toBe(true);
+		expect(
+			getDbAccessor().withReadDb((db) => db.prepare("SELECT status FROM entities WHERE id = ?").get("legacy-husk")),
+		).toEqual({ status: "archived" });
+	});
+
 	it("does not let attention provenance create claims or archive unrelated entities", () => {
 		getDbAccessor().withWriteTx((db) => {
 			for (const id of ["flagged", "unrelated"]) {

--- a/platform/daemon/src/pipeline/dreaming-operations.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.ts
@@ -1,9 +1,9 @@
 import { ONTOLOGY_PROPOSAL_OPERATIONS, SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES } from "@signet/core";
 import type { DbAccessor } from "../db-accessor";
 import { readEpisodicSource } from "../episodic-sources";
-import { applyOntologyOperationBatchInTx, type OntologyOperationInput } from "../ontology-proposals";
-import { getDreamingAttentionById } from "./dreaming-attention";
-import { createDreamingAgentEvidence, type DreamingAgentEvidence } from "./dreaming-evidence";
+import { type OntologyOperationInput, applyOntologyOperationBatchInTx } from "../ontology-proposals";
+import { type DreamingAttention, getDreamingAttentionById } from "./dreaming-attention";
+import { type DreamingAgentEvidence, createDreamingAgentEvidence } from "./dreaming-evidence";
 
 export interface DreamingOperationRequest {
 	readonly operation: string;
@@ -84,6 +84,32 @@ function noSelectors(payload: Readonly<Record<string, unknown>>, keys: readonly 
 	return keys.every((key) => payload[key] === undefined || payload[key] === null);
 }
 
+/** Accepted selector values that denote the flagged entity itself. */
+function acceptedTargetValues(attention: DreamingAttention, ...keys: readonly string[]): string[] {
+	return keys
+		.map((key) => attention.details[key])
+		.filter((value): value is string => typeof value === "string" && value.length > 0);
+}
+
+/**
+ * True when every present selector field names the flagged target itself.
+ * Downstream selector resolution prefers `selector`/`entity`/`name` over
+ * `entity_id`, so a stray selector naming a different row would hit the wrong
+ * target despite a matching id. Accept only the target's id or the name the
+ * attention record captured; anything else is rejected.
+ */
+function selectorsNameFlaggedTarget(
+	payload: Readonly<Record<string, unknown>>,
+	fields: readonly { readonly key: string; readonly accepted: readonly string[] }[],
+): boolean {
+	for (const { key, accepted } of fields) {
+		const value = payload[key];
+		if (typeof value !== "string" || value.length === 0) continue;
+		if (!accepted.includes(value)) return false;
+	}
+	return true;
+}
+
 function forceRequested(value: unknown): boolean {
 	return value === true || value === 1 || value === "1" || value === "true";
 }
@@ -125,19 +151,34 @@ function attentionProvenance(
 	if (forceRequested(payload.force)) return null;
 	let expectedTarget = false;
 	if (operation.operation === "archive_entity") {
+		// Redundant selectors are tolerated only when they name the flagged
+		// entity itself (the agent echoes the name from attention details);
+		// a selector naming a different row still cannot ride along.
+		const entityValues = acceptedTargetValues(attention, "entityId", "name");
 		expectedTarget =
 			typeof payload.entity_id === "string" &&
 			payload.entity_id === attention.details.entityId &&
-			noSelectors(payload, ["selector", "entity", "name"]) &&
-			attention.subjectRef === `entity:${payload.entity_id}`;
+			attention.subjectRef === `entity:${payload.entity_id}` &&
+			selectorsNameFlaggedTarget(payload, [
+				{ key: "selector", accepted: entityValues },
+				{ key: "entity", accepted: entityValues },
+				{ key: "name", accepted: entityValues },
+			]);
 	} else if (operation.operation === "archive_aspect") {
+		const entityValues = acceptedTargetValues(attention, "entityId", "name");
+		const aspectValues = acceptedTargetValues(attention, "aspectId", "aspectName");
 		expectedTarget =
 			typeof payload.entity_id === "string" &&
 			typeof payload.aspect_id === "string" &&
 			payload.entity_id === attention.details.entityId &&
 			payload.aspect_id === attention.details.aspectId &&
-			noSelectors(payload, ["entity", "selector", "aspect", "name"]) &&
-			attention.subjectRef === `aspect:${payload.aspect_id}`;
+			attention.subjectRef === `aspect:${payload.aspect_id}` &&
+			selectorsNameFlaggedTarget(payload, [
+				{ key: "selector", accepted: entityValues },
+				{ key: "entity", accepted: entityValues },
+				{ key: "name", accepted: entityValues },
+				{ key: "aspect", accepted: aspectValues },
+			]);
 	} else if (operation.operation === "archive_claim_value") {
 		expectedTarget =
 			typeof payload.attribute_id === "string" &&


### PR DESCRIPTION
## Summary

Verified live on v0.159.10: the Dreaming agent now cites valid `attention:<id>` provenance for hygiene archives (the #1069 fix works), but the apply gate still rejected every op. The agent's payloads echo the flagged entity's name (`entity: "CLAUDE.md audit initiative"`) alongside the required `entity_id` — and `noSelectors` in the attention provenance path banned any selector field outright. Every hygiene pass failed with "Every operation must cite an exact quote from scoped episodic evidence": 0 applied, 2 failed, with the runbook confirming the agent used the correct provenance format.

The blanket ban was also too loose in the other direction: downstream selector resolution prefers `selector`/`entity`/`name` over `entity_id`, so a stray selector naming a *different* row would archive the wrong target even with a matching id.

## Changes

- `dreaming-operations.ts` (`attentionProvenance`): `archive_entity` and `archive_aspect` now accept selector fields **only when they name the flagged target itself** — the target's id or the name captured in the attention record. A selector naming a different row is still rejected (the two existing security tests pin this).
- `archive_claim_value`, `archive_link`, and `merge_entities` checks unchanged.
- New regression test uses the exact production payload shape: `{ entity: <name>, entity_id: <id>, force: false }` + `confidence: 1` + `attention:<id>` → applied.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [ ] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Testing

- [x] `bun test` passes (10/10 dreaming-operations incl. 2 security tests + new regression; 34 across agent-tools/dreaming/evidence)
- [x] `bun run typecheck` passes (`@signet/daemon` build)
- [x] `bun run lint` passes (biome clean)
- [x] Tested against running daemon (diagnosis on v0.159.10 live)
- [ ] N/A

## AI disclosure

AI tools were used (see `Assisted-by` tags in commits).

## Notes

After this ships, the pending hygiene attention records (still ~110 unresolved in the production DB) apply on the next sweep; the 20 already-resolved entities from the failed pass can be re-flagged via `record_hygiene_attention` if the classifier does not re-flag them.