### PR TITLE
fix(dreaming): accept ids in get_evidence claim paths; derive citation kind/id from source_ref

### DIFF
--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -252,7 +252,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"get_evidence",
 			"Get evidence",
-			"Resolve provenance for a scoped claim path or a scoped dependency link by stable id.",
+			"Resolve provenance for a scoped claim path (entity/aspect by stable id or name) or a scoped dependency link by stable id.",
 			true,
 			z.object({
 				ref: z.union([
@@ -269,12 +269,25 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 			}),
 			async ({ ref, limit, offset }) => {
 				if (ref.type === "claim") {
+					let entityName = ref.entity;
+					let aspectName = ref.aspect;
+					// Accept stable ids as well as names for the claim path:
+					// search results surface ids, and the path resolver is
+					// name-based.
+					const detail = getKnowledgeEntityDetail(accessor, ref.entity, agentId);
+					if (detail) {
+						entityName = detail.entity.name;
+						const aspect = getEntityAspectsWithCounts(accessor, ref.entity, agentId).find(
+							(candidate) => candidate.aspect.id === ref.aspect || candidate.aspect.name === ref.aspect,
+						);
+						if (aspect) aspectName = aspect.aspect.name;
+					}
 					return {
 						ok: true,
 						result: getOntologyClaimEvidence(accessor, {
 							agentId,
-							entity: ref.entity,
-							aspect: ref.aspect,
+							entity: entityName,
+							aspect: aspectName,
 							group: ref.group,
 							claim: ref.claim,
 							limit,

--- a/platform/daemon/src/pipeline/dreaming-operation-contract.ts
+++ b/platform/daemon/src/pipeline/dreaming-operation-contract.ts
@@ -98,7 +98,7 @@ const operationBase = {
 	evidence: z
 		.array(z.unknown())
 		.describe(
-			"Content-bearing ops only: exact-quote citations from canonical episodic evidence, each {quote, source_ref}.",
+			'Content-bearing ops only: exact-quote citations from canonical episodic evidence, each {quote, source_ref} where source_ref is "kind:id" (e.g. transcript:abc) as returned by search_evidence.',
 		)
 		.optional(),
 	provenance: z

--- a/platform/daemon/src/pipeline/dreaming-operations.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.ts
@@ -53,7 +53,16 @@ function citationRecord(value: unknown): {
 	const sourceId = typeof citation.source_id === "string" ? citation.source_id.trim() : "";
 	const sourcePath = typeof citation.source_path === "string" ? citation.source_path.trim() : null;
 	const quote = typeof citation.quote === "string" ? citation.quote.trim() : "";
-	return sourceRef && sourceKind && sourceId && quote ? { sourceRef, sourceKind, sourceId, sourcePath, quote } : null;
+	// The canonical source_ref is "kind:id" (e.g. transcript:abc). When the
+	// agent supplies only {quote, source_ref}, derive kind and id from it.
+	let kind = sourceKind;
+	let id = sourceId;
+	const colon = sourceRef.indexOf(":");
+	if (colon > 0) {
+		if (!kind) kind = sourceRef.slice(0, colon);
+		if (!id) id = sourceRef.slice(colon + 1);
+	}
+	return sourceRef && kind && id && quote ? { sourceRef, sourceKind: kind, sourceId: id, sourcePath, quote } : null;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #1082, from the first live 0.160.0 pass.

The agent followed the runbook correctly (runbook_read → attention_list → search_evidence → apply_ontology_ops) but every content write was rejected:

1. **get_evidence claim refs are name-based, search surfaces ids.** The agent passed entity/aspect ids from search results; every path lookup failed with 'Claim path not found'. The claim path now resolves entity/aspect by id when the value is not a name (falls back to name resolution).

2. **Citation contract vs description mismatch.** The model description said evidence is `{quote, source_ref}` but the gate required `source_kind` + `source_id` too — the agent's first evidence-backed write was rejected for the missing fields. The canonical ref is `kind:id`, so the gate now derives kind and id from the ref when only `{quote, source_ref}` is supplied, and the contract description spells out the format.

Both fixes are small, live-observed friction points. Tests: dreaming suites 24/24 green, daemon build passes, biome clean.