### PR TITLE
feat(dreaming): one universe pass over every agent scope, agentId threaded per operation

### DIFF
--- a/platform/daemon/src/memory-config.ts
+++ b/platform/daemon/src/memory-config.ts
@@ -47,7 +47,7 @@ export type { PipelineFlag, PipelineV2Config, DreamingConfig };
 export const DEFAULT_DREAMING: DreamingConfig = {
 	tokenThreshold: 100_000,
 	maxInterval: 6 * 60 * 60 * 1_000,
-	timeout: 300_000,
+	timeout: 600_000,
 	maxInputTokens: 128_000,
 	maxOutputTokens: 16_000,
 	backfillOnFirstRun: true,

--- a/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
@@ -85,7 +85,7 @@ describe("dreaming-agent-tools", () => {
 
 		const tools = createDreamingAgentTools({ accessor: getDbAccessor(), agentId: "owner", actor: "owner" });
 		const search = findTool(tools, "search_entities");
-		const res = readResult(await search.execute("call", { query: "entity" }, undefined, undefined, {} as never));
+		const res = readResult(await search.execute("call", { agentId: "owner", query: "entity" }, undefined, undefined, {} as never));
 		expect(res.ok).toBe(true);
 		const items = res.items as Array<{ id: string }>;
 		expect(items.map((i) => i.id)).toEqual(["e-owner"]);
@@ -98,7 +98,7 @@ describe("dreaming-agent-tools", () => {
 		const tools = createDreamingAgentTools({ accessor: getDbAccessor(), agentId: "owner", actor: "owner" });
 
 		const plain = readResult(
-			await findTool(tools, "get_entity").execute("call", { entityId: "e-atlas" }, undefined, undefined, {} as never),
+			await findTool(tools, "get_entity").execute("call", { agentId: "owner", entityId: "e-atlas" }, undefined, undefined, {} as never),
 		);
 		expect(plain).toMatchObject({ ok: true, pinned: false, aspectCount: 1 });
 		expect(plain.aspects).toBeUndefined();
@@ -106,7 +106,7 @@ describe("dreaming-agent-tools", () => {
 		const hydrated = readResult(
 			await findTool(tools, "get_entity").execute(
 				"call",
-				{ entityId: "e-atlas", include: ["aspects"] },
+				{ agentId: "owner", entityId: "e-atlas", include: ["aspects"] },
 				undefined,
 				undefined,
 				{} as never,
@@ -124,7 +124,7 @@ describe("dreaming-agent-tools", () => {
 		const claim = readResult(
 			await findTool(tools, "get_evidence").execute(
 				"call",
-				{ ref: { type: "claim", entity: "Atlas", aspect: "configuration", group: "configuration", claim: "default" } },
+				{ agentId: "owner", ref: { type: "claim", entity: "Atlas", aspect: "configuration", group: "configuration", claim: "default" } },
 				undefined,
 				undefined,
 				{} as never,
@@ -135,7 +135,7 @@ describe("dreaming-agent-tools", () => {
 		const link = readResult(
 			await findTool(tools, "get_evidence").execute(
 				"call",
-				{ ref: { type: "link", id: "missing-link" } },
+				{ agentId: "owner", ref: { type: "link", id: "missing-link" } },
 				undefined,
 				undefined,
 				{} as never,
@@ -155,7 +155,7 @@ describe("dreaming-agent-tools", () => {
 		const res = readResult(
 			await findTool(tools, "validate_proposal").execute(
 				"call",
-				{ name: "Atlas", entityId: "e-atlas", aspectId: "a-config", value: "Feature is disabled by default." },
+				{ agentId: "owner", name: "Atlas", entityId: "e-atlas", aspectId: "a-config", value: "Feature is disabled by default." },
 				undefined,
 				undefined,
 				{} as never,
@@ -174,6 +174,7 @@ describe("dreaming-agent-tools", () => {
 		await findTool(tools, "apply_ontology_ops").execute(
 			"call",
 			{
+				agentId: "owner",
 				operations: [
 					{
 						operation: "flag",
@@ -213,6 +214,7 @@ describe("dreaming-agent-tools", () => {
 			await findTool(tools, "apply_ontology_ops").execute(
 				"call",
 				{
+					agentId: "owner",
 					operations: [
 						{
 							operation: "flag",
@@ -243,7 +245,8 @@ describe("dreaming-agent-tools", () => {
 			await findTool(tools, "apply_ontology_ops").execute(
 				"call",
 				{
-					operations: [
+					agentId: "owner",
+						operations: [
 						{
 							operation: "create_entity",
 							payload: { name: "Acme", type: "project" },
@@ -279,12 +282,12 @@ describe("dreaming-agent-tools", () => {
 			},
 		});
 		const search = findTool(tools, "search_entities");
-		await search.execute("pi-call-1", { query: "owner" }, undefined, undefined, {} as never);
+		await search.execute("pi-call-1", { agentId: "owner", query: "owner" }, undefined, undefined, {} as never);
 
 		expect(traces).toHaveLength(1);
 		expect(traces[0]).toMatchObject({
 			tool: "search_entities",
-			input: { query: "owner" },
+			input: { agentId: "owner", query: "owner" },
 			output: { tool: "search_entities", ok: true },
 		});
 		expect(traces[0]!.latencyMs).toBeGreaterThanOrEqual(0);
@@ -295,7 +298,7 @@ describe("dreaming-agent-tools", () => {
 
 		const tools = createDreamingAgentTools({ accessor: getDbAccessor(), agentId: "owner", actor: "owner" });
 		const getEntity = findTool(tools, "get_entity");
-		const res = readResult(await getEntity.execute("call", { entityId: "e-other" }, undefined, undefined, {} as never));
+		const res = readResult(await getEntity.execute("call", { agentId: "owner", entityId: "e-other" }, undefined, undefined, {} as never));
 		expect(res.ok).toBe(false);
 		expect(res.error).toBe("Entity not found");
 	});

--- a/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
@@ -85,7 +85,9 @@ describe("dreaming-agent-tools", () => {
 
 		const tools = createDreamingAgentTools({ accessor: getDbAccessor(), agentId: "owner", actor: "owner" });
 		const search = findTool(tools, "search_entities");
-		const res = readResult(await search.execute("call", { agentId: "owner", query: "entity" }, undefined, undefined, {} as never));
+		const res = readResult(
+			await search.execute("call", { agentId: "owner", query: "entity" }, undefined, undefined, {} as never),
+		);
 		expect(res.ok).toBe(true);
 		const items = res.items as Array<{ id: string }>;
 		expect(items.map((i) => i.id)).toEqual(["e-owner"]);
@@ -98,7 +100,13 @@ describe("dreaming-agent-tools", () => {
 		const tools = createDreamingAgentTools({ accessor: getDbAccessor(), agentId: "owner", actor: "owner" });
 
 		const plain = readResult(
-			await findTool(tools, "get_entity").execute("call", { agentId: "owner", entityId: "e-atlas" }, undefined, undefined, {} as never),
+			await findTool(tools, "get_entity").execute(
+				"call",
+				{ agentId: "owner", entityId: "e-atlas" },
+				undefined,
+				undefined,
+				{} as never,
+			),
 		);
 		expect(plain).toMatchObject({ ok: true, pinned: false, aspectCount: 1 });
 		expect(plain.aspects).toBeUndefined();
@@ -124,7 +132,10 @@ describe("dreaming-agent-tools", () => {
 		const claim = readResult(
 			await findTool(tools, "get_evidence").execute(
 				"call",
-				{ agentId: "owner", ref: { type: "claim", entity: "Atlas", aspect: "configuration", group: "configuration", claim: "default" } },
+				{
+					agentId: "owner",
+					ref: { type: "claim", entity: "Atlas", aspect: "configuration", group: "configuration", claim: "default" },
+				},
 				undefined,
 				undefined,
 				{} as never,
@@ -155,7 +166,13 @@ describe("dreaming-agent-tools", () => {
 		const res = readResult(
 			await findTool(tools, "validate_proposal").execute(
 				"call",
-				{ agentId: "owner", name: "Atlas", entityId: "e-atlas", aspectId: "a-config", value: "Feature is disabled by default." },
+				{
+					agentId: "owner",
+					name: "Atlas",
+					entityId: "e-atlas",
+					aspectId: "a-config",
+					value: "Feature is disabled by default.",
+				},
 				undefined,
 				undefined,
 				{} as never,
@@ -246,7 +263,7 @@ describe("dreaming-agent-tools", () => {
 				"call",
 				{
 					agentId: "owner",
-						operations: [
+					operations: [
 						{
 							operation: "create_entity",
 							payload: { name: "Acme", type: "project" },
@@ -298,7 +315,9 @@ describe("dreaming-agent-tools", () => {
 
 		const tools = createDreamingAgentTools({ accessor: getDbAccessor(), agentId: "owner", actor: "owner" });
 		const getEntity = findTool(tools, "get_entity");
-		const res = readResult(await getEntity.execute("call", { agentId: "owner", entityId: "e-other" }, undefined, undefined, {} as never));
+		const res = readResult(
+			await getEntity.execute("call", { agentId: "owner", entityId: "e-other" }, undefined, undefined, {} as never),
+		);
 		expect(res.ok).toBe(false);
 		expect(res.error).toBe("Entity not found");
 	});

--- a/platform/daemon/src/pipeline/dreaming-attention.ts
+++ b/platform/daemon/src/pipeline/dreaming-attention.ts
@@ -139,6 +139,51 @@ export function getDreamingAttentionScoped(
 	});
 }
 
+/**
+ * Universe-wide attention query: one Dreaming pass addresses every agent
+ * scope, so the queue is not partitioned by agent — each record carries its
+ * owning agentId as provenance for downstream attribution.
+ */
+export function getDreamingAttentionAcrossScopes(
+	accessor: DbAccessor,
+	options: {
+		readonly kind?: string;
+		readonly status?: "pending" | "resolved";
+		readonly limit?: number;
+	},
+): readonly (DreamingAttention & { readonly agentId: string })[] {
+	const boundedLimit = Math.max(1, Math.min(Math.floor(options.limit ?? 50), 200));
+	const kindFilter = typeof options.kind === "string" && options.kind.length > 0 ? "AND kind = ?" : "";
+	const statusFilter = options.status === "resolved" ? "AND resolved_at IS NOT NULL" : "AND resolved_at IS NULL";
+	const params: unknown[] = [];
+	if (kindFilter) params.push(options.kind);
+	params.push(boundedLimit);
+	return accessor.withReadDb((db) => {
+		const rows = db
+			.prepare(
+				`SELECT agent_id AS agentId, id, kind, subject_ref AS subjectRef, details_json AS detailsJson,
+				        priority, created_at AS createdAt
+				 FROM dreaming_attention
+				 WHERE 1=1 ${kindFilter} ${statusFilter}
+				 ORDER BY priority DESC, created_at ASC, id ASC
+				 LIMIT ?`,
+			)
+			.all(...params) as Array<{
+			agentId: string;
+			id: string;
+			kind: DreamingAttentionKind;
+			subjectRef: string;
+			detailsJson: string;
+			priority: number;
+			createdAt: string;
+		}>;
+		return rows.map(({ detailsJson, ...attention }) => ({
+			...attention,
+			details: parseDetails(detailsJson),
+		}));
+	});
+}
+
 export function getDreamingAttentionById(
 	accessor: DbAccessor,
 	input: { readonly agentId: string; readonly id: string },

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -22,7 +22,7 @@ import { getOntologyClaimEvidence } from "../ontology-claim-evidence";
 import { getOntologyLinkEvidence } from "../ontology-link-evidence";
 import { findDuplicateEntityMerges } from "../ontology-proposals";
 import { detectProspectiveContradictionRisk } from "./antonyms";
-import { getDreamingAttentionScoped } from "./dreaming-attention";
+import { getDreamingAttentionAcrossScopes, getDreamingAttentionScoped } from "./dreaming-attention";
 import type { DreamingAgentEvidence } from "./dreaming-evidence";
 import { DREAMING_ONTOLOGY_OPERATION_SCHEMA } from "./dreaming-operation-contract";
 import {
@@ -156,13 +156,13 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"search_entities",
 			"Search entities",
-			"Search the scoped knowledge graph by entity name fragment and optional type.",
+			"Search the knowledge graph for one agent scope by entity name fragment and optional type. Pass the agentId of the scope you are addressing.",
 			true,
-			z.object({ query: z.string().optional(), type: z.string().optional(), ...pagination }),
-			async ({ query, type, limit, offset }) => ({
+			z.object({ agentId: z.string().min(1), query: z.string().optional(), type: z.string().optional(), ...pagination }),
+			async ({ agentId: scopeId, query, type, limit, offset }) => ({
 				ok: true,
 				items: listKnowledgeEntities(accessor, {
-					agentId,
+					agentId: scopeId,
 					query,
 					type,
 					limit: bounded(limit, 20, 100),
@@ -182,15 +182,16 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"get_entity",
 			"Get entity detail",
-			"Fetch one scoped entity with attribute/constraint counts and pinned status, optionally hydrated with its aspect claims and/or dependency links in the same call.",
+			"Fetch one entity in one agent scope with attribute/constraint counts and pinned status, optionally hydrated with its aspect claims and/or dependency links in the same call.",
 			true,
 			z.object({
+				agentId: z.string().min(1),
 				entityId: z.string().min(1),
 				include: z.array(z.enum(["aspects", "links"])).optional(),
 				direction: z.enum(["incoming", "outgoing", "both"]).optional(),
 			}),
-			async ({ entityId, include, direction }) => {
-				const detail = getKnowledgeEntityDetail(accessor, entityId, agentId);
+			async ({ agentId: scopeId, entityId, include, direction }) => {
+				const detail = getKnowledgeEntityDetail(accessor, entityId, scopeId);
 				if (!detail) return { ok: false, error: "Entity not found" };
 				const result: MutableCapabilityOutput = {
 					ok: true,
@@ -202,7 +203,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 					dependencyCount: detail.dependencyCount,
 				};
 				if (include?.includes("aspects")) {
-					result.aspects = getEntityAspectsWithCounts(accessor, entityId, agentId).map((aspect) => ({
+					result.aspects = getEntityAspectsWithCounts(accessor, entityId, scopeId).map((aspect) => ({
 						id: aspect.aspect.id,
 						name: aspect.aspect.name,
 						attributeCount: aspect.attributeCount,
@@ -212,7 +213,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 				if (include?.includes("links")) {
 					result.links = getEntityDependenciesDetailed(accessor, {
 						entityId,
-						agentId,
+						agentId: scopeId,
 						direction: direction ?? "both",
 					});
 				}
@@ -222,15 +223,15 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"list_aspect_claims",
 			"List aspect claims",
-			"List active claim attributes for one scoped entity aspect by stable ids.",
+			"List active claim attributes for one entity aspect in one agent scope by stable ids.",
 			true,
-			z.object({ entityId: z.string().min(1), aspectId: z.string().min(1), ...pagination }),
-			async ({ entityId, aspectId, limit, offset }) => ({
+			z.object({ agentId: z.string().min(1), entityId: z.string().min(1), aspectId: z.string().min(1), ...pagination }),
+			async ({ agentId: scopeId, entityId, aspectId, limit, offset }) => ({
 				ok: true,
 				items: getAttributesForAspectFiltered(accessor, {
 					entityId,
 					aspectId,
-					agentId,
+					agentId: scopeId,
 					kind: "attribute",
 					status: "active",
 					limit: bounded(limit, 50, 200),
@@ -241,20 +242,21 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"walk_links",
 			"Walk dependency links",
-			"Walk incoming and/or outgoing scoped dependency links for an entity.",
+			"Walk incoming and/or outgoing dependency links for an entity in one agent scope.",
 			true,
-			z.object({ entityId: z.string().min(1), direction: z.enum(["incoming", "outgoing", "both"]).optional() }),
-			async ({ entityId, direction }) => ({
+			z.object({ agentId: z.string().min(1), entityId: z.string().min(1), direction: z.enum(["incoming", "outgoing", "both"]).optional() }),
+			async ({ agentId: scopeId, entityId, direction }) => ({
 				ok: true,
-				items: getEntityDependenciesDetailed(accessor, { entityId, agentId, direction: direction ?? "both" }),
+				items: getEntityDependenciesDetailed(accessor, { entityId, agentId: scopeId, direction: direction ?? "both" }),
 			}),
 		),
 		capability(
 			"get_evidence",
 			"Get evidence",
-			"Resolve provenance for a scoped claim path (entity/aspect by stable id or name) or a scoped dependency link by stable id.",
+			"Resolve provenance for a claim path in one agent scope (entity/aspect by stable id or name) or a dependency link by stable id.",
 			true,
 			z.object({
+				agentId: z.string().min(1),
 				ref: z.union([
 					z.object({
 						type: z.literal("claim"),
@@ -267,17 +269,17 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 				]),
 				...pagination,
 			}),
-			async ({ ref, limit, offset }) => {
+			async ({ agentId: scopeId, ref, limit, offset }) => {
 				if (ref.type === "claim") {
 					let entityName = ref.entity;
 					let aspectName = ref.aspect;
 					// Accept stable ids as well as names for the claim path:
 					// search results surface ids, and the path resolver is
 					// name-based.
-					const detail = getKnowledgeEntityDetail(accessor, ref.entity, agentId);
+					const detail = getKnowledgeEntityDetail(accessor, ref.entity, scopeId);
 					if (detail) {
 						entityName = detail.entity.name;
-						const aspect = getEntityAspectsWithCounts(accessor, ref.entity, agentId).find(
+						const aspect = getEntityAspectsWithCounts(accessor, ref.entity, scopeId).find(
 							(candidate) => candidate.aspect.id === ref.aspect || candidate.aspect.name === ref.aspect,
 						);
 						if (aspect) aspectName = aspect.aspect.name;
@@ -285,7 +287,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 					return {
 						ok: true,
 						result: getOntologyClaimEvidence(accessor, {
-							agentId,
+							agentId: scopeId,
 							entity: entityName,
 							aspect: aspectName,
 							group: ref.group,
@@ -295,51 +297,53 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 						}),
 					};
 				}
-				return { ok: true, result: getOntologyLinkEvidence(accessor, { agentId, id: ref.id }) };
+				return { ok: true, result: getOntologyLinkEvidence(accessor, { agentId: scopeId, id: ref.id }) };
 			},
 		),
 		capability(
 			"search_evidence",
 			"Search episodic evidence",
-			"Full-text search immutable episodic memories, artifacts, transcripts, and summaries in this scope. Artifacts are deduped by content hash: content-identical files across vault paths collapse to one canonical entry.",
+			"Full-text search immutable episodic memories, artifacts, transcripts, and summaries in one agent scope. Artifacts are deduped by content hash: content-identical files across vault paths collapse to one canonical entry.",
 			true,
 			z.object({
+				agentId: z.string().min(1),
 				query: z.string().optional(),
 				since: z.string().optional(),
 				before: z.string().optional(),
 				kind: z.enum(["memory", "artifact", "transcript", "summary"]).optional(),
 				limit: z.number().finite().optional(),
 			}),
-			async ({ query, since, before, kind, limit }) => ({
+			async ({ agentId: scopeId, query, since, before, kind, limit }) => ({
 				ok: true,
 				items: accessor.withReadDb((db) =>
-					searchEpisodicSources(db, { agentId, query: query ?? "", since, before, kind, limit }),
+					searchEpisodicSources(db, { agentId: scopeId, query: query ?? "", since, before, kind, limit }),
 				),
 			}),
 		),
 		capability(
 			"validate_proposal",
 			"Validate proposal",
-			"Run the daemon's deterministic pre-write guards in one pass: entity-label gate, duplicate-entity check, and/or contradiction check against active aspect values.",
+			"Run the daemon's deterministic pre-write guards in one pass for one agent scope: entity-label gate, duplicate-entity check, and/or contradiction check against active aspect values.",
 			true,
 			z.object({
+				agentId: z.string().min(1),
 				name: z.string().optional(),
 				type: z.string().optional(),
 				entityId: z.string().optional(),
 				aspectId: z.string().optional(),
 				value: z.string().optional(),
 			}),
-			async ({ name, type, entityId, aspectId, value }) => {
+			async ({ agentId: scopeId, name, type, entityId, aspectId, value }) => {
 				const result: MutableCapabilityOutput = { ok: true };
 				if (name !== undefined) {
 					result.label = classifyEntityQuality(name, type);
-					result.duplicates = findDuplicateEntityMerges(accessor, { agentId, name });
+					result.duplicates = findDuplicateEntityMerges(accessor, { agentId: scopeId, name });
 				}
 				if (entityId !== undefined && aspectId !== undefined && value !== undefined) {
 					result.contradiction = getAttributesForAspectFiltered(accessor, {
 						entityId,
 						aspectId,
-						agentId,
+						agentId: scopeId,
 						kind: "attribute",
 						status: "active",
 						limit: 200,
@@ -382,32 +386,43 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"attention_list",
 			"List attention",
-			"List scoped attention records (the hygiene queue) by kind and resolution status.",
+			"List attention records (the hygiene queue) by kind and resolution status. Omit agentId to see the whole install's queue (each record carries its owning agentId); pass agentId to narrow to one scope.",
 			true,
 			z.object({
+				agentId: z.string().optional(),
 				kind: z.string().optional(),
 				status: z.enum(["pending", "resolved"]).optional(),
 				limit: z.number().finite().optional(),
 			}),
-			async ({ kind, status, limit }) => ({
+			async ({ agentId: scopeId, kind, status, limit }) => ({
 				ok: true,
-				items: getDreamingAttentionScoped(accessor, agentId, {
-					kind,
-					status: status ?? "pending",
-					limit: bounded(limit, 20, 100),
-				}),
+				items:
+					scopeId !== undefined
+						? getDreamingAttentionScoped(accessor, scopeId, {
+								kind,
+								status: status ?? "pending",
+								limit: bounded(limit, 20, 100),
+							})
+						: getDreamingAttentionAcrossScopes(accessor, {
+								kind,
+								status: status ?? "pending",
+								limit: bounded(limit, 50, 200),
+							}),
 			}),
 		),
 		capability(
 			"apply_ontology_ops",
 			"Apply ontology operations",
-			'Apply every semantic write through the daemon audit seam in one batch. Ops are processed in array order. Hygiene ops (flag, archive_*, merge_entities) cite provenance: "attention:$<index>" for a flag earlier in the same batch, or "attention:<uuid>" from a prior batch. Content-bearing ops cite evidence with exact quotes from canonical episodic evidence.',
+			'Apply every semantic write through the daemon audit seam in one batch, in one agent scope (pass the agentId whose graph you are maintaining — hygiene attention records belong to the agent that flagged them). Ops are processed in array order. Hygiene ops (flag, archive_*, merge_entities) cite provenance: "attention:$<index>" for a flag earlier in the same batch, or "attention:<uuid>" from a prior batch. Content-bearing ops cite evidence with exact quotes from canonical episodic evidence in that scope.',
 			false,
-			z.object({ operations: z.array(DREAMING_ONTOLOGY_OPERATION_SCHEMA).min(1).max(100) }),
-			async ({ operations }) => {
+			z.object({
+				agentId: z.string().min(1),
+				operations: z.array(DREAMING_ONTOLOGY_OPERATION_SCHEMA).min(1).max(100),
+			}),
+			async ({ agentId: scopeId, operations }) => {
 				const result = applyDreamingOperations({
 					accessor,
-					agentId,
+					agentId: scopeId,
 					actor,
 					operations,
 					passId: params.passId,

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -158,7 +158,12 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 			"Search entities",
 			"Search the knowledge graph for one agent scope by entity name fragment and optional type. Pass the agentId of the scope you are addressing.",
 			true,
-			z.object({ agentId: z.string().min(1), query: z.string().optional(), type: z.string().optional(), ...pagination }),
+			z.object({
+				agentId: z.string().min(1),
+				query: z.string().optional(),
+				type: z.string().optional(),
+				...pagination,
+			}),
 			async ({ agentId: scopeId, query, type, limit, offset }) => ({
 				ok: true,
 				items: listKnowledgeEntities(accessor, {
@@ -244,7 +249,11 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 			"Walk dependency links",
 			"Walk incoming and/or outgoing dependency links for an entity in one agent scope.",
 			true,
-			z.object({ agentId: z.string().min(1), entityId: z.string().min(1), direction: z.enum(["incoming", "outgoing", "both"]).optional() }),
+			z.object({
+				agentId: z.string().min(1),
+				entityId: z.string().min(1),
+				direction: z.enum(["incoming", "outgoing", "both"]).optional(),
+			}),
 			async ({ agentId: scopeId, entityId, direction }) => ({
 				ok: true,
 				items: getEntityDependenciesDetailed(accessor, { entityId, agentId: scopeId, direction: direction ?? "both" }),

--- a/platform/daemon/src/pipeline/dreaming-worker.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.test.ts
@@ -147,14 +147,11 @@ describe("dreaming worker agent scope", () => {
 		}
 	});
 
-	it("keeps multi-agent check-cycle passes and semantic rows agent-isolated (#946)", async () => {
-		// Behavioral regression: one worker check cycle over two agents must
-		// produce a separate pass per agent, each consolidating only its own
-		// evidence into its own agent-scoped semantic rows. The agent_id is
-		// the hard boundary; no cross-agent evidence leaks into another
-		// agent's prompt or derived graph. This mirrors the private check()
-		// loop: getDreamingWorkerAgentIds -> one runPass(runAgentId, mode) per
-		// discovered agent, using a deterministic provider.
+	it("runs one universe pass over every agent scope and keeps semantic rows agent-isolated (#946)", async () => {
+		// Behavioral regression: one Dreaming pass covers the whole install.
+		// The pass addresses each agent scope via the per-call agentId on its
+		// tools; every write is attributed to the agent named on the call, and
+		// no cross-agent evidence leaks into another scope's derived graph.
 		const ALPHA = "alpha";
 		const BETA = "beta";
 		const alphaEvidence = "Alpha is building the Apex platform.";
@@ -174,43 +171,60 @@ describe("dreaming worker agent scope", () => {
 			         datetime('now'), datetime('now'), datetime('now'))`,
 		).run(BETA, betaEvidence);
 
-		// Deterministic provider: emit an operation that cites only THIS agent's
-		// evidence (each pass is bound to one agent_id). The fixed prompt no
-		// longer carries evidence; citations resolve against the store.
+		// Deterministic provider: one universe pass consolidates BOTH scopes
+		// in a single invocation, each apply batch carrying the agentId whose
+		// graph it maintains and citing that scope's own evidence.
 		const seenPrompts: string[] = [];
 		const executorFactory = (agentId: string) => ({
 			async run(input: {
 				prompt: string;
 				tools: ReadonlyArray<{ name: string; execute: (...args: unknown[]) => Promise<unknown> }>;
 			}) {
-				const prompt = input.prompt;
-				seenPrompts.push(prompt);
+				seenPrompts.push(input.prompt);
 				const apply = input.tools.find((tool) => tool.name === "apply_ontology_ops");
 				if (!apply) throw new Error("Missing apply_ontology_ops");
-				const isAlpha = agentId === ALPHA;
 				await apply.execute("call", {
+					agentId: ALPHA,
 					operations: [
 						{
 							operation: "create_entity",
-							payload: { name: isAlpha ? "Apex" : "Zenith", type: "project" },
+							payload: { name: "Apex", type: "project" },
 							reason: "The evidence identifies the project.",
 							confidence: 0.9,
 							evidence: [
 								{
-									source_ref: isAlpha ? "summary:summary-alpha" : "summary:summary-beta",
+									source_ref: "summary:summary-alpha",
 									source_kind: "summary",
-									source_id: isAlpha ? "summary-alpha" : "summary-beta",
-									quote: isAlpha ? alphaEvidence : betaEvidence,
+									source_id: "summary-alpha",
+									quote: alphaEvidence,
 								},
 							],
 						},
 					],
 				});
-				return { summary: isAlpha ? "Consolidated alpha evidence" : "Consolidated beta evidence" };
+				await apply.execute("call", {
+					agentId: BETA,
+					operations: [
+						{
+							operation: "create_entity",
+							payload: { name: "Zenith", type: "project" },
+							reason: "The evidence identifies the project.",
+							confidence: 0.9,
+							evidence: [
+								{
+									source_ref: "summary:summary-beta",
+									source_kind: "summary",
+									source_id: "summary-beta",
+									quote: betaEvidence,
+								},
+							],
+						},
+					],
+				});
+				return { summary: "Consolidated both scopes" };
 			},
 		});
 
-		// Mirror one check cycle: discover agents, run one pass per agent.
 		const worker = startDreamingWorker(
 			accessor,
 			defaultCfg({ tokenThreshold: 1, backfillOnFirstRun: true }),
@@ -219,28 +233,21 @@ describe("dreaming worker agent scope", () => {
 			{ executorFactory },
 		);
 		try {
-			for (const agentId of getDreamingWorkerAgentIds(accessor, "default")) {
-				// Only alpha and beta have episodic evidence worth consolidating.
-				if (agentId !== ALPHA && agentId !== BETA) continue;
-				await worker.trigger("incremental", agentId);
-			}
+			// One trigger = one pass covering every discovered scope.
+			await worker.trigger("incremental", "default");
 
-			// Two passes recorded, one per agent.
-			const alphaPass = db
-				.prepare("SELECT agent_id, status, mode FROM dreaming_passes WHERE agent_id = ?")
-				.get(ALPHA) as { agent_id: string; status: string; mode: string };
-			const betaPass = db
-				.prepare("SELECT agent_id, status, mode FROM dreaming_passes WHERE agent_id = ?")
-				.get(BETA) as { agent_id: string; status: string; mode: string };
-			expect(alphaPass).toEqual({ agent_id: ALPHA, status: "completed", mode: "incremental" });
-			expect(betaPass).toEqual({ agent_id: BETA, status: "completed", mode: "incremental" });
+			// A single pass row on the primary agent.
+			const passes = db
+				.prepare("SELECT agent_id, status, mode FROM dreaming_passes ORDER BY created_at")
+				.all() as Array<{ agent_id: string; status: string; mode: string }>;
+			expect(passes).toEqual([{ agent_id: "default", status: "completed", mode: "incremental" }]);
 
-			// Each pass ran with the fixed prompt; no cross-agent evidence is
-			// injected, and the citations above resolved against each agent's
-			// own store.
-			expect(seenPrompts).toHaveLength(2);
-			expect(seenPrompts[0]).toBe(DREAMING_AGENT_PROMPT);
-			expect(seenPrompts[1]).toBe(DREAMING_AGENT_PROMPT);
+			// One invocation, and the prompt names every scope in the install.
+			expect(seenPrompts).toHaveLength(1);
+			expect(seenPrompts[0]).toContain(DREAMING_AGENT_PROMPT);
+			expect(seenPrompts[0]).toContain("<agent_scopes>");
+			expect(seenPrompts[0]).toContain(ALPHA);
+			expect(seenPrompts[0]).toContain(BETA);
 
 			// Semantic rows are agent-isolated: each agent only owns its entity.
 			const alphaEntities = (

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -187,12 +187,14 @@ export function startDreamingWorker(
 		if (active) throw new AlreadyRunningError();
 		active = true;
 		activeAgent = runAgentId;
+		const scopes = getDreamingWorkerAgentIds(accessor, defaultAgentId);
 		const p = runDreamingAgentPass(
 			accessor,
 			executorForAgent(runAgentId),
 			cfg,
 			agentsDir,
 			runAgentId,
+			scopes,
 			mode,
 			existingPassId,
 		);
@@ -217,41 +219,33 @@ export function startDreamingWorker(
 			return;
 		}
 
-		for (const runAgentId of getDreamingWorkerAgentIds(accessor, defaultAgentId)) {
+		// One Dreaming universe: a single pass covers every agent scope. The
+		// sweep runs one pass when any scope has attention or a backlog; the
+		// pass itself addresses scopes via the per-call agentId on its tools.
+		let triggered = false;
+		for (const scopeId of getDreamingWorkerAgentIds(accessor, defaultAgentId)) {
 			if (stopped || active) return;
-			let attemptedPass = false;
 			try {
-				enqueueDreamingHygieneAttention(accessor, runAgentId);
-				const episodicTokens = getDreamingEpisodicTokenBacklog(accessor, runAgentId);
-				if (!shouldTriggerDreaming(accessor, cfg, runAgentId, Date.now(), episodicTokens)) continue;
-				// A first backfill integrates the full episodic window. Compact mode is
-				// an explicit maintenance action, not an automatic substitute for it.
-				const mode: DreamingMode = "incremental";
-
+				enqueueDreamingHygieneAttention(accessor, scopeId);
+				const episodicTokens = getDreamingEpisodicTokenBacklog(accessor, scopeId);
+				if (!shouldTriggerDreaming(accessor, cfg, scopeId, Date.now(), episodicTokens)) continue;
+				triggered = true;
 				logger.info("dreaming-worker", "Episodic evidence threshold reached, starting dreaming pass", {
-					agentId: runAgentId,
+					scopeId,
 					episodicTokens,
 					threshold: cfg.tokenThreshold,
-					mode,
 				});
-
-				attemptedPass = true;
-				await runPass(runAgentId, mode);
-				// Keep one expensive, deferrable pass per five-minute sweep. The
-				// next tick advances another eligible agent without burst-starting
-				// every backlogged workspace at once.
-				return;
+				break;
 			} catch (e) {
 				if (e instanceof AlreadyRunningError) return;
-				logger.error("dreaming-worker", "Dreaming check failed", undefined, {
-					agentId: runAgentId,
+				logger.error("dreaming-worker", "Dreaming scope check failed", undefined, {
+					agentId: scopeId,
 					error: e instanceof Error ? e.message : String(e),
 				});
-				// A provider failure is still an expensive attempt. Do not turn one
-				// unhealthy sweep into a burst across every remaining agent.
-				if (attemptedPass) return;
 			}
 		}
+		if (!triggered) return;
+		await runPass(defaultAgentId, "incremental");
 	}
 
 	function schedule(): void {
@@ -295,7 +289,16 @@ export function startDreamingWorker(
 			const passId = createDreamingPass(accessor, runAgentId, mode);
 			active = true;
 			activeAgent = runAgentId;
-			const p = runDreamingAgentPass(accessor, executorForAgent(runAgentId), cfg, agentsDir, runAgentId, mode, passId);
+			const p = runDreamingAgentPass(
+				accessor,
+				executorForAgent(runAgentId),
+				cfg,
+				agentsDir,
+				runAgentId,
+				getDreamingWorkerAgentIds(accessor, defaultAgentId),
+				mode,
+				passId,
+			);
 			activePassPromise = p;
 			p.catch((e) => {
 				recordDreamingFailure(accessor, runAgentId);

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -110,6 +110,7 @@ describe("Dreaming", () => {
 			defaultCfg(),
 			"/tmp",
 			AGENT,
+			[AGENT],
 			"incremental",
 		);
 		expect(result.summary).toBe("Done");
@@ -167,6 +168,7 @@ describe("Dreaming", () => {
 			defaultCfg(),
 			"/tmp",
 			AGENT,
+			[AGENT],
 			"incremental",
 		);
 
@@ -199,6 +201,7 @@ describe("Dreaming", () => {
 			defaultCfg(),
 			"/tmp",
 			AGENT,
+			[AGENT],
 			"incremental",
 		);
 		expect(prompt).toBe(DREAMING_AGENT_PROMPT);
@@ -285,6 +288,7 @@ describe("Dreaming", () => {
 				defaultCfg(),
 				"/tmp",
 				AGENT,
+				[AGENT],
 				"incremental",
 			),
 		).rejects.toThrow("provider unavailable");
@@ -319,6 +323,7 @@ describe("Dreaming", () => {
 			defaultCfg(),
 			"/tmp",
 			AGENT,
+			[AGENT],
 			"incremental",
 		);
 
@@ -358,6 +363,7 @@ describe("Dreaming", () => {
 					await apply.execute(
 						"call",
 						{
+							agentId: AGENT,
 							operations: [
 								{
 									operation: "create_entity",
@@ -384,6 +390,7 @@ describe("Dreaming", () => {
 			defaultCfg(),
 			"/tmp",
 			AGENT,
+			[AGENT],
 			"incremental",
 		);
 		expect(result).toMatchObject({ applied: 1, failed: 0, summary: "Created Aster" });
@@ -433,6 +440,7 @@ describe("Dreaming", () => {
 			defaultCfg(),
 			"/tmp",
 			AGENT,
+			[AGENT],
 			"incremental",
 		);
 		const stored = db.prepare("SELECT runbook_json FROM dreaming_passes WHERE id = ?").get(first.passId) as {
@@ -452,6 +460,7 @@ describe("Dreaming", () => {
 			defaultCfg(),
 			"/tmp",
 			AGENT,
+			[AGENT],
 			"compact",
 		);
 		// The pass prompt is fixed; the agent reads prior notes via runbook_read.
@@ -487,6 +496,7 @@ describe("Dreaming", () => {
 			defaultCfg(),
 			"/tmp",
 			AGENT,
+			[AGENT],
 			"incremental",
 		);
 		expect(result).toMatchObject({ applied: 0, failed: 1 });
@@ -503,6 +513,7 @@ describe("Dreaming", () => {
 			defaultCfg(),
 			"/tmp",
 			AGENT,
+			[AGENT],
 			"incremental",
 		);
 		expect(empty.summary).toBe("No new episodic evidence or semantic attention to process");
@@ -527,6 +538,7 @@ describe("Dreaming", () => {
 				defaultCfg(),
 				"/tmp",
 				AGENT,
+				[AGENT],
 				"incremental",
 			),
 		).rejects.toThrow("agent timeout");

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -607,6 +607,8 @@ export const DREAMING_AGENT_PROMPT = `You are a bounded Signet maintenance agent
 
 Purpose: maintain durable, evidence-cited semantic understanding in the knowledge graph. The graph is a derived structure; every write carries provenance (an attention id for hygiene, an exact quote from episodic evidence for content). Use the pass log (runbook_read) as the dedup source: the previous pass's viewed sources and changes are the cutoff.
 
+An install may have several agent scopes (listed in <agent_scopes> when there is more than one): the scoped tools take an agentId, so address any scope you need — each write is attributed to the agent you name. attention_list without an agentId lists the whole install's hygiene queue, with each record carrying its owning agentId.
+
 ### State targets
 
 - Hygiene queue: dreaming_attention pending records (kind=hygiene)
@@ -668,24 +670,31 @@ export async function runDreamingAgentPass(
 	cfg: DreamingConfig,
 	agentsDir: string,
 	agentId: string,
+	scopes: readonly string[],
 	mode: DreamingMode,
 	existingPassId?: string,
 ): Promise<{ passId: string; applied: number; skipped: number; failed: number; summary: string }> {
 	const passId = existingPassId ?? createDreamingPass(accessor, agentId, mode);
 	const passStartedAt = new Date().toISOString();
 	try {
-		const prompt = DREAMING_AGENT_PROMPT;
+		const prompt =
+			scopes.length > 1
+				? `${DREAMING_AGENT_PROMPT}\n\n<agent_scopes>\n${scopes.join("\n")}\n</agent_scopes>`
+				: DREAMING_AGENT_PROMPT;
 
 		// SQLite-format watermark so string comparisons against stored source
 		// dates stay consistent (ISO timestamps would mis-order).
 		const cutoff = accessor.withReadDb((db) => (db.prepare("SELECT datetime('now') AS now").get() as { now: string }).now);
 
-		// Incremental passes only invoke the agent when there is work: pending
-		// attention or an episodic backlog. Scheduled checks are already gated
-		// by shouldTriggerDreaming; this protects manual triggers and compact
-		// runs from spending tokens on nothing.
-		const hasPendingAttention = accessor.withReadDb((db) => getDreamingAttentionInDb(db, agentId, 1).length > 0);
-		if (mode === "incremental" && !hasPendingAttention && getDreamingEpisodicTokenBacklog(accessor, agentId) === 0) {
+		// One Dreaming pass covers the whole install: it only runs when some
+		// scope has pending attention or an episodic backlog. Scheduled checks
+		// are already gated by shouldTriggerDreaming; this protects manual
+		// triggers and compact runs from spending tokens on nothing.
+		const hasPendingAttention = scopes.some((scope) =>
+			accessor.withReadDb((db) => getDreamingAttentionInDb(db, scope, 1).length > 0),
+		);
+		const totalBacklog = scopes.reduce((total, scope) => total + getDreamingEpisodicTokenBacklog(accessor, scope), 0);
+		if (mode === "incremental" && !hasPendingAttention && totalBacklog === 0) {
 			const summary = "No new episodic evidence or semantic attention to process";
 			accessor.withWriteTx((db) => {
 				db.prepare(
@@ -693,7 +702,7 @@ export async function runDreamingAgentPass(
 					 tokens_consumed = 0, mutations_applied = 0, mutations_skipped = 0,
 					 mutations_failed = 0, summary = ? WHERE id = ?`,
 				).run(summary, passId);
-				resetDreamingTokens(db, agentId, passId, mode, null, cutoff);
+				for (const scope of scopes) resetDreamingTokens(db, scope, passId, mode, null, cutoff);
 			});
 			return { passId, applied: 0, skipped: 0, failed: 0, summary };
 		}
@@ -748,10 +757,11 @@ export async function runDreamingAgentPass(
 				 mutations_failed = ?, summary = ? WHERE id = ?`,
 			).run(tokensConsumed, applied, 0, failed, summary, passId);
 			recordDreamingEvidenceExclusionsInTx(db, agentId, passId, rejectedEvidence, "semantic_operation_rejected");
-			// The evidence queue resets to the pass watermark: the next pass's
-			// backlog counts only sources captured after this pass began. The
-			// agent's own pass log (runbook_write) carries the viewed-source dedup.
-			resetDreamingTokens(db, agentId, passId, mode, null, cutoff);
+			// The evidence queue resets to the pass watermark for EVERY scope:
+			// the next pass's backlog counts only sources captured after this
+			// pass began. The agent's own pass log (runbook_write) carries the
+			// viewed-source dedup.
+			for (const scope of scopes) resetDreamingTokens(db, scope, passId, mode, null, cutoff);
 		});
 		return { passId, applied, skipped: 0, failed, summary };
 	} catch (error) {

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -684,7 +684,9 @@ export async function runDreamingAgentPass(
 
 		// SQLite-format watermark so string comparisons against stored source
 		// dates stay consistent (ISO timestamps would mis-order).
-		const cutoff = accessor.withReadDb((db) => (db.prepare("SELECT datetime('now') AS now").get() as { now: string }).now);
+		const cutoff = accessor.withReadDb(
+			(db) => (db.prepare("SELECT datetime('now') AS now").get() as { now: string }).now,
+		);
 
 		// One Dreaming pass covers the whole install: it only runs when some
 		// scope has pending attention or an episodic backlog. Scheduled checks


### PR DESCRIPTION
## Summary

Dreaming previously ran a separate pass per agent id: the worker discovered every scope with data and spawned one model invocation each. This is wasteful and splits maintenance into parallel universes — the same episode of knowledge gets consolidated N times, N attention queues, N states, N passes.

The fix: one Dreaming universe. A single pass covers the whole install; the pass addresses any agent scope via a per-call `agentId` on its tools, and every write is attributed to the agent named on the call. The knowledge graph remains partitioned by agent (untouched) — agent-id stays provenance for downstream recall scoping, exactly as the graph's design intends.

## Changes

- **Worker** (`dreaming-worker.ts`): the sweep runs one pass when *any* scope has attention or a backlog (hygiene enqueue + trigger check still iterate scopes). No more per-agent loop.
- **Pass** (`dreaming.ts`): `runDreamingAgentPass` takes the discovered scope list; early-exit checks attention/backlog across all scopes; the pass-end watermark reset advances every scope's evidence queue; the prompt lists the install's scopes (`<agent_scopes>`) and the runbook tells the agent to address any scope by name.
- **Tools** (`dreaming-capabilities.ts`): `search_entities`, `get_entity`, `list_aspect_claims`, `walk_links`, `get_evidence`, `search_evidence`, `validate_proposal`, `apply_ontology_ops` take `agentId` per call; `attention_list` without `agentId` returns the whole install's queue with each record carrying its owning `agentId`.
- **Attention** (`dreaming-attention.ts`): new universe-wide query.
- **Timeout** (`memory-config.ts`): default dreaming timeout 5 min → 10 min.

## Type

- [x] `feat` — new user-facing feature (bumps minor)

## Packages affected

- [x] `@signet/daemon`

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries (per-call agentId)
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested
- [x] Security checks applied to admin/mutation endpoints
- [ ] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Testing

- [x] `bun test` — dreaming suites green (43/44; the 1 failure — "seeds deterministic hygiene attention" — is pre-existing on main)
- [x] `bun run typecheck` passes
- [ ] `bun run lint` (biome) — pending final pass
- [ ] Tested against running daemon
- [ ] N/A

## Notes

- Supersedes the per-agent pass loop; agent isolation of derived rows is preserved (verified by the rewritten #946 regression: one pass, two scopes, each write lands on the agent named in the call).
- Stacked on top of the #1083 fixes (get_evidence id resolution, citation kind/id derivation) which are prerequisite friction fixes observed live.