### PR TITLE
fix(dreaming): scan recent sources before narrowing — ingest steps list new evidence first

### DIFF
--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -312,7 +312,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"search_evidence",
 			"Search episodic evidence",
-			"Full-text search immutable episodic memories, artifacts, transcripts, and summaries in one agent scope. Artifacts are deduped by content hash: content-identical files across vault paths collapse to one canonical entry.",
+			"Full-text search immutable episodic memories, artifacts, transcripts, and summaries in one agent scope. Omit the query to list the most recent sources (e.g. with since as a cutoff). Artifacts are deduped by content hash: content-identical files across vault paths collapse to one canonical entry.",
 			true,
 			z.object({
 				agentId: z.string().min(1),

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -623,7 +623,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - Inspect the flagged target (get_entity — check aspects, claims, pinned).
    - Archive or merge it, citing its attention id (provenance: "attention:<uuid>", or attention:$<index> for a flag you minted in the same batch).
    - If you discover junk the queue did not flag, mint a flag op and archive in the same batch.
-3. Only when the hygiene queue is clear: find new evidence since the cutoff (search_evidence with since). For each new source:
+3. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. For each new source:
    - search_entities for subjects it establishes.
    - Extract/update claims with exact-quote evidence from that source.
    - create_entity only for durable subjects clearly established by the source.


### PR DESCRIPTION
Live-observed gap from the 0.161.0 ingestion test: the pass searched all nine scopes with a keyword phrase that matched nothing, while the single new memory in the install was discoverable via a since-only scan. The runbook's step 3 now instructs: list recent sources with search_evidence (since, no query) first, then narrow. The search_evidence tool description now states that omitting the query lists the most recent sources.

Small prompt/tool-description change; no logic changes. Typecheck clean, dreaming suites 25/25, biome clean.