### PR TITLE
fix(hermes): never use the harness name as an agent scope (#1084)

### DIFF
--- a/integrations/hermes-agent/connector/hermes-plugin/__init__.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/__init__.py
@@ -14,7 +14,7 @@ scoring.
 Config:
   - SIGNET_HOST / SIGNET_PORT env vars (default: localhost:3850)
   - SIGNET_DAEMON_URL env var for full URL override
-  - SIGNET_AGENT_ID env var for agent scoping (default: "hermes-agent")
+  - SIGNET_AGENT_ID env var for agent scoping (unset: daemon's configured agent, usually "default")
   - SIGNET_AGENT_WORKSPACE env var for the active named-agent workspace
 """
 
@@ -303,7 +303,7 @@ def _resolve_agent_workspace(agent_id: str, kwargs: Dict[str, Any]) -> str:
 
     signet_path = _sanitize_env(os.environ.get("SIGNET_PATH", ""))
     agents_root = Path(signet_path).expanduser() if signet_path else Path.home() / ".agents"
-    if agent_id and agent_id not in ("default", "hermes-agent"):
+    if agent_id and agent_id not in ("default",):
         candidate = agents_root / "agents" / agent_id
         if candidate.exists():
             return str(candidate)
@@ -379,8 +379,8 @@ class SignetMemoryProvider(MemoryProvider):
             },
             {
                 "key": "agent_id",
-                "description": "Agent scope identifier",
-                "default": "hermes-agent",
+                "description": "Agent scope identifier. Leave empty to use the daemon's configured agent.",
+                "default": "",
                 "env_var": "SIGNET_AGENT_ID",
             },
         ]
@@ -396,12 +396,19 @@ class SignetMemoryProvider(MemoryProvider):
             return
 
         agent_id = os.environ.get("SIGNET_AGENT_ID", "").strip()
-        if not agent_id:
+        if agent_id == "hermes-agent":
+            # The harness name is provenance, never an agent scope. A stale
+            # value from an older connector install is healed by letting the
+            # daemon resolve the workspace's configured agent instead.
             logger.warning(
-                "SIGNET_AGENT_ID is not set; memory will be stored under the 'hermes-agent' "
-                "scope. Set SIGNET_AGENT_ID to scope memories to a specific agent."
+                "SIGNET_AGENT_ID='hermes-agent' is the harness name, not an agent scope; "
+                "the daemon's configured agent will be used instead."
             )
-            agent_id = "hermes-agent"
+            agent_id = ""
+        if not agent_id:
+            # No explicit agent id: the daemon resolves its configured agent
+            # (its own SIGNET_AGENT_ID, or 'default' for the default workspace).
+            logger.debug("SIGNET_AGENT_ID is not set; the daemon's configured agent scope applies.")
 
         # Skip for cron/flush contexts — no memory injection needed
         agent_context = kwargs.get("agent_context", "")

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -715,6 +715,90 @@ describe("HermesAgentConnector.install()", () => {
 		expect(envContent).toContain(`SIGNET_AGENT_WORKSPACE=${join(tmpRoot, "agents", "dot")}`);
 	});
 
+	it("resolves SIGNET_AGENT_ID from the daemon status when the env var is unset (#1084)", async () => {
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (url: string | URL | Request, _init?: RequestInit): Promise<Response> => {
+			if (String(url).endsWith("/api/status")) {
+				return new Response(JSON.stringify({ agentId: "research" }), { status: 200 });
+			}
+			return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
+		}) as typeof fetch;
+
+		try {
+			const hermesRepo = join(tmpRoot, "hermes-agent");
+			mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+			const hermesHome = join(tmpRoot, ".hermes");
+			process.env.HERMES_REPO = hermesRepo;
+			process.env.HERMES_HOME = hermesHome;
+			// biome-ignore lint/performance/noDelete: exercise the daemon-resolved fallback
+			delete process.env.SIGNET_AGENT_ID;
+
+			const result = await new HermesAgentConnector().install(tmpRoot);
+
+			expect(result.success).toBe(true);
+			const envContent = await Bun.file(join(hermesHome, ".env")).text();
+			expect(envContent).toContain("SIGNET_AGENT_ID=research");
+			expect(envContent).not.toContain("hermes-agent");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it("writes SIGNET_AGENT_ID=default, never the harness name, when the daemon is unreachable (#1084)", async () => {
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (url: string | URL | Request, _init?: RequestInit): Promise<Response> => {
+			throw new TypeError("fetch failed");
+		}) as typeof fetch;
+
+		try {
+			const hermesRepo = join(tmpRoot, "hermes-agent");
+			mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+			const hermesHome = join(tmpRoot, ".hermes");
+			process.env.HERMES_REPO = hermesRepo;
+			process.env.HERMES_HOME = hermesHome;
+			// biome-ignore lint/performance/noDelete: exercise the default fallback
+			delete process.env.SIGNET_AGENT_ID;
+
+			const result = await new HermesAgentConnector().install(tmpRoot);
+
+			expect(result.success).toBe(true);
+			const envContent = await Bun.file(join(hermesHome, ".env")).text();
+			expect(envContent).toContain("SIGNET_AGENT_ID=default");
+			expect(envContent).not.toContain("hermes-agent");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it("heals a stale SIGNET_AGENT_ID=hermes-agent instead of honoring it (#1084)", async () => {
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (url: string | URL | Request, _init?: RequestInit): Promise<Response> => {
+			if (String(url).endsWith("/api/status")) {
+				return new Response(JSON.stringify({ agentId: "research" }), { status: 200 });
+			}
+			return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
+		}) as typeof fetch;
+
+		try {
+			const hermesRepo = join(tmpRoot, "hermes-agent");
+			mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+			const hermesHome = join(tmpRoot, ".hermes");
+			process.env.HERMES_REPO = hermesRepo;
+			process.env.HERMES_HOME = hermesHome;
+			process.env.SIGNET_AGENT_ID = "hermes-agent";
+
+			const result = await new HermesAgentConnector().install(tmpRoot);
+
+			expect(result.success).toBe(true);
+			const envContent = await Bun.file(join(hermesHome, ".env")).text();
+			expect(envContent).toContain("SIGNET_AGENT_ID=research");
+			expect(envContent).not.toContain("SIGNET_AGENT_ID=hermes-agent");
+			expect(result.warnings.some((w) => w.includes("harness name, not an agent scope"))).toBe(true);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
 	it("uses SIGNET_TOKEN and configured read policy when registering named agents", async () => {
 		const originalFetch = globalThis.fetch;
 		const calls: Array<{ url: string; init?: RequestInit }> = [];
@@ -1269,7 +1353,7 @@ for vector in contract["vectors"]:
 		expect(client).toContain("TimeoutError, ValueError");
 		expect(client).toContain('_safe_score(row.get("score"))');
 		expect(client).toContain('"noHits": len(kept) == 0');
-		expect(plugin).toContain('agent_id not in ("default", "hermes-agent")');
+		expect(plugin).toContain('agent_id not in ("default",)');
 	});
 });
 

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -648,6 +648,37 @@ function configuredAgentReadPolicy(warnings: string[]): AgentReadPolicy {
 	return "shared";
 }
 
+/**
+ * Resolve the daemon's configured agent id from `/api/status`.
+ *
+ * The daemon resolves its agent id from its own `SIGNET_AGENT_ID`, falling
+ * back to `default` (see `platform/daemon/src/agent-id.ts`). This is the
+ * workspace's real agent scope, which is what the plugin inherits when no
+ * explicit agent id is set. Returns null when the daemon is unreachable or
+ * reports none, so callers fall back to `default`.
+ */
+async function resolveDaemonAgentId(daemonUrl: string): Promise<string | null> {
+	try {
+		const baseUrl = trimTrailingSlashes(daemonUrl);
+		const token = sanitizedAuthTokenEnv();
+		const headers: Record<string, string> = {};
+		if (token) {
+			headers.Authorization = `Bearer ${token}`;
+		}
+		const resp = await fetch(`${baseUrl}/api/status`, {
+			headers,
+			signal: AbortSignal.timeout(1_000),
+		});
+		if (!resp.ok) return null;
+		const body = (await resp.json()) as { agentId?: unknown };
+		const agentId = typeof body.agentId === "string" ? body.agentId.trim() : "";
+		return agentId || null;
+	} catch {
+		// Daemon offline or still starting — caller falls back to "default".
+		return null;
+	}
+}
+
 async function ensureNamedAgentRegistered(daemonUrl: string, agentId: string, warnings: string[]): Promise<void> {
 	if (!agentId || agentId === "default" || agentId === "hermes-agent") return;
 	if (process.env.SIGNET_SKIP_AGENT_REGISTER === "1") return;
@@ -786,7 +817,7 @@ export class HermesAgentConnector extends BaseConnector {
 
 		// 2. Write env config for the Signet daemon connection
 		const envPath = join(hermesHome, ".env");
-		let configuredSignetAgentId = "hermes-agent";
+		let configuredSignetAgentId = "default";
 		const configuredDaemonUrl = (process.env.SIGNET_DAEMON_URL?.trim() || "http://localhost:3850").replace(
 			/[\r\n]+/g,
 			"",
@@ -805,16 +836,28 @@ export class HermesAgentConnector extends BaseConnector {
 			if (process.env.SIGNET_TRUSTED_DAEMON_ORIGINS) {
 				signetVars.SIGNET_TRUSTED_DAEMON_ORIGINS = sanitizedEnv("SIGNET_TRUSTED_DAEMON_ORIGINS");
 			}
-			// Always write SIGNET_AGENT_ID — never allow the plugin to fall back to the
-			// shared "default" scope (AGENTS.md: never hardcode "default" for scoped paths).
-			const signetAgentId = sanitizedEnv("SIGNET_AGENT_ID") || "hermes-agent";
+			// Always write SIGNET_AGENT_ID. Resolution order: explicit env, then
+			// the daemon's configured agent (its own SIGNET_AGENT_ID or "default"),
+			// then "default" for the default workspace. The harness name
+			// ("hermes-agent") is provenance, never an agent id — a stale value
+			// from an older install is healed instead of honored.
+			let signetAgentId = sanitizedEnv("SIGNET_AGENT_ID");
+			if (signetAgentId === "hermes-agent") {
+				warnings.push(
+					"SIGNET_AGENT_ID='hermes-agent' is the harness name, not an agent scope. Re-resolving from the daemon.",
+				);
+				signetAgentId = "";
+			}
+			if (!signetAgentId) {
+				signetAgentId = (await resolveDaemonAgentId(configuredDaemonUrl)) || "default";
+			}
 			configuredSignetAgentId = signetAgentId;
 			signetVars.SIGNET_AGENT_ID = signetAgentId;
 
 			const explicitAgentWorkspace = process.env.SIGNET_AGENT_WORKSPACE?.trim();
 			if (explicitAgentWorkspace) {
 				signetVars.SIGNET_AGENT_WORKSPACE = expandHome(explicitAgentWorkspace).replace(/[\r\n]+/g, "");
-			} else if (signetAgentId && signetAgentId !== "hermes-agent" && signetAgentId !== "default") {
+			} else if (signetAgentId && signetAgentId !== "default") {
 				const agentWorkspace = join(expandedBasePath, "agents", signetAgentId);
 				if (existsSync(agentWorkspace)) {
 					signetVars.SIGNET_AGENT_WORKSPACE = agentWorkspace;


### PR DESCRIPTION
## Summary

Fixes #1084. The Hermes connector fabricated `agent_id='hermes-agent'` as the fallback agent scope, so every memory/transcript/session captured through Hermes was written under a harness-named scope instead of the operator's real agent. The harness is provenance, not scope; `hermes-agent` must never become an `agent_id`.

This was the only connector in the repo fabricating a harness-name fallback (forge and opencode pass `SIGNET_AGENT_ID` through only when set). The fabrication existed in four places:

- `connector/src/index.ts` — install-time `.env` write fell back to `"hermes-agent"`, and the default for agent registration was `"hermes-agent"`.
- `hermes-plugin/__init__.py` — runtime fallback when `SIGNET_AGENT_ID` is unset defaulted to `"hermes-agent"`.
- `hermes-plugin/__init__.py` — the config schema default (`~/.hermes/signet.json`) advertised `"hermes-agent"`.
- `hermes-plugin/__init__.py` — the workspace resolver special-cased `"hermes-agent"`.

## Changes

- `integrations/hermes-agent/connector/src/index.ts`
  - Agent scope resolution is now: explicit `SIGNET_AGENT_ID` → the daemon's configured agent id from `GET /api/status` (the daemon resolves its own `SIGNET_AGENT_ID`, falling back to `default`) → `default`.
  - A stale `SIGNET_AGENT_ID=hermes-agent` (e.g. left in `~/.hermes/.env` by an older install) is healed with a warning, not honored.
  - The connector's always-write guarantee is preserved: `SIGNET_AGENT_ID` is still always written to `.env`, but never with the harness name.
  - `ensureNamedAgentRegistered` no longer receives the fabricated scope.
- `integrations/hermes-agent/connector/hermes-plugin/__init__.py`
  - Runtime fallback: when `SIGNET_AGENT_ID` is unset, the plugin sends no agent id and the daemon resolves its configured agent scope (same resolution the connector uses). A stale `hermes-agent` value is healed the same way.
  - Config schema default is now empty (leave blank = daemon's configured agent); the harness name is no longer advertised as a scope.
  - `_resolve_agent_workspace` no longer special-cases `"hermes-agent"`.
- `integrations/hermes-agent/connector/index.test.ts`
  - Updated the pinned plugin string.
  - Added three regression tests naming the bug (#1084): daemon-status resolution when env is unset, `default` fallback when the daemon is unreachable (never the harness name), and healing a stale `hermes-agent` value.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/connector-*` (`@signet/connector-hermes-agent`)

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migration in this PR. Databases already written under `agent_id='hermes-agent'` need a separate re-scoping migration (agent_id rewrite + collision handling) as noted in #1084. After this fix ships, affected workspaces self-heal on the next `signet setup --harness hermes-agent` run or plugin session start: the stale value is detected, the daemon's configured agent is used, and new data lands in the correct scope. Existing `hermes-agent` rows are untouched by this code change.
