### PR TITLE
fix(routing): synthesize a default policy when none is configured (#1072)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -592,6 +592,14 @@ Named routing policies that agents and workloads reference.
 | `maxLatencyMs` | number | Hard latency ceiling used by routing |
 | `costCeiling` | string | Hard cost ceiling used by routing |
 
+Policies are optional: when targets exist but no `policies` (and no
+`defaultPolicy`) are configured, the router synthesizes an implicit
+`default` policy (`mode: automatic`, `defaultTargets`/`fallbackTargets` over
+all configured target refs) so every generation path keeps working. `signet
+route list` shows it like any other policy. Add an explicit policy to pin
+routing deterministically; `signet route doctor` warns when agent.yaml relies
+on the synthesized policy.
+
 ### inference.taskClasses
 
 Task-family hints for automatic routing.

--- a/platform/core/src/routing.test.ts
+++ b/platform/core/src/routing.test.ts
@@ -903,5 +903,53 @@ describe("routing reference validation (#1005)", () => {
 		if (!parsed.ok) return;
 		expect(validateRoutingReferences(parsed.value)).toEqual([]);
 	});
+
+	it("synthesizes a default policy when targets exist but no policies are configured (#1072)", () => {
+		// Regression for #1072: the connect flow / aggregate-recall route emit
+		// targets + accounts + workloads but no policy, which previously dead-ended
+		// every routed generation path (dream trigger, daily brief, reflections,
+		// route explain) in "No routing policy is configured.".
+		const backgroundRef = makeRoutingTargetRef("background", "default");
+		const aggregationRef = makeRoutingTargetRef("aggregation", "default");
+		const parsed = parseRoutingConfig({
+			inference: {
+				targets: {
+					background: { executor: "ollama", models: { default: { model: "gemma3" } } },
+					aggregation: { executor: "ollama", models: { default: { model: "gemma3" } } },
+				},
+				workloads: {
+					memoryExtraction: { target: backgroundRef },
+					aggregateRecall: { target: aggregationRef },
+				},
+			},
+		});
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok) return;
+		expect(parsed.value.defaultPolicy).toBe("default");
+		expect(parsed.value.policies.default?.defaultTargets).toEqual([backgroundRef, aggregationRef]);
+		expect(validateRoutingReferences(parsed.value).filter((i) => i.severity === "error")).toEqual([]);
+
+		// session_synthesis (dreaming) must route instead of erroring.
+		const synthesis = resolveRoutingDecision(
+			parsed.value,
+			{ operation: "session_synthesis" },
+			{ targets: { [backgroundRef]: ready } },
+		);
+		expect(synthesis.ok).toBe(true);
+		if (!synthesis.ok) return;
+		expect(synthesis.value.policyId).toBe("default");
+		expect(synthesis.value.targetRef).toBe(backgroundRef);
+
+		// `route explain --target <healthy ref>` must bypass the policy search too.
+		const explicit = resolveRoutingDecision(
+			parsed.value,
+			{ operation: "interactive", explicitTargets: [aggregationRef] },
+			{ targets: { [aggregationRef]: ready } },
+		);
+		expect(explicit.ok).toBe(true);
+		if (!explicit.ok) return;
+		expect(explicit.value.policyId).toBe("default");
+		expect(explicit.value.targetRef).toBe(aggregationRef);
+	});
 });
 

--- a/platform/core/src/routing.ts
+++ b/platform/core/src/routing.ts
@@ -916,6 +916,29 @@ export function parseRoutingConfig(raw: unknown): RouterResult<RoutingConfig> {
 	}
 
 	const explicitDefaultPolicy = asString(routingRaw.defaultPolicy ?? routingRaw.default_policy);
+
+	// A targets-bearing config with zero policies must not dead-end every routed
+	// generation path in "No routing policy is configured." (#1072): the connect
+	// flow and aggregate-recall route emit targets/accounts/workloads but no
+	// policy. Synthesize an implicit default policy over all configured targets,
+	// mirroring the defaultPolicy auto-resolution below. `validateRoutingReferences`
+	// runs after this, so the synthetic refs are validated like any other policy.
+	// A dangling *explicit* defaultPolicy is left alone (#1005 tolerance: a
+	// mid-setup agent.yaml may name a policy before its block exists).
+	if (!explicitDefaultPolicy && Object.keys(policies).length === 0 && Object.keys(targets).length > 0) {
+		const refs: string[] = [];
+		for (const [targetId, target] of Object.entries(targets)) {
+			for (const modelId of Object.keys(target.models)) {
+				refs.push(makeRoutingTargetRef(targetId, modelId));
+			}
+		}
+		policies.default = {
+			mode: "automatic",
+			defaultTargets: refs,
+			fallbackTargets: refs,
+		};
+	}
+
 	const enabled = asBool(routingRaw.enabled) ?? (Object.keys(targets).length > 0 || base.enabled);
 	const defaultPolicy = explicitDefaultPolicy ?? base.defaultPolicy ?? Object.keys(policies)[0];
 

--- a/surfaces/cli/src/commands/route.ts
+++ b/surfaces/cli/src/commands/route.ts
@@ -262,6 +262,24 @@ export function registerRouteCommands(program: Command, deps: RouteDeps): void {
 					`${targetId}: ACPX model selection is agent-managed for ${target.acpx.agent}; verify the agent's native configuration matches the routed model`,
 				];
 			});
+			// #1072: a targets-bearing agent.yaml with no explicit policy still routes
+			// (the daemon synthesizes a default policy over all targets), but the user
+			// should pin it explicitly rather than rely on the implicit one.
+			const yaml = readAgentYaml(deps.AGENTS_DIR);
+			if (yaml.exists) {
+				const inference = isRecord(yaml.data.inference) ? yaml.data.inference : null;
+				const hasTargets =
+					inference !== null && isRecord(inference.targets) && Object.keys(inference.targets).length > 0;
+				const explicitPolicies =
+					inference !== null && isRecord(inference.policies) ? Object.keys(inference.policies) : [];
+				const explicitDefaultPolicy =
+					inference !== null ? (inference as { defaultPolicy?: unknown }).defaultPolicy : undefined;
+				if (hasTargets && explicitPolicies.length === 0 && explicitDefaultPolicy === undefined) {
+					warnings.push(
+						"No inference.policies / inference.defaultPolicy: routing auto-synthesizes a default policy over all targets. Add both to agent.yaml to pin routing explicitly (#1072).",
+					);
+				}
+			}
 			const summary = {
 				enabled: status.enabled,
 				source: status.source,

--- a/surfaces/cli/src/features/setup-pipeline.test.ts
+++ b/surfaces/cli/src/features/setup-pipeline.test.ts
@@ -291,4 +291,41 @@ describe("applyAggregateRecallRoute", () => {
 		expect(inference.workloads.memoryExtraction).toBeDefined();
 		expect(inference.workloads.aggregateRecall).toBeDefined();
 	});
+
+	it("emits a default policy over all merged targets when none exist (#1072)", () => {
+		// Regression for #1072: targets/accounts/workloads without a policy
+		// dead-end every generation path in "No routing policy is configured.".
+		const config: Record<string, unknown> = {};
+		applyAggregateRecallRoute(config, buildSetupAggregateRecall("ollama", "qwen3:4b"));
+		const inference = config.inference as {
+			defaultPolicy: string;
+			policies: Record<string, { mode: string; defaultTargets: string[]; fallbackTargets: string[] }>;
+		};
+		expect(inference.defaultPolicy).toBe("default");
+		expect(inference.policies.default).toMatchObject({
+			mode: "automatic",
+			defaultTargets: ["aggregation/default"],
+			fallbackTargets: ["aggregation/default"],
+		});
+	});
+
+	it("does not clobber existing policies when merging the aggregate-recall route (#1072)", () => {
+		const config: Record<string, unknown> = {
+			inference: {
+				defaultPolicy: "custom",
+				policies: {
+					custom: {
+						mode: "automatic",
+						defaultTargets: ["background-acpx/default"],
+						fallbackTargets: ["background-acpx/default"],
+					},
+				},
+				targets: { "background-acpx": { executor: "acpx" } },
+			},
+		};
+		applyAggregateRecallRoute(config, buildSetupAggregateRecall("ollama", "qwen3:4b"));
+		const inference = config.inference as { defaultPolicy: string; policies: Record<string, unknown> };
+		expect(inference.defaultPolicy).toBe("custom");
+		expect(Object.keys(inference.policies)).toEqual(["custom"]);
+	});
 });

--- a/surfaces/cli/src/features/setup-pipeline.ts
+++ b/surfaces/cli/src/features/setup-pipeline.ts
@@ -314,5 +314,35 @@ export function applyAggregateRecallRoute(
 	const accounts = aggregateRecall.accounts
 		? { ...((existing.accounts as Record<string, unknown>) ?? {}), ...aggregateRecall.accounts }
 		: (existing.accounts as Record<string, unknown> | undefined);
-	config.inference = { ...existing, targets, workloads, ...(accounts ? { accounts } : {}) };
+	const policies = (existing.policies as Record<string, unknown> | undefined) ?? {};
+	// Targets/accounts/workloads without a policy dead-end every generation path
+	// in "No routing policy is configured." (#1072). When the merged config has
+	// targets but zero policies, emit a default policy over all of them; leave
+	// user-authored or acpx-generated policies alone.
+	const refs =
+		Object.keys(policies).length === 0 && Object.keys(targets).length > 0
+			? Object.entries(targets).flatMap(([targetId, target]) =>
+					Object.keys((target as { models?: Record<string, unknown> })?.models ?? {}).map(
+						(modelId) => `${targetId}/${modelId}`,
+					),
+				)
+			: null;
+	config.inference = {
+		...existing,
+		targets,
+		workloads,
+		...(accounts ? { accounts } : {}),
+		...(refs
+			? {
+					defaultPolicy: "default",
+					policies: {
+						default: {
+							mode: "automatic",
+							defaultTargets: refs,
+							fallbackTargets: refs,
+						},
+					},
+				}
+			: {}),
+	};
 }

--- a/surfaces/dashboard/src/lib/components/tabs/settings/InferenceSection.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/InferenceSection.svelte
@@ -330,6 +330,26 @@ function writeTarget(opts: {
 		st.aDel(workloadBase);
 		return;
 	}
+	// A target write must leave routing routable: targets/accounts/workloads
+	// without a policy dead-end every generation path in "No routing policy is
+	// configured." (#1072). Emit an explicit default policy bound to this target
+	// when none exists; leave user-authored policies alone.
+	const existingPolicies = st.get(st.agent, "inference", "policies");
+	if (
+		existingPolicies == null ||
+		typeof existingPolicies !== "object" ||
+		Array.isArray(existingPolicies) ||
+		Object.keys(existingPolicies).length === 0
+	) {
+		st.set(st.agent, ["inference", "policies", "default"], {
+			mode: "automatic",
+			defaultTargets: [`${targetName}/default`],
+			fallbackTargets: [`${targetName}/default`],
+		});
+		if (!st.aStr(["inference", "defaultPolicy"])) {
+			st.aSetStr(["inference", "defaultPolicy"], "default");
+		}
+	}
 	// A model is only valid for its own provider family, so a backend switch
 	// must clear the stale model (and its legacy label) to force a re-pick —
 	// otherwise switching ollama:gemma3 -> anthropic would leave the routing


### PR DESCRIPTION
## Summary

Fixes #1072. A valid-looking `inference` config with healthy targets, accounts, and workload bindings but **no `policies` and no `defaultPolicy`** dead-ended every routed generation path — `signet dream trigger`, daily brief/reflections, `signet route explain`, and `signet route execute` — with `"No routing policy is configured."` The config flow (dashboard `InferenceSection`, CLI aggregate-recall route) emitted targets/accounts/workloads but no policy, and workload bindings only feed per-operation candidate ordering; they never satisfy the policy requirement.

## Changes

- **`@signet/core` routing** (`platform/core/src/routing.ts`): `parseRoutingConfig` now synthesizes an implicit `default` policy (`mode: automatic`, `defaultTargets`/`fallbackTargets` over all target refs) when targets exist but zero policies are configured. Fixes existing configs (no hand-edit needed) and every future policy-less producer, for all surfaces at once. A dangling *explicit* `defaultPolicy` is still left alone (preserves the #1005 mid-setup tolerance).
- **Writers emit canonical config**: dashboard `InferenceSection.writeTarget` and CLI `applyAggregateRecallRoute` now emit `policies.default` + `defaultPolicy` when none exists, so new configs are explicit rather than implicit. Existing user-authored policies are never clobbered.
- **`signet route doctor`** now warns when agent.yaml has inference targets but no explicit policies/defaultPolicy, with the exact remediation — distinct from the #1005 broken-target-reference case.
- **Docs**: `docs/CONFIGURATION.md` notes the synthesized default policy.
- **Regression tests**: a targets-without-policies config now parses with a synthesized policy and resolves `session_synthesis` (dreaming) and explicit-target explains; the aggregate-recall writer emits a policy when none exists and never clobbers existing ones.

With the synthesis in place, `signet route explain --target <healthy ref>` works without the policy requirement bypass.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A — no visual UI change (dashboard logic only).

## PR Readiness (MANDATORY)

- [ ] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries — none touch data
- [x] Input/config validation and bounds checks added — synthesized policy refs validated by existing `validateRoutingReferences`
- [x] Error handling and fallback paths tested (no silent swallow) — doctor warns loudly, synthesis is explicit in `route list`
- [x] Security checks applied to admin/mutation endpoints — none touched
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes

None — no schema or migration changes. Existing policy-less configs start routing on daemon restart (config is parsed at load).
