### PR TITLE
fix(daemon): hoist entity-context hot paths

### DIFF
--- a/platform/daemon/src/hooks.prompt-submit.test.ts
+++ b/platform/daemon/src/hooks.prompt-submit.test.ts
@@ -605,10 +605,10 @@ describe("handleUserPromptSubmit entity context", () => {
 			makeDeps(),
 		);
 
-		expect(fetchEmbeddingMock.mock.calls.map((call) => call[0])).toEqual([
-			"collaboration style",
-			"collaboration style",
-		]);
+		// The shared semantic query is embedded exactly once, with every
+		// matched entity's terms stripped (not once per entity — the
+		// duplicate-fetch behavior was the #1059 scaling defect).
+		expect(fetchEmbeddingMock.mock.calls.map((call) => call[0])).toEqual(["collaboration style"]);
 	});
 
 	it("requires lexical support for generic prompt context semantic hits", async () => {

--- a/platform/daemon/src/prompt-entity-context.test.ts
+++ b/platform/daemon/src/prompt-entity-context.test.ts
@@ -1,0 +1,186 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor, initDbAccessorAsync } from "./db-accessor";
+import type { EmbeddingConfig } from "./memory-config";
+import { buildEntityPromptContext, promptPhraseSpan } from "./prompt-entity-context";
+
+let dir = "";
+let prev: string | undefined;
+
+const DB_PATH = (): string => join(dir, "memory", "memories.db");
+
+function seedEntityContext(): void {
+	const now = new Date().toISOString();
+	getDbAccessor().withWriteTx((db) => {
+		db.prepare(
+			`INSERT INTO entities (
+				id, name, canonical_name, entity_type, agent_id, pinned, pinned_at, mentions, created_at, updated_at
+			) VALUES (?, ?, ?, 'person', 'default', 1, ?, 50, ?, ?)`,
+		).run("ent-nicholai", "Nicholai", "nicholai", now, now, now);
+
+		db.prepare(
+			`INSERT INTO entities (
+				id, name, canonical_name, entity_type, agent_id, pinned, pinned_at, mentions, created_at, updated_at
+			) VALUES (?, ?, ?, 'project', 'default', 0, NULL, 10, ?, ?)`,
+		).run("ent-signet", "Signet", "signet", now, now);
+
+		db.prepare(
+			`INSERT INTO entity_aspects (
+				id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at
+			) VALUES (?, ?, 'default', ?, ?, 0.9, ?, ?)`,
+		).run("asp-nicholai", "ent-nicholai", "background", "background", now, now);
+		db.prepare(
+			`INSERT INTO entity_aspects (
+				id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at
+			) VALUES (?, ?, 'default', ?, ?, 0.9, ?, ?)`,
+		).run("asp-signet", "ent-signet", "overview", "overview", now, now);
+
+		for (const memory of [
+			{ id: "mem-nicholai", content: "Nicholai prefers source-first engineering" },
+			{ id: "mem-signet", content: "Signet is a portable memory layer for AI agents" },
+		]) {
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, normalized_content, content_hash, who, project, type,
+					agent_id, visibility, created_at, updated_at, updated_by
+				) VALUES (?, ?, ?, ?, 'test', 'test', 'fact', 'default', 'private', ?, ?, 'test')`,
+			).run(memory.id, memory.content, memory.content.toLowerCase(), `hash-${memory.id}`, now, now);
+		}
+
+		db.prepare(
+			`INSERT INTO entity_attributes (
+				id, aspect_id, agent_id, memory_id, kind, content, normalized_content,
+				confidence, importance, status, group_key, claim_key, created_at, updated_at
+			) VALUES (?, ?, 'default', ?, 'attribute', ?, ?, 0.9, 0.8, 'active', ?, ?, ?, ?)`,
+		).run(
+			"attr-nicholai",
+			"asp-nicholai",
+			"mem-nicholai",
+			"Prefers source-first engineering",
+			"prefers source-first engineering",
+			"background",
+			"identity",
+			now,
+			now,
+		);
+		db.prepare(
+			`INSERT INTO entity_attributes (
+				id, aspect_id, agent_id, memory_id, kind, content, normalized_content,
+				confidence, importance, status, group_key, claim_key, created_at, updated_at
+			) VALUES (?, ?, 'default', ?, 'attribute', ?, ?, 0.9, 0.8, 'active', ?, ?, ?, ?)`,
+		).run(
+			"attr-signet",
+			"asp-signet",
+			"mem-signet",
+			"Portable memory layer for AI agents",
+			"portable memory layer for ai agents",
+			"overview",
+			"purpose",
+			now,
+			now,
+		);
+
+		for (const [id, sourceId] of [
+			["emb-nicholai", "mem-nicholai"],
+			["emb-signet", "mem-signet"],
+		]) {
+			db.prepare(
+				`INSERT INTO embeddings (
+					id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id
+				) VALUES (?, ?, ?, 2, 'memory', ?, ?, ?, 'default')`,
+			).run(id, `emb-hash-${id}`, Buffer.from(new Float32Array([0.5, 0.5]).buffer), sourceId, `${id} text`, now);
+		}
+	});
+}
+
+describe("prompt entity context scaling (#1059)", () => {
+	beforeAll(async () => {
+		prev = process.env.SIGNET_PATH;
+		dir = mkdtempSync(join(tmpdir(), "signet-prompt-entity-context-"));
+		mkdirSync(join(dir, "memory"), { recursive: true });
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			`memory:
+  pipelineV2:
+    enabled: false
+`,
+		);
+		process.env.SIGNET_PATH = dir;
+		await initDbAccessorAsync(DB_PATH(), { agentsDir: dir });
+	});
+
+	beforeEach(() => {
+		closeDbAccessor();
+		rmSync(DB_PATH(), { force: true });
+		rmSync(`${DB_PATH()}-shm`, { force: true });
+		rmSync(`${DB_PATH()}-wal`, { force: true });
+		initDbAccessor(DB_PATH(), { agentsDir: dir });
+		seedEntityContext();
+	});
+
+	afterEach(() => {
+		closeDbAccessor();
+	});
+
+	afterAll(() => {
+		closeDbAccessor();
+		if (prev === undefined) {
+			process.env.SIGNET_PATH = undefined;
+		} else {
+			process.env.SIGNET_PATH = prev;
+		}
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("embeds the shared semantic query once instead of once per matched entity", async () => {
+		let embeddingCalls = 0;
+		const result = await buildEntityPromptContext({
+			userMessage: "Tell me about Nicholai and the Signet project",
+			agentId: "default",
+			minScore: 0.3,
+			injectBudget: 4000,
+			memoryDbPath: DB_PATH(),
+			fetchEmbedding: async () => {
+				embeddingCalls += 1;
+				return [0.5, 0.5];
+			},
+			embedding: { provider: "test", model: "test" } as EmbeddingConfig,
+		});
+
+		// Two entities match the prompt, but both are scored against the same
+		// query vector. One fetch per entity would double embedding latency on
+		// every prompt-submit (#1059).
+		expect(embeddingCalls).toBe(1);
+		expect(result.engine).toBe("entity-context");
+		expect(result.lines.length).toBeGreaterThanOrEqual(2);
+		const joined = result.lines.join("\n");
+		expect(joined).toContain("Nicholai");
+		expect(joined).toContain("Signet");
+		expect(result.memoryCount).toBeGreaterThanOrEqual(2);
+	});
+
+	describe("promptPhraseSpan matches precomputed prompt terms", () => {
+		const promptTerms = ["tell", "me", "about", "nicholai", "and", "the", "signet", "project"];
+
+		it("locates an exact entity phrase", () => {
+			expect(promptPhraseSpan(promptTerms, "Nicholai")).toEqual({ start: 3, end: 4 });
+			expect(promptPhraseSpan(promptTerms, "Signet")).toEqual({ start: 6, end: 7 });
+		});
+
+		it("normalizes possessive forms before matching", () => {
+			expect(promptPhraseSpan(promptTerms, "Nicholai's")).toEqual({ start: 3, end: 4 });
+		});
+
+		it("matches a pluralized prompt term for a singular phrase", () => {
+			expect(promptPhraseSpan(["i", "love", "signets"], "signet")).toEqual({ start: 2, end: 3 });
+		});
+
+		it("rejects absent, too-short, and over-long phrases", () => {
+			expect(promptPhraseSpan(promptTerms, "zebra")).toBeNull();
+			expect(promptPhraseSpan(promptTerms, "ok")).toBeNull();
+			expect(promptPhraseSpan(promptTerms, "nicholai and the signet project plus extra")).toBeNull();
+		});
+	});
+});

--- a/platform/daemon/src/prompt-entity-context.ts
+++ b/platform/daemon/src/prompt-entity-context.ts
@@ -2,9 +2,9 @@ import { existsSync } from "node:fs";
 import { cosineSimilarity } from "@signet/core";
 import { selectWithBudgetSkippingOversized } from "./context-budget";
 import { type ReadDb, getDbAccessor, hasDbAccessor } from "./db-accessor";
+import type { EmbeddingRole } from "./embedding-profile";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
-import type { EmbeddingRole } from "./embedding-profile";
 import { countPromptTermOverlap, extractSubstantiveWords, stripUntrustedMetadata } from "./prompt-text";
 
 type FetchEmbedding = (text: string, cfg: EmbeddingConfig, role?: EmbeddingRole) => Promise<number[] | null>;
@@ -128,8 +128,17 @@ function promptEntityTermMatches(promptTerm: string, phraseTerm: string): boolea
 	);
 }
 
-function promptPhraseSpan(prompt: string, phrase: string): { readonly start: number; readonly end: number } | null {
-	const promptTerms = promptEntityTerms(prompt);
+/**
+ * Locate a phrase's token span inside precomputed prompt terms.
+ *
+ * Callers tokenize the prompt once and pass the terms in: tokenizing the
+ * prompt here would re-run the same regex pass per entity row, making
+ * prompt-submit O(rows x prompt length) on large graphs (#1059).
+ */
+export function promptPhraseSpan(
+	promptTerms: readonly string[],
+	phrase: string,
+): { readonly start: number; readonly end: number } | null {
 	const phraseTerms = promptEntityTerms(phrase);
 	if (phraseTerms.join(" ").length < MIN_PROMPT_ENTITY_MATCH_CHARS) return null;
 	if (phraseTerms.length === 0 || phraseTerms.length > promptTerms.length) return null;
@@ -286,11 +295,14 @@ function resolvePromptEntityMatches(db: ReadDb, agentId: string, userMessage: st
 	}>;
 
 	const candidatesByPhrase = new Map<string, PromptEntityCandidate[]>();
+	// Tokenize the prompt once: promptPhraseSpan takes precomputed terms, so
+	// the full-prompt regex pass does not repeat per entity row (#1059).
+	const promptTerms = promptEntityTerms(userMessage);
 	for (const row of rows) {
 		if (!isPromptEntityContextTypeAllowed(row.entity_type)) continue;
 		if (isPromptRoleEntity(row)) continue;
 		if (isPromptGenericEntityPhrase(promptEntityTerms(row.matched_text))) continue;
-		const span = promptPhraseSpan(userMessage, row.matched_text);
+		const span = promptPhraseSpan(promptTerms, row.matched_text);
 		if (!span) continue;
 		const normalizedPhrase = normalizePromptEntityText(row.matched_text);
 		const candidate: PromptEntityCandidate = {
@@ -656,36 +668,23 @@ export async function buildEntityPromptContext({
 	const matches = getDbAccessor().withReadDb((db) => resolvePromptEntityMatches(db, agentId, userMessage));
 	if (matches.length === 0) return { lines: [], memories: [], memoryCount: 0, engine: "no-entity" };
 
-	const vectorsByEntity = new Map<
-		string,
-		{ readonly semanticQuery: string; readonly queryVector: Float32Array | null }
-	>();
 	const sharedSemanticQuery = queryWithoutPromptEntities(userMessage, matches);
-	for (const entity of matches) {
-		const semanticQuery = sharedSemanticQuery;
-		if (!semanticQuery) continue;
-		let queryVector: Float32Array | null = null;
-		try {
-			const vector = await fetchEmbedding(semanticQuery, embedding, "query");
-			if (vector) queryVector = new Float32Array(vector);
-		} catch (error) {
-			logger.warn("hooks", "Entity attribute semantic scoring failed; using lexical attribute scoring", {
-				error: error instanceof Error ? error.message : String(error),
-			});
-		}
-		vectorsByEntity.set(entity.entityId, { semanticQuery, queryVector });
+	if (!sharedSemanticQuery) return { lines: [], memories: [], memoryCount: 0, engine: "no-aspect-hit" };
+	// Embed the invariant query once, not once per matched entity: every match
+	// is scored against the same vector, so per-entity fetches are identical
+	// calls that multiply embedding latency by the match count (#1059).
+	let sharedQueryVector: Float32Array | null = null;
+	try {
+		const vector = await fetchEmbedding(sharedSemanticQuery, embedding, "query");
+		if (vector) sharedQueryVector = new Float32Array(vector);
+	} catch (error) {
+		logger.warn("hooks", "Entity attribute semantic scoring failed; using lexical attribute scoring", {
+			error: error instanceof Error ? error.message : String(error),
+		});
 	}
-	if (vectorsByEntity.size === 0) return { lines: [], memories: [], memoryCount: 0, engine: "no-aspect-hit" };
 	return getDbAccessor().withReadDb((db) => {
 		const lines = matches.flatMap((entity) =>
-			loadEntityContextLines(
-				db,
-				entity,
-				agentId,
-				vectorsByEntity.get(entity.entityId)?.semanticQuery ?? "",
-				minScore,
-				vectorsByEntity.get(entity.entityId)?.queryVector ?? null,
-			),
+			loadEntityContextLines(db, entity, agentId, sharedSemanticQuery, minScore, sharedQueryVector),
 		);
 		if (lines.length === 0) return { lines: [], memories: [], memoryCount: 0, engine: "no-aspect-hit" };
 		const selected = selectWithBudgetSkippingOversized(


### PR DESCRIPTION
## Summary

Follow-up from #1059: the prompt-submit entity-context hook did two redundant passes that scale with the entity graph. On a 25,930-row graph this measured ~0.49s per call before the tokenization hoist (issue comment 2026-08-02, defect 1). Both passes are now O(1) instead of O(rows) / O(matches).

## Changes

- `platform/daemon/src/prompt-entity-context.ts`
  - `promptPhraseSpan` now takes precomputed prompt terms; `resolvePromptEntityMatches` tokenizes the prompt once instead of once per entity+alias row. Per-row re-tokenization is no longer representable (signature-level fix).
  - `buildEntityPromptContext` embeds the invariant shared semantic query exactly once and reuses the vector for every matched entity, instead of one identical `fetchEmbedding` call per match.
- `platform/daemon/src/prompt-entity-context.test.ts` (new)
  - Regression test: with two matched entities, `fetchEmbedding` is called exactly once — the old per-entity loop makes two calls and fails this assertion (verified by reverting).
  - Unit tests pin the hoisted `promptPhraseSpan(promptTerms, phrase)` contract and preserve span semantics (exact, possessive, plural, absent/too-short/over-long).

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`

## Screenshots

N/A — no UI change.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec change
- [x] Agent scoping verified on all new/changed data queries — unchanged queries; `agentId` still threaded through `resolvePromptEntityMatches` / `loadEntityContextLines`
- [x] Input/config validation and bounds checks added — no new inputs
- [x] Error handling and fallback paths tested (no silent swallow) — single shared fetch keeps the existing warn-and-fall-back-to-lexical path
- [x] Security checks applied to admin/mutation endpoints — N/A, read-only hook path
- [x] Docs updated for API/spec/status changes — N/A, no API change
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally — see Testing

## Migration Notes (if applicable)

N/A — no migrations touched.

## Testing

- [x] `bun test platform/daemon/src/prompt-entity-context.test.ts` passes (5 pass, 0 fail)
- [x] `bun run typecheck` passes (all workspaces)
- [x] `bun run lint` — pre-existing repo-wide failures in this checkout (6119 errors on clean main, all in `dist/` artifacts and generated files; the touched files pass `biome check` clean)
- [x] `bun run --filter '@signet/daemon' build` passes
- [ ] Tested against running daemon — N/A (perf-only refactor of a pure path, covered by the regression test)

## AI disclosure

- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The remaining #1059 follow-ups on main: the unbounded `getDreamingWorkerAgentIds` UNION, the missing halt-after-N-consecutive-failures counter, and the off-main `/health` probe (#1073 covers the native-embedding wedge).
