### PR TITLE
fix(daemon): bound dreaming agent-scope discovery and halt after repeated failures

### DIFF
--- a/platform/daemon/src/pipeline/dreaming-worker.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.test.ts
@@ -6,8 +6,13 @@ import { join } from "node:path";
 import type { DreamingConfig } from "@signet/core";
 import { runMigrations } from "../../../core/src/migrations";
 import type { DbAccessor } from "../db-accessor";
-import { DREAMING_AGENT_PROMPT } from "./dreaming";
-import { getDreamingWorkerAgentIds, shouldDeferDreamingSweep, startDreamingWorker } from "./dreaming-worker";
+import { DREAMING_AGENT_PROMPT, enqueueDreamingHygieneAttention } from "./dreaming";
+import {
+	createAgentScopeSnapshot,
+	getDreamingWorkerAgentIds,
+	shouldDeferDreamingSweep,
+	startDreamingWorker,
+} from "./dreaming-worker";
 
 function defaultCfg(overrides?: Partial<DreamingConfig>): DreamingConfig {
 	return {
@@ -97,6 +102,28 @@ describe("dreaming worker agent scope", () => {
 		]);
 	});
 
+	it("serves the agent-scope union from a snapshot refreshed on a cadence", () => {
+		let resolves = 0;
+		let now = 0;
+		const scopes = createAgentScopeSnapshot(
+			1_000,
+			() => {
+				resolves += 1;
+				return ["default", "new-scope"];
+			},
+			() => now,
+		);
+		expect(scopes()).toEqual(["default", "new-scope"]);
+		// Within the refresh window the union query does not run again.
+		now = 999;
+		expect(scopes()).toEqual(["default", "new-scope"]);
+		expect(resolves).toBe(1);
+		// Past the window the next read re-resolves the union.
+		now = 1_000;
+		expect(scopes()).toEqual(["default", "new-scope"]);
+		expect(resolves).toBe(2);
+	});
+
 	it("defers a sweep while the shared queue health watermark is exceeded", () => {
 		const now = new Date().toISOString();
 		for (let index = 0; index <= 50; index += 1) {
@@ -130,21 +157,20 @@ describe("dreaming worker agent scope", () => {
 		}
 	});
 
-	it("seeds deterministic hygiene attention for legacy graph rows at worker startup", () => {
+	it("seeds deterministic hygiene attention for legacy graph rows", () => {
+		// Hygiene attention is enqueued during regular check() ticks, not at
+		// worker startup (startup scans block the event loop before the HTTP
+		// server binds). Exercise the enqueue contract directly.
 		db.prepare(
 			`INSERT INTO entities
 			 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
 			 VALUES ('legacy-husk', 'Legacy Husk', 'legacy husk', 'project', 'default', 5, datetime('now'), datetime('now'))`,
 		).run();
-		const worker = startDreamingWorker(accessor, defaultCfg(), agentsDir, "default");
-		try {
-			expect(db.prepare("SELECT kind, subject_ref FROM dreaming_attention WHERE agent_id = ?").get("default")).toEqual({
-				kind: "hygiene",
-				subject_ref: "entity:legacy-husk",
-			});
-		} finally {
-			worker.stop();
-		}
+		enqueueDreamingHygieneAttention(accessor, "default");
+		expect(db.prepare("SELECT kind, subject_ref FROM dreaming_attention WHERE agent_id = ?").get("default")).toEqual({
+			kind: "hygiene",
+			subject_ref: "entity:legacy-husk",
+		});
 	});
 
 	it("runs one universe pass over every agent scope and keeps semantic rows agent-isolated (#946)", async () => {

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -16,6 +16,7 @@ import {
 	createDreamingPass,
 	enqueueDreamingHygieneAttention,
 	getDreamingEpisodicTokenBacklog,
+	isDreamingHaltActive,
 	recordDreamingFailure,
 	runDreamingAgentPass,
 	shouldTriggerDreaming,
@@ -63,6 +64,7 @@ export interface DreamingWorkerOptions {
 }
 
 const CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 min
+const AGENT_SCOPE_SNAPSHOT_REFRESH_MS = 30 * 60 * 1000; // 30 min
 
 /** Dreaming is deferrable work. Yield an entire sweep while live queues are under pressure. */
 export function shouldDeferDreamingSweep(accessor: DbAccessor): boolean {
@@ -106,6 +108,30 @@ export function getDreamingWorkerAgentIds(accessor: DbAccessor, defaultAgentId: 
 	});
 }
 
+/**
+ * Bounded agent-scope discovery: resolves the union query on a refresh
+ * cadence and serves the snapshot between refreshes. Periodic dreaming is
+ * deferrable, so a stale list only delays work for a brand-new scope by one
+ * refresh window instead of re-running the 9-table union on every sweep
+ * (#1059).
+ */
+export function createAgentScopeSnapshot(
+	refreshMs: number,
+	resolve: () => readonly string[],
+	now: () => number = Date.now,
+): () => readonly string[] {
+	let snapshot: readonly string[] | null = null;
+	let at = 0;
+	return () => {
+		const t = now();
+		if (snapshot === null || t - at >= refreshMs) {
+			snapshot = resolve();
+			at = t;
+		}
+		return snapshot;
+	};
+}
+
 export function startDreamingWorker(
 	accessor: DbAccessor,
 	cfg: DreamingConfig,
@@ -118,11 +144,19 @@ export function startDreamingWorker(
 	let activeAgent: string | null = null;
 	let stopped = false;
 	let activePassPromise: Promise<unknown> | null = null;
-	const router = options.executorFactory ? null : getOrCreateInferenceRouter(agentsDir);
-	const executorForAgent = (agentId: string): DreamingAgentExecutor =>
-		options.executorFactory?.(agentId) ?? {
+	const getAgentScopes = createAgentScopeSnapshot(AGENT_SCOPE_SNAPSHOT_REFRESH_MS, () =>
+		getDreamingWorkerAgentIds(accessor, defaultAgentId),
+	);
+	const executorForAgent = (agentId: string): DreamingAgentExecutor => {
+		const factory = options.executorFactory;
+		if (factory) return factory(agentId);
+		// getOrCreateInferenceRouter is a singleton accessor; resolving here
+		// (instead of a nullable eager handle) keeps the closure free of
+		// non-null assertions.
+		const router = getOrCreateInferenceRouter(agentsDir);
+		return {
 			async run(input) {
-				const result = await router!.runAgent(
+				const result = await router.runAgent(
 					{
 						agentId,
 						operation: "memory_extraction",
@@ -160,6 +194,7 @@ export function startDreamingWorker(
 				return { summary: `Dreaming agent completed through ${result.value.decision.targetRef}` };
 			},
 		};
+	};
 
 	// Sweep orphaned passes from unclean shutdown: any 'running' record
 	// was left by a crash or forced stop — mark it failed
@@ -183,18 +218,21 @@ export function startDreamingWorker(
 		runAgentId: string,
 		mode: DreamingMode,
 		existingPassId?: string,
+		scopes?: readonly string[],
 	): Promise<{ passId: string; applied: number; skipped: number; failed: number; summary: string }> {
 		if (active) throw new AlreadyRunningError();
 		active = true;
 		activeAgent = runAgentId;
-		const scopes = getDreamingWorkerAgentIds(accessor, defaultAgentId);
+		// Periodic sweeps pass their snapshot through; explicit triggers and
+		// CLI passes resolve fresh so operator intent is never stale.
+		const passScopes = scopes ?? getDreamingWorkerAgentIds(accessor, defaultAgentId);
 		const p = runDreamingAgentPass(
 			accessor,
 			executorForAgent(runAgentId),
 			cfg,
 			agentsDir,
 			runAgentId,
-			scopes,
+			passScopes,
 			mode,
 			existingPassId,
 		);
@@ -222,9 +260,13 @@ export function startDreamingWorker(
 		// One Dreaming universe: a single pass covers every agent scope. The
 		// sweep runs one pass when any scope has attention or a backlog; the
 		// pass itself addresses scopes via the per-call agentId on its tools.
+		const scopes = getAgentScopes();
 		let triggered = false;
-		for (const scopeId of getDreamingWorkerAgentIds(accessor, defaultAgentId)) {
+		for (const scopeId of scopes) {
 			if (stopped || active) return;
+			// A halted scope must not burn the 6-query hygiene scan and the
+			// episodic backlog read on every sweep: skip straight past it.
+			if (isDreamingHaltActive(accessor, scopeId)) continue;
 			try {
 				enqueueDreamingHygieneAttention(accessor, scopeId);
 				const episodicTokens = getDreamingEpisodicTokenBacklog(accessor, scopeId);
@@ -245,7 +287,7 @@ export function startDreamingWorker(
 			}
 		}
 		if (!triggered) return;
-		await runPass(defaultAgentId, "incremental");
+		await runPass(defaultAgentId, "incremental", undefined, scopes);
 	}
 
 	function schedule(): void {

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -5,12 +5,17 @@ import { runMigrations } from "../../../core/src/migrations";
 import type { DbAccessor } from "../db-accessor";
 import {
 	DREAMING_AGENT_PROMPT,
+	DREAMING_FAILURE_HALT_THRESHOLD,
+	DREAMING_HALT_COOLDOWN_MS,
+	type DreamingState,
 	_testParseEpisodicCursor,
 	enqueueDreamingHygieneAttention,
 	getDreamingEpisodicTokenBacklog,
 	getDreamingPasses,
 	getDreamingState,
 	getDreamingToolCalls,
+	isDreamingHaltActive,
+	isDreamingScopeHalted,
 	recordDreamingFailure,
 	requestDreamingEvidenceRequeue,
 	runDreamingAgentPass,
@@ -128,6 +133,64 @@ describe("Dreaming", () => {
 		expect(shouldTriggerDreaming(accessor, cfg, AGENT, failedAt + 10 * 60 * 1000 - 1)).toBe(false);
 		seedSummary(db, "later", "episodic source ".repeat(3_000), 3_000);
 		expect(shouldTriggerDreaming(accessor, cfg, AGENT, failedAt + 10 * 60 * 1000)).toBe(true);
+	});
+
+	it("halts automatic scheduling after repeated consecutive failures", () => {
+		seedSummary(db, "first", "episodic source", 10);
+		for (let i = 0; i < DREAMING_FAILURE_HALT_THRESHOLD; i += 1) {
+			recordDreamingFailure(accessor, AGENT);
+		}
+		const failedAt = Date.parse(getDreamingState(accessor, AGENT).lastFailureAt ?? "");
+		const cfg = defaultCfg({ tokenThreshold: 1, backfillOnFirstRun: false });
+		// Halted: a large backlog and fresh attention must not trigger a pass
+		// inside the cooldown window.
+		seedSummary(db, "later", "episodic source ".repeat(3_000), 3_000);
+		expect(shouldTriggerDreaming(accessor, cfg, AGENT, failedAt + 60 * 1000)).toBe(false);
+		// Cooldown elapsed: scheduling resumes (the next failure re-halts).
+		expect(shouldTriggerDreaming(accessor, cfg, AGENT, failedAt + DREAMING_HALT_COOLDOWN_MS + 1_000)).toBe(true);
+	});
+
+	it("isDreamingScopeHalted gates on the failure threshold and cooldown", () => {
+		const base = (overrides: Partial<DreamingState>): DreamingState => ({
+			consecutiveFailures: 0,
+			lastFailureAt: null,
+			lastPassAt: null,
+			evidenceCursor: null,
+			lastPassId: null,
+			lastPassMode: null,
+			...overrides,
+		});
+		const fresh = { lastFailureAt: "2026-08-05 12:00:00" };
+		expect(
+			isDreamingScopeHalted(
+				base({ ...fresh, consecutiveFailures: DREAMING_FAILURE_HALT_THRESHOLD - 1 }),
+				Date.parse("2026-08-05 12:30:00"),
+			),
+		).toBe(false);
+		expect(
+			isDreamingScopeHalted(
+				base({ ...fresh, consecutiveFailures: DREAMING_FAILURE_HALT_THRESHOLD }),
+				Date.parse("2026-08-05 12:30:00"),
+			),
+		).toBe(true);
+		expect(
+			isDreamingScopeHalted(
+				base({ ...fresh, consecutiveFailures: DREAMING_FAILURE_HALT_THRESHOLD }),
+				Date.parse("2026-08-05 12:00:00") + DREAMING_HALT_COOLDOWN_MS + 1_000,
+			),
+		).toBe(false);
+		expect(
+			isDreamingScopeHalted(base({ lastFailureAt: null, consecutiveFailures: 99 }), Date.parse("2026-08-05 12:30:00")),
+		).toBe(false);
+	});
+
+	it("isDreamingHaltActive reads the halt state through the accessor", () => {
+		for (let i = 0; i < DREAMING_FAILURE_HALT_THRESHOLD - 1; i += 1) {
+			recordDreamingFailure(accessor, AGENT);
+		}
+		expect(isDreamingHaltActive(accessor, AGENT)).toBe(false);
+		recordDreamingFailure(accessor, AGENT);
+		expect(isDreamingHaltActive(accessor, AGENT)).toBe(true);
 	});
 
 	it("runs a low-volume episodic backlog once its maximum wait elapses", () => {

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -782,6 +782,25 @@ export async function runDreamingAgentPass(
 const MAX_FAILURE_BACKOFF_MULTIPLIER = 6;
 const FAILURE_BACKOFF_BASE_MS = 5 * 60 * 1000;
 
+// A scope that fails this many consecutive passes is halted: automatic
+// scheduling stops for the cooldown below instead of retrying forever on
+// the backoff ceiling (~5.3h per attempt). Explicit triggers bypass the
+// gate, and any successful pass resets the counter, so a halt self-heals
+// on the next forced or post-cooldown pass (#1059).
+export const DREAMING_FAILURE_HALT_THRESHOLD = 5;
+export const DREAMING_HALT_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+
+export function isDreamingScopeHalted(state: DreamingState, nowMs = Date.now()): boolean {
+	if (state.consecutiveFailures < DREAMING_FAILURE_HALT_THRESHOLD) return false;
+	const failedAt = state.lastFailureAt === null ? Number.NaN : Date.parse(state.lastFailureAt);
+	return Number.isFinite(failedAt) && nowMs - failedAt < DREAMING_HALT_COOLDOWN_MS;
+}
+
+/** Cheap sweep pre-check: one indexed dreaming_state row, no attention scan. */
+export function isDreamingHaltActive(accessor: DbAccessor, agentId: string, nowMs = Date.now()): boolean {
+	return isDreamingScopeHalted(getDreamingState(accessor, agentId), nowMs);
+}
+
 /**
  * The worker's backlog is the episodic evidence it has not yet reasoned over,
  * not a separately maintained token counter. This keeps the trigger aligned
@@ -821,6 +840,10 @@ export function shouldTriggerDreaming(
 ): boolean {
 	const state = getDreamingState(accessor, agentId);
 	const hasAttention = accessor.withReadDb((db) => getDreamingAttentionInDb(db, agentId, 1).length > 0);
+
+	// Hard halt after repeated consecutive failures: no automatic scheduling
+	// for the cooldown window. Explicit operator triggers bypass this gate.
+	if (isDreamingScopeHalted(state, nowMs)) return false;
 
 	// Back off by wall clock, not by evidence volume. A transient provider outage
 	// must not require exponentially more incoming evidence before recovery.


### PR DESCRIPTION
## Summary

Closes the two remaining dreaming-worker items from the #1059 fix direction: the unbounded `getDreamingWorkerAgentIds` union, and the missing halt after repeated consecutive failures.

## Changes

- `platform/daemon/src/pipeline/dreaming-worker.ts`
  - `createAgentScopeSnapshot(refreshMs, resolve)`: periodic sweeps resolve the 9-table agent-scope union through a snapshot refreshed on a 30-minute cadence, instead of re-running it multiple times per 5-minute tick. Explicit triggers (`trigger`/`triggerAsync`) still resolve fresh so operator intent is never stale.
  - `check()` skips halted scopes before the 6-query hygiene scan and episodic backlog read, so a broken scope cannot burn sweep work on every tick.
  - Removed the `router!` non-null assertion by resolving the get-or-create router lazily inside the executor closure.
- `platform/daemon/src/pipeline/dreaming.ts`
  - `DREAMING_FAILURE_HALT_THRESHOLD` (5) + `DREAMING_HALT_COOLDOWN_MS` (24h): `shouldTriggerDreaming` returns false for a scope that has failed N consecutive passes within the cooldown. The existing wall-clock backoff covers failures 1..N-1; the halt caps the forever-retry case. A successful pass resets the counter (existing `resetDreamingTokens`), so the halt self-heals; explicit operator triggers bypass the gate.
  - `isDreamingScopeHalted` (pure) + `isDreamingHaltActive` (accessor-based, for the sweep fast-path).
- `platform/daemon/src/pipeline/dreaming.test.ts` — halt behavior tests: threshold gating, cooldown window, recovery after cooldown, accessor path.
- `platform/daemon/src/pipeline/dreaming-worker.test.ts` — snapshot cadence test (fake clock: cached within window, re-resolves after). Also fixed a pre-existing broken test that asserted startup hygiene seeding — commit `192d291a0` deliberately moved that to the first check tick; it now exercises `enqueueDreamingHygieneAttention` directly.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`

## Screenshots

N/A — no UI change.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec change
- [x] Agent scoping verified on all new/changed data queries — no new queries; `isDreamingHaltActive` reads one `dreaming_state` row by `agent_id`
- [x] Input/config validation and bounds checks added — constants only, no new inputs
- [x] Error handling and fallback paths tested (no silent swallow) — pass-failure path already covered by `recordDreamingFailure`; halt path covered by new tests
- [x] Security checks applied to admin/mutation endpoints — N/A, internal pipeline scheduling
- [x] Docs updated for API/spec/status changes — N/A, no API/status contract change
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally — see Testing

## Migration Notes (if applicable)

N/A.

## Testing

- [x] `bun test platform/daemon/src/pipeline/dreaming.test.ts platform/daemon/src/pipeline/dreaming-worker.test.ts` passes (24 pass, 0 fail)
- [x] `bun run typecheck` passes (all workspaces)
- [x] `bunx biome check` clean on all touched files
- [x] `bun run --filter '@signet/daemon' build` — see notes below
- [ ] Tested against running daemon — scheduling-path change; covered by the unit/integration harness, daemon behavior unchanged on a healthy workspace

## Notes

`bun run --filter '@signet/daemon' build` requires `@signet/core` rebuilt first in this checkout (stale `dist`); with core rebuilt it passes.

## AI disclosure

- [x] AI tools were used (see `Assisted-by` tags in commits)
