### PR TITLE
fix(daemon): cap concurrent prompt-submit work with 503 backpressure

### DIFF
--- a/docs/api/sessions-hooks.md
+++ b/docs/api/sessions-hooks.md
@@ -88,6 +88,12 @@ recall tools. Raw transcript search is not injected on prompt-submit; use the
 dedicated `session_search` MCP/API surface when a caller needs transcript
 evidence.
 
+Under sustained concurrency (many harnesses submitting at once), the daemon
+caps in-flight prompt-submit work: once more than 8 submissions are processing
+concurrently, the hook returns `503` with a `Retry shortly` error instead of
+queueing indefinitely. Callers should treat `503` as backpressure and retry
+with backoff.
+
 ### POST /api/hooks/session-end
 
 Called at session end. Captures immutable episodic transcript evidence for

--- a/platform/daemon/src/hooks-recall.test.ts
+++ b/platform/daemon/src/hooks-recall.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Hono } from "hono";
+import { __setPromptSubmitAdmissionForTests, createPromptSubmitAdmission } from "./routes/hooks-routes";
 
 let app: Hono;
 let dir = "";
@@ -660,5 +661,35 @@ memory:
 		expect(body.results.map((row: { id: string }) => row.id)).not.toContain("mem-type-fact");
 		expect(body.memories).toEqual(body.results);
 		expect(body.count).toBe(body.results.length);
+	});
+});
+
+describe("/api/hooks/user-prompt-submit admission cap (#1059)", () => {
+	it("acquires up to the cap, rejects past it, and re-acquires after release", () => {
+		const admission = createPromptSubmitAdmission(2);
+		expect(admission.acquire()).toBe(true);
+		expect(admission.acquire()).toBe(true);
+		expect(admission.acquire()).toBe(false);
+		expect(admission.inFlight()).toBe(2);
+		admission.release();
+		expect(admission.inFlight()).toBe(1);
+		expect(admission.acquire()).toBe(true);
+		expect(admission.inFlight()).toBe(2);
+	});
+
+	it("rejects with 503 while the cap is saturated and recovers after release", async () => {
+		__setPromptSubmitAdmissionForTests(createPromptSubmitAdmission(0));
+		try {
+			const resp = await app.request("/api/hooks/user-prompt-submit", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ harness: "codex", userMessage: "hello" }),
+			});
+			expect(resp.status).toBe(503);
+			const body = (await resp.json()) as { error?: string };
+			expect(body.error).toContain("concurrent prompt submissions");
+		} finally {
+			__setPromptSubmitAdmissionForTests(null);
+		}
 	});
 });

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -39,7 +39,6 @@ import {
 	resetSessionStartDedupe,
 	writeMemoryMd,
 } from "../hooks.js";
-import { getTranscriptCaptureJobStatus } from "../transcript-capture-worker";
 import { getInferenceRouterOrNull } from "../inference-router";
 import { logger } from "../logger";
 import { loadMemoryConfig } from "../memory-config";
@@ -65,6 +64,7 @@ import { recordSkillInvocation } from "../skill-invocations";
 import { recordSkillsFromTranscript } from "../skill-transcript-scan";
 import { validateTemporalTimeOptions } from "../temporal-recall";
 import { upsertThreadHead } from "../thread-heads";
+import { getTranscriptCaptureJobStatus } from "../transcript-capture-worker";
 import { autoConnectGraphiq } from "./graphiq-routes.js";
 import {
 	AGENTS_DIR,
@@ -313,6 +313,43 @@ function registerSessionStart(app: Hono): void {
 	});
 }
 
+// Bound concurrent prompt-submit work. Subagent-heavy sessions fire many
+// user-prompt-submit hooks at once; without a cap the requests stack on the
+// single event loop, /health starves, and the watchdog kills the daemon
+// (#1059). Past the cap the hook rejects with 503 so callers retry instead
+// of queueing indefinitely.
+export const PROMPT_SUBMIT_MAX_IN_FLIGHT = 8;
+
+export interface PromptSubmitAdmission {
+	acquire(): boolean;
+	release(): void;
+	inFlight(): number;
+}
+
+export function createPromptSubmitAdmission(maxInFlight: number): PromptSubmitAdmission {
+	let inFlight = 0;
+	return {
+		acquire(): boolean {
+			if (inFlight >= maxInFlight) return false;
+			inFlight += 1;
+			return true;
+		},
+		release(): void {
+			inFlight -= 1;
+		},
+		inFlight(): number {
+			return inFlight;
+		},
+	};
+}
+
+let promptSubmitAdmission: PromptSubmitAdmission = createPromptSubmitAdmission(PROMPT_SUBMIT_MAX_IN_FLIGHT);
+
+/** Test seam; mirrors native-embedding's __*ForTests pattern. */
+export function __setPromptSubmitAdmissionForTests(admission: PromptSubmitAdmission | null): void {
+	promptSubmitAdmission = admission ?? createPromptSubmitAdmission(PROMPT_SUBMIT_MAX_IN_FLIGHT);
+}
+
 // User prompt submit hook - inject relevant memories per prompt
 function registerUserPromptSubmit(app: Hono): void {
 	app.post("/api/hooks/user-prompt-submit", async (c) => {
@@ -372,7 +409,20 @@ function registerUserPromptSubmit(app: Hono): void {
 				return c.json({ inject: "", memoryCount: 0, bypassed: true });
 			}
 
-			const result = await handleUserPromptSubmit(body);
+			if (!promptSubmitAdmission.acquire()) {
+				return c.json(
+					{
+						error: `Too many concurrent prompt submissions (max ${PROMPT_SUBMIT_MAX_IN_FLIGHT}); retry shortly`,
+					},
+					503,
+				);
+			}
+			let result: Awaited<ReturnType<typeof handleUserPromptSubmit>>;
+			try {
+				result = await handleUserPromptSubmit(body);
+			} finally {
+				promptSubmitAdmission.release();
+			}
 			return c.json({ ...result, sessionKnown: known });
 		} catch (e) {
 			logger.error("hooks", "User prompt submit hook failed", e as Error);


### PR DESCRIPTION
## Summary

Closes the prompt-submit backpressure item from the #1059 fix direction: subagent-heavy sessions fire many `user-prompt-submit` hooks at once, and without a cap the requests stack on the single event loop, starving `/health` (the measured bimodal saturation from the issue thread).

## Changes

- `platform/daemon/src/routes/hooks-routes.ts`
  - `PROMPT_SUBMIT_MAX_IN_FLIGHT` (8) admission gate around `handleUserPromptSubmit`: submissions beyond the cap return `503` with a `Retry shortly` error instead of queueing indefinitely. The slot is released in a `finally`, so failures and errors cannot leak the cap.
  - `createPromptSubmitAdmission(maxInFlight)` is a small exported, unit-testable primitive; `__setPromptSubmitAdmissionForTests` is the test seam (mirrors `native-embedding`'s `__*ForTests` pattern).
- `platform/daemon/src/hooks-recall.test.ts` — admission primitive test (acquire/reject/re-acquire) and a route-level test proving the 503 path via an injected saturated gate.
- `docs/api/sessions-hooks.md` — documents the 503 backpressure contract.

Design note: a whole-hook hard timeout was deliberately not added. The dominant per-call costs are already bounded (entity-context hoist + `fetchEmbedding` timeouts: 15s native / 30s remote), and a deadline that fires mid-hook would orphan in-flight writes. The cap prevents the queueing that caused the 70–147s latencies; the bounded-work guarantee keeps `/health` servable.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`

## Screenshots

N/A — no UI change.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec change
- [x] Agent scoping verified on all new/changed data queries — no new queries
- [x] Input/config validation and bounds checks added — cap is a bound; rejection message includes the limit
- [x] Error handling and fallback paths tested (no silent swallow) — `finally` release covers failures; route test covers rejection
- [x] Security checks applied to admin/mutation endpoints — 503 is a rate/load signal, not a security boundary; auth checks run before the gate
- [x] Docs updated for API/spec/status changes — `sessions-hooks.md` documents the 503
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally — see Testing

## Migration Notes (if applicable)

N/A.

## Testing

- [x] `bun test platform/daemon/src/hooks-recall.test.ts platform/daemon/src/hooks.prompt-submit.test.ts` passes (42 pass, 0 fail)
- [x] `bun run typecheck` passes (all workspaces)
- [x] `bunx biome check` clean on all touched files
- [ ] Tested against running daemon — route-level behavior covered via `app.request` against the real daemon app; no live-daemon run

## AI disclosure

- [x] AI tools were used (see `Assisted-by` tags in commits)
