### PR TITLE
fix(dreaming): aspect-first husk scan (#1094)

### DIFF
--- a/platform/daemon/src/knowledge-graph-hygiene.test.ts
+++ b/platform/daemon/src/knowledge-graph-hygiene.test.ts
@@ -3,7 +3,11 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
-import { getDreamingHygieneCandidatesInDb, getKnowledgeHygieneReport } from "./knowledge-graph-hygiene";
+import {
+	ZERO_ACTIVE_ATTRIBUTE_ENTITIES_SQL,
+	getDreamingHygieneCandidatesInDb,
+	getKnowledgeHygieneReport,
+} from "./knowledge-graph-hygiene";
 
 function makeDbPath(): string {
 	const dir = join(tmpdir(), `signet-kg-hygiene-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -128,5 +132,29 @@ describe("knowledge graph hygiene report", () => {
 		);
 		expect(candidates.some((candidate) => candidate.subjectRef === "entity:source-doc")).toBe(false);
 		expect(candidates.some((candidate) => candidate.subjectRef === "entity:pinned-husk")).toBe(false);
+	});
+
+	test("zero-active-attribute detector probes per-entity aspects, not an agent-wide attribute scan (#1094)", () => {
+		// Regression: the detector's NOT EXISTS used a flat
+		// entity_aspects JOIN entity_attributes, which let the planner root
+		// the subquery in entity_attributes by agent_id alone. On a large
+		// install that made the dreaming worker's first check
+		// O(entities × attributes) — 200s+ on a 30k-entity/72k-attribute
+		// graph — blocking the daemon's event loop minutes after restart.
+		// The subquery must drive from entity_aspects (agent_id, entity_id)
+		// and probe attributes per aspect.
+		dbPath = makeDbPath();
+		initDbAccessor(dbPath);
+		seedEntity("husk", "Legacy Husk", 5);
+
+		const plan = getDbAccessor().withReadDb((db) => {
+			const rows = db.prepare(`EXPLAIN QUERY PLAN ${ZERO_ACTIVE_ATTRIBUTE_ENTITIES_SQL}`).all() as Array<{
+				detail: string;
+			}>;
+			return rows.map((row) => row.detail).join("\n");
+		});
+
+		expect(plan).toContain("SEARCH asp USING INDEX idx_entity_aspects_status (agent_id=? AND entity_id=?)");
+		expect(plan).not.toContain("SEARCH attr USING INDEX idx_entity_attributes_claim_version (agent_id=?)");
 	});
 });

--- a/platform/daemon/src/knowledge-graph-hygiene.ts
+++ b/platform/daemon/src/knowledge-graph-hygiene.ts
@@ -1,5 +1,5 @@
-import { SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES } from "@signet/core";
 import { createHash } from "node:crypto";
+import { SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES } from "@signet/core";
 import type { DbAccessor, ReadDb } from "./db-accessor";
 import { classifyEntityQuality, normalizeEntityName } from "./entity-quality";
 
@@ -98,6 +98,43 @@ function normalize(value: string): string {
 	return normalizeEntityName(value);
 }
 
+const TOPOLOGY_PLACEHOLDERS = SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES.map(() => "?").join(", ");
+
+/** Predicate shared by every hygiene detector: real semantic entities only. */
+const SEMANTIC_ENTITY_FRAGMENT = `COALESCE(e.pinned, 0) = 0
+	AND NOT (e.entity_type IN (${TOPOLOGY_PLACEHOLDERS}) OR (e.entity_type = 'source' AND e.source_root IS NOT NULL))`;
+
+/**
+ * Entities with no active attribute on any active aspect ("husks").
+ *
+ * The subquery deliberately nests the attribute check INSIDE the aspect
+ * lookup: the planner must drive from entity_aspects via (agent_id,
+ * entity_id, status) and probe attributes per aspect. A flat
+ * `entity_aspects JOIN entity_attributes` under NOT EXISTS lets the planner
+ * root the scan in entity_attributes by agent_id alone, making the detector
+ * O(entities × agent attributes) — on a large install that blocked the
+ * dreaming worker's first check (~5 min after restart) for minutes,
+ * wedging the daemon's event loop (Signet-AI/signetai#1094).
+ */
+export const ZERO_ACTIVE_ATTRIBUTE_ENTITIES_SQL = `
+	SELECT e.id, e.name
+	FROM entities e
+	WHERE e.agent_id = ? AND COALESCE(e.status, 'active') = 'active' AND ${SEMANTIC_ENTITY_FRAGMENT}
+	  AND NOT EXISTS (
+	    SELECT 1
+	    FROM entity_aspects asp
+	    WHERE asp.entity_id = e.id AND asp.agent_id = e.agent_id
+	      AND COALESCE(asp.status, 'active') = 'active'
+	      AND EXISTS (
+	        SELECT 1
+	        FROM entity_attributes attr
+	        WHERE attr.aspect_id = asp.id AND attr.agent_id = asp.agent_id
+	          AND attr.status = 'active'
+	      )
+	  )
+	ORDER BY e.updated_at ASC
+	LIMIT ?`;
+
 function reasonForEntity(name: string, canonicalName: string, mentions: number, entityType?: string): string | null {
 	const quality = classifyEntityQuality(name || canonicalName, entityType);
 	if (!quality.ok) return quality.reason ?? "invalid_entity";
@@ -136,9 +173,6 @@ export function getDreamingHygieneCandidatesInDb(
 	input: { readonly agentId: string; readonly limit?: number },
 ): readonly DreamingHygieneCandidate[] {
 	const limit = Math.min(Math.max(Math.floor(input.limit ?? 50), 1), 100);
-	const topologyPlaceholders = SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES.map(() => "?").join(", ");
-	const semanticEntity = `COALESCE(e.pinned, 0) = 0
-		AND NOT (e.entity_type IN (${topologyPlaceholders}) OR (e.entity_type = 'source' AND e.source_root IS NOT NULL))`;
 	const candidates = new Map<string, DreamingHygieneCandidate>();
 	const add = (candidate: DreamingHygieneCandidate): void => {
 		const existing = candidates.get(candidate.subjectRef);
@@ -149,7 +183,7 @@ export function getDreamingHygieneCandidatesInDb(
 		.prepare(
 			`SELECT e.id, e.name, e.canonical_name, e.entity_type, e.mentions
 			 FROM entities e
-			 WHERE e.agent_id = ? AND COALESCE(e.status, 'active') = 'active' AND ${semanticEntity}
+			 WHERE e.agent_id = ? AND COALESCE(e.status, 'active') = 'active' AND ${SEMANTIC_ENTITY_FRAGMENT}
 			 ORDER BY e.updated_at ASC
 			 LIMIT ?`,
 		)
@@ -176,20 +210,7 @@ export function getDreamingHygieneCandidatesInDb(
 	}
 
 	const zeroAttributeEntities = db
-		.prepare(
-			`SELECT e.id, e.name
-			 FROM entities e
-			 WHERE e.agent_id = ? AND COALESCE(e.status, 'active') = 'active' AND ${semanticEntity}
-			   AND NOT EXISTS (
-			     SELECT 1
-			     FROM entity_aspects asp
-			     JOIN entity_attributes attr ON attr.aspect_id = asp.id AND attr.agent_id = asp.agent_id
-			     WHERE asp.entity_id = e.id AND asp.agent_id = e.agent_id
-			       AND COALESCE(asp.status, 'active') = 'active' AND attr.status = 'active'
-			   )
-			 ORDER BY e.updated_at ASC
-			 LIMIT ?`,
-		)
+		.prepare(ZERO_ACTIVE_ATTRIBUTE_ENTITIES_SQL)
 		.all(input.agentId, ...SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES, limit) as Array<{ id: string; name: string }>;
 	for (const entity of zeroAttributeEntities) {
 		add({
@@ -205,7 +226,7 @@ export function getDreamingHygieneCandidatesInDb(
 			 FROM entity_attributes attr
 			 JOIN entity_aspects asp ON asp.id = attr.aspect_id AND asp.agent_id = attr.agent_id
 			 JOIN entities e ON e.id = asp.entity_id AND e.agent_id = asp.agent_id
-			 WHERE attr.agent_id = ? AND attr.status = 'active' AND ${semanticEntity}
+			 WHERE attr.agent_id = ? AND attr.status = 'active' AND ${SEMANTIC_ENTITY_FRAGMENT}
 			   AND (attr.claim_key IS NULL OR TRIM(attr.claim_key) = '')
 			 ORDER BY attr.updated_at ASC
 			 LIMIT ?`,
@@ -233,7 +254,7 @@ export function getDreamingHygieneCandidatesInDb(
 			`SELECT asp.id, asp.entity_id, asp.name
 			 FROM entity_aspects asp
 			 JOIN entities e ON e.id = asp.entity_id AND e.agent_id = asp.agent_id
-			 WHERE asp.agent_id = ? AND COALESCE(asp.status, 'active') = 'active' AND ${semanticEntity}
+			 WHERE asp.agent_id = ? AND COALESCE(asp.status, 'active') = 'active' AND ${SEMANTIC_ENTITY_FRAGMENT}
 			   AND LOWER(TRIM(asp.canonical_name)) IN (${GENERIC_ASPECTS.map(() => "?").join(", ")})
 			 ORDER BY asp.updated_at ASC
 			 LIMIT ?`,
@@ -255,7 +276,7 @@ export function getDreamingHygieneCandidatesInDb(
 		.prepare(
 			`SELECT e.canonical_name, COUNT(*) AS entity_count
 			 FROM entities e
-			 WHERE e.agent_id = ? AND COALESCE(e.status, 'active') = 'active' AND ${semanticEntity}
+			 WHERE e.agent_id = ? AND COALESCE(e.status, 'active') = 'active' AND ${SEMANTIC_ENTITY_FRAGMENT}
 			   AND e.canonical_name IS NOT NULL AND TRIM(e.canonical_name) != ''
 			 GROUP BY e.canonical_name HAVING COUNT(*) > 1
 			 ORDER BY COUNT(*) DESC, e.canonical_name ASC LIMIT ?`,
@@ -268,7 +289,7 @@ export function getDreamingHygieneCandidatesInDb(
 		const memberIds = db
 			.prepare(
 				`SELECT e.id FROM entities e
-				 WHERE e.agent_id = ? AND COALESCE(e.status, 'active') = 'active' AND ${semanticEntity}
+				 WHERE e.agent_id = ? AND COALESCE(e.status, 'active') = 'active' AND ${SEMANTIC_ENTITY_FRAGMENT}
 				   AND e.canonical_name = ?
 				 ORDER BY e.id ASC`,
 			)
@@ -293,8 +314,8 @@ export function getDreamingHygieneCandidatesInDb(
 			 JOIN entities dst ON dst.id = dep.target_entity_id AND dst.agent_id = dep.agent_id
 			 WHERE dep.agent_id = ? AND dep.dependency_type = 'related_to'
 			   AND COALESCE(dep.status, 'active') = 'active'
-			   AND ${semanticEntity.replaceAll("e.", "src.")}
-			   AND ${semanticEntity.replaceAll("e.", "dst.")}
+			   AND ${SEMANTIC_ENTITY_FRAGMENT.replaceAll("e.", "src.")}
+			   AND ${SEMANTIC_ENTITY_FRAGMENT.replaceAll("e.", "dst.")}
 			 ORDER BY dep.updated_at ASC LIMIT ?`,
 		)
 		.all(

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -78,24 +78,30 @@ function normalizeAgentId(agentId: string | undefined, fallback: string): string
 
 export function getDreamingWorkerAgentIds(accessor: DbAccessor, defaultAgentId: string): readonly string[] {
 	return accessor.withReadDb((db) => {
+		// UNION ALL + app-side dedup instead of UNION: the caller collapses
+		// rows into a Set, so the cross-branch sort/merge UNION performs is
+		// pure waste. UNION ALL concatenates the per-table index scans
+		// (every branch resolves through an agent_id-prefix or covering
+		// index), bounding the query by index size rather than table
+		// content (#1094).
 		const rows = db
 			.prepare(
-				`SELECT id FROM agents
-				 UNION
+				`SELECT id AS id FROM agents
+				 UNION ALL
 				 SELECT DISTINCT agent_id AS id FROM dreaming_state
-				 UNION
+				 UNION ALL
 				 SELECT DISTINCT agent_id AS id FROM dreaming_passes
-				 UNION
+				 UNION ALL
 				 SELECT DISTINCT agent_id AS id FROM memories WHERE is_deleted = 0
-				 UNION
+				 UNION ALL
 				 SELECT DISTINCT agent_id AS id FROM session_summaries
-				 UNION
+				 UNION ALL
 				 SELECT DISTINCT agent_id AS id FROM memory_artifacts WHERE is_deleted = 0
-				 UNION
+				 UNION ALL
 				 SELECT DISTINCT agent_id AS id FROM session_transcripts
-				 UNION
+				 UNION ALL
 				 SELECT DISTINCT agent_id AS id FROM dreaming_attention WHERE resolved_at IS NULL
-				 UNION
+				 UNION ALL
 				 SELECT DISTINCT agent_id AS id FROM entities`,
 			)
 			.all() as Array<{ id: string | null }>;
@@ -305,6 +311,24 @@ export function startDreamingWorker(
 	// server binds, making the daemon appear to fail to start.
 	schedule();
 
+	// Warm the agent-scope snapshot shortly after startup instead of letting
+	// the first check (5 min out) resolve it cold on the main loop
+	// (#1094). The union itself is index-fast; the warm-up moves first
+	// resolution off the sweep, surfaces DB problems before the first
+	// check, and the delay lands after the HTTP server binds.
+	let warmupTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+		warmupTimer = null;
+		if (stopped) return;
+		try {
+			const scopes = getAgentScopes();
+			logger.info("dreaming-worker", "Agent scope snapshot primed", { scopes: scopes.length });
+		} catch (e) {
+			logger.warn("dreaming-worker", "Agent scope snapshot warm-up failed; first check will retry", {
+				error: e instanceof Error ? e.message : String(e),
+			});
+		}
+	}, 15_000);
+
 	logger.info("dreaming-worker", "Dreaming worker started", {
 		threshold: cfg.tokenThreshold,
 	});
@@ -318,6 +342,10 @@ export function startDreamingWorker(
 			if (timer) {
 				clearTimeout(timer);
 				timer = null;
+			}
+			if (warmupTimer) {
+				clearTimeout(warmupTimer);
+				warmupTimer = null;
 			}
 		},
 


### PR DESCRIPTION
## Summary

The daemon wedged ~5 min after every restart on large installs (#1094): log goes silent, health hangs, CPU 50-78%. Investigation against the live 4.45GB production DB corrected the issue's root cause — the agent-scope union is index-only (~48ms; `session_transcripts` already has `idx_st_agent_updated` from migration 045). The actual wedge is the zero-active-attribute ("husk") detector inside `enqueueDreamingHygieneAttention`, which runs on the main thread during the first dreaming check: its flat `entity_aspects JOIN entity_attributes` under `NOT EXISTS` let the planner root the scan in `entity_attributes` by `agent_id` alone, making the detector O(entities × attributes). On the 30k-entity / 72k-attribute graph that single query took 200s+ (the whole 6-query hygiene scan timed out past 600s).

## Changes

- `platform/daemon/src/knowledge-graph-hygiene.ts` — the husk detector now nests the attribute `EXISTS` inside the aspect lookup, forcing the planner to drive from `entity_aspects (agent_id, entity_id, status)` and probe attributes per aspect. Identical semantics. The detector SQL is exported as `ZERO_ACTIVE_ATTRIBUTE_ENTITIES_SQL` so the plan shape is testable.
- `platform/daemon/src/knowledge-graph-hygiene.test.ts` — regression test pinning the query plan (names the bug).
- `platform/daemon/src/pipeline/dreaming-worker.ts` — agent-scope union uses `UNION ALL` (the app-side Set already dedups; drops the cross-branch sort) and the scope snapshot is primed ~15s after startup so the first 5-min check never resolves it cold.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A — daemon-side bug fix, no UI change.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no migrations touched. (The issue's suggested index fix is unnecessary: `session_transcripts` already has an `agent_id` index.)

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Proof (live 4.45GB production DB, read-only):

- Agent-scope union (9 tables): 48ms — was never the wedge.
- Husk detector before: 200s+ (timed out). After: 28ms.
- Full 6-query hygiene scan for `default` scope before: >600s (timed out). After: 231ms.
- `EXPLAIN QUERY PLAN` before: `SEARCH attr USING INDEX idx_entity_attributes_claim_version (agent_id=?)` as subquery root. After: `SEARCH asp USING INDEX idx_entity_aspects_status (agent_id=? AND entity_id=?)`.
- Regression test asserts the aspect-first plan and fails on the old shape.
- Pre-existing unrelated failure on clean main: `createMcpServer > schema compatibility > no tool schema emits propertyNames` (vite/rollup node_modules conflict in `surfaces/dashboard` typecheck) — same result with and without this PR.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- The issue's root-cause claim (unindexed union) is incorrect; the union was already fully indexed (verified on the production DB and in the schema). The fix targets the query that actually wedges.
- `surfaces/cli/*` files in the working tree are an unrelated in-progress change (parallel agent) and were deliberately not committed.
