### PR TITLE
fix(cli): surface real daemon failures (#1074)

### DIFF
--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -119,6 +119,7 @@ import {
 	getReachableDaemonUrls,
 	hasDaemonProcess,
 	isDaemonRunning,
+	isLaunchdDaemonLoaded,
 	sleep,
 	startDaemon,
 	stopDaemon,
@@ -956,6 +957,7 @@ const daemonDeps = {
 	getDaemonStatus,
 	hasDaemonProcess,
 	isDaemonRunning,
+	isLaunchdDaemonLoaded: () => Promise.resolve(isLaunchdDaemonLoaded()),
 	normalizeAgentPath,
 	signetLogo,
 	sleep,
@@ -1188,6 +1190,7 @@ registerSessionCommands(program, {
 
 registerDreamCommands(program, {
 	fetchFromDaemon,
+	fetchDaemonResult,
 });
 
 // ============================================================================

--- a/surfaces/cli/src/commands/dream.test.ts
+++ b/surfaces/cli/src/commands/dream.test.ts
@@ -1,51 +1,160 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import { Command } from "commander";
-import { registerDreamCommands } from "./dream";
+import type { DaemonFetchResult } from "../lib/daemon.js";
+import { type DreamDeps, registerDreamCommands } from "./dream.js";
 
 const previousLog = console.log;
+const previousError = console.error;
 
 afterEach(() => {
 	console.log = previousLog;
+	console.error = previousError;
 });
 
+function okResult<T>(data: T): DaemonFetchResult<T> {
+	return { ok: true, data };
+}
+
+function httpError<T>(status: number, error?: string): DaemonFetchResult<T> {
+	return error ? { ok: false, reason: "http", status, error } : { ok: false, reason: "http", status };
+}
+
+/**
+ * The deps signature is generic over the response payload; TypeScript cannot
+ * infer those type parameters from return position, so concrete mocks are
+ * widened once here instead of at every call site.
+ */
+function mockFetch(
+	impl: (path: string, options?: RequestInit & { timeout?: number }) => Promise<DaemonFetchResult<unknown>>,
+): DreamDeps["fetchDaemonResult"] {
+	return (async (path: string, options?: RequestInit & { timeout?: number }) =>
+		impl(path, options)) as DreamDeps["fetchDaemonResult"];
+}
+
+function makeDeps(): DreamDeps {
+	return {
+		fetchFromDaemon: async () => null,
+		fetchDaemonResult: async () => ({ ok: false, reason: "offline" }),
+	};
+}
+
+function captureOutput(): { lines: string[]; errorLines: string[]; restore: () => void } {
+	const lines: string[] = [];
+	const errorLines: string[] = [];
+	console.log = (...args: unknown[]) => {
+		lines.push(args.join(" "));
+	};
+	console.error = (...args: unknown[]) => {
+		errorLines.push(args.join(" "));
+	};
+	return {
+		lines,
+		errorLines,
+		restore: () => {
+			console.log = previousLog;
+			console.error = previousError;
+		},
+	};
+}
+
+interface StatusPayload {
+	worker: { running: boolean; active: boolean };
+	state: {
+		consecutiveFailures: number;
+		lastPassAt: string | null;
+		evidenceCursor: null;
+		lastPassId: string | null;
+		lastPassMode: string | null;
+	};
+	episodicTokensPending: number;
+	config: { tokenThreshold: number; backfillOnFirstRun: boolean };
+	passes: Array<{
+		id: string;
+		mode: string;
+		status: string;
+		startedAt: string;
+		completedAt: string | null;
+		tokensConsumed: number | null;
+		mutationsApplied: number | null;
+		mutationsSkipped: number | null;
+		mutationsFailed: number | null;
+		summary: string | null;
+		error: string | null;
+	}>;
+}
+
+function makeStatus(passes: Array<{ id: string; status: string; error?: string | null }>): StatusPayload {
+	return {
+		worker: { running: true, active: false },
+		state: {
+			consecutiveFailures: 0,
+			lastPassAt: null,
+			evidenceCursor: null,
+			lastPassId: null,
+			lastPassMode: null,
+		},
+		episodicTokensPending: 0,
+		config: { tokenThreshold: 10_000, backfillOnFirstRun: false },
+		passes: passes.map((pass) => ({
+			id: pass.id,
+			mode: "incremental",
+			status: pass.status,
+			startedAt: "2026-08-05T00:00:00.000Z",
+			completedAt: pass.status === "running" ? null : "2026-08-05T00:01:00.000Z",
+			tokensConsumed: null,
+			mutationsApplied: pass.status === "completed" ? 3 : null,
+			mutationsSkipped: null,
+			mutationsFailed: null,
+			summary: null,
+			error: pass.error ?? null,
+		})),
+	};
+}
+
 describe("Dreaming capability CLI binding", () => {
-	test("discovers the daemon-owned registry without a local capability list", async () => {
+	it("discovers the daemon-owned registry without a local capability list", async () => {
 		const calls: string[] = [];
+		const fetchFromDaemon: DreamDeps["fetchFromDaemon"] = (async (path: string) => {
+			calls.push(path);
+			return { items: [{ id: "search_entities", description: "Search entities" }] };
+		}) as DreamDeps["fetchFromDaemon"];
 		const program = new Command();
-		registerDreamCommands(program, {
-			fetchFromDaemon: async (path) => {
-				calls.push(path);
-				return { items: [{ id: "search_entities", description: "Search entities" }] };
-			},
-		});
-		console.log = () => {};
-		await program.parseAsync(["node", "test", "dream", "capabilities"]);
+		registerDreamCommands(program, { ...makeDeps(), fetchFromDaemon });
+		const capture = captureOutput();
+		try {
+			await program.parseAsync(["node", "test", "dream", "capabilities"]);
+		} finally {
+			capture.restore();
+		}
 		expect(calls).toEqual(["/api/dream/tools"]);
 	});
 
-	test("routes any registered capability through the daemon capability endpoint with an explicit agent scope", async () => {
+	it("routes any registered capability through the daemon capability endpoint with an explicit agent scope", async () => {
 		const calls: Array<{ path: string; options?: RequestInit }> = [];
-		const program = new Command();
-		registerDreamCommands(program, {
-			fetchFromDaemon: async (path, options) => {
-				calls.push({ path, options });
-				return { ok: true, tool: "search_entities", items: [] };
-			},
+		const fetchDaemonResult = mockFetch(async (path: string, options) => {
+			calls.push({ path, options });
+			return okResult({ ok: true, tool: "search_entities", items: [] });
 		});
-		console.log = () => {};
-		await program.parseAsync([
-			"node",
-			"test",
-			"dream",
-			"tool",
-			"search_entities",
-			"--agent",
-			"agent-a",
-			"--pass-id",
-			"pass-a",
-			"--input",
-			'{"query":"Atlas"}',
-		]);
+		const program = new Command();
+		registerDreamCommands(program, { ...makeDeps(), fetchDaemonResult });
+		const capture = captureOutput();
+		try {
+			await program.parseAsync([
+				"node",
+				"test",
+				"dream",
+				"tool",
+				"search_entities",
+				"--agent",
+				"agent-a",
+				"--pass-id",
+				"pass-a",
+				"--input",
+				'{"query":"Atlas"}',
+			]);
+		} finally {
+			capture.restore();
+		}
 		expect(calls).toEqual([
 			{
 				path: "/api/dream/tools/search_entities",
@@ -55,5 +164,159 @@ describe("Dreaming capability CLI binding", () => {
 				}),
 			},
 		]);
+	});
+
+	it("surfaces the daemon's error body when a capability call fails", async () => {
+		const fetchDaemonResult = mockFetch(async () => httpError(400, "evidence must include an exact quote"));
+		const program = new Command();
+		registerDreamCommands(program, { ...makeDeps(), fetchDaemonResult });
+		const capture = captureOutput();
+		const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("EXIT_1");
+		});
+		try {
+			await expect(
+				program.parseAsync(["node", "test", "dream", "tool", "runbook_write", "--input", "{}"]),
+			).rejects.toThrow("EXIT_1");
+			expect(capture.errorLines.join("\n")).toContain("evidence must include an exact quote");
+		} finally {
+			exitSpy.mockRestore();
+			capture.restore();
+		}
+	});
+});
+
+describe("dream status failure labeling", () => {
+	it("names an unresponsive daemon instead of asking whether it is running", async () => {
+		const fetchDaemonResult = mockFetch(async () => ({ ok: false, reason: "timeout" }));
+		const program = new Command();
+		registerDreamCommands(program, { ...makeDeps(), fetchDaemonResult });
+		const capture = captureOutput();
+		const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("EXIT_1");
+		});
+		try {
+			await expect(program.parseAsync(["node", "test", "dream", "status"])).rejects.toThrow("EXIT_1");
+			const output = capture.errorLines.join("\n");
+			expect(output).toContain("not responding");
+			expect(output).toContain("event loop");
+			expect(output).not.toContain("is the daemon running?");
+		} finally {
+			exitSpy.mockRestore();
+			capture.restore();
+		}
+	});
+
+	it("keeps the stopped-daemon wording when the probe is refused (offline)", async () => {
+		const fetchDaemonResult = mockFetch(async () => ({ ok: false, reason: "offline" }));
+		const program = new Command();
+		registerDreamCommands(program, { ...makeDeps(), fetchDaemonResult });
+		const capture = captureOutput();
+		const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("EXIT_1");
+		});
+		try {
+			await expect(program.parseAsync(["node", "test", "dream", "status"])).rejects.toThrow("EXIT_1");
+			expect(capture.errorLines.join("\n")).toContain("is the daemon running?");
+		} finally {
+			exitSpy.mockRestore();
+			capture.restore();
+		}
+	});
+});
+
+describe("dream trigger pass diagnostics", () => {
+	it("surfaces the daemon's error when the trigger itself is rejected", async () => {
+		const fetchDaemonResult = mockFetch(async (path: string) => {
+			return path === "/api/dream/trigger"
+				? httpError(500, "No routing policy is configured.")
+				: { ok: false, reason: "offline" };
+		});
+		const program = new Command();
+		registerDreamCommands(program, { ...makeDeps(), fetchDaemonResult });
+		const capture = captureOutput();
+		const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("EXIT_1");
+		});
+		try {
+			await expect(program.parseAsync(["node", "test", "dream", "trigger"])).rejects.toThrow("EXIT_1");
+			expect(capture.errorLines.join("\n")).toContain("No routing policy is configured.");
+		} finally {
+			exitSpy.mockRestore();
+			capture.restore();
+		}
+	});
+
+	it("surfaces the pass's terminal error instead of hiding it", async () => {
+		const fetchDaemonResult = mockFetch(async (path: string) => {
+			if (path === "/api/dream/trigger") {
+				return okResult({ accepted: true, passId: "pass-1", status: "running", mode: "incremental" });
+			}
+			return okResult(makeStatus([{ id: "pass-1", status: "failed", error: "No routing policy is configured." }]));
+		});
+		const program = new Command();
+		registerDreamCommands(program, { ...makeDeps(), fetchDaemonResult });
+		const capture = captureOutput();
+		const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("EXIT_1");
+		});
+		try {
+			await expect(program.parseAsync(["node", "test", "dream", "trigger"])).rejects.toThrow("EXIT_1");
+			expect(capture.errorLines.join("\n")).toContain("No routing policy is configured.");
+		} finally {
+			exitSpy.mockRestore();
+			capture.restore();
+		}
+	});
+
+	it("does not claim completion while a pass is still running", async () => {
+		const fetchDaemonResult = mockFetch(async (path: string) => {
+			if (path === "/api/dream/trigger") {
+				return okResult({ accepted: true, passId: "pass-1", status: "running", mode: "incremental" });
+			}
+			return okResult(makeStatus([{ id: "pass-1", status: "running" }]));
+		});
+		const program = new Command();
+		registerDreamCommands(program, { ...makeDeps(), pollIntervalMs: 1, minWaitMs: 1, fetchDaemonResult });
+		const capture = captureOutput();
+		const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("EXIT_1");
+		});
+		try {
+			await program.parseAsync(["node", "test", "dream", "trigger", "--wait-secs", "1"]);
+			const output = capture.lines.join("\n");
+			expect(output).toContain("still running");
+			expect(output).not.toContain("complete");
+			expect(exitSpy).not.toHaveBeenCalled();
+		} finally {
+			exitSpy.mockRestore();
+			capture.restore();
+		}
+	});
+
+	it("names an unresponsive daemon when status polls time out during a pass", async () => {
+		const fetchDaemonResult = mockFetch(async (path: string) => {
+			if (path === "/api/dream/trigger") {
+				return okResult({ accepted: true, passId: "pass-1", status: "running", mode: "incremental" });
+			}
+			return { ok: false, reason: "timeout" };
+		});
+		const program = new Command();
+		registerDreamCommands(program, { ...makeDeps(), fetchDaemonResult });
+		const capture = captureOutput();
+		const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("EXIT_1");
+		});
+		try {
+			await program.parseAsync(["node", "test", "dream", "trigger"]);
+			const output = capture.lines.join("\n");
+			expect(output).toContain("not responding");
+			expect(output).toContain("event loop");
+			expect(output).not.toContain("Could not retrieve pass result");
+			expect(exitSpy).not.toHaveBeenCalled();
+		} finally {
+			exitSpy.mockRestore();
+			capture.restore();
+		}
 	});
 });

--- a/surfaces/cli/src/commands/dream.ts
+++ b/surfaces/cli/src/commands/dream.ts
@@ -1,9 +1,19 @@
 import chalk from "chalk";
 import type { Command } from "commander";
+import type { DaemonFetch, DaemonFetchFailure, DaemonFetchResult } from "../lib/daemon.js";
 
 interface DreamDeps {
-	readonly fetchFromDaemon: <T>(path: string, opts?: RequestInit & { timeout?: number }) => Promise<T | null>;
+	readonly fetchFromDaemon: DaemonFetch;
+	readonly fetchDaemonResult: <T>(
+		path: string,
+		opts?: RequestInit & { timeout?: number },
+	) => Promise<DaemonFetchResult<T>>;
+	/** Poll cadence for `dream trigger` (test seams; defaults match production). */
+	readonly pollIntervalMs?: number;
+	readonly minWaitMs?: number;
 }
+
+export type { DreamDeps };
 
 interface DreamState {
 	readonly consecutiveFailures: number;
@@ -46,6 +56,25 @@ interface TriggerAccepted {
 	readonly error?: string;
 }
 
+/**
+ * Name the real cause instead of a generic connectivity message. A timed-out
+ * probe means the daemon process is up but its event loop is blocked (for
+ * example, a wedged worker) — a restart often re-triggers the same wedge, so
+ * point at the logs rather than advising one (#1074).
+ */
+function reportDaemonUnavailable(reason: DaemonFetchFailure, status: number | undefined, action: string): void {
+	if (reason === "timeout") {
+		console.error(chalk.red(`${action} — the daemon is not responding (its event loop may be blocked).`));
+		console.error(chalk.dim("  Check `signet daemon logs`; a restart may not clear a wedged worker."));
+		return;
+	}
+	if (reason === "http") {
+		console.error(chalk.red(`${action} — daemon returned HTTP ${status ?? "error"}.`));
+		return;
+	}
+	console.error(chalk.red(`${action} (is the daemon running?)`));
+}
+
 export function registerDreamCommands(program: Command, deps: DreamDeps): void {
 	const dream = program.command("dream").description("Manage dreaming memory consolidation");
 
@@ -54,9 +83,9 @@ export function registerDreamCommands(program: Command, deps: DreamDeps): void {
 		.description("List the daemon-owned Dreaming capability registry")
 		.option("--json", "Output as JSON")
 		.action(async (options: { json?: boolean }) => {
-			const data = await deps.fetchFromDaemon<{ readonly items?: readonly { readonly id: string; readonly description: string }[] }>(
-				"/api/dream/tools",
-			);
+			const data = await deps.fetchFromDaemon<{
+				readonly items?: readonly { readonly id: string; readonly description: string }[];
+			}>("/api/dream/tools");
 			if (!data) {
 				console.error(chalk.red("Failed to get Dreaming capabilities (is the daemon running?)"));
 				process.exit(1);
@@ -88,7 +117,7 @@ export function registerDreamCommands(program: Command, deps: DreamDeps): void {
 				process.exit(1);
 				return;
 			}
-			const data = await deps.fetchFromDaemon<unknown>(`/api/dream/tools/${encodeURIComponent(capability)}`, {
+			const result = await deps.fetchDaemonResult<unknown>(`/api/dream/tools/${encodeURIComponent(capability)}`, {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -97,22 +126,31 @@ export function registerDreamCommands(program: Command, deps: DreamDeps): void {
 					...(options.passId ? { passId: options.passId } : {}),
 				}),
 			});
-			if (!data) {
-				console.error(chalk.red("Dreaming capability failed (is the daemon running?)"));
+			if (!result.ok) {
+				if (result.reason === "http" && result.error) {
+					console.error(chalk.red(`Dreaming capability failed: ${result.error}`));
+				} else {
+					reportDaemonUnavailable(result.reason, result.status, "Dreaming capability failed");
+				}
 				process.exit(1);
 			}
-			console.log(JSON.stringify(data, null, 2));
+			console.log(JSON.stringify(result.data, null, 2));
 		});
 
 	dream
 		.command("status")
 		.description("Show dreaming worker status and recent passes")
 		.action(async () => {
-			const data = await deps.fetchFromDaemon<DreamStatus>("/api/dream/status");
-			if (!data) {
-				console.error(chalk.red("Failed to get dreaming status (is the daemon running?)"));
+			const result = await deps.fetchDaemonResult<DreamStatus>("/api/dream/status");
+			if (!result.ok) {
+				if (result.reason === "http" && result.error) {
+					console.error(chalk.red(`Failed to get dreaming status: ${result.error}`));
+				} else {
+					reportDaemonUnavailable(result.reason, result.status, "Failed to get dreaming status");
+				}
 				process.exit(1);
 			}
+			const data = result.data;
 
 			console.log(chalk.bold("\n  Dreaming Status\n"));
 
@@ -180,21 +218,26 @@ export function registerDreamCommands(program: Command, deps: DreamDeps): void {
 				);
 				process.exit(1);
 			}
-			const maxWait = Math.max(30, parsedWait);
-			const pollInterval = 5_000;
-			const maxPolls = Math.ceil((maxWait * 1000) / pollInterval);
+			const pollInterval = deps.pollIntervalMs ?? 5_000;
+			const maxWait = Math.max(deps.minWaitMs ?? 30_000, parsedWait * 1000);
+			const maxPolls = Math.ceil(maxWait / pollInterval);
 			console.log(chalk.dim(`\n  Triggering ${mode} dreaming pass...\n`));
 
-			const accepted = await deps.fetchFromDaemon<TriggerAccepted>("/api/dream/trigger", {
+			const acceptedResult = await deps.fetchDaemonResult<TriggerAccepted>("/api/dream/trigger", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ mode }),
 			});
 
-			if (!accepted) {
-				console.error(chalk.red("Failed to trigger dreaming pass (is the daemon running?)"));
+			if (!acceptedResult.ok) {
+				if (acceptedResult.reason === "http" && acceptedResult.error) {
+					console.error(chalk.red(`Failed to trigger dreaming pass: ${acceptedResult.error}`));
+				} else {
+					reportDaemonUnavailable(acceptedResult.reason, acceptedResult.status, "Failed to trigger dreaming pass");
+				}
 				process.exit(1);
 			}
+			const accepted = acceptedResult.data;
 
 			if (accepted.error) {
 				console.error(chalk.red(`  Error: ${accepted.error}`));
@@ -203,18 +246,50 @@ export function registerDreamCommands(program: Command, deps: DreamDeps): void {
 
 			console.log(chalk.dim(`  Pass ${accepted.passId} accepted, polling for result...\n`));
 
-			// Poll status until the pass completes or fails
+			// Poll status until the pass completes or fails. The first probe
+			// runs immediately so a fast terminal failure is surfaced without
+			// a full poll interval.
 			let pass: DreamPass | undefined;
+			let statusUnavailable: DaemonFetchFailure | null = null;
 			for (let i = 0; i < maxPolls; i++) {
-				await new Promise((r) => setTimeout(r, pollInterval));
-				const status = await deps.fetchFromDaemon<DreamStatus>("/api/dream/status");
-				if (!status) break;
-				pass = status.passes.find((p) => p.id === accepted.passId);
+				if (i > 0) await new Promise((r) => setTimeout(r, pollInterval));
+				const statusResult = await deps.fetchDaemonResult<DreamStatus>("/api/dream/status");
+				if (!statusResult.ok) {
+					statusUnavailable = statusResult.reason;
+					break;
+				}
+				pass = statusResult.data.passes.find((p) => p.id === accepted.passId);
 				if (pass && pass.status !== "running") break;
 			}
 
 			if (!pass) {
-				console.log(chalk.yellow("  Could not retrieve pass result. Check `signet dream status`."));
+				if (statusUnavailable === "timeout") {
+					console.log(
+						chalk.yellow("  Daemon is not responding (its event loop may be blocked); the pass result is unknown."),
+					);
+					console.log(
+						chalk.dim("  Check `signet daemon logs` for the pass error; a restart may not clear a wedged worker."),
+					);
+				} else if (statusUnavailable !== null) {
+					console.log(
+						chalk.yellow(
+							`  Could not retrieve pass result (${statusUnavailable === "offline" ? "daemon unreachable" : "daemon returned an error"}).`,
+						),
+					);
+					console.log(chalk.dim("  Check `signet dream status` once the daemon is healthy."));
+				} else {
+					console.log(
+						chalk.yellow(`  Pass ${accepted.passId} did not appear in status within ${Math.round(maxWait / 1000)}s.`),
+					);
+					console.log(chalk.dim("  Check `signet dream status` for the pass outcome."));
+				}
+				console.log();
+				return;
+			}
+
+			if (pass.status === "running") {
+				console.log(chalk.yellow(`  Pass ${pass.id} is still running after ${Math.round(maxWait / 1000)}s.`));
+				console.log(chalk.dim("  Check `signet dream status` for the outcome."));
 				console.log();
 				return;
 			}

--- a/surfaces/cli/src/features/daemon.test.ts
+++ b/surfaces/cli/src/features/daemon.test.ts
@@ -136,6 +136,43 @@ describe("daemon lifecycle recovery", () => {
 		expect(stopped).toBe(true);
 	});
 
+	// Regression (#1074): under launchd KeepAlive the daemon respawns on exit,
+	// so "stop" must boot the job out even when the health endpoint says
+	// stopped — otherwise the reported stop is silently undone.
+	it("stop unloads the launchd keepalive when the daemon is unhealthy but launchd-managed", async () => {
+		let stopped = false;
+		const deps = makeDeps({
+			isDaemonRunning: async () => false,
+			hasDaemonProcess: async () => false,
+			isLaunchdDaemonLoaded: async () => true,
+			stopDaemon: async () => {
+				stopped = true;
+				return true;
+			},
+		});
+
+		await doStop({}, deps);
+
+		expect(stopped).toBe(true);
+	});
+
+	it("stop reports not running when nothing is alive and no launchd agent is loaded", async () => {
+		let stopped = false;
+		const deps = makeDeps({
+			isDaemonRunning: async () => false,
+			hasDaemonProcess: async () => false,
+			isLaunchdDaemonLoaded: async () => false,
+			stopDaemon: async () => {
+				stopped = true;
+				return true;
+			},
+		});
+
+		await doStop({}, deps);
+
+		expect(stopped).toBe(false);
+	});
+
 	it("restart runs signet sync when the user accepts the sync prompt", async () => {
 		let synced = false;
 		const deps = makeDeps({

--- a/surfaces/cli/src/features/daemon.ts
+++ b/surfaces/cli/src/features/daemon.ts
@@ -53,6 +53,7 @@ interface Deps {
 	readonly sleep: (ms: number) => Promise<void>;
 	readonly startDaemon: (agentsDir?: string) => Promise<boolean>;
 	readonly stopDaemon: (agentsDir?: string) => Promise<boolean>;
+	readonly isLaunchdDaemonLoaded?: () => Promise<boolean>;
 	readonly confirmRestartSync?: () => Promise<boolean>;
 	readonly fetch?: FetchLike;
 	readonly isInteractive?: () => boolean;
@@ -213,15 +214,26 @@ export async function doStop(options: PathOptions, deps: Deps): Promise<void> {
 	const basePath = readPath(options, deps);
 	const running = await deps.isDaemonRunning();
 	const stale = running ? false : await deps.hasDaemonProcess(basePath);
-	if (!running && !stale) {
+	// Under launchd KeepAlive the daemon respawns on exit, so an unhealthy
+	// daemon still counts as managed: `stop` must boot the job out or the
+	// reported "stop" is silently undone moments later (#1074).
+	const launchdManaged = running ? false : await (deps.isLaunchdDaemonLoaded?.() ?? Promise.resolve(false));
+	if (!running && !stale && !launchdManaged) {
 		console.log(chalk.yellow("  Daemon is not running"));
 		return;
 	}
 
-	const spinner = ora("Stopping daemon...").start();
+	const spinner = ora(
+		launchdManaged ? "Stopping daemon (unloading launchd keepalive)..." : "Stopping daemon...",
+	).start();
 	const stopped = await deps.stopDaemon(basePath);
 	if (stopped) {
 		spinner.succeed("Daemon stopped");
+		if (launchdManaged) {
+			console.log(
+				chalk.dim("  launchd agent ai.signet.daemon unloaded; it will not respawn until `signet daemon start`."),
+			);
+		}
 		return;
 	}
 

--- a/surfaces/cli/src/features/health.test.ts
+++ b/surfaces/cli/src/features/health.test.ts
@@ -874,4 +874,42 @@ describe("showStatus readiness labeling", () => {
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
+
+	// Regression (#1074): a daemon whose event loop is wedged keeps its TCP
+	// listener (and often its process) alive while /health times out. That is
+	// "unresponsive", not "stopped" — a restart re-triggers the same wedge, so
+	// the label must not send the operator down the restart path.
+	it("labels an alive-but-unresponsive daemon as unresponsive, not stopped", async () => {
+		const root = mkdtempSync(join(tmpdir(), "health-status-"));
+		try {
+			const deps = {
+				...depsFor(root),
+				getDaemonStatus: async () => ({
+					running: false,
+					pid: 42,
+					uptime: null,
+					version: null,
+					host: null,
+					bindHost: null,
+					networkMode: null,
+					probe: {
+						status: "listener-unhealthy" as const,
+						detail:
+							"TCP listener is present on http://127.0.0.1:3850, but /health did not return successfully within the probe timeout",
+						url: "http://127.0.0.1:3850",
+						listenerPresent: true,
+						processPid: 42,
+						stalePid: null,
+					},
+				}),
+			};
+			const output = await captureStatus(deps);
+			expect(output).toContain("Daemon unresponsive");
+			expect(output).toContain("not answering");
+			expect(output).not.toContain("Daemon stopped");
+			expect(output).not.toContain("signet daemon restart");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
 });

--- a/surfaces/cli/src/features/health.ts
+++ b/surfaces/cli/src/features/health.ts
@@ -278,9 +278,25 @@ export async function showStatus(options: { path?: string; json?: boolean }, dep
 			console.log(`    ${icon} OpenClaw plugin ${report.daemon.openclaw.status}`);
 		}
 	} else {
-		console.log(`  ${chalk.red("○")} Daemon ${chalk.red("stopped")}`);
-		if (report.daemon.probe && report.daemon.probe.status !== "absent") {
-			console.log(chalk.dim(`    ${report.daemon.probe.detail}`));
+		const probe = report.daemon.probe;
+		// The process can be alive while /health is unreachable (event loop
+		// blocked by a wedged worker). Label that "unresponsive", not
+		// "stopped": a restart often re-triggers the same wedge, and the
+		// operator should look at the logs first (#1074).
+		const unresponsive = probe?.status === "listener-unhealthy" || probe?.status === "process-unhealthy";
+		if (unresponsive) {
+			console.log(`  ${chalk.yellow("◐")} Daemon ${chalk.yellow("unresponsive")}`);
+			console.log(chalk.dim(`    ${probe.detail}`));
+			console.log(
+				chalk.dim(
+					"    The daemon process is alive but not answering. Check `signet daemon logs`; a restart may not clear a wedged worker.",
+				),
+			);
+		} else {
+			console.log(`  ${chalk.red("○")} Daemon ${chalk.red("stopped")}`);
+			if (probe && probe.status !== "absent") {
+				console.log(chalk.dim(`    ${probe.detail}`));
+			}
 		}
 	}
 

--- a/surfaces/cli/src/lib/daemon.ts
+++ b/surfaces/cli/src/lib/daemon.ts
@@ -13,6 +13,8 @@ export type DaemonFetchResult<T> =
 			readonly ok: false;
 			readonly reason: DaemonFetchFailure;
 			readonly status?: number;
+			/** Daemon-provided error message, when the HTTP error body carries one. */
+			readonly error?: string;
 	  };
 
 export type DaemonApiCall = (
@@ -33,6 +35,18 @@ function isTimeoutError(err: unknown): boolean {
 	if (name === "AbortError" || name === "TimeoutError") return true;
 	const code = typeof err === "object" && err !== null ? Reflect.get(err, "code") : undefined;
 	return code === "ABORT_ERR";
+}
+
+/** Extract a daemon-provided `{ error: string }` message from an HTTP error body. */
+async function readHttpErrorBody(res: Response): Promise<string | undefined> {
+	const text = await res.text().catch(() => "");
+	if (!text.trim()) return undefined;
+	try {
+		const parsed = JSON.parse(text) as { error?: unknown };
+		return typeof parsed?.error === "string" && parsed.error.trim() ? parsed.error : undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 function readAuthToken(): string | undefined {
@@ -77,7 +91,12 @@ export function createDaemonClient(
 				signal: AbortSignal.timeout(timeout || 5_000),
 			});
 			if (!res.ok) {
-				return { ok: false, reason: "http", status: res.status };
+				// Surface the daemon's own error message (e.g. "A dreaming pass
+				// is already running", "No routing policy is configured.") so
+				// callers can name the real cause instead of a generic
+				// connectivity failure (#1074).
+				const error = await readHttpErrorBody(res);
+				return { ok: false, reason: "http", status: res.status, ...(error ? { error } : {}) };
 			}
 			try {
 				const data: T = await res.json();

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -10,6 +10,7 @@ import {
 	didLaunchdDaemonStart,
 	didSystemdDaemonStart,
 	getDaemonStatus,
+	isLaunchdDaemonLoaded,
 	launchdDaemonPlistPath,
 	macOSLaunchAgentAttributionNotice,
 	readDaemonStartFailureDiagnostics,
@@ -527,5 +528,36 @@ describe("getDaemonStatus", () => {
 		expect(status.probe.status).toBe("degraded");
 		expect(status.probe.readinessReasons).toEqual(["pending migrations"]);
 		expect(status.probe.detail).toContain("readiness degraded");
+	});
+});
+
+describe("isLaunchdDaemonLoaded", () => {
+	it("never probes launchctl off macOS", () => {
+		let spawned = false;
+		const loaded = isLaunchdDaemonLoaded({
+			platform: "linux",
+			spawnSync: (_command, _args, _options) => {
+				spawned = true;
+				return { status: 0 };
+			},
+		});
+		expect(loaded).toBe(false);
+		expect(spawned).toBe(false);
+	});
+
+	it("reports loaded when launchctl print succeeds", () => {
+		const loaded = isLaunchdDaemonLoaded({
+			platform: "darwin",
+			spawnSync: () => ({ status: 0 }),
+		});
+		expect(loaded).toBe(true);
+	});
+
+	it("reports not loaded when launchctl print fails (no such job)", () => {
+		const loaded = isLaunchdDaemonLoaded({
+			platform: "darwin",
+			spawnSync: () => ({ status: 3 }),
+		});
+		expect(loaded).toBe(false);
 	});
 });

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -952,6 +952,33 @@ export function buildLaunchdDaemonStopArgs(label: string = LAUNCHD_DAEMON_LABEL)
 	return ["bootout", `${currentLaunchdDomain()}/${label}`];
 }
 
+/** Minimal structural shape of the `launchctl print` probe so tests can stub it. */
+type LaunchctlProbeSpawnSync = (
+	command: string,
+	args: readonly string[],
+	options: { readonly stdio: "ignore"; readonly windowsHide: boolean; readonly timeout: number },
+) => {
+	readonly status: number | null;
+};
+
+/**
+ * Whether launchd currently has the Signet daemon job loaded. Under KeepAlive
+ * the job respawns the daemon on exit, so `stop`/`start` must coordinate with
+ * it. The check is darwin-only; other platforms return false.
+ */
+export function isLaunchdDaemonLoaded(
+	deps: { readonly platform?: NodeJS.Platform; readonly spawnSync?: LaunchctlProbeSpawnSync } = {},
+): boolean {
+	if ((deps.platform ?? process.platform) !== "darwin") return false;
+	const spawn = deps.spawnSync ?? spawnSync;
+	const result = spawn("launchctl", ["print", `${currentLaunchdDomain()}/${LAUNCHD_DAEMON_LABEL}`], {
+		stdio: "ignore",
+		windowsHide: true,
+		timeout: 3000,
+	});
+	return result.status === 0;
+}
+
 export function didSystemdDaemonStart(result: Pick<SpawnSyncReturns<Buffer>, "status" | "signal" | "error">): boolean {
 	return result.status === 0 && result.signal === null && result.error === undefined;
 }
@@ -1068,12 +1095,20 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 				startupLogPath,
 			}),
 		);
-		const bootout = spawnSync("launchctl", buildLaunchdDaemonStopArgs(), {
-			stdio: ["ignore", "ignore", stderrTarget],
-			windowsHide: true,
-			env: daemonEnv,
-			timeout: 5000,
-		});
+		// Boot out any loaded job before (re)bootstrap. When no job is loaded
+		// (fresh start, or a restart that already booted it out), launchctl
+		// exits 3 with "Boot-out failed: 3: No such process" — launchd handoff
+		// noise, not a start failure. Skip the bootout in that case so the
+		// message never pollutes the startup log (#1074).
+		let bootout: SpawnSyncReturns<Buffer> | null = null;
+		if (isLaunchdDaemonLoaded()) {
+			bootout = spawnSync("launchctl", buildLaunchdDaemonStopArgs(), {
+				stdio: ["ignore", "ignore", stderrTarget],
+				windowsHide: true,
+				env: daemonEnv,
+				timeout: 5000,
+			});
+		}
 		const bootstrap = spawnSync("launchctl", buildLaunchdDaemonStartArgs(plistPath), {
 			stdio: ["ignore", "ignore", stderrTarget],
 			windowsHide: true,
@@ -1094,7 +1129,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 				try {
 					appendFileSync(
 						startupLogPath,
-						`[launchd fallback] bootoutStatus=${bootout.status ?? "null"} bootstrapStatus=${bootstrap.status ?? "null"} kickstartStatus=${kickstart.status ?? "null"} bootoutError=${bootout.error?.message ?? ""} bootstrapError=${bootstrap.error?.message ?? ""} kickstartError=${kickstart.error?.message ?? ""}
+						`[launchd fallback] bootoutStatus=${bootout ? (bootout.status ?? "null") : "skipped"} bootstrapStatus=${bootstrap.status ?? "null"} kickstartStatus=${kickstart.status ?? "null"} bootoutError=${bootout?.error?.message ?? ""} bootstrapError=${bootstrap.error?.message ?? ""} kickstartError=${kickstart.error?.message ?? ""}
 `,
 					);
 				} catch {


### PR DESCRIPTION
## Summary

Fixes the four misleading daemon/CLI diagnostics from #1074: `dream trigger`/`dream status` hide the real failure (pass error, or "event loop blocked" vs "stopped"), `daemon stop` reads as success while the launchd keepalive respawns the daemon, and `daemon restart` prints `Boot-out failed: 3: No such process` as a start failure when the daemon comes up healthy.

## Changes

- `dream trigger` surfaces the daemon's rejected-trigger error body and the pass's terminal `error`, distinguishes a probe timeout (event loop blocked) from an offline daemon, and no longer reports "Dreaming pass complete" while a pass is still running.
- `dream status` / `dream tool` surface daemon `{error}` bodies on HTTP failures and label probe timeouts as "not responding (its event loop may be blocked)" instead of "(is the daemon running?)".
- `daemon status` / `status` label `listener-unhealthy` / `process-unhealthy` probes as "Daemon unresponsive" with a `signet daemon logs` pointer — no restart advice.
- `daemon stop` boots out the launchd keepalive (`ai.signet.daemon`) when the health endpoint says stopped, and reports the unload so the user knows it will not respawn.
- `daemon restart` only runs the pre-bootstrap `launchctl bootout` when the job is actually loaded, so `Boot-out failed: 3: No such process` never pollutes the startup log or start-failure diagnostics.
- `fetchDaemonResult` (lib/daemon.ts) now carries the daemon's `{error}` message on HTTP failures.

Before:
```text
$ signet dream trigger
  Pass … accepted, polling for result...
  Could not retrieve pass result. Check `signet dream status`.

$ signet dream status
  Failed to get dreaming status (is the daemon running?)
```

After:
```text
$ signet dream trigger
  Pass … accepted, polling for result...
  Error: No routing policy is configured.

$ signet dream status
  Failed to get dreaming status — the daemon is not responding (its event loop may be blocked).
  Check `signet daemon logs`; a restart may not clear a wedged worker.
```

## Type

<!-- Check one. -->

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

<!-- Check all that apply. -->

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

<!-- Required for any UI changes (dashboard, web, extension). PRs that
     touch the frontend without screenshots will not be merged. -->

N/A — CLI diagnostics text only; before/after output shown in Changes.

## PR Readiness (MANDATORY)

<!-- Derived from AGENTS.md recurring review failures. These checks are
     required and enforced by CI. -->

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Testing

<!-- How did you verify this works? -->

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Scope notes: 79/79 tests green on the four touched test files (13 new regression tests). The full CLI suite retains 13 pre-existing failures in sources/route tests (`process.exitCode` cross-file interference) — verified identical on the baseline by stashing these changes. `bun run typecheck` is green for `@signet/daemon`; `signet-dashboard` typecheck fails on a pre-existing bun-cache vite duplicate (unrelated, fails on main). Biome clean and `git diff --check` clean on all touched files; CLI build passes.

Live-verified with the built CLI against the running daemon: healthy `dream status` output unchanged, offline probe prints "(is the daemon running?)", and a hanging listener (accepts, never responds) triggers the "event loop may be blocked" path. launchd behaviors (stop bootout, restart bootout suppression) are darwin-only and covered by unit tests with a stubbed `launchctl` — cannot be exercised live on this Linux box.

## AI disclosure

<!-- See AI_POLICY.md for the full policy. The short version:

  Use AI freely, but understand everything you ship. AI is your hands,
  not your brain. Unreviewed AI output will be closed.

  If AI was used, include Assisted-by tags in your commit messages:

    Assisted-by: Claude-Code:claude-opus-4-6
    Assisted-by: Cursor:claude-sonnet-4-5 biome

  If no AI was used, check the box and move on.
-->

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

<!-- Anything reviewers should know — migration impacts, breaking changes, follow-up work. Leave blank if none. -->

No migrations touched. Launchd-managed stop/restart behavior is unit-tested only (no macOS available in this environment); a quick live check of `signet daemon stop`/`restart` on a launchd-managed install would be a good reviewer pass.
