### PR TITLE
fix(dreaming): alternate hygiene/content pass modes

### DIFF
--- a/docs/api/knowledge-ontology.md
+++ b/docs/api/knowledge-ontology.md
@@ -572,6 +572,15 @@ and defaults to the daemon configured agent; `agent_id`, the `agentId` query
 parameter, the `agent_id` query parameter, and `x-signet-agent-id` are also
 accepted.
 
+Explicit triggers always run the combined `incremental` runbook (hygiene
+queue first, then content ingestion). The worker's scheduled sweep passes,
+in contrast, alternate between two focused runbooks when both kinds of work
+are pending — `incremental-hygiene` (attention queue only) and
+`incremental-content` (new evidence only) — so content ingestion gets a
+guaranteed turn even while the hygiene queue stays full (#1098). The pass
+row's `mode` column and the status response's `state.lastPassMode` record
+the runbook that actually ran.
+
 **Response** — `202 Accepted`
 
 ```json

--- a/platform/daemon/src/pipeline/dreaming-worker.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.test.ts
@@ -6,10 +6,16 @@ import { join } from "node:path";
 import type { DreamingConfig } from "@signet/core";
 import { runMigrations } from "../../../core/src/migrations";
 import type { DbAccessor } from "../db-accessor";
-import { DREAMING_AGENT_PROMPT, enqueueDreamingHygieneAttention } from "./dreaming";
+import {
+	DREAMING_AGENT_PROMPT,
+	type DreamingPassFocus,
+	dreamingFocusOfMode,
+	enqueueDreamingHygieneAttention,
+} from "./dreaming";
 import {
 	createAgentScopeSnapshot,
 	getDreamingWorkerAgentIds,
+	selectDreamingCheckMode,
 	shouldDeferDreamingSweep,
 	startDreamingWorker,
 } from "./dreaming-worker";
@@ -155,6 +161,35 @@ describe("dreaming worker agent scope", () => {
 		} finally {
 			worker.stop();
 		}
+	});
+
+	it("alternates hygiene and content runbooks across sweep checks (#1098)", () => {
+		// Regression for #1098: with the hygiene queue perpetually full, the
+		// sweep scheduled the combined runbook every cycle and content
+		// ingestion never got budget. When both hygiene and content work are
+		// pending, the sweep must alternate so content gets a guaranteed
+		// turn.
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO entities
+			 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+			 VALUES ('legacy-husk', 'Legacy Husk', 'legacy husk', 'project', 'default', 5, ?, ?)`,
+		).run(now, now);
+		db.prepare(
+			`INSERT INTO session_summaries
+			 (id, agent_id, content, token_count, depth, kind, source_type, earliest_at, latest_at, created_at)
+			 VALUES ('sweep-evidence', 'default', 'New episodic evidence awaiting a content pass.', 10, 0, 'session', 'summary', datetime('now'), datetime('now'), datetime('now'))`,
+		).run();
+		enqueueDreamingHygieneAttention(accessor, "default");
+
+		let focus: DreamingPassFocus | null = null;
+		const first = selectDreamingCheckMode(accessor, ["default"], focus);
+		expect(first).toBe("incremental-hygiene");
+		focus = dreamingFocusOfMode(first) ?? focus;
+		const second = selectDreamingCheckMode(accessor, ["default"], focus);
+		expect(second).toBe("incremental-content");
+		focus = dreamingFocusOfMode(second) ?? focus;
+		expect(selectDreamingCheckMode(accessor, ["default"], focus)).toBe("incremental-hygiene");
 	});
 
 	it("seeds deterministic hygiene attention for legacy graph rows", () => {

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -13,14 +13,18 @@ import { isSystemPressureHigh } from "../system-pressure";
 import {
 	type DreamingAgentExecutor,
 	type DreamingMode,
+	type DreamingPassFocus,
 	createDreamingPass,
+	dreamingFocusOfMode,
 	enqueueDreamingHygieneAttention,
 	getDreamingEpisodicTokenBacklog,
 	isDreamingHaltActive,
 	recordDreamingFailure,
 	runDreamingAgentPass,
+	selectDreamingPassMode,
 	shouldTriggerDreaming,
 } from "./dreaming";
+import { getDreamingAttentionInDb } from "./dreaming-attention";
 
 /** Thrown when a trigger is attempted while a pass is already in-flight. */
 export class AlreadyRunningError extends Error {
@@ -138,6 +142,24 @@ export function createAgentScopeSnapshot(
 	};
 }
 
+/**
+ * The runbook for the next scheduled sweep pass (#1098): read the pending
+ * work across every scope, then pick hygiene/content — alternating when both
+ * kinds are pending so content gets a guaranteed turn even while the hygiene
+ * queue stays full. Shared between check() and tests.
+ */
+export function selectDreamingCheckMode(
+	accessor: DbAccessor,
+	scopes: readonly string[],
+	lastScheduled: DreamingPassFocus | null,
+): DreamingMode {
+	const hasPendingAttention = scopes.some((scope) =>
+		accessor.withReadDb((db) => getDreamingAttentionInDb(db, scope, 1).length > 0),
+	);
+	const hasBacklog = scopes.some((scope) => getDreamingEpisodicTokenBacklog(accessor, scope) > 0);
+	return selectDreamingPassMode(lastScheduled, hasPendingAttention, hasBacklog);
+}
+
 export function startDreamingWorker(
 	accessor: DbAccessor,
 	cfg: DreamingConfig,
@@ -150,6 +172,10 @@ export function startDreamingWorker(
 	let activeAgent: string | null = null;
 	let stopped = false;
 	let activePassPromise: Promise<unknown> | null = null;
+	// The last focused runbook the periodic sweep scheduled, used to
+	// alternate hygiene → content → hygiene → … when both kinds of work are
+	// pending (#1098). Explicit triggers do not touch it.
+	let nextScheduledFocus: DreamingPassFocus | null = null;
 	const getAgentScopes = createAgentScopeSnapshot(AGENT_SCOPE_SNAPSHOT_REFRESH_MS, () =>
 		getDreamingWorkerAgentIds(accessor, defaultAgentId),
 	);
@@ -293,7 +319,14 @@ export function startDreamingWorker(
 			}
 		}
 		if (!triggered) return;
-		await runPass(defaultAgentId, "incremental", undefined, scopes);
+		// #1098: with the hygiene queue perpetually full, every pass used to
+		// drain flags first and run out of budget before content work. Give
+		// content a guaranteed turn: alternate the runbook per check cycle
+		// when both kinds of work are pending; run the only-pending kind
+		// directly otherwise.
+		const mode = selectDreamingCheckMode(accessor, scopes, nextScheduledFocus);
+		nextScheduledFocus = dreamingFocusOfMode(mode) ?? nextScheduledFocus;
+		await runPass(defaultAgentId, mode, undefined, scopes);
 	}
 
 	function schedule(): void {

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -5,10 +5,13 @@ import { runMigrations } from "../../../core/src/migrations";
 import type { DbAccessor } from "../db-accessor";
 import {
 	DREAMING_AGENT_PROMPT,
+	DREAMING_CONTENT_AGENT_PROMPT,
 	DREAMING_FAILURE_HALT_THRESHOLD,
 	DREAMING_HALT_COOLDOWN_MS,
+	DREAMING_HYGIENE_AGENT_PROMPT,
 	type DreamingState,
 	_testParseEpisodicCursor,
+	dreamingEarlyExitSummary,
 	enqueueDreamingHygieneAttention,
 	getDreamingEpisodicTokenBacklog,
 	getDreamingPasses,
@@ -19,6 +22,7 @@ import {
 	recordDreamingFailure,
 	requestDreamingEvidenceRequeue,
 	runDreamingAgentPass,
+	selectDreamingPassMode,
 	shouldTriggerDreaming,
 } from "./dreaming";
 import {
@@ -606,5 +610,129 @@ describe("Dreaming", () => {
 			),
 		).rejects.toThrow("agent timeout");
 		expect(getDreamingPasses(accessor, AGENT).find((pass) => pass.status === "failed")?.error).toBe("agent timeout");
+	});
+
+	it("selects the focused runbook, alternating when both kinds of work are pending (#1098)", () => {
+		// Regression for #1098: with the hygiene queue perpetually full, the
+		// old worker ran the combined runbook hygiene-first every pass and
+		// content ingestion never got budget. With both kinds of work
+		// pending, the worker must alternate so content gets a guaranteed
+		// turn.
+		expect(selectDreamingPassMode(null, true, true)).toBe("incremental-hygiene");
+		expect(selectDreamingPassMode("hygiene", true, true)).toBe("incremental-content");
+		expect(selectDreamingPassMode("content", true, true)).toBe("incremental-hygiene");
+		// Only one kind pending: run that kind directly, no alternation.
+		expect(selectDreamingPassMode("content", true, false)).toBe("incremental-hygiene");
+		expect(selectDreamingPassMode("hygiene", false, true)).toBe("incremental-content");
+	});
+
+	it("early-exits each focused pass mode on its own empty work (#1098)", () => {
+		// Hygiene exits on an empty attention queue even while evidence is
+		// pending; content exits on an empty backlog even while attention is
+		// pending; combined modes need both empty; compact never exits.
+		expect(dreamingEarlyExitSummary("incremental-hygiene", false, 100)).toBe("No hygiene attention to process");
+		expect(dreamingEarlyExitSummary("incremental-hygiene", true, 0)).toBeNull();
+		expect(dreamingEarlyExitSummary("incremental-content", true, 0)).toBe("No new episodic evidence to process");
+		expect(dreamingEarlyExitSummary("incremental-content", false, 1)).toBeNull();
+		expect(dreamingEarlyExitSummary("incremental", false, 0)).toBe(
+			"No new episodic evidence or semantic attention to process",
+		);
+		expect(dreamingEarlyExitSummary("incremental", true, 0)).toBeNull();
+		expect(dreamingEarlyExitSummary("compact", false, 0)).toBeNull();
+	});
+
+	it("uses the mode-specific runbook prompt for focused passes (#1098)", async () => {
+		accessor.withWriteTx((tx) => {
+			enqueueDreamingAttentionInTx(tx, {
+				agentId: AGENT,
+				kind: "hygiene",
+				subjectRef: "entity:legacy-husk",
+			});
+		});
+		let hygienePrompt = "";
+		await runDreamingAgentPass(
+			accessor,
+			{
+				async run(input) {
+					hygienePrompt = input.prompt;
+					return { summary: "Archived flagged husks" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT],
+			"incremental-hygiene",
+		);
+		expect(hygienePrompt).toBe(DREAMING_HYGIENE_AGENT_PROMPT);
+		expect(hygienePrompt).not.toContain("find new evidence since the cutoff");
+
+		seedSummary(db, "content-prompt", "New evidence for the content runbook.", 8);
+		let contentPrompt = "";
+		await runDreamingAgentPass(
+			accessor,
+			{
+				async run(input) {
+					contentPrompt = input.prompt;
+					return { summary: "Extracted claims" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT],
+			"incremental-content",
+		);
+		expect(contentPrompt).toBe(DREAMING_CONTENT_AGENT_PROMPT);
+		expect(contentPrompt).not.toContain("Process ALL pending hygiene records");
+	});
+
+	it("does not advance the evidence watermark for hygiene-only work (#1098)", async () => {
+		// Regression for #1098: a pass that only processed hygiene used to
+		// reset the evidence cursor anyway, so the unprocessed episodic
+		// backlog no longer counted as new and content ingestion never got
+		// budget. A hygiene pass must leave the watermark untouched so the
+		// next content pass still sees the backlog.
+		seedSummary(db, "starved-evidence", "New transcript evidence that content passes never reached.", 8);
+		accessor.withWriteTx((tx) => {
+			enqueueDreamingAttentionInTx(tx, {
+				agentId: AGENT,
+				kind: "hygiene",
+				subjectRef: "entity:legacy-husk",
+			});
+		});
+		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+
+		await runDreamingAgentPass(
+			accessor,
+			{
+				async run() {
+					return { summary: "Archived flagged husks" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT],
+			"incremental-hygiene",
+		);
+		// The hygiene pass consumed no evidence: the backlog still counts as
+		// new, so the next scheduled content pass gets it.
+		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+
+		await runDreamingAgentPass(
+			accessor,
+			{
+				async run() {
+					return { summary: "Extracted claims" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT],
+			"incremental-content",
+		);
+		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBe(0);
 	});
 });

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -55,7 +55,14 @@ import { countTokens } from "./tokenizer";
 // Types
 // ---------------------------------------------------------------------------
 
-export type DreamingMode = "incremental" | "compact";
+export type DreamingMode = "incremental" | "compact" | "incremental-hygiene" | "incremental-content";
+
+/**
+ * The focused runbook a scheduled pass follows (#1098): hygiene passes
+ * process the attention queue only, content passes ingest new evidence
+ * only. Combined modes ("incremental", "compact") keep the full runbook.
+ */
+export type DreamingPassFocus = "hygiene" | "content";
 
 export interface DreamingState {
 	readonly consecutiveFailures: number;
@@ -656,6 +663,178 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 - No writes attempted against pinned or source-root entities.
 `;
 
+/**
+ * The fixed prompt for a hygiene-only pass (#1098): the attention-queue
+ * runbook (combined-process steps 1-2 + 4). Content maintenance is out of
+ * scope — content passes own it, so a hygiene pass spends its whole budget
+ * on the queue instead of running out before step 3.
+ */
+export const DREAMING_HYGIENE_AGENT_PROMPT = `You are a bounded Signet maintenance agent. Your task is to maintain durable, evidence-cited semantic understanding as the relevant entities, relationships, and claims change over time. Attach each claim to its entity and aspect rather than allowing it to exist as standalone.
+
+## Process
+
+Purpose: maintain durable, evidence-cited semantic understanding in the knowledge graph. This is a HYGIENE pass: process the attention queue — inspect flagged targets and archive or merge them with attention provenance, minting flags for junk the queue missed. Content maintenance (claims, entities) belongs to content passes, which cite exact quotes from episodic evidence. Use the pass log (runbook_read) as the dedup source: the previous pass's changes are the cutoff.
+
+An install may have several agent scopes (listed in <agent_scopes> when there is more than one): the scoped tools take an agentId, so address any scope you need — each write is attributed to the agent you name. attention_list without an agentId lists the whole install's hygiene queue, with each record carrying its owning agentId.
+
+### State targets
+
+- Hygiene queue: dreaming_attention pending records (kind=hygiene)
+- Graph: entities, aspects, claims, links (active/archived/pinned)
+- Pass log: dreaming_passes + runbook notes (what changed, what was viewed)
+
+### Per-pass process
+
+1. Read the pass log (runbook_read). Establish cutoff: sources viewed, changes applied, deferred items.
+2. Query the attention queue (attention_list, kind=hygiene, status=pending). Process ALL pending hygiene records:
+   - Inspect the flagged target (get_entity — check aspects, claims, pinned).
+   - Archive or merge it, citing its attention id (provenance: "attention:<uuid>", or attention:$<index> for a flag you minted in the same batch).
+   - If you discover junk the queue did not flag, mint a flag op and archive in the same batch.
+3. Write the pass log (runbook_write): what changed, any flags left for a later pass, anything deferred with exact names.
+
+### Safe
+
+- Archive attention-flagged entities that are non-concrete (zero active aspects/claims, non-concrete type, legacy-only deps).
+- Merge exact-canonical duplicates (same canonical name, same scope).
+
+### Unsafe
+
+- Archive any entity with active aspects/claims.
+- Merge entities across agent scopes.
+- Any write without provenance: hygiene ops need an attention id.
+- Content writes: claims and entities need exact-quote citations from episodic evidence and belong to content passes.
+- Touch pinned entities, source-root entities, or topology entities.
+
+### Verification (before finishing)
+
+- Every write in the batch carries attention provenance.
+- Hygiene queue is drained, or remaining records are explicitly deferred with reasons in the pass log.
+- Pass log written with changes applied (this is the next pass's dedup).
+- No flag left unresolved for a target you archived.
+- No writes attempted against pinned or source-root entities.
+`;
+
+/**
+ * The fixed prompt for a content-only pass (#1098): the evidence runbook
+ * (combined-process steps 1, 3, 4). Hygiene archives are out of scope —
+ * hygiene passes own the attention queue, so a content pass spends its
+ * whole budget ingesting new evidence instead of being crowded out.
+ */
+export const DREAMING_CONTENT_AGENT_PROMPT = `You are a bounded Signet maintenance agent. Your task is to maintain durable, evidence-cited semantic understanding as the relevant entities, relationships, and claims change over time. Attach each claim to its entity and aspect rather than allowing it to exist as standalone.
+
+## Process
+
+Purpose: maintain durable, evidence-cited semantic understanding in the knowledge graph. This is a CONTENT pass: find new evidence since the cutoff and extract/update claims with exact-quote citations, creating entities for durable subjects. Hygiene archives/merges belong to hygiene passes, which process the attention queue. Use the pass log (runbook_read) as the dedup source: the previous pass's viewed sources and changes are the cutoff.
+
+An install may have several agent scopes (listed in <agent_scopes> when there is more than one): the scoped tools take an agentId, so address any scope you need — each write is attributed to the agent you name. attention_list without an agentId lists the whole install's hygiene queue, with each record carrying its owning agentId.
+
+### State targets
+
+- Graph: entities, aspects, claims, links (active/archived/pinned)
+- Evidence: episodic store (memories, artifacts, transcripts, summaries)
+- Pass log: dreaming_passes + runbook notes (what changed, what was viewed)
+
+### Per-pass process
+
+1. Read the pass log (runbook_read). Establish cutoff: sources viewed, changes applied, deferred items.
+2. Find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. For each new source:
+   - search_entities for subjects it establishes.
+   - Extract/update claims with exact-quote evidence from that source.
+   - create_entity only for durable subjects clearly established by the source.
+   - Validate before writing (validate_proposal).
+3. Write the pass log (runbook_write): what changed, which sources were viewed, anything deferred with exact names.
+
+### Safe
+
+- Add/set/supersede claims with exact quotes from an episodic source.
+- Create entities for durable subjects the source clearly establishes.
+- Rename/update entities only with evidence.
+
+### Unsafe
+
+- Any write without provenance: content ops need an exact quote.
+- Claims without exact quotes, or relationships the source does not state.
+- Hygiene archives/merges: they need attention records, which hygiene passes process.
+- Touch pinned entities, source-root entities, or topology entities.
+- Rewrite existing claims without evidence that supersedes them.
+
+### Verification (before finishing)
+
+- Every write in the batch cites an exact quote from scoped episodic evidence.
+- Pass log written with sources viewed + changes applied (this is the next pass's dedup).
+- No claims without exact quotes, no relationships the source does not state.
+- No writes attempted against pinned or source-root entities.
+`;
+
+/** The fixed prompt contract for a pass mode: focused modes get their runbook, combined modes keep the full one. */
+export function dreamingPromptForMode(mode: DreamingMode): string {
+	if (mode === "incremental-hygiene") return DREAMING_HYGIENE_AGENT_PROMPT;
+	if (mode === "incremental-content") return DREAMING_CONTENT_AGENT_PROMPT;
+	return DREAMING_AGENT_PROMPT;
+}
+
+/** The focused runbook a pass mode follows, or null for the combined modes. */
+export function dreamingFocusOfMode(mode: DreamingMode): DreamingPassFocus | null {
+	if (mode === "incremental-hygiene") return "hygiene";
+	if (mode === "incremental-content") return "content";
+	return null;
+}
+
+/**
+ * Whether a pass mode consumes episodic evidence. A hygiene pass processes
+ * only the attention queue, so it must not advance the evidence watermark;
+ * every other mode reads evidence and resets the queue to pass start.
+ */
+function dreamingModeAdvancesEvidence(mode: DreamingMode): boolean {
+	return mode !== "incremental-hygiene";
+}
+
+/**
+ * The early-exit contract for a pass mode (#1098): a pass exits without
+ * invoking the agent when its own work is empty — hygiene on an empty
+ * attention queue, content on an empty episodic backlog. Combined modes
+ * exit only when both are empty; compact never early-exits.
+ */
+export function dreamingEarlyExitSummary(
+	mode: DreamingMode,
+	hasPendingAttention: boolean,
+	totalBacklog: number,
+): string | null {
+	if (mode === "incremental-hygiene") return hasPendingAttention ? null : "No hygiene attention to process";
+	if (mode === "incremental-content") return totalBacklog === 0 ? "No new episodic evidence to process" : null;
+	if (mode === "incremental") {
+		return !hasPendingAttention && totalBacklog === 0
+			? "No new episodic evidence or semantic attention to process"
+			: null;
+	}
+	return null; // compact never early-exits
+}
+
+/**
+ * Which runbook the next scheduled pass gets. When both hygiene and content
+ * work are pending, the worker alternates (hygiene → content → hygiene → …)
+ * so content gets a guaranteed turn even while the hygiene queue refills
+ * faster than passes drain it (#1098). When only one kind of work is
+ * pending, run that kind directly so no pass is spent on an empty runbook.
+ */
+export function selectDreamingPassMode(
+	lastScheduled: DreamingPassFocus | null,
+	hasPendingAttention: boolean,
+	hasBacklog: boolean,
+): DreamingMode {
+	if (hasPendingAttention && hasBacklog) {
+		// Tie: alternate so content gets a guaranteed turn even while the
+		// hygiene queue stays full, starting the cycle at hygiene.
+		return lastScheduled === "hygiene" ? "incremental-content" : "incremental-hygiene";
+	}
+	if (hasPendingAttention) return "incremental-hygiene";
+	if (hasBacklog) return "incremental-content";
+	// Unreachable through shouldTriggerDreaming (it fires only when attention
+	// or a backlog exists); the combined mode's early-exit gate is the
+	// defensive fallback.
+	return "incremental";
+}
+
 // ---------------------------------------------------------------------------
 // Main dreaming orchestrator
 // ---------------------------------------------------------------------------
@@ -679,8 +858,8 @@ export async function runDreamingAgentPass(
 	try {
 		const prompt =
 			scopes.length > 1
-				? `${DREAMING_AGENT_PROMPT}\n\n<agent_scopes>\n${scopes.join("\n")}\n</agent_scopes>`
-				: DREAMING_AGENT_PROMPT;
+				? `${dreamingPromptForMode(mode)}\n\n<agent_scopes>\n${scopes.join("\n")}\n</agent_scopes>`
+				: dreamingPromptForMode(mode);
 
 		// SQLite-format watermark so string comparisons against stored source
 		// dates stay consistent (ISO timestamps would mis-order).
@@ -696,17 +875,22 @@ export async function runDreamingAgentPass(
 			accessor.withReadDb((db) => getDreamingAttentionInDb(db, scope, 1).length > 0),
 		);
 		const totalBacklog = scopes.reduce((total, scope) => total + getDreamingEpisodicTokenBacklog(accessor, scope), 0);
-		if (mode === "incremental" && !hasPendingAttention && totalBacklog === 0) {
-			const summary = "No new episodic evidence or semantic attention to process";
+		const earlyExitSummary = dreamingEarlyExitSummary(mode, hasPendingAttention, totalBacklog);
+		if (earlyExitSummary !== null) {
 			accessor.withWriteTx((db) => {
 				db.prepare(
 					`UPDATE dreaming_passes SET status = 'completed', completed_at = datetime('now'),
 					 tokens_consumed = 0, mutations_applied = 0, mutations_skipped = 0,
 					 mutations_failed = 0, summary = ? WHERE id = ?`,
-				).run(summary, passId);
-				for (const scope of scopes) resetDreamingTokens(db, scope, passId, mode, null, cutoff);
+				).run(earlyExitSummary, passId);
+				// The evidence watermark only advances when nothing new
+				// remains: a focused pass that exits while the other mode's
+				// work is pending must not skip it for the next pass (#1098).
+				if (totalBacklog === 0) {
+					for (const scope of scopes) resetDreamingTokens(db, scope, passId, mode, null, cutoff);
+				}
 			});
-			return { passId, applied: 0, skipped: 0, failed: 0, summary };
+			return { passId, applied: 0, skipped: 0, failed: 0, summary: earlyExitSummary };
 		}
 
 		let applied = 0;
@@ -759,11 +943,15 @@ export async function runDreamingAgentPass(
 				 mutations_failed = ?, summary = ? WHERE id = ?`,
 			).run(tokensConsumed, applied, 0, failed, summary, passId);
 			recordDreamingEvidenceExclusionsInTx(db, agentId, passId, rejectedEvidence, "semantic_operation_rejected");
-			// The evidence queue resets to the pass watermark for EVERY scope:
-			// the next pass's backlog counts only sources captured after this
-			// pass began. The agent's own pass log (runbook_write) carries the
-			// viewed-source dedup.
-			for (const scope of scopes) resetDreamingTokens(db, scope, passId, mode, null, cutoff);
+			// The evidence queue resets to the pass watermark for EVERY scope
+			// the pass consumed evidence for: the next pass's backlog counts
+			// only sources captured after this pass began. A hygiene pass
+			// consumes no evidence, so it must not advance the watermark —
+			// advancing it would hide the unprocessed backlog from the next
+			// content pass and starve content again (#1098).
+			if (dreamingModeAdvancesEvidence(mode)) {
+				for (const scope of scopes) resetDreamingTokens(db, scope, passId, mode, null, cutoff);
+			}
 		});
 		return { passId, applied, skipped: 0, failed, summary };
 	} catch (error) {


### PR DESCRIPTION
Fixes #1098

## Summary

Dreaming passes never reach content maintenance (#1098): the combined runbook is hygiene-first, the enqueuer mints ~50 flags per check cycle, and the queue refills faster than passes drain it — so every pass spent its entire budget archiving (48-50 archives, zero content ops across five consecutive passes) and the pass-end watermark reset hid the unread episodic backlog from the next pass. Content ingestion had no turn.

Split the Process contract into two focused runbooks and have the worker alternate them so content gets a guaranteed turn even while the hygiene queue stays full.

## Changes

- `platform/daemon/src/pipeline/dreaming.ts`
  - New pass modes `incremental-hygiene` (attention queue only: old steps 1-2 + 4) and `incremental-content` (new evidence only: old steps 1, 3, 4), each with its own hardcoded prompt constant (`DREAMING_HYGIENE_AGENT_PROMPT`, `DREAMING_CONTENT_AGENT_PROMPT`). Explicit triggers keep the combined `incremental`/`compact` runbooks and the unchanged API contract.
  - Per-mode early-exit: hygiene exits on an empty attention queue, content on an empty episodic backlog; combined modes need both empty; compact never early-exits.
  - Hygiene passes no longer advance the evidence watermark (`dreaming_state.last_pass_at`/`evidence_cursor`) — a hygiene-only pass used to reset the cursor past evidence it never read, starving content a second way.
- `platform/daemon/src/pipeline/dreaming-worker.ts` — the sweep alternates hygiene → content per check cycle when both kinds of work are pending (`selectDreamingCheckMode`), runs the only-pending kind directly otherwise, and records the focused mode on the pass row / `last_pass_mode` so the log is auditable per runbook.
- Tests: regression tests naming the bug (hygiene pass does not advance the watermark; alternation when both pending; per-mode early-exit; mode-specific prompts).
- `docs/api/knowledge-ontology.md` — documents the scheduled focused modes vs explicit triggers.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A — daemon-side behavior change, no UI.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally
