### PR TITLE
fix(native): unblock compiled embedding runtime

### DIFF
--- a/platform/daemon/src/embedding-wasm-config.ts
+++ b/platform/daemon/src/embedding-wasm-config.ts
@@ -1,6 +1,11 @@
 export interface EmbeddingWasmConfig {
 	numThreads?: number;
 	wasmPaths?: string;
+	/** Preloaded wasm binary — onnxruntime-web 1.26 loads the .wasm via fetch()
+	 *  instead of the 1.22-era fs.readFileSync, so the compiled binary must
+	 *  hand the materialized binary over directly or session creation dies
+	 *  with `fetch() URL is invalid` on the filesystem path. */
+	wasmBinary?: ArrayBuffer;
 }
 
 export function configureEmbeddingWasm(wasm: EmbeddingWasmConfig | undefined, wasmDir: string | null): void {

--- a/platform/daemon/src/embedding-worker.ts
+++ b/platform/daemon/src/embedding-worker.ts
@@ -18,7 +18,8 @@
  *     workerData (the worker cannot read the main-thread asset globals).
  */
 
-import { mkdirSync } from "node:fs";
+import { mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { isMainThread, parentPort, workerData } from "node:worker_threads";
 import { type EmbeddingWasmConfig, configureEmbeddingWasm } from "./embedding-wasm-config";
 import type { EmbeddingWorkerInit, MainToWorkerMessage, WorkerToMainMessage } from "./embedding-worker-protocol";
@@ -166,6 +167,17 @@ async function doInit(): Promise<void> {
 			transformers.env.remoteHost = init.remoteHostOverride;
 		}
 		configureEmbeddingWasm(transformers.env.backends?.onnx?.wasm, init.wasmDir);
+		if (init.wasmDir && transformers.env.backends?.onnx?.wasm) {
+			// onnxruntime-web 1.26's emscripten glue fetches the .wasm file
+			// (1.22 read it with fs.readFileSync), which cannot resolve the
+			// materialized filesystem path inside the compiled binary. Load it
+			// here and pass the binary so session creation never fetches it.
+			const wasmBytes = readFileSync(join(init.wasmDir, "ort-wasm-simd-threaded.wasm"));
+			transformers.env.backends.onnx.wasm.wasmBinary = wasmBytes.buffer.slice(
+				wasmBytes.byteOffset,
+				wasmBytes.byteOffset + wasmBytes.byteLength,
+			) as ArrayBuffer;
+		}
 
 		log("info", `Initializing ${init.modelId} (q8 quantization)`, {
 			cachePath: init.cacheDir,

--- a/scripts/build-native-bun.ts
+++ b/scripts/build-native-bun.ts
@@ -193,6 +193,62 @@ const nodeDeviceDefault = /defaultDevices = \["cpu"\];/g;
 if ((patchedTransformersWebRuntimeSource.match(nodeDeviceDefault) ?? []).length !== 1) {
 	throw new Error("Unsupported @huggingface/transformers web runtime: Node device default changed");
 }
+// Transformers.js 4.x ALSO decides the null-device default in selectDevice
+// through a module-level DEFAULT_DEVICE const, separate from defaultDevices.
+// The compiled binary reports a Node-like environment, so without this pin
+// selectDevice(null) returns "cpu" and the patched WASM-only runtime throws
+// `Unsupported device: "cpu". Should be one of: wasm.` when the embedding
+// worker initializes a pipeline. Keep the unique-anchor guard so a future
+// restructure of this default fails loudly instead of shipping a broken binary.
+const deviceDefault = /var DEFAULT_DEVICE = apis\.IS_NODE_ENV \? "cpu" : "wasm";/g;
+if ((patchedTransformersWebRuntimeSource.match(deviceDefault) ?? []).length !== 1) {
+	throw new Error("Unsupported @huggingface/transformers web runtime: DEFAULT_DEVICE changed");
+}
+patchedTransformersWebRuntimeSource = patchedTransformersWebRuntimeSource.replace(
+	deviceDefault,
+	'var DEFAULT_DEVICE = "wasm";',
+);
+// Transformers.js 4.x web build stubs node:fs/path/url as empty objects
+// (`// ignore-modules:node:fs` + `var node_fs_default = {};`), which forces
+// env.useFS=false and breaks local model loading in the compiled binary:
+// getFile() falls through to fetch() on a bare filesystem path, throwing
+// `ERR_INVALID_URL` and failing pipeline init with "Unable to get model file
+// path or buffer". The 3.8.1 web build shipped real fs modules; wire the
+// Node builtins back in so FileResponse can read the model cache from disk.
+// Unique-anchor guards keep a future stub restructure loud.
+for (const [name, specifier] of [
+	["fs", "node:fs"],
+	["path", "node:path"],
+	["url", "node:url"],
+] as const) {
+	const nodeStub = new RegExp(`// ignore-modules:node:${name}\\nvar node_${name}_default = \\{\\};`, "g");
+	if ((patchedTransformersWebRuntimeSource.match(nodeStub) ?? []).length !== 1) {
+		throw new Error(`Unsupported @huggingface/transformers web runtime: node:${name} stub changed`);
+	}
+	patchedTransformersWebRuntimeSource = patchedTransformersWebRuntimeSource.replace(
+		nodeStub,
+		`import node_${name}_default from ${JSON.stringify(specifier)};`,
+	);
+}
+// Transformers.js 4.x treats a Node-like environment as able to hand model
+// files to onnxruntime by PATH (getCoreModelFile/getModelDataFiles pass
+// return_path = apis.IS_NODE_ENV). onnxruntime-web 1.26's session glue loads
+// a string path with fetch() (1.22 read it with fs.readFileSync), so the
+// compiled binary dies with `fetch() URL is invalid` once the model downloads.
+// Force return_path=false so the model bytes are handed to the session, which
+// never touches the filesystem for the onnx input.
+for (const returnPathAnchor of [
+	"const return_path = apis.IS_NODE_ENV;",
+	"return await getModelFile(pretrained_model_name_or_path, fullPath, true, options, apis.IS_NODE_ENV);",
+]) {
+	if ((patchedTransformersWebRuntimeSource.split(returnPathAnchor).length ?? 0) !== 2) {
+		throw new Error("Unsupported @huggingface/transformers web runtime: return_path anchor changed");
+	}
+	patchedTransformersWebRuntimeSource = patchedTransformersWebRuntimeSource.replace(
+		returnPathAnchor,
+		returnPathAnchor.replace("apis.IS_NODE_ENV", "false"),
+	);
+}
 const patchedTransformersWebRuntimePath = join(buildDir, "transformers.web.js");
 writeFileSync(patchedTransformersWebRuntimePath, patchedTransformersWebRuntimeSource);
 const wasmAssets = ["ort-wasm-simd-threaded.mjs", "ort-wasm-simd-threaded.wasm"].map((name) => ({

--- a/scripts/native-transformers-patch-contract.test.ts
+++ b/scripts/native-transformers-patch-contract.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression guard for the compiled-binary transformers web-runtime patch
+ * (scripts/build-native-bun.ts). The transformers 4.2.0 bump broke native
+ * embedding in the compiled binary via four anchors the patcher now rewrites
+ * with unique-match guards:
+ *
+ *   1. DEFAULT_DEVICE — selectDevice() null-device default; without the
+ *      wasm pin the binary throws `Unsupported device: "cpu". Should be one
+ *      of: wasm.` (the release smoke failed on every platform with this).
+ *   2. node:fs/path/url stubs — the web build ships them as empty objects,
+ *      forcing env.useFS=false so getFile() fetches bare filesystem paths.
+ *   3. return_path = apis.IS_NODE_ENV — makes transformers hand the onnx
+ *      model to onnxruntime by PATH, which the 1.26 glue fetch()es.
+ *   4. getCoreModelFile's direct apis.IS_NODE_ENV return_path argument.
+ *
+ * If a transformers bump restructures any anchor, the patcher already fails
+ * loudly at build time; this test surfaces the same drift at test time so
+ * every PR (not just release runs) catches it. Anchors must each appear
+ * exactly once, mirroring the patcher's guards.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+const daemonRequire = createRequire(join(import.meta.dir, "..", "platform", "daemon", "package.json"));
+const transformersPackageJson = daemonRequire.resolve("@huggingface/transformers/package.json");
+const transformersWebRuntimePath = join(dirname(transformersPackageJson), "dist", "transformers.web.js");
+const source = readFileSync(transformersWebRuntimePath, "utf8");
+
+const ANCHORS = [
+	"var DEFAULT_DEVICE = apis.IS_NODE_ENV ? \"cpu\" : \"wasm\";",
+	"// ignore-modules:node:fs\nvar node_fs_default = {};",
+	"// ignore-modules:node:path\nvar node_path_default = {};",
+	"// ignore-modules:node:url\nvar node_url_default = {};",
+	"const return_path = apis.IS_NODE_ENV;",
+	"return await getModelFile(pretrained_model_name_or_path, fullPath, true, options, apis.IS_NODE_ENV);",
+];
+
+describe("native transformers web-runtime patch contract", () => {
+	test("every patcher anchor appears exactly once in the installed runtime", () => {
+		for (const anchor of ANCHORS) {
+			expect(source.split(anchor).length - 1, anchor).toBe(1);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the compiled native binary's embedding runtime, which has been broken
since the transformers 4.2.0 / onnxruntime-web 1.26 deps bump (31b619d2d). The
release workflow's native smoke test ("embeds and recalls a fixed sentence
through the compiled native binary") has failed on every platform runner since
0.162.5, blocking npm publish of 0.162.5, 0.162.6, and 0.163.0. This PR makes
that smoke test pass against a locally built binary and unblocks the release
pipeline.

## Changes

- `scripts/build-native-bun.ts` — three more web-runtime patches (all with
  unique-anchor guards that fail loudly on future restructures):
  - Pin `DEFAULT_DEVICE = "wasm"` — transformers 4.x picks the null-device
    default in `selectDevice()` through a module-level const separate from
    `defaultDevices`; the compiled binary reports a Node-like env, so it
    returned `"cpu"` and the WASM-only runtime threw `Unsupported device:
    "cpu". Should be one of: wasm.`
  - Replace the web build's `// ignore-modules:node:*` stubs (empty objects)
    with real `node:fs`/`node:path`/`node:url` imports — without fs,
    `env.useFS` is false and `getFile()` fetches bare filesystem paths
    (`ERR_INVALID_URL`) when probing the local model cache.
  - Force `return_path = false` (both `getCoreModelFile` and
    `getModelDataFiles`) — transformers passes the onnx model by PATH in
    Node-like envs, and onnxruntime-web 1.26's session glue loads a string
    path with `fetch()` (1.22 used `fs.readFileSync`).
- `embedding-worker.ts` + `embedding-wasm-config.ts` — hand the embedded wasm
  binary to `env.backends.onnx.wasm.wasmBinary` so the onnxruntime glue never
  fetches the materialized filesystem path.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: native build scripts (`scripts/build-native-bun.ts`)

## Screenshots

N/A — build/runtime pipeline fix, no UI change.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

No migration. The patcher only affects the compiled native binary produced by
`build:native-bun`; source-mode daemons and existing binaries are untouched.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

The regression test is the existing release smoke suite
(`scripts/native-embedding-runtime-smoke.test.ts`, gated by
`SIGNET_NATIVE_EMBEDDING_SMOKE=1`). Verified locally: `bun
scripts/build-native-bun.ts` compiles the binary, then all 8 smoke tests pass
against it — including "embeds and recalls a fixed sentence through the
compiled native binary" (previously failing on every release runner) and the
/health SLA isolation test. This is the exact suite the release workflow's
`build-native` job runs, so a green release run is expected once merged.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Depends on #1102 being on main (its transformers 4.2.0 patch introduced the
  patcher this PR extends; both are needed for a working binary).
- Once merged, the 0.163.1 release should publish to npm @next for the first
  time since 0.162.4.
