### PR TITLE
fix(desktop): set safe Linux executable name

### DIFF
--- a/surfaces/desktop/package.json
+++ b/surfaces/desktop/package.json
@@ -33,6 +33,7 @@
 	"build": {
 		"appId": "ai.signet.app",
 		"productName": "Signet",
+		"executableName": "signet",
 		"artifactName": "Signet-${version}-${os}-${arch}.${ext}",
 		"asar": true,
 		"npmRebuild": false,

--- a/surfaces/desktop/src/desktop-updates.test.ts
+++ b/surfaces/desktop/src/desktop-updates.test.ts
@@ -46,6 +46,12 @@ describe("desktop update packaging", () => {
 		expect(workflow).toContain("surfaces/desktop/release/latest*.yml");
 	});
 
+	test("uses a Linux-safe Electron executable name", () => {
+		const packageJson = JSON.parse(readFileSync(join(desktopRoot, "package.json"), "utf8"));
+		expect(packageJson.build.executableName).toBe("signet");
+		expect(packageJson.build.executableName).toMatch(/^[A-Za-z0-9._ -]+$/);
+	});
+
 	test("ships a full macOS app iconset", () => {
 		if (process.platform !== "darwin") return;
 


### PR DESCRIPTION
## Summary

Fixes Linux Electron packaging after the electron-builder 26.15.3 upgrade began rejecting the executable name derived from `@signet/desktop`.

## Changes

- Set Electron Builder `executableName` to the Linux-safe value `signet`.
- Add a regression test that requires a safe explicit executable name.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `@signet/desktop`

## Screenshots

N/A. This changes desktop packaging metadata only.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — not applicable
- [x] Agent scoping verified on all new/changed data queries — not applicable
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints — not applicable
- [x] Docs updated for API/spec/status changes — not applicable
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally for the touched area

## Migration Notes (if applicable)

Not applicable.

## Testing

- [x] `bun test surfaces/desktop/src/desktop-updates.test.ts tests/integration/docker-build-regression.test.ts`
- [x] `bun run typecheck`
- [x] `bunx biome check surfaces/desktop/package.json surfaces/desktop/src/desktop-updates.test.ts`
- [x] `bun run --filter '@signet/desktop' typecheck`
- [x] `bun run build:desktop -- --x64` from `surfaces/desktop` on Linux. AppImage and deb packaging completed successfully.
- [ ] `bun test` passes — not run; targeted regression coverage was run instead
- [ ] `bun run lint` — repository-wide command is currently blocked by 2,051 pre-existing formatting errors in unrelated ignored checkout `.worktrees/hermes-b0cc6cf7`; touched-file Biome check passes
- [ ] Tested against running daemon — not applicable
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tag in the commit)

## Notes

The failing CI log was:

`executableName contains characters that cannot be safely used in file paths: @signetdesktop`

The failure is deterministic and occurs only in the Linux desktop packaging leg. macOS and Windows packaging were already passing.
