### PR TITLE
fix(ops): status and doctor surface dead-job backlog and unhealthy daemon health

### DIFF
--- a/surfaces/cli/src/features/health.test.ts
+++ b/surfaces/cli/src/features/health.test.ts
@@ -914,6 +914,185 @@ describe("showStatus readiness labeling", () => {
 	});
 });
 
+describe("dead-job backlog surfacing (#1048)", () => {
+	const queueFixture = {
+		memory: {
+			pending: 0,
+			leased: 0,
+			completed: 8548,
+			failed: 0,
+			dead: 10952,
+			oldestAgeSec: 0,
+			oldestDeadAgeSec: 86400 * 9,
+			lastError: "LLM extraction failed: All routing candidates were blocked by policy or runtime state.",
+		},
+		summary: {
+			pending: 0,
+			leased: 0,
+			completed: 2204,
+			failed: 0,
+			dead: 275,
+			oldestAgeSec: 0,
+			oldestDeadAgeSec: 86400 * 3,
+			lastError: "All routed targets failed.",
+		},
+	};
+
+	function deadBacklogDeps(basePath: string, withHealth = true) {
+		return {
+			...depsFor(basePath),
+			getDaemonStatus: async () => ({
+				running: true,
+				pid: 3046866,
+				uptime: 54,
+				version: "0.156.4",
+				host: "127.0.0.1",
+				bindHost: "127.0.0.1",
+				networkMode: "local",
+				extraction: null,
+				transcripts: { pending: 0, failed: 0, dead: 0 },
+				health: withHealth ? { score: 0.817, status: "unhealthy" } : null,
+				queue: queueFixture,
+				probe: {
+					status: "healthy" as const,
+					detail: "/health responded",
+					url: "http://127.0.0.1:3850",
+					listenerPresent: true,
+					processPid: 42,
+					stalePid: null,
+				},
+				openclaw: null,
+			}),
+		};
+	}
+
+	async function captureStatus(deps: ReturnType<typeof deadBacklogDeps>): Promise<string> {
+		const lines: string[] = [];
+		const oldLog = console.log;
+		console.log = (...args: unknown[]) => {
+			lines.push(args.join(" "));
+		};
+		try {
+			await showStatus({}, deps);
+		} finally {
+			console.log = oldLog;
+		}
+		return lines.join("\n");
+	}
+
+	it("status visibly warns about the dead-job backlog and its last error", async () => {
+		const root = mkdtempSync(join(tmpdir(), "health-dead-backlog-"));
+		try {
+			const output = await captureStatus(deadBacklogDeps(root));
+			expect(output).toContain("Pipeline queues (dead jobs present)");
+			expect(output).toContain("d=10952");
+			expect(output).toContain("d=275");
+			expect(output).toContain("LLM extraction failed");
+			expect(output).toContain("signet repair queue");
+			expect(output).toContain("unhealthy composite health");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("doctor flags the dead-job backlog as an error finding (ok becomes false)", async () => {
+		const root = mkdtempSync(join(tmpdir(), "doctor-dead-backlog-"));
+		try {
+			const jsonOut = await captureDoctorJson(deadBacklogDeps(root).getDaemonStatus);
+			expect(jsonOut.ok).toBe(false);
+			const deadFinding = jsonOut.findings.find((f) => f.code === "dead_jobs_backlog");
+			expect(deadFinding).toBeDefined();
+			expect(deadFinding?.level).toBe("error");
+			expect(deadFinding?.message).toContain("11227");
+			expect(deadFinding?.fix).toContain("signet repair queue requeue");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("doctor flags unhealthy composite health even without a dead backlog", async () => {
+		const root = mkdtempSync(join(tmpdir(), "doctor-unhealthy-"));
+		try {
+			const jsonOut = await captureDoctorJson(deadBacklogDeps(root, true).getDaemonStatus);
+			expect(jsonOut.ok).toBe(false);
+			const unhealthy = jsonOut.findings.find((f) => f.code === "daemon_unhealthy");
+			expect(unhealthy).toBeDefined();
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("doctor stays ok for a running daemon with clean queues", async () => {
+		const root = mkdtempSync(join(tmpdir(), "doctor-clean-"));
+		try {
+			const workspace = join(root, "agents");
+			mkdirSync(workspace, { recursive: true });
+			writeFileSync(join(workspace, "agent.yaml"), "version: 1\n");
+			writeFileSync(join(workspace, "SOUL.md"), "soul\n");
+			writeFileSync(join(workspace, "IDENTITY.md"), "identity\n");
+			writeFileSync(join(workspace, "USER.md"), "user\n");
+			writeFileSync(join(workspace, "MEMORY.md"), "memory\n");
+			writeFileSync(join(workspace, "AGENTS.md"), "# agents\n");
+			mkdirSync(join(workspace, "memory"), { recursive: true });
+			writeFileSync(join(workspace, "memory", "memories.db"), "sqlite");
+			process.env.HOME = root;
+
+			const base = deadBacklogDeps(workspace);
+			base.getDaemonStatus = async () => ({
+				...(await deadBacklogDeps(workspace).getDaemonStatus()),
+				health: { score: 0.99, status: "healthy" },
+				queue: {
+					memory: { ...queueFixture.memory, dead: 0, lastError: null },
+					summary: { ...queueFixture.summary, dead: 0, lastError: null },
+				},
+			});
+			const jsonOut = await captureDoctorJson(base.getDaemonStatus);
+			expect(jsonOut.findings.some((f) => f.code === "dead_jobs_backlog")).toBe(false);
+			expect(jsonOut.findings.some((f) => f.code === "daemon_unhealthy")).toBe(false);
+		} finally {
+			process.env.HOME = originalHome;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
+
+async function captureDoctorJson(
+	getDaemonStatus: () => Promise<Record<string, unknown>>,
+): Promise<{ ok: boolean; findings: Array<{ code?: string; level: string; message: string; fix?: string }> }> {
+	const lines: string[] = [];
+	const oldLog = console.log;
+	console.log = (...args: unknown[]) => {
+		lines.push(args.join(" "));
+	};
+	try {
+		await showDoctor(
+			{ json: true },
+			{
+				agentsDir: "/tmp/agents",
+				defaultPort: 3850,
+				detectExistingSetup: () => ({
+					agentsDir: true,
+					agentsMd: true,
+					agentYaml: true,
+					memoryDb: true,
+				}),
+				extractPathOption: () => null,
+				formatUptime: () => "0s",
+				getDaemonStatus,
+				normalizeAgentPath: (pathValue: string) => pathValue,
+				parseIntegerValue: (value: unknown) => (typeof value === "number" ? value : null),
+				signetLogo: () => "signet",
+			},
+		);
+	} finally {
+		console.log = oldLog;
+	}
+	return JSON.parse(lines.join("")) as {
+		ok: boolean;
+		findings: Array<{ code?: string; level: string; message: string; fix?: string }>;
+	};
+}
+
 describe("doctor unknown target", () => {
 	it("sets a non-zero exit code for an unsupported doctor target", async () => {
 		const lines: string[] = [];

--- a/surfaces/cli/src/features/health.ts
+++ b/surfaces/cli/src/features/health.ts
@@ -55,6 +55,32 @@ interface DaemonStatus {
 		readonly failed: number;
 		readonly dead: number;
 	} | null;
+	readonly health?: {
+		readonly score: number | null;
+		readonly status: string | null;
+	} | null;
+	readonly queue?: {
+		readonly memory: {
+			readonly pending: number;
+			readonly leased: number;
+			readonly completed: number;
+			readonly failed: number;
+			readonly dead: number;
+			readonly oldestAgeSec: number;
+			readonly oldestDeadAgeSec: number;
+			readonly lastError: string | null;
+		} | null;
+		readonly summary: {
+			readonly pending: number;
+			readonly leased: number;
+			readonly completed: number;
+			readonly failed: number;
+			readonly dead: number;
+			readonly oldestAgeSec: number;
+			readonly oldestDeadAgeSec: number;
+			readonly lastError: string | null;
+		} | null;
+	} | null;
 	readonly probe?: {
 		readonly status: "healthy" | "degraded" | "listener-unhealthy" | "process-unhealthy" | "stale-artifact" | "absent";
 		readonly detail: string;
@@ -302,7 +328,13 @@ export async function showStatus(options: { path?: string; json?: boolean }, dep
 
 	// Queue diagnostics include the live memory and summary workers.
 	if (report.daemon.running) {
-		await renderPipelineQueuesBlock(deps);
+		await renderPipelineQueuesBlock(deps, report.daemon.queue ?? undefined);
+		const daemonHealth = report.daemon.health;
+		if (daemonHealth?.status === "unhealthy") {
+			const score = typeof daemonHealth.score === "number" ? ` (score ${daemonHealth.score.toFixed(2)})` : "";
+			console.log(chalk.yellow(`  ⚠ Daemon reports unhealthy composite health${score}`));
+			console.log(chalk.dim("    Core memory processing may be failing; see the queue rows above."));
+		}
 	}
 
 	console.log();
@@ -403,9 +435,21 @@ function renderQueueRow(label: string, counts: QueueCountsForDisplay): string {
 	return `    ${chalk.bold(label.padEnd(10))} ${cells.join(" ")}`;
 }
 
-export async function renderPipelineQueuesBlock(deps: { defaultPort: number }): Promise<void> {
-	const base = getDaemonBaseUrl(deps.defaultPort);
-	const report = await fetchPipelineQueueReport(base);
+export async function renderPipelineQueuesBlock(
+	deps: { defaultPort: number },
+	captured?: NonNullable<DaemonStatus["queue"]>,
+): Promise<void> {
+	// Prefer the daemon's own /api/status queue block (always available when
+	// the daemon is up); fall back to the admin-guarded diagnostics endpoint
+	// for the richer age columns.
+	const report = captured
+		? ({
+				queues: {
+					memory: captured.memory,
+					summary: captured.summary,
+				},
+			} as PipelineQueueDisplayReport)
+		: await fetchPipelineQueueReport(getDaemonBaseUrl(deps.defaultPort));
 	if (!report?.queues) return;
 	const { memory, summary } = report.queues;
 	if (!memory || !summary) return;
@@ -415,7 +459,8 @@ export async function renderPipelineQueuesBlock(deps: { defaultPort: number }): 
 	console.log(`  ${heading}`);
 	console.log(renderQueueRow("memory", memory));
 	console.log(renderQueueRow("summary", summary));
-	if (summary.lastError) console.log(chalk.dim(`    last error: ${String(summary.lastError).slice(0, 120)}`));
+	if (memory.lastError) console.log(chalk.dim(`    memory last error: ${String(memory.lastError).slice(0, 120)}`));
+	if (summary.lastError) console.log(chalk.dim(`    summary last error: ${String(summary.lastError).slice(0, 120)}`));
 	console.log(chalk.dim("    (use 'signet repair queue {requeue|cancel|prune} [--apply]' to clean up)"));
 }
 
@@ -686,6 +731,43 @@ function addPhysicalMemoryFinding(report: StatusReport, findings: DoctorFinding[
 	});
 }
 
+function addQueueBacklogFindings(report: StatusReport, findings: DoctorFinding[]): void {
+	if (!report.daemon.running) return;
+	const queue = report.daemon.queue;
+	if (!queue) return;
+
+	const memory = queue.memory;
+	const summary = queue.summary;
+	const memoryDead = memory?.dead ?? 0;
+	const summaryDead = summary?.dead ?? 0;
+	const deadTotal = memoryDead + summaryDead;
+
+	const daemonHealth = report.daemon.health;
+	if (daemonHealth?.status === "unhealthy") {
+		const score = typeof daemonHealth.score === "number" ? ` (score ${daemonHealth.score.toFixed(2)})` : "";
+		findings.push({
+			level: "error",
+			code: "daemon_unhealthy",
+			message: `Daemon reports unhealthy composite health${score}.`,
+			fix: "Inspect the queue rows in `signet status`; dead jobs can be requeued with `signet repair queue requeue --apply`.",
+		});
+	}
+
+	if (deadTotal > 0) {
+		const lastError = memory?.lastError ?? summary?.lastError;
+		const detail = lastError ? ` Last error: ${lastError.slice(0, 160)}` : "";
+		const parts: string[] = [];
+		if (memoryDead > 0) parts.push(`${memoryDead} memory`);
+		if (summaryDead > 0) parts.push(`${summaryDead} summary`);
+		findings.push({
+			level: "error",
+			code: "dead_jobs_backlog",
+			message: `${deadTotal} permanently dead processing job(s) (${parts.join(", ")}).${detail}`,
+			fix: "Run `signet repair queue requeue --apply` to reset dead jobs, or `signet repair queue cancel --apply` to retire them.",
+		});
+	}
+}
+
 function getDoctorFindings(report: StatusReport, installations: SignetInstallationReport): DoctorFinding[] {
 	const findings: DoctorFinding[] = [];
 	addConcurrentInstallationFindings(installations, findings);
@@ -757,6 +839,7 @@ function getDoctorFindings(report: StatusReport, installations: SignetInstallati
 	addOpenClawRuntimeFindings(report, findings);
 	addOpenClawHeartbeatFindings(report, findings);
 	addPhysicalMemoryFinding(report, findings);
+	addQueueBacklogFindings(report, findings);
 
 	if (report.openclawWorkspaceUnprotected) {
 		findings.push({

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -83,8 +83,29 @@ interface DaemonInstance {
 		readonly failed: number;
 		readonly dead: number;
 	} | null;
+	/** Daemon composite health from `/api/status` (score + status). */
+	readonly health: {
+		readonly score: number | null;
+		readonly status: string | null;
+	} | null;
+	/** Pipeline queue counts from `/api/status` (memory/summary). */
+	readonly queue: {
+		readonly memory: QueueCountsFromStatus | null;
+		readonly summary: QueueCountsFromStatus | null;
+	} | null;
 	readonly probe: DaemonHealthProbe;
 	readonly openclaw: DaemonOpenClawHealthSummary | null;
+}
+
+interface QueueCountsFromStatus {
+	readonly pending: number;
+	readonly leased: number;
+	readonly completed: number;
+	readonly failed: number;
+	readonly dead: number;
+	readonly oldestAgeSec: number;
+	readonly oldestDeadAgeSec: number;
+	readonly lastError: string | null;
 }
 
 interface DaemonProbeDeps {
@@ -357,6 +378,10 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 						host?: string;
 						bindHost?: string;
 						networkMode?: string;
+						health?: {
+							score?: number;
+							status?: string;
+						};
 						resources?: {
 							rss?: number | null;
 							heapUsed?: number | null;
@@ -395,6 +420,30 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 					const resources = data.resources;
 					const openclawReport = await fetchJsonOrNull<unknown>(baseUrl, "/api/diagnostics/openclaw");
 					const readiness = await fetchDaemonReadiness(baseUrl);
+					const healthRaw = data.health;
+					const pipelineRaw = data.pipeline;
+					const queueRaw =
+						typeof pipelineRaw === "object" && pipelineRaw !== null ? Reflect.get(pipelineRaw, "queue") : undefined;
+					const health =
+						typeof healthRaw === "object" && healthRaw !== null
+							? {
+									score:
+										typeof Reflect.get(healthRaw, "score") === "number"
+											? (Reflect.get(healthRaw, "score") as number)
+											: null,
+									status:
+										typeof Reflect.get(healthRaw, "status") === "string"
+											? (Reflect.get(healthRaw, "status") as string)
+											: null,
+								}
+							: null;
+					const queue =
+						typeof queueRaw === "object" && queueRaw !== null
+							? {
+									memory: normalizeQueueCountsFromStatus(Reflect.get(queueRaw, "memory")),
+									summary: normalizeQueueCountsFromStatus(Reflect.get(queueRaw, "summary")),
+								}
+							: null;
 					return {
 						baseUrl,
 						pid: data.pid ?? null,
@@ -443,6 +492,8 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 									dead: typeof transcripts.dead === "number" ? transcripts.dead : 0,
 								}
 							: null,
+						health,
+						queue,
 						probe: reachableDaemonProbe(baseUrl, data.pid ?? null, readiness),
 						openclaw: summarizeOpenClawHealth(openclawReport),
 					};
@@ -462,6 +513,8 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 				resources: null,
 				extraction: null,
 				transcripts: null,
+				health: null,
+				queue: null,
 				probe: reachableDaemonProbe(
 					baseUrl,
 					null,
@@ -512,6 +565,26 @@ export function shouldRebindDaemon(currentCommand: string | null, desiredExecuta
 function matchesDaemon(cmd: string, paths: readonly string[]): boolean {
 	const normalizedCmd = normalizeCmd(cmd);
 	return daemonMarks(paths).some((path) => normalizedCmd.includes(normalizeCmd(path)));
+}
+
+function normalizeQueueCountsFromStatus(value: unknown): QueueCountsFromStatus | null {
+	if (typeof value !== "object" || value === null) return null;
+	const record = value as Record<string, unknown>;
+	const toNumber = (key: string): number => {
+		const raw = record[key];
+		return typeof raw === "number" && Number.isFinite(raw) ? raw : 0;
+	};
+	const lastErrorRaw = record.lastError;
+	return {
+		pending: toNumber("pending"),
+		leased: toNumber("leased"),
+		completed: toNumber("completed"),
+		failed: toNumber("failed"),
+		dead: toNumber("dead"),
+		oldestAgeSec: toNumber("oldestAgeSec"),
+		oldestDeadAgeSec: toNumber("oldestDeadAgeSec"),
+		lastError: typeof lastErrorRaw === "string" && lastErrorRaw.trim().length > 0 ? lastErrorRaw : null,
+	};
 }
 
 function readCmd(pid: number): string | null {
@@ -623,6 +696,8 @@ export async function getDaemonStatus(): Promise<{
 	resources: DaemonResourceUsage | null;
 	extraction: DaemonInstance["extraction"];
 	transcripts: DaemonInstance["transcripts"];
+	health: DaemonInstance["health"];
+	queue: DaemonInstance["queue"];
 	probe: DaemonHealthProbe;
 	openclaw: DaemonOpenClawHealthSummary | null;
 }> {
@@ -641,6 +716,8 @@ export async function getDaemonStatus(): Promise<{
 			resources: preferred.resources,
 			extraction: preferred.extraction,
 			transcripts: preferred.transcripts,
+			health: preferred.health,
+			queue: preferred.queue,
 			probe: {
 				...preferred.probe,
 				processPid: preferred.probe.processPid ?? fallbackPid,
@@ -661,6 +738,8 @@ export async function getDaemonStatus(): Promise<{
 		resources: null,
 		extraction: null,
 		transcripts: null,
+		health: null,
+		queue: null,
 		probe,
 		openclaw: null,
 	};


### PR DESCRIPTION
## Summary

`signet status` reported the daemon and transcript capture as healthy while the daemon's own `/api/status` classified runtime health as `unhealthy` with a large permanently dead job backlog (11,227 dead jobs in the issue's evidence). `signet doctor --json` returned `ok: true` with the same blind spot — operators had no signal that core memory extraction/summarization was failing.

## Changes

- `surfaces/cli/src/lib/runtime.ts` — `getDaemonStatus()` now parses the daemon's own unauthenticated `/api/status` composite health (`score`/`status`) and `pipeline.queue` counts (memory/summary with `dead` + `lastError`) into `DaemonInstance` instead of discarding them.
- `surfaces/cli/src/features/health.ts`
  - `showStatus` renders the queue block from the captured daemon queue (always available when the daemon is up) rather than depending solely on the admin-guarded `/api/diagnostics/queue` fetch, prints **both** queues' last errors, and warns when the daemon reports unhealthy composite health.
  - `getDoctorFindings` adds error-level findings for a dead-job backlog (`dead_jobs_backlog`) and unhealthy composite health (`daemon_unhealthy`), each with a repair-command fix — so `signet doctor --json` `ok` flips to `false` when the backlog exists.
- `surfaces/cli/src/features/health.test.ts` — regression tests for all four paths.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/cli` / dashboard

## Screenshots

N/A — CLI diagnostics output change.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no migrations touched.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Regression tests (features/health.test.ts) using the issue's exact numbers (10,952 memory + 275 summary dead, score 0.817 unhealthy):
1. `signet status` output contains "Pipeline queues (dead jobs present)", `d=10952`, `d=275`, the memory+summary last errors, the repair-queue hint, and the unhealthy-composite warning
2. `doctor --json` → `ok: false`, `dead_jobs_backlog` error finding mentions 11227 total and the `signet repair queue requeue` fix
3. unhealthy composite health without a dead backlog → `daemon_unhealthy` finding, `ok: false`
4. clean queues + healthy composite → no backlog/unhealthy findings

Full CLI suite: failures byte-identical (name-for-name) to a pristine `main` run — 9 pre-existing environment-dependent failures (desktop-install/setup/route); no new failures introduced.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Per AI_POLICY.md, the change was reviewed against the issue spec and repo conventions (AGENTS.md) before committing.
