### PR TITLE
fix(daemon): bound dreaming evidence tools

### DIFF
--- a/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
@@ -30,13 +30,19 @@ describe("dreaming-agent-tools", () => {
 		});
 	}
 
-	function insertActiveAttribute(entityId: string, aspectId: string, content: string, agentId: string): void {
+	function insertActiveAttribute(
+		entityId: string,
+		aspectId: string,
+		content: string,
+		agentId: string,
+		aspectName = "configuration",
+	): void {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				`INSERT INTO entity_aspects
 				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
-				 VALUES (?, ?, ?, 'configuration', 'configuration', 0.5, datetime('now'), datetime('now'))`,
-			).run(aspectId, entityId, agentId);
+				 VALUES (?, ?, ?, ?, ?, 0.5, datetime('now'), datetime('now'))`,
+			).run(aspectId, entityId, agentId, aspectName, aspectName.toLowerCase());
 			db.prepare(
 				`INSERT INTO entity_attributes
 				 (id, aspect_id, agent_id, kind, content, normalized_content,
@@ -67,7 +73,7 @@ describe("dreaming-agent-tools", () => {
 		return JSON.parse(text);
 	}
 
-	function findTool(tools: readonly ReturnType<typeof createDreamingAgentTools>, name: string) {
+	function findTool(tools: ReturnType<typeof createDreamingAgentTools>, name: string) {
 		const tool = tools.find((t) => t.name === name);
 		if (!tool) throw new Error(`tool ${name} not registered`);
 		return tool;
@@ -122,6 +128,101 @@ describe("dreaming-agent-tools", () => {
 		);
 		expect(hydrated.ok).toBe(true);
 		expect((hydrated.aspects as Array<{ id: string }>).map((a) => a.id)).toEqual(["a-config"]);
+	});
+
+	it("bounds content-pass tool results when evidence and entity provenance are large", async () => {
+		const largeContent = `${"context ".repeat(2_000)}Needle in the middle of a large source.`;
+		insertEpisodicMemory("mem-large", largeContent);
+		insertEntity("e-large", "Large Entity", "large entity", "owner");
+		for (let index = 0; index < 60; index += 1) {
+			insertActiveAttribute("e-large", `a-large-${index}`, `Large aspect ${index}`, "owner", `aspect-${index}`);
+		}
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE entities SET proposal_evidence = ? WHERE id = ? AND agent_id = ?").run(
+				JSON.stringify(["evidence ".repeat(20_000)]),
+				"e-large",
+				"owner",
+			);
+		});
+
+		const tools = createDreamingAgentTools({ accessor: getDbAccessor(), agentId: "owner", actor: "owner" });
+		const evidence = readResult(
+			await findTool(tools, "search_evidence").execute(
+				"call",
+				{ agentId: "owner", query: "Needle", kind: "memory", limit: 1 },
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		const item = (
+			evidence.items as Array<{
+				content: string;
+				contentLength: number;
+				contentTruncated: boolean;
+				contentHasPrevious: boolean;
+				contentHasNext: boolean;
+				sourceRef: string;
+			}>
+		)[0];
+		expect(item).toMatchObject({ sourceRef: "memory:mem-large", contentTruncated: true });
+		expect(item.content.length).toBeLessThanOrEqual(2_000);
+		expect(largeContent).toContain(item.content);
+		expect(item.content).toContain("Needle");
+		expect(item.contentLength).toBe(largeContent.length);
+		expect(item.contentHasPrevious).toBe(true);
+		expect(item.contentHasNext).toBe(false);
+
+		const firstFragment = readResult(
+			await findTool(tools, "search_evidence").execute(
+				"call",
+				{ agentId: "owner", sourceRef: item.sourceRef, offset: 0, chunkSize: 2_000 },
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		const firstFragmentItem = (
+			firstFragment.items as Array<{ content: string; contentOffset: number; contentHasNext: boolean }>
+		)[0];
+		expect(firstFragmentItem.contentOffset).toBe(0);
+		expect(firstFragmentItem.content.length).toBeLessThanOrEqual(2_000);
+		expect(firstFragmentItem.contentHasNext).toBe(true);
+		expect(largeContent).toContain(firstFragmentItem.content);
+
+		const secondFragment = readResult(
+			await findTool(tools, "search_evidence").execute(
+				"call",
+				{
+					agentId: "owner",
+					sourceRef: item.sourceRef,
+					offset: firstFragmentItem.contentOffset + firstFragmentItem.content.length,
+					chunkSize: 2_000,
+				},
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		const secondFragmentItem = (secondFragment.items as Array<{ contentOffset: number }>)[0];
+		expect(secondFragmentItem.contentOffset).toBe(firstFragmentItem.content.length);
+
+		const entity = readResult(
+			await findTool(tools, "get_entity").execute(
+				"call",
+				{ agentId: "owner", entityId: "e-large", include: ["aspects"] },
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		expect(entity.aspects).toHaveLength(50);
+		expect(entity.aspectsTruncated).toBe(true);
+		expect(
+			(entity.entity as { proposalEvidence?: unknown[]; proposalEvidenceCount: number }).proposalEvidence,
+		).toBeUndefined();
+		expect((entity.entity as { proposalEvidenceCount: number }).proposalEvidenceCount).toBe(1);
+		expect(JSON.stringify(entity).length).toBeLessThan(10_000);
 	});
 
 	it("get_evidence resolves claim provenance and link provenance through one tool", async () => {
@@ -307,7 +408,7 @@ describe("dreaming-agent-tools", () => {
 			input: { agentId: "owner", query: "owner" },
 			output: { tool: "search_entities", ok: true },
 		});
-		expect(traces[0]!.latencyMs).toBeGreaterThanOrEqual(0);
+		expect(traces[0]?.latencyMs).toBeGreaterThanOrEqual(0);
 	});
 
 	it("get_entity returns null result for an entity owned by another agent", async () => {

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -7,10 +7,12 @@
  * deliberately bounded: the agent can only do what these methods define
  * (search, validate, apply, log) — no open-ended escape hatches.
  */
+import type { Entity } from "@signet/core";
 import { z } from "zod";
 import type { DbAccessor } from "../db-accessor";
 import { classifyEntityQuality } from "../entity-quality";
-import { searchEpisodicSources } from "../episodic-sources";
+import type { EpisodicSourceRecord } from "../episodic-sources";
+import { readEpisodicSource, searchEpisodicSources } from "../episodic-sources";
 import {
 	getAttributesForAspectFiltered,
 	getEntityAspectsWithCounts,
@@ -23,6 +25,7 @@ import { getOntologyLinkEvidence } from "../ontology-link-evidence";
 import { findDuplicateEntityMerges } from "../ontology-proposals";
 import { detectProspectiveContradictionRisk } from "./antonyms";
 import { getDreamingAttentionAcrossScopes, getDreamingAttentionScoped } from "./dreaming-attention";
+import { nextDreamingEvidenceFragment, renderDreamingEvidence } from "./dreaming-evidence";
 import type { DreamingAgentEvidence } from "./dreaming-evidence";
 import { DREAMING_ONTOLOGY_OPERATION_SCHEMA } from "./dreaming-operation-contract";
 import {
@@ -34,6 +37,101 @@ import { readDreamingRunbook, writeDreamingRunbook } from "./dreaming-runbook";
 
 const bounded = (value: number | undefined, fallback: number, max: number): number =>
 	Math.min(Math.max(Math.floor(value ?? fallback), 1), max);
+
+const MAX_EVIDENCE_EXCERPT_CHARS = 2_000;
+const MAX_EVIDENCE_RESULT_CHARS = 16_000;
+const MAX_HYDRATED_ITEMS = 50;
+const MAX_ENTITY_TEXT_CHARS = 2_000;
+
+function boundedText(value: string | undefined, maxChars: number): string | undefined {
+	if (value === undefined || value.length <= maxChars) return value;
+	return value.slice(0, maxChars);
+}
+
+function evidenceExcerptStart(content: string, query: string, maxChars: number): number {
+	const terms = query
+		.toLowerCase()
+		.split(/\W+/)
+		.filter((term) => term.length >= 3)
+		.slice(0, 8);
+	const lower = content.toLowerCase();
+	for (const term of terms) {
+		const match = lower.indexOf(term);
+		if (match >= 0) return Math.max(0, match - Math.floor(maxChars * 0.35));
+	}
+	return 0;
+}
+
+function projectEvidenceItem(
+	source: EpisodicSourceRecord,
+	content: string,
+	contentOffset: number,
+	contentLength: number,
+): Record<string, unknown> {
+	return {
+		sourceRef: `${source.kind}:${source.id}`,
+		kind: source.kind,
+		id: source.id,
+		content,
+		contentOffset,
+		contentLength,
+		contentTruncated: contentOffset > 0 || contentOffset + content.length < contentLength,
+		contentHasPrevious: contentOffset > 0,
+		contentHasNext: contentOffset + content.length < contentLength,
+		sourceKind: source.sourceKind,
+		sourceId: source.sourceId,
+		sourcePath: source.sourcePath,
+		sourceEntryId: source.sourceEntryId,
+		project: source.project,
+		harness: source.harness,
+		capturedAt: source.capturedAt,
+	};
+}
+
+function projectEvidence(sources: readonly EpisodicSourceRecord[], query: string): readonly Record<string, unknown>[] {
+	let remaining = MAX_EVIDENCE_RESULT_CHARS;
+	return sources.map((source) => {
+		const rendered = renderDreamingEvidence(source);
+		const offset = evidenceExcerptStart(rendered, query, MAX_EVIDENCE_EXCERPT_CHARS);
+		const excerptLength = Math.min(MAX_EVIDENCE_EXCERPT_CHARS, remaining, rendered.length - offset);
+		const content = excerptLength > 0 ? rendered.slice(offset, offset + excerptLength) : "";
+		remaining = Math.max(0, remaining - content.length);
+		return projectEvidenceItem(source, content, content.length > 0 ? offset : 0, rendered.length);
+	});
+}
+
+function projectEvidenceFragment(
+	source: EpisodicSourceRecord,
+	offset: number,
+	chunkSize: number,
+): Record<string, unknown> | null {
+	const fragment = nextDreamingEvidenceFragment(source, offset, chunkSize);
+	return fragment === null
+		? null
+		: projectEvidenceItem(source, fragment.content, fragment.start, fragment.sourceLength);
+}
+
+function projectEntity(entity: Entity): Record<string, unknown> {
+	return {
+		id: entity.id,
+		name: entity.name,
+		canonicalName: entity.canonicalName,
+		entityType: entity.entityType,
+		agentId: entity.agentId,
+		description: boundedText(entity.description, MAX_ENTITY_TEXT_CHARS),
+		mentions: entity.mentions,
+		pinned: entity.pinned,
+		pinnedAt: entity.pinnedAt,
+		status: entity.status,
+		archivedAt: entity.archivedAt,
+		archivedBy: entity.archivedBy,
+		archiveReason: boundedText(entity.archiveReason ?? undefined, MAX_ENTITY_TEXT_CHARS),
+		proposalId: entity.proposalId,
+		proposalEvidenceCount: entity.proposalEvidence?.length ?? 0,
+		createdAt: entity.createdAt,
+		updatedAt: entity.updatedAt,
+	};
+}
 
 const pagination = {
 	limit: z.number().finite().optional(),
@@ -187,20 +285,24 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"get_entity",
 			"Get entity detail",
-			"Fetch one entity in one agent scope with attribute/constraint counts and pinned status, optionally hydrated with its aspect claims and/or dependency links in the same call.",
+			"Fetch one entity in one agent scope with attribute/constraint counts and pinned status, optionally hydrated with bounded aspect summaries and/or dependency links. Use limit and offset to page hydrated items; the response reports when a hydration list is truncated.",
 			true,
 			z.object({
 				agentId: z.string().min(1),
 				entityId: z.string().min(1),
 				include: z.array(z.enum(["aspects", "links"])).optional(),
 				direction: z.enum(["incoming", "outgoing", "both"]).optional(),
+				limit: z.number().finite().optional(),
+				offset: z.number().finite().optional(),
 			}),
-			async ({ agentId: scopeId, entityId, include, direction }) => {
+			async ({ agentId: scopeId, entityId, include, direction, limit, offset }) => {
 				const detail = getKnowledgeEntityDetail(accessor, entityId, scopeId);
 				if (!detail) return { ok: false, error: "Entity not found" };
+				const hydrationLimit = bounded(limit, 50, MAX_HYDRATED_ITEMS);
+				const hydrationOffset = Math.max(0, Math.floor(offset ?? 0));
 				const result: MutableCapabilityOutput = {
 					ok: true,
-					entity: detail.entity,
+					entity: projectEntity(detail.entity),
 					pinned: detail.entity.pinned === true,
 					aspectCount: detail.aspectCount,
 					attributeCount: detail.attributeCount,
@@ -208,19 +310,30 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 					dependencyCount: detail.dependencyCount,
 				};
 				if (include?.includes("aspects")) {
-					result.aspects = getEntityAspectsWithCounts(accessor, entityId, scopeId).map((aspect) => ({
+					const aspects = getEntityAspectsWithCounts(accessor, entityId, scopeId);
+					const hydratedAspects = aspects.slice(hydrationOffset, hydrationOffset + hydrationLimit).map((aspect) => ({
 						id: aspect.aspect.id,
-						name: aspect.aspect.name,
+						name: boundedText(aspect.aspect.name, MAX_ENTITY_TEXT_CHARS),
 						attributeCount: aspect.attributeCount,
 						constraintCount: aspect.constraintCount,
 					}));
+					result.aspects = hydratedAspects;
+					result.aspectsOffset = hydrationOffset;
+					result.aspectsTruncated = hydrationOffset + hydratedAspects.length < aspects.length;
 				}
 				if (include?.includes("links")) {
-					result.links = getEntityDependenciesDetailed(accessor, {
+					const links = getEntityDependenciesDetailed(accessor, {
 						entityId,
 						agentId: scopeId,
 						direction: direction ?? "both",
 					});
+					const hydratedLinks = links.slice(hydrationOffset, hydrationOffset + hydrationLimit).map((link) => ({
+						...link,
+						reason: boundedText(link.reason ?? undefined, MAX_ENTITY_TEXT_CHARS) ?? null,
+					}));
+					result.links = hydratedLinks;
+					result.linksOffset = hydrationOffset;
+					result.linksTruncated = hydrationOffset + hydratedLinks.length < links.length;
 				}
 				return result;
 			},
@@ -312,7 +425,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"search_evidence",
 			"Search episodic evidence",
-			"Full-text search immutable episodic memories, artifacts, transcripts, and summaries in one agent scope. Omit the query to list the most recent sources (e.g. with since as a cutoff). Artifacts are deduped by content hash: content-identical files across vault paths collapse to one canonical entry.",
+			"Full-text search immutable episodic memories, artifacts, transcripts, and summaries in one agent scope. Results contain exact bounded excerpts of the rendered evidence with contentOffset/contentLength; use sourceRef for citations, which are validated against the complete canonical source. If contentTruncated is true, page exact fragments with the same sourceRef and chunkSize: start at offset=0 when contentHasPrevious is true, then use offset=contentOffset+content.length from the fragment just returned until contentHasNext is false. Omit the query to list the most recent sources (e.g. with since as a cutoff). Artifacts are deduped by content hash: content-identical files across vault paths collapse to one canonical entry.",
 			true,
 			z.object({
 				agentId: z.string().min(1),
@@ -321,13 +434,34 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 				before: z.string().optional(),
 				kind: z.enum(["memory", "artifact", "transcript", "summary"]).optional(),
 				limit: z.number().finite().optional(),
+				sourceRef: z.string().min(1).optional(),
+				offset: z.number().finite().optional(),
+				chunkSize: z.number().finite().optional(),
 			}),
-			async ({ agentId: scopeId, query, since, before, kind, limit }) => ({
-				ok: true,
-				items: accessor.withReadDb((db) =>
-					searchEpisodicSources(db, { agentId: scopeId, query: query ?? "", since, before, kind, limit }),
-				),
-			}),
+			async ({ agentId: scopeId, query, since, before, kind, limit, sourceRef, offset, chunkSize }) =>
+				accessor.withReadDb((db) => {
+					if (sourceRef !== undefined) {
+						const source = readEpisodicSource(db, { agentId: scopeId, from: sourceRef });
+						if (source === null) return { ok: false, error: "Evidence source not found" };
+						const fragment = projectEvidenceFragment(
+							source,
+							Math.max(0, Math.floor(offset ?? 0)),
+							Math.min(Math.max(Math.floor(chunkSize ?? MAX_EVIDENCE_EXCERPT_CHARS), 1), MAX_EVIDENCE_EXCERPT_CHARS),
+						);
+						return fragment === null
+							? { ok: false, error: "Evidence fragment offset is outside the source" }
+							: { ok: true, items: [fragment] };
+					}
+					const sources = searchEpisodicSources(db, {
+						agentId: scopeId,
+						query: query ?? "",
+						since,
+						before,
+						kind,
+						limit,
+					});
+					return { ok: true, items: projectEvidence(sources, query ?? "") };
+				}),
 		),
 		capability(
 			"validate_proposal",


### PR DESCRIPTION
## Summary

Fixes #1113 by bounding Dreaming capability results without making immutable evidence inaccessible. Large evidence and entity provenance previously could overflow the model context, causing useful content to be missed.

## Changes

- Bound `search_evidence` results to exact rendered excerpts with source offsets and truncation metadata.
- Add lossless evidence paging with `sourceRef`, `offset`, and `chunkSize` so omitted prefixes and suffixes can be retrieved exactly.
- Keep citation validation against the complete canonical episodic source.
- Bound `get_entity` descriptions, proposal evidence, aspect hydration, and dependency-link hydration with pagination metadata.
- Add regression coverage for large evidence, resumable fragments, and large entity provenance.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A. This does not change a UI surface.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints (no admin/mutation endpoint changed)
- [x] Docs updated for API/spec/status changes (tool contract is documented in the capability description; no external API/spec entry applies)
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally (focused changed-area checks)

## Migration Notes (if applicable)

N/A. No migrations are touched.

## Testing

- [x] Focused Dreaming tests pass: 52 tests across 5 files.
- [x] `bun run --filter '@signet/daemon' typecheck` passes.
- [x] `bun run --filter '@signet/daemon' build` passes.
- [x] `bunx biome check` passes on both changed files.
- [ ] `bun test` passes. The root sweep currently includes unrelated baseline failures in generated docs/content-index and environment-dependent connector/maintenance tests.
- [ ] `bun run lint` passes. The repository baseline currently reports unrelated formatting errors outside this change.
- [ ] Tested against running daemon.
- [x] N/A for live daemon testing in this focused capability-registry regression.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used. Commit includes: `Assisted-by: Hermes Agent:gpt-5.6-luna`

## Notes

The branch was created before `main` advanced by four commits. Per request, it will be rebased onto the latest `main` only after CI is green, then admin-merged if the rebased checks remain green.
