### PR TITLE
fix(repair): --max-batch is an aggregate cap across selected queues

### DIFF
--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -12,6 +12,7 @@ import { toFtsSchemaQueryDb } from "./db-accessor";
 import { DEFAULT_PIPELINE_V2 } from "./memory-config";
 import type { EmbeddingConfig, PipelineV2Config } from "./memory-config";
 import {
+	cancelObsoleteJobs,
 	checkFtsConsistency,
 	checkRepairGate,
 	cleanOrphanedEmbeddings,
@@ -20,6 +21,7 @@ import {
 	getDedupStats,
 	getEmbeddingGapStats,
 	pruneGenericEntities,
+	pruneTerminalJobs,
 	reembedMissingMemories,
 	reembedModelMigration,
 	releaseStaleLeases,
@@ -156,6 +158,15 @@ function insertJob(
 		 (id, memory_id, job_type, status, attempts, max_attempts, leased_at, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 	).run(id, memId, jobType, status, attempts, maxAttempts, leasedAt ?? null, now, now);
+}
+
+function insertSummaryJob(db: Database, id: string, status: string, createdAt?: string): void {
+	const now = createdAt ?? new Date().toISOString();
+	db.prepare(
+		`INSERT INTO summary_jobs
+		 (id, session_key, harness, project, transcript, status, attempts, max_attempts, created_at, error)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	).run(id, `session-${id}`, "test", "test-project", `transcript ${id}`, status, 0, 3, now, null);
 }
 
 function ensureVecTable(db: Database): void {
@@ -482,6 +493,168 @@ describe("requeueDeadJobs", () => {
 		expect(result.success).toBe(true);
 		expect(result.affected).toBe(0);
 		expect(db.prepare("SELECT status FROM memory_jobs WHERE id = 'job-retired'").get()).toEqual({ status: "dead" });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// cancelObsoleteJobs / pruneTerminalJobs — aggregate --max-batch cap (#1053)
+// ---------------------------------------------------------------------------
+
+describe("repair --max-batch aggregate cap (#1053)", () => {
+	let db: Database;
+	let accessor: DbAccessor;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		accessor = asAccessor(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	function seedBothQueues(count: number): void {
+		const now = new Date().toISOString();
+		for (let i = 0; i < count; i += 1) {
+			const memId = `mem-batch-${i}`;
+			insertMemory(db, memId);
+			insertJob(db, `mem-job-${i}`, memId, "dead", undefined, 0, 3);
+			insertSummaryJob(db, `sum-job-${i}`, "dead", now);
+		}
+	}
+
+	function countMemoryByStatus(status: string): number {
+		const row = db.prepare("SELECT COUNT(*) as n FROM memory_jobs WHERE status = ?").get(status) as { n: number };
+		return row.n;
+	}
+
+	function countSummaryByStatus(status: string): number {
+		const row = db.prepare("SELECT COUNT(*) as n FROM summary_jobs WHERE status = ?").get(status) as { n: number };
+		return row.n;
+	}
+
+	describe("cancelObsoleteJobs", () => {
+		it("default both-queue apply affects at most 1000 total rows (not 2000)", () => {
+			seedBothQueues(1001);
+
+			const result = cancelObsoleteJobs(accessor, TEST_CFG, CTX_OPERATOR, createRateLimiter(), {
+				olderThanMs: 0,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.affected).toBeLessThanOrEqual(1000);
+			// memory_jobs is selected first and consumes the whole budget.
+			expect(countMemoryByStatus("cancelled")).toBe(1000);
+			expect(countSummaryByStatus("cancelled")).toBe(0);
+		});
+
+		it("--max-batch 50 affects at most 50 total rows across both queues", () => {
+			seedBothQueues(1001);
+
+			const result = cancelObsoleteJobs(accessor, TEST_CFG, CTX_OPERATOR, createRateLimiter(), {
+				olderThanMs: 0,
+				maxBatch: 50,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.affected).toBeLessThanOrEqual(50);
+			expect(countMemoryByStatus("cancelled")).toBe(50);
+			expect(countSummaryByStatus("cancelled")).toBe(0);
+		});
+
+		it("single-table selection still affects up to the requested cap from that table", () => {
+			seedBothQueues(1001);
+
+			const result = cancelObsoleteJobs(accessor, TEST_CFG, CTX_OPERATOR, createRateLimiter(), {
+				olderThanMs: 0,
+				maxBatch: 50,
+				tables: ["summary"],
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.affected).toBe(50);
+			expect(countSummaryByStatus("cancelled")).toBe(50);
+		});
+
+		it("dry-run preview is selected from the same globally bounded set as apply", () => {
+			seedBothQueues(1001);
+
+			const result = cancelObsoleteJobs(accessor, TEST_CFG, CTX_OPERATOR, createRateLimiter(), {
+				olderThanMs: 0,
+				maxBatch: 50,
+				dryRun: true,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.affected).toBe(0);
+			expect(result.preview?.length ?? 0).toBeLessThanOrEqual(50);
+			// Preview ids come only from the memory queue (the first table),
+			// matching the apply-time selection order.
+			expect(result.preview?.every((id) => id.startsWith("memory_jobs:mem-job-"))).toBe(true);
+			expect(countMemoryByStatus("cancelled")).toBe(0);
+			expect(countSummaryByStatus("cancelled")).toBe(0);
+		});
+	});
+
+	describe("pruneTerminalJobs", () => {
+		it("default both-queue apply affects at most 1000 total rows (not 2000)", () => {
+			seedBothQueues(1001);
+
+			const result = pruneTerminalJobs(accessor, TEST_CFG, CTX_OPERATOR, createRateLimiter(), {
+				retentionMs: 0,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.affected).toBeLessThanOrEqual(1000);
+			expect(countMemoryByStatus("dead")).toBe(1);
+			expect(countSummaryByStatus("dead")).toBe(1001);
+		});
+
+		it("--max-batch 50 affects at most 50 total rows across both queues", () => {
+			seedBothQueues(1001);
+
+			const result = pruneTerminalJobs(accessor, TEST_CFG, CTX_OPERATOR, createRateLimiter(), {
+				retentionMs: 0,
+				maxBatch: 50,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.affected).toBeLessThanOrEqual(50);
+			expect(countMemoryByStatus("dead")).toBe(951);
+			expect(countSummaryByStatus("dead")).toBe(1001);
+		});
+
+		it("single-table selection still affects up to the requested cap from that table", () => {
+			seedBothQueues(1001);
+
+			const result = pruneTerminalJobs(accessor, TEST_CFG, CTX_OPERATOR, createRateLimiter(), {
+				retentionMs: 0,
+				maxBatch: 50,
+				tables: ["summary"],
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.affected).toBe(50);
+			expect(countSummaryByStatus("dead")).toBe(951);
+		});
+
+		it("dry-run preview is selected from the same globally bounded set as apply", () => {
+			seedBothQueues(1001);
+
+			const result = pruneTerminalJobs(accessor, TEST_CFG, CTX_OPERATOR, createRateLimiter(), {
+				retentionMs: 0,
+				maxBatch: 50,
+				dryRun: true,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.affected).toBe(0);
+			expect(result.preview?.length ?? 0).toBeLessThanOrEqual(50);
+			expect(result.preview?.every((id) => id.startsWith("memory_jobs:mem-job-"))).toBe(true);
+			expect(countMemoryByStatus("dead")).toBe(1001);
+			expect(countSummaryByStatus("dead")).toBe(1001);
+		});
 	});
 });
 

--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -588,6 +588,7 @@ describe("repair --max-batch aggregate cap (#1053)", () => {
 
 			expect(result.success).toBe(true);
 			expect(result.affected).toBe(0);
+			expect(result.totalMatching).toBe(2002);
 			expect(result.preview?.length ?? 0).toBeLessThanOrEqual(50);
 			// Preview ids come only from the memory queue (the first table),
 			// matching the apply-time selection order.
@@ -650,6 +651,7 @@ describe("repair --max-batch aggregate cap (#1053)", () => {
 
 			expect(result.success).toBe(true);
 			expect(result.affected).toBe(0);
+			expect(result.totalMatching).toBe(2002);
 			expect(result.preview?.length ?? 0).toBeLessThanOrEqual(50);
 			expect(result.preview?.every((id) => id.startsWith("memory_jobs:mem-job-"))).toBe(true);
 			expect(countMemoryByStatus("dead")).toBe(1001);

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -2350,7 +2350,7 @@ export function cancelObsoleteJobs(
 			targets.push({ table: "memory_jobs", rows: r.rows, totalMatching: r.totalMatching });
 			remaining = Math.max(0, remaining - r.rows.length);
 		}
-		if (wantsSummary && remaining > 0) {
+		if (wantsSummary) {
 			const r = buildCancelPruneSql(db, "summary_jobs", ["dead", "completed"], {
 				...selection,
 				maxBatch: remaining,
@@ -2497,7 +2497,6 @@ export function pruneTerminalJobs(
 		// never exceed the requested blast radius (issue #1053).
 		let remaining = Math.min(options.maxBatch ?? MAX_BATCH_HARD_CAP, MAX_BATCH_HARD_CAP);
 		for (const t of targets) {
-			if (remaining <= 0) break;
 			const selection: JobFilterOptions = {
 				...options,
 				olderThanMs: t.cutoff,

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -2337,12 +2337,24 @@ export function cancelObsoleteJobs(
 			readonly rows: readonly CancelPruneMatchRow[];
 			readonly totalMatching: number;
 		}> = [];
+		// `--max-batch` is an aggregate cap across ALL selected tables, not a
+		// per-table cap. Select memory first, then hand only the remaining
+		// budget to summary so a both-queue operation can never exceed the
+		// requested blast radius (issue #1053).
+		let remaining = Math.min(selection.maxBatch ?? MAX_BATCH_HARD_CAP, MAX_BATCH_HARD_CAP);
 		if (wantsMemory) {
-			const r = buildCancelPruneSql(db, "memory_jobs", ["dead", "completed"], selection);
+			const r = buildCancelPruneSql(db, "memory_jobs", ["dead", "completed"], {
+				...selection,
+				maxBatch: remaining,
+			});
 			targets.push({ table: "memory_jobs", rows: r.rows, totalMatching: r.totalMatching });
+			remaining = Math.max(0, remaining - r.rows.length);
 		}
-		if (wantsSummary) {
-			const r = buildCancelPruneSql(db, "summary_jobs", ["dead", "completed"], selection);
+		if (wantsSummary && remaining > 0) {
+			const r = buildCancelPruneSql(db, "summary_jobs", ["dead", "completed"], {
+				...selection,
+				maxBatch: remaining,
+			});
 			targets.push({ table: "summary_jobs", rows: r.rows, totalMatching: r.totalMatching });
 		}
 
@@ -2480,15 +2492,21 @@ export function pruneTerminalJobs(
 			readonly totalMatching: number;
 		}> = [];
 		let totalMatching = 0;
+		// `--max-batch` is an aggregate cap across ALL selected tables; the
+		// remaining budget carries across tables so a both-queue prune can
+		// never exceed the requested blast radius (issue #1053).
+		let remaining = Math.min(options.maxBatch ?? MAX_BATCH_HARD_CAP, MAX_BATCH_HARD_CAP);
 		for (const t of targets) {
+			if (remaining <= 0) break;
 			const selection: JobFilterOptions = {
 				...options,
 				olderThanMs: t.cutoff,
-				maxBatch: options.maxBatch ?? MAX_BATCH_HARD_CAP,
+				maxBatch: remaining,
 			};
 			const r = buildCancelPruneSql(db, t.table, t.statusList, selection);
 			perTable.push({ rows: r.rows, totalMatching: r.totalMatching });
 			totalMatching += r.totalMatching;
+			remaining = Math.max(0, remaining - r.rows.length);
 		}
 
 		if (dryRun) {


### PR DESCRIPTION
## Summary

`cancel` and `prune` treated `--max-batch` as a **per-queue** cap: each of `memory_jobs` and `summary_jobs` received the full cap, so a both-queue operation with `--max-batch 1000` could affect 2,000 rows — and the default both-queue selection doubled the documented 1,000-row hard cap. `--max-batch N` now limits the aggregate mutation to at most `N` rows across all selected tables.

## Changes

- `platform/daemon/src/repair-actions.ts`
  - `cancelObsoleteJobs`: selects `memory_jobs` first with the aggregate cap, then hands only the **remaining budget** to `summary_jobs` — the same allocation semantics `requeueDeadJobs` already uses.
  - `pruneTerminalJobs`: carries a `remaining` budget across the per-table loop and stops once exhausted.
  - `totalMatching` still reflects the full unfiltered match count (used by the dry-run "N job(s) match filter" message); only the selected/apply/preview row sets are budgeted.
- `platform/daemon/src/repair-actions.test.ts` — new regression suite.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`
- [ ] Other: <!-- specify -->

## Screenshots

N/A — daemon-side repair selection logic.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no migrations touched.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Regression tests (repair-actions.test.ts, per the issue's spec), seeding 1,001 eligible rows in **each** queue, for both `cancel` and `prune`:
1. default both-queue apply affects **≤ 1,000 total** rows (was 2,000; memory consumes the budget, summary gets 0)
2. `--max-batch 50` affects **≤ 50 total** rows
3. single-table selection (`tables: ["summary"]`) still affects up to the requested cap from that table (exactly 50)
4. dry-run preview is selected from the same globally bounded set as apply (≤ 50 preview ids, memory-only, no rows mutated)

Verified the tests catch the bug: with the fix stashed, 6 of the 8 new tests fail (the 2 single-table tests behave identically either way). Full daemon suite: 1978 pass; the only diff vs a pristine base checkout are 3 timing-flaky tests in unrelated modules (native-memory-sources / scheduler spawn) that pass when run in isolation on pristine code.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Per AI_POLICY.md, the change was reviewed against the issue spec and repo conventions (AGENTS.md) before committing.
