### PR TITLE
fix(daemon): yield event loop in graph traversal

### DIFF
--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -133,6 +133,12 @@ export interface DbAccessor {
 	/** Open a readonly connection, run `fn`, close it. */
 	withReadDb<T>(fn: (db: ReadDb) => T): T;
 
+	/** Async variant of withReadDb. The connection stays checked out of the
+	 *  read pool for the whole `fn`, including across event-loop yields, so
+	 *  long readers can breathe without starving other readers (the pool
+	 *  grows on demand up to the connection limit). */
+	withReadDbAsync<T>(fn: (db: ReadDb) => Promise<T>): Promise<T>;
+
 	/** Checkpoint the WAL into the main DB file on the write connection,
 	 *  outside any transaction. Safe to call periodically or on startup. */
 	checkpointWal(): void;
@@ -1034,6 +1040,16 @@ function createAccessor(writeConn: SqliteDatabase): DbAccessor {
 			const conn = acquireRead();
 			try {
 				return fn(conn);
+			} finally {
+				releaseRead(conn);
+			}
+		},
+
+		async withReadDbAsync<T>(fn: (db: ReadDb) => Promise<T>): Promise<T> {
+			if (closed) throw new Error("DbAccessor is closed");
+			const conn = acquireRead();
+			try {
+				return await fn(conn);
 			} finally {
 				releaseRead(conn);
 			}

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -788,7 +788,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 			traversalEntityNames = focal.entityNames;
 
 			if (focal.entityIds.length > 0) {
-				const traversalResult = getDbAccessor().withReadDb((db) =>
+				const traversalResult = await getDbAccessor().withReadDbAsync((db) =>
 					traverseKnowledgeGraph(focal.entityIds, db, traversalAgentId, traversalRuntimeCfg),
 				);
 				traversalTimedOut = traversalResult.timedOut;

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -1582,7 +1582,7 @@ export async function hybridRecall(
 	let scored: Array<{ id: string; score: number; source: string }> = [];
 
 	if (traversalPrimary) {
-		timings.time("traversal_primary", () => {
+		await timings.timeAsync("traversal_primary", async () => {
 			// Channel A: graph traversal (primary retrieval path per DP-6)
 			const traversalScored: Array<{ id: string; score: number; source: string }> = [];
 
@@ -1595,7 +1595,7 @@ export async function hybridRecall(
 						const focal = getFocalEntities(agentId);
 
 						if (focal.entityIds.length > 0) {
-							const traversal = getDbAccessor().withReadDb((db) =>
+							const traversal = await getDbAccessor().withReadDbAsync((db) =>
 								traverseKnowledgeGraph(focal.entityIds, db, agentId, {
 									maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
 									maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,
@@ -1727,7 +1727,7 @@ export async function hybridRecall(
 		// --- KA traversal boost: structural one-hop retrieval via KA tables ---
 		if (cfg.pipelineV2.graph.enabled && cfg.pipelineV2.traversal?.enabled) {
 			try {
-				timings.time("traversal_boost", () => {
+				await timings.timeAsync("traversal_boost", async () => {
 					const traversalCfg = cfg.pipelineV2.traversal;
 					const queryTokens = getGraphQueryTokens();
 					if (traversalCfg && queryTokens.length > 0) {
@@ -1735,7 +1735,7 @@ export async function hybridRecall(
 						const focal = getFocalEntities(agentId);
 
 						if (focal.entityIds.length > 0) {
-							const traversal = getDbAccessor().withReadDb((db) =>
+							const traversal = await getDbAccessor().withReadDbAsync((db) =>
 								traverseKnowledgeGraph(focal.entityIds, db, agentId, {
 									maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
 									maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,

--- a/platform/daemon/src/pipeline/graph-traversal-compare.test.ts
+++ b/platform/daemon/src/pipeline/graph-traversal-compare.test.ts
@@ -168,7 +168,7 @@ describe.skipIf(!existsSync(dbPath))("traversal comparison (old vs new)", () => 
 
 	afterAll(() => { db?.close?.(); });
 
-	function compareResults(project: string): void {
+	async function compareResults(project: string): Promise<void> {
 		const focal = resolveFocalEntities(db as unknown as ReadDb, agentId, { project });
 
 		console.log(`\n  Project: ${project}`);
@@ -187,7 +187,7 @@ describe.skipIf(!existsSync(dbPath))("traversal comparison (old vs new)", () => 
 		const oldMs = performance.now() - t0;
 
 		const t1 = performance.now();
-		const newResult = traverseKnowledgeGraph_NEW(focal.entityIds, db as unknown as ReadDb, agentId, config);
+		const newResult = await traverseKnowledgeGraph_NEW(focal.entityIds, db as unknown as ReadDb, agentId, config);
 		const newMs = performance.now() - t1;
 
 		console.log(`\n  === Performance ===`);
@@ -266,6 +266,6 @@ describe.skipIf(!existsSync(dbPath))("traversal comparison (old vs new)", () => 
 		}
 	}
 
-	test("signetai project", () => compareResults("/home/nicholai/signet/signetai"));
-	test(".agents project", () => compareResults("/home/nicholai/.agents"));
+	test("signetai project", async () => compareResults("/home/nicholai/signet/signetai"));
+	test(".agents project", async () => compareResults("/home/nicholai/.agents"));
 });

--- a/platform/daemon/src/pipeline/graph-traversal.test.ts
+++ b/platform/daemon/src/pipeline/graph-traversal.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Regression test for #1118: traverseKnowledgeGraph was fully synchronous and
+ * blocked the daemon event loop for the whole walk (~1.7s per session start on
+ * a 102k-memory graph), serializing concurrent session starts and tripping the
+ * pressure gate. The walk must yield to the event loop between batches.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ReadDb } from "../db-accessor";
+import { invalidateTraversalCache, traverseKnowledgeGraph } from "./graph-traversal";
+
+const CONFIG = {
+	maxAspectsPerEntity: 10,
+	maxAttributesPerAspect: 20,
+	maxDependencyHops: 10,
+	minDependencyStrength: 0.3,
+	maxBranching: 4,
+	maxTraversalPaths: 50,
+	minConfidence: 0.5,
+	timeoutMs: 5000,
+} as const;
+
+function seedGraph(db: Database): void {
+	db.exec(`
+		CREATE TABLE entities (id TEXT PRIMARY KEY, name TEXT, agent_id TEXT);
+		CREATE TABLE entity_aspects (id TEXT PRIMARY KEY, entity_id TEXT, agent_id TEXT, weight REAL, canonical_name TEXT);
+		CREATE TABLE entity_attributes (aspect_id TEXT, memory_id TEXT, agent_id TEXT, status TEXT, kind TEXT, content TEXT, importance REAL);
+		CREATE TABLE entity_dependencies (id TEXT PRIMARY KEY, source_entity_id TEXT, target_entity_id TEXT, agent_id TEXT, confidence REAL, strength REAL);
+		CREATE TABLE memories (id TEXT PRIMARY KEY, importance REAL, is_deleted INTEGER);
+		CREATE TABLE memory_entity_mentions (memory_id TEXT, entity_id TEXT, confidence REAL);
+		CREATE INDEX idx_entity_aspects_entity ON entity_aspects (entity_id);
+		CREATE INDEX idx_entity_attributes_aspect ON entity_attributes (aspect_id);
+		CREATE INDEX idx_entity_dependencies_source ON entity_dependencies (source_entity_id);
+	`);
+	db.exec(`INSERT INTO entities VALUES ('e1', 'Alpha', 'default'), ('e2', 'Beta', 'default')`);
+	db.exec(
+		`INSERT INTO entity_aspects VALUES ('a1', 'e1', 'default', 1.0, 'preference'), ('a2', 'e2', 'default', 1.0, 'fact')`,
+	);
+	db.exec(`INSERT INTO memories VALUES ('m1', 0.8, 0), ('m2', 0.6, 0), ('m3', 0.5, 0)`);
+	db.exec(`INSERT INTO entity_attributes VALUES
+		('a1', 'm1', 'default', 'active', 'fact', 'alpha fact', 0.9),
+		('a1', 'm2', 'default', 'active', 'fact', 'alpha fact 2', 0.7),
+		('a2', 'm3', 'default', 'active', 'fact', 'beta fact', 0.6)`);
+	db.exec(`INSERT INTO entity_dependencies VALUES ('d1', 'e1', 'e2', 'default', 0.9, 0.8)`);
+	db.exec(`INSERT INTO memory_entity_mentions VALUES ('m1', 'e1', 0.9)`);
+}
+
+describe("traverseKnowledgeGraph event-loop yields (#1118)", () => {
+	let db: Database;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		seedGraph(db);
+		invalidateTraversalCache();
+	});
+
+	afterEach(() => {
+		db.close();
+		invalidateTraversalCache();
+	});
+
+	test("yields to the event loop during the walk instead of blocking it", async () => {
+		let loopBreaths = 0;
+		let done = false;
+		const breathe = (): void => {
+			if (done) return;
+			loopBreaths++;
+			setImmediate(breathe);
+		};
+		setImmediate(breathe);
+
+		const result = await traverseKnowledgeGraph(["e1"], db as unknown as ReadDb, "default", CONFIG);
+		done = true;
+
+		// The old synchronous walk resolved without a single macrotask
+		// opportunity — loopBreaths would be 0 and this test would fail.
+		expect(loopBreaths).toBeGreaterThan(0);
+		// Result identity: the seeded graph still resolves through both phases.
+		expect(result.memoryIds.has("m1")).toBe(true);
+		expect(result.memoryIds.has("m3")).toBe(true);
+		expect(result.entityCount).toBe(2);
+	});
+
+	test("concurrent traversals interleave instead of serializing", async () => {
+		let loopBreaths = 0;
+		let done = false;
+		const breathe = (): void => {
+			if (done) return;
+			loopBreaths++;
+			setImmediate(breathe);
+		};
+		setImmediate(breathe);
+
+		const [first, second] = await Promise.all([
+			traverseKnowledgeGraph(["e1"], db as unknown as ReadDb, "default", CONFIG),
+			traverseKnowledgeGraph(["e2"], db as unknown as ReadDb, "default", CONFIG),
+		]);
+		done = true;
+
+		expect(first.memoryIds.size).toBeGreaterThan(0);
+		expect(second.memoryIds.has("m3")).toBe(true);
+		expect(loopBreaths).toBeGreaterThan(0);
+	});
+});

--- a/platform/daemon/src/pipeline/graph-traversal.ts
+++ b/platform/daemon/src/pipeline/graph-traversal.ts
@@ -1,4 +1,13 @@
+import { yieldEvery } from "../async-yield";
 import type { ReadDb } from "../db-accessor";
+
+/**
+ * Yield cadence for long row loops inside the traversal. Row work is cheap
+ * per item but the batched queries can return tens of thousands of rows on
+ * large graphs — yielding every N rows keeps the event loop responsive
+ * (#1118: session-start traversal blocked the loop ~1.7s uninterrupted).
+ */
+const ROW_YIELD_BATCH = 500;
 
 export interface TraversalPath {
 	readonly entityIds: ReadonlyArray<string>;
@@ -346,21 +355,26 @@ function pathSize(path: TraversalPath): number {
  *
  * Produces identical output to the old collectForEntity loop, but collapses
  * up to 60+ sequential SQLite queries into 4 regardless of entity count.
+ *
+ * Async so the event loop breathes between batched query stages and inside
+ * long row loops (#1118) — query shapes and result identity are unchanged.
  */
-function batchCollectForEntities(
+async function batchCollectForEntities(
 	db: ReadDb,
 	entityIds: ReadonlyArray<string>,
 	agentId: string,
 	config: TraversalConfig,
 	budget: number,
-): {
+): Promise<{
 	readonly memoryIds: Set<string>;
 	readonly memoryScores: Map<string, number>;
 	readonly memoryPaths: Map<string, TraversalPath>;
 	readonly constraints: Array<{ readonly entityName: string; readonly content: string; readonly importance: number }>;
 	readonly activeAspectIds: Set<string>;
 	readonly visitedEntities: Set<string>;
-} {
+}> {
+	const stageYield = yieldEvery(1);
+	const rowYield = yieldEvery(ROW_YIELD_BATCH);
 	const memoryIds = new Set<string>();
 	const memoryScores = new Map<string, number>();
 	const memoryPaths = new Map<string, TraversalPath>();
@@ -406,7 +420,10 @@ function batchCollectForEntities(
 			content: row.content,
 			importance: row.importance,
 		});
+		await rowYield();
 	}
+
+	await stageYield();
 
 	// --- 2. Batch aspects for all entities ---
 	let aspectQuery: string;
@@ -440,7 +457,10 @@ function batchCollectForEntities(
 		if (list.length < config.maxAspectsPerEntity) {
 			list.push({ id: row.id });
 		}
+		await rowYield();
 	}
+
+	await stageYield();
 
 	// Collect the budgeted aspect IDs
 	const budgetedAspectIds: string[] = [];
@@ -516,8 +536,11 @@ function batchCollectForEntities(
 			if (current === undefined || row.importance > current) {
 				memoryScores.set(row.memory_id, row.importance);
 			}
+			await rowYield();
 		}
 	}
+
+	await stageYield();
 
 	// --- 4. Batch mentions for all entities (fallback) ---
 	if (memoryIds.size < budget) {
@@ -571,18 +594,24 @@ function batchCollectForEntities(
 			if (current === undefined || row.importance > current) {
 				memoryScores.set(row.memory_id, row.importance);
 			}
+			await rowYield();
 		}
 	}
 
 	return { memoryIds, memoryScores, memoryPaths, constraints, activeAspectIds, visitedEntities };
 }
 
-export function traverseKnowledgeGraph(
+/**
+ * Async since #1118: the walk yields to the event loop between batched
+ * query stages so concurrent session starts interleave instead of
+ * serializing on ~1.7s of uninterrupted main-thread work (large graphs).
+ */
+export async function traverseKnowledgeGraph(
 	focalEntityIds: ReadonlyArray<string>,
 	db: ReadDb,
 	agentId: string,
 	config: TraversalConfig,
-): TraversalResult {
+): Promise<TraversalResult> {
 	const empty: TraversalResult = {
 		memoryIds: new Set<string>(),
 		memoryScores: new Map<string, number>(),
@@ -600,12 +629,16 @@ export function traverseKnowledgeGraph(
 		const focalIds = sanitizeEntityIds(focalEntityIds);
 		if (focalIds.length === 0) return empty;
 
+		const stageYield = yieldEvery(1);
+		const rowYield = yieldEvery(ROW_YIELD_BATCH);
 		const deadline = Date.now() + config.timeoutMs;
 		const budget = config.maxTraversalPaths;
 
 		// --- Phase 1: Batch-collect for focal entities ---
-		const phase1 = batchCollectForEntities(db, focalIds, agentId, config, budget);
+		const phase1 = await batchCollectForEntities(db, focalIds, agentId, config, budget);
 		let timedOut = Date.now() > deadline;
+
+		await stageYield();
 
 		// --- Phase 2: Dependency expansion + batch collect for hops ---
 		if (!timedOut && phase1.memoryIds.size < budget) {
@@ -636,7 +669,7 @@ export function traverseKnowledgeGraph(
 
 			if (hopTargetIds.length > 0) {
 				const remainingBudget = budget - phase1.memoryIds.size;
-				const phase2 = batchCollectForEntities(db, hopTargetIds, agentId, config, remainingBudget);
+				const phase2 = await batchCollectForEntities(db, hopTargetIds, agentId, config, remainingBudget);
 
 				// Merge phase2 results into phase1
 				for (const mid of phase2.memoryIds) {
@@ -648,12 +681,14 @@ export function traverseKnowledgeGraph(
 					if (current === undefined || score > current) {
 						phase1.memoryScores.set(mid, score);
 					}
+					await rowYield();
 				}
 				for (const [mid, path] of phase2.memoryPaths) {
 					const prev = phase1.memoryPaths.get(mid);
 					if (!prev || pathSize(path) > pathSize(prev)) {
 						phase1.memoryPaths.set(mid, path);
 					}
+					await rowYield();
 				}
 				// Rebuild paths for hop entities with source/dependency provenance
 				const sourceByTarget = new Map<string, { sourceEntityId: string; dependencyId: string }>();
@@ -676,6 +711,7 @@ export function traverseKnowledgeGraph(
 							}
 						}
 					}
+					await rowYield();
 				}
 				phase1.constraints.push(...phase2.constraints);
 				// Deduplicate across phase1/phase2 boundary (in-place to respect readonly)

--- a/platform/daemon/src/routes/knowledge-routes.ts
+++ b/platform/daemon/src/routes/knowledge-routes.ts
@@ -397,8 +397,8 @@ export function registerKnowledgeRoutes(app: Hono): void {
 
 		const primaryEntityId = focal.entityIds[0];
 
-		return getDbAccessor().withReadDb((db) => {
-			const traversal = traverseKnowledgeGraph(focal.entityIds, db, agentId, {
+		return getDbAccessor().withReadDbAsync(async (db) => {
+			const traversal = await traverseKnowledgeGraph(focal.entityIds, db, agentId, {
 				maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
 				maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,
 				maxDependencyHops: traversalCfg.maxDependencyHops,


### PR DESCRIPTION
## Summary

Fixes #1118. `traverseKnowledgeGraph` was fully synchronous — on a 102k-memory install each session-start walk blocked the daemon event loop ~1.7s uninterrupted (median 1681ms measured), so concurrent session starts serialized on sync work and tripped the pressure gate. The batched walk is now async with yield points between query stages and inside long row loops, so concurrent starts interleave instead of starving the loop.

## Changes

- `pipeline/graph-traversal.ts`: `traverseKnowledgeGraph` and `batchCollectForEntities` are now async; yield via the existing `async-yield` helper between batched query stages and every 500 rows in long loops. Query shapes, deadline semantics, and result identity are unchanged.
- `db-accessor.ts`: new `withReadDbAsync` variant that holds the pooled read connection across event-loop yields.
- Call sites updated to await: `hooks.ts` (session start), `memory-search.ts` (traversal-primary + traversal-boost, now timed via `timeAsync`), `routes/knowledge-routes.ts` (`/api/knowledge/expand`).
- `pipeline/graph-traversal.test.ts`: regression test for #1118 — asserts the event loop runs macrotasks during the walk (the old sync walk allowed zero) and that concurrent traversals interleave; also pins result identity on a seeded graph.
- `pipeline/graph-traversal-compare.test.ts`: old-vs-new parity runner updated for the async signature.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec surface changed
- [x] Agent scoping verified on all new/changed data queries — queries unchanged, agent_id filters intact
- [x] Input/config validation and bounds checks added — config shape unchanged
- [x] Error handling and fallback paths tested (no silent swallow) — existing try/catch-returns-empty behavior preserved
- [x] Security checks applied to admin/mutation endpoints — read-only path
- [x] Docs updated for API/spec/status changes — internal responsiveness fix, no API/spec change
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally (note: `bun run lint` has pre-existing failures on main, unchanged by this PR; touched files are biome-clean apart from one pre-existing `noNonNullAssertion` in graph-traversal.ts)

## Testing

- [x] `bun test` passes (targeted: pipeline/, hooks, db-accessor, memory-search, knowledge-routes — 5 maintenance-worker failures reproduce on main, pre-existing)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (see note above)
- [ ] Tested against running daemon — not yet; recommend post-merge live verification of session-start phase timings + event-loop-lag warnings per signet-live-verification

## AI disclosure

- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

`withReadDbAsync` holds a read-pool connection across yields; the pool grows on demand up to the connection limit, so concurrent traversals do not starve each other. Follow-up live check on a large-graph install: session-start `traversal` phase wall time will be similar, but `Event loop blocked` warnings during concurrent starts should disappear.
