### PR TITLE
fix(dreaming): reject cross-scope evidence

### DIFF
--- a/platform/daemon/src/episodic-sources.ts
+++ b/platform/daemon/src/episodic-sources.ts
@@ -579,6 +579,69 @@ export function readEpisodicSource(db: ReadDb, options: ReadEpisodicSourceOption
 	);
 }
 
+/** Find scopes that own a resolvable source without exposing their contents. */
+export function findEpisodicSourceAgentIds(db: ReadDb, from: string): readonly string[] {
+	const trimmed = from.trim();
+	const colon = trimmed.indexOf(":");
+	if (colon <= 0) return [];
+	const kind = trimmed.slice(0, colon);
+	const sourceId = trimmed.slice(colon + 1);
+	const ids = sourceIdCandidates(sourceId);
+	const placeholders = ids.map(() => "?").join(", ");
+	let rows: Array<{ agent_id: string | null }>;
+
+	if (kind === "memory") {
+		rows = db
+			.prepare(
+				`SELECT DISTINCT agent_id
+				 FROM memories
+				 WHERE memory_kind = 'episodic'
+				   AND COALESCE(is_deleted, 0) = 0
+				   AND visibility != 'archived'
+				   AND scope IS NULL
+				   AND id IN (${placeholders})`,
+			)
+			.all(...ids) as Array<{ agent_id: string | null }>;
+	} else if (kind === "artifact" || kind === "source") {
+		rows = db
+			.prepare(
+				`SELECT DISTINCT agent_id
+				 FROM memory_artifacts
+				 WHERE COALESCE(is_deleted, 0) = 0
+				   AND (
+				     source_path = ?
+				     OR source_node_id IN (${placeholders})
+				     OR session_id IN (${placeholders})
+				     OR session_key IN (${placeholders})
+				     OR session_token IN (${placeholders})
+				   )`,
+			)
+			.all(sourceId, ...ids, ...ids, ...ids, ...ids) as Array<{ agent_id: string | null }>;
+	} else if (kind === "transcript" || kind === "session") {
+		rows = db
+			.prepare(
+				`SELECT DISTINCT agent_id
+				 FROM session_transcripts
+				 WHERE session_key IN (${placeholders})`,
+			)
+			.all(...ids) as Array<{ agent_id: string | null }>;
+	} else if (kind === "summary") {
+		rows = db
+			.prepare(
+				`SELECT DISTINCT agent_id
+				 FROM session_summaries
+				 WHERE depth = 0
+				   AND COALESCE(source_type, 'summary') IN ('summary', 'compaction', 'checkpoint')
+				   AND (id IN (${placeholders}) OR source_ref IN (${placeholders}))`,
+			)
+			.all(...ids, ...ids) as Array<{ agent_id: string | null }>;
+	} else {
+		return [];
+	}
+
+	return [...new Set(rows.map((row) => row.agent_id).filter((agentId): agentId is string => Boolean(agentId)))].sort();
+}
+
 /**
  * Search immutable episodic evidence without falling back to semantic memory.
  *

--- a/platform/daemon/src/pipeline/dreaming-operations.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.test.ts
@@ -256,6 +256,33 @@ describe("dreaming operations", () => {
 		expect(result.error).toBe("Every operation must cite an exact quote from scoped episodic evidence");
 	});
 
+	it("rejects evidence cited from another agent scope with a corrective error", () => {
+		insertEpisodicMemory("mem-other", "The source belongs to the default scope.", "default");
+		const result = applyDreamingOperations({
+			accessor: getDbAccessor(),
+			agentId: "hermes-agent",
+			actor: "dreaming",
+			operations: [
+				{
+					operation: "create_entity",
+					payload: { name: "Wrong Scope", type: "project" },
+					evidence: [
+						{
+							source_ref: "memory:mem-other",
+							source_kind: "manual",
+							source_id: "mem-other",
+							quote: "The source belongs to the default scope.",
+						},
+					],
+				},
+			],
+		});
+		expect(result.ok).toBe(false);
+		expect(result.error).toBe(
+			"Cited evidence belongs to scope 'default' but this operation targets 'hermes-agent'. Search evidence in the target scope before applying the operation.",
+		);
+	});
+
 	it("rejects a content op without evidence", () => {
 		const result = applyDreamingOperations({
 			accessor: getDbAccessor(),

--- a/platform/daemon/src/pipeline/dreaming-operations.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.ts
@@ -1,6 +1,6 @@
 import { SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES } from "@signet/core";
 import type { DbAccessor, ReadDb } from "../db-accessor";
-import { readEpisodicSource } from "../episodic-sources";
+import { findEpisodicSourceAgentIds, readEpisodicSource } from "../episodic-sources";
 import { type OntologyOperationInput, applyOntologyOperationBatchInTx } from "../ontology-proposals";
 import { type DreamingAttention, enqueueDreamingAttentionInTx, getDreamingAttentionById } from "./dreaming-attention";
 import { type DreamingAgentEvidence, createDreamingAgentEvidence } from "./dreaming-evidence";
@@ -71,23 +71,31 @@ function citationRecord(value: unknown): {
  * validate against the same immutable store the search tools read, so an
  * agent can cite any in-scope source it found and quoted verbatim.
  */
-function citeEvidence(accessor: DbAccessor, agentId: string, citation: unknown): DreamingAgentEvidence | null {
+interface CitationResolution {
+	readonly evidence: DreamingAgentEvidence | null;
+	readonly sourceAgentIds: readonly string[];
+}
+
+function citeEvidence(accessor: DbAccessor, agentId: string, citation: unknown): CitationResolution {
 	const requested = citationRecord(citation);
-	if (requested === null) return null;
-	const evidence = accessor.withReadDb((db) => {
+	if (requested === null) return { evidence: null, sourceAgentIds: [] };
+	const result = accessor.withReadDb((db) => {
 		const source = readEpisodicSource(db, { agentId, from: requested.sourceRef });
-		return source === null ? [] : createDreamingAgentEvidence([source]);
+		if (source !== null) return { evidence: createDreamingAgentEvidence([source]), sourceAgentIds: [] };
+		return { evidence: [], sourceAgentIds: findEpisodicSourceAgentIds(db, requested.sourceRef) };
 	});
-	return (
-		evidence.find(
-			(record) =>
-				record.sourceRef === requested.sourceRef &&
-				record.sourceKind === requested.sourceKind &&
-				record.sourceId === requested.sourceId &&
-				(requested.sourcePath === null || record.sourcePath === requested.sourcePath) &&
-				record.content.includes(requested.quote),
-		) ?? null
-	);
+	return {
+		evidence:
+			result.evidence.find(
+				(record) =>
+					record.sourceRef === requested.sourceRef &&
+					record.sourceKind === requested.sourceKind &&
+					record.sourceId === requested.sourceId &&
+					(requested.sourcePath === null || record.sourcePath === requested.sourcePath) &&
+					record.content.includes(requested.quote),
+			) ?? null,
+		sourceAgentIds: result.sourceAgentIds,
+	};
 }
 
 type DreamingOperationProvenance = {
@@ -243,23 +251,35 @@ function provenanceForEvidence(
 	accessor: DbAccessor,
 	agentId: string,
 	operation: DreamingOperationRequest,
-): DreamingOperationProvenance | null {
+): { readonly provenance: DreamingOperationProvenance | null; readonly scopeMismatch: string | null } {
 	const citations = operation.evidence ?? [];
-	if (citations.length === 0) return null;
+	if (citations.length === 0) return { provenance: null, scopeMismatch: null };
 	const matched: DreamingAgentEvidence[] = [];
 	for (const citation of citations) {
-		const record = citeEvidence(accessor, agentId, citation);
-		if (record === null) return null;
-		matched.push(record);
+		const resolution = citeEvidence(accessor, agentId, citation);
+		if (resolution.evidence === null) {
+			if (resolution.sourceAgentIds.length > 0) {
+				const scopes = resolution.sourceAgentIds.map((sourceAgentId) => `'${sourceAgentId}'`).join(", ");
+				return {
+					provenance: null,
+					scopeMismatch: `Cited evidence belongs to scope${resolution.sourceAgentIds.length === 1 ? "" : "s"} ${scopes} but this operation targets '${agentId}'. Search evidence in the target scope before applying the operation.`,
+				};
+			}
+			return { provenance: null, scopeMismatch: null };
+		}
+		matched.push(resolution.evidence);
 	}
 	const provenance = matched.find((source) => source.sourceEntryId !== null) ?? matched[0];
-	if (!provenance) return null;
+	if (!provenance) return { provenance: null, scopeMismatch: null };
 	return {
-		evidence: citations,
-		sourceKind: provenance.sourceKind,
-		sourceId: provenance.sourceEntryId ?? provenance.sourceId,
-		sourcePath: provenance.sourcePath,
-		sourceRoot: "dreaming",
+		provenance: {
+			evidence: citations,
+			sourceKind: provenance.sourceKind,
+			sourceId: provenance.sourceEntryId ?? provenance.sourceId,
+			sourcePath: provenance.sourcePath,
+			sourceRoot: "dreaming",
+		},
+		scopeMismatch: null,
 	};
 }
 
@@ -505,12 +525,14 @@ export function applyDreamingOperations(params: {
 				};
 			}
 		} else {
-			provenance = provenanceForEvidence(params.accessor, params.agentId, operation);
+			const evidenceResult = provenanceForEvidence(params.accessor, params.agentId, operation);
+			provenance = evidenceResult.provenance;
 			if (provenance === null) {
 				return {
 					ok: false,
 					items: [],
-					error: "Every operation must cite an exact quote from scoped episodic evidence",
+					error:
+						evidenceResult.scopeMismatch ?? "Every operation must cite an exact quote from scoped episodic evidence",
 				};
 			}
 		}

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -632,7 +632,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - If you discover junk the queue did not flag, mint a flag op and archive in the same batch.
 3. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. For each new source:
    - search_entities for subjects it establishes.
-   - Extract/update claims with exact-quote evidence from that source.
+   - Extract/update claims with exact-quote evidence from that source. The evidence source and the graph target must use the same agent scope: search evidence with the agentId of the entity you will update, then pass that same agentId to apply_ontology_ops. A source found in another scope cannot support a write here.
    - create_entity only for durable subjects clearly established by the source.
    - Validate before writing (validate_proposal).
 4. Write the pass log (runbook_write): what changed, which sources were viewed, anything deferred with exact names.
@@ -739,7 +739,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 1. Read the pass log (runbook_read). Establish cutoff: sources viewed, changes applied, deferred items.
 2. Find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. For each new source:
    - search_entities for subjects it establishes.
-   - Extract/update claims with exact-quote evidence from that source.
+   - Extract/update claims with exact-quote evidence from that source. The evidence source and the graph target must use the same agent scope: search evidence with the agentId of the entity you will update, then pass that same agentId to apply_ontology_ops. A source found in another scope cannot support a write here.
    - create_entity only for durable subjects clearly established by the source.
    - Validate before writing (validate_proposal).
 3. Write the pass log (runbook_write): what changed, which sources were viewed, anything deferred with exact names.
@@ -760,7 +760,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 
 ### Verification (before finishing)
 
-- Every write in the batch cites an exact quote from scoped episodic evidence.
+- Every write in the batch cites an exact quote from episodic evidence in the same agent scope as the graph target.
 - Pass log written with sources viewed + changes applied (this is the next pass's dedup).
 - No claims without exact quotes, no relationships the source does not state.
 - No writes attempted against pinned or source-root entities.


### PR DESCRIPTION
## Summary

Fix Dreaming content writes that cite episodic evidence from a different agent scope than the operation target. The daemon now rejects the mutation with a corrective error instead of silently treating the cross-scope source as missing.

Fixes #1120

## Changes

- Add scope-owner lookup for resolvable episodic memories, artifacts, transcripts, and summaries.
- Detect cross-scope evidence during Dreaming provenance validation and report both the source scope and target scope.
- Clarify both Dreaming content runbooks: evidence search and ontology writes must use the same `agentId`.
- Add a regression test covering a `default` source cited by a `hermes-agent` operation.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: Dreaming pipeline and episodic source access

## Screenshots

N/A: no UI changes.

## PR Readiness

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — N/A: no public spec or dependency changes.
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added — N/A: no new configuration surface; source refs remain validated by the existing citation parser.
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints — mutation provenance now fails closed on cross-scope evidence.
- [x] Docs updated for API/spec/status changes — internal Dreaming content runbooks updated.
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally — focused changed-area checks pass; unrelated root baseline failures are listed below.

## Testing

- [x] `bun test platform/daemon/src/pipeline/dreaming-operations.test.ts platform/daemon/src/episodic-sources.test.ts platform/daemon/src/pipeline/dreaming.test.ts` — 40 passed
- [x] `bun run --filter '@signet/daemon' typecheck` — passed
- [x] `bun run --filter '@signet/daemon' build` — passed
- [x] `bunx biome check` on changed files — passed with existing warnings only
- [x] `git diff --check` — passed
- [ ] `bun test` — blocked by unrelated baseline failures in connectors, OpenCode fetch mocks, generated content, package bundles, and other integration surfaces
- [ ] `bun run typecheck` — blocked by unrelated connector workspace build/linkage failures
- [ ] `bun run lint` — blocked by unrelated repository-wide package manifest formatting drift
- [x] Tested against running daemon: N/A; mutation behavior is covered through the daemon operation boundary test

## AI disclosure

- [x] AI tools were used (see `Assisted-by: Hermes-Agent:gpt-5.6-luna` in the commit)

## Notes

The implementation preserves the existing exact-quote and provenance checks. It only returns the new scope-mismatch diagnostic when the cited source is resolvable in another scope; missing or malformed citations retain the existing generic validation error.
