### PR TITLE
fix(daemon): scope-aware rejection for cross-scope dreaming citations (#1120)

### DIFF
--- a/platform/daemon/src/episodic-sources.ts
+++ b/platform/daemon/src/episodic-sources.ts
@@ -580,6 +580,33 @@ export function readEpisodicSource(db: ReadDb, options: ReadEpisodicSourceOption
 }
 
 /**
+ * Find which agent scopes actually own a given source reference. The scoped
+ * readers resolve a source only within one agent scope, so a cross-scope
+ * citation (evidence found under scope A cited by an op targeting scope B)
+ * silently fails the exact-quote gate with no corrective signal. This helper
+ * enumerates the scopes that own the source so callers can emit a scope-aware
+ * rejection (issue #1120).
+ *
+ * Returns the owning scopes, or an empty array when the source resolves
+ * nowhere or under no scope at all.
+ */
+export function findEpisodicSourceOwnerScopes(
+	db: ReadDb,
+	from: string,
+	candidateScopes: readonly string[],
+): readonly string[] {
+	const trimmed = from.trim();
+	if (!trimmed) return [];
+	const owners: string[] = [];
+	for (const scope of candidateScopes) {
+		if (readEpisodicSource(db, { agentId: scope, from: trimmed }) !== null) {
+			owners.push(scope);
+		}
+	}
+	return owners;
+}
+
+/**
  * Search immutable episodic evidence without falling back to semantic memory.
  *
  * This belongs beside the canonical cross-store reader so every Dreaming

--- a/platform/daemon/src/pipeline/dreaming-operations.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.test.ts
@@ -267,6 +267,60 @@ describe("dreaming operations", () => {
 		expect(result.error).toBe("Every operation must cite an exact quote from scoped episodic evidence");
 	});
 
+	it("rejects a cross-scope citation with a scope-aware message (#1120)", () => {
+		// The quote lives in agent-b's episodic store, but the op targets
+		// agent-a. The gate used to reject with the generic message, giving
+		// the agent no corrective signal.
+		insertEpisodicMemory("mem-1", "Acme switched its deployment target to edge runtime in Q2.", "agent-b");
+		const result = applyDreamingOperations({
+			accessor: getDbAccessor(),
+			agentId: "agent-a",
+			actor: "dreaming",
+			operations: [
+				{
+					operation: "create_entity",
+					payload: { name: "Acme", type: "project" },
+					evidence: [
+						{
+							source_ref: "memory:mem-1",
+							source_kind: "manual",
+							source_id: "mem-1",
+							quote: "Acme switched its deployment target to edge runtime in Q2.",
+						},
+					],
+				},
+			],
+		});
+		expect(result.ok).toBe(false);
+		expect(result.error).toBe("cited evidence belongs to scope 'agent-b' but this op targets 'agent-a'");
+	});
+
+	it("keeps the generic exact-quote rejection when the quote resolves nowhere (#1120)", () => {
+		// A quote that matches no source in ANY scope is not a scope-mixing
+		// problem — the generic message must be preserved.
+		const result = applyDreamingOperations({
+			accessor: getDbAccessor(),
+			agentId: "agent-a",
+			actor: "dreaming",
+			operations: [
+				{
+					operation: "create_entity",
+					payload: { name: "Acme", type: "project" },
+					evidence: [
+						{
+							source_ref: "memory:missing",
+							source_kind: "manual",
+							source_id: "missing",
+							quote: "This source does not exist in any scope.",
+						},
+					],
+				},
+			],
+		});
+		expect(result.ok).toBe(false);
+		expect(result.error).toBe("Every operation must cite an exact quote from scoped episodic evidence");
+	});
+
 	it("supersedes the current active claim for a key without an explicit attribute id", () => {
 		insertEntity("e-acme", "Acme", "acme");
 		insertAspect("a-main", "e-acme", "general");

--- a/platform/daemon/src/pipeline/dreaming-operations.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.ts
@@ -1,6 +1,6 @@
 import { SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES } from "@signet/core";
 import type { DbAccessor, ReadDb } from "../db-accessor";
-import { readEpisodicSource } from "../episodic-sources";
+import { readEpisodicSource, findEpisodicSourceOwnerScopes } from "../episodic-sources";
 import { type OntologyOperationInput, applyOntologyOperationBatchInTx } from "../ontology-proposals";
 import { type DreamingAttention, enqueueDreamingAttentionInTx, getDreamingAttentionById } from "./dreaming-attention";
 import { type DreamingAgentEvidence, createDreamingAgentEvidence } from "./dreaming-evidence";
@@ -265,6 +265,60 @@ function provenanceForEvidence(
 
 // --- model payload -> shared applicator payload mapping --------------------
 
+/**
+ * Enumerate the agent scopes that could own episodic evidence: the op's own
+ * scope, the implicit default scope, plus every scope that has ever written
+ * an episodic row. Used only on the rejection path to diagnose cross-scope
+ * citations (#1120), so the cost of a few indexed scans is acceptable.
+ */
+function listEpisodicAgentScopes(db: ReadDb, agentId: string): readonly string[] {
+	const rows = db
+		.prepare(
+			`SELECT DISTINCT agent_id AS id FROM (
+				SELECT id AS agent_id FROM agents
+				UNION ALL SELECT agent_id FROM memories WHERE is_deleted = 0
+				UNION ALL SELECT agent_id FROM session_transcripts
+				UNION ALL SELECT agent_id FROM session_summaries
+				UNION ALL SELECT agent_id FROM memory_artifacts WHERE is_deleted = 0
+			) WHERE agent_id IS NOT NULL AND agent_id != ''`,
+		)
+		.all() as Array<{ id: string }>;
+	const ids = new Set<string>([agentId, "default"]);
+	for (const row of rows) ids.add(row.id);
+	return [...ids];
+}
+
+/**
+ * When the exact-quote gate rejects a content op, diagnose whether the cited
+ * evidence actually resolves under a *different* agent scope than the op
+ * target. A cross-scope citation (evidence found in scope A, op targeting
+ * scope B) fails the scoped reader with no corrective signal; surface the
+ * owning scope so the agent can re-search in the target's scope and
+ * self-correct instead of repeating the same failed pairing (#1120).
+ */
+function crossScopeEvidenceHint(
+	accessor: DbAccessor,
+	agentId: string,
+	operation: DreamingOperationRequest,
+): string | null {
+	const citations = operation.evidence ?? [];
+	if (citations.length === 0) return null;
+	return accessor.withReadDb((db) => {
+		const scopes = listEpisodicAgentScopes(db, agentId);
+		for (const citation of citations) {
+			const requested = citationRecord(citation);
+			if (requested === null) continue;
+			const owners = findEpisodicSourceOwnerScopes(db, requested.sourceRef, scopes);
+			for (const owner of owners) {
+				if (owner !== agentId) {
+					return `cited evidence belongs to scope '${owner}' but this op targets '${agentId}'`;
+				}
+			}
+		}
+		return null;
+	});
+}
+
 function lookupString(db: ReadDb, sql: string, ...params: unknown[]): string | null {
 	const row = db.prepare(sql).get(...params) as { value: string | null } | undefined;
 	return row?.value ?? null;
@@ -507,10 +561,15 @@ export function applyDreamingOperations(params: {
 		} else {
 			provenance = provenanceForEvidence(params.accessor, params.agentId, operation);
 			if (provenance === null) {
+				// The quote gate failed: distinguish a genuinely missing or
+				// unquotable source from a citation that resolves under a
+				// different agent scope, so the agent gets a corrective
+				// signal instead of the generic rejection (#1120).
+				const scopeHint = crossScopeEvidenceHint(params.accessor, params.agentId, operation);
 				return {
 					ok: false,
 					items: [],
-					error: "Every operation must cite an exact quote from scoped episodic evidence",
+					error: scopeHint ?? "Every operation must cite an exact quote from scoped episodic evidence",
 				};
 			}
 		}

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -104,6 +104,15 @@ describe("Dreaming", () => {
 		).toEqual({ capturedAt: "2026-03-01T00:00:00.000Z", kind: "summary", id: "fragment" });
 	});
 
+	it("states the evidence scope-consistency rule in the agent prompt (#1120)", () => {
+		// The runbook must tell the agent that evidence and op target must
+		// share a scope, and that cross-scope citations are unsafe — that is
+		// the corrective signal that keeps content passes from repeating the
+		// same failed pairing.
+		expect(DREAMING_AGENT_PROMPT).toContain("evidence must be cited from the same scope as the op target");
+		expect(DREAMING_AGENT_PROMPT).toContain("Cite evidence from a different agent scope than the op target");
+	});
+
 	it("uses the fixed agent prompt and resets the evidence backlog each pass", async () => {
 		seedSummary(db, "s1", "durable episodic evidence for the backlog.", 500);
 		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -630,7 +630,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - Inspect the flagged target (get_entity — check aspects, claims, pinned).
    - Archive or merge it, citing its attention id (provenance: "attention:<uuid>", or attention:$<index> for a flag you minted in the same batch).
    - If you discover junk the queue did not flag, mint a flag op and archive in the same batch.
-3. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. For each new source:
+3. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. Search in the same agent scope as the entity you will update (pass the target entity's agentId to search_evidence): evidence must be cited from the same scope as the op target. For each new source:
    - search_entities for subjects it establishes.
    - Extract/update claims with exact-quote evidence from that source.
    - create_entity only for durable subjects clearly established by the source.
@@ -641,7 +641,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 
 - Archive attention-flagged entities that are non-concrete (zero active aspects/claims, non-concrete type, legacy-only deps).
 - Merge exact-canonical duplicates (same canonical name, same scope).
-- Add/set/supersede claims with exact quotes from an episodic source.
+- Add/set/supersede claims with exact quotes from an episodic source in the same scope as the target entity.
 - Create entities for durable subjects the source clearly establishes.
 - Rename/update entities only with evidence.
 
@@ -650,6 +650,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 - Archive any entity with active aspects/claims.
 - Merge entities across agent scopes.
 - Any write without provenance: hygiene ops need an attention id; content ops need an exact quote.
+- Cite evidence from a different agent scope than the op target — search the evidence in the scope of the entity you are updating.
 - Claims without exact quotes, or relationships the source does not state.
 - Touch pinned entities, source-root entities, or topology entities.
 - Rewrite existing claims without evidence that supersedes them.
@@ -737,7 +738,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 ### Per-pass process
 
 1. Read the pass log (runbook_read). Establish cutoff: sources viewed, changes applied, deferred items.
-2. Find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. For each new source:
+2. Find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. Search in the same agent scope as the entity you will update (pass the target entity's agentId to search_evidence): evidence must be cited from the same scope as the op target. For each new source:
    - search_entities for subjects it establishes.
    - Extract/update claims with exact-quote evidence from that source.
    - create_entity only for durable subjects clearly established by the source.
@@ -746,13 +747,14 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 
 ### Safe
 
-- Add/set/supersede claims with exact quotes from an episodic source.
+- Add/set/supersede claims with exact quotes from an episodic source in the same scope as the target entity.
 - Create entities for durable subjects the source clearly establishes.
 - Rename/update entities only with evidence.
 
 ### Unsafe
 
 - Any write without provenance: content ops need an exact quote.
+- Cite evidence from a different agent scope than the op target — search the evidence in the scope of the entity you are updating.
 - Claims without exact quotes, or relationships the source does not state.
 - Hygiene archives/merges: they need attention records, which hygiene passes process.
 - Touch pinned entities, source-root entities, or topology entities.


### PR DESCRIPTION
## Summary

Content-mode dreaming passes run the runbook end-to-end but never apply a
mutation: the agent cites evidence found in one agent scope while targeting
an entity in another scope. The exact-quote gate resolved citations only in
the op's scope, so a cross-scope citation returned nothing and the pass
reported the generic "Every operation must cite an exact quote from scoped
episodic evidence" — no signal about what the agent actually did wrong, so
the same failed pairing repeated every pass.

Fixes #1120.

## Changes

- `platform/daemon/src/episodic-sources.ts` — new
  `findEpisodicSourceOwnerScopes` helper: given a source ref, enumerates
  which agent scopes actually own it.
- `platform/daemon/src/pipeline/dreaming-operations.ts` — new
  `listEpisodicAgentScopes` + `crossScopeEvidenceHint`: when the quote gate
  rejects a content op, the hint checks whether the cited source resolves
  under a different agent scope and rejects with
  `cited evidence belongs to scope '<owner>' but this op targets '<agent>'`.
  Sources that resolve nowhere (or whose quote simply does not match) keep
  the original generic message.
- `platform/daemon/src/pipeline/dreaming.ts` — both content-mode prompts
  (combined and content-only) now state the scope-consistency rule
  ("evidence must be cited from the same scope as the op target") and list
  cross-scope citations under Unsafe.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no migrations touched.

## Testing

- New unit tests in `dreaming-operations.test.ts`: cross-scope citation →
  scope-aware rejection message (fails without the fix, passes with it);
  quote resolving nowhere → generic message preserved.
- New prompt test in `dreaming.test.ts`: `DREAMING_AGENT_PROMPT` contains
  the scope-consistency rule.
- Targeted run: `dreaming-operations.test.ts` + `dreaming.test.ts` +
  `episodic-sources.test.ts` — 42 pass / 0 fail.
- Full daemon suite vs pristine `main` baseline: failure sets byte-identical
  (pre-existing parallel-run flakiness in unrelated files).
- `bunx biome check` clean on all touched files.

- [x] `bun test` passes
- [ ] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

Assisted-by: Hermes-Agent:deepseek-v4-flash

## Notes

The gate's generic rejection message is preserved for citations that resolve
nowhere; only genuinely cross-scope citations get the new scope-aware
message, so existing behavior for non-scope-mixing failures is unchanged.