### PR TITLE
feat(core): review_after column + store surfaces for temporal-claim expiry (#945)

### DIFF
--- a/dist/signetai/hermes-plugin/__init__.py
+++ b/dist/signetai/hermes-plugin/__init__.py
@@ -167,6 +167,7 @@ MEMORY_STORE_SCHEMA = {
             "tags": {"type": "string", "description": "Comma-separated tags for categorization."},
             "pinned": {"type": "boolean", "description": "Pin this memory so it does not decay."},
             "project": {"type": "string", "description": "Optional project path. Defaults to the active Hermes Signet workspace."},
+            "review_after": {"type": "string", "description": "ISO timestamp after which Dreaming should surface this memory for temporal review."},
             "hints": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -952,6 +953,7 @@ class SignetMemoryProvider(MemoryProvider):
                 hints=hints,
                 transcript=str(store_args.get("transcript", "") or ""),
                 structured=structured,
+                review_after=str(store_args.get("review_after", "") or ""),
                 who="hermes-agent",
             )
             if not result:

--- a/dist/signetai/hermes-plugin/client.py
+++ b/dist/signetai/hermes-plugin/client.py
@@ -363,6 +363,7 @@ class SignetClient:
         hints: Optional[List[str]] = None,
         transcript: str = "",
         structured: Optional[Dict[str, Any]] = None,
+        review_after: str = "",
         who: str = "hermes-agent",
     ) -> Optional[Dict[str, Any]]:
         """Store a memory via the daemon API."""
@@ -391,6 +392,8 @@ class SignetClient:
             body["transcript"] = transcript
         if structured:
             body["structured"] = structured
+        if review_after:
+            body["reviewAfter"] = review_after
         return self._post("/api/memory/remember", body, timeout=_LONG_TIMEOUT_SECS)
 
     def recall(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -573,7 +573,7 @@ Database Schema
 SQLite with WAL mode. Migrations are numbered sequentially under
 `platform/core/src/migrations/`. Each migration is idempotent — safe
 to re-run against an existing database. Schema version is tracked in
-`schema_migrations`. The latest migration is `096-retire-legacy-ingestion.ts`.
+`schema_migrations`. The latest migration is `106-memory-review-after.ts`.
 
 **schema_migrations**
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -575,6 +575,7 @@ Options:
 | `--source-created-at <iso>` | Source-system creation time for this memory |
 | `--valid-from <iso>` | Start of validity window for this memory |
 | `--valid-until <iso>` | End of validity window for this memory |
+| `--review-after <iso>` | Surface a future temporal claim for review after this timestamp |
 
 Output:
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -152,6 +152,7 @@ forwarded as request metadata.
 | `hints` | string[] | no | Prospective recall hints and alternate phrasings |
 | `transcript` | string | no | Raw source text to preserve alongside the extracted memory |
 | `structured` | object | no | Pre-extracted entity/aspect/attribute data retained as episodic evidence alongside the content; not applied directly to the knowledge graph from this tool |
+| `reviewAfter` | string | no | ISO timestamp after which Dreaming should surface the memory for temporal review |
 
 **Returns:** The created memory object with its assigned ID.
 

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -74,6 +74,7 @@ const result = await signet.remember("Prefers TypeScript over JavaScript", {
   tags: "language,tooling",
   pinned: false,
   occurredAt: "2026-05-13T18:00:00Z",
+  reviewAfter: "2026-08-03T00:00:00.000Z",
   mode: "sync",         // "auto" | "sync" | "async"
   idempotencyKey: "pref-ts-001",
 });

--- a/docs/api/memory.md
+++ b/docs/api/memory.md
@@ -87,6 +87,7 @@ Body-level fields override prefix-parsed values.
   "sourceCreatedAt": "2026-02-20T15:05:00.000Z",
   "validFrom": "2026-02-20T00:00:00.000Z",
   "validUntil": "2026-03-01T00:00:00.000Z",
+  "reviewAfter": "2026-08-03T00:00:00.000Z",
   "agentId": "alice",
   "visibility": "global"
 }
@@ -112,6 +113,10 @@ attach explicit temporal edges to the memory without duplicating the memory
 content. Use them when the memory is saved later than the event, observation,
 source creation time, or validity window it describes. Each value must be a
 valid ISO timestamp; `validUntil` must be after `validFrom` when both are set.
+
+`reviewAfter` is an optional ISO timestamp for a future temporal claim. Dreaming
+uses it to surface the memory for review after the deadline instead of assuming
+that the planned event occurred.
 
 Row-level provenance fields are optional: `sourcePath`/`source_path` stores the
 original source path, `runtimePath`/`runtime_path` stores the runtime-relative

--- a/integrations/hermes-agent/connector/hermes-plugin/__init__.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/__init__.py
@@ -171,6 +171,7 @@ MEMORY_STORE_SCHEMA = {
             "tags": {"type": "string", "description": "Comma-separated tags for categorization."},
             "pinned": {"type": "boolean", "description": "Pin this memory so it does not decay."},
             "project": {"type": "string", "description": "Optional project path. Defaults to the active Hermes Signet workspace."},
+            "review_after": {"type": "string", "description": "ISO timestamp after which Dreaming should surface this memory for temporal review."},
             "hints": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -963,6 +964,7 @@ class SignetMemoryProvider(MemoryProvider):
                 hints=hints,
                 transcript=str(store_args.get("transcript", "") or ""),
                 structured=structured,
+                review_after=str(store_args.get("review_after", "") or ""),
                 who="hermes-agent",
             )
             if not result:

--- a/integrations/hermes-agent/connector/hermes-plugin/client.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/client.py
@@ -417,6 +417,7 @@ class SignetClient:
         hints: Optional[List[str]] = None,
         transcript: str = "",
         structured: Optional[Dict[str, Any]] = None,
+        review_after: str = "",
         who: str = "hermes-agent",
     ) -> Optional[Dict[str, Any]]:
         """Store a memory via the daemon API."""
@@ -445,6 +446,8 @@ class SignetClient:
             body["transcript"] = transcript
         if structured:
             body["structured"] = structured
+        if review_after:
+            body["reviewAfter"] = review_after
         return self._post("/api/memory/remember", body, timeout=_LONG_TIMEOUT_SECS)
 
     def recall(

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -1336,6 +1336,7 @@ for vector in contract["vectors"]:
 		expect(plugin).toContain('"required": ["content", "hints"]');
 		expect(plugin).toContain('"minItems": 1');
 		expect(plugin).toContain('"transcript"');
+		expect(plugin).toContain('"review_after"');
 		expect(plugin).toContain('"structured"');
 		expect(plugin).toContain('"entityName"');
 		expect(plugin).toContain('"attributes"');
@@ -1344,10 +1345,13 @@ for vector in contract["vectors"]:
 		expect(plugin).toContain("Missing required parameter: hints");
 		expect(plugin).toContain('transcript=str(store_args.get("transcript", "") or "")');
 		expect(plugin).toContain("structured=structured");
+		expect(plugin).toContain('review_after=str(store_args.get("review_after", "") or "")');
 		expect(client).toContain("hints: Optional[List[str]] = None");
+		expect(client).toContain('review_after: str = ""');
 		expect(client).toContain('body["hints"] = hints');
 		expect(client).toContain('body["transcript"] = transcript');
 		expect(client).toContain('body["structured"] = structured');
+		expect(client).toContain('body["reviewAfter"] = review_after');
 		expect(client).toContain("def _read_json_response");
 		expect(client).toContain("if not body:");
 		expect(client).toContain("TimeoutError, ValueError");

--- a/integrations/openclaw/memory-adapter/src/index.test.ts
+++ b/integrations/openclaw/memory-adapter/src/index.test.ts
@@ -468,6 +468,7 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 		const id = await memoryStore("save this", {
 			daemonUrl: "http://daemon.test",
 			tags: ["alpha", " beta ", ""],
+			reviewAfter: "2026-08-03T00:00:00.000Z",
 		});
 
 		expect(id).toBe("mem-1");
@@ -475,6 +476,7 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 			content: "save this",
 			tags: "alpha,beta",
 			who: "openclaw",
+			reviewAfter: "2026-08-03T00:00:00.000Z",
 		});
 		expect(lastRememberBody).not.toHaveProperty("type");
 		expect(lastRememberBody).not.toHaveProperty("importance");

--- a/integrations/openclaw/memory-adapter/src/index.ts
+++ b/integrations/openclaw/memory-adapter/src/index.ts
@@ -693,6 +693,7 @@ export async function memoryStore(
 		importance?: number;
 		tags?: string | readonly string[];
 		who?: string;
+		reviewAfter?: string;
 	} = {},
 ): Promise<string | null> {
 	const daemonUrl = options.daemonUrl || DEFAULT_DAEMON_URL;
@@ -703,6 +704,7 @@ export async function memoryStore(
 			importance: options.importance,
 			tags: options.tags,
 			who: options.who || "openclaw",
+			reviewAfter: options.reviewAfter,
 		}),
 		timeout: WRITE_TIMEOUT,
 	});
@@ -836,6 +838,7 @@ export async function remember(
 		importance?: number;
 		tags?: string | readonly string[];
 		who?: string;
+		reviewAfter?: string;
 	} = {},
 ): Promise<string | null> {
 	return memoryStore(content, options);

--- a/integrations/opencode/plugin/src/tools.ts
+++ b/integrations/opencode/plugin/src/tools.ts
@@ -90,6 +90,7 @@ async function storeMemory(
 		readonly importance?: number;
 		readonly tags?: readonly string[];
 		readonly pinned?: boolean;
+		readonly review_after?: string;
 	},
 ): Promise<{ readonly offline: true } | { readonly offline: false; readonly id?: string; readonly memoryId?: string }> {
 	const result = await client.post<{ readonly id?: string; readonly memoryId?: string }>(
@@ -99,6 +100,7 @@ async function storeMemory(
 			importance: args.importance,
 			tags: args.tags,
 			pinned: args.pinned,
+			reviewAfter: args.review_after,
 			who: HARNESS,
 		}),
 		WRITE_TIMEOUT,
@@ -140,6 +142,10 @@ export function createTools(client: DaemonClient): Record<string, ReturnType<typ
 				importance: tool.schema.number().optional().describe("Importance score 0-1"),
 				tags: tool.schema.array(tool.schema.string()).optional().describe("Tags for categorization"),
 				pinned: tool.schema.boolean().optional().describe("Pin this memory — prevents decay"),
+				review_after: tool.schema
+					.string()
+					.optional()
+					.describe("ISO timestamp after which this memory should be reviewed"),
 			},
 			async execute(args): Promise<string> {
 				const result = await storeMemory(client, args);
@@ -267,6 +273,10 @@ export function createTools(client: DaemonClient): Record<string, ReturnType<typ
 				importance: tool.schema.number().optional().describe("Importance 0-1"),
 				tags: tool.schema.array(tool.schema.string()).optional().describe("Tags"),
 				pinned: tool.schema.boolean().optional().describe("Pin this memory — prevents decay"),
+				review_after: tool.schema
+					.string()
+					.optional()
+					.describe("ISO timestamp after which this memory should be reviewed"),
 			},
 			async execute(args): Promise<string> {
 				const result = await storeMemory(client, args);

--- a/integrations/pi/extension/index.test.ts
+++ b/integrations/pi/extension/index.test.ts
@@ -402,10 +402,12 @@ describe("rememberContent", () => {
 		await rememberContent(`http://127.0.0.1:${server.port}`, "test memory", {
 			critical: true,
 			tags: ["tag1", "tag2"],
+			reviewAfter: "2026-08-03T00:00:00.000Z",
 		});
 		expect(capturedBody.content).toBe("test memory");
 		expect(capturedBody.pinned).toBe(true);
 		expect(capturedBody.tags).toBe("tag1,tag2");
+		expect(capturedBody.reviewAfter).toBe("2026-08-03T00:00:00.000Z");
 	});
 
 	it("throws when the daemon returns an error status", async () => {

--- a/integrations/pi/extension/src/index.ts
+++ b/integrations/pi/extension/src/index.ts
@@ -165,9 +165,10 @@ export async function rememberContent(
 		critical?: boolean;
 		tags?: string[];
 		agentId?: string;
+		reviewAfter?: string;
 	} = {},
 ): Promise<void> {
-	const { critical = false, tags = [], agentId } = options;
+	const { critical = false, tags = [], agentId, reviewAfter } = options;
 
 	const response = await fetch(`${daemonUrl}/api/hooks/remember`, {
 		method: "POST",
@@ -178,6 +179,7 @@ export async function rememberContent(
 				pinned: critical,
 				tags,
 				agentId,
+				reviewAfter,
 				source: "pi-extension",
 				runtimePath: RUNTIME_PATH,
 			}),

--- a/libs/sdk/src/__tests__/client.test.ts
+++ b/libs/sdk/src/__tests__/client.test.ts
@@ -71,6 +71,7 @@ describe("SignetClient", () => {
 		await client.remember("user prefers dark mode", {
 			type: "preference",
 			importance: 0.9,
+			reviewAfter: "2026-08-03T00:00:00.000Z",
 		});
 
 		const req = lastRequest();
@@ -80,6 +81,7 @@ describe("SignetClient", () => {
 			content: "user prefers dark mode",
 			type: "preference",
 			importance: 0.9,
+			reviewAfter: "2026-08-03T00:00:00.000Z",
 		});
 	});
 

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -136,6 +136,7 @@ export class SignetClient extends SignetClientHelpers {
 			readonly sourceCreatedAt?: string;
 			readonly validFrom?: string;
 			readonly validUntil?: string;
+			readonly reviewAfter?: string;
 			readonly mode?: "auto" | "sync" | "async";
 			readonly idempotencyKey?: string;
 			readonly runtimePath?: string;

--- a/platform/core/src/migrations/106-memory-review-after.ts
+++ b/platform/core/src/migrations/106-memory-review-after.ts
@@ -1,0 +1,29 @@
+import type { MigrationDb } from "./index";
+
+function hasColumn(db: MigrationDb, table: string, column: string): boolean {
+	return (db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>).some(
+		(row) => row.name === column,
+	);
+}
+
+/**
+ * Migration 106: `review_after` on memories for selective temporal-claim expiry.
+ *
+ * Issue #945: temporal claims (e.g. "X is going to Y on March 15th, 2027")
+ * need a way to surface as due for review once the referenced date passes,
+ * without NLP-parsing every memory on every dreaming pass. This adds a
+ * nullable indexed `review_after` (ISO timestamp) column to `memories` so
+ * the dreaming pass can query `WHERE review_after IS NOT NULL AND
+ * review_after < datetime('now')` directly.
+ *
+ * The column is additive and nullable — existing rows are unaffected, and
+ * any store surface that does not set it behaves exactly as before. The
+ * column guard keeps the migration idempotent for tests that re-run the
+ * migration set from a stamped schema.
+ */
+export function up(db: MigrationDb): void {
+	if (!hasColumn(db, "memories", "review_after")) {
+		db.exec(`ALTER TABLE memories ADD COLUMN review_after TEXT;`);
+	}
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_memories_review_after ON memories(review_after);`);
+}

--- a/platform/core/src/migrations/106-memory-review-after.ts
+++ b/platform/core/src/migrations/106-memory-review-after.ts
@@ -23,7 +23,7 @@ function hasColumn(db: MigrationDb, table: string, column: string): boolean {
  */
 export function up(db: MigrationDb): void {
 	if (!hasColumn(db, "memories", "review_after")) {
-		db.exec(`ALTER TABLE memories ADD COLUMN review_after TEXT;`);
+		db.exec("ALTER TABLE memories ADD COLUMN review_after TEXT;");
 	}
-	db.exec(`CREATE INDEX IF NOT EXISTS idx_memories_review_after ON memories(review_after);`);
+	db.exec("CREATE INDEX IF NOT EXISTS idx_memories_review_after ON memories(review_after);");
 }

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -111,6 +111,7 @@ import { up as attributeSemanticMemories } from "./102-attribute-semantic-memori
 import { up as semanticMemoryKind } from "./103-semantic-memory-kind";
 import { up as derivedMemoryProvenance } from "./104-derived-memory-provenance";
 import { up as agentScopedEntityName } from "./105-agent-scoped-entity-name";
+import { up as memoryReviewAfter } from "./106-memory-review-after";
 
 // -- Public interface consumed by Database.init() --
 
@@ -976,6 +977,14 @@ export const MIGRATIONS: readonly Migration[] = [
 		version: 105,
 		name: "agent-scoped-entity-name",
 		up: agentScopedEntityName,
+	},
+	{
+		version: 106,
+		name: "memory-review-after",
+		up: memoryReviewAfter,
+		artifacts: {
+			columns: [{ table: "memories", column: "review_after" }],
+		},
 	},
 ];
 

--- a/platform/core/src/recall.ts
+++ b/platform/core/src/recall.ts
@@ -162,6 +162,8 @@ export interface RememberRequestOptions {
 	readonly validFrom?: string;
 	readonly validUntil?: string;
 	readonly sourceCreatedAt?: string;
+	/** ISO timestamp; due-for-review marker for temporal claims (#945). */
+	readonly reviewAfter?: string;
 	readonly hints?: readonly string[];
 	readonly transcript?: string;
 	readonly structured?: unknown;
@@ -461,6 +463,7 @@ export function buildRememberRequestBody(
 		validFrom: options.validFrom,
 		validUntil: options.validUntil,
 		sourceCreatedAt: options.sourceCreatedAt,
+		reviewAfter: options.reviewAfter,
 		hints: options.hints,
 		transcript: options.transcript,
 		structured: normalizeStructuredMemoryPayload(options.structured),

--- a/platform/daemon/src/mcp/tools.ts
+++ b/platform/daemon/src/mcp/tools.ts
@@ -16,8 +16,8 @@ import {
 } from "@signet/core";
 import { z } from "zod";
 import { getActiveGraphiqDbPath, runGraphiqCli } from "../graphiq.js";
-import { createDefaultPluginHost } from "../plugins/index.js";
 import { DREAMING_ONTOLOGY_OPERATION_SCHEMA } from "../pipeline/dreaming-operation-contract.js";
+import { createDefaultPluginHost } from "../plugins/index.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -629,7 +629,8 @@ export async function refreshMarketplaceProxyTools(
 
 		nextNames.add(proxyName);
 
-		registerMcpTool(server,
+		registerMcpTool(
+			server,
 			proxyName,
 			{
 				title,
@@ -779,7 +780,8 @@ function registerGraphiqCompatAliases(server: McpServer, pluginHostProvider: Gra
 	];
 
 	for (const def of compatDefs) {
-		registerMcpTool(server,
+		registerMcpTool(
+			server,
 			def.alias,
 			{
 				title: `[deprecated: use ${def.canonical}]`,
@@ -837,7 +839,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	// memory_search — hybrid vector + keyword search
 	// ------------------------------------------------------------------
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"memory_search",
 		{
 			title: "Search Memories",
@@ -933,7 +936,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"signet_recall",
 		{
 			title: "Signet Recall",
@@ -1015,7 +1019,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"signet_source_search",
 		{
 			title: "Signet Source Search",
@@ -1053,7 +1058,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	// memory_store — save a new memory
 	// ------------------------------------------------------------------
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"memory_store",
 		{
 			title: "Store Memory",
@@ -1080,6 +1086,10 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 				sourceCreatedAt: z.string().optional().describe("Source-system creation time for this memory"),
 				validFrom: z.string().optional().describe("Start of validity window for this memory"),
 				validUntil: z.string().optional().describe("End of validity window for this memory"),
+				reviewAfter: z
+					.string()
+					.optional()
+					.describe("ISO timestamp when this temporal claim becomes due for review (issue #945)"),
 				transcript: z
 					.string()
 					.optional()
@@ -1159,6 +1169,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			sourceCreatedAt,
 			validFrom,
 			validUntil,
+			reviewAfter,
 		}) => {
 			const result = await fetchDaemon<unknown>(baseUrl, "/api/memory/remember", {
 				method: "POST",
@@ -1176,6 +1187,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					sourceCreatedAt,
 					validFrom,
 					validUntil,
+					reviewAfter,
 				}),
 			});
 
@@ -1186,7 +1198,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"signet_save_note",
 		{
 			title: "Save Codex Memory Note",
@@ -1213,7 +1226,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	// memory_get — retrieve a memory by ID
 	// ------------------------------------------------------------------
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"memory_get",
 		{
 			title: "Get Memory",
@@ -1235,7 +1249,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	// memory_list — list memories with optional filters
 	// ------------------------------------------------------------------
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"memory_list",
 		{
 			title: "List Memories",
@@ -1266,7 +1281,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	// memory_modify — edit an existing memory
 	// ------------------------------------------------------------------
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"memory_modify",
 		{
 			title: "Modify Memory",
@@ -1305,7 +1321,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	// memory_forget — soft-delete a memory
 	// ------------------------------------------------------------------
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"memory_forget",
 		{
 			title: "Forget Memory",
@@ -1332,7 +1349,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	// memory_feedback — rate relevance of injected memories
 	// ------------------------------------------------------------------
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"memory_feedback",
 		{
 			title: "Rate Memory Relevance",
@@ -1390,7 +1408,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	// agent_peers — list active peer sessions
 	// ------------------------------------------------------------------
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"agent_peers",
 		{
 			title: "List Peer Sessions",
@@ -1427,7 +1446,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	// agent_message_send — send message to another agent/session
 	// ------------------------------------------------------------------
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"agent_message_send",
 		{
 			title: "Send Agent Message",
@@ -1496,7 +1516,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	// agent_message_inbox — read recent inbound messages
 	// ------------------------------------------------------------------
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"agent_message_inbox",
 		{
 			title: "Read Agent Inbox",
@@ -1537,7 +1558,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	// secret_list — list available secret names
 	// ------------------------------------------------------------------
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"secret_list",
 		{
 			title: "List Secrets",
@@ -1557,7 +1579,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	// secret_exec — run a command with secrets injected as env vars
 	// ------------------------------------------------------------------
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"secret_exec",
 		{
 			title: "Execute with Secrets",
@@ -1609,7 +1632,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"secret_exec_status",
 		{
 			title: "Secret Exec Status",
@@ -1652,7 +1676,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 
 	const contextPath = (path: string): string => appendMarketplaceContext(path, proxyState.context);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"mcp_server_list",
 		{
 			title: "List Tool Servers",
@@ -1682,7 +1707,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"mcp_server_search",
 		{
 			title: "Search Tool Servers",
@@ -1740,7 +1766,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"mcp_server_enable",
 		{
 			title: "Enable Tool Server",
@@ -1770,7 +1797,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"mcp_server_disable",
 		{
 			title: "Disable Tool Server",
@@ -1800,7 +1828,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"mcp_server_scope_get",
 		{
 			title: "Get Tool Server Scope",
@@ -1832,7 +1861,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"mcp_server_scope_set",
 		{
 			title: "Set Tool Server Scope",
@@ -1870,7 +1900,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"mcp_server_policy_get",
 		{
 			title: "Get MCP Exposure Policy",
@@ -1886,7 +1917,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"mcp_server_policy_set",
 		{
 			title: "Set MCP Exposure Policy",
@@ -1924,7 +1956,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	// mcp_server_call — call a routed marketplace MCP tool
 	// ------------------------------------------------------------------
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"mcp_server_call",
 		{
 			title: "Call Tool Server",
@@ -1969,7 +2002,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"session_bypass",
 		{
 			title: "Toggle Session Bypass",
@@ -2000,7 +2034,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	// knowledge_expand — drill deeper into a knowledge graph entity
 	// ------------------------------------------------------------------
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"knowledge_expand",
 		{
 			title: "Expand Entity",
@@ -2169,7 +2204,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		return fetchNavigation("/api/knowledge/hygiene", params, "Knowledge hygiene report");
 	};
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"knowledge_tree",
 		{
 			title: "Knowledge Tree",
@@ -2184,7 +2220,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		knowledgeTree,
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"knowledge_list_entities",
 		{
 			title: "Knowledge: List Entities",
@@ -2197,7 +2234,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		listEntities,
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"knowledge_get_entity",
 		{
 			title: "Knowledge: Get Entity",
@@ -2210,7 +2248,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		getEntity,
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"knowledge_list_aspects",
 		{
 			title: "Knowledge: List Aspects",
@@ -2223,7 +2262,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		listAspects,
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"knowledge_list_groups",
 		{
 			title: "Knowledge: List Groups",
@@ -2236,7 +2276,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		listGroups,
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"knowledge_list_claims",
 		{
 			title: "Knowledge: List Claims",
@@ -2249,7 +2290,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		listClaims,
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"knowledge_list_attributes",
 		{
 			title: "Knowledge: List Attributes",
@@ -2262,7 +2304,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		listAttributes,
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"knowledge_hygiene_report",
 		{
 			title: "Knowledge Hygiene Report",
@@ -2279,7 +2322,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// The daemon validates every citation against scoped episodic evidence and
 	// applies each item through the audited Dreaming operation seam. ACPX gets
 	// this over stdio MCP; it never receives a SQLite handle.
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"apply_ontology_ops",
 		{
 			title: "Apply Dreaming ontology operations",
@@ -2300,7 +2344,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"entity_list",
 		{
 			title: "List Entities",
@@ -2311,7 +2356,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		listEntities,
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"entity_get",
 		{
 			title: "Get Entity",
@@ -2322,7 +2368,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		getEntity,
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"entity_aspects",
 		{
 			title: "List Entity Aspects",
@@ -2333,7 +2380,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		listAspects,
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"entity_groups",
 		{
 			title: "List Entity Groups",
@@ -2344,7 +2392,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		listGroups,
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"entity_claims",
 		{
 			title: "List Entity Claims",
@@ -2355,7 +2404,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		listClaims,
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"entity_attributes",
 		{
 			title: "List Entity Attributes",
@@ -2369,7 +2419,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	// knowledge_expand_session — temporal drill-down via session DAG
 	// ------------------------------------------------------------------
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"knowledge_expand_session",
 		{
 			title: "Expand Entity Sessions",
@@ -2402,7 +2453,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"lcm_expand",
 		{
 			title: "Expand Temporal Node",
@@ -2433,7 +2485,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"session_search",
 		{
 			title: "Search Session Transcripts",
@@ -2472,7 +2525,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"signet_session_search",
 		{
 			title: "Signet Session Search",
@@ -2510,7 +2564,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"signet_code_search",
 		{
 			title: "Search Code",
@@ -2543,7 +2598,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"signet_code_context",
 		{
 			title: "Code Context",
@@ -2564,7 +2620,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"signet_code_blast",
 		{
 			title: "Code Blast Radius",
@@ -2590,7 +2647,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"signet_code_status",
 		{
 			title: "Code Index Status",
@@ -2600,7 +2658,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		async () => graphIqToolResult(["status"], "Code status failed", "signet_code_status", pluginHostProvider),
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"signet_code_doctor",
 		{
 			title: "Code Index Doctor",
@@ -2610,7 +2669,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		async () => graphIqToolResult(["doctor"], "Code doctor failed", "signet_code_doctor", pluginHostProvider),
 	);
 
-	registerMcpTool(server,
+	registerMcpTool(
+		server,
 		"signet_code_constants",
 		{
 			title: "Code Constants",

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -388,6 +388,16 @@ function readString(record: Readonly<Record<string, unknown>>, key: string): str
 	return trimmed.length > 0 ? trimmed : null;
 }
 
+function readReviewAfter(payload: Readonly<Record<string, unknown>>): string | null {
+	const value = readString(payload, "review_after");
+	if (value === null) return null;
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) {
+		throw new OntologyProposalError("payload.review_after must be a valid ISO timestamp", 400);
+	}
+	return parsed.toISOString();
+}
+
 function readNumber(record: Readonly<Record<string, unknown>>, key: string): number | null {
 	const value = record[key];
 	return typeof value === "number" && Number.isFinite(value) ? value : null;
@@ -806,6 +816,7 @@ function materializeAttributeMemoryInTx(
 		readonly content: string;
 		readonly normalizedContent: string;
 		readonly importance: number;
+		readonly reviewAfter: string | null;
 		readonly proposal: ProposalRow;
 	},
 ): string {
@@ -835,6 +846,7 @@ function materializeAttributeMemoryInTx(
 			sourcePath: input.proposal.source_path,
 			agentId: input.agentId,
 			visibility: "global",
+			reviewAfter: input.reviewAfter,
 			createdAt: now(),
 		});
 	}
@@ -973,6 +985,7 @@ function applyAddClaimValue(
 	const id = crypto.randomUUID();
 	const confidence = clamp01(readNumber(payload, "confidence") ?? proposal.confidence);
 	const importance = clamp01(readNumber(payload, "importance") ?? confidence);
+	const reviewAfter = readReviewAfter(payload);
 	const proposalEvidence = proposalAuditEvidence(proposal);
 	db.prepare(
 		`INSERT INTO entity_attributes
@@ -1010,6 +1023,7 @@ function applyAddClaimValue(
 		content: value,
 		normalizedContent: normalized,
 		importance,
+		reviewAfter,
 		proposal,
 	});
 	return { entityId, aspectId, attributeId: id, memoryId, deduped: false };
@@ -1078,6 +1092,7 @@ function applySetClaimValue(
 	const id = version === 1 ? rootId : crypto.randomUUID();
 	const confidence = clamp01(readNumber(payload, "confidence") ?? proposal.confidence);
 	const importance = clamp01(readNumber(payload, "importance") ?? confidence);
+	const reviewAfter = readReviewAfter(payload);
 	db.prepare(
 		`INSERT INTO entity_attributes
 		 (id, aspect_id, agent_id, kind, content, normalized_content,
@@ -1115,6 +1130,7 @@ function applySetClaimValue(
 		content: value,
 		normalizedContent: normalized,
 		importance,
+		reviewAfter,
 		proposal,
 	});
 

--- a/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
@@ -36,6 +36,7 @@ describe("dreaming-agent-tools", () => {
 		content: string,
 		agentId: string,
 		aspectName = "configuration",
+		memoryId: string | null = null,
 	): void {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
@@ -45,21 +46,34 @@ describe("dreaming-agent-tools", () => {
 			).run(aspectId, entityId, agentId, aspectName, aspectName.toLowerCase());
 			db.prepare(
 				`INSERT INTO entity_attributes
-				 (id, aspect_id, agent_id, kind, content, normalized_content,
+				 (id, aspect_id, agent_id, memory_id, kind, content, normalized_content,
 				  confidence, importance, status, group_key, claim_key,
 				  version, version_root_id, created_at, updated_at)
-				 VALUES (?, ?, ?, 'attribute', ?, ?, 0.8, 0.5, 'active', 'configuration', 'default', 1, ?, datetime('now'), datetime('now'))`,
-			).run(`${aspectId}-attribute`, aspectId, agentId, content, content.toLowerCase(), `${aspectId}-attribute`);
+				 VALUES (?, ?, ?, ?, 'attribute', ?, ?, 0.8, 0.5, 'active', 'configuration', 'default', 1, ?, datetime('now'), datetime('now'))`,
+			).run(
+				`${aspectId}-attribute`,
+				aspectId,
+				agentId,
+				memoryId,
+				content,
+				content.toLowerCase(),
+				`${aspectId}-attribute`,
+			);
 		});
 	}
 
-	function insertEpisodicMemory(id: string, content: string, agentId = "owner"): void {
+	function insertEpisodicMemory(
+		id: string,
+		content: string,
+		agentId = "owner",
+		reviewAfter: string | null = null,
+	): void {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				`INSERT INTO memories
-				 (id, content, source_type, memory_kind, visibility, agent_id, created_at, updated_at)
-				 VALUES (?, ?, 'manual', 'episodic', 'normal', ?, datetime('now'), datetime('now'))`,
-			).run(id, content, agentId);
+				 (id, content, source_type, memory_kind, visibility, agent_id, review_after, created_at, updated_at)
+				 VALUES (?, ?, 'manual', 'episodic', 'normal', ?, ?, datetime('now'), datetime('now'))`,
+			).run(id, content, agentId, reviewAfter);
 		});
 	}
 
@@ -418,6 +432,36 @@ describe("dreaming-agent-tools", () => {
 		const items = pending.items as Array<{ subjectRef: string; kind: string }>;
 		expect(items).toHaveLength(1);
 		expect(items[0]).toMatchObject({ subjectRef: "entity:e-husk", kind: "hygiene" });
+	});
+
+	it("attention_list exposes scoped expired and approaching temporal claims", async () => {
+		const expiredAt = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+		const approachingAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+		insertEntity("e-trip", "Trip", "trip", "owner");
+		insertEpisodicMemory("mem-expired", "Trip was planned for yesterday.", "owner", expiredAt);
+		insertEpisodicMemory("mem-approaching", "Trip is planned for tomorrow.", "owner", approachingAt);
+		insertEpisodicMemory("mem-intruder", "Other agent's expired plan.", "intruder", expiredAt);
+		insertActiveAttribute("e-trip", "a-trip", "Trip was planned for yesterday.", "owner", "plans", "mem-expired");
+		const tools = createDreamingAgentTools({ accessor: getDbAccessor(), agentId: "owner", actor: "owner" });
+
+		const result = readResult(
+			await findTool(tools, "attention_list").execute(
+				"call",
+				{ agentId: "owner", kind: "review_due", status: "pending" },
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		expect(result.ok).toBe(true);
+		const items = result.items as Array<{
+			agentId: string;
+			details: { phase: string; attributeId: string | null };
+			subjectRef: string;
+		}>;
+		expect(items.map((item) => item.details.phase)).toEqual(["expired", "approaching"]);
+		expect(items.every((item) => item.agentId === "owner")).toBe(true);
+		expect(items[0]).toMatchObject({ subjectRef: "memory:mem-expired", details: { attributeId: "a-trip-attribute" } });
 	});
 
 	it("flags and archives a junk entity in one apply batch", async () => {

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -34,6 +34,7 @@ import {
 	applyDreamingOperations,
 } from "./dreaming-operations";
 import { readDreamingRunbook, writeDreamingRunbook } from "./dreaming-runbook";
+import { collectReviewDueClaims } from "./memory-review-due";
 
 const bounded = (value: number | undefined, fallback: number, max: number): number =>
 	Math.min(Math.max(Math.floor(value ?? fallback), 1), max);
@@ -530,7 +531,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"attention_list",
 			"List attention",
-			"List attention records (the hygiene queue) by kind and resolution status. Omit agentId to see the whole install's queue (each record carries its owning agentId); pass agentId to narrow to one scope.",
+			"List attention records by kind and resolution status. Use kind hygiene for the queue, or review_due for expired and approaching temporal claims. Omit agentId to see the whole install; pass agentId to narrow to one scope.",
 			true,
 			z.object({
 				agentId: z.string().optional(),
@@ -538,21 +539,58 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 				status: z.enum(["pending", "resolved"]).optional(),
 				limit: z.number().finite().optional(),
 			}),
-			async ({ agentId: scopeId, kind, status, limit }) => ({
-				ok: true,
-				items:
-					scopeId !== undefined
-						? getDreamingAttentionScoped(accessor, scopeId, {
-								kind,
-								status: status ?? "pending",
-								limit: bounded(limit, 20, 100),
-							})
-						: getDreamingAttentionAcrossScopes(accessor, {
-								kind,
-								status: status ?? "pending",
-								limit: bounded(limit, 50, 200),
-							}),
-			}),
+			async ({ agentId: scopeId, kind, status, limit }) => {
+				if (kind === "review_due") {
+					if (status === "resolved") return { ok: true, items: [] };
+					const due = accessor.withReadDb((db) =>
+						collectReviewDueClaims(
+							{ all: <T>(sql: string, ...params: unknown[]) => db.prepare(sql).all(...params) as T[] },
+							new Date(),
+							{ agentId: scopeId, limit: bounded(limit, scopeId ? 50 : 100, scopeId ? 100 : 200) },
+						),
+					);
+					return {
+						ok: true,
+						items: [
+							...due.expired.map((item) => ({
+								id: item.id,
+								kind: "review_due",
+								status: "pending",
+								subjectRef: `memory:${item.id}`,
+								details: { phase: "expired", ...item },
+								priority: "high",
+								createdAt: item.createdAt,
+								agentId: item.agentId,
+							})),
+							...due.approaching.map((item) => ({
+								id: item.id,
+								kind: "review_due",
+								status: "pending",
+								subjectRef: `memory:${item.id}`,
+								details: { phase: "approaching", ...item },
+								priority: "normal",
+								createdAt: item.createdAt,
+								agentId: item.agentId,
+							})),
+						],
+					};
+				}
+				return {
+					ok: true,
+					items:
+						scopeId !== undefined
+							? getDreamingAttentionScoped(accessor, scopeId, {
+									kind,
+									status: status ?? "pending",
+									limit: bounded(limit, 20, 100),
+								})
+							: getDreamingAttentionAcrossScopes(accessor, {
+									kind,
+									status: status ?? "pending",
+									limit: bounded(limit, 50, 200),
+								}),
+				};
+			},
 		),
 		capability(
 			"apply_ontology_ops",

--- a/platform/daemon/src/pipeline/dreaming-operation-contract.ts
+++ b/platform/daemon/src/pipeline/dreaming-operation-contract.ts
@@ -25,6 +25,9 @@ const aspectName = text.describe("The specific domain of knowledge this claim be
 const aspectId = text.describe("The stable id of an existing aspect.");
 const claimValue = text.describe("A complete atomic assertion that is understandable on its own.");
 const claimKey = text.describe("A stable semantic slot key for versions of the same claim.");
+const reviewAfter = text
+	.describe("An ISO timestamp after which a future temporal claim must be reviewed. Omit for non-temporal claims.")
+	.optional();
 const linkType = z.enum(DEPENDENCY_TYPES).describe("The dependency type between the two entities.");
 
 function payload<T extends z.ZodRawShape>(shape: T) {
@@ -59,8 +62,8 @@ export const DREAMING_ONTOLOGY_PAYLOAD_SCHEMAS = {
 
 	// --- content-bearing ops: require evidence with exact quotes ---
 	create_entity: payload({ name: entityName, type: entityType }),
-	add_claim_value: payload({ entityId, aspectId, claimKey, value: claimValue }),
-	set_claim_value: payload({ entityId, aspectId, claimKey, value: claimValue }),
+	add_claim_value: payload({ entityId, aspectId, claimKey, value: claimValue, reviewAfter }),
+	set_claim_value: payload({ entityId, aspectId, claimKey, value: claimValue, reviewAfter }),
 	supersede_claim_value: payload({
 		entityId,
 		aspectId,

--- a/platform/daemon/src/pipeline/dreaming-operations.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.test.ts
@@ -39,13 +39,18 @@ describe("dreaming operations", () => {
 		});
 	}
 
-	function insertEpisodicMemory(id: string, content: string, agentId = "agent-a"): void {
+	function insertEpisodicMemory(
+		id: string,
+		content: string,
+		agentId = "agent-a",
+		reviewAfter: string | null = null,
+	): void {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				`INSERT INTO memories
-				 (id, content, source_type, memory_kind, visibility, agent_id, created_at, updated_at)
-				 VALUES (?, ?, 'manual', 'episodic', 'normal', ?, datetime('now'), datetime('now'))`,
-			).run(id, content, agentId);
+				 (id, content, source_type, memory_kind, visibility, agent_id, review_after, created_at, updated_at)
+				 VALUES (?, ?, 'manual', 'episodic', 'normal', ?, ?, datetime('now'), datetime('now'))`,
+			).run(id, content, agentId, reviewAfter);
 		});
 	}
 
@@ -292,6 +297,50 @@ describe("dreaming operations", () => {
 		});
 		expect(result.ok).toBe(false);
 		expect(result.error).toBe("Every operation must cite an exact quote from scoped episodic evidence");
+	});
+
+	it("stores review_after on a semantic memory for a future temporal claim", () => {
+		insertEntity("e-acme", "Acme", "acme");
+		insertAspect("a-main", "e-acme", "general");
+		insertEpisodicMemory("mem-temporal", "Acme plans to travel on 2026-08-03.");
+		const result = applyDreamingOperations({
+			accessor: getDbAccessor(),
+			agentId: "agent-a",
+			actor: "dreaming",
+			operations: [
+				{
+					operation: "set_claim_value",
+					payload: {
+						entityId: "e-acme",
+						aspectId: "a-main",
+						claimKey: "travel_plan",
+						value: "Acme plans to travel on 2026-08-03.",
+						reviewAfter: "2026-08-03T00:00:00-06:00",
+					},
+					evidence: [
+						{
+							source_ref: "memory:mem-temporal",
+							source_kind: "manual",
+							source_id: "mem-temporal",
+							quote: "Acme plans to travel on 2026-08-03.",
+						},
+					],
+				},
+			],
+		});
+		expect(result.ok).toBe(true);
+		const row = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare(
+						`SELECT m.review_after
+						   FROM memories m
+						   JOIN entity_attributes ea ON ea.memory_id = m.id
+						  WHERE ea.agent_id = ? AND ea.claim_key = ?`,
+					)
+					.get("agent-a", "travel_plan") as { review_after: string },
+		);
+		expect(row.review_after).toBe("2026-08-03T06:00:00.000Z");
 	});
 
 	it("supersedes the current active claim for a key without an explicit attribute id", () => {

--- a/platform/daemon/src/pipeline/dreaming-operations.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.ts
@@ -401,7 +401,15 @@ function toApplicatorPayload(
 			if (entityId === null || aspectId === null || claimKey === null || value === null) return null;
 			const name = lookupEntityName(accessor, agentId, entityId);
 			const aspect = lookupAspectName(accessor, agentId, entityId, aspectId);
-			return name === null || aspect === null ? null : { entity: name, aspect, claim_key: claimKey, value };
+			return name === null || aspect === null
+				? null
+				: {
+						entity: name,
+						aspect,
+						claim_key: claimKey,
+						value,
+						...(stringField(payload, "reviewAfter") ? { review_after: stringField(payload, "reviewAfter") } : {}),
+					};
 		}
 		case "supersede_claim_value": {
 			const entityId = stringField(payload, "entityId");

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -630,20 +630,22 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - Inspect the flagged target (get_entity — check aspects, claims, pinned).
    - Archive or merge it, citing its attention id (provenance: "attention:<uuid>", or attention:$<index> for a flag you minted in the same batch).
    - If you discover junk the queue did not flag, mint a flag op and archive in the same batch.
-3. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
+3. Query attention_list with kind=review_due. For expired records, inspect the cited memory with search_evidence using its subjectRef, then supersede the matching active claim with supersede_claim_value. Use the supplied entityId, aspectId, attributeId, and claimKey when present. The replacement must state that the planned event remains unconfirmed; never rewrite it as if the event happened. Cite an exact quote from the original memory. Do not supersede approaching records. When creating or setting a future temporal claim, set payload.reviewAfter to the referenced ISO timestamp.
+4. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
    - search_entities for subjects it establishes.
    - File claims only for what the source establishes as settled fact: outcomes, decisions, shipped changes, stable behavior. Do not file instructions that were merely suggested, hypotheses or diagnoses, open questions, or intermediate states of an ongoing investigation. When a source shows an attempt and its outcome, file the outcome.
    - Before adding a claim, check the target aspect's existing claims; if one covers the same key or is contradicted by the new evidence, supersede it (supersede_claim_value) instead of adding alongside.
    - The evidence source and the graph target must use the same agent scope: search evidence with the agentId of the entity you will update, then pass that same agentId to apply_ontology_ops. A source found in another scope cannot support a write here.
    - create_entity only for durable subjects clearly established by the source.
    - Validate before writing (validate_proposal).
-4. Write the pass log (runbook_write): what changed, which sources were viewed, anything deferred with exact names.
+5. Write the pass log (runbook_write): what changed, which sources were viewed, anything deferred with exact names.
 
 ### Safe
 
 - Archive attention-flagged entities that are non-concrete (zero active aspects/claims, non-concrete type, legacy-only deps).
 - Merge exact-canonical duplicates (same canonical name, same scope).
 - Add/set/supersede claims with exact quotes from an episodic source.
+- Set reviewAfter when adding or setting a future temporal claim; supersede expired claims as unconfirmed rather than asserting that the event occurred.
 - Create entities for durable subjects the source clearly establishes.
 - Rename/update entities only with evidence.
 
@@ -660,6 +662,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 
 - Every write in the batch has valid provenance.
 - Hygiene queue is drained, or remaining records are explicitly deferred with reasons in the pass log.
+- Expired temporal claims were reviewed, and only claims with exact source evidence were superseded.
 - Pass log written with sources viewed + changes applied (this is the next pass's dedup).
 - No flag left unresolved for a target you archived.
 - No writes attempted against pinned or source-root entities.
@@ -739,18 +742,20 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 ### Per-pass process
 
 1. Read the pass log (runbook_read). Establish cutoff: sources viewed, changes applied, deferred items.
-2. Find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
+2. Query attention_list with kind=review_due. For expired records, inspect the cited memory with search_evidence using its subjectRef, then supersede the matching active claim with supersede_claim_value. Use the supplied entityId, aspectId, attributeId, and claimKey when present. The replacement must state that the planned event remains unconfirmed; never rewrite it as if the event happened. Cite an exact quote from the original memory. Do not supersede approaching records. When creating or setting a future temporal claim, set payload.reviewAfter to the referenced ISO timestamp.
+3. Find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
    - search_entities for subjects it establishes.
    - File claims only for what the source establishes as settled fact: outcomes, decisions, shipped changes, stable behavior. Do not file instructions that were merely suggested, hypotheses or diagnoses, open questions, or intermediate states of an ongoing investigation. When a source shows an attempt and its outcome, file the outcome.
    - Before adding a claim, check the target aspect's existing claims; if one covers the same key or is contradicted by the new evidence, supersede it (supersede_claim_value) instead of adding alongside.
    - The evidence source and the graph target must use the same agent scope: search evidence with the agentId of the entity you will update, then pass that same agentId to apply_ontology_ops. A source found in another scope cannot support a write here.
    - create_entity only for durable subjects clearly established by the source.
    - Validate before writing (validate_proposal).
-3. Write the pass log (runbook_write): what changed, which sources were viewed, anything deferred with exact names.
+4. Write the pass log (runbook_write): what changed, which sources were viewed, anything deferred with exact names.
 
 ### Safe
 
 - Add/set/supersede claims with exact quotes from an episodic source.
+- Set reviewAfter when adding or setting a future temporal claim; supersede expired claims as unconfirmed rather than asserting that the event occurred.
 - Create entities for durable subjects the source clearly establishes.
 - Rename/update entities only with evidence.
 
@@ -765,6 +770,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 ### Verification (before finishing)
 
 - Every write in the batch cites an exact quote from episodic evidence in the same agent scope as the graph target.
+- Expired temporal claims were reviewed, and only claims with exact source evidence were superseded.
 - Pass log written with sources viewed + changes applied (this is the next pass's dedup).
 - No claims without exact quotes, no relationships the source does not state.
 - No writes attempted against pinned or source-root entities.

--- a/platform/daemon/src/pipeline/memory-review-due.test.ts
+++ b/platform/daemon/src/pipeline/memory-review-due.test.ts
@@ -119,4 +119,12 @@ describe("collectReviewDueClaims", () => {
 		expect(result.expired.map((r) => r.id)).toEqual(["expired"]);
 		expect(result.approaching.map((r) => r.id)).toEqual(["approaching"]);
 	});
+
+	it("bounds the combined expired and approaching result by limit", () => {
+		const accessor = new FakeAccessor();
+		accessor.rows = [memory("expired", "2026-03-15T00:00:00.000Z"), memory("approaching", "2026-08-03T00:00:00.000Z")];
+		const result = collectReviewDueClaims(accessor, new Date(NOW), { limit: 1 });
+		expect(result.expired.map((r) => r.id)).toEqual(["expired"]);
+		expect(result.approaching).toEqual([]);
+	});
 });

--- a/platform/daemon/src/pipeline/memory-review-due.test.ts
+++ b/platform/daemon/src/pipeline/memory-review-due.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type ReviewDueAccessor,
+	collectReviewDueClaims,
+	findApproachingReviewDueMemories,
+	findExpiredReviewDueMemories,
+} from "./memory-review-due";
+
+interface Row {
+	readonly id: string;
+	readonly content: string;
+	readonly type: string;
+	readonly importance: number;
+	readonly review_after: string;
+	readonly created_at: string;
+	readonly agent_id: string;
+	readonly scope: string | null;
+	readonly is_deleted: number;
+}
+
+function memory(id: string, reviewAfter: string, isDeleted = 0): Row {
+	return {
+		id,
+		content: `claim ${id}`,
+		type: "fact",
+		importance: 0.7,
+		review_after: reviewAfter,
+		created_at: "2026-01-01T00:00:00.000Z",
+		agent_id: "default",
+		scope: null,
+		is_deleted: isDeleted,
+	};
+}
+
+class FakeAccessor implements ReviewDueAccessor {
+	rows: Row[] = [];
+	sqls: string[] = [];
+
+	all<T>(sql: string, ...params: unknown[]): T[] {
+		this.sqls.push(sql);
+		const now = String(params[0]);
+		const limit = Number(params[params.length - 1]);
+		// Minimal emulation of the SQL semantics for the two query shapes.
+		if (sql.includes("review_after < ?")) {
+			return this.rows
+				.filter((r) => r.review_after < now && r.is_deleted === 0)
+				.sort((a, b) => a.review_after.localeCompare(b.review_after))
+				.slice(0, limit) as unknown as T[];
+		}
+		const horizon = String(params[1]);
+		return this.rows
+			.filter((r) => r.review_after >= now && r.review_after <= horizon && r.is_deleted === 0)
+			.sort((a, b) => a.review_after.localeCompare(b.review_after))
+			.slice(0, limit) as unknown as T[];
+	}
+}
+
+const NOW = "2026-08-01T00:00:00.000Z";
+
+describe("findExpiredReviewDueMemories", () => {
+	it("returns claims whose review_after has passed, oldest first", () => {
+		const accessor = new FakeAccessor();
+		accessor.rows = [
+			memory("expired-old", "2026-03-15T00:00:00.000Z"),
+			memory("future", "2026-09-15T00:00:00.000Z"),
+			memory("expired-recent", "2026-07-20T00:00:00.000Z"),
+		];
+		const result = findExpiredReviewDueMemories(accessor, new Date(NOW));
+		expect(result.map((r) => r.id)).toEqual(["expired-old", "expired-recent"]);
+		expect(result[0]).toMatchObject({ reviewAfter: "2026-03-15T00:00:00.000Z" });
+	});
+
+	it("excludes soft-deleted memories", () => {
+		const accessor = new FakeAccessor();
+		accessor.rows = [memory("deleted", "2026-01-01T00:00:00.000Z", 1), memory("live", "2026-01-02T00:00:00.000Z")];
+		expect(findExpiredReviewDueMemories(accessor, new Date(NOW)).map((r) => r.id)).toEqual(["live"]);
+	});
+
+	it("returns nothing when no claim has expired", () => {
+		const accessor = new FakeAccessor();
+		accessor.rows = [memory("future", "2026-09-15T00:00:00.000Z")];
+		expect(findExpiredReviewDueMemories(accessor, new Date(NOW))).toEqual([]);
+	});
+});
+
+describe("findApproachingReviewDueMemories", () => {
+	it("returns claims within the look-ahead window", () => {
+		const accessor = new FakeAccessor();
+		accessor.rows = [
+			memory("in-window", "2026-08-03T00:00:00.000Z"),
+			memory("far-future", "2026-12-01T00:00:00.000Z"),
+			memory("already-expired", "2026-07-01T00:00:00.000Z"),
+		];
+		const result = findApproachingReviewDueMemories(accessor, new Date(NOW), {
+			expiringSoonMs: 7 * 24 * 60 * 60 * 1000,
+		});
+		expect(result.map((r) => r.id)).toEqual(["in-window"]);
+	});
+
+	it("honors a custom look-ahead window", () => {
+		const accessor = new FakeAccessor();
+		accessor.rows = [memory("in-30d", "2026-08-20T00:00:00.000Z")];
+		const result = findApproachingReviewDueMemories(accessor, new Date(NOW), {
+			expiringSoonMs: 30 * 24 * 60 * 60 * 1000,
+		});
+		expect(result.map((r) => r.id)).toEqual(["in-30d"]);
+	});
+});
+
+describe("collectReviewDueClaims", () => {
+	it("returns expired and approaching claims together", () => {
+		const accessor = new FakeAccessor();
+		accessor.rows = [
+			memory("expired", "2026-03-15T00:00:00.000Z"),
+			memory("approaching", "2026-08-03T00:00:00.000Z"),
+			memory("far", "2026-12-01T00:00:00.000Z"),
+		];
+		const result = collectReviewDueClaims(accessor, new Date(NOW));
+		expect(result.expired.map((r) => r.id)).toEqual(["expired"]);
+		expect(result.approaching.map((r) => r.id)).toEqual(["approaching"]);
+	});
+});

--- a/platform/daemon/src/pipeline/memory-review-due.ts
+++ b/platform/daemon/src/pipeline/memory-review-due.ts
@@ -163,11 +163,16 @@ export function findApproachingReviewDueMemories(
  */
 export function collectReviewDueClaims(
 	accessor: ReviewDueAccessor,
-	now = new Date(),
-	opts: ReviewWindowOptions = {},
+	now: Date,
+	options: ReviewWindowOptions = {},
 ): { readonly expired: readonly ReviewDueMemory[]; readonly approaching: readonly ReviewDueMemory[] } {
+	const limit = options.limit ?? 50;
+	const expired = findExpiredReviewDueMemories(accessor, now, { ...options, limit });
 	return {
-		expired: findExpiredReviewDueMemories(accessor, now, opts),
-		approaching: findApproachingReviewDueMemories(accessor, now, opts),
+		expired,
+		approaching:
+			expired.length >= limit
+				? []
+				: findApproachingReviewDueMemories(accessor, now, { ...options, limit: limit - expired.length }),
 	};
 }

--- a/platform/daemon/src/pipeline/memory-review-due.ts
+++ b/platform/daemon/src/pipeline/memory-review-due.ts
@@ -22,6 +22,12 @@ export interface ReviewDueMemory {
 	readonly createdAt: string;
 	readonly agentId: string;
 	readonly scope: string | null;
+	readonly attributeId: string | null;
+	readonly entityId: string | null;
+	readonly entityName: string | null;
+	readonly aspectId: string | null;
+	readonly aspectName: string | null;
+	readonly claimKey: string | null;
 }
 
 export interface ReviewWindowOptions {
@@ -31,6 +37,7 @@ export interface ReviewWindowOptions {
 	 */
 	readonly expiringSoonMs?: number;
 	readonly limit?: number;
+	readonly agentId?: string;
 }
 
 interface ReviewDueRow {
@@ -42,6 +49,12 @@ interface ReviewDueRow {
 	readonly created_at: string;
 	readonly agent_id: string;
 	readonly scope: string | null;
+	readonly attribute_id: string | null;
+	readonly entity_id: string | null;
+	readonly entity_name: string | null;
+	readonly aspect_id: string | null;
+	readonly aspect_name: string | null;
+	readonly claim_key: string | null;
 }
 
 export interface ReviewDueAccessor {
@@ -58,8 +71,38 @@ function toReviewDueMemory(row: ReviewDueRow): ReviewDueMemory {
 		createdAt: row.created_at,
 		agentId: row.agent_id,
 		scope: row.scope,
+		attributeId: row.attribute_id,
+		entityId: row.entity_id,
+		entityName: row.entity_name,
+		aspectId: row.aspect_id,
+		aspectName: row.aspect_name,
+		claimKey: row.claim_key,
 	};
 }
+
+function reviewDueQuery(options: ReviewWindowOptions): { readonly sql: string; readonly params: unknown[] } {
+	return options.agentId
+		? {
+				sql: "AND m.agent_id = ?",
+				params: [options.agentId],
+			}
+		: { sql: "", params: [] };
+}
+
+const REVIEW_DUE_SELECT = `
+	SELECT m.id, m.content, m.type, m.importance, m.review_after, m.created_at, m.agent_id, m.scope,
+	       ea.id AS attribute_id, a.entity_id, e.name AS entity_name,
+	       ea.aspect_id, a.name AS aspect_name, ea.claim_key
+	  FROM memories m
+	  LEFT JOIN entity_attributes ea
+	    ON ea.memory_id = m.id
+	   AND ea.agent_id = m.agent_id
+	   AND ea.status = 'active'
+	  LEFT JOIN entity_aspects a ON a.id = ea.aspect_id AND a.agent_id = ea.agent_id
+	  LEFT JOIN entities e ON e.id = a.entity_id AND e.agent_id = ea.agent_id
+	 WHERE m.review_after IS NOT NULL
+	   AND m.superseded_by IS NULL
+	   AND m.is_deleted = 0`;
 
 /**
  * Query memories whose `review_after` deadline has passed — temporal claims
@@ -71,15 +114,15 @@ export function findExpiredReviewDueMemories(
 	opts: ReviewWindowOptions = {},
 ): readonly ReviewDueMemory[] {
 	const limit = opts.limit ?? 50;
+	const query = reviewDueQuery(opts);
 	const rows = accessor.all<ReviewDueRow>(
-		`SELECT id, content, type, importance, review_after, created_at, agent_id, scope
-		   FROM memories
-		  WHERE review_after IS NOT NULL
-		    AND review_after < ?
-		    AND is_deleted = 0
+		`${REVIEW_DUE_SELECT}
+		    AND m.review_after < ?
+		    ${query.sql}
 		  ORDER BY review_after ASC
 		  LIMIT ?`,
 		now.toISOString(),
+		...query.params,
 		limit,
 	);
 	return rows.map(toReviewDueMemory);
@@ -97,18 +140,18 @@ export function findApproachingReviewDueMemories(
 ): readonly ReviewDueMemory[] {
 	const windowMs = opts.expiringSoonMs ?? 7 * 24 * 60 * 60 * 1000;
 	const limit = opts.limit ?? 50;
+	const query = reviewDueQuery(opts);
 	const horizon = new Date(now.getTime() + windowMs);
 	const rows = accessor.all<ReviewDueRow>(
-		`SELECT id, content, type, importance, review_after, created_at, agent_id, scope
-		   FROM memories
-		  WHERE review_after IS NOT NULL
-		    AND review_after >= ?
-		    AND review_after <= ?
-		    AND is_deleted = 0
+		`${REVIEW_DUE_SELECT}
+		    AND m.review_after >= ?
+		    AND m.review_after <= ?
+		    ${query.sql}
 		  ORDER BY review_after ASC
 		  LIMIT ?`,
 		now.toISOString(),
 		horizon.toISOString(),
+		...query.params,
 		limit,
 	);
 	return rows.map(toReviewDueMemory);

--- a/platform/daemon/src/pipeline/memory-review-due.ts
+++ b/platform/daemon/src/pipeline/memory-review-due.ts
@@ -1,0 +1,130 @@
+/**
+ * Due-for-review temporal claims (issue #945).
+ *
+ * Temporal claims ("X is going to Y on March 15th, 2027") carry a
+ * `review_after` ISO timestamp set when the claim is created. This module
+ * provides the query the dreaming pass needs to surface claims that are now
+ * due (review_after in the past) or about to become due, so supersession
+ * (prospective → retrospective) can run without scanning the whole table.
+ *
+ * The dreaming pass itself lives in the #913 unified pipeline; this helper is
+ * intentionally standalone so both pipeline dreaming and agentic dreaming can
+ * share it.
+ */
+
+export interface ReviewDueMemory {
+	readonly id: string;
+	readonly content: string;
+	readonly type: string;
+	readonly importance: number;
+	/** ISO timestamp of the review deadline. */
+	readonly reviewAfter: string;
+	readonly createdAt: string;
+	readonly agentId: string;
+	readonly scope: string | null;
+}
+
+export interface ReviewWindowOptions {
+	/**
+	 * Look-ahead window (ms) for "about to expire" claims. Defaults to 7 days
+	 * so the dreaming pass can act before the deadline passes.
+	 */
+	readonly expiringSoonMs?: number;
+	readonly limit?: number;
+}
+
+interface ReviewDueRow {
+	readonly id: string;
+	readonly content: string;
+	readonly type: string;
+	readonly importance: number;
+	readonly review_after: string;
+	readonly created_at: string;
+	readonly agent_id: string;
+	readonly scope: string | null;
+}
+
+export interface ReviewDueAccessor {
+	all<T = unknown>(sql: string, ...params: unknown[]): T[];
+}
+
+function toReviewDueMemory(row: ReviewDueRow): ReviewDueMemory {
+	return {
+		id: row.id,
+		content: row.content,
+		type: row.type,
+		importance: row.importance,
+		reviewAfter: row.review_after,
+		createdAt: row.created_at,
+		agentId: row.agent_id,
+		scope: row.scope,
+	};
+}
+
+/**
+ * Query memories whose `review_after` deadline has passed — temporal claims
+ * that are now due for supersession review.
+ */
+export function findExpiredReviewDueMemories(
+	accessor: ReviewDueAccessor,
+	now = new Date(),
+	opts: ReviewWindowOptions = {},
+): readonly ReviewDueMemory[] {
+	const limit = opts.limit ?? 50;
+	const rows = accessor.all<ReviewDueRow>(
+		`SELECT id, content, type, importance, review_after, created_at, agent_id, scope
+		   FROM memories
+		  WHERE review_after IS NOT NULL
+		    AND review_after < ?
+		    AND is_deleted = 0
+		  ORDER BY review_after ASC
+		  LIMIT ?`,
+		now.toISOString(),
+		limit,
+	);
+	return rows.map(toReviewDueMemory);
+}
+
+/**
+ * Query memories whose `review_after` deadline is approaching (within the
+ * look-ahead window) but has not yet passed — so the dreaming pass can
+ * prioritize them before they expire.
+ */
+export function findApproachingReviewDueMemories(
+	accessor: ReviewDueAccessor,
+	now = new Date(),
+	opts: ReviewWindowOptions = {},
+): readonly ReviewDueMemory[] {
+	const windowMs = opts.expiringSoonMs ?? 7 * 24 * 60 * 60 * 1000;
+	const limit = opts.limit ?? 50;
+	const horizon = new Date(now.getTime() + windowMs);
+	const rows = accessor.all<ReviewDueRow>(
+		`SELECT id, content, type, importance, review_after, created_at, agent_id, scope
+		   FROM memories
+		  WHERE review_after IS NOT NULL
+		    AND review_after >= ?
+		    AND review_after <= ?
+		    AND is_deleted = 0
+		  ORDER BY review_after ASC
+		  LIMIT ?`,
+		now.toISOString(),
+		horizon.toISOString(),
+		limit,
+	);
+	return rows.map(toReviewDueMemory);
+}
+
+/**
+ * Convenience bundle for the dreaming context: both expired and approaching
+ * claims in one call.
+ */
+export function collectReviewDueClaims(
+	accessor: ReviewDueAccessor,
+	now = new Date(),
+	opts: ReviewWindowOptions = {},
+): { readonly expired: readonly ReviewDueMemory[]; readonly approaching: readonly ReviewDueMemory[] } {
+	return {
+		expired: findExpiredReviewDueMemories(accessor, now, opts),
+		approaching: findApproachingReviewDueMemories(accessor, now, opts),
+	};
+}

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -1127,6 +1127,8 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			validFrom?: string;
 			validUntil?: string;
 			sourceCreatedAt?: string;
+			/** ISO timestamp; due-for-review marker for temporal claims (#945). */
+			reviewAfter?: string;
 			scope?: string | null;
 			agentId?: string;
 			visibility?: "global" | "private" | "archived";
@@ -1179,6 +1181,10 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		}
 		const temporalInputs = collectExplicitTemporalInputs(body);
 		if (temporalInputs.error) return c.json({ error: temporalInputs.error }, 400);
+		const requestedReviewAfter = parseOptionalIsoTimestamp(body.reviewAfter);
+		if (body.reviewAfter !== undefined && !requestedReviewAfter) {
+			return c.json({ error: "reviewAfter must be a valid ISO timestamp" }, 400);
+		}
 		const scope = body.scope ?? null;
 		const rowProvenance = parseRememberRowProvenance(body as Record<string, unknown>);
 		const agentId = resolveAgentId({ agentId: body.agentId, sessionKey: c.req.header("x-signet-session-key") });
@@ -1382,6 +1388,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 							scope,
 							agentId,
 							visibility,
+							reviewAfter: requestedReviewAfter ?? undefined,
 							createdAt: now,
 						});
 					}
@@ -1557,6 +1564,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					scope,
 					agentId,
 					visibility,
+					reviewAfter: requestedReviewAfter ?? undefined,
 					createdAt,
 				});
 				txInsertExplicitTemporalEdges({

--- a/platform/daemon/src/transactions.ts
+++ b/platform/daemon/src/transactions.ts
@@ -45,6 +45,9 @@ export interface IngestEnvelope {
 	scope?: string | null;
 	agentId?: string;
 	visibility?: "global" | "private" | "archived";
+	/** ISO timestamp; when set, this memory is due for temporal review after
+	 *  this instant (issue #945). The dreaming pass queries it directly. */
+	reviewAfter?: string | null;
 	createdAt: string;
 }
 
@@ -265,8 +268,8 @@ export function txIngestEnvelope(db: WriteDb, mem: IngestEnvelope): string {
 		  importance, type, tags, pinned, is_deleted, extraction_status,
 		  embedding_model, extraction_model, created_at, updated_at, updated_by,
 		  source_type, source_id, source_path, runtime_path, idempotency_key, scope, agent_id, visibility,
-		  memory_kind, evidence_meta)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		  memory_kind, evidence_meta, review_after)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 	).run(
 		mem.id,
 		mem.content,
@@ -296,6 +299,7 @@ export function txIngestEnvelope(db: WriteDb, mem: IngestEnvelope): string {
 		mem.visibility ?? "global",
 		mem.memoryKind ?? null,
 		mem.evidenceMeta ?? null,
+		mem.reviewAfter ?? null,
 	);
 
 	// FTS sync handled by memories_ai AFTER INSERT trigger (migration 001)

--- a/surfaces/cli/src/commands/memory.ts
+++ b/surfaces/cli/src/commands/memory.ts
@@ -45,6 +45,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 		.option("--source-created-at <iso>", "Source-system creation time for this memory")
 		.option("--valid-from <iso>", "Start of validity window for this memory")
 		.option("--valid-until <iso>", "End of validity window for this memory")
+		.option("--review-after <iso>", "ISO timestamp when this temporal claim becomes due for review (issue #945)")
 		.option("--private", "Set visibility to private", false)
 		.action(async (content: string, options) => {
 			if (!(await deps.ensureDaemonForSecrets())) return;
@@ -65,6 +66,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 					sourceCreatedAt: options.sourceCreatedAt,
 					validFrom: options.validFrom,
 					validUntil: options.validUntil,
+					reviewAfter: options.reviewAfter,
 					visibility: options.private ? "private" : undefined,
 				}),
 			);


### PR DESCRIPTION
## Summary

Step 1–2 of issue #945 (selective expiry for temporal claims): add a `review_after` column so temporal claims can surface as due for review once the referenced date passes — without NLP-parsing every memory — plus the optional `review_after` parameter on every memory-store surface, and the standalone due-for-review query the dreaming pass consumes.

**Scope note:** this PR now includes all five steps from issue #945. The dreaming integration targets the merged #913 agentic pipeline, not the superseded #981 planner architecture.

## Changes

- **Migration 106** (`platform/core/src/migrations/106-memory-review-after.ts`): nullable indexed `review_after TEXT` on `memories` (idempotent via `PRAGMA table_info` guard, matching the migration-104 pattern; index `idx_memories_review_after`).
- **`platform/core/src/recall.ts`**: `RememberRequestOptions.reviewAfter` + passthrough in `buildRememberRequestBody`.
- **`platform/daemon/src/transactions.ts`**: `IngestEnvelope.reviewAfter` + written in `txIngestEnvelope`.
- **`platform/daemon/src/routes/memory-routes.ts`**: `/api/memory/remember` accepts and validates `reviewAfter` (ISO timestamp, 400 on invalid); threaded into both the direct and chunked ingest envelopes.
- **`platform/daemon/src/mcp/tools.ts`**: `memory_store` tool gains an optional `review_after` param (passed through to the daemon).
- **`surfaces/cli/src/commands/memory.ts`**: `signet remember --review-after <iso>`.
- **`platform/daemon/src/pipeline/memory-review-due.ts`** (new): standalone, testable query helper — `findExpiredReviewDueMemories` (deadline passed), `findApproachingReviewDueMemories` (within a look-ahead window, default 7d), `collectReviewDueClaims` (both) — now agent-scoped, linked to active ontology claims, and excluding superseded memories.
- **Dreaming integration**: `attention_list(kind=review_due)` exposes expired and approaching claims to the agentic pass with entity/aspect/attribute identifiers; the runbook prompts instruct the pass to inspect exact source evidence and emit `supersede_claim_value` for expired plans as unconfirmed.
- **Temporal claim writes**: `add_claim_value` and `set_claim_value` accept `reviewAfter`, normalize it to canonical UTC ISO-8601, and persist it on the derived semantic memory.
- **Tests**: `memory-review-due.test.ts` (6 tests: expired/approaching/soft-delete/exclusion/window semantics); migration suite 50/50 (fresh + idempotent re-run).

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] **Schema change:** migration 106 adds nullable `review_after TEXT` to `memories` + `idx_memories_review_after`. Additive and nullable — no backfill, no data rewrite, existing rows unaffected. Fresh DBs get it via the migration chain.
- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

## Testing

- New: `memory-review-due.test.ts` 6/6 (expired ordering, soft-delete exclusion, empty-window, look-ahead window, custom horizon, combined bundle).
- Migration suite: 50/50 (fresh-DB full chain + idempotent re-run).
- `memory-routes.test.ts` + `mcp/tools.test.ts`: 49 pass; the 2 `tools.test.ts` failures (graphiq state fallback, `apply_ontology_ops` `propertyNames` OpenAI-compat) fail **identically on pristine main** — pre-existing, unrelated.
- `recall.test.ts` 14/14; CLI `memory.test.ts` 10/10.
- Full daemon suite run vs pristine `main` baseline: failure sets byte-identical (pre-existing parallel-run flakiness).
- `bunx biome check` clean on all 9 touched files.

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

Assisted-by: Hermes-Agent:deepseek-v4-flash

## Notes

The PR now covers the full selective-expiry lifecycle: temporal claims can carry a canonical review deadline; the agentic dreaming pass can list expired and approaching claims; and expired claims are instructed to become source-backed retrospective supersessions while preserving the version chain. #981 is not required: its planner architecture was superseded by the merged unified agentic dreaming path.

