### PR TITLE
feat(daemon): add GET /api/mode environment probe (#1001)

### DIFF
--- a/docs/api/health-status.md
+++ b/docs/api/health-status.md
@@ -376,3 +376,20 @@ Returns all runtime feature flags.
   "anotherFeature": false
 }
 ```
+
+### GET /api/mode
+
+Environment probe (issue #1001). Deliberately lightweight and **unauthenticated** — the dashboard uses it to distinguish "talking to a real daemon" (any hostname: localhost, Tailscale, `.local`, tunnel, LAN IP) from the marketing site or the cloud app. If this endpoint responds, there is a real daemon behind the URL.
+
+**Response**
+
+```json
+{
+  "mode": "local",
+  "requiresAuth": true
+}
+```
+
+- `mode`: the daemon's auth mode (`local`, `team`, or `hybrid`).
+- `requiresAuth`: always `true` — a reachable daemon always requires a token for data endpoints (Bearer auth only, no cookies, so CSRF is structurally impossible). The endpoint itself carries no data and exposes nothing beyond this shape.
+

--- a/docs/api/health-status.md
+++ b/docs/api/health-status.md
@@ -386,10 +386,9 @@ Environment probe (issue #1001). Deliberately lightweight and **unauthenticated*
 ```json
 {
   "mode": "local",
-  "requiresAuth": true
+  "requiresAuth": false
 }
 ```
 
 - `mode`: the daemon's auth mode (`local`, `team`, or `hybrid`).
-- `requiresAuth`: always `true` — a reachable daemon always requires a token for data endpoints (Bearer auth only, no cookies, so CSRF is structurally impossible). The endpoint itself carries no data and exposes nothing beyond this shape.
-
+- `requiresAuth`: `false` in `local` mode, `true` in `team` and `hybrid` modes. The endpoint itself is always unauthenticated and carries no data beyond this documented shape. Authenticated data endpoints use Bearer tokens only, with no cookies.

--- a/docs/api/route-inventory.md
+++ b/docs/api/route-inventory.md
@@ -31,6 +31,7 @@ silently disappear from the API reference.
 | GET | `/api/readme` | platform/daemon/src/routes/changelog.ts |
 | GET | `/health/live` | platform/daemon/src/routes/health.ts |
 | GET | `/health/ready` | platform/daemon/src/routes/health.ts |
+| GET | `/api/mode` | platform/daemon/src/routes/health.ts |
 | POST | `/api/connectors/resync` | platform/daemon/src/routes/connectors-routes.ts |
 | GET | `/api/os/events` | platform/daemon/src/routes/event-bus.ts |
 | GET | `/api/os/events/stream` | platform/daemon/src/routes/event-bus.ts |

--- a/platform/daemon/src/auth/auth.test.ts
+++ b/platform/daemon/src/auth/auth.test.ts
@@ -471,9 +471,13 @@ describe("middleware - createAuthMiddleware", () => {
 		app.get("/", (c) => c.text("dashboard"));
 		app.get("/assets/app.js", (c) => c.text("asset"));
 		app.get("/api/auth/methods", (c) => c.json({ ok: true }));
+		// /api/mode is the unauthenticated environment probe the dashboard
+		// uses to detect a real daemon before any token exchange (issue #1001).
+		app.get("/api/mode", (c) => c.json({ mode: "team", requiresAuth: true }));
 		expect((await app.request(new Request("http://localhost/"))).status).toBe(200);
 		expect((await app.request(new Request("http://localhost/assets/app.js"))).status).toBe(200);
 		expect((await app.request(new Request("http://localhost/api/auth/methods"))).status).toBe(200);
+		expect((await app.request(new Request("http://localhost/api/mode"))).status).toBe(200);
 	});
 
 	test("team mode: invalid token returns 401", async () => {

--- a/platform/daemon/src/auth/middleware.ts
+++ b/platform/daemon/src/auth/middleware.ts
@@ -29,6 +29,10 @@ const LOOPBACK = new Set(["127.0.0.1", "::1", "::ffff:127.0.0.1"]);
 
 export function isAuthOpenPath(path: string): boolean {
 	if (path === "/health" || path === "/health/live" || path === "/health/ready") return true;
+	// Lightweight, unauthenticated environment probe so the dashboard can
+	// distinguish "talking to a real daemon" from the marketing site or
+	// cloud app without a token (issue #1001).
+	if (path === "/api/mode") return true;
 	if (path === "/api/auth/login" || path === "/api/auth/methods" || path === "/api/auth/whoami") return true;
 	if (path.startsWith("/api/auth/sso/") || path.startsWith("/api/auth/saml/")) return true;
 	return false;

--- a/platform/daemon/src/routes/health.test.ts
+++ b/platform/daemon/src/routes/health.test.ts
@@ -196,3 +196,28 @@ describe("GET /health (back-compat)", () => {
 		expect(resources.peakPhysicalFootprint === null || typeof resources.peakPhysicalFootprint === "number").toBe(true);
 	});
 });
+
+describe("GET /api/mode", () => {
+	test("returns the auth mode and requiresAuth without any token (issue #1001)", async () => {
+		const app = makeApp();
+		const res = await app.request("/api/mode");
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { mode: string; requiresAuth: boolean };
+		expect(typeof body.mode).toBe("string");
+		expect(body.mode.length).toBeGreaterThan(0);
+		expect(body.requiresAuth).toBe(true);
+	});
+
+	test("is reachable without an Authorization header (auth-open)", async () => {
+		const app = makeApp();
+		const res = await app.request("/api/mode", { headers: {} });
+		expect(res.status).toBe(200);
+	});
+
+	test("does not expose daemon internals beyond the documented shape", async () => {
+		const app = makeApp();
+		const res = await app.request("/api/mode");
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(Object.keys(body).sort()).toEqual(["mode", "requiresAuth"]);
+	});
+});

--- a/platform/daemon/src/routes/health.test.ts
+++ b/platform/daemon/src/routes/health.test.ts
@@ -198,14 +198,13 @@ describe("GET /health (back-compat)", () => {
 });
 
 describe("GET /api/mode", () => {
-	test("returns the auth mode and requiresAuth without any token (issue #1001)", async () => {
+	test("reports the local mode auth contract without any token (issue #1001)", async () => {
 		const app = makeApp();
 		const res = await app.request("/api/mode");
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as { mode: string; requiresAuth: boolean };
-		expect(typeof body.mode).toBe("string");
-		expect(body.mode.length).toBeGreaterThan(0);
-		expect(body.requiresAuth).toBe(true);
+		expect(body.mode).toBe("local");
+		expect(body.requiresAuth).toBe(false);
 	});
 
 	test("is reachable without an Authorization header (auth-open)", async () => {

--- a/platform/daemon/src/routes/health.ts
+++ b/platform/daemon/src/routes/health.ts
@@ -17,6 +17,7 @@ import {
 	AGENTS_DIR,
 	CURRENT_VERSION,
 	PORT,
+	authConfig,
 	getCurrentAgentsDir,
 	getExtractionWorkloadState,
 	providerRuntimeResolution,
@@ -279,5 +280,15 @@ export function mountHealthRoutes(app: Hono): void {
 
 	app.get("/api/features", (c) => {
 		return c.json(getAllFeatureFlags());
+	});
+
+	// Environment probe (issue #1001): deliberately lightweight and
+	// unauthenticated so the dashboard can distinguish "talking to a real
+	// daemon" (any hostname: localhost, Tailscale, .local, tunnel, LAN IP)
+	// from the marketing site or cloud app. `mode` reflects the daemon's
+	// auth mode; `requiresAuth` is always true — a reachable daemon always
+	// requires a token for data endpoints.
+	app.get("/api/mode", (c) => {
+		return c.json({ mode: authConfig.mode, requiresAuth: true });
 	});
 }

--- a/platform/daemon/src/routes/health.ts
+++ b/platform/daemon/src/routes/health.ts
@@ -286,9 +286,9 @@ export function mountHealthRoutes(app: Hono): void {
 	// unauthenticated so the dashboard can distinguish "talking to a real
 	// daemon" (any hostname: localhost, Tailscale, .local, tunnel, LAN IP)
 	// from the marketing site or cloud app. `mode` reflects the daemon's
-	// auth mode; `requiresAuth` is always true — a reachable daemon always
-	// requires a token for data endpoints.
+	// auth mode; `requiresAuth` reflects whether data endpoints require a
+	// token in that mode.
 	app.get("/api/mode", (c) => {
-		return c.json({ mode: authConfig.mode, requiresAuth: true });
+		return c.json({ mode: authConfig.mode, requiresAuth: authConfig.mode !== "local" });
 	});
 }


### PR DESCRIPTION
## Summary

Implements the daemon environment probe from the Distribution Model issue: `GET /api/mode`. This is the endpoint the dashboard's three-way environment detection depends on (`app:` protocol → desktop; `/api/mode` succeeds → local daemon; `/api/mode` fails → cloud).

## Changes

- `platform/daemon/src/routes/health.ts` — adds the route:
  ```json
  { "mode": "local", "requiresAuth": false }
  ```
  `mode` reflects the daemon's auth mode (`local` / `team` / `hybrid`). `requiresAuth` reflects the current daemon contract: `false` for local mode and `true` for team or hybrid mode.
- `platform/daemon/src/auth/middleware.ts` — `/api/mode` is an auth-open path so the probe is reachable without a token. It carries no data beyond the documented shape.
- `platform/daemon/src/routes/health.test.ts` — covers the local-mode response, tokenless access, and exact response shape.
- `platform/daemon/src/auth/auth.test.ts` — the team-mode open-path test also covers `/api/mode`.
- `docs/api/health-status.md` — documents the endpoint and mode-dependent auth flag.
- `docs/api/route-inventory.md` — adds the route to the inventory.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no schema or migration changes.

## Testing

- `bun run --filter '@signet/core' build` passes.
- `bun test platform/daemon/src/routes/health.test.ts platform/daemon/src/auth/auth.test.ts` passes: 91 tests, 0 failures.
- `bun run --filter '@signet/daemon' typecheck` passes.
- `bunx biome check` passes on changed TypeScript source files.
- `git diff --check` passes.

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

Assisted-by: Hermes-Agent:deepseek-v4-flash

## Notes

Scope is deliberately the single concrete missing piece of #1001. The auth flag now reflects the repository's existing local/team/hybrid behavior rather than claiming that local mode requires a token when the current local middleware does not.

Fixes #1001