### PR TITLE
fix(cli): guard daemon ownership

### DIFF
--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -16,11 +16,9 @@ import {
 	macOSLaunchAgentAttributionNotice,
 	readDaemonStartFailureDiagnostics,
 	readManagedDaemonPid,
-	rebindDaemonIfNeeded,
 	resolveDaemonLaunchCommand,
 	resolveDaemonPaths,
 	resolveDaemonRuntimeCommand,
-	shouldRebindDaemon,
 } from "./runtime.js";
 
 const originalFetch = globalThis.fetch;
@@ -40,46 +38,6 @@ describe("daemon entrypoint ownership", () => {
 	it("accepts the explicit daemon marker and rejects an unmarked CLI environment", () => {
 		expect(isDaemonEntrypointEnvironment("PATH=/usr/bin\u0000SIGNET_DAEMON_ENTRYPOINT=1\u0000")).toBe(true);
 		expect(isDaemonEntrypointEnvironment("PATH=/usr/bin\u0000")).toBe(false);
-	});
-});
-
-describe("daemon installation ownership", () => {
-	it("rebinds an npm-launched daemon when the native CLI is now active", () => {
-		const nativeExecutable = "/Users/test/.local/bin/signet";
-		const npmExecutable = "/opt/homebrew/lib/node_modules/signetai/native/signet";
-
-		expect(shouldRebindDaemon(`${npmExecutable} daemon`, nativeExecutable)).toBe(true);
-		expect(shouldRebindDaemon(`${nativeExecutable} daemon`, nativeExecutable)).toBe(false);
-	});
-
-	it("restarts a mismatched healthy daemon instead of leaving the old install in charge", async () => {
-		const calls: string[] = [];
-		const result = await rebindDaemonIfNeeded("/Users/test/.local/bin/signet", {
-			getDaemonStatus: async () => ({ running: true, pid: 42 }),
-			readCommand: () => "/opt/homebrew/lib/node_modules/signetai/native/signet daemon",
-			stopDaemon: async (pid) => {
-				calls.push(`stop:${pid}`);
-				return true;
-			},
-		});
-
-		expect(result).toBe("restarted");
-		expect(calls).toEqual(["stop:42"]);
-	});
-
-	it("does not restart a daemon already using the current executable", async () => {
-		let stopped = false;
-		const result = await rebindDaemonIfNeeded("/Users/test/.local/bin/signet", {
-			getDaemonStatus: async () => ({ running: true, pid: 42 }),
-			readCommand: () => "/Users/test/.local/bin/signet daemon",
-			stopDaemon: async () => {
-				stopped = true;
-				return true;
-			},
-		});
-
-		expect(result).toBe("already-current");
-		expect(stopped).toBe(false);
 	});
 });
 

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -10,6 +10,7 @@ import {
 	didLaunchdDaemonStart,
 	didSystemdDaemonStart,
 	getDaemonStatus,
+	isDaemonEntrypointEnvironment,
 	isLaunchdDaemonLoaded,
 	launchdDaemonPlistPath,
 	macOSLaunchAgentAttributionNotice,
@@ -32,6 +33,13 @@ describe("resolveDaemonPaths", () => {
 	it("keeps the JavaScript daemon bundle as the default when SIGNET_DIR is set", () => {
 		const paths = resolveDaemonPaths({ SIGNET_DIR: "/opt/signet" });
 		expect(paths[0]).toBe("/opt/signet/runtime/daemon-js/daemon.js");
+	});
+});
+
+describe("daemon entrypoint ownership", () => {
+	it("accepts the explicit daemon marker and rejects an unmarked CLI environment", () => {
+		expect(isDaemonEntrypointEnvironment("PATH=/usr/bin\u0000SIGNET_DAEMON_ENTRYPOINT=1\u0000")).toBe(true);
+		expect(isDaemonEntrypointEnvironment("PATH=/usr/bin\u0000")).toBe(false);
 	});
 });
 
@@ -312,9 +320,28 @@ describe("readManagedDaemonPid", () => {
 			daemonPaths: ["/opt/signet/dist/daemon.js"],
 			isAlive: () => true,
 			readCmd: () => "bun /opt/signet/dist/daemon.js",
+			readEnv: () => "SIGNET_DAEMON_ENTRYPOINT=1\u0000",
 		});
 
 		expect(pid).toBe(4242);
+
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("rejects a daemon-path CLI process without the daemon entrypoint marker", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-runtime-test-"));
+		const dir = join(root, ".daemon");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "pid"), "6262\n");
+
+		const pid = readManagedDaemonPid(root, {
+			daemonPaths: ["/opt/signet/dist/daemon.js"],
+			isAlive: () => true,
+			readCmd: () => "bun /opt/signet/dist/daemon.js daemon start",
+			readEnv: () => "PATH=/usr/bin\u0000",
+		});
+
+		expect(pid).toBeNull();
 
 		rmSync(root, { recursive: true, force: true });
 	});
@@ -329,6 +356,7 @@ describe("readManagedDaemonPid", () => {
 			daemonPaths: ["/home/nicholai/.bun/install/global/node_modules/signetai/dist/daemon.js"],
 			isAlive: () => true,
 			readCmd: () => "bun /home/nicholai/.bun/install/cache/signetai@0.77.0/node_modules/signetai/dist/daemon.js",
+			readEnv: () => "SIGNET_DAEMON_ENTRYPOINT=1\u0000",
 		});
 
 		expect(pid).toBe(5252);
@@ -347,6 +375,7 @@ describe("readManagedDaemonPid", () => {
 			daemonPaths: ["/opt/signet/dist/daemon.js"],
 			isAlive: () => true,
 			readCmd: () => "/usr/bin/python3 /tmp/something-else.py",
+			readEnv: () => "PATH=/usr/bin\u0000",
 		});
 
 		expect(pid).toBeNull();

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -7,6 +7,7 @@ import {
 	mkdirSync,
 	openSync,
 	readFileSync,
+	readdirSync,
 	realpathSync,
 	rmSync,
 	writeFileSync,
@@ -112,6 +113,7 @@ interface DaemonProbeDeps {
 	readonly daemonPaths?: readonly string[];
 	readonly isAlive?: (pid: number) => boolean;
 	readonly readCmd?: (pid: number) => string | null;
+	readonly readEnv?: (pid: number) => string | null;
 }
 
 const __filename = fileURLToPath(import.meta.url);
@@ -308,7 +310,7 @@ function readPidArtifact(agentsDir: string): { pid: number | null; stale: boolea
 async function buildUnreachableDaemonProbe(agentsDir: string): Promise<DaemonHealthProbe> {
 	const artifact = readPidArtifact(agentsDir);
 	const managedPid = readManagedDaemonPid(agentsDir);
-	const processPid = managedPid ?? findDaemonProcessPids()[0] ?? null;
+	const processPid = managedPid ?? findMarkedDaemonProcessPids()[0] ?? null;
 	const listenerPresent = await canConnect("127.0.0.1", DEFAULT_PORT);
 	const url = `http://127.0.0.1:${DEFAULT_PORT}`;
 
@@ -536,6 +538,10 @@ function normalizeCmd(value: string): string {
 	return normalize(value).replaceAll("\\", "/").toLowerCase();
 }
 
+export function isDaemonEntrypointEnvironment(value: string): boolean {
+	return value.split("\u0000").some((entry) => entry === "SIGNET_DAEMON_ENTRYPOINT=1");
+}
+
 function executablePathVariants(executablePath: string): readonly string[] {
 	const variants = [executablePath];
 	try {
@@ -627,27 +633,37 @@ function readCmd(pid: number): string | null {
 	}
 }
 
-function findDaemonProcessPids(paths: readonly string[] = daemonPaths()): number[] {
+function readDaemonEntrypoint(pid: number): boolean | null {
+	if (process.platform !== "linux") return null;
 	try {
-		const proc = spawnSync("ps", ["-axo", "pid=,command="], {
-			encoding: "utf-8",
-			windowsHide: true,
-		});
-		if (proc.status !== 0) return [];
-		return proc.stdout
-			.split("\n")
-			.flatMap((line) => {
-				const match = line.trimStart().match(/^(\d+)\s+(.+)$/);
-				if (!match) return [];
-				const pid = Number.parseInt(match[1] ?? "", 10);
-				const cmd = match[2] ?? "";
+		return isDaemonEntrypointEnvironment(readFileSync(`/proc/${pid}/environ`, "utf-8"));
+	} catch {
+		return false;
+	}
+}
+
+function findMarkedDaemonProcessPids(): number[] {
+	if (process.platform !== "linux") return [];
+	try {
+		return readdirSync("/proc", { withFileTypes: true })
+			.flatMap((entry) => {
+				if (!entry.isDirectory() || !/^\d+$/.test(entry.name)) return [];
+				const pid = Number.parseInt(entry.name, 10);
 				if (!Number.isInteger(pid) || pid <= 1 || pid === process.pid) return [];
-				return matchesDaemon(cmd, paths) ? [pid] : [];
+				return readDaemonEntrypoint(pid) === true ? [pid] : [];
 			})
 			.filter((pid, index, items) => items.indexOf(pid) === index);
 	} catch {
 		return [];
 	}
+}
+
+function readManagedDaemonProcess(pid: number): boolean {
+	if (!Number.isInteger(pid) || pid <= 1 || !isAlive(pid)) return false;
+	const marker = readDaemonEntrypoint(pid);
+	if (marker !== null) return marker;
+	const cmd = readCmd(pid);
+	return cmd !== null && matchesDaemon(cmd, daemonPaths());
 }
 
 export function readManagedDaemonPid(agentsDir: string = AGENTS_DIR, deps: DaemonProbeDeps = {}): number | null {
@@ -668,12 +684,14 @@ export function readManagedDaemonPid(agentsDir: string = AGENTS_DIR, deps: Daemo
 			return null;
 		}
 
-		// Only reclaim live PIDs that still look like a Signet daemon process.
-		const cmd = (deps.readCmd ?? readCmd)(pid);
-		if (!cmd) {
-			return null;
-		}
+		const marker = deps.readEnv ? isDaemonEntrypointEnvironment(deps.readEnv(pid) ?? "") : readDaemonEntrypoint(pid);
+		if (marker === true) return pid;
+		if (marker === false) return null;
 
+		// On platforms without a readable process environment, only reclaim a
+		// live PID whose command line still identifies a Signet daemon.
+		const cmd = (deps.readCmd ?? readCmd)(pid);
+		if (!cmd) return null;
 		const paths = deps.daemonPaths ?? daemonPaths();
 		return matchesDaemon(cmd, paths) ? pid : null;
 	} catch {
@@ -682,7 +700,7 @@ export function readManagedDaemonPid(agentsDir: string = AGENTS_DIR, deps: Daemo
 }
 
 export async function hasDaemonProcess(agentsDir: string = AGENTS_DIR): Promise<boolean> {
-	return readManagedDaemonPid(agentsDir) !== null;
+	return readManagedDaemonPid(agentsDir) !== null || findMarkedDaemonProcessPids().length > 0;
 }
 
 export async function getDaemonStatus(): Promise<{
@@ -704,7 +722,7 @@ export async function getDaemonStatus(): Promise<{
 	const instances = await getDaemonInstances();
 	if (instances.length > 0) {
 		const preferred = instances.find((instance) => typeof instance.uptime === "number") ?? instances[0];
-		const fallbackPid = typeof preferred.pid === "number" ? null : (findDaemonProcessPids()[0] ?? null);
+		const fallbackPid = typeof preferred.pid === "number" ? null : (findMarkedDaemonProcessPids()[0] ?? null);
 		return {
 			running: true,
 			pid: preferred.pid ?? fallbackPid,
@@ -1065,32 +1083,12 @@ export function didSystemdDaemonStart(result: Pick<SpawnSyncReturns<Buffer>, "st
 export const didLaunchdDaemonStart = didSystemdDaemonStart;
 
 export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemonPath?: string): Promise<boolean> {
+	if ((await isDaemonRunning()) || (await hasDaemonProcess(agentsDir))) return true;
+
 	const daemonPath = preferredDaemonPath ?? resolveDaemonPath();
 	if (!daemonPath) {
 		console.error(chalk.red("Daemon not found. Try reinstalling signet."));
 		return false;
-	}
-
-	const rebindResult = await rebindDaemonIfNeeded(daemonPath, {
-		getDaemonStatus,
-		readCommand: (pid) => readCmd(pid),
-		stopDaemon: (pid) => stopDaemon(agentsDir, pid),
-	});
-	if (rebindResult === "already-current" || rebindResult === "unknown") {
-		return true;
-	}
-	if (rebindResult === "failed") {
-		return false;
-	}
-	if (rebindResult === "restarted") {
-		console.error(chalk.dim("  Existing daemon uses another Signet installation; switching to the current one."));
-	}
-
-	if (await hasDaemonProcess(agentsDir)) {
-		const stopped = await stopDaemon(agentsDir);
-		if (!stopped) {
-			return false;
-		}
 	}
 
 	const net = resolveDaemonNetwork(agentsDir, process.env);
@@ -1304,18 +1302,21 @@ export async function stopDaemon(agentsDir: string = AGENTS_DIR, preferredPid?: 
 		});
 	}
 
-	const pids = new Set<number>(preferredPid === undefined ? [] : [preferredPid]);
+	const pids = new Set<number>();
+	if (preferredPid !== undefined && readManagedDaemonProcess(preferredPid)) {
+		pids.add(preferredPid);
+	}
 	const managed = readManagedDaemonPid(agentsDir);
 	if (managed !== null) {
 		pids.add(managed);
 	}
 
 	for (const instance of await getDaemonInstances()) {
-		if (typeof instance.pid === "number" && instance.pid > 0) {
+		if (typeof instance.pid === "number" && readManagedDaemonProcess(instance.pid)) {
 			pids.add(instance.pid);
 		}
 	}
-	for (const pid of findDaemonProcessPids()) {
+	for (const pid of findMarkedDaemonProcessPids()) {
 		pids.add(pid);
 	}
 

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -8,7 +8,6 @@ import {
 	openSync,
 	readFileSync,
 	readdirSync,
-	realpathSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
@@ -542,32 +541,6 @@ export function isDaemonEntrypointEnvironment(value: string): boolean {
 	return value.split("\u0000").some((entry) => entry === "SIGNET_DAEMON_ENTRYPOINT=1");
 }
 
-function executablePathVariants(executablePath: string): readonly string[] {
-	const variants = [executablePath];
-	try {
-		variants.push(realpathSync(executablePath));
-	} catch {
-		// The executable may have been replaced during an update. The command
-		// line still gives us the best available ownership signal in that case.
-	}
-	return [...new Set(variants.map(normalizeCmd))];
-}
-
-/** Return whether a daemon command line contains the requested executable. */
-export function daemonCommandUsesExecutable(command: string, executablePath: string): boolean {
-	const normalizedCommand = normalizeCmd(command);
-	return executablePathVariants(executablePath).some((candidate) => normalizedCommand.includes(candidate));
-}
-
-/**
- * A running daemon may outlive the CLI installation that started it. Rebind
- * only when its command line is known and points at a different executable;
- * an unreadable command line is left alone for safety.
- */
-export function shouldRebindDaemon(currentCommand: string | null, desiredExecutablePath: string): boolean {
-	return currentCommand !== null && !daemonCommandUsesExecutable(currentCommand, desiredExecutablePath);
-}
-
 function matchesDaemon(cmd: string, paths: readonly string[]): boolean {
 	const normalizedCmd = normalizeCmd(cmd);
 	return daemonMarks(paths).some((path) => normalizedCmd.includes(normalizeCmd(path)));
@@ -761,35 +734,6 @@ export async function getDaemonStatus(): Promise<{
 		probe,
 		openclaw: null,
 	};
-}
-
-interface DaemonOwnershipStatus {
-	readonly running: boolean;
-	readonly pid: number | null;
-}
-
-export type DaemonRebindResult = "not-running" | "already-current" | "unknown" | "restarted" | "failed";
-
-/**
- * Switch a healthy daemon to the executable selected by the current CLI when
- * an older daemon was started from another Signet installation.
- */
-export async function rebindDaemonIfNeeded(
-	desiredExecutablePath: string,
-	deps: {
-		readonly getDaemonStatus: () => Promise<DaemonOwnershipStatus>;
-		readonly readCommand: (pid: number) => string | null;
-		readonly stopDaemon: (pid: number) => Promise<boolean>;
-	},
-): Promise<DaemonRebindResult> {
-	const status = await deps.getDaemonStatus();
-	if (!status.running) return "not-running";
-	if (status.pid === null) return "unknown";
-
-	const currentCommand = deps.readCommand(status.pid);
-	if (!shouldRebindDaemon(currentCommand, desiredExecutablePath)) return currentCommand ? "already-current" : "unknown";
-
-	return (await deps.stopDaemon(status.pid)) ? "restarted" : "failed";
 }
 
 export interface DaemonStartArgsInput {


### PR DESCRIPTION
## Summary

Fix daemon ownership detection so concurrent `signet daemon start` or `restart` invocations cannot identify and kill sibling CLI processes by matching a shared native executable path.

Fixes #1136.

## Changes

- Replace the broad `ps` command-line process scan with `/proc` enumeration gated by `SIGNET_DAEMON_ENTRYPOINT=1`.
- Validate pid-file and API-reported daemon PIDs against the explicit daemon marker on Linux.
- Make `startDaemon()` return success when a healthy or marked daemon is already running instead of stopping it for installation rebinding.
- Add regression coverage for an unmarked CLI process whose command line resembles the daemon.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/cli` / dashboard

## Screenshots

N/A. This is a CLI/runtime change.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — N/A, no spec/data contract change
- [x] Agent scoping verified on all new/changed data queries — N/A, no data queries changed
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints — N/A
- [x] Docs updated for API/spec/status changes — N/A, internal process ownership behavior only
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally — focused checks pass; repository-wide failures are documented below

## Testing

- [x] `bun test surfaces/cli/src/lib/runtime.test.ts` — 32 passed
- [x] `bunx biome check surfaces/cli/src/lib/runtime.ts surfaces/cli/src/lib/runtime.test.ts` — passed
- [x] `git diff --check` — passed
- [x] `bun build ./surfaces/cli/src/cli.ts --outfile /tmp/signet-cli-1136.js --target node --external better-sqlite3` — passed
- [x] `bun run --filter '@signet/cli' build` — passed
- [x] Tested against running daemon — `/health` and `/health/live` returned 200; PID 3690865 carried `SIGNET_DAEMON_ENTRYPOINT=1` under `signet-daemon-3690759.service`
- [ ] `bun run typecheck` — blocked by unrelated connector errors: missing exports from `@signet/connector-base` in connector-pi, connector-forge, connector-oh-my-pi, connector-openclaw, connector-gemini, connector-opencode, and connector-codex
- [ ] `bun run lint` — blocked by pre-existing formatting diagnostics under `.worktrees/hermes-1bb2ca63` (2,925 errors and 761 warnings)

## AI disclosure

- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The daemon marker is already present in both the systemd-run environment and detached fallback environment. On non-Linux platforms, existing launchd/process-path ownership behavior remains in place; macOS launchd is stopped through its managed service label rather than process enumeration.