### PR TITLE
fix(dreaming): content runbook defers mid-stream transcripts and supersedes contradictions (#1140)

### DIFF
--- a/platform/daemon/src/episodic-sources.test.ts
+++ b/platform/daemon/src/episodic-sources.test.ts
@@ -91,6 +91,75 @@ describe("episodic source selection", () => {
 		]);
 	});
 
+	it("marks transcripts completed when a session-end summary job is triggered, even if it fails", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO session_transcripts
+				 (session_key, content, harness, project, agent_id, created_at, updated_at)
+				 VALUES ('running-a', 'intermediate investigation states', 'pi', '/repo', 'ant',
+				  '2026-08-07T06:14:00.000Z', '2026-08-07T06:30:00.000Z')`,
+			).run();
+			db.prepare(
+				`INSERT INTO session_transcripts
+				 (session_key, content, harness, project, agent_id, created_at, updated_at)
+				 VALUES ('settled-b', 'settled outcome', 'pi', '/repo', 'ant',
+				  '2026-08-07T05:00:00.000Z', '2026-08-07T05:20:00.000Z')`,
+			).run();
+			db.prepare(
+				`INSERT INTO session_transcripts
+				 (session_key, content, harness, project, agent_id, created_at, updated_at)
+				 VALUES ('timed-out-c', 'outcome despite summary timeout', 'pi', '/repo', 'ant',
+				  '2026-08-07T04:00:00.000Z', '2026-08-07T04:30:00.000Z')`,
+			).run();
+			db.prepare(
+				`INSERT INTO session_transcripts
+				 (session_key, content, harness, project, agent_id, created_at, updated_at)
+				 VALUES ('checkpointed-d', 'mid-session checkpointed states', 'pi', '/repo', 'ant',
+				  '2026-08-07T07:00:00.000Z', '2026-08-07T07:10:00.000Z')`,
+			).run();
+			// Session ended normally: summary job triggered (status pending).
+			db.prepare(
+				`INSERT INTO summary_jobs
+				 (id, session_key, session_id, harness, project, agent_id, transcript,
+				  trigger, captured_at, started_at, ended_at, status, created_at)
+				 VALUES ('job-settled', 'settled-b', 'settled-b', 'pi', '/repo', 'ant',
+				  'settled outcome', 'session_end', '2026-08-07T05:20:00.000Z',
+				  '2026-08-07T05:20:00.000Z', '2026-08-07T05:20:00.000Z', 'pending',
+				  '2026-08-07T05:20:00.000Z')`,
+			).run();
+			// Summary timed out / failed: the job row still proves the session ended.
+			db.prepare(
+				`INSERT INTO summary_jobs
+				 (id, session_key, session_id, harness, project, agent_id, transcript,
+				  trigger, captured_at, started_at, ended_at, status, created_at)
+				 VALUES ('job-timed-out', 'timed-out-c', 'timed-out-c', 'pi', '/repo', 'ant',
+				  'outcome despite summary timeout', 'session_end', '2026-08-07T04:30:00.000Z',
+				  '2026-08-07T04:30:00.000Z', null, 'failed',
+				  '2026-08-07T04:30:00.000Z')`,
+			).run();
+			// A mid-session checkpoint extract is NOT a session-end signal.
+			db.prepare(
+				`INSERT INTO summary_jobs
+				 (id, session_key, session_id, harness, project, agent_id, transcript,
+				  trigger, captured_at, started_at, ended_at, status, created_at)
+				 VALUES ('job-checkpoint', 'checkpointed-d', 'checkpointed-d', 'pi', '/repo', 'ant',
+				  'mid-session checkpointed states', 'checkpoint_extract', '2026-08-07T07:10:00.000Z',
+				  '2026-08-07T07:10:00.000Z', null, 'completed',
+				  '2026-08-07T07:10:00.000Z')`,
+			).run();
+		});
+
+		const read = (from: string) => getDbAccessor().withReadDb((db) => readEpisodicSource(db, { agentId: "ant", from }));
+		// A still-running session has no session-end job yet: not settled evidence.
+		expect(read("transcript:running-a")).toMatchObject({ kind: "transcript", completed: false });
+		// A session-end summary job was triggered: settled, even while pending.
+		expect(read("transcript:settled-b")).toMatchObject({ kind: "transcript", completed: true });
+		// A failed/timed-out summary job still proves the session ended.
+		expect(read("transcript:timed-out-c")).toMatchObject({ kind: "transcript", completed: true });
+		// A mid-session checkpoint extract does not settle the session.
+		expect(read("transcript:checkpointed-d")).toMatchObject({ kind: "transcript", completed: false });
+	});
+
 	it("orders timezone-less artifact timestamps like SQLite's UTC cursor", () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(

--- a/platform/daemon/src/episodic-sources.ts
+++ b/platform/daemon/src/episodic-sources.ts
@@ -41,6 +41,17 @@ export interface EpisodicSourceRecord {
 	 * writes at save time.
 	 */
 	readonly evidenceMeta: string | null;
+	/**
+	 * Whether the record is a settled, complete capture. Immutable kinds
+	 * (memory, artifact, summary) are always completed; a transcript is
+	 * completed once a session-end summary job has been triggered for its
+	 * session (the session ended and finalization began), whether or not the
+	 * summary itself landed — a summary job that times out or fails must not
+	 * keep the transcript classified as mid-stream forever. A running
+	 * session's still-growing transcript is not settled evidence: its
+	 * intermediate states may be contradicted by the session's end.
+	 */
+	readonly completed: boolean;
 }
 
 export interface ReadEpisodicSourceOptions {
@@ -168,6 +179,8 @@ export function readEpisodicMemory(db: ReadDb, agentId: string, id: string): Epi
 		// re-submit already-processed evidence to Dreaming.
 		capturedAt: row.created_at,
 		evidenceMeta: row.evidence_meta,
+		// A memory is a point-in-time capture: always settled.
+		completed: true,
 	};
 }
 
@@ -220,6 +233,8 @@ export function readEpisodicArtifact(db: ReadDb, agentId: string, id: string): E
 		harness: row.harness,
 		capturedAt: row.captured_at ?? row.updated_at,
 		evidenceMeta: null,
+		// An artifact is a captured file snapshot: always settled.
+		completed: true,
 	};
 }
 
@@ -228,10 +243,15 @@ export function readEpisodicTranscript(db: ReadDb, agentId: string, id: string):
 	const placeholders = ids.map(() => "?").join(", ");
 	const row = db
 		.prepare(
-			`SELECT session_key, content, harness, project, created_at, updated_at
-			 FROM session_transcripts
-			 WHERE agent_id = ? AND session_key IN (${placeholders})
-			 ORDER BY updated_at DESC, created_at DESC
+			`SELECT st.session_key, st.content, st.harness, st.project, st.created_at, st.updated_at,
+			        EXISTS (
+			          SELECT 1 FROM summary_jobs AS sj
+			          WHERE sj.agent_id = st.agent_id AND sj.session_key = st.session_key
+			            AND sj.trigger IN ('session_end', 'ttl_expired')
+			        ) AS completed
+			 FROM session_transcripts AS st
+			 WHERE st.agent_id = ? AND st.session_key IN (${placeholders})
+			 ORDER BY st.updated_at DESC, st.created_at DESC
 			 LIMIT 1`,
 		)
 		.get(agentId, ...ids) as
@@ -242,6 +262,7 @@ export function readEpisodicTranscript(db: ReadDb, agentId: string, id: string):
 				readonly project: string | null;
 				readonly created_at: string;
 				readonly updated_at: string | null;
+				readonly completed: number;
 		  }
 		| undefined;
 	if (!row) return null;
@@ -257,6 +278,13 @@ export function readEpisodicTranscript(db: ReadDb, agentId: string, id: string):
 		harness: row.harness,
 		capturedAt: row.updated_at ?? row.created_at,
 		evidenceMeta: null,
+		// A transcript is settled once a session-end summary job has been
+		// triggered for the session: that is the signal the session ended,
+		// whether or not the summary itself lands (a timed-out or failed
+		// summary must not keep the transcript mid-stream forever). A
+		// still-running session's transcript is mid-stream evidence, not
+		// settled fact.
+		completed: row.completed === 1,
 	};
 }
 
@@ -302,6 +330,8 @@ export function readEpisodicSummary(db: ReadDb, agentId: string, id: string): Ep
 		harness: row.harness,
 		capturedAt: row.latest_at,
 		evidenceMeta: null,
+		// A summary is the session's consolidated end state: always settled.
+		completed: true,
 	};
 }
 
@@ -403,6 +433,7 @@ export function readRecentEpisodicSources(
 						harness: readNonEmptyTrimmed(memory.who),
 						capturedAt: memory.created_at,
 						evidenceMeta: memory.evidence_meta,
+						completed: true,
 					} satisfies EpisodicSourceRecord;
 				})
 		: [];
@@ -475,18 +506,24 @@ export function readRecentEpisodicSources(
 						harness: artifact.harness,
 						capturedAt: artifact.captured_at ?? artifact.updated_at,
 						evidenceMeta: null,
+						completed: true,
 					} satisfies EpisodicSourceRecord;
 				})
 		: [];
 	const transcripts: EpisodicSourceRecord[] = wants("transcript")
 		? db
 				.prepare(
-					`SELECT session_key, content, harness, project, created_at, updated_at
-			 FROM session_transcripts
-			 WHERE agent_id = ?
-			   AND (${transcriptCursor.sql} OR ${transcriptRequeue})
-			 ORDER BY julianday(COALESCE(updated_at, created_at)) ${direction}, session_key ${direction}
-			 LIMIT ?`,
+					`SELECT st.session_key, st.content, st.harness, st.project, st.created_at, st.updated_at,
+					        EXISTS (
+					          SELECT 1 FROM summary_jobs AS sj
+					          WHERE sj.agent_id = st.agent_id AND sj.session_key = st.session_key
+					            AND sj.trigger IN ('session_end', 'ttl_expired')
+					        ) AS completed
+					 FROM session_transcripts AS st
+					 WHERE st.agent_id = ?
+					   AND (${transcriptCursor.sql} OR ${transcriptRequeue})
+					 ORDER BY julianday(COALESCE(st.updated_at, st.created_at)) ${direction}, st.session_key ${direction}
+					 LIMIT ?`,
 				)
 				.all(agentId, ...transcriptCursor.args, ...requeueArgs, boundedLimit)
 				.map((row) => {
@@ -497,6 +534,7 @@ export function readRecentEpisodicSources(
 						readonly project: string | null;
 						readonly created_at: string;
 						readonly updated_at: string | null;
+						readonly completed: number;
 					};
 					return {
 						kind: "transcript",
@@ -510,6 +548,7 @@ export function readRecentEpisodicSources(
 						harness: transcript.harness,
 						capturedAt: transcript.updated_at ?? transcript.created_at,
 						evidenceMeta: null,
+						completed: transcript.completed === 1,
 					} satisfies EpisodicSourceRecord;
 				})
 		: [];
@@ -549,6 +588,7 @@ export function readRecentEpisodicSources(
 						harness: summary.harness,
 						capturedAt: summary.latest_at,
 						evidenceMeta: null,
+						completed: true,
 					} satisfies EpisodicSourceRecord;
 				})
 		: [];

--- a/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
@@ -225,6 +225,106 @@ describe("dreaming-agent-tools", () => {
 		expect(JSON.stringify(entity).length).toBeLessThan(10_000);
 	});
 
+	it("search_evidence exposes completed on transcripts and settled records", async () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO session_transcripts
+				 (session_key, content, harness, project, agent_id, created_at, updated_at)
+				 VALUES ('run-live', 'intermediate investigation states', 'pi', null, 'owner',
+				  '2026-08-07T06:14:00.000Z', '2026-08-07T06:30:00.000Z')`,
+			).run();
+			db.prepare(
+				`INSERT INTO session_transcripts
+				 (session_key, content, harness, project, agent_id, created_at, updated_at)
+				 VALUES ('run-done', 'settled outcome', 'pi', null, 'owner',
+				  '2026-08-07T05:00:00.000Z', '2026-08-07T05:20:00.000Z')`,
+			).run();
+			db.prepare(
+				`INSERT INTO session_transcripts
+				 (session_key, content, harness, project, agent_id, created_at, updated_at)
+				 VALUES ('run-failed-summary', 'outcome despite summary timeout', 'pi', null, 'owner',
+				  '2026-08-07T04:00:00.000Z', '2026-08-07T04:30:00.000Z')`,
+			).run();
+			db.prepare(
+				`INSERT INTO session_transcripts
+				 (session_key, content, harness, project, agent_id, created_at, updated_at)
+				 VALUES ('run-checkpoint', 'mid-session checkpointed states', 'pi', null, 'owner',
+				  '2026-08-07T07:00:00.000Z', '2026-08-07T07:10:00.000Z')`,
+			).run();
+			// Session ended: summary job triggered and pending.
+			db.prepare(
+				`INSERT INTO summary_jobs
+				 (id, session_key, session_id, harness, project, agent_id, transcript,
+				  trigger, captured_at, started_at, ended_at, status, created_at)
+				 VALUES ('job-done', 'run-done', 'run-done', 'pi', null, 'owner',
+				  'settled outcome', 'session_end', '2026-08-07T05:20:00.000Z',
+				  '2026-08-07T05:20:00.000Z', '2026-08-07T05:20:00.000Z', 'pending',
+				  '2026-08-07T05:20:00.000Z')`,
+			).run();
+			// Session ended but the summary failed/timed out: still settled.
+			db.prepare(
+				`INSERT INTO summary_jobs
+				 (id, session_key, session_id, harness, project, agent_id, transcript,
+				  trigger, captured_at, started_at, ended_at, status, created_at)
+				 VALUES ('job-failed', 'run-failed-summary', 'run-failed-summary', 'pi', null, 'owner',
+				  'outcome despite summary timeout', 'session_end', '2026-08-07T04:30:00.000Z',
+				  '2026-08-07T04:30:00.000Z', null, 'failed',
+				  '2026-08-07T04:30:00.000Z')`,
+			).run();
+			// Mid-session checkpoint extract: not a session-end signal.
+			db.prepare(
+				`INSERT INTO summary_jobs
+				 (id, session_key, session_id, harness, project, agent_id, transcript,
+				  trigger, captured_at, started_at, ended_at, status, created_at)
+				 VALUES ('job-checkpoint', 'run-checkpoint', 'run-checkpoint', 'pi', null, 'owner',
+				  'mid-session checkpointed states', 'checkpoint_extract', '2026-08-07T07:10:00.000Z',
+				  '2026-08-07T07:10:00.000Z', null, 'completed',
+				  '2026-08-07T07:10:00.000Z')`,
+			).run();
+		});
+		insertEpisodicMemory("mem-settled", "settled memory capture");
+
+		const tools = createDreamingAgentTools({ accessor: getDbAccessor(), agentId: "owner", actor: "owner" });
+		const res = readResult(
+			await findTool(tools, "search_evidence").execute(
+				"call",
+				{ agentId: "owner", limit: 10 },
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		expect(res.ok).toBe(true);
+		const items = res.items as Array<{ sourceRef: string; completed: boolean }>;
+		const byRef = new Map(items.map((item) => [item.sourceRef, item]));
+		// A session-end job was triggered: settled, even while pending.
+		expect(byRef.get("transcript:run-done")?.completed).toBe(true);
+		// A still-running transcript is not settled.
+		expect(byRef.get("transcript:run-live")?.completed).toBe(false);
+		// A failed/timed-out summary job still proves the session ended.
+		expect(byRef.get("transcript:run-failed-summary")?.completed).toBe(true);
+		// A mid-session checkpoint extract does not settle the session.
+		expect(byRef.get("transcript:run-checkpoint")?.completed).toBe(false);
+		// Memories are settled captures by construction.
+		expect(byRef.get("memory:mem-settled")?.completed).toBe(true);
+
+		// The fragment paging path carries the same flag.
+		const fragment = readResult(
+			await findTool(tools, "search_evidence").execute(
+				"call",
+				{ agentId: "owner", sourceRef: "transcript:run-live", offset: 0, chunkSize: 500 },
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		expect(fragment.ok).toBe(true);
+		expect((fragment.items as Array<{ sourceRef: string; completed: boolean }>)[0]).toMatchObject({
+			sourceRef: "transcript:run-live",
+			completed: false,
+		});
+	});
+
 	it("get_evidence resolves claim provenance and link provenance through one tool", async () => {
 		insertEntity("e-atlas", "Atlas", "atlas", "owner");
 		insertActiveAttribute("e-atlas", "a-config", "Feature is enabled by default.", "owner");

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -78,6 +78,7 @@ function projectEvidenceItem(
 		contentTruncated: contentOffset > 0 || contentOffset + content.length < contentLength,
 		contentHasPrevious: contentOffset > 0,
 		contentHasNext: contentOffset + content.length < contentLength,
+		completed: source.completed,
 		sourceKind: source.sourceKind,
 		sourceId: source.sourceId,
 		sourcePath: source.sourcePath,
@@ -425,7 +426,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"search_evidence",
 			"Search episodic evidence",
-			"Full-text search immutable episodic memories, artifacts, transcripts, and summaries in one agent scope. Results contain exact bounded excerpts of the rendered evidence with contentOffset/contentLength; use sourceRef for citations, which are validated against the complete canonical source. If contentTruncated is true, page exact fragments with the same sourceRef and chunkSize: start at offset=0 when contentHasPrevious is true, then use offset=contentOffset+content.length from the fragment just returned until contentHasNext is false. Omit the query to list the most recent sources (e.g. with since as a cutoff). Artifacts are deduped by content hash: content-identical files across vault paths collapse to one canonical entry.",
+			"Full-text search immutable episodic memories, artifacts, transcripts, and summaries in one agent scope. Results contain exact bounded excerpts of the rendered evidence with contentOffset/contentLength; use sourceRef for citations, which are validated against the complete canonical source. Each record carries completed: memory, artifact, and summary records are settled captures (true); a transcript is true once a session-end summary job has been triggered for its session (the session ended), whether or not the summary itself landed, and false while the session is still running — do not file claims from a still-growing transcript, since its states may be contradicted by the session's end. If contentTruncated is true, page exact fragments with the same sourceRef and chunkSize: start at offset=0 when contentHasPrevious is true, then use offset=contentOffset+content.length from the fragment just returned until contentHasNext is false. Omit the query to list the most recent sources (e.g. with since as a cutoff). Artifacts are deduped by content hash: content-identical files across vault paths collapse to one canonical entry.",
 			true,
 			z.object({
 				agentId: z.string().min(1),

--- a/platform/daemon/src/pipeline/dreaming-evidence.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-evidence.test.ts
@@ -14,6 +14,7 @@ const SOURCE: EpisodicSourceRecord = {
 	harness: "pi",
 	capturedAt: "2026-08-03T00:00:00.000Z",
 	evidenceMeta: JSON.stringify({ aspects: [{ entityName: "Signet", aspect: "architecture" }] }),
+	completed: true,
 };
 
 describe("dreaming evidence", () => {
@@ -43,6 +44,10 @@ describe("dreaming evidence", () => {
 		}
 		expect(fragments.length).toBeGreaterThan(1);
 		expect(fragments.map((fragment) => fragment.content).join("")).toBe(source.content);
-		expect(createDreamingAgentEvidence(fragments).map((evidence) => evidence.content).join("")).toBe(source.content);
+		expect(
+			createDreamingAgentEvidence(fragments)
+				.map((evidence) => evidence.content)
+				.join(""),
+		).toBe(source.content);
 	});
 });

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -630,9 +630,11 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - Inspect the flagged target (get_entity — check aspects, claims, pinned).
    - Archive or merge it, citing its attention id (provenance: "attention:<uuid>", or attention:$<index> for a flag you minted in the same batch).
    - If you discover junk the queue did not flag, mint a flag op and archive in the same batch.
-3. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. For each new source:
+3. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
    - search_entities for subjects it establishes.
-   - Extract/update claims with exact-quote evidence from that source. The evidence source and the graph target must use the same agent scope: search evidence with the agentId of the entity you will update, then pass that same agentId to apply_ontology_ops. A source found in another scope cannot support a write here.
+   - File claims only for what the source establishes as settled fact: outcomes, decisions, shipped changes, stable behavior. Do not file instructions that were merely suggested, hypotheses or diagnoses, open questions, or intermediate states of an ongoing investigation. When a source shows an attempt and its outcome, file the outcome.
+   - Before adding a claim, check the target aspect's existing claims; if one covers the same key or is contradicted by the new evidence, supersede it (supersede_claim_value) instead of adding alongside.
+   - The evidence source and the graph target must use the same agent scope: search evidence with the agentId of the entity you will update, then pass that same agentId to apply_ontology_ops. A source found in another scope cannot support a write here.
    - create_entity only for durable subjects clearly established by the source.
    - Validate before writing (validate_proposal).
 4. Write the pass log (runbook_write): what changed, which sources were viewed, anything deferred with exact names.
@@ -737,9 +739,11 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 ### Per-pass process
 
 1. Read the pass log (runbook_read). Establish cutoff: sources viewed, changes applied, deferred items.
-2. Find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. For each new source:
+2. Find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
    - search_entities for subjects it establishes.
-   - Extract/update claims with exact-quote evidence from that source. The evidence source and the graph target must use the same agent scope: search evidence with the agentId of the entity you will update, then pass that same agentId to apply_ontology_ops. A source found in another scope cannot support a write here.
+   - File claims only for what the source establishes as settled fact: outcomes, decisions, shipped changes, stable behavior. Do not file instructions that were merely suggested, hypotheses or diagnoses, open questions, or intermediate states of an ongoing investigation. When a source shows an attempt and its outcome, file the outcome.
+   - Before adding a claim, check the target aspect's existing claims; if one covers the same key or is contradicted by the new evidence, supersede it (supersede_claim_value) instead of adding alongside.
+   - The evidence source and the graph target must use the same agent scope: search evidence with the agentId of the entity you will update, then pass that same agentId to apply_ontology_ops. A source found in another scope cannot support a write here.
    - create_entity only for durable subjects clearly established by the source.
    - Validate before writing (validate_proposal).
 3. Write the pass log (runbook_write): what changed, which sources were viewed, anything deferred with exact names.


### PR DESCRIPTION
## Summary

Fixes #1140: content passes were filing a still-running session's transcript as settled fact — intermediate investigation states, an instruction (`VACUUM` reclaims the 29GB) and a hypothesis (`VACUUM` requires free disk ≈ db size) landed as durable claims, and nothing superseded them when later evidence contradicted them.

Two-part fix:

1. **Runbook** — step 3 of the combined prompt and step 2 of the content-only prompt now (a) prefer evidence from completed sessions and their summaries, deferring mid-stream transcripts (`completed: false`) with a pass-log note, (b) define what is filable (settled outcomes/decisions/changes only — not suggested instructions, hypotheses, open questions, or intermediate investigation states), and (c) require superseding an existing claim via `supersede_claim_value` when new evidence covers the same key or contradicts it, instead of adding alongside.

2. **Tool surface** — `search_evidence` records now carry `completed` so the runbook rule has something to ground on. Immutable kinds (memory, artifact, summary) are always `true`; a transcript is `true` once a session-end summary job has been triggered for its session (`summary_jobs.trigger IN ('session_end', 'ttl_expired')`), whether or not the summary itself lands, and `false` while the session is still running. The trigger row is written before any LLM work, so a timed-out or failed summary job cannot strand the transcript as mid-stream forever; mid-session `checkpoint_extract` jobs deliberately do not count.

## Changes

- `platform/daemon/src/episodic-sources.ts`: `EpisodicSourceRecord.completed`; transcript readers (single + batch) compute it via EXISTS on `summary_jobs` (agent-scoped, `trigger` in session_end/ttl_expired — the summary trigger, not its outcome); memory/artifact/summary construction sites set `true`.
- `platform/daemon/src/pipeline/dreaming-capabilities.ts`: `search_evidence` items expose `completed` (list and fragment paths); tool description documents the field and the mid-stream deferral rule.
- `platform/daemon/src/pipeline/dreaming.ts`: runbook step 3 (combined) and step 2 (content-only) replaced per the issue's proposed text.
- Tests: `episodic-sources.test.ts` (running vs session-ended vs failed-summary vs mid-session-checkpoint transcripts), `dreaming-agent-tools.test.ts` (search_evidence surfaces `completed` on list + fragment paths).

## Type

- [x] Bug fix (non-breaking; regression tests added)

## Packages affected

- `@signet/daemon`

## Screenshots

N/A (no UI change)

## Precision fixes vs. the issue text

- Kept the agent-scope sentence ("evidence source and graph target must use the same agent scope...") in both runbook steps. The issue's proposed replacement omitted it; dropping it would regress cross-scope evidence rejection. Listed per the dreaming workflow rule.
- Numbering/structure adapted for the content-only prompt (step 2, no hygiene preamble) — same substance as the combined prompt's step 3.

## Verification

- `bun test` on touched areas: 311 pass, 5 pre-existing failures in `maintenance-worker` (inference provider resolver not initialised in those tests — fail identically on main with these changes stashed).
- `bunx biome check` clean on all touched files (incl. a pre-existing format violation in `dreaming-evidence.test.ts` fixed while in the file).
- `bun run --filter '@signet/daemon' build` clean; `@signet/daemon` typecheck clean.

## AI assistance

Assisted-by: Hermes-Agent:deepseek-v4-flash

## Mandatory checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally