### PR TITLE
fix(daemon): defer source tombstone cleanup to post-DB-init (#1143)

### DIFF
--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -183,7 +183,7 @@ import { registerSecretRoutes } from "./routes/secrets-routes.js";
 import { registerSessionRoutes } from "./routes/session-routes.js";
 import { mountSkillAnalyticsRoutes } from "./routes/skill-analytics.js";
 import { mountSkillsRoutes, setFetchEmbedding } from "./routes/skills.js";
-import { registerSourcesRoutes } from "./routes/sources-routes.js";
+import { cleanupSourceDeletionTombstones, registerSourcesRoutes } from "./routes/sources-routes.js";
 import { registerTelemetryRoutes } from "./routes/telemetry-routes.js";
 import { checkEmbeddingProvider } from "./routes/utils.js";
 import { mountWidgetRoutes } from "./routes/widget.js";
@@ -1717,6 +1717,14 @@ async function main() {
 	// registration) would interfere with the DB write connection if allowed
 	// to run between recovery batches (#1059).
 	runStartupRecovery(getDbAccessor());
+
+	// Purge artifacts of sources deleted while the daemon was down (e.g.
+	// crash-loop-disabled sources). This needs the DB accessor, so it runs
+	// here in the startup sequence — not at route registration, which
+	// executes before DB init and crashed the daemon whenever a tombstone
+	// existed at boot (#1143). Failures are tolerated inside the cleanup;
+	// failed purges defer to the next boot.
+	cleanupSourceDeletionTombstones(AGENTS_DIR);
 
 	const { extensionPath } = getVectorRuntimeStatus();
 	const bundled = join(__dirname, "synthesis-render-worker.js");

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { addDiscordSource, addObsidianSource, loadSourcesConfig } from "@signet/core";
@@ -18,7 +18,7 @@ import {
 	markSourceIndexJobRunning,
 	updateSourceIndexJobProgress,
 } from "../source-index-progress";
-import { registerSourcesRoutes } from "./sources-routes";
+import { cleanupSourceDeletionTombstones, registerSourcesRoutes } from "./sources-routes";
 
 const originalFetch = globalThis.fetch;
 
@@ -386,7 +386,7 @@ describe("Sources routes", () => {
 		expect(purges).toBe(2);
 	});
 
-	it("purges tombstoned disconnected source artifacts when routes register after restart", async () => {
+	it("purges tombstoned disconnected source artifacts after DB init, not at route registration (#1143)", async () => {
 		let releaseScan = () => {};
 		let scanStarted = false;
 		let runtimePurges = 0;
@@ -409,18 +409,62 @@ describe("Sources routes", () => {
 		).toBe(200);
 		expect(runtimePurges).toBe(1);
 
+		// Route registration runs before the DB accessor is initialized, so it
+		// must not purge tombstones: the old behavior crashed the daemon with
+		// "DbAccessor not initialised" whenever a tombstone existed at boot.
 		const restarted = new Hono();
-		registerSourcesRoutes(restarted, {
-			agentsDir: dir,
-			purgeNativeSource: () => {
-				startupPurges++;
-				return 1;
-			},
+		expect(() =>
+			registerSourcesRoutes(restarted, {
+				agentsDir: dir,
+				purgeNativeSource: () => {
+					throw new Error("DbAccessor not initialised — call initDbAccessor() first");
+				},
+			}),
+		).not.toThrow();
+		expect(runtimePurges).toBe(1);
+
+		// The startup sequence runs the purge after DB init.
+		cleanupSourceDeletionTombstones(dir, () => {
+			startupPurges++;
+			return 1;
 		});
 		expect(startupPurges).toBe(1);
 
 		releaseScan();
 		await waitFor(() => runtimePurges === 2);
+	});
+
+	it("defers a failed tombstone purge instead of crashing startup", () => {
+		const tombstonePath = join(dir, ".daemon", "source-deletion-tombstones.json");
+		mkdirSync(join(dir, ".daemon"), { recursive: true });
+		writeFileSync(
+			tombstonePath,
+			`${JSON.stringify(
+				[
+					{
+						id: "tombstone-1",
+						source: { id: "ghost-vault", name: "Ghost Vault", kind: "obsidian", root: vault },
+						agentId: "test-agent",
+						deletedAt: new Date().toISOString(),
+					},
+				],
+				null,
+				2,
+			)}\n`,
+		);
+		let attempts = 0;
+		expect(() =>
+			cleanupSourceDeletionTombstones(dir, () => {
+				attempts++;
+				throw new Error("embedding store unavailable");
+			}),
+		).not.toThrow();
+		expect(attempts).toBe(1);
+		// The tombstone survives a failed purge so the next boot retries it.
+		expect(JSON.parse(readFileSync(tombstonePath, "utf8"))).toHaveLength(1);
+
+		cleanupSourceDeletionTombstones(dir, () => 1);
+		expect(JSON.parse(readFileSync(tombstonePath, "utf8"))).toHaveLength(0);
 	});
 
 	it("reports source chunk stats using source-owned chunk id prefixes", async () => {

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -19,6 +19,7 @@ import type { Hono } from "hono";
 import { resolveDaemonAgentId } from "../agent-id";
 import { type ReadDb, getDbAccessor } from "../db-accessor";
 import { fetchEmbedding } from "../embedding-fetch";
+import { logger } from "../logger";
 import { loadMemoryConfig } from "../memory-config";
 import {
 	type NativeMemoryBridgeHandle,
@@ -118,7 +119,6 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 	const agentsDir = deps.agentsDir ?? process.env.SIGNET_PATH ?? `${homedir()}/.agents`;
 	const startBridge = deps.startBridge ?? startNativeMemoryBridge;
 	const purgeNativeSource = deps.purgeNativeSource ?? purgeNativeMemorySourceArtifacts;
-	cleanupSourceDeletionTombstones(agentsDir, purgeNativeSource);
 	app.get("/api/sources", (c) => {
 		const config = loadSourcesConfig(agentsDir);
 		const agentId = resolveDaemonAgentId();
@@ -438,9 +438,19 @@ function scheduleSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob,
 	}, delayMs).unref?.();
 }
 
-function cleanupSourceDeletionTombstones(
-	agentsDir: string,
-	purgeNativeSource: typeof purgeNativeMemorySourceArtifacts,
+/**
+ * Purge artifacts of sources deleted while the daemon was down and drop their
+ * tombstones. Runs in the daemon startup sequence AFTER the DB accessor is
+ * initialized (#1143): route registration executes before DB init, so it must
+ * not trigger this — the old placement crashed the daemon with "DbAccessor not
+ * initialised" whenever a tombstone existed at boot.
+ *
+ * A failed purge is logged and its tombstone is kept for the next boot:
+ * tombstone processing must never brick startup.
+ */
+export function cleanupSourceDeletionTombstones(
+	agentsDir = process.env.SIGNET_PATH ?? `${homedir()}/.agents`,
+	purgeNativeSource: typeof purgeNativeMemorySourceArtifacts = purgeNativeMemorySourceArtifacts,
 ): void {
 	const tombstones = loadSourceDeletionTombstones(agentsDir);
 	if (tombstones.length === 0) return;
@@ -449,7 +459,17 @@ function cleanupSourceDeletionTombstones(
 	for (const tombstone of tombstones) {
 		if (configuredIds.has(tombstone.source.id)) continue;
 		const provider = getSourceProvider(tombstone.source.kind);
-		if (provider) purgeSource(provider, tombstone.source, tombstone.agentId, purgeNativeSource);
+		if (!provider) continue;
+		try {
+			purgeSource(provider, tombstone.source, tombstone.agentId, purgeNativeSource);
+		} catch (err) {
+			remaining.push(tombstone);
+			logger.warn(
+				"system",
+				`Source-deletion tombstone purge failed for source ${tombstone.source.id}; deferring to next boot`,
+				{ error: err instanceof Error ? err.message : String(err) },
+			);
+		}
 	}
 	saveSourceDeletionTombstones(remaining, agentsDir);
 }


### PR DESCRIPTION
## Summary

Fixes #1143. The daemon bricked at startup whenever `source-deletion-tombstones.json` had entries: `cleanupSourceDeletionTombstones` ran synchronously inside `registerSourcesRoutes`, which executes at module import time — before `initDbAccessorAsync`. The purge path calls `getDbAccessor()` unconditionally, so boot crashed with `DbAccessor not initialised` and the daemon could not start until the tombstone file was manually cleared.

## Changes

- `platform/daemon/src/routes/sources-routes.ts`:
  - Removed the `cleanupSourceDeletionTombstones` call from `registerSourcesRoutes` (route registration now never touches tombstones).
  - Exported `cleanupSourceDeletionTombstones` with default `agentsDir`/`purgeNativeSource` resolution.
  - Per-tombstone `try/catch`: a failed purge is logged and its tombstone is kept for the next boot instead of crashing startup.
- `platform/daemon/src/daemon.ts`: calls `cleanupSourceDeletionTombstones(AGENTS_DIR)` in `main()` after `runStartupRecovery` (DB accessor initialized, before workers start).
- `platform/daemon/src/routes/sources-routes.test.ts`:
  - Updated the restart test: registration with a purge that throws `DbAccessor not initialised` must not throw and must not purge; the startup-sequence cleanup purges exactly once.
  - Added regression test: a failing tombstone purge defers the tombstone (file retained), and a later successful run clears it.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`

## Screenshots

N/A (no UI changes).

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Testing

- [x] `bun test` passes (sources-routes.test.ts: 30 pass, 0 fail)
- [x] `bun run typecheck` passes (`@signet/daemon`)
- [x] `bun run lint` passes (touched files biome-clean)
- [ ] Tested against running daemon
- [x] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)
