### PR TITLE
fix(daemon): drop vanished native-memory artifacts, back off failed reads (#1142)

### DIFF
--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -743,6 +743,84 @@ describe("native memory sources", () => {
 		expect(after).toEqual({ artifacts: 0, entities: 0, attrs: 0 });
 	});
 
+	it("drops a vanished artifact from the index on ENOENT and stops retrying it (#1142)", async () => {
+		const root = join(dir, "vault");
+		const source = obsidianNativeMemorySource(root, "Vault", "obsidian:enoent-vault");
+		const file = join(root, "permanent", "Vanished.md");
+		mkdirSync(join(root, "permanent"), { recursive: true });
+		writeFileSync(file, "# Vanished\n\nThis file is deleted between the scan listing and the read.\n");
+
+		expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(true);
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare(
+							"SELECT COUNT(*) AS count FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0",
+						)
+						.get("agent-native", file) as { count: number },
+			).count,
+		).toBe(1);
+
+		// The file vanishes before the watcher reads it (ENOENT).
+		rmSync(file);
+
+		expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(false);
+		// The stale row is soft-deleted instead of being retried every scan.
+		const after = getDbAccessor().withReadDb((db) => ({
+			active: (
+				db
+					.prepare(
+						"SELECT COUNT(*) AS count FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0",
+					)
+					.get("agent-native", file) as { count: number }
+			).count,
+			softDeleted: (
+				db
+					.prepare(
+						"SELECT COUNT(*) AS count FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 1",
+					)
+					.get("agent-native", file) as { count: number }
+			).count,
+		}));
+		expect(after.active).toBe(0);
+		expect(after.softDeleted).toBe(1);
+
+		// Re-attempting the gone path stays a no-op.
+		expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(false);
+	});
+
+	it("keeps artifact rows on transient read failures and backs off retries (#1142)", async () => {
+		const root = join(dir, ".codex");
+		const file = join(root, "memories", "memory_summary.md");
+		mkdirSync(join(root, "memories"), { recursive: true });
+		writeFileSync(file, "Codex remembered the locked-file contract.\n");
+
+		expect(await indexNativeMemoryFile(codexNativeMemorySource(root), file, "agent-native")).toBe(true);
+
+		// Make the path fail with a non-ENOENT error (parent replaced by a
+		// file -> ENOTDIR), standing in for a transiently locked file.
+		rmSync(root, { recursive: true, force: true });
+		writeFileSync(join(dir, ".codex"), "now a plain file\n");
+
+		expect(await indexNativeMemoryFile(codexNativeMemorySource(root), file, "agent-native")).toBe(false);
+		// Transient failures must NOT drop the artifact row (only ENOENT does).
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare(
+							"SELECT COUNT(*) AS count FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0",
+						)
+						.get("agent-native", file) as { count: number },
+			).count,
+		).toBe(1);
+
+		// The path is in failure cooldown: the retry is skipped, still false,
+		// and the row is untouched.
+		expect(await indexNativeMemoryFile(codexNativeMemorySource(root), file, "agent-native")).toBe(false);
+	});
+
 	it("embeds heading-aware Obsidian source chunks when embedding options are provided", async () => {
 		const root = join(dir, "vault");
 		const file = join(root, "permanent", "Signet.md");

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, lstatSync, statSync } from "node:fs";
-import { readFile, readdir } from "node:fs/promises";
+import { lstat, readFile, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import {
@@ -99,6 +98,25 @@ interface IndexedNativeMemory {
 const indexed = new Map<string, IndexedNativeMemory>();
 const DEFAULT_OBSIDIAN_SOURCE_FILE_DELAY_MS = 250;
 
+// Read failures that are not permanent (ENOENT) enter a per-path cooldown so
+// a failing file cannot monopolize the scan loop. ENOENT drops the path from
+// the index entirely — the file is gone, retrying it is pointless (#1142).
+const READ_FAILURE_BACKOFF_MS = 60_000;
+const readFailureBackoffUntil = new Map<string, number>();
+
+function isEnoentError(err: unknown): boolean {
+	return typeof err === "object" && err !== null && (err as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+async function pathExists(path: string): Promise<boolean> {
+	try {
+		await stat(path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 function codexRoot(): string {
 	return join(homedir(), ".codex");
 }
@@ -178,7 +196,7 @@ export function configuredNativeMemorySources(agentsDir?: string): NativeMemoryS
 }
 
 async function* walkNativeMemoryFiles(dir: string): AsyncGenerator<string> {
-	if (!existsSync(dir)) return;
+	if (!(await pathExists(dir))) return;
 	const entries = await readdir(dir, { withFileTypes: true });
 	for (const entry of entries) {
 		if (entry.name === ".git") continue;
@@ -434,20 +452,40 @@ export async function indexNativeMemoryFile(
 	const pattern = matchesPattern(source, filePath);
 	if (!pattern) return false;
 
+	const key = fingerprintKey(source, filePath, agentId);
+	const cooldownUntil = readFailureBackoffUntil.get(key);
+	if (cooldownUntil !== undefined && Date.now() < cooldownUntil) return false;
+
 	let content = "";
 	let mtimeMs = 0;
 	try {
-		const linkStat = lstatSync(filePath);
+		const linkStat = await lstat(filePath);
 		if (linkStat.isSymbolicLink()) return false;
-		const stat = statSync(filePath);
-		if (!stat.isFile()) return false;
-		mtimeMs = stat.mtimeMs;
-		// Async read: a transiently locked file (EDEADLK from Obsidian or a
-		// sync service) must not block the daemon event loop for tens of
-		// seconds. Async readFile runs in the threadpool; the event loop stays
-		// responsive even while the lock is held.
+		const fileStat = await stat(filePath);
+		if (!fileStat.isFile()) return false;
+		mtimeMs = fileStat.mtimeMs;
+		// Async reads and stats run in the threadpool: a transiently locked
+		// file (EDEADLK from Obsidian or a sync service) or a stalled
+		// filesystem must not block the daemon event loop for seconds
+		// (#1135, #1142).
 		content = await readFile(filePath, "utf-8");
 	} catch (err) {
+		if (isEnoentError(err)) {
+			// The file vanished between the scan listing and the read — it is
+			// gone. Drop it from the index so later scans stop retrying the
+			// same ENOENT on every pass instead of accumulating stale
+			// artifact rows that desync the FTS index (#1142).
+			readFailureBackoffUntil.delete(key);
+			removeNativeMemoryFile(source, filePath, agentId);
+			logger.debug("watcher", "Dropped vanished native memory artifact", {
+				harness: source.harness,
+				path: filePath,
+			});
+			return false;
+		}
+		// Transient failures (locks, permission flaps) back off instead of
+		// being re-attempted on every scan iteration.
+		readFailureBackoffUntil.set(key, Date.now() + READ_FAILURE_BACKOFF_MS);
 		logger.warn("watcher", "Failed reading native memory artifact", {
 			harness: source.harness,
 			path: filePath,
@@ -455,9 +493,9 @@ export async function indexNativeMemoryFile(
 		});
 		return false;
 	}
+	readFailureBackoffUntil.delete(key);
 	if (!content.trim()) return false;
 
-	const key = fingerprintKey(source, filePath, agentId);
 	const hash = contentFingerprint(content);
 	const persistedHash = nativeArtifactContentHash(filePath, agentId);
 	const obsidian = source.harness === "obsidian" && pattern.kind === "source_obsidian_markdown";
@@ -667,7 +705,7 @@ export function startNativeMemoryBridge(
 			let scanned = 0;
 			const key = sourceStateKey(source, agentId);
 			const current = new Set<string>();
-			const rootExists = existsSync(source.root);
+			const rootExists = await pathExists(source.root);
 			if (rootExists) {
 				const files: string[] = [];
 				for await (const file of walkNativeMemoryFiles(source.root)) {

--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -26,6 +26,7 @@ import {
 	reembedModelMigration,
 	releaseStaleLeases,
 	requeueDeadJobs,
+	resetFtsRebuildConfirmation,
 	resyncVectorIndex,
 	triggerRetentionSweep,
 } from "./repair-actions";
@@ -134,12 +135,28 @@ const CTX_AGENT = {
 	actorType: "agent" as const,
 };
 
+const CTX_DAEMON = {
+	reason: "test run",
+	actor: "test-daemon",
+	actorType: "daemon" as const,
+};
+
 function insertMemory(db: Database, id: string): void {
 	const now = new Date().toISOString();
 	db.prepare(
 		`INSERT INTO memories (id, content, type, created_at, updated_at, updated_by)
 		 VALUES (?, ?, ?, ?, ?, ?)`,
 	).run(id, `content for ${id}`, "fact", now, now, "test");
+}
+
+function repairAuditCount(db: Database, action: string): number {
+	const rows = db.prepare("SELECT metadata FROM memory_history WHERE metadata LIKE ?").all(`%${action}%`) as Array<{
+		metadata: string;
+	}>;
+	return rows.filter((row) => {
+		const parsed = JSON.parse(row.metadata) as { repairAction?: string };
+		return parsed.repairAction === action;
+	}).length;
 }
 
 function insertJob(
@@ -750,6 +767,7 @@ describe("checkFtsConsistency", () => {
 		db = new Database(":memory:");
 		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
 		accessor = asAccessor(db);
+		resetFtsRebuildConfirmation();
 	});
 
 	afterEach(() => {
@@ -801,6 +819,41 @@ describe("checkFtsConsistency", () => {
 		const sql = readMemoriesFtsSql(toFtsSchemaQueryDb(db));
 		expect(sql).toContain("tokenize='unicode61'");
 		expect(sql).not.toContain("porter unicode61");
+	});
+
+	it("defers autonomous FTS rebuilds until the mismatch persists (#1142)", () => {
+		insertMemory(db, "mem-fts-defer");
+		// A soft-deleted (tombstoned) memory pushes the FTS backing count past
+		// the 10% tolerance — the mismatch signal the check acts on.
+		insertMemory(db, "mem-fts-defer-tombstone");
+		db.prepare("UPDATE memories SET is_deleted = 1 WHERE id = ?").run("mem-fts-defer-tombstone");
+
+		// First observation: held back so a transient spike cannot trigger a
+		// synchronous (event-loop-blocking) rebuild on every cycle.
+		const first = checkFtsConsistency(accessor, TEST_CFG, CTX_DAEMON, createRateLimiter(), true);
+		expect(first.success).toBe(true);
+		expect(first.affected).toBe(0);
+		expect(first.message).toMatch(/deferred/);
+		expect(repairAuditCount(db, "checkFtsConsistency")).toBe(0);
+
+		// Same mismatch on the next maintenance cycle: persistent, rebuild.
+		const second = checkFtsConsistency(accessor, TEST_CFG, CTX_DAEMON, createRateLimiter(), true);
+		expect(second.success).toBe(true);
+		expect(second.affected).toBe(1);
+		expect(second.message).toMatch(/rebuilt/);
+		expect(repairAuditCount(db, "checkFtsConsistency")).toBe(1);
+	});
+
+	it("rebuilds immediately when an operator explicitly triggers repair (#1142)", () => {
+		insertMemory(db, "mem-fts-operator");
+		insertMemory(db, "mem-fts-operator-tombstone");
+		db.prepare("UPDATE memories SET is_deleted = 1 WHERE id = ?").run("mem-fts-operator-tombstone");
+
+		const result = checkFtsConsistency(accessor, TEST_CFG, CTX_OPERATOR, createRateLimiter(), true);
+		expect(result.success).toBe(true);
+		expect(result.affected).toBe(1);
+		expect(result.message).toMatch(/rebuilt/);
+		expect(repairAuditCount(db, "checkFtsConsistency")).toBe(1);
 	});
 });
 

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -202,6 +202,17 @@ const DEFAULT_REQUEUE_BATCH = 50;
 // FTS rebuilds are heavyweight; cap their hourly budget at 5
 const FTS_HOURLY_BUDGET = 5;
 
+// FTS rebuilds run synchronously and can block the daemon event loop for
+// seconds on large stores. Hold an autonomous rebuild until the same mismatch
+// is observed on a second check, so a transient spike from in-flight artifact
+// writes cannot trigger a rebuild on every maintenance cycle (#1142).
+let ftsMismatchPendingRebuild = false;
+
+/** Reset the FTS rebuild confirmation state (for tests). */
+export function resetFtsRebuildConfirmation(): void {
+	ftsMismatchPendingRebuild = false;
+}
+
 // ---- Issue #901 shared constants ----
 /** Capped number of ids returned in dry-run previews. */
 const PREVIEW_CAP = 100;
@@ -535,6 +546,8 @@ export function checkFtsConsistency(
 				recreateMemoriesFts(db);
 				writeRepairAudit(db, action, ctx, 1, "FTS recreated with unicode61 tokenizer");
 			});
+			// The recreate is itself a full rebuild; any prior mismatch is moot.
+			ftsMismatchPendingRebuild = false;
 		}
 
 		limiter.record(action);
@@ -560,31 +573,51 @@ export function checkFtsConsistency(
 	// the threshold in diagnostics.ts getIndexHealth().
 	const mismatch = memCount > 0 && ftsCount > memCount * 1.1;
 
+	let rebuilt = false;
 	if (mismatch && repair) {
-		accessor.withWriteTx((db) => {
-			db.prepare("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')").run();
-			writeRepairAudit(db, action, ctx, 1, `FTS rebuilt: ${memCount} active vs ${ftsCount} FTS rows`);
-		});
+		// Operator-triggered repairs are explicit intent and rebuild at once;
+		// autonomous repair waits for a second observation so a transient
+		// mismatch cannot trigger a synchronous rebuild every cycle (#1142).
+		const confirmed = ctx.actorType === "operator" || ftsMismatchPendingRebuild;
+		if (confirmed) {
+			accessor.withWriteTx((db) => {
+				db.prepare("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')").run();
+				writeRepairAudit(db, action, ctx, 1, `FTS rebuilt: ${memCount} active vs ${ftsCount} FTS rows`);
+			});
+			ftsMismatchPendingRebuild = false;
+			rebuilt = true;
+		} else {
+			ftsMismatchPendingRebuild = true;
+			logger.warn("pipeline", "repair: FTS mismatch observed, deferring rebuild until it persists", {
+				memCount,
+				ftsCount,
+				actor: ctx.actor,
+			});
+		}
+	} else if (!mismatch) {
+		ftsMismatchPendingRebuild = false;
 	}
 
 	limiter.record(action);
 
 	const message = mismatch
-		? `FTS mismatch: ${memCount} active memories vs ${ftsCount} FTS rows${repair ? " — rebuilt" : ""}`
+		? rebuilt
+			? `FTS mismatch: ${memCount} active vs ${ftsCount} FTS rows — rebuilt`
+			: `FTS mismatch: ${memCount} active vs ${ftsCount} FTS rows (rebuild deferred until mismatch persists)`
 		: `FTS consistent: ${memCount} active, ${ftsCount} FTS rows`;
 
 	logger.info("pipeline", "repair: FTS consistency check", {
 		memCount,
 		ftsCount,
 		mismatch,
-		repaired: mismatch && repair,
+		repaired: rebuilt,
 		actor: ctx.actor,
 	});
 
 	return {
 		action,
 		success: true,
-		affected: mismatch ? 1 : 0,
+		affected: rebuilt ? 1 : 0,
 		message,
 	};
 }


### PR DESCRIPTION
## Summary

Fixes #1142 — the native-memory artifact watcher retry-loops forever on artifact paths whose files were deleted from disk. Each retry was a synchronous `statx` on the main thread; with no backoff the loop hammered the same ENOENT every ~250ms, desynced the FTS index (triggering the consistency repair loop), and produced sustained 16-17s event-loop blocks that wedged and killed the daemon (4 deaths over ~24h on the live box, plus a 91-ENOENT burst during the 2026-08-07 vault move).

## Changes

- `platform/daemon/src/native-memory-sources.ts`
  - `indexNativeMemoryFile` now stats via `fs/promises` (`lstat`/`stat`) instead of synchronous `lstatSync`/`statSync`, so a stalled filesystem can never block the daemon event loop (the sync-statx-on-main-thread class from the issue).
  - On ENOENT the path is dropped from the index: artifact rows are soft-deleted and Obsidian graph rows purged via `removeNativeMemoryFile`, so later scans stop retrying a gone path and stale rows stop desyncing FTS.
  - Non-ENOENT read failures (locks, permission flaps) enter a 60s per-path failure cooldown instead of being re-attempted every scan iteration.
  - Walk/root checks use async `pathExists` instead of `existsSync`.
- `platform/daemon/src/repair-actions.ts`
  - `checkFtsConsistency` defers the heavyweight synchronous FTS rebuild for autonomous/daemon repair until the same mismatch is observed on a second check; operator-triggered repair (`/api/repair/check-fts`) still rebuilds immediately. Transient mismatches from in-flight writes can no longer trigger a ~17s blocking rebuild on every maintenance cycle.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A — daemon-side fix.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no schema changes.

## Testing

- `native-memory-sources.test.ts` 44/44, including two new regression tests: ENOENT drop + stop retrying, and non-ENOENT failures keep rows + back off.
- `repair-actions.test.ts` 59/59, including two new tests: autonomous FTS rebuild deferred until the mismatch persists; operator-triggered repair rebuilds immediately.
- `memory-lineage.test.ts` + `routes/sources-routes.test.ts` 55/55.
- `maintenance-worker.test.ts` + `diagnostics.test.ts` show the same 5 pre-existing failures on pristine main (inference-provider env issue, unrelated).
- `@signet/daemon` build + typecheck pass; full-repo typecheck has pre-existing connector failures on main (`@signet/connector-base` needs a build step in fresh worktrees).
- `bunx biome check` clean on all touched files.

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Work was developed in a separate worktree (`/tmp/signet-1142`) because a concurrent Hermes session was hard-resetting the shared checkout while working on #1139.
- Follow-up (out of scope): production daemon runs `sourceCleanupEnabled: false`, so artifact rows for files deleted *between* scans (never re-walked, hence no ENOENT) still accumulate. The ENOENT drop fixes the retry loop; a separate cleanup reconciliation is a possible follow-up issue.
