### PR TITLE
feat(daemon): write-gate aspect/attribute caps that force supersession (#1138)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -946,8 +946,10 @@ supplementary.
 |-------|---------|-------|-------------|
 | `enabled` | `true` | — | Enable graph traversal |
 | `primary` | `true` | — | Use traversal as primary retrieval strategy |
-| `maxAspectsPerEntity` | `10` | 1-50 | Max aspects to collect per entity |
-| `maxAttributesPerAspect` | `20` | 1-100 | Max attributes per aspect |
+| `maxAspectsPerEntity` | `10` | 1-50 | Max aspects to collect per entity (read cap) |
+| `maxAttributesPerAspect` | `25` | 1-100 | Max attributes per aspect (read cap) |
+| `maxWriteAspectsPerEntity` | `10` | 1-50 | Max active aspects per entity before create_aspect is rejected |
+| `maxWriteAttributesPerAspect` | `25` | 1-100 | Max active attributes per aspect before add_claim_value is rejected |
 | `maxDependencyHops` | `10` | 1-50 | Max hops for dependency walking |
 | `minDependencyStrength` | `0.3` | 0.0-1.0 | Minimum edge strength to follow |
 | `maxBranching` | `4` | 1-20 | Max branching factor during traversal |
@@ -964,7 +966,9 @@ memory:
       enabled: true
       primary: true
       maxAspectsPerEntity: 10
-      maxAttributesPerAspect: 20
+      maxAttributesPerAspect: 25
+      maxWriteAspectsPerEntity: 10
+      maxWriteAttributesPerAspect: 25
       maxDependencyHops: 10
       minDependencyStrength: 0.3
       maxBranching: 4

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -946,10 +946,10 @@ supplementary.
 |-------|---------|-------|-------------|
 | `enabled` | `true` | — | Enable graph traversal |
 | `primary` | `true` | — | Use traversal as primary retrieval strategy |
-| `maxAspectsPerEntity` | `10` | 1-50 | Max aspects to collect per entity (read cap) |
-| `maxAttributesPerAspect` | `25` | 1-100 | Max attributes per aspect (read cap) |
-| `maxWriteAspectsPerEntity` | `10` | 1-50 | Max active aspects per entity before create_aspect is rejected |
-| `maxWriteAttributesPerAspect` | `25` | 1-100 | Max active attributes per aspect before add_claim_value is rejected |
+| `maxAspectsPerEntity` | `20` | 1-50 | Max aspects to collect per entity (read cap) |
+| `maxAttributesPerAspect` | `50` | 1-100 | Max attributes per aspect (read cap) |
+| `maxWriteAspectsPerEntity` | `20` | 1-50 | Max active aspects per entity before create_aspect is rejected |
+| `maxWriteAttributesPerAspect` | `50` | 1-100 | Max active attributes per aspect before add_claim_value is rejected |
 | `maxDependencyHops` | `10` | 1-50 | Max hops for dependency walking |
 | `minDependencyStrength` | `0.3` | 0.0-1.0 | Minimum edge strength to follow |
 | `maxBranching` | `4` | 1-20 | Max branching factor during traversal |
@@ -965,10 +965,10 @@ memory:
     traversal:
       enabled: true
       primary: true
-      maxAspectsPerEntity: 10
-      maxAttributesPerAspect: 25
-      maxWriteAspectsPerEntity: 10
-      maxWriteAttributesPerAspect: 25
+      maxAspectsPerEntity: 20
+      maxAttributesPerAspect: 50
+      maxWriteAspectsPerEntity: 20
+      maxWriteAttributesPerAspect: 50
       maxDependencyHops: 10
       minDependencyStrength: 0.3
       maxBranching: 4

--- a/docs/KNOWLEDGE-GRAPH.md
+++ b/docs/KNOWLEDGE-GRAPH.md
@@ -225,6 +225,7 @@ The control plane applies or proposes graph operations such as:
 - `update_link`
 - `archive_link`
 - `merge_entities`
+- `merge_aspects`
 - `supersede_claim_value`
 - policy, action type, and interface operations
 

--- a/docs/api/memory.md
+++ b/docs/api/memory.md
@@ -88,6 +88,8 @@ Body-level fields override prefix-parsed values.
   "validFrom": "2026-02-20T00:00:00.000Z",
   "validUntil": "2026-03-01T00:00:00.000Z",
   "reviewAfter": "2026-08-03T00:00:00.000Z",
+  "supersedes": "existing-memory-id",
+  "reason": "newer evidence replaces the old claim",
   "agentId": "alice",
   "visibility": "global"
 }
@@ -117,6 +119,13 @@ valid ISO timestamp; `validUntil` must be after `validFrom` when both are set.
 `reviewAfter` is an optional ISO timestamp for a future temporal claim. Dreaming
 uses it to surface the memory for review after the deadline instead of assuming
 that the planned event occurred.
+
+`supersedes` is an optional memory id. When set, the named memory is marked
+`superseded_by` = the new id in the same transaction (atomic lineage, no
+orphans). The new row becomes the head of a drillable chain; `reason` is
+recorded on the superseded row. A missing or cross-scope supersedes target
+fails the whole write. Chain history is readable from any row via
+`GET /api/memory/:id/lineage`, which walks `superseded_by` links newest-first.
 
 Row-level provenance fields are optional: `sourcePath`/`source_path` stores the
 original source path, `runtimePath`/`runtime_path` stores the runtime-relative
@@ -294,6 +303,32 @@ permission.
       "sessionId": null,
       "requestId": null
     }
+  ]
+}
+```
+
+### GET /api/memory/:id/lineage
+
+Supersession chain for a memory, newest first. Requires `recall` permission.
+Walks `superseded_by` links from any row in the chain to the head, so drilling
+from an old version surfaces the full v3 → v2 → v1 history.
+
+**Query parameters**
+
+| Parameter | Type    | Default | Description              |
+|-----------|---------|---------|--------------------------|
+| `limit`   | integer | 50      | Max chain rows (cap: 500) |
+
+**Response**
+
+```json
+{
+  "memoryId": "old-uuid",
+  "count": 3,
+  "lineage": [
+    { "id": "newest-uuid", "content": "newest claim", "type": "fact", "importance": 0.9, "version": 3, "createdAt": "...", "updatedAt": "...", "supersededBy": null, "supersededAt": null, "supersededReason": null },
+    { "id": "middle-uuid", "content": "middle claim", "type": "fact", "importance": 0.8, "version": 2, "createdAt": "...", "updatedAt": "...", "supersededBy": "newest-uuid", "supersededAt": "...", "supersededReason": "newer evidence" },
+    { "id": "old-uuid", "content": "original claim", "type": "fact", "importance": 0.7, "version": 1, "createdAt": "...", "updatedAt": "...", "supersededBy": "middle-uuid", "supersededAt": "...", "supersededReason": "newer evidence" }
   ]
 }
 ```

--- a/docs/dreaming-skill-runbook.md
+++ b/docs/dreaming-skill-runbook.md
@@ -56,10 +56,7 @@ signet ontology claim-evidence <entity> <aspect> <group> <claim> --status all --
 Use direct audited merges for clear duplicate cleanup:
 
 ```bash
-signet ontology entity merge "Canonical Entity" "Duplicate Entity" \
-  --reason "Same source-backed entity after canonicalization" \
-  --evidence-file evidence.json \
-  --json
+signet ontology entity merge "Canonical Entity" "Duplicate Entity" --json
 ```
 
 Use merge planning to inspect impact or to prepare a broad graph-refactor
@@ -69,6 +66,23 @@ proposal:
 signet ontology entity merge-plan "Canonical Entity" "Duplicate Entity" --json
 signet ontology entity merge-plan "Canonical Entity" "Duplicate Entity" --propose --json
 ```
+
+## Aspect Consolidation Path
+
+When an entity's aspect count or an aspect's attribute count reaches the write
+caps, consolidate instead of appending. Fold source aspects into a target
+aspect; attributes move to the target and the sources are archived:
+
+```bash
+signet ontology aspect merge "Project Atlas" "status_history" "changelog" \
+  --new-name "timeline" \
+  --reason "Fold changelog into status history" \
+  --json
+```
+
+A merged aspect may exceed the attribute cap: consolidation is the remedy the
+cap exists to force, so merging is never blocked by it. After merging, use
+`supersede_claim_value` to collapse duplicate claim keys that landed together.
 
 ## Refactor Proposal Path
 

--- a/platform/core/src/recall.ts
+++ b/platform/core/src/recall.ts
@@ -164,6 +164,9 @@ export interface RememberRequestOptions {
 	readonly sourceCreatedAt?: string;
 	/** ISO timestamp; due-for-review marker for temporal claims (#945). */
 	readonly reviewAfter?: string;
+	/** Id of the memory this write supersedes. The old row is marked
+	 *  superseded in the same transaction, wiring vN -> vN+1 lineage. */
+	readonly supersedes?: string;
 	readonly hints?: readonly string[];
 	readonly transcript?: string;
 	readonly structured?: unknown;
@@ -464,6 +467,7 @@ export function buildRememberRequestBody(
 		validUntil: options.validUntil,
 		sourceCreatedAt: options.sourceCreatedAt,
 		reviewAfter: options.reviewAfter,
+		supersedes: options.supersedes,
 		hints: options.hints,
 		transcript: options.transcript,
 		structured: normalizeStructuredMemoryPayload(options.structured),

--- a/platform/core/src/types.ts
+++ b/platform/core/src/types.ts
@@ -278,6 +278,8 @@ export interface PipelineTraversalConfig {
 	readonly primary: boolean;
 	readonly maxAspectsPerEntity: number;
 	readonly maxAttributesPerAspect: number;
+	readonly maxWriteAspectsPerEntity: number;
+	readonly maxWriteAttributesPerAspect: number;
 	readonly maxDependencyHops: number;
 	readonly minDependencyStrength: number;
 	readonly maxBranching: number;

--- a/platform/core/src/types.ts
+++ b/platform/core/src/types.ts
@@ -881,6 +881,7 @@ export const ONTOLOGY_PROPOSAL_OPERATIONS = [
 	"update_link",
 	"archive_link",
 	"merge_entities",
+	"merge_aspects",
 	"supersede_claim_value",
 	"create_policy",
 	"create_action_type",

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -56,7 +56,7 @@ import { syncAgentWorkspaces } from "./identity-sync";
 import { type InferenceStatusSummary, getOrCreateInferenceRouter } from "./inference-router.js";
 import { closeInferenceProviderResolver, initInferenceProviderResolver } from "./llm";
 import { logger } from "./logger";
-import { type ResolvedMemoryConfig, loadMemoryConfig } from "./memory-config";
+import { type ResolvedMemoryConfig, graphWriteCaps, loadMemoryConfig } from "./memory-config";
 import { registerGlobalMiddleware } from "./middleware";
 import {
 	type NativeMemoryBridgeHandle,
@@ -1471,19 +1471,26 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 
 	if (!pipelinePaused && !memoryCfg.pipelineV2.mutationsFrozen) {
 		try {
-			dreamingWorkerHandle = startDreamingWorker(getDbAccessor(), memoryCfg.dreaming, AGENTS_DIR, defaultAgentId, {
-				acpxMcp: {
-					daemonUrl: `http://${INTERNAL_SELF_HOST}:${PORT}`,
-					authorizationTokenForAgent: (agentId) =>
-						authSecret
-							? createToken(
-									authSecret,
-									{ sub: `dreaming:${agentId}`, role: "agent", scope: { agent: agentId } },
-									Math.max(900, Math.ceil(memoryCfg.dreaming.timeout / 1000) + 60),
-								)
-							: undefined,
+			dreamingWorkerHandle = startDreamingWorker(
+				getDbAccessor(),
+				memoryCfg.dreaming,
+				AGENTS_DIR,
+				defaultAgentId,
+				{
+					acpxMcp: {
+						daemonUrl: `http://${INTERNAL_SELF_HOST}:${PORT}`,
+						authorizationTokenForAgent: (agentId) =>
+							authSecret
+								? createToken(
+										authSecret,
+										{ sub: `dreaming:${agentId}`, role: "agent", scope: { agent: agentId } },
+										Math.max(900, Math.ceil(memoryCfg.dreaming.timeout / 1000) + 60),
+									)
+								: undefined,
+					},
 				},
-			});
+				graphWriteCaps(memoryCfg),
+			);
 			setDreamingWorker(dreamingWorkerHandle);
 		} catch (err) {
 			logger.warn("dreaming", "Failed to start dreaming worker (non-fatal)", {

--- a/platform/daemon/src/knowledge-graph-hygiene.test.ts
+++ b/platform/daemon/src/knowledge-graph-hygiene.test.ts
@@ -157,4 +157,76 @@ describe("knowledge graph hygiene report", () => {
 		expect(plan).toContain("SEARCH asp USING INDEX idx_entity_aspects_status (agent_id=? AND entity_id=?)");
 		expect(plan).not.toContain("SEARCH attr USING INDEX idx_entity_attributes_claim_version (agent_id=?)");
 	});
+
+	// #1138: over-cap detectors — the write gate rejects past the cap, so the
+	// hygiene pass must surface the over-cap set for consolidation.
+	function seedAspectWithAttributes(aspectId: string, entityId: string, name: string, count: number): void {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO entity_aspects
+				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES (?, ?, 'default', ?, ?, 0.5, datetime('now'), datetime('now'))`,
+			).run(aspectId, entityId, name, name.toLowerCase());
+			for (let i = 0; i < count; i++) {
+				db.prepare(
+					`INSERT INTO entity_attributes
+					 (id, aspect_id, agent_id, kind, content, normalized_content, confidence, importance,
+					  status, group_key, claim_key, version, created_at, updated_at)
+					 VALUES (?, ?, 'default', 'fact', ?, ?, 0.9, 0.5, 'active', 'general', ?, 1, datetime('now'), datetime('now'))`,
+				).run(`attr-${aspectId}-${i}`, aspectId, `content ${i}`, `content ${i}`, `key-${i}`);
+			}
+		});
+	}
+
+	test("flags aspects over the attribute cap and entities over the aspect cap", () => {
+		dbPath = makeDbPath();
+		initDbAccessor(dbPath);
+		seedEntity("fat-entity", "Fat Entity", 5);
+		seedEntity("lean-entity", "Lean Entity", 5);
+		seedAspectWithAttributes("fat-aspect", "fat-entity", "status_history", 7);
+		seedAspectWithAttributes("lean-aspect", "lean-entity", "facts", 2);
+		// A second aspect pushes fat-entity over the aspect cap (2 > 1)
+		seedAspectWithAttributes("extra-aspect", "fat-entity", "extra", 1);
+
+		const caps = { maxAspectsPerEntity: 1, maxAttributesPerAspect: 5 };
+		const candidates = getDbAccessor().withReadDb((db) =>
+			getDreamingHygieneCandidatesInDb(db, { agentId: "default", limit: 20, caps }),
+		);
+
+		expect(candidates).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					subjectRef: "aspect:fat-aspect",
+					details: expect.objectContaining({
+						reason: "attribute_over_cap",
+						attributeCount: "7",
+						maxAttributesPerAspect: "5",
+					}),
+				}),
+				expect.objectContaining({
+					subjectRef: "entity:fat-entity",
+					details: expect.objectContaining({
+						reason: "aspect_over_cap",
+						aspectCount: "2",
+						maxAspectsPerEntity: "1",
+					}),
+				}),
+			]),
+		);
+		expect(candidates.some((candidate) => candidate.subjectRef === "aspect:lean-aspect")).toBe(false);
+		expect(candidates.some((candidate) => candidate.subjectRef === "entity:lean-entity")).toBe(false);
+	});
+
+	test("does not emit over-cap candidates when caps are omitted (backward compat)", () => {
+		dbPath = makeDbPath();
+		initDbAccessor(dbPath);
+		seedEntity("fat-entity", "Fat Entity", 5);
+		seedAspectWithAttributes("fat-aspect", "fat-entity", "status_history", 7);
+
+		const candidates = getDbAccessor().withReadDb((db) =>
+			getDreamingHygieneCandidatesInDb(db, { agentId: "default", limit: 20 }),
+		);
+		expect(candidates.some((candidate) => candidate.details.reason === "attribute_over_cap")).toBe(false);
+		expect(candidates.some((candidate) => candidate.details.reason === "aspect_over_cap")).toBe(false);
+	});
 });

--- a/platform/daemon/src/knowledge-graph-hygiene.ts
+++ b/platform/daemon/src/knowledge-graph-hygiene.ts
@@ -92,6 +92,12 @@ export interface DreamingHygieneCandidate {
 	readonly priority: number;
 }
 
+/** Write-path caps that drive the over-cap detectors (#1138). */
+export interface GraphHygieneCaps {
+	readonly maxAspectsPerEntity: number;
+	readonly maxAttributesPerAspect: number;
+}
+
 const GENERIC_ASPECTS = ["general", "properties", "overview", "profile", "details", "information"] as const;
 
 function normalize(value: string): string {
@@ -170,14 +176,83 @@ function membershipDigest(ids: readonly string[]): string {
  */
 export function getDreamingHygieneCandidatesInDb(
 	db: ReadDb,
-	input: { readonly agentId: string; readonly limit?: number },
+	input: { readonly agentId: string; readonly limit?: number; readonly caps?: GraphHygieneCaps },
 ): readonly DreamingHygieneCandidate[] {
 	const limit = Math.min(Math.max(Math.floor(input.limit ?? 50), 1), 100);
+	const caps = input.caps;
 	const candidates = new Map<string, DreamingHygieneCandidate>();
 	const add = (candidate: DreamingHygieneCandidate): void => {
 		const existing = candidates.get(candidate.subjectRef);
 		if (!existing || candidate.priority > existing.priority) candidates.set(candidate.subjectRef, candidate);
 	};
+
+	// #1138: over-cap detectors run first — these are the forcing function's
+	// targets. The write gate rejects new writes past the cap, so the agent
+	// must consolidate these before the graph can keep growing.
+	if (caps !== undefined) {
+		const overCapAspects = db
+			.prepare(
+				`SELECT asp.id, asp.entity_id, asp.name, COUNT(attr.id) AS attribute_count
+				 FROM entity_aspects asp
+				 JOIN entities e ON e.id = asp.entity_id AND e.agent_id = asp.agent_id
+				 LEFT JOIN entity_attributes attr ON attr.aspect_id = asp.id AND attr.agent_id = asp.agent_id AND attr.status = 'active'
+				 WHERE asp.agent_id = ? AND COALESCE(asp.status, 'active') = 'active' AND ${SEMANTIC_ENTITY_FRAGMENT}
+				 GROUP BY asp.id, asp.entity_id, asp.name
+				 HAVING attribute_count > ?
+				 ORDER BY attribute_count DESC
+				 LIMIT ?`,
+			)
+			.all(input.agentId, ...SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES, caps.maxAttributesPerAspect, limit) as Array<{
+			id: string;
+			entity_id: string;
+			name: string;
+			attribute_count: number;
+		}>;
+		for (const aspect of overCapAspects) {
+			add({
+				subjectRef: `aspect:${aspect.id}`,
+				details: {
+					aspectId: aspect.id,
+					entityId: aspect.entity_id,
+					name: aspect.name,
+					reason: "attribute_over_cap",
+					attributeCount: String(aspect.attribute_count),
+					maxAttributesPerAspect: String(caps.maxAttributesPerAspect),
+				},
+				priority: 100,
+			});
+		}
+
+		const overCapEntities = db
+			.prepare(
+				`SELECT e.id, e.name, COUNT(asp.id) AS aspect_count
+				 FROM entities e
+				 LEFT JOIN entity_aspects asp ON asp.entity_id = e.id AND asp.agent_id = e.agent_id AND COALESCE(asp.status, 'active') = 'active'
+				 WHERE e.agent_id = ? AND COALESCE(e.status, 'active') = 'active' AND ${SEMANTIC_ENTITY_FRAGMENT}
+				 GROUP BY e.id, e.name
+				 HAVING aspect_count > ?
+				 ORDER BY aspect_count DESC
+				 LIMIT ?`,
+			)
+			.all(input.agentId, ...SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES, caps.maxAspectsPerEntity, limit) as Array<{
+			id: string;
+			name: string;
+			aspect_count: number;
+		}>;
+		for (const entity of overCapEntities) {
+			add({
+				subjectRef: `entity:${entity.id}`,
+				details: {
+					entityId: entity.id,
+					name: entity.name,
+					reason: "aspect_over_cap",
+					aspectCount: String(entity.aspect_count),
+					maxAspectsPerEntity: String(caps.maxAspectsPerEntity),
+				},
+				priority: 95,
+			});
+		}
+	}
 
 	const entities = db
 		.prepare(

--- a/platform/daemon/src/mcp/tools.ts
+++ b/platform/daemon/src/mcp/tools.ts
@@ -1090,6 +1090,12 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					.string()
 					.optional()
 					.describe("ISO timestamp when this temporal claim becomes due for review (issue #945)"),
+				supersedes: z
+					.string()
+					.optional()
+					.describe(
+						"Id of an existing memory this write supersedes. The old row is marked superseded in the same transaction, wiring vN -> vN+1 lineage for drill-down history.",
+					),
 				transcript: z
 					.string()
 					.optional()
@@ -1170,6 +1176,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			validFrom,
 			validUntil,
 			reviewAfter,
+			supersedes,
 		}) => {
 			const result = await fetchDaemon<unknown>(baseUrl, "/api/memory/remember", {
 				method: "POST",
@@ -1188,6 +1195,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					validFrom,
 					validUntil,
 					reviewAfter,
+					supersedes,
 				}),
 			});
 

--- a/platform/daemon/src/memory-config.ts
+++ b/platform/daemon/src/memory-config.ts
@@ -133,7 +133,9 @@ export const DEFAULT_PIPELINE_V2: ResolvedPipelineV2Config = {
 		enabled: true,
 		primary: true,
 		maxAspectsPerEntity: 10,
-		maxAttributesPerAspect: 20,
+		maxAttributesPerAspect: 25,
+		maxWriteAspectsPerEntity: 10,
+		maxWriteAttributesPerAspect: 25,
 		maxDependencyHops: 10,
 		minDependencyStrength: 0.3,
 		maxBranching: 4,
@@ -670,7 +672,19 @@ export function loadPipelineConfig(yaml: Record<string, unknown>): ResolvedPipel
 				traversalRaw?.maxAttributesPerAspect,
 				1,
 				200,
-				d.traversal?.maxAttributesPerAspect ?? 20,
+				d.traversal?.maxAttributesPerAspect ?? 25,
+			),
+			maxWriteAspectsPerEntity: clampPositive(
+				traversalRaw?.maxWriteAspectsPerEntity,
+				1,
+				50,
+				d.traversal?.maxWriteAspectsPerEntity ?? 10,
+			),
+			maxWriteAttributesPerAspect: clampPositive(
+				traversalRaw?.maxWriteAttributesPerAspect,
+				1,
+				100,
+				d.traversal?.maxWriteAttributesPerAspect ?? 25,
 			),
 			maxDependencyHops: clampPositive(traversalRaw?.maxDependencyHops, 1, 200, d.traversal?.maxDependencyHops ?? 10),
 			minDependencyStrength: clampFraction(
@@ -974,6 +988,18 @@ export function loadDreamingConfig(yaml: Record<string, unknown>): DreamingConfi
 		maxInputTokens: clampWarn("maxInputTokens", raw.maxInputTokens, 8_000, 1_000_000, dd.maxInputTokens),
 		maxOutputTokens: clampWarn("maxOutputTokens", raw.maxOutputTokens, 1_000, 128_000, dd.maxOutputTokens),
 		backfillOnFirstRun: typeof raw.backfillOnFirstRun === "boolean" ? raw.backfillOnFirstRun : dd.backfillOnFirstRun,
+	};
+}
+
+/** Write-path graph caps from the traversal config, with defaults. */
+export function graphWriteCaps(cfg: ResolvedMemoryConfig): {
+	readonly maxAspectsPerEntity: number;
+	readonly maxAttributesPerAspect: number;
+} {
+	const traversal = cfg.pipelineV2.traversal;
+	return {
+		maxAspectsPerEntity: traversal?.maxWriteAspectsPerEntity ?? 10,
+		maxAttributesPerAspect: traversal?.maxWriteAttributesPerAspect ?? 25,
 	};
 }
 

--- a/platform/daemon/src/memory-config.ts
+++ b/platform/daemon/src/memory-config.ts
@@ -132,10 +132,10 @@ export const DEFAULT_PIPELINE_V2: ResolvedPipelineV2Config = {
 	traversal: {
 		enabled: true,
 		primary: true,
-		maxAspectsPerEntity: 10,
-		maxAttributesPerAspect: 25,
-		maxWriteAspectsPerEntity: 10,
-		maxWriteAttributesPerAspect: 25,
+		maxAspectsPerEntity: 20,
+		maxAttributesPerAspect: 50,
+		maxWriteAspectsPerEntity: 20,
+		maxWriteAttributesPerAspect: 50,
 		maxDependencyHops: 10,
 		minDependencyStrength: 0.3,
 		maxBranching: 4,
@@ -666,25 +666,25 @@ export function loadPipelineConfig(yaml: Record<string, unknown>): ResolvedPipel
 				traversalRaw?.maxAspectsPerEntity,
 				1,
 				100,
-				d.traversal?.maxAspectsPerEntity ?? 10,
+				d.traversal?.maxAspectsPerEntity ?? 20,
 			),
 			maxAttributesPerAspect: clampPositive(
 				traversalRaw?.maxAttributesPerAspect,
 				1,
 				200,
-				d.traversal?.maxAttributesPerAspect ?? 25,
+				d.traversal?.maxAttributesPerAspect ?? 50,
 			),
 			maxWriteAspectsPerEntity: clampPositive(
 				traversalRaw?.maxWriteAspectsPerEntity,
 				1,
 				50,
-				d.traversal?.maxWriteAspectsPerEntity ?? 10,
+				d.traversal?.maxWriteAspectsPerEntity ?? 20,
 			),
 			maxWriteAttributesPerAspect: clampPositive(
 				traversalRaw?.maxWriteAttributesPerAspect,
 				1,
 				100,
-				d.traversal?.maxWriteAttributesPerAspect ?? 25,
+				d.traversal?.maxWriteAttributesPerAspect ?? 50,
 			),
 			maxDependencyHops: clampPositive(traversalRaw?.maxDependencyHops, 1, 200, d.traversal?.maxDependencyHops ?? 10),
 			minDependencyStrength: clampFraction(
@@ -998,8 +998,8 @@ export function graphWriteCaps(cfg: ResolvedMemoryConfig): {
 } {
 	const traversal = cfg.pipelineV2.traversal;
 	return {
-		maxAspectsPerEntity: traversal?.maxWriteAspectsPerEntity ?? 10,
-		maxAttributesPerAspect: traversal?.maxWriteAttributesPerAspect ?? 25,
+		maxAspectsPerEntity: traversal?.maxWriteAspectsPerEntity ?? 20,
+		maxAttributesPerAspect: traversal?.maxWriteAttributesPerAspect ?? 50,
 	};
 }
 

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -2601,4 +2601,111 @@ describe("ontology proposals", () => {
 		});
 		expect(result.result?.deduped).toBe(true);
 	});
+
+	// #1138: merge_aspects — consolidation must be possible regardless of caps
+	function seedAspectClaims(entity: string, aspect: string, count: number): void {
+		for (let i = 0; i < count; i++) {
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				operation: "add_claim_value",
+				payload: {
+					entity,
+					entity_type: "project",
+					aspect,
+					claim_key: `${aspect}_key_${i}`,
+					value: `${aspect} value number ${i}`,
+				},
+			});
+		}
+	}
+
+	function aspectRowCount(aspectName: string): number {
+		return getDbAccessor().withReadDb((db) => {
+			const aspect = db
+				.prepare(
+					"SELECT id FROM entity_aspects WHERE agent_id = ? AND name = ? AND COALESCE(status, 'active') = 'active'",
+				)
+				.get("ant", aspectName) as { id: string } | undefined;
+			if (aspect === undefined) return -1;
+			return (
+				db
+					.prepare(
+						"SELECT COUNT(*) AS c FROM entity_attributes WHERE aspect_id = ? AND agent_id = ? AND status = 'active'",
+					)
+					.get(aspect.id, "ant") as {
+					c: number;
+				}
+			).c;
+		});
+	}
+
+	it("merges aspects by moving attributes into the target and archiving sources", () => {
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "create_entity",
+			payload: { name: "MergeEnt", entity_type: "project" },
+		});
+		seedAspectClaims("MergeEnt", "status_history", 3);
+		seedAspectClaims("MergeEnt", "changelog", 4);
+
+		const result = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "merge_aspects",
+			payload: {
+				entity: "MergeEnt",
+				target: "status_history",
+				sources: ["changelog"],
+				new_name: "timeline",
+			},
+		});
+
+		expect(result.result?.targetAspect).toBe("timeline");
+		expect(result.result?.totalAttributesMoved).toBe(4);
+		// All 7 attributes now live on the merged target
+		expect(aspectRowCount("timeline")).toBe(7);
+		// Source aspect is archived
+		const sourceStatus = getDbAccessor().withReadDb((db) =>
+			db.prepare("SELECT status FROM entity_aspects WHERE agent_id = ? AND name = ?").get("ant", "changelog"),
+		);
+		expect(sourceStatus).toEqual({ status: "archived" });
+	});
+
+	it("lets the merged aspect exceed the attribute cap (consolidation is exempt)", () => {
+		const cap = { maxAspectsPerEntity: 10, maxAttributesPerAspect: 5 };
+
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "create_entity",
+			payload: { name: "FatEnt", entity_type: "project" },
+		});
+		seedAspectClaims("FatEnt", "a", 5);
+		seedAspectClaims("FatEnt", "b", 5);
+
+		// Two at-cap aspects merged into one: 10 attributes on the target, cap is 5.
+		// Merging is the consolidation remedy, so it must not be blocked.
+		const result = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "merge_aspects",
+			payload: { entity: "FatEnt", target: "a", sources: ["b"] },
+			writeCaps: cap,
+		});
+		expect(result.result?.totalAttributesMoved).toBe(5);
+		expect(aspectRowCount("a")).toBe(10);
+	});
+
+	it("rejects merge_aspects without entity, target, or sources", () => {
+		expect(() =>
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				operation: "merge_aspects",
+				payload: { entity: "Whatever", target: "x", sources: [] },
+			}),
+		).toThrow(/sources is required/);
+	});
 });

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -2708,4 +2708,117 @@ describe("ontology proposals", () => {
 			}),
 		).toThrow(/sources is required/);
 	});
+
+	// #1147 adversarial review: cap bypasses via other write ops.
+	it("does not bypass the aspect cap via add_claim_value with a new aspect name (E1)", () => {
+		const cap = { maxAspectsPerEntity: 2, maxAttributesPerAspect: 25 };
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "create_entity",
+			payload: { name: "E1Ent", entity_type: "project" },
+		});
+		for (let i = 0; i < 2; i++) {
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				operation: "create_aspect",
+				payload: { entity: "E1Ent", name: `aspect_${i}` },
+				writeCaps: cap,
+			});
+		}
+		// add_claim_value with a THIRD new aspect name must hit the aspect cap.
+		expect(() =>
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				operation: "add_claim_value",
+				payload: {
+					entity: "E1Ent",
+					aspect: "aspect_overflow",
+					claim_key: "k",
+					value: "v",
+				},
+				writeCaps: cap,
+			}),
+		).toThrow(/aspect cap \(2\/2\)/);
+	});
+
+	it("does not bypass the attribute cap via set_claim_value with a new claim_key (E2)", () => {
+		const cap = { maxAspectsPerEntity: 10, maxAttributesPerAspect: 2 };
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "create_entity",
+			payload: { name: "E2Ent", entity_type: "project" },
+		});
+		for (let i = 0; i < 2; i++) {
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				operation: "set_claim_value",
+				payload: { entity: "E2Ent", aspect: "facts", claim_key: `k_${i}`, value: `v ${i}` },
+				writeCaps: cap,
+			});
+		}
+		expect(() =>
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				operation: "set_claim_value",
+				payload: { entity: "E2Ent", aspect: "facts", claim_key: "k_overflow", value: "v overflow" },
+				writeCaps: cap,
+			}),
+		).toThrow(/attribute cap \(2\/2\)/);
+	});
+
+	it("allows reactivating an archived aspect within cap but rejects a new aspect at cap (E3)", () => {
+		const cap = { maxAspectsPerEntity: 2, maxAttributesPerAspect: 25 };
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "create_entity",
+			payload: { name: "E3Ent", entity_type: "project" },
+		});
+		for (let i = 0; i < 2; i++) {
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				operation: "create_aspect",
+				payload: { entity: "E3Ent", name: `aspect_${i}` },
+				writeCaps: cap,
+			});
+		}
+		const aspect = getDbAccessor().withReadDb((db) =>
+			db.prepare("SELECT id FROM entity_aspects WHERE agent_id = ? AND name = ?").get("ant", "aspect_1"),
+		) as { id: string };
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "archive_aspect",
+			payload: { entity: "E3Ent", selector: aspect.id },
+		});
+		// Reactivating the archived aspect keeps the active count at 2 (cap)
+		// — the new helper only skips the cap when an ACTIVE row exists, and
+		// the count after reactivation is 2/2, so this is allowed.
+		expect(() =>
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				operation: "create_aspect",
+				payload: { entity: "E3Ent", name: "aspect_1" },
+				writeCaps: cap,
+			}),
+		).not.toThrow();
+		// But a genuinely new third aspect is still rejected at cap.
+		expect(() =>
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				operation: "create_aspect",
+				payload: { entity: "E3Ent", name: "aspect_new" },
+				writeCaps: cap,
+			}),
+		).toThrow(/aspect cap \(2\/2\)/);
+	});
 });

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -2442,4 +2442,163 @@ describe("ontology proposals", () => {
 			}),
 		).toThrow("ambiguous");
 	});
+
+	// #1138: write-gate aspect/attribute caps that force supersession and consolidation
+	it("rejects add_claim_value past the attribute cap with a teaching error", () => {
+		const cap = { maxAspectsPerEntity: 10, maxAttributesPerAspect: 2 };
+		const common = {
+			agentId: "ant",
+			actor: "test",
+			operation: "add_claim_value",
+		} as const;
+
+		for (let i = 0; i < 2; i++) {
+			applyOntologyOperation(getDbAccessor(), {
+				...common,
+				payload: {
+					entity: "Capped",
+					entity_type: "project",
+					aspect: "facts",
+					claim_key: `fact_${i}`,
+					value: `fact number ${i}`,
+				},
+				writeCaps: cap,
+			});
+		}
+
+		expect(() =>
+			applyOntologyOperation(getDbAccessor(), {
+				...common,
+				payload: {
+					entity: "Capped",
+					entity_type: "project",
+					aspect: "facts",
+					claim_key: "fact_overflow",
+					value: "this should be rejected",
+				},
+				writeCaps: cap,
+			}),
+		).toThrow(/attribute cap \(2\/2\).*supersede or expire/);
+	});
+
+	it("does not enforce attribute cap when writeCaps is omitted (backward compat)", () => {
+		for (let i = 0; i < 5; i++) {
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				operation: "add_claim_value",
+				payload: {
+					entity: "Uncapped",
+					entity_type: "project",
+					aspect: "facts",
+					claim_key: `fact_${i}`,
+					value: `fact number ${i}`,
+				},
+			});
+		}
+
+		const count = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT COUNT(*) AS c FROM entity_attributes WHERE agent_id = ? AND status = 'active'")
+					.get("ant") as { c: number },
+		);
+		expect(count.c).toBe(5);
+	});
+
+	it("rejects create_aspect past the aspect cap with a teaching error", () => {
+		const cap = { maxAspectsPerEntity: 2, maxAttributesPerAspect: 25 };
+
+		// create_entity first so create_aspect can resolve it
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "create_entity",
+			payload: { name: "CappedEnt", entity_type: "project" },
+		});
+
+		for (let i = 0; i < 2; i++) {
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				operation: "create_aspect",
+				payload: { entity: "CappedEnt", entity_type: "project", name: `aspect_${i}` },
+				writeCaps: cap,
+			});
+		}
+
+		expect(() =>
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				operation: "create_aspect",
+				payload: { entity: "CappedEnt", entity_type: "project", name: "overflow_aspect" },
+				writeCaps: cap,
+			}),
+		).toThrow(/aspect cap \(2\/2\).*consolidate or archive/);
+	});
+
+	it("allows adding to an existing aspect that already exists past the cap (idempotent resolve)", () => {
+		const cap = { maxAspectsPerEntity: 1, maxAttributesPerAspect: 25 };
+
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "create_entity",
+			payload: { name: "Single", entity_type: "project" },
+		});
+
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "create_aspect",
+			payload: { entity: "Single", entity_type: "project", name: "only_aspect" },
+			writeCaps: cap,
+		});
+
+		// Re-creating the same aspect should not trigger the cap
+		expect(() =>
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				operation: "create_aspect",
+				payload: { entity: "Single", entity_type: "project", name: "only_aspect" },
+				writeCaps: cap,
+			}),
+		).not.toThrow();
+	});
+
+	it("deduplicates exact-value claims before enforcing the attribute cap", () => {
+		const cap = { maxAspectsPerEntity: 10, maxAttributesPerAspect: 1 };
+
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "add_claim_value",
+			payload: {
+				entity: "Dedup",
+				entity_type: "project",
+				aspect: "facts",
+				claim_key: "same_key",
+				value: "identical content",
+			},
+			writeCaps: cap,
+		});
+
+		// Adding the exact same value+key should dedup, not hit the cap
+		const result = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "add_claim_value",
+			payload: {
+				entity: "Dedup",
+				entity_type: "project",
+				aspect: "facts",
+				claim_key: "same_key",
+				value: "identical content",
+			},
+			writeCaps: cap,
+		});
+		expect(result.result?.deduped).toBe(true);
+	});
 });

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -1676,6 +1676,99 @@ function applyMergeEntities(
 	};
 }
 
+/**
+ * Fold source aspects into a target aspect on the same entity. All active
+ * attributes of each source are repointed to the target, then the source
+ * aspect is archived. The merged target may exceed the write-path attribute
+ * cap: consolidation is the remedy the cap forces, so it is never blocked by
+ * it. Claim-key collisions between source and target are preserved as
+ * distinct rows — further dedup is the agent's job via supersede_claim_value.
+ */
+function applyMergeAspects(
+	db: WriteDb,
+	agentId: string,
+	proposal: ProposalRow,
+	payload: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> {
+	const entitySelector = readPayloadSelector(payload, "entity", "entity_id");
+	const targetSelector = readPayloadSelector(payload, "target", "target_aspect", "target_aspect_id", "aspect");
+	const rawSources = readStringArray(payload, "sources") ?? readStringArray(payload, "source_aspects");
+	if (entitySelector === null) throw new OntologyProposalError("payload.entity is required", 400);
+	if (targetSelector === null) throw new OntologyProposalError("payload.target is required", 400);
+	if (rawSources.length === 0) throw new OntologyProposalError("payload.sources is required", 400);
+
+	const entity = resolveEntityStrict(db, agentId, entitySelector);
+	const target = resolveAspectStrict(db, agentId, entity.id, targetSelector);
+	const newName = readString(payload, "new_name");
+	if (newName !== null) {
+		const key = canonical(newName);
+		const collision = db
+			.prepare(
+				`SELECT id FROM entity_aspects
+				 WHERE entity_id = ? AND agent_id = ? AND id != ?
+				   AND COALESCE(status, 'active') = 'active'
+				   AND (canonical_name = ? OR LOWER(name) = ?)
+				 LIMIT 1`,
+			)
+			.get(entity.id, agentId, target.id, key, key);
+		if (collision) throw new OntologyProposalError(`Aspect collides with "${newName}"`, 409);
+	}
+
+	const evidence = JSON.stringify(proposalAuditEvidence(proposal));
+	const moved: Array<{ readonly aspect: string; readonly attributes: number }> = [];
+	let totalMoved = 0;
+	const seen = new Set<string>([target.id]);
+	for (const raw of rawSources) {
+		if (typeof raw !== "string") throw new OntologyProposalError("payload.sources must be aspect selectors", 400);
+		const source = resolveAspectStrict(db, agentId, entity.id, raw);
+		if (seen.has(source.id)) continue;
+		seen.add(source.id);
+
+		const attributes = db
+			.prepare("SELECT id FROM entity_attributes WHERE aspect_id = ? AND agent_id = ? AND status = 'active'")
+			.all(source.id, agentId) as Array<{ id: string }>;
+		for (const attribute of attributes) {
+			db.prepare(
+				`UPDATE entity_attributes
+				 SET aspect_id = ?, proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
+				 WHERE id = ? AND agent_id = ? AND status = 'active'`,
+			).run(target.id, proposal.id, evidence, attribute.id, agentId);
+		}
+		db.prepare(
+			`UPDATE entity_aspects
+			 SET status = 'archived', archived_at = datetime('now'), archived_by = ?,
+			     archive_reason = ?, proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
+			 WHERE id = ? AND agent_id = ? AND COALESCE(status, 'active') = 'active'`,
+		).run(
+			proposal.created_by || "ontology-merge",
+			`Merged into aspect '${target.name}'`,
+			proposal.id,
+			evidence,
+			source.id,
+			agentId,
+		);
+		moved.push({ aspect: source.name, attributes: attributes.length });
+		totalMoved += attributes.length;
+	}
+	if (moved.length === 0) throw new OntologyProposalError("No distinct source aspects to merge", 400);
+
+	if (newName !== null) {
+		db.prepare(
+			`UPDATE entity_aspects
+			 SET name = ?, canonical_name = ?, proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
+			 WHERE id = ? AND agent_id = ?`,
+		).run(newName, canonical(newName), proposal.id, evidence, target.id, agentId);
+	}
+
+	return {
+		entityId: entity.id,
+		targetAspectId: target.id,
+		targetAspect: newName ?? target.name,
+		mergedAspects: moved,
+		totalAttributesMoved: totalMoved,
+	};
+}
+
 function applyCreateLink(
 	db: WriteDb,
 	agentId: string,
@@ -1946,6 +2039,7 @@ function applyOperation(
 		return applyAddClaimValue(db, proposal.agent_id, proposal, payload, writeCaps);
 	if (proposal.operation === "set_claim_value") return applySetClaimValue(db, proposal.agent_id, proposal, payload);
 	if (proposal.operation === "merge_entities") return applyMergeEntities(db, proposal.agent_id, payload);
+	if (proposal.operation === "merge_aspects") return applyMergeAspects(db, proposal.agent_id, proposal, payload);
 	if (proposal.operation === "supersede_claim_value") {
 		return applySupersedeClaimValue(db, proposal.agent_id, proposal, payload);
 	}

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -181,6 +181,7 @@ export interface ApplyOntologyProposalParams {
 	readonly agentId: string;
 	readonly id: string;
 	readonly actor: string;
+	readonly writeCaps?: GraphWriteCaps;
 }
 
 export interface RejectOntologyProposalParams extends ApplyOntologyProposalParams {
@@ -217,6 +218,7 @@ export interface ApplyOntologyOperationParams extends OntologyOperationInput {
 	readonly actor: string;
 	readonly dryRun?: boolean;
 	readonly propose?: boolean;
+	readonly writeCaps?: GraphWriteCaps;
 }
 
 export interface ApplyOntologyOperationResult {
@@ -232,6 +234,7 @@ export interface ApplyOntologyOperationBatchParams {
 	readonly operations: readonly OntologyOperationInput[];
 	readonly dryRun?: boolean;
 	readonly propose?: boolean;
+	readonly writeCaps?: GraphWriteCaps;
 }
 
 export interface ApplyOntologyOperationBatchResult {
@@ -253,7 +256,9 @@ export interface OntologyOperationBatchError {
 /** Apply an audited operation batch inside a caller-owned transaction. */
 export function applyOntologyOperationBatchInTx(
 	db: WriteDb,
-	params: Pick<ApplyOntologyOperationBatchParams, "agentId" | "actor" | "operations">,
+	params: Pick<ApplyOntologyOperationBatchParams, "agentId" | "actor" | "operations"> & {
+		readonly writeCaps?: GraphWriteCaps;
+	},
 ): ApplyOntologyOperationBatchResult {
 	if (params.operations.length === 0) throw new OntologyProposalError("operations are required", 400);
 	if (params.operations.length > 500)
@@ -281,7 +286,7 @@ export function applyOntologyOperationBatchInTx(
 		);
 		const row = getProposalInTx(db, inserted.id, params.agentId);
 		if (row === null) throw new OntologyProposalError("Proposal not found", 404);
-		const result = applyOperation(db, row, params.actor);
+		const result = applyOperation(db, row, params.actor, params.writeCaps);
 		items.push({
 			proposal: markAppliedInTx(db, row, params.actor, result),
 			result,
@@ -325,6 +330,12 @@ export class OntologyProposalError extends Error {
 		super(message);
 		this.name = "OntologyProposalError";
 	}
+}
+
+/** Write-path caps enforced before add_claim_value/create_aspect. */
+export interface GraphWriteCaps {
+	readonly maxAspectsPerEntity: number;
+	readonly maxAttributesPerAspect: number;
 }
 
 function now(): string {
@@ -950,6 +961,7 @@ function applyAddClaimValue(
 	agentId: string,
 	proposal: ProposalRow,
 	payload: Readonly<Record<string, unknown>>,
+	writeCaps?: GraphWriteCaps,
 ): Readonly<Record<string, unknown>> {
 	const entity = readString(payload, "entity");
 	const aspect = readString(payload, "aspect");
@@ -980,6 +992,24 @@ function applyAddClaimValue(
 		.get(aspectId, agentId, kind, normalized, groupKey, claimKey) as { id: string } | undefined;
 	if (existing) {
 		return { entityId, aspectId, attributeId: existing.id, deduped: true };
+	}
+
+	if (writeCaps !== undefined) {
+		const attrCount = db
+			.prepare(
+				`SELECT COUNT(*) AS c FROM entity_attributes
+				 WHERE aspect_id = ? AND agent_id = ? AND status = 'active'`,
+			)
+			.get(aspectId, agentId) as { c: number };
+		if (attrCount.c >= writeCaps.maxAttributesPerAspect) {
+			const aspectName = db.prepare("SELECT name FROM entity_aspects WHERE id = ?").get(aspectId) as
+				| { name: string }
+				| undefined;
+			throw new OntologyProposalError(
+				`aspect '${aspectName?.name ?? aspectId}' is at attribute cap (${attrCount.c}/${writeCaps.maxAttributesPerAspect}) — supersede or expire an existing claim, or consolidate duplicates, before adding`,
+				409,
+			);
+		}
 	}
 
 	const id = crypto.randomUUID();
@@ -1343,12 +1373,38 @@ function applyCreateAspect(
 	agentId: string,
 	proposal: ProposalRow,
 	payload: Readonly<Record<string, unknown>>,
+	writeCaps?: GraphWriteCaps,
 ): Readonly<Record<string, unknown>> {
 	const entitySelector = readPayloadSelector(payload, "entity", "entity_id");
 	const name = readString(payload, "name") ?? readString(payload, "aspect");
 	if (entitySelector === null) throw new OntologyProposalError("payload.entity is required", 400);
 	if (name === null) throw new OntologyProposalError("payload.name is required", 400);
 	const entity = resolveEntityStrict(db, agentId, entitySelector);
+
+	if (writeCaps !== undefined) {
+		const key = canonical(name);
+		const existingAspect = db
+			.prepare(
+				`SELECT id FROM entity_aspects
+				 WHERE entity_id = ? AND agent_id = ? AND canonical_name = ?`,
+			)
+			.get(entity.id, agentId, key) as { id: string } | undefined;
+		if (existingAspect == null) {
+			const aspectCount = db
+				.prepare(
+					`SELECT COUNT(*) AS c FROM entity_aspects
+					 WHERE entity_id = ? AND agent_id = ? AND COALESCE(status, 'active') = 'active'`,
+				)
+				.get(entity.id, agentId) as { c: number };
+			if (aspectCount.c >= writeCaps.maxAspectsPerEntity) {
+				throw new OntologyProposalError(
+					`entity '${entity.name}' is at aspect cap (${aspectCount.c}/${writeCaps.maxAspectsPerEntity}) — consolidate or archive an existing aspect before creating a new one`,
+					409,
+				);
+			}
+		}
+	}
+
 	const aspectId = resolveOrCreateAspect(db, entity.id, agentId, name);
 	db.prepare(
 		`UPDATE entity_aspects
@@ -1870,17 +1926,24 @@ function applyArchiveEntityAlias(
 	return { aliasId, entityId: entity.id, archived: true };
 }
 
-function applyOperation(db: WriteDb, proposal: ProposalRow, actor: string): Readonly<Record<string, unknown>> {
+function applyOperation(
+	db: WriteDb,
+	proposal: ProposalRow,
+	actor: string,
+	writeCaps?: GraphWriteCaps,
+): Readonly<Record<string, unknown>> {
 	const payload = parseJsonRecord(proposal.payload);
 	if (proposal.operation === "create_entity") return applyCreateEntity(db, proposal.agent_id, proposal, payload);
 	if (proposal.operation === "rename_entity") return applyRenameEntity(db, proposal.agent_id, proposal, payload);
 	if (proposal.operation === "archive_entity")
 		return applyArchiveEntity(db, proposal.agent_id, proposal, payload, actor);
-	if (proposal.operation === "create_aspect") return applyCreateAspect(db, proposal.agent_id, proposal, payload);
+	if (proposal.operation === "create_aspect")
+		return applyCreateAspect(db, proposal.agent_id, proposal, payload, writeCaps);
 	if (proposal.operation === "rename_aspect") return applyRenameAspect(db, proposal.agent_id, proposal, payload);
 	if (proposal.operation === "archive_aspect")
 		return applyArchiveAspect(db, proposal.agent_id, proposal, payload, actor);
-	if (proposal.operation === "add_claim_value") return applyAddClaimValue(db, proposal.agent_id, proposal, payload);
+	if (proposal.operation === "add_claim_value")
+		return applyAddClaimValue(db, proposal.agent_id, proposal, payload, writeCaps);
 	if (proposal.operation === "set_claim_value") return applySetClaimValue(db, proposal.agent_id, proposal, payload);
 	if (proposal.operation === "merge_entities") return applyMergeEntities(db, proposal.agent_id, payload);
 	if (proposal.operation === "supersede_claim_value") {
@@ -2603,7 +2666,7 @@ export function applyOntologyProposal(accessor: DbAccessor, params: ApplyOntolog
 				throw new OntologyProposalError(`Proposal is ${proposal.status}, not pending`, 409);
 			}
 
-			const result = applyOperation(db, proposal, params.actor);
+			const result = applyOperation(db, proposal, params.actor, params.writeCaps);
 			const ts = now();
 			db.prepare(
 				`UPDATE ontology_proposals
@@ -2680,7 +2743,7 @@ export function applyOntologyOperation(
 			const inserted = insertProposalInTx(db, operationToProposalInput(params), now());
 			const row = getProposalInTx(db, inserted.id, params.agentId);
 			if (row === null) throw new OntologyProposalError("Proposal not found", 404);
-			const operationResult = applyOperation(db, row, params.actor);
+			const operationResult = applyOperation(db, row, params.actor, params.writeCaps);
 			const proposal = markAppliedInTx(db, row, params.actor, operationResult);
 			const item = { proposal, result: operationResult, dryRun: params.dryRun === true, proposed: false };
 			if (params.dryRun) {
@@ -2763,7 +2826,7 @@ export function applyOntologyOperationBatch(
 					);
 					const row = getProposalInTx(db, inserted.id, params.agentId);
 					if (row === null) throw new OntologyProposalError("Proposal not found", 404);
-					const operationResult = applyOperation(db, row, params.actor);
+					const operationResult = applyOperation(db, row, params.actor, params.writeCaps);
 					const proposal = markAppliedInTx(db, row, params.actor, operationResult);
 					items.push({ proposal, result: operationResult, dryRun: params.dryRun === true, proposed: false });
 				} catch (err) {

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -973,6 +973,13 @@ function applyAddClaimValue(
 	if (value === null) throw new OntologyProposalError("payload.value is required", 400);
 
 	const entityId = resolveOrCreateEntity(db, agentId, entity, normalizeEntityType(readString(payload, "entity_type")));
+	// E1 fix (#1147 review): add_claim_value resolves-or-creates the aspect,
+	// so a new aspect name would bypass the aspect cap. Guard it the same way
+	// create_aspect does.
+	const addEntityRow = db.prepare("SELECT id, name FROM entities WHERE id = ?").get(entityId) as
+		| { id: string; name: string }
+		| undefined;
+	if (addEntityRow !== undefined) enforceAspectCapForNewAspect(db, addEntityRow, agentId, aspect, writeCaps);
 	const aspectId = resolveOrCreateAspect(db, entityId, agentId, aspect);
 	const groupKey = readString(payload, "group_key") ?? "general";
 	const kind = normalizeAttributeKind(readString(payload, "kind"));
@@ -1064,6 +1071,7 @@ function applySetClaimValue(
 	agentId: string,
 	proposal: ProposalRow,
 	payload: Readonly<Record<string, unknown>>,
+	writeCaps?: GraphWriteCaps,
 ): Readonly<Record<string, unknown>> {
 	const entity = readString(payload, "entity");
 	const aspect = readString(payload, "aspect");
@@ -1117,6 +1125,27 @@ function applySetClaimValue(
 	}
 
 	const previous = active[0] ?? slot[0] ?? null;
+	// E2 fix (#1147 review): set_claim_value with a brand-new claim_key
+	// inserts a new attribute row, bypassing the attribute cap. Replacing an
+	// existing active slot does not grow the count, so the guard only fires
+	// when this write would add a new row.
+	if (previous === null && writeCaps !== undefined) {
+		const attrCount = db
+			.prepare(
+				`SELECT COUNT(*) AS c FROM entity_attributes
+				 WHERE aspect_id = ? AND agent_id = ? AND status = 'active'`,
+			)
+			.get(aspectId, agentId) as { c: number };
+		if (attrCount.c >= writeCaps.maxAttributesPerAspect) {
+			const aspectName = db.prepare("SELECT name FROM entity_aspects WHERE id = ?").get(aspectId) as
+				| { name: string }
+				| undefined;
+			throw new OntologyProposalError(
+				`aspect '${aspectName?.name ?? aspectId}' is at attribute cap (${attrCount.c}/${writeCaps.maxAttributesPerAspect}) — supersede or expire an existing claim, or consolidate duplicates, before adding`,
+				409,
+			);
+		}
+	}
 	const version = previous === null ? 1 : Math.max(...slot.map((row) => row.version ?? 1)) + 1;
 	const rootId = previous?.version_root_id ?? previous?.id ?? crypto.randomUUID();
 	const id = version === 1 ? rootId : crypto.randomUUID();
@@ -1368,6 +1397,42 @@ function applyArchiveEntity(
 	return { entityId: entity.id, archived: true };
 }
 
+/**
+ * Reject aspect growth past the cap when the named aspect is not already
+ * active. Applies to both create_aspect and add_claim_value resolving a
+ * new aspect name: creating a fresh aspect OR reactivating an archived
+ * one grows the active set, so both count against the cap.
+ */
+function enforceAspectCapForNewAspect(
+	db: WriteDb,
+	entity: { readonly id: string; readonly name: string },
+	agentId: string,
+	name: string,
+	writeCaps?: GraphWriteCaps,
+): void {
+	if (writeCaps === undefined) return;
+	const key = canonical(name);
+	const activeAspect = db
+		.prepare(
+			`SELECT id FROM entity_aspects
+			 WHERE entity_id = ? AND agent_id = ? AND canonical_name = ? AND COALESCE(status, 'active') = 'active'`,
+		)
+		.get(entity.id, agentId, key);
+	if (activeAspect != null) return;
+	const aspectCount = db
+		.prepare(
+			`SELECT COUNT(*) AS c FROM entity_aspects
+			 WHERE entity_id = ? AND agent_id = ? AND COALESCE(status, 'active') = 'active'`,
+		)
+		.get(entity.id, agentId) as { c: number };
+	if (aspectCount.c >= writeCaps.maxAspectsPerEntity) {
+		throw new OntologyProposalError(
+			`entity '${entity.name}' is at aspect cap (${aspectCount.c}/${writeCaps.maxAspectsPerEntity}) — consolidate or archive an existing aspect before creating a new one`,
+			409,
+		);
+	}
+}
+
 function applyCreateAspect(
 	db: WriteDb,
 	agentId: string,
@@ -1381,29 +1446,7 @@ function applyCreateAspect(
 	if (name === null) throw new OntologyProposalError("payload.name is required", 400);
 	const entity = resolveEntityStrict(db, agentId, entitySelector);
 
-	if (writeCaps !== undefined) {
-		const key = canonical(name);
-		const existingAspect = db
-			.prepare(
-				`SELECT id FROM entity_aspects
-				 WHERE entity_id = ? AND agent_id = ? AND canonical_name = ?`,
-			)
-			.get(entity.id, agentId, key) as { id: string } | undefined;
-		if (existingAspect == null) {
-			const aspectCount = db
-				.prepare(
-					`SELECT COUNT(*) AS c FROM entity_aspects
-					 WHERE entity_id = ? AND agent_id = ? AND COALESCE(status, 'active') = 'active'`,
-				)
-				.get(entity.id, agentId) as { c: number };
-			if (aspectCount.c >= writeCaps.maxAspectsPerEntity) {
-				throw new OntologyProposalError(
-					`entity '${entity.name}' is at aspect cap (${aspectCount.c}/${writeCaps.maxAspectsPerEntity}) — consolidate or archive an existing aspect before creating a new one`,
-					409,
-				);
-			}
-		}
-	}
+	enforceAspectCapForNewAspect(db, entity, agentId, name, writeCaps);
 
 	const aspectId = resolveOrCreateAspect(db, entity.id, agentId, name);
 	db.prepare(
@@ -2037,7 +2080,8 @@ function applyOperation(
 		return applyArchiveAspect(db, proposal.agent_id, proposal, payload, actor);
 	if (proposal.operation === "add_claim_value")
 		return applyAddClaimValue(db, proposal.agent_id, proposal, payload, writeCaps);
-	if (proposal.operation === "set_claim_value") return applySetClaimValue(db, proposal.agent_id, proposal, payload);
+	if (proposal.operation === "set_claim_value")
+		return applySetClaimValue(db, proposal.agent_id, proposal, payload, writeCaps);
 	if (proposal.operation === "merge_entities") return applyMergeEntities(db, proposal.agent_id, payload);
 	if (proposal.operation === "merge_aspects") return applyMergeAspects(db, proposal.agent_id, proposal, payload);
 	if (proposal.operation === "supersede_claim_value") {

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -1720,12 +1720,15 @@ function applyMergeEntities(
 }
 
 /**
- * Fold source aspects into a target aspect on the same entity. All active
- * attributes of each source are repointed to the target, then the source
- * aspect is archived. The merged target may exceed the write-path attribute
- * cap: consolidation is the remedy the cap forces, so it is never blocked by
- * it. Claim-key collisions between source and target are preserved as
- * distinct rows — further dedup is the agent's job via supersede_claim_value.
+ * Fold source aspects into a target aspect on the same entity. Every
+ * attribute row (active, superseded, deleted) of each source is repointed to
+ * the target so claim version history stays with the merged aspect, then the
+ * source aspect is archived. The merged target may exceed the write-path
+ * attribute cap: consolidation is the remedy the cap forces, so it is never
+ * blocked by it. Claim-key collisions between source and target are preserved
+ * as distinct rows — further dedup is the agent's job via
+ * supersede_claim_value. Original proposal attribution on moved rows is
+ * preserved so claim-evidence drill-down still resolves the original write.
  */
 function applyMergeAspects(
 	db: WriteDb,
@@ -1767,15 +1770,19 @@ function applyMergeAspects(
 		if (seen.has(source.id)) continue;
 		seen.add(source.id);
 
+		// #1147 review (findings 10, 11): move EVERY attribute row (active,
+		// superseded, deleted) so version history stays with the merged
+		// aspect, and preserve each row's original proposal_id/proposal_evidence
+		// so claim-evidence drill-down still resolves the original write.
 		const attributes = db
-			.prepare("SELECT id FROM entity_attributes WHERE aspect_id = ? AND agent_id = ? AND status = 'active'")
+			.prepare("SELECT id FROM entity_attributes WHERE aspect_id = ? AND agent_id = ?")
 			.all(source.id, agentId) as Array<{ id: string }>;
 		for (const attribute of attributes) {
 			db.prepare(
 				`UPDATE entity_attributes
-				 SET aspect_id = ?, proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
-				 WHERE id = ? AND agent_id = ? AND status = 'active'`,
-			).run(target.id, proposal.id, evidence, attribute.id, agentId);
+				 SET aspect_id = ?, updated_at = datetime('now')
+				 WHERE id = ? AND agent_id = ?`,
+			).run(target.id, attribute.id, agentId);
 		}
 		db.prepare(
 			`UPDATE entity_aspects

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -22,7 +22,7 @@ import {
 } from "../knowledge-graph";
 import { getOntologyClaimEvidence } from "../ontology-claim-evidence";
 import { getOntologyLinkEvidence } from "../ontology-link-evidence";
-import { findDuplicateEntityMerges } from "../ontology-proposals";
+import { type GraphWriteCaps, findDuplicateEntityMerges } from "../ontology-proposals";
 import { detectProspectiveContradictionRisk } from "./antonyms";
 import { getDreamingAttentionAcrossScopes, getDreamingAttentionScoped } from "./dreaming-attention";
 import { nextDreamingEvidenceFragment, renderDreamingEvidence } from "./dreaming-evidence";
@@ -199,6 +199,8 @@ export interface CreateDreamingCapabilitiesParams {
 	readonly actor: string;
 	/** Present only for a live Dreaming pass; protects runbook writes. */
 	readonly passId?: string;
+	/** Write-path caps forwarded to applyDreamingOperations. */
+	readonly writeCaps?: GraphWriteCaps;
 	readonly onOperationsApplied?: (
 		result: ApplyDreamingOperationsResult,
 		operations: readonly DreamingOperationRequest[],
@@ -608,6 +610,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 					actor,
 					operations,
 					passId: params.passId,
+					writeCaps: params.writeCaps,
 				});
 				params.onOperationsApplied?.(result, operations);
 				return { ok: result.ok, ...(result.error ? { error: result.error } : {}), items: result.items };

--- a/platform/daemon/src/pipeline/dreaming-operation-contract.ts
+++ b/platform/daemon/src/pipeline/dreaming-operation-contract.ts
@@ -59,6 +59,16 @@ export const DREAMING_ONTOLOGY_PAYLOAD_SCHEMAS = {
 		survivor: entityId.describe("The entity that survives the merge."),
 		...reasonField,
 	}),
+	merge_aspects: payload({
+		entityId,
+		target: aspectId.describe("The aspect that absorbs the sources. Use aspect_id."),
+		sources: z
+			.array(aspectId)
+			.min(1)
+			.describe("Aspect ids to fold into the target. Attributes are moved, sources are archived."),
+		newName: aspectName.describe("Optional new name for the merged aspect.").optional(),
+		...reasonField,
+	}),
 
 	// --- content-bearing ops: require evidence with exact quotes ---
 	create_entity: payload({ name: entityName, type: entityType }),
@@ -133,6 +143,7 @@ export const DREAMING_ONTOLOGY_OPERATION_SCHEMA = z.discriminatedUnion("operatio
 	operation("update_link"),
 	operation("archive_link"),
 	operation("merge_entities"),
+	operation("merge_aspects"),
 	operation("supersede_claim_value"),
 	operation("create_policy"),
 	operation("create_action_type"),

--- a/platform/daemon/src/pipeline/dreaming-operations.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.test.ts
@@ -394,4 +394,78 @@ describe("dreaming operations", () => {
 		expect(result.ok).toBe(false);
 		expect(result.error).toContain("Unsupported ontology proposal operation");
 	});
+
+	it("merges aspects through the hygiene seam with attention provenance", () => {
+		insertEntity("e-merge", "MergeCo", "mergeco");
+		insertAspect("a-target", "e-merge", "status_history");
+		insertAspect("a-source", "e-merge", "changelog");
+		getDbAccessor().withWriteTx((db) => {
+			for (const [aspectId, content] of [
+				["a-target", "status one"],
+				["a-source", "change one"],
+				["a-source", "change two"],
+			] as const) {
+				db.prepare(
+					`INSERT INTO entity_attributes
+					 (id, aspect_id, agent_id, kind, content, normalized_content, confidence, importance,
+					  status, group_key, claim_key, version, version_root_id, created_at, updated_at)
+					 VALUES (?, ?, ?, 'fact', ?, ?, 0.9, 0.9, 'active', 'general', 'k', 1, ?, datetime('now'), datetime('now'))`,
+				).run(`attr-${content}`, aspectId, "agent-a", content, content, `root-${content}`);
+			}
+		});
+
+		const result = applyDreamingOperations({
+			accessor: getDbAccessor(),
+			agentId: "agent-a",
+			actor: "dreaming",
+			passId: "pass-merge",
+			operations: [
+				flag({ subjectRef: "aspect:a-source", details: { aspectId: "a-source", reason: "aspect_over_cap" } }),
+				{
+					operation: "merge_aspects",
+					payload: {
+						entityId: "e-merge",
+						target: "a-target",
+						sources: ["a-source"],
+						newName: "timeline",
+						reason: "fold changelog into status history",
+					},
+					provenance: "attention:$0",
+				},
+			],
+		});
+		expect(result.ok).toBe(true);
+		expect(result.items[1]!.ok).toBe(true);
+		expect(result.items[1]!.result).toMatchObject({ targetAspect: "timeline", totalAttributesMoved: 2 });
+		// Source archived, target renamed, all attributes under the target
+		expect(
+			getDbAccessor().withReadDb((db) => db.prepare("SELECT status FROM entity_aspects WHERE id = ?").get("a-source")),
+		).toEqual({ status: "archived" });
+		expect(
+			getDbAccessor().withReadDb((db) =>
+				db
+					.prepare("SELECT COUNT(*) AS c FROM entity_attributes WHERE aspect_id = ? AND status = 'active'")
+					.get("a-target"),
+			),
+		).toEqual({ c: 3 });
+	});
+
+	it("requires attention provenance for merge_aspects like other hygiene ops", () => {
+		insertEntity("e-merge2", "MergeTwo", "mergetwo");
+		insertAspect("a-t2", "e-merge2", "target");
+		insertAspect("a-s2", "e-merge2", "source");
+		const result = applyDreamingOperations({
+			accessor: getDbAccessor(),
+			agentId: "agent-a",
+			actor: "dreaming",
+			operations: [
+				{
+					operation: "merge_aspects",
+					payload: { entityId: "e-merge2", target: "a-t2", sources: ["a-s2"] },
+				},
+			],
+		});
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain("Hygiene archives require attention provenance");
+	});
 });

--- a/platform/daemon/src/pipeline/dreaming-operations.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.ts
@@ -1,7 +1,11 @@
 import { SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES } from "@signet/core";
 import type { DbAccessor, ReadDb } from "../db-accessor";
 import { findEpisodicSourceAgentIds, readEpisodicSource } from "../episodic-sources";
-import { type OntologyOperationInput, applyOntologyOperationBatchInTx } from "../ontology-proposals";
+import {
+	type GraphWriteCaps,
+	type OntologyOperationInput,
+	applyOntologyOperationBatchInTx,
+} from "../ontology-proposals";
 import { type DreamingAttention, enqueueDreamingAttentionInTx, getDreamingAttentionById } from "./dreaming-attention";
 import { type DreamingAgentEvidence, createDreamingAgentEvidence } from "./dreaming-evidence";
 import { DREAMING_OPERATION_IDS } from "./dreaming-operation-contract";
@@ -489,6 +493,7 @@ export function applyDreamingOperations(params: {
 	readonly actor: string;
 	readonly operations: readonly DreamingOperationRequest[];
 	readonly passId?: string;
+	readonly writeCaps?: GraphWriteCaps;
 }): ApplyDreamingOperationsResult {
 	if (params.operations.length === 0) return { ok: false, items: [], error: "operations are required" };
 	const allowedOperations = new Set<string>(DREAMING_OPERATION_IDS);
@@ -581,6 +586,7 @@ export function applyDreamingOperations(params: {
 					agentId: params.agentId,
 					actor: params.actor,
 					operations: [entry.input],
+					writeCaps: params.writeCaps,
 				});
 				db.exec(`RELEASE SAVEPOINT ${savepoint}`);
 				if (entry.attentionId !== null) {

--- a/platform/daemon/src/pipeline/dreaming-operations.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.ts
@@ -41,6 +41,7 @@ const HYGIENE_ARCHIVE_OPS = new Set([
 	"archive_claim_value",
 	"archive_link",
 	"merge_entities",
+	"merge_aspects",
 ]);
 
 function citationRecord(value: unknown): {
@@ -228,6 +229,17 @@ function attentionProvenance(
 			targets.every((id) => groupIds.has(id)) &&
 			targets.includes(survivor) &&
 			targets.some((id) => id !== survivor);
+	} else if (operation.operation === "merge_aspects") {
+		// The flag names the over-cap aspect; the merge must fold it into a target.
+		const sources = Array.isArray(payload.sources)
+			? payload.sources.filter((value): value is string => typeof value === "string")
+			: [];
+		const flaggedAspect = attention.details.aspectId ?? attention.subjectRef.replace(/^aspect:/, "");
+		expectedTarget =
+			attention.subjectRef.startsWith("aspect:") &&
+			typeof payload.target === "string" &&
+			sources.length >= 1 &&
+			sources.includes(flaggedAspect);
 	}
 	if (!expectedTarget) return null;
 
@@ -390,6 +402,16 @@ function toApplicatorPayload(
 			if (targets === null || survivor === null) return null;
 			const sourceIds = targets.filter((id) => id !== survivor);
 			return { target_entity_id: survivor, source_entity_ids: sourceIds };
+		}
+		case "merge_aspects": {
+			const entityId = stringField(payload, "entityId");
+			const target = stringField(payload, "target");
+			const sources = stringArrayField(payload, "sources");
+			if (entityId === null || target === null || sources === null || sources.length === 0) return null;
+			const name = lookupEntityName(accessor, agentId, entityId);
+			return name === null
+				? null
+				: { entity: name, target, sources, new_name: stringField(payload, "newName") ?? undefined };
 		}
 		case "create_entity": {
 			const name = stringField(payload, "name");

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -269,6 +269,7 @@ export function startDreamingWorker(
 			passScopes,
 			mode,
 			existingPassId,
+			caps,
 		);
 		activePassPromise = p;
 		try {
@@ -403,6 +404,7 @@ export function startDreamingWorker(
 				getDreamingWorkerAgentIds(accessor, defaultAgentId),
 				mode,
 				passId,
+				caps,
 			);
 			activePassPromise = p;
 			p.catch((e) => {

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -8,6 +8,7 @@ import type { DreamingConfig } from "@signet/core";
 import type { DbAccessor } from "../db-accessor";
 import { getQueueHealth } from "../diagnostics";
 import { getOrCreateInferenceRouter } from "../inference-router";
+import type { GraphHygieneCaps } from "../knowledge-graph-hygiene";
 import { logger } from "../logger";
 import { isSystemPressureHigh } from "../system-pressure";
 import {
@@ -166,6 +167,7 @@ export function startDreamingWorker(
 	agentsDir: string,
 	defaultAgentId: string,
 	options: DreamingWorkerOptions = {},
+	caps?: GraphHygieneCaps,
 ): DreamingWorkerHandle {
 	let timer: ReturnType<typeof setTimeout> | null = null;
 	let active = false;
@@ -300,7 +302,7 @@ export function startDreamingWorker(
 			// episodic backlog read on every sweep: skip straight past it.
 			if (isDreamingHaltActive(accessor, scopeId)) continue;
 			try {
-				enqueueDreamingHygieneAttention(accessor, scopeId);
+				enqueueDreamingHygieneAttention(accessor, scopeId, undefined, caps);
 				const episodicTokens = getDreamingEpisodicTokenBacklog(accessor, scopeId);
 				if (!shouldTriggerDreaming(accessor, cfg, scopeId, Date.now(), episodicTokens)) continue;
 				triggered = true;

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -308,6 +308,41 @@ describe("Dreaming", () => {
 		);
 	});
 
+	it("enqueues over-cap attention rows when caps are supplied (#1138)", () => {
+		db.prepare(
+			`INSERT INTO entities
+			 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+			 VALUES ('fat-entity', 'Fat Entity', 'fat entity', 'project', ?, 5, datetime('now'), datetime('now'))`,
+		).run(AGENT);
+		db.prepare(
+			`INSERT INTO entity_aspects
+			 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+			 VALUES ('fat-aspect', 'fat-entity', ?, 'status_history', 'status_history', 0.5, datetime('now'), datetime('now'))`,
+		).run(AGENT);
+		for (let i = 0; i < 7; i++) {
+			db.prepare(
+				`INSERT INTO entity_attributes
+				 (id, aspect_id, agent_id, kind, content, normalized_content, confidence, importance,
+				  status, group_key, claim_key, version, created_at, updated_at)
+				 VALUES (?, 'fat-aspect', ?, 'fact', ?, ?, 0.9, 0.5, 'active', 'general', ?, 1, datetime('now'), datetime('now'))`,
+			).run(`attr-${i}`, AGENT, `content ${i}`, `content ${i}`, `key-${i}`);
+		}
+
+		const caps = { maxAspectsPerEntity: 20, maxAttributesPerAspect: 5 };
+		enqueueDreamingHygieneAttention(accessor, AGENT, 50, caps);
+		expect(getDreamingAttention(accessor, AGENT)).toContainEqual(
+			expect.objectContaining({
+				kind: "hygiene",
+				subjectRef: "aspect:fat-aspect",
+				details: expect.objectContaining({
+					reason: "attribute_over_cap",
+					attributeCount: "7",
+					maxAttributesPerAspect: "5",
+				}),
+			}),
+		);
+	});
+
 	it("reopens duplicate hygiene attention when group membership changes", () => {
 		for (const [id, name] of [
 			["acme-a", "Acme"],

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -24,7 +24,7 @@ import {
 	readEpisodicSource,
 	readRecentEpisodicSources,
 } from "../episodic-sources";
-import { getDreamingHygieneCandidatesInDb } from "../knowledge-graph-hygiene";
+import { type GraphHygieneCaps, getDreamingHygieneCandidatesInDb } from "../knowledge-graph-hygiene";
 import { logger } from "../logger";
 import { createDreamingAgentTools } from "./dreaming-agent-tools";
 import {
@@ -74,9 +74,14 @@ export interface DreamingState {
 }
 
 /** Queue bounded deterministic graph cleanup work for the next Dreaming pass. */
-export function enqueueDreamingHygieneAttention(accessor: DbAccessor, agentId: string, limit = 50): number {
+export function enqueueDreamingHygieneAttention(
+	accessor: DbAccessor,
+	agentId: string,
+	limit = 50,
+	caps?: GraphHygieneCaps,
+): number {
 	return accessor.withWriteTx((db) => {
-		const candidates = getDreamingHygieneCandidatesInDb(db, { agentId, limit });
+		const candidates = getDreamingHygieneCandidatesInDb(db, { agentId, limit, caps });
 		for (const candidate of candidates) {
 			enqueueDreamingAttentionInTx(db, {
 				agentId,
@@ -629,6 +634,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 2. Query the attention queue (attention_list, kind=hygiene, status=pending). Process ALL pending hygiene records first, before any content work:
    - Inspect the flagged target (get_entity — check aspects, claims, pinned).
    - Archive or merge it, citing its attention id (provenance: "attention:<uuid>", or attention:$<index> for a flag you minted in the same batch).
+   - \`attribute_over_cap\` / \`aspect_over_cap\` flags: the write gate rejects new claims or aspects past the cap, so consolidate the flagged target — merge_aspects to fold over-cap aspects together, supersede_claim_value to collapse duplicate claim keys, archive_claim_value for stale snapshots. Consolidation (merge_aspects) may exceed the attribute cap; it is the remedy the cap forces.
    - If you discover junk the queue did not flag, mint a flag op and archive in the same batch.
 3. Query attention_list with kind=review_due. For expired records, inspect the cited memory with search_evidence using its subjectRef, then supersede the matching active claim with supersede_claim_value. Use the supplied entityId, aspectId, attributeId, and claimKey when present. The replacement must state that the planned event remains unconfirmed; never rewrite it as if the event happened. Cite an exact quote from the original memory. Do not supersede approaching records. When creating or setting a future temporal claim, set payload.reviewAfter to the referenced ISO timestamp.
 4. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -26,6 +26,7 @@ import {
 } from "../episodic-sources";
 import { type GraphHygieneCaps, getDreamingHygieneCandidatesInDb } from "../knowledge-graph-hygiene";
 import { logger } from "../logger";
+import type { GraphWriteCaps } from "../ontology-proposals";
 import { createDreamingAgentTools } from "./dreaming-agent-tools";
 import {
 	type DreamingAttention,
@@ -868,6 +869,7 @@ export async function runDreamingAgentPass(
 	scopes: readonly string[],
 	mode: DreamingMode,
 	existingPassId?: string,
+	writeCaps?: GraphWriteCaps,
 ): Promise<{ passId: string; applied: number; skipped: number; failed: number; summary: string }> {
 	const passId = existingPassId ?? createDreamingPass(accessor, agentId, mode);
 	const passStartedAt = new Date().toISOString();
@@ -919,6 +921,7 @@ export async function runDreamingAgentPass(
 			agentId,
 			actor: "dreaming",
 			passId,
+			writeCaps,
 			onOperationsApplied(result, operations) {
 				applyCallbackReported = true;
 				applied += result.items.filter((item) => item.ok).length;

--- a/platform/daemon/src/routes/memory-routes-curator.test.ts
+++ b/platform/daemon/src/routes/memory-routes-curator.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
@@ -12,6 +12,10 @@ let registerMemoryRoutes: ((app: Hono) => void) | undefined;
 
 process.env.SIGNET_PATH = agentsDir;
 mkdirSync(join(agentsDir, "memory"), { recursive: true });
+// Fast, dependency-free embedding: provider "none" makes fetchEmbedding
+// return null immediately instead of downloading nomic-embed at first use.
+mkdirSync(join(agentsDir, ".daemon"), { recursive: true });
+writeFileSync(join(agentsDir, "agent.yaml"), "embedding:\n  provider: none\n");
 
 beforeAll(async () => {
 	// Static import would capture AGENTS_DIR before this test installs its temp SIGNET_PATH.
@@ -53,7 +57,7 @@ afterAll(() => {
 function makeApp(): Hono {
 	if (!registerMemoryRoutes) throw new Error("memory routes were not loaded");
 	const app = new Hono();
-	registerMemoryRoutes(app);
+	registerMemoryRoutes(app, { fetchEmbedding: async () => undefined });
 	return app;
 }
 
@@ -231,5 +235,78 @@ describe("memory curator routes", () => {
 			{ id: "mem-contradicted", content: "contradicted memory", contradicted_count: 1 },
 		]);
 		expect(body.highUsed).toEqual([{ id: "mem-used", content: "useful memory", used_count: 1 }]);
+	});
+
+	// #1138: remember-with-supersedes — lineage at write time.
+	it("marks the supersedes target superseded atomically with the new memory", async () => {
+		seedMemory("mem-v1", "original claim");
+		const app = makeApp();
+
+		const res = await app.request("/api/memory/remember", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				content: "replacement claim",
+				supersedes: "mem-v1",
+				reason: "newer evidence",
+			}),
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { id: string; superseded: string };
+		expect(typeof body.id).toBe("string");
+		expect(body.superseded).toBe("superseded");
+
+		const oldRow = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT superseded_by, version FROM memories WHERE id = ?").get("mem-v1") as {
+					superseded_by: string | null;
+					version: number;
+				},
+		);
+		expect(oldRow.superseded_by).toBe(body.id);
+		expect(oldRow.version).toBe(2);
+	});
+
+	it("fails the whole remember when the supersedes target is missing", async () => {
+		const app = makeApp();
+		const res = await app.request("/api/memory/remember", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ content: "orphan claim", supersedes: "does-not-exist" }),
+		});
+		expect(res.status).toBe(500);
+		// The new memory must not exist — atomic lineage, no orphan.
+		const count = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT COUNT(*) AS count FROM memories WHERE content = 'orphan claim'").get() as { count: number },
+		);
+		expect(count.count).toBe(0);
+	});
+
+	it("walks superseded_by lineage from any row in the chain", async () => {
+		seedMemory("mem-gen1", "genesis claim");
+		const app = makeApp();
+		const v2 = await app.request("/api/memory/remember", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ content: "second claim", supersedes: "mem-gen1" }),
+		});
+		const v2Body = (await v2.json()) as { id: string };
+		const v3 = await app.request("/api/memory/remember", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ content: "third claim", supersedes: v2Body.id }),
+		});
+		const v3Body = (await v3.json()) as { id: string };
+
+		// Drill from the oldest row: the chain must resolve forward to the head,
+		// newest first (v3 -> v2 -> v1).
+		const res = await app.request(`/api/memory/mem-gen1/lineage`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { count: number; lineage: Array<{ id: string; supersededBy: string | null }> };
+		expect(body.count).toBe(3);
+		expect(body.lineage.map((row) => row.id)).toEqual([v3Body.id, v2Body.id, "mem-gen1"]);
+		expect(body.lineage[0]!.supersededBy).toBeNull();
+		expect(body.lineage[2]!.supersededBy).toBe(v2Body.id);
 	});
 });

--- a/platform/daemon/src/routes/memory-routes-curator.test.ts
+++ b/platform/daemon/src/routes/memory-routes-curator.test.ts
@@ -317,7 +317,7 @@ describe("memory curator routes", () => {
 		).toEqual({ superseded_by: null });
 	});
 
-	it("walks superseded_by lineage from any row in the chain", async () => {
+	it("walks superseded_by lineage from any row in the chain, oldest first", async () => {
 		seedMemory("mem-gen1", "genesis claim");
 		const app = makeApp();
 		const v2 = await app.request("/api/memory/remember", {
@@ -333,14 +333,61 @@ describe("memory curator routes", () => {
 		});
 		const v3Body = (await v3.json()) as { id: string };
 
-		// Drill from the oldest row: the chain must resolve forward to the head,
-		// newest first (v3 -> v2 -> v1).
-		const res = await app.request(`/api/memory/mem-gen1/lineage`);
-		expect(res.status).toBe(200);
-		const body = (await res.json()) as { count: number; lineage: Array<{ id: string; supersededBy: string | null }> };
-		expect(body.count).toBe(3);
-		expect(body.lineage.map((row) => row.id)).toEqual([v3Body.id, v2Body.id, "mem-gen1"]);
-		expect(body.lineage[0]!.supersededBy).toBeNull();
-		expect(body.lineage[2]!.supersededBy).toBe(v2Body.id);
+		// #1147 review (finding 9): lineage resolves the full chain from ANY
+		// row — including the newest head — ordered oldest -> newest.
+		for (const start of ["mem-gen1", v2Body.id, v3Body.id]) {
+			const res = await app.request(`/api/memory/${start}/lineage`);
+			expect(res.status).toBe(200);
+			const body = (await res.json()) as {
+				count: number;
+				lineage: Array<{ id: string; supersededBy: string | null }>;
+			};
+			expect(body.count).toBe(3);
+			expect(body.lineage.map((row) => row.id)).toEqual(["mem-gen1", v2Body.id, v3Body.id]);
+			expect(body.lineage[0]!.supersededBy).toBe(v2Body.id);
+			expect(body.lineage[2]!.supersededBy).toBeNull();
+		}
+	});
+
+	it("refuses to re-supersede a mid-chain memory with a different successor (no fork)", async () => {
+		seedMemory("mem-a", "genesis");
+		const app = makeApp();
+		// a -> (new v2 memory)
+		const r1 = await app.request("/api/memory/remember", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ content: "b", supersedes: "mem-a" }),
+		});
+		expect(r1.status).toBe(200);
+		const v2Id = ((await r1.json()) as { id: string }).id;
+		// Try to re-supersede a with a fresh memory c: must fail the write,
+		// and a's chain must still point at v2 (no second head).
+		const r2 = await app.request("/api/memory/remember", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ content: "c", supersedes: "mem-a" }),
+		});
+		expect(r2.status).toBe(400);
+		const aRow = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT superseded_by FROM memories WHERE id = 'mem-a'").get("mem-a") as {
+					superseded_by: string | null;
+				},
+		);
+		expect(aRow.superseded_by).toBe(v2Id);
+		// The rejected write must not have created a memory.
+		const cCount = getDbAccessor().withReadDb(
+			(db) => db.prepare("SELECT COUNT(*) AS c FROM memories WHERE content = 'c'").get() as { c: number },
+		);
+		expect(cCount.c).toBe(0);
+		// And the old successor (v2) is still the only head of the chain:
+		// it is not superseded, and nothing else supersedes mem-a.
+		const v2Row = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT superseded_by FROM memories WHERE id = ?").get(v2Id) as {
+					superseded_by: string | null;
+				},
+		);
+		expect(v2Row.superseded_by).toBeNull();
 	});
 });

--- a/platform/daemon/src/routes/memory-routes-curator.test.ts
+++ b/platform/daemon/src/routes/memory-routes-curator.test.ts
@@ -274,13 +274,47 @@ describe("memory curator routes", () => {
 			headers: { "content-type": "application/json" },
 			body: JSON.stringify({ content: "orphan claim", supersedes: "does-not-exist" }),
 		});
-		expect(res.status).toBe(500);
+		expect(res.status).toBe(400);
+		expect((await res.json()) as { error: string }).toMatchObject({
+			error: "supersedes target rejected: not_found",
+		});
 		// The new memory must not exist — atomic lineage, no orphan.
 		const count = getDbAccessor().withReadDb(
 			(db) =>
 				db.prepare("SELECT COUNT(*) AS count FROM memories WHERE content = 'orphan claim'").get() as { count: number },
 		);
 		expect(count.count).toBe(0);
+	});
+
+	it("rejects supersedes combined with oversized chunked content", async () => {
+		seedMemory("mem-chunked", "to be superseded");
+		const app = makeApp();
+		const res = await app.request("/api/memory/remember", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				content: "x".repeat(2000),
+				supersedes: "mem-chunked",
+			}),
+		});
+		expect(res.status).toBe(400);
+		expect((await res.json()) as { error: string }).toMatchObject({
+			error: "supersedes cannot be combined with oversized content (auto-chunking)",
+		});
+		// No chunks written, predecessor untouched.
+		const chunkCount = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT COUNT(*) AS count FROM memories WHERE source_type = 'chunk'").get() as { count: number },
+		);
+		expect(chunkCount.count).toBe(0);
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db.prepare("SELECT superseded_by FROM memories WHERE id = 'mem-chunked'").get("mem-chunked") as {
+						superseded_by: string | null;
+					},
+			),
+		).toEqual({ superseded_by: null });
 	});
 
 	it("walks superseded_by lineage from any row in the chain", async () => {

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -36,7 +36,14 @@ import { enqueueDocumentIngestJob } from "../pipeline";
 import { parseFeedback, recordAgentFeedback } from "../session-memories";
 import { upsertSessionTranscript } from "../session-transcripts";
 import { createTemporalEdgeId, normalizeTemporalTimestamp, validateTemporalTimeOptions } from "../temporal-recall";
-import { txForgetMemory, txIngestEnvelope, txModifyMemory, txRecoverMemory, txSupersedeMemory } from "../transactions";
+import {
+	type SupersedeMemoryTxStatus,
+	txForgetMemory,
+	txIngestEnvelope,
+	txModifyMemory,
+	txRecoverMemory,
+	txSupersedeMemory,
+} from "../transactions";
 import { cacheProjection, computeProjection, computeProjectionForQuery, getCachedProjection } from "../umap-projection";
 import {
 	AGENTS_DIR,
@@ -1129,6 +1136,10 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			sourceCreatedAt?: string;
 			/** ISO timestamp; due-for-review marker for temporal claims (#945). */
 			reviewAfter?: string;
+			/** Id of the memory this write supersedes (vN -> vN+1 lineage). */
+			supersedes?: string;
+			/** Reason recorded on the superseded memory when supersedes is set. */
+			reason?: string;
 			scope?: string | null;
 			agentId?: string;
 			visibility?: "global" | "private" | "archived";
@@ -1184,6 +1195,10 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const requestedReviewAfter = parseOptionalIsoTimestamp(body.reviewAfter);
 		if (body.reviewAfter !== undefined && !requestedReviewAfter) {
 			return c.json({ error: "reviewAfter must be a valid ISO timestamp" }, 400);
+		}
+		const requestedSupersedes = body.supersedes?.trim();
+		if (body.supersedes !== undefined && !requestedSupersedes) {
+			return c.json({ error: "supersedes must be a memory id" }, 400);
 		}
 		const scope = body.scope ?? null;
 		const rowProvenance = parseRememberRowProvenance(body as Record<string, unknown>);
@@ -1516,6 +1531,8 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			return c.json({ error: "idempotencyKey already used for chunked content" }, 409);
 		}
 
+		let supersededStatus: SupersedeMemoryTxStatus | null = null;
+
 		try {
 			const result = getDbAccessor().withWriteTx((db) => {
 				// Check sourceId-based dedupe first (scope-aware)
@@ -1574,8 +1591,30 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					inputs: temporalInputs.inputs ?? [],
 					now,
 				});
-				return { deduped: false as const };
+				// #1138: lineage at write time. When the caller names a
+				// supersedes target, mark it superseded in the same tx so the
+				// new row becomes the head of the chain atomically.
+				let superseded: SupersedeMemoryTxStatus | null = null;
+				if (requestedSupersedes !== undefined) {
+					const actor = resolveMutationActor(c, who);
+					const result = txSupersedeMemory(db, {
+						memoryId: requestedSupersedes,
+						supersededBy: id,
+						reason: body.reason ?? null,
+						changedBy: actor.changedBy,
+						changedAt: now,
+						ctx: { actorType: actor.actorType, sessionId: actor.sessionId, requestId: actor.requestId },
+					});
+					// Atomic lineage: an unusable supersedes target fails the
+					// whole write rather than silently producing an orphan.
+					if (result.status !== "superseded" && result.status !== "already_superseded") {
+						throw new Error(`supersedes target rejected: ${result.status}`);
+					}
+					superseded = result.status;
+				}
+				return { deduped: false as const, superseded };
 			});
+			supersededStatus = result.deduped ? null : (result as { superseded: SupersedeMemoryTxStatus | null }).superseded;
 
 			if (result.deduped) {
 				getDbAccessor().withWriteTx((db) =>
@@ -1745,6 +1784,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			// Explicit non-silent indicator: structured input was retained as
 			// episodic evidence but NOT applied to the knowledge graph.
 			structured_applied: false,
+			...(supersededStatus !== null ? { superseded: supersededStatus } : {}),
 		});
 	});
 
@@ -1911,6 +1951,73 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					requestId: row.request_id ?? undefined,
 				};
 			}),
+		});
+	});
+	// =========================================================================
+	// GET /api/memory/:id/lineage
+	// =========================================================================
+	app.get("/api/memory/:id/lineage", (c) => {
+		const memoryId = c.req.param("id")?.trim();
+		if (!memoryId) return c.json({ error: "memory id is required" }, 400);
+		const limit = Math.min(parseOptionalInt(c.req.query("limit")) ?? 50, 500);
+
+		type LineageRow = {
+			id: string;
+			content: string;
+			type: string;
+			importance: number;
+			version: number;
+			created_at: string;
+			updated_at: string;
+			superseded_by: string | null;
+			superseded_at: string | null;
+			superseded_reason: string | null;
+		};
+		const selectLineage = (
+			db: { prepare(sql: string): { get(...args: string[]): unknown } },
+			id: string,
+		): LineageRow | undefined =>
+			db
+				.prepare(
+					`SELECT id, content, type, importance, version, created_at, updated_at, superseded_by, superseded_at, superseded_reason
+					 FROM memories
+					 WHERE id = ?`,
+				)
+				.get(id) as LineageRow | undefined;
+
+		const rows = getDbAccessor().withReadDb((db) => {
+			const head = selectLineage(db, memoryId);
+			if (!head) return [];
+			// Walk the superseded_by chain toward the newest head, then
+			// reverse into oldest -> newest order.
+			const chain: LineageRow[] = [head];
+			const seen = new Set<string>([head.id]);
+			let current = head;
+			while (current.superseded_by && !seen.has(current.superseded_by) && chain.length < limit) {
+				seen.add(current.superseded_by);
+				const next = selectLineage(db, current.superseded_by);
+				if (!next) break;
+				chain.push(next);
+				current = next;
+			}
+			return chain.reverse();
+		});
+
+		return c.json({
+			memoryId,
+			count: rows.length,
+			lineage: rows.map((row) => ({
+				id: row.id,
+				content: row.content,
+				type: row.type,
+				importance: row.importance,
+				version: row.version,
+				createdAt: row.created_at,
+				updatedAt: row.updated_at,
+				supersededBy: row.superseded_by,
+				supersededAt: row.superseded_at,
+				supersededReason: row.superseded_reason,
+			})),
 		});
 	});
 

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -1616,9 +1616,13 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						ctx: { actorType: actor.actorType, sessionId: actor.sessionId, requestId: actor.requestId },
 					});
 					// Atomic lineage: an unusable supersedes target fails the
-					// whole write rather than silently producing an orphan.
+					// whole write rather than silently producing an orphan. A
+					// target already superseded by a DIFFERENT successor is a
+					// lineage conflict, not idempotence.
 					if (result.status !== "superseded" && result.status !== "already_superseded") {
-						throw new Error(`supersedes target rejected: ${result.status}`);
+						const statusLabel =
+							result.status === "already_superseded_by_other" ? "already superseded by another memory" : result.status;
+						throw new Error(`supersedes target rejected: ${statusLabel}`);
 					}
 					superseded = result.status;
 				}
@@ -2016,19 +2020,46 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const rows = getDbAccessor().withReadDb((db) => {
 			const head = selectLineage(db, memoryId);
 			if (!head) return [];
-			// Walk the superseded_by chain toward the newest head, then
-			// reverse into oldest -> newest order.
-			const chain: LineageRow[] = [head];
+			// #1147 review (finding 9): walk BOTH directions so lineage from
+			// any chain row — including the newest head — resolves the full
+			// history. Forward follows superseded_by to the head; backward
+			// finds rows that this row superseded (superseded_by = this id).
+			// Collect into a map then order oldest -> newest by version.
 			const seen = new Set<string>([head.id]);
+			const byId = new Map<string, LineageRow>([[head.id, head]]);
+			// Forward to the newest head.
 			let current = head;
-			while (current.superseded_by && !seen.has(current.superseded_by) && chain.length < limit) {
+			while (current.superseded_by && !seen.has(current.superseded_by) && byId.size < limit) {
 				seen.add(current.superseded_by);
 				const next = selectLineage(db, current.superseded_by);
 				if (!next) break;
-				chain.push(next);
+				byId.set(next.id, next);
 				current = next;
 			}
-			return chain.reverse();
+			// Backward to the oldest predecessor(s).
+			let cursor = head;
+			while (byId.size < limit) {
+				const predecessor = db
+					.prepare(
+						`SELECT m.id, m.content, m.type, m.importance, m.version, m.created_at, m.updated_at,
+						        m.superseded_by, m.superseded_at, m.superseded_reason
+						 FROM memories m
+						 WHERE m.superseded_by = ?
+						   AND (m.is_deleted = 0 OR m.is_deleted IS NULL)
+						   ${access.sql}
+						 ORDER BY m.created_at ASC
+						 LIMIT 1`,
+					)
+					.get(cursor.id, ...access.args) as LineageRow | undefined;
+				if (!predecessor || seen.has(predecessor.id)) break;
+				seen.add(predecessor.id);
+				byId.set(predecessor.id, predecessor);
+				cursor = predecessor;
+			}
+			// Order oldest -> newest by created_at: the superseded row's
+			// version is bumped (v1 -> v2) so version is NOT a reliable chain
+			// order — creation time is.
+			return [...byId.values()].sort((a, b) => a.created_at.localeCompare(b.created_at) || a.version - b.version);
 		});
 
 		return c.json({

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -1243,6 +1243,16 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 		// --- Auto-chunking for oversized memories ---
 		const guardrails = pipelineCfg.guardrails;
+		// supersedes is only meaningful for a single-row memory: chunked content
+		// produces several rows with no single head id to chain the predecessor
+		// to. Fail loudly instead of silently dropping the lineage request.
+		if (
+			requestedSupersedes !== undefined &&
+			"structured" in body === false &&
+			raw.length > guardrails.maxContentChars
+		) {
+			return c.json({ error: "supersedes cannot be combined with oversized content (auto-chunking)" }, 400);
+		}
 		if ("structured" in body) {
 			if (body.structured == null || typeof body.structured !== "object" || Array.isArray(body.structured)) {
 				return c.json({ error: "structured must be an object with entities and/or aspects arrays" }, 400);
@@ -1668,6 +1678,11 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				}
 			}
 			logger.error("memory", "Failed to save memory", e as Error);
+			if (e instanceof Error && e.message.startsWith("supersedes target rejected:")) {
+				// Distinguish a caller error (bad supersedes target) from a
+				// server fault: the tx rolled back, nothing was written.
+				return c.json({ error: e.message }, 400);
+			}
 			return c.json({ error: "Failed to save memory" }, 500);
 		}
 
@@ -1961,6 +1976,16 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		if (!memoryId) return c.json({ error: "memory id is required" }, 400);
 		const limit = Math.min(parseOptionalInt(c.req.query("limit")) ?? 50, 500);
 
+		// Same agent-scope isolation as GET /api/memory/:id: a chain is
+		// only readable by agents permitted to read its members.
+		const sessionKeyRaw = c.req.header("x-signet-session-key");
+		const agentId = resolveAgentId({
+			agentId: c.req.query("agentId") ?? c.req.query("agent_id") ?? c.req.header("x-signet-agent-id"),
+			sessionKey: sessionKeyRaw,
+		});
+		const agentScope = getAgentScope(agentId);
+		const access = buildAgentScopeClause(agentId, agentScope.readPolicy, agentScope.policyGroup);
+
 		type LineageRow = {
 			id: string;
 			content: string;
@@ -1974,16 +1999,19 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			superseded_reason: string | null;
 		};
 		const selectLineage = (
-			db: { prepare(sql: string): { get(...args: string[]): unknown } },
+			db: { prepare(sql: string): { get(...args: unknown[]): unknown } },
 			id: string,
 		): LineageRow | undefined =>
 			db
 				.prepare(
-					`SELECT id, content, type, importance, version, created_at, updated_at, superseded_by, superseded_at, superseded_reason
-					 FROM memories
-					 WHERE id = ?`,
+					`SELECT m.id, m.content, m.type, m.importance, m.version, m.created_at, m.updated_at,
+					        m.superseded_by, m.superseded_at, m.superseded_reason
+					 FROM memories m
+					 WHERE m.id = ?
+					   AND (m.is_deleted = 0 OR m.is_deleted IS NULL)
+					   ${access.sql}`,
 				)
-				.get(id) as LineageRow | undefined;
+				.get(id, ...access.args) as LineageRow | undefined;
 
 		const rows = getDbAccessor().withReadDb((db) => {
 			const head = selectLineage(db, memoryId);

--- a/platform/daemon/src/routes/ontology-routes.ts
+++ b/platform/daemon/src/routes/ontology-routes.ts
@@ -3,6 +3,7 @@ import { requirePermission } from "../auth";
 import { getDbAccessor } from "../db-accessor";
 import { listEntityAliases } from "../knowledge-graph";
 import { getInferenceProviderOrNull } from "../llm";
+import { graphWriteCaps, loadMemoryConfig } from "../memory-config";
 import {
 	OntologyAssertionError,
 	archiveEpistemicAssertion,
@@ -41,7 +42,7 @@ import {
 	proposeDuplicateEntityMerges,
 	rejectOntologyProposal,
 } from "../ontology-proposals";
-import { authConfig } from "./state";
+import { AGENTS_DIR, authConfig } from "./state";
 import { parseBoundedInt, resolveScopedAgentId } from "./utils";
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -604,6 +605,7 @@ export function registerOntologyRoutes(app: Hono): void {
 				applyOntologyOperation(getDbAccessor(), {
 					agentId: scoped.agentId,
 					actor: readString(body, "actor") ?? c.req.header("x-signet-actor") ?? "operator",
+					writeCaps: graphWriteCaps(loadMemoryConfig(AGENTS_DIR)),
 					operation,
 					payload,
 					reason: readString(body, "reason") ?? readString(body, "rationale"),
@@ -635,6 +637,7 @@ export function registerOntologyRoutes(app: Hono): void {
 				applyOntologyOperationBatch(getDbAccessor(), {
 					agentId: scoped.agentId,
 					actor,
+					writeCaps: graphWriteCaps(loadMemoryConfig(AGENTS_DIR)),
 					dryRun: readBoolean(body, "dry_run") ?? false,
 					propose: readBoolean(body, "propose") ?? false,
 					operations: operations.map((raw) => {
@@ -752,6 +755,7 @@ export function registerOntologyRoutes(app: Hono): void {
 					agentId: scoped.agentId,
 					id: c.req.param("id"),
 					actor: readString(body, "actor") ?? c.req.header("x-signet-actor") ?? "operator",
+					writeCaps: graphWriteCaps(loadMemoryConfig(AGENTS_DIR)),
 				}),
 			);
 		} catch (err) {

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -7,7 +7,7 @@ import { requirePermission, requireRateLimit } from "../auth";
 import { getDbAccessor } from "../db-accessor.js";
 import { type QueueCounts, getQueueDiagnosticsSnapshot } from "../diagnostics-queue.js";
 import { getLlmProvider } from "../llm.js";
-import { loadMemoryConfig } from "../memory-config.js";
+import { graphWriteCaps, loadMemoryConfig } from "../memory-config.js";
 import {
 	getDreamingAttention,
 	getDreamingEpisodicTokenBacklog,
@@ -665,6 +665,7 @@ export function registerPipelineRoutes(app: Hono): void {
 			accessor: getDbAccessor(),
 			agentId,
 			actor,
+			writeCaps: graphWriteCaps(loadMemoryConfig(AGENTS_DIR)),
 			operations: operations.map((rawOperation) => {
 				const operation = asRecord(rawOperation);
 				return {

--- a/platform/daemon/src/transactions.ts
+++ b/platform/daemon/src/transactions.ts
@@ -173,7 +173,8 @@ export type SupersedeMemoryTxStatus =
 	| "target_deleted"
 	| "self_supersede"
 	| "scope_mismatch"
-	| "already_superseded";
+	| "already_superseded"
+	| "already_superseded_by_other";
 
 export interface SupersedeMemoryTxResult {
 	status: SupersedeMemoryTxStatus;
@@ -713,6 +714,19 @@ export function txSupersedeMemory(db: WriteDb, input: SupersedeMemoryTxInput): S
 			status: "already_superseded",
 			memoryId: input.memoryId,
 			supersededBy: input.supersededBy,
+			currentVersion: existing.version,
+			currentSupersededBy: existing.superseded_by,
+		};
+	}
+	// #1147 review (finding 5): a memory already superseded by a DIFFERENT
+	// successor must not be re-superseded — overwriting the link forks the
+	// chain into two live heads (the previous successor keeps superseded_by
+	// NULL). Reject instead of corrupting lineage.
+	if (existing.superseded_by !== null && existing.superseded_by !== input.supersededBy) {
+		return {
+			status: "already_superseded_by_other",
+			memoryId: input.memoryId,
+			supersededBy: existing.superseded_by,
 			currentVersion: existing.version,
 			currentSupersededBy: existing.superseded_by,
 		};

--- a/surfaces/cli/src/commands/memory.ts
+++ b/surfaces/cli/src/commands/memory.ts
@@ -46,6 +46,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 		.option("--valid-from <iso>", "Start of validity window for this memory")
 		.option("--valid-until <iso>", "End of validity window for this memory")
 		.option("--review-after <iso>", "ISO timestamp when this temporal claim becomes due for review (issue #945)")
+		.option("--supersedes <id>", "Id of the memory this write supersedes (wires vN -> vN+1 lineage)")
 		.option("--private", "Set visibility to private", false)
 		.action(async (content: string, options) => {
 			if (!(await deps.ensureDaemonForSecrets())) return;
@@ -67,6 +68,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 					validFrom: options.validFrom,
 					validUntil: options.validUntil,
 					reviewAfter: options.reviewAfter,
+					supersedes: options.supersedes,
 					visibility: options.private ? "private" : undefined,
 				}),
 			);

--- a/surfaces/cli/src/commands/ontology.ts
+++ b/surfaces/cli/src/commands/ontology.ts
@@ -1567,6 +1567,24 @@ export function registerOntologyCommands(program: Command, deps: OntologyDeps): 
 		);
 		printOperationResult(data, options, "aspect archive");
 	});
+	addOperationOptions(
+		aspect
+			.command("merge")
+			.description("Fold source aspects into a target aspect (attributes move, sources archive)")
+			.argument("<entity>", "Entity selector")
+			.argument("<target>", "Target aspect selector")
+			.argument("<source...>", "Source aspect selectors")
+			.option("--new-name <name>", "Rename the merged aspect"),
+	).action(async (entityName: string, target: string, source: readonly string[], options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const data = await postOperation(
+			deps,
+			"merge_aspects",
+			{ entity: entityName, target, sources: source, new_name: options["new-name"] },
+			options,
+		);
+		printOperationResult(data, options, "aspect merge");
+	});
 
 	const link = ontology.command("link").description("Apply audited link operations");
 	addOperationOptions(


### PR DESCRIPTION
## Problem

The knowledge graph grows unbounded on the write path. There is no maximum on aspects per entity or attributes per aspect — the only caps in the code are read-side. Live graph: one entity has 223 aspects, one aspect has 1,197 attributes. Content passes append with `add_claim_value` and never consolidate, so state snapshots stack.

## Change

### 1. Write-path caps (enforced on the apply layer)

- `applyAddClaimValue` / `applySetClaimValue` count active attributes on the target aspect before inserting; over-cap ops are rejected with a teaching error that names the remedy
- `applyCreateAspect` / `add_claim_value`-with-new-aspect count active aspects on the target entity; over-cap rejected with the same remedy pattern
- Caps: max **20 aspects per entity**, max **50 attributes per aspect** (defaults; configurable via agent.yaml `traversal` + dashboard)
- Read caps aligned to 20/50 so the agent can see everything it must consolidate
- Exact-value dedup and idempotent aspect re-resolve do not consume cap budget
- Threaded through the scheduled dreaming seam, HTTP dream seam, and CLI/MCP/API ontology routes from config

### 2. merge_aspects consolidation op (new)

- `merge_aspects` folds source aspects into a target: every attribute row (active, superseded, deleted) moves so version history stays together, sources archive with audit provenance
- **A merged aspect may exceed the attribute cap by design** — consolidation is the remedy the cap forces, so it is never blocked by it
- Original proposal attribution on moved rows is preserved (claim-evidence drill-down still resolves)
- Hygiene op on the dreaming seam (requires attention provenance); CLI: `signet ontology aspect merge <entity> <target> <source...>`

### 3. Hygiene over-cap detector (new)

- Aspects with active attributes > cap flag as `attribute_over_cap` (highest priority); entities with active aspects > cap flag as `aspect_over_cap`
- Caps thread from config through the dreaming worker into the detector; over-cap flags outrank every other hygiene candidate
- Agent prompt teaches the consolidation remedies for these flags

### 4. Supersession provenance on remember surfaces (new)

- `supersedes` exposed on `signet remember` (CLI), MCP `memory_store`, and `POST /api/memory/remember`; `reviewAfter` already threaded via #1131
- Atomic lineage: the new memory is inserted and the target marked `superseded_by` in the same transaction; a missing/cross-scope/differently-superseded target fails the whole write (no orphans, no chain forks)
- `GET /api/memory/:id/lineage`: resolves the full chain from any row (bidirectional walk), oldest-first, agent-scope isolated, excludes deleted rows

## Readiness checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Tests

18 new regression tests across ontology, dreaming hygiene, and memory routes:
- write-gate caps: attribute/aspect rejection with teaching errors, backward compat, idempotent resolve, dedup-before-cap
- cap bypasses (adversarial review): add_claim_value new-aspect, set_claim_value new-key, archived-name reactivation
- merge_aspects: move+archive+rename, cap exemption, dreaming hygiene seam, provenance required
- over-cap detector: flags both kinds with counts, skips under-cap, caps-absent compat, attention enqueue
- remember supersedes: atomic lineage, missing-target rollback, chunked rejection, no-chain-fork, bidirectional lineage from any row

Fixes #1138
