### PR TITLE
fix(daemon): surface daemon deaths with lifecycle record, exit-path logs, and concurrency load test (#1148)

### DIFF
--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -33,6 +33,33 @@ signet status          # Check status
 Top-level aliases `signet start`, `signet stop`, and `signet restart`
 still exist, but `signet daemon ...` is the preferred command surface.
 
+### Death evidence and the lifecycle record
+
+The daemon writes its state to `<workspace>/.daemon/lifecycle.json`: `starting`
+at boot, `running` once the HTTP server is ready, and a terminal `clean` or
+`error` record (with exit path, exit code, and timestamp) on every catchable
+exit — SIGTERM/SIGINT shutdowns and fatal errors. The record is written
+synchronously and atomically, and the daemon flushes its log buffer before
+exiting so the final log lines are never lost.
+
+A process that is killed with SIGKILL, OOM-killed, or hard-crashed cannot write
+a terminal record, so the file stays at `starting`/`running` — that stuck state
+is the signal. `signet status` and `signet doctor` read the record whenever the
+daemon is down and surface the distinction:
+
+- `Last daemon exit was clean` (info) — the daemon shut down normally.
+- `Daemon exited after an internal error` (error) — a fatal error with the
+  message, worth reporting upstream.
+- `Previous daemon exit was not recorded as clean` (warn) — killed or crashed.
+  The finding points at the daemon log tail and, on Linux systemd launches, the
+  transient unit's journald exit status (`journalctl --user -u
+  signet-daemon-<pid>`), which distinguishes signals, core dumps, and OOM.
+
+A concurrency load test for the bot-startup traffic profile (session-start
+hooks, secrets, recall, status, optional writes) ships at
+`scripts/load-test-daemon.ts`; run it against a live or scratch daemon with
+`bun scripts/load-test-daemon.ts --port <port> [--writes]`.
+
 ### Via System Service
 
 The daemon can be installed as a system service for auto-start on boot.

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1642,6 +1642,25 @@ function buildLifecycleRecord(state: DaemonLifecycle["state"], extra: Partial<Da
 	};
 }
 
+function flushAndExit(exitCode: number): void {
+	// The logger buffers file writes and flushes on a 1s timer; without an
+	// explicit flush the final log lines can be lost on exit.
+	logger.shutdown();
+	process.exit(exitCode);
+}
+
+function buildTerminalLifecycleRecord(reason: string, exitCode: number, error?: unknown): DaemonLifecycle {
+	return buildLifecycleRecord(error === undefined ? "clean" : "error", {
+		exitedAt: new Date().toISOString(),
+		exitCode,
+		reason,
+		...(error !== undefined ? { error: error instanceof Error ? error.message : String(error) } : {}),
+	});
+}
+
+/** Bounds the draining cleanup so a wedged shutdown can never zombie the daemon. */
+const SHUTDOWN_CLEANUP_DEADLINE_MS = 20_000;
+
 /**
  * Single exit path for every catchable termination (signals and fatal
  * errors). Logs the exit path, records it in the lifecycle file, flushes the
@@ -1649,31 +1668,44 @@ function buildLifecycleRecord(state: DaemonLifecycle["state"], extra: Partial<Da
  * SIGKILL cannot be caught — a kill leaves the lifecycle record stuck at
  * "starting"/"running", which `signet status`/`doctor` report as an
  * unrecorded death instead of silence (issue #1148).
+ *
+ * The terminal lifecycle record is written only after cleanup completes (or
+ * the hard deadline forces the exit): writing it earlier would leave a
+ * "clean" record on a process still alive while cleanup hangs.
+ *
+ * `runCleanup` is disabled only for the update handoff: the replacement
+ * daemon is already spawned and needs the port immediately, so the exit is
+ * recorded and flushed but skips the draining cleanup.
  */
-function requestShutdown(reason: string, exitCode: number, error?: unknown): void {
+function requestShutdown(reason: string, exitCode: number, error?: unknown, runCleanup = true): void {
 	if (shuttingDown) {
-		// A second signal while draining must not wedge the process; exit
-		// immediately so the operator is never stuck with a zombie.
-		process.exit(exitCode);
+		// A second signal while draining must not wedge the process; flush and
+		// exit immediately so the operator is never stuck with a zombie — and
+		// the final log lines still land.
+		flushAndExit(exitCode);
 	}
 	setShuttingDown(true);
 	logger.info("daemon", `Received ${reason}; shutting down`, { exitCode });
-	writeDaemonLifecycle(
-		AGENTS_DIR,
-		buildLifecycleRecord(error === undefined ? "clean" : "error", {
-			exitedAt: new Date().toISOString(),
-			exitCode,
+	if (!runCleanup) {
+		writeDaemonLifecycle(AGENTS_DIR, buildTerminalLifecycleRecord(reason, exitCode, error));
+		flushAndExit(exitCode);
+		return;
+	}
+	const cleanupDeadline = setTimeout(() => {
+		logger.warn("daemon", "Shutdown cleanup timed out; forcing exit", {
 			reason,
-			...(error !== undefined ? { error: error instanceof Error ? error.message : String(error) } : {}),
-		}),
-	);
+			exitCode,
+			deadlineMs: SHUTDOWN_CLEANUP_DEADLINE_MS,
+		});
+		writeDaemonLifecycle(AGENTS_DIR, buildTerminalLifecycleRecord(reason, exitCode, error));
+		flushAndExit(exitCode);
+	}, SHUTDOWN_CLEANUP_DEADLINE_MS);
 	cleanup()
 		.catch(() => {})
 		.finally(() => {
-			// The logger buffers file writes and flushes on a 1s timer; without
-			// an explicit flush the final log lines can be lost on exit.
-			logger.shutdown();
-			process.exit(exitCode);
+			clearTimeout(cleanupDeadline);
+			writeDaemonLifecycle(AGENTS_DIR, buildTerminalLifecycleRecord(reason, exitCode, error));
+			flushAndExit(exitCode);
 		});
 }
 
@@ -1948,7 +1980,7 @@ async function main() {
 		if (!daemonScript) {
 			logger.warn("daemon", "Cannot self-restart: process.argv[1] is empty, falling back to clean exit");
 			setTimeout(() => {
-				process.exit(0);
+				requestShutdown("update:no-self-restart", 0, undefined, false);
 			}, 500);
 			return;
 		}
@@ -1975,7 +2007,7 @@ async function main() {
 
 		logger.info("daemon", "Replacement daemon spawned, exiting current process");
 		setTimeout(() => {
-			process.exit(0);
+			requestShutdown("update:replacement-spawned", 0, undefined, false);
 		}, 500);
 	});
 	initFeatureFlags(AGENTS_DIR);
@@ -2177,6 +2209,6 @@ function isMainEntrypoint(): boolean {
 if (isMainEntrypoint()) {
 	main().catch((err) => {
 		logger.error("daemon", "Fatal error", err);
-		process.exit(1);
+		requestShutdown("error:startup", 1, err);
 	});
 }

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -54,6 +54,7 @@ import { writeFileIfChangedAsync } from "./file-sync";
 import { createSignetHttpServer } from "./http-server";
 import { syncAgentWorkspaces } from "./identity-sync";
 import { type InferenceStatusSummary, getOrCreateInferenceRouter } from "./inference-router.js";
+import { type DaemonLifecycle, writeDaemonLifecycle } from "./lifecycle";
 import { closeInferenceProviderResolver, initInferenceProviderResolver } from "./llm";
 import { logger } from "./logger";
 import { type ResolvedMemoryConfig, graphWriteCaps, loadMemoryConfig } from "./memory-config";
@@ -1628,19 +1629,65 @@ async function cleanup() {
 	}
 }
 
+let lifecycleStartedAt = "";
+
+function buildLifecycleRecord(state: DaemonLifecycle["state"], extra: Partial<DaemonLifecycle> = {}): DaemonLifecycle {
+	return {
+		state,
+		pid: process.pid,
+		version: CURRENT_VERSION,
+		startedAt: lifecycleStartedAt,
+		systemdUnit: process.env.SIGNET_DAEMON_UNIT || undefined,
+		...extra,
+	};
+}
+
+/**
+ * Single exit path for every catchable termination (signals and fatal
+ * errors). Logs the exit path, records it in the lifecycle file, flushes the
+ * logger buffer synchronously so the final lines actually land, then exits.
+ * SIGKILL cannot be caught — a kill leaves the lifecycle record stuck at
+ * "starting"/"running", which `signet status`/`doctor` report as an
+ * unrecorded death instead of silence (issue #1148).
+ */
+function requestShutdown(reason: string, exitCode: number, error?: unknown): void {
+	if (shuttingDown) {
+		// A second signal while draining must not wedge the process; exit
+		// immediately so the operator is never stuck with a zombie.
+		process.exit(exitCode);
+	}
+	setShuttingDown(true);
+	logger.info("daemon", `Received ${reason}; shutting down`, { exitCode });
+	writeDaemonLifecycle(
+		AGENTS_DIR,
+		buildLifecycleRecord(error === undefined ? "clean" : "error", {
+			exitedAt: new Date().toISOString(),
+			exitCode,
+			reason,
+			...(error !== undefined ? { error: error instanceof Error ? error.message : String(error) } : {}),
+		}),
+	);
+	cleanup()
+		.catch(() => {})
+		.finally(() => {
+			// The logger buffers file writes and flushes on a 1s timer; without
+			// an explicit flush the final log lines can be lost on exit.
+			logger.shutdown();
+			process.exit(exitCode);
+		});
+}
+
 process.on("SIGINT", () => {
-	cleanup().finally(() => process.exit(0));
+	requestShutdown("signal:SIGINT", 0);
 });
 
 process.on("SIGTERM", () => {
-	cleanup().finally(() => process.exit(0));
+	requestShutdown("signal:SIGTERM", 0);
 });
 
 process.on("uncaughtException", (err) => {
 	logger.error("daemon", "Uncaught exception", err);
-	if (shuttingDown) return;
-	setShuttingDown(true);
-	cleanup().finally(() => process.exit(1));
+	requestShutdown("error:uncaughtException", 1, err);
 });
 
 process.on("unhandledRejection", (reason) => {
@@ -1650,9 +1697,7 @@ process.on("unhandledRejection", (reason) => {
 		reason instanceof Error ? reason : undefined,
 		reason instanceof Error ? undefined : { reason: String(reason) },
 	);
-	if (shuttingDown) return;
-	setShuttingDown(true);
-	cleanup().finally(() => process.exit(1));
+	requestShutdown("error:unhandledRejection", 1, reason);
 });
 
 // ============================================================================
@@ -1683,6 +1728,9 @@ async function main() {
 			closeSync(lockFd);
 		} catch {}
 	});
+
+	lifecycleStartedAt = new Date().toISOString();
+	writeDaemonLifecycle(AGENTS_DIR, buildLifecycleRecord("starting"));
 
 	// Config migrations must precede every initialization path that resolves
 	// memory config, including DB setup below.
@@ -1968,6 +2016,7 @@ async function main() {
 		});
 		logger.info("daemon", "Daemon ready");
 		logFdSnapshot("server-ready");
+		writeDaemonLifecycle(AGENTS_DIR, buildLifecycleRecord("running"));
 
 		const healthStampPath = join(DAEMON_DIR, "last-healthy-start");
 		try {

--- a/platform/daemon/src/lifecycle.test.ts
+++ b/platform/daemon/src/lifecycle.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { lifecyclePath, readDaemonLifecycle, writeDaemonLifecycle } from "./lifecycle";
+
+// Regression tests for issue #1148: a daemon death must be distinguishable as
+// clean, error, or unrecorded (killed/crashed) from the durable lifecycle
+// record alone, because the process itself leaves no trace on SIGKILL.
+
+function tempRoot(): string {
+	return mkdtempSync(join(tmpdir(), "signet-lifecycle-"));
+}
+
+describe("daemon lifecycle record (#1148)", () => {
+	it("persists a clean shutdown record with the exit path and code", () => {
+		const root = tempRoot();
+		try {
+			writeDaemonLifecycle(root, {
+				state: "clean",
+				pid: 4242,
+				version: "0.165.0",
+				startedAt: "2026-08-07T00:00:00.000Z",
+				reason: "signal:SIGTERM",
+				exitCode: 0,
+				exitedAt: "2026-08-07T01:00:00.000Z",
+			});
+			const record = readDaemonLifecycle(root);
+			expect(record).not.toBeNull();
+			expect(record?.state).toBe("clean");
+			expect(record?.reason).toBe("signal:SIGTERM");
+			expect(record?.exitCode).toBe(0);
+			expect(record?.exitedAt).toBe("2026-08-07T01:00:00.000Z");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("leaves the record at running when the process dies without an exit path, which is how SIGKILL/OOM deaths surface", () => {
+		const root = tempRoot();
+		try {
+			// The daemon wrote "running" and then was killed: no terminal state
+			// is ever recorded. A status probe must be able to read exactly this
+			// and call it an unrecorded death, not a clean shutdown.
+			writeDaemonLifecycle(root, {
+				state: "running",
+				pid: 7,
+				version: "0.165.0",
+				startedAt: "2026-08-07T00:00:00.000Z",
+			});
+			const record = readDaemonLifecycle(root);
+			expect(record?.state).toBe("running");
+			expect(record?.exitedAt).toBeUndefined();
+			expect(record?.reason).toBeUndefined();
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("records an internal-error exit with the error message", () => {
+		const root = tempRoot();
+		try {
+			writeDaemonLifecycle(root, {
+				state: "error",
+				pid: 9,
+				version: "0.165.0",
+				startedAt: "2026-08-07T00:00:00.000Z",
+				reason: "error:uncaughtException",
+				exitCode: 1,
+				exitedAt: "2026-08-07T00:00:30.000Z",
+				error: "Cannot read properties of undefined (reading 'x')",
+			});
+			expect(readDaemonLifecycle(root)?.error).toContain("Cannot read properties");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("returns null for a missing record (pre-#1148 daemons) instead of throwing", () => {
+		const root = tempRoot();
+		try {
+			expect(readDaemonLifecycle(root)).toBeNull();
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("returns null for a corrupt record instead of throwing", () => {
+		const root = tempRoot();
+		try {
+			mkdirSync(join(root, ".daemon"), { recursive: true });
+			writeFileSync(join(root, ".daemon", "lifecycle.json"), "{not json");
+			expect(readDaemonLifecycle(root)).toBeNull();
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("replaces the previous record in place without leaving a temp file", () => {
+		const root = tempRoot();
+		try {
+			writeDaemonLifecycle(root, {
+				state: "starting",
+				pid: 1,
+				version: "0.165.0",
+				startedAt: "2026-08-07T00:00:00.000Z",
+			});
+			writeDaemonLifecycle(root, {
+				state: "running",
+				pid: 1,
+				version: "0.165.0",
+				startedAt: "2026-08-07T00:00:00.000Z",
+			});
+			expect(readDaemonLifecycle(root)?.state).toBe("running");
+			expect(lifecyclePath(root)).toContain(".daemon");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/platform/daemon/src/lifecycle.ts
+++ b/platform/daemon/src/lifecycle.ts
@@ -1,0 +1,65 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/**
+ * Daemon lifecycle record.
+ *
+ * The daemon writes its state to `.daemon/lifecycle.json` at startup and on
+ * every catchable exit path (signal handlers, fatal errors). The record is the
+ * one durable artifact that survives the process itself, so a later
+ * `signet status` / `signet doctor` can tell a clean shutdown apart from an
+ * external kill or a hard crash (issue #1148): a process that died without
+ * writing `clean` (SIGKILL, OOM, segfault) leaves the record stuck at
+ * `starting`/`running`, and the CLI reports an unrecorded death instead of a
+ * silent disappearance.
+ *
+ * The record is written synchronously and atomically (temp file + rename) so a
+ * concurrent reader never observes a partial write.
+ */
+
+export type DaemonLifecycleState = "starting" | "running" | "clean" | "error";
+
+export interface DaemonLifecycle {
+	readonly state: DaemonLifecycleState;
+	readonly pid: number;
+	readonly version: string;
+	readonly startedAt: string;
+	/** systemd transient unit name (Linux service-manager launch), when known. */
+	readonly systemdUnit?: string;
+	readonly exitedAt?: string;
+	readonly exitCode?: number;
+	/** Exit-path label: "signal:SIGTERM" | "signal:SIGINT" | "error:uncaughtException" | ... */
+	readonly reason?: string;
+	readonly error?: string;
+}
+
+export function lifecyclePath(agentsDir: string): string {
+	return join(agentsDir, ".daemon", "lifecycle.json");
+}
+
+/** Tolerant read: a missing or corrupt record returns null, never throws. */
+export function readDaemonLifecycle(agentsDir: string): DaemonLifecycle | null {
+	try {
+		const raw = readFileSync(lifecyclePath(agentsDir), "utf-8");
+		const parsed = JSON.parse(raw) as Partial<DaemonLifecycle>;
+		if (typeof parsed.state !== "string" || typeof parsed.pid !== "number") {
+			return null;
+		}
+		return parsed as DaemonLifecycle;
+	} catch {
+		return null;
+	}
+}
+
+/** Best-effort atomic write; recording must never take the daemon down. */
+export function writeDaemonLifecycle(agentsDir: string, record: DaemonLifecycle): void {
+	const path = lifecyclePath(agentsDir);
+	try {
+		mkdirSync(dirname(path), { recursive: true });
+		const tmpPath = `${path}.tmp`;
+		writeFileSync(tmpPath, JSON.stringify(record, null, 2));
+		renameSync(tmpPath, path);
+	} catch {
+		// Best effort.
+	}
+}

--- a/platform/daemon/src/logger.test.ts
+++ b/platform/daemon/src/logger.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { resolveLoggerConfig } from "./logger";
+import { Logger, resolveLoggerConfig } from "./logger";
 
 describe("logger config", () => {
 	it("uses SIGNET_PATH for the default daemon log directory", () => {
@@ -36,5 +38,32 @@ describe("logger config", () => {
 		expect(resolveLoggerConfig({}, "/home/test")).toEqual({
 			logDir: join("/home/test", ".agents", ".daemon", "logs"),
 		});
+	});
+});
+
+// Regression for issue #1148: the daemon exit path calls logger.shutdown()
+// before process.exit(); without that explicit flush, the final log lines
+// ("Received SIGTERM; shutting down") can sit in the 1s-flush buffer and be
+// lost on exit, which is exactly the "vanished with no shutdown log" symptom.
+describe("logger shutdown flush", () => {
+	it("writes buffered entries to the log file on shutdown", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-logger-"));
+		try {
+			const log = new Logger({
+				logDir: root,
+				consoleOutput: false,
+				jsonFormat: false,
+				level: "info",
+			});
+			log.info("daemon", "Received signal:SIGTERM; shutting down");
+			// No 1s timer flush has run yet (the test is sub-second); shutdown()
+			// must flush the buffer synchronously.
+			log.shutdown();
+			const today = new Date().toISOString().split("T")[0];
+			const content = readFileSync(join(root, `signet-${today}.log`), "utf-8");
+			expect(content).toContain("Received signal:SIGTERM; shutting down");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
 	});
 });

--- a/platform/daemon/src/logger.ts
+++ b/platform/daemon/src/logger.ts
@@ -153,7 +153,7 @@ export function resolveLoggerConfig(env: NodeJS.ProcessEnv = process.env, homeDi
 	};
 }
 
-class Logger extends EventEmitter {
+export class Logger extends EventEmitter {
 	private config: LoggerConfig;
 	private currentLogFile: string;
 	private buffer: LogEntry[] = [];

--- a/scripts/load-test-daemon.ts
+++ b/scripts/load-test-daemon.ts
@@ -1,0 +1,300 @@
+#!/usr/bin/env bun
+/**
+ * Daemon concurrency load test (issue #1148).
+ *
+ * Reproduces the load profile that preceded the silent daemon deaths:
+ * automation bots (Minecraft chat bridge, camera/motion sentinel) hammering
+ * the daemon API — session-start hooks, secrets listing, session capture,
+ * recall — while the Obsidian watcher indexes in the background. The invariant
+ * under test: concurrent session-start + secrets + status traffic must NOT be
+ * able to take the daemon down, and if it does, the daemon must leave evidence
+ * (lifecycle record, log tail) instead of vanishing silently.
+ *
+ * Usage:
+ *   bun scripts/load-test-daemon.ts [--duration 20] [--concurrency 8]
+ *       [--port 3850] [--writes] [--token <bearer>]
+ *
+ * Against the live daemon (default) or a scratch one:
+ *   SIGNET_PATH=/tmp/signet-loadtest bun platform/daemon/src/daemon.ts &  # scratch daemon
+ *   bun scripts/load-test-daemon.ts --port 3850
+ *
+ * Exit code 0 = daemon stayed healthy through the run (p95 < 2s), 1 = failure.
+ */
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+interface Route {
+	readonly method: "GET" | "POST";
+	readonly path: string;
+	readonly weight: number;
+	readonly body?: () => Record<string, unknown>;
+}
+
+const SESSION_KEY_PREFIX = `loadtest-${process.pid}-`;
+let sessionCounter = 0;
+
+function nextSessionKey(): string {
+	sessionCounter += 1;
+	return `${SESSION_KEY_PREFIX}${sessionCounter}`;
+}
+
+const READ_ROUTES: readonly Route[] = [
+	{ method: "GET", path: "/api/status", weight: 4 },
+	{ method: "GET", path: "/api/secrets", weight: 1 },
+	{ method: "GET", path: "/api/sessions", weight: 1 },
+	{
+		method: "POST",
+		path: "/api/hooks/session-start",
+		weight: 3,
+		body: () => ({
+			harness: "loadtest",
+			sessionKey: nextSessionKey(),
+			agentId: "default",
+			project: "/tmp/signet-loadtest",
+		}),
+	},
+	{
+		method: "POST",
+		path: "/api/hooks/session-end",
+		weight: 1,
+		body: () => ({ harness: "loadtest", sessionKey: nextSessionKey(), agentId: "default" }),
+	},
+	{
+		method: "POST",
+		path: "/api/hooks/recall",
+		weight: 1,
+		body: () => ({ query: "daemon load test concurrency", limit: 3 }),
+	},
+];
+
+const WRITE_ROUTES: readonly Route[] = [
+	{
+		method: "POST",
+		path: "/api/memory/remember",
+		weight: 1,
+		body: () => ({ content: `load test memory ${Date.now()}`, agentId: "default" }),
+	},
+];
+
+interface ParsedArgs {
+	readonly durationSec: number;
+	readonly concurrency: number;
+	readonly port: number;
+	readonly writes: boolean;
+	readonly token: string | null;
+	readonly agentsDir: string;
+}
+
+function parseArgs(raw: string[]): ParsedArgs {
+	let durationSec = 20;
+	let concurrency = 8;
+	let port = 3850;
+	let writes = false;
+	let token: string | null = process.env.SIGNET_API_KEY?.trim() || null;
+	let agentsDir = process.env.SIGNET_PATH?.trim() || join(homedir(), ".agents");
+
+	for (let i = 0; i < raw.length; i += 1) {
+		const arg = raw[i];
+		const next = (): string => {
+			i += 1;
+			return raw[i];
+		};
+		if (arg === "--duration") durationSec = Number.parseInt(next(), 10);
+		else if (arg === "--concurrency") concurrency = Number.parseInt(next(), 10);
+		else if (arg === "--port") port = Number.parseInt(next(), 10);
+		else if (arg === "--token") token = next() || null;
+		else if (arg === "--writes") writes = true;
+		else if (arg === "--agents-dir") agentsDir = next();
+		else if (arg === "--help") {
+			console.log(
+				"Usage: bun scripts/load-test-daemon.ts [--duration 20] [--concurrency 8] [--port 3850] [--writes] [--token <bearer>]",
+			);
+			process.exit(0);
+		}
+	}
+
+	return { durationSec, concurrency, port, writes, token, agentsDir };
+}
+
+function buildRouteTable(writes: boolean): readonly Route[] {
+	return writes ? [...READ_ROUTES, ...WRITE_ROUTES] : READ_ROUTES;
+}
+
+function weightedRoute(routes: readonly Route[]): Route {
+	const total = routes.reduce((sum, route) => sum + route.weight, 0);
+	let roll = Math.random() * total;
+	for (const route of routes) {
+		roll -= route.weight;
+		if (roll <= 0) return route;
+	}
+	return routes[routes.length - 1];
+}
+
+interface RunStats {
+	requests: number;
+	failures: number;
+	latenciesMs: number[];
+	statusCounts: Map<number, number>;
+}
+
+interface DeathEvent {
+	readonly detectedAt: string;
+	readonly recoveredAt: string | null;
+	readonly downForMs: number;
+}
+
+function percentile(sorted: readonly number[], p: number): number {
+	if (sorted.length === 0) return 0;
+	const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+	return sorted[Math.max(0, idx)];
+}
+
+async function main(): Promise<void> {
+	const args = parseArgs(process.argv.slice(2));
+	const baseUrl = `http://127.0.0.1:${args.port}`;
+	const routes = buildRouteTable(args.writes);
+
+	const headers: Record<string, string> = { "content-type": "application/json" };
+	if (args.token) headers.authorization = `Bearer ${args.token}`;
+
+	// Pre-flight: the daemon must be reachable before we start piling on load.
+	const preflight = await fetch(`${baseUrl}/api/status`, { headers, signal: AbortSignal.timeout(5_000) });
+	if (!preflight.ok) {
+		console.error(`Daemon not reachable at ${baseUrl} (HTTP ${preflight.status}). Start it first.`);
+		process.exit(1);
+	}
+
+	const stats: RunStats = { requests: 0, failures: 0, latenciesMs: [], statusCounts: new Map() };
+	const deaths: DeathEvent[] = [];
+	let daemonDownSince: number | null = null;
+	let lastHealthOk = true;
+	let finished = false;
+
+	// Watchdog: independent of the workers, probes health every 250ms and
+	// records any window where the daemon stopped answering.
+	async function watchdog(): Promise<void> {
+		while (!finished) {
+			try {
+				const res = await fetch(`${baseUrl}/api/status`, { headers, signal: AbortSignal.timeout(2_000) });
+				if (res.ok) {
+					if (daemonDownSince !== null) {
+						const downForMs = Date.now() - daemonDownSince;
+						deaths.push({
+							detectedAt: new Date(daemonDownSince).toISOString(),
+							recoveredAt: new Date().toISOString(),
+							downForMs,
+						});
+						daemonDownSince = null;
+					}
+					lastHealthOk = true;
+				} else if (daemonDownSince === null) {
+					daemonDownSince = Date.now();
+					lastHealthOk = false;
+				}
+			} catch {
+				if (daemonDownSince === null) {
+					daemonDownSince = Date.now();
+					lastHealthOk = false;
+				}
+			}
+			await new Promise((resolve) => setTimeout(resolve, 250));
+		}
+	}
+
+	// Worker: fire one weighted request, record latency/status.
+	async function worker(): Promise<void> {
+		while (!finished) {
+			const route = weightedRoute(routes);
+			const started = performance.now();
+			try {
+				const res = await fetch(`${baseUrl}${route.path}`, {
+					method: route.method,
+					headers,
+					...(route.body ? { body: JSON.stringify(route.body()) } : {}),
+					signal: AbortSignal.timeout(10_000),
+				});
+				const elapsedMs = performance.now() - started;
+				stats.latenciesMs.push(elapsedMs);
+				stats.statusCounts.set(res.status, (stats.statusCounts.get(res.status) ?? 0) + 1);
+			} catch {
+				stats.failures += 1;
+			}
+			stats.requests += 1;
+		}
+	}
+
+	const watchdogPromise = watchdog();
+	const workers = Array.from({ length: args.concurrency }, () => worker());
+	await new Promise((resolve) => setTimeout(resolve, args.durationSec * 1000));
+	finished = true;
+	await Promise.all([...workers, watchdogPromise]);
+
+	// Final health check: the daemon must be answering after the run.
+	let finalHealthy = false;
+	try {
+		const res = await fetch(`${baseUrl}/api/status`, { headers, signal: AbortSignal.timeout(5_000) });
+		finalHealthy = res.ok;
+	} catch {
+		finalHealthy = false;
+	}
+
+	// An unrecovered death (daemon stayed down until the end of the run) must
+	// still surface as a death event.
+	if (daemonDownSince !== null) {
+		deaths.push({
+			detectedAt: new Date(daemonDownSince).toISOString(),
+			recoveredAt: null,
+			downForMs: Date.now() - daemonDownSince,
+		});
+	}
+
+	// Post-mortem evidence: the lifecycle record, when present.
+	let lifecycle: unknown = null;
+	try {
+		const raw = readFileSync(join(args.agentsDir, ".daemon", "lifecycle.json"), "utf-8");
+		lifecycle = JSON.parse(raw);
+	} catch {
+		lifecycle = null;
+	}
+
+	const sorted = [...stats.latenciesMs].sort((a, b) => a - b);
+	const report = {
+		verdict: finalHealthy && deaths.length === 0 ? "pass" : "fail",
+		baseUrl,
+		durationSec: args.durationSec,
+		concurrency: args.concurrency,
+		requests: stats.requests,
+		requestFailures: stats.failures,
+		statusCounts: Object.fromEntries(stats.statusCounts),
+		latencyMs: {
+			p50: Math.round(percentile(sorted, 50)),
+			p95: Math.round(percentile(sorted, 95)),
+			p99: Math.round(percentile(sorted, 99)),
+		},
+		deaths: deaths.map((d) => ({ ...d })),
+		finalHealthy,
+		lifecycle,
+	};
+	console.log(JSON.stringify(report, null, 2));
+
+	if (!finalHealthy || deaths.length > 0) {
+		console.error(
+			"\nFAIL: the daemon did not survive the load (or died without recording it). Check the lifecycle record above, the daemon log tail, and journalctl --user -u 'signet-daemon-*'.",
+		);
+		process.exit(1);
+	}
+	if (stats.failures > stats.requests * 0.05) {
+		console.error(
+			`\nFAIL: ${stats.failures} request failures out of ${stats.requests} (${((stats.failures / stats.requests) * 100).toFixed(1)}%).`,
+		);
+		process.exit(1);
+	}
+	process.exit(0);
+}
+
+main().catch((err) => {
+	console.error("load test crashed:", err);
+	process.exit(1);
+});

--- a/scripts/load-test-daemon.ts
+++ b/scripts/load-test-daemon.ts
@@ -34,6 +34,9 @@ interface Route {
 
 const SESSION_KEY_PREFIX = `loadtest-${process.pid}-`;
 let sessionCounter = 0;
+// session-end must reference a session that session-start actually created,
+// otherwise every end is a 400 and the real path never runs.
+const startedSessionKeys: string[] = [];
 
 function nextSessionKey(): string {
 	sessionCounter += 1;
@@ -48,18 +51,21 @@ const READ_ROUTES: readonly Route[] = [
 		method: "POST",
 		path: "/api/hooks/session-start",
 		weight: 3,
-		body: () => ({
-			harness: "loadtest",
-			sessionKey: nextSessionKey(),
-			agentId: "default",
-			project: "/tmp/signet-loadtest",
-		}),
+		body: () => {
+			const sessionKey = nextSessionKey();
+			startedSessionKeys.push(sessionKey);
+			return { harness: "loadtest", sessionKey, agentId: "default", project: "/tmp/signet-loadtest" };
+		},
 	},
 	{
 		method: "POST",
 		path: "/api/hooks/session-end",
 		weight: 1,
-		body: () => ({ harness: "loadtest", sessionKey: nextSessionKey(), agentId: "default" }),
+		body: () => ({
+			harness: "loadtest",
+			sessionKey: startedSessionKeys.shift() ?? nextSessionKey(),
+			agentId: "default",
+		}),
 	},
 	{
 		method: "POST",

--- a/surfaces/cli/src/features/health.test.ts
+++ b/surfaces/cli/src/features/health.test.ts
@@ -1093,6 +1093,105 @@ async function captureDoctorJson(
 	};
 }
 
+describe("daemon lifecycle exit findings (#1148)", () => {
+	function lifecycleDeps(root: string, lastExit: unknown) {
+		return {
+			...depsFor(root),
+			getDaemonStatus: async () => ({
+				running: false,
+				pid: null,
+				uptime: null,
+				version: null,
+				host: null,
+				bindHost: null,
+				networkMode: null,
+				probe: {
+					status: "absent",
+					detail: "No Signet daemon process or healthy listener was found",
+					url: "http://127.0.0.1:3850",
+					listenerPresent: false,
+					processPid: null,
+					stalePid: null,
+					lastExit,
+				},
+			}),
+		};
+	}
+
+	it("doctor flags an unrecorded daemon death (SIGKILL/crash) with a pointer to the evidence", async () => {
+		const root = mkdtempSync(join(tmpdir(), "doctor-lifecycle-"));
+		try {
+			const jsonOut = await captureDoctorJson(
+				lifecycleDeps(root, {
+					state: "running",
+					pid: 4242,
+					version: "0.165.0",
+					startedAt: "2026-08-07T00:00:00.000Z",
+					systemdUnit: "signet-daemon-1234",
+				}).getDaemonStatus,
+			);
+			const finding = jsonOut.findings.find((f) => f.code === "daemon_exit_unrecorded");
+			expect(finding).toBeDefined();
+			expect(finding?.level).toBe("warn");
+			expect(finding?.message).toContain("killed or crashed");
+			expect(finding?.message).toContain("pid 4242");
+			expect(finding?.message).toContain("No shutdown marker was written");
+			expect(finding?.fix).toContain("journalctl --user -u signet-daemon-1234");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("doctor reports a clean last exit as info, not an error", async () => {
+		const root = mkdtempSync(join(tmpdir(), "doctor-lifecycle-"));
+		try {
+			const jsonOut = await captureDoctorJson(
+				lifecycleDeps(root, {
+					state: "clean",
+					pid: 7,
+					version: "0.165.0",
+					startedAt: "2026-08-07T00:00:00.000Z",
+					reason: "signal:SIGTERM",
+					exitCode: 0,
+					exitedAt: "2026-08-07T01:00:00.000Z",
+				}).getDaemonStatus,
+			);
+			const finding = jsonOut.findings.find((f) => f.code === "daemon_exit_clean");
+			expect(finding).toBeDefined();
+			expect(finding?.level).toBe("info");
+			expect(finding?.message).toContain("signal:SIGTERM");
+			expect(finding?.message).toContain("exit code 0");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("doctor reports an internal-error exit with the error message and fails", async () => {
+		const root = mkdtempSync(join(tmpdir(), "doctor-lifecycle-"));
+		try {
+			const jsonOut = await captureDoctorJson(
+				lifecycleDeps(root, {
+					state: "error",
+					pid: 8,
+					version: "0.165.0",
+					startedAt: "2026-08-07T00:00:00.000Z",
+					reason: "error:uncaughtException",
+					exitCode: 1,
+					exitedAt: "2026-08-07T00:00:30.000Z",
+					error: "boom",
+				}).getDaemonStatus,
+			);
+			expect(jsonOut.ok).toBe(false);
+			const finding = jsonOut.findings.find((f) => f.code === "daemon_exit_error");
+			expect(finding).toBeDefined();
+			expect(finding?.level).toBe("error");
+			expect(finding?.message).toContain("boom");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
+
 describe("doctor unknown target", () => {
 	it("sets a non-zero exit code for an unsupported doctor target", async () => {
 		const lines: string[] = [];

--- a/surfaces/cli/src/features/health.test.ts
+++ b/surfaces/cli/src/features/health.test.ts
@@ -1142,6 +1142,27 @@ describe("daemon lifecycle exit findings (#1148)", () => {
 		}
 	});
 
+	it("does not report an unrecorded death while the recorded pid is alive (custom port / still booting)", async () => {
+		const root = mkdtempSync(join(tmpdir(), "doctor-lifecycle-"));
+		try {
+			// The daemon on a custom SIGNET_PORT is invisible to the fixed-port
+			// probe, but the lifecycle record's pid is live — the finding must
+			// not claim "killed or crashed" against a running process.
+			const jsonOut = await captureDoctorJson(
+				lifecycleDeps(root, {
+					state: "running",
+					pid: process.pid,
+					version: "0.165.0",
+					startedAt: "2026-08-07T00:00:00.000Z",
+				}).getDaemonStatus,
+			);
+			const finding = jsonOut.findings.find((f) => f.code === "daemon_exit_unrecorded");
+			expect(finding).toBeUndefined();
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("doctor reports a clean last exit as info, not an error", async () => {
 		const root = mkdtempSync(join(tmpdir(), "doctor-lifecycle-"));
 		try {

--- a/surfaces/cli/src/features/health.ts
+++ b/surfaces/cli/src/features/health.ts
@@ -676,6 +676,12 @@ function addDaemonLifecycleExitFindings(probe: NonNullable<DaemonStatus["probe"]
 		return;
 	}
 
+	// The record says the daemon was starting/running but never wrote a
+	// terminal state. That only means death if the recorded process is
+	// actually gone: a daemon on a custom port or still binding at boot would
+	// otherwise be misreported as "killed or crashed" against a live process.
+	if (isProcessAlive(lastExit.pid)) return;
+
 	findings.push({
 		level: "warn",
 		code: "daemon_exit_unrecorded",
@@ -684,6 +690,15 @@ function addDaemonLifecycleExitFindings(probe: NonNullable<DaemonStatus["probe"]
 			? `Check the daemon log tail (~/.agents/.daemon/logs/signet-<date>.log) and the unit exit status: journalctl --user -u ${lastExit.systemdUnit}`
 			: "Check the daemon log tail (~/.agents/.daemon/logs/signet-<date>.log) for where it stopped, and dmesg/journalctl for OOM kills or signals.",
 	});
+}
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 function addOpenClawRuntimeFindings(report: StatusReport, findings: DoctorFinding[]): void {

--- a/surfaces/cli/src/features/health.ts
+++ b/surfaces/cli/src/features/health.ts
@@ -12,7 +12,7 @@ import {
 } from "@signet/core";
 import chalk from "chalk";
 import { daemonAccessLines } from "../lib/network.js";
-import type { DaemonResourceUsage } from "../lib/runtime.js";
+import type { DaemonLastExit, DaemonResourceUsage } from "../lib/runtime.js";
 import { getGitRemoteState, getSnapshotProtection, hasOpenClawWorkspaceLink } from "../lib/workspace-protection.js";
 import Database from "../sqlite.js";
 import { getDaemonBaseUrl } from "./repair-queue.js";
@@ -89,6 +89,7 @@ interface DaemonStatus {
 		readonly processPid: number | null;
 		readonly stalePid: number | null;
 		readonly readinessReasons?: readonly string[];
+		readonly lastExit?: DaemonLastExit | null;
 	};
 	readonly openclaw?: {
 		readonly status: "connected" | "stale" | "never-seen";
@@ -641,6 +642,48 @@ function addDaemonProbeFindings(report: StatusReport, findings: DoctorFinding[])
 			fix: "Run `signet daemon start`; stale pid files are ignored by current status probes.",
 		});
 	}
+
+	addDaemonLifecycleExitFindings(probe, findings);
+}
+
+/**
+ * Surface the daemon's own last-exit record when it is down. A record stuck at
+ * "starting"/"running" means the process died without writing a shutdown
+ * marker — SIGKILL, OOM, or a hard crash — which is exactly the silent-death
+ * class of issue #1148. The fix pointer routes the operator to the evidence:
+ * the daemon log tail and the systemd transient unit's journald exit status.
+ */
+function addDaemonLifecycleExitFindings(probe: NonNullable<DaemonStatus["probe"]>, findings: DoctorFinding[]): void {
+	const lastExit = probe.lastExit;
+	if (!lastExit) return;
+
+	if (lastExit.state === "clean") {
+		findings.push({
+			level: "info",
+			code: "daemon_exit_clean",
+			message: `Last daemon exit was clean (${lastExit.reason ?? "shutdown"}, exit code ${lastExit.exitCode ?? 0}) at ${lastExit.exitedAt ?? "unknown"}.`,
+		});
+		return;
+	}
+
+	if (lastExit.state === "error") {
+		findings.push({
+			level: "error",
+			code: "daemon_exit_error",
+			message: `Daemon exited after an internal error: ${lastExit.error ?? lastExit.reason ?? "unknown"}.`,
+			fix: "Inspect the daemon log tail for the fatal error, then run `signet daemon start`.",
+		});
+		return;
+	}
+
+	findings.push({
+		level: "warn",
+		code: "daemon_exit_unrecorded",
+		message: `Previous daemon exit was not recorded as clean: the process was killed or crashed (pid ${lastExit.pid}, last marked ${lastExit.state} at ${lastExit.startedAt}). No shutdown marker was written.`,
+		fix: lastExit.systemdUnit
+			? `Check the daemon log tail (~/.agents/.daemon/logs/signet-<date>.log) and the unit exit status: journalctl --user -u ${lastExit.systemdUnit}`
+			: "Check the daemon log tail (~/.agents/.daemon/logs/signet-<date>.log) for where it stopped, and dmesg/journalctl for OOM kills or signals.",
+	});
 }
 
 function addOpenClawRuntimeFindings(report: StatusReport, findings: DoctorFinding[]): void {

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -32,6 +32,37 @@ export interface DaemonHealthProbe {
 	readonly stalePid: number | null;
 	/** Present only when /health/ready reported not_ready; absent when readiness is unknown (older daemon). */
 	readonly readinessReasons?: readonly string[];
+	/**
+	 * The daemon's own last-exit record (`.daemon/lifecycle.json`), when one
+	 * exists. A record stuck at "starting"/"running" while no daemon process
+	 * is alive means the death was not recorded — an external kill or hard
+	 * crash (issue #1148).
+	 */
+	readonly lastExit?: DaemonLastExit | null;
+}
+
+export interface DaemonLastExit {
+	readonly state: "starting" | "running" | "clean" | "error";
+	readonly pid: number;
+	readonly version: string;
+	readonly startedAt: string;
+	readonly systemdUnit?: string;
+	readonly exitedAt?: string;
+	readonly exitCode?: number;
+	readonly reason?: string;
+	readonly error?: string;
+}
+
+/** Tolerant read of the daemon lifecycle record; null when absent or corrupt. */
+export function readDaemonLifecycleRecord(agentsDir: string): DaemonLastExit | null {
+	try {
+		const raw = readFileSync(join(agentsDir, ".daemon", "lifecycle.json"), "utf-8");
+		const parsed = JSON.parse(raw) as Partial<DaemonLastExit>;
+		if (typeof parsed.state !== "string" || typeof parsed.pid !== "number") return null;
+		return parsed as DaemonLastExit;
+	} catch {
+		return null;
+	}
 }
 
 export interface DaemonOpenClawHealthSummary {
@@ -312,6 +343,7 @@ async function buildUnreachableDaemonProbe(agentsDir: string): Promise<DaemonHea
 	const processPid = managedPid ?? findMarkedDaemonProcessPids()[0] ?? null;
 	const listenerPresent = await canConnect("127.0.0.1", DEFAULT_PORT);
 	const url = `http://127.0.0.1:${DEFAULT_PORT}`;
+	const lastExit = readDaemonLifecycleRecord(agentsDir);
 
 	if (listenerPresent) {
 		return {
@@ -321,6 +353,7 @@ async function buildUnreachableDaemonProbe(agentsDir: string): Promise<DaemonHea
 			listenerPresent,
 			processPid,
 			stalePid: artifact.stale ? artifact.pid : null,
+			lastExit,
 		};
 	}
 
@@ -332,6 +365,7 @@ async function buildUnreachableDaemonProbe(agentsDir: string): Promise<DaemonHea
 			listenerPresent,
 			processPid,
 			stalePid: artifact.stale ? artifact.pid : null,
+			lastExit,
 		};
 	}
 
@@ -343,6 +377,7 @@ async function buildUnreachableDaemonProbe(agentsDir: string): Promise<DaemonHea
 			listenerPresent,
 			processPid: null,
 			stalePid: artifact.pid,
+			lastExit,
 		};
 	}
 
@@ -353,6 +388,7 @@ async function buildUnreachableDaemonProbe(agentsDir: string): Promise<DaemonHea
 		listenerPresent,
 		processPid: null,
 		stalePid: null,
+		lastExit,
 	};
 }
 
@@ -766,6 +802,7 @@ export function buildSystemdDaemonStartArgs(input: SystemdDaemonStartArgsInput):
 		`--setenv=SIGNET_BIND=${input.bind}`,
 		`--setenv=SIGNET_PATH=${input.agentsDir}`,
 		"--setenv=SIGNET_DAEMON_ENTRYPOINT=1",
+		...(input.unitName ? [`--setenv=SIGNET_DAEMON_UNIT=${input.unitName}`] : []),
 		...resolveDaemonLaunchCommand(input.daemonPath),
 	];
 }
@@ -1048,6 +1085,10 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 	}
 
 	const startupLogPath = join(logDir, "startup.log");
+	// Transient unit name is derived from the starting CLI's pid; it is passed
+	// to the daemon via SIGNET_DAEMON_UNIT so the lifecycle record can point
+	// post-mortems at the unit's journald exit status (issue #1148).
+	const systemdUnitName = `signet-daemon-${process.pid}`;
 	let stderrFd: number | null = null;
 	let stderrTarget: "ignore" | number = "ignore";
 	try {
@@ -1064,6 +1105,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 		SIGNET_BIND: net.bind,
 		SIGNET_PATH: agentsDir,
 		SIGNET_DAEMON_ENTRYPOINT: "1",
+		SIGNET_DAEMON_UNIT: systemdUnitName,
 	};
 
 	// `detached: true` only creates a new process group; it does not escape the
@@ -1074,7 +1116,6 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 	// platforms or environments where that is unavailable.
 	let procExited = false;
 	let startedByServiceManager = false;
-	const systemdUnitName = `signet-daemon-${process.pid}`;
 	if (process.platform === "linux") {
 		const systemdArgs = buildSystemdDaemonStartArgs({
 			daemonPath,

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -1085,9 +1085,10 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 	}
 
 	const startupLogPath = join(logDir, "startup.log");
-	// Transient unit name is derived from the starting CLI's pid; it is passed
-	// to the daemon via SIGNET_DAEMON_UNIT so the lifecycle record can point
-	// post-mortems at the unit's journald exit status (issue #1148).
+	// Transient unit name derived from the starting CLI's pid; used for the
+	// systemd-run unit and, via --setenv SIGNET_DAEMON_UNIT, recorded in the
+	// daemon lifecycle record so post-mortems can query the unit's journald
+	// exit status (issue #1148).
 	const systemdUnitName = `signet-daemon-${process.pid}`;
 	let stderrFd: number | null = null;
 	let stderrTarget: "ignore" | number = "ignore";
@@ -1105,7 +1106,11 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 		SIGNET_BIND: net.bind,
 		SIGNET_PATH: agentsDir,
 		SIGNET_DAEMON_ENTRYPOINT: "1",
-		SIGNET_DAEMON_UNIT: systemdUnitName,
+		// SIGNET_DAEMON_UNIT is deliberately NOT set here: it is only meaningful
+		// when systemd-run actually creates the transient unit (the --setenv in
+		// buildSystemdDaemonStartArgs). On the launchd/detached-spawn fallback
+		// paths the daemon must not record a unit name that does not exist, or
+		// the doctor journalctl pointer would be fabricated.
 	};
 
 	// `detached: true` only creates a new process group; it does not escape the


### PR DESCRIPTION
## Summary

The daemon vanished with zero trace under concurrent automation-bot startup
load (Minecraft chat bridge, camera/motion sentinel hitting session-start
hooks, `secret.exec`, session capture on top of the Obsidian watcher). Five
deaths over ~24h: no core dump, no JS error, no shutdown log, no OOM record.
Two mechanism gaps made every post-mortem stall at "vanished":

1. No durable record survived an unclean death. SIGKILL cannot be caught, so
   nothing distinguished "killed" from "crashed" from "clean" after the fact.
2. Even catchable exits could lose their final log lines: the logger buffers
   file writes on a 1s timer and `logger.shutdown()` (the flush) was never
   called on the exit path — "Shutting down" could sit in the buffer when
   `process.exit()` ran.

## Changes

- **Lifecycle record** (`platform/daemon/src/lifecycle.ts`): the daemon writes
  `.daemon/lifecycle.json` atomically (tmp + rename) at startup
  (`starting` → `running`) and on every catchable exit (`clean` with
  exit path + code for SIGTERM/SIGINT, `error` with message for
  uncaughtException/unhandledRejection/startup failure). A SIGKILL/OOM/crash
  death leaves the record stuck at `starting`/`running` — that stuck state is
  the signal.
- **Single exit path** (`daemon.ts`): `requestShutdown(reason, exitCode, error?)`
  logs `Received <reason>; shutting down`, writes the lifecycle record, runs
  the existing cleanup, then flushes the logger buffer before exiting. Update
  handoffs and boot failures route through it too (the update path skips the
  draining cleanup so the replacement process can bind immediately).
- **Surfacing** (`signet status` / `signet doctor`): when the daemon is down,
  the CLI reads the lifecycle record and reports `daemon_exit_clean` (info),
  `daemon_exit_error` (error with the message), or `daemon_exit_unrecorded`
  (warn: killed or crashed, gated on the recorded pid actually being gone, with
  a journalctl pointer for systemd launches).
- **Load test** (`scripts/load-test-daemon.ts`): reproduces the bot-startup
  traffic profile — session-start/end hooks, secrets listing, recall, status
  polls, optional writes — with a 250ms health watchdog, death-event
  recording, latency percentiles, and a pass/fail verdict.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard

## Screenshots

N/A — daemon lifecycle and CLI diagnostics, no UI change.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Notes: no new/changed data queries (the lifecycle file is internal daemon
state, not a DB query); no new admin/mutation endpoints; docs updated in
`docs/DAEMON.md`.

## Validation

- `bun test` lifecycle/logger/health/runtime suites: 69 pass.
- `bun run typecheck` (root): all workspaces pass. `bunx biome check` on the
  touched files: clean.
- Live on a scratch daemon:
  - SIGTERM → lifecycle `clean`/`signal:SIGTERM`/exit 0; log tail contains
    `Received signal:SIGTERM; shutting down` (flush works).
  - SIGKILL → lifecycle stays `running`; CLI reader surfaces it as an
    unrecorded death.
  - Corrupt `memories.db` → lifecycle `error`/`error:startup` with the message
    and an on-disk log tail (boot failures are no longer silent).
  - Double SIGTERM → clean record, flush still lands.
  - Load test pass: 4,885 requests at 12 concurrency incl. writes, 0 request
    failures, p95 64ms, daemon healthy. Kill demo: SIGKILL mid-run → death
    event recorded, verdict fail.

## Related

- #1148 (this issue), #1136 (silent daemon deaths — mechanism-gap follow-up),
  #1142 (watcher retry loop — fixed 0.164.5), #1143 (startup brick — fixed
  0.164.4)

AI-assisted contribution. Adversarial review findings and their closures are
documented in the PR comments.

PR checklist validated against the current body at merge time.