### PR TITLE
fix(dreaming): advance evidence watermark only to surfaced evidence

### DIFF
--- a/platform/daemon/src/episodic-sources.test.ts
+++ b/platform/daemon/src/episodic-sources.test.ts
@@ -3,7 +3,12 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
-import { readEpisodicSource, readRecentEpisodicSources, searchEpisodicSources } from "./episodic-sources";
+import {
+	type EpisodicCursor,
+	readEpisodicSource,
+	readRecentEpisodicSources,
+	searchEpisodicSources,
+} from "./episodic-sources";
 
 describe("episodic source selection", () => {
 	let dir = "";
@@ -292,5 +297,138 @@ describe("episodic source selection", () => {
 			{ kind: "artifact", id: "sources/needle.md", content: "Needle in source evidence" },
 			{ kind: "memory", id: "matching-memory", content: "Needle in a manual memory" },
 		]);
+	});
+
+	it("re-lists corrupt pre-epoch artifacts behind the since watermark (#1149)", () => {
+		// Regression for #1149: artifacts stamped with the DOS-epoch sentinel
+		// (1980, from timestamp-stripping filesystems) can never be reached
+		// by a rolling `since` watermark, so the since-filtered scan-first
+		// listing used to exclude them forever. They must stay listable as a
+		// catch-up backstop.
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memory_artifacts
+				 (agent_id, source_path, source_sha256, source_kind, session_id, session_token,
+				  captured_at, content, updated_at, is_deleted)
+				 VALUES ('ant', 'sources/sentinel.md', 'sha-sentinel', 'source_obsidian_markdown', 'session-a',
+				  'token-a', '1980-01-01T06:00:00.000Z', 'sentinel artifact evidence',
+				  '2026-08-01T10:00:00.000Z', 0)`,
+			).run();
+			db.prepare(
+				`INSERT INTO memory_artifacts
+				 (agent_id, source_path, source_sha256, source_kind, session_id, session_token,
+				  captured_at, content, updated_at, is_deleted)
+				 VALUES ('ant', 'sources/modern.md', 'sha-modern', 'source_obsidian_markdown', 'session-a',
+				  'token-a', '2026-08-01T11:00:00.000Z', 'modern artifact evidence',
+				  '2026-08-01T11:00:00.000Z', 0)`,
+			).run();
+		});
+
+		const since = "2026-08-01T10:30:00.000Z";
+		const listed = getDbAccessor().withReadDb((db) =>
+			readRecentEpisodicSources(db, "ant", 10, undefined, since, "oldest"),
+		);
+		expect(listed.map((source) => source.id)).toEqual(
+			expect.arrayContaining(["sources/sentinel.md", "sources/modern.md"]),
+		);
+
+		const searched = getDbAccessor().withReadDb((db) =>
+			searchEpisodicSources(db, { agentId: "ant", query: "", since }),
+		);
+		expect(searched.map((source) => source.id)).toEqual(expect.arrayContaining(["sources/sentinel.md"]));
+	});
+
+	it("compares the since bound across ISO and space timestamp formats (#1149)", () => {
+		// Regression for #1149: the watermark can be ISO (an artifact's
+		// captured_at) while rows use SQLite space format. A raw string
+		// comparison would lexically misorder them (' ' < 'T'), silently
+		// dropping a space-format row captured after an ISO watermark.
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memory_artifacts
+				 (agent_id, source_path, source_sha256, source_kind, session_id, session_token,
+				  captured_at, content, updated_at, is_deleted)
+				 VALUES ('ant', 'sources/space-format.md', 'sha-space', 'source_obsidian_markdown', 'session-a',
+				  'token-a', '2026-08-01 12:00:00', 'space format artifact evidence',
+				  '2026-08-01 12:00:00', 0)`,
+			).run();
+			db.prepare(
+				`INSERT INTO session_summaries
+				 (id, project, depth, kind, content, token_count, earliest_at, latest_at, session_key, harness,
+				  agent_id, source_type, source_ref, meta_json, created_at)
+				 VALUES ('space-summary', '/repo', 0, 'session', 'space format summary evidence', 3,
+				  '2026-08-01 12:00:00', '2026-08-01 12:00:00', 'session-a', 'pi',
+				  'ant', 'summary', 'session-a', '{}', '2026-08-01 12:00:00')`,
+			).run();
+		});
+
+		// ISO watermark: both space-format rows are captured after it and
+		// must be listed.
+		const searched = getDbAccessor().withReadDb((db) =>
+			searchEpisodicSources(db, { agentId: "ant", query: "", since: "2026-08-01T11:00:00.000Z" }),
+		);
+		expect(searched.map((source) => source.id)).toEqual(
+			expect.arrayContaining(["sources/space-format.md", "space-summary"]),
+		);
+
+		// A space-format before bound still excludes rows captured after it.
+		const bounded = getDbAccessor().withReadDb((db) =>
+			searchEpisodicSources(db, {
+				agentId: "ant",
+				query: "",
+				since: "2026-08-01T11:00:00.000Z",
+				before: "2026-08-01 12:30:00",
+			}),
+		);
+		expect(bounded.map((source) => source.id)).toEqual(
+			expect.arrayContaining(["sources/space-format.md", "space-summary"]),
+		);
+	});
+
+	it("pages cursor listings past pre-epoch sentinel rows without re-listing them (#1149)", () => {
+		// Regression for #1149 (adversarial review F2): re-admitting sentinel
+		// rows on every cursor page froze paging on the pre-2000 block. The
+		// initial page surfaces them; later pages must move past them.
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memory_artifacts
+				 (agent_id, source_path, source_sha256, source_kind, session_id, session_token,
+				  captured_at, content, updated_at, is_deleted)
+				 VALUES ('ant', 'sources/sentinel.md', 'sha-sentinel', 'source_obsidian_markdown', 'session-a',
+				  'token-a', '1980-01-01T06:00:00.000Z', 'sentinel artifact evidence',
+				  '2026-08-01T10:00:00.000Z', 0)`,
+			).run();
+			db.prepare(
+				`INSERT INTO memory_artifacts
+				 (agent_id, source_path, source_sha256, source_kind, session_id, session_token,
+				  captured_at, content, updated_at, is_deleted)
+				 VALUES ('ant', 'sources/first.md', 'sha-first', 'source_obsidian_markdown', 'session-a',
+				  'token-a', '2026-08-01T11:00:00.000Z', 'first artifact evidence',
+				  '2026-08-01T11:00:00.000Z', 0)`,
+			).run();
+			db.prepare(
+				`INSERT INTO memory_artifacts
+				 (agent_id, source_path, source_sha256, source_kind, session_id, session_token,
+				  captured_at, content, updated_at, is_deleted)
+				 VALUES ('ant', 'sources/second.md', 'sha-second', 'source_obsidian_markdown', 'session-a',
+				  'token-a', '2026-08-01T12:00:00.000Z', 'second artifact evidence',
+				  '2026-08-01T12:00:00.000Z', 0)`,
+			).run();
+		});
+
+		const page = (cursor: EpisodicCursor | null) =>
+			getDbAccessor().withReadDb((db) =>
+				readRecentEpisodicSources(db, "ant", 2, undefined, "2026-08-01T00:00:00.000Z", "oldest", cursor),
+			);
+
+		const pageOne = page(null);
+		expect(pageOne.map((source) => source.id)).toEqual(["sources/sentinel.md", "sources/first.md"]);
+
+		const last = pageOne[pageOne.length - 1];
+		if (!last) throw new Error("page one empty");
+		const pageTwo = page({ capturedAt: last.capturedAt, kind: last.kind, id: last.id });
+		// The sentinel was surfaced by the initial page and must not re-enter.
+		expect(pageTwo.map((source) => source.id)).not.toContain("sources/sentinel.md");
+		expect(pageTwo.map((source) => source.id)).toEqual(["sources/second.md"]);
 	});
 });

--- a/platform/daemon/src/episodic-sources.ts
+++ b/platform/daemon/src/episodic-sources.ts
@@ -3,6 +3,24 @@ import type { ReadDb } from "./db-accessor";
 /** Immutable evidence available to Dreaming and ontology extraction. */
 export type EpisodicSourceKind = "memory" | "artifact" | "transcript" | "summary";
 
+/**
+ * The sane floor for evidence timestamps. Pre-2000 values are corrupt
+ * sentinels (the DOS epoch 1980 default from timestamp-stripping
+ * filesystems and sync layers): a rolling `since` watermark can never reach
+ * them, so a since/cursor-filtered scan must still list them or they fall
+ * permanently behind the Dreaming evidence cursor with no catch-up (#1149).
+ */
+export const EPISODIC_CAPTURED_AT_FLOOR = "2000-01-01T00:00:00.000Z";
+
+/** Match SQLite julianday's UTC interpretation of timezone-less timestamps. */
+export function timestampMillis(value: string): number {
+	const normalized = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(value)
+		? `${value.replace(" ", "T")}Z`
+		: value;
+	const parsed = Date.parse(normalized);
+	return Number.isFinite(parsed) ? parsed : 0;
+}
+
 /** A stable resume point across the merged episodic stores. */
 export interface EpisodicCursor {
 	readonly capturedAt: string;
@@ -73,6 +91,12 @@ function cursorPredicate(
 	newerThan: string | null,
 	cursor: EpisodicCursor | null | undefined,
 ): { readonly sql: string; readonly args: readonly (string | null)[] } {
+	// Rows stamped with a corrupt pre-epoch timestamp (EPISODIC_CAPTURED_AT_FLOOR)
+	// bypass a since watermark: no rolling cutoff can ever reach them, so the
+	// first listing must still surface them or they are silently lost to
+	// scan-first ingestion (#1149). Cursor pages do NOT re-admit them — they
+	// were surfaced by the initial page, and re-admitting them on every page
+	// would freeze cursor paging on the pre-2000 block forever.
 	if (cursor) {
 		const cursorRank = cursor.kind === null ? -1 : SOURCE_KIND_RANK[cursor.kind];
 		const rank = SOURCE_KIND_RANK[kind];
@@ -88,8 +112,8 @@ function cursorPredicate(
 		};
 	}
 	return {
-		sql: `(? IS NULL OR julianday(${timestampColumn}) > julianday(?))`,
-		args: [newerThan, newerThan],
+		sql: `(? IS NULL OR julianday(${timestampColumn}) > julianday(?) OR julianday(${timestampColumn}) < julianday(?))`,
+		args: [newerThan, newerThan, EPISODIC_CAPTURED_AT_FLOOR],
 	};
 }
 
@@ -100,15 +124,6 @@ function compareEpisodicSources(a: EpisodicSourceRecord, b: EpisodicSourceRecord
 	if (rank !== 0) return order === "oldest" ? rank : -rank;
 	const id = a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
 	return order === "oldest" ? id : -id;
-}
-
-/** Match SQLite julianday's UTC interpretation of timezone-less timestamps. */
-function timestampMillis(value: string): number {
-	const normalized = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(value)
-		? `${value.replace(" ", "T")}Z`
-		: value;
-	const parsed = Date.parse(normalized);
-	return Number.isFinite(parsed) ? parsed : 0;
 }
 
 function readNonEmptyTrimmed(value: unknown): string | null {
@@ -706,9 +721,16 @@ export function searchEpisodicSources(
 	const like = `%${query}%`;
 	// An empty query still lists recent sources (runbook cutoff pattern); the
 	// LIKE below degrades to a match-all and the outer ORDER BY picks newest.
-	const timeArgs: unknown[] = [];
-	if (params.since !== undefined) timeArgs.push(params.since);
-	if (params.before !== undefined) timeArgs.push(params.before);
+	// Both the `since` and `before` bounds compare via julianday(): the
+	// watermark can now be ISO (`...T11:00:00.000Z` from an artifact) while
+	// rows use SQLite space format (`... 11:00:00`), and a raw string
+	// comparison would lexically misorder the two (0x20 < 0x54), silently
+	// dropping space-format rows captured after an ISO watermark (#1149).
+	// A `since` cutoff also re-lists corrupt pre-epoch rows: no watermark can
+	// reach them, so they must stay listable or they are lost to ingestion
+	// forever.
+	const sinceArgs: unknown[] = params.since !== undefined ? [params.since, EPISODIC_CAPTURED_AT_FLOOR] : [];
+	const beforeArgs: unknown[] = params.before !== undefined ? [params.before] : [];
 
 	const branches: Array<{ sql: string; args: unknown[] }> = [];
 	if (params.kind === undefined || params.kind === "memory") {
@@ -718,8 +740,9 @@ export function searchEpisodicSources(
 			      WHERE agent_id = ? AND memory_kind = 'episodic'
 			        AND COALESCE(is_deleted, 0) = 0 AND visibility != 'archived' AND scope IS NULL
 			        AND COALESCE(type, '') != 'session_summary' AND content LIKE ?
-			        ${params.since ? "AND created_at >= ?" : ""} ${params.before ? "AND created_at <= ?" : ""}`,
-			args: [params.agentId, like, ...timeArgs],
+			        ${params.since ? "AND (julianday(created_at) >= julianday(?) OR julianday(created_at) < julianday(?))" : ""}
+			        ${params.before ? "AND julianday(created_at) <= julianday(?)" : ""}`,
+			args: [params.agentId, like, ...sinceArgs, ...beforeArgs],
 		});
 	}
 	if (params.kind === undefined || params.kind === "artifact") {
@@ -732,7 +755,8 @@ export function searchEpisodicSources(
 			      FROM memory_artifacts ma
 			      WHERE ma.agent_id = ? AND COALESCE(ma.is_deleted, 0) = 0
 			        AND length(ma.content) > 0 AND ma.content LIKE ?
-			        ${params.since ? "AND ma.captured_at >= ?" : ""} ${params.before ? "AND ma.captured_at <= ?" : ""}
+			        ${params.since ? "AND (julianday(ma.captured_at) >= julianday(?) OR julianday(ma.captured_at) < julianday(?))" : ""}
+			        ${params.before ? "AND julianday(ma.captured_at) <= julianday(?)" : ""}
 			        AND (ma.source_sha256 IS NULL OR ma.source_sha256 = ''
 			             OR (ma.agent_id, ma.source_path) = (
 			               SELECT ma2.agent_id, ma2.source_path FROM memory_artifacts ma2
@@ -741,7 +765,7 @@ export function searchEpisodicSources(
 			               ORDER BY ma2.captured_at DESC, ma2.source_path ASC
 			               LIMIT 1
 			             ))`,
-			args: [params.agentId, like, ...timeArgs],
+			args: [params.agentId, like, ...sinceArgs, ...beforeArgs],
 		});
 	}
 	if (params.kind === undefined || params.kind === "transcript") {
@@ -749,9 +773,9 @@ export function searchEpisodicSources(
 			sql: `SELECT 'transcript' AS kind, session_key AS id, COALESCE(updated_at, created_at) AS captured_at
 			      FROM session_transcripts
 			      WHERE agent_id = ? AND content LIKE ?
-			        ${params.since ? "AND COALESCE(updated_at, created_at) >= ?" : ""}
-			        ${params.before ? "AND COALESCE(updated_at, created_at) <= ?" : ""}`,
-			args: [params.agentId, like, ...timeArgs],
+			        ${params.since ? "AND (julianday(COALESCE(updated_at, created_at)) >= julianday(?) OR julianday(COALESCE(updated_at, created_at)) < julianday(?))" : ""}
+			        ${params.before ? "AND julianday(COALESCE(updated_at, created_at)) <= julianday(?)" : ""}`,
+			args: [params.agentId, like, ...sinceArgs, ...beforeArgs],
 		});
 	}
 	if (params.kind === undefined || params.kind === "summary") {
@@ -761,8 +785,9 @@ export function searchEpisodicSources(
 			      WHERE agent_id = ? AND depth = 0
 			        AND COALESCE(source_type, 'summary') IN ('summary', 'compaction', 'checkpoint')
 			        AND content LIKE ?
-			        ${params.since ? "AND latest_at >= ?" : ""} ${params.before ? "AND latest_at <= ?" : ""}`,
-			args: [params.agentId, like, ...timeArgs],
+			        ${params.since ? "AND (julianday(latest_at) >= julianday(?) OR julianday(latest_at) < julianday(?))" : ""}
+			        ${params.before ? "AND julianday(latest_at) <= julianday(?)" : ""}`,
+			args: [params.agentId, like, ...sinceArgs, ...beforeArgs],
 		});
 	}
 

--- a/platform/daemon/src/memory-lineage.test.ts
+++ b/platform/daemon/src/memory-lineage.test.ts
@@ -6,6 +6,7 @@ import cl100k_base from "js-tiktoken/ranks/cl100k_base";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import {
 	MEMORY_PROJECTION_MAX_TOKENS,
+	indexExternalMemoryArtifact,
 	purgeCanonicalNoiseSessions,
 	purgeCanonicalNoiseSessionsOnce,
 	reindexMemoryArtifacts,
@@ -944,6 +945,10 @@ describe("reindexMemoryArtifacts batch staging", () => {
 		resetWorkspace();
 	});
 
+	afterAll(() => {
+		closeDbAccessor();
+	});
+
 	it("threshold-crossing items are cached — second reindex is a no-op", async () => {
 		// Create >50 artifacts to exceed the batch size (50) and trigger a flush mid-loop.
 		// The regression: the 50th item's cache update was lost because it was only
@@ -999,5 +1004,51 @@ describe("reindexMemoryArtifacts batch staging", () => {
 		);
 
 		expect(afterSecond).toEqual(afterFirst);
+	});
+
+	it("stamps corrupt pre-epoch mtimes as the index time, not the DOS-epoch sentinel (#1149)", () => {
+		// Regression for #1149: files whose mtime is the 1980 DOS-epoch
+		// sentinel (timestamp-stripping filesystems/sync layers) used to get
+		// captured_at = 1980, which no rolling `since` watermark can reach —
+		// the row was invisible to Dreaming forever. The index time must be
+		// stamped instead; the raw mtime still lands in source_mtime_ms.
+		indexExternalMemoryArtifact({
+			agentId: "default",
+			sourcePath: "/vault/notes/sentinel.md",
+			sourceKind: "source_obsidian_markdown",
+			harness: "obsidian",
+			content: "sentinel artifact evidence",
+			sourceMtimeMs: Date.parse("1980-01-01T06:00:00.000Z"),
+		});
+		const sentinel = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare(
+						`SELECT captured_at, source_mtime_ms AS sourceMtimeMs FROM memory_artifacts
+					 WHERE agent_id = 'default' AND source_path = ?`,
+					)
+					.get("/vault/notes/sentinel.md") as { captured_at: string; sourceMtimeMs: number } | undefined,
+		);
+		expect(sentinel).toBeDefined();
+		if (sentinel === undefined) throw new Error("sentinel artifact row missing");
+		expect(Date.parse(sentinel.captured_at)).toBeGreaterThan(Date.parse("2025-01-01T00:00:00.000Z"));
+		expect(sentinel.sourceMtimeMs).toBe(Date.parse("1980-01-01T06:00:00.000Z"));
+
+		// A real mtime is still stamped verbatim.
+		indexExternalMemoryArtifact({
+			agentId: "default",
+			sourcePath: "/vault/notes/real.md",
+			sourceKind: "source_obsidian_markdown",
+			harness: "obsidian",
+			content: "real artifact evidence",
+			sourceMtimeMs: Date.parse("2026-05-24T00:00:00.000Z"),
+		});
+		const real = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT captured_at FROM memory_artifacts WHERE agent_id = 'default' AND source_path = ?")
+					.get("/vault/notes/real.md") as { captured_at: string } | undefined,
+		);
+		expect(real?.captured_at).toBe("2026-05-24T00:00:00.000Z");
 	});
 });

--- a/platform/daemon/src/memory-lineage.ts
+++ b/platform/daemon/src/memory-lineage.ts
@@ -11,6 +11,7 @@ import { getAgentScope } from "./agent-id";
 import { yieldEvery } from "./async-yield";
 import type { WriteDb } from "./db-accessor";
 import { getDbAccessor } from "./db-accessor";
+import { EPISODIC_CAPTURED_AT_FLOOR, timestampMillis } from "./episodic-sources";
 import { logger } from "./logger";
 import { MEMORY_HEAD_MAX_TOKENS } from "./memory-head";
 import { buildAgentScopeClause } from "./memory-search";
@@ -646,7 +647,16 @@ function upsertArtifactRowInTx(
 	const sessionToken = sourcePath.match(/--([a-z2-7]{16})--/)?.[1] ?? deriveSessionToken(agentId, sessionId);
 	const project = typeof frontmatter.project === "string" ? frontmatter.project : null;
 	const harness = typeof frontmatter.harness === "string" ? frontmatter.harness : null;
-	const capturedAt = typeof frontmatter.captured_at === "string" ? frontmatter.captured_at : new Date().toISOString();
+	// Corrupt pre-epoch timestamps (the DOS epoch 1980 sentinel from
+	// timestamp-stripping filesystems/sync layers) are stamped as the index
+	// time instead: a rolling `since` watermark can never reach 1980, so a
+	// captured_at below the floor would make the row invisible to Dreaming
+	// forever (#1149). The raw mtime still lands in source_mtime_ms.
+	const capturedAt =
+		typeof frontmatter.captured_at === "string" &&
+		timestampMillis(frontmatter.captured_at) >= Date.parse(EPISODIC_CAPTURED_AT_FLOOR)
+			? frontmatter.captured_at
+			: new Date().toISOString();
 	const startedAt = typeof frontmatter.started_at === "string" ? frontmatter.started_at : null;
 	const endedAt = typeof frontmatter.ended_at === "string" ? frontmatter.ended_at : null;
 	const manifestPath = typeof frontmatter.manifest_path === "string" ? frontmatter.manifest_path : null;

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -12,6 +12,7 @@ import {
 	obsidianNativeMemorySource,
 	purgeNativeMemorySourceArtifacts,
 	removeNativeMemoryFile,
+	resetNativeMemoryIndexCache,
 	resolveEmbeddingBridgeOptions,
 	startNativeMemoryBridge,
 } from "./native-memory-sources";
@@ -70,6 +71,42 @@ describe("native memory sources", () => {
 		expect(row.content).toContain("Hermes bridge decision");
 	});
 
+	it("heals legacy pre-epoch captured_at rows on rescan (#1149)", async () => {
+		// Regression for #1149 (adversarial review F3): rows already stamped
+		// with the 1980 DOS-epoch sentinel stay permanently pending — no
+		// watermark can reach them, so content passes never early-exit and
+		// re-list the same stale row forever. The watcher must re-stamp them
+		// with the index time once.
+		const root = join(dir, ".codex");
+		mkdirSync(join(root, "memories", "rollout_summaries"), { recursive: true });
+		const file = join(root, "memories", "rollout_summaries", "sentinel-heal.md");
+		writeFileSync(file, "thread_id: sentinel\n\nLegacy artifact with a corrupt mtime.\n");
+		const source = codexNativeMemorySource(root);
+
+		expect(await indexNativeMemoryFile(source, file)).toBe(true);
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE memory_artifacts SET captured_at = ? WHERE agent_id = ? AND source_path = ?").run(
+				"1980-01-01T06:00:00.000Z",
+				"default",
+				file,
+			);
+		});
+
+		// Cold scan (fresh daemon): the unchanged-file path heals the row.
+		resetNativeMemoryIndexCache();
+		expect(await indexNativeMemoryFile(source, file)).toBe(false);
+
+		const healed = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT captured_at FROM memory_artifacts WHERE agent_id = ? AND source_path = ?")
+					.get("default", file) as { captured_at: string } | undefined,
+		);
+		expect(healed).toBeDefined();
+		if (healed === undefined) throw new Error("artifact row missing");
+		expect(Date.parse(healed.captured_at)).toBeGreaterThan(Date.parse("2025-01-01T00:00:00.000Z"));
+	});
+
 	it("indexes Codex automation memory files as native artifacts", async () => {
 		const root = join(dir, ".codex");
 		const file = join(root, "automations", "obsidian-wiki", "memory.md");
@@ -108,7 +145,11 @@ describe("native memory sources", () => {
 
 		const rows = getDbAccessor().withReadDb(
 			(db) =>
-				db.prepare("SELECT source_kind, source_id, source_external_id, source_meta_json FROM memory_artifacts ORDER BY source_kind").all() as Array<{
+				db
+					.prepare(
+						"SELECT source_kind, source_id, source_external_id, source_meta_json FROM memory_artifacts ORDER BY source_kind",
+					)
+					.all() as Array<{
 					source_kind: string;
 					source_id: string | null;
 					source_external_id: string | null;
@@ -845,9 +886,7 @@ describe("native memory sources", () => {
 		const rows = getDbAccessor().withReadDb(
 			(db) =>
 				db
-					.prepare(
-						"SELECT source_id, chunk_text FROM embeddings WHERE source_type = 'source_chunk' ORDER BY source_id",
-					)
+					.prepare("SELECT source_id, chunk_text FROM embeddings WHERE source_type = 'source_chunk' ORDER BY source_id")
 					.all() as Array<{ source_id: string; chunk_text: string }>,
 		);
 		expect(rows.length).toBeGreaterThanOrEqual(1);

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -12,6 +12,7 @@ import {
 import { resolveDaemonAgentId } from "./agent-id";
 import { yieldEvery } from "./async-yield";
 import { getDbAccessor } from "./db-accessor";
+import { EPISODIC_CAPTURED_AT_FLOOR, timestampMillis } from "./episodic-sources";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
 import { hashNormalizedBody, indexExternalMemoryArtifact, softDeleteArtifactRowsForPath } from "./memory-lineage";
@@ -96,6 +97,11 @@ interface IndexedNativeMemory {
 }
 
 const indexed = new Map<string, IndexedNativeMemory>();
+
+/** Test-only: drop the in-process content-hash cache so scans behave like a fresh daemon. */
+export function resetNativeMemoryIndexCache(): void {
+	indexed.clear();
+}
 const DEFAULT_OBSIDIAN_SOURCE_FILE_DELAY_MS = 250;
 
 // Read failures that are not permanent (ENOENT) enter a per-path cooldown so
@@ -349,6 +355,53 @@ function nativeArtifactContentHash(filePath: string, agentId: string): string | 
 	}
 }
 
+function nativeArtifactCapturedAt(filePath: string, agentId: string): string | null {
+	const sourcePath = filePath.replace(/\\/g, "/");
+	try {
+		return getDbAccessor().withReadDb((db) => {
+			const row = db
+				.prepare(
+					"SELECT captured_at FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0 LIMIT 1",
+				)
+				.get(agentId, sourcePath) as { captured_at: string } | undefined;
+			return row?.captured_at ?? null;
+		});
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * One-shot heal for rows already stamped with a corrupt pre-epoch captured_at
+ * (the DOS epoch 1980 sentinel): they are re-stamped with the index time so
+ * they stop blocking backlog termination and get a normal lifecycle. New
+ * indexes never mint sentinels (the memory-lineage clamp), so this only fires
+ * once per legacy row (#1149).
+ */
+function healSentinelCapturedAt(filePath: string, agentId: string, harness: string, capturedAt: string): void {
+	if (timestampMillis(capturedAt) >= Date.parse(EPISODIC_CAPTURED_AT_FLOOR)) return;
+	try {
+		const stampedAt = new Date().toISOString();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`UPDATE memory_artifacts
+				 SET captured_at = ?, updated_at = ?
+				 WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0`,
+			).run(stampedAt, stampedAt, agentId, filePath.replace(/\\/g, "/"));
+		});
+		logger.warn("watcher", "Healed pre-epoch captured_at on native memory artifact", {
+			harness,
+			path: filePath,
+			was: capturedAt,
+		});
+	} catch (err) {
+		logger.warn("watcher", "Could not heal pre-epoch captured_at", {
+			path: filePath,
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+}
+
 function obsidianGraphExists(agentId: string, sourceId: string, filePath: string): boolean {
 	try {
 		return getDbAccessor().withReadDb((db) => {
@@ -523,6 +576,13 @@ export async function indexNativeMemoryFile(
 		indexed.delete(key);
 	}
 	if (persistedHash === hash && semanticComplete) {
+		// One-shot heal for legacy rows with a corrupt pre-epoch captured_at:
+		// they stay permanently pending otherwise (no watermark can reach
+		// 1980), keeping content passes from ever early-exiting (#1149).
+		const persistedCapturedAt = nativeArtifactCapturedAt(filePath, agentId);
+		if (persistedCapturedAt !== null) {
+			healSentinelCapturedAt(filePath, agentId, source.harness, persistedCapturedAt);
+		}
 		indexed.set(key, { contentHash: hash });
 		return false;
 	}

--- a/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
@@ -239,6 +239,59 @@ describe("dreaming-agent-tools", () => {
 		expect(JSON.stringify(entity).length).toBeLessThan(10_000);
 	});
 
+	it("search_evidence defaults since to the scope's evidence watermark when omitted (#1149)", async () => {
+		// Regression for #1149: the scan-first listing used to anchor `since`
+		// to pass-start (read off the runbook), so evidence captured between
+		// the last watermark and pass start was never listed. An omitted
+		// `since` must fall back to dreaming_state.last_pass_at — the
+		// frontier the last pass actually surfaced — so the unprocessed
+		// window is listed, and an explicit earlier `since` still reaches
+		// older evidence.
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("INSERT INTO dreaming_state (agent_id, last_pass_at) VALUES (?, ?)").run(
+				"owner",
+				"2026-08-06T12:00:00.000Z",
+			);
+			for (const [id, content, createdAt] of [
+				["mem-old", "Old evidence before the watermark.", "2026-08-06T11:00:00.000Z"],
+				["mem-new", "New evidence after the watermark.", "2026-08-06T13:00:00.000Z"],
+			] as const) {
+				db.prepare(
+					`INSERT INTO memories
+					 (id, content, source_type, memory_kind, visibility, agent_id, created_at, updated_at)
+					 VALUES (?, ?, 'manual', 'episodic', 'normal', 'owner', ?, ?)`,
+				).run(id, content, createdAt, createdAt);
+			}
+		});
+		const tools = createDreamingAgentTools({ accessor: getDbAccessor(), agentId: "owner", actor: "owner" });
+
+		const listed = readResult(
+			await findTool(tools, "search_evidence").execute(
+				"call",
+				{ agentId: "owner" }, // scan-first listing: omit query and since
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		const refs = (listed.items as Array<{ sourceRef: string }>).map((item) => item.sourceRef);
+		expect(refs).toContain("memory:mem-new");
+		expect(refs).not.toContain("memory:mem-old");
+
+		const explicit = readResult(
+			await findTool(tools, "search_evidence").execute(
+				"call",
+				{ agentId: "owner", since: "2026-08-06T10:00:00.000Z" },
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		expect((explicit.items as Array<{ sourceRef: string }>).map((item) => item.sourceRef)).toEqual(
+			expect.arrayContaining(["memory:mem-old", "memory:mem-new"]),
+		);
+	});
+
 	it("search_evidence exposes completed on transcripts and settled records", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -9,7 +9,7 @@
  */
 import type { Entity } from "@signet/core";
 import { z } from "zod";
-import type { DbAccessor } from "../db-accessor";
+import type { DbAccessor, ReadDb } from "../db-accessor";
 import { classifyEntityQuality } from "../entity-quality";
 import type { EpisodicSourceRecord } from "../episodic-sources";
 import { readEpisodicSource, searchEpisodicSources } from "../episodic-sources";
@@ -47,6 +47,25 @@ const MAX_ENTITY_TEXT_CHARS = 2_000;
 function boundedText(value: string | undefined, maxChars: number): string | undefined {
 	if (value === undefined || value.length <= maxChars) return value;
 	return value.slice(0, maxChars);
+}
+
+/**
+ * The scope's evidence watermark (`dreaming_state.last_pass_at`): the
+ * frontier the last pass actually surfaced. `search_evidence` anchors its
+ * scan-first listing here (when the agent omits `since`) so the unprocessed
+ * window is listed instead of pass-start (#1149). Missing on first run, an
+ * old workspace, or a scope that never passed: returns null so the listing
+ * falls back to unbounded.
+ */
+function readEvidenceWatermark(db: ReadDb, agentId: string): string | null {
+	try {
+		const row = db.prepare("SELECT last_pass_at AS lastPassAt FROM dreaming_state WHERE agent_id = ?").get(agentId) as
+			| { lastPassAt: string | null }
+			| undefined;
+		return row?.lastPassAt ?? null;
+	} catch {
+		return null;
+	}
 }
 
 function evidenceExcerptStart(content: string, query: string, maxChars: number): number {
@@ -429,7 +448,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"search_evidence",
 			"Search episodic evidence",
-			"Full-text search immutable episodic memories, artifacts, transcripts, and summaries in one agent scope. Results contain exact bounded excerpts of the rendered evidence with contentOffset/contentLength; use sourceRef for citations, which are validated against the complete canonical source. Each record carries completed: memory, artifact, and summary records are settled captures (true); a transcript is true once a session-end summary job has been triggered for its session (the session ended), whether or not the summary itself landed, and false while the session is still running — do not file claims from a still-growing transcript, since its states may be contradicted by the session's end. If contentTruncated is true, page exact fragments with the same sourceRef and chunkSize: start at offset=0 when contentHasPrevious is true, then use offset=contentOffset+content.length from the fragment just returned until contentHasNext is false. Omit the query to list the most recent sources (e.g. with since as a cutoff). Artifacts are deduped by content hash: content-identical files across vault paths collapse to one canonical entry.",
+			"Full-text search immutable episodic memories, artifacts, transcripts, and summaries in one agent scope. Results contain exact bounded excerpts of the rendered evidence with contentOffset/contentLength; use sourceRef for citations, which are validated against the complete canonical source. Each record carries completed: memory, artifact, and summary records are settled captures (true); a transcript is true once a session-end summary job has been triggered for its session (the session ended), whether or not the summary itself landed, and false while the session is still running — do not file claims from a still-growing transcript, since its states may be contradicted by the session's end. If contentTruncated is true, page exact fragments with the same sourceRef and chunkSize: start at offset=0 when contentHasPrevious is true, then use offset=contentOffset+content.length from the fragment just returned until contentHasNext is false. Omit the query AND since to list the unprocessed window: the listing starts at the scope's evidence watermark (the last pass's surfaced frontier), so the newest unseen sources come first. Narrow with a query if the list is large; pass an explicit earlier since only when you need older history. Artifacts are deduped by content hash: content-identical files across vault paths collapse to one canonical entry.",
 			true,
 			z.object({
 				agentId: z.string().min(1),
@@ -456,10 +475,16 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 							? { ok: false, error: "Evidence fragment offset is outside the source" }
 							: { ok: true, items: [fragment] };
 					}
+					// The scan-first listing omits `since`; anchor it to the
+					// scope's evidence watermark instead of pass-start so the
+					// unprocessed window [last surfaced frontier -> now] is
+					// listed, never the fresh minutes after pass start only
+					// (#1149).
+					const effectiveSince = since ?? readEvidenceWatermark(db, scopeId);
 					const sources = searchEpisodicSources(db, {
 						agentId: scopeId,
 						query: query ?? "",
-						since,
+						since: effectiveSince ?? undefined,
 						before,
 						kind,
 						limit,

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -104,7 +104,7 @@ describe("Dreaming", () => {
 		).toEqual({ capturedAt: "2026-03-01T00:00:00.000Z", kind: "summary", id: "fragment" });
 	});
 
-	it("uses the fixed agent prompt and resets the evidence backlog each pass", async () => {
+	it("uses the fixed agent prompt and resets the evidence backlog to the surfaced frontier", async () => {
 		seedSummary(db, "s1", "durable episodic evidence for the backlog.", 500);
 		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
 		let prompt = "";
@@ -113,6 +113,12 @@ describe("Dreaming", () => {
 			{
 				async run(input) {
 					prompt = input.prompt;
+					// The scan-first listing surfaces the pending evidence, so
+					// the pass-end watermark legitimately advances to it and
+					// the same evidence must not re-trigger the next pass.
+					const search = input.tools.find((tool) => tool.name === "search_evidence");
+					if (!search) throw new Error("Missing search_evidence");
+					await search.execute("call", { agentId: AGENT }, undefined, undefined, {} as never);
 					return { summary: "Done" };
 				},
 			},
@@ -124,8 +130,8 @@ describe("Dreaming", () => {
 		);
 		expect(result.summary).toBe("Done");
 		expect(prompt).toBe(DREAMING_AGENT_PROMPT);
-		// The evidence queue resets to pass start: the same evidence must not
-		// re-trigger the next pass.
+		// The evidence queue resets to the surfaced frontier: the same
+		// evidence must not re-trigger the next pass.
 		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBe(0);
 	});
 
@@ -758,7 +764,13 @@ describe("Dreaming", () => {
 		await runDreamingAgentPass(
 			accessor,
 			{
-				async run() {
+				async run(input) {
+					// The content pass surfaces the starved evidence through
+					// the scan-first listing, so the watermark legitimately
+					// advances to it and the backlog drains.
+					const search = input.tools.find((tool) => tool.name === "search_evidence");
+					if (!search) throw new Error("Missing search_evidence");
+					await search.execute("call", { agentId: AGENT }, undefined, undefined, {} as never);
 					return { summary: "Extracted claims" };
 				},
 			},
@@ -769,5 +781,147 @@ describe("Dreaming", () => {
 			"incremental-content",
 		);
 		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBe(0);
+	});
+
+	it("does not advance the evidence watermark past evidence a content pass never surfaced (#1149)", async () => {
+		// Regression for #1149: a content pass that completes without ever
+		// surfacing the pending evidence used to reset the watermark to
+		// pass-start anyway, so the un-surfaced window was counted as processed
+		// and the next scan-first search never re-listed it. A pass that
+		// surfaced nothing must leave the watermark untouched so the evidence
+		// stays pending.
+		seedSummary(db, "unread-evidence", "Evidence that a 0/0 content pass never surfaced.", 8);
+		await runDreamingAgentPass(
+			accessor,
+			{
+				async run() {
+					// The agent spent its budget elsewhere: no search_evidence
+					// call, so nothing was surfaced this pass.
+					return { summary: "Reviewed due claims only" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT],
+			"incremental-content",
+		);
+		expect(getDreamingState(accessor, AGENT).lastPassAt).toBeNull();
+		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+	});
+
+	it("advances the evidence watermark only to the evidence the pass surfaced (#1149)", async () => {
+		// Regression for #1149: the watermark must move to the newest source the
+		// pass actually surfaced, never to pass-start. Evidence captured after
+		// the surfaced frontier stays pending for the next scan-first search.
+		const seed = (id: string, latestAt: string): void => {
+			db.prepare(
+				`INSERT INTO session_summaries
+				 (id, agent_id, content, token_count, depth, kind, source_type, earliest_at, latest_at, created_at)
+				 VALUES (?, ?, ?, 8, 0, 'session', 'summary', ?, ?, datetime('now'))`,
+			).run(id, AGENT, `Summarized evidence for ${id}.`, latestAt, latestAt);
+		};
+		accessor.withWriteTx((tx) => {
+			tx.prepare("INSERT INTO dreaming_state (agent_id, last_pass_at) VALUES (?, ?)").run(
+				AGENT,
+				"2026-08-05T00:00:00.000Z",
+			);
+		});
+		seed("surfaced-old", "2026-08-06T00:00:00.000Z");
+		seed("surfaced-new", "2026-08-06T12:00:00.000Z");
+		seed("gap-evidence", "2026-08-07T00:00:00.000Z");
+
+		await runDreamingAgentPass(
+			accessor,
+			{
+				async run(input) {
+					const search = input.tools.find((tool) => tool.name === "search_evidence");
+					if (!search) throw new Error("Missing search_evidence");
+					// The listing is bounded below the gap evidence: only the two
+					// surfaced summaries are returned to the pass.
+					await search.execute(
+						"call",
+						{ agentId: AGENT, since: "2026-08-05T00:00:00.000Z", before: "2026-08-06T12:00:00.000Z" },
+						undefined,
+						undefined,
+						{} as never,
+					);
+					return { summary: "Filed surfaced summaries" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT],
+			"incremental-content",
+		);
+		// The watermark advanced to the newest surfaced source, not pass-start.
+		expect(getDreamingState(accessor, AGENT).lastPassAt).toBe("2026-08-06T12:00:00.000Z");
+		// The gap evidence (captured after the surfaced frontier, before pass
+		// start) remains pending for the next scan-first search.
+		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+	});
+
+	it("does not advance the watermark on a fragment read of an already-listed source (#1149)", async () => {
+		// Regression for #1149 (adversarial review F4): paging a sourceRef
+		// fragment is a content read of a source the listing already surfaced;
+		// it must not advance the frontier past the unread remainder.
+		db.prepare(
+			`INSERT INTO session_summaries
+			 (id, agent_id, content, token_count, depth, kind, source_type, earliest_at, latest_at, created_at)
+			 VALUES ('frag-source', ?, 'Fragment evidence for frontier checks.', 8, 0, 'session', 'summary',
+			  '2026-08-06T12:00:00.000Z', '2026-08-06T12:00:00.000Z', datetime('now'))`,
+		).run(AGENT);
+		accessor.withWriteTx((tx) => {
+			tx.prepare("INSERT INTO dreaming_state (agent_id, last_pass_at) VALUES (?, ?)").run(
+				AGENT,
+				"2026-08-05T00:00:00.000Z",
+			);
+		});
+
+		await runDreamingAgentPass(
+			accessor,
+			{
+				async run(input) {
+					const search = input.tools.find((tool) => tool.name === "search_evidence");
+					if (!search) throw new Error("Missing search_evidence");
+					await search.execute(
+						"call",
+						{ agentId: AGENT, sourceRef: "summary:frag-source", offset: 0, chunkSize: 10 },
+						undefined,
+						undefined,
+						{} as never,
+					);
+					return { summary: "Paged one fragment" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT],
+			"incremental-content",
+		);
+		expect(getDreamingState(accessor, AGENT).lastPassAt).toBe("2026-08-05T00:00:00.000Z");
+	});
+
+	it("does not advance the evidence watermark when a hygiene pass early-exits (#1098, #1149)", async () => {
+		// Regression for #1149 (adversarial review F5): a hygiene pass that
+		// early-exits on an empty queue used to advance the watermark to
+		// pass-start anyway, violating the hygiene-never-advances contract
+		// and skipping evidence indexed in the TOCTOU gap.
+		await runDreamingAgentPass(
+			accessor,
+			{
+				async run() {
+					throw new Error("agent should not be invoked for an empty hygiene pass");
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT],
+			"incremental-hygiene",
+		);
+		expect(getDreamingState(accessor, AGENT).lastPassAt).toBeNull();
 	});
 });

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -19,10 +19,12 @@ import {
 } from "@signet/core";
 import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
 import {
+	EPISODIC_CAPTURED_AT_FLOOR,
 	type EpisodicCursor,
 	type EpisodicSourceRecord,
 	readEpisodicSource,
 	readRecentEpisodicSources,
+	timestampMillis,
 } from "../episodic-sources";
 import { type GraphHygieneCaps, getDreamingHygieneCandidatesInDb } from "../knowledge-graph-hygiene";
 import { logger } from "../logger";
@@ -338,6 +340,47 @@ export function recordDreamingFailure(accessor: DbAccessor, agentId: string): vo
 // Dreaming pass records
 // ---------------------------------------------------------------------------
 
+/** Timestamps at or below the corrupt pre-epoch floor never advance a watermark. */
+const EVIDENCE_WATERMARK_FLOOR_MS = Date.parse(EPISODIC_CAPTURED_AT_FLOOR);
+
+/**
+ * The newest captured_at `search_evidence` actually returned to a pass. The
+ * pass-end watermark may advance only this far: evidence captured after the
+ * surfaced frontier but before pass start was never shown to the agent and
+ * must stay pending for the next scan-first search (#1149).
+ */
+function surfacedEvidenceWatermark(items: readonly unknown[]): string | null {
+	let watermark: string | null = null;
+	for (const item of items) {
+		if (!isRecord(item)) continue;
+		const capturedAt = typeof item.capturedAt === "string" ? item.capturedAt : null;
+		if (capturedAt === null) continue;
+		const ms = timestampMillis(capturedAt);
+		// Corrupt pre-epoch rows can never advance a watermark; the sentinel
+		// bypass in the episodic readers keeps them listable regardless.
+		if (ms <= EVIDENCE_WATERMARK_FLOOR_MS) continue;
+		if (watermark === null || ms > timestampMillis(watermark)) watermark = capturedAt;
+	}
+	return watermark;
+}
+
+/**
+ * The pass-end evidence watermark: the newer of the previous watermark and
+ * the newest source the pass surfaced, never later than the pass started.
+ * A pass that surfaced nothing keeps its previous watermark, so skipped
+ * evidence is re-listed by the next scan-first search instead of being
+ * counted as processed (#1149).
+ */
+function nextEvidenceWatermark(surfaced: string, previous: string | null, cutoff: string): string | null {
+	const surfacedMs = timestampMillis(surfaced);
+	const cutoffMs = timestampMillis(cutoff);
+	// Clock skew can date a source after pass start; cap the watermark so
+	// the cursor never advances past the pass itself.
+	const capped = surfacedMs > cutoffMs ? cutoff : surfaced;
+	if (previous === null) return capped;
+	return timestampMillis(capped) > timestampMillis(previous) ? capped : previous;
+}
+
 export function createDreamingPass(accessor: DbAccessor, agentId: string, mode: DreamingMode): string {
 	const id = randomUUID();
 	accessor.withWriteTx((db) => {
@@ -638,7 +681,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - \`attribute_over_cap\` / \`aspect_over_cap\` flags: the write gate rejects new claims or aspects past the cap, so consolidate the flagged target — merge_aspects to fold over-cap aspects together, supersede_claim_value to collapse duplicate claim keys, archive_claim_value for stale snapshots. Consolidation (merge_aspects) may exceed the attribute cap; it is the remedy the cap forces.
    - If you discover junk the queue did not flag, mint a flag op and archive in the same batch.
 3. Query attention_list with kind=review_due. For expired records, inspect the cited memory with search_evidence using its subjectRef, then supersede the matching active claim with supersede_claim_value. Use the supplied entityId, aspectId, attributeId, and claimKey when present. The replacement must state that the planned event remains unconfirmed; never rewrite it as if the event happened. Cite an exact quote from the original memory. Do not supersede approaching records. When creating or setting a future temporal claim, set payload.reviewAfter to the referenced ISO timestamp.
-4. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
+4. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST unprocessed sources with search_evidence — omit the query and omit since so it lists from the scope's evidence watermark (the frontier the last pass actually surfaced), newest first; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
    - search_entities for subjects it establishes.
    - File claims only for what the source establishes as settled fact: outcomes, decisions, shipped changes, stable behavior. Do not file instructions that were merely suggested, hypotheses or diagnoses, open questions, or intermediate states of an ongoing investigation. When a source shows an attempt and its outcome, file the outcome.
    - Before adding a claim, check the target aspect's existing claims; if one covers the same key or is contradicted by the new evidence, supersede it (supersede_claim_value) instead of adding alongside.
@@ -750,7 +793,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 
 1. Read the pass log (runbook_read). Establish cutoff: sources viewed, changes applied, deferred items.
 2. Query attention_list with kind=review_due. For expired records, inspect the cited memory with search_evidence using its subjectRef, then supersede the matching active claim with supersede_claim_value. Use the supplied entityId, aspectId, attributeId, and claimKey when present. The replacement must state that the planned event remains unconfirmed; never rewrite it as if the event happened. Cite an exact quote from the original memory. Do not supersede approaching records. When creating or setting a future temporal claim, set payload.reviewAfter to the referenced ISO timestamp.
-3. Find new evidence since the cutoff. First LIST recent sources with search_evidence — pass since and omit the query so it returns the newest sources; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
+3. Find new evidence since the cutoff. First LIST unprocessed sources with search_evidence — omit the query and omit since so it lists from the scope's evidence watermark (the frontier the last pass actually surfaced), newest first; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
    - search_entities for subjects it establishes.
    - File claims only for what the source establishes as settled fact: outcomes, decisions, shipped changes, stable behavior. Do not file instructions that were merely suggested, hypotheses or diagnoses, open questions, or intermediate states of an ongoing investigation. When a source shows an attempt and its outcome, file the outcome.
    - Before adding a claim, check the target aspect's existing claims; if one covers the same key or is contradicted by the new evidence, supersede it (supersede_claim_value) instead of adding alongside.
@@ -879,8 +922,9 @@ export async function runDreamingAgentPass(
 				? `${dreamingPromptForMode(mode)}\n\n<agent_scopes>\n${scopes.join("\n")}\n</agent_scopes>`
 				: dreamingPromptForMode(mode);
 
-		// SQLite-format watermark so string comparisons against stored source
-		// dates stay consistent (ISO timestamps would mis-order).
+		// Pass-start cutoff, SQLite format. The stored watermark may also be
+		// the raw surfaced captured_at (ISO); every comparison goes through
+		// julianday(), so the mixed formats stay ordered (#1149).
 		const cutoff = accessor.withReadDb(
 			(db) => (db.prepare("SELECT datetime('now') AS now").get() as { now: string }).now,
 		);
@@ -902,9 +946,12 @@ export async function runDreamingAgentPass(
 					 mutations_failed = 0, summary = ? WHERE id = ?`,
 				).run(earlyExitSummary, passId);
 				// The evidence watermark only advances when nothing new
-				// remains: a focused pass that exits while the other mode's
-				// work is pending must not skip it for the next pass (#1098).
-				if (totalBacklog === 0) {
+				// remains AND the mode consumes evidence: a focused pass
+				// that exits while the other mode's work is pending must not
+				// skip it for the next pass, and a hygiene pass must never
+				// advance the watermark even on an empty backlog (#1098,
+				// #1149).
+				if (totalBacklog === 0 && dreamingModeAdvancesEvidence(mode)) {
 					for (const scope of scopes) resetDreamingTokens(db, scope, passId, mode, null, cutoff);
 				}
 			});
@@ -916,6 +963,9 @@ export async function runDreamingAgentPass(
 		let toolCallSequence = 0;
 		let applyCallbackReported = false;
 		const rejectedEvidence: EpisodicSourceRecord[] = [];
+		// The newest captured_at each scope's search_evidence surfaced this
+		// pass; the pass-end watermark may advance only to it (#1149).
+		const surfacedWatermarkByScope = new Map<string, string>();
 		const tools = createDreamingAgentTools({
 			accessor,
 			agentId,
@@ -931,6 +981,23 @@ export async function runDreamingAgentPass(
 			},
 			onToolCall(trace) {
 				recordDreamingToolCall(accessor, agentId, passId, ++toolCallSequence, trace);
+				if (trace.tool === "search_evidence" && trace.output.ok === true && Array.isArray(trace.output.items)) {
+					const input = isRecord(trace.input) ? trace.input : null;
+					// A sourceRef call reads a fragment of a source the
+					// listing already surfaced: it adds no new frontier (the
+					// listing's max covers it) and must not advance the
+					// watermark past the unread remainder (#1149).
+					if (input === null || typeof input.sourceRef !== "string") {
+						const scope = input !== null && typeof input.agentId === "string" ? input.agentId : agentId;
+						const surfaced = surfacedEvidenceWatermark(trace.output.items);
+						if (surfaced !== null) {
+							const current = surfacedWatermarkByScope.get(scope);
+							if (current === undefined || timestampMillis(surfaced) > timestampMillis(current)) {
+								surfacedWatermarkByScope.set(scope, surfaced);
+							}
+						}
+					}
+				}
 				if (trace.tool === "apply_ontology_ops") {
 					if (!trace.output.ok && !applyCallbackReported) {
 						rejectedEvidence.push(
@@ -955,6 +1022,18 @@ export async function runDreamingAgentPass(
 		});
 		const summary = `${outcome.summary?.trim() || "Agentic Dreaming pass completed"}`;
 		const tokensConsumed = countTokens(prompt);
+		// The watermark advances only to what this pass actually surfaced: a
+		// pass that completes without surfacing (or deferring) pending
+		// evidence must not skip it for the next scan-first search (#1149).
+		const nextWatermarkByScope = new Map<string, string | null>();
+		for (const scope of scopes) {
+			const previous = accessor.withReadDb((db) => readDreamingState(db, scope).lastPassAt);
+			const surfaced = surfacedWatermarkByScope.get(scope);
+			nextWatermarkByScope.set(
+				scope,
+				surfaced === undefined ? previous : nextEvidenceWatermark(surfaced, previous, cutoff),
+			);
+		}
 		accessor.withWriteTx((db) => {
 			db.prepare(
 				`UPDATE dreaming_passes SET status = 'completed', completed_at = datetime('now'),
@@ -964,12 +1043,14 @@ export async function runDreamingAgentPass(
 			recordDreamingEvidenceExclusionsInTx(db, agentId, passId, rejectedEvidence, "semantic_operation_rejected");
 			// The evidence queue resets to the pass watermark for EVERY scope
 			// the pass consumed evidence for: the next pass's backlog counts
-			// only sources captured after this pass began. A hygiene pass
-			// consumes no evidence, so it must not advance the watermark —
+			// only sources captured after the surfaced frontier. A hygiene
+			// pass consumes no evidence, so it must not advance the watermark —
 			// advancing it would hide the unprocessed backlog from the next
 			// content pass and starve content again (#1098).
 			if (dreamingModeAdvancesEvidence(mode)) {
-				for (const scope of scopes) resetDreamingTokens(db, scope, passId, mode, null, cutoff);
+				for (const scope of scopes) {
+					resetDreamingTokens(db, scope, passId, mode, null, nextWatermarkByScope.get(scope) ?? null);
+				}
 			}
 		});
 		return { passId, applied, skipped: 0, failed, summary };


### PR DESCRIPTION
Fixes #1149

## Summary

Content-mode dreaming passes advanced the evidence watermark to pass-start time even when the pass never surfaced the evidence in that window. Evidence captured while passes failed, deferred, or ran 0/0 fell permanently behind the rolling `since` cutoff: the scan-first `search_evidence` listing only shows sources captured after the previous pass's watermark, so skipped evidence was never re-listed and never ingested. On the affected install, a 2,050-artifact Obsidian vault indexed during a crash/restart storm was skipped in full.

The precise mechanism (verified against live `dreaming_tool_calls`): the agent anchored every `search_evidence` `since` to the previous pass's timestamp read off the runbook — not the watermark. So even rewinding `last_pass_at` manually did not recover the vault: the next pass searched since its own pass-start and the unprocessed window was never listed.

Three coordinated fixes:

1. **Watermark advances only to what the pass actually surfaced** (`dreaming.ts`): the pass-end reset now tracks the newest `captured_at` each scope's `search_evidence` actually returned (via the existing tool-call trace) and advances `last_pass_at` to that frontier — never to pass-start. A pass that surfaces nothing leaves the watermark untouched, so the skipped evidence stays pending for the next scan-first search. Sentinels (pre-2000 corrupt timestamps) never advance a watermark.
2. **`search_evidence` defaults `since` to the scope's evidence watermark** (`dreaming-capabilities.ts`): an omitted `since` now anchors the listing to `dreaming_state.last_pass_at` — the frontier the last pass actually surfaced — instead of leaving the anchor to the agent's runbook guess. The runbook instruction in both fixed prompts now says "omit the query and omit since" for the scan-first list.
3. **Corrupt timestamps can no longer be lost** (`episodic-sources.ts`, `memory-lineage.ts`): pre-2000 `captured_at` rows (the DOS-epoch 1980 sentinel from timestamp-stripping filesystems/sync layers) bypass the since/cursor watermark so they stay listable forever as a catch-up backstop; new indexes clamp such mtimes to the index time (raw mtime still stored in `source_mtime_ms`).

The live-install recovery (rewind `default`'s watermark to before the vault's capture window) is now effective with these fixes and is documented in the issue.

## Changes

- `platform/daemon/src/pipeline/dreaming.ts` — pass-end watermark advances to max surfaced per scope (`surfacedEvidenceWatermark`/`nextEvidenceWatermark`); scan-first runbook instruction omits `since`; hygiene passes still never advance.
- `platform/daemon/src/pipeline/dreaming-capabilities.ts` — `search_evidence` defaults an omitted `since` to the scope's evidence watermark; tool description documents the scan-first pattern.
- `platform/daemon/src/episodic-sources.ts` — `EPISODIC_CAPTURED_AT_FLOOR` (2000-01-01) sentinel bypass in `cursorPredicate` and `searchEpisodicSources` since filters; `timestampMillis` exported.
- `platform/daemon/src/memory-lineage.ts` — pre-2000 `captured_at` values clamp to the index time at upsert.
- Tests: regression tests naming #1149 (watermark advances only to surfaced evidence; 0/0 pass keeps the backlog pending; search_evidence since-defaults to the watermark; sentinel rows stay listable; corrupt mtimes clamp). Two pre-existing tests updated: their stub content passes must now surface evidence via `search_evidence` before the backlog can legitimately reset. Also added the missing `afterAll` to the second `memory-lineage.test.ts` describe — its leaked global accessor broke any batch run with a following `initDbAccessor` file (`DbAccessor already initialised`), reproduced on pristine `origin/main`.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A — daemon-side behavior change, no UI.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Adversarial review fixes (second pass)

The subagent review (SHIP WITH FIXES) found five issues; all five are fixed and covered by new regression tests:

- **Mixed-format since comparisons** (HIGH in practice): the watermark can be ISO (an artifact's `captured_at`) while rows use SQLite space format; the `searchEpisodicSources` since/before bounds compared raw strings, so a space-format row captured after an ISO watermark failed lexically (`' ' < 'T'`) and was silently dropped — the same loss class as #1149. All bounds now compare via `julianday()`.
- **Cursor paging frozen on sentinel rows**: the pre-epoch floor bypass re-admitted sentinels on every cursor page. The bypass now applies only to the initial (no-cursor) listing; cursor pages move past them.
- **Sentinel rows never terminate the backlog**: a pre-2000 row stays pending forever (no watermark can reach it), so content passes never early-exit and re-list it each pass. The watcher now heals legacy sentinel rows to the index time on rescan (one-shot; new indexes never mint them via the clamp).
- **Fragment reads advanced the frontier**: a `sourceRef` fragment read of an already-listed source no longer advances the watermark past the unread remainder.
- **Hygiene early-exit advanced the watermark**: the early-exit reset is now gated by the mode's evidence contract, so a hygiene pass never advances even on an empty backlog.