### PR TITLE
feat(daemon): record embedding token usage at the fetch boundary (#1154)

### DIFF
--- a/docs/api/health-status.md
+++ b/docs/api/health-status.md
@@ -252,10 +252,35 @@ silent fallback or hard-blocked extraction after boot.
   "embedding": {
     "provider": "ollama",
     "model": "nomic-embed-text",
-    "available": true
+    "available": true,
+    "usage": {
+      "total": { "requests": 2084, "tokens": 812345 },
+      "today": { "requests": 12, "tokens": 4567 },
+      "bySource": [
+        { "source": "artifact-index", "requests": 2050, "tokens": 800000 },
+        { "source": "memory-capture", "requests": 30, "tokens": 12000 },
+        { "source": "recall", "requests": 4, "tokens": 345 }
+      ],
+      "byProvider": [
+        { "provider": "ollama", "requests": 2080, "tokens": 812000 },
+        { "provider": "llama-cpp", "requests": 4, "tokens": 345 }
+      ]
+    }
   }
 }
 ```
+
+The `embedding.usage` block reports embedding token consumption recorded at
+the shared embedding-fetch boundary (migration 108). Counts come from the
+real tokenizer (`countTokens`) applied to the text actually sent to the
+provider — never provider-reported usage, since Ollama's `/api/embeddings`
+returns none and the native ONNX path reports none either. `requests` counts
+successful embedding fetches; `tokens` sums their input token counts.
+`bySource` breaks totals down by `memory-capture`, `artifact-index`,
+`recall`, `dreaming`, and `other`; `byProvider` breaks them down by the
+provider that actually served (`ollama`, `llama-cpp`, `native`, `openai` —
+the native fallback chain reports the real serving provider). The block is
+omitted when the table does not exist (pre-migration database).
 
 The `bypassedSessions` field reports how many active sessions currently have
 bypass enabled (see [Sessions and hooks API](./sessions-hooks.md#sessions)).

--- a/platform/core/src/migrations/108-embedding-usage.ts
+++ b/platform/core/src/migrations/108-embedding-usage.ts
@@ -1,0 +1,31 @@
+import type { MigrationDb } from "./index";
+
+/**
+ * Migration 108: daily-aggregate embedding token usage.
+ *
+ * Every embedding fetch through the shared boundary (Ollama, native ONNX,
+ * llama.cpp, OpenAI-compatible) records the token count of the text actually
+ * sent, using the real tokenizer (countTokens) rather than provider-reported
+ * usage (Ollama's /api/embeddings returns none). Rows aggregate by
+ * (day, agent_id, source_kind, provider) so the table stays bounded (one row
+ * per day per dimension) while still answering "how much did vault ingest
+ * cost in tokens vs. captures" and "Ollama/native throughput" questions.
+ *
+ * `agent_id` defaults to '' when the fetch boundary had no agent context
+ * (a real identity is never substituted with "default"). `requests` counts
+ * successful embedding fetches; `tokens` sums the tokenizer count of the
+ * text sent to the provider.
+ */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS embedding_usage (
+			day TEXT NOT NULL,
+			agent_id TEXT NOT NULL DEFAULT '',
+			source_kind TEXT NOT NULL,
+			provider TEXT NOT NULL,
+			requests INTEGER NOT NULL DEFAULT 0,
+			tokens INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (day, agent_id, source_kind, provider)
+		);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -113,6 +113,7 @@ import { up as derivedMemoryProvenance } from "./104-derived-memory-provenance";
 import { up as agentScopedEntityName } from "./105-agent-scoped-entity-name";
 import { up as memoryReviewAfter } from "./106-memory-review-after";
 import { up as dreamingPassUsage } from "./107-dreaming-pass-usage";
+import { up as embeddingUsage } from "./108-embedding-usage";
 
 // -- Public interface consumed by Database.init() --
 
@@ -999,6 +1000,14 @@ export const MIGRATIONS: readonly Migration[] = [
 				{ table: "dreaming_passes", column: "tokens_cache_write" },
 				{ table: "dreaming_passes", column: "tokens_cost" },
 			],
+		},
+	},
+	{
+		version: 108,
+		name: "embedding-usage",
+		up: embeddingUsage,
+		artifacts: {
+			tables: ["embedding_usage"],
 		},
 	},
 ];

--- a/platform/daemon/src/embedding-fetch.ts
+++ b/platform/daemon/src/embedding-fetch.ts
@@ -1,6 +1,7 @@
 import { getDbAccessor, hasDbAccessor } from "./db-accessor";
 import { resolveActiveEmbeddingConfig } from "./embedding-index-state";
 import { type EmbeddingRole, formatEmbeddingInput } from "./embedding-profile";
+import { type EmbeddingUsageAttribution, recordEmbeddingUsage } from "./embedding-usage";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
 import {
@@ -52,6 +53,7 @@ type NativeFallbackProbeResult = {
 	readonly provider: NativeFallbackProvider | "unavailable";
 	readonly model: LlamaCppEmbeddingModel | null;
 	readonly embedding: number[] | null;
+	readonly tokenCount: number;
 };
 type NativeFallbackProbe = {
 	readonly promise: Promise<NativeFallbackProbeResult>;
@@ -71,9 +73,11 @@ export function setNativeEmbeddingProviderForTest(provider: ((text: string) => P
 	cachedNativeEmbed = provider;
 }
 
-type EmbeddingFetchOptions = {
+export type EmbeddingFetchOptions = {
 	readonly signal?: AbortSignal;
 	readonly timeoutMs?: number;
+	/** Optional usage attribution recorded with the fetch (source_kind, agent). */
+	readonly usage?: EmbeddingUsageAttribution;
 };
 
 function resolveEmbeddingTimeoutMs(opts: EmbeddingFetchOptions, fallback: number): number {
@@ -127,7 +131,7 @@ async function fetchOllamaEmbedding(
 	baseUrl: string,
 	model: string,
 	opts: EmbeddingFetchOptions = {},
-): Promise<number[] | null> {
+): Promise<{ readonly embedding: number[] | null; readonly tokenCount: number }> {
 	const res = await fetchWithEmbeddingTimeout(
 		`${baseUrl.replace(/\/$/, "")}/api/embeddings`,
 		{
@@ -143,20 +147,21 @@ async function fetchOllamaEmbedding(
 			status: res.status,
 			model,
 		});
-		return null;
+		return { embedding: null, tokenCount: countTokens(text) };
 	}
 	const data = (await res.json()) as { embedding: number[] };
-	return data.embedding ?? null;
+	return { embedding: data.embedding ?? null, tokenCount: countTokens(text) };
 }
 
-function boundLlamaCppEmbeddingInput(text: string, maxInputTokens: number): string {
+function boundLlamaCppEmbeddingInput(text: string, maxInputTokens: number): { text: string; tokenCount: number } {
 	const tokenCount = countTokens(text);
-	if (tokenCount <= maxInputTokens) return text;
+	if (tokenCount <= maxInputTokens) return { text, tokenCount };
 	logger.warn("embedding", "Truncating llama.cpp embedding input to physical-batch safety limit", {
 		inputTokens: tokenCount,
 		maxInputTokens,
 	});
-	return truncateToTokens(text, maxInputTokens);
+	const bounded = truncateToTokens(text, maxInputTokens);
+	return { text: bounded, tokenCount: countTokens(bounded) };
 }
 
 async function fetchLlamaCppEmbedding(
@@ -166,13 +171,14 @@ async function fetchLlamaCppEmbedding(
 	opts: EmbeddingFetchOptions,
 	timeoutMs: number,
 	maxInputTokens = DEFAULT_LLAMACPP_MAX_INPUT_TOKENS,
-): Promise<number[] | null> {
+): Promise<{ readonly embedding: number[] | null; readonly tokenCount: number }> {
+	const bounded = boundLlamaCppEmbeddingInput(text, maxInputTokens);
 	const res = await fetchWithEmbeddingTimeout(
 		`${baseUrl.replace(/\/$/, "")}/v1/embeddings`,
 		{
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ input: boundLlamaCppEmbeddingInput(text, maxInputTokens), model }),
+			body: JSON.stringify({ input: bounded.text, model }),
 		},
 		opts,
 		resolveEmbeddingTimeoutMs(opts, timeoutMs),
@@ -182,11 +188,17 @@ async function fetchLlamaCppEmbedding(
 			status: res.status,
 			model,
 		});
-		return null;
+		return { embedding: null, tokenCount: bounded.tokenCount };
 	}
 	const data = (await res.json()) as { data?: Array<{ embedding: number[] }> };
-	return data.data?.[0]?.embedding ?? null;
+	return { embedding: data.data?.[0]?.embedding ?? null, tokenCount: bounded.tokenCount };
 }
+
+type EmbeddingServeResult = {
+	readonly embedding: number[] | null;
+	readonly provider: string | null;
+	readonly tokenCount: number;
+};
 
 async function fetchNativeFallback(
 	provider: NativeFallbackProvider,
@@ -194,11 +206,12 @@ async function fetchNativeFallback(
 	cfg: EmbeddingConfig,
 	opts: EmbeddingFetchOptions,
 	model: LlamaCppEmbeddingModel | null = nativeFallbackModel,
-): Promise<number[] | null> {
+): Promise<EmbeddingServeResult> {
 	if (provider === "ollama") {
-		return fetchOllamaEmbedding(text, resolveOllamaUrl(), "nomic-embed-text", opts);
+		const r = await fetchOllamaEmbedding(text, resolveOllamaUrl(), "nomic-embed-text", opts);
+		return { embedding: r.embedding, provider: "ollama", tokenCount: r.tokenCount };
 	}
-	return fetchLlamaCppEmbedding(
+	const r = await fetchLlamaCppEmbedding(
 		text,
 		DEFAULT_LLAMACPP_BASE_URL,
 		model ?? "nomic-embed-text",
@@ -206,6 +219,7 @@ async function fetchNativeFallback(
 		5000,
 		cfg.llamaCppMaxInputTokens,
 	);
+	return { embedding: r.embedding, provider: "llama-cpp", tokenCount: r.tokenCount };
 }
 
 async function probeNativeFallback(
@@ -215,7 +229,7 @@ async function probeNativeFallback(
 ): Promise<NativeFallbackProbeResult> {
 	const discoveredModel = await findLlamaCppEmbeddingModel();
 	if (discoveredModel) {
-		const embedding = await fetchLlamaCppEmbedding(
+		const r = await fetchLlamaCppEmbedding(
 			text,
 			DEFAULT_LLAMACPP_BASE_URL,
 			discoveredModel,
@@ -223,21 +237,21 @@ async function probeNativeFallback(
 			5000,
 			cfg.llamaCppMaxInputTokens,
 		);
-		if (embedding) {
-			return { provider: "llama-cpp", model: discoveredModel, embedding };
+		if (r.embedding) {
+			return { provider: "llama-cpp", model: discoveredModel, embedding: r.embedding, tokenCount: r.tokenCount };
 		}
 	}
 
 	try {
-		const embedding = await fetchOllamaEmbedding(text, resolveOllamaUrl(), "nomic-embed-text", opts);
-		if (embedding) {
-			return { provider: "ollama", model: null, embedding };
+		const r = await fetchOllamaEmbedding(text, resolveOllamaUrl(), "nomic-embed-text", opts);
+		if (r.embedding) {
+			return { provider: "ollama", model: null, embedding: r.embedding, tokenCount: r.tokenCount };
 		}
 	} catch {
 		// The aggregate warning below is the single actionable diagnostic.
 	}
 
-	return { provider: "unavailable", model: null, embedding: null };
+	return { provider: "unavailable", model: null, embedding: null, tokenCount: 0 };
 }
 
 async function resolveNativeFallback(
@@ -245,15 +259,15 @@ async function resolveNativeFallback(
 	cfg: EmbeddingConfig,
 	opts: EmbeddingFetchOptions,
 	nativeError: string,
-): Promise<number[] | null> {
-	if (nativeFallbackProvider === "unavailable") return null;
+): Promise<EmbeddingServeResult> {
+	if (nativeFallbackProvider === "unavailable") return { embedding: null, provider: null, tokenCount: 0 };
 	if (nativeFallbackProvider) return fetchNativeFallback(nativeFallbackProvider, text, cfg, opts);
 
 	if (nativeFallbackProbe) {
 		const result = await nativeFallbackProbe.promise;
 		return result.provider !== "unavailable"
 			? fetchNativeFallback(result.provider, text, cfg, opts, result.model)
-			: null;
+			: { embedding: null, provider: null, tokenCount: 0 };
 	}
 
 	logger.warn("embedding", `Native embedding failed, probing local fallbacks: ${nativeError}`);
@@ -279,7 +293,11 @@ async function resolveNativeFallback(
 				});
 			}
 		}
-		return result.embedding;
+		return {
+			embedding: result.embedding,
+			provider: result.provider === "unavailable" ? null : result.provider,
+			tokenCount: result.tokenCount,
+		};
 	} finally {
 		if (nativeFallbackProbe === probe) nativeFallbackProbe = null;
 	}
@@ -348,82 +366,16 @@ export async function fetchEmbedding(
 	const opts = typeof roleOrOpts === "string" ? (typeof optsOrRole === "string" ? {} : optsOrRole) : roleOrOpts;
 	const formattedText = formatEmbeddingInput(text, effectiveCfg, role);
 	try {
-		if (effectiveCfg.provider === "native") {
-			// Kill-switch (#1073): warmNative: false means native is never
-			// warmed or routed to, even when the active embedding profile is
-			// native. Fall through to the llama.cpp/ollama fallback chain.
-			if (effectiveCfg.warmNative === false) {
-				return resolveNativeFallback(
-					formattedText,
-					effectiveCfg,
-					opts,
-					"native embedding disabled (embedding.warmNative: false)",
-				);
-			}
-			if (nativeFallbackProvider === "unavailable") return null;
-			if (nativeFallbackProvider) return fetchNativeFallback(nativeFallbackProvider, formattedText, effectiveCfg, opts);
-			try {
-				if (!cachedNativeEmbed) {
-					const mod = await import("./native-embedding");
-					cachedNativeEmbed = mod.nativeEmbed;
-				}
-				return await cachedNativeEmbed(formattedText);
-			} catch (nativeErr) {
-				return resolveNativeFallback(
-					formattedText,
-					effectiveCfg,
-					opts,
-					nativeErr instanceof Error ? nativeErr.message : String(nativeErr),
-				);
-			}
-		}
-		if (effectiveCfg.provider === "ollama") {
-			return await fetchOllamaEmbedding(formattedText, effectiveCfg.base_url, effectiveCfg.model, opts);
-		}
-
-		if (effectiveCfg.provider === "llama-cpp") {
-			const baseUrl = effectiveCfg.base_url.trim() || DEFAULT_LLAMACPP_BASE_URL;
-			return fetchLlamaCppEmbedding(
-				formattedText,
-				baseUrl,
-				effectiveCfg.model,
-				opts,
-				30000,
-				effectiveCfg.llamaCppMaxInputTokens,
-			);
-		}
-
-		const apiKey = await resolveEmbeddingApiKey(effectiveCfg.api_key);
-		const baseUrl = resolveEmbeddingBaseUrl(effectiveCfg);
-		if (!apiKey && requiresOpenAiApiKey(baseUrl)) {
-			logger.warn("embedding", "No API key configured for OpenAI embeddings, skipping request to api.openai.com");
-			return null;
-		}
-		const res = await fetchWithEmbeddingTimeout(
-			`${baseUrl.replace(/\/$/, "")}/embeddings`,
-			{
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-					...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
-				},
-				body: JSON.stringify({ model: effectiveCfg.model, input: formattedText }),
-			},
-			opts,
-			resolveEmbeddingTimeoutMs(opts, 30000),
-		);
-		if (!res.ok) {
-			logger.warn("embedding", "Embedding API request failed", {
-				status: res.status,
-				provider: effectiveCfg.provider,
-				model: effectiveCfg.model,
+		const serve = await serveEmbedding(formattedText, effectiveCfg, opts);
+		if (serve.embedding !== null && serve.provider !== null) {
+			recordEmbeddingUsage({
+				provider: serve.provider,
+				tokens: serve.tokenCount,
+				source: opts.usage?.source ?? "other",
+				agentId: opts.usage?.agentId,
 			});
-			return null;
 		}
-		const data = (await res.json()) as {
-			data: Array<{ embedding: number[] }>;
-		};
-		return data.data?.[0]?.embedding ?? null;
+		return serve.embedding;
 	} catch (e) {
 		logger.warn("embedding", "Embedding fetch error", {
 			provider: effectiveCfg.provider,
@@ -432,4 +384,101 @@ export async function fetchEmbedding(
 		});
 		return null;
 	}
+}
+
+/**
+ * Dispatch a formatted embedding request to the effective provider and report
+ * which provider actually served and how many tokens the sent text carried.
+ * The fallback chain (native -> llama.cpp/ollama) resolves the serving
+ * provider inside, so the boundary records the true provider rather than the
+ * configured one.
+ */
+async function serveEmbedding(
+	formattedText: string,
+	effectiveCfg: EmbeddingConfig,
+	opts: EmbeddingFetchOptions,
+): Promise<EmbeddingServeResult> {
+	if (effectiveCfg.provider === "native") {
+		// Kill-switch (#1073): warmNative: false means native is never
+		// warmed or routed to, even when the active embedding profile is
+		// native. Fall through to the llama.cpp/ollama fallback chain.
+		if (effectiveCfg.warmNative === false) {
+			return resolveNativeFallback(
+				formattedText,
+				effectiveCfg,
+				opts,
+				"native embedding disabled (embedding.warmNative: false)",
+			);
+		}
+		if (nativeFallbackProvider === "unavailable") return { embedding: null, provider: null, tokenCount: 0 };
+		if (nativeFallbackProvider) return fetchNativeFallback(nativeFallbackProvider, formattedText, effectiveCfg, opts);
+		try {
+			if (!cachedNativeEmbed) {
+				const mod = await import("./native-embedding");
+				cachedNativeEmbed = mod.nativeEmbed;
+			}
+			const embedding = await cachedNativeEmbed(formattedText);
+			return { embedding, provider: "native", tokenCount: countTokens(formattedText) };
+		} catch (nativeErr) {
+			return resolveNativeFallback(
+				formattedText,
+				effectiveCfg,
+				opts,
+				nativeErr instanceof Error ? nativeErr.message : String(nativeErr),
+			);
+		}
+	}
+	if (effectiveCfg.provider === "ollama") {
+		const r = await fetchOllamaEmbedding(formattedText, effectiveCfg.base_url, effectiveCfg.model, opts);
+		return { embedding: r.embedding, provider: "ollama", tokenCount: r.tokenCount };
+	}
+
+	if (effectiveCfg.provider === "llama-cpp") {
+		const baseUrl = effectiveCfg.base_url.trim() || DEFAULT_LLAMACPP_BASE_URL;
+		const r = await fetchLlamaCppEmbedding(
+			formattedText,
+			baseUrl,
+			effectiveCfg.model,
+			opts,
+			30000,
+			effectiveCfg.llamaCppMaxInputTokens,
+		);
+		return { embedding: r.embedding, provider: "llama-cpp", tokenCount: r.tokenCount };
+	}
+
+	const apiKey = await resolveEmbeddingApiKey(effectiveCfg.api_key);
+	const baseUrl = resolveEmbeddingBaseUrl(effectiveCfg);
+	if (!apiKey && requiresOpenAiApiKey(baseUrl)) {
+		logger.warn("embedding", "No API key configured for OpenAI embeddings, skipping request to api.openai.com");
+		return { embedding: null, provider: effectiveCfg.provider, tokenCount: countTokens(formattedText) };
+	}
+	const res = await fetchWithEmbeddingTimeout(
+		`${baseUrl.replace(/\/$/, "")}/embeddings`,
+		{
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+			},
+			body: JSON.stringify({ model: effectiveCfg.model, input: formattedText }),
+		},
+		opts,
+		resolveEmbeddingTimeoutMs(opts, 30000),
+	);
+	if (!res.ok) {
+		logger.warn("embedding", "Embedding API request failed", {
+			status: res.status,
+			provider: effectiveCfg.provider,
+			model: effectiveCfg.model,
+		});
+		return { embedding: null, provider: effectiveCfg.provider, tokenCount: countTokens(formattedText) };
+	}
+	const data = (await res.json()) as {
+		data: Array<{ embedding: number[] }>;
+	};
+	return {
+		embedding: data.data?.[0]?.embedding ?? null,
+		provider: effectiveCfg.provider,
+		tokenCount: countTokens(formattedText),
+	};
 }

--- a/platform/daemon/src/embedding-index-migration.ts
+++ b/platform/daemon/src/embedding-index-migration.ts
@@ -1,12 +1,14 @@
 import { randomUUID } from "node:crypto";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import { vectorToBlob } from "./db-helpers";
+import type { EmbeddingFetchOptions } from "./embedding-fetch";
 import {
 	type EmbeddingIndexState,
 	type PersistedEmbeddingProfile,
 	readEmbeddingIndexState,
 } from "./embedding-index-state";
 import { beginEmbeddingIndexBuild, failEmbeddingIndexBuild } from "./embedding-index-state";
+import type { EmbeddingRole } from "./embedding-profile";
 import type { EmbeddingConfig } from "./memory-config";
 
 const STAGING_VECTOR_TABLE = "vec_embeddings_staging";
@@ -158,7 +160,12 @@ function pruneStagingRows(accessor: DbAccessor): void {
 export async function stageEmbeddingBatch(input: {
 	readonly accessor: DbAccessor;
 	readonly configured: EmbeddingConfig;
-	readonly fetchEmbedding: (text: string, cfg: EmbeddingConfig, role?: "document") => Promise<number[] | null>;
+	readonly fetchEmbedding: (
+		text: string,
+		cfg: EmbeddingConfig,
+		role?: EmbeddingRole,
+		opts?: EmbeddingFetchOptions,
+	) => Promise<number[] | null>;
 	readonly batchSize: number;
 }): Promise<{ staged: number; coverage: EmbeddingMigrationCoverage | null }> {
 	const state = input.accessor.withReadDb((db) => readEmbeddingIndexState(db));
@@ -184,7 +191,9 @@ export async function stageEmbeddingBatch(input: {
 
 	let staged = 0;
 	for (const row of rows) {
-		const vector = await input.fetchEmbedding(row.chunk_text, configForProfile(profile, input.configured), "document");
+		const vector = await input.fetchEmbedding(row.chunk_text, configForProfile(profile, input.configured), "document", {
+			usage: { source: "artifact-index", agentId: row.agent_id ?? undefined },
+		});
 		if (!vector) continue;
 		if (vector.length !== profile.dimensions) {
 			throw new Error(
@@ -280,7 +289,12 @@ export function promoteStagingIndex(accessor: DbAccessor): boolean {
 export function startEmbeddingIndexMigration(input: {
 	readonly accessor: DbAccessor;
 	readonly configured: EmbeddingConfig;
-	readonly fetchEmbedding: (text: string, cfg: EmbeddingConfig, role?: "document") => Promise<number[] | null>;
+	readonly fetchEmbedding: (
+		text: string,
+		cfg: EmbeddingConfig,
+		role?: EmbeddingRole,
+		opts?: EmbeddingFetchOptions,
+	) => Promise<number[] | null>;
 	readonly checkProvider: (cfg: EmbeddingConfig) => Promise<{ available: boolean }>;
 	readonly pollMs: number;
 	readonly batchSize: number;

--- a/platform/daemon/src/embedding-usage.ts
+++ b/platform/daemon/src/embedding-usage.ts
@@ -1,0 +1,126 @@
+/**
+ * Embedding token usage accounting.
+ *
+ * The shared embedding-fetch boundary records every successful embedding
+ * fetch into the `embedding_usage` daily-aggregate table (migration 108).
+ * The count comes from the real tokenizer (countTokens) applied to the text
+ * actually sent to the provider — never provider-reported usage, because
+ * Ollama's /api/embeddings returns none and the native ONNX path reports
+ * none either.
+ *
+ * Rows are keyed by (day, agent_id, source_kind, provider) and accumulate
+ * `requests` + `tokens`, keeping the table bounded at one row per day per
+ * dimension while still answering "how much did vault ingest cost in tokens
+ * vs. captures" and "what is Ollama/native throughput".
+ *
+ * Recording is strictly best-effort: it must never fail or slow down the
+ * embedding path it observes.
+ */
+
+import type { DbAccessor } from "./db-accessor";
+import { getDbAccessor, hasDbAccessor } from "./db-accessor";
+import { logger } from "./logger";
+
+/** What produced the embedding. Used for per-source cost attribution. */
+export type EmbeddingUsageSource = "memory-capture" | "artifact-index" | "recall" | "dreaming" | "other";
+
+export interface EmbeddingUsageAttribution {
+	readonly source?: EmbeddingUsageSource;
+	readonly agentId?: string;
+}
+
+interface EmbeddingUsageRow {
+	readonly day: string;
+	readonly agent_id: string;
+	readonly source_kind: string;
+	readonly provider: string;
+	readonly requests: number;
+	readonly tokens: number;
+}
+
+/** UTC day key, matching the ISO timestamps used across the daemon. */
+function todayKey(now: Date = new Date()): string {
+	return now.toISOString().slice(0, 10);
+}
+
+const UPSERT_SQL = `
+	INSERT INTO embedding_usage (day, agent_id, source_kind, provider, requests, tokens)
+	VALUES (?, ?, ?, ?, 1, ?)
+	ON CONFLICT(day, agent_id, source_kind, provider)
+	DO UPDATE SET requests = requests + 1, tokens = tokens + excluded.tokens
+`;
+
+/**
+ * Record one successful embedding fetch. Best-effort: a DB failure is logged
+ * and swallowed so the embedding result is never affected. Skips silently
+ * when no daemon DB accessor is initialised (isolated migration worker,
+ * tests).
+ */
+export function recordEmbeddingUsage(input: {
+	readonly provider: string;
+	readonly tokens: number;
+	readonly source: EmbeddingUsageSource;
+	readonly agentId?: string;
+	readonly now?: Date;
+}): void {
+	if (!hasDbAccessor()) return;
+	try {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(UPSERT_SQL).run(todayKey(input.now), input.agentId ?? "", input.source, input.provider, input.tokens);
+		});
+	} catch (e) {
+		logger.warn("embedding", "Failed to record embedding usage", {
+			error: e instanceof Error ? e.message : String(e),
+		});
+	}
+}
+
+export interface EmbeddingUsageSummary {
+	readonly total: { readonly requests: number; readonly tokens: number };
+	readonly today: { readonly requests: number; readonly tokens: number };
+	readonly bySource: ReadonlyArray<{ readonly source: string; readonly requests: number; readonly tokens: number }>;
+	readonly byProvider: ReadonlyArray<{ readonly provider: string; readonly requests: number; readonly tokens: number }>;
+}
+
+/**
+ * Aggregate the daily table into totals, today's totals, and per-source /
+ * per-provider breakdowns for /api/status. Returns null when the table is
+ * absent (pre-migration database) or the DB is unavailable.
+ */
+export function readEmbeddingUsageSummary(accessor: DbAccessor, now: Date = new Date()): EmbeddingUsageSummary | null {
+	try {
+		return accessor.withReadDb((db) => {
+			const day = todayKey(now);
+			const totals = db
+				.prepare(
+					"SELECT COALESCE(SUM(requests), 0) AS requests, COALESCE(SUM(tokens), 0) AS tokens FROM embedding_usage",
+				)
+				.get() as { requests: number; tokens: number };
+			const today = db
+				.prepare(
+					"SELECT COALESCE(SUM(requests), 0) AS requests, COALESCE(SUM(tokens), 0) AS tokens FROM embedding_usage WHERE day = ?",
+				)
+				.get(day) as { requests: number; tokens: number };
+			const bySource = db
+				.prepare(
+					`SELECT source_kind AS source, SUM(requests) AS requests, SUM(tokens) AS tokens
+					 FROM embedding_usage GROUP BY source_kind ORDER BY tokens DESC`,
+				)
+				.all() as Array<{ source: string; requests: number; tokens: number }>;
+			const byProvider = db
+				.prepare(
+					`SELECT provider, SUM(requests) AS requests, SUM(tokens) AS tokens
+					 FROM embedding_usage GROUP BY provider ORDER BY tokens DESC`,
+				)
+				.all() as Array<{ provider: string; requests: number; tokens: number }>;
+			return { total: totals, today, bySource, byProvider };
+		});
+	} catch (e) {
+		logger.warn("embedding", "Failed to read embedding usage summary", {
+			error: e instanceof Error ? e.message : String(e),
+		});
+		return null;
+	}
+}
+
+export type { EmbeddingUsageRow };

--- a/platform/daemon/src/obsidian-source-embeddings.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.ts
@@ -4,14 +4,21 @@ import { LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE, SOURCE_CHUNK_SOURCE_TYPE } from "@si
 import { yieldEvery } from "./async-yield";
 import { getDbAccessor } from "./db-accessor";
 import { syncVecDeleteByEmbeddingIds, syncVecInsert, vectorToBlob } from "./db-helpers";
+import type { EmbeddingFetchOptions } from "./embedding-fetch";
 import { isActiveEmbeddingConfig, resolveActiveEmbeddingConfig } from "./embedding-index-state";
+import type { EmbeddingRole } from "./embedding-profile";
 import type { EmbeddingConfig } from "./memory-config";
 
 export const OBSIDIAN_CHUNK_SOURCE_TYPE = SOURCE_CHUNK_SOURCE_TYPE;
 const OBSIDIAN_SOURCE_CHUNK_DELAY_MS = 100;
 const OBSIDIAN_CHUNK_SOURCE_TYPES = [SOURCE_CHUNK_SOURCE_TYPE, LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE] as const;
 
-export type SourceEmbeddingFetch = (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>;
+export type SourceEmbeddingFetch = (
+	text: string,
+	cfg: EmbeddingConfig,
+	role?: EmbeddingRole,
+	opts?: EmbeddingFetchOptions,
+) => Promise<number[] | null>;
 
 export interface ObsidianSourceChunk {
 	readonly id: string;
@@ -251,7 +258,9 @@ export async function indexObsidianSourceEmbeddings(
 		let stored = false;
 		for (let attempt = 0; attempt < 2 && !stored; attempt += 1) {
 			const writeConfig = getDbAccessor().withReadDb((db) => resolveActiveEmbeddingConfig(db, input.embeddingConfig));
-			const vector = await input.fetchEmbedding(chunk.chunkText, writeConfig);
+			const vector = await input.fetchEmbedding(chunk.chunkText, writeConfig, "document", {
+				usage: { source: "artifact-index", agentId: input.agentId },
+			});
 			if (!vector || vector.length === 0) break;
 			stored = getDbAccessor().withWriteTx((db) => {
 				// Recheck after the asynchronous provider call: promotion may have

--- a/platform/daemon/src/pipeline/document-worker.ts
+++ b/platform/daemon/src/pipeline/document-worker.ts
@@ -12,7 +12,9 @@
 import { normalizeAndHashContent } from "../content-normalization";
 import type { DbAccessor, WriteDb } from "../db-accessor";
 import { syncVecInsert, vectorToBlob } from "../db-helpers";
+import type { EmbeddingFetchOptions } from "../embedding-fetch";
 import { isActiveEmbeddingConfig } from "../embedding-index-state";
+import type { EmbeddingRole } from "../embedding-profile";
 import { logger } from "../logger";
 import type { EmbeddingConfig, PipelineV2Config } from "../memory-config";
 import { isSystemPressureHigh } from "../system-pressure";
@@ -31,7 +33,12 @@ export interface DocumentWorkerHandle {
 export interface DocumentWorkerDeps {
 	readonly accessor: DbAccessor;
 	readonly embeddingCfg: EmbeddingConfig;
-	readonly fetchEmbedding: (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>;
+	readonly fetchEmbedding: (
+		text: string,
+		cfg: EmbeddingConfig,
+		role?: EmbeddingRole,
+		opts?: EmbeddingFetchOptions,
+	) => Promise<number[] | null>;
 	readonly pipelineCfg: PipelineV2Config;
 }
 
@@ -300,7 +307,9 @@ async function processDocument(deps: DocumentWorkerDeps, job: DocumentJobRow): P
 		if (!chunkText || chunkText.trim().length === 0) continue;
 
 		// Embedding call is outside write lock
-		const vector = await fetchEmbedding(chunkText, embeddingCfg);
+		const vector = await fetchEmbedding(chunkText, embeddingCfg, "document", {
+			usage: { source: "artifact-index", agentId: documentScope.agentId },
+		});
 
 		// Each chunk's memory creation in its own transaction
 		accessor.withWriteTx((db) => {

--- a/platform/daemon/src/pipeline/skill-graph.ts
+++ b/platform/daemon/src/pipeline/skill-graph.ts
@@ -18,7 +18,9 @@
 import { createHash } from "node:crypto";
 import type { DbAccessor } from "../db-accessor";
 import { syncVecDeleteByEmbeddingIds, syncVecInsert, vectorToBlob } from "../db-helpers";
+import type { EmbeddingFetchOptions } from "../embedding-fetch";
 import { isActiveEmbeddingConfig, resolveActiveEmbeddingConfig } from "../embedding-index-state";
+import type { EmbeddingRole } from "../embedding-profile";
 import { logger } from "../logger";
 import type { EmbeddingConfig, PipelineV2Config } from "../memory-config";
 
@@ -152,7 +154,12 @@ export async function installSkillNode(
 	accessor: DbAccessor,
 	config: PipelineV2Config,
 	embeddingCfg: EmbeddingConfig,
-	fetchEmbedding: (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>,
+	fetchEmbedding: (
+		text: string,
+		cfg: EmbeddingConfig,
+		role?: EmbeddingRole,
+		opts?: EmbeddingFetchOptions,
+	) => Promise<number[] | null>,
 ): Promise<SkillInstallResult> {
 	const agentId = input.agentId ?? "default";
 	let entityId = skillEntityId(agentId, input.frontmatter.name);
@@ -280,7 +287,9 @@ export async function installSkillNode(
 	let embeddingCreated = false;
 	const embeddingText = buildEmbeddingText(fm);
 	const writeConfig = accessor.withReadDb((db) => resolveActiveEmbeddingConfig(db, embeddingCfg));
-	const embVec = await fetchEmbedding(embeddingText, writeConfig);
+	const embVec = await fetchEmbedding(embeddingText, writeConfig, "document", {
+		usage: { source: "artifact-index", agentId },
+	});
 
 	if (embVec && embVec.length > 0) {
 		const embId = crypto.randomUUID();

--- a/platform/daemon/src/prompt-entity-context.ts
+++ b/platform/daemon/src/prompt-entity-context.ts
@@ -2,12 +2,18 @@ import { existsSync } from "node:fs";
 import { cosineSimilarity } from "@signet/core";
 import { selectWithBudgetSkippingOversized } from "./context-budget";
 import { type ReadDb, getDbAccessor, hasDbAccessor } from "./db-accessor";
+import type { EmbeddingFetchOptions } from "./embedding-fetch";
 import type { EmbeddingRole } from "./embedding-profile";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
 import { countPromptTermOverlap, extractSubstantiveWords, stripUntrustedMetadata } from "./prompt-text";
 
-type FetchEmbedding = (text: string, cfg: EmbeddingConfig, role?: EmbeddingRole) => Promise<number[] | null>;
+type FetchEmbedding = (
+	text: string,
+	cfg: EmbeddingConfig,
+	role?: EmbeddingRole,
+	opts?: EmbeddingFetchOptions,
+) => Promise<number[] | null>;
 
 type PromptEntityMatch = {
 	readonly entityId: string;
@@ -675,7 +681,9 @@ export async function buildEntityPromptContext({
 	// calls that multiply embedding latency by the match count (#1059).
 	let sharedQueryVector: Float32Array | null = null;
 	try {
-		const vector = await fetchEmbedding(sharedSemanticQuery, embedding, "query");
+		const vector = await fetchEmbedding(sharedSemanticQuery, embedding, "query", {
+			usage: { source: "recall", agentId },
+		});
 		if (vector) sharedQueryVector = new Float32Array(vector);
 	} catch (error) {
 		logger.warn("hooks", "Entity attribute semantic scoring failed; using lexical attribute scoring", {

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -21,6 +21,7 @@ import {
 } from "../cross-agent";
 import { getDbAccessor } from "../db-accessor";
 import { fetchEmbedding } from "../embedding-fetch";
+import type { EmbeddingRole } from "../embedding-profile";
 import {
 	type CheckpointExtractRequest,
 	type PreCompactionRequest,
@@ -41,7 +42,7 @@ import {
 } from "../hooks.js";
 import { getInferenceRouterOrNull } from "../inference-router";
 import { logger } from "../logger";
-import { loadMemoryConfig } from "../memory-config";
+import { type EmbeddingConfig, type ResolvedMemoryConfig, loadMemoryConfig } from "../memory-config";
 import { normalizeMarkdownBody, writeCompactionArtifact } from "../memory-lineage.js";
 import { type RecallParams, hybridRecall } from "../memory-search";
 import { getSynthesisWorker, readLastSynthesisTime } from "../pipeline";
@@ -780,9 +781,9 @@ function registerRecall(app: Hono): void {
 				body.aggregate === true
 					? await aggregateRecall(params, cfg, {
 							router: getInferenceRouterOrNull(),
-							embedFn: fetchEmbedding,
+							embedFn: recallAttributedEmbedFn(fetchEmbedding, agentId),
 						})
-					: await hybridRecall(params, cfg, fetchEmbedding);
+					: await hybridRecall(params, cfg, recallAttributedEmbedFn(fetchEmbedding, agentId));
 			return c.json(withHookRecallCompat(result));
 		} catch (e) {
 			logger.error("hooks", "Recall hook failed", e as Error);
@@ -1586,6 +1587,23 @@ function registerSynthesis(app: Hono): void {
 			config,
 		});
 	});
+}
+
+/**
+ * Wrap an embed function so embeddings produced during a recall hook are
+ * attributed to the recall source. Query-role embeddings (the search query
+ * vector) are "recall"; the document-role embed aggregateRecall performs on
+ * the synthesized aggregate memory content is a memory write, so it records
+ * as "memory-capture". Both carry the resolved agent id.
+ */
+function recallAttributedEmbedFn(
+	embedFn: typeof fetchEmbedding,
+	agentId: string,
+): (text: string, cfg: EmbeddingConfig, role?: EmbeddingRole) => Promise<number[] | null> {
+	return (text, cfg, role) =>
+		embedFn(text, cfg, role, {
+			usage: { source: role === "query" ? "recall" : "memory-capture", agentId },
+		});
 }
 
 export function registerHooksRoutes(app: Hono): void {

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -18,9 +18,10 @@ import {
 	readEmbeddingIndexState,
 	resolveActiveEmbeddingConfig,
 } from "../embedding-index-state";
+import type { EmbeddingRole } from "../embedding-profile";
 import { getInferenceRouterOrNull } from "../inference-router";
 import { logger } from "../logger";
-import { type ResolvedMemoryConfig, loadMemoryConfig } from "../memory-config";
+import { type EmbeddingConfig, type ResolvedMemoryConfig, loadMemoryConfig } from "../memory-config";
 import {
 	type RecallParams,
 	type RecallResponse,
@@ -531,6 +532,23 @@ function recordRecallQaTelemetry(input: {
 		response: input.result,
 		retentionDays: input.cfg.pipelineV2.telemetry.retentionDays,
 	});
+}
+
+/**
+ * Wrap an embed function so embeddings produced during a recall route are
+ * attributed to the recall source. Query-role embeddings (the search query
+ * vector) are "recall"; the document-role embed aggregateRecall performs on
+ * the synthesized aggregate memory content is a memory write, so it records
+ * as "memory-capture". Both carry the resolved agent id.
+ */
+function recallAttributedEmbedFn(
+	embedFn: typeof fetchEmbedding,
+	agentId: string,
+): (text: string, cfg: EmbeddingConfig, role?: EmbeddingRole) => Promise<number[] | null> {
+	return (text, cfg, role) =>
+		embedFn(text, cfg, role, {
+			usage: { source: role === "query" ? "recall" : "memory-capture", agentId },
+		});
 }
 
 function resolveAgentIdHint(input: { readonly agentId?: string; readonly sessionKey?: string }): string | undefined {
@@ -1447,7 +1465,9 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					const chunkId = savedChunkIds[chunkIndex];
 					// Generate embedding async
 					try {
-						const vec = await fetchEmbedding(plan.normalized.storageContent, fullCfg.embedding);
+						const vec = await fetchEmbedding(plan.normalized.storageContent, fullCfg.embedding, "document", {
+							usage: { source: "memory-capture", agentId },
+						});
 						if (vec) {
 							if (vec.length !== fullCfg.embedding.dimensions) {
 								logger.warn("memory", "Embedding dimension mismatch, skipping vector insert", {
@@ -1700,7 +1720,9 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		try {
 			const baseCfg = loadMemoryConfig(AGENTS_DIR);
 			const cfg = withActiveEmbeddingConfig(baseCfg);
-			const vec = await fetchEmbedding(normalizedContent.storageContent, cfg.embedding);
+			const vec = await fetchEmbedding(normalizedContent.storageContent, cfg.embedding, "document", {
+				usage: { source: "memory-capture", agentId },
+			});
 			if (vec) {
 				if (vec.length !== cfg.embedding.dimensions) {
 					logger.warn("memory", "Embedding dimension mismatch, skipping vector insert", {
@@ -2293,7 +2315,9 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 		let embeddingVector: number[] | null = null;
 		if (parsedPatch.value.contentForEmbedding !== null) {
-			embeddingVector = await fetchEmbedding(parsedPatch.value.contentForEmbedding, cfg.embedding);
+			embeddingVector = await fetchEmbedding(parsedPatch.value.contentForEmbedding, cfg.embedding, "document", {
+				usage: { source: "memory-capture" },
+			});
 		}
 
 		const now = new Date().toISOString();
@@ -2910,7 +2934,9 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 			let embeddingVector: number[] | null = null;
 			if (parsedPatch.value.contentForEmbedding !== null) {
-				embeddingVector = await fetchEmbedding(parsedPatch.value.contentForEmbedding, cfg.embedding);
+				embeddingVector = await fetchEmbedding(parsedPatch.value.contentForEmbedding, cfg.embedding, "document", {
+					usage: { source: "memory-capture" },
+				});
 			}
 
 			const txResult = getDbAccessor().withWriteTx((db) =>
@@ -3036,9 +3062,9 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				body.aggregate === true
 					? await aggregateRecallFn(params, cfg, {
 							router: getInferenceRouterOrNullFn(),
-							embedFn: fetchEmbeddingFn,
+							embedFn: recallAttributedEmbedFn(fetchEmbeddingFn, agentId),
 						})
-					: await hybridRecallFn(params, cfg, fetchEmbeddingFn);
+					: await hybridRecallFn(params, cfg, recallAttributedEmbedFn(fetchEmbeddingFn, agentId));
 			recordRecallQaTelemetry({
 				route: "POST /api/memory/recall",
 				agentId,
@@ -3106,7 +3132,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				recallMode: "direct",
 				...(scopeProject ? { project: scopeProject } : {}),
 			};
-			const result = await hybridRecall(params, cfg, fetchEmbedding);
+			const result = await hybridRecall(params, cfg, recallAttributedEmbedFn(fetchEmbedding, agentId));
 			recordRecallQaTelemetry({
 				route: "GET /api/memory/search",
 				agentId,

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -6,6 +6,7 @@ import { resolveAgentId, resolveDaemonAgentId } from "../agent-id.js";
 import { requirePermission, requireRateLimit } from "../auth";
 import { getDbAccessor } from "../db-accessor.js";
 import { type QueueCounts, getQueueDiagnosticsSnapshot } from "../diagnostics-queue.js";
+import { readEmbeddingUsageSummary } from "../embedding-usage";
 import { getLlmProvider } from "../llm.js";
 import { graphWriteCaps, loadMemoryConfig } from "../memory-config.js";
 import {
@@ -320,6 +321,7 @@ export function registerPipelineRoutes(app: Hono): void {
 				...(cachedEmbeddingStatus && Date.now() - statusCacheTime < STATUS_CACHE_TTL
 					? { available: cachedEmbeddingStatus.available }
 					: {}),
+				usage: readEmbeddingUsageSummary(getDbAccessor()),
 			},
 		});
 	});


### PR DESCRIPTION
## Summary

Closes #1154. Embedding token usage was untracked: Ollama's `/api/embeddings` returns no `usage`, the native ONNX fallback reports none, and the vault watcher alone embedded 2,050+ artifacts invisibly. This PR records embedding token usage at the shared `fetchEmbedding` boundary — provider-agnostic, using the real tokenizer (`countTokens`) on the text actually sent — accumulates it in a bounded daily-aggregate table, and surfaces it in `/api/status` alongside the generation-side pass accounting from 0.168.0.

## Changes

- **Migration 108** (`@signet/core`): new `embedding_usage` daily-aggregate table keyed by `(day, agent_id, source_kind, provider)` with `requests` + `tokens` counters. Bounded (one row per day per dimension); `agent_id` defaults to `''` when the boundary had no agent context (a real identity is never substituted with `"default"`).
- **`embedding-usage.ts`** (`@signet/daemon`): `recordEmbeddingUsage` (best-effort upsert — DB failure logs and is swallowed so it can never break or fail the embedding fetch) and `readEmbeddingUsageSummary` (totals, today, per-source, per-provider; `null` when the table is absent).
- **`embedding-fetch.ts`**: `EmbeddingFetchOptions` gains optional `usage?: { source?, agentId? }`. The dispatch now goes through `serveEmbedding`, which returns the **actual serving provider** (the native→llama.cpp/ollama fallback chain reports the real provider, not `"native"`) and the tokenizer count of the text sent. The llama.cpp path reuses its existing cap-count pass (`boundLlamaCppEmbeddingInput` returns `{ text, tokenCount }`); no double-encode in the common path. Usage is recorded only on success (embedding non-null), defaulting to source `"other"` when unattributed.
- **Caller attribution**: memory capture/remember/claim-write paths → `memory-capture` (+`agentId` where in scope); recall routes (`POST /api/memory/recall`, `GET /api/memory/search`, hooks recall) wrap the embed fn so query embeds are `recall` and the aggregate-memory content embed is `memory-capture`; vault watcher, document worker, skill graph, index migration → `artifact-index`; prompt-entity-context → `recall`.
- **`/api/status`**: `embedding.usage` block (totals, today, bySource, byProvider). `docs/api/health-status.md` updated.

## Type

- [x] `feat` — new user-facing feature (bumps minor)

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`

## Screenshots

N/A — daemon/API change, no UI.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries (`embedding_usage.agent_id` is attribution metadata; summary is a daemon-level aggregate on the existing `/api/status` surface)
- [x] Input/config validation and bounds checks added (usage record is clamped to valid enum sources at the call sites; `tokens` is a non-negative tokenizer count)
- [x] Error handling and fallback paths tested (no silent swallow) (recording is best-effort by design — DB failure logs and is swallowed so the embedding fetch is never affected; verified live)
- [x] Security checks applied to admin/mutation endpoints (no new mutation/admin surface; `/api/status` read-only aggregate)
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix (no bug fix in this PR — telemetry feature; repo rule is evals-not-tests for features, verified with live scratch-DB experiment + adversarial review subagent)
- [x] Lint/typecheck/tests pass locally (206 focused tests; full daemon suite failure count identical to clean main: 50 pre-existing, 0 new)

## Migration Notes (if applicable)

- [x] Migration is idempotent (`CREATE TABLE IF NOT EXISTS`)
- [x] Rollback / compatibility note included in PR description (additive only — no existing data touched; rollback = drop the aggregate table, rebuildable from the fetch boundary)

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

## AI disclosure

- [x] AI tools were used (see `Assisted-by` tags in commits)