### PR TITLE
fix(daemon): guard Dreaming sweep against unhandled rejections; add memory_entity_mentions join index

### DIFF
--- a/platform/core/src/migrations/106-memory-mention-join-index.ts
+++ b/platform/core/src/migrations/106-memory-mention-join-index.ts
@@ -1,0 +1,23 @@
+import type { MigrationDb } from "./index";
+
+/**
+ * Migration 106: entity-side composite index for memory_entity_mentions.
+ *
+ * The knowledge graph `COUNT(DISTINCT mem.memory_id)` join in
+ * getKnowledgeStats drives from the entity/memory tables (a planner-chosen
+ * cross-product when only `(entity_id)` and the `(memory_id, entity_id)`
+ * PRIMARY KEY exist), turning a stats call over a few thousand entities into
+ * ~30M nested-loop point lookups — 9.4s on a 5.5K-entity install, and the
+ * dashboard polls this endpoint every few seconds (Signet-AI/signetai#1139-adjacent).
+ *
+ * The composite `(entity_id, memory_id)` index lets SQLite drive the join
+ * from the mentions table (or resolve `entity_id` lookups covering both
+ * columns): the same query drops to ~13ms. It also serves entity-side
+ * mention scans in graph-traversal and relinking paths.
+ */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_memory_entity_mentions_entity_memory
+			ON memory_entity_mentions(entity_id, memory_id);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -111,6 +111,7 @@ import { up as attributeSemanticMemories } from "./102-attribute-semantic-memori
 import { up as semanticMemoryKind } from "./103-semantic-memory-kind";
 import { up as derivedMemoryProvenance } from "./104-derived-memory-provenance";
 import { up as agentScopedEntityName } from "./105-agent-scoped-entity-name";
+import { up as memoryMentionJoinIndex } from "./106-memory-mention-join-index";
 
 // -- Public interface consumed by Database.init() --
 
@@ -976,6 +977,11 @@ export const MIGRATIONS: readonly Migration[] = [
 		version: 105,
 		name: "agent-scoped-entity-name",
 		up: agentScopedEntityName,
+	},
+	{
+		version: 106,
+		name: "memory-mention-join-index",
+		up: memoryMentionJoinIndex,
 	},
 ];
 

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -326,7 +326,18 @@ export function startDreamingWorker(
 		// directly otherwise.
 		const mode = selectDreamingCheckMode(accessor, scopes, nextScheduledFocus);
 		nextScheduledFocus = dreamingFocusOfMode(mode) ?? nextScheduledFocus;
-		await runPass(defaultAgentId, mode, undefined, scopes);
+		try {
+			await runPass(defaultAgentId, mode, undefined, scopes);
+		} catch (e) {
+			// runPass already records the failure in dreaming_state via
+			// recordDreamingFailure. The scheduled sweep must not let a failed
+			// pass propagate into the timer callback: an unhandled rejection
+			// would terminate the whole daemon (Bun exits on unhandled
+			// rejections), turning one bad inference call into a crash loop.
+			logger.error("dreaming-worker", "Dreaming pass failed during scheduled sweep", undefined, {
+				error: e instanceof Error ? e.message : String(e),
+			});
+		}
 	}
 
 	function schedule(): void {


### PR DESCRIPTION
Fixes two issues from this debugging session:

**#1157 — daemon crash-loop on failed Dreaming passes.** `dreaming-worker.ts` ran `await runPass(...)` unguarded inside the worker's timer callback; a failed pass became an unhandled promise rejection and Bun terminated the daemon (silent death, exit 1, launchd restart loop every 5 min). The sweep now catches and logs pass failures — the failure is already recorded in `dreaming_state` with its backoff.

**#1158 — /api/knowledge/stats 9.4s.** `getKnowledgeStats` drove a ~30M-iteration cross-product because `memory_entity_mentions` lacked a composite `(entity_id, memory_id)` index. Migration 106 adds it; the query drops 9.43s → 13ms, endpoint ~10.7s → 0.07s.

Also comments the same unhandled-rejection root cause on #1148.