### PR TITLE
perf(core): add memory_entity_mentions (entity_id, memory_id) join index (#1158)

### DIFF
--- a/platform/core/src/migrations/110-memory-mention-join-index.ts
+++ b/platform/core/src/migrations/110-memory-mention-join-index.ts
@@ -1,0 +1,24 @@
+import type { MigrationDb } from "./index";
+
+/**
+ * Migration 110: entity-side composite index for memory_entity_mentions.
+ *
+ * The knowledge-graph `COUNT(DISTINCT mem.memory_id)` join in
+ * getKnowledgeStats drives from the entity/memory tables when only the
+ * `(entity_id)` index and the `(memory_id, entity_id)` PRIMARY KEY exist,
+ * turning a stats call over a few thousand entities into a ~30M-iteration
+ * nested loop (9.4s on a 5.5K-entity install). The dashboard polls
+ * `/api/knowledge/stats` every few seconds, so each poll blocks the main
+ * thread (Signet-AI/signetai#1158).
+ *
+ * The composite `(entity_id, memory_id)` index lets SQLite drive the join
+ * from the mentions table and covers both columns; the same query drops to
+ * ~13ms. It also serves entity-side mention scans in graph-traversal and
+ * relinking paths.
+ */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_memory_entity_mentions_entity_memory
+			ON memory_entity_mentions(entity_id, memory_id);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -115,6 +115,7 @@ import { up as memoryReviewAfter } from "./106-memory-review-after";
 import { up as dreamingPassUsage } from "./107-dreaming-pass-usage";
 import { up as embeddingUsage } from "./108-embedding-usage";
 import { up as telemetryInstall } from "./109-telemetry-install";
+import { up as memoryMentionJoinIndex } from "./110-memory-mention-join-index";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1018,6 +1019,11 @@ export const MIGRATIONS: readonly Migration[] = [
 		artifacts: {
 			tables: ["telemetry_install"],
 		},
+	},
+	{
+		version: 110,
+		name: "memory-mention-join-index",
+		up: memoryMentionJoinIndex,
 	},
 ];
 

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -1815,4 +1815,17 @@ describe("migration framework", () => {
 			expect.arrayContaining(["evidence_window_json", "runbook_json"]),
 		);
 	});
+	test("migration 110 adds the memory_entity_mentions entity-side composite index (#1158)", () => {
+		db = createFreshDb();
+		runMigrations(db);
+
+		const indexes = db.query("PRAGMA index_list(memory_entity_mentions)").all() as Array<{ name: string }>;
+		expect(indexes.map((row) => row.name)).toContain("idx_memory_entity_mentions_entity_memory");
+
+		// The composite drives entity-side joins and covers both columns.
+		const columns = db.query("PRAGMA index_info(idx_memory_entity_mentions_entity_memory)").all() as Array<{
+			name: string;
+		}>;
+		expect(columns.map((row) => row.name)).toEqual(["entity_id", "memory_id"]);
+	});
 });


### PR DESCRIPTION
## Summary

Perf fix for `/api/knowledge/stats` (see #1158 for the full evidence): the
`COUNT(DISTINCT mem.memory_id)` join in `getKnowledgeStats` drove from the
entity/memory tables when `memory_entity_mentions` only had the `(entity_id)`
index and the `(memory_id, entity_id)` PRIMARY KEY — a ~30M-iteration nested
loop, 9.4s on a 5.5K-entity install. The dashboard polls this endpoint every
few seconds, blocking the main thread each time.

This branch now carries only that fix. The original companion fix (guarding
the Dreaming sweep against unhandled rejections, #1157) landed separately as
#1198 and is already on main.

## Changes

- `platform/core/src/migrations/110-memory-mention-join-index.ts` (+
  registration in `index.ts`) — `CREATE INDEX IF NOT EXISTS
  idx_memory_entity_mentions_entity_memory ON memory_entity_mentions(entity_id,
  memory_id)`.
- `platform/core/src/migrations/migrations.test.ts` — migration 110 test
  (index exists, covers both columns).

## Verification

- `bun test platform/core/src/migrations/migrations.test.ts` — 51/51 pass.
- `bunx biome check` on changed files — clean.
- `bun run --filter '@signet/core' typecheck` and `@signet/daemon` — pass.
- Live experiment on a scratch DB (12K memories, 33K mentions, 5.5K entities),
  same query as `getKnowledgeStats`:
  - Without the index: planner drives from `idx_memories_is_deleted`
    (memory-side), 14.9s.
  - With the index: planner drives from `entities` via the new covering
    index, 21.5ms (~690x).

## Type

- [x] `perf` — performance improvement

## Packages affected

- [x] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — perf fix;
      no spec surface changed. The new index is additive and covered by the
      migration test.
- [x] Agent scoping verified on all new/changed data queries — the new index
      is agent-agnostic (join acceleration); the existing queries' `agent_id`
      filters are unchanged.
- [x] Input/config validation and bounds checks added — N/A (no new inputs).
- [x] Error handling and fallback paths tested (no silent swallow) — N/A.
- [x] Security checks applied to admin/mutation endpoints — N/A (no endpoint
      changes).
- [x] Docs updated for API/spec/status changes — N/A (no API changes); the
      migration is documented in its file header.
- [x] Regression tests added for each bug fix — the migration test pins the
      index and its column coverage.
- [x] Lint/typecheck/tests pass locally — verified, see Verification.

## Migration Notes (if applicable)

- [x] Migration is idempotent — `CREATE INDEX IF NOT EXISTS`.
- [x] Rollback / compatibility note included in PR description — the index is
      additive; dropping it returns to the previous (slow) query plan with no
      data impact. No down migration needed.

## Testing

- [x] `bun test` passes — `migrations.test.ts` 51/51.
- [x] `bun run typecheck` passes — `@signet/core` and `@signet/daemon`.
- [x] `bun run lint` passes — `biome check` on all changed files.
- [x] Live perf experiment (see Verification) — same query, 14.9s -> 21.5ms
      on a representative scratch install; matches the #1158 evidence
      (10.7s -> 0.07s on the affected install).
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)
