### PR TITLE
fix(daemon): defer summary jobs when synthesis resolver uninitialised

### DIFF
--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -3589,8 +3589,16 @@ describe("handleCheckpointExtract", () => {
 
 describe("summary worker tick gate", () => {
 	test.serial(
-		"processes enqueued job when pipelineV2 is enabled",
+		"does not burn attempts when the synthesis resolver is uninitialised despite the router gate passing",
 		async () => {
+			// Regression (#1155): the router's session_synthesis gate can pass
+			// while the module-level inference resolver is not wired up yet
+			// (init-order window during cold boot or pipeline restart). The
+			// worker previously called getInferenceProvider() unguarded,
+			// hard-failed the job, recorded the error, and burned an attempt
+			// on a transient condition — repeatedly failing every queued
+			// transcript. It must instead treat the missing resolver as
+			// workload-unavailable: restore the lease and retry later.
 			writeAgentYaml(`memory:
   pipelineV2:
     enabled: true
@@ -3608,6 +3616,8 @@ describe("summary worker tick gate", () => {
 			const jobId = enq.jobId;
 
 			const { startSummaryWorker } = await import("./pipeline/summary-worker");
+			// Router gate passes (synthesis "available") but no
+			// initInferenceProviderResolver() call — the #1155 window.
 			const handle = startSummaryWorker(getDbAccessor(), { isSynthesisAvailable: async () => true });
 
 			// First tick fires after POLL_INTERVAL_MS (5s)
@@ -3621,9 +3631,11 @@ describe("summary worker tick gate", () => {
 			db.close();
 
 			expect(job).toBeDefined();
-			// Gate allowed tick through → job was leased → attempts incremented.
-			// Without LLM the processing will fail, but that doesn't matter.
-			expect(job?.attempts).toBeGreaterThan(0);
+			// Tick ran and recognized the uninitialised resolver: the lease
+			// was restored, so no attempt was consumed and no failure was
+			// recorded against the job.
+			expect(job?.status).toBe("pending");
+			expect(job?.attempts).toBe(0);
 		},
 		15_000,
 	);

--- a/platform/daemon/src/pipeline/summary-worker.ts
+++ b/platform/daemon/src/pipeline/summary-worker.ts
@@ -15,7 +15,7 @@ import type { LlmProvider } from "@signet/core";
 import { resolveDefaultBasePath } from "@signet/core";
 import type { DbAccessor, WriteDb } from "../db-accessor";
 import { countChanges } from "../db-helpers";
-import { getInferenceProvider } from "../llm";
+import { getInferenceProviderOrNull } from "../llm";
 import { logger } from "../logger";
 import { type ResolvedMemoryConfig, loadMemoryConfig } from "../memory-config";
 import {
@@ -1257,7 +1257,18 @@ export function startSummaryWorker(accessor: DbAccessor, options: SummaryWorkerO
 			});
 
 			if (synthesisAvailable && !cachedProvider) {
-				cachedProvider = getInferenceProvider("sessionSynthesis");
+				cachedProvider = getInferenceProviderOrNull("sessionSynthesis");
+			}
+			if (synthesisAvailable && !cachedProvider) {
+				// The router says session_synthesis is configured, but the
+				// module-level resolver is not wired up yet (init-order window
+				// during cold boot or pipeline restart). This is a transient
+				// workload-unavailable condition, not a job failure — restore
+				// the lease and retry on the next tick instead of burning an
+				// attempt (#1155, same init-order class as #1143).
+				restoreUnprocessedSummaryLease(accessor, job);
+				scheduleTick(POLL_INTERVAL_MS);
+				return;
 			}
 			await processJob(accessor, synthesisAvailable ? cachedProvider : null, job, memoryCfg, activeAbort.signal);
 


### PR DESCRIPTION
## Summary

The summary worker gates job processing on *router* availability (`router.explain`) but then calls `getInferenceProvider("sessionSynthesis")` unguarded. In the init-order window during cold boot or pipeline restart (where `startPipelineRuntime` throws between `closeInferenceProviderResolver()` and `initInferenceProviderResolver()`), the gate passes while the module-level resolver is still null, so every queued summary job hard-fails with "Inference provider resolver not initialised" and burns an attempt — until jobs hit max attempts and die. That would leave transcripts permanently incomplete and stall content dreaming (#1155, same init-order class as #1143).

This change treats the missing resolver as workload-unavailable: the worker restores the lease and retries on the next tick instead of failing the job.

## Changes

- `platform/daemon/src/pipeline/summary-worker.ts`: resolve the synthesis provider via `getInferenceProviderOrNull("sessionSynthesis")`; when the router gate passes but the resolver is not wired up yet, restore the unprocessed lease and schedule the next tick rather than propagating a job failure.
- `platform/daemon/src/hooks.test.ts`: the "summary worker tick gate" test now asserts the job stays `pending` with `attempts: 0` in the uninitialised-resolver window (regression test for #1155). Verified it fails on the pre-fix code.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`

## Screenshots

N/A (no UI changes)

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec/schema surface touched
- [x] Agent scoping verified on all new/changed data queries — no scoping surface touched
- [x] Input/config validation and bounds checks added — N/A (no new inputs)
- [x] Error handling and fallback paths tested (no silent swallow) — the resolver-absent path now defers instead of failing; covered by the regression test
- [x] Security checks applied to admin/mutation endpoints — N/A
- [x] Docs updated for API/spec/status changes — N/A (no API/spec surface)
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes

N/A — no migrations touched.

## Testing

- [x] `bun test` passes — `hooks.test.ts` + `summary-worker.test.ts`: 193 pass / 0 fail; `maintenance-worker.test.ts` 5 pre-existing failures also reproduced on main, unchanged
- [x] `bun run typecheck` passes — `@signet/daemon` clean
- [x] `bun run lint` passes — biome clean on `summary-worker.ts` (pre-existing format drift in `hooks.test.ts` exists on main, untouched)
- [x] Tested against running daemon — live daemon verified healthy; the reported outage was test noise in the shared daemon log (see #1155)
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The investigation behind this fix is documented on issue #1155: the reported "317 failing summary jobs" were log lines from the repo's own test suite writing to the shared daemon log (fixture sessions, `/tmp/signet-hooks-test-*` transcripts), not live failures. The fix addresses the real latent failure mode the issue describes.
