### PR TITLE
feat(telemetry): per-install PostHog analytics (#1026)

### DIFF
--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -202,3 +202,30 @@ names: `queue`, `storage`, `index`, `provider`, `mutation`, `connector`.
 into the mutation domain for memory integrity monitoring).
 
 `GET /api/analytics/logs` — alias for structured log access.
+
+
+PostHog Telemetry
+---
+
+Separate from the in-memory analytics above, the daemon ships an
+anonymous telemetry collector for understanding install and usage
+patterns (see [[configuration]]). It buffers events to SQLite and
+flushes them in batches to a PostHog instance when both `posthogHost`
+and `posthogApiKey` are configured (`telemetryEnabled` defaults to
+true; set it to `false` to opt out).
+
+Privacy contract:
+
+- Events carry no memory content, user identity, agent ids, or file paths.
+- Each install gets a random anonymous id (persisted in the workspace
+  database) used as the PostHog `distinct_id`, so installs are countable
+  but not identifiable.
+- Telemetry is on by default and can be disabled with
+  `telemetryEnabled: false`.
+
+Events recorded today: `daemon.heartbeat` (every 5 minutes), the
+`inference.*` lifecycle (`route`, `execute`, `stream`, `fallback`),
+`llm.generate` (provider, latency, token and cost counts when reported,
+success — never prompt text), and `session.start` / `session.end`
+(harness and prompt count). The `pipeline.*` event types are declared
+for future use but not yet emitted.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -690,7 +690,7 @@ These top-level boolean fields gate major pipeline behaviors.
 | `shadowMode` | `false` | Extract facts but skip writes. Useful for evaluation. |
 | `mutationsFrozen` | `false` | Allow reads; block all writes. Overrides `shadowMode`. |
 | `semanticContradictionEnabled` | `true` | Enable LLM-based semantic contradiction detection for UPDATE/DELETE proposals. |
-| `telemetryEnabled` | `false` | Enable anonymous telemetry reporting. |
+| `telemetryEnabled` | `true` | Enable anonymous telemetry reporting (set `false` to opt out). |
 
 The relationship between `shadowMode` and `mutationsFrozen` matters:
 `shadowMode` suppresses writes from the normal extraction path only;
@@ -1116,13 +1116,17 @@ leaving the explicit `session_search` MCP/API surface available.
 
 ### Telemetry (`telemetry`)
 
-Anonymous usage telemetry. Only active when `telemetryEnabled: true`.
-Events are batched and flushed periodically.
+Anonymous usage telemetry. On by default; set `telemetryEnabled: false`
+to opt out. Events are batched and flushed periodically. Sending requires
+both `posthogHost` and `posthogApiKey`; telemetry never includes memory
+content, user identity, or file paths. Each install gets a random
+anonymous id (persisted in the workspace database) used as the PostHog
+`distinct_id`, so installs stay countable without being identifiable.
 
 | Field | Default | Range | Description |
 |-------|---------|-------|-------------|
-| `posthogHost` | `""` | — | PostHog instance URL (empty disables) |
-| `posthogApiKey` | `""` | — | PostHog project API key |
+| `posthogHost` | `https://us.i.posthog.com` | — | PostHog instance URL (empty disables) |
+| `posthogApiKey` | `phc_mLsvJmbmp6e9UarrX9Cq5QtTjVNiiphM9mvi5Xnddd8Q` | — | PostHog project API key. Public ingest key by design; overrides the `POSTHOG_API_KEY` secret when set |
 | `flushIntervalMs` | `60000` | 5s-10min | Time between event flushes |
 | `flushBatchSize` | `50` | 1-500 | Max events per flush batch |
 | `retentionDays` | `90` | 1-365 | Days before local telemetry data is purged |

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -1055,7 +1055,7 @@ shadowMode                      false
 mutationsFrozen                 false
 semanticContradictionEnabled        true
 semanticContradictionTimeoutMs      120000  # ms, range 5000-300000
-telemetryEnabled                    false
+telemetryEnabled                    true    # set false to opt out
 ```
 
 ### Nested sub-objects and defaults
@@ -1146,8 +1146,9 @@ continuity:
   recoveryBudgetChars: 2000      # range 200–10000
 
 telemetry:
-  posthogHost: ""
-  posthogApiKey: ""
+  telemetryEnabled: true        # set false to opt out
+  posthogHost: "https://us.i.posthog.com"
+  posthogApiKey: "phc_mLsvJmbmp6e9UarrX9Cq5QtTjVNiiphM9mvi5Xnddd8Q"  # public ingest key
   flushIntervalMs: 60000         # ms, range 5s–10min
   flushBatchSize: 50             # range 1–500
   retentionDays: 90              # range 1–365

--- a/platform/core/src/migrations/109-telemetry-install.ts
+++ b/platform/core/src/migrations/109-telemetry-install.ts
@@ -1,0 +1,21 @@
+/**
+ * Migration 109: Telemetry Install Identity
+ *
+ * Holds the anonymous per-install identifier used as the PostHog
+ * distinct_id. A single row persists across daemon restarts so every
+ * event from one install maps to one PostHog user. Before this table,
+ * the collector sent a constant "signet-anonymous" id, which collapsed
+ * all installs into a single PostHog user and made install and usage
+ * analytics impossible.
+ */
+
+import type { MigrationDb } from "./index";
+
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS telemetry_install (
+			id TEXT PRIMARY KEY,
+			created_at TEXT NOT NULL
+		);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -114,6 +114,7 @@ import { up as agentScopedEntityName } from "./105-agent-scoped-entity-name";
 import { up as memoryReviewAfter } from "./106-memory-review-after";
 import { up as dreamingPassUsage } from "./107-dreaming-pass-usage";
 import { up as embeddingUsage } from "./108-embedding-usage";
+import { up as telemetryInstall } from "./109-telemetry-install";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1008,6 +1009,14 @@ export const MIGRATIONS: readonly Migration[] = [
 		up: embeddingUsage,
 		artifacts: {
 			tables: ["embedding_usage"],
+		},
+	},
+	{
+		version: 109,
+		name: "telemetry-install",
+		up: telemetryInstall,
+		artifacts: {
+			tables: ["telemetry_install"],
 		},
 	},
 ];

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -136,7 +136,7 @@ import {
 } from "./source-index-progress";
 import { runStartupRecovery } from "./startup-recovery";
 import { reportStartupGrace } from "./system-pressure";
-import { type TelemetryCollector, createTelemetryCollector } from "./telemetry";
+import { type TelemetryCollector, createTelemetryCollector, setActiveTelemetry } from "./telemetry";
 import { type TranscriptCaptureWorkerHandle, startTranscriptCaptureWorker } from "./transcript-capture-worker";
 
 import {
@@ -1580,6 +1580,7 @@ async function cleanup() {
 		} catch {}
 		telemetryRef = undefined;
 		setTelemetryRef(undefined);
+		setActiveTelemetry(undefined);
 	}
 
 	try {
@@ -1917,6 +1918,7 @@ async function main() {
 		telemetryCollector.start();
 		telemetryRef = telemetryCollector;
 		setTelemetryRef(telemetryCollector);
+		setActiveTelemetry(telemetryCollector);
 
 		const daemonStartTime = Date.now();
 		heartbeatTimer = setInterval(

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -131,6 +131,7 @@ import {
 } from "./session-transcripts";
 import { type StructuralCandidateSource, type StructuralFeatures, getStructuralFeatures } from "./structural-features";
 import { assembleInheritedContextBlock, resolveParentSession } from "./subagent-context";
+import { getActiveTelemetry } from "./telemetry";
 import { searchTemporalFallback } from "./temporal-fallback";
 import { writeTranscriptAudit } from "./transcript-audit";
 import * as transcriptCapture from "./transcript-capture";
@@ -650,6 +651,12 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 			warnings: warnings?.length ? warnings : undefined,
 		};
 	}
+
+	// Anonymous usage telemetry: a real session start (dedup stubs and
+	// clear/reset paths above don't count as new sessions).
+	getActiveTelemetry()?.record("session.start", {
+		harness: req.harness,
+	});
 
 	// Initialize continuity state for checkpoint accumulation (first call only)
 	if (req.sessionKey) {
@@ -1747,6 +1754,13 @@ export async function handleSessionEnd(req: SessionEndRequest): Promise<SessionE
 	// Uses totalPromptCount so this reflects the full session, not just
 	// the interval since the last periodic/pre-compaction consume.
 	const snap = consumeState(sessionKey);
+
+	// Anonymous usage telemetry for real session ends (the clear path above
+	// returns early and doesn't count as a session).
+	getActiveTelemetry()?.record("session.end", {
+		harness: req.harness,
+		promptCount: snap?.totalPromptCount ?? null,
+	});
 	if (snap && snap.totalPromptCount > 0) {
 		try {
 			const cfg = loadMemoryConfig(getAgentsDir()).pipelineV2.continuity;

--- a/platform/daemon/src/memory-config.ts
+++ b/platform/daemon/src/memory-config.ts
@@ -196,10 +196,14 @@ export const DEFAULT_PIPELINE_V2: ResolvedPipelineV2Config = {
 		inheritContext: true,
 		tailChars: 3000,
 	},
-	telemetryEnabled: false,
+	telemetryEnabled: true,
 	telemetry: {
-		posthogHost: "",
-		posthogApiKey: "",
+		// PostHog cloud (US). On by default so Signet can understand how it
+		// runs in the wild; set telemetryEnabled: false to opt out. Sends
+		// only when both host and api key are configured. The project API
+		// key is a public ingest key (PostHog design); it is not a secret.
+		posthogHost: "https://us.i.posthog.com",
+		posthogApiKey: "phc_mLsvJmbmp6e9UarrX9Cq5QtTjVNiiphM9mvi5Xnddd8Q",
 		flushIntervalMs: 60000,
 		flushBatchSize: 50,
 		retentionDays: 90,

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -33,6 +33,7 @@ import {
 	resolveDefaultBasePath,
 } from "@signet/core";
 import { logger } from "../logger";
+import { getActiveTelemetry } from "../telemetry";
 import { which } from "../which";
 
 // ---------------------------------------------------------------------------
@@ -470,17 +471,40 @@ export interface StreamCapableLlmProvider extends LlmProvider {
 
 /**
  * Run a provider call, returning usage when the provider reports it.
+ * Records an anonymous `llm.generate` telemetry event (usage counts and
+ * latency only — never prompt content) when a collector is active.
  */
 export async function generateWithTracking(
 	provider: LlmProvider,
 	prompt: string,
 	opts?: LlmProviderCallOptions,
 ): Promise<LlmGenerateResult> {
-	if (provider.generateWithUsage) {
-		return provider.generateWithUsage(prompt, opts);
+	const startedAt = performance.now();
+	try {
+		const result = provider.generateWithUsage
+			? await provider.generateWithUsage(prompt, opts)
+			: { text: await provider.generate(prompt, opts), usage: null };
+		recordLlmGenerate(provider, result.usage, performance.now() - startedAt, true);
+		return result;
+	} catch (error) {
+		recordLlmGenerate(provider, null, performance.now() - startedAt, false);
+		throw error;
 	}
-	const text = await provider.generate(prompt, opts);
-	return { text, usage: null };
+}
+
+function recordLlmGenerate(provider: LlmProvider, usage: LlmUsage | null, latencyMs: number, success: boolean): void {
+	const telemetry = getActiveTelemetry();
+	if (!telemetry) return;
+	telemetry.record("llm.generate", {
+		provider: provider.name,
+		latencyMs: Math.round(latencyMs),
+		success,
+		inputTokens: usage?.inputTokens ?? null,
+		outputTokens: usage?.outputTokens ?? null,
+		cacheReadTokens: usage?.cacheReadTokens ?? null,
+		cacheCreationTokens: usage?.cacheCreationTokens ?? null,
+		totalCost: usage?.totalCost ?? null,
+	});
 }
 
 // ---------------------------------------------------------------------------

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Regression tests for the anonymous PostHog telemetry collector.
+ *
+ * Names the bug they guard: the constant "signet-anonymous" distinct_id
+ * collapsed every install into one PostHog user, making install and usage
+ * analytics impossible. The remaining tests pin the send lifecycle
+ * (batch shape, mark-sent, no-resend, backoff, retention pruning) so a
+ * future change can't silently stop events from reaching PostHog.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { type TelemetryCollector, createTelemetryCollector, nextFlushIntervalMs } from "./telemetry";
+import { cleanupTestTempDir, createTestTempDir } from "./test-temp-dir";
+
+const TELEMETRY_CONFIG = {
+	posthogHost: "http://posthog.test",
+	posthogApiKey: "phc_test_key",
+	flushIntervalMs: 60000,
+	flushBatchSize: 50,
+	retentionDays: 90,
+	memorySearchQaEnabled: false,
+} as const;
+
+interface CapturedBody {
+	readonly api_key: string;
+	readonly batch: ReadonlyArray<{
+		readonly event: string;
+		readonly distinct_id: string;
+		readonly properties: Record<string, unknown>;
+	}>;
+}
+
+let dir = "";
+let captured: Array<{ readonly url: string; readonly body: CapturedBody }> = [];
+const originalFetch = globalThis.fetch;
+
+function installFetchMock(): void {
+	captured = [];
+	globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+		captured.push({
+			url: String(input),
+			body: JSON.parse(String(init?.body ?? "{}")) as CapturedBody,
+		});
+		return new Response("1", { status: 200 });
+	}) as typeof fetch;
+}
+
+function resetWorkspace(): void {
+	closeDbAccessor();
+	rmSync(join(dir, "memory"), { recursive: true, force: true });
+	mkdirSync(join(dir, "memory"), { recursive: true });
+	initDbAccessor(join(dir, "memory", "memories.db"));
+}
+
+function makeCollector(): TelemetryCollector {
+	return createTelemetryCollector(getDbAccessor(), TELEMETRY_CONFIG, "0.0.0-test");
+}
+
+function lastBatchDistinctId(): string {
+	const last = captured.at(-1);
+	if (!last) throw new Error("no PostHog request captured");
+	const first = last.body.batch[0];
+	if (!first) throw new Error("captured batch was empty");
+	return first.distinct_id;
+}
+
+function unsentCount(): number {
+	return getDbAccessor().withReadDb((db) => {
+		const row = db.prepare("SELECT COUNT(*) AS count FROM telemetry_events WHERE sent_to_posthog = 0").get() as {
+			readonly count: number;
+		};
+		return row.count;
+	});
+}
+
+function installRowCount(): number {
+	return getDbAccessor().withReadDb((db) => {
+		const row = db.prepare("SELECT COUNT(*) AS count FROM telemetry_install").get() as { readonly count: number };
+		return row.count;
+	});
+}
+
+describe("telemetry collector", () => {
+	beforeAll(() => {
+		dir = createTestTempDir("signet-telemetry-");
+		installFetchMock();
+		resetWorkspace();
+	});
+
+	beforeEach(() => {
+		captured = [];
+		resetWorkspace();
+	});
+
+	afterAll(() => {
+		globalThis.fetch = originalFetch;
+		closeDbAccessor();
+		cleanupTestTempDir(dir);
+	});
+
+	it("uses a different anonymous id for different workspaces", async () => {
+		const collectorA = makeCollector();
+		collectorA.record("daemon.heartbeat", { uptimeMs: 1 });
+		await collectorA.flush();
+		const idA = lastBatchDistinctId();
+		expect(idA).not.toBe("signet-anonymous");
+
+		const dirB = createTestTempDir("signet-telemetry-b-");
+		try {
+			closeDbAccessor();
+			initDbAccessor(join(dirB, "memory", "memories.db"));
+			const collectorB = makeCollector();
+			collectorB.record("daemon.heartbeat", { uptimeMs: 1 });
+			await collectorB.flush();
+			expect(lastBatchDistinctId()).not.toBe(idA);
+		} finally {
+			closeDbAccessor();
+			cleanupTestTempDir(dirB);
+			resetWorkspace();
+		}
+	});
+
+	it("keeps one stable anonymous id across collector restarts", async () => {
+		const first = makeCollector();
+		first.record("daemon.heartbeat", { uptimeMs: 1 });
+		await first.flush();
+		const idA = lastBatchDistinctId();
+
+		// Second collector over the same database, like a daemon restart.
+		const second = makeCollector();
+		second.record("daemon.heartbeat", { uptimeMs: 2 });
+		await second.flush();
+		expect(lastBatchDistinctId()).toBe(idA);
+		expect(installRowCount()).toBe(1);
+	});
+
+	it("posts batches with the install id and marks events sent", async () => {
+		const collector = makeCollector();
+		collector.record("session.start", { harness: "hermes-agent" });
+		collector.record("llm.generate", { provider: "test", latencyMs: 42, success: true });
+		await collector.flush();
+
+		expect(captured).toHaveLength(1);
+		const body = captured[0]?.body;
+		expect(body?.api_key).toBe("phc_test_key");
+		expect(body?.batch).toHaveLength(2);
+		expect(body?.batch[0]?.distinct_id).toBe(lastBatchDistinctId());
+		expect(body?.batch[1]?.properties.$lib).toBe("signet-daemon");
+		expect(unsentCount()).toBe(0);
+	});
+
+	it("does not resend events already marked sent", async () => {
+		const collector = makeCollector();
+		collector.record("daemon.heartbeat", { uptimeMs: 1 });
+		await collector.flush();
+		await collector.flush();
+		expect(captured).toHaveLength(1);
+	});
+
+	it("backs off after three consecutive PostHog failures", () => {
+		expect(nextFlushIntervalMs(60000, 0)).toBe(60000);
+		expect(nextFlushIntervalMs(60000, 2)).toBe(60000);
+		expect(nextFlushIntervalMs(60000, 3)).toBe(300000);
+		expect(nextFlushIntervalMs(60000, 9)).toBe(300000);
+	});
+
+	it("prunes events older than the retention window", async () => {
+		const old = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000).toISOString();
+		getDbAccessor().withWriteTx((w) => {
+			w.prepare(
+				"INSERT INTO telemetry_events (id, event, timestamp, properties, sent_to_posthog, created_at) VALUES (?, ?, ?, ?, 0, ?)",
+			).run("old-1", "daemon.heartbeat", old, "{}", old);
+		});
+
+		const collector = makeCollector();
+		collector.record("daemon.heartbeat", { uptimeMs: 1 });
+		// Pruning runs on every 10th flush.
+		for (let i = 0; i < 10; i++) {
+			await collector.flush();
+		}
+
+		const rows = getDbAccessor().withReadDb(
+			(db) => db.prepare("SELECT id FROM telemetry_events").all() as Array<{ readonly id: string }>,
+		);
+		expect(rows.map((r) => r.id)).not.toContain("old-1");
+		expect(rows.length).toBe(1);
+	});
+});

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -62,6 +62,52 @@ export interface TelemetryCollector {
 }
 
 // ---------------------------------------------------------------------------
+// Active collector reference
+// ---------------------------------------------------------------------------
+// Mirrored here by the daemon for pipeline and hooks layers, which are not
+// route modules and therefore don't read the route-layer ref in routes/state.
+
+let activeCollector: TelemetryCollector | undefined;
+
+export function setActiveTelemetry(collector: TelemetryCollector | undefined): void {
+	activeCollector = collector;
+}
+
+export function getActiveTelemetry(): TelemetryCollector | undefined {
+	return activeCollector;
+}
+
+/**
+ * Resolve the anonymous per-install identifier, creating and persisting it on
+ * first use. Falls back to an in-memory id if the database is unusable.
+ * A truthy guard is required here: bun:sqlite returns null for a missing row
+ * while better-sqlite3 returns undefined (dual-DB daemon).
+ */
+function getOrCreateInstallId(db: DbAccessor): string {
+	try {
+		const existing = db.withReadDb((r) => {
+			const row = r.prepare("SELECT id FROM telemetry_install ORDER BY created_at ASC LIMIT 1").get() as
+				| { readonly id: string }
+				| null
+				| undefined;
+			return row?.id ?? null;
+		});
+		if (existing != null) return existing;
+
+		const id = crypto.randomUUID();
+		db.withWriteTx((w) => {
+			w.prepare("INSERT OR IGNORE INTO telemetry_install (id, created_at) VALUES (?, ?)").run(
+				id,
+				new Date().toISOString(),
+			);
+		});
+		return id;
+	} catch {
+		return crypto.randomUUID();
+	}
+}
+
+// ---------------------------------------------------------------------------
 // PostHog batch sender
 // ---------------------------------------------------------------------------
 
@@ -76,16 +122,26 @@ const MAX_BUFFER_SIZE = 200;
 const MAX_BUFFER_EVENTS = 5000;
 const MAX_CONSECUTIVE_FAILURES = 3;
 const BACKOFF_MULTIPLIER = 5;
+const PRUNE_EVERY_N_FLUSHES = 10;
+
+/**
+ * Interval used after `failures` consecutive PostHog failures. Pure so the
+ * backoff behavior is testable without driving timers.
+ */
+export function nextFlushIntervalMs(baseIntervalMs: number, consecutiveFailures: number): number {
+	return consecutiveFailures >= MAX_CONSECUTIVE_FAILURES ? baseIntervalMs * BACKOFF_MULTIPLIER : baseIntervalMs;
+}
 
 async function sendToPostHog(
 	host: string,
 	apiKey: string,
+	distinctId: string,
 	events: readonly TelemetryEvent[],
 	daemonVersion: string,
 ): Promise<boolean> {
 	const batch: readonly PostHogBatchEvent[] = events.map((e) => ({
 		event: e.event,
-		distinct_id: "signet-anonymous",
+		distinct_id: distinctId,
 		timestamp: e.timestamp,
 		properties: {
 			...e.properties,
@@ -120,7 +176,9 @@ export function createTelemetryCollector(
 	let flushTimer: ReturnType<typeof setTimeout> | null = null;
 	let running = false;
 	let consecutiveFailures = 0;
+	let flushCount = 0;
 	let effectiveIntervalMs = config.flushIntervalMs;
+	const installId = getOrCreateInstallId(db);
 
 	const posthogConfigured = config.posthogHost.length > 0 && config.posthogApiKey.length > 0;
 
@@ -202,6 +260,7 @@ export function createTelemetryCollector(
 	}
 
 	async function doFlush(): Promise<void> {
+		flushCount++;
 		// Drain buffer to SQLite
 		const pending = buffer.splice(0, buffer.length);
 		writeToDb(pending);
@@ -210,15 +269,15 @@ export function createTelemetryCollector(
 		if (posthogConfigured) {
 			const unsent = loadUnsent(config.flushBatchSize);
 			if (unsent.length > 0) {
-				const ok = await sendToPostHog(config.posthogHost, config.posthogApiKey, unsent, daemonVersion);
+				const ok = await sendToPostHog(config.posthogHost, config.posthogApiKey, installId, unsent, daemonVersion);
 				if (ok) {
 					markSent(unsent.map((e) => e.id));
 					consecutiveFailures = 0;
 					effectiveIntervalMs = config.flushIntervalMs;
 				} else {
 					consecutiveFailures++;
+					effectiveIntervalMs = nextFlushIntervalMs(config.flushIntervalMs, consecutiveFailures);
 					if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
-						effectiveIntervalMs = config.flushIntervalMs * BACKOFF_MULTIPLIER;
 						logger.warn("telemetry", "PostHog unreachable, backing off", {
 							intervalMs: effectiveIntervalMs,
 						});
@@ -227,8 +286,8 @@ export function createTelemetryCollector(
 			}
 		}
 
-		// Occasional pruning (roughly every 10th flush)
-		if (Math.random() < 0.1) {
+		// Occasional pruning (every 10th flush, deterministic for tests)
+		if (flushCount % PRUNE_EVERY_N_FLUSHES === 0) {
 			pruneOldEvents();
 		}
 	}


### PR DESCRIPTION
## Summary

Completes ROADMAP #1026 (usage analytics). Signet shipped an opt-in PostHog
telemetry collector in 0.169.0, but every event used the constant
`distinct_id: "signet-anonymous"`, collapsing all installs into one PostHog
user — installs were uncountable and the feature was useless. This PR gives
each install a persisted anonymous id, wires the declared-but-dead events,
and ships the PostHog cloud defaults so installs report to the project with
zero config.

Telemetry is **on by default** (basic usage telemetry — heartbeat, session,
inference, LLM usage counts — never conversation content, memory, identity,
or file paths). Opt-out is `telemetryEnabled: false`; a setup-time disclosure
prompt ships in the follow-up telemetry PR (#1130, rebased after this lands).

Live-verified against the Signet PostHog project: a scratch collector flushed
6 events to https://us.i.posthog.com/batch/ (0 unsent, 0 failures).

## Changes

- Migration 109: `telemetry_install` table holds one random anonymous UUID per
  install, used as the PostHog `distinct_id`. No identity, no PII.
- `telemetry.ts`: resolve-or-create install id (truthy guard for the
  bun:sqlite null / better-sqlite3 undefined split); deterministic
  every-10th-flush pruning; exported pure `nextFlushIntervalMs` for backoff.
- Event wiring: `llm.generate` at the provider choke point
  (pipeline/provider.ts — provider, latency, token/cost counts, success;
  never prompt content), `session.start`/`session.end` at the hooks lifecycle
  (harness + prompt count). `daemon.heartbeat` and `inference.*` were already
  live.
- Config: `telemetryEnabled` defaults to `true` (opt-out via `false`);
  `posthogHost` defaults to `https://us.i.posthog.com`; `posthogApiKey`
  defaults to the public Signet project ingest key (PostHog project API keys
  are public by design; the `POSTHOG_API_KEY` secret overrides it).
- Docs: CONFIGURATION.md telemetry section (on-by-default + opt-out),
  PIPELINE.md example, ANALYTICS.md gained a PostHog Telemetry section
  documenting the privacy contract.
- Regression tests (telemetry.test.ts, 6 tests): per-workspace distinct ids,
  stable id across collector restarts, batch shape + mark-sent, no resend of
  sent events, backoff threshold, retention pruning.

## Type

- [x] `feat` — new user-facing feature (bumps minor)

## Packages affected

- [x] `@signet/core` (migration 109)
- [x] `@signet/daemon` (collector, provider, hooks, config)
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: docs (ANALYTICS, CONFIGURATION, PIPELINE)

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries — telemetry is
      intentionally global-anonymous, no agent scoping applies; install id is
      workspace-scoped
- [x] Input/config validation and bounds checks added — config values are
      clamped via the existing memory-config resolvers (flushIntervalMs,
      flushBatchSize, retentionDays)
- [x] Error handling and fallback paths tested (no silent swallow) — install-id
      read falls back to in-memory id on DB failure; send failures back off
      and stay queued
- [x] Security checks applied to admin/mutation endpoints — N/A, no endpoints
      added
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent — `CREATE TABLE IF NOT EXISTS`, INSERT OR IGNORE
- [x] Rollback / compatibility note included in PR description
      (older daemons ignore the new table; `telemetry_install` has no consumers
      beyond the collector. No data is migrated.)

## Testing

- [x] `bun test` passes — telemetry.test.ts 6/6, hooks + hooks-recall +
      migrations suites 242/242
- [x] `bun run typecheck` passes — full workspace green
- [x] `bun run lint` passes — biome clean on all touched files
- [x] Tested against running daemon — live flush to the real PostHog project
      (6 events accepted, 0 unsent); inference/maintenance-worker suite
      failures are pre-existing on clean main (live-provider tests)
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- The 15 failing tests in the pipeline/inference suites are environmental
  (they call live Ollama/OpenAI-compatible providers with models this machine
  does not serve) and fail identically on clean main.
- Follow-up: #1130 (Avery Felts) rebases on top of this PR. Its install ping
  will be rerouted from the non-existent telemetry.signetai.sh endpoint to
  PostHog, and its setup prompt becomes a default-accept disclosure matching
  the on-by-default decision. The open JSONL telemetry log from #1130 stays —
  it is the auditability surface that makes default-on defensible.
- Heartbeat cadence (5 min) is the dominant event-volume driver at scale —
  hourly still tracks daily-active installs at 1/12 the cost. Not changed
  here; flagged for when volume matters.
