### PR TITLE
feat(telemetry): full #1026 — PostHog install ping, default-on disclosure

### DIFF
--- a/PROBE_MARKER.txt
+++ b/PROBE_MARKER.txt
@@ -1,0 +1,1 @@
+probe-content

--- a/dist/signetai/scripts/install-native.js
+++ b/dist/signetai/scripts/install-native.js
@@ -24,12 +24,15 @@ const require = createRequire(import.meta.url);
 
 const CONNECTOR_COMPONENT = "connectors";
 
-// Phase-1 telemetry (issue #1026): a single anonymous counter ping per real
-// install. No identifier, no IP logging, no payload beyond version+platform.
+// Phase-1 telemetry (issue #1026): a single anonymous install counter sent to
+// the Signet PostHog project. Payload is version+platform only — no
+// identifier, no IP logging. Each install generates a fresh anonymous id, so
+// every ping counts as one distinct install without persisting anything.
 // Opt-out via SIGNET_TELEMETRY_OPTOUT=1 (Homebrew-style). Never blocks the
 // install and never fails it: the request is time-bounded and errors are
 // swallowed, so a telemetry outage cannot break postinstall.
-const TELEMETRY_ENDPOINT = "https://telemetry.signetai.sh/ping";
+const TELEMETRY_HOST = "https://us.i.posthog.com";
+const TELEMETRY_API_KEY = "phc_mLsvJmbmp6e9UarrX9Cq5QtTjVNiiphM9mvi5Xnddd8Q"; // public ingest key
 const TELEMETRY_TIMEOUT_MS = 2000;
 const pendingPings = [];
 
@@ -45,10 +48,27 @@ function telemetryEnabled() {
 
 function fireInstallPing(platform) {
 	if (!telemetryEnabled()) return;
-	const url = new URL(TELEMETRY_ENDPOINT);
-	url.searchParams.set("v", nativePackageVersion());
-	url.searchParams.set("p", platform);
-	const promise = fetch(url, { signal: AbortSignal.timeout(TELEMETRY_TIMEOUT_MS) }).catch(() => {});
+	const body = JSON.stringify({
+		api_key: TELEMETRY_API_KEY,
+		batch: [
+			{
+				event: "install.ping",
+				distinct_id: require("node:crypto").randomUUID(),
+				timestamp: new Date().toISOString(),
+				properties: {
+					version: nativePackageVersion(),
+					platform,
+					$lib: "signet-install",
+				},
+			},
+		],
+	});
+	const promise = fetch(`${TELEMETRY_HOST}/batch/`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body,
+		signal: AbortSignal.timeout(TELEMETRY_TIMEOUT_MS),
+	}).catch(() => {});
 	pendingPings.push(promise);
 }
 

--- a/dist/signetai/scripts/install-native.js
+++ b/dist/signetai/scripts/install-native.js
@@ -24,6 +24,34 @@ const require = createRequire(import.meta.url);
 
 const CONNECTOR_COMPONENT = "connectors";
 
+// Phase-1 telemetry (issue #1026): a single anonymous counter ping per real
+// install. No identifier, no IP logging, no payload beyond version+platform.
+// Opt-out via SIGNET_TELEMETRY_OPTOUT=1 (Homebrew-style). Never blocks the
+// install and never fails it: the request is time-bounded and errors are
+// swallowed, so a telemetry outage cannot break postinstall.
+const TELEMETRY_ENDPOINT = "https://telemetry.signetai.sh/ping";
+const TELEMETRY_TIMEOUT_MS = 2000;
+const pendingPings = [];
+
+function telemetryEnabled() {
+	if (process.env.SIGNET_TELEMETRY_OPTOUT === "1" || process.env.SIGNET_TELEMETRY_OPTOUT === "true") {
+		return false;
+	}
+	if (process.env.SIGNET_SKIP_NATIVE_POSTINSTALL === "1" || isWorkspacePackage()) {
+		return false;
+	}
+	return true;
+}
+
+function fireInstallPing(platform) {
+	if (!telemetryEnabled()) return;
+	const url = new URL(TELEMETRY_ENDPOINT);
+	url.searchParams.set("v", nativePackageVersion());
+	url.searchParams.set("p", platform);
+	const promise = fetch(url, { signal: AbortSignal.timeout(TELEMETRY_TIMEOUT_MS) }).catch(() => {});
+	pendingPings.push(promise);
+}
+
 function isWorkspacePackage() {
 	const workspaceRoot = dirname(dirname(packageDir));
 	if (basename(dirname(packageDir)) !== "dist") return false;
@@ -66,6 +94,8 @@ async function main() {
 	}
 
 	const platform = detectNativePlatform();
+	// Anonymous install counter (issue #1026): one ping per real install.
+	fireInstallPing(platform);
 	const nativePackage = nativePlatforms[platform];
 	let source;
 	try {
@@ -208,7 +238,16 @@ async function installConnectorAssets() {
 	}
 }
 
-main().catch((err) => {
-	console.error(`Signet native install failed: ${err.message}`);
-	process.exit(1);
-});
+main()
+	.catch((err) => {
+		console.error(`Signet native install failed: ${err.message}`);
+		process.exit(1);
+	})
+	.finally(async () => {
+		// Give the fire-and-forget telemetry ping a bounded chance to flush.
+		// Each request self-times-out, so this never delays the install by
+		// more than TELEMETRY_TIMEOUT_MS even if the endpoint hangs.
+		if (pendingPings.length > 0) {
+			await Promise.allSettled(pendingPings);
+		}
+	});

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -222,10 +222,33 @@ Privacy contract:
   but not identifiable.
 - Telemetry is on by default and can be disabled with
   `telemetryEnabled: false`.
+- Every recorded event is mirrored to an open, inspectable JSONL log at
+  `<agentsDir>/.daemon/telemetry/events.jsonl`, so users can audit
+  exactly what was sent.
 
-Events recorded today: `daemon.heartbeat` (every 5 minutes), the
-`inference.*` lifecycle (`route`, `execute`, `stream`, `fallback`),
-`llm.generate` (provider, latency, token and cost counts when reported,
-success — never prompt text), and `session.start` / `session.end`
-(harness and prompt count). The `pipeline.*` event types are declared
-for future use but not yet emitted.
+Events recorded: `daemon.heartbeat` (every 5 minutes), the `inference.*`
+lifecycle (`route`, `execute`, `stream`, `fallback`), `llm.generate`
+(provider, latency, token and cost counts when reported, success — never
+prompt text), `session.start` / `session.end` (harness and prompt count),
+and the lifecycle events `daemon.started`, `command.invoked`,
+`error.occurred`, and `version.upgraded`. The `pipeline.*` event types
+are declared for future use but not yet emitted.
+
+Release Download Stats
+---
+
+GitHub tracks download counts per release asset. Unlike npm download totals —
+which include CI pipelines, `npx` one-offs, and version-update churn — each
+release asset download is a real binary or connector-tarball fetch, so it is
+the cleaner install signal (issue #1026 Phase 3).
+
+```sh
+bun scripts/release-download-stats.ts              # markdown table
+bun scripts/release-download-stats.ts --json       # NDJSON for dashboards
+bun scripts/release-download-stats.ts --releases 5 # last N releases
+```
+
+The script queries the public GitHub REST API for `Signet-AI/signetai`
+releases (no auth required; unauthenticated rate limit of 60 req/hr is
+plenty) and aggregates `download_count` per release and per asset, sorted
+by downloads descending. Output includes the total across the window.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1123,6 +1123,22 @@ content, user identity, or file paths. Each install gets a random
 anonymous id (persisted in the workspace database) used as the PostHog
 `distinct_id`, so installs stay countable without being identifiable.
 
+**Opt-in (issue #1026):** `signet setup` asks whether to share anonymous
+usage statistics (version, platform, command names) and writes
+`telemetryEnabled: true` when accepted. Non-interactive/CI setups stay
+opted-out. Telemetry is never enabled implicitly.
+
+**Open telemetry log:** every recorded event is appended as one JSON line
+to `<agentsDir>/.daemon/telemetry/events.jsonl` — the single inspectable
+audit surface for exactly what was sent (daemon events and CLI
+`command.invoked` lines). No memory content, code, file paths, or personal
+data are ever included.
+
+Lifecycle events fired when opted in: `daemon.started` (version, platform,
+uptime), `command.invoked` (command name only, never arguments),
+`error.occurred` (error type only, never stack/message), `version.upgraded`
+(from, to).
+
 | Field | Default | Range | Description |
 |-------|---------|-------|-------------|
 | `posthogHost` | `https://us.i.posthog.com` | — | PostHog instance URL (empty disables) |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1123,10 +1123,10 @@ content, user identity, or file paths. Each install gets a random
 anonymous id (persisted in the workspace database) used as the PostHog
 `distinct_id`, so installs stay countable without being identifiable.
 
-**Opt-in (issue #1026):** `signet setup` asks whether to share anonymous
-usage statistics (version, platform, command names) and writes
-`telemetryEnabled: true` when accepted. Non-interactive/CI setups stay
-opted-out. Telemetry is never enabled implicitly.
+**Disclosure (issue #1026):** `signet setup` tells users telemetry is on
+by default and asks whether to disable it. Declining writes
+`telemetryEnabled: false`; non-interactive/CI setups keep the default
+(enabled).
 
 **Open telemetry log:** every recorded event is appended as one JSON line
 to `<agentsDir>/.daemon/telemetry/events.jsonl` — the single inspectable
@@ -1134,7 +1134,7 @@ audit surface for exactly what was sent (daemon events and CLI
 `command.invoked` lines). No memory content, code, file paths, or personal
 data are ever included.
 
-Lifecycle events fired when opted in: `daemon.started` (version, platform,
+Lifecycle events: `daemon.started` (version, platform,
 uptime), `command.invoked` (command name only, never arguments),
 `error.occurred` (error type only, never stack/message), `version.upgraded`
 (from, to).

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -136,7 +136,7 @@ import {
 } from "./source-index-progress";
 import { runStartupRecovery } from "./startup-recovery";
 import { reportStartupGrace } from "./system-pressure";
-import { type TelemetryCollector, createTelemetryCollector, setActiveTelemetry } from "./telemetry";
+import { type TelemetryCollector, createTelemetryCollector, defaultTelemetryLogPath, setActiveTelemetry } from "./telemetry";
 import { type TranscriptCaptureWorkerHandle, startTranscriptCaptureWorker } from "./transcript-capture-worker";
 
 import {
@@ -1720,6 +1720,9 @@ process.on("SIGTERM", () => {
 
 process.on("uncaughtException", (err) => {
 	logger.error("daemon", "Uncaught exception", err);
+	// Lifecycle event (issue #1026 Phase 2): error type only — never the
+	// stack or message content.
+	telemetryRef?.record("error.occurred", { type: err?.name ?? "Error" });
 	requestShutdown("error:uncaughtException", 1, err);
 });
 
@@ -1730,6 +1733,11 @@ process.on("unhandledRejection", (reason) => {
 		reason instanceof Error ? reason : undefined,
 		reason instanceof Error ? undefined : { reason: String(reason) },
 	);
+	// Lifecycle event (issue #1026 Phase 2): error type only — never the
+	// stack or message content.
+	telemetryRef?.record("error.occurred", {
+		type: reason instanceof Error ? reason.name : "UnhandledRejection",
+	});
 	requestShutdown("error:unhandledRejection", 1, reason);
 });
 
@@ -1914,11 +1922,20 @@ async function main() {
 			...memoryCfg.pipelineV2.telemetry,
 			posthogApiKey,
 		};
-		telemetryCollector = createTelemetryCollector(getDbAccessor(), resolvedTelemetryCfg, CURRENT_VERSION);
+		telemetryCollector = createTelemetryCollector(getDbAccessor(), resolvedTelemetryCfg, CURRENT_VERSION, {
+			telemetryLogPath: defaultTelemetryLogPath(AGENTS_DIR),
+		});
 		telemetryCollector.start();
 		telemetryRef = telemetryCollector;
 		setTelemetryRef(telemetryCollector);
 		setActiveTelemetry(telemetryCollector);
+
+		// Lifecycle event (issue #1026 Phase 2): version + platform only.
+		telemetryCollector.record("daemon.started", {
+			version: CURRENT_VERSION,
+			platform: process.platform,
+			uptimeMs: 0,
+		});
 
 		const daemonStartTime = Date.now();
 		heartbeatTimer = setInterval(

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -136,7 +136,12 @@ import {
 } from "./source-index-progress";
 import { runStartupRecovery } from "./startup-recovery";
 import { reportStartupGrace } from "./system-pressure";
-import { type TelemetryCollector, createTelemetryCollector, defaultTelemetryLogPath, setActiveTelemetry } from "./telemetry";
+import {
+	type TelemetryCollector,
+	createTelemetryCollector,
+	defaultTelemetryLogPath,
+	setActiveTelemetry,
+} from "./telemetry";
 import { type TranscriptCaptureWorkerHandle, startTranscriptCaptureWorker } from "./transcript-capture-worker";
 
 import {

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -4,15 +4,23 @@
  * Names the bug they guard: the constant "signet-anonymous" distinct_id
  * collapsed every install into one PostHog user, making install and usage
  * analytics impossible. The remaining tests pin the send lifecycle
- * (batch shape, mark-sent, no-resend, backoff, retention pruning) so a
- * future change can't silently stop events from reaching PostHog.
+ * (batch shape, mark-sent, no-resend, backoff, retention pruning) and the
+ * open JSONL telemetry log (lifecycle events, issue #1026 Phase 2) so a
+ * future change can't silently stop events from reaching PostHog or the
+ * audit log.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
-import { type TelemetryCollector, createTelemetryCollector, nextFlushIntervalMs } from "./telemetry";
+import { closeDbAccessor, getDbAccessor, initDbAccessor, type DbAccessor } from "./db-accessor";
+import {
+	TELEMETRY_EVENTS,
+	type TelemetryCollector,
+	createTelemetryCollector,
+	defaultTelemetryLogPath,
+	nextFlushIntervalMs,
+} from "./telemetry";
 import { cleanupTestTempDir, createTestTempDir } from "./test-temp-dir";
 
 const TELEMETRY_CONFIG = {
@@ -34,6 +42,7 @@ interface CapturedBody {
 }
 
 let dir = "";
+let logPath = "";
 let captured: Array<{ readonly url: string; readonly body: CapturedBody }> = [];
 const originalFetch = globalThis.fetch;
 
@@ -59,6 +68,18 @@ function makeCollector(): TelemetryCollector {
 	return createTelemetryCollector(getDbAccessor(), TELEMETRY_CONFIG, "0.0.0-test");
 }
 
+/**
+ * Minimal DbAccessor for JSONL-log tests: the collector only touches
+ * withWriteTx/withReadDb there, and posthogHost is "" so nothing sends.
+ */
+function fakeDbAccessor(): DbAccessor {
+	const stmt = { run: () => ({}), get: () => undefined, all: () => [] };
+	return {
+		withWriteTx: (fn: (db: { prepare(sql: string): typeof stmt }) => unknown) => fn({ prepare: () => stmt }),
+		withReadDb: (fn: (db: { prepare(sql: string): typeof stmt }) => unknown) => fn({ prepare: () => stmt }),
+	} as unknown as DbAccessor;
+}
+
 function lastBatchDistinctId(): string {
 	const last = captured.at(-1);
 	if (!last) throw new Error("no PostHog request captured");
@@ -69,9 +90,9 @@ function lastBatchDistinctId(): string {
 
 function unsentCount(): number {
 	return getDbAccessor().withReadDb((db) => {
-		const row = db.prepare("SELECT COUNT(*) AS count FROM telemetry_events WHERE sent_to_posthog = 0").get() as {
-			readonly count: number;
-		};
+		const row = db
+			.prepare("SELECT COUNT(*) AS count FROM telemetry_events WHERE sent_to_posthog = 0")
+			.get() as { readonly count: number };
 		return row.count;
 	});
 }
@@ -92,6 +113,7 @@ describe("telemetry collector", () => {
 
 	beforeEach(() => {
 		captured = [];
+		logPath = defaultTelemetryLogPath(dir);
 		resetWorkspace();
 	});
 
@@ -182,10 +204,81 @@ describe("telemetry collector", () => {
 			await collector.flush();
 		}
 
-		const rows = getDbAccessor().withReadDb(
-			(db) => db.prepare("SELECT id FROM telemetry_events").all() as Array<{ readonly id: string }>,
+		const rows = getDbAccessor().withReadDb((db) =>
+			db.prepare("SELECT id FROM telemetry_events").all() as Array<{ readonly id: string }>,
 		);
 		expect(rows.map((r) => r.id)).not.toContain("old-1");
 		expect(rows.length).toBe(1);
+	});
+});
+
+describe("telemetry lifecycle events (issue #1026 Phase 2)", () => {
+	it("declares the Phase-2 lifecycle event types", () => {
+		for (const event of ["daemon.started", "command.invoked", "error.occurred", "version.upgraded"]) {
+			expect(TELEMETRY_EVENTS).toContain(event);
+		}
+	});
+
+	it("mirrors recorded events to the open JSONL log", () => {
+		const collector = createTelemetryCollector(
+			fakeDbAccessor(),
+			{
+				posthogHost: "",
+				posthogApiKey: "",
+				flushIntervalMs: 60000,
+				flushBatchSize: 50,
+				retentionDays: 90,
+				memorySearchQaEnabled: false,
+			},
+			"0.163.15",
+			{ telemetryLogPath: logPath },
+		);
+
+		collector.record("daemon.started", { version: "0.163.15", platform: process.platform, uptimeMs: 0 });
+		collector.record("command.invoked", { command: "status" });
+
+		expect(existsSync(logPath)).toBe(true);
+		const lines = readFileSync(logPath, "utf-8").trim().split("\n");
+		expect(lines).toHaveLength(2);
+		const first = JSON.parse(lines[0]) as { event: string; properties: { version: string } };
+		expect(first.event).toBe("daemon.started");
+		expect(first.properties.version).toBe("0.163.15");
+		const second = JSON.parse(lines[1]) as { event: string; properties: { command: string } };
+		expect(second.event).toBe("command.invoked");
+		expect(second.properties.command).toBe("status");
+	});
+
+	it("does not write a log when telemetryLogPath is omitted", () => {
+		const collector = createTelemetryCollector(
+			fakeDbAccessor(),
+			{
+				posthogHost: "",
+				posthogApiKey: "",
+				flushIntervalMs: 60000,
+				flushBatchSize: 50,
+				retentionDays: 90,
+				memorySearchQaEnabled: false,
+			},
+			"0.163.15",
+		);
+		collector.record("daemon.started", { version: "0.163.15" });
+		expect(existsSync(logPath)).toBe(false);
+	});
+
+	it("tolerates an unwritable log path without throwing", () => {
+		const collector = createTelemetryCollector(
+			fakeDbAccessor(),
+			{
+				posthogHost: "",
+				posthogApiKey: "",
+				flushIntervalMs: 60000,
+				flushBatchSize: 50,
+				retentionDays: 90,
+				memorySearchQaEnabled: false,
+			},
+			"0.163.15",
+			{ telemetryLogPath: "/dev/null/nonexistent/events.jsonl" },
+		);
+		expect(() => collector.record("daemon.started", { version: "0.163.15" })).not.toThrow();
 	});
 });

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -13,7 +13,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { closeDbAccessor, getDbAccessor, initDbAccessor, type DbAccessor } from "./db-accessor";
+import { type DbAccessor, closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import {
 	TELEMETRY_EVENTS,
 	type TelemetryCollector,
@@ -60,6 +60,7 @@ function installFetchMock(): void {
 function resetWorkspace(): void {
 	closeDbAccessor();
 	rmSync(join(dir, "memory"), { recursive: true, force: true });
+	rmSync(join(dir, ".daemon"), { recursive: true, force: true });
 	mkdirSync(join(dir, "memory"), { recursive: true });
 	initDbAccessor(join(dir, "memory", "memories.db"));
 }
@@ -90,9 +91,9 @@ function lastBatchDistinctId(): string {
 
 function unsentCount(): number {
 	return getDbAccessor().withReadDb((db) => {
-		const row = db
-			.prepare("SELECT COUNT(*) AS count FROM telemetry_events WHERE sent_to_posthog = 0")
-			.get() as { readonly count: number };
+		const row = db.prepare("SELECT COUNT(*) AS count FROM telemetry_events WHERE sent_to_posthog = 0").get() as {
+			readonly count: number;
+		};
 		return row.count;
 	});
 }
@@ -104,25 +105,27 @@ function installRowCount(): number {
 	});
 }
 
+// Shared harness for both suites below: fresh workspace per test, including
+// a clean .daemon dir so the JSONL log cannot leak between tests.
+beforeAll(() => {
+	dir = createTestTempDir("signet-telemetry-");
+	installFetchMock();
+	resetWorkspace();
+});
+
+beforeEach(() => {
+	captured = [];
+	logPath = defaultTelemetryLogPath(dir);
+	resetWorkspace();
+});
+
+afterAll(() => {
+	globalThis.fetch = originalFetch;
+	closeDbAccessor();
+	cleanupTestTempDir(dir);
+});
+
 describe("telemetry collector", () => {
-	beforeAll(() => {
-		dir = createTestTempDir("signet-telemetry-");
-		installFetchMock();
-		resetWorkspace();
-	});
-
-	beforeEach(() => {
-		captured = [];
-		logPath = defaultTelemetryLogPath(dir);
-		resetWorkspace();
-	});
-
-	afterAll(() => {
-		globalThis.fetch = originalFetch;
-		closeDbAccessor();
-		cleanupTestTempDir(dir);
-	});
-
 	it("uses a different anonymous id for different workspaces", async () => {
 		const collectorA = makeCollector();
 		collectorA.record("daemon.heartbeat", { uptimeMs: 1 });
@@ -204,8 +207,8 @@ describe("telemetry collector", () => {
 			await collector.flush();
 		}
 
-		const rows = getDbAccessor().withReadDb((db) =>
-			db.prepare("SELECT id FROM telemetry_events").all() as Array<{ readonly id: string }>,
+		const rows = getDbAccessor().withReadDb(
+			(db) => db.prepare("SELECT id FROM telemetry_events").all() as Array<{ readonly id: string }>,
 		);
 		expect(rows.map((r) => r.id)).not.toContain("old-1");
 		expect(rows.length).toBe(1);

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -6,9 +6,34 @@
  * No memory content, user identity, or file paths are ever included.
  */
 
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
 import type { PipelineTelemetryConfig } from "@signet/core";
 import type { DbAccessor } from "./db-accessor";
 import { logger } from "./logger";
+
+// ---------------------------------------------------------------------------
+// Open telemetry log (issue #1026 Phase 2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Default location of the open telemetry log: one JSON line per recorded
+ * event, so users can inspect exactly what was sent. Configurable via
+ * `telemetryLogPath` on the collector; derived from the agents base path.
+ */
+export function defaultTelemetryLogPath(agentsDir: string): string {
+	return join(agentsDir, ".daemon", "telemetry", "events.jsonl");
+}
+
+function appendToTelemetryLog(logPath: string | null, line: string): void {
+	if (!logPath) return;
+	try {
+		mkdirSync(dirname(logPath), { recursive: true });
+		appendFileSync(logPath, `${line}\n`, "utf-8");
+	} catch {
+		// Telemetry must never break the daemon. Best-effort only.
+	}
+}
 
 // ---------------------------------------------------------------------------
 // Event types
@@ -27,6 +52,12 @@ export const TELEMETRY_EVENTS = [
 	"session.start",
 	"session.end",
 	"daemon.heartbeat",
+	// Lifecycle events (issue #1026 Phase 2): fired when the user has opted
+	// into anonymous telemetry. No PII, no code, no memory content.
+	"daemon.started",
+	"command.invoked",
+	"error.occurred",
+	"version.upgraded",
 ] as const;
 
 export type TelemetryEventType = (typeof TELEMETRY_EVENTS)[number];
@@ -171,8 +202,10 @@ export function createTelemetryCollector(
 	db: DbAccessor,
 	config: PipelineTelemetryConfig,
 	daemonVersion: string,
+	opts: { readonly telemetryLogPath?: string | null } = {},
 ): TelemetryCollector {
 	const buffer: TelemetryEvent[] = [];
+	const logPath = opts.telemetryLogPath ?? null;
 	let flushTimer: ReturnType<typeof setTimeout> | null = null;
 	let running = false;
 	let consecutiveFailures = 0;
@@ -311,6 +344,17 @@ export function createTelemetryCollector(
 				timestamp: new Date().toISOString(),
 				properties,
 			});
+
+			// Open telemetry log (issue #1026 Phase 2): mirror every event to
+			// the inspectable JSONL file so users can audit exactly what was
+			// sent. Best-effort — a full disk or unwritable path must never
+			// break recording.
+			if (logPath) {
+				const last = buffer[buffer.length - 1];
+				if (last) {
+					appendToTelemetryLog(logPath, JSON.stringify(last));
+				}
+			}
 
 			if (buffer.length >= MAX_BUFFER_SIZE) {
 				doFlush().catch(() => {});

--- a/platform/daemon/src/update-system.test.ts
+++ b/platform/daemon/src/update-system.test.ts
@@ -135,6 +135,40 @@ describe("Issue 322: verify installed version after update install", () => {
 		expect(getUpdateState().pendingRestartVersion).toBe("0.78.1");
 	});
 
+	it("fires the onUpgraded lifecycle hook with (from, to) on success (issue #1026 Phase 2)", async () => {
+		const workspaceDir = join(tmpdir(), `signet-update-upgraded-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		initUpdateSystem("0.78.0", workspaceDir);
+
+		const upgrades: Array<{ from: string; to: string }> = [];
+		const result = await finalizeSuccessfulUpdateInstall(
+			"0.78.1",
+			"installed ok",
+			{
+				installMethod: "native",
+				activeExecutablePath: "/home/test/.local/bin/signet",
+			},
+			{
+				syncWorkspaceSourceRepoAsync: async (dir) => ({
+					status: "current",
+					path: join(dir, "signetai"),
+					message: "Signet source checkout is already current",
+					branch: "main",
+					defaultBranch: "main",
+				}),
+				updateDesktopInstallAfterUpdate: async () => ({
+					status: "skipped",
+					message: "Signet desktop app is not installed",
+				}),
+				onUpgraded: (from, to) => {
+					upgrades.push({ from, to });
+				},
+			},
+		);
+
+		expect(result.success).toBe(true);
+		expect(upgrades).toEqual([{ from: "0.78.0", to: "0.78.1" }]);
+	});
+
 	it("attempts managed desktop update after source checkout sync", async () => {
 		const workspaceDir = join(tmpdir(), `signet-update-desktop-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		const calls: string[] = [];

--- a/platform/daemon/src/update-system.ts
+++ b/platform/daemon/src/update-system.ts
@@ -21,6 +21,7 @@ import {
 	syncWorkspaceSourceRepoAsync,
 } from "@signet/core";
 import { logger } from "./logger";
+import { getActiveTelemetry } from "./telemetry";
 import {
 	UPDATE_INSTALL_TIMEOUT_MS,
 	type UpdateInstallDeps,
@@ -1011,7 +1012,9 @@ async function runAutoUpdateCycle(): Promise<void> {
 		}
 
 		logger.info("update", `Auto-installing update v${checkResult.latestVersion}`);
-		const installResult = await runUpdate(checkResult.latestVersion);
+		const installResult = await runUpdate(checkResult.latestVersion, {
+			onUpgraded: (from, to) => getActiveTelemetry()?.record("version.upgraded", { from, to }),
+		});
 
 		if (installResult.success) {
 			lastAutoUpdateAt = new Date();

--- a/platform/daemon/src/update-system.ts
+++ b/platform/daemon/src/update-system.ts
@@ -520,12 +520,15 @@ export function normalizeTargetVersion(targetVersion: string | undefined): strin
 }
 
 interface FinalizeSuccessfulUpdateDeps {
-	syncWorkspaceSourceRepoAsync: (workspaceDir: string) => Promise<WorkspaceSourceRepoSyncResult>;
+	syncWorkspaceSourceRepoAsync?: (workspaceDir: string) => Promise<WorkspaceSourceRepoSyncResult>;
 	updateDesktopInstallAfterUpdate?: (
 		repoSync: WorkspaceSourceRepoSyncResult,
 		installedVersion: string,
 		activeExecutablePath: string,
 	) => Promise<DesktopUpdateResult>;
+	/** Lifecycle hook (issue #1026 Phase 2): fired with (from, to) after a
+	 *  successful install so the daemon can emit `version.upgraded`. */
+	onUpgraded?: (from: string, to: string) => void;
 }
 
 interface SuccessfulUpdateMetadata {
@@ -536,6 +539,9 @@ interface SuccessfulUpdateMetadata {
 interface RunUpdateDeps extends UpdateInstallDeps {
 	readonly detectInstallations?: () => SignetInstallationReport;
 	readonly finalizeSuccessfulUpdate?: typeof finalizeSuccessfulUpdateInstall;
+	/** Lifecycle hook (issue #1026 Phase 2): (from, to) after a successful
+	 *  install; forwarded into finalizeSuccessfulUpdateInstall. */
+	readonly onUpgraded?: (from: string, to: string) => void;
 }
 
 function updateFailure(
@@ -761,7 +767,9 @@ export async function finalizeSuccessfulUpdateInstall(
 
 	let repoSync: WorkspaceSourceRepoSyncResult;
 	try {
-		repoSync = await deps.syncWorkspaceSourceRepoAsync(agentsDir);
+		repoSync = await (
+			deps.syncWorkspaceSourceRepoAsync ?? ((workspaceDir) => syncWorkspaceSourceRepoAsync(workspaceDir))
+		)(agentsDir);
 	} catch (error) {
 		repoSync = {
 			status: "error",
@@ -808,6 +816,7 @@ export async function finalizeSuccessfulUpdateInstall(
 	}
 
 	logger.info("system", "Update installed successfully");
+	deps.onUpgraded?.(currentVersion, installedVersion);
 	return {
 		success: true,
 		message: "Update installed. Restart daemon to apply.",
@@ -917,12 +926,16 @@ export async function runUpdate(targetVersion?: string, deps: RunUpdateDeps = {}
 		}
 
 		try {
-			return await (deps.finalizeSuccessfulUpdate ?? finalizeSuccessfulUpdateInstall)(
+			const finalizer = deps.finalizeSuccessfulUpdate ?? finalizeSuccessfulUpdateInstall;
+			return await finalizer(
 				verification.installedVersion,
 				output,
 				{
 					installMethod,
 					activeExecutablePath: target.executablePath,
+				},
+				{
+					onUpgraded: deps.onUpgraded,
 				},
 			);
 		} catch (error) {

--- a/scripts/install-copy-regression.test.ts
+++ b/scripts/install-copy-regression.test.ts
@@ -104,12 +104,15 @@ describe("install copy", () => {
 	test("keeps the postinstall telemetry ping anonymous and opt-out", () => {
 		const installer = read("dist/signetai/scripts/install-native.js");
 
-		// Phase-1 install counter (issue #1026): a single anonymous ping with
-		// version+platform only. No identifier, no payload beyond the query
-		// params, and never a hard failure path.
-		expect(installer).toContain("telemetry.signetai.sh/ping");
-		expect(installer).toContain('searchParams.set("v", nativePackageVersion())');
-		expect(installer).toContain('searchParams.set("p", platform)');
+		// Phase-1 install counter (issue #1026): a single anonymous PostHog
+		// event with version+platform only. No identifier, no payload beyond
+		// the event properties, and never a hard failure path. The project
+		// API key is a public ingest key by PostHog design.
+		expect(installer).toContain("us.i.posthog.com");
+		expect(installer).toContain("/batch/");
+		expect(installer).toContain('event: "install.ping"');
+		expect(installer).toContain("randomUUID");
+		expect(installer).toContain("phc_");
 
 		// Homebrew-style opt-out: one env var disables the ping entirely.
 		expect(installer).toContain("SIGNET_TELEMETRY_OPTOUT");

--- a/scripts/install-copy-regression.test.ts
+++ b/scripts/install-copy-regression.test.ts
@@ -101,6 +101,29 @@ describe("install copy", () => {
 		expect(installer).not.toContain("better-sqlite3");
 	});
 
+	test("keeps the postinstall telemetry ping anonymous and opt-out", () => {
+		const installer = read("dist/signetai/scripts/install-native.js");
+
+		// Phase-1 install counter (issue #1026): a single anonymous ping with
+		// version+platform only. No identifier, no payload beyond the query
+		// params, and never a hard failure path.
+		expect(installer).toContain("telemetry.signetai.sh/ping");
+		expect(installer).toContain('searchParams.set("v", nativePackageVersion())');
+		expect(installer).toContain('searchParams.set("p", platform)');
+
+		// Homebrew-style opt-out: one env var disables the ping entirely.
+		expect(installer).toContain("SIGNET_TELEMETRY_OPTOUT");
+
+		// The ping must never block or fail the install: it is fire-and-forget
+		// with a bounded timeout, and errors are swallowed.
+		expect(installer).toContain("AbortSignal.timeout");
+		expect(installer).toContain(".catch(() => {})");
+
+		// Workspace installs (dev) must not ping.
+		expect(installer).toContain("isWorkspacePackage()");
+		expect(installer).toContain("SIGNET_SKIP_NATIVE_POSTINSTALL");
+	});
+
 	test("curl installer downloads and verifies the connector-asset tarball", () => {
 		const installer = read("web/marketing/public/install.sh");
 

--- a/scripts/native-install-smoke.test.ts
+++ b/scripts/native-install-smoke.test.ts
@@ -310,6 +310,7 @@ describe("native install smoke", () => {
 		const result = await runCommand("node", [join(packageDir, "scripts", "install-native.js")], {
 			...process.env,
 			SIGNET_DOWNLOAD_BASE: release.downloadBase,
+			SIGNET_TELEMETRY_OPTOUT: "1",
 		});
 
 		expect(result.status).toBe(0);
@@ -414,6 +415,7 @@ describe("native install smoke", () => {
 		const result = await runCommand("node", [join(packageDir, "scripts", "install-native.js")], {
 			...process.env,
 			SIGNET_DOWNLOAD_BASE: `http://127.0.0.1:${address.port}/download`,
+			SIGNET_TELEMETRY_OPTOUT: "1",
 		});
 
 		expect(result.status).not.toBe(0);
@@ -557,7 +559,10 @@ describe("native install smoke", () => {
 		expect(directWrapper.stdout).toContain(`signet wrapper ${packageDir}`);
 		expect(directWrapper.stdout).toContain("fake native signet --version");
 
-		const install = await runCommand("node", [join(packageDir, "scripts", "install-native.js")], process.env);
+		const install = await runCommand("node", [join(packageDir, "scripts", "install-native.js")], {
+			...process.env,
+			SIGNET_TELEMETRY_OPTOUT: "1",
+		});
 
 		expect(install.status).toBe(0);
 		expect(install.stdout).toContain(`Linked Signet native binary for ${platform}`);

--- a/scripts/release-download-stats.test.ts
+++ b/scripts/release-download-stats.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import { type GitHubRelease, fetchReleases, summarizeReleases } from "./release-download-stats";
+
+const SAMPLE_RELEASES: readonly GitHubRelease[] = [
+	{
+		tag_name: "v0.163.15",
+		published_at: "2026-08-05T00:00:00Z",
+		assets: [
+			{ name: "signetai-linux-x64-0.163.15.tgz", download_count: 1200, size: 1000 },
+			{ name: "signetai-darwin-arm64-0.163.15.tgz", download_count: 800, size: 1000 },
+		],
+	},
+	{
+		tag_name: "v0.163.14",
+		published_at: "2026-08-01T00:00:00Z",
+		assets: [{ name: "signetai-linux-x64-0.163.14.tgz", download_count: 900, size: 1000 }],
+	},
+];
+
+describe("release-download-stats (issue #1026 Phase 3)", () => {
+	it("fetches releases from the GitHub API with the right request", async () => {
+		const calls: string[] = [];
+		const fakeFetch = async (url: string, init?: { headers?: Record<string, string> }): Promise<Response> => {
+			calls.push(url);
+			expect(init?.headers?.["Accept"]).toBe("application/vnd.github+json");
+			return new Response(JSON.stringify(SAMPLE_RELEASES), { status: 200 });
+		};
+
+		const releases = await fetchReleases("Signet-AI/signetai", 10, fakeFetch as unknown as typeof fetch);
+		expect(releases).toHaveLength(2);
+		expect(calls[0]).toContain("releases?per_page=10");
+	});
+
+	it("throws on a non-OK GitHub response", async () => {
+		const fakeFetch = async (): Promise<Response> => new Response("rate limited", { status: 403 });
+		await expect(fetchReleases("Signet-AI/signetai", 10, fakeFetch as unknown as typeof fetch)).rejects.toThrow(
+			"GitHub API 403",
+		);
+	});
+
+	it("aggregates per-release and per-asset download counts", () => {
+		const result = summarizeReleases(SAMPLE_RELEASES);
+		expect(result.repo).toBe("Signet-AI/signetai");
+		expect(result.totalDownloads).toBe(2900);
+		expect(result.releases[0].totalDownloads).toBe(2000);
+		expect(result.releases[0].assets[0]).toEqual({ name: "signetai-linux-x64-0.163.15.tgz", downloads: 1200 });
+		// Assets sorted by downloads descending
+		expect(result.releases[0].assets[0].downloads).toBeGreaterThanOrEqual(result.releases[0].assets[1].downloads);
+	});
+
+	it("handles releases without assets", () => {
+		const result = summarizeReleases([{ tag_name: "v0.1.0", published_at: null, assets: [] }]);
+		expect(result.releases[0].totalDownloads).toBe(0);
+		expect(result.releases[0].publishedAt).toBeNull();
+		expect(result.totalDownloads).toBe(0);
+	});
+});

--- a/scripts/release-download-stats.test.ts
+++ b/scripts/release-download-stats.test.ts
@@ -22,7 +22,7 @@ describe("release-download-stats (issue #1026 Phase 3)", () => {
 		const calls: string[] = [];
 		const fakeFetch = async (url: string, init?: { headers?: Record<string, string> }): Promise<Response> => {
 			calls.push(url);
-			expect(init?.headers?.["Accept"]).toBe("application/vnd.github+json");
+			expect(init?.headers?.Accept).toBe("application/vnd.github+json");
 			return new Response(JSON.stringify(SAMPLE_RELEASES), { status: 200 });
 		};
 

--- a/scripts/release-download-stats.ts
+++ b/scripts/release-download-stats.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env bun
+
+/**
+ * GitHub release download stats (issue #1026 Phase 3).
+ *
+ * Surfaces the cleaner install signal the issue calls out: GitHub release
+ * asset download counts. Each download is a real binary/connector fetch —
+ * unlike npm download totals, which include CI pipelines, npx one-offs, and
+ * version-update churn.
+ *
+ * Queries the public GitHub REST API (no auth needed for public repos; the
+ * unauthenticated rate limit of 60 req/hr is fine for this) and aggregates
+ * `download_count` per release and per asset. Output is a markdown table
+ * (default) or NDJSON (`--json`) suitable for dashboards.
+ *
+ * Usage:
+ *   bun scripts/release-download-stats.ts [--json] [--releases N]
+ */
+
+const REPO = "Signet-AI/signetai";
+const DEFAULT_RELEASES = 10;
+
+interface GitHubAsset {
+	readonly name: string;
+	readonly download_count: number;
+	readonly size: number;
+}
+
+export interface GitHubRelease {
+	readonly tag_name: string;
+	readonly published_at: string | null;
+	readonly assets: readonly GitHubAsset[];
+}
+
+export interface ReleaseDownloadStat {
+	readonly tag: string;
+	readonly publishedAt: string | null;
+	readonly totalDownloads: number;
+	readonly assets: ReadonlyArray<{ readonly name: string; readonly downloads: number }>;
+}
+
+export interface ReleaseStatsResult {
+	readonly repo: string;
+	readonly releases: readonly ReleaseDownloadStat[];
+	readonly totalDownloads: number;
+}
+
+/** Fetch releases from the GitHub API. Injectable for tests. */
+export async function fetchReleases(
+	repo: string,
+	releases = DEFAULT_RELEASES,
+	fetchImpl: typeof fetch = fetch,
+): Promise<readonly GitHubRelease[]> {
+	const url = `https://api.github.com/repos/${repo}/releases?per_page=${releases}`;
+	const res = await fetchImpl(url, {
+		headers: { Accept: "application/vnd.github+json", "User-Agent": "signet-release-stats" },
+	});
+	if (!res.ok) {
+		throw new Error(`GitHub API ${res.status} fetching ${url}`);
+	}
+	const body = (await res.json()) as readonly GitHubRelease[];
+	return body;
+}
+
+/** Aggregate per-release download counts. */
+export function summarizeReleases(releases: readonly GitHubRelease[]): ReleaseStatsResult {
+	const stats: ReleaseDownloadStat[] = releases.map((release) => ({
+		tag: release.tag_name,
+		publishedAt: release.published_at,
+		totalDownloads: release.assets.reduce((sum, asset) => sum + asset.download_count, 0),
+		assets: release.assets
+			.map((asset) => ({ name: asset.name, downloads: asset.download_count }))
+			.sort((a, b) => b.downloads - a.downloads),
+	}));
+	return {
+		repo: REPO,
+		releases: stats,
+		totalDownloads: stats.reduce((sum, release) => sum + release.totalDownloads, 0),
+	};
+}
+
+function formatTable(result: ReleaseStatsResult): string {
+	const rows = result.releases.map(
+		(release) =>
+			`| ${release.tag} | ${release.publishedAt?.slice(0, 10) ?? "—"} | ${release.totalDownloads.toLocaleString()} | ${release.assets
+				.slice(0, 3)
+				.map((asset) => `${asset.name}: ${asset.downloads.toLocaleString()}`)
+				.join("<br>")} |`,
+	);
+	return [
+		`# Release download stats — ${result.repo}`,
+		"",
+		`Total asset downloads across ${result.releases.length} releases: **${result.totalDownloads.toLocaleString()}**`,
+		"",
+		"| Release | Published | Downloads | Top assets |",
+		"|---|---|---|---|",
+		...rows,
+		"",
+	].join("\n");
+}
+
+async function main(): Promise<void> {
+	const json = process.argv.includes("--json");
+	const releasesFlag = process.argv.indexOf("--releases");
+	const releases = releasesFlag >= 0 ? Number.parseInt(process.argv[releasesFlag + 1] ?? "", 10) : DEFAULT_RELEASES;
+
+	const releasesData = await fetchReleases(
+		REPO,
+		Number.isFinite(releases) && releases > 0 ? releases : DEFAULT_RELEASES,
+	);
+	const result = summarizeReleases(releasesData);
+
+	if (json) {
+		console.log(JSON.stringify(result, null, 2));
+	} else {
+		console.log(formatTable(result));
+	}
+}
+
+if (import.meta.main) {
+	main().catch((err) => {
+		console.error(`release-download-stats failed: ${err instanceof Error ? err.message : String(err)}`);
+		process.exit(1);
+	});
+}

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -101,6 +101,7 @@ import { importFromGitHub } from "./features/import.js";
 import { installNativeBinary, printNativeInstallResult } from "./features/native-install.js";
 import { setupWizard } from "./features/setup.js";
 import { copyDirRecursive, syncBuiltinSkills, syncTemplates } from "./features/sync.js";
+import { recordCommandInvoked } from "./features/telemetry.js";
 import { signetBanner } from "./lib/banner.js";
 import { createDaemonClient, ensureDaemonRunning } from "./lib/daemon.js";
 import { gitAddAndCommit, gitInit, isGitRepo } from "./lib/git.js";
@@ -922,6 +923,10 @@ program.hook("preAction", async (_thisCommand, actionCommand) => {
 	if (!existsSync(AGENTS_DIR)) {
 		return;
 	}
+
+	// Open telemetry log (issue #1026 Phase 2): record the command name
+	// (never arguments) when the user has opted in. Best-effort.
+	recordCommandInvoked(AGENTS_DIR, topLevelCommand);
 
 	await ensureOpenClawPluginPackage(AGENTS_DIR, { silent: true });
 });

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -219,6 +219,26 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 			config.daemon = { url: plan.daemonUrl };
 		}
 
+		// Anonymous telemetry opt-in (issue #1026 Phase 2). Interactive setups
+		// get a clear yes/no; non-interactive (CI/scripted) setups stay
+		// opted-out by default. Telemetry is off unless explicitly enabled.
+		let telemetryOptIn = false;
+		if (!context.nonInteractive) {
+			telemetryOptIn = await import("@inquirer/prompts").then(({ confirm }) =>
+				confirm({
+					message:
+						"Share anonymous usage statistics (version, platform, command names) to help improve Signet? No memory content, code, or personal data. See ~/.agents/.daemon/telemetry/events.jsonl for exactly what is sent.",
+					default: false,
+				}),
+			);
+		}
+		if (telemetryOptIn) {
+			config.pipelineV2 = {
+				...(config.pipelineV2 as Record<string, unknown> | undefined),
+				telemetryEnabled: true,
+			};
+		}
+
 		writeFileSync(join(context.basePath, "agent.yaml"), formatYaml(config));
 
 		// Connect configured sources (config files the daemon indexes at boot).

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -234,10 +234,12 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 				}),
 			);
 		}
-		config.pipelineV2 = {
-			...(config.pipelineV2 as Record<string, unknown> | undefined),
-			telemetryEnabled,
-		};
+		// The daemon reads telemetryEnabled from memory.pipelineV2 — writing it
+		// at the top level would be silently ignored and the opt-out would not
+		// reach the daemon.
+		const memoryCfg = (config.memory as Record<string, unknown> | undefined) ?? {};
+		const pipelineCfg = (memoryCfg.pipelineV2 as Record<string, unknown> | undefined) ?? {};
+		config.memory = { ...memoryCfg, pipelineV2: { ...pipelineCfg, telemetryEnabled } };
 
 		writeFileSync(join(context.basePath, "agent.yaml"), formatYaml(config));
 

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -219,25 +219,25 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 			config.daemon = { url: plan.daemonUrl };
 		}
 
-		// Anonymous telemetry opt-in (issue #1026 Phase 2). Interactive setups
-		// get a clear yes/no; non-interactive (CI/scripted) setups stay
-		// opted-out by default. Telemetry is off unless explicitly enabled.
-		let telemetryOptIn = false;
+		// Anonymous telemetry disclosure (issue #1026 Phase 2). Telemetry is ON
+		// by default; interactive setups get a chance to disable it, and
+		// non-interactive (CI/scripted) setups keep the default. Every recorded
+		// event is mirrored to ~/.agents/.daemon/telemetry/events.jsonl so
+		// users can audit exactly what is sent.
+		let telemetryEnabled = true;
 		if (!context.nonInteractive) {
-			telemetryOptIn = await import("@inquirer/prompts").then(({ confirm }) =>
+			telemetryEnabled = await import("@inquirer/prompts").then(({ confirm }) =>
 				confirm({
 					message:
-						"Share anonymous usage statistics (version, platform, command names) to help improve Signet? No memory content, code, or personal data. See ~/.agents/.daemon/telemetry/events.jsonl for exactly what is sent.",
-					default: false,
+						"Help improve Signet by sharing anonymous usage statistics (version, platform, command names)? No memory content, code, or personal data. Every event is logged to ~/.agents/.daemon/telemetry/events.jsonl; disable anytime with telemetryEnabled: false.",
+					default: true,
 				}),
 			);
 		}
-		if (telemetryOptIn) {
-			config.pipelineV2 = {
-				...(config.pipelineV2 as Record<string, unknown> | undefined),
-				telemetryEnabled: true,
-			};
-		}
+		config.pipelineV2 = {
+			...(config.pipelineV2 as Record<string, unknown> | undefined),
+			telemetryEnabled,
+		};
 
 		writeFileSync(join(context.basePath, "agent.yaml"), formatYaml(config));
 

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -427,7 +427,11 @@ describe("setupWizard non-interactive harness hooks", () => {
 
 		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
 		// Telemetry is on by default; non-interactive setups keep the default.
-		expect(agentYaml).toContain("telemetryEnabled: true");
+		// The flag must land under memory.pipelineV2 — the path the daemon
+		// reads — or the opt-out would be silently ignored (regression:
+		// setup wrote top-level pipelineV2, which the daemon never sees).
+		expect(agentYaml.indexOf("memory:")).toBeGreaterThanOrEqual(0);
+		expect(agentYaml.indexOf("telemetryEnabled: true")).toBeGreaterThan(agentYaml.indexOf("memory:"));
 	});
 
 	it("writes custom identity preset with concrete files for every referenced path", async () => {

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -405,7 +405,7 @@ describe("setupWizard non-interactive harness hooks", () => {
 		expect(existsSync(join(basePath, "SOUL.md"))).toBe(false);
 	});
 
-	it("keeps telemetry opted out in non-interactive setup (issue #1026 Phase 2)", async () => {
+	it("keeps telemetry enabled in non-interactive setup (issue #1026 Phase 2)", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-ni-telemetry-"));
 		const basePath = join(root, "agents");
 		const templatesPath = join(root, "templates");
@@ -426,7 +426,8 @@ describe("setupWizard non-interactive harness hooks", () => {
 		await setupWizard({ nonInteractive: true, skipGit: true }, deps);
 
 		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
-		expect(agentYaml).not.toContain("telemetryEnabled: true");
+		// Telemetry is on by default; non-interactive setups keep the default.
+		expect(agentYaml).toContain("telemetryEnabled: true");
 	});
 
 	it("writes custom identity preset with concrete files for every referenced path", async () => {

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -405,6 +405,30 @@ describe("setupWizard non-interactive harness hooks", () => {
 		expect(existsSync(join(basePath, "SOUL.md"))).toBe(false);
 	});
 
+	it("keeps telemetry opted out in non-interactive setup (issue #1026 Phase 2)", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-ni-telemetry-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		mkdirSync(templatesPath, { recursive: true });
+
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			getTemplatesDir: mock(() => templatesPath),
+			normalizeAgentPath: mock((p: string) => p),
+			detectExistingSetup: mock(() => ({
+				...fakeDetection(basePath),
+				agentsDir: false,
+				memoryDb: false,
+				hasMemoryDir: false,
+			})),
+		});
+
+		await setupWizard({ nonInteractive: true, skipGit: true }, deps);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).not.toContain("telemetryEnabled: true");
+	});
+
 	it("writes custom identity preset with concrete files for every referenced path", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-ni-custom-identity-"));
 		const basePath = join(root, "agents");

--- a/surfaces/cli/src/features/telemetry.test.ts
+++ b/surfaces/cli/src/features/telemetry.test.ts
@@ -10,7 +10,7 @@ function writeAgentYaml(telemetryEnabled?: boolean): void {
 	const telemetryLine = telemetryEnabled === undefined ? "" : `telemetryEnabled: ${telemetryEnabled}`;
 	writeFileSync(
 		join(dir, "agent.yaml"),
-		`version: 1\nschema: signet/v1\npipelineV2:\n  ${telemetryLine || "# no telemetry"}\n`,
+		`version: 1\nschema: signet/v1\nmemory:\n  pipelineV2:\n    ${telemetryLine || "# no telemetry"}\n`,
 		"utf-8",
 	);
 }

--- a/surfaces/cli/src/features/telemetry.test.ts
+++ b/surfaces/cli/src/features/telemetry.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cliTelemetryEnabled, cliTelemetryLogPath, recordCommandInvoked } from "./telemetry";
+
+let dir = "";
+
+function writeAgentYaml(telemetryEnabled?: boolean): void {
+	const telemetryLine = telemetryEnabled === undefined ? "" : `telemetryEnabled: ${telemetryEnabled}`;
+	writeFileSync(
+		join(dir, "agent.yaml"),
+		`version: 1\nschema: signet/v1\npipelineV2:\n  ${telemetryLine || "# no telemetry"}\n`,
+		"utf-8",
+	);
+}
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "signet-cli-telemetry-"));
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("cli telemetry (issue #1026 Phase 2)", () => {
+	it("is disabled when agent.yaml has no telemetryEnabled", () => {
+		writeAgentYaml();
+		expect(cliTelemetryEnabled(dir)).toBe(false);
+	});
+
+	it("is disabled when telemetryEnabled is false", () => {
+		writeAgentYaml(false);
+		expect(cliTelemetryEnabled(dir)).toBe(false);
+	});
+
+	it("is enabled when telemetryEnabled is true", () => {
+		writeAgentYaml(true);
+		expect(cliTelemetryEnabled(dir)).toBe(true);
+	});
+
+	it("is disabled when agent.yaml is missing", () => {
+		expect(cliTelemetryEnabled(dir)).toBe(false);
+	});
+
+	it("records command.invoked to the shared log when enabled", () => {
+		writeAgentYaml(true);
+		recordCommandInvoked(dir, "remember");
+		const logPath = cliTelemetryLogPath(dir);
+		expect(existsSync(logPath)).toBe(true);
+		const line = JSON.parse(readFileSync(logPath, "utf-8").trim()) as {
+			event: string;
+			properties: { command: string };
+		};
+		expect(line.event).toBe("command.invoked");
+		expect(line.properties.command).toBe("remember");
+	});
+
+	it("does not write anything when telemetry is disabled", () => {
+		writeAgentYaml(false);
+		recordCommandInvoked(dir, "remember");
+		expect(existsSync(cliTelemetryLogPath(dir))).toBe(false);
+	});
+
+	it("never throws when the agents dir is missing", () => {
+		expect(() => recordCommandInvoked(join(dir, "missing"), "status")).not.toThrow();
+	});
+});

--- a/surfaces/cli/src/features/telemetry.test.ts
+++ b/surfaces/cli/src/features/telemetry.test.ts
@@ -24,9 +24,9 @@ afterEach(() => {
 });
 
 describe("cli telemetry (issue #1026 Phase 2)", () => {
-	it("is disabled when agent.yaml has no telemetryEnabled", () => {
+	it("is enabled by default when agent.yaml has no telemetryEnabled", () => {
 		writeAgentYaml();
-		expect(cliTelemetryEnabled(dir)).toBe(false);
+		expect(cliTelemetryEnabled(dir)).toBe(true);
 	});
 
 	it("is disabled when telemetryEnabled is false", () => {

--- a/surfaces/cli/src/features/telemetry.ts
+++ b/surfaces/cli/src/features/telemetry.ts
@@ -25,14 +25,18 @@ export function cliTelemetryLogPath(agentsDir: string): string {
 	return join(agentsDir, ".daemon", "telemetry", "events.jsonl");
 }
 
-/** True when the user has opted into anonymous telemetry in agent.yaml. */
+/**
+ * True when anonymous telemetry is active for this workspace. Telemetry is on
+ * by default, so the flag is only false when agent.yaml explicitly sets
+ * `telemetryEnabled: false`.
+ */
 export function cliTelemetryEnabled(agentsDir: string): boolean {
 	try {
 		const yamlPath = join(agentsDir, "agent.yaml");
 		if (!existsSync(yamlPath)) return false;
 		const config = parseSimpleYaml(readFileSync(yamlPath, "utf-8"));
 		const pipeline = config?.pipelineV2 as Record<string, unknown> | undefined;
-		return pipeline?.telemetryEnabled === true;
+		return pipeline?.telemetryEnabled !== false;
 	} catch {
 		return false;
 	}

--- a/surfaces/cli/src/features/telemetry.ts
+++ b/surfaces/cli/src/features/telemetry.ts
@@ -35,7 +35,8 @@ export function cliTelemetryEnabled(agentsDir: string): boolean {
 		const yamlPath = join(agentsDir, "agent.yaml");
 		if (!existsSync(yamlPath)) return false;
 		const config = parseSimpleYaml(readFileSync(yamlPath, "utf-8"));
-		const pipeline = config?.pipelineV2 as Record<string, unknown> | undefined;
+		const memory = config?.memory as Record<string, unknown> | undefined;
+		const pipeline = memory?.pipelineV2 as Record<string, unknown> | undefined;
 		return pipeline?.telemetryEnabled !== false;
 	} catch {
 		return false;

--- a/surfaces/cli/src/features/telemetry.ts
+++ b/surfaces/cli/src/features/telemetry.ts
@@ -1,0 +1,60 @@
+/**
+ * CLI-side open telemetry log (issue #1026 Phase 2).
+ *
+ * The daemon mirrors every opted-in telemetry event to a JSONL file at
+ * `<agentsDir>/.daemon/telemetry/events.jsonl`. The CLI appends
+ * `command.invoked` lines to the same file when the user has opted in
+ * (`telemetryEnabled: true` in agent.yaml), so the open telemetry log is
+ * the single audit surface for both daemon events and command usage.
+ *
+ * Local-first: reading the flag and appending a line are best-effort and
+ * never block or fail the command. No daemon round-trip, no auth needed.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { parseSimpleYaml } from "@signet/core";
+
+export const TELEMETRY_EVENT = "command.invoked";
+
+/**
+ * Resolve the shared open-telemetry log path, mirroring the daemon's
+ * `defaultTelemetryLogPath` (issue #1026).
+ */
+export function cliTelemetryLogPath(agentsDir: string): string {
+	return join(agentsDir, ".daemon", "telemetry", "events.jsonl");
+}
+
+/** True when the user has opted into anonymous telemetry in agent.yaml. */
+export function cliTelemetryEnabled(agentsDir: string): boolean {
+	try {
+		const yamlPath = join(agentsDir, "agent.yaml");
+		if (!existsSync(yamlPath)) return false;
+		const config = parseSimpleYaml(readFileSync(yamlPath, "utf-8"));
+		const pipeline = config?.pipelineV2 as Record<string, unknown> | undefined;
+		return pipeline?.telemetryEnabled === true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Append a `command.invoked` line to the open telemetry log when telemetry
+ * is enabled. Payload is the command name only — never arguments. Best-effort.
+ */
+export function recordCommandInvoked(agentsDir: string, commandName: string): void {
+	try {
+		if (!cliTelemetryEnabled(agentsDir)) return;
+		const logPath = cliTelemetryLogPath(agentsDir);
+		mkdirSync(dirname(logPath), { recursive: true });
+		const line = JSON.stringify({
+			id: crypto.randomUUID(),
+			event: TELEMETRY_EVENT,
+			timestamp: new Date().toISOString(),
+			properties: { command: commandName },
+		});
+		appendFileSync(logPath, `${line}\n`, "utf-8");
+	} catch {
+		// Never break the command on telemetry write failures.
+	}
+}


### PR DESCRIPTION
## Summary

Completes ROADMAP #1026 in full — the distribution telemetry plan, all three
phases — now that the PostHog foundation landed (#1169). This is a takeover
and rebase of #1130 (Avery Felts) onto current main, with the product
decisions applied:

- Telemetry is **on by default** (basic usage telemetry — version, platform,
  command names, LLM usage counts; never conversation content, memory,
  identity, or file paths). `signet setup` discloses this and asks whether to
  disable; `telemetryEnabled: false` opts out anywhere.
- PostHog is the single analytics sink. The Phase 1 install ping now posts to
  the Signet PostHog project (`/batch/` with the public ingest key) instead
  of the non-existent `telemetry.signetai.sh` endpoint. Each ping carries a
  fresh anonymous uuid so every install counts once.
- The open JSONL log at `<agentsDir>/.daemon/telemetry/events.jsonl` stays —
  it is the auditability surface that makes default-on defensible.

## Changes

Phase 1 — install counter (Avery's, modified):
- `dist/signetai/scripts/install-native.js`: postinstall ping rerouted to
  PostHog `https://us.i.posthog.com/batch/` with `install.ping` event,
  fresh uuid distinct_id, version+platform only. `SIGNET_TELEMETRY_OPTOUT=1`
  and workspace/skip guards preserved; fire-and-forget with 2s timeout.

Phase 2 — daemon/CLI lifecycle telemetry (Avery's, modified):
- `telemetry.ts`: `daemon.started`, `command.invoked`, `error.occurred`,
  `version.upgraded` event types + JSONL open-log mirroring
  (`defaultTelemetryLogPath`); merges cleanly with #1169's per-install id and
  distinct_id work.
- `daemon.ts`: `daemon.started` fired at startup; `error.occurred` on
  uncaughtException/unhandledRejection (type only, never stack/message) —
  adapted to the current `requestShutdown` crash path.
- `update-system.ts`: `onUpgraded` hook; **now actually wired** — the daemon
  auto-update path passes it so `version.upgraded` fires (was declared but
  never called).
- `surfaces/cli/src/features/telemetry.ts`: `command.invoked` appended to the
  shared open log from the CLI preAction hook; resolves default-on (only an
  explicit `telemetryEnabled: false` disables).
- `setup-fresh.ts`: telemetry disclosure prompt, default accept; writes the
  resolved flag explicitly.

Phase 3 — release download stats (Avery's, unmodified):
- `scripts/release-download-stats.ts` + test: per-release/per-asset download
  counts from the public GitHub API.

Docs: CONFIGURATION.md + ANALYTICS.md describe default-on, the open log, and
the recorded events. Tests: merged `telemetry.test.ts` suites (install-id +
JSONL) on a shared harness; all Phase 1/2/3 tests updated for the new
contracts.

## Type

- [x] `feat` — new user-facing feature (bumps minor)

## Packages affected

- [x] `@signet/core` — no schema change (uses #1169's migration 109)
- [x] `@signet/daemon` — telemetry, daemon, update-system
- [x] `@signet/cli` / dashboard — setup-fresh, cli, features/telemetry
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: dist/signetai wrapper + scripts + docs

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries — telemetry is
      intentionally global-anonymous; no agent scoping applies
- [x] Input/config validation and bounds checks added — config resolution
      unchanged from #1169 (clamped via memory-config resolvers); the CLI
      flag read is best-effort with try/catch
- [x] Error handling and fallback paths tested (no silent swallow) — install
      ping and CLI log writes are fire-and-forget, time-bounded, never fail
      the install/command (tested: unwritable log path, unreachable host)
- [x] Security checks applied to admin/mutation endpoints — N/A, no endpoints
      added; the public ingest key is a PostHog project API key (public by
      design, ingest-only)
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no schema changes in this PR (relies on #1169's migration 109).

## Testing

- [x] `bun test` passes — 335 pass / 0 fail across telemetry, update-system,
      hooks, migrations, install-copy-regression, release-download-stats,
      native-install-smoke, setup, CLI-telemetry suites
- [x] `bun run typecheck` passes — full workspace green
- [x] `bun run lint` passes — biome clean on all touched files
- [x] Tested against running daemon — the PostHog batch path was live-verified
      in #1169 against the real project (6 events accepted, 0 unsent)
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Original authorship preserved: commits 16cc785cb (ping), d22794e20 (Phase 2),
  0e7b259dd (Phase 3) are Avery Felts' work cherry-picked from #1130 and
  rebased onto main. The final commit applies the takeover decisions
  (PostHog routing, default-on disclosure, version.upgraded wiring).
- Avery's unrelated provider.test.ts flaky-test fixes (a5fc2d245) were
  deliberately left out — they belong in their own PR.
- `command.invoked` events land in the open JSONL log (audit surface); they
  are not flushed to PostHog, since the CLI has no collector. Documented in
  ANALYTICS.md.
- Known environmental failures on this machine (fail identically on clean
  main, not related to this PR): inference-api and maintenance-worker tests
  that call live Ollama/OpenAI-compatible providers.
- #1130 will be closed in favor of this PR.
- Adversarial review found one HIGH: setup wrote `telemetryEnabled` to a
  top-level `pipelineV2` key the daemon never reads, so declining the
  disclosure left telemetry enabled. Fixed (c51ea6674): the flag now lands
  under `memory.pipelineV2` (the canonical path), the CLI reads the same
  path, and the setup test pins the nesting as a regression guard.
