### PR TITLE
fix(dreaming): pin hygiene archive targets by subjectRef when flag details omit ids

### DIFF
--- a/platform/daemon/src/pipeline/dreaming-operations.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.test.ts
@@ -115,6 +115,106 @@ describe("dreaming operations", () => {
 		).toEqual({ c: 0 });
 	});
 
+	it("archives an entity flagged without an entityId in details, pinned by subjectRef alone (#1168)", () => {
+		insertEntity("e-husk", "Legacy Husk", "legacy husk");
+		const result = applyDreamingOperations({
+			accessor: getDbAccessor(),
+			agentId: "agent-a",
+			actor: "dreaming",
+			passId: "pass-1",
+			operations: [
+				// Agent-minted flags carry inspection facts in details but no
+				// entityId; the subjectRef is the only id pin.
+				flag({ subjectRef: "entity:e-husk", details: { reason: "zero_active_attributes" } }),
+				{
+					operation: "archive_entity",
+					payload: { target: "e-husk", reason: "non-concrete" },
+					provenance: "attention:$0",
+				},
+			],
+		});
+		expect(result.ok).toBe(true);
+		expect(result.items[1]!.ok).toBe(true);
+		expect(
+			getDbAccessor().withReadDb((db) => db.prepare("SELECT status FROM entities WHERE id = ?").get("e-husk")),
+		).toEqual({ status: "archived" });
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db.prepare("SELECT COUNT(*) AS c FROM dreaming_attention WHERE resolved_at IS NULL").get() as { c: number },
+			),
+		).toEqual({ c: 0 });
+	});
+
+	it("archives an entity flagged without an entityId in a prior batch via attention:<uuid> (#1168)", () => {
+		insertEntity("e-husk", "Legacy Husk", "legacy husk");
+		const minted = applyDreamingOperations({
+			accessor: getDbAccessor(),
+			agentId: "agent-a",
+			actor: "dreaming",
+			operations: [flag({ subjectRef: "entity:e-husk", details: { reason: "zero_active_attributes" } })],
+		});
+		const attentionId = (minted.items[0]!.result as { attentionId: string | null }).attentionId!;
+		const result = applyDreamingOperations({
+			accessor: getDbAccessor(),
+			agentId: "agent-a",
+			actor: "dreaming",
+			passId: "pass-2",
+			operations: [
+				{ operation: "archive_entity", payload: { target: "e-husk" }, provenance: `attention:${attentionId}` },
+			],
+		});
+		expect(result.ok).toBe(true);
+		expect(
+			getDbAccessor().withReadDb((db) => db.prepare("SELECT status FROM entities WHERE id = ?").get("e-husk")),
+		).toEqual({ status: "archived" });
+	});
+
+	it("rejects an archive whose details id contradicts the flagged subjectRef", () => {
+		insertEntity("e-flagged", "Flagged", "flagged");
+		const result = applyDreamingOperations({
+			accessor: getDbAccessor(),
+			agentId: "agent-a",
+			actor: "dreaming",
+			operations: [
+				flag({ subjectRef: "entity:e-flagged", details: { entityId: "e-other", reason: "x" } }),
+				{ operation: "archive_entity", payload: { target: "e-flagged" }, provenance: "attention:$0" },
+			],
+		});
+		expect(result.ok).toBe(false);
+		expect(result.error).toBe("Hygiene archives require attention provenance (attention:$<index> or attention:<uuid>)");
+		expect(
+			getDbAccessor().withReadDb((db) => db.prepare("SELECT status FROM entities WHERE id = ?").get("e-flagged")),
+		).toEqual({ status: "active" });
+	});
+
+	it("merges a flagged duplicate group flagged without a canonicalName in details (#1168)", () => {
+		insertEntity("e-target", "Acme", "acme");
+		insertEntity("e-source", "Acme App", "acme");
+		const result = applyDreamingOperations({
+			accessor: getDbAccessor(),
+			agentId: "agent-a",
+			actor: "dreaming",
+			passId: "pass-3",
+			operations: [
+				// Agent-minted flags carry the canonical name only in the subjectRef.
+				flag({ subjectRef: "duplicate:acme", details: { reason: "duplicate_canonical_name" } }),
+				{
+					operation: "merge_entities",
+					payload: { targets: ["e-target", "e-source"], survivor: "e-target" },
+					provenance: "attention:$0",
+				},
+			],
+		});
+		expect(result.ok).toBe(true);
+		expect(
+			getDbAccessor().withReadDb((db) => db.prepare("SELECT id FROM entities WHERE id = ?").get("e-source")),
+		).toBeNull();
+		expect(
+			getDbAccessor().withReadDb((db) => db.prepare("SELECT id FROM entities WHERE id = ?").get("e-target")),
+		).not.toBeNull();
+	});
+
 	it("rejects a same-batch archive whose target is not the flagged entity", () => {
 		insertEntity("e-flagged", "Flagged", "flagged");
 		insertEntity("e-other", "Other", "other");

--- a/platform/daemon/src/pipeline/dreaming-operations.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.test.ts
@@ -215,6 +215,79 @@ describe("dreaming operations", () => {
 		).not.toBeNull();
 	});
 
+
+	it("rejects a merge_aspects whose details aspectId contradicts the flagged subjectRef", () => {
+		insertEntity("e-merge3", "MergeThree", "mergethree");
+		insertAspect("a-t3", "e-merge3", "target");
+		insertAspect("a-s3", "e-merge3", "source");
+		const result = applyDreamingOperations({
+			accessor: getDbAccessor(),
+			agentId: "agent-a",
+			actor: "dreaming",
+			operations: [
+				// The details aspectId names a different aspect than the subjectRef pin.
+				flag({ subjectRef: "aspect:a-s3", details: { aspectId: "a-other", reason: "aspect_over_cap" } }),
+				{
+					operation: "merge_aspects",
+					payload: { entityId: "e-merge3", target: "a-t3", sources: ["a-other"] },
+					provenance: "attention:$0",
+				},
+			],
+		});
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain("Hygiene archives require attention provenance");
+	});
+
+	it("rejects a duplicate merge flagged with an empty canonical name", () => {
+		insertEntity("e-1", "One", "");
+		insertEntity("e-2", "Two", "");
+		const result = applyDreamingOperations({
+			accessor: getDbAccessor(),
+			agentId: "agent-a",
+			actor: "dreaming",
+			operations: [
+				flag({ subjectRef: "duplicate:", details: { reason: "duplicate_canonical_name" } }),
+				{
+					operation: "merge_entities",
+					payload: { targets: ["e-1", "e-2"], survivor: "e-1" },
+					provenance: "attention:$0",
+				},
+			],
+		});
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain("Hygiene archives require attention provenance");
+	});
+
+	it("consumes a flag after the first hygiene op citing it", () => {
+		insertEntity("e-a", "A", "acme");
+		insertEntity("e-b", "B", "acme");
+		insertEntity("e-c", "C", "acme");
+		insertEntity("e-d", "D", "acme");
+		const result = applyDreamingOperations({
+			accessor: getDbAccessor(),
+			agentId: "agent-a",
+			actor: "dreaming",
+			passId: "pass-4",
+			operations: [
+				flag({ subjectRef: "duplicate:acme", details: { canonicalName: "acme", reason: "duplicate_canonical_name" } }),
+				{
+					operation: "merge_entities",
+					payload: { targets: ["e-a", "e-b"], survivor: "e-a" },
+					provenance: "attention:$0",
+				},
+				{
+					operation: "merge_entities",
+					payload: { targets: ["e-c", "e-d"], survivor: "e-c" },
+					provenance: "attention:$0",
+				},
+			],
+		});
+		expect(result.ok).toBe(true);
+		expect(result.items[1]!.ok).toBe(true);
+		expect(result.items[2]!.ok).toBe(false);
+		expect(result.items[2]!.error).toContain("already consumed");
+	});
+
 	it("rejects a same-batch archive whose target is not the flagged entity", () => {
 		insertEntity("e-flagged", "Flagged", "flagged");
 		insertEntity("e-other", "Other", "other");

--- a/platform/daemon/src/pipeline/dreaming-operations.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.ts
@@ -215,6 +215,7 @@ function attentionProvenance(
 			attention.details.canonicalName ?? pinnedBySubjectRef(attention.subjectRef, "duplicate:") ?? "";
 		const groupIds = semanticDuplicateIds(accessor, agentId, canonicalName);
 		expectedTarget =
+			canonicalName.length > 0 &&
 			attention.subjectRef === `duplicate:${canonicalName}` &&
 			groupIds.size > 1 &&
 			groupIds.has(survivor) &&
@@ -223,16 +224,23 @@ function attentionProvenance(
 			targets.includes(survivor) &&
 			targets.some((id) => id !== survivor);
 	} else if (operation.operation === "merge_aspects") {
-		// The flag names the over-cap aspect; the merge must fold it into a target.
+		// The flag names the over-cap aspect; the merge must fold it into a
+		// target. The subjectRef is the pin; details.aspectId is an optional
+		// cross-check — a contradictory details id must reject, not redirect
+		// the merge to a different aspect (#1168).
 		const sources = Array.isArray(payload.sources)
 			? payload.sources.filter((value): value is string => typeof value === "string")
 			: [];
-		const flaggedAspect = attention.details.aspectId ?? pinnedBySubjectRef(attention.subjectRef, "aspect:") ?? "";
+		const pinnedAspect = pinnedBySubjectRef(attention.subjectRef, "aspect:");
+		const detailAgrees =
+			pinnedAspect !== null &&
+			(attention.details.aspectId === undefined || attention.details.aspectId === pinnedAspect);
 		expectedTarget =
-			attention.subjectRef.startsWith("aspect:") &&
+			detailAgrees &&
 			typeof payload.target === "string" &&
 			sources.length >= 1 &&
-			sources.includes(flaggedAspect);
+			pinnedAspect !== null &&
+			sources.includes(pinnedAspect);
 	}
 	if (!expectedTarget) return null;
 
@@ -621,6 +629,26 @@ export function applyDreamingOperations(params: {
 				// flag op: nothing to apply; surface the minted attention id
 				items.push({ index, ok: true, result: { attentionId: entry.attentionId } });
 				continue;
+			}
+			if (entry.attentionId !== null) {
+				// A flag is one-use: an earlier op in this batch may have
+				// already consumed it, so a second op citing the same
+				// attention must not apply. Resolved flags (from a prior
+				// batch) were already rejected by the provenance pin.
+				const pending = db
+					.prepare(
+						`SELECT 1 FROM dreaming_attention
+						 WHERE id = ? AND agent_id = ? AND resolved_at IS NULL`,
+					)
+					.get(entry.attentionId, params.agentId);
+				if (pending == null) {
+					items.push({
+						index,
+						ok: false,
+						error: "Attention already consumed by an earlier operation in this batch",
+					});
+					continue;
+				}
 			}
 			const savepoint = `signet_dream_op_${index}`;
 			db.exec(`SAVEPOINT ${savepoint}`);

--- a/platform/daemon/src/pipeline/dreaming-operations.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.ts
@@ -196,33 +196,26 @@ function attentionProvenance(
 
 	let expectedTarget = false;
 	if (operation.operation === "archive_entity") {
-		expectedTarget =
-			typeof payload.target === "string" &&
-			payload.target === attention.details.entityId &&
-			attention.subjectRef === `entity:${payload.target}`;
+		expectedTarget = pinnedTarget(payload, attention, "entity:", "entityId");
 	} else if (operation.operation === "archive_aspect") {
-		expectedTarget =
-			typeof payload.target === "string" &&
-			payload.target === attention.details.aspectId &&
-			attention.subjectRef === `aspect:${payload.target}`;
+		expectedTarget = pinnedTarget(payload, attention, "aspect:", "aspectId");
 	} else if (operation.operation === "archive_claim_value") {
-		expectedTarget =
-			typeof payload.target === "string" &&
-			payload.target === attention.details.attributeId &&
-			attention.subjectRef === `attribute:${payload.target}`;
+		expectedTarget = pinnedTarget(payload, attention, "attribute:", "attributeId");
 	} else if (operation.operation === "archive_link") {
-		expectedTarget =
-			typeof payload.target === "string" &&
-			payload.target === attention.details.linkId &&
-			attention.subjectRef === `link:${payload.target}`;
+		expectedTarget = pinnedTarget(payload, attention, "link:", "linkId");
 	} else if (operation.operation === "merge_entities") {
 		const targets = Array.isArray(payload.targets)
 			? payload.targets.filter((value): value is string => typeof value === "string")
 			: [];
 		const survivor = typeof payload.survivor === "string" ? payload.survivor : "";
-		const groupIds = semanticDuplicateIds(accessor, agentId, attention.details.canonicalName ?? "");
+		// The subjectRef is the canonical pin: agent-minted flags carry the
+		// canonical name in `duplicate:<name>` and may omit details, while
+		// daemon-enqueued flags repeat it in details.canonicalName (#1168).
+		const canonicalName =
+			attention.details.canonicalName ?? pinnedBySubjectRef(attention.subjectRef, "duplicate:") ?? "";
+		const groupIds = semanticDuplicateIds(accessor, agentId, canonicalName);
 		expectedTarget =
-			attention.subjectRef === `duplicate:${attention.details.canonicalName}` &&
+			attention.subjectRef === `duplicate:${canonicalName}` &&
 			groupIds.size > 1 &&
 			groupIds.has(survivor) &&
 			targets.length >= 2 &&
@@ -234,7 +227,7 @@ function attentionProvenance(
 		const sources = Array.isArray(payload.sources)
 			? payload.sources.filter((value): value is string => typeof value === "string")
 			: [];
-		const flaggedAspect = attention.details.aspectId ?? attention.subjectRef.replace(/^aspect:/, "");
+		const flaggedAspect = attention.details.aspectId ?? pinnedBySubjectRef(attention.subjectRef, "aspect:") ?? "";
 		expectedTarget =
 			attention.subjectRef.startsWith("aspect:") &&
 			typeof payload.target === "string" &&
@@ -261,6 +254,34 @@ function attentionProvenance(
 		},
 		attentionId: attention.id,
 	};
+}
+
+/** The row id a hygiene subjectRef pins: the kind prefix plus the id. */
+function pinnedBySubjectRef(subjectRef: string, prefix: string): string | null {
+	if (!subjectRef.startsWith(prefix)) return null;
+	const id = subjectRef.slice(prefix.length);
+	return id.length > 0 ? id : null;
+}
+
+/**
+ * An archive op targets exactly the flagged row when the subjectRef pins the
+ * same id. The details id fields are an optional cross-check: daemon-enqueued
+ * attention repeats the id there, but agent-minted flags may omit it entirely
+ * (#1168) — the subjectRef is mandatory and already pins the target, so a
+ * missing details id must not reject the archive, while a contradictory one
+ * (a redirect) must.
+ */
+function pinnedTarget(
+	payload: Readonly<Record<string, unknown>>,
+	attention: DreamingAttention,
+	prefix: string,
+	detailKey: keyof DreamingAttention["details"],
+): boolean {
+	const target = typeof payload.target === "string" ? payload.target : null;
+	const pinned = target !== null ? pinnedBySubjectRef(attention.subjectRef, prefix) : null;
+	if (pinned === null || target !== pinned) return false;
+	const detail = attention.details[detailKey];
+	return detail === undefined || detail === target;
 }
 
 function provenanceForEvidence(


### PR DESCRIPTION
## Summary

A Dreaming hygiene pass can never archive or merge anything it flags itself. Agent-minted `flag` ops write inspection facts into `details` but no id fields, while `attentionProvenance` required `attention.details.entityId === payload.target` to accept an archive. Every flag-then-archive cycle was rejected with "Hygiene archives require attention provenance", so the attention queue never drained: the worker re-triggered a pass every ~6 minutes around the clock (22 passes in 3h on the affected install), each burning 71k-483k tokens and 29%+ of a core in the in-process agent loop, applying 0 mutations. 93 of 109 pending attention items on the live install were stuck this way.

## Changes

- `platform/daemon/src/pipeline/dreaming-operations.ts`: `attentionProvenance` now pins the archive/merge target from the mandatory `subjectRef` (`entity:`, `aspect:`, `attribute:`, `link:`, `duplicate:` prefixes). The `details` id fields are an optional consistency cross-check: present and matching is fine, absent is fine, present and contradicting the subjectRef is still rejected (no redirect). `merge_aspects` already derived from subjectRef; the other five ops did not. `merge_entities` now falls back to `duplicate:<name>` from the subjectRef when `details.canonicalName` is missing.
- `platform/daemon/src/pipeline/dreaming-operations.test.ts`: four regression tests. Three reproduce the bug (same-batch archive, prior-batch `attention:<uuid>` archive, duplicate merge — all with flags that omit the details id) and fail on the old code; one pins the fail-closed invariant (details id contradicting the subjectRef is rejected).

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`

## Screenshots

N/A (no UI change)

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations touched.

## Testing

- [x] `bun test` passes (19/19 dreaming-operations; 44/44 sibling dreaming suites)
- [x] `bun run typecheck` passes (@signet/daemon build)
- [x] `bun run lint` passes (no new diagnostics on touched files)
- [ ] Tested against running daemon
- [x] N/A

Regression proof: the three #1168 tests fail when the fix is reverted (verified by reverse-applying the fix commit and re-running).

## AI disclosure

AI tools were used (see `Assisted-by` tags in commits).

## Notes

Root cause of the CPU investigation behind #1168. The timeout/abort enforcement from the issue is still worth doing as a backstop, but this fix is what stops the pass-every-6-minutes loop: the hygiene queue can now actually drain, so the cadence falls back to content-driven passes. Live evidence on the affected install: 77 of 182 `apply_ontology_ops` calls in 24h failed with the provenance error; 93 of 109 pending attention items lacked `entityId` in details.


Closes #1168



---

## Adversarial review resolution

An adversarial subagent reviewed this PR (live DB experiments + test runs). Verdict: ship-with-fixes. All findings fixed in 98cedd46f:

1. **HIGH (fixed)** — `merge_aspects` let `details.aspectId` override the subjectRef pin (the flag could name aspect A and merge a different aspect B). The subjectRef is now the pin; a contradictory `details.aspectId` rejects.
2. **MEDIUM (fixed)** — one flag authorized multiple hygiene ops in a batch. Each flag is now one-use: a second op citing the same attention fails with "Attention already consumed".
3. **LOW (fixed)** — a `duplicate:` flag with an empty canonical name could merge empty-name entities. Empty pinned names now reject.

New regression tests cover each. Suite: 22/22 dreaming-operations, 44/44 sibling dreaming suites, daemon build green. The three original regression tests still fail on the pre-fix code (verified both by me and by the reviewer in a scratch clone).
