### PR TITLE
fix(daemon): honor SIGNET_TELEMETRY_OPTOUT

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -61,6 +61,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build and start stack
+        env:
+          # CI runners must not pollute the Signet PostHog project with
+          # fake installs (each smoke run boots a fresh default-config daemon).
+          SIGNET_TELEMETRY_OPTOUT: "1"
         run: |
           SIGNET_HTTP_PORT=8080 SIGNET_HTTPS_PORT=8443 docker compose -f deploy/docker/compose.yml up -d --build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,9 @@ jobs:
           # separately. Avoid external model downloads and Hugging Face rate limits.
           SIGNET_NATIVE_EMBEDDING_SMOKE: "0"
           SIGNET_NATIVE_SMOKE_BINARY: ./dist/native/${{ matrix.asset }}
+          # The smoke boots a real default-config daemon; keep its telemetry
+          # out of the Signet PostHog project.
+          SIGNET_TELEMETRY_OPTOUT: "1"
         run: bun test scripts/native-embedding-runtime-smoke.test.ts
 
       - name: Upload to release

--- a/deploy/docker/compose.yml
+++ b/deploy/docker/compose.yml
@@ -12,6 +12,7 @@ services:
       SIGNET_PORT: 3850
       SIGNET_PATH: /data/agents
       SIGNET_LOG_FILE: /data/agents/.daemon/logs/daemon.log
+      SIGNET_TELEMETRY_OPTOUT: ${SIGNET_TELEMETRY_OPTOUT:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
     volumes:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1128,6 +1128,11 @@ by default and asks whether to disable it. Declining writes
 `telemetryEnabled: false`; non-interactive/CI setups keep the default
 (enabled).
 
+**Runtime opt-out:** setting `SIGNET_TELEMETRY_OPTOUT=1` in the daemon's
+environment disables telemetry without touching config — the same knob the
+install ping honors. CI runners, containers, and scripted environments
+should set it so automated daemon boots don't count as installs.
+
 **Open telemetry log:** every recorded event is appended as one JSON line
 to `<agentsDir>/.daemon/telemetry/events.jsonl` — the single inspectable
 audit surface for exactly what was sent (daemon events and CLI

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -141,6 +141,7 @@ import {
 	createTelemetryCollector,
 	defaultTelemetryLogPath,
 	setActiveTelemetry,
+	telemetryDisabledByEnv,
 } from "./telemetry";
 import { type TranscriptCaptureWorkerHandle, startTranscriptCaptureWorker } from "./transcript-capture-worker";
 
@@ -1914,7 +1915,7 @@ async function main() {
 
 	const memoryCfg = loadMemoryConfig(AGENTS_DIR);
 	let telemetryCollector: TelemetryCollector | undefined;
-	if (memoryCfg.pipelineV2.telemetryEnabled) {
+	if (memoryCfg.pipelineV2.telemetryEnabled && !telemetryDisabledByEnv()) {
 		let posthogApiKey = memoryCfg.pipelineV2.telemetry.posthogApiKey;
 		if (!posthogApiKey) {
 			try {

--- a/platform/daemon/src/native-embedding-eventloop-isolation.test.ts
+++ b/platform/daemon/src/native-embedding-eventloop-isolation.test.ts
@@ -103,6 +103,8 @@ async function waitForHealth(
 	throw new Error("daemon did not become healthy in time");
 }
 
+process.env.SIGNET_TELEMETRY_OPTOUT = "1"; // keep CI/test daemons out of the PostHog project
+
 describe("native embedding event-loop isolation (e2e)", () => {
 	// Generous timeout: daemon startup + a 5s probe window.
 	it("/health stays within SLA while the embedding worker is stuck on a model download", async () => {

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -20,6 +20,7 @@ import {
 	createTelemetryCollector,
 	defaultTelemetryLogPath,
 	nextFlushIntervalMs,
+	telemetryDisabledByEnv,
 } from "./telemetry";
 import { cleanupTestTempDir, createTestTempDir } from "./test-temp-dir";
 
@@ -183,6 +184,15 @@ describe("telemetry collector", () => {
 		await collector.flush();
 		await collector.flush();
 		expect(captured).toHaveLength(1);
+	});
+
+	it("honors SIGNET_TELEMETRY_OPTOUT as a runtime opt-out", () => {
+		// Regression: CI and test daemons boot with default config and the
+		// shipped key, so every smoke run became a fake PostHog install.
+		expect(telemetryDisabledByEnv({})).toBe(false);
+		expect(telemetryDisabledByEnv({ SIGNET_TELEMETRY_OPTOUT: "1" })).toBe(true);
+		expect(telemetryDisabledByEnv({ SIGNET_TELEMETRY_OPTOUT: "true" })).toBe(true);
+		expect(telemetryDisabledByEnv({ SIGNET_TELEMETRY_OPTOUT: "0" })).toBe(false);
 	});
 
 	it("backs off after three consecutive PostHog failures", () => {

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -109,6 +109,15 @@ export function getActiveTelemetry(): TelemetryCollector | undefined {
 }
 
 /**
+ * True when the process environment disables telemetry. The same
+ * SIGNET_TELEMETRY_OPTOUT knob the install ping honors (issue #1026) so one
+ * switch opts a whole machine or CI runner out — without touching config.
+ */
+export function telemetryDisabledByEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+	return env.SIGNET_TELEMETRY_OPTOUT === "1" || env.SIGNET_TELEMETRY_OPTOUT === "true";
+}
+
+/**
  * Resolve the anonymous per-install identifier, creating and persisting it on
  * first use. Falls back to an in-memory id if the database is unusable.
  * A truthy guard is required here: bun:sqlite returns null for a missing row

--- a/scripts/native-embedding-runtime-smoke.test.ts
+++ b/scripts/native-embedding-runtime-smoke.test.ts
@@ -152,6 +152,8 @@ async function startOAuthLoginSse(origin: string, providerId: string): Promise<s
 	return text;
 }
 
+process.env.SIGNET_TELEMETRY_OPTOUT = "1"; // keep CI/test daemons out of the PostHog project
+
 describe("native smoke binary path", () => {
 	test("resolves a relative SIGNET_NATIVE_SMOKE_BINARY override to an absolute path", () => {
 		const prev = process.env.SIGNET_NATIVE_SMOKE_BINARY;

--- a/scripts/native-hermes-release-smoke.test.ts
+++ b/scripts/native-hermes-release-smoke.test.ts
@@ -33,6 +33,8 @@ afterEach(() => {
 	}
 });
 
+process.env.SIGNET_TELEMETRY_OPTOUT = "1"; // keep CI/test daemons out of the PostHog project
+
 describe("native Hermes release smoke", () => {
 	const binary = process.env.SIGNET_NATIVE_SMOKE_BINARY?.trim();
 	const hermesFixture = process.env.SIGNET_HERMES_SMOKE_REPO?.trim();


### PR DESCRIPTION
## Summary

Default-on telemetry (from #1169) made every automated daemon boot a fake PostHog install: the docker-smoke workflow and the release/native smoke tests start fresh daemons whose default config enables telemetry with the shipped key — each run created a phantom distinct user (daemon.started + heartbeats) in the Signet PostHog project. This PR gives the daemon a runtime opt-out and sets it everywhere automated daemons boot.

## Changes

- `platform/daemon/src/telemetry.ts`: `telemetryDisabledByEnv()` — honors `SIGNET_TELEMETRY_OPTOUT=1|true`, the same knob the install ping already uses, so one switch opts a machine/CI runner out of the whole product.
- `platform/daemon/src/daemon.ts`: collector creation gated on the env opt-out (config stays canonical; env is a runtime gate).
- `.github/workflows/docker-smoke.yml`: `SIGNET_TELEMETRY_OPTOUT=1` on the compose step.
- `.github/workflows/release.yml`: env on the native release runtime smoke step.
- `deploy/docker/compose.yml`: `${SIGNET_TELEMETRY_OPTOUT:-}` passthrough into the signet service (CI sets it; real docker users get telemetry by default).
- Test fixtures that spawn real daemons (native-hermes-release-smoke, native-embedding-runtime-smoke, native-embedding-eventloop-isolation) set the env so local runs stay out of the project too.
- Regression test in telemetry.test.ts names the bug (CI daemons becoming fake installs).
- docs/CONFIGURATION.md: runtime opt-out documented.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/core`
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: workflows + deploy/docker + docs

## Screenshots

N/A.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries — N/A, no data queries
- [x] Input/config validation and bounds checks added — env read is a simple equality check
- [x] Error handling and fallback paths tested (no silent swallow) — collector gated off before creation; no partial state
- [x] Security checks applied to admin/mutation endpoints — N/A, no endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no schema changes.

## Testing

- [x] `bun test` passes — telemetry.test.ts 11/11 including the new regression test
- [x] `bun run typecheck` passes — daemon package green
- [x] `bun run lint` passes — biome clean on changed files (3 pre-existing lint errors in the untouched parts of native-embedding-runtime-smoke.test.ts remain)
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Pre-existing CI pollution: smoke runs between 0.170.0 (default-on shipped) and this merge created phantom users in the PostHog project. They are identifiable by `$lib: signet-daemon` + `daemon.started` events with no install.ping — filter or purge if the numbers matter.
- The install ping (postinstall) never fired in docker CI (workspace-package guard), so only daemon-side events polluted.
