### PR TITLE
fix(daemon): make the file logger recover from write failures instead of going silent forever (#1162)

### DIFF
--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1752,6 +1752,7 @@ process.on("unhandledRejection", (reason) => {
 
 async function main() {
 	logger.info("daemon", "Signet Daemon starting");
+	logger.info("daemon", `File logging to ${logger.logFilePath}`);
 	logger.info("daemon", "Agents directory", { path: AGENTS_DIR });
 	logger.info("daemon", "Network configured", { port: PORT, host: HOST, bindHost: BIND_HOST });
 

--- a/platform/daemon/src/logger.test.ts
+++ b/platform/daemon/src/logger.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { Logger, resolveLoggerConfig } from "./logger";
 
 describe("logger config", () => {
@@ -62,6 +62,56 @@ describe("logger shutdown flush", () => {
 			const today = new Date().toISOString().split("T")[0];
 			const content = readFileSync(join(root, `signet-${today}.log`), "utf-8");
 			expect(content).toContain("Received signal:SIGTERM; shutting down");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("logs the resolved log file path at startup (#1162)", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-logger-"));
+		try {
+			const log = new Logger({ logDir: root, consoleOutput: false, jsonFormat: false, level: "info" });
+			log.shutdown();
+			const today = new Date().toISOString().split("T")[0];
+			const expected = join(root, `signet-${today}.log`);
+			const content = readFileSync(expected, "utf-8");
+			expect(content).toContain("File logging to");
+			expect(content).toContain(expected);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("recovers file logging after the log directory becomes writable (#1162)", async () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-logger-"));
+		try {
+			// A file where the log directory should be: the initial mkdir fails
+			// and every append fails until the path is fixed.
+			const blocker = join(root, "blocker");
+			writeFileSync(blocker, "i am a file, not a directory");
+			const logPath = join(blocker, "logs", "signet.log");
+			const log = new Logger({
+				logFilePath: logPath,
+				logDir: dirname(logPath),
+				consoleOutput: false,
+				jsonFormat: false,
+				level: "info",
+				flushRetryBackoffMs: 20,
+			});
+			log.info("daemon", "before failure");
+			// Let the 1s flush timer run: the append fails (missing directory),
+			// but the buffered entries must be retained for the retry.
+			await new Promise((resolve) => setTimeout(resolve, 1100));
+			// Fix the path, then write more; the next flush retry must re-append
+			// the retained buffer and recover file logging.
+			rmSync(blocker, { force: true });
+			mkdirSync(join(root, "blocker", "logs"), { recursive: true });
+			log.info("daemon", "after recovery");
+			await new Promise((resolve) => setTimeout(resolve, 1100));
+			log.shutdown();
+			const content = readFileSync(logPath, "utf-8");
+			expect(content).toContain("before failure");
+			expect(content).toContain("after recovery");
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/platform/daemon/src/logger.test.ts
+++ b/platform/daemon/src/logger.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { Logger, resolveLoggerConfig } from "./logger";
+import { type LogEntry, Logger, resolveLoggerConfig } from "./logger";
 
 describe("logger config", () => {
 	it("uses SIGNET_PATH for the default daemon log directory", () => {
@@ -39,6 +39,23 @@ describe("logger config", () => {
 			logDir: join("/home/test", ".agents", ".daemon", "logs"),
 		});
 	});
+
+	it("exposes the resolved log file path for the daemon boot line (#1162)", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-logger-"));
+		try {
+			const log = new Logger({
+				logDir: root,
+				consoleOutput: false,
+				jsonFormat: false,
+				level: "info",
+			});
+			const today = new Date().toISOString().split("T")[0];
+			expect(log.logFilePath).toBe(join(root, `signet-${today}.log`));
+			log.shutdown();
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
 });
 
 // Regression for issue #1148: the daemon exit path calls logger.shutdown()
@@ -67,16 +84,23 @@ describe("logger shutdown flush", () => {
 		}
 	});
 
-	it("logs the resolved log file path at startup (#1162)", () => {
+	it("does not create the log file until the first flush (#1180)", () => {
 		const root = mkdtempSync(join(tmpdir(), "signet-logger-"));
 		try {
-			const log = new Logger({ logDir: root, consoleOutput: false, jsonFormat: false, level: "info" });
-			log.shutdown();
+			const log = new Logger({
+				logDir: root,
+				consoleOutput: false,
+				jsonFormat: false,
+				level: "info",
+			});
 			const today = new Date().toISOString().split("T")[0];
-			const expected = join(root, `signet-${today}.log`);
-			const content = readFileSync(expected, "utf-8");
-			expect(content).toContain("File logging to");
-			expect(content).toContain(expected);
+			const logPath = join(root, `signet-${today}.log`);
+			// Regression for the #1180 review finding: the constructor used
+			// to write a startup line, so any process importing logger.ts
+			// (tests, CLI, MCP) appended to the daemon's log file at import.
+			expect(existsSync(logPath)).toBe(false);
+			log.shutdown();
+			expect(existsSync(logPath)).toBe(false);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}
@@ -112,6 +136,66 @@ describe("logger shutdown flush", () => {
 			const content = readFileSync(logPath, "utf-8");
 			expect(content).toContain("before failure");
 			expect(content).toContain("after recovery");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("flushes the retained buffer on shutdown even inside the retry backoff (#1180)", async () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-logger-"));
+		try {
+			const blocker = join(root, "blocker");
+			writeFileSync(blocker, "i am a file, not a directory");
+			const logPath = join(blocker, "logs", "signet.log");
+			const log = new Logger({
+				logFilePath: logPath,
+				logDir: dirname(logPath),
+				consoleOutput: false,
+				jsonFormat: false,
+				level: "info",
+				flushRetryBackoffMs: 60_000, // long backoff: no timer retry can fire
+			});
+			log.info("daemon", "crash trail entry");
+			// Let the 1s flush timer fail the append once.
+			await new Promise((resolve) => setTimeout(resolve, 1100));
+			// Disk recovers, but the next timer retry is 60s away. A SIGTERM
+			// here must not drop the retained buffer (the #1148 crash-trail
+			// failure class): shutdown() force-flushes past the backoff gate.
+			rmSync(blocker, { force: true });
+			mkdirSync(dirname(logPath), { recursive: true });
+			log.shutdown();
+			const content = readFileSync(logPath, "utf-8");
+			expect(content).toContain("crash trail entry");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("caps the retained buffer during the retry backoff window (#1180)", async () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-logger-"));
+		try {
+			const blocker = join(root, "blocker");
+			writeFileSync(blocker, "i am a file, not a directory");
+			const log = new Logger({
+				logFilePath: join(blocker, "logs", "signet.log"),
+				logDir: join(blocker, "logs"),
+				consoleOutput: false,
+				jsonFormat: false,
+				level: "info",
+				flushRetryBackoffMs: 60_000,
+			});
+			log.info("daemon", "first entry");
+			// First append fails; the retry gate then holds the buffer.
+			await new Promise((resolve) => setTimeout(resolve, 1100));
+			for (let i = 0; i < 5000; i++) {
+				log.info("daemon", `entry ${i}`);
+			}
+			// The next flush tick must trim to the cap even though it cannot
+			// append yet (it is inside the backoff window).
+			await new Promise((resolve) => setTimeout(resolve, 1100));
+			const buffered = (log as unknown as { buffer: LogEntry[] }).buffer;
+			expect(buffered.length).toBeLessThanOrEqual(2000);
+			log.shutdown();
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/platform/daemon/src/logger.ts
+++ b/platform/daemon/src/logger.ts
@@ -116,6 +116,8 @@ export interface LoggerConfig {
 	maxFiles: number; // number of rotated files to keep
 	consoleOutput: boolean;
 	jsonFormat: boolean;
+	/** Backoff between file-write retry attempts after a transport failure. */
+	flushRetryBackoffMs?: number;
 }
 
 const LOG_LEVELS: Record<LogLevel, number> = {
@@ -134,6 +136,7 @@ const DEFAULT_CONFIG: LoggerConfig = {
 	maxFiles: 5,
 	consoleOutput: true,
 	jsonFormat: true,
+	flushRetryBackoffMs: 30_000,
 };
 
 export function resolveLoggerConfig(env: NodeJS.ProcessEnv = process.env, homeDir = homedir()): Partial<LoggerConfig> {
@@ -159,6 +162,10 @@ export class Logger extends EventEmitter {
 	private buffer: LogEntry[] = [];
 	private flushTimer: ReturnType<typeof setInterval> | null = null;
 	private fileOutputEnabled = true;
+	private lastFlushFailureAt = 0;
+	// Bound the in-memory buffer while the file transport is down so a long
+	// outage cannot grow it without limit (#1162).
+	private static readonly MAX_BUFFERED_ENTRIES = 2000;
 	private static readonly LOG_FILE_PATTERN = /^signet-(\d{4}-\d{2}-\d{2})(?:-(.+))?\.log$/;
 
 	constructor(config: Partial<LoggerConfig> = {}) {
@@ -167,6 +174,14 @@ export class Logger extends EventEmitter {
 		this.currentLogFile = this.getLogFileName();
 		this.ensureLogDir();
 		this.startFlushTimer();
+		// #1162: surface the resolved destination so a misconfigured log path
+		// is visible at startup instead of the daemon silently writing nowhere.
+		this.write({
+			timestamp: new Date().toISOString(),
+			level: "info",
+			category: "daemon",
+			message: `File logging to ${this.currentLogFile}`,
+		});
 	}
 
 	private ensureLogDir() {
@@ -305,8 +320,13 @@ export class Logger extends EventEmitter {
 			.join("\n")}\n`;
 
 		if (!this.fileOutputEnabled) {
-			this.buffer = [];
-			return;
+			// A previous append failed. Retry periodically instead of disabling
+			// file logging forever, so a transient error (disk full, sync lock,
+			// moved directory) recovers without a daemon restart (#1162). The
+			// buffer is retained (bounded) so the retry re-appends the entries.
+			const backoffMs = this.config.flushRetryBackoffMs ?? 30_000;
+			if (Date.now() - this.lastFlushFailureAt < backoffMs) return;
+			console.error(`[logger] retrying file logging to ${this.currentLogFile}`);
 		}
 
 		try {
@@ -318,10 +338,17 @@ export class Logger extends EventEmitter {
 
 			appendFileSync(this.currentLogFile, lines);
 			this.buffer = [];
+			if (!this.fileOutputEnabled) {
+				this.fileOutputEnabled = true;
+				console.error(`[logger] file logging recovered: ${this.currentLogFile}`);
+			}
 		} catch (e) {
 			this.fileOutputEnabled = false;
-			this.buffer = [];
-			console.error("Failed to write logs, disabling file logging:", e);
+			this.lastFlushFailureAt = Date.now();
+			if (this.buffer.length > Logger.MAX_BUFFERED_ENTRIES) {
+				this.buffer = this.buffer.slice(-Logger.MAX_BUFFERED_ENTRIES);
+			}
+			console.error(`Failed to write logs to ${this.currentLogFile}, disabling file logging (retrying):`, e);
 		}
 	}
 

--- a/platform/daemon/src/logger.ts
+++ b/platform/daemon/src/logger.ts
@@ -174,14 +174,6 @@ export class Logger extends EventEmitter {
 		this.currentLogFile = this.getLogFileName();
 		this.ensureLogDir();
 		this.startFlushTimer();
-		// #1162: surface the resolved destination so a misconfigured log path
-		// is visible at startup instead of the daemon silently writing nowhere.
-		this.write({
-			timestamp: new Date().toISOString(),
-			level: "info",
-			category: "daemon",
-			message: `File logging to ${this.currentLogFile}`,
-		});
 	}
 
 	private ensureLogDir() {
@@ -202,6 +194,14 @@ export class Logger extends EventEmitter {
 		}
 		const date = new Date().toISOString().split("T")[0];
 		return join(this.config.logDir, `signet-${date}.log`);
+	}
+
+	// The resolved file destination, logged by the daemon at boot (#1162).
+	// Kept out of the constructor so module import has no file-write side
+	// effects (any process importing logger.ts would otherwise append to the
+	// daemon's log file).
+	get logFilePath(): string {
+		return this.currentLogFile;
 	}
 
 	private shouldLog(level: LogLevel): boolean {
@@ -312,22 +312,35 @@ export class Logger extends EventEmitter {
 		this.checkRotation();
 	}
 
-	private flush() {
+	private flush(force = false) {
 		if (this.buffer.length === 0) return;
 
-		const lines = `${this.buffer
-			.map((entry) => (this.config.jsonFormat ? this.formatJson(entry) : this.formatConsole(entry)))
-			.join("\n")}\n`;
-
-		if (!this.fileOutputEnabled) {
+		if (!this.fileOutputEnabled && !force) {
 			// A previous append failed. Retry periodically instead of disabling
 			// file logging forever, so a transient error (disk full, sync lock,
 			// moved directory) recovers without a daemon restart (#1162). The
 			// buffer is retained (bounded) so the retry re-appends the entries.
 			const backoffMs = this.config.flushRetryBackoffMs ?? 30_000;
-			if (Date.now() - this.lastFlushFailureAt < backoffMs) return;
+			if (Date.now() - this.lastFlushFailureAt < backoffMs) {
+				this.trimBuffer();
+				return;
+			}
 			console.error(`[logger] retrying file logging to ${this.currentLogFile}`);
 		}
+
+		this.appendBuffered();
+	}
+
+	private trimBuffer() {
+		if (this.buffer.length > Logger.MAX_BUFFERED_ENTRIES) {
+			this.buffer = this.buffer.slice(-Logger.MAX_BUFFERED_ENTRIES);
+		}
+	}
+
+	private appendBuffered() {
+		const lines = `${this.buffer
+			.map((entry) => (this.config.jsonFormat ? this.formatJson(entry) : this.formatConsole(entry)))
+			.join("\n")}\n`;
 
 		try {
 			// Check if date changed (new log file)
@@ -345,9 +358,7 @@ export class Logger extends EventEmitter {
 		} catch (e) {
 			this.fileOutputEnabled = false;
 			this.lastFlushFailureAt = Date.now();
-			if (this.buffer.length > Logger.MAX_BUFFERED_ENTRIES) {
-				this.buffer = this.buffer.slice(-Logger.MAX_BUFFERED_ENTRIES);
-			}
+			this.trimBuffer();
 			console.error(`Failed to write logs to ${this.currentLogFile}, disabling file logging (retrying):`, e);
 		}
 	}
@@ -583,7 +594,11 @@ export class Logger extends EventEmitter {
 
 	// Cleanup
 	shutdown() {
-		this.flush();
+		// Final best-effort flush. Bypass the retry backoff so the retained
+		// buffer survives a shutdown that lands inside the backoff window
+		// (e.g. SIGTERM shortly after a failed append) — otherwise the crash
+		// trail the retry exists to preserve is dropped on exit.
+		this.flush(true);
 		if (this.flushTimer) {
 			clearInterval(this.flushTimer);
 		}


### PR DESCRIPTION
## Summary

A single failed log append permanently disabled the daemon's file logger: the transport flag flipped off and never came back, so every later crash vanished with zero trace (the #1148 symptom). This PR makes the logger resilient — failed appends are retried after a backoff with the buffer retained, the resolved destination is logged at startup, and failures/recoveries are surfaced on stderr (which launchd routes to `startup.log`).

## Changes

- `platform/daemon/src/logger.ts` — `flush()` retries the append after `flushRetryBackoffMs` (default 30s, configurable) instead of permanently disabling file logging; the buffer is retained (capped at 2000 entries) across failed flushes so the retry re-appends the crash trail; failures and the recovery emit stderr diagnostics.
- `platform/daemon/src/logger.ts` — `shutdown()` force-flushes past the retry backoff, so a SIGTERM landing inside the backoff window (the #1148 restart-loop class) no longer drops the retained buffer even after the disk recovered.
- `platform/daemon/src/logger.ts` — the retained-buffer cap is enforced during the backoff window, not only at retry-failure points, so sustained logging during an outage cannot grow the buffer past 2000 entries.
- `platform/daemon/src/daemon.ts` — the daemon logs `File logging to <path>` at boot. The line was moved out of the `Logger` constructor so importing `logger.ts` (tests, CLI, MCP processes) has no file-write side effect on the daemon's log.
- `platform/daemon/src/logger.test.ts` — regressions: (a) the resolved path is logged at daemon boot; (b) a blocked log directory followed by a fix recovers file logging with the pre-failure entries re-appended; (c) shutdown inside the backoff window still flushes the retained buffer; (d) the buffer stays capped during the backoff window; (e) constructing a `Logger` does not create the log file until the first flush.

## Type

- [x] `fix` — bug fix

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A — daemon-side fix, no UI.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

## Testing

- [x] `bun test` passes — `logger.test.ts` 9/9 (incl. the five regressions)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Resolves #1162. Review fixes from the #1180 adversarial review (shutdown force-flush, backoff-window buffer cap, boot-time destination line) are in `c957b514e`; all four new regression tests fail on the pre-fix code.

Assisted-by: Hermes-Agent:deepseek-v4-flash