### PR TITLE
fix(daemon): resolve attention flags the agent judged and declined (#1185)

### DIFF
--- a/docs/api/knowledge-ontology.md
+++ b/docs/api/knowledge-ontology.md
@@ -430,8 +430,11 @@ semantic operation. Oversized immutable evidence is instead resumed at a safe
 boundary across passes and is not quarantined.
 
 An attention item is selected with the next scoped pass and rendered as
-non-evidentiary context. It is resolved only after that pass completes; a
-failed pass leaves it pending. The worker can run for pending attention even
+non-evidentiary context. It resolves when the pass applies a hygiene operation
+citing it, or when the agent explicitly declines it (the `decline_attention`
+operation, used when the agent inspects the target and judges it should stay as
+is). Records the agent could not complete stay pending, and a failed pass
+leaves everything pending. The worker can run for pending attention even
 when no new episodic evidence has arrived, while normal failure backoff still
 applies.
 

--- a/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
@@ -517,6 +517,114 @@ describe("dreaming-agent-tools", () => {
 		expect(items[0]).toMatchObject({ subjectRef: "memory:mem-expired", details: { attributeId: "a-trip-attribute" } });
 	});
 
+	it("decline_attention resolves a pending flag and is one-use and scoped", async () => {
+		insertEntity("e-husk", "Legacy Husk", "legacy husk", "owner");
+		const tools = createDreamingAgentTools({
+			accessor: getDbAccessor(),
+			agentId: "owner",
+			actor: "owner",
+			passId: "pass-1",
+		});
+		const minted = readResult(
+			await findTool(tools, "apply_ontology_ops").execute(
+				"call",
+				{
+					agentId: "owner",
+					operations: [
+						{
+							operation: "flag",
+							payload: {
+								subjectRef: "entity:e-husk",
+								details: { entityId: "e-husk", reason: "zero_active_attributes" },
+							},
+						},
+					],
+				},
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		expect(minted.ok).toBe(true);
+		const mintedItems = minted.items as Array<{ result?: { attentionId?: string } }>;
+		const attentionId = mintedItems[0]?.result?.attentionId;
+		if (attentionId === undefined) throw new Error("flag op did not surface an attention id");
+
+		// Declining from another scope fails closed: the record is untouched.
+		const otherScope = createDreamingAgentTools({
+			accessor: getDbAccessor(),
+			agentId: "intruder",
+			actor: "intruder",
+			passId: "pass-1",
+		});
+		const crossScope = readResult(
+			await findTool(otherScope, "apply_ontology_ops").execute(
+				"call",
+				{
+					agentId: "intruder",
+					operations: [{ operation: "decline_attention", payload: { attentionId } }],
+				},
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		expect((crossScope.items as Array<{ ok: boolean }>)[0]?.ok).toBe(false);
+		const stillPending = readResult(
+			await findTool(tools, "attention_list").execute(
+				"call",
+				{ kind: "hygiene", status: "pending" },
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		expect(stillPending.items as Array<unknown>).toHaveLength(1);
+
+		// The owning scope declines it once: resolved.
+		const declined = readResult(
+			await findTool(tools, "apply_ontology_ops").execute(
+				"call",
+				{
+					agentId: "owner",
+					operations: [{ operation: "decline_attention", payload: { attentionId } }],
+				},
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		expect(declined.ok).toBe(true);
+		expect((declined.items as Array<{ ok: boolean }>)[0]?.ok).toBe(true);
+
+		// A flag is one-use: a second decline of the same record is rejected.
+		const twice = readResult(
+			await findTool(tools, "apply_ontology_ops").execute(
+				"call",
+				{
+					agentId: "owner",
+					operations: [{ operation: "decline_attention", payload: { attentionId } }],
+				},
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		expect((twice.items as Array<{ ok: boolean }>)[0]?.ok).toBe(false);
+
+		const resolved = readResult(
+			await findTool(tools, "attention_list").execute(
+				"call",
+				{ kind: "hygiene", status: "resolved" },
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		expect(resolved.ok).toBe(true);
+		expect(resolved.items as Array<unknown>).toHaveLength(1);
+	});
+
 	it("flags and archives a junk entity in one apply batch", async () => {
 		insertEntity("e-husk", "Legacy Husk", "legacy husk", "owner");
 		const tools = createDreamingAgentTools({

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -622,7 +622,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"apply_ontology_ops",
 			"Apply ontology operations",
-			'Apply every semantic write through the daemon audit seam in one batch, in one agent scope (pass the agentId whose graph you are maintaining — hygiene attention records belong to the agent that flagged them). Ops are processed in array order. Hygiene ops (flag, archive_*, merge_entities) cite provenance: "attention:$<index>" for a flag earlier in the same batch, or "attention:<uuid>" from a prior batch. Content-bearing ops cite evidence with exact quotes from canonical episodic evidence in that scope.',
+			'Apply every semantic write through the daemon audit seam in one batch, in one agent scope (pass the agentId whose graph you are maintaining — hygiene attention records belong to the agent that flagged them). Ops are processed in array order. Hygiene ops (flag, archive_*, merge_entities) cite provenance: "attention:$<index>" for a flag earlier in the same batch, or "attention:<uuid>" from a prior batch. decline_attention closes a pending attention record you inspected and judged to keep. Content-bearing ops cite evidence with exact quotes from canonical episodic evidence in that scope.',
 			false,
 			z.object({
 				agentId: z.string().min(1),

--- a/platform/daemon/src/pipeline/dreaming-operation-contract.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-operation-contract.test.ts
@@ -37,3 +37,18 @@ test("flag ops are part of the Dreaming vocabulary", () => {
 		}).success,
 	).toBe(true);
 });
+
+test("decline_attention is part of the Dreaming vocabulary and requires an attentionId", () => {
+	expect(
+		DREAMING_ONTOLOGY_OPERATION_SCHEMA.safeParse({
+			operation: "decline_attention",
+			payload: { attentionId: "attention-uuid" },
+		}).success,
+	).toBe(true);
+	expect(
+		DREAMING_ONTOLOGY_OPERATION_SCHEMA.safeParse({
+			operation: "decline_attention",
+			payload: {},
+		}).success,
+	).toBe(false);
+});

--- a/platform/daemon/src/pipeline/dreaming-operation-contract.ts
+++ b/platform/daemon/src/pipeline/dreaming-operation-contract.ts
@@ -50,6 +50,11 @@ export const DREAMING_ONTOLOGY_PAYLOAD_SCHEMAS = {
 		details: z.record(z.string(), z.string()).describe("Inspection facts about the flagged target.").optional(),
 		priority: z.number().finite().min(0).max(100).describe("Priority of the flag (0-100).").optional(),
 	}),
+	decline_attention: payload({
+		attentionId: text.describe(
+			"The stable id of a pending attention record you inspected and judged to keep. Declining is an affirmative judgment: never decline a record you did not examine, and never use it to skip records you could not complete this pass (defer those in the pass log instead).",
+		),
+	}),
 	archive_entity: payload({ target: entityId, ...reasonField }),
 	archive_aspect: payload({ target: aspectId, ...reasonField }),
 	archive_claim_value: payload({ target: text.describe("The stable id of the claim attribute."), ...reasonField }),
@@ -104,6 +109,7 @@ export const DREAMING_ONTOLOGY_PAYLOAD_SCHEMAS = {
 export const DREAMING_OPERATION_IDS = [
 	...ONTOLOGY_PROPOSAL_OPERATIONS.filter((op) => op !== "restore_claim_version" && op !== "attach_interface"),
 	"flag",
+	"decline_attention",
 ] as const;
 
 const operationBase = {
@@ -149,4 +155,5 @@ export const DREAMING_ONTOLOGY_OPERATION_SCHEMA = z.discriminatedUnion("operatio
 	operation("create_action_type"),
 	operation("create_interface"),
 	operation("flag"),
+	operation("decline_attention"),
 ]);

--- a/platform/daemon/src/pipeline/dreaming-operations.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.ts
@@ -35,6 +35,7 @@ export interface ApplyDreamingOperationsResult {
 }
 
 const FLAG_OP = "flag";
+const DECLINE_ATTENTION_OP = "decline_attention";
 const HYGIENE_ARCHIVE_OPS = new Set([
 	"archive_entity",
 	"archive_aspect",
@@ -565,12 +566,22 @@ export function applyDreamingOperations(params: {
 	const validated: Array<{
 		readonly input: OntologyOperationInput | null;
 		readonly attentionId: string | null;
+		/** Queue-only op that resolves its cited attention record instead of an ontology write. */
+		readonly decline?: boolean;
 	}> = [];
 	for (let index = 0; index < params.operations.length; index += 1) {
 		const operation = params.operations[index]!;
 		if (operation.operation === FLAG_OP) {
 			const attentionId = minted.get(index) ?? null;
 			validated.push({ input: null, attentionId });
+			continue;
+		}
+		if (operation.operation === DECLINE_ATTENTION_OP) {
+			const attentionId = stringField(operation.payload, "attentionId");
+			if (attentionId === null) {
+				return { ok: false, items: [], error: "decline_attention requires payload.attentionId" };
+			}
+			validated.push({ input: null, attentionId, decline: true });
 			continue;
 		}
 		let provenance: DreamingOperationProvenance | null = null;
@@ -626,6 +637,32 @@ export function applyDreamingOperations(params: {
 		for (let index = 0; index < validated.length; index += 1) {
 			const entry = validated[index]!;
 			if (entry.input === null) {
+				if (entry.decline === true && entry.attentionId !== null) {
+					// Decline resolves the cited record in this tx: it must
+					// still be pending in the named agent's scope and is
+					// one-use, exactly like a flag consumed by an archive.
+					const pending = db
+						.prepare(
+							`SELECT 1 FROM dreaming_attention
+							 WHERE id = ? AND agent_id = ? AND resolved_at IS NULL`,
+						)
+						.get(entry.attentionId, params.agentId);
+					if (pending == null) {
+						items.push({
+							index,
+							ok: false,
+							error: "Attention record is not pending in this agent scope",
+						});
+						continue;
+					}
+					db.prepare(
+						`UPDATE dreaming_attention
+						 SET resolved_at = datetime('now'), resolved_by_pass_id = ?
+						 WHERE id = ? AND agent_id = ? AND resolved_at IS NULL`,
+					).run(params.passId ?? null, entry.attentionId, params.agentId);
+					items.push({ index, ok: true, result: { attentionId: entry.attentionId } });
+					continue;
+				}
 				// flag op: nothing to apply; surface the minted attention id
 				items.push({ index, ok: true, result: { attentionId: entry.attentionId } });
 				continue;

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -252,6 +252,110 @@ describe("Dreaming", () => {
 		expect(getDreamingAttention(accessor, AGENT)).toHaveLength(1);
 	});
 
+	it("resolves attention the agent explicitly declined with decline_attention (#1185)", async () => {
+		let attentionId = "";
+		accessor.withWriteTx((tx) => {
+			attentionId = enqueueDreamingAttentionInTx(tx, {
+				agentId: AGENT,
+				kind: "hygiene",
+				subjectRef: "entity:aster",
+				details: { reason: "flagged for archive review" },
+				priority: 90,
+			});
+		});
+		expect(shouldTriggerDreaming(accessor, defaultCfg(), AGENT)).toBe(true);
+
+		const result = await runDreamingAgentPass(
+			accessor,
+			{
+				async run(input) {
+					// The agent surfaces the flag via attention_list, inspects
+					// the target, and judges it a deliberate keep — the
+					// affirmative decline closes the record.
+					const apply = input.tools.find((tool) => tool.name === "apply_ontology_ops");
+					if (!apply) throw new Error("Missing apply_ontology_ops");
+					const out = (await apply.execute(
+						"call",
+						{
+							agentId: AGENT,
+							operations: [{ operation: "decline_attention", payload: { attentionId } }],
+						},
+						undefined,
+						undefined,
+						{} as never,
+					)) as { content?: Array<{ text?: string }> };
+					const parsed = JSON.parse(out.content?.[0]?.text ?? "") as { ok: boolean };
+					if (!parsed.ok) throw new Error(`decline_attention failed: ${out.content?.[0]?.text}`);
+					return { summary: "Reviewed and kept" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT],
+			"incremental",
+		);
+
+		expect(result.summary).toBe("Reviewed and kept");
+		// The agent judged the flag and kept the target: the explicit decline
+		// closes it, so declined work stops re-triggering passes.
+		expect(getDreamingAttention(accessor, AGENT)).toHaveLength(0);
+	});
+
+	it("leaves listed-but-unfinished attention pending when the pass defers it (over-resolution regression)", async () => {
+		const ids: string[] = [];
+		accessor.withWriteTx((tx) => {
+			for (const subject of ["entity:aster", "entity:birch", "entity:cedar"]) {
+				ids.push(
+					enqueueDreamingAttentionInTx(tx, {
+						agentId: AGENT,
+						kind: "hygiene",
+						subjectRef: subject,
+						details: { reason: "flagged for archive review" },
+						priority: 90,
+					}),
+				);
+			}
+		});
+		expect(shouldTriggerDreaming(accessor, defaultCfg(), AGENT)).toBe(true);
+
+		await runDreamingAgentPass(
+			accessor,
+			{
+				async run(input) {
+					// The agent works the queue, closes one flag it judged to
+					// keep, and defers the rest with reasons in the pass log —
+					// the runbook-sanctioned state. Mere listing must not
+					// resolve the deferred records.
+					const apply = input.tools.find((tool) => tool.name === "apply_ontology_ops");
+					if (!apply) throw new Error("Missing apply_ontology_ops");
+					const out = (await apply.execute(
+						"call",
+						{
+							agentId: AGENT,
+							operations: [{ operation: "decline_attention", payload: { attentionId: ids[0] } }],
+						},
+						undefined,
+						undefined,
+						{} as never,
+					)) as { content?: Array<{ text?: string }> };
+					const parsed = JSON.parse(out.content?.[0]?.text ?? "") as { ok: boolean };
+					if (!parsed.ok) throw new Error(`decline_attention failed: ${out.content?.[0]?.text}`);
+					return { summary: "Declined aster; deferred birch and cedar in the pass log" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT],
+			"incremental",
+		);
+
+		// Exactly the declined record resolves; the deferred two stay pending
+		// for a later pass instead of being silently dropped.
+		expect(getDreamingAttention(accessor, AGENT)).toHaveLength(2);
+	});
+
 	it("navigates semantic state through scoped tools instead of a partial graph snapshot", async () => {
 		const evidence = "The deployment is now handled by Aster.";
 		seedSummary(db, "navigation-summary", evidence, 8);

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -690,6 +690,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - Archive or merge it, citing its attention id (provenance: "attention:<uuid>", or attention:$<index> for a flag you minted in the same batch).
    - \`attribute_over_cap\` / \`aspect_over_cap\` flags: the write gate rejects new claims or aspects past the cap, so consolidate the flagged target — merge_aspects to fold over-cap aspects together, supersede_claim_value to collapse duplicate claim keys, archive_claim_value for stale snapshots. Consolidation (merge_aspects) may exceed the attribute cap; it is the remedy the cap forces.
    - If you discover junk the queue did not flag, mint a flag op and archive in the same batch.
+   - If you inspect a flagged target and judge it should stay as it is (a deliberate keep — e.g. a live entity with a non-concrete type, or an over-cap aspect you chose not to consolidate), close the record with decline_attention citing its attention id. Declining is an affirmative judgment: only decline records you actually inspected, and never decline records you could not complete this pass — defer those in the pass log so they stay pending.
 3. Query attention_list with kind=review_due. For expired records, inspect the cited memory with search_evidence using its subjectRef, then supersede the matching active claim with supersede_claim_value. Use the supplied entityId, aspectId, attributeId, and claimKey when present. The replacement must state that the planned event remains unconfirmed; never rewrite it as if the event happened. Cite an exact quote from the original memory. Do not supersede approaching records. When creating or setting a future temporal claim, set payload.reviewAfter to the referenced ISO timestamp.
 4. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST unprocessed sources with search_evidence — omit the query and omit since so it lists from the scope's evidence watermark (the frontier the last pass actually surfaced), newest first; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
    - search_entities for subjects it establishes.
@@ -725,6 +726,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 - Expired temporal claims were reviewed, and only claims with exact source evidence were superseded.
 - Pass log written with sources viewed + changes applied (this is the next pass's dedup).
 - No flag left unresolved for a target you archived.
+- Records you judged to keep are closed with decline_attention; records you could not complete this pass stay pending and are deferred in the pass log.
 - No writes attempted against pinned or source-root entities.
 `;
 
@@ -755,6 +757,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - Inspect the flagged target (get_entity — check aspects, claims, pinned).
    - Archive or merge it, citing its attention id (provenance: "attention:<uuid>", or attention:$<index> for a flag you minted in the same batch).
    - If you discover junk the queue did not flag, mint a flag op and archive in the same batch.
+   - If you inspect a flagged target and judge it should stay as it is (a deliberate keep — e.g. a live entity with a non-concrete type, or an over-cap aspect you chose not to consolidate), close the record with decline_attention citing its attention id. Declining is an affirmative judgment: only decline records you actually inspected, and never decline records you could not complete this pass — defer those in the pass log so they stay pending.
 3. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write natural-language prose — what was examined, what changed (mutations by type and count, entities touched), why (the dominant reason driving the work), and what was deferred or left flagged and why. No bullet lists, no tool names; a few clear sentences. Put deferred items and open questions in the runbook's deferred and openQuestions fields, not only in the summary.
 
 ### Safe
@@ -776,6 +779,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 - Hygiene queue is drained, or remaining records are explicitly deferred with reasons in the pass log.
 - Pass log written with changes applied (this is the next pass's dedup).
 - No flag left unresolved for a target you archived.
+- Records you judged to keep are closed with decline_attention; records you could not complete this pass stay pending and are deferred in the pass log.
 - No writes attempted against pinned or source-root entities.
 `;
 


### PR DESCRIPTION
## Summary

Attention flags only resolve when an ontology op applies for their subject. When the agent deliberately **keeps** a candidate (the "declined" judgment — e.g. a live entity flagged `non_concrete_entity_type`, or an over-cap aspect the model chose not to consolidate), the flag stays pending forever and the check re-triggers a fresh pass every cycle to re-investigate the same declined work — indefinitely. Observed: four flags persisting across every pass (the model listed them, declined, and the flags never resolved).

The fix gives the agent an **affirmative decline**: a new `decline_attention` op in `apply_ontology_ops` closes exactly one pending record the agent inspected and judged to keep. A deliberate keep resolves and stops re-triggering passes, while records the agent could not complete stay pending — the runbook's "deferred with reasons in the pass log" contract is preserved.

An earlier revision swept every record the agent surfaced via `attention_list` at pass end. Adversarial review proved that conflates judgment with listing: an agent that listed the queue, applied a subset, and explicitly deferred the rest had its deferred work silently resolved forever (the enqueue upsert reopens a record only when its details change). This PR ships the affirmative form instead.

## Changes

- `platform/daemon/src/pipeline/dreaming-operation-contract.ts` — add the `decline_attention` op (payload: `attentionId`) to the Dreaming vocabulary.
- `platform/daemon/src/pipeline/dreaming-operations.ts` — apply the op in the daemon-owned batch seam: scoped to the agent named in the apply call, one-use (a flag is consumed once, like an archive op), and only resolves rows still pending (`resolved_at IS NULL`), so a record re-enqueued with changed details stays open.
- `platform/daemon/src/pipeline/dreaming.ts` — both runbooks (combined + hygiene) instruct the agent to close records it judged to keep with `decline_attention` and to defer, not decline, records it could not complete; verification contract updated.
- `platform/daemon/src/pipeline/dreaming-capabilities.ts` — apply tool description mentions the new op.
- `docs/api/knowledge-ontology.md` — attention lifecycle documented (resolve on apply or explicit decline; deferred and failed-pass records stay pending).

## Type

- [x] `fix` — bug fix

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A — daemon-side fix, no UI.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries (decline resolves only rows owned by the agent named in the apply call)
- [x] Input/config validation and bounds checks added (`attentionId` required, schema-enforced)
- [x] Error handling and fallback paths tested (no silent swallow) — not-pending and cross-scope declines fail closed with item-level errors
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

## Testing

- [x] `bun test` passes — dreaming + dreaming-agent-tools + dreaming-worker + operation-contract suites 56/56, including: the #1185 primary case (decline closes the flag), the over-resolution regression (list 3, decline 1, defer 2 → exactly 1 resolves, 2 stay pending), and the one-use/scoped invariants (cross-scope decline fails closed, second decline of the same record rejected)
- [x] `bun run typecheck` passes (`@signet/daemon` exit 0)
- [x] `bun run lint` passes (biome clean on touched files)
- [ ] Tested against running daemon — live verification follows the release per the dev process
- [x] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Resolves #1185

Assisted-by: Hermes-Agent:deepseek-v4-flash
