### PR TITLE
feat(telemetry): emit install.activated on first run

### DIFF
--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -231,10 +231,12 @@ lifecycle (`route`, `execute`, `stream`, `fallback`), `llm.generate`
 (provider, latency, token and cost counts when reported, success — never
 prompt text), `session.start` / `session.end` (harness and prompt count),
 the lifecycle events `daemon.started`, `command.invoked`,
-`error.occurred`, and `version.upgraded`, and `pipeline.embedding`
-(tokens, provider, sourceKind — memory capture / artifact index /
-recall / dreaming). The remaining `pipeline.*` event types are declared
-for future use but not yet emitted.
+`error.occurred`, and `version.upgraded`, `install.activated` (first
+daemon run of a new install — covers bun/desktop installs the npm
+postinstall ping never sees), and `pipeline.embedding` (tokens,
+provider, sourceKind — memory capture / artifact index / recall /
+dreaming). The remaining `pipeline.*` event types are declared for
+future use but not yet emitted.
 
 Release Download Stats
 ---

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -172,7 +172,10 @@ describe("telemetry collector", () => {
 		expect(captured).toHaveLength(1);
 		const body = captured[0]?.body;
 		expect(body?.api_key).toBe("phc_test_key");
-		expect(body?.batch).toHaveLength(2);
+		// install.activated fires first on a fresh install, then the two
+		// recorded events.
+		expect(body?.batch).toHaveLength(3);
+		expect(body?.batch[0]?.event).toBe("install.activated");
 		expect(body?.batch[0]?.distinct_id).toBe(lastBatchDistinctId());
 		expect(body?.batch[1]?.properties.$lib).toBe("signet-daemon");
 		expect(unsentCount()).toBe(0);
@@ -184,6 +187,24 @@ describe("telemetry collector", () => {
 		await collector.flush();
 		await collector.flush();
 		expect(captured).toHaveLength(1);
+	});
+
+	it("emits install.activated exactly once per install", async () => {
+		// Regression: the npm postinstall ping never fires for bun global or
+		// desktop installs, so the install counter missed them. The daemon
+		// emits install.activated on first run (new persisted install id).
+		const first = makeCollector();
+		first.record("daemon.heartbeat", { uptimeMs: 1 });
+		await first.flush();
+		expect(captured[0]?.body.batch[0]?.event).toBe("install.activated");
+		expect(captured[0]?.body.batch[0]?.properties.version).toBe("0.0.0-test");
+
+		// Restart over the same database: no second activation.
+		const second = makeCollector();
+		second.record("daemon.heartbeat", { uptimeMs: 2 });
+		await second.flush();
+		const lastBatch = captured.at(-1)?.body.batch ?? [];
+		expect(lastBatch.map((e) => e.event)).not.toContain("install.activated");
 	});
 
 	it("honors SIGNET_TELEMETRY_OPTOUT as a runtime opt-out", () => {
@@ -221,7 +242,8 @@ describe("telemetry collector", () => {
 			(db) => db.prepare("SELECT id FROM telemetry_events").all() as Array<{ readonly id: string }>,
 		);
 		expect(rows.map((r) => r.id)).not.toContain("old-1");
-		expect(rows.length).toBe(1);
+		// install.activated (first run) + the freshly recorded heartbeat.
+		expect(rows.length).toBe(2);
 	});
 });
 
@@ -252,13 +274,16 @@ describe("telemetry lifecycle events (issue #1026 Phase 2)", () => {
 
 		expect(existsSync(logPath)).toBe(true);
 		const lines = readFileSync(logPath, "utf-8").trim().split("\n");
-		expect(lines).toHaveLength(2);
+		expect(lines).toHaveLength(3);
 		const first = JSON.parse(lines[0]) as { event: string; properties: { version: string } };
-		expect(first.event).toBe("daemon.started");
+		expect(first.event).toBe("install.activated");
 		expect(first.properties.version).toBe("0.163.15");
-		const second = JSON.parse(lines[1]) as { event: string; properties: { command: string } };
-		expect(second.event).toBe("command.invoked");
-		expect(second.properties.command).toBe("status");
+		const second = JSON.parse(lines[1]) as { event: string; properties: { version: string } };
+		expect(second.event).toBe("daemon.started");
+		expect(second.properties.version).toBe("0.163.15");
+		const third = JSON.parse(lines[2]) as { event: string; properties: { command: string } };
+		expect(third.event).toBe("command.invoked");
+		expect(third.properties.command).toBe("status");
 	});
 
 	it("does not write a log when telemetryLogPath is omitted", () => {

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -55,6 +55,7 @@ export const TELEMETRY_EVENTS = [
 	// Lifecycle events (issue #1026 Phase 2): fired when the user has opted
 	// into anonymous telemetry. No PII, no code, no memory content.
 	"daemon.started",
+	"install.activated",
 	"command.invoked",
 	"error.occurred",
 	"version.upgraded",
@@ -122,8 +123,13 @@ export function telemetryDisabledByEnv(env: NodeJS.ProcessEnv = process.env): bo
  * first use. Falls back to an in-memory id if the database is unusable.
  * A truthy guard is required here: bun:sqlite returns null for a missing row
  * while better-sqlite3 returns undefined (dual-DB daemon).
+ *
+ * `created` is true only when the id was actually inserted — the daemon uses
+ * it to emit install.activated (the true first-run signal that covers bun,
+ * desktop, and npm installs alike; the wrapper postinstall ping misses bun
+ * and desktop entirely).
  */
-function getOrCreateInstallId(db: DbAccessor): string {
+function getOrCreateInstallId(db: DbAccessor): { readonly id: string; readonly created: boolean } {
 	try {
 		const existing = db.withReadDb((r) => {
 			const row = r.prepare("SELECT id FROM telemetry_install ORDER BY created_at ASC LIMIT 1").get() as
@@ -132,7 +138,7 @@ function getOrCreateInstallId(db: DbAccessor): string {
 				| undefined;
 			return row?.id ?? null;
 		});
-		if (existing != null) return existing;
+		if (existing != null) return { id: existing, created: false };
 
 		const id = crypto.randomUUID();
 		db.withWriteTx((w) => {
@@ -141,9 +147,9 @@ function getOrCreateInstallId(db: DbAccessor): string {
 				new Date().toISOString(),
 			);
 		});
-		return id;
+		return { id, created: true };
 	} catch {
-		return crypto.randomUUID();
+		return { id: crypto.randomUUID(), created: false };
 	}
 }
 
@@ -220,7 +226,7 @@ export function createTelemetryCollector(
 	let consecutiveFailures = 0;
 	let flushCount = 0;
 	let effectiveIntervalMs = config.flushIntervalMs;
-	const installId = getOrCreateInstallId(db);
+	const { id: installId, created: installActivated } = getOrCreateInstallId(db);
 
 	const posthogConfigured = config.posthogHost.length > 0 && config.posthogApiKey.length > 0;
 
@@ -334,7 +340,7 @@ export function createTelemetryCollector(
 		}
 	}
 
-	return {
+	const collector: TelemetryCollector = {
 		enabled: true,
 
 		record(event, properties): void {
@@ -454,4 +460,16 @@ export function createTelemetryCollector(
 			}
 		},
 	};
+
+	// First run of a new install: emit install.activated so daemon-running
+	// installs are countable regardless of how they were installed (the npm
+	// postinstall ping never fires for bun global or desktop installs).
+	if (installActivated) {
+		collector.record("install.activated", {
+			version: daemonVersion,
+			platform: process.platform,
+		});
+	}
+
+	return collector;
 }


### PR DESCRIPTION
## Summary

The npm postinstall `install.ping` never fires for bun global installs (postinstall skipped) or desktop-app installs (no postinstall at all), and its throwaway uuid can't join the daemon's persisted install id — so `install.ping` structurally undercounts real installs and can't measure "active installs." The daemon already knows the true install moment: creating the persisted install id on first run. It now emits `install.activated` (version + platform) exactly once there.

## Changes

- `platform/daemon/src/telemetry.ts`:
  - New `install.activated` event type.
  - `getOrCreateInstallId` returns `{ id, created }` — `created` is true only when the id was actually inserted (not on subsequent reads, not on the DB-failure fallback).
  - The collector emits `install.activated` on first run with `{ version, platform }`.
- Regression test: `install.activated` fires exactly once per install — present in the first batch on a fresh workspace, absent after a restart over the same database.
- Existing tests updated for the new first-batch event (batch counts, JSONL mirror, retention prune).
- docs/ANALYTICS.md: `install.activated` documented.

## Type

- [x] `feat` — new user-facing feature (bumps minor)

## Packages affected

- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/core`
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: docs

## Screenshots

N/A.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries — telemetry is global-anonymous; no agent scoping applies
- [x] Input/config validation and bounds checks added — event properties are typed; no new config
- [x] Error handling and fallback paths tested (no silent swallow) — DB-failure fallback explicitly does NOT emit activation (can't distinguish first run); emit is best-effort
- [x] Security checks applied to admin/mutation endpoints — N/A
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no schema changes.

## Testing

- [x] `bun test` passes — telemetry + embedding suites 13/13
- [x] `bun run typecheck` passes — daemon package green
- [x] `bun run lint` passes — biome clean
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Analytics semantics going forward: "active installs" = distinct_ids with `install.activated` (covers bun, desktop, npm uniformly). `install.ping` remains the npm-wrapper-installs signal. The two cohorts are intentionally not joinable (different ids by design) — treat them as complementary curves.
