### PR TITLE
feat(telemetry): emit dreaming.pass with token usage

### DIFF
--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -233,10 +233,11 @@ prompt text), `session.start` / `session.end` (harness and prompt count),
 the lifecycle events `daemon.started`, `command.invoked`,
 `error.occurred`, and `version.upgraded`, `install.activated` (first
 daemon run of a new install — covers bun/desktop installs the npm
-postinstall ping never sees), and `pipeline.embedding` (tokens,
-provider, sourceKind — memory capture / artifact index / recall /
-dreaming). The remaining `pipeline.*` event types are declared for
-future use but not yet emitted.
+postinstall ping never sees), `pipeline.embedding` (tokens, provider,
+sourceKind — memory capture / artifact index / recall / dreaming), and
+`dreaming.pass` (provider-reported input/output/cache tokens and cost
+per agentic pass). The remaining `pipeline.*` event types are declared
+for future use but not yet emitted.
 
 Release Download Stats
 ---

--- a/platform/daemon/src/pipeline/dreaming-telemetry.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-telemetry.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression test: dreaming pass token usage must reach the telemetry
+ * pipeline (dreaming.pass) so dreaming economics show up in PostHog — the
+ * local dreaming_passes table alone was invisible to analytics.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
+import { type TelemetryCollector, createTelemetryCollector, setActiveTelemetry } from "../telemetry";
+import { cleanupTestTempDir, createTestTempDir } from "../test-temp-dir";
+import { recordDreamingPassTelemetry } from "./dreaming";
+
+let dir = "";
+
+const TELEMETRY_CONFIG = {
+	posthogHost: "",
+	posthogApiKey: "",
+	flushIntervalMs: 60000,
+	flushBatchSize: 50,
+	retentionDays: 90,
+	memorySearchQaEnabled: false,
+} as const;
+
+describe("dreaming telemetry", () => {
+	beforeAll(() => {
+		dir = createTestTempDir("signet-dream-telemetry-");
+		closeDbAccessor();
+		rmSync(join(dir, "memory"), { recursive: true, force: true });
+		mkdirSync(join(dir, "memory"), { recursive: true });
+		initDbAccessor(join(dir, "memory", "memories.db"));
+	});
+
+	afterAll(() => {
+		setActiveTelemetry(undefined);
+		closeDbAccessor();
+		cleanupTestTempDir(dir);
+	});
+
+	it("emits dreaming.pass with provider-reported usage at pass completion", async () => {
+		const collector = createTelemetryCollector(getDbAccessor(), TELEMETRY_CONFIG, "0.0.0-test");
+		setActiveTelemetry(collector);
+
+		recordDreamingPassTelemetry({
+			mode: "agentic",
+			usage: {
+				inputTokens: 384561,
+				outputTokens: 18227,
+				cacheReadTokens: 100000,
+				cacheCreationTokens: 5000,
+				totalCost: 0.14574042,
+			},
+		});
+		recordDreamingPassTelemetry({ mode: "hygiene", usage: null });
+		await collector.flush();
+
+		const passes = collector.query().filter((e) => e.event === "dreaming.pass");
+		expect(passes).toHaveLength(2);
+		const full = passes.find((e) => e.properties.mode === "agentic");
+		expect(full?.properties.tokensInput).toBe(384561);
+		expect(full?.properties.tokensOutput).toBe(18227);
+		expect(full?.properties.tokensCacheRead).toBe(100000);
+		expect(full?.properties.tokensCacheWrite).toBe(5000);
+		expect(full?.properties.cost).toBe(0.14574042);
+		const bare = passes.find((e) => e.properties.mode === "hygiene");
+		expect(bare?.properties.tokensInput).toBeNull();
+		expect(bare?.properties.cost).toBeNull();
+	});
+});

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -30,6 +30,7 @@ import {
 import { type GraphHygieneCaps, getDreamingHygieneCandidatesInDb } from "../knowledge-graph-hygiene";
 import { logger } from "../logger";
 import type { GraphWriteCaps } from "../ontology-proposals";
+import { getActiveTelemetry } from "../telemetry";
 import { createDreamingAgentTools } from "./dreaming-agent-tools";
 import {
 	type DreamingAttention,
@@ -912,6 +913,31 @@ export function selectDreamingPassMode(
  * Bounded tool-loop Dreaming pass. The daemon owns evidence selection,
  * exclusion/cursor bookkeeping, tool construction, and audited writes.
  */
+
+/**
+ * Anonymous telemetry for a completed agentic dreaming pass: provider-reported
+ * token usage and cost so dreaming economics show up in PostHog alongside
+ * llm.generate and pipeline.embedding. Best-effort — never throws into the pass.
+ */
+export function recordDreamingPassTelemetry(input: {
+	readonly mode: string;
+	readonly usage: {
+		readonly inputTokens: number | null;
+		readonly outputTokens: number | null;
+		readonly cacheReadTokens: number | null;
+		readonly cacheCreationTokens: number | null;
+		readonly totalCost: number | null;
+	} | null;
+}): void {
+	getActiveTelemetry()?.record("dreaming.pass", {
+		mode: input.mode,
+		tokensInput: input.usage?.inputTokens ?? null,
+		tokensOutput: input.usage?.outputTokens ?? null,
+		tokensCacheRead: input.usage?.cacheReadTokens ?? null,
+		tokensCacheWrite: input.usage?.cacheCreationTokens ?? null,
+		cost: input.usage?.totalCost ?? null,
+	});
+}
 export async function runDreamingAgentPass(
 	accessor: DbAccessor,
 	executor: DreamingAgentExecutor,
@@ -1080,6 +1106,11 @@ export async function runDreamingAgentPass(
 				}
 			}
 		});
+		recordDreamingPassTelemetry({
+			mode,
+			usage,
+		});
+
 		return { passId, applied, skipped: 0, failed, summary };
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/platform/daemon/src/routes/telemetry-routes.ts
+++ b/platform/daemon/src/routes/telemetry-routes.ts
@@ -205,6 +205,12 @@ export function registerTelemetryRoutes(app: Hono): void {
 		let embeddingCalls = 0;
 		let embeddingTokens = 0;
 		const embeddingBySource = new Map<string, number>();
+		let dreamingCalls = 0;
+		let dreamingInput = 0;
+		let dreamingOutput = 0;
+		let dreamingCacheRead = 0;
+		let dreamingCacheWrite = 0;
+		let dreamingCost = 0;
 		const latencies: number[] = [];
 
 		for (const e of events) {
@@ -226,6 +232,14 @@ export function registerTelemetryRoutes(app: Hono): void {
 						(typeof e.properties.tokens === "number" ? e.properties.tokens : 0),
 				);
 			}
+			if (e.event === "dreaming.pass") {
+				dreamingCalls++;
+				if (typeof e.properties.tokensInput === "number") dreamingInput += e.properties.tokensInput;
+				if (typeof e.properties.tokensOutput === "number") dreamingOutput += e.properties.tokensOutput;
+				if (typeof e.properties.tokensCacheRead === "number") dreamingCacheRead += e.properties.tokensCacheRead;
+				if (typeof e.properties.tokensCacheWrite === "number") dreamingCacheWrite += e.properties.tokensCacheWrite;
+				if (typeof e.properties.cost === "number") dreamingCost += e.properties.cost;
+			}
 			if (e.event === "pipeline.error") pipelineErrors++;
 		}
 
@@ -243,6 +257,14 @@ export function registerTelemetryRoutes(app: Hono): void {
 				bySource: [...embeddingBySource.entries()]
 					.map(([source, tokens]) => ({ source, tokens }))
 					.sort((a, b) => b.tokens - a.tokens),
+			},
+			dreaming: {
+				calls: dreamingCalls,
+				tokensInput: dreamingInput,
+				tokensOutput: dreamingOutput,
+				tokensCacheRead: dreamingCacheRead,
+				tokensCacheWrite: dreamingCacheWrite,
+				cost: dreamingCost,
 			},
 			pipelineErrors,
 		});

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -56,6 +56,7 @@ export const TELEMETRY_EVENTS = [
 	// into anonymous telemetry. No PII, no code, no memory content.
 	"daemon.started",
 	"install.activated",
+	"dreaming.pass",
 	"command.invoked",
 	"error.occurred",
 	"version.upgraded",


### PR DESCRIPTION
## Summary

Dreaming pass token usage was tracked only in the local `dreaming_passes` table (migration 107) — invisible to PostHog, so per-install analytics missed the largest token consumer on the platform (169 passes / 8.66M input tokens on the reference install vs a few thousand tokens in llm.generate). The agentic pass completion now emits `dreaming.pass` with provider-reported usage.

## Changes

- `platform/daemon/src/pipeline/dreaming.ts`: `recordDreamingPassTelemetry()` called at agentic pass completion with `{ mode, usage }` → `dreaming.pass` event carrying `tokensInput/tokensOutput/tokensCacheRead/tokensCacheWrite/cost`. Early-exit passes (zero tokens) record nothing. Best-effort via the active collector.
- `platform/daemon/src/telemetry.ts`: `dreaming.pass` event type added.
- `platform/daemon/src/routes/telemetry-routes.ts`: `/api/telemetry/stats` gains `dreaming: { calls, tokensInput, tokensOutput, tokensCacheRead, tokensCacheWrite, cost }` alongside llm and embedding.
- Regression test pins the payload contract (full usage + null-usage hygiene pass).
- docs/ANALYTICS.md updated.

## Type

- [x] `feat` — new user-facing feature (bumps minor)

## Packages affected

- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/core`
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: docs

## Screenshots

N/A.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries — telemetry is global-anonymous; no agent scoping applies
- [x] Input/config validation and bounds checks added — event properties typed; stats sums guarded by typeof checks
- [x] Error handling and fallback paths tested (no silent swallow) — emit is best-effort behind optional chaining; early-exit passes intentionally silent
- [x] Security checks applied to admin/mutation endpoints — N/A, read-only stats extension
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no schema changes.

## Testing

- [x] `bun test` passes — dreaming-telemetry + telemetry suites 13/13
- [x] `bun run typecheck` passes — daemon package green
- [x] `bun run lint` passes — biome clean
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Provider-reported usage comes from pi-backed agent sessions; acpx-backed passes fall back to the local prompt estimate in `tokens_consumed` but the telemetry fields are null when the provider reports none (same contract as llm.generate).
