### PR TITLE
fix(dreaming): keep worker check loop alive when a pass fails

### DIFF
--- a/platform/daemon/src/pipeline/dreaming-worker.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.test.ts
@@ -52,6 +52,15 @@ function wrapDb(db: Database): DbAccessor {
 	} as unknown as DbAccessor;
 }
 
+async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(`Condition not met within ${timeoutMs}ms`);
+}
+
 describe("dreaming worker agent scope", () => {
 	let db: Database;
 	let accessor: DbAccessor;
@@ -160,6 +169,70 @@ describe("dreaming worker agent scope", () => {
 			).toEqual({ count: 0 });
 		} finally {
 			worker.stop();
+		}
+	});
+
+	it("keeps the check loop alive when a scheduled pass fails (#1198)", async () => {
+		// Regression for #1198: the periodic check loop awaited runPass
+		// without catching, so a provider 429 (or any executor rejection)
+		// escaped through the timer callback as an unhandled rejection. The
+		// daemon's unhandledRejection exit path (#1148) then shut down the
+		// whole process, and the sweep never re-armed. The check loop must
+		// record the failure (recordDreamingFailure + failDreamingPass), log
+		// it, and keep scheduling future checks.
+		db.prepare(
+			`INSERT INTO session_summaries
+		 (id, agent_id, content, token_count, depth, kind, source_type, earliest_at, latest_at, created_at)
+		 VALUES ('sweep-failure-evidence', 'alpha', 'Episodic evidence awaiting a doomed pass.', 10, 0, 'session', 'summary',
+		         datetime('now'), datetime('now'), datetime('now'))`,
+		).run();
+
+		const executorFactory = () => ({
+			async run(_input: { prompt: string; tools: ReadonlyArray<{ name: string }> }) {
+				throw new Error("429 rate_limit_error: Token usage limit reached");
+			},
+		});
+
+		// The bug's observable signature is an unhandled rejection escaping
+		// the check loop; capture any that surface during the test window.
+		const unhandled: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandledRejection);
+
+		const worker = startDreamingWorker(accessor, defaultCfg({ tokenThreshold: 1 }), agentsDir, "default", {
+			executorFactory,
+			checkIntervalMs: 20,
+		});
+		try {
+			// Failures accumulate on the run agent ("default") while the
+			// per-scope backoff reads each scope's own state, so "alpha"'s
+			// fresh backlog re-triggers on the next tick. Two recorded
+			// failures prove the loop survived the first one and kept
+			// checking instead of dying with it.
+			await waitFor(() => {
+				const state = db
+					.prepare("SELECT consecutive_failures AS n FROM dreaming_state WHERE agent_id = 'default'")
+					.get() as { n: number } | null;
+				return state != null && state.n >= 2;
+			}, 2_000);
+			expect(unhandled).toEqual([]);
+
+			const state = db
+				.prepare("SELECT consecutive_failures AS n FROM dreaming_state WHERE agent_id = 'default'")
+				.get() as { n: number };
+			expect(state.n).toBeGreaterThanOrEqual(2);
+
+			const passes = db.prepare("SELECT status, error FROM dreaming_passes ORDER BY created_at").all() as Array<{
+				status: string;
+				error: string | null;
+			}>;
+			expect(passes.length).toBeGreaterThanOrEqual(2);
+			expect(passes.every((pass) => pass.status === "failed" && pass.error?.includes("429"))).toBe(true);
+		} finally {
+			worker.stop();
+			process.off("unhandledRejection", onUnhandledRejection);
 		}
 	});
 

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -61,6 +61,8 @@ export interface DreamingWorkerHandle {
 export interface DreamingWorkerOptions {
 	/** Test seam; production always uses the configured inference router. */
 	readonly executorFactory?: (agentId: string) => DreamingAgentExecutor;
+	/** Test seam; production always uses the 5-minute check interval. */
+	readonly checkIntervalMs?: number;
 	/** Scoped connection details for ACPX's temporary MCP server. */
 	readonly acpxMcp?: {
 		readonly daemonUrl: string;
@@ -332,15 +334,45 @@ export function startDreamingWorker(
 		// directly otherwise.
 		const mode = selectDreamingCheckMode(accessor, scopes, nextScheduledFocus);
 		nextScheduledFocus = dreamingFocusOfMode(mode) ?? nextScheduledFocus;
-		await runPass(defaultAgentId, mode, undefined, scopes);
+		try {
+			await runPass(defaultAgentId, mode, undefined, scopes);
+		} catch (e) {
+			// runPass already recorded the failure (recordDreamingFailure)
+			// and failDreamingPass marked the pass row failed. A pass error
+			// (provider 429, timeout, any executor rejection) must never
+			// escape the check loop: as an unhandled rejection it hits the
+			// daemon's unhandledRejection exit path and kills the whole
+			// process (#1198). Log and keep the loop running; the per-scope
+			// failure backoff (keyed on the run agent's state) paces the
+			// retries.
+			logger.error(
+				"dreaming-worker",
+				"Scheduled dreaming pass failed; check loop continues",
+				e instanceof Error ? e : undefined,
+				{ mode, error: e instanceof Error ? e.message : String(e) },
+			);
+		}
 	}
 
 	function schedule(): void {
 		if (stopped) return;
 		timer = setTimeout(async () => {
-			await check();
+			// check() handles pass failures internally; this catch is the
+			// last line of defense so no check error (from any future
+			// path) becomes an unhandled rejection, and the sweep always
+			// re-arms instead of silently dying (#1198).
+			try {
+				await check();
+			} catch (e) {
+				logger.error(
+					"dreaming-worker",
+					"Dreaming check failed; scheduling next check",
+					e instanceof Error ? e : undefined,
+					{ error: e instanceof Error ? e.message : String(e) },
+				);
+			}
 			schedule();
-		}, CHECK_INTERVAL_MS);
+		}, options.checkIntervalMs ?? CHECK_INTERVAL_MS);
 	}
 
 	// Start the periodic check. Hygiene attention is enqueued during regular


### PR DESCRIPTION
## Summary

Fixes #1198: the dreaming worker's periodic check loop awaited `runPass` with no catch. When a pass failed (provider 429, timeout, any executor rejection), `runPass` recorded the failure and re-threw; the rejection escaped `check()` through the `schedule()` timer callback as an unhandled rejection, hitting the daemon's `unhandledRejection` exit path (#1148) and killing the whole process. The sweep loop also stopped re-arming, so dreaming silently died with it.

## Changes

- `check()` now catches scheduled pass failures: the failure is already recorded (`recordDreamingFailure` bumps `consecutive_failures`, `failDreamingPass` marks the pass row failed), so the catch logs and continues. A provider error can no longer escape the check loop.
- `schedule()`'s timer callback catches any check error as a last line of defense and always re-arms the loop, so no future check path can become an unhandled rejection or silently stop the sweep.
- `DreamingWorkerOptions` gains a `checkIntervalMs` test seam (production keeps the 5-minute interval; the daemon passes no override).

## Test

`dreaming-worker.test.ts` gains a regression test that seeds a scope with episodic backlog, runs a worker whose executor throws a 429, and asserts: no unhandled rejection escapes, failures are recorded (>= 2 consecutive failures proves the loop survived the first one and kept checking), and every pass row is marked failed with the provider error. Mutation-verified: reverting the catches makes the test fail with the exact stack from the issue (`runDreamingAgentPass -> runPass -> check -> timer callback`).

## Type

fix

## Packages affected

- platform/daemon

## Verification

- `bun test platform/daemon/src/pipeline/dreaming-worker.test.ts`: 8 pass / 0 fail
- Sibling suites (`dreaming.test.ts`): 35 pass / 0 fail
- `bunx biome check` on both touched files: clean
- `bun run --filter '@signet/daemon' build`: pass
- `@signet/daemon` typecheck: pass (repo-wide typecheck has pre-existing @signet/connector-codex errors on origin/main, untouched by this PR)

No screenshots: daemon-only change, no UI surface.


## Mandatory checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## AI disclosure

Implementation and review were assisted by AI agents (Hermes Agent, per AI_POLICY.md). The change was reviewed by a human before submission; an adversarial automated review found no HIGH/CRITICAL issues.
