### PR TITLE
feat(telemetry): sanitized crash reports for remote debugging

### DIFF
--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -231,12 +231,15 @@ lifecycle (`route`, `execute`, `stream`, `fallback`), `llm.generate`
 (provider, latency, token and cost counts when reported, success — never
 prompt text), `session.start` / `session.end` (harness and prompt count),
 the lifecycle events `daemon.started`, `command.invoked`,
-`error.occurred`, and `version.upgraded`, `install.activated` (first
-daemon run of a new install — covers bun/desktop installs the npm
-postinstall ping never sees), `pipeline.embedding` (tokens, provider,
-sourceKind — memory capture / artifact index / recall / dreaming), and
-`dreaming.pass` (provider-reported input/output/cache tokens and cost
-per agentic pass). The remaining `pipeline.*` event types are declared
+`error.occurred` (sanitized crash report — truncated message with user
+paths stripped, top stack frames with home directories removed, uptime;
+plus rate-limited `EventLoopLag` reports with measured lag), and
+`version.upgraded`, `install.activated` (first daemon run of a new
+install — covers bun/desktop installs the npm postinstall ping never
+sees), `pipeline.embedding` (tokens, provider, sourceKind — memory
+capture / artifact index / recall / dreaming), and `dreaming.pass`
+(provider-reported input/output/cache tokens and cost per agentic
+pass). The remaining `pipeline.*` event types are declared
 for future use but not yet emitted.
 
 Release Download Stats

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1141,7 +1141,9 @@ data are ever included.
 
 Lifecycle events: `daemon.started` (version, platform,
 uptime), `command.invoked` (command name only, never arguments),
-`error.occurred` (error type only, never stack/message), `version.upgraded`
+`error.occurred` (sanitized crash report — truncated message with user paths
+stripped, top stack frames with home directories removed, uptime, and
+rate-limited `EventLoopLag` reports with measured lag), `version.upgraded`
 (from, to).
 
 | Field | Default | Range | Description |

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -140,6 +140,7 @@ import {
 	type TelemetryCollector,
 	createTelemetryCollector,
 	defaultTelemetryLogPath,
+	sanitizeCrashError,
 	setActiveTelemetry,
 	telemetryDisabledByEnv,
 } from "./telemetry";
@@ -1726,9 +1727,9 @@ process.on("SIGTERM", () => {
 
 process.on("uncaughtException", (err) => {
 	logger.error("daemon", "Uncaught exception", err);
-	// Lifecycle event (issue #1026 Phase 2): error type only — never the
-	// stack or message content.
-	telemetryRef?.record("error.occurred", { type: err?.name ?? "Error" });
+	// Sanitized crash report: truncated message, home-stripped stack frames,
+	// uptime. No memory content. Joinable to the install's heartbeat context.
+	telemetryRef?.record("error.occurred", sanitizeCrashError(err, process.uptime() * 1000));
 	requestShutdown("error:uncaughtException", 1, err);
 });
 
@@ -1739,11 +1740,9 @@ process.on("unhandledRejection", (reason) => {
 		reason instanceof Error ? reason : undefined,
 		reason instanceof Error ? undefined : { reason: String(reason) },
 	);
-	// Lifecycle event (issue #1026 Phase 2): error type only — never the
-	// stack or message content.
-	telemetryRef?.record("error.occurred", {
-		type: reason instanceof Error ? reason.name : "UnhandledRejection",
-	});
+	// Sanitized crash report for rejections too (primitives degrade to a
+	// truncated string).
+	telemetryRef?.record("error.occurred", sanitizeCrashError(reason, process.uptime() * 1000));
 	requestShutdown("error:unhandledRejection", 1, reason);
 });
 

--- a/platform/daemon/src/system-pressure.ts
+++ b/platform/daemon/src/system-pressure.ts
@@ -16,6 +16,7 @@
  */
 
 import { logger } from "./logger";
+import { getActiveTelemetry } from "./telemetry";
 
 export type PressureLevel = "normal" | "elevated" | "critical";
 
@@ -38,7 +39,10 @@ let startupGraceUntil = 0;
 export function reportStartupGrace(durationMs = 10_000): void {
 	startupGraceUntil = Date.now() + durationMs;
 	if (currentLevel === "normal") currentLevel = "elevated";
-	logger.info("system-pressure", `Startup grace period active for ${Math.round(durationMs / 1000)}s — background workers deferred`);
+	logger.info(
+		"system-pressure",
+		`Startup grace period active for ${Math.round(durationMs / 1000)}s — background workers deferred`,
+	);
 }
 
 /**
@@ -46,8 +50,28 @@ export function reportStartupGrace(durationMs = 10_000): void {
  * difference between the expected callback interval and the actual interval —
  * i.e. how long the event loop was blocked since the last tick.
  */
-export function reportEventLoopLag(lagMs: number): void {
+const EVENT_LOOP_WEDGE_COOLDOWN_MS = 10 * 60 * 1000;
+let lastWedgeEmitAt = 0;
+
+/**
+ * Sanitized crash signal for a wedged event loop (the #1059/#1094 class):
+ * emitted at most once per 10 minutes so a stuck loop can't flood PostHog.
+ * `now` is injectable for tests.
+ */
+function reportEventLoopWedge(lagMs: number, now: number): void {
+	// lastWedgeEmitAt === 0 means never emitted — always report the first wedge.
+	if (lastWedgeEmitAt !== 0 && now - lastWedgeEmitAt < EVENT_LOOP_WEDGE_COOLDOWN_MS) return;
+	lastWedgeEmitAt = now;
+	getActiveTelemetry()?.record("error.occurred", {
+		type: "EventLoopLag",
+		message: `event loop critically blocked for ${Math.round(lagMs)}ms`,
+		lagMs: Math.round(lagMs),
+	});
+}
+
+export function reportEventLoopLag(lagMs: number, now: number = Date.now()): void {
 	if (lagMs >= CRITICAL_THRESHOLD_MS) {
+		reportEventLoopWedge(lagMs, now);
 		if (currentLevel !== "critical") {
 			logger.warn("system-pressure", `Event loop critically blocked (${lagMs}ms) — background work should pause`);
 		}

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -20,6 +20,7 @@ import {
 	createTelemetryCollector,
 	defaultTelemetryLogPath,
 	nextFlushIntervalMs,
+	sanitizeCrashError,
 	telemetryDisabledByEnv,
 } from "./telemetry";
 import { cleanupTestTempDir, createTestTempDir } from "./test-temp-dir";
@@ -205,6 +206,45 @@ describe("telemetry collector", () => {
 		await second.flush();
 		const lastBatch = captured.at(-1)?.body.batch ?? [];
 		expect(lastBatch.map((e) => e.event)).not.toContain("install.activated");
+	});
+
+	it("sanitizes crash reports: truncation, home-path stripping, frame cap", () => {
+		const longMessage =
+			'SQLiteError: database is locked near "a very long embedded fragment that goes on and on" at /home/alice/.agents/memory/memories.db'.repeat(
+				10,
+			);
+		const err = new Error(longMessage);
+		err.stack = [
+			"Error: database is locked",
+			"    at run (/home/alice/.agents/platform/daemon/src/db-accessor.ts:1045:12)",
+			"    at withWriteTx (/home/alice/.agents/platform/daemon/src/db-accessor.ts:1060:14)",
+			"    at main (/home/alice/.agents/platform/daemon/src/daemon.ts:2001:9)",
+			"    at Module._compile (node:internal/modules/cjs/loader:1234:17)",
+			"    at Module._extensions..js (node:internal/modules/cjs/loader:987:10)",
+			"    at Module.load (node:internal/modules/cjs/loader:812:32)",
+			"    at Module._load (node:internal/modules/cjs/loader:685:12)",
+			"    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main_module:99:12)",
+			"    at node:internal/main/run_main_module:18:47",
+		].join("\n");
+
+		const props = sanitizeCrashError(err, 123456);
+		expect(props.type).toBe("Error");
+		expect(props.message.length).toBeLessThanOrEqual(400);
+		expect(props.message).not.toContain("/home/alice");
+		expect(props.message).toContain("~");
+		expect(props.uptimeMs).toBe(123456);
+		const frames = (props.stack as string).split("\n");
+		expect(frames.length).toBeLessThanOrEqual(8);
+		expect(frames[0]).toBe("Error: database is locked");
+		expect(frames[1]).not.toContain("/home/alice");
+		expect(frames[1]).toContain("~");
+	});
+
+	it("degrades non-Error rejections to a truncated string", () => {
+		const props = sanitizeCrashError("oops: " + "x".repeat(500), 42);
+		expect(props.type).toBe("UnhandledRejection");
+		expect(props.message.length).toBeLessThanOrEqual(400);
+		expect(props.uptimeMs).toBe(42);
 	});
 
 	it("honors SIGNET_TELEMETRY_OPTOUT as a runtime opt-out", () => {

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -155,6 +155,64 @@ function getOrCreateInstallId(db: DbAccessor): { readonly id: string; readonly c
 }
 
 // ---------------------------------------------------------------------------
+// Crash diagnostics
+// ---------------------------------------------------------------------------
+// error.occurred reports are sanitized at the boundary: the message is
+// truncated and stripped of user paths, the stack keeps only the top frames
+// with home directories removed, and no memory content is ever captured.
+// Enough to reproduce and fix a crash remotely, nothing to leak.
+
+const MAX_CRASH_MESSAGE_CHARS = 400;
+const MAX_CRASH_STACK_FRAMES = 8;
+
+const HOME_PATH_PATTERNS = [/\/home\/[^\/\s]+/g, /\/Users\/[^\/\s]+/g];
+
+function stripUserPaths(text: string): string {
+	let out = text;
+	for (const pattern of HOME_PATH_PATTERNS) {
+		out = out.replace(pattern, "~");
+	}
+	return out;
+}
+
+function sanitizeCrashText(value: string): string {
+	return stripUserPaths(value.replace(/[\x00-\x1f\x7f]/g, " ")).slice(0, MAX_CRASH_MESSAGE_CHARS);
+}
+
+function crashStackFrames(stack: string | undefined): string[] | undefined {
+	if (!stack) return undefined;
+	return stack
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0)
+		.map((line) => stripUserPaths(line))
+		.slice(0, MAX_CRASH_STACK_FRAMES);
+}
+
+/**
+ * Build the sanitized error.occurred properties for a process-level crash.
+ * Non-Error reasons (unhandledRejection with a primitive) degrade to a
+ * truncated string.
+ */
+export function sanitizeCrashError(error: unknown, uptimeMs: number): TelemetryProperties {
+	const uptime = Math.round(uptimeMs);
+	if (error instanceof Error) {
+		const stack = crashStackFrames(error.stack);
+		return {
+			type: error.name || "Error",
+			message: sanitizeCrashText(error.message || String(error)),
+			...(stack ? { stack: stack.join("\n") } : {}),
+			uptimeMs: uptime,
+		};
+	}
+	return {
+		type: "UnhandledRejection",
+		message: sanitizeCrashText(String(error)),
+		uptimeMs: uptime,
+	};
+}
+
+// ---------------------------------------------------------------------------
 // PostHog batch sender
 // ---------------------------------------------------------------------------
 

--- a/platform/daemon/src/yielding-writes.test.ts
+++ b/platform/daemon/src/yielding-writes.test.ts
@@ -7,13 +7,13 @@
  * 3. The drain pauses when system pressure is elevated, then resumes.
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import type { WriteDb, ReadDb } from "./db-accessor";
-import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
-import { drainWriteBatches } from "./yielding-writes";
-import { reportEventLoopLag, getSystemPressure } from "./system-pressure";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ReadDb, WriteDb } from "./db-accessor";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { getSystemPressure, reportEventLoopLag } from "./system-pressure";
+import { drainWriteBatches } from "./yielding-writes";
 
 const dbFiles = ["memories.db", "memories.db-shm", "memories.db-wal"];
 let agentsDir = "";
@@ -53,7 +53,9 @@ describe("drainWriteBatches", () => {
 		const result = await drainWriteBatches(
 			getDbAccessor(),
 			(db: ReadDb, limit: number) => {
-				return db.prepare("SELECT id, payload FROM work WHERE id NOT IN (SELECT id FROM items) ORDER BY id LIMIT ?").all(limit) as Array<{ id: number; payload: string }>;
+				return db
+					.prepare("SELECT id, payload FROM work WHERE id NOT IN (SELECT id FROM items) ORDER BY id LIMIT ?")
+					.all(limit) as Array<{ id: number; payload: string }>;
 			},
 			(db: WriteDb, batch: readonly { id: number; payload: string }[]) => {
 				const stmt = db.prepare("INSERT INTO items (id) VALUES (?)");
@@ -67,8 +69,9 @@ describe("drainWriteBatches", () => {
 		expect(result.stopped).toBe("exhausted");
 
 		// Verify all items were processed.
-		const remaining = getDbAccessor().withReadDb((db) =>
-			(db.prepare("SELECT COUNT(*) AS n FROM work WHERE id NOT IN (SELECT id FROM items)").get() as { n: number }).n
+		const remaining = getDbAccessor().withReadDb(
+			(db) =>
+				(db.prepare("SELECT COUNT(*) AS n FROM work WHERE id NOT IN (SELECT id FROM items)").get() as { n: number }).n,
 		);
 		expect(remaining).toBe(0);
 	});
@@ -81,12 +84,16 @@ describe("drainWriteBatches", () => {
 
 		// Track whether other macrotasks run during the drain.
 		let otherRan = false;
-		const timer = setInterval(() => { otherRan = true; }, 5);
+		const timer = setInterval(() => {
+			otherRan = true;
+		}, 5);
 
 		await drainWriteBatches(
 			getDbAccessor(),
 			(db: ReadDb, limit: number) =>
-				db.prepare("SELECT id FROM work WHERE id NOT IN (SELECT id FROM items) ORDER BY id LIMIT ?").all(limit) as Array<{ id: number }>,
+				db
+					.prepare("SELECT id FROM work WHERE id NOT IN (SELECT id FROM items) ORDER BY id LIMIT ?")
+					.all(limit) as Array<{ id: number }>,
 			(db: WriteDb, batch: readonly { id: number }[]) => {
 				for (const item of batch) db.prepare("INSERT INTO items (id) VALUES (?)").run(item.id);
 			},
@@ -114,13 +121,20 @@ describe("drainWriteBatches", () => {
 		drainWriteBatches(
 			getDbAccessor(),
 			(db: ReadDb, limit: number) =>
-				db.prepare("SELECT id FROM work WHERE id NOT IN (SELECT id FROM items) ORDER BY id LIMIT ?").all(limit) as Array<{ id: number }>,
+				db
+					.prepare("SELECT id FROM work WHERE id NOT IN (SELECT id FROM items) ORDER BY id LIMIT ?")
+					.all(limit) as Array<{ id: number }>,
 			(db: WriteDb, batch: readonly { id: number }[]) => {
 				for (const item of batch) db.prepare("INSERT INTO items (id) VALUES (?)").run(item.id);
 			},
 			{ label: "test-pressure", maxPerTx: 50 },
-		).then(() => { drainDone = true; })
-			.catch(() => { /* drain aborted by test teardown — expected */ });
+		)
+			.then(() => {
+				drainDone = true;
+			})
+			.catch(() => {
+				/* drain aborted by test teardown — expected */
+			});
 
 		// Give it a moment — it should be paused, not done.
 		await new Promise((resolve) => setTimeout(resolve, 200));
@@ -130,4 +144,56 @@ describe("drainWriteBatches", () => {
 		// pause by showing drainDone is false after 200ms while pressure is
 		// critical. The .catch() on drainPromise handles teardown.
 	}, 1000); // 1s timeout — proves it pauses, doesn't need to finish
+});
+
+describe("event-loop wedge telemetry", () => {
+	it("emits error.occurred EventLoopLag on critical lag, rate-limited per 10 min", async () => {
+		const { closeDbAccessor, getDbAccessor, initDbAccessor } = await import("./db-accessor");
+		const { mkdirSync, rmSync } = await import("node:fs");
+		const { join } = await import("node:path");
+		const { cleanupTestTempDir, createTestTempDir } = await import("./test-temp-dir");
+		const { createTelemetryCollector, setActiveTelemetry } = await import("./telemetry");
+		const dir = createTestTempDir("signet-wedge-");
+		try {
+			closeDbAccessor();
+			rmSync(join(dir, "memory"), { recursive: true, force: true });
+			mkdirSync(join(dir, "memory"), { recursive: true });
+			initDbAccessor(join(dir, "memory", "memories.db"));
+			const collector = createTelemetryCollector(
+				getDbAccessor(),
+				{
+					posthogHost: "",
+					posthogApiKey: "",
+					flushIntervalMs: 60000,
+					flushBatchSize: 50,
+					retentionDays: 90,
+					memorySearchQaEnabled: false,
+				},
+				"0.0.0-test",
+			);
+			setActiveTelemetry(collector);
+
+			// Base the injected clock a day in the future — earlier tests in
+			// this file may already have set the wedge cooldown with real
+			// timestamps, so t0 must clear that window deterministically.
+			const t0 = Date.now() + 24 * 60 * 60 * 1000;
+			reportEventLoopLag(1500, t0);
+			reportEventLoopLag(2000, t0 + 1_000); // within cooldown: suppressed
+			await collector.flush();
+			const events = collector.query().filter((e) => e.event === "error.occurred");
+			expect(events).toHaveLength(1);
+			expect(events[0]?.properties.type).toBe("EventLoopLag");
+			expect(events[0]?.properties.lagMs).toBe(1500);
+
+			// After the cooldown elapses, a new wedge is reported.
+			reportEventLoopLag(999, t0 + 601_000);
+			await collector.flush();
+			const after = collector.query().filter((e) => e.event === "error.occurred");
+			expect(after).toHaveLength(2);
+		} finally {
+			setActiveTelemetry(undefined);
+			closeDbAccessor();
+			cleanupTestTempDir(dir);
+		}
+	});
 });


### PR DESCRIPTION
## Summary

`error.occurred` carried only the error type — enough to know something broke, not enough to fix it remotely. This PR makes crash reports actionable: sanitized message + stack + context, with the privacy contract preserved (no memory content, no identity, user paths stripped).

## Changes

- `platform/daemon/src/telemetry.ts`: `sanitizeCrashError()` — builds sanitized `error.occurred` properties:
  - `type` (error name, or `UnhandledRejection` for primitives)
  - `message` — truncated to 400 chars, `/home/<user>` and `/Users/<user>` paths stripped to `~`, control chars removed
  - `stack` — top 8 frames, home-stripped, joined string
  - `uptimeMs`
- `platform/daemon/src/daemon.ts`: both crash handlers (uncaughtException, unhandledRejection) now record the sanitized report instead of type-only.
- `platform/daemon/src/system-pressure.ts`: the event-loop wedge monitor (critical lag >= 500ms — the #1059/#1094 bug class) emits a rate-limited `error.occurred` with `type: EventLoopLag` and measured `lagMs` (max once per 10 min per process; clock injectable for tests).
- Tests: sanitizer regression tests (truncation, home-path stripping, frame cap, primitive degradation) + wedge-emission test (first emit, cooldown suppression, post-cooldown re-emit).
- Docs: ANALYTICS.md + CONFIGURATION.md updated — the "error type only, never stack/message" contract is now "sanitized crash report".

## Type

- [x] `feat` — new user-facing feature (bumps minor)

## Packages affected

- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/core`
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: docs

## Screenshots

N/A.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries — telemetry is global-anonymous; no agent scoping applies
- [x] Input/config validation and bounds checks added — message truncation, frame cap, path stripping are the bounds
- [x] Error handling and fallback paths tested (no silent swallow) — sanitizer is pure; wedge emit rate-limited so a stuck loop can't flood
- [x] Security checks applied to admin/mutation endpoints — N/A; sanitization is the security control (path stripping, truncation, no content)
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no schema changes.

## Testing

- [x] `bun test` passes — telemetry + yielding-writes suites 18/18
- [x] `bun run typecheck` passes — daemon package green
- [x] `bun run lint` passes — biome clean
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Privacy boundary: messages are truncated, not content-classified — the honest guarantee is that the daemon never collects memory/query content anywhere, so process-boundary errors can't carry it by design. Path stripping removes the user-identity leak from stacks.
- The 3 `error.occurred` events already in PostHog (type only) will be the last useless ones — everything after this ships with the full report.
