### PR TITLE
fix(dreaming): process-heavy runbook with narrow must-nots (#1211)

### DIFF
--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -1064,6 +1064,37 @@ describe("Dreaming runbook structure (#1211)", () => {
 			// never the same blocker twice in a row.
 			expect(prompt).toContain("named blocker");
 			expect(prompt).toContain("not the same blocker twice in a row");
+			// Deferral is not a close: deferred records stay pending and are
+			// re-examined next pass.
+			expect(prompt).toContain("Deferred records stay pending");
 		});
 	}
+
+	it("rejects fragment claims wherever claims are filed (#1210)", () => {
+		// The content and combined runbooks reach claim filing; both must
+		// carry the complete-statement standard with the concrete
+		// anti-examples the local model filed as durable knowledge.
+		for (const prompt of [DREAMING_AGENT_PROMPT, DREAMING_CONTENT_AGENT_PROMPT]) {
+			expect(prompt).toContain("complete statement");
+			expect(prompt).toContain("SHIP-WITH-FIXES");
+			expect(prompt).toContain("Root cause confirmed.");
+		}
+	});
+
+	it("keeps the focused-mode boundaries and names the mid-stream blocker (#1098, #1140)", () => {
+		// Focused modes own disjoint work: hygiene never ingests evidence,
+		// content never processes the hygiene queue.
+		expect(DREAMING_HYGIENE_AGENT_PROMPT).not.toContain("find new evidence since the cutoff");
+		expect(DREAMING_CONTENT_AGENT_PROMPT).not.toContain("Process ALL pending hygiene records");
+		expect(DREAMING_AGENT_PROMPT).toContain("find new evidence since the cutoff");
+		expect(DREAMING_AGENT_PROMPT).toContain("Process ALL pending hygiene records");
+		// The mid-stream deferral carries a named blocker that survives
+		// re-checking — a still-active session is a re-verified blocker,
+		// not a repeated one, so #1140 does not collide with the
+		// same-blocker-twice rule.
+		for (const prompt of [DREAMING_AGENT_PROMPT, DREAMING_CONTENT_AGENT_PROMPT]) {
+			expect(prompt).toContain("transcript still mid-stream");
+			expect(prompt).toContain("re-verified blocker");
+		}
+	});
 });

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -1029,3 +1029,41 @@ describe("Dreaming", () => {
 		expect(getDreamingState(accessor, AGENT).lastPassAt).toBeNull();
 	});
 });
+
+describe("Dreaming runbook structure (#1211)", () => {
+	// The runbook is served to whatever model the inference route resolves,
+	// from local 26B to large hosted models. #1211 pins the structure that
+	// keeps both ends working: a load-bearing numbered process, completion
+	// criteria that define done, and narrow "You may not" prohibitions
+	// instead of category-level safe/unsafe lists (which small models read
+	// as blanket caution and generalize into inaction — #1208).
+	const runbooks = [
+		["combined", DREAMING_AGENT_PROMPT],
+		["hygiene", DREAMING_HYGIENE_AGENT_PROMPT],
+		["content", DREAMING_CONTENT_AGENT_PROMPT],
+	] as const;
+
+	for (const [name, prompt] of runbooks) {
+		it(`${name} runbook defines completion criteria and narrow must-nots (#1211)`, () => {
+			// Completion criteria: what "done" looks like (flags resolved or
+			// blocker-named, claims complete, pass log written).
+			expect(prompt).toContain("### Done");
+			expect(prompt).toContain("The pass is done when");
+			// Narrow must-nots: every prohibition is finite and specific
+			// ("You may not ..."), never a category-level list.
+			const mustNot = prompt.split("### Must not")[1]?.split("### Done")[0] ?? "";
+			const prohibitions = mustNot.split("\n").filter((line) => line.trim().startsWith("- "));
+			expect(prohibitions.length).toBeGreaterThan(3);
+			for (const prohibition of prohibitions) {
+				expect(prohibition.trim()).toMatch(/^- You may not /);
+			}
+			// No category-level "unsafe" list remains.
+			expect(prompt).not.toContain("### Unsafe");
+			expect(prompt).not.toContain("### Safe");
+			// Deferral is not an escape hatch: it needs a named blocker,
+			// never the same blocker twice in a row.
+			expect(prompt).toContain("named blocker");
+			expect(prompt).toContain("not the same blocker twice in a row");
+		});
+	}
+});

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -692,7 +692,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - If you discover junk the queue did not flag, mint a flag op and archive in the same batch.
    - If you inspect a flagged target and judge it should stay as it is (a deliberate keep — e.g. a live entity with a non-concrete type, or an over-cap aspect you chose not to consolidate), close the record with decline_attention citing its attention id. Declining is an affirmative judgment: only decline records you actually inspected, and never decline records you could not complete this pass — defer those with a named blocker instead.
 3. Query attention_list with kind=review_due. For expired records, inspect the cited memory with search_evidence using its subjectRef, then supersede the matching active claim with supersede_claim_value. Use the supplied entityId, aspectId, attributeId, and claimKey when present. The replacement must state that the planned event remains unconfirmed; never rewrite it as if the event happened. Cite an exact quote from the original memory. Do not supersede approaching records. When creating or setting a future temporal claim, set payload.reviewAfter to the referenced ISO timestamp.
-4. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST unprocessed sources with search_evidence — omit the query and omit since so it lists from the scope's evidence watermark (the frontier the last pass actually surfaced), newest first; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
+4. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST unprocessed sources with search_evidence — omit the query and omit since so it lists from the scope's evidence watermark (the frontier the last pass actually surfaced), newest first; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it with the named blocker "transcript still mid-stream" (re-check completed each pass: a session still active when re-checked is a re-verified blocker, not a repeated one), and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
    - search_entities for subjects it establishes.
    - File claims only for what the source establishes as settled fact: outcomes, decisions, shipped changes, stable behavior. Do not file instructions that were merely suggested, hypotheses or diagnoses, open questions, or intermediate states of an ongoing investigation. When a source shows an attempt and its outcome, file the outcome.
    - A claim must be a complete statement: it names the subject and the fact about it. A bare label ("SHIP-WITH-FIXES"), a fragment ("Root cause confirmed."), or an implementation detail without its subject is not a claim — do not file it.
@@ -704,7 +704,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 
 ### What counts as durable
 
-A write is durable when the source establishes it as settled fact: an outcome, a decision, a shipped change, or a stable behavior, attached to the entity and aspect it belongs to. Trust your judgment beyond that.
+A write is durable when the source establishes it as settled fact: an outcome, a decision, a shipped change, or a stable behavior, attached to the entity and aspect it belongs to. An entity is removable when it is non-concrete (zero active aspects/claims, non-concrete type, legacy-only deps) or an exact-canonical duplicate (same canonical name, same scope). Trust your judgment beyond that.
 
 ### Must not
 
@@ -714,6 +714,7 @@ A write is durable when the source establishes it as settled fact: an outcome, a
 - You may not file a claim without an exact quote, or a relationship the source does not state.
 - You may not touch pinned entities, source-root entities, or topology entities.
 - You may not rewrite an existing claim without evidence that supersedes it.
+- You may not rename an entity or aspect without evidence that establishes the new name.
 - You may not defer without a named blocker, and not the same blocker twice in a row.
 
 ### Done
@@ -721,6 +722,7 @@ A write is durable when the source establishes it as settled fact: an outcome, a
 The pass is done when:
 
 - Every pending hygiene record is resolved: archived, merged, or declined after inspection — or deferred with a named blocker (not the same blocker twice in a row).
+- Deferred records stay pending: deferral is not a close — the record is re-examined next pass.
 - Every claim filed is a complete statement attached to an entity and aspect — no bare labels or fragments.
 - Expired temporal claims were reviewed, and only claims with exact source evidence were superseded.
 - Every write in the batch has valid provenance.
@@ -776,6 +778,7 @@ An entity is removable when it is non-concrete (zero active aspects/claims, non-
 The pass is done when:
 
 - Every pending hygiene record is resolved: archived, merged, or declined after inspection — or deferred with a named blocker (not the same blocker twice in a row).
+- Deferred records stay pending: deferral is not a close — the record is re-examined next pass.
 - Every write in the batch carries attention provenance.
 - The pass log is written with changes applied (this is the next pass's dedup).
 - No flag is left unresolved for a target you archived; no writes attempted against pinned or source-root entities.
@@ -805,7 +808,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 
 1. Read the pass log (runbook_read). Establish cutoff: sources viewed, changes applied, deferred items.
 2. Query attention_list with kind=review_due. For expired records, inspect the cited memory with search_evidence using its subjectRef, then supersede the matching active claim with supersede_claim_value. Use the supplied entityId, aspectId, attributeId, and claimKey when present. The replacement must state that the planned event remains unconfirmed; never rewrite it as if the event happened. Cite an exact quote from the original memory. Do not supersede approaching records. When creating or setting a future temporal claim, set payload.reviewAfter to the referenced ISO timestamp.
-3. Find new evidence since the cutoff. First LIST unprocessed sources with search_evidence — omit the query and omit since so it lists from the scope's evidence watermark (the frontier the last pass actually surfaced), newest first; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
+3. Find new evidence since the cutoff. First LIST unprocessed sources with search_evidence — omit the query and omit since so it lists from the scope's evidence watermark (the frontier the last pass actually surfaced), newest first; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it with the named blocker "transcript still mid-stream" (re-check completed each pass: a session still active when re-checked is a re-verified blocker, not a repeated one), and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
    - search_entities for subjects it establishes.
    - File claims only for what the source establishes as settled fact: outcomes, decisions, shipped changes, stable behavior. Do not file instructions that were merely suggested, hypotheses or diagnoses, open questions, or intermediate states of an ongoing investigation. When a source shows an attempt and its outcome, file the outcome.
    - A claim must be a complete statement: it names the subject and the fact about it. A bare label ("SHIP-WITH-FIXES"), a fragment ("Root cause confirmed."), or an implementation detail without its subject is not a claim — do not file it.
@@ -826,6 +829,7 @@ A write is durable when the source establishes it as settled fact: an outcome, a
 - You may not make hygiene writes: archives and merges need attention records, which hygiene passes process.
 - You may not touch pinned entities, source-root entities, or topology entities.
 - You may not rewrite an existing claim without evidence that supersedes it.
+- You may not rename an entity or aspect without evidence that establishes the new name.
 - You may not defer without a named blocker, and not the same blocker twice in a row.
 
 ### Done
@@ -833,6 +837,7 @@ A write is durable when the source establishes it as settled fact: an outcome, a
 The pass is done when:
 
 - Every claim filed is a complete statement attached to an entity and aspect — no bare labels or fragments.
+- Deferred records stay pending: deferral is not a close — the source is re-examined next pass.
 - Every write in the batch cites an exact quote from episodic evidence in the same agent scope as the graph target.
 - Expired temporal claims were reviewed, and only claims with exact source evidence were superseded.
 - The pass log is written with sources viewed + changes applied (this is the next pass's dedup).

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -690,44 +690,42 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - Archive or merge it, citing its attention id (provenance: "attention:<uuid>", or attention:$<index> for a flag you minted in the same batch).
    - \`attribute_over_cap\` / \`aspect_over_cap\` flags: the write gate rejects new claims or aspects past the cap, so consolidate the flagged target — merge_aspects to fold over-cap aspects together, supersede_claim_value to collapse duplicate claim keys, archive_claim_value for stale snapshots. Consolidation (merge_aspects) may exceed the attribute cap; it is the remedy the cap forces.
    - If you discover junk the queue did not flag, mint a flag op and archive in the same batch.
-   - If you inspect a flagged target and judge it should stay as it is (a deliberate keep — e.g. a live entity with a non-concrete type, or an over-cap aspect you chose not to consolidate), close the record with decline_attention citing its attention id. Declining is an affirmative judgment: only decline records you actually inspected, and never decline records you could not complete this pass — defer those in the pass log so they stay pending.
+   - If you inspect a flagged target and judge it should stay as it is (a deliberate keep — e.g. a live entity with a non-concrete type, or an over-cap aspect you chose not to consolidate), close the record with decline_attention citing its attention id. Declining is an affirmative judgment: only decline records you actually inspected, and never decline records you could not complete this pass — defer those with a named blocker instead.
 3. Query attention_list with kind=review_due. For expired records, inspect the cited memory with search_evidence using its subjectRef, then supersede the matching active claim with supersede_claim_value. Use the supplied entityId, aspectId, attributeId, and claimKey when present. The replacement must state that the planned event remains unconfirmed; never rewrite it as if the event happened. Cite an exact quote from the original memory. Do not supersede approaching records. When creating or setting a future temporal claim, set payload.reviewAfter to the referenced ISO timestamp.
 4. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST unprocessed sources with search_evidence — omit the query and omit since so it lists from the scope's evidence watermark (the frontier the last pass actually surfaced), newest first; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
    - search_entities for subjects it establishes.
    - File claims only for what the source establishes as settled fact: outcomes, decisions, shipped changes, stable behavior. Do not file instructions that were merely suggested, hypotheses or diagnoses, open questions, or intermediate states of an ongoing investigation. When a source shows an attempt and its outcome, file the outcome.
+   - A claim must be a complete statement: it names the subject and the fact about it. A bare label ("SHIP-WITH-FIXES"), a fragment ("Root cause confirmed."), or an implementation detail without its subject is not a claim — do not file it.
    - Before adding a claim, check the target aspect's existing claims; if one covers the same key or is contradicted by the new evidence, supersede it (supersede_claim_value) instead of adding alongside.
    - The evidence source and the graph target must use the same agent scope: search evidence with the agentId of the entity you will update, then pass that same agentId to apply_ontology_ops. A source found in another scope cannot support a write here.
    - create_entity only for durable subjects clearly established by the source.
    - Validate before writing (validate_proposal).
 5. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write natural-language prose — what was examined (attention state, sources), what changed (mutations by type and count, entities touched), why (the dominant reason driving the work), and what was deferred or left flagged and why. No bullet lists, no tool names; a few clear sentences. Put deferred items and open questions in the runbook's deferred and openQuestions fields, not only in the summary.
 
-### Safe
+### What counts as durable
 
-- Archive attention-flagged entities that are non-concrete (zero active aspects/claims, non-concrete type, legacy-only deps).
-- Merge exact-canonical duplicates (same canonical name, same scope).
-- Add/set/supersede claims with exact quotes from an episodic source.
-- Set reviewAfter when adding or setting a future temporal claim; supersede expired claims as unconfirmed rather than asserting that the event occurred.
-- Create entities for durable subjects the source clearly establishes.
-- Rename/update entities only with evidence.
+A write is durable when the source establishes it as settled fact: an outcome, a decision, a shipped change, or a stable behavior, attached to the entity and aspect it belongs to. Trust your judgment beyond that.
 
-### Unsafe
+### Must not
 
-- Archive any entity with active aspects/claims.
-- Merge entities across agent scopes.
-- Any write without provenance: hygiene ops need an attention id; content ops need an exact quote.
-- Claims without exact quotes, or relationships the source does not state.
-- Touch pinned entities, source-root entities, or topology entities.
-- Rewrite existing claims without evidence that supersedes them.
+- You may not archive an entity that has active aspects or claims.
+- You may not merge entities across agent scopes.
+- You may not write without provenance: hygiene ops need an attention id; content ops need an exact quote.
+- You may not file a claim without an exact quote, or a relationship the source does not state.
+- You may not touch pinned entities, source-root entities, or topology entities.
+- You may not rewrite an existing claim without evidence that supersedes it.
+- You may not defer without a named blocker, and not the same blocker twice in a row.
 
-### Verification (before finishing)
+### Done
 
-- Every write in the batch has valid provenance.
-- Hygiene queue is drained, or remaining records are explicitly deferred with reasons in the pass log.
+The pass is done when:
+
+- Every pending hygiene record is resolved: archived, merged, or declined after inspection — or deferred with a named blocker (not the same blocker twice in a row).
+- Every claim filed is a complete statement attached to an entity and aspect — no bare labels or fragments.
 - Expired temporal claims were reviewed, and only claims with exact source evidence were superseded.
-- Pass log written with sources viewed + changes applied (this is the next pass's dedup).
-- No flag left unresolved for a target you archived.
-- Records you judged to keep are closed with decline_attention; records you could not complete this pass stay pending and are deferred in the pass log.
-- No writes attempted against pinned or source-root entities.
+- Every write in the batch has valid provenance.
+- The pass log is written with sources viewed + changes applied (this is the next pass's dedup).
+- No flag is left unresolved for a target you archived; no writes attempted against pinned or source-root entities.
 `;
 
 /**
@@ -757,30 +755,30 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - Inspect the flagged target (get_entity — check aspects, claims, pinned).
    - Archive or merge it, citing its attention id (provenance: "attention:<uuid>", or attention:$<index> for a flag you minted in the same batch).
    - If you discover junk the queue did not flag, mint a flag op and archive in the same batch.
-   - If you inspect a flagged target and judge it should stay as it is (a deliberate keep — e.g. a live entity with a non-concrete type, or an over-cap aspect you chose not to consolidate), close the record with decline_attention citing its attention id. Declining is an affirmative judgment: only decline records you actually inspected, and never decline records you could not complete this pass — defer those in the pass log so they stay pending.
+   - If you inspect a flagged target and judge it should stay as it is (a deliberate keep — e.g. a live entity with a non-concrete type, or an over-cap aspect you chose not to consolidate), close the record with decline_attention citing its attention id. Declining is an affirmative judgment: only decline records you actually inspected, and never decline records you could not complete this pass — defer those with a named blocker instead.
 3. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write natural-language prose — what was examined, what changed (mutations by type and count, entities touched), why (the dominant reason driving the work), and what was deferred or left flagged and why. No bullet lists, no tool names; a few clear sentences. Put deferred items and open questions in the runbook's deferred and openQuestions fields, not only in the summary.
 
-### Safe
+### What counts as durable
 
-- Archive attention-flagged entities that are non-concrete (zero active aspects/claims, non-concrete type, legacy-only deps).
-- Merge exact-canonical duplicates (same canonical name, same scope).
+An entity is removable when it is non-concrete (zero active aspects/claims, non-concrete type, legacy-only deps) or an exact-canonical duplicate (same canonical name, same scope). Trust your judgment beyond that.
 
-### Unsafe
+### Must not
 
-- Archive any entity with active aspects/claims.
-- Merge entities across agent scopes.
-- Any write without provenance: hygiene ops need an attention id.
-- Content writes: claims and entities need exact-quote citations from episodic evidence and belong to content passes.
-- Touch pinned entities, source-root entities, or topology entities.
+- You may not archive an entity that has active aspects or claims.
+- You may not merge entities across agent scopes.
+- You may not write without provenance: hygiene ops need an attention id.
+- You may not make content writes: claims and entities need exact-quote citations from episodic evidence and belong to content passes.
+- You may not touch pinned entities, source-root entities, or topology entities.
+- You may not defer without a named blocker, and not the same blocker twice in a row.
 
-### Verification (before finishing)
+### Done
 
+The pass is done when:
+
+- Every pending hygiene record is resolved: archived, merged, or declined after inspection — or deferred with a named blocker (not the same blocker twice in a row).
 - Every write in the batch carries attention provenance.
-- Hygiene queue is drained, or remaining records are explicitly deferred with reasons in the pass log.
-- Pass log written with changes applied (this is the next pass's dedup).
-- No flag left unresolved for a target you archived.
-- Records you judged to keep are closed with decline_attention; records you could not complete this pass stay pending and are deferred in the pass log.
-- No writes attempted against pinned or source-root entities.
+- The pass log is written with changes applied (this is the next pass's dedup).
+- No flag is left unresolved for a target you archived; no writes attempted against pinned or source-root entities.
 `;
 
 /**
@@ -810,33 +808,34 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 3. Find new evidence since the cutoff. First LIST unprocessed sources with search_evidence — omit the query and omit since so it lists from the scope's evidence watermark (the frontier the last pass actually surfaced), newest first; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed sessions and their summaries; a transcript with completed: false is mid-stream — defer filing from it and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
    - search_entities for subjects it establishes.
    - File claims only for what the source establishes as settled fact: outcomes, decisions, shipped changes, stable behavior. Do not file instructions that were merely suggested, hypotheses or diagnoses, open questions, or intermediate states of an ongoing investigation. When a source shows an attempt and its outcome, file the outcome.
+   - A claim must be a complete statement: it names the subject and the fact about it. A bare label ("SHIP-WITH-FIXES"), a fragment ("Root cause confirmed."), or an implementation detail without its subject is not a claim — do not file it.
    - Before adding a claim, check the target aspect's existing claims; if one covers the same key or is contradicted by the new evidence, supersede it (supersede_claim_value) instead of adding alongside.
    - The evidence source and the graph target must use the same agent scope: search evidence with the agentId of the entity you will update, then pass that same agentId to apply_ontology_ops. A source found in another scope cannot support a write here.
    - create_entity only for durable subjects clearly established by the source.
    - Validate before writing (validate_proposal).
 4. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write natural-language prose — what was examined (sources viewed), what changed (claims filed or superseded, entities touched), why (what the evidence established), and what was deferred and why. No bullet lists, no tool names; a few clear sentences. Put deferred items and open questions in the runbook's deferred and openQuestions fields, not only in the summary.
 
-### Safe
+### What counts as durable
 
-- Add/set/supersede claims with exact quotes from an episodic source.
-- Set reviewAfter when adding or setting a future temporal claim; supersede expired claims as unconfirmed rather than asserting that the event occurred.
-- Create entities for durable subjects the source clearly establishes.
-- Rename/update entities only with evidence.
+A write is durable when the source establishes it as settled fact: an outcome, a decision, a shipped change, or a stable behavior, attached to the entity and aspect it belongs to. Trust your judgment beyond that.
 
-### Unsafe
+### Must not
 
-- Any write without provenance: content ops need an exact quote.
-- Claims without exact quotes, or relationships the source does not state.
-- Hygiene archives/merges: they need attention records, which hygiene passes process.
-- Touch pinned entities, source-root entities, or topology entities.
-- Rewrite existing claims without evidence that supersedes them.
+- You may not write without provenance: content ops need an exact quote.
+- You may not file a claim without an exact quote, or a relationship the source does not state.
+- You may not make hygiene writes: archives and merges need attention records, which hygiene passes process.
+- You may not touch pinned entities, source-root entities, or topology entities.
+- You may not rewrite an existing claim without evidence that supersedes it.
+- You may not defer without a named blocker, and not the same blocker twice in a row.
 
-### Verification (before finishing)
+### Done
 
+The pass is done when:
+
+- Every claim filed is a complete statement attached to an entity and aspect — no bare labels or fragments.
 - Every write in the batch cites an exact quote from episodic evidence in the same agent scope as the graph target.
 - Expired temporal claims were reviewed, and only claims with exact source evidence were superseded.
-- Pass log written with sources viewed + changes applied (this is the next pass's dedup).
-- No claims without exact quotes, no relationships the source does not state.
+- The pass log is written with sources viewed + changes applied (this is the next pass's dedup).
 - No writes attempted against pinned or source-root entities.
 `;
 


### PR DESCRIPTION
## Summary

Closes #1211 (consolidates #1208 and #1210). Rewrites the three dreaming runbook constants — `DREAMING_AGENT_PROMPT`, `DREAMING_HYGIENE_AGENT_PROMPT`, `DREAMING_CONTENT_AGENT_PROMPT` — to the process-heavy, judgment-light structure so one runbook serves both ends of the model spectrum (local 26B through large hosted models).

## Changes

All three runbooks share the same new skeleton (numbered process steps unchanged):

- **Process skeleton stays** — the numbered steps are the load-bearing structure that forces exploration; untouched.
- **Caution reframed as narrow must-nots** — the category-level `### Safe` / `### Unsafe` lists become a `### Must not` section of finite `You may not ...` prohibitions with no generalization surface (small models read the old lists as blanket caution and deferred everything — #1208).
- **Escape hatch killed** — deferral requires a named blocker, and the same blocker may not be named twice in a row; a still-mid-stream transcript re-checked this pass is a re-verified blocker, not a repeated one (#1140 carve-out).
- **Completion criteria** — `### Verification` checklist becomes `### Done`: a definition of done (records resolved or blocker-named, claims complete statements, pass log written); deferred records stay pending, deferral is not a close.
- **Judgment stays open** — one line on what counts as durable, then trust.

Content runbooks additionally reject fragment claims ("SHIP-WITH-FIXES", "Root cause confirmed.") as not claims — the #1210 failure mode. Rename-with-evidence constraint restored per adversarial review.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`

## Screenshots

N/A (prompt constants + tests)

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec files touched; prompt constants and their test only
- [x] Agent scoping verified on all new/changed data queries — no data queries touched
- [x] Input/config validation and bounds checks added — no inputs touched
- [x] Error handling and fallback paths tested (no silent swallow) — no runtime code touched
- [x] Security checks applied to admin/mutation endpoints — no endpoints touched
- [x] Docs updated for API/spec/status changes — no API/spec/status changes; docs/PIPELINE.md mode contract unchanged
- [x] Regression tests added for each bug fix — Dreaming runbook structure (#1211) suite pins completion criteria, narrow must-nots, fragment-claim rejection, mode boundaries
- [x] Lint/typecheck/tests pass locally — 42 pass / 0 fail on dreaming suites; biome clean; daemon typecheck/build pass

## Testing

- [x] `bun test` passes (targeted dreaming suites: 42/42)
- [x] `bun run typecheck` passes (@signet/daemon; connector-* errors pre-existing on main)
- [x] `bun run lint` passes (changed files; repo-wide format drift pre-existing on main)
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Prompt-only change: no runtime, schema, or API surface touched. Adversarial review (subagent) verdict ship-with-fixes; all findings addressed in follow-up commit 03c12c5ce.