### PR TITLE
feat(telemetry): flush CLI command events

### DIFF
--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -234,7 +234,10 @@ Privacy contract:
   `telemetryEnabled: false`.
 - Every recorded event is mirrored to an open, inspectable JSONL log at
   `<agentsDir>/.daemon/telemetry/events.jsonl`, so users can audit
-  exactly what was sent.
+  exactly what was sent. CLI `command.invoked` events are also queued in the
+  workspace database and flushed to PostHog in bounded, best-effort batches
+  without awaiting the command; the CLI reads the same persisted install id
+  as the daemon.
 
 Events recorded: `daemon.heartbeat` (every 5 minutes), the `inference.*`
 lifecycle (`route`, `execute`, `stream`, `fallback`), `llm.generate`
@@ -246,12 +249,17 @@ paths stripped, top stack frames with home directories removed, uptime;
 plus rate-limited `EventLoopLag` reports with measured lag), and
 `version.upgraded`, `install.activated` (first daemon run of a new
 install — covers bun/desktop installs the npm postinstall ping never
+<<<<<<< HEAD
 sees), and `config.snapshot` (first-run feature flags, embedding provider
 and model, local/remote inference mode, and configured harnesses). The
 per-install harness mix is queryable from `session.start.harness` events
 because they share the same anonymous `distinct_id`. `pipeline.embedding`
 (tokens, provider, sourceKind — memory capture / artifact index / recall /
 dreaming), and `dreaming.pass`
+=======
+sees), `pipeline.embedding` (tokens, provider, sourceKind — memory
+capture / artifact index / recall / dreaming), and `dreaming.pass`
+>>>>>>> 170cb3c3e (feat(telemetry): flush CLI command events)
 (provider-reported input/output/cache tokens and cost per agentic
 pass). The remaining `pipeline.*` event types are declared
 for future use but not yet emitted.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1154,7 +1154,7 @@ rate-limited `EventLoopLag` reports with measured lag), `version.upgraded`
 | Field | Default | Range | Description |
 |-------|---------|-------|-------------|
 | `posthogHost` | `https://us.i.posthog.com` | — | PostHog instance URL (empty disables) |
-| `posthogApiKey` | `phc_mLsvJmbmp6e9UarrX9Cq5QtTjVNiiphM9mvi5Xnddd8Q` | — | PostHog project API key. Public ingest key by design; overrides the `POSTHOG_API_KEY` secret when set |
+| `posthogApiKey` | `phc_mLsvJmbmp6e9UarrX9Cq5QtTjVNiiphM9mvi5Xnddd8Q` | — | PostHog project API key. Public ingest key by design; shared by daemon and CLI |
 | `flushIntervalMs` | `60000` | 5s-10min | Time between event flushes |
 | `flushBatchSize` | `50` | 1-500 | Max events per flush batch |
 | `retentionDays` | `90` | 1-365 | Days before local telemetry data is purged |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1131,6 +1131,26 @@ by default and asks whether to disable it. Declining writes
 `telemetryEnabled: false`; non-interactive/CI setups keep the default
 (enabled).
 
+**Runtime opt-out:** setting `SIGNET_TELEMETRY_OPTOUT=1` in the daemon's
+environment disables telemetry without touching config — the same knob the
+install ping honors. CI runners, containers, and scripted environments
+should set it so automated daemon boots don't count as installs.
+
+**Open telemetry log:** every recorded event is appended as one JSON line
+to `<agentsDir>/.daemon/telemetry/events.jsonl` — the single inspectable
+audit surface for exactly what was sent (daemon events and CLI
+`command.invoked` lines). CLI command events are also queued in the workspace
+database and flushed to PostHog in bounded, best-effort batches without
+awaiting the command. The CLI and daemon use the same persisted install id.
+No memory content, code, file paths, or personal
+data are ever included.
+
+Lifecycle events: `daemon.started` (version, platform,
+uptime), `command.invoked` (command name only, never arguments),
+`error.occurred` (sanitized crash report — truncated message with user paths
+stripped, top stack frames with home directories removed, uptime, and
+rate-limited `EventLoopLag` reports with measured lag), `version.upgraded`
+(from, to).
 | Field | Default | Range | Description |
 |-------|---------|-------|-------------|
 | `posthogHost` | `https://us.i.posthog.com` | — | PostHog instance URL (empty disables) |

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -149,7 +149,7 @@ All telemetry keys live under `memory.pipelineV2` in `agent.yaml`:
 |---|---|---|---|
 | `telemetryEnabled` | `true` | boolean | Master switch; `false` opts out |
 | `telemetry.posthogHost` | `https://us.i.posthog.com` | — | PostHog instance URL; empty disables sending |
-| `telemetry.posthogApiKey` | public ingest key | — | PostHog project API key; when empty, falls back to the `POSTHOG_API_KEY` secret |
+| `telemetry.posthogApiKey` | public ingest key | — | PostHog project API key shared by daemon and CLI |
 | `telemetry.flushIntervalMs` | `60000` | 5s-10min | Time between event flushes |
 | `telemetry.flushBatchSize` | `50` | 1-500 | Max events per flush batch |
 | `telemetry.retentionDays` | `90` | 1-365 | Days before local telemetry data is purged |

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -6,6 +6,12 @@
 export { Signet } from "./signet";
 export { Database, findSqliteVecExtension, loadSqliteVec } from "./database";
 export {
+	DEFAULT_TELEMETRY_FLUSH_BATCH_SIZE,
+	DEFAULT_TELEMETRY_FLUSH_INTERVAL_MS,
+	DEFAULT_TELEMETRY_POSTHOG_API_KEY,
+	DEFAULT_TELEMETRY_POSTHOG_HOST,
+} from "./telemetry-config";
+export {
 	MEMORY_TYPES,
 	EXTRACTION_STATUSES,
 	JOB_STATUSES,

--- a/platform/core/src/migrations/112-telemetry-queue-ownership.ts
+++ b/platform/core/src/migrations/112-telemetry-queue-ownership.ts
@@ -1,0 +1,29 @@
+/**
+ * Migration 112: Telemetry Queue Ownership
+ *
+ * Separates daemon and CLI telemetry rows and gives flushers a short-lived
+ * claim so concurrent processes cannot send the same batch simultaneously.
+ */
+
+import type { MigrationDb } from "./index";
+
+function hasColumn(db: MigrationDb, table: string, column: string): boolean {
+	const rows = db.prepare(`PRAGMA table_info(${table})`).all();
+	return rows.some((row) => row.name === column);
+}
+
+function addColumnIfMissing(db: MigrationDb, column: string, definition: string): void {
+	if (!hasColumn(db, "telemetry_events", column)) {
+		db.exec(`ALTER TABLE telemetry_events ADD COLUMN ${column} ${definition}`);
+	}
+}
+
+export function up(db: MigrationDb): void {
+	addColumnIfMissing(db, "source", "TEXT NOT NULL DEFAULT 'daemon'");
+	addColumnIfMissing(db, "claim_token", "TEXT");
+	addColumnIfMissing(db, "claimed_at", "TEXT");
+	db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_telemetry_events_queue
+			ON telemetry_events(source, sent_to_posthog, claimed_at, timestamp);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -117,6 +117,7 @@ import { up as embeddingUsage } from "./108-embedding-usage";
 import { up as telemetryInstall } from "./109-telemetry-install";
 import { up as memoryMentionJoinIndex } from "./110-memory-mention-join-index";
 import { up as telemetryFirstUse } from "./111-telemetry-first-use";
+import { up as telemetryQueueOwnership } from "./112-telemetry-queue-ownership";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1034,6 +1035,18 @@ export const MIGRATIONS: readonly Migration[] = [
 			columns: [
 				{ table: "telemetry_install", column: "first_remember_at" },
 				{ table: "telemetry_install", column: "first_recall_at" },
+			],
+		},
+	},
+	{
+		version: 112,
+		name: "telemetry-queue-ownership",
+		up: telemetryQueueOwnership,
+		artifacts: {
+			columns: [
+				{ table: "telemetry_events", column: "source" },
+				{ table: "telemetry_events", column: "claim_token" },
+				{ table: "telemetry_events", column: "claimed_at" },
 			],
 		},
 	},

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -1828,4 +1828,11 @@ describe("migration framework", () => {
 		}>;
 		expect(columns.map((row) => row.name)).toEqual(["entity_id", "memory_id"]);
 	});
+	test("migration 112 separates telemetry queue ownership and claims", () => {
+		db = createFreshDb();
+		runMigrations(db);
+
+		const columns = db.query("PRAGMA table_info(telemetry_events)").all() as Array<{ name: string }>;
+		expect(columns.map((row) => row.name)).toEqual(expect.arrayContaining(["source", "claim_token", "claimed_at"]));
+	});
 });

--- a/platform/core/src/telemetry-config.ts
+++ b/platform/core/src/telemetry-config.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared anonymous telemetry defaults.
+ *
+ * The PostHog project key is a public ingest key by design. Keeping the
+ * defaults in core prevents the daemon and CLI from silently targeting
+ * different projects.
+ */
+
+export const DEFAULT_TELEMETRY_POSTHOG_HOST = "https://us.i.posthog.com";
+export const DEFAULT_TELEMETRY_POSTHOG_API_KEY = "phc_mLsvJmbmp6e9UarrX9Cq5QtTjVNiiphM9mvi5Xnddd8Q";
+export const DEFAULT_TELEMETRY_FLUSH_INTERVAL_MS = 60000;
+export const DEFAULT_TELEMETRY_FLUSH_BATCH_SIZE = 50;

--- a/platform/daemon/src/memory-config.ts
+++ b/platform/daemon/src/memory-config.ts
@@ -3,6 +3,10 @@ import { join } from "node:path";
 import {
 	DEFAULT_PIPELINE_TIMEOUT_MS,
 	DEFAULT_PROVIDER_RATE_LIMIT,
+	DEFAULT_TELEMETRY_FLUSH_BATCH_SIZE,
+	DEFAULT_TELEMETRY_FLUSH_INTERVAL_MS,
+	DEFAULT_TELEMETRY_POSTHOG_API_KEY,
+	DEFAULT_TELEMETRY_POSTHOG_HOST,
 	type DreamingConfig,
 	PIPELINE_FLAGS,
 	type PipelineFlag,
@@ -202,10 +206,10 @@ export const DEFAULT_PIPELINE_V2: ResolvedPipelineV2Config = {
 		// runs in the wild; set telemetryEnabled: false to opt out. Sends
 		// only when both host and api key are configured. The project API
 		// key is a public ingest key (PostHog design); it is not a secret.
-		posthogHost: "https://us.i.posthog.com",
-		posthogApiKey: "phc_mLsvJmbmp6e9UarrX9Cq5QtTjVNiiphM9mvi5Xnddd8Q",
-		flushIntervalMs: 60000,
-		flushBatchSize: 50,
+		posthogHost: DEFAULT_TELEMETRY_POSTHOG_HOST,
+		posthogApiKey: DEFAULT_TELEMETRY_POSTHOG_API_KEY,
+		flushIntervalMs: DEFAULT_TELEMETRY_FLUSH_INTERVAL_MS,
+		flushBatchSize: DEFAULT_TELEMETRY_FLUSH_BATCH_SIZE,
 		retentionDays: 90,
 		memorySearchQaEnabled: false,
 	},

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -191,6 +191,36 @@ describe("telemetry collector", () => {
 		expect(captured).toHaveLength(1);
 	});
 
+	it("does not claim CLI-owned command events", async () => {
+		const collector = makeCollector();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO telemetry_events
+				 (id, event, timestamp, properties, sent_to_posthog, created_at, source)
+				 VALUES (?, ?, ?, ?, 0, ?, 'cli')`,
+			).run(
+				"cli-event",
+				"command.invoked",
+				new Date().toISOString(),
+				JSON.stringify({ command: "status" }),
+				new Date().toISOString(),
+			);
+		});
+
+		await collector.flush();
+
+		const events = captured.flatMap((request) => request.body.batch.map((event) => event.event));
+		expect(events).not.toContain("command.invoked");
+		expect(
+			getDbAccessor().withReadDb((db) => {
+				const row = db.prepare("SELECT sent_to_posthog FROM telemetry_events WHERE id = ?").get("cli-event") as {
+					readonly sent_to_posthog: number;
+				};
+				return row.sent_to_posthog;
+			}),
+		).toBe(0);
+	});
+
 	it("emits install.activated exactly once per install", async () => {
 		// Regression: the npm postinstall ping never fires for bun global or
 		// desktop installs, so the install counter missed them. The daemon

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -281,11 +281,17 @@ interface PostHogBatchEvent {
 	readonly properties: Record<string, string | number | boolean | null>;
 }
 
+interface ClaimedTelemetryEvents {
+	readonly token: string;
+	readonly events: readonly TelemetryEvent[];
+}
+
 const MAX_BUFFER_SIZE = 200;
 const MAX_BUFFER_EVENTS = 5000;
 const MAX_CONSECUTIVE_FAILURES = 3;
 const BACKOFF_MULTIPLIER = 5;
 const PRUNE_EVERY_N_FLUSHES = 10;
+const TELEMETRY_CLAIM_TIMEOUT_MS = 10 * 60 * 1_000;
 
 /**
  * Interval used after `failures` consecutive PostHog failures. Pure so the
@@ -417,47 +423,72 @@ export function createTelemetryCollector(
 		}
 	}
 
-	function markSent(ids: readonly string[]): void {
-		if (ids.length === 0) return;
+	function markSent(token: string): void {
 		try {
 			db.withWriteTx((w) => {
-				const stmt = w.prepare("UPDATE telemetry_events SET sent_to_posthog = 1 WHERE id = ?");
-				for (const id of ids) {
-					stmt.run(id);
-				}
+				w.prepare(
+					"UPDATE telemetry_events SET sent_to_posthog = 1, claim_token = NULL, claimed_at = NULL WHERE claim_token = ?",
+				).run(token);
 			});
 		} catch {
 			// best effort
 		}
 	}
 
-	function loadUnsent(limit: number): readonly TelemetryEvent[] {
+	function releaseClaim(token: string): void {
 		try {
-			return db.withReadDb((r) => {
-				const rows = r
+			db.withWriteTx((w) => {
+				w.prepare("UPDATE telemetry_events SET claim_token = NULL, claimed_at = NULL WHERE claim_token = ?").run(token);
+			});
+		} catch {
+			// best effort; stale claims are recoverable on a later flush
+		}
+	}
+
+	function claimUnsent(limit: number): ClaimedTelemetryEvents | null {
+		const token = crypto.randomUUID();
+		const now = new Date();
+		const staleBefore = new Date(now.getTime() - TELEMETRY_CLAIM_TIMEOUT_MS).toISOString();
+		try {
+			return db.withWriteTx((w) => {
+				w.prepare(
+					`UPDATE telemetry_events
+					 SET claim_token = ?, claimed_at = ?
+					 WHERE id IN (
+						 SELECT id FROM telemetry_events
+						 WHERE source = 'daemon' AND sent_to_posthog = 0
+							 AND (claim_token IS NULL OR claimed_at < ?)
+						 ORDER BY timestamp ASC
+						 LIMIT ?
+					 )`,
+				).run(token, now.toISOString(), staleBefore, limit);
+				const rows = w
 					.prepare(
 						`SELECT id, event, timestamp, properties
 						 FROM telemetry_events
-						 WHERE sent_to_posthog = 0
-						 ORDER BY timestamp ASC
-						 LIMIT ?`,
+						 WHERE claim_token = ?
+						 ORDER BY timestamp ASC`,
 					)
-					.all(limit) as unknown as readonly {
+					.all(token) as unknown as readonly {
 					id: string;
 					event: string;
 					timestamp: string;
 					properties: string;
 				}[];
-
-				return rows.map((row) => ({
-					id: row.id,
-					event: row.event as TelemetryEventType,
-					timestamp: row.timestamp,
-					properties: JSON.parse(row.properties) as TelemetryProperties,
-				}));
+				return rows.length > 0
+					? {
+							token,
+							events: rows.map((row) => ({
+								id: row.id,
+								event: row.event as TelemetryEventType,
+								timestamp: row.timestamp,
+								properties: JSON.parse(row.properties) as TelemetryProperties,
+							})),
+						}
+					: null;
 			});
 		} catch {
-			return [];
+			return null;
 		}
 	}
 
@@ -481,14 +512,21 @@ export function createTelemetryCollector(
 
 		// Send to PostHog if configured
 		if (posthogConfigured) {
-			const unsent = loadUnsent(config.flushBatchSize);
-			if (unsent.length > 0) {
-				const ok = await sendToPostHog(config.posthogHost, config.posthogApiKey, installId, unsent, daemonVersion);
+			const claimed = claimUnsent(config.flushBatchSize);
+			if (claimed) {
+				const ok = await sendToPostHog(
+					config.posthogHost,
+					config.posthogApiKey,
+					installId,
+					claimed.events,
+					daemonVersion,
+				);
 				if (ok) {
-					markSent(unsent.map((e) => e.id));
+					markSent(claimed.token);
 					consecutiveFailures = 0;
 					effectiveIntervalMs = config.flushIntervalMs;
 				} else {
+					releaseClaim(claimed.token);
 					consecutiveFailures++;
 					effectiveIntervalMs = nextFlushIntervalMs(config.flushIntervalMs, consecutiveFailures);
 					if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -101,7 +101,7 @@ import { importFromGitHub } from "./features/import.js";
 import { installNativeBinary, printNativeInstallResult } from "./features/native-install.js";
 import { setupWizard } from "./features/setup.js";
 import { copyDirRecursive, syncBuiltinSkills, syncTemplates } from "./features/sync.js";
-import { recordCommandInvoked } from "./features/telemetry.js";
+import { flushCliTelemetry, recordCommandInvoked } from "./features/telemetry.js";
 import { signetBanner } from "./lib/banner.js";
 import { createDaemonClient, ensureDaemonRunning } from "./lib/daemon.js";
 import { gitAddAndCommit, gitInit, isGitRepo } from "./lib/git.js";
@@ -927,6 +927,7 @@ program.hook("preAction", async (_thisCommand, actionCommand) => {
 	// Open telemetry log (issue #1026 Phase 2): record the command name
 	// (never arguments) when the user has opted in. Best-effort.
 	recordCommandInvoked(AGENTS_DIR, topLevelCommand);
+	void flushCliTelemetry(AGENTS_DIR, VERSION);
 
 	await ensureOpenClawPluginPackage(AGENTS_DIR, { silent: true });
 });

--- a/surfaces/cli/src/features/telemetry.test.ts
+++ b/surfaces/cli/src/features/telemetry.test.ts
@@ -85,7 +85,10 @@ describe("cli telemetry (issue #1206)", () => {
 				timestamp TEXT NOT NULL,
 				properties TEXT NOT NULL,
 				sent_to_posthog INTEGER NOT NULL DEFAULT 0,
-				created_at TEXT NOT NULL
+				created_at TEXT NOT NULL,
+				source TEXT NOT NULL DEFAULT 'daemon',
+				claim_token TEXT,
+				claimed_at TEXT
 			);
 			INSERT INTO telemetry_install (id, created_at) VALUES ('install-from-daemon', '2026-01-01T00:00:00.000Z');
 		`);
@@ -113,6 +116,62 @@ describe("cli telemetry (issue #1206)", () => {
 		const check = createDatabase(join(memoryDir, "memories.db"), { readonly: true });
 		const row = check.prepare("SELECT sent_to_posthog FROM telemetry_events").get() as { sent_to_posthog: number };
 		expect(row.sent_to_posthog).toBe(1);
+		check.close();
+	});
+
+	it("claims CLI rows so overlapping flushes send each event once", async () => {
+		writeAgentYaml(true);
+		const memoryDir = join(dir, "memory");
+		mkdirSync(memoryDir, { recursive: true });
+		const db = createDatabase(join(memoryDir, "memories.db"));
+		db.exec(`
+			CREATE TABLE telemetry_install (id TEXT PRIMARY KEY, created_at TEXT NOT NULL);
+			CREATE TABLE telemetry_events (
+				id TEXT PRIMARY KEY,
+				event TEXT NOT NULL,
+				timestamp TEXT NOT NULL,
+				properties TEXT NOT NULL,
+				sent_to_posthog INTEGER NOT NULL DEFAULT 0,
+				created_at TEXT NOT NULL,
+				source TEXT NOT NULL DEFAULT 'daemon',
+				claim_token TEXT,
+				claimed_at TEXT
+			);
+			INSERT INTO telemetry_install (id, created_at) VALUES ('install-from-daemon', '2026-01-01T00:00:00.000Z');
+		`);
+		db.close();
+
+		recordCommandInvoked(dir, "status");
+		let calls = 0;
+		let enteredResolve = (): void => {};
+		const entered = new Promise<void>((resolve) => {
+			enteredResolve = resolve;
+		});
+		let releaseResolve = (): void => {};
+		const release = new Promise<void>((resolve) => {
+			releaseResolve = resolve;
+		});
+		globalThis.fetch = (async () => {
+			calls++;
+			enteredResolve();
+			await release;
+			return new Response("1", { status: 200 });
+		}) as unknown as typeof fetch;
+
+		const first = flushCliTelemetry(dir, "0.176.9");
+		await entered;
+		const second = flushCliTelemetry(dir, "0.176.9");
+		releaseResolve();
+		await Promise.all([first, second]);
+
+		expect(calls).toBe(1);
+		const check = createDatabase(join(memoryDir, "memories.db"), { readonly: true });
+		const row = check.prepare("SELECT sent_to_posthog, claim_token FROM telemetry_events").get() as {
+			sent_to_posthog: number;
+			claim_token: string | null;
+		};
+		expect(row.sent_to_posthog).toBe(1);
+		expect(row.claim_token).toBeNull();
 		check.close();
 	});
 

--- a/surfaces/cli/src/features/telemetry.test.ts
+++ b/surfaces/cli/src/features/telemetry.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { cliTelemetryEnabled, cliTelemetryLogPath, recordCommandInvoked } from "./telemetry";
+import { createDatabase } from "../sqlite";
+import { cliTelemetryEnabled, cliTelemetryLogPath, flushCliTelemetry, recordCommandInvoked } from "./telemetry";
 
 let dir = "";
+const originalFetch = globalThis.fetch;
 
 function writeAgentYaml(telemetryEnabled?: boolean): void {
 	const telemetryLine = telemetryEnabled === undefined ? "" : `telemetryEnabled: ${telemetryEnabled}`;
@@ -20,10 +22,12 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	globalThis.fetch = originalFetch;
+	process.env.SIGNET_TELEMETRY_OPTOUT = undefined;
 	rmSync(dir, { recursive: true, force: true });
 });
 
-describe("cli telemetry (issue #1026 Phase 2)", () => {
+describe("cli telemetry (issue #1206)", () => {
 	it("is enabled by default when agent.yaml has no telemetryEnabled", () => {
 		writeAgentYaml();
 		expect(cliTelemetryEnabled(dir)).toBe(true);
@@ -37,6 +41,12 @@ describe("cli telemetry (issue #1026 Phase 2)", () => {
 	it("is enabled when telemetryEnabled is true", () => {
 		writeAgentYaml(true);
 		expect(cliTelemetryEnabled(dir)).toBe(true);
+	});
+
+	it("honors the shared runtime opt-out", () => {
+		writeAgentYaml(true);
+		process.env.SIGNET_TELEMETRY_OPTOUT = "1";
+		expect(cliTelemetryEnabled(dir)).toBe(false);
 	});
 
 	it("is disabled when agent.yaml is missing", () => {
@@ -60,6 +70,50 @@ describe("cli telemetry (issue #1026 Phase 2)", () => {
 		writeAgentYaml(false);
 		recordCommandInvoked(dir, "remember");
 		expect(existsSync(cliTelemetryLogPath(dir))).toBe(false);
+	});
+
+	it("flushes queued events with the daemon's persisted install id", async () => {
+		writeAgentYaml(true);
+		const memoryDir = join(dir, "memory");
+		mkdirSync(memoryDir, { recursive: true });
+		const db = createDatabase(join(memoryDir, "memories.db"));
+		db.exec(`
+			CREATE TABLE telemetry_install (id TEXT PRIMARY KEY, created_at TEXT NOT NULL);
+			CREATE TABLE telemetry_events (
+				id TEXT PRIMARY KEY,
+				event TEXT NOT NULL,
+				timestamp TEXT NOT NULL,
+				properties TEXT NOT NULL,
+				sent_to_posthog INTEGER NOT NULL DEFAULT 0,
+				created_at TEXT NOT NULL
+			);
+			INSERT INTO telemetry_install (id, created_at) VALUES ('install-from-daemon', '2026-01-01T00:00:00.000Z');
+		`);
+		db.close();
+
+		recordCommandInvoked(dir, "remember");
+		const request: { current: { api_key: string; batch: Array<{ distinct_id: string; event: string }> } | null } = {
+			current: null,
+		};
+		globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+			request.current = JSON.parse(String(init?.body ?? "{}")) as {
+				api_key: string;
+				batch: Array<{ distinct_id: string; event: string }>;
+			};
+			return new Response("1", { status: 200 });
+		}) as typeof fetch;
+
+		await flushCliTelemetry(dir, "0.176.8");
+
+		expect(request.current?.api_key).toBe("phc_mLsvJmbmp6e9UarrX9Cq5QtTjVNiiphM9mvi5Xnddd8Q");
+		expect(request.current?.batch).toHaveLength(1);
+		expect(request.current?.batch[0]?.event).toBe("command.invoked");
+		expect(request.current?.batch[0]?.distinct_id).toBe("install-from-daemon");
+
+		const check = createDatabase(join(memoryDir, "memories.db"), { readonly: true });
+		const row = check.prepare("SELECT sent_to_posthog FROM telemetry_events").get() as { sent_to_posthog: number };
+		expect(row.sent_to_posthog).toBe(1);
+		check.close();
 	});
 
 	it("never throws when the agents dir is missing", () => {

--- a/surfaces/cli/src/features/telemetry.ts
+++ b/surfaces/cli/src/features/telemetry.ts
@@ -20,6 +20,7 @@ import { createDatabase } from "../sqlite.js";
 
 export const TELEMETRY_EVENT = "command.invoked";
 const TELEMETRY_FLUSH_TIMEOUT_MS = 2_000;
+const TELEMETRY_CLAIM_TIMEOUT_MS = 10 * 60 * 1_000;
 const MIN_BATCH_SIZE = 1;
 const MAX_BATCH_SIZE = 500;
 
@@ -35,6 +36,22 @@ interface QueuedEvent {
 	readonly event: string;
 	readonly timestamp: string;
 	readonly properties: Record<string, string | number | boolean | null>;
+}
+
+interface ClaimedEvents {
+	readonly token: string;
+	readonly rows: readonly {
+		readonly id: string;
+		readonly event: string;
+		readonly timestamp: string;
+		readonly properties: string;
+	}[];
+}
+
+function createTelemetryDatabase(dbPath: string): ReturnType<typeof createDatabase> {
+	const db = createDatabase(dbPath);
+	db.exec("PRAGMA busy_timeout = 5000");
+	return db;
 }
 
 /**
@@ -62,7 +79,7 @@ function readTelemetrySettings(agentsDir: string): CliTelemetrySettings | null {
 		const posthogHost =
 			typeof telemetry?.posthogHost === "string" ? telemetry.posthogHost : DEFAULT_TELEMETRY_POSTHOG_HOST;
 		const configuredKey = typeof telemetry?.posthogApiKey === "string" ? telemetry.posthogApiKey : "";
-		const posthogApiKey = configuredKey || process.env.POSTHOG_API_KEY || DEFAULT_TELEMETRY_POSTHOG_API_KEY;
+		const posthogApiKey = configuredKey || DEFAULT_TELEMETRY_POSTHOG_API_KEY;
 		const configuredBatchSize = telemetry?.flushBatchSize;
 		const flushBatchSize =
 			typeof configuredBatchSize === "number"
@@ -113,17 +130,66 @@ function queueCommandEvent(agentsDir: string, event: QueuedEvent): void {
 
 	let db: ReturnType<typeof createDatabase> | null = null;
 	try {
-		db = createDatabase(dbPath);
+		db = createTelemetryDatabase(dbPath);
 		if (!getOrCreateInstallId(db)) return;
 		db.prepare(
 			`INSERT OR IGNORE INTO telemetry_events
-			 (id, event, timestamp, properties, sent_to_posthog, created_at)
-			 VALUES (?, ?, ?, ?, 0, ?)`,
+			 (id, event, timestamp, properties, sent_to_posthog, created_at, source)
+			 VALUES (?, ?, ?, ?, 0, ?, 'cli')`,
 		).run(event.id, event.event, event.timestamp, JSON.stringify(event.properties), new Date().toISOString());
 	} catch {
 		// Older workspaces may not have the telemetry migrations yet.
 	} finally {
 		db?.close();
+	}
+}
+
+function claimEvents(db: ReturnType<typeof createDatabase>, limit: number): ClaimedEvents | null {
+	const token = randomUUID();
+	const now = new Date();
+	const staleBefore = new Date(now.getTime() - TELEMETRY_CLAIM_TIMEOUT_MS).toISOString();
+	const claimedAt = now.toISOString();
+	try {
+		db.prepare(
+			`UPDATE telemetry_events
+			 SET claim_token = ?, claimed_at = ?
+			 WHERE id IN (
+				 SELECT id FROM telemetry_events
+				 WHERE event = ? AND source = 'cli' AND sent_to_posthog = 0
+					 AND (claim_token IS NULL OR claimed_at < ?)
+				 ORDER BY timestamp ASC
+				 LIMIT ?
+			 )`,
+		).run(token, claimedAt, TELEMETRY_EVENT, staleBefore, limit);
+		const rows = db
+			.prepare(
+				`SELECT id, event, timestamp, properties
+				 FROM telemetry_events
+				 WHERE claim_token = ?
+				 ORDER BY timestamp ASC`,
+			)
+			.all(token) as unknown as ClaimedEvents["rows"];
+		return rows.length > 0 ? { token, rows } : null;
+	} catch {
+		return null;
+	}
+}
+
+function releaseClaim(db: ReturnType<typeof createDatabase>, token: string): void {
+	try {
+		db.prepare("UPDATE telemetry_events SET claim_token = NULL, claimed_at = NULL WHERE claim_token = ?").run(token);
+	} catch {
+		// Best effort. Stale claims are recoverable on a later flush.
+	}
+}
+
+function markClaimedSent(db: ReturnType<typeof createDatabase>, token: string): void {
+	try {
+		db.prepare(
+			"UPDATE telemetry_events SET sent_to_posthog = 1, claim_token = NULL, claimed_at = NULL WHERE claim_token = ?",
+		).run(token);
+	} catch {
+		// Best effort. Stale claims are recoverable on a later flush.
 	}
 }
 
@@ -167,27 +233,16 @@ export async function flushCliTelemetry(agentsDir: string, cliVersion: string): 
 	if (!existsSync(dbPath)) return;
 
 	let db: ReturnType<typeof createDatabase> | null = null;
+	let claimToken: string | null = null;
 	try {
-		db = createDatabase(dbPath);
+		db = createTelemetryDatabase(dbPath);
 		const installId = getOrCreateInstallId(db);
 		if (!installId) return;
-		const rows = db
-			.prepare(
-				`SELECT id, event, timestamp, properties
-				 FROM telemetry_events
-				 WHERE event = ? AND sent_to_posthog = 0
-				 ORDER BY timestamp ASC
-				 LIMIT ?`,
-			)
-			.all(TELEMETRY_EVENT, settings.flushBatchSize) as unknown as readonly {
-			id: string;
-			event: string;
-			timestamp: string;
-			properties: string;
-		}[];
-		if (rows.length === 0) return;
+		const claimed = claimEvents(db, settings.flushBatchSize);
+		if (!claimed) return;
+		claimToken = claimed.token;
 
-		const batch = rows.map((row) => ({
+		const batch = claimed.rows.map((row) => ({
 			event: row.event,
 			distinct_id: installId,
 			timestamp: row.timestamp,
@@ -203,11 +258,15 @@ export async function flushCliTelemetry(agentsDir: string, cliVersion: string): 
 			body: JSON.stringify({ api_key: settings.posthogApiKey, batch }),
 			signal: AbortSignal.timeout(TELEMETRY_FLUSH_TIMEOUT_MS),
 		});
-		if (!response.ok) return;
+		if (!response.ok) {
+			releaseClaim(db, claimToken);
+			return;
+		}
 
-		const markSent = db.prepare("UPDATE telemetry_events SET sent_to_posthog = 1 WHERE id = ?");
-		for (const row of rows) markSent.run(row.id);
+		markClaimedSent(db, claimToken);
+		claimToken = null;
 	} catch {
+		if (db && claimToken) releaseClaim(db, claimToken);
 		// Best effort. Unsent rows remain queued for the daemon or next CLI run.
 	} finally {
 		db?.close();

--- a/surfaces/cli/src/features/telemetry.ts
+++ b/surfaces/cli/src/features/telemetry.ts
@@ -1,21 +1,41 @@
 /**
- * CLI-side open telemetry log (issue #1026 Phase 2).
+ * CLI-side anonymous telemetry.
  *
- * The daemon mirrors every opted-in telemetry event to a JSONL file at
- * `<agentsDir>/.daemon/telemetry/events.jsonl`. The CLI appends
- * `command.invoked` lines to the same file when the user has opted in
- * (`telemetryEnabled: true` in agent.yaml), so the open telemetry log is
- * the single audit surface for both daemon events and command usage.
- *
- * Local-first: reading the flag and appending a line are best-effort and
- * never block or fail the command. No daemon round-trip, no auth needed.
+ * The CLI mirrors command.invoked events to the open JSONL audit log and queues
+ * them in the workspace database. A best-effort, non-awaited batch flush sends
+ * queued CLI events to the same PostHog project and install id as the daemon.
+ * Telemetry must never change the command's result or failure behavior.
  */
 
+import { randomUUID } from "node:crypto";
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { parseSimpleYaml } from "@signet/core";
+import {
+	DEFAULT_TELEMETRY_FLUSH_BATCH_SIZE,
+	DEFAULT_TELEMETRY_POSTHOG_API_KEY,
+	DEFAULT_TELEMETRY_POSTHOG_HOST,
+	parseSimpleYaml,
+} from "@signet/core";
+import { createDatabase } from "../sqlite.js";
 
 export const TELEMETRY_EVENT = "command.invoked";
+const TELEMETRY_FLUSH_TIMEOUT_MS = 2_000;
+const MIN_BATCH_SIZE = 1;
+const MAX_BATCH_SIZE = 500;
+
+interface CliTelemetrySettings {
+	readonly enabled: boolean;
+	readonly posthogHost: string;
+	readonly posthogApiKey: string;
+	readonly flushBatchSize: number;
+}
+
+interface QueuedEvent {
+	readonly id: string;
+	readonly event: string;
+	readonly timestamp: string;
+	readonly properties: Record<string, string | number | boolean | null>;
+}
 
 /**
  * Resolve the shared open-telemetry log path, mirroring the daemon's
@@ -25,41 +45,171 @@ export function cliTelemetryLogPath(agentsDir: string): string {
 	return join(agentsDir, ".daemon", "telemetry", "events.jsonl");
 }
 
-/**
- * True when anonymous telemetry is active for this workspace. Telemetry is on
- * by default, so the flag is only false when agent.yaml explicitly sets
- * `telemetryEnabled: false`.
- */
-export function cliTelemetryEnabled(agentsDir: string): boolean {
+function readTelemetrySettings(agentsDir: string): CliTelemetrySettings | null {
 	try {
 		const yamlPath = join(agentsDir, "agent.yaml");
-		if (!existsSync(yamlPath)) return false;
+		if (!existsSync(yamlPath)) return null;
+		if (process.env.SIGNET_TELEMETRY_OPTOUT === "1" || process.env.SIGNET_TELEMETRY_OPTOUT === "true") {
+			return null;
+		}
+
 		const config = parseSimpleYaml(readFileSync(yamlPath, "utf-8"));
 		const memory = config?.memory as Record<string, unknown> | undefined;
 		const pipeline = memory?.pipelineV2 as Record<string, unknown> | undefined;
-		return pipeline?.telemetryEnabled !== false;
+		if (pipeline?.telemetryEnabled === false) return null;
+
+		const telemetry = pipeline?.telemetry as Record<string, unknown> | undefined;
+		const posthogHost =
+			typeof telemetry?.posthogHost === "string" ? telemetry.posthogHost : DEFAULT_TELEMETRY_POSTHOG_HOST;
+		const configuredKey = typeof telemetry?.posthogApiKey === "string" ? telemetry.posthogApiKey : "";
+		const posthogApiKey = configuredKey || process.env.POSTHOG_API_KEY || DEFAULT_TELEMETRY_POSTHOG_API_KEY;
+		const configuredBatchSize = telemetry?.flushBatchSize;
+		const flushBatchSize =
+			typeof configuredBatchSize === "number"
+				? Math.min(MAX_BATCH_SIZE, Math.max(MIN_BATCH_SIZE, Math.floor(configuredBatchSize)))
+				: DEFAULT_TELEMETRY_FLUSH_BATCH_SIZE;
+
+		return { enabled: true, posthogHost, posthogApiKey, flushBatchSize };
 	} catch {
-		return false;
+		return null;
 	}
 }
 
 /**
- * Append a `command.invoked` line to the open telemetry log when telemetry
- * is enabled. Payload is the command name only — never arguments. Best-effort.
+ * True when anonymous telemetry is active for this workspace. Telemetry is on
+ * by default, so the flag is only false when agent.yaml is unavailable,
+ * telemetry is explicitly disabled, or the runtime opt-out is set.
+ */
+export function cliTelemetryEnabled(agentsDir: string): boolean {
+	return readTelemetrySettings(agentsDir)?.enabled === true;
+}
+
+function getOrCreateInstallId(db: ReturnType<typeof createDatabase>): string | null {
+	try {
+		const existing = db.prepare("SELECT id FROM telemetry_install ORDER BY created_at ASC LIMIT 1").get() as
+			| { readonly id?: unknown }
+			| null
+			| undefined;
+		if (typeof existing?.id === "string" && existing.id.length > 0) return existing.id;
+
+		const id = randomUUID();
+		db.prepare("INSERT OR IGNORE INTO telemetry_install (id, created_at) VALUES (?, ?)").run(
+			id,
+			new Date().toISOString(),
+		);
+		const stored = db.prepare("SELECT id FROM telemetry_install ORDER BY created_at ASC LIMIT 1").get() as
+			| { readonly id?: unknown }
+			| null
+			| undefined;
+		return typeof stored?.id === "string" && stored.id.length > 0 ? stored.id : id;
+	} catch {
+		return null;
+	}
+}
+
+function queueCommandEvent(agentsDir: string, event: QueuedEvent): void {
+	const dbPath = join(agentsDir, "memory", "memories.db");
+	if (!existsSync(dbPath)) return;
+
+	let db: ReturnType<typeof createDatabase> | null = null;
+	try {
+		db = createDatabase(dbPath);
+		if (!getOrCreateInstallId(db)) return;
+		db.prepare(
+			`INSERT OR IGNORE INTO telemetry_events
+			 (id, event, timestamp, properties, sent_to_posthog, created_at)
+			 VALUES (?, ?, ?, ?, 0, ?)`,
+		).run(event.id, event.event, event.timestamp, JSON.stringify(event.properties), new Date().toISOString());
+	} catch {
+		// Older workspaces may not have the telemetry migrations yet.
+	} finally {
+		db?.close();
+	}
+}
+
+/**
+ * Append a `command.invoked` event to the audit log and durable flush queue.
+ * Payload is the command name only. This function is synchronous for the
+ * local write and never performs a network request.
  */
 export function recordCommandInvoked(agentsDir: string, commandName: string): void {
+	const settings = readTelemetrySettings(agentsDir);
+	if (!settings) return;
+
 	try {
-		if (!cliTelemetryEnabled(agentsDir)) return;
-		const logPath = cliTelemetryLogPath(agentsDir);
-		mkdirSync(dirname(logPath), { recursive: true });
-		const line = JSON.stringify({
-			id: crypto.randomUUID(),
+		const event: QueuedEvent = {
+			id: randomUUID(),
 			event: TELEMETRY_EVENT,
 			timestamp: new Date().toISOString(),
 			properties: { command: commandName },
-		});
-		appendFileSync(logPath, `${line}\n`, "utf-8");
+		};
+		const logPath = cliTelemetryLogPath(agentsDir);
+		mkdirSync(dirname(logPath), { recursive: true });
+		appendFileSync(logPath, `${JSON.stringify(event)}\n`, "utf-8");
+		if (settings.posthogHost.length > 0 && settings.posthogApiKey.length > 0) {
+			queueCommandEvent(agentsDir, event);
+		}
 	} catch {
 		// Never break the command on telemetry write failures.
+	}
+}
+
+/**
+ * Flush queued CLI command events to PostHog. Callers should deliberately not
+ * await this function from command hooks. The batch size and request timeout
+ * bound the work, while SQLite preserves events when the request fails.
+ */
+export async function flushCliTelemetry(agentsDir: string, cliVersion: string): Promise<void> {
+	const settings = readTelemetrySettings(agentsDir);
+	if (!settings || settings.posthogHost.length === 0 || settings.posthogApiKey.length === 0) return;
+
+	const dbPath = join(agentsDir, "memory", "memories.db");
+	if (!existsSync(dbPath)) return;
+
+	let db: ReturnType<typeof createDatabase> | null = null;
+	try {
+		db = createDatabase(dbPath);
+		const installId = getOrCreateInstallId(db);
+		if (!installId) return;
+		const rows = db
+			.prepare(
+				`SELECT id, event, timestamp, properties
+				 FROM telemetry_events
+				 WHERE event = ? AND sent_to_posthog = 0
+				 ORDER BY timestamp ASC
+				 LIMIT ?`,
+			)
+			.all(TELEMETRY_EVENT, settings.flushBatchSize) as unknown as readonly {
+			id: string;
+			event: string;
+			timestamp: string;
+			properties: string;
+		}[];
+		if (rows.length === 0) return;
+
+		const batch = rows.map((row) => ({
+			event: row.event,
+			distinct_id: installId,
+			timestamp: row.timestamp,
+			properties: {
+				...(JSON.parse(row.properties) as Record<string, string | number | boolean | null>),
+				$lib: "signet-cli",
+				$lib_version: cliVersion,
+			},
+		}));
+		const response = await fetch(`${settings.posthogHost}/batch/`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ api_key: settings.posthogApiKey, batch }),
+			signal: AbortSignal.timeout(TELEMETRY_FLUSH_TIMEOUT_MS),
+		});
+		if (!response.ok) return;
+
+		const markSent = db.prepare("UPDATE telemetry_events SET sent_to_posthog = 1 WHERE id = ?");
+		for (const row of rows) markSent.run(row.id);
+	} catch {
+		// Best effort. Unsent rows remain queued for the daemon or next CLI run.
+	} finally {
+		db?.close();
 	}
 }


### PR DESCRIPTION
## Summary

Flush CLI `command.invoked` telemetry to PostHog instead of leaving CLI usage only in the local JSONL audit log. Events use the same persisted workspace install id as daemon telemetry and remain best-effort.

Closes #1206.

## Changes

- Add shared PostHog telemetry defaults in `@signet/core` so CLI and daemon target the same project.
- Queue CLI `command.invoked` events in `telemetry_events` and flush bounded batches to the PostHog batch endpoint without awaiting command execution.
- Add queue ownership and short-lived SQLite claims so concurrent CLI processes cannot send duplicate batches, and the daemon does not drain CLI-owned rows.
- Honor `telemetryEnabled: false` and `SIGNET_TELEMETRY_OPTOUT` in the CLI path.
- Read or create the persisted `telemetry_install` id from the workspace database.
- Preserve the open JSONL audit log and update telemetry documentation.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: telemetry documentation and daemon default wiring

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries — telemetry is intentionally anonymous and global, with no user-data query
- [x] Input/config validation and bounds checks added — batch size is clamped to 1-500 and requests time out after 2 seconds
- [x] Error handling and fallback paths tested (no silent swallow) — telemetry failures leave rows unsent and never affect the CLI command
- [x] Security checks applied to admin/mutation endpoints — N/A, no endpoint added
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix — this is a feature; the CLI/daemon install-id contract is covered
- [x] Lint/typecheck/tests pass locally — focused lint, full typecheck, builds, and focused suites pass; full-repo lint is blocked by pre-existing formatting diagnostics outside this change

## Migration Notes (if applicable)

A migration 112 adds `source`, `claim_token`, and `claimed_at` to `telemetry_events`. Existing rows default to daemon ownership. Stale claims are recoverable after ten minutes. Older workspaces without the migration keep the JSONL audit behavior and skip the PostHog queue until the daemon upgrades the workspace.

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

## Testing

- [x] Focused test suites pass — CLI telemetry: 10 pass; daemon telemetry: 15 pass; core migrations: 52 pass
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes — full repo has pre-existing formatting diagnostics; changed files pass focused checks
- [ ] Tested against running daemon
- [x] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The daemon default telemetry constants now come from `@signet/core`, which prevents the CLI and daemon from silently diverging on the PostHog project key or endpoint. The adversarial review found and this revision fixes concurrent duplicate sends, daemon/CLI queue ownership collisions, and CLI API-key fallback drift.
