### PR TITLE
fix(daemon): emit pipeline error telemetry

### DIFF
--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -214,36 +214,15 @@ flushes them in batches to a PostHog instance when both `posthogHost`
 and `posthogApiKey` are configured (`telemetryEnabled` defaults to
 true; set it to `false` to opt out).
 
-Privacy contract:
-
-- Events carry no memory content, user identity, agent ids, or file paths.
-- Each install gets a random anonymous id (persisted in the workspace
-  database) used as the PostHog `distinct_id`, so installs are countable
-  but not identifiable.
-- Telemetry is on by default and can be disabled with
-  `telemetryEnabled: false`.
-- Every recorded event is mirrored to an open, inspectable JSONL log at
-  `<agentsDir>/.daemon/telemetry/events.jsonl`, so users can audit
-  exactly what was sent.
-
-Events recorded: `daemon.heartbeat` (every 5 minutes), the `inference.*`
-lifecycle (`route`, `execute`, `stream`, `fallback`), `llm.generate`
-(provider, latency, token and cost counts when reported, success — never
-prompt text), `session.start` / `session.end` (harness and prompt count),
-the lifecycle events `daemon.started`, `command.invoked`,
-`error.occurred` (sanitized crash report — truncated message with user
-paths stripped, top stack frames with home directories removed, uptime;
-plus rate-limited `EventLoopLag` reports with measured lag), and
-`version.upgraded`, `install.activated` (first daemon run of a new
-install — covers bun/desktop installs the npm postinstall ping never
-sees), `first.remember` / `first.recall` (first successful remember /
-recall per install, guarded by the persisted install id — the
-activation funnel: an install that was actually used, not just
-booted), `pipeline.embedding` (tokens, provider, sourceKind — memory
-capture / artifact index / recall / dreaming), and `dreaming.pass`
-(provider-reported input/output/cache tokens and cost per agentic
-pass). The remaining `pipeline.*` event types are declared
-for future use but not yet emitted.
+The event catalog, privacy contract, the open JSONL audit log, and how to
+query the project live in **[TELEMETRY.md](./TELEMETRY.md)** — the single
+telemetry reference. Telemetry carries no memory content, user identity,
+agent ids, or file paths; each install uses a random persisted anonymous id
+and every event is mirrored to the auditable JSONL log. `pipeline.error` is
+emitted for categorized extraction, decision, and embedding failures with
+stage/code-only properties. The remaining `pipeline.extraction` and
+`pipeline.decision` event types are declared for future use but not yet
+emitted.
 
 Privacy contract:
 

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -59,6 +59,7 @@ PostHog failures, and never throws into the daemon.
 | `llm.generate` | every LLM call | `provider`, `latencyMs`, `success`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `totalCost` |
 | `pipeline.embedding` | every embedding fetch, at the usage-recording boundary | `tokens`, `provider`, `sourceKind` (`memory-capture` / `artifact-index` / `recall` / `dreaming` / `other`) |
 | `recall.performed` | every completed shared recall search | `type` (`semantic` / `keyword` / `temporal` / `graph`), `results`, `latencyMs`, `truncated` |
+| `pipeline.error` | categorized extraction, decision, or embedding failure | `stage`, `code` only; no message or stack content |
 | `dreaming.pass` | completed agentic dreaming pass (early-exit passes emit nothing) | `mode`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `cost` |
 | `inference.route` | inference control-plane routing decision | `surface`, `agentId`, `operation`, `taskClass`, `policyId`, `selectedTarget`, `candidateCount`, `blockedCount`, `allowedCount`, `privacy`, `durationMs`, `success`, `errorCode` |
 | `inference.execute` / `inference.stream` | per-execution outcome | `surface`, `agentId`, `operation`, `taskClass`, `policyId`, `selectedTarget`, `finalTarget`, `attemptPath`, `failedTargets`, `attemptCount`, `failedCount`, `fallbackCount`, `privacy`, `durationMs`, `inputTokens`, `outputTokens`, `success`, `cancelled`, `errorCode` |
@@ -67,9 +68,8 @@ PostHog failures, and never throws into the daemon.
 | `version.upgraded` | daemon auto-update path only | `from`, `to` |
 | `command.invoked` | CLI command (name only, never arguments) | `command` |
 
-Declared but **not yet emitted**: `pipeline.extraction`, `pipeline.decision`,
-`pipeline.error` (issue #1205 covers firing `pipeline.error`). Docs must not
-claim them.
+Declared but **not yet emitted**: `pipeline.extraction` and
+`pipeline.decision`.
 
 Notes on individual events:
 

--- a/docs/api/telemetry-logs.md
+++ b/docs/api/telemetry-logs.md
@@ -235,7 +235,13 @@ Aggregated telemetry statistics since daemon start or since a given timestamp.
       { "type": "semantic", "calls": 50 }
     ]
   },
-  "pipelineErrors": 3
+  "pipelineErrors": 3,
+  "pipelineErrorsByStage": { "extraction": 1, "decision": 1, "embedding": 1 },
+  "pipelineErrorsByCode": {
+    "EXTRACTION_PARSE_FAIL": 1,
+    "DECISION_TIMEOUT": 1,
+    "EMBEDDING_PROVIDER_DOWN": 1
+  }
 }
 ```
 

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -484,6 +484,8 @@ export interface TelemetryStatsEnabledResponse {
 		readonly p95: number;
 	};
 	readonly pipelineErrors: number;
+	readonly pipelineErrorsByStage: Readonly<Record<string, number>>;
+	readonly pipelineErrorsByCode: Readonly<Record<string, number>>;
 }
 
 export type TelemetryStatsResponse = TelemetryStatsDisabledResponse | TelemetryStatsEnabledResponse;

--- a/platform/daemon/src/embedding-fetch.test.ts
+++ b/platform/daemon/src/embedding-fetch.test.ts
@@ -6,9 +6,27 @@ import {
 	setNativeFallbackProvider,
 } from "./embedding-fetch";
 import { countTokens } from "./pipeline/tokenizer";
+import { type TelemetryCollector, type TelemetryEvent, setActiveTelemetry } from "./telemetry";
 
 const originalFetch = globalThis.fetch;
 const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
+
+function captureTelemetry(): { readonly collector: TelemetryCollector; readonly events: TelemetryEvent[] } {
+	const events: TelemetryEvent[] = [];
+	const collector: TelemetryCollector = {
+		enabled: true,
+		record(event, properties): void {
+			events.push({ id: "test", event, timestamp: "2026-01-01T00:00:00.000Z", properties });
+		},
+		async flush(): Promise<void> {},
+		start(): void {},
+		async stop(): Promise<void> {},
+		query(): readonly TelemetryEvent[] {
+			return events;
+		},
+	};
+	return { collector, events };
+}
 
 describe("requiresOpenAiApiKey", () => {
 	it("requires a key for official OpenAI endpoints", () => {
@@ -27,6 +45,7 @@ describe("requiresOpenAiApiKey", () => {
 describe("fetchEmbedding", () => {
 	afterEach(() => {
 		globalThis.fetch = originalFetch;
+		setActiveTelemetry(undefined);
 		setNativeEmbeddingProviderForTest(null);
 		setNativeFallbackProvider(null);
 		if (originalOpenAiApiKey === undefined) {
@@ -106,6 +125,8 @@ describe("fetchEmbedding", () => {
 	});
 
 	it("uses configured timeout for provider requests", async () => {
+		const telemetry = captureTelemetry();
+		setActiveTelemetry(telemetry.collector);
 		let capturedSignal: AbortSignal | null | undefined;
 		globalThis.fetch = mock((_url: string | URL | Request, init?: RequestInit) => {
 			capturedSignal = init?.signal;
@@ -131,6 +152,12 @@ describe("fetchEmbedding", () => {
 		expect(result).toBeNull();
 		expect(capturedSignal?.aborted).toBe(true);
 		expect(Date.now() - start).toBeLessThan(1000);
+		expect(telemetry.events).toContainEqual(
+			expect.objectContaining({
+				event: "pipeline.error",
+				properties: { stage: "embedding", code: "EMBEDDING_TIMEOUT" },
+			}),
+		);
 	});
 
 	it("routes to ollama when nativeFallbackProvider is 'ollama'", async () => {
@@ -219,6 +246,8 @@ describe("fetchEmbedding", () => {
 	});
 
 	it("returns null when llama.cpp fallback provider is set but server unreachable", async () => {
+		const telemetry = captureTelemetry();
+		setActiveTelemetry(telemetry.collector);
 		globalThis.fetch = mock(() => {
 			return Promise.resolve(new Response("not found", { status: 500 }));
 		}) as unknown as typeof fetch;
@@ -232,6 +261,12 @@ describe("fetchEmbedding", () => {
 		});
 
 		expect(result).toBeNull();
+		expect(telemetry.events).toContainEqual(
+			expect.objectContaining({
+				event: "pipeline.error",
+				properties: { stage: "embedding", code: "EMBEDDING_PROVIDER_DOWN" },
+			}),
+		);
 	});
 
 	it("falls back to llama.cpp when native fails, skipping ollama", async () => {

--- a/platform/daemon/src/embedding-fetch.ts
+++ b/platform/daemon/src/embedding-fetch.ts
@@ -10,6 +10,7 @@ import {
 	DEFAULT_OLLAMA_BASE_URL,
 	DEFAULT_OPENAI_BASE_URL,
 } from "./memory-config";
+import { isPipelineTimeout, recordPipelineError } from "./pipeline-error";
 import { countTokens, truncateToTokens } from "./pipeline/tokenizer";
 import { getSecret } from "./secrets.js";
 
@@ -371,6 +372,9 @@ export async function fetchEmbedding(
 	const formattedText = formatEmbeddingInput(text, effectiveCfg, role);
 	try {
 		const serve = await serveEmbedding(formattedText, effectiveCfg, opts);
+		if (serve.embedding === null) {
+			recordPipelineError("embedding", "EMBEDDING_PROVIDER_DOWN");
+		}
 		if (serve.embedding !== null && serve.provider !== null) {
 			recordEmbeddingUsage({
 				provider: serve.provider,
@@ -381,6 +385,7 @@ export async function fetchEmbedding(
 		}
 		return serve.embedding;
 	} catch (e) {
+		recordPipelineError("embedding", isPipelineTimeout(e) ? "EMBEDDING_TIMEOUT" : "EMBEDDING_PROVIDER_DOWN");
 		logger.warn("embedding", "Embedding fetch error", {
 			provider: effectiveCfg.provider,
 			model: effectiveCfg.model,

--- a/platform/daemon/src/pipeline-error.test.ts
+++ b/platform/daemon/src/pipeline-error.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "bun:test";
+import { isPipelineTimeout } from "./pipeline-error";
+
+describe("pipeline error classification", () => {
+	it("classifies the inference router deadline error as a timeout", () => {
+		expect(isPipelineTimeout(new Error("Agent session exceeded the 90000ms deadline"))).toBe(true);
+	});
+});

--- a/platform/daemon/src/pipeline-error.ts
+++ b/platform/daemon/src/pipeline-error.ts
@@ -1,0 +1,25 @@
+import type { ErrorCode, ErrorStage } from "./analytics";
+import { getActiveTelemetry } from "./telemetry";
+
+export type PipelineErrorStage = Extract<ErrorStage, "extraction" | "decision" | "embedding">;
+
+export type PipelineErrorCode = Extract<
+	ErrorCode,
+	| "EXTRACTION_TIMEOUT"
+	| "EXTRACTION_PARSE_FAIL"
+	| "DECISION_TIMEOUT"
+	| "DECISION_INVALID"
+	| "EMBEDDING_PROVIDER_DOWN"
+	| "EMBEDDING_TIMEOUT"
+>;
+
+/** Record a stage/code pair without exposing provider messages or stack data. */
+export function recordPipelineError(stage: PipelineErrorStage, code: PipelineErrorCode): void {
+	getActiveTelemetry()?.record("pipeline.error", { stage, code });
+}
+
+export function isPipelineTimeout(error: unknown): boolean {
+	if (error instanceof DOMException && error.name === "AbortError") return true;
+	const message = error instanceof Error ? error.message : String(error);
+	return /\b(?:abort(?:ed)?|deadline|timeout|timed out)\b/i.test(message);
+}

--- a/platform/daemon/src/pipeline/document-worker.ts
+++ b/platform/daemon/src/pipeline/document-worker.ts
@@ -17,6 +17,7 @@ import { isActiveEmbeddingConfig } from "../embedding-index-state";
 import type { EmbeddingRole } from "../embedding-profile";
 import { logger } from "../logger";
 import type { EmbeddingConfig, PipelineV2Config } from "../memory-config";
+import { isPipelineTimeout, recordPipelineError } from "../pipeline-error";
 import { isSystemPressureHigh } from "../system-pressure";
 import { txIngestEnvelope } from "../transactions";
 import { fetchUrlContent } from "./url-fetcher";
@@ -241,14 +242,19 @@ async function processDocument(deps: DocumentWorkerDeps, job: DocumentJobRow): P
 	let content: string;
 	let title = doc.title;
 
-	if (doc.source_type === "url" && doc.source_url) {
-		const result = await fetchUrlContent(doc.source_url, {
-			maxBytes: pipelineCfg.documents.maxContentBytes,
-		});
-		content = result.content;
-		if (result.title && !title) title = result.title;
-	} else {
-		content = doc.raw_content ?? "";
+	try {
+		if (doc.source_type === "url" && doc.source_url) {
+			const result = await fetchUrlContent(doc.source_url, {
+				maxBytes: pipelineCfg.documents.maxContentBytes,
+			});
+			content = result.content;
+			if (result.title && !title) title = result.title;
+		} else {
+			content = doc.raw_content ?? "";
+		}
+	} catch (err) {
+		recordPipelineError("extraction", isPipelineTimeout(err) ? "EXTRACTION_TIMEOUT" : "EXTRACTION_PARSE_FAIL");
+		throw err;
 	}
 
 	let deletedAfterExtraction = false;
@@ -261,6 +267,7 @@ async function processDocument(deps: DocumentWorkerDeps, job: DocumentJobRow): P
 	if (deletedAfterExtraction) return;
 
 	if (content.length === 0) {
+		recordPipelineError("extraction", "EXTRACTION_PARSE_FAIL");
 		accessor.withWriteTx((db) => {
 			if (isDocumentDeleted(db, docId)) {
 				completeJob(db, job.id);

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import type { DreamingConfig } from "@signet/core";
 import { runMigrations } from "../../../core/src/migrations";
 import type { DbAccessor } from "../db-accessor";
+import { type TelemetryCollector, type TelemetryEvent, setActiveTelemetry } from "../telemetry";
 import {
 	DREAMING_AGENT_PROMPT,
 	DREAMING_CONTENT_AGENT_PROMPT,
@@ -66,6 +67,23 @@ function wrapDb(db: Database): DbAccessor {
 	} as unknown as DbAccessor;
 }
 
+function captureTelemetry(): { readonly collector: TelemetryCollector; readonly events: TelemetryEvent[] } {
+	const events: TelemetryEvent[] = [];
+	const collector: TelemetryCollector = {
+		enabled: true,
+		record(event, properties): void {
+			events.push({ id: "test", event, timestamp: "2026-01-01T00:00:00.000Z", properties });
+		},
+		async flush(): Promise<void> {},
+		start(): void {},
+		async stop(): Promise<void> {},
+		query(): readonly TelemetryEvent[] {
+			return events;
+		},
+	};
+	return { collector, events };
+}
+
 function seedSummary(db: Database, id: string, content: string, tokens: number): void {
 	db.prepare(
 		`INSERT INTO session_summaries
@@ -84,7 +102,10 @@ describe("Dreaming", () => {
 		accessor = wrapDb(db);
 	});
 
-	afterEach(() => db.close());
+	afterEach(() => {
+		setActiveTelemetry(undefined);
+		db.close();
+	});
 
 	it("round-trips only canonical episodic cursor kinds", () => {
 		for (const kind of ["memory", "artifact", "transcript", "summary"] as const) {
@@ -480,6 +501,8 @@ describe("Dreaming", () => {
 	});
 
 	it("keeps semantic attention pending when its pass fails", async () => {
+		const telemetry = captureTelemetry();
+		setActiveTelemetry(telemetry.collector);
 		accessor.withWriteTx((tx) => {
 			enqueueDreamingAttentionInTx(tx, {
 				agentId: AGENT,
@@ -504,6 +527,12 @@ describe("Dreaming", () => {
 				"incremental",
 			),
 		).rejects.toThrow("provider unavailable");
+		expect(telemetry.events).toContainEqual(
+			expect.objectContaining({
+				event: "pipeline.error",
+				properties: { stage: "decision", code: "DECISION_INVALID" },
+			}),
+		);
 		expect(getDreamingAttention(accessor, AGENT)).toContainEqual(
 			expect.objectContaining({ kind: "contested_claim", subjectRef: "claim:aster:owner" }),
 		);

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -30,6 +30,7 @@ import {
 import { type GraphHygieneCaps, getDreamingHygieneCandidatesInDb } from "../knowledge-graph-hygiene";
 import { logger } from "../logger";
 import type { GraphWriteCaps } from "../ontology-proposals";
+import { isPipelineTimeout, recordPipelineError } from "../pipeline-error";
 import { getActiveTelemetry } from "../telemetry";
 import { createDreamingAgentTools } from "./dreaming-agent-tools";
 import {
@@ -1122,6 +1123,7 @@ export async function runDreamingAgentPass(
 		return { passId, applied, skipped: 0, failed, summary };
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
+		recordPipelineError("decision", isPipelineTimeout(error) ? "DECISION_TIMEOUT" : "DECISION_INVALID");
 		logger.error("dreaming", "Agentic dreaming pass failed", undefined, { error: message });
 		failDreamingPass(accessor, passId, message);
 		throw error;

--- a/platform/daemon/src/routes/document-routes.test.ts
+++ b/platform/daemon/src/routes/document-routes.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Hono } from "hono";
 import type { DbAccessor } from "../db-accessor";
+import { type TelemetryCollector, type TelemetryEvent, setActiveTelemetry } from "../telemetry";
 
 const previousSignetPath = process.env.SIGNET_PATH;
 let agentsDir: string;
@@ -17,6 +18,23 @@ let createToken: typeof import("../auth").createToken;
 let loadMemoryConfig: typeof import("../memory-config").loadMemoryConfig;
 let startDocumentWorker: typeof import("../pipeline/document-worker").startDocumentWorker;
 let state: typeof import("./state.js");
+
+function captureTelemetry(): { readonly collector: TelemetryCollector; readonly events: TelemetryEvent[] } {
+	const events: TelemetryEvent[] = [];
+	const collector: TelemetryCollector = {
+		enabled: true,
+		record(event, properties): void {
+			events.push({ id: "test", event, timestamp: "2026-01-01T00:00:00.000Z", properties });
+		},
+		async flush(): Promise<void> {},
+		start(): void {},
+		async stop(): Promise<void> {},
+		query(): readonly TelemetryEvent[] {
+			return events;
+		},
+	};
+	return { collector, events };
+}
 
 function writeAuthConfig(mode: "local" | "team"): void {
 	writeFileSync(
@@ -148,6 +166,7 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+	setActiveTelemetry(undefined);
 	getDbAccessor().withWriteTx((db) => {
 		db.prepare("DELETE FROM document_memories").run();
 		db.prepare("DELETE FROM documents").run();
@@ -166,6 +185,104 @@ afterAll(() => {
 });
 
 describe("document routes", () => {
+	it("emits extraction parse-failure telemetry for empty document content", async () => {
+		const telemetry = captureTelemetry();
+		setActiveTelemetry(telemetry.collector);
+		const now = new Date().toISOString();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO agents (id, name, read_policy, policy_group, created_at, updated_at)
+				 VALUES ('agent-empty', 'agent-empty', 'isolated', NULL, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO documents
+				 (id, source_type, content_type, content_hash, title, raw_content, status,
+				  chunk_count, memory_count, agent_id, project, created_at, updated_at)
+				 VALUES ('doc-empty', 'text', 'text/plain', 'doc-empty-hash', NULL, NULL, 'queued', 0, 0,
+				         'agent-empty', NULL, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO memory_jobs
+				 (id, memory_id, document_id, job_type, status, attempts, max_attempts, created_at, updated_at)
+				 VALUES ('job-empty', NULL, 'doc-empty', 'document_ingest', 'pending', 0, 3, ?, ?)`,
+			).run(now, now);
+		});
+
+		const cfg = loadMemoryConfig(agentsDir);
+		const worker = startDocumentWorker({
+			accessor: getDbAccessor(),
+			embeddingCfg: cfg.embedding,
+			fetchEmbedding: async () => null,
+			pipelineCfg: {
+				...cfg.pipelineV2,
+				documents: {
+					...cfg.pipelineV2.documents,
+					workerIntervalMs: 5,
+				},
+			},
+		});
+		try {
+			await waitFor(() =>
+				getDbAccessor().withReadDb((db) => {
+					const row = db.prepare("SELECT status FROM documents WHERE id = 'doc-empty'").get() as { status: string };
+					return row.status === "failed";
+				}),
+			);
+		} finally {
+			await worker.stop();
+			setActiveTelemetry(undefined);
+		}
+
+		expect(telemetry.events).toContainEqual(
+			expect.objectContaining({
+				event: "pipeline.error",
+				properties: { stage: "extraction", code: "EXTRACTION_PARSE_FAIL" },
+			}),
+		);
+	});
+
+	it("does not label job validation failures as extraction errors", async () => {
+		const telemetry = captureTelemetry();
+		setActiveTelemetry(telemetry.collector);
+		const now = new Date().toISOString();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memory_jobs
+				 (id, memory_id, document_id, job_type, status, attempts, max_attempts, created_at, updated_at)
+				 VALUES ('job-invalid', NULL, NULL, 'document_ingest', 'pending', 0, 3, ?, ?)`,
+			).run(now, now);
+		});
+
+		const cfg = loadMemoryConfig(agentsDir);
+		const worker = startDocumentWorker({
+			accessor: getDbAccessor(),
+			embeddingCfg: cfg.embedding,
+			fetchEmbedding: async () => null,
+			pipelineCfg: {
+				...cfg.pipelineV2,
+				documents: {
+					...cfg.pipelineV2.documents,
+					workerIntervalMs: 5,
+				},
+			},
+		});
+		try {
+			await waitFor(() =>
+				getDbAccessor().withReadDb((db) => {
+					const row = db.prepare("SELECT attempts FROM memory_jobs WHERE id = 'job-invalid'").get() as {
+						attempts: number;
+					};
+					return row.attempts >= 1;
+				}),
+			);
+		} finally {
+			await worker.stop();
+			setActiveTelemetry(undefined);
+		}
+
+		expect(telemetry.events.filter((event) => event.event === "pipeline.error")).toHaveLength(0);
+	});
+
 	it("lists document chunks in local mode", async () => {
 		seedDocument(getDbAccessor(), { documentId: "doc-local", memoryId: "mem-local", agentId: "default" });
 		const app = await makeApp("local");

--- a/platform/daemon/src/routes/telemetry-routes.ts
+++ b/platform/daemon/src/routes/telemetry-routes.ts
@@ -202,6 +202,8 @@ export function registerTelemetryRoutes(app: Hono): void {
 		let llmCalls = 0;
 		let llmErrors = 0;
 		let pipelineErrors = 0;
+		const pipelineErrorsByStage = new Map<string, number>();
+		const pipelineErrorsByCode = new Map<string, number>();
 		let embeddingCalls = 0;
 		let embeddingTokens = 0;
 		const embeddingBySource = new Map<string, number>();
@@ -243,7 +245,15 @@ export function registerTelemetryRoutes(app: Hono): void {
 				if (typeof e.properties.tokensCacheWrite === "number") dreamingCacheWrite += e.properties.tokensCacheWrite;
 				if (typeof e.properties.cost === "number") dreamingCost += e.properties.cost;
 			}
-			if (e.event === "pipeline.error") pipelineErrors++;
+			if (e.event === "pipeline.error") {
+				pipelineErrors++;
+				if (typeof e.properties.stage === "string") {
+					pipelineErrorsByStage.set(e.properties.stage, (pipelineErrorsByStage.get(e.properties.stage) ?? 0) + 1);
+				}
+				if (typeof e.properties.code === "string") {
+					pipelineErrorsByCode.set(e.properties.code, (pipelineErrorsByCode.get(e.properties.code) ?? 0) + 1);
+				}
+			}
 			if (e.event === "recall.performed") {
 				recallCalls++;
 				if (typeof e.properties.latencyMs === "number") recallLatencies.push(e.properties.latencyMs);
@@ -288,6 +298,8 @@ export function registerTelemetryRoutes(app: Hono): void {
 					.sort((a, b) => a.type.localeCompare(b.type)),
 			},
 			pipelineErrors,
+			pipelineErrorsByStage: Object.fromEntries(pipelineErrorsByStage),
+			pipelineErrorsByCode: Object.fromEntries(pipelineErrorsByCode),
 		});
 	});
 


### PR DESCRIPTION
## Summary

Emit the previously declared `pipeline.error` telemetry event so pipeline health is visible by stage and error code. Closes #1205.

## Changes

- Add a centralized pipeline-error helper backed by the existing analytics taxonomy.
- Emit stage/code-only errors for extraction, dreaming decisions, and embedding provider failures/timeouts.
- Add regression coverage for embedding timeout/provider failures, extraction boundaries, and dreaming decision failures.
- Preserve the existing `/api/telemetry/stats` total while exposing stage/code breakdowns.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [x] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`): no spec or dependency changes.
- [x] Agent scoping verified on all new/changed data queries: no data queries added.
- [x] Input/config validation and bounds checks added: no new input boundary.
- [x] Error handling and fallback paths tested (no silent swallow).
- [x] Security checks applied to admin/mutation endpoints: N/A, no endpoint changes.
- [x] Docs updated for API/spec/status changes: telemetry event and stats breakdown docs updated.
- [x] Regression tests added for each bug fix.
- [x] Lint/typecheck/tests pass locally: daemon checks pass; unrelated workspace baseline failures remain documented below.

## Migration Notes (if applicable)

N/A. No migrations touched.

## Testing

- [x] Focused daemon tests: 82 passed, 0 failed across telemetry, embedding, embedding usage, pipeline-error, document worker, and dreaming suites.
- [x] Daemon build passed.
- [x] Daemon typecheck passed.
- [x] Touched-file Biome check and `git diff --check` passed.
- [ ] `bun test` passes: root test suite not run because it sweeps unrelated third-party tests.
- [ ] `bun run typecheck` passes: unrelated connector packages fail in this fresh worktree because generated bundles/exports are absent; `@signet/daemon` passes.
- [ ] `bun run lint` passes: root Biome reports existing formatting diagnostics across unrelated files; touched files pass.
- [ ] Tested against running daemon: not run; this change is covered at the telemetry emission boundaries.
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The telemetry event contains only `stage` and `code`, never provider messages, stack traces, or error text. `/api/telemetry/stats` retains the total and adds stage/code breakdowns for local health inspection.
