### PR TITLE
fix(telemetry): session.end at real boundaries only (#1212)

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -52,8 +52,9 @@ PostHog failures, and never throws into the daemon.
 | `install.activated` | first daemon run of a new install (persisted install id first created) | `version`, `platform` |
 | `daemon.started` | daemon boot | `version`, `platform`, `uptimeMs` |
 | `daemon.heartbeat` | every 5 minutes | `uptimeMs`, `memoryCount`, `connectorsActive`, `pipelineMode`, `extractionProvider`, `embeddingProvider` |
-| `session.start` | real session start (deduped; stubs and clear/reset paths don't count) | `harness` |
-| `session.end` | Stop/session-end hook | `harness`, `promptCount` |
+| `session.start` | real session start (deduped; stubs and clear/reset paths don't count) | `harness`, `sessionHash` |
+| `session.turn` | every `session-end` hook call (per turn, see notes) | `harness`, `promptCount`, `sessionHash` |
+| `session.end` | real session termination: explicit `reason: "clear"`, or a TTL-evicted (abandoned) session claim | `harness`, `reason` (`clear` / `expired`), `sessionHash` |
 | `llm.generate` | every LLM call | `provider`, `latencyMs`, `success`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `totalCost` |
 | `pipeline.embedding` | every embedding fetch, at the usage-recording boundary | `tokens`, `provider`, `sourceKind` (`memory-capture` / `artifact-index` / `recall` / `dreaming` / `other`) |
 | `dreaming.pass` | completed agentic dreaming pass (early-exit passes emit nothing) | `mode`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `cost` |
@@ -79,12 +80,18 @@ Notes on individual events:
   id is first created. It covers bun, desktop, and npm uniformly and is the
   **active installs** metric. Count distinct ids with `install.activated`;
   never sum ping and activated counts.
-- **`session.end`** — known naming quirk: it fires on the `session_end` hook
-  harnesses call per turn to save messages, so it measures *turns persisted*,
-  not session terminations. `session.start` is deduped per real session; the
-  end path is not, so the counters are not comparable (observed ~9:1 in the
-  wild). Rename to `session.turn` / `turn.persisted` plus a real termination
-  event is tracked in issue #1212.
+- **Session events (#1212)** — the three events measure different things and
+  are deliberately not comparable with each other: `session.start` fires once
+  per real session start (deduped per session key; resumed sessions do not
+  re-fire); `session.turn` fires on every `session-end` hook call, which
+  harnesses invoke per turn to persist messages — a *turns persisted* volume
+  counter; `session.end` fires only at real terminations (explicit
+  `reason: "clear"`, or TTL-evicted abandoned claims), deduped once per
+  session lifetime via `session-end-state.ts` (in-memory, cleared on real and
+  clear session starts). All three carry `sessionHash`, a 16-hex sha256 of the
+  normalized session key, so distinct sessions and concurrency are countable
+  without leaking raw keys. Cleanly-finished sessions that never send
+  `clear` are not counted as ended — only provable terminations are.
 - **`dreaming.pass`** — dreaming is the largest token consumer (millions of
   input tokens per heavy install), so always include it in token/cost
   aggregates.
@@ -162,7 +169,6 @@ it is never flushed to PostHog.
 
 ## Known semantics quirks
 
-- `session.end` counts turns, not sessions (#1212, rename pending).
 - `pipeline.embedding` is tokens-only; embedding cost accounting is pending
   (#1201).
 - `install.ping` and `install.activated` measure different populations —
@@ -214,6 +220,7 @@ vault mirrors the key PostHog aggregates for daily review via
 | 0.173.0 | `install.activated` on first daemon run |
 | 0.174.0 | `dreaming.pass` with provider-reported token usage and cost |
 | 0.176.0 | Sanitized crash reports: full `error.occurred` payload (truncated, home-stripped message + top-8 stack frames) and rate-limited `EventLoopLag` wedge reports |
+| next | `session.turn` + real `session.end` split (#1212): the per-turn event renamed from the old `session.end`; `session.end` now fires only at real terminations, deduped per lifetime; `sessionHash` added to all three session events |
 
 Related: #1026 (original rollout), #1200 (IP capture, dev tagging),
-#1201-#1207 (event-scoped follow-ups), #1212 (session.end rename).
+#1201-#1207 (event-scoped follow-ups), #1212 (session.end rename — resolved).

--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -25,6 +25,8 @@ const { deriveSessionEndFallbackId } = await import("./session-end-recovery");
 const { upsertSessionTranscript } = await import("./session-transcripts");
 const { buildSignetSystemPrompt } = await import("./session-start-format");
 const { resetTokenizerStats, tokenizerStats } = await import("./pipeline/tokenizer");
+const { resetSessionEndTelemetry } = await import("./session-end-state");
+const { createTelemetryCollector, setActiveTelemetry } = await import("./telemetry");
 const {
 	handleSessionStart,
 	handlePreCompaction,
@@ -73,6 +75,34 @@ function ensureDir(path: string): void {
 async function flushSessionEndDeferredWork(): Promise<void> {
 	await new Promise<void>((resolve) => setImmediate(resolve));
 	await hooks.flushDeferredSessionEndWorkForTests();
+}
+
+// Collector config for telemetry regression tests (#1212): empty posthogHost
+// means nothing is ever sent, and the buffer is queried directly.
+const TEST_TELEMETRY_CONFIG = {
+	posthogHost: "",
+	posthogApiKey: "",
+	flushIntervalMs: 60000,
+	flushBatchSize: 50,
+	retentionDays: 90,
+	memorySearchQaEnabled: false,
+} as const;
+
+/** Ensure the telemetry tables exist on the test DB (migrations 014/109). */
+function ensureTelemetryTables(): void {
+	getDbAccessor().withWriteTx((db) => {
+		db.prepare("CREATE TABLE IF NOT EXISTS telemetry_install (id TEXT PRIMARY KEY, created_at TEXT NOT NULL)").run();
+		db.prepare(
+			`CREATE TABLE IF NOT EXISTS telemetry_events (
+				id TEXT PRIMARY KEY,
+				event TEXT NOT NULL,
+				timestamp TEXT NOT NULL,
+				properties TEXT NOT NULL,
+				sent_to_posthog INTEGER NOT NULL DEFAULT 0,
+				created_at TEXT NOT NULL
+			)`,
+		).run();
+	});
 }
 
 /** Create an isolated test DB with the full schema */
@@ -2269,6 +2299,68 @@ memory:
 		});
 
 		expect(result.queued).toBe(false);
+	});
+
+	// ------------------------------------------------------------------
+	// #1212 — session.end telemetry fired per session-end hook call,
+	// inflating the counter ~9x vs dedup'd session.start. The per-turn
+	// event is now session.turn; session.end fires only at real session
+	// boundaries (explicit clear or TTL eviction), once per lifetime.
+	// ------------------------------------------------------------------
+
+	test.serial("session-end hook calls emit session.turn, never session.end (#1212)", async () => {
+		createMemoryDb([]);
+		ensureTelemetryTables();
+		const collector = createTelemetryCollector(getDbAccessor(), TEST_TELEMETRY_CONFIG, "0.0.0-test");
+		setActiveTelemetry(collector);
+		try {
+			await handleSessionEnd({ harness: "test", sessionKey: "sess-turn-a" });
+			await handleSessionEnd({ harness: "test", sessionKey: "sess-turn-a" });
+			await handleSessionEnd({ harness: "test", sessionKey: "sess-turn-b" });
+			await collector.flush();
+
+			const turns = collector.query().filter((e) => e.event === "session.turn");
+			const ends = collector.query().filter((e) => e.event === "session.end");
+			expect(turns).toHaveLength(3);
+			expect(ends).toHaveLength(0);
+			expect(turns[0]?.properties.harness).toBe("test");
+			expect(typeof turns[0]?.properties.sessionHash).toBe("string");
+		} finally {
+			setActiveTelemetry(undefined);
+			resetSessionEndTelemetry();
+		}
+	});
+
+	test.serial("explicit clear emits session.end once per session lifetime (#1212)", async () => {
+		createMemoryDb([]);
+		ensureTelemetryTables();
+		const collector = createTelemetryCollector(getDbAccessor(), TEST_TELEMETRY_CONFIG, "0.0.0-test");
+		setActiveTelemetry(collector);
+		try {
+			await handleSessionEnd({ harness: "test", sessionKey: "sess-clear-a", reason: "clear" });
+			// Repeated clear for the same lifetime must not inflate the counter.
+			await handleSessionEnd({ harness: "test", sessionKey: "sess-clear-a", reason: "clear" });
+			await collector.flush();
+
+			const ends = collector.query().filter((e) => e.event === "session.end");
+			expect(ends).toHaveLength(1);
+			expect(ends[0]?.properties.reason).toBe("clear");
+			expect(ends[0]?.properties.harness).toBe("test");
+
+			// A real session start opens a new lifetime — the next clear counts again.
+			await handleSessionStart({ harness: "test", sessionKey: "sess-clear-a" });
+			await collector.flush();
+			const starts = collector.query().filter((e) => e.event === "session.start");
+			expect(starts).toHaveLength(1);
+			expect(typeof starts[0]?.properties.sessionHash).toBe("string");
+
+			await handleSessionEnd({ harness: "test", sessionKey: "sess-clear-a", reason: "clear" });
+			await collector.flush();
+			expect(collector.query().filter((e) => e.event === "session.end")).toHaveLength(2);
+		} finally {
+			setActiveTelemetry(undefined);
+			resetSessionEndTelemetry();
+		}
 	});
 });
 

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -98,6 +98,13 @@ import {
 } from "./session-checkpoints";
 import { deriveSessionEndFallbackId, recoverMissingSessionEndOnClearStart } from "./session-end-recovery";
 import {
+	clearSessionEndTelemetry,
+	hasSessionEndTelemetry,
+	hashSessionKey,
+	markSessionEndTelemetry,
+	pruneSessionEndTelemetry,
+} from "./session-end-state";
+import {
 	type SessionMemoryCandidate,
 	parseFeedback,
 	recordAgentFeedback,
@@ -609,6 +616,13 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 		const sessionKey = req.sessionKey?.trim();
 		const recoveredJobId = recoverMissingSessionEndOnClearStart(req, agentId, memoryCfg, new Date().toISOString());
 		clearSessionStartDedupe(req);
+		// A reset also opens a new session lifetime — any prior session.end
+		// marker must not suppress a termination event for the new one (#1212).
+		clearSessionEndTelemetry({
+			agentId,
+			harness: req.harness,
+			sessionKey: req.sessionKey ?? undefined,
+		});
 		if (sessionKey) {
 			clearRawSessionStartDedupeKey(sessionKey);
 			clearContinuity(sessionKey);
@@ -654,9 +668,18 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	}
 
 	// Anonymous usage telemetry: a real session start (dedup stubs and
-	// clear/reset paths above don't count as new sessions).
+	// clear/reset paths above don't count as new sessions). A real start
+	// also opens a new session lifetime, so any prior session.end marker
+	// for this key must not suppress a later termination event (#1212).
+	pruneSessionEndTelemetry();
+	clearSessionEndTelemetry({
+		agentId,
+		harness: req.harness,
+		sessionKey: req.sessionKey,
+	});
 	getActiveTelemetry()?.record("session.start", {
 		harness: req.harness,
+		sessionHash: hashSessionKey(req.sessionKey),
 	});
 
 	// Initialize continuity state for checkpoint accumulation (first call only)
@@ -1748,6 +1771,17 @@ export async function handleSessionEnd(req: SessionEndRequest): Promise<SessionE
 			sourceRef: sessionKey ?? null,
 		});
 		clearContinuity(sessionKey);
+		// Real session termination: the caller explicitly discards the
+		// session. Emit session.end once per session lifetime (#1212) so the
+		// counter stays comparable with the dedup'd session.start.
+		if (!hasSessionEndTelemetry({ agentId, harness: req.harness, sessionKey })) {
+			getActiveTelemetry()?.record("session.end", {
+				harness: req.harness,
+				reason: "clear",
+				sessionHash: hashSessionKey(sessionKey),
+			});
+			markSessionEndTelemetry({ agentId, harness: req.harness, sessionKey });
+		}
 		return { memoriesSaved: 0 };
 	}
 
@@ -1756,11 +1790,15 @@ export async function handleSessionEnd(req: SessionEndRequest): Promise<SessionE
 	// the interval since the last periodic/pre-compaction consume.
 	const snap = consumeState(sessionKey);
 
-	// Anonymous usage telemetry for real session ends (the clear path above
-	// returns early and doesn't count as a session).
-	getActiveTelemetry()?.record("session.end", {
+	// Anonymous usage telemetry for session-end hook calls. Harnesses call
+	// this hook per turn (Stop/session.idle) to persist messages, so this
+	// is a "turns persisted" volume counter — not a session boundary.
+	// Real session termination is emitted separately as session.end on
+	// explicit clear or TTL eviction (#1212).
+	getActiveTelemetry()?.record("session.turn", {
 		harness: req.harness,
 		promptCount: snap?.totalPromptCount ?? null,
+		sessionHash: hashSessionKey(sessionKey),
 	});
 	if (snap && snap.totalPromptCount > 0) {
 		try {

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -124,12 +124,13 @@ function claimAutomaticSessionOrSkip(
 	sessionKey: string | undefined,
 	runtimePath: RuntimePath | undefined,
 	agentId: string,
+	harness: string | undefined,
 	hook: string,
 	noop: Record<string, unknown>,
 ): Record<string, unknown> | null {
 	if (!sessionKey || !runtimePath) return null;
 
-	const claim = claimSession(sessionKey, runtimePath, agentId);
+	const claim = claimSession(sessionKey, runtimePath, agentId, harness);
 	if (claim.ok) return null;
 
 	logger.info("hooks", "Duplicate runtime hook skipped", {
@@ -374,11 +375,18 @@ function registerUserPromptSubmit(app: Hono): void {
 			const known = sessionKey ? hasSession(sessionKey) : false;
 
 			const agentId = parseOptionalString(body.agentId) ?? "default";
-			const duplicate = claimAutomaticSessionOrSkip(sessionKey, runtimePath, agentId, "user-prompt-submit", {
-				inject: "",
-				memoryCount: 0,
-				sessionKnown: known,
-			});
+			const duplicate = claimAutomaticSessionOrSkip(
+				sessionKey,
+				runtimePath,
+				agentId,
+				body.harness,
+				"user-prompt-submit",
+				{
+					inject: "",
+					memoryCount: 0,
+					sessionKnown: known,
+				},
+			);
 			if (duplicate) {
 				return c.json(duplicate);
 			}
@@ -471,7 +479,7 @@ function registerSessionEnd(app: Hono): void {
 				agentId = scopedAgent.agentId;
 				body.agentId = agentId;
 			}
-			const duplicate = claimAutomaticSessionOrSkip(sessionKey, runtimePath, agentId, "session-end", {
+			const duplicate = claimAutomaticSessionOrSkip(sessionKey, runtimePath, agentId, body.harness, "session-end", {
 				memoriesSaved: 0,
 			});
 			if (duplicate) return c.json(duplicate);
@@ -612,6 +620,7 @@ function registerCheckpointExtract(app: Hono): void {
 				body.sessionKey,
 				runtimePath,
 				parseOptionalString(body.agentId) ?? "default",
+				body.harness,
 				"session-checkpoint-extract",
 				{
 					skipped: true,
@@ -822,11 +831,18 @@ function registerPreCompaction(app: Hono): void {
 				agentId = scopedAgent.agentId;
 				body.agentId = agentId;
 			}
-			const duplicate = claimAutomaticSessionOrSkip(body.sessionKey, runtimePath, agentId, "pre-compaction", {
-				guidelines: "",
-				instructions: "",
-				summaryPrompt: "",
-			});
+			const duplicate = claimAutomaticSessionOrSkip(
+				body.sessionKey,
+				runtimePath,
+				agentId,
+				body.harness,
+				"pre-compaction",
+				{
+					guidelines: "",
+					instructions: "",
+					summaryPrompt: "",
+				},
+			);
 			if (duplicate) return c.json(duplicate);
 
 			if (checkBypass(body)) {
@@ -876,6 +892,7 @@ function registerCompactionComplete(app: Hono): void {
 				body.sessionKey,
 				runtimePath,
 				parseOptionalString(body.agentId) ?? "default",
+				body.harness,
 				"compaction-complete",
 				{
 					success: true,

--- a/platform/daemon/src/session-end-state.ts
+++ b/platform/daemon/src/session-end-state.ts
@@ -1,0 +1,83 @@
+import { createHash } from "node:crypto";
+import { resolveAgentId } from "./agent-id";
+
+/**
+ * Session-end telemetry dedup state (#1212).
+ *
+ * `session.end` must fire at most once per session lifetime — at the real
+ * boundary (explicit clear or TTL eviction) — so its counter stays
+ * comparable with the dedup'd `session.start`. Hook state is in-memory and
+ * intentionally fail-open on daemon restart, mirroring session-start-state.
+ */
+
+const sessionEndSeen = new Map<string, number>();
+const SESSION_END_SEEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export type SessionEndIdentity = {
+	readonly harness?: string;
+	readonly agentId?: string;
+	readonly sessionKey?: string;
+	readonly sessionId?: string;
+};
+
+/**
+ * Normalize a session key: trim and strip the "session:" prefix harnesses
+ * send (e.g. openclaw). The dedup map and the anonymous hash MUST use the
+ * same normalized identity as the session tracker, or a "session:abc" key
+ * on the clear path would diverge from the eviction path's "abc" — double-
+ * counting the same lifetime and producing unjoinable hashes (#1212).
+ */
+export function normalizeSessionKey(sessionKey: string): string {
+	const trimmed = sessionKey.trim();
+	if (trimmed.startsWith("session:")) {
+		return trimmed.slice("session:".length);
+	}
+	return trimmed;
+}
+
+function sessionEndDedupeKey(identity: SessionEndIdentity): string | null {
+	const sessionKey = identity.sessionKey ?? identity.sessionId;
+	if (!sessionKey) return null;
+	const normalized = normalizeSessionKey(sessionKey);
+	if (normalized.length === 0) return null;
+	return [
+		resolveAgentId({ agentId: identity.agentId, sessionKey: normalized }),
+		identity.harness ?? "",
+		normalized,
+	].join("\0");
+}
+
+/** Anonymous per-session key for telemetry — hashed, never raw. */
+export function hashSessionKey(sessionKey: string | undefined): string | null {
+	if (!sessionKey) return null;
+	const normalized = normalizeSessionKey(sessionKey);
+	if (normalized.length === 0) return null;
+	return createHash("sha256").update(normalized).digest("hex").slice(0, 16);
+}
+
+export function pruneSessionEndTelemetry(now = Date.now()): void {
+	for (const [key, seenAt] of sessionEndSeen.entries()) {
+		if (now - seenAt > SESSION_END_SEEN_TTL_MS) sessionEndSeen.delete(key);
+	}
+}
+
+export function hasSessionEndTelemetry(identity: SessionEndIdentity): boolean {
+	const key = sessionEndDedupeKey(identity);
+	return key !== null && sessionEndSeen.has(key);
+}
+
+export function markSessionEndTelemetry(identity: SessionEndIdentity, seenAt = Date.now()): void {
+	const key = sessionEndDedupeKey(identity);
+	if (key) sessionEndSeen.set(key, seenAt);
+}
+
+/** Clear the end-telemetry marker when a session lifetime begins anew. */
+export function clearSessionEndTelemetry(identity: SessionEndIdentity): void {
+	const key = sessionEndDedupeKey(identity);
+	if (key) sessionEndSeen.delete(key);
+}
+
+/** Reset all markers (for tests). */
+export function resetSessionEndTelemetry(): void {
+	sessionEndSeen.clear();
+}

--- a/platform/daemon/src/session-tracker.test.ts
+++ b/platform/daemon/src/session-tracker.test.ts
@@ -1,4 +1,7 @@
+import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, it } from "bun:test";
+import type { DbAccessor } from "./db-accessor";
+import { hashSessionKey, markSessionEndTelemetry } from "./session-end-state";
 import {
 	type SessionEvictionHandler,
 	_expireSessionForTest,
@@ -17,10 +20,47 @@ import {
 	runStaleCleanup,
 	setSessionEvictionHandler,
 } from "./session-tracker";
+import { createTelemetryCollector, setActiveTelemetry } from "./telemetry";
+
+// Collector config for telemetry regression tests (#1212): empty posthogHost
+// means nothing is ever sent, and the buffer is queried directly.
+const TEST_TELEMETRY_CONFIG = {
+	posthogHost: "",
+	posthogApiKey: "",
+	flushIntervalMs: 60000,
+	flushBatchSize: 50,
+	retentionDays: 90,
+	memorySearchQaEnabled: false,
+} as const;
 
 afterEach(() => {
 	resetSessions();
 });
+
+/**
+ * Real in-memory telemetry DB: the collector writes the event buffer to
+ * `telemetry_events` on flush, and `query()` reads it back — a fake that
+ * returns [] for every SELECT would hide the events. Mirrors the real
+ * schema (migration 109) so flush + query behave like production.
+ */
+function telemetryTestDb(): DbAccessor {
+	const db = new Database(":memory:");
+	db.exec("CREATE TABLE telemetry_install (id TEXT PRIMARY KEY, created_at TEXT NOT NULL)");
+	db.exec(
+		`CREATE TABLE telemetry_events (
+			id TEXT PRIMARY KEY,
+			event TEXT NOT NULL,
+			timestamp TEXT NOT NULL,
+			properties TEXT NOT NULL,
+			sent_to_posthog INTEGER NOT NULL DEFAULT 0,
+			created_at TEXT NOT NULL
+		)`,
+	);
+	return {
+		withWriteTx: (fn: (d: Database) => unknown) => fn(db),
+		withReadDb: (fn: (d: Database) => unknown) => fn(db),
+	} as unknown as DbAccessor;
+}
 
 describe("bypass with allowUnknown", () => {
 	it("adds a bypass entry for an unclaimed session", () => {
@@ -267,5 +307,74 @@ describe("TTL eviction lifecycle handler (#902)", () => {
 
 		expect(evicted).toEqual(["ttl-reclaim", "ttl-has", "ttl-path", "ttl-active", "ttl-renew"]);
 		expect(getSessionTrackerStats().expired).toBe(5);
+	});
+
+	describe("session.end telemetry on TTL eviction (#1212)", () => {
+		it("emits session.end once per session lifetime when a claim TTL-evicts", async () => {
+			const collector = createTelemetryCollector(telemetryTestDb(), TEST_TELEMETRY_CONFIG, "0.0.0-test");
+			setActiveTelemetry(collector);
+			try {
+				claimSession("sess-evict", "legacy", "default", "claude-code");
+				_expireSessionForTest("sess-evict");
+				runStaleCleanup();
+				await collector.flush();
+
+				const ends = collector.query().filter((e) => e.event === "session.end");
+				expect(ends).toHaveLength(1);
+				expect(ends[0]?.properties.reason).toBe("expired");
+				expect(ends[0]?.properties.harness).toBe("claude-code");
+				expect(typeof ends[0]?.properties.sessionHash).toBe("string");
+
+				// A re-claimed session that evicts again without a new session
+				// start is the same lifetime — no second event.
+				claimSession("sess-evict", "legacy", "default", "claude-code");
+				_expireSessionForTest("sess-evict");
+				runStaleCleanup();
+				await collector.flush();
+				expect(collector.query().filter((e) => e.event === "session.end")).toHaveLength(1);
+			} finally {
+				setActiveTelemetry(undefined);
+			}
+		});
+
+		it("emits session.end for claims without a harness as harness null", async () => {
+			const collector = createTelemetryCollector(telemetryTestDb(), TEST_TELEMETRY_CONFIG, "0.0.0-test");
+			setActiveTelemetry(collector);
+			try {
+				claimSession("sess-evict-noharness", "plugin");
+				_expireSessionForTest("sess-evict-noharness");
+				runStaleCleanup();
+				await collector.flush();
+
+				const ends = collector.query().filter((e) => e.event === "session.end");
+				expect(ends).toHaveLength(1);
+				expect(ends[0]?.properties.harness).toBeNull();
+			} finally {
+				setActiveTelemetry(undefined);
+			}
+		});
+
+		it("does not double-count a lifetime whose clear used a session:-prefixed key (#1212)", async () => {
+			const collector = createTelemetryCollector(telemetryTestDb(), TEST_TELEMETRY_CONFIG, "0.0.0-test");
+			setActiveTelemetry(collector);
+			try {
+				// Harnesses (openclaw) send "session:<uuid>" keys. The clear
+				// path and the tracker eviction path must agree on the same
+				// normalized identity, or the same lifetime emits session.end
+				// twice — once for clear, once for the eviction.
+				markSessionEndTelemetry({ agentId: "default", harness: "claude-code", sessionKey: "session:evict-prefixed" });
+				claimSession("session:evict-prefixed", "legacy", "default", "claude-code");
+				_expireSessionForTest("session:evict-prefixed");
+				runStaleCleanup();
+				await collector.flush();
+
+				expect(collector.query().filter((e) => e.event === "session.end")).toHaveLength(0);
+
+				// And the anonymous hash is joinable across raw/normalized forms.
+				expect(hashSessionKey("session:abc")).toBe(hashSessionKey("abc"));
+			} finally {
+				setActiveTelemetry(undefined);
+			}
+		});
 	});
 });

--- a/platform/daemon/src/session-tracker.ts
+++ b/platform/daemon/src/session-tracker.ts
@@ -10,6 +10,16 @@
  */
 
 import { logger } from "./logger";
+import {
+	hashSessionKey,
+	hasSessionEndTelemetry,
+	markSessionEndTelemetry,
+	normalizeSessionKey,
+	resetSessionEndTelemetry,
+} from "./session-end-state";
+import { getActiveTelemetry } from "./telemetry";
+
+export { normalizeSessionKey } from "./session-end-state";
 
 export type RuntimePath = "plugin" | "legacy";
 
@@ -25,6 +35,8 @@ export interface SessionInfo {
 interface SessionClaim {
 	readonly agentId: string;
 	readonly runtimePath: RuntimePath;
+	/** Harness that claimed the session (for telemetry breakdowns). */
+	readonly harness?: string;
 	readonly claimedAt: string;
 	expiresAt: number;
 }
@@ -49,6 +61,7 @@ export interface EvictedSessionInfo {
 	readonly sessionKey: string;
 	readonly agentId: string;
 	readonly runtimePath: RuntimePath;
+	readonly harness?: string;
 	readonly claimedAt: string;
 }
 
@@ -82,13 +95,8 @@ let evictionHandler: SessionEvictionHandler | null = null;
 let expiredCount = 0;
 let unfinalizedCount = 0;
 
-export function normalizeSessionKey(sessionKey: string): string {
-	const trimmed = sessionKey.trim();
-	if (trimmed.startsWith("session:")) {
-		return trimmed.slice("session:".length);
-	}
-	return trimmed;
-}
+// normalizeSessionKey is defined in session-end-state.ts (single source of
+// truth for session-key identity) and re-exported here for the routes.
 
 function evictExpiredSession(key: string, claim: SessionClaim): void {
 	if (!sessions.delete(key)) return;
@@ -100,6 +108,19 @@ function evictExpiredSession(key: string, claim: SessionClaim): void {
 		runtimePath: claim.runtimePath,
 		claimedAt: claim.claimedAt,
 	});
+
+	// Real session termination: the daemon judged the session abandoned
+	// (no hooks for STALE_SESSION_MS). Emit session.end once per session
+	// lifetime (#1212) — dedup'd so a session already counted via explicit
+	// clear is not double-counted here.
+	if (!hasSessionEndTelemetry({ agentId: claim.agentId, harness: claim.harness, sessionKey: key })) {
+		getActiveTelemetry()?.record("session.end", {
+			harness: claim.harness ?? null,
+			reason: "expired",
+			sessionHash: hashSessionKey(key),
+		});
+		markSessionEndTelemetry({ agentId: claim.agentId, harness: claim.harness, sessionKey: key });
+	}
 
 	if (!evictionHandler) return;
 	try {
@@ -124,7 +145,12 @@ function evictExpiredSession(key: string, claim: SessionClaim): void {
  * session is unclaimed or already claimed by the same path. Returns
  * ok:false with claimedBy if claimed by the other path.
  */
-export function claimSession(sessionKey: string, runtimePath: RuntimePath, agentId = "default"): ClaimResult {
+export function claimSession(
+	sessionKey: string,
+	runtimePath: RuntimePath,
+	agentId = "default",
+	harness?: string,
+): ClaimResult {
 	const key = normalizeSessionKey(sessionKey);
 	const existing = sessions.get(key);
 	endedSessions.delete(key);
@@ -153,6 +179,7 @@ export function claimSession(sessionKey: string, runtimePath: RuntimePath, agent
 	sessions.set(key, {
 		agentId,
 		runtimePath,
+		harness,
 		claimedAt: new Date().toISOString(),
 		expiresAt: Date.now() + STALE_SESSION_MS,
 	});
@@ -471,6 +498,7 @@ export function resetSessions(): void {
 	evictionHandler = null;
 	expiredCount = 0;
 	unfinalizedCount = 0;
+	resetSessionEndTelemetry();
 }
 
 /** Test-only: force a session claim's expiry so cleanup evicts it. */

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -51,6 +51,11 @@ export const TELEMETRY_EVENTS = [
 	"inference.stream",
 	"inference.fallback",
 	"session.start",
+	// Per session-end hook call — a "turns persisted" counter (harness
+	// activity volume), distinct from the real session boundary event.
+	"session.turn",
+	// Fired only at actual session boundaries (explicit clear or TTL
+	// eviction), dedup'd once per session lifetime (#1212).
 	"session.end",
 	"daemon.heartbeat",
 	// Lifecycle events (issue #1026 Phase 2): fired when the user has opted


### PR DESCRIPTION
## Summary

`session.end` telemetry fired on every `session-end` hook call — the hook harnesses call **per turn** to persist messages — so the event was a "turns persisted" counter with a session-boundary name. Observed ~9:1 inflation vs the dedup'd `session.start` (707 vs 78 across the fleet; one dev install produced hundreds in ~2h from 11 concurrent sessions). This splits the semantics so the counters are honest and comparable.

## Changes

- **`session.turn`** — the per-turn event (renamed from `session.end`), keeps per-turn cadence as a harness-activity volume counter. Carries `harness`, `promptCount`, `sessionHash`.
- **`session.end`** — now fires only at real session terminations:
  - explicit `reason: "clear"` in `handleSessionEnd` (caller discards the session),
  - TTL-evicted (abandoned) session claims in `session-tracker.ts` (`evictExpiredSession` — the daemon's existing "this session is over" decision).
- **Once per session lifetime** — new `session-end-state.ts` dedup (mirrors `session-start-state.ts`), cleared on real and clear session starts. Repeated clears or re-claim-evict cycles without a new start cannot inflate the counter.
- **Normalized session identity** — `normalizeSessionKey` (trim + strip `session:` prefix) now lives in `session-end-state.ts`, re-exported by the tracker. The dedup map and `sessionHash` use the same normalized identity as the tracker, so `session:<uuid>` keys (openclaw sends these) can neither double-count a lifetime nor produce unjoinable hashes. Found by the adversarial review, regression-tested.
- **Harness on the claim** — `claimSession`/`claimAutomaticSessionOrSkip` now record the harness, so eviction events break down by harness (previously the tracker only knew plugin/legacy).
- **`sessionHash`** — 16-hex sha256 of the normalized session key on all three session events, so distinct sessions and concurrency are measurable without leaking raw keys (issue's optional item).

No DB schema changes; telemetry events only. `session.start` unchanged (still dedup'd). Cleanly-finished sessions that never send `clear` are not counted as ended — only provable terminations are.

## Type

bug (fix)

## Packages affected

- `@signet/daemon` (platform/daemon)

## Tests

- `hooks.test.ts`: per-turn session-end emits `session.turn` (never `session.end`); explicit clear emits `session.end` once per lifetime, and a real session start opens a new lifetime.
- `session-tracker.test.ts`: TTL eviction emits `session.end` once per lifetime with `reason: "expired"` + harness; harness-less claims emit `harness: null`; a `session:`-prefixed key cannot double-count a lifetime and the hash is joinable across raw/normalized forms.
- Full affected suites: 235 pass / 0 fail; daemon production tsc clean; daemon build clean.

## Docs

- `docs/TELEMETRY.md` — event catalog updated: `session.start` / `session.turn` / `session.end` rows, the "known naming quirk" note replaced with the fixed semantics, changelog row added.
- `signet-telemetry` skill updated to match.

## Related

Fixes #1212. Related: #1026, #1200, #1213 (TELEMETRY.md).
## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally
