### PR TITLE
feat(telemetry): first-run activation funnel (first.remember / first.recall)

### DIFF
--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -209,14 +209,41 @@ PostHog Telemetry
 
 Separate from the in-memory analytics above, the daemon ships an
 anonymous telemetry collector for understanding install and usage
-patterns (see [configuration](./CONFIGURATION.md#telemetry-telemetry)). It
-buffers events to SQLite and flushes them in batches to a PostHog instance
-when both `posthogHost` and `posthogApiKey` are configured
-(`telemetryEnabled` defaults to true; set it to `false` to opt out).
+patterns (see [[configuration]]). It buffers events to SQLite and
+flushes them in batches to a PostHog instance when both `posthogHost`
+and `posthogApiKey` are configured (`telemetryEnabled` defaults to
+true; set it to `false` to opt out).
 
-The event catalog, privacy contract, the open JSONL audit log, and how to
-query the project live in **[TELEMETRY.md](./TELEMETRY.md)** — the single
-telemetry reference.
+Privacy contract:
+
+- Events carry no memory content, user identity, agent ids, or file paths.
+- Each install gets a random anonymous id (persisted in the workspace
+  database) used as the PostHog `distinct_id`, so installs are countable
+  but not identifiable.
+- Telemetry is on by default and can be disabled with
+  `telemetryEnabled: false`.
+- Every recorded event is mirrored to an open, inspectable JSONL log at
+  `<agentsDir>/.daemon/telemetry/events.jsonl`, so users can audit
+  exactly what was sent.
+
+Events recorded: `daemon.heartbeat` (every 5 minutes), the `inference.*`
+lifecycle (`route`, `execute`, `stream`, `fallback`), `llm.generate`
+(provider, latency, token and cost counts when reported, success — never
+prompt text), `session.start` / `session.end` (harness and prompt count),
+the lifecycle events `daemon.started`, `command.invoked`,
+`error.occurred` (sanitized crash report — truncated message with user
+paths stripped, top stack frames with home directories removed, uptime;
+plus rate-limited `EventLoopLag` reports with measured lag), and
+`version.upgraded`, `install.activated` (first daemon run of a new
+install — covers bun/desktop installs the npm postinstall ping never
+sees), `first.remember` / `first.recall` (first successful remember /
+recall per install, guarded by the persisted install id — the
+activation funnel: an install that was actually used, not just
+booted), `pipeline.embedding` (tokens, provider, sourceKind — memory
+capture / artifact index / recall / dreaming), and `dreaming.pass`
+(provider-reported input/output/cache tokens and cost per agentic
+pass). The remaining `pipeline.*` event types are declared
+for future use but not yet emitted.
 
 Release Download Stats
 ---

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -50,6 +50,7 @@ PostHog failures, and never throws into the daemon.
 |---|---|---|
 | `install.ping` | npm wrapper postinstall (native binary install) | `version`, `platform` |
 | `install.activated` | first daemon run of a new install (persisted install id first created) | `version`, `platform` |
+| `first.remember` / `first.recall` | first successful remember / recall per install, exactly once | `version`, `platform` |
 | `daemon.started` | daemon boot | `version`, `platform`, `uptimeMs` |
 | `daemon.heartbeat` | every 5 minutes | `uptimeMs`, `memoryCount`, `connectorsActive`, `pipelineMode`, `extractionProvider`, `embeddingProvider` |
 | `session.start` | real session start (deduped; stubs and clear/reset paths don't count) | `harness`, `sessionHash` |
@@ -93,6 +94,14 @@ Notes on individual events:
   normalized session key, so distinct sessions and concurrency are countable
   without leaking raw keys. Cleanly-finished sessions that never send
   `clear` are not counted as ended — only provable terminations are.
+- **`first.remember` / `first.recall`** — the activation funnel. Emitted
+  exactly once per install, when the first successful remember / recall
+  completes (guarded by an atomic claim on the persisted install id, so
+  concurrent or repeated calls can't double-fire). Events carry only
+  `version` and `platform` — no content, no query text, no agent ids. The
+  funnel query is activated vs activated+first.remember vs +first.recall
+  (below). A deduped remember counts; the automatic recall injected into
+  prompt-submit context does not — only the explicit recall route fires it.
 - **`dreaming.pass`** — dreaming is the largest token consumer (millions of
   input tokens per heavy install), so always include it in token/cost
   aggregates.
@@ -205,6 +214,12 @@ HogQL examples that work:
 select event, count() as n from events group by event order by n desc
 -- active installs (distinct ids that ever activated)
 select distinct_id, count() as n from events where event = 'install.activated' group by distinct_id
+-- activation funnel: activated vs used (first remember) vs recalled
+select
+  count(distinct distinct_id) as activated,
+  count(distinct if(event = 'first.remember', distinct_id, null)) as first_remember,
+  count(distinct if(event = 'first.recall', distinct_id, null)) as first_recall
+from events where event in ('install.activated', 'first.remember', 'first.recall')
 -- llm cost by provider
 select properties.provider as provider, count() as calls, sum(properties.totalCost) as cost
   from events where event = 'llm.generate' group by provider
@@ -228,6 +243,7 @@ vault mirrors the key PostHog aggregates for daily review via
 | 0.176.0 | Sanitized crash reports: full `error.occurred` payload (truncated, home-stripped message + top-8 stack frames) and rate-limited `EventLoopLag` wedge reports |
 | next | `session.turn` + real `session.end` split (#1212): the per-turn event renamed from the old `session.end`; `session.end` now fires only at real terminations, deduped per lifetime; `sessionHash` added to all three session events |
 | Unreleased | `recall.performed` with anonymous recall type, result count, latency, and truncation metrics (#1203) |
+| Unreleased | First-run activation funnel: `first.remember` / `first.recall`, exactly once per install (#1202) |
 
 Related: #1026 (original rollout), #1200 (IP capture, dev tagging),
 #1201-#1207 (event-scoped follow-ups), #1212 (session.end rename — resolved).

--- a/platform/core/src/migrations/111-telemetry-first-use.ts
+++ b/platform/core/src/migrations/111-telemetry-first-use.ts
@@ -1,0 +1,29 @@
+/**
+ * Migration 111: Telemetry first-use milestones
+ *
+ * Extends the telemetry_install row (migration 109) with one-shot
+ * first-use timestamps. The daemon claims a milestone with an atomic
+ * guarded UPDATE (only the first caller wins, changes === 1) and emits
+ * first.remember / first.recall exactly once per install, so the
+ * activation funnel (install.activated -> first.remember/recall) counts
+ * installs that were actually used, not just booted.
+ *
+ * Idempotent: guards each ADD COLUMN with a pragma check (SQLite ALTER
+ * has no IF NOT EXISTS).
+ */
+import type { MigrationDb } from "./index";
+
+function hasColumn(db: MigrationDb, table: string, column: string): boolean {
+	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;
+	return rows.some((row) => row.name === column);
+}
+
+const COLUMNS = ["first_remember_at", "first_recall_at"] as const;
+
+export function up(db: MigrationDb): void {
+	for (const column of COLUMNS) {
+		if (!hasColumn(db, "telemetry_install", column)) {
+			db.exec(`ALTER TABLE telemetry_install ADD COLUMN ${column} TEXT`);
+		}
+	}
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -116,6 +116,7 @@ import { up as dreamingPassUsage } from "./107-dreaming-pass-usage";
 import { up as embeddingUsage } from "./108-embedding-usage";
 import { up as telemetryInstall } from "./109-telemetry-install";
 import { up as memoryMentionJoinIndex } from "./110-memory-mention-join-index";
+import { up as telemetryFirstUse } from "./111-telemetry-first-use";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1024,6 +1025,17 @@ export const MIGRATIONS: readonly Migration[] = [
 		version: 110,
 		name: "memory-mention-join-index",
 		up: memoryMentionJoinIndex,
+	},
+	{
+		version: 111,
+		name: "telemetry-first-use",
+		up: telemetryFirstUse,
+		artifacts: {
+			columns: [
+				{ table: "telemetry_install", column: "first_remember_at" },
+				{ table: "telemetry_install", column: "first_recall_at" },
+			],
+		},
 	},
 ];
 

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -36,6 +36,7 @@ import { recordPathFeedback } from "../path-feedback";
 import { enqueueDocumentIngestJob } from "../pipeline";
 import { parseFeedback, recordAgentFeedback } from "../session-memories";
 import { upsertSessionTranscript } from "../session-transcripts";
+import { getActiveTelemetry } from "../telemetry";
 import { createTemporalEdgeId, normalizeTemporalTimestamp, validateTemporalTimeOptions } from "../temporal-recall";
 import {
 	type SupersedeMemoryTxStatus,
@@ -622,6 +623,15 @@ function documentScopeOwnedBy(
 
 function documentMetadataJson(metadata: unknown): string | null {
 	return metadata === undefined ? null : JSON.stringify(metadata);
+}
+
+/**
+ * Claim the install's one-shot first-use milestone after a successful
+ * remember / recall. The collector fires first.remember / first.recall
+ * only when this call wins the persisted claim (issue #1202).
+ */
+function recordFirstUseTelemetry(kind: "remember" | "recall"): void {
+	getActiveTelemetry()?.recordFirstUse(kind);
 }
 
 export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): void {
@@ -1341,6 +1351,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					return c.json({ error: "idempotencyKey already used for different chunked content" }, 409);
 				}
 
+				recordFirstUseTelemetry("remember");
 				return c.json({
 					chunked: true,
 					chunk_count: existingChunks.length,
@@ -1449,6 +1460,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					return c.json({ error: "chunk content already exists for this agent and scope" }, 409);
 				}
 				if (result.status === "deduped") {
+					recordFirstUseTelemetry("remember");
 					return c.json({
 						chunked: true,
 						chunk_count: result.ids.length,
@@ -1509,6 +1521,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					chunkCount: savedChunkIds.length,
 				});
 
+				recordFirstUseTelemetry("remember");
 				return c.json({
 					chunked: true,
 					chunk_count: savedChunkIds.length,
@@ -1660,6 +1673,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						now,
 					}),
 				);
+				recordFirstUseTelemetry("remember");
 				return c.json({
 					id: result.row.id,
 					type: result.row.type,
@@ -1689,6 +1703,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 							now,
 						}),
 					);
+					recordFirstUseTelemetry("remember");
 					return c.json({
 						id: existing.id,
 						type: existing.type,
@@ -1811,6 +1826,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			structured: structuredRetained,
 		});
 
+		recordFirstUseTelemetry("remember");
 		return c.json({
 			id,
 			type: memType,
@@ -3074,6 +3090,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				result,
 				cfg,
 			});
+			recordFirstUseTelemetry("recall");
 			return c.json(result);
 		} catch (e) {
 			logger.error("memory", "Recall failed", e as Error);

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -281,6 +281,39 @@ describe("telemetry collector", () => {
 		}
 	});
 
+	it("emits first.remember and first.recall exactly once per install", async () => {
+		// Regression (issue #1202): the activation funnel needs one-shot
+		// first-use milestones guarded by the persisted install id, or
+		// repeated remembers/recalls inflate the funnel and daemon restarts
+		// double-count an install that already used the product.
+		const first = makeCollector();
+		first.recordFirstUse("remember");
+		first.recordFirstUse("remember");
+		first.recordFirstUse("recall");
+		await first.flush();
+
+		const rememberEvent = captured.flatMap((c) => c.body.batch).find((e) => e.event === "first.remember");
+		const recallEvent = captured.flatMap((c) => c.body.batch).find((e) => e.event === "first.recall");
+		expect(rememberEvent).toBeDefined();
+		expect(recallEvent).toBeDefined();
+		// No content: the event carries only the fact of first use.
+		expect(rememberEvent?.properties).toMatchObject({ version: "0.0.0-test", platform: process.platform });
+		expect(Object.keys(rememberEvent?.properties ?? {})).toEqual(["version", "platform", "$lib", "$lib_version"]);
+		const firstBatch = captured.flatMap((c) => c.body.batch.map((e) => e.event));
+		expect(firstBatch.filter((e) => e === "first.remember")).toHaveLength(1);
+		expect(firstBatch.filter((e) => e === "first.recall")).toHaveLength(1);
+
+		// Restart over the same database: no second first-use, even though
+		// the new collector claims again.
+		const second = makeCollector();
+		second.recordFirstUse("remember");
+		second.recordFirstUse("recall");
+		second.record("daemon.heartbeat", { uptimeMs: 2 });
+		await second.flush();
+		const lastBatch = captured.at(-1)?.body.batch ?? [];
+		expect(lastBatch.map((e) => e.event)).toEqual(["daemon.heartbeat"]);
+	});
+
 	it("sanitizes crash reports: truncation, home-path stripping, frame cap", () => {
 		const longMessage =
 			'SQLiteError: database is locked near "a very long embedded fragment that goes on and on" at /home/alice/.agents/memory/memories.db'.repeat(

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -62,6 +62,12 @@ export const TELEMETRY_EVENTS = [
 	// into anonymous telemetry. No PII, no code, no memory content.
 	"daemon.started",
 	"install.activated",
+	// First-use milestones (issue #1202): fired exactly once per install,
+	// at the first successful remember / recall. Guards the activation
+	// funnel (install.activated -> first.remember/recall) so "activated"
+	// stops including installs that never did anything.
+	"first.remember",
+	"first.recall",
 	"dreaming.pass",
 	"command.invoked",
 	"error.occurred",
@@ -78,6 +84,12 @@ export const TELEMETRY_EVENTS = [
 
 export type TelemetryEventType = (typeof TELEMETRY_EVENTS)[number];
 
+/**
+ * Which first-use milestone to claim. Each fires at most once per
+ * install, persisted on the telemetry_install row (migration 111).
+ */
+export type FirstUseKind = "remember" | "recall";
+
 export type TelemetryProperties = Readonly<Record<string, string | number | boolean | null>>;
 
 export interface TelemetryEvent {
@@ -93,6 +105,13 @@ export interface TelemetryEvent {
 
 export interface TelemetryCollector {
 	record(event: TelemetryEventType, properties: TelemetryProperties): void;
+
+	/**
+	 * Claim a one-shot first-use milestone (issue #1202). Emits
+	 * first.remember / first.recall only when this call wins the claim
+	 * for this install — later calls are silent no-ops.
+	 */
+	recordFirstUse(kind: FirstUseKind): void;
 
 	flush(): Promise<void>;
 	start(): void;
@@ -290,6 +309,25 @@ async function sendToPostHog(
 }
 
 // ---------------------------------------------------------------------------
+// First-use milestones (issue #1202)
+// ---------------------------------------------------------------------------
+
+/**
+ * telemetry_install column that records the first-use timestamp for each
+ * kind. Fixed internal map — the column name is interpolated into SQL,
+ * so it must never accept caller input.
+ */
+const FIRST_USE_COLUMNS: Readonly<Record<FirstUseKind, string>> = {
+	remember: "first_remember_at",
+	recall: "first_recall_at",
+};
+
+const FIRST_USE_EVENTS: Readonly<Record<FirstUseKind, TelemetryEventType>> = {
+	remember: "first.remember",
+	recall: "first.recall",
+};
+
+// ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
 
@@ -309,6 +347,33 @@ export function createTelemetryCollector(
 	const { id: installId, created: installActivated } = getOrCreateInstallId(db);
 
 	const posthogConfigured = config.posthogHost.length > 0 && config.posthogApiKey.length > 0;
+
+	/**
+	 * Atomically claim a first-use milestone for this install. Only the
+	 * first caller wins (changes === 1); every later call is a no-op, so
+	 * concurrent remembers can't double-fire. When the install id fell
+	 * back to an in-memory value (broken DB) the UPDATE matches no row
+	 * and the milestone never fires — acceptable, telemetry is degraded
+	 * anyway.
+	 */
+	function claimFirstUse(kind: FirstUseKind): boolean {
+		try {
+			const column = FIRST_USE_COLUMNS[kind];
+			let claimed = false;
+			db.withWriteTx((w) => {
+				const result = w
+					.prepare(
+						`UPDATE telemetry_install SET ${column} = ?
+						 WHERE id = ? AND ${column} IS NULL`,
+					)
+					.run(new Date().toISOString(), installId);
+				claimed = result.changes > 0;
+			});
+			return claimed;
+		} catch {
+			return false;
+		}
+	}
 
 	function writeToDb(events: readonly TelemetryEvent[]): void {
 		if (events.length === 0) return;
@@ -457,6 +522,17 @@ export function createTelemetryCollector(
 			if (buffer.length >= MAX_BUFFER_SIZE) {
 				doFlush().catch(() => {});
 			}
+		},
+
+		recordFirstUse(kind): void {
+			// Best-effort: a failed claim (no row, broken DB) means the
+			// milestone stays unclaimed and may fire on a later run —
+			// still exactly once overall.
+			if (!claimFirstUse(kind)) return;
+			collector.record(FIRST_USE_EVENTS[kind], {
+				version: daemonVersion,
+				platform: process.platform,
+			});
 		},
 
 		async flush(): Promise<void> {


### PR DESCRIPTION
## Summary

Closes #1202. The activation funnel was install.ping -> install.activated, but nothing showed whether an install was actually *used*. This adds `first.remember` / `first.recall`, fired exactly once per install at the first successful remember / recall, so the funnel becomes activated vs activated+first.remember vs +first.recall.

## Changes

- Migration 111: adds `first_remember_at` / `first_recall_at` to `telemetry_install` (pragma-guarded idempotent ADD COLUMN, same pattern as 082).
- `telemetry.ts`: new `first.remember` / `first.recall` event types; `TelemetryCollector.recordFirstUse(kind)` claims the milestone with an atomic guarded UPDATE (`WHERE id = ? AND <column> IS NULL`) — only the winning caller emits the event, so concurrent or repeated calls can't double-fire. Events carry only `{version, platform}` — no content, no query, no agent ids.
- `memory-routes.ts`: fires `recordFirstUse("remember")` on every success path of `POST /api/memory/remember` (plain insert, deduped paths, chunked insert/dedupe) and `recordFirstUse("recall")` on `POST /api/memory/recall` success. CLI, MCP, and the `/api/hook/remember` proxy all route through these handlers, so all surfaces are covered.
- `docs/ANALYTICS.md`: events list updated.

## Type

- [x] `feat` — new user-facing feature (bumps minor)

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) (no spec entry covers telemetry events; migration registered in the canonical migrations index)
- [x] Agent scoping verified on all new/changed data queries (no user-data queries touched; the claim UPDATE is scoped to the anonymous install id, never an agent)
- [x] Input/config validation and bounds checks added (no new external input; kind is a fixed union)
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints (n/a — telemetry write only)
- [x] Docs updated for API/spec/status changes (`docs/ANALYTICS.md`)
- [x] Regression tests added for each bug fix (one-shot regression test pins the pattern)
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent (pragma-guarded ADD COLUMN; fresh + re-run covered by migrations.test.ts, which also verifies declared artifacts)
- [x] Rollback / compatibility note included in PR description (columns are nullable TEXT; rollback = drop migration 111 registration — old code ignores the columns)

## Testing

- [x] `bun test` passes (144/144 across telemetry, migrations, memory-routes, mutation-api, analytics suites)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (only 3 pre-existing errors on main in these files, none introduced here)
- [x] Tested against running daemon (scratch daemon on port 3862: 2 remembers + 2 recalls produced exactly 1 `first.remember` and 1 `first.recall` in `telemetry_events`, both `sent_to_posthog=1`, properties `{version, platform}` only)
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Error handling: claim failure leaves the milestone unclaimed (may fire on a later run, still exactly once); the collector is best-effort and never throws — covered by the one-shot regression test.
- One anonymous scratch install (fresh uuid) was created by the live verification run against the real PostHog project — same class as #1200's dev-fleet pollution, one row, no PII.

