### PR TITLE
feat(telemetry): add config snapshot event

### DIFF
--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -245,6 +245,38 @@ capture / artifact index / recall / dreaming), and `dreaming.pass`
 pass). The remaining `pipeline.*` event types are declared
 for future use but not yet emitted.
 
+Privacy contract:
+
+- Events carry no memory content, user identity, agent ids, or file paths.
+- Each install gets a random anonymous id (persisted in the workspace
+  database) used as the PostHog `distinct_id`, so installs are countable
+  but not identifiable.
+- Telemetry is on by default and can be disabled with
+  `telemetryEnabled: false`.
+- Every recorded event is mirrored to an open, inspectable JSONL log at
+  `<agentsDir>/.daemon/telemetry/events.jsonl`, so users can audit
+  exactly what was sent.
+
+Events recorded: `daemon.heartbeat` (every 5 minutes), the `inference.*`
+lifecycle (`route`, `execute`, `stream`, `fallback`), `llm.generate`
+(provider, latency, token and cost counts when reported, success — never
+prompt text), `session.start` / `session.end` (harness and prompt count),
+the lifecycle events `daemon.started`, `command.invoked`,
+`error.occurred` (sanitized crash report — truncated message with user
+paths stripped, top stack frames with home directories removed, uptime;
+plus rate-limited `EventLoopLag` reports with measured lag), and
+`version.upgraded`, `install.activated` (first daemon run of a new
+install — covers bun/desktop installs the npm postinstall ping never
+sees), and `config.snapshot` (first-run feature flags, embedding provider
+and model, local/remote inference mode, and configured harnesses). The
+per-install harness mix is queryable from `session.start.harness` events
+because they share the same anonymous `distinct_id`. `pipeline.embedding`
+(tokens, provider, sourceKind — memory capture / artifact index / recall /
+dreaming), and `dreaming.pass`
+(provider-reported input/output/cache tokens and cost per agentic
+pass). The remaining `pipeline.*` event types are declared
+for future use but not yet emitted.
+
 Release Download Stats
 ---
 

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -20,10 +20,12 @@ import {
 	type PipelineSynthesisConfig,
 	buildArchitectureDoc,
 	identityModeManagesFiles,
+	isLocalInferenceEndpoint,
 	loadConfiguredHarnesses,
 	loadIdentityMode,
 	loadSourcesConfig,
 	normalizeAgentRosterEntry,
+	parseRoutingConfig,
 	parseRoutingTargetRef,
 	parseSimpleYaml,
 	resolveDefaultBasePath,
@@ -81,6 +83,7 @@ import { stopModelRegistry } from "./pipeline/model-registry";
 import { configureLlmConcurrency } from "./pipeline/provider";
 import { type ReflectionWorkerHandle, startReflectionWorker } from "./pipeline/reflection-worker";
 import { startReconciler } from "./pipeline/skill-reconciler";
+import { isRemotePipelineProviderForEndpoint } from "./provider-safety";
 import { logFdSnapshot, startEventLoopMonitor, startFdPollMonitor, stopResourceMonitors } from "./resource-monitor";
 import {
 	AGENTS_DIR,
@@ -138,6 +141,7 @@ import { runStartupRecovery } from "./startup-recovery";
 import { reportStartupGrace } from "./system-pressure";
 import {
 	type TelemetryCollector,
+	type TelemetryConfigSnapshot,
 	createTelemetryCollector,
 	defaultTelemetryLogPath,
 	sanitizeCrashError,
@@ -1324,6 +1328,65 @@ function syncAgentRoster(agentsDir: string): void {
 	logger.info("daemon", "Agent roster synced", { count: roster.length });
 }
 
+const LOCAL_INFERENCE_EXECUTORS = new Set(["none", "llama-cpp", "ollama"]);
+const INFERENCE_CONFIG_FILES = ["agent.yaml", "AGENT.yaml"] as const;
+
+function targetIsRemote(target: {
+	readonly executor: string;
+	readonly endpoint?: string;
+	readonly privacy?: string;
+}): boolean {
+	if (target.privacy === "local_only") return false;
+	if (target.executor === "openai-compatible") return !isLocalInferenceEndpoint(target.endpoint);
+	return !LOCAL_INFERENCE_EXECUTORS.has(target.executor);
+}
+
+function configuredInferenceMode(agentsDir: string, memoryCfg: ResolvedMemoryConfig): "local" | "remote" {
+	const legacyRemote = [
+		[memoryCfg.pipelineV2.extraction.provider, memoryCfg.pipelineV2.extraction.endpoint],
+		[memoryCfg.pipelineV2.synthesis.provider, memoryCfg.pipelineV2.synthesis.endpoint],
+	].some(([provider, endpoint]) => isRemotePipelineProviderForEndpoint(provider, endpoint));
+
+	for (const name of INFERENCE_CONFIG_FILES) {
+		const path = join(agentsDir, name);
+		if (!existsSync(path)) continue;
+		try {
+			const routing = parseRoutingConfig(parseSimpleYaml(readFileSync(path, "utf-8")));
+			if (routing.ok && routing.value.enabled) {
+				const bindings = Object.values(routing.value.workloads ?? {});
+				const refs = bindings.flatMap((binding) => (binding?.target ? [binding.target] : []));
+				const targets =
+					refs.length > 0
+						? refs.flatMap((ref) => {
+								const parsed = parseRoutingTargetRef(ref);
+								const target = parsed.ok ? routing.value.targets[parsed.value.targetId] : undefined;
+								return target ? [target] : [];
+							})
+						: Object.values(routing.value.targets);
+				return targets.some((target) => targetIsRemote(target)) ? "remote" : "local";
+			}
+		} catch {
+			// Fall through to the resolved legacy pipeline configuration.
+		}
+		break;
+	}
+
+	return legacyRemote ? "remote" : "local";
+}
+
+function buildTelemetryConfigSnapshot(agentsDir: string, memoryCfg: ResolvedMemoryConfig): TelemetryConfigSnapshot {
+	return {
+		graphEnabled: memoryCfg.pipelineV2.graph.enabled,
+		rerankerEnabled: memoryCfg.pipelineV2.reranker.enabled,
+		autonomousEnabled: memoryCfg.pipelineV2.autonomous.enabled,
+		semanticContradictionEnabled: memoryCfg.pipelineV2.semanticContradictionEnabled,
+		embeddingProvider: memoryCfg.embedding.provider,
+		embeddingModel: memoryCfg.embedding.model,
+		inferenceMode: configuredInferenceMode(agentsDir, memoryCfg),
+		harnesses: [...new Set(loadConfiguredHarnesses(agentsDir))].sort().join(","),
+	};
+}
+
 async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?: TelemetryCollector): Promise<void> {
 	const pipelinePaused = memoryCfg.pipelineV2.paused;
 	logger.info("dreaming", "Dreaming owns all semantic writes; legacy extraction is retired");
@@ -1965,6 +2028,7 @@ async function main() {
 		};
 		telemetryCollector = createTelemetryCollector(getDbAccessor(), resolvedTelemetryCfg, CURRENT_VERSION, {
 			telemetryLogPath: defaultTelemetryLogPath(AGENTS_DIR),
+			configSnapshot: buildTelemetryConfigSnapshot(AGENTS_DIR, memoryCfg),
 		});
 		telemetryCollector.start();
 		telemetryRef = telemetryCollector;

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -17,6 +17,7 @@ import { type DbAccessor, closeDbAccessor, getDbAccessor, initDbAccessor } from 
 import {
 	TELEMETRY_EVENTS,
 	type TelemetryCollector,
+	type TelemetryConfigSnapshot,
 	createTelemetryCollector,
 	defaultTelemetryLogPath,
 	nextFlushIntervalMs,
@@ -67,8 +68,8 @@ function resetWorkspace(): void {
 	initDbAccessor(join(dir, "memory", "memories.db"));
 }
 
-function makeCollector(): TelemetryCollector {
-	return createTelemetryCollector(getDbAccessor(), TELEMETRY_CONFIG, "0.0.0-test");
+function makeCollector(configSnapshot?: TelemetryConfigSnapshot): TelemetryCollector {
+	return createTelemetryCollector(getDbAccessor(), TELEMETRY_CONFIG, "0.0.0-test", { configSnapshot });
 }
 
 /**
@@ -76,7 +77,7 @@ function makeCollector(): TelemetryCollector {
  * withWriteTx/withReadDb there, and posthogHost is "" so nothing sends.
  */
 function fakeDbAccessor(): DbAccessor {
-	const stmt = { run: () => ({}), get: () => undefined, all: () => [] };
+	const stmt = { run: () => ({ changes: 1 }), get: () => undefined, all: () => [] };
 	return {
 		withWriteTx: (fn: (db: { prepare(sql: string): typeof stmt }) => unknown) => fn({ prepare: () => stmt }),
 		withReadDb: (fn: (db: { prepare(sql: string): typeof stmt }) => unknown) => fn({ prepare: () => stmt }),
@@ -314,6 +315,42 @@ describe("telemetry collector", () => {
 		expect(lastBatch.map((e) => e.event)).toEqual(["daemon.heartbeat"]);
 	});
 
+	it("emits one config snapshot alongside install activation", async () => {
+		const snapshot: TelemetryConfigSnapshot = {
+			graphEnabled: true,
+			rerankerEnabled: false,
+			autonomousEnabled: true,
+			semanticContradictionEnabled: true,
+			embeddingProvider: "native",
+			embeddingModel: "nomic-embed-text-v1.5",
+			inferenceMode: "local",
+			harnesses: "codex,hermes-agent",
+		};
+		const first = makeCollector(snapshot);
+		first.record("daemon.heartbeat", { uptimeMs: 1 });
+		await first.flush();
+
+		const firstBatch = captured[0]?.body.batch ?? [];
+		expect(firstBatch.map((event) => event.event)).toEqual([
+			"install.activated",
+			"config.snapshot",
+			"daemon.heartbeat",
+		]);
+		expect(firstBatch[1]?.properties).toMatchObject({
+			graphEnabled: true,
+			rerankerEnabled: false,
+			embeddingProvider: "native",
+			embeddingModel: "nomic-embed-text-v1.5",
+			inferenceMode: "local",
+			harnesses: "codex,hermes-agent",
+		});
+
+		const second = makeCollector(snapshot);
+		second.record("daemon.heartbeat", { uptimeMs: 2 });
+		await second.flush();
+		expect(captured[1]?.body.batch.map((event) => event.event)).toEqual(["daemon.heartbeat"]);
+	});
+
 	it("sanitizes crash reports: truncation, home-path stripping, frame cap", () => {
 		const longMessage =
 			'SQLiteError: database is locked near "a very long embedded fragment that goes on and on" at /home/alice/.agents/memory/memories.db'.repeat(
@@ -347,7 +384,7 @@ describe("telemetry collector", () => {
 	});
 
 	it("degrades non-Error rejections to a truncated string", () => {
-		const props = sanitizeCrashError("oops: " + "x".repeat(500), 42);
+		const props = sanitizeCrashError(`oops: ${"x".repeat(500)}`, 42);
 		expect(props.type).toBe("UnhandledRejection");
 		expect(props.message.length).toBeLessThanOrEqual(400);
 		expect(props.uptimeMs).toBe(42);

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -80,6 +80,7 @@ export const TELEMETRY_EVENTS = [
 	"cloud.sync",
 	"cloud.storage",
 	"recall.performed",
+	"config.snapshot",
 ] as const;
 
 export type TelemetryEventType = (typeof TELEMETRY_EVENTS)[number];
@@ -91,6 +92,17 @@ export type TelemetryEventType = (typeof TELEMETRY_EVENTS)[number];
 export type FirstUseKind = "remember" | "recall";
 
 export type TelemetryProperties = Readonly<Record<string, string | number | boolean | null>>;
+
+export interface TelemetryConfigSnapshot {
+	readonly graphEnabled: boolean;
+	readonly rerankerEnabled: boolean;
+	readonly autonomousEnabled: boolean;
+	readonly semanticContradictionEnabled: boolean;
+	readonly embeddingProvider: string;
+	readonly embeddingModel: string;
+	readonly inferenceMode: "local" | "remote";
+	readonly harnesses: string;
+}
 
 export interface TelemetryEvent {
 	readonly id: string;
@@ -172,23 +184,25 @@ export function telemetryDisabledByEnv(env: NodeJS.ProcessEnv = process.env): bo
  */
 function getOrCreateInstallId(db: DbAccessor): { readonly id: string; readonly created: boolean } {
 	try {
-		const existing = db.withReadDb((r) => {
-			const row = r.prepare("SELECT id FROM telemetry_install ORDER BY created_at ASC LIMIT 1").get() as
+		return db.withWriteTx((w) => {
+			const existing = w.prepare("SELECT id FROM telemetry_install ORDER BY created_at ASC LIMIT 1").get() as
 				| { readonly id: string }
 				| null
 				| undefined;
-			return row?.id ?? null;
-		});
-		if (existing != null) return { id: existing, created: false };
+			if (existing?.id) return { id: existing.id, created: false };
 
-		const id = crypto.randomUUID();
-		db.withWriteTx((w) => {
-			w.prepare("INSERT OR IGNORE INTO telemetry_install (id, created_at) VALUES (?, ?)").run(
-				id,
-				new Date().toISOString(),
-			);
+			const id = crypto.randomUUID();
+			const result = w
+				.prepare("INSERT OR IGNORE INTO telemetry_install (id, created_at) VALUES (?, ?)")
+				.run(id, new Date().toISOString());
+			if (result.changes > 0) return { id, created: true };
+
+			const inserted = w.prepare("SELECT id FROM telemetry_install ORDER BY created_at ASC LIMIT 1").get() as
+				| { readonly id: string }
+				| null
+				| undefined;
+			return inserted?.id ? { id: inserted.id, created: false } : { id, created: false };
 		});
-		return { id, created: true };
 	} catch {
 		return { id: crypto.randomUUID(), created: false };
 	}
@@ -216,7 +230,11 @@ function stripUserPaths(text: string): string {
 }
 
 function sanitizeCrashText(value: string): string {
-	return stripUserPaths(value.replace(/[\x00-\x1f\x7f]/g, " ")).slice(0, MAX_CRASH_MESSAGE_CHARS);
+	const cleaned = Array.from(value, (char) => {
+		const code = char.charCodeAt(0);
+		return code <= 0x1f || code === 0x7f ? " " : char;
+	}).join("");
+	return stripUserPaths(cleaned).slice(0, MAX_CRASH_MESSAGE_CHARS);
 }
 
 function crashStackFrames(stack: string | undefined): string[] | undefined {
@@ -335,7 +353,10 @@ export function createTelemetryCollector(
 	db: DbAccessor,
 	config: PipelineTelemetryConfig,
 	daemonVersion: string,
-	opts: { readonly telemetryLogPath?: string | null } = {},
+	opts: {
+		readonly telemetryLogPath?: string | null;
+		readonly configSnapshot?: TelemetryConfigSnapshot;
+	} = {},
 ): TelemetryCollector {
 	const buffer: TelemetryEvent[] = [];
 	const logPath = opts.telemetryLogPath ?? null;
@@ -628,6 +649,9 @@ export function createTelemetryCollector(
 			version: daemonVersion,
 			platform: process.platform,
 		});
+		if (opts.configSnapshot) {
+			collector.record("config.snapshot", { ...opts.configSnapshot });
+		}
 	}
 
 	return collector;


### PR DESCRIPTION
## Summary

Adds the first-run configuration snapshot requested by #1204 so Signet can measure feature configuration, embedding setup, inference mode, and harness configuration per anonymous install.

Closes #1204.

## Changes

- Added the `config.snapshot` telemetry event, emitted once alongside `install.activated`.
- Made telemetry install identity creation atomic so concurrent first starts cannot duplicate the snapshot.
- Captures graph, reranker, autonomous, and semantic contradiction flags; embedding provider/model; local/remote inference mode; and sorted configured harness names.
- Uses the daemon's canonical `agent.yaml` / `AGENT.yaml` routing configuration and falls back to resolved legacy pipeline providers.
- Preserved primitive-only telemetry properties and excludes memory content, identity, paths, endpoints, prompts, and credentials.
- Documented the event and per-install harness querying through shared `distinct_id` values.
- Added telemetry regression coverage for exactly-once snapshot emission.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `docs/ANALYTICS.md`

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no schema migration.

## Testing

- [ ] `bun test` passes — the repository-wide command includes third-party reference suites; the affected telemetry suite passes independently.
- [x] `bun test platform/daemon/src/telemetry.test.ts` passes: 15 passed, 0 failed.
- [x] `bun run typecheck` passes.
- [ ] `bun run lint` passes — the clean base currently reports 546 pre-existing formatting diagnostics across unrelated files; all touched TypeScript files pass Biome.
- [x] `bun run build` passes.
- [x] Tested against running daemon in an isolated temporary workspace: health returned 200 and the JSONL log contained `install.activated`, `config.snapshot`, and `daemon.started`.
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The config snapshot contains configuration names and boolean/provider metadata only. Harness usage remains queryable from `session.start.harness` events grouped by the same anonymous `distinct_id`.