### PR TITLE
fix(telemetry): tag development installs

### DIFF
--- a/dist/signetai/scripts/install-native.js
+++ b/dist/signetai/scripts/install-native.js
@@ -36,6 +36,16 @@ const TELEMETRY_API_KEY = "phc_mLsvJmbmp6e9UarrX9Cq5QtTjVNiiphM9mvi5Xnddd8Q"; //
 const TELEMETRY_TIMEOUT_MS = 2000;
 const pendingPings = [];
 
+function telemetryDeployment() {
+	return process.env.SIGNET_TELEMETRY_ENV?.trim().toLowerCase() === "dev" ? "dev" : undefined;
+}
+
+function telemetryReportedVersion(version) {
+	const deployment = telemetryDeployment();
+	if (deployment !== "dev" || version.endsWith("-dev")) return version;
+	return `${version}-dev`;
+}
+
 function telemetryEnabled() {
 	if (process.env.SIGNET_TELEMETRY_OPTOUT === "1" || process.env.SIGNET_TELEMETRY_OPTOUT === "true") {
 		return false;
@@ -56,8 +66,9 @@ function fireInstallPing(platform) {
 				distinct_id: require("node:crypto").randomUUID(),
 				timestamp: new Date().toISOString(),
 				properties: {
-					version: nativePackageVersion(),
+					version: telemetryReportedVersion(nativePackageVersion()),
 					platform,
+					...(telemetryDeployment() ? { deployment: telemetryDeployment() } : {}),
 					$lib: "signet-install",
 				},
 			},

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1156,6 +1156,15 @@ uptime), `command.invoked` (command name only, never arguments),
 stripped, top stack frames with home directories removed, uptime, and
 rate-limited `EventLoopLag` reports with measured lag), `version.upgraded`
 (from, to).
+
+**Development fleet marker:** setting `SIGNET_TELEMETRY_ENV=dev` keeps operator
+development checkouts in the dataset while making them filterable. The daemon
+adds `deployment: dev` to its local and PostHog events, while the CLI adds it
+to its JSONL-only command events. The native install ping applies the marker
+and `-dev` version suffix when the environment is present. The daemon and CLI
+`bun run dev` scripts set this marker automatically. The marker does not
+disable telemetry; use `SIGNET_TELEMETRY_OPTOUT=1` when development or
+automated events should be silenced entirely.
 | Field | Default | Range | Description |
 |-------|---------|-------|-------------|
 | `posthogHost` | `https://us.i.posthog.com` | — | PostHog instance URL (empty disables) |

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -187,6 +187,15 @@ knob for the whole product. CI runners, containers, and scripted
 environments should set it so automated daemon boots don't count as
 installs.
 
+**Development fleet marker:** `SIGNET_TELEMETRY_ENV=dev` adds
+`deployment: dev` to daemon events sent to PostHog and the local audit log,
+to CLI `command.invoked` events in that same log, and to native install pings
+when the environment is present. Daemon and install-ping version fields report
+the library version with a `-dev` suffix. The daemon and CLI `bun run dev`
+scripts set this marker automatically; direct source launches can set it
+explicitly. The marker is not an opt-out. `SIGNET_TELEMETRY_OPTOUT=1` or
+`true` silences daemon, CLI, and install-ping telemetry.
+
 **Disclosure:** `signet setup` tells users telemetry is on by default and
 asks whether to disable it. Declining writes `telemetryEnabled: false`;
 non-interactive/CI setups keep the default (enabled).
@@ -211,11 +220,11 @@ it is never flushed to PostHog.
   default and remote rates come from `embedding.costRates` (#1201).
 - `install.ping` and `install.activated` measure different populations —
   report them as complementary, never summed.
-- CI and dev fleets inflate "user" counts: every automated daemon boot with
-  default config is a phantom install. Identify them as `daemon.started`
-  without a matching `install.ping`, and set `SIGNET_TELEMETRY_OPTOUT=1` in
-  workflows. Dev-install tagging (`SIGNET_TELEMETRY_ENV=dev`) is under
-  discussion (#1200).
+- CI and dev fleets can inflate "user" counts: every automated daemon boot
+  with default config is a phantom install. Identify CI as
+  `daemon.started` without a matching `install.ping`, set
+  `SIGNET_TELEMETRY_OPTOUT=1` in workflows, and set
+  `SIGNET_TELEMETRY_ENV=dev` for operator-owned development checkouts.
 - Flush cadence is the configured interval (default 60s); a freshly started
   daemon takes up to a minute to appear in PostHog.
 

--- a/platform/daemon/package.json
+++ b/platform/daemon/package.json
@@ -27,7 +27,7 @@
     "build": "bun run prebuild && bun run build.ts && bun run build:dashboard",
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
     "typecheck": "tsc --noEmit",
-    "dev": "bun --watch src/daemon.ts",
+    "dev": "bun --watch src/dev-daemon.ts",
     "start": "cd ../core && bun run build && cd ../daemon && bun src/daemon.ts",
     "install:service": "bun src/daemon.ts --install",
     "uninstall:service": "bun src/daemon.ts --uninstall",

--- a/platform/daemon/src/dev-daemon.ts
+++ b/platform/daemon/src/dev-daemon.ts
@@ -1,0 +1,6 @@
+export {};
+
+process.env.SIGNET_TELEMETRY_ENV ||= "dev";
+process.env.SIGNET_DAEMON_ENTRYPOINT ||= "1";
+
+await import("./daemon");

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -22,7 +22,9 @@ import {
 	defaultTelemetryLogPath,
 	nextFlushIntervalMs,
 	sanitizeCrashError,
+	telemetryDeployment,
 	telemetryDisabledByEnv,
+	telemetryReportedVersion,
 } from "./telemetry";
 import { cleanupTestTempDir, createTestTempDir } from "./test-temp-dir";
 
@@ -427,6 +429,46 @@ describe("telemetry collector", () => {
 		expect(telemetryDisabledByEnv({ SIGNET_TELEMETRY_OPTOUT: "1" })).toBe(true);
 		expect(telemetryDisabledByEnv({ SIGNET_TELEMETRY_OPTOUT: "true" })).toBe(true);
 		expect(telemetryDisabledByEnv({ SIGNET_TELEMETRY_OPTOUT: "0" })).toBe(false);
+	});
+
+	it("tags development telemetry and marks its reported version", async () => {
+		expect(telemetryDeployment({})).toBeUndefined();
+		expect(telemetryDeployment({ SIGNET_TELEMETRY_ENV: "DEV" })).toBe("dev");
+		expect(telemetryDeployment({ SIGNET_TELEMETRY_ENV: "production" })).toBeUndefined();
+		expect(telemetryReportedVersion("0.176.8", "dev")).toBe("0.176.8-dev");
+		expect(telemetryReportedVersion("0.176.8-dev", "dev")).toBe("0.176.8-dev");
+
+		const collector = createTelemetryCollector(getDbAccessor(), TELEMETRY_CONFIG, "0.176.8", {
+			env: { SIGNET_TELEMETRY_ENV: "dev" },
+			telemetryLogPath: logPath,
+		});
+		collector.record("daemon.started", { version: "0.176.8", platform: process.platform });
+		await collector.flush();
+
+		const batch = captured[0]?.body.batch ?? [];
+		expect(batch).toHaveLength(2);
+		for (const event of batch) {
+			expect(event.properties.deployment).toBe("dev");
+			expect(event.properties.$lib_version).toBe("0.176.8-dev");
+		}
+		expect(batch[0]?.properties.version).toBe("0.176.8-dev");
+		expect(batch[1]?.properties.version).toBe("0.176.8-dev");
+
+		const lines = readFileSync(logPath, "utf-8").trim().split("\n");
+		for (const line of lines) {
+			expect((JSON.parse(line) as { properties: { deployment: string } }).properties.deployment).toBe("dev");
+		}
+	});
+
+	it("marks both sides of development upgrade events", async () => {
+		const collector = createTelemetryCollector(getDbAccessor(), TELEMETRY_CONFIG, "0.176.8", {
+			env: { SIGNET_TELEMETRY_ENV: "dev" },
+		});
+		collector.record("version.upgraded", { from: "0.176.6", to: "0.176.8" });
+		await collector.flush();
+		const [event] = collector.query({ event: "version.upgraded" });
+		expect(event?.properties.from).toBe("0.176.6-dev");
+		expect(event?.properties.to).toBe("0.176.8-dev");
 	});
 
 	it("backs off after three consecutive PostHog failures", () => {

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -233,6 +233,25 @@ export function telemetryDisabledByEnv(env: NodeJS.ProcessEnv = process.env): bo
 	return env.SIGNET_TELEMETRY_OPTOUT === "1" || env.SIGNET_TELEMETRY_OPTOUT === "true";
 }
 
+export type TelemetryDeployment = "dev";
+
+/**
+ * Resolve the optional deployment marker used to separate operator-owned
+ * development checkouts from production installs in PostHog.
+ */
+export function telemetryDeployment(env: NodeJS.ProcessEnv = process.env): TelemetryDeployment | undefined {
+	return env.SIGNET_TELEMETRY_ENV?.trim().toLowerCase() === "dev" ? "dev" : undefined;
+}
+
+/**
+ * Keep development builds visible in version breakdowns without changing the
+ * daemon's operational version or update behavior.
+ */
+export function telemetryReportedVersion(version: string, deployment: TelemetryDeployment | undefined): string {
+	if (deployment !== "dev" || version.endsWith("-dev")) return version;
+	return `${version}-dev`;
+}
+
 /**
  * Resolve the anonymous per-install identifier, creating and persisting it on
  * first use. Falls back to an in-memory id if the database is unusable.
@@ -424,10 +443,13 @@ export function createTelemetryCollector(
 	opts: {
 		readonly telemetryLogPath?: string | null;
 		readonly configSnapshot?: TelemetryConfigSnapshot;
+		readonly env?: NodeJS.ProcessEnv;
 	} = {},
 ): TelemetryCollector {
 	const buffer: TelemetryEvent[] = [];
 	const logPath = opts.telemetryLogPath ?? null;
+	const deployment = telemetryDeployment(opts.env);
+	const reportedVersion = telemetryReportedVersion(daemonVersion, deployment);
 	let flushTimer: ReturnType<typeof setTimeout> | null = null;
 	let running = false;
 	let consecutiveFailures = 0;
@@ -462,6 +484,18 @@ export function createTelemetryCollector(
 		} catch {
 			return false;
 		}
+	}
+
+	function addContext(properties: TelemetryProperties): TelemetryProperties {
+		return {
+			...properties,
+			...(deployment ? { deployment } : {}),
+			...(typeof properties.version === "string"
+				? { version: telemetryReportedVersion(properties.version, deployment) }
+				: {}),
+			...(typeof properties.from === "string" ? { from: telemetryReportedVersion(properties.from, deployment) } : {}),
+			...(typeof properties.to === "string" ? { to: telemetryReportedVersion(properties.to, deployment) } : {}),
+		};
 	}
 
 	function writeToDb(events: readonly TelemetryEvent[]): void {
@@ -581,7 +615,7 @@ export function createTelemetryCollector(
 					config.posthogApiKey,
 					installId,
 					claimed.events,
-					daemonVersion,
+					reportedVersion,
 				);
 				if (ok) {
 					markSent(claimed.token);
@@ -700,7 +734,7 @@ export function createTelemetryCollector(
 				id: crypto.randomUUID(),
 				event,
 				timestamp: new Date().toISOString(),
-				properties: enrichSessionEvent(event, properties),
+				properties: addContext(enrichSessionEvent(event, properties)),
 			});
 
 			// Open telemetry log (issue #1026 Phase 2): mirror every event to
@@ -820,7 +854,7 @@ export function createTelemetryCollector(
 	// postinstall ping never fires for bun global or desktop installs).
 	if (installActivated) {
 		collector.record("install.activated", {
-			version: daemonVersion,
+			version: reportedVersion,
 			platform: process.platform,
 		});
 		if (opts.configSnapshot) {

--- a/scripts/install-copy-regression.test.ts
+++ b/scripts/install-copy-regression.test.ts
@@ -116,6 +116,8 @@ describe("install copy", () => {
 
 		// Homebrew-style opt-out: one env var disables the ping entirely.
 		expect(installer).toContain("SIGNET_TELEMETRY_OPTOUT");
+		expect(installer).toContain("SIGNET_TELEMETRY_ENV");
+		expect(installer).toContain("telemetryReportedVersion(nativePackageVersion())");
 
 		// The ping must never block or fail the install: it is fire-and-forget
 		// with a bounded timeout, and errors are swallowed.

--- a/surfaces/cli/package.json
+++ b/surfaces/cli/package.json
@@ -18,7 +18,7 @@
     "build:workspace-deps": "cd ../.. && bun run build:core && bun run build:connector-base && bun run build:opencode-plugin && bun run build:oh-my-pi-extension && bun run build:connector-oh-my-pi && bun run build:pi-extension && bun run build:connector-pi && bun run --filter '@signet/connector-claude-code' --filter '@signet/connector-codex' --filter '@signet/connector-forge' --filter '@signet/connector-gemini' --filter '@signet/connector-hermes-agent' --filter '@signet/connector-opencode' --filter '@signet/connector-openclaw' build",
     "build:cli": "bun build ./src/cli.ts --outfile ./dist/cli.js --target node --external better-sqlite3",
     "build:dashboard": "cd ../dashboard && bun install && bun run build",
-    "dev": "bun --watch src/cli.ts",
+    "dev": "bun --watch src/dev-cli.ts",
     "dev:dashboard": "cd ../dashboard && bun run dev",
     "copy:skills": "rm -rf skills && cp -r ../../skills skills",
     "prebuild": "bun run build:workspace-deps && bun run copy:skills",

--- a/surfaces/cli/src/dev-cli.ts
+++ b/surfaces/cli/src/dev-cli.ts
@@ -1,0 +1,5 @@
+export {};
+
+process.env.SIGNET_TELEMETRY_ENV ||= "dev";
+
+await import("./cli");

--- a/surfaces/cli/src/features/telemetry.test.ts
+++ b/surfaces/cli/src/features/telemetry.test.ts
@@ -3,7 +3,13 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createDatabase } from "../sqlite";
-import { cliTelemetryEnabled, cliTelemetryLogPath, flushCliTelemetry, recordCommandInvoked } from "./telemetry";
+import {
+	cliTelemetryDeployment,
+	cliTelemetryEnabled,
+	cliTelemetryLogPath,
+	flushCliTelemetry,
+	recordCommandInvoked,
+} from "./telemetry";
 
 let dir = "";
 const originalFetch = globalThis.fetch;
@@ -64,6 +70,24 @@ describe("cli telemetry (issue #1206)", () => {
 		};
 		expect(line.event).toBe("command.invoked");
 		expect(line.properties.command).toBe("remember");
+	});
+
+	it("tags development command events", () => {
+		writeAgentYaml(true);
+		expect(cliTelemetryDeployment({})).toBeUndefined();
+		expect(cliTelemetryDeployment({ SIGNET_TELEMETRY_ENV: "DEV" })).toBe("dev");
+		recordCommandInvoked(dir, "remember", { SIGNET_TELEMETRY_ENV: "dev" });
+		const line = JSON.parse(readFileSync(cliTelemetryLogPath(dir), "utf-8").trim()) as {
+			properties: { deployment: string };
+		};
+		expect(line.properties.deployment).toBe("dev");
+	});
+
+	it("honors the runtime telemetry opt-out", () => {
+		writeAgentYaml(true);
+		expect(cliTelemetryEnabled(dir, { SIGNET_TELEMETRY_OPTOUT: "1" })).toBe(false);
+		recordCommandInvoked(dir, "remember", { SIGNET_TELEMETRY_OPTOUT: "true" });
+		expect(existsSync(cliTelemetryLogPath(dir))).toBe(false);
 	});
 
 	it("does not write anything when telemetry is disabled", () => {

--- a/surfaces/cli/src/features/telemetry.ts
+++ b/surfaces/cli/src/features/telemetry.ts
@@ -54,6 +54,16 @@ function createTelemetryDatabase(dbPath: string): ReturnType<typeof createDataba
 	return db;
 }
 
+export type CliTelemetryDeployment = "dev";
+
+export function cliTelemetryDeployment(env: NodeJS.ProcessEnv = process.env): CliTelemetryDeployment | undefined {
+	return env.SIGNET_TELEMETRY_ENV?.trim().toLowerCase() === "dev" ? "dev" : undefined;
+}
+
+function cliTelemetryDisabledByEnv(env: NodeJS.ProcessEnv): boolean {
+	return env.SIGNET_TELEMETRY_OPTOUT === "1" || env.SIGNET_TELEMETRY_OPTOUT === "true";
+}
+
 /**
  * Resolve the shared open-telemetry log path, mirroring the daemon's
  * `defaultTelemetryLogPath` (issue #1026).
@@ -62,11 +72,11 @@ export function cliTelemetryLogPath(agentsDir: string): string {
 	return join(agentsDir, ".daemon", "telemetry", "events.jsonl");
 }
 
-function readTelemetrySettings(agentsDir: string): CliTelemetrySettings | null {
+function readTelemetrySettings(agentsDir: string, env: NodeJS.ProcessEnv = process.env): CliTelemetrySettings | null {
 	try {
 		const yamlPath = join(agentsDir, "agent.yaml");
 		if (!existsSync(yamlPath)) return null;
-		if (process.env.SIGNET_TELEMETRY_OPTOUT === "1" || process.env.SIGNET_TELEMETRY_OPTOUT === "true") {
+		if (cliTelemetryDisabledByEnv(env)) {
 			return null;
 		}
 
@@ -97,8 +107,8 @@ function readTelemetrySettings(agentsDir: string): CliTelemetrySettings | null {
  * by default, so the flag is only false when agent.yaml is unavailable,
  * telemetry is explicitly disabled, or the runtime opt-out is set.
  */
-export function cliTelemetryEnabled(agentsDir: string): boolean {
-	return readTelemetrySettings(agentsDir)?.enabled === true;
+export function cliTelemetryEnabled(agentsDir: string, env: NodeJS.ProcessEnv = process.env): boolean {
+	return readTelemetrySettings(agentsDir, env)?.enabled === true;
 }
 
 function getOrCreateInstallId(db: ReturnType<typeof createDatabase>): string | null {
@@ -198,16 +208,21 @@ function markClaimedSent(db: ReturnType<typeof createDatabase>, token: string): 
  * Payload is the command name only. This function is synchronous for the
  * local write and never performs a network request.
  */
-export function recordCommandInvoked(agentsDir: string, commandName: string): void {
-	const settings = readTelemetrySettings(agentsDir);
+export function recordCommandInvoked(
+	agentsDir: string,
+	commandName: string,
+	env: NodeJS.ProcessEnv = process.env,
+): void {
+	const settings = readTelemetrySettings(agentsDir, env);
 	if (!settings) return;
 
 	try {
+		const deployment = cliTelemetryDeployment(env);
 		const event: QueuedEvent = {
 			id: randomUUID(),
 			event: TELEMETRY_EVENT,
 			timestamp: new Date().toISOString(),
-			properties: { command: commandName },
+			properties: { command: commandName, ...(deployment ? { deployment } : {}) },
 		};
 		const logPath = cliTelemetryLogPath(agentsDir);
 		mkdirSync(dirname(logPath), { recursive: true });


### PR DESCRIPTION
## Summary

Closes #1200. Local development checkouts now remain in telemetry while being filterable as development traffic, and the standard daemon/CLI development scripts set the marker automatically. Production behavior remains unchanged when the marker is absent.

## Changes

- Add the exact `SIGNET_TELEMETRY_ENV=dev` deployment marker to daemon events before they are persisted to SQLite, mirrored to JSONL, or sent to PostHog.
- Report daemon telemetry library versions with a `-dev` suffix without changing the operational daemon version or update behavior.
- Add cross-platform `src/dev-daemon.ts` and `src/dev-cli.ts` bootstrap entrypoints that default the marker without overriding an explicit environment value.
- Tag CLI `command.invoked` JSONL events at the CLI boundary, and make `SIGNET_TELEMETRY_OPTOUT=1|true` silence CLI telemetry as well as daemon telemetry.
- Update `docs/TELEMETRY.md` and `docs/CONFIGURATION.md` with the marker, opt-out, and JSONL/PostHog boundaries.

## Type

- [x] `fix` — bug fix / telemetry correctness

## Packages affected

- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/core`
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries (no user-data queries or agent scopes changed)
- [x] Input/config validation and bounds checks added (marker is an exact fixed value; unknown values are ignored)
- [x] Error handling and fallback paths tested (no silent swallow) — telemetry remains best-effort; opt-out and missing-workspace paths are covered
- [x] Security checks applied to admin/mutation endpoints (n/a — telemetry metadata only)
- [x] Docs updated for API/spec/status changes (`docs/TELEMETRY.md`, `docs/CONFIGURATION.md`)
- [x] Regression tests added for each bug fix (daemon and CLI marker/opt-out coverage)
- [x] Lint/typecheck/tests pass locally (daemon/CLI/install focused suites and typechecks pass; three pre-existing Biome diagnostics in unchanged sanitizer/test lines are noted below)

## Testing

- [x] `bun test --max-concurrency=1 platform/daemon/src/telemetry.test.ts` — 18/18 pass
- [x] `bun test --max-concurrency=1 surfaces/cli/src/features/telemetry.test.ts` — 9/9 pass
- [x] `bun test --max-concurrency=1 scripts/install-copy-regression.test.ts` — 6/6 pass
- [x] `bun run --filter '@signet/daemon' build` — pass
- [x] `bun run --filter '@signet/daemon' typecheck` — pass
- [x] `bun run --filter '@signet/cli' build:cli` — pass
- [x] `bun run typecheck` — full workspace pass
- [x] `bunx biome check` on new/changed lines — pass; three pre-existing diagnostics remain in unchanged sanitizer/test lines
- [ ] `bun run lint` — fails on pre-existing repository-wide Biome drift (549 errors / 154 warnings); no new formatter/lint finding remains in the added wrapper, install-ping, CLI, or upgrade-marker lines
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Review notes

- The adversarial review found and this follow-up fixed two real defects: the first dev wrapper did not set `SIGNET_DAEMON_ENTRYPOINT=1`, so it never served, and `version.upgraded` `from`/`to` fields bypassed the `-dev` suffix. The review also identified the install-ping boundary, which is now tagged and regression-covered. A scratch `bun run dev` probe returned HTTP 200 with operational version `0.176.11`.
- The review verified production JSONL events without `deployment`, development SQLite/JSONL events with `deployment: dev` and `-dev` versions, daemon opt-out, CLI dev tagging, and CLI opt-out. Its separate live PostHog interception attempt timed out; the focused collector batch test covers the send path.
- The repository's `bun scripts/doc-drift.ts` baseline remains red on unrelated route, migration, and package-table drift.
