### PR TITLE
fix(dreaming): format pass summaries as Markdown

### DIFF
--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -832,6 +832,18 @@ describe("Dreaming", () => {
 		expect(contentPrompt).not.toContain("Process ALL pending hygiene records");
 	});
 
+	it("requires bounded Markdown runbook summaries in every pass mode (#1226)", () => {
+		for (const prompt of [DREAMING_AGENT_PROMPT, DREAMING_HYGIENE_AGENT_PROMPT, DREAMING_CONTENT_AGENT_PROMPT]) {
+			expect(prompt).toContain("write Markdown");
+			expect(prompt).toContain("max 2000 chars");
+			expect(prompt).toContain("## sections");
+			expect(prompt).toContain("bullet lists");
+			expect(prompt).toContain("deferred and openQuestions fields");
+			expect(prompt).not.toContain("No bullet lists");
+			expect(prompt).not.toContain("natural-language prose");
+		}
+	});
+
 	it("does not advance the evidence watermark for hygiene-only work (#1098)", async () => {
 		// Regression for #1098: a pass that only processed hygiene used to
 		// reset the evidence cursor anyway, so the unprocessed episodic

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -700,7 +700,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - The evidence source and the graph target must use the same agent scope: search evidence with the agentId of the entity you will update, then pass that same agentId to apply_ontology_ops. A source found in another scope cannot support a write here.
    - create_entity only for durable subjects clearly established by the source.
    - Validate before writing (validate_proposal).
-5. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write natural-language prose — what was examined (attention state, sources), what changed (mutations by type and count, entities touched), why (the dominant reason driving the work), and what was deferred or left flagged and why. No bullet lists, no tool names; a few clear sentences. Put deferred items and open questions in the runbook's deferred and openQuestions fields, not only in the summary.
+5. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write Markdown, max 2000 chars, with ## sections and bullet lists where useful. Cover what was examined (attention state, sources), what changed (mutations by type and count, entities touched), why (the dominant reason driving the work), and what was deferred or left flagged and why. Put deferred items and open questions in the runbook's deferred and openQuestions fields as well.
 
 ### What counts as durable
 
@@ -758,7 +758,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - Archive or merge it, citing its attention id (provenance: "attention:<uuid>", or attention:$<index> for a flag you minted in the same batch).
    - If you discover junk the queue did not flag, mint a flag op and archive in the same batch.
    - If you inspect a flagged target and judge it should stay as it is (a deliberate keep — e.g. a live entity with a non-concrete type, or an over-cap aspect you chose not to consolidate), close the record with decline_attention citing its attention id. Declining is an affirmative judgment: only decline records you actually inspected, and never decline records you could not complete this pass — defer those with a named blocker instead.
-3. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write natural-language prose — what was examined, what changed (mutations by type and count, entities touched), why (the dominant reason driving the work), and what was deferred or left flagged and why. No bullet lists, no tool names; a few clear sentences. Put deferred items and open questions in the runbook's deferred and openQuestions fields, not only in the summary.
+3. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write Markdown, max 2000 chars, with ## sections and bullet lists where useful. Cover what was examined, what changed (mutations by type and count, entities touched), why (the dominant reason driving the work), and what was deferred or left flagged and why. Put deferred items and open questions in the runbook's deferred and openQuestions fields as well.
 
 ### What counts as durable
 
@@ -816,7 +816,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - The evidence source and the graph target must use the same agent scope: search evidence with the agentId of the entity you will update, then pass that same agentId to apply_ontology_ops. A source found in another scope cannot support a write here.
    - create_entity only for durable subjects clearly established by the source.
    - Validate before writing (validate_proposal).
-4. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write natural-language prose — what was examined (sources viewed), what changed (claims filed or superseded, entities touched), why (what the evidence established), and what was deferred and why. No bullet lists, no tool names; a few clear sentences. Put deferred items and open questions in the runbook's deferred and openQuestions fields, not only in the summary.
+4. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write Markdown, max 2000 chars, with ## sections and bullet lists where useful. Cover what was examined (sources viewed), what changed (claims filed or superseded, entities touched), why (what the evidence established), and what was deferred and why. Put deferred items and open questions in the runbook's deferred and openQuestions fields as well.
 
 ### What counts as durable
 

--- a/surfaces/dashboard/src/views/dreaming.tsx
+++ b/surfaces/dashboard/src/views/dreaming.tsx
@@ -584,6 +584,20 @@ function splitMarkdownBlocks(text: string): ReadonlyArray<{
 	return blocks;
 }
 
+/** Plain one-line preview for ledger rows and native browser tooltips. */
+function markdownSummaryPreview(text: string): string {
+	const content = splitMarkdownBlocks(text)
+		.map((block) => (block.type === "list" ? (block.items ?? []).map((item) => item.text).join(" · ") : block.text))
+		.join(" ");
+	return content
+		.replace(/\*\*([^*]+)\*\*/g, "$1")
+		.replace(/\*([^*]+)\*/g, "$1")
+		.replace(/`([^`]+)`/g, "$1")
+		.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
 /* ── Live pass + tool trace ──────────────────────────────────────────────── */
 
 function LivePassPanel({
@@ -775,7 +789,7 @@ function PassLedger({ passes, onSelect }: { passes: DreamPass[]; onSelect: (p: D
 									"relative grid w-full cursor-pointer grid-cols-[5rem_4rem_4rem_4.5rem_4rem_5.5rem_minmax(0,1fr)_1rem] items-center gap-2 rounded-[6px] px-2 py-[5px] text-left transition-colors",
 									"hover:bg-white/[0.03]",
 								)}
-								title={p.summary ?? undefined}
+								title={p.summary ? markdownSummaryPreview(p.summary) : undefined}
 							>
 								{/* Latest pass gets a blue accent bar — it's the active reference row. */}
 								{idx === 0 && (
@@ -794,7 +808,7 @@ function PassLedger({ passes, onSelect }: { passes: DreamPass[]; onSelect: (p: D
 									{(p.mutationsApplied ?? 0) > 0 ? `${p.mutationsApplied} applied` : "no mutations"}
 								</span>
 								<span className="min-w-0 truncate text-[11px] text-slate-700 dark:text-slate-300">
-									{p.error ?? p.summary ?? ""}
+									{p.error ?? (p.summary ? markdownSummaryPreview(p.summary) : "")}
 								</span>
 								<ChevronRight className="size-3 shrink-0 text-slate-500 dark:text-slate-500" />
 							</button>
@@ -859,9 +873,7 @@ function PassDetailDialog({ pass, onClose }: { pass: DreamPass; onClose: () => v
 				</DialogHeader>
 
 				<div className="flex max-h-[72vh] flex-col gap-4 overflow-y-auto px-5 py-4">
-					{pass.summary && (
-						<p className="m-0 text-[12px] leading-relaxed text-slate-500 dark:text-slate-400">{pass.summary}</p>
-					)}
+					{pass.summary && <MarkdownSummary text={pass.summary} />}
 					{pass.error && (
 						<p className="m-0 flex items-start gap-1.5 text-[12px] leading-relaxed text-destructive">
 							<AlertCircle className="mt-px size-3.5 shrink-0" />


### PR DESCRIPTION
## Summary

Closes #1226.

Dreaming pass summaries now ask the agent for bounded Markdown instead of prose-only paragraphs, and every dashboard path renders or previews that Markdown without exposing raw heading/list markers.

## Changes

- Updated the combined, hygiene-only, and content-only runbook instructions.
- Required Markdown with `##` sections and bullet lists where useful.
- Kept the existing 2,000-character `runbook_write` validation contract explicit in the prompt.
- Preserved structured `deferred` and `openQuestions` fields.
- Added a named regression test for all three pass modes.
- Updated the dashboard pass ledger preview and pass-detail dialog to handle Markdown summaries.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Packages affected

- `@signet/daemon`
- `signet-dashboard`

## Screenshots

Not applicable. The change is a compact runbook-summary presentation fix; the dashboard production build verifies the updated rendering path.

## Verification

- `bun test platform/daemon/src/pipeline/dreaming.test.ts` - 35 pass
- `bunx biome check surfaces/dashboard/src/views/dreaming.tsx platform/daemon/src/pipeline/dreaming.ts platform/daemon/src/pipeline/dreaming.test.ts` - pass
- `bun run --filter '@signet/core' build` - pass
- `bun run --filter '@signet/daemon' build` - pass
- `bun run --filter 'signet-dashboard' build` - pass
- Prompt contract eval - 3 prompts require bounded Markdown summaries

## Readiness checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) - no spec or dependency change
- [x] Agent scoping verified on all new/changed data queries - no data queries changed
- [x] Input/config validation and bounds checks added - existing 2,000-character schema bound preserved
- [x] Error handling and fallback paths tested (no silent swallow) - no error or fallback path changed
- [x] Security checks applied to admin/mutation endpoints - no endpoint or mutation path changed
- [x] Docs updated for API/spec/status changes - no API, spec, or status behavior changed
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

AI assistance disclosed in all commit trailers.