### PR TITLE
fix(daemon): persist session lifecycle claims

### DIFF
--- a/platform/core/src/migrations/113-session-claims.ts
+++ b/platform/core/src/migrations/113-session-claims.ts
@@ -1,0 +1,29 @@
+import type { MigrationDb } from "./index";
+
+/**
+ * Migration 113: durable session lifecycle claims (#1228).
+ *
+ * Session ownership and end markers must survive daemon restarts. The
+ * composite key keeps identical harness session keys isolated by agent.
+ */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS session_claims (
+			session_key TEXT NOT NULL,
+			agent_id TEXT NOT NULL DEFAULT 'default',
+			runtime_path TEXT CHECK(runtime_path IN ('plugin', 'legacy')),
+			harness TEXT,
+			claimed_at TEXT NOT NULL,
+			expires_at TEXT NOT NULL,
+			state TEXT NOT NULL DEFAULT 'active' CHECK(state IN ('active', 'expired', 'ended')),
+			ended_at TEXT,
+			end_marker TEXT,
+			PRIMARY KEY (agent_id, session_key)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_session_claims_expiry
+			ON session_claims(state, expires_at);
+		CREATE INDEX IF NOT EXISTS idx_session_claims_agent
+			ON session_claims(agent_id, state, expires_at);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -118,6 +118,7 @@ import { up as telemetryInstall } from "./109-telemetry-install";
 import { up as memoryMentionJoinIndex } from "./110-memory-mention-join-index";
 import { up as telemetryFirstUse } from "./111-telemetry-first-use";
 import { up as telemetryQueueOwnership } from "./112-telemetry-queue-ownership";
+import { up as sessionClaims } from "./113-session-claims";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1047,6 +1048,20 @@ export const MIGRATIONS: readonly Migration[] = [
 				{ table: "telemetry_events", column: "source" },
 				{ table: "telemetry_events", column: "claim_token" },
 				{ table: "telemetry_events", column: "claimed_at" },
+			],
+		},
+	},
+	{
+		version: 113,
+		name: "session-claims",
+		up: sessionClaims,
+		artifacts: {
+			tables: ["session_claims"],
+			columns: [
+				{ table: "session_claims", column: "agent_id" },
+				{ table: "session_claims", column: "harness" },
+				{ table: "session_claims", column: "expires_at" },
+				{ table: "session_claims", column: "end_marker" },
 			],
 		},
 	},

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -121,8 +121,11 @@ import {
 import { startSchedulerWorker } from "./scheduler";
 import { getSecret } from "./secrets.js";
 import { flushPendingCheckpoints, initCheckpointFlush, pruneCheckpoints } from "./session-checkpoints";
+import { createSessionClaimStore } from "./session-claims";
 import {
 	releaseAllSessions,
+	restorePersistedSessions,
+	setSessionClaimStore,
 	setSessionEvictionHandler,
 	startSessionCleanup,
 	stopSessionCleanup,
@@ -1888,6 +1891,7 @@ async function main() {
 	}
 
 	await initDbAccessorAsync(MEMORY_DB, { agentsDir: AGENTS_DIR });
+	setSessionClaimStore(createSessionClaimStore(getDbAccessor()));
 	startSessionCleanup();
 	// Formal TTL lifecycle (#902): when stale-session cleanup evicts a claim
 	// whose harness never sent session-end, checkpoint the residual continuity
@@ -1903,6 +1907,10 @@ async function main() {
 			},
 		}),
 	);
+	const restoredSessions = restorePersistedSessions();
+	if (restoredSessions.active > 0 || restoredSessions.expired > 0 || restoredSessions.ended > 0) {
+		logger.info("session-tracker", "Restored durable session lifecycle state", restoredSessions);
+	}
 	logFdSnapshot("post-db-init");
 	startEventLoopMonitor();
 	startFdPollMonitor();

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -659,7 +659,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 			timeStyle: "short",
 		});
 		const warnings = req.sessionKey
-			? [getExpiryWarning(req.sessionKey)].filter((w): w is string => w !== null)
+			? [getExpiryWarning(req.sessionKey, agentId)].filter((w): w is string => w !== null)
 			: undefined;
 		return {
 			identity: { name: "Agent" },
@@ -1246,7 +1246,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 		inject,
 		warnings: (() => {
 			if (!req.sessionKey) return undefined;
-			const w = [getExpiryWarning(req.sessionKey)].filter((v): v is string => v !== null);
+			const w = [getExpiryWarning(req.sessionKey, resolveAgentId(req))].filter((v): v is string => v !== null);
 			return w.length > 0 ? w : undefined;
 		})(),
 	};
@@ -1643,7 +1643,7 @@ export async function handleUserPromptSubmit(
 		timeStyle: "short",
 	});
 	const metadataHeader = `# Current Date & Time\n${now} (${tz})\n`;
-	const expiryWarning = req.sessionKey ? deps.getExpiryWarning(req.sessionKey) : null;
+	const expiryWarning = req.sessionKey ? deps.getExpiryWarning(req.sessionKey, agentId) : null;
 	const warnings = expiryWarning ? [expiryWarning] : undefined;
 
 	if (submitCfg.enabled === false) {

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -110,10 +110,11 @@ function checkSessionClaim(
 	c: Context,
 	sessionKey: string | undefined,
 	runtimePath: RuntimePath | undefined,
+	agentId = "default",
 ): Response | null {
 	if (!sessionKey || !runtimePath) return null;
 
-	const owner = getSessionPath(sessionKey);
+	const owner = getSessionPath(sessionKey, agentId);
 	if (owner && owner !== runtimePath) {
 		return c.json({ error: `session claimed by ${owner} path` }, 409) as unknown as Response;
 	}
@@ -150,9 +151,10 @@ function claimAutomaticSessionOrSkip(
 function skipConflictingSessionEnd(
 	sessionKey: string | undefined,
 	runtimePath: RuntimePath | undefined,
+	agentId = "default",
 ): Record<string, unknown> | null {
 	if (!sessionKey || !runtimePath) return null;
-	const ended = getEndedSession(sessionKey);
+	const ended = getEndedSession(sessionKey, agentId);
 	if (ended && !ended.runtimePath) return null;
 	if (ended) {
 		logger.info("hooks", "Duplicate session-end skipped", {
@@ -167,7 +169,7 @@ function skipConflictingSessionEnd(
 			endedBy: ended.runtimePath ?? "unknown",
 		};
 	}
-	const owner = getSessionPath(sessionKey);
+	const owner = getSessionPath(sessionKey, agentId);
 	if (!owner || owner === runtimePath) return null;
 
 	logger.info("hooks", "Duplicate runtime session-end skipped", {
@@ -211,10 +213,10 @@ function isInternalCall(c: Context): boolean {
 }
 
 // Check whether the session is bypassed (hooks return no-op responses)
-function checkBypass(body?: { sessionKey?: string; sessionId?: string }): boolean {
+function checkBypass(body?: { sessionKey?: string; sessionId?: string; agentId?: string }): boolean {
 	const key = body?.sessionKey ?? body?.sessionId;
 	if (!key) return false;
-	return isSessionBypassed(key);
+	return isSessionBypassed(key, body?.agentId ?? "default");
 }
 
 export function listLiveSessions(agentId: string): Array<{
@@ -243,7 +245,7 @@ export function listLiveSessions(agentId: string): Array<{
 			runtimePath: presence.runtimePath ?? "unknown",
 			claimedAt: presence.startedAt,
 			expiresAt: null,
-			bypassed: isSessionBypassed(key),
+			bypassed: isSessionBypassed(key, agentId),
 		});
 	}
 	return [...byKey.values()].sort((a, b) => b.claimedAt.localeCompare(a.claimedAt));
@@ -372,9 +374,8 @@ function registerUserPromptSubmit(app: Hono): void {
 			if (runtimePath) body.runtimePath = runtimePath;
 
 			const sessionKey = parseOptionalString(body.sessionKey);
-			const known = sessionKey ? hasSession(sessionKey) : false;
-
 			const agentId = parseOptionalString(body.agentId) ?? "default";
+			const known = sessionKey ? hasSession(sessionKey, agentId) : false;
 			const duplicate = claimAutomaticSessionOrSkip(
 				sessionKey,
 				runtimePath,
@@ -462,10 +463,10 @@ function registerSessionEnd(app: Hono): void {
 			stampHarness(body.harness);
 
 			const sessionKey = body.sessionKey || body.sessionId;
-			const conflict = skipConflictingSessionEnd(sessionKey, runtimePath);
+			let agentId = resolveAgentId({ agentId: parseOptionalString(body.agentId), sessionKey });
+			const conflict = skipConflictingSessionEnd(sessionKey, runtimePath, agentId);
 			if (conflict) return c.json(conflict);
 			const transcriptPath = parseOptionalString(body.transcriptPath);
-			let agentId = resolveAgentId({ agentId: parseOptionalString(body.agentId), sessionKey });
 			if (transcriptPath) {
 				const denied = await requirePermission("remember", authConfig)(c, () => Promise.resolve());
 				if (denied) return denied;
@@ -484,8 +485,8 @@ function registerSessionEnd(app: Hono): void {
 			});
 			if (duplicate) return c.json(duplicate);
 
-			if (sessionKey && isSessionBypassed(sessionKey)) {
-				markSessionEnded(sessionKey, runtimePath);
+			if (sessionKey && isSessionBypassed(sessionKey, agentId)) {
+				markSessionEnded(sessionKey, runtimePath, agentId);
 				removeAgentPresence(sessionKey);
 				return c.json({ memoriesSaved: 0, bypassed: true });
 			}
@@ -493,7 +494,7 @@ function registerSessionEnd(app: Hono): void {
 			try {
 				const result = await handleSessionEnd(body);
 				if (sessionKey) {
-					markSessionEnded(sessionKey, runtimePath);
+					markSessionEnded(sessionKey, runtimePath, agentId);
 					removeAgentPresence(sessionKey);
 				}
 				if (transcriptPath) {
@@ -511,7 +512,7 @@ function registerSessionEnd(app: Hono): void {
 				return c.json(result);
 			} catch (e) {
 				if (sessionKey) {
-					releaseSession(sessionKey);
+					releaseSession(sessionKey, agentId);
 					removeAgentPresence(sessionKey);
 				}
 				throw e;
@@ -557,7 +558,7 @@ function registerSkillInvocation(app: Hono): void {
 			if (createdAt.error) return c.json({ error: createdAt.error }, 400);
 			const sessionKey = parseOptionalString(body.sessionKey ?? body.sessionId);
 			const runtimePath = resolveRuntimePath(c, { runtimePath: parseOptionalString(body.runtimePath) });
-			const conflict = checkSessionClaim(c, sessionKey, runtimePath);
+			const conflict = checkSessionClaim(c, sessionKey, runtimePath, parseOptionalString(body.agentId) ?? "default");
 			if (conflict) return conflict;
 			const requestedAgentId = resolveAgentId({ agentId: parseOptionalString(body.agentId), sessionKey });
 			const denied = await requirePermission("remember", authConfig)(c, () => Promise.resolve());
@@ -615,11 +616,12 @@ function registerCheckpointExtract(app: Hono): void {
 
 			const runtimePath = resolveRuntimePath(c, body);
 			if (runtimePath) body.runtimePath = runtimePath;
+			const agentId = parseOptionalString(body.agentId) ?? "default";
 
 			const duplicate = claimAutomaticSessionOrSkip(
 				body.sessionKey,
 				runtimePath,
-				parseOptionalString(body.agentId) ?? "default",
+				agentId,
 				body.harness,
 				"session-checkpoint-extract",
 				{
@@ -630,11 +632,11 @@ function registerCheckpointExtract(app: Hono): void {
 
 			stampHarness(body.harness);
 
-			if (isSessionBypassed(body.sessionKey)) {
+			if (isSessionBypassed(body.sessionKey, agentId)) {
 				return c.json({ skipped: true });
 			}
 
-			renewSession(body.sessionKey);
+			renewSession(body.sessionKey, agentId);
 
 			const result = handleCheckpointExtract(body);
 			return c.json(result);
@@ -661,7 +663,12 @@ function registerRemember(app: Hono): void {
 			const runtimePath = resolveRuntimePath(c, body);
 			if (runtimePath) body.runtimePath = runtimePath;
 
-			const conflict = checkSessionClaim(c, body.sessionKey, runtimePath);
+			const conflict = checkSessionClaim(
+				c,
+				body.sessionKey,
+				runtimePath,
+				parseOptionalString(body.agentId) ?? "default",
+			);
 			if (conflict) return conflict;
 
 			if (checkBypass(body)) {
@@ -708,7 +715,12 @@ function registerRecall(app: Hono): void {
 			const runtimePath = resolveRuntimePath(c, body);
 			if (runtimePath) body.runtimePath = runtimePath;
 
-			const conflict = checkSessionClaim(c, body.sessionKey, runtimePath);
+			const conflict = checkSessionClaim(
+				c,
+				body.sessionKey,
+				runtimePath,
+				parseOptionalString(body.agentId) ?? "default",
+			);
 			if (conflict) return conflict;
 
 			if (checkBypass(body)) {

--- a/platform/daemon/src/routes/session-routes.ts
+++ b/platform/daemon/src/routes/session-routes.ts
@@ -47,7 +47,7 @@ function listLiveSessions(agentId: string): Array<{
 			runtimePath: presence.runtimePath ?? "unknown",
 			claimedAt: presence.startedAt,
 			expiresAt: null,
-			bypassed: isSessionBypassed(key),
+			bypassed: isSessionBypassed(key, agentId),
 		});
 	}
 	return [...byKey.values()].sort((a, b) => b.claimedAt.localeCompare(a.claimedAt));
@@ -274,12 +274,12 @@ export function registerSessionRoutes(app: Hono, deps: SessionRoutesDeps): void 
 		const enabled = body.enabled === true;
 
 		if (enabled) {
-			const ok = bypassSession(key, { allowUnknown: session.expiresAt === null });
+			const ok = bypassSession(key, { allowUnknown: session.expiresAt === null }, scopedAgent.agentId);
 			if (!ok) {
 				return c.json({ error: "Session not found or already released" }, 404);
 			}
 		} else {
-			unbypassSession(key);
+			unbypassSession(key, scopedAgent.agentId);
 		}
 		return c.json({ key, bypassed: enabled });
 	});
@@ -296,7 +296,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRoutesDeps): void 
 			touchAgentPresence(key, scopedAgent.agentId);
 			return c.json({ key, renewed: true });
 		}
-		const expiresAt = renewSession(key);
+		const expiresAt = renewSession(key, scopedAgent.agentId);
 		if (!expiresAt) {
 			return c.json({ error: "Session not found or expired" }, 404);
 		}

--- a/platform/daemon/src/session-claims.test.ts
+++ b/platform/daemon/src/session-claims.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { createSessionClaimStore } from "./session-claims";
+import {
+	claimSession,
+	getActiveSessions,
+	getEndedSession,
+	hasSession,
+	markSessionEnded,
+	resetSessions,
+	restorePersistedSessions,
+	setSessionClaimStore,
+	setSessionEvictionHandler,
+} from "./session-tracker";
+
+let agentsDir = "";
+
+function sessionClaimRow(sessionKey: string, agentId: string): Record<string, unknown> | null {
+	return getDbAccessor().withReadDb(
+		(db) =>
+			db
+				.prepare("SELECT * FROM session_claims WHERE session_key = ? AND agent_id = ?")
+				.get(sessionKey, agentId) as Record<string, unknown> | null,
+	);
+}
+
+describe("durable session lifecycle claims (#1228)", () => {
+	beforeEach(() => {
+		agentsDir = mkdtempSync(join(tmpdir(), "signet-session-claims-"));
+		mkdirSync(join(agentsDir, "memory"), { recursive: true });
+		initDbAccessor(join(agentsDir, "memory", "memories.db"));
+		setSessionClaimStore(createSessionClaimStore(getDbAccessor()));
+	});
+
+	afterEach(() => {
+		setSessionClaimStore(null);
+		resetSessions();
+		closeDbAccessor();
+		rmSync(agentsDir, { recursive: true, force: true });
+	});
+
+	it("rehydrates an active claim after the tracker process state is cleared", () => {
+		expect(claimSession("restart-active", "plugin", "agent-a", "hermes").ok).toBe(true);
+		expect(sessionClaimRow("restart-active", "agent-a")).toMatchObject({
+			state: "active",
+			harness: "hermes",
+		});
+
+		resetSessions();
+		const restored = restorePersistedSessions();
+
+		expect(restored).toMatchObject({ active: 1, expired: 0, ended: 0 });
+		expect(hasSession("restart-active", "agent-a")).toBe(true);
+	});
+
+	it("keeps identical session keys isolated across agents", () => {
+		expect(claimSession("shared-key", "plugin", "agent-a").ok).toBe(true);
+		expect(claimSession("shared-key", "legacy", "agent-b").ok).toBe(true);
+		expect(getActiveSessions()).toHaveLength(2);
+
+		resetSessions();
+		expect(restorePersistedSessions()).toMatchObject({ active: 2, expired: 0, ended: 0 });
+		expect(
+			getActiveSessions()
+				.map((session) => session.agentId)
+				.sort(),
+		).toEqual(["agent-a", "agent-b"]);
+	});
+
+	it("persists renewals instead of retaining the old expiry", () => {
+		claimSession("renew-durable", "legacy", "agent-b");
+		const before = String(sessionClaimRow("renew-durable", "agent-b")?.expires_at);
+
+		resetSessions();
+		setSessionClaimStore(createSessionClaimStore(getDbAccessor()));
+		claimSession("renew-durable", "legacy", "agent-b");
+		const after = String(sessionClaimRow("renew-durable", "agent-b")?.expires_at);
+
+		expect(after > before).toBe(true);
+	});
+
+	it("restores ended tombstones without reactivating the session", () => {
+		claimSession("restart-ended", "plugin", "agent-c");
+		markSessionEnded("restart-ended", "plugin", "agent-c");
+		expect(sessionClaimRow("restart-ended", "agent-c")).toMatchObject({ state: "ended" });
+
+		resetSessions();
+		const restored = restorePersistedSessions();
+
+		expect(restored).toMatchObject({ active: 0, expired: 0, ended: 1 });
+		expect(hasSession("restart-ended")).toBe(false);
+		expect(getEndedSession("restart-ended", "agent-c")).toBeDefined();
+	});
+
+	it("persists an end marker even when no runtime path was provided", () => {
+		markSessionEnded("restart-unmarked");
+		expect(sessionClaimRow("restart-unmarked", "default")).toMatchObject({
+			state: "ended",
+			runtime_path: null,
+			end_marker: expect.any(String),
+		});
+
+		resetSessions();
+		expect(restorePersistedSessions()).toMatchObject({ active: 0, expired: 0, ended: 1 });
+		expect(getEndedSession("restart-unmarked")).toBeDefined();
+	});
+
+	it("runs the TTL finalizer for an expired claim recovered at startup", () => {
+		claimSession("restart-expired", "plugin", "agent-d");
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				"UPDATE session_claims SET expires_at = ?, state = 'active' WHERE session_key = ? AND agent_id = ?",
+			).run("2000-01-01T00:00:00.000Z", "restart-expired", "agent-d");
+		});
+
+		resetSessions();
+		const evicted: string[] = [];
+		setSessionEvictionHandler((info) => {
+			evicted.push(info.sessionKey);
+			return "finalized";
+		});
+		const restored = restorePersistedSessions();
+
+		expect(restored).toMatchObject({ active: 0, expired: 1, ended: 0 });
+		expect(evicted).toEqual(["restart-expired"]);
+		expect(sessionClaimRow("restart-expired", "agent-d")).toBeNull();
+	});
+});

--- a/platform/daemon/src/session-claims.test.ts
+++ b/platform/daemon/src/session-claims.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { createSessionClaimStore } from "./session-claims";
 import {
+	_expireSessionForTest,
 	claimSession,
 	getActiveSessions,
 	getEndedSession,
@@ -12,11 +13,22 @@ import {
 	markSessionEnded,
 	resetSessions,
 	restorePersistedSessions,
+	runStaleCleanup,
 	setSessionClaimStore,
 	setSessionEvictionHandler,
 } from "./session-tracker";
+import { createTelemetryCollector, setActiveTelemetry } from "./telemetry";
 
 let agentsDir = "";
+
+const TEST_TELEMETRY_CONFIG = {
+	posthogHost: "",
+	posthogApiKey: "",
+	flushIntervalMs: 60000,
+	flushBatchSize: 50,
+	retentionDays: 90,
+	memorySearchQaEnabled: false,
+} as const;
 
 function sessionClaimRow(sessionKey: string, agentId: string): Record<string, unknown> | null {
 	return getDbAccessor().withReadDb(
@@ -127,5 +139,24 @@ describe("durable session lifecycle claims (#1228)", () => {
 		expect(restored).toMatchObject({ active: 0, expired: 1, ended: 0 });
 		expect(evicted).toEqual(["restart-expired"]);
 		expect(sessionClaimRow("restart-expired", "agent-d")).toBeNull();
+	});
+
+	it("does not re-emit expiry telemetry for an already-expired durable row", async () => {
+		const collector = createTelemetryCollector(getDbAccessor(), TEST_TELEMETRY_CONFIG, "0.0.0-test");
+		setActiveTelemetry(collector);
+		try {
+			claimSession("restart-telemetry", "plugin", "agent-e", "hermes");
+			_expireSessionForTest("restart-telemetry", "agent-e");
+			runStaleCleanup();
+			await collector.flush();
+
+			resetSessions();
+			expect(restorePersistedSessions()).toMatchObject({ active: 0, expired: 1, ended: 0 });
+			await collector.flush();
+
+			expect(collector.query().filter((event) => event.event === "session.end")).toHaveLength(1);
+		} finally {
+			setActiveTelemetry(undefined);
+		}
 	});
 });

--- a/platform/daemon/src/session-claims.ts
+++ b/platform/daemon/src/session-claims.ts
@@ -1,0 +1,123 @@
+import type { DbAccessor, ReadDb } from "./db-accessor";
+import type { RuntimePath } from "./session-tracker";
+
+export type PersistedSessionState = "active" | "expired" | "ended";
+
+export interface PersistedSessionClaim {
+	readonly sessionKey: string;
+	readonly agentId: string;
+	readonly runtimePath: RuntimePath | null;
+	readonly harness: string | null;
+	readonly claimedAt: string;
+	readonly expiresAt: string;
+	readonly state: PersistedSessionState;
+	readonly endedAt: string | null;
+	readonly endMarker: string | null;
+}
+
+export interface SessionClaimStore {
+	upsertActive(claim: PersistedSessionClaim): void;
+	markExpired(sessionKey: string, agentId: string): void;
+	markEnded(claim: PersistedSessionClaim): void;
+	remove(sessionKey: string, agentId: string): void;
+	list(): readonly PersistedSessionClaim[];
+}
+
+interface SessionClaimRow {
+	readonly session_key: string;
+	readonly agent_id: string;
+	readonly runtime_path: RuntimePath | null;
+	readonly harness: string | null;
+	readonly claimed_at: string;
+	readonly expires_at: string;
+	readonly state: PersistedSessionState;
+	readonly ended_at: string | null;
+	readonly end_marker: string | null;
+}
+
+function readClaims(db: ReadDb): readonly PersistedSessionClaim[] {
+	const rows = db
+		.prepare(
+			`SELECT session_key, agent_id, runtime_path, harness, claimed_at, expires_at,
+					state, ended_at, end_marker
+			 FROM session_claims
+			 ORDER BY claimed_at ASC`,
+		)
+		.all() as SessionClaimRow[];
+	return rows.map((row) => ({
+		sessionKey: row.session_key,
+		agentId: row.agent_id,
+		runtimePath: row.runtime_path,
+		harness: row.harness,
+		claimedAt: row.claimed_at,
+		expiresAt: row.expires_at,
+		state: row.state,
+		endedAt: row.ended_at,
+		endMarker: row.end_marker,
+	}));
+}
+
+export function createSessionClaimStore(accessor: DbAccessor): SessionClaimStore {
+	return {
+		upsertActive(claim): void {
+			accessor.withWriteTx((db) => {
+				db.prepare(
+					`INSERT INTO session_claims
+						(session_key, agent_id, runtime_path, harness, claimed_at, expires_at, state, ended_at, end_marker)
+					 VALUES (?, ?, ?, ?, ?, ?, 'active', NULL, NULL)
+					 ON CONFLICT(agent_id, session_key) DO UPDATE SET
+						runtime_path = excluded.runtime_path,
+						harness = excluded.harness,
+						claimed_at = excluded.claimed_at,
+						expires_at = excluded.expires_at,
+						state = 'active',
+						ended_at = NULL,
+						end_marker = NULL`,
+				).run(claim.sessionKey, claim.agentId, claim.runtimePath, claim.harness, claim.claimedAt, claim.expiresAt);
+			});
+		},
+		markExpired(sessionKey, agentId): void {
+			accessor.withWriteTx((db) => {
+				db.prepare(
+					`UPDATE session_claims
+					 SET state = 'expired'
+					 WHERE session_key = ? AND agent_id = ? AND state = 'active'`,
+				).run(sessionKey, agentId);
+			});
+		},
+		markEnded(claim): void {
+			accessor.withWriteTx((db) => {
+				db.prepare(
+					`INSERT INTO session_claims
+						(session_key, agent_id, runtime_path, harness, claimed_at, expires_at, state, ended_at, end_marker)
+					 VALUES (?, ?, ?, ?, ?, ?, 'ended', ?, ?)
+					 ON CONFLICT(agent_id, session_key) DO UPDATE SET
+						runtime_path = excluded.runtime_path,
+						harness = excluded.harness,
+						claimed_at = excluded.claimed_at,
+						expires_at = excluded.expires_at,
+						state = 'ended',
+						ended_at = excluded.ended_at,
+						end_marker = excluded.end_marker`,
+				).run(
+					claim.sessionKey,
+					claim.agentId,
+					claim.runtimePath,
+					claim.harness,
+					claim.claimedAt,
+					claim.expiresAt,
+					claim.endedAt,
+					claim.endMarker,
+				);
+			});
+		},
+		remove(sessionKey, agentId): void {
+			accessor.withWriteTx((db) => {
+				db.prepare("DELETE FROM session_claims WHERE session_key = ? AND agent_id = ?").run(sessionKey, agentId);
+			});
+		},
+		list(): readonly PersistedSessionClaim[] {
+			return accessor.withReadDb(readClaims);
+		},
+	};
+}

--- a/platform/daemon/src/session-tracker.test.ts
+++ b/platform/daemon/src/session-tracker.test.ts
@@ -219,10 +219,11 @@ describe("TTL eviction lifecycle handler (#902)", () => {
 		const seen: Array<{ key: string; agentId: string; runtimePath: string }> = [];
 		const handler: SessionEvictionHandler = (info) => {
 			seen.push({ key: info.sessionKey, agentId: info.agentId, runtimePath: info.runtimePath });
+			return undefined;
 		};
 		setSessionEvictionHandler(handler);
 		claimSession("ttl-sess-1", "plugin", "agent-a");
-		_expireSessionForTest("ttl-sess-1");
+		_expireSessionForTest("ttl-sess-1", "agent-a");
 
 		runStaleCleanup();
 
@@ -234,7 +235,7 @@ describe("TTL eviction lifecycle handler (#902)", () => {
 	it("counts a handler 'skipped' outcome as unfinalized", () => {
 		setSessionEvictionHandler(() => "skipped");
 		claimSession("ttl-sess-2", "legacy", "agent-b");
-		_expireSessionForTest("ttl-sess-2");
+		_expireSessionForTest("ttl-sess-2", "agent-b");
 
 		runStaleCleanup();
 
@@ -245,7 +246,7 @@ describe("TTL eviction lifecycle handler (#902)", () => {
 	it("does not count a 'finalized' outcome as unfinalized", () => {
 		setSessionEvictionHandler(() => "finalized");
 		claimSession("ttl-sess-3", "plugin", "agent-c");
-		_expireSessionForTest("ttl-sess-3");
+		_expireSessionForTest("ttl-sess-3", "agent-c");
 
 		runStaleCleanup();
 

--- a/platform/daemon/src/session-tracker.test.ts
+++ b/platform/daemon/src/session-tracker.test.ts
@@ -212,6 +212,18 @@ describe("ended session tombstones", () => {
 
 		expect(getEndedSession("reused-sess")).toBeUndefined();
 	});
+
+	it("removes expired ended markers from the agent-scoped map", () => {
+		markSessionEnded("expired-scoped", "plugin", "agent-scoped");
+		const realNow = Date.now;
+		Date.now = () => realNow() + 31 * 60 * 1000;
+		try {
+			expect(getEndedSession("expired-scoped", "agent-scoped")).toBeUndefined();
+			expect(getSessionTrackerStats().ended).toBe(0);
+		} finally {
+			Date.now = realNow;
+		}
+	});
 });
 
 describe("TTL eviction lifecycle handler (#902)", () => {

--- a/platform/daemon/src/session-tracker.ts
+++ b/platform/daemon/src/session-tracker.ts
@@ -126,7 +126,7 @@ function persistedClaim(
 // normalizeSessionKey is defined in session-end-state.ts (single source of
 // truth for session-key identity) and re-exported here for the routes.
 
-function evictExpiredSession(mapKey: string, claim: SessionClaim): void {
+function evictExpiredSession(mapKey: string, claim: SessionClaim, emitEndTelemetry = true): void {
 	if (!sessions.delete(mapKey)) return;
 	const key = claim.sessionKey;
 	const scopedKey = scopedSessionKey(key, claim.agentId);
@@ -143,7 +143,10 @@ function evictExpiredSession(mapKey: string, claim: SessionClaim): void {
 	// (no hooks for STALE_SESSION_MS). Emit session.end once per session
 	// lifetime (#1212) — dedup'd so a session already counted via explicit
 	// clear is not double-counted here.
-	if (!hasSessionEndTelemetry({ agentId: claim.agentId, harness: claim.harness, sessionKey: key })) {
+	if (
+		emitEndTelemetry &&
+		!hasSessionEndTelemetry({ agentId: claim.agentId, harness: claim.harness, sessionKey: key })
+	) {
 		getActiveTelemetry()?.record("session.end", {
 			harness: claim.harness ?? null,
 			reason: "expired",
@@ -326,7 +329,7 @@ export function getEndedSession(sessionKey: string, agentId = "default"): EndedS
 	if (!ended) return undefined;
 
 	if (Date.now() > ended.expiresAt) {
-		endedSessions.delete(key);
+		endedSessions.delete(scopedSessionKey(key, agentId));
 		return undefined;
 	}
 
@@ -566,7 +569,7 @@ export function restorePersistedSessions(): {
 		};
 		sessions.set(mapKey, claim);
 		if (expiresAt <= now || row.state === "expired") {
-			evictExpiredSession(mapKey, claim);
+			evictExpiredSession(mapKey, claim, row.state !== "expired");
 			expired++;
 		} else {
 			active++;

--- a/platform/daemon/src/session-tracker.ts
+++ b/platform/daemon/src/session-tracker.ts
@@ -10,9 +10,10 @@
  */
 
 import { logger } from "./logger";
+import type { PersistedSessionClaim, SessionClaimStore } from "./session-claims";
 import {
-	hashSessionKey,
 	hasSessionEndTelemetry,
+	hashSessionKey,
 	markSessionEndTelemetry,
 	normalizeSessionKey,
 	resetSessionEndTelemetry,
@@ -33,6 +34,7 @@ export interface SessionInfo {
 }
 
 interface SessionClaim {
+	readonly sessionKey: string;
 	readonly agentId: string;
 	readonly runtimePath: RuntimePath;
 	/** Harness that claimed the session (for telemetry breakdowns). */
@@ -49,6 +51,7 @@ export interface EndedSessionInfo {
 }
 
 interface EndedSession {
+	readonly agentId: string;
 	readonly runtimePath?: RuntimePath;
 	readonly endedAt: string;
 	expiresAt: number;
@@ -92,16 +95,43 @@ let cleanupTimer: ReturnType<typeof setInterval> | null = null;
 let cleanupStarted = false;
 // TTL-eviction lifecycle hook + counters (#902).
 let evictionHandler: SessionEvictionHandler | null = null;
+let claimStore: SessionClaimStore | null = null;
 let expiredCount = 0;
 let unfinalizedCount = 0;
+
+function scopedSessionKey(sessionKey: string, agentId: string): string {
+	return agentId === "default" ? sessionKey : JSON.stringify([agentId, sessionKey]);
+}
+
+function persistedClaim(
+	key: string,
+	claim: SessionClaim,
+	state: "active" | "expired" | "ended" = "active",
+	endedAt: string | null = null,
+	endMarker: string | null = null,
+): PersistedSessionClaim {
+	return {
+		sessionKey: key,
+		agentId: claim.agentId,
+		runtimePath: claim.runtimePath,
+		harness: claim.harness ?? null,
+		claimedAt: claim.claimedAt,
+		expiresAt: new Date(claim.expiresAt).toISOString(),
+		state,
+		endedAt,
+		endMarker,
+	};
+}
 
 // normalizeSessionKey is defined in session-end-state.ts (single source of
 // truth for session-key identity) and re-exported here for the routes.
 
-function evictExpiredSession(key: string, claim: SessionClaim): void {
-	if (!sessions.delete(key)) return;
-	bypassedSessions.delete(key);
-	warnedSessions.delete(key);
+function evictExpiredSession(mapKey: string, claim: SessionClaim): void {
+	if (!sessions.delete(mapKey)) return;
+	const key = claim.sessionKey;
+	const scopedKey = scopedSessionKey(key, claim.agentId);
+	bypassedSessions.delete(scopedKey);
+	warnedSessions.delete(scopedKey);
 	expiredCount++;
 	logger.warn("session-tracker", "Session evicted (TTL expired)", {
 		sessionKey: key,
@@ -122,12 +152,17 @@ function evictExpiredSession(key: string, claim: SessionClaim): void {
 		markSessionEndTelemetry({ agentId: claim.agentId, harness: claim.harness, sessionKey: key });
 	}
 
-	if (!evictionHandler) return;
+	if (!evictionHandler) {
+		claimStore?.markExpired(key, claim.agentId);
+		return;
+	}
+	let outcome: "finalized" | "skipped" | undefined;
 	try {
-		const outcome = evictionHandler({
+		outcome = evictionHandler({
 			sessionKey: key,
 			agentId: claim.agentId,
 			runtimePath: claim.runtimePath,
+			harness: claim.harness,
 			claimedAt: claim.claimedAt,
 		});
 		if (outcome === "skipped") unfinalizedCount++;
@@ -137,6 +172,11 @@ function evictExpiredSession(key: string, claim: SessionClaim): void {
 			sessionKey: key,
 			error: err instanceof Error ? err.message : String(err),
 		});
+	}
+	if (outcome === "finalized") {
+		claimStore?.remove(key, claim.agentId);
+	} else {
+		claimStore?.markExpired(key, claim.agentId);
 	}
 }
 
@@ -152,13 +192,15 @@ export function claimSession(
 	harness?: string,
 ): ClaimResult {
 	const key = normalizeSessionKey(sessionKey);
-	const existing = sessions.get(key);
-	endedSessions.delete(key);
+	const mapKey = scopedSessionKey(key, agentId);
+	const existing = sessions.get(mapKey);
+	endedSessions.delete(mapKey);
 
 	if (existing) {
 		if (existing.runtimePath === runtimePath) {
 			// Same path reclaiming — refresh expiry
 			existing.expiresAt = Date.now() + STALE_SESSION_MS;
+			claimStore?.upsertActive(persistedClaim(key, existing));
 			return { ok: true };
 		}
 
@@ -169,20 +211,23 @@ export function claimSession(
 				previousPath: existing.runtimePath,
 				newPath: runtimePath,
 			});
-			evictExpiredSession(key, existing);
+			evictExpiredSession(mapKey, existing);
 			// Fall through to create new claim
 		} else {
 			return { ok: false, claimedBy: existing.runtimePath };
 		}
 	}
 
-	sessions.set(key, {
+	const claim: SessionClaim = {
+		sessionKey: key,
 		agentId,
 		runtimePath,
 		harness,
 		claimedAt: new Date().toISOString(),
 		expiresAt: Date.now() + STALE_SESSION_MS,
-	});
+	};
+	sessions.set(mapKey, claim);
+	claimStore?.upsertActive(persistedClaim(key, claim));
 
 	logger.info("session-tracker", "Session claimed", {
 		sessionKey: key,
@@ -196,24 +241,46 @@ export function claimSession(
  * Release a session claim. Called on session-end.
  * Also cleans up bypass state for the session.
  */
-export function releaseSession(sessionKey: string): void {
+export function releaseSession(sessionKey: string, agentId = "default"): void {
 	const key = normalizeSessionKey(sessionKey);
-	const removed = sessions.delete(key);
-	bypassedSessions.delete(key);
-	warnedSessions.delete(key);
+	const mapKey = scopedSessionKey(key, agentId);
+	const existing = sessions.get(mapKey);
+	const removed = sessions.delete(mapKey);
+	bypassedSessions.delete(mapKey);
+	warnedSessions.delete(mapKey);
+	if (existing) claimStore?.remove(key, existing.agentId);
 	if (removed) {
 		logger.info("session-tracker", "Session released", { sessionKey: key });
 	}
 }
 
-export function markSessionEnded(sessionKey: string, runtimePath?: RuntimePath): void {
+export function markSessionEnded(sessionKey: string, runtimePath?: RuntimePath, agentId = "default"): void {
 	const key = normalizeSessionKey(sessionKey);
-	releaseSession(key);
-	endedSessions.set(key, {
-		runtimePath,
-		endedAt: new Date().toISOString(),
-		expiresAt: Date.now() + ENDED_SESSION_TOMBSTONE_MS,
+	const endedAt = new Date().toISOString();
+	const mapKey = scopedSessionKey(key, agentId);
+	const existing = sessions.get(mapKey);
+	releaseSession(key, agentId);
+	const resolvedRuntimePath = runtimePath ?? existing?.runtimePath;
+	const tombstoneExpiresAt = Date.now() + ENDED_SESSION_TOMBSTONE_MS;
+	endedSessions.set(mapKey, {
+		agentId: existing?.agentId ?? agentId,
+		runtimePath: resolvedRuntimePath,
+		endedAt,
+		expiresAt: tombstoneExpiresAt,
 	});
+	if (claimStore) {
+		claimStore.markEnded({
+			sessionKey: key,
+			agentId: existing?.agentId ?? agentId,
+			runtimePath: resolvedRuntimePath ?? null,
+			harness: existing?.harness ?? null,
+			claimedAt: existing?.claimedAt ?? endedAt,
+			expiresAt: new Date(tombstoneExpiresAt).toISOString(),
+			state: "ended",
+			endedAt,
+			endMarker: endedAt,
+		});
+	}
 	logger.info("session-tracker", "Session ended", {
 		sessionKey: key,
 		runtimePath,
@@ -224,12 +291,13 @@ export function markSessionEnded(sessionKey: string, runtimePath?: RuntimePath):
  * Return true if the session is currently claimed and not stale.
  * Used by hooks to detect daemon-restart mid-session.
  */
-export function hasSession(sessionKey: string): boolean {
+export function hasSession(sessionKey: string, agentId = "default"): boolean {
 	const key = normalizeSessionKey(sessionKey);
-	const claim = sessions.get(key);
+	const mapKey = scopedSessionKey(key, agentId);
+	const claim = sessions.get(mapKey);
 	if (!claim) return false;
 	if (Date.now() > claim.expiresAt) {
-		evictExpiredSession(key, claim);
+		evictExpiredSession(mapKey, claim);
 		return false;
 	}
 	return true;
@@ -238,22 +306,23 @@ export function hasSession(sessionKey: string): boolean {
 /**
  * Get the runtime path for a session, if claimed.
  */
-export function getSessionPath(sessionKey: string): RuntimePath | undefined {
+export function getSessionPath(sessionKey: string, agentId = "default"): RuntimePath | undefined {
 	const key = normalizeSessionKey(sessionKey);
-	const claim = sessions.get(key);
+	const mapKey = scopedSessionKey(key, agentId);
+	const claim = sessions.get(mapKey);
 	if (!claim) return undefined;
 
 	if (Date.now() > claim.expiresAt) {
-		evictExpiredSession(key, claim);
+		evictExpiredSession(mapKey, claim);
 		return undefined;
 	}
 
 	return claim.runtimePath;
 }
 
-export function getEndedSession(sessionKey: string): EndedSessionInfo | undefined {
+export function getEndedSession(sessionKey: string, agentId = "default"): EndedSessionInfo | undefined {
 	const key = normalizeSessionKey(sessionKey);
-	const ended = endedSessions.get(key);
+	const ended = endedSessions.get(scopedSessionKey(key, agentId));
 	if (!ended) return undefined;
 
 	if (Date.now() > ended.expiresAt) {
@@ -277,35 +346,38 @@ export function getEndedSession(sessionKey: string): EndedSessionInfo | undefine
 export function bypassSession(
 	sessionKey: string,
 	opts?: { readonly allowUnknown?: boolean; readonly ttlMs?: number },
+	agentId = "default",
 ): boolean {
 	const key = normalizeSessionKey(sessionKey);
-	if (!sessions.has(key) && opts?.allowUnknown !== true) {
+	const mapKey = scopedSessionKey(key, agentId);
+	if (!sessions.has(mapKey) && opts?.allowUnknown !== true) {
 		logger.warn("session-tracker", "Bypass requested for unknown session", { sessionKey: key });
 		return false;
 	}
 	const ttlMs = opts?.ttlMs;
 	const ttl = typeof ttlMs === "number" && Number.isFinite(ttlMs) && ttlMs > 0 ? ttlMs : STALE_SESSION_MS;
-	bypassedSessions.set(key, Date.now() + ttl);
+	bypassedSessions.set(mapKey, Date.now() + ttl);
 	logger.debug("session-tracker", "Session bypassed", { sessionKey: key });
 	return true;
 }
 
 /** Disable bypass for a session — hooks resume normal behavior. */
-export function unbypassSession(sessionKey: string): void {
+export function unbypassSession(sessionKey: string, agentId = "default"): void {
 	const key = normalizeSessionKey(sessionKey);
-	const removed = bypassedSessions.delete(key);
+	const removed = bypassedSessions.delete(scopedSessionKey(key, agentId));
 	if (removed) {
 		logger.debug("session-tracker", "Session bypass removed", { sessionKey: key });
 	}
 }
 
 /** Check whether a session is currently bypassed. */
-export function isSessionBypassed(sessionKey: string): boolean {
+export function isSessionBypassed(sessionKey: string, agentId = "default"): boolean {
 	const key = normalizeSessionKey(sessionKey);
-	const expiresAt = bypassedSessions.get(key);
+	const mapKey = scopedSessionKey(key, agentId);
+	const expiresAt = bypassedSessions.get(mapKey);
 	if (expiresAt === undefined) return false;
 	if (Date.now() > expiresAt) {
-		bypassedSessions.delete(key);
+		bypassedSessions.delete(mapKey);
 		return false;
 	}
 	return true;
@@ -321,18 +393,18 @@ export function getActiveSessions(): readonly SessionInfo[] {
 	const now = Date.now();
 	const result: SessionInfo[] = [];
 
-	for (const [key, claim] of sessions) {
+	for (const [mapKey, claim] of sessions) {
 		if (now > claim.expiresAt) {
-			evictExpiredSession(key, claim);
+			evictExpiredSession(mapKey, claim);
 			continue;
 		}
 		result.push({
-			key,
+			key: claim.sessionKey,
 			agentId: claim.agentId,
 			runtimePath: claim.runtimePath,
 			claimedAt: claim.claimedAt,
 			expiresAt: new Date(claim.expiresAt).toISOString(),
-			bypassed: isSessionBypassed(key),
+			bypassed: isSessionBypassed(claim.sessionKey, claim.agentId),
 		});
 	}
 
@@ -344,16 +416,17 @@ export function getActiveSessions(): readonly SessionInfo[] {
  * or null if healthy or not found. Throttled — only warns once per session
  * until the session is renewed.
  */
-export function getExpiryWarning(sessionKey: string): string | null {
-	if (isSessionBypassed(sessionKey)) return null;
+export function getExpiryWarning(sessionKey: string, agentId = "default"): string | null {
+	if (isSessionBypassed(sessionKey, agentId)) return null;
 	const key = normalizeSessionKey(sessionKey);
-	const claim = sessions.get(key);
+	const mapKey = scopedSessionKey(key, agentId);
+	const claim = sessions.get(mapKey);
 	if (!claim) return null;
 	const remaining = claim.expiresAt - Date.now();
 	if (remaining <= 0) return "session has expired — reconnect to start a new session";
 	if (remaining > WARN_BEFORE_MS) return null;
-	if (warnedSessions.has(sessionKey)) return null;
-	warnedSessions.add(sessionKey);
+	if (warnedSessions.has(mapKey)) return null;
+	warnedSessions.add(mapKey);
 	const mins = Math.max(1, Math.round(remaining / 60_000));
 	return `session expires in ~${mins} minute${mins === 1 ? "" : "s"} — consider /checkpoint`;
 }
@@ -362,23 +435,25 @@ export function getExpiryWarning(sessionKey: string): string | null {
  * Reset a session's TTL. Returns the new expiresAt ISO string, or null
  * if the session is not found.
  */
-export function renewSession(sessionKey: string): string | null {
+export function renewSession(sessionKey: string, agentId = "default"): string | null {
 	const key = normalizeSessionKey(sessionKey);
-	const claim = sessions.get(key);
+	const mapKey = scopedSessionKey(key, agentId);
+	const claim = sessions.get(mapKey);
 	if (!claim) return null;
 	// Reject renewal of already-expired sessions — caller should re-claim
 	if (claim.expiresAt <= Date.now()) {
-		evictExpiredSession(key, claim);
+		evictExpiredSession(mapKey, claim);
 		return null;
 	}
 	claim.expiresAt = Date.now() + STALE_SESSION_MS;
+	claimStore?.upsertActive(persistedClaim(key, claim));
 	// Keep bypass TTL aligned with the session TTL so bypassed sessions
 	// do not leak after renewal extends the session lifetime.
-	const existing = bypassedSessions.get(key);
+	const existing = bypassedSessions.get(mapKey);
 	if (existing !== undefined) {
-		bypassedSessions.set(key, claim.expiresAt);
+		bypassedSessions.set(mapKey, claim.expiresAt);
 	}
-	warnedSessions.delete(key);
+	warnedSessions.delete(mapKey);
 	logger.info("session-tracker", "Session renewed", { sessionKey: key });
 	return new Date(claim.expiresAt).toISOString();
 }
@@ -431,6 +506,73 @@ export function startSessionCleanup(): void {
 	if (cleanupStarted) return;
 	cleanupStarted = true;
 	cleanupTimer = setInterval(cleanupStaleSessions, CLEANUP_INTERVAL_MS);
+}
+
+/** Register the durable claim store after database migrations complete. */
+export function setSessionClaimStore(store: SessionClaimStore | null): void {
+	claimStore = store;
+}
+
+/**
+ * Rehydrate claims left by a previous daemon process. Expired rows are sent
+ * through the same finalizer as in-process TTL cleanup; ended rows restore the
+ * short duplicate-end tombstone without claiming the session again.
+ */
+export function restorePersistedSessions(): {
+	readonly active: number;
+	readonly expired: number;
+	readonly ended: number;
+} {
+	if (!claimStore) return { active: 0, expired: 0, ended: 0 };
+	const now = Date.now();
+	let active = 0;
+	let expired = 0;
+	let ended = 0;
+	for (const row of claimStore.list()) {
+		const expiresAt = Date.parse(row.expiresAt);
+		if (!Number.isFinite(expiresAt)) {
+			claimStore.markExpired(row.sessionKey, row.agentId);
+			expired++;
+			continue;
+		}
+		const mapKey = scopedSessionKey(row.sessionKey, row.agentId);
+		if (row.state === "ended") {
+			if (expiresAt <= now || !row.endedAt) {
+				claimStore.remove(row.sessionKey, row.agentId);
+				continue;
+			}
+			endedSessions.set(mapKey, {
+				agentId: row.agentId,
+				runtimePath: row.runtimePath ?? undefined,
+				endedAt: row.endedAt,
+				expiresAt,
+			});
+			ended++;
+			continue;
+		}
+		if (row.runtimePath === null) {
+			claimStore.remove(row.sessionKey, row.agentId);
+			expired++;
+			continue;
+		}
+
+		const claim: SessionClaim = {
+			sessionKey: row.sessionKey,
+			agentId: row.agentId,
+			runtimePath: row.runtimePath,
+			harness: row.harness ?? undefined,
+			claimedAt: row.claimedAt,
+			expiresAt,
+		};
+		sessions.set(mapKey, claim);
+		if (expiresAt <= now || row.state === "expired") {
+			evictExpiredSession(mapKey, claim);
+			expired++;
+		} else {
+			active++;
+		}
+	}
+	return { active, expired, ended };
 }
 
 /** Stop periodic cleanup (for graceful shutdown). */
@@ -502,8 +644,8 @@ export function resetSessions(): void {
 }
 
 /** Test-only: force a session claim's expiry so cleanup evicts it. */
-export function _expireSessionForTest(sessionKey: string): void {
+export function _expireSessionForTest(sessionKey: string, agentId = "default"): void {
 	const key = normalizeSessionKey(sessionKey);
-	const claim = sessions.get(key);
+	const claim = sessions.get(scopedSessionKey(key, agentId));
 	if (claim) claim.expiresAt = Date.now() - 1;
 }


### PR DESCRIPTION
Closes #1228.

## Summary

Persist session lifecycle state in SQLite so session ownership, TTL expiry, and end markers survive daemon restarts. This prevents restart-orphaned sessions from bypassing TTL finalization and keeps identical session keys isolated across agents.

## Changes

- Add migration 113 and the `session_claims` table keyed by `(session_key, agent_id)`.
- Persist claims, renewals, bypass state, expiry transitions, and ended-session tombstones.
- Restore active and ended claims during daemon startup.
- Route recovered expired claims through the existing TTL finalizer.
- Thread agent identity through session routes, hook conflict checks, ownership lookups, expiry warnings, and end handling.
- Add regression coverage for restart restoration, ended tombstones, expired claims, renewal persistence, unmarked ends, and cross-agent session-key isolation.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec changes.
- [x] Agent scoping verified on all new/changed data queries — durable claims use `(session_key, agent_id)` identity and agent-scoped route propagation.
- [x] Input/config validation and bounds checks added — lifecycle timestamps and state transitions use the existing validated tracker paths.
- [x] Error handling and fallback paths tested (no silent swallow) — startup recovery and TTL-finalizer outcomes are covered.
- [x] Security checks applied to admin/mutation endpoints — no new admin endpoint; ownership checks remain fail-closed and agent-scoped.
- [x] Docs updated for API/spec/status changes — no public API or documented behavior surface changed.
- [x] Regression tests added for each bug fix.
- [x] Lint/typecheck/tests pass locally — focused checks pass; full-repository baseline lint/typecheck issues remain outside this change.

## Migration Notes (if applicable)

Migration 113 creates `session_claims` with a composite `(session_key, agent_id)` primary key and nullable lifecycle metadata needed for restart recovery. Existing workspaces receive the table through the normal ordered migration path. Existing in-memory behavior remains compatible while the daemon upgrades and rehydrates persisted state.

- [x] Migration is idempotent — migration registration and artifact verification are covered by the core migration suite; the DDL uses `CREATE TABLE IF NOT EXISTS`.
- [x] Rollback / compatibility note included in PR description — older daemons ignore the additive table; rollback is a code rollback while retaining the unused table, or removal of migration 113 only in a controlled pre-deployment database rollback.

## Testing

- [x] `bun test platform/daemon/src/session-tracker.test.ts platform/daemon/src/session-claims.test.ts platform/daemon/src/hooks.test.ts platform/daemon/src/hooks.prompt-submit.test.ts` — 227 pass, 0 fail.
- [x] `bun test platform/core/src/migrations/migrations.test.ts` — 52 pass, 0 fail.
- [x] `bun run --filter '@signet/core' build` — pass.
- [x] `bun run --filter '@signet/daemon' build` — pass.
- [x] `bun run --filter '@signet/daemon' typecheck` — pass.
- [x] Touched-file Biome check — pass.
- [x] `git diff --check` — pass.
- [x] Tested against a running daemon in an isolated temporary workspace — health, session creation, daemon restart, and SQLite-backed session restoration verified.
- [ ] `bun test` full workspace sweep — not run; repository includes unrelated third-party reference suites.
- [ ] `bun run lint` full workspace — not run; known unrelated repository-wide formatting diagnostics remain.
- [ ] `bun run typecheck` full workspace — not run; known unrelated connector/generated-bundle failures remain outside this change.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The branch was rebased onto upstream `main` at `2d48b1cc4` (`0.181.0`). Upstream migration 112 was preserved for telemetry queue ownership; this change is registered as migration 113.

## Follow-up hardening

The second commit (`d2bb92cd8`) adds two restart/scoping regressions found during review:

- Expired ended tombstones now delete their agent-scoped map key instead of an unscoped key.
- Durable rows already marked `expired` do not emit duplicate `session.end` telemetry after each daemon restart.

Added regression coverage for both cases. The focused rerun passed 88 tests across the session, API, and migration suites, with daemon/core builds, daemon/core typechecks, touched-file Biome, and `git diff --check` passing.

The full workspace `bun run typecheck` and `bun run lint` were also exercised locally and remain blocked by unrelated connector-base/generated-bundle export errors and repository-wide package-manifest formatting drift; the touched packages and files pass their focused gates.

Live daemon proof from this branch:

- Started the built daemon on `127.0.0.1:3950` with `SIGNET_PATH=/tmp/ant-signet-1228`.
- POSTed `/api/hooks/session-start` for `restart-smoke`, agent `agent-smoke`, runtime path `plugin`.
- Confirmed the claim through `/api/sessions?agent_id=agent-smoke`.
- Terminated and restarted the daemon against the same workspace.
- New PID returned healthy from `/health`; `/api/sessions?agent_id=agent-smoke` returned the restored claim and original expiry.