### PR TITLE
fix(daemon): preserve legacy routing migration

### DIFF
--- a/platform/daemon/src/config-migration.ts
+++ b/platform/daemon/src/config-migration.ts
@@ -240,13 +240,43 @@ function writeAtomic(path: string, contents: string): void {
 // rerun for v4 configs because the incomplete migration shipped to users.
 // Idempotent: a file already at v5+ is skipped.
 
-const LEGACY_FLAT_KEYS = ["extractionProvider", "extractionModel", "extractionStrength"] as const;
+const LEGACY_FLAT_KEYS = [
+	"extractionProvider",
+	"extractionModel",
+	"extractionEndpoint",
+	"extractionBaseUrl",
+	"extractionFallbackProvider",
+	"extractionStrength",
+] as const;
+
+const LEGACY_FLAT_ROUTING_KEYS = [
+	"extractionProvider",
+	"extractionModel",
+	"extractionEndpoint",
+	"extractionBaseUrl",
+	"extractionFallbackProvider",
+] as const;
+
+const LEGACY_HARNESS_AGENT: Readonly<Record<string, string>> = {
+	"claude-code": "claude",
+	codex: "codex",
+	opencode: "opencode",
+};
 
 /** Map a legacy provider to the account name/id this migration creates. */
 function legacyAccountFor(provider: string): { name: string; family: string; cred: string } | null {
 	if (provider === "openrouter") return { name: "legacy-openrouter", family: "openrouter", cred: "OPENROUTER_API_KEY" };
 	if (provider === "anthropic") return { name: "legacy-anthropic", family: "anthropic", cred: "ANTHROPIC_API_KEY" };
 	return null; // local providers (ollama/llama-cpp/openai-compatible-local) need no account
+}
+
+function legacyExecutorFor(provider: string): { executor: string; acpxAgent?: string } | null {
+	const acpxAgent = LEGACY_HARNESS_AGENT[provider];
+	if (acpxAgent) return { executor: "acpx", acpxAgent };
+	if (["acpx", "anthropic", "openrouter", "ollama", "llama-cpp", "openai-compatible"].includes(provider)) {
+		return { executor: provider };
+	}
+	return null;
 }
 
 export function migrateLegacyRoutingToRegistry(agentsDir: string): void {
@@ -276,9 +306,11 @@ export function migrateLegacyRoutingToRegistry(agentsDir: string): void {
 	const extraction = doc.getIn(["memory", "pipelineV2", "extraction"], true);
 	const synthesis = doc.getIn(["memory", "pipelineV2", "synthesis"], true);
 	const hasLegacyFlatKeys = isMap(pipeline) && LEGACY_FLAT_KEYS.some((key) => pipeline.has(key));
+	const hasLegacyFlatRouting = isMap(pipeline) && LEGACY_FLAT_ROUTING_KEYS.some((key) => pipeline.has(key));
 	const hasNestedLegacyRouting =
-		(isMap(extraction) && (extraction.has("provider") || extraction.has("model") || extraction.has("endpoint"))) ||
-		(isMap(synthesis) && (synthesis.has("provider") || synthesis.has("model") || synthesis.has("endpoint")));
+		(isMap(extraction) &&
+			["provider", "model", "endpoint", "baseUrl", "base_url"].some((key) => extraction.has(key))) ||
+		(isMap(synthesis) && ["provider", "model", "endpoint", "baseUrl", "base_url"].some((key) => synthesis.has(key)));
 
 	if (!hasNestedLegacyRouting && !hasLegacyFlatKeys) {
 		// Nothing to migrate; still stamp v5 so we don't re-parse every startup.
@@ -289,7 +321,7 @@ export function migrateLegacyRoutingToRegistry(agentsDir: string): void {
 
 	const mutations: string[] = [];
 
-	if (hasNestedLegacyRouting) {
+	if (hasNestedLegacyRouting || hasLegacyFlatRouting) {
 		// Ensure inference/accounts and inference/targets maps exist.
 		const inference =
 			doc.getIn(["inference"], true) ?? doc.setIn(["inference"], doc.createNode({})) ?? doc.getIn(["inference"], true);
@@ -307,17 +339,40 @@ export function migrateLegacyRoutingToRegistry(agentsDir: string): void {
 		}
 	}
 
+	const existingWorkloads = doc.getIn(["inference", "workloads"], true);
+	const existingTargets = doc.getIn(["inference", "targets"], true);
+	const existingExtractionBinding = isMap(existingWorkloads)
+		? existingWorkloads.get("memoryExtraction", true)
+		: undefined;
+	const canonicalTargetRef = isMap(existingExtractionBinding)
+		? String(existingExtractionBinding.get("target", true) ?? "")
+		: "";
+	const canonicalTargetName = canonicalTargetRef.split("/", 1)[0] ?? "";
+	const hasCanonicalExtractionRoute =
+		isMap(existingTargets) && canonicalTargetName !== "" && existingTargets.has(canonicalTargetName);
+
 	function compileTarget(
-		source: ReturnType<typeof doc.getIn>,
+		providerValue: unknown,
+		modelValue: unknown,
+		endpointValue: unknown,
 		targetName: string,
-		workloadKey: "memoryExtraction",
-	): void {
-		if (!isMap(source)) return;
-		const provider = String(source.get("provider", true) ?? "");
-		const model = source.get("model", true);
-		const endpoint = source.get("endpoint", true);
-		if (!provider || provider === "none" || provider === "command") return;
-		// Create the account if the provider needs one.
+	): boolean {
+		const rawProvider = String(providerValue ?? "").trim();
+		const provider = rawProvider || (modelValue != null || endpointValue != null ? "llama-cpp" : "");
+		if (!provider || provider === "none") return false;
+		const executor = legacyExecutorFor(provider);
+		if (!executor) {
+			logger.warn("config-migration", "Legacy inference provider requires manual reconfiguration", {
+				provider,
+				target: targetName,
+				file: path,
+				note: "The legacy routing fields were preserved; configure an inference.targets entry.",
+			});
+			return false;
+		}
+
+		const model = String(modelValue ?? "");
+		const endpoint = String(endpointValue ?? "");
 		const acct = legacyAccountFor(provider);
 		if (acct) {
 			doc.setIn(
@@ -329,34 +384,55 @@ export function migrateLegacyRoutingToRegistry(agentsDir: string): void {
 				}),
 			);
 		}
-		// Create/update the target.
 		const targetNode = doc.createNode({
-			executor: provider,
+			executor: executor.executor,
+			...(executor.acpxAgent ? { acpx: { agent: executor.acpxAgent } } : {}),
 			...(acct ? { account: acct.name } : {}),
-			...(endpoint ? { endpoint: String(endpoint) } : {}),
-			models: { default: { model: model ? String(model) : "", reasoning: "medium" } },
+			...(endpoint ? { endpoint } : {}),
+			models: { default: { model, reasoning: "medium" } },
 		});
 		doc.setIn(["inference", "targets", targetName], targetNode);
-		// Bind the workload to it.
 		doc.setIn(
-			["inference", "workloads", workloadKey],
+			["inference", "workloads", "memoryExtraction"],
 			doc.createNode({
 				target: `${targetName}/default`,
 			}),
 		);
-		mutations.push(`${workloadKey} -> inference.targets.${targetName} (executor: ${provider})`);
+		mutations.push(`memoryExtraction -> inference.targets.${targetName} (executor: ${executor.executor})`);
+		return true;
 	}
 
-	if (hasNestedLegacyRouting) {
-		compileTarget(extraction, "legacy-extraction", "memoryExtraction");
+	const flatProvider = isMap(pipeline) ? pipeline.get("extractionProvider", true) : undefined;
+	const flatModel = isMap(pipeline) ? pipeline.get("extractionModel", true) : undefined;
+	const flatEndpoint = isMap(pipeline)
+		? (pipeline.get("extractionEndpoint", true) ?? pipeline.get("extractionBaseUrl", true))
+		: undefined;
+	const flatProviderText = String(flatProvider ?? "").trim();
+	let compiledFlat = false;
+	if (hasLegacyFlatRouting && !hasCanonicalExtractionRoute) {
+		compiledFlat = compileTarget(flatProvider, flatModel, flatEndpoint, "legacy-extraction");
+	}
+	if (
+		!hasCanonicalExtractionRoute &&
+		(!hasLegacyFlatRouting || (!compiledFlat && flatProviderText !== "none")) &&
+		hasNestedLegacyRouting &&
+		isMap(extraction)
+	) {
+		compileTarget(
+			extraction.get("provider", true),
+			extraction.get("model", true),
+			extraction.get("endpoint", true) ?? extraction.get("baseUrl", true) ?? extraction.get("base_url", true),
+			"legacy-extraction",
+		);
 	}
 
 	// Null the legacy ROUTING keys (keep tuning: timeout, maxTokens, enabled).
 	function nullRoutingKeys(node: ReturnType<typeof doc.getIn>, label: string): void {
 		if (!isMap(node)) return;
-		// The command provider cannot be auto-mapped (arbitrary bin/args). Leave its
-		// entire block intact so the user can manually reconfigure it.
-		if (String(node.get("provider", true) ?? "") === "command") return;
+		const provider = String(node.get("provider", true) ?? "").trim();
+		// Preserve unmappable providers so the runtime can report an actionable
+		// configuration error instead of silently deleting the user's route.
+		if (provider && provider !== "none" && !legacyExecutorFor(provider)) return;
 		for (const key of ["provider", "model", "endpoint", "fallbackProvider", "command", "baseUrl", "base_url"]) {
 			if (node.has(key)) {
 				node.delete(key);
@@ -378,11 +454,17 @@ export function migrateLegacyRoutingToRegistry(agentsDir: string): void {
 			}
 			mutations.push("moved memory.pipelineV2.extractionStrength -> extraction.strength");
 		}
+		const flatProviderText = String(pipeline.get("extractionProvider", true) ?? "").trim();
+		const canRemoveFlatRouting =
+			!flatProviderText ||
+			flatProviderText === "none" ||
+			legacyExecutorFor(flatProviderText) !== null ||
+			hasCanonicalExtractionRoute;
 		for (const key of LEGACY_FLAT_KEYS) {
-			if (pipeline.has(key)) {
-				pipeline.delete(key);
-				mutations.push(`removed memory.pipelineV2.${key}`);
-			}
+			if (!pipeline.has(key)) continue;
+			if (key !== "extractionStrength" && !canRemoveFlatRouting) continue;
+			pipeline.delete(key);
+			mutations.push(`removed memory.pipelineV2.${key}`);
 		}
 	}
 

--- a/platform/daemon/src/legacy-routing-migration.test.ts
+++ b/platform/daemon/src/legacy-routing-migration.test.ts
@@ -70,6 +70,87 @@ describe("migrateLegacyRoutingToRegistry (#947 v4, #1004 v5 cleanup)", () => {
 		}
 	});
 
+	it("compiles legacy flat extraction routing instead of deleting it", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`memory:
+  pipelineV2:
+    extractionProvider: openrouter
+    extractionModel: anthropic/claude-haiku
+    extractionEndpoint: https://openrouter.ai/api/v1
+    extractionStrength: high
+`,
+			);
+			migrateLegacyRoutingToRegistry(dir);
+			const after = readFileSync(join(dir, "agent.yaml"), "utf-8");
+
+			expect(after).toMatch(/legacy-extraction:/);
+			expect(after).toMatch(/executor: openrouter/);
+			expect(after).toMatch(/model: anthropic\/claude-haiku/);
+			expect(after).toMatch(/target: legacy-extraction\/default/);
+			expect(after).toMatch(/strength: high/);
+			expect(after).not.toContain("extractionProvider:");
+			expect(after).not.toContain("extractionModel:");
+			expect(after).not.toContain("extractionEndpoint:");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("falls back to a valid nested route when flat routing is unsupported", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`configVersion: 3
+memory:
+  pipelineV2:
+    extractionProvider: groq
+    extractionModel: groq/legacy
+    extraction:
+      provider: openrouter
+      model: anthropic/claude-haiku
+      endpoint: https://openrouter.ai/api/v1
+`,
+			);
+			migrateLegacyRoutingToRegistry(dir);
+			const after = readFileSync(join(dir, "agent.yaml"), "utf-8");
+
+			expect(after).toContain("extractionProvider: groq");
+			expect(after).toMatch(/executor: openrouter/);
+			expect(after).toMatch(/target: legacy-extraction\/default/);
+			expect(after).not.toMatch(/provider: openrouter/);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves a nested base_url when compiling the legacy route", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`memory:
+  pipelineV2:
+    extraction:
+      provider: openai-compatible
+      model: local-model
+      base_url: http://127.0.0.1:9999/v1
+`,
+			);
+			migrateLegacyRoutingToRegistry(dir);
+			const after = readFileSync(join(dir, "agent.yaml"), "utf-8");
+
+			expect(after).toMatch(/executor: openai-compatible/);
+			expect(after).toMatch(/endpoint: http:\/\/127\.0\.0\.1:9999\/v1/);
+			expect(after).not.toContain("base_url:");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("creates no account for local providers (ollama/llama-cpp/local-openai-compat)", () => {
 		const dir = setupDir();
 		try {
@@ -172,7 +253,7 @@ inference:
 memory:
   pipelineV2:
     enabled: true
-    extractionProvider: acpx
+    extractionProvider: openrouter
     extractionModel: gpt-5.3-codex-spark
     extractionStrength: medium
     extractionTimeout: 45000


### PR DESCRIPTION
## Summary

Fixes #1229. Legacy flat extraction routing fields were deleted during migration without being compiled into the inference registry, leaving background extraction with no workload target.

## Changes

- Compile `memory.pipelineV2.extractionProvider`, `extractionModel`, and endpoint fields into `inference.targets.legacy-extraction` and `inference.workloads.memoryExtraction` before cleanup.
- Map legacy folded harness providers to ACPX targets with the correct agent.
- Preserve unsupported legacy providers when no canonical extraction route exists, and emit an actionable warning instead of silently deleting configuration.
- Add a regression test covering the destructive flat-key migration path.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A: daemon migration only.

## PR Readiness (MANDATORY)

- [ ] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [ ] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [ ] Security checks applied to admin/mutation endpoints
- [ ] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

The migration remains compatible with already-canonical v4 configurations. Unsupported legacy providers are preserved for manual reconfiguration rather than deleted. A workspace already migrated by the affected release may require restoring the original legacy provider/model values before rerunning the migration; this fix prevents the destructive loss on future upgrades.

## Testing

- [x] `bun test platform/daemon/src/config-migration.test.ts platform/daemon/src/legacy-routing-migration.test.ts platform/daemon/src/inference-router.test.ts`
- [x] `bun run --filter '@signet/daemon' typecheck`
- [x] `bun run --filter '@signet/daemon' build`
- [x] `bun run typecheck`
- [ ] `bun run lint`
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The daemon package checks pass. Root typecheck currently fails in unrelated connector packages due workspace build artifacts/API drift (for example missing exports from `@signet/connector-base`), and root lint reports pre-existing repository-wide package.json formatting diagnostics; no unrelated files were changed.