### PR TITLE
fix(telemetry): count explicit session boundaries

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -27,6 +27,38 @@ Hooks are HTTP endpoints exposed by the Signet [[daemon]]. Harnesses call them a
 
 ---
 
+## Session-end Boundary Reasons
+
+**`POST /api/hooks/session-end`** accepts an optional `reason` field. Harnesses
+must send an explicit lifecycle reason when the request represents a real
+session boundary:
+
+| Reason | Boundary |
+|--------|----------|
+| `clear` | The caller discards the current session context |
+| `session.deleted` | OpenCode deleted the session |
+| `session_branch` | Oh My Pi forked the current session |
+| `session_fork` | pi forked the current session |
+| `session_shutdown` | pi shut down the current session |
+| `session_switch` | pi switched to another session |
+
+These reasons emit one anonymous `session.end` telemetry event per session
+lifetime. Repeated end requests for the same session are deduplicated.
+
+Requests without a recognized boundary reason, including ordinary
+`session.idle` calls, emit `session.turn` telemetry instead. They still persist
+the transcript and queue normal session-end processing.
+
+```json
+{
+  "harness": "opencode",
+  "sessionKey": "session-identifier",
+  "reason": "session.deleted"
+}
+```
+
+---
+
 ## Per-Session Bypass
 
 Bypass silences all Signet hooks for a single session without stopping the

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -54,8 +54,8 @@ PostHog failures, and never throws into the daemon.
 | `daemon.started` | daemon boot | `version`, `platform`, `uptimeMs` |
 | `daemon.heartbeat` | every 5 minutes | `uptimeMs`, `memoryCount`, `connectorsActive`, `pipelineMode`, `extractionProvider`, `embeddingProvider` |
 | `session.start` | real session start (deduped; stubs and clear/reset paths don't count) | `harness`, `sessionHash` |
-| `session.turn` | every `session-end` hook call (per turn, see notes) | `harness`, `promptCount`, `sessionHash` |
-| `session.end` | real session termination: explicit `reason: "clear"`, or a TTL-evicted (abandoned) session claim | `harness`, `reason` (`clear` / `expired`), `sessionHash`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `cost` |
+| `session.turn` | every non-boundary `session-end` hook call (per turn, see notes) | `harness`, `promptCount`, `sessionHash` |
+| `session.end` | real session termination: an explicit boundary reason or a TTL-evicted (abandoned) session claim | `harness`, `reason` (`clear` / `session.deleted` / `session_branch` / `session_fork` / `session_shutdown` / `session_switch` / `expired`), `sessionHash`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `cost` |
 | `llm.generate` | every LLM call | `provider`, `latencyMs`, `success`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `totalCost` |
 | `pipeline.embedding` | every embedding fetch, at the usage-recording boundary | `tokens`, `provider`, `sourceKind` (`memory-capture` / `artifact-index` / `recall` / `dreaming` / `other`), `cost` (USD) |
 | `recall.performed` | every completed shared recall search | `type` (`semantic` / `keyword` / `temporal` / `graph`), `results`, `latencyMs`, `truncated` |
@@ -82,18 +82,20 @@ Notes on individual events:
   id is first created. It covers bun, desktop, and npm uniformly and is the
   **active installs** metric. Count distinct ids with `install.activated`;
   never sum ping and activated counts.
-- **Session events (#1212)** — the three events measure different things and
+- **Session events (#1212/#1231)** — the three events measure different things and
   are deliberately not comparable with each other: `session.start` fires once
   per real session start (deduped per session key; resumed sessions do not
-  re-fire); `session.turn` fires on every `session-end` hook call, which
+  re-fire); `session.turn` fires on every non-boundary `session-end` hook call, which
   harnesses invoke per turn to persist messages — a *turns persisted* volume
-  counter; `session.end` fires only at real terminations (explicit
-  `reason: "clear"`, or TTL-evicted abandoned claims), deduped once per
+  counter; `session.end` fires only at real terminations (recognized explicit
+  boundary reasons `clear`, `session.deleted`, `session_branch`, `session_fork`,
+  `session_shutdown`, or `session_switch`, or TTL-evicted abandoned claims), deduped once per
   session lifetime via `session-end-state.ts` (in-memory, cleared on real and
   clear session starts). All three carry `sessionHash`, a 16-hex sha256 of the
   normalized session key, so distinct sessions and concurrency are countable
-  without leaking raw keys. Cleanly-finished sessions that never send
-  `clear` are not counted as ended — only provable terminations are.
+  without leaking raw keys. Cleanly-finished sessions that send a recognized
+  lifecycle reason are counted as ended; ordinary per-turn hooks without one
+  remain `session.turn` events.
 - **`first.remember` / `first.recall`** — the activation funnel. Emitted
   exactly once per install, when the first successful remember / recall
   completes (guarded by an atomic claim on the persisted install id, so

--- a/libs/sdk/src/client-p2.ts
+++ b/libs/sdk/src/client-p2.ts
@@ -110,6 +110,7 @@ export class SignetClientP2 {
 		readonly sessionId?: string;
 		readonly agentId?: string;
 		readonly capturedAt?: string;
+		readonly reason?: string;
 	}): Promise<SessionEndResponse> {
 		return this.transport.post<SessionEndResponse>("/api/hooks/session-end", opts);
 	}

--- a/platform/daemon/src/hooks-recall.test.ts
+++ b/platform/daemon/src/hooks-recall.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Hono } from "hono";
 import { __setPromptSubmitAdmissionForTests, createPromptSubmitAdmission } from "./routes/hooks-routes";
+import { resetSessionEndTelemetry } from "./session-end-state";
+import { createTelemetryCollector, setActiveTelemetry } from "./telemetry";
 
 let app: Hono;
 let dir = "";
@@ -115,6 +117,66 @@ memory:
 		expect(body.memories).toEqual(body.results);
 		expect(body.count).toBe(body.results.length);
 		expect(body.message).toBe("No matching memories found.");
+	});
+
+	it("records session.deleted as one real session.end at the route boundary", async () => {
+		if (!getDbAccessor) throw new Error("db accessor unavailable");
+		const collector = createTelemetryCollector(
+			getDbAccessor(),
+			{
+				posthogHost: "",
+				posthogApiKey: "test-key",
+				flushIntervalMs: 60000,
+				flushBatchSize: 50,
+				retentionDays: 90,
+				memorySearchQaEnabled: false,
+			},
+			"0.0.0-test",
+		);
+		setActiveTelemetry(collector);
+		resetSessionEndTelemetry();
+		try {
+			const sessionKey = "opencode-route-boundary";
+			const headers = { "Content-Type": "application/json" };
+			const start = await app.request("/api/hooks/session-start", {
+				method: "POST",
+				headers,
+				body: JSON.stringify({ harness: "opencode", sessionKey }),
+			});
+			expect(start.status).toBe(200);
+
+			const end = await app.request("/api/hooks/session-end", {
+				method: "POST",
+				headers,
+				body: JSON.stringify({ harness: "opencode", sessionKey, reason: "session.deleted" }),
+			});
+			expect(end.status).toBe(200);
+
+			const duplicate = await app.request("/api/hooks/session-end", {
+				method: "POST",
+				headers,
+				body: JSON.stringify({ harness: "opencode", sessionKey, reason: "session.deleted" }),
+			});
+			expect(duplicate.status).toBe(200);
+
+			await collector.flush();
+			const ends = collector.query().filter((event) => event.event === "session.end");
+			expect(ends).toHaveLength(1);
+			expect(ends[0]?.properties.reason).toBe("session.deleted");
+		} finally {
+			setActiveTelemetry(undefined);
+			resetSessionEndTelemetry();
+		}
+	});
+
+	it("treats a non-string session-end reason as a non-boundary call", async () => {
+		const resp = await app.request("/api/hooks/session-end", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ harness: "opencode", sessionKey: "malformed-reason", reason: 123 }),
+		});
+
+		expect(resp.status).toBe(200);
 	});
 
 	it("rejects requests missing harness", async () => {

--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -2302,13 +2302,12 @@ memory:
 	});
 
 	// ------------------------------------------------------------------
-	// #1212 — session.end telemetry fired per session-end hook call,
-	// inflating the counter ~9x vs dedup'd session.start. The per-turn
-	// event is now session.turn; session.end fires only at real session
-	// boundaries (explicit clear or TTL eviction), once per lifetime.
+	// #1212/#1231 — session.end telemetry must not fire per session-end hook
+	// call, but explicit lifecycle reasons are real boundaries. The per-turn
+	// event is session.turn; session.end is once per lifetime.
 	// ------------------------------------------------------------------
 
-	test.serial("session-end hook calls emit session.turn, never session.end (#1212)", async () => {
+	test.serial("non-boundary session-end calls emit session.turn (#1212/#1231)", async () => {
 		createMemoryDb([]);
 		ensureTelemetryTables();
 		const collector = createTelemetryCollector(getDbAccessor(), TEST_TELEMETRY_CONFIG, "0.0.0-test");
@@ -2316,7 +2315,7 @@ memory:
 		try {
 			await handleSessionEnd({ harness: "test", sessionKey: "sess-turn-a" });
 			await handleSessionEnd({ harness: "test", sessionKey: "sess-turn-a" });
-			await handleSessionEnd({ harness: "test", sessionKey: "sess-turn-b" });
+			await handleSessionEnd({ harness: "test", sessionKey: "sess-turn-b", reason: "session.idle" });
 			await collector.flush();
 
 			const turns = collector.query().filter((e) => e.event === "session.turn");
@@ -2325,6 +2324,31 @@ memory:
 			expect(ends).toHaveLength(0);
 			expect(turns[0]?.properties.harness).toBe("test");
 			expect(typeof turns[0]?.properties.sessionHash).toBe("string");
+		} finally {
+			setActiveTelemetry(undefined);
+			resetSessionEndTelemetry();
+		}
+	});
+
+	test.serial("explicit lifecycle reasons emit one session.end per boundary (#1231)", async () => {
+		createMemoryDb([]);
+		ensureTelemetryTables();
+		const collector = createTelemetryCollector(getDbAccessor(), TEST_TELEMETRY_CONFIG, "0.0.0-test");
+		setActiveTelemetry(collector);
+		try {
+			const reasons = ["session.deleted", "session_branch", "session_fork", "session_shutdown", "session_switch"];
+			const inputs = [" SESSION.DELETED ", ...reasons.slice(1)];
+			for (const [index, reason] of inputs.entries()) {
+				await handleSessionEnd({ harness: "test", sessionKey: `sess-boundary-${index}`, reason });
+			}
+			await handleSessionEnd({ harness: "test", sessionKey: "sess-boundary-0", reason: "session.deleted" });
+			await collector.flush();
+
+			const ends = collector.query().filter((e) => e.event === "session.end");
+			const turns = collector.query().filter((e) => e.event === "session.turn");
+			expect(ends).toHaveLength(reasons.length);
+			expect(ends.map((event) => event.properties.reason).sort()).toEqual([...reasons].sort());
+			expect(turns).toHaveLength(0);
 		} finally {
 			setActiveTelemetry(undefined);
 			resetSessionEndTelemetry();

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -102,6 +102,7 @@ import {
 	hasSessionEndTelemetry,
 	hashSessionKey,
 	markSessionEndTelemetry,
+	normalizeSessionBoundaryReason,
 	pruneSessionEndTelemetry,
 } from "./session-end-state";
 import {
@@ -1748,6 +1749,7 @@ export async function handleSessionEnd(req: SessionEndRequest): Promise<SessionE
 	const agentId = resolveAgentId({ agentId: req.agentId, sessionKey: req.sessionKey || req.sessionId });
 	ensureAgentRegistered(agentId);
 	const endedAt = req.capturedAt ?? new Date().toISOString();
+	const boundaryReason = normalizeSessionBoundaryReason(req.reason);
 
 	// Keep session-start dedup across normal Stop/session-end hooks. Codex can
 	// emit Stop between turns and then emit SessionStart again when an idle
@@ -1763,7 +1765,7 @@ export async function handleSessionEnd(req: SessionEndRequest): Promise<SessionE
 		});
 	}
 
-	if (req.reason === "clear") {
+	if (boundaryReason === "clear") {
 		// Caller intends to discard session context — skip checkpoint, just clean up
 		clearSessionStartDedupe(req);
 		clearRawSessionStartDedupeKey(sessionKey);
@@ -1797,12 +1799,25 @@ export async function handleSessionEnd(req: SessionEndRequest): Promise<SessionE
 	// this hook per turn (Stop/session.idle) to persist messages, so this
 	// is a "turns persisted" volume counter — not a session boundary.
 	// Real session termination is emitted separately as session.end on
-	// explicit clear or TTL eviction (#1212).
-	getActiveTelemetry()?.record("session.turn", {
-		harness: req.harness,
-		promptCount: snap?.totalPromptCount ?? null,
-		sessionHash: hashSessionKey(sessionKey),
-	});
+	// explicit lifecycle reasons or TTL eviction (#1212/#1231).
+	if (boundaryReason !== null) {
+		// Explicit lifecycle signals are real session boundaries, unlike the
+		// per-turn Stop/session.idle calls that also use this hook (#1231).
+		if (!hasSessionEndTelemetry({ agentId, harness: req.harness, sessionKey })) {
+			getActiveTelemetry()?.record("session.end", {
+				harness: req.harness,
+				reason: boundaryReason,
+				sessionHash: hashSessionKey(sessionKey),
+			});
+			markSessionEndTelemetry({ agentId, harness: req.harness, sessionKey });
+		}
+	} else {
+		getActiveTelemetry()?.record("session.turn", {
+			harness: req.harness,
+			promptCount: snap?.totalPromptCount ?? null,
+			sessionHash: hashSessionKey(sessionKey),
+		});
+	}
 	if (snap && snap.totalPromptCount > 0) {
 		try {
 			const cfg = loadMemoryConfig(getAgentsDir()).pipelineV2.continuity;

--- a/platform/daemon/src/session-end-state.ts
+++ b/platform/daemon/src/session-end-state.ts
@@ -12,6 +12,14 @@ import { resolveAgentId } from "./agent-id";
 
 const sessionEndSeen = new Map<string, number>();
 const SESSION_END_SEEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const SESSION_BOUNDARY_REASONS = new Set([
+	"clear",
+	"session.deleted",
+	"session_branch",
+	"session_fork",
+	"session_shutdown",
+	"session_switch",
+]);
 
 export type SessionEndIdentity = {
 	readonly harness?: string;
@@ -19,6 +27,13 @@ export type SessionEndIdentity = {
 	readonly sessionKey?: string;
 	readonly sessionId?: string;
 };
+
+/** Return the canonical boundary reason, or null for ordinary hook calls. */
+export function normalizeSessionBoundaryReason(reason: unknown): string | null {
+	if (typeof reason !== "string") return null;
+	const normalized = reason.trim().toLowerCase();
+	return SESSION_BOUNDARY_REASONS.has(normalized) ? normalized : null;
+}
 
 /**
  * Normalize a session key: trim and strip the "session:" prefix harnesses

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -51,11 +51,11 @@ export const TELEMETRY_EVENTS = [
 	"inference.stream",
 	"inference.fallback",
 	"session.start",
-	// Per session-end hook call — a "turns persisted" counter (harness
-	// activity volume), distinct from the real session boundary event.
+	// Per non-boundary session-end hook call — a "turns persisted" counter
+	// (harness activity volume), distinct from the real session boundary event.
 	"session.turn",
-	// Fired only at actual session boundaries (explicit clear or TTL
-	// eviction), dedup'd once per session lifetime (#1212).
+	// Fired only at actual session boundaries (recognized lifecycle reason or
+	// TTL eviction), dedup'd once per session lifetime (#1212/#1231).
 	"session.end",
 	"daemon.heartbeat",
 	// Lifecycle events (issue #1026 Phase 2): fired when the user has opted


### PR DESCRIPTION
## Summary

Fixes #1231 by distinguishing real session lifecycle boundaries from per-turn session-end hooks, so cleanly terminated sessions emit `session.end` telemetry exactly once.

## Changes

- Recognize `clear`, `session.deleted`, `session_branch`, `session_fork`, `session_shutdown`, and `session_switch` as explicit boundaries.
- Keep omitted reasons and `session.idle` as `session.turn` events.
- Deduplicate boundary telemetry by the existing normalized session identity.
- Normalize lifecycle reason casing and safely treat malformed non-string reasons as non-boundary calls.
- Add SDK support and update hook/telemetry documentation.
- Add direct handler and HTTP route regression coverage.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [x] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused verification:

- `bun test platform/daemon/src/hooks.test.ts platform/daemon/src/hooks-recall.test.ts`: 199 passed, 0 failed.
- `bun run --filter '@signet/daemon' typecheck`: passes.
- `bun run --filter '@signet/daemon' build`: passes.
- `bun run --filter '@signet/sdk' build`: passes.
- `bunx biome check` passes on all touched TypeScript files.
- `git diff --check` passes.
- Adversarial review completed; two medium findings and one normalization issue were fixed.

The full workspace commands are not clean in this checkout: root typecheck reports unrelated connector generated-artifact/export errors, and root lint reports pre-existing package JSON formatting drift. Those files are outside this PR and are not included in the diff.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This PR addresses the boundary classification gap. PR #1240 separately addresses session-end identity drift for #1233.
