### PR TITLE
feat(dashboard): make inference routes inspectable

### DIFF
--- a/docs/api/inference.md
+++ b/docs/api/inference.md
@@ -39,7 +39,8 @@ current runtime snapshot for each route target.
   "targetRefs": ["sonnet/default", "gpt/gpt54", "local/gemma4"],
   "workloadBindings": {
     "interactive": "auto",
-    "memoryExtraction": "memory-pipeline"
+    "memoryExtraction": "memory-pipeline",
+    "aggregateRecall": "aggregation/default"
   },
   "configIssues": [
     {

--- a/platform/daemon/src/inference-api.test.ts
+++ b/platform/daemon/src/inference-api.test.ts
@@ -67,6 +67,8 @@ inference:
     interactive:
       policy: auto
       taskClass: casual_chat
+    aggregateRecall:
+      target: local/gemma
 `,
 	);
 }
@@ -623,11 +625,13 @@ describe("inference routing api", () => {
 			source?: string;
 			targetRefs?: string[];
 			policies?: string[];
+			workloadBindings?: { aggregateRecall?: string };
 		};
 		expect(body.enabled).toBe(true);
 		expect(body.source).toBe("explicit");
 		expect(body.targetRefs).toContain("local/gemma");
 		expect(body.policies).toContain("auto");
+		expect(body.workloadBindings?.aggregateRecall).toBe("local/gemma");
 	});
 
 	it("exposes the pi-ai provider, OAuth, and model catalog without hiding resolver failures", async () => {

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -138,6 +138,7 @@ export interface InferenceStatusSummary {
 		readonly default?: string;
 		readonly interactive?: string;
 		readonly memoryExtraction?: string;
+		readonly aggregateRecall?: string;
 		readonly widgetGeneration?: string;
 		readonly repair?: string;
 	};
@@ -1304,6 +1305,9 @@ export class InferenceRouter {
 					memoryExtraction:
 						loaded.value.config.workloads?.memoryExtraction?.policy ??
 						loaded.value.config.workloads?.memoryExtraction?.target,
+					aggregateRecall:
+						loaded.value.config.workloads?.aggregateRecall?.policy ??
+						loaded.value.config.workloads?.aggregateRecall?.target,
 					widgetGeneration:
 						loaded.value.config.workloads?.widgetGeneration?.policy ??
 						loaded.value.config.workloads?.widgetGeneration?.target,

--- a/surfaces/dashboard/DASHBOARD_API_MAP.md
+++ b/surfaces/dashboard/DASHBOARD_API_MAP.md
@@ -145,6 +145,8 @@ native `EventSource` with headers, so auth is pumped manually).
 | `regenerateHarnesses` | POST | `/api/harnesses/regenerate` | Regenerate harness configs |
 | `getInferenceCatalog` | GET 🔐 | `/api/inference/catalog` | Model/provider catalog |
 | `getInferenceStatus` | GET 🔐 | `/api/inference/status` | Active provider/auth status |
+| `getInferenceDecision` | POST 🔐 | `/api/inference/explain` | Explain an effective route |
+| `executeInferenceProbe` | POST 🔐 | `/api/inference/execute` | Run a bounded route health probe |
 | `startOAuthLogin` | POST 🔐 (SSE) | `/api/inference/oauth/login/{provider}` | OAuth login stream (pi-ai: Claude Max/Codex/Copilot) |
 | `completeOAuthInteraction` | POST 🔐 | `/api/inference/oauth/complete` | Finish OAuth |
 | `disconnectOAuthProvider` | POST 🔐 | `/api/inference/oauth/disconnect/{provider}` | Revoke |

--- a/surfaces/dashboard/src/lib/agent-config.ts
+++ b/surfaces/dashboard/src/lib/agent-config.ts
@@ -72,6 +72,8 @@ export interface AgentConfigStore {
 	aSetNum: (path: readonly string[], value: number) => void;
 	/** Delete a key and prune now-empty parents (keeps YAML canonical). */
 	aDel: (path: readonly string[]) => void;
+	/** Apply one synchronous mutation to the current draft. */
+	aUpdate: (fn: (draft: Record<string, unknown>) => void) => void;
 	save: () => Promise<boolean>;
 	reload: () => Promise<void>;
 	saving: boolean;
@@ -158,6 +160,7 @@ export function useAgentConfig(): AgentConfigStore {
 		[mutate],
 	);
 	const aDel = useCallback((path: readonly string[]) => mutate((draft) => delPath(draft, path)), [mutate]);
+	const aUpdate = useCallback((fn: (draft: YamlObject) => void) => mutate(fn), [mutate]);
 
 	const save = useCallback(async () => {
 		if (!fileName) return false;
@@ -168,5 +171,5 @@ export function useAgentConfig(): AgentConfigStore {
 		return result.ok;
 	}, [fileName]);
 
-	return { ready, dirty, agent, aStr, aBool, aSetStr, aSetBool, aSetNum, aDel, save, reload, saving };
+	return { ready, dirty, agent, aStr, aBool, aSetStr, aSetBool, aSetNum, aDel, aUpdate, save, reload, saving };
 }

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -22,15 +22,31 @@ function authHeaders(): HeadersInit {
 }
 
 async function getJSON<T>(path: string, init?: RequestInit): Promise<T | null> {
+	return (await getJSONResult<T>(path, init)).data;
+}
+
+export interface ApiReadResult<T> {
+	readonly data: T | null;
+	readonly error: string | null;
+}
+
+async function getJSONResult<T>(path: string, init?: RequestInit): Promise<ApiReadResult<T>> {
 	try {
 		const res = await fetch(`${API_BASE}${path}`, {
 			...init,
 			headers: { Accept: "application/json", ...authHeaders(), ...(init?.headers ?? {}) },
 		});
-		if (!res.ok) return null;
-		return (await res.json()) as T;
+		const body = (await res.json().catch(() => null)) as { error?: unknown } | T | null;
+		if (!res.ok) {
+			const error =
+				typeof body === "object" && body !== null && "error" in body && typeof body.error === "string"
+					? body.error
+					: `request failed (${res.status})`;
+			return { data: null, error };
+		}
+		return { data: body as T, error: null };
 	} catch {
-		return null;
+		return { data: null, error: "request failed" };
 	}
 }
 
@@ -103,9 +119,30 @@ export interface InferenceCatalog {
 
 /** Subset of the inference router status the settings screens consume. */
 export interface InferenceStatus {
+	enabled?: boolean;
+	source?: string;
+	defaultPolicy?: string;
+	policies?: string[];
+	taskClasses?: string[];
+	targetRefs?: string[];
+	workloadBindings?: Record<string, string | undefined>;
+	configIssues?: Array<{ severity: "error" | "warning"; field: string; ref: string; message: string }>;
 	runtimeSnapshot?: {
 		targets?: Record<string, { available?: boolean; unavailableReason?: string } | undefined>;
 	};
+}
+
+export interface InferenceRouteDecision {
+	policyId: string;
+	mode: string;
+	taskClass: string;
+	targetRef: string;
+	fallbackTargetRefs: string[];
+}
+
+export interface InferenceProbeResult {
+	readonly text: string;
+	readonly decision?: InferenceRouteDecision;
 }
 
 export type OAuthLoginEvent =
@@ -745,6 +782,17 @@ export const api = {
 	},
 	getInferenceStatus: (refresh = false) =>
 		getJSON<InferenceStatus>(`/api/inference/status${refresh ? "?refresh=1" : ""}`),
+	getInferenceStatusDetailed: (refresh = false) =>
+		getJSONResult<InferenceStatus>(`/api/inference/status${refresh ? "?refresh=1" : ""}`),
+	getInferenceDecision: (body: { operation: string; refresh?: boolean }) =>
+		postJSON<InferenceRouteDecision>("/api/inference/explain", body),
+	executeInferenceProbe: (body: {
+		operation: string;
+		prompt: string;
+		maxTokens: number;
+		timeoutMs: number;
+		refresh: boolean;
+	}) => postJSON<InferenceProbeResult>("/api/inference/execute", body),
 
 	// Config files (settings: agent.yaml read/write)
 	getConfigFiles: async (): Promise<ConfigFile[]> => {

--- a/surfaces/dashboard/src/lib/inference-route-config.test.ts
+++ b/surfaces/dashboard/src/lib/inference-route-config.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "bun:test";
+import { ensureInferenceRoute } from "./inference-route-config";
+
+describe("ensureInferenceRoute", () => {
+	it("creates an explicit policy, workload bindings, and extraction task class", () => {
+		const agent: Record<string, unknown> = {
+			inference: {
+				targets: {
+					background: { executor: "llama-cpp", models: { default: { model: "gemma" } } },
+					aggregation: { executor: "llama-cpp", models: { default: { model: "qwen" } } },
+				},
+			},
+		};
+
+		ensureInferenceRoute(agent);
+
+		expect(agent.inference).toEqual({
+			targets: {
+				background: { executor: "llama-cpp", models: { default: { model: "gemma" } } },
+				aggregation: { executor: "llama-cpp", models: { default: { model: "qwen" } } },
+			},
+			workloads: {
+				memoryExtraction: { target: "background/default", taskClass: "memory_extraction" },
+				aggregateRecall: { target: "aggregation/default" },
+			},
+			taskClasses: {
+				memory_extraction: { reasoning: "low", toolsRequired: true, privacy: "restricted_remote" },
+			},
+			defaultPolicy: "default",
+			policies: {
+				default: {
+					mode: "automatic",
+					defaultTargets: ["background/default"],
+					fallbackTargets: ["background/default"],
+				},
+			},
+		});
+	});
+
+	it("keeps the generated policy scoped to primary when aggregation is added later", () => {
+		const agent: Record<string, unknown> = {
+			inference: {
+				targets: { background: { models: { default: { model: "gemma" } } } },
+			},
+		};
+
+		ensureInferenceRoute(agent);
+		(agent.inference as Record<string, unknown>).targets = {
+			background: { models: { default: { model: "gemma" } } },
+			aggregation: { models: { default: { model: "qwen" } } },
+		};
+		ensureInferenceRoute(agent);
+
+		const policy = ((agent.inference as Record<string, unknown>).policies as Record<string, unknown>).default as Record<
+			string,
+			unknown
+		>;
+		expect(policy.defaultTargets).toEqual(["background/default"]);
+		expect(policy.fallbackTargets).toEqual(["background/default"]);
+	});
+
+	it("does not promote aggregation into the generic default route", () => {
+		const agent: Record<string, unknown> = {
+			inference: {
+				targets: { aggregation: { models: { default: { model: "qwen" } } } },
+			},
+		};
+
+		ensureInferenceRoute(agent);
+
+		const inference = agent.inference as Record<string, unknown>;
+		expect(inference.defaultPolicy).toBe("default");
+		expect((inference.policies as Record<string, unknown>).default).toEqual({
+			mode: "automatic",
+			defaultTargets: [],
+			fallbackTargets: [],
+		});
+		expect(inference.workloads).toEqual({ aggregateRecall: { target: "aggregation/default" } });
+	});
+
+	it("repairs a named missing default policy without replacing custom task classes", () => {
+		const customTaskClass = { reasoning: "high", privacy: "local_only" };
+		const agent: Record<string, unknown> = {
+			inference: {
+				defaultPolicy: "local-llama",
+				policies: {},
+				taskClasses: { memory_extraction: customTaskClass },
+				targets: { background: { models: { default: { model: "gemma" } } } },
+			},
+		};
+
+		ensureInferenceRoute(agent);
+
+		const inference = agent.inference as Record<string, unknown>;
+		expect(inference.defaultPolicy).toBe("local-llama");
+		expect((inference.policies as Record<string, unknown>)["local-llama"]).toEqual({
+			mode: "automatic",
+			defaultTargets: ["background/default"],
+			fallbackTargets: ["background/default"],
+		});
+		expect((inference.taskClasses as Record<string, unknown>).memory_extraction).toBe(customTaskClass);
+	});
+
+	it("does not invent a route before a target has a model", () => {
+		const agent: Record<string, unknown> = { inference: { targets: { background: { executor: "llama-cpp" } } } };
+
+		ensureInferenceRoute(agent);
+
+		expect(agent.inference).toEqual({ targets: { background: { executor: "llama-cpp" } } });
+	});
+
+	it("preserves a custom workload binding when the dashboard target is incomplete", () => {
+		const agent: Record<string, unknown> = {
+			inference: {
+				targets: { background: { executor: "llama-cpp" } },
+				workloads: { memoryExtraction: { target: "remote/default", taskClass: "memory_extraction" } },
+			},
+		};
+
+		ensureInferenceRoute(agent);
+
+		expect((agent.inference as Record<string, unknown>).workloads).toEqual({
+			memoryExtraction: { target: "remote/default", taskClass: "memory_extraction" },
+		});
+	});
+});

--- a/surfaces/dashboard/src/lib/inference-route-config.ts
+++ b/surfaces/dashboard/src/lib/inference-route-config.ts
@@ -1,0 +1,74 @@
+type ConfigRecord = Record<string, unknown>;
+
+function record(value: unknown): ConfigRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as ConfigRecord) : {};
+}
+
+function targetRef(targetId: string, target: unknown): string | undefined {
+	const models = record(record(target).models);
+	const modelId = Object.keys(models)[0];
+	return modelId ? `${targetId}/${modelId}` : undefined;
+}
+
+/**
+ * Make the dashboard's two model assignments a complete canonical route.
+ * Existing policies and task classes remain authoritative. Generated values
+ * only fill missing routing structure so advanced configurations are not
+ * rewritten by a simple provider change.
+ */
+export function ensureInferenceRoute(agent: ConfigRecord): void {
+	const inference = record(agent.inference);
+	const targets = record(inference.targets);
+	const workloads = record(inference.workloads);
+	const taskClasses = record(inference.taskClasses);
+	const policies = record(inference.policies);
+	const backgroundRef = targetRef("background", targets.background);
+	const aggregationRef = targetRef("aggregation", targets.aggregation);
+
+	if (backgroundRef) {
+		const existing = record(workloads.memoryExtraction);
+		workloads.memoryExtraction = {
+			...existing,
+			target: backgroundRef,
+			taskClass:
+				typeof existing.taskClass === "string" && existing.taskClass.length > 0
+					? existing.taskClass
+					: "memory_extraction",
+		};
+		if (taskClasses.memory_extraction == null) {
+			taskClasses.memory_extraction = {
+				reasoning: "low",
+				toolsRequired: true,
+				privacy: "restricted_remote",
+			};
+		}
+	}
+
+	if (aggregationRef) {
+		const existing = record(workloads.aggregateRecall);
+		workloads.aggregateRecall = { ...existing, target: aggregationRef };
+	}
+
+	const refs = backgroundRef ? [backgroundRef] : [];
+	if (backgroundRef || aggregationRef) {
+		const configuredDefault =
+			typeof inference.defaultPolicy === "string" && inference.defaultPolicy.length > 0
+				? inference.defaultPolicy
+				: undefined;
+		const policyId = configuredDefault ?? Object.keys(policies)[0] ?? "default";
+		if (policies[policyId] == null) {
+			policies[policyId] = {
+				mode: "automatic",
+				defaultTargets: refs,
+				fallbackTargets: refs,
+			};
+		}
+		if (inference.defaultPolicy == null) inference.defaultPolicy = policyId;
+	}
+
+	if (Object.keys(workloads).length > 0) inference.workloads = workloads;
+	if (Object.keys(taskClasses).length > 0) inference.taskClasses = taskClasses;
+	if (Object.keys(policies).length > 0) inference.policies = policies;
+	if (Object.keys(targets).length > 0) inference.targets = targets;
+	agent.inference = inference;
+}

--- a/surfaces/dashboard/src/views/settings.tsx
+++ b/surfaces/dashboard/src/views/settings.tsx
@@ -13,7 +13,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { Download, Loader2, Search, TriangleAlert, X } from "lucide-react";
+import { CheckCircle, Download, Loader2, RefreshCw, Search, TriangleAlert, X } from "lucide-react";
 import { useSettings, type SettingsSection } from "@/lib/settings-context";
 import { api, type InferenceCatalog, type LogEntry } from "@/lib/api";
 import { useAsync } from "@/lib/use-async";
@@ -33,6 +33,7 @@ import {
 } from "@/lib/providers";
 import { ConnectProviderDialog } from "@/components/settings/connect-dialog";
 import { cn } from "@/lib/utils";
+import { ensureInferenceRoute } from "@/lib/inference-route-config";
 
 const NAV: { id: SettingsSection; label: string; icon: React.ReactNode }[] = [
 	{
@@ -305,6 +306,7 @@ function InferenceSection() {
 				/>
 				<EmbeddingEditor store={store} />
 			</div>
+			<RouteHealthPanel />
 
 			{/* BOTTOM ZONE: connected providers matrix */}
 			<div className="sig-mcard flex flex-col gap-px">
@@ -400,6 +402,120 @@ function InferenceSection() {
 	);
 }
 
+type RouteCheckReport = {
+	status: Awaited<ReturnType<typeof api.getInferenceStatusDetailed>>["data"];
+	statusError: string | null;
+	memoryExtraction: Awaited<ReturnType<typeof api.getInferenceDecision>>;
+	aggregateRecall: Awaited<ReturnType<typeof api.getInferenceDecision>>;
+	probeOk: boolean | null;
+};
+
+function RouteHealthPanel() {
+	const statusQuery = useAsync(() => api.getInferenceStatusDetailed(), { intervalMs: 60_000 });
+	const [checking, setChecking] = useState(false);
+	const [report, setReport] = useState<RouteCheckReport | null>(null);
+	const status = report?.status ?? statusQuery.data?.data;
+	const statusError = report?.statusError ?? statusQuery.data?.error;
+	const issues = status?.configIssues ?? [];
+	const targets = Object.entries(status?.runtimeSnapshot?.targets ?? {}) as Array<[
+		string,
+		{ available?: boolean; unavailableReason?: string } | undefined,
+	]>;
+
+	const checkRoutes = async () => {
+		setChecking(true);
+		const nextStatusResult = await api.getInferenceStatusDetailed(true);
+		const nextStatus = nextStatusResult.data;
+		const [memoryExtraction, aggregateRecall, probe] = await Promise.all([
+			api.getInferenceDecision({ operation: "memory_extraction", refresh: true }),
+			nextStatus?.workloadBindings?.aggregateRecall
+				? api.getInferenceDecision({ operation: "aggregate_recall", refresh: true })
+				: Promise.resolve(null),
+			nextStatus?.workloadBindings?.memoryExtraction
+				? api.executeInferenceProbe({
+						operation: "memory_extraction",
+						prompt: "Respond with exactly OK.",
+						maxTokens: 8,
+						timeoutMs: 15_000,
+						refresh: true,
+					})
+				: Promise.resolve(null),
+		]);
+		setReport({ status: nextStatus, statusError: nextStatusResult.error, memoryExtraction, aggregateRecall, probeOk: probe !== null });
+		setChecking(false);
+	};
+
+	return (
+		<div className="sig-mcard flex flex-col gap-px">
+			<div className="flex items-center justify-between px-1.5">
+				<GroupLabel suffix={report ? report.probeOk ? "· probe passed" : "· probe failed" : "· route resolution + executor availability"}>Runtime route</GroupLabel>
+				<button
+					type="button"
+					onClick={() => void checkRoutes()}
+					disabled={checking}
+					className="mb-1 flex items-center gap-1.5 rounded-[var(--radius)] border border-[oklch(1_0_0/0.14)] px-2 py-1 font-mono text-[9.5px] text-muted-foreground transition-colors hover:border-[oklch(1_0_0/0.28)] hover:text-foreground disabled:opacity-50 [html:not(.dark)_&]:border-[oklch(0_0_0/0.14)]"
+				>
+					<RefreshCw className={cn("size-3", checking && "animate-spin")} />
+					{checking ? "Checking…" : "Check routes"}
+				</button>
+			</div>
+			{status ? (
+				<>
+					<div className="grid grid-cols-2 gap-1.5 sm:grid-cols-4">
+						<RouteMeta label="Policy" value={status.defaultPolicy ?? "not set"} />
+						<RouteMeta label="Policies" value={String(status.policies?.length ?? 0)} />
+						<RouteMeta label="Task classes" value={String(status.taskClasses?.length ?? 0)} />
+						<RouteMeta label="Targets" value={String(status.targetRefs?.length ?? 0)} />
+					</div>
+					<div className="mt-1.5 flex flex-col gap-1">
+						<RouteDecisionRow label="Memory extraction" decision={report?.memoryExtraction} />
+						{status.workloadBindings?.aggregateRecall && (
+							<RouteDecisionRow label="Aggregate recall" decision={report?.aggregateRecall} />
+						)}
+					</div>
+					{targets.length > 0 && (
+						<div className="mt-1.5 flex flex-wrap gap-1.5">
+							{targets.map(([ref, state]) => (
+								<span key={ref} className={cn("rounded bg-[color-mix(in_oklch,var(--foreground)_5%,transparent)] px-1.5 py-1 font-mono text-[9px]", state?.available ? "text-success" : "text-muted-foreground")}>
+									{state?.available ? "●" : "○"} {ref}
+								</span>
+							))}
+						</div>
+					)}
+					{issues.length > 0 && (
+						<div className="mt-1.5 flex flex-col gap-1 rounded-[var(--radius)] bg-[oklch(0.7_0.15_85/0.08)] px-2.5 py-2 font-mono text-[9.5px] text-[oklch(0.72_0.15_85)]">
+							{issues.map((issue) => <span key={`${issue.field}:${issue.ref}`}>{issue.severity}: {issue.message}</span>)}
+						</div>
+					)}
+				</>
+			) : (
+				<div className="px-2.5 pb-1 text-[11px] text-muted-foreground">{statusError ?? "Route status is unavailable. Check routes to read the daemon&apos;s effective configuration."}</div>
+			)}
+		</div>
+	);
+}
+
+function RouteMeta({ label, value }: { label: string; value: string }) {
+	return (
+		<div className="rounded-[var(--radius)] bg-[color-mix(in_oklch,var(--foreground)_3%,transparent)] px-2.5 py-1.5">
+			<div className="font-mono text-[8.5px] uppercase tracking-[0.06em] text-muted-foreground">{label}</div>
+			<div className="mt-0.5 truncate font-mono text-[10.5px] font-medium">{value}</div>
+		</div>
+	);
+}
+
+function RouteDecisionRow({ label, decision }: { label: string; decision: Awaited<ReturnType<typeof api.getInferenceDecision>> | undefined }) {
+	return (
+		<div className="flex items-center gap-2 rounded-[var(--radius)] px-2.5 py-1.5 text-[11px]">
+			{decision ? <CheckCircle className="size-3.5 shrink-0 text-success" /> : <TriangleAlert className="size-3.5 shrink-0 text-[oklch(0.75_0.14_75)]" />}
+			<span className="font-medium">{label}</span>
+			<span className="truncate font-mono text-[9.5px] text-muted-foreground">
+				{decision ? `${decision.targetRef} · ${decision.policyId}` : "not resolved — check routes"}
+			</span>
+		</div>
+	);
+}
+
 /** One model-assignment row group (backend + model + endpoint + optional key).
  * Logic ported from the Svelte InferenceSection's writeTarget — field clearing
  * keeps stale config from a prior selection from leaking into agent.yaml. */
@@ -490,19 +606,23 @@ function TargetEditor({
 				}
 			}
 		}
+		store.aUpdate(ensureInferenceRoute);
 		void store.save();
 	};
 
 	const setModel = (v: string) => {
 		store.aSetStr([...targetBase, "models", "default", "model"], v);
+		store.aUpdate(ensureInferenceRoute);
 		void store.save();
 	};
 	const setEndpoint = (v: string) => {
 		store.aSetStr([...targetBase, "endpoint"], v);
+		store.aUpdate(ensureInferenceRoute);
 		void store.save();
 	};
 	const setAcpxAgent = (v: string) => {
 		store.aSetStr([...targetBase, "acpx", "agent"], v);
+		store.aUpdate(ensureInferenceRoute);
 		void store.save();
 	};
 	const setApiKey = (v: string) => {
@@ -514,6 +634,7 @@ function TargetEditor({
 			store.aDel([...targetBase, "account"]);
 			store.aDel(accountBase);
 		}
+		store.aUpdate(ensureInferenceRoute);
 		void store.save();
 	};
 


### PR DESCRIPTION
## Summary

Fix issue #1234 by making dashboard inference settings write a complete explicit route and exposing the daemon's effective route state in the UI. The settings dialog now offers a bounded routed inference probe instead of showing only model/provider configuration.

## Changes

- Add route scaffolding when inference targets are saved:
  - explicit default policy
  - memory extraction workload binding
  - aggregate recall workload binding
  - generated `memory_extraction` task-class defaults
- Preserve custom policies and task classes while repairing missing default policy entries.
- Add a Runtime route card with policy, task-class, target, workload, executor availability, route explain results, and a real bounded inference probe.
- Extend the daemon status response with the aggregate recall workload binding.
- Add API and documentation entries for detailed route status and the health probe.
- Add regression coverage for route scaffolding and aggregation-target updates.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

The Inference settings dialog was verified locally. It shows the Runtime route card between Model Assignment and Connected Providers, including the Check routes control and unavailable-state explanation when no daemon route is configured.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Focused verification passed after rebasing onto `origin/main`:

- `surfaces/dashboard`: `bun test` passed, 11 tests; `bun run typecheck` passed; `bun run build` passed.
- `@signet/core`: build passed.
- `@signet/daemon`: build passed; targeted inference status test passed.
- Touched daemon and dashboard files passed Biome checks; `git diff --check` passed.
- The full repository typecheck and lint are currently blocked by unrelated pre-existing connector/package formatting and generated-bundle failures outside this change. The daemon and dashboard checks above are clean.

The route probe is user-triggered from the settings dialog and sends the bounded prompt `Respond with exactly OK.` through the configured `memory_extraction` route.
