### PR TITLE
fix(hermes): recover claims without reinjection

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -122,6 +122,15 @@ Called when a new agent session begins. Returns memories and context formatted f
 persistence scope. Harness-native sub-agent identifiers should be sent as
 `harnessAgentId`; they are used only for parent-session inference.
 
+When a daemon restart is detected during an already-running session, a harness
+may send `claimOnly: true` with the same `sessionKey` and a `plugin` or `legacy`
+runtime path in `x-signet-runtime-path` or `runtimePath`. Signet renews the
+runtime claim and returns `{ "sessionKnown": true }` without generating
+memories, identity, or an `inject` block. This mode rejects requests without a
+runtime path. Do not use it for a new session: it deliberately preserves the
+existing conversation's stable system prompt rather than constructing startup
+context.
+
 ### Response
 
 ```json

--- a/docs/api/sessions-hooks.md
+++ b/docs/api/sessions-hooks.md
@@ -37,7 +37,8 @@ for injection into the harness system prompt. Requires `remember` permission
   "harnessAgentId": "optional-harness-subagent-id",
   "parentSessionKey": "optional-parent-session-key",
   "sessionKey": "session-uuid",
-  "runtimePath": "plugin"
+  "runtimePath": "plugin",
+  "claimOnly": false
 }
 ```
 
@@ -51,8 +52,18 @@ lineage. If it is absent, Signet infers parent context where possible from
 harness-native signals such as OpenClaw lineage session keys or recent Claude
 Code parent activity in the same project.
 
-**Response** — implementation-defined context object returned by
-`handleSessionStart`.
+Set `claimOnly: true` only when recovering an already-running harness session
+after a daemon restart. It requires a `plugin` or `legacy` runtime path in
+`x-signet-runtime-path` or `runtimePath`; requests without one return `400`.
+The daemon renews the runtime-path claim and returns `{ "sessionKnown": true }`
+without rebuilding or returning startup context. The caller must not inject
+startup memory or identity into an existing conversation: its original
+session-start context is already in the system prompt, and changing it
+mid-conversation invalidates prompt caching.
+
+**Response** — ordinary starts return the implementation-defined context object
+from `handleSessionStart`; claim-only recovery returns only
+`{ "sessionKnown": true }`.
 
 ### POST /api/hooks/user-prompt-submit
 

--- a/integrations/hermes-agent/connector/hermes-plugin/__init__.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/__init__.py
@@ -526,24 +526,19 @@ class SignetMemoryProvider(MemoryProvider):
                     project=project,
                 )
                 if result:
-                    # Handle daemon restart detection: re-initialize and refresh context.
-                    # Always return after this branch — result came from a session the
-                    # daemon no longer recognizes, so its inject would be stale/wrong.
+                    # Handle daemon restart detection by restoring only the runtime
+                    # claim. The initial system prompt is already part of this
+                    # conversation; injecting session-start context again would mutate
+                    # the cached prefix mid-conversation.
                     if not result.get("sessionKnown", True) and self._session_initialized:
-                        logger.debug("Signet daemon restarted mid-session, re-initializing")
+                        logger.debug("Signet daemon restarted mid-session, restoring session claim")
                         reinit = client.session_start(
-                            session_key, project=project,
+                            session_key, project=project, claim_only=True,
                         )
-                        if reinit:
-                            inject_from_reinit = reinit.get("inject", "")
-                            if inject_from_reinit and inject_from_reinit.strip():
-                                with self._prefetch_lock:
-                                    if prefetch_generation == self._prefetch_generation and session_key == self._session_key:
-                                        self._prefetch_result = inject_from_reinit
-                        else:
+                        if not reinit:
                             logger.warning(
-                                "Signet re-initialization after daemon restart returned no data; "
-                                "session context will be missing until next turn"
+                                "Signet session-claim recovery after daemon restart returned no data; "
+                                "the next prompt may be treated as a new session"
                             )
                         return
                     inject = result.get("inject", "")

--- a/integrations/hermes-agent/connector/hermes-plugin/client.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/client.py
@@ -280,16 +280,20 @@ class SignetClient:
         session_key: str,
         *,
         project: str = "",
+        claim_only: bool = False,
     ) -> Optional[Dict[str, Any]]:
-        """Call session-start hook. Returns identity + memories + inject text."""
+        """Call session-start hook, optionally recovering only the session claim."""
+        body: Dict[str, Any] = {
+            "harness": self._harness,
+            "sessionKey": session_key,
+            "project": project,
+            "agentId": self._agent_id,
+        }
+        if claim_only:
+            body["claimOnly"] = True
         return self._post(
             "/api/hooks/session-start",
-            {
-                "harness": self._harness,
-                "sessionKey": session_key,
-                "project": project,
-                "agentId": self._agent_id,
-            },
+            body,
             timeout=_LONG_TIMEOUT_SECS,
         )
 

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -972,6 +972,82 @@ for vector in contract["vectors"]:
 		expect(generationIncrement).toBeLessThan(queuePrefetchFn.indexOf("def _run"));
 	});
 
+	it("serializes claim-only session recovery for the daemon (#1243)", () => {
+		const clientPath = join(import.meta.dir, "hermes-plugin", "client.py");
+		const script = String.raw`
+import importlib.util
+import sys
+
+spec = importlib.util.spec_from_file_location("signet_client", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+client = module.SignetClient(agent_id="agent-a", harness="hermes-agent")
+calls = []
+def post(path, body, **kwargs):
+    calls.append({"path": path, "body": body, "kwargs": kwargs})
+    return {"sessionKnown": True}
+client._post = post
+result = client.session_start("active-session", project="/tmp/project", claim_only=True)
+assert result == {"sessionKnown": True}
+assert calls == [{
+    "path": "/api/hooks/session-start",
+    "body": {
+        "harness": "hermes-agent",
+        "sessionKey": "active-session",
+        "project": "/tmp/project",
+        "agentId": "agent-a",
+        "claimOnly": True,
+    },
+    "kwargs": {"timeout": 15},
+}]
+`;
+
+		const result = spawnSync(process.env.PYTHON?.trim() || "python3", ["-c", script, clientPath], {
+			encoding: "utf-8",
+		});
+
+		expect(result.status, result.stderr || result.stdout).toBe(0);
+	});
+
+	it("sends claim-only session-start recovery without injecting it into an active Hermes session (#1243)", () => {
+		const fixture = join(tmpRoot, "python-claim-only-recovery-fixture");
+		cpSync(join(import.meta.dir, "hermes-plugin"), join(fixture, "plugins", "memory", "signet"), { recursive: true });
+		mkdirSync(join(fixture, "agent"), { recursive: true });
+		writeFileSync(join(fixture, "agent", "__init__.py"), "");
+		writeFileSync(join(fixture, "plugins", "__init__.py"), "");
+		writeFileSync(join(fixture, "plugins", "memory", "__init__.py"), "");
+		writeFileSync(join(fixture, "agent", "memory_provider.py"), "class MemoryProvider:\n    pass\n");
+
+		const result = spawnSync(
+			"python",
+			[
+				"-c",
+				[
+					"import json",
+					"from plugins.memory.signet import SignetMemoryProvider",
+					"class FakeClient:",
+					"    def __init__(self): self.calls = []",
+					"    def user_prompt_submit(self, *args, **kwargs): return {'sessionKnown': False}",
+					"    def session_start(self, *args, **kwargs):",
+					"        self.calls.append({'args': args, 'kwargs': kwargs})",
+					"        return {'sessionKnown': True, 'inject': 'must not be injected'}",
+					"provider = SignetMemoryProvider()",
+					"provider._client = FakeClient()",
+					"provider._session_initialized = True",
+					"provider._session_key = 'active-session'",
+					"provider._project = '/tmp/project'",
+					"provider.queue_prefetch('restart recovery')",
+					"provider._prefetch_thread.join(1)",
+					"assert provider._client.calls == [{'args': ('active-session',), 'kwargs': {'project': '/tmp/project', 'claim_only': True}}]",
+					"assert provider.prefetch('restart recovery') == ''",
+				].join("\n"),
+			],
+			{ env: { ...process.env, PYTHONPATH: fixture }, encoding: "utf-8" },
+		);
+
+		expect(result.status, result.stderr || result.stdout).toBe(0);
+	});
+
 	it("accepts latest Hermes lifecycle calls with the daemon offline", () => {
 		const fixture = join(tmpRoot, "python-lifecycle-fixture");
 		cpSync(join(import.meta.dir, "hermes-plugin"), join(fixture, "plugins", "memory", "signet"), { recursive: true });

--- a/platform/daemon/src/hooks-recall.test.ts
+++ b/platform/daemon/src/hooks-recall.test.ts
@@ -279,6 +279,39 @@ memory:
 		});
 	});
 
+	it("reclaims a restarted session without rebuilding startup context (#1243)", async () => {
+		const sessionKey = "claim-only-recovery";
+		try {
+			const resp = await app.request("/api/hooks/session-start", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-signet-runtime-path": "plugin",
+				},
+				body: JSON.stringify({ harness: "hermes-agent", sessionKey, claimOnly: true }),
+			});
+
+			expect(resp.status).toBe(200);
+			expect(await resp.json()).toEqual({ sessionKnown: true });
+			expect(getSessionPath?.(sessionKey)).toBe("plugin");
+		} finally {
+			releaseSession?.(sessionKey);
+		}
+	});
+
+	it("rejects claim-only recovery without a runtime path (#1243)", async () => {
+		const sessionKey = "claim-only-missing-runtime-path";
+		const resp = await app.request("/api/hooks/session-start", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ harness: "hermes-agent", sessionKey, claimOnly: true }),
+		});
+
+		expect(resp.status).toBe(400);
+		expect(await resp.json()).toEqual({ error: "claimOnly requires a runtime path" });
+		expect(getSessionPath?.(sessionKey)).toBeUndefined();
+	});
+
 	it("skips duplicate user-prompt-submit calls from a conflicting runtime path", async () => {
 		const sessionKey = "duplicate-runtime-session";
 		try {

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -247,6 +247,8 @@ export interface SessionStartRequest {
 	harness: string;
 	project?: string;
 	agentId?: string;
+	/** Re-establish the runtime claim without rebuilding startup context. */
+	claimOnly?: boolean;
 	source?: string;
 	/** Harness-native agent/sub-agent identifier. Not used for Signet data scoping. */
 	harnessAgentId?: string;

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -269,6 +269,9 @@ function registerSessionStart(app: Hono): void {
 			}
 
 			const runtimePath = resolveRuntimePath(c, body);
+			if (body.claimOnly === true && !runtimePath) {
+				return c.json({ error: "claimOnly requires a runtime path" }, 400);
+			}
 			if (runtimePath) body.runtimePath = runtimePath;
 
 			if (body.sessionKey && runtimePath) {
@@ -303,6 +306,10 @@ function registerSessionStart(app: Hono): void {
 
 			if (checkBypass(body)) {
 				return c.json({ inject: "", memories: [], bypassed: true });
+			}
+
+			if (body.claimOnly === true) {
+				return c.json({ sessionKnown: true });
 			}
 
 			const result = await handleSessionStart(body);


### PR DESCRIPTION
## Summary

Fix #1243: daemon restart recovery now reclaims the active Hermes session without re-running session-start recall or injecting a second system-context block into the conversation.

## Changes

- Add an explicit `claimOnly: true` session-start route mode that preserves runtime-path ownership but returns only `{ "sessionKnown": true }`.
- Reject claim-only recovery without a `plugin` or `legacy` runtime path, so a successful recovery always renews an actual claim.
- Update the Hermes memory provider to use recovery mode after `sessionKnown: false`, discard every response payload, and avoid queuing an active-session injection.
- Add daemon route, Hermes client/provider, API, and hook documentation coverage for the recovery contract.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: API and hook documentation

## Screenshots

Not applicable: no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

No migration. Older daemons that ignore `claimOnly` remain safe because the Hermes provider deliberately discards the response and never queues a recovery injection.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Focused proof:

- `bun test platform/daemon/src/hooks-recall.test.ts`: 24 pass, 0 fail.
- `bun test integrations/hermes-agent/connector/index.test.ts`: 74 pass, 0 fail.
- Built `@signet/core`, `@signet/daemon`, `@signet/connector-base`, and `@signet/connector-hermes-agent`.
- Full workspace typecheck passed after generating the repository's existing embedded plugin assets.
- Isolated daemon proof: `claimOnly: true` returned `200 {"sessionKnown":true}`; a conflicting legacy runtime path then received `409`.

The full daemon suite was attempted but is not green in this worktree: 2,207 pass, 87 fail, and 21 errors. The failures include `DbAccessor is closed` background-worker errors and unrelated maintenance-worker assertions. Root lint also reports 543 existing diagnostics, predominantly repository-wide formatting drift. I did not mark either broad gate as passing.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

An adversarial review completed with no critical or high findings. It identified a missing-runtime-path hardening gap; this PR now rejects that claim-only request with `400` and includes a regression test. The review's remaining notes concern pre-existing recovery/claim ownership semantics and do not regress this change.
