### PR TITLE
fix(hermes): use python3 probe fallback

### DIFF
--- a/integrations/hermes-agent/connector/hermes-plugin/README.md
+++ b/integrations/hermes-agent/connector/hermes-plugin/README.md
@@ -30,6 +30,7 @@ Environment variables:
 - `SIGNET_AGENT_WORKSPACE` — Optional named-agent workspace path (for example `~/.agents/agents/dot`)
 - `SIGNET_AGENT_READ_POLICY` — Optional named-agent memory policy for first registration: `shared` (default), `isolated`, or `group`
 - `SIGNET_AGENT_POLICY_GROUP` — Required when `SIGNET_AGENT_READ_POLICY=group`
+- `PYTHON` — Optional Python interpreter command or path for connector probes; defaults to `python3` then `python` on Unix and `py -3`, `python`, then `python3` on Windows
 
 ## Tools
 

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -25,6 +25,39 @@ const originalEnv = {
 	SIGNET_DIR: process.env.SIGNET_DIR,
 	SIGNET_CONNECTOR_ASSETS_DIR: process.env.SIGNET_CONNECTOR_ASSETS_DIR,
 };
+
+function resolveTestPythonPath(): string {
+	const candidates =
+		process.platform === "win32"
+			? [
+					{ command: "py", args: ["-3"] },
+					{ command: "python", args: [] },
+					{ command: "python3", args: [] },
+				]
+			: [
+					{ command: "python3", args: [] },
+					{ command: "python", args: [] },
+				];
+	for (const candidate of candidates) {
+		const result = spawnSync(candidate.command, [...candidate.args, "-c", "import sys; print(sys.executable)"], {
+			encoding: "utf-8",
+		});
+		const executable = result.stdout.trim();
+		if (result.status === 0 && executable) return executable;
+	}
+	throw new Error("A Python 3 interpreter is required for the Hermes connector tests");
+}
+
+function writeTestPythonLauncher(source: string, destination: string): void {
+	if (process.platform === "win32") {
+		writeFileSync(`${destination}.cmd`, `@echo off\r\n"${source}" %*\r\n`);
+		return;
+	}
+
+	const escapedSource = source.replaceAll("'", "'\\''");
+	writeFileSync(destination, `#!/bin/sh\nexec '${escapedSource}' "$@"\n`);
+	chmodSync(destination, 0o755);
+}
 
 let tmpRoot = "";
 
@@ -933,9 +966,13 @@ for vector in contract["vectors"]:
     if actual != vector["expected"]:
         raise AssertionError(f"{vector['name']}: {actual!r} != {vector['expected']!r}")
 `;
-		const result = spawnSync(process.env.PYTHON?.trim() || "python3", ["-c", script, clientPath, contractPath], {
-			encoding: "utf-8",
-		});
+		const result = spawnSync(
+			process.env.PYTHON?.trim() || resolveTestPythonPath(),
+			["-c", script, clientPath, contractPath],
+			{
+				encoding: "utf-8",
+			},
+		);
 
 		expect(result.status, result.stderr || result.stdout).toBe(0);
 	});
@@ -1008,7 +1045,7 @@ assert calls == [{
 }]
 `;
 
-		const result = spawnSync(process.env.PYTHON?.trim() || "python3", ["-c", script, clientPath], {
+		const result = spawnSync(process.env.PYTHON?.trim() || resolveTestPythonPath(), ["-c", script, clientPath], {
 			encoding: "utf-8",
 		});
 
@@ -1025,7 +1062,7 @@ assert calls == [{
 		writeFileSync(join(fixture, "agent", "memory_provider.py"), "class MemoryProvider:\n    pass\n");
 
 		const result = spawnSync(
-			"python",
+			resolveTestPythonPath(),
 			[
 				"-c",
 				[
@@ -1072,7 +1109,7 @@ assert calls == [{
 		);
 
 		const result = spawnSync(
-			"python",
+			resolveTestPythonPath(),
 			[
 				"-c",
 				[
@@ -1100,7 +1137,7 @@ assert calls == [{
 		writeFileSync(join(fixture, "agent", "memory_provider.py"), "class MemoryProvider:\n    pass\n");
 
 		const result = spawnSync(
-			"python",
+			resolveTestPythonPath(),
 			[
 				"-c",
 				[
@@ -1140,7 +1177,7 @@ assert calls == [{
 		writeFileSync(join(fixture, "agent", "memory_provider.py"), "class MemoryProvider:\n    pass\n");
 
 		const result = spawnSync(
-			"python",
+			resolveTestPythonPath(),
 			[
 				"-c",
 				[
@@ -1194,7 +1231,7 @@ assert calls == [{
 		);
 
 		const result = spawnSync(
-			"python",
+			resolveTestPythonPath(),
 			[
 				"-c",
 				[
@@ -1236,7 +1273,7 @@ assert calls == [{
 		writeFileSync(join(fixture, "agent", "memory_provider.py"), "class MemoryProvider:\n    pass\n");
 
 		const result = spawnSync(
-			"python",
+			resolveTestPythonPath(),
 			[
 				"-c",
 				[
@@ -1280,7 +1317,7 @@ assert calls == [{
 	it("only forwards SIGNET_TOKEN to trusted daemon origins", () => {
 		const clientPath = join(import.meta.dir, "hermes-plugin", "client.py");
 		const result = spawnSync(
-			"python",
+			resolveTestPythonPath(),
 			[
 				"-c",
 				[
@@ -1351,7 +1388,7 @@ assert calls == [{
 		cpSync(join(import.meta.dir, "hermes-plugin"), pluginDir, { recursive: true });
 
 		const result = spawnSync(
-			"python",
+			resolveTestPythonPath(),
 			[
 				"-c",
 				[
@@ -1770,18 +1807,41 @@ describe("HermesAgentConnector — native bundle (SIGNET_DIR) plugin resolution"
 		const hermesRepo = join(tmpRoot, "hermes-agent");
 		const hermesHome = join(tmpRoot, ".hermes");
 		const pythonBinDir = join(tmpRoot, "bin");
-		const python3Path = spawnSync("python3", ["-c", "import sys; print(sys.executable)"], {
-			encoding: "utf-8",
-		}).stdout.trim();
+		const pythonPath = resolveTestPythonPath();
 
-		expect(python3Path).not.toBe("");
 		mkdirSync(pythonBinDir, { recursive: true });
-		symlinkSync(python3Path, join(pythonBinDir, "python3"));
+		writeTestPythonLauncher(pythonPath, join(pythonBinDir, "python3"));
 		writeHermesMemoryFixture(hermesRepo);
 		process.env.HERMES_HOME = hermesHome;
 		process.env.HERMES_REPO = hermesRepo;
 		process.env.PATH = pythonBinDir;
 		// biome-ignore lint/performance/noDelete: exercise the python3 default
+		delete process.env.PYTHON;
+
+		await new HermesAgentConnector().install(tmpRoot);
+		const report = await diagnoseHermesIntegration({
+			hermesHome,
+			hermesRepo: hermesRepo,
+			daemonUrl: "http://127.0.0.1:1",
+		});
+		const checks = Object.fromEntries(report.checks.map((check) => [check.id, check]));
+
+		expect(checks["tool-routing"]?.ok).toBe(true);
+	});
+
+	it("uses python when python3 is unavailable", async () => {
+		const hermesRepo = join(tmpRoot, "hermes-agent");
+		const hermesHome = join(tmpRoot, ".hermes");
+		const pythonBinDir = join(tmpRoot, "bin");
+		const pythonPath = resolveTestPythonPath();
+
+		mkdirSync(pythonBinDir, { recursive: true });
+		writeTestPythonLauncher(pythonPath, join(pythonBinDir, "python"));
+		writeHermesMemoryFixture(hermesRepo);
+		process.env.HERMES_HOME = hermesHome;
+		process.env.HERMES_REPO = hermesRepo;
+		process.env.PATH = pythonBinDir;
+		// biome-ignore lint/performance/noDelete: exercise the python fallback
 		delete process.env.PYTHON;
 
 		await new HermesAgentConnector().install(tmpRoot);
@@ -1813,7 +1873,7 @@ describe("HermesAgentConnector — native bundle (SIGNET_DIR) plugin resolution"
 		expect(result.warnings.some((warning) => warning.includes("Hermes Signet provider installed"))).toBe(false);
 
 		const probe = spawnSync(
-			process.env.PYTHON?.trim() || "python3",
+			process.env.PYTHON?.trim() || resolveTestPythonPath(),
 			[
 				"-c",
 				[

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -8,6 +8,8 @@ import { HermesAgentConnector, diagnoseHermesIntegration } from "./src/index.js"
 
 const originalEnv = {
 	HOME: process.env.HOME,
+	PATH: process.env.PATH,
+	PYTHON: process.env.PYTHON,
 	HERMES_REPO: process.env.HERMES_REPO,
 	HERMES_HOME: process.env.HERMES_HOME,
 	SIGNET_AGENT_ID: process.env.SIGNET_AGENT_ID,
@@ -153,6 +155,8 @@ beforeEach(() => {
 	tmpRoot = mkdtempSync(join(tmpdir(), "signet-hermes-connector-"));
 	process.env.HOME = tmpRoot;
 	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
+	delete process.env.PYTHON;
+	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.HERMES_REPO;
 	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.HERMES_HOME;
@@ -181,6 +185,8 @@ beforeEach(() => {
 
 afterEach(() => {
 	restoreEnv("HOME");
+	restoreEnv("PATH");
+	restoreEnv("PYTHON");
 	restoreEnv("HERMES_REPO");
 	restoreEnv("HERMES_HOME");
 	restoreEnv("SIGNET_AGENT_ID");
@@ -1760,6 +1766,35 @@ describe("HermesAgentConnector — native bundle (SIGNET_DIR) plugin resolution"
 		}
 	});
 
+	it("uses python3 for Hermes diagnostics when python is unavailable", async () => {
+		const hermesRepo = join(tmpRoot, "hermes-agent");
+		const hermesHome = join(tmpRoot, ".hermes");
+		const pythonBinDir = join(tmpRoot, "bin");
+		const python3Path = spawnSync("python3", ["-c", "import sys; print(sys.executable)"], {
+			encoding: "utf-8",
+		}).stdout.trim();
+
+		expect(python3Path).not.toBe("");
+		mkdirSync(pythonBinDir, { recursive: true });
+		symlinkSync(python3Path, join(pythonBinDir, "python3"));
+		writeHermesMemoryFixture(hermesRepo);
+		process.env.HERMES_HOME = hermesHome;
+		process.env.HERMES_REPO = hermesRepo;
+		process.env.PATH = pythonBinDir;
+		// biome-ignore lint/performance/noDelete: exercise the python3 default
+		delete process.env.PYTHON;
+
+		await new HermesAgentConnector().install(tmpRoot);
+		const report = await diagnoseHermesIntegration({
+			hermesHome,
+			hermesRepo: hermesRepo,
+			daemonUrl: "http://127.0.0.1:1",
+		});
+		const checks = Object.fromEntries(report.checks.map((check) => [check.id, check]));
+
+		expect(checks["tool-routing"]?.ok).toBe(true);
+	});
+
 	it("leaves Signet discoverable and active to Hermes without running hermes memory setup", async () => {
 		const signetDir = join(tmpRoot, "signet-bundle");
 		const bundlePluginDir = join(signetDir, "runtime", "connectors", "hermes-agent", "hermes-plugin");
@@ -1778,7 +1813,7 @@ describe("HermesAgentConnector — native bundle (SIGNET_DIR) plugin resolution"
 		expect(result.warnings.some((warning) => warning.includes("Hermes Signet provider installed"))).toBe(false);
 
 		const probe = spawnSync(
-			process.env.PYTHON?.trim() || "python",
+			process.env.PYTHON?.trim() || "python3",
 			[
 				"-c",
 				[

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -575,39 +575,59 @@ function probeHermesProvider(hermesRepo: string): HermesProbeResult {
 		"print(json.dumps({'toolNames': names, 'missing': [name for name in required if name not in names]}))",
 	].join("\n");
 
-	const python = process.env.PYTHON?.trim() || "python3";
-	const result = spawnSync(python, ["-c", script], {
-		cwd: hermesRepo,
-		env: { ...process.env, PYTHONPATH: hermesRepo },
-		encoding: "utf-8",
-		timeout: 5_000,
-	});
+	const configuredPython = process.env.PYTHON?.trim();
+	const candidates = configuredPython
+		? [{ command: configuredPython, args: [] }]
+		: process.platform === "win32"
+			? [
+					{ command: "py", args: ["-3"] },
+					{ command: "python", args: [] },
+					{ command: "python3", args: [] },
+				]
+			: [
+					{ command: "python3", args: [] },
+					{ command: "python", args: [] },
+				];
+	const errors: string[] = [];
 
-	if (result.error) {
-		return { ok: false, toolNames: [], error: result.error.message };
-	}
-	if (result.status !== 0) {
-		const err = `${result.stderr || result.stdout || `python exited ${result.status}`}`.trim();
-		return { ok: false, toolNames: [], error: err };
+	for (const candidate of candidates) {
+		const result = spawnSync(candidate.command, [...candidate.args, "-c", script], {
+			cwd: hermesRepo,
+			env: { ...process.env, PYTHONPATH: hermesRepo },
+			encoding: "utf-8",
+			timeout: 5_000,
+		});
+
+		if (result.error) {
+			errors.push(`${candidate.command}: ${result.error.message}`);
+			continue;
+		}
+		if (result.status !== 0) {
+			const err = `${result.stderr || result.stdout || `${candidate.command} exited ${result.status}`}`.trim();
+			errors.push(`${candidate.command}: ${err}`);
+			continue;
+		}
+
+		try {
+			const parsed = JSON.parse(result.stdout.trim()) as { toolNames?: unknown; missing?: unknown };
+			const toolNames = Array.isArray(parsed.toolNames)
+				? parsed.toolNames.filter((name): name is string => typeof name === "string")
+				: [];
+			const missing = Array.isArray(parsed.missing)
+				? parsed.missing.filter((name): name is string => typeof name === "string")
+				: [];
+			return {
+				ok: missing.length === 0,
+				toolNames,
+				error: missing.length > 0 ? `Missing tools: ${missing.join(", ")}` : null,
+			};
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			errors.push(`${candidate.command}: Could not parse Hermes provider probe output: ${msg}`);
+		}
 	}
 
-	try {
-		const parsed = JSON.parse(result.stdout.trim()) as { toolNames?: unknown; missing?: unknown };
-		const toolNames = Array.isArray(parsed.toolNames)
-			? parsed.toolNames.filter((name): name is string => typeof name === "string")
-			: [];
-		const missing = Array.isArray(parsed.missing)
-			? parsed.missing.filter((name): name is string => typeof name === "string")
-			: [];
-		return {
-			ok: missing.length === 0,
-			toolNames,
-			error: missing.length > 0 ? `Missing tools: ${missing.join(", ")}` : null,
-		};
-	} catch (e) {
-		const msg = e instanceof Error ? e.message : String(e);
-		return { ok: false, toolNames: [], error: `Could not parse Hermes provider probe output: ${msg}` };
-	}
+	return { ok: false, toolNames: [], error: errors.join("; ") || "No Python interpreter found" };
 }
 
 async function checkDaemon(daemonUrl: string): Promise<{ ok: boolean; detail: string }> {

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -575,7 +575,7 @@ function probeHermesProvider(hermesRepo: string): HermesProbeResult {
 		"print(json.dumps({'toolNames': names, 'missing': [name for name in required if name not in names]}))",
 	].join("\n");
 
-	const python = process.env.PYTHON?.trim() || "python";
+	const python = process.env.PYTHON?.trim() || "python3";
 	const result = spawnSync(python, ["-c", script], {
 		cwd: hermesRepo,
 		env: { ...process.env, PYTHONPATH: hermesRepo },


### PR DESCRIPTION
## Summary

Fixes #1230. Hermes connector provider probes now resolve a supported Python interpreter across Linux, macOS, and Windows instead of requiring one unversioned command name.

## Changes

- Honor an explicit `PYTHON` interpreter override when configured.
- Use `python3` then `python` on Unix, and `py -3`, `python`, then `python3` on Windows.
- Add regression coverage for both python3-only and python-only PATHs without requiring symlink privileges.
- Update the shipped Hermes provider documentation with the interpreter override and resolution order.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

Not applicable. This is a connector/runtime probe fix.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations were touched.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused verification:

- `bun test integrations/hermes-agent/connector/index.test.ts` passed: 76 tests, 0 failures.
- `bunx biome check integrations/hermes-agent/connector/src/index.ts integrations/hermes-agent/connector/index.test.ts` passed.
- `bun run --filter @signet/connector-hermes-agent typecheck` passed.
- `bun run --filter @signet/connector-hermes-agent build` passed.
- Both fallback regression tests fail when their fallback candidate is removed and pass with the platform-aware resolver.
- The branch was rebased onto current `origin/main` after adversarial review found stale telemetry base drift.
- Repository-wide `bun run lint` remains blocked by the existing unrelated formatting baseline; touched files pass Biome.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The readiness checks cover the repository contract. This change adds no data queries, API/schema changes, migrations, or admin mutations. The resolver keeps explicit `PYTHON` overrides unchanged and only tries fallback candidates when that variable is unset.