### PR TITLE
fix(telemetry): enforce pipeline error pairs

### DIFF
--- a/platform/daemon/src/pipeline-error.test.ts
+++ b/platform/daemon/src/pipeline-error.test.ts
@@ -1,8 +1,41 @@
-import { describe, expect, it } from "bun:test";
-import { isPipelineTimeout } from "./pipeline-error";
+import { afterEach, describe, expect, it } from "bun:test";
+import { isPipelineTimeout, recordPipelineError } from "./pipeline-error";
+import { type TelemetryCollector, type TelemetryEvent, setActiveTelemetry } from "./telemetry";
+
+afterEach(() => {
+	setActiveTelemetry(undefined);
+});
 
 describe("pipeline error classification", () => {
 	it("classifies the inference router deadline error as a timeout", () => {
 		expect(isPipelineTimeout(new Error("Agent session exceeded the 90000ms deadline"))).toBe(true);
+	});
+
+	it("preserves the stage/code telemetry payload for valid pairs", () => {
+		const events: TelemetryEvent[] = [];
+		const collector: TelemetryCollector = {
+			enabled: true,
+			record(event, properties): void {
+				events.push({ id: "test", event, timestamp: "2026-01-01T00:00:00.000Z", properties });
+			},
+			reopenSession(): void {},
+			recordFirstUse(): void {},
+			async flush(): Promise<void> {},
+			start(): void {},
+			async stop(): Promise<void> {},
+			query(): readonly TelemetryEvent[] {
+				return events;
+			},
+			anonymizeAgentId(agentId: string): string {
+				return agentId;
+			},
+		};
+		setActiveTelemetry(collector);
+
+		recordPipelineError("embedding", "EMBEDDING_TIMEOUT");
+
+		expect(events).toHaveLength(1);
+		expect(events[0]?.event).toBe("pipeline.error");
+		expect(events[0]?.properties).toEqual({ stage: "embedding", code: "EMBEDDING_TIMEOUT" });
 	});
 });

--- a/platform/daemon/src/pipeline-error.ts
+++ b/platform/daemon/src/pipeline-error.ts
@@ -1,4 +1,4 @@
-import type { ErrorCode, ErrorStage } from "./analytics";
+import type { ERROR_CODES, ErrorCode, ErrorStage } from "./analytics";
 import { getActiveTelemetry } from "./telemetry";
 
 export type PipelineErrorStage = Extract<ErrorStage, "extraction" | "decision" | "embedding">;
@@ -13,10 +13,27 @@ export type PipelineErrorCode = Extract<
 	| "EMBEDDING_TIMEOUT"
 >;
 
+type PipelineErrorCodeForStage<Stage extends PipelineErrorStage> = {
+	[Code in PipelineErrorCode]: (typeof ERROR_CODES)[Code] extends Stage ? Code : never;
+}[PipelineErrorCode];
+
+export type PipelineErrorPair = {
+	[Stage in PipelineErrorStage]: [stage: Stage, code: PipelineErrorCodeForStage<Stage>];
+}[PipelineErrorStage];
+
 /** Record a stage/code pair without exposing provider messages or stack data. */
-export function recordPipelineError(stage: PipelineErrorStage, code: PipelineErrorCode): void {
+export function recordPipelineError(...pair: PipelineErrorPair): void {
+	const [stage, code] = pair;
 	getActiveTelemetry()?.record("pipeline.error", { stage, code });
 }
+
+// Compile-time regression check: a code from another stage must not be accepted.
+type Assert<T extends true> = T;
+type IsAssignable<From, To> = [From] extends [To] ? true : false;
+type PipelineErrorParameters = Parameters<typeof recordPipelineError>;
+type MismatchedPipelineErrorPairIsRejected = Assert<
+	IsAssignable<["embedding", "DECISION_TIMEOUT"], PipelineErrorParameters> extends false ? true : false
+>;
 
 export function isPipelineTimeout(error: unknown): boolean {
 	if (error instanceof DOMException && error.name === "AbortError") return true;


### PR DESCRIPTION
## Summary

Closes #1236 by making `recordPipelineError()` accept only stage/code pairs allowed by the analytics taxonomy. Contradictory telemetry such as `embedding` + `DECISION_TIMEOUT` now fails at compile time.

## Changes

- Derive a stage-keyed tuple union from `ERROR_CODES` for the pipeline error emitter.
- Preserve the existing runtime `{ stage, code }` telemetry payload.
- Add a compile-time regression assertion that rejects mismatched pairs.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no migrations touched.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Focused telemetry tests passed: 66 tests, 258 assertions across `pipeline-error`, embedding, dreaming, and document-route paths.
- `bun run --filter '@signet/daemon' typecheck` passed.
- `bun run --filter '@signet/daemon' build` passed.
- The sabotage check restored the old independent signature and confirmed `tsc` fails on the compile-time regression assertion.
- The affected daemon source passed Biome; the aggregate local check refers to the affected package. Root `bun run lint` remains blocked by pre-existing formatting failures in untouched package manifests. Root `bun run typecheck` remains blocked by unrelated pre-existing connector errors; the affected daemon package typecheck passes.
