### PR TITLE
fix(daemon): report previous exit telemetry

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -52,6 +52,7 @@ PostHog failures, and never throws into the daemon.
 | `install.activated` | first daemon run of a new install (persisted install id first created) | `version`, `platform` |
 | `first.remember` / `first.recall` | first successful remember / recall per install, exactly once | `version`, `platform` |
 | `daemon.started` | daemon boot | `version`, `platform`, `uptimeMs` |
+| `daemon.previous_exit` | next successful boot reconciles the prior lifecycle record, exactly once when one exists | `classification` (`clean` / `error` / `unrecorded`), `reasonCategory`, `exitCode`, `previousVersion`, `previousUptimeMs`, `restartDelayMs` |
 | `daemon.heartbeat` | every 5 minutes | `uptimeMs`, `memoryCount`, `connectorsActive`, `pipelineMode`, `extractionProvider`, `embeddingProvider` |
 | `session.start` | real session start (deduped; stubs and clear/reset paths don't count) | `harness`, `sessionHash` |
 | `session.turn` | every non-boundary `session-end` hook call (per turn, see notes) | `harness`, `promptCount`, `sessionHash` |
@@ -73,6 +74,15 @@ Declared but **not yet emitted**: `pipeline.extraction` and
 
 Notes on individual events:
 
+- **`daemon.previous_exit`** — emitted once by the next successful boot when
+  a valid prior lifecycle record exists. `clean` and `error` come from terminal
+  records; `starting` and `running` become `unrecorded`, because the prior
+  process died before it could write a terminal state. The event never claims
+  SIGKILL versus OOM, which the local record cannot distinguish. `reasonCategory`
+  is a bounded category (`signal`, `update`, `uncaught_exception`,
+  `unhandled_rejection`, `startup`, or `other`), and the duration, version, and
+  exit-code fields are bounded. The raw lifecycle reason, error, PID, systemd
+  unit, and local paths are not sent.
 - **`install.ping`** — the wrapper postinstall counter. Each ping uses a
   *fresh throwaway UUID*, so it never joins the daemon's persisted id: one
   physical install is two PostHog users across ping and daemon events. Bun
@@ -276,6 +286,7 @@ vault mirrors the key PostHog aggregates for daily review via
 | 0.174.0 | `dreaming.pass` with provider-reported token usage and cost |
 | 0.176.0 | Sanitized crash reports: full `error.occurred` payload (truncated, home-stripped message + top-8 stack frames) and rate-limited `EventLoopLag` wedge reports |
 | next | `session.turn` + real `session.end` split (#1212): the per-turn event renamed from the old `session.end`; `session.end` now fires only at real terminations, deduped per lifetime; `sessionHash` added to all three session events |
+| Unreleased | Previous daemon-exit reconciliation: `daemon.previous_exit` reports bounded `clean`, `error`, or `unrecorded` classification on the next boot (#1255) |
 | Unreleased | `recall.performed` with anonymous recall type, result count, latency, and truncation metrics (#1203) |
 | Unreleased | First-run activation funnel: `first.remember` / `first.recall`, exactly once per install (#1202) |
 | Unreleased | `pipeline.embedding` cost rates and collector-derived session token/cost totals (#1201) |

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -57,7 +57,13 @@ import { writeFileIfChangedAsync } from "./file-sync";
 import { createSignetHttpServer } from "./http-server";
 import { syncAgentWorkspaces } from "./identity-sync";
 import { type InferenceStatusSummary, getOrCreateInferenceRouter } from "./inference-router.js";
-import { type DaemonLifecycle, writeDaemonLifecycle } from "./lifecycle";
+import {
+	type DaemonLifecycle,
+	classifyPreviousDaemonExit,
+	previousExitTelemetryProperties,
+	readDaemonLifecycle,
+	writeDaemonLifecycle,
+} from "./lifecycle";
 import { closeInferenceProviderResolver, initInferenceProviderResolver } from "./llm";
 import { logger } from "./logger";
 import { type ResolvedMemoryConfig, graphWriteCaps, loadMemoryConfig } from "./memory-config";
@@ -1873,7 +1879,9 @@ async function main() {
 		} catch {}
 	});
 
+	const previousLifecycle = readDaemonLifecycle(AGENTS_DIR);
 	lifecycleStartedAt = new Date().toISOString();
+	const previousExit = classifyPreviousDaemonExit(previousLifecycle, lifecycleStartedAt);
 	writeDaemonLifecycle(AGENTS_DIR, buildLifecycleRecord("starting"));
 
 	// Config migrations must precede every initialization path that resolves
@@ -2038,6 +2046,10 @@ async function main() {
 		telemetryRef = telemetryCollector;
 		setTelemetryRef(telemetryCollector);
 		setActiveTelemetry(telemetryCollector);
+
+		if (previousExit !== null) {
+			telemetryCollector.record("daemon.previous_exit", previousExitTelemetryProperties(previousExit));
+		}
 
 		// Lifecycle event (issue #1026 Phase 2): version + platform only.
 		telemetryCollector.record("daemon.started", {

--- a/platform/daemon/src/lifecycle.test.ts
+++ b/platform/daemon/src/lifecycle.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { lifecyclePath, readDaemonLifecycle, writeDaemonLifecycle } from "./lifecycle";
+import { classifyPreviousDaemonExit, lifecyclePath, readDaemonLifecycle, writeDaemonLifecycle } from "./lifecycle";
 
 // Regression tests for issue #1148: a daemon death must be distinguishable as
 // clean, error, or unrecorded (killed/crashed) from the durable lifecycle
@@ -94,6 +94,99 @@ describe("daemon lifecycle record (#1148)", () => {
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}
+	});
+
+	it("classifies a prior clean exit with bounded restart metadata (#1255)", () => {
+		const result = classifyPreviousDaemonExit(
+			{
+				state: "clean",
+				pid: 4242,
+				version: "0.165.0",
+				startedAt: "2026-08-07T00:00:00.000Z",
+				reason: "signal:SIGTERM",
+				exitCode: 0,
+				exitedAt: "2026-08-07T01:00:00.000Z",
+			},
+			"2026-08-07T01:05:00.000Z",
+		);
+		expect(result).toEqual({
+			classification: "clean",
+			previousVersion: "0.165.0",
+			previousUptimeMs: 3_600_000,
+			reasonCategory: "signal",
+			exitCode: 0,
+			restartDelayMs: 300_000,
+		});
+	});
+
+	it("classifies a catchable error without exporting its raw reason or message (#1255)", () => {
+		const result = classifyPreviousDaemonExit(
+			{
+				state: "error",
+				pid: 9,
+				version: "0.165.0",
+				startedAt: "2026-08-07T00:00:00.000Z",
+				reason: "error:uncaughtException",
+				exitCode: 1,
+				exitedAt: "2026-08-07T00:00:30.000Z",
+				error: "secret local error text",
+			},
+			"2026-08-07T00:02:00.000Z",
+		);
+		expect(result).toEqual({
+			classification: "error",
+			previousVersion: "0.165.0",
+			previousUptimeMs: 30_000,
+			reasonCategory: "uncaught_exception",
+			exitCode: 1,
+			restartDelayMs: 90_000,
+		});
+	});
+
+	it("bounds previous-exit fields and drops arbitrary reasons (#1255)", () => {
+		const result = classifyPreviousDaemonExit(
+			{
+				state: "error",
+				pid: 7,
+				version: "x".repeat(100),
+				startedAt: "2020-01-01T00:00:00.000Z",
+				reason: "error:secret local reason",
+				exitCode: 9999,
+				exitedAt: "2021-01-01T00:00:00.000Z",
+			},
+			"2022-01-01T00:00:00.000Z",
+		);
+		expect(result).toEqual({
+			classification: "error",
+			previousVersion: "x".repeat(64),
+			previousUptimeMs: 365 * 24 * 60 * 60 * 1000,
+			reasonCategory: "other",
+			exitCode: 255,
+			restartDelayMs: 365 * 24 * 60 * 60 * 1000,
+		});
+	});
+
+	it("classifies starting and running records as unrecorded deaths (#1255)", () => {
+		for (const state of ["starting", "running"] as const) {
+			const result = classifyPreviousDaemonExit(
+				{
+					state,
+					pid: 7,
+					version: "0.165.0",
+					startedAt: "2026-08-07T00:00:00.000Z",
+				},
+				"2026-08-07T01:00:00.000Z",
+			);
+			expect(result).toEqual({
+				classification: "unrecorded",
+				previousVersion: "0.165.0",
+				previousUptimeMs: 3_600_000,
+			});
+		}
+	});
+
+	it("does not classify a first boot without a prior lifecycle record (#1255)", () => {
+		expect(classifyPreviousDaemonExit(null, "2026-08-07T01:00:00.000Z")).toBeNull();
 	});
 
 	it("replaces the previous record in place without leaving a temp file", () => {

--- a/platform/daemon/src/lifecycle.ts
+++ b/platform/daemon/src/lifecycle.ts
@@ -33,6 +33,117 @@ export interface DaemonLifecycle {
 	readonly error?: string;
 }
 
+export type DaemonPreviousExitClassification = "clean" | "error" | "unrecorded";
+export type DaemonPreviousExitReasonCategory =
+	| "signal"
+	| "update"
+	| "uncaught_exception"
+	| "unhandled_rejection"
+	| "startup"
+	| "other";
+
+/** Bounded fields for the anonymous daemon.previous_exit event. */
+export interface DaemonPreviousExitTelemetry {
+	readonly classification: DaemonPreviousExitClassification;
+	readonly previousVersion?: string;
+	readonly previousUptimeMs?: number;
+	readonly reasonCategory?: DaemonPreviousExitReasonCategory;
+	readonly exitCode?: number;
+	readonly restartDelayMs?: number;
+}
+
+const MAX_PREVIOUS_EXIT_INTERVAL_MS = 365 * 24 * 60 * 60 * 1000;
+const MAX_EXIT_CODE = 255;
+
+function intervalMs(startAt: string | undefined, endAt: string | undefined): number | null {
+	if (typeof startAt !== "string" || typeof endAt !== "string") return null;
+	const duration = Date.parse(endAt) - Date.parse(startAt);
+	if (!Number.isFinite(duration) || duration < 0) return null;
+	return Math.min(Math.round(duration), MAX_PREVIOUS_EXIT_INTERVAL_MS);
+}
+
+function boundedVersion(version: string | undefined): string | null {
+	if (typeof version !== "string" || version.length === 0) return null;
+	return Array.from(version, (char) => {
+		const code = char.charCodeAt(0);
+		return code <= 0x1f || code === 0x7f ? " " : char;
+	})
+		.join("")
+		.slice(0, 64);
+}
+
+function boundedExitCode(exitCode: number | undefined): number | null {
+	if (typeof exitCode !== "number" || !Number.isInteger(exitCode) || !Number.isFinite(exitCode)) return null;
+	return Math.max(-MAX_EXIT_CODE, Math.min(MAX_EXIT_CODE, exitCode));
+}
+
+function reasonCategory(reason: string | undefined): DaemonPreviousExitReasonCategory | null {
+	if (typeof reason !== "string") return null;
+	if (reason.startsWith("signal:")) return "signal";
+	if (reason.startsWith("update:")) return "update";
+	if (reason === "error:uncaughtException") return "uncaught_exception";
+	if (reason === "error:unhandledRejection") return "unhandled_rejection";
+	if (reason === "error:startup") return "startup";
+	if (reason.startsWith("error:")) return "other";
+	return null;
+}
+
+/**
+ * Convert the previous durable record into bounded anonymous telemetry fields.
+ * A terminal record is a catchable exit; a starting/running record is an
+ * unrecorded death because the process did not reach a terminal exit path.
+ */
+export function classifyPreviousDaemonExit(
+	record: DaemonLifecycle | null,
+	currentStartedAt: string,
+): DaemonPreviousExitTelemetry | null {
+	if (record === null) return null;
+
+	const classification: DaemonPreviousExitClassification =
+		record.state === "clean" ? "clean" : record.state === "error" ? "error" : "unrecorded";
+	const properties: {
+		classification: DaemonPreviousExitClassification;
+		previousVersion?: string;
+		previousUptimeMs?: number;
+		reasonCategory?: DaemonPreviousExitReasonCategory;
+		exitCode?: number;
+		restartDelayMs?: number;
+	} = { classification };
+	const version = boundedVersion(record.version);
+	if (version !== null) properties.previousVersion = version;
+
+	const previousUptimeMs = intervalMs(
+		record.startedAt,
+		classification === "unrecorded" ? currentStartedAt : record.exitedAt,
+	);
+	if (previousUptimeMs !== null) properties.previousUptimeMs = previousUptimeMs;
+
+	if (classification !== "unrecorded") {
+		const category = reasonCategory(record.reason);
+		if (category !== null) properties.reasonCategory = category;
+		const exitCode = boundedExitCode(record.exitCode);
+		if (exitCode !== null) properties.exitCode = exitCode;
+		const restartDelayMs = intervalMs(record.exitedAt, currentStartedAt);
+		if (restartDelayMs !== null) properties.restartDelayMs = restartDelayMs;
+	}
+
+	return properties;
+}
+
+export function previousExitTelemetryProperties(
+	telemetry: DaemonPreviousExitTelemetry,
+): Readonly<Record<string, string | number>> {
+	const properties: Record<string, string | number> = {
+		classification: telemetry.classification,
+	};
+	if (telemetry.previousVersion !== undefined) properties.previousVersion = telemetry.previousVersion;
+	if (telemetry.previousUptimeMs !== undefined) properties.previousUptimeMs = telemetry.previousUptimeMs;
+	if (telemetry.reasonCategory !== undefined) properties.reasonCategory = telemetry.reasonCategory;
+	if (telemetry.exitCode !== undefined) properties.exitCode = telemetry.exitCode;
+	if (telemetry.restartDelayMs !== undefined) properties.restartDelayMs = telemetry.restartDelayMs;
+	return properties;
+}
+
 export function lifecyclePath(agentsDir: string): string {
 	return join(agentsDir, ".daemon", "lifecycle.json");
 }

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -504,7 +504,13 @@ describe("telemetry collector", () => {
 
 describe("telemetry lifecycle events (issue #1026 Phase 2)", () => {
 	it("declares the Phase-2 lifecycle event types", () => {
-		for (const event of ["daemon.started", "command.invoked", "error.occurred", "version.upgraded"]) {
+		for (const event of [
+			"daemon.started",
+			"daemon.previous_exit",
+			"command.invoked",
+			"error.occurred",
+			"version.upgraded",
+		]) {
 			expect(TELEMETRY_EVENTS).toContain(event);
 		}
 	});

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -61,6 +61,7 @@ export const TELEMETRY_EVENTS = [
 	// Lifecycle events (issue #1026 Phase 2): fired when the user has opted
 	// into anonymous telemetry. No PII, no code, no memory content.
 	"daemon.started",
+	"daemon.previous_exit",
 	"install.activated",
 	// First-use milestones (issue #1202): fired exactly once per install,
 	// at the first successful remember / recall. Guards the activation


### PR DESCRIPTION
## Summary

Reconcile the prior durable daemon lifecycle record on startup and report a bounded `daemon.previous_exit` telemetry event after the collector is ready. This gives PostHog a next-boot classification for clean, catchable-error, and unrecorded deaths without sending raw lifecycle data.

Closes #1255

## Changes

- Read the previous lifecycle record before writing the current `starting` record.
- Add an explicit bounded `DaemonPreviousExitTelemetry` contract and classifier.
- Emit `daemon.previous_exit` exactly once during each boot when a prior record exists.
- Cover clean, error, starting, running, first-boot, bounds, and privacy behavior with regression tests.
- Declare and document the event and its privacy contract in `docs/TELEMETRY.md`.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: <!-- specify --> docs/telemetry

## Screenshots

N/A: no UI changes.

## PR Readiness (MANDATORY)

- [ ] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migration or schema change.

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [x] Tested against running daemon

Focused checks:

- `bun test platform/daemon/src/lifecycle.test.ts`: 11 pass
- `bun test platform/daemon/src/telemetry.test.ts`: 24 pass
- `bun test platform/daemon/src/daemon-refactor.test.ts`: 3 pass
- `bun run --filter @signet/daemon build`: pass
- `bun run build`: pass
- `bunx biome check` on all six changed files: pass
- `bun run typecheck`: pass
- Regression sabotage: the lifecycle suite failed with the classifier replaced by the pre-fix stub, then passed after restoration.
- Live smoke: two real daemon boots in an isolated `SIGNET_PATH` with a local PostHog `/batch/` stub; the second boot received exactly one `daemon.previous_exit` with `classification: "clean"`, `reasonCategory: "signal"`, `exitCode: 0`, `previousVersion`, `previousUptimeMs`, and `restartDelayMs`.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The full root `bun run lint` command was executed after formatting and still reports pre-existing diagnostics outside the six changed files; the changed files pass targeted Biome checks. `bun scripts/doc-drift.ts` also reports existing route, migration, and package-table drift unrelated to this telemetry change. The unchecked root-gate boxes are intentional: they reflect the actual local result rather than claiming a green baseline.

Security/readiness scope note: no admin or mutation endpoints, schema, or spec files were changed. `INDEX.md` and `dependencies.yaml` are not present in this checkout.
