### PR TITLE
fix(daemon): make manifest locking async

### DIFF
--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -2577,6 +2577,7 @@ describe("handleSynthesisRequest", () => {
 				sessionId: "sess-pr390",
 				cwd: "/home/user/signetai",
 			});
+			await flushSessionEndDeferredWork();
 
 			await reindexMemoryArtifacts("default");
 			const before = await handleSynthesisRequest({ trigger: "manual" });
@@ -2790,7 +2791,7 @@ describe("memory-lineage", () => {
 	test.serial("compaction backfills only the manifest and keeps immutable transcript content unchanged", async () => {
 		createMemoryDb([]);
 
-		const transcript = writeTranscriptArtifact({
+		const transcript = await writeTranscriptArtifact({
 			agentId: "default",
 			sessionId: "sess-compaction",
 			sessionKey: "sess-compaction",
@@ -3004,7 +3005,7 @@ describe("memory-lineage", () => {
 				for (let idx = 0; idx < 50; idx++) {
 					const at = new Date(now - day * 24 * 60 * 60 * 1000 - idx * 1000).toISOString();
 					const sessionId = `sess-${day}-${idx}`;
-					writeTranscriptArtifact({
+					await writeTranscriptArtifact({
 						agentId: "default",
 						sessionId,
 						sessionKey: sessionId,
@@ -3035,7 +3036,7 @@ describe("memory-lineage", () => {
 		const defaultStamp = new Date(Date.now() - 1_000).toISOString();
 		const agentStamp = new Date().toISOString();
 
-		writeTranscriptArtifact({
+		await writeTranscriptArtifact({
 			agentId: "default",
 			sessionId: "sess-shared",
 			sessionKey: "sess-shared",
@@ -3050,7 +3051,7 @@ describe("memory-lineage", () => {
 				),
 		});
 
-		writeTranscriptArtifact({
+		await writeTranscriptArtifact({
 			agentId: "agent-b",
 			sessionId: "sess-shared",
 			sessionKey: "sess-shared",

--- a/platform/daemon/src/memory-lineage.test.ts
+++ b/platform/daemon/src/memory-lineage.test.ts
@@ -6,12 +6,14 @@ import cl100k_base from "js-tiktoken/ranks/cl100k_base";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import {
 	MEMORY_PROJECTION_MAX_TOKENS,
+	ensureCanonicalManifest,
 	indexExternalMemoryArtifact,
 	purgeCanonicalNoiseSessions,
 	purgeCanonicalNoiseSessionsOnce,
 	reindexMemoryArtifacts,
 	renderMemoryProjection,
 	resetProjectionPurgeState,
+	updateManifest,
 	writeSummaryArtifact,
 } from "./memory-lineage";
 import { NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID } from "./native-memory-constants";
@@ -170,6 +172,71 @@ describe("memory-lineage", () => {
 
 		expect(purgeCanonicalNoiseSessions("default", "test cleanup")).toBe(1);
 		expect(existsSync(join(dir, row.source_path))).toBe(false);
+	});
+
+	it("manifest lock contention yields to the event loop and removes dead owners", async () => {
+		const stamp = new Date().toISOString();
+		const manifest = ensureCanonicalManifest({
+			agentId: "default",
+			sessionId: "manifest-lock-contention",
+			sessionKey: "manifest-lock-contention",
+			project: "/home/user/project",
+			harness: "codex",
+			capturedAt: stamp,
+			startedAt: stamp,
+			endedAt: stamp,
+		});
+		const lockPath = `${manifest.path}.lock`;
+
+		mkdirSync(lockPath);
+		writeFileSync(`${lockPath}/owner.json`, JSON.stringify({ pid: process.pid, token: "live-test-owner" }));
+		const startedAt = performance.now();
+		const timer = new Promise<number>((resolve) => setTimeout(() => resolve(performance.now() - startedAt), 10));
+		const update = updateManifest(manifest.path, (frontmatter) => ({
+			...frontmatter,
+			summary_status: "completed",
+		}));
+
+		const eventLoopLag = await timer;
+		expect(eventLoopLag).toBeLessThan(100);
+		rmSync(lockPath, { recursive: true, force: true });
+		const updated = await update;
+		expect(updated.frontmatter.summary_status).toBe("completed");
+
+		mkdirSync(lockPath);
+		writeFileSync(`${lockPath}/owner.json`, JSON.stringify({ pid: process.pid + 100_000, token: "dead-test-owner" }));
+		const recovered = await updateManifest(manifest.path, (frontmatter) => ({
+			...frontmatter,
+			transcript_status: "completed",
+		}));
+		expect(recovered.frontmatter.transcript_status).toBe("completed");
+		expect(existsSync(lockPath)).toBe(false);
+	});
+
+	it("concurrent manifest updates are serialized without losing revisions", async () => {
+		const stamp = new Date().toISOString();
+		const manifest = ensureCanonicalManifest({
+			agentId: "default",
+			sessionId: "manifest-lock-queue",
+			sessionKey: "manifest-lock-queue",
+			project: "/home/user/project",
+			harness: "codex",
+			capturedAt: stamp,
+			startedAt: stamp,
+			endedAt: stamp,
+		});
+
+		const updates = Array.from({ length: 12 }, (_, index) =>
+			updateManifest(manifest.path, (frontmatter) => ({
+				...frontmatter,
+				last_writer: index,
+			})),
+		);
+		const results = await Promise.all(updates);
+		const revisions = results.map((result) => result.revision).sort((a, b) => a - b);
+
+		expect(revisions).toEqual(Array.from({ length: 12 }, (_, index) => index + 2));
+		expect(results[results.length - 1]?.frontmatter.last_writer).toBe(11);
 	});
 
 	it("writeSummaryArtifact is idempotent for identical content and rejects content mutation", async () => {

--- a/platform/daemon/src/memory-lineage.ts
+++ b/platform/daemon/src/memory-lineage.ts
@@ -1,7 +1,7 @@
 import type { Database } from "bun:sqlite";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import type { LlmProvider } from "@signet/core";
 import { resolveDefaultBasePath } from "@signet/core";
@@ -1180,17 +1180,6 @@ function ensureManifestRecord(seed: {
 	return manifest;
 }
 
-function saveManifest(path: string, frontmatter: Record<string, unknown>, body: string): ManifestState {
-	const content = `${serializeFrontmatter(frontmatter)}\n${normalizeMarkdownBody(body)}\n`;
-	writeAtomic(path, content);
-	const manifest = loadManifest(path);
-	if (!manifest) {
-		throw new Error(`Failed to reload manifest ${path}`);
-	}
-	upsertArtifactRow(path, manifest.frontmatter, manifest.body);
-	return manifest;
-}
-
 async function writeAtomicAsync(path: string, content: string): Promise<void> {
 	await mkdir(getMemoryDir(), { recursive: true });
 	const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
@@ -1198,7 +1187,7 @@ async function writeAtomicAsync(path: string, content: string): Promise<void> {
 	await rename(tmp, path);
 }
 
-async function saveManifestAsync(
+async function saveManifestAsyncUnlocked(
 	path: string,
 	frontmatter: Record<string, unknown>,
 	body: string,
@@ -1270,40 +1259,165 @@ export function ensureCanonicalManifest(seed: {
 	});
 }
 
-function withManifestLock<T>(path: string, fn: () => T): T {
-	const lockPath = `${path}.lock`;
-	const startedAt = Date.now();
-	while (true) {
-		try {
-			mkdirSync(lockPath);
-			break;
-		} catch (error) {
-			try {
-				const ageMs = Date.now() - statSync(lockPath).mtimeMs;
-				if (ageMs > 30_000) rmSync(lockPath, { recursive: true, force: true });
-			} catch {}
-			if (Date.now() - startedAt > 5_000) {
-				throw new Error(`Timed out waiting for manifest lock: ${path}`, { cause: error });
-			}
-			Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
-		}
-	}
+const MANIFEST_LOCK_TIMEOUT_MS = 5_000;
+const MANIFEST_LOCK_STALE_MS = 30_000;
+const MANIFEST_LOCK_RETRY_MS = 25;
+
+interface ManifestLockOwner {
+	readonly pid: number;
+	readonly token: string;
+}
+
+interface ManifestFileUpdate {
+	readonly frontmatter: Record<string, unknown>;
+	readonly body: string;
+}
+
+function manifestLockErrorCode(error: unknown): string | null {
+	if (!(error instanceof Error) || !("code" in error)) return null;
+	const code = error.code;
+	return typeof code === "string" ? code : null;
+}
+
+function parseManifestLockOwner(raw: string): ManifestLockOwner | null {
 	try {
-		return fn();
-	} finally {
-		rmSync(lockPath, { recursive: true, force: true });
+		const value: unknown = JSON.parse(raw);
+		if (typeof value !== "object" || value === null) return null;
+		const pid = Reflect.get(value, "pid");
+		const token = Reflect.get(value, "token");
+		if (!Number.isInteger(pid) || pid <= 0 || typeof token !== "string" || token.length === 0) return null;
+		return { pid, token };
+	} catch {
+		return null;
 	}
 }
 
-export function updateManifest(
+async function readManifestLockOwner(lockPath: string): Promise<ManifestLockOwner | null> {
+	try {
+		return parseManifestLockOwner(await readFile(join(lockPath, "owner.json"), "utf8"));
+	} catch {
+		return null;
+	}
+}
+
+async function manifestLockOwnedBy(lockPath: string, token: string): Promise<boolean> {
+	const owner = await readManifestLockOwner(lockPath);
+	return owner?.pid === process.pid && owner.token === token;
+}
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return error instanceof Error && "code" in error && error.code === "EPERM";
+	}
+}
+
+async function recoverManifestLock(lockPath: string): Promise<void> {
+	try {
+		const lockStat = await stat(lockPath);
+		const owner = await readManifestLockOwner(lockPath);
+		if (owner) {
+			if (!isProcessAlive(owner.pid)) {
+				await rm(lockPath, { recursive: true, force: true });
+			}
+			return;
+		}
+		if (Date.now() - lockStat.mtimeMs > MANIFEST_LOCK_STALE_MS) {
+			await rm(lockPath, { recursive: true, force: true });
+		}
+	} catch {}
+}
+
+function delayManifestLockRetry(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, MANIFEST_LOCK_RETRY_MS));
+}
+
+async function acquireManifestLock(lockPath: string, path: string): Promise<string> {
+	const startedAt = Date.now();
+	const token = randomUUID();
+	while (true) {
+		let lastError: unknown = null;
+		let owned = false;
+		try {
+			await mkdir(lockPath);
+			let ownerWriteError: unknown = null;
+			try {
+				await writeFile(join(lockPath, "owner.json"), JSON.stringify({ pid: process.pid, token }), "utf8");
+			} catch (error) {
+				if (await manifestLockOwnedBy(lockPath, token)) {
+					await rm(lockPath, { recursive: true, force: true });
+				}
+				ownerWriteError = error;
+			}
+			const ownerWriteCode = manifestLockErrorCode(ownerWriteError);
+			if (ownerWriteError && ownerWriteCode !== "EEXIST" && ownerWriteCode !== "ENOENT") {
+				throw ownerWriteError;
+			}
+			lastError = ownerWriteError;
+			if (!ownerWriteError) {
+				owned = await manifestLockOwnedBy(lockPath, token);
+				if (owned) return token;
+			}
+		} catch (error) {
+			if (manifestLockErrorCode(error) !== "EEXIST") throw error;
+			lastError = error;
+		}
+		if (manifestLockErrorCode(lastError) === "EEXIST") await recoverManifestLock(lockPath);
+		if (Date.now() - startedAt > MANIFEST_LOCK_TIMEOUT_MS) {
+			throw new Error(`Timed out waiting for manifest lock: ${path}`, { cause: lastError });
+		}
+		await delayManifestLockRetry();
+	}
+}
+
+async function releaseManifestLock(lockPath: string, token: string): Promise<void> {
+	if (!(await manifestLockOwnedBy(lockPath, token))) return;
+	await rm(lockPath, { recursive: true, force: true });
+}
+
+async function withManifestLock<T>(path: string, fn: () => Promise<T> | T): Promise<T> {
+	const lockPath = `${path}.lock`;
+	const token = await acquireManifestLock(lockPath, path);
+	try {
+		return await fn();
+	} finally {
+		await releaseManifestLock(lockPath, token);
+	}
+}
+
+let manifestUpdateTail: Promise<void> = Promise.resolve();
+
+function enqueueManifestUpdate<T>(work: () => Promise<T>): Promise<T> {
+	const run = manifestUpdateTail.catch(() => {}).then(work);
+	manifestUpdateTail = run.then(
+		() => undefined,
+		() => undefined,
+	);
+	return run;
+}
+
+async function mutateManifest(
+	path: string,
+	mutate: (current: ManifestState) => ManifestFileUpdate | null,
+): Promise<ManifestState | null> {
+	return enqueueManifestUpdate(() =>
+		withManifestLock(path, async () => {
+			const current = await loadManifestAsync(path);
+			if (!current) return null;
+			const next = mutate(current);
+			if (!next) return current;
+			return saveManifestAsyncUnlocked(path, next.frontmatter, next.body);
+		}),
+	);
+}
+
+export async function updateManifest(
 	path: string,
 	mutate: (frontmatter: Record<string, unknown>) => Record<string, unknown>,
-): ManifestState {
-	return withManifestLock(path, () => {
-		const current = loadManifest(path);
-		if (!current) {
-			throw new Error(`Manifest not found: ${path}`);
-		}
+): Promise<ManifestState> {
+	const result = await mutateManifest(path, (current) => {
 		const next = mutate({ ...current.frontmatter });
 		const revision = typeof next.revision === "number" ? next.revision : current.revision;
 		next.revision = revision + 1;
@@ -1314,15 +1428,17 @@ export function updateManifest(
 		if (!("hash_scope" in next)) {
 			next.hash_scope = HASH_SCOPE;
 		}
-		return saveManifest(path, next, current.body);
+		return { frontmatter: next, body: current.body };
 	});
+	if (!result) throw new Error(`Manifest not found: ${path}`);
+	return result;
 }
 
 function relativePath(path: string): string {
 	return path.replace(`${getAgentsDir()}/`, "").replace(/\\/g, "/");
 }
 
-export function writeTranscriptArtifact(params: {
+export async function writeTranscriptArtifact(params: {
 	readonly agentId: string;
 	readonly sessionId: string;
 	readonly sessionKey: string | null;
@@ -1333,7 +1449,7 @@ export function writeTranscriptArtifact(params: {
 	readonly endedAt: string | null;
 	readonly transcript: string;
 	readonly summaryStatus?: "pending" | "skipped" | "not_requested";
-}): { readonly manifestPath: string; readonly transcriptPath: string } {
+}): Promise<{ readonly manifestPath: string; readonly transcriptPath: string }> {
 	const manifest = ensureCanonicalManifest(params);
 	const sessionToken = deriveSessionToken(params.agentId, params.sessionId);
 	const body = sanitizeTranscriptV1(params.transcript);
@@ -1360,7 +1476,7 @@ export function writeTranscriptArtifact(params: {
 	});
 	const parsed = parseFrontmatterDocument(readFileSync(fullPath, "utf8"));
 	upsertArtifactRow(fullPath, parsed.frontmatter, normalizeMarkdownBody(parsed.body));
-	updateManifest(manifest.path, (frontmatter) => {
+	await updateManifest(manifest.path, (frontmatter) => {
 		const existingSummaryStatus = manifestValue(frontmatter, "summary_status");
 		const terminalSummaryStatus =
 			existingSummaryStatus === "completed" ||
@@ -1419,7 +1535,7 @@ export async function writeSummaryArtifact(params: {
 	});
 	const parsed = parseFrontmatterDocument(readFileSync(fullPath, "utf8"));
 	upsertArtifactRow(fullPath, parsed.frontmatter, normalizeMarkdownBody(parsed.body));
-	updateManifest(manifest.path, (frontmatter) => ({
+	await updateManifest(manifest.path, (frontmatter) => ({
 		...frontmatter,
 		summary_path: relativePath(fullPath),
 		summary_status: "completed",
@@ -1469,7 +1585,7 @@ export async function writeCompactionArtifact(params: {
 	});
 	const parsed = parseFrontmatterDocument(readFileSync(fullPath, "utf8"));
 	upsertArtifactRow(fullPath, parsed.frontmatter, normalizeMarkdownBody(parsed.body));
-	updateManifest(manifest.path, (frontmatter) => ({
+	await updateManifest(manifest.path, (frontmatter) => ({
 		...frontmatter,
 		compaction_path: relativePath(fullPath),
 		ended_at: params.endedAt,
@@ -1894,37 +2010,34 @@ async function syncManifestRefs(
 	}
 	const yielder = yieldEvery(20);
 	for (const path of files) {
-		const state = await loadManifestAsync(path);
-		if (!state) {
-			await yielder();
-			continue;
-		}
-		const rel = relativePath(path);
-		const nextRefs = set.has(rel) ? [LEDGER_HEADING] : [];
-		const nextBody =
-			nextRefs.length > 0 ? `## ${LEDGER_HEADING}\n\nThis session currently appears in the working memory ledger.` : "";
-		const currentRefs = Array.isArray(state.frontmatter.memory_md_refs)
-			? state.frontmatter.memory_md_refs.filter((value): value is string => typeof value === "string")
-			: [];
-		if (
-			currentRefs.length === nextRefs.length &&
-			currentRefs.every((value, idx) => value === nextRefs[idx]) &&
-			normalizeMarkdownBody(state.body) === nextBody
-		) {
-			await yielder();
-			continue;
-		}
-		await saveManifestAsync(
-			path,
-			{
-				...state.frontmatter,
-				memory_md_refs: nextRefs,
-				revision: state.revision + 1,
-				updated_at: new Date().toISOString(),
-				content_sha256: hashNormalizedBody(nextBody),
-			},
-			nextBody,
-		);
+		await mutateManifest(path, (state) => {
+			const rel = relativePath(path);
+			const nextRefs = set.has(rel) ? [LEDGER_HEADING] : [];
+			const nextBody =
+				nextRefs.length > 0
+					? `## ${LEDGER_HEADING}\n\nThis session currently appears in the working memory ledger.`
+					: "";
+			const currentRefs = Array.isArray(state.frontmatter.memory_md_refs)
+				? state.frontmatter.memory_md_refs.filter((value): value is string => typeof value === "string")
+				: [];
+			if (
+				currentRefs.length === nextRefs.length &&
+				currentRefs.every((value, idx) => value === nextRefs[idx]) &&
+				normalizeMarkdownBody(state.body) === nextBody
+			) {
+				return null;
+			}
+			return {
+				frontmatter: {
+					...state.frontmatter,
+					memory_md_refs: nextRefs,
+					revision: state.revision + 1,
+					updated_at: new Date().toISOString(),
+					content_sha256: hashNormalizedBody(nextBody),
+				},
+				body: nextBody,
+			};
+		});
 		await yielder();
 	}
 }

--- a/platform/daemon/src/pipeline/summary-worker.ts
+++ b/platform/daemon/src/pipeline/summary-worker.ts
@@ -352,7 +352,11 @@ export function tracksSessionSummaryArtifact(job: SummaryJobRow): boolean {
 	);
 }
 
-function updateSummaryArtifactStatus(job: SummaryJobRow, status: "failed" | "skipped", errorMessage?: string): void {
+async function updateSummaryArtifactStatus(
+	job: SummaryJobRow,
+	status: "failed" | "skipped",
+	errorMessage?: string,
+): Promise<void> {
 	if (!tracksSessionSummaryArtifact(job)) return;
 	try {
 		const manifest = ensureCanonicalManifest({
@@ -365,7 +369,7 @@ function updateSummaryArtifactStatus(job: SummaryJobRow, status: "failed" | "ski
 			startedAt: job.started_at,
 			endedAt: job.ended_at,
 		});
-		updateManifest(manifest.path, (frontmatter) => ({
+		await updateManifest(manifest.path, (frontmatter) => ({
 			...frontmatter,
 			summary_path: frontmatter.summary_path ?? null,
 			summary_status: frontmatter.summary_path ? "completed" : status,
@@ -381,12 +385,12 @@ function updateSummaryArtifactStatus(job: SummaryJobRow, status: "failed" | "ski
 	}
 }
 
-function markSummaryArtifactSkipped(job: SummaryJobRow): void {
-	updateSummaryArtifactStatus(job, "skipped");
+async function markSummaryArtifactSkipped(job: SummaryJobRow): Promise<void> {
+	await updateSummaryArtifactStatus(job, "skipped");
 }
 
-function markSummaryArtifactFailed(job: SummaryJobRow, errorMessage: string): void {
-	updateSummaryArtifactStatus(job, "failed", errorMessage);
+async function markSummaryArtifactFailed(job: SummaryJobRow, errorMessage: string): Promise<void> {
+	await updateSummaryArtifactStatus(job, "failed", errorMessage);
 }
 
 async function processJob(
@@ -401,7 +405,7 @@ async function processJob(
 	}
 
 	if (!passesSignificanceGate(accessor, job, memoryCfg)) {
-		markSummaryArtifactSkipped(job);
+		await markSummaryArtifactSkipped(job);
 		return;
 	}
 
@@ -1079,7 +1083,7 @@ export function recoverSummaryJobs(accessor: DbAccessor, limit: number = RECOVER
 		return { selected: rows.length, updated };
 	});
 	for (const row of deadRows) {
-		markSummaryArtifactFailed(row, "summary job recovered as dead after daemon restart");
+		void markSummaryArtifactFailed(row, "summary job recovered as dead after daemon restart");
 	}
 	return result;
 }
@@ -1316,7 +1320,7 @@ export function startSummaryWorker(accessor: DbAccessor, options: SummaryWorkerO
 						}
 					});
 					if (deadJobRow) {
-						markSummaryArtifactFailed(deadJobRow, errorMessage);
+						await markSummaryArtifactFailed(deadJobRow, errorMessage);
 					}
 				}
 			} catch {

--- a/platform/daemon/src/transcript-capture-worker.ts
+++ b/platform/daemon/src/transcript-capture-worker.ts
@@ -261,7 +261,7 @@ async function processTranscriptCaptureJob(basePath: string, job: TranscriptCapt
 		capturedAt: job.capturedAt,
 		transcriptPath: job.transcriptPath ?? undefined,
 	});
-	const transcriptArtifact = writeTranscriptArtifact({
+	const transcriptArtifact = await writeTranscriptArtifact({
 		agentId: job.agentId,
 		sessionId: job.sessionId,
 		sessionKey: job.sessionKey,

--- a/platform/daemon/src/transcript-jsonl.test.ts
+++ b/platform/daemon/src/transcript-jsonl.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -68,6 +68,52 @@ await appendCanonicalTranscriptTurns({
 		rmSync(lock, { recursive: true, force: true });
 		expect(await proc.exited).toBe(0);
 		expect(readFileSync(path, "utf8")).toContain("queued while lock is held");
+	});
+
+	test("reaps a known-dead owner without waiting for the stale-age threshold", async () => {
+		const root = makeRoot("dead-owner");
+		const path = canonicalTranscriptPath(root, "codex");
+		const lock = `${path}.lock`;
+		mkdirSync(lock, { recursive: true });
+		writeFileSync(join(lock, "owner.json"), JSON.stringify({ pid: process.pid + 100_000, token: "dead-owner-test" }));
+
+		const startedAt = performance.now();
+		await appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "dead-owner-session",
+			sourceFormat: "live",
+			turns: [{ role: "user", content: "recovered after dead owner" }],
+		});
+
+		expect(performance.now() - startedAt).toBeLessThan(500);
+		expect(readFileSync(path, "utf8")).toContain("recovered after dead owner");
+	});
+
+	test("does not reap a live owner merely because the lock is old", async () => {
+		const root = makeRoot("live-owner");
+		const path = canonicalTranscriptPath(root, "codex");
+		const lock = `${path}.lock`;
+		mkdirSync(lock, { recursive: true });
+		writeFileSync(join(lock, "owner.json"), JSON.stringify({ pid: process.pid, token: "live-owner-test" }));
+		const old = new Date(Date.now() - 60_000);
+		utimesSync(lock, old, old);
+
+		const write = appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "live-owner-session",
+			sourceFormat: "live",
+			turns: [{ role: "user", content: "waited for live owner" }],
+		});
+
+		await Bun.sleep(25);
+		expect(existsSync(path)).toBe(false);
+		rmSync(lock, { recursive: true, force: true });
+		await write;
+		expect(readFileSync(path, "utf8")).toContain("waited for live owner");
 	});
 
 	test("retries legacy markdown backfill after a transient read failure", async () => {

--- a/platform/daemon/src/transcript-jsonl.ts
+++ b/platform/daemon/src/transcript-jsonl.ts
@@ -235,20 +235,29 @@ function lockOwnerPid(path: string): number | null {
 	}
 }
 
+function lockOwnerToken(path: string): string | null {
+	try {
+		const parsed = JSON.parse(readFileSync(join(path, "owner.json"), "utf8")) as { readonly token?: unknown };
+		return typeof parsed.token === "string" ? parsed.token : null;
+	} catch {
+		return null;
+	}
+}
+
 function processIsRunning(pid: number): boolean {
 	try {
 		process.kill(pid, 0);
 		return true;
-	} catch {
-		return false;
+	} catch (error) {
+		return error instanceof Error && "code" in error && error.code === "EPERM";
 	}
 }
 
 function lockCanBeReaped(path: string, now: number): boolean {
 	try {
-		if (now - statSync(path).mtimeMs <= LOCK_DEAD_OWNER_STALE_MS) return false;
 		const pid = lockOwnerPid(path);
-		return pid === null || !processIsRunning(pid);
+		if (pid !== null) return !processIsRunning(pid);
+		return now - statSync(path).mtimeMs > LOCK_DEAD_OWNER_STALE_MS;
 	} catch {
 		return false;
 	}
@@ -265,6 +274,7 @@ async function acquireTranscriptFileLock(path: string): Promise<{ readonly lockP
 				JSON.stringify({ pid: process.pid, token, created_at: new Date().toISOString() }),
 				"utf8",
 			);
+			if (lockOwnerToken(lockPath) !== token) continue;
 			return { lockPath, token };
 		} catch (error) {
 			const code = error instanceof Error && "code" in error ? error.code : null;


### PR DESCRIPTION
## Summary

Fixes #1256.

Replace the synchronous manifest-lock retry that used `Atomics.wait` on the daemon main thread. Manifest updates now acquire locks asynchronously and serialize in-process, preventing concurrent session hooks from wedging the event loop or losing revisions.

## Changes

- Replace the blocking manifest lock loop with async `mkdir`/retry acquisition and bounded timeout handling.
- Write `owner.json` with PID/token metadata, revalidate ownership after acquisition, reap known-dead owners immediately, and retain age-based recovery for legacy locks without owner metadata.
- Serialize manifest mutations through one async queue and await transcript/summary/compaction status persistence.
- Apply immediate dead-owner recovery to the canonical transcript JSONL lock while never age-reaping a known-live owner, and revalidate transcript lock ownership after acquisition.
- Add regressions for event-loop lag, dead-owner recovery, concurrent revisions, and deferred transcript persistence.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A: no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A: no schema or data migration.

## Testing

- [x] Affected daemon test suites pass
- [x] Affected daemon typecheck passes
- [x] Affected primary files pass Biome
- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Verified `bun run --filter @signet/daemon build` passes.
- Verified `bun run --filter @signet/daemon typecheck` passes.
- Verified `bunx biome check` passes for the five primary changed daemon files.
- Verified affected suites: memory-lineage 29/29, transcript-jsonl 29/29, transcript-capture-worker 5/5, summary-worker 21/21, and hooks 177/177 all pass in isolation.
- Sabotage verification: replacing the async retry with a 250ms `Atomics.wait` made the event-loop regression fail with measured 253ms lag; restoring the fix passed.
- Adversarial review found and the follow-up patch fixed a dead-owner TOCTOU race: a waiter now verifies its PID/token after acquisition and retries transient ownership loss instead of entering the critical section or surfacing `ENOENT`.
- The full daemon directory sweep reached 2,268 passing tests but also hit 96 failures from existing cross-file global test contamination; the affected suites pass in isolation.
- The repository-wide `bun run typecheck` remains blocked by pre-existing generated connector exports/bundles outside this diff. The repository-wide `bun run lint` reports pre-existing diagnostics outside this diff; the sibling transcript-jsonl files also retain baseline formatter diagnostics, so their diff was kept minimal.
- No running-daemon verification was performed because this fix is covered by isolated persistence/concurrency tests and the local daemon environment was not started.
