### PR TITLE
fix(daemon): bound stale session sweep work

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -41,6 +41,7 @@ session boundary:
 | `session_fork` | pi forked the current session |
 | `session_shutdown` | pi shut down the current session |
 | `session_switch` | pi switched to another session |
+| `stale-session-sweep` | The daemon finalized an abandoned live-retained session after the stale-session TTL |
 
 These reasons emit one anonymous `session.end` telemetry event per session
 lifetime. Repeated end requests for the same session are deduplicated.
@@ -48,6 +49,16 @@ lifetime. Repeated end requests for the same session are deduplicated.
 Requests without a recognized boundary reason, including ordinary
 `session.idle` calls, emit `session.turn` telemetry instead. They still persist
 the transcript and queue normal session-end processing.
+
+The daemon's stale-session sweeper processes at most 10 abandoned sessions per
+15-minute timer tick. It is single-flight, yields between finalizations, pauses
+when system pressure is elevated, and defers when downstream capture or summary
+work has reached its backlog threshold. Reproduce the 50-session liveness eval
+in an isolated temporary database with:
+
+```sh
+bun scripts/load-test-stale-session-sweep.ts
+```
 
 ```json
 {

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -56,7 +56,7 @@ PostHog failures, and never throws into the daemon.
 | `daemon.heartbeat` | every 5 minutes | `uptimeMs`, `memoryCount`, `connectorsActive`, `pipelineMode`, `extractionProvider`, `embeddingProvider` |
 | `session.start` | real session start (deduped; stubs and clear/reset paths don't count) | `harness`, `sessionHash` |
 | `session.turn` | every non-boundary `session-end` hook call (per turn, see notes) | `harness`, `promptCount`, `sessionHash` |
-| `session.end` | real session termination: an explicit boundary reason or a TTL-evicted (abandoned) session claim | `harness`, `reason` (`clear` / `session.deleted` / `session_branch` / `session_fork` / `session_shutdown` / `session_switch` / `expired`), `sessionHash`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `cost` |
+| `session.end` | real session termination: an explicit boundary reason or a TTL-evicted (abandoned) session claim | `harness`, `reason` (`clear` / `session.deleted` / `session_branch` / `session_fork` / `session_shutdown` / `session_switch` / `stale-session-sweep` / `expired`), `sessionHash`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `cost` |
 | `llm.generate` | every LLM call | `provider`, `latencyMs`, `success`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `totalCost` |
 | `pipeline.embedding` | every embedding fetch, at the usage-recording boundary | `tokens`, `provider`, `sourceKind` (`memory-capture` / `artifact-index` / `recall` / `dreaming` / `other`), `cost` (USD) |
 | `recall.performed` | every completed shared recall search | `type` (`semantic` / `keyword` / `temporal` / `graph`), `results`, `latencyMs`, `truncated` |
@@ -99,7 +99,8 @@ Notes on individual events:
   harnesses invoke per turn to persist messages — a *turns persisted* volume
   counter; `session.end` fires only at real terminations (recognized explicit
   boundary reasons `clear`, `session.deleted`, `session_branch`, `session_fork`,
-  `session_shutdown`, or `session_switch`, or TTL-evicted abandoned claims), deduped once per
+  `session_shutdown`, `session_switch`, or the internal `stale-session-sweep` reason, or
+  TTL-evicted abandoned claims), deduped once per
   session lifetime via `session-end-state.ts` (in-memory, cleared on real and
   clear session starts). All three carry `sessionHash`, a 16-hex sha256 of the
   normalized session key, so distinct sessions and concurrency are countable

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1053,7 +1053,10 @@ function stopMemoryImportPoller(): void {
 function startStaleSessionSweeper(): void {
 	if (staleSessionSweepTimer !== null) return;
 	staleSessionSweepTimer = setInterval(() => {
-		sweepStaleSessions({ staleOlderThanMs: STALE_SESSION_TTL_MS }).catch((e) => {
+		// Keep each timer tick small. The sweep is single-flight and yields
+		// between finalizations, so a large abandoned-session backlog cannot
+		// monopolize the daemon or fan out downstream capture work.
+		sweepStaleSessions({ staleOlderThanMs: STALE_SESSION_TTL_MS, limit: 10 }).catch((e) => {
 			logger.error("daemon", "Stale session sweep failed", undefined, {
 				message: e instanceof Error ? e.message : String(e),
 			});

--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -538,7 +538,8 @@ beforeEach(() => {
 	ensureDir(TEST_DIR);
 });
 
-afterEach(() => {
+afterEach(async () => {
+	await flushSessionEndDeferredWork();
 	resetProjectionPurgeState();
 	closeDbAccessor();
 	if (existsSync(TEST_DIR)) {
@@ -2336,7 +2337,14 @@ memory:
 		const collector = createTelemetryCollector(getDbAccessor(), TEST_TELEMETRY_CONFIG, "0.0.0-test");
 		setActiveTelemetry(collector);
 		try {
-			const reasons = ["session.deleted", "session_branch", "session_fork", "session_shutdown", "session_switch"];
+			const reasons = [
+				"session.deleted",
+				"session_branch",
+				"session_fork",
+				"session_shutdown",
+				"session_switch",
+				"stale-session-sweep",
+			];
 			const inputs = [" SESSION.DELETED ", ...reasons.slice(1)];
 			for (const [index, reason] of inputs.entries()) {
 				await handleSessionEnd({ harness: "test", sessionKey: `sess-boundary-${index}`, reason });
@@ -3162,7 +3170,7 @@ describe("handleSessionStart multi-agent identity", () => {
 					"hermes-agent",
 					null,
 					doneContent,
-					"pending",
+					"leased",
 					0,
 					3,
 					new Date().toISOString(),
@@ -3189,6 +3197,88 @@ describe("handleSessionStart multi-agent identity", () => {
 			) as { n: number };
 			expect(staleJobs.n).toBe(1);
 			expect(freshJobs.n).toBe(0);
+		});
+
+		test.serial(
+			"classifies a 50-session stale backlog as session.end without session.turn",
+			async () => {
+				const now = Date.now();
+				const staleAt = new Date(now - 3 * 24 * 60 * 60 * 1000).toISOString();
+				const content = `User: ${"s".repeat(300)}\nAssistant: ${"t".repeat(300)}`;
+				for (let index = 0; index < 50; index++) {
+					upsertSessionTranscript(
+						`sweep-stale-batch-${now}-${index}`,
+						content,
+						"hermes-agent",
+						null,
+						"default",
+						staleAt,
+					);
+				}
+				ensureTelemetryTables();
+				const collector = createTelemetryCollector(getDbAccessor(), TEST_TELEMETRY_CONFIG, "0.0.0-test");
+				setActiveTelemetry(collector);
+				try {
+					const result = await hooks.sweepStaleSessions({
+						staleOlderThanMs: 24 * 60 * 60 * 1000,
+						limit: 50,
+					});
+					await collector.flush();
+
+					const ends = collector.query().filter((event) => event.event === "session.end");
+					const turns = collector.query().filter((event) => event.event === "session.turn");
+					expect(result.closed).toBe(50);
+					expect(result.totalMatching).toBe(50);
+					expect(ends).toHaveLength(50);
+					expect(ends.every((event) => event.properties.reason === "stale-session-sweep")).toBe(true);
+					expect(turns).toHaveLength(0);
+				} finally {
+					setActiveTelemetry(undefined);
+					resetSessionEndTelemetry();
+				}
+			},
+			120_000,
+		);
+
+		test.serial("defers while the downstream finalization backlog is at capacity", async () => {
+			const now = Date.now();
+			const staleKey = `sweep-backlogged-${now}`;
+			const staleContent = `User: ${"s".repeat(300)}\nAssistant: ${"t".repeat(300)}`;
+			upsertSessionTranscript(
+				staleKey,
+				staleContent,
+				"hermes-agent",
+				null,
+				"default",
+				new Date(now - 3 * 24 * 60 * 60 * 1000).toISOString(),
+			);
+			getDbAccessor().withWriteTx((db) => {
+				const insert = db.prepare(
+					`INSERT INTO summary_jobs (id, session_key, harness, project, transcript, status,
+					 attempts, max_attempts, created_at, agent_id, content_hash, trigger)
+				 VALUES (?, ?, ?, ?, ?, ?, 0, 3, ?, ?, ?, 'session_end')`,
+				);
+				for (let index = 0; index < 20; index++) {
+					insert.run(
+						`sweep-backlog-job-${now}-${index}`,
+						`sweep-backlog-existing-${now}-${index}`,
+						"hermes-agent",
+						null,
+						staleContent,
+						index % 2 === 0 ? "leased" : "pending",
+						new Date().toISOString(),
+						"default",
+						null,
+					);
+				}
+			});
+
+			const result = await hooks.sweepStaleSessions({ staleOlderThanMs: 24 * 60 * 60 * 1000 });
+			expect(result).toEqual({ closed: 0, skipped: 0, totalMatching: 0 });
+			const staleJobs = getDbAccessor().withReadDb((db) =>
+				db.prepare("SELECT COUNT(*) AS n FROM summary_jobs WHERE session_key = ?").get(staleKey),
+			) as { n: number };
+			expect(staleJobs.n).toBe(0);
 		});
 
 		test.serial("does not fire when there is nothing stale", async () => {

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -140,11 +140,16 @@ import {
 } from "./session-transcripts";
 import { type StructuralCandidateSource, type StructuralFeatures, getStructuralFeatures } from "./structural-features";
 import { assembleInheritedContextBlock, resolveParentSession } from "./subagent-context";
+import { awaitPressureClear, isSystemPressureHigh } from "./system-pressure";
 import { getActiveTelemetry } from "./telemetry";
 import { searchTemporalFallback } from "./temporal-fallback";
 import { writeTranscriptAudit } from "./transcript-audit";
 import * as transcriptCapture from "./transcript-capture";
-import { enqueueTranscriptCaptureJob, runTranscriptCaptureOnce } from "./transcript-capture-worker";
+import {
+	enqueueTranscriptCaptureJob,
+	getTranscriptCaptureStatus,
+	runTranscriptCaptureOnce,
+} from "./transcript-capture-worker";
 import {
 	normalizeCodexTranscript,
 	normalizeJsonConversationTranscript,
@@ -161,6 +166,15 @@ function getMemoryDbPath(): string {
 }
 
 const deferredSessionEndWork = new Set<Promise<void>>();
+let deferredSessionEndWorkTail: Promise<void> = Promise.resolve();
+let staleSessionSweepInFlight: Promise<{ closed: number; skipped: number; totalMatching: number }> | null = null;
+const STALE_SESSION_SWEEP_DEFAULT_LIMIT = 10;
+const STALE_SESSION_SWEEP_MAX_LIMIT = 50;
+const STALE_SESSION_SWEEP_MAX_DOWNSTREAM_BACKLOG = 20;
+
+function yieldToEventLoop(): Promise<void> {
+	return new Promise((resolve) => setImmediate(resolve));
+}
 
 function summaryJobsHasColumn(column: string): boolean {
 	try {
@@ -184,7 +198,7 @@ function summaryJobWithContentHashExists(
 			.prepare(
 				`SELECT id FROM summary_jobs
 				 WHERE agent_id = ? AND session_key = ? AND content_hash = ?
-				 AND status IN ('pending', 'processing', 'completed')
+				 AND status IN ('pending', 'processing', 'leased', 'completed')
 				 LIMIT 1`,
 			)
 			.get(agentId, sessionKey, contentHash) as { id: string } | undefined;
@@ -201,6 +215,34 @@ function storeSummaryJobContentHash(jobId: string | undefined, contentHash: stri
 
 export async function flushDeferredSessionEndWorkForTests(): Promise<void> {
 	await Promise.allSettled([...deferredSessionEndWork]);
+}
+
+function scheduleDeferredSessionEndWork(params: {
+	readonly sessionKey: string | undefined;
+	readonly agentId: string;
+	readonly memoryCfg: ResolvedMemoryConfig;
+}): void {
+	const dbAccessor = loadDbAccessor();
+	if (!dbAccessor) return;
+	const basePath = getAgentsDir();
+	const work = deferredSessionEndWorkTail.then(async () => {
+		await yieldToEventLoop();
+		try {
+			await runTranscriptCaptureOnce(dbAccessor, basePath);
+		} catch (error) {
+			logger.warn("hooks", "Deferred transcript capture job failed", {
+				error: error instanceof Error ? error.message : String(error),
+				sessionKey: params.sessionKey,
+			});
+		}
+		await deferSessionEndWork(params);
+	});
+	deferredSessionEndWorkTail = work.catch(() => undefined);
+	deferredSessionEndWork.add(work);
+	void work.then(
+		() => deferredSessionEndWork.delete(work),
+		() => deferredSessionEndWork.delete(work),
+	);
 }
 
 function loadDbAccessor() {
@@ -2030,35 +2072,10 @@ export async function handleSessionEnd(req: SessionEndRequest): Promise<SessionE
 		}
 	}
 
-	setImmediate(() => {
-		let work: Promise<void>;
-		try {
-			work = runTranscriptCaptureOnce(getDbAccessor(), getAgentsDir())
-				.then(() => undefined)
-				.catch((error) => {
-					logger.warn("hooks", "Deferred transcript capture job failed", {
-						error: error instanceof Error ? error.message : String(error),
-						sessionKey,
-					});
-				});
-		} catch (error) {
-			logger.warn("hooks", "Deferred transcript capture job failed", {
-				error: error instanceof Error ? error.message : String(error),
-				sessionKey,
-			});
-			return;
-		}
-		work = work.then(() =>
-			deferSessionEndWork({
-				sessionKey,
-				agentId,
-				memoryCfg,
-			}),
-		);
-		deferredSessionEndWork.add(work);
-		void work.finally(() => {
-			deferredSessionEndWork.delete(work);
-		});
+	scheduleDeferredSessionEndWork({
+		sessionKey,
+		agentId,
+		memoryCfg,
 	});
 
 	return {
@@ -2077,15 +2094,68 @@ export async function handleSessionEnd(req: SessionEndRequest): Promise<SessionE
  * Sweep the stale sessions and fire the deferred session-end with the stored
  * transcript snapshot, so summaries land and content passes stop deferring.
  */
-export async function sweepStaleSessions(options: {
+type StaleSessionSweepResult = { closed: number; skipped: number; totalMatching: number };
+
+async function waitForCurrentDeferredSessionEndWork(): Promise<void> {
+	await yieldToEventLoop();
+	const pending = [...deferredSessionEndWork];
+	if (pending.length === 0) return;
+	await Promise.allSettled(pending);
+}
+
+function shouldDeferStaleSessionSweep(): boolean {
+	if (deferredSessionEndWork.size > 0) {
+		logger.debug("hooks", "Stale session-end sweep deferred while session-end work is pending", {
+			deferredWork: deferredSessionEndWork.size,
+		});
+		return true;
+	}
+	const dbAccessor = loadDbAccessor();
+	if (!dbAccessor) return true;
+	try {
+		const capture = getTranscriptCaptureStatus(dbAccessor);
+		const summary = dbAccessor.withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT COUNT(*) AS count FROM summary_jobs WHERE status IN ('pending', 'processing', 'leased')")
+					.get() as {
+					count?: number;
+				} | null,
+		);
+		const downstreamBacklog =
+			capture.pending + capture.processing + (typeof summary?.count === "number" ? summary.count : 0);
+		if (downstreamBacklog < STALE_SESSION_SWEEP_MAX_DOWNSTREAM_BACKLOG) return false;
+		logger.debug("hooks", "Stale session-end sweep deferred while downstream work is backlogged", {
+			capturePending: capture.pending,
+			captureProcessing: capture.processing,
+			summaryPending: summary?.count ?? 0,
+			backlogLimit: STALE_SESSION_SWEEP_MAX_DOWNSTREAM_BACKLOG,
+		});
+		return true;
+	} catch (error) {
+		logger.warn("hooks", "Stale session-end sweep backlog check failed closed", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return true;
+	}
+}
+
+async function runStaleSessionSweep(options: {
 	staleOlderThanMs: number;
 	limit?: number;
-}): Promise<{ closed: number; skipped: number; totalMatching: number }> {
-	const { staleOlderThanMs, limit = 50 } = options;
-	const stale = findStaleLiveSessions(staleOlderThanMs, limit);
+}): Promise<StaleSessionSweepResult> {
+	if (shouldDeferStaleSessionSweep()) return { closed: 0, skipped: 0, totalMatching: 0 };
+
+	const requestedLimit = options.limit ?? STALE_SESSION_SWEEP_DEFAULT_LIMIT;
+	const limit = Number.isFinite(requestedLimit)
+		? Math.max(0, Math.min(STALE_SESSION_SWEEP_MAX_LIMIT, Math.trunc(requestedLimit)))
+		: STALE_SESSION_SWEEP_DEFAULT_LIMIT;
+	const stale = findStaleLiveSessions(options.staleOlderThanMs, limit);
 	let closed = 0;
 	let skipped = 0;
 	for (const session of stale) {
+		if (isSystemPressureHigh()) await awaitPressureClear();
+		await yieldToEventLoop();
 		// Dedup: a summary job already exists for this exact content, so the
 		// session-end already ran (or is running) for it — never re-fire.
 		// The guard is unconditional: a null harness must not turn the dedup
@@ -2105,6 +2175,7 @@ export async function sweepStaleSessions(options: {
 				reason: "stale-session-sweep",
 			});
 			closed++;
+			await waitForCurrentDeferredSessionEndWork();
 		} catch (error) {
 			logger.warn("hooks", "Stale session-end sweep failed", {
 				error: error instanceof Error ? error.message : String(error),
@@ -2120,6 +2191,20 @@ export async function sweepStaleSessions(options: {
 		});
 	}
 	return { closed, skipped, totalMatching: stale.length };
+}
+
+export async function sweepStaleSessions(options: {
+	staleOlderThanMs: number;
+	limit?: number;
+}): Promise<StaleSessionSweepResult> {
+	if (staleSessionSweepInFlight) return staleSessionSweepInFlight;
+	const work = runStaleSessionSweep(options);
+	staleSessionSweepInFlight = work;
+	try {
+		return await work;
+	} finally {
+		if (staleSessionSweepInFlight === work) staleSessionSweepInFlight = null;
+	}
 }
 
 async function deferSessionEndWork(params: {

--- a/platform/daemon/src/session-end-state.ts
+++ b/platform/daemon/src/session-end-state.ts
@@ -19,6 +19,7 @@ const SESSION_BOUNDARY_REASONS = new Set([
 	"session_fork",
 	"session_shutdown",
 	"session_switch",
+	"stale-session-sweep",
 ]);
 
 export type SessionEndIdentity = {

--- a/platform/daemon/src/session-transcripts.ts
+++ b/platform/daemon/src/session-transcripts.ts
@@ -585,7 +585,7 @@ export function findStaleLiveSessions(staleOlderThanMs: number, limit = 50): Sta
 				SELECT 1 FROM summary_jobs sj
 				WHERE sj.agent_id = session_transcripts.agent_id
 				  AND sj.session_key = session_transcripts.session_key
-				  AND sj.status IN ('pending', 'processing', 'completed')
+				  AND sj.status IN ('pending', 'processing', 'leased', 'completed')
 			)`
 		: "";
 	try {

--- a/platform/daemon/src/transcript-capture-worker.ts
+++ b/platform/daemon/src/transcript-capture-worker.ts
@@ -3,6 +3,7 @@ import type { DbAccessor, WriteDb } from "./db-accessor";
 import { logger } from "./logger";
 import { indexCanonicalTranscriptJsonl, writeTranscriptArtifact } from "./memory-lineage";
 import { isNoiseSession } from "./session-noise";
+import { awaitPressureClear, isSystemPressureHigh } from "./system-pressure";
 import { writeTranscriptAudit } from "./transcript-audit";
 import { writeCanonicalTranscriptFromSnapshot } from "./transcript-capture";
 import { canonicalTranscriptRelativePath } from "./transcript-jsonl";
@@ -55,6 +56,12 @@ export interface TranscriptCaptureJobReceipt {
 
 const DEFAULT_MAX_ATTEMPTS = 5;
 const POLL_INTERVAL_MS = 30_000;
+const MAX_JOBS_PER_DRAIN_TICK = 5;
+let captureRunTail: Promise<void> = Promise.resolve();
+
+function yieldToEventLoop(): Promise<void> {
+	return new Promise((resolve) => setImmediate(resolve));
+}
 
 function nowIso(): string {
 	return new Date().toISOString();
@@ -309,7 +316,7 @@ function markFailed(dbAccessor: DbAccessor, job: TranscriptCaptureJobRow, error:
 	});
 }
 
-export async function runTranscriptCaptureOnce(dbAccessor: DbAccessor, basePath: string): Promise<boolean> {
+async function runTranscriptCaptureOnceInternal(dbAccessor: DbAccessor, basePath: string): Promise<boolean> {
 	const job = leaseJob(dbAccessor);
 	if (!job) return false;
 	try {
@@ -320,6 +327,15 @@ export async function runTranscriptCaptureOnce(dbAccessor: DbAccessor, basePath:
 		throw error;
 	}
 	return true;
+}
+
+export function runTranscriptCaptureOnce(dbAccessor: DbAccessor, basePath: string): Promise<boolean> {
+	const run = captureRunTail.then(() => runTranscriptCaptureOnceInternal(dbAccessor, basePath));
+	captureRunTail = run.then(
+		() => undefined,
+		() => undefined,
+	);
+	return run;
 }
 
 export function startTranscriptCaptureWorker(dbAccessor: DbAccessor, basePath: string): TranscriptCaptureWorkerHandle {
@@ -340,19 +356,27 @@ export function startTranscriptCaptureWorker(dbAccessor: DbAccessor, basePath: s
 	const drain = async (): Promise<void> => {
 		if (stopped || running) return;
 		running = true;
+		let nextDelayMs = POLL_INTERVAL_MS;
 		try {
 			let processed = false;
+			let processedThisTick = 0;
 			do {
+				if (isSystemPressureHigh()) await awaitPressureClear();
 				processed = await runTranscriptCaptureOnce(dbAccessor, basePath).catch((error) => {
 					logger.warn("transcripts", "Transcript capture job failed", {
 						error: error instanceof Error ? error.message : String(error),
 					});
 					return false;
 				});
-			} while (processed && !stopped);
+				if (processed && !stopped) {
+					processedThisTick++;
+					await yieldToEventLoop();
+				}
+				if (processedThisTick >= MAX_JOBS_PER_DRAIN_TICK) nextDelayMs = 0;
+			} while (processed && !stopped && processedThisTick < MAX_JOBS_PER_DRAIN_TICK);
 		} finally {
 			running = false;
-			schedule(POLL_INTERVAL_MS);
+			schedule(nextDelayMs);
 		}
 	};
 

--- a/scripts/load-test-stale-session-sweep.ts
+++ b/scripts/load-test-stale-session-sweep.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env bun
+/**
+ * Stale-session sweep liveness eval (#1254).
+ *
+ * This runs the production daemon hook modules against an isolated temporary
+ * SIGNET_PATH. It seeds 50 live-retained stale sessions, runs the same sweep
+ * used by the daemon, measures event-loop lag with a 10ms probe, and fails if
+ * any session is classified as session.turn or the liveness budget is missed.
+ *
+ * Usage:
+ *   bun scripts/load-test-stale-session-sweep.ts [--count 50] [--max-lag-ms 500]
+ */
+
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+interface ParsedArgs {
+	readonly count: number;
+	readonly maxLagMs: number;
+}
+
+function parseArgs(raw: readonly string[]): ParsedArgs {
+	let count = 50;
+	let maxLagMs = 500;
+	for (let index = 0; index < raw.length; index += 1) {
+		const arg = raw[index];
+		if (arg === "--count") {
+			count = Number.parseInt(raw[index + 1] ?? "", 10);
+			index += 1;
+		}
+		if (arg === "--max-lag-ms") {
+			maxLagMs = Number.parseInt(raw[index + 1] ?? "", 10);
+			index += 1;
+		}
+		if (arg === "--help") {
+			console.log("Usage: bun scripts/load-test-stale-session-sweep.ts [--count 50] [--max-lag-ms 500]");
+			process.exit(0);
+		}
+	}
+	if (!Number.isInteger(count) || count < 1 || count > 50) throw new Error("--count must be an integer from 1 to 50");
+	if (!Number.isFinite(maxLagMs) || maxLagMs < 1) throw new Error("--max-lag-ms must be positive");
+	return { count, maxLagMs };
+}
+
+function percentile(sorted: readonly number[], percentileValue: number): number {
+	if (sorted.length === 0) return 0;
+	const index = Math.min(sorted.length - 1, Math.ceil((percentileValue / 100) * sorted.length) - 1);
+	return sorted[Math.max(0, index)] ?? 0;
+}
+
+async function main(): Promise<void> {
+	const args = parseArgs(process.argv.slice(2));
+	const agentsDir = mkdtempSync(join(tmpdir(), "signet-stale-sweep-eval-"));
+	process.env.SIGNET_PATH = agentsDir;
+	process.env.SIGNET_AGENT_ID = "default";
+	writeFileSync(join(agentsDir, "AGENTS.md"), "Stale-session sweep liveness eval.\n");
+
+	const { closeDbAccessor, getDbAccessor, initDbAccessor } = await import("../platform/daemon/src/db-accessor");
+	const hooks = await import("../platform/daemon/src/hooks");
+	const { createTelemetryCollector, setActiveTelemetry } = await import("../platform/daemon/src/telemetry");
+	const { upsertSessionTranscript } = await import("../platform/daemon/src/session-transcripts");
+
+	const dbPath = join(agentsDir, "memory", "memories.db");
+	const telemetryConfig = {
+		posthogHost: "",
+		posthogApiKey: "",
+		flushIntervalMs: 60_000,
+		flushBatchSize: 100,
+		retentionDays: 90,
+		memorySearchQaEnabled: false,
+	} as const;
+
+	try {
+		initDbAccessor(dbPath, { agentsDir });
+		const now = Date.now();
+		const staleAt = new Date(now - 3 * 24 * 60 * 60 * 1000).toISOString();
+		const transcript = `User: ${"s".repeat(300)}\nAssistant: ${"t".repeat(300)}`;
+		for (let index = 0; index < args.count; index += 1) {
+			upsertSessionTranscript(`stale-sweep-eval-${process.pid}-${index}`, transcript, "eval", null, "default", staleAt);
+		}
+
+		const collector = createTelemetryCollector(getDbAccessor(), telemetryConfig, "eval");
+		setActiveTelemetry(collector);
+		const lagSamples: number[] = [];
+		const probeIntervalMs = 10;
+		let expectedAt = performance.now() + probeIntervalMs;
+		const probe = setInterval(() => {
+			const nowAt = performance.now();
+			lagSamples.push(Math.max(0, nowAt - expectedAt));
+			expectedAt = nowAt + probeIntervalMs;
+		}, probeIntervalMs);
+		try {
+			const startedAt = performance.now();
+			const result = await hooks.sweepStaleSessions({
+				staleOlderThanMs: 24 * 60 * 60 * 1000,
+				limit: args.count,
+			});
+			const elapsedMs = performance.now() - startedAt;
+			await collector.flush();
+			clearInterval(probe);
+
+			const ends = collector.query().filter((event) => event.event === "session.end");
+			const turns = collector.query().filter((event) => event.event === "session.turn");
+			const sortedLag = [...lagSamples].sort((a, b) => a - b);
+			const maxLagMs = Math.round(Math.max(...lagSamples, 0));
+			const p95LagMs = Math.round(percentile(sortedLag, 95));
+			const report = {
+				verdict:
+					result.closed === args.count && ends.length === args.count && turns.length === 0 && maxLagMs <= args.maxLagMs
+						? "pass"
+						: "fail",
+				count: args.count,
+				closed: result.closed,
+				totalMatching: result.totalMatching,
+				sessionEndEvents: ends.length,
+				sessionTurnEvents: turns.length,
+				elapsedMs: Math.round(elapsedMs),
+				maxLagMs,
+				p95LagMs,
+				maxAllowedLagMs: args.maxLagMs,
+			};
+			console.log(JSON.stringify(report, null, 2));
+			if (report.verdict !== "pass") process.exitCode = 1;
+		} finally {
+			clearInterval(probe);
+			setActiveTelemetry(undefined);
+			await collector.stop();
+		}
+	} finally {
+		closeDbAccessor();
+		if (existsSync(agentsDir)) rmSync(agentsDir, { recursive: true, force: true });
+	}
+}
+
+main()
+	.then(() => {
+		process.exit(process.exitCode ?? 0);
+	})
+	.catch((error) => {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	});


### PR DESCRIPTION
## Summary

Closes #1254.

Bound stale-session recovery so a large abandoned-session backlog cannot create overlapping downstream work or misclassify recovered closures as turns. The sweep now emits canonical `session.end` telemetry while preserving content-hash deduplication and agent scoping.

## Changes

- Added `stale-session-sweep` to the canonical session boundary classification.
- Limited timer sweeps to 10 sessions per tick, with a hard maximum of 50, single-flight protection, event-loop yields, pressure waits, and downstream backlog gating.
- Serialized deferred session-end work and bounded transcript-capture worker drains to 5 jobs per tick.
- Included leased summary jobs in backlog and deduplication checks.
- Added regression coverage and `scripts/load-test-stale-session-sweep.ts`.
- Updated hook and telemetry documentation.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: daemon documentation and stale-session load eval

## Screenshots

No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Exact verification on the rebased head:

- `bun test platform/daemon/src/hooks.test.ts platform/daemon/src/transcript-capture-worker.test.ts platform/daemon/src/pipeline/boundary-reason-regression.test.ts`: 192 pass, 0 fail.
- `bun scripts/load-test-stale-session-sweep.ts`: 50 closed, 50 `session.end`, 0 `session.turn`, 143 ms elapsed, 2 ms maximum lag, 2 ms p95 lag, 500 ms budget.
- `bun run --filter '@signet/daemon' build`: passed.
- `bun run --filter '@signet/daemon' typecheck`: passed.
- `bun run typecheck`: passed.
- Scoped Biome and `git diff --check`: passed.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- The repository-wide `bun run lint` command still reports pre-existing formatting failures in unrelated JSON files. All changed files pass scoped Biome checks. No unrelated formatting was included in this PR.
- `INDEX.md` and `dependencies.yaml` are not present in the repository; no package or dependency surface changed.
- The running production daemon was not modified or restarted as part of this PR.
