### PR TITLE
feat(daemon): reconcile indeterminate ACP deliveries (#1263)

### DIFF
--- a/docs/ACP-INTEGRATION.md
+++ b/docs/ACP-INTEGRATION.md
@@ -293,8 +293,18 @@ local daemon delivery or an ACP relay path:
 }
 ```
 
-That path is about message delivery between agents. The ACPX inference backend
-is about daemon-owned background LLM calls. They are complementary:
+That path is about message delivery between agents. ACP relay attempts are
+persisted before the remote request, carry a stable `Idempotency-Key`, and use a
+lease so startup/background reconciliation can mark only abandoned attempts.
+Inspect `deliveryState` on the stored message: `indeterminate` means Signet
+cannot prove whether the remote run happened. Reconciliation does not resend
+such attempts automatically. Use `POST /api/cross-agent/messages/:messageId/retry`
+or the SDK `retryAgentMessage` method for the bounded retry, which reuses the
+same idempotency key. The limit is three total attempts; after exhaustion the
+endpoint returns `409` and leaves the row indeterminate for manual review. Remote ACP implementations that do not honor idempotency
+or offer run lookup cannot provide stronger remote truth.
+
+The ACPX inference backend is about daemon-owned background LLM calls. They are complementary:
 
 - **MCP messaging / ACP relay:** agent-to-agent communication.
 - **ACPX inference target:** daemon-to-harness inference for Signet workloads.

--- a/docs/specs/approved/cross-agent-notification-delivery.md
+++ b/docs/specs/approved/cross-agent-notification-delivery.md
@@ -102,8 +102,29 @@ seeing the block.
 ### ACP relay
 
 An ACP message is committed locally with `queued` status before the remote
-request begins. Relay completion updates that durable row to `delivered` or
-`failed` with the bounded receipt. If local capacity or persistence fails, the
+request begins. Each ACP row also has a stable attempt identity, bounded retry
+count, lease, persisted target, and an explicit `delivery_state`: `pending`,
+`in_flight`, `indeterminate`, `delivered`, or `failed`. A relay claims the row
+with a lease before making the remote request. Another daemon may reconcile only
+an expired lease, so an active relay is not failed by startup recovery.
+
+The stable attempt identity is sent as the HTTP `Idempotency-Key` header. A
+successful response updates the row to `delivered`; a definitive non-2xx
+response updates it to `failed`. A timeout, transport error, crash, or local
+status-write failure leaves or moves the row to `indeterminate` because remote
+truth is unknown. Reconciliation never resends automatically. Operators can
+inspect the persisted attempt/error and use the bounded retry endpoint. There
+are three total attempts: the initial relay and at most two retries. Once that
+limit is reached, the row remains explicitly `indeterminate` and the retry
+endpoint returns `409` for manual review rather than silently sending more
+requests. Retries reuse the same idempotency key and therefore do not silently
+create a duplicate when the remote ACP implementation honors that key. If the remote does not
+provide idempotency or run lookup, the row remains an explicit indeterminate
+outcome rather than pretending delivery is known. Rows created before this
+reconciliation migration had no idempotency key on their original request;
+those legacy rows require manual review before treating a retry as duplicate-safe.
+
+If local capacity or persistence fails before the durable row is committed, the
 remote relay is not attempted.
 
 ## Failure behavior

--- a/libs/sdk/src/client-p2.ts
+++ b/libs/sdk/src/client-p2.ts
@@ -753,6 +753,12 @@ export class SignetClientP2 {
 		readonly content: string;
 		readonly broadcast?: boolean;
 		readonly via?: "local" | "acp";
+		readonly acp?: {
+			readonly baseUrl: string;
+			readonly targetAgentName: string;
+			readonly timeoutMs?: number;
+			readonly metadata?: Readonly<Record<string, unknown>>;
+		};
 	}): Promise<AgentMessageSendResponse> {
 		return this.transport.post<AgentMessageSendResponse>("/api/cross-agent/messages", opts);
 	}
@@ -764,6 +770,14 @@ export class SignetClientP2 {
 	): Promise<AgentMessageAcknowledgeResponse> {
 		return this.transport.post<AgentMessageAcknowledgeResponse>(
 			`/api/cross-agent/messages/${encodeURIComponent(messageId)}/ack`,
+			opts ?? {},
+		);
+	}
+
+	/** Retry an indeterminate ACP delivery using the same durable idempotency key. */
+	async retryAgentMessage(messageId: string, opts?: { readonly agentId?: string }): Promise<AgentMessageSendResponse> {
+		return this.transport.post<AgentMessageSendResponse>(
+			`/api/cross-agent/messages/${encodeURIComponent(messageId)}/retry`,
 			opts ?? {},
 		);
 	}

--- a/libs/sdk/src/types-p2.ts
+++ b/libs/sdk/src/types-p2.ts
@@ -420,6 +420,11 @@ export interface AgentMessage {
 	readonly expiresAt: string;
 	readonly deliveryPath: "local" | "acp";
 	readonly deliveryStatus: "queued" | "delivered" | "failed";
+	readonly deliveryState: "pending" | "in_flight" | "indeterminate" | "delivered" | "failed";
+	readonly deliveryAttemptId?: string;
+	readonly deliveryAttempts: number;
+	readonly deliveryAttemptStartedAt?: string;
+	readonly deliveryUpdatedAt?: string;
 	readonly deliveryError?: string;
 	readonly deliveryReceipt?: Readonly<Record<string, unknown>>;
 	readonly acknowledgedAt?: string;

--- a/platform/core/src/migrations/116-acp-delivery-reconciliation.ts
+++ b/platform/core/src/migrations/116-acp-delivery-reconciliation.ts
@@ -1,0 +1,62 @@
+import type { MigrationDb } from "./index";
+
+function hasColumn(db: MigrationDb, table: string, column: string): boolean {
+	return db
+		.prepare(`PRAGMA table_info(${table})`)
+		.all()
+		.some((row) => row.name === column);
+}
+
+function addColumnIfMissing(db: MigrationDb, column: string, definition: string): void {
+	if (!hasColumn(db, "cross_agent_messages", column)) {
+		db.exec(`ALTER TABLE cross_agent_messages ADD COLUMN ${column} ${definition}`);
+	}
+}
+
+/**
+ * Migration 116: durable ACP relay attempt reconciliation (#1263).
+ *
+ * The existing delivery_status column is kept for compatibility with clients
+ * that only understand queued/delivered/failed. delivery_state carries the
+ * finer-grained crash-window state and the lease fields prevent another
+ * daemon from declaring an active relay abandoned.
+ */
+export function up(db: MigrationDb): void {
+	const table = db
+		.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'cross_agent_messages'")
+		.get() as { name?: string } | null | undefined;
+	if (table == null) return;
+
+	addColumnIfMissing(db, "delivery_state", "TEXT NOT NULL DEFAULT 'pending'");
+	addColumnIfMissing(db, "delivery_attempt_id", "TEXT");
+	addColumnIfMissing(db, "delivery_attempts", "INTEGER NOT NULL DEFAULT 0");
+	addColumnIfMissing(db, "delivery_lease_token", "TEXT");
+	addColumnIfMissing(db, "delivery_lease_expires_at", "TEXT");
+	addColumnIfMissing(db, "delivery_attempt_started_at", "TEXT");
+	addColumnIfMissing(db, "delivery_updated_at", "TEXT");
+	addColumnIfMissing(db, "acp_base_url", "TEXT");
+	addColumnIfMissing(db, "acp_target_agent_name", "TEXT");
+	addColumnIfMissing(db, "acp_timeout_ms", "INTEGER");
+	addColumnIfMissing(db, "acp_metadata_json", "TEXT");
+
+	db.exec(`
+		UPDATE cross_agent_messages
+		SET delivery_state = CASE delivery_status
+			WHEN 'delivered' THEN 'delivered'
+			WHEN 'failed' THEN 'failed'
+			ELSE 'pending'
+		END
+		WHERE delivery_state = 'pending';
+
+		UPDATE cross_agent_messages
+		SET delivery_attempt_id = id
+		WHERE delivery_attempt_id IS NULL;
+
+		UPDATE cross_agent_messages
+		SET delivery_updated_at = created_at
+		WHERE delivery_updated_at IS NULL;
+
+		CREATE INDEX IF NOT EXISTS idx_cross_agent_messages_delivery_reconciliation
+			ON cross_agent_messages(delivery_path, delivery_state, delivery_lease_expires_at, delivery_updated_at);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -121,6 +121,7 @@ import { up as telemetryQueueOwnership } from "./112-telemetry-queue-ownership";
 import { up as sessionClaims } from "./113-session-claims";
 import { up as memoryTraversalHydrationIndex } from "./114-memory-traversal-hydration-index";
 import { up as crossAgentMessageNotifications } from "./115-cross-agent-message-notifications";
+import { up as acpDeliveryReconciliation } from "./116-acp-delivery-reconciliation";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1078,6 +1079,20 @@ export const MIGRATIONS: readonly Migration[] = [
 		up: crossAgentMessageNotifications,
 		artifacts: {
 			tables: ["cross_agent_messages", "cross_agent_message_receipts"],
+		},
+	},
+	{
+		version: 116,
+		name: "acp-delivery-reconciliation",
+		up: acpDeliveryReconciliation,
+		artifacts: {
+			columns: [
+				{ table: "cross_agent_messages", column: "delivery_state" },
+				{ table: "cross_agent_messages", column: "delivery_attempt_id" },
+				{ table: "cross_agent_messages", column: "delivery_lease_expires_at" },
+				{ table: "cross_agent_messages", column: "acp_base_url" },
+				{ table: "cross_agent_messages", column: "acp_target_agent_name" },
+			],
 		},
 	},
 ];

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -21,6 +21,7 @@ import { up as retireLegacyIngestion } from "./096-retire-legacy-ingestion";
 import { up as dreamingRunbook } from "./100-dreaming-runbook";
 import { up as agentScopedEntityName } from "./105-agent-scoped-entity-name";
 import { up as crossAgentMessageNotifications } from "./115-cross-agent-message-notifications";
+import { up as acpDeliveryReconciliation } from "./116-acp-delivery-reconciliation";
 import { MIGRATIONS, hasPendingMigrations, runMigrations } from "./index";
 
 function createFreshDb(): Database {
@@ -1889,5 +1890,38 @@ describe("migration 115: cross-agent message notifications", () => {
 		const receipt = db.query("SELECT message_id FROM cross_agent_message_receipts").get();
 		expect(receipt).toBeNull();
 		db.close();
+	});
+});
+
+describe("migration 116: ACP delivery reconciliation", () => {
+	test("adds lease, attempt, target, and explicit state columns idempotently", () => {
+		const db = createFreshDb();
+		crossAgentMessageNotifications(db);
+		db.prepare(
+			`INSERT INTO cross_agent_messages (
+				id, from_agent_id, content, message_type, delivery_path, delivery_status, created_at, expires_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run("acp-1", "alpha", "pending", "info", "acp", "queued", "2026-08-08T00:00:00.000Z", "2026-08-15T00:00:00.000Z");
+
+		acpDeliveryReconciliation(db);
+		acpDeliveryReconciliation(db);
+		const columns = db.query("PRAGMA table_info(cross_agent_messages)").all() as Array<{ name: string }>;
+		expect(columns.map((column) => column.name)).toEqual(
+			expect.arrayContaining([
+				"delivery_state",
+				"delivery_attempt_id",
+				"delivery_attempts",
+				"delivery_lease_token",
+				"delivery_lease_expires_at",
+				"acp_base_url",
+				"acp_target_agent_name",
+			]),
+		);
+		expect(
+			db.prepare("SELECT delivery_state, delivery_attempt_id FROM cross_agent_messages WHERE id = ?").get("acp-1"),
+		).toEqual({
+			delivery_state: "pending",
+			delivery_attempt_id: "acp-1",
+		});
 	});
 });

--- a/platform/daemon/src/cross-agent-acp.ts
+++ b/platform/daemon/src/cross-agent-acp.ts
@@ -8,6 +8,7 @@ export interface AcpRelayRequest {
 	readonly fromSessionKey?: string;
 	readonly metadata?: Readonly<Record<string, unknown>>;
 	readonly timeoutMs?: number;
+	readonly idempotencyKey?: string;
 }
 
 export interface AcpRelayResult {
@@ -15,10 +16,12 @@ export interface AcpRelayResult {
 	readonly status: number;
 	readonly runId?: string;
 	readonly error?: string;
+	readonly indeterminate?: boolean;
 }
 
 const ACP_TIMEOUT_MS = 20_000;
 const ACP_ALLOWED_ORIGINS_ENV = "SIGNET_ACP_ALLOWED_ORIGINS";
+const MAX_ACP_TIMEOUT_MS = 120_000;
 
 function normalizeText(value: unknown): string | undefined {
 	if (typeof value !== "string") return undefined;
@@ -172,7 +175,10 @@ export async function relayMessageViaAcp(request: AcpRelayRequest): Promise<AcpR
 	const content = normalizeText(request.content);
 	if (!content) return { ok: false, status: 0, error: "content is required" };
 
-	const timeoutMs = typeof request.timeoutMs === "number" && request.timeoutMs > 0 ? request.timeoutMs : ACP_TIMEOUT_MS;
+	const timeoutMs =
+		typeof request.timeoutMs === "number" && request.timeoutMs > 0
+			? Math.min(MAX_ACP_TIMEOUT_MS, request.timeoutMs)
+			: ACP_TIMEOUT_MS;
 	const runsUrl = resolveAcpRunsUrl(baseUrl);
 	if (!runsUrl.ok) return { ok: false, status: 0, error: runsUrl.error };
 
@@ -200,7 +206,10 @@ export async function relayMessageViaAcp(request: AcpRelayRequest): Promise<AcpR
 	try {
 		const response = await fetch(runsUrl.url, {
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: {
+				"Content-Type": "application/json",
+				...(normalizeText(request.idempotencyKey) ? { "Idempotency-Key": normalizeText(request.idempotencyKey) } : {}),
+			},
 			body: JSON.stringify(payload),
 			signal: AbortSignal.timeout(timeoutMs),
 		});
@@ -217,7 +226,12 @@ export async function relayMessageViaAcp(request: AcpRelayRequest): Promise<AcpR
 				isRecord(parsedBody) && typeof parsedBody.error === "string"
 					? parsedBody.error
 					: `ACP request failed with ${response.status}`;
-			return { ok: false, status: response.status, error };
+			return {
+				ok: false,
+				status: response.status,
+				error,
+				indeterminate: response.status >= 500,
+			};
 		}
 
 		return { ok: true, status: response.status, runId: extractRunId(parsedBody) };
@@ -226,6 +240,7 @@ export async function relayMessageViaAcp(request: AcpRelayRequest): Promise<AcpR
 			ok: false,
 			status: 0,
 			error: error instanceof Error ? error.message : String(error),
+			indeterminate: true,
 		};
 	}
 }

--- a/platform/daemon/src/cross-agent.test.ts
+++ b/platform/daemon/src/cross-agent.test.ts
@@ -4,11 +4,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	acknowledgeAgentMessage,
+	claimAcpMessageDelivery,
+	completeAcpMessageDelivery,
 	createAgentMessage,
 	isMessageVisibleToAgent,
 	listAgentMessagePage,
 	listAgentMessages,
 	listAgentPresence,
+	reconcileAcpDeliveries,
 	relayMessageViaAcp,
 	removeAgentPresence,
 	resetCrossAgentStateForTest,
@@ -316,14 +319,86 @@ describe("cross-agent messages", () => {
 	});
 });
 
+describe("ACP delivery reconciliation", () => {
+	it("marks a committed ACP row indeterminate if the process dies before claiming it", () => {
+		const message = createAgentMessage({
+			fromAgentId: "alpha",
+			content: "queued before crash",
+			deliveryPath: "acp",
+			deliveryStatus: "queued",
+			acpBaseUrl: "https://acp.example.com",
+			acpTargetAgentName: "helper",
+		});
+
+		expect(reconcileAcpDeliveries(undefined, Date.parse(message.createdAt) + 31_000)).toBe(1);
+		const recovered = listAgentMessages({ agentId: "alpha", includeSent: true })[0];
+		expect(recovered?.deliveryState).toBe("indeterminate");
+		expect(recovered?.deliveryError).toBe("ACP relay was queued but never started");
+	});
+
+	it("uses a lease so a second daemon cannot reconcile an active relay", () => {
+		const message = createAgentMessage({
+			fromAgentId: "alpha",
+			content: "lease me",
+			deliveryPath: "acp",
+			deliveryStatus: "queued",
+			acpBaseUrl: "https://acp.example.com",
+			acpTargetAgentName: "helper",
+		});
+		const first = claimAcpMessageDelivery({ messageId: message.id, agentId: "alpha", nowMs: 1_000 });
+		expect(() => reconcileAcpDeliveries(undefined, 80_000)).not.toThrow();
+		expect(() => claimAcpMessageDelivery({ messageId: message.id, agentId: "alpha", nowMs: 20_000 })).toThrow(
+			"already active",
+		);
+		expect(first.idempotencyKey).toBe(`signet-acp-${message.deliveryAttemptId}`);
+		expect(completeAcpMessageDelivery(message.id, first.leaseToken, { status: "delivered" }).deliveryState).toBe(
+			"delivered",
+		);
+	});
+
+	it("marks a fetch-complete but locally-uncommitted relay indeterminate and retries with the same idempotency key", () => {
+		const message = createAgentMessage({
+			fromAgentId: "alpha",
+			content: "recover me",
+			deliveryPath: "acp",
+			deliveryStatus: "queued",
+			acpBaseUrl: "https://acp.example.com",
+			acpTargetAgentName: "helper",
+		});
+		const first = claimAcpMessageDelivery({ messageId: message.id, agentId: "alpha", nowMs: 1_000 });
+		expect(reconcileAcpDeliveries(undefined, 200_000)).toBe(1);
+		const indeterminate = listAgentMessages({ agentId: "alpha", includeSent: true })[0];
+		expect(indeterminate?.deliveryState).toBe("indeterminate");
+		expect(indeterminate?.deliveryStatus).toBe("queued");
+		expect(() =>
+			claimAcpMessageDelivery({
+				messageId: message.id,
+				agentId: "other-agent",
+				retryIndeterminate: true,
+				nowMs: 101_000,
+			}),
+		).toThrow();
+
+		const retry = claimAcpMessageDelivery({
+			messageId: message.id,
+			agentId: "alpha",
+			retryIndeterminate: true,
+			nowMs: 201_000,
+		});
+		expect(retry.idempotencyKey).toBe(first.idempotencyKey);
+		expect(retry.message.deliveryAttempts).toBe(2);
+	});
+});
+
 describe("ACP relay", () => {
 	it("posts a run request and returns run id", async () => {
 		const originalFetch = globalThis.fetch;
-		const capture: { url?: string; body?: string } = {};
+		const capture: { url?: string; body?: string; idempotencyKey?: string } = {};
 
 		globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
 			capture.url = typeof input === "string" ? input : input.toString();
 			capture.body = typeof init?.body === "string" ? init.body : "";
+			capture.idempotencyKey = new Headers(init?.headers).get("Idempotency-Key") ?? undefined;
 			return new Response(JSON.stringify({ run_id: "run-123", status: "running" }), {
 				status: 201,
 				headers: { "Content-Type": "application/json" },
@@ -336,6 +411,7 @@ describe("ACP relay", () => {
 			content: "Can you verify this deployment plan?",
 			fromAgentId: "alpha",
 			fromSessionKey: "sess-a",
+			idempotencyKey: "signet-acp-attempt-123",
 		});
 
 		globalThis.fetch = originalFetch;
@@ -344,8 +420,32 @@ describe("ACP relay", () => {
 		const body = JSON.parse(capture.body ?? "{}");
 		expect(body.agent_name).toBe("helper-agent");
 		expect(body.input?.[0]?.parts?.[0]?.content).toContain("deployment plan");
+		expect(capture.idempotencyKey).toBe("signet-acp-attempt-123");
 		expect(result.ok).toBe(true);
 		expect(result.runId).toBe("run-123");
+	});
+
+	it("treats ACP 5xx responses as indeterminate", async () => {
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = mock(
+			async () =>
+				new Response(JSON.stringify({ error: "upstream overloaded" }), {
+					status: 503,
+					headers: { "Content-Type": "application/json" },
+				}),
+		) as unknown as typeof fetch;
+
+		try {
+			const result = await relayMessageViaAcp({
+				baseUrl: "https://acp.example.com/",
+				targetAgentName: "helper-agent",
+				content: "retry safely",
+			});
+			expect(result.ok).toBe(false);
+			expect(result.indeterminate).toBe(true);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
 	});
 
 	it("rejects private ACP origins unless allowlisted", async () => {

--- a/platform/daemon/src/cross-agent.ts
+++ b/platform/daemon/src/cross-agent.ts
@@ -1,11 +1,12 @@
 import { randomUUID } from "node:crypto";
-import { type ReadDb, type WriteDb, getDbAccessor, hasDbAccessor } from "./db-accessor";
+import { type DbAccessor, type ReadDb, type WriteDb, getDbAccessor, hasDbAccessor } from "./db-accessor";
 export { relayMessageViaAcp, type AcpRelayRequest, type AcpRelayResult } from "./cross-agent-acp";
 
 export type AgentMessageType = "assist_request" | "decision_update" | "info" | "question";
 
 export type AgentMessageDeliveryPath = "local" | "acp";
 export type AgentMessageDeliveryStatus = "queued" | "delivered" | "failed";
+export type AgentMessageDeliveryState = "pending" | "in_flight" | "indeterminate" | "delivered" | "failed";
 
 export interface AgentPresence {
 	readonly key: string;
@@ -62,6 +63,11 @@ export interface AgentMessage {
 	readonly broadcast: boolean;
 	readonly deliveryPath: AgentMessageDeliveryPath;
 	readonly deliveryStatus: AgentMessageDeliveryStatus;
+	readonly deliveryState: AgentMessageDeliveryState;
+	readonly deliveryAttemptId?: string;
+	readonly deliveryAttempts: number;
+	readonly deliveryAttemptStartedAt?: string;
+	readonly deliveryUpdatedAt?: string;
 	readonly deliveryError?: string;
 	readonly deliveryReceipt?: Record<string, unknown>;
 	readonly acknowledgedAt?: string;
@@ -84,6 +90,17 @@ interface CrossAgentMessageRow {
 	readonly delivery_error: string | null;
 	readonly delivery_receipt_json: string | null;
 	readonly acknowledged_at: string | null;
+	readonly delivery_state: AgentMessageDeliveryState;
+	readonly delivery_attempt_id: string | null;
+	readonly delivery_attempts: number;
+	readonly delivery_lease_token: string | null;
+	readonly delivery_lease_expires_at: string | null;
+	readonly delivery_attempt_started_at: string | null;
+	readonly delivery_updated_at: string | null;
+	readonly acp_base_url: string | null;
+	readonly acp_target_agent_name: string | null;
+	readonly acp_timeout_ms: number | null;
+	readonly acp_metadata_json: string | null;
 }
 
 export interface CreateAgentMessageInput {
@@ -98,6 +115,10 @@ export interface CreateAgentMessageInput {
 	readonly deliveryStatus?: AgentMessageDeliveryStatus;
 	readonly deliveryError?: string;
 	readonly deliveryReceipt?: Record<string, unknown>;
+	readonly acpBaseUrl?: string;
+	readonly acpTargetAgentName?: string;
+	readonly acpTimeoutMs?: number;
+	readonly acpMetadata?: Record<string, unknown>;
 }
 
 export interface ListAgentMessageOptions {
@@ -171,6 +192,9 @@ const DEFAULT_MESSAGE_LIMIT = 100;
 const MAX_MESSAGE_LIMIT = 500;
 const MAX_MESSAGE_CONTENT_CHARS = 65_536;
 const MAX_DURABLE_MESSAGES = 10_000;
+const ACP_RELAY_LEASE_MS = 150_000; // 120s max ACP timeout plus a 30s reconciliation grace period
+const ACP_PENDING_GRACE_MS = 30_000;
+const ACP_MAX_RETRY_ATTEMPTS = 3;
 
 const presenceByKey = new Map<string, MutableAgentPresence>();
 const subscribers = new Set<(event: CrossAgentEvent) => void>();
@@ -455,6 +479,11 @@ function rowToAgentMessage(row: CrossAgentMessageRow): AgentMessage {
 		broadcast: row.broadcast === 1,
 		deliveryPath: row.delivery_path,
 		deliveryStatus: row.delivery_status,
+		deliveryState: row.delivery_state,
+		deliveryAttemptId: row.delivery_attempt_id ?? undefined,
+		deliveryAttempts: row.delivery_attempts,
+		deliveryAttemptStartedAt: row.delivery_attempt_started_at ?? undefined,
+		deliveryUpdatedAt: row.delivery_updated_at ?? undefined,
 		deliveryError: row.delivery_error ?? undefined,
 		deliveryReceipt: parseDeliveryReceipt(row.delivery_receipt_json),
 		acknowledgedAt: row.acknowledged_at ?? undefined,
@@ -593,8 +622,22 @@ export function createAgentMessage(input: CreateAgentMessageInput): AgentMessage
 		broadcast: broadcast ? 1 : 0,
 		delivery_path: deliveryPath,
 		delivery_status: input.deliveryStatus ?? "delivered",
+		delivery_state: deliveryPath === "acp" ? "pending" : "delivered",
+		delivery_attempt_id: randomUUID(),
+		delivery_attempts: 0,
+		delivery_lease_token: null,
+		delivery_lease_expires_at: null,
+		delivery_attempt_started_at: null,
+		delivery_updated_at: now,
 		delivery_error: normalizeText(input.deliveryError) ?? null,
 		delivery_receipt_json: serializeDeliveryReceipt(input.deliveryReceipt),
+		acp_base_url: normalizeText(input.acpBaseUrl) ?? null,
+		acp_target_agent_name: normalizeText(input.acpTargetAgentName) ?? null,
+		acp_timeout_ms:
+			typeof input.acpTimeoutMs === "number" && Number.isFinite(input.acpTimeoutMs)
+				? Math.round(input.acpTimeoutMs)
+				: null,
+		acp_metadata_json: serializeDeliveryReceipt(input.acpMetadata),
 		acknowledged_at: null,
 	};
 
@@ -609,8 +652,11 @@ export function createAgentMessage(input: CreateAgentMessageInput): AgentMessage
 			`INSERT INTO cross_agent_messages (
 				id, from_agent_id, from_session_key, to_agent_id, to_session_key,
 				to_session_agent_id, broadcast, message_type, content, delivery_path,
-				delivery_status, delivery_error, delivery_receipt_json, created_at, expires_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				delivery_status, delivery_state, delivery_attempt_id, delivery_attempts,
+				delivery_lease_token, delivery_lease_expires_at, delivery_attempt_started_at,
+				delivery_updated_at, delivery_error, delivery_receipt_json, acp_base_url,
+				acp_target_agent_name, acp_timeout_ms, acp_metadata_json, created_at, expires_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		).run(
 			row.id,
 			row.from_agent_id,
@@ -623,8 +669,19 @@ export function createAgentMessage(input: CreateAgentMessageInput): AgentMessage
 			row.content,
 			row.delivery_path,
 			row.delivery_status,
+			row.delivery_state,
+			row.delivery_attempt_id,
+			row.delivery_attempts,
+			row.delivery_lease_token,
+			row.delivery_lease_expires_at,
+			row.delivery_attempt_started_at,
+			row.delivery_updated_at,
 			row.delivery_error,
 			row.delivery_receipt_json,
+			row.acp_base_url,
+			row.acp_target_agent_name,
+			row.acp_timeout_ms,
+			row.acp_metadata_json,
 			row.created_at,
 			row.expires_at,
 		);
@@ -633,6 +690,149 @@ export function createAgentMessage(input: CreateAgentMessageInput): AgentMessage
 	const out = rowToAgentMessage(row);
 	emit({ type: "message", message: out, timestamp: now });
 	return out;
+}
+
+export class AgentMessageDeliveryLeaseError extends Error {
+	constructor(messageId: string) {
+		super(`ACP delivery lease was lost for message ${messageId}`);
+		this.name = "AgentMessageDeliveryLeaseError";
+	}
+}
+
+export interface AcpDeliveryAttempt {
+	readonly message: AgentMessage;
+	readonly leaseToken: string;
+	readonly idempotencyKey: string;
+	readonly request: {
+		readonly baseUrl: string;
+		readonly targetAgentName: string;
+		readonly content: string;
+		readonly fromAgentId: string;
+		readonly fromSessionKey?: string;
+		readonly metadata?: Readonly<Record<string, unknown>>;
+		readonly timeoutMs?: number;
+	};
+}
+
+function readMessageRow(db: ReadDb | WriteDb, messageId: string): CrossAgentMessageRow | null {
+	return (
+		(db.prepare("SELECT m.*, NULL AS acknowledged_at FROM cross_agent_messages m WHERE m.id = ?").get(messageId) as
+			| CrossAgentMessageRow
+			| null
+			| undefined) ?? null
+	);
+}
+
+function buildAcpAttempt(row: CrossAgentMessageRow): AcpDeliveryAttempt {
+	const baseUrl = normalizeText(row.acp_base_url ?? undefined);
+	const targetAgentName = normalizeText(row.acp_target_agent_name ?? undefined);
+	const attemptId = normalizeText(row.delivery_attempt_id ?? undefined);
+	const leaseToken = normalizeText(row.delivery_lease_token ?? undefined);
+	if (!baseUrl || !targetAgentName || !attemptId || !leaseToken) {
+		throw new Error("ACP delivery attempt is missing durable target or lease state");
+	}
+	return {
+		message: rowToAgentMessage(row),
+		leaseToken,
+		idempotencyKey: `signet-acp-${attemptId}`,
+		request: {
+			baseUrl,
+			targetAgentName,
+			content: row.content,
+			fromAgentId: row.from_agent_id,
+			fromSessionKey: row.from_session_key ?? undefined,
+			metadata: parseDeliveryReceipt(row.acp_metadata_json),
+			timeoutMs: row.acp_timeout_ms ?? undefined,
+		},
+	};
+}
+
+export function claimAcpMessageDelivery(input: {
+	readonly messageId: string;
+	readonly agentId?: string;
+	readonly retryIndeterminate?: boolean;
+	readonly nowMs?: number;
+}): AcpDeliveryAttempt {
+	const messageId = normalizeText(input.messageId);
+	if (!messageId) throw new Error("messageId is required");
+	const agentId = normalizeText(input.agentId);
+	const nowMs = input.nowMs ?? Date.now();
+	const now = new Date(nowMs).toISOString();
+	const leaseExpiresAt = new Date(nowMs + ACP_RELAY_LEASE_MS).toISOString();
+	const leaseToken = randomUUID();
+	const allowedState = input.retryIndeterminate ? "indeterminate" : "pending";
+	let attempt: AcpDeliveryAttempt | null = null;
+
+	getDbAccessor().withWriteTx((db) => {
+		const result = db
+			.prepare(
+				`UPDATE cross_agent_messages
+				 SET delivery_state = 'in_flight', delivery_status = 'queued',
+				     delivery_attempts = delivery_attempts + 1,
+				     delivery_lease_token = ?, delivery_lease_expires_at = ?,
+				     delivery_attempt_started_at = ?, delivery_updated_at = ?
+				 WHERE id = ? AND delivery_path = 'acp'
+				   AND delivery_state = ? AND delivery_attempts < ?
+				   AND (delivery_lease_expires_at IS NULL OR delivery_lease_expires_at <= ?)`,
+			)
+			.run(leaseToken, leaseExpiresAt, now, now, messageId, allowedState, ACP_MAX_RETRY_ATTEMPTS, now);
+		if (result.changes !== 1) {
+			const row = readMessageRow(db, messageId);
+			if (row == null) throw new AgentMessageNotFoundError(messageId);
+			if (row.delivery_state === "in_flight") throw new Error("ACP delivery is already active");
+			if (row.delivery_attempts >= ACP_MAX_RETRY_ATTEMPTS) throw new Error("ACP retry limit reached");
+			throw new Error(`ACP delivery is not ${allowedState}`);
+		}
+		const row = readMessageRow(db, messageId);
+		if (row == null) throw new AgentMessageNotFoundError(messageId);
+		if (agentId && row.from_agent_id !== agentId) throw new AgentMessageNotFoundError(messageId);
+		attempt = buildAcpAttempt(row);
+	});
+	if (attempt == null) throw new AgentMessageNotFoundError(messageId);
+	return attempt;
+}
+
+export function completeAcpMessageDelivery(
+	messageId: string,
+	leaseToken: string,
+	input: {
+		readonly status: "delivered" | "failed" | "indeterminate";
+		readonly error?: string;
+		readonly receipt?: Record<string, unknown>;
+	},
+): AgentMessage {
+	const normalizedId = normalizeText(messageId);
+	const normalizedToken = normalizeText(leaseToken);
+	if (!normalizedId) throw new Error("messageId is required");
+	if (!normalizedToken) throw new Error("leaseToken is required");
+	const now = new Date().toISOString();
+	let updated: AgentMessage | null = null;
+	getDbAccessor().withWriteTx((db) => {
+		const result = db
+			.prepare(
+				`UPDATE cross_agent_messages
+				 SET delivery_state = ?, delivery_status = ?, delivery_error = ?,
+				     delivery_receipt_json = ?, delivery_lease_token = NULL,
+				     delivery_lease_expires_at = NULL, delivery_updated_at = ?
+				 WHERE id = ? AND delivery_state = 'in_flight' AND delivery_lease_token = ?`,
+			)
+			.run(
+				input.status,
+				input.status === "delivered" ? "delivered" : input.status === "failed" ? "failed" : "queued",
+				normalizeText(input.error) ?? null,
+				serializeDeliveryReceipt(input.receipt),
+				now,
+				normalizedId,
+				normalizedToken,
+			);
+		if (result.changes !== 1) throw new AgentMessageDeliveryLeaseError(normalizedId);
+		const row = readMessageRow(db, normalizedId);
+		if (row == null) throw new AgentMessageNotFoundError(normalizedId);
+		updated = rowToAgentMessage(row);
+	});
+	if (updated == null) throw new AgentMessageNotFoundError(normalizedId);
+	emit({ type: "message", message: updated, timestamp: now });
+	return updated;
 }
 
 export function updateAgentMessageDelivery(
@@ -646,21 +846,54 @@ export function updateAgentMessageDelivery(
 	const normalizedId = normalizeText(messageId);
 	if (!normalizedId) throw new Error("messageId is required");
 	let updated: AgentMessage | null = null;
+	const state: AgentMessageDeliveryState =
+		input.status === "delivered" ? "delivered" : input.status === "failed" ? "failed" : "pending";
+	const now = new Date().toISOString();
 	getDbAccessor().withWriteTx((db) => {
 		db.prepare(
 			`UPDATE cross_agent_messages
-			 SET delivery_status = ?, delivery_error = ?, delivery_receipt_json = ?
+			 SET delivery_status = ?, delivery_state = ?, delivery_error = ?,
+			     delivery_receipt_json = ?, delivery_lease_token = NULL,
+			     delivery_lease_expires_at = NULL, delivery_updated_at = ?
 			 WHERE id = ?`,
-		).run(input.status, normalizeText(input.error) ?? null, serializeDeliveryReceipt(input.receipt), normalizedId);
-		const row = db
-			.prepare("SELECT m.*, NULL AS acknowledged_at FROM cross_agent_messages m WHERE m.id = ?")
-			.get(normalizedId) as CrossAgentMessageRow | null | undefined;
+		).run(
+			input.status,
+			state,
+			normalizeText(input.error) ?? null,
+			serializeDeliveryReceipt(input.receipt),
+			now,
+			normalizedId,
+		);
+		const row = readMessageRow(db, normalizedId);
 		if (row == null) throw new AgentMessageNotFoundError(normalizedId);
 		updated = rowToAgentMessage(row);
 	});
 	if (updated == null) throw new AgentMessageNotFoundError(normalizedId);
-	emit({ type: "message", message: updated, timestamp: new Date().toISOString() });
+	emit({ type: "message", message: updated, timestamp: now });
 	return updated;
+}
+
+export function reconcileAcpDeliveries(accessor: DbAccessor = getDbAccessor(), nowMs = Date.now()): number {
+	const now = new Date(nowMs).toISOString();
+	const pendingCutoff = new Date(nowMs - ACP_PENDING_GRACE_MS).toISOString();
+	return accessor.withWriteTx((db) => {
+		const result = db
+			.prepare(
+				`UPDATE cross_agent_messages
+				 SET delivery_state = 'indeterminate', delivery_status = 'queued',
+				     delivery_error = CASE
+				       WHEN delivery_state = 'in_flight' THEN 'ACP relay interrupted; remote outcome is unknown'
+				       ELSE 'ACP relay was queued but never started'
+				     END,
+				     delivery_lease_token = NULL, delivery_lease_expires_at = NULL,
+				     delivery_updated_at = ?
+				 WHERE delivery_path = 'acp'
+				   AND ((delivery_state = 'in_flight' AND delivery_lease_expires_at <= ?)
+				     OR (delivery_state = 'pending' AND delivery_updated_at <= ?))`,
+			)
+			.run(now, now, pendingCutoff);
+		return result.changes;
+	});
 }
 
 export function listAgentMessagePage(options: ListAgentMessageOptions = {}): AgentMessagePage {

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -46,7 +46,7 @@ import {
 	migrateSessionSynthesisRoute,
 } from "./config-migration";
 import { listConnectors } from "./connectors/registry";
-import { clearAllPresence } from "./cross-agent";
+import { clearAllPresence, reconcileAcpDeliveries } from "./cross-agent";
 import { closeDbAccessor, getDbAccessor, getVectorRuntimeStatus, initDbAccessorAsync } from "./db-accessor";
 import { fetchEmbedding } from "./embedding-fetch";
 import { type EmbeddingIndexMigrationHandle, startEmbeddingIndexMigration } from "./embedding-index-migration";
@@ -320,10 +320,12 @@ const MEMORY_IMPORT_POLL_MS = 30_000;
 // chats) leave live-retained transcripts unclosed; sweep the stale sessions
 // and fire the deferred session-end on a timer.
 const STALE_SESSION_SWEEP_INTERVAL_MS = 15 * 60 * 1000;
+const ACP_DELIVERY_RECONCILIATION_INTERVAL_MS = 30_000;
 const STALE_SESSION_TTL_MS = 12 * 60 * 60 * 1000;
 const MEMORY_IMPORT_FILE_DELAY_MS = 50;
 let memoryImportTimer: ReturnType<typeof setInterval> | null = null;
 let staleSessionSweepTimer: ReturnType<typeof setInterval> | null = null;
+let acpDeliveryReconciliationTimer: ReturnType<typeof setInterval> | null = null;
 let memoryImportInFlight = false;
 
 let syncTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1075,6 +1077,30 @@ function stopStaleSessionSweeper(): void {
 	staleSessionSweepTimer = null;
 }
 
+function startAcpDeliveryReconciliation(): void {
+	if (acpDeliveryReconciliationTimer !== null) return;
+	acpDeliveryReconciliationTimer = setInterval(() => {
+		try {
+			const reconciled = reconcileAcpDeliveries();
+			if (reconciled > 0) logger.info("daemon", "Reconciled abandoned ACP delivery attempts", { reconciled });
+		} catch (error) {
+			logger.warn("daemon", "ACP delivery reconciliation failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}, ACP_DELIVERY_RECONCILIATION_INTERVAL_MS);
+	acpDeliveryReconciliationTimer.unref?.();
+	logger.debug("watcher", "Started ACP delivery reconciliation", {
+		intervalMs: ACP_DELIVERY_RECONCILIATION_INTERVAL_MS,
+	});
+}
+
+function stopAcpDeliveryReconciliation(): void {
+	if (acpDeliveryReconciliationTimer === null) return;
+	clearInterval(acpDeliveryReconciliationTimer);
+	acpDeliveryReconciliationTimer = null;
+}
+
 function startFileWatcher() {
 	// Do NOT watch the memory/ directory directly — Bun's fs.watch()
 	// opens one O_RDONLY FD per file in a watched directory and never
@@ -1670,6 +1696,7 @@ async function cleanup() {
 	}
 	stopMemoryImportPoller();
 	stopStaleSessionSweeper();
+	stopAcpDeliveryReconciliation();
 	if (nativeMemoryBridge) {
 		await nativeMemoryBridge.close();
 		nativeMemoryBridge = null;
@@ -2226,6 +2253,7 @@ async function main() {
 		});
 		startMemoryImportPoller();
 		startStaleSessionSweeper();
+		startAcpDeliveryReconciliation();
 
 		if (!nativeMemoryBridge) {
 			const startupSourceJobs = new Map<string, string>();

--- a/platform/daemon/src/mcp/tools.test.ts
+++ b/platform/daemon/src/mcp/tools.test.ts
@@ -265,6 +265,7 @@ describe("createMcpServer", () => {
 		expect(names).toContain("session_search");
 		expect(names).toContain("agent_peers");
 		expect(names).toContain("agent_message_send");
+		expect(names).toContain("agent_message_retry");
 		expect(names).toContain("agent_message_inbox");
 		expect(names).toContain("agent_message_ack");
 		expect(names).toContain("mcp_server_list");
@@ -286,7 +287,7 @@ describe("createMcpServer", () => {
 		for (const alias of GRAPHIQ_COMPAT_ALIASES) {
 			expect(names).toContain(alias);
 		}
-		expect(names.length).toBe(63);
+		expect(names.length).toBe(64);
 	});
 
 	it("registers generic code tools when GraphIQ has an active project", async () => {
@@ -1273,6 +1274,20 @@ describe("createMcpServer", () => {
 			expect(body.acp.baseUrl).toBe("https://acp.example.com");
 			expect(body.acp.targetAgentName).toBe("peer-helper");
 			expect(body.acp.timeoutMs).toBe(7000);
+		});
+
+		it("agent_message_retry posts the scoped retry", async () => {
+			const cap: { url?: string; method?: string; body?: string } = {};
+			mockFetch(200, { message: { deliveryState: "delivered" } }, cap);
+
+			await callTool(server, "agent_message_retry", {
+				message_id: "msg-1",
+				agent_id: "alpha",
+			});
+
+			expect(cap.method).toBe("POST");
+			expect(cap.url).toContain("/api/cross-agent/messages/msg-1/retry");
+			expect(JSON.parse(cap.body ?? "{}")).toEqual({ agentId: "alpha" });
 		});
 
 		it("agent_message_inbox calls messages endpoint", async () => {

--- a/platform/daemon/src/mcp/tools.ts
+++ b/platform/daemon/src/mcp/tools.ts
@@ -1560,6 +1560,32 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	);
 
 	// ------------------------------------------------------------------
+	// agent_message_retry — retry an indeterminate ACP delivery
+	// ------------------------------------------------------------------
+	registerMcpTool(
+		server,
+		"agent_message_retry",
+		{
+			title: "Retry ACP Agent Message",
+			description: "Retry an indeterminate ACP delivery with the same durable idempotency key; retries are bounded.",
+			inputSchema: z.object({
+				message_id: z.string().describe("Message id returned by agent_message_send"),
+				agent_id: z.string().optional().describe("Sending agent id (defaults to authenticated scope/current agent)"),
+			}),
+			annotations: { readOnlyHint: false },
+		},
+		async ({ message_id, agent_id }) => {
+			const result = await fetchDaemon<unknown>(
+				baseUrl,
+				`/api/cross-agent/messages/${encodeURIComponent(message_id)}/retry`,
+				{ method: "POST", body: { agentId: agent_id } },
+			);
+			if (!result.ok) return errorResult(`Retry failed: ${result.error}`);
+			return textResult(result.data);
+		},
+	);
+
+	// ------------------------------------------------------------------
 	// agent_message_inbox — read recent inbound messages
 	// ------------------------------------------------------------------
 	registerMcpTool(

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -7,11 +7,14 @@ import { getAgentScope, resolveAgentId } from "../agent-id";
 import { aggregateRecall, parseAggregateRecallBudget, readAggregateRecallBudgetInput } from "../aggregate-recall";
 import { checkScope, requirePermission, requireRateLimit } from "../auth";
 import {
+	type AcpDeliveryAttempt,
 	type AgentMessage,
 	AgentMessageCapacityError,
 	AgentMessageNotFoundError,
 	type AgentMessageType,
 	acknowledgeAgentMessage,
+	claimAcpMessageDelivery,
+	completeAcpMessageDelivery,
 	createAgentMessage,
 	isMessageVisibleToAgent,
 	listAgentMessagePage,
@@ -21,7 +24,6 @@ import {
 	removeAgentPresence,
 	subscribeCrossAgentEvents,
 	touchAgentPresence,
-	updateAgentMessageDelivery,
 	upsertAgentPresence,
 } from "../cross-agent";
 import { getDbAccessor } from "../db-accessor";
@@ -1350,6 +1352,20 @@ function registerCrossAgentPresence(app: Hono): void {
 	});
 }
 
+async function relayClaimedAcpMessage(attempt: AcpDeliveryAttempt): Promise<AgentMessage> {
+	const relay = await relayMessageViaAcp({
+		...attempt.request,
+		idempotencyKey: attempt.idempotencyKey,
+	});
+	const receipt: Record<string, unknown> = { status: relay.status, idempotencyKey: attempt.idempotencyKey };
+	if (relay.runId) receipt.runId = relay.runId;
+	return completeAcpMessageDelivery(attempt.message.id, attempt.leaseToken, {
+		status: relay.ok ? "delivered" : relay.indeterminate ? "indeterminate" : "failed",
+		error: relay.error,
+		receipt,
+	});
+}
+
 function registerCrossAgentMessages(app: Hono): void {
 	app.get("/api/cross-agent/messages", (c) => {
 		const requestedAgentId = parseOptionalString(c.req.query("agent_id"));
@@ -1424,6 +1440,39 @@ function registerCrossAgentMessages(app: Hono): void {
 				error instanceof Error ? error : new Error(String(error)),
 			);
 			return c.json({ error: "Failed to acknowledge cross-agent message" }, 500);
+		}
+	});
+
+	app.post("/api/cross-agent/messages/:messageId/retry", async (c) => {
+		const payload = await readOptionalJsonObject(c);
+		if (payload === null) return c.json({ error: "invalid request body" }, 400);
+		const messageId = parseOptionalString(c.req.param("messageId"));
+		if (!messageId) return c.json({ error: "messageId is required" }, 400);
+		const requestedAgentId =
+			parseOptionalString(payload.agentId) ?? parseOptionalString(c.req.header("x-signet-agent-id"));
+		const scopedAgent = resolveScopedAgentId(c, requestedAgentId, "default");
+		if (scopedAgent.error) return c.json({ error: scopedAgent.error }, 403);
+
+		try {
+			const attempt = claimAcpMessageDelivery({
+				messageId,
+				agentId: scopedAgent.agentId,
+				retryIndeterminate: true,
+			});
+			const message = await relayClaimedAcpMessage(attempt);
+			return c.json({ message });
+		} catch (error) {
+			if (error instanceof AgentMessageNotFoundError) return c.json({ error: error.message }, 404);
+			const message = error instanceof Error ? error.message : String(error);
+			if (
+				message.includes("already active") ||
+				message.includes("retry limit") ||
+				message.includes("not indeterminate")
+			) {
+				return c.json({ error: message }, 409);
+			}
+			logger.error("hooks", "ACP retry failed", error instanceof Error ? error : new Error(message));
+			return c.json({ error: "ACP retry could not be completed" }, 500);
 		}
 	});
 
@@ -1507,6 +1556,10 @@ function registerCrossAgentMessages(app: Hono): void {
 				broadcast,
 				deliveryPath,
 				deliveryStatus: acpRequest ? "queued" : "delivered",
+				acpBaseUrl: acpRequest?.baseUrl,
+				acpTargetAgentName: acpRequest?.targetAgentName,
+				acpTimeoutMs: acpRequest?.timeoutMs,
+				acpMetadata: acpRequest?.metadata,
 			});
 		} catch (error) {
 			if (error instanceof AgentMessageCapacityError) {
@@ -1517,22 +1570,15 @@ function registerCrossAgentMessages(app: Hono): void {
 		}
 
 		if (acpRequest) {
-			const relay = await relayMessageViaAcp({
-				...acpRequest,
-				content,
-				fromAgentId: scopedSender.agentId,
-				fromSessionKey,
-			});
-			const receipt: Record<string, unknown> = { status: relay.status };
-			if (relay.runId) receipt.runId = relay.runId;
 			try {
-				message = updateAgentMessageDelivery(message.id, {
-					status: relay.ok ? "delivered" : "failed",
-					error: relay.error,
-					receipt,
-				});
+				const attempt = claimAcpMessageDelivery({ messageId: message.id, agentId: scopedSender.agentId });
+				message = await relayClaimedAcpMessage(attempt);
 			} catch (error) {
-				logger.error("hooks", "Failed to persist ACP delivery result", error as Error);
+				logger.error(
+					"hooks",
+					"Failed to persist ACP delivery result",
+					error instanceof Error ? error : new Error(String(error)),
+				);
 				return c.json({ error: "ACP delivery result could not be persisted", message }, 500);
 			}
 		}

--- a/platform/daemon/src/startup-recovery.ts
+++ b/platform/daemon/src/startup-recovery.ts
@@ -16,6 +16,7 @@
  * (no HTTP server, no workers, no competing load).
  */
 
+import { reconcileAcpDeliveries } from "./cross-agent";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import { logger } from "./logger";
 
@@ -24,6 +25,7 @@ export interface StartupRecoveryReport {
 	readonly deadJobsPurged: number;
 	readonly stagingRowsCleaned: number;
 	readonly orphanedPassesSwept: number;
+	readonly acpDeliveriesReconciled: number;
 	readonly durationMs: number;
 }
 
@@ -108,7 +110,9 @@ export function runStartupRecovery(accessor: DbAccessor): StartupRecoveryReport 
 				.prepare("SELECT COUNT(*) AS n FROM sqlite_master WHERE type = 'table' AND name = 'embedding_index_state'")
 				.get() as { n: number } | undefined;
 			if (!tableExists?.n) return false;
-			const state = db.prepare("SELECT state FROM embedding_index_state WHERE id = 1").get() as { state: string } | undefined;
+			const state = db.prepare("SELECT state FROM embedding_index_state WHERE id = 1").get() as
+				| { state: string }
+				| undefined;
 			return state?.state === "building";
 		});
 
@@ -170,16 +174,26 @@ export function runStartupRecovery(accessor: DbAccessor): StartupRecoveryReport 
 		});
 	}
 
+	let acpDeliveriesReconciled = 0;
+	try {
+		acpDeliveriesReconciled = reconcileAcpDeliveries(accessor);
+	} catch (err) {
+		logger.warn("startup-recovery", "ACP delivery reconciliation failed", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+
 	const durationMs = Date.now() - startedAt;
 	const report: StartupRecoveryReport = {
 		walCheckpointed: false,
 		deadJobsPurged,
 		stagingRowsCleaned,
 		orphanedPassesSwept,
+		acpDeliveriesReconciled,
 		durationMs,
 	};
 
-	const totalCleaned = deadJobsPurged + stagingRowsCleaned + orphanedPassesSwept;
+	const totalCleaned = deadJobsPurged + stagingRowsCleaned + orphanedPassesSwept + acpDeliveriesReconciled;
 	if (totalCleaned > 0) {
 		logger.info("startup-recovery", "Recovery complete", { ...report });
 	} else {

--- a/web/docs/src/content/docs/api/route-inventory.md
+++ b/web/docs/src/content/docs/api/route-inventory.md
@@ -45,6 +45,7 @@ silently disappear from the API reference.
 | GET | `/api/cross-agent/messages` | platform/daemon/src/routes/hooks-routes.ts |
 | POST | `/api/cross-agent/messages` | platform/daemon/src/routes/hooks-routes.ts |
 | POST | `/api/cross-agent/messages/:messageId/ack` | platform/daemon/src/routes/hooks-routes.ts |
+| POST | `/api/cross-agent/messages/:messageId/retry` | platform/daemon/src/routes/hooks-routes.ts |
 | GET | `/api/cross-agent/stream` | platform/daemon/src/routes/hooks-routes.ts |
 | POST | `/api/synthesis/trigger` | platform/daemon/src/routes/hooks-routes.ts |
 | GET | `/api/synthesis/status` | platform/daemon/src/routes/hooks-routes.ts |

--- a/web/docs/src/content/docs/mcp.md
+++ b/web/docs/src/content/docs/mcp.md
@@ -383,6 +383,14 @@ Supports local daemon delivery and optional ACP relay.
 
 **Daemon endpoint:** `POST /api/cross-agent/messages`
 
+ACP responses include `deliveryState`: `pending`, `in_flight`, `indeterminate`,
+`delivered`, or `failed`. `indeterminate` means the remote outcome is unknown
+after a transport failure, 5xx response, or crash. Signet does not resend
+automatically; use `POST /api/cross-agent/messages/:messageId/retry` or the SDK
+`retryAgentMessage` method for the bounded retry. There are three total attempts
+(initial send plus two retries); after that, retry returns `409` and the row
+remains indeterminate for manual review. Retries reuse the same idempotency key.
+
 ### agent_message_inbox
 
 Read recent inbound cross-agent messages for an agent/session.


### PR DESCRIPTION
## Summary

Closes #1263.

ACP cross-agent messages are persisted before relay, but a daemon crash or local write failure could leave the durable row queued forever or make a retry duplicate a remote run. This PR adds durable reconciliation state, lease-safe relay recovery, stable idempotency keys, bounded retries, and operator inspection across the public surfaces.

## Changes

- Add migration 116 for ACP attempt identity, lease metadata, retry counters, target metadata, errors, and explicit delivery state.
- Reconcile abandoned pending and in-flight attempts during startup and in the background.
- Protect active relays with a 150-second lease: 120 seconds for the ACP timeout plus 30 seconds of reconciliation grace.
- Treat transport errors, timeouts, crashes, local persistence gaps, and ACP 5xx responses as `indeterminate`.
- Reuse a stable `Idempotency-Key` on retries and bound delivery to three total attempts.
- Expose inspection and scoped retry through HTTP, SDK, and MCP.
- Document legacy compatibility and indeterminate delivery semantics.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [x] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: MCP and API documentation

## Screenshots

Not applicable. This PR does not change a UI surface.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally (focused checks pass; unrelated full-repository failures are documented below)

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

Migration 116 preserves the legacy `delivery_status` values and maps existing ACP rows into the new richer `delivery_state` field. Existing pre-reconciliation queued rows receive a stable row-derived attempt identity, but their original remote request did not include an idempotency key, so those rows remain subject to the documented manual-review caveat.

## Testing

- [x] Focused cross-agent tests: 22 pass
- [x] Migration tests: 55 pass
- [x] Startup recovery tests: 4 pass
- [x] MCP retry test passes
- [x] Full `bun run build` passes
- [x] Daemon typecheck and Biome checks pass
- [ ] Full `bun test` passes: not claimed; the MCP suite retains an unrelated ontology `propertyNames` schema failure
- [ ] Full `bun run typecheck` passes: not claimed; existing connector-package failures remain outside this PR
- [ ] Full `bun run lint` passes: not claimed; existing package.json formatting drift remains outside this PR
- [ ] Tested against running daemon

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tag in the commit)

## Notes

An adversarial review covered agent scoping, transaction rollback, lease races, crash windows, migration idempotence, retry bounds, 4xx/5xx behavior, startup ordering, and SDK/MCP parity. The review findings were addressed before opening this PR.
