### PR TITLE
fix(daemon): add bounded wedge pressure telemetry

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -53,7 +53,7 @@ PostHog failures, and never throws into the daemon.
 | `first.remember` / `first.recall` | first successful remember / recall per install, exactly once | `version`, `platform` |
 | `daemon.started` | daemon boot | `version`, `platform`, `uptimeMs` |
 | `daemon.previous_exit` | next successful boot reconciles the prior lifecycle record, exactly once when one exists | `classification` (`clean` / `error` / `unrecorded`), `reasonCategory`, `exitCode`, `previousVersion`, `previousUptimeMs`, `restartDelayMs` |
-| `daemon.heartbeat` | every 5 minutes | `uptimeMs`, `memoryCount`, `connectorsActive`, `pipelineMode`, `extractionProvider`, `embeddingProvider` |
+| `daemon.heartbeat` | every 5 minutes | `uptimeMs`, `memoryCount`, `connectorsActive`, `pipelineMode`, `extractionProvider`, `embeddingProvider`, bounded runtime-pressure buckets |
 | `session.start` | real session start (deduped; stubs and clear/reset paths don't count) | `harness`, `sessionHash` |
 | `session.turn` | every non-boundary `session-end` hook call (per turn, see notes) | `harness`, `promptCount`, `sessionHash` |
 | `session.end` | real session termination: an explicit boundary reason or a TTL-evicted (abandoned) session claim | `harness`, `reason` (`clear` / `session.deleted` / `session_branch` / `session_fork` / `session_shutdown` / `session_switch` / `stale-session-sweep` / `expired`), `sessionHash`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `cost` |
@@ -65,7 +65,7 @@ PostHog failures, and never throws into the daemon.
 | `inference.route` | inference control-plane routing decision | `surface`, `agentId`, `operation`, `taskClass`, `policyId`, `selectedTarget`, `candidateCount`, `blockedCount`, `allowedCount`, `privacy`, `durationMs`, `success`, `errorCode` |
 | `inference.execute` / `inference.stream` | per-execution outcome | `surface`, `agentId`, `operation`, `taskClass`, `policyId`, `selectedTarget`, `finalTarget`, `attemptPath`, `failedTargets`, `attemptCount`, `failedCount`, `fallbackCount`, `privacy`, `durationMs`, `inputTokens`, `outputTokens`, `success`, `cancelled`, `errorCode` |
 | `inference.fallback` | emitted alongside execute/stream when a target failed and routing fell back | same fields as execute/stream |
-| `error.occurred` | process-level crash, unhandled rejection, or event-loop wedge | `type`, `message`, `stack`, `uptimeMs`; `EventLoopLag` reports add `lagMs` |
+| `error.occurred` | process-level crash, unhandled rejection, or event-loop wedge | `type`, `message`, `stack`, `uptimeMs`; `EventLoopLag` reports add `lagMs` and the latest bounded runtime-pressure buckets |
 | `version.upgraded` | daemon auto-update path only | `from`, `to` |
 | `command.invoked` | CLI command (name only, never arguments) | `command` |
 
@@ -127,6 +127,15 @@ Notes on individual events:
   search and additional events for decomposed subqueries. Local stats read the
   flushed telemetry table, so they can lag the in-memory event buffer by one
   flush interval.
+- **Runtime-pressure buckets (#1282)** — heartbeats and rate-limited
+  `EventLoopLag` reports carry `runtimePressureVersion`, queue-depth and
+  oldest-job-age buckets, active-worker and configured batch-size buckets,
+  database and embedding latency buckets, process memory/CPU pressure buckets,
+  `recoveryOutcome`, and a coarse `snapshotAgeBucket`. The daemon keeps only
+  the latest observations in memory; the wedge path never queries SQLite,
+  touches the filesystem, or starts provider work. `recoveryOutcome` is
+  `still_degraded` during an episode, `recovered` after the pressure state
+  clears, and `restarted` on the first heartbeat after an abnormal prior exit.
 
 ## Privacy contract
 
@@ -143,6 +152,11 @@ Notes on individual events:
   reports (the event-loop-wedge class) are rate-limited to once per 10
   minutes per process so a stuck loop can't flood the project. No memory
   content is ever captured anywhere, so errors cannot carry it by design.
+- **Bounded wedge context.** Runtime pressure contains fixed bucket labels,
+  never raw queue counts, ages, latencies, RSS, CPU percentages, provider
+  messages, queue errors, payloads, source names, paths, PIDs, or additional
+  stack data. The existing once-per-10-minute `EventLoopLag` rate limit applies
+  to the complete event, including its pressure envelope.
 - **Agent ids in `inference.*` are hashed.** Inference events carry
   `agentId` as a SHA-256 hash salted with the per-install install id (16 hex
   chars). Stable within an install (per-agent analysis still works), not

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -48,6 +48,7 @@ import {
 import { listConnectors } from "./connectors/registry";
 import { clearAllPresence, reconcileAcpDeliveries } from "./cross-agent";
 import { closeDbAccessor, getDbAccessor, getVectorRuntimeStatus, initDbAccessorAsync } from "./db-accessor";
+import { getQueueDiagnosticsSnapshot } from "./diagnostics-queue";
 import { fetchEmbedding } from "./embedding-fetch";
 import { type EmbeddingIndexMigrationHandle, startEmbeddingIndexMigration } from "./embedding-index-migration";
 import { resolveActiveEmbeddingConfig } from "./embedding-index-state";
@@ -79,6 +80,7 @@ import {
 	ensureRetentionWorker,
 	ensureSummaryRecovery,
 	ensureSummaryWorker,
+	getPipelineWorkerStatus,
 	setDreamingWorker,
 	startPipeline,
 	stopPipeline,
@@ -91,7 +93,13 @@ import { configureLlmConcurrency } from "./pipeline/provider";
 import { type ReflectionWorkerHandle, startReflectionWorker } from "./pipeline/reflection-worker";
 import { startReconciler } from "./pipeline/skill-reconciler";
 import { isRemotePipelineProviderForEndpoint } from "./provider-safety";
-import { logFdSnapshot, startEventLoopMonitor, startFdPollMonitor, stopResourceMonitors } from "./resource-monitor";
+import {
+	getResourceSnapshot,
+	logFdSnapshot,
+	startEventLoopMonitor,
+	startFdPollMonitor,
+	stopResourceMonitors,
+} from "./resource-monitor";
 import {
 	AGENTS_DIR,
 	BIND_HOST,
@@ -124,6 +132,12 @@ import {
 	embeddingTrackerHandle as sharedEmbeddingTrackerHandle,
 	shuttingDown,
 } from "./routes/state.js";
+import {
+	type PressureRecoveryOutcome,
+	buildRuntimePressureEnvelope,
+	countActiveWorkers,
+	setRuntimePressureEnvelope,
+} from "./runtime-pressure";
 import { startSchedulerWorker } from "./scheduler";
 import { getSecret } from "./secrets.js";
 import { flushPendingCheckpoints, initCheckpointFlush, pruneCheckpoints } from "./session-checkpoints";
@@ -148,7 +162,7 @@ import {
 	updateSourceIndexJobProgress,
 } from "./source-index-progress";
 import { runStartupRecovery } from "./startup-recovery";
-import { reportStartupGrace } from "./system-pressure";
+import { getPressureRecoveryOutcome, reportStartupGrace } from "./system-pressure";
 import {
 	type TelemetryCollector,
 	type TelemetryConfigSnapshot,
@@ -1783,11 +1797,27 @@ function buildLifecycleRecord(state: DaemonLifecycle["state"], extra: Partial<Da
 	};
 }
 
-function flushAndExit(exitCode: number): void {
-	// The logger buffers file writes and flushes on a 1s timer; without an
-	// explicit flush the final log lines can be lost on exit.
-	logger.shutdown();
-	process.exit(exitCode);
+let exitFlushInFlight: Promise<void> | null = null;
+
+async function flushAndExit(exitCode: number): Promise<void> {
+	if (exitFlushInFlight) return exitFlushInFlight;
+	exitFlushInFlight = (async () => {
+		// Update handoffs and repeated signals bypass normal cleanup. Give the
+		// telemetry collector a bounded final drain before process.exit so a
+		// wedge/crash record is not discarded on those paths.
+		if (telemetryRef) {
+			const timeout = new Promise<void>((resolve) => {
+				const timer = setTimeout(resolve, 2_000);
+				if (timer.unref) timer.unref();
+			});
+			await Promise.race([telemetryRef.stop(), timeout]).catch(() => {});
+		}
+		// The logger buffers file writes and flushes on a 1s timer; without an
+		// explicit flush the final log lines can be lost on exit.
+		logger.shutdown();
+		process.exit(exitCode);
+	})();
+	return exitFlushInFlight;
 }
 
 function buildTerminalLifecycleRecord(reason: string, exitCode: number, error?: unknown): DaemonLifecycle {
@@ -1823,13 +1853,14 @@ function requestShutdown(reason: string, exitCode: number, error?: unknown, runC
 		// A second signal while draining must not wedge the process; flush and
 		// exit immediately so the operator is never stuck with a zombie — and
 		// the final log lines still land.
-		flushAndExit(exitCode);
+		void flushAndExit(exitCode);
+		return;
 	}
 	setShuttingDown(true);
 	logger.info("daemon", `Received ${reason}; shutting down`, { exitCode });
 	if (!runCleanup) {
 		writeDaemonLifecycle(AGENTS_DIR, buildTerminalLifecycleRecord(reason, exitCode, error));
-		flushAndExit(exitCode);
+		void flushAndExit(exitCode);
 		return;
 	}
 	const cleanupDeadline = setTimeout(() => {
@@ -1839,14 +1870,14 @@ function requestShutdown(reason: string, exitCode: number, error?: unknown, runC
 			deadlineMs: SHUTDOWN_CLEANUP_DEADLINE_MS,
 		});
 		writeDaemonLifecycle(AGENTS_DIR, buildTerminalLifecycleRecord(reason, exitCode, error));
-		flushAndExit(exitCode);
+		void flushAndExit(exitCode);
 	}, SHUTDOWN_CLEANUP_DEADLINE_MS);
 	cleanup()
 		.catch(() => {})
 		.finally(() => {
 			clearTimeout(cleanupDeadline);
 			writeDaemonLifecycle(AGENTS_DIR, buildTerminalLifecycleRecord(reason, exitCode, error));
-			flushAndExit(exitCode);
+			void flushAndExit(exitCode);
 		});
 }
 
@@ -1912,6 +1943,7 @@ async function main() {
 	const previousLifecycle = readDaemonLifecycle(AGENTS_DIR);
 	lifecycleStartedAt = new Date().toISOString();
 	const previousExit = classifyPreviousDaemonExit(previousLifecycle, lifecycleStartedAt);
+	let restartedHeartbeatPending = previousExit !== null && previousExit.classification !== "clean";
 	writeDaemonLifecycle(AGENTS_DIR, buildLifecycleRecord("starting"));
 
 	// Config migrations must precede every initialization path that resolves
@@ -2101,6 +2133,40 @@ async function main() {
 						return row?.cnt ?? 0;
 					});
 					const connectors = listConnectors(getDbAccessor());
+					let runtimePressure: ReturnType<typeof buildRuntimePressureEnvelope> | undefined;
+					try {
+						const queue = getDbAccessor().withReadDb((db) => getQueueDiagnosticsSnapshot(db, { fresh: true }));
+						const workers = getPipelineWorkerStatus();
+						const resources = getResourceSnapshot();
+						const recoveryOutcome: PressureRecoveryOutcome = restartedHeartbeatPending
+							? "restarted"
+							: getPressureRecoveryOutcome();
+						runtimePressure = buildRuntimePressureEnvelope({
+							memoryQueueDepth: queue.memory.pending + queue.memory.leased,
+							summaryQueueDepth: queue.summary.pending + queue.summary.leased,
+							oldestJobAgeSec: Math.max(queue.memory.oldestAgeSec, queue.summary.oldestAgeSec),
+							activeWorkers: countActiveWorkers(
+								[
+									workers.summary.running,
+									workers.document.running,
+									workers.retention.running,
+									workers.maintenance.running,
+									workers.synthesis.running,
+									workers.hints.running,
+									workers.dreaming.running,
+								],
+								workers.llmConcurrency.concurrency.running,
+							),
+							batchSize: liveCfg.pipelineV2.embeddingTracker.batchSize,
+							memoryRssMb: resources.rss,
+							cpuPercent: resources.cpuPercent,
+							recoveryOutcome,
+						});
+						setRuntimePressureEnvelope(runtimePressure);
+					} catch {
+						// Pressure context is best-effort; a slow or unavailable
+						// subsystem must never suppress the liveness heartbeat.
+					}
 					telemetryRef.record("daemon.heartbeat", {
 						uptimeMs: Date.now() - daemonStartTime,
 						memoryCount,
@@ -2108,7 +2174,11 @@ async function main() {
 						pipelineMode: readPipelineMode(liveCfg.pipelineV2),
 						extractionProvider: providerRuntimeResolution.extraction.effective,
 						embeddingProvider: liveCfg.embedding.provider,
+						...(runtimePressure ?? {}),
 					});
+					if (runtimePressure?.recoveryOutcome === "restarted") {
+						restartedHeartbeatPending = false;
+					}
 				} catch {}
 			},
 			5 * 60 * 1000,

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -33,6 +33,7 @@ import {
 import { convertToIncrementalVacuum } from "./db-vacuum";
 import { ensureEmbeddingIndexState } from "./embedding-index-state";
 import { loadMemoryConfig } from "./memory-config";
+import { observeDbLatency } from "./runtime-pressure";
 
 const isBun = typeof (globalThis as Record<string, unknown>).Bun !== "undefined";
 const require = createRequire(import.meta.url);
@@ -746,9 +747,9 @@ function finishDbAccessorInit(writeConn: SqliteDatabase, opts?: { readonly agent
 	// older installs where the table was dropped or never created.
 	ensureFtsTable(writeConn);
 	const configuredEmbedding = loadMemoryConfig(opts?.agentsDir ?? resolveSqliteAgentsDir()).embedding;
-	const legacyVecSql = writeConn.prepare("SELECT sql FROM sqlite_master WHERE name = 'vec_embeddings' AND type = 'table'").get() as
-		| { sql?: string }
-		| undefined;
+	const legacyVecSql = writeConn
+		.prepare("SELECT sql FROM sqlite_master WHERE name = 'vec_embeddings' AND type = 'table'")
+		.get() as { sql?: string } | undefined;
 	const legacyDimensions = readVecEmbeddingDimensions(legacyVecSql?.sql);
 	const embeddingIndexState = ensureEmbeddingIndexState(
 		writeConn,
@@ -1042,47 +1043,66 @@ function createAccessor(writeConn: SqliteDatabase): DbAccessor {
 	return {
 		withWriteTx<T>(fn: (db: WriteDb) => T): T {
 			if (closed) throw new Error("DbAccessor is closed");
-			writeConn.exec("BEGIN IMMEDIATE");
+			const startedAt = performance.now();
 			try {
-				const result = fn(writeConn);
-				writeConn.exec("COMMIT");
-				return result;
-			} catch (err) {
-				writeConn.exec("ROLLBACK");
-				throw err;
+				writeConn.exec("BEGIN IMMEDIATE");
+				try {
+					const result = fn(writeConn);
+					writeConn.exec("COMMIT");
+					return result;
+				} catch (err) {
+					writeConn.exec("ROLLBACK");
+					throw err;
+				}
+			} finally {
+				observeDbLatency(performance.now() - startedAt);
 			}
 		},
 
 		withReadDb<T>(fn: (db: ReadDb) => T): T {
 			if (closed) throw new Error("DbAccessor is closed");
+			const startedAt = performance.now();
 			const conn = acquireRead();
 			try {
 				return fn(conn);
 			} finally {
 				releaseRead(conn);
+				observeDbLatency(performance.now() - startedAt);
 			}
 		},
 
 		async withReadDbAsync<T>(fn: (db: ReadDb) => Promise<T>): Promise<T> {
 			if (closed) throw new Error("DbAccessor is closed");
+			const startedAt = performance.now();
 			const conn = acquireRead();
 			try {
 				return await fn(conn);
 			} finally {
 				releaseRead(conn);
+				observeDbLatency(performance.now() - startedAt);
 			}
 		},
 
 		checkpointWal(): void {
 			if (closed) throw new Error("DbAccessor is closed");
-			writeConn.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+			const startedAt = performance.now();
+			try {
+				writeConn.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+			} finally {
+				observeDbLatency(performance.now() - startedAt);
+			}
 		},
 
 		incrementalVacuum(): number {
 			if (closed) throw new Error("DbAccessor is closed");
-			writeConn.exec("PRAGMA incremental_vacuum");
-			const row = writeConn.prepare("PRAGMA freelist_count").get() as { freelist_count?: number } | undefined;
-			return typeof row?.freelist_count === "number" ? row.freelist_count : 0;
+			const startedAt = performance.now();
+			try {
+				writeConn.exec("PRAGMA incremental_vacuum");
+				const row = writeConn.prepare("PRAGMA freelist_count").get() as { freelist_count?: number } | undefined;
+				return typeof row?.freelist_count === "number" ? row.freelist_count : 0;
+			} finally {
+				observeDbLatency(performance.now() - startedAt);
+			}
 		},
 
 		close(): void {

--- a/platform/daemon/src/embedding-fetch.ts
+++ b/platform/daemon/src/embedding-fetch.ts
@@ -12,6 +12,7 @@ import {
 } from "./memory-config";
 import { isPipelineTimeout, recordPipelineError } from "./pipeline-error";
 import { countTokens, truncateToTokens } from "./pipeline/tokenizer";
+import { observeEmbeddingLatency } from "./runtime-pressure";
 import { getSecret } from "./secrets.js";
 
 export function resolveOllamaUrl(): string {
@@ -371,7 +372,13 @@ export async function fetchEmbedding(
 	const opts = typeof roleOrOpts === "string" ? (typeof optsOrRole === "string" ? {} : optsOrRole) : roleOrOpts;
 	const formattedText = formatEmbeddingInput(text, effectiveCfg, role);
 	try {
-		const serve = await serveEmbedding(formattedText, effectiveCfg, opts);
+		let serve: EmbeddingServeResult;
+		const providerStartedAt = performance.now();
+		try {
+			serve = await serveEmbedding(formattedText, effectiveCfg, opts);
+		} finally {
+			observeEmbeddingLatency(performance.now() - providerStartedAt);
+		}
 		if (serve.embedding === null && serve.provider !== null) {
 			recordPipelineError("embedding", "EMBEDDING_PROVIDER_DOWN");
 		}

--- a/platform/daemon/src/resource-monitor.test.ts
+++ b/platform/daemon/src/resource-monitor.test.ts
@@ -35,8 +35,13 @@ describe("getResourceSnapshot", () => {
 			"other",
 			"rss",
 			"heapUsed",
+			"cpuPercent",
 		];
 		for (const key of keys) {
+			if (key === "cpuPercent") {
+				expect(snap[key] === null || typeof snap[key] === "number").toBe(true);
+				continue;
+			}
 			expect(typeof snap[key]).toBe("number");
 		}
 		expect(snap.physicalFootprint === null || typeof snap.physicalFootprint === "number").toBe(true);

--- a/platform/daemon/src/resource-monitor.ts
+++ b/platform/daemon/src/resource-monitor.ts
@@ -4,6 +4,7 @@
 import { dlopen, ptr } from "bun:ffi";
 import { readdirSync, readlinkSync } from "node:fs";
 import { join } from "node:path";
+import { performance } from "node:perf_hooks";
 import { logger } from "./logger";
 import { reportEventLoopLag, tickPressureState } from "./system-pressure";
 
@@ -77,6 +78,28 @@ export interface ResourceSnapshot {
 	heapUsed: number;
 	physicalFootprint: number | null;
 	peakPhysicalFootprint: number | null;
+	cpuPercent: number | null;
+}
+
+let lastCpuUsage: NodeJS.CpuUsage | null = null;
+let lastCpuSampleAt: number | null = null;
+
+function readCpuPercent(): number | null {
+	try {
+		const now = performance.now();
+		const usage = process.cpuUsage();
+		const previous = lastCpuUsage;
+		const previousAt = lastCpuSampleAt;
+		lastCpuUsage = usage;
+		lastCpuSampleAt = now;
+		if (!previous || previousAt === null) return null;
+		const elapsedMs = now - previousAt;
+		if (!Number.isFinite(elapsedMs) || elapsedMs <= 0) return null;
+		const cpuMicros = Math.max(0, usage.user - previous.user) + Math.max(0, usage.system - previous.system);
+		return Math.max(0, Math.min(1000, (cpuMicros / (elapsedMs * 1000)) * 100));
+	} catch {
+		return null;
+	}
 }
 
 function snapshotResources(readPhysicalMemory: PhysicalMemoryReader = readMacOsPhysicalMemory): ResourceSnapshot {
@@ -92,6 +115,7 @@ function snapshotResources(readPhysicalMemory: PhysicalMemoryReader = readMacOsP
 		heapUsed: 0,
 		physicalFootprint: null,
 		peakPhysicalFootprint: null,
+		cpuPercent: null,
 	};
 
 	try {
@@ -123,6 +147,7 @@ function snapshotResources(readPhysicalMemory: PhysicalMemoryReader = readMacOsP
 		snap.physicalFootprint = physicalMemory.current;
 		snap.peakPhysicalFootprint = physicalMemory.peak;
 	}
+	snap.cpuPercent = readCpuPercent();
 
 	return snap;
 }
@@ -144,6 +169,7 @@ export function logFdSnapshot(stage: string): ResourceSnapshot {
 		rss: `${snap.rss}MB`,
 		heap: `${snap.heapUsed}MB`,
 		...(snap.physicalFootprint !== null ? { physicalFootprint: `${snap.physicalFootprint}MB` } : {}),
+		...(snap.cpuPercent !== null ? { cpuPercent: `${Math.round(snap.cpuPercent)}%` } : {}),
 	});
 	return snap;
 }
@@ -164,13 +190,6 @@ export function startEventLoopMonitor(intervalMs = 2000): void {
 	eventLoopTimer = setInterval(() => {
 		const now = Date.now();
 		const lag = now - lastTick - intervalMs;
-		if (lag > 100) {
-			logger.warn("resources", "Event loop blocked", {
-				lagMs: lag,
-				expectedMs: intervalMs,
-				actualMs: now - lastTick,
-			});
-		}
 		// Feed the pressure signal so background write loops can yield/pause.
 		reportEventLoopLag(lag);
 		// Advance the pressure state machine on the monitor's own cadence so

--- a/platform/daemon/src/runtime-pressure.test.ts
+++ b/platform/daemon/src/runtime-pressure.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	bucketAgeSec,
+	bucketCpuPressure,
+	bucketLatencyMs,
+	bucketMemoryPressure,
+	bucketQueueDepth,
+	bucketWorkerCount,
+	buildRuntimePressureEnvelope,
+	countActiveWorkers,
+	getObservedLatencies,
+	getRuntimePressureEnvelope,
+	observeDbLatency,
+	observeEmbeddingLatency,
+	resetRuntimePressureState,
+	setRuntimePressureEnvelope,
+} from "./runtime-pressure";
+
+afterEach(() => {
+	resetRuntimePressureState();
+});
+
+describe("runtime pressure buckets", () => {
+	it("keeps queue and worker cardinality bounded at each boundary", () => {
+		expect(bucketQueueDepth(undefined)).toBe("unknown");
+		expect(bucketQueueDepth(0)).toBe("0");
+		expect(bucketQueueDepth(10)).toBe("1-10");
+		expect(bucketQueueDepth(11)).toBe("11-50");
+		expect(bucketQueueDepth(1001)).toBe("1001+");
+		expect(bucketWorkerCount(0)).toBe("0");
+		expect(bucketWorkerCount(4)).toBe("1-4");
+		expect(bucketWorkerCount(5)).toBe("5-16");
+		expect(bucketWorkerCount(257)).toBe("257+");
+	});
+
+	it("buckets age and latency without exposing exact measurements", () => {
+		expect(bucketAgeSec(0)).toBe("<10s");
+		expect(bucketAgeSec(60)).toBe("10-60s");
+		expect(bucketAgeSec(901)).toBe("901+s");
+		expect(bucketLatencyMs(9)).toBe("<10ms");
+		expect(bucketLatencyMs(100)).toBe("10-100ms");
+		expect(bucketLatencyMs(10_001)).toBe("10001+ms");
+		expect(bucketAgeSec(Number.NaN)).toBe("unknown");
+		expect(bucketLatencyMs(-1)).toBe("unknown");
+	});
+
+	it("maps process resource samples to coarse pressure levels", () => {
+		expect(bucketMemoryPressure(100)).toBe("normal");
+		expect(bucketMemoryPressure(512)).toBe("high");
+		expect(bucketMemoryPressure(undefined)).toBe("unknown");
+		expect(bucketCpuPressure(10)).toBe("normal");
+		expect(bucketCpuPressure(75)).toBe("high");
+		expect(bucketCpuPressure(null)).toBe("unknown");
+	});
+});
+
+describe("runtime pressure envelope", () => {
+	it("retains only the latest bounded latency observations", () => {
+		observeDbLatency(12);
+		observeEmbeddingLatency(2_500);
+		expect(getObservedLatencies()).toEqual({ dbLatencyMs: 12, embeddingLatencyMs: 2_500 });
+		observeDbLatency(Number.POSITIVE_INFINITY);
+		expect(getObservedLatencies().dbLatencyMs).toBe(12);
+
+		const envelope = buildRuntimePressureEnvelope({
+			memoryQueueDepth: 51,
+			summaryQueueDepth: 0,
+			oldestJobAgeSec: 301,
+			activeWorkers: countActiveWorkers([true, true, true, true, true], 1),
+			batchSize: 8,
+			memoryRssMb: 700,
+			cpuPercent: 82,
+			recoveryOutcome: "still_degraded",
+		});
+
+		expect(envelope).toMatchObject({
+			runtimePressureVersion: 1,
+			memoryQueueDepthBucket: "51-200",
+			summaryQueueDepthBucket: "0",
+			oldestJobAgeBucket: "301-900s",
+			activeWorkersBucket: "5-16",
+			batchSizeBucket: "5-16",
+			dbLatencyBucket: "10-100ms",
+			embeddingLatencyBucket: "2001-10000ms",
+			memoryPressureBucket: "high",
+			cpuPressureBucket: "high",
+			recoveryOutcome: "still_degraded",
+		});
+		for (const value of Object.values(envelope)) {
+			expect(typeof value === "string" || typeof value === "number").toBe(true);
+		}
+	});
+
+	it("marks cached context stale without doing work on the read path", () => {
+		const envelope = buildRuntimePressureEnvelope({ memoryQueueDepth: 1 });
+		setRuntimePressureEnvelope(envelope, 1_000);
+		expect(getRuntimePressureEnvelope(2_000).snapshotAgeBucket).toBe("fresh");
+		expect(getRuntimePressureEnvelope(16 * 60 * 1000).snapshotAgeBucket).toBe("old");
+	});
+});

--- a/platform/daemon/src/runtime-pressure.ts
+++ b/platform/daemon/src/runtime-pressure.ts
@@ -1,0 +1,219 @@
+/**
+ * Bounded runtime context for daemon liveness telemetry.
+ *
+ * This module deliberately stores only the latest coarse observations. The
+ * event-loop wedge path must be able to report context without doing database,
+ * filesystem, or provider work while the event loop is recovering.
+ */
+
+export type PressureBucket =
+	| "unknown"
+	| "none"
+	| "normal"
+	| "elevated"
+	| "high"
+	| "critical"
+	| "0"
+	| "1-10"
+	| "11-50"
+	| "51-200"
+	| "201-1000"
+	| "1001+"
+	| "1-4"
+	| "5-16"
+	| "17-64"
+	| "65-256"
+	| "257+"
+	| "<10ms"
+	| "10-100ms"
+	| "101-500ms"
+	| "501-2000ms"
+	| "2001-10000ms"
+	| "10001+ms"
+	| "<10s"
+	| "10-60s"
+	| "61-300s"
+	| "301-900s"
+	| "901+s"
+	| "fresh"
+	| "stale"
+	| "old";
+
+export type PressureRecoveryOutcome = "not_observed" | "recovered" | "restarted" | "still_degraded";
+
+export interface RuntimePressureEnvelope {
+	readonly runtimePressureVersion: 1;
+	readonly memoryQueueDepthBucket: PressureBucket;
+	readonly summaryQueueDepthBucket: PressureBucket;
+	readonly oldestJobAgeBucket: PressureBucket;
+	readonly activeWorkersBucket: PressureBucket;
+	readonly batchSizeBucket: PressureBucket;
+	readonly dbLatencyBucket: PressureBucket;
+	readonly embeddingLatencyBucket: PressureBucket;
+	readonly memoryPressureBucket: PressureBucket;
+	readonly cpuPressureBucket: PressureBucket;
+	readonly recoveryOutcome: PressureRecoveryOutcome;
+	readonly snapshotAgeBucket: PressureBucket;
+}
+
+export interface RuntimePressureInputs {
+	readonly memoryQueueDepth?: number;
+	readonly summaryQueueDepth?: number;
+	readonly oldestJobAgeSec?: number;
+	readonly activeWorkers?: number;
+	readonly batchSize?: number;
+	readonly memoryRssMb?: number;
+	readonly cpuPercent?: number | null;
+	readonly dbLatencyMs?: number | null;
+	readonly embeddingLatencyMs?: number | null;
+	readonly recoveryOutcome?: PressureRecoveryOutcome;
+}
+
+const EMPTY_ENVELOPE: RuntimePressureEnvelope = {
+	runtimePressureVersion: 1,
+	memoryQueueDepthBucket: "unknown",
+	summaryQueueDepthBucket: "unknown",
+	oldestJobAgeBucket: "unknown",
+	activeWorkersBucket: "unknown",
+	batchSizeBucket: "unknown",
+	dbLatencyBucket: "unknown",
+	embeddingLatencyBucket: "unknown",
+	memoryPressureBucket: "unknown",
+	cpuPressureBucket: "unknown",
+	recoveryOutcome: "not_observed",
+	snapshotAgeBucket: "unknown",
+};
+
+let latestDbLatencyMs: number | null = null;
+let latestEmbeddingLatencyMs: number | null = null;
+let latestEnvelope: RuntimePressureEnvelope = EMPTY_ENVELOPE;
+let latestEnvelopeAt = 0;
+
+function finite(value: number | null | undefined): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+export function bucketQueueDepth(value: number | null | undefined): PressureBucket {
+	if (!finite(value)) return "unknown";
+	if (value === 0) return "0";
+	if (value <= 10) return "1-10";
+	if (value <= 50) return "11-50";
+	if (value <= 200) return "51-200";
+	if (value <= 1000) return "201-1000";
+	return "1001+";
+}
+
+export function bucketWorkerCount(value: number | null | undefined): PressureBucket {
+	if (!finite(value)) return "unknown";
+	if (value === 0) return "0";
+	if (value <= 4) return "1-4";
+	if (value <= 16) return "5-16";
+	if (value <= 64) return "17-64";
+	if (value <= 256) return "65-256";
+	return "257+";
+}
+
+export function bucketLatencyMs(value: number | null | undefined): PressureBucket {
+	if (!finite(value)) return "unknown";
+	if (value < 10) return "<10ms";
+	if (value <= 100) return "10-100ms";
+	if (value <= 500) return "101-500ms";
+	if (value <= 2000) return "501-2000ms";
+	if (value <= 10000) return "2001-10000ms";
+	return "10001+ms";
+}
+
+export function bucketAgeSec(value: number | null | undefined): PressureBucket {
+	if (!finite(value)) return "unknown";
+	if (value < 10) return "<10s";
+	if (value <= 60) return "10-60s";
+	if (value <= 300) return "61-300s";
+	if (value <= 900) return "301-900s";
+	return "901+s";
+}
+
+export function bucketBatchSize(value: number | null | undefined): PressureBucket {
+	return bucketWorkerCount(value);
+}
+
+export function bucketMemoryPressure(rssMb: number | null | undefined): PressureBucket {
+	if (!finite(rssMb)) return "unknown";
+	if (rssMb < 256) return "normal";
+	if (rssMb < 512) return "elevated";
+	if (rssMb < 1024) return "high";
+	return "critical";
+}
+
+export function bucketCpuPressure(cpuPercent: number | null | undefined): PressureBucket {
+	if (!finite(cpuPercent)) return "unknown";
+	if (cpuPercent < 25) return "normal";
+	if (cpuPercent < 75) return "elevated";
+	if (cpuPercent < 100) return "high";
+	return "critical";
+}
+
+function snapshotAgeBucket(ageMs: number): PressureBucket {
+	if (!finite(ageMs)) return "unknown";
+	if (ageMs < 2 * 60 * 1000) return "fresh";
+	if (ageMs < 15 * 60 * 1000) return "stale";
+	return "old";
+}
+
+export function countActiveWorkers(runningWorkers: readonly boolean[], activeLlmCalls = 0): number {
+	const workerCount = runningWorkers.filter(Boolean).length;
+	return workerCount + (finite(activeLlmCalls) ? activeLlmCalls : 0);
+}
+
+export function observeDbLatency(latencyMs: number): void {
+	if (finite(latencyMs)) latestDbLatencyMs = latencyMs;
+}
+
+export function observeEmbeddingLatency(latencyMs: number): void {
+	if (finite(latencyMs)) latestEmbeddingLatencyMs = latencyMs;
+}
+
+export function getObservedLatencies(): {
+	readonly dbLatencyMs: number | null;
+	readonly embeddingLatencyMs: number | null;
+} {
+	return { dbLatencyMs: latestDbLatencyMs, embeddingLatencyMs: latestEmbeddingLatencyMs };
+}
+
+export function buildRuntimePressureEnvelope(input: RuntimePressureInputs = {}): RuntimePressureEnvelope {
+	const latencies = getObservedLatencies();
+	const envelope: RuntimePressureEnvelope = {
+		runtimePressureVersion: 1,
+		memoryQueueDepthBucket: bucketQueueDepth(input.memoryQueueDepth),
+		summaryQueueDepthBucket: bucketQueueDepth(input.summaryQueueDepth),
+		oldestJobAgeBucket: bucketAgeSec(input.oldestJobAgeSec),
+		activeWorkersBucket: bucketWorkerCount(input.activeWorkers),
+		batchSizeBucket: bucketBatchSize(input.batchSize),
+		dbLatencyBucket: bucketLatencyMs(input.dbLatencyMs ?? latencies.dbLatencyMs),
+		embeddingLatencyBucket: bucketLatencyMs(input.embeddingLatencyMs ?? latencies.embeddingLatencyMs),
+		memoryPressureBucket: bucketMemoryPressure(input.memoryRssMb),
+		cpuPressureBucket: bucketCpuPressure(input.cpuPercent),
+		recoveryOutcome: input.recoveryOutcome ?? "not_observed",
+		snapshotAgeBucket: "fresh",
+	};
+	return envelope;
+}
+
+export function setRuntimePressureEnvelope(envelope: RuntimePressureEnvelope, now = Date.now()): void {
+	latestEnvelope = envelope;
+	latestEnvelopeAt = finite(now) ? now : 0;
+}
+
+export function getRuntimePressureEnvelope(now = Date.now()): RuntimePressureEnvelope {
+	return {
+		...latestEnvelope,
+		snapshotAgeBucket: latestEnvelopeAt === 0 ? "unknown" : snapshotAgeBucket(Math.max(0, now - latestEnvelopeAt)),
+	};
+}
+
+/** Test-only reset that also protects daemon tests from cross-case state. */
+export function resetRuntimePressureState(): void {
+	latestDbLatencyMs = null;
+	latestEmbeddingLatencyMs = null;
+	latestEnvelope = EMPTY_ENVELOPE;
+	latestEnvelopeAt = 0;
+}

--- a/platform/daemon/src/system-pressure.ts
+++ b/platform/daemon/src/system-pressure.ts
@@ -16,6 +16,7 @@
  */
 
 import { logger } from "./logger";
+import { type PressureRecoveryOutcome, getRuntimePressureEnvelope } from "./runtime-pressure";
 import { getActiveTelemetry } from "./telemetry";
 
 export type PressureLevel = "normal" | "elevated" | "critical";
@@ -28,6 +29,7 @@ const CLEAR_COOLDOWN_MS = 5_000;
 let currentLevel: PressureLevel = "normal";
 let lastLagAt = 0;
 let startupGraceUntil = 0;
+let recoveryOutcome: PressureRecoveryOutcome = "not_observed";
 
 /**
  * Set a startup grace period during which background workers skip their ticks.
@@ -61,28 +63,46 @@ let lastWedgeEmitAt = 0;
 function reportEventLoopWedge(lagMs: number, now: number): void {
 	// lastWedgeEmitAt === 0 means never emitted — always report the first wedge.
 	if (lastWedgeEmitAt !== 0 && now - lastWedgeEmitAt < EVENT_LOOP_WEDGE_COOLDOWN_MS) return;
-	lastWedgeEmitAt = now;
-	getActiveTelemetry()?.record("error.occurred", {
+	const telemetry = getActiveTelemetry();
+	if (!telemetry) return;
+	const properties = {
 		type: "EventLoopLag",
 		message: `event loop critically blocked for ${Math.round(lagMs)}ms`,
 		lagMs: Math.round(lagMs),
-	});
+		...getRuntimePressureEnvelope(now),
+		recoveryOutcome,
+	};
+	if (telemetry.recordDeferred) {
+		telemetry.recordDeferred("error.occurred", properties);
+	} else {
+		telemetry.record("error.occurred", properties);
+	}
+	// Do not consume the cooldown until telemetry accepted the event. The
+	// monitor can run before telemetry initialization during daemon startup.
+	lastWedgeEmitAt = now;
+}
+
+/** Keep synchronous logger I/O off the event-loop wedge callback. */
+function schedulePressureWarning(message: string): void {
+	setImmediate(() => logger.warn("system-pressure", message));
 }
 
 export function reportEventLoopLag(lagMs: number, now: number = Date.now()): void {
 	if (lagMs >= CRITICAL_THRESHOLD_MS) {
+		recoveryOutcome = "still_degraded";
 		reportEventLoopWedge(lagMs, now);
 		if (currentLevel !== "critical") {
-			logger.warn("system-pressure", `Event loop critically blocked (${lagMs}ms) — background work should pause`);
+			schedulePressureWarning(`Event loop critically blocked (${lagMs}ms) — background work should pause`);
 		}
 		currentLevel = "critical";
-		lastLagAt = Date.now();
+		lastLagAt = now;
 	} else if (lagMs >= ELEVATED_THRESHOLD_MS) {
+		recoveryOutcome = "still_degraded";
 		if (currentLevel === "normal") {
-			logger.warn("system-pressure", `Event loop degraded (${lagMs}ms) — background work yielding`);
+			schedulePressureWarning(`Event loop degraded (${lagMs}ms) — background work yielding`);
 		}
 		if (currentLevel !== "critical") currentLevel = "elevated";
-		lastLagAt = Date.now();
+		lastLagAt = now;
 	}
 }
 
@@ -99,6 +119,7 @@ export function tickPressureState(): void {
 	}
 	if (currentLevel !== "normal" && now >= startupGraceUntil && now - lastLagAt > CLEAR_COOLDOWN_MS) {
 		currentLevel = "normal";
+		recoveryOutcome = "recovered";
 	}
 }
 
@@ -110,6 +131,20 @@ export function getSystemPressure(): PressureLevel {
 /** True when background work should pause to let the event loop recover. */
 export function isSystemPressureHigh(): boolean {
 	return currentLevel !== "normal";
+}
+
+/** Latest bounded outcome for the current pressure episode. */
+export function getPressureRecoveryOutcome(): PressureRecoveryOutcome {
+	return recoveryOutcome;
+}
+
+/** Reset process-local pressure state between daemon runs and isolated tests. */
+export function resetPressureState(): void {
+	currentLevel = "normal";
+	lastLagAt = 0;
+	startupGraceUntil = 0;
+	recoveryOutcome = "not_observed";
+	lastWedgeEmitAt = 0;
 }
 
 /**
@@ -125,6 +160,7 @@ export async function awaitPressureClear(timeoutMs = 30_000): Promise<boolean> {
 		tickPressureState();
 		if (getSystemPressure() === "normal") return true;
 	}
+	recoveryOutcome = "still_degraded";
 	logger.warn("system-pressure", `Pressure did not clear within ${timeoutMs}ms — proceeding`);
 	return false;
 }

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -547,6 +547,28 @@ describe("telemetry lifecycle events (issue #1026 Phase 2)", () => {
 		expect(third.properties.command).toBe("status");
 	});
 
+	it("defers wedge persistence until the normal flush", async () => {
+		const collector = createTelemetryCollector(
+			fakeDbAccessor(),
+			{
+				posthogHost: "",
+				posthogApiKey: "",
+				flushIntervalMs: 60000,
+				flushBatchSize: 50,
+				retentionDays: 90,
+				memorySearchQaEnabled: false,
+			},
+			"0.163.15",
+			{ telemetryLogPath: logPath },
+		);
+
+		const before = readFileSync(logPath, "utf-8");
+		collector.recordDeferred?.("error.occurred", { type: "EventLoopLag", lagMs: 900 });
+		expect(readFileSync(logPath, "utf-8")).toBe(before);
+		await collector.flush();
+		expect(readFileSync(logPath, "utf-8")).toContain('"event":"error.occurred"');
+	});
+
 	it("does not write a log when telemetryLogPath is omitted", () => {
 		const collector = createTelemetryCollector(
 			fakeDbAccessor(),

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -179,6 +179,11 @@ function sessionCostProperties(cost: SessionCostAccumulator): TelemetryPropertie
 
 export interface TelemetryCollector {
 	record(event: TelemetryEventType, properties: TelemetryProperties): void;
+	/**
+	 * Record without synchronous JSONL or SQLite work. Used by the event-loop
+	 * wedge path, where even best-effort persistence can block recovery.
+	 */
+	recordDeferred?(event: TelemetryEventType, properties: TelemetryProperties): void;
 	reopenSession(sessionHash: string): void;
 
 	/**
@@ -448,11 +453,14 @@ export function createTelemetryCollector(
 	} = {},
 ): TelemetryCollector {
 	const buffer: TelemetryEvent[] = [];
+	const deferredAuditIds = new Set<string>();
 	const logPath = opts.telemetryLogPath ?? null;
 	const deployment = telemetryDeployment(opts.env);
 	const reportedVersion = telemetryReportedVersion(daemonVersion, deployment);
 	let flushTimer: ReturnType<typeof setTimeout> | null = null;
 	let running = false;
+	let flushInFlight: Promise<void> | null = null;
+	let recordingStopped = false;
 	let consecutiveFailures = 0;
 	let flushCount = 0;
 	let effectiveIntervalMs = config.flushIntervalMs;
@@ -605,6 +613,11 @@ export function createTelemetryCollector(
 		flushCount++;
 		// Drain buffer to SQLite
 		const pending = buffer.splice(0, buffer.length);
+		for (const event of pending) {
+			if (deferredAuditIds.delete(event.id)) {
+				appendToTelemetryLog(logPath, JSON.stringify(event));
+			}
+		}
 		writeToDb(pending);
 
 		// Send to PostHog if configured
@@ -639,6 +652,15 @@ export function createTelemetryCollector(
 		if (flushCount % PRUNE_EVERY_N_FLUSHES === 0) {
 			pruneOldEvents();
 		}
+	}
+
+	/** Serialize timer, threshold, explicit, and shutdown flushes. */
+	function flush(): Promise<void> {
+		if (flushInFlight) return flushInFlight;
+		flushInFlight = doFlush().finally(() => {
+			flushInFlight = null;
+		});
+		return flushInFlight;
 	}
 
 	function sessionKeyFor(properties: TelemetryProperties): string | null {
@@ -714,6 +736,46 @@ export function createTelemetryCollector(
 		return cost ? { ...properties, ...sessionCostProperties(cost) } : properties;
 	}
 
+	function recordEvent(event: TelemetryEventType, properties: TelemetryProperties, persistAuditLog: boolean): void {
+		if (recordingStopped) return;
+		if (buffer.length >= MAX_BUFFER_EVENTS) {
+			const dropCount = buffer.length - MAX_BUFFER_EVENTS + 1;
+			const dropped = buffer.splice(0, dropCount);
+			for (const event of dropped) deferredAuditIds.delete(event.id);
+			if (persistAuditLog) {
+				logger.warn("telemetry", "Buffer exceeded max capacity, dropping oldest events", {
+					dropped: dropCount,
+					maxBufferEvents: MAX_BUFFER_EVENTS,
+				});
+			}
+		}
+
+		buffer.push({
+			id: crypto.randomUUID(),
+			event,
+			timestamp: new Date().toISOString(),
+			properties: addContext(enrichSessionEvent(event, properties)),
+		});
+		if (!persistAuditLog) {
+			const deferred = buffer[buffer.length - 1];
+			if (deferred) deferredAuditIds.add(deferred.id);
+		}
+
+		if (persistAuditLog && logPath) {
+			const last = buffer[buffer.length - 1];
+			if (last) {
+				appendToTelemetryLog(logPath, JSON.stringify(last));
+			}
+		}
+
+		// Deferred records wait for the normal timer. Calling doFlush here would
+		// synchronously enter SQLite before its first await, defeating the wedge
+		// path's non-blocking guarantee.
+		if (persistAuditLog && buffer.length >= MAX_BUFFER_SIZE) {
+			flush().catch(() => {});
+		}
+	}
+
 	const collector: TelemetryCollector = {
 		enabled: true,
 		reopenSession,
@@ -722,36 +784,11 @@ export function createTelemetryCollector(
 		},
 
 		record(event, properties): void {
-			if (buffer.length >= MAX_BUFFER_EVENTS) {
-				const dropCount = buffer.length - MAX_BUFFER_EVENTS + 1;
-				buffer.splice(0, dropCount);
-				logger.warn("telemetry", "Buffer exceeded max capacity, dropping oldest events", {
-					dropped: dropCount,
-					maxBufferEvents: MAX_BUFFER_EVENTS,
-				});
-			}
+			recordEvent(event, properties, true);
+		},
 
-			buffer.push({
-				id: crypto.randomUUID(),
-				event,
-				timestamp: new Date().toISOString(),
-				properties: addContext(enrichSessionEvent(event, properties)),
-			});
-
-			// Open telemetry log (issue #1026 Phase 2): mirror every event to
-			// the inspectable JSONL file so users can audit exactly what was
-			// sent. Best-effort — a full disk or unwritable path must never
-			// break recording.
-			if (logPath) {
-				const last = buffer[buffer.length - 1];
-				if (last) {
-					appendToTelemetryLog(logPath, JSON.stringify(last));
-				}
-			}
-
-			if (buffer.length >= MAX_BUFFER_SIZE) {
-				doFlush().catch(() => {});
-			}
+		recordDeferred(event, properties): void {
+			recordEvent(event, properties, false);
 		},
 
 		recordFirstUse(kind): void {
@@ -766,7 +803,7 @@ export function createTelemetryCollector(
 		},
 
 		async flush(): Promise<void> {
-			await doFlush();
+			await flush();
 		},
 
 		start(): void {
@@ -777,7 +814,7 @@ export function createTelemetryCollector(
 				if (!running) return;
 				flushTimer = setTimeout(() => {
 					flushTimer = null;
-					doFlush()
+					flush()
 						.catch(() => {})
 						.finally(() => scheduleFlush());
 				}, effectiveIntervalMs);
@@ -796,7 +833,16 @@ export function createTelemetryCollector(
 				clearTimeout(flushTimer);
 				flushTimer = null;
 			}
-			await doFlush();
+			try {
+				await flush();
+			} catch {}
+			// Stop accepting new events only after the first flush has completed,
+			// so events produced while an outbound request was awaiting are
+			// drained by this final serialized flush.
+			recordingStopped = true;
+			try {
+				await flush();
+			} catch {}
 			logger.info("telemetry", "Telemetry collector stopped");
 		},
 

--- a/platform/daemon/src/yielding-writes.test.ts
+++ b/platform/daemon/src/yielding-writes.test.ts
@@ -12,11 +12,26 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ReadDb, WriteDb } from "./db-accessor";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
-import { getSystemPressure, reportEventLoopLag } from "./system-pressure";
+import {
+	buildRuntimePressureEnvelope,
+	resetRuntimePressureState,
+	setRuntimePressureEnvelope,
+} from "./runtime-pressure";
+import {
+	getPressureRecoveryOutcome,
+	getSystemPressure,
+	reportEventLoopLag,
+	resetPressureState,
+} from "./system-pressure";
 import { drainWriteBatches } from "./yielding-writes";
 
 const dbFiles = ["memories.db", "memories.db-shm", "memories.db-wal"];
 let agentsDir = "";
+
+afterEach(() => {
+	resetPressureState();
+	resetRuntimePressureState();
+});
 
 function resetDbFiles(): void {
 	for (const file of dbFiles) rmSync(join(agentsDir, "memory", file), { force: true });
@@ -144,6 +159,11 @@ describe("drainWriteBatches", () => {
 		// pause by showing drainDone is false after 200ms while pressure is
 		// critical. The .catch() on drainPromise handles teardown.
 	}, 1000); // 1s timeout — proves it pauses, doesn't need to finish
+
+	it("classifies elevated lag as still degraded", () => {
+		reportEventLoopLag(100);
+		expect(getPressureRecoveryOutcome()).toBe("still_degraded");
+	});
 });
 
 describe("event-loop wedge telemetry", () => {
@@ -172,11 +192,23 @@ describe("event-loop wedge telemetry", () => {
 				"0.0.0-test",
 			);
 			setActiveTelemetry(collector);
-
 			// Base the injected clock a day in the future — earlier tests in
 			// this file may already have set the wedge cooldown with real
 			// timestamps, so t0 must clear that window deterministically.
 			const t0 = Date.now() + 24 * 60 * 60 * 1000;
+			setRuntimePressureEnvelope(
+				buildRuntimePressureEnvelope({
+					memoryQueueDepth: 51,
+					summaryQueueDepth: 3,
+					oldestJobAgeSec: 90,
+					activeWorkers: 4,
+					batchSize: 8,
+					memoryRssMb: 700,
+					cpuPercent: 82,
+				}),
+				t0,
+			);
+
 			reportEventLoopLag(1500, t0);
 			reportEventLoopLag(2000, t0 + 1_000); // within cooldown: suppressed
 			await collector.flush();
@@ -184,6 +216,11 @@ describe("event-loop wedge telemetry", () => {
 			expect(events).toHaveLength(1);
 			expect(events[0]?.properties.type).toBe("EventLoopLag");
 			expect(events[0]?.properties.lagMs).toBe(1500);
+			expect(events[0]?.properties.runtimePressureVersion).toBe(1);
+			expect(events[0]?.properties.memoryQueueDepthBucket).toBe("51-200");
+			expect(events[0]?.properties.embeddingLatencyBucket).toBe("unknown");
+			expect(events[0]?.properties.recoveryOutcome).toBe("still_degraded");
+			expect(events[0]?.properties.message).not.toContain("/Users/");
 
 			// After the cooldown elapses, a new wedge is reported.
 			reportEventLoopLag(999, t0 + 601_000);

--- a/scripts/evals/runtime-pressure-envelope.ts
+++ b/scripts/evals/runtime-pressure-envelope.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+/**
+ * Runtime-pressure liveness/load eval (#1282).
+ *
+ * Exercises the same bounded envelope builder used by daemon heartbeats with
+ * a deterministic synthetic load. It fails if envelope construction becomes
+ * slow, grows its key set, or starts carrying forbidden process/user data.
+ */
+
+import { performance } from "node:perf_hooks";
+import {
+	buildRuntimePressureEnvelope,
+	getRuntimePressureEnvelope,
+	setRuntimePressureEnvelope,
+} from "../../platform/daemon/src/runtime-pressure";
+
+const SAMPLE_COUNT = 2_000;
+const MAX_P95_BUILD_MS = 1;
+const FORBIDDEN_KEYS = ["pid", "path", "source", "stack", "payload", "processId"];
+
+function percentile(values: readonly number[], ratio: number): number {
+	const ordered = [...values].sort((left, right) => left - right);
+	const index = Math.min(ordered.length - 1, Math.ceil(ordered.length * ratio) - 1);
+	return ordered[Math.max(0, index)] ?? 0;
+}
+
+const durations: number[] = [];
+let lastEnvelope = buildRuntimePressureEnvelope();
+for (let index = 0; index < SAMPLE_COUNT; index += 1) {
+	const startedAt = performance.now();
+	lastEnvelope = buildRuntimePressureEnvelope({
+		memoryQueueDepth: index % 1_001,
+		summaryQueueDepth: (index * 3) % 257,
+		oldestJobAgeSec: index % 1_200,
+		activeWorkers: index % 17,
+		batchSize: 8,
+		memoryRssMb: 512,
+		cpuPercent: 42,
+		recoveryOutcome: index % 2 === 0 ? "still_degraded" : "recovered",
+	});
+	durations.push(performance.now() - startedAt);
+}
+
+setRuntimePressureEnvelope(lastEnvelope);
+const cached = getRuntimePressureEnvelope();
+const keys = Object.keys(cached);
+const forbidden = keys.filter((key) => FORBIDDEN_KEYS.some((term) => key.toLowerCase().includes(term.toLowerCase())));
+const report = {
+	verdict:
+		cached.runtimePressureVersion === 1 && forbidden.length === 0 && percentile(durations, 0.95) <= MAX_P95_BUILD_MS
+			? "pass"
+			: "fail",
+	samples: SAMPLE_COUNT,
+	keyCount: keys.length,
+	p95BuildMs: Number(percentile(durations, 0.95).toFixed(3)),
+	maxP95BuildMs: MAX_P95_BUILD_MS,
+	forbiddenKeys: forbidden,
+};
+
+console.log(JSON.stringify(report, null, 2));
+if (report.verdict !== "pass") process.exit(1);


### PR DESCRIPTION
## Summary

Closes #1282. Adds a bounded, privacy-safe runtime-pressure envelope to daemon heartbeats and rate-limited severe `EventLoopLag` telemetry so operators can group wedge incidents by the pressure profile that preceded them.

## Changes

- Added fixed buckets for memory/summary queue depth, oldest job age, active workers, batch size, database/embedding latency, process memory/CPU pressure, recovery outcome, and snapshot age.
- Cached only the latest coarse observations; wedge reporting performs no database, filesystem, or provider work.
- Enriched the existing five-minute heartbeat and existing ten-minute rate-limited `EventLoopLag` event without changing their cadence or rate limit.
- Added provider-only embedding timing, bounded database operation timing, portable CPU sampling, recovery classification, focused regression tests, and a runnable liveness/load eval.
- Updated `docs/TELEMETRY.md` with the event and privacy contract.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: telemetry documentation and runtime-pressure eval

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally (affected files and suites; root baseline caveats are documented below)

## Migration Notes (if applicable)

N/A — no schema or data migration.

## Testing

- [x] `bun test` passes (affected daemon suites pass; full root run is documented below)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (changed-file Biome check passes; root command reports pre-existing repository-wide package-format diagnostics)
- [x] Tested against running daemon (daemon status suite exercises the real route/runtime surface)
- [x] `bun run build` passes
- [x] `bun scripts/evals/runtime-pressure-envelope.ts` passes with 2,000 synthetic samples

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tag in the commit)

## Notes

The full concurrent root test run completed with 3,179 passing tests, 49 skips, 310 failures, and 34 errors. The failures are unrelated baseline/environment issues (including parallel SQLite contention, stale generated content-index expectations, native-install path normalization, and unrelated SDK/mock suites); all issue-focused and affected daemon suites pass. The repository-wide lint command also reports existing package-format diagnostics outside this change; the changed-file Biome check is clean.
