### PR TITLE
fix(telemetry): classify deployment role and install provenance

### DIFF
--- a/dist/signetai/bin/launch.js
+++ b/dist/signetai/bin/launch.js
@@ -48,7 +48,13 @@ export function launchSignet() {
 	// doesn't carry inline. The env is only set when the wrapper actually
 	// has a runtime tree to share; the binary's own bootstrap can derive
 	// its own path otherwise.
-	const env = { ...process.env, SIGNET_WRAPPER_DIR: packageDir };
+	const env = {
+		...process.env,
+		SIGNET_WRAPPER_DIR: packageDir,
+		// The wrapper is the explicit package-manager distribution boundary.
+		// Preserve an operator override for source, container, or CI launches.
+		SIGNET_TELEMETRY_INSTALL_CHANNEL: process.env.SIGNET_TELEMETRY_INSTALL_CHANNEL ?? "package-manager",
+	};
 	if (!env.SIGNET_DIR && existsSync(join(packageDir, "runtime", "connectors"))) {
 		env.SIGNET_DIR = packageDir;
 	}

--- a/dist/signetai/scripts/install-native.js
+++ b/dist/signetai/scripts/install-native.js
@@ -46,6 +46,12 @@ function telemetryReportedVersion(version) {
 	return `${version}-dev`;
 }
 
+function telemetryDeploymentRole() {
+	if (telemetryDeployment() === "dev") return "development";
+	const role = process.env.SIGNET_TELEMETRY_DEPLOYMENT_ROLE?.trim().toLowerCase();
+	return ["personal", "service", "automation", "development", "ci", "unknown"].includes(role) ? role : "unknown";
+}
+
 function telemetryEnabled() {
 	if (process.env.SIGNET_TELEMETRY_OPTOUT === "1" || process.env.SIGNET_TELEMETRY_OPTOUT === "true") {
 		return false;
@@ -68,6 +74,8 @@ function fireInstallPing(platform) {
 				properties: {
 					version: telemetryReportedVersion(nativePackageVersion()),
 					platform,
+					deploymentRole: telemetryDeploymentRole(),
+					installChannel: "package-manager",
 					...(telemetryDeployment() ? { deployment: telemetryDeployment() } : {}),
 					$lib: "signet-install",
 				},

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -48,8 +48,8 @@ PostHog failures, and never throws into the daemon.
 
 | Event | When | Key payload fields |
 |---|---|---|
-| `install.ping` | npm wrapper postinstall (native binary install) | `version`, `platform` |
-| `install.activated` | first daemon run of a new install (persisted install id first created) | `version`, `platform` |
+| `install.ping` | npm wrapper postinstall (native binary install) | `version`, `platform`, `deploymentRole`, `installChannel` (`package-manager`) |
+| `install.activated` | first daemon run of a new install (persisted install id first created) | `version`, `platform`, `deploymentRole`, `installChannel` |
 | `first.remember` / `first.recall` | first successful remember / recall per install, exactly once | `version`, `platform` |
 | `daemon.started` | daemon boot | `version`, `platform`, `uptimeMs` |
 | `daemon.previous_exit` | next successful boot reconciles the prior lifecycle record, exactly once when one exists | `classification` (`clean` / `error` / `unrecorded`), `reasonCategory`, `exitCode`, `previousVersion`, `previousUptimeMs`, `restartDelayMs` |
@@ -69,7 +69,8 @@ PostHog failures, and never throws into the daemon.
 | `inference.fallback` | emitted alongside execute/stream when a target failed and routing fell back | same fields as execute/stream |
 | `error.occurred` | process-level crash, unhandled rejection, or event-loop wedge | `type`, `message`, `stack`, `uptimeMs`; `EventLoopLag` reports add `lagMs` and the latest bounded runtime-pressure buckets |
 | `version.upgraded` | daemon auto-update path only | `from`, `to` |
-| `command.invoked` | CLI command (name only, never arguments) | `command` |
+| `version.observed` | daemon start sees a different persisted version (any update mechanism) | `from`, `to` |
+| `command.invoked` | CLI command (name only, never arguments) | `command`, `deploymentRole`, `installChannel` |
 
 Declared but **not yet emitted**: `pipeline.extraction` and
 `pipeline.decision`.
@@ -94,6 +95,12 @@ Notes on individual events:
   id is first created. It covers bun, desktop, and npm uniformly and is the
   **active installs** metric. Count distinct ids with `install.activated`;
   never sum ping and activated counts.
+- **Deployment metadata** — every daemon and CLI event carries bounded
+  `deploymentRole` and `installChannel` values. Both default to `unknown` and
+  are set only by explicit configuration or the documented environment
+  variables. `SIGNET_TELEMETRY_ENV=dev` remains compatible and maps the role
+  to `development` while retaining `deployment: dev` and the `-dev` version
+  suffix. `version.observed` is an observation, not an auto-update claim.
 - **Session events (#1212/#1231)** — the three events measure different things and
   are deliberately not comparable with each other: `session.start` fires once
   per real session start (deduped per session key; resumed sessions do not
@@ -199,6 +206,8 @@ All telemetry keys live under `memory.pipelineV2` in `agent.yaml`:
 | `telemetry.flushIntervalMs` | `60000` | 5s-10min | Time between event flushes |
 | `telemetry.flushBatchSize` | `50` | 1-500 | Max events per flush batch |
 | `telemetry.retentionDays` | `90` | 1-365 | Days before local telemetry data is purged |
+| `telemetry.deploymentRole` | `unknown` | `personal` / `service` / `automation` / `development` / `ci` / `unknown` | Explicit deployment role; invalid or absent values are `unknown` |
+| `telemetry.installChannel` | `unknown` | `desktop` / `package-manager` / `source` / `container` / `unknown` | Explicit installation provenance; invalid or absent values are `unknown` |
 | `memorySearchQaEnabled` | `false` | boolean | Local-only recall QA ledger (never sent) |
 
 Embedding billing rates are configured separately under the canonical
@@ -237,6 +246,13 @@ the library version with a `-dev` suffix. The daemon and CLI `bun run dev`
 scripts set this marker automatically; direct source launches can set it
 explicitly. The marker is not an opt-out. `SIGNET_TELEMETRY_OPTOUT=1` or
 `true` silences daemon, CLI, and install-ping telemetry.
+
+For process-managed deployments, the equivalent explicit overrides are
+`SIGNET_TELEMETRY_DEPLOYMENT_ROLE` and `SIGNET_TELEMETRY_INSTALL_CHANNEL`.
+Accepted values are the config values above; invalid values are ignored and
+resolve to the configured value or `unknown`. No paths, package URLs, process
+names, repository names, IP addresses, or memory content are used to infer
+either field.
 
 **Disclosure:** `signet setup` tells users telemetry is on by default and
 asks whether to disable it. Declining writes `telemetryEnabled: false`;

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -30,6 +30,8 @@ export {
 	EPISTEMIC_ASSERTION_STATUSES,
 	TASK_HARNESSES,
 	DEFAULT_PROVIDER_RATE_LIMIT,
+	TELEMETRY_DEPLOYMENT_ROLES,
+	TELEMETRY_INSTALL_CHANNELS,
 } from "./types";
 export type {
 	Agent,
@@ -67,6 +69,8 @@ export type {
 	PipelineDocumentsConfig,
 	PipelineGuardrailsConfig,
 	PipelineTelemetryConfig,
+	TelemetryDeploymentRole,
+	TelemetryInstallChannel,
 	PipelineEmbeddingTrackerConfig,
 	PipelineContinuityConfig,
 	PipelineSynthesisConfig,

--- a/platform/core/src/migrations/117-telemetry-version-observation.ts
+++ b/platform/core/src/migrations/117-telemetry-version-observation.ts
@@ -1,0 +1,22 @@
+import type { MigrationDb } from "./index";
+
+function hasColumn(db: MigrationDb, table: string, column: string): boolean {
+	return db
+		.prepare(`PRAGMA table_info(${table})`)
+		.all()
+		.some((row) => row.name === column);
+}
+
+/**
+ * Migration 117: retain the last daemon version observed for an install.
+ *
+ * This is deliberately a nullable operational value. It lets the daemon
+ * report a version transition on the next start without treating a manual
+ * package/source change as an auto-upgrade. No path, package URL, or owner
+ * information is persisted.
+ */
+export function up(db: MigrationDb): void {
+	if (!hasColumn(db, "telemetry_install", "last_seen_version")) {
+		db.exec("ALTER TABLE telemetry_install ADD COLUMN last_seen_version TEXT");
+	}
+}

--- a/platform/core/src/migrations/119-telemetry-version-observation.ts
+++ b/platform/core/src/migrations/119-telemetry-version-observation.ts
@@ -8,7 +8,7 @@ function hasColumn(db: MigrationDb, table: string, column: string): boolean {
 }
 
 /**
- * Migration 117: retain the last daemon version observed for an install.
+ * Migration 119: retain the last daemon version observed for an install.
  *
  * This is deliberately a nullable operational value. It lets the daemon
  * report a version transition on the next start without treating a manual

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -124,7 +124,7 @@ import { up as crossAgentMessageNotifications } from "./115-cross-agent-message-
 import { up as acpDeliveryReconciliation } from "./116-acp-delivery-reconciliation";
 import { up as retireSummaryWorker } from "./117-retire-summary-worker";
 import { up as queuePressureIndices } from "./118-queue-pressure-indices";
-import { up as telemetryVersionObservation } from "./117-telemetry-version-observation";
+import { up as telemetryVersionObservation } from "./119-telemetry-version-observation";
 
 // -- Public interface consumed by Database.init() --
 

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -124,6 +124,7 @@ import { up as crossAgentMessageNotifications } from "./115-cross-agent-message-
 import { up as acpDeliveryReconciliation } from "./116-acp-delivery-reconciliation";
 import { up as retireSummaryWorker } from "./117-retire-summary-worker";
 import { up as queuePressureIndices } from "./118-queue-pressure-indices";
+import { up as telemetryVersionObservation } from "./117-telemetry-version-observation";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1112,6 +1113,12 @@ export const MIGRATIONS: readonly Migration[] = [
 		version: 118,
 		name: "queue-pressure-indices",
 		up: queuePressureIndices,
+	},
+	{
+		version: 119,
+		name: "telemetry-version-observation",
+		up: telemetryVersionObservation,
+		artifacts: { columns: [{ table: "telemetry_install", column: "last_seen_version" }] },
 	},
 ];
 

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -24,7 +24,7 @@ import { up as agentScopedEntityName } from "./105-agent-scoped-entity-name";
 import { up as crossAgentMessageNotifications } from "./115-cross-agent-message-notifications";
 import { up as acpDeliveryReconciliation } from "./116-acp-delivery-reconciliation";
 import { up as retireSummaryWorker } from "./117-retire-summary-worker";
-import { up as telemetryVersionObservation } from "./117-telemetry-version-observation";
+import { up as telemetryVersionObservation } from "./119-telemetry-version-observation";
 import { MIGRATIONS, hasPendingMigrations, runMigrations } from "./index";
 
 function createFreshDb(): Database {

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -24,6 +24,7 @@ import { up as agentScopedEntityName } from "./105-agent-scoped-entity-name";
 import { up as crossAgentMessageNotifications } from "./115-cross-agent-message-notifications";
 import { up as acpDeliveryReconciliation } from "./116-acp-delivery-reconciliation";
 import { up as retireSummaryWorker } from "./117-retire-summary-worker";
+import { up as telemetryVersionObservation } from "./117-telemetry-version-observation";
 import { MIGRATIONS, hasPendingMigrations, runMigrations } from "./index";
 
 function createFreshDb(): Database {
@@ -2086,6 +2087,15 @@ describe("migration framework", () => {
 
 		const columns = db.query("PRAGMA table_info(telemetry_events)").all() as Array<{ name: string }>;
 		expect(columns.map((row) => row.name)).toEqual(expect.arrayContaining(["source", "claim_token", "claimed_at"]));
+	});
+	test("migration 117 adds the last observed telemetry version idempotently", () => {
+		db = createFreshDb();
+		db.exec("CREATE TABLE telemetry_install (id TEXT PRIMARY KEY, created_at TEXT NOT NULL)");
+		telemetryVersionObservation(db);
+		telemetryVersionObservation(db);
+
+		const columns = db.query("PRAGMA table_info(telemetry_install)").all() as Array<{ name: string }>;
+		expect(columns.map((row) => row.name)).toContain("last_seen_version");
 	});
 });
 

--- a/platform/core/src/types.ts
+++ b/platform/core/src/types.ts
@@ -332,6 +332,21 @@ export interface PipelineGuardrailsConfig {
 	readonly contextBudgetChars?: number;
 }
 
+export const TELEMETRY_DEPLOYMENT_ROLES = [
+	"personal",
+	"service",
+	"automation",
+	"development",
+	"ci",
+	"unknown",
+] as const;
+
+export type TelemetryDeploymentRole = (typeof TELEMETRY_DEPLOYMENT_ROLES)[number];
+
+export const TELEMETRY_INSTALL_CHANNELS = ["desktop", "package-manager", "source", "container", "unknown"] as const;
+
+export type TelemetryInstallChannel = (typeof TELEMETRY_INSTALL_CHANNELS)[number];
+
 export interface PipelineTelemetryConfig {
 	readonly posthogHost: string;
 	readonly posthogApiKey: string;
@@ -339,6 +354,10 @@ export interface PipelineTelemetryConfig {
 	readonly flushBatchSize: number;
 	readonly retentionDays: number;
 	readonly memorySearchQaEnabled: boolean;
+	/** Explicit operator declaration; absent or invalid values resolve to unknown. */
+	readonly deploymentRole?: TelemetryDeploymentRole;
+	/** Explicit installation provenance; absent or invalid values resolve to unknown. */
+	readonly installChannel?: TelemetryInstallChannel;
 }
 
 export interface PipelineContinuityConfig {

--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -495,7 +495,7 @@ describe("auth guard co-location", () => {
 			const scopedToolRes = await app.request("/api/dream/tools/search_entities", {
 				method: "POST",
 				headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-				body: JSON.stringify({ input: { query: "Atlas" } }),
+				body: JSON.stringify({ input: { agentId: "agent-a", query: "Atlas" } }),
 			});
 			expect(scopedToolRes.status).toBe(200);
 			expect(await scopedToolRes.json()).toMatchObject({ tool: "search_entities", ok: true, agentId: "agent-a" });

--- a/platform/daemon/src/dev-daemon.ts
+++ b/platform/daemon/src/dev-daemon.ts
@@ -1,6 +1,7 @@
 export {};
 
 process.env.SIGNET_TELEMETRY_ENV ||= "dev";
+process.env.SIGNET_TELEMETRY_INSTALL_CHANNEL ||= "source";
 process.env.SIGNET_DAEMON_ENTRYPOINT ||= "1";
 
 await import("./daemon");

--- a/platform/daemon/src/mcp/tools.test.ts
+++ b/platform/daemon/src/mcp/tools.test.ts
@@ -380,6 +380,12 @@ describe("createMcpServer", () => {
 			projectPath: projectDir,
 			indexedAt: new Date("2026-04-21T00:00:00.000Z"),
 		});
+		const binDir = join(tempAgentsDir, "bin");
+		const graphiqPath = join(binDir, "graphiq");
+		mkdirSync(binDir, { recursive: true });
+		writeFileSync(graphiqPath, "#!/bin/sh\necho graphiq status\n");
+		chmodSync(graphiqPath, 0o755);
+		process.env.PATH = `${binDir}:${originalPath ?? ""}`;
 
 		const graphServer = await createMcpServer({
 			daemonUrl: "http://localhost:3850",

--- a/platform/daemon/src/memory-config.test.ts
+++ b/platform/daemon/src/memory-config.test.ts
@@ -944,6 +944,28 @@ describe("loadPipelineConfig", () => {
 		expect(result.autonomous.frozen).toBe(DEFAULT_PIPELINE_V2.autonomous.frozen);
 	});
 
+	it("bounds explicit telemetry deployment role and install channel declarations", () => {
+		const configured = loadPipelineConfig({
+			memory: {
+				pipelineV2: {
+					telemetry: { deploymentRole: "SERVICE", installChannel: "container" },
+				},
+			},
+		});
+		expect(configured.telemetry.deploymentRole).toBe("service");
+		expect(configured.telemetry.installChannel).toBe("container");
+
+		const invalid = loadPipelineConfig({
+			memory: {
+				pipelineV2: {
+					telemetry: { deploymentRole: "owner", installChannel: "local-path" },
+				},
+			},
+		});
+		expect(invalid.telemetry.deploymentRole).toBe("unknown");
+		expect(invalid.telemetry.installChannel).toBe("unknown");
+	});
+
 	it("loads feedback config and clamps weights", () => {
 		const result = loadPipelineConfig({
 			memory: {

--- a/platform/daemon/src/memory-config.ts
+++ b/platform/daemon/src/memory-config.ts
@@ -11,6 +11,8 @@ import {
 	PIPELINE_FLAGS,
 	type PipelineFlag,
 	type PipelineV2Config,
+	TELEMETRY_DEPLOYMENT_ROLES,
+	TELEMETRY_INSTALL_CHANNELS,
 	defaultPipelineModel,
 	isPipelineProvider,
 	parseSimpleYaml,
@@ -215,6 +217,8 @@ export const DEFAULT_PIPELINE_V2: ResolvedPipelineV2Config = {
 		flushBatchSize: DEFAULT_TELEMETRY_FLUSH_BATCH_SIZE,
 		retentionDays: 90,
 		memorySearchQaEnabled: false,
+		deploymentRole: "unknown",
+		installChannel: "unknown",
 	},
 	embeddingTracker: {
 		enabled: true,
@@ -302,6 +306,12 @@ function clampPositive(raw: unknown, min: number, max: number, fallback: number)
 	if (typeof raw !== "number" || !Number.isFinite(raw)) return fallback;
 	// Bounds are inclusive; a few config fields intentionally use 0 as a disable sentinel.
 	return Math.max(min, Math.min(max, raw));
+}
+
+function resolveTelemetryValue<T extends string>(raw: unknown, allowed: readonly T[], fallback: T): T {
+	if (typeof raw !== "string") return fallback;
+	const normalized = raw.trim().toLowerCase();
+	return (allowed as readonly string[]).includes(normalized) ? (normalized as T) : fallback;
 }
 
 function clampNonNegative(raw: unknown, max: number, fallback: number): number {
@@ -895,6 +905,16 @@ export function loadPipelineConfig(yaml: Record<string, unknown>): ResolvedPipel
 				telemetryRaw?.memorySearchQaEnabled,
 				undefined,
 				d.telemetry.memorySearchQaEnabled,
+			),
+			deploymentRole: resolveTelemetryValue(
+				telemetryRaw?.deploymentRole,
+				TELEMETRY_DEPLOYMENT_ROLES,
+				d.telemetry.deploymentRole ?? "unknown",
+			),
+			installChannel: resolveTelemetryValue(
+				telemetryRaw?.installChannel,
+				TELEMETRY_INSTALL_CHANNELS,
+				d.telemetry.installChannel ?? "unknown",
 			),
 		},
 

--- a/platform/daemon/src/pipeline/dreaming-operation-contract.ts
+++ b/platform/daemon/src/pipeline/dreaming-operation-contract.ts
@@ -47,7 +47,7 @@ export const DREAMING_ONTOLOGY_PAYLOAD_SCHEMAS = {
 		subjectRef: text.describe(
 			"The flagged target, e.g. entity:<id>, aspect:<id>, attribute:<id>, link:<id>, or duplicate:<canonical name>.",
 		),
-		details: z.record(z.string(), z.string()).describe("Inspection facts about the flagged target.").optional(),
+		details: z.object({}).catchall(z.string()).describe("Inspection facts about the flagged target.").optional(),
 		priority: z.number().finite().min(0).max(100).describe("Priority of the flag (0-100).").optional(),
 	}),
 	decline_attention: payload({

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -772,10 +772,10 @@ describe("session economics (issue #1201)", () => {
 		await collector.flush();
 
 		const ends = collector.query({ event: "session.end" });
-		expect(ends[0]?.properties.tokensInput).toBe(100);
-		expect(ends[0]?.properties.cost).toBe(0.5);
-		expect(ends[1]?.properties.tokensInput).toBe(200);
-		expect(ends[1]?.properties.cost).toBe(1);
+		const sessionA = ends.find((event) => event.properties.tokensInput === 100);
+		const sessionC = ends.find((event) => event.properties.tokensInput === 200);
+		expect(sessionA?.properties.cost).toBe(0.5);
+		expect(sessionC?.properties.cost).toBe(1);
 	});
 
 	it("reopens the accumulator for a resumed session", async () => {

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -331,7 +331,14 @@ describe("telemetry collector", () => {
 		expect(recallEvent).toBeDefined();
 		// No content: the event carries only the fact of first use.
 		expect(rememberEvent?.properties).toMatchObject({ version: "0.0.0-test", platform: process.platform });
-		expect(Object.keys(rememberEvent?.properties ?? {})).toEqual(["version", "platform", "$lib", "$lib_version"]);
+		expect(Object.keys(rememberEvent?.properties ?? {})).toEqual([
+			"version",
+			"platform",
+			"deploymentRole",
+			"installChannel",
+			"$lib",
+			"$lib_version",
+		]);
 		const firstBatch = captured.flatMap((c) => c.body.batch.map((e) => e.event));
 		expect(firstBatch.filter((e) => e === "first.remember")).toHaveLength(1);
 		expect(firstBatch.filter((e) => e === "first.recall")).toHaveLength(1);
@@ -515,6 +522,69 @@ describe("telemetry collector", () => {
 		for (const line of lines) {
 			expect((JSON.parse(line) as { properties: { deployment: string } }).properties.deployment).toBe("dev");
 		}
+	});
+
+	it("uses explicit bounded deployment metadata and keeps unknown as the fallback", async () => {
+		const collector = createTelemetryCollector(
+			getDbAccessor(),
+			{
+				...TELEMETRY_CONFIG,
+				deploymentRole: "service",
+				installChannel: "container",
+			},
+			"0.176.8",
+			{ telemetryLogPath: logPath },
+		);
+		collector.record("daemon.started", { version: "0.176.8", platform: process.platform });
+		await collector.flush();
+
+		const event = captured[0]?.body.batch.at(-1);
+		expect(event?.properties.deploymentRole).toBe("service");
+		expect(event?.properties.installChannel).toBe("container");
+
+		const unknown = createTelemetryCollector(getDbAccessor(), TELEMETRY_CONFIG, "0.176.8", {
+			env: {
+				SIGNET_TELEMETRY_DEPLOYMENT_ROLE: "not-a-role",
+				SIGNET_TELEMETRY_INSTALL_CHANNEL: "not-a-channel",
+			},
+		});
+		unknown.record("daemon.heartbeat", { uptimeMs: 1 });
+		await unknown.flush();
+		const unknownEvent = captured.at(-1)?.body.batch.at(-1);
+		expect(unknownEvent?.properties.deploymentRole).toBe("unknown");
+		expect(unknownEvent?.properties.installChannel).toBe("unknown");
+
+		const envRole = createTelemetryCollector(getDbAccessor(), TELEMETRY_CONFIG, "0.176.8", {
+			env: { SIGNET_TELEMETRY_DEPLOYMENT_ROLE: "CI" },
+		});
+		envRole.record("daemon.heartbeat", { uptimeMs: 2 });
+		await envRole.flush();
+		expect(captured.at(-1)?.body.batch.at(-1)?.properties.deploymentRole).toBe("ci");
+	});
+
+	it("reports observed version transitions without calling them upgrades", async () => {
+		const first = createTelemetryCollector(getDbAccessor(), TELEMETRY_CONFIG, "0.176.8");
+		await first.flush();
+		const second = createTelemetryCollector(getDbAccessor(), TELEMETRY_CONFIG, "0.176.9");
+		await second.flush();
+
+		const observed = second.query({ event: "version.observed" })[0];
+		expect(observed?.properties).toMatchObject({ from: "0.176.8", to: "0.176.9" });
+		expect(second.query({ event: "version.upgraded" })).toHaveLength(0);
+	});
+
+	it("keeps an observed prior version raw when the deployment marker changes", async () => {
+		const first = createTelemetryCollector(getDbAccessor(), TELEMETRY_CONFIG, "0.176.8");
+		await first.flush();
+		const second = createTelemetryCollector(getDbAccessor(), TELEMETRY_CONFIG, "0.176.9", {
+			env: { SIGNET_TELEMETRY_ENV: "dev" },
+		});
+		await second.flush();
+
+		expect(second.query({ event: "version.observed" })[0]?.properties).toMatchObject({
+			from: "0.176.8",
+			to: "0.176.9-dev",
+		});
 	});
 
 	it("marks both sides of development upgrade events", async () => {

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -9,7 +9,13 @@
 import { createHash } from "node:crypto";
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
-import type { PipelineTelemetryConfig } from "@signet/core";
+import {
+	type PipelineTelemetryConfig,
+	TELEMETRY_DEPLOYMENT_ROLES,
+	TELEMETRY_INSTALL_CHANNELS,
+	type TelemetryDeploymentRole,
+	type TelemetryInstallChannel,
+} from "@signet/core";
 import type { DbAccessor } from "./db-accessor";
 import { logger } from "./logger";
 
@@ -73,6 +79,9 @@ export const TELEMETRY_EVENTS = [
 	"command.invoked",
 	"error.occurred",
 	"version.upgraded",
+	// Observed at daemon start; unlike version.upgraded, this makes no claim
+	// about the mechanism that changed the installed version.
+	"version.observed",
 	// Cloud events (issue #1207): declared now so the future cloud-connect
 	// layer inherits the typed contract instead of retrofitting it. Nothing
 	// emits them until the Signet Cloud surface exists. Same anonymous
@@ -254,6 +263,41 @@ export function telemetryDeployment(env: NodeJS.ProcessEnv = process.env): Telem
 	return env.SIGNET_TELEMETRY_ENV?.trim().toLowerCase() === "dev" ? "dev" : undefined;
 }
 
+function validTelemetryValue<T extends string>(value: unknown, allowed: readonly T[]): T | undefined {
+	return typeof value === "string" && (allowed as readonly string[]).includes(value.trim().toLowerCase())
+		? (value.trim().toLowerCase() as T)
+		: undefined;
+}
+
+/**
+ * Resolve a bounded deployment declaration. The dev marker remains a
+ * compatible shorthand for the existing development-fleet behavior. No
+ * paths, process names, repository names, or network data participate.
+ */
+export function telemetryDeploymentRole(
+	configured: TelemetryDeploymentRole | undefined,
+	env: NodeJS.ProcessEnv = process.env,
+): TelemetryDeploymentRole {
+	if (telemetryDeployment(env) === "dev") return "development";
+	return (
+		validTelemetryValue(env.SIGNET_TELEMETRY_DEPLOYMENT_ROLE, TELEMETRY_DEPLOYMENT_ROLES) ??
+		validTelemetryValue(configured, TELEMETRY_DEPLOYMENT_ROLES) ??
+		"unknown"
+	);
+}
+
+/** Resolve installation provenance only from an explicit config or env value. */
+export function telemetryInstallChannel(
+	configured: TelemetryInstallChannel | undefined,
+	env: NodeJS.ProcessEnv = process.env,
+): TelemetryInstallChannel {
+	return (
+		validTelemetryValue(env.SIGNET_TELEMETRY_INSTALL_CHANNEL, TELEMETRY_INSTALL_CHANNELS) ??
+		validTelemetryValue(configured, TELEMETRY_INSTALL_CHANNELS) ??
+		"unknown"
+	);
+}
+
 /**
  * Keep development builds visible in version breakdowns without changing the
  * daemon's operational version or update behavior.
@@ -274,29 +318,70 @@ export function telemetryReportedVersion(version: string, deployment: TelemetryD
  * desktop, and npm installs alike; the wrapper postinstall ping misses bun
  * and desktop entirely).
  */
-function getOrCreateInstallId(db: DbAccessor): { readonly id: string; readonly created: boolean } {
+function getOrCreateInstallId(
+	db: DbAccessor,
+	daemonVersion: string,
+): { readonly id: string; readonly created: boolean; readonly previousVersion?: string } {
 	try {
 		return db.withWriteTx((w) => {
-			const existing = w.prepare("SELECT id FROM telemetry_install ORDER BY created_at ASC LIMIT 1").get() as
-				| { readonly id: string }
-				| null
-				| undefined;
-			if (existing?.id) return { id: existing.id, created: false };
+			const existing = w
+				.prepare("SELECT id, last_seen_version FROM telemetry_install ORDER BY created_at ASC LIMIT 1")
+				.get() as { readonly id: string; readonly last_seen_version?: string | null } | null | undefined;
+			if (existing?.id) {
+				if (!existing.last_seen_version) {
+					// Establish a baseline for installs upgraded from pre-117
+					// schemas without fabricating a transition event.
+					w.prepare("UPDATE telemetry_install SET last_seen_version = ? WHERE id = ?").run(daemonVersion, existing.id);
+				}
+				return {
+					id: existing.id,
+					created: false,
+					...(existing.last_seen_version ? { previousVersion: existing.last_seen_version } : {}),
+				};
+			}
 
 			const id = crypto.randomUUID();
 			const result = w
-				.prepare("INSERT OR IGNORE INTO telemetry_install (id, created_at) VALUES (?, ?)")
-				.run(id, new Date().toISOString());
+				.prepare("INSERT OR IGNORE INTO telemetry_install (id, created_at, last_seen_version) VALUES (?, ?, ?)")
+				.run(id, new Date().toISOString(), daemonVersion);
 			if (result.changes > 0) return { id, created: true };
 
-			const inserted = w.prepare("SELECT id FROM telemetry_install ORDER BY created_at ASC LIMIT 1").get() as
-				| { readonly id: string }
-				| null
-				| undefined;
-			return inserted?.id ? { id: inserted.id, created: false } : { id, created: false };
+			const inserted = w
+				.prepare("SELECT id, last_seen_version FROM telemetry_install ORDER BY created_at ASC LIMIT 1")
+				.get() as { readonly id: string; readonly last_seen_version?: string | null } | null | undefined;
+			return inserted?.id
+				? {
+						id: inserted.id,
+						created: false,
+						...(inserted.last_seen_version ? { previousVersion: inserted.last_seen_version } : {}),
+					}
+				: { id, created: false };
 		});
 	} catch {
-		return { id: crypto.randomUUID(), created: false };
+		// Test harnesses and partially upgraded workspaces can still expose the
+		// pre-117 telemetry_install shape. Preserve telemetry there without
+		// claiming a transition; the next normal migration adds the column.
+		try {
+			return db.withWriteTx((w) => {
+				const existing = w.prepare("SELECT id FROM telemetry_install ORDER BY created_at ASC LIMIT 1").get() as
+					| { readonly id: string }
+					| null
+					| undefined;
+				if (existing?.id) return { id: existing.id, created: false };
+				const id = crypto.randomUUID();
+				const result = w
+					.prepare("INSERT OR IGNORE INTO telemetry_install (id, created_at) VALUES (?, ?)")
+					.run(id, new Date().toISOString());
+				if (result.changes > 0) return { id, created: true };
+				const inserted = w.prepare("SELECT id FROM telemetry_install ORDER BY created_at ASC LIMIT 1").get() as
+					| { readonly id: string }
+					| null
+					| undefined;
+				return inserted?.id ? { id: inserted.id, created: false } : { id, created: false };
+			});
+		} catch {
+			return { id: crypto.randomUUID(), created: false };
+		}
 	}
 }
 
@@ -461,6 +546,8 @@ export function createTelemetryCollector(
 	const logPath = opts.telemetryLogPath ?? null;
 	const deployment = telemetryDeployment(opts.env);
 	const reportedVersion = telemetryReportedVersion(daemonVersion, deployment);
+	const deploymentRole = telemetryDeploymentRole(config.deploymentRole, opts.env);
+	const installChannel = telemetryInstallChannel(config.installChannel, opts.env);
 	let flushTimer: ReturnType<typeof setTimeout> | null = null;
 	let running = false;
 	let flushInFlight: Promise<void> | null = null;
@@ -468,18 +555,25 @@ export function createTelemetryCollector(
 	let consecutiveFailures = 0;
 	let flushCount = 0;
 	let effectiveIntervalMs = config.flushIntervalMs;
-	const { id: installId, created: installActivated } = getOrCreateInstallId(db);
+	const { id: installId, created: installActivated, previousVersion } = getOrCreateInstallId(db, daemonVersion);
 
 	const posthogConfigured = config.posthogHost.length > 0 && config.posthogApiKey.length > 0;
 
-	function addContext(properties: TelemetryProperties): TelemetryProperties {
+	function addContext(event: TelemetryEventType, properties: TelemetryProperties): TelemetryProperties {
 		return {
 			...properties,
+			deploymentRole,
+			installChannel,
 			...(deployment ? { deployment } : {}),
 			...(typeof properties.version === "string"
 				? { version: telemetryReportedVersion(properties.version, deployment) }
 				: {}),
-			...(typeof properties.from === "string" ? { from: telemetryReportedVersion(properties.from, deployment) } : {}),
+			...(typeof properties.from === "string"
+				? {
+						from:
+							event === "version.observed" ? properties.from : telemetryReportedVersion(properties.from, deployment),
+					}
+				: {}),
 			...(typeof properties.to === "string" ? { to: telemetryReportedVersion(properties.to, deployment) } : {}),
 		};
 	}
@@ -500,7 +594,7 @@ export function createTelemetryCollector(
 			id: crypto.randomUUID(),
 			event: FIRST_USE_EVENTS[kind],
 			timestamp: new Date().toISOString(),
-			properties: addContext({
+			properties: addContext(FIRST_USE_EVENTS[kind], {
 				version: daemonVersion,
 				platform: process.platform,
 			}),
@@ -545,6 +639,12 @@ export function createTelemetryCollector(
 				const now = new Date().toISOString();
 				for (const e of events) {
 					stmt.run(e.id, e.event, e.timestamp, JSON.stringify(e.properties), now);
+				}
+				// Advance the observation marker in the same transaction as the
+				// event. A crash before flush therefore repeats the observation
+				// instead of losing it permanently.
+				if (events.some((event) => event.event === "version.observed")) {
+					w.prepare("UPDATE telemetry_install SET last_seen_version = ? WHERE id = ?").run(daemonVersion, installId);
 				}
 			});
 		} catch (err) {
@@ -778,7 +878,7 @@ export function createTelemetryCollector(
 			id: crypto.randomUUID(),
 			event,
 			timestamp: new Date().toISOString(),
-			properties: addContext(enrichSessionEvent(event, properties)),
+			properties: addContext(event, enrichSessionEvent(event, properties)),
 		});
 		if (options.persistAuditLog && logPath) {
 			const last = buffer[buffer.length - 1];
@@ -923,6 +1023,12 @@ export function createTelemetryCollector(
 		if (opts.configSnapshot) {
 			collector.record("config.snapshot", { ...opts.configSnapshot });
 		}
+	}
+	if (previousVersion && previousVersion !== daemonVersion) {
+		collector.record("version.observed", {
+			from: previousVersion,
+			to: daemonVersion,
+		});
 	}
 
 	return collector;

--- a/scripts/install-copy-regression.test.ts
+++ b/scripts/install-copy-regression.test.ts
@@ -85,6 +85,9 @@ describe("install copy", () => {
 		expect(launcher).toContain("resolveNativePackageBinaryPath");
 		expect(launcher).toContain("require.resolve");
 		expect(launcher).toContain("SIGNET_DIR");
+		expect(launcher).toContain(
+			'SIGNET_TELEMETRY_INSTALL_CHANNEL: process.env.SIGNET_TELEMETRY_INSTALL_CHANNEL ?? "package-manager"',
+		);
 		expect(nativePlatforms).toContain('"linux-x64"');
 		expect(nativePlatforms).toContain('"linux-arm64"');
 		expect(nativePlatforms).toContain('"darwin-x64"');
@@ -109,10 +112,9 @@ describe("install copy", () => {
 	test("keeps the postinstall telemetry ping anonymous and opt-out", () => {
 		const installer = read("dist/signetai/scripts/install-native.js");
 
-		// Phase-1 install counter (issue #1026): a single anonymous PostHog
-		// event with version+platform only. No identifier, no payload beyond
-		// the event properties, and never a hard failure path. The project
-		// API key is a public ingest key by PostHog design.
+		// Phase-1 install counter (issue #1026) plus bounded provenance metadata
+		// (issue #1274). No identifier, paths, or owner data enter the payload,
+		// and the request is never a hard failure path.
 		expect(installer).toContain("us.i.posthog.com");
 		expect(installer).toContain("/batch/");
 		expect(installer).toContain('event: "install.ping"');
@@ -123,6 +125,8 @@ describe("install copy", () => {
 		expect(installer).toContain("SIGNET_TELEMETRY_OPTOUT");
 		expect(installer).toContain("SIGNET_TELEMETRY_ENV");
 		expect(installer).toContain("telemetryReportedVersion(nativePackageVersion())");
+		expect(installer).toContain("SIGNET_TELEMETRY_DEPLOYMENT_ROLE");
+		expect(installer).toContain('installChannel: "package-manager"');
 
 		// The ping must never block or fail the install: it is fire-and-forget
 		// with a bounded timeout, and errors are swallowed.

--- a/surfaces/cli/src/dev-cli.ts
+++ b/surfaces/cli/src/dev-cli.ts
@@ -1,5 +1,6 @@
 export {};
 
 process.env.SIGNET_TELEMETRY_ENV ||= "dev";
+process.env.SIGNET_TELEMETRY_INSTALL_CHANNEL ||= "source";
 
 await import("./cli");

--- a/surfaces/cli/src/features/telemetry.test.ts
+++ b/surfaces/cli/src/features/telemetry.test.ts
@@ -5,7 +5,9 @@ import { join } from "node:path";
 import { createDatabase } from "../sqlite";
 import {
 	cliTelemetryDeployment,
+	cliTelemetryDeploymentRole,
 	cliTelemetryEnabled,
+	cliTelemetryInstallChannel,
 	cliTelemetryLogPath,
 	flushCliTelemetry,
 	recordCommandInvoked,
@@ -78,9 +80,20 @@ describe("cli telemetry (issue #1206)", () => {
 		expect(cliTelemetryDeployment({ SIGNET_TELEMETRY_ENV: "DEV" })).toBe("dev");
 		recordCommandInvoked(dir, "remember", { SIGNET_TELEMETRY_ENV: "dev" });
 		const line = JSON.parse(readFileSync(cliTelemetryLogPath(dir), "utf-8").trim()) as {
-			properties: { deployment: string };
+			properties: { deployment: string; deploymentRole: string; installChannel: string };
 		};
 		expect(line.properties.deployment).toBe("dev");
+		expect(line.properties.deploymentRole).toBe("development");
+		expect(line.properties.installChannel).toBe("unknown");
+	});
+
+	it("accepts only bounded explicit role and channel declarations", () => {
+		expect(cliTelemetryDeploymentRole("service", {})).toBe("service");
+		expect(cliTelemetryInstallChannel("container", {})).toBe("container");
+		expect(cliTelemetryDeploymentRole("service", { SIGNET_TELEMETRY_DEPLOYMENT_ROLE: "CI" })).toBe("ci");
+		expect(cliTelemetryInstallChannel("container", { SIGNET_TELEMETRY_INSTALL_CHANNEL: "bad" })).toBe("container");
+		expect(cliTelemetryDeploymentRole("bad", {})).toBe("unknown");
+		expect(cliTelemetryInstallChannel("bad", {})).toBe("unknown");
 	});
 
 	it("honors the runtime telemetry opt-out", () => {

--- a/surfaces/cli/src/features/telemetry.ts
+++ b/surfaces/cli/src/features/telemetry.ts
@@ -14,6 +14,10 @@ import {
 	DEFAULT_TELEMETRY_FLUSH_BATCH_SIZE,
 	DEFAULT_TELEMETRY_POSTHOG_API_KEY,
 	DEFAULT_TELEMETRY_POSTHOG_HOST,
+	TELEMETRY_DEPLOYMENT_ROLES,
+	TELEMETRY_INSTALL_CHANNELS,
+	type TelemetryDeploymentRole,
+	type TelemetryInstallChannel,
 	parseSimpleYaml,
 } from "@signet/core";
 import { createDatabase } from "../sqlite.js";
@@ -29,6 +33,8 @@ interface CliTelemetrySettings {
 	readonly posthogHost: string;
 	readonly posthogApiKey: string;
 	readonly flushBatchSize: number;
+	readonly deploymentRole: TelemetryDeploymentRole;
+	readonly installChannel: TelemetryInstallChannel;
 }
 
 interface QueuedEvent {
@@ -58,6 +64,35 @@ export type CliTelemetryDeployment = "dev";
 
 export function cliTelemetryDeployment(env: NodeJS.ProcessEnv = process.env): CliTelemetryDeployment | undefined {
 	return env.SIGNET_TELEMETRY_ENV?.trim().toLowerCase() === "dev" ? "dev" : undefined;
+}
+
+function validTelemetryValue<T extends string>(value: unknown, allowed: readonly T[]): T | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = value.trim().toLowerCase();
+	return (allowed as readonly string[]).includes(normalized) ? (normalized as T) : undefined;
+}
+
+export function cliTelemetryDeploymentRole(
+	configured: unknown,
+	env: NodeJS.ProcessEnv = process.env,
+): TelemetryDeploymentRole {
+	if (cliTelemetryDeployment(env) === "dev") return "development";
+	return (
+		validTelemetryValue(env.SIGNET_TELEMETRY_DEPLOYMENT_ROLE, TELEMETRY_DEPLOYMENT_ROLES) ??
+		validTelemetryValue(configured, TELEMETRY_DEPLOYMENT_ROLES) ??
+		"unknown"
+	);
+}
+
+export function cliTelemetryInstallChannel(
+	configured: unknown,
+	env: NodeJS.ProcessEnv = process.env,
+): TelemetryInstallChannel {
+	return (
+		validTelemetryValue(env.SIGNET_TELEMETRY_INSTALL_CHANNEL, TELEMETRY_INSTALL_CHANNELS) ??
+		validTelemetryValue(configured, TELEMETRY_INSTALL_CHANNELS) ??
+		"unknown"
+	);
 }
 
 function cliTelemetryDisabledByEnv(env: NodeJS.ProcessEnv): boolean {
@@ -96,7 +131,14 @@ function readTelemetrySettings(agentsDir: string, env: NodeJS.ProcessEnv = proce
 				? Math.min(MAX_BATCH_SIZE, Math.max(MIN_BATCH_SIZE, Math.floor(configuredBatchSize)))
 				: DEFAULT_TELEMETRY_FLUSH_BATCH_SIZE;
 
-		return { enabled: true, posthogHost, posthogApiKey, flushBatchSize };
+		return {
+			enabled: true,
+			posthogHost,
+			posthogApiKey,
+			flushBatchSize,
+			deploymentRole: cliTelemetryDeploymentRole(telemetry?.deploymentRole, env),
+			installChannel: cliTelemetryInstallChannel(telemetry?.installChannel, env),
+		};
 	} catch {
 		return null;
 	}
@@ -222,7 +264,12 @@ export function recordCommandInvoked(
 			id: randomUUID(),
 			event: TELEMETRY_EVENT,
 			timestamp: new Date().toISOString(),
-			properties: { command: commandName, ...(deployment ? { deployment } : {}) },
+			properties: {
+				command: commandName,
+				deploymentRole: settings.deploymentRole,
+				installChannel: settings.installChannel,
+				...(deployment ? { deployment } : {}),
+			},
 		};
 		const logPath = cliTelemetryLogPath(agentsDir);
 		mkdirSync(dirname(logPath), { recursive: true });

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -142,6 +142,42 @@ describe("buildSystemdDaemonStartArgs", () => {
 		expect(args).toContain("--setenv=BUN_INSPECT=127.0.0.1:9230");
 	});
 
+	it("forwards only allowlisted telemetry variables through service-manager boundaries", () => {
+		const input = {
+			daemonPath: "/opt/signet/dist/daemon.js",
+			agentsDir: "/home/user/.agents",
+			port: 3850,
+			host: "127.0.0.1",
+			bind: "0.0.0.0",
+			startupLogPath: "/home/user/.agents/.daemon/logs/startup.log",
+			telemetryEnv: {
+				SIGNET_TELEMETRY_ENV: "dev",
+				SIGNET_TELEMETRY_OPTOUT: "1",
+				SIGNET_TELEMETRY_DEPLOYMENT_ROLE: "ci",
+				SIGNET_TELEMETRY_INSTALL_CHANNEL: "package-manager",
+				SIGNET_TELEMETRY_SECRET: "must-not-cross-boundary",
+			},
+		};
+
+		const args = buildSystemdDaemonStartArgs(input);
+		const plist = buildLaunchdDaemonPlist(input);
+
+		expect(args).toEqual(
+			expect.arrayContaining([
+				"--setenv=SIGNET_TELEMETRY_ENV=dev",
+				"--setenv=SIGNET_TELEMETRY_OPTOUT=1",
+				"--setenv=SIGNET_TELEMETRY_DEPLOYMENT_ROLE=ci",
+				"--setenv=SIGNET_TELEMETRY_INSTALL_CHANNEL=package-manager",
+			]),
+		);
+		expect(plist).toContain("<key>SIGNET_TELEMETRY_ENV</key>");
+		expect(plist).toContain("<key>SIGNET_TELEMETRY_OPTOUT</key>");
+		expect(plist).toContain("<key>SIGNET_TELEMETRY_DEPLOYMENT_ROLE</key>");
+		expect(plist).toContain("<key>SIGNET_TELEMETRY_INSTALL_CHANNEL</key>");
+		expect(args.join(" ")).not.toContain("SIGNET_TELEMETRY_SECRET");
+		expect(plist).not.toContain("SIGNET_TELEMETRY_SECRET");
+	});
+
 	it("omits empty inspector settings", () => {
 		const input = {
 			daemonPath: "/opt/signet/dist/daemon.js",

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -782,12 +782,32 @@ export interface DaemonStartArgsInput {
 	readonly unitName?: string;
 	// Service managers do not inherit this debugger setting unless it is explicit.
 	readonly bunInspect?: string;
+	/** Source environment for the allowlisted telemetry variables below. */
+	readonly telemetryEnv?: NodeJS.ProcessEnv;
 }
 
 export type SystemdDaemonStartArgsInput = DaemonStartArgsInput;
 
 export interface LaunchdDaemonPlistInput extends DaemonStartArgsInput {
 	readonly label?: string;
+}
+
+const TELEMETRY_ENVIRONMENT_KEYS = [
+	"SIGNET_TELEMETRY_ENV",
+	"SIGNET_TELEMETRY_OPTOUT",
+	"SIGNET_TELEMETRY_DEPLOYMENT_ROLE",
+	"SIGNET_TELEMETRY_INSTALL_CHANNEL",
+] as const;
+
+type TelemetryEnvironmentKey = (typeof TELEMETRY_ENVIRONMENT_KEYS)[number];
+
+function resolveTelemetryEnvironment(env: NodeJS.ProcessEnv): Partial<Record<TelemetryEnvironmentKey, string>> {
+	const resolved: Partial<Record<TelemetryEnvironmentKey, string>> = {};
+	for (const key of TELEMETRY_ENVIRONMENT_KEYS) {
+		const value = env[key];
+		if (value) resolved[key] = value;
+	}
+	return resolved;
 }
 
 export function buildSystemdDaemonStartArgs(input: SystemdDaemonStartArgsInput): string[] {
@@ -804,6 +824,9 @@ export function buildSystemdDaemonStartArgs(input: SystemdDaemonStartArgsInput):
 		`--setenv=SIGNET_BIND=${input.bind}`,
 		`--setenv=SIGNET_PATH=${input.agentsDir}`,
 		"--setenv=SIGNET_DAEMON_ENTRYPOINT=1",
+		...Object.entries(resolveTelemetryEnvironment(input.telemetryEnv ?? process.env)).map(
+			([key, value]) => `--setenv=${key}=${value}`,
+		),
 		...(input.unitName ? [`--setenv=SIGNET_DAEMON_UNIT=${input.unitName}`] : []),
 		...(input.bunInspect ? [`--setenv=BUN_INSPECT=${input.bunInspect}`] : []),
 		...resolveDaemonLaunchCommand(input.daemonPath),
@@ -982,6 +1005,7 @@ export function buildLaunchdDaemonPlist(input: LaunchdDaemonPlistInput): string 
 		SIGNET_BIND: input.bind,
 		SIGNET_PATH: input.agentsDir,
 		SIGNET_DAEMON_ENTRYPOINT: "1",
+		...resolveTelemetryEnvironment(input.telemetryEnv ?? process.env),
 		...(input.bunInspect ? { BUN_INSPECT: input.bunInspect } : {}),
 		...(process.env.SIGNET_DIR ? { SIGNET_DIR: process.env.SIGNET_DIR } : {}),
 		...(process.env.SIGNET_DASHBOARD_DIR ? { SIGNET_DASHBOARD_DIR: process.env.SIGNET_DASHBOARD_DIR } : {}),
@@ -1135,6 +1159,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 			startupLogPath,
 			unitName: systemdUnitName,
 			bunInspect: process.env.BUN_INSPECT,
+			telemetryEnv: process.env,
 		});
 		const result = spawnSync("systemd-run", systemdArgs, {
 			stdio: ["ignore", "ignore", stderrTarget],
@@ -1166,6 +1191,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 				bind: net.bind,
 				startupLogPath,
 				bunInspect: process.env.BUN_INSPECT,
+				telemetryEnv: process.env,
 			}),
 		);
 		// Boot out any loaded job before (re)bootstrap. When no job is loaded

--- a/surfaces/desktop/src/daemon-manager.ts
+++ b/surfaces/desktop/src/daemon-manager.ts
@@ -224,11 +224,19 @@ export class DaemonManager {
 
 	#closeFds(): void {
 		if (this.#stdoutFd !== null) {
-			try { closeSync(this.#stdoutFd); } catch { /* ignore */ }
+			try {
+				closeSync(this.#stdoutFd);
+			} catch {
+				/* ignore */
+			}
 			this.#stdoutFd = null;
 		}
 		if (this.#stderrFd !== null) {
-			try { closeSync(this.#stderrFd); } catch { /* ignore */ }
+			try {
+				closeSync(this.#stderrFd);
+			} catch {
+				/* ignore */
+			}
 			this.#stderrFd = null;
 		}
 	}
@@ -282,7 +290,7 @@ export class DaemonManager {
 				SIGNET_PATH: this.#workspacePath,
 				SIGNET_WORKSPACE: this.#workspacePath,
 				SIGNET_DESKTOP: "1",
-			SIGNET_TELEMETRY_INSTALL_CHANNEL: process.env.SIGNET_TELEMETRY_INSTALL_CHANNEL ?? "desktop",
+				SIGNET_TELEMETRY_INSTALL_CHANNEL: process.env.SIGNET_TELEMETRY_INSTALL_CHANNEL ?? "desktop",
 			},
 		});
 		this.#owned = true;

--- a/surfaces/desktop/src/daemon-manager.ts
+++ b/surfaces/desktop/src/daemon-manager.ts
@@ -282,6 +282,7 @@ export class DaemonManager {
 				SIGNET_PATH: this.#workspacePath,
 				SIGNET_WORKSPACE: this.#workspacePath,
 				SIGNET_DESKTOP: "1",
+			SIGNET_TELEMETRY_INSTALL_CHANNEL: process.env.SIGNET_TELEMETRY_INSTALL_CHANNEL ?? "desktop",
 			},
 		});
 		this.#owned = true;

--- a/web/docs/src/content/docs/architecture/pipeline-storage.md
+++ b/web/docs/src/content/docs/architecture/pipeline-storage.md
@@ -266,7 +266,7 @@ error message. The job follows standard retry logic — up to
 SQLite with WAL mode. Migrations are numbered sequentially under
 `platform/core/src/migrations/`. Each migration is idempotent — safe
 to re-run against an existing database. Schema version is tracked in
-`schema_migrations`. The latest migration is `117-retire-summary-worker.ts`.
+`schema_migrations`. The latest migration is `117-telemetry-version-observation.ts`.
 
 **schema_migrations**
 

--- a/web/docs/src/content/docs/architecture/pipeline-storage.md
+++ b/web/docs/src/content/docs/architecture/pipeline-storage.md
@@ -266,7 +266,7 @@ error message. The job follows standard retry logic — up to
 SQLite with WAL mode. Migrations are numbered sequentially under
 `platform/core/src/migrations/`. Each migration is idempotent — safe
 to re-run against an existing database. Schema version is tracked in
-`schema_migrations`. The latest migration is `117-telemetry-version-observation.ts`.
+`schema_migrations`. The latest migration is `119-telemetry-version-observation.ts`.
 
 **schema_migrations**
 

--- a/web/docs/src/content/docs/configuration/pipeline.md
+++ b/web/docs/src/content/docs/configuration/pipeline.md
@@ -507,7 +507,8 @@ uptime), `command.invoked` (command name only, never arguments),
 `error.occurred` (sanitized crash report — truncated message with user paths
 stripped, top stack frames with home directories removed, uptime, and
 rate-limited `EventLoopLag` reports with measured lag), `version.upgraded`
-(from, to).
+(from, to), and `version.observed` (from, to for any observed daemon-start
+transition).
 
 **Development fleet marker:** setting `SIGNET_TELEMETRY_ENV=dev` keeps operator
 development checkouts in the dataset while making them filterable. The daemon
@@ -517,6 +518,12 @@ and `-dev` version suffix when the environment is present. The daemon and CLI
 `bun run dev` scripts set this marker automatically. The marker does not
 disable telemetry; use `SIGNET_TELEMETRY_OPTOUT=1` when development or
 automated events should be silenced entirely.
+
+Every daemon and CLI event carries `deploymentRole` and `installChannel`.
+Both default to `unknown` and are populated only from the explicit config
+keys below or `SIGNET_TELEMETRY_DEPLOYMENT_ROLE` and
+`SIGNET_TELEMETRY_INSTALL_CHANNEL`. The `SIGNET_TELEMETRY_ENV=dev` marker
+remains compatible and maps the role to `development`.
 | Field | Default | Range | Description |
 |-------|---------|-------|-------------|
 | `posthogHost` | `https://us.i.posthog.com` | — | PostHog instance URL (empty disables) |
@@ -524,6 +531,8 @@ automated events should be silenced entirely.
 | `flushIntervalMs` | `60000` | 5s-10min | Time between event flushes |
 | `flushBatchSize` | `50` | 1-500 | Max events per flush batch |
 | `retentionDays` | `90` | 1-365 | Days before local telemetry data is purged |
+| `deploymentRole` | `unknown` | `personal`, `service`, `automation`, `development`, `ci`, `unknown` | Explicit deployment role |
+| `installChannel` | `unknown` | `desktop`, `package-manager`, `source`, `container`, `unknown` | Explicit installation provenance |
 | `memorySearchQaEnabled` | `false` | boolean | Capture local-only recall QA rows with query text and result snapshots |
 
 `memorySearchQaEnabled` is separate from anonymous telemetry. It writes a


### PR DESCRIPTION
## Summary

Fixes #1274 by making telemetry cohorts explicitly classifiable without collecting identity or filesystem provenance.

## Changes

- Add bounded `deploymentRole` and `installChannel` metadata to daemon, CLI, desktop, source-dev, package-manager, and install-ping telemetry paths.
- Preserve `SIGNET_TELEMETRY_ENV=dev` compatibility while mapping it to the development role.
- Add migration 117 and an atomic `version.observed` event for manual, source, package-manager, and downgrade/version transitions; retain `version.upgraded` for daemon auto-updates only.
- Update telemetry docs, configuration parsing, install/runtime regression coverage, and migration documentation.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: desktop launcher and published native wrapper

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

Migration 117 adds a nullable `last_seen_version` column to `telemetry_install`. Existing rows establish a baseline without fabricating a transition; pre-117 test/partial schemas retain telemetry via a compatibility fallback. The transition event and marker update are written in the same transaction.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused validation passed:

- `bun test platform/daemon/src/telemetry.test.ts platform/daemon/src/memory-config.test.ts platform/core/src/migrations/migrations.test.ts surfaces/cli/src/features/telemetry.test.ts scripts/install-copy-regression.test.ts platform/daemon/src/session-tracker.test.ts` — 214 passed, 0 failed; the final telemetry rerun after review fixes was 27 passed, 0 failed.
- `bun run typecheck` — passed after building the repository's generated connector bundles.
- Scoped Biome checks on all changed source/generated files — passed.
- `bun scripts/doc-drift.ts` — migration reference aligned; remaining route/package drift is pre-existing.
- Independent self-review — no actionable findings.

The full repository test/lint commands were also attempted. Full `bun test` is currently not clean in this shared workspace (307 unrelated failures/34 errors from manifest-lock and daemon/environment-dependent suites), and root `bun run lint` reports 537 pre-existing formatting errors/160 warnings across unrelated files. These do not occur in the focused issue suites above.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Telemetry values are allowlisted and default to `unknown`; no paths, URLs, account identity, raw agent IDs, IP data, or content are used for classification. The prior auto-update event remains semantically unchanged.
