### PR TITLE
fix(telemetry): measure recall delivery outcomes

### DIFF
--- a/dist/signetai/hermes-plugin/__init__.py
+++ b/dist/signetai/hermes-plugin/__init__.py
@@ -75,7 +75,7 @@ MEMORY_SEARCH_SCHEMA = {
                 "type": "number",
                 "description": "Deprecated compatibility alias for importance_min; ignored when importance_min is set.",
             },
-            "score_min": {"type": "number", "description": "Minimum recall score threshold, applied client-side."},
+            "score_min": {"type": "number", "description": "Minimum recall score threshold."},
             "aggregate": {
                 "type": "boolean",
                 "description": "Synthesize an aggregate answer from bounded recall evidence.",

--- a/dist/signetai/hermes-plugin/client.py
+++ b/dist/signetai/hermes-plugin/client.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import ipaddress
 import urllib.error
@@ -447,6 +448,9 @@ class SignetClient:
                 body["saveAggregate"] = save_aggregate
         if agent_scoped and self._agent_id:
             body["agentId"] = self._agent_id
+        if score_min is not None and isinstance(score_min, (int, float)) and not isinstance(score_min, bool) and math.isfinite(score_min):
+            body["minScore"] = score_min
+        body["recallSurface"] = "tool_call"
 
         result = self._post("/api/memory/recall", body, timeout=_RECALL_TIMEOUT_SECS)
         if (

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -59,7 +59,9 @@ PostHog failures, and never throws into the daemon.
 | `session.end` | real session termination: an explicit boundary reason or a TTL-evicted (abandoned) session claim | `harness`, `reason` (`clear` / `session.deleted` / `session_branch` / `session_fork` / `session_shutdown` / `session_switch` / `stale-session-sweep` / `expired`), `sessionHash`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `cost` |
 | `llm.generate` | every LLM call | `provider`, `latencyMs`, `success`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `totalCost` |
 | `pipeline.embedding` | every embedding fetch, at the usage-recording boundary | `tokens`, `provider`, `sourceKind` (`memory-capture` / `artifact-index` / `recall` / `dreaming` / `other`), `cost` (USD) |
-| `recall.performed` | every completed shared recall search | `type` (`semantic` / `keyword` / `temporal` / `graph`), `results`, `latencyMs`, `truncated` |
+| `recall.performed` | every completed shared recall search | `surface`, `type` (`semantic` / `keyword` / `temporal` / `graph`), `results`, `latencyMs`, `truncated` |
+| `recall.attempted` | every valid recall request or automatic prompt-context retrieval attempt | `surface` (`explicit_api` / `tool_call` / `prompt_injection` / `dashboard` / `other`) |
+| `recall.outcome` | result and delivery boundary for a recall attempt | `surface`, `resultState` (`empty` / `non_empty` / `truncated` / `error`), `deliveryState` (`returned` / `injected` / `consumed` / `not_delivered`), `results` |
 | `pipeline.error` | categorized extraction, decision, or embedding failure | `stage`, `code` only; no message or stack content |
 | `dreaming.pass` | completed agentic dreaming pass (early-exit passes emit nothing) | `mode`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `cost` |
 | `inference.route` | inference control-plane routing decision | `surface`, `agentId`, `operation`, `taskClass`, `policyId`, `selectedTarget`, `candidateCount`, `blockedCount`, `allowedCount`, `privacy`, `durationMs`, `success`, `errorCode` |
@@ -124,9 +126,9 @@ Notes on individual events:
   aggregates.
 - **`recall.performed`** — emitted at the shared `hybridRecall` boundary with
   counts and timing only. Aggregate recall can emit one event for the main
-  search and additional events for decomposed subqueries. Local stats read the
-  flushed telemetry table, so they can lag the in-memory event buffer by one
-  flush interval.
+  search and additional events for decomposed subqueries. It measures search
+  execution, not delivery. Local stats read the flushed telemetry table, so
+  they can lag the in-memory event buffer by one flush interval.
 - **Runtime-pressure buckets (#1282)** — heartbeats and rate-limited
   `EventLoopLag` reports carry `runtimePressureVersion`, queue-depth and
   oldest-job-age buckets, active-worker and configured batch-size buckets,
@@ -136,6 +138,17 @@ Notes on individual events:
   touches the filesystem, or starts provider work. `recoveryOutcome` is
   `still_degraded` during an episode, `recovered` after the pressure state
   clears, and `restarted` on the first heartbeat after an abnormal prior exit.
+- **`recall.attempted` / `recall.outcome`** — the bounded retrieval-outcome
+  contract (#1277). Attempts are recorded once at each supported recall
+  surface. Outcomes separate empty, non-empty, truncated, and error results
+  from the delivery boundary: explicit API and tool results are `returned`,
+  automatic session-start and prompt-submit context is `injected`, and failed
+  paths are `not_delivered`. `consumed` is reserved for a deliberate client
+  acknowledgement; no client emits it by default. Surface values are fixed
+  enums. No query, prompt, memory, citation, agent, or harness identifiers
+  are included. Local stats expose attempted, returned, and delivered counts
+  by surface; they read the flushed telemetry table and can lag the in-memory
+  event buffer by one flush interval.
 
 ## Privacy contract
 
@@ -303,6 +316,7 @@ vault mirrors the key PostHog aggregates for daily review via
 | next | `session.turn` + real `session.end` split (#1212): the per-turn event renamed from the old `session.end`; `session.end` now fires only at real terminations, deduped per lifetime; `sessionHash` added to all three session events |
 | Unreleased | Previous daemon-exit reconciliation: `daemon.previous_exit` reports bounded `clean`, `error`, or `unrecorded` classification on the next boot (#1255) |
 | Unreleased | `recall.performed` with anonymous recall type, result count, latency, and truncation metrics (#1203) |
+| Unreleased | Bounded recall attempt and delivery outcomes by surface, without query or prompt content (#1277) |
 | Unreleased | First-run activation funnel: `first.remember` / `first.recall`, exactly once per install (#1202) |
 | Unreleased | `pipeline.embedding` cost rates and collector-derived session token/cost totals (#1201) |
 

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -10,7 +10,7 @@ Integrates Signet's memory system into Hermes Agent as a native plugin.
 - Registers memory tools: `memory_search`, `memory_store`, `memory_get`, `memory_list`, `memory_modify`, `memory_forget`, `signet_session_search`, `recall`, and `remember`
 - Backs up existing provider configuration for safe uninstallation
 - Uses content hashing to detect when the plugin needs updating
-- Uses Signet's canonical recall request defaults and bounds (`10`, `1..100`); `score_min` remains a client-side filter
+- Uses Signet's canonical recall request defaults and bounds (`10`, `1..100`); `score_min` is applied at the daemon response boundary and checked defensively by the plugin
 - Preserves Hermes's explicit `agent_scoped` opt-in instead of silently restricting shared recall
 
 ## Installation

--- a/integrations/hermes-agent/connector/hermes-plugin/__init__.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/__init__.py
@@ -75,7 +75,7 @@ MEMORY_SEARCH_SCHEMA = {
                 "type": "number",
                 "description": "Deprecated compatibility alias for importance_min; ignored when importance_min is set.",
             },
-            "score_min": {"type": "number", "description": "Minimum recall score threshold, applied client-side."},
+            "score_min": {"type": "number", "description": "Minimum recall score threshold."},
             "aggregate": {
                 "type": "boolean",
                 "description": "Synthesize an aggregate answer from bounded recall evidence.",

--- a/integrations/hermes-agent/connector/hermes-plugin/client.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/client.py
@@ -61,7 +61,9 @@ def _build_recall_request_body(
     aggregate: bool = False,
     aggregate_budget: str = "",
     save_aggregate: Optional[bool] = None,
+    min_score: Optional[float] = None,
     agent_id: str = "",
+    recall_surface: str = "",
 ) -> Dict[str, Any]:
     """Build canonical daemon JSON for the options exposed by Hermes."""
     body: Dict[str, Any] = {"query": query, "limit": _normalize_recall_limit(limit)}
@@ -86,6 +88,10 @@ def _build_recall_request_body(
         body["aggregateBudget"] = aggregate_budget
     if isinstance(save_aggregate, bool):
         body["saveAggregate"] = save_aggregate
+    if isinstance(min_score, (int, float)) and not isinstance(min_score, bool) and math.isfinite(min_score):
+        body["minScore"] = min_score
+    if recall_surface in ("explicit_api", "tool_call", "prompt_injection", "dashboard", "other"):
+        body["recallSurface"] = recall_surface
     return body
 
 
@@ -510,7 +516,9 @@ class SignetClient:
             aggregate=aggregate,
             aggregate_budget=aggregate_budget,
             save_aggregate=save_aggregate,
+            min_score=score_min,
             agent_id=self._agent_id if agent_scoped else "",
+            recall_surface="tool_call",
         )
 
         result = self._post("/api/memory/recall", body, timeout=_RECALL_TIMEOUT_SECS)

--- a/integrations/openclaw/memory-adapter/src/index.test.ts
+++ b/integrations/openclaw/memory-adapter/src/index.test.ts
@@ -329,10 +329,10 @@ afterEach(async () => {
 describe("signet-memory-openclaw lifecycle hooks", () => {
 	it("delegates recall defaults and bounds to the canonical request builder", async () => {
 		await memoryRecall("default recall", { daemonUrl: "http://daemon.test" });
-		expect(lastMemoryRecallBody).toEqual({ query: "default recall", limit: 10 });
+		expect(lastMemoryRecallBody).toEqual({ query: "default recall", limit: 10, recallSurface: "tool_call" });
 
 		await memoryRecall("bounded recall", { daemonUrl: "http://daemon.test", limit: 5000 });
-		expect(lastMemoryRecallBody).toEqual({ query: "bounded recall", limit: 100 });
+		expect(lastMemoryRecallBody).toEqual({ query: "bounded recall", limit: 100, recallSurface: "tool_call" });
 	});
 
 	it("forwards session_search requests to the transcript search endpoint", async () => {
@@ -381,6 +381,8 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 			sessionKey: "ctx-session",
 			agentId: "agent-openclaw",
 			includeRecalled: true,
+			minScore: 0.5,
+			recallSurface: "tool_call",
 		});
 		expect(result?.details).toMatchObject({
 			count: 1,

--- a/integrations/openclaw/memory-adapter/src/index.ts
+++ b/integrations/openclaw/memory-adapter/src/index.ts
@@ -663,6 +663,8 @@ export async function memoryRecall(
 			sessionKey: options.sessionKey,
 			agentId: options.agentId,
 			includeRecalled: options.includeRecalled,
+			minScore: options.minScore,
+			recallSurface: "tool_call",
 		}),
 		timeout: READ_TIMEOUT,
 	});

--- a/integrations/opencode/plugin/src/tools.test.ts
+++ b/integrations/opencode/plugin/src/tools.test.ts
@@ -20,8 +20,14 @@ describe("createTools", () => {
 		);
 
 		expect(captured).toEqual([
-			{ query: "default recall", limit: 10 },
-			{ query: "bounded recall", limit: 100, scope: "world:alpha", includeRecalled: true },
+			{ query: "default recall", limit: 10, recallSurface: "tool_call" },
+			{
+				query: "bounded recall",
+				limit: 100,
+				scope: "world:alpha",
+				includeRecalled: true,
+				recallSurface: "tool_call",
+			},
 		]);
 	});
 

--- a/integrations/opencode/plugin/src/tools.ts
+++ b/integrations/opencode/plugin/src/tools.ts
@@ -46,6 +46,8 @@ async function searchMemory(
 			agentId: args.agent_id,
 			includeRecalled: args.include_recalled,
 			scope: args.scope,
+			minScore: args.min_score,
+			recallSurface: "tool_call",
 		}),
 		READ_TIMEOUT,
 	);

--- a/integrations/pi/extension/src/index.ts
+++ b/integrations/pi/extension/src/index.ts
@@ -147,6 +147,7 @@ export async function recallMemories(
 		body: JSON.stringify(
 			buildRecallRequestBody(query, {
 				...options,
+				recallSurface: "tool_call",
 			}),
 		),
 		signal: AbortSignal.timeout(options.aggregate ? Math.max(READ_TIMEOUT * 6, 30_000) : READ_TIMEOUT),
@@ -216,6 +217,7 @@ export async function searchSourceArtifacts(
 				sessionKey,
 				includeRecalled,
 				project,
+				recallSurface: "tool_call",
 			}),
 			sourceOnly: true,
 		}),

--- a/integrations/unreal/plugin/SignetUnreal/Source/SignetUnrealRuntime/Private/SignetRecallRequest.cpp
+++ b/integrations/unreal/plugin/SignetUnreal/Source/SignetUnrealRuntime/Private/SignetRecallRequest.cpp
@@ -15,6 +15,7 @@ TSharedRef<FJsonObject> BuildNpcBody(
 	Body->SetStringField(TEXT("scope"), Scope);
 	Body->SetNumberField(TEXT("limit"), FMath::Clamp(Limit, MinimumNpcLimit, MaximumNpcLimit));
 	Body->SetBoolField(TEXT("includeRecalled"), true);
+	Body->SetStringField(TEXT("recallSurface"), TEXT("tool_call"));
 	return Body;
 }
 }

--- a/integrations/unreal/plugin/SignetUnreal/Source/SignetUnrealRuntime/Private/Tests/SignetRecallRequestTest.cpp
+++ b/integrations/unreal/plugin/SignetUnreal/Source/SignetUnrealRuntime/Private/Tests/SignetRecallRequestTest.cpp
@@ -57,6 +57,7 @@ bool FSignetRecallRequestContractTest::RunTest(const FString& Parameters)
 	TestEqual(TEXT("Custom world scope is preserved"), Body->GetStringField(TEXT("scope")), FString(TEXT("world:alpha")));
 	TestEqual(TEXT("NPC limit is clamped"), static_cast<int32>(Body->GetNumberField(TEXT("limit"))), SignetRecallRequest::MaximumNpcLimit);
 	TestTrue(TEXT("includeRecalled is serialized"), Body->GetBoolField(TEXT("includeRecalled")));
+	TestEqual(TEXT("tool recall surface is serialized"), Body->GetStringField(TEXT("recallSurface")), FString(TEXT("tool_call")));
 	return true;
 }
 

--- a/libs/sdk/src/__tests__/client.test.ts
+++ b/libs/sdk/src/__tests__/client.test.ts
@@ -121,7 +121,7 @@ describe("SignetClient", () => {
 		});
 	});
 
-	test("recall() returns the daemon recall shape and applies minScore client-side", async () => {
+	test("recall() returns the daemon recall shape and reapplies minScore defensively", async () => {
 		const { client } = mockDaemon((req) => {
 			if (req.path === "/api/memory/recall") {
 				return {
@@ -200,6 +200,7 @@ describe("SignetClient", () => {
 		expect(req.body).toEqual({
 			query: "confidence",
 			limit: 5,
+			minScore: 0.8,
 			until: "2026-04-03T00:00:00Z",
 			project: "proj-a",
 			keywordQuery: "confidence",

--- a/libs/sdk/src/__tests__/helpers.test.ts
+++ b/libs/sdk/src/__tests__/helpers.test.ts
@@ -168,7 +168,7 @@ describe("SignetClientHelpers", () => {
 		expect(result.meta.totalReturned).toBe(1);
 	});
 
-	test("recallOrThrow() throws when client-side minScore filtering removes all results", async () => {
+	test("recallOrThrow() throws when minScore filtering removes all results", async () => {
 		const { client } = mockDaemon(() => ({
 			results: [
 				{
@@ -199,7 +199,7 @@ describe("SignetClientHelpers", () => {
 		await expect(client.recallOrThrow("nonexistent", { minScore: 0.5 })).rejects.toThrow(
 			'No memories found for query: "nonexistent"',
 		);
-		expect(lastRequest().body).toEqual({ query: "nonexistent", limit: 10 });
+		expect(lastRequest().body).toEqual({ query: "nonexistent", limit: 10, minScore: 0.5 });
 	});
 
 	test("getMemoryOrThrow() returns memory when found", async () => {

--- a/libs/sdk/src/__tests__/openai.test.ts
+++ b/libs/sdk/src/__tests__/openai.test.ts
@@ -95,6 +95,7 @@ describe("executeMemoryTool", () => {
 		expect(calls[0].method).toBe("recall");
 		expect(calls[0].args[0]).toBe("preferences");
 		expect(calls[0].args[1]).toEqual({
+			recallSurface: "tool_call",
 			limit: 5,
 			type: "preference",
 			aggregate: true,

--- a/libs/sdk/src/ai-sdk.ts
+++ b/libs/sdk/src/ai-sdk.ts
@@ -61,6 +61,7 @@ export async function memoryTools(client: SignetClient) {
 					sessionKey,
 					agentId,
 					includeRecalled,
+					recallSurface: "tool_call",
 				});
 			},
 		},

--- a/libs/sdk/src/helpers.ts
+++ b/libs/sdk/src/helpers.ts
@@ -133,7 +133,10 @@ export class SignetClientHelpers {
 	async recallOrThrow(query: string, opts?: SdkRecallOptions): Promise<RecallResponse> {
 		const { minScore, ...requestOptions } = opts ?? {};
 		const result = applyRecallMinScore(
-			await this.transport.post<RecallResponse>("/api/memory/recall", buildRecallRequestBody(query, requestOptions)),
+			await this.transport.post<RecallResponse>(
+				"/api/memory/recall",
+				buildRecallRequestBody(query, { ...requestOptions, minScore }),
+			),
 			minScore,
 		);
 

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -151,7 +151,10 @@ export class SignetClient extends SignetClientHelpers {
 	async recall(query: string, opts?: SdkRecallOptions): Promise<RecallResponse> {
 		const { minScore, ...requestOptions } = opts ?? {};
 		return applyRecallMinScore(
-			await this.transport.post<RecallResponse>("/api/memory/recall", buildRecallRequestBody(query, requestOptions)),
+			await this.transport.post<RecallResponse>(
+				"/api/memory/recall",
+				buildRecallRequestBody(query, { ...requestOptions, minScore }),
+			),
 			minScore,
 		);
 	}

--- a/libs/sdk/src/openai.ts
+++ b/libs/sdk/src/openai.ts
@@ -155,6 +155,7 @@ export async function executeMemoryTool(
 	switch (toolName) {
 		case "memory_search":
 			return client.recall(requireString(args, "query"), {
+				recallSurface: "tool_call",
 				limit: optionalNumber(args, "limit"),
 				type: optionalString(args, "type"),
 				aggregate: optionalBoolean(args, "aggregate"),

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -150,7 +150,9 @@ export interface SdkRecallOptions {
 	readonly aggregate_budget?: "small" | "medium" | "large";
 	readonly saveAggregate?: boolean;
 	readonly save_aggregate?: boolean;
-	/** Applied to returned rows by the SDK; never sent to the daemon. */
+	/** Internal bounded attribution for first-party tool integrations. */
+	readonly recallSurface?: "explicit_api" | "tool_call" | "prompt_injection" | "dashboard" | "other";
+	/** Applied at the daemon response boundary; the SDK also re-applies it defensively. */
 	readonly minScore?: number;
 }
 
@@ -503,6 +505,17 @@ export interface TelemetryStatsEnabledResponse {
 	};
 	readonly recall: {
 		readonly calls: number;
+		readonly outcomes: {
+			readonly attempted: number;
+			readonly returned: number;
+			readonly delivered: number;
+			readonly bySurface: readonly {
+				readonly surface: string;
+				readonly attempted: number;
+				readonly returned: number;
+				readonly delivered: number;
+			}[];
+		};
 		readonly p50: number;
 		readonly p95: number;
 		readonly byType: readonly {

--- a/platform/core/contracts/recall-request-v1.json
+++ b/platform/core/contracts/recall-request-v1.json
@@ -13,6 +13,21 @@
 			}
 		},
 		{
+			"name": "bounded-score-and-surface",
+			"clients": ["core", "sdk"],
+			"query": "graph",
+			"options": {
+				"minScore": 0.8,
+				"recallSurface": "tool_call"
+			},
+			"expected": {
+				"query": "graph",
+				"limit": 10,
+				"minScore": 0.8,
+				"recallSurface": "tool_call"
+			}
+		},
+		{
 			"name": "lower-limit-bound",
 			"clients": ["core", "openclaw", "opencode", "sdk", "hermes"],
 			"query": "graph",
@@ -174,7 +189,8 @@
 			"minimumLimit": 1,
 			"maximumLimit": 20,
 			"includeRecalled": true,
-			"scope": "world-or-player"
+			"scope": "world-or-player",
+			"recallSurface": "tool_call"
 		}
 	}
 }

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -177,6 +177,7 @@ export type {
 	RecallPayload,
 	RecallRequestOptions,
 	RecallRow,
+	RecallSurface,
 	RecallScoreFilterRow,
 	RecallTemporalMeta,
 	RecallTimeOptions,

--- a/platform/core/src/recall.test.ts
+++ b/platform/core/src/recall.test.ts
@@ -99,10 +99,11 @@ describe("recall surface helpers", () => {
 		expect(text).not.toContain("No matching memories found.");
 	});
 
-	it("builds recall request bodies without forwarding client-side score thresholds", () => {
+	it("builds recall request bodies with bounded score thresholds", () => {
 		expect(
 			buildRecallRequestBody("graph", {
 				limit: 5,
+				minScore: 0.8,
 				keyword_query: "graph OR entity",
 				pinned: false,
 				expand: false,
@@ -114,6 +115,7 @@ describe("recall surface helpers", () => {
 			query: "graph",
 			keywordQuery: "graph OR entity",
 			limit: 5,
+			minScore: 0.8,
 			agentId: "default",
 			sessionKey: "sess-1",
 			includeRecalled: true,
@@ -124,6 +126,14 @@ describe("recall surface helpers", () => {
 		expect(buildRecallRequestBody("graph")).toEqual({
 			query: "graph",
 			limit: 10,
+		});
+	});
+
+	it("forwards only the bounded recall surface attribution", () => {
+		expect(buildRecallRequestBody("graph", { recallSurface: "tool_call" })).toEqual({
+			query: "graph",
+			limit: 10,
+			recallSurface: "tool_call",
 		});
 	});
 

--- a/platform/core/src/recall.ts
+++ b/platform/core/src/recall.ts
@@ -145,7 +145,17 @@ export interface RecallRequestOptions {
 	readonly aggregate_budget?: AggregateRecallBudget;
 	readonly saveAggregate?: boolean;
 	readonly save_aggregate?: boolean;
+	/** Optional score threshold applied at the daemon response boundary. */
+	readonly minScore?: number;
+	/** Internal bounded attribution for first-party recall surfaces. */
+	readonly recallSurface?: RecallSurface;
 }
+
+/**
+ * Coarse recall origin used by anonymous retrieval-outcome telemetry.
+ * Keep this an enum: it must never carry a harness, agent, or client name.
+ */
+export type RecallSurface = "explicit_api" | "tool_call" | "prompt_injection" | "dashboard" | "other";
 
 export interface RememberRequestOptions {
 	readonly type?: string;
@@ -413,6 +423,8 @@ export function buildRecallRequestBody(query: string, options: RecallRequestOpti
 				: options.saveAggregate === true || options.save_aggregate === true
 					? true
 					: undefined,
+		minScore: typeof options.minScore === "number" && Number.isFinite(options.minScore) ? options.minScore : undefined,
+		recallSurface: options.recallSurface,
 	});
 }
 

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -84,6 +84,7 @@ import {
 	buildEntityPromptContext,
 } from "./prompt-entity-context";
 import { buildRecallQueryShape, queryAnchorsMissingFromRecall, stripUntrustedMetadata } from "./prompt-text";
+import { recordRecallAttempt, recordRecallOutcome } from "./recall-telemetry";
 import { listSecrets } from "./secrets";
 import {
 	flushPendingCheckpoints,
@@ -1706,6 +1707,10 @@ export async function handleUserPromptSubmit(
 		);
 	}
 
+	let promptRecallAttempted = false;
+	let promptRecallOutcomeRecorded = false;
+	recordRecallAttempt("prompt_injection");
+	promptRecallAttempted = true;
 	try {
 		const cfg = deps.loadMemoryConfig(getAgentsDir());
 		const injectBudget = submitCfg.maxInjectChars ?? cfg.pipelineV2.guardrails.contextBudgetChars;
@@ -1730,6 +1735,12 @@ export async function handleUserPromptSubmit(
 				startedAt: start,
 				engine: entityContext.engine,
 			});
+			recordRecallOutcome({
+				surface: "prompt_injection",
+				resultCount: 0,
+				delivery: "not_delivered",
+			});
+			promptRecallOutcomeRecorded = true;
 			return finalizeUserPromptSubmitSuccess(
 				req,
 				userMessage,
@@ -1757,12 +1768,19 @@ export async function handleUserPromptSubmit(
 			engine: "entity-context",
 		});
 		const pluginContext = buildPluginPromptContributionSection("user-prompt-submit", deps.logger);
+		const inject = buildEntityContextInject(metadataHeader, entityContext.lines, pluginContext);
+		recordRecallOutcome({
+			surface: "prompt_injection",
+			resultCount: entityContext.memoryCount,
+			delivery: "injected",
+		});
+		promptRecallOutcomeRecorded = true;
 		return finalizeUserPromptSubmitSuccess(
 			req,
 			userMessage,
 			start,
 			{
-				inject: buildEntityContextInject(metadataHeader, entityContext.lines, pluginContext),
+				inject,
 				memoryCount: entityContext.memoryCount,
 				queryTerms: keywordTerms.join(" ") || undefined,
 				engine: "entity-context",
@@ -1771,6 +1789,9 @@ export async function handleUserPromptSubmit(
 			deps.logger,
 		);
 	} catch (e) {
+		if (promptRecallAttempted && !promptRecallOutcomeRecorded) {
+			recordRecallOutcome({ surface: "prompt_injection", error: true, delivery: "not_delivered" });
+		}
 		deps.logger.error("hooks", "User prompt submit failed", e as Error);
 		return {
 			inject: "",

--- a/platform/daemon/src/mcp/tools.test.ts
+++ b/platform/daemon/src/mcp/tools.test.ts
@@ -660,7 +660,7 @@ describe("createMcpServer", () => {
 			expect(body.aggregate).toBe(true);
 			expect(body.aggregateBudget).toBe("medium");
 			expect(body.saveAggregate).toBe(false);
-			expect(body.min_score).toBeUndefined();
+			expect(body.minScore).toBe(0.8);
 			expect(body.score_min).toBeUndefined();
 			expect(result.isError).toBeUndefined();
 			expect(result.content[0]?.text).toContain("Found 1 memory (hybrid).");
@@ -867,6 +867,7 @@ describe("createMcpServer", () => {
 			expect(body.sessionKey).toBe("session-a");
 			expect(body.agentId).toBe("agent-a");
 			expect(body.includeRecalled).toBe(true);
+			expect(body.recallSurface).toBe("tool_call");
 			expect(body.sourceOnly).toBe(true);
 			expect(result.isError).toBeUndefined();
 			expect(result.content[0]?.text).toContain("Source-backed context");

--- a/platform/daemon/src/mcp/tools.ts
+++ b/platform/daemon/src/mcp/tools.ts
@@ -908,7 +908,10 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					.number()
 					.optional()
 					.describe("Deprecated compatibility alias for importance_min; ignored when importance_min is also set"),
-				score_min: z.number().optional().describe("Minimum recall score threshold (client-side)"),
+				score_min: z
+					.number()
+					.optional()
+					.describe("Minimum recall score threshold; applied by the daemon and checked defensively by the adapter"),
 				aggregate: z.boolean().optional().describe("Synthesize an aggregate answer from bounded recall evidence"),
 				aggregate_budget: z.enum(["small", "medium", "large"]).optional().describe("Aggregate recall budget"),
 				save_aggregate: z.boolean().optional().describe("Save the aggregate answer as a memory"),
@@ -962,6 +965,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					agentId: agent_id,
 					includeRecalled: include_recalled,
 					scope,
+					minScore: score_min,
+					recallSurface: "tool_call",
 				}),
 			});
 
@@ -1000,7 +1005,10 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					.optional()
 					.describe("Temporal recall range/facet options for date and timeline queries"),
 				keyword_query: z.string().optional().describe("Override the keyword/FTS query used for recall"),
-				score_min: z.number().optional().describe("Minimum recall score threshold (client-side)"),
+				score_min: z
+					.number()
+					.optional()
+					.describe("Minimum recall score threshold; applied by the daemon and checked defensively by the adapter"),
 				aggregate: z.boolean().optional().describe("Synthesize an aggregate answer from bounded recall evidence"),
 				aggregate_budget: z.enum(["small", "medium", "large"]).optional().describe("Aggregate recall budget"),
 				save_aggregate: z.boolean().optional().describe("Save the aggregate answer as a memory"),
@@ -1049,6 +1057,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					agentId: agent_id,
 					includeRecalled: include_recalled,
 					scope,
+					minScore: score_min,
+					recallSurface: "tool_call",
 				}),
 			});
 
@@ -1083,6 +1093,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 						sessionKey: session_key,
 						agentId: agent_id,
 						includeRecalled: include_recalled,
+						recallSurface: "tool_call",
 					}),
 					sourceOnly: true,
 				},

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -17,6 +17,7 @@ import {
 	type AgentRosterReadPolicy,
 	LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE,
 	type LlmUsage,
+	type RecallSurface,
 	type RecallTemporalMeta,
 	SOURCE_CHUNK_SOURCE_TYPE,
 	vectorSearch,
@@ -97,6 +98,8 @@ export interface RecallParams {
 	excludeAggregateRecallMemories?: boolean;
 	/** Internal escape hatch for hooks that must track only injected rows elsewhere. */
 	trackRecallAccess?: boolean;
+	/** Anonymous retrieval-outcome attribution; never carries caller text. */
+	telemetrySurface?: RecallSurface;
 }
 
 export interface RecallResult {
@@ -1280,6 +1283,7 @@ export async function hybridRecall(
 		const telemetryType = classifyRecallTelemetry(response);
 		getActiveTelemetry()?.record("recall.performed", {
 			...(telemetryType ? { type: telemetryType } : {}),
+			surface: params.telemetrySurface ?? "other",
 			results: response.results.length,
 			latencyMs: recallTimings.totalMs,
 			truncated: response.results.length >= limit,

--- a/platform/daemon/src/recall-telemetry.test.ts
+++ b/platform/daemon/src/recall-telemetry.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	effectiveRecallLimit,
+	normalizeRecallSurface,
+	recallResultState,
+	recordRecallAttempt,
+	recordRecallOutcome,
+} from "./recall-telemetry";
+import { setActiveTelemetry } from "./telemetry";
+
+describe("recall outcome telemetry", () => {
+	const events: Array<{ event: string; properties: Record<string, unknown> }> = [];
+
+	afterEach(() => {
+		events.length = 0;
+		setActiveTelemetry(undefined);
+	});
+
+	it("normalizes surfaces and result states to bounded enums", () => {
+		expect(normalizeRecallSurface("tool_call")).toBe("tool_call");
+		expect(normalizeRecallSurface("agent-name", "explicit_api")).toBe("explicit_api");
+		expect(recallResultState(0)).toBe("empty");
+		expect(recallResultState(2)).toBe("non_empty");
+		expect(recallResultState(2, true)).toBe("truncated");
+		expect(effectiveRecallLimit(undefined)).toBe(10);
+		expect(effectiveRecallLimit(50)).toBe(50);
+		expect(effectiveRecallLimit(100)).toBe(50);
+	});
+
+	it("records attempt and delivery boundaries without content or identity", () => {
+		setActiveTelemetry({
+			record: (event, properties) => events.push({ event, properties: { ...properties } }),
+		} as never);
+
+		recordRecallAttempt("prompt_injection");
+		recordRecallOutcome({
+			surface: "prompt_injection",
+			resultCount: 3,
+			delivery: "injected",
+		});
+
+		expect(events).toEqual([
+			{ event: "recall.attempted", properties: { surface: "prompt_injection" } },
+			{
+				event: "recall.outcome",
+				properties: {
+					surface: "prompt_injection",
+					resultState: "non_empty",
+					deliveryState: "injected",
+					results: 3,
+				},
+			},
+		]);
+		for (const event of events) {
+			expect(Object.keys(event.properties)).not.toContain("query");
+			expect(Object.keys(event.properties)).not.toContain("prompt");
+			expect(Object.keys(event.properties)).not.toContain("memoryId");
+		}
+	});
+
+	it("forces failed outcomes to not delivered", () => {
+		setActiveTelemetry({
+			record: (event, properties) => events.push({ event, properties: { ...properties } }),
+		} as never);
+		recordRecallOutcome({ surface: "tool_call", delivery: "consumed", error: true });
+
+		expect(events[0]).toEqual({
+			event: "recall.outcome",
+			properties: {
+				surface: "tool_call",
+				resultState: "error",
+				deliveryState: "not_delivered",
+				results: 0,
+			},
+		});
+	});
+});

--- a/platform/daemon/src/recall-telemetry.ts
+++ b/platform/daemon/src/recall-telemetry.ts
@@ -1,0 +1,62 @@
+import type { RecallSurface } from "@signet/core";
+import { getActiveTelemetry } from "./telemetry";
+
+export type RecallResultState = "empty" | "non_empty" | "truncated" | "error";
+export type RecallDeliveryState = "returned" | "injected" | "consumed" | "not_delivered";
+
+const RECALL_SURFACES: ReadonlySet<string> = new Set<RecallSurface>([
+	"explicit_api",
+	"tool_call",
+	"prompt_injection",
+	"dashboard",
+	"other",
+]);
+
+/** Resolve untrusted request metadata to the bounded telemetry vocabulary. */
+export function normalizeRecallSurface(value: unknown, fallback: RecallSurface = "other"): RecallSurface {
+	return typeof value === "string" && RECALL_SURFACES.has(value) ? (value as RecallSurface) : fallback;
+}
+
+export function recallResultState(resultCount: number, truncated = false): Exclude<RecallResultState, "error"> {
+	if (resultCount <= 0) return "empty";
+	return truncated ? "truncated" : "non_empty";
+}
+
+/** Keep funnel truncation comparisons aligned with the recall engine cap. */
+export function effectiveRecallLimit(value: unknown): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return 10;
+	return Math.min(50, Math.max(1, Math.trunc(value)));
+}
+
+function boundedResultCount(value: number): number {
+	return Number.isFinite(value) ? Math.min(100, Math.max(0, Math.trunc(value))) : 0;
+}
+
+/** Record a retrieval attempt without accepting query or caller-identifying data. */
+export function recordRecallAttempt(surface: RecallSurface): void {
+	getActiveTelemetry()?.record("recall.attempted", { surface });
+}
+
+/**
+ * Record the result and delivery boundary for one supported recall surface.
+ * The event deliberately contains only bounded enums and a result count.
+ */
+export function recordRecallOutcome(input: {
+	readonly surface: RecallSurface;
+	readonly resultCount?: number;
+	readonly truncated?: boolean;
+	readonly delivery: RecallDeliveryState;
+	readonly error?: boolean;
+}): void {
+	const resultCount = boundedResultCount(input.resultCount ?? 0);
+	const resultState: RecallResultState = input.error
+		? "error"
+		: recallResultState(resultCount, input.truncated === true);
+	const deliveryState = input.error ? "not_delivered" : input.delivery;
+	getActiveTelemetry()?.record("recall.outcome", {
+		surface: input.surface,
+		resultState,
+		deliveryState,
+		results: resultCount,
+	});
+}

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -59,6 +59,7 @@ import {
 	isNotificationCompatibleHook,
 } from "../notifications/cross-agent-notifications";
 import { getSynthesisWorker, readLastSynthesisTime } from "../pipeline";
+import { effectiveRecallLimit, recordRecallAttempt, recordRecallOutcome } from "../recall-telemetry";
 import { isNoiseSession } from "../session-noise";
 import { advanceRecallContextEpoch } from "../session-recall-dedupe";
 import {
@@ -290,6 +291,8 @@ function registerSessionStart(app: Hono): void {
 		if (isInternalCall(c)) {
 			return c.json({ inject: "", memories: [] });
 		}
+		let recallAttempted = false;
+		let recallOutcomeRecorded = false;
 		try {
 			const body = (await c.req.json()) as SessionStartRequest;
 
@@ -348,16 +351,26 @@ function registerSessionStart(app: Hono): void {
 				return c.json({ sessionKnown: true });
 			}
 
+			recordRecallAttempt("prompt_injection");
+			recallAttempted = true;
 			const result = await handleSessionStart(body);
-			return c.json(
-				withCrossAgentNotifications(result, {
-					harness: body.harness,
-					hook: "SessionStart",
-					agentId: scopedAgent.agentId,
-					sessionKey: parseOptionalString(body.sessionKey),
-				}),
-			);
+			const response = withCrossAgentNotifications(result, {
+				harness: body.harness,
+				hook: "SessionStart",
+				agentId: scopedAgent.agentId,
+				sessionKey: parseOptionalString(body.sessionKey),
+			});
+			recordRecallOutcome({
+				surface: "prompt_injection",
+				resultCount: result.memories.length,
+				delivery: result.memories.length > 0 ? "injected" : "not_delivered",
+			});
+			recallOutcomeRecorded = true;
+			return c.json(response);
 		} catch (e) {
+			if (recallAttempted && !recallOutcomeRecorded) {
+				recordRecallOutcome({ surface: "prompt_injection", error: true, delivery: "not_delivered" });
+			}
 			logger.error("hooks", "Session start hook failed", e as Error);
 			return c.json({ error: "Hook execution failed" }, 500);
 		}
@@ -822,6 +835,7 @@ function registerRecall(app: Hono): void {
 		if (isInternalCall(c)) {
 			return c.json(emptyHookRecallResponse("", { internal: true }));
 		}
+		let recallAttempted = false;
 		try {
 			const body = (await c.req.json()) as RecallRequest;
 
@@ -884,6 +898,7 @@ function registerRecall(app: Hono): void {
 
 			const agentScope = getAgentScope(agentId);
 			const cfg = loadMemoryConfig(AGENTS_DIR);
+			const recallSurface = "tool_call" as const;
 			if (body.aggregate === true && authConfig.mode !== "local") {
 				const actor = c.get("auth")?.claims?.sub ?? "anonymous";
 				const check = authRecallLlmLimiter.check(actor);
@@ -896,6 +911,8 @@ function registerRecall(app: Hono): void {
 			const requestedProject = parseOptionalString(body.project);
 			const scopedP = resolveScopedProject(c, requestedProject);
 			if (scopedP.error) return c.json({ error: scopedP.error }, 403);
+			recordRecallAttempt(recallSurface);
+			recallAttempted = true;
 			const project = scopedP.project ?? requestedProject;
 			const params: RecallParams = {
 				query: body.query,
@@ -921,6 +938,7 @@ function registerRecall(app: Hono): void {
 				includeRecalled: body.includeRecalled === true,
 				recallSurface: "api.hooks.recall",
 				recallMode: "hook",
+				telemetrySurface: recallSurface,
 			};
 			const result =
 				body.aggregate === true
@@ -929,8 +947,15 @@ function registerRecall(app: Hono): void {
 							embedFn: recallAttributedEmbedFn(fetchEmbedding, agentId),
 						})
 					: await hybridRecall(params, cfg, recallAttributedEmbedFn(fetchEmbedding, agentId));
+			recordRecallOutcome({
+				surface: recallSurface,
+				resultCount: result.results.length,
+				truncated: result.results.length >= effectiveRecallLimit(params.limit),
+				delivery: "returned",
+			});
 			return c.json(withHookRecallCompat(result));
 		} catch (e) {
+			if (recallAttempted) recordRecallOutcome({ surface: "tool_call", error: true, delivery: "not_delivered" });
 			logger.error("hooks", "Recall hook failed", e as Error);
 			return c.json({ error: "Hook execution failed" }, 500);
 		}

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { vectorSearch } from "@signet/core";
+import { applyRecallScoreThreshold, vectorSearch } from "@signet/core";
 import type { Context, Hono } from "hono";
 import { ensureAgentRegistered, getAgentScope, resolveAgentId } from "../agent-id";
 import { aggregateRecall, parseAggregateRecallBudget, readAggregateRecallBudgetInput } from "../aggregate-recall";
@@ -34,6 +34,12 @@ import { resolveMemorySearchTelemetryProject } from "../memory-search-telemetry-
 import { buildMemoryTimeline } from "../memory-timeline";
 import { recordPathFeedback } from "../path-feedback";
 import { enqueueDocumentIngestJob } from "../pipeline";
+import {
+	effectiveRecallLimit,
+	normalizeRecallSurface,
+	recordRecallAttempt,
+	recordRecallOutcome,
+} from "../recall-telemetry";
 import { parseFeedback, recordAgentFeedback } from "../session-memories";
 import { upsertSessionTranscript } from "../session-transcripts";
 import { getActiveTelemetry } from "../telemetry";
@@ -1023,7 +1029,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const query = c.req.query("q") ?? "";
 		const distinct = c.req.query("distinct");
 		const limitParam = c.req.query("limit");
-		const limit = limitParam ? Number.parseInt(limitParam, 10) : null;
+		const parsedLimit = limitParam ? Number.parseInt(limitParam, 10) : undefined;
 
 		// Shortcut: return distinct values for a column
 		if (distinct === "who") {
@@ -1050,6 +1056,10 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		};
 
 		const hasFilters = Object.values(filterParams).some((v) => v !== "" && v !== false && v !== null);
+		if (!query.trim() && !hasFilters) return c.json({ results: [] });
+		const limit = effectiveRecallLimit(parsedLimit ?? (query.trim() ? 20 : 50));
+		const recallSurface = normalizeRecallSurface(c.req.header("x-signet-recall-surface"), "dashboard");
+		recordRecallAttempt(recallSurface);
 
 		try {
 			const results = getDbAccessor().withReadDb((db) => {
@@ -1068,7 +1078,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
             JOIN memories m ON memories_fts.rowid = m.rowid
             WHERE memories_fts MATCH ?${clause}
             ORDER BY score
-            LIMIT ${limit ?? 20}
+							LIMIT ${limit}
           `,
 						).all(query, ...args);
 					} catch {
@@ -1081,7 +1091,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
             FROM memories
             WHERE (content LIKE ? OR tags LIKE ?)${rc}
             ORDER BY created_at DESC
-            LIMIT ${limit ?? 20}
+							LIMIT ${limit}
           `,
 						).all(`%${query}%`, `%${query}%`, ...rargs);
 					}
@@ -1099,7 +1109,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
           FROM memories
           WHERE 1=1${clause}
           ORDER BY score DESC
-          LIMIT ${limit ?? 50}
+						LIMIT ${limit}
         `,
 					).all(...args);
 				}
@@ -1107,8 +1117,15 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				return rows;
 			});
 
+			recordRecallOutcome({
+				surface: recallSurface,
+				resultCount: results.length,
+				truncated: results.length >= limit,
+				delivery: "returned",
+			});
 			return c.json({ results });
 		} catch (e) {
+			recordRecallOutcome({ surface: recallSurface, error: true, delivery: "not_delivered" });
 			logger.error("memory", "Error searching memories", e as Error);
 			return c.json({ results: [], error: "Search failed" });
 		}
@@ -3013,6 +3030,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 		const aggregateSaveRequested =
 			body.aggregate === true && body.saveAggregate !== false && body.save_aggregate !== false;
+		const recallLimit = effectiveRecallLimit(body.limit);
 		if (aggregateSaveRequested) {
 			const denied = await requirePermission("remember", authConfig)(c, () => Promise.resolve());
 			if (denied) return denied;
@@ -3031,10 +3049,12 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			}
 			authRecallLlmLimiter.record(actor);
 		}
+		let recallAttempted = false;
 		try {
 			const sessionKeyRaw = body.sessionKey ?? c.req.header("x-signet-session-key");
 			const sessionKey = sessionKeyRaw ?? null;
 			const agentId = resolveAgentId({ agentId: body.agentId, sessionKey: sessionKeyRaw });
+			const recallSurface = normalizeRecallSurface(body.recallSurface, "explicit_api");
 
 			// When aggregate save is requested, enforce scope for non-admin tokens.
 			if (aggregateSaveRequested) {
@@ -3055,11 +3075,14 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				}
 			}
 
+			recordRecallAttempt(recallSurface);
+			recallAttempted = true;
 			const agentScope = getAgentScope(agentId);
 			const scopeProject = c.get("auth")?.claims?.scope?.project;
 			const params = {
 				...body,
 				query,
+				limit: recallLimit,
 				aggregate: body.aggregate,
 				aggregateBudget: aggregateBudget ?? undefined,
 				aggregate_budget: aggregateBudget ?? undefined,
@@ -3070,6 +3093,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				policyGroup: agentScope.policyGroup ?? undefined,
 				sessionKey: sessionKeyRaw,
 				includeRecalled: body.includeRecalled === true,
+				telemetrySurface: recallSurface,
 				recallSurface: "api.memory.recall",
 				recallMode: "direct",
 				...(scopeProject ? { project: scopeProject } : {}),
@@ -3081,18 +3105,31 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 							embedFn: recallAttributedEmbedFn(fetchEmbeddingFn, agentId),
 						})
 					: await hybridRecallFn(params, cfg, recallAttributedEmbedFn(fetchEmbeddingFn, agentId));
+			const requestedMinScore = (body as { readonly minScore?: unknown }).minScore;
+			const returnedResult = applyRecallScoreThreshold(
+				result,
+				typeof requestedMinScore === "number" ? requestedMinScore : undefined,
+			) as typeof result;
 			recordRecallQaTelemetry({
 				route: "POST /api/memory/recall",
 				agentId,
 				sessionKey,
 				project: resolveMemorySearchTelemetryProject(params),
 				params,
-				result,
+				result: returnedResult,
 				cfg,
 			});
+			recordRecallOutcome({
+				surface: recallSurface,
+				resultCount: returnedResult.results.length,
+				truncated: returnedResult.results.length >= recallLimit,
+				delivery: "returned",
+			});
 			recordFirstUseTelemetry("recall");
-			return c.json(result);
+			return c.json(returnedResult);
 		} catch (e) {
+			const recallSurface = normalizeRecallSurface(body.recallSurface, "explicit_api");
+			if (recallAttempted) recordRecallOutcome({ surface: recallSurface, error: true, delivery: "not_delivered" });
 			logger.error("memory", "Recall failed", e as Error);
 			return c.json({ error: "Recall failed", results: [] }, 500);
 		}
@@ -3105,7 +3142,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const q = (c.req.query("q") ?? "").trim();
 		if (!q) return c.json({ error: "query is required" }, 400);
 
-		const limit = Number.parseInt(c.req.query("limit") ?? "10", 10);
+		const limit = effectiveRecallLimit(Number.parseInt(c.req.query("limit") ?? "10", 10));
 		const type = c.req.query("type");
 		const tags = c.req.query("tags");
 		const who = c.req.query("who");
@@ -3127,6 +3164,8 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				agentId: c.req.query("agentId") ?? c.req.query("agent_id") ?? c.req.header("x-signet-agent-id"),
 				sessionKey: sessionKeyRaw,
 			});
+			const recallSurface = "explicit_api" as const;
+			recordRecallAttempt(recallSurface);
 			const agentScope = getAgentScope(agentId);
 			const params = {
 				query: q,
@@ -3145,6 +3184,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				policyGroup: agentScope.policyGroup ?? undefined,
 				sessionKey: sessionKeyRaw,
 				includeRecalled: includeRecalled === "1" || includeRecalled === "true",
+				telemetrySurface: recallSurface,
 				recallSurface: "api.memory.search",
 				recallMode: "direct",
 				...(scopeProject ? { project: scopeProject } : {}),
@@ -3159,8 +3199,15 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				result,
 				cfg,
 			});
+			recordRecallOutcome({
+				surface: recallSurface,
+				resultCount: result.results.length,
+				truncated: result.results.length >= limit,
+				delivery: "returned",
+			});
 			return c.json(result);
 		} catch (e) {
+			recordRecallOutcome({ surface: "explicit_api", error: true, delivery: "not_delivered" });
 			logger.error("memory", "Search (recall alias) failed", e as Error);
 			return c.json({ error: "Recall failed", results: [] }, 500);
 		}

--- a/platform/daemon/src/routes/telemetry-routes.ts
+++ b/platform/daemon/src/routes/telemetry-routes.ts
@@ -215,6 +215,10 @@ export function registerTelemetryRoutes(app: Hono): void {
 		let dreamingCacheWrite = 0;
 		let dreamingCost = 0;
 		let recallCalls = 0;
+		let recallAttempts = 0;
+		let recallReturned = 0;
+		let recallDelivered = 0;
+		const recallOutcomesBySurface = new Map<string, { attempted: number; returned: number; delivered: number }>();
 		const recallLatencies: number[] = [];
 		const recallByType = new Map<string, number>();
 		let sessionEnds = 0;
@@ -278,6 +282,25 @@ export function registerTelemetryRoutes(app: Hono): void {
 					recallByType.set(e.properties.type, (recallByType.get(e.properties.type) ?? 0) + 1);
 				}
 			}
+			if (e.event === "recall.attempted") {
+				recallAttempts++;
+				const surface = typeof e.properties.surface === "string" ? e.properties.surface : "other";
+				const totals = recallOutcomesBySurface.get(surface) ?? { attempted: 0, returned: 0, delivered: 0 };
+				totals.attempted++;
+				recallOutcomesBySurface.set(surface, totals);
+			}
+			if (e.event === "recall.outcome") {
+				const surface = typeof e.properties.surface === "string" ? e.properties.surface : "other";
+				const delivery = e.properties.deliveryState;
+				const returned = delivery === "returned";
+				const delivered = delivery === "injected" || delivery === "consumed";
+				if (returned) recallReturned++;
+				if (delivered) recallDelivered++;
+				const totals = recallOutcomesBySurface.get(surface) ?? { attempted: 0, returned: 0, delivered: 0 };
+				if (returned) totals.returned++;
+				if (delivered) totals.delivered++;
+				recallOutcomesBySurface.set(surface, totals);
+			}
 		}
 
 		latencies.sort((a, b) => a - b);
@@ -309,6 +332,14 @@ export function registerTelemetryRoutes(app: Hono): void {
 			},
 			recall: {
 				calls: recallCalls,
+				outcomes: {
+					attempted: recallAttempts,
+					returned: recallReturned,
+					delivered: recallDelivered,
+					bySurface: [...recallOutcomesBySurface.entries()]
+						.map(([surface, totals]) => ({ surface, ...totals }))
+						.sort((a, b) => a.surface.localeCompare(b.surface)),
+				},
 				p50: recallP50,
 				p95: recallP95,
 				byType: [...recallByType.entries()]

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -81,6 +81,10 @@ export const TELEMETRY_EVENTS = [
 	"cloud.sync",
 	"cloud.storage",
 	"recall.performed",
+	// Retrieval-outcome contract (#1277): attempt and delivery are separate
+	// boundaries so search execution cannot be mistaken for delivered context.
+	"recall.attempted",
+	"recall.outcome",
 	"config.snapshot",
 ] as const;
 

--- a/surfaces/cli/src/commands/memory.test.ts
+++ b/surfaces/cli/src/commands/memory.test.ts
@@ -200,10 +200,11 @@ describe("registerMemoryCommands recall", () => {
 			"--json",
 		]);
 
-		expect(capturedBody).toEqual({
+			expect(capturedBody).toEqual({
 			query: "deploy checklist",
 			keywordQuery: "deploy OR rollback",
 			limit: 10,
+			minScore: 0.8,
 			project: "/tmp/proj",
 			type: "decision",
 			tags: "release",

--- a/surfaces/cli/src/commands/memory.ts
+++ b/surfaces/cli/src/commands/memory.ts
@@ -112,7 +112,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 		.option("--keyword-query <query>", "Override the keyword/FTS query used for recall")
 		.option("--pinned", "Only return pinned memories", false)
 		.option("--importance-min <n>", "Only return memories at or above this importance", Number.parseFloat)
-		.option("--min-score <n>", "Minimum recall score threshold (client-side)", Number.parseFloat)
+		.option("--min-score <n>", "Minimum recall score threshold", Number.parseFloat)
 		.option("--agent <name>", "Filter by agent ID")
 		.option("--aggregate", "Synthesize an aggregate answer from bounded recall evidence", false)
 		.option("--aggregate-budget <budget>", "Aggregate recall budget: small, medium, or large", "small")
@@ -157,6 +157,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 					saveAggregate: aggregateRequested ? options.saveAggregate : undefined,
 					sessionKey: options.sessionKey,
 					includeRecalled: options.includeRecalled,
+					minScore: options.minScore,
 				}),
 				timeoutMs,
 			);

--- a/web/docs/src/content/docs/api/memory/recall-search.md
+++ b/web/docs/src/content/docs/api/memory/recall-search.md
@@ -235,10 +235,10 @@ No additional permission level is required beyond `recall`.
 
 | Client | Canonical default/bounds | Scope surface | Score threshold | Intentional override |
 |---|---|---|---|---|
-| Core, SDK | `10`, `1..100` | Any daemon scope string | SDK `minScore` is local | None |
-| OpenClaw | `10`, `1..100` | Not exposed by its tool schema | `min_score` is local | Product schema exposes a focused subset |
-| OpenCode | `10`, `1..100` | Exact daemon scope string | `min_score` is local | None |
-| Hermes Agent | `10`, `1..100` | Agent opt-in through `agent_scoped` | `score_min` is local | Product schema exposes a focused subset |
+| Core, SDK | `10`, `1..100` | Any daemon scope string | `minScore` is applied at the daemon response boundary and checked defensively by clients | None |
+| OpenClaw | `10`, `1..100` | Not exposed by its tool schema | `min_score` is applied at the daemon response boundary and checked defensively by the adapter | Product schema exposes a focused subset |
+| OpenCode | `10`, `1..100` | Exact daemon scope string | `min_score` is applied at the daemon response boundary and checked defensively by the plugin | None |
+| Hermes Agent | `10`, `1..100` | Agent opt-in through `agent_scoped` | `score_min` is applied at the daemon response boundary and checked defensively by the plugin | Product schema exposes a focused subset |
 | Unreal | NPC default `6`, `1..20` | World/player namespace | Not exposed | Always sets `includeRecalled: true` |
 
 The versioned cross-runtime request vectors live in

--- a/web/docs/src/content/docs/api/telemetry-logs.md
+++ b/web/docs/src/content/docs/api/telemetry-logs.md
@@ -183,9 +183,15 @@ These events intentionally exclude raw prompts, response text, secrets,
 credentials, and session references.
 
 Recall emits `recall.performed` at the shared search boundary. Its properties
-are counts and metadata only: `type` when classification is reliable
-(`semantic`, `keyword`, `temporal`, or `graph`), `results`, `latencyMs`, and
-`truncated`. It never includes query text, memory content, or result snippets.
+are counts and metadata only: `surface`, `type` when classification is
+reliable (`semantic`, `keyword`, `temporal`, or `graph`), `results`,
+`latencyMs`, and `truncated`. Retrieval-outcome telemetry separately emits
+`recall.attempted` and `recall.outcome`. Those events use only bounded surface,
+result-state, delivery-state, and count fields: `explicit_api`, `tool_call`,
+`prompt_injection`, `dashboard`, or `other`; `empty`, `non_empty`,
+`truncated`, or `error`; and `returned`, `injected`, `consumed`, or
+`not_delivered`. They never include query text, prompt text, memory content,
+identifiers, citations, or feedback prose.
 
 ### GET /api/telemetry/stats
 
@@ -249,6 +255,15 @@ Aggregated telemetry statistics since daemon start or since a given timestamp.
   },
   "recall": {
     "calls": 80,
+    "outcomes": {
+      "attempted": 100,
+      "returned": 70,
+      "delivered": 20,
+      "bySurface": [
+        { "surface": "explicit_api", "attempted": 70, "returned": 50, "delivered": 0 },
+        { "surface": "prompt_injection", "attempted": 30, "returned": 0, "delivered": 20 }
+      ]
+    },
     "p50": 42,
     "p95": 310,
     "byType": [

--- a/web/docs/src/content/docs/cli/memory-search.md
+++ b/web/docs/src/content/docs/cli/memory-search.md
@@ -87,7 +87,7 @@ Advanced controls:
 | `--keyword-query <query>` | Override the keyword/FTS query used for recall |
 | `--pinned` | Only return pinned memories |
 | `--importance-min <n>` | Only return memories at or above this importance |
-| `--min-score <n>` | Minimum recall score threshold, applied client-side |
+| `--min-score <n>` | Minimum recall score threshold, applied at the daemon response boundary |
 | `--agent <name>` | Filter by agent ID |
 | `--aggregate` | Synthesize one aggregate answer from bounded recall evidence |
 | `--aggregate-budget <budget>` | Aggregate recall budget: `small`, `medium`, or `large` |

--- a/web/docs/src/content/docs/mcp.md
+++ b/web/docs/src/content/docs/mcp.md
@@ -98,7 +98,7 @@ Advanced controls:
 | `pinned` | boolean | no | Only return pinned memories |
 | `importance_min` | number | no | Minimum memory importance threshold |
 | `min_score` | number | no | Deprecated compatibility alias for `importance_min` |
-| `score_min` | number | no | Minimum recall score threshold, applied client-side to returned rows |
+| `score_min` | number | no | Minimum recall score threshold, applied at the daemon response boundary and checked defensively by the MCP adapter |
 | `aggregate` | boolean | no | Synthesize one aggregate answer from bounded recall evidence |
 | `aggregate_budget` | `"small" \| "medium" \| "large"` | no | Aggregate recall budget; defaults to `small` |
 | `save_aggregate` | boolean | no | Save the aggregate answer as a normal memory; defaults to true when aggregate mode is enabled and requires `remember` permission |

--- a/web/docs/src/content/docs/sdk/core-client.md
+++ b/web/docs/src/content/docs/sdk/core-client.md
@@ -64,16 +64,15 @@ const result = await signet.recall("language preferences", {
 // result.results[n].supplementary — true for supporting context like summary cards
 // result.query — normalized query used by the daemon
 // result.method — "hybrid" | "keyword"
-// result.meta.totalReturned — result count after client-side minScore filtering
+// result.meta.totalReturned — result count after the daemon threshold (also re-applied defensively by the SDK)
 // result.meta.timings — present when the daemon returns recall stage timings
 ```
 
 `recall()` and `recallOrThrow()` use the canonical Signet request builder, so
 they share default, bound, alias, omission, session, agent, scope, and aggregate
-semantics with runtime integrations. `minScore` is applied client-side by the
-SDK after the daemon returns recall results and is never included in daemon
-JSON. This keeps the API contract honest while preserving compatibility for
-existing SDK callers that already rely on score thresholding.
+semantics with runtime integrations. `minScore` is applied at the daemon
+response boundary and re-applied defensively by the SDK, preserving compatibility
+for existing SDK callers that already rely on score thresholding.
 
 Explicit aggregate recall is available through the same method:
 

--- a/web/docs/src/content/docs/sdk/integrations.md
+++ b/web/docs/src/content/docs/sdk/integrations.md
@@ -94,7 +94,7 @@ const context = await getMemoryContext(signet, userMessage, {
   limit: 5,
   minScore: 0.3,
 });
-// Returns "" if no results survive client-side filtering,
+// Returns "" if no results survive score filtering,
 // or "## Relevant Memories\n- ..." otherwise
 ```
 

--- a/web/docs/src/content/docs/sdk/types-migration.md
+++ b/web/docs/src/content/docs/sdk/types-migration.md
@@ -37,7 +37,7 @@ try {
   const { results, meta } = await signet.recallOrThrow("user preferences", {
     type: "preference",
     limit: 5,
-    minScore: 0.5, // applied locally; never sent to the daemon
+    minScore: 0.5, // applied at the daemon response boundary; also checked locally
     agentId: "my-agent",
   });
   // Guaranteed to have at least one result


### PR DESCRIPTION
## Summary

Closes #1277.

Adds privacy-bounded retrieval outcome telemetry so Signet can measure whether recall was attempted, returned results, and reached downstream consumers without recording query content, result content, memory IDs, citations, prompts, agent names, or feedback prose.

## Changes

- Added `recall.attempted` and `recall.outcome` telemetry with empty/non-empty/truncated/error result states and returned/injected/consumed/not-delivered delivery states.
- Instrumented explicit API, tool calls, automatic prompt/session context injection, and dashboard search surfaces.
- Added surface attribution through core, SDK, CLI, MCP, Unreal, OpenCode, OpenClaw, Pi, and Hermes integrations, including bundled Hermes assets.
- Applied score thresholds at the daemon response boundary while retaining defensive client filtering, and covered the shared request contract.
- Extended telemetry stats and public telemetry documentation; preserved existing recall telemetry and dedupe metadata.
- Added privacy, normalization, forwarding, delivery lifecycle, and threshold regression coverage.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [x] `@signet/sdk`
- [x] `@signet/connector-*`
- [x] `@signet/web`
- [ ] `predictor`
- [x] Other: first-party integrations, Unreal plugin, and telemetry documentation

## Screenshots

Not applicable — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations are required.

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

## Testing

- [ ] `bun test` passes (repository-wide run encounters pre-existing shared SQLite/schema and memory-lineage failures; changed-scope tests pass)
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes (repository-wide run reports pre-existing package.json formatting outside this change)
- [ ] Tested against running daemon
- [x] N/A

Changed-scope verification passed:

- `bun test` for core, daemon recall/telemetry, SDK, CLI, OpenClaw, OpenCode, Pi, Hermes, and MCP suites
- `bun run typecheck`
- Core, daemon, SDK, OpenCode, CLI, and connector builds
- `python3 -m py_compile` for source and bundled Hermes clients
- Changed-file Biome checks and `git diff --check`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Telemetry payloads use fixed enums and bounded counts only. Feedback remains opt-in and no feedback endpoint is introduced here. The full repository lint/test results are documented above; failures were outside the changed scope and were not masked by modifying unrelated files.
