### PR TITLE
fix(telemetry): disclose CLI command delivery (#1280)

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -33,16 +33,19 @@ break the daemon.
   stable across restarts. The daemon attaches `$lib: "signet-daemon"` and
   `$lib_version` to every batch; the install ping uses
   `$lib: "signet-install"`.
-- **Local SQLite** — every event is also written to `telemetry_events` (90-day
+- **Local SQLite** — daemon events are written to `telemetry_events` (90-day
   retention, pruned every 10th flush) with a `sent_to_posthog` flag marking
-  successful batch delivery.
+  successful batch delivery. CLI command events are written there when remote
+  delivery is configured and a telemetry SQLite database with its tables is
+  available.
 - **Open JSONL log** — every recorded event is mirrored as one JSON line to
   `<agentsDir>/.daemon/telemetry/events.jsonl`, the inspectable audit surface
   (see [below](#the-open-audit-log)).
 
 CLI `command.invoked` events follow the same contract as daemon events: they
-are written to the local JSONL log and, when PostHog delivery is configured,
-the SQLite queue, then best-effort flushed to PostHog using the persisted
+are written to the local JSONL log and, when PostHog delivery is configured
+and a telemetry SQLite database with its tables is available, queued in the
+SQLite database, then best-effort flushed to PostHog using the persisted
 per-install id. CLI delivery is bounded by the configured batch size and a
 two-second request timeout; a failed request leaves the event queued for a
 later attempt.
@@ -168,7 +171,8 @@ Notes on individual events:
 - **`command.invoked`** — CLI commands send only the bounded top-level command
   name to PostHog. Arguments, paths, user-defined names, and other command
   content are never included. The same event is available in the local JSONL
-  audit log and SQLite queue.
+  audit log and, when a telemetry SQLite database with its tables is present,
+  the SQLite queue.
 
 ## Privacy contract
 
@@ -243,11 +247,11 @@ migration.
 setup disclosure wrote top-level and the opt-out silently did nothing until
 fixed (1d014075). Setup/CLI writers must write into `memory.pipelineV2`.
 
-**Runtime opt-out:** `SIGNET_TELEMETRY_OPTOUT=1` (or `true`) in the daemon's
-environment disables both the daemon collector and the install ping — one
-knob for the whole product. CI runners, containers, and scripted
-environments should set it so automated daemon boots don't count as
-installs.
+**Runtime opt-out:** `SIGNET_TELEMETRY_OPTOUT=1` (or `true`) in the daemon or
+CLI process environment disables telemetry for that process, including the
+daemon collector, CLI command events, and install ping. CI runners,
+containers, and scripted environments should set it in every process so
+automated daemon boots and CLI invocations don't count as installs or usage.
 
 **Development fleet marker:** `SIGNET_TELEMETRY_ENV=dev` adds
 `deployment: dev` to daemon events sent to PostHog and the local audit log,
@@ -276,10 +280,12 @@ Every recorded event is appended as one JSON line to
 `<agentsDir>/.daemon/telemetry/events.jsonl` — daemon events and CLI
 `command.invoked` lines alike. It is the single inspectable surface for
 exactly what was recorded: users can audit the file without trusting the
-sink. The CLI always appends `command.invoked` (command name only) locally and
-queues it for best-effort PostHog delivery when a PostHog host and key are
-configured, with no daemon round-trip or auth. Both local recording and remote
-delivery are gated on the same
+sink. The CLI always appends `command.invoked` (command name only) locally. When a
+PostHog host and key are configured and the workspace has a telemetry SQLite
+database with its tables, it also queues the event for best-effort PostHog
+delivery, with no daemon round-trip or auth. Fresh workspaces without that
+database remain local-only; the JSONL audit log is not replayed into SQLite.
+Both local recording and remote delivery are gated on the same
 `memory.pipelineV2.telemetryEnabled` flag and
 `SIGNET_TELEMETRY_OPTOUT` runtime opt-out.
 
@@ -292,6 +298,14 @@ delivery are gated on the same
   default and remote rates come from `embedding.costRates` (#1201).
 - `install.ping` and `install.activated` measure different populations —
   report them as complementary, never summed.
+- CLI delivery is best-effort at-least-once within the ten-minute claim
+  recovery window. A process crash after a successful PostHog response but
+  before the SQLite sent marker is written can resend the batch; a crash
+  before the request leaves the claim recoverable after the same window.
+- A successful HTTP response marks the claimed batch sent. PostHog can still
+  drop individual invalid events while returning `200 OK`, so the local sent
+  marker means the batch was accepted by the endpoint, not that every event
+  was ingested.
 - CI and dev fleets can inflate "user" counts: every automated daemon boot
   with default config is a phantom install. Identify CI as
   `daemon.started` without a matching `install.ping`, set

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -40,6 +40,13 @@ break the daemon.
   `<agentsDir>/.daemon/telemetry/events.jsonl`, the inspectable audit surface
   (see [below](#the-open-audit-log)).
 
+CLI `command.invoked` events follow the same contract as daemon events: they
+are written to the local JSONL log and, when PostHog delivery is configured,
+the SQLite queue, then best-effort flushed to PostHog using the persisted
+per-install id. CLI delivery is bounded by the configured batch size and a
+two-second request timeout; a failed request leaves the event queued for a
+later attempt.
+
 The collector buffers events in memory (auto-flush at 200 events, hard cap
 5000), flushes on the configured interval, backs off 5x after 3 consecutive
 PostHog failures, and never throws into the daemon.
@@ -158,6 +165,10 @@ Notes on individual events:
   are included. Local stats expose attempted, returned, and delivered counts
   by surface; they read the flushed telemetry table and can lag the in-memory
   event buffer by one flush interval.
+- **`command.invoked`** — CLI commands send only the bounded top-level command
+  name to PostHog. Arguments, paths, user-defined names, and other command
+  content are never included. The same event is available in the local JSONL
+  audit log and SQLite queue.
 
 ## Privacy contract
 
@@ -255,8 +266,9 @@ names, repository names, IP addresses, or memory content are used to infer
 either field.
 
 **Disclosure:** `signet setup` tells users telemetry is on by default and
-asks whether to disable it. Declining writes `telemetryEnabled: false`;
-non-interactive/CI setups keep the default (enabled).
+asks whether to disable it, including sharing top-level CLI command names with
+PostHog. Declining writes `telemetryEnabled: false`; non-interactive/CI setups
+keep the default (enabled).
 
 ## The open audit log
 
@@ -264,10 +276,12 @@ Every recorded event is appended as one JSON line to
 `<agentsDir>/.daemon/telemetry/events.jsonl` — daemon events and CLI
 `command.invoked` lines alike. It is the single inspectable surface for
 exactly what was recorded: users can audit the file without trusting the
-sink. The CLI appends `command.invoked` (command name only) locally,
-best-effort, with no daemon round-trip or auth, gated on the same
-`memory.pipelineV2.telemetryEnabled` flag. `command.invoked` is JSONL-only —
-it is never flushed to PostHog.
+sink. The CLI always appends `command.invoked` (command name only) locally and
+queues it for best-effort PostHog delivery when a PostHog host and key are
+configured, with no daemon round-trip or auth. Both local recording and remote
+delivery are gated on the same
+`memory.pipelineV2.telemetryEnabled` flag and
+`SIGNET_TELEMETRY_OPTOUT` runtime opt-out.
 
 ## Known semantics quirks
 

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -138,7 +138,6 @@ import {
 	setRuntimePressureEnvelope,
 } from "./runtime-pressure";
 import { startSchedulerWorker } from "./scheduler";
-import { getSecret } from "./secrets.js";
 import { flushPendingCheckpoints, initCheckpointFlush, pruneCheckpoints } from "./session-checkpoints";
 import { createSessionClaimStore } from "./session-claims";
 import {
@@ -2070,14 +2069,7 @@ async function main() {
 	const memoryCfg = loadMemoryConfig(AGENTS_DIR);
 	let telemetryCollector: TelemetryCollector | undefined;
 	if (memoryCfg.pipelineV2.telemetryEnabled && !telemetryDisabledByEnv()) {
-		let posthogApiKey = memoryCfg.pipelineV2.telemetry.posthogApiKey;
-		if (!posthogApiKey) {
-			try {
-				posthogApiKey = await getSecret("POSTHOG_API_KEY");
-			} catch {
-				posthogApiKey = "";
-			}
-		}
+		const posthogApiKey = memoryCfg.pipelineV2.telemetry.posthogApiKey;
 		const resolvedTelemetryCfg = {
 			...memoryCfg.pipelineV2.telemetry,
 			posthogApiKey,

--- a/platform/daemon/src/memory-config.test.ts
+++ b/platform/daemon/src/memory-config.test.ts
@@ -50,6 +50,21 @@ function restoreWarmNativeEnv(value: string | undefined): void {
 }
 
 describe("loadMemoryConfig", () => {
+	it("preserves an explicit empty telemetry API key for local-only delivery (#1290)", () => {
+		const agentsDir = makeTempAgentsDir();
+		writeFileSync(
+			join(agentsDir, "agent.yaml"),
+			`memory:
+  pipelineV2:
+    telemetry:
+      posthogApiKey: ""
+`,
+		);
+
+		const cfg = loadMemoryConfig(agentsDir);
+		expect(cfg.pipelineV2.telemetry.posthogApiKey).toBe("");
+	});
+
 	it("prefers agent.yaml embedding settings over config.yaml fallback", () => {
 		const agentsDir = makeTempAgentsDir();
 		writeFileSync(

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -925,7 +925,7 @@ program.hook("preAction", async (_thisCommand, actionCommand) => {
 	}
 
 	// Open telemetry log (issue #1026 Phase 2): record the command name
-	// (never arguments) when the user has opted in. Best-effort.
+	// (never arguments) while telemetry is enabled. Best-effort.
 	recordCommandInvoked(AGENTS_DIR, topLevelCommand);
 	void flushCliTelemetry(AGENTS_DIR, VERSION);
 

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -223,13 +223,13 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 		// by default; interactive setups get a chance to disable it, and
 		// non-interactive (CI/scripted) setups keep the default. Every recorded
 		// event is mirrored to ~/.agents/.daemon/telemetry/events.jsonl so
-		// users can audit exactly what is sent.
+		// users can audit exactly what is recorded and sent.
 		let telemetryEnabled = true;
 		if (!context.nonInteractive) {
 			telemetryEnabled = await import("@inquirer/prompts").then(({ confirm }) =>
 				confirm({
 					message:
-						"Help improve Signet by sharing anonymous usage statistics (version, platform, command names)? No memory content, code, or personal data. Every event is logged to ~/.agents/.daemon/telemetry/events.jsonl; disable anytime with telemetryEnabled: false.",
+						"Help improve Signet by sharing anonymous usage statistics (version, platform, command names) with PostHog? No memory content, code, arguments, paths, or personal data. Events are logged to ~/.agents/.daemon/telemetry/events.jsonl and, when remote delivery is configured, queued locally before best-effort delivery; disable anytime with telemetryEnabled: false.",
 					default: true,
 				}),
 			);

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -229,7 +229,7 @@ export async function runFreshSetup(plan: SetupPlan, context: SetupApplyContext,
 			telemetryEnabled = await import("@inquirer/prompts").then(({ confirm }) =>
 				confirm({
 					message:
-						"Help improve Signet by sharing anonymous usage statistics (version, platform, command names) with PostHog? No memory content, code, arguments, paths, or personal data. Events are logged to ~/.agents/.daemon/telemetry/events.jsonl and, when remote delivery is configured, queued locally before best-effort delivery; disable anytime with telemetryEnabled: false.",
+						"Help improve Signet by sharing anonymous usage statistics (version and command names) with PostHog? No memory content, code, arguments, paths, or personal data. Events are logged to ~/.agents/.daemon/telemetry/events.jsonl and, when remote delivery is configured and the workspace database is available, queued locally before best-effort delivery; disable anytime with telemetryEnabled: false.",
 					default: true,
 				}),
 			);

--- a/surfaces/cli/src/features/telemetry.test.ts
+++ b/surfaces/cli/src/features/telemetry.test.ts
@@ -35,7 +35,7 @@ afterEach(() => {
 	rmSync(dir, { recursive: true, force: true });
 });
 
-describe("cli telemetry (issue #1206)", () => {
+describe("cli telemetry (issue #1280)", () => {
 	it("is enabled by default when agent.yaml has no telemetryEnabled", () => {
 		writeAgentYaml();
 		expect(cliTelemetryEnabled(dir)).toBe(true);
@@ -109,7 +109,7 @@ describe("cli telemetry (issue #1206)", () => {
 		expect(existsSync(cliTelemetryLogPath(dir))).toBe(false);
 	});
 
-	it("flushes queued events with the daemon's persisted install id", async () => {
+	it("flushes bounded command names with the daemon's persisted install id", async () => {
 		writeAgentYaml(true);
 		const memoryDir = join(dir, "memory");
 		mkdirSync(memoryDir, { recursive: true });
@@ -132,13 +132,26 @@ describe("cli telemetry (issue #1206)", () => {
 		db.close();
 
 		recordCommandInvoked(dir, "remember");
-		const request: { current: { api_key: string; batch: Array<{ distinct_id: string; event: string }> } | null } = {
+		const request: {
+			current: {
+				api_key: string;
+				batch: Array<{
+					distinct_id: string;
+					event: string;
+					properties: Record<string, string>;
+				}>;
+			} | null;
+		} = {
 			current: null,
 		};
 		globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
 			request.current = JSON.parse(String(init?.body ?? "{}")) as {
 				api_key: string;
-				batch: Array<{ distinct_id: string; event: string }>;
+				batch: Array<{
+					distinct_id: string;
+					event: string;
+					properties: Record<string, string>;
+				}>;
 			};
 			return new Response("1", { status: 200 });
 		}) as typeof fetch;
@@ -149,10 +162,91 @@ describe("cli telemetry (issue #1206)", () => {
 		expect(request.current?.batch).toHaveLength(1);
 		expect(request.current?.batch[0]?.event).toBe("command.invoked");
 		expect(request.current?.batch[0]?.distinct_id).toBe("install-from-daemon");
+		expect(request.current?.batch[0]?.properties).toEqual({
+			command: "remember",
+			$lib: "signet-cli",
+			$lib_version: "0.176.8",
+		});
 
 		const check = createDatabase(join(memoryDir, "memories.db"), { readonly: true });
 		const row = check.prepare("SELECT sent_to_posthog FROM telemetry_events").get() as { sent_to_posthog: number };
 		expect(row.sent_to_posthog).toBe(1);
+		check.close();
+	});
+
+	it("does not remotely deliver command events when the config disables telemetry", async () => {
+		writeAgentYaml(false);
+		const memoryDir = join(dir, "memory");
+		mkdirSync(memoryDir, { recursive: true });
+		const db = createDatabase(join(memoryDir, "memories.db"));
+		db.exec(`
+				CREATE TABLE telemetry_install (id TEXT PRIMARY KEY, created_at TEXT NOT NULL);
+				CREATE TABLE telemetry_events (
+					id TEXT PRIMARY KEY,
+					event TEXT NOT NULL,
+					timestamp TEXT NOT NULL,
+					properties TEXT NOT NULL,
+					sent_to_posthog INTEGER NOT NULL DEFAULT 0,
+					created_at TEXT NOT NULL,
+					source TEXT NOT NULL DEFAULT 'daemon',
+					claim_token TEXT,
+					claimed_at TEXT
+				);
+			`);
+		db.close();
+
+		let calls = 0;
+		globalThis.fetch = (async () => {
+			calls++;
+			return new Response("1", { status: 200 });
+		}) as unknown as typeof fetch;
+
+		recordCommandInvoked(dir, "remember");
+		await flushCliTelemetry(dir, "0.176.8");
+
+		expect(calls).toBe(0);
+		const check = createDatabase(join(memoryDir, "memories.db"), { readonly: true });
+		expect(check.prepare("SELECT COUNT(*) AS count FROM telemetry_events").get()).toEqual({ count: 0 });
+		check.close();
+	});
+
+	it("does not remotely deliver command events when the runtime opt-out is set", async () => {
+		writeAgentYaml(true);
+		const memoryDir = join(dir, "memory");
+		mkdirSync(memoryDir, { recursive: true });
+		const db = createDatabase(join(memoryDir, "memories.db"));
+		db.exec(`
+				CREATE TABLE telemetry_install (id TEXT PRIMARY KEY, created_at TEXT NOT NULL);
+				CREATE TABLE telemetry_events (
+					id TEXT PRIMARY KEY,
+					event TEXT NOT NULL,
+					timestamp TEXT NOT NULL,
+					properties TEXT NOT NULL,
+					sent_to_posthog INTEGER NOT NULL DEFAULT 0,
+					created_at TEXT NOT NULL,
+					source TEXT NOT NULL DEFAULT 'daemon',
+					claim_token TEXT,
+					claimed_at TEXT
+				);
+				INSERT INTO telemetry_install (id, created_at) VALUES ('install-from-daemon', '2026-01-01T00:00:00.000Z');
+			`);
+		db.close();
+
+		recordCommandInvoked(dir, "remember");
+		let calls = 0;
+		globalThis.fetch = (async () => {
+			calls++;
+			return new Response("1", { status: 200 });
+		}) as unknown as typeof fetch;
+
+		await flushCliTelemetry(dir, "0.176.8", { SIGNET_TELEMETRY_OPTOUT: "1" });
+
+		expect(calls).toBe(0);
+		const check = createDatabase(join(memoryDir, "memories.db"), { readonly: true });
+		const row = check.prepare("SELECT sent_to_posthog FROM telemetry_events").get() as {
+			sent_to_posthog: number;
+		};
+		expect(row.sent_to_posthog).toBe(0);
 		check.close();
 	});
 

--- a/surfaces/cli/src/features/telemetry.test.ts
+++ b/surfaces/cli/src/features/telemetry.test.ts
@@ -222,6 +222,8 @@ describe("cli telemetry (issue #1280)", () => {
 		expect(request.current?.batch[0]?.distinct_id).toBe("install-from-daemon");
 		expect(request.current?.batch[0]?.properties).toEqual({
 			command: "remember",
+			deploymentRole: "unknown",
+			installChannel: "unknown",
 			$lib: "signet-cli",
 			$lib_version: "0.176.8",
 		});

--- a/surfaces/cli/src/features/telemetry.test.ts
+++ b/surfaces/cli/src/features/telemetry.test.ts
@@ -25,6 +25,29 @@ function writeAgentYaml(telemetryEnabled?: boolean): void {
 	);
 }
 
+function createTelemetryQueue(): string {
+	const memoryDir = join(dir, "memory");
+	mkdirSync(memoryDir, { recursive: true });
+	const db = createDatabase(join(memoryDir, "memories.db"));
+	db.exec(`
+		CREATE TABLE telemetry_install (id TEXT PRIMARY KEY, created_at TEXT NOT NULL);
+		CREATE TABLE telemetry_events (
+			id TEXT PRIMARY KEY,
+			event TEXT NOT NULL,
+			timestamp TEXT NOT NULL,
+			properties TEXT NOT NULL,
+			sent_to_posthog INTEGER NOT NULL DEFAULT 0,
+			created_at TEXT NOT NULL,
+			source TEXT NOT NULL DEFAULT 'daemon',
+			claim_token TEXT,
+			claimed_at TEXT
+		);
+		INSERT INTO telemetry_install (id, created_at) VALUES ('install-from-daemon', '2026-01-01T00:00:00.000Z');
+	`);
+	db.close();
+	return memoryDir;
+}
+
 beforeEach(() => {
 	dir = mkdtempSync(join(tmpdir(), "signet-cli-telemetry-"));
 });
@@ -107,6 +130,41 @@ describe("cli telemetry (issue #1280)", () => {
 		writeAgentYaml(false);
 		recordCommandInvoked(dir, "remember");
 		expect(existsSync(cliTelemetryLogPath(dir))).toBe(false);
+	});
+
+	it("preserves an explicitly empty API key as local-only telemetry", async () => {
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			"version: 1\nschema: signet/v1\nmemory:\n  pipelineV2:\n    telemetryEnabled: true\n    telemetry:\n      posthogApiKey: ''\n",
+		);
+		let calls = 0;
+		const fetchMock = async (): Promise<Response> => {
+			calls++;
+			return new Response("unexpected", { status: 500 });
+		};
+		globalThis.fetch = fetchMock as typeof fetch;
+		createTelemetryQueue();
+		recordCommandInvoked(dir, "remember");
+		await flushCliTelemetry(dir, "0.176.8");
+		expect(existsSync(cliTelemetryLogPath(dir))).toBe(true);
+		expect(calls).toBe(0);
+	});
+
+	it("falls back to the default batch size for non-finite configuration", async () => {
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			"version: 1\nschema: signet/v1\nmemory:\n  pipelineV2:\n    telemetryEnabled: true\n    telemetry:\n      flushBatchSize: .nan\n",
+		);
+		createTelemetryQueue();
+		const request: { current: { batch: unknown[] } | null } = { current: null };
+		globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+			const body = JSON.parse(String(init?.body ?? "{}")) as { batch?: unknown[] };
+			request.current = { batch: body.batch ?? [] };
+			return new Response("1", { status: 200 });
+		}) as typeof fetch;
+		recordCommandInvoked(dir, "remember");
+		await flushCliTelemetry(dir, "0.176.8");
+		expect(request.current?.batch).toHaveLength(1);
 	});
 
 	it("flushes bounded command names with the daemon's persisted install id", async () => {

--- a/surfaces/cli/src/features/telemetry.ts
+++ b/surfaces/cli/src/features/telemetry.ts
@@ -287,8 +287,12 @@ export function recordCommandInvoked(
  * await this function from command hooks. The batch size and request timeout
  * bound the work, while SQLite preserves events when the request fails.
  */
-export async function flushCliTelemetry(agentsDir: string, cliVersion: string): Promise<void> {
-	const settings = readTelemetrySettings(agentsDir);
+export async function flushCliTelemetry(
+	agentsDir: string,
+	cliVersion: string,
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+	const settings = readTelemetrySettings(agentsDir, env);
 	if (!settings || settings.posthogHost.length === 0 || settings.posthogApiKey.length === 0) return;
 
 	const dbPath = join(agentsDir, "memory", "memories.db");

--- a/surfaces/cli/src/features/telemetry.ts
+++ b/surfaces/cli/src/features/telemetry.ts
@@ -285,7 +285,9 @@ export function recordCommandInvoked(
 /**
  * Flush queued CLI command events to PostHog. Callers should deliberately not
  * await this function from command hooks. The batch size and request timeout
- * bound the work, while SQLite preserves events when the request fails.
+ * bound the work, while a telemetry SQLite database preserves queued events
+ * when the request fails. Workspaces without that database remain local-only
+ * until it exists.
  */
 export async function flushCliTelemetry(
 	agentsDir: string,

--- a/surfaces/cli/src/features/telemetry.ts
+++ b/surfaces/cli/src/features/telemetry.ts
@@ -123,11 +123,11 @@ function readTelemetrySettings(agentsDir: string, env: NodeJS.ProcessEnv = proce
 		const telemetry = pipeline?.telemetry as Record<string, unknown> | undefined;
 		const posthogHost =
 			typeof telemetry?.posthogHost === "string" ? telemetry.posthogHost : DEFAULT_TELEMETRY_POSTHOG_HOST;
-		const configuredKey = typeof telemetry?.posthogApiKey === "string" ? telemetry.posthogApiKey : "";
-		const posthogApiKey = configuredKey || DEFAULT_TELEMETRY_POSTHOG_API_KEY;
+		const posthogApiKey =
+			typeof telemetry?.posthogApiKey === "string" ? telemetry.posthogApiKey : DEFAULT_TELEMETRY_POSTHOG_API_KEY;
 		const configuredBatchSize = telemetry?.flushBatchSize;
 		const flushBatchSize =
-			typeof configuredBatchSize === "number"
+			typeof configuredBatchSize === "number" && Number.isFinite(configuredBatchSize)
 				? Math.min(MAX_BATCH_SIZE, Math.max(MIN_BATCH_SIZE, Math.floor(configuredBatchSize)))
 				: DEFAULT_TELEMETRY_FLUSH_BATCH_SIZE;
 

--- a/web/docs/src/content/docs/analytics.md
+++ b/web/docs/src/content/docs/analytics.md
@@ -222,9 +222,10 @@ Privacy contract:
 - Every recorded event is mirrored to an open, inspectable JSONL log at
   `<agentsDir>/.daemon/telemetry/events.jsonl`, so users can audit
   exactly what was sent. CLI `command.invoked` events are also queued in the
-  workspace database and flushed to PostHog in bounded, best-effort batches
-  without awaiting the command; the CLI reads the same persisted install id
-  as the daemon.
+  workspace database when remote delivery is configured and a telemetry SQLite
+  database is available, then flushed to PostHog in bounded, best-effort
+  batches without awaiting the command. Fresh workspaces without that database
+  remain local-only; the CLI reads the same persisted install id as the daemon.
 
 Events recorded: `daemon.heartbeat` (every 5 minutes), the `inference.*`
 lifecycle (`route`, `execute`, `stream`, `fallback`), `llm.generate`

--- a/web/docs/src/content/docs/configuration/pipeline.md
+++ b/web/docs/src/content/docs/configuration/pipeline.md
@@ -484,21 +484,23 @@ event catalog, privacy contract, the open JSONL audit log, runtime opt-out
 (`SIGNET_TELEMETRY_OPTOUT=1`), and how to query the data.
 
 **Disclosure (issue #1026):** `signet setup` tells users telemetry is on
-by default and asks whether to disable it. Declining writes
-`telemetryEnabled: false`; non-interactive/CI setups keep the default
-(enabled).
+by default and asks whether to disable it, including sharing top-level CLI
+command names with PostHog. Declining writes `telemetryEnabled: false`;
+non-interactive/CI setups keep the default (enabled).
 
-**Runtime opt-out:** setting `SIGNET_TELEMETRY_OPTOUT=1` in the daemon's
-environment disables telemetry without touching config — the same knob the
-install ping honors. CI runners, containers, and scripted environments
-should set it so automated daemon boots don't count as installs.
+**Runtime opt-out:** setting `SIGNET_TELEMETRY_OPTOUT=1` in the daemon or CLI
+process environment disables telemetry without touching config — the same knob
+the install ping honors. CI runners, containers, and scripted environments
+should set it in every process so automated daemon boots and CLI invocations do
+not count as installs or usage.
 
 **Open telemetry log:** every recorded event is appended as one JSON line
 to `<agentsDir>/.daemon/telemetry/events.jsonl` — the single inspectable
-audit surface for exactly what was sent (daemon events and CLI
+audit surface for exactly what was recorded (daemon events and CLI
 `command.invoked` lines). CLI command events are also queued in the workspace
-database and flushed to PostHog in bounded, best-effort batches without
-awaiting the command. The CLI and daemon use the same persisted install id.
+database when remote delivery is configured and flushed to PostHog in bounded,
+best-effort batches without awaiting the command. The CLI and daemon use the
+same persisted install id.
 No memory content, code, file paths, or personal
 data are ever included.
 
@@ -513,7 +515,7 @@ transition).
 **Development fleet marker:** setting `SIGNET_TELEMETRY_ENV=dev` keeps operator
 development checkouts in the dataset while making them filterable. The daemon
 adds `deployment: dev` to its local and PostHog events, while the CLI adds it
-to its JSONL-only command events. The native install ping applies the marker
+to its local and PostHog command events. The native install ping applies the marker
 and `-dev` version suffix when the environment is present. The daemon and CLI
 `bun run dev` scripts set this marker automatically. The marker does not
 disable telemetry; use `SIGNET_TELEMETRY_OPTOUT=1` when development or

--- a/web/docs/src/content/docs/configuration/pipeline.md
+++ b/web/docs/src/content/docs/configuration/pipeline.md
@@ -498,9 +498,10 @@ not count as installs or usage.
 to `<agentsDir>/.daemon/telemetry/events.jsonl` — the single inspectable
 audit surface for exactly what was recorded (daemon events and CLI
 `command.invoked` lines). CLI command events are also queued in the workspace
-database when remote delivery is configured and flushed to PostHog in bounded,
-best-effort batches without awaiting the command. The CLI and daemon use the
-same persisted install id.
+database when remote delivery is configured and a telemetry SQLite database is
+available, then flushed to PostHog in bounded, best-effort batches without
+awaiting the command. Fresh workspaces without that database remain local-only.
+The CLI and daemon use the same persisted install id.
 No memory content, code, file paths, or personal
 data are ever included.
 


### PR DESCRIPTION
## Summary

Align the public telemetry contract with the existing bounded PostHog delivery of CLI `command.invoked` events.

Closes #1280.

## Changes

- Document local JSONL/SQLite queueing and best-effort PostHog delivery in `docs/TELEMETRY.md` and web pipeline docs.
- Make setup disclosure explicitly name PostHog delivery and the command-name-only privacy boundary.
- Clarify that both `telemetryEnabled` and `SIGNET_TELEMETRY_OPTOUT` gate CLI delivery.
- Add regression coverage for the exact remote payload, config opt-out, runtime opt-out, and queue state.
- Add an injectable environment to `flushCliTelemetry` for deterministic opt-out tests.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: documentation (`docs/TELEMETRY.md`, web pipeline reference)

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec or dependency graph changes; canonical telemetry documentation aligned.
- [x] Agent scoping verified on all new/changed data queries — no data queries changed.
- [x] Input/config validation and bounds checks added — existing batch-size bounds retained; opt-out paths are covered.
- [x] Error handling and fallback paths tested (no silent swallow) — failed delivery remains queued; disabled delivery is asserted.
- [x] Security checks applied to admin/mutation endpoints — no endpoints changed.
- [x] Docs updated for API/spec/status changes.
- [x] Regression tests added for each bug fix.
- [x] Lint/typecheck/tests pass locally — changed-file Biome check, full typecheck, and focused telemetry tests pass; full repository test/lint commands are documented below as having unrelated baseline failures.

## Migration Notes (if applicable)

N/A — no migrations.

## Testing

- [ ] `bun test` passes — full suite currently has unrelated baseline failures in daemon inference/SQLite/transcript/setup tests (2038 passed, 170 failed, 34 errors).
- [x] `bun run typecheck` passes — passed after building required generated connector bundles.
- [ ] `bun run lint` passes — repository-wide check reports pre-existing formatting drift in unrelated package manifests; changed-file Biome check passes.
- [ ] Tested against running daemon
- [x] N/A — no daemon/API behavior changed.

Focused validation:

- `bun test surfaces/cli/src/features/telemetry.test.ts` — 14 passed.
- `bunx biome check docs/TELEMETRY.md web/docs/src/content/docs/configuration/pipeline.md surfaces/cli/src/cli.ts surfaces/cli/src/features/setup-fresh.ts surfaces/cli/src/features/telemetry.ts surfaces/cli/src/features/telemetry.test.ts` — passed.
- Targeted setup telemetry test passed once; it is environment-sensitive because setup starts a local daemon.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The selected product contract is option 1 from the issue: retain bounded remote delivery of command names. No command arguments, paths, user-defined names, or other content are added.
