### PR TITLE
feat(telemetry): add source lifecycle telemetry (#1276)

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -72,6 +72,7 @@ PostHog failures, and never throws into the daemon.
 | `recall.performed` | every completed shared recall search | `surface`, `type` (`semantic` / `keyword` / `temporal` / `graph`), `results`, `latencyMs`, `truncated` |
 | `recall.attempted` | every valid recall request or automatic prompt-context retrieval attempt | `surface` (`explicit_api` / `tool_call` / `prompt_injection` / `dashboard` / `other`) |
 | `recall.outcome` | result and delivery boundary for a recall attempt | `surface`, `resultState` (`empty` / `non_empty` / `truncated` / `error`), `deliveryState` (`returned` / `injected` / `consumed` / `not_delivered`), `results` |
+| `source.lifecycle` | bounded source connect, index, readiness, first-recall, and recurring freshness milestones | `phase`, fixed `sourceClass`, bounded outcomes/counts/buckets |
 | `pipeline.error` | categorized extraction, decision, or embedding failure | `stage`, `code` only; no message or stack content |
 | `dreaming.pass` | every terminal agentic dreaming pass, including no-op, failed, and cancelled passes | `mode`, `outcome`, `outcomeCode`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `cost`, `artifactsConsidered`, `memoriesCreated`, `memoriesUpdated`, `memoriesSuperseded`, `memoriesRetired`, `claimsChanged`, `relationshipsChanged`, `provenanceLinksChanged`, `toolCalls`, `durationMs` |
 | `inference.route` | inference control-plane routing decision | `surface`, `agentId`, `operation`, `taskClass`, `policyId`, `selectedTarget`, `candidateCount`, `blockedCount`, `allowedCount`, `privacy`, `durationMs`, `success`, `errorCode` |
@@ -206,6 +207,12 @@ Notes on individual events:
   content are never included. The same event is available in the local JSONL
   audit log and, when a telemetry SQLite database with its tables is present,
   the SQLite queue.
+- **`source.lifecycle` (#1276)** — emitted at operation boundaries, never once
+  per document, message, chunk, or embedding. `phase` is `connect`, `index`,
+  `readiness`, `first_recall`, or `freshness`; source identity is represented
+  only by fixed source classes and local correlation state. Counts, sizes,
+  durations, and freshness lag use bounded buckets; names, roots, URLs,
+  identifiers, error text, queries, and content are omitted.
 
 ## Privacy contract
 

--- a/platform/core/src/migrations/120-source-lifecycle-telemetry.ts
+++ b/platform/core/src/migrations/120-source-lifecycle-telemetry.ts
@@ -1,0 +1,29 @@
+/**
+ * Migration 120: private source lifecycle state.
+ *
+ * The table is local correlation state only. The source key is a digest of
+ * the configured source identity; it is never copied into telemetry events.
+ */
+import type { MigrationDb } from "./index";
+
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS source_lifecycle_state (
+			agent_id TEXT NOT NULL,
+			source_key TEXT NOT NULL,
+			source_class TEXT NOT NULL,
+			mode TEXT NOT NULL,
+			connected_at TEXT,
+			first_indexed_at TEXT,
+			first_searchable_at TEXT,
+			first_recall_at TEXT,
+			last_success_at TEXT,
+			last_freshness_state TEXT,
+			last_freshness_event_at TEXT,
+			PRIMARY KEY (agent_id, source_key)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_source_lifecycle_state_ready
+			ON source_lifecycle_state(agent_id, source_class, first_searchable_at, first_recall_at);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -125,6 +125,7 @@ import { up as acpDeliveryReconciliation } from "./116-acp-delivery-reconciliati
 import { up as retireSummaryWorker } from "./117-retire-summary-worker";
 import { up as queuePressureIndices } from "./118-queue-pressure-indices";
 import { up as telemetryVersionObservation } from "./119-telemetry-version-observation";
+import { up as sourceLifecycleTelemetry } from "./120-source-lifecycle-telemetry";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1119,6 +1120,12 @@ export const MIGRATIONS: readonly Migration[] = [
 		name: "telemetry-version-observation",
 		up: telemetryVersionObservation,
 		artifacts: { columns: [{ table: "telemetry_install", column: "last_seen_version" }] },
+	},
+	{
+		version: 120,
+		name: "source-lifecycle-telemetry",
+		up: sourceLifecycleTelemetry,
+		artifacts: { tables: ["source_lifecycle_state"] },
 	},
 ];
 

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -222,7 +222,7 @@ import { registerSecretRoutes } from "./routes/secrets-routes.js";
 import { registerSessionRoutes } from "./routes/session-routes.js";
 import { mountSkillAnalyticsRoutes } from "./routes/skill-analytics.js";
 import { mountSkillsRoutes, setFetchEmbedding } from "./routes/skills.js";
-import { cleanupSourceDeletionTombstones, registerSourcesRoutes } from "./routes/sources-routes.js";
+import { cleanupSourceDeletionTombstones, registerSourcesRoutes, stopSourceIndexJobs } from "./routes/sources-routes.js";
 import { registerTelemetryRoutes } from "./routes/telemetry-routes.js";
 import { checkEmbeddingProvider } from "./routes/utils.js";
 import { mountWidgetRoutes } from "./routes/widget.js";
@@ -1698,6 +1698,7 @@ async function cleanup() {
 	stopMemoryImportPoller();
 	stopStaleSessionSweeper();
 	stopAcpDeliveryReconciliation();
+	await stopSourceIndexJobs();
 	if (nativeMemoryBridge) {
 		await nativeMemoryBridge.close();
 		nativeMemoryBridge = null;
@@ -2118,6 +2119,9 @@ async function main() {
 				},
 				usage: null,
 			});
+		}
+		for (const source of loadSourcesConfig(AGENTS_DIR).sources) {
+			if (source.enabled) recordSourceConnected(source, resolveDaemonAgentId());
 		}
 
 		const daemonStartTime = Date.now();

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -156,10 +156,12 @@ import {
 	clearSourceIndexInFlight,
 	completeSourceIndexJobFromProgress,
 	failSourceIndexJob,
+	getSourceIndexJob,
 	markSourceIndexInFlight,
 	markSourceIndexJobRunning,
 	updateSourceIndexJobProgress,
 } from "./source-index-progress";
+import { recordSourceConnected, recordSourceIndexOperation, sourceFailureClass } from "./source-lifecycle-telemetry";
 import { runStartupRecovery } from "./startup-recovery";
 import { getPressureRecoveryOutcome, reportStartupGrace } from "./system-pressure";
 import {
@@ -2330,6 +2332,7 @@ async function main() {
 			const startupSourceJobs = new Map<string, string>();
 			for (const source of loadSourcesConfig(AGENTS_DIR).sources) {
 				if (!source.enabled || source.kind !== "obsidian") continue;
+				recordSourceConnected(source, resolveDaemonAgentId());
 				const job = beginSourceIndexJob(source.id, "source-startup");
 				startupSourceJobs.set(source.id, job.id);
 				markSourceIndexInFlight(source.id);
@@ -2360,10 +2363,42 @@ async function main() {
 				.then(() => {
 					for (const [sourceId, jobId] of startupSourceJobs) {
 						completeSourceIndexJobFromProgress(sourceId, jobId);
+						const source = loadSourcesConfig(AGENTS_DIR).sources.find((entry) => entry.id === sourceId);
+						const job = getSourceIndexJob(sourceId);
+						if (source) {
+							recordSourceIndexOperation({
+								source,
+								agentId: resolveDaemonAgentId(),
+								discovered: job?.scanned ?? 0,
+								accepted: job?.indexed ?? 0,
+								durationMs:
+									job?.startedAt && job.finishedAt
+										? Math.max(0, Date.parse(job.finishedAt) - Date.parse(job.startedAt))
+										: 0,
+								outcome: "success",
+							});
+						}
 					}
 				})
 				.catch((e) => {
-					for (const [sourceId, jobId] of startupSourceJobs) failSourceIndexJob(sourceId, jobId, e);
+					for (const [sourceId, jobId] of startupSourceJobs) {
+						const source = loadSourcesConfig(AGENTS_DIR).sources.find((entry) => entry.id === sourceId);
+						const job = getSourceIndexJob(sourceId);
+						if (source) {
+							recordSourceIndexOperation({
+								source,
+								agentId: resolveDaemonAgentId(),
+								discovered: job?.scanned ?? 0,
+								accepted: job?.indexed ?? 0,
+								failed: 1,
+								durationMs: job?.startedAt ? Math.max(0, Date.now() - Date.parse(job.startedAt)) : 0,
+								outcome: (job?.indexed ?? 0) > 0 ? "partial" : "failed",
+								failureClass: sourceFailureClass(e),
+								searchable: (job?.indexed ?? 0) > 0,
+							});
+						}
+						failSourceIndexJob(sourceId, jobId, e);
+					}
 					const errDetails = e instanceof Error ? { message: e.message, stack: e.stack } : { error: String(e) };
 					logger.error("daemon", "Failed to sync native memory sources", undefined, errDetails);
 				})

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -49,6 +49,7 @@ import {
 	scoreStructuredPathEvidence,
 } from "./pipeline/structured-path-evidence";
 import { type RecallDedupeMeta, applyRecallDedupe } from "./session-recall-dedupe";
+import { recordFirstSourceRecall } from "./source-lifecycle-telemetry";
 import { escapeLike } from "./sql-utils";
 import { getActiveTelemetry } from "./telemetry";
 import { type TemporalTimeOptions, hasFreshnessIntent, resolveTemporalRecall } from "./temporal-recall";
@@ -840,6 +841,7 @@ function annotateCurrentness(content: string, info: CurrentnessInfo | undefined)
 
 interface NativeArtifactRecallHit {
 	readonly rowid: number;
+	readonly sourceId: string | null;
 	readonly sourcePath: string;
 	readonly sourceKind: string;
 	readonly harness: string | null;
@@ -1090,7 +1092,7 @@ function buildNativeArtifactRecallHits(
 			if (!table) return [];
 
 			const parts = [
-				"SELECT ma.rowid, ma.source_path, ma.source_kind, ma.harness, ma.project,",
+				"SELECT ma.rowid, ma.source_id, ma.source_path, ma.source_kind, ma.harness, ma.project,",
 				"COALESCE(ma.updated_at, ma.captured_at) AS updated_at, ma.content,",
 				"bm25(memory_artifacts_fts) AS rank",
 				"FROM memory_artifacts_fts",
@@ -1112,6 +1114,7 @@ function buildNativeArtifactRecallHits(
 
 			const rows = db.prepare(parts.join("\n")).all(...args) as Array<{
 				rowid: number;
+				source_id: string | null;
 				source_path: string;
 				source_kind: string;
 				harness: string | null;
@@ -1125,6 +1128,7 @@ function buildNativeArtifactRecallHits(
 			return rows
 				.map((row) => ({
 					rowid: row.rowid,
+					sourceId: row.source_id,
 					sourcePath: row.source_path,
 					sourceKind: row.source_kind,
 					harness: row.harness,
@@ -1213,6 +1217,7 @@ export async function hybridRecall(
 	const needsPostFilter = params.scope !== undefined || !!params.project || !!params.agentId;
 	const timings = createRecallTimingCollector();
 	const selectionSuppressedIds = new Set<string>();
+	const lifecycleSourceResults = new Map<string, { readonly source?: string; readonly source_id?: string }>();
 	const selectionDedupeEnabled = !!params.sessionKey?.trim() && params.includeRecalled !== true;
 	const suppressPreviouslyRecalledForSelection = <T extends RecallResult>(items: T[]): T[] => {
 		if (!selectionDedupeEnabled || items.length === 0) return items;
@@ -1288,6 +1293,11 @@ export async function hybridRecall(
 			latencyMs: recallTimings.totalMs,
 			truncated: response.results.length >= limit,
 		});
+		const selectedLifecycleSources = response.results.flatMap((row) => {
+			const source = lifecycleSourceResults.get(row.id);
+			return source ? [source] : [];
+		});
+		recordFirstSourceRecall(params.agentId ?? "default", [...response.results, ...selectedLifecycleSources]);
 		if (recallTimings.totalMs >= RECALL_TIMING_LOG_THRESHOLD_MS) {
 			logger.warn("memory", "Recall stage timings", {
 				agentId: params.agentId ?? "default",
@@ -2293,6 +2303,11 @@ export async function hybridRecall(
 					const content = nativeArtifactRecallContent(hit);
 					const truncated = content.length > recallTruncate;
 					const sourceId = nativeArtifactPublicId(hit);
+					if (hit.sourceId)
+						lifecycleSourceResults.set(`native-artifact:${hit.rowid}`, {
+							source: nativeArtifactRecallSource(hit),
+							source_id: hit.sourceId,
+						});
 					return {
 						id: `native-artifact:${hit.rowid}`,
 						content: truncated ? `${content.slice(0, recallTruncate)} [truncated]` : content,
@@ -2462,6 +2477,11 @@ export async function hybridRecall(
 			const content = nativeArtifactRecallContent(hit);
 			const truncated = content.length > recallTruncate;
 			const sourceId = nativeArtifactPublicId(hit);
+			if (hit.sourceId)
+				lifecycleSourceResults.set(`native-artifact:${hit.rowid}`, {
+					source: nativeArtifactRecallSource(hit),
+					source_id: hit.sourceId,
+				});
 			return {
 				id: `native-artifact:${hit.rowid}`,
 				content: truncated ? `${content.slice(0, recallTruncate)} [truncated]` : content,

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -42,6 +42,16 @@ import {
 	markSourceIndexJobRunning,
 	updateSourceIndexJobProgress,
 } from "../source-index-progress";
+import {
+	recordSourceConnected,
+	recordSourceConnectionFailure,
+	recordSourceFreshness,
+	recordSourceIndexOperation,
+	recordSourceReadiness,
+	removeSourceLifecycleState,
+	sourceFailureClass,
+	sourceModeFor,
+} from "../source-lifecycle-telemetry";
 import { getSourceProvider } from "../source-providers";
 import { exportSourceSnapshot, importSourceSnapshot } from "../source-snapshots";
 
@@ -154,6 +164,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		try {
 			body = (await c.req.json()) as AddObsidianSourceBody;
 		} catch {
+			recordSourceConnectionFailure("obsidian", "invalid configuration");
 			return c.json({ error: "Invalid JSON body" }, 400);
 		}
 
@@ -162,7 +173,11 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 			? body.excludeGlobs.filter((entry) => typeof entry === "string")
 			: undefined;
 		const result = addObsidianSource({ root, name: body.name, excludeGlobs }, agentsDir);
-		if (result.ok === false) return c.json({ error: result.error }, 400);
+		if (result.ok === false) {
+			recordSourceConnectionFailure("obsidian", result.error);
+			return c.json({ error: result.error }, 400);
+		}
+		recordSourceConnected(result.source, resolveDaemonAgentId());
 
 		const job = enqueueSourceIndexJob({
 			source: result.source,
@@ -179,6 +194,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		try {
 			body = (await c.req.json()) as AddDiscordSourceBody;
 		} catch {
+			recordSourceConnectionFailure("discord", "invalid configuration");
 			return c.json({ error: "Invalid JSON body" }, 400);
 		}
 
@@ -216,7 +232,11 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 			},
 			agentsDir,
 		);
-		if (result.ok === false) return c.json({ error: result.error }, 400);
+		if (result.ok === false) {
+			recordSourceConnectionFailure("discord", result.error);
+			return c.json({ error: result.error }, 400);
+		}
+		recordSourceConnected(result.source, resolveDaemonAgentId());
 
 		const job = enqueueSourceIndexJob({
 			source: result.source,
@@ -284,6 +304,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		try {
 			body = (await c.req.json()) as AddGitHubSourceBody;
 		} catch {
+			recordSourceConnectionFailure("github", "invalid configuration");
 			return c.json({ error: "Invalid JSON body" }, 400);
 		}
 
@@ -310,7 +331,11 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 			},
 			agentsDir,
 		);
-		if (result.ok === false) return c.json({ error: result.error }, 400);
+		if (result.ok === false) {
+			recordSourceConnectionFailure("github", result.error);
+			return c.json({ error: result.error }, 400);
+		}
+		recordSourceConnected(result.source, resolveDaemonAgentId());
 
 		const job = enqueueSourceIndexJob({
 			source: result.source,
@@ -329,6 +354,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		cancelSourceIndexJob(result.source.id);
 
 		const sourceAgentId = resolveDaemonAgentId();
+		removeSourceLifecycleState(result.source, sourceAgentId);
 		recordSourceDeletionTombstone(result.source, sourceAgentId, agentsDir);
 		const provider = getSourceProvider(result.source.kind);
 		const purged = provider ? purgeSource(provider, result.source, sourceAgentId, purgeNativeSource) : 0;
@@ -354,6 +380,8 @@ function enqueueSourceIndexJob(input: SourceIndexJobInput): SourceIndexJob {
 }
 
 async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob): Promise<void> {
+	const startedAt = Date.now();
+	const agentId = resolveDaemonAgentId();
 	if (isSourceIndexInFlight(input.source.id)) {
 		scheduleSourceIndexJob(input, job, 50);
 		return;
@@ -365,6 +393,7 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 	}
 
 	let bridge: NativeMemoryBridgeHandle | null = null;
+	let lastRecurringFreshnessAt = 0;
 
 	try {
 		const provider = getSourceProvider(input.source.kind);
@@ -373,22 +402,50 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 			const result = await provider.sync({
 				source: input.source,
 				agentsDir: input.agentsDir,
-				agentId: resolveDaemonAgentId(),
+				agentId,
 				shouldContinue: () => isCurrentSourceIndexJob(input.source.id, job.id),
 				onProgress: (event) => {
 					if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
 					updateSourceIndexJobProgress(input.source.id, job.id, event);
+					const recurring = sourceModeFor(input.source) === "recurring";
+					if (recurring && event.currentPath !== "discord://gateway") recordSourceReadiness(input.source, agentId);
+					if (recurring && Date.now() - lastRecurringFreshnessAt >= 5 * 60 * 1_000) {
+						lastRecurringFreshnessAt = Date.now();
+						recordSourceFreshness(input.source, agentId);
+					}
 				},
 			});
 			if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
 			if (result.failures.length > 0) {
+				const accepted = Math.max(0, result.indexed - result.failures.length);
+				const discovered = Math.max(result.scanned, result.indexed);
+				recordSourceIndexOperation({
+					source: input.source,
+					agentId,
+					discovered,
+					accepted,
+					failed: result.failures.length,
+					durationMs: Date.now() - startedAt,
+					outcome: accepted > 0 ? "partial" : "failed",
+					failureClass: sourceFailureClass(result.failures[0]),
+					searchable: accepted > 0,
+				});
 				failSourceIndexJob(
 					input.source.id,
 					job.id,
 					`${input.source.kind} source sync completed with ${result.failures.length} failure(s)`,
 				);
 			} else {
+				const discovered = Math.max(result.scanned, result.indexed);
 				markSourceIndexed(input.source.id, undefined, input.agentsDir);
+				recordSourceIndexOperation({
+					source: input.source,
+					agentId,
+					discovered,
+					accepted: result.indexed,
+					durationMs: Date.now() - startedAt,
+					outcome: "success",
+				});
 				completeSourceIndexJob(input.source.id, job.id, result.indexed);
 			}
 			return;
@@ -416,9 +473,29 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 		const indexed = await bridge.syncExisting();
 		if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
 		markSourceIndexed(input.source.id, undefined, input.agentsDir);
+		const progress = getSourceIndexJob(input.source.id);
+		recordSourceIndexOperation({
+			source: input.source,
+			agentId,
+			discovered: progress?.scanned ?? indexed,
+			accepted: indexed,
+			durationMs: Date.now() - startedAt,
+			outcome: "success",
+		});
 		completeSourceIndexJob(input.source.id, job.id, indexed);
 	} catch (err) {
 		if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
+		recordSourceIndexOperation({
+			source: input.source,
+			agentId,
+			discovered: getSourceIndexJob(input.source.id)?.scanned ?? 0,
+			accepted: getSourceIndexJob(input.source.id)?.indexed ?? 0,
+			failed: 1,
+			durationMs: Date.now() - startedAt,
+			outcome: "failed",
+			failureClass: sourceFailureClass(err),
+			searchable: false,
+		});
 		failSourceIndexJob(input.source.id, job.id, err);
 	} finally {
 		await bridge?.close().catch(() => undefined);
@@ -458,6 +535,7 @@ export function cleanupSourceDeletionTombstones(
 	const remaining: SourceDeletionTombstone[] = [];
 	for (const tombstone of tombstones) {
 		if (configuredIds.has(tombstone.source.id)) continue;
+		removeSourceLifecycleState(tombstone.source, tombstone.agentId);
 		const provider = getSourceProvider(tombstone.source.kind);
 		if (!provider) continue;
 		try {

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -36,6 +36,7 @@ import {
 	consumeCanceledSourceIndexJob,
 	failSourceIndexJob,
 	getSourceIndexJob,
+	invalidateSourceIndexJob,
 	isCurrentSourceIndexJob,
 	isSourceIndexInFlight,
 	markSourceIndexInFlight,
@@ -50,6 +51,7 @@ import {
 	recordSourceReadiness,
 	removeSourceLifecycleState,
 	sourceFailureClass,
+	sourceHasSearchableArtifacts,
 	sourceModeFor,
 } from "../source-lifecycle-telemetry";
 import { getSourceProvider } from "../source-providers";
@@ -123,6 +125,36 @@ export interface RegisterSourcesRoutesDeps {
 	readonly agentsDir?: string;
 	readonly startBridge?: typeof startNativeMemoryBridge;
 	readonly purgeNativeSource?: typeof purgeNativeMemorySourceArtifacts;
+}
+
+const sourceIndexRuns = new Set<{ readonly sourceId: string; readonly jobId: string; readonly run: Promise<void> }>();
+const sourceIndexTimers = new Set<ReturnType<typeof setTimeout>>();
+const routeSourceJobs = new Map<string, { readonly job: SourceIndexJob; readonly input: SourceIndexJobInput }>();
+let sourceIndexStopping = false;
+
+/** Stop route-owned source work before the daemon closes telemetry and SQLite. */
+export async function stopSourceIndexJobs(): Promise<void> {
+	sourceIndexStopping = true;
+	for (const timer of sourceIndexTimers) clearTimeout(timer);
+	sourceIndexTimers.clear();
+	for (const [sourceId, routeJob] of routeSourceJobs) {
+		const current = getSourceIndexJob(sourceId);
+		if (current?.id !== routeJob.job.id || (current.status !== "queued" && current.status !== "running")) continue;
+		recordSourceIndexOperation({
+			source: routeJob.input.source,
+			agentId: resolveDaemonAgentId(),
+			discovered: current.total ?? current.scanned ?? 0,
+			accepted: current.indexed ?? 0,
+			durationMs: Math.max(0, Date.now() - Date.parse(current.startedAt ?? current.queuedAt)),
+			outcome: "cancelled",
+			failureClass: "cancelled",
+			searchable: false,
+		});
+		invalidateSourceIndexJob(sourceId);
+	}
+	await Promise.allSettled([...sourceIndexRuns].map(({ run }) => run));
+	sourceIndexRuns.clear();
+	routeSourceJobs.clear();
 }
 
 export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps = {}): void {
@@ -272,6 +304,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 	});
 
 	app.post("/api/sources/:sourceId/snapshot/import", async (c) => {
+		const startedAt = Date.now();
 		const sourceId = c.req.param("sourceId");
 		const source = findConfiguredSource(sourceId, agentsDir);
 		if (!source) return c.json({ error: "Source not found" }, 404);
@@ -284,6 +317,18 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 			try {
 				body = await c.req.json();
 			} catch {
+				recordSourceIndexOperation({
+					source,
+					agentId: resolveDaemonAgentId(),
+					discovered: 0,
+					accepted: 0,
+					failed: 1,
+					durationMs: Date.now() - startedAt,
+					outcome: "failed",
+					failureClass: "parse",
+					updateFreshness: false,
+					searchable: false,
+				});
 				return c.json({ error: "Invalid JSON body" }, 400);
 			}
 			const result = importSourceSnapshot({
@@ -292,7 +337,33 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 				snapshot: body,
 				includeLocalDiscord: c.req.query("includeLocalDiscord") === "true",
 			});
-			if (result.ok === false) return c.json({ error: result.error }, 400);
+			if (result.ok === false) {
+				recordSourceIndexOperation({
+					source,
+					agentId: resolveDaemonAgentId(),
+					discovered: 0,
+					accepted: 0,
+					failed: 1,
+					durationMs: Date.now() - startedAt,
+					outcome: "failed",
+					failureClass: sourceFailureClass(result.error),
+					updateFreshness: false,
+					searchable: false,
+				});
+				return c.json({ error: result.error }, 400);
+			}
+			markSourceIndexed(source.id, undefined, agentsDir);
+			recordSourceIndexOperation({
+				source,
+				agentId: resolveDaemonAgentId(),
+				discovered: result.imported + result.skipped.localDiscordArtifacts,
+				accepted: result.imported,
+				skipped: result.skipped.localDiscordArtifacts,
+				durationMs: Date.now() - startedAt,
+				outcome: "success",
+				updateFreshness: false,
+				searchable: sourceHasSearchableArtifacts(source, resolveDaemonAgentId()),
+			});
 			return c.json(result);
 		} finally {
 			clearSourceIndexInFlight(source.id);
@@ -375,6 +446,7 @@ function isSourceImportBlocked(sourceId: string): boolean {
 
 function enqueueSourceIndexJob(input: SourceIndexJobInput): SourceIndexJob {
 	const job = beginSourceIndexJob(input.source.id);
+	if (job.id.startsWith("source-index:")) routeSourceJobs.set(input.source.id, { job, input });
 	scheduleSourceIndexJob(input, job, 0);
 	return job;
 }
@@ -499,7 +571,7 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 		failSourceIndexJob(input.source.id, job.id, err);
 	} finally {
 		await bridge?.close().catch(() => undefined);
-		if (consumeCanceledSourceIndexJob(job.id)) {
+		if (consumeCanceledSourceIndexJob(job.id) && !sourceIndexStopping) {
 			const provider = getSourceProvider(input.source.kind);
 			if (provider) purgeSource(provider, input.source, resolveDaemonAgentId(), input.purgeNativeSource);
 			clearSourceDeletionTombstone(input.source.id, resolveDaemonAgentId(), input.agentsDir);
@@ -509,10 +581,19 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 }
 
 function scheduleSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob, delayMs: number): void {
-	setTimeout(() => {
+	if (sourceIndexStopping) return;
+	const timer = setTimeout(() => {
+		sourceIndexTimers.delete(timer);
 		if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
-		void runSourceIndexJob(input, job);
-	}, delayMs).unref?.();
+		const run = runSourceIndexJob(input, job);
+		const activeRun = { sourceId: input.source.id, jobId: job.id, run };
+		sourceIndexRuns.add(activeRun);
+		void run.finally(() => {
+			sourceIndexRuns.delete(activeRun);
+		});
+	}, delayMs);
+	sourceIndexTimers.add(timer);
+	timer.unref?.();
 }
 
 /**

--- a/platform/daemon/src/source-index-progress.ts
+++ b/platform/daemon/src/source-index-progress.ts
@@ -121,6 +121,11 @@ export function cancelSourceIndexJob(sourceId: string): void {
 	sourceIndexJobs.delete(sourceId);
 }
 
+/** Invalidate work because the daemon is stopping, without purging source data. */
+export function invalidateSourceIndexJob(sourceId: string): void {
+	sourceIndexJobs.delete(sourceId);
+}
+
 export function consumeCanceledSourceIndexJob(jobId: string): boolean {
 	return canceledSourceIndexJobs.delete(jobId);
 }

--- a/platform/daemon/src/source-lifecycle-telemetry.test.ts
+++ b/platform/daemon/src/source-lifecycle-telemetry.test.ts
@@ -26,6 +26,8 @@ describe("source lifecycle telemetry contract", () => {
 	it("classifies failures without exposing their message", () => {
 		expect(sourceFailureClass(new Error("401 https://private.example/user-token"))).toBe("authentication");
 		expect(sourceFailureClass({ message: "429 rate limit" })).toBe("rate_limited");
+		expect(sourceFailureClass(new Error("Obsidian root is required"))).toBe("configuration");
+		expect(sourceFailureClass(new Error("Invalid Discord source configuration"))).toBe("configuration");
 		expect(sourceFailureClass(new Error("unexpected implementation detail with /Users/alice/private.md"))).toBe(
 			"unknown",
 		);

--- a/platform/daemon/src/source-lifecycle-telemetry.test.ts
+++ b/platform/daemon/src/source-lifecycle-telemetry.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import {
+	sourceClassForKind,
+	sourceCountBucket,
+	sourceDurationBucket,
+	sourceFailureClass,
+	sourceLagBucket,
+	sourceSizeBucket,
+} from "./source-lifecycle-telemetry";
+
+describe("source lifecycle telemetry contract", () => {
+	it("maps providers into a fixed taxonomy instead of forwarding provider input", () => {
+		expect(sourceClassForKind("obsidian")).toBe("note_vault");
+		expect(sourceClassForKind("github")).toBe("repository");
+		expect(sourceClassForKind("user-defined-provider-with-a-path-/Users/alice/vault")).toBe("other");
+	});
+
+	it("bounds corpus, size, duration, and freshness values into finite buckets", () => {
+		expect(sourceCountBucket(Number.MAX_SAFE_INTEGER)).toBe("10k_plus");
+		expect(sourceCountBucket(-1)).toBe("0");
+		expect(sourceSizeBucket(1_000_000_000)).toBe("1gb_plus");
+		expect(sourceDurationBucket(Number.POSITIVE_INFINITY)).toBe("unknown");
+		expect(sourceLagBucket(Number.MAX_SAFE_INTEGER)).toBe("7d_plus");
+	});
+
+	it("classifies failures without exposing their message", () => {
+		expect(sourceFailureClass(new Error("401 https://private.example/user-token"))).toBe("authentication");
+		expect(sourceFailureClass({ message: "429 rate limit" })).toBe("rate_limited");
+		expect(sourceFailureClass(new Error("unexpected implementation detail with /Users/alice/private.md"))).toBe(
+			"unknown",
+		);
+	});
+});

--- a/platform/daemon/src/source-lifecycle-telemetry.test.ts
+++ b/platform/daemon/src/source-lifecycle-telemetry.test.ts
@@ -28,6 +28,7 @@ describe("source lifecycle telemetry contract", () => {
 		expect(sourceFailureClass({ message: "429 rate limit" })).toBe("rate_limited");
 		expect(sourceFailureClass(new Error("Obsidian root is required"))).toBe("configuration");
 		expect(sourceFailureClass(new Error("Invalid Discord source configuration"))).toBe("configuration");
+		expect(sourceFailureClass(new Error("invalid configuration"))).toBe("configuration");
 		expect(sourceFailureClass(new Error("unexpected implementation detail with /Users/alice/private.md"))).toBe(
 			"unknown",
 		);

--- a/platform/daemon/src/source-lifecycle-telemetry.ts
+++ b/platform/daemon/src/source-lifecycle-telemetry.ts
@@ -175,15 +175,15 @@ export function sourceFailureClass(error: unknown): SourceFailureClass {
 			: "";
 	if (/cancel|abort/i.test(text)) return "cancelled";
 	if (/unsupported|unknown provider|no sync/i.test(text)) return "unsupported";
+	if (
+		/configuration|config(?:uration)?|required|must be provided|at least one .* (?:id|guild|repo|source)/i.test(text)
+	) {
+		return "configuration";
+	}
 	if (/EACCES|ENOENT|EISDIR/i.test(code) || /enoent|eacces|file|directory|path|vault/i.test(text)) return "filesystem";
 	if (/403|permission|forbidden|not authorized|authorization/i.test(text)) return "authorization";
 	if (/token|credential|secret|auth|401/i.test(text)) return "authentication";
 	if (/429|rate limit|too many requests/i.test(text)) return "rate_limited";
-	if (
-		/configuration|root is required|guild id is required|missing .*config|config/i.test(text) ||
-		(/invalid/i.test(text) && /source|root|guild|config|provider/i.test(text))
-	)
-		return "configuration";
 	if (/json|parse|invalid|malformed|schema/i.test(text)) return "parse";
 	if (/network|fetch|socket|timeout|dns|connect|gateway|http 5/i.test(text)) return "network";
 	return "unknown";

--- a/platform/daemon/src/source-lifecycle-telemetry.ts
+++ b/platform/daemon/src/source-lifecycle-telemetry.ts
@@ -78,6 +78,7 @@ export interface SourceIndexTelemetryInput {
 	readonly failureClass?: SourceFailureClass;
 	readonly searchable?: boolean;
 	readonly sourceBytes?: number;
+	readonly updateFreshness?: boolean;
 }
 
 export interface SourceRecallTelemetryResult {
@@ -246,6 +247,7 @@ function ensureState(
 }
 
 export function recordSourceConnected(source: SignetSourceEntry, agentId: string, mode = sourceModeFor(source)): void {
+	if (!getActiveTelemetry()?.enabled) return;
 	const now = new Date().toISOString();
 	try {
 		let claimed = false;
@@ -285,17 +287,59 @@ export function recordSourceConnectionFailure(kind: string, error: unknown, mode
 function sourceSizeBytes(source: SourceLifecycleSource, agentId: string): number | undefined {
 	try {
 		return getDbAccessor().withReadDb((db) => {
+			const rootPrefix = `${(source.root ?? "").replace(/\\/g, "/").replace(/\/$/, "")}/`;
+			const legacyObsidianClause =
+				source.kind === "obsidian"
+					? "OR (harness = 'obsidian' AND source_id IS NULL AND source_path >= ? AND source_path < ?)"
+					: "";
 			const row = db
 				.prepare(`
 				SELECT SUM(length(content)) AS bytes
 				FROM memory_artifacts
-				WHERE agent_id = ? AND source_id = ? AND COALESCE(is_deleted, 0) = 0
+				WHERE agent_id = ?
+				  AND (
+					source_id = ?
+					${legacyObsidianClause}
+				  )
+				  AND COALESCE(is_deleted, 0) = 0
 			`)
-				.get(agentId, source.id) as { bytes?: unknown } | undefined;
+				.get(agentId, source.id, ...(source.kind === "obsidian" ? [rootPrefix, `${rootPrefix}\uffff`] : [])) as
+				| { bytes?: unknown }
+				| undefined;
 			return typeof row?.bytes === "number" && Number.isFinite(row.bytes) ? row.bytes : undefined;
 		});
 	} catch {
 		return undefined;
+	}
+}
+
+export function sourceHasSearchableArtifacts(source: SignetSourceEntry, agentId: string): boolean {
+	if (!getActiveTelemetry()?.enabled) return false;
+	try {
+		return getDbAccessor().withReadDb((db) => {
+			const rootPrefix = `${source.root.replace(/\\/g, "/").replace(/\/$/, "")}/`;
+			const legacyObsidianClause =
+				source.kind === "obsidian"
+					? "OR (harness = 'obsidian' AND source_id IS NULL AND source_path >= ? AND source_path < ?)"
+					: "";
+			const row = db
+				.prepare(
+					`SELECT 1 AS n FROM memory_artifacts
+					 WHERE agent_id = ?
+					   AND (
+						 source_id = ?
+						 ${legacyObsidianClause}
+					   )
+					   AND COALESCE(is_deleted, 0) = 0
+					   AND COALESCE(source_kind, '') NOT LIKE 'source_%_failure'
+					   AND COALESCE(source_kind, '') NOT LIKE 'source_%_checkpoint'
+					 LIMIT 1`,
+				)
+				.get(agentId, source.id, ...(source.kind === "obsidian" ? [rootPrefix, `${rootPrefix}\uffff`] : []));
+			return Boolean(row);
+		});
+	} catch {
+		return false;
 	}
 }
 
@@ -310,6 +354,7 @@ function freshnessEventNeeded(
 }
 
 export function recordSourceIndexOperation(input: SourceIndexTelemetryInput): void {
+	if (!getActiveTelemetry()?.enabled) return;
 	const mode = input.mode ?? sourceModeFor(input.source);
 	const now = new Date();
 	const nowIso = now.toISOString();
@@ -331,11 +376,15 @@ export function recordSourceIndexOperation(input: SourceIndexTelemetryInput): vo
 			const before = readState(db, input.agentId, ensured.key);
 			if (accepted > 0 && !before?.firstIndexedAt) firstIndexed = true;
 			if (searchable && !before?.firstSearchableAt) firstSearchable = true;
-			const success = input.outcome === "success";
+			const success = input.outcome === "success" && input.updateFreshness !== false;
 			const nextSuccessAt = success ? nowIso : (before?.lastSuccessAt ?? null);
 			const freshnessState: SourceFreshnessState = success ? "healthy" : before?.lastSuccessAt ? "stale" : "unknown";
 			const lagMs = before?.lastSuccessAt ? now.getTime() - Date.parse(before.lastSuccessAt) : null;
-			if (mode === "recurring" && freshnessEventNeeded(before, freshnessState, now.getTime())) {
+			if (
+				mode === "recurring" &&
+				input.updateFreshness !== false &&
+				freshnessEventNeeded(before, freshnessState, now.getTime())
+			) {
 				freshness = { state: freshnessState, lag: sourceLagBucket(success ? 0 : lagMs) };
 			}
 			db.prepare(`
@@ -415,6 +464,7 @@ function recallSourceIdCandidates(value: string): readonly string[] {
 }
 
 export function recordFirstSourceRecall(agentId: string, results: readonly SourceRecallTelemetryResult[]): void {
+	if (!getActiveTelemetry()?.enabled) return;
 	const byClass = new Map<SourceClass, string[]>();
 	const seenIds = new Set<string>();
 	for (const result of results) {

--- a/platform/daemon/src/source-lifecycle-telemetry.ts
+++ b/platform/daemon/src/source-lifecycle-telemetry.ts
@@ -1,0 +1,566 @@
+import { createHash } from "node:crypto";
+import type { SignetSourceEntry, SignetSourceKind } from "@signet/core";
+import { getDbAccessor } from "./db-accessor";
+import { getActiveTelemetry } from "./telemetry";
+
+export const SOURCE_LIFECYCLE_EVENT = "source.lifecycle" as const;
+
+export const SOURCE_CLASSES = ["transcript", "document", "repository", "note_vault", "browser", "other"] as const;
+export type SourceClass = (typeof SOURCE_CLASSES)[number];
+
+export const SOURCE_MODES = ["one_shot", "recurring"] as const;
+export type SourceMode = (typeof SOURCE_MODES)[number];
+
+export const SOURCE_FAILURE_CLASSES = [
+	"configuration",
+	"authentication",
+	"authorization",
+	"network",
+	"rate_limited",
+	"filesystem",
+	"parse",
+	"unsupported",
+	"cancelled",
+	"unknown",
+] as const;
+export type SourceFailureClass = (typeof SOURCE_FAILURE_CLASSES)[number];
+
+export const SOURCE_OUTCOMES = ["success", "partial", "failed", "cancelled"] as const;
+export type SourceOutcome = (typeof SOURCE_OUTCOMES)[number];
+
+export const SOURCE_FRESHNESS_STATES = ["healthy", "stale", "unknown"] as const;
+export type SourceFreshnessState = (typeof SOURCE_FRESHNESS_STATES)[number];
+
+export const SOURCE_COUNT_BUCKETS = ["0", "1_10", "11_100", "101_1k", "1k_10k", "10k_plus"] as const;
+export type SourceCountBucket = (typeof SOURCE_COUNT_BUCKETS)[number];
+
+export const SOURCE_SIZE_BUCKETS = ["unknown", "lt_1mb", "1_10mb", "10_100mb", "100mb_1gb", "1gb_plus"] as const;
+export type SourceSizeBucket = (typeof SOURCE_SIZE_BUCKETS)[number];
+
+export const SOURCE_DURATION_BUCKETS = ["unknown", "lt_1s", "1_10s", "10_60s", "1_10m", "10_60m", "60m_plus"] as const;
+export type SourceDurationBucket = (typeof SOURCE_DURATION_BUCKETS)[number];
+
+export const SOURCE_LAG_BUCKETS = ["unknown", "lt_1h", "1_6h", "6_24h", "1_7d", "7d_plus"] as const;
+export type SourceLagBucket = (typeof SOURCE_LAG_BUCKETS)[number];
+
+type SourceLifecyclePhase = "connect" | "index" | "readiness" | "first_recall" | "freshness";
+
+interface SourceLifecycleSource {
+	readonly id: string;
+	readonly kind: SignetSourceKind | string;
+	readonly root?: string;
+	readonly providerSettings?: Readonly<Record<string, unknown>>;
+}
+
+interface SourceLifecycleState {
+	readonly sourceKey: string;
+	readonly sourceClass: SourceClass;
+	readonly mode: SourceMode;
+	readonly connectedAt: string | null;
+	readonly firstIndexedAt: string | null;
+	readonly firstSearchableAt: string | null;
+	readonly firstRecallAt: string | null;
+	readonly lastSuccessAt: string | null;
+	readonly lastFreshnessState: SourceFreshnessState | null;
+	readonly lastFreshnessEventAt: string | null;
+}
+
+export interface SourceIndexTelemetryInput {
+	readonly source: SourceLifecycleSource;
+	readonly agentId: string;
+	readonly mode?: SourceMode;
+	readonly discovered: number;
+	readonly accepted: number;
+	readonly skipped?: number;
+	readonly failed?: number;
+	readonly durationMs: number;
+	readonly outcome: SourceOutcome;
+	readonly failureClass?: SourceFailureClass;
+	readonly searchable?: boolean;
+	readonly sourceBytes?: number;
+}
+
+export interface SourceRecallTelemetryResult {
+	readonly source?: string;
+	readonly source_id?: string;
+}
+
+const MAX_COUNT = 1_000_000;
+const MAX_RECALL_CLAIMS_PER_CALL = 20;
+const FRESHNESS_EVENT_INTERVAL_MS = 60 * 60 * 1_000;
+const CONNECTION_FAILURE_INTERVAL_MS = 5 * 60 * 1_000;
+const recentConnectionFailures = new Map<SourceClass, number>();
+const readinessClaimedInProcess = new Set<string>();
+
+function boundedCount(value: number): number {
+	return Number.isFinite(value) ? Math.max(0, Math.min(MAX_COUNT, Math.floor(value))) : 0;
+}
+
+export function sourceClassForKind(kind: string): SourceClass {
+	switch (kind.trim().toLowerCase()) {
+		case "discord":
+		case "codex":
+		case "claude-code":
+		case "transcript":
+			return "transcript";
+		case "github":
+		case "repository":
+			return "repository";
+		case "obsidian":
+		case "note_vault":
+			return "note_vault";
+		case "browser":
+			return "browser";
+		case "document":
+			return "document";
+		default:
+			return "other";
+	}
+}
+
+export function sourceModeFor(source: Pick<SourceLifecycleSource, "kind" | "providerSettings">): SourceMode {
+	return source.providerSettings?.syncMode === "gateway-tail" ? "recurring" : "one_shot";
+}
+
+export function sourceCountBucket(value: number): SourceCountBucket {
+	const count = boundedCount(value);
+	if (count === 0) return "0";
+	if (count <= 10) return "1_10";
+	if (count <= 100) return "11_100";
+	if (count <= 1_000) return "101_1k";
+	if (count <= 10_000) return "1k_10k";
+	return "10k_plus";
+}
+
+export function sourceSizeBucket(bytes: number | undefined): SourceSizeBucket {
+	if (bytes === undefined || !Number.isFinite(bytes) || bytes < 0) return "unknown";
+	if (bytes < 1_000_000) return "lt_1mb";
+	if (bytes < 10_000_000) return "1_10mb";
+	if (bytes < 100_000_000) return "10_100mb";
+	if (bytes < 1_000_000_000) return "100mb_1gb";
+	return "1gb_plus";
+}
+
+export function sourceDurationBucket(durationMs: number): SourceDurationBucket {
+	if (!Number.isFinite(durationMs) || durationMs < 0) return "unknown";
+	const duration = durationMs;
+	if (duration < 1_000) return "lt_1s";
+	if (duration < 10_000) return "1_10s";
+	if (duration < 60_000) return "10_60s";
+	if (duration < 600_000) return "1_10m";
+	if (duration < 3_600_000) return "10_60m";
+	return "60m_plus";
+}
+
+export function sourceLagBucket(lagMs: number | null | undefined): SourceLagBucket {
+	if (lagMs === null || lagMs === undefined || !Number.isFinite(lagMs) || lagMs < 0) return "unknown";
+	if (lagMs < 3_600_000) return "lt_1h";
+	if (lagMs < 21_600_000) return "1_6h";
+	if (lagMs < 86_400_000) return "6_24h";
+	if (lagMs < 604_800_000) return "1_7d";
+	return "7d_plus";
+}
+
+export function sourceFailureClass(error: unknown): SourceFailureClass {
+	const text =
+		error instanceof Error
+			? `${error.name} ${error.message}`
+			: typeof error === "object" && error !== null && "message" in error
+				? String((error as { readonly message?: unknown }).message ?? "")
+				: String(error);
+	const code =
+		typeof error === "object" && error !== null && "code" in error
+			? String((error as { readonly code?: unknown }).code ?? "")
+			: "";
+	if (/cancel|abort/i.test(text)) return "cancelled";
+	if (/unsupported|unknown provider|no sync/i.test(text)) return "unsupported";
+	if (/EACCES|ENOENT|EISDIR/i.test(code) || /enoent|eacces|file|directory|path|vault/i.test(text)) return "filesystem";
+	if (/403|permission|forbidden|not authorized|authorization/i.test(text)) return "authorization";
+	if (/token|credential|secret|auth|401/i.test(text)) return "authentication";
+	if (/429|rate limit|too many requests/i.test(text)) return "rate_limited";
+	if (/json|parse|invalid|malformed|schema/i.test(text)) return "parse";
+	if (/network|fetch|socket|timeout|dns|connect|gateway|http 5/i.test(text)) return "network";
+	return "unknown";
+}
+
+function sourceKey(sourceIdentity: string): string {
+	return createHash("sha256").update(sourceIdentity).digest("hex").slice(0, 32);
+}
+
+function sourceIdentity(source: SourceLifecycleSource): string {
+	return source.id || `${source.kind}:${source.root ?? ""}`;
+}
+
+function emit(properties: Readonly<Record<string, string | number | boolean | null>>): void {
+	getActiveTelemetry()?.record(SOURCE_LIFECYCLE_EVENT, properties);
+}
+
+function readState(
+	db: { prepare: (sql: string) => { get: (...args: unknown[]) => unknown } },
+	agentId: string,
+	key: string,
+): SourceLifecycleState | null {
+	const row = db
+		.prepare(`
+		SELECT source_key, source_class, mode, connected_at, first_indexed_at,
+			first_searchable_at, first_recall_at, last_success_at,
+			last_freshness_state, last_freshness_event_at
+		FROM source_lifecycle_state WHERE agent_id = ? AND source_key = ?
+	`)
+		.get(agentId, key) as Record<string, unknown> | undefined;
+	if (!row) return null;
+	return {
+		sourceKey: String(row.source_key),
+		sourceClass: sourceClassForKind(String(row.source_class)),
+		mode: row.mode === "recurring" ? "recurring" : "one_shot",
+		connectedAt: typeof row.connected_at === "string" ? row.connected_at : null,
+		firstIndexedAt: typeof row.first_indexed_at === "string" ? row.first_indexed_at : null,
+		firstSearchableAt: typeof row.first_searchable_at === "string" ? row.first_searchable_at : null,
+		firstRecallAt: typeof row.first_recall_at === "string" ? row.first_recall_at : null,
+		lastSuccessAt: typeof row.last_success_at === "string" ? row.last_success_at : null,
+		lastFreshnessState:
+			row.last_freshness_state === "healthy" ||
+			row.last_freshness_state === "stale" ||
+			row.last_freshness_state === "unknown"
+				? row.last_freshness_state
+				: null,
+		lastFreshnessEventAt: typeof row.last_freshness_event_at === "string" ? row.last_freshness_event_at : null,
+	};
+}
+
+function ensureState(
+	db: { prepare: (sql: string) => { run: (...args: unknown[]) => { changes?: number } } },
+	agentId: string,
+	source: SourceLifecycleSource,
+	mode: SourceMode,
+): { readonly key: string; readonly inserted: boolean } {
+	const key = sourceKey(sourceIdentity(source));
+	const result = db
+		.prepare(`
+			INSERT OR IGNORE INTO source_lifecycle_state
+			(agent_id, source_key, source_class, mode, connected_at)
+			VALUES (?, ?, ?, ?, NULL)
+		`)
+		.run(agentId, key, sourceClassForKind(String(source.kind)), mode);
+	return { key, inserted: (result.changes ?? 0) > 0 };
+}
+
+export function recordSourceConnected(source: SignetSourceEntry, agentId: string, mode = sourceModeFor(source)): void {
+	const now = new Date().toISOString();
+	try {
+		let claimed = false;
+		getDbAccessor().withWriteTx((db) => {
+			const state = ensureState(db, agentId, source, mode);
+			const result = db
+				.prepare(`
+				UPDATE source_lifecycle_state SET connected_at = ?, mode = ?
+				WHERE agent_id = ? AND source_key = ? AND connected_at IS NULL
+			`)
+				.run(now, mode, agentId, state.key);
+			claimed = (result.changes ?? 0) > 0;
+		});
+		if (claimed) {
+			emit({ phase: "connect", outcome: "success", sourceClass: sourceClassForKind(String(source.kind)), mode });
+		}
+	} catch {
+		// Telemetry is best effort and must not affect source configuration.
+	}
+}
+
+export function recordSourceConnectionFailure(kind: string, error: unknown, mode: SourceMode = "one_shot"): void {
+	const sourceClass = sourceClassForKind(kind);
+	const now = Date.now();
+	const previous = recentConnectionFailures.get(sourceClass) ?? 0;
+	if (now - previous < CONNECTION_FAILURE_INTERVAL_MS) return;
+	recentConnectionFailures.set(sourceClass, now);
+	emit({
+		phase: "connect",
+		outcome: "failed",
+		sourceClass,
+		mode,
+		failureClass: sourceFailureClass(error),
+	});
+}
+
+function sourceSizeBytes(source: SourceLifecycleSource, agentId: string): number | undefined {
+	try {
+		return getDbAccessor().withReadDb((db) => {
+			const row = db
+				.prepare(`
+				SELECT SUM(length(content)) AS bytes
+				FROM memory_artifacts
+				WHERE agent_id = ? AND source_id = ? AND COALESCE(is_deleted, 0) = 0
+			`)
+				.get(agentId, source.id) as { bytes?: unknown } | undefined;
+			return typeof row?.bytes === "number" && Number.isFinite(row.bytes) ? row.bytes : undefined;
+		});
+	} catch {
+		return undefined;
+	}
+}
+
+function freshnessEventNeeded(
+	state: SourceLifecycleState | null,
+	freshness: SourceFreshnessState,
+	nowMs: number,
+): boolean {
+	if (!state || state.lastFreshnessState !== freshness || !state.lastFreshnessEventAt) return true;
+	const last = Date.parse(state.lastFreshnessEventAt);
+	return !Number.isFinite(last) || nowMs - last >= FRESHNESS_EVENT_INTERVAL_MS;
+}
+
+export function recordSourceIndexOperation(input: SourceIndexTelemetryInput): void {
+	const mode = input.mode ?? sourceModeFor(input.source);
+	const now = new Date();
+	const nowIso = now.toISOString();
+	const sourceClass = sourceClassForKind(String(input.source.kind));
+	const accepted = boundedCount(input.accepted);
+	const discovered = boundedCount(input.discovered);
+	const skipped = boundedCount(input.skipped ?? Math.max(0, discovered - accepted - boundedCount(input.failed ?? 0)));
+	const failed = boundedCount(input.failed ?? 0);
+	const bytes = input.sourceBytes ?? sourceSizeBytes(input.source, input.agentId);
+	const searchable = input.searchable ?? (accepted > 0 || (bytes !== undefined && bytes > 0));
+	const sizeBucket = sourceSizeBucket(bytes);
+	let firstIndexed = false;
+	let firstSearchable = false;
+	let freshness: { readonly state: SourceFreshnessState; readonly lag: SourceLagBucket } | null = null;
+
+	try {
+		getDbAccessor().withWriteTx((db) => {
+			const ensured = ensureState(db, input.agentId, input.source, mode);
+			const before = readState(db, input.agentId, ensured.key);
+			if (accepted > 0 && !before?.firstIndexedAt) firstIndexed = true;
+			if (searchable && !before?.firstSearchableAt) firstSearchable = true;
+			const success = input.outcome === "success";
+			const nextSuccessAt = success ? nowIso : (before?.lastSuccessAt ?? null);
+			const freshnessState: SourceFreshnessState = success ? "healthy" : before?.lastSuccessAt ? "stale" : "unknown";
+			const lagMs = before?.lastSuccessAt ? now.getTime() - Date.parse(before.lastSuccessAt) : null;
+			if (mode === "recurring" && freshnessEventNeeded(before, freshnessState, now.getTime())) {
+				freshness = { state: freshnessState, lag: sourceLagBucket(success ? 0 : lagMs) };
+			}
+			db.prepare(`
+				UPDATE source_lifecycle_state SET
+					mode = ?,
+					first_indexed_at = CASE WHEN ? = 1 AND first_indexed_at IS NULL THEN ? ELSE first_indexed_at END,
+					first_searchable_at = CASE WHEN ? = 1 AND first_searchable_at IS NULL THEN ? ELSE first_searchable_at END,
+					last_success_at = ?,
+					last_freshness_state = CASE WHEN ? = 'recurring' THEN ? ELSE last_freshness_state END,
+					last_freshness_event_at = CASE WHEN ? = 1 THEN ? ELSE last_freshness_event_at END
+				WHERE agent_id = ? AND source_key = ?
+			`).run(
+				mode,
+				firstIndexed ? 1 : 0,
+				nowIso,
+				firstSearchable ? 1 : 0,
+				nowIso,
+				nextSuccessAt,
+				mode,
+				freshness?.state ?? before?.lastFreshnessState ?? null,
+				freshness ? 1 : 0,
+				freshness ? nowIso : null,
+				input.agentId,
+				ensured.key,
+			);
+		});
+	} catch {
+		// A missing or unavailable DB must not turn a completed source sync into a failure.
+	}
+
+	emit({
+		phase: "index",
+		outcome: input.outcome,
+		sourceClass,
+		mode,
+		discovered,
+		accepted,
+		skipped,
+		failed,
+		countBucket: sourceCountBucket(discovered),
+		sourceSizeBucket: sizeBucket,
+		durationBucket: sourceDurationBucket(input.durationMs),
+		...(input.failureClass ? { failureClass: input.failureClass } : {}),
+	});
+	if (firstIndexed) emit({ phase: "readiness", readiness: "indexed", outcome: "success", sourceClass, mode });
+	if (firstSearchable) emit({ phase: "readiness", readiness: "searchable", outcome: "success", sourceClass, mode });
+	const freshnessEvent = freshness as { readonly state: SourceFreshnessState; readonly lag: SourceLagBucket } | null;
+	if (freshnessEvent)
+		emit({
+			phase: "freshness",
+			freshness: freshnessEvent.state,
+			lagBucket: freshnessEvent.lag,
+			outcome: input.outcome,
+			sourceClass,
+			mode,
+		});
+}
+
+function recallClass(result: SourceRecallTelemetryResult): SourceClass | null {
+	const source = result.source ?? "";
+	const sourceId = result.source_id ?? "";
+	if (source === "source_obsidian" || sourceId.startsWith("obsidian:")) return "note_vault";
+	if (sourceId.startsWith("github:")) return "repository";
+	if (sourceId.startsWith("discord:") || sourceId.startsWith("discord-cache:")) return "transcript";
+	if (source === "native_memory") return "transcript";
+	return null;
+}
+
+function recallSourceIdCandidates(value: string): readonly string[] {
+	const parts = value.split(":");
+	const candidates: string[] = [];
+	for (let index = 1; index <= Math.min(parts.length, 4); index++) {
+		const candidate = parts.slice(0, index).join(":");
+		if (candidate) candidates.push(candidate);
+	}
+	return candidates;
+}
+
+export function recordFirstSourceRecall(agentId: string, results: readonly SourceRecallTelemetryResult[]): void {
+	const byClass = new Map<SourceClass, string[]>();
+	const seenIds = new Set<string>();
+	for (const result of results) {
+		const klass = recallClass(result);
+		if (!klass) continue;
+		const ids = byClass.get(klass) ?? [];
+		for (const sourceId of result.source_id ? recallSourceIdCandidates(result.source_id) : []) {
+			if (seenIds.has(sourceId) || seenIds.size >= MAX_RECALL_CLAIMS_PER_CALL) continue;
+			seenIds.add(sourceId);
+			ids.push(sourceId);
+		}
+		byClass.set(klass, ids);
+	}
+	for (const [sourceClass, ids] of byClass) claimFirstSourceRecall(agentId, sourceClass, ids);
+}
+
+/** Record a rate-limited checkpoint for a long-lived source stream. */
+export function recordSourceFreshness(source: SignetSourceEntry, agentId: string): void {
+	if (sourceModeFor(source) !== "recurring") return;
+	const now = new Date();
+	const nowIso = now.toISOString();
+	let lag: SourceLagBucket = "unknown";
+	let suppressed = false;
+	try {
+		getDbAccessor().withWriteTx((db) => {
+			const ensured = ensureState(db, agentId, source, "recurring");
+			const state = readState(db, agentId, ensured.key);
+			if (state?.lastFreshnessEventAt) {
+				const lastEvent = Date.parse(state.lastFreshnessEventAt);
+				if (Number.isFinite(lastEvent) && now.getTime() - lastEvent < FRESHNESS_EVENT_INTERVAL_MS) {
+					suppressed = true;
+					return;
+				}
+			}
+			const previous = state?.lastSuccessAt ? Date.parse(state.lastSuccessAt) : Number.NaN;
+			lag = sourceLagBucket(Number.isFinite(previous) ? now.getTime() - previous : null);
+			db.prepare(`
+				UPDATE source_lifecycle_state
+				SET mode = 'recurring', last_success_at = ?, last_freshness_state = 'healthy', last_freshness_event_at = ?
+				WHERE agent_id = ? AND source_key = ?
+			`).run(nowIso, nowIso, agentId, ensured.key);
+		});
+	} catch {
+		// Best effort.
+	}
+	if (suppressed) return;
+	emit({
+		phase: "freshness",
+		freshness: "healthy",
+		lagBucket: lag,
+		outcome: "success",
+		sourceClass: sourceClassForKind(String(source.kind)),
+		mode: "recurring",
+	});
+}
+
+/** Claim readiness once a recurring source has produced its first item. */
+export function recordSourceReadiness(source: SignetSourceEntry, agentId: string): void {
+	const processKey = `${agentId}:${sourceKey(sourceIdentity(source))}`;
+	if (readinessClaimedInProcess.has(processKey)) return;
+	const now = new Date().toISOString();
+	let firstIndexed = false;
+	let firstSearchable = false;
+	try {
+		getDbAccessor().withWriteTx((db) => {
+			const ensured = ensureState(db, agentId, source, "recurring");
+			const state = readState(db, agentId, ensured.key);
+			if (state?.firstIndexedAt && state.firstSearchableAt) {
+				readinessClaimedInProcess.add(processKey);
+				return;
+			}
+			firstIndexed = !state?.firstIndexedAt;
+			firstSearchable = !state?.firstSearchableAt;
+			db.prepare(`
+				UPDATE source_lifecycle_state SET
+					mode = 'recurring',
+					first_indexed_at = COALESCE(first_indexed_at, ?),
+					first_searchable_at = COALESCE(first_searchable_at, ?)
+				WHERE agent_id = ? AND source_key = ?
+			`).run(now, now, agentId, ensured.key);
+		});
+	} catch {
+		return;
+	}
+	readinessClaimedInProcess.add(processKey);
+	const sourceClass = sourceClassForKind(String(source.kind));
+	if (firstIndexed)
+		emit({ phase: "readiness", readiness: "indexed", outcome: "success", sourceClass, mode: "recurring" });
+	if (firstSearchable)
+		emit({ phase: "readiness", readiness: "searchable", outcome: "success", sourceClass, mode: "recurring" });
+}
+
+export function removeSourceLifecycleState(source: SignetSourceEntry, agentId: string): void {
+	const processKey = `${agentId}:${sourceKey(sourceIdentity(source))}`;
+	readinessClaimedInProcess.delete(processKey);
+	try {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("DELETE FROM source_lifecycle_state WHERE agent_id = ? AND source_key = ?").run(
+				agentId,
+				sourceKey(sourceIdentity(source)),
+			);
+		});
+	} catch {
+		// Best effort; source deletion must not depend on telemetry state.
+	}
+}
+
+function claimFirstSourceRecall(agentId: string, sourceClass: SourceClass, candidateIds: readonly string[]): void {
+	try {
+		const claimed: SourceLifecycleState[] = [];
+		getDbAccessor().withWriteTx((db) => {
+			const keys = candidateIds.map(sourceKey);
+			if (keys.length === 0) return;
+			const rows = db
+				.prepare(`
+					SELECT source_key, source_class, mode, connected_at, first_indexed_at, first_searchable_at,
+						first_recall_at, last_success_at, last_freshness_state, last_freshness_event_at
+					FROM source_lifecycle_state
+					WHERE agent_id = ? AND source_class = ? AND first_searchable_at IS NOT NULL
+						AND first_recall_at IS NULL AND source_key IN (${keys.map(() => "?").join(",")})
+					ORDER BY first_searchable_at ASC LIMIT 20
+				`)
+				.all(agentId, sourceClass, ...keys) as Array<Record<string, unknown>>;
+			for (const row of rows) {
+				const state = readState(db, agentId, String(row.source_key));
+				if (!state) continue;
+				const result = db
+					.prepare(`
+				UPDATE source_lifecycle_state SET first_recall_at = ?
+				WHERE agent_id = ? AND source_key = ? AND first_recall_at IS NULL
+			`)
+					.run(new Date().toISOString(), agentId, state.sourceKey);
+				if ((result.changes ?? 0) > 0) claimed.push(state);
+			}
+		});
+		for (const state of claimed) {
+			const searchableAt = state.firstSearchableAt ? Date.parse(state.firstSearchableAt) : Number.NaN;
+			emit({
+				phase: "first_recall",
+				outcome: "success",
+				sourceClass,
+				mode: state.mode,
+				latencyBucket: sourceDurationBucket(Number.isFinite(searchableAt) ? Date.now() - searchableAt : 0),
+			});
+		}
+	} catch {
+		// Best effort; recall itself must never depend on telemetry state.
+	}
+}

--- a/platform/daemon/src/source-lifecycle-telemetry.ts
+++ b/platform/daemon/src/source-lifecycle-telemetry.ts
@@ -179,6 +179,11 @@ export function sourceFailureClass(error: unknown): SourceFailureClass {
 	if (/403|permission|forbidden|not authorized|authorization/i.test(text)) return "authorization";
 	if (/token|credential|secret|auth|401/i.test(text)) return "authentication";
 	if (/429|rate limit|too many requests/i.test(text)) return "rate_limited";
+	if (
+		/configuration|root is required|guild id is required|missing .*config|config/i.test(text) ||
+		(/invalid/i.test(text) && /source|root|guild|config|provider/i.test(text))
+	)
+		return "configuration";
 	if (/json|parse|invalid|malformed|schema/i.test(text)) return "parse";
 	if (/network|fetch|socket|timeout|dns|connect|gateway|http 5/i.test(text)) return "network";
 	return "unknown";

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -411,6 +411,45 @@ describe("telemetry collector", () => {
 		).toEqual([]);
 	});
 
+	it("drains events recorded while the shutdown flush is in flight", async () => {
+		let releaseRequest!: () => void;
+		let requestStarted!: () => void;
+		const fetchStarted = new Promise<void>((resolve) => {
+			requestStarted = resolve;
+		});
+		const requestReleased = new Promise<void>((resolve) => {
+			releaseRequest = resolve;
+		});
+		globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+			captured.push({
+				url: String(input),
+				body: JSON.parse(String(init?.body ?? "{}")) as CapturedBody,
+			});
+			requestStarted();
+			await requestReleased;
+			return new Response("1", { status: 200 });
+		}) as typeof fetch;
+
+		try {
+			const collector = makeCollector();
+			collector.record("daemon.started", { version: "0.0.0-test" });
+			const stopping = collector.stop();
+			await fetchStarted;
+
+			// This record lands after the first buffer drain but before the
+			// in-flight PostHog request completes. stop() must flush it after
+			// recording is disabled.
+			collector.record("daemon.heartbeat", { uptimeMs: 1 });
+			releaseRequest();
+			await stopping;
+
+			expect(captured).toHaveLength(2);
+			expect(captured[1]?.body.batch.map((event) => event.event)).toEqual(["daemon.heartbeat"]);
+		} finally {
+			installFetchMock();
+		}
+	});
+
 	it("emits one config snapshot alongside install activation", async () => {
 		const snapshot: TelemetryConfigSnapshot = {
 			graphEnabled: true,

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -49,6 +49,7 @@ interface CapturedBody {
 let dir = "";
 let logPath = "";
 let captured: Array<{ readonly url: string; readonly body: CapturedBody }> = [];
+let pendingFetch: { readonly gate: Promise<void>; readonly started: () => void } | null = null;
 const originalFetch = globalThis.fetch;
 
 function installFetchMock(): void {
@@ -58,6 +59,12 @@ function installFetchMock(): void {
 			url: String(input),
 			body: JSON.parse(String(init?.body ?? "{}")) as CapturedBody,
 		});
+		const blocked = pendingFetch;
+		pendingFetch = null;
+		if (blocked) {
+			blocked.started();
+			await blocked.gate;
+		}
 		return new Response("1", { status: 200 });
 	}) as typeof fetch;
 }
@@ -120,6 +127,7 @@ beforeAll(() => {
 
 beforeEach(() => {
 	captured = [];
+	pendingFetch = null;
 	logPath = defaultTelemetryLogPath(dir);
 	resetWorkspace();
 });
@@ -411,43 +419,38 @@ describe("telemetry collector", () => {
 		).toEqual([]);
 	});
 
-	it("drains events recorded while the shutdown flush is in flight", async () => {
-		let releaseRequest!: () => void;
-		let requestStarted!: () => void;
+	it("drains events recorded while a PostHog flush is in flight before shutdown", async () => {
+		// Regression: overlapping shutdown and timer/explicit flushes could let
+		// stop() return while an earlier PostHog request still owned a claimed
+		// batch. Events recorded during that request then escaped the final drain.
+		let releaseFetch: (() => void) | undefined;
+		let signalFetchStarted: (() => void) | undefined;
 		const fetchStarted = new Promise<void>((resolve) => {
-			requestStarted = resolve;
+			signalFetchStarted = resolve;
 		});
-		const requestReleased = new Promise<void>((resolve) => {
-			releaseRequest = resolve;
+		const fetchGate = new Promise<void>((resolve) => {
+			releaseFetch = resolve;
 		});
-		globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-			captured.push({
-				url: String(input),
-				body: JSON.parse(String(init?.body ?? "{}")) as CapturedBody,
-			});
-			requestStarted();
-			await requestReleased;
-			return new Response("1", { status: 200 });
-		}) as typeof fetch;
+		pendingFetch = { gate: fetchGate, started: () => signalFetchStarted?.() };
 
-		try {
-			const collector = makeCollector();
-			collector.record("daemon.started", { version: "0.0.0-test" });
-			const stopping = collector.stop();
-			await fetchStarted;
+		const collector = makeCollector();
+		collector.record("daemon.heartbeat", { uptimeMs: 1 });
+		const firstFlush = collector.flush();
+		await fetchStarted;
+		collector.record("daemon.heartbeat", { uptimeMs: 2 });
 
-			// This record lands after the first buffer drain but before the
-			// in-flight PostHog request completes. stop() must flush it after
-			// recording is disabled.
-			collector.record("daemon.heartbeat", { uptimeMs: 1 });
-			releaseRequest();
-			await stopping;
+		let stopResolved = false;
+		const stop = collector.stop().then(() => {
+			stopResolved = true;
+		});
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+		expect(stopResolved).toBe(false);
 
-			expect(captured).toHaveLength(2);
-			expect(captured[1]?.body.batch.map((event) => event.event)).toEqual(["daemon.heartbeat"]);
-		} finally {
-			installFetchMock();
-		}
+		releaseFetch?.();
+		await Promise.all([firstFlush, stop]);
+		expect(captured).toHaveLength(2);
+		expect(captured.at(-1)?.body.batch.map((event) => event.event)).toEqual(["daemon.heartbeat"]);
+		expect(unsentCount()).toBe(0);
 	});
 
 	it("emits one config snapshot alongside install activation", async () => {

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -94,6 +94,7 @@ export const TELEMETRY_EVENTS = [
 	// boundaries so search execution cannot be mistaken for delivered context.
 	"recall.attempted",
 	"recall.outcome",
+	"source.lifecycle",
 	"config.snapshot",
 ] as const;
 

--- a/web/docs/src/content/docs/analytics.md
+++ b/web/docs/src/content/docs/analytics.md
@@ -211,6 +211,10 @@ stage/code-only properties. The remaining `pipeline.extraction` and
 `pipeline.decision` event types are declared for future use but not yet
 emitted.
 
+Source lifecycle telemetry uses fixed source classes and bounded lifecycle
+summaries. Local-only hashed state correlates first indexed, searchable, and
+first-recall milestones; the hash itself is never sent.
+
 Privacy contract:
 
 - Events carry no memory content, user identity, agent ids, or file paths.

--- a/web/docs/src/content/docs/api/telemetry-logs.md
+++ b/web/docs/src/content/docs/api/telemetry-logs.md
@@ -193,6 +193,14 @@ result-state, delivery-state, and count fields: `explicit_api`, `tool_call`,
 `not_delivered`. They never include query text, prompt text, memory content,
 identifiers, citations, or feedback prose.
 
+Source indexing emits bounded `source.lifecycle` summaries. The `sourceClass`
+taxonomy is fixed (`transcript`, `document`, `repository`, `note_vault`,
+`browser`, `other`); lifecycle phases cover connection, indexing, readiness,
+first recall, and recurring freshness. Counts, source size, duration, and
+freshness lag are bucketed or capped, and operation summaries replace
+per-document events. Source names, identifiers, paths, URLs, titles, error
+messages, and content are never included.
+
 ### GET /api/telemetry/stats
 
 Aggregated telemetry statistics since daemon start or since a given timestamp.


### PR DESCRIPTION
## Summary

Fixes #1276 by adding bounded, privacy-safe source lifecycle telemetry so analytics can measure source connection, ingest, readiness, first recall, and recurring freshness without receiving source identifiers or content.

## Changes

- Add the `source.lifecycle` event contract with fixed source classes, bounded failure classes, counts, size/duration buckets, readiness milestones, first-recall latency, and freshness lag.
- Add migration 120 for agent-scoped local lifecycle state keyed only by a digest; remove state when sources are deleted.
- Instrument source configuration/index jobs, startup indexing, recurring gateway progress, and shared recall attribution with operation-level summaries.
- Add privacy/bucket contract tests and update telemetry/API documentation.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [x] `@signet/web`
- [ ] `predictor`
- [x] Other: telemetry contract and documentation

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

Migration 120 is append-only and creates `source_lifecycle_state` with `CREATE TABLE IF NOT EXISTS` and a stable index. Existing databases retain all source and telemetry data; source lifecycle state is local correlation metadata and is cleaned up on source deletion. No rollback is required beyond reverting the application migration before it is applied; once applied, the unused table is harmless to older binaries.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused validation completed:

- `bun test platform/core/src/migrations/migrations.test.ts` — 61 passed
- `bun test platform/daemon/src/source-lifecycle-telemetry.test.ts platform/daemon/src/routes/sources-routes.test.ts` — 33 passed
- `bun test platform/daemon/src/telemetry.test.ts platform/daemon/src/memory-search-telemetry.test.ts platform/daemon/src/memory-search.test.ts` — 80 passed
- `bun run --filter '@signet/core' build` — passed
- `bun run --filter '@signet/daemon' build` — passed
- `bun run --filter '@signet/daemon' typecheck` — passed
- Changed-file Biome checks — passed

Repository-wide `bun test`, `bun run typecheck`, and `bun run lint` were also attempted. The current main baseline has unrelated parallel-test/global-state failures, missing generated connector artifacts, and repository-wide formatting drift; those failures are documented in the implementation session and do not involve the changed files.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Telemetry is best-effort and never blocks source ingestion or recall. The external event payload contains only fixed taxonomy values, capped counts, buckets, and lifecycle outcomes; local hashed state is never sent. An independent final self-review reported no actionable findings.

