### PR TITLE
fix(telemetry): summarize pipeline operations (#1278)

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -75,6 +75,7 @@ PostHog failures, and never throws into the daemon.
 | `source.lifecycle` | bounded source connect, index, readiness, first-recall, and recurring freshness milestones | `phase`, fixed `sourceClass`, bounded outcomes/counts/buckets |
 | `pipeline.error` | categorized extraction, decision, or embedding failure | `stage`, `code` only; no message or stack content |
 | `dreaming.pass` | every terminal agentic dreaming pass, including no-op, failed, and cancelled passes | `mode`, `outcome`, `outcomeCode`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `tokensTotal`, `cost`, `accountingProvenance`, `artifactsConsidered`, `memoriesCreated`, `memoriesUpdated`, `memoriesSuperseded`, `memoriesRetired`, `claimsChanged`, `relationshipsChanged`, `provenanceLinksChanged`, `toolCalls`, `durationMs` |
+| `pipeline.operation` | one bounded summary for a logical indexing, capture, recall, dreaming, extraction, or other operation | `operationClass`, `outcome`, `accepted`, `skipped`, `retried`, `failed`, duration/queue-age buckets, optional `causeFamily` |
 | `inference.route` | inference control-plane routing decision | `surface`, `agentId`, `operation`, `taskClass`, `policyId`, `selectedTarget`, `candidateCount`, `blockedCount`, `allowedCount`, `privacy`, `durationMs`, `success`, `errorCode` |
 | `inference.execute` / `inference.stream` | per-execution outcome | `surface`, `agentId`, `operation`, `taskClass`, `policyId`, `selectedTarget`, `finalTarget`, `attemptPath`, `failedTargets`, `attemptCount`, `failedCount`, `fallbackCount`, `privacy`, `durationMs`, `inputTokens`, `outputTokens`, `success`, `cancelled`, `errorCode` |
 | `inference.fallback` | emitted alongside execute/stream when a target failed and routing fell back | same fields as execute/stream |
@@ -107,6 +108,15 @@ and send destination categories rather than raw URLs.
 
 Declared but **not yet emitted**: `pipeline.extraction` and
 `pipeline.decision`.
+
+`pipeline.error` remains the backward-compatible raw attempt stream. Product
+reliability dashboards should use `pipeline.operation` for the primary
+incident count: a source indexing job emits one summary regardless of how
+many chunks or retries it contains. The local `/api/telemetry/stats` response
+exposes both `pipelineErrors` (raw attempts) and `pipelineOperations.incidents`
+(failed or partial logical operations), grouped by operation class and
+normalized cause family. Operation events intentionally carry no operation id,
+source id, content hash, path, provider message, stack, or input details.
 
 Notes on individual events:
 
@@ -191,6 +201,11 @@ Notes on individual events:
   search and additional events for decomposed subqueries. It measures search
   execution, not delivery. Local stats read the flushed telemetry table, so
   they can lag the in-memory event buffer by one flush interval.
+- **Normalized causes** are a bounded taxonomy: `context_limit`,
+  `invalid_input`, `auth`, `quota`, `rate_limit`, `provider_unavailable`,
+  `timeout`, `parse_failure`, `cancellation`, and `internal_error`. HTTP
+  context-limit responses are classified locally from status and response
+  shape, but the response body is never recorded or sent.
 - **Runtime-pressure buckets (#1282)** — heartbeats and rate-limited
   `EventLoopLag` reports carry `runtimePressureVersion`, queue-depth and
   oldest-job-age buckets, active-worker and configured batch-size buckets,

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -588,6 +588,29 @@ export interface TelemetryStatsEnabledResponse {
 	readonly pipelineErrors: number;
 	readonly pipelineErrorsByStage: Readonly<Record<string, number>>;
 	readonly pipelineErrorsByCode: Readonly<Record<string, number>>;
+	readonly pipelineOperations: {
+		readonly total: number;
+		/** Failed or partial operations, bounded independently from raw attempt errors. */
+		readonly incidents: number;
+		readonly classes: Readonly<
+			Record<
+				string,
+				{
+					readonly operations: number;
+					readonly accepted: number;
+					readonly skipped: number;
+					readonly retried: number;
+					readonly failed: number;
+					readonly durationMs: number;
+					readonly queueAgeMs: number;
+					readonly outcomes: Readonly<Record<string, number>>;
+					readonly causes: Readonly<Record<string, number>>;
+					readonly durationBuckets: Readonly<Record<string, number>>;
+					readonly queueAgeBuckets: Readonly<Record<string, number>>;
+				}
+			>
+		>;
+	};
 }
 
 export type TelemetryStatsResponse = TelemetryStatsDisabledResponse | TelemetryStatsEnabledResponse;

--- a/platform/daemon/src/embedding-fetch.test.ts
+++ b/platform/daemon/src/embedding-fetch.test.ts
@@ -199,6 +199,28 @@ describe("fetchEmbedding", () => {
 		expect(capturedUrl).toContain("/api/embeddings");
 	});
 
+	it("classifies an embedding context-limit rejection without exposing its response body", async () => {
+		const causes: string[] = [];
+		globalThis.fetch = mock(() =>
+			Promise.resolve(Response.json({ error: { message: "maximum context length exceeded" } }, { status: 400 })),
+		) as unknown as typeof fetch;
+
+		await expect(
+			fetchEmbedding(
+				"oversized input",
+				{
+					provider: "openai",
+					model: "text-embedding-3-small",
+					dimensions: 3,
+					base_url: "http://localhost:1234/v1",
+				},
+				{ onFailure: (cause) => causes.push(cause) },
+			),
+		).resolves.toBeNull();
+
+		expect(causes).toEqual(["context_limit"]);
+	});
+
 	it("never touches native when warmNative is false and routes to the fallback chain (#1073)", async () => {
 		let capturedUrl: string | undefined;
 		globalThis.fetch = mock((url: string | URL | Request) => {

--- a/platform/daemon/src/embedding-fetch.ts
+++ b/platform/daemon/src/embedding-fetch.ts
@@ -11,8 +11,8 @@ import {
 	DEFAULT_OPENAI_BASE_URL,
 } from "./memory-config";
 import { isPipelineTimeout, recordPipelineError } from "./pipeline-error";
+import { type PipelineCauseFamily, normalizePipelineCause, pipelineCauseFromHttpFailure } from "./pipeline-operation";
 import { countTokens, truncateToTokens } from "./pipeline/tokenizer";
-import { observeEmbeddingLatency } from "./runtime-pressure";
 import { getSecret } from "./secrets.js";
 
 export function resolveOllamaUrl(): string {
@@ -56,6 +56,7 @@ type NativeFallbackProbeResult = {
 	readonly model: LlamaCppEmbeddingModel | null;
 	readonly embedding: number[] | null;
 	readonly tokenCount: number;
+	readonly failureCause?: PipelineCauseFamily;
 };
 type NativeFallbackProbe = {
 	readonly promise: Promise<NativeFallbackProbeResult>;
@@ -80,6 +81,8 @@ export type EmbeddingFetchOptions = {
 	readonly timeoutMs?: number;
 	/** Optional usage attribution recorded with the fetch (source_kind, agent). */
 	readonly usage?: EmbeddingUsageAttribution;
+	/** Internal operation accounting hook; never serialized into telemetry. */
+	readonly onFailure?: (causeFamily: PipelineCauseFamily) => void;
 };
 
 function resolveEmbeddingTimeoutMs(opts: EmbeddingFetchOptions, fallback: number): number {
@@ -90,12 +93,17 @@ function resolveEmbeddingTimeoutMs(opts: EmbeddingFetchOptions, fallback: number
 
 type EmbeddingFetchSignal = {
 	readonly signal: AbortSignal;
+	readonly timedOut: boolean;
 	readonly cleanup: () => void;
 };
 
 function createEmbeddingFetchSignal(opts: EmbeddingFetchOptions, timeoutMs: number): EmbeddingFetchSignal {
 	const controller = new AbortController();
-	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	let timedOut = false;
+	const timer = setTimeout(() => {
+		timedOut = true;
+		controller.abort();
+	}, timeoutMs);
 	let abortCaller: (() => void) | null = null;
 	if (opts.signal) {
 		if (opts.signal.aborted) {
@@ -107,6 +115,9 @@ function createEmbeddingFetchSignal(opts: EmbeddingFetchOptions, timeoutMs: numb
 	}
 	return {
 		signal: controller.signal,
+		get timedOut() {
+			return timedOut;
+		},
 		cleanup: () => {
 			clearTimeout(timer);
 			if (abortCaller) opts.signal?.removeEventListener("abort", abortCaller);
@@ -123,9 +134,56 @@ async function fetchWithEmbeddingTimeout(
 	const state = createEmbeddingFetchSignal(opts, timeoutMs);
 	try {
 		return await fetch(input, { ...init, signal: state.signal });
+	} catch (error) {
+		if (state.timedOut) throw new Error("Embedding request timed out");
+		throw error;
 	} finally {
 		state.cleanup();
 	}
+}
+
+async function readResponsePrefix(response: Response, maxBytes = 4096, timeoutMs = 5000): Promise<string> {
+	const reader = response.clone().body?.getReader();
+	if (!reader) return "";
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			(async () => {
+				const chunks: Uint8Array[] = [];
+				let total = 0;
+				while (total < maxBytes) {
+					const next = await reader.read();
+					if (next.done || !next.value) break;
+					const remaining = maxBytes - total;
+					const chunk = next.value.byteLength > remaining ? next.value.slice(0, remaining) : next.value;
+					chunks.push(chunk);
+					total += chunk.byteLength;
+					if (chunk.byteLength < next.value.byteLength) break;
+				}
+				const bytes = new Uint8Array(total);
+				let offset = 0;
+				for (const chunk of chunks) {
+					bytes.set(chunk, offset);
+					offset += chunk.byteLength;
+				}
+				return new TextDecoder().decode(bytes);
+			})(),
+			new Promise<string>((_, reject) => {
+				timer = setTimeout(() => reject(new Error("Embedding response body timed out")), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+		await reader.cancel().catch(() => {});
+	}
+}
+
+function isEmbeddingVector(value: unknown): value is number[] {
+	return (
+		Array.isArray(value) &&
+		value.length > 0 &&
+		value.every((entry) => typeof entry === "number" && Number.isFinite(entry))
+	);
 }
 
 async function fetchOllamaEmbedding(
@@ -133,7 +191,11 @@ async function fetchOllamaEmbedding(
 	baseUrl: string,
 	model: string,
 	opts: EmbeddingFetchOptions = {},
-): Promise<{ readonly embedding: number[] | null; readonly tokenCount: number }> {
+): Promise<{
+	readonly embedding: number[] | null;
+	readonly tokenCount: number;
+	readonly failureCause?: PipelineCauseFamily;
+}> {
 	const res = await fetchWithEmbeddingTimeout(
 		`${baseUrl.replace(/\/$/, "")}/api/embeddings`,
 		{
@@ -149,10 +211,20 @@ async function fetchOllamaEmbedding(
 			status: res.status,
 			model,
 		});
-		return { embedding: null, tokenCount: countTokens(text) };
+		const responseText = await readResponsePrefix(res, 4096, resolveEmbeddingTimeoutMs(opts, 30000)).catch(() => "");
+		return {
+			embedding: null,
+			tokenCount: countTokens(text),
+			failureCause: pipelineCauseFromHttpFailure(res.status, responseText),
+		};
 	}
-	const data = (await res.json()) as { embedding: number[] };
-	return { embedding: data.embedding ?? null, tokenCount: countTokens(text) };
+	const data = (await res.json()) as { embedding?: unknown };
+	const embedding = isEmbeddingVector(data.embedding) ? data.embedding : null;
+	return {
+		embedding,
+		tokenCount: countTokens(text),
+		...(embedding === null ? { failureCause: "parse_failure" as const } : {}),
+	};
 }
 
 function boundLlamaCppEmbeddingInput(text: string, maxInputTokens: number): { text: string; tokenCount: number } {
@@ -173,7 +245,11 @@ async function fetchLlamaCppEmbedding(
 	opts: EmbeddingFetchOptions,
 	timeoutMs: number,
 	maxInputTokens = DEFAULT_LLAMACPP_MAX_INPUT_TOKENS,
-): Promise<{ readonly embedding: number[] | null; readonly tokenCount: number }> {
+): Promise<{
+	readonly embedding: number[] | null;
+	readonly tokenCount: number;
+	readonly failureCause?: PipelineCauseFamily;
+}> {
 	const bounded = boundLlamaCppEmbeddingInput(text, maxInputTokens);
 	const res = await fetchWithEmbeddingTimeout(
 		`${baseUrl.replace(/\/$/, "")}/v1/embeddings`,
@@ -190,16 +266,29 @@ async function fetchLlamaCppEmbedding(
 			status: res.status,
 			model,
 		});
-		return { embedding: null, tokenCount: bounded.tokenCount };
+		const responseText = await readResponsePrefix(res, 4096, resolveEmbeddingTimeoutMs(opts, timeoutMs)).catch(
+			() => "",
+		);
+		return {
+			embedding: null,
+			tokenCount: bounded.tokenCount,
+			failureCause: pipelineCauseFromHttpFailure(res.status, responseText),
+		};
 	}
-	const data = (await res.json()) as { data?: Array<{ embedding: number[] }> };
-	return { embedding: data.data?.[0]?.embedding ?? null, tokenCount: bounded.tokenCount };
+	const data = (await res.json()) as { data?: Array<{ embedding?: unknown }> };
+	const embedding = data.data?.[0]?.embedding;
+	return {
+		embedding: isEmbeddingVector(embedding) ? embedding : null,
+		tokenCount: bounded.tokenCount,
+		...(isEmbeddingVector(embedding) ? {} : { failureCause: "parse_failure" as const }),
+	};
 }
 
 type EmbeddingServeResult = {
 	readonly embedding: number[] | null;
 	readonly provider: string | null;
 	readonly tokenCount: number;
+	readonly failureCause?: PipelineCauseFamily;
 };
 
 async function fetchNativeFallback(
@@ -211,7 +300,7 @@ async function fetchNativeFallback(
 ): Promise<EmbeddingServeResult> {
 	if (provider === "ollama") {
 		const r = await fetchOllamaEmbedding(text, resolveOllamaUrl(), "nomic-embed-text", opts);
-		return { embedding: r.embedding, provider: "ollama", tokenCount: r.tokenCount };
+		return { embedding: r.embedding, provider: "ollama", tokenCount: r.tokenCount, failureCause: r.failureCause };
 	}
 	const r = await fetchLlamaCppEmbedding(
 		text,
@@ -221,7 +310,7 @@ async function fetchNativeFallback(
 		5000,
 		cfg.llamaCppMaxInputTokens,
 	);
-	return { embedding: r.embedding, provider: "llama-cpp", tokenCount: r.tokenCount };
+	return { embedding: r.embedding, provider: "llama-cpp", tokenCount: r.tokenCount, failureCause: r.failureCause };
 }
 
 async function probeNativeFallback(
@@ -229,6 +318,7 @@ async function probeNativeFallback(
 	cfg: EmbeddingConfig,
 	opts: EmbeddingFetchOptions,
 ): Promise<NativeFallbackProbeResult> {
+	let observedCause: PipelineCauseFamily | undefined;
 	const baseUrl = resolveLlamaCppFallbackBaseUrl(cfg);
 	const discoveredModel = await findLlamaCppEmbeddingModel(baseUrl);
 	if (discoveredModel) {
@@ -236,6 +326,7 @@ async function probeNativeFallback(
 		if (r.embedding) {
 			return { provider: "llama-cpp", model: discoveredModel, embedding: r.embedding, tokenCount: r.tokenCount };
 		}
+		observedCause = preferFallbackCause(observedCause, r.failureCause);
 	}
 
 	try {
@@ -243,11 +334,41 @@ async function probeNativeFallback(
 		if (r.embedding) {
 			return { provider: "ollama", model: null, embedding: r.embedding, tokenCount: r.tokenCount };
 		}
-	} catch {
-		// The aggregate warning below is the single actionable diagnostic.
+		observedCause = preferFallbackCause(observedCause, r.failureCause);
+	} catch (error) {
+		// The aggregate warning below is the single actionable diagnostic, while
+		// retaining the most specific observed cause for operation telemetry.
+		observedCause = preferFallbackCause(observedCause, normalizePipelineCause(error));
 	}
 
-	return { provider: "unavailable", model: null, embedding: null, tokenCount: 0 };
+	return {
+		provider: "unavailable",
+		model: null,
+		embedding: null,
+		tokenCount: 0,
+		failureCause: observedCause ?? "provider_unavailable",
+	};
+}
+
+function preferFallbackCause(
+	current: PipelineCauseFamily | undefined,
+	candidate: PipelineCauseFamily | undefined,
+): PipelineCauseFamily | undefined {
+	if (!candidate) return current;
+	if (!current) return candidate;
+	const priority: Record<PipelineCauseFamily, number> = {
+		context_limit: 100,
+		auth: 90,
+		quota: 80,
+		rate_limit: 70,
+		timeout: 60,
+		parse_failure: 50,
+		invalid_input: 40,
+		provider_unavailable: 30,
+		cancellation: 20,
+		internal_error: 10,
+	};
+	return priority[candidate] > priority[current] ? candidate : current;
 }
 
 async function resolveNativeFallback(
@@ -256,14 +377,16 @@ async function resolveNativeFallback(
 	opts: EmbeddingFetchOptions,
 	nativeError: string,
 ): Promise<EmbeddingServeResult> {
-	if (nativeFallbackProvider === "unavailable") return { embedding: null, provider: null, tokenCount: 0 };
+	if (nativeFallbackProvider === "unavailable") {
+		return { embedding: null, provider: null, tokenCount: 0, failureCause: "provider_unavailable" };
+	}
 	if (nativeFallbackProvider) return fetchNativeFallback(nativeFallbackProvider, text, cfg, opts);
 
 	if (nativeFallbackProbe) {
 		const result = await nativeFallbackProbe.promise;
 		return result.provider !== "unavailable"
 			? fetchNativeFallback(result.provider, text, cfg, opts, result.model)
-			: { embedding: null, provider: null, tokenCount: 0 };
+			: { embedding: null, provider: null, tokenCount: 0, failureCause: result.failureCause };
 	}
 
 	logger.warn("embedding", `Native embedding failed, probing local fallbacks: ${nativeError}`);
@@ -293,6 +416,7 @@ async function resolveNativeFallback(
 			embedding: result.embedding,
 			provider: result.provider === "unavailable" ? null : result.provider,
 			tokenCount: result.tokenCount,
+			failureCause: result.failureCause,
 		};
 	} finally {
 		if (nativeFallbackProbe === probe) nativeFallbackProbe = null;
@@ -372,15 +496,11 @@ export async function fetchEmbedding(
 	const opts = typeof roleOrOpts === "string" ? (typeof optsOrRole === "string" ? {} : optsOrRole) : roleOrOpts;
 	const formattedText = formatEmbeddingInput(text, effectiveCfg, role);
 	try {
-		let serve: EmbeddingServeResult;
-		const providerStartedAt = performance.now();
-		try {
-			serve = await serveEmbedding(formattedText, effectiveCfg, opts);
-		} finally {
-			observeEmbeddingLatency(performance.now() - providerStartedAt);
-		}
-		if (serve.embedding === null && serve.provider !== null) {
-			recordPipelineError("embedding", "EMBEDDING_PROVIDER_DOWN");
+		const serve = await serveEmbedding(formattedText, effectiveCfg, opts);
+		if (serve.embedding === null) {
+			const causeFamily = serve.failureCause ?? "provider_unavailable";
+			if (serve.provider !== null) recordPipelineError("embedding", "EMBEDDING_PROVIDER_DOWN");
+			opts.onFailure?.(causeFamily);
 		}
 		if (serve.embedding !== null && serve.provider !== null) {
 			recordEmbeddingUsage({
@@ -395,7 +515,9 @@ export async function fetchEmbedding(
 		}
 		return serve.embedding;
 	} catch (e) {
+		const causeFamily = normalizePipelineCause(e);
 		recordPipelineError("embedding", isPipelineTimeout(e) ? "EMBEDDING_TIMEOUT" : "EMBEDDING_PROVIDER_DOWN");
+		opts.onFailure?.(causeFamily);
 		logger.warn("embedding", "Embedding fetch error", {
 			provider: effectiveCfg.provider,
 			model: effectiveCfg.model,
@@ -429,7 +551,9 @@ async function serveEmbedding(
 				"native embedding disabled (embedding.warmNative: false)",
 			);
 		}
-		if (nativeFallbackProvider === "unavailable") return { embedding: null, provider: null, tokenCount: 0 };
+		if (nativeFallbackProvider === "unavailable") {
+			return { embedding: null, provider: null, tokenCount: 0, failureCause: "provider_unavailable" };
+		}
 		if (nativeFallbackProvider) return fetchNativeFallback(nativeFallbackProvider, formattedText, effectiveCfg, opts);
 		try {
 			if (!cachedNativeEmbed) {
@@ -437,7 +561,12 @@ async function serveEmbedding(
 				cachedNativeEmbed = mod.nativeEmbed;
 			}
 			const embedding = await cachedNativeEmbed(formattedText);
-			return { embedding, provider: "native", tokenCount: countTokens(formattedText) };
+			return {
+				embedding: isEmbeddingVector(embedding) ? embedding : null,
+				provider: "native",
+				tokenCount: countTokens(formattedText),
+				...(isEmbeddingVector(embedding) ? {} : { failureCause: "parse_failure" as const }),
+			};
 		} catch (nativeErr) {
 			const fallback = await resolveNativeFallback(
 				formattedText,
@@ -450,7 +579,7 @@ async function serveEmbedding(
 	}
 	if (effectiveCfg.provider === "ollama") {
 		const r = await fetchOllamaEmbedding(formattedText, effectiveCfg.base_url, effectiveCfg.model, opts);
-		return { embedding: r.embedding, provider: "ollama", tokenCount: r.tokenCount };
+		return { embedding: r.embedding, provider: "ollama", tokenCount: r.tokenCount, failureCause: r.failureCause };
 	}
 
 	if (effectiveCfg.provider === "llama-cpp") {
@@ -463,14 +592,14 @@ async function serveEmbedding(
 			30000,
 			effectiveCfg.llamaCppMaxInputTokens,
 		);
-		return { embedding: r.embedding, provider: "llama-cpp", tokenCount: r.tokenCount };
+		return { embedding: r.embedding, provider: "llama-cpp", tokenCount: r.tokenCount, failureCause: r.failureCause };
 	}
 
 	const apiKey = await resolveEmbeddingApiKey(effectiveCfg.api_key);
 	const baseUrl = resolveEmbeddingBaseUrl(effectiveCfg);
 	if (!apiKey && requiresOpenAiApiKey(baseUrl)) {
 		logger.warn("embedding", "No API key configured for OpenAI embeddings, skipping request to api.openai.com");
-		return { embedding: null, provider: null, tokenCount: countTokens(formattedText) };
+		return { embedding: null, provider: null, tokenCount: countTokens(formattedText), failureCause: "auth" };
 	}
 	const res = await fetchWithEmbeddingTimeout(
 		`${baseUrl.replace(/\/$/, "")}/embeddings`,
@@ -491,14 +620,20 @@ async function serveEmbedding(
 			provider: effectiveCfg.provider,
 			model: effectiveCfg.model,
 		});
-		return { embedding: null, provider: effectiveCfg.provider, tokenCount: countTokens(formattedText) };
+		const responseText = await readResponsePrefix(res, 4096, resolveEmbeddingTimeoutMs(opts, 30000)).catch(() => "");
+		return {
+			embedding: null,
+			provider: effectiveCfg.provider,
+			tokenCount: countTokens(formattedText),
+			failureCause: pipelineCauseFromHttpFailure(res.status, responseText),
+		};
 	}
-	const data = (await res.json()) as {
-		data: Array<{ embedding: number[] }>;
-	};
+	const data = (await res.json()) as { data?: Array<{ embedding?: unknown }> };
+	const embedding = data.data?.[0]?.embedding;
 	return {
-		embedding: data.data?.[0]?.embedding ?? null,
+		embedding: isEmbeddingVector(embedding) ? embedding : null,
 		provider: effectiveCfg.provider,
 		tokenCount: countTokens(formattedText),
+		...(isEmbeddingVector(embedding) ? {} : { failureCause: "parse_failure" as const }),
 	};
 }

--- a/platform/daemon/src/hooks-recall.test.ts
+++ b/platform/daemon/src/hooks-recall.test.ts
@@ -119,6 +119,46 @@ memory:
 		expect(body.message).toBe("No matching memories found.");
 	});
 
+	it("records recall attempt and outcome telemetry at the hook boundary", async () => {
+		if (!getDbAccessor) throw new Error("db accessor unavailable");
+		const collector = createTelemetryCollector(
+			getDbAccessor(),
+			{
+				posthogHost: "",
+				posthogApiKey: "",
+				flushIntervalMs: 60000,
+				flushBatchSize: 50,
+				retentionDays: 90,
+				memorySearchQaEnabled: false,
+			},
+			"0.0.0-test",
+		);
+		setActiveTelemetry(collector);
+		try {
+			const resp = await app.request("/api/hooks/recall", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					harness: "openclaw",
+					query: "telemetry boundary",
+					limit: 5,
+				}),
+			});
+			expect(resp.status).toBe(200);
+
+			await collector.flush();
+			const events = collector.query();
+			expect(
+				events.some((event) => event.event === "recall.attempted" && event.properties.surface === "tool_call"),
+			).toBeTrue();
+			expect(
+				events.some((event) => event.event === "recall.outcome" && event.properties.surface === "tool_call"),
+			).toBeTrue();
+		} finally {
+			setActiveTelemetry(undefined);
+		}
+	});
+
 	it("records session.deleted as one real session.end at the route boundary", async () => {
 		if (!getDbAccessor) throw new Error("db accessor unavailable");
 		const collector = createTelemetryCollector(
@@ -160,9 +200,16 @@ memory:
 			expect(duplicate.status).toBe(200);
 
 			await collector.flush();
-			const ends = collector.query().filter((event) => event.event === "session.end");
+			const events = collector.query();
+			const ends = events.filter((event) => event.event === "session.end");
 			expect(ends).toHaveLength(1);
 			expect(ends[0]?.properties.reason).toBe("session.deleted");
+			expect(
+				events.some((event) => event.event === "recall.attempted" && event.properties.surface === "prompt_injection"),
+			).toBeTrue();
+			expect(
+				events.some((event) => event.event === "recall.outcome" && event.properties.surface === "prompt_injection"),
+			).toBeTrue();
 		} finally {
 			setActiveTelemetry(undefined);
 			resetSessionEndTelemetry();

--- a/platform/daemon/src/pipeline-operation.test.ts
+++ b/platform/daemon/src/pipeline-operation.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	bucketDurationMs,
+	bucketQueueAgeMs,
+	normalizePipelineCause,
+	recordPipelineOperation,
+} from "./pipeline-operation";
+import { type TelemetryCollector, type TelemetryEvent, setActiveTelemetry } from "./telemetry";
+
+afterEach(() => setActiveTelemetry(undefined));
+
+describe("pipeline operation telemetry", () => {
+	it("keeps logical operation incidents bounded independently from attempts", () => {
+		const events: TelemetryEvent[] = [];
+		const collector = {
+			enabled: true,
+			record(event, properties): void {
+				events.push({ id: "test", event, timestamp: "2026-01-01T00:00:00.000Z", properties });
+			},
+		} as unknown as TelemetryCollector;
+		setActiveTelemetry(collector);
+
+		recordPipelineOperation({
+			operationClass: "indexing",
+			outcome: "partial",
+			accepted: 999,
+			skipped: 1,
+			retried: 4,
+			failed: 17,
+			durationMs: 12_345,
+			queueAgeMs: 61_000,
+			causeFamily: "context_limit",
+		});
+
+		expect(events).toHaveLength(1);
+		expect(events[0]?.event).toBe("pipeline.operation");
+		expect(events[0]?.properties).toEqual({
+			operationClass: "indexing",
+			outcome: "partial",
+			accepted: 999,
+			skipped: 1,
+			retried: 4,
+			failed: 17,
+			durationMs: 12345,
+			durationBucket: "10-59s",
+			queueAgeMs: 61000,
+			queueAgeBucket: "1-4m",
+			causeFamily: "context_limit",
+		});
+	});
+
+	it("normalizes context-limit failures separately from provider outages", () => {
+		expect(normalizePipelineCause({ status: 400, message: "maximum context length exceeded" })).toBe("context_limit");
+		expect(normalizePipelineCause({ status: 503, message: "service unavailable" })).toBe("provider_unavailable");
+		expect(normalizePipelineCause({ status: 429, message: "too many requests" })).toBe("rate_limit");
+		expect(normalizePipelineCause({ status: 429, message: "insufficient_quota" })).toBe("quota");
+		expect(normalizePipelineCause(new Error("request timed out"))).toBe("timeout");
+		expect(normalizePipelineCause({ message: "fetch failed", cause: { code: "ECONNREFUSED" } })).toBe(
+			"provider_unavailable",
+		);
+	});
+
+	it("uses stable duration and queue-age buckets", () => {
+		expect(bucketDurationMs(99)).toBe("0-99ms");
+		expect(bucketDurationMs(60_000)).toBe("1-4m");
+		expect(bucketDurationMs(300_000)).toBe("5m+");
+		expect(bucketQueueAgeMs(999)).toBe("0-999ms");
+		expect(bucketQueueAgeMs(300_000)).toBe("5m+");
+	});
+});

--- a/platform/daemon/src/pipeline-operation.ts
+++ b/platform/daemon/src/pipeline-operation.ts
@@ -1,0 +1,139 @@
+import { getActiveTelemetry } from "./telemetry";
+
+export const PIPELINE_OPERATION_CLASSES = [
+	"indexing",
+	"memory_capture",
+	"recall",
+	"dreaming",
+	"extraction",
+	"other",
+] as const;
+
+export type PipelineOperationClass = (typeof PIPELINE_OPERATION_CLASSES)[number];
+
+export const PIPELINE_OPERATION_OUTCOMES = ["completed", "partial", "skipped", "failed", "cancelled"] as const;
+export type PipelineOperationOutcome = (typeof PIPELINE_OPERATION_OUTCOMES)[number];
+
+export const PIPELINE_CAUSE_FAMILIES = [
+	"context_limit",
+	"invalid_input",
+	"auth",
+	"quota",
+	"rate_limit",
+	"provider_unavailable",
+	"timeout",
+	"parse_failure",
+	"cancellation",
+	"internal_error",
+] as const;
+
+export type PipelineCauseFamily = (typeof PIPELINE_CAUSE_FAMILIES)[number];
+
+function pipelineErrorDetails(error: unknown, depth = 0): { readonly status?: number; readonly text: string } {
+	if (depth > 2) return { text: String(error) };
+	if (typeof error !== "object" || error === null) return { text: String(error) };
+	const record = error as Record<string, unknown>;
+	const nested = record.cause === undefined ? undefined : pipelineErrorDetails(record.cause, depth + 1);
+	return {
+		...(typeof record.status === "number"
+			? { status: record.status }
+			: nested?.status !== undefined
+				? { status: nested.status }
+				: {}),
+		text: [
+			typeof record.message === "string" ? record.message : "",
+			typeof record.code === "string" ? record.code : "",
+			nested?.text ?? "",
+		]
+			.filter(Boolean)
+			.join(" "),
+	};
+}
+
+export function bucketDurationMs(durationMs: number): string {
+	if (!Number.isFinite(durationMs) || durationMs < 0) return "unknown";
+	if (durationMs < 100) return "0-99ms";
+	if (durationMs < 1_000) return "100-999ms";
+	if (durationMs < 10_000) return "1-9s";
+	if (durationMs < 60_000) return "10-59s";
+	if (durationMs < 300_000) return "1-4m";
+	return "5m+";
+}
+
+export function bucketQueueAgeMs(queueAgeMs: number): string {
+	if (!Number.isFinite(queueAgeMs) || queueAgeMs < 0) return "unknown";
+	if (queueAgeMs < 1_000) return "0-999ms";
+	if (queueAgeMs < 10_000) return "1-9s";
+	if (queueAgeMs < 60_000) return "10-59s";
+	if (queueAgeMs < 300_000) return "1-4m";
+	return "5m+";
+}
+
+export function normalizePipelineCause(error: unknown): PipelineCauseFamily {
+	const details = pipelineErrorDetails(error);
+	const status = details.status;
+	const text = details.text.toLowerCase();
+
+	if (status === 401 || status === 403 || /\b(?:unauthori[sz]ed|forbidden|api key|credential|permission)/i.test(text)) {
+		return "auth";
+	}
+	if (status === 402 || /\b(?:quota|billing|credit balance|insufficient funds)\b|insufficient[_ ]quota/i.test(text)) {
+		return "quota";
+	}
+	if (status === 429 || /\b(?:rate.?limit|too many requests|throttl)/i.test(text)) return "rate_limit";
+	if (status === 408 || status === 504) return "timeout";
+	if (
+		status === 413 ||
+		(status === 400 && /\b(?:context|prompt|input|token).{0,30}\b(?:limit|length|max|exceed|long|large)/i.test(text)) ||
+		/\b(?:context(?: window| length)?|prompt|input|token).{0,30}\b(?:limit|length|max|exceed|long|large)/i.test(text) ||
+		/\b(?:maximum context|context length exceeded|too many tokens|input too long|payload too large)\b/i.test(text)
+	) {
+		return "context_limit";
+	}
+	if (/\b(?:abort(?:ed)?|cancel(?:led|ed)?|shutdown)\b/i.test(text)) return "cancellation";
+	if (/\b(?:timeout|timed out|deadline|etimedout)\b/i.test(text)) return "timeout";
+	if (/\b(?:parse|parsing|json|malformed|invalid response|unexpected token)\b/i.test(text)) return "parse_failure";
+	if (/\b(?:econnrefused|enotfound|econnreset|unreachable|unavailable|connection reset|provider down)\b/i.test(text)) {
+		return "provider_unavailable";
+	}
+	if (status !== undefined && status >= 500) return "provider_unavailable";
+	if (status !== undefined && status >= 400 && status < 500) return "invalid_input";
+	return "internal_error";
+}
+
+export function pipelineCauseFromHttpFailure(status: number, responseText = ""): PipelineCauseFamily {
+	return normalizePipelineCause({ status, message: responseText });
+}
+
+export interface PipelineOperationSummary {
+	readonly operationClass: PipelineOperationClass;
+	readonly outcome: PipelineOperationOutcome;
+	readonly accepted: number;
+	readonly skipped: number;
+	readonly retried: number;
+	readonly failed: number;
+	readonly durationMs: number;
+	readonly queueAgeMs: number;
+	readonly causeFamily?: PipelineCauseFamily;
+}
+
+/** Emit one bounded operation summary. Never include ids, paths, content, or provider messages. */
+export function recordPipelineOperation(summary: PipelineOperationSummary): void {
+	const durationMs =
+		Number.isFinite(summary.durationMs) && summary.durationMs >= 0 ? Math.round(summary.durationMs) : 0;
+	const queueAgeMs =
+		Number.isFinite(summary.queueAgeMs) && summary.queueAgeMs >= 0 ? Math.round(summary.queueAgeMs) : 0;
+	getActiveTelemetry()?.record("pipeline.operation", {
+		operationClass: summary.operationClass,
+		outcome: summary.outcome,
+		accepted: Math.max(0, Math.trunc(summary.accepted)),
+		skipped: Math.max(0, Math.trunc(summary.skipped)),
+		retried: Math.max(0, Math.trunc(summary.retried)),
+		failed: Math.max(0, Math.trunc(summary.failed)),
+		durationMs,
+		durationBucket: bucketDurationMs(durationMs),
+		queueAgeMs,
+		queueAgeBucket: bucketQueueAgeMs(queueAgeMs),
+		...(summary.causeFamily ? { causeFamily: summary.causeFamily } : {}),
+	});
+}

--- a/platform/daemon/src/pipeline/document-worker.ts
+++ b/platform/daemon/src/pipeline/document-worker.ts
@@ -67,6 +67,7 @@ interface MutableDocumentOperation {
 	skipped: number;
 	failed: number;
 	cancelled: boolean;
+	operationClass: "indexing" | "extraction";
 	causeFamily?: PipelineCauseFamily;
 }
 
@@ -238,6 +239,7 @@ async function processDocument(
 	operation: MutableDocumentOperation,
 ): Promise<DocumentProcessResult> {
 	const { accessor, embeddingCfg, fetchEmbedding, pipelineCfg } = deps;
+	operation.operationClass = "indexing";
 	const docId = job.document_id;
 	if (!docId) {
 		throw new Error("document_ingest job missing document_id");
@@ -275,6 +277,7 @@ async function processDocument(
 			content = doc.raw_content ?? "";
 		}
 	} catch (err) {
+		operation.operationClass = "extraction";
 		recordPipelineError("extraction", isPipelineTimeout(err) ? "EXTRACTION_TIMEOUT" : "EXTRACTION_PARSE_FAIL");
 		throw err;
 	}
@@ -293,6 +296,7 @@ async function processDocument(
 	}
 
 	if (content.length === 0) {
+		operation.operationClass = "extraction";
 		recordPipelineError("extraction", "EXTRACTION_PARSE_FAIL");
 		let deletedWhileEmpty = false;
 		accessor.withWriteTx((db) => {
@@ -605,7 +609,7 @@ export function startDocumentWorker(deps: DocumentWorkerDeps): DocumentWorkerHan
 					? "skipped"
 					: "completed";
 		recordPipelineOperation({
-			operationClass: "indexing",
+			operationClass: state.operationClass,
 			outcome,
 			accepted: state.accepted,
 			skipped: state.skipped,
@@ -628,7 +632,7 @@ export function startDocumentWorker(deps: DocumentWorkerDeps): DocumentWorkerHan
 		const operation = operations.get(job.id) ?? {
 			startedAtMs: leasedAt,
 			firstLeaseAtMs: leasedAt,
-			state: { accepted: 0, skipped: 0, failed: 0, cancelled: false },
+			state: { accepted: 0, skipped: 0, failed: 0, cancelled: false, operationClass: "indexing" },
 		};
 		operations.set(job.id, operation);
 

--- a/platform/daemon/src/pipeline/document-worker.ts
+++ b/platform/daemon/src/pipeline/document-worker.ts
@@ -18,6 +18,7 @@ import type { EmbeddingRole } from "../embedding-profile";
 import { logger } from "../logger";
 import type { EmbeddingConfig, PipelineV2Config } from "../memory-config";
 import { isPipelineTimeout, recordPipelineError } from "../pipeline-error";
+import { type PipelineCauseFamily, normalizePipelineCause, recordPipelineOperation } from "../pipeline-operation";
 import { isSystemPressureHigh } from "../system-pressure";
 import { txIngestEnvelope } from "../transactions";
 import { fetchUrlContent } from "./url-fetcher";
@@ -51,6 +52,22 @@ interface DocumentJobRow {
 	readonly payload: string | null;
 	readonly attempts: number;
 	readonly max_attempts: number;
+	readonly created_at: string;
+}
+
+interface DocumentProcessResult {
+	readonly accepted: number;
+	readonly skipped: number;
+	readonly failed: number;
+	readonly causeFamily?: PipelineCauseFamily;
+}
+
+interface MutableDocumentOperation {
+	accepted: number;
+	skipped: number;
+	failed: number;
+	cancelled: boolean;
+	causeFamily?: PipelineCauseFamily;
 }
 
 interface DocumentRow {
@@ -105,7 +122,7 @@ function leaseDocumentJob(db: WriteDb, maxAttempts: number): DocumentJobRow | nu
 	const row = db
 		.prepare(
 			`SELECT id, memory_id, document_id, job_type, payload,
-			        attempts, max_attempts
+			        attempts, max_attempts, created_at
 			 FROM memory_jobs
 			 WHERE job_type = 'document_ingest'
 			   AND status = 'pending'
@@ -215,7 +232,11 @@ export function enqueueDocumentIngestJob(accessor: DbAccessor, documentId: strin
 // Core processing logic
 // ---------------------------------------------------------------------------
 
-async function processDocument(deps: DocumentWorkerDeps, job: DocumentJobRow): Promise<void> {
+async function processDocument(
+	deps: DocumentWorkerDeps,
+	job: DocumentJobRow,
+	operation: MutableDocumentOperation,
+): Promise<DocumentProcessResult> {
 	const { accessor, embeddingCfg, fetchEmbedding, pipelineCfg } = deps;
 	const docId = job.document_id;
 	if (!docId) {
@@ -232,7 +253,8 @@ async function processDocument(deps: DocumentWorkerDeps, job: DocumentJobRow): P
 
 	if (doc.status === "done" || doc.status === "deleted") {
 		accessor.withWriteTx((db) => completeJob(db, job.id));
-		return;
+		operation.skipped++;
+		return { accepted: 0, skipped: 1, failed: 0 };
 	}
 	const documentScope = readDocumentScope(doc);
 
@@ -264,19 +286,48 @@ async function processDocument(deps: DocumentWorkerDeps, job: DocumentJobRow): P
 			deletedAfterExtraction = true;
 		}
 	});
-	if (deletedAfterExtraction) return;
+	if (deletedAfterExtraction) {
+		operation.skipped++;
+		operation.cancelled = true;
+		return { accepted: 0, skipped: 1, failed: 0 };
+	}
 
 	if (content.length === 0) {
 		recordPipelineError("extraction", "EXTRACTION_PARSE_FAIL");
+		let deletedWhileEmpty = false;
 		accessor.withWriteTx((db) => {
 			if (isDocumentDeleted(db, docId)) {
 				completeJob(db, job.id);
+				deletedWhileEmpty = true;
 				return;
 			}
 			updateDocumentStatus(db, docId, "failed", "Empty content");
 			failJob(db, job.id, "Empty content", job.attempts, job.max_attempts);
 		});
-		return;
+		if (deletedWhileEmpty) {
+			operation.skipped++;
+			operation.cancelled = true;
+			return {
+				accepted: operation.accepted,
+				skipped: operation.skipped,
+				failed: operation.failed,
+				causeFamily: operation.causeFamily,
+			};
+		}
+		// A retry is still one logical invalid-input operation. Defer its
+		// summary counters until the terminal attempt so retries are represented
+		// only by `retried`, not by duplicate failures or skips.
+		if (job.attempts >= job.max_attempts) {
+			operation.skipped++;
+			operation.failed++;
+			operation.causeFamily ??= "invalid_input";
+		}
+		return {
+			accepted: 0,
+			skipped: job.attempts >= job.max_attempts ? 1 : 0,
+			failed: job.attempts >= job.max_attempts ? 1 : 0,
+			causeFamily: "invalid_input",
+		};
 	}
 
 	// Update title if discovered
@@ -311,11 +362,18 @@ async function processDocument(deps: DocumentWorkerDeps, job: DocumentJobRow): P
 	let aborted = false;
 	for (let i = 0; i < chunks.length; i++) {
 		const chunkText = chunks[i];
-		if (!chunkText || chunkText.trim().length === 0) continue;
+		if (!chunkText || chunkText.trim().length === 0) {
+			operation.skipped++;
+			continue;
+		}
 
 		// Embedding call is outside write lock
 		const vector = await fetchEmbedding(chunkText, embeddingCfg, "document", {
 			usage: { source: "artifact-index", agentId: documentScope.agentId },
+			onFailure: (causeFamily) => {
+				operation.failed++;
+				operation.causeFamily ??= causeFamily;
+			},
 		});
 
 		// Each chunk's memory creation in its own transaction
@@ -323,6 +381,7 @@ async function processDocument(deps: DocumentWorkerDeps, job: DocumentJobRow): P
 			if (isDocumentDeleted(db, docId)) {
 				completeJob(db, job.id);
 				aborted = true;
+				operation.cancelled = true;
 				return;
 			}
 			const normalized = normalizeAndHashContent(chunkText);
@@ -338,7 +397,10 @@ async function processDocument(deps: DocumentWorkerDeps, job: DocumentJobRow): P
 					 LIMIT 1`,
 				)
 				.get(docId, normalized.contentHash);
-			if (existingLink) return;
+			if (existingLink) {
+				operation.skipped++;
+				return;
+			}
 
 			const now = new Date().toISOString();
 			const existingScopedMemory = db
@@ -426,8 +488,17 @@ async function processDocument(deps: DocumentWorkerDeps, job: DocumentJobRow): P
 			}
 
 			memoriesCreated++;
+			operation.accepted++;
 		});
-		if (aborted) return;
+		if (aborted) {
+			operation.skipped++;
+			return {
+				accepted: operation.accepted,
+				skipped: operation.skipped,
+				failed: operation.failed,
+				causeFamily: operation.causeFamily,
+			};
+		}
 	}
 
 	// -- Step 4: Finalize --
@@ -439,12 +510,21 @@ async function processDocument(deps: DocumentWorkerDeps, job: DocumentJobRow): P
 		if (isDocumentDeleted(db, docId)) {
 			completeJob(db, job.id);
 			aborted = true;
+			operation.cancelled = true;
 			return;
 		}
 		completeDocument(db, docId, chunks.length, memoriesCreated);
 		completeJob(db, job.id);
 	});
-	if (aborted) return;
+	if (aborted) {
+		operation.skipped++;
+		return {
+			accepted: operation.accepted,
+			skipped: operation.skipped,
+			failed: operation.failed,
+			causeFamily: operation.causeFamily,
+		};
+	}
 
 	logger.info("document-worker", "Document processed", {
 		documentId: docId,
@@ -452,6 +532,12 @@ async function processDocument(deps: DocumentWorkerDeps, job: DocumentJobRow): P
 		memories: memoriesCreated,
 		title: title ?? "(untitled)",
 	});
+	return {
+		accepted: operation.accepted,
+		skipped: operation.skipped,
+		failed: operation.failed,
+		causeFamily: operation.causeFamily,
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -461,17 +547,98 @@ async function processDocument(deps: DocumentWorkerDeps, job: DocumentJobRow): P
 export function startDocumentWorker(deps: DocumentWorkerDeps): DocumentWorkerHandle {
 	let running = true;
 	let timer: ReturnType<typeof setInterval> | null = null;
+	const operations = new Map<
+		string,
+		{ readonly startedAtMs: number; readonly firstLeaseAtMs: number; readonly state: MutableDocumentOperation }
+	>();
+
+	function terminalStatus(jobId: string): string | null {
+		return deps.accessor.withReadDb((db) => {
+			const row = db.prepare("SELECT status FROM memory_jobs WHERE id = ?").get(jobId) as
+				| { status?: string }
+				| undefined;
+			return row?.status ?? null;
+		});
+	}
+
+	function emitOperation(
+		job: DocumentJobRow,
+		operation: {
+			readonly startedAtMs: number;
+			readonly firstLeaseAtMs: number;
+			readonly state: MutableDocumentOperation;
+		},
+	): void {
+		const { state } = operation;
+		if (job.document_id) {
+			const durable = deps.accessor.withReadDb(
+				(db) =>
+					db.prepare("SELECT chunk_count, memory_count FROM documents WHERE id = ?").get(job.document_id) as
+						| { chunk_count?: number | null; memory_count?: number | null }
+						| undefined,
+			);
+			const durableLinks = deps.accessor.withReadDb(
+				(db) =>
+					db.prepare("SELECT COUNT(*) AS count FROM document_memories WHERE document_id = ?").get(job.document_id) as
+						| { count?: number | null }
+						| undefined,
+			);
+			if (durable) {
+				const accepted =
+					typeof durableLinks?.count === "number"
+						? durableLinks.count
+						: typeof durable.memory_count === "number"
+							? durable.memory_count
+							: 0;
+				const chunks = typeof durable.chunk_count === "number" ? durable.chunk_count : 0;
+				state.accepted = Math.max(state.accepted, accepted);
+				if (chunks > 0) state.skipped = Math.min(state.skipped, Math.max(0, chunks - accepted));
+			}
+		}
+		const outcome = state.cancelled
+			? "cancelled"
+			: state.failed > 0
+				? state.accepted > 0
+					? "partial"
+					: "failed"
+				: state.skipped > 0 && state.accepted === 0
+					? "skipped"
+					: "completed";
+		recordPipelineOperation({
+			operationClass: "indexing",
+			outcome,
+			accepted: state.accepted,
+			skipped: state.skipped,
+			retried: Math.max(0, job.attempts - 1),
+			failed: state.failed,
+			durationMs: Date.now() - operation.startedAtMs,
+			queueAgeMs: operation.firstLeaseAtMs - Date.parse(job.created_at),
+			causeFamily: state.causeFamily,
+		});
+	}
 
 	async function tick(): Promise<void> {
 		if (!running) return;
 		if (isSystemPressureHigh()) return;
 
+		const leasedAt = Date.now();
 		const job = deps.accessor.withWriteTx((db) => leaseDocumentJob(db, deps.pipelineCfg.worker.maxRetries));
 
 		if (!job) return;
+		const operation = operations.get(job.id) ?? {
+			startedAtMs: leasedAt,
+			firstLeaseAtMs: leasedAt,
+			state: { accepted: 0, skipped: 0, failed: 0, cancelled: false },
+		};
+		operations.set(job.id, operation);
 
 		try {
-			await processDocument(deps, job);
+			await processDocument(deps, job, operation.state);
+			const status = terminalStatus(job.id);
+			if (status === "completed" || status === "dead") {
+				emitOperation(job, operation);
+				operations.delete(job.id);
+			}
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : String(err);
 			logger.warn("document-worker", "Job failed", {
@@ -483,6 +650,8 @@ export function startDocumentWorker(deps: DocumentWorkerDeps): DocumentWorkerHan
 			deps.accessor.withWriteTx((db) => {
 				if (job.document_id && isDocumentDeleted(db, job.document_id)) {
 					completeJob(db, job.id);
+					operation.state.skipped++;
+					operation.state.cancelled = true;
 					return;
 				}
 				failJob(db, job.id, msg, job.attempts, job.max_attempts);
@@ -490,6 +659,15 @@ export function startDocumentWorker(deps: DocumentWorkerDeps): DocumentWorkerHan
 					updateDocumentStatus(db, job.document_id, "failed", msg);
 				}
 			});
+			operation.state.causeFamily ??= normalizePipelineCause(err);
+			const status = terminalStatus(job.id);
+			if (status === "dead") {
+				operation.state.failed++;
+			}
+			if (status === "dead" || status === "completed") {
+				emitOperation(job, operation);
+				operations.delete(job.id);
+			}
 		}
 	}
 

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -33,6 +33,7 @@ import { type GraphHygieneCaps, getDreamingHygieneCandidatesInDb } from "../know
 import { logger } from "../logger";
 import type { GraphWriteCaps } from "../ontology-proposals";
 import { isPipelineTimeout, recordPipelineError } from "../pipeline-error";
+import { normalizePipelineCause, recordPipelineOperation } from "../pipeline-operation";
 import { getActiveTelemetry } from "../telemetry";
 import { upsertThreadHead } from "../thread-heads";
 import { createDreamingAgentTools } from "./dreaming-agent-tools";
@@ -1268,6 +1269,8 @@ export async function runDreamingAgentPass(
 	const passStartedAtMs = Date.now();
 	const effects = createDreamingPassEffectState();
 	let toolCallSequence = 0;
+	let applied = 0;
+	let failed = 0;
 	try {
 		const prompt =
 			scopes.length > 1
@@ -1314,11 +1317,19 @@ export async function runDreamingAgentPass(
 				effects: dreamingPassEffects(effects, 0, passStartedAtMs),
 				usage: null,
 			});
+			recordPipelineOperation({
+				operationClass: "dreaming",
+				outcome: "skipped",
+				accepted: 0,
+				skipped: 1,
+				retried: 0,
+				failed: 0,
+				durationMs: Date.now() - passStartedAtMs,
+				queueAgeMs: 0,
+			});
 			return { passId, applied: 0, skipped: 0, failed: 0, summary: earlyExitSummary };
 		}
 
-		let applied = 0;
-		let failed = 0;
 		let applyCallbackReported = false;
 		let retirementCandidates: DreamingRetirementCandidates = new Map();
 		const rejectedEvidence: EpisodicSourceRecord[] = [];
@@ -1490,6 +1501,16 @@ export async function runDreamingAgentPass(
 			effects: dreamingPassEffects(effects, toolCallSequence, passStartedAtMs),
 			usage,
 		});
+		recordPipelineOperation({
+			operationClass: "dreaming",
+			outcome: failed > 0 ? (applied > 0 ? "partial" : "failed") : "completed",
+			accepted: applied,
+			skipped: 0,
+			retried: 0,
+			failed,
+			durationMs: Date.now() - passStartedAtMs,
+			queueAgeMs: 0,
+		});
 
 		return { passId, applied, skipped: 0, failed, summary };
 	} catch (error) {
@@ -1507,6 +1528,17 @@ export async function runDreamingAgentPass(
 				usage: null,
 			});
 		}
+		recordPipelineOperation({
+			operationClass: "dreaming",
+			outcome: applied > 0 ? "partial" : "failed",
+			accepted: applied,
+			skipped: 0,
+			retried: 0,
+			failed: Math.max(1, failed),
+			durationMs: Date.now() - passStartedAtMs,
+			queueAgeMs: 0,
+			causeFamily: normalizePipelineCause(error),
+		});
 		throw error;
 	}
 }

--- a/platform/daemon/src/routes/document-routes.test.ts
+++ b/platform/daemon/src/routes/document-routes.test.ts
@@ -239,6 +239,15 @@ describe("document routes", () => {
 				properties: { stage: "extraction", code: "EXTRACTION_PARSE_FAIL" },
 			}),
 		);
+		expect(telemetry.events).toContainEqual(
+			expect.objectContaining({
+				event: "pipeline.operation",
+				properties: expect.objectContaining({
+					operationClass: "extraction",
+					outcome: "failed",
+				}),
+			}),
+		);
 	});
 
 	it("does not label job validation failures as extraction errors", async () => {

--- a/platform/daemon/src/routes/document-routes.test.ts
+++ b/platform/daemon/src/routes/document-routes.test.ts
@@ -224,8 +224,8 @@ describe("document routes", () => {
 		try {
 			await waitFor(() =>
 				getDbAccessor().withReadDb((db) => {
-					const row = db.prepare("SELECT status FROM documents WHERE id = 'doc-empty'").get() as { status: string };
-					return row.status === "failed";
+					const row = db.prepare("SELECT status FROM memory_jobs WHERE id = 'job-empty'").get() as { status: string };
+					return row.status === "dead";
 				}),
 			);
 		} finally {

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -59,6 +59,7 @@ import {
 	isNotificationCompatibleHook,
 } from "../notifications/cross-agent-notifications";
 import { getSynthesisWorker, readLastSynthesisTime } from "../pipeline";
+import { type PipelineCauseFamily, normalizePipelineCause, recordPipelineOperation } from "../pipeline-operation";
 import { effectiveRecallLimit, recordRecallAttempt, recordRecallOutcome } from "../recall-telemetry";
 import { isNoiseSession } from "../session-noise";
 import { advanceRecallContextEpoch } from "../session-recall-dedupe";
@@ -105,6 +106,51 @@ import {
 export function stampHarness(harness: string | undefined): void {
 	if (harness) {
 		harnessLastSeen.set(harness, new Date().toISOString());
+	}
+}
+
+async function recordHookRecallOperation(handler: () => Promise<Response>): Promise<Response> {
+	const startedAt = Date.now();
+	try {
+		const response = await handler();
+		const status = response.status;
+		const skipped = response.headers.get("x-signet-operation-skipped") === "1";
+		const degraded = response.headers.get("x-signet-operation-degraded") === "1";
+		const cause = response.headers.get("x-signet-operation-cause") as PipelineCauseFamily | null;
+		response.headers.delete("x-signet-operation-skipped");
+		response.headers.delete("x-signet-operation-degraded");
+		response.headers.delete("x-signet-operation-cause");
+		const failed = status >= 400 ? 1 : degraded ? 1 : 0;
+		recordPipelineOperation({
+			operationClass: "recall",
+			outcome: failed > 0 ? "failed" : skipped ? "skipped" : degraded ? "partial" : "completed",
+			accepted: failed > 0 || skipped ? 0 : 1,
+			skipped: skipped ? 1 : 0,
+			retried: 0,
+			failed,
+			durationMs: Date.now() - startedAt,
+			queueAgeMs: 0,
+			causeFamily:
+				failed > 0
+					? (cause ?? normalizePipelineCause({ status }))
+					: degraded
+						? (cause ?? "provider_unavailable")
+						: undefined,
+		});
+		return response;
+	} catch (error) {
+		recordPipelineOperation({
+			operationClass: "recall",
+			outcome: "failed",
+			accepted: 0,
+			skipped: 0,
+			retried: 0,
+			failed: 1,
+			durationMs: Date.now() - startedAt,
+			queueAgeMs: 0,
+			causeFamily: normalizePipelineCause(error),
+		});
+		throw error;
 	}
 }
 
@@ -835,130 +881,154 @@ function registerRecall(app: Hono): void {
 		if (isInternalCall(c)) {
 			return c.json(emptyHookRecallResponse("", { internal: true }));
 		}
-		let recallAttempted = false;
-		try {
-			const body = (await c.req.json()) as RecallRequest;
+		return recordHookRecallOperation(async () => {
+			let recallAttempted = false;
+			try {
+				const body = (await c.req.json()) as RecallRequest;
 
-			if (!body.harness || !body.query) {
-				return c.json({ error: "harness and query are required" }, 400);
-			}
-			const aggregateBudgetInput = readAggregateRecallBudgetInput(body);
-			const aggregateBudget = parseAggregateRecallBudget(aggregateBudgetInput);
-			if (aggregateBudgetInput !== undefined && aggregateBudget === null) {
-				return c.json({ error: "Invalid aggregateBudget. Expected one of: small, medium, large." }, 400);
-			}
-			const temporalTimeError = validateTemporalTimeOptions(body.time);
-			if (temporalTimeError) return c.json({ error: temporalTimeError }, 400);
+				if (!body.harness || !body.query) {
+					return c.json({ error: "harness and query are required" }, 400);
+				}
+				const aggregateBudgetInput = readAggregateRecallBudgetInput(body);
+				const aggregateBudget = parseAggregateRecallBudget(aggregateBudgetInput);
+				if (aggregateBudgetInput !== undefined && aggregateBudget === null) {
+					return c.json({ error: "Invalid aggregateBudget. Expected one of: small, medium, large." }, 400);
+				}
+				const temporalTimeError = validateTemporalTimeOptions(body.time);
+				if (temporalTimeError) return c.json({ error: temporalTimeError }, 400);
 
-			const runtimePath = resolveRuntimePath(c, body);
-			if (runtimePath) body.runtimePath = runtimePath;
+				const runtimePath = resolveRuntimePath(c, body);
+				if (runtimePath) body.runtimePath = runtimePath;
 
-			const conflict = checkSessionClaim(
-				c,
-				body.sessionKey,
-				runtimePath,
-				resolveAgentId({ agentId: parseOptionalString(body.agentId), sessionKey: body.sessionKey }),
-			);
-			if (conflict) return conflict;
+				const conflict = checkSessionClaim(
+					c,
+					body.sessionKey,
+					runtimePath,
+					resolveAgentId({ agentId: parseOptionalString(body.agentId), sessionKey: body.sessionKey }),
+				);
+				if (conflict) return conflict;
 
-			if (checkBypass(body)) {
-				return c.json(emptyHookRecallResponse(body.query, { bypassed: true }));
-			}
+				if (checkBypass(body)) {
+					c.header("x-signet-operation-skipped", "1");
+					return c.json(emptyHookRecallResponse(body.query, { bypassed: true }));
+				}
 
-			const aggregateSaveRequested =
-				body.aggregate === true && body.saveAggregate !== false && body.save_aggregate !== false;
-			if (aggregateSaveRequested) {
-				const denied = await requirePermission("remember", authConfig)(c, () => Promise.resolve());
-				if (denied) return denied;
-			}
+				const aggregateSaveRequested =
+					body.aggregate === true && body.saveAggregate !== false && body.save_aggregate !== false;
+				if (aggregateSaveRequested) {
+					const denied = await requirePermission("remember", authConfig)(c, () => Promise.resolve());
+					if (denied) return denied;
+				}
 
-			const agentId = resolveAgentId({
-				agentId: body.agentId ?? c.req.header("x-signet-agent-id"),
-				sessionKey: body.sessionKey,
-			});
+				const agentId = resolveAgentId({
+					agentId: body.agentId ?? c.req.header("x-signet-agent-id"),
+					sessionKey: body.sessionKey,
+				});
 
-			// When aggregate save is requested, enforce scope for non-admin tokens.
-			if (aggregateSaveRequested) {
-				const aggAuth = c.get("auth");
-				if (aggAuth?.claims && aggAuth.claims.role !== "admin") {
-					const tokenProject = aggAuth.claims.scope?.project;
-					if (tokenProject && (!body.project || body.project !== tokenProject)) {
-						return c.json({ error: `scope restricted to project '${tokenProject}'` }, 403);
-					}
-					const scopeDecision = checkScope(
-						aggAuth.claims,
-						{ agent: agentId, project: body.project ?? undefined },
-						authConfig.mode,
-					);
-					if (!scopeDecision.allowed) {
-						return c.json({ error: scopeDecision.reason ?? "scope violation" }, 403);
+				// When aggregate save is requested, enforce scope for non-admin tokens.
+				if (aggregateSaveRequested) {
+					const aggAuth = c.get("auth");
+					if (aggAuth?.claims && aggAuth.claims.role !== "admin") {
+						const tokenProject = aggAuth.claims.scope?.project;
+						if (tokenProject && (!body.project || body.project !== tokenProject)) {
+							return c.json({ error: `scope restricted to project '${tokenProject}'` }, 403);
+						}
+						const scopeDecision = checkScope(
+							aggAuth.claims,
+							{ agent: agentId, project: body.project ?? undefined },
+							authConfig.mode,
+						);
+						if (!scopeDecision.allowed) {
+							return c.json({ error: scopeDecision.reason ?? "scope violation" }, 403);
+						}
 					}
 				}
-			}
 
-			const agentScope = getAgentScope(agentId);
-			const cfg = loadMemoryConfig(AGENTS_DIR);
-			const recallSurface = "tool_call" as const;
-			if (body.aggregate === true && authConfig.mode !== "local") {
-				const actor = c.get("auth")?.claims?.sub ?? "anonymous";
-				const check = authRecallLlmLimiter.check(actor);
-				if (!check.allowed) {
-					c.header("Retry-After", String(Math.ceil((check.resetAt - Date.now()) / 1000)));
-					return c.json({ error: "rate limit exceeded", retryAfter: check.resetAt }, 429);
+				const agentScope = getAgentScope(agentId);
+				const cfg = loadMemoryConfig(AGENTS_DIR);
+				const recallSurface = "tool_call" as const;
+				if (body.aggregate === true && authConfig.mode !== "local") {
+					const actor = c.get("auth")?.claims?.sub ?? "anonymous";
+					const check = authRecallLlmLimiter.check(actor);
+					if (!check.allowed) {
+						c.header("Retry-After", String(Math.ceil((check.resetAt - Date.now()) / 1000)));
+						return c.json({ error: "rate limit exceeded", retryAfter: check.resetAt }, 429);
+					}
+					authRecallLlmLimiter.record(actor);
 				}
-				authRecallLlmLimiter.record(actor);
+				const requestedProject = parseOptionalString(body.project);
+				const scopedP = resolveScopedProject(c, requestedProject);
+				if (scopedP.error) return c.json({ error: scopedP.error }, 403);
+				recordRecallAttempt(recallSurface);
+				recallAttempted = true;
+				const project = scopedP.project ?? requestedProject;
+				const params: RecallParams = {
+					query: body.query,
+					keywordQuery: body.keywordQuery,
+					limit: body.limit,
+					project,
+					aggregate: body.aggregate,
+					aggregateBudget: aggregateBudget ?? undefined,
+					aggregate_budget: aggregateBudget ?? undefined,
+					saveAggregate: body.saveAggregate ?? body.save_aggregate,
+					save_aggregate: body.save_aggregate ?? body.saveAggregate,
+					type: body.type,
+					tags: body.tags,
+					who: body.who,
+					since: body.since,
+					until: body.until,
+					time: body.time as RecallParams["time"],
+					expand: body.expand,
+					agentId,
+					readPolicy: agentScope.readPolicy,
+					policyGroup: agentScope.policyGroup,
+					sessionKey: body.sessionKey,
+					includeRecalled: body.includeRecalled === true,
+					recallSurface: "api.hooks.recall",
+					recallMode: "hook",
+					telemetrySurface: recallSurface,
+				};
+				let embeddingDegraded = false;
+				let embeddingCause: PipelineCauseFamily | undefined;
+				const embedFn = async (text: string, embeddingConfig: EmbeddingConfig, role?: EmbeddingRole) => {
+					const embedding = await recallAttributedEmbedFn(fetchEmbedding, agentId, (causeFamily) => {
+						embeddingDegraded = true;
+						embeddingCause ??= causeFamily;
+					})(text, embeddingConfig, role);
+					if (embedding === null && embeddingConfig.provider !== "none") embeddingDegraded = true;
+					return embedding;
+				};
+				const result =
+					body.aggregate === true
+						? await aggregateRecall(params, cfg, {
+								router: getInferenceRouterOrNull(),
+								embedFn,
+							})
+						: await hybridRecall(params, cfg, embedFn);
+				if (result.aggregate?.partial === true || embeddingDegraded) {
+					c.header("x-signet-operation-degraded", "1");
+					if (!embeddingCause && result.aggregate?.stoppedReason === "router_unavailable") {
+						embeddingCause = "provider_unavailable";
+					}
+					if (!embeddingCause && result.aggregate?.stoppedReason === "synthesis_failed") {
+						embeddingCause = "internal_error";
+					}
+					if (embeddingCause) c.header("x-signet-operation-cause", embeddingCause);
+				}
+				recordRecallOutcome({
+					surface: recallSurface,
+					resultCount: result.results.length,
+					truncated: result.results.length >= effectiveRecallLimit(params.limit),
+					delivery: "returned",
+				});
+				return c.json(withHookRecallCompat(result));
+			} catch (e) {
+				if (recallAttempted) recordRecallOutcome({ surface: "tool_call", error: true, delivery: "not_delivered" });
+				logger.error("hooks", "Recall hook failed", e as Error);
+				c.header("x-signet-operation-cause", normalizePipelineCause(e));
+				return c.json({ error: "Hook execution failed" }, 500);
 			}
-			const requestedProject = parseOptionalString(body.project);
-			const scopedP = resolveScopedProject(c, requestedProject);
-			if (scopedP.error) return c.json({ error: scopedP.error }, 403);
-			recordRecallAttempt(recallSurface);
-			recallAttempted = true;
-			const project = scopedP.project ?? requestedProject;
-			const params: RecallParams = {
-				query: body.query,
-				keywordQuery: body.keywordQuery,
-				limit: body.limit,
-				project,
-				aggregate: body.aggregate,
-				aggregateBudget: aggregateBudget ?? undefined,
-				aggregate_budget: aggregateBudget ?? undefined,
-				saveAggregate: body.saveAggregate ?? body.save_aggregate,
-				save_aggregate: body.save_aggregate ?? body.saveAggregate,
-				type: body.type,
-				tags: body.tags,
-				who: body.who,
-				since: body.since,
-				until: body.until,
-				time: body.time as RecallParams["time"],
-				expand: body.expand,
-				agentId,
-				readPolicy: agentScope.readPolicy,
-				policyGroup: agentScope.policyGroup,
-				sessionKey: body.sessionKey,
-				includeRecalled: body.includeRecalled === true,
-				recallSurface: "api.hooks.recall",
-				recallMode: "hook",
-				telemetrySurface: recallSurface,
-			};
-			const result =
-				body.aggregate === true
-					? await aggregateRecall(params, cfg, {
-							router: getInferenceRouterOrNull(),
-							embedFn: recallAttributedEmbedFn(fetchEmbedding, agentId),
-						})
-					: await hybridRecall(params, cfg, recallAttributedEmbedFn(fetchEmbedding, agentId));
-			recordRecallOutcome({
-				surface: recallSurface,
-				resultCount: result.results.length,
-				truncated: result.results.length >= effectiveRecallLimit(params.limit),
-				delivery: "returned",
-			});
-			return c.json(withHookRecallCompat(result));
-		} catch (e) {
-			if (recallAttempted) recordRecallOutcome({ surface: "tool_call", error: true, delivery: "not_delivered" });
-			logger.error("hooks", "Recall hook failed", e as Error);
-			return c.json({ error: "Hook execution failed" }, 500);
-		}
+		});
 	});
 }
 
@@ -1865,10 +1935,12 @@ function registerSynthesis(app: Hono): void {
 function recallAttributedEmbedFn(
 	embedFn: typeof fetchEmbedding,
 	agentId: string,
+	onFailure?: (causeFamily: PipelineCauseFamily) => void,
 ): (text: string, cfg: EmbeddingConfig, role?: EmbeddingRole) => Promise<number[] | null> {
 	return (text, cfg, role) =>
 		embedFn(text, cfg, role, {
 			usage: { source: role === "query" ? "recall" : "memory-capture", agentId },
+			onFailure,
 		});
 }
 

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -120,10 +120,11 @@ async function recordHookRecallOperation(handler: () => Promise<Response>): Prom
 		response.headers.delete("x-signet-operation-skipped");
 		response.headers.delete("x-signet-operation-degraded");
 		response.headers.delete("x-signet-operation-cause");
-		const failed = status >= 400 ? 1 : degraded ? 1 : 0;
+		const failed = status >= 400 ? 1 : 0;
+		const partial = degraded ? 1 : 0;
 		recordPipelineOperation({
 			operationClass: "recall",
-			outcome: failed > 0 ? "failed" : skipped ? "skipped" : degraded ? "partial" : "completed",
+			outcome: failed > 0 ? "failed" : skipped ? "skipped" : partial > 0 ? "partial" : "completed",
 			accepted: failed > 0 || skipped ? 0 : 1,
 			skipped: skipped ? 1 : 0,
 			retried: 0,
@@ -133,7 +134,7 @@ async function recordHookRecallOperation(handler: () => Promise<Response>): Prom
 			causeFamily:
 				failed > 0
 					? (cause ?? normalizePipelineCause({ status }))
-					: degraded
+					: partial > 0
 						? (cause ?? "provider_unavailable")
 						: undefined,
 		});
@@ -881,8 +882,9 @@ function registerRecall(app: Hono): void {
 		if (isInternalCall(c)) {
 			return c.json(emptyHookRecallResponse("", { internal: true }));
 		}
+		let recallAttempted = false;
+		const recallSurface = "tool_call" as const;
 		return recordHookRecallOperation(async () => {
-			let recallAttempted = false;
 			try {
 				const body = (await c.req.json()) as RecallRequest;
 
@@ -1023,7 +1025,7 @@ function registerRecall(app: Hono): void {
 				});
 				return c.json(withHookRecallCompat(result));
 			} catch (e) {
-				if (recallAttempted) recordRecallOutcome({ surface: "tool_call", error: true, delivery: "not_delivered" });
+				if (recallAttempted) recordRecallOutcome({ surface: recallSurface, error: true, delivery: "not_delivered" });
 				logger.error("hooks", "Recall hook failed", e as Error);
 				c.header("x-signet-operation-cause", normalizePipelineCause(e));
 				return c.json({ error: "Hook execution failed" }, 500);

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { applyRecallScoreThreshold, vectorSearch } from "@signet/core";
+import { vectorSearch } from "@signet/core";
 import type { Context, Hono } from "hono";
 import { ensureAgentRegistered, getAgentScope, resolveAgentId } from "../agent-id";
 import { aggregateRecall, parseAggregateRecallBudget, readAggregateRecallBudgetInput } from "../aggregate-recall";
@@ -34,12 +34,7 @@ import { resolveMemorySearchTelemetryProject } from "../memory-search-telemetry-
 import { buildMemoryTimeline } from "../memory-timeline";
 import { recordPathFeedback } from "../path-feedback";
 import { enqueueDocumentIngestJob } from "../pipeline";
-import {
-	effectiveRecallLimit,
-	normalizeRecallSurface,
-	recordRecallAttempt,
-	recordRecallOutcome,
-} from "../recall-telemetry";
+import { type PipelineCauseFamily, normalizePipelineCause, recordPipelineOperation } from "../pipeline-operation";
 import { parseFeedback, recordAgentFeedback } from "../session-memories";
 import { upsertSessionTranscript } from "../session-transcripts";
 import { getActiveTelemetry } from "../telemetry";
@@ -551,10 +546,12 @@ function recordRecallQaTelemetry(input: {
 function recallAttributedEmbedFn(
 	embedFn: typeof fetchEmbedding,
 	agentId: string,
+	onFailure?: (causeFamily: PipelineCauseFamily) => void,
 ): (text: string, cfg: EmbeddingConfig, role?: EmbeddingRole) => Promise<number[] | null> {
 	return (text, cfg, role) =>
 		embedFn(text, cfg, role, {
 			usage: { source: role === "query" ? "recall" : "memory-capture", agentId },
+			onFailure,
 		});
 }
 
@@ -640,6 +637,55 @@ function recordFirstUseTelemetry(kind: "remember" | "recall"): void {
 	getActiveTelemetry()?.recordFirstUse(kind);
 }
 
+const routeOperationFailures = new WeakMap<object, PipelineCauseFamily[]>();
+
+function recordRouteOperationFailure(c: Context): (causeFamily: PipelineCauseFamily) => void {
+	const failures = routeOperationFailures.get(c);
+	return (causeFamily) => failures?.push(causeFamily);
+}
+
+function normalizeRouteFailure(status: number): PipelineCauseFamily {
+	return status === 500 ? "internal_error" : normalizePipelineCause({ status });
+}
+
+async function responseOperationSummary(
+	response: Response,
+): Promise<{ readonly deduped: boolean; readonly accepted?: number }> {
+	const reader = response.clone().body?.getReader();
+	if (!reader) return { deduped: false };
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	try {
+		while (total < 64 * 1024) {
+			const next = await reader.read();
+			if (next.done || !next.value) break;
+			const remaining = 64 * 1024 - total;
+			const chunk = next.value.byteLength > remaining ? next.value.slice(0, remaining) : next.value;
+			chunks.push(chunk);
+			total += chunk.byteLength;
+			if (chunk.byteLength < next.value.byteLength) break;
+		}
+	} finally {
+		await reader.cancel().catch(() => {});
+	}
+	const bytes = new Uint8Array(total);
+	let offset = 0;
+	for (const chunk of chunks) {
+		bytes.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	try {
+		const parsed = JSON.parse(new TextDecoder().decode(bytes)) as { deduped?: unknown; chunk_count?: unknown };
+		const chunkCount =
+			typeof parsed.chunk_count === "number" && Number.isSafeInteger(parsed.chunk_count) && parsed.chunk_count >= 0
+				? Math.min(parsed.chunk_count, 10_000)
+				: undefined;
+		return { deduped: parsed.deduped === true, ...(chunkCount === undefined ? {} : { accepted: chunkCount }) };
+	} catch {
+		return { deduped: false };
+	}
+}
+
 export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): void {
 	const aggregateRecallFn = deps.aggregateRecall ?? aggregateRecall;
 	const hybridRecallFn = deps.hybridRecall ?? hybridRecall;
@@ -666,6 +712,75 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	app.use("/api/memory/recall", async (c, next) => {
 		return requirePermission("recall", authConfig)(c, next);
 	});
+
+	async function recordRequestOperation(
+		c: Context,
+		next: () => Promise<void>,
+		operationClass: "memory_capture" | "recall",
+	): Promise<Response> {
+		const startedAt = Date.now();
+		const failures: PipelineCauseFamily[] = [];
+		routeOperationFailures.set(c, failures);
+		try {
+			await next();
+		} catch (error) {
+			recordPipelineOperation({
+				operationClass,
+				outcome: "failed",
+				accepted: 0,
+				skipped: 0,
+				retried: 0,
+				failed: 1,
+				durationMs: Date.now() - startedAt,
+				queueAgeMs: 0,
+				causeFamily: normalizePipelineCause(error),
+			});
+			routeOperationFailures.delete(c);
+			throw error;
+		}
+		const status = c.res.status;
+		if (c.res.headers.get("x-signet-operation-recorded") === "1") {
+			c.res.headers.delete("x-signet-operation-recorded");
+			routeOperationFailures.delete(c);
+			return c.res;
+		}
+		const responseSummary = operationClass === "memory_capture" ? await responseOperationSummary(c.res) : undefined;
+		const skipped =
+			operationClass === "memory_capture" &&
+			(c.res.headers.get("x-signet-operation-skipped") === "1" || responseSummary?.deduped === true)
+				? 1
+				: 0;
+		const failed = failures.length > 0 ? failures.length : status >= 400 && skipped === 0 ? 1 : 0;
+		const outcome = skipped > 0 ? "skipped" : failed > 0 ? (status >= 400 ? "failed" : "partial") : "completed";
+		const accepted = outcome === "completed" || outcome === "partial" ? (responseSummary?.accepted ?? 1) : 0;
+		recordPipelineOperation({
+			operationClass,
+			outcome,
+			accepted,
+			skipped,
+			retried: 0,
+			failed,
+			durationMs: Date.now() - startedAt,
+			queueAgeMs: 0,
+			causeFamily: failed > 0 ? (failures[0] ?? normalizeRouteFailure(status)) : undefined,
+		});
+		c.res.headers.delete("x-signet-operation-skipped");
+		if (c.req.header("x-signet-operation-forwarded") === "1") {
+			c.header("x-signet-operation-recorded", "1");
+		} else {
+			c.res.headers.delete("x-signet-operation-recorded");
+		}
+		routeOperationFailures.delete(c);
+		return c.res;
+	}
+
+	app.use("/api/memory/remember", async (c, next) => recordRequestOperation(c, next, "memory_capture"));
+	app.use("/api/memory/save", async (c, next) => recordRequestOperation(c, next, "memory_capture"));
+	app.use("/api/hook/remember", async (c, next) => recordRequestOperation(c, next, "memory_capture"));
+	app.use("/api/memory/recall", async (c, next) => recordRequestOperation(c, next, "recall"));
+	app.use("/api/memory/search", async (c, next) => recordRequestOperation(c, next, "recall"));
+	app.use("/memory/search", async (c, next) => recordRequestOperation(c, next, "recall"));
+	app.use("/memory/similar", async (c, next) => recordRequestOperation(c, next, "recall"));
 	app.use("/api/memory/search", async (c, next) => {
 		return requirePermission("recall", authConfig)(c, next);
 	});
@@ -1029,7 +1144,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const query = c.req.query("q") ?? "";
 		const distinct = c.req.query("distinct");
 		const limitParam = c.req.query("limit");
-		const parsedLimit = limitParam ? Number.parseInt(limitParam, 10) : undefined;
+		const limit = limitParam ? Number.parseInt(limitParam, 10) : null;
 
 		// Shortcut: return distinct values for a column
 		if (distinct === "who") {
@@ -1056,10 +1171,6 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		};
 
 		const hasFilters = Object.values(filterParams).some((v) => v !== "" && v !== false && v !== null);
-		if (!query.trim() && !hasFilters) return c.json({ results: [] });
-		const limit = effectiveRecallLimit(parsedLimit ?? (query.trim() ? 20 : 50));
-		const recallSurface = normalizeRecallSurface(c.req.header("x-signet-recall-surface"), "dashboard");
-		recordRecallAttempt(recallSurface);
 
 		try {
 			const results = getDbAccessor().withReadDb((db) => {
@@ -1078,7 +1189,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
             JOIN memories m ON memories_fts.rowid = m.rowid
             WHERE memories_fts MATCH ?${clause}
             ORDER BY score
-							LIMIT ${limit}
+            LIMIT ${limit ?? 20}
           `,
 						).all(query, ...args);
 					} catch {
@@ -1091,7 +1202,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
             FROM memories
             WHERE (content LIKE ? OR tags LIKE ?)${rc}
             ORDER BY created_at DESC
-							LIMIT ${limit}
+            LIMIT ${limit ?? 20}
           `,
 						).all(`%${query}%`, `%${query}%`, ...rargs);
 					}
@@ -1109,7 +1220,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
           FROM memories
           WHERE 1=1${clause}
           ORDER BY score DESC
-						LIMIT ${limit}
+          LIMIT ${limit ?? 50}
         `,
 					).all(...args);
 				}
@@ -1117,17 +1228,10 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				return rows;
 			});
 
-			recordRecallOutcome({
-				surface: recallSurface,
-				resultCount: results.length,
-				truncated: results.length >= limit,
-				delivery: "returned",
-			});
 			return c.json({ results });
 		} catch (e) {
-			recordRecallOutcome({ surface: recallSurface, error: true, delivery: "not_delivered" });
 			logger.error("memory", "Error searching memories", e as Error);
-			return c.json({ results: [], error: "Search failed" });
+			return c.json({ results: [], error: "Search failed" }, 500);
 		}
 	});
 
@@ -1368,6 +1472,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					return c.json({ error: "idempotencyKey already used for different chunked content" }, 409);
 				}
 
+				c.header("x-signet-operation-skipped", "1");
 				recordFirstUseTelemetry("remember");
 				return c.json({
 					chunked: true,
@@ -1477,6 +1582,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					return c.json({ error: "chunk content already exists for this agent and scope" }, 409);
 				}
 				if (result.status === "deduped") {
+					c.header("x-signet-operation-skipped", "1");
 					recordFirstUseTelemetry("remember");
 					return c.json({
 						chunked: true,
@@ -1496,6 +1602,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					try {
 						const vec = await fetchEmbedding(plan.normalized.storageContent, fullCfg.embedding, "document", {
 							usage: { source: "memory-capture", agentId },
+							onFailure: recordRouteOperationFailure(c),
 						});
 						if (vec) {
 							if (vec.length !== fullCfg.embedding.dimensions) {
@@ -1681,6 +1788,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			supersededStatus = result.deduped ? null : (result as { superseded: SupersedeMemoryTxStatus | null }).superseded;
 
 			if (result.deduped) {
+				c.header("x-signet-operation-skipped", "1");
 				getDbAccessor().withWriteTx((db) =>
 					txInsertExplicitTemporalEdges({
 						db,
@@ -1711,6 +1819,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					return getScopedContentHashDedupeRow(db, contentHash, dedupeScope);
 				});
 				if (existing) {
+					c.header("x-signet-operation-skipped", "1");
 					getDbAccessor().withWriteTx((db) =>
 						txInsertExplicitTemporalEdges({
 							db,
@@ -1754,6 +1863,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			const cfg = withActiveEmbeddingConfig(baseCfg);
 			const vec = await fetchEmbedding(normalizedContent.storageContent, cfg.embedding, "document", {
 				usage: { source: "memory-capture", agentId },
+				onFailure: recordRouteOperationFailure(c),
 			});
 			if (vec) {
 				if (vec.length !== cfg.embedding.dimensions) {
@@ -1868,6 +1978,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	app.post("/api/memory/save", async (c) => {
 		const body = await c.req.json().catch(() => ({}));
 		const headers: Record<string, string> = { "Content-Type": "application/json" };
+		headers["x-signet-operation-forwarded"] = "1";
 		const authHdr = c.req.header("authorization");
 		if (authHdr) headers.authorization = authHdr;
 		const sessionKey = c.req.header("x-signet-session-key");
@@ -1885,6 +1996,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	app.post("/api/hook/remember", async (c) => {
 		const body = await c.req.json().catch(() => ({}));
 		const headers: Record<string, string> = { "Content-Type": "application/json" };
+		headers["x-signet-operation-forwarded"] = "1";
 		const authHdr = c.req.header("authorization");
 		if (authHdr) headers.authorization = authHdr;
 		const sessionKey = c.req.header("x-signet-session-key");
@@ -3030,7 +3142,6 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 		const aggregateSaveRequested =
 			body.aggregate === true && body.saveAggregate !== false && body.save_aggregate !== false;
-		const recallLimit = effectiveRecallLimit(body.limit);
 		if (aggregateSaveRequested) {
 			const denied = await requirePermission("remember", authConfig)(c, () => Promise.resolve());
 			if (denied) return denied;
@@ -3049,12 +3160,10 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			}
 			authRecallLlmLimiter.record(actor);
 		}
-		let recallAttempted = false;
 		try {
 			const sessionKeyRaw = body.sessionKey ?? c.req.header("x-signet-session-key");
 			const sessionKey = sessionKeyRaw ?? null;
 			const agentId = resolveAgentId({ agentId: body.agentId, sessionKey: sessionKeyRaw });
-			const recallSurface = normalizeRecallSurface(body.recallSurface, "explicit_api");
 
 			// When aggregate save is requested, enforce scope for non-admin tokens.
 			if (aggregateSaveRequested) {
@@ -3075,14 +3184,11 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				}
 			}
 
-			recordRecallAttempt(recallSurface);
-			recallAttempted = true;
 			const agentScope = getAgentScope(agentId);
 			const scopeProject = c.get("auth")?.claims?.scope?.project;
 			const params = {
 				...body,
 				query,
-				limit: recallLimit,
 				aggregate: body.aggregate,
 				aggregateBudget: aggregateBudget ?? undefined,
 				aggregate_budget: aggregateBudget ?? undefined,
@@ -3093,7 +3199,6 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				policyGroup: agentScope.policyGroup ?? undefined,
 				sessionKey: sessionKeyRaw,
 				includeRecalled: body.includeRecalled === true,
-				telemetrySurface: recallSurface,
 				recallSurface: "api.memory.recall",
 				recallMode: "direct",
 				...(scopeProject ? { project: scopeProject } : {}),
@@ -3102,34 +3207,25 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				body.aggregate === true
 					? await aggregateRecallFn(params, cfg, {
 							router: getInferenceRouterOrNullFn(),
-							embedFn: recallAttributedEmbedFn(fetchEmbeddingFn, agentId),
+							embedFn: recallAttributedEmbedFn(fetchEmbeddingFn, agentId, recordRouteOperationFailure(c)),
 						})
-					: await hybridRecallFn(params, cfg, recallAttributedEmbedFn(fetchEmbeddingFn, agentId));
-			const requestedMinScore = (body as { readonly minScore?: unknown }).minScore;
-			const returnedResult = applyRecallScoreThreshold(
-				result,
-				typeof requestedMinScore === "number" ? requestedMinScore : undefined,
-			) as typeof result;
+					: await hybridRecallFn(
+							params,
+							cfg,
+							recallAttributedEmbedFn(fetchEmbeddingFn, agentId, recordRouteOperationFailure(c)),
+						);
 			recordRecallQaTelemetry({
 				route: "POST /api/memory/recall",
 				agentId,
 				sessionKey,
 				project: resolveMemorySearchTelemetryProject(params),
 				params,
-				result: returnedResult,
+				result,
 				cfg,
 			});
-			recordRecallOutcome({
-				surface: recallSurface,
-				resultCount: returnedResult.results.length,
-				truncated: returnedResult.results.length >= recallLimit,
-				delivery: "returned",
-			});
 			recordFirstUseTelemetry("recall");
-			return c.json(returnedResult);
+			return c.json(result);
 		} catch (e) {
-			const recallSurface = normalizeRecallSurface(body.recallSurface, "explicit_api");
-			if (recallAttempted) recordRecallOutcome({ surface: recallSurface, error: true, delivery: "not_delivered" });
 			logger.error("memory", "Recall failed", e as Error);
 			return c.json({ error: "Recall failed", results: [] }, 500);
 		}
@@ -3142,7 +3238,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const q = (c.req.query("q") ?? "").trim();
 		if (!q) return c.json({ error: "query is required" }, 400);
 
-		const limit = effectiveRecallLimit(Number.parseInt(c.req.query("limit") ?? "10", 10));
+		const limit = Number.parseInt(c.req.query("limit") ?? "10", 10);
 		const type = c.req.query("type");
 		const tags = c.req.query("tags");
 		const who = c.req.query("who");
@@ -3164,8 +3260,6 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				agentId: c.req.query("agentId") ?? c.req.query("agent_id") ?? c.req.header("x-signet-agent-id"),
 				sessionKey: sessionKeyRaw,
 			});
-			const recallSurface = "explicit_api" as const;
-			recordRecallAttempt(recallSurface);
 			const agentScope = getAgentScope(agentId);
 			const params = {
 				query: q,
@@ -3184,12 +3278,15 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				policyGroup: agentScope.policyGroup ?? undefined,
 				sessionKey: sessionKeyRaw,
 				includeRecalled: includeRecalled === "1" || includeRecalled === "true",
-				telemetrySurface: recallSurface,
 				recallSurface: "api.memory.search",
 				recallMode: "direct",
 				...(scopeProject ? { project: scopeProject } : {}),
 			};
-			const result = await hybridRecall(params, cfg, recallAttributedEmbedFn(fetchEmbedding, agentId));
+			const result = await hybridRecall(
+				params,
+				cfg,
+				recallAttributedEmbedFn(fetchEmbedding, agentId, recordRouteOperationFailure(c)),
+			);
 			recordRecallQaTelemetry({
 				route: "GET /api/memory/search",
 				agentId,
@@ -3199,15 +3296,8 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				result,
 				cfg,
 			});
-			recordRecallOutcome({
-				surface: recallSurface,
-				resultCount: result.results.length,
-				truncated: result.results.length >= limit,
-				delivery: "returned",
-			});
 			return c.json(result);
 		} catch (e) {
-			recordRecallOutcome({ surface: "explicit_api", error: true, delivery: "not_delivered" });
 			logger.error("memory", "Search (recall alias) failed", e as Error);
 			return c.json({ error: "Recall failed", results: [] }, 500);
 		}

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -791,10 +791,24 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		return requirePermission("recall", authConfig)(c, next);
 	});
 	app.use("/api/memory/timeline", async (c, next) => {
-		return requirePermission("recall", authConfig)(c, next);
+		return recordRequestOperation(
+			c,
+			async () => {
+				const denied = await requirePermission("recall", authConfig)(c, next);
+				if (denied) c.res = denied;
+			},
+			"recall",
+		);
 	});
 	app.use("/api/memories/curator-slices", async (c, next) => {
-		return requirePermission("recall", authConfig)(c, next);
+		return recordRequestOperation(
+			c,
+			async () => {
+				const denied = await requirePermission("recall", authConfig)(c, next);
+				if (denied) c.res = denied;
+			},
+			"recall",
+		);
 	});
 
 	// Modify — with rate limiting

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { vectorSearch } from "@signet/core";
+import { applyRecallScoreThreshold, vectorSearch } from "@signet/core";
 import type { Context, Hono } from "hono";
 import { ensureAgentRegistered, getAgentScope, resolveAgentId } from "../agent-id";
 import { aggregateRecall, parseAggregateRecallBudget, readAggregateRecallBudgetInput } from "../aggregate-recall";
@@ -35,6 +35,12 @@ import { buildMemoryTimeline } from "../memory-timeline";
 import { recordPathFeedback } from "../path-feedback";
 import { enqueueDocumentIngestJob } from "../pipeline";
 import { type PipelineCauseFamily, normalizePipelineCause, recordPipelineOperation } from "../pipeline-operation";
+import {
+	effectiveRecallLimit,
+	normalizeRecallSurface,
+	recordRecallAttempt,
+	recordRecallOutcome,
+} from "../recall-telemetry";
 import { parseFeedback, recordAgentFeedback } from "../session-memories";
 import { upsertSessionTranscript } from "../session-transcripts";
 import { getActiveTelemetry } from "../telemetry";
@@ -1158,7 +1164,6 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const query = c.req.query("q") ?? "";
 		const distinct = c.req.query("distinct");
 		const limitParam = c.req.query("limit");
-		const limit = limitParam ? Number.parseInt(limitParam, 10) : null;
 
 		// Shortcut: return distinct values for a column
 		if (distinct === "who") {
@@ -1185,6 +1190,10 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		};
 
 		const hasFilters = Object.values(filterParams).some((v) => v !== "" && v !== false && v !== null);
+		if (!query.trim() && !hasFilters) return c.json({ results: [] });
+		const limit = effectiveRecallLimit(limitParam ? Number.parseInt(limitParam, 10) : query.trim() ? 20 : 50);
+		const recallSurface = normalizeRecallSurface(c.req.header("x-signet-recall-surface"), "dashboard");
+		recordRecallAttempt(recallSurface);
 
 		try {
 			const results = getDbAccessor().withReadDb((db) => {
@@ -1242,8 +1251,15 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				return rows;
 			});
 
+			recordRecallOutcome({
+				surface: recallSurface,
+				resultCount: results.length,
+				truncated: results.length >= limit,
+				delivery: "returned",
+			});
 			return c.json({ results });
 		} catch (e) {
+			recordRecallOutcome({ surface: recallSurface, error: true, delivery: "not_delivered" });
 			logger.error("memory", "Error searching memories", e as Error);
 			return c.json({ results: [], error: "Search failed" }, 500);
 		}
@@ -3156,6 +3172,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 		const aggregateSaveRequested =
 			body.aggregate === true && body.saveAggregate !== false && body.save_aggregate !== false;
+		const recallLimit = effectiveRecallLimit(body.limit);
 		if (aggregateSaveRequested) {
 			const denied = await requirePermission("remember", authConfig)(c, () => Promise.resolve());
 			if (denied) return denied;
@@ -3174,10 +3191,12 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			}
 			authRecallLlmLimiter.record(actor);
 		}
+		let recallAttempted = false;
 		try {
 			const sessionKeyRaw = body.sessionKey ?? c.req.header("x-signet-session-key");
 			const sessionKey = sessionKeyRaw ?? null;
 			const agentId = resolveAgentId({ agentId: body.agentId, sessionKey: sessionKeyRaw });
+			const recallSurface = normalizeRecallSurface(body.recallSurface, "explicit_api");
 
 			// When aggregate save is requested, enforce scope for non-admin tokens.
 			if (aggregateSaveRequested) {
@@ -3198,11 +3217,14 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				}
 			}
 
+			recordRecallAttempt(recallSurface);
+			recallAttempted = true;
 			const agentScope = getAgentScope(agentId);
 			const scopeProject = c.get("auth")?.claims?.scope?.project;
 			const params = {
 				...body,
 				query,
+				limit: recallLimit,
 				aggregate: body.aggregate,
 				aggregateBudget: aggregateBudget ?? undefined,
 				aggregate_budget: aggregateBudget ?? undefined,
@@ -3213,6 +3235,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				policyGroup: agentScope.policyGroup ?? undefined,
 				sessionKey: sessionKeyRaw,
 				includeRecalled: body.includeRecalled === true,
+				telemetrySurface: recallSurface,
 				recallSurface: "api.memory.recall",
 				recallMode: "direct",
 				...(scopeProject ? { project: scopeProject } : {}),
@@ -3228,18 +3251,31 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 							cfg,
 							recallAttributedEmbedFn(fetchEmbeddingFn, agentId, recordRouteOperationFailure(c)),
 						);
+			const requestedMinScore = (body as { readonly minScore?: unknown }).minScore;
+			const returnedResult = applyRecallScoreThreshold(
+				result,
+				typeof requestedMinScore === "number" ? requestedMinScore : undefined,
+			) as typeof result;
 			recordRecallQaTelemetry({
 				route: "POST /api/memory/recall",
 				agentId,
 				sessionKey,
 				project: resolveMemorySearchTelemetryProject(params),
 				params,
-				result,
+				result: returnedResult,
 				cfg,
 			});
+			recordRecallOutcome({
+				surface: recallSurface,
+				resultCount: returnedResult.results.length,
+				truncated: returnedResult.results.length >= recallLimit,
+				delivery: "returned",
+			});
 			recordFirstUseTelemetry("recall");
-			return c.json(result);
+			return c.json(returnedResult);
 		} catch (e) {
+			const recallSurface = normalizeRecallSurface(body.recallSurface, "explicit_api");
+			if (recallAttempted) recordRecallOutcome({ surface: recallSurface, error: true, delivery: "not_delivered" });
 			logger.error("memory", "Recall failed", e as Error);
 			return c.json({ error: "Recall failed", results: [] }, 500);
 		}
@@ -3252,7 +3288,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const q = (c.req.query("q") ?? "").trim();
 		if (!q) return c.json({ error: "query is required" }, 400);
 
-		const limit = Number.parseInt(c.req.query("limit") ?? "10", 10);
+		const limit = effectiveRecallLimit(Number.parseInt(c.req.query("limit") ?? "10", 10));
 		const type = c.req.query("type");
 		const tags = c.req.query("tags");
 		const who = c.req.query("who");
@@ -3266,6 +3302,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		const scopeProject = c.get("auth")?.claims?.scope?.project;
+		const recallSurface = "explicit_api" as const;
 		try {
 			const sessionKeyRaw =
 				c.req.query("sessionKey") ?? c.req.query("session_key") ?? c.req.header("x-signet-session-key");
@@ -3274,6 +3311,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				agentId: c.req.query("agentId") ?? c.req.query("agent_id") ?? c.req.header("x-signet-agent-id"),
 				sessionKey: sessionKeyRaw,
 			});
+			recordRecallAttempt(recallSurface);
 			const agentScope = getAgentScope(agentId);
 			const params = {
 				query: q,
@@ -3292,6 +3330,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				policyGroup: agentScope.policyGroup ?? undefined,
 				sessionKey: sessionKeyRaw,
 				includeRecalled: includeRecalled === "1" || includeRecalled === "true",
+				telemetrySurface: recallSurface,
 				recallSurface: "api.memory.search",
 				recallMode: "direct",
 				...(scopeProject ? { project: scopeProject } : {}),
@@ -3310,8 +3349,15 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				result,
 				cfg,
 			});
+			recordRecallOutcome({
+				surface: recallSurface,
+				resultCount: result.results.length,
+				truncated: result.results.length >= limit,
+				delivery: "returned",
+			});
 			return c.json(result);
 		} catch (e) {
+			recordRecallOutcome({ surface: recallSurface, error: true, delivery: "not_delivered" });
 			logger.error("memory", "Search (recall alias) failed", e as Error);
 			return c.json({ error: "Recall failed", results: [] }, 500);
 		}

--- a/platform/daemon/src/routes/telemetry-routes.ts
+++ b/platform/daemon/src/routes/telemetry-routes.ts
@@ -262,6 +262,23 @@ export function registerTelemetryRoutes(app: Hono): void {
 		let pipelineErrors = 0;
 		const pipelineErrorsByStage = new Map<string, number>();
 		const pipelineErrorsByCode = new Map<string, number>();
+		const pipelineOperationsByClass = new Map<
+			string,
+			{
+				operations: number;
+				accepted: number;
+				skipped: number;
+				retried: number;
+				failed: number;
+				durationMs: number;
+				queueAgeMs: number;
+				outcomes: Map<string, number>;
+				causes: Map<string, number>;
+				durationBuckets: Map<string, number>;
+				queueAgeBuckets: Map<string, number>;
+			}
+		>();
+		let pipelineOperationIncidents = 0;
 		let embeddingCalls = 0;
 		let embeddingTokens = 0;
 		let embeddingCost = 0;
@@ -427,6 +444,43 @@ export function registerTelemetryRoutes(app: Hono): void {
 					pipelineErrorsByCode.set(e.properties.code, (pipelineErrorsByCode.get(e.properties.code) ?? 0) + 1);
 				}
 			}
+			if (e.event === "pipeline.operation") {
+				const operationClass = typeof e.properties.operationClass === "string" ? e.properties.operationClass : "other";
+				const stats = pipelineOperationsByClass.get(operationClass) ?? {
+					operations: 0,
+					accepted: 0,
+					skipped: 0,
+					retried: 0,
+					failed: 0,
+					durationMs: 0,
+					queueAgeMs: 0,
+					outcomes: new Map<string, number>(),
+					causes: new Map<string, number>(),
+					durationBuckets: new Map<string, number>(),
+					queueAgeBuckets: new Map<string, number>(),
+				};
+				stats.operations++;
+				for (const key of ["accepted", "skipped", "retried", "failed"] as const) {
+					const value = e.properties[key];
+					if (typeof value === "number" && Number.isFinite(value)) stats[key] += value;
+				}
+				const durationMs = typeof e.properties.durationMs === "number" ? e.properties.durationMs : 0;
+				const queueAgeMs = typeof e.properties.queueAgeMs === "number" ? e.properties.queueAgeMs : 0;
+				stats.durationMs += durationMs;
+				stats.queueAgeMs += queueAgeMs;
+				const outcome = typeof e.properties.outcome === "string" ? e.properties.outcome : "other";
+				stats.outcomes.set(outcome, (stats.outcomes.get(outcome) ?? 0) + 1);
+				const cause = typeof e.properties.causeFamily === "string" ? e.properties.causeFamily : null;
+				if (cause) stats.causes.set(cause, (stats.causes.get(cause) ?? 0) + 1);
+				const durationBucket =
+					typeof e.properties.durationBucket === "string" ? e.properties.durationBucket : "unknown";
+				const queueAgeBucket =
+					typeof e.properties.queueAgeBucket === "string" ? e.properties.queueAgeBucket : "unknown";
+				stats.durationBuckets.set(durationBucket, (stats.durationBuckets.get(durationBucket) ?? 0) + 1);
+				stats.queueAgeBuckets.set(queueAgeBucket, (stats.queueAgeBuckets.get(queueAgeBucket) ?? 0) + 1);
+				if (outcome === "failed" || outcome === "partial") pipelineOperationIncidents++;
+				pipelineOperationsByClass.set(operationClass, stats);
+			}
 			if (e.event === "session.end") {
 				sessionEnds++;
 				if (typeof e.properties.tokensInput === "number") sessionInput += e.properties.tokensInput;
@@ -475,6 +529,29 @@ export function registerTelemetryRoutes(app: Hono): void {
 		recallLatencies.sort((a, b) => a - b);
 		const recallP50 = recallLatencies[Math.floor(recallLatencies.length * 0.5)] ?? 0;
 		const recallP95 = recallLatencies[Math.floor(recallLatencies.length * 0.95)] ?? 0;
+
+		const pipelineOperations = {
+			total: [...pipelineOperationsByClass.values()].reduce((total, stats) => total + stats.operations, 0),
+			incidents: pipelineOperationIncidents,
+			classes: Object.fromEntries(
+				[...pipelineOperationsByClass.entries()].map(([operationClass, stats]) => [
+					operationClass,
+					{
+						operations: stats.operations,
+						accepted: stats.accepted,
+						skipped: stats.skipped,
+						retried: stats.retried,
+						failed: stats.failed,
+						durationMs: stats.durationMs,
+						queueAgeMs: stats.queueAgeMs,
+						outcomes: Object.fromEntries(stats.outcomes),
+						causes: Object.fromEntries(stats.causes),
+						durationBuckets: Object.fromEntries(stats.durationBuckets),
+						queueAgeBuckets: Object.fromEntries(stats.queueAgeBuckets),
+					},
+				]),
+			),
+		};
 
 		return c.json({
 			enabled: true,
@@ -554,6 +631,7 @@ export function registerTelemetryRoutes(app: Hono): void {
 			pipelineErrors,
 			pipelineErrorsByStage: Object.fromEntries(pipelineErrorsByStage),
 			pipelineErrorsByCode: Object.fromEntries(pipelineErrorsByCode),
+			pipelineOperations,
 		});
 	});
 

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -54,6 +54,7 @@ export const TELEMETRY_EVENTS = [
 	"pipeline.decision",
 	"pipeline.embedding",
 	"pipeline.error",
+	"pipeline.operation",
 	"inference.route",
 	"inference.execute",
 	"inference.stream",

--- a/web/docs/src/content/docs/analytics.md
+++ b/web/docs/src/content/docs/analytics.md
@@ -207,9 +207,10 @@ telemetry reference. Telemetry carries no memory content, user identity,
 agent ids, or file paths; each install uses a random persisted anonymous id
 and every event is mirrored to the auditable JSONL log. `pipeline.error` is
 emitted for categorized extraction, decision, and embedding failures with
-stage/code-only properties. The remaining `pipeline.extraction` and
-`pipeline.decision` event types are declared for future use but not yet
-emitted.
+stage/code-only properties. `pipeline.operation` adds one bounded summary per
+logical indexing, memory-capture, recall, or dreaming operation, so dashboards
+can distinguish raw failed attempts from completed/failed operations without
+counting every source chunk as a separate incident.
 
 Source lifecycle telemetry uses fixed source classes and bounded lifecycle
 summaries. Local-only hashed state correlates first indexed, searchable, and

--- a/web/docs/src/content/docs/api/telemetry-logs.md
+++ b/web/docs/src/content/docs/api/telemetry-logs.md
@@ -318,11 +318,30 @@ Aggregated telemetry statistics since daemon start or since a given timestamp.
   },
   "pipelineErrors": 3,
   "pipelineErrorsByStage": { "extraction": 1, "decision": 1, "embedding": 1 },
-  "pipelineErrorsByCode": {
-    "EXTRACTION_PARSE_FAIL": 1,
-    "DECISION_TIMEOUT": 1,
-    "EMBEDDING_PROVIDER_DOWN": 1
-  }
+	"pipelineErrorsByCode": {
+	  "EXTRACTION_PARSE_FAIL": 1,
+	  "DECISION_TIMEOUT": 1,
+	  "EMBEDDING_PROVIDER_DOWN": 1
+	},
+	"pipelineOperations": {
+	  "total": 12,
+	  "incidents": 2,
+	  "classes": {
+	    "indexing": {
+	      "operations": 8,
+	      "accepted": 42,
+	      "skipped": 3,
+	      "retried": 5,
+	      "failed": 2,
+	      "durationMs": 18400,
+	      "queueAgeMs": 3200,
+	      "outcomes": { "completed": 6, "partial": 2 },
+	      "causes": { "context_limit": 1, "provider_unavailable": 1 },
+	      "durationBuckets": { "1-9s": 8 },
+	      "queueAgeBuckets": { "1-9s": 8 }
+	    }
+	  }
+	}
 }
 ```
 
@@ -337,6 +356,16 @@ Embedding `cost` values are USD. The `sessions` block is a derived view over
 matching usage events and should not be added to event-level cost totals. The
 `session.end` event carries the same collector-derived totals, keyed by a
 truncated hash of the session key rather than the raw key.
+
+`pipelineErrors` and its stage/code maps count raw failed attempts and remain
+backward-compatible. `pipelineOperations` is the bounded primary reliability
+view: it reports one logical operation summary per class (`indexing`,
+`memory_capture`, `recall`, `dreaming`, `extraction`, or `other`), including
+accepted, skipped, retried, and failed counts, duration and queue-age buckets,
+outcomes, and normalized cause families. Its `incidents` count includes failed
+or partial operations, so a large source cannot inflate the primary incident
+count by chunk count or retry count. Operation summaries contain no source
+identifiers, hashes, paths, provider messages, stacks, or raw input.
 
 ### GET /api/telemetry/export
 


### PR DESCRIPTION
## Summary

Closes #1278 by adding privacy-safe logical pipeline operation summaries without changing the existing raw `pipeline.error` attempt telemetry.

## Changes

- Added bounded `pipeline.operation` summaries for indexing, memory capture, recall, dreaming, extraction, and other operations.
- Aggregated accepted/skipped/retried/failed counts, outcomes, duration/queue-age buckets, and normalized cause families.
- Kept raw stage/code attempt analytics and added `pipelineOperations` to telemetry stats and the SDK type surface.
- Preserved logical operation identity across document retries, with durable accepted-count recovery where possible.
- Added bounded provider response parsing, context-limit versus outage classification, timeout/cancellation handling, and network-cause normalization.
- Updated telemetry/API/analytics documentation and regression coverage.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [x] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: documentation

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No database migration or configuration migration is required.

## Testing

- [x] Changed-file Biome formatting/check passes.
- [x] `bun run --filter '@signet/core' build` passes.
- [x] `bun run --filter '@signet/daemon' typecheck` passes.
- [x] Focused embedding, pipeline-operation, document-worker, dreaming, and memory-route regression suites pass when run independently.
- [x] `bun run typecheck` confirms daemon/core/docs and other built packages; it also reports pre-existing connector failures caused by missing generated/build artifacts.
- [ ] `bun test` passes — the full daemon run has unrelated baseline ontology/synthesis timeout and parallel SQLite/environment failures; focused suites pass independently.
- [ ] `bun run lint` passes — repository-wide lint reports pre-existing formatting drift in untouched package manifests; all changed files pass targeted Biome checks.
- [ ] Tested against running daemon
- [x] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Raw `pipeline.error` events remain backward-compatible and continue to count failed attempts by stage/code.
- Operation summaries intentionally exclude source identifiers, hashes, paths, provider messages, stacks, and raw input.
- No durable operation table was added; terminal summaries use in-memory aggregation plus existing document persistence for restart-safe counts where available.
