### PR TITLE
fix(daemon): bound wedge pressure probes

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -133,9 +133,11 @@ Notes on individual events:
   `EventLoopLag` reports carry `runtimePressureVersion`, queue-depth and
   oldest-job-age buckets, active-worker and configured batch-size buckets,
   database and embedding latency buckets, process memory/CPU pressure buckets,
-  `recoveryOutcome`, and a coarse `snapshotAgeBucket`. The daemon keeps only
-  the latest observations in memory; the wedge path never queries SQLite,
-  touches the filesystem, or starts provider work. `recoveryOutcome` is
+  `recoveryOutcome`, and a coarse `snapshotAgeBucket`. Heartbeat queue
+  observations use capped, indexed probes and never scan the full queue. The
+  wedge path reads only the latest observations, appends one bounded sanitized
+  JSONL audit line for hard-kill survivability, and never enters SQLite or
+  provider work. `recoveryOutcome` is
   `still_degraded` during an episode, `recovered` after the pressure state
   clears, and `restarted` on the first heartbeat after an abnormal prior exit.
 - **`recall.attempted` / `recall.outcome`** — the bounded retrieval-outcome

--- a/platform/core/src/migrations/118-queue-pressure-indices.ts
+++ b/platform/core/src/migrations/118-queue-pressure-indices.ts
@@ -1,0 +1,26 @@
+import type { MigrationDb } from "./index";
+
+/**
+ * Migration 118: bounded queue-pressure observation
+ *
+ * Heartbeat pressure telemetry only needs active queue depth buckets and the
+ * oldest active job age. These partial indexes let that path probe a bounded
+ * number of live rows without scanning terminal jobs or retired extraction
+ * jobs.
+ */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_memory_jobs_pressure_status
+			ON memory_jobs(status)
+			WHERE status IN ('pending', 'leased') AND job_type <> 'extract';
+		CREATE INDEX IF NOT EXISTS idx_memory_jobs_pressure_created_at
+			ON memory_jobs(created_at)
+			WHERE status IN ('pending', 'leased') AND job_type <> 'extract';
+		CREATE INDEX IF NOT EXISTS idx_summary_jobs_pressure_status
+			ON summary_jobs(status)
+			WHERE status IN ('pending', 'leased');
+		CREATE INDEX IF NOT EXISTS idx_summary_jobs_pressure_created_at
+			ON summary_jobs(created_at)
+			WHERE status IN ('pending', 'leased');
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -123,6 +123,7 @@ import { up as memoryTraversalHydrationIndex } from "./114-memory-traversal-hydr
 import { up as crossAgentMessageNotifications } from "./115-cross-agent-message-notifications";
 import { up as acpDeliveryReconciliation } from "./116-acp-delivery-reconciliation";
 import { up as retireSummaryWorker } from "./117-retire-summary-worker";
+import { up as queuePressureIndices } from "./118-queue-pressure-indices";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1096,7 +1097,6 @@ export const MIGRATIONS: readonly Migration[] = [
 			],
 		},
 	},
-
 	{
 		version: 117,
 		name: "retire-summary-worker",
@@ -1107,6 +1107,11 @@ export const MIGRATIONS: readonly Migration[] = [
 				{ table: "session_transcripts", column: "content_hash" },
 			],
 		},
+	},
+	{
+		version: 118,
+		name: "queue-pressure-indices",
+		up: queuePressureIndices,
 	},
 ];
 

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -48,7 +48,7 @@ import {
 import { listConnectors } from "./connectors/registry";
 import { clearAllPresence, reconcileAcpDeliveries } from "./cross-agent";
 import { closeDbAccessor, getDbAccessor, getVectorRuntimeStatus, initDbAccessorAsync } from "./db-accessor";
-import { getQueueDiagnosticsSnapshot } from "./diagnostics-queue";
+import { getQueueDiagnosticsSnapshot, getQueuePressureSnapshot } from "./diagnostics-queue";
 import { fetchEmbedding } from "./embedding-fetch";
 import { type EmbeddingIndexMigrationHandle, startEmbeddingIndexMigration } from "./embedding-index-migration";
 import { resolveActiveEmbeddingConfig } from "./embedding-index-state";
@@ -2115,16 +2115,16 @@ async function main() {
 					const connectors = listConnectors(getDbAccessor());
 					let runtimePressure: ReturnType<typeof buildRuntimePressureEnvelope> | undefined;
 					try {
-						const queue = getDbAccessor().withReadDb((db) => getQueueDiagnosticsSnapshot(db, { fresh: true }));
+						const queue = getDbAccessor().withReadDb((db) => getQueuePressureSnapshot(db));
 						const workers = getPipelineWorkerStatus();
 						const resources = getResourceSnapshot();
 						const recoveryOutcome: PressureRecoveryOutcome = restartedHeartbeatPending
 							? "restarted"
 							: getPressureRecoveryOutcome();
 						runtimePressure = buildRuntimePressureEnvelope({
-							memoryQueueDepth: queue.memory.pending + queue.memory.leased,
-							summaryQueueDepth: queue.summary.pending + queue.summary.leased,
-							oldestJobAgeSec: Math.max(queue.memory.oldestAgeSec, queue.summary.oldestAgeSec),
+							memoryQueueDepth: queue.memoryQueueDepth,
+							summaryQueueDepth: queue.summaryQueueDepth,
+							oldestJobAgeSec: queue.oldestJobAgeSec,
 							activeWorkers: countActiveWorkers(
 								[
 									workers.summary.running,

--- a/platform/daemon/src/diagnostics-queue.ts
+++ b/platform/daemon/src/diagnostics-queue.ts
@@ -148,6 +148,81 @@ export function getQueueCounts(db: ReadDb, source: QueueSource): QueueCounts {
 	return EMPTY_QUEUE_COUNTS;
 }
 
+const QUEUE_PRESSURE_DEPTH_LIMIT = 1_001;
+
+interface QueuePressureQueryResult {
+	readonly depth: number;
+	readonly oldestAt: string | null;
+}
+
+/**
+ * Read only the bounded data needed by heartbeat pressure telemetry.
+ *
+ * The full diagnostics snapshot intentionally remains exact for operator
+ * routes. Heartbeats use this separate path so a large terminal queue cannot
+ * turn a liveness callback into an unbounded synchronous scan.
+ */
+function getQueuePressureQueryResult(db: ReadDb, source: QueueSource): QueuePressureQueryResult | undefined {
+	const table = source === "memory" ? "memory_jobs" : "summary_jobs";
+	const statusIndex = source === "memory" ? "idx_memory_jobs_pressure_status" : "idx_summary_jobs_pressure_status";
+	const createdIndex =
+		source === "memory" ? "idx_memory_jobs_pressure_created_at" : "idx_summary_jobs_pressure_created_at";
+	const predicate = source === "memory" ? " AND job_type <> 'extract'" : "";
+	if (!tableExists(db, table)) return undefined;
+
+	try {
+		const rows = db
+			.prepare(
+				`SELECT 1
+				 FROM ${table} INDEXED BY ${statusIndex}
+				 WHERE status IN ('pending', 'leased')${predicate}
+				 LIMIT ${QUEUE_PRESSURE_DEPTH_LIMIT}`,
+			)
+			.all();
+		const oldest = db
+			.prepare(
+				`SELECT created_at AS oldestAt
+				 FROM ${table} INDEXED BY ${createdIndex}
+				 WHERE status IN ('pending', 'leased')${predicate}
+				 ORDER BY created_at ASC
+				 LIMIT 1`,
+			)
+			.get() as { readonly oldestAt?: string | null } | undefined;
+		return { depth: rows.length, oldestAt: oldest?.oldestAt ?? null };
+	} catch {
+		// A partially repaired legacy schema must not break the heartbeat.
+		return undefined;
+	}
+}
+
+export interface QueuePressureSnapshot {
+	/** Capped at 1,001 because the next bucket is already `1001+`. */
+	readonly memoryQueueDepth: number | undefined;
+	/** Capped at 1,001 because the next bucket is already `1001+`. */
+	readonly summaryQueueDepth: number | undefined;
+	/** Undefined when neither queue has an active row or age is unavailable. */
+	readonly oldestJobAgeSec: number | undefined;
+}
+
+/**
+ * Bounded queue observation for the daemon heartbeat and wedge context.
+ *
+ * This function is deliberately not used by the exact diagnostics routes.
+ */
+export function getQueuePressureSnapshot(db: ReadDb): QueuePressureSnapshot {
+	const memory = getQueuePressureQueryResult(db, "memory");
+	const summary = getQueuePressureQueryResult(db, "summary");
+	const oldestAt = [memory?.oldestAt, summary?.oldestAt].filter(
+		(value): value is string => value !== undefined && value !== null,
+	);
+	const ages = oldestAt.map((value) => ageSec(value));
+	return {
+		memoryQueueDepth: memory?.depth,
+		summaryQueueDepth: summary?.depth,
+		oldestJobAgeSec: ages.length === 0 ? undefined : Math.max(...ages),
+	};
+}
+
 /**
  * Oldest `dead` row's identifying fields. `null` when no dead rows or
  * when the queue table is missing.

--- a/platform/daemon/src/diagnostics.test.ts
+++ b/platform/daemon/src/diagnostics.test.ts
@@ -23,6 +23,7 @@ import {
 	DEFAULT_QUEUE_THRESHOLDS,
 	EMPTY_QUEUE_COUNTS,
 	getQueueDiagnosticsSnapshot,
+	getQueuePressureSnapshot,
 	scoreCountsWithThresholds,
 } from "./diagnostics-queue";
 
@@ -201,6 +202,25 @@ describe("expanded queue diagnostics", () => {
 
 		expect(getQueueDiagnosticsSnapshot(readDb).memory.dead).toBe(0);
 		expect(getQueueDiagnosticsSnapshot(readDb, { fresh: true }).memory.dead).toBe(1);
+	});
+
+	test("bounds heartbeat queue observation and distinguishes empty queue age", () => {
+		const readDb = asReadDb(db);
+		const empty = getQueuePressureSnapshot(readDb);
+		expect(empty.memoryQueueDepth).toBe(0);
+		expect(empty.summaryQueueDepth).toBe(0);
+		expect(empty.oldestJobAgeSec).toBeUndefined();
+
+		for (let i = 0; i < 1_100; i++) {
+			const memoryId = `mem-pressure-${i}`;
+			insertMemory(db, memoryId);
+			insertJob(db, `job-pressure-${i}`, memoryId, "pending");
+		}
+
+		const pressure = getQueuePressureSnapshot(readDb);
+		expect(pressure.memoryQueueDepth).toBe(1_001);
+		expect(pressure.summaryQueueDepth).toBe(0);
+		expect(pressure.oldestJobAgeSec).toBeGreaterThanOrEqual(0);
 	});
 });
 

--- a/platform/daemon/src/runtime-pressure.test.ts
+++ b/platform/daemon/src/runtime-pressure.test.ts
@@ -97,4 +97,13 @@ describe("runtime pressure envelope", () => {
 		expect(getRuntimePressureEnvelope(2_000).snapshotAgeBucket).toBe("fresh");
 		expect(getRuntimePressureEnvelope(16 * 60 * 1000).snapshotAgeBucket).toBe("old");
 	});
+
+	it("does not label an empty queue as a fresh job", () => {
+		const envelope = buildRuntimePressureEnvelope({
+			memoryQueueDepth: 0,
+			summaryQueueDepth: 0,
+			oldestJobAgeSec: 0,
+		});
+		expect(envelope.oldestJobAgeBucket).toBe("none");
+	});
 });

--- a/platform/daemon/src/runtime-pressure.ts
+++ b/platform/daemon/src/runtime-pressure.ts
@@ -2,8 +2,9 @@
  * Bounded runtime context for daemon liveness telemetry.
  *
  * This module deliberately stores only the latest coarse observations. The
- * event-loop wedge path must be able to report context without doing database,
- * filesystem, or provider work while the event loop is recovering.
+ * event-loop wedge path reads this context without doing database or provider
+ * work while the event loop is recovering; the telemetry layer separately
+ * handles its bounded local audit append.
  */
 
 export type PressureBucket =
@@ -185,7 +186,8 @@ export function buildRuntimePressureEnvelope(input: RuntimePressureInputs = {}):
 		runtimePressureVersion: 1,
 		memoryQueueDepthBucket: bucketQueueDepth(input.memoryQueueDepth),
 		summaryQueueDepthBucket: bucketQueueDepth(input.summaryQueueDepth),
-		oldestJobAgeBucket: bucketAgeSec(input.oldestJobAgeSec),
+		oldestJobAgeBucket:
+			input.memoryQueueDepth === 0 && input.summaryQueueDepth === 0 ? "none" : bucketAgeSec(input.oldestJobAgeSec),
 		activeWorkersBucket: bucketWorkerCount(input.activeWorkers),
 		batchSizeBucket: bucketBatchSize(input.batchSize),
 		dbLatencyBucket: bucketLatencyMs(input.dbLatencyMs ?? latencies.dbLatencyMs),

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -604,7 +604,7 @@ describe("telemetry lifecycle events (issue #1026 Phase 2)", () => {
 		expect(third.properties.command).toBe("status");
 	});
 
-	it("defers wedge persistence until the normal flush", async () => {
+	it("persists wedge events to the local audit log before normal flush", async () => {
 		const collector = createTelemetryCollector(
 			fakeDbAccessor(),
 			{
@@ -621,7 +621,9 @@ describe("telemetry lifecycle events (issue #1026 Phase 2)", () => {
 
 		const before = readFileSync(logPath, "utf-8");
 		collector.recordDeferred?.("error.occurred", { type: "EventLoopLag", lagMs: 900 });
-		expect(readFileSync(logPath, "utf-8")).toBe(before);
+		const afterRecord = readFileSync(logPath, "utf-8");
+		expect(afterRecord).not.toBe(before);
+		expect(afterRecord).toContain('"event":"error.occurred"');
 		await collector.flush();
 		expect(readFileSync(logPath, "utf-8")).toContain('"event":"error.occurred"');
 	});

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -184,8 +184,9 @@ function sessionCostProperties(cost: SessionCostAccumulator): TelemetryPropertie
 export interface TelemetryCollector {
 	record(event: TelemetryEventType, properties: TelemetryProperties): void;
 	/**
-	 * Record without synchronous JSONL or SQLite work. Used by the event-loop
-	 * wedge path, where even best-effort persistence can block recovery.
+	 * Record with a bounded synchronous JSONL audit append while deferring
+	 * SQLite persistence. The local line survives a hard process kill; the
+	 * wedge path does not enter SQLite or provider work.
 	 */
 	recordDeferred?(event: TelemetryEventType, properties: TelemetryProperties): void;
 	reopenSession(sessionHash: string): void;
@@ -457,7 +458,6 @@ export function createTelemetryCollector(
 	} = {},
 ): TelemetryCollector {
 	const buffer: TelemetryEvent[] = [];
-	const deferredAuditIds = new Set<string>();
 	const logPath = opts.telemetryLogPath ?? null;
 	const deployment = telemetryDeployment(opts.env);
 	const reportedVersion = telemetryReportedVersion(daemonVersion, deployment);
@@ -639,11 +639,6 @@ export function createTelemetryCollector(
 		flushCount++;
 		// Drain buffer to SQLite
 		const pending = buffer.splice(0, buffer.length);
-		for (const event of pending) {
-			if (deferredAuditIds.delete(event.id)) {
-				appendToTelemetryLog(logPath, JSON.stringify(event));
-			}
-		}
 		writeToDb(pending);
 
 		// Send to PostHog if configured
@@ -762,13 +757,16 @@ export function createTelemetryCollector(
 		return cost ? { ...properties, ...sessionCostProperties(cost) } : properties;
 	}
 
-	function recordEvent(event: TelemetryEventType, properties: TelemetryProperties, persistAuditLog: boolean): void {
+	function recordEvent(
+		event: TelemetryEventType,
+		properties: TelemetryProperties,
+		options: { readonly persistAuditLog: boolean; readonly flushWhenFull: boolean },
+	): void {
 		if (recordingStopped) return;
 		if (buffer.length >= MAX_BUFFER_EVENTS) {
 			const dropCount = buffer.length - MAX_BUFFER_EVENTS + 1;
-			const dropped = buffer.splice(0, dropCount);
-			for (const event of dropped) deferredAuditIds.delete(event.id);
-			if (persistAuditLog) {
+			buffer.splice(0, dropCount);
+			if (options.persistAuditLog) {
 				logger.warn("telemetry", "Buffer exceeded max capacity, dropping oldest events", {
 					dropped: dropCount,
 					maxBufferEvents: MAX_BUFFER_EVENTS,
@@ -782,22 +780,17 @@ export function createTelemetryCollector(
 			timestamp: new Date().toISOString(),
 			properties: addContext(enrichSessionEvent(event, properties)),
 		});
-		if (!persistAuditLog) {
-			const deferred = buffer[buffer.length - 1];
-			if (deferred) deferredAuditIds.add(deferred.id);
-		}
-
-		if (persistAuditLog && logPath) {
+		if (options.persistAuditLog && logPath) {
 			const last = buffer[buffer.length - 1];
 			if (last) {
 				appendToTelemetryLog(logPath, JSON.stringify(last));
 			}
 		}
 
-		// Deferred records wait for the normal timer. Calling doFlush here would
+		// Deferred records skip the eager flush. Calling doFlush here would
 		// synchronously enter SQLite before its first await, defeating the wedge
 		// path's non-blocking guarantee.
-		if (persistAuditLog && buffer.length >= MAX_BUFFER_SIZE) {
+		if (options.flushWhenFull && buffer.length >= MAX_BUFFER_SIZE) {
 			flush().catch(() => {});
 		}
 	}
@@ -810,11 +803,11 @@ export function createTelemetryCollector(
 		},
 
 		record(event, properties): void {
-			recordEvent(event, properties, true);
+			recordEvent(event, properties, { persistAuditLog: true, flushWhenFull: true });
 		},
 
 		recordDeferred(event, properties): void {
-			recordEvent(event, properties, false);
+			recordEvent(event, properties, { persistAuditLog: true, flushWhenFull: false });
 		},
 
 		recordFirstUse(kind): void {

--- a/scripts/evals/runtime-pressure-envelope.ts
+++ b/scripts/evals/runtime-pressure-envelope.ts
@@ -2,12 +2,18 @@
 /**
  * Runtime-pressure liveness/load eval (#1282).
  *
- * Exercises the same bounded envelope builder used by daemon heartbeats with
- * a deterministic synthetic load. It fails if envelope construction becomes
- * slow, grows its key set, or starts carrying forbidden process/user data.
+ * Exercises the envelope builder and the heartbeat's bounded queue probe with
+ * deterministic synthetic load. It fails if envelope construction or queue
+ * observation becomes slow, queue depth escapes its bucket cap, the query plan
+ * falls back to a table scan, or pressure data starts carrying forbidden
+ * process/user data.
  */
 
+import { Database } from "bun:sqlite";
 import { performance } from "node:perf_hooks";
+import { runMigrations } from "../../platform/core/src/migrations";
+import type { ReadDb } from "../../platform/daemon/src/db-accessor";
+import { getQueuePressureSnapshot } from "../../platform/daemon/src/diagnostics-queue";
 import {
 	buildRuntimePressureEnvelope,
 	getRuntimePressureEnvelope,
@@ -15,13 +21,47 @@ import {
 } from "../../platform/daemon/src/runtime-pressure";
 
 const SAMPLE_COUNT = 2_000;
+const QUEUE_SAMPLE_COUNT = 100;
+const QUEUE_ROWS_PER_SOURCE = 50_000;
 const MAX_P95_BUILD_MS = 1;
+const MAX_P95_QUEUE_SNAPSHOT_MS = 50;
 const FORBIDDEN_KEYS = ["pid", "path", "source", "stack", "payload", "processId"];
 
 function percentile(values: readonly number[], ratio: number): number {
 	const ordered = [...values].sort((left, right) => left - right);
 	const index = Math.min(ordered.length - 1, Math.ceil(ordered.length * ratio) - 1);
 	return ordered[Math.max(0, index)] ?? 0;
+}
+
+function makePressureDb(): Database {
+	const db = new Database(":memory:");
+	db.exec("PRAGMA journal_mode = WAL");
+	runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+
+	const memoryJob = db.prepare(
+		`INSERT INTO memory_jobs
+			(id, memory_id, job_type, status, created_at, updated_at)
+			VALUES (?, NULL, 'document_ingest', 'pending', ?, ?)`,
+	);
+	const summaryJob = db.prepare(
+		`INSERT INTO summary_jobs
+			(id, harness, transcript, status, created_at)
+			VALUES (?, 'eval', 'bounded-pressure-fixture', 'pending', ?)`,
+	);
+	const now = Date.now();
+	db.exec("BEGIN");
+	for (let index = 0; index < QUEUE_ROWS_PER_SOURCE; index += 1) {
+		const createdAt = new Date(now - (index % 10_000) * 1_000).toISOString();
+		memoryJob.run(`memory-pressure-${index}`, createdAt, createdAt);
+		summaryJob.run(`summary-pressure-${index}`, createdAt);
+	}
+	db.exec("COMMIT");
+	return db;
+}
+
+function planDetails(db: Database, sql: string): readonly string[] {
+	const rows = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all() as unknown as ReadonlyArray<{ readonly detail: string }>;
+	return rows.map((row) => row.detail);
 }
 
 const durations: number[] = [];
@@ -45,17 +85,73 @@ setRuntimePressureEnvelope(lastEnvelope);
 const cached = getRuntimePressureEnvelope();
 const keys = Object.keys(cached);
 const forbidden = keys.filter((key) => FORBIDDEN_KEYS.some((term) => key.toLowerCase().includes(term.toLowerCase())));
+
+const pressureDb = makePressureDb();
+const queueDurations: number[] = [];
+let lastQueueSnapshot = getQueuePressureSnapshot(pressureDb as unknown as ReadDb);
+for (let index = 0; index < QUEUE_SAMPLE_COUNT; index += 1) {
+	const startedAt = performance.now();
+	lastQueueSnapshot = getQueuePressureSnapshot(pressureDb as unknown as ReadDb);
+	queueDurations.push(performance.now() - startedAt);
+}
+const memoryStatusPlan = planDetails(
+	pressureDb,
+	`SELECT 1 FROM memory_jobs INDEXED BY idx_memory_jobs_pressure_status
+	 WHERE status IN ('pending', 'leased') AND job_type <> 'extract' LIMIT 1001`,
+);
+const memoryCreatedPlan = planDetails(
+	pressureDb,
+	`SELECT created_at FROM memory_jobs INDEXED BY idx_memory_jobs_pressure_created_at
+	 WHERE status IN ('pending', 'leased') AND job_type <> 'extract'
+	 ORDER BY created_at ASC LIMIT 1`,
+);
+const summaryStatusPlan = planDetails(
+	pressureDb,
+	`SELECT 1 FROM summary_jobs INDEXED BY idx_summary_jobs_pressure_status
+	 WHERE status IN ('pending', 'leased') LIMIT 1001`,
+);
+const summaryCreatedPlan = planDetails(
+	pressureDb,
+	`SELECT created_at FROM summary_jobs INDEXED BY idx_summary_jobs_pressure_created_at
+	 WHERE status IN ('pending', 'leased')
+	 ORDER BY created_at ASC LIMIT 1`,
+);
+pressureDb.close();
+
+const queuePlan = [...memoryStatusPlan, ...memoryCreatedPlan, ...summaryStatusPlan, ...summaryCreatedPlan];
+const unindexedPlans = queuePlan.filter((detail) => !detail.includes("USING") || !detail.includes("INDEX"));
+const queueSnapshotBounded =
+	lastQueueSnapshot.memoryQueueDepth === 1_001 &&
+	lastQueueSnapshot.summaryQueueDepth === 1_001 &&
+	lastQueueSnapshot.oldestJobAgeSec !== undefined;
+const buildP95Ms = percentile(durations, 0.95);
+const queueP95Ms = percentile(queueDurations, 0.95);
 const report = {
 	verdict:
-		cached.runtimePressureVersion === 1 && forbidden.length === 0 && percentile(durations, 0.95) <= MAX_P95_BUILD_MS
+		cached.runtimePressureVersion === 1 &&
+		forbidden.length === 0 &&
+		buildP95Ms <= MAX_P95_BUILD_MS &&
+		queueSnapshotBounded &&
+		unindexedPlans.length === 0 &&
+		queueP95Ms <= MAX_P95_QUEUE_SNAPSHOT_MS
 			? "pass"
 			: "fail",
 	samples: SAMPLE_COUNT,
+	queueSamples: QUEUE_SAMPLE_COUNT,
+	queueRowsPerSource: QUEUE_ROWS_PER_SOURCE,
 	keyCount: keys.length,
-	p95BuildMs: Number(percentile(durations, 0.95).toFixed(3)),
+	p95BuildMs: Number(buildP95Ms.toFixed(3)),
 	maxP95BuildMs: MAX_P95_BUILD_MS,
+	p95QueueSnapshotMs: Number(queueP95Ms.toFixed(3)),
+	maxP95QueueSnapshotMs: MAX_P95_QUEUE_SNAPSHOT_MS,
+	queueDepthCaps: {
+		memory: lastQueueSnapshot.memoryQueueDepth,
+		summary: lastQueueSnapshot.summaryQueueDepth,
+	},
+	queuePlan,
+	unindexedPlans,
 	forbiddenKeys: forbidden,
 };
 
 console.log(JSON.stringify(report, null, 2));
-if (report.verdict !== "pass") process.exit(1);
+process.exit(report.verdict === "pass" ? 0 : 1);


### PR DESCRIPTION
## Summary

Follow-up to #1287, addressing the post-merge wedge telemetry findings.

The heartbeat no longer performs an exact queue scan, and critical event-loop telemetry now leaves a local audit record before the normal SQLite/remote flush. Exact operator diagnostics remain unchanged.

## Changes

- Add migration 118 with idempotent partial indexes for active memory and summary queue pressure probes.
- Replace the heartbeat's fresh exact queue snapshot with capped, indexed probes: depth stops at 1,001 and oldest-job age uses an indexed `LIMIT 1` query.
- Keep partial-schema failures fail-open so a legacy or partially repaired database cannot break the heartbeat.
- Represent an explicitly empty queue as having no oldest-job age instead of a misleading `<10s` age bucket.
- Make `recordDeferred` append the sanitized wedge event to the local JSONL audit log immediately while still deferring SQLite and provider work.
- Expand regression coverage and the runtime-pressure eval to exercise real SQLite plans, 50,000-row queue fixtures, bounded depth, latency, and forbidden-key checks.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: docs and eval coverage only

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally (affected files and suites; root baseline caveats are documented below)

## Migration Notes

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

Migration 118 is additive and creates only partial indexes. It rewrites no data and is safe for older rows and queue statuses. The repository has no down-migration mechanism; rolling back the code can leave these unused indexes in place, and a future cleanup migration can remove them if needed.

## Testing

- [x] Focused `bun test` passes: 125 pass, 0 fail, 821 expectations across migrations, diagnostics, runtime pressure, telemetry, and yielding writes.
- [ ] `bun run typecheck` passes: the full root check still fails in unrelated connector/generated-bundle packages; the affected core and daemon builds pass.
- [ ] `bun run lint` passes: the full root check reports the pre-existing package-format baseline (536 errors, 160 warnings); changed-file Biome check passes.
- [ ] Tested against running daemon: not run for this follow-up.
- [x] `bun run --filter '@signet/core' build` passes.
- [x] `bun run --filter '@signet/daemon' build` passes.
- [x] `bun scripts/evals/runtime-pressure-envelope.ts` passes with 50,000 rows per queue source, depth caps of 1,001, indexed plans, p95 queue snapshot time of 0.225ms, and no forbidden keys.
- [x] `git diff --check` passes.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The full root typecheck and lint failures are outside this change set and predate this follow-up. No unrelated connector or formatting files were modified. The branch is rebased onto the current `origin/main` release before opening this PR.