### PR TITLE
fix(dashboard): canonicalize embedding endpoint (#1264)

### DIFF
--- a/platform/daemon/src/config-migration.test.ts
+++ b/platform/daemon/src/config-migration.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { migrateInferenceProviders } from "./config-migration";
+import { migrateEmbeddingBaseUrl, migrateInferenceProviders } from "./config-migration";
 
 function setupDir(): string {
 	const dir = mkdtempSync(join(tmpdir(), "signet-config-migration-"));
@@ -164,6 +164,83 @@ inference:
 		try {
 			writeFileSync(join(dir, "agent.yaml"), "inference:\n  [unterminated");
 			expect(() => migrateInferenceProviders(dir)).not.toThrow();
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("migrateEmbeddingBaseUrl (#1264)", () => {
+	it("rewrites dashboard baseUrl to the daemon's canonical base_url", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`# preserve operator context
+embedding:
+  provider: ollama
+  baseUrl: http://192.168.1.10:11434
+`,
+			);
+			migrateEmbeddingBaseUrl(dir);
+			const after = readFileSync(join(dir, "agent.yaml"), "utf-8");
+			expect(after).toContain("base_url: http://192.168.1.10:11434");
+			expect(after).not.toContain("baseUrl:");
+			expect(after).toContain("# preserve operator context");
+			expect(after).toMatch(/^configVersion: 8/m);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps the canonical value when both endpoint spellings conflict", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`embedding:
+  provider: ollama
+  base_url: http://127.0.0.1:11434
+  baseUrl: http://192.168.1.10:11434
+`,
+			);
+			migrateEmbeddingBaseUrl(dir);
+			const after = readFileSync(join(dir, "agent.yaml"), "utf-8");
+			expect(after).toContain("base_url: http://127.0.0.1:11434");
+			expect(after).not.toContain("baseUrl:");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("canonicalizes the legacy memory.embeddings block", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`memory:
+  embeddings:
+    provider: ollama
+    baseUrl: http://192.168.1.10:11434
+`,
+			);
+			migrateEmbeddingBaseUrl(dir);
+			const after = readFileSync(join(dir, "agent.yaml"), "utf-8");
+			expect(after).toContain("base_url: http://192.168.1.10:11434");
+			expect(after).not.toContain("baseUrl:");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("is idempotent after stamping config version 8", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(join(dir, "agent.yaml"), "embedding:\n  baseUrl: http://192.168.1.10:11434\n");
+			migrateEmbeddingBaseUrl(dir);
+			const after1 = readFileSync(join(dir, "agent.yaml"), "utf-8");
+			migrateEmbeddingBaseUrl(dir);
+			expect(readFileSync(join(dir, "agent.yaml"), "utf-8")).toBe(after1);
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}

--- a/platform/daemon/src/config-migration.test.ts
+++ b/platform/daemon/src/config-migration.test.ts
@@ -180,12 +180,14 @@ describe("migrateEmbeddingBaseUrl (#1264)", () => {
 embedding:
   provider: ollama
   baseUrl: http://192.168.1.10:11434
+  endpoint: http://127.0.0.1:11434
 `,
 			);
 			migrateEmbeddingBaseUrl(dir);
 			const after = readFileSync(join(dir, "agent.yaml"), "utf-8");
 			expect(after).toContain("base_url: http://192.168.1.10:11434");
 			expect(after).not.toContain("baseUrl:");
+			expect(after).not.toContain("endpoint:");
 			expect(after).toContain("# preserve operator context");
 			expect(after).toMatch(/^configVersion: 8/m);
 		} finally {

--- a/platform/daemon/src/config-migration.ts
+++ b/platform/daemon/src/config-migration.ts
@@ -587,3 +587,57 @@ export function migrateRetiredExtractionWriterConfig(agentsDir: string): void {
 		logger.info("config-migration", "Removed retired extraction writer configuration", { mutations, file: path });
 	}
 }
+
+// ---------------------------------------------------------------------------
+// v8: canonicalize dashboard embedding endpoint spelling (#1264)
+// ---------------------------------------------------------------------------
+// The dashboard briefly wrote `baseUrl`, while the daemon's canonical embedding
+// schema uses `base_url`. Rewrite both current and legacy embedding blocks once
+// at startup so existing files do not keep an endpoint the runtime ignores.
+export function migrateEmbeddingBaseUrl(agentsDir: string): void {
+	const path = findConfigPath(agentsDir);
+	if (!path) return;
+
+	let text: string;
+	try {
+		text = readFileSync(path, "utf-8");
+	} catch {
+		return;
+	}
+
+	const vMatch = /^configVersion:\s*(\d+)/m.exec(text);
+	if (vMatch && Number(vMatch[1]) >= 8) return;
+
+	const doc = parseDocument(text);
+	if (doc.errors.length > 0) {
+		logger.warn("config-migration", "Skipping embedding migration: agent.yaml has parse errors", {
+			file: path,
+			errors: doc.errors.map((error) => error.message).slice(0, 3),
+		});
+		return;
+	}
+
+	const mutations: string[] = [];
+	for (const pathParts of [["embedding"], ["memory", "embeddings"]] as const) {
+		const block = doc.getIn(pathParts, true);
+		if (!isMap(block) || !block.has("baseUrl")) continue;
+
+		const alias = block.get("baseUrl", true);
+		if (!block.has("base_url")) {
+			block.set("base_url", alias);
+			mutations.push(`${pathParts.join(".")}.baseUrl → base_url`);
+		} else if (String(block.get("base_url")) !== String(alias)) {
+			logger.warn("config-migration", "Embedding config contains conflicting endpoint keys; keeping base_url", {
+				file: path,
+				path: pathParts.join("."),
+			});
+		}
+		block.delete("baseUrl");
+	}
+
+	stampConfigVersion(doc, 8);
+	writeAtomic(path, doc.toString());
+	if (mutations.length > 0) {
+		logger.info("config-migration", "Canonicalized embedding endpoint configuration", { mutations, file: path });
+	}
+}

--- a/platform/daemon/src/config-migration.ts
+++ b/platform/daemon/src/config-migration.ts
@@ -633,6 +633,7 @@ export function migrateEmbeddingBaseUrl(agentsDir: string): void {
 			});
 		}
 		block.delete("baseUrl");
+		block.delete("endpoint");
 	}
 
 	stampConfigVersion(doc, 8);

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -40,6 +40,7 @@ import { createToken, requirePermission } from "./auth";
 import { bindWithRetry } from "./bind-with-retry";
 import {
 	migrateConfig,
+	migrateEmbeddingBaseUrl,
 	migrateInferenceProviders,
 	migrateLegacyRoutingToRegistry,
 	migrateRetiredExtractionWriterConfig,
@@ -1938,6 +1939,7 @@ async function main() {
 		migrateLegacyRoutingToRegistry(AGENTS_DIR);
 		migrateSessionSynthesisRoute(AGENTS_DIR);
 		migrateRetiredExtractionWriterConfig(AGENTS_DIR);
+		migrateEmbeddingBaseUrl(AGENTS_DIR);
 	} catch (err) {
 		logger.warn("config-migration", "Config migration failed; continuing startup", {
 			error: err instanceof Error ? err.message : String(err),

--- a/surfaces/dashboard/src/lib/agent-config.test.tsx
+++ b/surfaces/dashboard/src/lib/agent-config.test.tsx
@@ -16,6 +16,7 @@ import { act } from "react";
 import { useEffect, useRef } from "react";
 import { type Root, createRoot } from "react-dom/client";
 import { type AgentConfigStore, isDreamingEnabled, useAgentConfig } from "./agent-config";
+import { writeEmbeddingEndpoint } from "./embedding-config";
 
 const INITIAL_CONFIG = `inference:
   defaultPolicy: background
@@ -31,6 +32,9 @@ const INITIAL_CONFIG = `inference:
     background:
       executor: openai-compatible
       endpoint: http://127.0.0.1:1234/v1
+embedding:
+  provider: ollama
+  baseUrl: http://127.0.0.1:11434
 memory:
   pipelineV2:
     mutationsFrozen: true
@@ -188,6 +192,22 @@ describe("agent config store", () => {
 		expect(body).toContain("executor: openai-compatible");
 		expect(body).toContain("x-custom-operator-key:");
 		expect(body).toContain("nested: keep-me");
+		await harness.unmount();
+	});
+
+	test("saves embedding endpoints as base_url and removes the dashboard alias (#1264)", async () => {
+		capturedSaveBody = null;
+		const harness = await mountHarness();
+
+		await act(async () => {
+			writeEmbeddingEndpoint(harness.store, ["embedding"], "http://192.168.1.10:11434");
+			await harness.store.save();
+		});
+
+		const body = requireSaveBody(capturedSaveBody);
+		expect(body).toContain("base_url: http://192.168.1.10:11434");
+		expect(body).not.toContain("baseUrl:");
+		expect(body).not.toContain("127.0.0.1:11434");
 		await harness.unmount();
 	});
 });

--- a/surfaces/dashboard/src/lib/embedding-config.ts
+++ b/surfaces/dashboard/src/lib/embedding-config.ts
@@ -1,0 +1,17 @@
+import type { AgentConfigStore } from "./agent-config";
+
+type EmbeddingConfigStore = Pick<AgentConfigStore, "aDel" | "aSetStr" | "aStr">;
+
+export function readEmbeddingEndpoint(store: Pick<EmbeddingConfigStore, "aStr">, path: readonly string[]): string {
+	return store.aStr([...path, "base_url"]) || store.aStr([...path, "baseUrl"]) || store.aStr([...path, "endpoint"]);
+}
+
+export function writeEmbeddingEndpoint(
+	store: Pick<EmbeddingConfigStore, "aDel" | "aSetStr">,
+	path: readonly string[],
+	value: string,
+): void {
+	store.aSetStr([...path, "base_url"], value);
+	store.aDel([...path, "baseUrl"]);
+	store.aDel([...path, "endpoint"]);
+}

--- a/surfaces/dashboard/src/views/settings.tsx
+++ b/surfaces/dashboard/src/views/settings.tsx
@@ -4,6 +4,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Switch } from "@/components/ui/switch";
 import { type AgentConfigStore, isDreamingEnabled, useAgentConfig } from "@/lib/agent-config";
 import { type InferenceCatalog, type LogEntry, api } from "@/lib/api";
+import { readEmbeddingEndpoint, writeEmbeddingEndpoint } from "@/lib/embedding-config";
 import { allowRemoteMemoryExtraction, ensureInferenceRoute, requiresRemoteMemoryConsent } from "@/lib/inference-route-config";
 import {
 	ACPX_AGENTS,
@@ -798,7 +799,7 @@ function EmbeddingEditor({ store }: { store: AgentConfigStore }) {
 
 	const provider = store.aStr([...embPath, "provider"]) || "native";
 	const model = store.aStr([...embPath, "model"]);
-	const endpoint = store.aStr([...embPath, "baseUrl"]) || store.aStr([...embPath, "endpoint"]);
+	const endpoint = readEmbeddingEndpoint(store, embPath);
 	const nonNative = provider !== "native" && provider !== "";
 
 	const apply = (path: readonly string[], value: string) => {
@@ -829,7 +830,14 @@ function EmbeddingEditor({ store }: { store: AgentConfigStore }) {
 			</Row>
 			{nonNative && (
 				<Row title="Endpoint" desc="Base URL of the embedding server.">
-					<CtrlInput value={endpoint} placeholder="http://localhost:11434" onChange={(v) => apply([...embPath, "baseUrl"], v)} />
+					<CtrlInput
+						value={endpoint}
+						placeholder="http://localhost:11434"
+						onChange={(v) => {
+							writeEmbeddingEndpoint(store, embPath, v);
+							void store.save();
+						}}
+					/>
 				</Row>
 			)}
 		</>


### PR DESCRIPTION
## Summary

Fixes #1264. The dashboard now writes the daemon's canonical `embedding.base_url` field instead of `embedding.baseUrl`, so changing an Ollama endpoint updates the endpoint the daemon actually resolves. Existing camelCase entries are canonicalized during daemon startup.

## Changes

- Added dashboard embedding endpoint helpers that read legacy aliases but save only `base_url` and remove `baseUrl` / `endpoint` aliases.
- Added config migration v8 for both `embedding` and legacy `memory.embeddings` blocks.
- Preserved an existing canonical `base_url` when both spellings conflict and emit a warning.
- Added dashboard save and daemon migration regression coverage for #1264.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

![Inference settings with runtime route status](https://github.com/Signet-AI/signetai/blob/main/screenshots/1258-inference-settings.png)

No layout or visual surface changed; this is the same Inference settings endpoint field. The screenshot is the existing fresh dashboard capture from the related Inference settings work.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

The v8 startup migration is idempotent and uses the existing atomic YAML rewrite path. It moves `baseUrl` to `base_url`, removes the duplicate alias, preserves an existing canonical value on conflict, and leaves parse-error files untouched with a warning. Reverting the commit restores the prior runtime behavior but does not need a schema rollback.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Targeted verification:

- `bun test platform/daemon/src/config-migration.test.ts platform/daemon/src/memory-config.test.ts`: 96 passed, 0 failed.
- `bun test surfaces/dashboard/src/lib/agent-config.test.tsx`: 5 passed, 0 failed.
- `bun run --filter '@signet/daemon' typecheck`: passed.
- `bun run --filter signet-dashboard typecheck`: passed.
- `bun run --filter '@signet/core' build`: passed.
- `bun run --filter '@signet/daemon' build`: passed.
- `bun run --filter signet-dashboard build`: passed.
- Touched daemon/helper files pass the pinned Biome check; the full dashboard `settings.tsx` lint still reports pre-existing baseline diagnostics.
- `git diff --check`: passed.
- Regression sabotage confirmed the new dashboard test fails with the old camelCase writer and passes with the fix restored.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The daemon remains the runtime source of truth. The dashboard accepts legacy spellings for display only, while all new saves use the canonical serialized field.
