### PR TITLE
feat(telemetry): expose accounting provenance

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -170,7 +170,8 @@ Notes on individual events:
   response exposes `coverage` per usage family with calls, tokens, and cost
   totals by provenance. Aggregate recall usage and session summaries use the
   same values, with `mixed` for combined totals. Session coverage includes a
-  `mixed` bucket so combined totals are not misclassified as `unavailable`.
+  `mixed` bucket so those combined totals are not misclassified as
+  `unavailable`.
 - **`dreaming.pass`** — dreaming is the largest token consumer (millions of
   input tokens per heavy install), so always include it in token/cost
   aggregates. `outcome` is one of `completed`, `no-op`, `failed`, or

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -66,15 +66,15 @@ PostHog failures, and never throws into the daemon.
 | `daemon.heartbeat` | every 5 minutes | `uptimeMs`, `memoryCount`, `connectorsActive`, `pipelineMode`, `extractionProvider`, `embeddingProvider`, bounded runtime-pressure buckets |
 | `session.start` | real session start (deduped; stubs and clear/reset paths don't count) | `harness`, `sessionHash` |
 | `session.turn` | every non-boundary `session-end` hook call (per turn, see notes) | `harness`, `promptCount`, `sessionHash` |
-| `session.end` | real session termination: an explicit boundary reason or a TTL-evicted (abandoned) session claim | `harness`, `reason` (`clear` / `session.deleted` / `session_branch` / `session_fork` / `session_shutdown` / `session_switch` / `stale-session-sweep` / `expired`), `sessionHash`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `cost` |
-| `llm.generate` | every LLM call | `provider`, `latencyMs`, `success`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `totalCost` |
-| `pipeline.embedding` | every embedding fetch, at the usage-recording boundary | `tokens`, `provider`, `sourceKind` (`memory-capture` / `artifact-index` / `recall` / `dreaming` / `other`), `cost` (USD) |
+| `session.end` | real session termination: an explicit boundary reason or a TTL-evicted (abandoned) session claim | `harness`, `reason` (`clear` / `session.deleted` / `session_branch` / `session_fork` / `session_shutdown` / `session_switch` / `stale-session-sweep` / `expired`), `sessionHash`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `cost`, `accountingProvenance` |
+| `llm.generate` | every LLM call | `provider`, `latencyMs`, `success`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `totalTokens`, `totalCost`, `accountingProvenance` |
+| `pipeline.embedding` | every embedding fetch, at the usage-recording boundary | `tokens`, `provider`, `sourceKind` (`memory-capture` / `artifact-index` / `recall` / `dreaming` / `other`), `cost` (USD), `accountingProvenance` |
 | `recall.performed` | every completed shared recall search | `surface`, `type` (`semantic` / `keyword` / `temporal` / `graph`), `results`, `latencyMs`, `truncated` |
 | `recall.attempted` | every valid recall request or automatic prompt-context retrieval attempt | `surface` (`explicit_api` / `tool_call` / `prompt_injection` / `dashboard` / `other`) |
 | `recall.outcome` | result and delivery boundary for a recall attempt | `surface`, `resultState` (`empty` / `non_empty` / `truncated` / `error`), `deliveryState` (`returned` / `injected` / `consumed` / `not_delivered`), `results` |
 | `source.lifecycle` | bounded source connect, index, readiness, first-recall, and recurring freshness milestones | `phase`, fixed `sourceClass`, bounded outcomes/counts/buckets |
 | `pipeline.error` | categorized extraction, decision, or embedding failure | `stage`, `code` only; no message or stack content |
-| `dreaming.pass` | every terminal agentic dreaming pass, including no-op, failed, and cancelled passes | `mode`, `outcome`, `outcomeCode`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `cost`, `artifactsConsidered`, `memoriesCreated`, `memoriesUpdated`, `memoriesSuperseded`, `memoriesRetired`, `claimsChanged`, `relationshipsChanged`, `provenanceLinksChanged`, `toolCalls`, `durationMs` |
+| `dreaming.pass` | every terminal agentic dreaming pass, including no-op, failed, and cancelled passes | `mode`, `outcome`, `outcomeCode`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `tokensTotal`, `cost`, `accountingProvenance`, `artifactsConsidered`, `memoriesCreated`, `memoriesUpdated`, `memoriesSuperseded`, `memoriesRetired`, `claimsChanged`, `relationshipsChanged`, `provenanceLinksChanged`, `toolCalls`, `durationMs` |
 | `inference.route` | inference control-plane routing decision | `surface`, `agentId`, `operation`, `taskClass`, `policyId`, `selectedTarget`, `candidateCount`, `blockedCount`, `allowedCount`, `privacy`, `durationMs`, `success`, `errorCode` |
 | `inference.execute` / `inference.stream` | per-execution outcome | `surface`, `agentId`, `operation`, `taskClass`, `policyId`, `selectedTarget`, `finalTarget`, `attemptPath`, `failedTargets`, `attemptCount`, `failedCount`, `fallbackCount`, `privacy`, `durationMs`, `inputTokens`, `outputTokens`, `success`, `cancelled`, `errorCode` |
 | `inference.fallback` | emitted alongside execute/stream when a target failed and routing fell back | same fields as execute/stream |
@@ -160,7 +160,17 @@ Notes on individual events:
   The `session.end` token and cost fields are collector-derived sums of
   matching `llm.generate`, `dreaming.pass`, and `pipeline.embedding` events.
   Unscoped usage is attributed only when exactly one session is active;
-  concurrent sessions are never guessed together.
+  concurrent sessions are never guessed together. `accountingProvenance` is
+  preserved from the matching events and becomes `mixed` when a total combines
+  more than one accounting mode.
+- **Accounting provenance** — every usage-bearing event records one bounded
+  value: `provider_reported`, `locally_estimated`, `configured_rate`,
+  `local_zero_cost`, or `unavailable`. A missing provider usage report is
+  `unavailable`, not a zero-token or zero-cost result. The `/api/telemetry/stats`
+  response exposes `coverage` per usage family with calls, tokens, and cost
+  totals by provenance. Aggregate recall usage and session summaries use the
+  same values, with `mixed` for combined totals. Session coverage includes a
+  `mixed` bucket so combined totals are not misclassified as `unavailable`.
 - **`dreaming.pass`** — dreaming is the largest token consumer (millions of
   input tokens per heavy install), so always include it in token/cost
   aggregates. `outcome` is one of `completed`, `no-op`, `failed`, or

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -1310,6 +1310,10 @@ export {
 	SignetTimeoutError,
 } from "./errors.js";
 export type {
+	AccountingCoverage,
+	AccountingCoverageTotals,
+	AccountingProvenance,
+	AccountingSummaryProvenance,
 	BatchModifyItemResult,
 	BatchModifyResponse,
 	CheckpointListResponse,

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -76,13 +76,32 @@ export interface AggregateRecallMeta {
 	readonly usage?: AggregateRecallUsage;
 }
 
+export type AccountingProvenance =
+	| "provider_reported"
+	| "locally_estimated"
+	| "configured_rate"
+	| "local_zero_cost"
+	| "unavailable";
+
+export type AccountingSummaryProvenance = AccountingProvenance | "mixed";
+
+export interface AccountingCoverageTotals {
+	readonly calls: number;
+	readonly tokens: number;
+	readonly cost: number;
+}
+
+export type AccountingCoverage = Readonly<Record<AccountingSummaryProvenance, AccountingCoverageTotals>>;
+
 export interface AggregateRecallUsage {
 	readonly inputTokens: number | null;
 	readonly outputTokens: number | null;
 	readonly cacheReadTokens: number | null;
 	readonly cacheCreationTokens: number | null;
+	readonly totalTokens: number | null;
 	readonly totalCost: number | null;
 	readonly totalDurationMs: number | null;
+	readonly accountingProvenance: AccountingSummaryProvenance;
 	readonly stages: readonly AggregateRecallUsageStage[];
 }
 
@@ -95,8 +114,10 @@ export interface AggregateRecallUsageStage {
 	readonly outputTokens: number | null;
 	readonly cacheReadTokens: number | null;
 	readonly cacheCreationTokens: number | null;
+	readonly totalTokens: number | null;
 	readonly totalCost: number | null;
 	readonly totalDurationMs: number | null;
+	readonly accountingProvenance: AccountingProvenance;
 }
 
 export interface RecallEntityAttribute {
@@ -484,6 +505,7 @@ export interface TelemetryStatsEnabledResponse {
 		readonly totalCost: number;
 		readonly p50: number;
 		readonly p95: number;
+		readonly coverage: AccountingCoverage;
 	};
 	readonly embedding: {
 		readonly calls: number;
@@ -494,6 +516,7 @@ export interface TelemetryStatsEnabledResponse {
 			readonly tokens: number;
 			readonly cost: number;
 		}[];
+		readonly coverage: AccountingCoverage;
 	};
 	readonly dreaming: {
 		readonly calls: number;
@@ -502,6 +525,7 @@ export interface TelemetryStatsEnabledResponse {
 		readonly tokensCacheRead: number;
 		readonly tokensCacheWrite: number;
 		readonly cost: number;
+		readonly coverage: AccountingCoverage;
 		readonly artifactsConsidered: number;
 		readonly memoriesCreated: number;
 		readonly memoriesUpdated: number;
@@ -559,6 +583,7 @@ export interface TelemetryStatsEnabledResponse {
 		readonly tokensCacheRead: number;
 		readonly tokensCacheWrite: number;
 		readonly cost: number;
+		readonly coverage: AccountingCoverage;
 	};
 	readonly pipelineErrors: number;
 	readonly pipelineErrorsByStage: Readonly<Record<string, number>>;

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -32,6 +32,8 @@ export {
 	DEFAULT_PROVIDER_RATE_LIMIT,
 	TELEMETRY_DEPLOYMENT_ROLES,
 	TELEMETRY_INSTALL_CHANNELS,
+	ACCOUNTING_PROVENANCES,
+	summarizeAccountingProvenance,
 } from "./types";
 export type {
 	Agent,
@@ -40,6 +42,8 @@ export type {
 	LlmProvider,
 	LlmUsage,
 	LlmGenerateResult,
+	AccountingProvenance,
+	AccountingSummaryProvenance,
 	ReadPolicy,
 	AgentDefinition,
 	Memory,

--- a/platform/core/src/recall.ts
+++ b/platform/core/src/recall.ts
@@ -1,3 +1,5 @@
+import type { AccountingProvenance, AccountingSummaryProvenance } from "./types";
+
 export interface RecallScoreFilterRow {
 	readonly score?: number;
 	readonly supplementary?: boolean;
@@ -81,8 +83,10 @@ export interface AggregateRecallUsage {
 	readonly outputTokens: number | null;
 	readonly cacheReadTokens: number | null;
 	readonly cacheCreationTokens: number | null;
+	readonly totalTokens: number | null;
 	readonly totalCost: number | null;
 	readonly totalDurationMs: number | null;
+	readonly accountingProvenance: AccountingSummaryProvenance;
 	readonly stages: readonly AggregateRecallUsageStage[];
 }
 
@@ -95,8 +99,10 @@ export interface AggregateRecallUsageStage {
 	readonly outputTokens: number | null;
 	readonly cacheReadTokens: number | null;
 	readonly cacheCreationTokens: number | null;
+	readonly totalTokens: number | null;
 	readonly totalCost: number | null;
 	readonly totalDurationMs: number | null;
+	readonly accountingProvenance: AccountingProvenance;
 }
 
 export interface RecallPayload {

--- a/platform/core/src/types.ts
+++ b/platform/core/src/types.ts
@@ -6,6 +6,33 @@
 // LLM Provider interface (used by ingest extractors, daemon pipeline, etc.)
 // ---------------------------------------------------------------------------
 
+export const ACCOUNTING_PROVENANCES = [
+	"provider_reported",
+	"locally_estimated",
+	"configured_rate",
+	"local_zero_cost",
+	"unavailable",
+] as const;
+
+export type AccountingProvenance = (typeof ACCOUNTING_PROVENANCES)[number];
+export type AccountingSummaryProvenance = AccountingProvenance | "mixed";
+
+/**
+ * Summarize the provenance of one or more accounting values without treating
+ * a missing value as a zero. The result is intentionally bounded so API
+ * consumers can render it without knowing provider-specific names.
+ */
+export function summarizeAccountingProvenance(
+	values: readonly (AccountingProvenance | null | undefined)[],
+): AccountingSummaryProvenance {
+	const present = new Set<AccountingProvenance>(
+		values.filter((value): value is AccountingProvenance => value !== null && value !== undefined),
+	);
+	if (present.size === 0) return "unavailable";
+	if (present.size === 1) return present.values().next().value ?? "unavailable";
+	return "mixed";
+}
+
 export interface LlmUsage {
 	readonly inputTokens: number | null;
 	readonly outputTokens: number | null;
@@ -14,6 +41,8 @@ export interface LlmUsage {
 	readonly totalTokens: number | null;
 	readonly totalCost: number | null;
 	readonly totalDurationMs: number | null;
+	/** Cost/token accounting source. Omitted by legacy providers means unavailable. */
+	readonly accountingProvenance?: AccountingProvenance;
 }
 
 export interface LlmGenerateResult {
@@ -32,6 +61,8 @@ export interface LlmGenerateOptions {
 
 export interface LlmProvider {
 	readonly name: string;
+	/** Known cost accounting mode for local providers; remote providers may report it per result. */
+	readonly accountingProvenance?: AccountingProvenance;
 	generate(prompt: string, opts?: LlmGenerateOptions): Promise<string>;
 	generateWithUsage?(prompt: string, opts?: LlmGenerateOptions): Promise<LlmGenerateResult>;
 	available(): Promise<boolean>;

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -114,6 +114,7 @@ class StaticRouter implements AggregateInferenceRouter {
 					totalTokens: callNumber * 10 + callNumber + callNumber,
 					totalCost: callNumber / 1000,
 					totalDurationMs: callNumber * 100,
+					accountingProvenance: "provider_reported",
 				},
 				attempts: [
 					{
@@ -128,6 +129,7 @@ class StaticRouter implements AggregateInferenceRouter {
 							totalTokens: callNumber * 10 + callNumber + callNumber,
 							totalCost: callNumber / 1000,
 							totalDurationMs: callNumber * 100,
+							accountingProvenance: "provider_reported",
 						},
 					},
 				],
@@ -262,6 +264,7 @@ describe("aggregateRecall", () => {
 				cacheReadTokens: 3,
 				totalCost: 0.003,
 				totalDurationMs: 300,
+				accountingProvenance: "provider_reported",
 				stages: [
 					{
 						name: "planning",
@@ -269,6 +272,7 @@ describe("aggregateRecall", () => {
 						attemptCount: 1,
 						fallbackCount: 0,
 						inputTokens: 10,
+						accountingProvenance: "provider_reported",
 					},
 					{
 						name: "synthesis",
@@ -276,6 +280,7 @@ describe("aggregateRecall", () => {
 						attemptCount: 1,
 						fallbackCount: 0,
 						inputTokens: 20,
+						accountingProvenance: "provider_reported",
 					},
 				],
 			},

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import type { LlmUsage, RouteRequest, RouterResult } from "@signet/core";
+import { type LlmUsage, type RouteRequest, type RouterResult, summarizeAccountingProvenance } from "@signet/core";
 import { normalizeAndHashContent } from "./content-normalization";
 import { type WriteDb, getDbAccessor } from "./db-accessor";
 import { syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "./db-helpers";
@@ -106,8 +106,8 @@ function addNullableNumbers(left: number | null, right: number | null): number |
 	return (left ?? 0) + (right ?? 0);
 }
 
-function sumUsage(stages: readonly AggregateRecallUsageStage[]): LlmUsage {
-	return stages.reduce<LlmUsage>(
+function sumUsage(stages: readonly AggregateRecallUsageStage[]): Omit<AggregateRecallUsage, "stages"> {
+	return stages.reduce<Omit<AggregateRecallUsage, "stages">>(
 		(total, stage) => ({
 			inputTokens: addNullableNumbers(total.inputTokens, stage.inputTokens),
 			outputTokens: addNullableNumbers(total.outputTokens, stage.outputTokens),
@@ -116,6 +116,7 @@ function sumUsage(stages: readonly AggregateRecallUsageStage[]): LlmUsage {
 			totalTokens: addNullableNumbers(total.totalTokens, stage.totalTokens),
 			totalCost: addNullableNumbers(total.totalCost, stage.totalCost),
 			totalDurationMs: addNullableNumbers(total.totalDurationMs, stage.totalDurationMs),
+			accountingProvenance: summarizeAccountingProvenance(stages.map((item) => item.accountingProvenance)),
 		}),
 		{
 			inputTokens: null,
@@ -125,6 +126,7 @@ function sumUsage(stages: readonly AggregateRecallUsageStage[]): LlmUsage {
 			totalTokens: null,
 			totalCost: null,
 			totalDurationMs: null,
+			accountingProvenance: "unavailable" as const,
 		},
 	);
 }
@@ -147,6 +149,7 @@ function usageStage(
 		totalTokens: usage?.totalTokens ?? null,
 		totalCost: usage?.totalCost ?? null,
 		totalDurationMs: usage?.totalDurationMs ?? okAttempt?.durationMs ?? null,
+		accountingProvenance: usage?.accountingProvenance ?? "unavailable",
 	};
 }
 

--- a/platform/daemon/src/embedding-cost.test.ts
+++ b/platform/daemon/src/embedding-cost.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { DEFAULT_EMBEDDING_COST_RATES, calculateEmbeddingCost, resolveEmbeddingCostProvider } from "./embedding-cost";
+import {
+	DEFAULT_EMBEDDING_COST_RATES,
+	calculateEmbeddingCost,
+	resolveEmbeddingAccounting,
+	resolveEmbeddingCostProvider,
+} from "./embedding-cost";
 
 describe("embedding cost attribution", () => {
 	it("uses configured rates and identifies OpenRouter by endpoint", () => {
@@ -16,5 +21,17 @@ describe("embedding cost attribution", () => {
 		expect(calculateEmbeddingCost("ollama", 100_000)).toBe(0);
 		expect(calculateEmbeddingCost("openai", 1_000_000)).toBe(DEFAULT_EMBEDDING_COST_RATES.openai);
 		expect(calculateEmbeddingCost("unknown", 1_000_000)).toBeNull();
+	});
+
+	it("labels the accounting source separately from the numeric cost", () => {
+		expect(resolveEmbeddingAccounting("ollama", 100_000)).toEqual({
+			cost: 0,
+			accountingProvenance: "local_zero_cost",
+		});
+		expect(resolveEmbeddingAccounting("openai", 1_000_000).accountingProvenance).toBe("configured_rate");
+		expect(resolveEmbeddingAccounting("unknown", 1_000_000)).toEqual({
+			cost: null,
+			accountingProvenance: "unavailable",
+		});
 	});
 });

--- a/platform/daemon/src/embedding-cost.test.ts
+++ b/platform/daemon/src/embedding-cost.test.ts
@@ -33,5 +33,9 @@ describe("embedding cost attribution", () => {
 			cost: null,
 			accountingProvenance: "unavailable",
 		});
+		expect(resolveEmbeddingAccounting("openai", 1_000_000, { baseUrl: "http://127.0.0.1:1234/v1" })).toEqual({
+			cost: 0,
+			accountingProvenance: "local_zero_cost",
+		});
 	});
 });

--- a/platform/daemon/src/embedding-cost.test.ts
+++ b/platform/daemon/src/embedding-cost.test.ts
@@ -37,5 +37,9 @@ describe("embedding cost attribution", () => {
 			cost: 0,
 			accountingProvenance: "local_zero_cost",
 		});
+		expect(resolveEmbeddingAccounting("ollama", 1_000_000, { rates: { ollama: 5 } })).toEqual({
+			cost: 5,
+			accountingProvenance: "configured_rate",
+		});
 	});
 });

--- a/platform/daemon/src/embedding-cost.ts
+++ b/platform/daemon/src/embedding-cost.ts
@@ -20,6 +20,10 @@ export const DEFAULT_EMBEDDING_COST_RATES: Readonly<Record<EmbeddingCostProvider
 	openrouter: 0.004,
 };
 
+function isLocalBaseUrl(url: string): boolean {
+	return /^https?:\/\/(127\.0\.0\.1|localhost|\[?::1\]?)/i.test(url);
+}
+
 export function resolveEmbeddingCostProvider(provider: string, baseUrl?: string): EmbeddingCostProvider | null {
 	if (provider === "native" || provider === "llama-cpp" || provider === "ollama") return provider;
 	if (provider === "openai") {
@@ -46,6 +50,9 @@ export function resolveEmbeddingAccounting(
 	if (!Number.isFinite(tokens) || tokens < 0) return { cost: null, accountingProvenance: "unavailable" };
 	const rateProvider = resolveEmbeddingCostProvider(provider, opts.baseUrl);
 	if (!rateProvider) return { cost: null, accountingProvenance: "unavailable" };
+	if (rateProvider === "openai" && opts.baseUrl !== undefined && isLocalBaseUrl(opts.baseUrl)) {
+		return { cost: 0, accountingProvenance: "local_zero_cost" };
+	}
 	if (rateProvider === "native" || rateProvider === "llama-cpp" || rateProvider === "ollama") {
 		return { cost: 0, accountingProvenance: "local_zero_cost" };
 	}

--- a/platform/daemon/src/embedding-cost.ts
+++ b/platform/daemon/src/embedding-cost.ts
@@ -6,6 +6,8 @@
  * model pricing changes independently of the daemon release.
  */
 
+import type { AccountingProvenance } from "@signet/core";
+
 export type EmbeddingCostProvider = "native" | "llama-cpp" | "ollama" | "openai" | "openrouter";
 
 export type EmbeddingCostRates = Readonly<Partial<Record<EmbeddingCostProvider, number>>>;
@@ -33,11 +35,22 @@ export function calculateEmbeddingCost(
 	tokens: number,
 	opts: { readonly baseUrl?: string; readonly rates?: EmbeddingCostRates } = {},
 ): number | null {
-	if (!Number.isFinite(tokens) || tokens < 0) return null;
+	return resolveEmbeddingAccounting(provider, tokens, opts).cost;
+}
+
+export function resolveEmbeddingAccounting(
+	provider: string,
+	tokens: number,
+	opts: { readonly baseUrl?: string; readonly rates?: EmbeddingCostRates } = {},
+): { readonly cost: number | null; readonly accountingProvenance: AccountingProvenance } {
+	if (!Number.isFinite(tokens) || tokens < 0) return { cost: null, accountingProvenance: "unavailable" };
 	const rateProvider = resolveEmbeddingCostProvider(provider, opts.baseUrl);
-	if (!rateProvider) return null;
+	if (!rateProvider) return { cost: null, accountingProvenance: "unavailable" };
+	if (rateProvider === "native" || rateProvider === "llama-cpp" || rateProvider === "ollama") {
+		return { cost: 0, accountingProvenance: "local_zero_cost" };
+	}
 	const configuredRate = opts.rates?.[rateProvider];
 	const rate = configuredRate ?? DEFAULT_EMBEDDING_COST_RATES[rateProvider];
-	if (!Number.isFinite(rate) || rate < 0) return null;
-	return (tokens * rate) / 1_000_000;
+	if (!Number.isFinite(rate) || rate < 0) return { cost: null, accountingProvenance: "unavailable" };
+	return { cost: (tokens * rate) / 1_000_000, accountingProvenance: "configured_rate" };
 }

--- a/platform/daemon/src/embedding-cost.ts
+++ b/platform/daemon/src/embedding-cost.ts
@@ -50,14 +50,23 @@ export function resolveEmbeddingAccounting(
 	if (!Number.isFinite(tokens) || tokens < 0) return { cost: null, accountingProvenance: "unavailable" };
 	const rateProvider = resolveEmbeddingCostProvider(provider, opts.baseUrl);
 	if (!rateProvider) return { cost: null, accountingProvenance: "unavailable" };
+	const configuredRate = opts.rates?.[rateProvider];
+	if (configuredRate !== undefined) {
+		if (!Number.isFinite(configuredRate) || configuredRate < 0) {
+			return { cost: null, accountingProvenance: "unavailable" };
+		}
+		return { cost: (tokens * configuredRate) / 1_000_000, accountingProvenance: "configured_rate" };
+	}
 	if (rateProvider === "openai" && opts.baseUrl !== undefined && isLocalBaseUrl(opts.baseUrl)) {
 		return { cost: 0, accountingProvenance: "local_zero_cost" };
 	}
-	if (rateProvider === "native" || rateProvider === "llama-cpp" || rateProvider === "ollama") {
+	if (
+		(rateProvider === "native" || rateProvider === "llama-cpp" || rateProvider === "ollama") &&
+		(opts.baseUrl === undefined || isLocalBaseUrl(opts.baseUrl))
+	) {
 		return { cost: 0, accountingProvenance: "local_zero_cost" };
 	}
-	const configuredRate = opts.rates?.[rateProvider];
-	const rate = configuredRate ?? DEFAULT_EMBEDDING_COST_RATES[rateProvider];
+	const rate = DEFAULT_EMBEDDING_COST_RATES[rateProvider];
 	if (!Number.isFinite(rate) || rate < 0) return { cost: null, accountingProvenance: "unavailable" };
 	return { cost: (tokens * rate) / 1_000_000, accountingProvenance: "configured_rate" };
 }

--- a/platform/daemon/src/embedding-usage.ts
+++ b/platform/daemon/src/embedding-usage.ts
@@ -19,7 +19,7 @@
 
 import type { DbAccessor } from "./db-accessor";
 import { getDbAccessor, hasDbAccessor } from "./db-accessor";
-import { type EmbeddingCostRates, calculateEmbeddingCost } from "./embedding-cost";
+import { type EmbeddingCostRates, resolveEmbeddingAccounting } from "./embedding-cost";
 import { logger } from "./logger";
 import { getActiveTelemetry } from "./telemetry";
 
@@ -72,15 +72,17 @@ export function recordEmbeddingUsage(input: {
 	// Anonymous telemetry: emit the pipeline.embedding event at the same fetch
 	// boundary so embedding token spend shows up in PostHog alongside
 	// llm.generate (issue #1181). Best-effort, like the DB accounting below.
+	const accounting = resolveEmbeddingAccounting(input.provider, input.tokens, {
+		baseUrl: input.baseUrl,
+		rates: input.costRates,
+	});
 	getActiveTelemetry()?.record("pipeline.embedding", {
 		tokens: input.tokens,
 		provider: input.provider,
 		sourceKind: input.source,
 		...(input.sessionHash ? { sessionHash: input.sessionHash } : {}),
-		cost: calculateEmbeddingCost(input.provider, input.tokens, {
-			baseUrl: input.baseUrl,
-			rates: input.costRates,
-		}),
+		cost: accounting.cost,
+		accountingProvenance: accounting.accountingProvenance,
 	});
 	if (!hasDbAccessor()) return;
 	try {

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -879,7 +879,11 @@ export class InferenceRouter {
 						// Read the session aggregate before dispose() tears the
 						// in-memory entries down. getStats is the only way to
 						// capture provider-reported tokens for the agentic loop.
-						sessionUsage = mapSessionStatsToUsage(session.getStats(), Date.now() - startedAt);
+						sessionUsage = mapSessionStatsToUsage(
+							session.getStats(),
+							Date.now() - startedAt,
+							provider.accountingProvenance ?? "unavailable",
+						);
 					} finally {
 						if (timer) clearTimeout(timer);
 						session.dispose();

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -14,6 +14,8 @@
 
 import { createHash } from "node:crypto";
 import {
+	type AccountingProvenance,
+	type AccountingSummaryProvenance,
 	type AgentRosterReadPolicy,
 	LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE,
 	type LlmUsage,
@@ -175,11 +177,13 @@ export function classifyRecallTelemetry(
 	return undefined;
 }
 
-export interface AggregateRecallUsage extends LlmUsage {
+export interface AggregateRecallUsage extends Omit<LlmUsage, "accountingProvenance"> {
+	readonly accountingProvenance: AccountingSummaryProvenance;
 	readonly stages: readonly AggregateRecallUsageStage[];
 }
 
-export interface AggregateRecallUsageStage extends LlmUsage {
+export interface AggregateRecallUsageStage extends Omit<LlmUsage, "accountingProvenance"> {
+	readonly accountingProvenance: AccountingProvenance;
 	readonly name: "planning" | "synthesis";
 	readonly targetRef: string | null;
 	readonly attemptCount: number;

--- a/platform/daemon/src/pipeline/dreaming-telemetry.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-telemetry.test.ts
@@ -63,7 +63,9 @@ describe("dreaming telemetry", () => {
 				outputTokens: 18227,
 				cacheReadTokens: 100000,
 				cacheCreationTokens: 5000,
+				totalTokens: 502788,
 				totalCost: 0.14574042,
+				accountingProvenance: "provider_reported",
 			},
 		});
 		recordDreamingPassTelemetry({
@@ -93,7 +95,9 @@ describe("dreaming telemetry", () => {
 		expect(full?.properties.tokensOutput).toBe(18227);
 		expect(full?.properties.tokensCacheRead).toBe(100000);
 		expect(full?.properties.tokensCacheWrite).toBe(5000);
+		expect(full?.properties.tokensTotal).toBe(502788);
 		expect(full?.properties.cost).toBe(0.14574042);
+		expect(full?.properties.accountingProvenance).toBe("provider_reported");
 		expect(full?.properties.outcome).toBe("completed");
 		expect(full?.properties.outcomeCode).toBe("completed");
 		expect(full?.properties.artifactsConsidered).toBe(12);

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -13,6 +13,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
+	type AccountingProvenance,
 	type DreamingConfig,
 	type IdentityContextFileEntry,
 	type LlmUsage,
@@ -940,7 +941,9 @@ export function recordDreamingPassTelemetry(input: {
 		readonly outputTokens: number | null;
 		readonly cacheReadTokens: number | null;
 		readonly cacheCreationTokens: number | null;
+		readonly totalTokens?: number | null;
 		readonly totalCost: number | null;
+		readonly accountingProvenance?: AccountingProvenance;
 	} | null;
 }): void {
 	try {
@@ -952,7 +955,9 @@ export function recordDreamingPassTelemetry(input: {
 			tokensOutput: input.usage?.outputTokens ?? null,
 			tokensCacheRead: input.usage?.cacheReadTokens ?? null,
 			tokensCacheWrite: input.usage?.cacheCreationTokens ?? null,
+			tokensTotal: input.usage?.totalTokens ?? null,
 			cost: input.usage?.totalCost ?? null,
+			accountingProvenance: input.usage?.accountingProvenance ?? "unavailable",
 			artifactsConsidered: input.effects.artifactsConsidered,
 			memoriesCreated: input.effects.memoriesCreated,
 			memoriesUpdated: input.effects.memoriesUpdated,

--- a/platform/daemon/src/pipeline/pi-provider.test.ts
+++ b/platform/daemon/src/pipeline/pi-provider.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, mock, test } from "bun:test";
-import type { Api, Model } from "@earendil-works/pi-ai";
+import type { Api, Model, Usage } from "@earendil-works/pi-ai";
 import { getBuiltinModels as getModels } from "@earendil-works/pi-ai/providers/all";
 import type { SessionStats } from "@earendil-works/pi-coding-agent";
-import { createPiModelProvider, isPiAgentSessionProvider, mapSessionStatsToUsage, resolvePiModel } from "./pi-provider";
+import {
+	createPiModelProvider,
+	isPiAgentSessionProvider,
+	mapSessionStatsToUsage,
+	mapUsage,
+	resolvePiModel,
+} from "./pi-provider";
 
 describe("pi provider catalog models", () => {
 	test("preserves the Codex responses API and registry metadata", () => {
@@ -57,6 +63,14 @@ describe("pi provider catalog models", () => {
 		expect(provider.accountingProvenance).toBe("unavailable");
 		expect(mapSessionStatsToUsage(stats, 10, provider.accountingProvenance)).toMatchObject({
 			totalTokens: 4,
+			totalCost: null,
+			accountingProvenance: "unavailable",
+		});
+	});
+
+	test("does not label missing remote usage as provider-reported zero tokens", () => {
+		expect(mapUsage({} as Usage, "provider_reported")).toMatchObject({
+			totalTokens: null,
 			totalCost: null,
 			accountingProvenance: "unavailable",
 		});

--- a/platform/daemon/src/pipeline/pi-provider.test.ts
+++ b/platform/daemon/src/pipeline/pi-provider.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { getBuiltinModels as getModels } from "@earendil-works/pi-ai/providers/all";
-import { createPiModelProvider, isPiAgentSessionProvider, resolvePiModel } from "./pi-provider";
+import type { SessionStats } from "@earendil-works/pi-coding-agent";
+import { createPiModelProvider, isPiAgentSessionProvider, mapSessionStatsToUsage, resolvePiModel } from "./pi-provider";
 
 describe("pi provider catalog models", () => {
 	test("preserves the Codex responses API and registry metadata", () => {
@@ -33,6 +34,32 @@ describe("pi provider catalog models", () => {
 		});
 
 		expect(resolved.piModel.baseUrl).toBe("https://opencode.ai/zen/go/v1");
+	});
+
+	test("does not label a remote zero-rate model as provider-reported cost", () => {
+		const provider = createPiModelProvider({
+			executor: "openai-compatible",
+			model: "gateway-model",
+			baseUrl: "https://gateway.example.test/v1",
+		});
+		const stats: SessionStats = {
+			sessionFile: undefined,
+			sessionId: "session",
+			userMessages: 1,
+			assistantMessages: 1,
+			toolCalls: 0,
+			toolResults: 0,
+			totalMessages: 2,
+			tokens: { input: 3, output: 1, cacheRead: 0, cacheWrite: 0, total: 4 },
+			cost: 0,
+		};
+
+		expect(provider.accountingProvenance).toBe("unavailable");
+		expect(mapSessionStatsToUsage(stats, 10, provider.accountingProvenance)).toMatchObject({
+			totalTokens: 4,
+			totalCost: null,
+			accountingProvenance: "unavailable",
+		});
 	});
 
 	test("creates an isolated AgentSession with no ambient tools", async () => {

--- a/platform/daemon/src/pipeline/pi-provider.ts
+++ b/platform/daemon/src/pipeline/pi-provider.ts
@@ -267,16 +267,39 @@ export function resolvePiModel(config: PiModelProviderConfig): ResolvedModel {
 	}
 }
 
-function mapUsage(usage: Usage, accountingProvenance: AccountingProvenance): LlmUsage {
+function hasUsageValues(values: readonly (number | null | undefined)[]): boolean {
+	return values.some((value) => typeof value === "number" && Number.isFinite(value) && value > 0);
+}
+
+function usageHasAccounting(usage: Usage): boolean {
+	return hasUsageValues([
+		usage.input,
+		usage.output,
+		usage.cacheRead,
+		usage.cacheWrite,
+		usage.totalTokens,
+		usage.cost?.total,
+	]);
+}
+
+function effectiveAccountingProvenance(
+	hasUsage: boolean,
+	accountingProvenance: AccountingProvenance,
+): AccountingProvenance {
+	return hasUsage || accountingProvenance === "local_zero_cost" ? accountingProvenance : "unavailable";
+}
+
+export function mapUsage(usage: Usage, accountingProvenance: AccountingProvenance): LlmUsage {
+	const effectiveProvenance = effectiveAccountingProvenance(usageHasAccounting(usage), accountingProvenance);
 	return {
 		inputTokens: usage.input ?? null,
 		outputTokens: usage.output ?? null,
 		cacheReadTokens: usage.cacheRead ?? null,
 		cacheCreationTokens: usage.cacheWrite ?? null,
 		totalTokens: usage.totalTokens ?? null,
-		totalCost: accountingProvenance === "unavailable" ? null : (usage.cost?.total ?? null),
+		totalCost: effectiveProvenance === "unavailable" ? null : (usage.cost?.total ?? null),
 		totalDurationMs: null,
-		accountingProvenance,
+		accountingProvenance: effectiveProvenance,
 	};
 }
 
@@ -304,15 +327,26 @@ export function mapSessionStatsToUsage(
 			accountingProvenance,
 		};
 	}
+	const effectiveProvenance = effectiveAccountingProvenance(
+		hasUsageValues([
+			stats.tokens.input,
+			stats.tokens.output,
+			stats.tokens.cacheRead,
+			stats.tokens.cacheWrite,
+			stats.tokens.total,
+			stats.cost,
+		]),
+		accountingProvenance,
+	);
 	return {
 		inputTokens: stats.tokens.input,
 		outputTokens: stats.tokens.output,
 		cacheReadTokens: stats.tokens.cacheRead,
 		cacheCreationTokens: stats.tokens.cacheWrite,
 		totalTokens: stats.tokens.total,
-		totalCost: accountingProvenance === "unavailable" ? null : stats.cost,
+		totalCost: effectiveProvenance === "unavailable" ? null : stats.cost,
 		totalDurationMs,
-		accountingProvenance,
+		accountingProvenance: effectiveProvenance,
 	};
 }
 

--- a/platform/daemon/src/pipeline/pi-provider.ts
+++ b/platform/daemon/src/pipeline/pi-provider.ts
@@ -27,7 +27,7 @@ import {
 	type ToolDefinition,
 	createAgentSession,
 } from "@earendil-works/pi-coding-agent";
-import type { LlmGenerateResult, LlmProvider, LlmUsage } from "@signet/core";
+import type { AccountingProvenance, LlmGenerateResult, LlmProvider, LlmUsage } from "@signet/core";
 import { logger } from "../logger";
 import type {
 	LlmProviderCallOptions,
@@ -135,6 +135,12 @@ interface ResolvedModel {
 
 function isLocalBaseUrl(url: string): boolean {
 	return /^https?:\/\/(127\.0\.0\.1|localhost|\[?::1\]?)/i.test(url);
+}
+
+function localAccountingForConfig(config: PiModelProviderConfig): AccountingProvenance | undefined {
+	if (config.executor === "ollama" || config.executor === "llama-cpp") return "local_zero_cost";
+	if (config.executor !== "openai-compatible") return undefined;
+	return isLocalBaseUrl(config.baseUrl ?? DEFAULT_OPENAI_COMPATIBLE_BASE_URL) ? "local_zero_cost" : undefined;
 }
 
 function withVersionPath(baseUrl: string): string {
@@ -254,7 +260,7 @@ export function resolvePiModel(config: PiModelProviderConfig): ResolvedModel {
 	}
 }
 
-function mapUsage(usage: Usage): LlmUsage {
+function mapUsage(usage: Usage, accountingProvenance: AccountingProvenance): LlmUsage {
 	return {
 		inputTokens: usage.input ?? null,
 		outputTokens: usage.output ?? null,
@@ -263,6 +269,7 @@ function mapUsage(usage: Usage): LlmUsage {
 		totalTokens: usage.totalTokens ?? null,
 		totalCost: usage.cost?.total ?? null,
 		totalDurationMs: null,
+		accountingProvenance,
 	};
 }
 
@@ -273,7 +280,11 @@ function mapUsage(usage: Usage): LlmUsage {
  * yields an all-null usage so callers can distinguish "no usage reported"
  * from a real zero-token pass.
  */
-export function mapSessionStatsToUsage(stats: SessionStats | undefined, totalDurationMs: number): LlmUsage {
+export function mapSessionStatsToUsage(
+	stats: SessionStats | undefined,
+	totalDurationMs: number,
+	accountingProvenance: AccountingProvenance = "unavailable",
+): LlmUsage {
 	if (stats === undefined) {
 		return {
 			inputTokens: null,
@@ -283,6 +294,7 @@ export function mapSessionStatsToUsage(stats: SessionStats | undefined, totalDur
 			totalTokens: null,
 			totalCost: null,
 			totalDurationMs,
+			accountingProvenance,
 		};
 	}
 	return {
@@ -293,6 +305,7 @@ export function mapSessionStatsToUsage(stats: SessionStats | undefined, totalDur
 		totalTokens: stats.tokens.total,
 		totalCost: stats.cost,
 		totalDurationMs,
+		accountingProvenance,
 	};
 }
 
@@ -356,6 +369,7 @@ export function createPiModelProvider(
 ): StreamCapableLlmProvider & PiAgentSessionProvider {
 	const { piModel, apiKey, label } = resolvePiModel(config);
 	const name = config.name ?? label;
+	const accountingProvenance = localAccountingForConfig(config);
 	const defaultTimeoutMs = config.defaultTimeoutMs ?? 60_000;
 	const reasoning = config.reasoning;
 	const modelRuntime = ModelRuntime.create({
@@ -416,7 +430,7 @@ export function createPiModelProvider(
 			return {
 				text,
 				usage: {
-					...mapUsage(msg.usage),
+					...mapUsage(msg.usage, accountingProvenance ?? "provider_reported"),
 					totalDurationMs: durationMs,
 				},
 			};
@@ -427,6 +441,7 @@ export function createPiModelProvider(
 
 	const provider: LlmProvider = {
 		name,
+		...(accountingProvenance ? { accountingProvenance } : {}),
 		async generate(prompt, opts) {
 			const { text } = await callOnce(prompt, opts);
 			return text;
@@ -477,10 +492,16 @@ export function createPiModelProvider(
 								fullText += ev.delta;
 								controller.enqueue({ type: "text-delta", text: ev.delta });
 							} else if (ev.type === "done") {
-								finalUsage = { ...mapUsage(ev.message.usage), totalDurationMs: Date.now() - t0 };
+								finalUsage = {
+									...mapUsage(ev.message.usage, accountingProvenance ?? "provider_reported"),
+									totalDurationMs: Date.now() - t0,
+								};
 								controller.enqueue({ type: "done", text: fullText, usage: finalUsage });
 							} else if (ev.type === "error") {
-								finalUsage = { ...mapUsage(ev.error.usage), totalDurationMs: Date.now() - t0 };
+								finalUsage = {
+									...mapUsage(ev.error.usage, accountingProvenance ?? "provider_reported"),
+									totalDurationMs: Date.now() - t0,
+								};
 								controller.error(toError(name, { stopReason: ev.reason, errorMessage: ev.error.errorMessage }));
 								return;
 							}
@@ -513,6 +534,7 @@ export function createPiModelProvider(
 
 	return {
 		...streamCapable,
+		...(accountingProvenance ? { accountingProvenance } : {}),
 		isPiAgentSessionProvider: true,
 		agentSessionTimeoutMs: defaultTimeoutMs,
 		async createAgentSession(tools: readonly ToolDefinition[], options: { readonly maxTokens?: number } = {}) {

--- a/platform/daemon/src/pipeline/pi-provider.ts
+++ b/platform/daemon/src/pipeline/pi-provider.ts
@@ -143,6 +143,13 @@ function localAccountingForConfig(config: PiModelProviderConfig): AccountingProv
 	return isLocalBaseUrl(config.baseUrl ?? DEFAULT_OPENAI_COMPATIBLE_BASE_URL) ? "local_zero_cost" : undefined;
 }
 
+function accountingProvenanceForConfig(config: PiModelProviderConfig, piModel: Model<Api>): AccountingProvenance {
+	const local = localAccountingForConfig(config);
+	if (local) return local;
+	const hasModelRates = Object.values(piModel.cost).some((rate) => Number.isFinite(rate) && rate > 0);
+	return hasModelRates ? "locally_estimated" : "unavailable";
+}
+
 function withVersionPath(baseUrl: string): string {
 	const trimmed = baseUrl.trim().replace(/\/+$/, "");
 	// Routing targets conventionally store an OpenAI *base* URL, while users
@@ -267,7 +274,7 @@ function mapUsage(usage: Usage, accountingProvenance: AccountingProvenance): Llm
 		cacheReadTokens: usage.cacheRead ?? null,
 		cacheCreationTokens: usage.cacheWrite ?? null,
 		totalTokens: usage.totalTokens ?? null,
-		totalCost: usage.cost?.total ?? null,
+		totalCost: accountingProvenance === "unavailable" ? null : (usage.cost?.total ?? null),
 		totalDurationMs: null,
 		accountingProvenance,
 	};
@@ -275,8 +282,8 @@ function mapUsage(usage: Usage, accountingProvenance: AccountingProvenance): Llm
 
 /**
  * Map a pi-coding-agent SessionStats aggregate to the shared LlmUsage shape.
- * The stats object aggregates provider-reported usage across every assistant
- * turn and tool result in the session; a session that reported nothing
+ * The stats object aggregates usage across every assistant turn and tool
+ * result in the session; a session that reported nothing
  * yields an all-null usage so callers can distinguish "no usage reported"
  * from a real zero-token pass.
  */
@@ -303,7 +310,7 @@ export function mapSessionStatsToUsage(
 		cacheReadTokens: stats.tokens.cacheRead,
 		cacheCreationTokens: stats.tokens.cacheWrite,
 		totalTokens: stats.tokens.total,
-		totalCost: stats.cost,
+		totalCost: accountingProvenance === "unavailable" ? null : stats.cost,
 		totalDurationMs,
 		accountingProvenance,
 	};
@@ -369,7 +376,7 @@ export function createPiModelProvider(
 ): StreamCapableLlmProvider & PiAgentSessionProvider {
 	const { piModel, apiKey, label } = resolvePiModel(config);
 	const name = config.name ?? label;
-	const accountingProvenance = localAccountingForConfig(config);
+	const accountingProvenance = accountingProvenanceForConfig(config, piModel);
 	const defaultTimeoutMs = config.defaultTimeoutMs ?? 60_000;
 	const reasoning = config.reasoning;
 	const modelRuntime = ModelRuntime.create({
@@ -441,7 +448,7 @@ export function createPiModelProvider(
 
 	const provider: LlmProvider = {
 		name,
-		...(accountingProvenance ? { accountingProvenance } : {}),
+		accountingProvenance,
 		async generate(prompt, opts) {
 			const { text } = await callOnce(prompt, opts);
 			return text;

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -503,7 +503,10 @@ function recordLlmGenerate(provider: LlmProvider, usage: LlmUsage | null, latenc
 		outputTokens: usage?.outputTokens ?? null,
 		cacheReadTokens: usage?.cacheReadTokens ?? null,
 		cacheCreationTokens: usage?.cacheCreationTokens ?? null,
+		totalTokens: usage?.totalTokens ?? null,
 		totalCost: usage?.totalCost ?? null,
+		accountingProvenance:
+			provider.accountingProvenance ?? usage?.accountingProvenance ?? (usage ? "provider_reported" : "unavailable"),
 	});
 }
 

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -351,6 +351,7 @@ export function withRateLimit(provider: LlmProvider, config?: ProviderRateLimitC
 	const genWithUsage = provider.generateWithUsage;
 	return {
 		name: provider.name,
+		...(provider.accountingProvenance ? { accountingProvenance: provider.accountingProvenance } : {}),
 
 		async generate(prompt, opts): Promise<string> {
 			if (!(await bucket.acquire(waitTimeoutMs))) {

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -507,7 +507,12 @@ function recordLlmGenerate(provider: LlmProvider, usage: LlmUsage | null, latenc
 		totalTokens: usage?.totalTokens ?? null,
 		totalCost: usage?.totalCost ?? null,
 		accountingProvenance:
-			provider.accountingProvenance ?? usage?.accountingProvenance ?? (usage ? "provider_reported" : "unavailable"),
+			usage?.accountingProvenance ??
+			(usage === null && provider.accountingProvenance === "local_zero_cost"
+				? "local_zero_cost"
+				: provider.accountingProvenance && usage !== null
+					? provider.accountingProvenance
+					: "unavailable"),
 	});
 }
 

--- a/platform/daemon/src/routes/telemetry-routes.test.ts
+++ b/platform/daemon/src/routes/telemetry-routes.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { addAccountingCoverage, emptyAccountingCoverage } from "./telemetry-routes";
+
+describe("telemetry accounting coverage", () => {
+	test("keeps mixed session summaries out of unavailable coverage", () => {
+		const coverage = emptyAccountingCoverage();
+
+		addAccountingCoverage(coverage, "mixed", 42, 0.12);
+
+		expect(coverage.mixed).toEqual({ calls: 1, tokens: 42, cost: 0.12 });
+		expect(coverage.unavailable).toEqual({ calls: 0, tokens: 0, cost: 0 });
+	});
+
+	test("maps unknown legacy provenance to unavailable", () => {
+		const coverage = emptyAccountingCoverage();
+
+		addAccountingCoverage(coverage, undefined, null, null);
+
+		expect(coverage.unavailable).toEqual({ calls: 1, tokens: 0, cost: 0 });
+		expect(coverage.mixed).toEqual({ calls: 0, tokens: 0, cost: 0 });
+	});
+});

--- a/platform/daemon/src/routes/telemetry-routes.ts
+++ b/platform/daemon/src/routes/telemetry-routes.ts
@@ -1,5 +1,6 @@
 import { realpathSync } from "node:fs";
 import { join } from "node:path";
+import type { AccountingSummaryProvenance } from "@signet/core";
 import type { Hono } from "hono";
 import type { ErrorStage } from "../analytics.js";
 import { requirePermission } from "../auth";
@@ -20,6 +21,63 @@ import {
 	telemetryRef,
 } from "./state.js";
 import { resolveScopedAgentId, resolveScopedProject } from "./utils.js";
+
+interface AccountingCoverageTotals {
+	calls: number;
+	tokens: number;
+	cost: number;
+}
+
+type AccountingCoverage = Record<AccountingSummaryProvenance, AccountingCoverageTotals>;
+
+export function emptyAccountingCoverage(): AccountingCoverage {
+	return {
+		provider_reported: { calls: 0, tokens: 0, cost: 0 },
+		locally_estimated: { calls: 0, tokens: 0, cost: 0 },
+		configured_rate: { calls: 0, tokens: 0, cost: 0 },
+		local_zero_cost: { calls: 0, tokens: 0, cost: 0 },
+		unavailable: { calls: 0, tokens: 0, cost: 0 },
+		mixed: { calls: 0, tokens: 0, cost: 0 },
+	};
+}
+
+export function addAccountingCoverage(
+	coverage: AccountingCoverage,
+	value: unknown,
+	tokens: number | null,
+	cost: number | null,
+): void {
+	const provenance: AccountingSummaryProvenance =
+		value === "provider_reported" ||
+		value === "locally_estimated" ||
+		value === "configured_rate" ||
+		value === "local_zero_cost" ||
+		value === "mixed"
+			? value
+			: "unavailable";
+	const totals = coverage[provenance];
+	totals.calls++;
+	if (typeof tokens === "number" && Number.isFinite(tokens)) totals.tokens += tokens;
+	if (typeof cost === "number" && Number.isFinite(cost)) totals.cost += cost;
+}
+
+function numberProperty(properties: Readonly<Record<string, unknown>>, key: string): number | null {
+	const value = properties[key];
+	return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function totalTokens(
+	properties: Readonly<Record<string, unknown>>,
+	totalKey: string,
+	inputKey: string,
+	outputKey: string,
+): number | null {
+	const total = numberProperty(properties, totalKey);
+	if (total !== null) return total;
+	const input = numberProperty(properties, inputKey);
+	const output = numberProperty(properties, outputKey);
+	return input === null && output === null ? null : (input ?? 0) + (output ?? 0);
+}
 
 export function registerTelemetryRoutes(app: Hono): void {
 	app.use("/api/analytics", async (c, next) => {
@@ -258,6 +316,10 @@ export function registerTelemetryRoutes(app: Hono): void {
 		let sessionCacheRead = 0;
 		let sessionCacheWrite = 0;
 		let sessionCost = 0;
+		const llmCoverage = emptyAccountingCoverage();
+		const embeddingCoverage = emptyAccountingCoverage();
+		const dreamingCoverage = emptyAccountingCoverage();
+		const sessionCoverage = emptyAccountingCoverage();
 		const latencies: number[] = [];
 
 		for (const e of events) {
@@ -266,6 +328,12 @@ export function registerTelemetryRoutes(app: Hono): void {
 				if (typeof e.properties.inputTokens === "number") totalInputTokens += e.properties.inputTokens;
 				if (typeof e.properties.outputTokens === "number") totalOutputTokens += e.properties.outputTokens;
 				if (typeof e.properties.totalCost === "number") totalCost += e.properties.totalCost;
+				addAccountingCoverage(
+					llmCoverage,
+					e.properties.accountingProvenance,
+					totalTokens(e.properties, "totalTokens", "inputTokens", "outputTokens"),
+					numberProperty(e.properties, "totalCost"),
+				);
 				if (e.properties.success === false) llmErrors++;
 				if (typeof e.properties.latencyMs === "number") latencies.push(e.properties.latencyMs);
 			}
@@ -275,6 +343,12 @@ export function registerTelemetryRoutes(app: Hono): void {
 				const cost = typeof e.properties.cost === "number" ? e.properties.cost : 0;
 				embeddingTokens += tokens;
 				embeddingCost += cost;
+				addAccountingCoverage(
+					embeddingCoverage,
+					e.properties.accountingProvenance,
+					tokens,
+					numberProperty(e.properties, "cost"),
+				);
 				const sourceKind = typeof e.properties.sourceKind === "string" ? e.properties.sourceKind : "other";
 				const source = embeddingBySource.get(sourceKind) ?? { tokens: 0, cost: 0 };
 				source.tokens += tokens;
@@ -288,22 +362,28 @@ export function registerTelemetryRoutes(app: Hono): void {
 				if (typeof e.properties.tokensCacheRead === "number") dreamingCacheRead += e.properties.tokensCacheRead;
 				if (typeof e.properties.tokensCacheWrite === "number") dreamingCacheWrite += e.properties.tokensCacheWrite;
 				if (typeof e.properties.cost === "number") dreamingCost += e.properties.cost;
-				const numberProperty = (name: string): number =>
+				addAccountingCoverage(
+					dreamingCoverage,
+					e.properties.accountingProvenance,
+					totalTokens(e.properties, "tokensTotal", "tokensInput", "tokensOutput"),
+					numberProperty(e.properties, "cost"),
+				);
+				const effectNumberProperty = (name: string): number =>
 					typeof e.properties[name] === "number" && Number.isFinite(e.properties[name]) ? e.properties[name] : 0;
 				const outcome = typeof e.properties.outcome === "string" ? e.properties.outcome : "unknown";
 				const outcomeCode = typeof e.properties.outcomeCode === "string" ? e.properties.outcomeCode : "unknown";
 				dreamingOutcomes.set(outcome, (dreamingOutcomes.get(outcome) ?? 0) + 1);
 				dreamingOutcomeCodes.set(outcomeCode, (dreamingOutcomeCodes.get(outcomeCode) ?? 0) + 1);
-				dreamingArtifacts += numberProperty("artifactsConsidered");
-				dreamingMemoriesCreated += numberProperty("memoriesCreated");
-				dreamingMemoriesUpdated += numberProperty("memoriesUpdated");
-				dreamingMemoriesSuperseded += numberProperty("memoriesSuperseded");
-				dreamingMemoriesRetired += numberProperty("memoriesRetired");
-				dreamingClaimsChanged += numberProperty("claimsChanged");
-				dreamingRelationshipsChanged += numberProperty("relationshipsChanged");
-				dreamingProvenanceLinksChanged += numberProperty("provenanceLinksChanged");
-				dreamingToolCalls += numberProperty("toolCalls");
-				dreamingDurationMs += numberProperty("durationMs");
+				dreamingArtifacts += effectNumberProperty("artifactsConsidered");
+				dreamingMemoriesCreated += effectNumberProperty("memoriesCreated");
+				dreamingMemoriesUpdated += effectNumberProperty("memoriesUpdated");
+				dreamingMemoriesSuperseded += effectNumberProperty("memoriesSuperseded");
+				dreamingMemoriesRetired += effectNumberProperty("memoriesRetired");
+				dreamingClaimsChanged += effectNumberProperty("claimsChanged");
+				dreamingRelationshipsChanged += effectNumberProperty("relationshipsChanged");
+				dreamingProvenanceLinksChanged += effectNumberProperty("provenanceLinksChanged");
+				dreamingToolCalls += effectNumberProperty("toolCalls");
+				dreamingDurationMs += effectNumberProperty("durationMs");
 
 				const mode = typeof e.properties.mode === "string" ? e.properties.mode : "unknown";
 				const byMode = dreamingByMode.get(mode) ?? {
@@ -323,19 +403,19 @@ export function registerTelemetryRoutes(app: Hono): void {
 					durationMs: 0,
 				};
 				byMode.calls++;
-				byMode.tokensInput += numberProperty("tokensInput");
-				byMode.tokensOutput += numberProperty("tokensOutput");
-				byMode.cost += numberProperty("cost");
-				byMode.artifactsConsidered += numberProperty("artifactsConsidered");
-				byMode.memoriesCreated += numberProperty("memoriesCreated");
-				byMode.memoriesUpdated += numberProperty("memoriesUpdated");
-				byMode.memoriesSuperseded += numberProperty("memoriesSuperseded");
-				byMode.memoriesRetired += numberProperty("memoriesRetired");
-				byMode.claimsChanged += numberProperty("claimsChanged");
-				byMode.relationshipsChanged += numberProperty("relationshipsChanged");
-				byMode.provenanceLinksChanged += numberProperty("provenanceLinksChanged");
-				byMode.toolCalls += numberProperty("toolCalls");
-				byMode.durationMs += numberProperty("durationMs");
+				byMode.tokensInput += effectNumberProperty("tokensInput");
+				byMode.tokensOutput += effectNumberProperty("tokensOutput");
+				byMode.cost += effectNumberProperty("cost");
+				byMode.artifactsConsidered += effectNumberProperty("artifactsConsidered");
+				byMode.memoriesCreated += effectNumberProperty("memoriesCreated");
+				byMode.memoriesUpdated += effectNumberProperty("memoriesUpdated");
+				byMode.memoriesSuperseded += effectNumberProperty("memoriesSuperseded");
+				byMode.memoriesRetired += effectNumberProperty("memoriesRetired");
+				byMode.claimsChanged += effectNumberProperty("claimsChanged");
+				byMode.relationshipsChanged += effectNumberProperty("relationshipsChanged");
+				byMode.provenanceLinksChanged += effectNumberProperty("provenanceLinksChanged");
+				byMode.toolCalls += effectNumberProperty("toolCalls");
+				byMode.durationMs += effectNumberProperty("durationMs");
 				dreamingByMode.set(mode, byMode);
 			}
 			if (e.event === "pipeline.error") {
@@ -354,6 +434,12 @@ export function registerTelemetryRoutes(app: Hono): void {
 				if (typeof e.properties.tokensCacheRead === "number") sessionCacheRead += e.properties.tokensCacheRead;
 				if (typeof e.properties.tokensCacheWrite === "number") sessionCacheWrite += e.properties.tokensCacheWrite;
 				if (typeof e.properties.cost === "number") sessionCost += e.properties.cost;
+				addAccountingCoverage(
+					sessionCoverage,
+					e.properties.accountingProvenance,
+					totalTokens(e.properties, "tokensTotal", "tokensInput", "tokensOutput"),
+					numberProperty(e.properties, "cost"),
+				);
 			}
 			if (e.event === "recall.performed") {
 				recallCalls++;
@@ -393,7 +479,16 @@ export function registerTelemetryRoutes(app: Hono): void {
 		return c.json({
 			enabled: true,
 			totalEvents: events.length,
-			llm: { calls: llmCalls, errors: llmErrors, totalInputTokens, totalOutputTokens, totalCost, p50, p95 },
+			llm: {
+				calls: llmCalls,
+				errors: llmErrors,
+				totalInputTokens,
+				totalOutputTokens,
+				totalCost,
+				p50,
+				p95,
+				coverage: llmCoverage,
+			},
 			embedding: {
 				calls: embeddingCalls,
 				totalTokens: embeddingTokens,
@@ -401,6 +496,7 @@ export function registerTelemetryRoutes(app: Hono): void {
 				bySource: [...embeddingBySource.entries()]
 					.map(([source, totals]) => ({ source, tokens: totals.tokens, cost: totals.cost }))
 					.sort((a, b) => b.tokens - a.tokens),
+				coverage: embeddingCoverage,
 			},
 			dreaming: {
 				calls: dreamingCalls,
@@ -409,6 +505,7 @@ export function registerTelemetryRoutes(app: Hono): void {
 				tokensCacheRead: dreamingCacheRead,
 				tokensCacheWrite: dreamingCacheWrite,
 				cost: dreamingCost,
+				coverage: dreamingCoverage,
 				artifactsConsidered: dreamingArtifacts,
 				memoriesCreated: dreamingMemoriesCreated,
 				memoriesUpdated: dreamingMemoriesUpdated,
@@ -452,6 +549,7 @@ export function registerTelemetryRoutes(app: Hono): void {
 				tokensCacheRead: sessionCacheRead,
 				tokensCacheWrite: sessionCacheWrite,
 				cost: sessionCost,
+				coverage: sessionCoverage,
 			},
 			pipelineErrors,
 			pipelineErrorsByStage: Object.fromEntries(pipelineErrorsByStage),

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -786,11 +786,13 @@ describe("session economics (issue #1201)", () => {
 			cacheReadTokens: 10,
 			cacheCreationTokens: 5,
 			totalCost: 0.5,
+			accountingProvenance: "provider_reported",
 		});
 		collector.record("pipeline.embedding", {
 			sessionHash: "session-1",
 			tokens: 2_000_000,
 			cost: 0.04,
+			accountingProvenance: "configured_rate",
 		});
 		collector.record("session.end", { sessionHash: "session-1" });
 		await collector.flush();
@@ -801,6 +803,7 @@ describe("session economics (issue #1201)", () => {
 		expect(end?.properties.tokensCacheRead).toBe(10);
 		expect(end?.properties.tokensCacheWrite).toBe(5);
 		expect(end?.properties.cost).toBe(0.54);
+		expect(end?.properties.accountingProvenance).toBe("mixed");
 	});
 
 	it("recovers from a missing session-end key without poisoning later sessions", async () => {

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -10,7 +10,9 @@ import { createHash } from "node:crypto";
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
+	type AccountingProvenance,
 	type PipelineTelemetryConfig,
+	summarizeAccountingProvenance,
 	TELEMETRY_DEPLOYMENT_ROLES,
 	TELEMETRY_INSTALL_CHANNELS,
 	type TelemetryDeploymentRole,
@@ -132,6 +134,7 @@ interface SessionCostAccumulator {
 	tokensCacheRead: number;
 	tokensCacheWrite: number;
 	cost: number;
+	provenances: AccountingProvenance[];
 }
 
 const MAX_ACTIVE_SESSIONS = 1024;
@@ -143,6 +146,7 @@ function emptySessionCost(): SessionCostAccumulator {
 		tokensCacheRead: 0,
 		tokensCacheWrite: 0,
 		cost: 0,
+		provenances: [],
 	};
 }
 
@@ -150,11 +154,21 @@ function addNumber(target: number, value: string | number | boolean | null | und
 	return typeof value === "number" && Number.isFinite(value) ? target + value : target;
 }
 
+function accountingProvenance(value: unknown): AccountingProvenance {
+	return value === "provider_reported" ||
+		value === "locally_estimated" ||
+		value === "configured_rate" ||
+		value === "local_zero_cost"
+		? value
+		: "unavailable";
+}
+
 function addEventCost(
 	accumulator: SessionCostAccumulator,
 	event: TelemetryEventType,
 	properties: TelemetryProperties,
 ): void {
+	accumulator.provenances.push(accountingProvenance(properties.accountingProvenance));
 	if (event === "llm.generate") {
 		accumulator.tokensInput = addNumber(accumulator.tokensInput, properties.inputTokens);
 		accumulator.tokensOutput = addNumber(accumulator.tokensOutput, properties.outputTokens);
@@ -184,6 +198,7 @@ function sessionCostProperties(cost: SessionCostAccumulator): TelemetryPropertie
 		tokensCacheRead: cost.tokensCacheRead,
 		tokensCacheWrite: cost.tokensCacheWrite,
 		cost: cost.cost,
+		accountingProvenance: summarizeAccountingProvenance(cost.provenances),
 	};
 }
 

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -12,11 +12,11 @@ import { dirname, join } from "node:path";
 import {
 	type AccountingProvenance,
 	type PipelineTelemetryConfig,
-	summarizeAccountingProvenance,
 	TELEMETRY_DEPLOYMENT_ROLES,
 	TELEMETRY_INSTALL_CHANNELS,
 	type TelemetryDeploymentRole,
 	type TelemetryInstallChannel,
+	summarizeAccountingProvenance,
 } from "@signet/core";
 import type { DbAccessor } from "./db-accessor";
 import { logger } from "./logger";

--- a/web/docs/src/content/docs/api/telemetry-logs.md
+++ b/web/docs/src/content/docs/api/telemetry-logs.md
@@ -326,6 +326,13 @@ Aggregated telemetry statistics since daemon start or since a given timestamp.
 }
 ```
 
+Each `llm`, `embedding`, `dreaming`, and `sessions` object also contains a
+`coverage` object keyed by `provider_reported`, `locally_estimated`,
+`configured_rate`, `local_zero_cost`, `unavailable`, and `mixed`. Each bucket
+contains `calls`, `tokens`, and `cost` totals. The `mixed` bucket is used for
+session summaries that combine more than one accounting provenance; it is not
+missing accounting.
+
 Embedding `cost` values are USD. The `sessions` block is a derived view over
 matching usage events and should not be added to event-level cost totals. The
 `session.end` event carries the same collector-derived totals, keyed by a


### PR DESCRIPTION
## Summary

Closes #1283. Add bounded accounting provenance to usage events and summaries so recorded cost is separated from accounting coverage.

## Changes

- Add `provider_reported`, `locally_estimated`, `configured_rate`, `local_zero_cost`, and `unavailable` provenance values in core types.
- Propagate provenance through LLM, embedding, dreaming, aggregate recall, and session accounting.
- Add per-provenance calls, token, and cost coverage to `/api/telemetry/stats` and SDK response types.
- Document the event fields and coverage semantics in `docs/TELEMETRY.md`.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [x] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A. No frontend files changed.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A. No database migration.

## Testing

- [x] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Targeted verification passed:

- `bun test platform/daemon/src/routes/telemetry-routes.test.ts platform/daemon/src/pipeline/pi-provider.test.ts platform/daemon/src/embedding-cost.test.ts platform/daemon/src/aggregate-recall.test.ts platform/daemon/src/pipeline/dreaming-telemetry.test.ts platform/daemon/src/telemetry.test.ts libs/sdk/src/__tests__/telemetry.test.ts`: 72 passed, 0 failed, 292 assertions.
- `bun run --filter '@signet/core' build`: passed.
- `bun run --filter '@signet/daemon' build`: passed.
- `bun run --filter '@signet/sdk' build`: passed.
- `platform/daemon` typecheck and Biome checks for all changed source files: passed.

The adversarial review found that remote Pi models with zero placeholder rates were being labeled `provider_reported`; the follow-up fix now labels those calls `unavailable` with null cost, preserves real token counts, labels positive catalog-rate calculations `locally_estimated`, and detects localhost OpenAI embedding endpoints as `local_zero_cost`. A second review identified mixed session summaries being collapsed into unavailable coverage; the follow-up now preserves a `mixed` coverage bucket. Explicit embedding rates are honored before local-zero-cost classification, and completed calls with missing remote usage are recorded as unavailable rather than zero-token provider-reported calls. Regression coverage was added for these paths.

The full workspace typecheck remains blocked by pre-existing connector package resolution errors (`@signet/connector-base` exports and generated extension bundles). The full workspace lint also reports pre-existing formatting diagnostics across unrelated files. No unrelated files were changed.

Mutation verification: replacing the local zero-cost provenance with `unavailable` caused the new embedding provenance test to fail; restoring it passed.