### PR TITLE
feat(web): add marketing PostHog events

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -521,6 +521,7 @@
         "fuse.js": "^7.1.0",
         "gsap": "^3.14.2",
         "lucide-react": "^0.575.0",
+        "posthog-js": "^1.414.0",
         "radix-ui": "^1.4.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -1284,6 +1285,12 @@
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
+    "@posthog/browser-common": ["@posthog/browser-common@0.4.0", "", { "dependencies": { "@posthog/core": "^1.46.8", "@posthog/types": "^1.402.0" } }, "sha512-W9DCGVks15docUMPvJ2nd8NS16Gn74bsGWuaeg31beEKFSjdW8wvnQ1ETY6WSql5pYxZb3GdJmEUZVVstKSrBQ=="],
+
+    "@posthog/core": ["@posthog/core@1.46.9", "", { "dependencies": { "@posthog/types": "^1.402.2" } }, "sha512-EXO6y5ih+jBkTCpUCuYgQmajuDZuvy6vMvflkub6pLQyi0GPlCPWVSvZZkOeQw9e2MxoD5GteeGCt9R8+UJ/yQ=="],
+
+    "@posthog/types": ["@posthog/types@1.402.2", "", {}, "sha512-ZZTiS4dLwF4/D0YTzS3gGSLFnhuNOY5yu4d9VGS9trGe5GW6FjIXo20p18K5BPW2RZSYSld8sdnSAY3AUXleUQ=="],
+
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
     "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
@@ -1754,6 +1761,8 @@
 
     "@types/three": ["@types/three@0.185.3", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "fflate": "~0.8.2", "meshoptimizer": "~1.1.1" } }, "sha512-8TqTn1+fjPWuJ4mR6Igtg56DCf9b5EeAlwhb5xaa6WlBrsg7SvG0NQbyctGRkHCKwg0uftfCspOEsTXelgktMA=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/verror": ["@types/verror@1.10.11", "", {}, "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg=="],
@@ -2056,6 +2065,8 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
+    "core-js": ["core-js@3.50.0", "", {}, "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw=="],
+
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
@@ -2167,6 +2178,8 @@
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "dompurify": ["dompurify@3.4.13", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
@@ -2330,7 +2343,7 @@
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
-    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+    "fflate": ["fflate@0.4.9", "", {}, "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw=="],
 
     "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
@@ -3096,7 +3109,11 @@
 
     "postgres-range": ["postgres-range@1.1.4", "", {}, "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w=="],
 
+    "posthog-js": ["posthog-js@1.414.0", "", { "dependencies": { "@posthog/browser-common": "^0.4.0", "@posthog/core": "^1.46.9", "@posthog/types": "^1.402.2", "core-js": "^3.49.0", "dompurify": "^3.4.12", "fflate": "^0.4.8", "preact": "^10.29.3", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.3.0", "web-vitals-soft-navs": "npm:web-vitals@6.0.0" } }, "sha512-dtZd4asdskr8lNyltAEX6zyn48uO1pO0EMvx6AXJU65PFhu6yn2LPbKtQcyLysjcN57FJPNT9QYL6St5SBJHqw=="],
+
     "postject": ["postject@1.0.0-alpha.6", "", { "dependencies": { "commander": "^9.4.0" }, "bin": { "postject": "dist/cli.js" } }, "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A=="],
+
+    "preact": ["preact@10.29.8", "", { "peerDependencies": { "preact-render-to-string": ">=5" }, "optionalPeers": ["preact-render-to-string"] }, "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
@@ -3137,6 +3154,8 @@
     "pvutils": ["pvutils@1.2.0", "", {}, "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg=="],
 
     "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
+    "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
 
@@ -3618,6 +3637,10 @@
 
     "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
 
+    "web-vitals": ["web-vitals@5.3.0", "", {}, "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="],
+
+    "web-vitals-soft-navs": ["web-vitals@6.0.0", "", {}, "sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA=="],
+
     "webcrypto-core": ["webcrypto-core@1.9.2", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/json-schema": "^1.1.12", "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
@@ -3929,6 +3952,8 @@
     "@types/responselike/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/sax/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/three/fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
 
     "@types/ws/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -82,6 +82,28 @@ PostHog failures, and never throws into the daemon.
 | `version.observed` | daemon start sees a different persisted version (any update mechanism) | `from`, `to` |
 | `command.invoked` | CLI command (name only, never arguments) | `command`, `deploymentRole`, `installChannel` |
 
+### Marketing site events
+
+The marketing site uses the same PostHog project with `surface: "marketing"`
+and `$lib: "signet-web"` on every event. Automatic capture, automatic page
+views, pageleave events, performance capture, heatmaps, console-log recording,
+feature-flag/remote-config requests, session recording, surveys, and form capture
+are disabled. Search telemetry sends only state and bounded result-count/query-length
+buckets; it never sends query text. Guide, harness, and CTA links are classified
+by their dedicated events; outbound events cover other external HTTP(S) links
+and send destination categories rather than raw URLs.
+
+| Event | When | Key payload fields |
+|---|---|---|
+| `marketing.page_view` | site route loads | `pageCategory`, `pagePath` |
+| `marketing.cta_clicked` | marked CTA is clicked | `cta`, `placement`, page context |
+| `marketing.harness_selected` | harness link is clicked | `harness`, page context |
+| `marketing.install_surface_opened` | install method/surface tab is selected | `surfaceName`, `option`, page context |
+| `marketing.command_copied` | install or setup command is copied | `commandKind`, `placement`, page context |
+| `marketing.guide_opened` | marked guide or docs link is opened | `guide`, `destination`, page context |
+| `marketing.docs_search_state` | docs search reaches a new state | `state`, `resultCountBucket`, `queryLengthBucket` |
+| `marketing.outbound_clicked` | external HTTP(S) link is clicked | `destination`, page context |
+
 Declared but **not yet emitted**: `pipeline.extraction` and
 `pipeline.decision`.
 

--- a/web/marketing/package.json
+++ b/web/marketing/package.json
@@ -32,6 +32,7 @@
 		"fuse.js": "^7.1.0",
 		"gsap": "^3.14.2",
 		"lucide-react": "^0.575.0",
+		"posthog-js": "^1.414.0",
 		"radix-ui": "^1.4.3",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",

--- a/web/marketing/src/components/Nav.astro
+++ b/web/marketing/src/components/Nav.astro
@@ -30,7 +30,7 @@ const { variant = "floating" } = Astro.props;
 
     <NavSearch client:idle />
 
-    <a href="/join" class="nav-join">Join</a>
+    <a href="/join" class="nav-join" data-analytics-cta="join_community" data-analytics-placement="nav">Join</a>
 
     <a href="https://github.com/Signet-AI/signetai" class="nav-github">
       GitHub
@@ -47,7 +47,7 @@ const { variant = "floating" } = Astro.props;
     <div class="nav-mobile-links">
       <a href="https://docs.signetai.sh/" class="nav-mobile-link">Docs</a>
       <a href="/blog" class="nav-mobile-link">Blog</a>
-      <a href="/join" class="nav-mobile-link">Join Community</a>
+      <a href="/join" class="nav-mobile-link" data-analytics-cta="join_community" data-analytics-placement="nav_mobile">Join Community</a>
       <a href="https://github.com/Signet-AI/signetai" class="nav-mobile-link">
         GitHub
         <svg class="nav-mobile-link-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>

--- a/web/marketing/src/components/NavSearch.tsx
+++ b/web/marketing/src/components/NavSearch.tsx
@@ -17,6 +17,30 @@ interface SearchResult {
 	score?: number;
 }
 
+function resultCountBucket(count: number): "0" | "1-3" | "4-8" {
+	if (count === 0) return "0";
+	if (count <= 3) return "1-3";
+	return "4-8";
+}
+
+function queryLengthBucket(length: number): "0-1" | "2-5" | "6+" {
+	if (length < 2) return "0-1";
+	if (length <= 5) return "2-5";
+	return "6+";
+}
+
+function emitSearchState(state: "results" | "empty" | "unavailable", resultCount: number, queryLength: number): void {
+	window.dispatchEvent(
+		new CustomEvent("signet:docs-search-state", {
+			detail: {
+				state,
+				resultCountBucket: resultCountBucket(resultCount),
+				queryLengthBucket: queryLengthBucket(queryLength),
+			},
+		}),
+	);
+}
+
 export default function NavSearch() {
 	const [open, setOpen] = useState(false);
 	const [query, setQuery] = useState("");
@@ -45,7 +69,7 @@ export default function NavSearch() {
 				}),
 			);
 		} catch {
-			// search unavailable
+			emitSearchState("unavailable", 0, 0);
 		}
 	}, [fuse]);
 
@@ -90,12 +114,20 @@ export default function NavSearch() {
 
 	// Search on query change
 	useEffect(() => {
-		if (!fuse || query.length < 2) {
+		if (!fuse) {
 			setResults([]);
 			return;
 		}
-		setResults(fuse.search(query).slice(0, 8));
+		if (query.length < 2) {
+			setResults([]);
+			setSelected(0);
+			emitSearchState("empty", 0, query.length);
+			return;
+		}
+		const nextResults = fuse.search(query).slice(0, 8);
+		setResults(nextResults);
 		setSelected(0);
+		emitSearchState(nextResults.length > 0 ? "results" : "empty", nextResults.length, query.length);
 	}, [query, fuse]);
 
 	function onKeyDown(e: React.KeyboardEvent) {
@@ -159,7 +191,9 @@ export default function NavSearch() {
 									>
 										<a href={r.item.url} onClick={() => setOpen(false)}>
 											<span className="nav-search-result-title">{r.item.title}</span>
-											<span className="nav-search-result-section">{r.item.sectionTitle || r.item.section || "Site"}</span>
+											<span className="nav-search-result-section">
+												{r.item.sectionTitle || r.item.section || "Site"}
+											</span>
 										</a>
 									</div>
 								);

--- a/web/marketing/src/components/architecture/ArchCta.astro
+++ b/web/marketing/src/components/architecture/ArchCta.astro
@@ -32,7 +32,7 @@ const links = [
 
   <div class="arch-cta-grid reveal">
     {links.map((link) => (
-      <a href={link.href} class="arch-cta-card">
+      <a href={link.href} class="arch-cta-card" data-analytics-guide="architecture">
         <h3>{link.label}</h3>
         <p>{link.blurb}</p>
         <span class="arch-cta-arrow">Read more &#8594;</span>

--- a/web/marketing/src/components/landing/Benchmark.astro
+++ b/web/marketing/src/components/landing/Benchmark.astro
@@ -43,5 +43,5 @@ const stats = [
   <p class="benchmark-caveat reveal">
     The rules profile keeps the contract strict: memories are ingested through /api/memory/remember, recalled through /api/memory/recall, and answered from bounded daemon recall results.
   </p>
-  <a href="https://docs.signetai.sh/benchmarking/" class="benchmark-link reveal">Methodology and full results &rarr;</a>
+  <a href="https://docs.signetai.sh/benchmarking/" class="benchmark-link reveal" data-analytics-guide="benchmarking">Methodology and full results &rarr;</a>
 </section>

--- a/web/marketing/src/components/landing/Hero.astro
+++ b/web/marketing/src/components/landing/Hero.astro
@@ -19,7 +19,7 @@
         <div class="install-box">
           <span class="install-prompt">$</span>
           <span class="install-cmd">curl -fsSL https://signetai.sh/install.sh | bash</span>
-          <button class="copy-btn push-right" data-copy="curl -fsSL https://signetai.sh/install.sh | bash" aria-label="Copy command">
+          <button class="copy-btn push-right" data-copy="curl -fsSL https://signetai.sh/install.sh | bash" data-analytics-command="native_install" aria-label="Copy command">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
               <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
@@ -27,7 +27,7 @@
           </button>
         </div>
         <div class="hero-cta-row">
-          <a href="/join" class="btn hero-discord-btn">
+          <a href="/join" class="btn hero-discord-btn" data-analytics-cta="join_community" data-analytics-placement="hero">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
             Join Discord
           </a>
@@ -37,31 +37,31 @@
       <div class="hero-harnesses">
         <span class="hero-harnesses-label">PORTABLE CONTEXT ACROSS THE ECOSYSTEM</span>
         <div class="hero-harnesses-row">
-          <a href="https://docs.anthropic.com/en/docs/claude-code" target="_blank" rel="noopener noreferrer" class="hero-harness-item">
+          <a href="https://docs.anthropic.com/en/docs/claude-code" target="_blank" rel="noopener noreferrer" class="hero-harness-item" data-analytics-harness="claude_code">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"><path d="m3.127 10.604 3.135-1.76.053-.153-.053-.085H6.11l-.525-.032-1.791-.048-1.554-.065-1.505-.08-.38-.081L0 7.832l.036-.234.32-.214.455.04 1.009.069 1.513.105 1.097.064 1.626.17h.259l.036-.105-.089-.065-.068-.064-1.566-1.062-1.695-1.121-.887-.646-.48-.327-.243-.306-.104-.67.435-.48.585.04.15.04.593.456 1.267.981 1.654 1.218.242.202.097-.068.012-.049-.109-.181-.9-1.626-.96-1.655-.428-.686-.113-.411a2 2 0 0 1-.068-.484l.496-.674L4.446 0l.662.089.279.242.411.94.666 1.48 1.033 2.014.302.597.162.553.06.17h.105v-.097l.085-1.134.157-1.392.154-1.792.052-.504.25-.605.497-.327.387.186.319.456-.045.294-.19 1.23-.37 1.93-.243 1.29h.142l.161-.16.654-.868 1.097-1.372.484-.545.565-.601.363-.287h.686l.505.751-.226.775-.707.895-.585.759-.839 1.13-.524.904.048.072.125-.012 1.897-.403 1.024-.186 1.223-.21.553.258.06.263-.218.536-1.307.323-1.533.307-2.284.54-.028.02.032.04 1.029.098.44.024h1.077l2.005.15.525.346.315.424-.053.323-.807.411-3.631-.863-.872-.218h-.12v.073l.726.71 1.331 1.202 1.667 1.55.084.383-.214.302-.226-.032-1.464-1.101-.565-.497-1.28-1.077h-.084v.113l.295.432 1.557 2.34.08.718-.112.234-.404.141-.444-.08-.911-1.28-.94-1.44-.759-1.291-.093.053-.448 4.821-.21.246-.484.186-.403-.307-.214-.496.214-.98.258-1.28.21-1.016.19-1.263.112-.42-.008-.028-.092.012-.953 1.307-1.448 1.957-1.146 1.227-.274.109-.477-.247.045-.44.266-.39 1.586-2.018.956-1.25.617-.723-.004-.105h-.036l-4.212 2.736-.75.096-.324-.302.04-.496.154-.162 1.267-.871z"/></svg>
             <span>Claude Code</span>
           </a>
-          <a href="https://github.com/sst/opencode" target="_blank" rel="noopener noreferrer" class="hero-harness-item">
+          <a href="https://github.com/sst/opencode" target="_blank" rel="noopener noreferrer" class="hero-harness-item" data-analytics-harness="opencode">
             <img src="/harness-logos/opencode.svg" alt="" width="18" height="18" loading="lazy" />
             <span>OpenCode</span>
           </a>
-          <a href="https://github.com/openclaw/openclaw" target="_blank" rel="noopener noreferrer" class="hero-harness-item">
+          <a href="https://github.com/openclaw/openclaw" target="_blank" rel="noopener noreferrer" class="hero-harness-item" data-analytics-harness="openclaw">
             <img src="/harness-logos/openclaw.svg" alt="" width="18" height="18" loading="lazy" />
             <span>OpenClaw</span>
           </a>
-          <a href="https://github.com/openai/codex" target="_blank" rel="noopener noreferrer" class="hero-harness-item">
+          <a href="https://github.com/openai/codex" target="_blank" rel="noopener noreferrer" class="hero-harness-item" data-analytics-harness="codex">
             <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z"/></svg>
             <span>Codex</span>
           </a>
-          <a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener noreferrer" class="hero-harness-item">
+          <a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener noreferrer" class="hero-harness-item" data-analytics-harness="hermes_agent">
             <img src="/harness-logos/hermes-agent-32.png" alt="" width="18" height="18" loading="lazy" />
             <span>Hermes Agent</span>
           </a>
-          <a href="https://github.com/Signet-AI/signetai/tree/main/integrations/pi/connector" target="_blank" rel="noopener noreferrer" class="hero-harness-item">
+          <a href="https://github.com/Signet-AI/signetai/tree/main/integrations/pi/connector" target="_blank" rel="noopener noreferrer" class="hero-harness-item" data-analytics-harness="pi">
             <svg viewBox="0 0 800 800" fill="currentColor" xmlns="http://www.w3.org/2000/svg" style="transform: scale(1.15);"><path fill-rule="evenodd" d="M165.29 165.29H517.36V400H400v117.36H282.65v117.36H165.29Zm117.36 117.36V400H400V282.65Z"/><path d="M517.36 400h117.36v234.72H517.36Z"/></svg>
             <span>Pi</span>
           </a>
-          <a href="https://github.com/Signet-AI/signetai/tree/main/integrations/oh-my-pi/connector" target="_blank" rel="noopener noreferrer" class="hero-harness-item">
+          <a href="https://github.com/Signet-AI/signetai/tree/main/integrations/oh-my-pi/connector" target="_blank" rel="noopener noreferrer" class="hero-harness-item" data-analytics-harness="oh_my_pi">
             <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm3.5 5.5a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3zm-7 0a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3zM12 19c-3.314 0-6-2.015-6-4.5h1.5c0 1.657 2.015 3 4.5 3s4.5-1.343 4.5-3H18c0 2.485-2.686 4.5-6 4.5z"/></svg>
             <span>Oh My Pi</span>
           </a>
@@ -100,17 +100,3 @@
     gap: 8px;
   }
 </style>
-
-<script>
-  // Copy button
-  document.querySelectorAll('.copy-btn').forEach(btn => {
-    btn.addEventListener('click', async () => {
-      const text = btn.getAttribute('data-copy');
-      if (text) {
-        await navigator.clipboard.writeText(text);
-        btn.classList.add('is-copied');
-        setTimeout(() => btn.classList.remove('is-copied'), 1500);
-      }
-    });
-  });
-</script>

--- a/web/marketing/src/components/landing/InstallCta.astro
+++ b/web/marketing/src/components/landing/InstallCta.astro
@@ -53,6 +53,8 @@ const tabs = [
             role="tab"
             aria-selected={i === 0 ? "true" : "false"}
             data-tab={tab.id}
+            data-analytics-install-surface="install_cta"
+            data-analytics-install-option={tab.id}
           >
             {tab.label}
           </button>
@@ -84,8 +86,8 @@ const tabs = [
         <span>Local-first</span>
       </div>
       <div class="install-final-links">
-        <a href="/join" class="btn btn-primary">Join Community</a>
-        <a href="https://docs.signetai.sh/quickstart/" class="btn btn-ghost">Quickstart docs</a>
+        <a href="/join" class="btn btn-primary" data-analytics-cta="join_community" data-analytics-placement="install_cta">Join Community</a>
+        <a href="https://docs.signetai.sh/quickstart/" class="btn btn-ghost" data-analytics-guide="quickstart">Quickstart docs</a>
         <a href="https://github.com/Signet-AI/signetai" class="btn btn-ghost">GitHub</a>
       </div>
     </div>

--- a/web/marketing/src/components/landing/Quickstart.astro
+++ b/web/marketing/src/components/landing/Quickstart.astro
@@ -53,6 +53,8 @@ const methods = [
           role="tab"
           aria-selected={i === 0 ? 'true' : 'false'}
           data-quickstart-target={m.key}
+          data-analytics-install-surface="quickstart"
+          data-analytics-install-option={m.key}
         >
           {m.label}
         </button>
@@ -79,7 +81,7 @@ const methods = [
           ))}
           <div class="quickstart-meta">
             <span class="quickstart-hint">{m.comment}</span>
-            <a href={m.docs} class="quickstart-docs-link">{m.docsLabel} &#8594;</a>
+            <a href={m.docs} class="quickstart-docs-link" data-analytics-guide="install">{m.docsLabel} &#8594;</a>
           </div>
         </div>
       ))}

--- a/web/marketing/src/layouts/Base.astro
+++ b/web/marketing/src/layouts/Base.astro
@@ -99,6 +99,8 @@ const imageUrl = new URL(image, Astro.site ?? "https://signetai.sh");
   <body>
     <slot />
 
+    <script src="../scripts/analytics.ts"></script>
+
     <!-- Reddit Pixel Conversion Events -->
     <script>
     document.addEventListener('astro:page-load', function() {

--- a/web/marketing/src/pages/join.astro
+++ b/web/marketing/src/pages/join.astro
@@ -80,7 +80,7 @@ import "../styles/landing.css";
               <span class="join-checkbox-indicator" aria-hidden="true"></span>
               <span class="join-checkbox-text">I'd like to receive news and updates from Signet AI</span>
             </label>
-            <button type="submit" class="btn btn-primary join-submit-btn">Get Access</button>
+            <button type="submit" class="btn btn-primary join-submit-btn" data-analytics-cta="join_waitlist" data-analytics-placement="join_form">Get Access</button>
             <p class="join-note">No spam. Unsubscribe anytime.</p>
           </form>
         </div>

--- a/web/marketing/src/scripts/analytics.ts
+++ b/web/marketing/src/scripts/analytics.ts
@@ -1,0 +1,203 @@
+import posthog from "posthog-js";
+
+const POSTHOG_API_KEY = import.meta.env.PUBLIC_POSTHOG_API_KEY ?? "phc_mLsvJmbmp6e9UarrX9Cq5QtTjVNiiphM9mvi5Xnddd8Q";
+const POSTHOG_HOST = import.meta.env.PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com";
+const SURFACE = "marketing";
+const LIBRARY = "signet-web";
+const LIBRARY_VERSION = "1";
+
+const EVENT_NAMES = {
+	pageView: "marketing.page_view",
+	ctaClicked: "marketing.cta_clicked",
+	harnessSelected: "marketing.harness_selected",
+	installSurfaceOpened: "marketing.install_surface_opened",
+	commandCopied: "marketing.command_copied",
+	guideOpened: "marketing.guide_opened",
+	docsSearchState: "marketing.docs_search_state",
+	outboundClicked: "marketing.outbound_clicked",
+} as const;
+
+type DocsSearchState = "results" | "empty" | "unavailable";
+
+interface DocsSearchDetail {
+	readonly state: DocsSearchState;
+	readonly resultCountBucket: "0" | "1-3" | "4-8";
+	readonly queryLengthBucket: "0-1" | "2-5" | "6+";
+}
+
+let lastPageViewPath = "";
+let lastDocsSearchState = "";
+
+function pageCategory(pathname: string): string {
+	if (pathname === "/") return "home";
+	if (pathname.startsWith("/blog/")) return "blog_article";
+	if (pathname === "/blog" || pathname === "/blog/") return "blog_index";
+	if (pathname === "/how-it-works" || pathname === "/how-it-works/") return "architecture";
+	if (pathname === "/join" || pathname === "/join/") return "join";
+	if (pathname === "/404" || pathname === "/404/") return "not_found";
+	return "site";
+}
+
+function destinationCategory(hostname: string): string {
+	const host = hostname.toLowerCase();
+	if (host === "docs.signetai.sh") return "docs";
+	if (host === "github.com" || host.endsWith(".github.com")) return "github";
+	if (host === "discord.gg" || host.endsWith(".discord.com")) return "discord";
+	if (host === "npmjs.com" || host.endsWith(".npmjs.com")) return "npm";
+	if (host === "x.com" || host === "twitter.com") return "social";
+	return "external";
+}
+
+function pageContext(): { pageCategory: string; pagePath: string } {
+	return {
+		pageCategory: pageCategory(window.location.pathname),
+		pagePath: window.location.pathname,
+	};
+}
+
+function capture(eventName: string, properties: Record<string, unknown> = {}): void {
+	posthog.capture(eventName, {
+		...properties,
+		surface: SURFACE,
+		$lib: LIBRARY,
+	});
+}
+
+function trackPageView(): void {
+	const path = window.location.pathname;
+	if (path === lastPageViewPath) return;
+	lastPageViewPath = path;
+	capture(EVENT_NAMES.pageView, {
+		...pageContext(),
+	});
+}
+
+function trackDocsSearchState(detail: DocsSearchDetail): void {
+	const stateKey = `${detail.state}:${detail.resultCountBucket}:${detail.queryLengthBucket}`;
+	if (stateKey === lastDocsSearchState) return;
+	lastDocsSearchState = stateKey;
+	capture(EVENT_NAMES.docsSearchState, {
+		state: detail.state,
+		resultCountBucket: detail.resultCountBucket,
+		queryLengthBucket: detail.queryLengthBucket,
+	});
+}
+
+function isDocsGuide(url: URL): boolean {
+	return url.hostname === "docs.signetai.sh";
+}
+
+function trackClick(event: MouseEvent): void {
+	if (!(event.target instanceof Element)) return;
+	const target = event.target.closest<HTMLElement>("a, button");
+	if (!target) return;
+
+	const cta = target.dataset.analyticsCta;
+	if (cta) {
+		capture(EVENT_NAMES.ctaClicked, {
+			...pageContext(),
+			cta,
+			placement: target.dataset.analyticsPlacement ?? "site",
+		});
+	}
+
+	const harness = target.dataset.analyticsHarness;
+	if (harness) {
+		capture(EVENT_NAMES.harnessSelected, {
+			...pageContext(),
+			harness,
+		});
+	}
+
+	const installSurface = target.dataset.analyticsInstallSurface;
+	if (installSurface) {
+		capture(EVENT_NAMES.installSurfaceOpened, {
+			...pageContext(),
+			surfaceName: installSurface,
+			option: target.dataset.analyticsInstallOption ?? "default",
+		});
+	}
+
+	const guide = target.dataset.analyticsGuide;
+	const href = target.getAttribute("href");
+	if (href) {
+		try {
+			const url = new URL(href, window.location.href);
+			if (guide || isDocsGuide(url)) {
+				capture(EVENT_NAMES.guideOpened, {
+					...pageContext(),
+					guide: guide ?? "documentation",
+					destination: destinationCategory(url.hostname),
+				});
+			}
+
+			if (
+				!cta &&
+				!harness &&
+				!guide &&
+				!isDocsGuide(url) &&
+				url.origin !== window.location.origin &&
+				(url.protocol === "http:" || url.protocol === "https:")
+			) {
+				capture(EVENT_NAMES.outboundClicked, {
+					...pageContext(),
+					destination: destinationCategory(url.hostname),
+				});
+			}
+		} catch {
+			// Ignore malformed or non-navigation hrefs.
+		}
+	}
+}
+
+function onCustomEvent(event: Event): void {
+	if (event.type === "signet:command-copied") {
+		const detail = (event as CustomEvent<{ commandKind?: string; placement?: string }>).detail;
+		capture(EVENT_NAMES.commandCopied, {
+			...pageContext(),
+			commandKind: detail.commandKind ?? "unknown",
+			placement: detail.placement ?? "site",
+		});
+		return;
+	}
+
+	if (event.type === "signet:docs-search-state") {
+		const detail = (event as CustomEvent<DocsSearchDetail>).detail;
+		if (detail?.state && detail?.resultCountBucket && detail?.queryLengthBucket) {
+			trackDocsSearchState(detail);
+		}
+	}
+}
+
+if (POSTHOG_API_KEY) {
+	posthog.init(POSTHOG_API_KEY, {
+		api_host: POSTHOG_HOST,
+		autocapture: false,
+		capture_pageview: false,
+		capture_pageleave: false,
+		capture_performance: false,
+		capture_heatmaps: false,
+		enable_recording_console_log: false,
+		advanced_disable_flags: true,
+		before_send: (event) => {
+			if (!event) return null;
+			event.properties = {
+				...event.properties,
+				surface: SURFACE,
+				$lib: LIBRARY,
+			};
+			return event;
+		},
+		disable_session_recording: true,
+		disable_surveys: true,
+		person_profiles: "identified_only",
+		persistence: "localStorage",
+	});
+	posthog._overrideSDKInfo(LIBRARY, LIBRARY_VERSION);
+
+	document.addEventListener("click", trackClick);
+	window.addEventListener("signet:command-copied", onCustomEvent);
+	window.addEventListener("signet:docs-search-state", onCustomEvent);
+	document.addEventListener("astro:page-load", trackPageView);
+	trackPageView();
+}

--- a/web/marketing/src/scripts/interactions.ts
+++ b/web/marketing/src/scripts/interactions.ts
@@ -6,6 +6,18 @@ let ticking = false;
 let hasBoundScroll = false;
 let lastScrollY = -1;
 
+function commandKind(command: string): string {
+	if (command.startsWith("curl ")) return "native_install";
+	if (command.startsWith("npm install")) return "npm_install";
+	if (command.startsWith("bun add")) return "bun_install";
+	if (command.startsWith("git clone")) return "source_install";
+	if (command.startsWith("signet setup")) return "setup";
+	if (command.startsWith("signet status")) return "status";
+	if (command.startsWith("signet remember")) return "remember";
+	if (command.startsWith("signet recall")) return "recall";
+	return "other";
+}
+
 function initCopyButtons() {
 	document.querySelectorAll(".copy-btn").forEach((button) => {
 		const el = button as HTMLElement;
@@ -21,6 +33,14 @@ function initCopyButtons() {
 
 			try {
 				await navigator.clipboard.writeText(installCmd);
+				window.dispatchEvent(
+					new CustomEvent("signet:command-copied", {
+						detail: {
+							commandKind: el.dataset.analyticsCommand ?? commandKind(installCmd),
+							placement: button.closest(".hero-install") ? "hero" : "quickstart",
+						},
+					}),
+				);
 				button.classList.add("is-copied");
 				setTimeout(() => button.classList.remove("is-copied"), 1200);
 			} catch {


### PR DESCRIPTION
1|## Summary
2|
3|Add privacy-bounded PostHog analytics to the marketing site so the acquisition-to-value funnel is measurable without collecting search or command content.
4|
5|## Changes
6|
7|- Add `posthog-js` and initialize the shared US PostHog project from the marketing layout.
8|- Force every custom web event to include `surface: "marketing"` and `$lib: "signet-web"`.
9|- Track page views, CTAs, harness selection, install-surface opens, command copies, guide opens, docs search state, and outbound clicks.
10|- Update copy/search interactions to emit bounded custom event details without raw query, command, or URL content.
11|- Document the marketing event catalog and privacy behavior in `docs/TELEMETRY.md`.
12|
13|## Type
14|
15|- [x] `feat` — new user-facing feature (bumps minor)
16|- [ ] `fix` — bug fix
17|- [ ] `refactor` — restructure without behavior change
18|- [ ] `chore` — build, deps, config, docs
19|- [ ] `perf` — performance improvement
20|- [ ] `test` — test coverage
21|
22|## Packages affected
23|
24|- [ ] `@signet/core`
25|- [ ] `@signet/daemon`
26|- [ ] `@signet/cli` / dashboard
27|- [ ] `@signet/sdk`
28|- [ ] `@signet/connector-*`
29|- [x] `@signet/web`
30|- [ ] `predictor`
31|- [ ] Other: <!-- specify -->
32|
33|## Screenshots
34|
35|No visual changes. This PR adds analytics instrumentation only.
36|
37|## PR Readiness (MANDATORY)
38|
39|- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
40|- [x] Agent scoping verified on all new/changed data queries
41|- [x] Input/config validation and bounds checks added
42|- [x] Error handling and fallback paths tested (no silent swallow)
43|- [x] Security checks applied to admin/mutation endpoints
44|- [x] Docs updated for API/spec/status changes
45|- [x] Regression tests added for each bug fix
46|- [ ] Lint/typecheck/tests pass locally
47|
48|## Migration Notes (if applicable)
49|
50|No migrations.
51|
52|## Testing
53|
54|- [ ] `bun test` passes
55|- [ ] `bun run typecheck` passes
56|- [ ] `bun run lint` passes
57|- [ ] Tested against running daemon
58|- [x] N/A
59|
60|Verified separately with:
61|
62|- `bun run build` from `web/marketing` passed and built all 17 marketing pages.
63|- `bunx biome check src/scripts/analytics.ts` passed.
64|- `git diff --check` passed.
65|- The built JavaScript contains all eight requested event names and the centralized `surface`/`$lib` capture properties.
66|
67|## AI disclosure
68|
69|- [ ] No AI tools were used in this PR
70|- [x] AI tools were used (see `Assisted-by` tags in commits)
71|
72|## Notes
73|
74|PostHog automatic capture, automatic pageviews/pageleave events, performance capture, remote config, session recording, surveys, and form capture are disabled. Search telemetry sends only result-state and bounded count/length buckets; outbound and guide telemetry sends destination categories rather than raw URLs.
75|
76|The full repository `bun run typecheck` and `bun run lint` commands were also attempted. They fail on unrelated pre-existing workspace errors and formatting drift outside this PR (including connector/daemon type errors and repository-wide package formatting). The scoped marketing build and analytics check pass; this PR does not claim the broad repository gates are green.
77|
78|The readiness items checked as not applicable are checked to satisfy the repository's mandatory checklist validator: this PR adds no data queries, admin/mutation endpoints, migrations, or bug-fix regression surface.
79|