### PR TITLE
docs: improve issue triage workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,132 @@
+name: Bug report
+description: Report a reproducible problem in Signet
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening this issue:
+        - Search existing issues for the same failure or failure family.
+        - Reproduce on current `main` or the latest release when possible.
+        - Include the smallest reproducible case and exact error output.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues for duplicates or related work.
+          required: true
+        - label: I reproduced this on current `main` or the latest release, or explained why I cannot.
+          required: true
+        - label: I removed secrets and personal data from logs and examples.
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: What is failing, and who or what is affected?
+      placeholder: Describe the observable failure and its user impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Give the shortest deterministic sequence that reproduces the issue.
+      placeholder: |
+        1. Start Signet with ...
+        2. Configure ...
+        3. Run ...
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      options:
+        - Core
+        - Daemon
+        - CLI
+        - Dashboard
+        - Desktop
+        - Browser extension
+        - Connector or integration
+        - Dreaming or ontology
+        - Inference or routing
+        - Rust or native runtime
+        - Unsure
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: risks
+    attributes:
+      label: Potential risk dimensions
+      description: Select every risk that may apply. Maintainers will confirm these during triage.
+      options:
+        - label: Agent, tenant, workspace, or visibility isolation
+        - label: Data loss, corruption, orphaning, or misassociation
+        - label: Provenance, evidence, or auditability
+        - label: Session, routing, transcript, or context state
+        - label: Configuration compatibility, migration, or upgrade
+        - label: Connector delivery, duplication, or routing
+        - label: Performance, event-loop, memory, or cost regression
+        - label: Privacy, telemetry, or usage attribution
+        - label: Inference provider, model selection, or spend
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include Signet version or commit, OS, Bun version, deployment mode, and relevant provider or connector.
+      placeholder: |
+        Signet version/commit:
+        OS:
+        Bun version:
+        Deployment mode:
+        Provider/connector:
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, trace, or reproduction artifact
+      description: Paste the relevant output. Redact secrets and personal data.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: root_cause
+    attributes:
+      label: Root-cause hypothesis or proposed fix
+      description: Optional. Distinguish confirmed code evidence from inference.
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I would like to work on a fix and can submit a pull request.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,93 @@
+name: Feature request
+description: Propose a focused, evidence-backed improvement to Signet
+title: "[Feature]: "
+labels:
+  - enhancement
+  - spec: needs-spec
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before proposing a new core surface, check whether the capability belongs in an existing route, connector, plugin, skill, or MCP server. Prefer the smallest surface that solves the problem correctly.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem and use case
+      description: Who needs this, what are they trying to do, and what is blocked today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior and user-facing contract, not only an implementation sketch.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Include existing Signet surfaces, manual workarounds, connectors, plugins, or MCP approaches.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: route
+    attributes:
+      label: Preferred implementation route
+      description: Maintainers may choose a different route during triage.
+      options:
+        - Extend an existing surface
+        - CLI command or skill
+        - Connector or plugin
+        - MCP server
+        - Daemon or core API
+        - Dashboard, desktop, or browser surface
+        - Documentation or eval
+        - Unsure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Initial scope estimate
+      options:
+        - Small: one focused surface or package
+        - Medium: multiple packages or a new integration
+        - Large: cross-cutting contract or migration
+        - Unsure
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: risks
+    attributes:
+      label: Potential risk dimensions
+      description: Select every risk that may apply. Maintainers will confirm these during triage.
+      options:
+        - label: Agent, tenant, workspace, or visibility isolation
+        - label: Data loss, corruption, orphaning, or misassociation
+        - label: Provenance, evidence, or auditability
+        - label: Session, routing, transcript, or context state
+        - label: Configuration compatibility, migration, or upgrade
+        - label: Connector delivery, duplication, or routing
+        - label: Performance, event-loop, memory, or cost regression
+        - label: Privacy, telemetry, or usage attribution
+        - label: Inference provider, model selection, or spend
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or related work
+      description: Link related issues, user reports, evals, measurements, or prior art. Include numbers when they motivate the request.
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I would like to work on this and can submit a pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,6 +231,56 @@ function foo() {
 }
 ```
 
+Issue Triage
+---
+
+Use the issue forms under `.github/ISSUE_TEMPLATE/` whenever possible. A useful
+issue separates the observed behavior from its explanation and includes enough
+evidence for another maintainer to reproduce it on current `main`.
+
+Triage is multidimensional. Apply one label from each relevant axis rather than
+using labels as a single bucket:
+
+- Type: `bug`, `enhancement`, `documentation`, or another existing type.
+- Priority: `priority: P0` through `priority: P3`, based on user impact and urgency.
+- Component: `component: core`, `component: daemon`, `component: cli`,
+  `component: dashboard`, `component: desktop`, `component: browser-extension`,
+  `component: connector`, `component: dreaming`, `component: inference`, or
+  `component: native`.
+- Risk: use every applicable `risk:` label for the invariant that could be
+  damaged while fixing the issue.
+- Blast radius: `blast: contained`, `blast: subsystem`, `blast: broad`, or
+  `blast: invariant`.
+- Triage state: use one `triage:` label when evidence or a decision is still
+  missing.
+
+Priority and risk are separate. A P2 configuration issue can still be a
+security-boundary risk; a P1 delivery issue can be narrowly contained. Do not
+infer risk from priority.
+
+Before calling an issue a confirmed bug:
+
+1. Search for duplicates and related work.
+2. Reproduce on current `main` or record exactly why reproduction is unavailable.
+3. Trace the relevant code path and distinguish confirmed behavior from a
+   root-cause hypothesis.
+4. Check adjacent callers and sibling paths for the same failure class.
+5. Record the smallest regression proof the eventual fix must add.
+
+Use `triage: needs-repro`, `triage: needs-decision`, or `triage: blocked` when
+that is the honest current state. Automated or batch triage may identify
+`triage: implemented-on-main`, `triage: cannot-reproduce`, or
+`triage: incoherent`, but those labels require evidence in the issue comment.
+Do not close an issue merely because the proposed direction is unpopular or
+out of scope; that remains a maintainer decision. Use `duplicate` only after an
+overlap audit names the canonical issue and explains what is distinct.
+
+For new capabilities, prefer the smallest correct route: extend an existing
+surface, then CLI or skill, connector or plugin, MCP, and only then daemon/core
+API. Label telemetry and usage-attribution work with `telemetry` and the
+relevant privacy risk; it requires an explicit opt-in and privacy contract
+before implementation.
+
 Pull Requests
 ---
 

--- a/web/docs/src/content/docs/contributing.md
+++ b/web/docs/src/content/docs/contributing.md
@@ -238,6 +238,56 @@ function foo() {
 }
 ```
 
+Issue Triage
+---
+
+Use the issue forms under `.github/ISSUE_TEMPLATE/` whenever possible. A useful
+issue separates the observed behavior from its explanation and includes enough
+evidence for another maintainer to reproduce it on current `main`.
+
+Triage is multidimensional. Apply one label from each relevant axis rather than
+using labels as a single bucket:
+
+- Type: `bug`, `enhancement`, `documentation`, or another existing type.
+- Priority: `priority: P0` through `priority: P3`, based on user impact and urgency.
+- Component: `component: core`, `component: daemon`, `component: cli`,
+  `component: dashboard`, `component: desktop`, `component: browser-extension`,
+  `component: connector`, `component: dreaming`, `component: inference`, or
+  `component: native`.
+- Risk: use every applicable `risk:` label for the invariant that could be
+  damaged while fixing the issue.
+- Blast radius: `blast: contained`, `blast: subsystem`, `blast: broad`, or
+  `blast: invariant`.
+- Triage state: use one `triage:` label when evidence or a decision is still
+  missing.
+
+Priority and risk are separate. A P2 configuration issue can still be a
+security-boundary risk; a P1 delivery issue can be narrowly contained. Do not
+infer risk from priority.
+
+Before calling an issue a confirmed bug:
+
+1. Search for duplicates and related work.
+2. Reproduce on current `main` or record exactly why reproduction is unavailable.
+3. Trace the relevant code path and distinguish confirmed behavior from a
+   root-cause hypothesis.
+4. Check adjacent callers and sibling paths for the same failure class.
+5. Record the smallest regression proof the eventual fix must add.
+
+Use `triage: needs-repro`, `triage: needs-decision`, or `triage: blocked` when
+that is the honest current state. Automated or batch triage may identify
+`triage: implemented-on-main`, `triage: cannot-reproduce`, or
+`triage: incoherent`, but those labels require evidence in the issue comment.
+Do not close an issue merely because the proposed direction is unpopular or
+out of scope; that remains a maintainer decision. Use `duplicate` only after an
+overlap audit names the canonical issue and explains what is distinct.
+
+For new capabilities, prefer the smallest correct route: extend an existing
+surface, then CLI or skill, connector or plugin, MCP, and only then daemon/core
+API. Label telemetry and usage-attribution work with `telemetry` and the
+relevant privacy risk; it requires an explicit opt-in and privacy contract
+before implementation.
+
 Pull Requests
 ---
 


### PR DESCRIPTION
## Summary

Apply a Hermes-inspired, evidence-first issue triage workflow to Signet.

## Changes

- Add bug and feature issue forms that collect reproduction evidence, environment, component, risk dimensions, scope, and implementation route.
- Add contributor guidance for multidimensional triage: type, priority, component, risk, blast radius, and triage state.
- Define evidence requirements for confirmed bugs, duplicate decisions, automated triage states, and telemetry/privacy work.
- Synchronize the generated public contributing guide.
- Add the corresponding live GitHub labels and apply the new taxonomy to the current open issue set, including the telemetry cluster.

## Type

- [x] Documentation and workflow
- [x] Issue intake and triage

## Required readiness checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Packages affected

- None. Root contribution guidance and GitHub issue templates only.

## Screenshots

- Not applicable.

## Verification

- `git diff --check`
- `bun scripts/sync-root-docs.ts --check`
- Python YAML parse for all `.github/ISSUE_TEMPLATE/*.yml`
- Verified live labels and representative issue assignments through the GitHub API.

## Notes

- `bun scripts/doc-drift.ts` still reports pre-existing unrelated drift: seven undocumented routes and 21 package-table entries missing from root docs. This change does not alter that drift.
- The GitHub label changes are live repository metadata and are not represented in the git diff.
