### PR TITLE
fix(dreaming): retain transcript manifest projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Signet are documented here.
 Surface summary of the most recent release dates. See the release ledger below for exact version-by-version history.
 
 ### 2026-08-10
-- Bug fixes: bound wedge pressure probes; merge growing recovery snapshots; retain worker status telemetry; harden retired transcript recovery; retire summary-worker delivery; measure recall delivery outcomes; add bounded wedge pressure telemetry; persist first-use milestones atomically.
+- Bug fixes: canonicalize embedding endpoint (#1264); bound wedge pressure probes; merge growing recovery snapshots; retain worker status telemetry; harden retired transcript recovery; retire summary-worker delivery; measure recall delivery outcomes; add bounded wedge pressure telemetry; persist first-use milestones atomically.
 
 ### 2026-08-09
 - Features: reconcile indeterminate ACP deliveries (#1263); launch Starlight documentation; deliver cross-agent notifications.
@@ -41,6 +41,15 @@ Surface summary of the most recent release dates. See the release ledger below f
 - Docs: reflect Dreaming cutover; clarify inline linking boundary; align pipeline with Dreaming cutover; describe summary lineage cutover.
 
 ## Release Ledger
+
+## [0.185.7] - 2026-08-10
+
+Release summary: 1 bug fix.
+Tag range: `v0.185.6..v0.185.7`.
+
+### Bug Fixes
+
+- **dashboard**: canonicalize embedding endpoint (#1264) (#1299)
 
 ## [0.185.6] - 2026-08-10
 

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "dist/signetai": {
       "name": "signetai",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "bin": {
         "signet": "bin/signet.js",
         "signet-mcp": "dist/mcp-stdio.js",
@@ -25,27 +25,27 @@
     },
     "dist/signetai-darwin-arm64": {
       "name": "signetai-darwin-arm64",
-      "version": "0.185.6",
+      "version": "0.185.7",
     },
     "dist/signetai-darwin-x64": {
       "name": "signetai-darwin-x64",
-      "version": "0.185.6",
+      "version": "0.185.7",
     },
     "dist/signetai-linux-arm64": {
       "name": "signetai-linux-arm64",
-      "version": "0.185.6",
+      "version": "0.185.7",
     },
     "dist/signetai-linux-x64": {
       "name": "signetai-linux-x64",
-      "version": "0.185.6",
+      "version": "0.185.7",
     },
     "dist/signetai-win32-x64": {
       "name": "signetai-win32-x64",
-      "version": "0.185.6",
+      "version": "0.185.7",
     },
     "integrations/claude-code/connector": {
       "name": "@signet/connector-claude-code",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "bin": {
         "signet-connector-claude-code": "bin/install.js",
       },
@@ -60,7 +60,7 @@
     },
     "integrations/codex/connector": {
       "name": "@signet/connector-codex",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "bin": {
         "signet-connector-codex": "bin/install.js",
       },
@@ -75,7 +75,7 @@
     },
     "integrations/codex/plugin": {
       "name": "@signet/codex-plugin",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "bin": {
         "signet-codex-plugin": "bin/install.js",
       },
@@ -86,7 +86,7 @@
     },
     "integrations/forge/connector": {
       "name": "@signet/connector-forge",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "bin": {
         "signet-connector-forge": "bin/install.js",
       },
@@ -101,7 +101,7 @@
     },
     "integrations/gemini/connector": {
       "name": "@signet/connector-gemini",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "bin": {
         "signet-connector-gemini": "bin/install.js",
       },
@@ -116,7 +116,7 @@
     },
     "integrations/hermes-agent/connector": {
       "name": "@signet/connector-hermes-agent",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "bin": {
         "signet-connector-hermes-agent": "bin/install.js",
       },
@@ -131,7 +131,7 @@
     },
     "integrations/oh-my-pi/connector": {
       "name": "@signet/connector-oh-my-pi",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "bin": {
         "signet-connector-oh-my-pi": "bin/install.js",
       },
@@ -146,7 +146,7 @@
     },
     "integrations/oh-my-pi/extension": {
       "name": "@signet/oh-my-pi-extension",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/pi-extension-base": "workspace:*",
@@ -159,7 +159,7 @@
     },
     "integrations/openclaw/connector": {
       "name": "@signet/connector-openclaw",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "bin": {
         "signet-connector-openclaw": "bin/install.js",
       },
@@ -174,7 +174,7 @@
     },
     "integrations/openclaw/memory-adapter": {
       "name": "@signetai/signet-memory-openclaw",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "dependencies": {
         "@sinclair/typebox": "0.34.47",
       },
@@ -192,7 +192,7 @@
     },
     "integrations/opencode/connector": {
       "name": "@signet/connector-opencode",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "bin": {
         "signet-connector-opencode": "bin/install.js",
       },
@@ -208,7 +208,7 @@
     },
     "integrations/opencode/plugin": {
       "name": "@signet/opencode-plugin",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "dependencies": {
         "@signet/core": "workspace:*",
       },
@@ -224,7 +224,7 @@
     },
     "integrations/pi/connector": {
       "name": "@signet/connector-pi",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "bin": {
         "signet-connector-pi": "bin/install.js",
       },
@@ -239,7 +239,7 @@
     },
     "integrations/pi/extension": {
       "name": "@signet/pi-extension",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/pi-extension-base": "workspace:*",
@@ -253,18 +253,18 @@
     },
     "integrations/pi/extension-base": {
       "name": "@signet/pi-extension-base",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "dependencies": {
         "@signet/core": "workspace:*",
       },
     },
     "integrations/unreal/plugin": {
       "name": "@signet/unreal-plugin",
-      "version": "0.185.6",
+      "version": "0.185.7",
     },
     "libs/connector-base": {
       "name": "@signet/connector-base",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "dependencies": {
         "@signet/core": "0.162.4",
         "json5": "^2.2.3",
@@ -277,7 +277,7 @@
     },
     "libs/sdk": {
       "name": "@signet/sdk",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "devDependencies": {
         "@signet/core": "workspace:*",
         "@types/react": "^19.0.0",
@@ -317,7 +317,7 @@
     },
     "platform/core": {
       "name": "@signet/core",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "dependencies": {
         "sqlite-vec": "^0.1.7-alpha.2",
         "yaml": "^2.6.0",
@@ -339,7 +339,7 @@
     },
     "platform/daemon": {
       "name": "@signet/daemon",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "bin": {
         "signet-daemon": "./dist/daemon.js",
         "signet-mcp": "./dist/mcp-stdio.js",
@@ -382,14 +382,14 @@
     },
     "platform/native": {
       "name": "@signet/native",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",
       },
     },
     "surfaces/browser-extension": {
       "name": "@signet/extension",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",
@@ -397,7 +397,7 @@
     },
     "surfaces/cli": {
       "name": "@signet/cli",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "bin": "./dist/cli.js",
       "dependencies": {
         "@earendil-works/pi-ai": "0.83.0",
@@ -461,7 +461,7 @@
     },
     "surfaces/desktop": {
       "name": "@signet/desktop",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/tray": "workspace:*",
@@ -476,7 +476,7 @@
     },
     "surfaces/tray": {
       "name": "@signet/tray",
-      "version": "0.185.6",
+      "version": "0.185.7",
       "devDependencies": {
         "typescript": "^5.7.0",
       },

--- a/dist/signetai-darwin-arm64/package.json
+++ b/dist/signetai-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-darwin-arm64",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet native binary for macOS arm64",
   "os": [
     "darwin"

--- a/dist/signetai-darwin-x64/package.json
+++ b/dist/signetai-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-darwin-x64",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet native binary for macOS x64",
   "os": [
     "darwin"

--- a/dist/signetai-linux-arm64/package.json
+++ b/dist/signetai-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-linux-arm64",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet native binary for Linux arm64",
   "os": [
     "linux"

--- a/dist/signetai-linux-x64/package.json
+++ b/dist/signetai-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-linux-x64",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet native binary for Linux x64",
   "os": [
     "linux"

--- a/dist/signetai-win32-x64/package.json
+++ b/dist/signetai-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-win32-x64",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet native binary for Windows x64",
   "os": [
     "win32"

--- a/dist/signetai/package.json
+++ b/dist/signetai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet native CLI installer wrapper",
   "type": "module",
   "bin": {

--- a/integrations/claude-code/connector/package.json
+++ b/integrations/claude-code/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-claude-code",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet connector for Claude Code (Anthropic CLI)",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.185.6",
-    "@signet/core": "0.185.6"
+    "@signet/connector-base": "0.185.7",
+    "@signet/core": "0.185.7"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/codex/connector/package.json
+++ b/integrations/codex/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-codex",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet connector for Codex CLI",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.185.6",
-    "@signet/core": "0.185.6"
+    "@signet/connector-base": "0.185.7",
+    "@signet/core": "0.185.7"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/codex/plugin/package.json
+++ b/integrations/codex/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/codex-plugin",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Native Codex plugin installer for Signet",
   "type": "module",
   "bin": {
@@ -13,8 +13,8 @@
     "test": "node bin/install.js --help >/dev/null"
   },
   "dependencies": {
-    "@signet/connector-base": "0.185.6",
-    "@signet/connector-codex": "0.185.6"
+    "@signet/connector-base": "0.185.7",
+    "@signet/connector-codex": "0.185.7"
   },
   "keywords": [
     "signet",

--- a/integrations/forge/connector/package.json
+++ b/integrations/forge/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-forge",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet connector for ForgeCode - installs MCP, identity, and skills integration",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.185.6",
-    "@signet/core": "0.185.6"
+    "@signet/connector-base": "0.185.7",
+    "@signet/core": "0.185.7"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/gemini/connector/package.json
+++ b/integrations/gemini/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-gemini",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet connector for Gemini CLI",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.185.6",
-    "@signet/core": "0.185.6"
+    "@signet/connector-base": "0.185.7",
+    "@signet/core": "0.185.7"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/hermes-agent/connector/package.json
+++ b/integrations/hermes-agent/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-hermes-agent",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet connector for Hermes Agent — installs Signet as a pluggable memory provider",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.185.6",
-    "@signet/core": "0.185.6"
+    "@signet/connector-base": "0.185.7",
+    "@signet/core": "0.185.7"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/oh-my-pi/connector/package.json
+++ b/integrations/oh-my-pi/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-oh-my-pi",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet connector for Oh My Pi",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.185.6",
-    "@signet/core": "0.185.6"
+    "@signet/connector-base": "0.185.7",
+    "@signet/core": "0.185.7"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/oh-my-pi/extension/package.json
+++ b/integrations/oh-my-pi/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/oh-my-pi-extension",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet runtime extension for Oh My Pi — session lifecycle hooks and memory recall",
   "type": "module",
   "main": "dist/signet-oh-my-pi.mjs",

--- a/integrations/openclaw/connector/package.json
+++ b/integrations/openclaw/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-openclaw",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet connector for OpenClaw - configures workspace and memory hooks",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@signet/connector-base": "0.185.6",
-    "@signet/core": "0.185.6"
+    "@signet/connector-base": "0.185.7",
+    "@signet/core": "0.185.7"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/openclaw/memory-adapter/package.json
+++ b/integrations/openclaw/memory-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signetai/signet-memory-openclaw",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet adapter for OpenClaw — runtime plugin for AI agent memory",
   "type": "module",
   "main": "dist/index.js",

--- a/integrations/opencode/connector/package.json
+++ b/integrations/opencode/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-opencode",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet connector for OpenCode - installs hooks and generates config",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.185.6",
-    "@signet/core": "0.185.6",
+    "@signet/connector-base": "0.185.7",
+    "@signet/core": "0.185.7",
     "jsonc-parser": "3.3.1"
   },
   "devDependencies": {

--- a/integrations/opencode/plugin/package.json
+++ b/integrations/opencode/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/opencode-plugin",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet runtime plugin for OpenCode — memory tools and session lifecycle hooks",
   "type": "module",
   "main": "dist/signet.mjs",

--- a/integrations/pi/connector/package.json
+++ b/integrations/pi/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-pi",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet connector for pi",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.185.6",
-    "@signet/core": "0.185.6"
+    "@signet/connector-base": "0.185.7",
+    "@signet/core": "0.185.7"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/pi/extension-base/package.json
+++ b/integrations/pi/extension-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/pi-extension-base",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Shared runtime utilities for Signet harness extensions (helpers, transcript, types, lifecycle, session state)",
   "type": "module",
   "main": "./src/index.ts",

--- a/integrations/pi/extension/package.json
+++ b/integrations/pi/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/pi-extension",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Signet runtime extension for pi — session lifecycle hooks and memory recall",
   "type": "module",
   "main": "dist/signet-pi.mjs",

--- a/integrations/unreal/plugin/package.json
+++ b/integrations/unreal/plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/unreal-plugin",
-	"version": "0.185.6",
+	"version": "0.185.7",
 	"private": true,
 	"description": "Signet Unreal Engine plugin manifest and source checks",
 	"type": "module",

--- a/libs/connector-base/package.json
+++ b/libs/connector-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-base",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "Base class for Signet harness connectors",
   "type": "module",
   "main": "./dist/index.js",
@@ -26,7 +26,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/core": "0.185.6",
+    "@signet/core": "0.185.7",
     "json5": "^2.2.3",
     "jsonc-parser": "3.3.1"
   },

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/sdk",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "license": "Apache-2.0",
   "description": "HTTP client SDK for the Signet daemon API",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signet",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "private": true,
   "packageManager": "bun@1.3.11",
   "description": "Local-first identity, memory, and secrets for AI agents",

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/core",
-	"version": "0.185.6",
+	"version": "0.185.7",
 	"license": "Apache-2.0",
 	"description": "Core library for Signet - portable AI agent identity",
 	"type": "module",

--- a/platform/daemon/package.json
+++ b/platform/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/daemon",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "license": "Apache-2.0",
   "description": "Background daemon for Signet - serves dashboard, API, and memory system",
   "type": "module",

--- a/platform/daemon/src/config-migration.test.ts
+++ b/platform/daemon/src/config-migration.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { migrateInferenceProviders } from "./config-migration";
+import { migrateEmbeddingBaseUrl, migrateInferenceProviders } from "./config-migration";
 
 function setupDir(): string {
 	const dir = mkdtempSync(join(tmpdir(), "signet-config-migration-"));
@@ -164,6 +164,85 @@ inference:
 		try {
 			writeFileSync(join(dir, "agent.yaml"), "inference:\n  [unterminated");
 			expect(() => migrateInferenceProviders(dir)).not.toThrow();
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("migrateEmbeddingBaseUrl (#1264)", () => {
+	it("rewrites dashboard baseUrl to the daemon's canonical base_url", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`# preserve operator context
+embedding:
+  provider: ollama
+  baseUrl: http://192.168.1.10:11434
+  endpoint: http://127.0.0.1:11434
+`,
+			);
+			migrateEmbeddingBaseUrl(dir);
+			const after = readFileSync(join(dir, "agent.yaml"), "utf-8");
+			expect(after).toContain("base_url: http://192.168.1.10:11434");
+			expect(after).not.toContain("baseUrl:");
+			expect(after).not.toContain("endpoint:");
+			expect(after).toContain("# preserve operator context");
+			expect(after).toMatch(/^configVersion: 8/m);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps the canonical value when both endpoint spellings conflict", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`embedding:
+  provider: ollama
+  base_url: http://127.0.0.1:11434
+  baseUrl: http://192.168.1.10:11434
+`,
+			);
+			migrateEmbeddingBaseUrl(dir);
+			const after = readFileSync(join(dir, "agent.yaml"), "utf-8");
+			expect(after).toContain("base_url: http://127.0.0.1:11434");
+			expect(after).not.toContain("baseUrl:");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("canonicalizes the legacy memory.embeddings block", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`memory:
+  embeddings:
+    provider: ollama
+    baseUrl: http://192.168.1.10:11434
+`,
+			);
+			migrateEmbeddingBaseUrl(dir);
+			const after = readFileSync(join(dir, "agent.yaml"), "utf-8");
+			expect(after).toContain("base_url: http://192.168.1.10:11434");
+			expect(after).not.toContain("baseUrl:");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("is idempotent after stamping config version 8", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(join(dir, "agent.yaml"), "embedding:\n  baseUrl: http://192.168.1.10:11434\n");
+			migrateEmbeddingBaseUrl(dir);
+			const after1 = readFileSync(join(dir, "agent.yaml"), "utf-8");
+			migrateEmbeddingBaseUrl(dir);
+			expect(readFileSync(join(dir, "agent.yaml"), "utf-8")).toBe(after1);
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}

--- a/platform/daemon/src/config-migration.ts
+++ b/platform/daemon/src/config-migration.ts
@@ -587,3 +587,58 @@ export function migrateRetiredExtractionWriterConfig(agentsDir: string): void {
 		logger.info("config-migration", "Removed retired extraction writer configuration", { mutations, file: path });
 	}
 }
+
+// ---------------------------------------------------------------------------
+// v8: canonicalize dashboard embedding endpoint spelling (#1264)
+// ---------------------------------------------------------------------------
+// The dashboard briefly wrote `baseUrl`, while the daemon's canonical embedding
+// schema uses `base_url`. Rewrite both current and legacy embedding blocks once
+// at startup so existing files do not keep an endpoint the runtime ignores.
+export function migrateEmbeddingBaseUrl(agentsDir: string): void {
+	const path = findConfigPath(agentsDir);
+	if (!path) return;
+
+	let text: string;
+	try {
+		text = readFileSync(path, "utf-8");
+	} catch {
+		return;
+	}
+
+	const vMatch = /^configVersion:\s*(\d+)/m.exec(text);
+	if (vMatch && Number(vMatch[1]) >= 8) return;
+
+	const doc = parseDocument(text);
+	if (doc.errors.length > 0) {
+		logger.warn("config-migration", "Skipping embedding migration: agent.yaml has parse errors", {
+			file: path,
+			errors: doc.errors.map((error) => error.message).slice(0, 3),
+		});
+		return;
+	}
+
+	const mutations: string[] = [];
+	for (const pathParts of [["embedding"], ["memory", "embeddings"]] as const) {
+		const block = doc.getIn(pathParts, true);
+		if (!isMap(block) || !block.has("baseUrl")) continue;
+
+		const alias = block.get("baseUrl", true);
+		if (!block.has("base_url")) {
+			block.set("base_url", alias);
+			mutations.push(`${pathParts.join(".")}.baseUrl → base_url`);
+		} else if (String(block.get("base_url")) !== String(alias)) {
+			logger.warn("config-migration", "Embedding config contains conflicting endpoint keys; keeping base_url", {
+				file: path,
+				path: pathParts.join("."),
+			});
+		}
+		block.delete("baseUrl");
+		block.delete("endpoint");
+	}
+
+	stampConfigVersion(doc, 8);
+	writeAtomic(path, doc.toString());
+	if (mutations.length > 0) {
+		logger.info("config-migration", "Canonicalized embedding endpoint configuration", { mutations, file: path });
+	}
+}

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -40,6 +40,7 @@ import { createToken, requirePermission } from "./auth";
 import { bindWithRetry } from "./bind-with-retry";
 import {
 	migrateConfig,
+	migrateEmbeddingBaseUrl,
 	migrateInferenceProviders,
 	migrateLegacyRoutingToRegistry,
 	migrateRetiredExtractionWriterConfig,
@@ -1938,6 +1939,7 @@ async function main() {
 		migrateLegacyRoutingToRegistry(AGENTS_DIR);
 		migrateSessionSynthesisRoute(AGENTS_DIR);
 		migrateRetiredExtractionWriterConfig(AGENTS_DIR);
+		migrateEmbeddingBaseUrl(AGENTS_DIR);
 	} catch (err) {
 		logger.warn("config-migration", "Config migration failed; continuing startup", {
 			error: err instanceof Error ? err.message : String(err),

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -220,6 +220,16 @@ describe("Dreaming", () => {
 			content: "compaction evidence",
 		});
 		expect(nodes).toHaveLength(2);
+		const threadHead = db
+			.prepare(
+				"SELECT node_id, source_type, source_ref FROM memory_thread_heads WHERE agent_id = ? AND session_key = ?",
+			)
+			.get(AGENT, "legacy-session") as { node_id: string; source_type: string; source_ref: string } | null;
+		expect(threadHead).toEqual({
+			node_id: "legacy-summary-node",
+			source_type: "transcript",
+			source_ref: "legacy-session",
+		});
 	});
 
 	it("uses wall-clock backoff independently of later evidence volume", () => {

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -8,7 +8,8 @@
  * See docs/specs/approved/dreaming-memory-consolidation.md
  */
 
-import { randomUUID } from "node:crypto";
+import type { Database } from "bun:sqlite";
+import { createHash, randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
@@ -32,6 +33,7 @@ import { logger } from "../logger";
 import type { GraphWriteCaps } from "../ontology-proposals";
 import { isPipelineTimeout, recordPipelineError } from "../pipeline-error";
 import { getActiveTelemetry } from "../telemetry";
+import { upsertThreadHead } from "../thread-heads";
 import { createDreamingAgentTools } from "./dreaming-agent-tools";
 import {
 	type DreamingAttention,
@@ -1413,7 +1415,25 @@ export async function runDreamingAgentPass(
 				surfaced === undefined ? previous : nextEvidenceWatermark(surfaced, previous, cutoff),
 			);
 		}
+		// Any pass that surfaces transcript evidence owns its direct temporal
+		// projection. Combined passes can ingest content too; gating this on the
+		// focused-mode name would advance the watermark without writing the
+		// manifest.
+		const transcriptManifestEntries = [...surfacedTranscriptRefsByScope.entries()].flatMap(([scope, refs]) =>
+			accessor.withReadDb((db) =>
+				[...refs].flatMap((sourceRef) => {
+					const source = readEpisodicSource(db, { agentId: scope, from: sourceRef });
+					return source === null || !source.completed
+						? []
+						: [{ scope, source, content: renderDreamingEvidence(source) }];
+				}),
+			),
+		);
 		accessor.withWriteTx((db) => {
+			writeDreamingTranscriptManifestInTx(db, {
+				passId,
+				entries: transcriptManifestEntries,
+			});
 			db.prepare(
 				`UPDATE dreaming_passes SET status = 'completed', completed_at = datetime('now'),
 				 tokens_consumed = ?, tokens_input = ?, tokens_output = ?,
@@ -1497,6 +1517,89 @@ export async function runDreamingAgentPass(
 // Max backoff: 5min * 2^6 = ~5.3 hours.
 const MAX_FAILURE_BACKOFF_MULTIPLIER = 6;
 const FAILURE_BACKOFF_BASE_MS = 5 * 60 * 1000;
+
+function writeDreamingTranscriptManifestInTx(
+	db: WriteDb,
+	params: {
+		readonly passId: string;
+		readonly entries: readonly {
+			readonly scope: string;
+			readonly source: EpisodicSourceRecord;
+			readonly content: string;
+		}[];
+	},
+): void {
+	const table = db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'session_summaries'").get();
+	if (table == null) return;
+	const statement = db.prepare(
+		`INSERT INTO session_summaries (
+			id, project, depth, kind, content, token_count,
+			earliest_at, latest_at, session_key, harness,
+			agent_id, source_type, source_ref, meta_json, created_at
+		) VALUES (?, ?, 0, 'session', ?, ?, ?, ?, ?, ?, ?, 'transcript', ?, ?, ?)
+		 ON CONFLICT(id) DO UPDATE SET
+			project = excluded.project,
+			content = excluded.content,
+			token_count = excluded.token_count,
+			earliest_at = excluded.earliest_at,
+			latest_at = excluded.latest_at,
+			session_key = excluded.session_key,
+			harness = excluded.harness,
+			agent_id = excluded.agent_id,
+			source_type = excluded.source_type,
+			source_ref = excluded.source_ref,
+			meta_json = excluded.meta_json`,
+	);
+	const now = new Date().toISOString();
+	for (const entry of params.entries) {
+		if (!entry.source.completed || entry.content.trim().length === 0) continue;
+		const content = entry.content.trim();
+		const contentHash = createHash("sha256").update(content).digest("hex");
+		// Reuse an existing depth-0 row for this agent/session. The historical
+		// summary path used a different id, and the partial unique index cannot
+		// be handled by ON CONFLICT(id) alone. Updating it in place preserves
+		// child/memory lineage while replacing the derived content source.
+		const existing = db
+			.prepare(
+				`SELECT id FROM session_summaries
+				 WHERE agent_id = ? AND session_key = ? AND depth = 0
+				   AND COALESCE(source_type, 'summary') IN ('summary', 'checkpoint')
+				 LIMIT 1`,
+			)
+			.get(entry.scope, entry.source.id) as { id: string } | null;
+		const nodeId = existing?.id ?? `transcript:${entry.scope}:${entry.source.id}`;
+		statement.run(
+			nodeId,
+			entry.source.project,
+			content,
+			countTokens(content),
+			entry.source.capturedAt,
+			entry.source.capturedAt,
+			entry.source.id,
+			entry.source.harness,
+			entry.scope,
+			entry.source.id,
+			JSON.stringify({
+				source: "dreaming-content-pass",
+				passId: params.passId,
+				sourceRef: `transcript:${entry.source.id}`,
+				contentHash,
+			}),
+			now,
+		);
+		upsertThreadHead(db as unknown as Database, {
+			agentId: entry.scope,
+			nodeId,
+			content,
+			latestAt: now,
+			project: entry.source.project,
+			sessionKey: entry.source.id,
+			sourceType: "transcript",
+			sourceRef: entry.source.id,
+			harness: entry.source.harness,
+		});
+	}
+}
 
 // A scope that fails this many consecutive passes is halted: automatic
 // scheduling stops for the cooldown below instead of retrying forever on

--- a/platform/native/Cargo.lock
+++ b/platform/native/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "signet-native"
-version = "0.185.6"
+version = "0.185.7"
 dependencies = [
  "napi",
  "napi-build",

--- a/platform/native/Cargo.toml
+++ b/platform/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signet-native"
-version = "0.185.6"
+version = "0.185.7"
 edition = "2021"
 license = "Apache-2.0"
 description = "Signet native accelerators (napi-rs)"

--- a/platform/native/package.json
+++ b/platform/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/native",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "private": true,
   "description": "Signet native accelerators",
   "main": "index.js",

--- a/surfaces/browser-extension/package.json
+++ b/surfaces/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/extension",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "private": true,
   "description": "Signet browser extension for Chrome and Firefox",
   "scripts": {

--- a/surfaces/cli/package.json
+++ b/surfaces/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/cli",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "description": "CLI for Signet - portable AI agent identity",
   "type": "module",
   "bin": "./dist/cli.js",

--- a/surfaces/dashboard/src/lib/agent-config.test.tsx
+++ b/surfaces/dashboard/src/lib/agent-config.test.tsx
@@ -16,6 +16,7 @@ import { act } from "react";
 import { useEffect, useRef } from "react";
 import { type Root, createRoot } from "react-dom/client";
 import { type AgentConfigStore, isDreamingEnabled, useAgentConfig } from "./agent-config";
+import { writeEmbeddingEndpoint } from "./embedding-config";
 
 const INITIAL_CONFIG = `inference:
   defaultPolicy: background
@@ -31,6 +32,9 @@ const INITIAL_CONFIG = `inference:
     background:
       executor: openai-compatible
       endpoint: http://127.0.0.1:1234/v1
+embedding:
+  provider: ollama
+  baseUrl: http://127.0.0.1:11434
 memory:
   pipelineV2:
     mutationsFrozen: true
@@ -188,6 +192,22 @@ describe("agent config store", () => {
 		expect(body).toContain("executor: openai-compatible");
 		expect(body).toContain("x-custom-operator-key:");
 		expect(body).toContain("nested: keep-me");
+		await harness.unmount();
+	});
+
+	test("saves embedding endpoints as base_url and removes the dashboard alias (#1264)", async () => {
+		capturedSaveBody = null;
+		const harness = await mountHarness();
+
+		await act(async () => {
+			writeEmbeddingEndpoint(harness.store, ["embedding"], "http://192.168.1.10:11434");
+			await harness.store.save();
+		});
+
+		const body = requireSaveBody(capturedSaveBody);
+		expect(body).toContain("base_url: http://192.168.1.10:11434");
+		expect(body).not.toContain("baseUrl:");
+		expect(body).not.toContain("127.0.0.1:11434");
 		await harness.unmount();
 	});
 });

--- a/surfaces/dashboard/src/lib/embedding-config.ts
+++ b/surfaces/dashboard/src/lib/embedding-config.ts
@@ -1,0 +1,17 @@
+import type { AgentConfigStore } from "./agent-config";
+
+type EmbeddingConfigStore = Pick<AgentConfigStore, "aDel" | "aSetStr" | "aStr">;
+
+export function readEmbeddingEndpoint(store: Pick<EmbeddingConfigStore, "aStr">, path: readonly string[]): string {
+	return store.aStr([...path, "base_url"]) || store.aStr([...path, "baseUrl"]) || store.aStr([...path, "endpoint"]);
+}
+
+export function writeEmbeddingEndpoint(
+	store: Pick<EmbeddingConfigStore, "aDel" | "aSetStr">,
+	path: readonly string[],
+	value: string,
+): void {
+	store.aSetStr([...path, "base_url"], value);
+	store.aDel([...path, "baseUrl"]);
+	store.aDel([...path, "endpoint"]);
+}

--- a/surfaces/dashboard/src/views/settings.tsx
+++ b/surfaces/dashboard/src/views/settings.tsx
@@ -4,6 +4,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Switch } from "@/components/ui/switch";
 import { type AgentConfigStore, isDreamingEnabled, useAgentConfig } from "@/lib/agent-config";
 import { type InferenceCatalog, type LogEntry, api } from "@/lib/api";
+import { readEmbeddingEndpoint, writeEmbeddingEndpoint } from "@/lib/embedding-config";
 import { allowRemoteMemoryExtraction, ensureInferenceRoute, requiresRemoteMemoryConsent } from "@/lib/inference-route-config";
 import {
 	ACPX_AGENTS,
@@ -798,7 +799,7 @@ function EmbeddingEditor({ store }: { store: AgentConfigStore }) {
 
 	const provider = store.aStr([...embPath, "provider"]) || "native";
 	const model = store.aStr([...embPath, "model"]);
-	const endpoint = store.aStr([...embPath, "baseUrl"]) || store.aStr([...embPath, "endpoint"]);
+	const endpoint = readEmbeddingEndpoint(store, embPath);
 	const nonNative = provider !== "native" && provider !== "";
 
 	const apply = (path: readonly string[], value: string) => {
@@ -829,7 +830,14 @@ function EmbeddingEditor({ store }: { store: AgentConfigStore }) {
 			</Row>
 			{nonNative && (
 				<Row title="Endpoint" desc="Base URL of the embedding server.">
-					<CtrlInput value={endpoint} placeholder="http://localhost:11434" onChange={(v) => apply([...embPath, "baseUrl"], v)} />
+					<CtrlInput
+						value={endpoint}
+						placeholder="http://localhost:11434"
+						onChange={(v) => {
+							writeEmbeddingEndpoint(store, embPath, v);
+							void store.save();
+						}}
+					/>
 				</Row>
 			)}
 		</>

--- a/surfaces/desktop/package.json
+++ b/surfaces/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/desktop",
-	"version": "0.185.6",
+	"version": "0.185.7",
 	"private": true,
 	"description": "Electron desktop distribution layer for Signet",
 	"homepage": "https://signetai.sh",

--- a/surfaces/tray/package.json
+++ b/surfaces/tray/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/tray",
-  "version": "0.185.6",
+  "version": "0.185.7",
   "private": true,
   "description": "Shared tray and menu bar state utilities for Signet desktop shells",
   "type": "module",


### PR DESCRIPTION
## Summary

Restores the transcript manifest projection removed from PR #1291. Successful Dreaming passes that surface transcript evidence must continue replacing historical depth-0 summary rows and writing the direct transcript manifest before advancing the evidence watermark.

## Changes

- Restore `transcriptManifestEntries` collection for surfaced, completed transcripts.
- Restore the transactional `writeDreamingTranscriptManifestInTx` projection and thread-head update.
- Add a regression assertion for the persisted transcript thread head.
- Keep the telemetry changes from PR #1291 unchanged.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A. No schema changes.

## Testing

- [x] `bun test` passes for the focused Dreaming and telemetry suites
- [x] `bun run typecheck` passes for the daemon
- [x] `bun run lint` equivalent Biome check passes for changed files
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see review and implementation history)

## Notes

This is a stacked fix targeting the head branch of PR #1291. The original PR branch does not allow maintainer pushes, so this follow-up preserves the original PR's scope while restoring the deleted behavior.