### PR TITLE
fix(daemon): preserve explicit telemetry opt-out

### DIFF
--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -138,7 +138,6 @@ import {
 	setRuntimePressureEnvelope,
 } from "./runtime-pressure";
 import { startSchedulerWorker } from "./scheduler";
-import { getSecret } from "./secrets.js";
 import { flushPendingCheckpoints, initCheckpointFlush, pruneCheckpoints } from "./session-checkpoints";
 import { createSessionClaimStore } from "./session-claims";
 import {
@@ -2070,14 +2069,7 @@ async function main() {
 	const memoryCfg = loadMemoryConfig(AGENTS_DIR);
 	let telemetryCollector: TelemetryCollector | undefined;
 	if (memoryCfg.pipelineV2.telemetryEnabled && !telemetryDisabledByEnv()) {
-		let posthogApiKey = memoryCfg.pipelineV2.telemetry.posthogApiKey;
-		if (!posthogApiKey) {
-			try {
-				posthogApiKey = await getSecret("POSTHOG_API_KEY");
-			} catch {
-				posthogApiKey = "";
-			}
-		}
+		const posthogApiKey = memoryCfg.pipelineV2.telemetry.posthogApiKey;
 		const resolvedTelemetryCfg = {
 			...memoryCfg.pipelineV2.telemetry,
 			posthogApiKey,

--- a/platform/daemon/src/memory-config.test.ts
+++ b/platform/daemon/src/memory-config.test.ts
@@ -50,6 +50,21 @@ function restoreWarmNativeEnv(value: string | undefined): void {
 }
 
 describe("loadMemoryConfig", () => {
+	it("preserves an explicit empty telemetry API key for local-only delivery (#1290)", () => {
+		const agentsDir = makeTempAgentsDir();
+		writeFileSync(
+			join(agentsDir, "agent.yaml"),
+			`memory:
+  pipelineV2:
+    telemetry:
+      posthogApiKey: ""
+`,
+		);
+
+		const cfg = loadMemoryConfig(agentsDir);
+		expect(cfg.pipelineV2.telemetry.posthogApiKey).toBe("");
+	});
+
 	it("prefers agent.yaml embedding settings over config.yaml fallback", () => {
 		const agentsDir = makeTempAgentsDir();
 		writeFileSync(


### PR DESCRIPTION
## Summary

Follow-up to #1290. Align daemon telemetry with the CLI contract so an explicitly empty `posthogApiKey` remains local-only instead of falling through to the `POSTHOG_API_KEY` secret store.

This should merge after #1290, which adds the CLI-side contract and disclosure updates.

## Changes

- Remove daemon startup fallback from an explicit empty telemetry API key to the secret store.
- Preserve the empty key through `loadMemoryConfig`.
- Add regression coverage for the local-only configuration contract.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations are touched.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused verification:

- `bun test platform/daemon/src/memory-config.test.ts platform/daemon/src/telemetry.test.ts surfaces/cli/src/features/telemetry.test.ts` — 125 passed, 0 failed.
- `bunx biome check platform/daemon/src/daemon.ts platform/daemon/src/memory-config.test.ts` — passed.
- `bun run --filter '@signet/daemon' typecheck` — passed.
- `bun run --filter '@signet/daemon' build` — passed.
- `bun run typecheck` — reaches the daemon successfully but has unrelated baseline failures in generated connector packages due missing/stale bundle exports.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This is intentionally a dependent follow-up to #1290. Do not merge this before #1290, or merge both changes together. The parity issue was reported on #1290 in review and we are fixing it from our end.
