### PR TITLE
feat(telemetry): expose collector delivery health

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -52,7 +52,23 @@ later attempt.
 
 The collector buffers events in memory (auto-flush at 200 events, hard cap
 5000), flushes on the configured interval, backs off 5x after 3 consecutive
-PostHog failures, and never throws into the daemon.
+PostHog failures, and never throws into the daemon. Every scheduled flush
+also emits one bounded `telemetry.health` event. Its local-only aggregate
+fields include queue depth, oldest unsent age, daemon activity freshness,
+delivery success/failure counts for the last 24 hours, backoff state, and
+dropped-buffer count. The event is logged locally before the delivery attempt,
+so it remains diagnostically useful during a remote outage.
+
+Delivery state is persisted in `telemetry_delivery_state` and queue rows keep
+stable event IDs for PostHog `$insert_id` de-duplication across retries. A
+timeout remains an indeterminate remote result, so the row is retried rather
+than marked sent. Retention pruning removes delivered rows only; daemon-owned
+unsent rows remain available for later delivery up to the bounded 20,000-row
+queue. CLI command rows have their own bounded 5,000-row queue because they
+are flushed by short-lived CLI processes rather than the daemon. The authenticated
+`GET /api/telemetry/health` route and the dashboard Logs panel expose the same
+aggregate state without exposing event payloads, install IDs, credentials,
+paths, or user identity.
 
 ## Event catalog
 

--- a/platform/core/src/migrations/121-telemetry-delivery-health.ts
+++ b/platform/core/src/migrations/121-telemetry-delivery-health.ts
@@ -1,0 +1,46 @@
+/**
+ * Migration 121: durable telemetry delivery health (#1279).
+ *
+ * The event queue already survives daemon restarts, but delivery outcomes did
+ * not. Keep the queue ownership columns intact and add only bounded metadata
+ * needed to explain whether an empty remote feed means daemon silence or a
+ * collector that is waiting to retry.
+ */
+
+import type { MigrationDb } from "./index";
+
+function hasColumn(db: MigrationDb, table: string, column: string): boolean {
+	return db
+		.prepare(`PRAGMA table_info(${table})`)
+		.all()
+		.some((row) => row.name === column);
+}
+
+function addColumnIfMissing(db: MigrationDb, column: string, definition: string): void {
+	if (!hasColumn(db, "telemetry_events", column)) {
+		db.exec(`ALTER TABLE telemetry_events ADD COLUMN ${column} ${definition}`);
+	}
+}
+
+export function up(db: MigrationDb): void {
+	addColumnIfMissing(db, "delivery_attempts", "INTEGER NOT NULL DEFAULT 0");
+	addColumnIfMissing(db, "last_attempt_at", "TEXT");
+	addColumnIfMissing(db, "sent_at", "TEXT");
+	addColumnIfMissing(db, "last_failure_code", "TEXT");
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS telemetry_delivery_state (
+			id INTEGER PRIMARY KEY CHECK (id = 1),
+			window_started_at TEXT NOT NULL,
+			success_count INTEGER NOT NULL DEFAULT 0,
+			failure_count INTEGER NOT NULL DEFAULT 0,
+			consecutive_failures INTEGER NOT NULL DEFAULT 0,
+			last_attempt_at TEXT,
+			last_success_at TEXT,
+			last_failure_code TEXT,
+			dropped_event_count INTEGER NOT NULL DEFAULT 0
+		);
+		INSERT OR IGNORE INTO telemetry_delivery_state (id, window_started_at)
+		VALUES (1, CURRENT_TIMESTAMP);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -126,6 +126,7 @@ import { up as retireSummaryWorker } from "./117-retire-summary-worker";
 import { up as queuePressureIndices } from "./118-queue-pressure-indices";
 import { up as telemetryVersionObservation } from "./119-telemetry-version-observation";
 import { up as sourceLifecycleTelemetry } from "./120-source-lifecycle-telemetry";
+import { up as telemetryDeliveryHealth } from "./121-telemetry-delivery-health";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1126,6 +1127,20 @@ export const MIGRATIONS: readonly Migration[] = [
 		name: "source-lifecycle-telemetry",
 		up: sourceLifecycleTelemetry,
 		artifacts: { tables: ["source_lifecycle_state"] },
+	},
+	{
+		version: 121,
+		name: "telemetry-delivery-health",
+		up: telemetryDeliveryHealth,
+		artifacts: {
+			tables: ["telemetry_delivery_state"],
+			columns: [
+				{ table: "telemetry_events", column: "delivery_attempts" },
+				{ table: "telemetry_events", column: "last_attempt_at" },
+				{ table: "telemetry_events", column: "sent_at" },
+				{ table: "telemetry_events", column: "last_failure_code" },
+			],
+		},
 	},
 ];
 

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -2173,3 +2173,24 @@ describe("migration 116: ACP delivery reconciliation", () => {
 		});
 	});
 });
+
+describe("migration 121: telemetry delivery health", () => {
+	test("persists bounded delivery state and retry metadata idempotently", () => {
+		const db = createFreshDb();
+		runMigrations(db);
+		runMigrations(db);
+
+		const columns = db.query("PRAGMA table_info(telemetry_events)").all() as Array<{ name: string }>;
+		expect(columns.map((row) => row.name)).toEqual(
+			expect.arrayContaining(["delivery_attempts", "last_attempt_at", "sent_at", "last_failure_code"]),
+		);
+		const state = db.query("SELECT * FROM telemetry_delivery_state WHERE id = 1").get() as {
+			window_started_at: string;
+			success_count: number;
+			failure_count: number;
+		};
+		expect(state.window_started_at).toEqual(expect.any(String));
+		expect(state.success_count).toBe(0);
+		expect(state.failure_count).toBe(0);
+	});
+});

--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -546,7 +546,14 @@ describe("auth guard co-location", () => {
 		});
 	});
 
-	describe("telemetry routes need analytics guards", () => {
+		describe("telemetry routes need analytics guards", () => {
+		it("GET /api/telemetry/health returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { registerTelemetryRoutes } = await import("./routes/telemetry-routes");
+			registerTelemetryRoutes(app);
+			expect(await status(app, "GET", "/api/telemetry/health")).toBe(403);
+		});
+
 		it("GET /api/telemetry/memory-search returns 403 without auth", async () => {
 			const app = await makeApp();
 			const { registerTelemetryRoutes } = await import("./routes/telemetry-routes");

--- a/platform/daemon/src/routes/telemetry-routes.ts
+++ b/platform/daemon/src/routes/telemetry-routes.ts
@@ -219,6 +219,11 @@ export function registerTelemetryRoutes(app: Hono): void {
 		return c.json({ events, enabled: true });
 	});
 
+	app.get("/api/telemetry/health", (c) => {
+		if (!telemetryRef) return c.json({ enabled: false });
+		return c.json({ enabled: true, ...telemetryRef.deliveryHealth() });
+	});
+
 	app.get("/api/telemetry/memory-search", (c) => {
 		const agent = resolveScopedAgentId(c, c.req.query("agent_id") ?? c.req.query("agentId"));
 		if (agent.error) return c.json({ error: agent.error }, 403);

--- a/platform/daemon/src/routes/telemetry-routes.ts
+++ b/platform/daemon/src/routes/telemetry-routes.ts
@@ -79,6 +79,11 @@ function totalTokens(
 	return input === null && output === null ? null : (input ?? 0) + (output ?? 0);
 }
 
+function boundedTelemetryLimit(raw: string | undefined, fallback: number, maximum: number): number {
+	const parsed = Number.parseInt(raw ?? "", 10);
+	return Number.isSafeInteger(parsed) ? Math.min(Math.max(parsed, 1), maximum) : fallback;
+}
+
 export function registerTelemetryRoutes(app: Hono): void {
 	app.use("/api/analytics", async (c, next) => {
 		return requirePermission("analytics", authConfig)(c, next);
@@ -214,7 +219,7 @@ export function registerTelemetryRoutes(app: Hono): void {
 		const event = c.req.query("event") as TelemetryEventType | undefined;
 		const since = c.req.query("since");
 		const until = c.req.query("until");
-		const limit = Number.parseInt(c.req.query("limit") ?? "100", 10);
+		const limit = boundedTelemetryLimit(c.req.query("limit"), 100, 10_000);
 		const events = telemetryRef.query({ event, since, until, limit });
 		return c.json({ events, enabled: true });
 	});
@@ -645,7 +650,7 @@ export function registerTelemetryRoutes(app: Hono): void {
 			return c.text("telemetry not enabled", 404);
 		}
 		const since = c.req.query("since");
-		const limit = Number.parseInt(c.req.query("limit") ?? "10000", 10);
+		const limit = boundedTelemetryLimit(c.req.query("limit"), 10_000, 100_000);
 		const events = telemetryRef.query({ since, limit });
 
 		const lines = events.map((e) => JSON.stringify(e)).join("\n");

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -21,6 +21,7 @@ import {
 	createTelemetryCollector,
 	defaultTelemetryLogPath,
 	nextFlushIntervalMs,
+	parseTelemetryTimestamp,
 	sanitizeCrashError,
 	telemetryDeployment,
 	telemetryDeploymentRole,
@@ -77,7 +78,7 @@ function resetWorkspace(): void {
 	rmSync(join(dir, "memory"), { recursive: true, force: true });
 	rmSync(join(dir, ".daemon"), { recursive: true, force: true });
 	mkdirSync(join(dir, "memory"), { recursive: true });
-	initDbAccessor(join(dir, "memory", "memories.db"));
+	initDbAccessor(join(dir, "memory", "memories.db"), { agentsDir: dir });
 }
 
 function makeCollector(configSnapshot?: TelemetryConfigSnapshot): TelemetryCollector {
@@ -153,7 +154,7 @@ describe("telemetry collector", () => {
 		const dirB = createTestTempDir("signet-telemetry-b-");
 		try {
 			closeDbAccessor();
-			initDbAccessor(join(dirB, "memory", "memories.db"));
+			initDbAccessor(join(dirB, "memory", "memories.db"), { agentsDir: dirB });
 			const collectorB = makeCollector();
 			collectorB.record("daemon.heartbeat", { uptimeMs: 1 });
 			await collectorB.flush();
@@ -258,7 +259,7 @@ describe("telemetry collector", () => {
 		const dir = createTestTempDir("signet-anon-");
 		try {
 			closeDbAccessor();
-			initDbAccessor(join(dir, "memory", "memories.db"));
+			initDbAccessor(join(dir, "memory", "memories.db"), { agentsDir: dir });
 			const collector = createTelemetryCollector(
 				getDbAccessor(),
 				{
@@ -289,7 +290,7 @@ describe("telemetry collector", () => {
 		const dirB = createTestTempDir("signet-anon-b-");
 		try {
 			closeDbAccessor();
-			initDbAccessor(join(dirA, "memory", "memories.db"));
+			initDbAccessor(join(dirA, "memory", "memories.db"), { agentsDir: dirA });
 			const ca = createTelemetryCollector(
 				getDbAccessor(),
 				{
@@ -304,7 +305,7 @@ describe("telemetry collector", () => {
 			);
 			const ha = ca.anonymizeAgentId("default");
 			closeDbAccessor();
-			initDbAccessor(join(dirB, "memory", "memories.db"));
+			initDbAccessor(join(dirB, "memory", "memories.db"), { agentsDir: dirB });
 			const cb = createTelemetryCollector(
 				getDbAccessor(),
 				{
@@ -404,7 +405,7 @@ describe("telemetry collector", () => {
 		// activation event) disappears, but the atomically persisted
 		// first-use rows survive and are recoverable by the next daemon.
 		closeDbAccessor();
-		initDbAccessor(join(dir, "memory", "memories.db"));
+		initDbAccessor(join(dir, "memory", "memories.db"), { agentsDir: dir });
 		const restarted = makeCollector();
 		restarted.recordFirstUse("remember");
 		restarted.recordFirstUse("recall");
@@ -655,6 +656,10 @@ describe("telemetry collector", () => {
 		expect(nextFlushIntervalMs(60000, 9)).toBe(300000);
 	});
 
+	it("parses SQLite CURRENT_TIMESTAMP as UTC regardless of host timezone", () => {
+		expect(parseTelemetryTimestamp("2026-08-10 12:34:56")).toBe(Date.parse("2026-08-10T12:34:56.000Z"));
+	});
+
 	it("persists delivery health and retries failed events with stable insert ids", async () => {
 		fetchStatus = 503;
 		const collector = makeCollector();
@@ -703,6 +708,34 @@ describe("telemetry collector", () => {
 		expect(health?.properties).not.toHaveProperty("posthogHost");
 		expect(health?.properties).not.toHaveProperty("installId");
 		expect(readFileSync(logPath, "utf-8")).toContain('"event":"telemetry.health"');
+	});
+
+	it("drains events recorded during an in-flight flush before stopping", async () => {
+		let releaseFetch: (() => void) | undefined;
+		const fetchBlocked = new Promise<void>((resolve) => {
+			releaseFetch = resolve;
+		});
+		globalThis.fetch = (async () => {
+			await fetchBlocked;
+			return new Response("1", { status: 200 });
+		}) as unknown as typeof fetch;
+
+		const collector = makeCollector();
+		collector.record("daemon.heartbeat", { uptimeMs: 1 });
+		const firstFlush = collector.flush();
+		collector.record("daemon.heartbeat", { uptimeMs: 2 });
+		releaseFetch?.();
+		await firstFlush;
+		await collector.stop();
+
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db.prepare("SELECT COUNT(*) AS count FROM telemetry_events WHERE event = 'daemon.heartbeat'").get() as {
+						readonly count: number;
+					},
+			).count,
+		).toBe(2);
 	});
 
 	it("retains old unsent events during retention pruning", async () => {
@@ -911,8 +944,10 @@ describe("session economics (issue #1201)", () => {
 		await collector.flush();
 
 		const ends = collector.query({ event: "session.end" });
-		expect(ends[0]?.properties.tokensInput).toBe(100);
-		expect(ends[1]?.properties.tokensInput).toBe(300);
-		expect(ends[1]?.properties.cost).toBe(1.5);
+		const first = ends.find((event) => event.properties.tokensInput === 100);
+		const resumed = ends.find((event) => event.properties.tokensInput === 300);
+		expect(first?.properties.tokensInput).toBe(100);
+		expect(resumed?.properties.tokensInput).toBe(300);
+		expect(resumed?.properties.cost).toBe(1.5);
 	});
 });

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -23,7 +23,9 @@ import {
 	nextFlushIntervalMs,
 	sanitizeCrashError,
 	telemetryDeployment,
+	telemetryDeploymentRole,
 	telemetryDisabledByEnv,
+	telemetryInstallChannel,
 	telemetryReportedVersion,
 } from "./telemetry";
 import { cleanupTestTempDir, createTestTempDir } from "./test-temp-dir";
@@ -50,6 +52,7 @@ let dir = "";
 let logPath = "";
 let captured: Array<{ readonly url: string; readonly body: CapturedBody }> = [];
 let pendingFetch: { readonly gate: Promise<void>; readonly started: () => void } | null = null;
+let fetchStatus = 200;
 const originalFetch = globalThis.fetch;
 
 function installFetchMock(): void {
@@ -65,7 +68,7 @@ function installFetchMock(): void {
 			blocked.started();
 			await blocked.gate;
 		}
-		return new Response("1", { status: 200 });
+		return new Response(fetchStatus === 200 ? "1" : "failure", { status: fetchStatus });
 	}) as typeof fetch;
 }
 
@@ -128,6 +131,7 @@ beforeAll(() => {
 beforeEach(() => {
 	captured = [];
 	pendingFetch = null;
+	fetchStatus = 200;
 	logPath = defaultTelemetryLogPath(dir);
 	resetWorkspace();
 });
@@ -344,6 +348,7 @@ describe("telemetry collector", () => {
 			"platform",
 			"deploymentRole",
 			"installChannel",
+			"$insert_id",
 			"$lib",
 			"$lib_version",
 		]);
@@ -567,6 +572,9 @@ describe("telemetry collector", () => {
 	});
 
 	it("uses explicit bounded deployment metadata and keeps unknown as the fallback", async () => {
+		expect(telemetryDeploymentRole(undefined, { SIGNET_TELEMETRY_ENV: "dev" })).toBe("development");
+		expect(telemetryInstallChannel(undefined, { SIGNET_TELEMETRY_INSTALL_CHANNEL: "container" })).toBe("container");
+
 		const collector = createTelemetryCollector(
 			getDbAccessor(),
 			{
@@ -647,11 +655,80 @@ describe("telemetry collector", () => {
 		expect(nextFlushIntervalMs(60000, 9)).toBe(300000);
 	});
 
-	it("prunes events older than the retention window", async () => {
+	it("persists delivery health and retries failed events with stable insert ids", async () => {
+		fetchStatus = 503;
+		const collector = makeCollector();
+		collector.record("daemon.heartbeat", { uptimeMs: 1 });
+		await collector.flush();
+
+		const failedHealth = collector.deliveryHealth();
+		expect(failedHealth.status).toBe("degraded");
+		expect(failedHealth.queuedUnsentEventCount).toBeGreaterThan(0);
+		expect(failedHealth.recentDeliveryFailureCount).toBe(1);
+		expect(failedHealth.backoffActive).toBe(false);
+		const firstIds = captured[0]?.body.batch.map((event) => event.properties.$insert_id);
+		expect(firstIds?.every((id) => typeof id === "string")).toBe(true);
+		const attempts = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT delivery_attempts, last_failure_code FROM telemetry_events WHERE event = ?")
+					.all("daemon.heartbeat") as Array<{
+					readonly delivery_attempts: number;
+					readonly last_failure_code: string;
+				}>,
+		);
+		expect(attempts[0]).toMatchObject({ delivery_attempts: 1, last_failure_code: "http" });
+
+		fetchStatus = 200;
+		await collector.flush();
+		expect(captured[1]?.body.batch.map((event) => event.properties.$insert_id)).toEqual(firstIds);
+		expect(collector.deliveryHealth().queuedUnsentEventCount).toBe(0);
+		expect(collector.deliveryHealth().lastSuccessfulDeliveryAgeSec).not.toBeNull();
+	});
+
+	it("emits a bounded local health event without exposing delivery secrets", async () => {
+		const collector = createTelemetryCollector(getDbAccessor(), TELEMETRY_CONFIG, "0.0.0-test", {
+			telemetryLogPath: logPath,
+		});
+		collector.record("daemon.heartbeat", { uptimeMs: 1 });
+		await collector.stop();
+
+		const health = collector.query({ event: "telemetry.health" })[0];
+		expect(health).toBeDefined();
+		expect(health?.properties).toMatchObject({
+			queuedUnsentEventCount: 2,
+			deliveryConfigured: true,
+		});
+		expect(health?.properties).not.toHaveProperty("posthogApiKey");
+		expect(health?.properties).not.toHaveProperty("posthogHost");
+		expect(health?.properties).not.toHaveProperty("installId");
+		expect(readFileSync(logPath, "utf-8")).toContain('"event":"telemetry.health"');
+	});
+
+	it("retains old unsent events during retention pruning", async () => {
 		const old = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000).toISOString();
 		getDbAccessor().withWriteTx((w) => {
 			w.prepare(
 				"INSERT INTO telemetry_events (id, event, timestamp, properties, sent_to_posthog, created_at) VALUES (?, ?, ?, ?, 0, ?)",
+			).run("old-unsent", "daemon.heartbeat", old, "{}", old);
+		});
+		const collector = createTelemetryCollector(
+			getDbAccessor(),
+			{ ...TELEMETRY_CONFIG, posthogHost: "", posthogApiKey: "" },
+			"0.0.0-test",
+		);
+		for (let i = 0; i < 10; i++) await collector.flush();
+		const row = getDbAccessor().withReadDb((db) =>
+			db.prepare("SELECT id FROM telemetry_events WHERE id = ?").get("old-unsent"),
+		);
+		expect(row).toBeDefined();
+	});
+
+	it("prunes events older than the retention window", async () => {
+		const old = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000).toISOString();
+		getDbAccessor().withWriteTx((w) => {
+			w.prepare(
+				"INSERT INTO telemetry_events (id, event, timestamp, properties, sent_to_posthog, created_at) VALUES (?, ?, ?, ?, 1, ?)",
 			).run("old-1", "daemon.heartbeat", old, "{}", old);
 		});
 

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -67,6 +67,7 @@ export const TELEMETRY_EVENTS = [
 	// TTL eviction), dedup'd once per session lifetime (#1212/#1231).
 	"session.end",
 	"daemon.heartbeat",
+	"telemetry.health",
 	// Lifecycle events (issue #1026 Phase 2): fired when the user has opted
 	// into anonymous telemetry. No PII, no code, no memory content.
 	"daemon.started",
@@ -127,6 +128,26 @@ export interface TelemetryEvent {
 	readonly event: TelemetryEventType;
 	readonly timestamp: string;
 	readonly properties: TelemetryProperties;
+}
+
+export type TelemetryDeliveryStatus = "healthy" | "degraded" | "local-only";
+
+/** Aggregate collector state safe for local diagnostics and PostHog. */
+export interface TelemetryDeliveryHealth {
+	readonly status: TelemetryDeliveryStatus;
+	readonly deliveryConfigured: boolean;
+	readonly bufferedEventCount: number;
+	readonly queuedUnsentEventCount: number;
+	readonly oldestUnsentEventAgeSec: number | null;
+	readonly lastDaemonEventAgeSec: number | null;
+	readonly lastAttemptAgeSec: number | null;
+	readonly lastSuccessfulDeliveryAgeSec: number | null;
+	readonly recentDeliverySuccessCount: number;
+	readonly recentDeliveryFailureCount: number;
+	readonly consecutiveFailures: number;
+	readonly backoffActive: boolean;
+	readonly droppedEventCount: number;
+	readonly flushIntervalMs: number;
 }
 
 interface SessionCostAccumulator {
@@ -225,6 +246,7 @@ export interface TelemetryCollector {
 	recordFirstUse(kind: FirstUseKind): void;
 
 	flush(): Promise<void>;
+	deliveryHealth(): TelemetryDeliveryHealth;
 	start(): void;
 	stop(): Promise<void>;
 
@@ -475,6 +497,22 @@ interface PostHogBatchEvent {
 	readonly properties: Record<string, string | number | boolean | null>;
 }
 
+interface PostHogDeliveryResult {
+	readonly ok: boolean;
+	readonly failureCode?: "http" | "timeout" | "network";
+}
+
+interface TelemetryDeliveryState {
+	readonly windowStartedAt: string;
+	readonly successCount: number;
+	readonly failureCount: number;
+	readonly consecutiveFailures: number;
+	readonly lastAttemptAt: string | null;
+	readonly lastSuccessAt: string | null;
+	readonly lastFailureCode: string | null;
+	readonly droppedEventCount: number;
+}
+
 interface ClaimedTelemetryEvents {
 	readonly token: string;
 	readonly events: readonly TelemetryEvent[];
@@ -486,6 +524,9 @@ const MAX_CONSECUTIVE_FAILURES = 3;
 const BACKOFF_MULTIPLIER = 5;
 const PRUNE_EVERY_N_FLUSHES = 10;
 const TELEMETRY_CLAIM_TIMEOUT_MS = 10 * 60 * 1_000;
+const DELIVERY_HEALTH_WINDOW_MS = 24 * 60 * 60 * 1_000;
+const MAX_HEALTH_FAILURE_CODE_LENGTH = 24;
+const MAX_PERSISTED_QUEUE_EVENTS = 20_000;
 
 /**
  * Interval used after `failures` consecutive PostHog failures. Pure so the
@@ -501,13 +542,14 @@ async function sendToPostHog(
 	distinctId: string,
 	events: readonly TelemetryEvent[],
 	daemonVersion: string,
-): Promise<boolean> {
+): Promise<PostHogDeliveryResult> {
 	const batch: readonly PostHogBatchEvent[] = events.map((e) => ({
 		event: e.event,
 		distinct_id: distinctId,
 		timestamp: e.timestamp,
 		properties: {
 			...e.properties,
+			$insert_id: e.id,
 			$lib: "signet-daemon",
 			$lib_version: daemonVersion,
 		},
@@ -520,9 +562,12 @@ async function sendToPostHog(
 			body: JSON.stringify({ api_key: apiKey, batch }),
 			signal: AbortSignal.timeout(10000),
 		});
-		return res.ok;
-	} catch {
-		return false;
+		return res.ok ? { ok: true } : { ok: false, failureCode: "http" };
+	} catch (error) {
+		return {
+			ok: false,
+			failureCode: error instanceof DOMException && error.name === "TimeoutError" ? "timeout" : "network",
+		};
 	}
 }
 
@@ -567,44 +612,87 @@ export function createTelemetryCollector(
 	const installChannel = telemetryInstallChannel(config.installChannel, opts.env);
 	let flushTimer: ReturnType<typeof setTimeout> | null = null;
 	let running = false;
-	let flushInFlight: Promise<void> | null = null;
 	let recordingStopped = false;
 	let consecutiveFailures = 0;
 	let flushCount = 0;
 	let effectiveIntervalMs = config.flushIntervalMs;
+	let nextAllowedFlushAt = 0;
+	let droppedEventCount = 0;
+	let pendingDroppedEventCount = 0;
+	let flushPromise: Promise<void> | null = null;
+	let deliveryStatePersistenceFailed = false;
 	const { id: installId, created: installActivated, previousVersion } = getOrCreateInstallId(db, daemonVersion);
 
 	const posthogConfigured = config.posthogHost.length > 0 && config.posthogApiKey.length > 0;
 
-	function addContext(event: TelemetryEventType, properties: TelemetryProperties): TelemetryProperties {
+	function readDeliveryState(): TelemetryDeliveryState {
+		try {
+			const row = db.withReadDb(
+				(r) =>
+					r
+						.prepare(
+							`SELECT window_started_at AS windowStartedAt,
+							success_count AS successCount, failure_count AS failureCount,
+							consecutive_failures AS consecutiveFailures,
+							last_attempt_at AS lastAttemptAt, last_success_at AS lastSuccessAt,
+							last_failure_code AS lastFailureCode,
+							dropped_event_count AS droppedEventCount
+					 FROM telemetry_delivery_state WHERE id = 1`,
+						)
+						.get() as TelemetryDeliveryState | undefined,
+			);
+			if (row) {
+				droppedEventCount = Math.max(droppedEventCount, row.droppedEventCount ?? 0);
+				return row;
+			}
+		} catch {
+			// Test doubles and pre-migration workspaces fall back to in-memory state.
+			deliveryStatePersistenceFailed = true;
+		}
 		return {
-			...properties,
-			deploymentRole,
-			installChannel,
-			...(deployment ? { deployment } : {}),
-			...(typeof properties.version === "string"
-				? { version: telemetryReportedVersion(properties.version, deployment) }
-				: {}),
-			...(typeof properties.from === "string"
-				? {
-						from:
-							event === "version.observed" ? properties.from : telemetryReportedVersion(properties.from, deployment),
-					}
-				: {}),
-			...(typeof properties.to === "string" ? { to: telemetryReportedVersion(properties.to, deployment) } : {}),
+			windowStartedAt: new Date().toISOString(),
+			successCount: 0,
+			failureCount: 0,
+			consecutiveFailures,
+			lastAttemptAt: null,
+			lastSuccessAt: null,
+			lastFailureCode: null,
+			droppedEventCount,
 		};
 	}
+
+	function recordDroppedEvents(count: number): void {
+		droppedEventCount += count;
+		pendingDroppedEventCount += count;
+	}
+
+	function persistPendingDroppedEvents(w: { prepare(sql: string): { run(...args: unknown[]): unknown } }): void {
+		if (pendingDroppedEventCount === 0) return;
+		w.prepare(
+			`UPDATE telemetry_delivery_state
+			 SET dropped_event_count = dropped_event_count + ? WHERE id = 1`,
+		).run(pendingDroppedEventCount);
+		pendingDroppedEventCount = 0;
+	}
+
+	const initialDeliveryState = readDeliveryState();
+	consecutiveFailures = initialDeliveryState.consecutiveFailures;
+	effectiveIntervalMs = nextFlushIntervalMs(config.flushIntervalMs, consecutiveFailures);
+	const lastAttemptMs = initialDeliveryState.lastAttemptAt
+		? Date.parse(initialDeliveryState.lastAttemptAt)
+		: Number.NaN;
+	if (Number.isFinite(lastAttemptMs)) nextAllowedFlushAt = lastAttemptMs + effectiveIntervalMs;
 
 	/**
 	 * Claim and persist a first-use event in one transaction. Only the first
 	 * caller wins (changes === 1); every later call is a no-op, so concurrent
-	 * remembers can't double-fire. Keeping the event in the same transaction
+	 * remembers cannot double-fire. Keeping the event in the same transaction
 	 * as the claim means a process can be terminated before the normal buffer
 	 * flush without losing the milestone.
 	 *
 	 * When the install id fell back to an in-memory value (broken DB), the
-	 * UPDATE matches no row and the milestone never fires — acceptable,
-	 * telemetry is degraded anyway.
+	 * UPDATE matches no row and the milestone never fires. Telemetry is
+	 * degraded anyway.
 	 */
 	function persistFirstUse(kind: FirstUseKind): TelemetryEvent | null {
 		const event: TelemetryEvent = {
@@ -644,14 +732,33 @@ export function createTelemetryCollector(
 		}
 	}
 
-	function writeToDb(events: readonly TelemetryEvent[]): void {
-		if (events.length === 0) return;
+	function addContext(event: TelemetryEventType, properties: TelemetryProperties): TelemetryProperties {
+		return {
+			...properties,
+			deploymentRole,
+			installChannel,
+			...(deployment ? { deployment } : {}),
+			...(typeof properties.version === "string"
+				? { version: telemetryReportedVersion(properties.version, deployment) }
+				: {}),
+			...(typeof properties.from === "string"
+				? {
+						from:
+							event === "version.observed" ? properties.from : telemetryReportedVersion(properties.from, deployment),
+					}
+				: {}),
+			...(typeof properties.to === "string" ? { to: telemetryReportedVersion(properties.to, deployment) } : {}),
+		};
+	}
+
+	function writeToDb(events: readonly TelemetryEvent[]): boolean {
+		if (events.length === 0) return true;
 		try {
 			db.withWriteTx((w) => {
 				const stmt = w.prepare(
 					`INSERT OR IGNORE INTO telemetry_events
-					 (id, event, timestamp, properties, sent_to_posthog, created_at)
-					 VALUES (?, ?, ?, ?, 0, ?)`,
+					 (id, event, timestamp, properties, sent_to_posthog, created_at, source)
+					 VALUES (?, ?, ?, ?, 0, ?, 'daemon')`,
 				);
 				const now = new Date().toISOString();
 				for (const e of events) {
@@ -663,34 +770,137 @@ export function createTelemetryCollector(
 				if (events.some((event) => event.event === "version.observed")) {
 					w.prepare("UPDATE telemetry_install SET last_seen_version = ? WHERE id = ?").run(daemonVersion, installId);
 				}
+				persistPendingDroppedEvents(w);
+				const overflow = w
+					.prepare(
+						`SELECT COUNT(*) AS count FROM telemetry_events
+						 WHERE source = 'daemon' AND sent_to_posthog = 0 AND claim_token IS NULL`,
+					)
+					.get() as { count?: number } | undefined;
+				const dropCount = Math.max(0, (overflow?.count ?? 0) - MAX_PERSISTED_QUEUE_EVENTS);
+				if (dropCount > 0) {
+					w.prepare(
+						`DELETE FROM telemetry_events WHERE id IN (
+						 SELECT id FROM telemetry_events
+						 WHERE source = 'daemon' AND sent_to_posthog = 0 AND claim_token IS NULL
+						 ORDER BY timestamp ASC LIMIT ?
+					 )`,
+					).run(dropCount);
+					w.prepare(
+						"UPDATE telemetry_delivery_state SET dropped_event_count = dropped_event_count + ? WHERE id = 1",
+					).run(dropCount);
+					droppedEventCount += dropCount;
+					logger.warn("telemetry", "Persisted telemetry queue reached capacity", {
+						dropped: dropCount,
+						maxQueueEvents: MAX_PERSISTED_QUEUE_EVENTS,
+					});
+				}
 			});
+			return true;
 		} catch (err) {
 			logger.warn("telemetry", "Failed to write events to db", {
 				error: err instanceof Error ? err.message : String(err),
 			});
+			return false;
 		}
 	}
 
 	function markSent(token: string): void {
+		const now = new Date().toISOString();
+		let stateUpdated = false;
 		try {
 			db.withWriteTx((w) => {
 				w.prepare(
-					"UPDATE telemetry_events SET sent_to_posthog = 1, claim_token = NULL, claimed_at = NULL WHERE claim_token = ?",
-				).run(token);
+					"UPDATE telemetry_events SET sent_to_posthog = 1, sent_at = ?, claim_token = NULL, claimed_at = NULL WHERE claim_token = ?",
+				).run(now, token);
+				const row = w.prepare("SELECT id FROM telemetry_delivery_state WHERE id = 1").get();
+				if (row) {
+					w.prepare(
+						`UPDATE telemetry_delivery_state
+						 SET success_count = CASE WHEN julianday(?) - julianday(window_started_at) >= ? / 86400000.0 THEN 1 ELSE success_count + 1 END,
+						     failure_count = CASE WHEN julianday(?) - julianday(window_started_at) >= ? / 86400000.0 THEN 0 ELSE failure_count END,
+						     window_started_at = CASE WHEN julianday(?) - julianday(window_started_at) >= ? / 86400000.0 THEN ? ELSE window_started_at END,
+						     consecutive_failures = 0, last_attempt_at = ?, last_success_at = ?, last_failure_code = NULL
+						 WHERE id = 1`,
+					).run(
+						now,
+						DELIVERY_HEALTH_WINDOW_MS,
+						now,
+						DELIVERY_HEALTH_WINDOW_MS,
+						now,
+						DELIVERY_HEALTH_WINDOW_MS,
+						now,
+						now,
+						now,
+					);
+					stateUpdated = true;
+				}
 			});
 		} catch {
-			// best effort
+			// Older/partially migrated workspaces still need the event marked sent
+			// after PostHog accepted it; otherwise the claim would be retried.
+			try {
+				db.withWriteTx((w) => {
+					w.prepare(
+						"UPDATE telemetry_events SET sent_to_posthog = 1, claim_token = NULL, claimed_at = NULL WHERE claim_token = ?",
+					).run(token);
+				});
+			} catch {
+				// best effort
+			}
 		}
+		deliveryStatePersistenceFailed = !stateUpdated;
+		consecutiveFailures = 0;
+		effectiveIntervalMs = config.flushIntervalMs;
+		nextAllowedFlushAt = 0;
 	}
 
-	function releaseClaim(token: string): void {
+	function releaseClaim(token: string, failureCode?: string): void {
+		const now = new Date().toISOString();
+		let stateUpdated = false;
 		try {
 			db.withWriteTx((w) => {
-				w.prepare("UPDATE telemetry_events SET claim_token = NULL, claimed_at = NULL WHERE claim_token = ?").run(token);
+				w.prepare(
+					"UPDATE telemetry_events SET last_attempt_at = ?, last_failure_code = ?, claim_token = NULL, claimed_at = NULL WHERE claim_token = ?",
+				).run(now, failureCode?.slice(0, MAX_HEALTH_FAILURE_CODE_LENGTH) ?? "unknown", token);
+				const row = w.prepare("SELECT id FROM telemetry_delivery_state WHERE id = 1").get();
+				if (row) {
+					w.prepare(
+						`UPDATE telemetry_delivery_state
+						 SET failure_count = CASE WHEN julianday(?) - julianday(window_started_at) >= ? / 86400000.0 THEN 1 ELSE failure_count + 1 END,
+						     success_count = CASE WHEN julianday(?) - julianday(window_started_at) >= ? / 86400000.0 THEN 0 ELSE success_count END,
+						     window_started_at = CASE WHEN julianday(?) - julianday(window_started_at) >= ? / 86400000.0 THEN ? ELSE window_started_at END,
+						     consecutive_failures = consecutive_failures + 1, last_attempt_at = ?, last_failure_code = ?
+						 WHERE id = 1`,
+					).run(
+						now,
+						DELIVERY_HEALTH_WINDOW_MS,
+						now,
+						DELIVERY_HEALTH_WINDOW_MS,
+						now,
+						DELIVERY_HEALTH_WINDOW_MS,
+						now,
+						now,
+						failureCode?.slice(0, MAX_HEALTH_FAILURE_CODE_LENGTH) ?? "unknown",
+					);
+					stateUpdated = true;
+				}
 			});
 		} catch {
-			// best effort; stale claims are recoverable on a later flush
+			try {
+				db.withWriteTx((w) => {
+					w.prepare("UPDATE telemetry_events SET claim_token = NULL, claimed_at = NULL WHERE claim_token = ?").run(
+						token,
+					);
+				});
+			} catch {
+				// Stale claims remain recoverable on a later flush.
+			}
 		}
+		deliveryStatePersistenceFailed = !stateUpdated;
+		consecutiveFailures++;
+		effectiveIntervalMs = nextFlushIntervalMs(config.flushIntervalMs, consecutiveFailures);
+		nextAllowedFlushAt = Date.now() + effectiveIntervalMs;
 	}
 
 	function claimUnsent(limit: number): ClaimedTelemetryEvents | null {
@@ -702,6 +912,7 @@ export function createTelemetryCollector(
 				w.prepare(
 					`UPDATE telemetry_events
 					 SET claim_token = ?, claimed_at = ?
+					     , delivery_attempts = delivery_attempts + 1, last_attempt_at = ?
 					 WHERE id IN (
 						 SELECT id FROM telemetry_events
 						 WHERE source = 'daemon' AND sent_to_posthog = 0
@@ -709,7 +920,7 @@ export function createTelemetryCollector(
 						 ORDER BY timestamp ASC
 						 LIMIT ?
 					 )`,
-				).run(token, now.toISOString(), staleBefore, limit);
+				).run(token, now.toISOString(), now.toISOString(), staleBefore, limit);
 				const rows = w
 					.prepare(
 						`SELECT id, event, timestamp, properties
@@ -745,38 +956,145 @@ export function createTelemetryCollector(
 		cutoff.setDate(cutoff.getDate() - config.retentionDays);
 		try {
 			db.withWriteTx((w) => {
-				w.prepare("DELETE FROM telemetry_events WHERE timestamp < ?").run(cutoff.toISOString());
+				// Never prune a row that is still waiting for remote delivery.
+				w.prepare("DELETE FROM telemetry_events WHERE timestamp < ? AND sent_to_posthog = 1").run(cutoff.toISOString());
 			});
 		} catch {
 			// best effort
 		}
 	}
 
-	async function doFlush(): Promise<void> {
+	function ageSec(timestamp: string | null): number | null {
+		if (!timestamp) return null;
+		const parsed = new Date(timestamp).getTime();
+		return Number.isFinite(parsed) ? Math.max(0, (Date.now() - parsed) / 1000) : null;
+	}
+
+	function deliveryHealth(): TelemetryDeliveryHealth {
+		const state = readDeliveryState();
+		let queuedUnsentEventCount = buffer.length;
+		let oldestUnsentTimestamp: string | null = null;
+		let lastDaemonEventTimestamp: string | null = null;
+		try {
+			db.withReadDb((r) => {
+				const queue = r
+					.prepare(
+						`SELECT COUNT(*) AS count, MIN(timestamp) AS oldestTimestamp
+						 FROM telemetry_events WHERE source = 'daemon' AND sent_to_posthog = 0`,
+					)
+					.get() as { count?: number; oldestTimestamp?: string | null } | undefined;
+				queuedUnsentEventCount += queue?.count ?? 0;
+				oldestUnsentTimestamp = queue?.oldestTimestamp ?? null;
+				const latest = r
+					.prepare(
+						"SELECT MAX(timestamp) AS timestamp FROM telemetry_events WHERE source = 'daemon' AND event <> 'telemetry.health'",
+					)
+					.get() as { timestamp?: string | null } | undefined;
+				lastDaemonEventTimestamp = latest?.timestamp ?? null;
+			});
+		} catch {
+			// Keep local in-memory health available when SQLite is unavailable.
+		}
+		const bufferedOldest = buffer[0]?.timestamp ?? null;
+		if (bufferedOldest && (oldestUnsentTimestamp === null || bufferedOldest.localeCompare(oldestUnsentTimestamp) < 0)) {
+			oldestUnsentTimestamp = bufferedOldest;
+		}
+		const bufferedLatest = buffer.at(-1)?.timestamp ?? null;
+		if (
+			bufferedLatest &&
+			(lastDaemonEventTimestamp === null || bufferedLatest.localeCompare(lastDaemonEventTimestamp) > 0)
+		) {
+			lastDaemonEventTimestamp = bufferedLatest;
+		}
+		const windowExpired = Date.now() - new Date(state.windowStartedAt).getTime() >= DELIVERY_HEALTH_WINDOW_MS;
+		const recentSuccesses = windowExpired ? 0 : state.successCount;
+		const recentFailures = windowExpired ? 0 : state.failureCount;
+		const oldestAge = ageSec(oldestUnsentTimestamp);
+		const effectiveConsecutiveFailures = deliveryStatePersistenceFailed
+			? consecutiveFailures
+			: Math.max(state.consecutiveFailures, consecutiveFailures);
+		const degraded =
+			posthogConfigured &&
+			(effectiveConsecutiveFailures > 0 ||
+				recentFailures > 0 ||
+				(oldestAge !== null && oldestAge > (effectiveIntervalMs / 1000) * 2));
+		return {
+			status: !posthogConfigured ? "local-only" : degraded ? "degraded" : "healthy",
+			deliveryConfigured: posthogConfigured,
+			bufferedEventCount: buffer.length,
+			queuedUnsentEventCount,
+			oldestUnsentEventAgeSec: oldestAge,
+			lastDaemonEventAgeSec: ageSec(lastDaemonEventTimestamp),
+			lastAttemptAgeSec: ageSec(state.lastAttemptAt),
+			lastSuccessfulDeliveryAgeSec: ageSec(state.lastSuccessAt),
+			recentDeliverySuccessCount: recentSuccesses,
+			recentDeliveryFailureCount: recentFailures,
+			consecutiveFailures: effectiveConsecutiveFailures,
+			backoffActive: effectiveConsecutiveFailures >= MAX_CONSECUTIVE_FAILURES,
+			droppedEventCount: Math.max(droppedEventCount, state.droppedEventCount),
+			flushIntervalMs: effectiveIntervalMs,
+		};
+	}
+
+	function appendBufferedEvent(event: TelemetryEventType, properties: TelemetryProperties): void {
+		if (recordingStopped) return;
+		if (buffer.length >= MAX_BUFFER_EVENTS) {
+			const dropCount = buffer.length - MAX_BUFFER_EVENTS + 1;
+			buffer.splice(0, dropCount);
+			recordDroppedEvents(dropCount);
+			logger.warn("telemetry", "Buffer exceeded max capacity, dropping oldest events", {
+				dropped: dropCount,
+				maxBufferEvents: MAX_BUFFER_EVENTS,
+			});
+		}
+		const next: TelemetryEvent = {
+			id: crypto.randomUUID(),
+			event,
+			timestamp: new Date().toISOString(),
+			properties: addContext(event, enrichSessionEvent(event, properties)),
+		};
+		buffer.push(next);
+		if (logPath) appendToTelemetryLog(logPath, JSON.stringify(next));
+	}
+
+	function drainBuffer(): void {
+		const pending = buffer.splice(0, buffer.length);
+		if (writeToDb(pending)) return;
+		// Preserve events for a later attempt when SQLite is temporarily locked.
+		buffer.unshift(...pending);
+		if (buffer.length > MAX_BUFFER_EVENTS) {
+			const dropped = buffer.length - MAX_BUFFER_EVENTS;
+			buffer.splice(0, dropped);
+			recordDroppedEvents(dropped);
+		}
+	}
+
+	async function doFlush(emitHealth: boolean, allowRemote = true): Promise<void> {
 		flushCount++;
 		// Drain buffer to SQLite
-		const pending = buffer.splice(0, buffer.length);
-		writeToDb(pending);
+		drainBuffer();
+		if (emitHealth) {
+			// Snapshot before adding this diagnostic event. Its local value must not
+			// depend on the success of the request that carries the snapshot.
+			appendBufferedEvent("telemetry.health", { ...deliveryHealth() });
+			drainBuffer();
+		}
 
 		// Send to PostHog if configured
-		if (posthogConfigured) {
+		if (allowRemote && posthogConfigured) {
 			const claimed = claimUnsent(config.flushBatchSize);
 			if (claimed) {
-				const ok = await sendToPostHog(
+				const result = await sendToPostHog(
 					config.posthogHost,
 					config.posthogApiKey,
 					installId,
 					claimed.events,
 					reportedVersion,
 				);
-				if (ok) {
+				if (result.ok) {
 					markSent(claimed.token);
-					consecutiveFailures = 0;
-					effectiveIntervalMs = config.flushIntervalMs;
 				} else {
-					releaseClaim(claimed.token);
-					consecutiveFailures++;
-					effectiveIntervalMs = nextFlushIntervalMs(config.flushIntervalMs, consecutiveFailures);
+					releaseClaim(claimed.token, result.failureCode);
 					if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
 						logger.warn("telemetry", "PostHog unreachable, backing off", {
 							intervalMs: effectiveIntervalMs,
@@ -792,13 +1110,27 @@ export function createTelemetryCollector(
 		}
 	}
 
-	/** Serialize timer, threshold, explicit, and shutdown flushes. */
-	function flush(): Promise<void> {
-		if (flushInFlight) return flushInFlight;
-		flushInFlight = doFlush().finally(() => {
-			flushInFlight = null;
-		});
-		return flushInFlight;
+	function flushInternal(emitHealth: boolean, force = false): Promise<void> {
+		if (flushPromise) return flushPromise;
+		if (!force && Date.now() < nextAllowedFlushAt) {
+			// Backoff suppresses network claims, not local durability. Persist the
+			// in-memory buffer so an outage cannot exhaust RAM or lose events;
+			// retain local health/pruning maintenance while skipping PostHog.
+			flushPromise = doFlush(emitHealth, false)
+				.catch(() => {})
+				.finally(() => {
+					flushPromise = null;
+				});
+			return flushPromise;
+		}
+		flushPromise = doFlush(emitHealth)
+			.catch(() => {
+				// Telemetry must never surface a flush failure to the daemon.
+			})
+			.finally(() => {
+				flushPromise = null;
+			});
+		return flushPromise;
 	}
 
 	function sessionKeyFor(properties: TelemetryProperties): string | null {
@@ -874,57 +1206,24 @@ export function createTelemetryCollector(
 		return cost ? { ...properties, ...sessionCostProperties(cost) } : properties;
 	}
 
-	function recordEvent(
-		event: TelemetryEventType,
-		properties: TelemetryProperties,
-		options: { readonly persistAuditLog: boolean; readonly flushWhenFull: boolean },
-	): void {
-		if (recordingStopped) return;
-		if (buffer.length >= MAX_BUFFER_EVENTS) {
-			const dropCount = buffer.length - MAX_BUFFER_EVENTS + 1;
-			buffer.splice(0, dropCount);
-			if (options.persistAuditLog) {
-				logger.warn("telemetry", "Buffer exceeded max capacity, dropping oldest events", {
-					dropped: dropCount,
-					maxBufferEvents: MAX_BUFFER_EVENTS,
-				});
-			}
-		}
-
-		buffer.push({
-			id: crypto.randomUUID(),
-			event,
-			timestamp: new Date().toISOString(),
-			properties: addContext(event, enrichSessionEvent(event, properties)),
-		});
-		if (options.persistAuditLog && logPath) {
-			const last = buffer[buffer.length - 1];
-			if (last) {
-				appendToTelemetryLog(logPath, JSON.stringify(last));
-			}
-		}
-
-		// Deferred records skip the eager flush. Calling doFlush here would
-		// synchronously enter SQLite before its first await, defeating the wedge
-		// path's non-blocking guarantee.
-		if (options.flushWhenFull && buffer.length >= MAX_BUFFER_SIZE) {
-			flush().catch(() => {});
-		}
-	}
-
 	const collector: TelemetryCollector = {
 		enabled: true,
 		reopenSession,
+		deliveryHealth,
 		anonymizeAgentId(agentId: string): string {
 			return createHash("sha256").update(`${agentId}:${installId}`).digest("hex").slice(0, 16);
 		},
 
 		record(event, properties): void {
-			recordEvent(event, properties, { persistAuditLog: true, flushWhenFull: true });
+			appendBufferedEvent(event, properties);
+
+			if (buffer.length >= MAX_BUFFER_SIZE) {
+				void flushInternal(false);
+			}
 		},
 
 		recordDeferred(event, properties): void {
-			recordEvent(event, properties, { persistAuditLog: true, flushWhenFull: false });
+			appendBufferedEvent(event, properties);
 		},
 
 		recordFirstUse(kind): void {
@@ -936,7 +1235,7 @@ export function createTelemetryCollector(
 		},
 
 		async flush(): Promise<void> {
-			await flush();
+			await flushInternal(false, true);
 		},
 
 		start(): void {
@@ -945,12 +1244,11 @@ export function createTelemetryCollector(
 
 			function scheduleFlush(): void {
 				if (!running) return;
+				const delayMs = nextAllowedFlushAt > Date.now() ? nextAllowedFlushAt - Date.now() : effectiveIntervalMs;
 				flushTimer = setTimeout(() => {
 					flushTimer = null;
-					flush()
-						.catch(() => {})
-						.finally(() => scheduleFlush());
-				}, effectiveIntervalMs);
+					flushInternal(true).finally(() => scheduleFlush());
+				}, delayMs);
 			}
 
 			scheduleFlush();
@@ -966,16 +1264,12 @@ export function createTelemetryCollector(
 				clearTimeout(flushTimer);
 				flushTimer = null;
 			}
-			try {
-				await flush();
-			} catch {}
-			// Stop accepting new events only after the first flush has completed,
-			// so events produced while an outbound request was awaiting are
-			// drained by this final serialized flush.
+			await flushInternal(true, true);
+			// Stop accepting new events only after the first drain completes,
+			// so events recorded while an outbound request was awaiting are
+			// included in this final serialized drain.
 			recordingStopped = true;
-			try {
-				await flush();
-			} catch {}
+			await flushInternal(true, true);
 			logger.info("telemetry", "Telemetry collector stopped");
 		},
 

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -34,6 +34,14 @@ export function defaultTelemetryLogPath(agentsDir: string): string {
 	return join(agentsDir, ".daemon", "telemetry", "events.jsonl");
 }
 
+/** Parse both ISO timestamps and SQLite's UTC `CURRENT_TIMESTAMP` format. */
+export function parseTelemetryTimestamp(timestamp: string): number {
+	const normalized = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(timestamp)
+		? `${timestamp.replace(" ", "T")}Z`
+		: timestamp;
+	return Date.parse(normalized);
+}
+
 function appendToTelemetryLog(logPath: string | null, line: string): void {
 	if (!logPath) return;
 	try {
@@ -679,7 +687,7 @@ export function createTelemetryCollector(
 	consecutiveFailures = initialDeliveryState.consecutiveFailures;
 	effectiveIntervalMs = nextFlushIntervalMs(config.flushIntervalMs, consecutiveFailures);
 	const lastAttemptMs = initialDeliveryState.lastAttemptAt
-		? Date.parse(initialDeliveryState.lastAttemptAt)
+		? parseTelemetryTimestamp(initialDeliveryState.lastAttemptAt)
 		: Number.NaN;
 	if (Number.isFinite(lastAttemptMs)) nextAllowedFlushAt = lastAttemptMs + effectiveIntervalMs;
 
@@ -966,7 +974,7 @@ export function createTelemetryCollector(
 
 	function ageSec(timestamp: string | null): number | null {
 		if (!timestamp) return null;
-		const parsed = new Date(timestamp).getTime();
+		const parsed = parseTelemetryTimestamp(timestamp);
 		return Number.isFinite(parsed) ? Math.max(0, (Date.now() - parsed) / 1000) : null;
 	}
 
@@ -1006,7 +1014,7 @@ export function createTelemetryCollector(
 		) {
 			lastDaemonEventTimestamp = bufferedLatest;
 		}
-		const windowExpired = Date.now() - new Date(state.windowStartedAt).getTime() >= DELIVERY_HEALTH_WINDOW_MS;
+		const windowExpired = Date.now() - parseTelemetryTimestamp(state.windowStartedAt) >= DELIVERY_HEALTH_WINDOW_MS;
 		const recentSuccesses = windowExpired ? 0 : state.successCount;
 		const recentFailures = windowExpired ? 0 : state.failureCount;
 		const oldestAge = ageSec(oldestUnsentTimestamp);

--- a/surfaces/cli/src/features/telemetry.test.ts
+++ b/surfaces/cli/src/features/telemetry.test.ts
@@ -224,6 +224,7 @@ describe("cli telemetry (issue #1280)", () => {
 			command: "remember",
 			deploymentRole: "unknown",
 			installChannel: "unknown",
+			$insert_id: expect.any(String),
 			$lib: "signet-cli",
 			$lib_version: "0.176.8",
 		});

--- a/surfaces/cli/src/features/telemetry.ts
+++ b/surfaces/cli/src/features/telemetry.ts
@@ -25,6 +25,7 @@ import { createDatabase } from "../sqlite.js";
 export const TELEMETRY_EVENT = "command.invoked";
 const TELEMETRY_FLUSH_TIMEOUT_MS = 2_000;
 const TELEMETRY_CLAIM_TIMEOUT_MS = 10 * 60 * 1_000;
+const MAX_CLI_PENDING_EVENTS = 5_000;
 const MIN_BATCH_SIZE = 1;
 const MAX_BATCH_SIZE = 500;
 
@@ -187,8 +188,19 @@ function queueCommandEvent(agentsDir: string, event: QueuedEvent): void {
 		db.prepare(
 			`INSERT OR IGNORE INTO telemetry_events
 			 (id, event, timestamp, properties, sent_to_posthog, created_at, source)
-			 VALUES (?, ?, ?, ?, 0, ?, 'cli')`,
+				VALUES (?, ?, ?, ?, 0, ?, 'cli')`,
 		).run(event.id, event.event, event.timestamp, JSON.stringify(event.properties), new Date().toISOString());
+		// CLI commands can continue to run while the daemon or PostHog is down.
+		// Keep the shared durable queue bounded without touching daemon-owned rows.
+		db.prepare(
+			`DELETE FROM telemetry_events
+			 WHERE source = 'cli' AND sent_to_posthog = 0 AND claim_token IS NULL
+			   AND id NOT IN (
+				   SELECT id FROM telemetry_events
+				   WHERE source = 'cli' AND sent_to_posthog = 0 AND claim_token IS NULL
+				   ORDER BY timestamp DESC LIMIT ?
+			   )`,
+		).run(MAX_CLI_PENDING_EVENTS);
 	} catch {
 		// Older workspaces may not have the telemetry migrations yet.
 	} finally {
@@ -316,6 +328,7 @@ export async function flushCliTelemetry(
 			timestamp: row.timestamp,
 			properties: {
 				...(JSON.parse(row.properties) as Record<string, string | number | boolean | null>),
+				$insert_id: row.id,
 				$lib: "signet-cli",
 				$lib_version: cliVersion,
 			},

--- a/surfaces/dashboard/DASHBOARD_API_MAP.md
+++ b/surfaces/dashboard/DASHBOARD_API_MAP.md
@@ -164,6 +164,7 @@ native `EventSource` with headers, so auth is pumped manually).
 | `getBlackBoxSessions` / `getBlackBoxSession` | GET 🔐 | `/api/sessions/blackbox{,/{key}}` | Black-box session traces |
 | `toggleSessionBypass` | POST | `/api/sessions/{key}/bypass` | Toggle hook bypass |
 | Logs | GET (SSE) | `/api/logs/stream` | Live log tail (`AuthEventStream`) |
+| `getTelemetryHealth` | GET 🔐 | `/api/telemetry/health` | Privacy-safe collector queue and delivery health |
 | Presence | GET | `/api/cross-agent/presence` | Cross-agent presence (issue #944) |
 | `fetchChangelog` / `fetchRoadmap` / `fetchReadme` | GET | `/api/changelog`, `/api/roadmap`, `/api/readme` | Docs tabs (+ raw GitHub fetch) |
 

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -198,6 +198,25 @@ export interface LogEntry {
 	data?: Record<string, unknown>;
 }
 
+export interface TelemetryHealth {
+	status: "healthy" | "degraded" | "local-only";
+	deliveryConfigured: boolean;
+	bufferedEventCount: number;
+	queuedUnsentEventCount: number;
+	oldestUnsentEventAgeSec: number | null;
+	lastDaemonEventAgeSec: number | null;
+	lastAttemptAgeSec: number | null;
+	lastSuccessfulDeliveryAgeSec: number | null;
+	recentDeliverySuccessCount: number;
+	recentDeliveryFailureCount: number;
+	consecutiveFailures: number;
+	backoffActive: boolean;
+	droppedEventCount: number;
+	flushIntervalMs: number;
+}
+
+export type TelemetryHealthResponse = { enabled: false } | ({ enabled: true } & TelemetryHealth);
+
 // 1Password service-account integration (daemon routes/secrets-routes.ts).
 export interface OnePasswordVault {
 	id: string;
@@ -835,6 +854,7 @@ export const api = {
 
 	// Daemon logs (settings → Logs section)
 	getLogs: (limit = 200) => getJSON<{ logs: LogEntry[]; count: number }>(`/api/logs?limit=${limit}`),
+	getTelemetryHealth: () => getJSON<TelemetryHealthResponse>("/api/telemetry/health"),
 };
 
 // postJSON is exported for future mutation surfaces (review-queue apply/reject,

--- a/surfaces/dashboard/src/lib/demo.ts
+++ b/surfaces/dashboard/src/lib/demo.ts
@@ -32,6 +32,7 @@ import type {
 	MemoryTimeline,
 	OnePasswordStatus,
 	SourcesResponse,
+	TelemetryHealth,
 	TodayReflectionResponse,
 } from "./api";
 
@@ -566,6 +567,24 @@ const demoLogs: { logs: LogEntry[]; count: number } = {
 	],
 };
 
+const demoTelemetryHealth: { enabled: true } & TelemetryHealth = {
+	enabled: true,
+	status: "healthy",
+	deliveryConfigured: true,
+	bufferedEventCount: 0,
+	queuedUnsentEventCount: 0,
+	oldestUnsentEventAgeSec: null,
+	lastDaemonEventAgeSec: 21,
+	lastAttemptAgeSec: 21,
+	lastSuccessfulDeliveryAgeSec: 21,
+	recentDeliverySuccessCount: 84,
+	recentDeliveryFailureCount: 0,
+	consecutiveFailures: 0,
+	backoffActive: false,
+	droppedEventCount: 0,
+	flushIntervalMs: 60_000,
+};
+
 const demoOnePassword: OnePasswordStatus = {
 	configured: false,
 	connected: false,
@@ -613,6 +632,7 @@ export function installDemoApi(target: ApiClient): void {
 	target.pickDirectory = async () => ({ ok: false, unavailable: true });
 	target.getSourceSnapshot = async () => null;
 	target.getLogs = async () => demoLogs;
+	target.getTelemetryHealth = async () => demoTelemetryHealth;
 	target.getConfigFiles = async () => [];
 	target.getOnePasswordStatus = async () => demoOnePassword;
 }

--- a/surfaces/dashboard/src/views/settings.tsx
+++ b/surfaces/dashboard/src/views/settings.tsx
@@ -1047,6 +1047,52 @@ function formatLogTime(ts: string): string {
 	return `${base}.${String(d.getMilliseconds()).padStart(3, "0")}`;
 }
 
+function formatAge(seconds: number | null): string {
+	if (seconds === null) return "never";
+	if (seconds < 60) return `${Math.round(seconds)}s ago`;
+	if (seconds < 3600) return `${Math.round(seconds / 60)}m ago`;
+	return `${Math.round(seconds / 3600)}h ago`;
+}
+
+function TelemetryHealthPanel() {
+	const healthQuery = useAsync(() => api.getTelemetryHealth(), { intervalMs: 30_000 });
+	const health = healthQuery.data;
+	const status = !health ? "unavailable" : !health.enabled ? "disabled" : health.status;
+	const statusClass =
+		status === "healthy"
+			? "text-success"
+			: status === "degraded"
+				? "text-[oklch(0.78_0.15_85)]"
+				: "text-muted-foreground";
+	return (
+		<div className="mb-3 rounded-[var(--radius)] border border-[oklch(1_0_0/0.08)] bg-[color-mix(in_oklch,var(--foreground)_3%,transparent)] px-3 py-2.5 [html:not(.dark)_&]:border-[oklch(0_0_0/0.08)]">
+			<div className="flex items-center justify-between gap-3">
+				<GroupLabel suffix="local queue + remote delivery">Telemetry delivery</GroupLabel>
+				<span className={cn("font-mono text-[9.5px] font-semibold uppercase", statusClass)}>{status}</span>
+			</div>
+			{health?.enabled ? (
+				<div className="grid grid-cols-2 gap-1.5 sm:grid-cols-4">
+					<HealthMeta label="Daemon activity" value={formatAge(health.lastDaemonEventAgeSec)} />
+					<HealthMeta label="Queued" value={String(health.queuedUnsentEventCount)} />
+					<HealthMeta label="Last delivery" value={formatAge(health.lastSuccessfulDeliveryAgeSec)} />
+					<HealthMeta label="Recent failures" value={String(health.recentDeliveryFailureCount)} />
+				</div>
+			) : (
+				<div className="font-mono text-[10px] text-muted-foreground">Collector health is unavailable from this daemon.</div>
+			)}
+		</div>
+	);
+}
+
+function HealthMeta({ label, value }: { label: string; value: string }) {
+	return (
+		<div className="rounded-[var(--radius)] bg-[color-mix(in_oklch,var(--foreground)_4%,transparent)] px-2 py-1.5">
+			<div className="font-mono text-[8px] uppercase tracking-[0.06em] text-muted-foreground">{label}</div>
+			<div className="mt-0.5 truncate font-mono text-[10px] font-medium">{value}</div>
+		</div>
+	);
+}
+
 function LogsSection() {
 	const [level, setLevel] = useState<LogLevel | "all">("all");
 	const [query, setQuery] = useState("");
@@ -1077,6 +1123,7 @@ function LogsSection() {
 
 	return (
 		<div className="-m-5 flex h-full flex-col">
+			<TelemetryHealthPanel />
 			<div className="flex items-center gap-2.5 border-b border-[oklch(1_0_0/0.06)] px-6 pb-3 pt-1.5 [html:not(.dark)_&]:border-[oklch(0_0_0/0.06)]">
 				<button
 					type="button"

--- a/web/docs/src/content/docs/api/route-inventory.md
+++ b/web/docs/src/content/docs/api/route-inventory.md
@@ -141,6 +141,7 @@ silently disappear from the API reference.
 | POST | `/api/sessions/:key/renew` | platform/daemon/src/routes/session-routes.ts |
 | GET | `/api/skills/browse` | platform/daemon/src/routes/skills.ts |
 | GET | `/api/telemetry/memory-search` | platform/daemon/src/routes/telemetry-routes.ts |
+| GET | `/api/telemetry/health` | platform/daemon/src/routes/telemetry-routes.ts |
 | GET | `/api/telemetry/memory-search/export` | platform/daemon/src/routes/telemetry-routes.ts |
 | POST | `/api/os/widget/generate` | platform/daemon/src/routes/widget.ts |
 | GET | `/api/os/widget/:id` | platform/daemon/src/routes/widget.ts |

--- a/web/docs/src/content/docs/api/telemetry-logs.md
+++ b/web/docs/src/content/docs/api/telemetry-logs.md
@@ -172,6 +172,38 @@ Query raw telemetry events.
 }
 ```
 
+### GET /api/telemetry/health
+
+Returns a bounded, payload-free summary of the daemon collector. This route
+requires `analytics` permission and is also the dashboard's source for
+distinguishing daemon silence from a delivery outage.
+
+```json
+{
+  "enabled": true,
+  "status": "degraded",
+  "deliveryConfigured": true,
+  "bufferedEventCount": 0,
+  "queuedUnsentEventCount": 12,
+  "oldestUnsentEventAgeSec": 184,
+  "lastDaemonEventAgeSec": 9,
+  "lastSuccessfulDeliveryAgeSec": 902,
+  "recentDeliverySuccessCount": 31,
+  "recentDeliveryFailureCount": 3,
+  "consecutiveFailures": 3,
+  "backoffActive": true,
+  "droppedEventCount": 0,
+  "flushIntervalMs": 300000
+}
+```
+
+`status` is `local-only` when no remote sink is configured, `healthy` when
+delivery is current, and `degraded` when delivery is failing or an unsent
+queue is aging. `enabled: false` means the daemon collector is disabled. Age
+values are seconds and may be `null` when no event or successful delivery has
+ever been observed. The response never includes install identifiers, endpoint
+credentials, paths, event properties, response bodies, or user identity.
+
 Inference emits additional local-first telemetry events:
 
 - `inference.route`

--- a/web/docs/src/content/docs/api/telemetry-logs.md
+++ b/web/docs/src/content/docs/api/telemetry-logs.md
@@ -155,7 +155,7 @@ Query raw telemetry events.
 | `event`   | string  | Filter by event type (e.g., `llm.generate`)    |
 | `since`   | string  | ISO timestamp lower bound                      |
 | `until`   | string  | ISO timestamp upper bound                      |
-| `limit`   | integer | Max events (default: 100)                      |
+| `limit`   | integer | Max events (default: 100, clamped to 1-10000)  |
 
 **Response**
 
@@ -408,7 +408,7 @@ Export raw telemetry events as newline-delimited JSON (NDJSON).
 | Parameter | Type    | Description                           |
 |-----------|---------|---------------------------------------|
 | `since`   | string  | ISO timestamp lower bound (optional)  |
-| `limit`   | integer | Max events (default: 10000)           |
+| `limit`   | integer | Max events (default: 10000, clamped to 1-100000) |
 
 **Response** — `Content-Type: application/x-ndjson`. Each line is a
 JSON-serialized telemetry event. Returns `404` if telemetry is not enabled.


### PR DESCRIPTION
## Summary

Replacement for #1292. Carries the telemetry delivery health feature with the collector-contract and migration corrections required for a buildable, durable implementation.

## Changes

- Restore the existing `recordDeferred` wedge-path contract and synchronous JSONL behavior.
- Restore `recall.attempted` and `recall.outcome` event types consumed by recall telemetry and route statistics.
- Persist first-use milestone claims and their events in one SQLite transaction, preserving crash recovery.
- Register the delivery-health migration as version 121 because main already owns version 120 and update its import and test description.
- Preserve the delivery-health API, dashboard panel, bounded queues, retry metadata, and documentation from #1292.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [x] `@signet/web`
- [ ] `predictor`
- [ ] Other: telemetry contract and migration metadata

## Screenshots

The dashboard Logs-panel telemetry card is carried from #1292. No additional visual changes were made in the correction commit.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

Migration 121 is additive and idempotent. It adds delivery metadata columns and a singleton delivery-state table. Existing telemetry rows remain intact. There is no destructive down migration. Rollback is the normal pre-migration SQLite backup/restore path.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused verification passed:

- `bun test platform/daemon/src/telemetry.test.ts` — 35 pass
- `bun test platform/daemon/src/recall-telemetry.test.ts` — 3 pass
- `bun test platform/core/src/migrations/migrations.test.ts` — 62 pass
- `bun test surfaces/cli/src/features/telemetry.test.ts` — 17 pass
- `bun run --filter '@signet/core' build` — pass
- `bun run --filter '@signet/daemon' typecheck` — pass
- `bun run --filter '@signet/daemon' build` — pass
- `bunx biome check` on the changed telemetry surfaces — pass
- `git diff --check` — pass

Repository-wide `bun run typecheck` and `bun run lint` were also attempted. They retain unrelated baseline failures in connector packages and repository-wide Biome drift. The changed core and daemon surfaces pass their package gates.

Mutation verification passed: reverting atomic first-use persistence made `recovers first-use events after termination before the normal flush` fail, and disabling `recordDeferred` made `persists wedge events to the local audit log before normal flush` fail. Restoring the fix returned the telemetry suite to 35 pass, 0 fail.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This replacement supersedes #1292 because the original fork branch does not accept maintainer updates. The original feature implementation remains otherwise unchanged. The correction commit is `fix(telemetry): preserve collector contracts`.


