### PR TITLE
feat(dashboard): wire dreaming review suggestions

### DIFF
--- a/platform/daemon/src/pipeline/dreaming-operations.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
+import { applyOntologyProposal, getOntologyProposal, rejectOntologyProposal } from "../ontology-proposals";
 import { type DreamingOperationRequest, applyDreamingOperations } from "./dreaming-operations";
 
 describe("dreaming operations", () => {
@@ -58,6 +59,23 @@ describe("dreaming operations", () => {
 		return { operation: "flag", payload: operation };
 	}
 
+	function reviewLinkOperation(): DreamingOperationRequest {
+		return {
+			operation: "create_link",
+			payload: { fromEntityId: "e-source", toEntityId: "e-target", linkType: "supports_claim" },
+			reason: "Local-first and hosted inference may be two deployment modes. Link them?",
+			risk: "review_required",
+			evidence: [
+				{
+					source_ref: "memory:m-review",
+					source_kind: "manual",
+					source_id: "m-review",
+					quote: "Local-first and hosted inference may be two deployment modes.",
+				},
+			],
+		};
+	}
+
 	it("mints hygiene attention for a flag op and returns the id", () => {
 		insertEntity("e-husk", "Legacy Husk", "legacy husk");
 		const result = applyDreamingOperations({
@@ -81,6 +99,80 @@ describe("dreaming operations", () => {
 				db.prepare("SELECT COUNT(*) AS c FROM dreaming_attention WHERE resolved_at IS NULL").get() as { c: number },
 		);
 		expect(pending.c).toBe(1);
+	});
+
+	it("escalates review-required content operations without mutating the ontology", () => {
+		insertEntity("e-source", "Local-first", "local-first");
+		insertEntity("e-target", "Hosted inference", "hosted inference");
+		insertEpisodicMemory("m-review", "Local-first and hosted inference may be two deployment modes.");
+		const result = applyDreamingOperations({
+			accessor: getDbAccessor(),
+			agentId: "agent-a",
+			actor: "dreaming",
+			operations: [reviewLinkOperation()],
+		});
+		expect(result.ok).toBe(true);
+		expect((result.items[0]?.result as { reviewRequired?: boolean }).reviewRequired).toBe(true);
+		const proposalId = (result.items[0]?.proposal as { id: string }).id;
+		expect(getOntologyProposal(getDbAccessor(), proposalId, "agent-a")).toMatchObject({
+			operation: "create_link",
+			status: "pending",
+			risk: "review_required",
+		});
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db.prepare("SELECT COUNT(*) AS c FROM entity_dependencies WHERE agent_id = ?").get("agent-a") as {
+						c: number;
+					},
+			),
+		).toEqual({ c: 0 });
+		const applied = applyOntologyProposal(getDbAccessor(), {
+			agentId: "agent-a",
+			id: proposalId,
+			actor: "dashboard",
+		});
+		expect(applied.status).toBe("applied");
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db.prepare("SELECT COUNT(*) AS c FROM entity_dependencies WHERE agent_id = ?").get("agent-a") as {
+						c: number;
+					},
+			),
+		).toEqual({ c: 1 });
+	});
+
+	it("deduplicates repeated review-required operations and honors a rejection", () => {
+		insertEntity("e-source", "Local-first", "local-first");
+		insertEntity("e-target", "Hosted inference", "hosted inference");
+		insertEpisodicMemory("m-review", "Local-first and hosted inference may be two deployment modes.");
+		const run = () =>
+			applyDreamingOperations({
+				accessor: getDbAccessor(),
+				agentId: "agent-a",
+				actor: "dreaming",
+				operations: [reviewLinkOperation()],
+			});
+		const first = run();
+		const proposalId = (first.items[0]?.proposal as { id: string }).id;
+		const second = run();
+		expect((second.items[0]?.result as { deduped?: boolean }).deduped).toBe(true);
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db.prepare("SELECT COUNT(*) AS c FROM ontology_proposals WHERE agent_id = ?").get("agent-a") as { c: number },
+			),
+		).toEqual({ c: 1 });
+		rejectOntologyProposal(getDbAccessor(), {
+			agentId: "agent-a",
+			id: proposalId,
+			actor: "dashboard",
+			reason: "Not the same relationship",
+		});
+		const third = run();
+		expect((third.items[0]?.result as { deduped?: boolean }).deduped).toBe(true);
+		expect(getOntologyProposal(getDbAccessor(), proposalId, "agent-a")).toMatchObject({ status: "rejected" });
 	});
 
 	it("archives a flagged entity in the same batch via attention:$<index>", () => {
@@ -214,7 +306,6 @@ describe("dreaming operations", () => {
 			getDbAccessor().withReadDb((db) => db.prepare("SELECT id FROM entities WHERE id = ?").get("e-target")),
 		).not.toBeNull();
 	});
-
 
 	it("rejects a merge_aspects whose details aspectId contradicts the flagged subjectRef", () => {
 		insertEntity("e-merge3", "MergeThree", "mergethree");

--- a/platform/daemon/src/pipeline/dreaming-operations.ts
+++ b/platform/daemon/src/pipeline/dreaming-operations.ts
@@ -1,10 +1,11 @@
 import { SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES } from "@signet/core";
-import type { DbAccessor, ReadDb } from "../db-accessor";
+import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
 import { findEpisodicSourceAgentIds, readEpisodicSource } from "../episodic-sources";
 import {
 	type GraphWriteCaps,
 	type OntologyOperationInput,
 	applyOntologyOperationBatchInTx,
+	createOntologyProposalsInTx,
 } from "../ontology-proposals";
 import { type DreamingAttention, enqueueDreamingAttentionInTx, getDreamingAttentionById } from "./dreaming-attention";
 import { type DreamingAgentEvidence, createDreamingAgentEvidence } from "./dreaming-evidence";
@@ -535,6 +536,28 @@ function toApplicatorPayload(
 	}
 }
 
+function existingReviewProposalId(
+	db: WriteDb,
+	params: {
+		readonly agentId: string;
+		readonly operation: string;
+		readonly payload: Readonly<Record<string, unknown>>;
+		readonly evidence: readonly unknown[];
+	},
+): string | null {
+	const row = db
+		.prepare(
+			`SELECT id FROM ontology_proposals
+			 WHERE agent_id = ? AND operation = ? AND status IN ('pending', 'applied', 'rejected')
+			   AND payload = ? AND evidence = ?
+			 ORDER BY updated_at DESC LIMIT 1`,
+		)
+		.get(params.agentId, params.operation, JSON.stringify(params.payload), JSON.stringify(params.evidence)) as
+		| { id?: unknown }
+		| undefined;
+	return typeof row?.id === "string" ? row.id : null;
+}
+
 /**
  * The sole daemon-owned apply seam for Dreaming agents. Flag ops mint hygiene
  * attention in-batch; hygiene archives/merges cite attention provenance;
@@ -570,6 +593,8 @@ export function applyDreamingOperations(params: {
 		readonly attentionId: string | null;
 		/** Queue-only op that resolves its cited attention record instead of an ontology write. */
 		readonly decline?: boolean;
+		/** Content operation was escalated for an explicit user decision. */
+		readonly reviewOnly?: boolean;
 	}> = [];
 	for (let index = 0; index < params.operations.length; index += 1) {
 		const operation = params.operations[index]!;
@@ -631,6 +656,7 @@ export function applyDreamingOperations(params: {
 				sourceRoot: provenance.sourceRoot,
 			},
 			attentionId,
+			reviewOnly: operation.risk === "review_required" && !HYGIENE_ARCHIVE_OPS.has(operation.operation),
 		});
 	}
 
@@ -667,6 +693,41 @@ export function applyDreamingOperations(params: {
 				}
 				// flag op: nothing to apply; surface the minted attention id
 				items.push({ index, ok: true, result: { attentionId: entry.attentionId } });
+				continue;
+			}
+			if (entry.reviewOnly) {
+				const existingId = existingReviewProposalId(db, {
+					agentId: params.agentId,
+					operation: entry.input.operation,
+					payload: entry.input.payload,
+					evidence: entry.input.evidence ?? [],
+				});
+				if (existingId !== null) {
+					items.push({ index, ok: true, result: { reviewRequired: true, deduped: true, proposalId: existingId } });
+					continue;
+				}
+				const created = createOntologyProposalsInTx(db, [
+					{
+						agentId: params.agentId,
+						operation: entry.input.operation,
+						payload: entry.input.payload,
+						confidence: entry.input.confidence,
+						rationale: entry.input.reason,
+						evidence: entry.input.evidence,
+						risk: entry.input.risk,
+						sourceKind: entry.input.sourceKind,
+						sourceId: entry.input.sourceId,
+						sourcePath: entry.input.sourcePath,
+						sourceRoot: entry.input.sourceRoot,
+						createdBy: params.actor,
+					},
+				]);
+				items.push({
+					index,
+					ok: true,
+					proposal: created.items[0],
+					result: { reviewRequired: true },
+				});
 				continue;
 			}
 			if (entry.attentionId !== null) {

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -704,6 +704,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - Before adding a claim, check the target aspect's existing claims; if one covers the same key or is contradicted by the new evidence, supersede it (supersede_claim_value) instead of adding alongside.
    - The evidence source and the graph target must use the same agent scope: search evidence with the agentId of the entity you will update, then pass that same agentId to apply_ontology_ops. A source found in another scope cannot support a write here.
    - create_entity only for durable subjects clearly established by the source.
+   - When the evidence supports a possible relationship, merge, or other ontology change but the relationship is ambiguous rather than settled, do not apply it immediately. Emit the normal ontology operation with risk: "review_required". Its reason must be a concise, human-readable explanation that names the entities and the proposed relationship; the exact evidence citation remains required. The daemon will place it in the user's review queue for confirmation, not treat the queue as a work-deferral mechanism.
    - Validate before writing (validate_proposal).
 5. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write a specific entity-named change manifest, not process narration. Use Markdown, max 2000 chars, with these sections when applicable: ## Updated, ## Created, ## Deferred, ## No-op. Under every section, each line must name the entity or entity id, state the exact change (claim filed or superseded, aspect touched, entity/aspect/link archived or merged, or why no change was needed), and cite the source or provenance reference (memory, artifact, or transcript as kind:id; hygiene attention:<id>). Deferred and No-op lines must state the specific blocker or reason; never use generic categories such as "content-related" or "ongoing structural process". Omit empty sections. Put the same deferred items and open questions in the runbook's deferred and openQuestions fields.
 
@@ -820,6 +821,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - Before adding a claim, check the target aspect's existing claims; if one covers the same key or is contradicted by the new evidence, supersede it (supersede_claim_value) instead of adding alongside.
    - The evidence source and the graph target must use the same agent scope: search evidence with the agentId of the entity you will update, then pass that same agentId to apply_ontology_ops. A source found in another scope cannot support a write here.
    - create_entity only for durable subjects clearly established by the source.
+   - When the evidence supports a possible relationship, merge, or other ontology change but the relationship is ambiguous rather than settled, do not apply it immediately. Emit the normal ontology operation with risk: "review_required". Its reason must be a concise, human-readable explanation that names the entities and the proposed relationship; the exact evidence citation remains required. The daemon will place it in the user's review queue for confirmation, not treat the queue as a work-deferral mechanism.
    - Validate before writing (validate_proposal).
 4. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write a specific entity-named change manifest, not process narration. Use Markdown, max 2000 chars, with these sections when applicable: ## Updated, ## Created, ## Deferred, ## No-op. Under every section, each line must name the entity or entity id, state the exact change (claim filed or superseded, aspect touched, entity/aspect/link archived or merged, or why no change was needed), and cite the source or provenance reference (memory, artifact, or transcript as kind:id; hygiene attention:<id>). Deferred and No-op lines must state the specific blocker or reason; never use generic categories such as "content-related" or "ongoing structural process". Omit empty sections. Put the same deferred items and open questions in the runbook's deferred and openQuestions fields.
 
@@ -1178,7 +1180,8 @@ function recordDreamingOperationEffects(
 		if (!operation) continue;
 		const details = asResultRecord(item.result);
 		const deduped = details?.deduped === true;
-		if (operation.operation === "flag" || operation.operation === "decline_attention") {
+		const reviewRequired = details?.reviewRequired === true;
+		if (operation.operation === "flag" || operation.operation === "decline_attention" || reviewRequired) {
 			continue;
 		}
 		if (deduped) continue;

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -297,6 +297,25 @@ export interface KnowledgeConstellation {
 	metadata: { proposals: { pending: number } };
 }
 
+export interface OntologyProposal {
+	id: string;
+	agentId: string;
+	operation: string;
+	status: "pending" | "applied" | "rejected" | "failed";
+	payload: Record<string, unknown>;
+	confidence: number;
+	rationale: string;
+	evidence: readonly unknown[];
+	risk: string | null;
+	sourceKind: string | null;
+	sourceId: string | null;
+	sourcePath: string | null;
+	sourceRoot: string | null;
+	createdBy: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
 export interface MemoryStats {
 	total: number;
 	withEmbeddings: number;
@@ -656,6 +675,25 @@ export const api = {
 		getJSON<KnowledgeConstellation>(
 			`/api/knowledge/constellation?limit=${limit}&max_aspects_per_entity=4&dependency_limit=${dependencyLimit}`,
 		),
+	getOntologyProposals: (status: "pending" | "applied" | "rejected" | "failed" = "pending", limit = 20) =>
+		getJSON<{ items: OntologyProposal[]; limit: number; offset: number }>(
+			`/api/ontology/proposals?status=${status}&limit=${limit}`,
+		),
+	applyOntologyProposal: async (id: string): Promise<{ ok: boolean; error?: string }> => {
+		const { ok, data } = await mutateJSON<{ error?: string }>(
+			`/api/ontology/proposals/${encodeURIComponent(id)}/apply`,
+			"POST",
+		);
+		return { ok, error: ok ? undefined : (data?.error ?? "Failed to apply proposal") };
+	},
+	rejectOntologyProposal: async (id: string, reason?: string): Promise<{ ok: boolean; error?: string }> => {
+		const { ok, data } = await mutateJSON<{ error?: string }>(
+			`/api/ontology/proposals/${encodeURIComponent(id)}/reject`,
+			"POST",
+			reason ? { reason } : undefined,
+		);
+		return { ok, error: ok ? undefined : (data?.error ?? "Failed to reject proposal") };
+	},
 
 	// Sources
 	getSources: () => getJSON<SourcesResponse>("/api/sources"),

--- a/surfaces/dashboard/src/lib/demo.ts
+++ b/surfaces/dashboard/src/lib/demo.ts
@@ -31,6 +31,7 @@ import type {
 	MemoryStats,
 	MemoryTimeline,
 	OnePasswordStatus,
+	OntologyProposal,
 	SourcesResponse,
 	TelemetryHealth,
 	TodayReflectionResponse,
@@ -88,7 +89,27 @@ const demoStatus: DaemonStatus = {
 	},
 };
 
-/** Internally consistent graph stats: entityCount drives the sidebar badge. */
+const demoOntologyProposal: OntologyProposal = {
+	id: "demo-proposal-review",
+	agentId: DEMO_AGENT,
+	operation: "create_link",
+	status: "pending",
+	payload: { source_entity_id: "demo-entity-1", target_entity_id: "demo-entity-2", link_type: "supports_claim" },
+	confidence: 0.74,
+	rationale:
+		"local-first and hosted inference may describe two deployment modes of the same Signet inference system. Link them?",
+	evidence: [{ source_ref: "memory:demo-memory-1", quote: "Source-backed claims keep provenance chains intact" }],
+	risk: "review_required",
+	sourceKind: "memory",
+	sourceId: "demo-memory-1",
+	sourcePath: null,
+	sourceRoot: "demo",
+	createdBy: "dreaming",
+	createdAt: new Date().toISOString(),
+	updatedAt: new Date().toISOString(),
+};
+
+let demoOntologyProposals: OntologyProposal[] = [demoOntologyProposal];
 const demoStats: KnowledgeStats = {
 	entityCount: 1247,
 	aspectCount: 1893,
@@ -604,6 +625,17 @@ export function installDemoApi(target: ApiClient): void {
 	target.getSources = async () => demoSources;
 	target.getMemoryTimeline = async () => demoTimeline;
 	target.getKnowledgeConstellation = async () => demoConstellation();
+	target.getOntologyProposals = async () => ({ items: demoOntologyProposals, limit: 20, offset: 0 });
+	target.applyOntologyProposal = async (id) => {
+		const exists = demoOntologyProposals.some((proposal) => proposal.id === id);
+		if (exists) demoOntologyProposals = demoOntologyProposals.filter((proposal) => proposal.id !== id);
+		return exists ? { ok: true } : { ok: false, error: "Proposal not found" };
+	};
+	target.rejectOntologyProposal = async (id) => {
+		const exists = demoOntologyProposals.some((proposal) => proposal.id === id);
+		if (exists) demoOntologyProposals = demoOntologyProposals.filter((proposal) => proposal.id !== id);
+		return exists ? { ok: true } : { ok: false, error: "Proposal not found" };
+	};
 	target.getTodayReflections = async () => demoReflectionsResponse;
 	target.generateReflections = async () => demoReflectionsResponse;
 	target.answerReflection = async () => ({ success: true, memoryId: "demo-memory-answer" });

--- a/surfaces/dashboard/src/views/home.tsx
+++ b/surfaces/dashboard/src/views/home.tsx
@@ -36,7 +36,12 @@ export function HomeView() {
 				live: true,
 			},
 			{ label: "Ontology nodes", value: stats?.entityCount?.toLocaleString() ?? "—", sub: "indexed", live: true },
-			{ label: "Agents", value: String(agentCount), sub: `${agentCount} of ${agentCount} active`, ring: { value: agentCount > 0 ? 1 : 0, sub: "" } },
+			{
+				label: "Agents",
+				value: String(agentCount),
+				sub: `${agentCount} of ${agentCount} active`,
+				ring: { value: agentCount > 0 ? 1 : 0, sub: "" },
+			},
 			{
 				label: "Sources",
 				value: sources ? String(sources.length) : "—",
@@ -58,12 +63,8 @@ export function HomeView() {
 	return (
 		<div className="flex flex-col gap-3.5">
 			<div className="flex shrink-0 items-center justify-between gap-4">
-				<h1 className="m-0 text-[19px] font-semibold leading-none tracking-[-0.02em]">
-					Home
-				</h1>
-				<span className="text-[12.5px] leading-none text-muted-foreground">
-					{today}
-				</span>
+				<h1 className="m-0 text-[19px] font-semibold leading-none tracking-[-0.02em]">Home</h1>
+				<span className="text-[12.5px] leading-none text-muted-foreground">{today}</span>
 			</div>
 			<KpiRow cards={kpis}>
 				<HomeControls />
@@ -99,10 +100,7 @@ export function HomeView() {
 				</div>
 
 				<div className="flex flex-col gap-4.5">
-					<Panel
-						title="Sources"
-						meta={`${sources?.filter((s) => s.enabled).length ?? 0} connected · 24h`}
-					>
+					<Panel title="Sources" meta={`${sources?.filter((s) => s.enabled).length ?? 0} connected · 24h`}>
 						{sourcesQuery.loading ? (
 							<div className="grid min-h-[210px] place-items-center">
 								<span className="font-mono text-[10.5px] text-muted-foreground">Loading sources…</span>
@@ -117,15 +115,15 @@ export function HomeView() {
 						) : sources?.length ? (
 							<div className="flex flex-col">
 								{sources.slice(0, 4).map((s, idx) => (
-								<SourceRow
-									key={s.id}
-									logo={sourceLogo(s.kind)}
-									name={s.name}
-									acct={s.root}
-									delta={s.stats?.indexed}
-									last={idx === Math.min(3, sources.length - 1)}
-								/>
-							))}
+									<SourceRow
+										key={s.id}
+										logo={sourceLogo(s.kind)}
+										name={s.name}
+										acct={s.root}
+										delta={s.stats?.indexed}
+										last={idx === Math.min(3, sources.length - 1)}
+									/>
+								))}
 							</div>
 						) : (
 							<div className="grid min-h-[210px] place-items-center text-center">
@@ -137,13 +135,7 @@ export function HomeView() {
 						)}
 					</Panel>
 
-					<Panel title="Review suggestions" meta="3 pending">
-						<div className="flex flex-col">
-							{REVIEW_ROWS.map((r, idx) => (
-								<ReviewRow key={idx} {...r} last={idx === REVIEW_ROWS.length - 1} />
-							))}
-						</div>
-					</Panel>
+					<ReviewSuggestions />
 				</div>
 			</div>
 		</div>
@@ -165,39 +157,87 @@ function SourceRow({
 }) {
 	return (
 		<div
-			className={cn(
-				"grid grid-cols-[18px_1fr_auto] items-center gap-2.5 py-1.75",
-				!last && "border-b border-border",
-			)}
+			className={cn("grid grid-cols-[18px_1fr_auto] items-center gap-2.5 py-1.75", !last && "border-b border-border")}
 		>
 			<span className="grid size-4.5 place-items-center text-foreground">{logo}</span>
 			<span className="flex flex-col leading-tight">
 				<span className="text-[12px] font-medium">{name}</span>
 				<span className="font-mono text-[10.5px] text-[oklch(0.46_0_0)] dark:text-[oklch(0.84_0_0)]">{acct}</span>
 			</span>
-			<span
-				className={cn(
-					"font-mono text-[10.5px] text-muted-foreground",
-					delta === 0 && "opacity-40",
-				)}
-			>
-				<b className={delta === 0 ? "text-muted-foreground opacity-40" : "text-foreground"}>
-					+{delta ?? 0}
-				</b>
+			<span className={cn("font-mono text-[10.5px] text-muted-foreground", delta === 0 && "opacity-40")}>
+				<b className={delta === 0 ? "text-muted-foreground opacity-40" : "text-foreground"}>+{delta ?? 0}</b>
 			</span>
 		</div>
 	);
 }
 
-function ReviewRow({
-	text,
-	actions,
+function ReviewSuggestions() {
+	const proposals = useAsync(() => api.getOntologyProposals("pending", 20), { intervalMs: 15000 });
+	const items = proposals.data?.items ?? [];
+	const meta = proposals.loading && proposals.data === null ? "loading…" : `${items.length} pending`;
+
+	return (
+		<Panel title="Review suggestions" meta={meta}>
+			{proposals.loading && proposals.data === null ? (
+				<div className="grid min-h-[120px] place-items-center">
+					<span className="font-mono text-[10.5px] text-muted-foreground">Loading suggestions…</span>
+				</div>
+			) : proposals.data === null ? (
+				<div className="grid min-h-[120px] place-items-center text-center">
+					<div className="flex flex-col items-center gap-1.5">
+						<span className="font-mono text-[10.5px] text-muted-foreground">Couldn’t load suggestions</span>
+						<span className="text-[11px] text-muted-foreground">Check the daemon connection and try again.</span>
+					</div>
+				</div>
+			) : items.length === 0 ? (
+				<div className="grid min-h-[120px] place-items-center text-center">
+					<span className="text-[12px] text-muted-foreground">No ontology decisions need your attention.</span>
+				</div>
+			) : (
+				<div className="flex flex-col">
+					{items.map((proposal, index) => (
+						<ReviewProposalRow
+							key={proposal.id}
+							proposal={proposal}
+							last={index === items.length - 1}
+							onSettled={proposals.refresh}
+						/>
+					))}
+				</div>
+			)}
+		</Panel>
+	);
+}
+
+function ReviewProposalRow({
+	proposal,
 	last,
+	onSettled,
 }: {
-	text: React.ReactNode;
-	actions: readonly [string, string];
+	proposal: import("@/lib/api").OntologyProposal;
 	last: boolean;
+	onSettled: () => void;
 }) {
+	const [busy, setBusy] = useState<"apply" | "reject" | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [secondary, primary] = proposalActions(proposal.operation);
+	const text = proposal.rationale.trim() || proposalFallback(proposal.operation);
+
+	const settle = async (action: "apply" | "reject") => {
+		setBusy(action);
+		setError(null);
+		const result =
+			action === "apply"
+				? await api.applyOntologyProposal(proposal.id)
+				: await api.rejectOntologyProposal(proposal.id, "Rejected from dashboard review");
+		setBusy(null);
+		if (!result.ok) {
+			setError(result.error ?? "Request failed");
+			return;
+		}
+		onSettled();
+	};
+
 	return (
 		<div
 			className={cn(
@@ -205,53 +245,75 @@ function ReviewRow({
 				!last && "border-b border-border",
 			)}
 		>
-			<div className="text-[12.5px] leading-[1.4] [&_b]:font-semibold">{text}</div>
+			<div className="min-w-0 text-[12.5px] leading-[1.4]">
+				<div>{text}</div>
+				{error && <div className="mt-1 font-mono text-[10px] text-destructive">{error}</div>}
+			</div>
 			<div className="flex justify-end gap-1.5">
-				{actions.map((action, index) => (
-					<button
-						key={action}
-						type="button"
-						className={cn(
-							"min-w-[74px] whitespace-nowrap rounded-[var(--radius)] border px-2 py-[5px] text-[11.5px] font-medium transition-colors",
-							index === 1
-								? "border-primary bg-primary text-primary-foreground"
-								: "border-[oklch(1_0_0/0.2)] text-muted-foreground hover:border-[oklch(1_0_0/0.34)] hover:bg-[oklch(1_0_0/0.07)] hover:text-foreground [html:not(.dark)_&]:border-[oklch(0_0_0/0.16)] [html:not(.dark)_&]:hover:border-[oklch(0_0_0/0.28)] [html:not(.dark)_&]:hover:bg-[oklch(0_0_0/0.05)]",
-						)}
-					>
-						{action}
-					</button>
-				))}
+				<ReviewActionButton
+					label={secondary}
+					busy={busy === "reject"}
+					disabled={busy !== null}
+					onClick={() => void settle("reject")}
+				/>
+				<ReviewActionButton
+					label={primary}
+					primary
+					busy={busy === "apply"}
+					disabled={busy !== null}
+					onClick={() => void settle("apply")}
+				/>
 			</div>
 		</div>
 	);
 }
 
-const REVIEW_ROWS: { text: React.ReactNode; actions: readonly [string, string] }[] = [
-	{
-		text: (
-			<>
-				<b>signet</b> and <b>dashboard</b> are the same entity across 4 sources. Merge?
-			</>
-		),
-		actions: ["Discard", "Confirm"],
-	},
-	{
-		text: (
-			<>
-				New recurring actor <b>Mira</b> detected in 12 memories — create an agent?
-			</>
-		),
-		actions: ["Merge", "New agent"],
-	},
-	{
-		text: (
-			<>
-				<b>local-first</b> and <b>hosted inference</b> appear contradictory in recent notes.
-			</>
-		),
-		actions: ["Skip", "Link"],
-	},
-];
+function ReviewActionButton({
+	label,
+	primary = false,
+	busy,
+	disabled,
+	onClick,
+}: {
+	label: string;
+	primary?: boolean;
+	busy: boolean;
+	disabled: boolean;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			disabled={disabled}
+			className={cn(
+				"min-w-[74px] whitespace-nowrap rounded-[var(--radius)] border px-2 py-[5px] text-[11.5px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+				primary
+					? "border-primary bg-primary text-primary-foreground"
+					: "border-[oklch(1_0_0/0.2)] text-muted-foreground hover:border-[oklch(1_0_0/0.34)] hover:bg-[oklch(1_0_0/0.07)] hover:text-foreground [html:not(.dark)_&]:border-[oklch(0_0_0/0.16)] [html:not(.dark)_&]:hover:border-[oklch(0_0_0/0.28)] [html:not(.dark)_&]:hover:bg-[oklch(0_0_0/0.05)]",
+			)}
+		>
+			{busy ? "…" : label}
+		</button>
+	);
+}
+
+function proposalActions(operation: string): readonly [string, string] {
+	if (operation === "merge_entities" || operation === "merge_aspects") return ["Discard", "Merge"];
+	if (operation === "create_link" || operation === "update_link") return ["Skip", "Link"];
+	if (operation === "create_entity") return ["Discard", "Create"];
+	return ["Discard", "Confirm"];
+}
+
+function proposalFallback(operation: string): string {
+	if (operation === "merge_entities") return "Dreaming found entities that may be duplicates. Merge them?";
+	if (operation === "merge_aspects") return "Dreaming found aspects that may describe the same domain. Merge them?";
+	if (operation === "create_link" || operation === "update_link")
+		return "Dreaming found a relationship that may belong in the ontology. Link them?";
+	if (operation === "create_entity")
+		return "Dreaming found a durable entity that may belong in the ontology. Create it?";
+	return "Dreaming found an ontology change that needs your confirmation.";
+}
 
 /** Page-head controls: time-range segmented control + ⌘K command trigger + refresh. */
 function HomeControls() {
@@ -278,7 +340,15 @@ function HomeControls() {
 				title="Command palette"
 				className="inline-flex h-7.5 items-center justify-center gap-1.5 rounded-[var(--radius)] border border-[oklch(1_0_0/0.1)] px-2.25 font-mono text-[11px] text-muted-foreground [html:not(.dark)_&]:border-border"
 			>
-				<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+				<svg
+					viewBox="0 0 24 24"
+					width="13"
+					height="13"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={2}
+					strokeLinecap="round"
+				>
 					<circle cx="11" cy="11" r="7" />
 					<path d="m21 21-4.3-4.3" />
 				</svg>
@@ -290,7 +360,16 @@ function HomeControls() {
 				aria-label="Refresh"
 				className="grid size-7.5 place-items-center rounded-[var(--radius)] border border-[oklch(1_0_0/0.1)] text-muted-foreground hover:text-foreground [html:not(.dark)_&]:border-border"
 			>
-				<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+				<svg
+					viewBox="0 0 24 24"
+					width="14"
+					height="14"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={2}
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				>
 					<path d="M21 12a9 9 0 1 1-2.64-6.36" />
 					<path d="M21 3v6h-6" />
 				</svg>

--- a/surfaces/dashboard/src/views/home.tsx
+++ b/surfaces/dashboard/src/views/home.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useMemo, useState } from "react";
-import { Filter, Maximize2 } from "lucide-react";
-import { Surface } from "@/components/ui/surface";
-import { ActivityHeatmap, KpiRow, useDateString, type DayBucket, type KpiData } from "@/components/home/kpi";
 import { DailyBrief } from "@/components/home/daily-brief";
+import { ActivityHeatmap, type DayBucket, type KpiData, KpiRow, useDateString } from "@/components/home/kpi";
 import { Panel } from "@/components/home/panel";
 import { sourceLogo } from "@/components/icons";
+import { Surface } from "@/components/ui/surface";
 import { api } from "@/lib/api";
 import { useAsync } from "@/lib/use-async";
 import { cn } from "@/lib/utils";
+import { Filter, Maximize2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 
 export function HomeView() {
 	const today = useDateString("");
@@ -341,6 +341,7 @@ function HomeControls() {
 				className="inline-flex h-7.5 items-center justify-center gap-1.5 rounded-[var(--radius)] border border-[oklch(1_0_0/0.1)] px-2.25 font-mono text-[11px] text-muted-foreground [html:not(.dark)_&]:border-border"
 			>
 				<svg
+					aria-hidden="true"
 					viewBox="0 0 24 24"
 					width="13"
 					height="13"
@@ -361,6 +362,7 @@ function HomeControls() {
 				className="grid size-7.5 place-items-center rounded-[var(--radius)] border border-[oklch(1_0_0/0.1)] text-muted-foreground hover:text-foreground [html:not(.dark)_&]:border-border"
 			>
 				<svg
+					aria-hidden="true"
 					viewBox="0 0 24 24"
 					width="14"
 					height="14"


### PR DESCRIPTION
## Summary
- replace the homepage review-suggestions mockup with a live pending ontology-proposal queue
- escalate ambiguous dreaming content operations as evidence-backed review_required proposals
- let dashboard actions apply or reject proposals through the existing scoped ontology routes

## Changes
- add dashboard proposal list/apply/reject API methods and demo fixtures
- preserve hygiene operations as immediate dreaming work; only explicitly ambiguous content operations escalate
- add agent-scoped replay deduplication so identical evidence does not reappear after rejection
- add regression coverage for pending proposal creation, no pre-confirmation graph mutation, post-confirmation link creation, and replay deduplication

## PR readiness
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Type
- [x] Feature

## Packages affected
- platform/daemon
- surfaces/dashboard

## Verification
- `bun test platform/daemon/src/pipeline/dreaming-operations.test.ts` (24 pass)
- `bun test platform/daemon/src/ontology-proposals.test.ts` (60 pass)
- `bun run --filter @signet/core build`
- `bun run --filter @signet/daemon build`
- `bun run build` from `surfaces/dashboard`
- `bunx biome check` on dashboard API/demo files
- repository-wide typecheck has unrelated pre-existing connector errors; daemon and dashboard typechecks pass
