### PR TITLE
feat(dreaming): retry repaired evidence

### DIFF
--- a/platform/core/src/migrations/122-dreaming-evidence-retry.ts
+++ b/platform/core/src/migrations/122-dreaming-evidence-retry.ts
@@ -1,0 +1,24 @@
+import type { MigrationDb } from "./index";
+
+/** Add restart-safe repair-aware retry state to quarantined Dreaming evidence. */
+export function up(db: MigrationDb): void {
+	const columns = db.prepare("PRAGMA table_info(dreaming_evidence_exclusions)").all() as Array<{ name: string }>;
+	const names = new Set(columns.map((column) => column.name));
+	if (!names.has("failure_class")) {
+		db.exec(
+			"ALTER TABLE dreaming_evidence_exclusions ADD COLUMN failure_class TEXT NOT NULL DEFAULT 'unknown' CHECK (failure_class IN ('incomplete_transcript', 'source_projection', 'scope_mismatch', 'quote_mismatch', 'unknown'))",
+		);
+	}
+	if (!names.has("source_fingerprint")) {
+		db.exec("ALTER TABLE dreaming_evidence_exclusions ADD COLUMN source_fingerprint TEXT");
+	}
+	if (!names.has("retry_count")) {
+		db.exec("ALTER TABLE dreaming_evidence_exclusions ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0");
+	}
+	if (!names.has("last_requeued_at")) {
+		db.exec("ALTER TABLE dreaming_evidence_exclusions ADD COLUMN last_requeued_at TEXT");
+	}
+	db.exec(
+		"CREATE INDEX IF NOT EXISTS idx_dreaming_evidence_exclusions_retry ON dreaming_evidence_exclusions (resolved_at, requeue_requested_at, failure_class, retry_count, last_requeued_at)",
+	);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -127,6 +127,7 @@ import { up as queuePressureIndices } from "./118-queue-pressure-indices";
 import { up as telemetryVersionObservation } from "./119-telemetry-version-observation";
 import { up as sourceLifecycleTelemetry } from "./120-source-lifecycle-telemetry";
 import { up as telemetryDeliveryHealth } from "./121-telemetry-delivery-health";
+import { up as dreamingEvidenceRetry } from "./122-dreaming-evidence-retry";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1139,6 +1140,19 @@ export const MIGRATIONS: readonly Migration[] = [
 				{ table: "telemetry_events", column: "last_attempt_at" },
 				{ table: "telemetry_events", column: "sent_at" },
 				{ table: "telemetry_events", column: "last_failure_code" },
+			],
+		},
+	},
+	{
+		version: 122,
+		name: "dreaming-evidence-retry",
+		up: dreamingEvidenceRetry,
+		artifacts: {
+			columns: [
+				{ table: "dreaming_evidence_exclusions", column: "failure_class" },
+				{ table: "dreaming_evidence_exclusions", column: "source_fingerprint" },
+				{ table: "dreaming_evidence_exclusions", column: "retry_count" },
+				{ table: "dreaming_evidence_exclusions", column: "last_requeued_at" },
 			],
 		},
 	},

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -25,6 +25,7 @@ import { up as crossAgentMessageNotifications } from "./115-cross-agent-message-
 import { up as acpDeliveryReconciliation } from "./116-acp-delivery-reconciliation";
 import { up as retireSummaryWorker } from "./117-retire-summary-worker";
 import { up as telemetryVersionObservation } from "./119-telemetry-version-observation";
+import { up as dreamingEvidenceRetry } from "./122-dreaming-evidence-retry";
 import { MIGRATIONS, hasPendingMigrations, runMigrations } from "./index";
 
 function createFreshDb(): Database {
@@ -2192,5 +2193,33 @@ describe("migration 121: telemetry delivery health", () => {
 		expect(state.window_started_at).toEqual(expect.any(String));
 		expect(state.success_count).toBe(0);
 		expect(state.failure_count).toBe(0);
+	});
+});
+
+describe("migration 122: Dreaming evidence retry", () => {
+	test("adds repair state to an existing exclusion table idempotently", () => {
+		const db = createFreshDb();
+		db.exec(`
+			CREATE TABLE dreaming_evidence_exclusions (
+				agent_id TEXT NOT NULL,
+				source_kind TEXT NOT NULL,
+				source_id TEXT NOT NULL,
+				reason TEXT NOT NULL,
+				pass_id TEXT NOT NULL,
+				excluded_at TEXT NOT NULL,
+				requeue_requested_at TEXT,
+				resolved_at TEXT,
+				PRIMARY KEY (agent_id, source_kind, source_id)
+			);
+		`);
+		dreamingEvidenceRetry(db);
+		dreamingEvidenceRetry(db);
+
+		const columns = db.query("PRAGMA table_info(dreaming_evidence_exclusions)").all() as Array<{ name: string }>;
+		expect(columns.map((column) => column.name)).toEqual(
+			expect.arrayContaining(["failure_class", "source_fingerprint", "retry_count", "last_requeued_at"]),
+		);
+		expect(db.prepare("SELECT retry_count, failure_class FROM dreaming_evidence_exclusions").all()).toEqual([]);
+		db.close();
 	});
 });

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -221,7 +221,11 @@ import { registerSecretRoutes } from "./routes/secrets-routes.js";
 import { registerSessionRoutes } from "./routes/session-routes.js";
 import { mountSkillAnalyticsRoutes } from "./routes/skill-analytics.js";
 import { mountSkillsRoutes, setFetchEmbedding } from "./routes/skills.js";
-import { cleanupSourceDeletionTombstones, registerSourcesRoutes, stopSourceIndexJobs } from "./routes/sources-routes.js";
+import {
+	cleanupSourceDeletionTombstones,
+	registerSourcesRoutes,
+	stopSourceIndexJobs,
+} from "./routes/sources-routes.js";
 import { registerTelemetryRoutes } from "./routes/telemetry-routes.js";
 import { checkEmbeddingProvider } from "./routes/utils.js";
 import { mountWidgetRoutes } from "./routes/widget.js";
@@ -1631,6 +1635,11 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 										Math.max(900, Math.ceil(memoryCfg.dreaming.timeout / 1000) + 60),
 									)
 								: undefined,
+					},
+					evidenceRetry: {
+						cooldownMs: memoryCfg.pipelineV2.repair.requeueCooldownMs,
+						hourlyBudget: memoryCfg.pipelineV2.repair.requeueHourlyBudget,
+						maxAttempts: 3,
 					},
 				},
 				graphWriteCaps(memoryCfg),

--- a/platform/daemon/src/pipeline/dreaming-evidence-retry.ts
+++ b/platform/daemon/src/pipeline/dreaming-evidence-retry.ts
@@ -1,0 +1,296 @@
+import { createHash } from "node:crypto";
+import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
+import {
+	type EpisodicSourceKind,
+	type EpisodicSourceRecord,
+	findEpisodicSourceAgentIds,
+	readEpisodicSource,
+} from "../episodic-sources";
+import { enqueueDreamingAttentionInTx } from "./dreaming-attention";
+import { renderDreamingEvidence } from "./dreaming-evidence";
+import type { ApplyDreamingOperationsResult, DreamingOperationRequest } from "./dreaming-operations";
+
+export const DREAMING_EVIDENCE_FAILURE_CLASSES = [
+	"incomplete_transcript",
+	"source_projection",
+	"scope_mismatch",
+	"quote_mismatch",
+	"unknown",
+] as const;
+export type DreamingEvidenceFailureClass = (typeof DREAMING_EVIDENCE_FAILURE_CLASSES)[number];
+
+export interface DreamingEvidenceRetryPolicy {
+	readonly cooldownMs: number;
+	readonly hourlyBudget: number;
+	readonly maxAttempts: number;
+}
+
+export interface RejectedDreamingEvidence {
+	readonly agentId: string;
+	readonly sourceKind: EpisodicSourceKind;
+	readonly sourceId: string;
+	readonly failureClass: DreamingEvidenceFailureClass;
+	readonly sourceFingerprint: string | null;
+}
+
+interface EvidenceReference {
+	readonly sourceRef: string;
+	readonly quote: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | null {
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function sourceReference(value: unknown): EvidenceReference | null {
+	if (!isRecord(value)) return null;
+	const quote = nonEmptyString(value.quote);
+	if (!quote) return null;
+	const explicit = nonEmptyString(value.source_ref);
+	if (explicit) return { sourceRef: explicit, quote };
+	const kind = nonEmptyString(value.source_kind);
+	const id = nonEmptyString(value.source_id);
+	return kind && id ? { sourceRef: `${kind}:${id}`, quote } : null;
+}
+
+function sourceFingerprint(source: EpisodicSourceRecord): string {
+	const renderedContent = renderDreamingEvidence(source);
+	return createHash("sha256")
+		.update(
+			JSON.stringify({
+				kind: source.kind,
+				id: source.id,
+				content: source.content,
+				renderedContent,
+				completed: source.completed,
+				capturedAt: source.capturedAt,
+				sourceKind: source.sourceKind,
+				sourceId: source.sourceId,
+				sourcePath: source.sourcePath,
+				sourceEntryId: source.sourceEntryId,
+			}),
+		)
+		.digest("hex");
+}
+
+function failureClass(
+	db: ReadDb,
+	agentId: string,
+	reference: EvidenceReference,
+): {
+	readonly kind: EpisodicSourceKind;
+	readonly id: string;
+	readonly failureClass: DreamingEvidenceFailureClass;
+	readonly sourceFingerprint: string | null;
+} | null {
+	const colon = reference.sourceRef.indexOf(":");
+	if (colon <= 0) return null;
+	const kind = reference.sourceRef.slice(0, colon);
+	const id = reference.sourceRef.slice(colon + 1);
+	if (kind !== "memory" && kind !== "artifact" && kind !== "transcript" && kind !== "summary") return null;
+	const source = readEpisodicSource(db, { agentId, from: reference.sourceRef });
+	if (source === null) {
+		return {
+			kind,
+			id,
+			failureClass:
+				findEpisodicSourceAgentIds(db, reference.sourceRef).length > 0 ? "scope_mismatch" : "source_projection",
+			sourceFingerprint: null,
+		};
+	}
+	if (source.kind === "transcript" && !source.completed) {
+		return { kind, id: source.id, failureClass: "incomplete_transcript", sourceFingerprint: sourceFingerprint(source) };
+	}
+	if (!renderDreamingEvidence(source).includes(reference.quote)) {
+		return { kind, id: source.id, failureClass: "quote_mismatch", sourceFingerprint: sourceFingerprint(source) };
+	}
+	return { kind, id: source.id, failureClass: "unknown", sourceFingerprint: sourceFingerprint(source) };
+}
+
+function rejectedIndexes(
+	result: ApplyDreamingOperationsResult,
+	operations: readonly Pick<DreamingOperationRequest, "evidence">[],
+): ReadonlySet<number> {
+	const indexes = result.items.filter((item) => !item.ok).map((item) => item.index);
+	return new Set(indexes.length > 0 ? indexes : result.ok ? [] : operations.map((_operation, index) => index));
+}
+
+/** Resolve rejected citations to the source state that caused the rejection. */
+export function collectRejectedDreamingEvidence(
+	accessor: DbAccessor,
+	agentId: string,
+	result: ApplyDreamingOperationsResult,
+	operations: readonly Pick<DreamingOperationRequest, "evidence">[],
+): readonly RejectedDreamingEvidence[] {
+	const indexes = rejectedIndexes(result, operations);
+	return accessor.withReadDb((db) => {
+		const candidates = new Map<string, RejectedDreamingEvidence>();
+		for (const index of indexes) {
+			const operation = operations[index];
+			if (!operation) continue;
+			for (const rawEvidence of operation.evidence ?? []) {
+				const reference = sourceReference(rawEvidence);
+				const candidate = reference ? failureClass(db, agentId, reference) : null;
+				if (!candidate) continue;
+				const key = `${agentId}:${candidate.kind}:${candidate.id}`;
+				candidates.set(key, {
+					agentId,
+					sourceKind: candidate.kind,
+					sourceId: candidate.id,
+					failureClass: candidate.failureClass,
+					sourceFingerprint: candidate.sourceFingerprint,
+				});
+			}
+		}
+		return [...candidates.values()];
+	});
+}
+
+export function recordRejectedDreamingEvidenceInTx(
+	db: WriteDb,
+	passId: string,
+	items: readonly RejectedDreamingEvidence[],
+): void {
+	const statement = db.prepare(
+		`INSERT INTO dreaming_evidence_exclusions
+		 (agent_id, source_kind, source_id, reason, pass_id, excluded_at, requeue_requested_at, resolved_at,
+		  failure_class, source_fingerprint, retry_count, last_requeued_at)
+		 VALUES (?, ?, ?, 'semantic_operation_rejected', ?, datetime('now'), NULL, NULL, ?, ?, 0, NULL)
+		 ON CONFLICT(agent_id, source_kind, source_id) DO UPDATE SET
+		   reason = excluded.reason,
+		   pass_id = excluded.pass_id,
+		   excluded_at = excluded.excluded_at,
+		   requeue_requested_at = NULL,
+		   resolved_at = NULL,
+		   failure_class = excluded.failure_class,
+		   source_fingerprint = excluded.source_fingerprint`,
+	);
+	for (const item of items) {
+		statement.run(item.agentId, item.sourceKind, item.sourceId, passId, item.failureClass, item.sourceFingerprint);
+	}
+}
+
+/** Mark a requeued citation repaired once the daemon accepts it again. */
+export function resolveRequeuedDreamingEvidenceInTx(
+	db: WriteDb,
+	agentId: string,
+	result: ApplyDreamingOperationsResult,
+	operations: readonly Pick<DreamingOperationRequest, "evidence">[],
+): void {
+	const indexes = result.items.filter((item) => item.ok).map((item) => item.index);
+	if (indexes.length === 0) return;
+	const statement = db.prepare(
+		`UPDATE dreaming_evidence_exclusions
+		 SET resolved_at = datetime('now')
+		 WHERE agent_id = ? AND source_kind = ? AND source_id = ?
+		   AND requeue_requested_at IS NOT NULL AND resolved_at IS NULL`,
+	);
+	const seen = new Set<string>();
+	for (const index of indexes) {
+		const operation = operations[index];
+		if (!operation) continue;
+		for (const rawEvidence of operation.evidence ?? []) {
+			const reference = sourceReference(rawEvidence);
+			if (!reference) continue;
+			const colon = reference.sourceRef.indexOf(":");
+			if (colon <= 0) continue;
+			const kind = reference.sourceRef.slice(0, colon);
+			const id = reference.sourceRef.slice(colon + 1);
+			if (kind !== "memory" && kind !== "artifact" && kind !== "transcript" && kind !== "summary") continue;
+			const key = `${kind}:${id}`;
+			if (seen.has(key)) continue;
+			seen.add(key);
+			statement.run(agentId, kind, id);
+		}
+	}
+}
+
+interface RetryRow {
+	readonly agent_id: string;
+	readonly source_kind: EpisodicSourceKind;
+	readonly source_id: string;
+	readonly failure_class: DreamingEvidenceFailureClass;
+	readonly source_fingerprint: string | null;
+	readonly retry_count: number;
+	readonly last_requeued_at: string | null;
+}
+
+function parsedTime(value: string | null): number | null {
+	if (!value) return null;
+	const parsed = Date.parse(value.replace(" ", "T") + (value.includes("T") ? "" : "Z"));
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Requeue only a source whose canonical state changed since a transient
+ * rejection. The update and attention mint are atomic, and retry_count plus
+ * the hourly budget make this a bounded repair aid rather than a hot loop.
+ */
+export function autoRequeueRepairedDreamingEvidence(
+	accessor: DbAccessor,
+	policy: DreamingEvidenceRetryPolicy,
+	nowMs = Date.now(),
+): number {
+	const cooldownMs = Math.max(0, Math.floor(policy.cooldownMs));
+	const hourlyBudget = Math.max(0, Math.floor(policy.hourlyBudget));
+	const maxAttempts = Math.max(0, Math.floor(policy.maxAttempts));
+	if (hourlyBudget === 0 || maxAttempts === 0) return 0;
+	const now = new Date(nowMs).toISOString();
+	const hourAgo = nowMs - 60 * 60 * 1000;
+	return accessor.withWriteTx((db) => {
+		const recent = db
+			.prepare(
+				`SELECT COUNT(*) AS count FROM dreaming_evidence_exclusions
+				 WHERE last_requeued_at IS NOT NULL AND julianday(last_requeued_at) >= julianday(?)`,
+			)
+			.get(new Date(hourAgo).toISOString()) as { count: number };
+		let budget = Math.max(0, hourlyBudget - (recent.count ?? 0));
+		if (budget === 0) return 0;
+		const rows = db
+			.prepare(
+				`SELECT agent_id, source_kind, source_id, failure_class, source_fingerprint,
+				        retry_count, last_requeued_at
+				 FROM dreaming_evidence_exclusions
+				 WHERE resolved_at IS NULL AND requeue_requested_at IS NULL
+				   AND failure_class IN ('incomplete_transcript', 'source_projection', 'scope_mismatch', 'quote_mismatch')
+				   AND retry_count < ?
+				 ORDER BY excluded_at ASC, source_kind ASC, source_id ASC`,
+			)
+			.all(maxAttempts) as RetryRow[];
+		let affected = 0;
+		for (const row of rows) {
+			if (budget === 0) break;
+			const lastRequeued = parsedTime(row.last_requeued_at);
+			if (lastRequeued !== null && nowMs - lastRequeued < cooldownMs) continue;
+			const source = readEpisodicSource(db, { agentId: row.agent_id, from: `${row.source_kind}:${row.source_id}` });
+			if (source === null) continue;
+			if (row.failure_class === "incomplete_transcript" && !source.completed) continue;
+			const currentFingerprint = sourceFingerprint(source);
+			if (row.source_fingerprint === currentFingerprint) continue;
+			const updated = db
+				.prepare(
+					`UPDATE dreaming_evidence_exclusions
+					 SET requeue_requested_at = ?, last_requeued_at = ?, retry_count = retry_count + 1
+					 WHERE agent_id = ? AND source_kind = ? AND source_id = ?
+					   AND resolved_at IS NULL AND requeue_requested_at IS NULL
+					   AND retry_count < ?`,
+				)
+				.run(now, now, row.agent_id, row.source_kind, row.source_id, maxAttempts) as { changes: number };
+			if (updated.changes !== 1) continue;
+			enqueueDreamingAttentionInTx(db, {
+				agentId: row.agent_id,
+				kind: "evidence_requeue",
+				subjectRef: `${row.source_kind}:${row.source_id}`,
+				details: { sourceKind: row.source_kind, sourceId: row.source_id, automatic: "true" },
+				priority: 80,
+			});
+			budget -= 1;
+			affected += 1;
+		}
+		return affected;
+	});
+}

--- a/platform/daemon/src/pipeline/dreaming-evidence-retry.ts
+++ b/platform/daemon/src/pipeline/dreaming-evidence-retry.ts
@@ -178,6 +178,7 @@ export function recordRejectedDreamingEvidenceInTx(
 export function resolveRequeuedDreamingEvidenceInTx(
 	db: WriteDb,
 	agentId: string,
+	passId: string,
 	result: ApplyDreamingOperationsResult,
 	operations: readonly Pick<DreamingOperationRequest, "evidence">[],
 ): void {
@@ -188,6 +189,11 @@ export function resolveRequeuedDreamingEvidenceInTx(
 		 SET resolved_at = datetime('now')
 		 WHERE agent_id = ? AND source_kind = ? AND source_id = ?
 		   AND requeue_requested_at IS NOT NULL AND resolved_at IS NULL`,
+	);
+	const attentionStatement = db.prepare(
+		`UPDATE dreaming_attention
+		 SET resolved_at = datetime('now'), resolved_by_pass_id = ?
+		 WHERE agent_id = ? AND kind = 'evidence_requeue' AND subject_ref = ? AND resolved_at IS NULL`,
 	);
 	const seen = new Set<string>();
 	for (const index of indexes) {
@@ -205,6 +211,7 @@ export function resolveRequeuedDreamingEvidenceInTx(
 			if (seen.has(key)) continue;
 			seen.add(key);
 			statement.run(agentId, kind, id);
+			attentionStatement.run(passId, agentId, `${kind}:${id}`);
 		}
 	}
 }

--- a/platform/daemon/src/pipeline/dreaming-worker.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.test.ts
@@ -105,12 +105,18 @@ describe("dreaming worker agent scope", () => {
 			`INSERT INTO session_transcripts (session_key, content, harness, agent_id, created_at, updated_at)
 			 VALUES ('transcript-agent', 'agent transcript', 'pi', ?, ?, ?)`,
 		).run("transcript-agent", now, now);
+		db.prepare(
+			`INSERT INTO dreaming_evidence_exclusions
+			 (agent_id, source_kind, source_id, reason, pass_id)
+			 VALUES ('quarantine-agent', 'transcript', 'repaired-later', 'semantic_operation_rejected', 'pass-1')`,
+		).run();
 
 		expect(getDreamingWorkerAgentIds(accessor, "default")).toEqual([
 			"artifact-agent",
 			"default",
 			"memory-agent",
 			"noam",
+			"quarantine-agent",
 			"state-agent",
 			"summary-agent",
 			"transcript-agent",

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -26,6 +26,7 @@ import {
 	shouldTriggerDreaming,
 } from "./dreaming";
 import { getDreamingAttentionInDb } from "./dreaming-attention";
+import { type DreamingEvidenceRetryPolicy, autoRequeueRepairedDreamingEvidence } from "./dreaming-evidence-retry";
 
 /** Thrown when a trigger is attempted while a pass is already in-flight. */
 export class AlreadyRunningError extends Error {
@@ -68,6 +69,8 @@ export interface DreamingWorkerOptions {
 		readonly daemonUrl: string;
 		readonly authorizationTokenForAgent?: (agentId: string) => string | undefined;
 	};
+	/** Repair-aware automatic evidence requeue policy. */
+	readonly evidenceRetry?: DreamingEvidenceRetryPolicy;
 }
 
 const CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 min
@@ -108,6 +111,8 @@ export function getDreamingWorkerAgentIds(accessor: DbAccessor, defaultAgentId: 
 				 SELECT DISTINCT agent_id AS id FROM session_transcripts
 				 UNION ALL
 				 SELECT DISTINCT agent_id AS id FROM dreaming_attention WHERE resolved_at IS NULL
+				 UNION ALL
+				 SELECT DISTINCT agent_id AS id FROM dreaming_evidence_exclusions WHERE resolved_at IS NULL
 				 UNION ALL
 				 SELECT DISTINCT agent_id AS id FROM entities`,
 			)
@@ -183,6 +188,11 @@ export function startDreamingWorker(
 	const getAgentScopes = createAgentScopeSnapshot(AGENT_SCOPE_SNAPSHOT_REFRESH_MS, () =>
 		getDreamingWorkerAgentIds(accessor, defaultAgentId),
 	);
+	const evidenceRetry: DreamingEvidenceRetryPolicy = options.evidenceRetry ?? {
+		cooldownMs: 60_000,
+		hourlyBudget: 50,
+		maxAttempts: 3,
+	};
 	const executorForAgent = (agentId: string): DreamingAgentExecutor => {
 		const factory = options.executorFactory;
 		if (factory) return factory(agentId);
@@ -301,6 +311,13 @@ export function startDreamingWorker(
 		// sweep runs one pass when any scope has attention or a backlog; the
 		// pass itself addresses scopes via the per-call agentId on its tools.
 		const scopes = getAgentScopes();
+		const autoRequeued = autoRequeueRepairedDreamingEvidence(accessor, evidenceRetry);
+		if (autoRequeued > 0) {
+			logger.info("dreaming-worker", "Automatically requeued repaired Dreaming evidence", {
+				affected: autoRequeued,
+				budget: evidenceRetry.hourlyBudget,
+			});
+		}
 		let triggered = false;
 		for (const scopeId of scopes) {
 			if (stopped || active) return;

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -99,16 +99,21 @@ function seedTranscript(db: Database, id: string, content: string, capturedAt?: 
 	).run(id, content, AGENT, timestamp, timestamp, timestamp);
 }
 
-function seedSummary(db: Database, id: string, content: string, tokens: number): void {
+function seedSummary(db: Database, id: string, content: string, tokens: number, agentId = AGENT): void {
 	// Keep a legacy row for explicit provenance-compatibility assertions, but
 	// seed the canonical direct transcript path used by Dreaming's default
 	// evidence selector.
-	seedTranscript(db, id, content);
+	const timestamp = (db.prepare("SELECT datetime('now') AS now").get() as { now: string }).now;
+	db.prepare(
+		`INSERT INTO session_transcripts
+		 (session_key, content, agent_id, created_at, updated_at, completed_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+	).run(id, content, agentId, timestamp, timestamp, timestamp);
 	db.prepare(
 		`INSERT INTO session_summaries
 		 (id, agent_id, content, token_count, depth, kind, source_type, earliest_at, latest_at, created_at)
 		 VALUES (?, ?, ?, ?, 0, 'session', 'summary', datetime('now'), datetime('now'), datetime('now'))`,
-	).run(id, AGENT, content, tokens);
+	).run(id, agentId, content, tokens);
 }
 
 describe("Dreaming", () => {
@@ -807,8 +812,17 @@ describe("Dreaming", () => {
 		).toMatchObject({ resolvedAt: expect.any(String) });
 	});
 
-	it("records the repair classification when an agent operation fails exact quote validation", async () => {
-		seedSummary(db, "rejected-citation", "The canonical source says the deployment is local.", 12);
+	it("records the repair classification under the operation's target scope when pre-apply validation fails", async () => {
+		accessor.withWriteTx((tx) => {
+			enqueueDreamingAttentionInTx(tx, {
+				agentId: AGENT,
+				kind: "review_due",
+				subjectRef: "entity:rejected-citation",
+				details: { reason: "force the apply path for scope attribution" },
+				priority: 90,
+			});
+		});
+		seedSummary(db, "rejected-citation", "The canonical source says the deployment is local.", 12, "other-agent");
 		const result = await runDreamingAgentPass(
 			accessor,
 			{
@@ -818,12 +832,9 @@ describe("Dreaming", () => {
 					await apply.execute(
 						"call",
 						{
-							agentId: AGENT,
+							agentId: "other-agent",
 							operations: [
 								{
-									operation: "create_entity",
-									payload: { name: "Local deployment", type: "project" },
-									reason: "The source describes the deployment.",
 									evidence: [{ source_ref: "summary:rejected-citation", quote: "the deployment is remote" }],
 								},
 							],
@@ -842,8 +853,8 @@ describe("Dreaming", () => {
 			"incremental",
 		);
 
-		expect(result.failed).toBe(1);
-		expect(getDreamingEvidenceExclusions(accessor, AGENT)).toContainEqual(
+		expect(result.summary).toBe("Rejected citation");
+		expect(getDreamingEvidenceExclusions(accessor, "other-agent")).toContainEqual(
 			expect.objectContaining({
 				sourceKind: "summary",
 				sourceId: "rejected-citation",
@@ -851,6 +862,7 @@ describe("Dreaming", () => {
 				retryCount: 0,
 			}),
 		);
+		expect(getDreamingEvidenceExclusions(accessor, AGENT)).toEqual([]);
 	});
 
 	it("applies cited operations only through the daemon-owned tool surface", async () => {

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -15,6 +15,7 @@ import {
 	dreamingEarlyExitSummary,
 	enqueueDreamingHygieneAttention,
 	getDreamingEpisodicTokenBacklog,
+	getDreamingEvidenceExclusions,
 	getDreamingPasses,
 	getDreamingState,
 	getDreamingToolCalls,
@@ -32,6 +33,11 @@ import {
 	getDreamingAttentionSnapshots,
 	resolveDreamingAttentionInTx,
 } from "./dreaming-attention";
+import {
+	autoRequeueRepairedDreamingEvidence,
+	collectRejectedDreamingEvidence,
+	resolveRequeuedDreamingEvidenceInTx,
+} from "./dreaming-evidence-retry";
 import { readDreamingRunbook } from "./dreaming-runbook";
 
 const AGENT = "default";
@@ -666,6 +672,185 @@ describe("Dreaming", () => {
 			}),
 		]);
 		expect(Object.keys(attention[0] ?? {})).not.toContain("detailsJson");
+	});
+
+	it("classifies rejected evidence by the repair that can make it retryable", () => {
+		const timestamp = "2026-08-10T12:00:00.000Z";
+		db.prepare(
+			`INSERT INTO session_transcripts
+			 (session_key, content, agent_id, created_at, updated_at, completed_at)
+			 VALUES ('incomplete', 'still running', ?, ?, ?, NULL)`,
+		).run(AGENT, timestamp, timestamp);
+		seedTranscript(db, "quote-changed", "The repaired source has new wording.", timestamp);
+		db.prepare(
+			`INSERT INTO session_transcripts
+			 (session_key, content, agent_id, created_at, updated_at, completed_at)
+			 VALUES ('other-scope', 'private evidence', 'other-agent', ?, ?, ?)`,
+		).run(timestamp, timestamp, timestamp);
+
+		const operations = [
+			{ evidence: [{ source_ref: "transcript:incomplete", quote: "still running" }] },
+			{ evidence: [{ source_ref: "transcript:quote-changed", quote: "The old wording." }] },
+			{ evidence: [{ source_ref: "transcript:missing", quote: "projected later" }] },
+			{ evidence: [{ source_ref: "transcript:other-scope", quote: "private evidence" }] },
+		] as const;
+		const rejected = collectRejectedDreamingEvidence(
+			accessor,
+			AGENT,
+			{
+				ok: false,
+				items: operations.map((_operation, index) => ({ index, ok: false })),
+			},
+			operations,
+		);
+
+		expect(rejected).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ sourceId: "incomplete", failureClass: "incomplete_transcript" }),
+				expect.objectContaining({ sourceId: "quote-changed", failureClass: "quote_mismatch" }),
+				expect.objectContaining({ sourceId: "missing", failureClass: "source_projection" }),
+				expect.objectContaining({ sourceId: "other-scope", failureClass: "scope_mismatch" }),
+			]),
+		);
+		expect(rejected).toHaveLength(4);
+	});
+
+	it("requeues repaired quarantines once, within budget, without deleting the audit row", () => {
+		const timestamp = "2026-08-10T12:00:00.000Z";
+		db.prepare(
+			`INSERT INTO session_transcripts
+			 (session_key, content, agent_id, created_at, updated_at, completed_at)
+			 VALUES ('incomplete', 'now complete', ?, ?, ?, NULL)`,
+		).run(AGENT, timestamp, timestamp);
+		db.prepare(
+			`INSERT INTO session_transcripts
+			 (session_key, content, agent_id, created_at, updated_at, completed_at)
+			 VALUES ('scope-repaired', 'returned to the scope', ?, ?, ?, ?)`,
+		).run("other-agent", timestamp, timestamp, timestamp);
+		seedTranscript(db, "quote-repaired", "new rendered quote", timestamp);
+
+		const exclusions = [
+			["incomplete", "incomplete_transcript", null],
+			["projected", "source_projection", null],
+			["scope-repaired", "scope_mismatch", null],
+			["quote-repaired", "quote_mismatch", "old-fingerprint"],
+		] as const;
+		for (const [sourceId, failureClass, fingerprint] of exclusions) {
+			db.prepare(
+				`INSERT INTO dreaming_evidence_exclusions
+				 (agent_id, source_kind, source_id, reason, pass_id, excluded_at, requeue_requested_at, resolved_at,
+				  failure_class, source_fingerprint, retry_count, last_requeued_at)
+				 VALUES (?, 'transcript', ?, 'semantic_operation_rejected', 'failed-pass', ?, NULL, NULL, ?, ?, 0, NULL)`,
+			).run(AGENT, sourceId, timestamp, failureClass, fingerprint);
+		}
+
+		// The incomplete transcript, absent projection, and scope mismatch
+		// remain quarantined; only the changed rendered source is retryable.
+		expect(
+			autoRequeueRepairedDreamingEvidence(
+				accessor,
+				{ cooldownMs: 0, hourlyBudget: 10, maxAttempts: 3 },
+				Date.parse(timestamp),
+			),
+		).toBe(1);
+		// Repair the remaining three sources, including the scope that was
+		// temporarily owned by another agent.
+		seedTranscript(db, "projected", "projected later", timestamp);
+		seedTranscript(db, "scope-repaired", "returned to the scope", timestamp);
+		db.prepare("UPDATE session_transcripts SET completed_at = ? WHERE agent_id = ? AND session_key = 'incomplete'").run(
+			timestamp,
+			AGENT,
+		);
+		expect(
+			autoRequeueRepairedDreamingEvidence(
+				accessor,
+				{ cooldownMs: 0, hourlyBudget: 10, maxAttempts: 3 },
+				Date.parse(timestamp) + 1_000,
+			),
+		).toBe(3);
+		// A requested repair is not re-enqueued on every sweep.
+		expect(
+			autoRequeueRepairedDreamingEvidence(
+				accessor,
+				{ cooldownMs: 0, hourlyBudget: 10, maxAttempts: 3 },
+				Date.parse(timestamp) + 2_000,
+			),
+		).toBe(0);
+
+		const rows = db
+			.prepare(
+				`SELECT source_id AS sourceId, retry_count AS retryCount, requeue_requested_at AS requestedAt,
+				        resolved_at AS resolvedAt
+				 FROM dreaming_evidence_exclusions WHERE agent_id = ? ORDER BY source_id`,
+			)
+			.all(AGENT) as Array<{
+			sourceId: string;
+			retryCount: number;
+			requestedAt: string | null;
+			resolvedAt: string | null;
+		}>;
+		expect(rows).toHaveLength(4);
+		expect(rows.every((row) => row.retryCount === 1 && row.requestedAt !== null && row.resolvedAt === null)).toBe(true);
+		expect(getDreamingAttention(accessor, AGENT).filter((item) => item.kind === "evidence_requeue")).toHaveLength(4);
+
+		accessor.withWriteTx((tx) =>
+			resolveRequeuedDreamingEvidenceInTx(tx, AGENT, { ok: true, items: [{ index: 0, ok: true }] }, [
+				{ evidence: [{ source_ref: "transcript:incomplete", quote: "now complete" }] },
+			]),
+		);
+		expect(
+			db
+				.prepare(
+					"SELECT resolved_at AS resolvedAt FROM dreaming_evidence_exclusions WHERE agent_id = ? AND source_id = 'incomplete'",
+				)
+				.get(AGENT),
+		).toMatchObject({ resolvedAt: expect.any(String) });
+	});
+
+	it("records the repair classification when an agent operation fails exact quote validation", async () => {
+		seedSummary(db, "rejected-citation", "The canonical source says the deployment is local.", 12);
+		const result = await runDreamingAgentPass(
+			accessor,
+			{
+				async run(input) {
+					const apply = input.tools.find((tool) => tool.name === "apply_ontology_ops");
+					if (!apply) throw new Error("Missing apply_ontology_ops");
+					await apply.execute(
+						"call",
+						{
+							agentId: AGENT,
+							operations: [
+								{
+									operation: "create_entity",
+									payload: { name: "Local deployment", type: "project" },
+									reason: "The source describes the deployment.",
+									evidence: [{ source_ref: "summary:rejected-citation", quote: "the deployment is remote" }],
+								},
+							],
+						},
+						undefined,
+						undefined,
+						{} as never,
+					);
+					return { summary: "Rejected citation" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT],
+			"incremental",
+		);
+
+		expect(result.failed).toBe(1);
+		expect(getDreamingEvidenceExclusions(accessor, AGENT)).toContainEqual(
+			expect.objectContaining({
+				sourceKind: "summary",
+				sourceId: "rejected-citation",
+				failureClass: "quote_mismatch",
+				retryCount: 0,
+			}),
+		);
 	});
 
 	it("applies cited operations only through the daemon-owned tool surface", async () => {

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -799,7 +799,7 @@ describe("Dreaming", () => {
 		expect(getDreamingAttention(accessor, AGENT).filter((item) => item.kind === "evidence_requeue")).toHaveLength(4);
 
 		accessor.withWriteTx((tx) =>
-			resolveRequeuedDreamingEvidenceInTx(tx, AGENT, { ok: true, items: [{ index: 0, ok: true }] }, [
+			resolveRequeuedDreamingEvidenceInTx(tx, AGENT, "repair-pass", { ok: true, items: [{ index: 0, ok: true }] }, [
 				{ evidence: [{ source_ref: "transcript:incomplete", quote: "now complete" }] },
 			]),
 		);
@@ -810,6 +810,7 @@ describe("Dreaming", () => {
 				)
 				.get(AGENT),
 		).toMatchObject({ resolvedAt: expect.any(String) });
+		expect(getDreamingAttention(accessor, AGENT).filter((item) => item.kind === "evidence_requeue")).toHaveLength(3);
 	});
 
 	it("records the repair classification under the operation's target scope when pre-apply validation fails", async () => {

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -1338,8 +1338,15 @@ export async function runDreamingAgentPass(
 								if (!isRecord(operation)) return [];
 								return [{ evidence: Array.isArray(operation.evidence) ? operation.evidence : [] }];
 							});
+							const operationAgentId =
+								typeof input?.agentId === "string" && input.agentId.trim().length > 0 ? input.agentId.trim() : agentId;
 							rejectedEvidence.push(
-								...collectRejectedDreamingEvidence(accessor, agentId, { ok: false, items: [] }, evidenceOperations),
+								...collectRejectedDreamingEvidence(
+									accessor,
+									operationAgentId,
+									{ ok: false, items: [] },
+									evidenceOperations,
+								),
 							);
 						}
 						failed++;

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -1294,7 +1294,7 @@ export async function runDreamingAgentPass(
 				if (!result.ok && result.items.length === 0) failed++;
 				recordDreamingOperationEffects(accessor, scopeId, effects, result, operations, retirementCandidates);
 				retirementCandidates = new Map();
-				accessor.withWriteTx((db) => resolveRequeuedDreamingEvidenceInTx(db, scopeId, result, operations));
+				accessor.withWriteTx((db) => resolveRequeuedDreamingEvidenceInTx(db, scopeId, passId, result, operations));
 				rejectedEvidence.push(...collectRejectedDreamingEvidence(accessor, scopeId, result, operations));
 			},
 			onToolCall(trace) {

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -53,6 +53,13 @@ import {
 	nextDreamingEvidenceFragment,
 	renderDreamingEvidence,
 } from "./dreaming-evidence";
+import {
+	type RejectedDreamingEvidence,
+	autoRequeueRepairedDreamingEvidence,
+	collectRejectedDreamingEvidence,
+	recordRejectedDreamingEvidenceInTx,
+	resolveRequeuedDreamingEvidenceInTx,
+} from "./dreaming-evidence-retry";
 import type { ApplyDreamingOperationsResult, DreamingOperationRequest } from "./dreaming-operations";
 import {
 	readDreamingRunbook,
@@ -183,6 +190,10 @@ export interface DreamingEvidenceExclusion {
 	readonly sourceKind: EpisodicSourceRecord["kind"];
 	readonly sourceId: string;
 	readonly reason: string;
+	readonly failureClass: string;
+	readonly sourceFingerprint: string | null;
+	readonly retryCount: number;
+	readonly lastRequeuedAt: string | null;
 	readonly passId: string;
 	readonly excludedAt: string;
 	readonly requeueRequestedAt: string | null;
@@ -204,47 +215,6 @@ export interface DreamingAgentExecutor {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function readNonEmptyString(value: unknown): string | null {
-	return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
-}
-
-/**
- * Keep evidence cited by an agent operation that the daemon rejects. The
- * agentic calls preserve this audit/requeue trail even when citation
- * validation fails before the operation service can return per-item results.
- */
-function rejectedAgentEvidence(
-	result: ApplyDreamingOperationsResult,
-	operations: readonly Pick<DreamingOperationRequest, "evidence">[],
-	sources: readonly EpisodicSourceRecord[],
-): readonly EpisodicSourceRecord[] {
-	const rejectedIndexes = new Set<number>(result.items.filter((item) => !item.ok).map((item) => item.index));
-	const rejectedOperations =
-		rejectedIndexes.size > 0
-			? operations.filter((_operation, index) => rejectedIndexes.has(index))
-			: result.ok
-				? []
-				: operations;
-	const references = new Set<string>();
-	for (const operation of rejectedOperations) {
-		for (const evidence of operation.evidence ?? []) {
-			if (!isRecord(evidence)) continue;
-			const sourceRef = readNonEmptyString(evidence.source_ref);
-			if (sourceRef) references.add(sourceRef);
-		}
-	}
-	return sources.filter((source) => references.has(`${source.kind}:${source.id}`));
-}
-
-/** Recover cited sources when tool-schema validation rejects an operation before the apply seam runs. */
-function operationEvidenceFromToolInput(input: unknown): readonly Pick<DreamingOperationRequest, "evidence">[] {
-	if (!isRecord(input) || !Array.isArray(input.operations)) return [];
-	return input.operations.flatMap((operation) => {
-		if (!isRecord(operation) || !Array.isArray(operation.evidence)) return [];
-		return [{ evidence: operation.evidence }];
-	});
 }
 
 // ---------------------------------------------------------------------------
@@ -547,6 +517,8 @@ export function getDreamingEvidenceExclusions(
 			db
 				.prepare(
 					`SELECT source_kind AS sourceKind, source_id AS sourceId, reason,
+				        failure_class AS failureClass, source_fingerprint AS sourceFingerprint,
+				        retry_count AS retryCount, last_requeued_at AS lastRequeuedAt,
 				        pass_id AS passId, excluded_at AS excludedAt,
 				        requeue_requested_at AS requeueRequestedAt, resolved_at AS resolvedAt
 				 FROM dreaming_evidence_exclusions
@@ -581,37 +553,6 @@ export function requestDreamingEvidenceRequeue(
 		});
 		return true;
 	});
-}
-
-function recordDreamingEvidenceExclusionsInTx(
-	db: WriteDb,
-	agentId: string,
-	passId: string,
-	sources: readonly EpisodicSourceRecord[],
-	reason: string,
-): void {
-	const statement = db.prepare(
-		`INSERT INTO dreaming_evidence_exclusions
-		 (agent_id, source_kind, source_id, reason, pass_id, excluded_at, requeue_requested_at, resolved_at)
-			 VALUES (?, ?, ?, ?, ?, datetime('now'), NULL, NULL)
-		 ON CONFLICT(agent_id, source_kind, source_id) DO UPDATE SET
-		   reason = excluded.reason,
-		   pass_id = excluded.pass_id,
-		   excluded_at = excluded.excluded_at,
-		   requeue_requested_at = NULL,
-		   resolved_at = NULL`,
-	);
-	for (const source of sources) statement.run(agentId, source.kind, source.id, reason, passId);
-}
-
-function resolveRequeuedEvidenceInTx(db: WriteDb, agentId: string, sources: readonly EpisodicSourceRecord[]): void {
-	const statement = db.prepare(
-		`UPDATE dreaming_evidence_exclusions
-		 SET resolved_at = datetime('now')
-		 WHERE agent_id = ? AND source_kind = ? AND source_id = ?
-		   AND requeue_requested_at IS NOT NULL AND resolved_at IS NULL`,
-	);
-	for (const source of sources) statement.run(agentId, source.kind, source.id);
 }
 
 // ---------------------------------------------------------------------------
@@ -1332,7 +1273,7 @@ export async function runDreamingAgentPass(
 
 		let applyCallbackReported = false;
 		let retirementCandidates: DreamingRetirementCandidates = new Map();
-		const rejectedEvidence: EpisodicSourceRecord[] = [];
+		const rejectedEvidence: RejectedDreamingEvidence[] = [];
 		// The newest captured_at each scope's search_evidence surfaced this
 		// pass; the pass-end watermark may advance only to it (#1149).
 		const surfacedWatermarkByScope = new Map<string, string>();
@@ -1353,7 +1294,8 @@ export async function runDreamingAgentPass(
 				if (!result.ok && result.items.length === 0) failed++;
 				recordDreamingOperationEffects(accessor, scopeId, effects, result, operations, retirementCandidates);
 				retirementCandidates = new Map();
-				rejectedEvidence.push(...rejectedAgentEvidence(result, operations, []));
+				accessor.withWriteTx((db) => resolveRequeuedDreamingEvidenceInTx(db, scopeId, result, operations));
+				rejectedEvidence.push(...collectRejectedDreamingEvidence(accessor, scopeId, result, operations));
 			},
 			onToolCall(trace) {
 				recordDreamingToolCall(accessor, agentId, passId, ++toolCallSequence, trace);
@@ -1389,9 +1331,17 @@ export async function runDreamingAgentPass(
 				}
 				if (trace.tool === "apply_ontology_ops") {
 					if (!trace.output.ok && !applyCallbackReported) {
-						rejectedEvidence.push(
-							...rejectedAgentEvidence({ ok: false, items: [] }, operationEvidenceFromToolInput(trace.input), []),
-						);
+						const input = isRecord(trace.input) ? trace.input : null;
+						const operations = input?.operations;
+						if (Array.isArray(operations)) {
+							const evidenceOperations = operations.flatMap((operation) => {
+								if (!isRecord(operation)) return [];
+								return [{ evidence: Array.isArray(operation.evidence) ? operation.evidence : [] }];
+							});
+							rejectedEvidence.push(
+								...collectRejectedDreamingEvidence(accessor, agentId, { ok: false, items: [] }, evidenceOperations),
+							);
+						}
 						failed++;
 					}
 					applyCallbackReported = false;
@@ -1465,7 +1415,7 @@ export async function runDreamingAgentPass(
 				summary,
 				passId,
 			);
-			recordDreamingEvidenceExclusionsInTx(db, agentId, passId, rejectedEvidence, "semantic_operation_rejected");
+			recordRejectedDreamingEvidenceInTx(db, passId, rejectedEvidence);
 			// The evidence queue resets to the pass watermark for EVERY scope
 			// the pass consumed evidence for: the next pass's backlog counts
 			// only sources captured after the surfaced frontier. A hygiene

--- a/web/docs/src/content/docs/api/knowledge-ontology.md
+++ b/web/docs/src/content/docs/api/knowledge-ontology.md
@@ -400,6 +400,8 @@ episodic evidence. Requires `admin` permission.
       "sourceKind": "artifact",
       "sourceId": "sources/notebook/large-export.md",
       "reason": "semantic_operation_rejected",
+      "failureClass": "quote_mismatch",
+      "retryCount": 0,
       "passId": "pass-uuid",
       "excludedAt": "2026-04-01 12:00:00",
       "requeueRequestedAt": null,
@@ -424,6 +426,16 @@ not modify or discard the underlying episodic evidence. Current Dreaming passes
 record `semantic_operation_rejected` when the daemon rejects an agent's cited
 semantic operation. Oversized immutable evidence is instead resumed at a safe
 boundary across passes and is not quarantined.
+
+Transient exclusions are classified as `incomplete_transcript`,
+`source_projection`, `scope_mismatch`, or `quote_mismatch`. The worker compares
+the current canonical source fingerprint with the quarantined fingerprint and
+automatically requests a bounded retry when a repair is visible. Automatic
+retries use the repair cooldown and hourly budget, allow at most three attempts
+per exclusion, and mint the same scoped `evidence_requeue` attention as an
+explicit request. An unchanged source, an unknown failure, or a source outside
+the agent scope remains quarantined. The exclusion row stays auditable until a
+subsequent accepted citation resolves it.
 
 An attention item is selected with the next scoped pass and rendered as
 non-evidentiary context. It resolves when the pass applies a hygiene operation


### PR DESCRIPTION
## Summary

Closes #1346. Make quarantined Dreaming evidence retryable after the canonical source is repaired, without mutating the source or losing the quarantine audit trail.

## Changes

- Add migration 122 with failure classification, source fingerprints, bounded retry counters, and retry timestamps.
- Classify rejected citations as incomplete transcript, source projection, scope mismatch, quote mismatch, or unknown.
- Automatically mint scoped `evidence_requeue` attention only when a transient source has changed, subject to cooldown, hourly budget, and three-attempt maximum.
- Preserve explicit requeue and resolve both the audit row and matching requeue attention only after a subsequent accepted citation.
- Include quarantine-only agents in Dreaming scope discovery.
- Add migration, classification, retry, scope-discovery, and exact-quote regression tests.
- Document the retry and audit behavior.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: daemon API documentation

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

Migration 122 is additive and preserves all existing exclusion rows. Existing rows receive `unknown` classification and are not auto-requeued until a new rejection records a transient classification; explicit requeue remains available. The exclusion row is retained after successful retry and marked resolved.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused verification passes:

- `bun test platform/daemon/src/pipeline/dreaming.test.ts platform/daemon/src/pipeline/dreaming-worker.test.ts platform/core/src/migrations/migrations.test.ts` (110 passed, 0 failed)
- `bun run --filter '@signet/core' build`
- `bun run --filter '@signet/daemon' build`
- touched-file `bunx biome check`
- `git diff --check`

The repository-wide typecheck and lint commands were also attempted. They remain blocked by pre-existing unrelated connector/package errors and repository-wide formatting drift; no unrelated fixes were included in this PR.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Automatic retries are deliberately conservative: unchanged or unknown failures remain quarantined, exact quote validation is still performed by the existing ontology operation path, and retry state plus attention creation or resolution are committed atomically.


