### PR TITLE
fix(daemon): bound SQLite writer admission

### DIFF
--- a/platform/daemon/src/db-accessor.test.ts
+++ b/platform/daemon/src/db-accessor.test.ts
@@ -6,6 +6,8 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	DbWriteQueueFullError,
+	MAX_WRITE_QUEUE,
 	backupBeforeMigration,
 	closeDbAccessor,
 	getDbAccessor,
@@ -119,6 +121,76 @@ describe("DbAccessor", () => {
 		});
 		expect(rows).toHaveLength(1);
 		expect(rows[0].id).toBe(1);
+	});
+
+	test("async writes are admitted in order and yield between transactions", async () => {
+		const dbPath = tmpDbPath();
+		cleanupDirs.push(join(dbPath, ".."));
+		initDbAccessor(dbPath);
+		const acc = getDbAccessor();
+		const enqueue = acc.withWriteTxAsync;
+		if (!enqueue) throw new Error("async write API is unavailable");
+
+		acc.withWriteTx((db) => {
+			db.exec("CREATE TABLE async_write_test (id INTEGER PRIMARY KEY)");
+		});
+
+		const writes = Array.from({ length: 4 }, (_, id) =>
+			enqueue((db) => {
+				db.prepare("INSERT INTO async_write_test (id) VALUES (?)").run(id);
+				return id;
+			}),
+		);
+		expect(acc.getWritePressure?.().queued).toBe(4);
+		expect(await Promise.all(writes)).toEqual([0, 1, 2, 3]);
+		expect(acc.getWritePressure?.().queued).toBe(0);
+		expect(acc.getWritePressure?.().lastDurationMs).toBeNumber();
+
+		const count = acc.withReadDb(
+			(db) => (db.prepare("SELECT COUNT(*) AS n FROM async_write_test").get() as { n: number }).n,
+		);
+		expect(count).toBe(4);
+	});
+
+	test("async maintenance writes use the bounded writer queue", async () => {
+		const dbPath = tmpDbPath();
+		cleanupDirs.push(join(dbPath, ".."));
+		initDbAccessor(dbPath);
+		const acc = getDbAccessor();
+		const checkpoint = acc.checkpointWalAsync;
+		const vacuum = acc.incrementalVacuumAsync;
+		if (!checkpoint || !vacuum) throw new Error("async maintenance API is unavailable");
+
+		await checkpoint();
+		expect(await vacuum()).toBeNumber();
+		expect(acc.getWritePressure?.().lastDurationMs).toBeNumber();
+	});
+
+	test("async write admission rejects work beyond the bounded queue", async () => {
+		const dbPath = tmpDbPath();
+		cleanupDirs.push(join(dbPath, ".."));
+		initDbAccessor(dbPath);
+		const acc = getDbAccessor();
+		const enqueue = acc.withWriteTxAsync;
+		if (!enqueue) throw new Error("async write API is unavailable");
+
+		const pending = Array.from({ length: MAX_WRITE_QUEUE }, () => enqueue(() => undefined));
+		const rejected = enqueue(() => undefined);
+		await expect(rejected).rejects.toBeInstanceOf(DbWriteQueueFullError);
+		await Promise.all(pending);
+	});
+
+	test("close rejects queued async writes", async () => {
+		const dbPath = tmpDbPath();
+		cleanupDirs.push(join(dbPath, ".."));
+		initDbAccessor(dbPath);
+		const acc = getDbAccessor();
+		const enqueue = acc.withWriteTxAsync;
+		if (!enqueue) throw new Error("async write API is unavailable");
+
+		const pending = enqueue(() => undefined);
+		closeDbAccessor();
+		await expect(pending).rejects.toThrow("DbAccessor is closed");
 	});
 
 	test("close works without error", () => {

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -128,9 +128,47 @@ export interface ReadDb {
 	prepare(sql: string): SqliteStatement;
 }
 
+export interface WritePressure {
+	/** Number of async write operations waiting for admission. */
+	readonly queued: number;
+	/** Maximum number of async write operations waiting for admission. */
+	readonly maxQueue: number;
+	/** Age of the oldest queued operation, or null when the queue is empty. */
+	readonly oldestWaitMs: number | null;
+	/** Duration of the most recently completed write operation. */
+	readonly lastDurationMs: number | null;
+}
+
+export class DbWriteQueueFullError extends Error {
+	readonly code = "DB_WRITE_QUEUE_FULL" as const;
+
+	constructor() {
+		super("Database write queue is full; retry after write pressure clears");
+		this.name = "DbWriteQueueFullError";
+	}
+}
+
 export interface DbAccessor {
 	/** Run `fn` inside BEGIN IMMEDIATE / COMMIT (ROLLBACK on error). */
 	withWriteTx<T>(fn: (db: WriteDb) => T): T;
+
+	/**
+	 * Admit a write transaction through the bounded async writer queue.
+	 *
+	 * The synchronous API remains available for transactions that must be
+	 * composed inline. Async request and background paths should prefer this
+	 * method so bursts are bounded instead of accumulating unobserved work.
+	 */
+	withWriteTxAsync?<T>(fn: (db: WriteDb) => T): Promise<T>;
+
+	/** Admit a WAL checkpoint through the bounded async writer queue. */
+	checkpointWalAsync?(): Promise<void>;
+
+	/** Admit incremental vacuum through the bounded async writer queue. */
+	incrementalVacuumAsync?(): Promise<number>;
+
+	/** Return bounded local diagnostics for the writer admission path. */
+	getWritePressure?(): WritePressure;
 
 	/** Open a readonly connection, run `fn`, close it. */
 	withReadDb<T>(fn: (db: ReadDb) => T): T;
@@ -1004,10 +1042,24 @@ function backfillVecEmbeddings(db: SqliteDatabase, expectedDimensions: number): 
 
 const READ_POOL_SIZE = 4;
 const MAX_READ_CONNECTIONS = 16;
+export const MAX_WRITE_QUEUE = 64;
+
+type WriteJob<T> = {
+	readonly run: () => T;
+	readonly queuedAt: number;
+	readonly resolve: (value: T | PromiseLike<T>) => void;
+	readonly reject: (reason?: unknown) => void;
+};
+
+function yieldToEventLoop(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
 
 function createAccessor(writeConn: SqliteDatabase): DbAccessor {
 	let closed = false;
-
+	let writeDraining = false;
+	let lastWriteDurationMs: number | null = null;
+	const writeQueue: WriteJob<unknown>[] = [];
 	// Small pool of reusable read connections. Recall does 3 reads per
 	// request so opening/closing every time adds measurable overhead.
 	const readPool: SqliteDatabase[] = [];
@@ -1040,23 +1092,112 @@ function createAccessor(writeConn: SqliteDatabase): DbAccessor {
 		}
 	}
 
+	function runWriteOperation<T>(fn: () => T): T {
+		const startedAt = performance.now();
+		try {
+			return fn();
+		} finally {
+			lastWriteDurationMs = performance.now() - startedAt;
+			observeDbLatency(lastWriteDurationMs);
+		}
+	}
+
+	function runWriteTx<T>(fn: (db: WriteDb) => T): T {
+		return runWriteOperation(() => {
+			writeConn.exec("BEGIN IMMEDIATE");
+			try {
+				const result = fn(writeConn);
+				writeConn.exec("COMMIT");
+				return result;
+			} catch (err) {
+				writeConn.exec("ROLLBACK");
+				throw err;
+			}
+		});
+	}
+
+	function runCheckpointWal(): void {
+		runWriteOperation(() => {
+			writeConn.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+		});
+	}
+
+	function runIncrementalVacuum(): number {
+		return runWriteOperation(() => {
+			writeConn.exec("PRAGMA incremental_vacuum");
+			const row = writeConn.prepare("PRAGMA freelist_count").get() as { freelist_count?: number } | undefined;
+			return typeof row?.freelist_count === "number" ? row.freelist_count : 0;
+		});
+	}
+
+	function enqueueWrite<T>(run: () => T): Promise<T> {
+		if (closed) return Promise.reject(new Error("DbAccessor is closed"));
+		if (writeQueue.length >= MAX_WRITE_QUEUE) return Promise.reject(new DbWriteQueueFullError());
+		return new Promise<T>((resolve, reject) => {
+			writeQueue.push({
+				run,
+				queuedAt: performance.now(),
+				resolve: (value) => resolve(value as T),
+				reject,
+			});
+			drainWriteQueue();
+		});
+	}
+
+	function drainWriteQueue(): void {
+		if (writeDraining) return;
+		writeDraining = true;
+		const next = (): void => {
+			const job = writeQueue.shift();
+			if (!job) {
+				writeDraining = false;
+				return;
+			}
+			if (closed) {
+				job.reject(new Error("DbAccessor is closed"));
+				setTimeout(next, 0);
+				return;
+			}
+			try {
+				job.resolve(job.run());
+			} catch (err) {
+				job.reject(err);
+			}
+			if (writeQueue.length > 0) {
+				void yieldToEventLoop().then(next);
+			} else {
+				writeDraining = false;
+			}
+		};
+		void yieldToEventLoop().then(next);
+	}
+
 	return {
 		withWriteTx<T>(fn: (db: WriteDb) => T): T {
 			if (closed) throw new Error("DbAccessor is closed");
-			const startedAt = performance.now();
-			try {
-				writeConn.exec("BEGIN IMMEDIATE");
-				try {
-					const result = fn(writeConn);
-					writeConn.exec("COMMIT");
-					return result;
-				} catch (err) {
-					writeConn.exec("ROLLBACK");
-					throw err;
-				}
-			} finally {
-				observeDbLatency(performance.now() - startedAt);
-			}
+			return runWriteTx(fn);
+		},
+
+		withWriteTxAsync<T>(fn: (db: WriteDb) => T): Promise<T> {
+			return enqueueWrite(() => runWriteTx(fn));
+		},
+
+		checkpointWalAsync(): Promise<void> {
+			return enqueueWrite(runCheckpointWal);
+		},
+
+		incrementalVacuumAsync(): Promise<number> {
+			return enqueueWrite(runIncrementalVacuum);
+		},
+
+		getWritePressure(): WritePressure {
+			const oldest = writeQueue[0];
+			return {
+				queued: writeQueue.length,
+				maxQueue: MAX_WRITE_QUEUE,
+				oldestWaitMs: oldest ? Math.max(0, performance.now() - oldest.queuedAt) : null,
+				lastDurationMs: lastWriteDurationMs,
+			};
 		},
 
 		withReadDb<T>(fn: (db: ReadDb) => T): T {
@@ -1085,24 +1226,12 @@ function createAccessor(writeConn: SqliteDatabase): DbAccessor {
 
 		checkpointWal(): void {
 			if (closed) throw new Error("DbAccessor is closed");
-			const startedAt = performance.now();
-			try {
-				writeConn.exec("PRAGMA wal_checkpoint(TRUNCATE)");
-			} finally {
-				observeDbLatency(performance.now() - startedAt);
-			}
+			runCheckpointWal();
 		},
 
 		incrementalVacuum(): number {
 			if (closed) throw new Error("DbAccessor is closed");
-			const startedAt = performance.now();
-			try {
-				writeConn.exec("PRAGMA incremental_vacuum");
-				const row = writeConn.prepare("PRAGMA freelist_count").get() as { freelist_count?: number } | undefined;
-				return typeof row?.freelist_count === "number" ? row.freelist_count : 0;
-			} finally {
-				observeDbLatency(performance.now() - startedAt);
-			}
+			return runIncrementalVacuum();
 		},
 
 		close(): void {

--- a/platform/daemon/src/embedding-index-migration.test.ts
+++ b/platform/daemon/src/embedding-index-migration.test.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
 import { findSqliteVecExtension } from "@signet/core";
 import { up as embeddingIndexGenerations } from "../../core/src/migrations/091-embedding-index-generations";
-import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
+import { type DbAccessor, DbWriteQueueFullError, type ReadDb, type WriteDb } from "./db-accessor";
 import {
 	promoteStagingIndex,
 	stageEmbeddingBatch,
@@ -420,5 +420,45 @@ describe("staging migration lifecycle", () => {
 		const state = readEmbeddingIndexState(raw as unknown as ReadDb);
 		expect(state?.staging?.model).toBe("custom-c");
 		await handle?.stop();
+	});
+
+	it("retries a full async write queue without rejecting the migration tick (#1349)", async () => {
+		const raw = new Database(":memory:");
+		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);
+		raw.exec(`
+			CREATE TABLE embeddings (id TEXT, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER, source_type TEXT, source_id TEXT, chunk_text TEXT, created_at TEXT, agent_id TEXT);
+			CREATE TABLE embeddings_staging (id TEXT, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER, source_type TEXT, source_id TEXT, chunk_text TEXT, created_at TEXT, agent_id TEXT);
+			CREATE TABLE vec_embeddings (id TEXT PRIMARY KEY, embedding BLOB);
+			CREATE TABLE vec_embeddings_staging (id TEXT PRIMARY KEY, embedding BLOB);
+		`);
+		const db = raw as unknown as WriteDb;
+		const active = {
+			provider: "ollama",
+			model: "custom-a",
+			dimensions: 3,
+			base_url: "http://127.0.0.1:11434",
+		} as const;
+		const desired = { ...active, model: "custom-b" };
+		ensureEmbeddingIndexState(db, active);
+		beginEmbeddingIndexBuild(db, desired);
+		const accessor: DbAccessor = {
+			withWriteTx: (fn) => fn(db),
+			withWriteTxAsync: <T>(_fn: (writeDb: WriteDb) => T): Promise<T> => Promise.reject(new DbWriteQueueFullError()),
+			withReadDb: (fn) => fn(raw as unknown as ReadDb),
+			close: () => undefined,
+		};
+		const handle = startEmbeddingIndexMigration({
+			accessor,
+			configured: desired,
+			fetchEmbedding: async () => [0, 0, 0],
+			checkProvider: async () => ({ available: true }),
+			pollMs: 2,
+			batchSize: 10,
+		});
+		expect(handle).not.toBeNull();
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(handle?.getStats().running).toBe(true);
+		await handle?.stop();
+		expect(handle?.getStats().running).toBe(false);
 	});
 });

--- a/platform/daemon/src/embedding-index-migration.ts
+++ b/platform/daemon/src/embedding-index-migration.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
+import { type DbAccessor, DbWriteQueueFullError, type ReadDb, type WriteDb } from "./db-accessor";
 import { vectorToBlob } from "./db-helpers";
 import type { EmbeddingFetchOptions } from "./embedding-fetch";
 import {
@@ -70,6 +70,11 @@ function configForProfile(profile: PersistedEmbeddingProfile, configured: Embedd
 
 function tableExists(db: ReadDb, name: string): boolean {
 	return db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(name) !== undefined;
+}
+
+async function withQueuedWrite<T>(accessor: DbAccessor, fn: (db: WriteDb) => T): Promise<T> {
+	if (accessor.withWriteTxAsync) return accessor.withWriteTxAsync(fn);
+	return accessor.withWriteTx(fn);
 }
 
 function isVecVirtualTable(db: ReadDb, name: string): boolean {
@@ -146,8 +151,8 @@ export function stagingCoverage(db: ReadDb, dimensions: number): EmbeddingMigrat
 }
 
 /** Remove rows whose active source was deleted or changed while staging ran. */
-function pruneStagingRows(accessor: DbAccessor): void {
-	accessor.withWriteTx((db) => {
+async function pruneStagingRows(accessor: DbAccessor): Promise<void> {
+	await withQueuedWrite(accessor, (db) => {
 		const stale = db
 			.prepare(
 				`SELECT s.id FROM embeddings_staging s
@@ -185,7 +190,7 @@ export async function stageEmbeddingBatch(input: {
 	// Writes and source purges continue against the active slot during a build.
 	// Without this cleanup, an obsolete staging row would keep the count-based
 	// readiness gate false forever after its active counterpart disappears.
-	pruneStagingRows(input.accessor);
+	await pruneStagingRows(input.accessor);
 	const rows = input.accessor.withReadDb((db) => {
 		if (!tableExists(db, STAGING_VECTOR_TABLE)) throw new Error("Staging vector index is unavailable");
 		return db
@@ -211,7 +216,7 @@ export async function stageEmbeddingBatch(input: {
 				`Staging provider returned ${vector.length} dimensions for ${profile.model}; expected ${profile.dimensions}`,
 			);
 		}
-		input.accessor.withWriteTx((db) => {
+		await withQueuedWrite(input.accessor, (db) => {
 			const id = randomUUID();
 			db.prepare(
 				`INSERT INTO embeddings_staging
@@ -329,6 +334,7 @@ export function startEmbeddingIndexMigration(input: {
 	// ~100% CPU forever retrying an unreachable provider.
 	let consecutiveFailures = 0;
 	let nextDelayMs = input.pollMs;
+	let tickPromise: Promise<void> | null = null;
 
 	const before = input.accessor.withReadDb((db) => readEmbeddingIndexState(db));
 	const initial = input.accessor.withWriteTx((db) => beginEmbeddingIndexBuild(db, input.configured));
@@ -361,7 +367,7 @@ export function startEmbeddingIndexMigration(input: {
 			// from disk each tick): a no-op when nothing changed, a restart when
 			// the config did.
 			const configured = input.readConfigured ? input.readConfigured() : input.configured;
-			const restarted = input.accessor.withWriteTx((db) => beginEmbeddingIndexBuild(db, configured));
+			const restarted = await withQueuedWrite(input.accessor, (db) => beginEmbeddingIndexBuild(db, configured));
 			if (restarted.state !== "building" || !restarted.staging) {
 				// The live config now matches the active generation, so begin
 				// abandoned the in-flight build; stop polling until a new build
@@ -375,7 +381,7 @@ export function startEmbeddingIndexMigration(input: {
 					"embedding",
 					"Embedding config changed during migration; restarting the staging build with the current profile",
 				);
-				input.accessor.withWriteTx((db) => resetStagingVectorIndex(db, currentStaging.dimensions));
+				await withQueuedWrite(input.accessor, (db) => resetStagingVectorIndex(db, currentStaging.dimensions));
 				consecutiveFailures = 0;
 				return;
 			}
@@ -386,7 +392,7 @@ export function startEmbeddingIndexMigration(input: {
 				if (consecutiveFailures >= MAX_CONSECUTIVE_PROVIDER_FAILURES) {
 					const message = `Embedding provider unavailable after ${consecutiveFailures} consecutive checks; aborting the build`;
 					logger.error("embedding", message);
-					input.accessor.withWriteTx((db) => failEmbeddingIndexBuild(db, message));
+					await withQueuedWrite(input.accessor, (db) => failEmbeddingIndexBuild(db, message));
 					running = false;
 					return;
 				}
@@ -402,22 +408,53 @@ export function startEmbeddingIndexMigration(input: {
 				input.onPromoted?.();
 			}
 		} catch (error) {
+			if (error instanceof DbWriteQueueFullError) {
+				nextDelayMs = Math.min(Math.max(input.pollMs, 100), MAX_PROVIDER_BACKOFF_MS);
+				logger.warn("embedding", "Embedding migration write admission is full; retrying later");
+				return;
+			}
+			if (!running || (error instanceof Error && error.message === "DbAccessor is closed")) {
+				running = false;
+				return;
+			}
 			consecutiveFailures++;
 			failed++;
-			input.accessor.withWriteTx((db) =>
-				failEmbeddingIndexBuild(db, error instanceof Error ? error.message : String(error)),
-			);
+			try {
+				await withQueuedWrite(input.accessor, (db) =>
+					failEmbeddingIndexBuild(db, error instanceof Error ? error.message : String(error)),
+				);
+			} catch (persistError) {
+				logger.warn("embedding", "Failed to persist embedding migration failure", {
+					error: persistError instanceof Error ? persistError.message : String(persistError),
+				});
+			}
 			running = false;
 		} finally {
-			if (running) timer = setTimeout(() => void tick(), nextDelayMs);
+			if (running) timer = setTimeout(scheduleTick, nextDelayMs);
 		}
 	};
-	void tick();
+
+	const scheduleTick = (): void => {
+		const promise = tick();
+		tickPromise = promise;
+		void promise
+			.catch((error: unknown) => {
+				running = false;
+				logger.warn("embedding", "Embedding migration tick failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			})
+			.finally(() => {
+				if (tickPromise === promise) tickPromise = null;
+			});
+	};
+	scheduleTick();
 
 	return {
 		async stop(): Promise<void> {
 			running = false;
 			if (timer) clearTimeout(timer);
+			if (tickPromise) await tickPromise;
 		},
 		getStats: () => ({ running, staged, failed, coverage }),
 	};

--- a/platform/daemon/src/pipeline/maintenance-worker.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.ts
@@ -368,7 +368,11 @@ export function startMaintenanceWorker(
 		try {
 			const ratio = accessor.withReadDb((db) => getFreePageRatio(db));
 			if (ratio >= 0.2) {
-				accessor.incrementalVacuum();
+				if (accessor.incrementalVacuumAsync) {
+					await accessor.incrementalVacuumAsync();
+				} else {
+					accessor.incrementalVacuum();
+				}
 			}
 		} catch {
 			// Non-fatal — vacuum should never interrupt the maintenance cycle

--- a/platform/daemon/src/routes/health.test.ts
+++ b/platform/daemon/src/routes/health.test.ts
@@ -189,6 +189,11 @@ describe("GET /health (back-compat)", () => {
 		expect(typeof body.uptime).toBe("number");
 		expect(typeof body.pid).toBe("number");
 		expect(typeof body.version).toBe("string");
+		const dbWriter = body.dbWriter as Record<string, unknown>;
+		expect(typeof dbWriter.queued).toBe("number");
+		expect(typeof dbWriter.maxQueue).toBe("number");
+		expect(dbWriter.oldestWaitMs === null || typeof dbWriter.oldestWaitMs === "number").toBe(true);
+		expect(dbWriter.lastDurationMs === null || typeof dbWriter.lastDurationMs === "number").toBe(true);
 		const resources = body.resources as Record<string, unknown>;
 		expect(typeof resources.rss).toBe("number");
 		expect(typeof resources.heapUsed).toBe("number");

--- a/platform/daemon/src/routes/health.ts
+++ b/platform/daemon/src/routes/health.ts
@@ -1,7 +1,7 @@
 import type { SQLQueryBindings } from "bun:sqlite";
 import { type MigrationDb, hasPendingMigrations } from "@signet/core";
 import type { Hono } from "hono";
-import { type ReadDb, getDbAccessor } from "../db-accessor";
+import { type ReadDb, type WritePressure, getDbAccessor } from "../db-accessor";
 import {
 	QUEUE_MAX_DEAD_RATE,
 	QUEUE_MAX_DEPTH,
@@ -179,11 +179,14 @@ export function mountHealthRoutes(app: Hono): void {
 	app.get("/health", (c) => {
 		const us = getUpdateState();
 		let dbOk = false;
+		let dbWriter: WritePressure | null = null;
 		try {
-			getDbAccessor().withReadDb((db) => {
+			const accessor = getDbAccessor();
+			accessor.withReadDb((db) => {
 				db.prepare("SELECT 1").get();
 				dbOk = true;
 			});
+			dbWriter = accessor.getWritePressure?.() ?? null;
 		} catch {}
 
 		return c.json({
@@ -194,6 +197,7 @@ export function mountHealthRoutes(app: Hono): void {
 			port: PORT,
 			agentsDir: AGENTS_DIR,
 			db: dbOk,
+			dbWriter,
 			shuttingDown,
 			updateAvailable: us.lastCheck?.updateAvailable ?? false,
 			pendingRestart: us.pendingRestartVersion !== null,

--- a/platform/daemon/src/yielding-writes.ts
+++ b/platform/daemon/src/yielding-writes.ts
@@ -23,8 +23,8 @@
  */
 
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
-import { awaitPressureClear, isSystemPressureHigh } from "./system-pressure";
 import { logger } from "./logger";
+import { awaitPressureClear, isSystemPressureHigh } from "./system-pressure";
 
 /** Yield a macrotask so pending HTTP handlers (and the event-loop monitor) can run. */
 const yieldToEventLoop = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
@@ -51,6 +51,14 @@ export interface DrainResult {
 	readonly batches: number;
 	readonly paused: number;
 	readonly stopped: "exhausted" | "capped";
+}
+
+async function writeBatch(accessor: DbAccessor, processBatch: (db: WriteDb) => void): Promise<void> {
+	if (accessor.withWriteTxAsync) {
+		await accessor.withWriteTxAsync(processBatch);
+		return;
+	}
+	accessor.withWriteTx(processBatch);
 }
 
 /**
@@ -97,8 +105,8 @@ export async function drainWriteBatches<Item>(
 			await awaitPressureClear();
 		}
 
-		// 3. Process in one short transaction.
-		accessor.withWriteTx((db) => processBatch(db, batch));
+		// 3. Process in one short transaction through bounded writer admission.
+		await writeBatch(accessor, (db) => processBatch(db, batch));
 
 		processed += batch.length;
 		batches++;

--- a/web/docs/src/content/docs/api/health-status.md
+++ b/web/docs/src/content/docs/api/health-status.md
@@ -26,6 +26,12 @@ and `GET /health/ready` for readiness.
   "port": 3850,
   "agentsDir": "/home/user/.agents",
   "db": true,
+  "dbWriter": {
+    "queued": 0,
+    "maxQueue": 64,
+    "oldestWaitMs": null,
+    "lastDurationMs": 2.1
+  },
   "shuttingDown": false,
   "updateAvailable": false,
   "pendingRestart": false,

--- a/web/docs/src/content/docs/daemon.md
+++ b/web/docs/src/content/docs/daemon.md
@@ -277,6 +277,12 @@ GET /health
   "port": 3850,
   "agentsDir": "/home/user/.agents",
   "db": true,
+  "dbWriter": {
+    "queued": 0,
+    "maxQueue": 64,
+    "oldestWaitMs": null,
+    "lastDurationMs": 2.1
+  },
   "shuttingDown": false,
   "updateAvailable": false,
   "pendingRestart": false,
@@ -284,8 +290,10 @@ GET /health
 }
 ```
 
-`GET /health` is the legacy health check. For orchestration and monitoring,
-prefer the dedicated probes: `GET /health/live` is a cheap liveness probe that
+`GET /health` remains the legacy health check. `dbWriter` is local writer-pressure diagnostics: `queued` counts waiting writes, `oldestWaitMs` reports the oldest wait, and `lastDurationMs` reports the last completed write. Async write paths are admitted through a bounded queue; when `queued` reaches `maxQueue`, callers receive a retryable `DB_WRITE_QUEUE_FULL` error instead of adding unbounded work. The legacy synchronous transaction API remains available for startup and atomic control-plane operations.
+
+For orchestration and monitoring, prefer the dedicated probes: `GET /health/live`
+is a cheap liveness probe that
 never touches the database or subsystems (always 200 while the process is up),
 and `GET /health/ready` returns 200 only when the database, migrations,
 embedding, inference, and queue gates all pass — 503 with a `reasons` list


### PR DESCRIPTION
## Summary

Fixes #1349 by adding bounded async admission for daemon SQLite writes and exposing writer pressure for diagnosis. The queue yields between synchronous SQLite operations, rejects excess work with a retryable error, and reports queue depth, wait age, and last completed write duration.

## Changes

- Added a bounded async writer queue with FIFO ordering, close rejection, rollback preservation, and `DB_WRITE_QUEUE_FULL` backpressure.
- Added queued async checkpoint and incremental-vacuum operations.
- Routed embedding-index migration, yielding write batches, and maintenance vacuum through async admission when available.
- Added `/health` `dbWriter` diagnostics and documentation.
- Kept the synchronous API for startup and atomic control-plane callers while providing the migration seam for remaining legacy paths.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [x] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused verification completed:

- `bun test platform/daemon/src/routes/health.test.ts platform/daemon/src/embedding-index-migration.test.ts platform/daemon/src/db-accessor.test.ts platform/daemon/src/yielding-writes.test.ts`: 52 passed, 0 failed.
- `bun run --filter '@signet/daemon' typecheck`: passed.
- `bunx biome check` on all changed TypeScript files: passed.
- `bun build.ts` from `platform/daemon`: passed for all four daemon bundles.
- `git diff --check`: passed.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This is intentionally incremental rather than a wholesale rewrite of every existing synchronous caller. The bounded path is now exercised by the embedding migration, yielding batches, and maintenance vacuum; startup and atomic control-plane code retains the synchronous API for compatibility. Full daemon package build orchestration was attempted but timed out under concurrent host load; the direct daemon bundle build and daemon typecheck passed.
