### PR TITLE
docs(telemetry): catalog health events

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -80,6 +80,7 @@ paths, or user identity.
 | `daemon.started` | daemon boot | `version`, `platform`, `uptimeMs` |
 | `daemon.previous_exit` | next successful boot reconciles the prior lifecycle record, exactly once when one exists | `classification` (`clean` / `error` / `unrecorded`), `reasonCategory`, `exitCode`, `previousVersion`, `previousUptimeMs`, `restartDelayMs` |
 | `daemon.heartbeat` | every 5 minutes | `uptimeMs`, `memoryCount`, `connectorsActive`, `pipelineMode`, `extractionProvider`, `embeddingProvider`, bounded runtime-pressure buckets |
+| `telemetry.health` | every scheduled telemetry flush | `status`, `deliveryConfigured`, queue/buffer counts, unsent and delivery age buckets, recent success/failure counts, backoff state, dropped-event count, `flushIntervalMs` |
 | `session.start` | real session start (deduped; stubs and clear/reset paths don't count) | `harness`, `sessionHash` |
 | `session.turn` | every non-boundary `session-end` hook call (per turn, see notes) | `harness`, `promptCount`, `sessionHash` |
 | `session.end` | real session termination: an explicit boundary reason or a TTL-evicted (abandoned) session claim | `harness`, `reason` (`clear` / `session.deleted` / `session_branch` / `session_fork` / `session_shutdown` / `session_switch` / `stale-session-sweep` / `expired`), `sessionHash`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `cost`, `accountingProvenance` |


### PR DESCRIPTION
## Summary

Add the shipped `telemetry.health` event to the normative telemetry event catalog.

## Changes

- Document the event cadence and aggregate payload fields in `docs/TELEMETRY.md`.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [x] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [x] Other: documentation only

## Screenshots

N/A: documentation-only change.

## PR Readiness (MANDATORY)

- [ ] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [ ] Agent scoping verified on all new/changed data queries
- [ ] Input/config validation and bounds checks added
- [ ] Error handling and fallback paths tested (no silent swallow)
- [ ] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [ ] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A: no migration changes.

## Testing

- [x] `git diff --check`
- [x] N/A: documentation-only change

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Follow-up to the telemetry delivery-health work in merged PR #1305; no runtime behavior changes.

The full-repository `bun run lint` and `bun run typecheck` checks are currently blocked by unrelated pre-existing repository failures. `bun run lint` reports 507 existing Biome errors and 157 warnings in files outside this change; `bun run typecheck` reports existing connector export/bundle errors. The changed file passes `git diff --check`.
