### PR TITLE
feat(dreaming): fair progress across agent scopes

### DIFF
--- a/docs/dreaming-skill-runbook.md
+++ b/docs/dreaming-skill-runbook.md
@@ -5,6 +5,13 @@ audited semantic memory. It reads selected artifacts, transcripts, summaries,
 compactions, and checkpoints; it does not rewrite them. The worker emits
 provenance-backed ontology operations through the shared daemon-owned writer.
 
+Each automatic pass gives every eligible agent scope one sequential bounded
+turn. Attention priority chooses turn order, while evidence and model-output
+budgets are divided across scopes so a large backlog cannot starve a smaller
+scope. A failed scope turn leaves that scope's cursor pending and does not
+block healthy scopes in the same persisted pass. Automatic sweeps honor that
+scope's failure backoff; explicit operator triggers can retry it immediately.
+
 ## Worker Path
 
 Inspect the current graph write gates and worker state:

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -40,6 +40,7 @@ flowchart TD
   PAF[Predictor Agent Feedback]
   SACC[Sub-Agent Context Continuity]
   DMC[Dreaming Memory Consolidation]
+  DSF[Dreaming Scope Fair Progress]
 
   subgraph W9[Wave 9 Strategic Stubs]
     DHO[Distributed Harness Orchestration]
@@ -98,6 +99,8 @@ flowchart TD
   MP --> DMC
   KA --> DMC
   SCP -.-> DMC
+  DMC --> DSF
+  MA --> DSF
 
   MA --> DHO
   SR --> DHO
@@ -150,6 +153,7 @@ and market subdirectories). Reference repos live in `references/`.
 | `marketplace-official-skills` | RESEARCH-MARKETPLACE-OFFICIAL-SKILLS | How should the dashboard marketplace spotlight Signet official skills without hiding the broader community catalog? |
 | `markdown-embedding-normalization-hardening` | RESEARCH-MARKDOWN-EMBEDDING-NORMALIZATION | How should Signet preserve structured markdown for embeddings while preventing repeated poison-pill retries from malformed or provider-sensitive payloads? |
 | `dreaming-memory-consolidation` | LCM-PATTERNS, memory-pipeline-plan, knowledge-architecture-schema | How should Signet consolidate accumulated session knowledge into a cleaner entity graph during idle periods? |
+| `dreaming-scope-fairness` | dreaming-memory-consolidation, multi-agent-support | How should one-universe Dreaming guarantee bounded progress for independent agent scopes without adding a parallel semantic writer? |
 | `native-harness-memory-bridge` | RESEARCH-NATIVE-HARNESS-MEMORY-BRIDGE | How should Signet make harness-native memories portable without duplicating each harness's memory pipeline? |
 | `model-provider-router` | RESEARCH-INFERENCE-CONTROL-PLANE, RESEARCH-COMPETITIVE-SYSTEMS | How should Signet centralize inference across harnesses, daemon workloads, and heterogeneous provider backends under one policy surface? |
 
@@ -486,6 +490,17 @@ cannot suppress them. This is a hard retrieval invariant.
 - The executor is selected through the daemon inference router and only reasons
   over daemon-owned tool capabilities; it does not receive direct SQLite access.
 
+### Dreaming Scope Fair Progress <-> Multi-Agent Dreaming
+
+- One persisted `dreaming_passes` row contains sequential, scope-bound turns;
+  fairness does not create a second semantic pipeline or a parallel writer.
+- Every eligible scope receives a deterministic share of the pass budget.
+  Attention priority controls turn order, not eligibility.
+- Evidence watermarks, attention provenance, operation audit rows, and derived
+  graph writes remain owned by the scope named on the turn.
+- A failed scope turn leaves only that scope's backlog pending and does not
+  prevent healthy scopes from completing their turns.
+
 ### Multi-Agent <-> All Specs
 
 - `agent_id` column appears on every data table (see invariant 1).
@@ -789,6 +804,7 @@ Legend:
 | `docker-self-hosting-stack` | planning | `docs/specs/planning/docker-self-hosting-stack.md` | `signet-runtime` | - | First-party Docker image + Compose + Caddy deployment contract with team-mode bootstrap path and operations runbook |
 | `system-prompt-extraction` | approved | `docs/specs/approved/system-prompt-extraction.md` | - | - | Move Signet system prompt injection to session-start runtime context and keep AGENTS.md as user-owned identity content |
 | `dreaming-memory-consolidation` | approved | `docs/specs/approved/dreaming-memory-consolidation.md` | `memory-pipeline-v2`, `knowledge-architecture-schema` | - | Phase 1 (consolidation engine, trigger, config, API, CLI) delivered in PR #442. Source-backed attribute promotion uses direct audited operations outside Pipeline V2. Phase 2 (dreaming-as-session, incremental deltas, V2 exclusion, chunked compaction, dashboard, identity context) deferred. |
+| `dreaming-scope-fairness` | approved | `docs/specs/approved/dreaming-scope-fairness.md` | `dreaming-memory-consolidation`, `multi-agent-support` | - | Issue #1344: one sequential, scope-bound turn per eligible scope with deterministic evidence/output budgets, priority ordering, and failure isolation inside one persisted pass. |
 | `ci-changed-files-selective` | planning | `docs/specs/planning/ci-changed-files-selective.md` | `memory-pipeline-v2` | - | Stub: selective PR CI by changed package graph |
 | `ci-contract-invariants-lane` | planning | `docs/specs/planning/ci-contract-invariants-lane.md` | `knowledge-architecture-schema` | - | Stub: mandatory fast invariant contract checks, including frozen lockfile integrity |
 | `ci-flaky-test-quarantine` | planning | `docs/specs/planning/ci-flaky-test-quarantine.md` | `ci-contract-invariants-lane` | - | Stub: flaky detection, quarantine, threshold policy |
@@ -894,6 +910,12 @@ bounded and configurable. Phase 1 (mechanical consolidation engine) is
 delivered. Phase 2 (dreaming as a session, incremental deltas, pipeline mutual
 exclusion, chunked compaction, dashboard observability, identity context
 injection) is required before spec moves to `complete`.
+
+**dreaming-scope-fairness**: Every eligible agent scope receives one
+sequential, scope-bound Dreaming turn in a persisted one-universe pass.
+Evidence/output budgets are divided deterministically, attention priority
+changes order without causing starvation, cross-scope tool calls fail closed,
+and a failed scope does not block healthy scopes or advance its watermark.
 
 **wave-9 strategic stubs**: The strategic backlog items listed in Wave 9
 are intentionally tracked as planning stubs and require dedicated planning

--- a/docs/specs/approved/dreaming-scope-fairness.md
+++ b/docs/specs/approved/dreaming-scope-fairness.md
@@ -1,0 +1,113 @@
+---
+title: "Dreaming: Fair Progress Across Agent Scopes"
+description: "Bound one-universe Dreaming passes so independent agent scopes receive fair, isolated progress without creating a second semantic writer."
+order: 2
+section: "Memory Architecture"
+informed_by:
+  - "docs/specs/approved/dreaming-memory-consolidation.md"
+  - "docs/specs/approved/multi-agent-support.md"
+success_criteria:
+  - "Every eligible agent scope receives one sequential Dreaming turn in a pass, regardless of another scope's backlog size"
+  - "Evidence and output budgets are divided deterministically across eligible scopes"
+  - "Higher-priority pending attention is handled first without removing another eligible scope's turn"
+  - "Scope-bound Dreaming tools reject cross-scope reads and writes"
+  - "A failed scope turn does not prevent remaining scopes from making progress"
+  - "One dreaming_passes row, one audited operation seam, and one evidence cursor remain authoritative"
+scope_boundary: "This spec covers fairness inside the existing one-universe Dreaming worker. It does not add parallel semantic writers, a new queue, or a dashboard surface."
+---
+
+# Dreaming: Fair Progress Across Agent Scopes
+
+## Problem
+
+The one-universe Dreaming worker intentionally uses one persisted pass and one
+bounded agent session to maintain every agent scope in an installation. The
+shared session is the correct writer boundary, but it gives the model control
+over which scope it reads next. A scope with a large evidence backlog can spend
+the pass's tool and model budget before a smaller scope's pending evidence or
+attention is inspected.
+
+This is starvation, not merely uneven throughput: an independently healthy
+scope can remain untouched while another scope continually receives new work.
+The failure is most visible with a synthetic 100:1 evidence imbalance, but the
+same mechanism affects hygiene and overdue temporal attention.
+
+## Decision
+
+Keep one Dreaming universe and divide it into **sequential scope turns** inside
+the existing persisted pass:
+
+1. At pass start, resolve each scope's pending attention, evidence backlog, and
+   last successful watermark.
+2. Exclude scopes with no work for the selected mode. Compact mode retains its
+   existing explicit all-scope behavior.
+3. Give every eligible scope exactly one turn. Pending attention priority and
+   age determine order only; they cannot remove another scope's turn.
+4. Divide the configured output, timeout, and evidence budgets across turns.
+   The remainder is assigned deterministically to the earlier turns.
+5. Build a scope-bound capability registry for each turn. A turn can read and
+   write only its own `agent_id`; its runbook remains attached to the single
+   pass owner and its operations use the existing audited apply seam.
+6. Continue with later turns when one scope's provider call fails. The failed
+   scope keeps its evidence cursor/backlog for retry; successful scopes alone
+   advance their watermarks.
+
+Turns are sequential, not parallel. This preserves SQLite serialization,
+one canonical semantic writer, attention provenance, and bounded operation
+batches while making time-to-first-progress independent of backlog size in a
+different scope.
+
+## Scheduling and budgets
+
+The scheduler uses deterministic inputs already owned by Dreaming:
+
+- highest pending attention priority, then oldest pending attention;
+- scopes that have never completed a pass before older completed scopes;
+- stable `agent_id` order as the final tie breaker.
+
+The first factor gives overdue or explicitly urgent maintenance priority. It is
+not a weighted share: every eligible scope still receives one turn. Evidence
+returned by `search_evidence` consumes that turn's evidence budget, so repeated
+searches from a dominant scope return a bounded page and cannot spend another
+scope's allowance. The existing `apply_ontology_ops` schema continues to cap
+each operation batch at 100 operations.
+
+The configured `maxOutputTokens`, `timeout`, and `maxInputTokens` values remain
+the pass-level controls. Their deterministic shares are sent to each turn;
+the provider therefore cannot receive the full pass output budget repeatedly
+for every scope. A very large installation may produce a minimum one-token
+share for a late scope; it is still attempted and its backlog is never marked
+processed without a successful turn.
+
+## State, provenance, and failure behavior
+
+- There is still exactly one `dreaming_passes` row for a trigger.
+- Every semantic operation still goes through `applyDreamingOperations` with
+  the turn's scope and the same pass id.
+- Evidence remains immutable. A scope watermark advances only to evidence
+  surfaced by that scope's successful turn.
+- A failed turn is recorded as a pass failure contribution and leaves that
+  scope eligible for the normal failure backoff/retry path. It must not block
+  healthy scopes in the same pass.
+- A scope-bound tool rejects a requested `agentId` that differs from the turn,
+  including both read and mutation capabilities. Cross-agent isolation remains
+  enforced by the database and operation applicators as a second boundary.
+- Existing system-pressure deferral, failure halts, attention provenance,
+  and operation caps remain unchanged.
+
+## Evaluation contract
+
+The regression fixture uses two independent scopes with a 100:1 evidence
+imbalance and a deterministic executor. It records:
+
+- scope turn order and time-to-first-turn;
+- evidence pages surfaced per scope;
+- applied operations per scope and exact source provenance;
+- remaining backlog/watermark after a pass;
+- per-turn output/evidence budgets and aggregate token usage;
+- behavior when the dominant scope repeatedly searches or its provider fails.
+
+The minimum pass condition is that the smaller scope receives a turn and can
+surface or apply its own evidence in the same persisted pass, while the
+dominant scope cannot read or mutate the smaller scope and cannot consume its
+budget.

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -1316,6 +1316,26 @@ specs:
       - "Dreaming passes run as full sessions with transcript capture and self-improvement loop (Phase 2)"
       - "Pipeline V2 extraction is gated off when dreaming is enabled (Phase 2)"
     decision: null
+  - id: dreaming-scope-fairness
+    status: approved
+    path: docs/specs/approved/dreaming-scope-fairness.md
+    hard_depends_on:
+      - dreaming-memory-consolidation
+      - multi-agent-support
+    soft_depends_on:
+      - ontology-proposal-loop
+    blocks: []
+    informed_by:
+      - docs/specs/approved/dreaming-memory-consolidation.md
+      - docs/specs/approved/multi-agent-support.md
+    success_criteria:
+      - "Every eligible agent scope receives one sequential Dreaming turn in a pass, regardless of another scope's backlog size"
+      - "Evidence and output budgets are divided deterministically across eligible scopes"
+      - "Higher-priority pending attention is handled first without removing another eligible scope's turn"
+      - "Scope-bound Dreaming tools reject cross-scope reads and writes"
+      - "A failed scope turn does not prevent remaining scopes from making progress"
+      - "One dreaming_passes row, one audited operation seam, and one evidence cursor remain authoritative"
+    decision: null
   - id: native-harness-memory-bridge
     status: approved
     path: docs/specs/approved/native-harness-memory-bridge.md

--- a/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
@@ -114,6 +114,35 @@ describe("dreaming-agent-tools", () => {
 		expect(items.some((i) => i.id === "e-other")).toBe(false);
 	});
 
+	it("rejects a cross-scope call from a bounded Dreaming turn", async () => {
+		const tools = createDreamingAgentTools({
+			accessor: getDbAccessor(),
+			agentId: "owner",
+			actor: "owner",
+			scopeId: "owner",
+		});
+		const result = readResult(
+			await findTool(tools, "search_entities").execute(
+				"call",
+				{ agentId: "intruder", query: "anything" },
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		expect(result).toMatchObject({ ok: false, error: "Dreaming scope turn is bound to agent 'owner'" });
+		const writeResult = readResult(
+			await findTool(tools, "apply_ontology_ops").execute(
+				"call",
+				{ agentId: "intruder", operations: [] },
+				undefined,
+				undefined,
+				{} as never,
+			),
+		);
+		expect(writeResult).toMatchObject({ ok: false, error: "Dreaming scope turn is bound to agent 'owner'" });
+	});
+
 	it("get_entity surfaces pinned status and hydrates aspects on demand", async () => {
 		insertEntity("e-atlas", "Atlas", "atlas", "owner");
 		insertActiveAttribute("e-atlas", "a-config", "Feature is enabled by default.", "owner");

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -35,6 +35,7 @@ import {
 } from "./dreaming-operations";
 import { readDreamingRunbook, writeDreamingRunbook } from "./dreaming-runbook";
 import { collectReviewDueClaims } from "./memory-review-due";
+import { countTokens } from "./tokenizer";
 
 const bounded = (value: number | undefined, fallback: number, max: number): number =>
 	Math.min(Math.max(Math.floor(value ?? fallback), 1), max);
@@ -47,6 +48,32 @@ const MAX_ENTITY_TEXT_CHARS = 2_000;
 function boundedText(value: string | undefined, maxChars: number): string | undefined {
 	if (value === undefined || value.length <= maxChars) return value;
 	return value.slice(0, maxChars);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function scopeMismatch(input: unknown, scopeId: string): string | null {
+	if (!isRecord(input)) return null;
+	const requested = input.agentId;
+	return typeof requested === "string" && requested !== scopeId
+		? `Dreaming scope turn is bound to agent '${scopeId}'`
+		: null;
+}
+
+function budgetEvidenceItems(
+	items: readonly Record<string, unknown>[],
+	budget: DreamingScopeBudget,
+): { readonly items: readonly Record<string, unknown>[]; readonly truncated: boolean } {
+	const selected: Record<string, unknown>[] = [];
+	for (const item of items) {
+		if (!budget.reserveEvidence(countTokens(JSON.stringify(item)))) {
+			return { items: selected, truncated: true };
+		}
+		selected.push(item);
+	}
+	return { items: selected, truncated: false };
 }
 
 /**
@@ -203,6 +230,15 @@ export interface DreamingToolCallTrace {
 	readonly latencyMs: number;
 }
 
+/** Mutable per-turn budget owned by the Dreaming pass orchestrator. */
+export interface DreamingScopeBudget {
+	readonly scopeId: string;
+	readonly maxEvidenceTokens: number;
+	readonly evidenceTokensUsed: number;
+	readonly evidenceTokensRemaining: number;
+	reserveEvidence(tokens: number): boolean;
+}
+
 export interface DreamingCapability {
 	readonly id: DreamingCapabilityId;
 	readonly title: string;
@@ -218,6 +254,12 @@ export interface CreateDreamingCapabilitiesParams {
 	readonly actor: string;
 	/** Present only for a live Dreaming pass; protects runbook writes. */
 	readonly passId?: string;
+	/** Pass owner used for the shared runbook when tools are scope-bound. */
+	readonly runbookAgentId?: string;
+	/** When set, every scope-bearing tool call is restricted to this scope. */
+	readonly scopeId?: string;
+	/** Optional evidence budget for one scope turn. */
+	readonly scopeBudget?: DreamingScopeBudget;
 	/** Write-path caps forwarded to applyDreamingOperations. */
 	readonly writeCaps?: GraphWriteCaps;
 	readonly onOperationsApplied?: (
@@ -275,7 +317,8 @@ function capability<T extends z.ZodType>(
 /** The one scope-bound handler registry used by Pi, daemon HTTP, MCP, and CLI. */
 export function createDreamingCapabilities(params: CreateDreamingCapabilitiesParams): readonly DreamingCapability[] {
 	const { accessor, agentId, actor } = params;
-	return [
+	const runbookAgentId = params.runbookAgentId ?? agentId;
+	const capabilities: DreamingCapability[] = [
 		capability(
 			"search_entities",
 			"Search entities",
@@ -476,9 +519,17 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 							Math.max(0, Math.floor(offset ?? 0)),
 							Math.min(Math.max(Math.floor(chunkSize ?? MAX_EVIDENCE_EXCERPT_CHARS), 1), MAX_EVIDENCE_EXCERPT_CHARS),
 						);
-						return fragment === null
-							? { ok: false, error: "Evidence fragment offset is outside the source" }
-							: { ok: true, items: [fragment] };
+						if (fragment === null) return { ok: false, error: "Evidence fragment offset is outside the source" };
+						if (
+							params.scopeBudget !== undefined &&
+							!params.scopeBudget.reserveEvidence(countTokens(JSON.stringify(fragment)))
+						) {
+							return {
+								ok: false,
+								error: "This scope's evidence budget is exhausted; continue with the next scope",
+							};
+						}
+						return { ok: true, items: [fragment] };
 					}
 					// The scan-first listing omits `since`; anchor it to the
 					// scope's evidence watermark instead of pass-start so the
@@ -494,7 +545,14 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 						kind,
 						limit,
 					});
-					return { ok: true, items: projectEvidence(sources, query ?? "") };
+					const projected = projectEvidence(sources, query ?? "");
+					if (params.scopeBudget === undefined) return { ok: true, items: projected };
+					const budgeted = budgetEvidenceItems(projected, params.scopeBudget);
+					return {
+						ok: true,
+						items: budgeted.items,
+						...(budgeted.truncated ? { truncatedByScopeBudget: true } : {}),
+					};
 				}),
 		),
 		capability(
@@ -540,7 +598,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 			"Read recent scoped pass outcomes, evidence windows, quarantines, and structured runbook notes.",
 			true,
 			z.object({ limit: z.number().finite().optional() }),
-			async ({ limit }) => ({ ok: true, items: readDreamingRunbook(accessor, agentId, bounded(limit, 5, 20)) }),
+			async ({ limit }) => ({ ok: true, items: readDreamingRunbook(accessor, runbookAgentId, bounded(limit, 5, 20)) }),
 		),
 		capability(
 			"runbook_write",
@@ -554,7 +612,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 			}),
 			async (entry) => {
 				if (!params.passId) return { ok: false, error: "Runbook writes require a live Dreaming pass" };
-				if (!writeDreamingRunbook(accessor, { agentId, passId: params.passId, entry })) {
+				if (!writeDreamingRunbook(accessor, { agentId: runbookAgentId, passId: params.passId, entry })) {
 					return { ok: false, error: "Dreaming pass is not running in this agent scope" };
 				}
 				return { ok: true, passId: params.passId };
@@ -563,7 +621,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"attention_list",
 			"List attention",
-			"List attention records by kind and resolution status. Use kind hygiene for the queue, or review_due for expired and approaching temporal claims. Omit agentId to see the whole install; pass agentId to narrow to one scope.",
+			"List attention records by kind and resolution status. Use kind hygiene for the queue, or review_due for expired and approaching temporal claims. In a scope-bound Dreaming turn, omitting agentId means the active scope; in an unbound registry, omission lists the whole install. Pass agentId to narrow to one scope.",
 			true,
 			z.object({
 				agentId: z.string().optional(),
@@ -571,7 +629,8 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 				status: z.enum(["pending", "resolved"]).optional(),
 				limit: z.number().finite().optional(),
 			}),
-			async ({ agentId: scopeId, kind, status, limit }) => {
+			async ({ agentId: requestedAgentId, kind, status, limit }) => {
+				const scopeId = requestedAgentId ?? params.scopeId;
 				if (kind === "review_due") {
 					if (status === "resolved") return { ok: true, items: [] };
 					const due = accessor.withReadDb((db) =>
@@ -648,6 +707,14 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 			},
 		),
 	];
+	if (params.scopeId === undefined) return capabilities;
+	return capabilities.map((candidate) => ({
+		...candidate,
+		async invoke(input: unknown): Promise<DreamingCapabilityResult> {
+			const error = scopeMismatch(input, params.scopeId ?? "");
+			return error === null ? candidate.invoke(input) : { tool: candidate.id, ok: false, error };
+		},
+	}));
 }
 
 export function getDreamingCapability(

--- a/platform/daemon/src/pipeline/dreaming-runbook.ts
+++ b/platform/daemon/src/pipeline/dreaming-runbook.ts
@@ -202,9 +202,11 @@ export function readDreamingRunbook(accessor: DbAccessor, agentId: string, limit
 			 ORDER BY excluded_at DESC, source_kind ASC, source_id ASC`,
 		);
 		const operationCalls = db.prepare(
-			`SELECT input_json AS inputJson, output_json AS outputJson
-			 FROM dreaming_tool_calls WHERE agent_id = ? AND pass_id = ? AND tool_name = 'apply_ontology_ops'
-			 ORDER BY sequence ASC`,
+			`SELECT calls.input_json AS inputJson, calls.output_json AS outputJson
+			 FROM dreaming_tool_calls calls
+			 JOIN dreaming_passes pass ON pass.id = calls.pass_id AND pass.agent_id = ?
+			 WHERE calls.pass_id = ? AND calls.tool_name = 'apply_ontology_ops'
+			 ORDER BY calls.sequence ASC`,
 		);
 		return rows.map((row) => ({
 			passId: row.id as string,

--- a/platform/daemon/src/pipeline/dreaming-worker.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.test.ts
@@ -206,23 +206,36 @@ describe("dreaming worker agent scope", () => {
 			checkIntervalMs: 20,
 		});
 		try {
-			// Failures accumulate on the run agent ("default") while the
-			// per-scope backoff reads each scope's own state, so "alpha"'s
-			// fresh backlog re-triggers on the next tick. Two recorded
-			// failures prove the loop survived the first one and kept
-			// checking instead of dying with it.
+			// Failures accumulate on the scope that failed, so "alpha" is paced
+			// by its own retry state instead of immediately consuming every sweep.
+			// Once the first pass is recorded, add work to the already-discovered
+			// default scope to prove the timer re-armed and the next pass can run.
 			await waitFor(() => {
 				const state = db
-					.prepare("SELECT consecutive_failures AS n FROM dreaming_state WHERE agent_id = 'default'")
+					.prepare("SELECT consecutive_failures AS n FROM dreaming_state WHERE agent_id = 'alpha'")
 					.get() as { n: number } | null;
-				return state != null && state.n >= 2;
+				return state != null && state.n >= 1;
+			}, 2_000);
+			db.prepare(
+				`INSERT INTO session_transcripts
+				 (session_key, agent_id, content, harness, created_at, updated_at, completed_at)
+				 VALUES ('sweep-failure-default', 'default', 'A second scope pass must remain scheduled.', 'pi',
+				         datetime('now'), datetime('now'), datetime('now'))`,
+			).run();
+			await waitFor(() => {
+				const row = db.prepare("SELECT COUNT(*) AS n FROM dreaming_passes").get() as { n: number };
+				return row.n >= 2;
 			}, 2_000);
 			expect(unhandled).toEqual([]);
 
-			const state = db
+			const alphaState = db
+				.prepare("SELECT consecutive_failures AS n FROM dreaming_state WHERE agent_id = 'alpha'")
+				.get() as { n: number };
+			expect(alphaState.n).toBe(1);
+			const defaultState = db
 				.prepare("SELECT consecutive_failures AS n FROM dreaming_state WHERE agent_id = 'default'")
 				.get() as { n: number };
-			expect(state.n).toBeGreaterThanOrEqual(2);
+			expect(defaultState.n).toBe(1);
 
 			const passes = db.prepare("SELECT status, error FROM dreaming_passes ORDER BY created_at").all() as Array<{
 				status: string;
@@ -283,9 +296,9 @@ describe("dreaming worker agent scope", () => {
 
 	it("runs one universe pass over every agent scope and keeps semantic rows agent-isolated (#946)", async () => {
 		// Behavioral regression: one Dreaming pass covers the whole install.
-		// The pass addresses each agent scope via the per-call agentId on its
-		// tools; every write is attributed to the agent named on the call, and
-		// no cross-agent evidence leaks into another scope's derived graph.
+		// The pass addresses each agent scope through its own bounded turn; every
+		// write is attributed to the agent named on the turn, and no cross-agent
+		// evidence leaks into another scope's derived graph.
 		const ALPHA = "alpha";
 		const BETA = "beta";
 		const alphaEvidence = "Alpha is building the Apex platform.";
@@ -303,57 +316,43 @@ describe("dreaming worker agent scope", () => {
 			 VALUES ('summary-beta', ?, ?, 'pi', datetime('now'), datetime('now'), datetime('now'))`,
 		).run(BETA, betaEvidence);
 
-		// Deterministic provider: one universe pass consolidates BOTH scopes
-		// in a single invocation, each apply batch carrying the agentId whose
+		// Deterministic provider: one universe pass consolidates BOTH scopes in
+		// sequential invocations, each apply batch carrying the agentId whose
 		// graph it maintains and citing that scope's own evidence.
 		const seenPrompts: string[] = [];
 		const executorFactory = (agentId: string) => ({
 			async run(input: {
+				agentId?: string;
 				prompt: string;
 				tools: ReadonlyArray<{ name: string; execute: (...args: unknown[]) => Promise<unknown> }>;
 			}) {
 				seenPrompts.push(input.prompt);
 				const apply = input.tools.find((tool) => tool.name === "apply_ontology_ops");
 				if (!apply) throw new Error("Missing apply_ontology_ops");
+				const scope = input.agentId ?? agentId;
+				const isAlpha = scope === ALPHA;
+				const sourceId = isAlpha ? "summary-alpha" : "summary-beta";
+				const evidence = isAlpha ? alphaEvidence : betaEvidence;
 				await apply.execute("call", {
-					agentId: ALPHA,
+					agentId: scope,
 					operations: [
 						{
 							operation: "create_entity",
-							payload: { name: "Apex", type: "project" },
+							payload: { name: isAlpha ? "Apex" : "Zenith", type: "project" },
 							reason: "The evidence identifies the project.",
 							confidence: 0.9,
 							evidence: [
 								{
-									source_ref: "transcript:summary-alpha",
+									source_ref: `transcript:${sourceId}`,
 									source_kind: "transcript",
-									source_id: "summary-alpha",
-									quote: alphaEvidence,
+									source_id: sourceId,
+									quote: evidence,
 								},
 							],
 						},
 					],
 				});
-				await apply.execute("call", {
-					agentId: BETA,
-					operations: [
-						{
-							operation: "create_entity",
-							payload: { name: "Zenith", type: "project" },
-							reason: "The evidence identifies the project.",
-							confidence: 0.9,
-							evidence: [
-								{
-									source_ref: "transcript:summary-beta",
-									source_kind: "transcript",
-									source_id: "summary-beta",
-									quote: betaEvidence,
-								},
-							],
-						},
-					],
-				});
-				return { summary: "Consolidated both scopes" };
+				return { summary: `Consolidated ${scope}` };
 			},
 		});
 
@@ -365,7 +364,8 @@ describe("dreaming worker agent scope", () => {
 			{ executorFactory },
 		);
 		try {
-			// One trigger = one pass covering every discovered scope.
+			// One trigger = one persisted pass with one bounded sequential turn per
+			// discovered scope.
 			await worker.trigger("incremental", "default");
 
 			// A single pass row on the primary agent.
@@ -374,12 +374,17 @@ describe("dreaming worker agent scope", () => {
 				.all() as Array<{ agent_id: string; status: string; mode: string }>;
 			expect(passes).toEqual([{ agent_id: "default", status: "completed", mode: "incremental" }]);
 
-			// One invocation, and the prompt names every scope in the install.
-			expect(seenPrompts).toHaveLength(1);
-			expect(seenPrompts[0]).toContain(DREAMING_AGENT_PROMPT);
-			expect(seenPrompts[0]).toContain("<agent_scopes>");
-			expect(seenPrompts[0]).toContain(ALPHA);
-			expect(seenPrompts[0]).toContain(BETA);
+			// One persisted pass, and one bounded invocation per scope. Every
+			// turn still receives the install scope list for auditability, while
+			// its tool registry rejects cross-scope reads and writes.
+			expect(seenPrompts).toHaveLength(2);
+			expect(seenPrompts.every((prompt) => prompt.includes(DREAMING_AGENT_PROMPT))).toBe(true);
+			expect(seenPrompts.every((prompt) => prompt.includes("<agent_scopes>"))).toBe(true);
+			expect(seenPrompts.every((prompt) => prompt.includes(ALPHA) && prompt.includes(BETA))).toBe(true);
+			const traceScopes = (
+				db.prepare("SELECT agent_id FROM dreaming_tool_calls ORDER BY sequence").all() as Array<{ agent_id: string }>
+			).map((row) => row.agent_id);
+			expect(traceScopes).toEqual([ALPHA, BETA]);
 
 			// Semantic rows are agent-isolated: each agent only owns its entity.
 			const alphaEntities = (

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -20,7 +20,7 @@ import {
 	enqueueDreamingHygieneAttention,
 	getDreamingEpisodicTokenBacklog,
 	isDreamingHaltActive,
-	recordDreamingFailure,
+	isDreamingScopeRetryBlockedForAgent,
 	runDreamingAgentPass,
 	selectDreamingPassMode,
 	shouldTriggerDreaming,
@@ -192,9 +192,10 @@ export function startDreamingWorker(
 		const router = getOrCreateInferenceRouter(agentsDir);
 		return {
 			async run(input) {
+				const scopeId = input.agentId ?? agentId;
 				const result = await router.runAgent(
 					{
-						agentId,
+						agentId: scopeId,
 						operation: "memory_extraction",
 						promptPreview: input.prompt.slice(0, 8000),
 					},
@@ -206,10 +207,10 @@ export function startDreamingWorker(
 						...(options.acpxMcp
 							? {
 									acpxMcp: {
-										agentId,
+										agentId: scopeId,
 										passId: input.passId,
 										daemonUrl: options.acpxMcp.daemonUrl,
-										authorizationToken: options.acpxMcp.authorizationTokenForAgent?.(agentId),
+										authorizationToken: options.acpxMcp.authorizationTokenForAgent?.(scopeId),
 									},
 								}
 							: {}),
@@ -279,9 +280,6 @@ export function startDreamingWorker(
 		activePassPromise = p;
 		try {
 			return await p;
-		} catch (e) {
-			recordDreamingFailure(accessor, runAgentId);
-			throw e;
 		} finally {
 			active = false;
 			activeAgent = null;
@@ -297,9 +295,9 @@ export function startDreamingWorker(
 			return;
 		}
 
-		// One Dreaming universe: a single pass covers every agent scope. The
-		// sweep runs one pass when any scope has attention or a backlog; the
-		// pass itself addresses scopes via the per-call agentId on its tools.
+		// One Dreaming universe: a single pass covers every eligible agent scope.
+		// The sweep runs one pass when any scope has attention or a backlog; the
+		// pass itself gives each eligible scope one sequential bounded turn.
 		const scopes = getAgentScopes();
 		let triggered = false;
 		for (const scopeId of scopes) {
@@ -327,24 +325,25 @@ export function startDreamingWorker(
 			}
 		}
 		if (!triggered) return;
+		const passScopes = scopes.filter((scope) => !isDreamingScopeRetryBlockedForAgent(accessor, scope));
+		if (passScopes.length === 0) return;
 		// #1098: with the hygiene queue perpetually full, every pass used to
 		// drain flags first and run out of budget before content work. Give
 		// content a guaranteed turn: alternate the runbook per check cycle
 		// when both kinds of work are pending; run the only-pending kind
 		// directly otherwise.
-		const mode = selectDreamingCheckMode(accessor, scopes, nextScheduledFocus);
+		const mode = selectDreamingCheckMode(accessor, passScopes, nextScheduledFocus);
 		nextScheduledFocus = dreamingFocusOfMode(mode) ?? nextScheduledFocus;
 		try {
-			await runPass(defaultAgentId, mode, undefined, scopes);
+			await runPass(defaultAgentId, mode, undefined, passScopes);
 		} catch (e) {
-			// runPass already recorded the failure (recordDreamingFailure)
+			// runDreamingAgentPass already recorded the per-scope failure
 			// and failDreamingPass marked the pass row failed. A pass error
 			// (provider 429, timeout, any executor rejection) must never
 			// escape the check loop: as an unhandled rejection it hits the
 			// daemon's unhandledRejection exit path and kills the whole
-			// process (#1198). Log and keep the loop running; the per-scope
-			// failure backoff (keyed on the run agent's state) paces the
-			// retries.
+			// process (#1198). Log and keep the loop running; per-scope
+			// failure backoff paces each scope's retries.
 			logger.error(
 				"dreaming-worker",
 				"Scheduled dreaming pass failed; check loop continues",
@@ -443,7 +442,6 @@ export function startDreamingWorker(
 			);
 			activePassPromise = p;
 			p.catch((e) => {
-				recordDreamingFailure(accessor, runAgentId);
 				logger.error("dreaming-worker", "Async trigger failed", undefined, {
 					agentId: runAgentId,
 					passId,

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -12,9 +12,11 @@ import {
 	DREAMING_HYGIENE_AGENT_PROMPT,
 	type DreamingState,
 	_testParseEpisodicCursor,
+	allocateDreamingScopeBudgets,
 	dreamingEarlyExitSummary,
 	enqueueDreamingHygieneAttention,
 	getDreamingEpisodicTokenBacklog,
+	getDreamingEvidenceExclusions,
 	getDreamingPasses,
 	getDreamingState,
 	getDreamingToolCalls,
@@ -24,6 +26,7 @@ import {
 	requestDreamingEvidenceRequeue,
 	runDreamingAgentPass,
 	selectDreamingPassMode,
+	selectDreamingScopeTurns,
 	shouldTriggerDreaming,
 } from "./dreaming";
 import {
@@ -93,6 +96,15 @@ function seedTranscript(db: Database, id: string, content: string, capturedAt?: 
 	).run(id, content, AGENT, timestamp, timestamp, timestamp);
 }
 
+function seedScopedTranscript(db: Database, id: string, agentId: string, content: string): void {
+	const timestamp = (db.prepare("SELECT datetime('now') AS now").get() as { now: string }).now;
+	db.prepare(
+		`INSERT INTO session_transcripts
+		 (session_key, content, agent_id, created_at, updated_at, completed_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+	).run(id, content, agentId, timestamp, timestamp, timestamp);
+}
+
 function seedSummary(db: Database, id: string, content: string, tokens: number): void {
 	// Keep a legacy row for explicit provenance-compatibility assertions, but
 	// seed the canonical direct transcript path used by Dreaming's default
@@ -136,6 +148,172 @@ describe("Dreaming", () => {
 				JSON.stringify({ capturedAt: "2026-03-01T00:00:00.000Z", kind: "summary", id: "fragment", fragmentOffset: -1 }),
 			),
 		).toEqual({ capturedAt: "2026-03-01T00:00:00.000Z", kind: "summary", id: "fragment" });
+	});
+
+	it("gives every eligible scope a bounded turn while prioritizing attention", () => {
+		const turns = selectDreamingScopeTurns("incremental", [
+			{
+				agentId: "busy",
+				hasPendingAttention: false,
+				attentionPriority: -1,
+				oldestAttentionAt: null,
+				episodicTokens: 100_000,
+				lastPassAt: "2026-08-10 12:00:00",
+			},
+			{
+				agentId: "maintenance",
+				hasPendingAttention: true,
+				attentionPriority: 90,
+				oldestAttentionAt: "2026-08-10 11:00:00",
+				episodicTokens: 1,
+				lastPassAt: null,
+			},
+		]);
+
+		expect(turns.map((turn) => turn.agentId)).toEqual(["maintenance", "busy"]);
+		expect(allocateDreamingScopeBudgets(101, 2)).toEqual([51, 50]);
+	});
+
+	it("does not let a 100:1 evidence scope consume its neighbor's turn budget (#1344)", async () => {
+		seedScopedTranscript(db, "alpha-heavy", "alpha", `${"Alpha evidence ".repeat(8_000)}settled alpha outcome.`);
+		seedScopedTranscript(db, "beta-light", "beta", "Beta has one settled outcome.");
+
+		const turns: Array<{ readonly agentId: string; readonly maxTokens: number; readonly truncated: boolean }> = [];
+		const result = await runDreamingAgentPass(
+			accessor,
+			{
+				async run(input) {
+					const scope = input.agentId ?? "";
+					const search = input.tools.find((tool) => tool.name === "search_evidence");
+					if (!search) throw new Error("Missing search_evidence");
+					const read = async (): Promise<boolean> => {
+						const output = (await search.execute("call", { agentId: scope }, undefined, undefined, {} as never)) as {
+							readonly content?: ReadonlyArray<{ readonly text?: string }>;
+						};
+						const payload = JSON.parse(output.content?.[0]?.text ?? "{}") as { truncatedByScopeBudget?: boolean };
+						return payload.truncatedByScopeBudget === true;
+					};
+					let truncated = false;
+					for (let attempt = 0; attempt < (scope === "alpha" ? 8 : 1); attempt += 1) {
+						truncated = (await read()) || truncated;
+					}
+					turns.push({ agentId: scope, maxTokens: input.maxTokens, truncated });
+					return { summary: `Inspected ${scope}` };
+				},
+			},
+			defaultCfg({ maxInputTokens: 4_000, maxOutputTokens: 100 }),
+			"/tmp",
+			"alpha",
+			["alpha", "beta"],
+			"incremental",
+		);
+
+		expect(result.failed).toBe(0);
+		expect(turns.map((turn) => turn.agentId)).toEqual(["alpha", "beta"]);
+		expect(turns.map((turn) => turn.maxTokens)).toEqual([50, 50]);
+		expect(turns[0]?.truncated).toBe(true);
+		expect(turns[1]?.truncated).toBe(false);
+	});
+
+	it("continues healthy scope turns after one provider failure (#1344)", async () => {
+		seedScopedTranscript(db, "alpha-failure", "alpha", "Alpha provider failure must not block beta.");
+		seedScopedTranscript(db, "beta-progress", "beta", "Beta remains independently processable.");
+		const seen: string[] = [];
+
+		const result = await runDreamingAgentPass(
+			accessor,
+			{
+				async run(input) {
+					const scope = input.agentId ?? "";
+					seen.push(scope);
+					if (scope === "alpha") {
+						const search = input.tools.find((tool) => tool.name === "search_evidence");
+						if (!search) throw new Error("Missing search_evidence");
+						await search.execute("call", { agentId: scope }, undefined, undefined, {} as never);
+						throw new Error("alpha provider unavailable");
+					}
+					return { summary: "Beta turn completed" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			"alpha",
+			["alpha", "beta"],
+			"incremental",
+		);
+
+		expect(seen).toEqual(["alpha", "beta"]);
+		expect(result.failed).toBe(1);
+		expect(result.summary).toContain("alpha: scope turn failed");
+		expect(db.prepare("SELECT status FROM dreaming_passes WHERE id = ?").get(result.passId)).toEqual({
+			status: "completed",
+		});
+		expect(getDreamingState(accessor, "alpha").consecutiveFailures).toBe(1);
+		expect(getDreamingEpisodicTokenBacklog(accessor, "alpha")).toBeGreaterThan(0);
+	});
+
+	it("identifies a sole scope when it differs from the persisted pass owner", async () => {
+		seedScopedTranscript(db, "alpha-single", "alpha", "The alpha scope has independent evidence.");
+		let prompt = "";
+		await runDreamingAgentPass(
+			accessor,
+			{
+				async run(input) {
+					prompt = input.prompt;
+					return { summary: "Inspected alpha" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			"default",
+			["alpha"],
+			"incremental",
+		);
+		expect(prompt).toContain("<dreaming_scope_turn>");
+		expect(prompt).toContain('"agentId":"alpha"');
+	});
+
+	it("records rejected evidence exclusions under the turn scope", async () => {
+		const evidence = "The rejected alpha operation cites this exact source.";
+		seedScopedTranscript(db, "alpha-rejected", "alpha", evidence);
+		const result = await runDreamingAgentPass(
+			accessor,
+			{
+				async run(input) {
+					const apply = input.tools.find((tool) => tool.name === "apply_ontology_ops");
+					if (!apply) throw new Error("Missing apply_ontology_ops");
+					await apply.execute("call", {
+						agentId: "alpha",
+						operations: [
+							{
+								operation: "not-supported",
+								payload: {},
+								evidence: [
+									{
+										source_ref: "transcript:alpha-rejected",
+										source_kind: "transcript",
+										source_id: "alpha-rejected",
+										quote: evidence,
+									},
+								],
+							},
+						],
+					});
+					return { summary: "Rejected alpha operation" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			"default",
+			["alpha"],
+			"incremental",
+		);
+
+		expect(result.failed).toBe(1);
+		expect(getDreamingEvidenceExclusions(accessor, "alpha")).toMatchObject([
+			{ sourceKind: "transcript", sourceId: "alpha-rejected", passId: result.passId },
+		]);
+		expect(getDreamingEvidenceExclusions(accessor, "default")).toEqual([]);
 	});
 
 	it("uses the fixed agent prompt and resets the evidence backlog to the surfaced frontier", async () => {

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -46,7 +46,7 @@ import {
 	renderDreamingAttentionForPrompt,
 	resolveDreamingAttentionInTx,
 } from "./dreaming-attention";
-import type { DreamingToolCallTrace } from "./dreaming-capabilities";
+import type { DreamingScopeBudget, DreamingToolCallTrace } from "./dreaming-capabilities";
 import {
 	type DreamingEvidenceFragment,
 	createDreamingAgentEvidence,
@@ -195,6 +195,8 @@ export type { DreamingAttention } from "./dreaming-attention";
 export interface DreamingAgentExecutor {
 	run(input: {
 		readonly passId: string;
+		/** Scope receiving this sequential turn; omitted by legacy test seams. */
+		readonly agentId?: string;
 		readonly prompt: string;
 		readonly tools: ReturnType<typeof createDreamingAgentTools>;
 		readonly timeoutMs: number;
@@ -245,6 +247,28 @@ function operationEvidenceFromToolInput(input: unknown): readonly Pick<DreamingO
 		if (!isRecord(operation) || !Array.isArray(operation.evidence)) return [];
 		return [{ evidence: operation.evidence }];
 	});
+}
+
+function readCitedDreamingSources(
+	accessor: DbAccessor,
+	agentId: string,
+	operations: readonly Pick<DreamingOperationRequest, "evidence">[],
+): readonly EpisodicSourceRecord[] {
+	const references = new Set<string>();
+	for (const operation of operations) {
+		for (const evidence of operation.evidence ?? []) {
+			if (!isRecord(evidence)) continue;
+			const sourceRef = readNonEmptyString(evidence.source_ref);
+			if (sourceRef !== null) references.add(sourceRef);
+		}
+	}
+	if (references.size === 0) return [];
+	return accessor.withReadDb((db) =>
+		[...references].flatMap((sourceRef) => {
+			const source = readEpisodicSource(db, { agentId, from: sourceRef });
+			return source === null ? [] : [source];
+		}),
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -678,7 +702,7 @@ export const DREAMING_AGENT_PROMPT = `You are a bounded Signet maintenance agent
 
 Purpose: maintain durable, evidence-cited semantic understanding in the knowledge graph. The graph is a derived structure; every write carries provenance (an attention id for hygiene, an exact quote from episodic evidence for content). Use the pass log (runbook_read) as the dedup source: the previous pass's viewed sources and changes are the cutoff.
 
-An install may have several agent scopes (listed in <agent_scopes> when there is more than one): the scoped tools take an agentId, so address any scope you need — each write is attributed to the agent you name. attention_list without an agentId lists the whole install's hygiene queue, with each record carrying its owning agentId.
+The runtime gives every eligible agent scope one sequential, bounded turn in this pass. When multiple scopes are eligible, the active scope is listed in <dreaming_scope_turn>; use only that agentId until the turn ends. A busy scope cannot consume another scope's evidence or output budget. Do not try to work another scope from the current turn. attention_list without an agentId is limited to the active scope.
 
 ### State targets
 
@@ -747,7 +771,7 @@ export const DREAMING_HYGIENE_AGENT_PROMPT = `You are a bounded Signet maintenan
 
 Purpose: maintain durable, evidence-cited semantic understanding in the knowledge graph. This is a HYGIENE pass: process the attention queue — inspect flagged targets and archive or merge them with attention provenance, minting flags for junk the queue missed. Content maintenance (claims, entities) belongs to content passes, which cite exact quotes from episodic evidence. Use the pass log (runbook_read) as the dedup source: the previous pass's changes are the cutoff.
 
-An install may have several agent scopes (listed in <agent_scopes> when there is more than one): the scoped tools take an agentId, so address any scope you need — each write is attributed to the agent you name. attention_list without an agentId lists the whole install's hygiene queue, with each record carrying its owning agentId.
+The runtime gives every eligible agent scope one sequential, bounded turn in this pass. When multiple scopes are eligible, the active scope is listed in <dreaming_scope_turn>; use only that agentId until the turn ends. A busy scope cannot consume another scope's evidence or output budget. Do not try to work another scope from the current turn. attention_list without an agentId is limited to the active scope.
 
 ### State targets
 
@@ -801,7 +825,7 @@ export const DREAMING_CONTENT_AGENT_PROMPT = `You are a bounded Signet maintenan
 
 Purpose: maintain durable, evidence-cited semantic understanding in the knowledge graph. This is a CONTENT pass: find new evidence since the cutoff and extract/update claims with exact-quote citations, creating entities for durable subjects. Hygiene archives/merges belong to hygiene passes, which process the attention queue. Use the pass log (runbook_read) as the dedup source: the previous pass's viewed sources and changes are the cutoff.
 
-An install may have several agent scopes (listed in <agent_scopes> when there is more than one): the scoped tools take an agentId, so address any scope you need — each write is attributed to the agent you name. attention_list without an agentId lists the whole install's hygiene queue, with each record carrying its owning agentId.
+The runtime gives every eligible agent scope one sequential, bounded turn in this pass. When multiple scopes are eligible, the active scope is listed in <dreaming_scope_turn>; use only that agentId until the turn ends. A busy scope cannot consume another scope's evidence or output budget. Do not try to work another scope from the current turn. attention_list without an agentId is limited to the active scope.
 
 ### State targets
 
@@ -870,6 +894,124 @@ export function dreamingFocusOfMode(mode: DreamingMode): DreamingPassFocus | nul
  */
 function dreamingModeAdvancesEvidence(mode: DreamingMode): boolean {
 	return mode !== "incremental-hygiene";
+}
+
+export interface DreamingScopeWork {
+	readonly agentId: string;
+	readonly hasPendingAttention: boolean;
+	readonly attentionPriority: number;
+	readonly oldestAttentionAt: string | null;
+	readonly episodicTokens: number;
+	readonly lastPassAt: string | null;
+}
+
+/**
+ * Select one bounded turn for every eligible scope. Attention priority only
+ * controls order; it never removes another scope's turn from the pass.
+ */
+export function selectDreamingScopeTurns(
+	mode: DreamingMode,
+	work: readonly DreamingScopeWork[],
+): readonly DreamingScopeWork[] {
+	const unique = new Map<string, DreamingScopeWork>();
+	for (const item of work) {
+		if (!unique.has(item.agentId)) unique.set(item.agentId, item);
+	}
+	const eligible = [...unique.values()].filter((item) => {
+		if (mode === "compact") return true;
+		if (mode === "incremental-hygiene") return item.hasPendingAttention;
+		if (mode === "incremental-content") return item.episodicTokens > 0;
+		return item.hasPendingAttention || item.episodicTokens > 0;
+	});
+	return eligible.sort((left, right) => {
+		if (left.attentionPriority !== right.attentionPriority) return right.attentionPriority - left.attentionPriority;
+		if (left.oldestAttentionAt !== right.oldestAttentionAt) {
+			if (left.oldestAttentionAt === null) return 1;
+			if (right.oldestAttentionAt === null) return -1;
+			const byAttentionAge = timestampMillis(left.oldestAttentionAt) - timestampMillis(right.oldestAttentionAt);
+			if (byAttentionAge !== 0) return byAttentionAge;
+		}
+		if (left.lastPassAt !== right.lastPassAt) {
+			if (left.lastPassAt === null) return -1;
+			if (right.lastPassAt === null) return 1;
+			const byPassAge = timestampMillis(left.lastPassAt) - timestampMillis(right.lastPassAt);
+			if (byPassAge !== 0) return byPassAge;
+		}
+		return left.agentId.localeCompare(right.agentId);
+	});
+}
+
+/** Divide one pass budget deterministically, giving the remainder to older turns. */
+export function allocateDreamingScopeBudgets(total: number, scopeCount: number): readonly number[] {
+	if (!Number.isFinite(total) || !Number.isFinite(scopeCount) || scopeCount <= 0) return [];
+	const count = Math.floor(scopeCount);
+	if (count <= 0) return [];
+	const boundedTotal = Math.max(0, Math.floor(total));
+	const base = Math.floor(boundedTotal / count);
+	const remainder = boundedTotal % count;
+	return Array.from({ length: count }, (_, index) => base + (index < remainder ? 1 : 0));
+}
+
+function createDreamingScopeBudget(scopeId: string, maxEvidenceTokens: number): DreamingScopeBudget {
+	let evidenceTokensUsed = 0;
+	const maximum = Math.max(0, Math.floor(maxEvidenceTokens));
+	return {
+		scopeId,
+		maxEvidenceTokens: maximum,
+		get evidenceTokensUsed() {
+			return evidenceTokensUsed;
+		},
+		get evidenceTokensRemaining() {
+			return Math.max(0, maximum - evidenceTokensUsed);
+		},
+		reserveEvidence(tokens: number): boolean {
+			const bounded = Math.max(0, Math.floor(tokens));
+			if (evidenceTokensUsed + bounded > maximum) return false;
+			evidenceTokensUsed += bounded;
+			return true;
+		},
+	};
+}
+
+function scopeTurnPrompt(
+	basePrompt: string,
+	turn: DreamingScopeWork,
+	allTurns: readonly DreamingScopeWork[],
+	passOwnerId: string,
+	evidenceTokenBudget: number,
+	outputTokenBudget: number,
+): string {
+	if (allTurns.length === 1 && turn.agentId === passOwnerId) return basePrompt;
+	return `${basePrompt}
+
+<agent_scopes>
+${allTurns.map((scope) => JSON.stringify(scope.agentId)).join("\n")}
+</agent_scopes>
+<dreaming_scope_turn>
+${JSON.stringify({
+	agentId: turn.agentId,
+	evidenceTokenBudget,
+	outputTokenBudget,
+})}
+</dreaming_scope_turn>`;
+}
+
+function sumDreamingUsage(usages: readonly (LlmUsage | null)[]): LlmUsage | null {
+	const present = usages.filter((usage): usage is LlmUsage => usage !== null);
+	if (present.length === 0) return null;
+	const sum = (read: (usage: LlmUsage) => number | null): number | null => {
+		const values = present.map(read).filter((value): value is number => value !== null && Number.isFinite(value));
+		return values.length > 0 ? values.reduce((total, value) => total + value, 0) : null;
+	};
+	return {
+		inputTokens: sum((usage) => usage.inputTokens),
+		outputTokens: sum((usage) => usage.outputTokens),
+		cacheReadTokens: sum((usage) => usage.cacheReadTokens),
+		cacheCreationTokens: sum((usage) => usage.cacheCreationTokens),
+		totalTokens: sum((usage) => usage.totalTokens),
+		totalCost: sum((usage) => usage.totalCost),
+		totalDurationMs: sum((usage) => usage.totalDurationMs),
+	};
 }
 
 /**
@@ -1271,12 +1413,8 @@ export async function runDreamingAgentPass(
 	let toolCallSequence = 0;
 	let applied = 0;
 	let failed = 0;
+	const failureRecordedFor = new Set<string>();
 	try {
-		const prompt =
-			scopes.length > 1
-				? `${dreamingPromptForMode(mode)}\n\n<agent_scopes>\n${scopes.join("\n")}\n</agent_scopes>`
-				: dreamingPromptForMode(mode);
-
 		// Pass-start cutoff, SQLite format. The stored watermark may also be
 		// the raw surfaced captured_at (ISO); every comparison goes through
 		// julianday(), so the mixed formats stay ordered (#1149).
@@ -1288,10 +1426,20 @@ export async function runDreamingAgentPass(
 		// scope has pending attention or an episodic backlog. Scheduled checks
 		// are already gated by shouldTriggerDreaming; this protects manual
 		// triggers and compact runs from spending tokens on nothing.
-		const hasPendingAttention = scopes.some((scope) =>
-			accessor.withReadDb((db) => getDreamingAttentionInDb(db, scope, 1).length > 0),
-		);
-		const totalBacklog = scopes.reduce((total, scope) => total + getDreamingEpisodicTokenBacklog(accessor, scope), 0);
+		const uniqueScopes = [...new Set(scopes.filter((scope) => scope.trim().length > 0))];
+		const scopeWork = uniqueScopes.map((scope): DreamingScopeWork => {
+			const attention = accessor.withReadDb((db) => getDreamingAttentionInDb(db, scope, 1)[0]);
+			return {
+				agentId: scope,
+				hasPendingAttention: attention !== undefined,
+				attentionPriority: attention?.priority ?? -1,
+				oldestAttentionAt: attention?.createdAt ?? null,
+				episodicTokens: getDreamingEpisodicTokenBacklog(accessor, scope),
+				lastPassAt: accessor.withReadDb((db) => readDreamingState(db, scope).lastPassAt),
+			};
+		});
+		const hasPendingAttention = scopeWork.some((scope) => scope.hasPendingAttention);
+		const totalBacklog = scopeWork.reduce((total, scope) => total + scope.episodicTokens, 0);
 		const earlyExitSummary = dreamingEarlyExitSummary(mode, hasPendingAttention, totalBacklog);
 		if (earlyExitSummary !== null) {
 			accessor.withWriteTx((db) => {
@@ -1307,7 +1455,7 @@ export async function runDreamingAgentPass(
 				// advance the watermark even on an empty backlog (#1098,
 				// #1149).
 				if (totalBacklog === 0 && dreamingModeAdvancesEvidence(mode)) {
-					for (const scope of scopes) resetDreamingTokens(db, scope, passId, mode, null, cutoff);
+					for (const scope of uniqueScopes) resetDreamingTokens(db, scope, passId, mode, null, cutoff);
 				}
 			});
 			recordDreamingPassTelemetry({
@@ -1329,97 +1477,172 @@ export async function runDreamingAgentPass(
 			});
 			return { passId, applied: 0, skipped: 0, failed: 0, summary: earlyExitSummary };
 		}
-
+		const turns = selectDreamingScopeTurns(mode, scopeWork);
+		if (turns.length === 0) {
+			throw new Error("Dreaming pass has no eligible agent scope");
+		}
+		const outputBudgets = allocateDreamingScopeBudgets(cfg.maxOutputTokens, turns.length);
+		const evidenceBudgets = allocateDreamingScopeBudgets(cfg.maxInputTokens, turns.length);
+		const timeoutBudgets = allocateDreamingScopeBudgets(cfg.timeout, turns.length);
 		let applyCallbackReported = false;
 		let retirementCandidates: DreamingRetirementCandidates = new Map();
-		const rejectedEvidence: EpisodicSourceRecord[] = [];
+		const rejectedEvidenceByScope = new Map<string, Map<string, EpisodicSourceRecord>>();
+		const successfulScopes = new Set<string>();
+		const scopeSummaries: string[] = [];
+		const scopeErrors: Array<{ readonly agentId: string; readonly error: unknown }> = [];
+		const usages: Array<LlmUsage | null> = [];
+		let promptTokenEstimate = 0;
+		const recordScopeFailure = (scopeId: string): void => {
+			if (failureRecordedFor.has(scopeId)) return;
+			recordDreamingFailure(accessor, scopeId);
+			failureRecordedFor.add(scopeId);
+		};
+		const recordRejectedEvidence = (
+			scopeId: string,
+			result: ApplyDreamingOperationsResult,
+			operations: readonly Pick<DreamingOperationRequest, "evidence">[],
+		): void => {
+			const sources = rejectedAgentEvidence(
+				result,
+				operations,
+				readCitedDreamingSources(accessor, scopeId, operations),
+			);
+			if (sources.length === 0) return;
+			const scopeSources = rejectedEvidenceByScope.get(scopeId) ?? new Map<string, EpisodicSourceRecord>();
+			for (const source of sources) scopeSources.set(`${source.kind}:${source.id}`, source);
+			rejectedEvidenceByScope.set(scopeId, scopeSources);
+		};
 		// The newest captured_at each scope's search_evidence surfaced this
 		// pass; the pass-end watermark may advance only to it (#1149).
 		const surfacedWatermarkByScope = new Map<string, string>();
 		const surfacedTranscriptRefsByScope = new Map<string, Set<string>>();
-		const tools = createDreamingAgentTools({
-			accessor,
-			agentId,
-			actor: "dreaming",
-			passId,
-			writeCaps,
-			onOperationsAboutToApply(operations, scopeId) {
-				retirementCandidates = collectDreamingRetirementCandidates(accessor, scopeId, operations);
-			},
-			onOperationsApplied(result, operations, scopeId) {
-				applyCallbackReported = true;
-				applied += result.items.filter((item) => item.ok).length;
-				failed += result.items.filter((item) => !item.ok).length;
-				if (!result.ok && result.items.length === 0) failed++;
-				recordDreamingOperationEffects(accessor, scopeId, effects, result, operations, retirementCandidates);
-				retirementCandidates = new Map();
-				rejectedEvidence.push(...rejectedAgentEvidence(result, operations, []));
-			},
-			onToolCall(trace) {
-				recordDreamingToolCall(accessor, agentId, passId, ++toolCallSequence, trace);
-				if (trace.tool === "search_evidence" && trace.output.ok === true && Array.isArray(trace.output.items)) {
-					const input = isRecord(trace.input) ? trace.input : null;
-					const scope = input !== null && typeof input.agentId === "string" ? input.agentId : agentId;
-					const transcriptRefs = surfacedTranscriptRefsByScope.get(scope) ?? new Set<string>();
-					for (const item of trace.output.items) {
-						const record = isRecord(item) ? item : null;
-						const sourceRef = typeof record?.sourceRef === "string" ? record.sourceRef : null;
-						const kind = typeof record?.kind === "string" ? record.kind : null;
-						const id = typeof record?.id === "string" ? record.id : null;
-						if (sourceRef !== null) effects.consideredArtifacts.add(sourceRef);
-						else if (kind !== null && id !== null) effects.consideredArtifacts.add(`${kind}:${id}`);
-						else effects.consideredArtifacts.add(`anonymous:${effects.consideredArtifacts.size}`);
-						if (sourceRef?.startsWith("transcript:")) transcriptRefs.add(sourceRef);
-					}
-					if (transcriptRefs.size > 0) surfacedTranscriptRefsByScope.set(scope, transcriptRefs);
-					// A sourceRef call reads a fragment of a source the
-					// listing already surfaced: it adds no new frontier (the
-					// listing's max covers it) and must not advance the
-					// watermark past the unread remainder (#1149).
-					if (input === null || typeof input.sourceRef !== "string") {
-						const scope = input !== null && typeof input.agentId === "string" ? input.agentId : agentId;
-						const surfaced = surfacedEvidenceWatermark(trace.output.items);
-						if (surfaced !== null) {
-							const current = surfacedWatermarkByScope.get(scope);
-							if (current === undefined || timestampMillis(surfaced) > timestampMillis(current)) {
-								surfacedWatermarkByScope.set(scope, surfaced);
+
+		for (const [index, turn] of turns.entries()) {
+			const outputTokenBudget = Math.max(1, outputBudgets[index] ?? 1);
+			const evidenceTokenBudget = Math.max(1, evidenceBudgets[index] ?? 1);
+			const timeoutMs = Math.max(1_000, timeoutBudgets[index] ?? 1_000);
+			const scopeBudget = createDreamingScopeBudget(turn.agentId, evidenceTokenBudget);
+			const prompt = scopeTurnPrompt(
+				dreamingPromptForMode(mode),
+				turn,
+				turns,
+				agentId,
+				evidenceTokenBudget,
+				outputTokenBudget,
+			);
+			promptTokenEstimate += countTokens(prompt);
+			const tools = createDreamingAgentTools({
+				accessor,
+				agentId: turn.agentId,
+				scopeId: turn.agentId,
+				runbookAgentId: agentId,
+				actor: "dreaming",
+				passId,
+				scopeBudget,
+				writeCaps,
+				onOperationsAboutToApply(operations, scopeId) {
+					retirementCandidates = collectDreamingRetirementCandidates(accessor, scopeId, operations);
+				},
+				onOperationsApplied(result, operations, scopeId) {
+					applyCallbackReported = true;
+					applied += result.items.filter((item) => item.ok).length;
+					failed += result.items.filter((item) => !item.ok).length;
+					if (!result.ok && result.items.length === 0) failed++;
+					recordDreamingOperationEffects(accessor, scopeId, effects, result, operations, retirementCandidates);
+					retirementCandidates = new Map();
+					recordRejectedEvidence(scopeId, result, operations);
+				},
+				onToolCall(trace) {
+					recordDreamingToolCall(accessor, turn.agentId, passId, ++toolCallSequence, trace);
+					if (trace.tool === "search_evidence" && trace.output.ok === true && Array.isArray(trace.output.items)) {
+						const input = isRecord(trace.input) ? trace.input : null;
+						const scope = turn.agentId;
+						const transcriptRefs = surfacedTranscriptRefsByScope.get(scope) ?? new Set<string>();
+						for (const item of trace.output.items) {
+							const record = isRecord(item) ? item : null;
+							const sourceRef = typeof record?.sourceRef === "string" ? record.sourceRef : null;
+							const kind = typeof record?.kind === "string" ? record.kind : null;
+							const id = typeof record?.id === "string" ? record.id : null;
+							if (sourceRef !== null) effects.consideredArtifacts.add(sourceRef);
+							else if (kind !== null && id !== null) effects.consideredArtifacts.add(`${kind}:${id}`);
+							else effects.consideredArtifacts.add(`anonymous:${effects.consideredArtifacts.size}`);
+							if (sourceRef?.startsWith("transcript:")) transcriptRefs.add(sourceRef);
+						}
+						if (transcriptRefs.size > 0) surfacedTranscriptRefsByScope.set(scope, transcriptRefs);
+						// A sourceRef call reads a fragment of a source the
+						// listing already surfaced: it adds no new frontier (the
+						// listing's max covers it) and must not advance the
+						// watermark past the unread remainder (#1149).
+						if (input === null || typeof input.sourceRef !== "string") {
+							const surfaced = surfacedEvidenceWatermark(trace.output.items);
+							if (surfaced !== null) {
+								const current = surfacedWatermarkByScope.get(scope);
+								if (current === undefined || timestampMillis(surfaced) > timestampMillis(current)) {
+									surfacedWatermarkByScope.set(scope, surfaced);
+								}
 							}
 						}
 					}
-				}
-				if (trace.tool === "apply_ontology_ops") {
-					if (!trace.output.ok && !applyCallbackReported) {
-						rejectedEvidence.push(
-							...rejectedAgentEvidence({ ok: false, items: [] }, operationEvidenceFromToolInput(trace.input), []),
-						);
-						failed++;
+					if (trace.tool === "apply_ontology_ops") {
+						if (!trace.output.ok && !applyCallbackReported) {
+							recordRejectedEvidence(
+								turn.agentId,
+								{ ok: false, items: [] },
+								operationEvidenceFromToolInput(trace.input),
+							);
+							failed++;
+						}
+						applyCallbackReported = false;
 					}
-					applyCallbackReported = false;
-				}
-			},
-		});
-		logger.info("dreaming", "Starting agentic dreaming pass", {
-			mode,
-			promptChars: prompt.length,
-		});
-		const executorResult = await executor.run({
-			passId,
-			prompt,
-			tools,
-			timeoutMs: cfg.timeout,
-			maxTokens: cfg.maxOutputTokens,
-		});
-		const summary = `${executorResult.summary?.trim() || "Agentic Dreaming pass completed"}`;
+				},
+			});
+			logger.info("dreaming", "Starting agentic dreaming scope turn", {
+				mode,
+				agentId: turn.agentId,
+				evidenceTokenBudget,
+				outputTokenBudget,
+			});
+			try {
+				const executorResult = await executor.run({
+					passId,
+					agentId: turn.agentId,
+					prompt,
+					tools,
+					timeoutMs,
+					maxTokens: outputTokenBudget,
+				});
+				successfulScopes.add(turn.agentId);
+				usages.push(executorResult.usage ?? null);
+				const turnSummary = executorResult.summary?.trim() || "Agentic Dreaming scope turn completed";
+				scopeSummaries.push(turns.length === 1 ? turnSummary : `${turn.agentId}: ${turnSummary}`);
+			} catch (error) {
+				if (isDreamingPassCancellation(error)) throw error;
+				recordScopeFailure(turn.agentId);
+				if (turns.length === 1) throw error;
+				scopeErrors.push({ agentId: turn.agentId, error });
+				recordPipelineError("decision", isPipelineTimeout(error) ? "DECISION_TIMEOUT" : "DECISION_INVALID");
+				logger.error("dreaming", "Dreaming scope turn failed; continuing with remaining scopes", undefined, {
+					agentId: turn.agentId,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				scopeSummaries.push(
+					`${turn.agentId}: scope turn failed (${error instanceof Error ? error.message : String(error)})`,
+				);
+			}
+		}
+		if (successfulScopes.size === 0 && scopeErrors.length > 0)
+			throw scopeErrors[0]?.error ?? new Error("Dreaming scope turns failed");
+		const summary = `${scopeSummaries.join("\n") || "Agentic Dreaming pass completed"}`.slice(0, 8_000);
 		// Provider-reported aggregate when the executor surfaced it (pi-backed
 		// agent sessions); otherwise fall back to the local prompt estimate so
 		// acpx-backed passes keep a meaningful total.
-		const usage = executorResult.usage ?? null;
-		const tokensConsumed = usage?.totalTokens ?? countTokens(prompt);
+		const usage = sumDreamingUsage(usages);
+		const tokensConsumed = usage?.totalTokens ?? promptTokenEstimate;
 		// The watermark advances only to what this pass actually surfaced: a
 		// pass that completes without surfacing (or deferring) pending
 		// evidence must not skip it for the next scan-first search (#1149).
 		const nextWatermarkByScope = new Map<string, string | null>();
-		for (const scope of scopes) {
+		for (const scope of turns.map((turn) => turn.agentId)) {
 			const previous = accessor.withReadDb((db) => readDreamingState(db, scope).lastPassAt);
 			const surfaced = surfacedWatermarkByScope.get(scope);
 			nextWatermarkByScope.set(
@@ -1431,16 +1654,18 @@ export async function runDreamingAgentPass(
 		// projection. Combined passes can ingest content too; gating this on the
 		// focused-mode name would advance the watermark without writing the
 		// manifest.
-		const transcriptManifestEntries = [...surfacedTranscriptRefsByScope.entries()].flatMap(([scope, refs]) =>
-			accessor.withReadDb((db) =>
-				[...refs].flatMap((sourceRef) => {
-					const source = readEpisodicSource(db, { agentId: scope, from: sourceRef });
-					return source === null || !source.completed
-						? []
-						: [{ scope, source, content: renderDreamingEvidence(source) }];
-				}),
-			),
-		);
+		const transcriptManifestEntries = [...surfacedTranscriptRefsByScope.entries()]
+			.filter(([scope]) => successfulScopes.has(scope))
+			.flatMap(([scope, refs]) =>
+				accessor.withReadDb((db) =>
+					[...refs].flatMap((sourceRef) => {
+						const source = readEpisodicSource(db, { agentId: scope, from: sourceRef });
+						return source === null || !source.completed
+							? []
+							: [{ scope, source, content: renderDreamingEvidence(source) }];
+					}),
+				),
+			);
 		accessor.withWriteTx((db) => {
 			writeDreamingTranscriptManifestInTx(db, {
 				passId,
@@ -1451,7 +1676,7 @@ export async function runDreamingAgentPass(
 				 tokens_consumed = ?, tokens_input = ?, tokens_output = ?,
 				 tokens_cache_read = ?, tokens_cache_write = ?, tokens_cost = ?,
 				 mutations_applied = ?, mutations_skipped = ?,
-				 mutations_failed = ?, summary = ? WHERE id = ?`,
+					mutations_failed = ?, summary = ? WHERE id = ?`,
 			).run(
 				tokensConsumed,
 				usage?.inputTokens ?? null,
@@ -1461,11 +1686,13 @@ export async function runDreamingAgentPass(
 				usage?.totalCost ?? null,
 				applied,
 				0,
-				failed,
+				failed + scopeErrors.length,
 				summary,
 				passId,
 			);
-			recordDreamingEvidenceExclusionsInTx(db, agentId, passId, rejectedEvidence, "semantic_operation_rejected");
+			for (const [scopeId, sources] of rejectedEvidenceByScope) {
+				recordDreamingEvidenceExclusionsInTx(db, scopeId, passId, [...sources.values()], "semantic_operation_rejected");
+			}
 			// The evidence queue resets to the pass watermark for EVERY scope
 			// the pass consumed evidence for: the next pass's backlog counts
 			// only sources captured after the surfaced frontier. A hygiene
@@ -1473,13 +1700,14 @@ export async function runDreamingAgentPass(
 			// advancing it would hide the unprocessed backlog from the next
 			// content pass and starve content again (#1098).
 			if (dreamingModeAdvancesEvidence(mode)) {
-				for (const scope of scopes) {
+				for (const scope of successfulScopes) {
 					resetDreamingTokens(db, scope, passId, mode, null, nextWatermarkByScope.get(scope) ?? null);
 				}
 			}
 		});
+		const totalFailures = failed + scopeErrors.length;
 		const outcome: DreamingPassOutcome =
-			failed > 0
+			totalFailures > 0
 				? effects.usefulEffects === 0
 					? "failed"
 					: "completed"
@@ -1488,10 +1716,10 @@ export async function runDreamingAgentPass(
 					: "completed";
 		const outcomeCode: DreamingPassOutcomeCode =
 			effects.usefulEffects === 0
-				? failed > 0
+				? totalFailures > 0
 					? "mutation_failure"
 					: "no_effects"
-				: failed > 0
+				: totalFailures > 0
 					? "partial_failure"
 					: "completed";
 		recordDreamingPassTelemetry({
@@ -1503,19 +1731,20 @@ export async function runDreamingAgentPass(
 		});
 		recordPipelineOperation({
 			operationClass: "dreaming",
-			outcome: failed > 0 ? (applied > 0 ? "partial" : "failed") : "completed",
+			outcome: totalFailures > 0 ? (applied > 0 ? "partial" : "failed") : "completed",
 			accepted: applied,
 			skipped: 0,
 			retried: 0,
-			failed,
+			failed: totalFailures,
 			durationMs: Date.now() - passStartedAtMs,
 			queueAgeMs: 0,
 		});
 
-		return { passId, applied, skipped: 0, failed, summary };
+		return { passId, applied, skipped: 0, failed: totalFailures, summary };
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		recordPipelineError("decision", isPipelineTimeout(error) ? "DECISION_TIMEOUT" : "DECISION_INVALID");
+		if (failureRecordedFor.size === 0) recordDreamingFailure(accessor, agentId);
 		logger.error("dreaming", "Agentic dreaming pass failed", undefined, { error: message });
 		try {
 			failDreamingPass(accessor, passId, message);
@@ -1649,6 +1878,23 @@ export function isDreamingScopeHalted(state: DreamingState, nowMs = Date.now()):
 	return Number.isFinite(failedAt) && nowMs - failedAt < DREAMING_HALT_COOLDOWN_MS;
 }
 
+/** Whether automatic scheduling must leave this scope for a later retry. */
+export function isDreamingScopeRetryBlocked(state: DreamingState, nowMs = Date.now()): boolean {
+	if (isDreamingScopeHalted(state, nowMs)) return true;
+	if (state.consecutiveFailures <= 0) return false;
+	const exp = Math.min(state.consecutiveFailures, MAX_FAILURE_BACKOFF_MULTIPLIER);
+	const failedAt = state.lastFailureAt === null ? Number.NaN : Date.parse(state.lastFailureAt);
+	return !Number.isFinite(failedAt) || nowMs - failedAt < FAILURE_BACKOFF_BASE_MS * 2 ** exp;
+}
+
+export function isDreamingScopeRetryBlockedForAgent(
+	accessor: DbAccessor,
+	agentId: string,
+	nowMs = Date.now(),
+): boolean {
+	return isDreamingScopeRetryBlocked(getDreamingState(accessor, agentId), nowMs);
+}
+
 /** Cheap sweep pre-check: one indexed dreaming_state row, no attention scan. */
 export function isDreamingHaltActive(accessor: DbAccessor, agentId: string, nowMs = Date.now()): boolean {
 	return isDreamingScopeHalted(getDreamingState(accessor, agentId), nowMs);
@@ -1694,17 +1940,10 @@ export function shouldTriggerDreaming(
 	const state = getDreamingState(accessor, agentId);
 	const hasAttention = accessor.withReadDb((db) => getDreamingAttentionInDb(db, agentId, 1).length > 0);
 
-	// Hard halt after repeated consecutive failures: no automatic scheduling
-	// for the cooldown window. Explicit operator triggers bypass this gate.
-	if (isDreamingScopeHalted(state, nowMs)) return false;
-
 	// Back off by wall clock, not by evidence volume. A transient provider outage
 	// must not require exponentially more incoming evidence before recovery.
-	if (state.consecutiveFailures > 0) {
-		const exp = Math.min(state.consecutiveFailures, MAX_FAILURE_BACKOFF_MULTIPLIER);
-		const failedAt = state.lastFailureAt === null ? Number.NaN : Date.parse(state.lastFailureAt);
-		if (!Number.isFinite(failedAt) || nowMs - failedAt < FAILURE_BACKOFF_BASE_MS * 2 ** exp) return false;
-	}
+	// Explicit operator triggers bypass this gate.
+	if (isDreamingScopeRetryBlocked(state, nowMs)) return false;
 
 	// First run only backfills actual episodic evidence, except for explicit
 	// scoped attention that has been queued for a Dreaming review.


### PR DESCRIPTION
## Summary

Closes #1344.

Dreaming now guarantees bounded progress for independent agent scopes without adding a second semantic writer or persisted pass.

## Changes

- Added the approved `dreaming-scope-fairness` spec, dependency graph entry, index integration, and runbook guidance.
- Reworked one-universe Dreaming into deterministic sequential, scope-bound turns with fair evidence, output, and timeout budgets.
- Bound every scope-bearing tool call to the active scope, kept evidence cursors and rejected-evidence exclusions scope-owned, and routed provider/auth execution to the turn scope.
- Isolated provider failures so healthy scopes continue while failed scopes retain backlog and automatic retry backoff.
- Added 100:1 imbalance, priority ordering, failure-isolation, prompt, audit-scope, exclusion-scope, and cross-scope read/write regression coverage.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

Not applicable; no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No schema migration is required. Existing pass/tool-call tables are reused; new tool traces use the active scope's existing `agent_id` column.

- [x] Migration is idempotent — N/A, no migration touched
- [x] Rollback / compatibility note included in PR description — N/A, no migration touched

## Testing

- [x] `bun test` passes for the affected daemon pipeline suite
- [x] `bun run typecheck` passes
- [x] `bunx biome check` passes for all changed TypeScript files
- [x] `bun scripts/spec-deps-check.ts` passes
- [x] `bun run build` passes
- [x] Tested against running daemon — N/A; no live daemon/API surface changed

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The full affected-package `bun run --filter '@signet/daemon' test` suite was also attempted with an isolated `SIGNET_PATH`; it reported 2,189 passing, 162 failing, and 14 errors after unrelated hook, HTTP, native-memory, and manifest-lock timeouts in this shared macOS environment. The three changed Dreaming pipeline suites pass cleanly (65 passing, 0 failing). The full-repository `bun run lint` command also reports pre-existing Biome formatting diagnostics in release-generated package manifests on `origin/main`; none are changed by this PR. The changed daemon TypeScript files pass the scoped Biome check above.
