### PR TITLE
feat: unified dashboard source imports

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -348,6 +348,7 @@
         "@1password/sdk": "^0.3.0",
         "@earendil-works/pi-ai": "0.83.0",
         "@earendil-works/pi-coding-agent": "0.83.0",
+        "@firecrawl/anydoc": "0.1.7",
         "@hono/node-server": "^2.1.0",
         "@huggingface/transformers": "^4.2.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -928,6 +929,22 @@
     "@expressive-code/plugin-shiki": ["@expressive-code/plugin-shiki@0.44.1", "", { "dependencies": { "@expressive-code/core": "^0.44.1", "shiki": "^4.0.2" } }, "sha512-YApiZt3buUzBwL5tqj8G+sYC5NjMjRCHgQwr9bmGl69rtcHy6fE9dooWUeKYB978fJT2BuxT5FeHcF47rA3SEg=="],
 
     "@expressive-code/plugin-text-markers": ["@expressive-code/plugin-text-markers@0.44.1", "", { "dependencies": { "@expressive-code/core": "^0.44.1" } }, "sha512-B3BsJoJ8CFMlcIX9f+X9tcI3C4zPDO601+YuLi9GheSTNro7ZfqSjLptMQKBHOWZvxnAtY5zvIX7iO/qtBhNBg=="],
+
+    "@firecrawl/anydoc": ["@firecrawl/anydoc@0.1.7", "", { "optionalDependencies": { "@firecrawl/anydoc-darwin-arm64": "0.1.7", "@firecrawl/anydoc-darwin-x64": "0.1.7", "@firecrawl/anydoc-linux-arm64-gnu": "0.1.7", "@firecrawl/anydoc-linux-arm64-musl": "0.1.7", "@firecrawl/anydoc-linux-x64-gnu": "0.1.7", "@firecrawl/anydoc-linux-x64-musl": "0.1.7", "@firecrawl/anydoc-win32-x64-msvc": "0.1.7" }, "bin": { "anydoc": "cli.js" } }, "sha512-UbJ6I49uaeUopcxozvX3TT7bvt9Gnx2tk2wf8ykaLtrThxvY9ZIZlbY47odT+x01ce3rXH9Pkpj40A796jN7Og=="],
+
+    "@firecrawl/anydoc-darwin-arm64": ["@firecrawl/anydoc-darwin-arm64@0.1.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1qi2pg6ija1EulitX/WkA9lkA9oa0CIFluUycFir5oP7M+Zpv1J12aEgleD/aHXr0EwiWVsRgTkGy3vBxy3rBA=="],
+
+    "@firecrawl/anydoc-darwin-x64": ["@firecrawl/anydoc-darwin-x64@0.1.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-BkmkrnkcbxCQi/+YIWbtPIoM6kM5ULDLw8tjAC7EsNb+H3tyCUdUg1fkBDzhRGCBo0urocTuGkG0uVR+udH0YA=="],
+
+    "@firecrawl/anydoc-linux-arm64-gnu": ["@firecrawl/anydoc-linux-arm64-gnu@0.1.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-T+2QkmGnnOCwaGX4nuq4rri3wQRp7Q9U52kI/vEGvq9699hLUkFjMP6aYxug8WBkgavQ6wU8Hd3u9wGkU9FnJQ=="],
+
+    "@firecrawl/anydoc-linux-arm64-musl": ["@firecrawl/anydoc-linux-arm64-musl@0.1.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-fiFUrHas8Gi8/G99CkuOkIN5HydSxvIsqN/fZI5jlhzkVm4ODRd47P0NRN0G0zPTKyzVvju9NypWfvZh5ptH8A=="],
+
+    "@firecrawl/anydoc-linux-x64-gnu": ["@firecrawl/anydoc-linux-x64-gnu@0.1.7", "", { "os": "linux", "cpu": "x64" }, "sha512-ezIvZ8IAfIHEXc7GW0Urt3cO2dcaS8Ko2YqZubCEGO3+4VjQz7x9ZZEBDFFr4xUSdlORyoOx7+a3OVbHaWdm2Q=="],
+
+    "@firecrawl/anydoc-linux-x64-musl": ["@firecrawl/anydoc-linux-x64-musl@0.1.7", "", { "os": "linux", "cpu": "x64" }, "sha512-5/YlfHT+u1dZ4gWgVp4QBWDQRExNDGiE5b0CvL9ZD7lOPK5N3Q+wkCl6Q5UV9/V/Ku6GgVxrI8p21TqG0ZZJlA=="],
+
+    "@firecrawl/anydoc-win32-x64-msvc": ["@firecrawl/anydoc-win32-x64-msvc@0.1.7", "", { "os": "win32", "cpu": "x64" }, "sha512-mo2jdUAxd87z9CATfN9dPiwJENaF0ZmS1Ll0Z0lWxWLN2ufqicrVZBMKU4c0+B/wX4OfzACh2Kh6J2x5918CtQ=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -273,6 +273,7 @@ export type {
 export {
 	addDiscordSource,
 	addGitHubSource,
+	addImportedSource,
 	addObsidianSource,
 	DEFAULT_DISCORD_DESKTOP_CACHE_PATH,
 	DEFAULT_DISCORD_MAX_ATTACHMENT_TEXT_BYTES,
@@ -297,6 +298,8 @@ export {
 export type {
 	AddDiscordSourceInput,
 	AddGitHubSourceInput,
+	AddImportedSourceInput,
+	AddImportedSourceResult,
 	AddObsidianSourceInput,
 	AddSourceResult,
 	DiscordSourceSettings,
@@ -304,6 +307,7 @@ export type {
 	GitHubSourceResourceType,
 	GitHubSourceSettings,
 	GitHubSourceState,
+	ImportedSourceDuplicateMode,
 	RemoveSourceResult,
 	SignetSourceEntry,
 	SignetSourceKind,

--- a/platform/core/src/migrations/124-import-derived-lifecycle.ts
+++ b/platform/core/src/migrations/124-import-derived-lifecycle.ts
@@ -1,0 +1,26 @@
+import type { MigrationDb } from "./index";
+
+/**
+ * Imported source removal is not ordinary source purge: derived ontology must
+ * remain available for review, but its evidence is no longer supported by a
+ * live source. Keep that lifecycle state separately from the graph rows so
+ * provenance remains intact and Dreaming can review it later.
+ */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS imported_source_lifecycle (
+			id TEXT PRIMARY KEY,
+			source_id TEXT NOT NULL,
+			agent_id TEXT NOT NULL,
+			status TEXT NOT NULL CHECK(status IN ('unsupported', 'reviewed')),
+			reason TEXT NOT NULL,
+			removed_at TEXT NOT NULL,
+			reviewed_at TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			UNIQUE(source_id, agent_id)
+		);
+		CREATE INDEX IF NOT EXISTS idx_imported_source_lifecycle_agent
+			ON imported_source_lifecycle(agent_id, status, updated_at DESC);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -129,6 +129,7 @@ import { up as sourceLifecycleTelemetry } from "./120-source-lifecycle-telemetry
 import { up as telemetryDeliveryHealth } from "./121-telemetry-delivery-health";
 import { up as dreamingEvidenceRetry } from "./122-dreaming-evidence-retry";
 import { up as embeddingIndexFailures } from "./123-embedding-index-failures";
+import { up as importedDerivedLifecycle } from "./124-import-derived-lifecycle";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1162,6 +1163,14 @@ export const MIGRATIONS: readonly Migration[] = [
 		name: "embedding-index-failures",
 		up: embeddingIndexFailures,
 		artifacts: { tables: ["embedding_index_failures"] },
+	},
+	{
+		version: 124,
+		name: "import-derived-lifecycle",
+		up: importedDerivedLifecycle,
+		artifacts: {
+			tables: ["imported_source_lifecycle"],
+		},
 	},
 ];
 

--- a/platform/core/src/sources-config.test.ts
+++ b/platform/core/src/sources-config.test.ts
@@ -9,6 +9,7 @@ import {
 	DEFAULT_OBSIDIAN_EXCLUDE_GLOBS,
 	addDiscordSource,
 	addGitHubSource,
+	addImportedSource,
 	addObsidianSource,
 	getSourcesConfigPath,
 	loadSourcesConfig,
@@ -520,6 +521,60 @@ describe("sources-config", () => {
 		if (removed.ok === true) throw new Error("expected removeSource to fail");
 		expect(removed.error).toContain("refusing to overwrite");
 		expect(readFileSync(configPath, "utf8")).toBe("{ not valid json");
+	});
+
+	it("creates imported sources and applies duplicate modes by content hash", () => {
+		const agentsDir = tmp();
+		const input = {
+			fileName: "export.json",
+			contentHash: "a".repeat(64),
+			format: "json",
+			now: "2026-01-01T00:00:00.000Z",
+		};
+
+		const first = addImportedSource(input, agentsDir);
+		expect(first.ok).toBe(true);
+		if (first.ok === false) throw new Error(first.error);
+		expect(first.created).toBe(true);
+		expect(first.duplicate).toBe(false);
+		expect(first.source.kind).toBe("import");
+		expect(first.source.providerSettings).toEqual({
+			fileName: "export.json",
+			contentHash: input.contentHash,
+			format: "json",
+		});
+
+		const skipped = addImportedSource({ ...input, duplicateMode: "skip" }, agentsDir);
+		expect(skipped).toEqual({ ok: true, source: first.source, created: false, duplicate: true });
+
+		const replaced = addImportedSource(
+			{ ...input, duplicateMode: "replace", now: "2026-01-02T00:00:00.000Z" },
+			agentsDir,
+		);
+		expect(replaced.ok).toBe(true);
+		if (replaced.ok === false) throw new Error(replaced.error);
+		expect(replaced.source.id).toBe(first.source.id);
+		expect(replaced.created).toBe(false);
+		expect(replaced.duplicate).toBe(true);
+
+		const reimported = addImportedSource({ ...input, duplicateMode: "reimport" }, agentsDir);
+		expect(reimported.ok).toBe(true);
+		if (reimported.ok === false) throw new Error(reimported.error);
+		expect(reimported.created).toBe(true);
+		expect(reimported.duplicate).toBe(true);
+		expect(reimported.source.id).not.toBe(first.source.id);
+		expect(loadSourcesConfig(agentsDir).sources).toHaveLength(2);
+	});
+
+	it("rejects malformed imported source metadata", () => {
+		const agentsDir = tmp();
+		expect(addImportedSource({ fileName: "", contentHash: "a".repeat(64), format: "json" }, agentsDir)).toEqual({
+			ok: false,
+			error: "Imported file name is required",
+		});
+		expect(
+			addImportedSource({ fileName: "export.json", contentHash: "not-a-hash", format: "json" }, agentsDir),
+		).toEqual({ ok: false, error: "Imported content hash is invalid" });
 	});
 
 	it("returns a not-found result when removing an unknown source", () => {

--- a/platform/core/src/sources-config.test.ts
+++ b/platform/core/src/sources-config.test.ts
@@ -577,6 +577,25 @@ describe("sources-config", () => {
 		).toEqual({ ok: false, error: "Imported content hash is invalid" });
 	});
 
+	it("does not replace an imported source owned by another agent", () => {
+		const agentsDir = tmp();
+		const input = {
+			fileName: "export.json",
+			contentHash: "b".repeat(64),
+			format: "json",
+			agentId: "agent-a",
+		};
+		const first = addImportedSource(input, agentsDir);
+		expect(first.ok).toBe(true);
+		if (first.ok === false) throw new Error(first.error);
+
+		const replaced = addImportedSource({ ...input, agentId: "agent-b", duplicateMode: "replace" }, agentsDir);
+		expect(replaced).toMatchObject({ ok: true, created: true, duplicate: false });
+		if (replaced.ok === false) throw new Error(replaced.error);
+		expect(replaced.source.id).not.toBe(first.source.id);
+		expect(loadSourcesConfig(agentsDir).sources).toHaveLength(2);
+	});
+
 	it("returns a not-found result when removing an unknown source", () => {
 		const agentsDir = tmp();
 		const removed = removeSource("obsidian:missing", agentsDir);

--- a/platform/core/src/sources-config.ts
+++ b/platform/core/src/sources-config.ts
@@ -230,7 +230,7 @@ export function addImportedSource(input: AddImportedSourceInput, agentsDir = get
 			(source) =>
 				source.kind === "import" &&
 				source.providerSettings?.contentHash === contentHash &&
-				(mode !== "replace" || agentId === undefined || source.providerSettings?.agentId === agentId),
+				(agentId === undefined || source.providerSettings?.agentId === agentId),
 		);
 		if (duplicate && mode === "skip") {
 			return { ok: true, source: duplicate, created: false, duplicate: true };

--- a/platform/core/src/sources-config.ts
+++ b/platform/core/src/sources-config.ts
@@ -113,6 +113,20 @@ export interface AddGitHubSourceInput {
 	readonly now?: string;
 }
 
+export type ImportedSourceDuplicateMode = "skip" | "replace" | "reimport";
+
+export interface AddImportedSourceInput {
+	readonly fileName: string;
+	readonly contentHash: string;
+	readonly format: string;
+	readonly duplicateMode?: ImportedSourceDuplicateMode;
+	readonly now?: string;
+}
+
+export type AddImportedSourceResult =
+	| { readonly ok: true; readonly source: SignetSourceEntry; readonly created: boolean; readonly duplicate: boolean }
+	| { readonly ok: false; readonly error: string };
+
 export type AddSourceResult =
 	| { readonly ok: true; readonly source: SignetSourceEntry; readonly created: boolean }
 	| { readonly ok: false; readonly error: string };
@@ -196,6 +210,53 @@ export function addDiscordSource(input: AddDiscordSourceInput, agentsDir = getAg
 
 export function addGitHubSource(input: AddGitHubSourceInput, agentsDir = getAgentsDir()): AddSourceResult {
 	return withSourcesConfigLock(agentsDir, () => addGitHubSourceUnlocked(input, agentsDir));
+}
+
+export function addImportedSource(input: AddImportedSourceInput, agentsDir = getAgentsDir()): AddImportedSourceResult {
+	return withSourcesConfigLock(agentsDir, () => {
+		const fileName = input.fileName.trim();
+		const contentHash = input.contentHash.trim().toLowerCase();
+		const format = input.format.trim().toLowerCase();
+		if (!fileName) return { ok: false, error: "Imported file name is required" };
+		if (!/^[a-f0-9]{64}$/.test(contentHash)) return { ok: false, error: "Imported content hash is invalid" };
+		if (!format) return { ok: false, error: "Imported file format is required" };
+
+		const now = input.now ?? new Date().toISOString();
+		const config = loadSourcesConfigForWrite(agentsDir);
+		const duplicate = config.sources.find(
+			(source) => source.kind === "import" && source.providerSettings?.contentHash === contentHash,
+		);
+		const mode = input.duplicateMode ?? "skip";
+		if (duplicate && mode === "skip") {
+			return { ok: true, source: duplicate, created: false, duplicate: true };
+		}
+
+		const sourceId =
+			duplicate && mode === "replace"
+				? duplicate.id
+				: `import:${contentHash.slice(0, 16)}${mode === "reimport" ? `:${randomUUID().slice(0, 8)}` : ""}`;
+		const source: SignetSourceEntry = {
+			id: sourceId,
+			kind: "import",
+			name: basename(fileName),
+			root: basename(fileName),
+			enabled: true,
+			mode: "read-only",
+			createdAt: duplicate?.createdAt ?? now,
+			updatedAt: now,
+			providerSettings: {
+				fileName: basename(fileName),
+				contentHash,
+				format,
+			},
+		};
+		const sources =
+			duplicate && mode === "replace"
+				? config.sources.map((entry) => (entry.id === duplicate.id ? source : entry))
+				: [...config.sources, source];
+		saveSourcesConfig({ version: SOURCES_CONFIG_VERSION, sources }, agentsDir);
+		return { ok: true, source, created: !duplicate || mode === "reimport", duplicate: Boolean(duplicate) };
+	});
 }
 
 function addDiscordSourceUnlocked(input: AddDiscordSourceInput, agentsDir = getAgentsDir()): AddSourceResult {

--- a/platform/core/src/sources-config.ts
+++ b/platform/core/src/sources-config.ts
@@ -119,6 +119,7 @@ export interface AddImportedSourceInput {
 	readonly fileName: string;
 	readonly contentHash: string;
 	readonly format: string;
+	readonly agentId?: string;
 	readonly duplicateMode?: ImportedSourceDuplicateMode;
 	readonly now?: string;
 }
@@ -217,24 +218,29 @@ export function addImportedSource(input: AddImportedSourceInput, agentsDir = get
 		const fileName = input.fileName.trim();
 		const contentHash = input.contentHash.trim().toLowerCase();
 		const format = input.format.trim().toLowerCase();
+		const agentId = input.agentId?.trim() || undefined;
 		if (!fileName) return { ok: false, error: "Imported file name is required" };
 		if (!/^[a-f0-9]{64}$/.test(contentHash)) return { ok: false, error: "Imported content hash is invalid" };
 		if (!format) return { ok: false, error: "Imported file format is required" };
 
 		const now = input.now ?? new Date().toISOString();
 		const config = loadSourcesConfigForWrite(agentsDir);
-		const duplicate = config.sources.find(
-			(source) => source.kind === "import" && source.providerSettings?.contentHash === contentHash,
-		);
 		const mode = input.duplicateMode ?? "skip";
+		const duplicate = config.sources.find(
+			(source) =>
+				source.kind === "import" &&
+				source.providerSettings?.contentHash === contentHash &&
+				(mode !== "replace" || agentId === undefined || source.providerSettings?.agentId === agentId),
+		);
 		if (duplicate && mode === "skip") {
 			return { ok: true, source: duplicate, created: false, duplicate: true };
 		}
 
+		const ownerSuffix = agentId ? `:${createHash("sha256").update(agentId).digest("hex").slice(0, 8)}` : "";
 		const sourceId =
 			duplicate && mode === "replace"
 				? duplicate.id
-				: `import:${contentHash.slice(0, 16)}${mode === "reimport" ? `:${randomUUID().slice(0, 8)}` : ""}`;
+				: `import:${contentHash.slice(0, 16)}${mode === "reimport" ? `:${randomUUID().slice(0, 8)}` : ownerSuffix}`;
 		const source: SignetSourceEntry = {
 			id: sourceId,
 			kind: "import",
@@ -248,6 +254,7 @@ export function addImportedSource(input: AddImportedSourceInput, agentsDir = get
 				fileName: basename(fileName),
 				contentHash,
 				format,
+				...(agentId === undefined ? {} : { agentId }),
 			},
 		};
 		const sources =

--- a/platform/daemon/package.json
+++ b/platform/daemon/package.json
@@ -39,6 +39,7 @@
     "@1password/sdk": "^0.3.0",
     "@earendil-works/pi-ai": "0.83.0",
     "@earendil-works/pi-coding-agent": "0.83.0",
+    "@firecrawl/anydoc": "0.1.7",
     "@hono/node-server": "^2.1.0",
     "@huggingface/transformers": "^4.2.0",
     "@modelcontextprotocol/sdk": "^1.30.0",

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -203,6 +203,7 @@ import {
 import { registerGraphiqRoutes } from "./routes/graphiq-routes.js";
 import { mountHealthRoutes } from "./routes/health.js";
 import { registerHooksRoutes } from "./routes/hooks-routes.js";
+import { registerImportRoutes } from "./routes/import-routes.js";
 import { mountInferenceRoutes } from "./routes/inference.js";
 import { registerKnowledgeRoutes } from "./routes/knowledge-routes.js";
 import { mountMarketplaceReviewsRoutes } from "./routes/marketplace-reviews.js";
@@ -284,6 +285,7 @@ registerGraphiqRoutes(app);
 registerSecretRoutes(app);
 registerSessionRoutes(app, { gitConfig, stopGitSyncTimer, startGitSyncTimer, getGitStatus, gitPull, gitPush, gitSync });
 registerSourcesRoutes(app);
+registerImportRoutes(app);
 registerPipelineRoutes(app);
 registerReflectionRoutes(app);
 registerTelemetryRoutes(app);

--- a/platform/daemon/src/import-normalizer.test.ts
+++ b/platform/daemon/src/import-normalizer.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeImportedFile } from "./import-normalizer";
+
+function bytes(value: string): Uint8Array {
+	return new TextEncoder().encode(value);
+}
+
+describe("import normalizer", () => {
+	it("preserves structured JSON as canonical pretty-printed content", async () => {
+		const result = await normalizeImportedFile(
+			"conversation.json",
+			bytes('{"messages":[{"role":"user","content":"hello"}]}'),
+			"application/json",
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok === false) throw new Error(result.error);
+		expect(result.value.format).toBe("json");
+		expect(result.value.content).toContain('"messages"');
+		expect(result.value.sourceMeta).toEqual({ representation: "structured-json", rootType: "object" });
+		expect(result.value.contentHash).toMatch(/^[a-f0-9]{64}$/);
+	});
+
+	it("normalizes CSV as one table artifact with row metadata", async () => {
+		const result = await normalizeImportedFile(
+			"contacts.csv",
+			bytes("name,email\r\nAda,ada@example.com\r\n"),
+			"text/csv",
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok === false) throw new Error(result.error);
+		expect(result.value.format).toBe("csv");
+		expect(result.value.content).toBe("name,email\nAda,ada@example.com\n");
+		expect(result.value.sourceMeta).toEqual({ representation: "table", rowCount: 1 });
+	});
+
+	it("projects HTML to text without scripts or markup", async () => {
+		const result = await normalizeImportedFile(
+			"page.html",
+			bytes("<h1>Hello &amp; world</h1><script>secret()</script><p>Body</p>"),
+			"text/html",
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok === false) throw new Error(result.error);
+		expect(result.value.content).toBe("Hello & world\nBody\n");
+		expect(result.value.content).not.toContain("secret");
+	});
+
+	it("rejects unsupported formats before creating a source", async () => {
+		expect(await normalizeImportedFile("archive.zip", bytes("PK"), "application/zip")).toEqual({
+			ok: false,
+			error: "Unsupported file format: .zip",
+		});
+	});
+
+	it("converts a document format through anydoc", async () => {
+		const result = await normalizeImportedFile("note.rtf", bytes("{\\rtf1\\ansi Imported note}"), "application/rtf");
+
+		expect(result.ok).toBe(true);
+		if (result.ok === false) throw new Error(result.error);
+		expect(result.value.format).toBe("rtf");
+		expect(result.value.sourceMeta).toEqual({ representation: "markdown-projection", converter: "anydoc" });
+		expect(result.value.content.toLowerCase()).toContain("imported note");
+	});
+});

--- a/platform/daemon/src/import-normalizer.test.ts
+++ b/platform/daemon/src/import-normalizer.test.ts
@@ -17,6 +17,8 @@ describe("import normalizer", () => {
 		if (result.ok === false) throw new Error(result.error);
 		expect(result.value.format).toBe("json");
 		expect(result.value.content).toContain('"messages"');
+		expect(result.value.canonicalContent).toBe('{"messages":[{"role":"user","content":"hello"}]}\n');
+		expect(result.value.canonicalContent).not.toBe(result.value.content);
 		expect(result.value.sourceMeta).toEqual({ representation: "structured-json", rootType: "object" });
 		expect(result.value.contentHash).toMatch(/^[a-f0-9]{64}$/);
 	});

--- a/platform/daemon/src/import-normalizer.test.ts
+++ b/platform/daemon/src/import-normalizer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { normalizeImportedFile } from "./import-normalizer";
+import { IMPORT_MAX_FILE_BYTES, normalizeImportedFile } from "./import-normalizer";
 
 function bytes(value: string): Uint8Array {
 	return new TextEncoder().encode(value);
@@ -33,6 +33,19 @@ describe("import normalizer", () => {
 		expect(result.value.format).toBe("csv");
 		expect(result.value.content).toBe("name,email\nAda,ada@example.com\n");
 		expect(result.value.sourceMeta).toEqual({ representation: "table", rowCount: 1 });
+	});
+
+	it("rejects normalized content that expands beyond the per-file limit", async () => {
+		const result = await normalizeImportedFile(
+			"large.txt",
+			new Uint8Array(IMPORT_MAX_FILE_BYTES).fill(97),
+			"text/plain",
+		);
+
+		expect(result).toEqual({
+			ok: false,
+			error: `Normalized file exceeds the ${IMPORT_MAX_FILE_BYTES} byte limit`,
+		});
 	});
 
 	it("projects HTML to text without scripts or markup", async () => {

--- a/platform/daemon/src/import-normalizer.ts
+++ b/platform/daemon/src/import-normalizer.ts
@@ -12,6 +12,12 @@ export interface NormalizedImport {
 	readonly content: string;
 	readonly contentHash: string;
 	readonly sourceMeta: Readonly<Record<string, unknown>>;
+	readonly searchChunks: readonly NormalizedImportChunk[];
+}
+
+export interface NormalizedImportChunk {
+	readonly content: string;
+	readonly sourceMeta: Readonly<Record<string, unknown>>;
 }
 
 export type NormalizeImportResult =
@@ -53,10 +59,16 @@ export async function normalizeImportedFile(
 		if (extension === ".json" || mediaType === "application/json") {
 			const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
 			const content = `${JSON.stringify(parsed, null, 2)}\n`;
-			return success(safeName, "json", content, {
-				representation: "structured-json",
-				rootType: Array.isArray(parsed) ? "array" : typeof parsed,
-			});
+			return success(
+				safeName,
+				"json",
+				content,
+				{
+					representation: "structured-json",
+					rootType: Array.isArray(parsed) ? "array" : typeof parsed,
+				},
+				[],
+			);
 		}
 		if (extension === ".html" || extension === ".htm" || mediaType === "text/html") {
 			const content = htmlToText(new TextDecoder().decode(bytes));
@@ -66,10 +78,16 @@ export async function normalizeImportedFile(
 		}
 		if (extension === ".csv" || mediaType === "text/csv") {
 			const content = normalizeText(new TextDecoder().decode(bytes));
-			return success(safeName, "csv", content, {
-				representation: "table",
-				rowCount: Math.max(0, content.split("\n").filter((line) => line.trim().length > 0).length - 1),
-			});
+			return success(
+				safeName,
+				"csv",
+				content,
+				{
+					representation: "table",
+					rowCount: Math.max(0, csvRecords(content).length - 1),
+				},
+				csvSearchChunks(content),
+			);
 		}
 		if (
 			extension === ".txt" ||
@@ -106,6 +124,7 @@ function success(
 	format: string,
 	content: string,
 	sourceMeta: Readonly<Record<string, unknown>>,
+	searchChunks: readonly NormalizedImportChunk[] = [],
 ): NormalizeImportResult {
 	return {
 		ok: true,
@@ -115,12 +134,64 @@ function success(
 			content,
 			contentHash: createHash("sha256").update(content, "utf8").digest("hex"),
 			sourceMeta,
+			searchChunks,
 		},
 	};
 }
 
 function failure(error: string): NormalizeImportResult {
 	return { ok: false, error };
+}
+
+const CSV_CHUNK_ROWS = 100;
+
+function csvRecords(content: string): string[] {
+	const records: string[] = [];
+	let current = "";
+	let quoted = false;
+	for (let index = 0; index < content.length; index += 1) {
+		const character = content[index] ?? "";
+		if (character === '"') {
+			if (quoted && content[index + 1] === '"') {
+				current += '""';
+				index += 1;
+				continue;
+			}
+			quoted = !quoted;
+			current += character;
+			continue;
+		}
+		if (character === "\n" && !quoted) {
+			if (current.trim().length > 0) records.push(current);
+			current = "";
+			continue;
+		}
+		current += character;
+	}
+	if (current.trim().length > 0) records.push(current);
+	return records;
+}
+
+function csvSearchChunks(content: string): NormalizedImportChunk[] {
+	const records = csvRecords(content);
+	if (records.length <= 1) return [];
+	const header = records[0] ?? "";
+	const chunks: NormalizedImportChunk[] = [];
+	for (let offset = 1; offset < records.length; offset += CSV_CHUNK_ROWS) {
+		const rows = records.slice(offset, offset + CSV_CHUNK_ROWS);
+		const rowStart = offset;
+		const rowEnd = offset + rows.length - 1;
+		chunks.push({
+			content: `${[header, ...rows].join("\n")}\n`,
+			sourceMeta: {
+				representation: "table-row-range",
+				rowStart,
+				rowEnd,
+				rowCount: rows.length,
+			},
+		});
+	}
+	return chunks;
 }
 
 function normalizeText(value: string): string {

--- a/platform/daemon/src/import-normalizer.ts
+++ b/platform/daemon/src/import-normalizer.ts
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+import { basename, extname } from "node:path";
+import { formatFromExtension, toMarkdownBytes } from "@firecrawl/anydoc";
+
+export const IMPORT_MAX_FILE_BYTES = 25 * 1024 * 1024;
+export const IMPORT_MAX_BATCH_BYTES = 100 * 1024 * 1024;
+export const IMPORT_MAX_FILES = 25;
+
+export interface NormalizedImport {
+	readonly fileName: string;
+	readonly format: string;
+	readonly content: string;
+	readonly contentHash: string;
+	readonly sourceMeta: Readonly<Record<string, unknown>>;
+}
+
+export type NormalizeImportResult =
+	| { readonly ok: true; readonly value: NormalizedImport }
+	| { readonly ok: false; readonly error: string };
+
+const ANYDOC_EXTENSIONS = new Set([
+	".doc",
+	".docx",
+	".docm",
+	".odt",
+	".rtf",
+	".pdf",
+	".ppt",
+	".pptx",
+	".ppsx",
+	".odp",
+	".epub",
+	".xls",
+	".xlsx",
+	".xlsm",
+	".ods",
+]);
+
+export async function normalizeImportedFile(
+	fileName: string,
+	bytes: Uint8Array,
+	mediaType?: string,
+): Promise<NormalizeImportResult> {
+	const safeName = basename(fileName).trim();
+	if (!safeName) return { ok: false, error: "File name is required" };
+	if (bytes.byteLength === 0) return { ok: false, error: "File is empty" };
+	if (bytes.byteLength > IMPORT_MAX_FILE_BYTES) {
+		return { ok: false, error: `File exceeds the ${IMPORT_MAX_FILE_BYTES} byte limit` };
+	}
+
+	const extension = extname(safeName).toLowerCase();
+	try {
+		if (extension === ".json" || mediaType === "application/json") {
+			const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
+			const content = `${JSON.stringify(parsed, null, 2)}\n`;
+			return success(safeName, "json", content, {
+				representation: "structured-json",
+				rootType: Array.isArray(parsed) ? "array" : typeof parsed,
+			});
+		}
+		if (extension === ".html" || extension === ".htm" || mediaType === "text/html") {
+			const content = htmlToText(new TextDecoder().decode(bytes));
+			return content.trim()
+				? success(safeName, "html", content, { representation: "text-projection" })
+				: failure("HTML has no meaningful text content");
+		}
+		if (extension === ".csv" || mediaType === "text/csv") {
+			const content = normalizeText(new TextDecoder().decode(bytes));
+			return success(safeName, "csv", content, {
+				representation: "table",
+				rowCount: Math.max(0, content.split("\n").filter((line) => line.trim().length > 0).length - 1),
+			});
+		}
+		if (
+			extension === ".txt" ||
+			extension === ".text" ||
+			extension === ".md" ||
+			extension === ".markdown" ||
+			mediaType?.startsWith("text/")
+		) {
+			return success(
+				safeName,
+				extension === ".md" || extension === ".markdown" ? "markdown" : "text",
+				normalizeText(new TextDecoder().decode(bytes)),
+				{
+					representation: extension === ".md" || extension === ".markdown" ? "markdown" : "plain-text",
+				},
+			);
+		}
+		if (!ANYDOC_EXTENSIONS.has(extension)) return failure(`Unsupported file format: ${extension || "unknown"}`);
+
+		const markdown = normalizeText(await toMarkdownBytes(bytes, formatFromExtension(extension)));
+		if (!markdown.trim()) return failure("Document conversion produced no meaningful content");
+		return success(safeName, extension.slice(1), markdown, {
+			representation: "markdown-projection",
+			converter: "anydoc",
+		});
+	} catch (error) {
+		const code = typeof error === "object" && error !== null && "code" in error ? String(error.code) : "conversion";
+		return failure(`Could not normalize ${safeName} (${code})`);
+	}
+}
+
+function success(
+	fileName: string,
+	format: string,
+	content: string,
+	sourceMeta: Readonly<Record<string, unknown>>,
+): NormalizeImportResult {
+	return {
+		ok: true,
+		value: {
+			fileName,
+			format,
+			content,
+			contentHash: createHash("sha256").update(content, "utf8").digest("hex"),
+			sourceMeta,
+		},
+	};
+}
+
+function failure(error: string): NormalizeImportResult {
+	return { ok: false, error };
+}
+
+function normalizeText(value: string): string {
+	return `${value.replace(/\r\n?/g, "\n").split(String.fromCharCode(0)).join("").trimEnd()}\n`;
+}
+
+function htmlToText(value: string): string {
+	return normalizeText(
+		decodeEntities(
+			value
+				.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "")
+				.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "")
+				.replace(/<br\s*\/?>(?=.)/gi, "\n")
+				.replace(/<\/(p|div|li|h[1-6]|tr|section|article)>/gi, "\n")
+				.replace(/<[^>]+>/g, "")
+				.replace(/[ \t]+/g, " "),
+		),
+	);
+}
+
+function decodeEntities(value: string): string {
+	return value
+		.replace(/&nbsp;/gi, " ")
+		.replace(/&amp;/gi, "&")
+		.replace(/&lt;/gi, "<")
+		.replace(/&gt;/gi, ">")
+		.replace(/&quot;/gi, '"')
+		.replace(/&#39;/gi, "'");
+}

--- a/platform/daemon/src/import-normalizer.ts
+++ b/platform/daemon/src/import-normalizer.ts
@@ -10,6 +10,7 @@ export interface NormalizedImport {
 	readonly fileName: string;
 	readonly format: string;
 	readonly content: string;
+	readonly canonicalContent?: string;
 	readonly contentHash: string;
 	readonly sourceMeta: Readonly<Record<string, unknown>>;
 	readonly searchChunks: readonly NormalizedImportChunk[];
@@ -58,6 +59,7 @@ export async function normalizeImportedFile(
 	try {
 		if (extension === ".json" || mediaType === "application/json") {
 			const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
+			const canonicalContent = `${JSON.stringify(parsed)}\n`;
 			const content = `${JSON.stringify(parsed, null, 2)}\n`;
 			return success(
 				safeName,
@@ -68,6 +70,7 @@ export async function normalizeImportedFile(
 					rootType: Array.isArray(parsed) ? "array" : typeof parsed,
 				},
 				[],
+				canonicalContent,
 			);
 		}
 		if (extension === ".html" || extension === ".htm" || mediaType === "text/html") {
@@ -128,15 +131,20 @@ function success(
 	content: string,
 	sourceMeta: Readonly<Record<string, unknown>>,
 	searchChunks: readonly NormalizedImportChunk[] = [],
+	canonicalContent?: string,
 ): NormalizeImportResult {
-	if (new TextEncoder().encode(content).byteLength > IMPORT_MAX_FILE_BYTES)
+	const encoder = new TextEncoder();
+	if (encoder.encode(content).byteLength > IMPORT_MAX_FILE_BYTES)
 		return failure(`Normalized file exceeds the ${IMPORT_MAX_FILE_BYTES} byte limit`);
+	if (canonicalContent !== undefined && encoder.encode(canonicalContent).byteLength > IMPORT_MAX_FILE_BYTES)
+		return failure(`Canonical file exceeds the ${IMPORT_MAX_FILE_BYTES} byte limit`);
 	return {
 		ok: true,
 		value: {
 			fileName,
 			format,
 			content,
+			...(canonicalContent === undefined ? {} : { canonicalContent }),
 			contentHash: createHash("sha256").update(content, "utf8").digest("hex"),
 			sourceMeta,
 			searchChunks,

--- a/platform/daemon/src/import-normalizer.ts
+++ b/platform/daemon/src/import-normalizer.ts
@@ -107,9 +107,12 @@ export async function normalizeImportedFile(
 		}
 		if (!ANYDOC_EXTENSIONS.has(extension)) return failure(`Unsupported file format: ${extension || "unknown"}`);
 
-		const markdown = normalizeText(await toMarkdownBytes(bytes, formatFromExtension(extension)));
-		if (!markdown.trim()) return failure("Document conversion produced no meaningful content");
-		return success(safeName, extension.slice(1), markdown, {
+		const markdown = await toMarkdownBytes(bytes, formatFromExtension(extension));
+		if (new TextEncoder().encode(markdown).byteLength > IMPORT_MAX_FILE_BYTES)
+			return failure(`Converted file exceeds the ${IMPORT_MAX_FILE_BYTES} byte limit`);
+		const normalizedMarkdown = normalizeText(markdown);
+		if (!normalizedMarkdown.trim()) return failure("Document conversion produced no meaningful content");
+		return success(safeName, extension.slice(1), normalizedMarkdown, {
 			representation: "markdown-projection",
 			converter: "anydoc",
 		});
@@ -126,6 +129,8 @@ function success(
 	sourceMeta: Readonly<Record<string, unknown>>,
 	searchChunks: readonly NormalizedImportChunk[] = [],
 ): NormalizeImportResult {
+	if (new TextEncoder().encode(content).byteLength > IMPORT_MAX_FILE_BYTES)
+		return failure(`Normalized file exceeds the ${IMPORT_MAX_FILE_BYTES} byte limit`);
 	return {
 		ok: true,
 		value: {

--- a/platform/daemon/src/imported-source-lifecycle.test.ts
+++ b/platform/daemon/src/imported-source-lifecycle.test.ts
@@ -59,11 +59,79 @@ describe("imported source lifecycle", () => {
 				agentId,
 				new Date().toISOString(),
 			);
+			db.prepare(
+				`INSERT INTO memories
+				 (id, content, type, agent_id, visibility, is_deleted, created_at, updated_at, updated_by)
+				 VALUES (?, ?, 'fact', ?, 'global', 0, ?, ?, 'test')`,
+			).run("memory-derived-1", "A derived imported fact", agentId, new Date().toISOString(), new Date().toISOString());
+			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at,
+				  source_id, source_kind, source_path, source_root)
+				 VALUES (?, 'Imported document', 'imported document', 'source_document', ?, 1, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"entity-source-1",
+				agentId,
+				new Date().toISOString(),
+				new Date().toISOString(),
+				sourceId,
+				"source_import_json_projection",
+				"notes.json",
+				"notes.json",
+			);
+			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES (?, 'Target', 'target', 'person', ?, 1, ?, ?)`,
+			).run("entity-target-1", agentId, new Date().toISOString(), new Date().toISOString());
+			db.prepare(
+				`INSERT INTO entity_aspects
+				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES (?, ?, ?, 'facts', 'facts', 0.8, ?, ?)`,
+			).run("aspect-source-1", "entity-source-1", agentId, new Date().toISOString(), new Date().toISOString());
+			db.prepare(
+				`INSERT INTO entity_attributes
+				 (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance, status,
+				  created_at, updated_at, source_id, source_kind, source_path, source_root)
+				 VALUES (?, ?, ?, NULL, 'claim', 'Imported claim', 'imported claim', 0.8, 0.5, 'active', ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"attribute-source-1",
+				"aspect-source-1",
+				agentId,
+				new Date().toISOString(),
+				new Date().toISOString(),
+				sourceId,
+				"source_import_json_projection",
+				"notes.json",
+				"notes.json",
+			);
+			db.prepare(
+				`INSERT INTO entity_dependencies
+				 (id, source_entity_id, target_entity_id, agent_id, dependency_type, strength, confidence, reason,
+				  created_at, updated_at, source_id, source_kind, source_path, source_root)
+				 VALUES (?, ?, ?, ?, 'contains', 1, 1, 'imported evidence', ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"dependency-source-1",
+				"entity-source-1",
+				"entity-target-1",
+				agentId,
+				new Date().toISOString(),
+				new Date().toISOString(),
+				sourceId,
+				"source_import_json_projection",
+				"notes.json",
+				"notes.json",
+			);
 		});
 
 		const result = markImportedSourceUnsupported({ sourceId, agentId, reason: "source removed by user" });
 
 		expect(result.artifacts).toBeGreaterThan(0);
+		expect(result.derivedMemories).toBe(1);
+		expect(result.entities).toBeGreaterThan(0);
+		expect(result.aspects).toBeGreaterThan(0);
+		expect(result.attributes).toBeGreaterThan(0);
+		expect(result.dependencies).toBeGreaterThan(0);
 		expect(
 			getDbAccessor().withReadDb(
 				(db) =>
@@ -72,6 +140,62 @@ describe("imported source lifecycle", () => {
 					},
 			).count,
 		).toBe(0);
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db.prepare("SELECT stale_at FROM memories WHERE id = ?").get("memory-derived-1") as {
+						stale_at: string | null;
+					},
+			).stale_at,
+		).toEqual(expect.any(String));
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db.prepare("SELECT status, archive_reason, source_id FROM entities WHERE id = ?").get("entity-source-1") as {
+						status: string;
+						archive_reason: string;
+						source_id: string;
+					},
+			),
+		).toEqual({
+			status: "archived",
+			archive_reason: "unsupported source: source removed by user",
+			source_id: sourceId,
+		});
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db.prepare("SELECT status, archive_reason FROM entity_aspects WHERE id = ?").get("aspect-source-1") as {
+						status: string;
+						archive_reason: string;
+					},
+			),
+		).toEqual({ status: "archived", archive_reason: "unsupported source: source removed by user" });
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare("SELECT status, archive_reason, source_id FROM entity_attributes WHERE id = ?")
+						.get("attribute-source-1") as { status: string; archive_reason: string; source_id: string },
+			),
+		).toEqual({
+			status: "archived",
+			archive_reason: "unsupported source: source removed by user",
+			source_id: sourceId,
+		});
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare("SELECT status, archive_reason, source_id FROM entity_dependencies WHERE id = ?")
+						.get("dependency-source-1") as { status: string; archive_reason: string; source_id: string },
+			),
+		).toEqual({
+			status: "archived",
+			archive_reason: "unsupported source: source removed by user",
+			source_id: sourceId,
+		});
+
 		expect(
 			getDbAccessor().withReadDb(
 				(db) =>

--- a/platform/daemon/src/imported-source-lifecycle.test.ts
+++ b/platform/daemon/src/imported-source-lifecycle.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { markImportedSourceUnsupported } from "./imported-source-lifecycle";
+import { indexExternalMemoryArtifact } from "./memory-lineage";
+
+describe("imported source lifecycle", () => {
+	let dir = "";
+	let previousPath: string | undefined;
+	let previousAgentId: string | undefined;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "signet-import-lifecycle-"));
+		mkdirSync(join(dir, "memory"), { recursive: true });
+		previousPath = process.env.SIGNET_PATH;
+		previousAgentId = process.env.SIGNET_AGENT_ID;
+		process.env.SIGNET_PATH = dir;
+		process.env.SIGNET_AGENT_ID = "lifecycle-test-agent";
+		closeDbAccessor();
+		initDbAccessor(join(dir, "memory", "memories.db"));
+	});
+
+	afterEach(() => {
+		closeDbAccessor();
+		if (previousPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
+		else process.env.SIGNET_PATH = previousPath;
+		if (previousAgentId === undefined) Reflect.deleteProperty(process.env, "SIGNET_AGENT_ID");
+		else process.env.SIGNET_AGENT_ID = previousAgentId;
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("removes searchable artifacts while preserving provenance for Dreaming review", () => {
+		const sourceId = "source-import-1";
+		const agentId = "lifecycle-test-agent";
+		indexExternalMemoryArtifact({
+			agentId,
+			sourcePath: "imports/source-import-1/notes.json",
+			sourceKind: "source_import_json_projection",
+			harness: "dashboard-import",
+			content: "A durable imported fact",
+			sourceMtimeMs: Date.now(),
+			sourceId,
+			sourceRoot: "notes.json",
+			sourceExternalId: "hash-1",
+			sourceMeta: { representation: "structured-json-projection" },
+		});
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO derived_memory_sources
+				 (derived_memory_id, source_kind, source_id, source_path, agent_id, created_at)
+				 VALUES (?, ?, ?, ?, ?, ?)`,
+			).run(
+				"memory-derived-1",
+				"source_import_json_projection",
+				sourceId,
+				"notes.json",
+				agentId,
+				new Date().toISOString(),
+			);
+		});
+
+		const result = markImportedSourceUnsupported({ sourceId, agentId, reason: "source removed by user" });
+
+		expect(result.artifacts).toBeGreaterThan(0);
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db.prepare("SELECT COUNT(*) AS count FROM memory_artifacts WHERE source_id = ?").get(sourceId) as {
+						count: number;
+					},
+			).count,
+		).toBe(0);
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db.prepare("SELECT source_id, source_path FROM derived_memory_sources WHERE source_id = ?").get(sourceId) as {
+						source_id: string;
+						source_path: string;
+					},
+			),
+		).toEqual({ source_id: sourceId, source_path: "notes.json" });
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db.prepare("SELECT status, reason FROM imported_source_lifecycle WHERE source_id = ?").get(sourceId) as {
+						status: string;
+						reason: string;
+					},
+			),
+		).toEqual({ status: "unsupported", reason: "source removed by user" });
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare("SELECT kind, subject_ref FROM dreaming_attention WHERE subject_ref = ?")
+						.get(`source:${sourceId}`) as {
+						kind: string;
+						subject_ref: string;
+					},
+			),
+		).toEqual({ kind: "hygiene", subject_ref: `source:${sourceId}` });
+	});
+});

--- a/platform/daemon/src/imported-source-lifecycle.ts
+++ b/platform/daemon/src/imported-source-lifecycle.ts
@@ -1,0 +1,76 @@
+import { createHash } from "node:crypto";
+import { SOURCE_CHUNK_SOURCE_TYPE } from "@signet/core";
+import { getDbAccessor } from "./db-accessor";
+import { countChanges, syncVecDeleteByEmbeddingIds } from "./db-helpers";
+import { enqueueDreamingAttentionInTx } from "./pipeline/dreaming-attention";
+
+export interface MarkImportedSourceUnsupportedInput {
+	readonly sourceId: string;
+	readonly agentId: string;
+	readonly reason?: string;
+}
+
+export interface MarkImportedSourceUnsupportedResult {
+	readonly artifacts: number;
+	readonly embeddings: number;
+}
+
+/**
+ * Detach imported evidence without deleting ontology derived from it. The
+ * lifecycle row is the durable marker used by Dreaming/hygiene review; graph
+ * rows keep their original source_id/source_path provenance.
+ */
+export function markImportedSourceUnsupported(
+	input: MarkImportedSourceUnsupportedInput,
+): MarkImportedSourceUnsupportedResult {
+	const sourceId = input.sourceId.trim();
+	const agentId = input.agentId.trim();
+	if (!sourceId || !agentId) return { artifacts: 0, embeddings: 0 };
+	return getDbAccessor().withWriteTx((db) => {
+		const now = new Date().toISOString();
+		const reason = input.reason?.trim() || "imported source removed";
+		db.prepare(
+			`INSERT INTO imported_source_lifecycle
+			 (id, source_id, agent_id, status, reason, removed_at, created_at, updated_at)
+			 VALUES (?, ?, ?, 'unsupported', ?, ?, ?, ?)
+			 ON CONFLICT(source_id, agent_id) DO UPDATE SET
+			   status = 'unsupported', reason = excluded.reason,
+			   removed_at = excluded.removed_at, updated_at = excluded.updated_at,
+			   reviewed_at = NULL`,
+		).run(
+			`import-lifecycle:${createHash("sha256").update(`${agentId}\0${sourceId}`).digest("hex")}`,
+			sourceId,
+			agentId,
+			reason,
+			now,
+			now,
+			now,
+		);
+
+		const artifacts = countChanges(
+			db.prepare("DELETE FROM memory_artifacts WHERE agent_id = ? AND source_id = ?").run(agentId, sourceId),
+		);
+		const prefix = `${sourceId}:`;
+		const embeddingRows = db
+			.prepare(
+				`SELECT id FROM embeddings
+				 WHERE agent_id = ? AND source_type = ? AND source_id >= ? AND source_id < ?`,
+			)
+			.all(agentId, SOURCE_CHUNK_SOURCE_TYPE, prefix, `${prefix}\uffff`) as Array<{ id: string }>;
+		const embeddingIds = embeddingRows.map((row) => row.id);
+		syncVecDeleteByEmbeddingIds(db, embeddingIds);
+		if (embeddingIds.length > 0) {
+			const stmt = db.prepare("DELETE FROM embeddings WHERE id = ?");
+			for (const id of embeddingIds) stmt.run(id);
+		}
+
+		enqueueDreamingAttentionInTx(db, {
+			agentId,
+			kind: "hygiene",
+			subjectRef: `source:${sourceId}`,
+			details: { sourceId, reason: "import-source-removed", lifecycle: "unsupported" },
+			priority: 90,
+		});
+		return { artifacts, embeddings: embeddingIds.length };
+	});
+}

--- a/platform/daemon/src/imported-source-lifecycle.ts
+++ b/platform/daemon/src/imported-source-lifecycle.ts
@@ -13,6 +13,11 @@ export interface MarkImportedSourceUnsupportedInput {
 export interface MarkImportedSourceUnsupportedResult {
 	readonly artifacts: number;
 	readonly embeddings: number;
+	readonly derivedMemories: number;
+	readonly entities: number;
+	readonly aspects: number;
+	readonly attributes: number;
+	readonly dependencies: number;
 }
 
 /**
@@ -25,7 +30,8 @@ export function markImportedSourceUnsupported(
 ): MarkImportedSourceUnsupportedResult {
 	const sourceId = input.sourceId.trim();
 	const agentId = input.agentId.trim();
-	if (!sourceId || !agentId) return { artifacts: 0, embeddings: 0 };
+	if (!sourceId || !agentId)
+		return { artifacts: 0, embeddings: 0, derivedMemories: 0, entities: 0, aspects: 0, attributes: 0, dependencies: 0 };
 	return getDbAccessor().withWriteTx((db) => {
 		const now = new Date().toISOString();
 		const reason = input.reason?.trim() || "imported source removed";
@@ -64,6 +70,67 @@ export function markImportedSourceUnsupported(
 			for (const id of embeddingIds) stmt.run(id);
 		}
 
+		const derivedMemoryRows = db
+			.prepare(
+				`SELECT DISTINCT dms.derived_memory_id AS id
+				 FROM derived_memory_sources dms
+				 JOIN memories derived ON derived.id = dms.derived_memory_id
+				 WHERE dms.agent_id = ? AND dms.source_id = ?
+				   AND derived.agent_id = ? AND derived.is_deleted = 0
+				   AND derived.stale_at IS NULL`,
+			)
+			.all(agentId, sourceId, agentId) as Array<{ id: string }>;
+		const derivedMemoryIds = derivedMemoryRows.map((row) => row.id);
+		if (derivedMemoryIds.length > 0) {
+			db.prepare(
+				`UPDATE memories SET stale_at = ?
+				 WHERE agent_id = ? AND stale_at IS NULL
+				   AND id IN (${derivedMemoryIds.map(() => "?").join(", ")})`,
+			).run(now, agentId, ...derivedMemoryIds);
+		}
+
+		const entityIds = db
+			.prepare("SELECT id FROM entities WHERE agent_id = ? AND source_id = ?")
+			.all(agentId, sourceId) as Array<{ id: string }>;
+		const entityIdValues = entityIds.map((row) => row.id);
+		const archiveReason = `unsupported source: ${reason}`;
+		const entities = countChanges(
+			db
+				.prepare(
+					`UPDATE entities SET status = 'archived', archived_at = ?, archived_by = ?, archive_reason = ?, updated_at = ?
+				 WHERE agent_id = ? AND source_id = ? AND status = 'active'`,
+				)
+				.run(now, "source-lifecycle", archiveReason, now, agentId, sourceId),
+		);
+		let aspects = 0;
+		if (entityIdValues.length > 0) {
+			aspects = countChanges(
+				db
+					.prepare(
+						`UPDATE entity_aspects SET status = 'archived', archived_at = ?, archived_by = ?, archive_reason = ?, updated_at = ?
+					 WHERE agent_id = ? AND status = 'active'
+					   AND entity_id IN (${entityIdValues.map(() => "?").join(", ")})`,
+					)
+					.run(now, "source-lifecycle", archiveReason, now, agentId, ...entityIdValues),
+			);
+		}
+		const attributes = countChanges(
+			db
+				.prepare(
+					`UPDATE entity_attributes SET status = 'archived', archived_at = ?, archived_by = ?, archive_reason = ?, updated_at = ?
+				 WHERE agent_id = ? AND source_id = ? AND status = 'active'`,
+				)
+				.run(now, "source-lifecycle", archiveReason, now, agentId, sourceId),
+		);
+		const dependencies = countChanges(
+			db
+				.prepare(
+					`UPDATE entity_dependencies SET status = 'archived', archived_at = ?, archived_by = ?, archive_reason = ?, updated_at = ?
+				 WHERE agent_id = ? AND source_id = ? AND status = 'active'`,
+				)
+				.run(now, "source-lifecycle", archiveReason, now, agentId, sourceId),
+		);
+
 		enqueueDreamingAttentionInTx(db, {
 			agentId,
 			kind: "hygiene",
@@ -71,6 +138,14 @@ export function markImportedSourceUnsupported(
 			details: { sourceId, reason: "import-source-removed", lifecycle: "unsupported" },
 			priority: 90,
 		});
-		return { artifacts, embeddings: embeddingIds.length };
+		return {
+			artifacts,
+			embeddings: embeddingIds.length,
+			derivedMemories: derivedMemoryIds.length,
+			entities,
+			aspects,
+			attributes,
+			dependencies,
+		};
 	});
 }

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -463,6 +463,42 @@ describe("hybridRecall", () => {
 		});
 	});
 
+	it("recalls imported source artifacts through the source-backed fallback", async () => {
+		indexExternalMemoryArtifact({
+			agentId: "default",
+			sourcePath: "imports/source-csv/contacts.csv#rows-1-1",
+			sourceKind: "source_import_csv_chunk",
+			harness: "dashboard-import",
+			content: "name,email\nAda,ada@example.com\n",
+			sourceMtimeMs: Date.now(),
+			sourceId: "source-csv",
+			sourceRoot: "contacts.csv",
+			sourceExternalId: "csv-hash",
+			sourceMeta: { representation: "table-row-range", rowStart: 1, rowEnd: 1 },
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "ada@example.com",
+				keywordQuery: "ada@example.com",
+				limit: 3,
+				agentId: "default",
+				readPolicy: "isolated",
+				sourceOnly: true,
+			},
+			testCfg(),
+			async () => null,
+		);
+
+		expect(result.results[0]).toMatchObject({
+			source: "source_import",
+			type: "source_import_csv_chunk",
+			source_id: "source-csv",
+			source_path: "imports/source-csv/contacts.csv#rows-1-1",
+		});
+		expect(result.results[0]?.content).toContain("Ada");
+	});
+
 	it("skips source chunk vector fallback for project-scoped recall", async () => {
 		const now = new Date().toISOString();
 		const vec = unitVector();

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -885,10 +885,14 @@ function nativeArtifactRecallContent(hit: NativeArtifactRecallHit): string {
 	if (hit.harness === "obsidian") {
 		return `[Obsidian vault note: ${hit.sourcePath}]\n${hit.content}`;
 	}
+	if (hit.sourceKind.startsWith("source_import_")) {
+		return `[Imported source: ${hit.sourcePath}]\n${hit.content}`;
+	}
 	return `[Native ${hit.harness ?? "harness"} memory: ${hit.sourcePath}]\n${hit.content}`;
 }
 
 function nativeArtifactRecallSource(hit: NativeArtifactRecallHit): string {
+	if (hit.sourceKind.startsWith("source_import_")) return "source_import";
 	return hit.harness === "obsidian" ? "source_obsidian" : "native_memory";
 }
 
@@ -2306,7 +2310,8 @@ export async function hybridRecall(
 				nativeHits.slice(0, fallbackLimit).map((hit): RecallResult => {
 					const content = nativeArtifactRecallContent(hit);
 					const truncated = content.length > recallTruncate;
-					const sourceId = nativeArtifactPublicId(hit);
+					const sourceId =
+						hit.sourceKind.startsWith("source_import_") && hit.sourceId ? hit.sourceId : nativeArtifactPublicId(hit);
 					if (hit.sourceId)
 						lifecycleSourceResults.set(`native-artifact:${hit.rowid}`, {
 							source: nativeArtifactRecallSource(hit),

--- a/platform/daemon/src/routes/import-routes.test.ts
+++ b/platform/daemon/src/routes/import-routes.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadSourcesConfig } from "@signet/core";
 import { Hono } from "hono";
-import { closeDbAccessor, initDbAccessor } from "../db-accessor";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 import { IMPORT_MAX_BATCH_BYTES } from "../import-normalizer";
 import { registerImportRoutes } from "./import-routes";
 
@@ -65,6 +65,51 @@ describe("import routes", () => {
 		expect(body.files[0]?.status).toBe("imported");
 		expect(loadSourcesConfig(dir).sources[0]?.kind).toBe("import");
 		expect(loadSourcesConfig(dir).sources[0]?.providerSettings?.format).toBe("json");
+		const artifacts = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT source_kind, source_path, source_meta_json FROM memory_artifacts ORDER BY source_path")
+					.all() as Array<{ source_kind: string; source_path: string; source_meta_json: string }>,
+		);
+		expect(artifacts.map((row) => row.source_kind).sort()).toEqual(
+			["source_import_json_canonical", "source_import_json_projection"].sort(),
+		);
+		const canonical = artifacts.find((row) => row.source_kind === "source_import_json_canonical");
+		expect(JSON.parse(canonical?.source_meta_json ?? "{}")).toMatchObject({
+			representation: "structured-json-canonical",
+		});
+		const attention = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT subject_ref, kind FROM dreaming_attention").all() as Array<{
+					subject_ref: string;
+					kind: string;
+				}>,
+		);
+		expect(attention).toContainEqual({ subject_ref: `source:${body.files[0]?.sourceId}`, kind: "hygiene" });
+	});
+
+	it("imports a selected local filesystem path and rejects remote path acquisition", async () => {
+		const path = join(dir, "selected.json");
+		writeFileSync(path, '{"selected":true}');
+		const localForm = new FormData();
+		localForm.append("paths", path);
+		const localResponse = await app().request("http://localhost/api/sources/import", {
+			method: "POST",
+			body: localForm,
+		});
+		expect(localResponse.status).toBe(201);
+		expect((await localResponse.json()).imported).toBe(1);
+
+		const remoteForm = new FormData();
+		remoteForm.append("paths", path);
+		const remoteResponse = await app().request("https://remote.example/api/sources/import", {
+			method: "POST",
+			body: remoteForm,
+		});
+		expect(remoteResponse.status).toBe(400);
+		expect(await remoteResponse.json()).toEqual({
+			error: "Filesystem path imports are only available on a local daemon",
+		});
 	});
 
 	it("reports duplicates without creating a second source", async () => {
@@ -76,8 +121,24 @@ describe("import routes", () => {
 		});
 
 		expect(first.status).toBe(201);
+		const chunks = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT source_kind, source_meta_json FROM memory_artifacts WHERE source_kind = ?")
+					.all("source_import_csv_chunk") as Array<{ source_kind: string; source_meta_json: string }>,
+		);
+		expect(chunks).toHaveLength(1);
+		expect(JSON.parse(chunks[0]?.source_meta_json ?? "{}")).toMatchObject({
+			representation: "table-row-range",
+			rowStart: 1,
+			rowEnd: 1,
+		});
 		expect(second.status).toBe(201);
-		const body = (await second.json()) as { imported: number; failed: number; files: Array<{ status: string }> };
+		const body = (await second.json()) as {
+			imported: number;
+			failed: number;
+			files: Array<{ fileName: string; status: string; sourceId: string }>;
+		};
 		expect(body).toEqual({
 			imported: 0,
 			failed: 0,
@@ -120,12 +181,33 @@ describe("import routes", () => {
 		});
 
 		expect(first.status).toBe(201);
+		const firstBody = (await first.json()) as { files: Array<{ sourceId: string }> };
 		expect(second.status).toBe(201);
 		expect(await second.json()).toMatchObject({
 			imported: 1,
 			failed: 0,
 			files: [{ fileName: "new-name.csv", status: "imported", duplicate: true }],
 		});
+		const lifecycle = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT status, reason FROM imported_source_lifecycle WHERE source_id = ?")
+					.all(firstBody.files[0]?.sourceId) as Array<{
+					status: string;
+					reason: string;
+				}>,
+		);
+		expect(lifecycle).toEqual([{ status: "unsupported", reason: "imported source replaced" }]);
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare("SELECT COUNT(*) AS count FROM memory_artifacts WHERE source_id = ?")
+						.get(firstBody.files[0]?.sourceId) as {
+						count: number;
+					},
+			).count,
+		).toBe(0);
 		expect(loadSourcesConfig(dir).sources).toMatchObject([
 			{ kind: "import", providerSettings: { fileName: "new-name.csv" } },
 		]);

--- a/platform/daemon/src/routes/import-routes.test.ts
+++ b/platform/daemon/src/routes/import-routes.test.ts
@@ -108,6 +108,30 @@ describe("import routes", () => {
 		expect(loadSourcesConfig(dir).sources).toHaveLength(1);
 	});
 
+	it("stages replacement before removing the old source", async () => {
+		const content = "name,email\nAda,ada@example.com\n";
+		const first = await app().request("/api/sources/import", {
+			method: "POST",
+			body: formWithFile(new File([content], "old-name.csv", { type: "text/csv" })),
+		});
+		const second = await app().request("/api/sources/import", {
+			method: "POST",
+			body: formWithFile(new File([content], "new-name.csv", { type: "text/csv" }), "replace"),
+		});
+
+		expect(first.status).toBe(201);
+		expect(second.status).toBe(201);
+		expect(await second.json()).toMatchObject({
+			imported: 1,
+			failed: 0,
+			files: [{ fileName: "new-name.csv", status: "imported", duplicate: true }],
+		});
+		expect(loadSourcesConfig(dir).sources).toMatchObject([
+			{ kind: "import", providerSettings: { fileName: "new-name.csv" } },
+		]);
+		expect(loadSourcesConfig(dir).sources).toHaveLength(1);
+	});
+
 	it("rejects a batch that exceeds the file-count boundary", async () => {
 		const form = new FormData();
 		for (let index = 0; index < 26; index++)

--- a/platform/daemon/src/routes/import-routes.test.ts
+++ b/platform/daemon/src/routes/import-routes.test.ts
@@ -86,6 +86,28 @@ describe("import routes", () => {
 		expect(loadSourcesConfig(dir).sources).toHaveLength(1);
 	});
 
+	it("indexes an existing duplicate for a different agent scope", async () => {
+		const content = "name,email\nAda,ada@example.com\n";
+		const first = await app().request("/api/sources/import", {
+			method: "POST",
+			body: formWithFile(new File([content], "contacts.csv", { type: "text/csv" })),
+		});
+		process.env.SIGNET_AGENT_ID = "second-import-test-agent";
+		const second = await app().request("/api/sources/import", {
+			method: "POST",
+			body: formWithFile(new File([content], "contacts.csv", { type: "text/csv" })),
+		});
+
+		expect(first.status).toBe(201);
+		expect(second.status).toBe(201);
+		expect(await second.json()).toMatchObject({
+			imported: 1,
+			failed: 0,
+			files: [{ fileName: "contacts.csv", status: "imported", duplicate: true }],
+		});
+		expect(loadSourcesConfig(dir).sources).toHaveLength(1);
+	});
+
 	it("rejects a batch that exceeds the file-count boundary", async () => {
 		const form = new FormData();
 		for (let index = 0; index < 26; index++)

--- a/platform/daemon/src/routes/import-routes.test.ts
+++ b/platform/daemon/src/routes/import-routes.test.ts
@@ -169,6 +169,43 @@ describe("import routes", () => {
 		expect(loadSourcesConfig(dir).sources).toHaveLength(1);
 	});
 
+	it("does not replace another agent's imported source", async () => {
+		const content = "name,email\nAda,ada@example.com\n";
+		const first = await app().request("/api/sources/import", {
+			method: "POST",
+			body: formWithFile(new File([content], "old-name.csv", { type: "text/csv" })),
+		});
+		const firstBody = (await first.json()) as { files: Array<{ sourceId: string }> };
+		process.env.SIGNET_AGENT_ID = "second-import-test-agent";
+		const second = await app().request("/api/sources/import", {
+			method: "POST",
+			body: formWithFile(new File([content], "new-name.csv", { type: "text/csv" }), "replace"),
+		});
+		const secondBody = (await second.json()) as {
+			imported: number;
+			failed: number;
+			files: Array<{ status: string; duplicate: boolean; sourceId: string }>;
+		};
+
+		expect(first.status).toBe(201);
+		expect(second.status).toBe(201);
+		expect(secondBody).toMatchObject({
+			imported: 1,
+			failed: 0,
+			files: [{ status: "imported", duplicate: false }],
+		});
+		expect(secondBody.files[0]?.sourceId).not.toBe(firstBody.files[0]?.sourceId);
+		expect(loadSourcesConfig(dir).sources).toHaveLength(2);
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare("SELECT COUNT(*) AS count FROM memory_artifacts WHERE agent_id = ? AND source_id = ?")
+						.get("import-test-agent", firstBody.files[0]?.sourceId) as { count: number },
+			).count,
+		).toBeGreaterThan(0);
+	});
+
 	it("stages replacement before removing the old source", async () => {
 		const content = "name,email\nAda,ada@example.com\n";
 		const first = await app().request("/api/sources/import", {

--- a/platform/daemon/src/routes/import-routes.test.ts
+++ b/platform/daemon/src/routes/import-routes.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadSourcesConfig } from "@signet/core";
+import { Hono } from "hono";
+import { closeDbAccessor, initDbAccessor } from "../db-accessor";
+import { registerImportRoutes } from "./import-routes";
+
+function formWithFile(file: File, duplicateMode = "skip"): FormData {
+	const form = new FormData();
+	form.append("files", file);
+	form.set("duplicateMode", duplicateMode);
+	return form;
+}
+
+describe("import routes", () => {
+	let dir = "";
+	let previousPath: string | undefined;
+	let previousAgentId: string | undefined;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "signet-import-routes-"));
+		mkdirSync(join(dir, "memory"), { recursive: true });
+		previousPath = process.env.SIGNET_PATH;
+		previousAgentId = process.env.SIGNET_AGENT_ID;
+		process.env.SIGNET_PATH = dir;
+		process.env.SIGNET_AGENT_ID = "import-test-agent";
+		closeDbAccessor();
+		initDbAccessor(join(dir, "memory", "memories.db"));
+	});
+
+	afterEach(() => {
+		closeDbAccessor();
+		if (previousPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
+		else process.env.SIGNET_PATH = previousPath;
+		if (previousAgentId === undefined) Reflect.deleteProperty(process.env, "SIGNET_AGENT_ID");
+		else process.env.SIGNET_AGENT_ID = previousAgentId;
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	function app(): Hono {
+		const instance = new Hono();
+		registerImportRoutes(instance);
+		return instance;
+	}
+
+	it("imports a JSON file and records durable source metadata", async () => {
+		const response = await app().request("/api/sources/import", {
+			method: "POST",
+			body: formWithFile(
+				new File(['{"messages":[{"role":"user","content":"hello"}]}'], "export.json", { type: "application/json" }),
+			),
+		});
+
+		expect(response.status).toBe(201);
+		const body = (await response.json()) as {
+			imported: number;
+			failed: number;
+			files: Array<{ status: string; sourceId?: string }>;
+		};
+		expect(body.imported).toBe(1);
+		expect(body.failed).toBe(0);
+		expect(body.files[0]?.status).toBe("imported");
+		expect(loadSourcesConfig(dir).sources[0]?.kind).toBe("import");
+		expect(loadSourcesConfig(dir).sources[0]?.providerSettings?.format).toBe("json");
+	});
+
+	it("reports duplicates without creating a second source", async () => {
+		const file = new File(["name,email\nAda,ada@example.com\n"], "contacts.csv", { type: "text/csv" });
+		const first = await app().request("/api/sources/import", { method: "POST", body: formWithFile(file) });
+		const second = await app().request("/api/sources/import", {
+			method: "POST",
+			body: formWithFile(new File(["name,email\nAda,ada@example.com\n"], "contacts.csv", { type: "text/csv" })),
+		});
+
+		expect(first.status).toBe(201);
+		expect(second.status).toBe(201);
+		const body = (await second.json()) as { imported: number; failed: number; files: Array<{ status: string }> };
+		expect(body).toEqual({
+			imported: 0,
+			failed: 0,
+			files: [{ fileName: "contacts.csv", status: "duplicate", sourceId: expect.any(String) }],
+		});
+		expect(loadSourcesConfig(dir).sources).toHaveLength(1);
+	});
+
+	it("rejects a batch that exceeds the file-count boundary", async () => {
+		const form = new FormData();
+		for (let index = 0; index < 26; index++)
+			form.append("files", new File(["x"], `file-${index}.txt`, { type: "text/plain" }));
+		const response = await app().request("/api/sources/import", { method: "POST", body: form });
+
+		expect(response.status).toBe(413);
+		expect(await response.json()).toEqual({ error: "Import accepts at most 25 files" });
+	});
+});

--- a/platform/daemon/src/routes/import-routes.test.ts
+++ b/platform/daemon/src/routes/import-routes.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { loadSourcesConfig } from "@signet/core";
 import { Hono } from "hono";
 import { closeDbAccessor, initDbAccessor } from "../db-accessor";
+import { IMPORT_MAX_BATCH_BYTES } from "../import-normalizer";
 import { registerImportRoutes } from "./import-routes";
 
 function formWithFile(file: File, duplicateMode = "skip"): FormData {
@@ -93,5 +94,25 @@ describe("import routes", () => {
 
 		expect(response.status).toBe(413);
 		expect(await response.json()).toEqual({ error: "Import accepts at most 25 files" });
+	});
+
+	it("rejects oversized chunked request bodies before form-data buffering", async () => {
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new Uint8Array(IMPORT_MAX_BATCH_BYTES + 1 * 1024 * 1024 + 1));
+				controller.close();
+			},
+		});
+		const request = new Request("http://localhost/api/sources/import", {
+			method: "POST",
+			headers: { "Content-Type": "multipart/form-data; boundary=import-test" },
+			body,
+			duplex: "half",
+		} as RequestInit & { duplex: "half" });
+
+		const response = await app().request(request);
+
+		expect(response.status).toBe(413);
+		expect(await response.json()).toEqual({ error: "Import batch exceeds the 104857600 byte limit" });
 	});
 });

--- a/platform/daemon/src/routes/import-routes.test.ts
+++ b/platform/daemon/src/routes/import-routes.test.ts
@@ -93,10 +93,14 @@ describe("import routes", () => {
 		writeFileSync(path, '{"selected":true}');
 		const localForm = new FormData();
 		localForm.append("paths", path);
-		const localResponse = await app().request("http://localhost/api/sources/import", {
-			method: "POST",
-			body: localForm,
-		});
+		const localResponse = await app().request(
+			"http://localhost/api/sources/import",
+			{
+				method: "POST",
+				body: localForm,
+			},
+			{ incoming: { socket: { remoteAddress: "127.0.0.1" } } },
+		);
 		expect(localResponse.status).toBe(201);
 		expect((await localResponse.json()).imported).toBe(1);
 
@@ -164,9 +168,9 @@ describe("import routes", () => {
 		expect(await second.json()).toMatchObject({
 			imported: 1,
 			failed: 0,
-			files: [{ fileName: "contacts.csv", status: "imported", duplicate: true }],
+			files: [{ fileName: "contacts.csv", status: "imported", duplicate: false }],
 		});
-		expect(loadSourcesConfig(dir).sources).toHaveLength(1);
+		expect(loadSourcesConfig(dir).sources).toHaveLength(2);
 	});
 
 	it("does not replace another agent's imported source", async () => {

--- a/platform/daemon/src/routes/import-routes.ts
+++ b/platform/daemon/src/routes/import-routes.ts
@@ -1,8 +1,10 @@
 import { readFile, stat } from "node:fs/promises";
 import { basename } from "node:path";
 import { addImportedSource, loadSourcesConfig, markSourceIndexed, removeSource } from "@signet/core";
+import type { Context } from "hono";
 import type { Hono } from "hono";
 import { resolveDaemonAgentId } from "../agent-id";
+import { getPeerAddress } from "../auth/middleware";
 import { getDbAccessor } from "../db-accessor";
 import {
 	IMPORT_MAX_BATCH_BYTES,
@@ -52,7 +54,7 @@ export function registerImportRoutes(app: Hono): void {
 		const pathEntries = form
 			.getAll("paths")
 			.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0);
-		if (pathEntries.length > 0 && !isLoopbackRequest(c.req.raw))
+		if (pathEntries.length > 0 && !isLoopbackRequest(c))
 			return c.json({ error: "Filesystem path imports are only available on a local daemon" }, 400);
 		if (uploadedEntries.length + pathEntries.length === 0)
 			return c.json({ error: "At least one file is required" }, 400);
@@ -176,7 +178,7 @@ export function registerImportRoutes(app: Hono): void {
 						sourcePath: `${sourcePath}#canonical`,
 						sourceKind: "source_import_json_canonical",
 						harness: "dashboard-import",
-						content: normalized.value.content,
+						content: normalized.value.canonicalContent ?? normalized.value.content,
 						sourceMtimeMs: Date.now(),
 						capturedAt: now,
 						sourceId: added.source.id,
@@ -274,9 +276,19 @@ export function registerImportRoutes(app: Hono): void {
 	});
 }
 
-function isLoopbackRequest(request: Request): boolean {
-	const hostname = new URL(request.url).hostname;
-	return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname === "::1";
+function isLoopbackRequest(c: Context): boolean {
+	const peer = getPeerAddress(c);
+	if (peer === null) return false;
+	const normalizedPeer = peer
+		.trim()
+		.toLowerCase()
+		.replace(/^\[|\]$/g, "");
+	return (
+		normalizedPeer === "localhost" ||
+		normalizedPeer === "127.0.0.1" ||
+		normalizedPeer === "::1" ||
+		normalizedPeer === "::ffff:127.0.0.1"
+	);
 }
 
 function hasIndexedSource(sourceId: string, agentId: string): boolean {
@@ -295,12 +307,13 @@ function hasIndexedSource(sourceId: string, agentId: string): boolean {
 
 function persistedImportBytes(value: {
 	readonly content: string;
+	readonly canonicalContent?: string;
 	readonly format: string;
 	readonly searchChunks: readonly { readonly content: string }[];
 }): number {
 	const encoder = new TextEncoder();
 	const contentBytes = encoder.encode(value.content).byteLength;
-	const canonicalBytes = value.format === "json" ? contentBytes : 0;
+	const canonicalBytes = value.format === "json" ? encoder.encode(value.canonicalContent ?? "").byteLength : 0;
 	const chunkBytes = value.searchChunks.reduce((total, chunk) => total + encoder.encode(chunk.content).byteLength, 0);
 	return contentBytes + canonicalBytes + chunkBytes;
 }

--- a/platform/daemon/src/routes/import-routes.ts
+++ b/platform/daemon/src/routes/import-routes.ts
@@ -1,3 +1,5 @@
+import { readFile, stat } from "node:fs/promises";
+import { basename } from "node:path";
 import { addImportedSource, loadSourcesConfig, markSourceIndexed, removeSource } from "@signet/core";
 import type { Hono } from "hono";
 import { resolveDaemonAgentId } from "../agent-id";
@@ -8,8 +10,10 @@ import {
 	IMPORT_MAX_FILE_BYTES,
 	normalizeImportedFile,
 } from "../import-normalizer";
+import { markImportedSourceUnsupported } from "../imported-source-lifecycle";
 import { logger } from "../logger";
 import { indexExternalMemoryArtifact } from "../memory-lineage";
+import { enqueueDreamingAttentionInTx } from "../pipeline/dreaming-attention";
 import { indexSourceArtifactStructure } from "../source-artifact-graph";
 import { purgeSourceOwnedRows } from "../source-purge";
 
@@ -44,19 +48,48 @@ export function registerImportRoutes(app: Hono): void {
 				return c.json({ error: `Import batch exceeds the ${IMPORT_MAX_BATCH_BYTES} byte limit` }, 413);
 			return c.json({ error: "Expected a multipart form with files" }, 400);
 		}
-		const entries = form.getAll("files").filter((entry): entry is File => entry instanceof File);
-		if (entries.length === 0) return c.json({ error: "At least one file is required" }, 400);
-		if (entries.length > IMPORT_MAX_FILES)
+		const uploadedEntries = form.getAll("files").filter((entry): entry is File => entry instanceof File);
+		const pathEntries = form
+			.getAll("paths")
+			.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0);
+		if (pathEntries.length > 0 && !isLoopbackRequest(c.req.raw))
+			return c.json({ error: "Filesystem path imports are only available on a local daemon" }, 400);
+		if (uploadedEntries.length + pathEntries.length === 0)
+			return c.json({ error: "At least one file is required" }, 400);
+		if (uploadedEntries.length + pathEntries.length > IMPORT_MAX_FILES)
 			return c.json({ error: `Import accepts at most ${IMPORT_MAX_FILES} files` }, 413);
 
 		const duplicateModeValue = form.get("duplicateMode");
 		const duplicateMode =
 			duplicateModeValue === "replace" || duplicateModeValue === "reimport" ? duplicateModeValue : "skip";
+		const statuses: ImportFileStatus[] = [];
+		const pathFiles: File[] = [];
+		for (const path of pathEntries) {
+			try {
+				const fileStat = await stat(path);
+				if (!fileStat.isFile()) throw new Error("path is not a file");
+				if (fileStat.size > IMPORT_MAX_FILE_BYTES) {
+					statuses.push({
+						fileName: basename(path),
+						status: "failed",
+						error: `File exceeds the ${IMPORT_MAX_FILE_BYTES} byte limit`,
+					});
+					continue;
+				}
+				pathFiles.push(new File([new Uint8Array(await readFile(path))], basename(path)));
+			} catch (error) {
+				statuses.push({
+					fileName: basename(path),
+					status: "failed",
+					error: error instanceof Error ? error.message : "Could not read file",
+				});
+			}
+		}
+		const entries = [...uploadedEntries, ...pathFiles];
 		const totalBytes = entries.reduce((total, file) => total + file.size, 0);
 		if (totalBytes > IMPORT_MAX_BATCH_BYTES)
 			return c.json({ error: `Import batch exceeds the ${IMPORT_MAX_BATCH_BYTES} byte limit` }, 413);
 
-		const statuses: ImportFileStatus[] = [];
 		let imported = 0;
 		for (const file of entries) {
 			if (file.size > IMPORT_MAX_FILE_BYTES) {
@@ -101,11 +134,13 @@ export function registerImportRoutes(app: Hono): void {
 
 			try {
 				const sourcePath = `imports/${added.source.id}/${normalized.value.fileName}`;
+				const sourceKind = `source_import_${normalized.value.format}`;
 				const now = new Date().toISOString();
+				const agentId = resolveDaemonAgentId();
 				indexExternalMemoryArtifact({
-					agentId: resolveDaemonAgentId(),
+					agentId,
 					sourcePath,
-					sourceKind: "import",
+					sourceKind: normalized.value.format === "json" ? "source_import_json_projection" : sourceKind,
 					harness: "dashboard-import",
 					content: normalized.value.content,
 					sourceMtimeMs: Date.now(),
@@ -115,18 +150,63 @@ export function registerImportRoutes(app: Hono): void {
 					sourceExternalId: normalized.value.contentHash,
 					sourceMeta: normalized.value.sourceMeta,
 				});
+				if (normalized.value.format === "json") {
+					indexExternalMemoryArtifact({
+						agentId,
+						sourcePath: `${sourcePath}#canonical`,
+						sourceKind: "source_import_json_canonical",
+						harness: "dashboard-import",
+						content: normalized.value.content,
+						sourceMtimeMs: Date.now(),
+						capturedAt: now,
+						sourceId: added.source.id,
+						sourceRoot: normalized.value.fileName,
+						sourceExternalId: normalized.value.contentHash,
+						sourceMeta: { ...normalized.value.sourceMeta, representation: "structured-json-canonical" },
+					});
+				}
 				indexSourceArtifactStructure({
-					agentId: resolveDaemonAgentId(),
+					agentId,
 					sourceId: added.source.id,
-					sourceKind: "import",
+					sourceKind,
 					sourceRoot: normalized.value.fileName,
 					sourcePath,
 					displayName: normalized.value.fileName,
 					content: normalized.value.content,
 				});
+				for (const chunk of normalized.value.searchChunks) {
+					const rowStart = typeof chunk.sourceMeta.rowStart === "number" ? chunk.sourceMeta.rowStart : 0;
+					const rowEnd = typeof chunk.sourceMeta.rowEnd === "number" ? chunk.sourceMeta.rowEnd : rowStart;
+					indexExternalMemoryArtifact({
+						agentId,
+						sourcePath: `${sourcePath}#rows-${rowStart}-${rowEnd}`,
+						sourceKind: "source_import_csv_chunk",
+						harness: "dashboard-import",
+						content: chunk.content,
+						sourceMtimeMs: Date.now(),
+						capturedAt: now,
+						sourceId: added.source.id,
+						sourceRoot: normalized.value.fileName,
+						sourceExternalId: normalized.value.contentHash,
+						sourceMeta: { ...normalized.value.sourceMeta, ...chunk.sourceMeta },
+					});
+				}
+				getDbAccessor().withWriteTx((db) => {
+					enqueueDreamingAttentionInTx(db, {
+						agentId,
+						kind: "hygiene",
+						subjectRef: `source:${added.source.id}`,
+						details: { sourceId: added.source.id, sourceKind, reason: "import-completed" },
+						priority: 40,
+					});
+				});
 				if (replacedSource !== undefined) {
 					try {
-						purgeSourceOwnedRows({ sourceId: replacedSource.id, agentId: resolveDaemonAgentId() });
+						markImportedSourceUnsupported({
+							sourceId: replacedSource.id,
+							agentId: resolveDaemonAgentId(),
+							reason: "imported source replaced",
+						});
 					} catch (cleanupError) {
 						logger.warn("documents", "Replaced dashboard import purge failed", {
 							sourceId: replacedSource.id,
@@ -172,6 +252,11 @@ export function registerImportRoutes(app: Hono): void {
 		const failed = statuses.filter((status) => status.status === "failed").length;
 		return c.json({ imported, failed, files: statuses }, failed > 0 ? 207 : 201);
 	});
+}
+
+function isLoopbackRequest(request: Request): boolean {
+	const hostname = new URL(request.url).hostname;
+	return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname === "::1";
 }
 
 function hasIndexedSource(sourceId: string, agentId: string): boolean {

--- a/platform/daemon/src/routes/import-routes.ts
+++ b/platform/daemon/src/routes/import-routes.ts
@@ -13,6 +13,9 @@ import { indexSourceArtifactStructure } from "../source-artifact-graph";
 import { purgeSourceOwnedRows } from "../source-purge";
 
 const MAX_MULTIPART_OVERHEAD = 1 * 1024 * 1024;
+const MAX_MULTIPART_BYTES = IMPORT_MAX_BATCH_BYTES + MAX_MULTIPART_OVERHEAD;
+
+class ImportPayloadTooLargeError extends Error {}
 
 type ImportFileStatus =
 	| {
@@ -34,8 +37,10 @@ export function registerImportRoutes(app: Hono): void {
 
 		let form: FormData;
 		try {
-			form = await c.req.formData();
-		} catch {
+			form = await boundedFormData(c.req.raw);
+		} catch (error) {
+			if (error instanceof ImportPayloadTooLargeError)
+				return c.json({ error: `Import batch exceeds the ${IMPORT_MAX_BATCH_BYTES} byte limit` }, 413);
 			return c.json({ error: "Expected a multipart form with files" }, 400);
 		}
 		const entries = form.getAll("files").filter((entry): entry is File => entry instanceof File);
@@ -144,4 +149,41 @@ export function registerImportRoutes(app: Hono): void {
 		const failed = statuses.filter((status) => status.status === "failed").length;
 		return c.json({ imported, failed, files: statuses }, failed > 0 ? 207 : 201);
 	});
+}
+
+async function boundedFormData(request: Request): Promise<FormData> {
+	if (request.body === null) return request.formData();
+	const body = new ReadableStream<Uint8Array>({
+		async start(controller) {
+			const reader = request.body?.getReader();
+			if (reader === undefined) {
+				controller.close();
+				return;
+			}
+			let totalBytes = 0;
+			try {
+				while (true) {
+					const next = await reader.read();
+					if (next.done) {
+						controller.close();
+						return;
+					}
+					totalBytes += next.value.byteLength;
+					if (totalBytes > MAX_MULTIPART_BYTES) {
+						await reader.cancel();
+						controller.error(new ImportPayloadTooLargeError());
+						return;
+					}
+					controller.enqueue(next.value);
+				}
+			} catch (error) {
+				controller.error(error);
+			}
+		},
+	});
+	const boundedRequest = new Request(request, {
+		body,
+		duplex: "half",
+	} as RequestInit & { duplex: "half" });
+	return boundedRequest.formData();
 }

--- a/platform/daemon/src/routes/import-routes.ts
+++ b/platform/daemon/src/routes/import-routes.ts
@@ -1,0 +1,147 @@
+import { addImportedSource, markSourceIndexed, removeSource } from "@signet/core";
+import type { Hono } from "hono";
+import { resolveDaemonAgentId } from "../agent-id";
+import {
+	IMPORT_MAX_BATCH_BYTES,
+	IMPORT_MAX_FILES,
+	IMPORT_MAX_FILE_BYTES,
+	normalizeImportedFile,
+} from "../import-normalizer";
+import { logger } from "../logger";
+import { indexExternalMemoryArtifact } from "../memory-lineage";
+import { indexSourceArtifactStructure } from "../source-artifact-graph";
+import { purgeSourceOwnedRows } from "../source-purge";
+
+const MAX_MULTIPART_OVERHEAD = 1 * 1024 * 1024;
+
+type ImportFileStatus =
+	| {
+			readonly fileName: string;
+			readonly status: "imported";
+			readonly sourceId: string;
+			readonly format: string;
+			readonly duplicate: boolean;
+	  }
+	| { readonly fileName: string; readonly status: "duplicate"; readonly sourceId: string }
+	| { readonly fileName: string; readonly status: "failed"; readonly error: string };
+
+export function registerImportRoutes(app: Hono): void {
+	app.post("/api/sources/import", async (c) => {
+		const contentLength = Number.parseInt(c.req.header("content-length") ?? "", 10);
+		if (Number.isFinite(contentLength) && contentLength > IMPORT_MAX_BATCH_BYTES + MAX_MULTIPART_OVERHEAD) {
+			return c.json({ error: `Import batch exceeds the ${IMPORT_MAX_BATCH_BYTES} byte limit` }, 413);
+		}
+
+		let form: FormData;
+		try {
+			form = await c.req.formData();
+		} catch {
+			return c.json({ error: "Expected a multipart form with files" }, 400);
+		}
+		const entries = form.getAll("files").filter((entry): entry is File => entry instanceof File);
+		if (entries.length === 0) return c.json({ error: "At least one file is required" }, 400);
+		if (entries.length > IMPORT_MAX_FILES)
+			return c.json({ error: `Import accepts at most ${IMPORT_MAX_FILES} files` }, 413);
+
+		const duplicateModeValue = form.get("duplicateMode");
+		const duplicateMode =
+			duplicateModeValue === "replace" || duplicateModeValue === "reimport" ? duplicateModeValue : "skip";
+		const totalBytes = entries.reduce((total, file) => total + file.size, 0);
+		if (totalBytes > IMPORT_MAX_BATCH_BYTES)
+			return c.json({ error: `Import batch exceeds the ${IMPORT_MAX_BATCH_BYTES} byte limit` }, 413);
+
+		const statuses: ImportFileStatus[] = [];
+		let imported = 0;
+		for (const file of entries) {
+			if (file.size > IMPORT_MAX_FILE_BYTES) {
+				statuses.push({
+					fileName: file.name,
+					status: "failed",
+					error: `File exceeds the ${IMPORT_MAX_FILE_BYTES} byte limit`,
+				});
+				continue;
+			}
+			const normalized = await normalizeImportedFile(file.name, new Uint8Array(await file.arrayBuffer()), file.type);
+			if (normalized.ok === false) {
+				statuses.push({ fileName: file.name, status: "failed", error: normalized.error });
+				continue;
+			}
+
+			const added = addImportedSource(
+				{
+					fileName: normalized.value.fileName,
+					contentHash: normalized.value.contentHash,
+					format: normalized.value.format,
+					duplicateMode,
+				},
+				process.env.SIGNET_PATH,
+			);
+			if (added.ok === false) {
+				statuses.push({ fileName: file.name, status: "failed", error: added.error });
+				continue;
+			}
+			if (added.duplicate && duplicateMode === "skip") {
+				statuses.push({ fileName: file.name, status: "duplicate", sourceId: added.source.id });
+				continue;
+			}
+
+			try {
+				if (added.duplicate && duplicateMode === "replace")
+					purgeSourceOwnedRows({ sourceId: added.source.id, agentId: resolveDaemonAgentId() });
+				const sourcePath = `imports/${added.source.id}/${normalized.value.fileName}`;
+				const now = new Date().toISOString();
+				indexExternalMemoryArtifact({
+					agentId: resolveDaemonAgentId(),
+					sourcePath,
+					sourceKind: "import",
+					harness: "dashboard-import",
+					content: normalized.value.content,
+					sourceMtimeMs: Date.now(),
+					capturedAt: now,
+					sourceId: added.source.id,
+					sourceRoot: normalized.value.fileName,
+					sourceExternalId: normalized.value.contentHash,
+					sourceMeta: normalized.value.sourceMeta,
+				});
+				indexSourceArtifactStructure({
+					agentId: resolveDaemonAgentId(),
+					sourceId: added.source.id,
+					sourceKind: "import",
+					sourceRoot: normalized.value.fileName,
+					sourcePath,
+					displayName: normalized.value.fileName,
+					content: normalized.value.content,
+				});
+				markSourceIndexed(added.source.id, now, process.env.SIGNET_PATH);
+				imported += 1;
+				statuses.push({
+					fileName: file.name,
+					status: "imported",
+					sourceId: added.source.id,
+					format: normalized.value.format,
+					duplicate: added.duplicate,
+				});
+			} catch (error) {
+				if (added.created) {
+					try {
+						purgeSourceOwnedRows({ sourceId: added.source.id, agentId: resolveDaemonAgentId() });
+						removeSource(added.source.id, process.env.SIGNET_PATH);
+					} catch (cleanupError) {
+						logger.warn("documents", "Dashboard import cleanup failed", {
+							sourceId: added.source.id,
+							error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+						});
+					}
+				}
+				logger.warn("documents", "Dashboard import failed after source registration", {
+					sourceId: added.source.id,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				statuses.push({ fileName: file.name, status: "failed", error: "Could not persist imported source" });
+			}
+		}
+
+		const failed = statuses.filter((status) => status.status === "failed").length;
+		return c.json({ imported, failed, files: statuses }, failed > 0 ? 207 : 201);
+	});
+}

--- a/platform/daemon/src/routes/import-routes.ts
+++ b/platform/daemon/src/routes/import-routes.ts
@@ -1,4 +1,4 @@
-import { addImportedSource, markSourceIndexed, removeSource } from "@signet/core";
+import { addImportedSource, loadSourcesConfig, markSourceIndexed, removeSource } from "@signet/core";
 import type { Hono } from "hono";
 import { resolveDaemonAgentId } from "../agent-id";
 import { getDbAccessor } from "../db-accessor";
@@ -73,14 +73,22 @@ export function registerImportRoutes(app: Hono): void {
 				continue;
 			}
 
+			const agentsDir = process.env.SIGNET_PATH;
+			const replacedSource =
+				duplicateMode === "replace"
+					? loadSourcesConfig(agentsDir).sources.find(
+							(source) =>
+								source.kind === "import" && source.providerSettings?.contentHash === normalized.value.contentHash,
+						)
+					: undefined;
 			const added = addImportedSource(
 				{
 					fileName: normalized.value.fileName,
 					contentHash: normalized.value.contentHash,
 					format: normalized.value.format,
-					duplicateMode,
+					duplicateMode: replacedSource === undefined ? duplicateMode : "reimport",
 				},
-				process.env.SIGNET_PATH,
+				agentsDir,
 			);
 			if (added.ok === false) {
 				statuses.push({ fileName: file.name, status: "failed", error: added.error });
@@ -92,8 +100,6 @@ export function registerImportRoutes(app: Hono): void {
 			}
 
 			try {
-				if (added.duplicate && duplicateMode === "replace")
-					purgeSourceOwnedRows({ sourceId: added.source.id, agentId: resolveDaemonAgentId() });
 				const sourcePath = `imports/${added.source.id}/${normalized.value.fileName}`;
 				const now = new Date().toISOString();
 				indexExternalMemoryArtifact({
@@ -118,7 +124,23 @@ export function registerImportRoutes(app: Hono): void {
 					displayName: normalized.value.fileName,
 					content: normalized.value.content,
 				});
-				markSourceIndexed(added.source.id, now, process.env.SIGNET_PATH);
+				if (replacedSource !== undefined) {
+					try {
+						purgeSourceOwnedRows({ sourceId: replacedSource.id, agentId: resolveDaemonAgentId() });
+					} catch (cleanupError) {
+						logger.warn("documents", "Replaced dashboard import purge failed", {
+							sourceId: replacedSource.id,
+							error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+						});
+					}
+					const removed = removeSource(replacedSource.id, agentsDir);
+					if (removed.ok === false)
+						logger.warn("documents", "Replaced dashboard import config cleanup failed", {
+							sourceId: replacedSource.id,
+							error: removed.error,
+						});
+				}
+				markSourceIndexed(added.source.id, now, agentsDir);
 				imported += 1;
 				statuses.push({
 					fileName: file.name,

--- a/platform/daemon/src/routes/import-routes.ts
+++ b/platform/daemon/src/routes/import-routes.ts
@@ -96,6 +96,7 @@ export function registerImportRoutes(app: Hono): void {
 			return c.json({ error: `Import batch exceeds the ${IMPORT_MAX_BATCH_BYTES} byte limit` }, 413);
 
 		let imported = 0;
+		let normalizedBatchBytes = 0;
 		for (const file of entries) {
 			if (file.size > IMPORT_MAX_FILE_BYTES) {
 				statuses.push({
@@ -110,6 +111,16 @@ export function registerImportRoutes(app: Hono): void {
 				statuses.push({ fileName: file.name, status: "failed", error: normalized.error });
 				continue;
 			}
+			const normalizedBytes = persistedImportBytes(normalized.value);
+			if (normalizedBatchBytes + normalizedBytes > IMPORT_MAX_BATCH_BYTES) {
+				statuses.push({
+					fileName: file.name,
+					status: "failed",
+					error: `Normalized import batch exceeds the ${IMPORT_MAX_BATCH_BYTES} byte limit`,
+				});
+				continue;
+			}
+			normalizedBatchBytes += normalizedBytes;
 
 			const agentsDir = process.env.SIGNET_PATH;
 			const replacedSource =
@@ -276,6 +287,18 @@ function hasIndexedSource(sourceId: string, agentId: string): boolean {
 			.get(agentId, sourceId) as { present: number } | null | undefined;
 		return row != null;
 	});
+}
+
+function persistedImportBytes(value: {
+	readonly content: string;
+	readonly format: string;
+	readonly searchChunks: readonly { readonly content: string }[];
+}): number {
+	const encoder = new TextEncoder();
+	const contentBytes = encoder.encode(value.content).byteLength;
+	const canonicalBytes = value.format === "json" ? contentBytes : 0;
+	const chunkBytes = value.searchChunks.reduce((total, chunk) => total + encoder.encode(chunk.content).byteLength, 0);
+	return contentBytes + canonicalBytes + chunkBytes;
 }
 
 async function boundedFormData(request: Request): Promise<FormData> {

--- a/platform/daemon/src/routes/import-routes.ts
+++ b/platform/daemon/src/routes/import-routes.ts
@@ -123,11 +123,14 @@ export function registerImportRoutes(app: Hono): void {
 			normalizedBatchBytes += normalizedBytes;
 
 			const agentsDir = process.env.SIGNET_PATH;
+			const agentId = resolveDaemonAgentId();
 			const replacedSource =
 				duplicateMode === "replace"
 					? loadSourcesConfig(agentsDir).sources.find(
 							(source) =>
-								source.kind === "import" && source.providerSettings?.contentHash === normalized.value.contentHash,
+								source.kind === "import" &&
+								source.providerSettings?.contentHash === normalized.value.contentHash &&
+								source.providerSettings?.agentId === agentId,
 						)
 					: undefined;
 			const added = addImportedSource(
@@ -135,6 +138,7 @@ export function registerImportRoutes(app: Hono): void {
 					fileName: normalized.value.fileName,
 					contentHash: normalized.value.contentHash,
 					format: normalized.value.format,
+					agentId,
 					duplicateMode: replacedSource === undefined ? duplicateMode : "reimport",
 				},
 				agentsDir,
@@ -152,7 +156,7 @@ export function registerImportRoutes(app: Hono): void {
 				const sourcePath = `imports/${added.source.id}/${normalized.value.fileName}`;
 				const sourceKind = `source_import_${normalized.value.format}`;
 				const now = new Date().toISOString();
-				const agentId = resolveDaemonAgentId();
+
 				indexExternalMemoryArtifact({
 					agentId,
 					sourcePath,

--- a/platform/daemon/src/routes/import-routes.ts
+++ b/platform/daemon/src/routes/import-routes.ts
@@ -64,6 +64,8 @@ export function registerImportRoutes(app: Hono): void {
 			duplicateModeValue === "replace" || duplicateModeValue === "reimport" ? duplicateModeValue : "skip";
 		const statuses: ImportFileStatus[] = [];
 		const pathFiles: File[] = [];
+		const uploadedBytes = uploadedEntries.reduce((total, file) => total + file.size, 0);
+		let pathBytes = 0;
 		for (const path of pathEntries) {
 			try {
 				const fileStat = await stat(path);
@@ -76,6 +78,9 @@ export function registerImportRoutes(app: Hono): void {
 					});
 					continue;
 				}
+				pathBytes += fileStat.size;
+				if (uploadedBytes + pathBytes > IMPORT_MAX_BATCH_BYTES)
+					return c.json({ error: `Import batch exceeds the ${IMPORT_MAX_BATCH_BYTES} byte limit` }, 413);
 				pathFiles.push(new File([new Uint8Array(await readFile(path))], basename(path)));
 			} catch (error) {
 				statuses.push({

--- a/platform/daemon/src/routes/import-routes.ts
+++ b/platform/daemon/src/routes/import-routes.ts
@@ -1,6 +1,7 @@
 import { addImportedSource, markSourceIndexed, removeSource } from "@signet/core";
 import type { Hono } from "hono";
 import { resolveDaemonAgentId } from "../agent-id";
+import { getDbAccessor } from "../db-accessor";
 import {
 	IMPORT_MAX_BATCH_BYTES,
 	IMPORT_MAX_FILES,
@@ -85,7 +86,7 @@ export function registerImportRoutes(app: Hono): void {
 				statuses.push({ fileName: file.name, status: "failed", error: added.error });
 				continue;
 			}
-			if (added.duplicate && duplicateMode === "skip") {
+			if (added.duplicate && duplicateMode === "skip" && hasIndexedSource(added.source.id, resolveDaemonAgentId())) {
 				statuses.push({ fileName: file.name, status: "duplicate", sourceId: added.source.id });
 				continue;
 			}
@@ -148,6 +149,20 @@ export function registerImportRoutes(app: Hono): void {
 
 		const failed = statuses.filter((status) => status.status === "failed").length;
 		return c.json({ imported, failed, files: statuses }, failed > 0 ? 207 : 201);
+	});
+}
+
+function hasIndexedSource(sourceId: string, agentId: string): boolean {
+	return getDbAccessor().withReadDb((db) => {
+		const row = db
+			.prepare(
+				`SELECT 1 AS present
+				 FROM memory_artifacts
+				 WHERE agent_id = ? AND source_id = ? AND COALESCE(is_deleted, 0) = 0
+				 LIMIT 1`,
+			)
+			.get(agentId, sourceId) as { present: number } | null | undefined;
+		return row != null;
 	});
 }
 

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { addDiscordSource, addObsidianSource, loadSourcesConfig } from "@signet/core";
+import { addDiscordSource, addImportedSource, addObsidianSource, loadSourcesConfig } from "@signet/core";
 import { Hono } from "hono";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 import { hashNormalizedBody } from "../memory-lineage";
@@ -293,6 +293,33 @@ describe("Sources routes", () => {
 		await waitFor(() => !!loadSourcesConfig(dir).sources[0]?.lastIndexedAt);
 	});
 
+	it("does not let another agent delete an imported source", async () => {
+		process.env.SIGNET_AGENT_ID = "source-owner-a";
+		const added = addImportedSource(
+			{
+				fileName: "owned.json",
+				contentHash: "b".repeat(64),
+				format: "json",
+				agentId: "source-owner-a",
+			},
+			dir,
+		);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		process.env.SIGNET_AGENT_ID = "source-owner-b";
+		const response = await makeApp().request(`/api/sources/${encodeURIComponent(added.source.id)}`, {
+			method: "DELETE",
+		});
+
+		expect(response.status).toBe(404);
+		expect(loadSourcesConfig(dir).sources).toHaveLength(1);
+		expect(
+			getDbAccessor().withReadDb(
+				(db) => db.prepare("SELECT COUNT(*) AS count FROM imported_source_lifecycle").get() as { count: number },
+			).count,
+		).toBe(0);
+	});
 	it("purges again when a disconnected source still has an in-flight index job", async () => {
 		let releaseScan = () => {};
 		let purges = 0;

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -320,6 +320,41 @@ describe("Sources routes", () => {
 			).count,
 		).toBe(0);
 	});
+
+	it("does not expose another agent's imported source through list or read routes", async () => {
+		process.env.SIGNET_AGENT_ID = "source-owner-a";
+		const added = addImportedSource(
+			{
+				fileName: "private.json",
+				contentHash: "c".repeat(64),
+				format: "json",
+				agentId: "source-owner-a",
+			},
+			dir,
+		);
+		if (added.ok === false) throw new Error(added.error);
+
+		process.env.SIGNET_AGENT_ID = "source-owner-b";
+		const app = makeApp();
+		const list = await app.request("/api/sources");
+		expect(list.status).toBe(200);
+		expect((await list.json()) as { version: number; sources: unknown[] }).toEqual({ version: 1, sources: [] });
+
+		const paths = [
+			`/api/sources/${encodeURIComponent(added.source.id)}/health`,
+			`/api/sources/${encodeURIComponent(added.source.id)}/snapshot`,
+			`/api/sources/${encodeURIComponent(added.source.id)}/snapshot/import`,
+		];
+		for (const path of paths) {
+			const isImport = path.endsWith("/import");
+			const response = await app.request(path, {
+				method: isImport ? "POST" : "GET",
+				headers: isImport ? { "Content-Type": "application/json" } : undefined,
+				body: isImport ? "{}" : undefined,
+			});
+			expect(response.status).toBe(404);
+		}
+	});
 	it("purges again when a disconnected source still has an in-flight index job", async () => {
 		let releaseScan = () => {};
 		let purges = 0;

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -15,8 +15,9 @@ import {
 	markSourceIndexed,
 	removeSource,
 } from "@signet/core";
-import type { Hono } from "hono";
+import type { Context, Hono } from "hono";
 import { resolveDaemonAgentId } from "../agent-id";
+import { getPeerAddress } from "../auth/middleware";
 import { type ReadDb, getDbAccessor } from "../db-accessor";
 import { fetchEmbedding } from "../embedding-fetch";
 import { logger } from "../logger";
@@ -192,7 +193,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 	});
 
 	app.post("/api/sources/pick-files", async (c) => {
-		if (!isLoopbackRequest(c.req.raw)) return c.json({ error: "Native file picking is local-only" }, 400);
+		if (!isLoopbackRequest(c)) return c.json({ error: "Native file picking is local-only" }, 400);
 		let body: PickDirectoryBody = {};
 		try {
 			body = (await c.req.json().catch(() => ({}))) as PickDirectoryBody;
@@ -434,11 +435,15 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 
 	app.delete("/api/sources/:sourceId", (c) => {
 		const sourceId = c.req.param("sourceId");
+		const source = findConfiguredSource(sourceId, agentsDir);
+		if (source === undefined) return c.json({ error: "Source not found" }, 404);
+		const sourceAgentId = resolveDaemonAgentId();
+		if (source.kind === "import" && source.providerSettings?.agentId !== sourceAgentId)
+			return c.json({ error: "Source not found" }, 404);
 		const result = removeSource(sourceId, agentsDir);
 		if (result.ok === false) return c.json({ error: result.error }, 404);
 		cancelSourceIndexJob(result.source.id);
 
-		const sourceAgentId = resolveDaemonAgentId();
 		removeSourceLifecycleState(result.source, sourceAgentId);
 		recordSourceDeletionTombstone(result.source, sourceAgentId, agentsDir);
 		const provider = getSourceProvider(result.source.kind);
@@ -1169,9 +1174,19 @@ async function pickFiles(title: string): Promise<{ ok: true; paths: string[] } |
 	};
 }
 
-function isLoopbackRequest(request: Request): boolean {
-	const hostname = new URL(request.url).hostname;
-	return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname === "::1";
+function isLoopbackRequest(c: Context): boolean {
+	const peer = getPeerAddress(c);
+	if (peer === null) return false;
+	const normalized = peer
+		.trim()
+		.toLowerCase()
+		.replace(/^\[|\]$/g, "");
+	return (
+		normalized === "localhost" ||
+		normalized === "127.0.0.1" ||
+		normalized === "::1" ||
+		normalized === "::ffff:127.0.0.1"
+	);
 }
 
 function filePickerCommands(title: string): Array<{ command: string; args: string[] }> {

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -167,15 +167,17 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		const agentId = resolveDaemonAgentId();
 		return c.json({
 			version: config.version,
-			sources: config.sources.map((source) => {
-				const stats = sourceStats(source, agentId);
-				return {
-					...source,
-					stats,
-					health: sourceHealth(source, agentId, stats),
-					indexJob: getSourceIndexJob(source.id),
-				};
-			}),
+			sources: config.sources
+				.filter((source) => isSourceVisibleToAgent(source, agentId))
+				.map((source) => {
+					const stats = sourceStats(source, agentId);
+					return {
+						...source,
+						stats,
+						health: sourceHealth(source, agentId, stats),
+						indexJob: getSourceIndexJob(source.id),
+					};
+				}),
 		});
 	});
 
@@ -297,7 +299,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 
 	app.get("/api/sources/:sourceId/snapshot", (c) => {
 		const sourceId = c.req.param("sourceId");
-		const source = findConfiguredSource(sourceId, agentsDir);
+		const source = findConfiguredSource(sourceId, agentsDir, resolveDaemonAgentId());
 		if (!source) return c.json({ error: "Source not found" }, 404);
 		const includeLocalDiscord = c.req.query("includeLocalDiscord") === "true";
 		return c.json(
@@ -311,7 +313,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 
 	app.get("/api/sources/:sourceId/health", (c) => {
 		const sourceId = c.req.param("sourceId");
-		const source = findConfiguredSource(sourceId, agentsDir);
+		const source = findConfiguredSource(sourceId, agentsDir, resolveDaemonAgentId());
 		if (!source) return c.json({ error: "Source not found" }, 404);
 		const agentId = resolveDaemonAgentId();
 		const stats = sourceStats(source, agentId);
@@ -321,7 +323,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 	app.post("/api/sources/:sourceId/snapshot/import", async (c) => {
 		const startedAt = Date.now();
 		const sourceId = c.req.param("sourceId");
-		const source = findConfiguredSource(sourceId, agentsDir);
+		const source = findConfiguredSource(sourceId, agentsDir, resolveDaemonAgentId());
 		if (!source) return c.json({ error: "Source not found" }, 404);
 		if (isSourceImportBlocked(source.id)) {
 			return c.json({ error: "Source snapshot import cannot run while source indexing is queued or running" }, 409);
@@ -435,7 +437,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 
 	app.delete("/api/sources/:sourceId", (c) => {
 		const sourceId = c.req.param("sourceId");
-		const source = findConfiguredSource(sourceId, agentsDir);
+		const source = findConfiguredSource(sourceId, agentsDir, resolveDaemonAgentId());
 		if (source === undefined) return c.json({ error: "Source not found" }, 404);
 		const sourceAgentId = resolveDaemonAgentId();
 		if (source.kind === "import" && source.providerSettings?.agentId !== sourceAgentId)
@@ -454,8 +456,14 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 	});
 }
 
-function findConfiguredSource(sourceId: string, agentsDir: string): SignetSourceEntry | undefined {
-	return loadSourcesConfig(agentsDir).sources.find((source) => source.id === sourceId);
+function findConfiguredSource(sourceId: string, agentsDir: string, agentId: string): SignetSourceEntry | undefined {
+	return loadSourcesConfig(agentsDir).sources.find(
+		(source) => source.id === sourceId && isSourceVisibleToAgent(source, agentId),
+	);
+}
+
+function isSourceVisibleToAgent(source: SignetSourceEntry, agentId: string): boolean {
+	return source.kind !== "import" || source.providerSettings?.agentId === agentId;
 }
 
 function isSourceImportBlocked(sourceId: string): boolean {

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -191,6 +191,20 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		return c.json({ path: result.path });
 	});
 
+	app.post("/api/sources/pick-files", async (c) => {
+		if (!isLoopbackRequest(c.req.raw)) return c.json({ error: "Native file picking is local-only" }, 400);
+		let body: PickDirectoryBody = {};
+		try {
+			body = (await c.req.json().catch(() => ({}))) as PickDirectoryBody;
+		} catch {
+			body = {};
+		}
+
+		const result = await pickFiles(body.title ?? "Choose files");
+		if (result.ok === false) return c.json({ error: result.error }, 501);
+		return c.json({ paths: result.paths });
+	});
+
 	app.post("/api/sources/obsidian", async (c) => {
 		let body: AddObsidianSourceBody = {};
 		try {
@@ -1130,6 +1144,73 @@ function countRow(row: unknown): number {
 	return typeof row === "object" && row !== null && "n" in row && typeof (row as { n?: unknown }).n === "number"
 		? (row as { n: number }).n
 		: 0;
+}
+
+async function pickFiles(title: string): Promise<{ ok: true; paths: string[] } | { ok: false; error: string }> {
+	const trimmedTitle = title.trim() || "Choose files";
+	const errors: string[] = [];
+
+	for (const candidate of filePickerCommands(trimmedTitle)) {
+		try {
+			const { stdout } = await execFileAsync(candidate.command, candidate.args, { timeout: 120_000 });
+			const paths = stdout
+				.split(/\r?\n|\|/)
+				.map((path) => path.trim())
+				.filter((path) => path.length > 0);
+			if (paths.length > 0) return { ok: true, paths };
+		} catch (err) {
+			errors.push(`${candidate.command}: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
+	return {
+		ok: false,
+		error: `No native file picker is available for this daemon environment. Tried: ${errors.join("; ")}`,
+	};
+}
+
+function isLoopbackRequest(request: Request): boolean {
+	const hostname = new URL(request.url).hostname;
+	return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname === "::1";
+}
+
+function filePickerCommands(title: string): Array<{ command: string; args: string[] }> {
+	if (process.env.SIGNET_FILE_PICKER) {
+		return [{ command: process.env.SIGNET_FILE_PICKER, args: [] }];
+	}
+
+	if (process.platform === "darwin") {
+		return [
+			{
+				command: "osascript",
+				args: [
+					"-e",
+					`set picked to choose file with prompt ${JSON.stringify(title)} with multiple selections allowed\nset output to ""\nrepeat with itemRef in picked\nset output to output & POSIX path of itemRef & linefeed\nend repeat\nreturn output`,
+				],
+			},
+		];
+	}
+
+	if (process.platform === "win32") {
+		return [
+			{
+				command: "powershell.exe",
+				args: [
+					"-NoProfile",
+					"-Command",
+					`Add-Type -AssemblyName System.Windows.Forms; $d = New-Object System.Windows.Forms.OpenFileDialog; $d.Multiselect = $true; $d.Title = ${JSON.stringify(title)}; if ($d.ShowDialog() -eq 'OK') { $d.FileNames -join [Environment]::NewLine }`,
+				],
+			},
+		];
+	}
+
+	return [
+		{ command: "zenity", args: ["--file-selection", "--multiple", "--separator=|", "--title", title] },
+		{
+			command: "kdialog",
+			args: ["--getopenfilename", homedir(), "*", "--multiple", "--separate-output", "--title", title],
+		},
+	];
 }
 
 async function pickDirectory(title: string): Promise<{ ok: true; path: string } | { ok: false; error: string }> {

--- a/platform/daemon/src/source-providers.ts
+++ b/platform/daemon/src/source-providers.ts
@@ -1,12 +1,12 @@
 import type { SignetSourceEntry, SignetSourceKind, SourceFailureState } from "@signet/core";
 import { discordSourceProvider } from "./discord-source-provider";
 import { githubSourceProvider } from "./github-source-provider";
+import { markImportedSourceUnsupported } from "./imported-source-lifecycle";
 import {
 	type NativeMemorySource,
 	obsidianNativeMemorySource,
 	purgeNativeMemorySourceArtifacts,
 } from "./native-memory-sources";
-import { purgeSourceOwnedRows } from "./source-purge";
 
 export interface SourceProviderProgressEvent {
 	readonly scanned: number;
@@ -51,7 +51,11 @@ export const obsidianSourceProvider: SourceProviderAdapter = {
 
 export const importedSourceProvider: SourceProviderAdapter = {
 	kind: "import",
-	purge: (source, agentId) => purgeSourceOwnedRows({ sourceId: source.id, agentId }),
+	purge: (source, agentId) =>
+		markImportedSourceUnsupported({
+			sourceId: source.id,
+			agentId: agentId ?? "default",
+		}).artifacts,
 };
 
 export function registerSourceProvider(provider: SourceProviderAdapter): void {

--- a/platform/daemon/src/source-providers.ts
+++ b/platform/daemon/src/source-providers.ts
@@ -6,6 +6,7 @@ import {
 	obsidianNativeMemorySource,
 	purgeNativeMemorySourceArtifacts,
 } from "./native-memory-sources";
+import { purgeSourceOwnedRows } from "./source-purge";
 
 export interface SourceProviderProgressEvent {
 	readonly scanned: number;
@@ -48,6 +49,11 @@ export const obsidianSourceProvider: SourceProviderAdapter = {
 		),
 };
 
+export const importedSourceProvider: SourceProviderAdapter = {
+	kind: "import",
+	purge: (source, agentId) => purgeSourceOwnedRows({ sourceId: source.id, agentId }),
+};
+
 export function registerSourceProvider(provider: SourceProviderAdapter): void {
 	additionalProviders.set(provider.kind, provider);
 }
@@ -56,9 +62,16 @@ export function getSourceProvider(kind: SignetSourceKind): SourceProviderAdapter
 	if (kind === obsidianSourceProvider.kind) return obsidianSourceProvider;
 	if (kind === discordSourceProvider.kind) return discordSourceProvider;
 	if (kind === githubSourceProvider.kind) return githubSourceProvider;
+	if (kind === importedSourceProvider.kind) return importedSourceProvider;
 	return additionalProviders.get(kind);
 }
 
 export function configuredSourceProviders(): readonly SourceProviderAdapter[] {
-	return [obsidianSourceProvider, discordSourceProvider, githubSourceProvider, ...additionalProviders.values()];
+	return [
+		obsidianSourceProvider,
+		discordSourceProvider,
+		githubSourceProvider,
+		importedSourceProvider,
+		...additionalProviders.values(),
+	];
 }

--- a/surfaces/dashboard/DASHBOARD_API_MAP.md
+++ b/surfaces/dashboard/DASHBOARD_API_MAP.md
@@ -101,6 +101,7 @@ native `EventSource` with headers, so auth is pumped manually).
 | `addObsidianSource` | POST | `/api/sources/obsidian` | Add Obsidian vault |
 | `addDiscordSource` | POST | `/api/sources/discord` | Add Discord source |
 | `addGitHubSource` | POST | `/api/sources/github` | Add GitHub source |
+| `importSources` | POST | `/api/sources/import` | Import and index durable files |
 | `removeSource` | DELETE | `/api/sources/{id}` | Disconnect source |
 | `getSourceSnapshot` | GET | `/api/sources/{id}/snapshot` | Source snapshot/export |
 | `importSourceSnapshot` | POST | `/api/sources/{id}/snapshot/import` | Re-import snapshot |

--- a/surfaces/dashboard/src/components/sources/import-sources-dialog.tsx
+++ b/surfaces/dashboard/src/components/sources/import-sources-dialog.tsx
@@ -1,0 +1,131 @@
+import { type ImportSourcesResponse, api } from "@/lib/api";
+import { Loader2, Upload, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+export function ImportSourcesDialog({
+	open,
+	onClose,
+	onImported,
+}: {
+	open: boolean;
+	onClose: () => void;
+	onImported: () => void;
+}) {
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [files, setFiles] = useState<File[]>([]);
+	const [duplicateMode, setDuplicateMode] = useState<"skip" | "replace" | "reimport">("skip");
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [result, setResult] = useState<ImportSourcesResponse | null>(null);
+
+	useEffect(() => {
+		if (!open) return;
+		setFiles([]);
+		setDuplicateMode("skip");
+		setBusy(false);
+		setError(null);
+		setResult(null);
+	}, [open]);
+
+	if (!open) return null;
+
+	const choose = (selected: FileList | null) => {
+		if (!selected) return;
+		setFiles(Array.from(selected));
+		setResult(null);
+		setError(null);
+	};
+
+	const submit = async () => {
+		if (files.length === 0 || busy) return;
+		setBusy(true);
+		setError(null);
+		const response = await api.importSources(files, duplicateMode);
+		setBusy(false);
+		if (!response.ok || !response.data) {
+			setError(response.error ?? "Import failed");
+			return;
+		}
+		setResult(response.data);
+		onImported();
+	};
+
+	return (
+		<div
+			className="cs-backdrop"
+			role="presentation"
+			onClick={(event) => {
+				if (event.target === event.currentTarget && !busy) onClose();
+			}}
+			onKeyDown={(event) => {
+				if (event.key === "Escape" && !busy) onClose();
+			}}
+		>
+			<dialog open className="cs-panel" aria-modal="true" aria-label="Import files">
+				<header className="cs-head">
+					<span className="cs-title">Import files</span>
+					<button type="button" className="cs-close" onClick={onClose} disabled={busy} aria-label="Close">
+						<X className="size-4" />
+					</button>
+				</header>
+				<div className="cs-body">
+					<button
+						type="button"
+						className="flex min-h-28 w-full flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-[oklch(1_0_0/0.14)] bg-[color-mix(in_oklch,var(--foreground)_3%,transparent)] text-muted-foreground hover:border-success hover:text-foreground"
+						onClick={() => inputRef.current?.click()}
+						disabled={busy}
+					>
+						<Upload className="size-5" />
+						<span className="text-xs font-medium">Choose one or more files</span>
+						<span className="font-mono text-[9px]">JSON · Markdown · CSV · HTML · documents</span>
+					</button>
+					<input
+						ref={inputRef}
+						type="file"
+						multiple
+						className="hidden"
+						accept=".txt,.md,.markdown,.json,.html,.htm,.csv,.doc,.docx,.docm,.odt,.rtf,.pdf,.ppt,.pptx,.ppsx,.odp,.epub,.xls,.xlsx,.xlsm,.ods"
+						onChange={(event) => choose(event.target.files)}
+					/>
+					{files.length > 0 && (
+						<div className="flex flex-col gap-1 rounded-md bg-[color-mix(in_oklch,var(--foreground)_3%,transparent)] p-2 font-mono text-[10px]">
+							{files.map((file) => (
+								<span key={`${file.name}:${file.size}`} className="truncate">
+									{file.name} · {(file.size / 1024).toFixed(0)} KB
+								</span>
+							))}
+						</div>
+					)}
+					<label className="cs-field">
+						<span className="cs-field__label">If a content hash already exists</span>
+						<select
+							className="cs-field__input"
+							value={duplicateMode}
+							onChange={(event) => setDuplicateMode(event.target.value as typeof duplicateMode)}
+							disabled={busy}
+						>
+							<option value="skip">Skip duplicate</option>
+							<option value="replace">Replace and re-index</option>
+							<option value="reimport">Import as a new source</option>
+						</select>
+					</label>
+					{result && (
+						<div className="cs-field__hint">
+							Imported {result.imported}; failed {result.failed}.
+						</div>
+					)}
+					{error && <div className="cs-error">{error}</div>}
+				</div>
+				<footer className="cs-foot">
+					<button type="button" className="cs-btn-ghost" onClick={onClose} disabled={busy}>
+						Close
+					</button>
+					<button type="button" className="cs-btn-primary" onClick={submit} disabled={busy || files.length === 0}>
+						{busy && <Loader2 className="size-3.5 animate-spin" />}
+						Import &amp; index
+					</button>
+				</footer>
+			</dialog>
+		</div>
+	);
+}

--- a/surfaces/dashboard/src/components/sources/import-sources-dialog.tsx
+++ b/surfaces/dashboard/src/components/sources/import-sources-dialog.tsx
@@ -1,5 +1,5 @@
 import { type ImportSourcesResponse, api } from "@/lib/api";
-import { Loader2, Upload, X } from "lucide-react";
+import { Loader2, RotateCcw, Upload, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 export function ImportSourcesDialog({
@@ -13,6 +13,7 @@ export function ImportSourcesDialog({
 }) {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [files, setFiles] = useState<File[]>([]);
+	const [desktopPaths, setDesktopPaths] = useState<string[]>([]);
 	const [duplicateMode, setDuplicateMode] = useState<"skip" | "replace" | "reimport">("skip");
 	const [busy, setBusy] = useState(false);
 	const [error, setError] = useState<string | null>(null);
@@ -21,6 +22,7 @@ export function ImportSourcesDialog({
 	useEffect(() => {
 		if (!open) return;
 		setFiles([]);
+		setDesktopPaths([]);
 		setDuplicateMode("skip");
 		setBusy(false);
 		setError(null);
@@ -32,15 +34,18 @@ export function ImportSourcesDialog({
 	const choose = (selected: FileList | null) => {
 		if (!selected) return;
 		setFiles(Array.from(selected));
+		setDesktopPaths([]);
 		setResult(null);
 		setError(null);
 	};
 
-	const submit = async () => {
-		if (files.length === 0 || busy) return;
+	const importFiles = async (targetFiles: readonly File[], targetPaths: readonly string[] = []) => {
+		if (targetFiles.length === 0 && targetPaths.length === 0) return;
+		if (busy) return;
 		setBusy(true);
 		setError(null);
-		const response = await api.importSources(files, duplicateMode);
+		setResult(null);
+		const response = await api.importSources(targetFiles, duplicateMode, targetPaths);
 		setBusy(false);
 		if (!response.ok || !response.data) {
 			setError(response.error ?? "Import failed");
@@ -48,6 +53,30 @@ export function ImportSourcesDialog({
 		}
 		setResult(response.data);
 		onImported();
+	};
+
+	const submit = () => void importFiles(files, desktopPaths);
+
+	const chooseDesktop = async () => {
+		if (busy) return;
+		setError(null);
+		const response = await api.pickFiles();
+		if (!response.ok || !response.paths) {
+			setError(response.error ?? "Native file picker unavailable");
+			return;
+		}
+		setFiles([]);
+		setDesktopPaths(response.paths);
+		setResult(null);
+	};
+
+	const retryFailed = () => {
+		if (!result) return;
+		const failedNames = new Set(result.files.filter((file) => file.status === "failed").map((file) => file.fileName));
+		void importFiles(
+			files.filter((file) => failedNames.has(file.name)),
+			desktopPaths.filter((path) => failedNames.has(path.split(/[\\/]/).pop() ?? path)),
+		);
 	};
 
 	return (
@@ -79,6 +108,9 @@ export function ImportSourcesDialog({
 						<span className="text-xs font-medium">Choose one or more files</span>
 						<span className="font-mono text-[9px]">JSON · Markdown · CSV · HTML · documents</span>
 					</button>
+					<button type="button" className="cs-btn-ghost self-center" onClick={chooseDesktop} disabled={busy}>
+						Choose from desktop
+					</button>
 					<input
 						ref={inputRef}
 						type="file"
@@ -87,11 +119,16 @@ export function ImportSourcesDialog({
 						accept=".txt,.md,.markdown,.json,.html,.htm,.csv,.doc,.docx,.docm,.odt,.rtf,.pdf,.ppt,.pptx,.ppsx,.odp,.epub,.xls,.xlsx,.xlsm,.ods"
 						onChange={(event) => choose(event.target.files)}
 					/>
-					{files.length > 0 && (
+					{(files.length > 0 || desktopPaths.length > 0) && (
 						<div className="flex flex-col gap-1 rounded-md bg-[color-mix(in_oklch,var(--foreground)_3%,transparent)] p-2 font-mono text-[10px]">
 							{files.map((file) => (
 								<span key={`${file.name}:${file.size}`} className="truncate">
 									{file.name} · {(file.size / 1024).toFixed(0)} KB
+								</span>
+							))}
+							{desktopPaths.map((path) => (
+								<span key={path} className="truncate">
+									{path.split(/[\\/]/).pop() ?? path} · desktop path
 								</span>
 							))}
 						</div>
@@ -109,9 +146,32 @@ export function ImportSourcesDialog({
 							<option value="reimport">Import as a new source</option>
 						</select>
 					</label>
+					{busy && (
+						<div className="cs-field__hint" aria-live="polite">
+							Importing {files.length} {files.length === 1 ? "file" : "files"}…
+						</div>
+					)}
 					{result && (
-						<div className="cs-field__hint">
-							Imported {result.imported}; failed {result.failed}.
+						<div className="flex flex-col gap-2" aria-live="polite">
+							<div className="cs-field__hint">
+								Imported {result.imported}; failed {result.failed}.
+							</div>
+							<div className="flex flex-col gap-1 rounded-md bg-[color-mix(in_oklch,var(--foreground)_3%,transparent)] p-2 text-[10px]">
+								{result.files.map((file) => (
+									<div key={`${file.fileName}:${file.status}`} className="flex items-start justify-between gap-2">
+										<span className="min-w-0 truncate font-mono">{file.fileName}</span>
+										<span className={file.status === "failed" ? "text-destructive" : "text-success"}>
+											{file.status === "failed" ? file.error : file.status === "duplicate" ? "duplicate" : "indexed"}
+										</span>
+									</div>
+								))}
+							</div>
+							{result.failed > 0 && (
+								<button type="button" className="cs-btn-ghost self-start" onClick={retryFailed} disabled={busy}>
+									<RotateCcw className="size-3" />
+									Retry failed
+								</button>
+							)}
 						</div>
 					)}
 					{error && <div className="cs-error">{error}</div>}
@@ -120,7 +180,12 @@ export function ImportSourcesDialog({
 					<button type="button" className="cs-btn-ghost" onClick={onClose} disabled={busy}>
 						Close
 					</button>
-					<button type="button" className="cs-btn-primary" onClick={submit} disabled={busy || files.length === 0}>
+					<button
+						type="button"
+						className="cs-btn-primary"
+						onClick={submit}
+						disabled={busy || (files.length === 0 && desktopPaths.length === 0)}
+					>
 						{busy && <Loader2 className="size-3.5 animate-spin" />}
 						Import &amp; index
 					</button>

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -710,10 +710,12 @@ export const api = {
 	importSources: async (
 		files: readonly File[],
 		duplicateMode: "skip" | "replace" | "reimport" = "skip",
+		paths: readonly string[] = [],
 	): Promise<{ ok: boolean; data?: ImportSourcesResponse; error?: string }> => {
 		try {
 			const form = new FormData();
 			for (const file of files) form.append("files", file, file.name);
+			for (const path of paths) form.append("paths", path);
 			form.set("duplicateMode", duplicateMode);
 			const res = await fetch(`${API_BASE}/api/sources/import`, {
 				method: "POST",
@@ -722,6 +724,21 @@ export const api = {
 			});
 			const data = (await res.json().catch(() => null)) as (ImportSourcesResponse & { error?: string }) | null;
 			return { ok: res.ok || res.status === 207, data: data ?? undefined, error: data?.error };
+		} catch {
+			return { ok: false, error: "daemon unreachable" };
+		}
+	},
+	/** POST /api/sources/pick-files — native multi-file picker for a local desktop daemon. */
+	pickFiles: async (): Promise<{ ok: boolean; paths?: string[]; unavailable?: boolean; error?: string }> => {
+		try {
+			const res = await fetch(`${API_BASE}/api/sources/pick-files`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json", ...authHeaders() },
+				body: JSON.stringify({ title: "Choose files to import" }),
+			});
+			const body = (await res.json().catch(() => null)) as { paths?: string[]; error?: string } | null;
+			if (res.status === 501) return { ok: false, unavailable: true, error: body?.error };
+			return res.ok && Array.isArray(body?.paths) ? { ok: true, paths: body.paths } : { ok: false, error: body?.error };
 		} catch {
 			return { ok: false, error: "daemon unreachable" };
 		}

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -409,6 +409,16 @@ export interface SourcesResponse {
 	sources: SignetSource[];
 }
 
+export interface ImportSourcesResponse {
+	imported: number;
+	failed: number;
+	files: ReadonlyArray<
+		| { fileName: string; status: "imported"; sourceId: string; format: string; duplicate: boolean }
+		| { fileName: string; status: "duplicate"; sourceId: string }
+		| { fileName: string; status: "failed"; error: string }
+	>;
+}
+
 /** Daily brief reflections — daemon `reflection-routes.ts` formatReflection. */
 export interface DailyReflection {
 	id: string;
@@ -697,6 +707,25 @@ export const api = {
 
 	// Sources
 	getSources: () => getJSON<SourcesResponse>("/api/sources"),
+	importSources: async (
+		files: readonly File[],
+		duplicateMode: "skip" | "replace" | "reimport" = "skip",
+	): Promise<{ ok: boolean; data?: ImportSourcesResponse; error?: string }> => {
+		try {
+			const form = new FormData();
+			for (const file of files) form.append("files", file, file.name);
+			form.set("duplicateMode", duplicateMode);
+			const res = await fetch(`${API_BASE}/api/sources/import`, {
+				method: "POST",
+				headers: authHeaders(),
+				body: form,
+			});
+			const data = (await res.json().catch(() => null)) as (ImportSourcesResponse & { error?: string }) | null;
+			return { ok: res.ok || res.status === 207, data: data ?? undefined, error: data?.error };
+		} catch {
+			return { ok: false, error: "daemon unreachable" };
+		}
+	},
 	/** Re-index = re-POST the source's own config; the daemon upserts (created:false) and re-queues an index job. */
 	reindexSource: async (source: SignetSource): Promise<{ ok: boolean; error?: string }> => {
 		const ps = source.providerSettings ?? {};

--- a/surfaces/dashboard/src/views/sources.tsx
+++ b/surfaces/dashboard/src/views/sources.tsx
@@ -1,12 +1,13 @@
-import { Check, Copy, Download, Folder, GitBranch, Globe, Plus, RotateCw, Trash2, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
-import { Surface } from "@/components/ui/surface";
 import { sourceLogo } from "@/components/icons";
 import { ConnectSourceDialog } from "@/components/sources/connect-source-dialog";
-import { api, type SignetSource, type SourceIndexJob } from "@/lib/api";
+import { ImportSourcesDialog } from "@/components/sources/import-sources-dialog";
+import { Surface } from "@/components/ui/surface";
+import { type SignetSource, type SourceIndexJob, api } from "@/lib/api";
 import { useAsync } from "@/lib/use-async";
-import { useView } from "@/lib/view-context";
 import { cn } from "@/lib/utils";
+import { useView } from "@/lib/view-context";
+import { Check, Copy, Download, Folder, GitBranch, Globe, Plus, RotateCw, Trash2, Upload, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
 const HEALTH_STYLES: Record<string, string> = {
 	healthy: "text-[oklch(0.72_0.15_150)]",
@@ -27,6 +28,7 @@ export function SourcesView() {
 	const { data, refresh } = useAsync(() => api.getSources(), { intervalMs: 30000 });
 	const sources = data?.sources;
 	const [connectOpen, setConnectOpen] = useState(false);
+	const [importOpen, setImportOpen] = useState(false);
 	const { connectSourceRequested, clearConnectSource } = useView();
 
 	// Cross-view handoff: the memory view's "Ingest source" button sets this
@@ -66,10 +68,21 @@ export function SourcesView() {
 			<div className="grid flex-1 grid-cols-1 content-start gap-3 overflow-y-auto py-3 md:grid-cols-2 [mask-image:linear-gradient(180deg,#000_0,#000_calc(100%-24px),transparent_100%)]">
 				<button
 					type="button"
-					onClick={() => setConnectOpen(true)}
+					onClick={() => setImportOpen(true)}
 					className="flex min-h-[180px] flex-col items-center justify-center gap-2.5 rounded-[var(--radius)] border-[1.5px] border-dashed border-[oklch(1_0_0/0.12)] bg-[color-mix(in_oklch,var(--card)_86%,transparent)] p-6 transition-all hover:border-[color-mix(in_oklch,var(--success)_45%,transparent)] hover:bg-[color-mix(in_oklch,var(--success)_5%,transparent)] [html:not(.dark)_&]:border-[oklch(0_0_0/0.12)]"
 				>
 					<span className="grid size-10 place-items-center rounded-full border border-[oklch(1_0_0/0.08)] bg-[color-mix(in_oklch,var(--foreground)_4%,transparent)] text-muted-foreground transition-all group-hover:text-[oklch(0.82_0.16_150)]">
+						<Upload className="size-[18px]" />
+					</span>
+					<span className="text-[12.5px] font-medium">Import files</span>
+					<span className="font-mono text-[9.5px] text-muted-foreground">JSON · CSV · Markdown · documents</span>
+				</button>
+				<button
+					type="button"
+					onClick={() => setConnectOpen(true)}
+					className="flex min-h-[180px] flex-col items-center justify-center gap-2.5 rounded-[var(--radius)] border-[1.5px] border-dashed border-[oklch(1_0_0/0.12)] bg-[color-mix(in_oklch,var(--card)_86%,transparent)] p-6 transition-all hover:border-[color-mix(in_oklch,var(--success)_45%,transparent)] hover:bg-[color-mix(in_oklch,var(--success)_5%,transparent)] [html:not(.dark)_&]:border-[oklch(0_0_0/0.12)]"
+				>
+					<span className="grid size-10 place-items-center rounded-full border border-[oklch(1_0_0/0.08)] bg-[color-mix(in_oklch,var(--foreground)_4%,transparent)] text-muted-foreground">
 						<Plus className="size-[18px]" />
 					</span>
 					<span className="text-[12.5px] font-medium">Connect a source</span>
@@ -80,6 +93,7 @@ export function SourcesView() {
 				))}
 			</div>
 			<ConnectSourceDialog open={connectOpen} onClose={() => setConnectOpen(false)} onConnected={refresh} />
+			<ImportSourcesDialog open={importOpen} onClose={() => setImportOpen(false)} onImported={refresh} />
 		</div>
 	);
 }
@@ -92,9 +106,12 @@ function SourceCard({ source, onMutate }: { source: SignetSource; onMutate: () =
 	const [busy, setBusy] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-	useEffect(() => () => {
-		if (copyTimer.current) clearTimeout(copyTimer.current);
-	}, []);
+	useEffect(
+		() => () => {
+			if (copyTimer.current) clearTimeout(copyTimer.current);
+		},
+		[],
+	);
 
 	const copyRoot = async () => {
 		try {
@@ -167,7 +184,12 @@ function SourceCard({ source, onMutate }: { source: SignetSource; onMutate: () =
 						<span>{source.mode}</span>
 					</div>
 				</div>
-				<span className={cn("flex shrink-0 items-center gap-1.25 font-mono text-[9.5px] font-medium", HEALTH_STYLES[health])}>
+				<span
+					className={cn(
+						"flex shrink-0 items-center gap-1.25 font-mono text-[9.5px] font-medium",
+						HEALTH_STYLES[health],
+					)}
+				>
 					<span className="size-1.5 rounded-full bg-current shadow-[0_0_6px_currentColor]" />
 					{health.charAt(0).toUpperCase() + health.slice(1)}
 					{failures > 0 && ` · ${failures} fail`}
@@ -198,7 +220,9 @@ function SourceCard({ source, onMutate }: { source: SignetSource; onMutate: () =
 
 			<div className="mt-0.5 flex items-center justify-between border-t border-[oklch(1_0_0/0.06)] pt-2 [html:not(.dark)_&]:border-[oklch(0_0_0/0.06)]">
 				{error ? (
-					<span className="truncate font-mono text-[9.5px] text-destructive" title={error}>{error}</span>
+					<span className="truncate font-mono text-[9.5px] text-destructive" title={error}>
+						{error}
+					</span>
 				) : (
 					<span className="font-mono text-[9.5px] text-muted-foreground">{relTime(source.lastIndexedAt)}</span>
 				)}
@@ -276,15 +300,20 @@ function PipeStrip({ job, health }: { job?: SourceIndexJob | null; health: strin
 				<div
 					className={cn(
 						"h-full rounded-sm transition-[width] duration-500",
-						fill === "error" || fill === "unhealthy" ? "bg-[oklch(0.7_0.18_25)]"
-						: fill === "queued" ? "bg-[oklch(0.75_0.15_85)]"
-						: fill === "degraded" ? "bg-[oklch(0.75_0.15_85)] shadow-[0_0_6px_oklch(0.75_0.15_85/0.4)]"
-						: "bg-success shadow-[0_0_6px_color-mix(in_oklch,var(--success)_50%,transparent)]",
+						fill === "error" || fill === "unhealthy"
+							? "bg-[oklch(0.7_0.18_25)]"
+							: fill === "queued"
+								? "bg-[oklch(0.75_0.15_85)]"
+								: fill === "degraded"
+									? "bg-[oklch(0.75_0.15_85)] shadow-[0_0_6px_oklch(0.75_0.15_85/0.4)]"
+									: "bg-success shadow-[0_0_6px_color-mix(in_oklch,var(--success)_50%,transparent)]",
 					)}
 					style={{ width: `${pct}%` }}
 				/>
 			</div>
-			<span className="max-w-[45%] shrink-0 truncate font-mono text-[9.5px] text-muted-foreground" title={text}>{text}</span>
+			<span className="max-w-[45%] shrink-0 truncate font-mono text-[9.5px] text-muted-foreground" title={text}>
+				{text}
+			</span>
 		</div>
 	);
 }

--- a/web/docs/src/content/docs/api/documents-sources.md
+++ b/web/docs/src/content/docs/api/documents-sources.md
@@ -180,16 +180,29 @@ Import one or more files as durable, read-only source artifacts. The request is
 `replace` or `reimport`.
 
 The dashboard importer accepts text, Markdown, JSON, HTML, CSV, and document
-formats supported by AnyDoc (`doc`, `docx`, `odt`, `rtf`, `pdf`, `ppt`, `pptx`,
-`odp`, `epub`, `xls`, `xlsx`, and `ods`). JSON remains a structured JSON
-projection; CSV remains one table artifact with row metadata; document formats
-are converted to a Markdown projection. Raw upload bytes are not retained by
-the importer.
+formats supported by AnyDoc (`doc`, `docx`, `docm`, `odt`, `rtf`, `pdf`, `ppt`,
+`pptx`, `ppsx`, `odp`, `epub`, `xls`, `xlsx`, `xlsm`, and `ods`). JSON is stored
+as both a structured canonical artifact and a searchable projection. CSV keeps
+one table artifact and adds bounded searchable row-range chunks with row-range
+provenance. Document formats are converted to a Markdown projection. Raw upload
+bytes are not retained by the importer.
+
+A local desktop daemon may also receive repeated `paths` fields instead of
+`files`; it reads those paths directly only for loopback requests. Remote
+clients must upload file bytes through `files`, so a desktop path is never
+interpreted by a remote daemon.
+
+Imported artifacts are available immediately through source-backed recall, with
+`source_id` and `source_path` pointing back to the imported source. Import
+completion queues a hygiene Dreaming attention for asynchronous semantic
+processing. Removing or replacing an imported source removes its searchable
+artifacts, preserves derived provenance rows, records an `unsupported`
+lifecycle marker, and queues another hygiene review rather than silently
+deleting derived ontology.
 
 The default safety bounds are 25 files per request, 25 MiB per file, and 100
 MiB per batch. Each file returns an individual result so a mixed batch can
-partially succeed. A successful import is indexed immediately for source-backed
-recall; semantic Dreaming remains asynchronous.
+partially succeed.
 
 **Response**
 
@@ -206,6 +219,20 @@ recall; semantic Dreaming remains asynchronous.
       "duplicate": false
     }
   ]
+}
+```
+
+### POST /api/sources/pick-files
+
+Open the native multi-file picker on a local desktop daemon. This endpoint is
+loopback-only and returns filesystem paths for a subsequent `paths`-based import.
+A remote client must upload bytes through `POST /api/sources/import` instead.
+
+**Response**
+
+```json
+{
+  "paths": ["/home/user/Downloads/export.json"]
 }
 ```
 

--- a/web/docs/src/content/docs/api/documents-sources.md
+++ b/web/docs/src/content/docs/api/documents-sources.md
@@ -131,7 +131,7 @@ the document are soft-deleted one at a time with audit history.
 
 Sources connect read-only external knowledge bases to Signet recall without
 turning them into ordinary saved memories. Supported source kinds are
-`obsidian`, `discord`, and `github`.
+`obsidian`, `discord`, `github`, and `import`.
 
 ### GET /api/sources
 
@@ -172,7 +172,45 @@ agent.
 }
 ```
 
+### POST /api/sources/import
+
+Import one or more files as durable, read-only source artifacts. The request is
+`multipart/form-data` with one or more `files` fields and an optional
+`duplicateMode` field. `duplicateMode` is `skip` by default and can also be
+`replace` or `reimport`.
+
+The dashboard importer accepts text, Markdown, JSON, HTML, CSV, and document
+formats supported by AnyDoc (`doc`, `docx`, `odt`, `rtf`, `pdf`, `ppt`, `pptx`,
+`odp`, `epub`, `xls`, `xlsx`, and `ods`). JSON remains a structured JSON
+projection; CSV remains one table artifact with row metadata; document formats
+are converted to a Markdown projection. Raw upload bytes are not retained by
+the importer.
+
+The default safety bounds are 25 files per request, 25 MiB per file, and 100
+MiB per batch. Each file returns an individual result so a mixed batch can
+partially succeed. A successful import is indexed immediately for source-backed
+recall; semantic Dreaming remains asynchronous.
+
+**Response**
+
+```json
+{
+  "imported": 1,
+  "failed": 0,
+  "files": [
+    {
+      "fileName": "export.json",
+      "status": "imported",
+      "sourceId": "import:abc123",
+      "format": "json",
+      "duplicate": false
+    }
+  ]
+}
+```
+
 ### POST /api/sources/obsidian
+
 
 Add or update an Obsidian vault source and queue a source index job. The vault
 stays read-only; Signet writes only derived source artifacts, graph rows, and

--- a/web/docs/src/content/docs/api/route-inventory.md
+++ b/web/docs/src/content/docs/api/route-inventory.md
@@ -53,6 +53,7 @@ silently disappear from the API reference.
 | POST | `/api/sources/pick-directory` | platform/daemon/src/routes/sources-routes.ts |
 | POST | `/api/sources/obsidian` | platform/daemon/src/routes/sources-routes.ts |
 | POST | `/api/sources/discord` | platform/daemon/src/routes/sources-routes.ts |
+| POST | `/api/sources/import` | platform/daemon/src/routes/import-routes.ts |
 | GET | `/api/sources/:sourceId/health` | platform/daemon/src/routes/sources-routes.ts |
 | GET | `/api/sources/:sourceId/snapshot` | platform/daemon/src/routes/sources-routes.ts |
 | POST | `/api/sources/:sourceId/snapshot/import` | platform/daemon/src/routes/sources-routes.ts |

--- a/web/docs/src/content/docs/sources.md
+++ b/web/docs/src/content/docs/sources.md
@@ -251,6 +251,26 @@ Removing a source is symmetrical with connecting it:
 
 From the dashboard and daemon API, removal performs the full purge. From the CLI, `signet sources remove <sourceId>` tries the daemon first. If the daemon is unavailable, the CLI falls back to local config-only removal and prints an explicit warning that already indexed database rows were not purged.
 
+## Durable file imports
+
+The dashboard Sources page can import files without creating a connector-specific
+integration. The importer creates one read-only `import` source per file and
+keeps the normalized representation source-backed and immediately searchable.
+It does not write to the original file and does not retain the raw upload bytes.
+
+Accepted inputs are text, Markdown, JSON, HTML, CSV, and AnyDoc-backed document
+formats. JSON is preserved as structured JSON, CSV remains one table artifact,
+and office/PDF/e-book formats are converted to Markdown for indexing. Imports
+are bounded to 25 files per batch, 25 MiB per file, and 100 MiB total. Each file
+reports its own result, so unsupported or malformed files do not hide successful
+imports in the same request.
+
+Duplicate content is selected in the import dialog: skip the existing source,
+replace and re-index it, or re-import it as a separate source. The normalized
+content hash, format, original file name, and converter metadata are retained as
+provenance. Semantic graph refinement remains asynchronous; source-backed recall
+is available as soon as indexing completes.
+
 ## API surface
 
 The daemon exposes the Sources lifecycle under `/api/sources`:
@@ -258,6 +278,7 @@ The daemon exposes the Sources lifecycle under `/api/sources`:
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/api/sources` | List configured sources. |
+| `POST` | `/api/sources/import` | Import bounded file batches as durable source artifacts. |
 | `POST` | `/api/sources/obsidian` | Add/update an Obsidian vault source and index it. |
 | `POST` | `/api/sources/discord` | Add/update a Discord source and queue a shared source index job. |
 | `POST` | `/api/sources/github` | Add/update a GitHub source and queue a shared source index job. |


### PR DESCRIPTION
## Summary

Implements the unified dashboard Sources-page import flow for #1367, including source-backed recall, bounded structured projections, non-destructive source removal, desktop path acquisition, and per-file import feedback.

## Changes

- Added `POST /api/sources/import` multipart endpoint with 25-file, 25 MiB/file, and 100 MiB/batch limits.
- Added loopback-only desktop path imports and `POST /api/sources/pick-files`; remote clients must upload file bytes.
- Added generic normalizers for text, Markdown, JSON, HTML, CSV, and AnyDoc-backed formats, including `.docm`, `.ppsx`, and `.xlsm`.
- JSON imports now retain separate canonical and searchable projection artifacts.
- CSV imports now retain bounded row-range search chunks with header, row ranges, and source-path provenance.
- Imported artifacts are reachable through the existing source-backed memory search fallback immediately, with durable imported source IDs and paths in results.
- Added SHA-256 content-hash duplicate handling: skip, replace/re-index, and deliberate re-import, with replacement ownership isolated per agent.
- Replacement/removal now marks imported sources unsupported, removes searchable source artifacts, preserves derived provenance, and queues a Dreaming hygiene review instead of deleting derived ontology.
- Import completion queues the normal Dreaming attention handoff.
- Added dashboard desktop selection, per-file indexed/duplicate/error details, progress state, and retry-failed behavior.
- Updated source/API documentation and route inventories.

## PR readiness

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally
- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

## Migration Notes (if applicable)

Migration 123 creates the agent-scoped `imported_source_lifecycle` table with an idempotent `CREATE TABLE IF NOT EXISTS` and unique `(source_id, agent_id)` constraint. Existing databases apply it on the next normal migration run without rewriting existing source or ontology rows. There is no destructive rollback in the runtime migration system; reverting the feature leaves the additive lifecycle table unused. A future rollback should preserve the table and data, or explicitly archive it in a follow-up migration after confirming no unsupported-source review state remains.

## Packages affected

- `@signet/core`
- `@signet/daemon`
- `signet-dashboard`
- `@signet/docs`

## Verification

- Focused import, recall, lifecycle, normalizer, and route suites: 96 pass, 0 fail
- Core migration/config suites: 85 pass, 0 fail
- `bun run --filter '@signet/core' build` (pass)
- `bun run --filter '@signet/daemon' typecheck` (pass)
- `bun run build` in `surfaces/dashboard` (pass)
- `bun run check && bun run build` in `web/docs` (pass)
- Focused Biome checks and `git diff --check` (pass)

## Screenshots

Not included: no browser session was available for a captured dashboard screenshot. The dashboard production build passed.

## AI disclosure

Assisted-by: Hermes-Agent:gpt-5.6-luna

Fixes #1367
