### PR TITLE
fix(daemon): bound OS Chat inference

### DIFF
--- a/docs/specs/approved/model-provider-router.md
+++ b/docs/specs/approved/model-provider-router.md
@@ -192,6 +192,9 @@ the spec stays useful as both contract and progress tracker.
 - Signet-owned OS surfaces now try the router first and fall back cleanly:
   - `os-chat`
   - `os-agent`
+- OS Chat interactive calls carry an explicit route deadline and abort signal
+  through routed and legacy provider paths; timed-out requests return a
+  terminal error and release provider admission permits.
 - CLI route tooling exists:
   - `signet route list`
   - `signet route status`

--- a/platform/daemon/src/routes/os-chat.test.ts
+++ b/platform/daemon/src/routes/os-chat.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { LlmProvider } from "@signet/core";
+import { Hono } from "hono";
+import { getOrCreateInferenceRouter, resetInferenceRouterForTests } from "../inference-router";
+import { closeInferenceProviderResolver, initInferenceProviderResolver } from "../llm";
+import { mountOsChatRoutes } from "./os-chat";
+
+const originalFetch = globalThis.fetch;
+const originalSignetPath = process.env.SIGNET_PATH;
+const TEST_TIMEOUT_MS = 250;
+const TOOLS = [
+	{
+		serverId: "test-server",
+		serverName: "Test server",
+		toolName: "fetch_test_data",
+		description: "Fetch test data",
+	},
+] as const;
+
+let tempDir: string | undefined;
+
+function app(timeoutMs: number): Hono {
+	const next = new Hono();
+	mountOsChatRoutes(next, { timeoutMs, tools: TOOLS });
+	return next;
+}
+
+function hangingProvider(
+	onAbort: () => void,
+	onOptions: (options: Parameters<LlmProvider["generate"]>[1]) => void,
+): LlmProvider {
+	return {
+		name: "test-interactive",
+		async available(): Promise<boolean> {
+			return true;
+		},
+		async generate(_prompt, options): Promise<string> {
+			onOptions(options);
+			const signal = options?.signal;
+			return new Promise<string>(() => {
+				if (signal?.aborted) {
+					onAbort();
+					return;
+				}
+				signal?.addEventListener(
+					"abort",
+					() => {
+						onAbort();
+					},
+					{ once: true },
+				);
+			});
+		},
+	};
+}
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	closeInferenceProviderResolver();
+	resetInferenceRouterForTests();
+	if (originalSignetPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
+	else process.env.SIGNET_PATH = originalSignetPath;
+	if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+	tempDir = undefined;
+});
+
+beforeEach(() => {
+	closeInferenceProviderResolver();
+	resetInferenceRouterForTests();
+});
+
+describe("OS Chat request deadlines", () => {
+	it("#1347 passes a bounded timeout and abort signal through the legacy provider fallback", async () => {
+		let aborted = false;
+		let seenTimeout: number | undefined;
+		let seenSignal: AbortSignal | undefined;
+		initInferenceProviderResolver(() =>
+			hangingProvider(
+				() => {
+					aborted = true;
+				},
+				(options) => {
+					seenTimeout = options?.timeoutMs;
+					seenSignal = options?.signal;
+				},
+			),
+		);
+
+		const response = await app(TEST_TIMEOUT_MS).request("/api/os/chat", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ message: "wait for the provider" }),
+		});
+		const body = (await response.json()) as { error?: string; code?: string; timeoutMs?: number };
+
+		expect(response.status).toBe(504);
+		expect(body).toMatchObject({ code: "TIMEOUT", timeoutMs: TEST_TIMEOUT_MS });
+		expect(body.error).toContain(`${TEST_TIMEOUT_MS}ms`);
+		expect(seenTimeout).toBe(TEST_TIMEOUT_MS);
+		expect(seenSignal).toBeDefined();
+		expect(aborted).toBe(true);
+		expect(seenSignal?.aborted).toBe(true);
+	});
+
+	it("#1347 aborts routed inference and returns a terminal error", async () => {
+		tempDir = mkdtempSync(join(tmpdir(), "signet-os-chat-deadline-"));
+		mkdirSync(join(tempDir, "memory"), { recursive: true });
+		writeFileSync(
+			join(tempDir, "agent.yaml"),
+			`inference:
+  defaultPolicy: interactive
+  targets:
+    local:
+      executor: openai-compatible
+      endpoint: http://127.0.0.1:9999/v1
+      models:
+        default:
+          model: test-model
+          toolUse: true
+  policies:
+    interactive:
+      mode: strict
+      defaultTargets:
+        - local/default
+  workloads:
+    interactive:
+      policy: interactive
+`,
+		);
+		process.env.SIGNET_PATH = tempDir;
+
+		let sawChatRequest = false;
+		let sawAbort = false;
+		globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			if (String(input).endsWith("/models")) return Response.json({ data: [] });
+			sawChatRequest = true;
+			return new Promise<Response>(() => {
+				const signal = init?.signal;
+				const abort = (): void => {
+					sawAbort = true;
+				};
+				if (signal?.aborted) abort();
+				else signal?.addEventListener("abort", abort, { once: true });
+			});
+		}) as typeof fetch;
+
+		getOrCreateInferenceRouter(tempDir);
+		const response = await app(TEST_TIMEOUT_MS).request("/api/os/chat", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ message: "wait for the routed provider" }),
+		});
+		const body = (await response.json()) as { error?: string; code?: string; timeoutMs?: number };
+
+		expect(response.status).toBe(504);
+		expect(body).toMatchObject({ code: "TIMEOUT", timeoutMs: TEST_TIMEOUT_MS });
+		expect(sawChatRequest).toBe(true);
+		expect(sawAbort).toBe(true);
+	});
+});

--- a/platform/daemon/src/routes/os-chat.ts
+++ b/platform/daemon/src/routes/os-chat.ts
@@ -13,6 +13,79 @@ import { getInteractiveLlmProviderOrNull } from "../llm.js";
 import { logger } from "../logger.js";
 import { loadProbeResult } from "../mcp-probe.js";
 
+const DEFAULT_OS_CHAT_TIMEOUT_MS = 30_000;
+const MAX_OS_CHAT_TIMEOUT_MS = 10 * 60_000;
+
+export interface OsChatRouteOptions {
+	/** Optional bounded override for embedders; production uses the default. */
+	readonly timeoutMs?: number;
+	/** Optional tool fixture for isolated route consumers and tests. */
+	readonly tools?: readonly ToolSpec[];
+}
+
+class OsChatTimeoutError extends Error {
+	readonly timeoutMs: number;
+
+	constructor(timeoutMs: number) {
+		super(`OS Chat inference timed out after ${timeoutMs}ms`);
+		this.name = "OsChatTimeoutError";
+		this.timeoutMs = timeoutMs;
+	}
+}
+
+interface LlmCallOptions {
+	readonly timeoutMs: number;
+	readonly signal: AbortSignal;
+}
+
+function resolveTimeoutMs(value: number | undefined): number {
+	if (value === undefined || !Number.isFinite(value) || value <= 0) return DEFAULT_OS_CHAT_TIMEOUT_MS;
+	return Math.max(1, Math.min(Math.floor(value), MAX_OS_CHAT_TIMEOUT_MS));
+}
+
+function abortReason(signal: AbortSignal, timeoutMs: number): Error {
+	return signal.reason instanceof Error ? signal.reason : new OsChatTimeoutError(timeoutMs);
+}
+
+/**
+ * Bound the whole interactive request, not only the provider's implementation.
+ * The abort signal lets current providers release their admission permit while
+ * the race keeps a non-cooperative legacy provider from holding the HTTP route.
+ */
+async function withOsChatDeadline<T>(
+	timeoutMs: number,
+	requestSignal: AbortSignal,
+	work: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+	const controller = new AbortController();
+	const onRequestAbort = (): void => controller.abort(requestSignal.reason);
+	if (requestSignal.aborted) onRequestAbort();
+	else requestSignal.addEventListener("abort", onRequestAbort, { once: true });
+
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let deadlineExpired = false;
+	const deadlineError = new OsChatTimeoutError(timeoutMs);
+	const deadline = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => {
+			deadlineExpired = true;
+			controller.abort(deadlineError);
+			reject(deadlineError);
+		}, timeoutMs);
+	});
+
+	try {
+		const result = await Promise.race([work(controller.signal), deadline]);
+		if (deadlineExpired) throw deadlineError;
+		return result;
+	} catch (error) {
+		if (deadlineExpired) throw deadlineError;
+		throw error;
+	} finally {
+		if (timer !== null) clearTimeout(timer);
+		requestSignal.removeEventListener("abort", onRequestAbort);
+	}
+}
+
 function buildPrompt(systemPrompt: string, userMessage: string): string {
 	return `${systemPrompt}\n\nUser message:\n${userMessage}`;
 }
@@ -20,40 +93,56 @@ function buildPrompt(systemPrompt: string, userMessage: string): string {
 async function callLlm(
 	systemPrompt: string,
 	userMessage: string,
-	maxTokens = 2048,
+	maxTokens: number,
+	options: LlmCallOptions,
 	route?: {
 		readonly agentId?: string;
 		readonly taskClass?: string;
 		readonly privacy?: RoutingPrivacyTier;
 	},
 ): Promise<string> {
+	const prompt = buildPrompt(systemPrompt, userMessage);
 	const router = getInferenceRouterOrNull();
-	if (router && (await router.hasWorkload("interactive"))) {
-		const routed = await router.execute(
-			{
-				agentId: route?.agentId,
-				operation: "tool_planning",
-				taskClass: route?.taskClass,
-				privacy: route?.privacy,
-				promptPreview: userMessage,
-				requireTools: true,
-			},
-			buildPrompt(systemPrompt, userMessage),
-			{ maxTokens },
-		);
-		if (routed.ok) {
-			return routed.value.text;
+	if (router) {
+		const hasInteractiveWorkload = await router.hasWorkload("interactive");
+		if (options.signal.aborted) throw abortReason(options.signal, options.timeoutMs);
+		if (hasInteractiveWorkload) {
+			const routed = await router.execute(
+				{
+					agentId: route?.agentId,
+					operation: "tool_planning",
+					taskClass: route?.taskClass,
+					privacy: route?.privacy,
+					promptPreview: userMessage,
+					requireTools: true,
+				},
+				prompt,
+				{
+					maxTokens,
+					timeoutMs: options.timeoutMs,
+					signal: options.signal,
+				},
+			);
+			if (routed.ok) {
+				return routed.value.text;
+			}
+			if (options.signal.aborted) throw abortReason(options.signal, options.timeoutMs);
+			logger.warn("os-chat", "Inference router failed, falling back to legacy interactive provider", {
+				error: routed.error.message,
+			});
 		}
-		logger.warn("os-chat", "Inference router failed, falling back to legacy interactive provider", {
-			error: routed.error.message,
-		});
 	}
 
+	if (options.signal.aborted) throw abortReason(options.signal, options.timeoutMs);
 	const provider = getInteractiveLlmProviderOrNull();
 	if (!provider) {
 		throw new Error("Interactive inference provider is not configured");
 	}
-	return provider.generate(buildPrompt(systemPrompt, userMessage), { maxTokens });
+	return provider.generate(prompt, {
+		maxTokens,
+		timeoutMs: options.timeoutMs,
+		signal: options.signal,
+	});
 }
 
 interface ChatRequest {
@@ -212,7 +301,9 @@ function parseLlmResponse(raw: string): {
 /**
  * Mount OS chat routes on the Hono app.
  */
-export function mountOsChatRoutes(app: Hono): void {
+export function mountOsChatRoutes(app: Hono, options: OsChatRouteOptions = {}): void {
+	const timeoutMs = resolveTimeoutMs(options.timeoutMs);
+
 	app.post("/api/os/chat", async (c) => {
 		let body: ChatRequest;
 		try {
@@ -226,141 +317,166 @@ export function mountOsChatRoutes(app: Hono): void {
 		}
 
 		try {
-			// Gather available tools from all MCP servers
-			const tools = gatherAvailableTools();
+			return await withOsChatDeadline(timeoutMs, c.req.raw.signal, async (signal) => {
+				// Gather available tools from all MCP servers
+				const tools = options.tools ? [...options.tools] : gatherAvailableTools();
 
-			if (tools.length === 0) {
-				return c.json({
-					response: "No MCP servers are installed yet. Add some from the dock to get started.",
-					toolCalls: [],
-				});
-			}
-
-			// Build prompt and call the shared interactive LLM provider
-			const systemPrompt = buildSystemPrompt(tools);
-
-			logger.info("os-chat", "Processing chat message", {
-				message: body.message.slice(0, 100),
-				availableTools: tools.length,
-			});
-
-			const rawResponse = await callLlm(systemPrompt, body.message, 2048, {
-				agentId: body.agentId,
-				taskClass: body.taskClass,
-				privacy: body.privacy,
-			});
-
-			const parsed = parseLlmResponse(rawResponse);
-
-			// If LLM decided this needs the visual agent, return immediately
-			// (no tool execution — the dashboard will handle it via agent executor)
-			if (parsed.useAgent && parsed.agentServerId) {
-				logger.info("os-chat", "Routing to visual agent", {
-					serverId: parsed.agentServerId,
-					task: body.message.slice(0, 100),
-				});
-				return c.json({
-					response: parsed.response,
-					toolCalls: [],
-					useAgent: true,
-					agentServerId: parsed.agentServerId,
-					agentTask: body.message,
-				});
-			}
-
-			// Execute tool calls if any
-			const toolCallResults: ToolCallResult[] = [];
-
-			if (parsed.toolCalls.length > 0) {
-				for (const call of parsed.toolCalls.slice(0, 5)) {
-					// Max 5 tool calls
-					try {
-						logger.info("os-chat", `Calling tool ${call.serverId}/${call.toolName}`, {
-							args: JSON.stringify(call.args || {}).slice(0, 500),
-						});
-
-						// Call the tool via the marketplace /mcp/call endpoint internally
-						const callRes = await fetch(
-							`http://127.0.0.1:${process.env.SIGNET_PORT || 3850}/api/marketplace/mcp/call`,
-							{
-								method: "POST",
-								headers: { "Content-Type": "application/json" },
-								body: JSON.stringify({
-									serverId: call.serverId,
-									toolName: call.toolName,
-									args: call.args || {},
-								}),
-							},
-						);
-
-						const callData = (await callRes.json()) as { success?: boolean; result?: unknown; error?: string };
-
-						if (callData.success) {
-							toolCallResults.push({
-								tool: call.toolName,
-								server: call.serverId,
-								result: callData.result,
-							});
-						} else {
-							toolCallResults.push({
-								tool: call.toolName,
-								server: call.serverId,
-								error: callData.error || "Tool call failed",
-							});
-						}
-					} catch (err) {
-						const msg = err instanceof Error ? err.message : String(err);
-						toolCallResults.push({
-							tool: call.toolName,
-							server: call.serverId,
-							error: msg,
-						});
-					}
+				if (tools.length === 0) {
+					return c.json({
+						response: "No MCP servers are installed yet. Add some from the dock to get started.",
+						toolCalls: [],
+					});
 				}
 
-				// If we got results, send them back to the LLM for a natural response
-				if (toolCallResults.some((r) => r.result)) {
-					const resultsText = toolCallResults
-						.map((r) => {
-							if (r.error) return `${r.tool}: ERROR — ${r.error}`;
-							const resultStr =
-								typeof r.result === "string" ? r.result.slice(0, 2000) : JSON.stringify(r.result).slice(0, 2000);
-							return `${r.tool}: ${resultStr}`;
-						})
-						.join("\n\n");
+				// Build prompt and call the shared interactive LLM provider
+				const systemPrompt = buildSystemPrompt(tools);
 
-					const followUp = `The user asked: "${body.message}"
+				logger.info("os-chat", "Processing chat message", {
+					message: body.message.slice(0, 100),
+					availableTools: tools.length,
+				});
+
+				const llmOptions = { timeoutMs, signal };
+				const rawResponse = await callLlm(systemPrompt, body.message, 2048, llmOptions, {
+					agentId: body.agentId,
+					taskClass: body.taskClass,
+					privacy: body.privacy,
+				});
+				if (signal.aborted) throw abortReason(signal, timeoutMs);
+
+				const parsed = parseLlmResponse(rawResponse);
+
+				// If LLM decided this needs the visual agent, return immediately
+				// (no tool execution — the dashboard will handle it via agent executor)
+				if (parsed.useAgent && parsed.agentServerId) {
+					logger.info("os-chat", "Routing to visual agent", {
+						serverId: parsed.agentServerId,
+						task: body.message.slice(0, 100),
+					});
+					return c.json({
+						response: parsed.response,
+						toolCalls: [],
+						useAgent: true,
+						agentServerId: parsed.agentServerId,
+						agentTask: body.message,
+					});
+				}
+
+				// Execute tool calls if any
+				const toolCallResults: ToolCallResult[] = [];
+
+				if (parsed.toolCalls.length > 0) {
+					for (const call of parsed.toolCalls.slice(0, 5)) {
+						if (signal.aborted) throw abortReason(signal, timeoutMs);
+						// Max 5 tool calls
+						try {
+							logger.info("os-chat", `Calling tool ${call.serverId}/${call.toolName}`, {
+								args: JSON.stringify(call.args || {}).slice(0, 500),
+							});
+
+							// Call the tool via the marketplace /mcp/call endpoint internally
+							const callRes = await fetch(
+								`http://127.0.0.1:${process.env.SIGNET_PORT || 3850}/api/marketplace/mcp/call`,
+								{
+									method: "POST",
+									headers: { "Content-Type": "application/json" },
+									body: JSON.stringify({
+										serverId: call.serverId,
+										toolName: call.toolName,
+										args: call.args || {},
+									}),
+									signal,
+								},
+							);
+
+							const callData = (await callRes.json()) as { success?: boolean; result?: unknown; error?: string };
+							if (signal.aborted) throw abortReason(signal, timeoutMs);
+
+							if (callData.success) {
+								toolCallResults.push({
+									tool: call.toolName,
+									server: call.serverId,
+									result: callData.result,
+								});
+							} else {
+								toolCallResults.push({
+									tool: call.toolName,
+									server: call.serverId,
+									error: callData.error || "Tool call failed",
+								});
+							}
+						} catch (err) {
+							if (signal.aborted) throw abortReason(signal, timeoutMs);
+							const msg = err instanceof Error ? err.message : String(err);
+							toolCallResults.push({
+								tool: call.toolName,
+								server: call.serverId,
+								error: msg,
+							});
+						}
+					}
+
+					// If we got results, send them back to the LLM for a natural response
+					if (toolCallResults.some((r) => r.result)) {
+						if (signal.aborted) throw abortReason(signal, timeoutMs);
+						const resultsText = toolCallResults
+							.map((r) => {
+								if (r.error) return `${r.tool}: ERROR — ${r.error}`;
+								const resultStr =
+									typeof r.result === "string" ? r.result.slice(0, 2000) : JSON.stringify(r.result).slice(0, 2000);
+								return `${r.tool}: ${resultStr}`;
+							})
+							.join("\n\n");
+
+						const followUp = `The user asked: "${body.message}"
 
 You called these tools and got these results:
 ${resultsText}
 
 Now give a concise, natural language summary of the results for the user. Be specific — mention names, numbers, and key details. No JSON, just a friendly response.`;
 
-					try {
-						const summary = await callLlm(
-							"You are Oogie, Jake's AI assistant. Summarize tool results in a casual, direct way. Mention specific names, numbers, and details. No JSON, no corporate speak. Sound like a real person chatting. Use keyboard emojis occasionally like ᕕ( ᐛ )ᕗ or (╯°□°)╯ but don't overdo it.",
-							followUp,
-							1024,
-						);
-						return c.json({
-							response: summary.trim(),
-							toolCalls: toolCallResults,
-						});
-					} catch {
-						// If summary fails, return raw response + results
-						return c.json({
-							response: parsed.response,
-							toolCalls: toolCallResults,
-						});
+						try {
+							const summary = await callLlm(
+								"You are Oogie, Jake's AI assistant. Summarize tool results in a casual, direct way. Mention specific names, numbers, and details. No JSON, no corporate speak. Sound like a real person chatting. Use keyboard emojis occasionally like ᕕ( ᐛ )ᕗ or (╯°□°)╯ but don't overdo it.",
+								followUp,
+								1024,
+								llmOptions,
+								undefined,
+							);
+							if (signal.aborted) throw abortReason(signal, timeoutMs);
+							return c.json({
+								response: summary.trim(),
+								toolCalls: toolCallResults,
+							});
+						} catch {
+							if (signal.aborted) throw abortReason(signal, timeoutMs);
+							// If summary fails, return raw response + results
+							return c.json({
+								response: parsed.response,
+								toolCalls: toolCallResults,
+							});
+						}
 					}
 				}
-			}
 
-			return c.json({
-				response: parsed.response,
-				toolCalls: toolCallResults,
+				return c.json({
+					response: parsed.response,
+					toolCalls: toolCallResults,
+				});
 			});
 		} catch (error) {
+			if (error instanceof OsChatTimeoutError) {
+				logger.warn("os-chat", "Chat request exceeded its deadline", { timeoutMs: error.timeoutMs });
+				return c.json(
+					{
+						error: error.message,
+						code: "TIMEOUT",
+						timeoutMs: error.timeoutMs,
+						toolCalls: [],
+					},
+					504,
+				);
+			}
 			const msg = error instanceof Error ? error.message : String(error);
 			logger.warn("os-chat", `Chat error: ${msg}`);
 			return c.json({

--- a/web/docs/src/content/docs/api/inference.md
+++ b/web/docs/src/content/docs/api/inference.md
@@ -15,6 +15,29 @@ for first-party harnesses and CLI tooling. The OpenAI-compatible gateway is for
 harnesses that can point at a model endpoint but cannot yet send the richer
 Signet routing metadata.
 
+### POST /api/os/chat
+
+Runs the dashboard's interactive OS Chat flow through the `interactive`
+workload, with a legacy provider fallback when routed inference is unavailable.
+The request body accepts `message` and optional `agentId`, `taskClass`, and
+`privacy` routing hints.
+
+OS Chat has a 30-second end-to-end deadline. The deadline and its abort signal
+cover routed inference, the legacy provider fallback, and internal MCP tool
+calls, so a stalled provider cannot keep the HTTP request or its inference
+admission permit open indefinitely.
+
+On deadline expiry, the route aborts the active work and returns HTTP `504`:
+
+```json
+{
+  "error": "OS Chat inference timed out after 30000ms",
+  "code": "TIMEOUT",
+  "timeoutMs": 30000,
+  "toolCalls": []
+}
+```
+
 ### GET /api/inference/status
 
 Requires `diagnostics` permission in authenticated modes.


### PR DESCRIPTION
## Summary

Fixes #1347. Bound the dashboard OS Chat request independently of provider configuration so stalled routed or legacy interactive inference terminates cleanly.

## Changes

- Added a bounded 30-second end-to-end OS Chat deadline with a propagated `AbortSignal`.
- Forwarded timeout and cancellation through routed inference, legacy provider fallback, and internal MCP tool calls.
- Return a terminal HTTP 504 `TIMEOUT` response on expiry and prevent fallback/tool work from continuing after cancellation.
- Added regression coverage for non-cooperative legacy and routed providers.
- Updated the inference API documentation and approved model-provider-router implementation ledger.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/daemon`
- [ ] `@signet/core`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: API documentation and approved inference spec ledger

## Screenshots

Not applicable; no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] N/A

## Testing

- [x] `bun test` passes — focused OS Chat regression: 2 pass, 0 fail; the same tests pass in the daemon suite.
- [x] `bun run typecheck` passes — core and daemon production typechecks pass.
- [ ] `bun run lint` passes — changed-file Biome checks pass; the full repository baseline reports unrelated manifest-format diagnostics.
- [ ] Tested against running daemon — live provider credentials were not required for the Hono route integration coverage.
- [x] N/A

Additional checks:

- `bun run build:core` passes.
- `bun run --filter '@signet/daemon' build` passes.
- `bun run --cwd web/docs check` and `bun run --cwd web/docs build` pass.
- `git diff --check` passes.
- The full monorepo test/typecheck commands were attempted; they retain pre-existing workspace build/module-resolution, SQLite extension, and macOS process-path failures outside this change. No changed-file or OS Chat test failed.
- Related inference/provider tests pass except existing macOS `/var` vs `/private` path and process-group cleanup assumptions.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The production route uses a fixed 30-second deadline. The bounded route option exists for isolated embedders/tests and is clamped to a safe range; it does not add user configuration.
