### PR TITLE
fix(recall): parse abbreviated date ranges

### DIFF
--- a/platform/daemon/src/temporal-recall.test.ts
+++ b/platform/daemon/src/temporal-recall.test.ts
@@ -3,7 +3,46 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
-import { resolveTemporalRecall } from "./temporal-recall";
+import { parseTemporalRecallIntent, resolveTemporalRecall } from "./temporal-recall";
+
+describe("temporal recall parser", () => {
+	it("parses abbreviated numeric ranges without leaving the end day in the content query", () => {
+		const parsed = parseTemporalRecallIntent({ query: "what happened on 2026-07-25/26?" });
+		expect(parsed).toMatchObject({
+			source: "query",
+			contentQuery: "happened",
+			mode: "filter",
+			start: new Date(2026, 6, 25).toISOString(),
+			end: new Date(2026, 6, 27).toISOString(),
+		});
+	});
+
+	it("consumes expanded and named date ranges as complete temporal expressions", () => {
+		const expanded = parseTemporalRecallIntent({ query: "2026-07-25/2026-07-26" });
+		const named = parseTemporalRecallIntent({ query: "what happened on July 25/26 2026?" });
+
+		expect(expanded).toMatchObject({
+			contentQuery: "",
+			mode: "timeline",
+			start: new Date(2026, 6, 25).toISOString(),
+			end: new Date(2026, 6, 27).toISOString(),
+		});
+		expect(named).toMatchObject({
+			contentQuery: "happened",
+			mode: "filter",
+			start: new Date(2026, 6, 25).toISOString(),
+			end: new Date(2026, 6, 27).toISOString(),
+		});
+	});
+
+	it("does not treat a reversed abbreviated range as a valid temporal query", () => {
+		expect(parseTemporalRecallIntent({ query: "what happened on 2026-07-25/01?" })).toBeNull();
+	});
+
+	it("does not partially parse an unsupported numeric range suffix", () => {
+		expect(parseTemporalRecallIntent({ query: "report 2026-07-25/26th" })).toBeNull();
+	});
+});
 
 describe("temporal recall", () => {
 	let dir = "";
@@ -11,7 +50,7 @@ describe("temporal recall", () => {
 	beforeEach(() => {
 		dir = mkdtempSync(join(tmpdir(), "signet-temporal-recall-"));
 		mkdirSync(join(dir, "memory"), { recursive: true });
-		initDbAccessor(join(dir, "memory", "memories.db"));
+		initDbAccessor(join(dir, "memory", "memories.db"), { agentsDir: dir });
 	});
 
 	afterEach(() => {
@@ -34,9 +73,33 @@ describe("temporal recall", () => {
 				 (id, agent_id, subject_type, subject_id, facet, start_at, end_at, confidence, created_at, updated_at)
 				 VALUES (?, ?, 'source_document', ?, 'occurred', ?, ?, 1.0, ?, ?)`,
 			);
-			edge.run("owner-edge", "owner", "owner-doc", "2026-05-13T12:00:00.000Z", "2026-05-13T12:00:00.000Z", createdAt, createdAt);
-			edge.run("teammate-edge", "teammate", "teammate-doc", "2026-05-13T13:00:00.000Z", "2026-05-13T13:00:00.000Z", createdAt, createdAt);
-			edge.run("outsider-edge", "outsider", "outsider-doc", "2026-05-13T14:00:00.000Z", "2026-05-13T14:00:00.000Z", createdAt, createdAt);
+			edge.run(
+				"owner-edge",
+				"owner",
+				"owner-doc",
+				"2026-05-13T12:00:00.000Z",
+				"2026-05-13T12:00:00.000Z",
+				createdAt,
+				createdAt,
+			);
+			edge.run(
+				"teammate-edge",
+				"teammate",
+				"teammate-doc",
+				"2026-05-13T13:00:00.000Z",
+				"2026-05-13T13:00:00.000Z",
+				createdAt,
+				createdAt,
+			);
+			edge.run(
+				"outsider-edge",
+				"outsider",
+				"outsider-doc",
+				"2026-05-13T14:00:00.000Z",
+				"2026-05-13T14:00:00.000Z",
+				createdAt,
+				createdAt,
+			);
 		});
 
 		const time = {

--- a/platform/daemon/src/temporal-recall.ts
+++ b/platform/daemon/src/temporal-recall.ts
@@ -167,9 +167,50 @@ function localDayRange(year: number, month: number, day: number): { start: strin
 	return { start: start.toISOString(), end: end.toISOString() };
 }
 
+function localDateRange(
+	startYear: number,
+	startMonth: number,
+	startDay: number,
+	endYear: number,
+	endMonth: number,
+	endDay: number,
+): { start: string; end: string } | null {
+	const start = localDayRange(startYear, startMonth, startDay);
+	const end = localDayRange(endYear, endMonth, endDay);
+	if (!start || !end || new Date(end.start).getTime() <= new Date(start.start).getTime()) return null;
+	return { start: start.start, end: end.end };
+}
+
 function parseExplicitDay(raw: string): { range: { start: string; end: string }; matched: string } | null {
+	const numericRange = raw.match(/\b(\d{4})[/-](\d{1,2})[/-](\d{1,2})\s*\/\s*(?:(\d{4})[/-](\d{1,2})[/-])?(\d{1,2})\b/);
+	if (numericRange) {
+		const year = Number.parseInt(numericRange[1] ?? "", 10);
+		const month = Number.parseInt(numericRange[2] ?? "", 10);
+		const day = Number.parseInt(numericRange[3] ?? "", 10);
+		const endYear = Number.parseInt(numericRange[4] ?? String(year), 10);
+		const endMonth = Number.parseInt(numericRange[5] ?? String(month), 10);
+		const endDay = Number.parseInt(numericRange[6] ?? "", 10);
+		const range = localDateRange(year, month, day, endYear, endMonth, endDay);
+		return range ? { range, matched: numericRange[0] } : null;
+	}
+
+	const namedRange = raw.match(
+		/\b(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t|tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+(\d{1,2})(?:st|nd|rd|th)?\s*\/\s*(?:(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t|tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+)?(\d{1,2})(?:st|nd|rd|th)?[,]?\s+(\d{4})\b/i,
+	);
+	if (namedRange) {
+		const month = MONTHS.get((namedRange[1] ?? "").toLowerCase());
+		const endMonth = MONTHS.get((namedRange[3] ?? namedRange[1] ?? "").toLowerCase());
+		const day = Number.parseInt(namedRange[2] ?? "", 10);
+		const endDay = Number.parseInt(namedRange[4] ?? "", 10);
+		const year = Number.parseInt(namedRange[5] ?? "", 10);
+		const range = month && endMonth ? localDateRange(year, month, day, year, endMonth, endDay) : null;
+		return range ? { range, matched: namedRange[0] } : null;
+	}
+
 	const numeric = raw.match(/\b(\d{4})[/-](\d{1,2})[/-](\d{1,2})\b/);
 	if (numeric) {
+		const end = (numeric.index ?? 0) + numeric[0].length;
+		if (/^\s*\//.test(raw.slice(end))) return null;
 		const year = Number.parseInt(numeric[1] ?? "", 10);
 		const month = Number.parseInt(numeric[2] ?? "", 10);
 		const day = Number.parseInt(numeric[3] ?? "", 10);

--- a/web/docs/src/content/docs/api/memory/recall-search.md
+++ b/web/docs/src/content/docs/api/memory/recall-search.md
@@ -50,11 +50,13 @@ camel-case wire fields shown above. False opt-in flags are omitted, except an
 explicit `saveAggregate: false`, which is significant for recall-only callers.
 
 Exact date phrases in `query`, such as `2026/05/13`, `2026-05-13`, or
-`May 13 2026`, activate temporal recall automatically. A date-only query
-returns a timeline assembled from existing session, source, captured-memory,
+`May 13 2026`, activate temporal recall automatically. Date-only queries return
+a timeline assembled from existing session, source, captured-memory,
 and explicit temporal-edge metadata. A date plus topic uses the date as a
-filter and the remaining words as the content query. Callers can also pass a
-`time` object directly. Supported temporal facets are `session`, `source`,
+filter and the remaining words as the content query. Date ranges accept full
+`YYYY-MM-DD/YYYY-MM-DD` or abbreviated same-month `YYYY-MM-DD/DD` notation;
+named ranges such as `July 25/26 2026` are also accepted. Callers can also pass
+a `time` object directly. Supported temporal facets are `session`, `source`,
 `captured`, `observed`, `occurred`, and `valid`; `mode` may be `auto`,
 `timeline`, or `filter`.
 

--- a/web/docs/src/content/docs/cli/memory-search.md
+++ b/web/docs/src/content/docs/cli/memory-search.md
@@ -78,7 +78,9 @@ Common refinements:
 
 Exact date queries such as `2026/05/13`, `2026-05-13`, and `May 13 2026`
 activate temporal recall automatically. Date-only queries return a timeline;
-date plus topic filters recall to matching temporal rows.
+date plus topic filters recall to matching temporal rows. Date ranges accept
+full `YYYY-MM-DD/YYYY-MM-DD` or abbreviated same-month `YYYY-MM-DD/DD`
+notation, and named ranges such as `July 25/26 2026`.
 
 Advanced controls:
 


### PR DESCRIPTION
## Summary

Closes #1359. Fixes recall queries containing abbreviated ISO date ranges such as `2026-07-25/26`, which previously left `26` in the normalized content query and could produce false no-hit responses.

## Changes

- Parse abbreviated numeric ranges as inclusive local-calendar-day windows with an end-exclusive boundary after the final day.
- Consume full numeric and named range expressions so date tokens do not leak into content queries.
- Reject reversed ranges rather than treating them as temporal queries.
- Add parser regression coverage and document the supported range forms.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: documentation under `web/docs/src/content/docs/`

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migration or compatibility data changes.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused verification:

- `bun test src/temporal-recall.test.ts` (4 pass)
- `bun test src/memory-search.test.ts` (50 pass)
- `bun run --filter '@signet/daemon' typecheck`
- `bun run --filter '@signet/daemon' build`
- `bunx biome check platform/daemon/src/temporal-recall.ts platform/daemon/src/temporal-recall.test.ts`
- `git diff --check`

The repository-wide `doc-drift.ts` check reports pre-existing unrelated drift in route, migration, and package documentation inventories.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The old parser behavior was reproduced directly: `what happened on 2026-07-25/26?` normalized to `happened 26`. The new parser returns `contentQuery: "happened"` and a local-day window from July 25 through the end of July 26.
