### PR TITLE
feat(dreaming): evaluate surprisal-guided attention selection

### DIFF
--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -41,6 +41,7 @@ flowchart TD
   PAF[Predictor Agent Feedback]
   SACC[Sub-Agent Context Continuity]
   DMC[Dreaming Memory Consolidation]
+  DSA[Dreaming Surprisal Attention Evaluation]
 
   subgraph W9[Wave 9 Strategic Stubs]
     DHO[Distributed Harness Orchestration]
@@ -102,6 +103,7 @@ flowchart TD
   MP --> DMC
   KA --> DMC
   SCP -.-> DMC
+  DMC --> DSA
 
   MA --> DHO
   SR --> DHO
@@ -802,6 +804,7 @@ Legend:
 | `docker-self-hosting-stack` | planning | `docs/specs/planning/docker-self-hosting-stack.md` | `signet-runtime` | - | First-party Docker image + Compose + Caddy deployment contract with team-mode bootstrap path and operations runbook |
 | `system-prompt-extraction` | approved | `docs/specs/approved/system-prompt-extraction.md` | - | - | Move Signet system prompt injection to session-start runtime context and keep AGENTS.md as user-owned identity content |
 | `dreaming-memory-consolidation` | approved | `docs/specs/approved/dreaming-memory-consolidation.md` | `memory-pipeline-v2`, `knowledge-architecture-schema` | - | Phase 1 (consolidation engine, trigger, config, API, CLI) delivered in PR #442. Source-backed attribute promotion uses direct audited operations outside Pipeline V2. Phase 2 (dreaming-as-session, incremental deltas, V2 exclusion, chunked compaction, dashboard, identity context) deferred. |
+| `dreaming-surprisal-attention` | planning | `docs/specs/planning/dreaming-surprisal-attention.md` | `dreaming-memory-consolidation` | `model-provider-router` | Optional bounded embedding-surprisal hints for content-pass exploration; rule-only versus assisted evaluation required before rollout. |
 | `ci-changed-files-selective` | planning | `docs/specs/planning/ci-changed-files-selective.md` | `memory-pipeline-v2` | - | Stub: selective PR CI by changed package graph |
 | `ci-contract-invariants-lane` | planning | `docs/specs/planning/ci-contract-invariants-lane.md` | `knowledge-architecture-schema` | - | Stub: mandatory fast invariant contract checks, including frozen lockfile integrity |
 | `ci-flaky-test-quarantine` | planning | `docs/specs/planning/ci-flaky-test-quarantine.md` | `ci-contract-invariants-lane` | - | Stub: flaky detection, quarantine, threshold policy |
@@ -907,6 +910,14 @@ bounded and configurable. Phase 1 (mechanical consolidation engine) is
 delivered. Phase 2 (dreaming as a session, incremental deltas, pipeline mutual
 exclusion, chunked compaction, dashboard observability, identity context
 injection) is required before spec moves to `complete`.
+
+**dreaming-surprisal-attention**: A disabled-by-default, agent-scoped selector
+can sample existing episodic embeddings within fixed bounds and queue only
+operational `surprisal` hints. Hints never advance the evidence cursor, create
+semantic state, or bypass audited operations. A reproducible rule-only versus
+assisted evaluation reports useful-review yield, valid-but-not-useful false
+positives, candidate overlap, graph-quality delta, latency, and embedding
+request/token/cost impact; selector failures fail open to ordinary Dreaming.
 
 **wave-9 strategic stubs**: The strategic backlog items listed in Wave 9
 are intentionally tracked as planning stubs and require dedicated planning

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -1355,6 +1355,26 @@ specs:
       - "Dreaming passes run as full sessions with transcript capture and self-improvement loop (Phase 2)"
       - "Pipeline V2 extraction is gated off when dreaming is enabled (Phase 2)"
     decision: null
+
+  - id: dreaming-surprisal-attention
+    status: planning
+    path: docs/specs/planning/dreaming-surprisal-attention.md
+    hard_depends_on:
+      - dreaming-memory-consolidation
+    soft_depends_on:
+      - model-provider-router
+    blocks: []
+    informed_by:
+      - docs/specs/approved/dreaming-memory-consolidation.md
+      - docs/specs/approved/knowledge-architecture-navigation.md
+      - docs/specs/approved/model-provider-router.md
+    success_criteria:
+      - "The optional selector is disabled by default, bounded, agent-scoped, and uses only already-stored embeddings"
+      - "Surprisal hints remain operational attention and never advance the evidence cursor or bypass audited operations"
+      - "Rule-only and rule-plus-surprisal runs can be compared with useful-review, false-positive, overlap, quality, latency, and embedding-cost measurements"
+      - "Selector failures and insufficient samples fail open to ordinary Dreaming behavior"
+    decision: null
+
   - id: native-harness-memory-bridge
     status: approved
     path: docs/specs/approved/native-harness-memory-bridge.md

--- a/docs/specs/planning/dreaming-surprisal-attention.md
+++ b/docs/specs/planning/dreaming-surprisal-attention.md
@@ -1,0 +1,199 @@
+---
+title: "Dreaming: Surprisal-Guided Attention Evaluation"
+description: "Evaluate a bounded, opt-in embedding-geometry signal that gives Dreaming content passes exploration hints without changing evidence watermarks or audited write paths."
+order: 2
+section: "Memory Architecture"
+informed_by:
+  - "docs/specs/approved/dreaming-memory-consolidation.md"
+  - "docs/specs/approved/knowledge-architecture-navigation.md"
+  - "docs/specs/approved/model-provider-router.md"
+success_criteria:
+  - "The selector is disabled by default and cannot create ontology state or bypass an audited Dreaming operation."
+  - "A bounded, agent-scoped sample of existing episodic memory embeddings can produce deterministic, deduplicated attention hints without provider embedding requests."
+  - "Structural attention and surprisal attention remain complementary: both signals can be measured in the same bounded pass and content work is not starved by hygiene work."
+  - "Selector failure, insufficient data, invalid vectors, and embedding-store failure fail open to ordinary Dreaming behavior with observable bounded-sweep statistics."
+  - "The evaluation reports useful-review yield, false-positive review of valid unusual evidence, structural/surprisal overlap, graph-quality delta, latency, and embedding request/token/cost impact."
+scope_boundary: "This spec covers the evaluation lane and the optional attention hint contract. It does not approve automatic claims from embedding geometry, a new ontology writer, replacement of the evidence cursor, or production rollout without measured gates."
+---
+
+# Dreaming: Surprisal-Guided Attention Evaluation
+
+## Decision
+
+Dreaming keeps its existing structural attention selectors (`review_due`,
+`hygiene`, `contested_claim`, and `evidence_requeue`) as the default. This
+spec adds an **evaluation-only, opt-in** exploration signal named
+`surprisal`. The signal is a bounded hint about an unusual embedding region;
+it is not a claim, evidence record, confidence score, or authorization to
+write the graph.
+
+The design is motivated by Honcho's use of embedding-tree path surprisal for
+sampling unusual observations, but it is not a drop-in implementation of that
+algorithm. Signet's selector is deterministic so repeated scheduled checks do
+not churn attention records: local nearest-neighbour density is the primary
+signal and a bounded median projection tree supplies a secondary sparse-region
+signal. The selector reuses vectors already persisted by the normal embedding
+pipeline and never calls an embedding provider.
+
+Reference reading: [Honcho's surprisal sampler](https://github.com/plastic-labs/honcho/blob/main/src/dreamer/surprisal.py).
+
+## Problem and hypothesis
+
+Structural flags identify known maintenance debt. They do not necessarily
+identify a valid, semantically important observation that is unusual relative
+to the agent's recent memory. The hypothesis is that a small number of
+high-surprisal observations can improve the useful-review rate of a bounded
+content pass without materially increasing latency, provider spend, or false
+positive attention.
+
+The hypothesis is not accepted merely because the selector ranks a synthetic
+outlier. It must be tested against a fixed coherent memory set with a semantic
+outlier and, separately, real agent-scoped samples. A semantically unusual
+observation can be valid evidence and must be counted as a false positive if
+it causes unnecessary review, not discarded as noise by definition.
+
+## Attention contract
+
+### Candidate source and scope
+
+1. Read only primary memories owned by the requested `agent_id`.
+2. Include only episodic, non-deleted, non-archived, unpinned memories with
+   the default empty scope. Do not read another agent's evidence.
+3. Join the latest agent-compatible stored memory embedding. If no usable
+   finite, non-zero vector exists, skip that observation.
+4. Order by captured time and id, then inspect at most `sampleSize` rows.
+   The selector must never scan an unbounded embedding table.
+5. The optional `since` argument is a read filter for callers that need one;
+   the scheduled exploratory sweep intentionally does not use the Dreaming
+   evidence cursor as a frontier. A hint sweep must never mark evidence
+   processed or advance `dreaming_state.evidence_cursor`.
+
+### Scoring and bounds
+
+For each valid vector, calculate:
+
+- the mean cosine distance to up to `neighborCount` nearest other vectors;
+- a deterministic projection-tree path surprisal, with a maximum leaf size of
+  `treeLeafSize`; and
+- a normalized bounded score, weighted 75% local density and 25% tree path.
+
+The implementation clamps scores to `[0, 1]`, emits at most `maxCandidates`
+hints, requires `minObservations` valid vectors, and records a stable selector
+version in each hint. Ties are deterministic. Defaults are conservative and
+the whole nested configuration is disabled unless `memory.dreaming.surprisal.enabled`
+is explicitly true:
+
+```yaml
+memory:
+  dreaming:
+    surprisal:
+      enabled: false
+      sampleSize: 128
+      maxCandidates: 5
+      minObservations: 20
+      neighborCount: 5
+      treeLeafSize: 10
+      minScore: 0.75
+```
+
+Configuration parsing clamps the sample and candidate bounds before the
+selector runs. The selector reports sampled rows, valid vectors, candidate
+count, elapsed time, and embedding requests/tokens/cost. The latter three
+values are expected to remain zero for this stored-vector implementation.
+
+### Queue lifecycle
+
+The daemon stores a candidate as an agent-scoped `dreaming_attention` row with
+`kind=surprisal`, `subject_ref=memory:<id>`, score/rank/sample metadata, and a
+bounded priority. The existing unique attention key prevents duplicate rows.
+The worker evaluates the opt-in selector during its scheduled check, then the
+existing workload resolver decides whether a pass should run. Structural
+attention remains independently schedulable; when both structural and content
+work are pending, focused checks alternate so hygiene cannot permanently starve
+content.
+
+The content runbook must:
+
+1. list `kind=surprisal` hints and inspect each referenced memory through the
+   normal, agent-scoped evidence tool;
+2. treat the score only as review priority;
+3. use a normal audited content operation with an exact quote only when the
+   evidence establishes a useful settled fact; or use `decline_attention` after
+   inspection when it is valid but not useful/noisy; and
+4. never cite `attention:<id>` as content provenance, create an entity or claim
+   from geometry alone, or bypass the existing evidence cursor/resolver.
+
+Hygiene passes leave `surprisal` rows pending for a content pass. No new
+writer, direct semantic SQL, provider bypass, or evidence mutation is part of
+this feature.
+
+## Failure and safety behavior
+
+- Disabled configuration is a no-op.
+- Too few observations or no valid vectors produces no hints and does not
+  fail a Dreaming check.
+- A missing/incompatible embedding store produces no hints and leaves the
+  ordinary structural/content path available.
+- A malformed vector cannot poison ranking; invalid dimensions are excluded.
+- All queries are agent-scoped and sample-limited.
+- A resolved hint is not reopened just because a scheduled sweep sees the
+  same stable sample again. A changed selector record can be reconsidered by
+  the existing attention upsert rules, but it never changes evidence state.
+- Every eventual graph mutation continues through the existing audited
+  capability registry and provenance validation.
+
+## Evaluation protocol
+
+The evaluation must compare **rule-only** and **rule + surprisal** conditions
+using the same seeded observations, agent scope, pass budget, model/provider,
+and bounded wall-clock window. The rule-only condition runs the existing
+structural selectors with surprisal disabled. The assisted condition enables
+surprisal with fixed bounds. Neither condition may receive an extra evidence
+cursor advance or a larger model budget.
+
+### Synthetic calibration
+
+Seed a coherent cluster, one semantically valid outlier, ordinary structural
+debt, and unrelated noise. Repeat with the outlier in different capture-order
+positions and with a second coherent cluster. Record:
+
+- whether the valid outlier is selected;
+- candidate rank, score, and deterministic repeatability;
+- structural/surprisal overlap and candidate-set Jaccard;
+- useful-review yield and false-positive attention rate;
+- selector latency, rows scanned, valid-vector ratio, and tree/distance work;
+- additional embedding requests, tokens, and cost (expected zero); and
+- before/after graph quality: duplicate rate, supported-claim precision,
+  unsupported or stale claim rate, and the number of unresolved attention rows.
+
+### Real-sample shadow evaluation
+
+Run the same two conditions over a bounded, agent-scoped sample of completed
+episodic memories in a non-production or shadow database. A reviewer labels
+each surfaced observation as useful review, valid-but-not-useful, noise, or
+not-reviewable. Graph-quality measurements must be computed from the same
+snapshot and the same pass budget; do not credit changes caused by unrelated
+new evidence. Publish the sample size, provider/model, latency distribution,
+embedding-store dimensions, and all exclusions so a zero-candidate run is not
+mistaken for a successful precision result.
+
+### Rollout gate
+
+This PR establishes the bounded selector, queue contract, prompt guardrails,
+and reproducible tests/evaluation protocol. It does not claim that the
+hypothesis passed. Enable the feature only after the observed assisted
+condition improves useful-review yield or graph-quality delta without an
+unacceptable increase in false-positive attention or pass latency. If the
+result is neutral or regresses, keep the feature disabled and retain the
+measurements for a later selector change.
+
+## Compatibility and observability
+
+Migration 123 extends the existing `dreaming_attention.kind` check while
+preserving existing rows and indexes. Existing installations and fresh
+databases therefore share one queue contract. Configuration remains backward
+compatible because the optional nested setting defaults off. Structured log
+fields (`sampled`, `valid`, `candidates`, `durationMs`,
+`embeddingRequests`, `embeddingTokens`, `embeddingCostUsd`, and
+`skippedReason`) make the evaluation auditable without storing vectors or
+duplicating evidence.

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -104,6 +104,7 @@ export type {
 	PipelineSignificanceConfig,
 	PipelineModelRegistryConfig,
 	PipelineHintsConfig,
+	DreamingSurprisalConfig,
 	DreamingConfig,
 	ModelRegistryEntry,
 } from "./types";

--- a/platform/core/src/migrations/126-dreaming-surprisal-attention.ts
+++ b/platform/core/src/migrations/126-dreaming-surprisal-attention.ts
@@ -1,0 +1,43 @@
+import type { MigrationDb } from "./index";
+
+/**
+ * Add the opt-in embedding-geometry attention kind without rewriting any
+ * attention records. SQLite CHECK constraints are part of the table definition,
+ * so existing installs need an additive table rebuild rather than an ALTER
+ * COLUMN. The migration runs inside the migration runner's savepoint.
+ */
+export function up(db: MigrationDb): void {
+	const table = db
+		.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'dreaming_attention'")
+		.get() as { sql?: string | null } | undefined;
+	if (!table) return;
+	if (table.sql?.includes("'surprisal'")) return;
+
+	db.exec(`
+		DROP INDEX IF EXISTS idx_dreaming_attention_pending;
+		ALTER TABLE dreaming_attention RENAME TO dreaming_attention_legacy_126;
+		CREATE TABLE dreaming_attention (
+			id TEXT PRIMARY KEY,
+			agent_id TEXT NOT NULL,
+			kind TEXT NOT NULL CHECK (kind IN ('review_due', 'hygiene', 'contested_claim', 'evidence_requeue', 'surprisal')),
+			subject_ref TEXT NOT NULL,
+			details_json TEXT NOT NULL DEFAULT '{}',
+			priority INTEGER NOT NULL DEFAULT 0 CHECK (priority >= 0 AND priority <= 100),
+			created_at TEXT NOT NULL DEFAULT (datetime('now')),
+			generation INTEGER NOT NULL DEFAULT 0,
+			resolved_at TEXT,
+			resolved_by_pass_id TEXT,
+			UNIQUE(agent_id, kind, subject_ref)
+		);
+		INSERT INTO dreaming_attention (
+			id, agent_id, kind, subject_ref, details_json, priority, created_at,
+			generation, resolved_at, resolved_by_pass_id
+		)
+		SELECT id, agent_id, kind, subject_ref, details_json, priority, created_at,
+			generation, resolved_at, resolved_by_pass_id
+		FROM dreaming_attention_legacy_126;
+		DROP TABLE dreaming_attention_legacy_126;
+		CREATE INDEX idx_dreaming_attention_pending
+			ON dreaming_attention (agent_id, resolved_at, priority DESC, created_at ASC);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -131,6 +131,7 @@ import { up as dreamingEvidenceRetry } from "./122-dreaming-evidence-retry";
 import { up as embeddingIndexFailures } from "./123-embedding-index-failures";
 import { up as importedDerivedLifecycle } from "./124-import-derived-lifecycle";
 import { up as memoryContentSafety } from "./125-memory-content-safety";
+import { up as dreamingSurprisalAttention } from "./126-dreaming-surprisal-attention";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1178,6 +1179,12 @@ export const MIGRATIONS: readonly Migration[] = [
 		name: "memory-content-safety",
 		up: memoryContentSafety,
 		artifacts: { tables: ["memory_content_safety"] },
+	},
+	{
+		version: 126,
+		name: "dreaming-surprisal-attention",
+		up: dreamingSurprisalAttention,
+		artifacts: { tables: ["dreaming_attention"] },
 	},
 ];
 

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -27,6 +27,7 @@ import { up as retireSummaryWorker } from "./117-retire-summary-worker";
 import { up as telemetryVersionObservation } from "./119-telemetry-version-observation";
 import { up as dreamingEvidenceRetry } from "./122-dreaming-evidence-retry";
 import { up as memoryContentSafety } from "./125-memory-content-safety";
+import { up as dreamingSurprisalAttention } from "./126-dreaming-surprisal-attention";
 import { MIGRATIONS, hasPendingMigrations, runMigrations } from "./index";
 
 function createFreshDb(): Database {
@@ -2090,6 +2091,49 @@ describe("migration framework", () => {
 		expect(columns.map((column) => column.name)).toEqual(
 			expect.arrayContaining(["evidence_window_json", "runbook_json"]),
 		);
+	});
+
+	test("migration 123 preserves existing attention rows and adds surprisal kind", () => {
+		db = createFreshDb();
+		db.exec(`
+		CREATE TABLE dreaming_attention (
+			id TEXT PRIMARY KEY,
+			agent_id TEXT NOT NULL,
+			kind TEXT NOT NULL CHECK (kind IN ('review_due', 'hygiene', 'contested_claim', 'evidence_requeue')),
+			subject_ref TEXT NOT NULL,
+			details_json TEXT NOT NULL DEFAULT '{}',
+			priority INTEGER NOT NULL DEFAULT 0 CHECK (priority >= 0 AND priority <= 100),
+			created_at TEXT NOT NULL DEFAULT (datetime('now')),
+			generation INTEGER NOT NULL DEFAULT 0,
+			resolved_at TEXT,
+			resolved_by_pass_id TEXT,
+			UNIQUE(agent_id, kind, subject_ref)
+		);
+		CREATE INDEX idx_dreaming_attention_pending
+			ON dreaming_attention (agent_id, resolved_at, priority DESC, created_at ASC);
+		INSERT INTO dreaming_attention (id, agent_id, kind, subject_ref, details_json, priority)
+		VALUES ('legacy-attention', 'default', 'hygiene', 'entity:legacy', '{"reason":"legacy"}', 80);
+	`);
+
+		dreamingSurprisalAttention(db as unknown as Parameters<typeof dreamingSurprisalAttention>[0]);
+		dreamingSurprisalAttention(db as unknown as Parameters<typeof dreamingSurprisalAttention>[0]);
+
+		expect(db.prepare("SELECT agent_id, kind, subject_ref, details_json FROM dreaming_attention").all()).toEqual([
+			{
+				agent_id: "default",
+				kind: "hygiene",
+				subject_ref: "entity:legacy",
+				details_json: '{"reason":"legacy"}',
+			},
+		]);
+		expect(() =>
+			db
+				.prepare(
+					`INSERT INTO dreaming_attention (id, agent_id, kind, subject_ref)
+					 VALUES ('surprisal-attention', 'default', 'surprisal', 'memory:outlier')`,
+				)
+				.run(),
+		).not.toThrow();
 	});
 	test("migration 110 adds the memory_entity_mentions entity-side composite index (#1158)", () => {
 		db = createFreshDb();

--- a/platform/core/src/types.ts
+++ b/platform/core/src/types.ts
@@ -492,6 +492,23 @@ export interface PipelineReflectionsConfig {
 	readonly maxSummaries: number;
 }
 
+export interface DreamingSurprisalConfig {
+	/** Opt-in only: structural attention remains the default selector. */
+	readonly enabled: boolean;
+	/** Maximum number of recent, already-embedded episodic observations to inspect. */
+	readonly sampleSize: number;
+	/** Maximum number of embedding-surprisal hints to queue for one pass. */
+	readonly maxCandidates: number;
+	/** Minimum number of valid vectors needed before geometry is meaningful. */
+	readonly minObservations: number;
+	/** Number of nearest neighbours used for local-density surprisal. */
+	readonly neighborCount: number;
+	/** Maximum number of points held by a deterministic projection-tree leaf. */
+	readonly treeLeafSize: number;
+	/** Normalized score below which a candidate is not queued. */
+	readonly minScore: number;
+}
+
 export interface DreamingConfig {
 	readonly tokenThreshold: number;
 	/** Maximum time that non-empty episodic evidence may wait below the token threshold. */
@@ -500,6 +517,8 @@ export interface DreamingConfig {
 	readonly maxInputTokens: number;
 	readonly maxOutputTokens: number;
 	readonly backfillOnFirstRun: boolean;
+	/** Optional, fail-open embedding-geometry hints for Dreaming attention. */
+	readonly surprisal?: DreamingSurprisalConfig;
 }
 
 // -- Status/union constants --

--- a/platform/daemon/src/memory-config.test.ts
+++ b/platform/daemon/src/memory-config.test.ts
@@ -33,6 +33,43 @@ describe("loadDreamingConfig", () => {
 			7 * 24 * 60 * 60 * 1_000,
 		);
 	});
+
+	it("keeps surprisal attention opt-in and clamps its resource bounds", () => {
+		expect(loadDreamingConfig({}).surprisal).toEqual({
+			enabled: false,
+			sampleSize: 128,
+			maxCandidates: 5,
+			minObservations: 20,
+			neighborCount: 5,
+			treeLeafSize: 10,
+			minScore: 0.75,
+		});
+
+		const config = loadDreamingConfig({
+			memory: {
+				dreaming: {
+					surprisal: {
+						enabled: true,
+						sampleSize: 10_000,
+						maxCandidates: 0,
+						minObservations: 1,
+						neighborCount: 99,
+						treeLeafSize: 1,
+						minScore: -1,
+					},
+				},
+			},
+		});
+		expect(config.surprisal).toEqual({
+			enabled: true,
+			sampleSize: 500,
+			maxCandidates: 1,
+			minObservations: 8,
+			neighborCount: 32,
+			treeLeafSize: 2,
+			minScore: 0,
+		});
+	});
 });
 
 function makeTempAgentsDir(): string {

--- a/platform/daemon/src/memory-config.ts
+++ b/platform/daemon/src/memory-config.ts
@@ -76,6 +76,16 @@ function isValidTimeZone(timeZone: string): boolean {
 	}
 }
 
+const DEFAULT_DREAMING_SURPRISAL = {
+	enabled: false,
+	sampleSize: 128,
+	maxCandidates: 5,
+	minObservations: 20,
+	neighborCount: 5,
+	treeLeafSize: 10,
+	minScore: 0.75,
+} as const;
+
 export const DEFAULT_DREAMING: DreamingConfig = {
 	tokenThreshold: 100_000,
 	maxInterval: 6 * 60 * 60 * 1_000,
@@ -83,6 +93,7 @@ export const DEFAULT_DREAMING: DreamingConfig = {
 	maxInputTokens: 128_000,
 	maxOutputTokens: 16_000,
 	backfillOnFirstRun: true,
+	surprisal: DEFAULT_DREAMING_SURPRISAL,
 };
 
 class PipelineConfigValidationError extends Error {
@@ -877,6 +888,8 @@ export function loadDreamingConfig(yaml: Record<string, unknown>): DreamingConfi
 	const raw = mem?.dreaming as Record<string, unknown> | undefined;
 	if (!raw) return { ...DEFAULT_DREAMING };
 	const dd = DEFAULT_DREAMING;
+	const defaultSurprisal = dd.surprisal ?? DEFAULT_DREAMING_SURPRISAL;
+	const surprisal = raw.surprisal as Record<string, unknown> | undefined;
 	return {
 		tokenThreshold: clampWarn("tokenThreshold", raw.tokenThreshold, 10_000, 1_000_000, dd.tokenThreshold),
 		maxInterval: clampWarn("maxInterval", raw.maxInterval, 5 * 60 * 1_000, 7 * 24 * 60 * 60 * 1_000, dd.maxInterval),
@@ -884,6 +897,33 @@ export function loadDreamingConfig(yaml: Record<string, unknown>): DreamingConfi
 		maxInputTokens: clampWarn("maxInputTokens", raw.maxInputTokens, 8_000, 1_000_000, dd.maxInputTokens),
 		maxOutputTokens: clampWarn("maxOutputTokens", raw.maxOutputTokens, 1_000, 128_000, dd.maxOutputTokens),
 		backfillOnFirstRun: typeof raw.backfillOnFirstRun === "boolean" ? raw.backfillOnFirstRun : dd.backfillOnFirstRun,
+		surprisal: {
+			enabled: typeof surprisal?.enabled === "boolean" ? surprisal.enabled : defaultSurprisal.enabled,
+			sampleSize: clampWarn("surprisal.sampleSize", surprisal?.sampleSize, 20, 500, defaultSurprisal.sampleSize),
+			maxCandidates: clampWarn(
+				"surprisal.maxCandidates",
+				surprisal?.maxCandidates,
+				1,
+				20,
+				defaultSurprisal.maxCandidates,
+			),
+			minObservations: clampWarn(
+				"surprisal.minObservations",
+				surprisal?.minObservations,
+				8,
+				500,
+				defaultSurprisal.minObservations,
+			),
+			neighborCount: clampWarn(
+				"surprisal.neighborCount",
+				surprisal?.neighborCount,
+				1,
+				32,
+				defaultSurprisal.neighborCount,
+			),
+			treeLeafSize: clampWarn("surprisal.treeLeafSize", surprisal?.treeLeafSize, 2, 64, defaultSurprisal.treeLeafSize),
+			minScore: clampWarn("surprisal.minScore", surprisal?.minScore, 0, 1, defaultSurprisal.minScore),
+		},
 	};
 }
 

--- a/platform/daemon/src/pipeline/dreaming-attention.ts
+++ b/platform/daemon/src/pipeline/dreaming-attention.ts
@@ -1,8 +1,20 @@
 import { randomUUID } from "node:crypto";
 import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
 
-export const DREAMING_ATTENTION_KINDS = ["review_due", "hygiene", "contested_claim", "evidence_requeue"] as const;
+export const DREAMING_ATTENTION_KINDS = [
+	"review_due",
+	"hygiene",
+	"contested_claim",
+	"evidence_requeue",
+	"surprisal",
+] as const;
 export type DreamingAttentionKind = (typeof DREAMING_ATTENTION_KINDS)[number];
+export const DREAMING_CONTENT_ATTENTION_KINDS = [
+	"review_due",
+	"contested_claim",
+	"evidence_requeue",
+	"surprisal",
+] as const;
 
 export interface DreamingAttention {
 	readonly id: string;
@@ -89,6 +101,24 @@ function getDreamingAttentionSnapshotsInDb(
 
 export function getDreamingAttentionInDb(db: ReadDb, agentId: string, limit = 20): readonly DreamingAttention[] {
 	return getDreamingAttentionSnapshotsInDb(db, agentId, limit).map(({ generation: _, ...attention }) => attention);
+}
+
+export function hasDreamingAttentionKindInDb(
+	db: ReadDb,
+	agentId: string,
+	kinds: readonly DreamingAttentionKind[],
+): boolean {
+	if (kinds.length === 0) return false;
+	const placeholders = kinds.map(() => "?").join(", ");
+	return (
+		db
+			.prepare(
+				`SELECT 1 FROM dreaming_attention
+				 WHERE agent_id = ? AND resolved_at IS NULL AND kind IN (${placeholders})
+				 LIMIT 1`,
+			)
+			.get(agentId, ...kinds) != null
+	);
 }
 
 export function getDreamingAttention(

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -613,7 +613,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"attention_list",
 			"List attention",
-			"List attention records by kind and resolution status. Use kind hygiene for the queue, or review_due for expired and approaching temporal claims. Omit agentId to see the whole install; pass agentId to narrow to one scope.",
+			"List attention records by kind and resolution status. Use kind hygiene for structural queue work, kind surprisal for bounded exploration hints, or review_due for expired and approaching temporal claims. Omit agentId to see the whole install; pass agentId to narrow to one scope.",
 			true,
 			z.object({
 				agentId: z.string().optional(),

--- a/platform/daemon/src/pipeline/dreaming-surprisal.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-surprisal.test.ts
@@ -1,0 +1,196 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Buffer } from "node:buffer";
+import type { DreamingConfig } from "@signet/core";
+import { runMigrations } from "../../../core/src/migrations";
+import type { DbAccessor, ReadDb } from "../db-accessor";
+import { enqueueDreamingSurprisalAttention } from "./dreaming";
+import {
+	type DreamingSurprisalObservation,
+	rankDreamingSurprisal,
+	selectDreamingSurprisalInDb,
+} from "./dreaming-surprisal";
+
+const CONFIG = {
+	enabled: true,
+	sampleSize: 128,
+	maxCandidates: 3,
+	minObservations: 8,
+	neighborCount: 3,
+	treeLeafSize: 4,
+	minScore: 0.75,
+} as const;
+
+const DREAMING_CONFIG: DreamingConfig = {
+	tokenThreshold: 100_000,
+	maxInterval: 6 * 60 * 60 * 1_000,
+	timeout: 300_000,
+	maxInputTokens: 32_000,
+	maxOutputTokens: 16_000,
+	backfillOnFirstRun: false,
+	surprisal: CONFIG,
+};
+
+function wrapDb(db: Database): DbAccessor {
+	return {
+		withReadDb<T>(fn: (db: Database) => T): T {
+			return fn(db);
+		},
+		withWriteTx<T>(fn: (db: Database) => T): T {
+			db.exec("BEGIN IMMEDIATE");
+			try {
+				const result = fn(db);
+				db.exec("COMMIT");
+				return result;
+			} catch (error) {
+				db.exec("ROLLBACK");
+				throw error;
+			}
+		},
+	} as unknown as DbAccessor;
+}
+
+function vectorBlob(values: readonly number[]): Buffer {
+	return Buffer.from(new Float32Array(values).buffer);
+}
+
+function makeObservations(): DreamingSurprisalObservation[] {
+	const observations: DreamingSurprisalObservation[] = [];
+	for (let index = 0; index < 19; index += 1) {
+		observations.push({
+			id: `cluster-${index}`,
+			capturedAt: `2026-01-01T00:00:${String(index).padStart(2, "0")}.000Z`,
+			vector: new Float32Array([1, (index % 3) * 0.001, ((index + 1) % 2) * 0.001]),
+		});
+	}
+	observations.push({
+		id: "semantic-outlier",
+		capturedAt: "2026-01-01T00:01:00.000Z",
+		vector: new Float32Array([-1, 0, 0]),
+	});
+	return observations;
+}
+
+function seedMemory(db: Database, agentId: string, id: string, values: readonly number[], createdAt: string): void {
+	db.prepare(
+		`INSERT INTO memories
+			(id, type, content, agent_id, created_at, updated_at, updated_by, memory_kind)
+		 VALUES (?, 'fact', ?, ?, ?, ?, 'test', 'episodic')`,
+	).run(id, `${agentId}:${id}`, agentId, createdAt, createdAt);
+	db.prepare(
+		`INSERT INTO embeddings
+			(id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+		 VALUES (?, ?, ?, ?, 'memory', ?, ?, ?, ?)`,
+	).run(
+		`embedding-${agentId}-${id}`,
+		`hash-${agentId}-${id}`,
+		vectorBlob(values),
+		values.length,
+		id,
+		id,
+		createdAt,
+		agentId,
+	);
+}
+
+describe("dreaming surprisal attention", () => {
+	let db: Database;
+	let accessor: DbAccessor;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		accessor = wrapDb(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("ranks a semantic outlier above a coherent embedding cluster", () => {
+		const selection = rankDreamingSurprisal(makeObservations(), CONFIG, () => 1000);
+
+		expect(selection.sampled).toBe(20);
+		expect(selection.valid).toBe(20);
+		expect(selection.embeddingRequests).toBe(0);
+		expect(selection.embeddingTokens).toBe(0);
+		expect(selection.embeddingCostUsd).toBe(0);
+		expect(selection.candidates[0]?.id).toBe("semantic-outlier");
+		expect(selection.candidates[0]?.score).toBeGreaterThanOrEqual(CONFIG.minScore);
+		expect(selection.candidates.length).toBeLessThanOrEqual(CONFIG.maxCandidates);
+		expect(selection.candidates.every((candidate) => candidate.score >= 0 && candidate.score <= 1)).toBe(true);
+	});
+
+	it("fails open when the sample is too small or has no valid vectors", () => {
+		const tooSmall = rankDreamingSurprisal(makeObservations().slice(0, 7), CONFIG);
+		expect(tooSmall.candidates).toEqual([]);
+		expect(tooSmall.skippedReason).toBe("too_few_observations");
+
+		const invalid = rankDreamingSurprisal(
+			[{ id: "bad", capturedAt: "2026-01-01T00:00:00.000Z", vector: new Float32Array([Number.NaN, 0]) }],
+			CONFIG,
+		);
+		expect(invalid.candidates).toEqual([]);
+		expect(invalid.skippedReason).toBe("no_valid_vectors");
+	});
+
+	it("does not promote a uniform embedding sample into attention", () => {
+		const observations = Array.from({ length: 12 }, (_, index) => ({
+			id: `same-${index}`,
+			capturedAt: `2026-01-01T00:00:${String(index).padStart(2, "0")}.000Z`,
+			vector: new Float32Array([1, 0, 0]),
+		}));
+
+		const selection = rankDreamingSurprisal(observations, CONFIG);
+		expect(selection.candidates).toEqual([]);
+	});
+
+	it("fails open when the embedding store is unavailable", () => {
+		const unavailableDb = {
+			prepare(): never {
+				throw new Error("embedding store unavailable");
+			},
+		} as unknown as ReadDb;
+
+		const selection = selectDreamingSurprisalInDb(unavailableDb, "default", CONFIG, null);
+		expect(selection.candidates).toEqual([]);
+		expect(selection.skippedReason).toBe("embedding_store_unavailable");
+	});
+
+	it("reads only the bounded agent-scoped primary embedding sample", () => {
+		const observations = makeObservations();
+		for (const observation of observations) {
+			seedMemory(db, "default", observation.id, [...observation.vector], observation.capturedAt);
+		}
+		seedMemory(db, "default", "malformed-dimensions", [0, 1, 0], "2026-01-01T00:01:30.000Z");
+		db.prepare("UPDATE embeddings SET dimensions = 99 WHERE source_id = 'malformed-dimensions'").run();
+		seedMemory(db, "other-agent", "other-outlier", [-1, 0, 0], "2026-01-01T00:02:00.000Z");
+
+		const selection = selectDreamingSurprisalInDb(db, "default", CONFIG, null);
+		expect(selection.sampled).toBe(21);
+		expect(selection.valid).toBe(20);
+		expect(selection.candidates[0]?.id).toBe("semantic-outlier");
+		expect(selection.candidates.some((candidate) => candidate.id === "other-outlier")).toBe(false);
+	});
+
+	it("queues hints without advancing the evidence cursor", () => {
+		for (const observation of makeObservations()) {
+			seedMemory(db, "default", observation.id, [...observation.vector], observation.capturedAt);
+		}
+		db.prepare(
+			`INSERT INTO dreaming_state (agent_id, tokens_since_last_pass, evidence_cursor)
+			 VALUES ('default', 0, 'cursor-sentinel')`,
+		).run();
+
+		const selection = enqueueDreamingSurprisalAttention(accessor, "default", DREAMING_CONFIG);
+		expect(selection?.candidates[0]?.id).toBe("semantic-outlier");
+		expect(
+			db.prepare("SELECT kind, subject_ref, details_json FROM dreaming_attention WHERE agent_id = 'default'").all(),
+		).toEqual(
+			expect.arrayContaining([expect.objectContaining({ kind: "surprisal", subject_ref: "memory:semantic-outlier" })]),
+		);
+		expect(db.prepare("SELECT evidence_cursor FROM dreaming_state WHERE agent_id = 'default'").get()).toEqual({
+			evidence_cursor: "cursor-sentinel",
+		});
+	});
+});

--- a/platform/daemon/src/pipeline/dreaming-surprisal.ts
+++ b/platform/daemon/src/pipeline/dreaming-surprisal.ts
@@ -1,0 +1,332 @@
+import type { DreamingSurprisalConfig } from "@signet/core";
+import type { ReadDb } from "../db-accessor";
+
+/** A point-in-time episodic observation with an already persisted embedding. */
+export interface DreamingSurprisalObservation {
+	readonly id: string;
+	readonly capturedAt: string;
+	readonly vector: Float32Array;
+}
+
+export interface DreamingSurprisalCandidate {
+	readonly id: string;
+	readonly capturedAt: string;
+	readonly score: number;
+	readonly rank: number;
+	readonly sampleSize: number;
+	readonly dimensions: number;
+}
+
+export interface DreamingSurprisalSelection {
+	readonly candidates: readonly DreamingSurprisalCandidate[];
+	readonly sampled: number;
+	readonly valid: number;
+	readonly durationMs: number;
+	/** This selector reuses stored vectors; no provider embedding work is done. */
+	readonly embeddingRequests: number;
+	readonly embeddingTokens: number;
+	readonly embeddingCostUsd: number;
+	readonly skippedReason?: "too_few_observations" | "no_valid_vectors" | "embedding_store_unavailable";
+}
+
+interface ProjectionTreeLeaf {
+	readonly kind: "leaf";
+	readonly count: number;
+	readonly indexes: readonly number[];
+}
+
+interface ProjectionTreeBranch {
+	readonly kind: "branch";
+	readonly count: number;
+	readonly axis: number;
+	readonly threshold: number;
+	readonly left: ProjectionTreeNode;
+	readonly right: ProjectionTreeNode;
+}
+
+type ProjectionTreeNode = ProjectionTreeLeaf | ProjectionTreeBranch;
+
+const SURPRISAL_SELECTOR_VERSION = "embedding-surprisal-v1";
+
+function clampInteger(value: number, min: number, max: number, fallback = min): number {
+	const normalized = Number.isFinite(value) ? Math.floor(value) : fallback;
+	return Math.max(min, Math.min(max, normalized));
+}
+
+function finiteVector(vector: Float32Array): boolean {
+	if (vector.length === 0) return false;
+	let norm = 0;
+	for (const value of vector) {
+		if (!Number.isFinite(value)) return false;
+		norm += value * value;
+	}
+	return norm > 0;
+}
+
+function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+	if (a.length !== b.length) return 0;
+	let dot = 0;
+	let normA = 0;
+	let normB = 0;
+	for (let index = 0; index < a.length; index += 1) {
+		const left = a[index] ?? 0;
+		const right = b[index] ?? 0;
+		dot += left * right;
+		normA += left * left;
+		normB += right * right;
+	}
+	const denominator = Math.sqrt(normA) * Math.sqrt(normB);
+	return denominator > 0 ? Math.max(-1, Math.min(1, dot / denominator)) : 0;
+}
+
+function chooseProjectionAxis(indexes: readonly number[], vectors: readonly Float32Array[], depth: number): number {
+	const dimensions = vectors[indexes[0] ?? 0]?.length ?? 0;
+	if (dimensions === 0) return 0;
+	let bestAxis = depth % dimensions;
+	let bestVariance = -1;
+	for (let axis = 0; axis < dimensions; axis += 1) {
+		let mean = 0;
+		for (const index of indexes) mean += vectors[index]?.[axis] ?? 0;
+		mean /= indexes.length;
+		let variance = 0;
+		for (const index of indexes) {
+			const delta = (vectors[index]?.[axis] ?? 0) - mean;
+			variance += delta * delta;
+		}
+		if (variance > bestVariance) {
+			bestVariance = variance;
+			bestAxis = axis;
+		}
+	}
+	return bestAxis;
+}
+
+/**
+ * Build a deterministic projection tree. Honcho's tree family uses random
+ * projections; Dreaming needs repeatable attention records so a re-run does
+ * not churn the queue, therefore this bounded variant projects onto the
+ * highest-variance coordinate and splits at its median.
+ */
+function buildProjectionTree(
+	indexes: readonly number[],
+	vectors: readonly Float32Array[],
+	leafSize: number,
+	depth = 0,
+): ProjectionTreeNode {
+	if (indexes.length <= leafSize) return { kind: "leaf", count: indexes.length, indexes: [...indexes] };
+	const axis = chooseProjectionAxis(indexes, vectors, depth);
+	const ordered = [...indexes].sort(
+		(left, right) => (vectors[left]?.[axis] ?? 0) - (vectors[right]?.[axis] ?? 0) || left - right,
+	);
+	const middle = Math.max(1, Math.min(ordered.length - 1, Math.floor(ordered.length / 2)));
+	const left = ordered.slice(0, middle);
+	const right = ordered.slice(middle);
+	const leftValue = vectors[left[left.length - 1] ?? 0]?.[axis] ?? 0;
+	const rightValue = vectors[right[0] ?? 0]?.[axis] ?? leftValue;
+	return {
+		kind: "branch",
+		count: indexes.length,
+		axis,
+		threshold: (leftValue + rightValue) / 2,
+		left: buildProjectionTree(left, vectors, leafSize, depth + 1),
+		right: buildProjectionTree(right, vectors, leafSize, depth + 1),
+	};
+}
+
+function pathSurprisal(node: ProjectionTreeNode, vector: Float32Array): number {
+	let current = node;
+	let score = 0;
+	while (current.kind === "branch") {
+		const child = (vector[current.axis] ?? 0) < current.threshold ? current.left : current.right;
+		if (child.count <= 0 || current.count <= 0) break;
+		score += -Math.log(child.count / current.count);
+		current = child;
+	}
+	// A smaller leaf represents a less populated region of the embedding
+	// space. Keep this bounded even when a malformed tree is supplied.
+	return Number.isFinite(score) ? Math.max(0, score) : 0;
+}
+
+function normalizeScores(values: readonly number[]): number[] {
+	if (values.length === 0) return [];
+	const finite = values.map((value) => (Number.isFinite(value) ? value : 0));
+	const min = Math.min(...finite);
+	const max = Math.max(...finite);
+	if (max <= min) return finite.map(() => 0.5);
+	return finite.map((value) => Math.max(0, Math.min(1, (value - min) / (max - min))));
+}
+
+function emptySelection(
+	sampled: number,
+	valid: number,
+	durationMs: number,
+	skippedReason: DreamingSurprisalSelection["skippedReason"],
+): DreamingSurprisalSelection {
+	return {
+		candidates: [],
+		sampled,
+		valid,
+		durationMs,
+		embeddingRequests: 0,
+		embeddingTokens: 0,
+		embeddingCostUsd: 0,
+		skippedReason,
+	};
+}
+
+/**
+ * Rank a bounded observation sample by embedding geometry.
+ *
+ * The local-density term is the primary signal: an observation is surprising
+ * when its nearest neighbours are far away. The projection-tree path term is
+ * a small stabilizing signal for sparse regions. This is deliberately a
+ * selector only; it never emits an ontology operation or evidence claim.
+ */
+export function rankDreamingSurprisal(
+	observations: readonly DreamingSurprisalObservation[],
+	config: Pick<
+		DreamingSurprisalConfig,
+		"maxCandidates" | "minObservations" | "neighborCount" | "treeLeafSize" | "minScore"
+	>,
+	now: () => number = Date.now,
+): DreamingSurprisalSelection {
+	const startedAt = now();
+	const dimensions = observations.find((observation) => finiteVector(observation.vector))?.vector.length ?? 0;
+	const validObservations = observations.filter(
+		(observation) => observation.vector.length === dimensions && finiteVector(observation.vector),
+	);
+	if (validObservations.length === 0)
+		return emptySelection(observations.length, 0, Math.max(0, now() - startedAt), "no_valid_vectors");
+	const minObservations = clampInteger(config.minObservations, 1, 500);
+	if (validObservations.length < minObservations) {
+		return emptySelection(
+			observations.length,
+			validObservations.length,
+			Math.max(0, now() - startedAt),
+			"too_few_observations",
+		);
+	}
+
+	const vectors = validObservations.map((observation) => observation.vector);
+	const indexes = vectors.map((_vector, index) => index);
+	const tree = buildProjectionTree(indexes, vectors, clampInteger(config.treeLeafSize, 2, 64));
+	const neighbourCount = clampInteger(config.neighborCount, 1, Math.max(1, vectors.length - 1));
+	const localDistances = vectors.map((vector, index) => {
+		const distances = vectors
+			.map((other, otherIndex) =>
+				otherIndex === index ? Number.POSITIVE_INFINITY : 1 - cosineSimilarity(vector, other),
+			)
+			.sort((left, right) => left - right)
+			.slice(0, neighbourCount);
+		return distances.reduce((total, distance) => total + distance, 0) / distances.length;
+	});
+	const treeScores = vectors.map((vector) => pathSurprisal(tree, vector));
+	const normalizedDistances = normalizeScores(localDistances);
+	const normalizedTreeScores = normalizeScores(treeScores);
+	const ranked = validObservations
+		.map((observation, index) => ({
+			observation,
+			score: Math.max(
+				0,
+				Math.min(1, 0.75 * (normalizedDistances[index] ?? 0) + 0.25 * (normalizedTreeScores[index] ?? 0)),
+			),
+		}))
+		.sort(
+			(left, right) =>
+				right.score - left.score ||
+				right.observation.capturedAt.localeCompare(left.observation.capturedAt) ||
+				left.observation.id.localeCompare(right.observation.id),
+		);
+	const maxCandidates = clampInteger(config.maxCandidates, 1, 20);
+	const minScore = Math.max(0, Math.min(1, Number.isFinite(config.minScore) ? config.minScore : 1));
+	const candidates = ranked
+		.filter((item) => item.score >= minScore)
+		.slice(0, maxCandidates)
+		.map((item, index) => ({
+			id: item.observation.id,
+			capturedAt: item.observation.capturedAt,
+			score: item.score,
+			rank: index + 1,
+			sampleSize: validObservations.length,
+			dimensions,
+		}));
+
+	return {
+		candidates,
+		sampled: observations.length,
+		valid: validObservations.length,
+		durationMs: Math.max(0, now() - startedAt),
+		embeddingRequests: 0,
+		embeddingTokens: 0,
+		embeddingCostUsd: 0,
+	};
+}
+
+function blobToVector(value: unknown): Float32Array | null {
+	if (value instanceof ArrayBuffer) {
+		if (value.byteLength % Float32Array.BYTES_PER_ELEMENT !== 0) return null;
+		return Float32Array.from(new Float32Array(value));
+	}
+	if (!ArrayBuffer.isView(value)) return null;
+	const bytes = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+	if (bytes.byteLength % Float32Array.BYTES_PER_ELEMENT !== 0) return null;
+	const aligned = new Uint8Array(bytes.byteLength);
+	aligned.set(bytes);
+	return Float32Array.from(new Float32Array(aligned.buffer));
+}
+
+/** Read only primary, scoped memory embeddings; never asks the provider for new vectors. */
+export function selectDreamingSurprisalInDb(
+	db: ReadDb,
+	agentId: string,
+	config: DreamingSurprisalConfig,
+	since: string | null,
+): DreamingSurprisalSelection {
+	const startedAt = Date.now();
+	try {
+		const limit = clampInteger(config.sampleSize, 20, 500);
+		const rows = db
+			.prepare(
+				`SELECT m.id, m.created_at AS capturedAt, e.vector, e.dimensions
+				 FROM memories AS m
+				 JOIN embeddings AS e ON e.source_type = 'memory' AND e.source_id = m.id
+				   AND e.id = (
+					   SELECT latest.id
+					   FROM embeddings AS latest
+					   WHERE latest.source_type = 'memory'
+						 AND latest.source_id = m.id
+						 AND (latest.agent_id = m.agent_id OR latest.agent_id IS NULL)
+					   ORDER BY latest.created_at DESC, latest.id DESC
+					   LIMIT 1
+				   )
+				 WHERE m.agent_id = ?
+				   AND (e.agent_id = ? OR e.agent_id IS NULL)
+				   AND COALESCE(m.memory_kind, 'episodic') = 'episodic'
+				   AND COALESCE(m.is_deleted, 0) = 0
+				   AND (m.visibility IS NULL OR m.visibility <> 'archived')
+				   AND COALESCE(m.scope, '') = ''
+				   AND COALESCE(m.pinned, 0) = 0
+				   AND (? IS NULL OR julianday(m.created_at) > julianday(?))
+				 ORDER BY m.created_at DESC, m.id DESC
+				 LIMIT ?`,
+			)
+			.all(agentId, agentId, since, since, limit) as Array<{
+			id: string;
+			capturedAt: string;
+			vector: unknown;
+			dimensions: number;
+		}>;
+		const observations = rows.flatMap((row) => {
+			const vector = blobToVector(row.vector);
+			return vector === null || !Number.isInteger(row.dimensions) || row.dimensions !== vector.length
+				? []
+				: [{ id: row.id, capturedAt: row.capturedAt, vector }];
+		});
+		const selection = rankDreamingSurprisal(observations, config);
+		return { ...selection, sampled: rows.length, durationMs: Math.max(0, Date.now() - startedAt) };
+	} catch {
+		return emptySelection(0, 0, Math.max(0, Date.now() - startedAt), "embedding_store_unavailable");
+	}
+}
+
+export const DREAMING_SURPRISAL_SELECTOR_VERSION = SURPRISAL_SELECTOR_VERSION;

--- a/platform/daemon/src/pipeline/dreaming-worker.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.test.ts
@@ -271,6 +271,24 @@ describe("dreaming worker agent scope", () => {
 		expect(selectDreamingCheckMode(accessor, ["default"], focus)).toBe("incremental-hygiene");
 	});
 
+	it("routes pending surprisal hints to a content pass without an evidence backlog", () => {
+		db.prepare(
+			`INSERT INTO dreaming_attention (id, agent_id, kind, subject_ref, details_json, priority)
+			 VALUES ('surprisal-hint', 'default', 'surprisal', 'memory:outlier', '{}', 90)`,
+		).run();
+
+		expect(selectDreamingCheckMode(accessor, ["default"], null)).toBe("incremental-content");
+	});
+
+	it("routes pending temporal review attention to a content pass", () => {
+		db.prepare(
+			`INSERT INTO dreaming_attention (id, agent_id, kind, subject_ref, details_json, priority)
+			 VALUES ('review-hint', 'default', 'review_due', 'memory:temporal', '{}', 90)`,
+		).run();
+
+		expect(selectDreamingCheckMode(accessor, ["default"], null)).toBe("incremental-content");
+	});
+
 	it("seeds deterministic hygiene attention for legacy graph rows", () => {
 		// Hygiene attention is enqueued during regular check() ticks, not at
 		// worker startup (startup scans block the event loop before the HTTP

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -18,6 +18,7 @@ import {
 	createDreamingPass,
 	dreamingFocusOfMode,
 	enqueueDreamingHygieneAttention,
+	enqueueDreamingSurprisalAttention,
 	getDreamingEpisodicTokenBacklog,
 	isDreamingHaltActive,
 	recordDreamingFailure,
@@ -25,7 +26,7 @@ import {
 	selectDreamingPassMode,
 	shouldTriggerDreaming,
 } from "./dreaming";
-import { getDreamingAttentionInDb } from "./dreaming-attention";
+import { DREAMING_CONTENT_ATTENTION_KINDS, hasDreamingAttentionKindInDb } from "./dreaming-attention";
 import { type DreamingEvidenceRetryPolicy, autoRequeueRepairedDreamingEvidence } from "./dreaming-evidence-retry";
 
 /** Thrown when a trigger is attempted while a pass is already in-flight. */
@@ -161,11 +162,14 @@ export function selectDreamingCheckMode(
 	scopes: readonly string[],
 	lastScheduled: DreamingPassFocus | null,
 ): DreamingMode {
-	const hasPendingAttention = scopes.some((scope) =>
-		accessor.withReadDb((db) => getDreamingAttentionInDb(db, scope, 1).length > 0),
+	const hasPendingHygieneAttention = scopes.some((scope) =>
+		accessor.withReadDb((db) => hasDreamingAttentionKindInDb(db, scope, ["hygiene"])),
+	);
+	const hasPendingContentAttention = scopes.some((scope) =>
+		accessor.withReadDb((db) => hasDreamingAttentionKindInDb(db, scope, DREAMING_CONTENT_ATTENTION_KINDS)),
 	);
 	const hasBacklog = scopes.some((scope) => getDreamingEpisodicTokenBacklog(accessor, scope) > 0);
-	return selectDreamingPassMode(lastScheduled, hasPendingAttention, hasBacklog);
+	return selectDreamingPassMode(lastScheduled, hasPendingHygieneAttention, hasBacklog, hasPendingContentAttention);
 }
 
 export function startDreamingWorker(
@@ -327,6 +331,7 @@ export function startDreamingWorker(
 			if (isDreamingHaltActive(accessor, scopeId)) continue;
 			try {
 				enqueueDreamingHygieneAttention(accessor, scopeId, undefined, caps);
+				enqueueDreamingSurprisalAttention(accessor, scopeId, cfg);
 				const episodicTokens = getDreamingEpisodicTokenBacklog(accessor, scopeId);
 				if (!shouldTriggerDreaming(accessor, cfg, scopeId, Date.now(), episodicTokens)) continue;
 				triggered = true;

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -1109,6 +1109,9 @@ describe("Dreaming", () => {
 		// Only one kind pending: run that kind directly, no alternation.
 		expect(selectDreamingPassMode("content", true, false)).toBe("incremental-hygiene");
 		expect(selectDreamingPassMode("hygiene", false, true)).toBe("incremental-content");
+		expect(selectDreamingPassMode(null, false, false, true)).toBe("incremental-content");
+		expect(selectDreamingPassMode(null, true, false, true)).toBe("incremental-hygiene");
+		expect(selectDreamingPassMode("hygiene", true, false, true)).toBe("incremental-content");
 	});
 
 	it("early-exits each focused pass mode on its own empty work (#1098)", () => {
@@ -1118,10 +1121,12 @@ describe("Dreaming", () => {
 		expect(dreamingEarlyExitSummary("incremental-hygiene", false, 100)).toBe("No hygiene attention to process");
 		expect(dreamingEarlyExitSummary("incremental-hygiene", true, 0)).toBeNull();
 		expect(dreamingEarlyExitSummary("incremental-content", true, 0)).toBe("No new episodic evidence to process");
+		expect(dreamingEarlyExitSummary("incremental-content", false, 0, true)).toBeNull();
 		expect(dreamingEarlyExitSummary("incremental-content", false, 1)).toBeNull();
 		expect(dreamingEarlyExitSummary("incremental", false, 0)).toBe(
 			"No new episodic evidence or semantic attention to process",
 		);
+		expect(dreamingEarlyExitSummary("incremental", false, 0, true)).toBeNull();
 		expect(dreamingEarlyExitSummary("incremental", true, 0)).toBeNull();
 		expect(dreamingEarlyExitSummary("compact", false, 0)).toBeNull();
 	});
@@ -1170,6 +1175,49 @@ describe("Dreaming", () => {
 		);
 		expect(contentPrompt).toBe(DREAMING_CONTENT_AGENT_PROMPT);
 		expect(contentPrompt).not.toContain("Process ALL pending hygiene records");
+		expect(contentPrompt).toContain("kind=surprisal");
+		expect(contentPrompt).toContain("never cite attention:<id>");
+	});
+
+	it("does not advance the evidence cursor for a surprisal-only content pass", async () => {
+		const cursor = JSON.stringify({
+			capturedAt: "2026-01-01T00:00:00.000Z",
+			kind: "transcript",
+			id: "already-surfaced",
+		});
+		accessor.withWriteTx((tx) => {
+			tx.prepare(
+				`INSERT INTO dreaming_state (agent_id, last_pass_at, evidence_cursor)
+				 VALUES (?, ?, ?)`,
+			).run(AGENT, "2026-01-01T00:00:00.000Z", cursor);
+			enqueueDreamingAttentionInTx(tx, {
+				agentId: AGENT,
+				kind: "surprisal",
+				subjectRef: "memory:semantic-outlier",
+				details: { selector: "embedding-surprisal-v1" },
+			});
+		});
+
+		await runDreamingAgentPass(
+			accessor,
+			{
+				async run() {
+					return { summary: "Inspected surprisal hint" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT],
+			"incremental-content",
+		);
+
+		expect(
+			db.prepare("SELECT last_pass_at, evidence_cursor FROM dreaming_state WHERE agent_id = ?").get(AGENT),
+		).toEqual({
+			last_pass_at: "2026-01-01T00:00:00.000Z",
+			evidence_cursor: cursor,
+		});
 	});
 
 	it("requires bounded Markdown runbook summaries in every pass mode (#1226)", () => {
@@ -1182,6 +1230,8 @@ describe("Dreaming", () => {
 			expect(prompt).toContain("never use generic categories");
 			expect(prompt).toContain("max 2000 chars");
 		}
+		expect(DREAMING_AGENT_PROMPT).toContain("kind=surprisal");
+		expect(DREAMING_HYGIENE_AGENT_PROMPT).toContain("Leave kind=surprisal records pending");
 	});
 
 	it("does not advance the evidence watermark for hygiene-only work (#1098)", async () => {

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -39,11 +39,13 @@ import { getActiveTelemetry } from "../telemetry";
 import { upsertThreadHead } from "../thread-heads";
 import { createDreamingAgentTools } from "./dreaming-agent-tools";
 import {
+	DREAMING_CONTENT_ATTENTION_KINDS,
 	type DreamingAttention,
 	enqueueDreamingAttentionInTx,
 	getDreamingAttention,
 	getDreamingAttentionInDb,
 	getDreamingAttentionSnapshots,
+	hasDreamingAttentionKindInDb,
 	renderDreamingAttentionForPrompt,
 	resolveDreamingAttentionInTx,
 } from "./dreaming-attention";
@@ -67,6 +69,11 @@ import {
 	recordDreamingEvidenceWindowInTx,
 	renderDreamingRunbookForPrompt,
 } from "./dreaming-runbook";
+import {
+	DREAMING_SURPRISAL_SELECTOR_VERSION,
+	type DreamingSurprisalSelection,
+	selectDreamingSurprisalInDb,
+} from "./dreaming-surprisal";
 import { countTokens } from "./tokenizer";
 
 // ---------------------------------------------------------------------------
@@ -77,8 +84,9 @@ export type DreamingMode = "incremental" | "compact" | "incremental-hygiene" | "
 
 /**
  * The focused runbook a scheduled pass follows (#1098): hygiene passes
- * process the attention queue only, content passes ingest new evidence
- * only. Combined modes ("incremental", "compact") keep the full runbook.
+ * process structural attention only, content passes handle evidence-linked
+ * work and bounded exploration hints. Combined modes ("incremental",
+ * "compact") keep the full runbook.
  */
 export type DreamingPassFocus = "hygiene" | "content";
 
@@ -112,6 +120,58 @@ export function enqueueDreamingHygieneAttention(
 		}
 		return candidates.length;
 	});
+}
+
+/**
+ * Queue bounded embedding-geometry hints without touching the evidence cursor
+ * or invoking an embedding provider. The selector is deliberately independent
+ * of the workload resolver: it only reuses vectors already stored for primary
+ * episodic memories, then the normal Dreaming worker decides when and how to
+ * spend an inference pass.
+ */
+export function enqueueDreamingSurprisalAttention(
+	accessor: DbAccessor,
+	agentId: string,
+	cfg: DreamingConfig,
+): DreamingSurprisalSelection | null {
+	const surprisal = cfg.surprisal;
+	if (!surprisal?.enabled) return null;
+	// Do not pass the Dreaming cursor as a write frontier. A surprisal hint is a
+	// bounded exploration sample and must never mark evidence as processed.
+	const selection = accessor.withReadDb((db) => selectDreamingSurprisalInDb(db, agentId, surprisal, null));
+	if (selection.candidates.length > 0) {
+		accessor.withWriteTx((db) => {
+			for (const candidate of selection.candidates) {
+				enqueueDreamingAttentionInTx(db, {
+					agentId,
+					kind: "surprisal",
+					subjectRef: `memory:${candidate.id}`,
+					details: {
+						selector: DREAMING_SURPRISAL_SELECTOR_VERSION,
+						score: candidate.score.toFixed(6),
+						rank: String(candidate.rank),
+						sampleSize: String(candidate.sampleSize),
+						dimensions: String(candidate.dimensions),
+						capturedAt: candidate.capturedAt,
+					},
+					priority: Math.round(60 + candidate.score * 40),
+					reopen: false,
+				});
+			}
+		});
+	}
+	logger.info("dreaming", "Embedding-surprisal attention sweep completed", {
+		agentId,
+		sampled: selection.sampled,
+		valid: selection.valid,
+		candidates: selection.candidates.length,
+		durationMs: selection.durationMs,
+		embeddingRequests: selection.embeddingRequests,
+		embeddingTokens: selection.embeddingTokens,
+		embeddingCostUsd: selection.embeddingCostUsd,
+		skippedReason: selection.skippedReason,
+	});
+	return selection;
 }
 
 function parseEpisodicCursor(value: string | null): EpisodicCursor | null {
@@ -629,11 +689,12 @@ export const DREAMING_AGENT_PROMPT = `You are a bounded Signet maintenance agent
 
 Purpose: maintain durable, evidence-cited semantic understanding in the knowledge graph. The graph is a derived structure; every write carries provenance (an attention id for hygiene, an exact quote from episodic evidence for content). Use the pass log (runbook_read) as the dedup source: the previous pass's viewed sources and changes are the cutoff.
 
-An install may have several agent scopes (listed in <agent_scopes> when there is more than one): the scoped tools take an agentId, so address any scope you need — each write is attributed to the agent you name. attention_list without an agentId lists the whole install's hygiene queue, with each record carrying its owning agentId.
+An install may have several agent scopes (listed in <agent_scopes> when there is more than one): the scoped tools take an agentId, so address any scope you need — each write is attributed to the agent you name. attention_list without an agentId lists the whole install's attention queue, with each record carrying its owning agentId.
 
 ### State targets
 
 - Hygiene queue: dreaming_attention pending records (kind=hygiene)
+- Exploration hints: bounded embedding-surprisal records (kind=surprisal); these are not evidence
 - Graph: entities, aspects, claims, links (active/archived/pinned)
 - Evidence: episodic store (memories, artifacts, completed transcripts)
 - Pass log: dreaming_passes + runbook notes (what changed, what was viewed)
@@ -647,8 +708,9 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - \`attribute_over_cap\` / \`aspect_over_cap\` flags: the write gate rejects new claims or aspects past the cap, so consolidate the flagged target — merge_aspects to fold over-cap aspects together, supersede_claim_value to collapse duplicate claim keys, archive_claim_value for stale snapshots. Consolidation (merge_aspects) may exceed the attribute cap; it is the remedy the cap forces.
    - If you discover junk the queue did not flag, mint a flag op and archive in the same batch.
    - If you inspect a flagged target and judge it should stay as it is (a deliberate keep — e.g. a live entity with a non-concrete type, or an over-cap aspect you chose not to consolidate), close the record with decline_attention citing its attention id. Declining is an affirmative judgment: only decline records you actually inspected, and never decline records you could not complete this pass — defer those with a named blocker instead.
-3. Query attention_list with kind=review_due. For expired records, inspect the cited memory with search_evidence using its subjectRef, then supersede the matching active claim with supersede_claim_value. Use the supplied entityId, aspectId, attributeId, and claimKey when present. The replacement must state that the planned event remains unconfirmed; never rewrite it as if the event happened. Cite an exact quote from the original memory. Do not supersede approaching records. When creating or setting a future temporal claim, set payload.reviewAfter to the referenced ISO timestamp.
-4. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST unprocessed sources with search_evidence — omit the query and omit since so it lists from the scope's evidence watermark (the frontier the last pass actually surfaced), newest first; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed transcript sessions; historical summary rows are not part of the default delivery path. A transcript with completed: false is mid-stream — defer filing from it with the named blocker "transcript still mid-stream" (re-check completed each pass: a session still active when re-checked is a re-verified blocker, not a repeated one), and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
+3. Query attention_list with kind=surprisal. These are bounded exploration hints, not evidence and not hygiene provenance. For each hint, inspect its memory:<id> subjectRef with search_evidence in the owning scope. Treat the score only as a priority signal: if the source establishes a useful, settled fact, use a normal content operation with an exact quote; if it is valid but not useful or is noise, use decline_attention after inspecting it. Never create a claim or entity from the score alone, and never cite attention:<id> for a content operation. A surprisal hint must not bypass the evidence cursor or audited apply path.
+4. Query attention_list with kind=review_due. For expired records, inspect the cited memory with search_evidence using its subjectRef, then supersede the matching active claim with supersede_claim_value. Use the supplied entityId, aspectId, attributeId, and claimKey when present. The replacement must state that the planned event remains unconfirmed; never rewrite it as if the event happened. Cite an exact quote from the original memory. Do not supersede approaching records. When creating or setting a future temporal claim, set payload.reviewAfter to the referenced ISO timestamp.
+5. Only when the hygiene queue is clear: find new evidence since the cutoff. First LIST unprocessed sources with search_evidence — omit the query and omit since so it lists from the scope's evidence watermark (the frontier the last pass actually surfaced), newest first; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed transcript sessions; historical summary rows are not part of the default delivery path. A transcript with completed: false is mid-stream — defer filing from it with the named blocker "transcript still mid-stream" (re-check completed each pass: a session still active when re-checked is a re-verified blocker, not a repeated one), and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
    - search_entities for subjects it establishes.
    - File claims only for what the source establishes as settled fact: outcomes, decisions, shipped changes, stable behavior. Do not file instructions that were merely suggested, hypotheses or diagnoses, open questions, or intermediate states of an ongoing investigation. When a source shows an attempt and its outcome, file the outcome.
    - A claim must be a complete statement: it names the subject and the fact about it. A bare label ("SHIP-WITH-FIXES"), a fragment ("Root cause confirmed."), or an implementation detail without its subject is not a claim — do not file it.
@@ -657,7 +719,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - create_entity only for durable subjects clearly established by the source.
    - When the evidence supports a possible relationship, merge, or other ontology change but the relationship is ambiguous rather than settled, do not apply it immediately. Emit the normal ontology operation with risk: "review_required". Its reason must be a concise, human-readable explanation that names the entities and the proposed relationship; the exact evidence citation remains required. The daemon will place it in the user's review queue for confirmation, not treat the queue as a work-deferral mechanism.
    - Validate before writing (validate_proposal).
-5. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write a specific entity-named change manifest, not process narration. Use Markdown, max 2000 chars, with these sections when applicable: ## Updated, ## Created, ## Deferred, ## No-op. Under every section, each line must name the entity or entity id, state the exact change (claim filed or superseded, aspect touched, entity/aspect/link archived or merged, or why no change was needed), and cite the source or provenance reference (memory, artifact, or transcript as kind:id; hygiene attention:<id>). Deferred and No-op lines must state the specific blocker or reason; never use generic categories such as "content-related" or "ongoing structural process". Omit empty sections. Put the same deferred items and open questions in the runbook's deferred and openQuestions fields.
+6. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write a specific entity-named change manifest, not process narration. Use Markdown, max 2000 chars, with these sections when applicable: ## Updated, ## Created, ## Deferred, ## No-op. Under every section, each line must name the entity or entity id, state the exact change (claim filed or superseded, aspect touched, entity/aspect/link archived or merged, or why no change was needed), and cite the source or provenance reference (memory, artifact, or transcript as kind:id; hygiene attention:<id>). Deferred and No-op lines must state the specific blocker or reason; never use generic categories such as "content-related" or "ongoing structural process". Omit empty sections. Put the same deferred items and open questions in the runbook's deferred and openQuestions fields.
 
 ### What counts as durable
 
@@ -699,7 +761,7 @@ export const DREAMING_HYGIENE_AGENT_PROMPT = `You are a bounded Signet maintenan
 
 Purpose: maintain durable, evidence-cited semantic understanding in the knowledge graph. This is a HYGIENE pass: process the attention queue — inspect flagged targets and archive or merge them with attention provenance, minting flags for junk the queue missed. Content maintenance (claims, entities) belongs to content passes, which cite exact quotes from episodic evidence. Use the pass log (runbook_read) as the dedup source: the previous pass's changes are the cutoff.
 
-An install may have several agent scopes (listed in <agent_scopes> when there is more than one): the scoped tools take an agentId, so address any scope you need — each write is attributed to the agent you name. attention_list without an agentId lists the whole install's hygiene queue, with each record carrying its owning agentId.
+An install may have several agent scopes (listed in <agent_scopes> when there is more than one): the scoped tools take an agentId, so address any scope you need — each write is attributed to the agent you name. attention_list without an agentId lists the whole install's attention queue, with each record carrying its owning agentId.
 
 ### State targets
 
@@ -715,6 +777,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - Archive or merge it, citing its attention id (provenance: "attention:<uuid>", or attention:$<index> for a flag you minted in the same batch).
    - If you discover junk the queue did not flag, mint a flag op and archive in the same batch.
    - If you inspect a flagged target and judge it should stay as it is (a deliberate keep — e.g. a live entity with a non-concrete type, or an over-cap aspect you chose not to consolidate), close the record with decline_attention citing its attention id. Declining is an affirmative judgment: only decline records you actually inspected, and never decline records you could not complete this pass — defer those with a named blocker instead.
+   - Leave kind=surprisal records pending. They are content-pass exploration hints and must be inspected with exact evidence by a content pass.
 3. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write a specific entity-named change manifest, not process narration. Use Markdown, max 2000 chars, with these sections when applicable: ## Updated, ## Created, ## Deferred, ## No-op. Under every section, each line must name the entity or entity id, state the exact change (claim filed or superseded, aspect touched, entity/aspect/link archived or merged, or why no change was needed), and cite the source or provenance reference (memory, artifact, or transcript as kind:id; hygiene attention:<id>). Deferred and No-op lines must state the specific blocker or reason; never use generic categories such as "content-related" or "ongoing structural process". Omit empty sections. Put the same deferred items and open questions in the runbook's deferred and openQuestions fields.
 
 ### What counts as durable
@@ -744,19 +807,20 @@ The pass is done when:
 /**
  * The fixed prompt for a content-only pass (#1098): the evidence runbook
  * (combined-process steps 1, 3, 4). Hygiene archives are out of scope —
- * hygiene passes own the attention queue, so a content pass spends its
- * whole budget ingesting new evidence instead of being crowded out.
+ * hygiene passes own that queue, while content passes handle review and
+ * bounded surprisal hints alongside new evidence.
  */
 export const DREAMING_CONTENT_AGENT_PROMPT = `You are a bounded Signet maintenance agent. Your task is to maintain durable, evidence-cited semantic understanding as the relevant entities, relationships, and claims change over time. Attach each claim to its entity and aspect rather than allowing it to exist as standalone.
 
 ## Process
 
-Purpose: maintain durable, evidence-cited semantic understanding in the knowledge graph. This is a CONTENT pass: find new evidence since the cutoff and extract/update claims with exact-quote citations, creating entities for durable subjects. Hygiene archives/merges belong to hygiene passes, which process the attention queue. Use the pass log (runbook_read) as the dedup source: the previous pass's viewed sources and changes are the cutoff.
+Purpose: maintain durable, evidence-cited semantic understanding in the knowledge graph. This is a CONTENT pass: process review work, inspect bounded surprisal hints, and find new evidence since the cutoff; extract/update claims with exact-quote citations and create entities only for durable subjects. Hygiene archives/merges belong to hygiene passes, which process structural attention. Use the pass log (runbook_read) as the dedup source: the previous pass's viewed sources and changes are the cutoff.
 
-An install may have several agent scopes (listed in <agent_scopes> when there is more than one): the scoped tools take an agentId, so address any scope you need — each write is attributed to the agent you name. attention_list without an agentId lists the whole install's hygiene queue, with each record carrying its owning agentId.
+An install may have several agent scopes (listed in <agent_scopes> when there is more than one): the scoped tools take an agentId, so address any scope you need — each write is attributed to the agent you name. attention_list without an agentId lists the whole install's attention queue, with each record carrying its owning agentId.
 
 ### State targets
 
+- Exploration hints: bounded embedding-surprisal records (kind=surprisal); these are not evidence
 - Graph: entities, aspects, claims, links (active/archived/pinned)
 - Evidence: episodic store (memories, artifacts, completed transcripts)
 - Pass log: dreaming_passes + runbook notes (what changed, what was viewed)
@@ -765,7 +829,8 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
 
 1. Read the pass log (runbook_read). Establish cutoff: sources viewed, changes applied, deferred items.
 2. Query attention_list with kind=review_due. For expired records, inspect the cited memory with search_evidence using its subjectRef, then supersede the matching active claim with supersede_claim_value. Use the supplied entityId, aspectId, attributeId, and claimKey when present. The replacement must state that the planned event remains unconfirmed; never rewrite it as if the event happened. Cite an exact quote from the original memory. Do not supersede approaching records. When creating or setting a future temporal claim, set payload.reviewAfter to the referenced ISO timestamp.
-3. Find new evidence since the cutoff. First LIST unprocessed sources with search_evidence — omit the query and omit since so it lists from the scope's evidence watermark (the frontier the last pass actually surfaced), newest first; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed transcript sessions; historical summary rows are not part of the default delivery path. A transcript with completed: false is mid-stream — defer filing from it with the named blocker "transcript still mid-stream" (re-check completed each pass: a session still active when re-checked is a re-verified blocker, not a repeated one), and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
+3. Query attention_list with kind=surprisal. These are bounded exploration hints, not evidence and not hygiene provenance. Inspect each hint's memory:<id> subjectRef with search_evidence in the owning scope. If the source establishes a useful settled fact, use a normal content operation with an exact quote; otherwise decline_attention after inspection. Never create a claim or entity from the score alone, and never cite attention:<id> for a content operation.
+4. Find new evidence since the cutoff. First LIST unprocessed sources with search_evidence — omit the query and omit since so it lists from the scope's evidence watermark (the frontier the last pass actually surfaced), newest first; only after seeing what is there, narrow with a query if the list is large. Prefer evidence from completed transcript sessions; historical summary rows are not part of the default delivery path. A transcript with completed: false is mid-stream — defer filing from it with the named blocker "transcript still mid-stream" (re-check completed each pass: a session still active when re-checked is a re-verified blocker, not a repeated one), and note the deferral in the pass log, because its states may be contradicted by the session's end. For each new source:
    - search_entities for subjects it establishes.
    - File claims only for what the source establishes as settled fact: outcomes, decisions, shipped changes, stable behavior. Do not file instructions that were merely suggested, hypotheses or diagnoses, open questions, or intermediate states of an ongoing investigation. When a source shows an attempt and its outcome, file the outcome.
    - A claim must be a complete statement: it names the subject and the fact about it. A bare label ("SHIP-WITH-FIXES"), a fragment ("Root cause confirmed."), or an implementation detail without its subject is not a claim — do not file it.
@@ -774,7 +839,7 @@ An install may have several agent scopes (listed in <agent_scopes> when there is
    - create_entity only for durable subjects clearly established by the source.
    - When the evidence supports a possible relationship, merge, or other ontology change but the relationship is ambiguous rather than settled, do not apply it immediately. Emit the normal ontology operation with risk: "review_required". Its reason must be a concise, human-readable explanation that names the entities and the proposed relationship; the exact evidence citation remains required. The daemon will place it in the user's review queue for confirmation, not treat the queue as a work-deferral mechanism.
    - Validate before writing (validate_proposal).
-4. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write a specific entity-named change manifest, not process narration. Use Markdown, max 2000 chars, with these sections when applicable: ## Updated, ## Created, ## Deferred, ## No-op. Under every section, each line must name the entity or entity id, state the exact change (claim filed or superseded, aspect touched, entity/aspect/link archived or merged, or why no change was needed), and cite the source or provenance reference (memory, artifact, or transcript as kind:id; hygiene attention:<id>). Deferred and No-op lines must state the specific blocker or reason; never use generic categories such as "content-related" or "ongoing structural process". Omit empty sections. Put the same deferred items and open questions in the runbook's deferred and openQuestions fields.
+5. Write the pass log (runbook_write) last. Its summary is read back by a human who did not watch the pass: write a specific entity-named change manifest, not process narration. Use Markdown, max 2000 chars, with these sections when applicable: ## Updated, ## Created, ## Deferred, ## No-op. Under every section, each line must name the entity or entity id, state the exact change (claim filed or superseded, aspect touched, entity/aspect/link archived or merged, or why no change was needed), and cite the source or provenance reference (memory, artifact, or transcript as kind:id; hygiene attention:<id>). Deferred and No-op lines must state the specific blocker or reason; never use generic categories such as "content-related" or "ongoing structural process". Omit empty sections. Put the same deferred items and open questions in the runbook's deferred and openQuestions fields.
 
 ### What counts as durable
 
@@ -817,12 +882,12 @@ export function dreamingFocusOfMode(mode: DreamingMode): DreamingPassFocus | nul
 }
 
 /**
- * Whether a pass mode consumes episodic evidence. A hygiene pass processes
- * only the attention queue, so it must not advance the evidence watermark;
- * every other mode reads evidence and resets the queue to pass start.
+ * Whether a pass mode is allowed to update episodic state for this pass.
+ * Attention-only content work (for example, a surprisal hint with an empty
+ * backlog) must not advance or clear the evidence watermark.
  */
-function dreamingModeAdvancesEvidence(mode: DreamingMode): boolean {
-	return mode !== "incremental-hygiene";
+function dreamingModeAdvancesEvidence(mode: DreamingMode, hasEpisodicWork: boolean): boolean {
+	return mode !== "incremental-hygiene" && hasEpisodicWork;
 }
 
 /**
@@ -833,13 +898,18 @@ function dreamingModeAdvancesEvidence(mode: DreamingMode): boolean {
  */
 export function dreamingEarlyExitSummary(
 	mode: DreamingMode,
-	hasPendingAttention: boolean,
+	hasPendingHygieneAttention: boolean,
 	totalBacklog: number,
+	hasPendingContentAttention = false,
 ): string | null {
-	if (mode === "incremental-hygiene") return hasPendingAttention ? null : "No hygiene attention to process";
-	if (mode === "incremental-content") return totalBacklog === 0 ? "No new episodic evidence to process" : null;
+	if (mode === "incremental-hygiene") {
+		return hasPendingHygieneAttention ? null : "No hygiene attention to process";
+	}
+	if (mode === "incremental-content") {
+		return totalBacklog === 0 && !hasPendingContentAttention ? "No new episodic evidence to process" : null;
+	}
 	if (mode === "incremental") {
-		return !hasPendingAttention && totalBacklog === 0
+		return !hasPendingHygieneAttention && !hasPendingContentAttention && totalBacklog === 0
 			? "No new episodic evidence or semantic attention to process"
 			: null;
 	}
@@ -855,16 +925,18 @@ export function dreamingEarlyExitSummary(
  */
 export function selectDreamingPassMode(
 	lastScheduled: DreamingPassFocus | null,
-	hasPendingAttention: boolean,
+	hasPendingHygieneAttention: boolean,
 	hasBacklog: boolean,
+	hasPendingContentAttention = false,
 ): DreamingMode {
-	if (hasPendingAttention && hasBacklog) {
+	const hasContentWork = hasBacklog || hasPendingContentAttention;
+	if (hasPendingHygieneAttention && hasContentWork) {
 		// Tie: alternate so content gets a guaranteed turn even while the
 		// hygiene queue stays full, starting the cycle at hygiene.
 		return lastScheduled === "hygiene" ? "incremental-content" : "incremental-hygiene";
 	}
-	if (hasPendingAttention) return "incremental-hygiene";
-	if (hasBacklog) return "incremental-content";
+	if (hasPendingHygieneAttention) return "incremental-hygiene";
+	if (hasContentWork) return "incremental-content";
 	// Unreachable through shouldTriggerDreaming (it fires only when attention
 	// or a backlog exists); the combined mode's early-exit gate is the
 	// defensive fallback.
@@ -1249,11 +1321,25 @@ export async function runDreamingAgentPass(
 		// scope has pending attention or an episodic backlog. Scheduled checks
 		// are already gated by shouldTriggerDreaming; this protects manual
 		// triggers and compact runs from spending tokens on nothing.
+		const hasPendingHygieneAttention = scopes.some((scope) =>
+			accessor.withReadDb((db) => hasDreamingAttentionKindInDb(db, scope, ["hygiene"])),
+		);
+		const hasPendingContentAttention = scopes.some((scope) =>
+			accessor.withReadDb((db) => hasDreamingAttentionKindInDb(db, scope, DREAMING_CONTENT_ATTENTION_KINDS)),
+		);
 		const hasPendingAttention = scopes.some((scope) =>
 			accessor.withReadDb((db) => getDreamingAttentionInDb(db, scope, 1).length > 0),
 		);
-		const totalBacklog = scopes.reduce((total, scope) => total + getDreamingEpisodicTokenBacklog(accessor, scope), 0);
-		const earlyExitSummary = dreamingEarlyExitSummary(mode, hasPendingAttention, totalBacklog);
+		const backlogByScope = new Map(
+			scopes.map((scope) => [scope, getDreamingEpisodicTokenBacklog(accessor, scope)] as const),
+		);
+		const totalBacklog = [...backlogByScope.values()].reduce((total, backlog) => total + backlog, 0);
+		const earlyExitSummary = dreamingEarlyExitSummary(
+			mode,
+			hasPendingHygieneAttention,
+			totalBacklog,
+			hasPendingContentAttention || (hasPendingAttention && !hasPendingHygieneAttention),
+		);
 		if (earlyExitSummary !== null) {
 			accessor.withWriteTx((db) => {
 				db.prepare(
@@ -1267,8 +1353,10 @@ export async function runDreamingAgentPass(
 				// skip it for the next pass, and a hygiene pass must never
 				// advance the watermark even on an empty backlog (#1098,
 				// #1149).
-				if (totalBacklog === 0 && dreamingModeAdvancesEvidence(mode)) {
-					for (const scope of scopes) resetDreamingTokens(db, scope, passId, mode, null, cutoff);
+				if (dreamingModeAdvancesEvidence(mode, totalBacklog > 0)) {
+					for (const scope of scopes) {
+						if ((backlogByScope.get(scope) ?? 0) > 0) resetDreamingTokens(db, scope, passId, mode, null, cutoff);
+					}
 				}
 			});
 			recordDreamingPassTelemetry({
@@ -1450,8 +1538,9 @@ export async function runDreamingAgentPass(
 			// pass consumes no evidence, so it must not advance the watermark —
 			// advancing it would hide the unprocessed backlog from the next
 			// content pass and starve content again (#1098).
-			if (dreamingModeAdvancesEvidence(mode)) {
+			if (dreamingModeAdvancesEvidence(mode, totalBacklog > 0)) {
 				for (const scope of scopes) {
+					if ((backlogByScope.get(scope) ?? 0) === 0) continue;
 					resetDreamingTokens(db, scope, passId, mode, null, nextWatermarkByScope.get(scope) ?? null);
 				}
 			}

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -643,6 +643,7 @@ export function registerPipelineRoutes(app: Hono): void {
 				maxInputTokens: cfg.dreaming.maxInputTokens,
 				maxOutputTokens: cfg.dreaming.maxOutputTokens,
 				timeout: cfg.dreaming.timeout,
+				surprisal: cfg.dreaming.surprisal,
 			},
 			passes,
 			attention,


### PR DESCRIPTION
## Summary

- Adds an opt-in, bounded embedding-geometry surprisal selector for Dreaming attention.
- Queues deterministic `surprisal` hints for content passes without advancing the evidence cursor, requesting embeddings, or bypassing audited writes.
- Adds the required planning spec and a reproducible evaluation protocol for rule-only versus surprisal-assisted selection.

Closes #1320

## Changes

- Added `DreamingSurprisalConfig` with conservative defaults, validation, and `/api/dream/status` visibility.
- Added migration 123 to extend `dreaming_attention` safely while preserving existing rows and indexes.
- Added deterministic local-density plus projection-tree ranking over bounded, agent-scoped stored vectors.
- Integrated scheduled hint selection with content/hygiene pass routing and explicit prompt guardrails.
- Added fallback, migration, configuration, ranking, agent-scope, cursor-preservation, routing, and prompt regression coverage.
- Added `docs/specs/planning/dreaming-surprisal-attention.md` and synchronized `INDEX.md`/`dependencies.yaml`.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: docs/spec registry

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

Migration 123 rebuilds only the existing `dreaming_attention` table when its legacy CHECK constraint does not include `surprisal`; it runs inside the migration runner transaction, copies all existing rows, and recreates the pending index. Re-running is a no-op. A pre-migration database backup remains the rollback path.

## Testing

- [x] `bun test` targeted Dreaming/core migration suite: **228 pass, 0 fail, 1,203 expect() calls**
- [x] `bun run --filter '@signet/daemon' typecheck`
- [x] `bun run --filter '@signet/core' typecheck` and `bun run build:core`
- [x] Changed-file Biome check
- [x] Spec dependency check (`bun scripts/spec-deps-check.ts`)
- [ ] Tested against running daemon — N/A for this database/pipeline unit change

The root `bun run lint` and root `bun run typecheck` commands were also run; they report pre-existing repository-wide package formatting (499 errors/157 warnings) and connector workspace declaration/generated-bundle errors outside this change. The changed files and affected core/daemon packages pass their checks.

The workspace-wide `bun run test` was also attempted; it is not green on this checkout because unrelated daemon tests fail under repository-wide manifest/config/resource conditions (**2,099 pass, 155 fail, 27 errors, 7 skipped** across 2,261 tests). The isolated affected suite above is green.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Surprisal remains disabled by default.
- This PR establishes the evaluation lane and does not claim that the assisted condition passed its rollout gates.
- No new ontology writer or evidence-linked bypass was added.

Assisted-by: Codex
