### PR TITLE
fix(daemon): bound service health probe

### DIFF
--- a/.bump-level
+++ b/.bump-level
@@ -1,1 +1,1 @@
-minor
+patch

--- a/.bump-level
+++ b/.bump-level
@@ -1,1 +1,1 @@
-patch
+minor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Surface summary of the most recent release dates. See the release ledger below f
 
 ### 2026-08-10
 - Features: expose authorized claim reasoning traces (#1318); unified dashboard source imports; attribute dreaming pass target; wire dreaming review suggestions; retry repaired evidence; add telemetry opt-out; expose collector delivery health; expose accounting provenance; add source lifecycle telemetry (#1276); add marketing PostHog events; record dreaming pass effects.
-- Bug fixes: complete cache-stable memory injection; gate hostile content projections; scroll dreaming summary; recover document leases on startup; quarantine migration embedding failures; repair stale synthesis config; make entity merges idempotent; close telemetry repair gaps; make integrity repair audit atomic; repair corrupt telemetry indexes; parse abbreviated date ranges; bound SQLite writer admission; bound memory capture concurrency; remove legacy memory pipeline routing; summarize pipeline operations (#1278); preserve mixed coverage; correct Pi accounting provenance; filter reasoning from evidence; remove duplicate projection helper; retain transcript manifest projection; account for recovered dreaming passes; disclose CLI command delivery (#1280); classify deployment role and install provenance; canonicalize embedding endpoint (#1264); bound wedge pressure probes; merge growing recovery snapshots; retain worker status telemetry; harden retired transcript recovery; retire summary-worker delivery; measure recall delivery outcomes; add bounded wedge pressure telemetry; persist first-use milestones atomically.
+- Bug fixes: mirror replace/remove; complete cache-stable memory injection; gate hostile content projections; scroll dreaming summary; recover document leases on startup; quarantine migration embedding failures; repair stale synthesis config; make entity merges idempotent; close telemetry repair gaps; make integrity repair audit atomic; repair corrupt telemetry indexes; parse abbreviated date ranges; bound SQLite writer admission; bound memory capture concurrency; remove legacy memory pipeline routing; summarize pipeline operations (#1278); preserve mixed coverage; correct Pi accounting provenance; filter reasoning from evidence; remove duplicate projection helper; retain transcript manifest projection; account for recovered dreaming passes; disclose CLI command delivery (#1280); classify deployment role and install provenance; canonicalize embedding endpoint (#1264); bound wedge pressure probes; merge growing recovery snapshots; retain worker status telemetry; harden retired transcript recovery; retire summary-worker delivery; measure recall delivery outcomes; add bounded wedge pressure telemetry; persist first-use milestones atomically.
 - Performance: stabilize memory injection.
 - Docs: catalog health events; improve issue triage workflow.
 
@@ -44,6 +44,15 @@ Surface summary of the most recent release dates. See the release ledger below f
 - Docs: reflect Dreaming cutover; clarify inline linking boundary; align pipeline with Dreaming cutover; describe summary lineage cutover.
 
 ## Release Ledger
+
+## [0.194.1] - 2026-08-10
+
+Release summary: 1 bug fix.
+Tag range: `v0.194.0..v0.194.1`.
+
+### Bug Fixes
+
+- **hermes**: mirror replace/remove (#1376)
 
 ## [0.194.0] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Surface summary of the most recent release dates. See the release ledger below f
 
 ### 2026-08-10
 - Features: unified dashboard source imports; attribute dreaming pass target; wire dreaming review suggestions; retry repaired evidence; add telemetry opt-out; expose collector delivery health; expose accounting provenance; add source lifecycle telemetry (#1276); add marketing PostHog events; record dreaming pass effects.
-- Bug fixes: gate hostile content projections; scroll dreaming summary; recover document leases on startup; quarantine migration embedding failures; repair stale synthesis config; make entity merges idempotent; close telemetry repair gaps; make integrity repair audit atomic; repair corrupt telemetry indexes; parse abbreviated date ranges; bound SQLite writer admission; bound memory capture concurrency; remove legacy memory pipeline routing; summarize pipeline operations (#1278); preserve mixed coverage; correct Pi accounting provenance; filter reasoning from evidence; remove duplicate projection helper; retain transcript manifest projection; account for recovered dreaming passes; disclose CLI command delivery (#1280); classify deployment role and install provenance; canonicalize embedding endpoint (#1264); bound wedge pressure probes; merge growing recovery snapshots; retain worker status telemetry; harden retired transcript recovery; retire summary-worker delivery; measure recall delivery outcomes; add bounded wedge pressure telemetry; persist first-use milestones atomically.
+- Bug fixes: complete cache-stable memory injection; gate hostile content projections; scroll dreaming summary; recover document leases on startup; quarantine migration embedding failures; repair stale synthesis config; make entity merges idempotent; close telemetry repair gaps; make integrity repair audit atomic; repair corrupt telemetry indexes; parse abbreviated date ranges; bound SQLite writer admission; bound memory capture concurrency; remove legacy memory pipeline routing; summarize pipeline operations (#1278); preserve mixed coverage; correct Pi accounting provenance; filter reasoning from evidence; remove duplicate projection helper; retain transcript manifest projection; account for recovered dreaming passes; disclose CLI command delivery (#1280); classify deployment role and install provenance; canonicalize embedding endpoint (#1264); bound wedge pressure probes; merge growing recovery snapshots; retain worker status telemetry; harden retired transcript recovery; retire summary-worker delivery; measure recall delivery outcomes; add bounded wedge pressure telemetry; persist first-use milestones atomically.
 - Performance: stabilize memory injection.
 - Docs: catalog health events; improve issue triage workflow.
 
@@ -44,6 +44,15 @@ Surface summary of the most recent release dates. See the release ledger below f
 - Docs: reflect Dreaming cutover; clarify inline linking boundary; align pipeline with Dreaming cutover; describe summary lineage cutover.
 
 ## Release Ledger
+
+## [0.193.3] - 2026-08-10
+
+Release summary: 1 bug fix.
+Tag range: `v0.193.2..v0.193.3`.
+
+### Bug Fixes
+
+- **context**: complete cache-stable memory injection (#1382)
 
 ## [0.193.2] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Signet are documented here.
 Surface summary of the most recent release dates. See the release ledger below for exact version-by-version history.
 
 ### 2026-08-10
-- Features: unified dashboard source imports; attribute dreaming pass target; wire dreaming review suggestions; retry repaired evidence; add telemetry opt-out; expose collector delivery health; expose accounting provenance; add source lifecycle telemetry (#1276); add marketing PostHog events; record dreaming pass effects.
+- Features: expose authorized claim reasoning traces (#1318); unified dashboard source imports; attribute dreaming pass target; wire dreaming review suggestions; retry repaired evidence; add telemetry opt-out; expose collector delivery health; expose accounting provenance; add source lifecycle telemetry (#1276); add marketing PostHog events; record dreaming pass effects.
 - Bug fixes: complete cache-stable memory injection; gate hostile content projections; scroll dreaming summary; recover document leases on startup; quarantine migration embedding failures; repair stale synthesis config; make entity merges idempotent; close telemetry repair gaps; make integrity repair audit atomic; repair corrupt telemetry indexes; parse abbreviated date ranges; bound SQLite writer admission; bound memory capture concurrency; remove legacy memory pipeline routing; summarize pipeline operations (#1278); preserve mixed coverage; correct Pi accounting provenance; filter reasoning from evidence; remove duplicate projection helper; retain transcript manifest projection; account for recovered dreaming passes; disclose CLI command delivery (#1280); classify deployment role and install provenance; canonicalize embedding endpoint (#1264); bound wedge pressure probes; merge growing recovery snapshots; retain worker status telemetry; harden retired transcript recovery; retire summary-worker delivery; measure recall delivery outcomes; add bounded wedge pressure telemetry; persist first-use milestones atomically.
 - Performance: stabilize memory injection.
 - Docs: catalog health events; improve issue triage workflow.
@@ -44,6 +44,15 @@ Surface summary of the most recent release dates. See the release ledger below f
 - Docs: reflect Dreaming cutover; clarify inline linking boundary; align pipeline with Dreaming cutover; describe summary lineage cutover.
 
 ## Release Ledger
+
+## [0.194.0] - 2026-08-10
+
+Release summary: 1 feature.
+Tag range: `v0.193.3..v0.194.0`.
+
+### Features
+
+- **memory**: expose authorized claim reasoning traces (#1318) (#1381)
 
 ## [0.193.3] - 2026-08-10
 

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "dist/signetai": {
       "name": "signetai",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "bin": {
         "signet": "bin/signet.js",
         "signet-mcp": "dist/mcp-stdio.js",
@@ -25,27 +25,27 @@
     },
     "dist/signetai-darwin-arm64": {
       "name": "signetai-darwin-arm64",
-      "version": "0.193.2",
+      "version": "0.193.3",
     },
     "dist/signetai-darwin-x64": {
       "name": "signetai-darwin-x64",
-      "version": "0.193.2",
+      "version": "0.193.3",
     },
     "dist/signetai-linux-arm64": {
       "name": "signetai-linux-arm64",
-      "version": "0.193.2",
+      "version": "0.193.3",
     },
     "dist/signetai-linux-x64": {
       "name": "signetai-linux-x64",
-      "version": "0.193.2",
+      "version": "0.193.3",
     },
     "dist/signetai-win32-x64": {
       "name": "signetai-win32-x64",
-      "version": "0.193.2",
+      "version": "0.193.3",
     },
     "integrations/claude-code/connector": {
       "name": "@signet/connector-claude-code",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "bin": {
         "signet-connector-claude-code": "bin/install.js",
       },
@@ -60,7 +60,7 @@
     },
     "integrations/codex/connector": {
       "name": "@signet/connector-codex",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "bin": {
         "signet-connector-codex": "bin/install.js",
       },
@@ -75,7 +75,7 @@
     },
     "integrations/codex/plugin": {
       "name": "@signet/codex-plugin",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "bin": {
         "signet-codex-plugin": "bin/install.js",
       },
@@ -86,7 +86,7 @@
     },
     "integrations/forge/connector": {
       "name": "@signet/connector-forge",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "bin": {
         "signet-connector-forge": "bin/install.js",
       },
@@ -101,7 +101,7 @@
     },
     "integrations/gemini/connector": {
       "name": "@signet/connector-gemini",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "bin": {
         "signet-connector-gemini": "bin/install.js",
       },
@@ -116,7 +116,7 @@
     },
     "integrations/hermes-agent/connector": {
       "name": "@signet/connector-hermes-agent",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "bin": {
         "signet-connector-hermes-agent": "bin/install.js",
       },
@@ -131,7 +131,7 @@
     },
     "integrations/oh-my-pi/connector": {
       "name": "@signet/connector-oh-my-pi",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "bin": {
         "signet-connector-oh-my-pi": "bin/install.js",
       },
@@ -146,7 +146,7 @@
     },
     "integrations/oh-my-pi/extension": {
       "name": "@signet/oh-my-pi-extension",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/pi-extension-base": "workspace:*",
@@ -159,7 +159,7 @@
     },
     "integrations/openclaw/connector": {
       "name": "@signet/connector-openclaw",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "bin": {
         "signet-connector-openclaw": "bin/install.js",
       },
@@ -174,7 +174,7 @@
     },
     "integrations/openclaw/memory-adapter": {
       "name": "@signetai/signet-memory-openclaw",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "dependencies": {
         "@sinclair/typebox": "0.34.47",
       },
@@ -192,7 +192,7 @@
     },
     "integrations/opencode/connector": {
       "name": "@signet/connector-opencode",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "bin": {
         "signet-connector-opencode": "bin/install.js",
       },
@@ -208,7 +208,7 @@
     },
     "integrations/opencode/plugin": {
       "name": "@signet/opencode-plugin",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "dependencies": {
         "@signet/core": "workspace:*",
       },
@@ -224,7 +224,7 @@
     },
     "integrations/pi/connector": {
       "name": "@signet/connector-pi",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "bin": {
         "signet-connector-pi": "bin/install.js",
       },
@@ -239,7 +239,7 @@
     },
     "integrations/pi/extension": {
       "name": "@signet/pi-extension",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/pi-extension-base": "workspace:*",
@@ -253,18 +253,18 @@
     },
     "integrations/pi/extension-base": {
       "name": "@signet/pi-extension-base",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "dependencies": {
         "@signet/core": "workspace:*",
       },
     },
     "integrations/unreal/plugin": {
       "name": "@signet/unreal-plugin",
-      "version": "0.193.2",
+      "version": "0.193.3",
     },
     "libs/connector-base": {
       "name": "@signet/connector-base",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "dependencies": {
         "@signet/core": "0.162.4",
         "json5": "^2.2.3",
@@ -277,7 +277,7 @@
     },
     "libs/sdk": {
       "name": "@signet/sdk",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "devDependencies": {
         "@signet/core": "workspace:*",
         "@types/react": "^19.0.0",
@@ -317,7 +317,7 @@
     },
     "platform/core": {
       "name": "@signet/core",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "dependencies": {
         "sqlite-vec": "^0.1.7-alpha.2",
         "yaml": "^2.6.0",
@@ -339,7 +339,7 @@
     },
     "platform/daemon": {
       "name": "@signet/daemon",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "bin": {
         "signet-daemon": "./dist/daemon.js",
         "signet-mcp": "./dist/mcp-stdio.js",
@@ -383,14 +383,14 @@
     },
     "platform/native": {
       "name": "@signet/native",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",
       },
     },
     "surfaces/browser-extension": {
       "name": "@signet/extension",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",
@@ -398,7 +398,7 @@
     },
     "surfaces/cli": {
       "name": "@signet/cli",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "bin": "./dist/cli.js",
       "dependencies": {
         "@earendil-works/pi-ai": "0.83.0",
@@ -462,7 +462,7 @@
     },
     "surfaces/desktop": {
       "name": "@signet/desktop",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/tray": "workspace:*",
@@ -477,7 +477,7 @@
     },
     "surfaces/tray": {
       "name": "@signet/tray",
-      "version": "0.193.2",
+      "version": "0.193.3",
       "devDependencies": {
         "typescript": "^5.7.0",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "dist/signetai": {
       "name": "signetai",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "bin": {
         "signet": "bin/signet.js",
         "signet-mcp": "dist/mcp-stdio.js",
@@ -25,27 +25,27 @@
     },
     "dist/signetai-darwin-arm64": {
       "name": "signetai-darwin-arm64",
-      "version": "0.193.3",
+      "version": "0.194.0",
     },
     "dist/signetai-darwin-x64": {
       "name": "signetai-darwin-x64",
-      "version": "0.193.3",
+      "version": "0.194.0",
     },
     "dist/signetai-linux-arm64": {
       "name": "signetai-linux-arm64",
-      "version": "0.193.3",
+      "version": "0.194.0",
     },
     "dist/signetai-linux-x64": {
       "name": "signetai-linux-x64",
-      "version": "0.193.3",
+      "version": "0.194.0",
     },
     "dist/signetai-win32-x64": {
       "name": "signetai-win32-x64",
-      "version": "0.193.3",
+      "version": "0.194.0",
     },
     "integrations/claude-code/connector": {
       "name": "@signet/connector-claude-code",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "bin": {
         "signet-connector-claude-code": "bin/install.js",
       },
@@ -60,7 +60,7 @@
     },
     "integrations/codex/connector": {
       "name": "@signet/connector-codex",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "bin": {
         "signet-connector-codex": "bin/install.js",
       },
@@ -75,7 +75,7 @@
     },
     "integrations/codex/plugin": {
       "name": "@signet/codex-plugin",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "bin": {
         "signet-codex-plugin": "bin/install.js",
       },
@@ -86,7 +86,7 @@
     },
     "integrations/forge/connector": {
       "name": "@signet/connector-forge",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "bin": {
         "signet-connector-forge": "bin/install.js",
       },
@@ -101,7 +101,7 @@
     },
     "integrations/gemini/connector": {
       "name": "@signet/connector-gemini",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "bin": {
         "signet-connector-gemini": "bin/install.js",
       },
@@ -116,7 +116,7 @@
     },
     "integrations/hermes-agent/connector": {
       "name": "@signet/connector-hermes-agent",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "bin": {
         "signet-connector-hermes-agent": "bin/install.js",
       },
@@ -131,7 +131,7 @@
     },
     "integrations/oh-my-pi/connector": {
       "name": "@signet/connector-oh-my-pi",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "bin": {
         "signet-connector-oh-my-pi": "bin/install.js",
       },
@@ -146,7 +146,7 @@
     },
     "integrations/oh-my-pi/extension": {
       "name": "@signet/oh-my-pi-extension",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/pi-extension-base": "workspace:*",
@@ -159,7 +159,7 @@
     },
     "integrations/openclaw/connector": {
       "name": "@signet/connector-openclaw",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "bin": {
         "signet-connector-openclaw": "bin/install.js",
       },
@@ -174,7 +174,7 @@
     },
     "integrations/openclaw/memory-adapter": {
       "name": "@signetai/signet-memory-openclaw",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.47",
       },
@@ -192,7 +192,7 @@
     },
     "integrations/opencode/connector": {
       "name": "@signet/connector-opencode",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "bin": {
         "signet-connector-opencode": "bin/install.js",
       },
@@ -208,7 +208,7 @@
     },
     "integrations/opencode/plugin": {
       "name": "@signet/opencode-plugin",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "dependencies": {
         "@signet/core": "workspace:*",
       },
@@ -224,7 +224,7 @@
     },
     "integrations/pi/connector": {
       "name": "@signet/connector-pi",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "bin": {
         "signet-connector-pi": "bin/install.js",
       },
@@ -239,7 +239,7 @@
     },
     "integrations/pi/extension": {
       "name": "@signet/pi-extension",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/pi-extension-base": "workspace:*",
@@ -253,18 +253,18 @@
     },
     "integrations/pi/extension-base": {
       "name": "@signet/pi-extension-base",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "dependencies": {
         "@signet/core": "workspace:*",
       },
     },
     "integrations/unreal/plugin": {
       "name": "@signet/unreal-plugin",
-      "version": "0.193.3",
+      "version": "0.194.0",
     },
     "libs/connector-base": {
       "name": "@signet/connector-base",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "dependencies": {
         "@signet/core": "0.162.4",
         "json5": "^2.2.3",
@@ -277,7 +277,7 @@
     },
     "libs/sdk": {
       "name": "@signet/sdk",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "devDependencies": {
         "@signet/core": "workspace:*",
         "@types/react": "^19.0.0",
@@ -317,7 +317,7 @@
     },
     "platform/core": {
       "name": "@signet/core",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "dependencies": {
         "sqlite-vec": "^0.1.7-alpha.2",
         "yaml": "^2.6.0",
@@ -339,7 +339,7 @@
     },
     "platform/daemon": {
       "name": "@signet/daemon",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "bin": {
         "signet-daemon": "./dist/daemon.js",
         "signet-mcp": "./dist/mcp-stdio.js",
@@ -383,14 +383,14 @@
     },
     "platform/native": {
       "name": "@signet/native",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",
       },
     },
     "surfaces/browser-extension": {
       "name": "@signet/extension",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",
@@ -398,7 +398,7 @@
     },
     "surfaces/cli": {
       "name": "@signet/cli",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "bin": "./dist/cli.js",
       "dependencies": {
         "@earendil-works/pi-ai": "0.83.0",
@@ -462,7 +462,7 @@
     },
     "surfaces/desktop": {
       "name": "@signet/desktop",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/tray": "workspace:*",
@@ -477,7 +477,7 @@
     },
     "surfaces/tray": {
       "name": "@signet/tray",
-      "version": "0.193.3",
+      "version": "0.194.0",
       "devDependencies": {
         "typescript": "^5.7.0",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "dist/signetai": {
       "name": "signetai",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "bin": {
         "signet": "bin/signet.js",
         "signet-mcp": "dist/mcp-stdio.js",
@@ -25,27 +25,27 @@
     },
     "dist/signetai-darwin-arm64": {
       "name": "signetai-darwin-arm64",
-      "version": "0.194.0",
+      "version": "0.194.1",
     },
     "dist/signetai-darwin-x64": {
       "name": "signetai-darwin-x64",
-      "version": "0.194.0",
+      "version": "0.194.1",
     },
     "dist/signetai-linux-arm64": {
       "name": "signetai-linux-arm64",
-      "version": "0.194.0",
+      "version": "0.194.1",
     },
     "dist/signetai-linux-x64": {
       "name": "signetai-linux-x64",
-      "version": "0.194.0",
+      "version": "0.194.1",
     },
     "dist/signetai-win32-x64": {
       "name": "signetai-win32-x64",
-      "version": "0.194.0",
+      "version": "0.194.1",
     },
     "integrations/claude-code/connector": {
       "name": "@signet/connector-claude-code",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "bin": {
         "signet-connector-claude-code": "bin/install.js",
       },
@@ -60,7 +60,7 @@
     },
     "integrations/codex/connector": {
       "name": "@signet/connector-codex",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "bin": {
         "signet-connector-codex": "bin/install.js",
       },
@@ -75,7 +75,7 @@
     },
     "integrations/codex/plugin": {
       "name": "@signet/codex-plugin",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "bin": {
         "signet-codex-plugin": "bin/install.js",
       },
@@ -86,7 +86,7 @@
     },
     "integrations/forge/connector": {
       "name": "@signet/connector-forge",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "bin": {
         "signet-connector-forge": "bin/install.js",
       },
@@ -101,7 +101,7 @@
     },
     "integrations/gemini/connector": {
       "name": "@signet/connector-gemini",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "bin": {
         "signet-connector-gemini": "bin/install.js",
       },
@@ -116,7 +116,7 @@
     },
     "integrations/hermes-agent/connector": {
       "name": "@signet/connector-hermes-agent",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "bin": {
         "signet-connector-hermes-agent": "bin/install.js",
       },
@@ -131,7 +131,7 @@
     },
     "integrations/oh-my-pi/connector": {
       "name": "@signet/connector-oh-my-pi",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "bin": {
         "signet-connector-oh-my-pi": "bin/install.js",
       },
@@ -146,7 +146,7 @@
     },
     "integrations/oh-my-pi/extension": {
       "name": "@signet/oh-my-pi-extension",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/pi-extension-base": "workspace:*",
@@ -159,7 +159,7 @@
     },
     "integrations/openclaw/connector": {
       "name": "@signet/connector-openclaw",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "bin": {
         "signet-connector-openclaw": "bin/install.js",
       },
@@ -174,7 +174,7 @@
     },
     "integrations/openclaw/memory-adapter": {
       "name": "@signetai/signet-memory-openclaw",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "dependencies": {
         "@sinclair/typebox": "0.34.47",
       },
@@ -192,7 +192,7 @@
     },
     "integrations/opencode/connector": {
       "name": "@signet/connector-opencode",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "bin": {
         "signet-connector-opencode": "bin/install.js",
       },
@@ -208,7 +208,7 @@
     },
     "integrations/opencode/plugin": {
       "name": "@signet/opencode-plugin",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "dependencies": {
         "@signet/core": "workspace:*",
       },
@@ -224,7 +224,7 @@
     },
     "integrations/pi/connector": {
       "name": "@signet/connector-pi",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "bin": {
         "signet-connector-pi": "bin/install.js",
       },
@@ -239,7 +239,7 @@
     },
     "integrations/pi/extension": {
       "name": "@signet/pi-extension",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/pi-extension-base": "workspace:*",
@@ -253,18 +253,18 @@
     },
     "integrations/pi/extension-base": {
       "name": "@signet/pi-extension-base",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "dependencies": {
         "@signet/core": "workspace:*",
       },
     },
     "integrations/unreal/plugin": {
       "name": "@signet/unreal-plugin",
-      "version": "0.194.0",
+      "version": "0.194.1",
     },
     "libs/connector-base": {
       "name": "@signet/connector-base",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "dependencies": {
         "@signet/core": "0.162.4",
         "json5": "^2.2.3",
@@ -277,7 +277,7 @@
     },
     "libs/sdk": {
       "name": "@signet/sdk",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "devDependencies": {
         "@signet/core": "workspace:*",
         "@types/react": "^19.0.0",
@@ -317,7 +317,7 @@
     },
     "platform/core": {
       "name": "@signet/core",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "dependencies": {
         "sqlite-vec": "^0.1.7-alpha.2",
         "yaml": "^2.6.0",
@@ -339,7 +339,7 @@
     },
     "platform/daemon": {
       "name": "@signet/daemon",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "bin": {
         "signet-daemon": "./dist/daemon.js",
         "signet-mcp": "./dist/mcp-stdio.js",
@@ -383,14 +383,14 @@
     },
     "platform/native": {
       "name": "@signet/native",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",
       },
     },
     "surfaces/browser-extension": {
       "name": "@signet/extension",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",
@@ -398,7 +398,7 @@
     },
     "surfaces/cli": {
       "name": "@signet/cli",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "bin": "./dist/cli.js",
       "dependencies": {
         "@earendil-works/pi-ai": "0.83.0",
@@ -462,7 +462,7 @@
     },
     "surfaces/desktop": {
       "name": "@signet/desktop",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "dependencies": {
         "@signet/core": "workspace:*",
         "@signet/tray": "workspace:*",
@@ -477,7 +477,7 @@
     },
     "surfaces/tray": {
       "name": "@signet/tray",
-      "version": "0.194.0",
+      "version": "0.194.1",
       "devDependencies": {
         "typescript": "^5.7.0",
       },

--- a/dist/signetai-darwin-arm64/package.json
+++ b/dist/signetai-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-darwin-arm64",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet native binary for macOS arm64",
   "os": [
     "darwin"

--- a/dist/signetai-darwin-arm64/package.json
+++ b/dist/signetai-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-darwin-arm64",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet native binary for macOS arm64",
   "os": [
     "darwin"

--- a/dist/signetai-darwin-arm64/package.json
+++ b/dist/signetai-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-darwin-arm64",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet native binary for macOS arm64",
   "os": [
     "darwin"

--- a/dist/signetai-darwin-x64/package.json
+++ b/dist/signetai-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-darwin-x64",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet native binary for macOS x64",
   "os": [
     "darwin"

--- a/dist/signetai-darwin-x64/package.json
+++ b/dist/signetai-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-darwin-x64",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet native binary for macOS x64",
   "os": [
     "darwin"

--- a/dist/signetai-darwin-x64/package.json
+++ b/dist/signetai-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-darwin-x64",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet native binary for macOS x64",
   "os": [
     "darwin"

--- a/dist/signetai-linux-arm64/package.json
+++ b/dist/signetai-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-linux-arm64",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet native binary for Linux arm64",
   "os": [
     "linux"

--- a/dist/signetai-linux-arm64/package.json
+++ b/dist/signetai-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-linux-arm64",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet native binary for Linux arm64",
   "os": [
     "linux"

--- a/dist/signetai-linux-arm64/package.json
+++ b/dist/signetai-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-linux-arm64",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet native binary for Linux arm64",
   "os": [
     "linux"

--- a/dist/signetai-linux-x64/package.json
+++ b/dist/signetai-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-linux-x64",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet native binary for Linux x64",
   "os": [
     "linux"

--- a/dist/signetai-linux-x64/package.json
+++ b/dist/signetai-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-linux-x64",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet native binary for Linux x64",
   "os": [
     "linux"

--- a/dist/signetai-linux-x64/package.json
+++ b/dist/signetai-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-linux-x64",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet native binary for Linux x64",
   "os": [
     "linux"

--- a/dist/signetai-win32-x64/package.json
+++ b/dist/signetai-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-win32-x64",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet native binary for Windows x64",
   "os": [
     "win32"

--- a/dist/signetai-win32-x64/package.json
+++ b/dist/signetai-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-win32-x64",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet native binary for Windows x64",
   "os": [
     "win32"

--- a/dist/signetai-win32-x64/package.json
+++ b/dist/signetai-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai-win32-x64",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet native binary for Windows x64",
   "os": [
     "win32"

--- a/dist/signetai/package.json
+++ b/dist/signetai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet native CLI installer wrapper",
   "type": "module",
   "bin": {

--- a/dist/signetai/package.json
+++ b/dist/signetai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet native CLI installer wrapper",
   "type": "module",
   "bin": {

--- a/dist/signetai/package.json
+++ b/dist/signetai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signetai",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet native CLI installer wrapper",
   "type": "module",
   "bin": {

--- a/docs/dreaming-skill-runbook.md
+++ b/docs/dreaming-skill-runbook.md
@@ -49,7 +49,15 @@ Inspect versioned claim evidence:
 signet ontology claim versions <entity> <aspect> <group> <claim> --json
 signet ontology claim show <entity> <aspect> <group> <claim> --version 1 --json
 signet ontology claim-evidence <entity> <aspect> <group> <claim> --status all --json
+signet ontology explain-claim <entity> <aspect> <group> <claim> --json
 ```
+
+`explain-claim` is a read-only, bounded audit view over the same applied claim
+versions and derived-memory source links Dreaming already writes. Check
+`integrity.status` before treating a value as verified: deleted, stale, or
+incomplete premises are reported as invalidated/unverified, and a fabricated
+or cross-agent source reference fails closed. Use `--session-key` when a
+Dreaming review must remain within one session's evidence boundary.
 
 ## Entity Merge Path
 

--- a/docs/knowledge-graph-control-plane.md
+++ b/docs/knowledge-graph-control-plane.md
@@ -45,6 +45,7 @@ graph control plane. It is not a speculative product spec.
 | `POST /api/ontology/operations/apply` | CLI/API | dry-run, pending refactor proposal, or applied operation + graph mutation | Direct operation endpoint. Requires `modify`. Covered through operation engine and CLI tests. |
 | `POST /api/ontology/operations/batch` | CLI/API | atomic batch dry-run/propose/apply | Requires `modify`; rolls back on invalid operation. Covered by operation batch tests. |
 | `GET /api/ontology/claims/evidence` | CLI/API | read-only | Covered by claim evidence tests. |
+| `GET /api/ontology/claims/explain` | CLI/API/MCP | read-only | Bounded authorized trace over current/history/competing claims, exact source premises, invalidation state, and reverse lineage. Fabricated or cross-scope premises fail closed. |
 | `GET /api/ontology/claims/versions` | CLI/API | read-only | Covered by version chain tests. |
 | `GET /api/ontology/claims/version` | CLI/API | read-only | Covered by version show tests. |
 | `GET /api/ontology/links/:id/evidence` | CLI/API | read-only | Covered by link evidence tests. |
@@ -66,6 +67,7 @@ graph control plane. It is not a speculative product spec.
 | `signet ontology assertion show/create/link-claim/archive/supersede/import` | CLI | assertion ledger writes | Creates and maintains attributed assertion rows. `supersede` preserves the old predicate when `--predicate` is omitted. `import` accepts a JSON array or `{ "assertions": [...] }`. |
 | `signet ontology entity create/rename/merge/archive` | CLI | direct operation endpoint | Applies by default with audit/provenance. Supports `--dry-run`, `--propose`, `--json`, `--agent`, `--actor`, `--reason`, `--evidence-file`; reserve `--propose` for broad refactors or explicit review. |
 | `signet ontology claim set/versions/show/archive/restore` | CLI | operation endpoint for writes, read endpoints for versions | `set` creates version chains; `restore` only required for claim versions in this slice. |
+| `signet ontology explain-claim <entity> <aspect> <group> <claim>` | CLI | read-only | Uses the canonical HTTP trace; accepts bounded version/premise/reverse limits and optional `--session-key`. |
 | `signet ontology aspect create/rename/archive` | CLI | direct operation endpoint | Uses same audited operation path. |
 | `signet ontology link create/update/archive` | CLI | direct operation endpoint | Uses `entity_dependencies`. |
 | `signet ontology stream apply <path|- >` | CLI | atomic JSONL operation batch | Supports file and stdin, `--dry-run`, `--propose`, `--json`, `--agent`, `--actor`. |

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -33,6 +33,7 @@ flowchart TD
   OEC[Ontology Evolution Core]
   OGW[Ontology Governance Workflow]
   OPL[Ontology Proposal Loop]
+  ACT[Authorized Claim Trace]
   SSF[SSM Foundation Eval]
   EIPT[Engram-Informed Predictor Track]
   SST[SSM Temporal Backbone]
@@ -73,6 +74,9 @@ flowchart TD
   DP --> OEC
   OEC --> OGW
   KA --> OPL
+  KA --> ACT
+  MA --> ACT
+  SR --> ACT
   DMC -.-> OPL
   PMS --> SSF
   DP --> SSF
@@ -630,6 +634,11 @@ Phase ordering based on hard dependencies and integration contracts.
   - proposal/review gates for ontology-impacting schema changes
   - compatibility + rollback requirements
   - CI checks for INDEX/dependencies contract drift
+- **Authorized Claim Trace**: approved (`authorized-claim-trace`)
+  - expose current/history/competing claim state and existing source lineage
+  - preserve agent, project, and session authorization while failing closed on
+    fabricated or cross-scope premises
+  - keep reverse traversal bounded and report invalidated evidence explicitly
 
 ### Wave 8 (SSM translation and shadow deployment)
 
@@ -732,6 +741,7 @@ Legend:
 | `procedural-memory-plan` | approved | `docs/specs/approved/procedural-memory-plan.md` | `memory-pipeline-v2` | `knowledge-architecture-schema` | P1 complete; P2 usage ledger + `skill_meta` usage updates shipped, with decay and broader retrieval follow-ups still remaining |
 | `knowledge-architecture-schema` | complete | `docs/specs/complete/knowledge-architecture-schema.md` | `memory-pipeline-v2`, `session-continuity-protocol`, `procedural-memory-plan` | `predictive-memory-scorer` | KA-1 through KA-6 fully implemented. Audit contract: `entity_dependency_history` captures all dependency mutations via DB-level triggers (`changed_by='db-trigger'`); `related_to` edges require a non-empty reason enforced at both app layer and DB BEFORE INSERT/UPDATE triggers. |
 | `knowledge-architecture-navigation` | approved | `docs/specs/approved/knowledge-architecture-navigation.md` | `knowledge-architecture-schema` | - | Entity/aspect/group/claim/attribute navigation surface for MCP and daemon API. |
+| `authorized-claim-trace` | approved | `docs/specs/approved/authorized-claim-trace.md` | `knowledge-architecture-schema`, `knowledge-architecture-navigation`, `multi-agent-support`, `signet-runtime` | - | Read-only bounded claim reasoning trace over existing versions, assertions, episodic evidence, and derived-memory provenance; fail-closed agent/project/session authorization. |
 | `predictive-memory-scorer` | approved | `docs/specs/approved/predictive-memory-scorer.md` | `memory-pipeline-v2`, `knowledge-architecture-schema`, `session-continuity-protocol` | - | |
 | `multi-agent-support` | approved | `docs/specs/approved/multi-agent-support.md` | `memory-pipeline-v2` | - | |
 | `cross-agent-notification-delivery` | approved | `docs/specs/approved/cross-agent-notification-delivery.md` | `multi-agent-support`, `signet-runtime` | - | Durable agent-scoped peer inbox, explicit acknowledgement, and next-compatible-hook delivery for issue #944 |

--- a/docs/specs/approved/authorized-claim-trace.md
+++ b/docs/specs/approved/authorized-claim-trace.md
@@ -1,0 +1,135 @@
+---
+title: "Authorized Claim Trace"
+id: authorized-claim-trace
+status: approved
+informed_by:
+  - "docs/specs/complete/knowledge-architecture-schema.md"
+  - "docs/specs/approved/knowledge-architecture-navigation.md"
+  - "docs/specs/approved/multi-agent-support.md"
+  - "docs/specs/approved/dreaming-memory-consolidation.md"
+section: "Knowledge Architecture"
+depends_on:
+  - "knowledge-architecture-schema"
+  - "knowledge-architecture-navigation"
+  - "multi-agent-support"
+  - "signet-runtime"
+success_criteria:
+  - "An authorized caller can inspect current truth, bounded claim history, competing assertions, exact source spans, and derived-memory premises through one read-only contract."
+  - "Every returned premise is resolved through the existing agent-scoped source and session authorization path; fabricated, cross-agent, cross-project, or cross-session references fail closed."
+  - "Deleted, superseded, stale, and incomplete evidence is reported as invalidated or unverified rather than presented as current truth."
+  - "Reverse lineage and version traversal remain bounded and expose truncation and traversal limits."
+  - "HTTP, CLI, and MCP consumers expose the same trace operation without creating a second provenance store."
+scope_boundary: "Read-only claim explanation over existing entity_attributes, epistemic_assertions, ontology_proposals, memories, episodic sources, and derived_memory_sources. No new derivation store, cross-agent read policy, or claim mutation behavior."
+---
+
+# Authorized Claim Trace
+
+## Problem
+
+The ontology already stores the pieces needed to explain a claim: version
+links on `entity_attributes`, proposal evidence, source-attributed
+`epistemic_assertions`, semantic memories, and the canonical
+`derived_memory_sources` relation. Existing claim evidence and version
+endpoints expose those pieces separately, while a caller still has to join
+them manually. That makes it easy to mistake a superseded value for current
+truth or to accept an embedded quote whose source no longer exists.
+
+Issue #1318 adds one bounded, read-only explanation operation. It is an
+authorized view over existing rows, not a new lineage database.
+
+## Contract
+
+`GET /api/ontology/claims/explain` accepts:
+
+| Query | Required | Bounds |
+|---|---:|---|
+| `entity`, `aspect`, `group`, `claim` | yes | non-empty path selectors |
+| `kind` | no | `attribute` or `constraint` |
+| `version_limit` | no | 1–50, default 20 |
+| `premise_limit` | no | 1–100, default 50 |
+| `reverse_limit` | no | 1–100, default 50 |
+| `max_depth` | no | 0–3, default 3 |
+| `agent_id` | no | resolved through the normal scoped-agent path |
+| `session_key` | no | optional fail-closed session boundary |
+
+The same `session_key` may be supplied as `x-signet-session-key`; conflicting
+values are rejected. Remote calls must bind the session to the resolved
+agent before the trace is read.
+
+The response contains:
+
+- `current`: active claim versions and a status of `active`, `competing`, or
+  `historical`;
+- `versions`: prior and superseded versions, with `truncated`;
+- `competing`: active competing values and linked `denies` assertions;
+- `assertions`: linked, agent-scoped epistemic assertions;
+- `premises.items`: source kind/id/path, exact verified quote when supplied,
+  bounded excerpt, lifecycle state, source scope metadata, and the owning
+  derived-memory id when the premise came from a derived-memory relation
+  (`null` for assertion-only evidence);
+- `reverse`: bounded derived claims that cite the returned claim's semantic
+  memory;
+- `authorization`: resolved agent/project/session decisions and the fact that
+  the read path is `recall`;
+- `integrity`: `verified`, `unverified`, or `invalidated`, plus counts and a
+  reason when exact evidence cannot support current certainty;
+- `traversal`: all limits, visited counts, and bounded traversal metadata;
+- `latencyMs`: local operation latency for evaluation.
+
+`premises` are not accepted merely because a JSON object contains a quote. A
+reference must identify one of the canonical episodic source kinds
+(`memory`, `artifact`, `transcript`, or `summary`) and the referenced row must
+exist for the same agent. If an exact quote is provided, it must occur in the
+immutable source content. A missing source id or a mismatched quote returns a
+conflict error; a source owned by another agent or outside the authorized
+project/session returns forbidden. Session-scoped calls fail closed when a
+source's session cannot be proven or does not match the requested session.
+
+Deleted or stale source rows remain visible only as bounded lifecycle metadata
+when the caller is authorized to see that row. They never contribute a
+verified quote. The response therefore distinguishes an explanation of what
+was once believed from a current, verified claim.
+
+## Source of truth and invariants
+
+1. `entity_attributes` remains the current/history claim store.
+2. `epistemic_assertions` remains the attributed statement store; `denies`
+   assertions are contradictory context, not current truth.
+3. `derived_memory_sources` remains the only reverse-indexed premise relation
+   for derived semantic memories.
+4. Every ontology query filters by the resolved `agent_id`; the operation does
+   not reuse shared/global recall to widen graph visibility.
+5. Project authorization follows the token project scope used by recall for
+   linked semantic claim memories, source premises, and reverse dependents.
+6. Session authorization uses the existing session-agent binding and requires
+   a provable source session for session-scoped traces.
+7. Limits are enforced before traversal and truncation is explicit.
+
+## Surface parity
+
+- HTTP is the canonical operation.
+- CLI: `signet ontology explain-claim <entity> <aspect> <group> <claim>`.
+- MCP: `signet_explain_claim`.
+
+All three surfaces pass the same selectors, limits, agent scope, and optional
+session boundary to the HTTP operation. They do not perform local joins or
+source authorization.
+
+## Evaluation
+
+The runnable claim-trace evaluation uses fixed local rows and pass/fail
+assertions for:
+
+1. changed preferences: current and prior versions are both present;
+2. competing values and contradictory assertions: both are surfaced without
+   collapsing them into one unsupported truth;
+3. multi-session derivations: an allowlisted session cannot read a premise
+   from another session;
+4. deleted evidence: dependent claims report invalidated integrity;
+5. cross-agent sources and fabricated source ids: both fail closed;
+6. reverse traversal: dependent claims are bounded and report limits.
+
+The evaluation prints scenario accuracy (passed expected outcomes divided by
+scenario count), unsupported-certainty count, latency, and one canonical
+operation count. A non-zero exit status means any expected pass/fail assertion
+failed.

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -1,5 +1,5 @@
 version: 3
-updated_at: "2026-05-06"
+updated_at: "2026-08-10"
 
 specs:
   - id: memory-pipeline-v2
@@ -338,6 +338,30 @@ specs:
       - "Prompt-submit recall remains a lightweight injection path and does not absorb explicit recall product concerns"
       - "Legacy or duplicate TypeScript recall helpers are either removed or reduced to thin wrappers around the canonical recall path"
       - "Consumer renderers preserve useful recall metadata instead of flattening results into source-less snippet lists"
+    decision: null
+
+  - id: authorized-claim-trace
+    status: approved
+    path: docs/specs/approved/authorized-claim-trace.md
+    hard_depends_on:
+      - knowledge-architecture-schema
+      - knowledge-architecture-navigation
+      - multi-agent-support
+      - signet-runtime
+    soft_depends_on:
+      - dreaming-memory-consolidation
+      - explicit-recall-surface-alignment
+    blocks: []
+    informed_by:
+      - docs/specs/complete/knowledge-architecture-schema.md
+      - docs/specs/approved/knowledge-architecture-navigation.md
+      - docs/specs/approved/multi-agent-support.md
+      - docs/specs/approved/dreaming-memory-consolidation.md
+    success_criteria:
+      - "An authorized caller can inspect bounded current/history/competing claim state and existing source lineage without a second provenance store"
+      - "Fabricated, cross-agent, cross-project, and cross-session premise references fail closed"
+      - "Deleted, superseded, stale, and incomplete evidence is marked invalidated or unverified instead of presented as verified current truth"
+      - "HTTP, CLI, and MCP expose one parity operation with explicit limits and truncation"
     decision: null
 
   - id: semantic-prospective-hints

--- a/integrations/claude-code/connector/package.json
+++ b/integrations/claude-code/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-claude-code",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet connector for Claude Code (Anthropic CLI)",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.3",
-    "@signet/core": "0.193.3"
+    "@signet/connector-base": "0.194.0",
+    "@signet/core": "0.194.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/claude-code/connector/package.json
+++ b/integrations/claude-code/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-claude-code",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet connector for Claude Code (Anthropic CLI)",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.2",
-    "@signet/core": "0.193.2"
+    "@signet/connector-base": "0.193.3",
+    "@signet/core": "0.193.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/claude-code/connector/package.json
+++ b/integrations/claude-code/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-claude-code",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet connector for Claude Code (Anthropic CLI)",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.194.0",
-    "@signet/core": "0.194.0"
+    "@signet/connector-base": "0.194.1",
+    "@signet/core": "0.194.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/codex/connector/package.json
+++ b/integrations/codex/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-codex",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet connector for Codex CLI",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.2",
-    "@signet/core": "0.193.2"
+    "@signet/connector-base": "0.193.3",
+    "@signet/core": "0.193.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/codex/connector/package.json
+++ b/integrations/codex/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-codex",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet connector for Codex CLI",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.194.0",
-    "@signet/core": "0.194.0"
+    "@signet/connector-base": "0.194.1",
+    "@signet/core": "0.194.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/codex/connector/package.json
+++ b/integrations/codex/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-codex",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet connector for Codex CLI",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.3",
-    "@signet/core": "0.193.3"
+    "@signet/connector-base": "0.194.0",
+    "@signet/core": "0.194.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/codex/plugin/package.json
+++ b/integrations/codex/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/codex-plugin",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Native Codex plugin installer for Signet",
   "type": "module",
   "bin": {
@@ -13,8 +13,8 @@
     "test": "node bin/install.js --help >/dev/null"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.2",
-    "@signet/connector-codex": "0.193.2"
+    "@signet/connector-base": "0.193.3",
+    "@signet/connector-codex": "0.193.3"
   },
   "keywords": [
     "signet",

--- a/integrations/codex/plugin/package.json
+++ b/integrations/codex/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/codex-plugin",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Native Codex plugin installer for Signet",
   "type": "module",
   "bin": {
@@ -13,8 +13,8 @@
     "test": "node bin/install.js --help >/dev/null"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.3",
-    "@signet/connector-codex": "0.193.3"
+    "@signet/connector-base": "0.194.0",
+    "@signet/connector-codex": "0.194.0"
   },
   "keywords": [
     "signet",

--- a/integrations/codex/plugin/package.json
+++ b/integrations/codex/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/codex-plugin",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Native Codex plugin installer for Signet",
   "type": "module",
   "bin": {
@@ -13,8 +13,8 @@
     "test": "node bin/install.js --help >/dev/null"
   },
   "dependencies": {
-    "@signet/connector-base": "0.194.0",
-    "@signet/connector-codex": "0.194.0"
+    "@signet/connector-base": "0.194.1",
+    "@signet/connector-codex": "0.194.1"
   },
   "keywords": [
     "signet",

--- a/integrations/forge/connector/package.json
+++ b/integrations/forge/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-forge",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet connector for ForgeCode - installs MCP, identity, and skills integration",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.3",
-    "@signet/core": "0.193.3"
+    "@signet/connector-base": "0.194.0",
+    "@signet/core": "0.194.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/forge/connector/package.json
+++ b/integrations/forge/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-forge",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet connector for ForgeCode - installs MCP, identity, and skills integration",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.2",
-    "@signet/core": "0.193.2"
+    "@signet/connector-base": "0.193.3",
+    "@signet/core": "0.193.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/forge/connector/package.json
+++ b/integrations/forge/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-forge",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet connector for ForgeCode - installs MCP, identity, and skills integration",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.194.0",
-    "@signet/core": "0.194.0"
+    "@signet/connector-base": "0.194.1",
+    "@signet/core": "0.194.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/gemini/connector/package.json
+++ b/integrations/gemini/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-gemini",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet connector for Gemini CLI",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.3",
-    "@signet/core": "0.193.3"
+    "@signet/connector-base": "0.194.0",
+    "@signet/core": "0.194.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/gemini/connector/package.json
+++ b/integrations/gemini/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-gemini",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet connector for Gemini CLI",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.2",
-    "@signet/core": "0.193.2"
+    "@signet/connector-base": "0.193.3",
+    "@signet/core": "0.193.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/gemini/connector/package.json
+++ b/integrations/gemini/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-gemini",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet connector for Gemini CLI",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.194.0",
-    "@signet/core": "0.194.0"
+    "@signet/connector-base": "0.194.1",
+    "@signet/core": "0.194.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -41,3 +41,13 @@ The connector package exposes programmatic cleanup that restores the previous me
 ```
 
 The connector extends `BaseConnector` from `@signet/connector-base` and ships a bundled Python plugin (`__init__.py`, `client.py`, `plugin.yaml`).
+
+## Built-in memory mirror
+
+Committed Hermes built-in memory writes are synchronized into Signet: adds
+create episodic evidence, replacements create a new row that supersedes the
+old mirrored row, and removals soft-delete it. Historical rows remain
+auditable, while superseded/deleted rows are excluded from current recall.
+Callbacks are processed FIFO after Hermes's atomic batch commit and carry
+agent, project, session, source, visibility, and deterministic idempotency
+provenance so retries cannot recreate stale current context.

--- a/integrations/hermes-agent/connector/hermes-plugin/README.md
+++ b/integrations/hermes-agent/connector/hermes-plugin/README.md
@@ -26,7 +26,7 @@ Environment variables:
 - `SIGNET_HOST` / `SIGNET_PORT` — Host and port separately
 - `SIGNET_TOKEN` — Optional daemon bearer token; sent to loopback daemon URLs by default
 - `SIGNET_TRUSTED_DAEMON_ORIGINS` — Comma-separated remote daemon origins allowed to receive `SIGNET_TOKEN`
-- `SIGNET_AGENT_ID` — Agent scope identifier (default: `hermes-agent`)
+- `SIGNET_AGENT_ID` — Agent scope identifier (unset: inherit the daemon's configured agent, usually `default`)
 - `SIGNET_AGENT_WORKSPACE` — Optional named-agent workspace path (for example `~/.agents/agents/dot`)
 - `SIGNET_AGENT_READ_POLICY` — Optional named-agent memory policy for first registration: `shared` (default), `isolated`, or `group`
 - `SIGNET_AGENT_POLICY_GROUP` — Required when `SIGNET_AGENT_READ_POLICY=group`
@@ -63,3 +63,24 @@ The plugin bridges Hermes Agent's memory lifecycle to the Signet daemon:
 3. **Session end** — Sends a transcript with internal Signet memory delimiters removed to Signet's session-end hook, which queues it for the memory pipeline: extraction, knowledge graph updates, retention decay, and MEMORY.md synthesis.
 
 4. **Explicit tools** — The agent can call canonical Signet tools such as `memory_search` and `memory_store` directly during conversation for on-demand memory operations. Legacy `signet_*` names are handled for compatibility but are not advertised to the model.
+
+## Built-in memory synchronization
+
+The plugin uses a **synchronization** model for Hermes's built-in
+`on_memory_write()` hook:
+
+- `add` creates an immutable episodic Signet row tagged with
+  `hermes-builtin` and the Hermes target (`memory` or `user`).
+- `replace` creates a new episodic row and atomically supersedes the mirrored
+  row identified by Hermes's `old_text`.
+- `remove` soft-deletes the matching mirrored row.
+
+Superseded and soft-deleted rows remain available as historical evidence and
+audit history, but Signet's current recall/list views exclude them. The
+connector queues hook callbacks on one FIFO worker, so operations emitted for
+an already-committed Hermes batch retain their order. Each operation carries
+session, project, agent, source, and a deterministic idempotency key. Mirror
+rows use Signet's default `global` visibility, matching the connector's prior
+write contract; agent and project filters still bound lookup and mutation.
+Retrying the same callback does not create a second current row. A failed
+lookup never falls back to mutating an untagged Signet memory.

--- a/integrations/hermes-agent/connector/hermes-plugin/__init__.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/__init__.py
@@ -20,12 +20,15 @@ Config:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
 import re
 import threading
+import time
 from pathlib import Path
+from queue import Empty, Queue
 from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
@@ -302,6 +305,11 @@ ALL_TOOL_SCHEMAS = [
     REMEMBER_ALIAS_SCHEMA,
 ]
 
+HERMES_MEMORY_SOURCE_TYPE = "hermes-memory-write"
+HERMES_MEMORY_TAG = "hermes-builtin"
+MIRROR_SEARCH_LIMIT = 100
+
+
 def _sanitize_env(value: str) -> str:
     return value.strip().replace("\r", "").replace("\n", "")
 
@@ -337,6 +345,7 @@ class SignetMemoryProvider(MemoryProvider):
 
     def __init__(self):
         self._client = None  # SignetClient
+        self._agent_id = ""
         self._session_key = ""
         self._project = ""
         self._inject_cache = ""
@@ -362,6 +371,13 @@ class SignetMemoryProvider(MemoryProvider):
         _CHECKPOINT_INTERVAL = 30
         self._checkpoint_interval = _CHECKPOINT_INTERVAL
         self._last_checkpoint_turn = 0
+        # Hermes calls on_memory_write once per committed operation, including
+        # once for each operation in an atomic batch. Keep one FIFO worker so
+        # replace/remove cannot overtake the add that established their target.
+        self._mirror_queue: Queue = Queue()
+        self._mirror_worker: Optional[threading.Thread] = None
+        self._mirror_state_lock = threading.Lock()
+        self._mirror_shutdown = False
 
     @property
     def name(self) -> str:
@@ -431,6 +447,10 @@ class SignetMemoryProvider(MemoryProvider):
             # No explicit agent id: the daemon resolves its configured agent
             # (its own SIGNET_AGENT_ID, or 'default' for the default workspace).
             logger.debug("SIGNET_AGENT_ID is not set; the daemon's configured agent scope applies.")
+
+        self._agent_id = agent_id
+        with self._mirror_state_lock:
+            self._mirror_shutdown = False
 
         # Skip for cron/flush contexts — no memory injection needed
         agent_context = kwargs.get("agent_context", "")
@@ -698,7 +718,7 @@ class SignetMemoryProvider(MemoryProvider):
             self._prefetch_result = ""
             self._notification_result = ""
 
-        agent_id = os.environ.get("SIGNET_AGENT_ID", "").strip() or "hermes-agent"
+        agent_id = self._agent_id
         self._project = _resolve_agent_workspace(agent_id, kwargs)
         client = self._client
         if not client:
@@ -723,49 +743,406 @@ class SignetMemoryProvider(MemoryProvider):
         except Exception as e:
             logger.debug("Signet session switch failed: %s", e)
 
-    def on_memory_write(self, action: str, target: str, content: str, metadata: Optional[Dict[str, Any]] = None) -> None:
-        """Mirror built-in memory writes to Signet."""
-        if action != "add" or not content:
+    @staticmethod
+    def _mirror_tags(raw: Any) -> set[str]:
+        if isinstance(raw, list):
+            return {str(tag).strip() for tag in raw if str(tag).strip()}
+        if isinstance(raw, str):
+            return {tag.strip() for tag in raw.split(",") if tag.strip()}
+        return set()
+
+    @staticmethod
+    def _mirror_tag(prefix: str, value: str) -> str:
+        clean = value.replace("\n", " ").replace("\r", " ").strip()
+        return f"{prefix}:{clean[:80]}" if clean else ""
+
+    def _mirror_operation_details(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Dict[str, Any],
+    ) -> Dict[str, str]:
+        """Derive durable, retry-stable identity for one Hermes write."""
+        old_text = str(metadata.get("old_text", "") or "").strip()
+        session_id = str(
+            metadata.get("session_id", "")
+            or metadata.get("_mirror_session_key", "")
+            or self._session_key
+        ).strip()
+        parent_session_id = str(metadata.get("parent_session_id", "") or "").strip()
+        tool_call_id = str(metadata.get("tool_call_id", "") or "").strip()
+        project = str(metadata.get("_mirror_project", self._project) or "").strip()
+        agent_id = str(metadata.get("_mirror_agent_id", self._agent_id) or "").strip()
+        seed = "\0".join(
+            (
+                agent_id,
+                project,
+                session_id,
+                parent_session_id,
+                target,
+                action,
+                old_text,
+                content,
+                tool_call_id,
+            )
+        )
+        digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()
+        operation_key = f"hermes-memory-write:{digest}"
+
+        # Preserve Hermes's tool-call id as the source id for the common add
+        # path. Replacements get an operation-specific suffix because every
+        # operation in a Hermes batch shares one tool-call id.
+        if tool_call_id and action == "add":
+            source_id = tool_call_id
+        elif tool_call_id:
+            source_id = f"{tool_call_id}:{action}:{digest[:16]}"
+        else:
+            source_id = f"hermes-memory-write:{digest}"
+
+        return {
+            "old_text": old_text,
+            "session_id": session_id,
+            "request_id": operation_key,
+            "source_id": source_id,
+            "idempotency_key": operation_key,
+            "mirror_tag": f"mirror:{digest[:24]}",
+            "project": project,
+            "agent_id": agent_id,
+        }
+
+    def _mirror_write_tags(
+        self,
+        target: str,
+        metadata: Dict[str, Any],
+        operation_tag: str,
+        session_id: str,
+    ) -> List[str]:
+        tags = [HERMES_MEMORY_TAG, target, operation_tag]
+        for tag in (
+            self._mirror_tag(
+                "origin",
+                str(metadata.get("write_origin", "") or metadata.get("source", "")),
+            ),
+            self._mirror_tag("context", str(metadata.get("execution_context", "") or "")),
+            self._mirror_tag("platform", str(metadata.get("platform", "") or "")),
+            self._mirror_tag("session", session_id),
+            self._mirror_tag("parent-session", str(metadata.get("parent_session_id", "") or "")),
+            self._mirror_tag("tool", str(metadata.get("tool_name", "") or "")),
+        ):
+            if tag:
+                tags.append(tag)
+        return tags
+
+    def _find_mirrored_entries(
+        self,
+        query: str,
+        target: str,
+        *,
+        client: Any = None,
+        project: str = "",
+        source_id: str = "",
+        operation_tag: str = "",
+    ) -> List[Dict[str, Any]]:
+        """Find active Hermes rows without crossing project/agent boundaries."""
+        client = client or self._client
+        if not client:
+            return []
+        scoped_project = project or self._project
+        rows = client.search(
+            query,
+            limit=MIRROR_SEARCH_LIMIT,
+            tags=HERMES_MEMORY_TAG,
+            project=scoped_project,
+        )
+
+        matches: List[Dict[str, Any]] = []
+        for row in rows or []:
+            if not isinstance(row, dict):
+                continue
+            content = str(row.get("content", "") or "")
+            tags = self._mirror_tags(row.get("tags"))
+            row_source_id = str(row.get("source_id", "") or row.get("sourceId", "") or "")
+            if HERMES_MEMORY_TAG not in tags or target not in tags:
+                continue
+            if source_id and row_source_id != source_id and operation_tag not in tags:
+                continue
+            if operation_tag and operation_tag not in tags:
+                continue
+            if query and query not in content:
+                continue
+            matches.append(row)
+        return matches
+
+    def _remember_mirror(
+        self,
+        content: str,
+        *,
+        client: Any = None,
+        tags: List[str],
+        project: str,
+        source_id: str,
+        operation_key: str,
+        visibility: str = "global",
+        supersedes: str = "",
+        reason: str = "",
+        session_id: str = "",
+        request_id: str = "",
+    ) -> Optional[Dict[str, Any]]:
+        """Write one mirror row, retrying a source-id collision safely."""
+        client = client or self._client
+        if not client:
+            return None
+        result = client.remember(
+            content,
+            importance=0.6,
+            tags=tags,
+            project=project,
+            visibility=visibility,
+            source_type=HERMES_MEMORY_SOURCE_TYPE,
+            source_id=source_id,
+            idempotency_key=operation_key,
+            supersedes=supersedes,
+            reason=reason,
+            session_id=session_id,
+            request_id=request_id,
+        )
+        if not result or not isinstance(result, dict):
+            return result
+
+        # A tool-call id is shared by every operation in a Hermes batch. If an
+        # earlier add claimed that source id, retry the new operation with its
+        # content-derived id rather than accepting a false dedupe.
+        returned_content = str(result.get("content", "") or "").strip()
+        if result.get("deduped") is True and returned_content and returned_content != content.strip():
+            fallback_source_id = f"{source_id}:{operation_key[-16:]}"
+            return client.remember(
+                content,
+                importance=0.6,
+                tags=tags,
+                project=project,
+                visibility=visibility,
+                source_type=HERMES_MEMORY_SOURCE_TYPE,
+                source_id=fallback_source_id,
+                idempotency_key=operation_key,
+                supersedes=supersedes,
+                reason=reason,
+                session_id=session_id,
+                request_id=request_id,
+            )
+        return result
+
+    def _mirror_operation(
+        self,
+        client: Any,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Dict[str, Any],
+    ) -> None:
+        if not client:
+            return
+
+        details = self._mirror_operation_details(action, target, content, metadata)
+        old_text = details["old_text"]
+        session_id = details["session_id"]
+        source_id = details["source_id"]
+        operation_key = details["idempotency_key"]
+        operation_tag = details["mirror_tag"]
+        tags = self._mirror_write_tags(target, metadata, operation_tag, session_id)
+        request_id = details["request_id"]
+        project = details["project"]
+
+        if action == "add":
+            result = self._remember_mirror(
+                content,
+                client=client,
+                tags=tags,
+                project=project,
+                source_id=source_id,
+                operation_key=operation_key,
+                session_id=session_id,
+                request_id=request_id,
+            )
+            if result is None:
+                logger.warning("Signet Hermes add mirror returned no response")
+            return
+
+        if not old_text:
+            logger.warning("Signet Hermes %s mirror skipped: old_text was not supplied", action)
+            return
+
+        if action == "replace":
+            if not content:
+                logger.warning("Signet Hermes replace mirror skipped: content was empty")
+                return
+
+            # A completed replace is found by its operation tag/source id. This
+            # makes a retry a no-op even though the old row is no longer in the
+            # current recall view.
+            completed = self._find_mirrored_entries(
+                content,
+                target,
+                client=client,
+                project=project,
+                source_id=source_id,
+                operation_tag=operation_tag,
+            )
+            if completed:
+                return
+
+            matches = self._find_mirrored_entries(old_text, target, client=client, project=project)
+            distinct_contents = {str(row.get("content", "")) for row in matches}
+            if len(distinct_contents) > 1:
+                logger.warning(
+                    "Signet Hermes replace mirror skipped: old_text matched multiple mirrored entries"
+                )
+                return
+            if not matches:
+                # The old row may already have been superseded by a prior
+                # delivery. No current stale row can be reintroduced.
+                logger.debug("Signet Hermes replace mirror found no active source row")
+                return
+
+            old_id = str(matches[0].get("id", "") or "").strip()
+            if not old_id:
+                logger.warning("Signet Hermes replace mirror skipped: matched row had no id")
+                return
+            result = self._remember_mirror(
+                content,
+                client=client,
+                tags=tags,
+                project=project,
+                source_id=source_id,
+                operation_key=operation_key,
+                supersedes=old_id,
+                reason="Hermes built-in memory replacement",
+                session_id=session_id,
+                request_id=request_id,
+            )
+            if not result:
+                logger.warning("Signet Hermes replace mirror returned no response")
+                return
+
+            # A content/source dedupe can return an existing current row before
+            # the daemon sees `supersedes`. Link that row explicitly so the old
+            # Hermes entry still cannot remain current.
+            if result.get("deduped") is True:
+                replacement_id = str(result.get("id", "") or "").strip()
+                if replacement_id and replacement_id != old_id and hasattr(client, "supersede_memory"):
+                    linked = client.supersede_memory(
+                        old_id,
+                        replacement_id,
+                        reason="Hermes built-in memory replacement",
+                        session_id=session_id,
+                        request_id=request_id,
+                    )
+                    if linked is None:
+                        logger.warning("Signet Hermes replace mirror could not link a deduped replacement")
+            return
+
+        if action == "remove":
+            matches = self._find_mirrored_entries(old_text, target, client=client, project=project)
+            distinct_contents = {str(row.get("content", "")) for row in matches}
+            if len(distinct_contents) > 1:
+                logger.warning(
+                    "Signet Hermes remove mirror skipped: old_text matched multiple mirrored entries"
+                )
+                return
+            if not matches:
+                # Soft-delete is idempotent from the current-view perspective:
+                # a prior delivery already removed this row, or it was never
+                # mirrored. In neither case should a stale row be recreated.
+                return
+            memory_id = str(matches[0].get("id", "") or "").strip()
+            if not memory_id:
+                logger.warning("Signet Hermes remove mirror skipped: matched row had no id")
+                return
+            result = client.forget_memory(
+                memory_id,
+                reason="Hermes built-in memory removal",
+                session_id=session_id,
+                request_id=request_id,
+            )
+            if result is None:
+                logger.warning("Signet Hermes remove mirror returned no response")
+
+    def _mirror_worker_loop(self) -> None:
+        while True:
+            try:
+                client, action, target, content, metadata = self._mirror_queue.get(timeout=0.1)
+            except Empty:
+                with self._mirror_state_lock:
+                    if self._mirror_shutdown or self._mirror_queue.empty():
+                        self._mirror_worker = None
+                        return
+                continue
+            try:
+                self._mirror_operation(client, action, target, content, metadata)
+            except Exception as e:
+                logger.warning(
+                    "Signet Hermes memory mirror failed for %s/%s: %s",
+                    action,
+                    target,
+                    e,
+                )
+            finally:
+                self._mirror_queue.task_done()
+
+    def flush_mirror_writes(self, timeout: float = 5.0) -> bool:
+        """Wait for queued mirror operations, primarily for shutdown/tests."""
+        deadline = time.monotonic() + max(0.0, timeout)
+        while self._mirror_queue.unfinished_tasks > 0 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        return self._mirror_queue.unfinished_tasks == 0
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Mirror committed Hermes memory writes in FIFO order.
+
+        Hermes only calls this after the built-in memory tool commits. The
+        single daemon worker therefore preserves the order of atomic batch
+        operations without blocking the agent turn on a network request.
+        """
+        if not isinstance(action, str) or not isinstance(target, str) or not isinstance(content, str):
+            logger.warning("Signet Hermes memory mirror skipped malformed operation")
+            return
+        action = action.strip()
+        target = target.strip()
+        content = content.strip()
+        if action not in {"add", "replace", "remove"}:
+            return
+        if action in {"add", "replace"} and not content:
+            return
+        if target not in {"memory", "user"}:
+            logger.warning("Signet Hermes memory mirror skipped unknown target: %s", target)
             return
         client = self._client
         if not client:
             return
-        project = self._project
-        metadata = metadata if isinstance(metadata, dict) else {}
-        write_origin = str(metadata.get("write_origin", "") or metadata.get("source", "")).strip()
-        execution_context = str(metadata.get("execution_context", "")).strip()
-        platform = str(metadata.get("platform", "")).strip()
-        source_id = str(metadata.get("tool_call_id", "") or "").strip()
-        session_id = str(metadata.get("session_id", "") or self._session_key).strip()
-
-        def _tag(prefix: str, value: str) -> str:
-            clean = value.replace("\n", " ").replace("\r", " ").strip()
-            return f"{prefix}:{clean[:80]}" if clean else ""
-
-        def _write():
-            try:
-                tags = ["hermes-builtin", target]
-                for tag in (
-                    _tag("origin", write_origin),
-                    _tag("context", execution_context),
-                    _tag("platform", platform),
-                    _tag("session", session_id),
-                ):
-                    if tag:
-                        tags.append(tag)
-                client.remember(
-                    content,
-                    importance=0.6,
-                    tags=tags,
-                    project=project,
-                    source_type="hermes-memory-write" if source_id else "",
-                    source_id=source_id,
+        snapshot = dict(metadata) if isinstance(metadata, dict) else {}
+        snapshot["_mirror_project"] = self._project
+        snapshot["_mirror_agent_id"] = self._agent_id or str(
+            getattr(client, "_agent_id", "") or ""
+        )
+        snapshot["_mirror_session_key"] = self._session_key
+        with self._mirror_state_lock:
+            if self._mirror_shutdown:
+                logger.debug("Signet Hermes memory mirror rejected after shutdown")
+                return
+            self._mirror_queue.put((client, action, target, content, snapshot))
+            if self._mirror_worker is None or not self._mirror_worker.is_alive():
+                self._mirror_worker = threading.Thread(
+                    target=self._mirror_worker_loop,
+                    daemon=True,
+                    name="signet-memwrite-serial",
                 )
-            except Exception as e:
-                logger.debug("Signet memory mirror failed: %s", e)
-
-        t = threading.Thread(target=_write, daemon=True, name="signet-memwrite")
-        t.start()
+                self._mirror_worker.start()
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Call session-end hook to trigger memory extraction from transcript."""
@@ -1134,6 +1511,12 @@ class SignetMemoryProvider(MemoryProvider):
 
     def shutdown(self) -> None:
         """Clean shutdown — wait for background threads."""
+        with self._mirror_state_lock:
+            self._mirror_shutdown = True
+            mirror_worker = self._mirror_worker
+        self.flush_mirror_writes(timeout=5.0)
+        if mirror_worker and mirror_worker.is_alive():
+            mirror_worker.join(timeout=0.1)
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=5.0)
 

--- a/integrations/hermes-agent/connector/hermes-plugin/client.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/client.py
@@ -194,6 +194,22 @@ class SignetClient:
             h.update(extra)
         return h
 
+    @staticmethod
+    def _mutation_context_headers(
+        *,
+        session_id: str = "",
+        request_id: str = "",
+    ) -> Optional[Dict[str, str]]:
+        """Build optional audit headers for a mirrored memory mutation."""
+        headers: Dict[str, str] = {}
+        clean_session_id = _sanitize(session_id)
+        clean_request_id = _sanitize(request_id)
+        if clean_session_id:
+            headers["x-signet-session-id"] = clean_session_id
+        if clean_request_id:
+            headers["x-signet-request-id"] = clean_request_id
+        return headers or None
+
     def _post(
         self,
         path: str,
@@ -261,10 +277,11 @@ class SignetClient:
         path: str,
         *,
         timeout: float = _TIMEOUT_SECS,
+        extra_headers: Optional[Dict[str, str]] = None,
     ) -> Optional[Dict[str, Any]]:
         """DELETE from the daemon. Returns parsed response or None on failure."""
         url = f"{self._base_url}{path}"
-        req = urllib.request.Request(url, headers=self._headers(), method="DELETE")
+        req = urllib.request.Request(url, headers=self._headers(extra_headers), method="DELETE")
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
                 return _read_json_response(resp)
@@ -449,6 +466,12 @@ class SignetClient:
         structured: Optional[Dict[str, Any]] = None,
         review_after: str = "",
         who: str = "hermes-agent",
+        visibility: str = "",
+        supersedes: str = "",
+        reason: str = "",
+        idempotency_key: str = "",
+        session_id: str = "",
+        request_id: str = "",
     ) -> Optional[Dict[str, Any]]:
         """Store a memory via the daemon API."""
         body: Dict[str, Any] = {
@@ -478,6 +501,22 @@ class SignetClient:
             body["structured"] = structured
         if review_after:
             body["reviewAfter"] = review_after
+        if visibility in {"global", "private", "archived"}:
+            body["visibility"] = visibility
+        if supersedes:
+            body["supersedes"] = supersedes
+        if reason:
+            body["reason"] = reason
+        if idempotency_key:
+            body["idempotencyKey"] = idempotency_key
+        context_headers = self._mutation_context_headers(session_id=session_id, request_id=request_id)
+        if context_headers:
+            return self._post(
+                "/api/memory/remember",
+                body,
+                timeout=_LONG_TIMEOUT_SECS,
+                extra_headers=context_headers,
+            )
         return self._post("/api/memory/remember", body, timeout=_LONG_TIMEOUT_SECS)
 
     def recall(
@@ -611,10 +650,36 @@ class SignetClient:
         memory_id: str,
         *,
         reason: str,
+        session_id: str = "",
+        request_id: str = "",
     ) -> Optional[Dict[str, Any]]:
         """Soft-delete a memory by ID."""
         params = urllib.parse.urlencode({"reason": reason})
-        return self._delete(f"/api/memory/{urllib.parse.quote(memory_id)}?{params}")
+        path = f"/api/memory/{urllib.parse.quote(memory_id, safe='')}?{params}"
+        context_headers = self._mutation_context_headers(session_id=session_id, request_id=request_id)
+        if context_headers:
+            return self._delete(path, extra_headers=context_headers)
+        return self._delete(path)
+
+    def supersede_memory(
+        self,
+        memory_id: str,
+        superseded_by: str,
+        *,
+        reason: str,
+        session_id: str = "",
+        request_id: str = "",
+    ) -> Optional[Dict[str, Any]]:
+        """Mark one memory as superseded by another in an audited transaction."""
+        path = f"/api/memories/{urllib.parse.quote(memory_id, safe='')}/supersede"
+        body = {
+            "superseded_by": superseded_by,
+            "reason": reason,
+        }
+        context_headers = self._mutation_context_headers(session_id=session_id, request_id=request_id)
+        if context_headers:
+            return self._post(path, body, extra_headers=context_headers)
+        return self._post(path, body)
 
     def search(
         self,
@@ -622,11 +687,17 @@ class SignetClient:
         *,
         limit: int = 10,
         memory_type: str = "",
+        tags: str = "",
+        project: str = "",
     ) -> List[Dict[str, Any]]:
         """Search memories. Returns list of memory objects."""
-        params = f"?q={urllib.parse.quote(query)}&limit={limit}"
+        params = f"?q={urllib.parse.quote(query, safe='')}&limit={limit}"
         if memory_type:
-            params += f"&type={urllib.parse.quote(memory_type)}"
+            params += f"&type={urllib.parse.quote(memory_type, safe='')}"
+        if tags:
+            params += f"&tags={urllib.parse.quote(tags, safe='')}"
+        if project:
+            params += f"&project={urllib.parse.quote(project, safe='')}"
         result = self._get(f"/api/memory/search{params}")
         if result and isinstance(result, dict):
             return result.get("results", result.get("memories", []))

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -999,7 +999,7 @@ for vector in contract["vectors"]:
 		expect(plugin).toContain("metadata: Optional[Dict[str, Any]] = None");
 		expect(plugin).toContain('metadata.get("write_origin", "")');
 		expect(plugin).toContain('metadata.get("tool_call_id", "")');
-		expect(plugin).toContain('source_type="hermes-memory-write" if source_id else ""');
+		expect(plugin).toContain("source_type=HERMES_MEMORY_SOURCE_TYPE");
 		expect(plugin).toContain('self._inject_cache = ""');
 		expect(plugin).toContain("self._prefetch_generation += 1");
 	});
@@ -1162,12 +1162,13 @@ assert calls == [{
 					"from plugins.memory.signet import SignetMemoryProvider",
 					"class FakeClient:",
 					"    def __init__(self): self.calls = []",
-					"    def remember(self, content, **kwargs): self.calls.append({'content': content, **kwargs})",
+					"    def remember(self, content, **kwargs): self.calls.append({'content': content, **kwargs}); return {'id': 'memory-id', 'content': content}",
 					"provider = SignetMemoryProvider()",
 					"provider._client = FakeClient()",
 					"provider._project = '/tmp/project'",
 					"provider._session_key = 'session-a'",
 					"provider.on_memory_write('add', 'memory', 'durable fact', metadata={'write_origin': 'assistant_tool', 'execution_context': 'foreground', 'platform': 'cli', 'session_id': 'session-a', 'tool_call_id': 'call-123'})",
+					"assert provider.flush_mirror_writes()",
 					"provider._client.calls and print(json.dumps(provider._client.calls[0], sort_keys=True))",
 				].join("\n"),
 			],
@@ -1182,6 +1183,70 @@ assert calls == [{
 		expect(result.stdout).toContain('"context:foreground"');
 		expect(result.stdout).toContain('"platform:cli"');
 		expect(result.stdout).toContain('"session:session-a"');
+	});
+
+	it("mirrors add, replace, and remove in order without reviving stale context", () => {
+		const fixture = join(tmpRoot, "python-memory-mirror-fixture");
+		cpSync(join(import.meta.dir, "hermes-plugin"), join(fixture, "plugins", "memory", "signet"), { recursive: true });
+		mkdirSync(join(fixture, "agent"), { recursive: true });
+		writeFileSync(join(fixture, "agent", "__init__.py"), "");
+		writeFileSync(join(fixture, "plugins", "__init__.py"), "");
+		writeFileSync(join(fixture, "plugins", "memory", "__init__.py"), "");
+		writeFileSync(join(fixture, "agent", "memory_provider.py"), "class MemoryProvider:\n    pass\n");
+
+		const result = spawnSync(
+			resolveTestPythonPath(),
+			[
+				"-c",
+				[
+					"import json",
+					"from plugins.memory.signet import SignetMemoryProvider",
+					"class FakeClient:",
+					"    def __init__(self): self.rows = []; self.mutations = []",
+					"    def search(self, query, **kwargs):",
+					"        return [row for row in self.rows if row.get('active') and query in row['content']]",
+					"    def recall(self, query, **kwargs): return {'results': self.search(query, **kwargs)}",
+					"    def remember(self, content, **kwargs):",
+					"        old_id = kwargs.get('supersedes')",
+					"        if old_id:",
+					"            for row in self.rows:",
+					"                if row['id'] == old_id: row['active'] = False",
+					"            memory_id = 'replacement'",
+					"            self.mutations.append(('replace', old_id, memory_id))",
+					"        else:",
+					"            memory_id = 'original'",
+					"            self.mutations.append(('add', memory_id))",
+					"        self.rows.append({'id': memory_id, 'content': content, 'tags': kwargs['tags'], 'source_id': kwargs['source_id'], 'active': True})",
+					"        return {'id': memory_id, 'content': content}",
+					"    def forget_memory(self, memory_id, **kwargs):",
+					"        for row in self.rows:",
+					"            if row['id'] == memory_id: row['active'] = False",
+					"        self.mutations.append(('remove', memory_id))",
+					"        return {'id': memory_id, 'status': 'deleted'}",
+					"provider = SignetMemoryProvider()",
+					"provider._client = FakeClient()",
+					"provider._project = '/tmp/project'",
+					"provider._session_key = 'session-a'",
+					"metadata = {'session_id': 'session-a', 'tool_call_id': 'batch-call'}",
+					"provider.on_memory_write('add', 'memory', 'old preference', metadata=metadata)",
+					"provider.on_memory_write('replace', 'memory', 'new preference', metadata={**metadata, 'old_text': 'old preference'})",
+					"provider.on_memory_write('replace', 'memory', 'new preference', metadata={**metadata, 'old_text': 'old preference'})",
+					"provider.on_memory_write('remove', 'memory', '', metadata={**metadata, 'old_text': 'new preference'})",
+					"provider.on_memory_write('remove', 'memory', '', metadata={**metadata, 'old_text': 'new preference'})",
+					"assert provider.flush_mirror_writes()",
+					"assert provider._client.mutations == [('add', 'original'), ('replace', 'original', 'replacement'), ('remove', 'replacement')]",
+					"assert [row['content'] for row in provider._client.rows] == ['old preference', 'new preference']",
+					"assert not any(row['active'] for row in provider._client.rows)",
+					"assert provider._client.recall('preference')['results'] == []",
+					"print(json.dumps(provider._client.mutations))",
+				].join("\n"),
+			],
+			{ env: { ...process.env, PYTHONPATH: fixture }, encoding: "utf-8" },
+		);
+
+		expect(result.status, result.stderr || result.stdout).toBe(0);
+		expect(result.stdout).toContain("replace");
+		expect(result.stdout).toContain("remove");
 	});
 
 	it("stores Hermes delegation memories with project scope", () => {
@@ -1433,6 +1498,82 @@ assert calls == [{
 		expect(result.stdout).toContain('"path": "/api/sessions/search"');
 		expect(result.stdout).toContain('"agentId": "research-agent"');
 		expect(result.stdout).toContain('"agentId": "explicit-agent"');
+	});
+
+	it("sends mirror lineage, visibility, and audit provenance to the daemon", () => {
+		const clientPath = join(import.meta.dir, "hermes-plugin", "client.py");
+		const script = String.raw`
+import importlib.util
+
+spec = importlib.util.spec_from_file_location("signet_client", __import__("sys").argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+client = module.SignetClient(agent_id="research-agent", harness="hermes-agent")
+posts = []
+deletes = []
+gets = []
+def fake_post(path, body, **kwargs):
+    posts.append((path, body, kwargs))
+    return {"id": "replacement-id", "content": body.get("content", "")}
+def fake_delete(path, **kwargs):
+    deletes.append((path, kwargs))
+    return {"status": "deleted"}
+def fake_get(path, **kwargs):
+    gets.append((path, kwargs))
+    return {"results": []}
+client._post = fake_post
+client._delete = fake_delete
+client._get = fake_get
+client.remember(
+    "new preference",
+    project="/tmp/project",
+    visibility="global",
+    source_type="hermes-memory-write",
+    source_id="call-123:replace:abc",
+    idempotency_key="hermes-memory-write:operation",
+    supersedes="old-id",
+    reason="Hermes built-in memory replacement",
+    session_id="session-a",
+    request_id="request-a",
+)
+client.supersede_memory(
+    "old-id",
+    "replacement-id",
+    reason="Hermes built-in memory replacement",
+    session_id="session-a",
+    request_id="request-a",
+)
+client.forget_memory(
+    "replacement-id",
+    reason="Hermes built-in memory removal",
+    session_id="session-a",
+    request_id="request-b",
+)
+client.search("new preference", tags="hermes-builtin", project="/tmp/project")
+assert posts[0][0] == "/api/memory/remember"
+assert posts[0][1]["agentId"] == "research-agent"
+assert posts[0][1]["visibility"] == "global"
+assert posts[0][1]["supersedes"] == "old-id"
+assert posts[0][1]["idempotencyKey"] == "hermes-memory-write:operation"
+assert posts[0][2]["extra_headers"] == {
+    "x-signet-session-id": "session-a",
+    "x-signet-request-id": "request-a",
+}
+assert posts[1] == (
+    "/api/memories/old-id/supersede",
+    {"superseded_by": "replacement-id", "reason": "Hermes built-in memory replacement"},
+    {"extra_headers": {"x-signet-session-id": "session-a", "x-signet-request-id": "request-a"}},
+)
+assert deletes[0] == (
+    "/api/memory/replacement-id?reason=Hermes+built-in+memory+removal",
+    {"extra_headers": {"x-signet-session-id": "session-a", "x-signet-request-id": "request-b"}},
+)
+assert gets[0][0] == "/api/memory/search?q=new%20preference&limit=10&tags=hermes-builtin&project=%2Ftmp%2Fproject"
+`;
+
+		const result = spawnSync(resolveTestPythonPath(), ["-c", script, clientPath], { encoding: "utf-8" });
+
+		expect(result.status, result.stderr || result.stdout).toBe(0);
 	});
 
 	it("uses longer timeouts for recall paths", () => {

--- a/integrations/hermes-agent/connector/package.json
+++ b/integrations/hermes-agent/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-hermes-agent",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet connector for Hermes Agent — installs Signet as a pluggable memory provider",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.2",
-    "@signet/core": "0.193.2"
+    "@signet/connector-base": "0.193.3",
+    "@signet/core": "0.193.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/hermes-agent/connector/package.json
+++ b/integrations/hermes-agent/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-hermes-agent",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet connector for Hermes Agent — installs Signet as a pluggable memory provider",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.194.0",
-    "@signet/core": "0.194.0"
+    "@signet/connector-base": "0.194.1",
+    "@signet/core": "0.194.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/hermes-agent/connector/package.json
+++ b/integrations/hermes-agent/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-hermes-agent",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet connector for Hermes Agent — installs Signet as a pluggable memory provider",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.3",
-    "@signet/core": "0.193.3"
+    "@signet/connector-base": "0.194.0",
+    "@signet/core": "0.194.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/oh-my-pi/connector/package.json
+++ b/integrations/oh-my-pi/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-oh-my-pi",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet connector for Oh My Pi",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.3",
-    "@signet/core": "0.193.3"
+    "@signet/connector-base": "0.194.0",
+    "@signet/core": "0.194.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/oh-my-pi/connector/package.json
+++ b/integrations/oh-my-pi/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-oh-my-pi",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet connector for Oh My Pi",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.2",
-    "@signet/core": "0.193.2"
+    "@signet/connector-base": "0.193.3",
+    "@signet/core": "0.193.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/oh-my-pi/connector/package.json
+++ b/integrations/oh-my-pi/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-oh-my-pi",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet connector for Oh My Pi",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.194.0",
-    "@signet/core": "0.194.0"
+    "@signet/connector-base": "0.194.1",
+    "@signet/core": "0.194.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/oh-my-pi/extension/package.json
+++ b/integrations/oh-my-pi/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/oh-my-pi-extension",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet runtime extension for Oh My Pi — session lifecycle hooks and memory recall",
   "type": "module",
   "main": "dist/signet-oh-my-pi.mjs",

--- a/integrations/oh-my-pi/extension/package.json
+++ b/integrations/oh-my-pi/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/oh-my-pi-extension",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet runtime extension for Oh My Pi — session lifecycle hooks and memory recall",
   "type": "module",
   "main": "dist/signet-oh-my-pi.mjs",

--- a/integrations/oh-my-pi/extension/package.json
+++ b/integrations/oh-my-pi/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/oh-my-pi-extension",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet runtime extension for Oh My Pi — session lifecycle hooks and memory recall",
   "type": "module",
   "main": "dist/signet-oh-my-pi.mjs",

--- a/integrations/openclaw/connector/package.json
+++ b/integrations/openclaw/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-openclaw",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet connector for OpenClaw - configures workspace and memory hooks",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@signet/connector-base": "0.194.0",
-    "@signet/core": "0.194.0"
+    "@signet/connector-base": "0.194.1",
+    "@signet/core": "0.194.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/openclaw/connector/package.json
+++ b/integrations/openclaw/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-openclaw",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet connector for OpenClaw - configures workspace and memory hooks",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.3",
-    "@signet/core": "0.193.3"
+    "@signet/connector-base": "0.194.0",
+    "@signet/core": "0.194.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/openclaw/connector/package.json
+++ b/integrations/openclaw/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-openclaw",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet connector for OpenClaw - configures workspace and memory hooks",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.2",
-    "@signet/core": "0.193.2"
+    "@signet/connector-base": "0.193.3",
+    "@signet/core": "0.193.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/openclaw/memory-adapter/package.json
+++ b/integrations/openclaw/memory-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signetai/signet-memory-openclaw",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet adapter for OpenClaw — runtime plugin for AI agent memory",
   "type": "module",
   "main": "dist/index.js",

--- a/integrations/openclaw/memory-adapter/package.json
+++ b/integrations/openclaw/memory-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signetai/signet-memory-openclaw",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet adapter for OpenClaw — runtime plugin for AI agent memory",
   "type": "module",
   "main": "dist/index.js",

--- a/integrations/openclaw/memory-adapter/package.json
+++ b/integrations/openclaw/memory-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signetai/signet-memory-openclaw",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet adapter for OpenClaw — runtime plugin for AI agent memory",
   "type": "module",
   "main": "dist/index.js",

--- a/integrations/opencode/connector/package.json
+++ b/integrations/opencode/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-opencode",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet connector for OpenCode - installs hooks and generates config",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.2",
-    "@signet/core": "0.193.2",
+    "@signet/connector-base": "0.193.3",
+    "@signet/core": "0.193.3",
     "jsonc-parser": "3.3.1"
   },
   "devDependencies": {

--- a/integrations/opencode/connector/package.json
+++ b/integrations/opencode/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-opencode",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet connector for OpenCode - installs hooks and generates config",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.3",
-    "@signet/core": "0.193.3",
+    "@signet/connector-base": "0.194.0",
+    "@signet/core": "0.194.0",
     "jsonc-parser": "3.3.1"
   },
   "devDependencies": {

--- a/integrations/opencode/connector/package.json
+++ b/integrations/opencode/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-opencode",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet connector for OpenCode - installs hooks and generates config",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.194.0",
-    "@signet/core": "0.194.0",
+    "@signet/connector-base": "0.194.1",
+    "@signet/core": "0.194.1",
     "jsonc-parser": "3.3.1"
   },
   "devDependencies": {

--- a/integrations/opencode/plugin/package.json
+++ b/integrations/opencode/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/opencode-plugin",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet runtime plugin for OpenCode — memory tools and session lifecycle hooks",
   "type": "module",
   "main": "dist/signet.mjs",

--- a/integrations/opencode/plugin/package.json
+++ b/integrations/opencode/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/opencode-plugin",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet runtime plugin for OpenCode — memory tools and session lifecycle hooks",
   "type": "module",
   "main": "dist/signet.mjs",

--- a/integrations/opencode/plugin/package.json
+++ b/integrations/opencode/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/opencode-plugin",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet runtime plugin for OpenCode — memory tools and session lifecycle hooks",
   "type": "module",
   "main": "dist/signet.mjs",

--- a/integrations/pi/connector/package.json
+++ b/integrations/pi/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-pi",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet connector for pi",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.2",
-    "@signet/core": "0.193.2"
+    "@signet/connector-base": "0.193.3",
+    "@signet/core": "0.193.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/pi/connector/package.json
+++ b/integrations/pi/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-pi",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet connector for pi",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.194.0",
-    "@signet/core": "0.194.0"
+    "@signet/connector-base": "0.194.1",
+    "@signet/core": "0.194.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/pi/connector/package.json
+++ b/integrations/pi/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-pi",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet connector for pi",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/connector-base": "0.193.3",
-    "@signet/core": "0.193.3"
+    "@signet/connector-base": "0.194.0",
+    "@signet/core": "0.194.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/integrations/pi/extension-base/package.json
+++ b/integrations/pi/extension-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/pi-extension-base",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Shared runtime utilities for Signet harness extensions (helpers, transcript, types, lifecycle, session state)",
   "type": "module",
   "main": "./src/index.ts",

--- a/integrations/pi/extension-base/package.json
+++ b/integrations/pi/extension-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/pi-extension-base",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Shared runtime utilities for Signet harness extensions (helpers, transcript, types, lifecycle, session state)",
   "type": "module",
   "main": "./src/index.ts",

--- a/integrations/pi/extension-base/package.json
+++ b/integrations/pi/extension-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/pi-extension-base",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Shared runtime utilities for Signet harness extensions (helpers, transcript, types, lifecycle, session state)",
   "type": "module",
   "main": "./src/index.ts",

--- a/integrations/pi/extension/package.json
+++ b/integrations/pi/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/pi-extension",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Signet runtime extension for pi — session lifecycle hooks and memory recall",
   "type": "module",
   "main": "dist/signet-pi.mjs",

--- a/integrations/pi/extension/package.json
+++ b/integrations/pi/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/pi-extension",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Signet runtime extension for pi — session lifecycle hooks and memory recall",
   "type": "module",
   "main": "dist/signet-pi.mjs",

--- a/integrations/pi/extension/package.json
+++ b/integrations/pi/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/pi-extension",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Signet runtime extension for pi — session lifecycle hooks and memory recall",
   "type": "module",
   "main": "dist/signet-pi.mjs",

--- a/integrations/unreal/plugin/package.json
+++ b/integrations/unreal/plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/unreal-plugin",
-	"version": "0.193.2",
+	"version": "0.193.3",
 	"private": true,
 	"description": "Signet Unreal Engine plugin manifest and source checks",
 	"type": "module",

--- a/integrations/unreal/plugin/package.json
+++ b/integrations/unreal/plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/unreal-plugin",
-	"version": "0.193.3",
+	"version": "0.194.0",
 	"private": true,
 	"description": "Signet Unreal Engine plugin manifest and source checks",
 	"type": "module",

--- a/integrations/unreal/plugin/package.json
+++ b/integrations/unreal/plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/unreal-plugin",
-	"version": "0.194.0",
+	"version": "0.194.1",
 	"private": true,
 	"description": "Signet Unreal Engine plugin manifest and source checks",
 	"type": "module",

--- a/libs/connector-base/package.json
+++ b/libs/connector-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-base",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "Base class for Signet harness connectors",
   "type": "module",
   "main": "./dist/index.js",
@@ -26,7 +26,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/core": "0.193.2",
+    "@signet/core": "0.193.3",
     "json5": "^2.2.3",
     "jsonc-parser": "3.3.1"
   },

--- a/libs/connector-base/package.json
+++ b/libs/connector-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-base",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "Base class for Signet harness connectors",
   "type": "module",
   "main": "./dist/index.js",
@@ -26,7 +26,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/core": "0.193.3",
+    "@signet/core": "0.194.0",
     "json5": "^2.2.3",
     "jsonc-parser": "3.3.1"
   },

--- a/libs/connector-base/package.json
+++ b/libs/connector-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/connector-base",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "Base class for Signet harness connectors",
   "type": "module",
   "main": "./dist/index.js",
@@ -26,7 +26,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@signet/core": "0.194.0",
+    "@signet/core": "0.194.1",
     "json5": "^2.2.3",
     "jsonc-parser": "3.3.1"
   },

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/sdk",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "license": "Apache-2.0",
   "description": "HTTP client SDK for the Signet daemon API",
   "type": "module",

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/sdk",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "license": "Apache-2.0",
   "description": "HTTP client SDK for the Signet daemon API",
   "type": "module",

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/sdk",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "license": "Apache-2.0",
   "description": "HTTP client SDK for the Signet daemon API",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signet",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "private": true,
   "packageManager": "bun@1.3.11",
   "description": "Local-first identity, memory, and secrets for AI agents",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signet",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "private": true,
   "packageManager": "bun@1.3.11",
   "description": "Local-first identity, memory, and secrets for AI agents",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signet",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "private": true,
   "packageManager": "bun@1.3.11",
   "description": "Local-first identity, memory, and secrets for AI agents",

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/core",
-	"version": "0.193.3",
+	"version": "0.194.0",
 	"license": "Apache-2.0",
 	"description": "Core library for Signet - portable AI agent identity",
 	"type": "module",

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/core",
-	"version": "0.193.2",
+	"version": "0.193.3",
 	"license": "Apache-2.0",
 	"description": "Core library for Signet - portable AI agent identity",
 	"type": "module",

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/core",
-	"version": "0.194.0",
+	"version": "0.194.1",
 	"license": "Apache-2.0",
 	"description": "Core library for Signet - portable AI agent identity",
 	"type": "module",

--- a/platform/daemon/package.json
+++ b/platform/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/daemon",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "license": "Apache-2.0",
   "description": "Background daemon for Signet - serves dashboard, API, and memory system",
   "type": "module",

--- a/platform/daemon/package.json
+++ b/platform/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/daemon",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "license": "Apache-2.0",
   "description": "Background daemon for Signet - serves dashboard, API, and memory system",
   "type": "module",

--- a/platform/daemon/package.json
+++ b/platform/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/daemon",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "license": "Apache-2.0",
   "description": "Background daemon for Signet - serves dashboard, API, and memory system",
   "type": "module",

--- a/platform/daemon/src/index.ts
+++ b/platform/daemon/src/index.ts
@@ -13,5 +13,6 @@ export {
 	isServiceInstalled,
 	getDaemonStatus,
 	getDaemonLogs,
+	type ServiceHealthStatus,
 	type ServiceStatus,
 } from "./service";

--- a/platform/daemon/src/mcp/tools.test.ts
+++ b/platform/daemon/src/mcp/tools.test.ts
@@ -252,6 +252,7 @@ describe("createMcpServer", () => {
 		expect(names).toContain("knowledge_list_groups");
 		expect(names).toContain("knowledge_list_claims");
 		expect(names).toContain("knowledge_list_attributes");
+		expect(names).toContain("signet_explain_claim");
 		expect(names).toContain("knowledge_hygiene_report");
 		expect(names).toContain("apply_ontology_ops");
 		expect(names).toContain("entity_list");
@@ -287,7 +288,30 @@ describe("createMcpServer", () => {
 		for (const alias of GRAPHIQ_COMPAT_ALIASES) {
 			expect(names).toContain(alias);
 		}
-		expect(names.length).toBe(64);
+		expect(names.length).toBe(65);
+	});
+
+	it("forwards bounded claim trace inputs to the canonical daemon route", async () => {
+		const capture: { url?: string; method?: string } = {};
+		mockFetch(200, { integrity: { status: "verified" } }, capture);
+
+		await callTool(server, "signet_explain_claim", {
+			entity: "Signet",
+			aspect: "architecture",
+			group: "ontology",
+			claim: "proposal_loop",
+			version_limit: 5,
+			premise_limit: 7,
+			reverse_limit: 9,
+			max_depth: 2,
+			session_key: "session-1",
+			agent_id: "ant",
+		});
+
+		expect(capture.method).toBe("GET");
+		expect(capture.url).toBe(
+			"http://localhost:3850/api/ontology/claims/explain?entity=Signet&aspect=architecture&group=ontology&claim=proposal_loop&version_limit=5&premise_limit=7&reverse_limit=9&max_depth=2&session_key=session-1&agent_id=ant",
+		);
 	});
 
 	it("registers generic code tools when GraphIQ has an active project", async () => {

--- a/platform/daemon/src/mcp/tools.ts
+++ b/platform/daemon/src/mcp/tools.ts
@@ -175,6 +175,7 @@ const BASE_TOOL_NAMES = new Set<string>([
 	"knowledge_list_groups",
 	"knowledge_list_claims",
 	"knowledge_list_attributes",
+	"signet_explain_claim",
 	"knowledge_hygiene_report",
 	"apply_ontology_ops",
 	"entity_list",
@@ -2244,6 +2245,19 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		offset: z.number().optional().describe("Pagination offset, default 0"),
 		agent_id: z.string().optional().describe("Agent scope, default default"),
 	});
+	const explainClaimInput = z.object({
+		entity: z.string().min(1).describe("Entity name"),
+		aspect: z.string().min(1).describe("Aspect/room name"),
+		group: z.string().min(1).describe("Group/dresser key"),
+		claim: z.string().min(1).describe("Claim/drawer key"),
+		kind: z.enum(["attribute", "constraint"]).optional(),
+		version_limit: z.number().int().min(1).max(50).optional().describe("Max claim versions"),
+		premise_limit: z.number().int().min(1).max(100).optional().describe("Max source premises"),
+		reverse_limit: z.number().int().min(1).max(100).optional().describe("Max reverse dependents"),
+		max_depth: z.number().int().min(0).max(3).optional().describe("Max bounded lineage depth"),
+		session_key: z.string().optional().describe("Optional session boundary for fail-closed provenance"),
+		agent_id: z.string().optional().describe("Agent scope, default default"),
+	});
 	const hygieneReportInput = z.object({
 		limit: z.number().optional().describe("Max rows per report section, default 50"),
 		memory_limit: z.number().optional().describe("Recent memories to scan for safe mention candidates, default 200"),
@@ -2325,6 +2339,29 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		if (offset !== undefined) params.set("offset", String(offset));
 		if (agent_id) params.set("agent_id", agent_id);
 		return fetchNavigation("/api/knowledge/navigation/attributes", params, "Entity attributes");
+	};
+	const explainClaim = async ({
+		entity,
+		aspect,
+		group,
+		claim,
+		kind,
+		version_limit,
+		premise_limit,
+		reverse_limit,
+		max_depth,
+		session_key,
+		agent_id,
+	}: z.infer<typeof explainClaimInput>) => {
+		const params = new URLSearchParams({ entity, aspect, group, claim });
+		if (kind) params.set("kind", kind);
+		if (version_limit !== undefined) params.set("version_limit", String(version_limit));
+		if (premise_limit !== undefined) params.set("premise_limit", String(premise_limit));
+		if (reverse_limit !== undefined) params.set("reverse_limit", String(reverse_limit));
+		if (max_depth !== undefined) params.set("max_depth", String(max_depth));
+		if (session_key) params.set("session_key", session_key);
+		if (agent_id) params.set("agent_id", agent_id);
+		return fetchNavigation("/api/ontology/claims/explain", params, "Claim trace");
 	};
 	const hygieneReport = async ({ limit, memory_limit, agent_id }: z.infer<typeof hygieneReportInput>) => {
 		const params = new URLSearchParams();
@@ -2432,6 +2469,20 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			annotations: { readOnlyHint: true },
 		},
 		listAttributes,
+	);
+
+	registerMcpTool(
+		server,
+		"signet_explain_claim",
+		{
+			title: "Explain Claim",
+			description:
+				"Return an authorized, bounded claim trace with current and historical versions, competing assertions, " +
+				"exact source spans, premise integrity, scope decisions, and reverse lineage. Missing or cross-agent source IDs fail closed.",
+			inputSchema: explainClaimInput,
+			annotations: { readOnlyHint: true },
+		},
+		explainClaim,
 	);
 
 	registerMcpTool(

--- a/platform/daemon/src/ontology-claim-trace.test.ts
+++ b/platform/daemon/src/ontology-claim-trace.test.ts
@@ -1,0 +1,419 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Hono } from "hono";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { createEpistemicAssertion, linkEpistemicAssertionClaim } from "./ontology-assertions";
+import { OntologyClaimTraceError, explainOntologyClaim } from "./ontology-claim-trace";
+import { registerOntologyRoutes } from "./routes/ontology-routes";
+
+const now = "2026-08-10T00:00:00.000Z";
+
+function insertMemory(
+	db: { prepare(sql: string): { run(...params: unknown[]): unknown } },
+	input: {
+		readonly id: string;
+		readonly content: string;
+		readonly agentId: string;
+		readonly memoryKind: "episodic" | "derived";
+		readonly isDeleted?: number;
+	},
+): void {
+	db.prepare(
+		`INSERT INTO memories
+		 (id, content, type, agent_id, updated_by, memory_kind, visibility, scope, is_deleted, created_at, updated_at)
+		 VALUES (?, ?, 'fact', ?, 'test', ?, 'global', NULL, ?, ?, ?)`,
+	).run(input.id, input.content, input.agentId, input.memoryKind, input.isDeleted ?? 0, now, now);
+}
+
+function insertAttribute(
+	db: { prepare(sql: string): { run(...params: unknown[]): unknown } },
+	input: {
+		readonly id: string;
+		readonly memoryId: string;
+		readonly status: "active" | "superseded" | "deleted";
+		readonly content: string;
+		readonly version: number;
+		readonly previousId: string | null;
+		readonly evidence: readonly unknown[];
+		readonly groupKey?: string;
+		readonly claimKey?: string;
+	},
+): void {
+	db.prepare(
+		`INSERT INTO entity_attributes
+		 (id, aspect_id, agent_id, memory_id, kind, content, normalized_content,
+		  confidence, importance, status, group_key, claim_key, version, version_root_id,
+		  previous_attribute_id, proposal_evidence, created_at, updated_at)
+		 VALUES (?, 'aspect-1', 'ant', ?, 'attribute', ?, ?, 0.9, 0.8, ?, ?,
+		         ?, ?, 'attr-old', ?, ?, ?, ?)`,
+	).run(
+		input.id,
+		input.memoryId,
+		input.content,
+		input.content.toLowerCase(),
+		input.status,
+		input.groupKey ?? "preferences",
+		input.claimKey ?? "editor",
+		input.version,
+		input.previousId,
+		JSON.stringify(input.evidence),
+		now,
+		now,
+	);
+}
+
+function linkSource(
+	db: { prepare(sql: string): { run(...params: unknown[]): unknown } },
+	derivedMemoryId: string,
+	sourceKind: string,
+	sourceId: string,
+): void {
+	db.prepare(
+		`INSERT INTO derived_memory_sources
+		 (derived_memory_id, source_kind, source_id, source_path, agent_id, created_at)
+		 VALUES (?, ?, ?, NULL, 'ant', ?)`,
+	).run(derivedMemoryId, sourceKind, sourceId, now);
+}
+
+describe("authorized ontology claim traces", () => {
+	let dir = "";
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "signet-ontology-claim-trace-"));
+		mkdirSync(join(dir, "memory"), { recursive: true });
+		initDbAccessor(join(dir, "memory", "memories.db"));
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES ('entity-1', 'Editor', 'editor', 'tool', 'ant', 1, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_aspects
+				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES ('aspect-1', 'entity-1', 'ant', 'preferences', 'preferences', 0.8, ?, ?)`,
+			).run(now, now);
+			insertMemory(db, {
+				id: "source-a",
+				content: "The user prefers the editor to open files in tabs.",
+				agentId: "ant",
+				memoryKind: "episodic",
+			});
+			insertMemory(db, {
+				id: "derived-old",
+				content: "The editor opens files in tabs.",
+				agentId: "ant",
+				memoryKind: "derived",
+			});
+			insertMemory(db, {
+				id: "derived-current",
+				content: "The user prefers the editor to open files in tabs.",
+				agentId: "ant",
+				memoryKind: "derived",
+			});
+			insertMemory(db, {
+				id: "derived-dependent",
+				content: "The editor tab behavior is a current preference.",
+				agentId: "ant",
+				memoryKind: "derived",
+			});
+			insertAttribute(db, {
+				id: "attr-old",
+				memoryId: "derived-old",
+				status: "superseded",
+				content: "The editor opens files in tabs.",
+				version: 1,
+				previousId: null,
+				evidence: [{ source_ref: "memory:source-a", quote: "open files in tabs" }],
+			});
+			insertAttribute(db, {
+				id: "attr-current",
+				memoryId: "derived-current",
+				status: "active",
+				content: "The user prefers the editor to open files in tabs.",
+				version: 2,
+				previousId: "attr-old",
+				evidence: [{ source_ref: "memory:source-a", quote: "prefers the editor to open files in tabs" }],
+			});
+			db.prepare("UPDATE entity_attributes SET superseded_by = 'attr-current' WHERE id = 'attr-old'").run();
+			insertAttribute(db, {
+				id: "attr-dependent",
+				memoryId: "derived-dependent",
+				status: "active",
+				content: "The editor tab behavior is a current preference.",
+				version: 1,
+				previousId: null,
+				evidence: [],
+				groupKey: "other",
+				claimKey: "dependent",
+			});
+			linkSource(db, "derived-old", "memory", "source-a");
+			linkSource(db, "derived-current", "memory", "source-a");
+			linkSource(db, "derived-dependent", "memory", "derived-current");
+		});
+	});
+
+	afterEach(() => {
+		closeDbAccessor();
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("returns current truth, history, exact premises, assertions, and bounded reverse lineage", () => {
+		const assertion = createEpistemicAssertion(getDbAccessor(), {
+			agentId: "ant",
+			entityId: "entity-1",
+			predicate: "denies",
+			content: "The editor should not open files in tabs.",
+			evidence: [{ source_ref: "memory:source-a", quote: "prefers the editor" }],
+		});
+		linkEpistemicAssertionClaim(getDbAccessor(), {
+			agentId: "ant",
+			id: assertion.id,
+			attributeId: "attr-current",
+		});
+
+		const trace = explainOntologyClaim(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Editor",
+			aspect: "preferences",
+			group: "preferences",
+			claim: "editor",
+			versionLimit: 10,
+			premiseLimit: 10,
+			reverseLimit: 10,
+			maxDepth: 2,
+		});
+
+		expect(trace.current.status).toBe("active");
+		expect(trace.current.items.map((item) => item.attribute.id)).toEqual(["attr-current"]);
+		expect(trace.versions.items.map((item) => item.attribute.id)).toEqual(["attr-current", "attr-old"]);
+		expect(trace.versions.items[1]?.history.supersededBy).toBe("attr-current");
+		expect(trace.premises.items).toHaveLength(3);
+		expect(trace.premises.items.map((item) => item.evidence.exactQuote)).toEqual([
+			"prefers the editor to open files in tabs",
+			"open files in tabs",
+			"prefers the editor",
+		]);
+		expect(trace.premises.items[0]?.evidence.excerpt).toContain("prefers the editor");
+		expect(trace.integrity.status).toBe("verified");
+		expect(trace.competing.contradictoryAssertions.map((item) => item.id)).toEqual([assertion.id]);
+		expect(trace.reverse.items).toEqual([
+			expect.objectContaining({
+				memoryId: "derived-dependent",
+				attributeId: "attr-dependent",
+				depth: 1,
+			}),
+		]);
+		expect(trace.traversal.bounded).toBe(true);
+		expect(trace.traversal.limits.maxDepth).toBe(2);
+	});
+
+	it("keeps project-scoped reverse lineage within the authorized project", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				"UPDATE memories SET project = 'project-a' WHERE id IN ('source-a', 'derived-old', 'derived-current')",
+			).run();
+			db.prepare("UPDATE memories SET project = 'project-b' WHERE id = 'derived-dependent'").run();
+		});
+
+		const trace = explainOntologyClaim(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Editor",
+			aspect: "preferences",
+			group: "preferences",
+			claim: "editor",
+			project: "project-a",
+		});
+		expect(trace.reverse.items).toHaveLength(0);
+	});
+
+	it("rejects a project-scoped claim whose semantic memory is outside the project", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE memories SET project = 'project-b' WHERE id = 'derived-current'").run();
+		});
+		expect(() =>
+			explainOntologyClaim(getDbAccessor(), {
+				agentId: "ant",
+				entity: "Editor",
+				aspect: "preferences",
+				group: "preferences",
+				claim: "editor",
+				project: "project-a",
+			}),
+		).toThrowError(new OntologyClaimTraceError("Claim is outside the authorized project scope", 403));
+	});
+
+	it("resolves exact artifact spans without returning artifact session tokens", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				"DELETE FROM derived_memory_sources WHERE derived_memory_id IN ('derived-old', 'derived-current')",
+			).run();
+			db.prepare(
+				"UPDATE entity_attributes SET proposal_evidence = '[]' WHERE id IN ('attr-old', 'attr-current')",
+			).run();
+			db.prepare("UPDATE entity_attributes SET proposal_evidence = ? WHERE id = 'attr-current'").run(
+				JSON.stringify([
+					"artifact-secret-token",
+					{
+						source_ref: "artifact:sources/claim.md",
+						quote: "The artifact confirms tabs.",
+						session_token: "artifact-secret-token",
+					},
+				]),
+			);
+			db.prepare(
+				`INSERT INTO memory_artifacts
+				 (agent_id, source_path, source_sha256, source_kind, session_id, session_key, session_token,
+				  captured_at, content, updated_at, is_deleted)
+				 VALUES ('ant', 'sources/claim.md', 'sha-claim', 'source_obsidian_markdown',
+				         'artifact-session', 'artifact-session', 'artifact-secret-token', ?,
+				         'The artifact confirms tabs.', ?, 0)`,
+			).run(now, now);
+		});
+
+		const trace = explainOntologyClaim(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Editor",
+			aspect: "preferences",
+			group: "preferences",
+			claim: "editor",
+		});
+		expect(trace.integrity.status).toBe("verified");
+		expect(JSON.stringify(trace)).not.toContain("artifact-secret-token");
+		expect(trace.premises.items[0]?.evidence).toMatchObject({
+			sourceKind: "artifact",
+			sourceId: "sources/claim.md",
+			exactQuote: "The artifact confirms tabs.",
+			scope: { sessionKeys: [] },
+		});
+	});
+
+	it("does not treat legacy noncanonical lineage metadata as source evidence", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				"DELETE FROM derived_memory_sources WHERE derived_memory_id IN ('derived-old', 'derived-current')",
+			).run();
+			db.prepare(
+				"UPDATE entity_attributes SET proposal_evidence = '[]' WHERE id IN ('attr-old', 'attr-current')",
+			).run();
+			linkSource(db, "derived-current", "ontology_claim", "attr-old");
+		});
+
+		const trace = explainOntologyClaim(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Editor",
+			aspect: "preferences",
+			group: "preferences",
+			claim: "editor",
+		});
+		expect(trace.premises.items).toHaveLength(0);
+		expect(trace.integrity.status).toBe("unverified");
+	});
+
+	it("rejects fabricated and cross-agent premise ids", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("DELETE FROM derived_memory_sources WHERE derived_memory_id = 'derived-current'").run();
+			linkSource(db, "derived-current", "memory", "missing-source");
+		});
+		expect(() =>
+			explainOntologyClaim(getDbAccessor(), {
+				agentId: "ant",
+				entity: "Editor",
+				aspect: "preferences",
+				group: "preferences",
+				claim: "editor",
+			}),
+		).toThrowError(new OntologyClaimTraceError("Claim premise 'memory:missing-source' was not found", 409));
+
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("DELETE FROM derived_memory_sources WHERE derived_memory_id = 'derived-current'").run();
+			insertMemory(db, {
+				id: "shared-id",
+				content: "Other agent evidence.",
+				agentId: "other",
+				memoryKind: "episodic",
+			});
+			linkSource(db, "derived-current", "memory", "shared-id");
+		});
+		expect(() =>
+			explainOntologyClaim(getDbAccessor(), {
+				agentId: "ant",
+				entity: "Editor",
+				aspect: "preferences",
+				group: "preferences",
+				claim: "editor",
+			}),
+		).toThrowError(new OntologyClaimTraceError("Claim premise crosses the authorized agent scope", 403));
+	});
+
+	it("rejects an exact-quote claim that is not present in the source", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE entity_attributes SET proposal_evidence = ? WHERE id = 'attr-current'").run(
+				JSON.stringify([{ source_ref: "memory:source-a", quote: "This sentence was never recorded." }]),
+			);
+		});
+		expect(() =>
+			explainOntologyClaim(getDbAccessor(), {
+				agentId: "ant",
+				entity: "Editor",
+				aspect: "preferences",
+				group: "preferences",
+				claim: "editor",
+			}),
+		).toThrowError(new OntologyClaimTraceError("Claim premise quote does not match the immutable source", 409));
+	});
+
+	it("reports deleted evidence as invalidated and rejects a session boundary crossing", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE memories SET is_deleted = 1 WHERE id = 'source-a'").run();
+		});
+		const invalidated = explainOntologyClaim(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Editor",
+			aspect: "preferences",
+			group: "preferences",
+			claim: "editor",
+		});
+		expect(invalidated.integrity.status).toBe("invalidated");
+		expect(invalidated.premises.items[0]?.evidence.state).toBe("deleted");
+
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("DELETE FROM derived_memory_sources WHERE derived_memory_id = 'derived-current'").run();
+			db.prepare(
+				`INSERT INTO session_transcripts
+				 (session_key, content, harness, project, agent_id, created_at, updated_at, completed_at)
+				 VALUES ('session-a', 'The user prefers the editor.', 'test', '/repo', 'ant', ?, ?, ?)`,
+			).run(now, now, now);
+			linkSource(db, "derived-current", "transcript", "session-a");
+		});
+		expect(() =>
+			explainOntologyClaim(getDbAccessor(), {
+				agentId: "ant",
+				entity: "Editor",
+				aspect: "preferences",
+				group: "preferences",
+				claim: "editor",
+				sessionKey: "session-b",
+			}),
+		).toThrowError(new OntologyClaimTraceError("Claim trace premise crosses the authorized session boundary", 403));
+	});
+
+	it("serves the trace through the read-only HTTP route", async () => {
+		const app = new Hono();
+		registerOntologyRoutes(app);
+		const response = await app.request(
+			"/api/ontology/claims/explain?entity=Editor&aspect=preferences&group=preferences&claim=editor&agent_id=ant",
+		);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { readonly integrity?: { readonly status?: string } };
+		expect(body.integrity?.status).toBe("verified");
+
+		const conflict = await app.request(
+			"/api/ontology/claims/explain?entity=Editor&aspect=preferences&group=preferences&claim=editor&session_key=one",
+			{ headers: { "x-signet-session-key": "two" } },
+		);
+		expect(conflict.status).toBe(400);
+	});
+});

--- a/platform/daemon/src/ontology-claim-trace.ts
+++ b/platform/daemon/src/ontology-claim-trace.ts
@@ -1,0 +1,1189 @@
+import type { AttributeKind, Entity, EntityAspect, EntityAttribute, EpistemicAssertion } from "@signet/core";
+import type { DbAccessor, ReadDb } from "./db-accessor";
+import { tableExists } from "./db-helpers";
+import { findEpisodicSourceAgentIds, readEpisodicSource, sourceIdCandidates } from "./episodic-sources";
+import { listEntityAttributesByPath } from "./knowledge-graph";
+
+const SOURCE_KINDS = ["memory", "artifact", "transcript", "summary"] as const;
+const MAX_VERSION_LIMIT = 50;
+const MAX_PREMISE_LIMIT = 100;
+const MAX_REVERSE_LIMIT = 100;
+const MAX_DEPTH = 3;
+const MAX_EXCERPT_LENGTH = 1200;
+
+type TraceSourceKind = (typeof SOURCE_KINDS)[number];
+type TraceIntegrity = "verified" | "unverified" | "invalidated";
+
+interface TraceReference {
+	readonly sourceKind: string | null;
+	readonly sourceId: string | null;
+	readonly sourcePath: string | null;
+	readonly quote: string | null;
+	readonly strict?: boolean;
+	readonly derivedMemoryId?: string | null;
+	readonly reference: unknown;
+}
+
+interface TraceSource {
+	readonly kind: TraceSourceKind;
+	readonly id: string;
+	readonly path: string | null;
+	readonly content: string | null;
+	readonly project: string | null;
+	readonly visibility: string | null;
+	readonly scope: string | null;
+	readonly sessionKeys: readonly string[];
+	readonly state: "available" | "deleted" | "stale" | "incomplete";
+}
+
+interface TraceEvidence {
+	readonly sourceKind: TraceSourceKind;
+	readonly sourceId: string;
+	readonly sourcePath: string | null;
+	readonly exactQuote: string | null;
+	readonly excerpt: string | null;
+	readonly found: boolean;
+	readonly state: TraceSource["state"] | "quote_unverified";
+	readonly scope: {
+		readonly agentId: string;
+		readonly project: string | null;
+		readonly visibility: string | null;
+		readonly sessionKeys: readonly string[];
+	};
+	readonly reference: unknown;
+}
+
+interface TracePremise {
+	readonly depth: number;
+	readonly derivedMemoryId: string | null;
+	readonly evidence: TraceEvidence;
+}
+
+interface TraceVersion {
+	readonly attribute: EntityAttribute;
+	readonly lifecycle: {
+		readonly status: EntityAttribute["status"];
+		readonly memoryId: string | null;
+		readonly memoryPresent: boolean;
+		readonly staleAt: string | null;
+		readonly supersededBy: string | null;
+	};
+	readonly history: {
+		readonly version: number | null;
+		readonly versionRootId: string | null;
+		readonly previousAttributeId: string | null;
+		readonly supersededBy: string | null;
+	};
+}
+
+interface TraceAssertion {
+	readonly id: string;
+	readonly agentId: string;
+	readonly subjectEntityId: string;
+	readonly subjectEntityName: string | null;
+	readonly claimAttributeId: string | null;
+	readonly predicate: EpistemicAssertion["predicate"];
+	readonly content: string;
+	readonly normalizedContent: string;
+	readonly speaker: string | null;
+	readonly assertedAt: string;
+	readonly confidence: number;
+	readonly evidence: readonly unknown[];
+	readonly sourceKind: string | null;
+	readonly sourceId: string | null;
+	readonly sourcePath: string | null;
+	readonly sourceRoot: string | null;
+	readonly status: EpistemicAssertion["status"];
+	readonly supersedesAssertionId: string | null;
+	readonly archivedAt: string | null;
+	readonly archivedBy: string | null;
+	readonly archiveReason: string | null;
+	readonly createdBy: string;
+	readonly createdAt: string;
+	readonly updatedAt: string;
+	readonly evidenceRefs: readonly TraceReference[];
+}
+
+interface ReverseTraceItem {
+	readonly attributeId: string | null;
+	readonly memoryId: string;
+	readonly entity: string | null;
+	readonly aspect: string | null;
+	readonly groupKey: string | null;
+	readonly claimKey: string | null;
+	readonly content: string;
+	readonly status: string;
+	readonly depth: number;
+}
+
+export interface ExplainClaimParams {
+	readonly agentId: string;
+	readonly entity: string;
+	readonly aspect: string;
+	readonly group: string;
+	readonly claim: string;
+	readonly kind?: AttributeKind;
+	readonly versionLimit?: number;
+	readonly premiseLimit?: number;
+	readonly reverseLimit?: number;
+	readonly maxDepth?: number;
+	readonly sessionKey?: string | null;
+	readonly project?: string | null;
+}
+
+export interface ClaimTraceResult {
+	readonly entity: Entity;
+	readonly aspect: EntityAspect;
+	readonly path: {
+		readonly groupKey: string;
+		readonly claimKey: string;
+		readonly kind: AttributeKind | null;
+	};
+	readonly current: {
+		readonly items: readonly TraceVersion[];
+		readonly status: "active" | "competing" | "historical" | "empty";
+	};
+	readonly versions: {
+		readonly items: readonly TraceVersion[];
+		readonly truncated: boolean;
+	};
+	readonly competing: {
+		readonly items: readonly TraceVersion[];
+		readonly contradictoryAssertions: readonly TraceAssertion[];
+	};
+	readonly assertions: readonly TraceAssertion[];
+	readonly premises: {
+		readonly items: readonly TracePremise[];
+		readonly truncated: boolean;
+	};
+	readonly reverse: {
+		readonly items: readonly ReverseTraceItem[];
+		readonly truncated: boolean;
+	};
+	readonly authorization: {
+		readonly agentId: string;
+		readonly project: string | null;
+		readonly sessionKey: string | null;
+		readonly decisions: {
+			readonly agent: "allowed";
+			readonly project: "unrestricted" | "allowed";
+			readonly session: "unrestricted" | "allowed";
+		};
+		readonly readPath: "recall";
+	};
+	readonly integrity: {
+		readonly status: TraceIntegrity;
+		readonly verifiedPremises: number;
+		readonly invalidatedPremises: number;
+		readonly unverifiedPremises: number;
+		readonly reason: string | null;
+	};
+	readonly traversal: {
+		readonly limits: {
+			readonly versionLimit: number;
+			readonly premiseLimit: number;
+			readonly reverseLimit: number;
+			readonly maxDepth: number;
+		};
+		readonly versionsVisited: number;
+		readonly premisesVisited: number;
+		readonly reverseVisited: number;
+		readonly maxDepthReached: number;
+		readonly bounded: true;
+	};
+	readonly latencyMs: number;
+}
+
+export class OntologyClaimTraceError extends Error {
+	constructor(
+		message: string,
+		readonly status: 400 | 403 | 404 | 409,
+	) {
+		super(message);
+		this.name = "OntologyClaimTraceError";
+	}
+}
+
+interface MemoryStateRow {
+	id: string;
+	is_deleted: number | null;
+	stale_at: string | null;
+	superseded_by: string | null;
+	project: string | null;
+	visibility: string | null;
+	scope: string | null;
+}
+
+interface RawAssertionRow {
+	id: string;
+	agent_id: string;
+	subject_entity_id: string;
+	subject_entity_name: string | null;
+	claim_attribute_id: string | null;
+	predicate: EpistemicAssertion["predicate"];
+	content: string;
+	normalized_content: string;
+	speaker: string | null;
+	asserted_at: string;
+	confidence: number;
+	evidence: string;
+	source_kind: string | null;
+	source_id: string | null;
+	source_path: string | null;
+	source_root: string | null;
+	status: EpistemicAssertion["status"];
+	supersedes_assertion_id: string | null;
+	archived_at: string | null;
+	archived_by: string | null;
+	archive_reason: string | null;
+	created_by: string;
+	created_at: string;
+	updated_at: string;
+}
+
+interface RawReverseRow {
+	readonly memory_id: string;
+	readonly attribute_id: string | null;
+	readonly entity_name: string | null;
+	readonly aspect_name: string | null;
+	readonly group_key: string | null;
+	readonly claim_key: string | null;
+	readonly content: string;
+	readonly status: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | null {
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function parseJsonArray(value: string | null | undefined): readonly unknown[] {
+	if (!value) return [];
+	try {
+		const parsed: unknown = JSON.parse(value);
+		return Array.isArray(parsed) ? parsed : [];
+	} catch {
+		return [];
+	}
+}
+
+function parseReference(value: unknown): TraceReference | null {
+	if (typeof value === "string") {
+		const trimmed = value.trim();
+		if (!trimmed) return null;
+		const separator = trimmed.indexOf(":");
+		return separator > 0
+			? {
+					sourceKind: trimmed.slice(0, separator),
+					sourceId: trimmed.slice(separator + 1),
+					sourcePath: null,
+					quote: null,
+					strict: true,
+					reference: value,
+				}
+			: { sourceKind: null, sourceId: trimmed, sourcePath: null, quote: null, strict: true, reference: value };
+	}
+	if (!isRecord(value)) return null;
+	const sourceRef = stringValue(value.source_ref) ?? stringValue(value.sourceRef);
+	let sourceKind = stringValue(value.source_kind) ?? stringValue(value.sourceKind);
+	let sourceId = stringValue(value.source_id) ?? stringValue(value.sourceId);
+	if (sourceRef) {
+		const separator = sourceRef.indexOf(":");
+		if (separator > 0 && separator < sourceRef.length - 1) {
+			sourceKind = sourceRef.slice(0, separator);
+			sourceId = sourceRef.slice(separator + 1);
+		}
+	}
+	if (!sourceId) sourceId = stringValue(value.memory_id) ?? stringValue(value.memoryId);
+	if (!sourceKind && (value.memory_id !== undefined || value.memoryId !== undefined) && sourceId) {
+		sourceKind = "memory";
+	}
+	return {
+		sourceKind,
+		sourceId,
+		sourcePath: stringValue(value.source_path) ?? stringValue(value.sourcePath),
+		quote: stringValue(value.quote),
+		strict:
+			Boolean(sourceRef) ||
+			(canonicalSourceKind(sourceKind) !== null && sourceId !== null) ||
+			Boolean(value.memory_id) ||
+			Boolean(value.memoryId),
+		reference: value,
+	};
+}
+
+function canonicalSourceKind(value: string | null): TraceSourceKind | null {
+	if (!value) return null;
+	return SOURCE_KINDS.includes(value as TraceSourceKind) ? (value as TraceSourceKind) : null;
+}
+
+function sourceRefParts(reference: TraceReference): { readonly kind: string | null; readonly id: string } {
+	const explicitKind = reference.sourceKind;
+	const sourceId = reference.sourceId?.trim() ?? "";
+	if (explicitKind) return { kind: explicitKind, id: sourceId };
+	const separator = sourceId.indexOf(":");
+	if (separator > 0 && separator < sourceId.length - 1) {
+		return { kind: sourceId.slice(0, separator), id: sourceId.slice(separator + 1) };
+	}
+	return { kind: null, id: sourceId };
+}
+
+function mergeReferences(references: readonly TraceReference[]): TraceReference[] {
+	const merged = new Map<string, TraceReference>();
+	const quotedBases = new Set<string>();
+	for (const reference of references) {
+		const parts = sourceRefParts(reference);
+		const kind = parts.kind;
+		const id = parts.id;
+		const baseKey = `${kind ?? ""}\u0000${id}\u0000${reference.sourcePath ?? ""}`;
+		if (reference.quote !== null) {
+			const key = `${baseKey}\u0000quote\u0000${reference.quote}`;
+			merged.delete(`${baseKey}\u0000noquote`);
+			if (!merged.has(key)) {
+				merged.set(key, {
+					...reference,
+					sourceKind: kind,
+					sourceId: id,
+				});
+			}
+			quotedBases.add(baseKey);
+			continue;
+		}
+		if (quotedBases.has(baseKey)) continue;
+		const key = `${baseKey}\u0000noquote`;
+		if (!merged.has(key)) {
+			merged.set(key, {
+				...reference,
+				sourceKind: kind,
+				sourceId: id,
+			});
+		}
+	}
+	return [...merged.values()];
+}
+
+function compactExcerpt(content: string, quote: string): string {
+	const index = content.indexOf(quote);
+	const start = Math.max(0, index - Math.floor((MAX_EXCERPT_LENGTH - quote.length) / 2));
+	const end = Math.min(content.length, start + MAX_EXCERPT_LENGTH);
+	return `${start > 0 ? "..." : ""}${content.slice(start, end)}${end < content.length ? "..." : ""}`;
+}
+
+function publicReference(value: unknown): unknown | null {
+	const parsed = parseReference(value);
+	if (!parsed) return null;
+	const kind = canonicalSourceKind(parsed.sourceKind);
+	const sourceId = parsed.sourceId?.trim() ?? "";
+	if (!kind || !sourceId) return null;
+	if (typeof value === "string") return `${kind}:${sourceId}`;
+	if (!isRecord(value)) return null;
+
+	// Evidence metadata is untrusted input. Return only the canonical source
+	// identity and human-readable span fields; in particular, never echo
+	// session IDs/tokens or connector-specific metadata from the stored object.
+	const result: Record<string, string> = { source_ref: `${kind}:${sourceId}` };
+	const sourcePath = parsed.sourcePath;
+	const quote = parsed.quote;
+	const sourceRoot = stringValue(value.source_root) ?? stringValue(value.sourceRoot);
+	if (sourcePath) result.source_path = sourcePath;
+	if (sourceRoot) result.source_root = sourceRoot;
+	if (quote) result.quote = quote;
+	return result;
+}
+
+function publicEvidence(values: readonly unknown[]): readonly unknown[] {
+	return values.map(publicReference).filter((item): item is unknown => item !== null);
+}
+
+function visibleSessionKeys(sessionKey: string | null): readonly string[] {
+	// Source-native session tokens remain internal authorization material. Only
+	// echo the boundary the caller explicitly supplied; never return discovered
+	// session IDs/tokens from artifact metadata.
+	return sessionKey === null ? [] : [sessionKey];
+}
+
+function boundedInteger(value: number | undefined, fallback: number, max: number, name: string): number {
+	const normalized = value ?? fallback;
+	if (!Number.isInteger(normalized) || normalized < 1 || normalized > max) {
+		throw new OntologyClaimTraceError(`${name} must be an integer between 1 and ${max}`, 400);
+	}
+	return normalized;
+}
+
+function boundedDepth(value: number | undefined): number {
+	const normalized = value ?? MAX_DEPTH;
+	if (!Number.isInteger(normalized) || normalized < 0 || normalized > MAX_DEPTH) {
+		throw new OntologyClaimTraceError(`maxDepth must be an integer between 0 and ${MAX_DEPTH}`, 400);
+	}
+	return normalized;
+}
+
+function memoryState(db: ReadDb, agentId: string, memoryId: string | null): MemoryStateRow | null {
+	if (!memoryId || !tableExists(db, "memories")) return null;
+	return (
+		(db
+			.prepare(
+				`SELECT id, COALESCE(is_deleted, 0) AS is_deleted, stale_at, superseded_by, project, visibility, scope
+			 FROM memories WHERE id = ? AND agent_id = ? LIMIT 1`,
+			)
+			.get(memoryId, agentId) as MemoryStateRow | undefined) ?? null
+	);
+}
+
+function requireProjectScopedAttribute(db: ReadDb, attribute: EntityAttribute, project: string | null): void {
+	if (project === null) return;
+	const memory = memoryState(db, attribute.agentId, attribute.memoryId);
+	if (!memory || memory.project !== project) {
+		throw new OntologyClaimTraceError("Claim is outside the authorized project scope", 403);
+	}
+}
+
+function sourceSessionKeys(
+	db: ReadDb,
+	agentId: string,
+	kind: TraceSourceKind,
+	id: string,
+	path: string | null,
+): string[] {
+	const keys = new Set<string>();
+	const candidates = sourceIdCandidates(id);
+	const placeholders = candidates.map(() => "?").join(", ");
+	if (kind === "transcript") keys.add(id.replace(/^(transcript|session):/, ""));
+	if (kind === "artifact" && tableExists(db, "memory_artifacts")) {
+		const rows = db
+			.prepare(
+				`SELECT session_id, session_key, session_token
+				 FROM memory_artifacts
+				 WHERE agent_id = ? AND (
+				   source_path = ? OR source_node_id IN (${placeholders}) OR session_id IN (${placeholders})
+				   OR session_key IN (${placeholders}) OR session_token IN (${placeholders})
+				 )`,
+			)
+			.all(agentId, path ?? id, ...candidates, ...candidates, ...candidates, ...candidates) as Array<{
+			readonly session_id: string | null;
+			readonly session_key: string | null;
+			readonly session_token: string | null;
+		}>;
+		for (const row of rows) {
+			for (const value of [row.session_key, row.session_id, row.session_token]) {
+				if (value) keys.add(value);
+			}
+		}
+	}
+	if (kind === "summary" && tableExists(db, "session_summaries")) {
+		const rows = db
+			.prepare(
+				`SELECT session_key, source_ref FROM session_summaries
+				 WHERE agent_id = ? AND (id IN (${placeholders}) OR source_ref IN (${placeholders}))`,
+			)
+			.all(agentId, ...candidates, ...candidates) as Array<{
+			readonly session_key: string | null;
+			readonly source_ref: string | null;
+		}>;
+		for (const row of rows) {
+			if (row.session_key) keys.add(row.session_key);
+			const sourceRef = row.source_ref?.trim();
+			if (sourceRef?.startsWith("session:") || sourceRef?.startsWith("transcript:")) {
+				keys.add(sourceRef.slice(sourceRef.indexOf(":") + 1));
+			}
+		}
+	}
+	if (kind === "memory" && tableExists(db, "memories")) {
+		const row = db
+			.prepare("SELECT source_type, source_id FROM memories WHERE id = ? AND agent_id = ? LIMIT 1")
+			.get(id, agentId) as { readonly source_type: string | null; readonly source_id: string | null } | undefined;
+		if (row?.source_id) {
+			if (row.source_type === "transcript" || row.source_type === "session") {
+				keys.add(row.source_id.replace(/^(transcript|session):/, ""));
+			}
+			if (tableExists(db, "memory_artifacts")) {
+				const linked = db
+					.prepare(
+						`SELECT session_key, session_id, session_token FROM memory_artifacts
+							 WHERE agent_id = ? AND (source_node_id = ? OR source_id = ?)`,
+					)
+					.all(agentId, row.source_id, row.source_id) as Array<{
+					readonly session_key: string | null;
+					readonly session_id: string | null;
+					readonly session_token: string | null;
+				}>;
+				for (const linkedRow of linked) {
+					for (const value of [linkedRow.session_key, linkedRow.session_id, linkedRow.session_token]) {
+						if (value) keys.add(value);
+					}
+				}
+			}
+		}
+	}
+	return [...keys];
+}
+
+function sourceAgentIds(db: ReadDb, kind: TraceSourceKind, id: string, path: string | null): readonly string[] {
+	// This is an ownership probe, not a content read: it deliberately checks
+	// all agent rows so an inaccessible source is forbidden rather than
+	// misreported as missing. The returned rows contain agent IDs only; every
+	// source body is still read through the requested agent scope below.
+	const owners = new Set(findEpisodicSourceAgentIds(db, `${kind}:${path ?? id}`));
+	const candidates = sourceIdCandidates(id);
+	const placeholders = candidates.map(() => "?").join(", ");
+	if (kind === "memory" && tableExists(db, "memories")) {
+		const rows = db
+			.prepare(`SELECT DISTINCT agent_id FROM memories WHERE id IN (${placeholders})`)
+			.all(...candidates) as Array<{ readonly agent_id: string | null }>;
+		for (const row of rows) if (row.agent_id) owners.add(row.agent_id);
+	}
+	if (kind === "artifact" && tableExists(db, "memory_artifacts")) {
+		const rows = db
+			.prepare(
+				`SELECT DISTINCT agent_id FROM memory_artifacts
+				 WHERE source_path = ? OR source_node_id IN (${placeholders}) OR session_id IN (${placeholders})
+				    OR session_key IN (${placeholders}) OR session_token IN (${placeholders})`,
+			)
+			.all(path ?? id, ...candidates, ...candidates, ...candidates, ...candidates) as Array<{
+			readonly agent_id: string | null;
+		}>;
+		for (const row of rows) if (row.agent_id) owners.add(row.agent_id);
+	}
+	if (
+		(kind === "transcript" || kind === "summary") &&
+		tableExists(db, kind === "transcript" ? "session_transcripts" : "session_summaries")
+	) {
+		const rows =
+			kind === "transcript"
+				? (db
+						.prepare(`SELECT DISTINCT agent_id FROM session_transcripts WHERE session_key IN (${placeholders})`)
+						.all(...candidates) as Array<{ readonly agent_id: string | null }>)
+				: (db
+						.prepare(
+							`SELECT DISTINCT agent_id FROM session_summaries
+							 WHERE id IN (${placeholders}) OR source_ref IN (${placeholders})`,
+						)
+						.all(...candidates, ...candidates) as Array<{ readonly agent_id: string | null }>);
+		for (const row of rows) if (row.agent_id) owners.add(row.agent_id);
+	}
+	return [...owners];
+}
+
+function readDeletedArtifact(
+	db: ReadDb,
+	params: { readonly agentId: string; readonly id: string; readonly path: string | null },
+): TraceSource | null {
+	if (!tableExists(db, "memory_artifacts")) return null;
+	const candidates = sourceIdCandidates(params.id);
+	const placeholders = candidates.map(() => "?").join(", ");
+	const row = db
+		.prepare(
+			`SELECT source_path, source_node_id, session_id, session_key, session_token, project, content
+			 FROM memory_artifacts
+			 WHERE agent_id = ? AND COALESCE(is_deleted, 0) != 0 AND (
+			   source_path = ? OR source_node_id IN (${placeholders}) OR session_id IN (${placeholders})
+			   OR session_key IN (${placeholders}) OR session_token IN (${placeholders})
+			 )
+			 ORDER BY captured_at DESC LIMIT 1`,
+		)
+		.get(params.agentId, params.path ?? params.id, ...candidates, ...candidates, ...candidates, ...candidates) as
+		| {
+				readonly source_path: string;
+				readonly source_node_id: string | null;
+				readonly session_id: string | null;
+				readonly session_key: string | null;
+				readonly session_token: string | null;
+				readonly project: string | null;
+				readonly content: string;
+		  }
+		| undefined;
+	if (!row) return null;
+	return {
+		kind: "artifact",
+		id: row.source_path,
+		path: row.source_path,
+		content: null,
+		project: row.project,
+		visibility: "scoped",
+		scope: null,
+		sessionKeys: [row.session_key, row.session_id, row.session_token].filter(
+			(value): value is string => value !== null && value.length > 0,
+		),
+		state: "deleted",
+	};
+}
+
+function readSource(
+	db: ReadDb,
+	params: {
+		readonly agentId: string;
+		readonly kind: TraceSourceKind;
+		readonly id: string;
+		readonly path: string | null;
+		readonly project: string | null;
+		readonly sessionKey: string | null;
+	},
+): TraceSource {
+	const normalizedId = params.id.replace(new RegExp(`^${params.kind}:`), "");
+	const sourceRef = `${params.kind}:${params.path ?? normalizedId}`;
+	const source = readEpisodicSource(db, { agentId: params.agentId, from: sourceRef });
+	if (!source) {
+		const agents = sourceAgentIds(db, params.kind, normalizedId, params.path);
+		if (agents.some((agentId) => agentId !== params.agentId)) {
+			throw new OntologyClaimTraceError("Claim premise crosses the authorized agent scope", 403);
+		}
+		const deleted =
+			params.kind === "artifact"
+				? readDeletedArtifact(db, { agentId: params.agentId, id: normalizedId, path: params.path })
+				: null;
+		if (deleted) {
+			if (params.project !== null && deleted.project !== params.project) {
+				throw new OntologyClaimTraceError("Claim premise is outside the authorized project scope", 403);
+			}
+			if (params.sessionKey !== null && !deleted.sessionKeys.includes(params.sessionKey)) {
+				throw new OntologyClaimTraceError("Claim trace premise crosses the authorized session boundary", 403);
+			}
+			return deleted;
+		}
+		throw new OntologyClaimTraceError(`Claim premise '${sourceRef}' was not found`, 409);
+	}
+	if (params.project !== null && source.project !== params.project) {
+		throw new OntologyClaimTraceError("Claim premise is outside the authorized project scope", 403);
+	}
+	const sessionKeys = sourceSessionKeys(db, params.agentId, params.kind, normalizedId, params.path);
+	if (params.sessionKey !== null && !sessionKeys.includes(params.sessionKey)) {
+		throw new OntologyClaimTraceError("Claim trace premise crosses the authorized session boundary", 403);
+	}
+	const state: TraceSource["state"] = source.completed ? "available" : "incomplete";
+	return {
+		kind: params.kind,
+		id: source.id,
+		path: source.sourcePath,
+		content: state === "available" ? source.content : null,
+		project: source.project,
+		visibility: "scoped",
+		scope: null,
+		sessionKeys,
+		state,
+	};
+}
+
+function readMemorySource(
+	db: ReadDb,
+	params: {
+		readonly agentId: string;
+		readonly id: string;
+		readonly project: string | null;
+		readonly sessionKey: string | null;
+	},
+): TraceSource {
+	const row = db
+		.prepare(
+			`SELECT id, content, source_path, project, visibility, scope, memory_kind, COALESCE(is_deleted, 0) AS is_deleted,
+			        stale_at, superseded_by, source_type, source_id
+			 FROM memories WHERE id = ? AND agent_id = ? LIMIT 1`,
+		)
+		.get(params.id, params.agentId) as
+		| {
+				readonly id: string;
+				readonly content: string;
+				readonly source_path: string | null;
+				readonly project: string | null;
+				readonly visibility: string | null;
+				readonly scope: string | null;
+				readonly memory_kind: string | null;
+				readonly is_deleted: number;
+				readonly stale_at: string | null;
+				readonly superseded_by: string | null;
+				readonly source_type: string | null;
+				readonly source_id: string | null;
+		  }
+		| undefined;
+	if (!row) {
+		// Return only existence, never cross-agent content, so fabricated and
+		// cross-agent source IDs have distinct fail-closed outcomes.
+		const crossAgent = db.prepare("SELECT 1 FROM memories WHERE id = ? LIMIT 1").get(params.id);
+		if (crossAgent) throw new OntologyClaimTraceError("Claim premise crosses the authorized agent scope", 403);
+		throw new OntologyClaimTraceError(`Claim premise 'memory:${params.id}' was not found`, 409);
+	}
+	if (params.project !== null && row.project !== params.project) {
+		throw new OntologyClaimTraceError("Claim premise is outside the authorized project scope", 403);
+	}
+	const sessionKeys = sourceSessionKeys(db, params.agentId, "memory", row.id, null);
+	if (params.sessionKey !== null && !sessionKeys.includes(params.sessionKey)) {
+		throw new OntologyClaimTraceError("Claim trace premise crosses the authorized session boundary", 403);
+	}
+	const state: TraceSource["state"] =
+		row.is_deleted !== 0
+			? "deleted"
+			: row.stale_at !== null || row.superseded_by !== null
+				? "stale"
+				: row.memory_kind !== "episodic" || row.visibility === "archived" || row.scope !== null
+					? "incomplete"
+					: "available";
+	return {
+		kind: "memory",
+		id: row.id,
+		path: row.source_path,
+		content: state === "available" ? row.content : null,
+		project: row.project,
+		visibility: row.visibility,
+		scope: row.scope,
+		sessionKeys,
+		state,
+	};
+}
+
+function sourceFromReference(
+	db: ReadDb,
+	params: {
+		readonly agentId: string;
+		readonly reference: TraceReference;
+		readonly project: string | null;
+		readonly sessionKey: string | null;
+	},
+): TraceEvidence {
+	const kind = canonicalSourceKind(params.reference.sourceKind);
+	const id = params.reference.sourceId?.trim() ?? "";
+	if (!kind || !id) {
+		throw new OntologyClaimTraceError("Claim premise must include a canonical source_ref", 409);
+	}
+	const source =
+		kind === "memory"
+			? readMemorySource(db, {
+					agentId: params.agentId,
+					id: id.replace(/^memory:/, ""),
+					project: params.project,
+					sessionKey: params.sessionKey,
+				})
+			: readSource(db, {
+					agentId: params.agentId,
+					kind,
+					id,
+					path: params.reference.sourcePath,
+					project: params.project,
+					sessionKey: params.sessionKey,
+				});
+	const quote = params.reference.quote;
+	const exact = source.content !== null && quote !== null && source.content.includes(quote);
+	if (source.state === "available" && quote === null) {
+		return {
+			sourceKind: kind,
+			sourceId: source.id,
+			sourcePath: source.path,
+			exactQuote: null,
+			excerpt: null,
+			found: true,
+			state: "quote_unverified",
+			scope: {
+				agentId: params.agentId,
+				project: source.project,
+				visibility: source.visibility,
+				sessionKeys: visibleSessionKeys(params.sessionKey),
+			},
+			reference: publicReference(params.reference.reference),
+		};
+	}
+	if (source.state === "available" && quote !== null && !exact) {
+		throw new OntologyClaimTraceError("Claim premise quote does not match the immutable source", 409);
+	}
+	return {
+		sourceKind: kind,
+		sourceId: source.id,
+		sourcePath: source.path,
+		exactQuote: exact ? quote : null,
+		excerpt: exact && source.content !== null && quote !== null ? compactExcerpt(source.content, quote) : null,
+		found: source.state !== "deleted",
+		state: source.state,
+		scope: {
+			agentId: params.agentId,
+			project: source.project,
+			visibility: source.visibility,
+			sessionKeys: visibleSessionKeys(params.sessionKey),
+		},
+		reference: publicReference(params.reference.reference),
+	};
+}
+
+function attributeReferences(
+	db: ReadDb,
+	attribute: EntityAttribute,
+	proposalEvidence: readonly unknown[],
+): TraceReference[] {
+	const references: TraceReference[] = [];
+	if (tableExists(db, "derived_memory_sources") && attribute.memoryId) {
+		const rows = db
+			.prepare(
+				`SELECT source_kind, source_id, source_path FROM derived_memory_sources
+				 WHERE derived_memory_id = ? AND agent_id = ? ORDER BY created_at ASC LIMIT ?`,
+			)
+			.all(attribute.memoryId, attribute.agentId, MAX_PREMISE_LIMIT + 1) as Array<{
+			readonly source_kind: string;
+			readonly source_id: string;
+			readonly source_path: string | null;
+		}>;
+		references.push(
+			...rows.map((row) => ({
+				sourceKind: row.source_kind,
+				sourceId: row.source_id,
+				sourcePath: row.source_path,
+				quote: null,
+				strict: true,
+				derivedMemoryId: attribute.memoryId,
+				reference: {
+					source_ref: `${row.source_kind}:${row.source_id}`,
+					source_path: row.source_path,
+				},
+			})),
+		);
+	}
+	for (const raw of [...attribute.proposalEvidence, ...proposalEvidence]) {
+		const parsed = parseReference(raw);
+		if (parsed) references.push({ ...parsed, derivedMemoryId: attribute.memoryId });
+	}
+	if (attribute.sourceKind || attribute.sourceId || attribute.sourcePath) {
+		const kind = sourceRefParts({
+			sourceKind: attribute.sourceKind,
+			sourceId: attribute.sourceId,
+			sourcePath: attribute.sourcePath,
+			quote: null,
+			reference: attribute,
+		}).kind;
+		if (canonicalSourceKind(kind) !== null) {
+			references.push({
+				sourceKind: attribute.sourceKind,
+				sourceId: attribute.sourceId,
+				sourcePath: attribute.sourcePath,
+				quote: null,
+				strict: true,
+				derivedMemoryId: attribute.memoryId,
+				reference: {
+					source_kind: attribute.sourceKind,
+					source_id: attribute.sourceId,
+					source_path: attribute.sourcePath,
+				},
+			});
+		}
+	}
+	return mergeReferences(references).filter(
+		(reference) =>
+			reference.sourceKind !== "ontology_proposal" &&
+			reference.strict === true &&
+			canonicalSourceKind(reference.sourceKind) !== null &&
+			(reference.sourceId?.trim().length ?? 0) > 0,
+	);
+}
+
+function traceVersion(db: ReadDb, attribute: EntityAttribute): TraceVersion {
+	const memory = memoryState(db, attribute.agentId, attribute.memoryId);
+	return {
+		attribute: {
+			...attribute,
+			proposalEvidence: publicEvidence(attribute.proposalEvidence),
+		},
+		lifecycle: {
+			status: attribute.status,
+			memoryId: attribute.memoryId,
+			memoryPresent: memory !== null,
+			staleAt: memory?.stale_at ?? null,
+			supersededBy: memory?.superseded_by ?? attribute.supersededBy ?? null,
+		},
+		history: {
+			version: attribute.version ?? null,
+			versionRootId: attribute.versionRootId ?? null,
+			previousAttributeId: attribute.previousAttributeId ?? null,
+			supersededBy: attribute.supersededBy,
+		},
+	};
+}
+
+function readProposalEvidence(db: ReadDb, agentId: string, proposalId: string | null): readonly unknown[] {
+	if (!proposalId || !tableExists(db, "ontology_proposals")) return [];
+	const row = db
+		.prepare("SELECT evidence FROM ontology_proposals WHERE id = ? AND agent_id = ? LIMIT 1")
+		.get(proposalId, agentId) as { readonly evidence: string | null } | undefined;
+	return parseJsonArray(row?.evidence);
+}
+
+function readAssertions(db: ReadDb, agentId: string, attributeIds: readonly string[]): TraceAssertion[] {
+	if (!tableExists(db, "epistemic_assertions") || attributeIds.length === 0) return [];
+	const placeholders = attributeIds.map(() => "?").join(", ");
+	const rows = db
+		.prepare(
+			`SELECT a.*, e.name AS subject_entity_name
+			 FROM epistemic_assertions a
+			 JOIN entities e ON e.id = a.subject_entity_id AND e.agent_id = a.agent_id
+			 WHERE a.agent_id = ? AND a.claim_attribute_id IN (${placeholders})
+			 ORDER BY a.asserted_at DESC, a.created_at DESC
+			 LIMIT ?`,
+		)
+		.all(agentId, ...attributeIds, MAX_PREMISE_LIMIT) as RawAssertionRow[];
+	return rows.map((row) => {
+		const evidenceRefs = [
+			...parseJsonArray(row.evidence),
+			...(row.source_kind || row.source_id || row.source_path
+				? [
+						{
+							source_kind: row.source_kind,
+							source_id: row.source_id,
+							source_path: row.source_path,
+						},
+					]
+				: []),
+		]
+			.map(parseReference)
+			.filter((ref): ref is TraceReference => ref !== null);
+		return {
+			id: row.id,
+			agentId: row.agent_id,
+			subjectEntityId: row.subject_entity_id,
+			subjectEntityName: row.subject_entity_name,
+			claimAttributeId: row.claim_attribute_id,
+			predicate: row.predicate,
+			content: row.content,
+			normalizedContent: row.normalized_content,
+			speaker: row.speaker,
+			assertedAt: row.asserted_at,
+			confidence: row.confidence,
+			evidence: publicEvidence(parseJsonArray(row.evidence)),
+			sourceKind: row.source_kind,
+			sourceId: row.source_id,
+			sourcePath: row.source_path,
+			sourceRoot: row.source_root,
+			status: row.status,
+			supersedesAssertionId: row.supersedes_assertion_id,
+			archivedAt: row.archived_at,
+			archivedBy: row.archived_by,
+			archiveReason: row.archive_reason,
+			createdBy: row.created_by,
+			createdAt: row.created_at,
+			updatedAt: row.updated_at,
+			evidenceRefs: mergeReferences(evidenceRefs).map((reference) => ({
+				...reference,
+				reference: publicReference(reference.reference),
+			})),
+		};
+	});
+}
+
+function readReverse(
+	db: ReadDb,
+	params: {
+		readonly agentId: string;
+		readonly project: string | null;
+		readonly memoryIds: readonly string[];
+		readonly limit: number;
+		readonly maxDepth: number;
+	},
+): { readonly items: ReverseTraceItem[]; readonly truncated: boolean; readonly maxDepthReached: number } {
+	if (!tableExists(db, "derived_memory_sources") || params.memoryIds.length === 0 || params.maxDepth === 0) {
+		return { items: [], truncated: false, maxDepthReached: 0 };
+	}
+	const visited = new Set(params.memoryIds);
+	let frontier = [...visited];
+	const items: ReverseTraceItem[] = [];
+	let truncated = false;
+	let maxDepthReached = 0;
+	for (let depth = 1; depth <= params.maxDepth && frontier.length > 0 && items.length < params.limit; depth += 1) {
+		const placeholders = frontier.map(() => "?").join(", ");
+		const rows = db
+			.prepare(
+				`SELECT DISTINCT dms.derived_memory_id AS memory_id, ea.id AS attribute_id,
+				        e.name AS entity_name, eas.name AS aspect_name, ea.group_key, ea.claim_key,
+				        COALESCE(ea.content, m.content) AS content, COALESCE(ea.status, 'derived') AS status
+				 FROM derived_memory_sources dms
+				 JOIN memories m ON m.id = dms.derived_memory_id AND m.agent_id = dms.agent_id
+				 LEFT JOIN entity_attributes ea ON ea.memory_id = m.id AND ea.agent_id = m.agent_id
+				 LEFT JOIN entity_aspects eas ON eas.id = ea.aspect_id AND eas.agent_id = ea.agent_id
+				 LEFT JOIN entities e ON e.id = eas.entity_id AND e.agent_id = eas.agent_id
+				 WHERE dms.agent_id = ? AND dms.source_kind = 'memory' AND dms.source_id IN (${placeholders})
+				   AND COALESCE(m.is_deleted, 0) = 0 AND m.visibility != 'archived' AND m.scope IS NULL
+				   AND (? IS NULL OR m.project = ?)
+				 ORDER BY m.updated_at DESC, m.id ASC
+				 LIMIT ?`,
+			)
+			.all(
+				params.agentId,
+				...frontier,
+				params.project,
+				params.project,
+				params.limit - items.length + 1,
+			) as RawReverseRow[];
+		if (rows.length > params.limit - items.length) truncated = true;
+		const nextFrontier: string[] = [];
+		for (const row of rows) {
+			if (visited.has(row.memory_id)) continue;
+			visited.add(row.memory_id);
+			if (items.length < params.limit) {
+				items.push({
+					attributeId: row.attribute_id,
+					memoryId: row.memory_id,
+					entity: row.entity_name,
+					aspect: row.aspect_name,
+					groupKey: row.group_key,
+					claimKey: row.claim_key,
+					content: row.content,
+					status: row.status,
+					depth,
+				});
+				maxDepthReached = depth;
+				nextFrontier.push(row.memory_id);
+			}
+		}
+		if (depth === params.maxDepth && nextFrontier.length > 0) truncated = true;
+		frontier = nextFrontier;
+	}
+	return { items, truncated, maxDepthReached };
+}
+
+export function explainOntologyClaim(accessor: DbAccessor, params: ExplainClaimParams): ClaimTraceResult {
+	const started = performance.now();
+	const versionLimit = boundedInteger(params.versionLimit, 20, MAX_VERSION_LIMIT, "versionLimit");
+	const premiseLimit = boundedInteger(params.premiseLimit, 50, MAX_PREMISE_LIMIT, "premiseLimit");
+	const reverseLimit = boundedInteger(params.reverseLimit, 50, MAX_REVERSE_LIMIT, "reverseLimit");
+	const maxDepth = boundedDepth(params.maxDepth);
+	const sessionKey = params.sessionKey?.trim() || null;
+	const project = params.project?.trim() || null;
+	const result = listEntityAttributesByPath(accessor, {
+		agentId: params.agentId,
+		entity: params.entity,
+		aspect: params.aspect,
+		group: params.group,
+		claim: params.claim,
+		kind: params.kind,
+		status: "all",
+		limit: versionLimit + 1,
+		offset: 0,
+	});
+	if (result === null) throw new OntologyClaimTraceError("Claim path not found", 404);
+	if (result.items.length === 0) throw new OntologyClaimTraceError("Claim path has no versions", 404);
+
+	return accessor.withReadDb((db) => {
+		if (project !== null) {
+			// Graph rows are agent-scoped but do not carry a project column. A
+			// project-scoped caller may only receive a claim whose linked semantic
+			// memory proves the same project; otherwise fail closed before any
+			// claim content, history, or assertion is returned.
+			for (const attribute of result.items) requireProjectScopedAttribute(db, attribute, project);
+		}
+		const versions = result.items.slice(0, versionLimit).map((attribute) => traceVersion(db, attribute));
+		const current = versions.filter((version) => version.attribute.status === "active");
+		const currentContent = new Set(current.map((version) => version.attribute.normalizedContent));
+		const assertions = readAssertions(
+			db,
+			params.agentId,
+			versions.map((version) => version.attribute.id),
+		);
+		const contradictoryAssertions = assertions.filter(
+			(assertion) => assertion.predicate === "denies" && assertion.status === "active",
+		);
+		const references = versions.flatMap((version) =>
+			attributeReferences(
+				db,
+				version.attribute,
+				readProposalEvidence(db, params.agentId, version.attribute.proposalId),
+			),
+		);
+		references.push(...assertions.flatMap((assertion) => assertion.evidenceRefs));
+		const uniqueReferences = mergeReferences(references);
+		const premiseItems: TracePremise[] = [];
+		let verifiedPremises = 0;
+		let invalidatedPremises = 0;
+		let unverifiedPremises = 0;
+		for (const reference of uniqueReferences.slice(0, premiseLimit + 1)) {
+			if (premiseItems.length >= premiseLimit) break;
+			const evidence = sourceFromReference(db, {
+				agentId: params.agentId,
+				reference,
+				project,
+				sessionKey,
+			});
+			const derivedMemoryId = reference.derivedMemoryId ?? null;
+			const depth = 0;
+			premiseItems.push({ depth, derivedMemoryId, evidence });
+			if (evidence.state === "available") {
+				if (evidence.exactQuote !== null) verifiedPremises += 1;
+				else unverifiedPremises += 1;
+			} else if (evidence.state === "deleted" || evidence.state === "stale" || evidence.state === "incomplete") {
+				invalidatedPremises += 1;
+			}
+		}
+		const reverseTrace = readReverse(db, {
+			agentId: params.agentId,
+			project,
+			memoryIds: versions
+				.map((version) => version.attribute.memoryId)
+				.filter((memoryId): memoryId is string => memoryId !== null),
+			limit: reverseLimit,
+			maxDepth,
+		});
+		const integrity: TraceIntegrity =
+			invalidatedPremises > 0
+				? "invalidated"
+				: verifiedPremises === 0
+					? "unverified"
+					: unverifiedPremises > 0
+						? "unverified"
+						: "verified";
+		const hasCompeting = currentContent.size > 1;
+		return {
+			entity: {
+				...result.entity,
+				proposalEvidence: publicEvidence(result.entity.proposalEvidence ?? []),
+			},
+			aspect: {
+				...result.aspect,
+				proposalEvidence: publicEvidence(result.aspect.proposalEvidence ?? []),
+			},
+			path: {
+				groupKey: params.group,
+				claimKey: params.claim,
+				kind: params.kind ?? null,
+			},
+			current: {
+				items: current,
+				status: current.length === 0 ? "historical" : hasCompeting ? "competing" : "active",
+			},
+			versions: { items: versions, truncated: result.items.length > versionLimit },
+			competing: { items: hasCompeting ? current : [], contradictoryAssertions },
+			assertions,
+			premises: {
+				items: premiseItems,
+				truncated: uniqueReferences.length > premiseLimit,
+			},
+			reverse: { items: reverseTrace.items, truncated: reverseTrace.truncated },
+			authorization: {
+				agentId: params.agentId,
+				project,
+				sessionKey,
+				decisions: {
+					agent: "allowed",
+					project: project === null ? "unrestricted" : "allowed",
+					session: sessionKey === null ? "unrestricted" : "allowed",
+				},
+				readPath: "recall",
+			},
+			integrity: {
+				status: integrity,
+				verifiedPremises,
+				invalidatedPremises,
+				unverifiedPremises,
+				reason:
+					integrity === "verified"
+						? null
+						: invalidatedPremises > 0
+							? "one or more premise records were deleted, superseded, stale, or incomplete"
+							: "the claim has no verified exact-quote premise",
+			},
+			traversal: {
+				limits: { versionLimit, premiseLimit, reverseLimit, maxDepth },
+				versionsVisited: versions.length,
+				premisesVisited: premiseItems.length,
+				reverseVisited: reverseTrace.items.length,
+				maxDepthReached: reverseTrace.maxDepthReached,
+				bounded: true,
+			},
+			latencyMs: Math.round((performance.now() - started) * 100) / 100,
+		};
+	});
+}
+
+export type { TraceAssertion, TraceEvidence, TracePremise, TraceVersion, ReverseTraceItem };

--- a/platform/daemon/src/routes/ontology-routes.ts
+++ b/platform/daemon/src/routes/ontology-routes.ts
@@ -21,6 +21,7 @@ import {
 	parseOntologyClaimAttributeKind,
 	parseOntologyClaimAttributeStatus,
 } from "../ontology-claim-evidence";
+import { OntologyClaimTraceError, explainOntologyClaim } from "../ontology-claim-trace";
 import { OntologyConsolidationError, consolidateOntologyProposals } from "../ontology-consolidation";
 import { OntologyExtractionError, extractOntologyProposals } from "../ontology-extraction";
 import { OntologyLinkEvidenceError, getOntologyLinkEvidence } from "../ontology-link-evidence";
@@ -43,7 +44,7 @@ import {
 	rejectOntologyProposal,
 } from "../ontology-proposals";
 import { AGENTS_DIR, authConfig } from "./state";
-import { parseBoundedInt, resolveScopedAgentId } from "./utils";
+import { parseBoundedInt, resolveScopedAgentId, validateSessionAgentBinding } from "./utils";
 
 function asRecord(value: unknown): Record<string, unknown> {
 	if (typeof value === "object" && value !== null && !Array.isArray(value)) {
@@ -94,9 +95,10 @@ async function readJsonRecord(c: Context): Promise<Record<string, unknown>> {
 	}
 }
 
-function statusForError(err: unknown): 400 | 404 | 409 | 500 {
+function statusForError(err: unknown): 400 | 403 | 404 | 409 | 500 {
 	if (err instanceof OntologyProposalError) return err.status;
 	if (err instanceof OntologyClaimEvidenceError) return err.status;
+	if (err instanceof OntologyClaimTraceError) return err.status;
 	if (err instanceof OntologyLinkEvidenceError) return err.status;
 	if (err instanceof OntologyExtractionError) return err.status;
 	if (err instanceof OntologyConsolidationError) return err.status;
@@ -415,6 +417,54 @@ export function registerOntologyRoutes(app: Hono): void {
 		try {
 			return c.json(
 				listClaimVersions(getDbAccessor(), { agentId: scoped.agentId, entity, aspect, group, claim, kind }),
+			);
+		} catch (err) {
+			return c.json({ error: messageForError(err) }, statusForError(err));
+		}
+	});
+
+	app.get("/api/ontology/claims/explain", (c) => {
+		const scoped = resolveAgent(c, c.req.query("agent_id"));
+		if (scoped.response) return scoped.response;
+		const entity = c.req.query("entity")?.trim();
+		const aspect = c.req.query("aspect")?.trim();
+		const group = c.req.query("group")?.trim();
+		const claim = c.req.query("claim")?.trim();
+		if (!entity) return c.json({ error: "entity is required" }, 400);
+		if (!aspect) return c.json({ error: "aspect is required" }, 400);
+		if (!group) return c.json({ error: "group is required" }, 400);
+		if (!claim) return c.json({ error: "claim is required" }, 400);
+		const kind = parseOntologyClaimAttributeKind(c.req.query("kind"));
+		if (c.req.query("kind") && !kind) return c.json({ error: "kind is invalid" }, 400);
+		const querySessionKey = c.req.query("session_key")?.trim() || undefined;
+		const headerSessionKey = c.req.header("x-signet-session-key")?.trim() || undefined;
+		if (querySessionKey && headerSessionKey && querySessionKey !== headerSessionKey) {
+			return c.json({ error: "session_key conflicts with x-signet-session-key" }, 400);
+		}
+		const sessionKey = querySessionKey ?? headerSessionKey;
+		const sessionError = validateSessionAgentBinding(c, sessionKey, scoped.agentId, {
+			requireExisting: true,
+			context: "session_key",
+		});
+		if (sessionError) return c.json({ error: sessionError }, 403);
+		const claims = c.get("auth")?.claims;
+		const project = claims?.role === "admin" ? null : (claims?.scope?.project ?? null);
+		try {
+			return c.json(
+				explainOntologyClaim(getDbAccessor(), {
+					agentId: scoped.agentId,
+					entity,
+					aspect,
+					group,
+					claim,
+					kind,
+					versionLimit: parseBoundedInt(c.req.query("version_limit"), 20, 1, 50),
+					premiseLimit: parseBoundedInt(c.req.query("premise_limit"), 50, 1, 100),
+					reverseLimit: parseBoundedInt(c.req.query("reverse_limit"), 50, 1, 100),
+					maxDepth: parseBoundedInt(c.req.query("max_depth"), 3, 0, 3),
+					sessionKey,
+					project,
+				}),
 			);
 		} catch (err) {
 			return c.json({ error: messageForError(err) }, statusForError(err));

--- a/platform/daemon/src/service.test.ts
+++ b/platform/daemon/src/service.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { probeDaemonHealth } from "./service";
+
+describe("daemon service health probe (#1340)", () => {
+	it("uses the liveness endpoint with a bounded request", async () => {
+		let url = "";
+		let signal: AbortSignal | undefined;
+		const result = await probeDaemonHealth(async (input, init) => {
+			url = String(input);
+			signal = init?.signal;
+			return Response.json({ status: "healthy", uptime: 12, pid: 42 });
+		});
+
+		expect(url).toBe("http://localhost:3850/health/live");
+		expect(signal).toBeDefined();
+		expect(signal?.aborted).toBe(false);
+		expect(result).toEqual({ status: "healthy", uptime: 12, pid: 42 });
+	});
+
+	it("reports a degraded status when the liveness probe times out", async () => {
+		const result = await probeDaemonHealth((_input, init) => {
+			const signal = init?.signal;
+			if (!signal) return Promise.reject(new Error("health probe signal missing"));
+
+			return new Promise<Response>((_resolve, reject) => {
+				signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+			});
+		});
+
+		expect(result).toEqual({ status: "degraded", uptime: null, pid: null });
+	});
+});

--- a/platform/daemon/src/service.ts
+++ b/platform/daemon/src/service.ts
@@ -13,10 +13,15 @@ const AGENTS_DIR = resolveDefaultBasePath();
 const DAEMON_DIR = join(AGENTS_DIR, ".daemon");
 const PID_FILE = join(DAEMON_DIR, "pid");
 const LOG_DIR = join(DAEMON_DIR, "logs");
+const DAEMON_PORT = 3850;
+const HEALTH_PROBE_TIMEOUT_MS = 1_200;
+const HEALTH_PROBE_URL = `http://localhost:${DAEMON_PORT}/health/live`;
 
 // Platform-specific paths
 const LAUNCHD_PLIST = join(homedir(), "Library", "LaunchAgents", "ai.signet.daemon.plist");
 const SYSTEMD_UNIT = join(homedir(), ".config", "systemd", "user", "signet.service");
+
+export type ServiceHealthStatus = "healthy" | "degraded" | "unavailable";
 
 export interface ServiceStatus {
 	installed: boolean;
@@ -24,6 +29,53 @@ export interface ServiceStatus {
 	pid: number | null;
 	uptime: number | null;
 	port: number;
+	/** The management probe status; a running process can still be degraded. */
+	status: ServiceHealthStatus;
+}
+
+interface HealthProbeResult {
+	status: ServiceHealthStatus;
+	uptime: number | null;
+	pid: number | null;
+}
+
+/**
+ * Probe only daemon liveness. Service management does not need the database
+ * work performed by the legacy `/health` endpoint, and the deadline prevents
+ * a wedged local daemon from blocking status callers indefinitely.
+ */
+export async function probeDaemonHealth(
+	fetcher?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
+): Promise<HealthProbeResult> {
+	try {
+		const request = fetcher ?? globalThis.fetch;
+		if (typeof request !== "function") {
+			return { status: "degraded", uptime: null, pid: null };
+		}
+
+		const response = await request(HEALTH_PROBE_URL, {
+			signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+		});
+		if (!response.ok) {
+			return { status: "degraded", uptime: null, pid: null };
+		}
+
+		const body = await response.json();
+		if (typeof body !== "object" || body === null) {
+			return { status: "degraded", uptime: null, pid: null };
+		}
+
+		const uptime =
+			"uptime" in body && typeof body.uptime === "number" && Number.isFinite(body.uptime) && body.uptime >= 0
+				? body.uptime
+				: null;
+		const pid =
+			"pid" in body && typeof body.pid === "number" && Number.isInteger(body.pid) && body.pid > 0 ? body.pid : null;
+		const status = "status" in body && body.status === "shutting_down" ? "degraded" : "healthy";
+		return { status, uptime, pid };
+	} catch {
+		return { status: "degraded", uptime: null, pid: null };
+	}
 }
 
 /**
@@ -456,6 +508,9 @@ export async function getDaemonStatus(): Promise<ServiceStatus> {
 	const running = isDaemonRunning();
 	let pid: number | null = null;
 	let uptime: number | null = null;
+	const health: HealthProbeResult = running
+		? await probeDaemonHealth()
+		: { status: "unavailable", uptime: null, pid: null };
 
 	if (running && existsSync(PID_FILE)) {
 		try {
@@ -465,23 +520,11 @@ export async function getDaemonStatus(): Promise<ServiceStatus> {
 		}
 	}
 
-	// Try to get uptime from the daemon API
-	if (running) {
-		try {
-			const response = await fetch("http://localhost:3850/health");
-			if (response.ok) {
-				const data = (await response.json()) as {
-					uptime?: number;
-					pid?: number;
-				};
-				uptime = data.uptime ?? null;
-				if (!pid && data.pid) {
-					pid = data.pid;
-				}
-			}
-		} catch {
-			// Daemon might be starting up
-		}
+	if (health.uptime !== null) {
+		uptime = health.uptime;
+	}
+	if (!pid && health.pid !== null) {
+		pid = health.pid;
 	}
 
 	return {
@@ -489,7 +532,8 @@ export async function getDaemonStatus(): Promise<ServiceStatus> {
 		running,
 		pid,
 		uptime,
-		port: 3850,
+		port: DAEMON_PORT,
+		status: health.status,
 	};
 }
 

--- a/platform/native/Cargo.lock
+++ b/platform/native/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "signet-native"
-version = "0.193.3"
+version = "0.194.0"
 dependencies = [
  "napi",
  "napi-build",

--- a/platform/native/Cargo.lock
+++ b/platform/native/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "signet-native"
-version = "0.194.0"
+version = "0.194.1"
 dependencies = [
  "napi",
  "napi-build",

--- a/platform/native/Cargo.lock
+++ b/platform/native/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "signet-native"
-version = "0.193.2"
+version = "0.193.3"
 dependencies = [
  "napi",
  "napi-build",

--- a/platform/native/Cargo.toml
+++ b/platform/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signet-native"
-version = "0.193.2"
+version = "0.193.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Signet native accelerators (napi-rs)"

--- a/platform/native/Cargo.toml
+++ b/platform/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signet-native"
-version = "0.194.0"
+version = "0.194.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Signet native accelerators (napi-rs)"

--- a/platform/native/Cargo.toml
+++ b/platform/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signet-native"
-version = "0.193.3"
+version = "0.194.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Signet native accelerators (napi-rs)"

--- a/platform/native/package.json
+++ b/platform/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/native",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "private": true,
   "description": "Signet native accelerators",
   "main": "index.js",

--- a/platform/native/package.json
+++ b/platform/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/native",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "private": true,
   "description": "Signet native accelerators",
   "main": "index.js",

--- a/platform/native/package.json
+++ b/platform/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/native",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "private": true,
   "description": "Signet native accelerators",
   "main": "index.js",

--- a/scripts/claim-trace-eval.ts
+++ b/scripts/claim-trace-eval.ts
@@ -1,0 +1,372 @@
+/**
+ * Fixed-input evaluation for the authorized ontology claim trace (#1318).
+ *
+ * Run with:
+ *   bun scripts/claim-trace-eval.ts
+ *
+ * The fixture is intentionally local and deterministic. It exercises the
+ * operation directly, so the metric measures the canonical trace rather than
+ * a renderer or a network server.
+ */
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../platform/daemon/src/db-accessor";
+import { createEpistemicAssertionsInTx } from "../platform/daemon/src/ontology-assertions";
+import {
+	type ClaimTraceResult,
+	OntologyClaimTraceError,
+	explainOntologyClaim,
+} from "../platform/daemon/src/ontology-claim-trace";
+
+const agentId = "eval-agent";
+const now = "2026-08-10T00:00:00.000Z";
+const dir = mkdtempSync(join(tmpdir(), "signet-claim-trace-eval-"));
+mkdirSync(join(dir, "memory"), { recursive: true });
+initDbAccessor(join(dir, "memory", "memories.db"));
+
+interface ScenarioResult {
+	readonly name: string;
+	readonly passed: boolean;
+	readonly unsupportedCertainty: boolean;
+	readonly expected: string;
+	readonly observed: string;
+}
+
+function insertMemory(
+	db: { prepare(sql: string): { run(...params: unknown[]): unknown } },
+	input: {
+		readonly id: string;
+		readonly content: string;
+		readonly agentId?: string;
+		readonly memoryKind: string;
+		readonly deleted?: number;
+	},
+): void {
+	db.prepare(
+		`INSERT INTO memories
+		 (id, content, type, agent_id, updated_by, memory_kind, visibility, scope, is_deleted, created_at, updated_at)
+		 VALUES (?, ?, 'fact', ?, 'claim-trace-eval', ?, 'global', NULL, ?, ?, ?)`,
+	).run(input.id, input.content, input.agentId ?? agentId, input.memoryKind, input.deleted ?? 0, now, now);
+}
+
+function insertClaim(
+	db: { prepare(sql: string): { run(...params: unknown[]): unknown } },
+	input: {
+		readonly id: string;
+		readonly memoryId: string;
+		readonly claimKey: string;
+		readonly content: string;
+		readonly status?: string;
+		readonly version?: number;
+		readonly rootId?: string;
+		readonly previousId?: string | null;
+		readonly groupKey?: string;
+		readonly evidence?: readonly unknown[];
+		readonly agentId?: string;
+	},
+): void {
+	db.prepare(
+		`INSERT INTO entity_attributes
+		 (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
+		  status, group_key, claim_key, version, version_root_id, previous_attribute_id, proposal_evidence,
+		  created_at, updated_at)
+		 VALUES (?, 'eval-aspect', ?, ?, 'attribute', ?, ?, 0.9, 0.8, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	).run(
+		input.id,
+		input.agentId ?? agentId,
+		input.memoryId,
+		input.content,
+		input.content.toLowerCase(),
+		input.status ?? "active",
+		input.groupKey ?? "eval",
+		input.claimKey,
+		input.version ?? 1,
+		input.rootId ?? input.id,
+		input.previousId ?? null,
+		JSON.stringify(input.evidence ?? []),
+		now,
+		now,
+	);
+}
+
+function link(
+	db: { prepare(sql: string): { run(...params: unknown[]): unknown } },
+	derivedMemoryId: string,
+	sourceKind: string,
+	sourceId: string,
+	linkAgentId = agentId,
+): void {
+	db.prepare(
+		`INSERT INTO derived_memory_sources
+		 (derived_memory_id, source_kind, source_id, source_path, agent_id, created_at)
+		 VALUES (?, ?, ?, NULL, ?, ?)`,
+	).run(derivedMemoryId, sourceKind, sourceId, linkAgentId, now);
+}
+
+function explain(
+	claim: string,
+	options: { readonly sessionKey?: string; readonly premiseLimit?: number } = {},
+): ClaimTraceResult {
+	return explainOntologyClaim(getDbAccessor(), {
+		agentId,
+		entity: "Eval Editor",
+		aspect: "preferences",
+		group: claim === "session_pref" ? "sessions" : "eval",
+		claim,
+		sessionKey: options.sessionKey,
+		premiseLimit: options.premiseLimit,
+	});
+}
+
+const scenarios: ScenarioResult[] = [];
+const started = performance.now();
+
+try {
+	getDbAccessor().withWriteTx((db) => {
+		db.prepare(
+			`INSERT INTO entities
+			 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+			 VALUES ('eval-entity', 'Eval Editor', 'eval editor', 'tool', ?, 1, ?, ?)`,
+		).run(agentId, now, now);
+		db.prepare(
+			`INSERT INTO entity_aspects
+			 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+			 VALUES ('eval-aspect', 'eval-entity', ?, 'preferences', 'preferences', 0.8, ?, ?)`,
+		).run(agentId, now, now);
+
+		insertMemory(db, {
+			id: "eval-source-pref",
+			content: "The user prefers the editor to open files in tabs.",
+			memoryKind: "episodic",
+		});
+		insertMemory(db, { id: "eval-derived-old", content: "The editor opens files in tabs.", memoryKind: "derived" });
+		insertMemory(db, {
+			id: "eval-derived-current",
+			content: "The user prefers the editor to open files in tabs.",
+			memoryKind: "derived",
+		});
+		insertMemory(db, {
+			id: "eval-dependent",
+			content: "The editor tab behavior is a current preference.",
+			memoryKind: "derived",
+		});
+		insertClaim(db, {
+			id: "eval-old",
+			memoryId: "eval-derived-old",
+			claimKey: "editor_pref",
+			content: "The editor opens files in tabs.",
+			status: "superseded",
+			version: 1,
+			rootId: "eval-old",
+			evidence: [{ source_ref: "memory:eval-source-pref", quote: "open files in tabs" }],
+		});
+		insertClaim(db, {
+			id: "eval-current",
+			memoryId: "eval-derived-current",
+			claimKey: "editor_pref",
+			content: "The user prefers the editor to open files in tabs.",
+			version: 2,
+			rootId: "eval-old",
+			previousId: "eval-old",
+			evidence: [{ source_ref: "memory:eval-source-pref", quote: "prefers the editor to open files in tabs" }],
+		});
+		db.prepare("UPDATE entity_attributes SET superseded_by = 'eval-current' WHERE id = 'eval-old'").run();
+		insertClaim(db, {
+			id: "eval-dependent-attr",
+			memoryId: "eval-dependent",
+			claimKey: "dependent_note",
+			groupKey: "other",
+			content: "The editor tab behavior is a current preference.",
+		});
+		link(db, "eval-derived-old", "memory", "eval-source-pref");
+		link(db, "eval-derived-current", "memory", "eval-source-pref");
+		link(db, "eval-dependent", "memory", "eval-derived-current");
+
+		for (const [id, content] of [
+			["eval-source-a", "The user prefers tabs in the editor."],
+			["eval-source-b", "The user prefers a single editor pane."],
+		] as const) {
+			insertMemory(db, { id, content, memoryKind: "episodic" });
+		}
+		for (const [id, memoryId, content, sourceId, quote] of [
+			["eval-comp-a", "eval-comp-memory-a", "The editor uses tabs.", "eval-source-a", "prefers tabs"],
+			[
+				"eval-comp-b",
+				"eval-comp-memory-b",
+				"The editor uses one pane.",
+				"eval-source-b",
+				"prefers a single editor pane",
+			],
+		] as const) {
+			insertMemory(db, { id: memoryId, content, memoryKind: "derived" });
+			insertClaim(db, {
+				id,
+				memoryId,
+				claimKey: "competing",
+				content,
+				evidence: [{ source_ref: `memory:${sourceId}`, quote }],
+			});
+			link(db, memoryId, "memory", sourceId);
+		}
+		createEpistemicAssertionsInTx(getDbAccessor(), db, [
+			{
+				agentId,
+				entityId: "eval-entity",
+				claimAttributeId: "eval-comp-a",
+				predicate: "denies",
+				content: "The editor does not use tabs.",
+				evidence: [{ source_ref: "memory:eval-source-a", quote: "prefers tabs" }],
+			},
+		]);
+
+		db.prepare(
+			`INSERT INTO session_transcripts
+			 (session_key, content, harness, project, agent_id, created_at, updated_at, completed_at)
+			 VALUES ('eval-session-a', 'The user prefers tabs in the editor.', 'eval', '/eval', ?, ?, ?, ?)`,
+		).run(agentId, now, now, now);
+		insertMemory(db, { id: "eval-session-derived", content: "Session preference.", memoryKind: "derived" });
+		insertClaim(db, {
+			id: "eval-session-attr",
+			memoryId: "eval-session-derived",
+			claimKey: "session_pref",
+			groupKey: "sessions",
+			content: "The user prefers tabs in the editor.",
+			evidence: [{ source_ref: "transcript:eval-session-a", quote: "prefers tabs in the editor" }],
+		});
+		link(db, "eval-session-derived", "transcript", "eval-session-a");
+
+		insertMemory(db, {
+			id: "eval-deleted-source",
+			content: "The user preferred a deleted option.",
+			memoryKind: "episodic",
+			deleted: 1,
+		});
+		insertMemory(db, { id: "eval-deleted-derived", content: "Deleted claim.", memoryKind: "derived" });
+		insertClaim(db, {
+			id: "eval-deleted-attr",
+			memoryId: "eval-deleted-derived",
+			claimKey: "deleted",
+			content: "The user preferred a deleted option.",
+			evidence: [{ source_ref: "memory:eval-deleted-source", quote: "preferred a deleted option" }],
+		});
+		link(db, "eval-deleted-derived", "memory", "eval-deleted-source");
+
+		insertMemory(db, {
+			id: "eval-foreign-source",
+			content: "Other agent evidence.",
+			agentId: "other-agent",
+			memoryKind: "episodic",
+		});
+		insertMemory(db, { id: "eval-foreign-derived", content: "Foreign claim.", memoryKind: "derived" });
+		insertClaim(db, {
+			id: "eval-foreign-attr",
+			memoryId: "eval-foreign-derived",
+			claimKey: "foreign",
+			content: "Foreign claim.",
+		});
+		link(db, "eval-foreign-derived", "memory", "eval-foreign-source");
+
+		insertMemory(db, { id: "eval-fabricated-derived", content: "Fabricated claim.", memoryKind: "derived" });
+		insertClaim(db, {
+			id: "eval-fabricated-attr",
+			memoryId: "eval-fabricated-derived",
+			claimKey: "fabricated",
+			content: "Fabricated claim.",
+		});
+		link(db, "eval-fabricated-derived", "memory", "does-not-exist");
+	});
+
+	const run = (name: string, expected: string, fn: () => unknown, check: (value: unknown) => boolean): void => {
+		try {
+			const value = fn();
+			const observed =
+				value instanceof Error ? value.message : typeof value === "object" && value !== null ? "trace" : String(value);
+			scenarios.push({
+				name,
+				expected,
+				observed,
+				passed: check(value),
+				unsupportedCertainty: isTrace(value) && value.integrity.status !== "verified",
+			});
+		} catch (error) {
+			const observed = error instanceof OntologyClaimTraceError ? `${error.status}: ${error.message}` : String(error);
+			scenarios.push({ name, expected, observed, passed: check(error), unsupportedCertainty: false });
+		}
+	};
+
+	run(
+		"changed preference exposes current and prior versions",
+		"active + 2 versions",
+		() => explain("editor_pref"),
+		(value) => {
+			return isTrace(value) && value.current.status === "active" && value.versions.items.length === 2;
+		},
+	);
+	run(
+		"competing values remain visible",
+		"competing with contradictory assertion",
+		() => explain("competing"),
+		(value) =>
+			isTrace(value) && value.current.status === "competing" && value.competing.contradictoryAssertions.length === 1,
+	);
+	run(
+		"session allowlist accepts matching transcript",
+		"verified",
+		() => explain("session_pref", { sessionKey: "eval-session-a" }),
+		(value) => isTrace(value) && value.integrity.status === "verified",
+	);
+	run(
+		"session allowlist rejects a different session",
+		"403",
+		() => explain("session_pref", { sessionKey: "eval-session-b" }),
+		(value) => value instanceof OntologyClaimTraceError && value.status === 403,
+	);
+	run(
+		"deleted evidence is not current truth",
+		"invalidated",
+		() => explain("deleted"),
+		(value) => isTrace(value) && value.integrity.status === "invalidated",
+	);
+	run(
+		"cross-agent source is forbidden",
+		"403",
+		() => explain("foreign"),
+		(value) => value instanceof OntologyClaimTraceError && value.status === 403,
+	);
+	run(
+		"fabricated source id is rejected",
+		"409",
+		() => explain("fabricated"),
+		(value) => value instanceof OntologyClaimTraceError && value.status === 409,
+	);
+	run(
+		"reverse lineage is bounded",
+		"one dependent at depth one",
+		() => explain("editor_pref", { premiseLimit: 1 }),
+		(value) => isTrace(value) && value.reverse.items.length === 1 && value.traversal.bounded,
+	);
+} finally {
+	const elapsedMs = Math.round((performance.now() - started) * 100) / 100;
+	const passed = scenarios.filter((scenario) => scenario.passed).length;
+	const unsupportedCertainty = scenarios.filter((scenario) => scenario.unsupportedCertainty).length;
+	const report = {
+		scenarios: scenarios.length,
+		passed,
+		accuracy: scenarios.length === 0 ? 0 : Math.round((passed / scenarios.length) * 1000) / 1000,
+		unsupportedCertainty,
+		latencyMs: elapsedMs,
+		toolCalls: scenarios.length,
+		results: scenarios,
+	};
+	console.log(JSON.stringify(report, null, 2));
+	closeDbAccessor();
+	rmSync(dir, { recursive: true, force: true });
+	if (passed !== scenarios.length) process.exitCode = 1;
+}
+
+function isTrace(value: unknown): value is ClaimTraceResult {
+	return typeof value === "object" && value !== null && "integrity" in value && "traversal" in value;
+}
+
+process.exit(process.exitCode ?? 0);

--- a/surfaces/browser-extension/package.json
+++ b/surfaces/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/extension",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "private": true,
   "description": "Signet browser extension for Chrome and Firefox",
   "scripts": {

--- a/surfaces/browser-extension/package.json
+++ b/surfaces/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/extension",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "private": true,
   "description": "Signet browser extension for Chrome and Firefox",
   "scripts": {

--- a/surfaces/browser-extension/package.json
+++ b/surfaces/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/extension",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "private": true,
   "description": "Signet browser extension for Chrome and Firefox",
   "scripts": {

--- a/surfaces/cli/package.json
+++ b/surfaces/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/cli",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "description": "CLI for Signet - portable AI agent identity",
   "type": "module",
   "bin": "./dist/cli.js",

--- a/surfaces/cli/package.json
+++ b/surfaces/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/cli",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "description": "CLI for Signet - portable AI agent identity",
   "type": "module",
   "bin": "./dist/cli.js",

--- a/surfaces/cli/package.json
+++ b/surfaces/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/cli",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "description": "CLI for Signet - portable AI agent identity",
   "type": "module",
   "bin": "./dist/cli.js",

--- a/surfaces/cli/src/commands/ontology.test.ts
+++ b/surfaces/cli/src/commands/ontology.test.ts
@@ -25,7 +25,16 @@ describe("registerOntologyCommands", () => {
 		expect(ontology).toBeDefined();
 		if (!ontology) throw new Error("ontology command was not registered");
 		expect(ontology?.commands.map((cmd) => cmd.name())).toEqual(
-			expect.arrayContaining(["entity", "claim", "aspect", "link", "stream", "assertions", "assertion"]),
+			expect.arrayContaining([
+				"entity",
+				"claim",
+				"aspect",
+				"link",
+				"stream",
+				"assertions",
+				"assertion",
+				"explain-claim",
+			]),
 		);
 
 		const names = (parent: Command, name: string): readonly string[] =>
@@ -296,6 +305,66 @@ describe("registerOntologyCommands", () => {
 		);
 		expect(lines.join("\n")).toContain("Claim Evidence");
 		expect(lines.join("\n")).toContain("Applied claims retain evidence.");
+	});
+
+	test("explain-claim calls the bounded authorized trace endpoint", async () => {
+		let capturedPath = "";
+		const lines: string[] = [];
+		console.log = (line?: unknown) => {
+			lines.push(String(line ?? ""));
+		};
+
+		const program = new Command();
+		registerOntologyCommands(program, {
+			ensureDaemonForSecrets: async () => true,
+			secretApiCall: async (_method, path) => {
+				capturedPath = path;
+				return {
+					ok: true,
+					data: {
+						path: { groupKey: "ontology", claimKey: "proposal_loop" },
+						current: {
+							status: "active",
+							items: [{ attribute: { content: "Traceable claim", status: "active" } }],
+						},
+						integrity: { status: "verified", verifiedPremises: 1, invalidatedPremises: 0 },
+						traversal: { versionsVisited: 1, premisesVisited: 1, reverseVisited: 0 },
+					},
+				};
+			},
+		});
+
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"explain-claim",
+			"Signet",
+			"architecture",
+			"ontology",
+			"proposal_loop",
+			"--kind",
+			"attribute",
+			"--version-limit",
+			"5",
+			"--premise-limit",
+			"7",
+			"--reverse-limit",
+			"9",
+			"--max-depth",
+			"2",
+			"--session-key",
+			"session-1",
+			"--agent",
+			"ant",
+		]);
+
+		expect(capturedPath).toBe(
+			"/api/ontology/claims/explain?entity=Signet&aspect=architecture&group=ontology&claim=proposal_loop&agent_id=ant&kind=attribute&version_limit=5&premise_limit=7&reverse_limit=9&max_depth=2&session_key=session-1",
+		);
+		expect(lines.join("\n")).toContain("Authorized Claim Trace");
+		expect(lines.join("\n")).toContain("Traceable claim");
+		expect(lines.join("\n")).toContain("verified");
 	});
 
 	test("link-evidence calls the applied link evidence endpoint", async () => {

--- a/surfaces/cli/src/commands/ontology.ts
+++ b/surfaces/cli/src/commands/ontology.ts
@@ -625,6 +625,98 @@ function printClaimEvidence(data: unknown): void {
 	console.log();
 }
 
+function printClaimTrace(data: unknown): void {
+	const record = asRecord(data);
+	const path = asRecord(record.path);
+	const current = asRecord(record.current);
+	const competing = asRecord(record.competing);
+	const integrity = asRecord(record.integrity);
+	const traversal = asRecord(record.traversal);
+	const currentItems = readArray(current, "items") ?? [];
+	const versions = readArray(asRecord(record.versions), "items") ?? [];
+	const premises = readArray(asRecord(record.premises), "items") ?? [];
+	const reverse = readArray(asRecord(record.reverse), "items") ?? [];
+	const competingItems = readArray(competing, "items") ?? [];
+	const assertions = readArray(record, "assertions") ?? [];
+	console.log(chalk.bold("\n  Authorized Claim Trace\n"));
+	console.log(
+		chalk.dim(
+			`  ${String(path.groupKey ?? "general")} / ${String(path.claimKey ?? "unknown")} · ${String(
+				current.status ?? "unknown",
+			)}`,
+		),
+	);
+	for (const raw of currentItems) {
+		const item = asRecord(raw);
+		const attribute = asRecord(item.attribute);
+		console.log(`  ${chalk.cyan(String(attribute.status ?? "unknown"))} ${attribute.content ?? ""}`);
+	}
+	const historical = versions.filter((raw) => {
+		const attribute = asRecord(asRecord(raw).attribute);
+		return attribute.status !== "active";
+	});
+	if (historical.length > 0) {
+		console.log(chalk.dim("  history:"));
+		for (const raw of historical) {
+			const item = asRecord(raw);
+			const attribute = asRecord(item.attribute);
+			console.log(`    ${chalk.yellow(String(attribute.status ?? "unknown"))} ${attribute.content ?? ""}`);
+		}
+	}
+	if (competingItems.length > 0) {
+		console.log(chalk.dim("  competing values:"));
+		for (const raw of competingItems) {
+			const attribute = asRecord(asRecord(raw).attribute);
+			console.log(`    ${chalk.magenta(String(attribute.content ?? ""))}`);
+		}
+	}
+	if (assertions.length > 0) {
+		console.log(chalk.dim("  linked assertions:"));
+		for (const raw of assertions) {
+			const assertion = asRecord(raw);
+			console.log(`    ${chalk.magenta(String(assertion.predicate ?? "asserts"))} ${assertion.content ?? ""}`);
+		}
+	}
+	if (premises.length > 0) {
+		console.log(chalk.dim("  premises:"));
+		for (const raw of premises) {
+			const premise = asRecord(raw);
+			const evidence = asRecord(premise.evidence);
+			const source = `${String(evidence.sourceKind ?? "source")}:${String(evidence.sourceId ?? "unknown")}`;
+			const quote = String(evidence.exactQuote ?? evidence.excerpt ?? "unverified").slice(0, 1200);
+			console.log(`    ${chalk.cyan(String(evidence.state ?? "unknown"))} ${source} — ${quote}`);
+		}
+	}
+	if (reverse.length > 0) {
+		console.log(chalk.dim("  reverse lineage:"));
+		for (const raw of reverse) {
+			const item = asRecord(raw);
+			console.log(`    depth ${String(item.depth ?? "?")} ${item.content ?? ""}`);
+		}
+	}
+	console.log(
+		chalk.dim(
+			`  ${versions.length} version(s) · ${premises.length} premise(s) · ${reverse.length} reverse dependent(s)`,
+		),
+	);
+	console.log(
+		chalk.dim(
+			`  integrity ${String(integrity.status ?? "unknown")} · ${String(
+				integrity.verifiedPremises ?? 0,
+			)} verified · ${String(integrity.invalidatedPremises ?? 0)} invalidated`,
+		),
+	);
+	if (integrity.reason) console.log(chalk.yellow(`  ${String(integrity.reason)}`));
+	console.log(
+		chalk.dim(
+			`  bounded traversal: ${String(traversal.versionsVisited ?? versions.length)} versions, ${String(
+				traversal.premisesVisited ?? premises.length,
+			)} premises, ${String(traversal.reverseVisited ?? reverse.length)} reverse`,
+		),
+	);
+	console.log();
+}
+
 function printAssertions(data: unknown, title = "Epistemic Assertions"): void {
 	const record = asRecord(data);
 	const items = (((record as EpistemicAssertionsResponse).items as readonly EpistemicAssertionItem[] | undefined) ??
@@ -939,6 +1031,39 @@ export function registerOntologyCommands(program: Command, deps: OntologyDeps): 
 		const data = await apiGet(deps, "/api/ontology/claims/evidence", params);
 		if (options.json) console.log(JSON.stringify(data, null, 2));
 		else printClaimEvidence(data);
+	});
+
+	addCommonOptions(
+		ontology
+			.command("explain-claim")
+			.description("Explain an authorized, bounded claim trace")
+			.argument("<entity>", "Entity/object name")
+			.argument("<aspect>", "Aspect name")
+			.argument("<group>", "Group key")
+			.argument("<claim>", "Claim key")
+			.option("--kind <kind>", "attribute or constraint")
+			.option("--version-limit <n>", "Max claim versions", Number.parseInt)
+			.option("--premise-limit <n>", "Max source premises", Number.parseInt)
+			.option("--reverse-limit <n>", "Max reverse dependents", Number.parseInt)
+			.option("--max-depth <n>", "Max lineage depth (0-3)", Number.parseInt)
+			.option("--session-key <key>", "Fail closed when provenance leaves this session"),
+	).action(async (entity: string, aspect: string, group: string, claim: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const params = new URLSearchParams({ entity, aspect, group, claim });
+		appendAgent(params, options.agent);
+		for (const [key, value] of [
+			["kind", options.kind],
+			["version_limit", options.versionLimit],
+			["premise_limit", options.premiseLimit],
+			["reverse_limit", options.reverseLimit],
+			["max_depth", options.maxDepth],
+			["session_key", options.sessionKey],
+		] as const) {
+			if (value !== undefined && value !== "") params.set(key, String(value));
+		}
+		const data = await apiGet(deps, "/api/ontology/claims/explain", params);
+		if (options.json) console.log(JSON.stringify(data, null, 2));
+		else printClaimTrace(data);
 	});
 
 	addCommonOptions(

--- a/surfaces/desktop/package.json
+++ b/surfaces/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/desktop",
-	"version": "0.193.3",
+	"version": "0.194.0",
 	"private": true,
 	"description": "Electron desktop distribution layer for Signet",
 	"homepage": "https://signetai.sh",

--- a/surfaces/desktop/package.json
+++ b/surfaces/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/desktop",
-	"version": "0.194.0",
+	"version": "0.194.1",
 	"private": true,
 	"description": "Electron desktop distribution layer for Signet",
 	"homepage": "https://signetai.sh",

--- a/surfaces/desktop/package.json
+++ b/surfaces/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signet/desktop",
-	"version": "0.193.2",
+	"version": "0.193.3",
 	"private": true,
 	"description": "Electron desktop distribution layer for Signet",
 	"homepage": "https://signetai.sh",

--- a/surfaces/tray/package.json
+++ b/surfaces/tray/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/tray",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "private": true,
   "description": "Shared tray and menu bar state utilities for Signet desktop shells",
   "type": "module",

--- a/surfaces/tray/package.json
+++ b/surfaces/tray/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/tray",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "private": true,
   "description": "Shared tray and menu bar state utilities for Signet desktop shells",
   "type": "module",

--- a/surfaces/tray/package.json
+++ b/surfaces/tray/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signet/tray",
-  "version": "0.193.3",
+  "version": "0.194.0",
   "private": true,
   "description": "Shared tray and menu bar state utilities for Signet desktop shells",
   "type": "module",

--- a/web/docs/src/content/docs/api/health-status.md
+++ b/web/docs/src/content/docs/api/health-status.md
@@ -77,6 +77,12 @@ subsystem, and always returns 200 while the process is alive.
 
 `status` is `"healthy"`, or `"shutting_down"` once shutdown has begun.
 
+The `@signet/daemon` service-management API uses this liveness endpoint for
+`getDaemonStatus()` with a 1.2-second deadline. Its returned `status` is
+`"healthy"` when the probe succeeds, `"degraded"` when the service manager
+reports a running process but the probe fails or reports shutdown, and
+`"unavailable"` when no service is running.
+
 ### GET /health/ready
 
 No authentication required. Readiness probe: reports whether the daemon can

--- a/web/docs/src/content/docs/api/knowledge-ontology.md
+++ b/web/docs/src/content/docs/api/knowledge-ontology.md
@@ -221,6 +221,50 @@ parameters: `entity`, `aspect`, `group`, `claim`, `status`, `kind`, `limit`,
 /api/ontology/claims/evidence?entity=Signet&aspect=architecture&group=ontology&claim=proposal_loop
 ```
 
+### GET /api/ontology/claims/explain
+
+Return one bounded, authorized claim trace over the existing ontology
+versions, linked epistemic assertions, proposal evidence, episodic sources,
+and `derived_memory_sources` reverse lineage. This endpoint is read-only and
+does not create a second provenance store or widen cross-agent recall.
+
+Required query parameters are `entity`, `aspect`, `group`, and `claim`.
+Optional parameters are `kind` (`attribute` or `constraint`),
+`version_limit` (1–50, default 20), `premise_limit` (1–100, default 50),
+`reverse_limit` (1–100, default 50), `max_depth` (0–3, default 3),
+`agent_id`, and `session_key`.
+
+The resolved agent follows the normal scoped-agent/recall permission path.
+Project-scoped tokens can only inspect linked claim memories, premises, and
+reverse dependents in their project. A supplied session key may also be sent
+as `x-signet-session-key`; conflicting values are rejected, and remote calls
+must bind the session to the resolved agent.
+
+Premises must resolve to an existing same-agent canonical episodic source
+(`memory`, `artifact`, `transcript`, or `summary`). When a premise includes an
+exact `quote`, the quote must occur in the immutable source content. Fabricated
+or mismatched references return `409`; cross-agent, cross-project, or
+cross-session references return `403`. Session-scoped traces fail closed when
+the source session cannot be proven. Deleted, superseded, stale, and
+incomplete source records are reported as invalidated or unverified and are
+never returned as verified evidence.
+
+The response includes `current`, `versions`, `competing`, `assertions`,
+`premises`, `reverse`, `authorization`, `integrity`, `traversal`, and
+`latencyMs`. `versions`, `premises`, and `reverse` each expose their bounded
+items and truncation state. `integrity.status` is `verified`, `unverified`, or
+`invalidated` so consumers cannot silently treat an old explanation as current
+truth.
+
+CLI and MCP equivalents:
+
+```bash
+signet ontology explain-claim Signet architecture ontology proposal_loop
+signet ontology explain-claim Signet architecture ontology proposal_loop --session-key session-123 --json
+```
+
+MCP clients call `signet_explain_claim` with the same selectors and bounds.
+
 ### GET /api/ontology/links/:id/evidence
 
 Resolve evidence for an already-applied ontology link from stored dependency

--- a/web/docs/src/content/docs/api/route-inventory.md
+++ b/web/docs/src/content/docs/api/route-inventory.md
@@ -75,6 +75,7 @@ silently disappear from the API reference.
 | POST | `/api/knowledge/expand/session` | platform/daemon/src/routes/knowledge-routes.ts |
 | POST | `/api/graph/impact` | platform/daemon/src/routes/knowledge-routes.ts |
 | GET | `/api/ontology/claims/versions` | platform/daemon/src/routes/ontology-routes.ts |
+| GET | `/api/ontology/claims/explain` | platform/daemon/src/routes/ontology-routes.ts |
 | GET | `/api/ontology/claims/version` | platform/daemon/src/routes/ontology-routes.ts |
 | POST | `/api/ontology/operations/apply` | platform/daemon/src/routes/ontology-routes.ts |
 | POST | `/api/ontology/operations/batch` | platform/daemon/src/routes/ontology-routes.ts |

--- a/web/docs/src/content/docs/harnesses/hermes-agent.md
+++ b/web/docs/src/content/docs/harnesses/hermes-agent.md
@@ -41,13 +41,33 @@ Hermes lifecycle.
    the prompt mentions a known entity or active alias.
 5. At session end, `on_session_end()` sends the accumulated transcript via
    `POST /api/hooks/session-end` for async pipeline extraction.
+6. Committed Hermes built-in memory writes are mirrored through a serialized
+   FIFO queue so add/replace/remove callbacks retain their batch order.
+
+### Built-in memory mirror semantics
+
+The Hermes connector uses synchronization rather than leaving Signet with an
+add-only copy of Hermes memory:
+
+- `add` creates immutable episodic evidence in Signet.
+- `replace` creates a new row and atomically supersedes the row matched by
+  Hermes's `old_text`.
+- `remove` soft-deletes the matched row.
+
+Superseded and deleted rows remain available for provenance and audit history,
+but current Signet recall and list views exclude them. Mirror rows are tagged
+with their Hermes target and use Signet's default `global` visibility, matching
+the connector's existing write contract. They carry agent, project, session,
+source, and a deterministic idempotency key. Retrying a callback is therefore
+safe, and a missing or ambiguous mirrored match is never treated as permission
+to mutate an unrelated Signet memory.
 
 ### Tools exposed to the agent
 
 | Tool | Description |
 |------|-------------|
 | `memory_search` | Hybrid memory search (keyword + semantic + knowledge graph) |
-| `session_search` | Search active or completed session transcripts |
+| `signet_session_search` | Search active or completed session transcripts |
 | `memory_store` | Store a fact/preference/decision with auto entity extraction |
 | `memory_get` | Retrieve a memory by ID |
 | `memory_list` | List memories with optional filters |

--- a/web/docs/src/content/docs/mcp.md
+++ b/web/docs/src/content/docs/mcp.md
@@ -45,6 +45,7 @@ unsafe shell syntax into generated lifecycle hooks.
 | Automatic memory extraction after each prompt | Hooks |
 | Agent wants to search memories mid-conversation | MCP (`signet_recall`, compatibility `memory_search`) |
 | Agent wants to search source-backed docs/artifacts | MCP (`signet_source_search`) |
+| Agent needs to audit a claim's versions and authorized evidence | MCP (`signet_explain_claim`) |
 | Sub-agent needs to inspect its parent session | MCP (`signet_session_search`, compatibility `session_search`) |
 | Codex agent wants to save a durable native-memory note | MCP (`signet_save_note`) |
 | Agent wants to store a specific Signet memory row | MCP (`memory_store`) |
@@ -306,6 +307,38 @@ whose memory IDs were actually recorded for the given session and agent.
 **Note:** Prefer this tool over embedding feedback as raw JSON text. Both
 are supported for backward compatibility, but the MCP tool is recorded
 immediately on the current turn.
+
+### signet_explain_claim
+
+Return an authorized, bounded explanation of one ontology claim. The tool
+joins current and historical claim versions, competing values, contradictory
+epistemic assertions, exact source spans, premise integrity, authorization
+decisions, and reverse derived-memory lineage through the daemon's canonical
+HTTP operation.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `entity` | string | yes | Entity/object name |
+| `aspect` | string | yes | Aspect/room name |
+| `group` | string | yes | Group/dresser key |
+| `claim` | string | yes | Claim/drawer key |
+| `kind` | `attribute \| constraint` | no | Restrict the claim kind |
+| `version_limit` | integer | no | 1–50, default 20 |
+| `premise_limit` | integer | no | 1–100, default 50 |
+| `reverse_limit` | integer | no | 1–100, default 50 |
+| `max_depth` | integer | no | 0–3, default 3 |
+| `session_key` | string | no | Fail closed if a premise crosses this session |
+| `agent_id` | string | no | Agent scope, default `default` |
+
+Fabricated or mismatched source references return an error instead of
+presenting a quote as evidence. Cross-agent, project, and session violations
+fail closed. Deleted or stale evidence is reported as invalidated, and the
+response's `integrity.status` must be checked before treating a claim as
+verified current truth.
+
+**Daemon endpoint:** `GET /api/ontology/claims/explain`
 
 ### session_search
 


### PR DESCRIPTION
## Summary

Bound the daemon service-management health probe so `getDaemonStatus()` cannot wait indefinitely on a wedged local daemon. The management path now uses the DB-free liveness endpoint with an explicit deadline and reports degraded/unavailable status instead of silently looking healthy.

Fixes #1340.

## Changes

- Added a 1.2-second `/health/live` probe with `AbortSignal.timeout()` and structured degraded fallback handling.
- Extended `ServiceStatus` with `healthy`, `degraded`, and `unavailable` management status while preserving the process-level `running` signal.
- Added regression coverage for the liveness endpoint, cancellation signal, and timeout path.
- Documented the service-management probe contract.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/daemon`
- [ ] `@signet/core`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no migrations.

## Testing

- [x] `bun test platform/daemon/src/service.test.ts`
- [x] `bun run --filter '@signet/daemon' typecheck`
- [x] `bun run --filter '@signet/daemon' build`
- [x] `bun run --filter '@signet/docs' typecheck`
- [x] `bun scripts/spec-deps-check.ts`
- [x] Tested against the installed running daemon (`getDaemonStatus()` returned `status: "healthy"`).
- [ ] `bun run lint` — baseline main contains unrelated package-format/style failures; changed-file formatting and daemon checks were run.
- [ ] Full workspace test/typecheck run — baseline workspace checks currently include unrelated daemon/database, extraction-config, connector, and SDK failures; the focused daemon regression test and daemon typecheck pass.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- `getDaemonStatus()` keeps `running` as the service/process observation and uses `status` for liveness availability, so a process that is alive but wedged is reported as degraded rather than incorrectly reported as stopped.
- No schema, agent-scoped data query, admin endpoint, or migration changed. The repository spec dependency check passes.
