### PR TITLE
fix(hermes): mirror replace/remove operations

### DIFF
--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -41,3 +41,13 @@ The connector package exposes programmatic cleanup that restores the previous me
 ```
 
 The connector extends `BaseConnector` from `@signet/connector-base` and ships a bundled Python plugin (`__init__.py`, `client.py`, `plugin.yaml`).
+
+## Built-in memory mirror
+
+Committed Hermes built-in memory writes are synchronized into Signet: adds
+create episodic evidence, replacements create a new row that supersedes the
+old mirrored row, and removals soft-delete it. Historical rows remain
+auditable, while superseded/deleted rows are excluded from current recall.
+Callbacks are processed FIFO after Hermes's atomic batch commit and carry
+agent, project, session, source, visibility, and deterministic idempotency
+provenance so retries cannot recreate stale current context.

--- a/integrations/hermes-agent/connector/hermes-plugin/README.md
+++ b/integrations/hermes-agent/connector/hermes-plugin/README.md
@@ -26,7 +26,7 @@ Environment variables:
 - `SIGNET_HOST` / `SIGNET_PORT` — Host and port separately
 - `SIGNET_TOKEN` — Optional daemon bearer token; sent to loopback daemon URLs by default
 - `SIGNET_TRUSTED_DAEMON_ORIGINS` — Comma-separated remote daemon origins allowed to receive `SIGNET_TOKEN`
-- `SIGNET_AGENT_ID` — Agent scope identifier (default: `hermes-agent`)
+- `SIGNET_AGENT_ID` — Agent scope identifier (unset: inherit the daemon's configured agent, usually `default`)
 - `SIGNET_AGENT_WORKSPACE` — Optional named-agent workspace path (for example `~/.agents/agents/dot`)
 - `SIGNET_AGENT_READ_POLICY` — Optional named-agent memory policy for first registration: `shared` (default), `isolated`, or `group`
 - `SIGNET_AGENT_POLICY_GROUP` — Required when `SIGNET_AGENT_READ_POLICY=group`
@@ -63,3 +63,24 @@ The plugin bridges Hermes Agent's memory lifecycle to the Signet daemon:
 3. **Session end** — Sends a transcript with internal Signet memory delimiters removed to Signet's session-end hook, which queues it for the memory pipeline: extraction, knowledge graph updates, retention decay, and MEMORY.md synthesis.
 
 4. **Explicit tools** — The agent can call canonical Signet tools such as `memory_search` and `memory_store` directly during conversation for on-demand memory operations. Legacy `signet_*` names are handled for compatibility but are not advertised to the model.
+
+## Built-in memory synchronization
+
+The plugin uses a **synchronization** model for Hermes's built-in
+`on_memory_write()` hook:
+
+- `add` creates an immutable episodic Signet row tagged with
+  `hermes-builtin` and the Hermes target (`memory` or `user`).
+- `replace` creates a new episodic row and atomically supersedes the mirrored
+  row identified by Hermes's `old_text`.
+- `remove` soft-deletes the matching mirrored row.
+
+Superseded and soft-deleted rows remain available as historical evidence and
+audit history, but Signet's current recall/list views exclude them. The
+connector queues hook callbacks on one FIFO worker, so operations emitted for
+an already-committed Hermes batch retain their order. Each operation carries
+session, project, agent, source, and a deterministic idempotency key. Mirror
+rows use Signet's default `global` visibility, matching the connector's prior
+write contract; agent and project filters still bound lookup and mutation.
+Retrying the same callback does not create a second current row. A failed
+lookup never falls back to mutating an untagged Signet memory.

--- a/integrations/hermes-agent/connector/hermes-plugin/__init__.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/__init__.py
@@ -20,12 +20,15 @@ Config:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
 import re
 import threading
+import time
 from pathlib import Path
+from queue import Empty, Queue
 from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
@@ -302,6 +305,11 @@ ALL_TOOL_SCHEMAS = [
     REMEMBER_ALIAS_SCHEMA,
 ]
 
+HERMES_MEMORY_SOURCE_TYPE = "hermes-memory-write"
+HERMES_MEMORY_TAG = "hermes-builtin"
+MIRROR_SEARCH_LIMIT = 100
+
+
 def _sanitize_env(value: str) -> str:
     return value.strip().replace("\r", "").replace("\n", "")
 
@@ -337,6 +345,7 @@ class SignetMemoryProvider(MemoryProvider):
 
     def __init__(self):
         self._client = None  # SignetClient
+        self._agent_id = ""
         self._session_key = ""
         self._project = ""
         self._inject_cache = ""
@@ -362,6 +371,13 @@ class SignetMemoryProvider(MemoryProvider):
         _CHECKPOINT_INTERVAL = 30
         self._checkpoint_interval = _CHECKPOINT_INTERVAL
         self._last_checkpoint_turn = 0
+        # Hermes calls on_memory_write once per committed operation, including
+        # once for each operation in an atomic batch. Keep one FIFO worker so
+        # replace/remove cannot overtake the add that established their target.
+        self._mirror_queue: Queue = Queue()
+        self._mirror_worker: Optional[threading.Thread] = None
+        self._mirror_state_lock = threading.Lock()
+        self._mirror_shutdown = False
 
     @property
     def name(self) -> str:
@@ -431,6 +447,10 @@ class SignetMemoryProvider(MemoryProvider):
             # No explicit agent id: the daemon resolves its configured agent
             # (its own SIGNET_AGENT_ID, or 'default' for the default workspace).
             logger.debug("SIGNET_AGENT_ID is not set; the daemon's configured agent scope applies.")
+
+        self._agent_id = agent_id
+        with self._mirror_state_lock:
+            self._mirror_shutdown = False
 
         # Skip for cron/flush contexts — no memory injection needed
         agent_context = kwargs.get("agent_context", "")
@@ -698,7 +718,7 @@ class SignetMemoryProvider(MemoryProvider):
             self._prefetch_result = ""
             self._notification_result = ""
 
-        agent_id = os.environ.get("SIGNET_AGENT_ID", "").strip() or "hermes-agent"
+        agent_id = self._agent_id
         self._project = _resolve_agent_workspace(agent_id, kwargs)
         client = self._client
         if not client:
@@ -723,49 +743,406 @@ class SignetMemoryProvider(MemoryProvider):
         except Exception as e:
             logger.debug("Signet session switch failed: %s", e)
 
-    def on_memory_write(self, action: str, target: str, content: str, metadata: Optional[Dict[str, Any]] = None) -> None:
-        """Mirror built-in memory writes to Signet."""
-        if action != "add" or not content:
+    @staticmethod
+    def _mirror_tags(raw: Any) -> set[str]:
+        if isinstance(raw, list):
+            return {str(tag).strip() for tag in raw if str(tag).strip()}
+        if isinstance(raw, str):
+            return {tag.strip() for tag in raw.split(",") if tag.strip()}
+        return set()
+
+    @staticmethod
+    def _mirror_tag(prefix: str, value: str) -> str:
+        clean = value.replace("\n", " ").replace("\r", " ").strip()
+        return f"{prefix}:{clean[:80]}" if clean else ""
+
+    def _mirror_operation_details(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Dict[str, Any],
+    ) -> Dict[str, str]:
+        """Derive durable, retry-stable identity for one Hermes write."""
+        old_text = str(metadata.get("old_text", "") or "").strip()
+        session_id = str(
+            metadata.get("session_id", "")
+            or metadata.get("_mirror_session_key", "")
+            or self._session_key
+        ).strip()
+        parent_session_id = str(metadata.get("parent_session_id", "") or "").strip()
+        tool_call_id = str(metadata.get("tool_call_id", "") or "").strip()
+        project = str(metadata.get("_mirror_project", self._project) or "").strip()
+        agent_id = str(metadata.get("_mirror_agent_id", self._agent_id) or "").strip()
+        seed = "\0".join(
+            (
+                agent_id,
+                project,
+                session_id,
+                parent_session_id,
+                target,
+                action,
+                old_text,
+                content,
+                tool_call_id,
+            )
+        )
+        digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()
+        operation_key = f"hermes-memory-write:{digest}"
+
+        # Preserve Hermes's tool-call id as the source id for the common add
+        # path. Replacements get an operation-specific suffix because every
+        # operation in a Hermes batch shares one tool-call id.
+        if tool_call_id and action == "add":
+            source_id = tool_call_id
+        elif tool_call_id:
+            source_id = f"{tool_call_id}:{action}:{digest[:16]}"
+        else:
+            source_id = f"hermes-memory-write:{digest}"
+
+        return {
+            "old_text": old_text,
+            "session_id": session_id,
+            "request_id": operation_key,
+            "source_id": source_id,
+            "idempotency_key": operation_key,
+            "mirror_tag": f"mirror:{digest[:24]}",
+            "project": project,
+            "agent_id": agent_id,
+        }
+
+    def _mirror_write_tags(
+        self,
+        target: str,
+        metadata: Dict[str, Any],
+        operation_tag: str,
+        session_id: str,
+    ) -> List[str]:
+        tags = [HERMES_MEMORY_TAG, target, operation_tag]
+        for tag in (
+            self._mirror_tag(
+                "origin",
+                str(metadata.get("write_origin", "") or metadata.get("source", "")),
+            ),
+            self._mirror_tag("context", str(metadata.get("execution_context", "") or "")),
+            self._mirror_tag("platform", str(metadata.get("platform", "") or "")),
+            self._mirror_tag("session", session_id),
+            self._mirror_tag("parent-session", str(metadata.get("parent_session_id", "") or "")),
+            self._mirror_tag("tool", str(metadata.get("tool_name", "") or "")),
+        ):
+            if tag:
+                tags.append(tag)
+        return tags
+
+    def _find_mirrored_entries(
+        self,
+        query: str,
+        target: str,
+        *,
+        client: Any = None,
+        project: str = "",
+        source_id: str = "",
+        operation_tag: str = "",
+    ) -> List[Dict[str, Any]]:
+        """Find active Hermes rows without crossing project/agent boundaries."""
+        client = client or self._client
+        if not client:
+            return []
+        scoped_project = project or self._project
+        rows = client.search(
+            query,
+            limit=MIRROR_SEARCH_LIMIT,
+            tags=HERMES_MEMORY_TAG,
+            project=scoped_project,
+        )
+
+        matches: List[Dict[str, Any]] = []
+        for row in rows or []:
+            if not isinstance(row, dict):
+                continue
+            content = str(row.get("content", "") or "")
+            tags = self._mirror_tags(row.get("tags"))
+            row_source_id = str(row.get("source_id", "") or row.get("sourceId", "") or "")
+            if HERMES_MEMORY_TAG not in tags or target not in tags:
+                continue
+            if source_id and row_source_id != source_id and operation_tag not in tags:
+                continue
+            if operation_tag and operation_tag not in tags:
+                continue
+            if query and query not in content:
+                continue
+            matches.append(row)
+        return matches
+
+    def _remember_mirror(
+        self,
+        content: str,
+        *,
+        client: Any = None,
+        tags: List[str],
+        project: str,
+        source_id: str,
+        operation_key: str,
+        visibility: str = "global",
+        supersedes: str = "",
+        reason: str = "",
+        session_id: str = "",
+        request_id: str = "",
+    ) -> Optional[Dict[str, Any]]:
+        """Write one mirror row, retrying a source-id collision safely."""
+        client = client or self._client
+        if not client:
+            return None
+        result = client.remember(
+            content,
+            importance=0.6,
+            tags=tags,
+            project=project,
+            visibility=visibility,
+            source_type=HERMES_MEMORY_SOURCE_TYPE,
+            source_id=source_id,
+            idempotency_key=operation_key,
+            supersedes=supersedes,
+            reason=reason,
+            session_id=session_id,
+            request_id=request_id,
+        )
+        if not result or not isinstance(result, dict):
+            return result
+
+        # A tool-call id is shared by every operation in a Hermes batch. If an
+        # earlier add claimed that source id, retry the new operation with its
+        # content-derived id rather than accepting a false dedupe.
+        returned_content = str(result.get("content", "") or "").strip()
+        if result.get("deduped") is True and returned_content and returned_content != content.strip():
+            fallback_source_id = f"{source_id}:{operation_key[-16:]}"
+            return client.remember(
+                content,
+                importance=0.6,
+                tags=tags,
+                project=project,
+                visibility=visibility,
+                source_type=HERMES_MEMORY_SOURCE_TYPE,
+                source_id=fallback_source_id,
+                idempotency_key=operation_key,
+                supersedes=supersedes,
+                reason=reason,
+                session_id=session_id,
+                request_id=request_id,
+            )
+        return result
+
+    def _mirror_operation(
+        self,
+        client: Any,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Dict[str, Any],
+    ) -> None:
+        if not client:
+            return
+
+        details = self._mirror_operation_details(action, target, content, metadata)
+        old_text = details["old_text"]
+        session_id = details["session_id"]
+        source_id = details["source_id"]
+        operation_key = details["idempotency_key"]
+        operation_tag = details["mirror_tag"]
+        tags = self._mirror_write_tags(target, metadata, operation_tag, session_id)
+        request_id = details["request_id"]
+        project = details["project"]
+
+        if action == "add":
+            result = self._remember_mirror(
+                content,
+                client=client,
+                tags=tags,
+                project=project,
+                source_id=source_id,
+                operation_key=operation_key,
+                session_id=session_id,
+                request_id=request_id,
+            )
+            if result is None:
+                logger.warning("Signet Hermes add mirror returned no response")
+            return
+
+        if not old_text:
+            logger.warning("Signet Hermes %s mirror skipped: old_text was not supplied", action)
+            return
+
+        if action == "replace":
+            if not content:
+                logger.warning("Signet Hermes replace mirror skipped: content was empty")
+                return
+
+            # A completed replace is found by its operation tag/source id. This
+            # makes a retry a no-op even though the old row is no longer in the
+            # current recall view.
+            completed = self._find_mirrored_entries(
+                content,
+                target,
+                client=client,
+                project=project,
+                source_id=source_id,
+                operation_tag=operation_tag,
+            )
+            if completed:
+                return
+
+            matches = self._find_mirrored_entries(old_text, target, client=client, project=project)
+            distinct_contents = {str(row.get("content", "")) for row in matches}
+            if len(distinct_contents) > 1:
+                logger.warning(
+                    "Signet Hermes replace mirror skipped: old_text matched multiple mirrored entries"
+                )
+                return
+            if not matches:
+                # The old row may already have been superseded by a prior
+                # delivery. No current stale row can be reintroduced.
+                logger.debug("Signet Hermes replace mirror found no active source row")
+                return
+
+            old_id = str(matches[0].get("id", "") or "").strip()
+            if not old_id:
+                logger.warning("Signet Hermes replace mirror skipped: matched row had no id")
+                return
+            result = self._remember_mirror(
+                content,
+                client=client,
+                tags=tags,
+                project=project,
+                source_id=source_id,
+                operation_key=operation_key,
+                supersedes=old_id,
+                reason="Hermes built-in memory replacement",
+                session_id=session_id,
+                request_id=request_id,
+            )
+            if not result:
+                logger.warning("Signet Hermes replace mirror returned no response")
+                return
+
+            # A content/source dedupe can return an existing current row before
+            # the daemon sees `supersedes`. Link that row explicitly so the old
+            # Hermes entry still cannot remain current.
+            if result.get("deduped") is True:
+                replacement_id = str(result.get("id", "") or "").strip()
+                if replacement_id and replacement_id != old_id and hasattr(client, "supersede_memory"):
+                    linked = client.supersede_memory(
+                        old_id,
+                        replacement_id,
+                        reason="Hermes built-in memory replacement",
+                        session_id=session_id,
+                        request_id=request_id,
+                    )
+                    if linked is None:
+                        logger.warning("Signet Hermes replace mirror could not link a deduped replacement")
+            return
+
+        if action == "remove":
+            matches = self._find_mirrored_entries(old_text, target, client=client, project=project)
+            distinct_contents = {str(row.get("content", "")) for row in matches}
+            if len(distinct_contents) > 1:
+                logger.warning(
+                    "Signet Hermes remove mirror skipped: old_text matched multiple mirrored entries"
+                )
+                return
+            if not matches:
+                # Soft-delete is idempotent from the current-view perspective:
+                # a prior delivery already removed this row, or it was never
+                # mirrored. In neither case should a stale row be recreated.
+                return
+            memory_id = str(matches[0].get("id", "") or "").strip()
+            if not memory_id:
+                logger.warning("Signet Hermes remove mirror skipped: matched row had no id")
+                return
+            result = client.forget_memory(
+                memory_id,
+                reason="Hermes built-in memory removal",
+                session_id=session_id,
+                request_id=request_id,
+            )
+            if result is None:
+                logger.warning("Signet Hermes remove mirror returned no response")
+
+    def _mirror_worker_loop(self) -> None:
+        while True:
+            try:
+                client, action, target, content, metadata = self._mirror_queue.get(timeout=0.1)
+            except Empty:
+                with self._mirror_state_lock:
+                    if self._mirror_shutdown or self._mirror_queue.empty():
+                        self._mirror_worker = None
+                        return
+                continue
+            try:
+                self._mirror_operation(client, action, target, content, metadata)
+            except Exception as e:
+                logger.warning(
+                    "Signet Hermes memory mirror failed for %s/%s: %s",
+                    action,
+                    target,
+                    e,
+                )
+            finally:
+                self._mirror_queue.task_done()
+
+    def flush_mirror_writes(self, timeout: float = 5.0) -> bool:
+        """Wait for queued mirror operations, primarily for shutdown/tests."""
+        deadline = time.monotonic() + max(0.0, timeout)
+        while self._mirror_queue.unfinished_tasks > 0 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        return self._mirror_queue.unfinished_tasks == 0
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Mirror committed Hermes memory writes in FIFO order.
+
+        Hermes only calls this after the built-in memory tool commits. The
+        single daemon worker therefore preserves the order of atomic batch
+        operations without blocking the agent turn on a network request.
+        """
+        if not isinstance(action, str) or not isinstance(target, str) or not isinstance(content, str):
+            logger.warning("Signet Hermes memory mirror skipped malformed operation")
+            return
+        action = action.strip()
+        target = target.strip()
+        content = content.strip()
+        if action not in {"add", "replace", "remove"}:
+            return
+        if action in {"add", "replace"} and not content:
+            return
+        if target not in {"memory", "user"}:
+            logger.warning("Signet Hermes memory mirror skipped unknown target: %s", target)
             return
         client = self._client
         if not client:
             return
-        project = self._project
-        metadata = metadata if isinstance(metadata, dict) else {}
-        write_origin = str(metadata.get("write_origin", "") or metadata.get("source", "")).strip()
-        execution_context = str(metadata.get("execution_context", "")).strip()
-        platform = str(metadata.get("platform", "")).strip()
-        source_id = str(metadata.get("tool_call_id", "") or "").strip()
-        session_id = str(metadata.get("session_id", "") or self._session_key).strip()
-
-        def _tag(prefix: str, value: str) -> str:
-            clean = value.replace("\n", " ").replace("\r", " ").strip()
-            return f"{prefix}:{clean[:80]}" if clean else ""
-
-        def _write():
-            try:
-                tags = ["hermes-builtin", target]
-                for tag in (
-                    _tag("origin", write_origin),
-                    _tag("context", execution_context),
-                    _tag("platform", platform),
-                    _tag("session", session_id),
-                ):
-                    if tag:
-                        tags.append(tag)
-                client.remember(
-                    content,
-                    importance=0.6,
-                    tags=tags,
-                    project=project,
-                    source_type="hermes-memory-write" if source_id else "",
-                    source_id=source_id,
+        snapshot = dict(metadata) if isinstance(metadata, dict) else {}
+        snapshot["_mirror_project"] = self._project
+        snapshot["_mirror_agent_id"] = self._agent_id or str(
+            getattr(client, "_agent_id", "") or ""
+        )
+        snapshot["_mirror_session_key"] = self._session_key
+        with self._mirror_state_lock:
+            if self._mirror_shutdown:
+                logger.debug("Signet Hermes memory mirror rejected after shutdown")
+                return
+            self._mirror_queue.put((client, action, target, content, snapshot))
+            if self._mirror_worker is None or not self._mirror_worker.is_alive():
+                self._mirror_worker = threading.Thread(
+                    target=self._mirror_worker_loop,
+                    daemon=True,
+                    name="signet-memwrite-serial",
                 )
-            except Exception as e:
-                logger.debug("Signet memory mirror failed: %s", e)
-
-        t = threading.Thread(target=_write, daemon=True, name="signet-memwrite")
-        t.start()
+                self._mirror_worker.start()
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Call session-end hook to trigger memory extraction from transcript."""
@@ -1134,6 +1511,12 @@ class SignetMemoryProvider(MemoryProvider):
 
     def shutdown(self) -> None:
         """Clean shutdown — wait for background threads."""
+        with self._mirror_state_lock:
+            self._mirror_shutdown = True
+            mirror_worker = self._mirror_worker
+        self.flush_mirror_writes(timeout=5.0)
+        if mirror_worker and mirror_worker.is_alive():
+            mirror_worker.join(timeout=0.1)
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=5.0)
 

--- a/integrations/hermes-agent/connector/hermes-plugin/client.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/client.py
@@ -194,6 +194,22 @@ class SignetClient:
             h.update(extra)
         return h
 
+    @staticmethod
+    def _mutation_context_headers(
+        *,
+        session_id: str = "",
+        request_id: str = "",
+    ) -> Optional[Dict[str, str]]:
+        """Build optional audit headers for a mirrored memory mutation."""
+        headers: Dict[str, str] = {}
+        clean_session_id = _sanitize(session_id)
+        clean_request_id = _sanitize(request_id)
+        if clean_session_id:
+            headers["x-signet-session-id"] = clean_session_id
+        if clean_request_id:
+            headers["x-signet-request-id"] = clean_request_id
+        return headers or None
+
     def _post(
         self,
         path: str,
@@ -261,10 +277,11 @@ class SignetClient:
         path: str,
         *,
         timeout: float = _TIMEOUT_SECS,
+        extra_headers: Optional[Dict[str, str]] = None,
     ) -> Optional[Dict[str, Any]]:
         """DELETE from the daemon. Returns parsed response or None on failure."""
         url = f"{self._base_url}{path}"
-        req = urllib.request.Request(url, headers=self._headers(), method="DELETE")
+        req = urllib.request.Request(url, headers=self._headers(extra_headers), method="DELETE")
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
                 return _read_json_response(resp)
@@ -449,6 +466,12 @@ class SignetClient:
         structured: Optional[Dict[str, Any]] = None,
         review_after: str = "",
         who: str = "hermes-agent",
+        visibility: str = "",
+        supersedes: str = "",
+        reason: str = "",
+        idempotency_key: str = "",
+        session_id: str = "",
+        request_id: str = "",
     ) -> Optional[Dict[str, Any]]:
         """Store a memory via the daemon API."""
         body: Dict[str, Any] = {
@@ -478,6 +501,22 @@ class SignetClient:
             body["structured"] = structured
         if review_after:
             body["reviewAfter"] = review_after
+        if visibility in {"global", "private", "archived"}:
+            body["visibility"] = visibility
+        if supersedes:
+            body["supersedes"] = supersedes
+        if reason:
+            body["reason"] = reason
+        if idempotency_key:
+            body["idempotencyKey"] = idempotency_key
+        context_headers = self._mutation_context_headers(session_id=session_id, request_id=request_id)
+        if context_headers:
+            return self._post(
+                "/api/memory/remember",
+                body,
+                timeout=_LONG_TIMEOUT_SECS,
+                extra_headers=context_headers,
+            )
         return self._post("/api/memory/remember", body, timeout=_LONG_TIMEOUT_SECS)
 
     def recall(
@@ -611,10 +650,36 @@ class SignetClient:
         memory_id: str,
         *,
         reason: str,
+        session_id: str = "",
+        request_id: str = "",
     ) -> Optional[Dict[str, Any]]:
         """Soft-delete a memory by ID."""
         params = urllib.parse.urlencode({"reason": reason})
-        return self._delete(f"/api/memory/{urllib.parse.quote(memory_id)}?{params}")
+        path = f"/api/memory/{urllib.parse.quote(memory_id, safe='')}?{params}"
+        context_headers = self._mutation_context_headers(session_id=session_id, request_id=request_id)
+        if context_headers:
+            return self._delete(path, extra_headers=context_headers)
+        return self._delete(path)
+
+    def supersede_memory(
+        self,
+        memory_id: str,
+        superseded_by: str,
+        *,
+        reason: str,
+        session_id: str = "",
+        request_id: str = "",
+    ) -> Optional[Dict[str, Any]]:
+        """Mark one memory as superseded by another in an audited transaction."""
+        path = f"/api/memories/{urllib.parse.quote(memory_id, safe='')}/supersede"
+        body = {
+            "superseded_by": superseded_by,
+            "reason": reason,
+        }
+        context_headers = self._mutation_context_headers(session_id=session_id, request_id=request_id)
+        if context_headers:
+            return self._post(path, body, extra_headers=context_headers)
+        return self._post(path, body)
 
     def search(
         self,
@@ -622,11 +687,17 @@ class SignetClient:
         *,
         limit: int = 10,
         memory_type: str = "",
+        tags: str = "",
+        project: str = "",
     ) -> List[Dict[str, Any]]:
         """Search memories. Returns list of memory objects."""
-        params = f"?q={urllib.parse.quote(query)}&limit={limit}"
+        params = f"?q={urllib.parse.quote(query, safe='')}&limit={limit}"
         if memory_type:
-            params += f"&type={urllib.parse.quote(memory_type)}"
+            params += f"&type={urllib.parse.quote(memory_type, safe='')}"
+        if tags:
+            params += f"&tags={urllib.parse.quote(tags, safe='')}"
+        if project:
+            params += f"&project={urllib.parse.quote(project, safe='')}"
         result = self._get(f"/api/memory/search{params}")
         if result and isinstance(result, dict):
             return result.get("results", result.get("memories", []))

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -999,7 +999,7 @@ for vector in contract["vectors"]:
 		expect(plugin).toContain("metadata: Optional[Dict[str, Any]] = None");
 		expect(plugin).toContain('metadata.get("write_origin", "")');
 		expect(plugin).toContain('metadata.get("tool_call_id", "")');
-		expect(plugin).toContain('source_type="hermes-memory-write" if source_id else ""');
+		expect(plugin).toContain("source_type=HERMES_MEMORY_SOURCE_TYPE");
 		expect(plugin).toContain('self._inject_cache = ""');
 		expect(plugin).toContain("self._prefetch_generation += 1");
 	});
@@ -1162,12 +1162,13 @@ assert calls == [{
 					"from plugins.memory.signet import SignetMemoryProvider",
 					"class FakeClient:",
 					"    def __init__(self): self.calls = []",
-					"    def remember(self, content, **kwargs): self.calls.append({'content': content, **kwargs})",
+					"    def remember(self, content, **kwargs): self.calls.append({'content': content, **kwargs}); return {'id': 'memory-id', 'content': content}",
 					"provider = SignetMemoryProvider()",
 					"provider._client = FakeClient()",
 					"provider._project = '/tmp/project'",
 					"provider._session_key = 'session-a'",
 					"provider.on_memory_write('add', 'memory', 'durable fact', metadata={'write_origin': 'assistant_tool', 'execution_context': 'foreground', 'platform': 'cli', 'session_id': 'session-a', 'tool_call_id': 'call-123'})",
+					"assert provider.flush_mirror_writes()",
 					"provider._client.calls and print(json.dumps(provider._client.calls[0], sort_keys=True))",
 				].join("\n"),
 			],
@@ -1182,6 +1183,70 @@ assert calls == [{
 		expect(result.stdout).toContain('"context:foreground"');
 		expect(result.stdout).toContain('"platform:cli"');
 		expect(result.stdout).toContain('"session:session-a"');
+	});
+
+	it("mirrors add, replace, and remove in order without reviving stale context", () => {
+		const fixture = join(tmpRoot, "python-memory-mirror-fixture");
+		cpSync(join(import.meta.dir, "hermes-plugin"), join(fixture, "plugins", "memory", "signet"), { recursive: true });
+		mkdirSync(join(fixture, "agent"), { recursive: true });
+		writeFileSync(join(fixture, "agent", "__init__.py"), "");
+		writeFileSync(join(fixture, "plugins", "__init__.py"), "");
+		writeFileSync(join(fixture, "plugins", "memory", "__init__.py"), "");
+		writeFileSync(join(fixture, "agent", "memory_provider.py"), "class MemoryProvider:\n    pass\n");
+
+		const result = spawnSync(
+			resolveTestPythonPath(),
+			[
+				"-c",
+				[
+					"import json",
+					"from plugins.memory.signet import SignetMemoryProvider",
+					"class FakeClient:",
+					"    def __init__(self): self.rows = []; self.mutations = []",
+					"    def search(self, query, **kwargs):",
+					"        return [row for row in self.rows if row.get('active') and query in row['content']]",
+					"    def recall(self, query, **kwargs): return {'results': self.search(query, **kwargs)}",
+					"    def remember(self, content, **kwargs):",
+					"        old_id = kwargs.get('supersedes')",
+					"        if old_id:",
+					"            for row in self.rows:",
+					"                if row['id'] == old_id: row['active'] = False",
+					"            memory_id = 'replacement'",
+					"            self.mutations.append(('replace', old_id, memory_id))",
+					"        else:",
+					"            memory_id = 'original'",
+					"            self.mutations.append(('add', memory_id))",
+					"        self.rows.append({'id': memory_id, 'content': content, 'tags': kwargs['tags'], 'source_id': kwargs['source_id'], 'active': True})",
+					"        return {'id': memory_id, 'content': content}",
+					"    def forget_memory(self, memory_id, **kwargs):",
+					"        for row in self.rows:",
+					"            if row['id'] == memory_id: row['active'] = False",
+					"        self.mutations.append(('remove', memory_id))",
+					"        return {'id': memory_id, 'status': 'deleted'}",
+					"provider = SignetMemoryProvider()",
+					"provider._client = FakeClient()",
+					"provider._project = '/tmp/project'",
+					"provider._session_key = 'session-a'",
+					"metadata = {'session_id': 'session-a', 'tool_call_id': 'batch-call'}",
+					"provider.on_memory_write('add', 'memory', 'old preference', metadata=metadata)",
+					"provider.on_memory_write('replace', 'memory', 'new preference', metadata={**metadata, 'old_text': 'old preference'})",
+					"provider.on_memory_write('replace', 'memory', 'new preference', metadata={**metadata, 'old_text': 'old preference'})",
+					"provider.on_memory_write('remove', 'memory', '', metadata={**metadata, 'old_text': 'new preference'})",
+					"provider.on_memory_write('remove', 'memory', '', metadata={**metadata, 'old_text': 'new preference'})",
+					"assert provider.flush_mirror_writes()",
+					"assert provider._client.mutations == [('add', 'original'), ('replace', 'original', 'replacement'), ('remove', 'replacement')]",
+					"assert [row['content'] for row in provider._client.rows] == ['old preference', 'new preference']",
+					"assert not any(row['active'] for row in provider._client.rows)",
+					"assert provider._client.recall('preference')['results'] == []",
+					"print(json.dumps(provider._client.mutations))",
+				].join("\n"),
+			],
+			{ env: { ...process.env, PYTHONPATH: fixture }, encoding: "utf-8" },
+		);
+
+		expect(result.status, result.stderr || result.stdout).toBe(0);
+		expect(result.stdout).toContain("replace");
+		expect(result.stdout).toContain("remove");
 	});
 
 	it("stores Hermes delegation memories with project scope", () => {
@@ -1433,6 +1498,82 @@ assert calls == [{
 		expect(result.stdout).toContain('"path": "/api/sessions/search"');
 		expect(result.stdout).toContain('"agentId": "research-agent"');
 		expect(result.stdout).toContain('"agentId": "explicit-agent"');
+	});
+
+	it("sends mirror lineage, visibility, and audit provenance to the daemon", () => {
+		const clientPath = join(import.meta.dir, "hermes-plugin", "client.py");
+		const script = String.raw`
+import importlib.util
+
+spec = importlib.util.spec_from_file_location("signet_client", __import__("sys").argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+client = module.SignetClient(agent_id="research-agent", harness="hermes-agent")
+posts = []
+deletes = []
+gets = []
+def fake_post(path, body, **kwargs):
+    posts.append((path, body, kwargs))
+    return {"id": "replacement-id", "content": body.get("content", "")}
+def fake_delete(path, **kwargs):
+    deletes.append((path, kwargs))
+    return {"status": "deleted"}
+def fake_get(path, **kwargs):
+    gets.append((path, kwargs))
+    return {"results": []}
+client._post = fake_post
+client._delete = fake_delete
+client._get = fake_get
+client.remember(
+    "new preference",
+    project="/tmp/project",
+    visibility="global",
+    source_type="hermes-memory-write",
+    source_id="call-123:replace:abc",
+    idempotency_key="hermes-memory-write:operation",
+    supersedes="old-id",
+    reason="Hermes built-in memory replacement",
+    session_id="session-a",
+    request_id="request-a",
+)
+client.supersede_memory(
+    "old-id",
+    "replacement-id",
+    reason="Hermes built-in memory replacement",
+    session_id="session-a",
+    request_id="request-a",
+)
+client.forget_memory(
+    "replacement-id",
+    reason="Hermes built-in memory removal",
+    session_id="session-a",
+    request_id="request-b",
+)
+client.search("new preference", tags="hermes-builtin", project="/tmp/project")
+assert posts[0][0] == "/api/memory/remember"
+assert posts[0][1]["agentId"] == "research-agent"
+assert posts[0][1]["visibility"] == "global"
+assert posts[0][1]["supersedes"] == "old-id"
+assert posts[0][1]["idempotencyKey"] == "hermes-memory-write:operation"
+assert posts[0][2]["extra_headers"] == {
+    "x-signet-session-id": "session-a",
+    "x-signet-request-id": "request-a",
+}
+assert posts[1] == (
+    "/api/memories/old-id/supersede",
+    {"superseded_by": "replacement-id", "reason": "Hermes built-in memory replacement"},
+    {"extra_headers": {"x-signet-session-id": "session-a", "x-signet-request-id": "request-a"}},
+)
+assert deletes[0] == (
+    "/api/memory/replacement-id?reason=Hermes+built-in+memory+removal",
+    {"extra_headers": {"x-signet-session-id": "session-a", "x-signet-request-id": "request-b"}},
+)
+assert gets[0][0] == "/api/memory/search?q=new%20preference&limit=10&tags=hermes-builtin&project=%2Ftmp%2Fproject"
+`;
+
+		const result = spawnSync(resolveTestPythonPath(), ["-c", script, clientPath], { encoding: "utf-8" });
+
+		expect(result.status, result.stderr || result.stdout).toBe(0);
 	});
 
 	it("uses longer timeouts for recall paths", () => {

--- a/web/docs/src/content/docs/harnesses/hermes-agent.md
+++ b/web/docs/src/content/docs/harnesses/hermes-agent.md
@@ -41,13 +41,33 @@ Hermes lifecycle.
    the prompt mentions a known entity or active alias.
 5. At session end, `on_session_end()` sends the accumulated transcript via
    `POST /api/hooks/session-end` for async pipeline extraction.
+6. Committed Hermes built-in memory writes are mirrored through a serialized
+   FIFO queue so add/replace/remove callbacks retain their batch order.
+
+### Built-in memory mirror semantics
+
+The Hermes connector uses synchronization rather than leaving Signet with an
+add-only copy of Hermes memory:
+
+- `add` creates immutable episodic evidence in Signet.
+- `replace` creates a new row and atomically supersedes the row matched by
+  Hermes's `old_text`.
+- `remove` soft-deletes the matched row.
+
+Superseded and deleted rows remain available for provenance and audit history,
+but current Signet recall and list views exclude them. Mirror rows are tagged
+with their Hermes target and use Signet's default `global` visibility, matching
+the connector's existing write contract. They carry agent, project, session,
+source, and a deterministic idempotency key. Retrying a callback is therefore
+safe, and a missing or ambiguous mirrored match is never treated as permission
+to mutate an unrelated Signet memory.
 
 ### Tools exposed to the agent
 
 | Tool | Description |
 |------|-------------|
 | `memory_search` | Hybrid memory search (keyword + semantic + knowledge graph) |
-| `session_search` | Search active or completed session transcripts |
+| `signet_session_search` | Search active or completed session transcripts |
 | `memory_store` | Store a fact/preference/decision with auto entity extraction |
 | `memory_get` | Retrieve a memory by ID |
 | `memory_list` | List memories with optional filters |


### PR DESCRIPTION
## Summary

Fixes Hermes's built-in memory mirror so replacements and removals keep Signet's current view aligned with Hermes while retaining historical evidence.

Closes #1310.

## Changes

- Queue committed Hermes `add`/`replace`/`remove` callbacks through one FIFO worker, preserving committed batch order.
- Store immutable episodic evidence for adds, use atomic Signet supersession for replacements, and soft-delete removals.
- Add deterministic operation/source/idempotency provenance with agent, project, session, visibility, and audit context; fail closed on missing or ambiguous matches.
- Add client support for supersession, scoped mirror searches, soft-delete audit headers, and documented mirror semantics.
- Add regression coverage for add -> replace -> remove -> current recall and retry behavior.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: Hermes Agent integration documentation and bundled Python plugin

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations.

## Testing

- [x] `bun test integrations/hermes-agent/connector/index.test.ts` — 78 passed, 0 failed.
- [x] `bun run --cwd integrations/hermes-agent/connector build`
- [x] `bun run --cwd integrations/hermes-agent/connector typecheck`
- [x] `python3 -m py_compile integrations/hermes-agent/connector/hermes-plugin/__init__.py integrations/hermes-agent/connector/hermes-plugin/client.py`
- [x] `bunx biome check integrations/hermes-agent/connector/index.test.ts`
- [x] `SIGNET_PATH=$(mktemp -d) bun test platform/daemon/src/routes/memory-routes-curator.test.ts` — 11 passed, 0 failed.
- [x] `SIGNET_PATH=$(mktemp -d) bun test platform/daemon/src/mutation-api.test.ts` — 32 passed, 0 failed.
- [ ] `bun run test` — the full repository run was attempted after rebuilding core; the current baseline/environment run reported 2,249 passed, 7 skipped, 171 failed, and 14 errors across 2,427 tests, with unrelated SQLite/auth/lock/config/fixture/timeout failures.
- [ ] `bun run typecheck` — the changed Hermes connector passes; unrelated packages fail because generated `extension-bundle.js`/`plugin-bundle.js` files are absent.
- [ ] Tested against a running daemon — the in-process daemon route contract suites above use clean isolated `SIGNET_PATH` directories; no external daemon was required for this connector change.
- [x] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The approved native-harness memory bridge spec was reviewed. This change stays on the existing live Hermes hook write path; it does not add a migration or alter the native-artifact bridge. Superseded/deleted rows remain historical evidence but are excluded from current recall/list views. The root lint command also reports pre-existing formatting failures in untouched package manifests; the changed connector test passes scoped Biome checks.
