### PR TITLE
feat(memory): expose authorized claim reasoning traces (#1318)

### DIFF
--- a/docs/dreaming-skill-runbook.md
+++ b/docs/dreaming-skill-runbook.md
@@ -49,7 +49,15 @@ Inspect versioned claim evidence:
 signet ontology claim versions <entity> <aspect> <group> <claim> --json
 signet ontology claim show <entity> <aspect> <group> <claim> --version 1 --json
 signet ontology claim-evidence <entity> <aspect> <group> <claim> --status all --json
+signet ontology explain-claim <entity> <aspect> <group> <claim> --json
 ```
+
+`explain-claim` is a read-only, bounded audit view over the same applied claim
+versions and derived-memory source links Dreaming already writes. Check
+`integrity.status` before treating a value as verified: deleted, stale, or
+incomplete premises are reported as invalidated/unverified, and a fabricated
+or cross-agent source reference fails closed. Use `--session-key` when a
+Dreaming review must remain within one session's evidence boundary.
 
 ## Entity Merge Path
 

--- a/docs/knowledge-graph-control-plane.md
+++ b/docs/knowledge-graph-control-plane.md
@@ -45,6 +45,7 @@ graph control plane. It is not a speculative product spec.
 | `POST /api/ontology/operations/apply` | CLI/API | dry-run, pending refactor proposal, or applied operation + graph mutation | Direct operation endpoint. Requires `modify`. Covered through operation engine and CLI tests. |
 | `POST /api/ontology/operations/batch` | CLI/API | atomic batch dry-run/propose/apply | Requires `modify`; rolls back on invalid operation. Covered by operation batch tests. |
 | `GET /api/ontology/claims/evidence` | CLI/API | read-only | Covered by claim evidence tests. |
+| `GET /api/ontology/claims/explain` | CLI/API/MCP | read-only | Bounded authorized trace over current/history/competing claims, exact source premises, invalidation state, and reverse lineage. Fabricated or cross-scope premises fail closed. |
 | `GET /api/ontology/claims/versions` | CLI/API | read-only | Covered by version chain tests. |
 | `GET /api/ontology/claims/version` | CLI/API | read-only | Covered by version show tests. |
 | `GET /api/ontology/links/:id/evidence` | CLI/API | read-only | Covered by link evidence tests. |
@@ -66,6 +67,7 @@ graph control plane. It is not a speculative product spec.
 | `signet ontology assertion show/create/link-claim/archive/supersede/import` | CLI | assertion ledger writes | Creates and maintains attributed assertion rows. `supersede` preserves the old predicate when `--predicate` is omitted. `import` accepts a JSON array or `{ "assertions": [...] }`. |
 | `signet ontology entity create/rename/merge/archive` | CLI | direct operation endpoint | Applies by default with audit/provenance. Supports `--dry-run`, `--propose`, `--json`, `--agent`, `--actor`, `--reason`, `--evidence-file`; reserve `--propose` for broad refactors or explicit review. |
 | `signet ontology claim set/versions/show/archive/restore` | CLI | operation endpoint for writes, read endpoints for versions | `set` creates version chains; `restore` only required for claim versions in this slice. |
+| `signet ontology explain-claim <entity> <aspect> <group> <claim>` | CLI | read-only | Uses the canonical HTTP trace; accepts bounded version/premise/reverse limits and optional `--session-key`. |
 | `signet ontology aspect create/rename/archive` | CLI | direct operation endpoint | Uses same audited operation path. |
 | `signet ontology link create/update/archive` | CLI | direct operation endpoint | Uses `entity_dependencies`. |
 | `signet ontology stream apply <path|- >` | CLI | atomic JSONL operation batch | Supports file and stdin, `--dry-run`, `--propose`, `--json`, `--agent`, `--actor`. |

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -33,6 +33,7 @@ flowchart TD
   OEC[Ontology Evolution Core]
   OGW[Ontology Governance Workflow]
   OPL[Ontology Proposal Loop]
+  ACT[Authorized Claim Trace]
   SSF[SSM Foundation Eval]
   EIPT[Engram-Informed Predictor Track]
   SST[SSM Temporal Backbone]
@@ -73,6 +74,9 @@ flowchart TD
   DP --> OEC
   OEC --> OGW
   KA --> OPL
+  KA --> ACT
+  MA --> ACT
+  SR --> ACT
   DMC -.-> OPL
   PMS --> SSF
   DP --> SSF
@@ -630,6 +634,11 @@ Phase ordering based on hard dependencies and integration contracts.
   - proposal/review gates for ontology-impacting schema changes
   - compatibility + rollback requirements
   - CI checks for INDEX/dependencies contract drift
+- **Authorized Claim Trace**: approved (`authorized-claim-trace`)
+  - expose current/history/competing claim state and existing source lineage
+  - preserve agent, project, and session authorization while failing closed on
+    fabricated or cross-scope premises
+  - keep reverse traversal bounded and report invalidated evidence explicitly
 
 ### Wave 8 (SSM translation and shadow deployment)
 
@@ -732,6 +741,7 @@ Legend:
 | `procedural-memory-plan` | approved | `docs/specs/approved/procedural-memory-plan.md` | `memory-pipeline-v2` | `knowledge-architecture-schema` | P1 complete; P2 usage ledger + `skill_meta` usage updates shipped, with decay and broader retrieval follow-ups still remaining |
 | `knowledge-architecture-schema` | complete | `docs/specs/complete/knowledge-architecture-schema.md` | `memory-pipeline-v2`, `session-continuity-protocol`, `procedural-memory-plan` | `predictive-memory-scorer` | KA-1 through KA-6 fully implemented. Audit contract: `entity_dependency_history` captures all dependency mutations via DB-level triggers (`changed_by='db-trigger'`); `related_to` edges require a non-empty reason enforced at both app layer and DB BEFORE INSERT/UPDATE triggers. |
 | `knowledge-architecture-navigation` | approved | `docs/specs/approved/knowledge-architecture-navigation.md` | `knowledge-architecture-schema` | - | Entity/aspect/group/claim/attribute navigation surface for MCP and daemon API. |
+| `authorized-claim-trace` | approved | `docs/specs/approved/authorized-claim-trace.md` | `knowledge-architecture-schema`, `knowledge-architecture-navigation`, `multi-agent-support`, `signet-runtime` | - | Read-only bounded claim reasoning trace over existing versions, assertions, episodic evidence, and derived-memory provenance; fail-closed agent/project/session authorization. |
 | `predictive-memory-scorer` | approved | `docs/specs/approved/predictive-memory-scorer.md` | `memory-pipeline-v2`, `knowledge-architecture-schema`, `session-continuity-protocol` | - | |
 | `multi-agent-support` | approved | `docs/specs/approved/multi-agent-support.md` | `memory-pipeline-v2` | - | |
 | `cross-agent-notification-delivery` | approved | `docs/specs/approved/cross-agent-notification-delivery.md` | `multi-agent-support`, `signet-runtime` | - | Durable agent-scoped peer inbox, explicit acknowledgement, and next-compatible-hook delivery for issue #944 |

--- a/docs/specs/approved/authorized-claim-trace.md
+++ b/docs/specs/approved/authorized-claim-trace.md
@@ -1,0 +1,135 @@
+---
+title: "Authorized Claim Trace"
+id: authorized-claim-trace
+status: approved
+informed_by:
+  - "docs/specs/complete/knowledge-architecture-schema.md"
+  - "docs/specs/approved/knowledge-architecture-navigation.md"
+  - "docs/specs/approved/multi-agent-support.md"
+  - "docs/specs/approved/dreaming-memory-consolidation.md"
+section: "Knowledge Architecture"
+depends_on:
+  - "knowledge-architecture-schema"
+  - "knowledge-architecture-navigation"
+  - "multi-agent-support"
+  - "signet-runtime"
+success_criteria:
+  - "An authorized caller can inspect current truth, bounded claim history, competing assertions, exact source spans, and derived-memory premises through one read-only contract."
+  - "Every returned premise is resolved through the existing agent-scoped source and session authorization path; fabricated, cross-agent, cross-project, or cross-session references fail closed."
+  - "Deleted, superseded, stale, and incomplete evidence is reported as invalidated or unverified rather than presented as current truth."
+  - "Reverse lineage and version traversal remain bounded and expose truncation and traversal limits."
+  - "HTTP, CLI, and MCP consumers expose the same trace operation without creating a second provenance store."
+scope_boundary: "Read-only claim explanation over existing entity_attributes, epistemic_assertions, ontology_proposals, memories, episodic sources, and derived_memory_sources. No new derivation store, cross-agent read policy, or claim mutation behavior."
+---
+
+# Authorized Claim Trace
+
+## Problem
+
+The ontology already stores the pieces needed to explain a claim: version
+links on `entity_attributes`, proposal evidence, source-attributed
+`epistemic_assertions`, semantic memories, and the canonical
+`derived_memory_sources` relation. Existing claim evidence and version
+endpoints expose those pieces separately, while a caller still has to join
+them manually. That makes it easy to mistake a superseded value for current
+truth or to accept an embedded quote whose source no longer exists.
+
+Issue #1318 adds one bounded, read-only explanation operation. It is an
+authorized view over existing rows, not a new lineage database.
+
+## Contract
+
+`GET /api/ontology/claims/explain` accepts:
+
+| Query | Required | Bounds |
+|---|---:|---|
+| `entity`, `aspect`, `group`, `claim` | yes | non-empty path selectors |
+| `kind` | no | `attribute` or `constraint` |
+| `version_limit` | no | 1–50, default 20 |
+| `premise_limit` | no | 1–100, default 50 |
+| `reverse_limit` | no | 1–100, default 50 |
+| `max_depth` | no | 0–3, default 3 |
+| `agent_id` | no | resolved through the normal scoped-agent path |
+| `session_key` | no | optional fail-closed session boundary |
+
+The same `session_key` may be supplied as `x-signet-session-key`; conflicting
+values are rejected. Remote calls must bind the session to the resolved
+agent before the trace is read.
+
+The response contains:
+
+- `current`: active claim versions and a status of `active`, `competing`, or
+  `historical`;
+- `versions`: prior and superseded versions, with `truncated`;
+- `competing`: active competing values and linked `denies` assertions;
+- `assertions`: linked, agent-scoped epistemic assertions;
+- `premises.items`: source kind/id/path, exact verified quote when supplied,
+  bounded excerpt, lifecycle state, source scope metadata, and the owning
+  derived-memory id when the premise came from a derived-memory relation
+  (`null` for assertion-only evidence);
+- `reverse`: bounded derived claims that cite the returned claim's semantic
+  memory;
+- `authorization`: resolved agent/project/session decisions and the fact that
+  the read path is `recall`;
+- `integrity`: `verified`, `unverified`, or `invalidated`, plus counts and a
+  reason when exact evidence cannot support current certainty;
+- `traversal`: all limits, visited counts, and bounded traversal metadata;
+- `latencyMs`: local operation latency for evaluation.
+
+`premises` are not accepted merely because a JSON object contains a quote. A
+reference must identify one of the canonical episodic source kinds
+(`memory`, `artifact`, `transcript`, or `summary`) and the referenced row must
+exist for the same agent. If an exact quote is provided, it must occur in the
+immutable source content. A missing source id or a mismatched quote returns a
+conflict error; a source owned by another agent or outside the authorized
+project/session returns forbidden. Session-scoped calls fail closed when a
+source's session cannot be proven or does not match the requested session.
+
+Deleted or stale source rows remain visible only as bounded lifecycle metadata
+when the caller is authorized to see that row. They never contribute a
+verified quote. The response therefore distinguishes an explanation of what
+was once believed from a current, verified claim.
+
+## Source of truth and invariants
+
+1. `entity_attributes` remains the current/history claim store.
+2. `epistemic_assertions` remains the attributed statement store; `denies`
+   assertions are contradictory context, not current truth.
+3. `derived_memory_sources` remains the only reverse-indexed premise relation
+   for derived semantic memories.
+4. Every ontology query filters by the resolved `agent_id`; the operation does
+   not reuse shared/global recall to widen graph visibility.
+5. Project authorization follows the token project scope used by recall for
+   linked semantic claim memories, source premises, and reverse dependents.
+6. Session authorization uses the existing session-agent binding and requires
+   a provable source session for session-scoped traces.
+7. Limits are enforced before traversal and truncation is explicit.
+
+## Surface parity
+
+- HTTP is the canonical operation.
+- CLI: `signet ontology explain-claim <entity> <aspect> <group> <claim>`.
+- MCP: `signet_explain_claim`.
+
+All three surfaces pass the same selectors, limits, agent scope, and optional
+session boundary to the HTTP operation. They do not perform local joins or
+source authorization.
+
+## Evaluation
+
+The runnable claim-trace evaluation uses fixed local rows and pass/fail
+assertions for:
+
+1. changed preferences: current and prior versions are both present;
+2. competing values and contradictory assertions: both are surfaced without
+   collapsing them into one unsupported truth;
+3. multi-session derivations: an allowlisted session cannot read a premise
+   from another session;
+4. deleted evidence: dependent claims report invalidated integrity;
+5. cross-agent sources and fabricated source ids: both fail closed;
+6. reverse traversal: dependent claims are bounded and report limits.
+
+The evaluation prints scenario accuracy (passed expected outcomes divided by
+scenario count), unsupported-certainty count, latency, and one canonical
+operation count. A non-zero exit status means any expected pass/fail assertion
+failed.

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -1,5 +1,5 @@
 version: 3
-updated_at: "2026-05-06"
+updated_at: "2026-08-10"
 
 specs:
   - id: memory-pipeline-v2
@@ -338,6 +338,30 @@ specs:
       - "Prompt-submit recall remains a lightweight injection path and does not absorb explicit recall product concerns"
       - "Legacy or duplicate TypeScript recall helpers are either removed or reduced to thin wrappers around the canonical recall path"
       - "Consumer renderers preserve useful recall metadata instead of flattening results into source-less snippet lists"
+    decision: null
+
+  - id: authorized-claim-trace
+    status: approved
+    path: docs/specs/approved/authorized-claim-trace.md
+    hard_depends_on:
+      - knowledge-architecture-schema
+      - knowledge-architecture-navigation
+      - multi-agent-support
+      - signet-runtime
+    soft_depends_on:
+      - dreaming-memory-consolidation
+      - explicit-recall-surface-alignment
+    blocks: []
+    informed_by:
+      - docs/specs/complete/knowledge-architecture-schema.md
+      - docs/specs/approved/knowledge-architecture-navigation.md
+      - docs/specs/approved/multi-agent-support.md
+      - docs/specs/approved/dreaming-memory-consolidation.md
+    success_criteria:
+      - "An authorized caller can inspect bounded current/history/competing claim state and existing source lineage without a second provenance store"
+      - "Fabricated, cross-agent, cross-project, and cross-session premise references fail closed"
+      - "Deleted, superseded, stale, and incomplete evidence is marked invalidated or unverified instead of presented as verified current truth"
+      - "HTTP, CLI, and MCP expose one parity operation with explicit limits and truncation"
     decision: null
 
   - id: semantic-prospective-hints

--- a/platform/daemon/src/mcp/tools.test.ts
+++ b/platform/daemon/src/mcp/tools.test.ts
@@ -252,6 +252,7 @@ describe("createMcpServer", () => {
 		expect(names).toContain("knowledge_list_groups");
 		expect(names).toContain("knowledge_list_claims");
 		expect(names).toContain("knowledge_list_attributes");
+		expect(names).toContain("signet_explain_claim");
 		expect(names).toContain("knowledge_hygiene_report");
 		expect(names).toContain("apply_ontology_ops");
 		expect(names).toContain("entity_list");
@@ -287,7 +288,30 @@ describe("createMcpServer", () => {
 		for (const alias of GRAPHIQ_COMPAT_ALIASES) {
 			expect(names).toContain(alias);
 		}
-		expect(names.length).toBe(64);
+		expect(names.length).toBe(65);
+	});
+
+	it("forwards bounded claim trace inputs to the canonical daemon route", async () => {
+		const capture: { url?: string; method?: string } = {};
+		mockFetch(200, { integrity: { status: "verified" } }, capture);
+
+		await callTool(server, "signet_explain_claim", {
+			entity: "Signet",
+			aspect: "architecture",
+			group: "ontology",
+			claim: "proposal_loop",
+			version_limit: 5,
+			premise_limit: 7,
+			reverse_limit: 9,
+			max_depth: 2,
+			session_key: "session-1",
+			agent_id: "ant",
+		});
+
+		expect(capture.method).toBe("GET");
+		expect(capture.url).toBe(
+			"http://localhost:3850/api/ontology/claims/explain?entity=Signet&aspect=architecture&group=ontology&claim=proposal_loop&version_limit=5&premise_limit=7&reverse_limit=9&max_depth=2&session_key=session-1&agent_id=ant",
+		);
 	});
 
 	it("registers generic code tools when GraphIQ has an active project", async () => {

--- a/platform/daemon/src/mcp/tools.ts
+++ b/platform/daemon/src/mcp/tools.ts
@@ -175,6 +175,7 @@ const BASE_TOOL_NAMES = new Set<string>([
 	"knowledge_list_groups",
 	"knowledge_list_claims",
 	"knowledge_list_attributes",
+	"signet_explain_claim",
 	"knowledge_hygiene_report",
 	"apply_ontology_ops",
 	"entity_list",
@@ -2244,6 +2245,19 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		offset: z.number().optional().describe("Pagination offset, default 0"),
 		agent_id: z.string().optional().describe("Agent scope, default default"),
 	});
+	const explainClaimInput = z.object({
+		entity: z.string().min(1).describe("Entity name"),
+		aspect: z.string().min(1).describe("Aspect/room name"),
+		group: z.string().min(1).describe("Group/dresser key"),
+		claim: z.string().min(1).describe("Claim/drawer key"),
+		kind: z.enum(["attribute", "constraint"]).optional(),
+		version_limit: z.number().int().min(1).max(50).optional().describe("Max claim versions"),
+		premise_limit: z.number().int().min(1).max(100).optional().describe("Max source premises"),
+		reverse_limit: z.number().int().min(1).max(100).optional().describe("Max reverse dependents"),
+		max_depth: z.number().int().min(0).max(3).optional().describe("Max bounded lineage depth"),
+		session_key: z.string().optional().describe("Optional session boundary for fail-closed provenance"),
+		agent_id: z.string().optional().describe("Agent scope, default default"),
+	});
 	const hygieneReportInput = z.object({
 		limit: z.number().optional().describe("Max rows per report section, default 50"),
 		memory_limit: z.number().optional().describe("Recent memories to scan for safe mention candidates, default 200"),
@@ -2325,6 +2339,29 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		if (offset !== undefined) params.set("offset", String(offset));
 		if (agent_id) params.set("agent_id", agent_id);
 		return fetchNavigation("/api/knowledge/navigation/attributes", params, "Entity attributes");
+	};
+	const explainClaim = async ({
+		entity,
+		aspect,
+		group,
+		claim,
+		kind,
+		version_limit,
+		premise_limit,
+		reverse_limit,
+		max_depth,
+		session_key,
+		agent_id,
+	}: z.infer<typeof explainClaimInput>) => {
+		const params = new URLSearchParams({ entity, aspect, group, claim });
+		if (kind) params.set("kind", kind);
+		if (version_limit !== undefined) params.set("version_limit", String(version_limit));
+		if (premise_limit !== undefined) params.set("premise_limit", String(premise_limit));
+		if (reverse_limit !== undefined) params.set("reverse_limit", String(reverse_limit));
+		if (max_depth !== undefined) params.set("max_depth", String(max_depth));
+		if (session_key) params.set("session_key", session_key);
+		if (agent_id) params.set("agent_id", agent_id);
+		return fetchNavigation("/api/ontology/claims/explain", params, "Claim trace");
 	};
 	const hygieneReport = async ({ limit, memory_limit, agent_id }: z.infer<typeof hygieneReportInput>) => {
 		const params = new URLSearchParams();
@@ -2432,6 +2469,20 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			annotations: { readOnlyHint: true },
 		},
 		listAttributes,
+	);
+
+	registerMcpTool(
+		server,
+		"signet_explain_claim",
+		{
+			title: "Explain Claim",
+			description:
+				"Return an authorized, bounded claim trace with current and historical versions, competing assertions, " +
+				"exact source spans, premise integrity, scope decisions, and reverse lineage. Missing or cross-agent source IDs fail closed.",
+			inputSchema: explainClaimInput,
+			annotations: { readOnlyHint: true },
+		},
+		explainClaim,
 	);
 
 	registerMcpTool(

--- a/platform/daemon/src/ontology-claim-trace.test.ts
+++ b/platform/daemon/src/ontology-claim-trace.test.ts
@@ -1,0 +1,419 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Hono } from "hono";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { createEpistemicAssertion, linkEpistemicAssertionClaim } from "./ontology-assertions";
+import { OntologyClaimTraceError, explainOntologyClaim } from "./ontology-claim-trace";
+import { registerOntologyRoutes } from "./routes/ontology-routes";
+
+const now = "2026-08-10T00:00:00.000Z";
+
+function insertMemory(
+	db: { prepare(sql: string): { run(...params: unknown[]): unknown } },
+	input: {
+		readonly id: string;
+		readonly content: string;
+		readonly agentId: string;
+		readonly memoryKind: "episodic" | "derived";
+		readonly isDeleted?: number;
+	},
+): void {
+	db.prepare(
+		`INSERT INTO memories
+		 (id, content, type, agent_id, updated_by, memory_kind, visibility, scope, is_deleted, created_at, updated_at)
+		 VALUES (?, ?, 'fact', ?, 'test', ?, 'global', NULL, ?, ?, ?)`,
+	).run(input.id, input.content, input.agentId, input.memoryKind, input.isDeleted ?? 0, now, now);
+}
+
+function insertAttribute(
+	db: { prepare(sql: string): { run(...params: unknown[]): unknown } },
+	input: {
+		readonly id: string;
+		readonly memoryId: string;
+		readonly status: "active" | "superseded" | "deleted";
+		readonly content: string;
+		readonly version: number;
+		readonly previousId: string | null;
+		readonly evidence: readonly unknown[];
+		readonly groupKey?: string;
+		readonly claimKey?: string;
+	},
+): void {
+	db.prepare(
+		`INSERT INTO entity_attributes
+		 (id, aspect_id, agent_id, memory_id, kind, content, normalized_content,
+		  confidence, importance, status, group_key, claim_key, version, version_root_id,
+		  previous_attribute_id, proposal_evidence, created_at, updated_at)
+		 VALUES (?, 'aspect-1', 'ant', ?, 'attribute', ?, ?, 0.9, 0.8, ?, ?,
+		         ?, ?, 'attr-old', ?, ?, ?, ?)`,
+	).run(
+		input.id,
+		input.memoryId,
+		input.content,
+		input.content.toLowerCase(),
+		input.status,
+		input.groupKey ?? "preferences",
+		input.claimKey ?? "editor",
+		input.version,
+		input.previousId,
+		JSON.stringify(input.evidence),
+		now,
+		now,
+	);
+}
+
+function linkSource(
+	db: { prepare(sql: string): { run(...params: unknown[]): unknown } },
+	derivedMemoryId: string,
+	sourceKind: string,
+	sourceId: string,
+): void {
+	db.prepare(
+		`INSERT INTO derived_memory_sources
+		 (derived_memory_id, source_kind, source_id, source_path, agent_id, created_at)
+		 VALUES (?, ?, ?, NULL, 'ant', ?)`,
+	).run(derivedMemoryId, sourceKind, sourceId, now);
+}
+
+describe("authorized ontology claim traces", () => {
+	let dir = "";
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "signet-ontology-claim-trace-"));
+		mkdirSync(join(dir, "memory"), { recursive: true });
+		initDbAccessor(join(dir, "memory", "memories.db"));
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES ('entity-1', 'Editor', 'editor', 'tool', 'ant', 1, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_aspects
+				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES ('aspect-1', 'entity-1', 'ant', 'preferences', 'preferences', 0.8, ?, ?)`,
+			).run(now, now);
+			insertMemory(db, {
+				id: "source-a",
+				content: "The user prefers the editor to open files in tabs.",
+				agentId: "ant",
+				memoryKind: "episodic",
+			});
+			insertMemory(db, {
+				id: "derived-old",
+				content: "The editor opens files in tabs.",
+				agentId: "ant",
+				memoryKind: "derived",
+			});
+			insertMemory(db, {
+				id: "derived-current",
+				content: "The user prefers the editor to open files in tabs.",
+				agentId: "ant",
+				memoryKind: "derived",
+			});
+			insertMemory(db, {
+				id: "derived-dependent",
+				content: "The editor tab behavior is a current preference.",
+				agentId: "ant",
+				memoryKind: "derived",
+			});
+			insertAttribute(db, {
+				id: "attr-old",
+				memoryId: "derived-old",
+				status: "superseded",
+				content: "The editor opens files in tabs.",
+				version: 1,
+				previousId: null,
+				evidence: [{ source_ref: "memory:source-a", quote: "open files in tabs" }],
+			});
+			insertAttribute(db, {
+				id: "attr-current",
+				memoryId: "derived-current",
+				status: "active",
+				content: "The user prefers the editor to open files in tabs.",
+				version: 2,
+				previousId: "attr-old",
+				evidence: [{ source_ref: "memory:source-a", quote: "prefers the editor to open files in tabs" }],
+			});
+			db.prepare("UPDATE entity_attributes SET superseded_by = 'attr-current' WHERE id = 'attr-old'").run();
+			insertAttribute(db, {
+				id: "attr-dependent",
+				memoryId: "derived-dependent",
+				status: "active",
+				content: "The editor tab behavior is a current preference.",
+				version: 1,
+				previousId: null,
+				evidence: [],
+				groupKey: "other",
+				claimKey: "dependent",
+			});
+			linkSource(db, "derived-old", "memory", "source-a");
+			linkSource(db, "derived-current", "memory", "source-a");
+			linkSource(db, "derived-dependent", "memory", "derived-current");
+		});
+	});
+
+	afterEach(() => {
+		closeDbAccessor();
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("returns current truth, history, exact premises, assertions, and bounded reverse lineage", () => {
+		const assertion = createEpistemicAssertion(getDbAccessor(), {
+			agentId: "ant",
+			entityId: "entity-1",
+			predicate: "denies",
+			content: "The editor should not open files in tabs.",
+			evidence: [{ source_ref: "memory:source-a", quote: "prefers the editor" }],
+		});
+		linkEpistemicAssertionClaim(getDbAccessor(), {
+			agentId: "ant",
+			id: assertion.id,
+			attributeId: "attr-current",
+		});
+
+		const trace = explainOntologyClaim(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Editor",
+			aspect: "preferences",
+			group: "preferences",
+			claim: "editor",
+			versionLimit: 10,
+			premiseLimit: 10,
+			reverseLimit: 10,
+			maxDepth: 2,
+		});
+
+		expect(trace.current.status).toBe("active");
+		expect(trace.current.items.map((item) => item.attribute.id)).toEqual(["attr-current"]);
+		expect(trace.versions.items.map((item) => item.attribute.id)).toEqual(["attr-current", "attr-old"]);
+		expect(trace.versions.items[1]?.history.supersededBy).toBe("attr-current");
+		expect(trace.premises.items).toHaveLength(3);
+		expect(trace.premises.items.map((item) => item.evidence.exactQuote)).toEqual([
+			"prefers the editor to open files in tabs",
+			"open files in tabs",
+			"prefers the editor",
+		]);
+		expect(trace.premises.items[0]?.evidence.excerpt).toContain("prefers the editor");
+		expect(trace.integrity.status).toBe("verified");
+		expect(trace.competing.contradictoryAssertions.map((item) => item.id)).toEqual([assertion.id]);
+		expect(trace.reverse.items).toEqual([
+			expect.objectContaining({
+				memoryId: "derived-dependent",
+				attributeId: "attr-dependent",
+				depth: 1,
+			}),
+		]);
+		expect(trace.traversal.bounded).toBe(true);
+		expect(trace.traversal.limits.maxDepth).toBe(2);
+	});
+
+	it("keeps project-scoped reverse lineage within the authorized project", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				"UPDATE memories SET project = 'project-a' WHERE id IN ('source-a', 'derived-old', 'derived-current')",
+			).run();
+			db.prepare("UPDATE memories SET project = 'project-b' WHERE id = 'derived-dependent'").run();
+		});
+
+		const trace = explainOntologyClaim(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Editor",
+			aspect: "preferences",
+			group: "preferences",
+			claim: "editor",
+			project: "project-a",
+		});
+		expect(trace.reverse.items).toHaveLength(0);
+	});
+
+	it("rejects a project-scoped claim whose semantic memory is outside the project", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE memories SET project = 'project-b' WHERE id = 'derived-current'").run();
+		});
+		expect(() =>
+			explainOntologyClaim(getDbAccessor(), {
+				agentId: "ant",
+				entity: "Editor",
+				aspect: "preferences",
+				group: "preferences",
+				claim: "editor",
+				project: "project-a",
+			}),
+		).toThrowError(new OntologyClaimTraceError("Claim is outside the authorized project scope", 403));
+	});
+
+	it("resolves exact artifact spans without returning artifact session tokens", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				"DELETE FROM derived_memory_sources WHERE derived_memory_id IN ('derived-old', 'derived-current')",
+			).run();
+			db.prepare(
+				"UPDATE entity_attributes SET proposal_evidence = '[]' WHERE id IN ('attr-old', 'attr-current')",
+			).run();
+			db.prepare("UPDATE entity_attributes SET proposal_evidence = ? WHERE id = 'attr-current'").run(
+				JSON.stringify([
+					"artifact-secret-token",
+					{
+						source_ref: "artifact:sources/claim.md",
+						quote: "The artifact confirms tabs.",
+						session_token: "artifact-secret-token",
+					},
+				]),
+			);
+			db.prepare(
+				`INSERT INTO memory_artifacts
+				 (agent_id, source_path, source_sha256, source_kind, session_id, session_key, session_token,
+				  captured_at, content, updated_at, is_deleted)
+				 VALUES ('ant', 'sources/claim.md', 'sha-claim', 'source_obsidian_markdown',
+				         'artifact-session', 'artifact-session', 'artifact-secret-token', ?,
+				         'The artifact confirms tabs.', ?, 0)`,
+			).run(now, now);
+		});
+
+		const trace = explainOntologyClaim(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Editor",
+			aspect: "preferences",
+			group: "preferences",
+			claim: "editor",
+		});
+		expect(trace.integrity.status).toBe("verified");
+		expect(JSON.stringify(trace)).not.toContain("artifact-secret-token");
+		expect(trace.premises.items[0]?.evidence).toMatchObject({
+			sourceKind: "artifact",
+			sourceId: "sources/claim.md",
+			exactQuote: "The artifact confirms tabs.",
+			scope: { sessionKeys: [] },
+		});
+	});
+
+	it("does not treat legacy noncanonical lineage metadata as source evidence", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				"DELETE FROM derived_memory_sources WHERE derived_memory_id IN ('derived-old', 'derived-current')",
+			).run();
+			db.prepare(
+				"UPDATE entity_attributes SET proposal_evidence = '[]' WHERE id IN ('attr-old', 'attr-current')",
+			).run();
+			linkSource(db, "derived-current", "ontology_claim", "attr-old");
+		});
+
+		const trace = explainOntologyClaim(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Editor",
+			aspect: "preferences",
+			group: "preferences",
+			claim: "editor",
+		});
+		expect(trace.premises.items).toHaveLength(0);
+		expect(trace.integrity.status).toBe("unverified");
+	});
+
+	it("rejects fabricated and cross-agent premise ids", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("DELETE FROM derived_memory_sources WHERE derived_memory_id = 'derived-current'").run();
+			linkSource(db, "derived-current", "memory", "missing-source");
+		});
+		expect(() =>
+			explainOntologyClaim(getDbAccessor(), {
+				agentId: "ant",
+				entity: "Editor",
+				aspect: "preferences",
+				group: "preferences",
+				claim: "editor",
+			}),
+		).toThrowError(new OntologyClaimTraceError("Claim premise 'memory:missing-source' was not found", 409));
+
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("DELETE FROM derived_memory_sources WHERE derived_memory_id = 'derived-current'").run();
+			insertMemory(db, {
+				id: "shared-id",
+				content: "Other agent evidence.",
+				agentId: "other",
+				memoryKind: "episodic",
+			});
+			linkSource(db, "derived-current", "memory", "shared-id");
+		});
+		expect(() =>
+			explainOntologyClaim(getDbAccessor(), {
+				agentId: "ant",
+				entity: "Editor",
+				aspect: "preferences",
+				group: "preferences",
+				claim: "editor",
+			}),
+		).toThrowError(new OntologyClaimTraceError("Claim premise crosses the authorized agent scope", 403));
+	});
+
+	it("rejects an exact-quote claim that is not present in the source", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE entity_attributes SET proposal_evidence = ? WHERE id = 'attr-current'").run(
+				JSON.stringify([{ source_ref: "memory:source-a", quote: "This sentence was never recorded." }]),
+			);
+		});
+		expect(() =>
+			explainOntologyClaim(getDbAccessor(), {
+				agentId: "ant",
+				entity: "Editor",
+				aspect: "preferences",
+				group: "preferences",
+				claim: "editor",
+			}),
+		).toThrowError(new OntologyClaimTraceError("Claim premise quote does not match the immutable source", 409));
+	});
+
+	it("reports deleted evidence as invalidated and rejects a session boundary crossing", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE memories SET is_deleted = 1 WHERE id = 'source-a'").run();
+		});
+		const invalidated = explainOntologyClaim(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Editor",
+			aspect: "preferences",
+			group: "preferences",
+			claim: "editor",
+		});
+		expect(invalidated.integrity.status).toBe("invalidated");
+		expect(invalidated.premises.items[0]?.evidence.state).toBe("deleted");
+
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("DELETE FROM derived_memory_sources WHERE derived_memory_id = 'derived-current'").run();
+			db.prepare(
+				`INSERT INTO session_transcripts
+				 (session_key, content, harness, project, agent_id, created_at, updated_at, completed_at)
+				 VALUES ('session-a', 'The user prefers the editor.', 'test', '/repo', 'ant', ?, ?, ?)`,
+			).run(now, now, now);
+			linkSource(db, "derived-current", "transcript", "session-a");
+		});
+		expect(() =>
+			explainOntologyClaim(getDbAccessor(), {
+				agentId: "ant",
+				entity: "Editor",
+				aspect: "preferences",
+				group: "preferences",
+				claim: "editor",
+				sessionKey: "session-b",
+			}),
+		).toThrowError(new OntologyClaimTraceError("Claim trace premise crosses the authorized session boundary", 403));
+	});
+
+	it("serves the trace through the read-only HTTP route", async () => {
+		const app = new Hono();
+		registerOntologyRoutes(app);
+		const response = await app.request(
+			"/api/ontology/claims/explain?entity=Editor&aspect=preferences&group=preferences&claim=editor&agent_id=ant",
+		);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { readonly integrity?: { readonly status?: string } };
+		expect(body.integrity?.status).toBe("verified");
+
+		const conflict = await app.request(
+			"/api/ontology/claims/explain?entity=Editor&aspect=preferences&group=preferences&claim=editor&session_key=one",
+			{ headers: { "x-signet-session-key": "two" } },
+		);
+		expect(conflict.status).toBe(400);
+	});
+});

--- a/platform/daemon/src/ontology-claim-trace.ts
+++ b/platform/daemon/src/ontology-claim-trace.ts
@@ -1,0 +1,1189 @@
+import type { AttributeKind, Entity, EntityAspect, EntityAttribute, EpistemicAssertion } from "@signet/core";
+import type { DbAccessor, ReadDb } from "./db-accessor";
+import { tableExists } from "./db-helpers";
+import { findEpisodicSourceAgentIds, readEpisodicSource, sourceIdCandidates } from "./episodic-sources";
+import { listEntityAttributesByPath } from "./knowledge-graph";
+
+const SOURCE_KINDS = ["memory", "artifact", "transcript", "summary"] as const;
+const MAX_VERSION_LIMIT = 50;
+const MAX_PREMISE_LIMIT = 100;
+const MAX_REVERSE_LIMIT = 100;
+const MAX_DEPTH = 3;
+const MAX_EXCERPT_LENGTH = 1200;
+
+type TraceSourceKind = (typeof SOURCE_KINDS)[number];
+type TraceIntegrity = "verified" | "unverified" | "invalidated";
+
+interface TraceReference {
+	readonly sourceKind: string | null;
+	readonly sourceId: string | null;
+	readonly sourcePath: string | null;
+	readonly quote: string | null;
+	readonly strict?: boolean;
+	readonly derivedMemoryId?: string | null;
+	readonly reference: unknown;
+}
+
+interface TraceSource {
+	readonly kind: TraceSourceKind;
+	readonly id: string;
+	readonly path: string | null;
+	readonly content: string | null;
+	readonly project: string | null;
+	readonly visibility: string | null;
+	readonly scope: string | null;
+	readonly sessionKeys: readonly string[];
+	readonly state: "available" | "deleted" | "stale" | "incomplete";
+}
+
+interface TraceEvidence {
+	readonly sourceKind: TraceSourceKind;
+	readonly sourceId: string;
+	readonly sourcePath: string | null;
+	readonly exactQuote: string | null;
+	readonly excerpt: string | null;
+	readonly found: boolean;
+	readonly state: TraceSource["state"] | "quote_unverified";
+	readonly scope: {
+		readonly agentId: string;
+		readonly project: string | null;
+		readonly visibility: string | null;
+		readonly sessionKeys: readonly string[];
+	};
+	readonly reference: unknown;
+}
+
+interface TracePremise {
+	readonly depth: number;
+	readonly derivedMemoryId: string | null;
+	readonly evidence: TraceEvidence;
+}
+
+interface TraceVersion {
+	readonly attribute: EntityAttribute;
+	readonly lifecycle: {
+		readonly status: EntityAttribute["status"];
+		readonly memoryId: string | null;
+		readonly memoryPresent: boolean;
+		readonly staleAt: string | null;
+		readonly supersededBy: string | null;
+	};
+	readonly history: {
+		readonly version: number | null;
+		readonly versionRootId: string | null;
+		readonly previousAttributeId: string | null;
+		readonly supersededBy: string | null;
+	};
+}
+
+interface TraceAssertion {
+	readonly id: string;
+	readonly agentId: string;
+	readonly subjectEntityId: string;
+	readonly subjectEntityName: string | null;
+	readonly claimAttributeId: string | null;
+	readonly predicate: EpistemicAssertion["predicate"];
+	readonly content: string;
+	readonly normalizedContent: string;
+	readonly speaker: string | null;
+	readonly assertedAt: string;
+	readonly confidence: number;
+	readonly evidence: readonly unknown[];
+	readonly sourceKind: string | null;
+	readonly sourceId: string | null;
+	readonly sourcePath: string | null;
+	readonly sourceRoot: string | null;
+	readonly status: EpistemicAssertion["status"];
+	readonly supersedesAssertionId: string | null;
+	readonly archivedAt: string | null;
+	readonly archivedBy: string | null;
+	readonly archiveReason: string | null;
+	readonly createdBy: string;
+	readonly createdAt: string;
+	readonly updatedAt: string;
+	readonly evidenceRefs: readonly TraceReference[];
+}
+
+interface ReverseTraceItem {
+	readonly attributeId: string | null;
+	readonly memoryId: string;
+	readonly entity: string | null;
+	readonly aspect: string | null;
+	readonly groupKey: string | null;
+	readonly claimKey: string | null;
+	readonly content: string;
+	readonly status: string;
+	readonly depth: number;
+}
+
+export interface ExplainClaimParams {
+	readonly agentId: string;
+	readonly entity: string;
+	readonly aspect: string;
+	readonly group: string;
+	readonly claim: string;
+	readonly kind?: AttributeKind;
+	readonly versionLimit?: number;
+	readonly premiseLimit?: number;
+	readonly reverseLimit?: number;
+	readonly maxDepth?: number;
+	readonly sessionKey?: string | null;
+	readonly project?: string | null;
+}
+
+export interface ClaimTraceResult {
+	readonly entity: Entity;
+	readonly aspect: EntityAspect;
+	readonly path: {
+		readonly groupKey: string;
+		readonly claimKey: string;
+		readonly kind: AttributeKind | null;
+	};
+	readonly current: {
+		readonly items: readonly TraceVersion[];
+		readonly status: "active" | "competing" | "historical" | "empty";
+	};
+	readonly versions: {
+		readonly items: readonly TraceVersion[];
+		readonly truncated: boolean;
+	};
+	readonly competing: {
+		readonly items: readonly TraceVersion[];
+		readonly contradictoryAssertions: readonly TraceAssertion[];
+	};
+	readonly assertions: readonly TraceAssertion[];
+	readonly premises: {
+		readonly items: readonly TracePremise[];
+		readonly truncated: boolean;
+	};
+	readonly reverse: {
+		readonly items: readonly ReverseTraceItem[];
+		readonly truncated: boolean;
+	};
+	readonly authorization: {
+		readonly agentId: string;
+		readonly project: string | null;
+		readonly sessionKey: string | null;
+		readonly decisions: {
+			readonly agent: "allowed";
+			readonly project: "unrestricted" | "allowed";
+			readonly session: "unrestricted" | "allowed";
+		};
+		readonly readPath: "recall";
+	};
+	readonly integrity: {
+		readonly status: TraceIntegrity;
+		readonly verifiedPremises: number;
+		readonly invalidatedPremises: number;
+		readonly unverifiedPremises: number;
+		readonly reason: string | null;
+	};
+	readonly traversal: {
+		readonly limits: {
+			readonly versionLimit: number;
+			readonly premiseLimit: number;
+			readonly reverseLimit: number;
+			readonly maxDepth: number;
+		};
+		readonly versionsVisited: number;
+		readonly premisesVisited: number;
+		readonly reverseVisited: number;
+		readonly maxDepthReached: number;
+		readonly bounded: true;
+	};
+	readonly latencyMs: number;
+}
+
+export class OntologyClaimTraceError extends Error {
+	constructor(
+		message: string,
+		readonly status: 400 | 403 | 404 | 409,
+	) {
+		super(message);
+		this.name = "OntologyClaimTraceError";
+	}
+}
+
+interface MemoryStateRow {
+	id: string;
+	is_deleted: number | null;
+	stale_at: string | null;
+	superseded_by: string | null;
+	project: string | null;
+	visibility: string | null;
+	scope: string | null;
+}
+
+interface RawAssertionRow {
+	id: string;
+	agent_id: string;
+	subject_entity_id: string;
+	subject_entity_name: string | null;
+	claim_attribute_id: string | null;
+	predicate: EpistemicAssertion["predicate"];
+	content: string;
+	normalized_content: string;
+	speaker: string | null;
+	asserted_at: string;
+	confidence: number;
+	evidence: string;
+	source_kind: string | null;
+	source_id: string | null;
+	source_path: string | null;
+	source_root: string | null;
+	status: EpistemicAssertion["status"];
+	supersedes_assertion_id: string | null;
+	archived_at: string | null;
+	archived_by: string | null;
+	archive_reason: string | null;
+	created_by: string;
+	created_at: string;
+	updated_at: string;
+}
+
+interface RawReverseRow {
+	readonly memory_id: string;
+	readonly attribute_id: string | null;
+	readonly entity_name: string | null;
+	readonly aspect_name: string | null;
+	readonly group_key: string | null;
+	readonly claim_key: string | null;
+	readonly content: string;
+	readonly status: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | null {
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function parseJsonArray(value: string | null | undefined): readonly unknown[] {
+	if (!value) return [];
+	try {
+		const parsed: unknown = JSON.parse(value);
+		return Array.isArray(parsed) ? parsed : [];
+	} catch {
+		return [];
+	}
+}
+
+function parseReference(value: unknown): TraceReference | null {
+	if (typeof value === "string") {
+		const trimmed = value.trim();
+		if (!trimmed) return null;
+		const separator = trimmed.indexOf(":");
+		return separator > 0
+			? {
+					sourceKind: trimmed.slice(0, separator),
+					sourceId: trimmed.slice(separator + 1),
+					sourcePath: null,
+					quote: null,
+					strict: true,
+					reference: value,
+				}
+			: { sourceKind: null, sourceId: trimmed, sourcePath: null, quote: null, strict: true, reference: value };
+	}
+	if (!isRecord(value)) return null;
+	const sourceRef = stringValue(value.source_ref) ?? stringValue(value.sourceRef);
+	let sourceKind = stringValue(value.source_kind) ?? stringValue(value.sourceKind);
+	let sourceId = stringValue(value.source_id) ?? stringValue(value.sourceId);
+	if (sourceRef) {
+		const separator = sourceRef.indexOf(":");
+		if (separator > 0 && separator < sourceRef.length - 1) {
+			sourceKind = sourceRef.slice(0, separator);
+			sourceId = sourceRef.slice(separator + 1);
+		}
+	}
+	if (!sourceId) sourceId = stringValue(value.memory_id) ?? stringValue(value.memoryId);
+	if (!sourceKind && (value.memory_id !== undefined || value.memoryId !== undefined) && sourceId) {
+		sourceKind = "memory";
+	}
+	return {
+		sourceKind,
+		sourceId,
+		sourcePath: stringValue(value.source_path) ?? stringValue(value.sourcePath),
+		quote: stringValue(value.quote),
+		strict:
+			Boolean(sourceRef) ||
+			(canonicalSourceKind(sourceKind) !== null && sourceId !== null) ||
+			Boolean(value.memory_id) ||
+			Boolean(value.memoryId),
+		reference: value,
+	};
+}
+
+function canonicalSourceKind(value: string | null): TraceSourceKind | null {
+	if (!value) return null;
+	return SOURCE_KINDS.includes(value as TraceSourceKind) ? (value as TraceSourceKind) : null;
+}
+
+function sourceRefParts(reference: TraceReference): { readonly kind: string | null; readonly id: string } {
+	const explicitKind = reference.sourceKind;
+	const sourceId = reference.sourceId?.trim() ?? "";
+	if (explicitKind) return { kind: explicitKind, id: sourceId };
+	const separator = sourceId.indexOf(":");
+	if (separator > 0 && separator < sourceId.length - 1) {
+		return { kind: sourceId.slice(0, separator), id: sourceId.slice(separator + 1) };
+	}
+	return { kind: null, id: sourceId };
+}
+
+function mergeReferences(references: readonly TraceReference[]): TraceReference[] {
+	const merged = new Map<string, TraceReference>();
+	const quotedBases = new Set<string>();
+	for (const reference of references) {
+		const parts = sourceRefParts(reference);
+		const kind = parts.kind;
+		const id = parts.id;
+		const baseKey = `${kind ?? ""}\u0000${id}\u0000${reference.sourcePath ?? ""}`;
+		if (reference.quote !== null) {
+			const key = `${baseKey}\u0000quote\u0000${reference.quote}`;
+			merged.delete(`${baseKey}\u0000noquote`);
+			if (!merged.has(key)) {
+				merged.set(key, {
+					...reference,
+					sourceKind: kind,
+					sourceId: id,
+				});
+			}
+			quotedBases.add(baseKey);
+			continue;
+		}
+		if (quotedBases.has(baseKey)) continue;
+		const key = `${baseKey}\u0000noquote`;
+		if (!merged.has(key)) {
+			merged.set(key, {
+				...reference,
+				sourceKind: kind,
+				sourceId: id,
+			});
+		}
+	}
+	return [...merged.values()];
+}
+
+function compactExcerpt(content: string, quote: string): string {
+	const index = content.indexOf(quote);
+	const start = Math.max(0, index - Math.floor((MAX_EXCERPT_LENGTH - quote.length) / 2));
+	const end = Math.min(content.length, start + MAX_EXCERPT_LENGTH);
+	return `${start > 0 ? "..." : ""}${content.slice(start, end)}${end < content.length ? "..." : ""}`;
+}
+
+function publicReference(value: unknown): unknown | null {
+	const parsed = parseReference(value);
+	if (!parsed) return null;
+	const kind = canonicalSourceKind(parsed.sourceKind);
+	const sourceId = parsed.sourceId?.trim() ?? "";
+	if (!kind || !sourceId) return null;
+	if (typeof value === "string") return `${kind}:${sourceId}`;
+	if (!isRecord(value)) return null;
+
+	// Evidence metadata is untrusted input. Return only the canonical source
+	// identity and human-readable span fields; in particular, never echo
+	// session IDs/tokens or connector-specific metadata from the stored object.
+	const result: Record<string, string> = { source_ref: `${kind}:${sourceId}` };
+	const sourcePath = parsed.sourcePath;
+	const quote = parsed.quote;
+	const sourceRoot = stringValue(value.source_root) ?? stringValue(value.sourceRoot);
+	if (sourcePath) result.source_path = sourcePath;
+	if (sourceRoot) result.source_root = sourceRoot;
+	if (quote) result.quote = quote;
+	return result;
+}
+
+function publicEvidence(values: readonly unknown[]): readonly unknown[] {
+	return values.map(publicReference).filter((item): item is unknown => item !== null);
+}
+
+function visibleSessionKeys(sessionKey: string | null): readonly string[] {
+	// Source-native session tokens remain internal authorization material. Only
+	// echo the boundary the caller explicitly supplied; never return discovered
+	// session IDs/tokens from artifact metadata.
+	return sessionKey === null ? [] : [sessionKey];
+}
+
+function boundedInteger(value: number | undefined, fallback: number, max: number, name: string): number {
+	const normalized = value ?? fallback;
+	if (!Number.isInteger(normalized) || normalized < 1 || normalized > max) {
+		throw new OntologyClaimTraceError(`${name} must be an integer between 1 and ${max}`, 400);
+	}
+	return normalized;
+}
+
+function boundedDepth(value: number | undefined): number {
+	const normalized = value ?? MAX_DEPTH;
+	if (!Number.isInteger(normalized) || normalized < 0 || normalized > MAX_DEPTH) {
+		throw new OntologyClaimTraceError(`maxDepth must be an integer between 0 and ${MAX_DEPTH}`, 400);
+	}
+	return normalized;
+}
+
+function memoryState(db: ReadDb, agentId: string, memoryId: string | null): MemoryStateRow | null {
+	if (!memoryId || !tableExists(db, "memories")) return null;
+	return (
+		(db
+			.prepare(
+				`SELECT id, COALESCE(is_deleted, 0) AS is_deleted, stale_at, superseded_by, project, visibility, scope
+			 FROM memories WHERE id = ? AND agent_id = ? LIMIT 1`,
+			)
+			.get(memoryId, agentId) as MemoryStateRow | undefined) ?? null
+	);
+}
+
+function requireProjectScopedAttribute(db: ReadDb, attribute: EntityAttribute, project: string | null): void {
+	if (project === null) return;
+	const memory = memoryState(db, attribute.agentId, attribute.memoryId);
+	if (!memory || memory.project !== project) {
+		throw new OntologyClaimTraceError("Claim is outside the authorized project scope", 403);
+	}
+}
+
+function sourceSessionKeys(
+	db: ReadDb,
+	agentId: string,
+	kind: TraceSourceKind,
+	id: string,
+	path: string | null,
+): string[] {
+	const keys = new Set<string>();
+	const candidates = sourceIdCandidates(id);
+	const placeholders = candidates.map(() => "?").join(", ");
+	if (kind === "transcript") keys.add(id.replace(/^(transcript|session):/, ""));
+	if (kind === "artifact" && tableExists(db, "memory_artifacts")) {
+		const rows = db
+			.prepare(
+				`SELECT session_id, session_key, session_token
+				 FROM memory_artifacts
+				 WHERE agent_id = ? AND (
+				   source_path = ? OR source_node_id IN (${placeholders}) OR session_id IN (${placeholders})
+				   OR session_key IN (${placeholders}) OR session_token IN (${placeholders})
+				 )`,
+			)
+			.all(agentId, path ?? id, ...candidates, ...candidates, ...candidates, ...candidates) as Array<{
+			readonly session_id: string | null;
+			readonly session_key: string | null;
+			readonly session_token: string | null;
+		}>;
+		for (const row of rows) {
+			for (const value of [row.session_key, row.session_id, row.session_token]) {
+				if (value) keys.add(value);
+			}
+		}
+	}
+	if (kind === "summary" && tableExists(db, "session_summaries")) {
+		const rows = db
+			.prepare(
+				`SELECT session_key, source_ref FROM session_summaries
+				 WHERE agent_id = ? AND (id IN (${placeholders}) OR source_ref IN (${placeholders}))`,
+			)
+			.all(agentId, ...candidates, ...candidates) as Array<{
+			readonly session_key: string | null;
+			readonly source_ref: string | null;
+		}>;
+		for (const row of rows) {
+			if (row.session_key) keys.add(row.session_key);
+			const sourceRef = row.source_ref?.trim();
+			if (sourceRef?.startsWith("session:") || sourceRef?.startsWith("transcript:")) {
+				keys.add(sourceRef.slice(sourceRef.indexOf(":") + 1));
+			}
+		}
+	}
+	if (kind === "memory" && tableExists(db, "memories")) {
+		const row = db
+			.prepare("SELECT source_type, source_id FROM memories WHERE id = ? AND agent_id = ? LIMIT 1")
+			.get(id, agentId) as { readonly source_type: string | null; readonly source_id: string | null } | undefined;
+		if (row?.source_id) {
+			if (row.source_type === "transcript" || row.source_type === "session") {
+				keys.add(row.source_id.replace(/^(transcript|session):/, ""));
+			}
+			if (tableExists(db, "memory_artifacts")) {
+				const linked = db
+					.prepare(
+						`SELECT session_key, session_id, session_token FROM memory_artifacts
+							 WHERE agent_id = ? AND (source_node_id = ? OR source_id = ?)`,
+					)
+					.all(agentId, row.source_id, row.source_id) as Array<{
+					readonly session_key: string | null;
+					readonly session_id: string | null;
+					readonly session_token: string | null;
+				}>;
+				for (const linkedRow of linked) {
+					for (const value of [linkedRow.session_key, linkedRow.session_id, linkedRow.session_token]) {
+						if (value) keys.add(value);
+					}
+				}
+			}
+		}
+	}
+	return [...keys];
+}
+
+function sourceAgentIds(db: ReadDb, kind: TraceSourceKind, id: string, path: string | null): readonly string[] {
+	// This is an ownership probe, not a content read: it deliberately checks
+	// all agent rows so an inaccessible source is forbidden rather than
+	// misreported as missing. The returned rows contain agent IDs only; every
+	// source body is still read through the requested agent scope below.
+	const owners = new Set(findEpisodicSourceAgentIds(db, `${kind}:${path ?? id}`));
+	const candidates = sourceIdCandidates(id);
+	const placeholders = candidates.map(() => "?").join(", ");
+	if (kind === "memory" && tableExists(db, "memories")) {
+		const rows = db
+			.prepare(`SELECT DISTINCT agent_id FROM memories WHERE id IN (${placeholders})`)
+			.all(...candidates) as Array<{ readonly agent_id: string | null }>;
+		for (const row of rows) if (row.agent_id) owners.add(row.agent_id);
+	}
+	if (kind === "artifact" && tableExists(db, "memory_artifacts")) {
+		const rows = db
+			.prepare(
+				`SELECT DISTINCT agent_id FROM memory_artifacts
+				 WHERE source_path = ? OR source_node_id IN (${placeholders}) OR session_id IN (${placeholders})
+				    OR session_key IN (${placeholders}) OR session_token IN (${placeholders})`,
+			)
+			.all(path ?? id, ...candidates, ...candidates, ...candidates, ...candidates) as Array<{
+			readonly agent_id: string | null;
+		}>;
+		for (const row of rows) if (row.agent_id) owners.add(row.agent_id);
+	}
+	if (
+		(kind === "transcript" || kind === "summary") &&
+		tableExists(db, kind === "transcript" ? "session_transcripts" : "session_summaries")
+	) {
+		const rows =
+			kind === "transcript"
+				? (db
+						.prepare(`SELECT DISTINCT agent_id FROM session_transcripts WHERE session_key IN (${placeholders})`)
+						.all(...candidates) as Array<{ readonly agent_id: string | null }>)
+				: (db
+						.prepare(
+							`SELECT DISTINCT agent_id FROM session_summaries
+							 WHERE id IN (${placeholders}) OR source_ref IN (${placeholders})`,
+						)
+						.all(...candidates, ...candidates) as Array<{ readonly agent_id: string | null }>);
+		for (const row of rows) if (row.agent_id) owners.add(row.agent_id);
+	}
+	return [...owners];
+}
+
+function readDeletedArtifact(
+	db: ReadDb,
+	params: { readonly agentId: string; readonly id: string; readonly path: string | null },
+): TraceSource | null {
+	if (!tableExists(db, "memory_artifacts")) return null;
+	const candidates = sourceIdCandidates(params.id);
+	const placeholders = candidates.map(() => "?").join(", ");
+	const row = db
+		.prepare(
+			`SELECT source_path, source_node_id, session_id, session_key, session_token, project, content
+			 FROM memory_artifacts
+			 WHERE agent_id = ? AND COALESCE(is_deleted, 0) != 0 AND (
+			   source_path = ? OR source_node_id IN (${placeholders}) OR session_id IN (${placeholders})
+			   OR session_key IN (${placeholders}) OR session_token IN (${placeholders})
+			 )
+			 ORDER BY captured_at DESC LIMIT 1`,
+		)
+		.get(params.agentId, params.path ?? params.id, ...candidates, ...candidates, ...candidates, ...candidates) as
+		| {
+				readonly source_path: string;
+				readonly source_node_id: string | null;
+				readonly session_id: string | null;
+				readonly session_key: string | null;
+				readonly session_token: string | null;
+				readonly project: string | null;
+				readonly content: string;
+		  }
+		| undefined;
+	if (!row) return null;
+	return {
+		kind: "artifact",
+		id: row.source_path,
+		path: row.source_path,
+		content: null,
+		project: row.project,
+		visibility: "scoped",
+		scope: null,
+		sessionKeys: [row.session_key, row.session_id, row.session_token].filter(
+			(value): value is string => value !== null && value.length > 0,
+		),
+		state: "deleted",
+	};
+}
+
+function readSource(
+	db: ReadDb,
+	params: {
+		readonly agentId: string;
+		readonly kind: TraceSourceKind;
+		readonly id: string;
+		readonly path: string | null;
+		readonly project: string | null;
+		readonly sessionKey: string | null;
+	},
+): TraceSource {
+	const normalizedId = params.id.replace(new RegExp(`^${params.kind}:`), "");
+	const sourceRef = `${params.kind}:${params.path ?? normalizedId}`;
+	const source = readEpisodicSource(db, { agentId: params.agentId, from: sourceRef });
+	if (!source) {
+		const agents = sourceAgentIds(db, params.kind, normalizedId, params.path);
+		if (agents.some((agentId) => agentId !== params.agentId)) {
+			throw new OntologyClaimTraceError("Claim premise crosses the authorized agent scope", 403);
+		}
+		const deleted =
+			params.kind === "artifact"
+				? readDeletedArtifact(db, { agentId: params.agentId, id: normalizedId, path: params.path })
+				: null;
+		if (deleted) {
+			if (params.project !== null && deleted.project !== params.project) {
+				throw new OntologyClaimTraceError("Claim premise is outside the authorized project scope", 403);
+			}
+			if (params.sessionKey !== null && !deleted.sessionKeys.includes(params.sessionKey)) {
+				throw new OntologyClaimTraceError("Claim trace premise crosses the authorized session boundary", 403);
+			}
+			return deleted;
+		}
+		throw new OntologyClaimTraceError(`Claim premise '${sourceRef}' was not found`, 409);
+	}
+	if (params.project !== null && source.project !== params.project) {
+		throw new OntologyClaimTraceError("Claim premise is outside the authorized project scope", 403);
+	}
+	const sessionKeys = sourceSessionKeys(db, params.agentId, params.kind, normalizedId, params.path);
+	if (params.sessionKey !== null && !sessionKeys.includes(params.sessionKey)) {
+		throw new OntologyClaimTraceError("Claim trace premise crosses the authorized session boundary", 403);
+	}
+	const state: TraceSource["state"] = source.completed ? "available" : "incomplete";
+	return {
+		kind: params.kind,
+		id: source.id,
+		path: source.sourcePath,
+		content: state === "available" ? source.content : null,
+		project: source.project,
+		visibility: "scoped",
+		scope: null,
+		sessionKeys,
+		state,
+	};
+}
+
+function readMemorySource(
+	db: ReadDb,
+	params: {
+		readonly agentId: string;
+		readonly id: string;
+		readonly project: string | null;
+		readonly sessionKey: string | null;
+	},
+): TraceSource {
+	const row = db
+		.prepare(
+			`SELECT id, content, source_path, project, visibility, scope, memory_kind, COALESCE(is_deleted, 0) AS is_deleted,
+			        stale_at, superseded_by, source_type, source_id
+			 FROM memories WHERE id = ? AND agent_id = ? LIMIT 1`,
+		)
+		.get(params.id, params.agentId) as
+		| {
+				readonly id: string;
+				readonly content: string;
+				readonly source_path: string | null;
+				readonly project: string | null;
+				readonly visibility: string | null;
+				readonly scope: string | null;
+				readonly memory_kind: string | null;
+				readonly is_deleted: number;
+				readonly stale_at: string | null;
+				readonly superseded_by: string | null;
+				readonly source_type: string | null;
+				readonly source_id: string | null;
+		  }
+		| undefined;
+	if (!row) {
+		// Return only existence, never cross-agent content, so fabricated and
+		// cross-agent source IDs have distinct fail-closed outcomes.
+		const crossAgent = db.prepare("SELECT 1 FROM memories WHERE id = ? LIMIT 1").get(params.id);
+		if (crossAgent) throw new OntologyClaimTraceError("Claim premise crosses the authorized agent scope", 403);
+		throw new OntologyClaimTraceError(`Claim premise 'memory:${params.id}' was not found`, 409);
+	}
+	if (params.project !== null && row.project !== params.project) {
+		throw new OntologyClaimTraceError("Claim premise is outside the authorized project scope", 403);
+	}
+	const sessionKeys = sourceSessionKeys(db, params.agentId, "memory", row.id, null);
+	if (params.sessionKey !== null && !sessionKeys.includes(params.sessionKey)) {
+		throw new OntologyClaimTraceError("Claim trace premise crosses the authorized session boundary", 403);
+	}
+	const state: TraceSource["state"] =
+		row.is_deleted !== 0
+			? "deleted"
+			: row.stale_at !== null || row.superseded_by !== null
+				? "stale"
+				: row.memory_kind !== "episodic" || row.visibility === "archived" || row.scope !== null
+					? "incomplete"
+					: "available";
+	return {
+		kind: "memory",
+		id: row.id,
+		path: row.source_path,
+		content: state === "available" ? row.content : null,
+		project: row.project,
+		visibility: row.visibility,
+		scope: row.scope,
+		sessionKeys,
+		state,
+	};
+}
+
+function sourceFromReference(
+	db: ReadDb,
+	params: {
+		readonly agentId: string;
+		readonly reference: TraceReference;
+		readonly project: string | null;
+		readonly sessionKey: string | null;
+	},
+): TraceEvidence {
+	const kind = canonicalSourceKind(params.reference.sourceKind);
+	const id = params.reference.sourceId?.trim() ?? "";
+	if (!kind || !id) {
+		throw new OntologyClaimTraceError("Claim premise must include a canonical source_ref", 409);
+	}
+	const source =
+		kind === "memory"
+			? readMemorySource(db, {
+					agentId: params.agentId,
+					id: id.replace(/^memory:/, ""),
+					project: params.project,
+					sessionKey: params.sessionKey,
+				})
+			: readSource(db, {
+					agentId: params.agentId,
+					kind,
+					id,
+					path: params.reference.sourcePath,
+					project: params.project,
+					sessionKey: params.sessionKey,
+				});
+	const quote = params.reference.quote;
+	const exact = source.content !== null && quote !== null && source.content.includes(quote);
+	if (source.state === "available" && quote === null) {
+		return {
+			sourceKind: kind,
+			sourceId: source.id,
+			sourcePath: source.path,
+			exactQuote: null,
+			excerpt: null,
+			found: true,
+			state: "quote_unverified",
+			scope: {
+				agentId: params.agentId,
+				project: source.project,
+				visibility: source.visibility,
+				sessionKeys: visibleSessionKeys(params.sessionKey),
+			},
+			reference: publicReference(params.reference.reference),
+		};
+	}
+	if (source.state === "available" && quote !== null && !exact) {
+		throw new OntologyClaimTraceError("Claim premise quote does not match the immutable source", 409);
+	}
+	return {
+		sourceKind: kind,
+		sourceId: source.id,
+		sourcePath: source.path,
+		exactQuote: exact ? quote : null,
+		excerpt: exact && source.content !== null && quote !== null ? compactExcerpt(source.content, quote) : null,
+		found: source.state !== "deleted",
+		state: source.state,
+		scope: {
+			agentId: params.agentId,
+			project: source.project,
+			visibility: source.visibility,
+			sessionKeys: visibleSessionKeys(params.sessionKey),
+		},
+		reference: publicReference(params.reference.reference),
+	};
+}
+
+function attributeReferences(
+	db: ReadDb,
+	attribute: EntityAttribute,
+	proposalEvidence: readonly unknown[],
+): TraceReference[] {
+	const references: TraceReference[] = [];
+	if (tableExists(db, "derived_memory_sources") && attribute.memoryId) {
+		const rows = db
+			.prepare(
+				`SELECT source_kind, source_id, source_path FROM derived_memory_sources
+				 WHERE derived_memory_id = ? AND agent_id = ? ORDER BY created_at ASC LIMIT ?`,
+			)
+			.all(attribute.memoryId, attribute.agentId, MAX_PREMISE_LIMIT + 1) as Array<{
+			readonly source_kind: string;
+			readonly source_id: string;
+			readonly source_path: string | null;
+		}>;
+		references.push(
+			...rows.map((row) => ({
+				sourceKind: row.source_kind,
+				sourceId: row.source_id,
+				sourcePath: row.source_path,
+				quote: null,
+				strict: true,
+				derivedMemoryId: attribute.memoryId,
+				reference: {
+					source_ref: `${row.source_kind}:${row.source_id}`,
+					source_path: row.source_path,
+				},
+			})),
+		);
+	}
+	for (const raw of [...attribute.proposalEvidence, ...proposalEvidence]) {
+		const parsed = parseReference(raw);
+		if (parsed) references.push({ ...parsed, derivedMemoryId: attribute.memoryId });
+	}
+	if (attribute.sourceKind || attribute.sourceId || attribute.sourcePath) {
+		const kind = sourceRefParts({
+			sourceKind: attribute.sourceKind,
+			sourceId: attribute.sourceId,
+			sourcePath: attribute.sourcePath,
+			quote: null,
+			reference: attribute,
+		}).kind;
+		if (canonicalSourceKind(kind) !== null) {
+			references.push({
+				sourceKind: attribute.sourceKind,
+				sourceId: attribute.sourceId,
+				sourcePath: attribute.sourcePath,
+				quote: null,
+				strict: true,
+				derivedMemoryId: attribute.memoryId,
+				reference: {
+					source_kind: attribute.sourceKind,
+					source_id: attribute.sourceId,
+					source_path: attribute.sourcePath,
+				},
+			});
+		}
+	}
+	return mergeReferences(references).filter(
+		(reference) =>
+			reference.sourceKind !== "ontology_proposal" &&
+			reference.strict === true &&
+			canonicalSourceKind(reference.sourceKind) !== null &&
+			(reference.sourceId?.trim().length ?? 0) > 0,
+	);
+}
+
+function traceVersion(db: ReadDb, attribute: EntityAttribute): TraceVersion {
+	const memory = memoryState(db, attribute.agentId, attribute.memoryId);
+	return {
+		attribute: {
+			...attribute,
+			proposalEvidence: publicEvidence(attribute.proposalEvidence),
+		},
+		lifecycle: {
+			status: attribute.status,
+			memoryId: attribute.memoryId,
+			memoryPresent: memory !== null,
+			staleAt: memory?.stale_at ?? null,
+			supersededBy: memory?.superseded_by ?? attribute.supersededBy ?? null,
+		},
+		history: {
+			version: attribute.version ?? null,
+			versionRootId: attribute.versionRootId ?? null,
+			previousAttributeId: attribute.previousAttributeId ?? null,
+			supersededBy: attribute.supersededBy,
+		},
+	};
+}
+
+function readProposalEvidence(db: ReadDb, agentId: string, proposalId: string | null): readonly unknown[] {
+	if (!proposalId || !tableExists(db, "ontology_proposals")) return [];
+	const row = db
+		.prepare("SELECT evidence FROM ontology_proposals WHERE id = ? AND agent_id = ? LIMIT 1")
+		.get(proposalId, agentId) as { readonly evidence: string | null } | undefined;
+	return parseJsonArray(row?.evidence);
+}
+
+function readAssertions(db: ReadDb, agentId: string, attributeIds: readonly string[]): TraceAssertion[] {
+	if (!tableExists(db, "epistemic_assertions") || attributeIds.length === 0) return [];
+	const placeholders = attributeIds.map(() => "?").join(", ");
+	const rows = db
+		.prepare(
+			`SELECT a.*, e.name AS subject_entity_name
+			 FROM epistemic_assertions a
+			 JOIN entities e ON e.id = a.subject_entity_id AND e.agent_id = a.agent_id
+			 WHERE a.agent_id = ? AND a.claim_attribute_id IN (${placeholders})
+			 ORDER BY a.asserted_at DESC, a.created_at DESC
+			 LIMIT ?`,
+		)
+		.all(agentId, ...attributeIds, MAX_PREMISE_LIMIT) as RawAssertionRow[];
+	return rows.map((row) => {
+		const evidenceRefs = [
+			...parseJsonArray(row.evidence),
+			...(row.source_kind || row.source_id || row.source_path
+				? [
+						{
+							source_kind: row.source_kind,
+							source_id: row.source_id,
+							source_path: row.source_path,
+						},
+					]
+				: []),
+		]
+			.map(parseReference)
+			.filter((ref): ref is TraceReference => ref !== null);
+		return {
+			id: row.id,
+			agentId: row.agent_id,
+			subjectEntityId: row.subject_entity_id,
+			subjectEntityName: row.subject_entity_name,
+			claimAttributeId: row.claim_attribute_id,
+			predicate: row.predicate,
+			content: row.content,
+			normalizedContent: row.normalized_content,
+			speaker: row.speaker,
+			assertedAt: row.asserted_at,
+			confidence: row.confidence,
+			evidence: publicEvidence(parseJsonArray(row.evidence)),
+			sourceKind: row.source_kind,
+			sourceId: row.source_id,
+			sourcePath: row.source_path,
+			sourceRoot: row.source_root,
+			status: row.status,
+			supersedesAssertionId: row.supersedes_assertion_id,
+			archivedAt: row.archived_at,
+			archivedBy: row.archived_by,
+			archiveReason: row.archive_reason,
+			createdBy: row.created_by,
+			createdAt: row.created_at,
+			updatedAt: row.updated_at,
+			evidenceRefs: mergeReferences(evidenceRefs).map((reference) => ({
+				...reference,
+				reference: publicReference(reference.reference),
+			})),
+		};
+	});
+}
+
+function readReverse(
+	db: ReadDb,
+	params: {
+		readonly agentId: string;
+		readonly project: string | null;
+		readonly memoryIds: readonly string[];
+		readonly limit: number;
+		readonly maxDepth: number;
+	},
+): { readonly items: ReverseTraceItem[]; readonly truncated: boolean; readonly maxDepthReached: number } {
+	if (!tableExists(db, "derived_memory_sources") || params.memoryIds.length === 0 || params.maxDepth === 0) {
+		return { items: [], truncated: false, maxDepthReached: 0 };
+	}
+	const visited = new Set(params.memoryIds);
+	let frontier = [...visited];
+	const items: ReverseTraceItem[] = [];
+	let truncated = false;
+	let maxDepthReached = 0;
+	for (let depth = 1; depth <= params.maxDepth && frontier.length > 0 && items.length < params.limit; depth += 1) {
+		const placeholders = frontier.map(() => "?").join(", ");
+		const rows = db
+			.prepare(
+				`SELECT DISTINCT dms.derived_memory_id AS memory_id, ea.id AS attribute_id,
+				        e.name AS entity_name, eas.name AS aspect_name, ea.group_key, ea.claim_key,
+				        COALESCE(ea.content, m.content) AS content, COALESCE(ea.status, 'derived') AS status
+				 FROM derived_memory_sources dms
+				 JOIN memories m ON m.id = dms.derived_memory_id AND m.agent_id = dms.agent_id
+				 LEFT JOIN entity_attributes ea ON ea.memory_id = m.id AND ea.agent_id = m.agent_id
+				 LEFT JOIN entity_aspects eas ON eas.id = ea.aspect_id AND eas.agent_id = ea.agent_id
+				 LEFT JOIN entities e ON e.id = eas.entity_id AND e.agent_id = eas.agent_id
+				 WHERE dms.agent_id = ? AND dms.source_kind = 'memory' AND dms.source_id IN (${placeholders})
+				   AND COALESCE(m.is_deleted, 0) = 0 AND m.visibility != 'archived' AND m.scope IS NULL
+				   AND (? IS NULL OR m.project = ?)
+				 ORDER BY m.updated_at DESC, m.id ASC
+				 LIMIT ?`,
+			)
+			.all(
+				params.agentId,
+				...frontier,
+				params.project,
+				params.project,
+				params.limit - items.length + 1,
+			) as RawReverseRow[];
+		if (rows.length > params.limit - items.length) truncated = true;
+		const nextFrontier: string[] = [];
+		for (const row of rows) {
+			if (visited.has(row.memory_id)) continue;
+			visited.add(row.memory_id);
+			if (items.length < params.limit) {
+				items.push({
+					attributeId: row.attribute_id,
+					memoryId: row.memory_id,
+					entity: row.entity_name,
+					aspect: row.aspect_name,
+					groupKey: row.group_key,
+					claimKey: row.claim_key,
+					content: row.content,
+					status: row.status,
+					depth,
+				});
+				maxDepthReached = depth;
+				nextFrontier.push(row.memory_id);
+			}
+		}
+		if (depth === params.maxDepth && nextFrontier.length > 0) truncated = true;
+		frontier = nextFrontier;
+	}
+	return { items, truncated, maxDepthReached };
+}
+
+export function explainOntologyClaim(accessor: DbAccessor, params: ExplainClaimParams): ClaimTraceResult {
+	const started = performance.now();
+	const versionLimit = boundedInteger(params.versionLimit, 20, MAX_VERSION_LIMIT, "versionLimit");
+	const premiseLimit = boundedInteger(params.premiseLimit, 50, MAX_PREMISE_LIMIT, "premiseLimit");
+	const reverseLimit = boundedInteger(params.reverseLimit, 50, MAX_REVERSE_LIMIT, "reverseLimit");
+	const maxDepth = boundedDepth(params.maxDepth);
+	const sessionKey = params.sessionKey?.trim() || null;
+	const project = params.project?.trim() || null;
+	const result = listEntityAttributesByPath(accessor, {
+		agentId: params.agentId,
+		entity: params.entity,
+		aspect: params.aspect,
+		group: params.group,
+		claim: params.claim,
+		kind: params.kind,
+		status: "all",
+		limit: versionLimit + 1,
+		offset: 0,
+	});
+	if (result === null) throw new OntologyClaimTraceError("Claim path not found", 404);
+	if (result.items.length === 0) throw new OntologyClaimTraceError("Claim path has no versions", 404);
+
+	return accessor.withReadDb((db) => {
+		if (project !== null) {
+			// Graph rows are agent-scoped but do not carry a project column. A
+			// project-scoped caller may only receive a claim whose linked semantic
+			// memory proves the same project; otherwise fail closed before any
+			// claim content, history, or assertion is returned.
+			for (const attribute of result.items) requireProjectScopedAttribute(db, attribute, project);
+		}
+		const versions = result.items.slice(0, versionLimit).map((attribute) => traceVersion(db, attribute));
+		const current = versions.filter((version) => version.attribute.status === "active");
+		const currentContent = new Set(current.map((version) => version.attribute.normalizedContent));
+		const assertions = readAssertions(
+			db,
+			params.agentId,
+			versions.map((version) => version.attribute.id),
+		);
+		const contradictoryAssertions = assertions.filter(
+			(assertion) => assertion.predicate === "denies" && assertion.status === "active",
+		);
+		const references = versions.flatMap((version) =>
+			attributeReferences(
+				db,
+				version.attribute,
+				readProposalEvidence(db, params.agentId, version.attribute.proposalId),
+			),
+		);
+		references.push(...assertions.flatMap((assertion) => assertion.evidenceRefs));
+		const uniqueReferences = mergeReferences(references);
+		const premiseItems: TracePremise[] = [];
+		let verifiedPremises = 0;
+		let invalidatedPremises = 0;
+		let unverifiedPremises = 0;
+		for (const reference of uniqueReferences.slice(0, premiseLimit + 1)) {
+			if (premiseItems.length >= premiseLimit) break;
+			const evidence = sourceFromReference(db, {
+				agentId: params.agentId,
+				reference,
+				project,
+				sessionKey,
+			});
+			const derivedMemoryId = reference.derivedMemoryId ?? null;
+			const depth = 0;
+			premiseItems.push({ depth, derivedMemoryId, evidence });
+			if (evidence.state === "available") {
+				if (evidence.exactQuote !== null) verifiedPremises += 1;
+				else unverifiedPremises += 1;
+			} else if (evidence.state === "deleted" || evidence.state === "stale" || evidence.state === "incomplete") {
+				invalidatedPremises += 1;
+			}
+		}
+		const reverseTrace = readReverse(db, {
+			agentId: params.agentId,
+			project,
+			memoryIds: versions
+				.map((version) => version.attribute.memoryId)
+				.filter((memoryId): memoryId is string => memoryId !== null),
+			limit: reverseLimit,
+			maxDepth,
+		});
+		const integrity: TraceIntegrity =
+			invalidatedPremises > 0
+				? "invalidated"
+				: verifiedPremises === 0
+					? "unverified"
+					: unverifiedPremises > 0
+						? "unverified"
+						: "verified";
+		const hasCompeting = currentContent.size > 1;
+		return {
+			entity: {
+				...result.entity,
+				proposalEvidence: publicEvidence(result.entity.proposalEvidence ?? []),
+			},
+			aspect: {
+				...result.aspect,
+				proposalEvidence: publicEvidence(result.aspect.proposalEvidence ?? []),
+			},
+			path: {
+				groupKey: params.group,
+				claimKey: params.claim,
+				kind: params.kind ?? null,
+			},
+			current: {
+				items: current,
+				status: current.length === 0 ? "historical" : hasCompeting ? "competing" : "active",
+			},
+			versions: { items: versions, truncated: result.items.length > versionLimit },
+			competing: { items: hasCompeting ? current : [], contradictoryAssertions },
+			assertions,
+			premises: {
+				items: premiseItems,
+				truncated: uniqueReferences.length > premiseLimit,
+			},
+			reverse: { items: reverseTrace.items, truncated: reverseTrace.truncated },
+			authorization: {
+				agentId: params.agentId,
+				project,
+				sessionKey,
+				decisions: {
+					agent: "allowed",
+					project: project === null ? "unrestricted" : "allowed",
+					session: sessionKey === null ? "unrestricted" : "allowed",
+				},
+				readPath: "recall",
+			},
+			integrity: {
+				status: integrity,
+				verifiedPremises,
+				invalidatedPremises,
+				unverifiedPremises,
+				reason:
+					integrity === "verified"
+						? null
+						: invalidatedPremises > 0
+							? "one or more premise records were deleted, superseded, stale, or incomplete"
+							: "the claim has no verified exact-quote premise",
+			},
+			traversal: {
+				limits: { versionLimit, premiseLimit, reverseLimit, maxDepth },
+				versionsVisited: versions.length,
+				premisesVisited: premiseItems.length,
+				reverseVisited: reverseTrace.items.length,
+				maxDepthReached: reverseTrace.maxDepthReached,
+				bounded: true,
+			},
+			latencyMs: Math.round((performance.now() - started) * 100) / 100,
+		};
+	});
+}
+
+export type { TraceAssertion, TraceEvidence, TracePremise, TraceVersion, ReverseTraceItem };

--- a/platform/daemon/src/routes/ontology-routes.ts
+++ b/platform/daemon/src/routes/ontology-routes.ts
@@ -21,6 +21,7 @@ import {
 	parseOntologyClaimAttributeKind,
 	parseOntologyClaimAttributeStatus,
 } from "../ontology-claim-evidence";
+import { OntologyClaimTraceError, explainOntologyClaim } from "../ontology-claim-trace";
 import { OntologyConsolidationError, consolidateOntologyProposals } from "../ontology-consolidation";
 import { OntologyExtractionError, extractOntologyProposals } from "../ontology-extraction";
 import { OntologyLinkEvidenceError, getOntologyLinkEvidence } from "../ontology-link-evidence";
@@ -43,7 +44,7 @@ import {
 	rejectOntologyProposal,
 } from "../ontology-proposals";
 import { AGENTS_DIR, authConfig } from "./state";
-import { parseBoundedInt, resolveScopedAgentId } from "./utils";
+import { parseBoundedInt, resolveScopedAgentId, validateSessionAgentBinding } from "./utils";
 
 function asRecord(value: unknown): Record<string, unknown> {
 	if (typeof value === "object" && value !== null && !Array.isArray(value)) {
@@ -94,9 +95,10 @@ async function readJsonRecord(c: Context): Promise<Record<string, unknown>> {
 	}
 }
 
-function statusForError(err: unknown): 400 | 404 | 409 | 500 {
+function statusForError(err: unknown): 400 | 403 | 404 | 409 | 500 {
 	if (err instanceof OntologyProposalError) return err.status;
 	if (err instanceof OntologyClaimEvidenceError) return err.status;
+	if (err instanceof OntologyClaimTraceError) return err.status;
 	if (err instanceof OntologyLinkEvidenceError) return err.status;
 	if (err instanceof OntologyExtractionError) return err.status;
 	if (err instanceof OntologyConsolidationError) return err.status;
@@ -415,6 +417,54 @@ export function registerOntologyRoutes(app: Hono): void {
 		try {
 			return c.json(
 				listClaimVersions(getDbAccessor(), { agentId: scoped.agentId, entity, aspect, group, claim, kind }),
+			);
+		} catch (err) {
+			return c.json({ error: messageForError(err) }, statusForError(err));
+		}
+	});
+
+	app.get("/api/ontology/claims/explain", (c) => {
+		const scoped = resolveAgent(c, c.req.query("agent_id"));
+		if (scoped.response) return scoped.response;
+		const entity = c.req.query("entity")?.trim();
+		const aspect = c.req.query("aspect")?.trim();
+		const group = c.req.query("group")?.trim();
+		const claim = c.req.query("claim")?.trim();
+		if (!entity) return c.json({ error: "entity is required" }, 400);
+		if (!aspect) return c.json({ error: "aspect is required" }, 400);
+		if (!group) return c.json({ error: "group is required" }, 400);
+		if (!claim) return c.json({ error: "claim is required" }, 400);
+		const kind = parseOntologyClaimAttributeKind(c.req.query("kind"));
+		if (c.req.query("kind") && !kind) return c.json({ error: "kind is invalid" }, 400);
+		const querySessionKey = c.req.query("session_key")?.trim() || undefined;
+		const headerSessionKey = c.req.header("x-signet-session-key")?.trim() || undefined;
+		if (querySessionKey && headerSessionKey && querySessionKey !== headerSessionKey) {
+			return c.json({ error: "session_key conflicts with x-signet-session-key" }, 400);
+		}
+		const sessionKey = querySessionKey ?? headerSessionKey;
+		const sessionError = validateSessionAgentBinding(c, sessionKey, scoped.agentId, {
+			requireExisting: true,
+			context: "session_key",
+		});
+		if (sessionError) return c.json({ error: sessionError }, 403);
+		const claims = c.get("auth")?.claims;
+		const project = claims?.role === "admin" ? null : (claims?.scope?.project ?? null);
+		try {
+			return c.json(
+				explainOntologyClaim(getDbAccessor(), {
+					agentId: scoped.agentId,
+					entity,
+					aspect,
+					group,
+					claim,
+					kind,
+					versionLimit: parseBoundedInt(c.req.query("version_limit"), 20, 1, 50),
+					premiseLimit: parseBoundedInt(c.req.query("premise_limit"), 50, 1, 100),
+					reverseLimit: parseBoundedInt(c.req.query("reverse_limit"), 50, 1, 100),
+					maxDepth: parseBoundedInt(c.req.query("max_depth"), 3, 0, 3),
+					sessionKey,
+					project,
+				}),
 			);
 		} catch (err) {
 			return c.json({ error: messageForError(err) }, statusForError(err));

--- a/scripts/claim-trace-eval.ts
+++ b/scripts/claim-trace-eval.ts
@@ -1,0 +1,372 @@
+/**
+ * Fixed-input evaluation for the authorized ontology claim trace (#1318).
+ *
+ * Run with:
+ *   bun scripts/claim-trace-eval.ts
+ *
+ * The fixture is intentionally local and deterministic. It exercises the
+ * operation directly, so the metric measures the canonical trace rather than
+ * a renderer or a network server.
+ */
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../platform/daemon/src/db-accessor";
+import { createEpistemicAssertionsInTx } from "../platform/daemon/src/ontology-assertions";
+import {
+	type ClaimTraceResult,
+	OntologyClaimTraceError,
+	explainOntologyClaim,
+} from "../platform/daemon/src/ontology-claim-trace";
+
+const agentId = "eval-agent";
+const now = "2026-08-10T00:00:00.000Z";
+const dir = mkdtempSync(join(tmpdir(), "signet-claim-trace-eval-"));
+mkdirSync(join(dir, "memory"), { recursive: true });
+initDbAccessor(join(dir, "memory", "memories.db"));
+
+interface ScenarioResult {
+	readonly name: string;
+	readonly passed: boolean;
+	readonly unsupportedCertainty: boolean;
+	readonly expected: string;
+	readonly observed: string;
+}
+
+function insertMemory(
+	db: { prepare(sql: string): { run(...params: unknown[]): unknown } },
+	input: {
+		readonly id: string;
+		readonly content: string;
+		readonly agentId?: string;
+		readonly memoryKind: string;
+		readonly deleted?: number;
+	},
+): void {
+	db.prepare(
+		`INSERT INTO memories
+		 (id, content, type, agent_id, updated_by, memory_kind, visibility, scope, is_deleted, created_at, updated_at)
+		 VALUES (?, ?, 'fact', ?, 'claim-trace-eval', ?, 'global', NULL, ?, ?, ?)`,
+	).run(input.id, input.content, input.agentId ?? agentId, input.memoryKind, input.deleted ?? 0, now, now);
+}
+
+function insertClaim(
+	db: { prepare(sql: string): { run(...params: unknown[]): unknown } },
+	input: {
+		readonly id: string;
+		readonly memoryId: string;
+		readonly claimKey: string;
+		readonly content: string;
+		readonly status?: string;
+		readonly version?: number;
+		readonly rootId?: string;
+		readonly previousId?: string | null;
+		readonly groupKey?: string;
+		readonly evidence?: readonly unknown[];
+		readonly agentId?: string;
+	},
+): void {
+	db.prepare(
+		`INSERT INTO entity_attributes
+		 (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
+		  status, group_key, claim_key, version, version_root_id, previous_attribute_id, proposal_evidence,
+		  created_at, updated_at)
+		 VALUES (?, 'eval-aspect', ?, ?, 'attribute', ?, ?, 0.9, 0.8, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	).run(
+		input.id,
+		input.agentId ?? agentId,
+		input.memoryId,
+		input.content,
+		input.content.toLowerCase(),
+		input.status ?? "active",
+		input.groupKey ?? "eval",
+		input.claimKey,
+		input.version ?? 1,
+		input.rootId ?? input.id,
+		input.previousId ?? null,
+		JSON.stringify(input.evidence ?? []),
+		now,
+		now,
+	);
+}
+
+function link(
+	db: { prepare(sql: string): { run(...params: unknown[]): unknown } },
+	derivedMemoryId: string,
+	sourceKind: string,
+	sourceId: string,
+	linkAgentId = agentId,
+): void {
+	db.prepare(
+		`INSERT INTO derived_memory_sources
+		 (derived_memory_id, source_kind, source_id, source_path, agent_id, created_at)
+		 VALUES (?, ?, ?, NULL, ?, ?)`,
+	).run(derivedMemoryId, sourceKind, sourceId, linkAgentId, now);
+}
+
+function explain(
+	claim: string,
+	options: { readonly sessionKey?: string; readonly premiseLimit?: number } = {},
+): ClaimTraceResult {
+	return explainOntologyClaim(getDbAccessor(), {
+		agentId,
+		entity: "Eval Editor",
+		aspect: "preferences",
+		group: claim === "session_pref" ? "sessions" : "eval",
+		claim,
+		sessionKey: options.sessionKey,
+		premiseLimit: options.premiseLimit,
+	});
+}
+
+const scenarios: ScenarioResult[] = [];
+const started = performance.now();
+
+try {
+	getDbAccessor().withWriteTx((db) => {
+		db.prepare(
+			`INSERT INTO entities
+			 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+			 VALUES ('eval-entity', 'Eval Editor', 'eval editor', 'tool', ?, 1, ?, ?)`,
+		).run(agentId, now, now);
+		db.prepare(
+			`INSERT INTO entity_aspects
+			 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+			 VALUES ('eval-aspect', 'eval-entity', ?, 'preferences', 'preferences', 0.8, ?, ?)`,
+		).run(agentId, now, now);
+
+		insertMemory(db, {
+			id: "eval-source-pref",
+			content: "The user prefers the editor to open files in tabs.",
+			memoryKind: "episodic",
+		});
+		insertMemory(db, { id: "eval-derived-old", content: "The editor opens files in tabs.", memoryKind: "derived" });
+		insertMemory(db, {
+			id: "eval-derived-current",
+			content: "The user prefers the editor to open files in tabs.",
+			memoryKind: "derived",
+		});
+		insertMemory(db, {
+			id: "eval-dependent",
+			content: "The editor tab behavior is a current preference.",
+			memoryKind: "derived",
+		});
+		insertClaim(db, {
+			id: "eval-old",
+			memoryId: "eval-derived-old",
+			claimKey: "editor_pref",
+			content: "The editor opens files in tabs.",
+			status: "superseded",
+			version: 1,
+			rootId: "eval-old",
+			evidence: [{ source_ref: "memory:eval-source-pref", quote: "open files in tabs" }],
+		});
+		insertClaim(db, {
+			id: "eval-current",
+			memoryId: "eval-derived-current",
+			claimKey: "editor_pref",
+			content: "The user prefers the editor to open files in tabs.",
+			version: 2,
+			rootId: "eval-old",
+			previousId: "eval-old",
+			evidence: [{ source_ref: "memory:eval-source-pref", quote: "prefers the editor to open files in tabs" }],
+		});
+		db.prepare("UPDATE entity_attributes SET superseded_by = 'eval-current' WHERE id = 'eval-old'").run();
+		insertClaim(db, {
+			id: "eval-dependent-attr",
+			memoryId: "eval-dependent",
+			claimKey: "dependent_note",
+			groupKey: "other",
+			content: "The editor tab behavior is a current preference.",
+		});
+		link(db, "eval-derived-old", "memory", "eval-source-pref");
+		link(db, "eval-derived-current", "memory", "eval-source-pref");
+		link(db, "eval-dependent", "memory", "eval-derived-current");
+
+		for (const [id, content] of [
+			["eval-source-a", "The user prefers tabs in the editor."],
+			["eval-source-b", "The user prefers a single editor pane."],
+		] as const) {
+			insertMemory(db, { id, content, memoryKind: "episodic" });
+		}
+		for (const [id, memoryId, content, sourceId, quote] of [
+			["eval-comp-a", "eval-comp-memory-a", "The editor uses tabs.", "eval-source-a", "prefers tabs"],
+			[
+				"eval-comp-b",
+				"eval-comp-memory-b",
+				"The editor uses one pane.",
+				"eval-source-b",
+				"prefers a single editor pane",
+			],
+		] as const) {
+			insertMemory(db, { id: memoryId, content, memoryKind: "derived" });
+			insertClaim(db, {
+				id,
+				memoryId,
+				claimKey: "competing",
+				content,
+				evidence: [{ source_ref: `memory:${sourceId}`, quote }],
+			});
+			link(db, memoryId, "memory", sourceId);
+		}
+		createEpistemicAssertionsInTx(getDbAccessor(), db, [
+			{
+				agentId,
+				entityId: "eval-entity",
+				claimAttributeId: "eval-comp-a",
+				predicate: "denies",
+				content: "The editor does not use tabs.",
+				evidence: [{ source_ref: "memory:eval-source-a", quote: "prefers tabs" }],
+			},
+		]);
+
+		db.prepare(
+			`INSERT INTO session_transcripts
+			 (session_key, content, harness, project, agent_id, created_at, updated_at, completed_at)
+			 VALUES ('eval-session-a', 'The user prefers tabs in the editor.', 'eval', '/eval', ?, ?, ?, ?)`,
+		).run(agentId, now, now, now);
+		insertMemory(db, { id: "eval-session-derived", content: "Session preference.", memoryKind: "derived" });
+		insertClaim(db, {
+			id: "eval-session-attr",
+			memoryId: "eval-session-derived",
+			claimKey: "session_pref",
+			groupKey: "sessions",
+			content: "The user prefers tabs in the editor.",
+			evidence: [{ source_ref: "transcript:eval-session-a", quote: "prefers tabs in the editor" }],
+		});
+		link(db, "eval-session-derived", "transcript", "eval-session-a");
+
+		insertMemory(db, {
+			id: "eval-deleted-source",
+			content: "The user preferred a deleted option.",
+			memoryKind: "episodic",
+			deleted: 1,
+		});
+		insertMemory(db, { id: "eval-deleted-derived", content: "Deleted claim.", memoryKind: "derived" });
+		insertClaim(db, {
+			id: "eval-deleted-attr",
+			memoryId: "eval-deleted-derived",
+			claimKey: "deleted",
+			content: "The user preferred a deleted option.",
+			evidence: [{ source_ref: "memory:eval-deleted-source", quote: "preferred a deleted option" }],
+		});
+		link(db, "eval-deleted-derived", "memory", "eval-deleted-source");
+
+		insertMemory(db, {
+			id: "eval-foreign-source",
+			content: "Other agent evidence.",
+			agentId: "other-agent",
+			memoryKind: "episodic",
+		});
+		insertMemory(db, { id: "eval-foreign-derived", content: "Foreign claim.", memoryKind: "derived" });
+		insertClaim(db, {
+			id: "eval-foreign-attr",
+			memoryId: "eval-foreign-derived",
+			claimKey: "foreign",
+			content: "Foreign claim.",
+		});
+		link(db, "eval-foreign-derived", "memory", "eval-foreign-source");
+
+		insertMemory(db, { id: "eval-fabricated-derived", content: "Fabricated claim.", memoryKind: "derived" });
+		insertClaim(db, {
+			id: "eval-fabricated-attr",
+			memoryId: "eval-fabricated-derived",
+			claimKey: "fabricated",
+			content: "Fabricated claim.",
+		});
+		link(db, "eval-fabricated-derived", "memory", "does-not-exist");
+	});
+
+	const run = (name: string, expected: string, fn: () => unknown, check: (value: unknown) => boolean): void => {
+		try {
+			const value = fn();
+			const observed =
+				value instanceof Error ? value.message : typeof value === "object" && value !== null ? "trace" : String(value);
+			scenarios.push({
+				name,
+				expected,
+				observed,
+				passed: check(value),
+				unsupportedCertainty: isTrace(value) && value.integrity.status !== "verified",
+			});
+		} catch (error) {
+			const observed = error instanceof OntologyClaimTraceError ? `${error.status}: ${error.message}` : String(error);
+			scenarios.push({ name, expected, observed, passed: check(error), unsupportedCertainty: false });
+		}
+	};
+
+	run(
+		"changed preference exposes current and prior versions",
+		"active + 2 versions",
+		() => explain("editor_pref"),
+		(value) => {
+			return isTrace(value) && value.current.status === "active" && value.versions.items.length === 2;
+		},
+	);
+	run(
+		"competing values remain visible",
+		"competing with contradictory assertion",
+		() => explain("competing"),
+		(value) =>
+			isTrace(value) && value.current.status === "competing" && value.competing.contradictoryAssertions.length === 1,
+	);
+	run(
+		"session allowlist accepts matching transcript",
+		"verified",
+		() => explain("session_pref", { sessionKey: "eval-session-a" }),
+		(value) => isTrace(value) && value.integrity.status === "verified",
+	);
+	run(
+		"session allowlist rejects a different session",
+		"403",
+		() => explain("session_pref", { sessionKey: "eval-session-b" }),
+		(value) => value instanceof OntologyClaimTraceError && value.status === 403,
+	);
+	run(
+		"deleted evidence is not current truth",
+		"invalidated",
+		() => explain("deleted"),
+		(value) => isTrace(value) && value.integrity.status === "invalidated",
+	);
+	run(
+		"cross-agent source is forbidden",
+		"403",
+		() => explain("foreign"),
+		(value) => value instanceof OntologyClaimTraceError && value.status === 403,
+	);
+	run(
+		"fabricated source id is rejected",
+		"409",
+		() => explain("fabricated"),
+		(value) => value instanceof OntologyClaimTraceError && value.status === 409,
+	);
+	run(
+		"reverse lineage is bounded",
+		"one dependent at depth one",
+		() => explain("editor_pref", { premiseLimit: 1 }),
+		(value) => isTrace(value) && value.reverse.items.length === 1 && value.traversal.bounded,
+	);
+} finally {
+	const elapsedMs = Math.round((performance.now() - started) * 100) / 100;
+	const passed = scenarios.filter((scenario) => scenario.passed).length;
+	const unsupportedCertainty = scenarios.filter((scenario) => scenario.unsupportedCertainty).length;
+	const report = {
+		scenarios: scenarios.length,
+		passed,
+		accuracy: scenarios.length === 0 ? 0 : Math.round((passed / scenarios.length) * 1000) / 1000,
+		unsupportedCertainty,
+		latencyMs: elapsedMs,
+		toolCalls: scenarios.length,
+		results: scenarios,
+	};
+	console.log(JSON.stringify(report, null, 2));
+	closeDbAccessor();
+	rmSync(dir, { recursive: true, force: true });
+	if (passed !== scenarios.length) process.exitCode = 1;
+}
+
+function isTrace(value: unknown): value is ClaimTraceResult {
+	return typeof value === "object" && value !== null && "integrity" in value && "traversal" in value;
+}
+
+process.exit(process.exitCode ?? 0);

--- a/surfaces/cli/src/commands/ontology.test.ts
+++ b/surfaces/cli/src/commands/ontology.test.ts
@@ -25,7 +25,16 @@ describe("registerOntologyCommands", () => {
 		expect(ontology).toBeDefined();
 		if (!ontology) throw new Error("ontology command was not registered");
 		expect(ontology?.commands.map((cmd) => cmd.name())).toEqual(
-			expect.arrayContaining(["entity", "claim", "aspect", "link", "stream", "assertions", "assertion"]),
+			expect.arrayContaining([
+				"entity",
+				"claim",
+				"aspect",
+				"link",
+				"stream",
+				"assertions",
+				"assertion",
+				"explain-claim",
+			]),
 		);
 
 		const names = (parent: Command, name: string): readonly string[] =>
@@ -296,6 +305,66 @@ describe("registerOntologyCommands", () => {
 		);
 		expect(lines.join("\n")).toContain("Claim Evidence");
 		expect(lines.join("\n")).toContain("Applied claims retain evidence.");
+	});
+
+	test("explain-claim calls the bounded authorized trace endpoint", async () => {
+		let capturedPath = "";
+		const lines: string[] = [];
+		console.log = (line?: unknown) => {
+			lines.push(String(line ?? ""));
+		};
+
+		const program = new Command();
+		registerOntologyCommands(program, {
+			ensureDaemonForSecrets: async () => true,
+			secretApiCall: async (_method, path) => {
+				capturedPath = path;
+				return {
+					ok: true,
+					data: {
+						path: { groupKey: "ontology", claimKey: "proposal_loop" },
+						current: {
+							status: "active",
+							items: [{ attribute: { content: "Traceable claim", status: "active" } }],
+						},
+						integrity: { status: "verified", verifiedPremises: 1, invalidatedPremises: 0 },
+						traversal: { versionsVisited: 1, premisesVisited: 1, reverseVisited: 0 },
+					},
+				};
+			},
+		});
+
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"explain-claim",
+			"Signet",
+			"architecture",
+			"ontology",
+			"proposal_loop",
+			"--kind",
+			"attribute",
+			"--version-limit",
+			"5",
+			"--premise-limit",
+			"7",
+			"--reverse-limit",
+			"9",
+			"--max-depth",
+			"2",
+			"--session-key",
+			"session-1",
+			"--agent",
+			"ant",
+		]);
+
+		expect(capturedPath).toBe(
+			"/api/ontology/claims/explain?entity=Signet&aspect=architecture&group=ontology&claim=proposal_loop&agent_id=ant&kind=attribute&version_limit=5&premise_limit=7&reverse_limit=9&max_depth=2&session_key=session-1",
+		);
+		expect(lines.join("\n")).toContain("Authorized Claim Trace");
+		expect(lines.join("\n")).toContain("Traceable claim");
+		expect(lines.join("\n")).toContain("verified");
 	});
 
 	test("link-evidence calls the applied link evidence endpoint", async () => {

--- a/surfaces/cli/src/commands/ontology.ts
+++ b/surfaces/cli/src/commands/ontology.ts
@@ -625,6 +625,98 @@ function printClaimEvidence(data: unknown): void {
 	console.log();
 }
 
+function printClaimTrace(data: unknown): void {
+	const record = asRecord(data);
+	const path = asRecord(record.path);
+	const current = asRecord(record.current);
+	const competing = asRecord(record.competing);
+	const integrity = asRecord(record.integrity);
+	const traversal = asRecord(record.traversal);
+	const currentItems = readArray(current, "items") ?? [];
+	const versions = readArray(asRecord(record.versions), "items") ?? [];
+	const premises = readArray(asRecord(record.premises), "items") ?? [];
+	const reverse = readArray(asRecord(record.reverse), "items") ?? [];
+	const competingItems = readArray(competing, "items") ?? [];
+	const assertions = readArray(record, "assertions") ?? [];
+	console.log(chalk.bold("\n  Authorized Claim Trace\n"));
+	console.log(
+		chalk.dim(
+			`  ${String(path.groupKey ?? "general")} / ${String(path.claimKey ?? "unknown")} · ${String(
+				current.status ?? "unknown",
+			)}`,
+		),
+	);
+	for (const raw of currentItems) {
+		const item = asRecord(raw);
+		const attribute = asRecord(item.attribute);
+		console.log(`  ${chalk.cyan(String(attribute.status ?? "unknown"))} ${attribute.content ?? ""}`);
+	}
+	const historical = versions.filter((raw) => {
+		const attribute = asRecord(asRecord(raw).attribute);
+		return attribute.status !== "active";
+	});
+	if (historical.length > 0) {
+		console.log(chalk.dim("  history:"));
+		for (const raw of historical) {
+			const item = asRecord(raw);
+			const attribute = asRecord(item.attribute);
+			console.log(`    ${chalk.yellow(String(attribute.status ?? "unknown"))} ${attribute.content ?? ""}`);
+		}
+	}
+	if (competingItems.length > 0) {
+		console.log(chalk.dim("  competing values:"));
+		for (const raw of competingItems) {
+			const attribute = asRecord(asRecord(raw).attribute);
+			console.log(`    ${chalk.magenta(String(attribute.content ?? ""))}`);
+		}
+	}
+	if (assertions.length > 0) {
+		console.log(chalk.dim("  linked assertions:"));
+		for (const raw of assertions) {
+			const assertion = asRecord(raw);
+			console.log(`    ${chalk.magenta(String(assertion.predicate ?? "asserts"))} ${assertion.content ?? ""}`);
+		}
+	}
+	if (premises.length > 0) {
+		console.log(chalk.dim("  premises:"));
+		for (const raw of premises) {
+			const premise = asRecord(raw);
+			const evidence = asRecord(premise.evidence);
+			const source = `${String(evidence.sourceKind ?? "source")}:${String(evidence.sourceId ?? "unknown")}`;
+			const quote = String(evidence.exactQuote ?? evidence.excerpt ?? "unverified").slice(0, 1200);
+			console.log(`    ${chalk.cyan(String(evidence.state ?? "unknown"))} ${source} — ${quote}`);
+		}
+	}
+	if (reverse.length > 0) {
+		console.log(chalk.dim("  reverse lineage:"));
+		for (const raw of reverse) {
+			const item = asRecord(raw);
+			console.log(`    depth ${String(item.depth ?? "?")} ${item.content ?? ""}`);
+		}
+	}
+	console.log(
+		chalk.dim(
+			`  ${versions.length} version(s) · ${premises.length} premise(s) · ${reverse.length} reverse dependent(s)`,
+		),
+	);
+	console.log(
+		chalk.dim(
+			`  integrity ${String(integrity.status ?? "unknown")} · ${String(
+				integrity.verifiedPremises ?? 0,
+			)} verified · ${String(integrity.invalidatedPremises ?? 0)} invalidated`,
+		),
+	);
+	if (integrity.reason) console.log(chalk.yellow(`  ${String(integrity.reason)}`));
+	console.log(
+		chalk.dim(
+			`  bounded traversal: ${String(traversal.versionsVisited ?? versions.length)} versions, ${String(
+				traversal.premisesVisited ?? premises.length,
+			)} premises, ${String(traversal.reverseVisited ?? reverse.length)} reverse`,
+		),
+	);
+	console.log();
+}
+
 function printAssertions(data: unknown, title = "Epistemic Assertions"): void {
 	const record = asRecord(data);
 	const items = (((record as EpistemicAssertionsResponse).items as readonly EpistemicAssertionItem[] | undefined) ??
@@ -939,6 +1031,39 @@ export function registerOntologyCommands(program: Command, deps: OntologyDeps): 
 		const data = await apiGet(deps, "/api/ontology/claims/evidence", params);
 		if (options.json) console.log(JSON.stringify(data, null, 2));
 		else printClaimEvidence(data);
+	});
+
+	addCommonOptions(
+		ontology
+			.command("explain-claim")
+			.description("Explain an authorized, bounded claim trace")
+			.argument("<entity>", "Entity/object name")
+			.argument("<aspect>", "Aspect name")
+			.argument("<group>", "Group key")
+			.argument("<claim>", "Claim key")
+			.option("--kind <kind>", "attribute or constraint")
+			.option("--version-limit <n>", "Max claim versions", Number.parseInt)
+			.option("--premise-limit <n>", "Max source premises", Number.parseInt)
+			.option("--reverse-limit <n>", "Max reverse dependents", Number.parseInt)
+			.option("--max-depth <n>", "Max lineage depth (0-3)", Number.parseInt)
+			.option("--session-key <key>", "Fail closed when provenance leaves this session"),
+	).action(async (entity: string, aspect: string, group: string, claim: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const params = new URLSearchParams({ entity, aspect, group, claim });
+		appendAgent(params, options.agent);
+		for (const [key, value] of [
+			["kind", options.kind],
+			["version_limit", options.versionLimit],
+			["premise_limit", options.premiseLimit],
+			["reverse_limit", options.reverseLimit],
+			["max_depth", options.maxDepth],
+			["session_key", options.sessionKey],
+		] as const) {
+			if (value !== undefined && value !== "") params.set(key, String(value));
+		}
+		const data = await apiGet(deps, "/api/ontology/claims/explain", params);
+		if (options.json) console.log(JSON.stringify(data, null, 2));
+		else printClaimTrace(data);
 	});
 
 	addCommonOptions(

--- a/web/docs/src/content/docs/api/knowledge-ontology.md
+++ b/web/docs/src/content/docs/api/knowledge-ontology.md
@@ -221,6 +221,50 @@ parameters: `entity`, `aspect`, `group`, `claim`, `status`, `kind`, `limit`,
 /api/ontology/claims/evidence?entity=Signet&aspect=architecture&group=ontology&claim=proposal_loop
 ```
 
+### GET /api/ontology/claims/explain
+
+Return one bounded, authorized claim trace over the existing ontology
+versions, linked epistemic assertions, proposal evidence, episodic sources,
+and `derived_memory_sources` reverse lineage. This endpoint is read-only and
+does not create a second provenance store or widen cross-agent recall.
+
+Required query parameters are `entity`, `aspect`, `group`, and `claim`.
+Optional parameters are `kind` (`attribute` or `constraint`),
+`version_limit` (1–50, default 20), `premise_limit` (1–100, default 50),
+`reverse_limit` (1–100, default 50), `max_depth` (0–3, default 3),
+`agent_id`, and `session_key`.
+
+The resolved agent follows the normal scoped-agent/recall permission path.
+Project-scoped tokens can only inspect linked claim memories, premises, and
+reverse dependents in their project. A supplied session key may also be sent
+as `x-signet-session-key`; conflicting values are rejected, and remote calls
+must bind the session to the resolved agent.
+
+Premises must resolve to an existing same-agent canonical episodic source
+(`memory`, `artifact`, `transcript`, or `summary`). When a premise includes an
+exact `quote`, the quote must occur in the immutable source content. Fabricated
+or mismatched references return `409`; cross-agent, cross-project, or
+cross-session references return `403`. Session-scoped traces fail closed when
+the source session cannot be proven. Deleted, superseded, stale, and
+incomplete source records are reported as invalidated or unverified and are
+never returned as verified evidence.
+
+The response includes `current`, `versions`, `competing`, `assertions`,
+`premises`, `reverse`, `authorization`, `integrity`, `traversal`, and
+`latencyMs`. `versions`, `premises`, and `reverse` each expose their bounded
+items and truncation state. `integrity.status` is `verified`, `unverified`, or
+`invalidated` so consumers cannot silently treat an old explanation as current
+truth.
+
+CLI and MCP equivalents:
+
+```bash
+signet ontology explain-claim Signet architecture ontology proposal_loop
+signet ontology explain-claim Signet architecture ontology proposal_loop --session-key session-123 --json
+```
+
+MCP clients call `signet_explain_claim` with the same selectors and bounds.
+
 ### GET /api/ontology/links/:id/evidence
 
 Resolve evidence for an already-applied ontology link from stored dependency

--- a/web/docs/src/content/docs/api/route-inventory.md
+++ b/web/docs/src/content/docs/api/route-inventory.md
@@ -75,6 +75,7 @@ silently disappear from the API reference.
 | POST | `/api/knowledge/expand/session` | platform/daemon/src/routes/knowledge-routes.ts |
 | POST | `/api/graph/impact` | platform/daemon/src/routes/knowledge-routes.ts |
 | GET | `/api/ontology/claims/versions` | platform/daemon/src/routes/ontology-routes.ts |
+| GET | `/api/ontology/claims/explain` | platform/daemon/src/routes/ontology-routes.ts |
 | GET | `/api/ontology/claims/version` | platform/daemon/src/routes/ontology-routes.ts |
 | POST | `/api/ontology/operations/apply` | platform/daemon/src/routes/ontology-routes.ts |
 | POST | `/api/ontology/operations/batch` | platform/daemon/src/routes/ontology-routes.ts |

--- a/web/docs/src/content/docs/mcp.md
+++ b/web/docs/src/content/docs/mcp.md
@@ -45,6 +45,7 @@ unsafe shell syntax into generated lifecycle hooks.
 | Automatic memory extraction after each prompt | Hooks |
 | Agent wants to search memories mid-conversation | MCP (`signet_recall`, compatibility `memory_search`) |
 | Agent wants to search source-backed docs/artifacts | MCP (`signet_source_search`) |
+| Agent needs to audit a claim's versions and authorized evidence | MCP (`signet_explain_claim`) |
 | Sub-agent needs to inspect its parent session | MCP (`signet_session_search`, compatibility `session_search`) |
 | Codex agent wants to save a durable native-memory note | MCP (`signet_save_note`) |
 | Agent wants to store a specific Signet memory row | MCP (`memory_store`) |
@@ -306,6 +307,38 @@ whose memory IDs were actually recorded for the given session and agent.
 **Note:** Prefer this tool over embedding feedback as raw JSON text. Both
 are supported for backward compatibility, but the MCP tool is recorded
 immediately on the current turn.
+
+### signet_explain_claim
+
+Return an authorized, bounded explanation of one ontology claim. The tool
+joins current and historical claim versions, competing values, contradictory
+epistemic assertions, exact source spans, premise integrity, authorization
+decisions, and reverse derived-memory lineage through the daemon's canonical
+HTTP operation.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `entity` | string | yes | Entity/object name |
+| `aspect` | string | yes | Aspect/room name |
+| `group` | string | yes | Group/dresser key |
+| `claim` | string | yes | Claim/drawer key |
+| `kind` | `attribute \| constraint` | no | Restrict the claim kind |
+| `version_limit` | integer | no | 1–50, default 20 |
+| `premise_limit` | integer | no | 1–100, default 50 |
+| `reverse_limit` | integer | no | 1–100, default 50 |
+| `max_depth` | integer | no | 0–3, default 3 |
+| `session_key` | string | no | Fail closed if a premise crosses this session |
+| `agent_id` | string | no | Agent scope, default `default` |
+
+Fabricated or mismatched source references return an error instead of
+presenting a quote as evidence. Cross-agent, project, and session violations
+fail closed. Deleted or stale evidence is reported as invalidated, and the
+response's `integrity.status` must be checked before treating a claim as
+verified current truth.
+
+**Daemon endpoint:** `GET /api/ontology/claims/explain`
 
 ### session_search
 


### PR DESCRIPTION
## Summary

Closes #1318. Adds one canonical, read-only operation for an authorized, bounded trace of ontology claim truth, history, competing assertions, exact source evidence, integrity, and reverse derivation.

## Changes

- Added the approved `authorized-claim-trace` spec plus `INDEX.md`/`dependencies.yaml` registration.
- Added an agent/project/session-scoped daemon trace over existing graph, assertion, episodic-source, and derived-memory rows; no migration or second provenance store.
- Exposed `GET /api/ontology/claims/explain` through the CLI and `signet_explain_claim` MCP tool.
- Added fixed-input evaluation and regression coverage for history, contradictory values, exact artifact spans, deleted/fabricated/cross-agent evidence, session boundaries, project filtering, and bounded lineage.
- Updated API, MCP, graph-control-plane, Dreaming runbook, and route-inventory docs.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: approved specs and API/MCP docs

## Screenshots

N/A — no UI changes; this adds read-only API/CLI/MCP surfaces.

## PR Readiness

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migration. This is a read-only projection over existing tables and preserves current schema compatibility.

## Testing

- [x] `bun test platform/daemon/src/ontology-claim-trace.test.ts` — 9 pass
- [x] `bun test platform/daemon/src/mcp/tools.test.ts` — 54 pass
- [x] `bun test surfaces/cli/src/commands/ontology.test.ts` — 20 pass
- [x] `bun scripts/claim-trace-eval.ts` — 8/8 scenarios, accuracy 1.0, unsupported certainty 1, latency ~7 ms, 8 canonical calls
- [x] `bun scripts/spec-deps-check.ts`
- [x] `bun run typecheck` — pass after refreshing `@signet/core` build artifacts
- [x] `bun run build` — pass
- [x] targeted Biome check and `git diff --check`

The isolated full workspace suite was also attempted at the latest pre-final-release base: 2,204 pass, 7 skip, 166 daemon failures, 14 daemon errors, plus 9 CLI/2 core/1 dashboard baseline failures. The changed claim-trace, MCP, and CLI ontology suites passed in that run. Full-repo `bun run lint` remains blocked by pre-existing Biome formatting diagnostics across unrelated package manifests/files; all changed files pass targeted Biome.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- No mutation endpoint or schema migration was introduced; existing recall authorization/session binding is reused.
- Premise references are canonicalized and exact quotes are checked against immutable same-agent source content. Arbitrary evidence metadata and session tokens are not returned.
