### PR TITLE
fix(daemon): repair stale synthesis config

### DIFF
--- a/platform/daemon/src/config-migration.ts
+++ b/platform/daemon/src/config-migration.ts
@@ -610,6 +610,52 @@ const RETIRED_MEMORY_ROUTING_KEYS = [
 	"extractionCommand",
 ] as const;
 
+function removeRetiredMemoryPipelineRouting(doc: Document.Parsed, mutations: string[]): void {
+	const memory = doc.getIn(["memory"], true);
+	if (isMap(memory) && memory.has("synthesis")) {
+		memory.delete("synthesis");
+		mutations.push("removed memory.synthesis");
+	}
+
+	const pipeline = doc.getIn(["memory", "pipelineV2"], true);
+	if (!isMap(pipeline)) return;
+
+	if (pipeline.has("synthesis")) {
+		pipeline.delete("synthesis");
+		mutations.push("removed memory.pipelineV2.synthesis");
+	}
+	const flatProvider = String(pipeline.get("extractionProvider", true) ?? "").trim();
+	const preserveFlatRouting =
+		flatProvider !== "" && flatProvider !== "none" && legacyExecutorFor(flatProvider) === null;
+	for (const key of RETIRED_MEMORY_ROUTING_KEYS) {
+		if (!pipeline.has(key)) continue;
+		if (preserveFlatRouting && key !== "allowRemoteProviders") continue;
+		pipeline.delete(key);
+		mutations.push(`removed memory.pipelineV2.${key}`);
+	}
+	const extraction = pipeline.get("extraction", true);
+	if (!isMap(extraction)) return;
+
+	const nestedProvider = String(extraction.get("provider", true) ?? "").trim();
+	const preserveNestedRouting =
+		nestedProvider !== "" && nestedProvider !== "none" && legacyExecutorFor(nestedProvider) === null;
+	for (const key of [
+		"provider",
+		"model",
+		"endpoint",
+		"baseUrl",
+		"base_url",
+		"fallbackProvider",
+		"allowRemoteProviders",
+		"command",
+	]) {
+		if (!extraction.has(key)) continue;
+		if (preserveNestedRouting && key !== "allowRemoteProviders") continue;
+		extraction.delete(key);
+		mutations.push(`removed memory.pipelineV2.extraction.${key}`);
+	}
+}
+
 function migrateV8(agentsDir: string): void {
 	const path = findConfigPath(agentsDir);
 	if (!path) return;
@@ -652,54 +698,58 @@ function migrateV8(agentsDir: string): void {
 		block.delete("endpoint");
 	}
 
-	const memory = doc.getIn(["memory"], true);
-	if (isMap(memory) && memory.has("synthesis")) {
-		memory.delete("synthesis");
-		mutations.push("removed memory.synthesis");
-	}
-
-	const pipeline = doc.getIn(["memory", "pipelineV2"], true);
-	if (isMap(pipeline)) {
-		if (pipeline.has("synthesis")) {
-			pipeline.delete("synthesis");
-			mutations.push("removed memory.pipelineV2.synthesis");
-		}
-		const flatProvider = String(pipeline.get("extractionProvider", true) ?? "").trim();
-		const preserveFlatRouting =
-			flatProvider !== "" && flatProvider !== "none" && legacyExecutorFor(flatProvider) === null;
-		for (const key of RETIRED_MEMORY_ROUTING_KEYS) {
-			if (!pipeline.has(key)) continue;
-			if (preserveFlatRouting && key !== "allowRemoteProviders") continue;
-			pipeline.delete(key);
-			mutations.push(`removed memory.pipelineV2.${key}`);
-		}
-		const extraction = pipeline.get("extraction", true);
-		if (isMap(extraction)) {
-			const nestedProvider = String(extraction.get("provider", true) ?? "").trim();
-			const preserveNestedRouting =
-				nestedProvider !== "" && nestedProvider !== "none" && legacyExecutorFor(nestedProvider) === null;
-			for (const key of [
-				"provider",
-				"model",
-				"endpoint",
-				"baseUrl",
-				"base_url",
-				"fallbackProvider",
-				"allowRemoteProviders",
-				"command",
-			]) {
-				if (!extraction.has(key)) continue;
-				if (preserveNestedRouting && key !== "allowRemoteProviders") continue;
-				extraction.delete(key);
-				mutations.push(`removed memory.pipelineV2.extraction.${key}`);
-			}
-		}
-	}
+	removeRetiredMemoryPipelineRouting(doc, mutations);
 
 	stampConfigVersion(doc, 8);
 	writeAtomic(path, doc.toString());
 	if (mutations.length > 0) {
 		logger.info("config-migration", "Applied v8 config migration", { mutations, file: path });
+	}
+}
+
+// ---------------------------------------------------------------------------
+// v9: repair retired routing left behind by the v8 migration
+// ---------------------------------------------------------------------------
+// v8 originally owned this cleanup, but configs already stamped v8 were
+// skipped when the cleanup was added. Keep the repair on its own version so
+// those workspaces can reach validation without manual agent.yaml edits.
+export function migrateRetiredMemoryPipelineRoutingV9(agentsDir: string): void {
+	const path = findConfigPath(agentsDir);
+	if (!path) return;
+
+	let text: string;
+	try {
+		text = readFileSync(path, "utf-8");
+	} catch {
+		return;
+	}
+
+	const vMatch = /^configVersion:\s*(\d+)/m.exec(text);
+	if (vMatch && Number(vMatch[1]) >= 9) return;
+
+	const doc = parseDocument(text);
+	if (doc.errors.length > 0) {
+		logger.warn("config-migration", "Skipping v9 config migration: agent.yaml has parse errors", {
+			file: path,
+			errors: doc.errors.map((error) => error.message).slice(0, 3),
+		});
+		return;
+	}
+
+	const mutations: string[] = [];
+	removeRetiredMemoryPipelineRouting(doc, mutations);
+	const pipeline = doc.getIn(["memory", "pipelineV2"], true);
+	if (isMap(pipeline)) {
+		for (const key of RETIRED_EXTRACTION_WRITER_KEYS) {
+			if (!pipeline.has(key)) continue;
+			pipeline.delete(key);
+			mutations.push(`removed memory.pipelineV2.${key}`);
+		}
+	}
+	stampConfigVersion(doc, 9);
+	writeAtomic(path, doc.toString());
+	if (mutations.length > 0) {
+		logger.info("config-migration", "Applied v9 config migration", { mutations, file: path });
 	}
 }
 

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -43,6 +43,7 @@ import {
 	migrateInferenceProviders,
 	migrateLegacyRoutingToRegistry,
 	migrateRetiredExtractionWriterConfig,
+	migrateRetiredMemoryPipelineRoutingV9,
 	migrateSessionSynthesisRoute,
 } from "./config-migration";
 import { listConnectors } from "./connectors/registry";
@@ -1956,6 +1957,7 @@ async function main() {
 		migrateSessionSynthesisRoute(AGENTS_DIR);
 		migrateRetiredExtractionWriterConfig(AGENTS_DIR);
 		migrateEmbeddingBaseUrl(AGENTS_DIR);
+		migrateRetiredMemoryPipelineRoutingV9(AGENTS_DIR);
 	} catch (err) {
 		logger.warn("config-migration", "Config migration failed; continuing startup", {
 			error: err instanceof Error ? err.message : String(err),

--- a/platform/daemon/src/legacy-routing-migration.test.ts
+++ b/platform/daemon/src/legacy-routing-migration.test.ts
@@ -6,6 +6,7 @@ import {
 	migrateLegacyRoutingToRegistry,
 	migrateRetiredExtractionWriterConfig,
 	migrateRetiredMemoryPipelineRouting,
+	migrateRetiredMemoryPipelineRoutingV9,
 	migrateSessionSynthesisRoute,
 } from "./config-migration";
 import { loadMemoryConfig } from "./memory-config";
@@ -17,6 +18,49 @@ function setupDir(): string {
 }
 
 describe("migrateLegacyRoutingToRegistry (#947 v4, #1004 v5 cleanup)", () => {
+	it("repairs retired synthesis in an already-v8 config before strict loading (#1380)", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`configVersion: 8
+memory:
+  pipelineV2:
+    enabled: true
+    extraction: {}
+    writeGate:
+      threshold: 0.45
+    durability:
+      enabled: true
+    synthesis:
+      enabled: false
+      timeout: 120000
+    paused: false
+inference:
+  workloads:
+    memoryExtraction:
+      target: canonical/default
+  targets:
+    canonical:
+      executor: openai-compatible
+      models:
+        default:
+          model: local-model
+`,
+			);
+
+			migrateRetiredMemoryPipelineRoutingV9(dir);
+			const after = readFileSync(join(dir, "agent.yaml"), "utf-8");
+			expect(after).toMatch(/^configVersion: 9/m);
+			expect(after).not.toMatch(/^\s+synthesis:/m);
+			expect(after).not.toContain("writeGate:");
+			expect(after).not.toContain("durability:");
+			expect(() => loadMemoryConfig(dir)).not.toThrow();
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("compiles legacy extraction and removes the obsolete synthesis block", () => {
 		const dir = setupDir();
 		try {

--- a/web/docs/src/content/docs/upgrading.md
+++ b/web/docs/src/content/docs/upgrading.md
@@ -51,9 +51,12 @@ back to another provider.
 ## Memory pipeline routing migration
 
 On startup, the config migrator advances eligible `agent.yaml` files through
-`configVersion: 8`. It removes the obsolete `memory.synthesis` and
+`configVersion: 9`. It removes the obsolete `memory.synthesis` and
 `memory.pipelineV2.synthesis` blocks and removes provider/model/endpoint fields
-that can be migrated safely. The migration is atomic and idempotent.
+that can be migrated safely. It also removes retired extraction-writer settings
+left behind by older migrations. Version 9 repairs workspaces that were already
+stamped `configVersion: 8` before those cleanups were added. The migration is
+atomic and idempotent.
 
 If a legacy provider cannot be mapped to a supported inference executor, its
 routing fields are preserved and the strict loader stops with an actionable


### PR DESCRIPTION
## Summary

Fixes #1380. Workspaces already stamped `configVersion: 8` could retain the retired `memory.pipelineV2.synthesis` block because the v8 migration returned before its cleanup ran. Startup then rejected the config before serving HTTP.

## Changes

- Factor retired memory-pipeline cleanup into a shared migration helper.
- Add an idempotent v9 migration for workspaces already at configVersion 8.
- Run the v9 repair during daemon startup before the first `loadMemoryConfig` call.
- Add a regression test covering disabled synthesis with canonical inference routing.
- Update the upgrading guide to document the v9 repair.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

Not applicable; daemon startup/config migration only.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

The migration only removes retired synthesis/routing keys and advances the config version. Existing unsupported providers remain preserved for manual reconfiguration. Reverting the code does not restore removed config keys, so recover from the workspace's config backup if rollback is required.

## Testing

- [x] `bun test` passes (focused daemon migration suites: 27 passed)
- [x] `bun run typecheck` passes (daemon package typecheck)
- [x] `bun run lint` passes (Biome on changed files)
- [ ] Tested against running daemon
- [ ] N/A

Additional verification: `@signet/core` build, `@signet/daemon` build, and a disposable pre-fix run reproduced the v8 migration deadlock.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The v8 migration remains unchanged for configs below version 8. The new v9 pass repairs stale cleanup state after v8 and runs before daemon initialization.
