### PR TITLE
feat(telemetry): attribute dreaming pass target

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -91,7 +91,7 @@ paths, or user identity.
 | `recall.outcome` | result and delivery boundary for a recall attempt | `surface`, `resultState` (`empty` / `non_empty` / `truncated` / `error`), `deliveryState` (`returned` / `injected` / `consumed` / `not_delivered`), `results` |
 | `source.lifecycle` | bounded source connect, index, readiness, first-recall, and recurring freshness milestones | `phase`, fixed `sourceClass`, bounded outcomes/counts/buckets |
 | `pipeline.error` | categorized extraction, decision, or embedding failure | `stage`, `code` only; no message or stack content |
-| `dreaming.pass` | every terminal agentic dreaming pass, including no-op, failed, and cancelled passes | `mode`, `outcome`, `outcomeCode`, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `tokensTotal`, `cost`, `accountingProvenance`, `artifactsConsidered`, `memoriesCreated`, `memoriesUpdated`, `memoriesSuperseded`, `memoriesRetired`, `claimsChanged`, `relationshipsChanged`, `provenanceLinksChanged`, `toolCalls`, `durationMs` |
+| `dreaming.pass` | every terminal agentic dreaming pass, including no-op, failed, and cancelled passes | `mode`, `outcome`, `outcomeCode`, bounded successful-target `provider` and `model` when available, `tokensInput`, `tokensOutput`, `tokensCacheRead`, `tokensCacheWrite`, `tokensTotal`, `cost`, `accountingProvenance`, `artifactsConsidered`, `memoriesCreated`, `memoriesUpdated`, `memoriesSuperseded`, `memoriesRetired`, `claimsChanged`, `relationshipsChanged`, `provenanceLinksChanged`, `toolCalls`, `durationMs` |
 | `pipeline.operation` | one bounded summary for a logical indexing, capture, recall, dreaming, extraction, or other operation | `operationClass`, `outcome`, `accepted`, `skipped`, `retried`, `failed`, duration/queue-age buckets, optional `causeFamily` |
 | `inference.route` | inference control-plane routing decision | `surface`, `agentId`, `operation`, `taskClass`, `policyId`, `selectedTarget`, `candidateCount`, `blockedCount`, `allowedCount`, `privacy`, `durationMs`, `success`, `errorCode` |
 | `inference.execute` / `inference.stream` | per-execution outcome | `surface`, `agentId`, `operation`, `taskClass`, `policyId`, `selectedTarget`, `finalTarget`, `attemptPath`, `failedTargets`, `attemptCount`, `failedCount`, `fallbackCount`, `privacy`, `durationMs`, `inputTokens`, `outputTokens`, `success`, `cancelled`, `errorCode` |
@@ -212,7 +212,12 @@ Notes on individual events:
   memory version replacements are counted as created/superseded rather than
   in-place updates. `artifactsConsidered` counts unique evidence references
   surfaced by the pass, `toolCalls` counts completed capability calls, and
-  `durationMs` is the bounded wall-clock pass duration.
+  `durationMs` is the bounded wall-clock pass duration. When the routed run
+  succeeds, `provider` is the normalized provider family and `model` is the
+  configured model ID for the target that actually completed the pass,
+  including a fallback target. These fields are omitted when no successful
+  target metadata is available. They never contain target refs, account IDs or
+  labels, endpoints, credential refs, agent identities, or content.
 - **`recall.performed`** — emitted at the shared `hybridRecall` boundary with
   counts and timing only. Aggregate recall can emit one event for the main
   search and additional events for decomposed subqueries. It measures search

--- a/platform/daemon/src/inference-router.test.ts
+++ b/platform/daemon/src/inference-router.test.ts
@@ -123,6 +123,7 @@ describe("InferenceRouter legacy API credentials", () => {
 			if (!result.ok) return;
 			expect(result.value.decision.targetRef).toBe("dreaming/default");
 			expect(result.value.attempts).toEqual([expect.objectContaining({ targetRef: "dreaming/default", ok: true })]);
+			expect(result.value.attribution).toEqual({ provider: "acpx", model: "gpt-5.4-mini" });
 
 			const args = readFileSync(fixture.argsPath, "utf8").trim().split("\n");
 			expect(args).toContain("--mcp-config");
@@ -145,6 +146,74 @@ describe("InferenceRouter legacy API credentials", () => {
 				]),
 			);
 			expect(existsSync(mcpConfigPath)).toBe(false);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("attributes a Dreaming run to the fallback target that succeeds", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-router-dreaming-fallback-"));
+		const failedBin = join(dir, "failed-agent.sh");
+		const fallbackBin = join(dir, "fallback-agent.sh");
+		writeFileSync(failedBin, "#!/usr/bin/env bash\nexit 1\n");
+		writeFileSync(fallbackBin, "#!/usr/bin/env bash\ncat >/dev/null\nprintf 'fallback agent completed\\n'\n");
+		chmodSync(failedBin, 0o755);
+		chmodSync(fallbackBin, 0o755);
+		mkdirSync(join(dir, "memory"), { recursive: true });
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			`inference:
+  defaultPolicy: dreaming
+  targets:
+    primary:
+      executor: acpx
+      acpx:
+        agent: codex
+        bin: ${failedBin}
+      models:
+        default:
+          model: gpt-primary
+    fallback:
+      executor: acpx
+      acpx:
+        agent: codex
+        bin: ${fallbackBin}
+      models:
+        default:
+          model: gpt-fallback
+  policies:
+    dreaming:
+      mode: automatic
+      defaultTargets:
+        - primary/default
+      fallbackTargets:
+        - fallback/default
+  workloads:
+    memoryExtraction:
+      policy: dreaming
+`,
+		);
+		try {
+			const router = getOrCreateInferenceRouter(dir);
+			const result = await router.runAgent(
+				{ operation: "memory_extraction", promptPreview: "fallback attribution" },
+				"Use the supplied evidence and daemon tools.",
+				[],
+				{
+					acpxMcp: {
+						agentId: "agent-fallback",
+						passId: "pass-fallback",
+						daemonUrl: "http://127.0.0.1:3850",
+					},
+				},
+			);
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.attempts.map((attempt) => [attempt.targetRef, attempt.ok])).toEqual([
+				["primary/default", false],
+				["fallback/default", true],
+			]);
+			expect(result.value.attribution).toEqual({ provider: "acpx", model: "gpt-fallback" });
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -48,6 +48,11 @@ const OBSERVED_MISSING_TTL_MS = 60_000;
 const REDACTED_UPSTREAM_DETAIL = "[redacted upstream detail]";
 const BACKGROUND_OPERATIONS = new Set<RoutingOperationKind>(["memory_extraction", "session_synthesis", "repair"]);
 
+function normalizeAttributionValue(value: string | undefined): string | null {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : null;
+}
+
 export interface BackgroundInferenceQuiescence {
 	readonly activeAtStart: number;
 	readonly aborted: number;
@@ -74,6 +79,13 @@ export interface InferenceExecutionResult {
 export interface InferenceAgentExecutionResult {
 	readonly decision: RouteDecision;
 	readonly attempts: readonly InferenceExecutionAttempt[];
+	/** Privacy-safe metadata for the target that actually completed the run. */
+	readonly attribution: InferenceExecutionAttribution | null;
+}
+
+export interface InferenceExecutionAttribution {
+	readonly provider: string;
+	readonly model: string;
 }
 
 export type InferenceStreamEvent =
@@ -154,6 +166,21 @@ interface LoadedRoutingConfig {
 	readonly signature: string;
 	readonly path: string | null;
 	readonly configIssues: readonly RoutingValidationIssue[];
+}
+
+function attributionForTarget(
+	loaded: LoadedRoutingConfig,
+	targetId: string,
+	modelId: string,
+): InferenceExecutionAttribution | null {
+	const target = loaded.config.targets[targetId];
+	const model = target?.models[modelId];
+	if (!target || !model) return null;
+	const account = target.account ? loaded.config.accounts[target.account] : undefined;
+	const provider = normalizeAttributionValue(account?.providerFamily ?? target.executor);
+	const configuredModel = normalizeAttributionValue(model.model);
+	if (!provider || !configuredModel) return null;
+	return { provider: provider.toLowerCase(), model: configuredModel };
 }
 
 interface SnapshotCacheEntry {
@@ -852,7 +879,14 @@ export class InferenceRouter {
 						if (!generated.trim()) throw new Error("ACPX agent returned no completion");
 						this.clearObservedRuntimeState(loaded.value, targetRef);
 						attempts.push({ targetRef, ok: true, durationMs: Date.now() - startedAt, usage: null });
-						return { ok: true, value: { decision: decision.value, attempts } };
+						return {
+							ok: true,
+							value: {
+								decision: decision.value,
+								attempts,
+								attribution: attributionForTarget(loaded.value, parsed.value.targetId, parsed.value.modelId),
+							},
+						};
 					}
 					const session = await provider.createAgentSession(tools, { maxTokens: opts?.maxTokens });
 					const deadlineMs = opts?.timeoutMs ?? provider.agentSessionTimeoutMs;
@@ -890,7 +924,14 @@ export class InferenceRouter {
 					}
 					this.clearObservedRuntimeState(loaded.value, targetRef);
 					attempts.push({ targetRef, ok: true, durationMs: Date.now() - startedAt, usage: sessionUsage });
-					return { ok: true, value: { decision: decision.value, attempts } };
+					return {
+						ok: true,
+						value: {
+							decision: decision.value,
+							attempts,
+							attribution: attributionForTarget(loaded.value, parsed.value.targetId, parsed.value.modelId),
+						},
+					};
 				} catch (error) {
 					const message = formatExecutionError(error);
 					this.observeExecutionFailure(loaded.value, targetRef, message);

--- a/platform/daemon/src/pipeline/dreaming-telemetry.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-telemetry.test.ts
@@ -67,6 +67,7 @@ describe("dreaming telemetry", () => {
 				totalCost: 0.14574042,
 				accountingProvenance: "provider_reported",
 			},
+			attribution: { provider: "openai-compatible", model: "gpt-5.4-mini" },
 		});
 		recordDreamingPassTelemetry({
 			mode: "hygiene",
@@ -98,6 +99,8 @@ describe("dreaming telemetry", () => {
 		expect(full?.properties.tokensTotal).toBe(502788);
 		expect(full?.properties.cost).toBe(0.14574042);
 		expect(full?.properties.accountingProvenance).toBe("provider_reported");
+		expect(full?.properties.provider).toBe("openai-compatible");
+		expect(full?.properties.model).toBe("gpt-5.4-mini");
 		expect(full?.properties.outcome).toBe("completed");
 		expect(full?.properties.outcomeCode).toBe("completed");
 		expect(full?.properties.artifactsConsidered).toBe(12);

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -239,6 +239,7 @@ export function startDreamingWorker(
 				}
 				return {
 					summary: `Dreaming agent completed through ${result.value.decision.targetRef}`,
+					attribution: result.value.attribution,
 					usage: result.value.attempts.find((attempt) => attempt.ok)?.usage ?? null,
 				};
 			},

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -1042,6 +1042,34 @@ describe("Dreaming", () => {
 			}),
 		);
 
+		seedTranscript(db, "attributed", "Evidence for an attributed pass.", new Date(Date.now() + 60_000).toISOString());
+		await runDreamingAgentPass(
+			accessor,
+			{
+				async run() {
+					return {
+						summary: "Attributed pass",
+						attribution: { provider: "ollama", model: "gemma4" },
+					};
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT],
+			"incremental",
+		);
+		expect(telemetry.events).toContainEqual(
+			expect.objectContaining({
+				event: "dreaming.pass",
+				properties: expect.objectContaining({
+					outcome: "no-op",
+					provider: "ollama",
+					model: "gemma4",
+				}),
+			}),
+		);
+
 		// Seed evidence with a future watermark so it is unambiguously newer
 		// than the previous pass's cutoff (same-second seeds are racy).
 		seedTranscript(db, "failure", "Evidence that reaches the agent.", new Date(Date.now() + 60_000).toISOString());

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -210,7 +210,16 @@ export interface DreamingAgentExecutor {
 		readonly tools: ReturnType<typeof createDreamingAgentTools>;
 		readonly timeoutMs: number;
 		readonly maxTokens: number;
-	}): Promise<{ readonly summary?: string; readonly usage?: LlmUsage | null }>;
+	}): Promise<{
+		readonly summary?: string;
+		readonly usage?: LlmUsage | null;
+		readonly attribution?: DreamingPassAttribution | null;
+	}>;
+}
+
+export interface DreamingPassAttribution {
+	readonly provider: string;
+	readonly model: string;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -880,6 +889,7 @@ export function recordDreamingPassTelemetry(input: {
 	readonly outcome: DreamingPassOutcome;
 	readonly outcomeCode: DreamingPassOutcomeCode;
 	readonly effects: DreamingPassEffects;
+	readonly attribution?: DreamingPassAttribution | null;
 	readonly usage: {
 		readonly inputTokens: number | null;
 		readonly outputTokens: number | null;
@@ -895,6 +905,12 @@ export function recordDreamingPassTelemetry(input: {
 			mode: input.mode,
 			outcome: input.outcome,
 			outcomeCode: input.outcomeCode,
+			...(input.attribution
+				? {
+						provider: input.attribution.provider,
+						model: input.attribution.model,
+					}
+				: {}),
 			tokensInput: input.usage?.inputTokens ?? null,
 			tokensOutput: input.usage?.outputTokens ?? null,
 			tokensCacheRead: input.usage?.cacheReadTokens ?? null,
@@ -1370,6 +1386,7 @@ export async function runDreamingAgentPass(
 			maxTokens: cfg.maxOutputTokens,
 		});
 		const summary = `${executorResult.summary?.trim() || "Agentic Dreaming pass completed"}`;
+		const attribution = executorResult.attribution ?? null;
 		// Provider-reported aggregate when the executor surfaced it (pi-backed
 		// agent sessions); otherwise fall back to the local prompt estimate so
 		// acpx-backed passes keep a meaningful total.
@@ -1459,6 +1476,7 @@ export async function runDreamingAgentPass(
 			outcome,
 			outcomeCode,
 			effects: dreamingPassEffects(effects, toolCallSequence, passStartedAtMs),
+			attribution,
 			usage,
 		});
 		recordPipelineOperation({

--- a/web/docs/src/content/docs/analytics.md
+++ b/web/docs/src/content/docs/analytics.md
@@ -251,7 +251,8 @@ because they share the same anonymous `distinct_id`. `pipeline.embedding`
 (tokens, provider, sourceKind — memory capture / artifact index / recall /
 dreaming), and `dreaming.pass`
 (provider-reported input/output/cache tokens and cost per agentic
-pass, plus bounded outcomes and content-free artifact, durable-effect,
+pass, plus the bounded successful-target `provider` and configured `model`
+when available, outcomes and content-free artifact, durable-effect,
 tool-call, and duration counters). `dreaming.pass` never includes artifact
 names, memory text, prompts, tool arguments, source paths, or raw agent
 identities; unavailable provider usage remains null rather than inferred zero


### PR DESCRIPTION
## Summary

Adds privacy-safe provider/model attribution to completed `dreaming.pass` telemetry events, using the provider/model that actually completed the routed agent run. This includes fallback winners and preserves the existing usage and cost fields.

Fixes #1378

## Changes

- Return normalized successful-target attribution from the inference router without exposing raw target refs, account IDs, endpoints, labels, credentials, or content.
- Thread the successful target's provider/model through the Dreaming worker into `dreaming.pass` telemetry.
- Preserve omission when attribution metadata is unavailable and preserve all existing event fields.
- Add direct and fallback-success regression coverage, including a local Ollama-style provider attribution case.
- Document the telemetry contract and privacy boundary.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: telemetry documentation

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no migrations.

## Testing

- [x] Focused Dreaming telemetry, Dreaming worker, and inference-router tests: 53 passed, 0 failed.
- [x] Targeted Biome check on all changed TypeScript files.
- [x] `@signet/core` build passed.
- [x] `@signet/daemon` build passed.
- [x] `git diff --check` passed.
- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

The full-repo typecheck and lint commands were run but remain blocked by unrelated pre-existing connector/generated-bundle errors and repo-wide formatting violations. The changed daemon files pass targeted checks and the daemon package build passes.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Attribution is emitted only for a completed pass when the successful target exposes both a bounded provider family and canonical configured model ID. Fallback attribution uses the fallback target that actually succeeded. Local targets use their bounded executor/provider family, so zero-cost local execution remains attributable rather than being treated as missing metadata.
