### PR TITLE
fix(daemon): quarantine migration embedding failures

### DIFF
--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -700,6 +700,17 @@ export interface EmbeddingStatusResponse {
 	readonly base_url: string;
 	readonly error?: string;
 	readonly checkedAt: string;
+	readonly index?: {
+		readonly state: "ready" | "building" | "failed";
+		readonly coverage?: {
+			readonly active: number;
+			readonly staged: number;
+			readonly missing: number;
+			readonly wrongDimensions: number;
+			readonly quarantined: number;
+			readonly ready: boolean;
+		};
+	};
 }
 
 export interface EmbeddingHealthResponse {

--- a/platform/core/src/migrations/123-embedding-index-failures.ts
+++ b/platform/core/src/migrations/123-embedding-index-failures.ts
@@ -1,0 +1,32 @@
+import type { MigrationDb } from "./index";
+
+/**
+ * Persist terminal failures from an embedding-index migration. A provider can
+ * be healthy while one source row is not representable by its context window;
+ * keeping that decision in SQLite prevents a poison row from blocking future
+ * polls or disappearing from migration diagnostics.
+ */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS embedding_index_failures (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			content_hash TEXT NOT NULL,
+			source_type TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			agent_id TEXT,
+			target_fingerprint TEXT NOT NULL,
+			provider TEXT NOT NULL,
+			model TEXT NOT NULL,
+			failure_class TEXT NOT NULL CHECK (failure_class IN ('context_limit', 'invalid_input')),
+			attempts INTEGER NOT NULL DEFAULT 1,
+			retry_policy TEXT NOT NULL DEFAULT 'quarantined',
+			first_failed_at TEXT NOT NULL,
+			last_failed_at TEXT NOT NULL,
+			UNIQUE(content_hash, target_fingerprint)
+		);
+		CREATE INDEX IF NOT EXISTS idx_embedding_index_failures_target
+			ON embedding_index_failures(target_fingerprint, failure_class, last_failed_at);
+		CREATE INDEX IF NOT EXISTS idx_embedding_index_failures_source
+			ON embedding_index_failures(source_type, source_id);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -128,6 +128,7 @@ import { up as telemetryVersionObservation } from "./119-telemetry-version-obser
 import { up as sourceLifecycleTelemetry } from "./120-source-lifecycle-telemetry";
 import { up as telemetryDeliveryHealth } from "./121-telemetry-delivery-health";
 import { up as dreamingEvidenceRetry } from "./122-dreaming-evidence-retry";
+import { up as embeddingIndexFailures } from "./123-embedding-index-failures";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1155,6 +1156,12 @@ export const MIGRATIONS: readonly Migration[] = [
 				{ table: "dreaming_evidence_exclusions", column: "last_requeued_at" },
 			],
 		},
+	},
+	{
+		version: 123,
+		name: "embedding-index-failures",
+		up: embeddingIndexFailures,
+		artifacts: { tables: ["embedding_index_failures"] },
 	},
 ];
 

--- a/platform/daemon/src/embedding-index-migration.test.ts
+++ b/platform/daemon/src/embedding-index-migration.test.ts
@@ -25,13 +25,34 @@ describe("staging embedding coverage", () => {
 			INSERT INTO embeddings_staging VALUES ('m2', 'memory-hash', 1024);
 		`);
 		const db = raw as unknown as ReadDb;
-		expect(stagingCoverage(db, 1024)).toEqual({ active: 2, staged: 1, missing: 1, wrongDimensions: 0, ready: false });
+		expect(stagingCoverage(db, 1024)).toEqual({
+			active: 2,
+			staged: 1,
+			missing: 1,
+			wrongDimensions: 0,
+			quarantined: 0,
+			ready: false,
+		});
 
 		raw.exec("INSERT INTO embeddings_staging VALUES ('s2', 'source-hash', 768)");
-		expect(stagingCoverage(db, 1024)).toEqual({ active: 2, staged: 2, missing: 0, wrongDimensions: 1, ready: false });
+		expect(stagingCoverage(db, 1024)).toEqual({
+			active: 2,
+			staged: 2,
+			missing: 0,
+			wrongDimensions: 1,
+			quarantined: 0,
+			ready: false,
+		});
 
 		raw.exec("UPDATE embeddings_staging SET dimensions = 1024 WHERE id = 's2'");
-		expect(stagingCoverage(db, 1024)).toEqual({ active: 2, staged: 2, missing: 0, wrongDimensions: 0, ready: true });
+		expect(stagingCoverage(db, 1024)).toEqual({
+			active: 2,
+			staged: 2,
+			missing: 0,
+			wrongDimensions: 0,
+			quarantined: 0,
+			ready: true,
+		});
 	});
 
 	it("prunes obsolete staged rows while active writes and purges continue", async () => {
@@ -72,7 +93,14 @@ describe("staging embedding coverage", () => {
 			fetchEmbedding: async (text) => [text.length, 0, 0, 1],
 			batchSize: 10,
 		});
-		expect(first.coverage).toEqual({ active: 2, staged: 2, missing: 0, wrongDimensions: 0, ready: true });
+		expect(first.coverage).toEqual({
+			active: 2,
+			staged: 2,
+			missing: 0,
+			wrongDimensions: 0,
+			quarantined: 0,
+			ready: true,
+		});
 		expect(raw.prepare("SELECT COUNT(*) AS count FROM vec_embeddings_staging").get()).toEqual({ count: 2 });
 
 		// A source purge during an asynchronous build must not strand an orphan
@@ -84,7 +112,14 @@ describe("staging embedding coverage", () => {
 			fetchEmbedding: async () => [0, 0, 0, 0],
 			batchSize: 10,
 		});
-		expect(second.coverage).toEqual({ active: 1, staged: 1, missing: 0, wrongDimensions: 0, ready: true });
+		expect(second.coverage).toEqual({
+			active: 1,
+			staged: 1,
+			missing: 0,
+			wrongDimensions: 0,
+			quarantined: 0,
+			ready: true,
+		});
 		expect(raw.prepare("SELECT id FROM vec_embeddings_staging").all()).toHaveLength(1);
 	});
 
@@ -121,6 +156,104 @@ describe("staging embedding coverage", () => {
 			}),
 		).rejects.toThrow("expected 4");
 		expect(stagingCoverage(raw as unknown as ReadDb, 4).ready).toBe(false);
+	});
+
+	it("quarantines a context-limit row and continues staging later rows", async () => {
+		const raw = new Database(":memory:");
+		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);
+		raw.exec(`
+			CREATE TABLE embeddings (
+				id TEXT PRIMARY KEY, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER,
+				source_type TEXT, source_id TEXT, chunk_text TEXT, created_at TEXT, agent_id TEXT
+			);
+			CREATE TABLE embeddings_staging (
+				id TEXT PRIMARY KEY, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER,
+				source_type TEXT, source_id TEXT, chunk_text TEXT, created_at TEXT, agent_id TEXT
+			);
+			CREATE TABLE vec_embeddings_staging (id TEXT PRIMARY KEY, embedding BLOB);
+			CREATE TABLE embedding_index_failures (
+				id INTEGER PRIMARY KEY AUTOINCREMENT, content_hash TEXT NOT NULL,
+				source_type TEXT NOT NULL, source_id TEXT NOT NULL, agent_id TEXT,
+				target_fingerprint TEXT NOT NULL, provider TEXT NOT NULL, model TEXT NOT NULL,
+				failure_class TEXT NOT NULL, attempts INTEGER NOT NULL DEFAULT 1,
+				retry_policy TEXT NOT NULL DEFAULT 'quarantined', first_failed_at TEXT NOT NULL,
+				last_failed_at TEXT NOT NULL, UNIQUE(content_hash, target_fingerprint)
+			);
+			INSERT INTO embeddings VALUES
+				('poison', 'poison-hash', X'00', 768, 'memory', 'memory-poison', 'poison', '2026-01-01', 'agent-a'),
+				('later-a', 'later-hash-a', X'00', 768, 'memory', 'memory-a', 'later-a', '2026-01-02', 'agent-a'),
+				('later-b', 'later-hash-b', X'00', 768, 'memory', 'memory-b', 'later-b', '2026-01-03', 'agent-a');
+		`);
+		const db = raw as unknown as WriteDb;
+		const active = {
+			provider: "ollama",
+			model: "custom-a",
+			dimensions: 768,
+			base_url: "http://127.0.0.1:11434",
+		} as const;
+		const desired = { ...active, model: "custom-b", dimensions: 4 };
+		ensureEmbeddingIndexState(db, active);
+		beginEmbeddingIndexBuild(db, desired);
+		const accessor: DbAccessor = {
+			withWriteTx: (fn) => fn(db),
+			withReadDb: (fn) => fn(raw as unknown as ReadDb),
+			close: () => undefined,
+		};
+		let fetches = 0;
+		const first = await stageEmbeddingBatch({
+			accessor,
+			configured: desired,
+			fetchEmbedding: async (text, _cfg, _role, opts) => {
+				fetches++;
+				if (text === "poison") {
+					opts?.onFailure?.("context_limit");
+					return null;
+				}
+				return [1, 0, 0, 0];
+			},
+			batchSize: 10,
+		});
+		expect(first.coverage).toEqual({
+			active: 3,
+			staged: 2,
+			missing: 1,
+			wrongDimensions: 0,
+			quarantined: 1,
+			ready: true,
+		});
+		expect(raw.prepare("SELECT source_id, failure_class, retry_policy FROM embedding_index_failures").all()).toEqual([
+			{ source_id: "memory-poison", failure_class: "context_limit", retry_policy: "quarantined" },
+		]);
+		expect(fetches).toBe(3);
+
+		const second = await stageEmbeddingBatch({
+			accessor,
+			configured: desired,
+			fetchEmbedding: async () => {
+				fetches++;
+				return [1, 0, 0, 0];
+			},
+			batchSize: 10,
+		});
+		expect(second.staged).toBe(0);
+		expect(second.coverage?.ready).toBe(true);
+		expect(fetches).toBe(3);
+
+		raw.exec("DELETE FROM embeddings WHERE id = 'poison'");
+		const afterPurge = await stageEmbeddingBatch({
+			accessor,
+			configured: desired,
+			fetchEmbedding: async () => [1, 0, 0, 0],
+			batchSize: 10,
+		});
+		expect(afterPurge.coverage).toEqual({
+			active: 2,
+			staged: 2,
+			missing: 0,
+			wrongDimensions: 0,
+			quarantined: 0,
+			ready: true,
+		});
 	});
 });
 

--- a/platform/daemon/src/embedding-index-migration.test.ts
+++ b/platform/daemon/src/embedding-index-migration.test.ts
@@ -55,6 +55,33 @@ describe("staging embedding coverage", () => {
 		});
 	});
 
+	it("does not promote an empty replacement when every active row is quarantined", () => {
+		const raw = new Database(":memory:");
+		raw.exec(`
+			CREATE TABLE embeddings (id TEXT, content_hash TEXT, dimensions INTEGER);
+			CREATE TABLE embeddings_staging (id TEXT, content_hash TEXT, dimensions INTEGER);
+			CREATE TABLE embedding_index_failures (
+				content_hash TEXT,
+				target_fingerprint TEXT,
+				retry_policy TEXT
+			);
+			INSERT INTO embeddings VALUES
+				('active-a', 'hash-a', 768), ('active-b', 'hash-b', 768);
+			INSERT INTO embedding_index_failures VALUES
+				('hash-a', 'target-profile', 'quarantined'),
+				('hash-b', 'target-profile', 'quarantined');
+		`);
+
+		expect(stagingCoverage(raw as unknown as ReadDb, 768, "target-profile")).toEqual({
+			active: 2,
+			staged: 0,
+			missing: 2,
+			wrongDimensions: 0,
+			quarantined: 2,
+			ready: false,
+		});
+	});
+
 	it("prunes obsolete staged rows while active writes and purges continue", async () => {
 		const raw = new Database(":memory:");
 		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);

--- a/platform/daemon/src/embedding-index-migration.ts
+++ b/platform/daemon/src/embedding-index-migration.ts
@@ -173,7 +173,11 @@ export function stagingCoverage(
 		missing,
 		wrongDimensions,
 		quarantined,
-		ready: missing === quarantined && wrongDimensions === 0 && active === staged + quarantined,
+		ready:
+			missing === quarantined &&
+			wrongDimensions === 0 &&
+			active === staged + quarantined &&
+			(active === 0 || staged > 0),
 	};
 }
 

--- a/platform/daemon/src/embedding-index-migration.ts
+++ b/platform/daemon/src/embedding-index-migration.ts
@@ -11,6 +11,7 @@ import { beginEmbeddingIndexBuild, failEmbeddingIndexBuild } from "./embedding-i
 import type { EmbeddingRole } from "./embedding-profile";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
+import type { PipelineCauseFamily } from "./pipeline-operation";
 
 const STAGING_VECTOR_TABLE = "vec_embeddings_staging";
 
@@ -34,6 +35,7 @@ export interface EmbeddingMigrationCoverage {
 	readonly staged: number;
 	readonly missing: number;
 	readonly wrongDimensions: number;
+	readonly quarantined: number;
 	readonly ready: boolean;
 }
 
@@ -69,7 +71,7 @@ function configForProfile(profile: PersistedEmbeddingProfile, configured: Embedd
 }
 
 function tableExists(db: ReadDb, name: string): boolean {
-	return db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(name) !== undefined;
+	return db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(name) != null;
 }
 
 async function withQueuedWrite<T>(accessor: DbAccessor, fn: (db: WriteDb) => T): Promise<T> {
@@ -91,6 +93,25 @@ function createVectorIndex(db: WriteDb, table: string, dimensions: number): void
 			embedding FLOAT[${assertDimensions(dimensions)}] distance_metric=cosine
 		)
 	`);
+}
+
+function isTerminalMigrationFailure(
+	cause: PipelineCauseFamily | undefined,
+): cause is "context_limit" | "invalid_input" {
+	return cause === "context_limit" || cause === "invalid_input";
+}
+
+function migrationFailureCount(db: ReadDb, targetFingerprint: string | undefined): number {
+	if (!targetFingerprint || !tableExists(db, "embedding_index_failures")) return 0;
+	return (
+		(
+			db
+				.prepare(
+					"SELECT COUNT(*) AS n FROM embedding_index_failures f INNER JOIN embeddings e ON e.content_hash = f.content_hash WHERE f.target_fingerprint = ? AND f.retry_policy = 'quarantined'",
+				)
+				.get(targetFingerprint) as { n: number } | undefined
+		)?.n ?? 0
+	);
 }
 
 /** Creates a dimension-safe inactive vec0 table without touching active recall. */
@@ -121,7 +142,11 @@ function rebuildActiveVectorIndex(db: WriteDb, dimensions: number): void {
 	}
 }
 
-export function stagingCoverage(db: ReadDb, dimensions: number): EmbeddingMigrationCoverage {
+export function stagingCoverage(
+	db: ReadDb,
+	dimensions: number,
+	targetFingerprint?: string,
+): EmbeddingMigrationCoverage {
 	const active = (db.prepare("SELECT COUNT(*) AS n FROM embeddings").get() as { n: number } | undefined)?.n ?? 0;
 	const staged =
 		(db.prepare("SELECT COUNT(*) AS n FROM embeddings_staging").get() as { n: number } | undefined)?.n ?? 0;
@@ -141,12 +166,14 @@ export function stagingCoverage(db: ReadDb, dimensions: number): EmbeddingMigrat
 				| { n: number }
 				| undefined
 		)?.n ?? 0;
+	const quarantined = migrationFailureCount(db, targetFingerprint);
 	return {
 		active,
 		staged,
 		missing,
 		wrongDimensions,
-		ready: missing === 0 && wrongDimensions === 0 && active === staged,
+		quarantined,
+		ready: missing === quarantined && wrongDimensions === 0 && active === staged + quarantined,
 	};
 }
 
@@ -167,6 +194,40 @@ async function pruneStagingRows(accessor: DbAccessor): Promise<void> {
 			deleteVector.run(id);
 			deleteEmbedding.run(id);
 		}
+	});
+}
+
+async function recordMigrationFailure(
+	accessor: DbAccessor,
+	row: ActiveEmbeddingRow,
+	profile: PersistedEmbeddingProfile,
+	failureClass: "context_limit" | "invalid_input",
+): Promise<void> {
+	await withQueuedWrite(accessor, (db) => {
+		if (!tableExists(db, "embedding_index_failures")) return;
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO embedding_index_failures
+			 (content_hash, source_type, source_id, agent_id, target_fingerprint, provider, model,
+			  failure_class, attempts, retry_policy, first_failed_at, last_failed_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, 'quarantined', ?, ?)
+			 ON CONFLICT(content_hash, target_fingerprint) DO UPDATE SET
+			   source_type = excluded.source_type, source_id = excluded.source_id, agent_id = excluded.agent_id,
+			   provider = excluded.provider, model = excluded.model, failure_class = excluded.failure_class,
+			   attempts = embedding_index_failures.attempts + 1, retry_policy = 'quarantined',
+			   last_failed_at = excluded.last_failed_at`,
+		).run(
+			row.content_hash,
+			row.source_type,
+			row.source_id,
+			row.agent_id,
+			profile.fingerprint,
+			profile.provider,
+			profile.model,
+			failureClass,
+			now,
+			now,
+		);
 	});
 }
 
@@ -193,24 +254,47 @@ export async function stageEmbeddingBatch(input: {
 	await pruneStagingRows(input.accessor);
 	const rows = input.accessor.withReadDb((db) => {
 		if (!tableExists(db, STAGING_VECTOR_TABLE)) throw new Error("Staging vector index is unavailable");
+		const hasFailures = tableExists(db, "embedding_index_failures");
+		const failureFilter = hasFailures
+			? ` AND NOT EXISTS (
+					SELECT 1 FROM embedding_index_failures f
+					WHERE f.content_hash = e.content_hash
+					  AND f.target_fingerprint = ?
+					  AND f.retry_policy = 'quarantined'
+				)`
+			: "";
 		return db
 			.prepare(
 				`SELECT e.content_hash, e.source_type, e.source_id, e.chunk_text, e.agent_id
 				 FROM embeddings e
 				 LEFT JOIN embeddings_staging s ON s.content_hash = e.content_hash
-				 WHERE s.id IS NULL OR s.dimensions != ?
+				 WHERE (s.id IS NULL OR s.dimensions != ?)
+				 ${failureFilter}
 				 ORDER BY e.created_at ASC
 				 LIMIT ?`,
 			)
-			.all(profile.dimensions, input.batchSize) as ActiveEmbeddingRow[];
+			.all(
+				...(hasFailures
+					? [profile.dimensions, profile.fingerprint, input.batchSize]
+					: [profile.dimensions, input.batchSize]),
+			) as ActiveEmbeddingRow[];
 	});
 
 	let staged = 0;
 	for (const row of rows) {
+		let failureCause: PipelineCauseFamily | undefined;
 		const vector = await input.fetchEmbedding(row.chunk_text, configForProfile(profile, configured), "document", {
 			usage: { source: "artifact-index", agentId: row.agent_id ?? undefined },
+			onFailure: (cause) => {
+				failureCause = cause;
+			},
 		});
-		if (!vector) continue;
+		if (!vector) {
+			if (isTerminalMigrationFailure(failureCause)) {
+				await recordMigrationFailure(input.accessor, row, profile, failureCause);
+			}
+			continue;
+		}
 		if (vector.length !== profile.dimensions) {
 			throw new Error(
 				`Staging provider returned ${vector.length} dimensions for ${profile.model}; expected ${profile.dimensions}`,
@@ -248,7 +332,7 @@ export async function stageEmbeddingBatch(input: {
 		staged++;
 	}
 
-	const coverage = input.accessor.withReadDb((db) => stagingCoverage(db, profile.dimensions));
+	const coverage = input.accessor.withReadDb((db) => stagingCoverage(db, profile.dimensions, profile.fingerprint));
 	return { staged, coverage };
 }
 
@@ -260,7 +344,7 @@ export function promoteStagingIndex(accessor: DbAccessor): boolean {
 	return accessor.withWriteTx((db) => {
 		const state = readEmbeddingIndexState(db);
 		if (state?.state !== "building" || !state.staging) return false;
-		if (!stagingCoverage(db, state.staging.dimensions).ready) return false;
+		if (!stagingCoverage(db, state.staging.dimensions, state.staging.fingerprint).ready) return false;
 		if (!tableExists(db, STAGING_VECTOR_TABLE)) return false;
 		db.prepare(
 			`UPDATE memories SET embedding_model = ?

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -28,6 +28,8 @@ import {
 	listEmbeddingMigrationSources,
 	listUnembeddedMemories,
 } from "./embedding-coverage";
+import { type EmbeddingMigrationCoverage, stagingCoverage } from "./embedding-index-migration";
+import { readEmbeddingIndexState } from "./embedding-index-state";
 import { classifyEntityQuality } from "./entity-quality";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
@@ -559,6 +561,7 @@ export interface EmbeddingGapStats {
 	readonly embedded: number;
 	readonly complete: boolean;
 	readonly coverage: string;
+	readonly staging: EmbeddingMigrationCoverage | null;
 }
 
 export function getEmbeddingGapStats(accessor: DbAccessor): EmbeddingGapStats {
@@ -567,7 +570,12 @@ export function getEmbeddingGapStats(accessor: DbAccessor): EmbeddingGapStats {
 		const total = totalRow.n;
 		const unembedded = countUnembeddedMemories(db);
 		const embedded = total - unembedded;
-		const complete = unembedded === 0;
+		const state = tableExists(db, "embedding_index_state") ? readEmbeddingIndexState(db) : null;
+		const staging =
+			state?.staging && tableExists(db, "embeddings_staging")
+				? stagingCoverage(db, state.staging.dimensions, state.staging.fingerprint)
+				: null;
+		const complete = unembedded === 0 && (staging === null || staging.ready);
 		// Floor to one decimal so a near-complete store never rounds up to
 		// 100% while embeddings are still missing (issue #906). When the
 		// store is complete the ratio is exactly 100%.
@@ -580,6 +588,7 @@ export function getEmbeddingGapStats(accessor: DbAccessor): EmbeddingGapStats {
 			embedded,
 			complete,
 			coverage: `${displayed.toFixed(1)}%`,
+			staging,
 		};
 	});
 }

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -3615,7 +3615,9 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const tracker = embeddingTrackerHandle?.getStats() ?? null;
 		const index = getDbAccessor().withReadDb((db) => {
 			const state = readEmbeddingIndexState(db);
-			return state?.staging ? { ...state, coverage: stagingCoverage(db, state.staging.dimensions) } : state;
+			return state?.staging
+				? { ...state, coverage: stagingCoverage(db, state.staging.dimensions, state.staging.fingerprint) }
+				: state;
 		});
 		return c.json({ ...status, tracker, index });
 	});

--- a/surfaces/cli/src/commands/memory.ts
+++ b/surfaces/cli/src/commands/memory.ts
@@ -206,15 +206,17 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 			}
 
 			spinner.stop();
-			const stats = typeof data === "object" && data !== null ? data : {};
+			const stats = typeof data === "object" && data !== null ? (data as Record<string, unknown>) : {};
 			const total = typeof stats.total === "number" ? stats.total : 0;
 			const unembedded = typeof stats.unembedded === "number" ? stats.unembedded : 0;
 			const embedded = typeof stats.embedded === "number" ? stats.embedded : Math.max(0, total - unembedded);
 			const complete = stats.complete === true;
 			const coverage = typeof stats.coverage === "string" ? stats.coverage : "0%";
+			const staging =
+				typeof stats.staging === "object" && stats.staging !== null ? (stats.staging as Record<string, unknown>) : null;
 
 			if (options.json) {
-				console.log(JSON.stringify({ total, embedded, unembedded, complete, coverage }, null, 2));
+				console.log(JSON.stringify({ total, embedded, unembedded, complete, coverage, staging }, null, 2));
 				return;
 			}
 
@@ -224,6 +226,16 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 			console.log(`  Embedded:          ${chalk.green(embedded)}`);
 			console.log(`  Missing:           ${unembedded > 0 ? chalk.red(unembedded) : chalk.green(0)}`);
 			console.log(`  Coverage:          ${coverageColor(coverage)}`);
+			if (staging) {
+				const staged = typeof staging.staged === "number" ? staging.staged : 0;
+				const stagingTotal = typeof staging.active === "number" ? staging.active : 0;
+				const missing = typeof staging.missing === "number" ? staging.missing : 0;
+				const quarantined = typeof staging.quarantined === "number" ? staging.quarantined : 0;
+				console.log(`  Staging:           ${staged}/${stagingTotal} represented`);
+				if (missing > 0 || quarantined > 0) {
+					console.log(`  Staging missing:   ${missing} (${quarantined} quarantined)`);
+				}
+			}
 			console.log();
 
 			if (unembedded > 0) {

--- a/surfaces/dashboard/DASHBOARD_API_MAP.md
+++ b/surfaces/dashboard/DASHBOARD_API_MAP.md
@@ -67,6 +67,7 @@ native `EventSource` with headers, so auth is pumped manually).
 | Fn | Method | Path | Purpose |
 |---|---|---|---|
 | `getEmbeddings` | GET | `/api/embeddings` | Raw embedding vectors (paginated) |
+| `getEmbeddingStatus` | GET | `/api/embeddings/status` | Provider and active/staging migration coverage |
 | `getProjection` | GET | `/api/embeddings/projection` | UMAP 2D/3D projection |
 | `getEmbeddingHealth` | GET | `/api/embeddings/health` | Embedding health report |
 | `getEmbeddingGapStats` | GET | `/api/repair/embedding-gaps` | Missing-vector gaps |

--- a/web/docs/src/content/docs/api/memory/embeddings.md
+++ b/web/docs/src/content/docs/api/memory/embeddings.md
@@ -48,8 +48,9 @@ Requires `recall` permission.
 
 ### GET /api/embeddings/status
 
-Check the configured embedding provider's availability. Results are cached for
-30 seconds. Requires `recall` permission.
+Check the configured embedding provider's availability and any active embedding
+index migration. Results are cached for 30 seconds. Requires `recall`
+permission.
 
 **Response**
 
@@ -60,9 +61,27 @@ Check the configured embedding provider's availability. Results are cached for
   "available": true,
   "dimensions": 768,
   "base_url": "http://localhost:11434",
-  "checkedAt": "2026-02-21T10:00:00.000Z"
+  "checkedAt": "2026-02-21T10:00:00.000Z",
+  "index": {
+    "state": "building",
+    "coverage": {
+      "active": 45004,
+      "staged": 45003,
+      "missing": 1,
+      "wrongDimensions": 0,
+      "quarantined": 1,
+      "ready": true
+    }
+  }
 }
 ```
+
+`index.coverage.quarantined` counts active rows that the target provider
+rejected as permanently unrepresentable, such as an input exceeding its
+context limit. These rows retain their source id and content hash in the
+durable migration-failure table, are excluded from future polls for that
+target profile, and do not block promotion. The status response therefore
+reports staging coverage separately from active-index coverage.
 
 On failure, `available` is `false` and `error` contains a description.
 If a native inference call times out, Signet disables that native worker for

--- a/web/docs/src/content/docs/configuration/workspace-identity.md
+++ b/web/docs/src/content/docs/configuration/workspace-identity.md
@@ -216,7 +216,8 @@ to avoid aborted explicit recall embeddings.
 Changing the embedding provider, model, dimensions, or base URL starts a
 background index migration. Existing semantic recall remains on the active
 index until Signet has re-embedded every active memory and source chunk with
-the new profile; only then is the new index promoted. Check
+the new index; rows that the target provider permanently rejects are durably
+quarantined and reported in staging coverage so they do not block promotion. Check
 `GET /api/embeddings/status` for the active/staging profile and migration
 coverage. If the daemon restarts, the incomplete staged build resumes; a
 failed build leaves the active index unchanged.


### PR DESCRIPTION
## Summary

Fixes #1358.

A provider can be healthy while one active embedding is permanently rejected by the target profile, for example an Ollama context-limit response. The migration previously treated that row as an ordinary null result, selected it again on every poll, and never promoted the rest of the rebuild.

## Changes

- Add durable `embedding_index_failures` state keyed by source content hash and target profile fingerprint.
- Persist source type/id, agent provenance, provider/model, failure category, attempts, and quarantine retry policy for terminal `context_limit` and `invalid_input` failures.
- Exclude quarantined rows from later polls and count only active quarantined rows as accounted-for staging coverage, allowing the healthy portion of the index to promote.
- Expose staging coverage and quarantine counts through the embedding status and `signet embed audit` surfaces.
- Add migration, SDK type, dashboard map, and documentation parity.
- Add regression coverage for progress past a poison row, for purging its active source afterward, and for rejecting an empty replacement when every active row is quarantined.

## PR Readiness

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Notes: This is an additive daemon migration and status/audit read-surface change; it adds no admin or mutation endpoint. The migration query is scoped by target fingerprint and active embedding membership, and the regression test covers terminal failure handling and continued progress.

## Tests

- `bun test platform/daemon/src/embedding-index-migration.test.ts` - 12 pass
- `bun test platform/core/src/migrations/migrations.test.ts` - 63 pass
- `bun test platform/daemon/src/repair-actions.test.ts` - 59 pass
- `bun run --filter '@signet/core' build` - passed
- `bun run --filter '@signet/daemon' build` - passed
- `bun run --filter '@signet/sdk' build` - passed
- `bun run typecheck` - passed
- `bun run build:workspace-deps` from `surfaces/cli` - passed
- `bun run build:cli` from `surfaces/cli` - passed
- `bunx biome check` on changed TypeScript files - passed
- `git diff --check` - passed

## Risk and exclusions

This intentionally does not quarantine provider-unavailable, timeout, auth, quota, or rate-limit failures; those remain retryable. Quarantined rows are reported as staging failures and retain provenance, but they are not represented in the target vector index.

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

Migration 123 is additive and uses `CREATE TABLE IF NOT EXISTS` plus `CREATE INDEX IF NOT EXISTS`. Existing embedding rows are untouched. Rolling back the application leaves the quarantine table unused; rolling back the schema requires the normal database backup/restore path and would remove failure history.
