### PR TITLE
fix(daemon): bound skill catalog fetches

### DIFF
--- a/platform/daemon/src/routes/skills.test.ts
+++ b/platform/daemon/src/routes/skills.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
 import {
 	buildSkillInstallPlan,
+	fetchCatalogUrl,
 	formatInstalls,
 	listInstalledSkills,
 	mountSkillsRoutes,
@@ -503,6 +504,94 @@ This is a test skill.`,
 		expect(res.status).toBe(400);
 		const body = await res.json();
 		expect(body.error).toContain("Query parameter q is required");
+	});
+
+	it("bounds external skill fetches with abort signals", async () => {
+		const originalFetch = globalThis.fetch;
+		const calls: Array<{ url: string; signal: AbortSignal | undefined }> = [];
+		globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			calls.push({ url, signal: init?.signal as AbortSignal | undefined });
+
+			if (url.startsWith("https://skills.sh/api/search")) {
+				return new Response(JSON.stringify({ skills: [] }), { status: 200 });
+			}
+			if (url.startsWith("https://clawhub.ai/api/v1/skills")) {
+				return new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 });
+			}
+			if (url.startsWith("https://api.github.com/")) {
+				return new Response(JSON.stringify({ tree: [{ path: "remote-skill/SKILL.md" }] }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/")) {
+				return new Response("---\ndescription: Remote skill\n---\n", { status: 200 });
+			}
+			return new Response("not a zip", { status: 200 });
+		}) as unknown as typeof fetch;
+
+		try {
+			await app.request("/api/skills/search?q=remote");
+			await app.request("/api/skills/remote-skill?source=owner/repo");
+			await app.request("/api/skills/install", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ name: "remote-skill", source: "clawhub@remote-skill" }),
+			});
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+
+		const externalUrls = [
+			"https://clawhub.ai/api/v1/download?slug=remote-skill",
+			"https://skills.sh/api/search?q=remote",
+			"https://api.github.com/repos/owner/repo/git/trees/main?recursive=1",
+			"https://raw.githubusercontent.com/owner/repo/main/remote-skill/SKILL.md",
+		];
+		for (const url of externalUrls) {
+			const call = calls.find((entry) => entry.url === url);
+			expect(call, `expected bounded fetch for ${url}`).toBeDefined();
+			expect(call?.signal, `expected abort signal for ${url}`).toBeDefined();
+		}
+	});
+
+	it("aborts a stalled catalog fetch at its deadline", async () => {
+		const originalFetch = globalThis.fetch;
+		let signal: AbortSignal | undefined;
+		globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+			signal = init?.signal as AbortSignal | undefined;
+			return new Promise<Response>((_resolve, reject) => {
+				signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+			});
+		}) as unknown as typeof fetch;
+
+		try {
+			await expect(fetchCatalogUrl("https://skills.example.invalid", 5)).rejects.toThrow("aborted");
+			expect(signal?.aborted).toBe(true);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it("keeps the deadline active while consuming a catalog response body", async () => {
+		const originalFetch = globalThis.fetch;
+		let signal: AbortSignal | undefined;
+		globalThis.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+			signal = init?.signal as AbortSignal | undefined;
+			const body = new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.enqueue(new TextEncoder().encode("partial"));
+					signal?.addEventListener("abort", () => controller.error(new Error("aborted")), { once: true });
+				},
+			});
+			return new Response(body, { status: 200 });
+		}) as unknown as typeof fetch;
+
+		try {
+			const response = await fetchCatalogUrl("https://skills.example.invalid", 5);
+			await expect(response.text()).rejects.toThrow("aborted");
+			expect(signal?.aborted).toBe(true);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
 	});
 
 	it("POST /api/skills/install accepts valid name with source", async () => {

--- a/platform/daemon/src/routes/skills.test.ts
+++ b/platform/daemon/src/routes/skills.test.ts
@@ -10,6 +10,8 @@ import {
 	listInstalledSkills,
 	mountSkillsRoutes,
 	parseSkillFrontmatter,
+	readCatalogResponseJson,
+	readCatalogResponseText,
 	replaceSkillDirectoryAtomically,
 	validateClawhubZipEntryMetadata,
 	validateExtractedSkillTree,
@@ -587,11 +589,72 @@ This is a test skill.`,
 
 		try {
 			const response = await fetchCatalogUrl("https://skills.example.invalid", 5);
-			await expect(response.text()).rejects.toThrow("aborted");
+			await expect(readCatalogResponseText(response)).rejects.toThrow("aborted");
 			expect(signal?.aborted).toBe(true);
 		} finally {
 			globalThis.fetch = originalFetch;
 		}
+	});
+
+	it("rejects an oversized text response while it is still streaming", async () => {
+		const limit = 1024;
+		let pulls = 0;
+		let cancelled = false;
+		const body = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				pulls += 1;
+				if (pulls === 1) {
+					controller.enqueue(new Uint8Array(limit));
+					return;
+				}
+				controller.enqueue(new Uint8Array(1));
+			},
+			cancel() {
+				cancelled = true;
+			},
+		});
+
+		await expect(readCatalogResponseText(new Response(body), limit)).rejects.toThrow("catalog response too large");
+		expect(pulls).toBe(2);
+		expect(cancelled).toBe(true);
+	});
+
+	it("rejects an oversized JSON response before parsing", async () => {
+		const limit = 1024;
+		const response = new Response("not valid JSON", {
+			status: 200,
+			headers: { "content-length": String(limit + 1) },
+		});
+
+		await expect(readCatalogResponseJson(response, limit)).rejects.toThrow("catalog response too large");
+	});
+
+	it("preserves normal bounded text and JSON responses", async () => {
+		expect(await readCatalogResponseText(new Response("catalog entry"))).toBe("catalog entry");
+		expect(await readCatalogResponseJson<{ skills: string[] }>(new Response('{"skills":["remote"]}'))).toEqual({
+			skills: ["remote"],
+		});
+	});
+
+	it("preserves downstream body and parse errors", async () => {
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.error(new Error("catalog body failed"));
+			},
+		});
+		await expect(readCatalogResponseText(new Response(body))).rejects.toThrow("catalog body failed");
+		await expect(readCatalogResponseJson(new Response("{"))).rejects.toThrow(SyntaxError);
+	});
+
+	it("routes every external catalog/document body through the shared bounded reader", () => {
+		const source = readFileSync(join(__dirname, "skills.ts"), "utf-8");
+		expect(source).not.toContain("await res.text()");
+		expect(source).not.toContain("await res.json()");
+		expect(source).not.toContain("await treeRes.json()");
+		expect(source).not.toContain("await mdRes.text()");
+		expect(source).toContain("readCatalogResponseText(res)");
+		expect(source).toContain("readCatalogResponseText(mdRes)");
+		expect(source).toContain("readCatalogResponseJson<");
 	});
 
 	it("POST /api/skills/install accepts valid name with source", async () => {

--- a/platform/daemon/src/routes/skills.ts
+++ b/platform/daemon/src/routes/skills.ts
@@ -135,6 +135,43 @@ export async function fetchCatalogUrl(
 	});
 }
 
+const MAX_CATALOG_RESPONSE_BYTES = 5 * 1024 * 1024;
+
+/** Read an external catalog/document response without materializing an unbounded body. */
+export async function readCatalogResponseText(res: Response, limit = MAX_CATALOG_RESPONSE_BYTES): Promise<string> {
+	const contentLength = res.headers.get("content-length");
+	if (contentLength) {
+		const bytes = Number(contentLength);
+		if (Number.isFinite(bytes) && bytes > limit) {
+			throw new Error(`catalog response too large: ${bytes} bytes`);
+		}
+	}
+	if (!res.body) throw new Error("catalog response did not include a response body");
+
+	const reader = res.body.getReader();
+	const decoder = new TextDecoder();
+	let bytes = 0;
+	let text = "";
+	try {
+		while (true) {
+			const chunk = await reader.read();
+			if (chunk.done) return text + decoder.decode();
+			bytes += chunk.value.byteLength;
+			if (bytes > limit) {
+				await reader.cancel().catch(() => undefined);
+				throw new Error(`catalog response too large: more than ${limit} bytes`);
+			}
+			text += decoder.decode(chunk.value, { stream: true });
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+export async function readCatalogResponseJson<T>(res: Response, limit = MAX_CATALOG_RESPONSE_BYTES): Promise<T> {
+	return JSON.parse(await readCatalogResponseText(res, limit)) as T;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -256,7 +293,7 @@ async function fetchCatalog(): Promise<CatalogEntry[]> {
 	logger.info("skills", "Fetching skills.sh catalog");
 	try {
 		const res = await fetchCatalogUrl("https://skills.sh", CATALOG_FETCH_TIMEOUT_MS);
-		const html = await res.text();
+		const html = await readCatalogResponseText(res);
 		const entries: CatalogEntry[] = [];
 		const re =
 			/\{\\"source\\":\\"([^\\]+)\\",\\"skillId\\":\\"([^\\]+)\\",\\"name\\":\\"([^\\]+)\\",\\"installs\\":(\d+)\}/g;
@@ -302,10 +339,10 @@ async function fetchClawhubCatalog(): Promise<ClawhubItem[]> {
 
 			const res = await fetchCatalogUrl(url.toString(), Math.max(1, deadline - Date.now()));
 			if (!res.ok) throw new Error(`ClawHub returned ${res.status}`);
-			const data = (await res.json()) as {
+			const data = await readCatalogResponseJson<{
 				items: ClawhubItem[];
 				nextCursor: string | null;
-			};
+			}>(res);
 			items.push(...data.items);
 			if (!data.nextCursor) break;
 			cursor = data.nextCursor;
@@ -934,7 +971,7 @@ export function mountSkillsRoutes(app: Hono, _authMode: AuthMode = "local"): voi
 						CATALOG_FETCH_TIMEOUT_MS,
 					);
 					if (!res.ok) throw new Error(`skills.sh returned ${res.status}`);
-					const data = (await res.json()) as {
+					const data = await readCatalogResponseJson<{
 						skills: Array<{
 							id: string;
 							skillId: string;
@@ -942,7 +979,7 @@ export function mountSkillsRoutes(app: Hono, _authMode: AuthMode = "local"): voi
 							installs: number;
 							source: string;
 						}>;
-					};
+					}>(res);
 					return (data.skills ?? []).map((s) =>
 						createSkillBrowseResult({
 							name: s.name,
@@ -1067,16 +1104,16 @@ export function mountSkillsRoutes(app: Hono, _authMode: AuthMode = "local"): voi
 					{ Accept: "application/vnd.github.v3+json" },
 				);
 				if (treeRes.ok) {
-					const tree = (await treeRes.json()) as {
+					const tree = await readCatalogResponseJson<{
 						tree: { path: string }[];
-					};
+					}>(treeRes);
 					const needle = `${name}/SKILL.md`;
 					const match = tree.tree.find((t) => t.path.endsWith(needle));
 					if (match) {
 						const rawUrl = `https://raw.githubusercontent.com/${repo}/main/${match.path}`;
 						const mdRes = await fetchCatalogUrl(rawUrl, CATALOG_FETCH_TIMEOUT_MS);
 						if (mdRes.ok) {
-							const content = await mdRes.text();
+							const content = await readCatalogResponseText(mdRes);
 							const meta = parseSkillFrontmatter(content);
 							return c.json({ name, ...meta, content });
 						}

--- a/platform/daemon/src/routes/skills.ts
+++ b/platform/daemon/src/routes/skills.ts
@@ -124,17 +124,15 @@ const MAX_CLAWHUB_ZIP_ENTRIES = 500;
 const MAX_CLAWHUB_ENTRY_BYTES = 25 * 1024 * 1024;
 const MAX_CLAWHUB_UNCOMPRESSED_BYTES = 100 * 1024 * 1024;
 
-async function fetchCatalogUrl(url: string, timeoutMs: number): Promise<Response> {
-	const controller = new AbortController();
-	const timer = setTimeout(() => controller.abort(), timeoutMs);
-	try {
-		return await fetch(url, {
-			headers: { "User-Agent": "signet-daemon" },
-			signal: controller.signal,
-		});
-	} finally {
-		clearTimeout(timer);
-	}
+export async function fetchCatalogUrl(
+	url: string,
+	timeoutMs: number,
+	extraHeaders: Record<string, string> = {},
+): Promise<Response> {
+	return fetch(url, {
+		headers: { "User-Agent": "signet-daemon", ...extraHeaders },
+		signal: AbortSignal.timeout(timeoutMs),
+	});
 }
 
 // ---------------------------------------------------------------------------
@@ -715,7 +713,7 @@ async function installClawhubSkill(
 	try {
 		const url = new URL(CLAWHUB_DOWNLOAD_BASE);
 		url.searchParams.set("slug", slug);
-		const res = await fetch(url, { headers: { "User-Agent": "signet-daemon" } });
+		const res = await fetchCatalogUrl(url.toString(), CATALOG_FETCH_TIMEOUT_MS);
 		if (!res.ok) {
 			return { success: false, error: `ClawHub download failed with HTTP ${res.status}` };
 		}
@@ -931,9 +929,10 @@ export function mountSkillsRoutes(app: Hono, _authMode: AuthMode = "local"): voi
 		const [skillsShResults, clawhubFiltered] = await Promise.all([
 			(async (): Promise<SkillBrowseResult[]> => {
 				try {
-					const res = await fetch(`https://skills.sh/api/search?q=${encodeURIComponent(query)}`, {
-						headers: { "User-Agent": "signet-daemon" },
-					});
+					const res = await fetchCatalogUrl(
+						`https://skills.sh/api/search?q=${encodeURIComponent(query)}`,
+						CATALOG_FETCH_TIMEOUT_MS,
+					);
 					if (!res.ok) throw new Error(`skills.sh returned ${res.status}`);
 					const data = (await res.json()) as {
 						skills: Array<{
@@ -1062,9 +1061,11 @@ export function mountSkillsRoutes(app: Hono, _authMode: AuthMode = "local"): voi
 
 		if (repo) {
 			try {
-				const treeRes = await fetch(`https://api.github.com/repos/${repo}/git/trees/main?recursive=1`, {
-					headers: { Accept: "application/vnd.github.v3+json" },
-				});
+				const treeRes = await fetchCatalogUrl(
+					`https://api.github.com/repos/${repo}/git/trees/main?recursive=1`,
+					CATALOG_FETCH_TIMEOUT_MS,
+					{ Accept: "application/vnd.github.v3+json" },
+				);
 				if (treeRes.ok) {
 					const tree = (await treeRes.json()) as {
 						tree: { path: string }[];
@@ -1073,7 +1074,7 @@ export function mountSkillsRoutes(app: Hono, _authMode: AuthMode = "local"): voi
 					const match = tree.tree.find((t) => t.path.endsWith(needle));
 					if (match) {
 						const rawUrl = `https://raw.githubusercontent.com/${repo}/main/${match.path}`;
-						const mdRes = await fetch(rawUrl);
+						const mdRes = await fetchCatalogUrl(rawUrl, CATALOG_FETCH_TIMEOUT_MS);
 						if (mdRes.ok) {
 							const content = await mdRes.text();
 							const meta = parseSkillFrontmatter(content);


### PR DESCRIPTION
## Summary

Fixes #1335 by routing the named external skill catalog fetches through the existing bounded helper. Connection and response-body stalls now terminate at the configured deadline while existing URL, size, archive, and parsing protections remain in place.

## Changes

- Routed ClawHub ZIP, skills.sh search, GitHub recursive-tree, and raw GitHub `SKILL.md` fetches through the bounded helper.
- Preserved the daemon User-Agent and added per-request headers without duplicating fetch safety logic.
- Kept the ClawHub response-size and archive validation behavior unchanged.
- Added regressions for stalled headers and stalled response-body consumption.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Verified from the PR worktree after rebasing onto current `origin/main`:

- `bun run --filter '@signet/core' build`
- `bun run --filter '@signet/daemon' build`
- `bun test platform/daemon/src/routes/skills.test.ts --test-name-pattern 'bounds external|stalled catalog|catalog response body'` (3 passed)
- `bunx biome check platform/daemon/src/routes/skills.ts platform/daemon/src/routes/skills.test.ts`
- `git diff --check origin/main..HEAD`

The full `skills.test.ts` file has one pre-existing missing-fixture failure involving `skills/memory-debug/SKILL.md`; it is unrelated to this change and was not changed opportunistically. The focused timeout regressions and daemon build/typecheck pass.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The bounded helper now keeps its abort deadline active through response-body consumption. The existing ClawHub response-size limit, archive validation, URL handling, redirect behavior, and route errors remain in place. Marketplace and internal self-HTTP fetches are intentionally out of scope.
