### PR TITLE
fix(daemon): bound marketplace review sync

### DIFF
--- a/platform/daemon/src/routes/marketplace-reviews.test.ts
+++ b/platform/daemon/src/routes/marketplace-reviews.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,6 +7,7 @@ import { mountMarketplaceReviewsRoutes } from "./marketplace-reviews.js";
 
 describe("marketplace reviews routes", () => {
 	const tmpAgentsDir = join(tmpdir(), `signet-marketplace-reviews-route-test-${process.pid}`);
+	const originalFetch = globalThis.fetch;
 	let origSignetPath: string | undefined;
 	let app: Hono;
 
@@ -20,6 +21,7 @@ describe("marketplace reviews routes", () => {
 	});
 
 	afterEach(() => {
+		globalThis.fetch = originalFetch;
 		process.env.SIGNET_PATH = origSignetPath;
 		if (existsSync(tmpAgentsDir)) {
 			rmSync(tmpAgentsDir, { recursive: true, force: true });
@@ -74,5 +76,163 @@ describe("marketplace reviews routes", () => {
 		expect(patchBody.success).toBe(true);
 		expect(patchBody.config.enabled).toBe(true);
 		expect(patchBody.config.endpointUrl).toBe("https://example.com/reviews");
+	});
+
+	it("preserves pending reviews when the sync endpoint returns a failure", async () => {
+		await app.request("/api/marketplace/reviews", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				targetType: "skill",
+				targetId: "skills.sh/failing",
+				displayName: "avery",
+				rating: 4,
+				title: "Needs retry",
+				body: "The downstream endpoint is unavailable",
+			}),
+		});
+		await app.request("/api/marketplace/reviews/config", {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ enabled: true, endpointUrl: "https://example.com/reviews" }),
+		});
+
+		globalThis.fetch = mock(() => Promise.resolve(new Response(null, { status: 503 }))) as unknown as typeof fetch;
+		const syncRes = await app.request("/api/marketplace/reviews/sync", { method: "POST" });
+		expect(syncRes.status).toBe(502);
+		const syncBody = (await syncRes.json()) as { success: boolean; error: string };
+		expect(syncBody.success).toBe(false);
+		expect(syncBody.error).toContain("pending reviews were preserved for retry");
+
+		const configRes = await app.request("/api/marketplace/reviews/config");
+		const configBody = (await configRes.json()) as { pending: number; lastSyncError: string | null };
+		expect(configBody.pending).toBe(1);
+		expect(configBody.lastSyncError).toBe(syncBody.error);
+	});
+
+	it("preserves pending reviews when the sync request times out", async () => {
+		await app.request("/api/marketplace/reviews", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				targetType: "mcp",
+				targetId: "mcp/failing",
+				displayName: "avery",
+				rating: 3,
+				title: "Slow",
+				body: "The downstream endpoint timed out",
+			}),
+		});
+		await app.request("/api/marketplace/reviews/config", {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ enabled: true, endpointUrl: "https://example.com/reviews" }),
+		});
+
+		let receivedSignal: AbortSignal | undefined;
+		globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+			receivedSignal = init?.signal ?? undefined;
+			return Promise.reject(new DOMException("The operation was aborted", "TimeoutError"));
+		}) as unknown as typeof fetch;
+		const syncRes = await app.request("/api/marketplace/reviews/sync", { method: "POST" });
+		expect(syncRes.status).toBe(502);
+		const syncBody = (await syncRes.json()) as { success: boolean; error: string };
+		expect(syncBody.success).toBe(false);
+		expect(syncBody.error).toContain("timed out after 15 seconds");
+		expect(syncBody.error).toContain("pending reviews were preserved for retry");
+		expect(receivedSignal).toBeInstanceOf(AbortSignal);
+
+		const listRes = await app.request("/api/marketplace/reviews");
+		const listBody = (await listRes.json()) as { reviews: Array<{ syncedAt: string | null }> };
+		expect(listBody.reviews[0]?.syncedAt).toBeNull();
+	});
+
+	it("preserves pending reviews after a thrown failure and allows retry", async () => {
+		await app.request("/api/marketplace/reviews", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				targetType: "skill",
+				targetId: "skills.sh/retry",
+				displayName: "avery",
+				rating: 5,
+				title: "Retry",
+				body: "A later attempt should be able to send this review",
+			}),
+		});
+		await app.request("/api/marketplace/reviews/config", {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ enabled: true, endpointUrl: "https://example.com/reviews" }),
+		});
+
+		let calls = 0;
+		globalThis.fetch = mock(() => {
+			calls += 1;
+			return calls === 1 ? Promise.reject(new TypeError("fetch failed")) : Promise.resolve(Response.json({ ok: true }));
+		}) as unknown as typeof fetch;
+
+		const failedRes = await app.request("/api/marketplace/reviews/sync", { method: "POST" });
+		expect(failedRes.status).toBe(502);
+		const failedBody = (await failedRes.json()) as { error: string };
+		expect(failedBody.error).toContain("Review sync failed: fetch failed");
+
+		const retryRes = await app.request("/api/marketplace/reviews/sync", { method: "POST" });
+		expect(retryRes.status).toBe(200);
+		expect(calls).toBe(2);
+		const retryBody = (await retryRes.json()) as { sent: number; synced: number };
+		expect(retryBody.sent).toBe(1);
+		expect(retryBody.synced).toBe(1);
+	});
+
+	it("serializes concurrent sync attempts for one workspace", async () => {
+		await app.request("/api/marketplace/reviews", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				targetType: "skill",
+				targetId: "skills.sh/concurrent",
+				displayName: "avery",
+				rating: 5,
+				title: "Concurrent",
+				body: "Only one downstream batch should be sent",
+			}),
+		});
+		await app.request("/api/marketplace/reviews/config", {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ enabled: true, endpointUrl: "https://example.com/reviews" }),
+		});
+
+		let calls = 0;
+		let markStarted: (() => void) | undefined;
+		let releaseResponse: ((response: Response) => void) | undefined;
+		const started = new Promise<void>((resolve) => {
+			markStarted = resolve;
+		});
+		const response = new Promise<Response>((resolve) => {
+			releaseResponse = resolve;
+		});
+		globalThis.fetch = mock(() => {
+			calls += 1;
+			markStarted?.();
+			return response;
+		}) as unknown as typeof fetch;
+
+		const first = app.request("/api/marketplace/reviews/sync", { method: "POST" });
+		await started;
+		const second = app.request("/api/marketplace/reviews/sync", { method: "POST" });
+		await Bun.sleep(0);
+		expect(calls).toBe(1);
+
+		releaseResponse?.(Response.json({ ok: true }));
+		const [firstRes, secondRes] = await Promise.all([first, second]);
+		expect(firstRes.status).toBe(200);
+		expect(secondRes.status).toBe(200);
+		expect(calls).toBe(1);
+		const firstBody = (await firstRes.json()) as { sent: number; synced: number };
+		const secondBody = (await secondRes.json()) as { sent: number; synced: number };
+		expect(firstBody.sent + secondBody.sent).toBe(1);
+		expect(firstBody.synced + secondBody.synced).toBe(1);
 	});
 });

--- a/platform/daemon/src/routes/marketplace-reviews.ts
+++ b/platform/daemon/src/routes/marketplace-reviews.ts
@@ -29,6 +29,10 @@ interface ReviewsSyncConfig {
 
 // Production sync endpoint. Pre-configured so users only need to set enabled: true.
 const REVIEWS_SYNC_URL = "https://reviews.signetai.sh/api/reviews/sync";
+const REVIEW_SYNC_TIMEOUT_MS = 15_000;
+// A daemon normally owns a workspace; keying the queue keeps distinct test or
+// embedded workspaces independent while serializing calls for the same one.
+const reviewSyncFlights = new Map<string, Promise<unknown>>();
 
 const DEFAULT_CONFIG: ReviewsSyncConfig = {
 	enabled: false,
@@ -179,6 +183,29 @@ function summarize(reviews: readonly MarketplaceReview[]): { count: number; avgR
 		count: reviews.length,
 		avgRating: Number((total / reviews.length).toFixed(2)),
 	};
+}
+
+async function withReviewSyncLock<T>(workspacePath: string, run: () => Promise<T>): Promise<T> {
+	const previous = reviewSyncFlights.get(workspacePath) ?? Promise.resolve();
+	const next = previous.then(
+		() => run(),
+		() => run(),
+	);
+	reviewSyncFlights.set(workspacePath, next);
+	try {
+		return await next;
+	} finally {
+		if (reviewSyncFlights.get(workspacePath) === next) {
+			reviewSyncFlights.delete(workspacePath);
+		}
+	}
+}
+
+function isReviewSyncTimeout(error: unknown): boolean {
+	if (error instanceof DOMException) {
+		return error.name === "AbortError" || error.name === "TimeoutError";
+	}
+	return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }
 
 export function mountMarketplaceReviewsRoutes(app: Hono): void {
@@ -339,48 +366,53 @@ export function mountMarketplaceReviewsRoutes(app: Hono): void {
 	});
 
 	app.post("/api/marketplace/reviews/sync", async (c) => {
-		const config = readConfig();
-		if (!config.enabled || config.endpointUrl.length === 0) {
-			return c.json({ success: false, error: "Review sync endpoint is not configured" }, 400);
-		}
+		return withReviewSyncLock(getAgentsDir(), async () => {
+			const config = readConfig();
+			if (!config.enabled || config.endpointUrl.length === 0) {
+				return c.json({ success: false, error: "Review sync endpoint is not configured" }, 400);
+			}
 
-		const reviews = readReviews();
-		const pending = reviews.filter((item) => item.syncedAt === null || item.updatedAt > item.syncedAt);
-		if (pending.length === 0) {
-			return c.json({ success: true, sent: 0, synced: 0, message: "No pending reviews" });
-		}
+			const reviews = readReviews();
+			const pending = reviews.filter((item) => item.syncedAt === null || item.updatedAt > item.syncedAt);
+			if (pending.length === 0) {
+				return c.json({ success: true, sent: 0, synced: 0, message: "No pending reviews" });
+			}
 
-		try {
-			const response = await fetch(config.endpointUrl, {
-				method: "POST",
-				headers: { "Content-Type": "application/json", "X-Signet-Sync": "1" },
-				body: JSON.stringify({
-					source: "signet-marketplace",
-					type: "reviews-sync",
-					sentAt: new Date().toISOString(),
-					reviews: pending,
-				}),
-			});
+			try {
+				const response = await fetch(config.endpointUrl, {
+					method: "POST",
+					headers: { "Content-Type": "application/json", "X-Signet-Sync": "1" },
+					body: JSON.stringify({
+						source: "signet-marketplace",
+						type: "reviews-sync",
+						sentAt: new Date().toISOString(),
+						reviews: pending,
+					}),
+					signal: AbortSignal.timeout(REVIEW_SYNC_TIMEOUT_MS),
+				});
 
-			if (!response.ok) {
-				const errorText = `Sync endpoint returned HTTP ${response.status}`;
+				if (!response.ok) {
+					const errorText = `Sync endpoint returned HTTP ${response.status}; pending reviews were preserved for retry`;
+					writeConfig({ ...config, lastSyncError: errorText });
+					return c.json({ success: false, error: errorText }, 502);
+				}
+
+				const syncedAt = new Date().toISOString();
+				const pendingIds = new Set(pending.map((item) => item.id));
+				const nextReviews = reviews.map((item) =>
+					pendingIds.has(item.id) ? { ...item, syncedAt, source: "synced" as const } : item,
+				);
+				writeReviews(nextReviews);
+
+				writeConfig({ ...config, lastSyncAt: syncedAt, lastSyncError: null });
+				return c.json({ success: true, sent: pending.length, synced: pending.length, syncedAt });
+			} catch (error) {
+				const errorText = isReviewSyncTimeout(error)
+					? `Review sync timed out after ${REVIEW_SYNC_TIMEOUT_MS / 1000} seconds; pending reviews were preserved for retry`
+					: `Review sync failed: ${error instanceof Error ? error.message : String(error)}; pending reviews were preserved for retry`;
 				writeConfig({ ...config, lastSyncError: errorText });
 				return c.json({ success: false, error: errorText }, 502);
 			}
-
-			const syncedAt = new Date().toISOString();
-			const pendingIds = new Set(pending.map((item) => item.id));
-			const nextReviews = reviews.map((item) =>
-				pendingIds.has(item.id) ? { ...item, syncedAt, source: "synced" as const } : item,
-			);
-			writeReviews(nextReviews);
-
-			writeConfig({ ...config, lastSyncAt: syncedAt, lastSyncError: null });
-			return c.json({ success: true, sent: pending.length, synced: pending.length, syncedAt });
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			writeConfig({ ...config, lastSyncError: message });
-			return c.json({ success: false, error: message }, 502);
-		}
+		});
 	});
 }


### PR DESCRIPTION
## Summary

Fixes #1336 by bounding and serializing marketplace review synchronization. A stalled downstream endpoint now aborts at a fixed deadline, concurrent sync attempts for the same workspace coalesce, and pending reviews remain retryable after failure.

## Changes

- Added a 15-second abort deadline to the external review-batch POST.
- Added per-workspace single-flight admission around pending-state read, downstream POST, and sync marking.
- Preserved pending reviews on timeout, thrown fetch failures, non-OK responses, and write failures.
- Mark reviews synced only after a successful downstream response and local write.
- Added timeout, thrown-failure/retry, and concurrent-sync regression coverage.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Verified from the PR worktree after rebasing onto current `origin/main`:

- `bun run --filter '@signet/core' build`
- `bun run --filter '@signet/daemon' build`
- `bun test platform/daemon/src/routes/marketplace-reviews.test.ts` (6 passed, 35 expectations)
- `bunx biome check platform/daemon/src/routes/marketplace-reviews.ts platform/daemon/src/routes/marketplace-reviews.test.ts`
- `git diff --check origin/main..HEAD`

The daemon build/typecheck and focused route suite pass. The build emitted only the existing large-chunk warning. An adversarial read-only review found no CRITICAL or HIGH findings. The remaining deliberate boundary is that the single-flight lock is process-local, matching normal one-daemon-per-workspace operation.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Failures record `lastSyncError`, return bounded actionable errors, and leave reviews pending for retry. This change does not broaden into skills-fetch or internal self-HTTP timeout handling.
