### PR TITLE
fix(daemon): serialize skill reconciliation triggers

### DIFF
--- a/platform/daemon/src/pipeline/skill-reconciler.test.ts
+++ b/platform/daemon/src/pipeline/skill-reconciler.test.ts
@@ -343,6 +343,58 @@ body`,
 		).toBeNull();
 	});
 
+	it("does not let an in-flight failure cancel a queued fresh trigger (#1354)", async () => {
+		const paths = setup();
+		root = paths.root;
+		db = paths.db;
+		initDbAccessor(db);
+
+		const skill = "fresh-trigger-skill";
+		const file = join(paths.root, "skills", skill, "SKILL.md");
+		mkdirSync(join(paths.root, "skills", skill), { recursive: true });
+		writeFileSync(
+			file,
+			`---
+name: ${skill}
+description: fresh trigger test
+---
+body`,
+		);
+
+		let calls = 0;
+		let rejectFirstEmbedding: ((error: Error) => void) | undefined;
+		let resolveFirstCall: (() => void) | undefined;
+		const firstCall = new Promise<void>((resolve) => {
+			resolveFirstCall = resolve;
+		});
+		const firstEmbedding = new Promise<number[] | null>((_, reject) => {
+			rejectFirstEmbedding = reject;
+		});
+		const deps = {
+			accessor: getDbAccessor(),
+			pipelineConfig: cfg(),
+			embeddingConfig: emb,
+			fetchEmbedding: async () => {
+				calls++;
+				if (calls === 1) {
+					resolveFirstCall?.();
+					return firstEmbedding;
+				}
+				return [0.1, 0.2, 0.3];
+			},
+			agentsDir: root,
+		};
+
+		const first = reconcileSkillFile(skill, file, deps);
+		await firstCall;
+		const fresh = reconcileSkillFile(skill, file, deps, { forceInstall: true });
+		rejectFirstEmbedding?.(new Error("first provider call failed"));
+
+		expect(await first).toBe("failed");
+		expect(await fresh).toBe("updated");
+		expect(calls).toBe(2);
+	});
+
 	it("updates skill metadata when a non-embedding frontmatter field changes on disk", async () => {
 		const paths = setup();
 		root = paths.root;

--- a/platform/daemon/src/pipeline/skill-reconciler.test.ts
+++ b/platform/daemon/src/pipeline/skill-reconciler.test.ts
@@ -12,7 +12,37 @@ import {
 	reconcileUnlinkedSkill,
 	resetSkillFailureState,
 	skillBackoffDelayMs,
+	startReconciler,
+	withSkillReconciliationLock,
 } from "./skill-reconciler";
+
+/** Poll `cond` until it returns true or `timeoutMs` elapses. */
+async function waitFor(cond: () => boolean, timeoutMs = 3_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!cond()) {
+		if (Date.now() > deadline) throw new Error("waitFor timed out");
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+}
+
+function entityCount(skillName: string): number {
+	return getDbAccessor().withReadDb(
+		(db) =>
+			(db.prepare("SELECT COUNT(*) AS n FROM entities WHERE id = ?").get(`skill:default:${skillName}`) as { n: number })
+				.n,
+	);
+}
+
+function embeddingCount(skillName: string): number {
+	return getDbAccessor().withReadDb(
+		(db) =>
+			(
+				db
+					.prepare("SELECT COUNT(*) AS n FROM embeddings WHERE source_type = 'skill' AND source_id = ?")
+					.get(`skill:default:${skillName}`) as { n: number }
+			).n,
+	);
+}
 
 function setup(): { root: string; db: string } {
 	const root = join(tmpdir(), `signet-skill-reconciler-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -631,5 +661,226 @@ body`,
 		// fifth pass attempt the skill again (a fresh failure, not a skip).
 		expect(failures.length).toBe(5);
 		expect(backoffs.length).toBe(1);
+	});
+});
+
+describe("single-flight trigger overlap (#1354)", () => {
+	it("coalesces a periodic tick onto the in-flight startup backfill so the embedding boundary is reached once", async () => {
+		const paths = setup();
+		root = paths.root;
+		db = paths.db;
+		initDbAccessor(db);
+
+		// Two skills so a pre-fix second pass has installable work left after
+		// the startup pass parks on the first skill's embedding call.
+		for (const skill of ["alpha-skill", "beta-skill"]) {
+			const dir = join(root, "skills", skill);
+			mkdirSync(dir, { recursive: true });
+			writeFileSync(join(dir, "SKILL.md"), `---\nname: ${skill}\ndescription: overlap test\n---\nbody`);
+		}
+
+		let calls = 0;
+		let resolveFirstCall: (() => void) | undefined;
+		let releaseEmbedding: (() => void) | undefined;
+		const firstCall = new Promise<void>((resolve) => {
+			resolveFirstCall = resolve;
+		});
+		const embeddingGate = new Promise<void>((resolve) => {
+			releaseEmbedding = resolve;
+		});
+		const deps = {
+			accessor: getDbAccessor(),
+			pipelineConfig: {
+				...cfg(),
+				procedural: { ...cfg().procedural, reconcileIntervalMs: 25 },
+			},
+			embeddingConfig: emb,
+			fetchEmbedding: async () => {
+				calls++;
+				resolveFirstCall?.();
+				await embeddingGate;
+				return [0.1, 0.2, 0.3];
+			},
+			agentsDir: root,
+		};
+
+		const handle = startReconciler(deps);
+		try {
+			// Startup backfill parks on the first skill's embedding call.
+			await firstCall;
+			// Hold the gate across several periodic intervals (~120ms at 25ms
+			// interval). A periodic tick must coalesce onto the active startup
+			// pass instead of starting a second full pass that reaches the
+			// embedding provider for the other skill.
+			await new Promise((resolve) => setTimeout(resolve, 120));
+			expect(calls).toBe(1);
+
+			releaseEmbedding?.();
+			await waitFor(() => calls === 2);
+
+			expect(entityCount("alpha-skill")).toBe(1);
+			expect(entityCount("beta-skill")).toBe(1);
+			expect(embeddingCount("alpha-skill")).toBe(1);
+			expect(embeddingCount("beta-skill")).toBe(1);
+		} finally {
+			handle.stop();
+		}
+	});
+
+	it("queues an explicit post-install reconcile behind an in-flight watcher-style install", async () => {
+		const paths = setup();
+		root = paths.root;
+		db = paths.db;
+		initDbAccessor(db);
+
+		const skill = "watcher-explicit-skill";
+		const dir = join(root, "skills", skill);
+		const file = join(dir, "SKILL.md");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(file, `---\nname: ${skill}\ndescription: watcher vs explicit\n---\nbody`);
+
+		let calls = 0;
+		let resolveFirstCall: (() => void) | undefined;
+		let releaseEmbedding: (() => void) | undefined;
+		const firstCall = new Promise<void>((resolve) => {
+			resolveFirstCall = resolve;
+		});
+		const embeddingGate = new Promise<void>((resolve) => {
+			releaseEmbedding = resolve;
+		});
+		const deps = {
+			accessor: getDbAccessor(),
+			pipelineConfig: cfg(),
+			embeddingConfig: emb,
+			fetchEmbedding: async () => {
+				calls++;
+				resolveFirstCall?.();
+				await embeddingGate;
+				return [0.1, 0.2, 0.3];
+			},
+			agentsDir: root,
+		};
+
+		// Watcher add/change handler body: forceInstall reconcile.
+		const watcherTrigger = reconcileSkillFile(skill, file, deps, { forceInstall: true });
+		await firstCall;
+
+		// Explicit post-install hook (routes onSkillInstalled) fires while the
+		// watcher install is parked at the embedding boundary. It must queue
+		// behind the same flight and observe the written embedding.
+		const explicitTrigger = reconcileSkillFile(skill, file, deps, { forceInstall: true, source: "installed" });
+		expect(calls).toBe(1);
+
+		releaseEmbedding?.();
+		await expect(watcherTrigger).resolves.toBe("installed");
+		await expect(explicitTrigger).resolves.toBe("unchanged");
+		expect(calls).toBe(1);
+		expect(entityCount(skill)).toBe(1);
+		expect(embeddingCount(skill)).toBe(1);
+	});
+
+	it("keys the single-flight lock by workspace so agent scoping is preserved", async () => {
+		// Two different agentsDirs with the same skill name must not serialize
+		// against each other: a lock held for one agent's workspace cannot
+		// block another agent's reconcile of the same-named skill.
+		const dirA = join(tmpdir(), `signet-lock-a-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		const dirB = join(tmpdir(), `signet-lock-b-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		try {
+			let releaseA: (() => void) | undefined;
+			let startedB = 0;
+			const gateA = new Promise<void>((resolve) => {
+				releaseA = resolve;
+			});
+
+			const a = withSkillReconciliationLock(dirA, "shared-skill", async () => {
+				await gateA;
+			});
+			const b = withSkillReconciliationLock(dirB, "shared-skill", () => {
+				startedB++;
+			});
+
+			// B must run while A is still parked (different workspace key).
+			await Promise.race([
+				b,
+				new Promise((_, reject) => setTimeout(() => reject(new Error("B blocked behind A")), 500)),
+			]);
+			expect(startedB).toBe(1);
+
+			// Same workspace + same skill still serializes.
+			let startedA2 = 0;
+			const a2 = withSkillReconciliationLock(dirA, "shared-skill", () => {
+				startedA2++;
+			});
+			await new Promise((resolve) => setTimeout(resolve, 25));
+			expect(startedA2).toBe(0);
+
+			releaseA?.();
+			await a;
+			await a2;
+			expect(startedA2).toBe(1);
+		} finally {
+			rmSync(dirA, { recursive: true, force: true });
+			rmSync(dirB, { recursive: true, force: true });
+		}
+	});
+
+	it("lets an in-flight pass finish and starts no new passes after stop()", async () => {
+		const paths = setup();
+		root = paths.root;
+		db = paths.db;
+		initDbAccessor(db);
+
+		const skill = "shutdown-skill";
+		const dir = join(root, "skills", skill);
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "SKILL.md"), `---\nname: ${skill}\ndescription: shutdown test\n---\nbody`);
+
+		let calls = 0;
+		let resolveFirstCall: (() => void) | undefined;
+		let releaseEmbedding: (() => void) | undefined;
+		const firstCall = new Promise<void>((resolve) => {
+			resolveFirstCall = resolve;
+		});
+		const embeddingGate = new Promise<void>((resolve) => {
+			releaseEmbedding = resolve;
+		});
+		const deps = {
+			accessor: getDbAccessor(),
+			pipelineConfig: {
+				...cfg(),
+				procedural: { ...cfg().procedural, reconcileIntervalMs: 25 },
+			},
+			embeddingConfig: emb,
+			fetchEmbedding: async () => {
+				calls++;
+				resolveFirstCall?.();
+				await embeddingGate;
+				return [0.1, 0.2, 0.3];
+			},
+			agentsDir: root,
+		};
+
+		const handle = startReconciler(deps);
+		try {
+			// Park the startup pass at the embedding boundary, then stop the
+			// reconciler mid-flight.
+			await firstCall;
+			handle.stop();
+
+			// The in-flight pass must complete exactly once.
+			releaseEmbedding?.();
+			await waitFor(() => calls === 1 && embeddingCount(skill) === 1);
+			expect(entityCount(skill)).toBe(1);
+
+			// No periodic tick after stop() may start new work.
+			const callsAfter = calls;
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			expect(calls).toBe(callsAfter);
+
+			// A second stop() is safe.
+			handle.stop();
+		} finally {
+			handle.stop();
+		}
 	});
 });

--- a/platform/daemon/src/pipeline/skill-reconciler.test.ts
+++ b/platform/daemon/src/pipeline/skill-reconciler.test.ts
@@ -6,7 +6,7 @@ import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 import { type LogEntry, logger } from "../logger";
 import { DEFAULT_PIPELINE_V2, type EmbeddingConfig, type PipelineV2Config } from "../memory-config";
 import { installSkillNode, skillEmbeddingHash } from "./skill-graph";
-import { reconcileOnce, resetSkillFailureState, skillBackoffDelayMs } from "./skill-reconciler";
+import { reconcileOnce, reconcileSkillFile, resetSkillFailureState, skillBackoffDelayMs } from "./skill-reconciler";
 
 function setup(): { root: string; db: string } {
 	const root = join(tmpdir(), `signet-skill-reconciler-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -227,6 +227,60 @@ this skill helps with reconciliation loop debugging.`,
 		});
 
 		expect(pass).toEqual({ installed: 0, updated: 0, removed: 0 });
+	});
+
+	it("prevents overlapping triggers from reaching the embedding provider twice (#1354)", async () => {
+		const paths = setup();
+		root = paths.root;
+		db = paths.db;
+		initDbAccessor(db);
+
+		const skill = "single-flight-skill";
+		const file = join(paths.root, "skills", skill, "SKILL.md");
+		mkdirSync(join(paths.root, "skills", skill), { recursive: true });
+		writeFileSync(
+			file,
+			`---
+name: ${skill}
+description: shared trigger test
+---
+body`,
+		);
+
+		let calls = 0;
+		let releaseEmbedding: (() => void) | undefined;
+		let resolveFirstCall: (() => void) | undefined;
+		const firstCall = new Promise<void>((resolve) => {
+			resolveFirstCall = resolve;
+		});
+		const embeddingGate = new Promise<void>((resolve) => {
+			releaseEmbedding = resolve;
+		});
+		const deps = {
+			accessor: getDbAccessor(),
+			pipelineConfig: cfg(),
+			embeddingConfig: emb,
+			fetchEmbedding: async () => {
+				calls++;
+				resolveFirstCall?.();
+				await embeddingGate;
+				return [0.1, 0.2, 0.3];
+			},
+			agentsDir: root,
+		};
+
+		const startupPass = reconcileOnce(deps);
+		await firstCall;
+		const explicitInstall = reconcileSkillFile(skill, file, deps, { forceInstall: true, source: "installed" });
+
+		// The explicit post-install trigger is queued behind the startup pass,
+		// rather than reaching fetchEmbedding while the first call is pending.
+		expect(calls).toBe(1);
+		releaseEmbedding?.();
+
+		await expect(startupPass).resolves.toEqual({ installed: 1, updated: 0, removed: 0 });
+		await expect(explicitInstall).resolves.toBe("unchanged");
+		expect(calls).toBe(1);
 	});
 
 	it("updates skill metadata when a non-embedding frontmatter field changes on disk", async () => {

--- a/platform/daemon/src/pipeline/skill-reconciler.test.ts
+++ b/platform/daemon/src/pipeline/skill-reconciler.test.ts
@@ -6,7 +6,13 @@ import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 import { type LogEntry, logger } from "../logger";
 import { DEFAULT_PIPELINE_V2, type EmbeddingConfig, type PipelineV2Config } from "../memory-config";
 import { installSkillNode, skillEmbeddingHash } from "./skill-graph";
-import { reconcileOnce, reconcileSkillFile, resetSkillFailureState, skillBackoffDelayMs } from "./skill-reconciler";
+import {
+	reconcileOnce,
+	reconcileSkillFile,
+	reconcileUnlinkedSkill,
+	resetSkillFailureState,
+	skillBackoffDelayMs,
+} from "./skill-reconciler";
 
 function setup(): { root: string; db: string } {
 	const root = join(tmpdir(), `signet-skill-reconciler-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -281,6 +287,60 @@ body`,
 		await expect(startupPass).resolves.toEqual({ installed: 1, updated: 0, removed: 0 });
 		await expect(explicitInstall).resolves.toBe("unchanged");
 		expect(calls).toBe(1);
+	});
+
+	it("serializes watcher unlink with an in-flight install under the same workspace key (#1354)", async () => {
+		const paths = setup();
+		root = paths.root;
+		db = paths.db;
+		initDbAccessor(db);
+
+		const skill = "unlink-single-flight-skill";
+		const file = join(paths.root, "skills", skill, "SKILL.md");
+		mkdirSync(join(paths.root, "skills", skill), { recursive: true });
+		writeFileSync(
+			file,
+			`---
+name: ${skill}
+description: unlink trigger test
+---
+body`,
+		);
+
+		let releaseEmbedding: (() => void) | undefined;
+		let resolveEmbeddingCall: (() => void) | undefined;
+		const embeddingCall = new Promise<void>((resolve) => {
+			resolveEmbeddingCall = resolve;
+		});
+		const embeddingGate = new Promise<void>((resolve) => {
+			releaseEmbedding = resolve;
+		});
+		const deps = {
+			accessor: getDbAccessor(),
+			pipelineConfig: cfg(),
+			embeddingConfig: emb,
+			fetchEmbedding: async () => {
+				resolveEmbeddingCall?.();
+				await embeddingGate;
+				return [0.1, 0.2, 0.3];
+			},
+			agentsDir: root,
+		};
+
+		const install = reconcileSkillFile(skill, file, deps);
+		await embeddingCall;
+		const unlink = reconcileUnlinkedSkill(skill, deps);
+
+		// The watcher unlink must wait for the install to finish before removing
+		// the graph node that the install is about to write.
+		releaseEmbedding?.();
+		await expect(install).resolves.toBe("installed");
+		await expect(unlink).resolves.toBe("removed");
+		expect(
+			getDbAccessor().withReadDb((dbh) =>
+				dbh.prepare("SELECT id FROM entities WHERE id = ?").get(`skill:default:${skill}`),
+			),
+		).toBeNull();
 	});
 
 	it("updates skill metadata when a non-embedding frontmatter field changes on disk", async () => {

--- a/platform/daemon/src/pipeline/skill-reconciler.ts
+++ b/platform/daemon/src/pipeline/skill-reconciler.ts
@@ -215,6 +215,10 @@ export async function reconcileSkillFile(
 	options: ReconcileSkillFileOptions = {},
 ): Promise<ReconcileSkillResult> {
 	return withSkillReconciliationLock(deps.agentsDir, skillName, async () => {
+		// A watcher or explicit install is a fresh signal. Reset only after
+		// entering the flight so an older in-flight failure cannot overwrite
+		// this reset before the queued trigger starts.
+		if (options.forceInstall) resetSkillFailureState(skillName);
 		const failureState = skillFailureState.get(skillName);
 		if (failureState && failureState.nextAttemptAt > Date.now()) {
 			return "skipped";
@@ -375,7 +379,6 @@ export function startReconciler(deps: ReconcilerDeps): ReconcilerHandle {
 		watcher.on("add", (filePath) => {
 			const skillName = basename(dirname(filePath));
 			logger.info("reconciler", "SKILL.md added", { skill: skillName });
-			resetSkillFailureState(skillName);
 			reconcileSkillFile(skillName, filePath, deps, { forceInstall: true }).catch((e) => {
 				logger.error("reconciler", "Watcher reconciliation failed", e instanceof Error ? e : undefined, {
 					skill: skillName,
@@ -387,7 +390,6 @@ export function startReconciler(deps: ReconcilerDeps): ReconcilerHandle {
 		watcher.on("change", (filePath) => {
 			const skillName = basename(dirname(filePath));
 			logger.info("reconciler", "SKILL.md changed", { skill: skillName });
-			resetSkillFailureState(skillName);
 			reconcileSkillFile(skillName, filePath, deps, { forceInstall: true }).catch((e) => {
 				logger.error("reconciler", "Watcher reconciliation failed", e instanceof Error ? e : undefined, {
 					skill: skillName,

--- a/platform/daemon/src/pipeline/skill-reconciler.ts
+++ b/platform/daemon/src/pipeline/skill-reconciler.ts
@@ -39,6 +39,29 @@ export interface ReconcileOptions {
 	readonly scanFilesystem?: boolean;
 }
 
+export type ReconcileSkillResult = "installed" | "updated" | "unchanged" | "removed" | "skipped" | "failed";
+
+// Every trigger that can reconcile a skill uses this queue. The lock is keyed
+// by workspace and skill so a startup/periodic scan, watcher event, and
+// post-install hook cannot observe the same stale embedding concurrently.
+const skillReconcileFlights = new Map<string, Promise<unknown>>();
+
+export function withSkillReconciliationLock<T>(
+	agentsDir: string,
+	skillName: string,
+	fn: () => Promise<T> | T,
+): Promise<T> {
+	const key = `${agentsDir}\u0000${skillName}`;
+	const previous = skillReconcileFlights.get(key) ?? Promise.resolve();
+	const next = previous.then(fn, fn).finally(() => {
+		if (skillReconcileFlights.get(key) === next) {
+			skillReconcileFlights.delete(key);
+		}
+	});
+	skillReconcileFlights.set(key, next);
+	return next;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -121,97 +144,17 @@ export async function reconcileOnce(
 		}
 	}
 
-	// 2. Check each disk skill against the graph
+	// 2. Check each disk skill against the graph. The per-skill helper is
+	// shared with watcher and explicit post-install triggers, so all callers
+	// re-check the embedding state after acquiring the same single-flight lock.
 	for (const [name, mdPath] of diskSkills) {
-		const failureState = skillFailureState.get(name);
-		if (failureState && failureState.nextAttemptAt > Date.now()) {
-			continue;
-		}
-
-		try {
-			const content = readFileSync(mdPath, "utf-8");
-			const parsed = parseSkillFile(content);
-			if (!parsed) continue;
-
-			const entityId = `skill:default:${name}`;
-
-			// Check if entity already exists (by id or name collision)
-			const existing = deps.accessor.withReadDb(
-				(db) =>
-					db
-						.prepare("SELECT id FROM entities WHERE id = ? OR (name = ? AND agent_id = 'default')")
-						.get(entityId, name) as { id: string } | undefined,
-			);
-
-			if (!existing) {
-				// Missing from graph — install
-				await installSkillNode(
-					{
-						frontmatter: parsed.frontmatter,
-						body: parsed.body,
-						source: "reconciler",
-						fsPath: mdPath,
-					},
-					deps.accessor,
-					deps.pipelineConfig,
-					deps.embeddingConfig,
-					deps.fetchEmbedding,
-				);
-				installed++;
-				logger.info("reconciler", "Backfilled skill node", { skill: name });
-			} else {
-				// Entity exists — check if frontmatter changed
-				// Use actual entity id (may differ from skill:default:... if adopted)
-				const actualId = existing.id;
-				const storedEmb = deps.accessor.withReadDb(
-					(db) =>
-						db
-							.prepare("SELECT content_hash FROM embeddings WHERE source_type = 'skill' AND source_id = ?")
-							.get(actualId) as { content_hash: string } | undefined,
-				);
-				const rawHash = skillEmbeddingHash(actualId, parsed.frontmatter);
-
-				// Compare the raw on-disk frontmatter fingerprint against the
-				// stored one, not the embedding chunk text, so metadata-only
-				// changes reinstall without creating update loops.
-				if (storedEmb && storedEmb.content_hash !== rawHash) {
-					await installSkillNode(
-						{
-							frontmatter: parsed.frontmatter,
-							body: parsed.body,
-							source: "reconciler",
-							fsPath: mdPath,
-						},
-						deps.accessor,
-						deps.pipelineConfig,
-						deps.embeddingConfig,
-						deps.fetchEmbedding,
-					);
-					updated++;
-					logger.info("reconciler", "Updated changed skill node", { skill: name });
-				}
-			}
-
-			// Reaching here means this pass handled the skill without
-			// throwing — clear any accumulated failure state.
-			resetSkillFailureState(name);
-		} catch (e) {
-			const msg = e instanceof Error ? e.message : String(e);
-			logger.warn("reconciler", "Failed to reconcile skill", {
-				skill: name,
-				error: msg,
-			});
-
-			const consecutiveFailures = (failureState?.consecutiveFailures ?? 0) + 1;
-			const backoffMs = skillBackoffDelayMs(consecutiveFailures);
-			skillFailureState.set(name, { consecutiveFailures, nextAttemptAt: Date.now() + backoffMs });
-			if (backoffMs > 0) {
-				logger.warn("reconciler", "Skill reconcile failed repeatedly; entering backoff", {
-					skill: name,
-					consecutiveFailures,
-					backoffMs,
-				});
-			}
+		const result = await reconcileSkillFile(name, mdPath, deps);
+		if (result === "installed") {
+			installed++;
+			logger.info("reconciler", "Backfilled skill node", { skill: name });
+		} else if (result === "updated") {
+			updated++;
+			logger.info("reconciler", "Updated changed skill node", { skill: name });
 		}
 	}
 
@@ -230,7 +173,9 @@ export async function reconcileOnce(
 			const parts = row.entity_id.split(":");
 			const skillName = parts[0] === "skill" ? parts.slice(2).join(":") : basename(dirname(row.fs_path));
 			if (skillName) {
-				const result = uninstallSkillNode({ skillName, entityId: row.entity_id }, deps.accessor);
+				const result = await withSkillReconciliationLock(deps.agentsDir, skillName, () =>
+					uninstallSkillNode({ skillName, entityId: row.entity_id }, deps.accessor),
+				);
 				if (!result.removed) continue;
 
 				removed++;
@@ -253,6 +198,101 @@ export async function reconcileOnce(
 	return { installed, updated, removed };
 }
 
+export interface ReconcileSkillFileOptions {
+	readonly forceInstall?: boolean;
+	readonly source?: string;
+}
+
+/**
+ * Reconcile one skill through the shared per-skill flight. The state check is
+ * deliberately inside the lock: a queued trigger must observe the embedding
+ * written by the first trigger instead of issuing a duplicate provider call.
+ */
+export async function reconcileSkillFile(
+	skillName: string,
+	mdPath: string,
+	deps: ReconcilerDeps,
+	options: ReconcileSkillFileOptions = {},
+): Promise<ReconcileSkillResult> {
+	return withSkillReconciliationLock(deps.agentsDir, skillName, async () => {
+		const failureState = skillFailureState.get(skillName);
+		if (failureState && failureState.nextAttemptAt > Date.now()) {
+			return "skipped";
+		}
+
+		try {
+			if (!existsSync(mdPath)) {
+				const result = uninstallSkillNode({ skillName }, deps.accessor);
+				resetSkillFailureState(skillName);
+				return result.removed ? "removed" : "unchanged";
+			}
+
+			const content = readFileSync(mdPath, "utf-8");
+			const parsed = parseSkillFile(content);
+			if (!parsed) return "skipped";
+
+			const entityId = `skill:default:${skillName}`;
+			const existing = deps.accessor.withReadDb(
+				(db) =>
+					db
+						.prepare("SELECT id FROM entities WHERE id = ? OR (name = ? AND agent_id = 'default')")
+						.get(entityId, skillName) as { id: string } | undefined,
+			);
+			const actualId = existing?.id ?? entityId;
+			const rawHash = skillEmbeddingHash(actualId, parsed.frontmatter);
+			const storedEmb = deps.accessor.withReadDb(
+				(db) =>
+					db
+						.prepare("SELECT content_hash FROM embeddings WHERE source_type = 'skill' AND source_id = ?")
+						.get(actualId) as { content_hash: string } | undefined,
+			);
+
+			const shouldInstall =
+				!existing ||
+				(Boolean(storedEmb) && storedEmb?.content_hash !== rawHash) ||
+				(Boolean(options.forceInstall) && !storedEmb);
+			if (!shouldInstall) {
+				resetSkillFailureState(skillName);
+				logger.debug("reconciler", "Skill unchanged, skipping", { skill: skillName });
+				return "unchanged";
+			}
+
+			await installSkillNode(
+				{
+					frontmatter: parsed.frontmatter,
+					body: parsed.body,
+					source: options.source ?? "reconciler",
+					fsPath: mdPath,
+				},
+				deps.accessor,
+				deps.pipelineConfig,
+				deps.embeddingConfig,
+				deps.fetchEmbedding,
+			);
+			resetSkillFailureState(skillName);
+			return existing ? "updated" : "installed";
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			logger.warn("reconciler", "Failed to reconcile skill", {
+				skill: skillName,
+				error: msg,
+			});
+
+			const consecutiveFailures = (failureState?.consecutiveFailures ?? 0) + 1;
+			const backoffMs = skillBackoffDelayMs(consecutiveFailures);
+			skillFailureState.set(skillName, { consecutiveFailures, nextAttemptAt: Date.now() + backoffMs });
+			if (backoffMs > 0) {
+				logger.warn("reconciler", "Skill reconcile failed repeatedly; entering backoff", {
+					skill: skillName,
+					consecutiveFailures,
+					backoffMs,
+				});
+			}
+			return "failed";
+		}
+	});
+}
+
 // ---------------------------------------------------------------------------
 // Reconciler lifecycle
 // ---------------------------------------------------------------------------
@@ -266,8 +306,9 @@ export async function reconcileOnce(
 export function startReconciler(deps: ReconcilerDeps): ReconcilerHandle {
 	const intervalMs = deps.pipelineConfig.procedural.reconcileIntervalMs;
 	const dir = skillsDir(deps.agentsDir);
-	let reconciling = false;
 	let lastScannedDirMtimeMs: number | null | undefined;
+	let activePass: Promise<void> | null = null;
+	let stopped = false;
 
 	const directoryMtimeMs = (): number | null => {
 		try {
@@ -277,33 +318,37 @@ export function startReconciler(deps: ReconcilerDeps): ReconcilerHandle {
 		}
 	};
 
-	const reconcileIfChanged = async (): Promise<void> => {
-		const currentMtimeMs = directoryMtimeMs();
-		const scanFilesystem = currentMtimeMs !== lastScannedDirMtimeMs;
-		await reconcileOnce(deps, { scanFilesystem });
-		lastScannedDirMtimeMs = currentMtimeMs;
+	const reconcileIfChanged = (): Promise<void> => {
+		if (stopped) return Promise.resolve();
+		if (activePass) return activePass;
+
+		const pass = (async () => {
+			const currentMtimeMs = directoryMtimeMs();
+			const scanFilesystem = currentMtimeMs !== lastScannedDirMtimeMs;
+			await reconcileOnce(deps, { scanFilesystem });
+			lastScannedDirMtimeMs = currentMtimeMs;
+		})();
+		const guardedPass = pass.finally(() => {
+			if (activePass === guardedPass) activePass = null;
+		});
+		activePass = guardedPass;
+		return guardedPass;
 	};
 
-	// Immediate backfill (async, doesn't block startup)
+	// Immediate backfill and periodic scans share one pass flight. A periodic
+	// tick that arrives during startup coalesces onto the startup pass.
 	reconcileIfChanged().catch((e) => {
 		logger.error("reconciler", "Startup backfill failed", e instanceof Error ? e : undefined, {
 			error: String(e),
 		});
 	});
 
-	// Periodic reconciliation (guarded against overlapping runs)
 	const timer = setInterval(() => {
-		if (reconciling) return;
-		reconciling = true;
-		reconcileIfChanged()
-			.catch((e) => {
-				logger.error("reconciler", "Periodic reconciliation failed", e instanceof Error ? e : undefined, {
-					error: String(e),
-				});
-			})
-			.finally(() => {
-				reconciling = false;
+		reconcileIfChanged().catch((e) => {
+			logger.error("reconciler", "Periodic reconciliation failed", e instanceof Error ? e : undefined, {
+				error: String(e),
 			});
+		});
 	}, intervalMs);
 
 	// File watcher for low-latency reconciliation
@@ -319,21 +364,38 @@ export function startReconciler(deps: ReconcilerDeps): ReconcilerHandle {
 			const skillName = basename(dirname(filePath));
 			logger.info("reconciler", "SKILL.md added", { skill: skillName });
 			resetSkillFailureState(skillName);
-			reconcileSkill(skillName, filePath, deps);
+			reconcileSkillFile(skillName, filePath, deps, { forceInstall: true }).catch((e) => {
+				logger.error("reconciler", "Watcher reconciliation failed", e instanceof Error ? e : undefined, {
+					skill: skillName,
+					error: String(e),
+				});
+			});
 		});
 
 		watcher.on("change", (filePath) => {
 			const skillName = basename(dirname(filePath));
 			logger.info("reconciler", "SKILL.md changed", { skill: skillName });
 			resetSkillFailureState(skillName);
-			reconcileSkill(skillName, filePath, deps);
+			reconcileSkillFile(skillName, filePath, deps, { forceInstall: true }).catch((e) => {
+				logger.error("reconciler", "Watcher reconciliation failed", e instanceof Error ? e : undefined, {
+					skill: skillName,
+					error: String(e),
+				});
+			});
 		});
 
 		watcher.on("unlink", (filePath) => {
 			const skillName = basename(dirname(filePath));
 			logger.info("reconciler", "SKILL.md removed", { skill: skillName });
 			resetSkillFailureState(skillName);
-			uninstallSkillNode({ skillName }, deps.accessor);
+			withSkillReconciliationLock(dir, skillName, () => {
+				uninstallSkillNode({ skillName }, deps.accessor);
+			}).catch((e) => {
+				logger.error("reconciler", "Watcher uninstall failed", e instanceof Error ? e : undefined, {
+					skill: skillName,
+					error: String(e),
+				});
+			});
 		});
 	}
 
@@ -345,6 +407,7 @@ export function startReconciler(deps: ReconcilerDeps): ReconcilerHandle {
 
 	return {
 		stop() {
+			stopped = true;
 			clearInterval(timer);
 			if (watcher) {
 				watcher.close();
@@ -353,63 +416,4 @@ export function startReconciler(deps: ReconcilerDeps): ReconcilerHandle {
 			logger.info("reconciler", "Skill reconciler stopped");
 		},
 	};
-}
-
-/**
- * Reconcile a single skill by name (triggered by file watcher).
- */
-async function reconcileSkill(skillName: string, mdPath: string, deps: ReconcilerDeps): Promise<void> {
-	try {
-		if (!existsSync(mdPath)) {
-			uninstallSkillNode({ skillName }, deps.accessor);
-			return;
-		}
-
-		const content = readFileSync(mdPath, "utf-8");
-		const parsed = parseSkillFile(content);
-		if (!parsed) return;
-
-		const entityId = `skill:default:${skillName}`;
-
-		// Look up by id or name (entity may have been adopted from extraction)
-		const existingEntity = deps.accessor.withReadDb(
-			(db) =>
-				db
-					.prepare("SELECT id FROM entities WHERE id = ? OR (name = ? AND agent_id = 'default')")
-					.get(entityId, skillName) as { id: string } | undefined,
-		);
-		const lookupId = existingEntity?.id ?? entityId;
-		const rawHash = skillEmbeddingHash(lookupId, parsed.frontmatter);
-		const storedEmb = deps.accessor.withReadDb(
-			(db) =>
-				db.prepare("SELECT content_hash FROM embeddings WHERE source_type = 'skill' AND source_id = ?").get(lookupId) as
-					| { content_hash: string }
-					| undefined,
-		);
-
-		if (storedEmb && storedEmb.content_hash === rawHash) {
-			logger.debug("reconciler", "Skill unchanged, skipping", { skill: skillName });
-			return;
-		}
-
-		await installSkillNode(
-			{
-				frontmatter: parsed.frontmatter,
-				body: parsed.body,
-				source: "reconciler",
-				fsPath: mdPath,
-			},
-			deps.accessor,
-			deps.pipelineConfig,
-			deps.embeddingConfig,
-			deps.fetchEmbedding,
-		);
-
-		logger.debug("reconciler", "Skill reconciled via watcher", { skill: skillName });
-	} catch (e) {
-		logger.warn("reconciler", "Watcher reconciliation failed", {
-			skill: skillName,
-			error: e instanceof Error ? e.message : String(e),
-		});
-	}
 }

--- a/platform/daemon/src/pipeline/skill-reconciler.ts
+++ b/platform/daemon/src/pipeline/skill-reconciler.ts
@@ -293,6 +293,18 @@ export async function reconcileSkillFile(
 	});
 }
 
+/**
+ * Remove one skill through the shared per-skill flight. This is the watcher
+ * unlink path and must use the workspace key, not the skills directory path.
+ */
+export function reconcileUnlinkedSkill(skillName: string, deps: ReconcilerDeps): Promise<ReconcileSkillResult> {
+	return withSkillReconciliationLock(deps.agentsDir, skillName, () => {
+		const result = uninstallSkillNode({ skillName }, deps.accessor);
+		resetSkillFailureState(skillName);
+		return result.removed ? "removed" : "unchanged";
+	});
+}
+
 // ---------------------------------------------------------------------------
 // Reconciler lifecycle
 // ---------------------------------------------------------------------------
@@ -387,10 +399,7 @@ export function startReconciler(deps: ReconcilerDeps): ReconcilerHandle {
 		watcher.on("unlink", (filePath) => {
 			const skillName = basename(dirname(filePath));
 			logger.info("reconciler", "SKILL.md removed", { skill: skillName });
-			resetSkillFailureState(skillName);
-			withSkillReconciliationLock(dir, skillName, () => {
-				uninstallSkillNode({ skillName }, deps.accessor);
-			}).catch((e) => {
+			reconcileUnlinkedSkill(skillName, deps).catch((e) => {
 				logger.error("reconciler", "Watcher uninstall failed", e instanceof Error ? e : undefined, {
 					skill: skillName,
 					error: String(e),

--- a/platform/daemon/src/routes/skills.ts
+++ b/platform/daemon/src/routes/skills.ts
@@ -31,12 +31,7 @@ import { type DbAccessor, getDbAccessor } from "../db-accessor.js";
 import { logger } from "../logger.js";
 import { type EmbeddingConfig, type PipelineV2Config, loadMemoryConfig } from "../memory-config.js";
 import { uninstallSkillNode } from "../pipeline/skill-graph.js";
-import {
-	type ReconcilerDeps,
-	reconcileSkillFile,
-	resetSkillFailureState,
-	withSkillReconciliationLock,
-} from "../pipeline/skill-reconciler.js";
+import { type ReconcilerDeps, reconcileSkillFile, withSkillReconciliationLock } from "../pipeline/skill-reconciler.js";
 
 function getAgentsDir(): string {
 	return resolveDefaultBasePath();
@@ -811,7 +806,6 @@ async function onSkillInstalled(skillName: string): Promise<void> {
 		fetchEmbedding: fetchEmbeddingFn,
 		agentsDir: getAgentsDir(),
 	};
-	resetSkillFailureState(skillName);
 	const result = await reconcileSkillFile(skillName, join(getSkillsDir(), skillName, "SKILL.md"), deps, {
 		forceInstall: true,
 		source: "installed",

--- a/platform/daemon/src/routes/skills.ts
+++ b/platform/daemon/src/routes/skills.ts
@@ -30,8 +30,13 @@ import type { AuthMode } from "../auth/index.js";
 import { type DbAccessor, getDbAccessor } from "../db-accessor.js";
 import { logger } from "../logger.js";
 import { type EmbeddingConfig, type PipelineV2Config, loadMemoryConfig } from "../memory-config.js";
-import { parseSkillFile } from "../pipeline/skill-frontmatter.js";
-import { installSkillNode, uninstallSkillNode } from "../pipeline/skill-graph.js";
+import { uninstallSkillNode } from "../pipeline/skill-graph.js";
+import {
+	type ReconcilerDeps,
+	reconcileSkillFile,
+	resetSkillFailureState,
+	withSkillReconciliationLock,
+} from "../pipeline/skill-reconciler.js";
 
 function getAgentsDir(): string {
 	return resolveDefaultBasePath();
@@ -788,81 +793,42 @@ async function installClawhubSkill(
 	}
 }
 
-// Per-skill lock to serialize graph node creation for the same skill
-const skillLocks = new Map<string, Promise<void>>();
-
-function withSkillLock(skillName: string, fn: () => Promise<void>): Promise<void> {
-	const prev = skillLocks.get(skillName) ?? Promise.resolve();
-	const next = prev.then(fn, fn).finally(() => {
-		if (skillLocks.get(skillName) === next) {
-			skillLocks.delete(skillName);
-		}
-	});
-	skillLocks.set(skillName, next);
-	return next;
-}
-
 /**
- * After a successful skill install, create the graph node.
- * Runs async — does not block the install response.
- * Serialized per skill name to prevent concurrent SKILL.md writes.
+ * After a successful skill install, reconcile the graph node through the same
+ * per-skill flight used by startup, periodic, and filesystem watcher paths.
  */
 async function onSkillInstalled(skillName: string): Promise<void> {
-	return withSkillLock(skillName, () => onSkillInstalledInner(skillName));
-}
-
-async function onSkillInstalledInner(skillName: string): Promise<void> {
 	const accessor = getAccessorSafe();
-	if (!accessor) return;
+	if (!accessor || !fetchEmbeddingFn) return;
 
-	const skillMdPath = join(getSkillsDir(), skillName, "SKILL.md");
-	if (!existsSync(skillMdPath)) return;
+	const memoryCfg = loadMemoryConfig(getAgentsDir());
+	if (!memoryCfg.pipelineV2.procedural.enabled) return;
 
-	try {
-		const content = readFileSync(skillMdPath, "utf-8");
-		const parsed = parseSkillFile(content);
-		if (!parsed) {
-			logger.warn("skills", "Failed to parse SKILL.md frontmatter for graph", { skill: skillName });
-			return;
-		}
-
-		const memoryCfg = loadMemoryConfig(getAgentsDir());
-		if (!memoryCfg.pipelineV2.procedural.enabled) return;
-		if (!fetchEmbeddingFn) return;
-
-		const result = await installSkillNode(
-			{
-				frontmatter: parsed.frontmatter,
-				body: parsed.body,
-				source: "installed",
-				fsPath: skillMdPath,
-			},
-			accessor,
-			memoryCfg.pipelineV2,
-			memoryCfg.embedding,
-			fetchEmbeddingFn,
-		);
-
-		logger.info("skills", "Graph node created for skill", {
-			skill: skillName,
-			entityId: result.entityId,
-			embeddingCreated: result.embeddingCreated,
-		});
-	} catch (e) {
-		logger.error("skills", "Failed to create graph node for skill", e as Error, {
-			skill: skillName,
-		});
+	const deps: ReconcilerDeps = {
+		accessor,
+		pipelineConfig: memoryCfg.pipelineV2,
+		embeddingConfig: memoryCfg.embedding,
+		fetchEmbedding: fetchEmbeddingFn,
+		agentsDir: getAgentsDir(),
+	};
+	resetSkillFailureState(skillName);
+	const result = await reconcileSkillFile(skillName, join(getSkillsDir(), skillName, "SKILL.md"), deps, {
+		forceInstall: true,
+		source: "installed",
+	});
+	if (result === "failed") {
+		throw new Error(`Skill graph reconciliation failed for ${skillName}`);
 	}
 }
 
 /**
  * Before a skill is uninstalled from the filesystem, remove its graph node.
  */
-function onSkillUninstalling(skillName: string): void {
+async function onSkillUninstalling(skillName: string): Promise<void> {
 	const accessor = getAccessorSafe();
 	if (!accessor) return;
 
-	try {
+	await withSkillReconciliationLock(getAgentsDir(), skillName, () => {
 		const result = uninstallSkillNode({ skillName }, accessor);
 		if (result.removed) {
 			logger.info("skills", "Graph node removed for skill", {
@@ -870,11 +836,7 @@ function onSkillUninstalling(skillName: string): void {
 				entityId: result.entityId,
 			});
 		}
-	} catch (e) {
-		logger.error("skills", "Failed to remove graph node for skill", e as Error, {
-			skill: skillName,
-		});
-	}
+	});
 }
 
 export function mountSkillsRoutes(app: Hono, _authMode: AuthMode = "local"): void {
@@ -1226,7 +1188,7 @@ export function mountSkillsRoutes(app: Hono, _authMode: AuthMode = "local"): voi
 	});
 
 	// DELETE /api/skills/:name - uninstall a skill
-	app.delete("/api/skills/:name", (c) => {
+	app.delete("/api/skills/:name", async (c) => {
 		const name = c.req.param("name");
 		if (!name || name.includes("..") || name.includes("/") || name.includes("\\")) {
 			return c.json({ error: "Invalid skill name" }, 400);
@@ -1239,7 +1201,7 @@ export function mountSkillsRoutes(app: Hono, _authMode: AuthMode = "local"): voi
 
 		try {
 			// Remove graph node before filesystem cleanup
-			onSkillUninstalling(name);
+			await onSkillUninstalling(name);
 			rmSync(skillDir, { recursive: true, force: true });
 			logger.info("skills", "Skill removed", { name });
 			return c.json({ success: true, name, message: `Removed ${name}` });


### PR DESCRIPTION
## Summary

Fix #1354 by making skill reconciliation triggers share one workspace+skill single-flight boundary, including watcher unlink events. This prevents overlapping provider calls and graph writes for the same skill while preserving independent work across different skills.

## Changes

- Added a shared workspace+skill reconciliation flight used by startup, periodic, watcher add/change/unlink, explicit install, and explicit uninstall paths.
- Moved the embedding/hash state check inside the flight so queued triggers re-check state after the first trigger completes.
- Added a dedicated watcher-unlink helper using the workspace key, fixing the prior `skillsDir` versus `agentsDir` key mismatch.
- Preserved per-skill failure/backoff handling and fresh watcher/install signals when an older in-flight attempt fails.
- Added regression coverage for overlapping startup/install, watcher-unlink/install, and queued fresh-trigger behavior.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A: no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A: no migrations touched.

## Testing

- [ ] `bun test` passes (full suite not run; focused suites listed below)
- [ ] `bun run typecheck` passes (full-repo gate not run; daemon package gate passed below)
- [ ] `bun run lint` passes (full-repo gate not run; targeted Biome passed below)
- [ ] Tested against running daemon
- [ ] N/A

Focused verification after rebase onto origin/main `e51cd5808`:

- `bun test platform/daemon/src/pipeline/skill-reconciler.test.ts`: 12 pass, 0 fail.
- `bun test platform/daemon/src/routes/skills.test.ts --test-name-pattern 'skills routes|install command args|ClawHub skill archive validation'`: 27 pass, 0 fail.
- `bun run --filter '@signet/core' build`: pass.
- `bun run --filter '@signet/daemon' typecheck`: pass.
- `bun run --filter '@signet/daemon' build`: pass.
- `bunx biome check platform/daemon/src/pipeline/skill-reconciler.ts platform/daemon/src/pipeline/skill-reconciler.test.ts platform/daemon/src/routes/skills.ts`: pass.
- `git diff --check`: pass.

The unfiltered skills route suite has one pre-existing fixture failure because this checkout does not contain `skills/memory-debug/SKILL.md`; the changed tests and focused route tests pass.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

A read-only adversarial reviewer timed out after partial inspection and therefore supplied no final verdict. Its three /tmp-only concurrency probes passed, including queued unlink after a failed install and independent-skill behavior; human review remains required.

The branch is rebased onto current origin/main at `e51cd5808` (v0.193.2), and the final head is `01087bc0c`. No generated configuration was modified. Do not merge from this task; human review remains required.
