### PR TITLE
fix(daemon): prevent runtime probe stampedes (#1329)

### DIFF
--- a/platform/daemon/src/inference-router.test.ts
+++ b/platform/daemon/src/inference-router.test.ts
@@ -472,6 +472,86 @@ printf 'never reached\\n'
 		}
 	});
 
+	it("does not reuse or cache a stale snapshot across credential invalidation (#1329)", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-router-invalidation-flight-"));
+		try {
+			mkdirSync(join(dir, "memory"), { recursive: true });
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`inference:
+  defaultPolicy: local
+  targets:
+    local:
+      executor: openai-compatible
+      endpoint: http://127.0.0.1:1234/v1
+      models:
+        default:
+          model: local-model
+  policies:
+    local:
+      mode: automatic
+      defaultTargets:
+        - local/default
+  workloads:
+    interactive:
+      policy: local
+`,
+			);
+
+			let probeCount = 0;
+			let releaseStaleProbe: ((response: Response) => void) | undefined;
+			let resolveStaleProbeStarted: (() => void) | undefined;
+			let resolveFreshProbeStarted: (() => void) | undefined;
+			const staleProbeStarted = new Promise<void>((resolve) => {
+				resolveStaleProbeStarted = resolve;
+			});
+			const freshProbeStarted = new Promise<void>((resolve) => {
+				resolveFreshProbeStarted = resolve;
+			});
+			globalThis.fetch = mock((input: string | URL | Request) => {
+				if (String(input).endsWith("/models")) {
+					probeCount += 1;
+					if (probeCount === 1) {
+						resolveStaleProbeStarted?.();
+						return new Promise<Response>((resolve) => {
+							releaseStaleProbe = resolve;
+						});
+					}
+					resolveFreshProbeStarted?.();
+					return Promise.reject(new Error("fresh probe failed"));
+				}
+				return Promise.resolve(openAiSseResponse("unused"));
+			}) as unknown as typeof fetch;
+
+			const router = getOrCreateInferenceRouter(dir);
+			const stale = router.status(true);
+			await staleProbeStarted;
+			router.invalidateCredentialState();
+			const fresh = router.status(true);
+			await freshProbeStarted;
+			expect(probeCount).toBe(2);
+
+			const freshResult = await fresh;
+			expect(freshResult.ok).toBe(true);
+			if (!freshResult.ok) return;
+			expect(freshResult.value.runtimeSnapshot.targets["local/default"]?.available).toBe(false);
+			if (!releaseStaleProbe) throw new Error("stale runtime snapshot probe did not start");
+			releaseStaleProbe(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+
+			const staleResult = await stale;
+			expect(staleResult.ok).toBe(true);
+			if (!staleResult.ok) return;
+			expect(staleResult.value.runtimeSnapshot.targets["local/default"]?.available).toBe(true);
+
+			const cachedResult = await router.status();
+			expect(cachedResult.ok).toBe(true);
+			if (!cachedResult.ok) return;
+			expect(cachedResult.value.runtimeSnapshot.targets["local/default"]?.available).toBe(false);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("requires an explicit inference workload instead of compiling legacy pipeline routing", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "signet-router-no-legacy-routing-"));
 		try {

--- a/platform/daemon/src/inference-router.test.ts
+++ b/platform/daemon/src/inference-router.test.ts
@@ -385,6 +385,93 @@ printf 'never reached\\n'
 		}
 	});
 
+	it("single-flights concurrent runtime snapshot probes and cleans up failed flights (#1329)", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-router-snapshot-flight-"));
+		try {
+			mkdirSync(join(dir, "memory"), { recursive: true });
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`inference:
+  defaultPolicy: local
+  targets:
+    local:
+      executor: openai-compatible
+      endpoint: http://127.0.0.1:1234/v1
+      models:
+        default:
+          model: local-model
+  policies:
+    local:
+      mode: automatic
+      defaultTargets:
+        - local/default
+  workloads:
+    interactive:
+      policy: local
+`,
+			);
+
+			let probeCount = 0;
+			let releaseProbe: ((response: Response) => void) | undefined;
+			let resolveProbeStarted: (() => void) | undefined;
+			const probeStarted = new Promise<void>((resolve) => {
+				resolveProbeStarted = resolve;
+			});
+			globalThis.fetch = mock((input: string | URL | Request) => {
+				if (String(input).endsWith("/models")) {
+					probeCount += 1;
+					resolveProbeStarted?.();
+					return new Promise<Response>((resolve) => {
+						releaseProbe = resolve;
+					});
+				}
+				return Promise.resolve(openAiSseResponse("unused"));
+			}) as unknown as typeof fetch;
+
+			const router = getOrCreateInferenceRouter(dir);
+			const first = router.status(true);
+			const second = router.status(true);
+			await probeStarted;
+			expect(probeCount).toBe(1);
+			if (!releaseProbe) throw new Error("runtime snapshot probe did not start");
+			releaseProbe(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+
+			const results = await Promise.all([first, second]);
+			expect(results[0]?.ok).toBe(true);
+			expect(results[1]?.ok).toBe(true);
+			if (!results[0]?.ok || !results[1]?.ok) return;
+			expect(results[0].value.runtimeSnapshot.targets["local/default"]?.available).toBe(true);
+			expect(results[1].value.runtimeSnapshot.targets["local/default"]?.available).toBe(true);
+
+			globalThis.fetch = mock((input: string | URL | Request) => {
+				if (String(input).endsWith("/models")) {
+					probeCount += 1;
+					return Promise.reject(new Error("probe timeout"));
+				}
+				return Promise.resolve(openAiSseResponse("unused"));
+			}) as unknown as typeof fetch;
+			const failed = await router.status(true);
+			expect(failed.ok).toBe(true);
+			if (!failed.ok) return;
+			expect(failed.value.runtimeSnapshot.targets["local/default"]?.available).toBe(false);
+
+			globalThis.fetch = mock((input: string | URL | Request) => {
+				if (String(input).endsWith("/models")) {
+					probeCount += 1;
+					return Promise.resolve(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+				}
+				return Promise.resolve(openAiSseResponse("unused"));
+			}) as unknown as typeof fetch;
+			const recovered = await router.status(true);
+			expect(recovered.ok).toBe(true);
+			if (!recovered.ok) return;
+			expect(recovered.value.runtimeSnapshot.targets["local/default"]?.available).toBe(true);
+			expect(probeCount).toBe(3);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("requires an explicit inference workload instead of compiling legacy pipeline routing", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "signet-router-no-legacy-routing-"));
 		try {

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -303,6 +303,7 @@ function buildPromptFromMessages(messages: ReadonlyArray<{ readonly role: string
 export class InferenceRouter {
 	private snapshotCache: SnapshotCacheEntry | null = null;
 	private readonly snapshotFlights = new Map<string, Promise<RoutingRuntimeSnapshot>>();
+	private runtimeCacheGeneration = 0;
 	private readonly providerCache = new Map<string, Promise<StreamCapableLlmProvider>>();
 	private readonly observedTargetState = new Map<string, ObservedRuntimeOverride>();
 	private readonly observedAccountState = new Map<string, ObservedRuntimeOverride>();
@@ -497,7 +498,9 @@ export class InferenceRouter {
 	}
 
 	private resetRuntimeCaches(): void {
+		this.runtimeCacheGeneration += 1;
 		this.snapshotCache = null;
+		this.snapshotFlights.clear();
 	}
 
 	private pruneObservedState(now = Date.now()): void {
@@ -805,6 +808,7 @@ export class InferenceRouter {
 		const existingFlight = this.snapshotFlights.get(loaded.signature);
 		if (existingFlight) return existingFlight;
 
+		const generation = this.runtimeCacheGeneration;
 		const build = (async (): Promise<RoutingRuntimeSnapshot> => {
 			const entries = await Promise.all(
 				allTargetRefs(loaded.config).map(async (targetRef) => {
@@ -815,11 +819,13 @@ export class InferenceRouter {
 			const snapshot: RoutingRuntimeSnapshot = {
 				targets: Object.fromEntries(entries),
 			};
-			this.snapshotCache = {
-				signature: loaded.signature,
-				expiresAt: Date.now() + SNAPSHOT_TTL_MS,
-				snapshot,
-			};
+			if (generation === this.runtimeCacheGeneration) {
+				this.snapshotCache = {
+					signature: loaded.signature,
+					expiresAt: Date.now() + SNAPSHOT_TTL_MS,
+					snapshot,
+				};
+			}
 			return snapshot;
 		})();
 		this.snapshotFlights.set(loaded.signature, build);

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -302,6 +302,7 @@ function buildPromptFromMessages(messages: ReadonlyArray<{ readonly role: string
 
 export class InferenceRouter {
 	private snapshotCache: SnapshotCacheEntry | null = null;
+	private readonly snapshotFlights = new Map<string, Promise<RoutingRuntimeSnapshot>>();
 	private readonly providerCache = new Map<string, Promise<StreamCapableLlmProvider>>();
 	private readonly observedTargetState = new Map<string, ObservedRuntimeOverride>();
 	private readonly observedAccountState = new Map<string, ObservedRuntimeOverride>();
@@ -800,21 +801,35 @@ export class InferenceRouter {
 		) {
 			return this.snapshotCache.snapshot;
 		}
-		const entries = await Promise.all(
-			allTargetRefs(loaded.config).map(async (targetRef) => {
-				const state = await this.runtimeStateForTarget(loaded, targetRef);
-				return [targetRef, state] as const;
-			}),
-		);
-		const snapshot: RoutingRuntimeSnapshot = {
-			targets: Object.fromEntries(entries),
+
+		const existingFlight = this.snapshotFlights.get(loaded.signature);
+		if (existingFlight) return existingFlight;
+
+		const build = (async (): Promise<RoutingRuntimeSnapshot> => {
+			const entries = await Promise.all(
+				allTargetRefs(loaded.config).map(async (targetRef) => {
+					const state = await this.runtimeStateForTarget(loaded, targetRef);
+					return [targetRef, state] as const;
+				}),
+			);
+			const snapshot: RoutingRuntimeSnapshot = {
+				targets: Object.fromEntries(entries),
+			};
+			this.snapshotCache = {
+				signature: loaded.signature,
+				expiresAt: Date.now() + SNAPSHOT_TTL_MS,
+				snapshot,
+			};
+			return snapshot;
+		})();
+		this.snapshotFlights.set(loaded.signature, build);
+		const clearFlight = (): void => {
+			if (this.snapshotFlights.get(loaded.signature) === build) {
+				this.snapshotFlights.delete(loaded.signature);
+			}
 		};
-		this.snapshotCache = {
-			signature: loaded.signature,
-			expiresAt: Date.now() + SNAPSHOT_TTL_MS,
-			snapshot,
-		};
-		return snapshot;
+		void build.then(clearFlight, clearFlight);
+		return build;
 	}
 
 	async explain(request: RouteRequest, refresh = false): Promise<RouterResult<RouteDecision>> {


### PR DESCRIPTION
## Summary

Prevent concurrent inference status/explain requests from independently probing every configured provider target when the runtime snapshot is missing, expired, or force-refreshed. The router now shares one in-flight snapshot build per routing-config signature and removes the flight on both success and failure without changing the completed snapshot TTL.

Closes #1329.

## Changes

- Add single-flight admission for runtime snapshot construction keyed by the loaded routing configuration signature.
- Preserve forced refresh coalescing, completed snapshot TTL, independent target probes, and retry after failed probes.
- Guard in-flight snapshots with an invalidation generation so credential-state resets cannot reuse or repopulate stale probe results.
- Add a regression test proving concurrent callers issue one probe and a failed probe does not wedge later refreshes.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A: no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A: no migrations.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused verification for this daemon change:

- `bun test platform/daemon/src/inference-router.test.ts` (15 pass, 0 fail)
- `bunx biome check platform/daemon/src/inference-router.ts platform/daemon/src/inference-router.test.ts` (pass)
- `bun run --filter '@signet/core' build` (pass)
- `bun run --filter '@signet/daemon' build` (pass)
- `bun run --filter '@signet/daemon' typecheck` (pass)
- `git diff --check` (pass)

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

No database writes, agent-scoped queries, admin/mutation endpoints, public API schema, or user-facing docs changed. The readiness items above are checked because the relevant surfaces were reviewed or unchanged; the exact focused checks and package gates are listed in Testing. This PR is intentionally not merged by the worker.