### PR TITLE
fix(daemon): cap marketplace MCP clients

### DIFF
--- a/platform/daemon/src/marketplace-client-budget.test.ts
+++ b/platform/daemon/src/marketplace-client-budget.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { MarketplaceMcpClientBudget, withMarketplaceMcpTimeout } from "./marketplace-client-budget.js";
+
+describe("MarketplaceMcpClientBudget", () => {
+	it("caps active clients and reports stdio process counts", async () => {
+		const budget = new MarketplaceMcpClientBudget(2);
+		const first = await budget.acquire(100);
+		const second = await budget.acquire(100);
+		first.markProcessStarted();
+		second.markProcessStarted();
+
+		const queued = budget.acquire(1_000);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(budget.status()).toEqual({ activeClients: 2, activeProcesses: 2, pending: 1, limit: 2 });
+
+		first.release();
+		const third = await queued;
+		expect(budget.status()).toEqual({ activeClients: 2, activeProcesses: 1, pending: 0, limit: 2 });
+
+		third.markProcessStarted();
+		third.release();
+		second.release();
+		expect(budget.status()).toEqual({ activeClients: 0, activeProcesses: 0, pending: 0, limit: 2 });
+	});
+
+	it("removes timed-out waiters without consuming a later permit", async () => {
+		const budget = new MarketplaceMcpClientBudget(1);
+		const active = await budget.acquire(100);
+
+		await expect(budget.acquire(10)).rejects.toThrow(/budget timed out/);
+		expect(budget.status().pending).toBe(0);
+
+		active.release();
+		expect(budget.status()).toEqual({ activeClients: 0, activeProcesses: 0, pending: 0, limit: 1 });
+	});
+
+	it("invokes cleanup when an operation reaches its deadline", async () => {
+		let closed = false;
+
+		await expect(
+			withMarketplaceMcpTimeout(new Promise<never>(() => undefined), 10, "test MCP operation", async () => {
+				closed = true;
+			}),
+		).rejects.toThrow(/test MCP operation timed out/);
+
+		expect(closed).toBe(true);
+	});
+});

--- a/platform/daemon/src/marketplace-client-budget.ts
+++ b/platform/daemon/src/marketplace-client-budget.ts
@@ -1,0 +1,172 @@
+/**
+ * Process and client budget for marketplace MCP operations.
+ *
+ * Marketplace MCP calls may create stdio child processes. Keep discovery,
+ * probes, and user calls behind one daemon-wide budget so one cache refresh or
+ * burst of callers cannot exhaust local process and file-descriptor limits.
+ */
+
+const DEFAULT_MAX_CONCURRENT_CLIENTS = 4;
+const MAX_CONCURRENT_CLIENTS = 16;
+const MAX_CLIENTS_ENV = "SIGNET_MARKETPLACE_MAX_CONCURRENT_CLIENTS";
+
+export interface MarketplaceMcpRuntimeStatus {
+	readonly activeClients: number;
+	readonly activeProcesses: number;
+	readonly pending: number;
+	readonly limit: number;
+}
+
+export interface MarketplaceMcpClientPermit {
+	readonly markProcessStarted: () => void;
+	readonly release: () => void;
+}
+
+interface QueueEntry {
+	readonly start: () => void;
+}
+
+export class MarketplaceMcpClientBudget {
+	private readonly max: number;
+	private active = 0;
+	private processes = 0;
+	private readonly queue: QueueEntry[] = [];
+
+	constructor(max: number) {
+		this.max = normalizeLimit(max);
+	}
+
+	async acquire(timeoutMs: number): Promise<MarketplaceMcpClientPermit> {
+		await this.acquireSlot(timeoutMs);
+
+		let processStarted = false;
+		let released = false;
+		return {
+			markProcessStarted: (): void => {
+				if (released || processStarted) return;
+				processStarted = true;
+				this.processes++;
+			},
+			release: (): void => {
+				if (released) return;
+				released = true;
+				if (processStarted) this.processes--;
+				this.active--;
+				this.drain();
+			},
+		};
+	}
+
+	status(): MarketplaceMcpRuntimeStatus {
+		return {
+			activeClients: this.active,
+			activeProcesses: this.processes,
+			pending: this.queue.length,
+			limit: this.max,
+		};
+	}
+
+	private async acquireSlot(timeoutMs: number): Promise<void> {
+		if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+			throw new Error("marketplace MCP timeout must be positive");
+		}
+
+		if (this.active < this.max) {
+			this.active++;
+			return;
+		}
+
+		await new Promise<void>((resolve, reject) => {
+			let settled = false;
+			const timer = setTimeout(() => {
+				if (settled) return;
+				settled = true;
+				const index = this.queue.indexOf(entry);
+				if (index >= 0) this.queue.splice(index, 1);
+				reject(new Error(`marketplace MCP client budget timed out after ${timeoutMs}ms`));
+			}, timeoutMs);
+			const entry: QueueEntry = {
+				start: (): void => {
+					if (settled) return;
+					settled = true;
+					clearTimeout(timer);
+					this.active++;
+					resolve();
+				},
+			};
+			this.queue.push(entry);
+		});
+	}
+
+	private drain(): void {
+		while (this.active < this.max) {
+			const next = this.queue.shift();
+			if (!next) return;
+			next.start();
+		}
+	}
+}
+
+function normalizeLimit(value: number): number {
+	return Number.isSafeInteger(value)
+		? Math.min(MAX_CONCURRENT_CLIENTS, Math.max(1, value))
+		: DEFAULT_MAX_CONCURRENT_CLIENTS;
+}
+
+function configuredLimit(): number {
+	const raw = process.env[MAX_CLIENTS_ENV];
+	if (raw === undefined) return DEFAULT_MAX_CONCURRENT_CLIENTS;
+	const parsed = Number(raw);
+	return Number.isSafeInteger(parsed) && parsed >= 1 ? normalizeLimit(parsed) : DEFAULT_MAX_CONCURRENT_CLIENTS;
+}
+
+export const marketplaceMcpClientBudget = new MarketplaceMcpClientBudget(configuredLimit());
+
+export function getMarketplaceMcpRuntimeStatus(): MarketplaceMcpRuntimeStatus {
+	return marketplaceMcpClientBudget.status();
+}
+
+/**
+ * Run an operation under the shared client budget and return its remaining
+ * deadline after queue acquisition.
+ */
+export async function withMarketplaceMcpPermit<T>(
+	timeoutMs: number,
+	fn: (permit: MarketplaceMcpClientPermit, remainingTimeoutMs: number) => Promise<T>,
+): Promise<T> {
+	const startedAt = Date.now();
+	const permit = await marketplaceMcpClientBudget.acquire(timeoutMs);
+	try {
+		const remainingTimeoutMs = Math.max(1, timeoutMs - (Date.now() - startedAt));
+		return await fn(permit, remainingTimeoutMs);
+	} finally {
+		permit.release();
+	}
+}
+
+/**
+ * Race an MCP operation against its deadline and close the underlying client
+ * as soon as the deadline fires. Closing before releasing the permit prevents
+ * timed-out stdio children from occupying an invisible slot indefinitely.
+ */
+export async function withMarketplaceMcpTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+	label: string,
+	onTimeout: () => Promise<void>,
+): Promise<T> {
+	let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<T>((_resolve, reject) => {
+				timeoutHandle = setTimeout(() => {
+					void onTimeout().catch(() => undefined);
+					reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+				}, timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timeoutHandle) clearTimeout(timeoutHandle);
+	}
+}

--- a/platform/daemon/src/mcp-probe.ts
+++ b/platform/daemon/src/mcp-probe.ts
@@ -16,14 +16,11 @@ import type {
 import { DEFAULT_APP_SIZE, resolveDefaultBasePath } from "@signet/core";
 import { createEvent, eventBus } from "./event-bus.js";
 import { logger } from "./logger.js";
+import { withMarketplaceMcpPermit, withMarketplaceMcpTimeout } from "./marketplace-client-budget.js";
 // Note: validatePublicHttpUrl from url-validation.ts is used by the install
 // endpoint (server-side fetch = real SSRF risk). Manifest ui/icon fields are
 // client-side (iframe/img) so they only need scheme validation, not address blocking.
-import type {
-	InstalledMarketplaceMcpServer,
-	MarketplaceMcpConfigHttp,
-	MarketplaceMcpConfigStdio,
-} from "./routes/marketplace.js";
+import type { InstalledMarketplaceMcpServer } from "./routes/marketplace.js";
 import { getSecret } from "./secrets.js";
 import { deleteCachedWidget, loadCachedWidget } from "./widget-gen.js";
 
@@ -84,65 +81,54 @@ async function withProbeClient<T>(
 	fn: (client: Client) => Promise<T>,
 ): Promise<T> {
 	const timeoutMs = Math.min(server.config.timeoutMs, 30_000);
-
-	const run = async (): Promise<T> => {
+	return withMarketplaceMcpPermit(timeoutMs, async (permit, remainingTimeoutMs) => {
 		const client = new Client({
 			name: "signet-os-probe",
 			version: "0.1.0",
 		});
-
-		if (server.config.transport === "stdio") {
-			const runtimeEnv: Record<string, string> = {};
-			for (const [k, v] of Object.entries(process.env)) {
-				if (typeof v === "string") runtimeEnv[k] = v;
+		let closePromise: Promise<void> | null = null;
+		const close = (): Promise<void> => {
+			if (!closePromise) {
+				closePromise = client.close().catch(() => undefined);
 			}
-			const resolvedEnv = await resolveSecretReferences((server.config as MarketplaceMcpConfigStdio).env);
-			const stdioConfig = server.config as MarketplaceMcpConfigStdio;
-			const transport = new StdioClientTransport({
-				command: stdioConfig.command,
-				args: [...stdioConfig.args],
-				env: { ...runtimeEnv, ...resolvedEnv },
-				cwd: stdioConfig.cwd,
+			return closePromise;
+		};
+
+		const run = async (): Promise<T> => {
+			if (server.config.transport === "stdio") {
+				const runtimeEnv: Record<string, string> = {};
+				for (const [k, v] of Object.entries(process.env)) {
+					if (typeof v === "string") runtimeEnv[k] = v;
+				}
+				const resolvedEnv = await resolveSecretReferences(server.config.env);
+				const transport = new StdioClientTransport({
+					command: server.config.command,
+					args: [...server.config.args],
+					env: { ...runtimeEnv, ...resolvedEnv },
+					cwd: server.config.cwd,
+				});
+
+				permit.markProcessStarted();
+				await client.connect(transport);
+				return fn(client);
+			}
+
+			const resolvedHeaders = await resolveSecretReferences(server.config.headers);
+			const transport = new StreamableHTTPClientTransport(new URL(server.config.url), {
+				requestInit: {
+					headers: resolvedHeaders,
+				},
 			});
-
 			await client.connect(transport);
-			try {
-				return await fn(client);
-			} finally {
-				await client.close().catch(() => undefined);
-			}
-		}
+			return fn(client);
+		};
 
-		// HTTP transport
-		const httpConfig = server.config as MarketplaceMcpConfigHttp;
-		const resolvedHeaders = await resolveSecretReferences(httpConfig.headers);
-		const transport = new StreamableHTTPClientTransport(new URL(httpConfig.url), {
-			requestInit: {
-				headers: resolvedHeaders,
-			},
-		});
-		await client.connect(transport);
 		try {
-			return await fn(client);
+			return await withMarketplaceMcpTimeout(run(), remainingTimeoutMs, `Probe ${server.id}`, close);
 		} finally {
-			await client.close().catch(() => undefined);
+			await close();
 		}
-	};
-
-	// Timeout wrapper
-	let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
-	try {
-		return await Promise.race([
-			run(),
-			new Promise<T>((_resolve, reject) => {
-				timeoutHandle = setTimeout(() => {
-					reject(new Error(`Probe timed out after ${timeoutMs}ms`));
-				}, timeoutMs);
-			}),
-		]);
-	} finally {
-		if (timeoutHandle) clearTimeout(timeoutHandle);
-	}
+	});
 }
 
 // ---------------------------------------------------------------------------

--- a/platform/daemon/src/mcp/tools.test.ts
+++ b/platform/daemon/src/mcp/tools.test.ts
@@ -19,7 +19,9 @@ import {
 	SIGNET_SECRETS_PLUGIN_ID,
 	updateGraphiqActiveProject,
 } from "@signet/core";
+import { Hono } from "hono";
 import { resetDefaultPluginHostForTests } from "../plugins/index.js";
+import { mountMarketplaceRoutes } from "../routes/marketplace.js";
 import { createMcpServer, refreshMarketplaceProxyTools } from "./tools.js";
 
 // ---------------------------------------------------------------------------
@@ -1628,6 +1630,106 @@ describe("createMcpServer", () => {
 			const refresh = await refreshMarketplaceProxyTools(dynamicServer, { notify: false });
 			expect(refresh.changed).toBe(true);
 			expect(getToolNames(dynamicServer)).toContain("signet_dogfood_everything_get_sum");
+		});
+
+		it("registers proxy tools after capped delayed marketplace discovery", async () => {
+			const scriptPath = join(tempAgentsDir, "delayed-marketplace-server.js");
+			mkdirSync(join(tempAgentsDir, "marketplace"), { recursive: true });
+			writeFileSync(
+				scriptPath,
+				`const delayMs = Number(process.argv[2]);
+process.stdin.setEncoding("utf8");
+let pending = "";
+const send = (message) => process.stdout.write(JSON.stringify(message) + "\\n");
+process.stdin.on("data", (chunk) => {
+  pending += chunk;
+  const lines = pending.split("\\n");
+  pending = lines.pop() ?? "";
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const message = JSON.parse(line);
+    if (message.method === "initialize") {
+      send({ jsonrpc: "2.0", id: message.id, result: {
+        protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "delayed", version: "1" }
+      }});
+    } else if (message.method === "tools/list") {
+      setTimeout(() => send({ jsonrpc: "2.0", id: message.id, result: {
+        tools: [{ name: "delayed_tool", description: "delayed test tool", inputSchema: { type: "object" } }]
+      }}), delayMs);
+    }
+  }
+});
+`,
+			);
+
+			const now = new Date().toISOString();
+			const servers = Array.from({ length: 6 }, (_, index) => ({
+				id: `delayed-server-${index}`,
+				source: "manual",
+				name: `Delayed Server ${index}`,
+				description: "Delayed marketplace server",
+				category: "Test",
+				official: false,
+				enabled: true,
+				scope: { harnesses: [], workspaces: [], channels: [] },
+				config: {
+					transport: "stdio",
+					command: process.execPath,
+					args: [scriptPath, "2000"],
+					env: {},
+					timeoutMs: 5_000,
+				},
+				installedAt: now,
+				updatedAt: now,
+			}));
+			writeFileSync(join(tempAgentsDir, "marketplace", "mcp-servers.json"), JSON.stringify(servers));
+
+			const app = new Hono();
+			mountMarketplaceRoutes(app);
+			globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+				const url = new URL(typeof input === "string" ? input : input.toString());
+				if (url.pathname === "/api/marketplace/mcp/policy") {
+					return new Response(
+						JSON.stringify({ policy: { mode: "expanded", maxExpandedTools: 12, maxSearchResults: 8 } }),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				if (url.pathname === "/api/marketplace/mcp/tools") {
+					const request = app.request(`${url.pathname}${url.search}`);
+					const signal = init?.signal;
+					if (!signal) return request;
+					return new Promise<Response>((resolve, reject) => {
+						const abort = (): void => reject(signal.reason);
+						if (signal.aborted) {
+							abort();
+							return;
+						}
+						signal.addEventListener("abort", abort, { once: true });
+						void request.then(
+							(response) => {
+								signal.removeEventListener("abort", abort);
+								resolve(response);
+							},
+							(error: unknown) => {
+								signal.removeEventListener("abort", abort);
+								reject(error);
+							},
+						);
+					});
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 404 });
+			}) as unknown as typeof fetch;
+
+			await server.close();
+			server = await createMcpServer({
+				daemonUrl: "http://localhost:3850",
+				version: "0.0.1-test",
+				enableMarketplaceProxyTools: true,
+			});
+
+			for (const index of Array.from({ length: 6 }, (_, value) => value)) {
+				expect(getToolNames(server)).toContain(`signet_delayed_server_${index}_delayed_tool`);
+			}
 		});
 	});
 

--- a/platform/daemon/src/mcp/tools.ts
+++ b/platform/daemon/src/mcp/tools.ts
@@ -256,6 +256,11 @@ const GRAPHIQ_COMPAT_ALIASES: ReadonlyMap<string, string> = new Map([
 // Internal HTTP helper
 // ---------------------------------------------------------------------------
 
+// Initial proxy registration waits for marketplace discovery. The shared
+// four-client budget can require two normal two-second discovery batches, so
+// its deadline must exceed the old 3s request timeout while remaining bounded.
+const MARKETPLACE_PROXY_REFRESH_TIMEOUT_MS = 5_000;
+
 // Standalone `signet-mcp` uses process env auth. Hosted `/mcp` requests pass
 // a per-request Authorization header through createMcpServer(), which takes
 // precedence in daemonFetch().
@@ -596,7 +601,7 @@ export async function refreshMarketplaceProxyTools(
 		state.baseUrl,
 		appendMarketplaceContext("/api/marketplace/mcp/tools?refresh=1", state.context),
 		{
-			timeout: 3_000,
+			timeout: MARKETPLACE_PROXY_REFRESH_TIMEOUT_MS,
 			authorizationHeader: state.authorizationHeader,
 		},
 	);

--- a/platform/daemon/src/routes/marketplace.test.ts
+++ b/platform/daemon/src/routes/marketplace.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
@@ -111,12 +111,20 @@ describe("marketplace routes", () => {
 			tools: unknown[];
 			servers: unknown[];
 			error?: string;
+			runtime: {
+				activeClients: number;
+				activeProcesses: number;
+				pending: number;
+				limit: number;
+			};
 		};
 
 		expect(body.error).toBeUndefined();
 		expect(body.count).toBe(0);
 		expect(body.tools).toEqual([]);
 		expect(body.servers).toEqual([]);
+		expect(body.runtime).toMatchObject({ activeClients: 0, activeProcesses: 0, pending: 0 });
+		expect(body.runtime.limit).toBeGreaterThan(0);
 	});
 
 	it("GET /api/marketplace/mcp/search resolves to search handler", async () => {
@@ -134,5 +142,95 @@ describe("marketplace routes", () => {
 		expect(body.query).toBe("time");
 		expect(body.count).toBe(0);
 		expect(body.results).toEqual([]);
+	});
+
+	it("bounds concurrent discovery and coalesces simultaneous cache misses", async () => {
+		const markerDir = join(tmpAgentsDir, "markers");
+		const scriptPath = join(tmpAgentsDir, "mcp-server.js");
+		mkdirSync(join(tmpAgentsDir, "marketplace"), { recursive: true });
+		mkdirSync(markerDir, { recursive: true });
+		writeFileSync(
+			scriptPath,
+			`const { appendFileSync, unlinkSync, writeFileSync } = require("node:fs");
+const { join } = require("node:path");
+const markerDir = process.argv[2];
+const delayMs = Number(process.argv[3]);
+const marker = join(markerDir, String(process.pid));
+const starts = join(markerDir, "starts.log");
+writeFileSync(marker, "active");
+appendFileSync(starts, String(process.pid) + "\\n");
+const cleanup = () => { try { unlinkSync(marker); } catch {} };
+process.on("exit", cleanup);
+process.stdin.setEncoding("utf8");
+let pending = "";
+const send = (message) => process.stdout.write(JSON.stringify(message) + "\\n");
+process.stdin.on("data", (chunk) => {
+  pending += chunk;
+  const lines = pending.split("\\n");
+  pending = lines.pop() ?? "";
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const message = JSON.parse(line);
+    if (message.method === "initialize") {
+      send({ jsonrpc: "2.0", id: message.id, result: {
+        protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "budget-test", version: "1" }
+      }});
+    } else if (message.method === "tools/list") {
+      setTimeout(() => send({ jsonrpc: "2.0", id: message.id, result: {
+        tools: [{ name: "budget_tool", description: "budget test", inputSchema: { type: "object" } }]
+      }}), delayMs);
+    }
+  }
+});
+`,
+		);
+
+		const servers = Array.from({ length: 6 }, (_, index) => ({
+			id: `budget-server-${index}`,
+			source: "manual",
+			name: `Budget Server ${index}`,
+			description: "Budget test server",
+			category: "Test",
+			official: false,
+			enabled: true,
+			scope: { harnesses: [], workspaces: [], channels: [] },
+			config: {
+				transport: "stdio",
+				command: process.execPath,
+				args: [scriptPath, markerDir, "80"],
+				env: {},
+				timeoutMs: 2_000,
+			},
+			installedAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		}));
+		writeFileSync(join(tmpAgentsDir, "marketplace", "mcp-servers.json"), JSON.stringify(servers));
+
+		const samples: number[] = [];
+		const sample = (): void => {
+			const active = readdirSync(markerDir).filter((name) => name !== "starts.log").length;
+			samples.push(active);
+		};
+		const sampler = setInterval(sample, 2);
+		try {
+			const [first, second] = await Promise.all([
+				app.request("/api/marketplace/mcp/tools?refresh=1"),
+				app.request("/api/marketplace/mcp/tools?refresh=1"),
+			]);
+
+			expect(first.status).toBe(200);
+			expect(second.status).toBe(200);
+			const body = (await first.json()) as {
+				count: number;
+				runtime: { activeClients: number; activeProcesses: number; pending: number; limit: number };
+			};
+			expect(body.count).toBe(6);
+			expect(Math.max(...samples)).toBeLessThanOrEqual(body.runtime.limit);
+			expect(body.runtime).toMatchObject({ activeClients: 0, activeProcesses: 0, pending: 0 });
+			expect(readFileSync(join(markerDir, "starts.log"), "utf8").trim().split("\n")).toHaveLength(6);
+		} finally {
+			clearInterval(sampler);
+			sample();
+		}
 	});
 });

--- a/platform/daemon/src/routes/marketplace.ts
+++ b/platform/daemon/src/routes/marketplace.ts
@@ -13,6 +13,11 @@ import { resolveDefaultBasePath } from "@signet/core";
 import type { Hono } from "hono";
 import { getDbAccessor } from "../db-accessor.js";
 import { logger } from "../logger.js";
+import {
+	getMarketplaceMcpRuntimeStatus,
+	withMarketplaceMcpPermit,
+	withMarketplaceMcpTimeout,
+} from "../marketplace-client-budget.js";
 import { probeServer, removeProbeResult, storeProbeResult } from "../mcp-probe.js";
 import { resolveScopedAgent } from "../request-scope.js";
 import { getSecret } from "../secrets.js";
@@ -148,6 +153,7 @@ let referenceCatalogCache: {
 	readonly entries: readonly MarketplaceMcpCatalogEntry[];
 } | null = null;
 const toolsCache = new Map<string, MarketplaceToolsCache>();
+const toolsLoadInFlight = new Map<string, Promise<MarketplaceToolsCache>>();
 
 function getAgentsDir(): string {
 	return resolveDefaultBasePath();
@@ -378,24 +384,6 @@ async function resolveSecretReferences(values: Readonly<Record<string, string>>)
 		resolved[key] = await getSecret(secretName);
 	}
 	return resolved;
-}
-
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
-	let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
-	try {
-		return await Promise.race([
-			promise,
-			new Promise<T>((_resolve, reject) => {
-				timeoutHandle = setTimeout(() => {
-					reject(new Error(`${label} timed out after ${timeoutMs}ms`));
-				}, timeoutMs);
-			}),
-		]);
-	} finally {
-		if (timeoutHandle) {
-			clearTimeout(timeoutHandle);
-		}
-	}
 }
 
 function sanitizeServerId(value: string): string {
@@ -928,48 +916,54 @@ async function withConnectedClient<T>(
 	server: InstalledMarketplaceMcpServer,
 	fn: (client: Client) => Promise<T>,
 ): Promise<T> {
-	const run = async (): Promise<T> => {
+	return withMarketplaceMcpPermit(server.config.timeoutMs, async (permit, timeoutMs) => {
 		const client = new Client({
 			name: "signet-marketplace-router",
 			version: "0.1.0",
 		});
-
-		if (server.config.transport === "stdio") {
-			const runtimeEnv: Record<string, string> = {};
-			for (const [k, v] of Object.entries(process.env)) {
-				if (typeof v === "string") runtimeEnv[k] = v;
+		let closePromise: Promise<void> | null = null;
+		const close = (): Promise<void> => {
+			if (!closePromise) {
+				closePromise = client.close().catch(() => undefined);
 			}
-			const resolvedEnv = await resolveSecretReferences(server.config.env);
-			const transport = new StdioClientTransport({
-				command: server.config.command,
-				args: [...server.config.args],
-				env: { ...runtimeEnv, ...resolvedEnv },
-				cwd: server.config.cwd,
+			return closePromise;
+		};
+
+		const run = async (): Promise<T> => {
+			if (server.config.transport === "stdio") {
+				const runtimeEnv: Record<string, string> = {};
+				for (const [k, v] of Object.entries(process.env)) {
+					if (typeof v === "string") runtimeEnv[k] = v;
+				}
+				const resolvedEnv = await resolveSecretReferences(server.config.env);
+				const transport = new StdioClientTransport({
+					command: server.config.command,
+					args: [...server.config.args],
+					env: { ...runtimeEnv, ...resolvedEnv },
+					cwd: server.config.cwd,
+				});
+
+				permit.markProcessStarted();
+				await client.connect(transport);
+				return fn(client);
+			}
+
+			const resolvedHeaders = await resolveSecretReferences(server.config.headers);
+			const transport = new StreamableHTTPClientTransport(new URL(server.config.url), {
+				requestInit: {
+					headers: resolvedHeaders,
+				},
 			});
-
 			await client.connect(transport);
-			try {
-				return await fn(client);
-			} finally {
-				await client.close().catch(() => undefined);
-			}
-		}
+			return fn(client);
+		};
 
-		const resolvedHeaders = await resolveSecretReferences(server.config.headers);
-		const transport = new StreamableHTTPClientTransport(new URL(server.config.url), {
-			requestInit: {
-				headers: resolvedHeaders,
-			},
-		});
-		await client.connect(transport);
 		try {
-			return await fn(client);
+			return await withMarketplaceMcpTimeout(run(), timeoutMs, `MCP server ${server.id}`, close);
 		} finally {
-			await client.close().catch(() => undefined);
+			await close();
 		}
-	};
-
-	return withTimeout(run(), server.config.timeoutMs, `MCP server ${server.id}`);
+	});
 }
 
 function sanitizeToolName(name: string): string {
@@ -991,74 +985,86 @@ async function loadMarketplaceTools(
 		return cached;
 	}
 
-	const enabled = installed.filter((s) => s.enabled);
-	const toolBuckets = await Promise.all(
-		enabled.map(
-			async (
-				server,
-			): Promise<{
-				tools: MarketplaceMcpTool[];
-				health: MarketplaceMcpServerHealth;
-			}> => {
-				try {
-					const listResult = await withConnectedClient(server, async (client) => {
-						const result = (await client.listTools()) as {
-							tools?: Array<{
-								name: string;
-								description?: string;
-								inputSchema?: unknown;
-								annotations?: { readOnlyHint?: boolean };
-							}>;
+	const existingLoad = toolsLoadInFlight.get(cacheKey);
+	if (existingLoad) return existingLoad;
+
+	const load = (async (): Promise<MarketplaceToolsCache> => {
+		const enabled = installed.filter((s) => s.enabled);
+		const toolBuckets = await Promise.all(
+			enabled.map(
+				async (
+					server,
+				): Promise<{
+					tools: MarketplaceMcpTool[];
+					health: MarketplaceMcpServerHealth;
+				}> => {
+					try {
+						const listResult = await withConnectedClient(server, async (client) => {
+							const result = (await client.listTools()) as {
+								tools?: Array<{
+									name: string;
+									description?: string;
+									inputSchema?: unknown;
+									annotations?: { readOnlyHint?: boolean };
+								}>;
+							};
+							return result.tools ?? [];
+						});
+
+						const tools = listResult
+							.filter((tool) => typeof tool.name === "string" && tool.name.length > 0)
+							.map((tool) => ({
+								id: `${server.id}:${sanitizeToolName(tool.name)}`,
+								serverId: server.id,
+								serverName: server.name,
+								toolName: tool.name,
+								description: tool.description ?? "",
+								readOnly: tool.annotations?.readOnlyHint === true,
+								inputSchema: tool.inputSchema ?? {},
+							}));
+
+						return {
+							tools,
+							health: {
+								serverId: server.id,
+								serverName: server.name,
+								ok: true,
+								toolCount: tools.length,
+							},
 						};
-						return result.tools ?? [];
-					});
+					} catch (error) {
+						const msg = error instanceof Error ? error.message : String(error);
+						return {
+							tools: [],
+							health: {
+								serverId: server.id,
+								serverName: server.name,
+								ok: false,
+								toolCount: 0,
+								error: msg,
+							},
+						};
+					}
+				},
+			),
+		);
 
-					const tools = listResult
-						.filter((tool) => typeof tool.name === "string" && tool.name.length > 0)
-						.map((tool) => ({
-							id: `${server.id}:${sanitizeToolName(tool.name)}`,
-							serverId: server.id,
-							serverName: server.name,
-							toolName: tool.name,
-							description: tool.description ?? "",
-							readOnly: tool.annotations?.readOnlyHint === true,
-							inputSchema: tool.inputSchema ?? {},
-						}));
+		const nextCache: MarketplaceToolsCache = {
+			fetchedAt: now,
+			tools: toolBuckets.flatMap((b) => b.tools),
+			serverHealth: toolBuckets.map((b) => b.health),
+		};
 
-					return {
-						tools,
-						health: {
-							serverId: server.id,
-							serverName: server.name,
-							ok: true,
-							toolCount: tools.length,
-						},
-					};
-				} catch (error) {
-					const msg = error instanceof Error ? error.message : String(error);
-					return {
-						tools: [],
-						health: {
-							serverId: server.id,
-							serverName: server.name,
-							ok: false,
-							toolCount: 0,
-							error: msg,
-						},
-					};
-				}
-			},
-		),
-	);
+		toolsCache.set(cacheKey, nextCache);
+		return nextCache;
+	})();
 
-	const nextCache: MarketplaceToolsCache = {
-		fetchedAt: now,
-		tools: toolBuckets.flatMap((b) => b.tools),
-		serverHealth: toolBuckets.map((b) => b.health),
-	};
-
-	toolsCache.set(cacheKey, nextCache);
-	return nextCache;
+	toolsLoadInFlight.set(cacheKey, load);
+	try {
+		return await load;
+	} finally {
+		if (toolsLoadInFlight.get(cacheKey) === load) toolsLoadInFlight.delete(cacheKey);
+	}
 }
 
 function invalidateMarketplaceToolsCache(): void {
@@ -1150,6 +1156,7 @@ export function mountMarketplaceRoutes(app: Hono): void {
 			count: visible.length,
 			scoped,
 			context,
+			runtime: getMarketplaceMcpRuntimeStatus(),
 		});
 	});
 
@@ -1494,10 +1501,21 @@ export function mountMarketplaceRoutes(app: Hono): void {
 				count: cached.tools.length,
 				context,
 				policy: readExposurePolicy(),
+				runtime: getMarketplaceMcpRuntimeStatus(),
 			});
 		} catch (error) {
 			logger.error("skills", "Failed to load marketplace MCP tools", error as Error);
-			return c.json({ tools: [], servers: [], count: 0, error: "Failed to load tools", context }, 500);
+			return c.json(
+				{
+					tools: [],
+					servers: [],
+					count: 0,
+					error: "Failed to load tools",
+					context,
+					runtime: getMarketplaceMcpRuntimeStatus(),
+				},
+				500,
+			);
 		}
 	});
 
@@ -1526,10 +1544,14 @@ export function mountMarketplaceRoutes(app: Hono): void {
 				count: ranked.length,
 				results: ranked,
 				context,
+				runtime: getMarketplaceMcpRuntimeStatus(),
 			});
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
-			return c.json({ query, count: 0, results: [], error: message, context }, 500);
+			return c.json(
+				{ query, count: 0, results: [], error: message, context, runtime: getMarketplaceMcpRuntimeStatus() },
+				500,
+			);
 		}
 	});
 

--- a/web/docs/src/content/docs/api/route-inventory.md
+++ b/web/docs/src/content/docs/api/route-inventory.md
@@ -151,6 +151,11 @@ silently disappear from the API reference.
 | GET | `/api/os/widget/:id` | platform/daemon/src/routes/widget.ts |
 | DELETE | `/api/os/widget/:id` | platform/daemon/src/routes/widget.ts |
 
+`GET /api/marketplace/mcp` and the marketplace tools/search responses include a
+`runtime` object with `activeClients`, `activeProcesses`, `pending`, and
+`limit`. The counts cover marketplace discovery, probes, and user operations;
+the limit is the daemon-wide client/process budget.
+
 
 ## Dashboard
 

--- a/web/docs/src/content/docs/configuration/security-lifecycle.md
+++ b/web/docs/src/content/docs/configuration/security-lifecycle.md
@@ -230,6 +230,7 @@ editing the config file is impractical.
 | `SIGNET_SESSION_START_TIMEOUT` | `15000` | Session-start daemon wait budget in ms for Signet-managed clients. Generated Claude Code hook config writes this value directly. Generated Codex hook config rounds up to seconds and adds 5 seconds of harness grace |
 | `SIGNET_FETCH_TIMEOUT` | `15000` | Legacy fallback for session-start timeout in ms when `SIGNET_SESSION_START_TIMEOUT` is unset |
 | `SIGNET_PROMPT_SUBMIT_TIMEOUT` | `5000` | Prompt-submit daemon wait budget in ms; OpenCode uses this value directly, generated Claude Code hook config writes this value + 2000 ms grace, and generated Codex hook config rounds up to seconds and adds 2 seconds of harness grace |
+| `SIGNET_MARKETPLACE_MAX_CONCURRENT_CLIENTS` | `4` | Maximum concurrent marketplace MCP clients, including stdio child processes; bounded to 1-16 |
 | `SIGNET_TRUSTED_PROVIDER_ENDPOINT_HOSTS` | — | Comma-separated host allowlist for Anthropic endpoint overrides used during credentialed startup preflight (supports entries like `proxy.example.com` and `*.example.com`) |
 | `OPENAI_API_KEY` | — | OpenAI key when embedding provider is `openai` |
 


### PR DESCRIPTION
## Summary

Fixes #1345 by bounding marketplace MCP client and stdio subprocess activity in the daemon while preserving parallel discovery throughput.

## Changes

- Added a daemon-wide FIFO budget (default 4, configurable from 1-16) shared by marketplace discovery, probes, test calls, tool calls, and resource reads.
- Counted stdio processes explicitly, closed timed-out clients before releasing permits, and coalesced simultaneous tool-cache misses.
- Exposed current marketplace runtime counts and the configured limit for operational diagnosis.
- Added concurrency, timeout, and running-route regression coverage plus configuration/API documentation.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

Not applicable; no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No database or data migrations.

## Testing

- [x] Focused `bun test platform/daemon/src/marketplace-client-budget.test.ts platform/daemon/src/routes/marketplace.test.ts` — 9 passed, 0 failed.
- [x] `bun run --filter '@signet/daemon' typecheck` — passed.
- [x] Targeted Biome check on all changed TypeScript files — passed.
- [x] `bun run build:core` and `bun run --filter '@signet/daemon' build` — passed.
- [x] Tested against a running daemon with an isolated `SIGNET_PATH`; `/health/live` passed and `/api/marketplace/mcp` reported the configured runtime limit and idle counters.
- [x] `bun scripts/spec-deps-check.ts` — passed.
- [ ] Full workspace `bun run typecheck` — attempted; daemon/docs/core packages pass, but existing connector packages fail on missing generated workspace modules and unrelated type errors.
- [ ] Full workspace `bun run test` — attempted with an isolated `SIGNET_PATH`; marketplace tests passed, but unrelated baseline/environment failures remain (daemon: 2249 passed, 7 skipped, 171 failed, 14 errors; root command exited 1).
- [ ] Full workspace `bun run lint` — attempted; existing repository-wide formatting diagnostics remain (498 errors and 157 warnings across 1354 files), while changed-file checks pass.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Reviewed `docs/specs/INDEX.md` and `docs/specs/dependencies.yaml`. This is operational hardening of the existing marketplace MCP contract, not a new ontology, schema, or product contract, so no spec registry change is required. The new `SIGNET_MARKETPLACE_MAX_CONCURRENT_CLIENTS` setting defaults to 4 and is clamped to 1-16. The repository doc-drift report still contains unrelated existing route, migration, and package-table drift.
