### PR TITLE
fix(daemon): expose bounded workload pressure diagnostics

### DIFF
--- a/platform/daemon/src/inference-router.test.ts
+++ b/platform/daemon/src/inference-router.test.ts
@@ -784,6 +784,12 @@ describe("InferenceRouter background quiescence", () => {
 				timeoutMs: 30_000,
 			});
 			await started;
+			expect(router.getBackgroundWorkloadDiagnostics("default")).toMatchObject({
+				active: 1,
+				agentSessions: 0,
+				byOperation: { memory_extraction: 1 },
+			});
+			expect(router.getBackgroundWorkloadDiagnostics("other").active).toBe(0);
 
 			expect(await router.quiesceBackgroundInference(1_000)).toEqual({
 				activeAtStart: 1,

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -60,6 +60,14 @@ export interface BackgroundInferenceQuiescence {
 	readonly timedOut: boolean;
 }
 
+export interface BackgroundWorkloadDiagnostics {
+	readonly active: number;
+	readonly agentSessions: number;
+	readonly oldestAgeMs: number | null;
+	readonly oldestAgentSessionAgeMs: number | null;
+	readonly byOperation: Readonly<Partial<Record<RoutingOperationKind, number>>>;
+}
+
 export interface InferenceExecutionAttempt {
 	readonly targetRef: string;
 	readonly ok: boolean;
@@ -300,7 +308,16 @@ export class InferenceRouter {
 	private providerCacheSignature: string | null = null;
 	private lastValidationSignature: string | null = null;
 	private backgroundAdmissionsOpen = true;
-	private readonly activeBackgroundExecutions = new Map<number, AbortController>();
+	private readonly activeBackgroundExecutions = new Map<
+		number,
+		{
+			readonly controller: AbortController;
+			readonly operation: RoutingOperationKind;
+			readonly agentId: string;
+			readonly kind: "inference" | "agent";
+			readonly startedAt: number;
+		}
+	>();
 	private readonly backgroundSettledWaiters = new Set<() => void>();
 	private nextBackgroundExecutionId = 1;
 
@@ -327,7 +344,7 @@ export class InferenceRouter {
 	async quiesceBackgroundInference(timeoutMs = 5_000): Promise<BackgroundInferenceQuiescence> {
 		this.backgroundAdmissionsOpen = false;
 		const activeAtStart = this.activeBackgroundExecutions.size;
-		for (const controller of this.activeBackgroundExecutions.values()) controller.abort();
+		for (const execution of this.activeBackgroundExecutions.values()) execution.controller.abort();
 		if (this.activeBackgroundExecutions.size === 0) {
 			return { activeAtStart, aborted: activeAtStart, remaining: 0, timedOut: false };
 		}
@@ -354,13 +371,43 @@ export class InferenceRouter {
 
 	private beginBackgroundExecution(
 		operation: RoutingOperationKind,
+		agentId: string | undefined,
+		kind: "inference" | "agent",
 	): { readonly id: number; readonly signal: AbortSignal } | null | undefined {
 		if (!BACKGROUND_OPERATIONS.has(operation)) return undefined;
 		if (!this.backgroundAdmissionsOpen) return null;
 		const id = this.nextBackgroundExecutionId++;
 		const controller = new AbortController();
-		this.activeBackgroundExecutions.set(id, controller);
+		this.activeBackgroundExecutions.set(id, {
+			controller,
+			operation,
+			agentId: agentId?.trim() || "default",
+			kind,
+			startedAt: Date.now(),
+		});
 		return { id, signal: controller.signal };
+	}
+
+	getBackgroundWorkloadDiagnostics(agentId = "default"): BackgroundWorkloadDiagnostics {
+		const byOperation: Partial<Record<RoutingOperationKind, number>> = {};
+		const scopedAgentId = agentId.trim() || "default";
+		let active = 0;
+		let agentSessions = 0;
+		let oldestAgeMs: number | null = null;
+		let oldestAgentSessionAgeMs: number | null = null;
+		const now = Date.now();
+		for (const execution of this.activeBackgroundExecutions.values()) {
+			if (execution.agentId !== scopedAgentId) continue;
+			active += 1;
+			byOperation[execution.operation] = (byOperation[execution.operation] ?? 0) + 1;
+			const ageMs = Math.max(0, now - execution.startedAt);
+			oldestAgeMs = oldestAgeMs === null ? ageMs : Math.max(oldestAgeMs, ageMs);
+			if (execution.kind === "agent") {
+				agentSessions += 1;
+				oldestAgentSessionAgeMs = oldestAgentSessionAgeMs === null ? ageMs : Math.max(oldestAgentSessionAgeMs, ageMs);
+			}
+		}
+		return { active, agentSessions, oldestAgeMs, oldestAgentSessionAgeMs, byOperation };
 	}
 
 	private finishBackgroundExecution(id: number | undefined): void {
@@ -796,7 +843,7 @@ export class InferenceRouter {
 			readonly abortSignal?: AbortSignal;
 		},
 	): Promise<RouterResult<InferenceExecutionResult>> {
-		const background = this.beginBackgroundExecution(request.operation);
+		const background = this.beginBackgroundExecution(request.operation, request.agentId, "inference");
 		if (background === null) {
 			return {
 				ok: false,
@@ -837,7 +884,7 @@ export class InferenceRouter {
 			};
 		},
 	): Promise<RouterResult<InferenceAgentExecutionResult>> {
-		const background = this.beginBackgroundExecution(request.operation);
+		const background = this.beginBackgroundExecution(request.operation, request.agentId, "agent");
 		if (background === null) {
 			return { ok: false, error: { code: "execution-failed", message: "Background inference is paused." } };
 		}

--- a/platform/daemon/src/mcp/route.ts
+++ b/platform/daemon/src/mcp/route.ts
@@ -11,6 +11,40 @@ import type { Context } from "hono";
 import type { Hono } from "hono";
 import { createMcpServer } from "./tools.js";
 
+interface ActiveMcpRequest {
+	readonly agentId: string;
+	readonly startedAt: number;
+}
+
+const activeMcpRequests = new Map<number, ActiveMcpRequest>();
+let nextMcpRequestId = 1;
+
+export interface McpWorkloadDiagnostics {
+	readonly inFlight: number;
+	readonly oldestAgeMs: number | null;
+}
+
+export function getMcpWorkloadDiagnostics(agentId = "default"): McpWorkloadDiagnostics {
+	const scopedAgentId = agentId.trim() || "default";
+	const now = Date.now();
+	let inFlight = 0;
+	let oldestAgeMs: number | null = null;
+	for (const request of activeMcpRequests.values()) {
+		if (request.agentId !== scopedAgentId) continue;
+		inFlight += 1;
+		const ageMs = Math.max(0, now - request.startedAt);
+		oldestAgeMs = oldestAgeMs === null ? ageMs : Math.max(oldestAgeMs, ageMs);
+	}
+	return { inFlight, oldestAgeMs };
+}
+
+function resolveMcpWorkloadAgentId(c: Context): string {
+	const scopedAgentId = c.get("auth")?.claims?.scope.agent?.trim();
+	if (scopedAgentId) return scopedAgentId;
+	const requestedAgentId = c.req.query("agentId") ?? c.req.header("x-signet-agent-id") ?? "default";
+	return requestedAgentId.trim() || "default";
+}
+
 export function mountMcpRoute(app: Hono): void {
 	// POST /mcp — main MCP message endpoint
 	// GET /mcp — SSE stream for server-initiated notifications
@@ -20,35 +54,43 @@ export function mountMcpRoute(app: Hono): void {
 		if (parsedBody instanceof Response) {
 			return parsedBody;
 		}
-
-		const transport = new WebStandardStreamableHTTPServerTransport({
-			sessionIdGenerator: undefined, // stateless
-			enableJsonResponse: true,
+		const requestId = nextMcpRequestId++;
+		activeMcpRequests.set(requestId, {
+			agentId: resolveMcpWorkloadAgentId(c),
+			startedAt: Date.now(),
 		});
-
-		const harness = c.req.query("harness") ?? c.req.header("x-signet-harness") ?? undefined;
-		const workspace = c.req.query("workspace") ?? c.req.header("x-signet-workspace") ?? undefined;
-		const channel = c.req.query("channel") ?? c.req.header("x-signet-channel") ?? undefined;
-
-		const server = await createMcpServer({
-			authorizationHeader: c.req.header("authorization"),
-			context: {
-				harness,
-				workspace,
-				channel,
-			},
-		});
-		await server.connect(transport);
-
+		let transport: WebStandardStreamableHTTPServerTransport | null = null;
+		let server: Awaited<ReturnType<typeof createMcpServer>> | null = null;
 		try {
-			const response = await transport.handleRequest(
-				c.req.raw,
-				parsedBody === undefined ? undefined : { parsedBody },
-			);
+			transport = new WebStandardStreamableHTTPServerTransport({
+				sessionIdGenerator: undefined, // stateless
+				enableJsonResponse: true,
+			});
+			const harness = c.req.query("harness") ?? c.req.header("x-signet-harness") ?? undefined;
+			const workspace = c.req.query("workspace") ?? c.req.header("x-signet-workspace") ?? undefined;
+			const channel = c.req.query("channel") ?? c.req.header("x-signet-channel") ?? undefined;
+
+			server = await createMcpServer({
+				authorizationHeader: c.req.header("authorization"),
+				context: {
+					harness,
+					workspace,
+					channel,
+				},
+			});
+			await server.connect(transport);
+			const response = await transport.handleRequest(c.req.raw, parsedBody === undefined ? undefined : { parsedBody });
 			return response;
 		} finally {
-			await transport.close();
-			await server.close();
+			try {
+				if (transport) await transport.close();
+			} finally {
+				try {
+					if (server) await server.close();
+				} finally {
+					activeMcpRequests.delete(requestId);
+				}
+			}
 		}
 	});
 }

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -7,7 +7,10 @@ import { requirePermission, requireRateLimit } from "../auth";
 import { getDbAccessor } from "../db-accessor.js";
 import { type QueueCounts, getQueueDiagnosticsSnapshot } from "../diagnostics-queue.js";
 import { readEmbeddingUsageSummary } from "../embedding-usage";
+import { getInferenceRouterOrNull } from "../inference-router.js";
+import type { BackgroundWorkloadDiagnostics } from "../inference-router.js";
 import { getLlmProvider } from "../llm.js";
+import { getMcpWorkloadDiagnostics } from "../mcp/route.js";
 import { graphWriteCaps, loadMemoryConfig } from "../memory-config.js";
 import { listMemoryContentSafety, parseMemorySafetyReasons } from "../memory-content-safety.js";
 import {
@@ -101,6 +104,30 @@ function pipelineQueueBlock(): PipelineQueueBlock {
 			oldestDeadSummaryJob: null,
 		};
 	}
+}
+
+function workloadDiagnosticsSnapshot(agentId: string): {
+	readonly inference: BackgroundWorkloadDiagnostics;
+	readonly mcp: ReturnType<typeof getMcpWorkloadDiagnostics>;
+} {
+	const inference: BackgroundWorkloadDiagnostics = getInferenceRouterOrNull()?.getBackgroundWorkloadDiagnostics(
+		agentId,
+	) ?? {
+		active: 0,
+		agentSessions: 0,
+		oldestAgeMs: null,
+		oldestAgentSessionAgeMs: null,
+		byOperation: {},
+	};
+	return { inference, mcp: getMcpWorkloadDiagnostics(agentId) };
+}
+
+function workloadDiagnostics(c: Context): Response {
+	const requestedAgentId = c.req.query("agentId") ?? c.req.query("agent_id") ?? c.req.header("x-signet-agent-id");
+	const scopedAgent = resolveScopedAgentId(c, requestedAgentId, resolveDaemonAgentId());
+	if (scopedAgent.error) return c.json({ error: scopedAgent.error }, 403);
+	const agentId = resolveAgentId({ agentId: scopedAgent.agentId });
+	return c.json({ agentId, ...workloadDiagnosticsSnapshot(agentId) });
 }
 
 const pipelineAdminGuard = async (c: Context, next: () => Promise<void>): Promise<Response | undefined> => {
@@ -219,6 +246,8 @@ export function registerPipelineRoutes(app: Hono): void {
 		const agentId = resolveAgentId({ agentId: scopedAgent.agentId });
 		return c.json(getTranscriptHealthReport(getDbAccessor(), AGENTS_DIR, agentId));
 	});
+
+	app.get("/api/diagnostics/workloads", (c) => workloadDiagnostics(c));
 
 	app.get("/api/status", (c) => {
 		const config = loadMemoryConfig(AGENTS_DIR);
@@ -366,7 +395,14 @@ export function registerPipelineRoutes(app: Hono): void {
 
 	app.get("/api/diagnostics", (c) => {
 		const report = getCachedDiagnosticsReport();
-		return c.json(report);
+		const requestedAgentId = c.req.query("agentId") ?? c.req.query("agent_id") ?? c.req.header("x-signet-agent-id");
+		const scopedAgent = resolveScopedAgentId(c, requestedAgentId, resolveDaemonAgentId());
+		if (scopedAgent.error) return c.json({ error: scopedAgent.error }, 403);
+		const agentId = resolveAgentId({ agentId: scopedAgent.agentId });
+		return c.json({
+			...report,
+			workloads: { agentId, ...workloadDiagnosticsSnapshot(agentId) },
+		});
 	});
 
 	app.get("/api/diagnostics/memory-content-safety", (c) => {
@@ -426,7 +462,7 @@ export function registerPipelineRoutes(app: Hono): void {
 		// domain route. Let each return its own response rather than a cached
 		// aggregate subobject. Any new single-segment diagnostics route must
 		// either be registered before this route or be added here.
-		if (domain === "queue" || domain === "openclaw") return next();
+		if (domain === "queue" || domain === "openclaw" || domain === "workloads") return next();
 		const report = getCachedDiagnosticsReport();
 
 		const domainData = report[domain as keyof typeof report];

--- a/web/docs/src/content/docs/api/health-status.md
+++ b/web/docs/src/content/docs/api/health-status.md
@@ -312,6 +312,33 @@ use `GET /api/diagnostics/transcripts` for detailed artifact/audit diagnostics.
 Use `GET /api/inference/status` for the shared inference control plane status.
 
 
+### GET /api/diagnostics/workloads
+
+Returns bounded in-flight workload pressure for one resolved agent. The
+inference snapshot covers background routed work and Pi agent sessions; the
+MCP snapshot covers stateless Streamable HTTP requests. Counts are held in
+memory and ages are calculated from admission time, so this endpoint does not
+scan durable queue tables. `agentId` may be supplied as a query parameter or
+`x-signet-agent-id` header; scoped deployments reject requests for another
+agent.
+
+**Response**
+
+```json
+{
+  "agentId": "default",
+  "inference": {
+    "active": 1,
+    "agentSessions": 1,
+    "oldestAgeMs": 3200,
+    "oldestAgentSessionAgeMs": 3200,
+    "byOperation": { "memory_extraction": 1 }
+  },
+  "mcp": { "inFlight": 0, "oldestAgeMs": null }
+}
+```
+
+
 ### GET /api/diagnostics/queue
 
 Per-queue counts (memory / summary), oldest-dead job

--- a/web/docs/src/content/docs/api/operations.md
+++ b/web/docs/src/content/docs/api/operations.md
@@ -207,10 +207,13 @@ metadata. When graph is enabled, `graph.status` is included in composite status
 so a flatlined knowledge graph cannot be hidden behind otherwise healthy
 storage and index signals. Dreaming is the sole automatic semantic writer;
 graph diagnostics report graph health without exposing a retired extractor gate.
+When `agentId` is supplied in a scoped deployment, it must match the
+authenticated agent scope; the embedded `workloads` snapshot is for that
+resolved agent.
 
 **Response** — a multi-domain report object. Domains include `queue`,
 `storage`, `index`, `provider`, `mutation`, `duplicate`, `connector`, `update`,
-`graph`, `openclaw`, and `composite`. The `composite` field looks like:
+`graph`, `openclaw`, `composite`, and `workloads`. The `composite` field looks like:
 
 ```json
 { "score": 0.95, "status": "healthy" }
@@ -231,6 +234,20 @@ session transcript row age metadata, manifest/artifact counts, pending or failed
 summary counts, missing transcript/summary artifact counts, and transcript audit
 log metadata. Agent-scoped requests do not expose legacy flat audit log counts
 because those filenames are not agent-scoped.
+
+### GET /api/diagnostics/workloads
+
+Returns bounded in-flight workload pressure for one resolved agent. The
+inference snapshot covers background routed work and Pi agent sessions; the
+MCP snapshot covers stateless Streamable HTTP requests. Counts are held in
+memory and ages are calculated from admission time, so this endpoint does not
+scan durable queue tables. `agentId` may be supplied as a query parameter or
+`x-signet-agent-id` header; scoped deployments reject requests for another
+agent.
+
+The response contains `agentId`, `inference` (`active`, `agentSessions`,
+`oldestAgeMs`, `oldestAgentSessionAgeMs`, and per-operation `byOperation`), and
+`mcp` (`inFlight` and `oldestAgeMs`).
 
 ### GET /api/diagnostics/memory-content-safety
 

--- a/web/docs/src/content/docs/api/route-inventory.md
+++ b/web/docs/src/content/docs/api/route-inventory.md
@@ -125,6 +125,7 @@ silently disappear from the API reference.
 | GET | `/api/diagnostics/openclaw` | platform/daemon/src/routes/pipeline-routes.ts |
 | GET | `/api/diagnostics/transcripts` | platform/daemon/src/routes/pipeline-routes.ts |
 | GET | `/api/diagnostics/memory-content-safety` | platform/daemon/src/routes/pipeline-routes.ts |
+| GET | `/api/diagnostics/workloads` | platform/daemon/src/routes/pipeline-routes.ts |
 | GET | `/api/pipeline/models` | platform/daemon/src/routes/pipeline-routes.ts |
 | GET | `/api/pipeline/models/by-provider` | platform/daemon/src/routes/pipeline-routes.ts |
 | POST | `/api/pipeline/models/refresh` | platform/daemon/src/routes/pipeline-routes.ts |


### PR DESCRIPTION
## Summary

Adds bounded workload-pressure diagnostics for issue #1339. The daemon now exposes per-agent in-flight background inference, Pi/agent-session, and stateless MCP request counts with oldest ages, while preserving the existing durable queue backlog diagnostics.

## Changes

- Track background routed executions with operation, agent scope, kind, and admission time.
- Add `GET /api/diagnostics/workloads` and include its scoped snapshot in `GET /api/diagnostics`.
- Track stateless MCP requests in memory and prefer authenticated agent scope over spoofable request headers.
- Keep diagnostics in-memory and bounded to active work; no new durable-table scan or metrics subsystem.
- Add regression coverage for active accounting and cross-agent isolation; update API docs and route inventory.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/daemon`
- [ ] `@signet/core`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: API documentation under `web/docs`

## Screenshots

N/A: no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

Not applicable: no migrations are included.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Exact checks run:
- `bun run --filter '@signet/core' build`
- `bun run --filter '@signet/daemon' build`
- 51 focused tests across inference-router, MCP route, queue diagnostics, and diagnostics queue-pressure suites: 51 pass, 0 fail
- `bun run --filter '@signet/daemon' typecheck`
- targeted Biome check and `git diff --check`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- The branch is rebased onto current `origin/main` (0.194.0 release base).
- An independent adversarial review returned SHIP with no CRITICAL/HIGH findings. It identified and this branch fixed MCP attribution precedence and transport-constructor cleanup hardening.
- The full repository test/lint suite was not run; the checks above are the relevant package and focused gates.
- `bun scripts/doc-drift.ts` still reports pre-existing missing route/package-table documentation elsewhere in the repository; the new workload route is present in the API inventory and the migration check remains clean.
