### PR TITLE
fix(daemon): cap document ingest concurrency

### DIFF
--- a/platform/daemon/src/pipeline/document-worker.test.ts
+++ b/platform/daemon/src/pipeline/document-worker.test.ts
@@ -1,0 +1,158 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it } from "bun:test";
+import { runMigrations } from "../../../core/src/migrations";
+import { createConcurrencyAdmission } from "../concurrency-admission";
+import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
+import type { EmbeddingConfig, PipelineV2Config } from "../memory-config";
+import { DEFAULT_PIPELINE_V2 } from "../memory-config";
+import { startDocumentWorker } from "./document-worker";
+
+function freshDb(): Database {
+	const db = new Database(":memory:");
+	runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+	return db;
+}
+
+function asAccessor(db: Database): DbAccessor {
+	return {
+		withWriteTx<T>(fn: (wdb: WriteDb) => T): T {
+			db.exec("BEGIN IMMEDIATE");
+			try {
+				const result = fn(db as unknown as WriteDb);
+				db.exec("COMMIT");
+				return result;
+			} catch (err) {
+				db.exec("ROLLBACK");
+				throw err;
+			}
+		},
+		withReadDb<T>(fn: (rdb: ReadDb) => T): T {
+			return fn(db as unknown as ReadDb);
+		},
+		close(): void {
+			db.close();
+		},
+	};
+}
+
+const embeddingCfg: EmbeddingConfig = {
+	provider: "none",
+	model: "test",
+	dimensions: 1,
+	base_url: "",
+};
+
+function workerConfig(): PipelineV2Config {
+	return {
+		...DEFAULT_PIPELINE_V2,
+		documents: {
+			...DEFAULT_PIPELINE_V2.documents,
+			workerIntervalMs: 1,
+			chunkSize: 1_000,
+			chunkOverlap: 0,
+		},
+	};
+}
+
+function insertDocumentJob(db: Database, id: string, agentId: string, content: string): void {
+	const now = new Date().toISOString();
+	db.prepare(
+		`INSERT INTO agents (id, name, read_policy, created_at, updated_at)
+		 VALUES (?, ?, 'isolated', ?, ?)`,
+	).run(agentId, agentId, now, now);
+	db.prepare(
+		`INSERT INTO documents
+		 (id, source_type, content_type, content_hash, title, raw_content, status,
+		  chunk_count, memory_count, agent_id, project, created_at, updated_at)
+		 VALUES (?, 'text', 'text/plain', ?, ?, ?, 'queued', 0, 0, ?, NULL, ?, ?)`,
+	).run(id, `${id}-hash`, id, content, agentId, now, now);
+	db.prepare(
+		`INSERT INTO memory_jobs
+		 (id, memory_id, document_id, job_type, status, attempts, max_attempts, created_at, updated_at)
+		 VALUES (?, NULL, ?, 'document_ingest', 'pending', 0, 3, ?, ?)`,
+	).run(`${id}-job`, id, now, now);
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 2_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (condition()) return;
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+	throw new Error("timed out waiting for document worker");
+}
+
+function jobStatus(db: Database, id: string): string {
+	return (db.prepare("SELECT status FROM memory_jobs WHERE id = ?").get(id) as { status: string }).status;
+}
+
+describe("document worker admission", () => {
+	it("shares the cap across worker instances before leasing another job", async () => {
+		const db = freshDb();
+		const accessor = asAccessor(db);
+		insertDocumentJob(db, "doc-a", "agent-a", "slow");
+		insertDocumentJob(db, "doc-b", "agent-b", "other");
+		const admission = createConcurrencyAdmission(1);
+		const started: string[] = [];
+		let unblock = (): void => {};
+		const blocked = new Promise<number[] | null>((resolve) => {
+			unblock = () => resolve(null);
+		});
+		const config = workerConfig();
+		const makeDeps = () => ({
+			accessor,
+			admission,
+			embeddingCfg,
+			fetchEmbedding: async (content: string): Promise<number[] | null> => {
+				started.push(content);
+				if (content === "slow") return blocked;
+				return null;
+			},
+			pipelineCfg: config,
+		});
+		const workerA = startDocumentWorker(makeDeps());
+		const workerB = startDocumentWorker(makeDeps());
+		try {
+			await waitFor(() => started.length === 1);
+			await new Promise((resolve) => setTimeout(resolve, 25));
+			expect(started).toEqual(["slow"]);
+			expect(admission.inFlight()).toBe(1);
+			expect(jobStatus(db, "doc-a-job")).toBe("leased");
+			expect(jobStatus(db, "doc-b-job")).toBe("pending");
+
+			unblock();
+			await waitFor(() => jobStatus(db, "doc-a-job") === "completed" && jobStatus(db, "doc-b-job") === "completed");
+		} finally {
+			unblock();
+			await Promise.all([workerA.stop(), workerB.stop()]);
+			db.close();
+		}
+	});
+
+	it("releases admission after failure so another agent's job is not starved", async () => {
+		const db = freshDb();
+		const accessor = asAccessor(db);
+		insertDocumentJob(db, "doc-fail", "agent-a", "fail");
+		insertDocumentJob(db, "doc-ok", "agent-b", "ok");
+		const started: string[] = [];
+		const worker = startDocumentWorker({
+			accessor,
+			admission: createConcurrencyAdmission(1),
+			embeddingCfg,
+			fetchEmbedding: async (content: string): Promise<number[] | null> => {
+				started.push(content);
+				if (content === "fail") throw new Error("provider unavailable");
+				return null;
+			},
+			pipelineCfg: workerConfig(),
+		});
+		try {
+			await waitFor(() => jobStatus(db, "doc-ok-job") === "completed");
+			expect(started).toContain("ok");
+			expect(jobStatus(db, "doc-fail-job")).not.toBe("leased");
+		} finally {
+			await worker.stop();
+			db.close();
+		}
+	});
+});

--- a/platform/daemon/src/pipeline/document-worker.ts
+++ b/platform/daemon/src/pipeline/document-worker.ts
@@ -9,6 +9,7 @@
  * calls inside write locks.
  */
 
+import { type ConcurrencyAdmission, createConcurrencyAdmission } from "../concurrency-admission";
 import { normalizeAndHashContent } from "../content-normalization";
 import type { DbAccessor, WriteDb } from "../db-accessor";
 import { syncVecInsert, vectorToBlob } from "../db-helpers";
@@ -32,8 +33,15 @@ export interface DocumentWorkerHandle {
 	readonly running: boolean;
 }
 
+/** Keep URL, chunking, and embedding work bounded before leasing another job. */
+export const DOCUMENT_WORK_MAX_IN_FLIGHT = 2;
+
+const sharedDocumentAdmission = createConcurrencyAdmission(DOCUMENT_WORK_MAX_IN_FLIGHT);
+
 export interface DocumentWorkerDeps {
 	readonly accessor: DbAccessor;
+	/** Shared by all document workers in a daemon; injectable for isolated tests. */
+	readonly admission?: ConcurrencyAdmission;
 	readonly embeddingCfg: EmbeddingConfig;
 	readonly fetchEmbedding: (
 		text: string,
@@ -551,6 +559,7 @@ async function processDocument(
 export function startDocumentWorker(deps: DocumentWorkerDeps): DocumentWorkerHandle {
 	let running = true;
 	let timer: ReturnType<typeof setInterval> | null = null;
+	const admission = deps.admission ?? sharedDocumentAdmission;
 	const operations = new Map<
 		string,
 		{ readonly startedAtMs: number; readonly firstLeaseAtMs: number; readonly state: MutableDocumentOperation }
@@ -624,54 +633,59 @@ export function startDocumentWorker(deps: DocumentWorkerDeps): DocumentWorkerHan
 	async function tick(): Promise<void> {
 		if (!running) return;
 		if (isSystemPressureHigh()) return;
-
-		const leasedAt = Date.now();
-		const job = deps.accessor.withWriteTx((db) => leaseDocumentJob(db, deps.pipelineCfg.worker.maxRetries));
-
-		if (!job) return;
-		const operation = operations.get(job.id) ?? {
-			startedAtMs: leasedAt,
-			firstLeaseAtMs: leasedAt,
-			state: { accepted: 0, skipped: 0, failed: 0, cancelled: false, operationClass: "indexing" },
-		};
-		operations.set(job.id, operation);
+		if (!admission.acquire()) return;
 
 		try {
-			await processDocument(deps, job, operation.state);
-			const status = terminalStatus(job.id);
-			if (status === "completed" || status === "dead") {
-				emitOperation(job, operation);
-				operations.delete(job.id);
-			}
-		} catch (err) {
-			const msg = err instanceof Error ? err.message : String(err);
-			logger.warn("document-worker", "Job failed", {
-				jobId: job.id,
-				documentId: job.document_id,
-				error: msg,
-			});
+			const leasedAt = Date.now();
+			const job = deps.accessor.withWriteTx((db) => leaseDocumentJob(db, deps.pipelineCfg.worker.maxRetries));
 
-			deps.accessor.withWriteTx((db) => {
-				if (job.document_id && isDocumentDeleted(db, job.document_id)) {
-					completeJob(db, job.id);
-					operation.state.skipped++;
-					operation.state.cancelled = true;
-					return;
+			if (!job) return;
+			const operation = operations.get(job.id) ?? {
+				startedAtMs: leasedAt,
+				firstLeaseAtMs: leasedAt,
+				state: { accepted: 0, skipped: 0, failed: 0, cancelled: false, operationClass: "indexing" },
+			};
+			operations.set(job.id, operation);
+
+			try {
+				await processDocument(deps, job, operation.state);
+				const status = terminalStatus(job.id);
+				if (status === "completed" || status === "dead") {
+					emitOperation(job, operation);
+					operations.delete(job.id);
 				}
-				failJob(db, job.id, msg, job.attempts, job.max_attempts);
-				if (job.document_id) {
-					updateDocumentStatus(db, job.document_id, "failed", msg);
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				logger.warn("document-worker", "Job failed", {
+					jobId: job.id,
+					documentId: job.document_id,
+					error: msg,
+				});
+
+				deps.accessor.withWriteTx((db) => {
+					if (job.document_id && isDocumentDeleted(db, job.document_id)) {
+						completeJob(db, job.id);
+						operation.state.skipped++;
+						operation.state.cancelled = true;
+						return;
+					}
+					failJob(db, job.id, msg, job.attempts, job.max_attempts);
+					if (job.document_id) {
+						updateDocumentStatus(db, job.document_id, "failed", msg);
+					}
+				});
+				operation.state.causeFamily ??= normalizePipelineCause(err);
+				const status = terminalStatus(job.id);
+				if (status === "dead") {
+					operation.state.failed++;
 				}
-			});
-			operation.state.causeFamily ??= normalizePipelineCause(err);
-			const status = terminalStatus(job.id);
-			if (status === "dead") {
-				operation.state.failed++;
+				if (status === "dead" || status === "completed") {
+					emitOperation(job, operation);
+					operations.delete(job.id);
+				}
 			}
-			if (status === "dead" || status === "completed") {
-				emitOperation(job, operation);
-				operations.delete(job.id);
-			}
+		} finally {
+			admission.release();
 		}
 	}
 

--- a/web/docs/src/content/docs/pipeline/workers-maintenance.md
+++ b/web/docs/src/content/docs/pipeline/workers-maintenance.md
@@ -50,7 +50,13 @@ The document worker processes `document_ingest` jobs from the same
 `memory_jobs` table. It runs as a fixed-interval polling loop,
 defaulting to 10,000 ms between ticks.
 
-A document ingest job carries a `document_id` rather than a `memory_id`.
+The worker processes at most two documents concurrently across all
+`startDocumentWorker()` instances in the daemon. Admission is checked before
+leasing a `memory_jobs` row, so URL fetch, chunking, embedding, and indexing
+cannot outrun the shared budget. A failed operation releases its slot before
+retry handling runs, and the durable lease/recovery path remains responsible
+for jobs interrupted by shutdown or process failure.
+
 The referenced row in the `documents` table carries the source content and
 type. Two source types are supported: `url` (content fetched via HTTP) and
 anything else (content read from `raw_content`). URL fetch is bounded by


### PR DESCRIPTION
## Summary

Add a shared in-flight admission cap to document ingest before a job is leased or provider work begins. This prevents concurrent worker instances from exceeding the bounded document-processing capacity while preserving existing lease, retry, failure, and recovery behavior.

## Changes

- Add a shared two-job admission cap across `startDocumentWorker()` instances, with injectable admission for tests.
- Release admission on empty queues, success, provider failures, and all other processing exits.
- Add regression coverage for cross-worker capping and release after failure so an unrelated agent's job is not starved.
- Document the cap and its lease/recovery boundary in the worker maintenance guide.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: docs only in `web/docs`

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations touched.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Focused verification on the changed surface passed:

- `bun test platform/daemon/src/pipeline/document-worker.test.ts platform/daemon/src/routes/document-routes.test.ts platform/daemon/src/pipeline/stale-leases.test.ts platform/daemon/src/concurrency-admission.test.ts`: 17 passed, 0 failed.
- `bun run --filter '@signet/core' build`: passed.
- `bun run --filter '@signet/daemon' build`: passed.
- `bun run --filter '@signet/daemon' typecheck`: passed.
- `bunx biome check platform/daemon/src/pipeline/document-worker.ts platform/daemon/src/pipeline/document-worker.test.ts`: passed.
- `git diff --check`: passed.

The full workspace `bun run typecheck` remains blocked by pre-existing unrelated connector bundle/export errors in `@signet/connector-*`, and the full `bun run lint` remains blocked by pre-existing formatting diagnostics across unrelated packages. Core and daemon checks pass. An independent read-only adversarial review inspected the final diff and focused tests but timed out while running the broader daemon suite; the worktree was verified clean afterward and no reviewer changes were present.
