### PR TITLE
fix(daemon): release traversal read connections

### DIFF
--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -34,7 +34,7 @@ import {
 	shouldCheckpoint,
 } from "./continuity-state";
 import { listAgentPresence } from "./cross-agent";
-import { getDbAccessor } from "./db-accessor";
+import { type ReadDb, getDbAccessor } from "./db-accessor";
 import { fetchEmbedding } from "./embedding-fetch";
 import {
 	DEFAULT_SESSION_START_MAX_INJECT_TOKENS,
@@ -842,8 +842,11 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 			traversalEntityNames = focal.entityNames;
 
 			if (focal.entityIds.length > 0) {
-				const traversalResult = await getDbAccessor().withReadDbAsync((db) =>
-					traverseKnowledgeGraph(focal.entityIds, db, traversalAgentId, traversalRuntimeCfg),
+				const traversalResult = await traverseKnowledgeGraph(
+					focal.entityIds,
+					<T>(fn: (db: ReadDb) => T): T => getDbAccessor().withReadDb(fn),
+					traversalAgentId,
+					traversalRuntimeCfg,
 				);
 				traversalTimedOut = traversalResult.timedOut;
 				traversalTraversedEntities = traversalResult.entityCount;

--- a/platform/daemon/src/memory-candidates.ts
+++ b/platform/daemon/src/memory-candidates.ts
@@ -140,14 +140,14 @@ export async function fetchTraversalCandidates(
 	}
 
 	try {
-		const rows = await getDbAccessor().withReadDbAsync(async (db) => {
-			const rows: ScoredMemory[] = [];
-			const yieldBetweenBatches = yieldEvery(1);
+		const rows: ScoredMemory[] = [];
+		const yieldBetweenBatches = yieldEvery(1);
 
-			for (let offset = 0; offset < boundedMemoryIds.length; offset += TRAVERSAL_CANDIDATE_BATCH_SIZE) {
-				const batch = boundedMemoryIds.slice(offset, offset + TRAVERSAL_CANDIDATE_BATCH_SIZE);
-				const placeholders = batch.map(() => "?").join(", ");
-				const batchRows = db
+		for (let offset = 0; offset < boundedMemoryIds.length; offset += TRAVERSAL_CANDIDATE_BATCH_SIZE) {
+			const batch = boundedMemoryIds.slice(offset, offset + TRAVERSAL_CANDIDATE_BATCH_SIZE);
+			const placeholders = batch.map(() => "?").join(", ");
+			const batchRows = getDbAccessor().withReadDb((db) => {
+				const queried = db
 					.prepare(
 						`SELECT
 						 m.id,
@@ -173,21 +173,19 @@ export async function fetchTraversalCandidates(
 					   AND m.is_deleted = 0`,
 					)
 					.all(agentId, ...batch) as unknown as ScoredMemory[];
-				rows.push(
-					...batchRows.filter((row) =>
-						isMemoryContentContextEligible(db, {
-							agentId,
-							sourceKind: "memory",
-							sourceId: row.id,
-							content: row.content,
-						}),
-					),
+				return queried.filter((row) =>
+					isMemoryContentContextEligible(db, {
+						agentId,
+						sourceKind: "memory",
+						sourceId: row.id,
+						content: row.content,
+					}),
 				);
-				await yieldBetweenBatches();
-			}
+			});
+			rows.push(...batchRows);
+			await yieldBetweenBatches();
+		}
 
-			return rows;
-		});
 		return rows.map((row) => ({
 			...row,
 			effScore: clampScore01(row.effScore),

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -25,7 +25,7 @@ import {
 	scanMemoryContent,
 	vectorSearch,
 } from "@signet/core";
-import { getDbAccessor, prepareTypedStatement } from "./db-accessor";
+import { type ReadDb, getDbAccessor, prepareTypedStatement } from "./db-accessor";
 import type { EmbeddingRole } from "./embedding-profile";
 import { getLlmProvider } from "./llm";
 import { logger } from "./logger";
@@ -1693,8 +1693,11 @@ export async function hybridRecall(
 						const focal = getFocalEntities(agentId);
 
 						if (focal.entityIds.length > 0) {
-							const traversal = await getDbAccessor().withReadDbAsync((db) =>
-								traverseKnowledgeGraph(focal.entityIds, db, agentId, {
+							const traversal = await traverseKnowledgeGraph(
+								focal.entityIds,
+								<T>(fn: (db: ReadDb) => T): T => getDbAccessor().withReadDb(fn),
+								agentId,
+								{
 									maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
 									maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,
 									maxDependencyHops: traversalCfg.maxDependencyHops,
@@ -1704,7 +1707,7 @@ export async function hybridRecall(
 									minConfidence: traversalCfg.minConfidence,
 									timeoutMs: traversalCfg.timeoutMs,
 									scope: params.scope,
-								}),
+								},
 							);
 
 							// Cosine re-scoring: when query embedding is available,
@@ -1833,8 +1836,11 @@ export async function hybridRecall(
 						const focal = getFocalEntities(agentId);
 
 						if (focal.entityIds.length > 0) {
-							const traversal = await getDbAccessor().withReadDbAsync((db) =>
-								traverseKnowledgeGraph(focal.entityIds, db, agentId, {
+							const traversal = await traverseKnowledgeGraph(
+								focal.entityIds,
+								<T>(fn: (db: ReadDb) => T): T => getDbAccessor().withReadDb(fn),
+								agentId,
+								{
 									maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
 									maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,
 									maxDependencyHops: traversalCfg.maxDependencyHops,
@@ -1843,7 +1849,7 @@ export async function hybridRecall(
 									maxTraversalPaths: traversalCfg.maxTraversalPaths,
 									minConfidence: traversalCfg.minConfidence,
 									timeoutMs: traversalCfg.timeoutMs,
-								}),
+								},
 							);
 
 							const tw = traversalCfg.boostWeight;

--- a/platform/daemon/src/pipeline/graph-traversal.test.ts
+++ b/platform/daemon/src/pipeline/graph-traversal.test.ts
@@ -33,15 +33,25 @@ function seedGraph(db: Database): void {
 		CREATE INDEX idx_entity_attributes_aspect ON entity_attributes (aspect_id);
 		CREATE INDEX idx_entity_dependencies_source ON entity_dependencies (source_entity_id);
 	`);
-	db.exec(`INSERT INTO entities VALUES ('e1', 'Alpha', 'default'), ('e2', 'Beta', 'default')`);
 	db.exec(
-		`INSERT INTO entity_aspects VALUES ('a1', 'e1', 'default', 1.0, 'preference'), ('a2', 'e2', 'default', 1.0, 'fact')`,
+		`INSERT INTO entities VALUES ('e1', 'Alpha', 'default'), ('e2', 'Beta', 'default'), ('e3', 'Other', 'other')`,
 	);
-	db.exec(`INSERT INTO memories VALUES ('m1', 0.8, 0), ('m2', 0.6, 0), ('m3', 0.5, 0)`);
+	db.exec(
+		`INSERT INTO entity_aspects VALUES
+			('a1', 'e1', 'default', 1.0, 'preference'),
+			('a2', 'e2', 'default', 1.0, 'fact'),
+			('a3', 'e3', 'other', 1.0, 'fact')`,
+	);
+	db.exec(`INSERT INTO memories VALUES
+		('m1', 0.8, 0),
+		('m2', 0.6, 0),
+		('m3', 0.5, 0),
+		('m-other', 0.9, 0)`);
 	db.exec(`INSERT INTO entity_attributes VALUES
 		('a1', 'm1', 'default', 'active', 'fact', 'alpha fact', 0.9),
 		('a1', 'm2', 'default', 'active', 'fact', 'alpha fact 2', 0.7),
-		('a2', 'm3', 'default', 'active', 'fact', 'beta fact', 0.6)`);
+		('a2', 'm3', 'default', 'active', 'fact', 'beta fact', 0.6),
+		('a3', 'm-other', 'other', 'active', 'fact', 'other fact', 0.95)`);
 	db.exec(`INSERT INTO entity_dependencies VALUES ('d1', 'e1', 'e2', 'default', 0.9, 0.8)`);
 	db.exec(`INSERT INTO memory_entity_mentions VALUES ('m1', 'e1', 0.9)`);
 }
@@ -101,5 +111,57 @@ describe("traverseKnowledgeGraph event-loop yields (#1118)", () => {
 		expect(first.memoryIds.size).toBeGreaterThan(0);
 		expect(second.memoryIds.has("m3")).toBe(true);
 		expect(loopBreaths).toBeGreaterThan(0);
+	});
+
+	test("does not retain a read connection across traversal yields (#1348)", async () => {
+		let activeReads = 0;
+		let maxActiveReads = 0;
+		let activeAtYield = 0;
+		const read = <T>(fn: (readDb: ReadDb) => T): T => {
+			activeReads++;
+			maxActiveReads = Math.max(maxActiveReads, activeReads);
+			try {
+				const result = fn(db as unknown as ReadDb);
+				setImmediate(() => {
+					activeAtYield = Math.max(activeAtYield, activeReads);
+				});
+				return result;
+			} finally {
+				activeReads--;
+			}
+		};
+
+		const result = await traverseKnowledgeGraph(["e1"], read, "default", CONFIG);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		expect(result.memoryIds.has("m1")).toBe(true);
+		expect(result.memoryIds.has("m-other")).toBe(false);
+		expect(maxActiveReads).toBe(1);
+		expect(activeAtYield).toBe(0);
+		expect(activeReads).toBe(0);
+	});
+
+	test("releases the read connection when a traversal query fails (#1348)", async () => {
+		let activeReads = 0;
+		const failingDb: ReadDb = {
+			prepare(sql: string) {
+				if (sql.includes("entity_dependencies")) throw new Error("injected traversal failure");
+				return db.prepare(sql) as unknown as ReturnType<ReadDb["prepare"]>;
+			},
+		};
+		const read = <T>(fn: (readDb: ReadDb) => T): T => {
+			activeReads++;
+			try {
+				return fn(failingDb);
+			} finally {
+				activeReads--;
+			}
+		};
+
+		const result = await traverseKnowledgeGraph(["e1"], read, "default", CONFIG);
+
+		expect(result.memoryIds.size).toBe(0);
+		expect(result.constraints).toEqual([]);
+		expect(activeReads).toBe(0);
 	});
 });

--- a/platform/daemon/src/pipeline/graph-traversal.ts
+++ b/platform/daemon/src/pipeline/graph-traversal.ts
@@ -61,6 +61,18 @@ export interface TraversalConfig {
 	readonly aspectFilter?: string;
 }
 
+/**
+ * Traversal yields between SQL stages to keep the event loop responsive. A
+ * callback source lets each synchronous query acquire and release a pooled
+ * connection independently; the direct ReadDb form remains useful for
+ * callers that already own a bounded read scope.
+ */
+type ReadDbSource = ReadDb | (<T>(fn: (db: ReadDb) => T) => T);
+
+function withReadDb<T>(source: ReadDbSource, fn: (db: ReadDb) => T): T {
+	return typeof source === "function" ? source(fn) : fn(source);
+}
+
 export interface FocalEntityResult {
 	readonly entityIds: string[];
 	readonly entityNames: string[];
@@ -360,7 +372,7 @@ function pathSize(path: TraversalPath): number {
  * long row loops (#1118) — query shapes and result identity are unchanged.
  */
 async function batchCollectForEntities(
-	db: ReadDb,
+	db: ReadDbSource,
 	entityIds: ReadonlyArray<string>,
 	agentId: string,
 	config: TraversalConfig,
@@ -390,9 +402,12 @@ async function batchCollectForEntities(
 	const entityPh = entityIds.map(() => "?").join(", ");
 
 	// --- 1. Batch constraints for all entities ---
-	const constraintRows = db
-		.prepare(
-			`SELECT asp.entity_id, e.name as entity_name, ea.content, ea.importance
+	const constraintRows = withReadDb(
+		db,
+		(readDb) =>
+			readDb
+				.prepare(
+					`SELECT asp.entity_id, e.name as entity_name, ea.content, ea.importance
 				 FROM entity_aspects asp INDEXED BY idx_entity_aspects_entity
 				 CROSS JOIN entity_attributes ea INDEXED BY idx_entity_attributes_aspect
 				   ON ea.aspect_id = asp.id
@@ -403,13 +418,14 @@ async function batchCollectForEntities(
 				   AND ea.kind = 'constraint'
 				   AND ea.status = 'active'
 				 ORDER BY ea.importance DESC`,
-		)
-		.all(...entityIds, agentId, agentId) as Array<{
-		entity_id: string;
-		entity_name: string;
-		content: string;
-		importance: number;
-	}>;
+				)
+				.all(...entityIds, agentId, agentId) as Array<{
+				entity_id: string;
+				entity_name: string;
+				content: string;
+				importance: number;
+			}>,
+	);
 
 	for (const row of constraintRows) {
 		const key = `${row.entity_name}::${row.content}`;
@@ -441,10 +457,14 @@ async function batchCollectForEntities(
 		aspectArgs = [...entityIds, agentId];
 	}
 
-	const allAspectRows = db.prepare(aspectQuery).all(...aspectArgs) as Array<{
-		id: string;
-		entity_id: string;
-	}>;
+	const allAspectRows = withReadDb(
+		db,
+		(readDb) =>
+			readDb.prepare(aspectQuery).all(...aspectArgs) as Array<{
+				id: string;
+				entity_id: string;
+			}>,
+	);
 
 	// Apply maxAspectsPerEntity budget by grouping and slicing
 	const aspectsByEntity = new Map<string, Array<{ id: string }>>();
@@ -484,9 +504,12 @@ async function batchCollectForEntities(
 		if (config.scope !== undefined) {
 			const scopeClause = config.scope === null ? "AND m.scope IS NULL" : "AND m.scope = ?";
 			const scopeArgs: unknown[] = config.scope === null ? [] : [config.scope];
-			attributeRows = db
-				.prepare(
-					`SELECT ea.memory_id, ea.importance, ea.aspect_id
+			attributeRows = withReadDb(
+				db,
+				(readDb) =>
+					readDb
+						.prepare(
+							`SELECT ea.memory_id, ea.importance, ea.aspect_id
 						 FROM entity_attributes ea INDEXED BY idx_entity_attributes_aspect
 						 JOIN memories m ON m.id = ea.memory_id
 						 WHERE ea.aspect_id IN (${aspectPh})
@@ -494,26 +517,31 @@ async function batchCollectForEntities(
 						   AND ea.status = 'active'
 						   AND m.is_deleted = 0 ${scopeClause}
 						 ORDER BY ea.importance DESC`,
-				)
-				.all(...budgetedAspectIds, agentId, ...scopeArgs) as Array<{
-				memory_id: string | null;
-				importance: number;
-				aspect_id: string;
-			}>;
+						)
+						.all(...budgetedAspectIds, agentId, ...scopeArgs) as Array<{
+						memory_id: string | null;
+						importance: number;
+						aspect_id: string;
+					}>,
+			);
 		} else {
-			attributeRows = db
-				.prepare(
-					`SELECT memory_id, importance, aspect_id FROM entity_attributes INDEXED BY idx_entity_attributes_aspect
+			attributeRows = withReadDb(
+				db,
+				(readDb) =>
+					readDb
+						.prepare(
+							`SELECT memory_id, importance, aspect_id FROM entity_attributes INDEXED BY idx_entity_attributes_aspect
 						 WHERE aspect_id IN (${aspectPh})
 						   AND agent_id = ?
 						   AND status = 'active'
 						 ORDER BY importance DESC`,
-				)
-				.all(...budgetedAspectIds, agentId) as Array<{
-				memory_id: string | null;
-				importance: number;
-				aspect_id: string;
-			}>;
+						)
+						.all(...budgetedAspectIds, agentId) as Array<{
+						memory_id: string | null;
+						importance: number;
+						aspect_id: string;
+					}>,
+			);
 		}
 
 		// Apply maxAttributesPerAspect budget and collect memories
@@ -549,37 +577,45 @@ async function batchCollectForEntities(
 		if (config.scope !== undefined) {
 			const scopeClause = config.scope === null ? "AND m.scope IS NULL" : "AND m.scope = ?";
 			const scopeArgs: unknown[] = config.scope === null ? [] : [config.scope];
-			mentionRows = db
-				.prepare(
-					`SELECT mem.memory_id, COALESCE(m.importance, 0.5) AS importance, mem.entity_id
+			mentionRows = withReadDb(
+				db,
+				(readDb) =>
+					readDb
+						.prepare(
+							`SELECT mem.memory_id, COALESCE(m.importance, 0.5) AS importance, mem.entity_id
 						 FROM memory_entity_mentions mem
 						 JOIN memories m ON m.id = mem.memory_id
 						 WHERE mem.entity_id IN (${entityPh})
 						   AND m.is_deleted = 0 ${scopeClause}
 						 ORDER BY mem.confidence DESC, m.importance DESC
 						 LIMIT ?`,
-				)
-				.all(...entityIds, ...scopeArgs, mentionBudget) as Array<{
-				memory_id: string;
-				importance: number;
-				entity_id: string;
-			}>;
+						)
+						.all(...entityIds, ...scopeArgs, mentionBudget) as Array<{
+						memory_id: string;
+						importance: number;
+						entity_id: string;
+					}>,
+			);
 		} else {
-			mentionRows = db
-				.prepare(
-					`SELECT mem.memory_id, COALESCE(m.importance, 0.5) AS importance, mem.entity_id
+			mentionRows = withReadDb(
+				db,
+				(readDb) =>
+					readDb
+						.prepare(
+							`SELECT mem.memory_id, COALESCE(m.importance, 0.5) AS importance, mem.entity_id
 						 FROM memory_entity_mentions mem
 						 JOIN memories m ON m.id = mem.memory_id
 						 WHERE mem.entity_id IN (${entityPh})
 						   AND m.is_deleted = 0
 						 ORDER BY mem.confidence DESC, m.importance DESC
 						 LIMIT ?`,
-				)
-				.all(...entityIds, mentionBudget) as Array<{
-				memory_id: string;
-				importance: number;
-				entity_id: string;
-			}>;
+						)
+						.all(...entityIds, mentionBudget) as Array<{
+						memory_id: string;
+						importance: number;
+						entity_id: string;
+					}>,
+			);
 		}
 
 		for (const row of mentionRows) {
@@ -608,7 +644,7 @@ async function batchCollectForEntities(
  */
 export async function traverseKnowledgeGraph(
 	focalEntityIds: ReadonlyArray<string>,
-	db: ReadDb,
+	db: ReadDbSource,
 	agentId: string,
 	config: TraversalConfig,
 ): Promise<TraversalResult> {
@@ -624,7 +660,7 @@ export async function traverseKnowledgeGraph(
 	};
 
 	try {
-		if (!hasTraversalTables(db)) return empty;
+		if (!withReadDb(db, hasTraversalTables)) return empty;
 
 		const focalIds = sanitizeEntityIds(focalEntityIds);
 		if (focalIds.length === 0) return empty;
@@ -643,9 +679,12 @@ export async function traverseKnowledgeGraph(
 		// --- Phase 2: Dependency expansion + batch collect for hops ---
 		if (!timedOut && phase1.memoryIds.size < budget) {
 			const focalPh = focalIds.map(() => "?").join(", ");
-			const dependencyRows = db
-				.prepare(
-					`SELECT id, source_entity_id, target_entity_id FROM entity_dependencies
+			const dependencyRows = withReadDb(
+				db,
+				(readDb) =>
+					readDb
+						.prepare(
+							`SELECT id, source_entity_id, target_entity_id FROM entity_dependencies
 						 INDEXED BY idx_entity_dependencies_source
 						 WHERE agent_id = ?
 						   AND source_entity_id IN (${focalPh})
@@ -653,14 +692,15 @@ export async function traverseKnowledgeGraph(
 						   AND COALESCE(confidence, 0.7) >= ?
 						 ORDER BY (COALESCE(confidence, 0.7) * strength) DESC
 						 LIMIT ?`,
-				)
-				.all(
-					agentId,
-					...focalIds,
-					config.minDependencyStrength,
-					config.minConfidence,
-					config.maxBranching * focalIds.length,
-				) as Array<{ id: string; source_entity_id: string; target_entity_id: string }>;
+						)
+						.all(
+							agentId,
+							...focalIds,
+							config.minDependencyStrength,
+							config.minConfidence,
+							config.maxBranching * focalIds.length,
+						) as Array<{ id: string; source_entity_id: string; target_entity_id: string }>,
+			);
 
 			// Filter to hop targets not already visited
 			const hopTargetIds = dependencyRows
@@ -705,7 +745,12 @@ export async function traverseKnowledgeGraph(
 						if (!source) continue;
 						// Check if the memory path involves this hop entity
 						if (existingPath.entityIds.includes(hopId) && !existingPath.dependencyIds.length) {
-							const upgraded = toPathStatic(hopId, source.sourceEntityId, existingPath.aspectIds[0], source.dependencyId);
+							const upgraded = toPathStatic(
+								hopId,
+								source.sourceEntityId,
+								existingPath.aspectIds[0],
+								source.dependencyId,
+							);
 							if (pathSize(upgraded) > pathSize(existingPath)) {
 								phase1.memoryPaths.set(mid, upgraded);
 							}

--- a/platform/daemon/src/routes/knowledge-routes.ts
+++ b/platform/daemon/src/routes/knowledge-routes.ts
@@ -3,7 +3,7 @@ import type { Hono } from "hono";
 
 import { resolveAgentId, resolveDaemonAgentId } from "../agent-id";
 import { requirePermission } from "../auth";
-import { getDbAccessor } from "../db-accessor";
+import { type ReadDb, getDbAccessor } from "../db-accessor";
 import { walkImpact } from "../graph-impact";
 import {
 	getAttributesForAspectFiltered,
@@ -399,8 +399,11 @@ export function registerKnowledgeRoutes(app: Hono): void {
 
 		const primaryEntityId = focal.entityIds[0];
 
-		return getDbAccessor().withReadDbAsync(async (db) => {
-			const traversal = await traverseKnowledgeGraph(focal.entityIds, db, agentId, {
+		const traversal = await traverseKnowledgeGraph(
+			focal.entityIds,
+			<T>(fn: (db: ReadDb) => T): T => getDbAccessor().withReadDb(fn),
+			agentId,
+			{
 				maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
 				maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,
 				maxDependencyHops: traversalCfg.maxDependencyHops,
@@ -410,8 +413,10 @@ export function registerKnowledgeRoutes(app: Hono): void {
 				minConfidence: traversalCfg.minConfidence,
 				timeoutMs: traversalCfg.timeoutMs,
 				aspectFilter: aspectFilter || undefined,
-			});
+			},
+		);
 
+		return getDbAccessor().withReadDb((db) => {
 			const entityRow = db
 				.prepare(
 					`SELECT id, name, entity_type, description


### PR DESCRIPTION
## Summary

Fixes #1348 by ensuring knowledge graph traversal and traversal-candidate hydration release pooled SQLite read connections before asynchronous yields. This preserves traversal ordering, agent scope, deleted-row filtering, and existing error handling while preventing overlapping session starts from exhausting the 16-connection read pool.

## Changes

- Run each synchronous traversal query inside a bounded `withReadDb` scope.
- Update graph traversal callers and candidate hydration so no `withReadDbAsync` scope spans an await.
- Add regressions for release-before-yield, agent isolation, and cleanup after a mid-traversal query failure.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

Not applicable: no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable: no schema or migration changes.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Targeted verification completed:

- `bun run --filter '@signet/core' build`
- `bun run --filter '@signet/daemon' typecheck`
- `bun test platform/daemon/src/pipeline/graph-traversal.test.ts platform/daemon/src/memory-candidates.test.ts platform/daemon/src/knowledge-expand-api.test.ts platform/daemon/src/db-accessor.test.ts` (34 passed, 0 failed)
- `bun test platform/daemon/src/memory-search.test.ts platform/daemon/src/hooks-recall.test.ts platform/daemon/src/knowledge-navigation.test.ts platform/daemon/src/knowledge-graph-list.test.ts` (97 passed, 0 failed)
- `bunx biome check` on all six changed files (passes with one pre-existing warning at `graph-traversal.ts:766`)
- `git diff --check`

The full root test/lint commands were not run; no live daemon test was needed because this is an internal connection-lifetime fix covered by the focused API and regression suites.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Rebased onto current `origin/main` before pushing.
- Adversarial review verdict: SHIP.
- No public API, schema, or behavior documentation changed; the fix is internal resource-lifetime handling.
