### PR TITLE
fix(daemon): repair FTS health and rebuilds

### DIFF
--- a/platform/core/src/fts-schema.ts
+++ b/platform/core/src/fts-schema.ts
@@ -58,6 +58,18 @@ export function readMemoriesFtsSql(db: FtsSchemaQueryDb): string | null {
 	return typeof row?.sql === "string" ? row.sql : null;
 }
 
+/**
+ * Return the number of documents physically present in the FTS index.
+ *
+ * An external-content FTS table resolves COUNT(*) through its content table,
+ * so COUNT(*) FROM memories_fts includes tombstones and cannot describe index
+ * integrity. The docsize shadow table tracks indexed documents instead.
+ */
+export function readMemoriesFtsIndexRowCount(db: FtsSchemaQueryDb): number | null {
+	const row = db.prepare("SELECT COUNT(*) AS count FROM memories_fts_docsize").get() as { count?: unknown } | undefined;
+	return typeof row?.count === "number" ? row.count : null;
+}
+
 export function memoriesFtsNeedsTokenizerRepair(sql: string | null): boolean {
 	if (sql === null) return false;
 	const normalized = normalizeSql(sql);

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -219,6 +219,7 @@ export type {
 export {
 	createMemoriesFts,
 	memoriesFtsNeedsTokenizerRepair,
+	readMemoriesFtsIndexRowCount,
 	readMemoriesFtsSql,
 	recreateMemoriesFts,
 } from "./fts-schema";

--- a/platform/daemon/src/diagnostics.test.ts
+++ b/platform/daemon/src/diagnostics.test.ts
@@ -306,13 +306,11 @@ describe("getIndexHealth", () => {
 		expect(result.embeddingCoverage).toBe(1);
 	});
 
-	test("FTS mismatch detected when tombstones exceed 10% of active count", () => {
-		// memories_fts is a content table backed by memories.
-		// COUNT(*) on it returns ALL memories (active + deleted).
-		// Insert 5 active, 6 deleted => ftsRowCount=11, memoriesRowCount=5
-		// 11 > 5 * 1.1 (5.5) => mismatch
+	test("tombstones remain searchable in the FTS index without degrading health", () => {
+		// memories_fts is an external-content table. Soft deletion changes the
+		// canonical row, but intentionally does not remove its indexed document.
 		for (let i = 0; i < 5; i++) {
-			insertMemory(db, `mem-active-fts-${i}`);
+			insertMemory(db, `mem-active-fts-${i}`, { embeddingModel: "text-embedding-3" });
 		}
 		for (let i = 0; i < 6; i++) {
 			insertMemory(db, `mem-del-fts-${i}`, { isDeleted: 1 });
@@ -321,8 +319,9 @@ describe("getIndexHealth", () => {
 		const result = getIndexHealth(asReadDb(db));
 		expect(result.memoriesRowCount).toBe(5);
 		expect(result.ftsRowCount).toBe(11);
-		expect(result.ftsMismatch).toBe(true);
-		expect(result.score).toBeLessThanOrEqual(0.5);
+		expect(result.ftsMismatch).toBe(false);
+		expect(result.embeddingCoverage).toBe(1);
+		expect(result.score).toBe(1);
 	});
 
 	test("low embedding coverage degrades index health", () => {

--- a/platform/daemon/src/diagnostics.ts
+++ b/platform/daemon/src/diagnostics.ts
@@ -5,6 +5,7 @@
  * data structs — no side effects, no mutations.
  */
 
+import { readMemoriesFtsIndexRowCount } from "@signet/core";
 import type { ReadDb } from "./db-accessor";
 import {
 	DEFAULT_QUEUE_THRESHOLDS,
@@ -339,30 +340,34 @@ function getDatabaseSizeBytes(db: ReadDb): number {
 }
 
 export function getIndexHealth(db: ReadDb): IndexHealth {
-	// Active (non-deleted) memories are what should be searchable
-	const memRow = db.prepare("SELECT COUNT(*) AS cnt FROM memories WHERE is_deleted = 0").get() as
+	// FTS external-content indexes intentionally retain soft-deleted memories;
+	// health must compare the physical index to the full canonical row set.
+	const canonicalMemRow = db.prepare("SELECT COUNT(*) AS cnt FROM memories").get() as { cnt: number } | undefined;
+	const activeMemRow = db.prepare("SELECT COUNT(*) AS cnt FROM memories WHERE is_deleted = 0").get() as
 		| { cnt: number }
 		| undefined;
 
-	const memoriesRowCount = memRow?.cnt ?? 0;
+	const canonicalMemoriesRowCount = canonicalMemRow?.cnt ?? 0;
+	// Preserve the existing public field and embedding denominator: embedding
+	// coverage describes live memories, not retained tombstones.
+	const memoriesRowCount = activeMemRow?.cnt ?? 0;
 
-	// memories_fts is a content table backed by memories — COUNT(*) returns
-	// the total memories row count (active + tombstones). A mismatch against
-	// the active count reveals tombstone accumulation visible in FTS.
-	// Guard against missing table (can happen on upgrades before self-heal).
+	// COUNT(*) FROM memories_fts resolves through the external content table and
+	// therefore cannot detect an index gap. The docsize shadow table counts the
+	// documents actually present in the FTS index.
 	let ftsRowCount = 0;
+	let ftsIndexAvailable = false;
 	try {
-		const ftsRow = db.prepare("SELECT COUNT(*) AS cnt FROM memories_fts").get() as { cnt: number } | undefined;
-		ftsRowCount = ftsRow?.cnt ?? 0;
+		const indexRowCount = readMemoriesFtsIndexRowCount(db);
+		if (indexRowCount !== null) {
+			ftsRowCount = indexRowCount;
+			ftsIndexAvailable = true;
+		}
 	} catch {
-		// FTS table missing — report as full mismatch
+		// Missing FTS shadow state — report as a full mismatch.
 	}
 
-	// Mismatch means FTS backing table has more rows than active memories,
-	// i.e., tombstones are included in the FTS index. Detect when the gap
-	// exceeds 10% of the active count (a content table will always show
-	// at least the active rows, so ftsRowCount >= memoriesRowCount).
-	const ftsMismatch = memoriesRowCount > 0 && ftsRowCount > memoriesRowCount * 1.1;
+	const ftsMismatch = !ftsIndexAvailable || canonicalMemoriesRowCount !== ftsRowCount;
 
 	const embRow = db
 		.prepare(

--- a/platform/daemon/src/pipeline/maintenance-worker.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.ts
@@ -83,7 +83,7 @@ function buildRecommendations(report: DiagnosticsReport): RepairRecommendation[]
 		recs.push({
 			domain: "index",
 			action: "checkFtsConsistency",
-			trigger: `FTS mismatch: ${report.index.memoriesRowCount} active vs ${report.index.ftsRowCount} FTS`,
+			trigger: `FTS mismatch: ${report.index.ftsRowCount} indexed rows`,
 		});
 	}
 	if (report.storage.deletedTombstones > 0) {

--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -35,7 +35,7 @@ import {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function asAccessor(db: Database): DbAccessor {
+function asAccessor(db: Database, onAsyncWrite?: () => void): DbAccessor {
 	return {
 		withWriteTx<T>(fn: (wdb: WriteDb) => T): T {
 			db.exec("BEGIN IMMEDIATE");
@@ -48,6 +48,18 @@ function asAccessor(db: Database): DbAccessor {
 				throw err;
 			}
 		},
+		withWriteTxAsync<T>(fn: (wdb: WriteDb) => T): Promise<T> {
+			onAsyncWrite?.();
+			return new Promise<T>((resolve, reject) => {
+				setTimeout(() => {
+					try {
+						resolve(this.withWriteTx(fn));
+					} catch (error) {
+						reject(error);
+					}
+				}, 0);
+			});
+		},
 		withReadDb<T>(fn: (rdb: ReadDb) => T): T {
 			return fn(db as unknown as ReadDb);
 		},
@@ -57,7 +69,7 @@ function asAccessor(db: Database): DbAccessor {
 	};
 }
 
-function installLegacyPorterMemoriesFts(db: Database): void {
+function installLegacyPorterMemoriesFts(db: Database, indexedId?: string, tokenizer = "porter unicode61"): void {
 	db.exec("DROP TRIGGER IF EXISTS memories_ai");
 	db.exec("DROP TRIGGER IF EXISTS memories_ad");
 	db.exec("DROP TRIGGER IF EXISTS memories_au");
@@ -67,7 +79,7 @@ function installLegacyPorterMemoriesFts(db: Database): void {
 			content,
 			content='memories',
 			content_rowid='rowid',
-			tokenize='porter unicode61'
+			tokenize='${tokenizer}'
 		);
 	`);
 	db.exec(`
@@ -86,7 +98,13 @@ function installLegacyPorterMemoriesFts(db: Database): void {
 			INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content);
 		END;
 	`);
-	db.exec("INSERT INTO memories_fts(rowid, content) SELECT rowid, content FROM memories");
+	if (indexedId === undefined) {
+		db.exec("INSERT INTO memories_fts(rowid, content) SELECT rowid, content FROM memories");
+	} else {
+		db.prepare("INSERT INTO memories_fts(rowid, content) SELECT rowid, content FROM memories WHERE id = ?").run(
+			indexedId,
+		);
+	}
 }
 
 const TEST_CFG: PipelineV2Config = {
@@ -762,11 +780,15 @@ describe("releaseStaleLeases", () => {
 describe("checkFtsConsistency", () => {
 	let db: Database;
 	let accessor: DbAccessor;
+	let asyncWriterUsed = false;
 
 	beforeEach(() => {
 		db = new Database(":memory:");
+		asyncWriterUsed = false;
 		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
-		accessor = asAccessor(db);
+		accessor = asAccessor(db, () => {
+			asyncWriterUsed = true;
+		});
 		resetFtsRebuildConfirmation();
 	});
 
@@ -774,10 +796,10 @@ describe("checkFtsConsistency", () => {
 		db.close();
 	});
 
-	it("reports consistent FTS when counts match", () => {
+	it("reports consistent FTS when counts match", async () => {
 		insertMemory(db, "mem-fts-ok");
 		const limiter = createRateLimiter();
-		const result = checkFtsConsistency(accessor, TEST_CFG, CTX_OPERATOR, limiter, false);
+		const result = await checkFtsConsistency(accessor, TEST_CFG, CTX_OPERATOR, limiter, false);
 
 		expect(result.success).toBe(true);
 		// counts match (FTS5 external content reads from memories)
@@ -785,20 +807,20 @@ describe("checkFtsConsistency", () => {
 		expect(result.message).toMatch(/consistent/);
 	});
 
-	it("runs rebuild without error when repair=true", () => {
+	it("runs rebuild without error when repair=true", async () => {
 		insertMemory(db, "mem-fts-rebuild");
 		const limiter = createRateLimiter();
 		// repair=true triggers rebuild even when consistent; should not throw
-		const result = checkFtsConsistency(accessor, TEST_CFG, CTX_OPERATOR, limiter, true);
+		const result = await checkFtsConsistency(accessor, TEST_CFG, CTX_OPERATOR, limiter, true);
 		// Rebuild only runs on mismatch; consistent case is a no-op
 		expect(result.success).toBe(true);
 	});
 
-	it("detects legacy porter tokenizer drift", () => {
+	it("detects legacy porter tokenizer drift", async () => {
 		insertMemory(db, "We celebrate wins together");
 		installLegacyPorterMemoriesFts(db);
 		const limiter = createRateLimiter();
-		const result = checkFtsConsistency(accessor, TEST_CFG, CTX_OPERATOR, limiter, false);
+		const result = await checkFtsConsistency(accessor, TEST_CFG, CTX_OPERATOR, limiter, false);
 
 		expect(result.success).toBe(true);
 		expect(result.affected).toBe(1);
@@ -806,11 +828,11 @@ describe("checkFtsConsistency", () => {
 		expect(readMemoriesFtsSql(toFtsSchemaQueryDb(db))).toContain("porter unicode61");
 	});
 
-	it("repairs legacy porter tokenizer drift when repair=true", () => {
+	it("repairs legacy porter tokenizer drift when repair=true", async () => {
 		insertMemory(db, "We celebrate wins together");
 		installLegacyPorterMemoriesFts(db);
 		const limiter = createRateLimiter();
-		const result = checkFtsConsistency(accessor, TEST_CFG, CTX_OPERATOR, limiter, true);
+		const result = await checkFtsConsistency(accessor, TEST_CFG, CTX_OPERATOR, limiter, true);
 
 		expect(result.success).toBe(true);
 		expect(result.affected).toBe(1);
@@ -821,38 +843,65 @@ describe("checkFtsConsistency", () => {
 		expect(sql).not.toContain("porter unicode61");
 	});
 
-	it("defers autonomous FTS rebuilds until the mismatch persists (#1142)", () => {
-		insertMemory(db, "mem-fts-defer");
-		// A soft-deleted (tombstoned) memory pushes the FTS backing count past
-		// the 10% tolerance — the mismatch signal the check acts on.
-		insertMemory(db, "mem-fts-defer-tombstone");
-		db.prepare("UPDATE memories SET is_deleted = 1 WHERE id = ?").run("mem-fts-defer-tombstone");
+	it("does not treat legitimate tombstones as FTS corruption", async () => {
+		insertMemory(db, "mem-fts-tombstone");
+		insertMemory(db, "mem-fts-tombstone-deleted");
+		db.prepare("UPDATE memories SET is_deleted = 1 WHERE id = ?").run("mem-fts-tombstone-deleted");
 
-		// First observation: held back so a transient spike cannot trigger a
-		// synchronous (event-loop-blocking) rebuild on every cycle.
-		const first = checkFtsConsistency(accessor, TEST_CFG, CTX_DAEMON, createRateLimiter(), true);
+		const result = await checkFtsConsistency(accessor, TEST_CFG, CTX_DAEMON, createRateLimiter(), true);
+		expect(result.success).toBe(true);
+		expect(result.affected).toBe(0);
+		expect(result.message).toMatch(/consistent/);
+		expect(repairAuditCount(db, "checkFtsConsistency")).toBe(0);
+	});
+
+	it("defers autonomous repair until a genuine mismatch persists", async () => {
+		insertMemory(db, "mem-fts-deferred");
+		insertMemory(db, "mem-fts-deferred-missing");
+		installLegacyPorterMemoriesFts(db, "mem-fts-deferred", "unicode61");
+
+		const first = await checkFtsConsistency(accessor, TEST_CFG, CTX_DAEMON, createRateLimiter(), true);
 		expect(first.success).toBe(true);
 		expect(first.affected).toBe(0);
-		expect(first.message).toMatch(/deferred/);
+		expect(first.message).toMatch(/deferred/i);
+		expect(asyncWriterUsed).toBe(false);
 		expect(repairAuditCount(db, "checkFtsConsistency")).toBe(0);
 
-		// Same mismatch on the next maintenance cycle: persistent, rebuild.
-		const second = checkFtsConsistency(accessor, TEST_CFG, CTX_DAEMON, createRateLimiter(), true);
+		const second = await checkFtsConsistency(accessor, TEST_CFG, CTX_DAEMON, createRateLimiter(), true);
 		expect(second.success).toBe(true);
 		expect(second.affected).toBe(1);
-		expect(second.message).toMatch(/rebuilt/);
+		expect(second.message).toMatch(/rebuilt/i);
+		expect(asyncWriterUsed).toBe(true);
 		expect(repairAuditCount(db, "checkFtsConsistency")).toBe(1);
 	});
 
-	it("rebuilds immediately when an operator explicitly triggers repair (#1142)", () => {
-		insertMemory(db, "mem-fts-operator");
-		insertMemory(db, "mem-fts-operator-tombstone");
-		db.prepare("UPDATE memories SET is_deleted = 1 WHERE id = ?").run("mem-fts-operator-tombstone");
+	it("repairs a genuinely incomplete FTS index", async () => {
+		insertMemory(db, "mem-fts-corrupt-indexed");
+		insertMemory(db, "mem-fts-corrupt-missing");
+		installLegacyPorterMemoriesFts(db, "mem-fts-corrupt-indexed", "unicode61");
 
-		const result = checkFtsConsistency(accessor, TEST_CFG, CTX_OPERATOR, createRateLimiter(), true);
+		const result = await checkFtsConsistency(accessor, TEST_CFG, CTX_OPERATOR, createRateLimiter(), true);
 		expect(result.success).toBe(true);
 		expect(result.affected).toBe(1);
 		expect(result.message).toMatch(/rebuilt/);
+		expect(asyncWriterUsed).toBe(true);
+		expect(repairAuditCount(db, "checkFtsConsistency")).toBe(1);
+		expect(db.prepare("SELECT COUNT(*) AS count FROM memories_fts_docsize").get()).toEqual({ count: 2 });
+	});
+
+	it("coalesces concurrent FTS rebuilds through one async write", async () => {
+		insertMemory(db, "mem-fts-concurrent-indexed");
+		insertMemory(db, "mem-fts-concurrent-missing");
+		installLegacyPorterMemoriesFts(db, "mem-fts-concurrent-indexed", "unicode61");
+
+		const results = await Promise.all([
+			checkFtsConsistency(accessor, TEST_CFG, CTX_OPERATOR, createRateLimiter(), true),
+			checkFtsConsistency(accessor, TEST_CFG, CTX_OPERATOR, createRateLimiter(), true),
+		]);
+
+		expect(results.filter((result) => result.affected === 1)).toHaveLength(1);
+		expect(results.filter((result) => /already in progress/i.test(result.message))).toHaveLength(1);
+		expect(asyncWriterUsed).toBe(true);
 		expect(repairAuditCount(db, "checkFtsConsistency")).toBe(1);
 	});
 });

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -6,7 +6,12 @@
  * All actions respect autonomousFrozen regardless of actor type.
  */
 
-import { memoriesFtsNeedsTokenizerRepair, readMemoriesFtsSql, recreateMemoriesFts } from "@signet/core";
+import {
+	memoriesFtsNeedsTokenizerRepair,
+	readMemoriesFtsIndexRowCount,
+	readMemoriesFtsSql,
+	recreateMemoriesFts,
+} from "@signet/core";
 import { normalizeAndHashContent } from "./content-normalization";
 import type { IntegrityCheckStatus } from "./database-integrity";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
@@ -205,15 +210,23 @@ const DEFAULT_REQUEUE_BATCH = 50;
 // FTS rebuilds are heavyweight; cap their hourly budget at 5
 const FTS_HOURLY_BUDGET = 5;
 
-// FTS rebuilds run synchronously and can block the daemon event loop for
-// seconds on large stores. Hold an autonomous rebuild until the same mismatch
-// is observed on a second check, so a transient spike from in-flight artifact
-// writes cannot trigger a rebuild on every maintenance cycle (#1142).
+async function withRepairWriteTx<T>(accessor: DbAccessor, fn: (db: WriteDb) => T): Promise<T> {
+	if (accessor.withWriteTxAsync) {
+		return accessor.withWriteTxAsync(fn);
+	}
+	return accessor.withWriteTx(fn);
+}
+
+// Hold an autonomous rebuild until the same mismatch is observed on a second
+// check, so a transient spike from in-flight artifact writes cannot trigger a
+// rebuild on every maintenance cycle (#1142).
 let ftsMismatchPendingRebuild = false;
+let ftsRebuildInFlight = false;
 
 /** Reset the FTS rebuild confirmation state (for tests). */
 export function resetFtsRebuildConfirmation(): void {
 	ftsMismatchPendingRebuild = false;
+	ftsRebuildInFlight = false;
 }
 
 // ---- Issue #901 shared constants ----
@@ -373,13 +386,13 @@ export function releaseStaleLeases(
  * Check FTS row count and tokenizer definition, optionally rebuilding.
  * Uses a longer cooldown since FTS recreation is expensive.
  */
-export function checkFtsConsistency(
+export async function checkFtsConsistency(
 	accessor: DbAccessor,
 	cfg: PipelineV2Config,
 	ctx: RepairContext,
 	limiter: RateLimiter,
 	repair = false,
-): RepairResult {
+): Promise<RepairResult> {
 	const action = "checkFtsConsistency";
 	const gate = checkRepairGate(cfg, ctx, limiter, action, cfg.repair.reembedCooldownMs, FTS_HOURLY_BUDGET);
 
@@ -393,21 +406,22 @@ export function checkFtsConsistency(
 	}
 
 	const { memCount, ftsCount, ftsMissing, tokenizerDrift } = accessor.withReadDb((db) => {
-		const memRow = db.prepare("SELECT COUNT(*) as n FROM memories WHERE is_deleted = 0").get() as { n: number };
+		const memRow = db.prepare("SELECT COUNT(*) as n FROM memories").get() as { n: number };
 
-		// Guard against missing FTS table (can happen on upgrades)
-		let ftsN = 0;
-		let missing = false;
+		// Guard against missing FTS index state (can happen on upgrades before
+		// self-heal). Count the physical docsize rows, not the external-content
+		// table, whose COUNT(*) resolves through memories and includes tombstones.
+		let ftsN: number | null = null;
 		try {
-			const ftsRow = db.prepare("SELECT COUNT(*) as n FROM memories_fts").get() as { n: number };
-			ftsN = ftsRow.n;
+			ftsN = readMemoriesFtsIndexRowCount(toFtsSchemaQueryDb(db));
 		} catch {
-			missing = true;
+			// Missing FTS shadow state.
 		}
+		const missing = ftsN === null;
 		const ftsSql = missing ? null : readMemoriesFtsSql(toFtsSchemaQueryDb(db));
 		return {
 			memCount: memRow.n,
-			ftsCount: ftsN,
+			ftsCount: ftsN ?? 0,
 			ftsMissing: missing,
 			tokenizerDrift: memoriesFtsNeedsTokenizerRepair(ftsSql),
 		};
@@ -418,9 +432,9 @@ export function checkFtsConsistency(
 	if (ftsMissing) {
 		limiter.record(action);
 		const msg = repair
-			? "FTS table missing — restart daemon to trigger self-healing rebuild"
-			: "FTS table missing — run with repair=true or restart daemon";
-		logger.warn("pipeline", "repair: FTS table missing", {
+			? "FTS index state missing — restart daemon to trigger self-healing rebuild"
+			: "FTS index state missing — run with repair=true or restart daemon";
+		logger.warn("pipeline", "repair: FTS index state missing", {
 			memCount,
 			actor: ctx.actor,
 		});
@@ -434,9 +448,21 @@ export function checkFtsConsistency(
 
 	if (tokenizerDrift) {
 		if (repair) {
-			accessor.withWriteTx((db) => {
+			if (ftsRebuildInFlight) {
+				limiter.record(action);
+				return {
+					action,
+					success: true,
+					affected: 0,
+					message: "FTS rebuild already in progress",
+				};
+			}
+			ftsRebuildInFlight = true;
+			await withRepairWriteTx(accessor, (db) => {
 				recreateMemoriesFts(db);
 				writeRepairAudit(db, action, ctx, 1, "FTS recreated with unicode61 tokenizer");
+			}).finally(() => {
+				ftsRebuildInFlight = false;
 			});
 			// The recreate is itself a full rebuild; any prior mismatch is moot.
 			ftsMismatchPendingRebuild = false;
@@ -460,10 +486,10 @@ export function checkFtsConsistency(
 		};
 	}
 
-	// FTS5 external content tables include tombstones, so ftsCount >=
-	// memCount is normal. Only flag when the gap exceeds 10%, matching
-	// the threshold in diagnostics.ts getIndexHealth().
-	const mismatch = memCount > 0 && ftsCount > memCount * 1.1;
+	// The physical FTS index must contain one document for every canonical
+	// memory row, including tombstones. Async writer admission keeps a repair
+	// out of the request call stack while preserving the existing transaction.
+	const mismatch = memCount !== ftsCount;
 
 	let rebuilt = false;
 	if (mismatch && repair) {
@@ -472,9 +498,21 @@ export function checkFtsConsistency(
 		// mismatch cannot trigger a synchronous rebuild every cycle (#1142).
 		const confirmed = ctx.actorType === "operator" || ftsMismatchPendingRebuild;
 		if (confirmed) {
-			accessor.withWriteTx((db) => {
+			if (ftsRebuildInFlight) {
+				limiter.record(action);
+				return {
+					action,
+					success: true,
+					affected: 0,
+					message: "FTS rebuild already in progress",
+				};
+			}
+			ftsRebuildInFlight = true;
+			await withRepairWriteTx(accessor, (db) => {
 				db.prepare("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')").run();
-				writeRepairAudit(db, action, ctx, 1, `FTS rebuilt: ${memCount} active vs ${ftsCount} FTS rows`);
+				writeRepairAudit(db, action, ctx, 1, `FTS rebuilt: ${memCount} canonical vs ${ftsCount} indexed rows`);
+			}).finally(() => {
+				ftsRebuildInFlight = false;
 			});
 			ftsMismatchPendingRebuild = false;
 			rebuilt = true;
@@ -494,9 +532,9 @@ export function checkFtsConsistency(
 
 	const message = mismatch
 		? rebuilt
-			? `FTS mismatch: ${memCount} active vs ${ftsCount} FTS rows — rebuilt`
-			: `FTS mismatch: ${memCount} active vs ${ftsCount} FTS rows (rebuild deferred until mismatch persists)`
-		: `FTS consistent: ${memCount} active, ${ftsCount} FTS rows`;
+			? `FTS mismatch: ${memCount} canonical vs ${ftsCount} indexed rows — rebuilt`
+			: `FTS mismatch: ${memCount} canonical vs ${ftsCount} indexed rows (rebuild deferred until mismatch persists)`
+		: `FTS consistent: ${memCount} canonical, ${ftsCount} indexed rows`;
 
 	logger.info("pipeline", "repair: FTS consistency check", {
 		memCount,
@@ -2043,7 +2081,7 @@ export async function rebuildDerivedIndexes(
 	const integrity = integrityCheck(accessor);
 
 	// Step 1: FTS rebuild
-	const ftsResult = checkFtsConsistency(accessor, cfg, ctx, limiter, true);
+	const ftsResult = await checkFtsConsistency(accessor, cfg, ctx, limiter, true);
 
 	// Step 2: Re-embed missing memories (batch of 200, not full sweep)
 	const reembedResult = await reembedMissingMemoriesBatch(accessor, embeddingFn, embeddingCfg, 200);

--- a/platform/daemon/src/routes/repair-routes.ts
+++ b/platform/daemon/src/routes/repair-routes.ts
@@ -114,7 +114,7 @@ export function registerRepairRoutes(
 		} catch {
 			// no body or invalid JSON — default repair=false
 		}
-		const result = checkFtsConsistency(getDbAccessor(), cfg.pipelineV2, ctx, repairLimiter, repair);
+		const result = await checkFtsConsistency(getDbAccessor(), cfg.pipelineV2, ctx, repairLimiter, repair);
 		return c.json(result, result.success ? 200 : 429);
 	});
 

--- a/web/docs/src/content/docs/analytics.md
+++ b/web/docs/src/content/docs/analytics.md
@@ -150,12 +150,11 @@ ratio (soft-deleted rows / total rows). A tombstone ratio above 30%
 deducts 0.3. The `dbSizeBytes` field is always 0 from a read connection
 — it's present in the type for future use.
 
-**Index** (weight 0.19) compares the FTS5 content table row count against
-active (non-deleted) memory rows, and measures embedding coverage —
+**Index** (weight 0.19) compares the physical FTS5 document count against
+canonical memory rows, including retained tombstones, and measures embedding coverage —
 the fraction of active memories that have an `embedding_model` set (see
-[Memory](/memory/) for how memories are stored). FTS mismatch (FTS row count
-more than 10% above active count, indicating tombstones are surfacing
-in full-text search) deducts 0.5. Embedding
+[Memory](/memory/) for how memories are stored). FTS mismatch deducts 0.5.
+Embedding
 coverage below 80% deducts 0.3.
 
 **Provider** (weight 0.24) uses a separate in-memory ring buffer

--- a/web/docs/src/content/docs/architecture/platform-services.md
+++ b/web/docs/src/content/docs/architecture/platform-services.md
@@ -131,9 +131,11 @@ scan.
   (batch limit 50 per call).
 - `releaseStaleLeases`: resets `leased` jobs whose `leased_at` predates
   the lease timeout back to `pending`.
-- `checkFtsConsistency`: compares FTS row count to active memory count.
-  If mismatch > 10% and `repair = true`, runs
-  `INSERT INTO memories_fts(memories_fts) VALUES('rebuild')`.
+- `checkFtsConsistency`: compares the physical FTS index document count to
+  the canonical memory row count, including retained tombstones. A mismatch
+  is reported without repair; with `repair = true`, rebuild admission is
+  rate-limited, confirmed for autonomous callers, and sent through the async
+  write queue before `INSERT INTO memories_fts(memories_fts) VALUES('rebuild')`.
 - `triggerRetentionSweep`: calls the retention worker's `sweep()` method
   immediately outside the normal schedule.
 

--- a/web/docs/src/content/docs/daemon.md
+++ b/web/docs/src/content/docs/daemon.md
@@ -218,7 +218,7 @@ domains and returns a composite score:
 |--------|-----------------|
 | `queue` | Job queue depth, dead job rate, stale leases |
 | `storage` | Total memories, tombstone ratio, database size |
-| `index` | FTS row count vs active memories, embedding coverage |
+| `index` | Physical FTS document count vs canonical memories, embedding coverage |
 | `provider` | Ollama availability rate, recent timeouts and failures |
 | `mutation` | Recent recover and delete event rates |
 | `connector` | Active connector count, sync errors, error age |

--- a/web/docs/src/content/docs/diagnostics.md
+++ b/web/docs/src/content/docs/diagnostics.md
@@ -280,12 +280,14 @@ curl -X POST http://localhost:3850/api/repair/release-leases
 
 ### POST /api/repair/check-fts
 
-Verifies that the FTS5 index is consistent with the active memory count
-and that `memories_fts` is using the canonical `unicode61` tokenizer.
-Pass `{ "repair": true }` in the JSON body to trigger a full repair:
+Verifies that the physical FTS5 index document count is consistent with the
+canonical memory count, including retained tombstones, and that `memories_fts`
+is using the canonical `unicode61` tokenizer.
+Pass `{ "repair": true }` in the JSON body to request a full repair:
 row-count mismatches rebuild the index, while tokenizer drift recreates
 `memories_fts` and backfills it from `memories`. Without that flag, the
-endpoint checks and reports only.
+endpoint checks and reports only. Rebuilds are confirmed for autonomous
+callers and admitted through the async write queue.
 
 FTS rebuilds are expensive. This action uses a separate, stricter rate limit:
 

--- a/web/docs/src/content/docs/pipeline/workers-maintenance.md
+++ b/web/docs/src/content/docs/pipeline/workers-maintenance.md
@@ -136,7 +136,7 @@ on-demand inspection.
 
 Each maintenance cycle runs three phases. First, `getDiagnostics` produces
 a `DiagnosticsReport` that captures queue health (dead rate, stale lease
-count), index health (FTS row count vs active memory count), storage health
+count), index health (physical FTS document count vs canonical memory count), storage health
 (tombstone ratio and SQLite page size), and graph health. A composite score in
 [0, 1] summarizes overall health, and when graph is enabled the composite
 status propagates graph degradation when the graph has flatlined across many
@@ -146,8 +146,8 @@ Second, `buildRecommendations` translates the report into a list of repair
 actions:
 - `requeueDeadJobs` when the dead job rate exceeds 1%.
 - `releaseStaleLeases` when stale leases are detected.
-- `checkFtsConsistency` when the FTS row count does not match active
-  memories.
+- `checkFtsConsistency` when the physical FTS document count does not match
+  canonical memory rows, including retained tombstones.
 - `triggerRetentionSweep` when tombstones exceed 30% of total memories.
 
 Third, if `maintenanceMode` is `observe`, the recommendations are logged and


### PR DESCRIPTION
## Summary

Fix FTS health so legitimate tombstones do not appear as corruption, while real index gaps still repair through the daemon's async write queue instead of blocking the latency-sensitive caller.

Fixes #1352.

## Changes

- Add a core helper that counts physical `memories_fts_docsize` documents rather than querying the external-content table.
- Compare FTS physical documents with canonical memory rows, while preserving active-only embedding coverage semantics.
- Route tokenizer and mismatch rebuilds through `withWriteTxAsync` when available, preserve autonomous second-observation confirmation, and coalesce concurrent rebuilds with a single-flight guard.
- Keep missing-index and write failures visible without weakening the existing policy/rate gates or audit transaction.
- Add regression coverage for tombstones, real incomplete indexes, autonomous deferral, and concurrent rebuild admission.
- Update diagnostics, maintenance, and architecture docs to describe canonical-vs-physical FTS health.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [x] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A: no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A: no migrations changed.

## Testing

- [x] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Details:

- `bun test platform/daemon/src/diagnostics.test.ts platform/daemon/src/repair-actions.test.ts`: 89 pass, 0 fail, 333 expect calls.
- `bun test platform/core/src/migrations/migrations.test.ts`: 64 pass, 0 fail, 601 expect calls.
- `bun run --filter '@signet/core' build`: passed.
- `bun run --filter '@signet/daemon' build`: passed; existing Vite chunk-size warning only.
- `bunx biome check` on all changed TypeScript files: passed.
- `git diff --check`: passed.
- `bun scripts/doc-drift.ts`: reports pre-existing repository drift (7 undocumented routes and 21 package-table omissions); migration drift is false.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The FTS detector intentionally uses `memories_fts_docsize`, the FTS5 shadow table that tracks physically indexed documents. External-content `COUNT(*) FROM memories_fts` resolves through `memories` and cannot distinguish a complete index from a missing indexed row. Tombstones remain indexed and therefore participate in the canonical FTS count; embedding coverage remains active-only.

An independent read-only adversarial review found and prompted fixes for the active-only embedding denominator and missing autonomous-deferral coverage. A follow-up read-only review left the worktree clean and its SQLite probes confirmed tombstones and retention purge cycles stay aligned while a trigger-bypassing row gap is detected, but it timed out before returning a final verdict. No migrations were changed and the PR is not merged.
