### PR TITLE
fix(inference): bound Pi concurrency

### DIFF
--- a/platform/daemon/src/inference-router.test.ts
+++ b/platform/daemon/src/inference-router.test.ts
@@ -537,6 +537,51 @@ printf 'never reached\\n'
 		}
 	});
 
+	it("allows a Pi agent session with timeoutMs: 0 to complete without a deadline (#1416)", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-router-pi-no-deadline-"));
+		mkdirSync(join(dir, "memory"), { recursive: true });
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			`inference:
+  defaultPolicy: pi-test
+  targets:
+    pi-test:
+      executor: openai-compatible
+      endpoint: http://127.0.0.1:1234/v1
+      models:
+        default:
+          model: pi-test-model
+  policies:
+    pi-test:
+      mode: strict
+      defaultTargets:
+        - pi-test/default
+  workloads:
+    memoryExtraction:
+      policy: pi-test
+`,
+		);
+		let chatRequests = 0;
+		globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+			if (String(input).endsWith("/models")) return new Response("not found", { status: 404 });
+			chatRequests++;
+			return openAiSseResponse("agent completed", { prompt_tokens: 3, completion_tokens: 1 });
+		}) as unknown as typeof fetch;
+		try {
+			const router = getOrCreateInferenceRouter(dir);
+			const result = await router.runAgent(
+				{ operation: "memory_extraction", promptPreview: "zero timeout" },
+				"Use the supplied daemon tools.",
+				[],
+				{ timeoutMs: 0 },
+			);
+			expect(result.ok).toBe(true);
+			expect(chatRequests).toBe(1);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("keeps the Pi agent permit until timeout abort cleanup settles (#1333)", async () => {
 		const originalLimit = getLlmConcurrencyStatus().limit;
 		let settleAbort: (() => void) | undefined;

--- a/platform/daemon/src/inference-router.test.ts
+++ b/platform/daemon/src/inference-router.test.ts
@@ -4,10 +4,18 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { registerOAuthProviderForTests, resetOAuthStateForTests, storeOAuthCredentials } from "./inference-oauth";
 import {
+	PiAgentSessionTimeoutError,
 	getOrCreateInferenceRouter,
 	isInferenceRouterConfigPath,
+	promptPiAgentSession,
 	resetInferenceRouterForTests,
 } from "./inference-router";
+import {
+	acquireLlmConcurrencyPermit,
+	configureLlmConcurrency,
+	getLlmConcurrencyStatus,
+	withLlmConcurrency,
+} from "./pipeline/provider";
 import { invalidateSecretsCache } from "./secrets";
 
 const originalFetch = globalThis.fetch;
@@ -433,6 +441,147 @@ printf 'never reached\\n'
 			}
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("routes Pi agent sessions through the global LLM semaphore (#1333)", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-router-pi-concurrency-"));
+		mkdirSync(join(dir, "memory"), { recursive: true });
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			`inference:
+  defaultPolicy: pi-test
+  targets:
+    pi-test:
+      executor: openai-compatible
+      endpoint: http://127.0.0.1:1234/v1
+      models:
+        default:
+          model: pi-test-model
+  policies:
+    pi-test:
+      mode: strict
+      defaultTargets:
+        - pi-test/default
+  workloads:
+    memoryExtraction:
+      policy: pi-test
+`,
+		);
+		const originalLimit = getLlmConcurrencyStatus().limit;
+		let releaseBlocker: (() => void) | undefined;
+		try {
+			configureLlmConcurrency(1);
+			let chatRequests = 0;
+			let hangChatRequests = false;
+			globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = String(input);
+				if (url.endsWith("/models")) return new Response("not found", { status: 404 });
+				chatRequests++;
+				if (hangChatRequests) {
+					const signal = input instanceof Request ? input.signal : init?.signal;
+					return new Promise<Response>((_, reject) => {
+						signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+					});
+				}
+				return openAiSseResponse("agent completed", { prompt_tokens: 3, completion_tokens: 1 });
+			}) as unknown as typeof fetch;
+
+			const blocker = withLlmConcurrency(
+				() =>
+					new Promise<void>((resolve) => {
+						releaseBlocker = resolve;
+					}),
+				5_000,
+				"test-blocker",
+			);
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			const router = getOrCreateInferenceRouter(dir);
+			const run = router.runAgent(
+				{ operation: "memory_extraction", promptPreview: "pi concurrency" },
+				"Use the supplied daemon tools.",
+				[],
+				{ timeoutMs: 5_000 },
+			);
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			expect(chatRequests).toBe(0);
+
+			releaseBlocker?.();
+			await blocker;
+			const result = await run;
+			expect(result.ok).toBe(true);
+			expect(chatRequests).toBe(1);
+			expect(getLlmConcurrencyStatus().running).toBe(0);
+
+			hangChatRequests = true;
+			const timedOut = await router.runAgent(
+				{ operation: "memory_extraction", promptPreview: "pi timeout" },
+				"Use the supplied daemon tools.",
+				[],
+				{ timeoutMs: 50 },
+			);
+			expect(timedOut.ok).toBe(false);
+			expect(chatRequests).toBe(2);
+			// runAgent returns at its deadline, but the permit remains held until
+			// Pi's abort has settled the active upstream request.
+			expect(getLlmConcurrencyStatus().running).toBe(1);
+			for (let i = 0; i < 20 && getLlmConcurrencyStatus().running !== 0; i += 1) {
+				await new Promise((resolve) => setTimeout(resolve, 10));
+			}
+			expect(getLlmConcurrencyStatus().running).toBe(0);
+		} finally {
+			releaseBlocker?.();
+			configureLlmConcurrency(originalLimit);
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps the Pi agent permit until timeout abort cleanup settles (#1333)", async () => {
+		const originalLimit = getLlmConcurrencyStatus().limit;
+		let settleAbort: (() => void) | undefined;
+		let settlePrompt: (() => void) | undefined;
+		try {
+			configureLlmConcurrency(1);
+			const abortSettled = new Promise<void>((resolve) => {
+				settleAbort = resolve;
+			});
+			const promptSettled = new Promise<void>((resolve) => {
+				settlePrompt = resolve;
+			});
+			let aborts = 0;
+			const session = {
+				prompt: () => promptSettled,
+				abort: () => {
+					aborts++;
+					return abortSettled.then(() => {
+						settlePrompt?.();
+					});
+				},
+				dispose: () => {},
+				getActiveToolNames: () => [],
+				getFailureMessage: () => undefined,
+				getStats: () => undefined,
+			};
+			const release = await acquireLlmConcurrencyPermit(5000, "pi-agent");
+			const timedOut = await promptPiAgentSession(session, "cancel", 20).then(
+				() => {
+					throw new Error("expected Pi agent timeout");
+				},
+				(error) => error,
+			);
+			expect(timedOut).toBeInstanceOf(PiAgentSessionTimeoutError);
+			if (!(timedOut instanceof PiAgentSessionTimeoutError)) return;
+			expect(aborts).toBe(1);
+			expect(getLlmConcurrencyStatus().running).toBe(1);
+
+			settleAbort?.();
+			await timedOut.cleanup;
+			release();
+			expect(getLlmConcurrencyStatus().running).toBe(0);
+		} finally {
+			settleAbort?.();
+			configureLlmConcurrency(originalLimit);
 		}
 	});
 

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -31,12 +31,13 @@ import { type ResolvedInferenceCredential, createRoutingProvider } from "./infer
 import { logger } from "./logger";
 import { loadMemoryConfig } from "./memory-config";
 import { createDreamingAcpxMcpConfig } from "./pipeline/acpx-dreaming-mcp";
-import { isPiAgentSessionProvider, mapSessionStatsToUsage } from "./pipeline/pi-provider";
+import { type PiAgentSession, isPiAgentSessionProvider, mapSessionStatsToUsage } from "./pipeline/pi-provider";
 import {
 	type AcpxHooksMode,
 	type LlmProviderStreamEvent,
 	type LlmProviderStreamResult,
 	type StreamCapableLlmProvider,
+	acquireLlmConcurrencyPermit,
 	generateWithTracking,
 } from "./pipeline/provider";
 import { getSecret } from "./secrets";
@@ -126,6 +127,50 @@ export interface InferenceStreamResult {
 	readonly decision: RouteDecision;
 	readonly stream: ReadableStream<InferenceStreamEvent>;
 	cancel(reason?: string): void;
+}
+
+export class PiAgentSessionTimeoutError extends Error {
+	readonly cleanup: Promise<void>;
+
+	constructor(deadlineMs: number, cleanup: Promise<void>) {
+		super(`Agent session exceeded the ${deadlineMs}ms deadline`);
+		this.name = "PiAgentSessionTimeoutError";
+		this.cleanup = cleanup;
+	}
+}
+
+/**
+ * Race a Pi agent prompt against its deadline. A timeout returns immediately,
+ * but carries the cancellation-settlement promise so the caller can retain its
+ * concurrency permit until the upstream work has actually stopped.
+ */
+export async function promptPiAgentSession(session: PiAgentSession, prompt: string, deadlineMs: number): Promise<void> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	let aborting: Promise<void> | undefined;
+	const abort = (): Promise<void> => {
+		aborting ??= Promise.resolve().then(() => session.abort());
+		return aborting;
+	};
+	const promptResult = session.prompt(prompt);
+	const cleanup = (): Promise<void> =>
+		Promise.all([
+			promptResult.then(
+				() => undefined,
+				() => undefined,
+			),
+			abort().catch(() => {}),
+		]).then(() => undefined);
+	try {
+		if (deadlineMs <= 0) {
+			throw new PiAgentSessionTimeoutError(deadlineMs, cleanup());
+		}
+		const timedOut = new Promise<never>((_, reject) => {
+			timer = setTimeout(() => reject(new PiAgentSessionTimeoutError(deadlineMs, cleanup())), deadlineMs);
+		});
+		await Promise.race([promptResult, timedOut]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
 }
 
 export interface InferenceAccountSummary {
@@ -1014,26 +1059,38 @@ export class InferenceRouter {
 							},
 						};
 					}
-					const session = await provider.createAgentSession(tools, { maxTokens: opts?.maxTokens });
 					const deadlineMs = opts?.timeoutMs ?? provider.agentSessionTimeoutMs;
-					let timer: ReturnType<typeof setTimeout> | null = null;
-					// The deadline must stop the router from waiting on a session
-					// whose agent loop ignores (or never sees) the abort signal:
-					// race the prompt against the deadline so runAgent returns and
-					// disposes the session either way. Without the race, a stuck
-					// loop hangs runAgent — and the Dreaming pass with it — past
-					// every deadline (#1168).
-					const timedOut = new Promise<never>((_, reject) => {
-						if (deadlineMs > 0) {
-							timer = setTimeout(() => {
-								void session.abort();
-								reject(new Error(`Agent session exceeded the ${deadlineMs}ms deadline`));
-							}, deadlineMs);
-						}
-					});
+					const deadline = deadlineMs > 0 ? performance.now() + deadlineMs : undefined;
 					let sessionUsage: LlmUsage | null = null;
+					const release = await acquireLlmConcurrencyPermit(deadlineMs > 0 ? deadlineMs : undefined, "pi-agent");
+					let session: PiAgentSession | undefined;
+					let releaseDeferred = false;
 					try {
-						await Promise.race([session.prompt(prompt), timedOut]);
+						session = await provider.createAgentSession(tools, { maxTokens: opts?.maxTokens });
+						// AgentSession owns an internal model loop, so acquire the
+						// process-wide permit before initialization and hold it until
+						// the whole session is disposed. This prevents tool-driven
+						// Pi turns from multiplying concurrency outside the canonical
+						// provider boundary, including cancellation cleanup.
+						const remainingMs = deadline === undefined ? deadlineMs : deadline - performance.now();
+						if (remainingMs <= 0) {
+							throw new Error(`Agent session exceeded the ${deadlineMs}ms deadline`);
+						}
+						try {
+							await promptPiAgentSession(session, prompt, remainingMs);
+						} catch (error) {
+							if (error instanceof PiAgentSessionTimeoutError) {
+								releaseDeferred = true;
+								void error.cleanup.finally(() => {
+									try {
+										session?.dispose();
+									} finally {
+										release();
+									}
+								});
+							}
+							throw error;
+						}
 						const failure = session.getFailureMessage();
 						if (failure) throw new Error(failure);
 						// Read the session aggregate before dispose() tears the
@@ -1045,8 +1102,13 @@ export class InferenceRouter {
 							provider.accountingProvenance ?? "unavailable",
 						);
 					} finally {
-						if (timer) clearTimeout(timer);
-						session.dispose();
+						if (!releaseDeferred) {
+							try {
+								session?.dispose();
+							} finally {
+								release();
+							}
+						}
 					}
 					this.clearObservedRuntimeState(loaded.value, targetRef);
 					attempts.push({ targetRef, ok: true, durationMs: Date.now() - startedAt, usage: sessionUsage });

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -144,7 +144,11 @@ export class PiAgentSessionTimeoutError extends Error {
  * but carries the cancellation-settlement promise so the caller can retain its
  * concurrency permit until the upstream work has actually stopped.
  */
-export async function promptPiAgentSession(session: PiAgentSession, prompt: string, deadlineMs: number): Promise<void> {
+export async function promptPiAgentSession(
+	session: PiAgentSession,
+	prompt: string,
+	deadlineMs: number | undefined,
+): Promise<void> {
 	let timer: ReturnType<typeof setTimeout> | undefined;
 	let aborting: Promise<void> | undefined;
 	const abort = (): Promise<void> => {
@@ -161,6 +165,10 @@ export async function promptPiAgentSession(session: PiAgentSession, prompt: stri
 			abort().catch(() => {}),
 		]).then(() => undefined);
 	try {
+		if (deadlineMs === undefined) {
+			await promptResult;
+			return;
+		}
 		if (deadlineMs <= 0) {
 			throw new PiAgentSessionTimeoutError(deadlineMs, cleanup());
 		}
@@ -1072,8 +1080,8 @@ export class InferenceRouter {
 						// the whole session is disposed. This prevents tool-driven
 						// Pi turns from multiplying concurrency outside the canonical
 						// provider boundary, including cancellation cleanup.
-						const remainingMs = deadline === undefined ? deadlineMs : deadline - performance.now();
-						if (remainingMs <= 0) {
+						const remainingMs = deadline === undefined ? undefined : deadline - performance.now();
+						if (remainingMs !== undefined && remainingMs <= 0) {
 							throw new Error(`Agent session exceeded the ${deadlineMs}ms deadline`);
 						}
 						try {

--- a/platform/daemon/src/pipeline/pi-provider.test.ts
+++ b/platform/daemon/src/pipeline/pi-provider.test.ts
@@ -9,6 +9,7 @@ import {
 	mapUsage,
 	resolvePiModel,
 } from "./pi-provider";
+import { configureLlmConcurrency, getLlmConcurrencyStatus, withLlmConcurrency } from "./provider";
 
 describe("pi provider catalog models", () => {
 	test("preserves the Codex responses API and registry metadata", () => {
@@ -136,6 +137,157 @@ describe("pi provider catalog models", () => {
 			await expect(session.prompt("finish without tools")).resolves.toBeUndefined();
 		} finally {
 			session.dispose();
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	test("admits normal Pi completions through the global LLM semaphore (#1333)", async () => {
+		const originalFetch = globalThis.fetch;
+		const originalLimit = getLlmConcurrencyStatus().limit;
+		let releaseBlocker: (() => void) | undefined;
+		try {
+			configureLlmConcurrency(1);
+			const blocker = withLlmConcurrency(
+				() =>
+					new Promise<void>((resolve) => {
+						releaseBlocker = resolve;
+					}),
+				5000,
+				"test-blocker",
+			);
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			let requests = 0;
+			globalThis.fetch = mock(() => {
+				requests++;
+				return Promise.resolve(
+					new Response(
+						`data: ${JSON.stringify({ choices: [{ delta: { content: "done" } }] })}\n\ndata: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: "stop" }] })}\n\ndata: [DONE]\n\n`,
+						{ status: 200, headers: { "content-type": "text/event-stream" } },
+					),
+				);
+			}) as unknown as typeof fetch;
+			const provider = createPiModelProvider({
+				executor: "openai-compatible",
+				model: "concurrency-test",
+				baseUrl: "http://127.0.0.1:1234/v1",
+			});
+			const generated = provider.generate("wait for admission", { timeoutMs: 5000 });
+			await new Promise((resolve) => setTimeout(resolve, 25));
+			expect(requests).toBe(0);
+
+			releaseBlocker?.();
+			await blocker;
+			await expect(generated).resolves.toBe("done");
+			expect(requests).toBe(1);
+			expect(getLlmConcurrencyStatus().running).toBe(0);
+		} finally {
+			releaseBlocker?.();
+			configureLlmConcurrency(originalLimit);
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	test("admits Pi streams through the global LLM semaphore until their upstream work settles (#1333)", async () => {
+		const originalFetch = globalThis.fetch;
+		const originalLimit = getLlmConcurrencyStatus().limit;
+		let releaseBlocker: (() => void) | undefined;
+		try {
+			configureLlmConcurrency(1);
+			const blocker = withLlmConcurrency(
+				() =>
+					new Promise<void>((resolve) => {
+						releaseBlocker = resolve;
+					}),
+				5000,
+				"test-blocker",
+			);
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			let requests = 0;
+			globalThis.fetch = mock(() => {
+				requests++;
+				return Promise.resolve(
+					new Response(
+						`data: ${JSON.stringify({ choices: [{ delta: { content: "streamed" } }] })}\n\ndata: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: "stop" }] })}\n\ndata: [DONE]\n\n`,
+						{ status: 200, headers: { "content-type": "text/event-stream" } },
+					),
+				);
+			}) as unknown as typeof fetch;
+			const provider = createPiModelProvider({
+				executor: "openai-compatible",
+				model: "stream-concurrency-test",
+				baseUrl: "http://127.0.0.1:1234/v1",
+			});
+			const streamWithUsage = provider.streamWithUsage;
+			if (!streamWithUsage) throw new Error("expected Pi stream support");
+			const upstream = streamWithUsage("wait for admission", { timeoutMs: 5000 });
+			await new Promise((resolve) => setTimeout(resolve, 25));
+			expect(requests).toBe(0);
+
+			releaseBlocker?.();
+			await blocker;
+			const result = await upstream;
+			const reader = result.stream.getReader();
+			let text = "";
+			while (true) {
+				const next = await reader.read();
+				if (next.done) break;
+				if (next.value.type === "text-delta") text += next.value.text;
+			}
+			expect(text).toBe("streamed");
+			expect(requests).toBe(1);
+			expect(getLlmConcurrencyStatus().running).toBe(0);
+		} finally {
+			releaseBlocker?.();
+			configureLlmConcurrency(originalLimit);
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	test("keeps the Pi stream permit through cancellation until the upstream stream settles (#1333)", async () => {
+		const originalFetch = globalThis.fetch;
+		const originalLimit = getLlmConcurrencyStatus().limit;
+		let resolveResponse: ((response: Response) => void) | undefined;
+		try {
+			configureLlmConcurrency(1);
+			let requests = 0;
+			globalThis.fetch = mock(() => {
+				requests++;
+				return new Promise<Response>((resolve) => {
+					resolveResponse = resolve;
+				});
+			}) as unknown as typeof fetch;
+			const provider = createPiModelProvider({
+				executor: "openai-compatible",
+				model: "stream-cancel-concurrency-test",
+				baseUrl: "http://127.0.0.1:1234/v1",
+			});
+			const streamWithUsage = provider.streamWithUsage;
+			if (!streamWithUsage) throw new Error("expected Pi stream support");
+			const result = await streamWithUsage("cancel after opening", { timeoutMs: 5000 });
+			for (let i = 0; i < 20 && requests === 0; i += 1) {
+				await new Promise((resolve) => setTimeout(resolve, 10));
+			}
+			expect(requests).toBe(1);
+			expect(getLlmConcurrencyStatus().running).toBe(1);
+
+			result.cancel();
+			expect(getLlmConcurrencyStatus().running).toBe(1);
+			resolveResponse?.(
+				new Response(
+					`data: ${JSON.stringify({ choices: [{ delta: { content: "late" } }] })}\n\ndata: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: "stop" }] })}\n\ndata: [DONE]\n\n`,
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				),
+			);
+			await result.stream.getReader().closed.catch(() => {});
+			for (let i = 0; i < 20 && getLlmConcurrencyStatus().running !== 0; i += 1) {
+				await new Promise((resolve) => setTimeout(resolve, 10));
+			}
+			expect(getLlmConcurrencyStatus().running).toBe(0);
+		} finally {
+			resolveResponse?.(
+				new Response("data: [DONE]\n\n", { status: 200, headers: { "content-type": "text/event-stream" } }),
+			);
+			configureLlmConcurrency(originalLimit);
 			globalThis.fetch = originalFetch;
 		}
 	});

--- a/platform/daemon/src/pipeline/pi-provider.ts
+++ b/platform/daemon/src/pipeline/pi-provider.ts
@@ -29,11 +29,12 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type { AccountingProvenance, LlmGenerateResult, LlmProvider, LlmUsage } from "@signet/core";
 import { logger } from "../logger";
-import type {
-	LlmProviderCallOptions,
-	LlmProviderStreamEvent,
-	LlmProviderStreamResult,
-	StreamCapableLlmProvider,
+import {
+	type LlmProviderCallOptions,
+	type LlmProviderStreamEvent,
+	type LlmProviderStreamResult,
+	type StreamCapableLlmProvider,
+	acquireLlmConcurrencyPermit,
 } from "./provider";
 
 /** Executors that route through pi-ai. `acpx` is handled separately. */
@@ -462,19 +463,24 @@ export function createPiModelProvider(
 		const abort = callerAbort(opts, defaultTimeoutMs);
 		const t0 = Date.now();
 		try {
-			const msg = await (await modelRuntime).completeSimple(piModel, buildContext(prompt), buildOptions(opts, abort));
-			const durationMs = Date.now() - t0;
-			if (msg.stopReason === "error" || msg.stopReason === "aborted") {
-				throw toError(name, msg);
+			const release = await acquireLlmConcurrencyPermit(opts?.timeoutMs ?? defaultTimeoutMs, name, abort.signal);
+			try {
+				const msg = await (await modelRuntime).completeSimple(piModel, buildContext(prompt), buildOptions(opts, abort));
+				const durationMs = Date.now() - t0;
+				if (msg.stopReason === "error" || msg.stopReason === "aborted") {
+					throw toError(name, msg);
+				}
+				const text = extractText(msg.content);
+				return {
+					text,
+					usage: {
+						...mapUsage(msg.usage, accountingProvenance ?? "provider_reported"),
+						totalDurationMs: durationMs,
+					},
+				};
+			} finally {
+				release();
 			}
-			const text = extractText(msg.content);
-			return {
-				text,
-				usage: {
-					...mapUsage(msg.usage, accountingProvenance ?? "provider_reported"),
-					totalDurationMs: durationMs,
-				},
-			};
 		} finally {
 			abort.cleanup();
 		}
@@ -523,7 +529,22 @@ export function createPiModelProvider(
 			let fullText = "";
 			let finalUsage: LlmUsage | null = null;
 
-			const piStream = (await modelRuntime).streamSimple(piModel, buildContext(prompt), buildOptions(opts, abort));
+			const release = await acquireLlmConcurrencyPermit(opts?.timeoutMs ?? defaultTimeoutMs, name, abort.signal);
+			let released = false;
+			const releaseWhenSettled = (): void => {
+				if (released) return;
+				released = true;
+				abort.cleanup();
+				release();
+			};
+			const piStream = await (async () => {
+				try {
+					return (await modelRuntime).streamSimple(piModel, buildContext(prompt), buildOptions(opts, abort));
+				} catch (error) {
+					releaseWhenSettled();
+					throw error;
+				}
+			})();
 
 			const stream = new ReadableStream<LlmProviderStreamEvent>({
 				async start(controller) {
@@ -555,7 +576,7 @@ export function createPiModelProvider(
 						});
 						controller.error(err instanceof Error ? err : new Error(String(err)));
 					} finally {
-						abort.cleanup();
+						releaseWhenSettled();
 					}
 				},
 				cancel() {
@@ -567,7 +588,6 @@ export function createPiModelProvider(
 				stream,
 				cancel: () => {
 					abort.abort();
-					abort.cleanup();
 				},
 			};
 		},

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -22,6 +22,7 @@ import {
 	configureLlmConcurrency,
 	createAcpxProvider,
 	getLlmConcurrencyStatus,
+	withLlmConcurrency,
 } from "./provider";
 
 // ---------------------------------------------------------------------------
@@ -1109,6 +1110,26 @@ describe("LlmConcurrencySemaphore", () => {
 		sem.release();
 		sem.release();
 		expect(sem.running).toBe(0);
+	});
+
+	it("withLlmConcurrency releases the permit when guarded work fails", async () => {
+		const originalLimit = getLlmConcurrencyStatus().limit;
+		configureLlmConcurrency(1);
+		try {
+			await expect(
+				withLlmConcurrency(
+					async () => {
+						throw new Error("agent session failed");
+					},
+					100,
+					"pi-agent",
+				),
+			).rejects.toThrow("agent session failed");
+			expect(getLlmConcurrencyStatus().running).toBe(0);
+			expect(await withLlmConcurrency(async () => "next", 100, "pi-agent")).toBe("next");
+		} finally {
+			configureLlmConcurrency(originalLimit);
+		}
 	});
 
 	it("rejects fractional SIGNET_MAX_LLM_CONCURRENCY", () => {

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -391,7 +391,7 @@ function generateSignal(opts?: { readonly signal?: AbortSignal; readonly abortSi
 	return opts?.signal ?? opts?.abortSignal;
 }
 
-async function withLlmConcurrency<T>(
+export async function withLlmConcurrency<T>(
 	fn: () => Promise<T>,
 	timeoutMs?: number,
 	label?: string,
@@ -405,7 +405,7 @@ async function withLlmConcurrency<T>(
 	}
 }
 
-async function acquireLlmConcurrencyPermit(
+export async function acquireLlmConcurrencyPermit(
 	timeoutMs?: number,
 	label?: string,
 	signal?: AbortSignal,


### PR DESCRIPTION
## Summary

Closes #1333.

Pi normal completions, streams, and agent sessions now share the process-wide LLM concurrency limit. A timed-out agent call returns at its deadline, while its permit remains held until both Pi cancellation and the active prompt have settled.

## Changes

- Admit Pi `completeSimple` and `streamSimple` calls through the canonical global semaphore.
- Keep a stream permit through completion, errors, and cancellation until its upstream iterator settles.
- Give Pi agent sessions an explicit permit lifecycle spanning initialization, prompt execution, and timeout cleanup.
- Preserve one absolute agent deadline across queue admission and prompt execution.
- Add regression coverage for normal admission, stream admission, stream cancellation, agent admission, timeout cleanup, and failed guarded work.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

## Testing

- [x] `bun test` passes (targeted daemon suites)
- [x] `bun run typecheck` passes (`@signet/daemon`)
- [x] `bun run lint` passes (targeted Biome check)
- [ ] Tested against running daemon
- [ ] N/A

Focused command:

`bun test platform/daemon/src/pipeline/provider.test.ts platform/daemon/src/inference-router.test.ts platform/daemon/src/pipeline/pi-provider.test.ts`

Result: 70 pass, 0 fail, 255 expectations.

Also verified:

- `bun run --filter '@signet/daemon' build`
- `bun run --filter '@signet/daemon' typecheck`
- `bunx biome check` on the five directly changed implementation/test files
- `git diff --check`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The scope covers every Pi inference surface: one-shot completion, streaming completion, and the AgentSession loop. The availability probe is a reachability check, not upstream generation. No user-facing API, configuration, or documentation contract changed. The mandatory readiness categories were assessed; this change adds no data query, configuration input, or admin/mutation endpoint.
