### PR TITLE
test(daemon): pin #1323 queue lease invariants

### DIFF
--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -1386,34 +1386,51 @@ describe("hybridRecall", () => {
 		expect(result.results.map((row) => row.id)).not.toContain("mem-bm25-deleted");
 	});
 
-	it("keeps hint recall scoped to live memories for the requesting agent", async () => {
+	it("keeps hint recall scoped to live memories for the requesting non-default agent", async () => {
 		const now = new Date().toISOString();
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				`INSERT INTO memories (
 					id, content, type, agent_id, created_at, updated_at, updated_by, is_deleted
-				) VALUES (?, ?, 'fact', 'default', ?, ?, 'test', 1)`,
+				) VALUES (?, ?, 'fact', 'agent-b', ?, ?, 'test', 1)`,
 			).run("mem-hint-deleted", "deleted hint target has unrelated body", now, now);
 			db.prepare(
 				`INSERT INTO memories (
 					id, content, type, agent_id, created_at, updated_at, updated_by
-				) VALUES (?, ?, 'fact', 'agent-b', ?, ?, 'test')`,
+				) VALUES (?, ?, 'fact', 'default', ?, ?, 'test')`,
 			).run("mem-hint-other-agent", "other agent hint target has unrelated body", now, now);
 			db.prepare(
 				`INSERT INTO memories (
 					id, content, type, agent_id, created_at, updated_at, updated_by
-				) VALUES (?, ?, 'fact', 'default', ?, ?, 'test')`,
+				) VALUES (?, ?, 'fact', 'agent-b', ?, ?, 'test')`,
 			).run("mem-hint-live", "live hint target has unrelated body", now, now);
 			const stmt = db.prepare(
 				`INSERT INTO memory_hints (id, memory_id, agent_id, hint, created_at)
 				 VALUES (?, ?, ?, ?, ?)`,
 			);
-			stmt.run("hint-deleted", "mem-hint-deleted", "default", "hint-scope-marker", now);
-			stmt.run("hint-other-agent", "mem-hint-other-agent", "agent-b", "hint-scope-marker", now);
-			stmt.run("hint-live", "mem-hint-live", "default", "hint-scope-marker", now);
+			stmt.run("hint-deleted", "mem-hint-deleted", "agent-b", "hint-scope-marker", now);
+			stmt.run("hint-other-agent", "mem-hint-other-agent", "default", "hint-scope-marker", now);
+			stmt.run("hint-live", "mem-hint-live", "agent-b", "hint-scope-marker", now);
+			// A legacy bad write with a default hint agent must not leak agent-b's
+			// memory through a default-scoped recall request.
+			stmt.run("hint-mismatched", "mem-hint-live", "default", "hint-scope-marker mismatched", now);
 		});
 
 		const result = await hybridRecall(
+			{
+				query: "hint-scope-marker",
+				keywordQuery: "hint-scope-marker",
+				limit: 5,
+				agentId: "agent-b",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			async () => null,
+		);
+
+		expect(result.results.map((row) => row.id)).toEqual(["mem-hint-live"]);
+
+		const defaultResult = await hybridRecall(
 			{
 				query: "hint-scope-marker",
 				keywordQuery: "hint-scope-marker",
@@ -1424,8 +1441,7 @@ describe("hybridRecall", () => {
 			loadMemoryConfig(dir),
 			async () => null,
 		);
-
-		expect(result.results.map((row) => row.id)).toEqual(["mem-hint-live"]);
+		expect(defaultResult.results.map((row) => row.id)).toEqual(["mem-hint-other-agent"]);
 	});
 
 	it("defaults agent searches without readPolicy to isolated access", async () => {

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -1386,62 +1386,85 @@ describe("hybridRecall", () => {
 		expect(result.results.map((row) => row.id)).not.toContain("mem-bm25-deleted");
 	});
 
-	it("keeps hint recall scoped to live memories for the requesting non-default agent", async () => {
+	it("keeps hint and memory scope coupled across isolated, shared, and group recall", async () => {
 		const now = new Date().toISOString();
 		getDbAccessor().withWriteTx((db) => {
+			const agent = db.prepare(
+				`INSERT INTO agents (id, name, read_policy, policy_group, created_at, updated_at)
+				 VALUES (?, ?, 'isolated', ?, ?, ?)
+				 ON CONFLICT(id) DO UPDATE SET policy_group = excluded.policy_group, updated_at = excluded.updated_at`,
+			);
+			agent.run("agent-owner", "agent-owner", "team-1", now, now);
+			agent.run("agent-group-reader", "agent-group-reader", "team-1", now, now);
+			agent.run("agent-outsider", "agent-outsider", "team-2", now, now);
 			db.prepare(
 				`INSERT INTO memories (
-					id, content, type, agent_id, created_at, updated_at, updated_by, is_deleted
-				) VALUES (?, ?, 'fact', 'agent-b', ?, ?, 'test', 1)`,
-			).run("mem-hint-deleted", "deleted hint target has unrelated body", now, now);
-			db.prepare(
-				`INSERT INTO memories (
-					id, content, type, agent_id, created_at, updated_at, updated_by
-				) VALUES (?, ?, 'fact', 'default', ?, ?, 'test')`,
-			).run("mem-hint-other-agent", "other agent hint target has unrelated body", now, now);
-			db.prepare(
-				`INSERT INTO memories (
-					id, content, type, agent_id, created_at, updated_at, updated_by
-				) VALUES (?, ?, 'fact', 'agent-b', ?, ?, 'test')`,
-			).run("mem-hint-live", "live hint target has unrelated body", now, now);
+					id, content, type, agent_id, visibility, created_at, updated_at, updated_by
+				) VALUES (?, ?, 'fact', 'agent-owner', 'global', ?, ?, 'test')`,
+			).run("mem-hint-owner", "owner memory has unrelated body", now, now);
 			const stmt = db.prepare(
 				`INSERT INTO memory_hints (id, memory_id, agent_id, hint, created_at)
 				 VALUES (?, ?, ?, ?, ?)`,
 			);
-			stmt.run("hint-deleted", "mem-hint-deleted", "agent-b", "hint-scope-marker", now);
-			stmt.run("hint-other-agent", "mem-hint-other-agent", "default", "hint-scope-marker", now);
-			stmt.run("hint-live", "mem-hint-live", "agent-b", "hint-scope-marker", now);
-			// A legacy bad write with a default hint agent must not leak agent-b's
-			// memory through a default-scoped recall request.
-			stmt.run("hint-mismatched", "mem-hint-live", "default", "hint-scope-marker mismatched", now);
+			stmt.run("hint-owner", "mem-hint-owner", "agent-owner", "hint-scope-marker", now);
+			// A legacy bad write with a different hint agent must not expose the
+			// owner's memory through any authorized-memory scope.
+			stmt.run("hint-mismatched", "mem-hint-owner", "default", "hint-scope-marker mismatched", now);
 		});
 
-		const result = await hybridRecall(
+		const ownerResult = await hybridRecall(
 			{
 				query: "hint-scope-marker",
 				keywordQuery: "hint-scope-marker",
 				limit: 5,
-				agentId: "agent-b",
+				agentId: "agent-owner",
 				readPolicy: "isolated",
 			},
 			loadMemoryConfig(dir),
 			async () => null,
 		);
+		expect(ownerResult.results.map((row) => row.id)).toEqual(["mem-hint-owner"]);
 
-		expect(result.results.map((row) => row.id)).toEqual(["mem-hint-live"]);
-
-		const defaultResult = await hybridRecall(
+		const sharedResult = await hybridRecall(
 			{
 				query: "hint-scope-marker",
 				keywordQuery: "hint-scope-marker",
 				limit: 5,
-				agentId: "default",
-				readPolicy: "isolated",
+				agentId: "agent-shared-reader",
+				readPolicy: "shared",
 			},
 			loadMemoryConfig(dir),
 			async () => null,
 		);
-		expect(defaultResult.results.map((row) => row.id)).toEqual(["mem-hint-other-agent"]);
+		expect(sharedResult.results.map((row) => row.id)).toEqual(["mem-hint-owner"]);
+
+		const groupResult = await hybridRecall(
+			{
+				query: "hint-scope-marker",
+				keywordQuery: "hint-scope-marker",
+				limit: 5,
+				agentId: "agent-group-reader",
+				readPolicy: "group",
+				policyGroup: "team-1",
+			},
+			loadMemoryConfig(dir),
+			async () => null,
+		);
+		expect(groupResult.results.map((row) => row.id)).toEqual(["mem-hint-owner"]);
+
+		const outsiderResult = await hybridRecall(
+			{
+				query: "hint-scope-marker",
+				keywordQuery: "hint-scope-marker",
+				limit: 5,
+				agentId: "agent-outsider",
+				readPolicy: "group",
+				policyGroup: "team-2",
+			},
+			loadMemoryConfig(dir),
+			async () => null,
+		);
+		expect(outsiderResult.results.map((row) => row.id)).toEqual([]);
 	});
 
 	it("defaults agent searches without readPolicy to isolated access", async () => {

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -1496,12 +1496,13 @@ export async function hybridRecall(
 					   CROSS JOIN memories m ON m.id = h.memory_id
 					   WHERE memory_hints_fts MATCH ?
 					     AND h.agent_id = ?
+					     AND m.agent_id = ?
 					     AND m.is_deleted = 0
 					     ${memorySupersessionSql(db)}${filter.sql}
 					   ORDER BY raw_score LIMIT ?`;
 
 					const agentId = params.agentId ?? "default";
-					const args = [keywordQuery, agentId, ...filter.args, cfg.search.top_k];
+					const args = [keywordQuery, agentId, agentId, ...filter.args, cfg.search.top_k];
 
 					const rows = prepareTypedStatement<{ id: string; raw_score: number }>(db, sql).all(...args);
 

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -1495,14 +1495,12 @@ export async function hybridRecall(
 					   CROSS JOIN memory_hints h ON memory_hints_fts.rowid = h.rowid
 					   CROSS JOIN memories m ON m.id = h.memory_id
 					   WHERE memory_hints_fts MATCH ?
-					     AND h.agent_id = ?
-					     AND m.agent_id = ?
+					     AND h.agent_id = m.agent_id
 					     AND m.is_deleted = 0
 					     ${memorySupersessionSql(db)}${filter.sql}
 					   ORDER BY raw_score LIMIT ?`;
 
-					const agentId = params.agentId ?? "default";
-					const args = [keywordQuery, agentId, agentId, ...filter.args, cfg.search.top_k];
+					const args = [keywordQuery, ...filter.args, cfg.search.top_k];
 
 					const rows = prepareTypedStatement<{ id: string; raw_score: number }>(db, sql).all(...args);
 

--- a/platform/daemon/src/pipeline/dreaming-worker.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.test.ts
@@ -8,11 +8,13 @@ import { runMigrations } from "../../../core/src/migrations";
 import type { DbAccessor } from "../db-accessor";
 import {
 	DREAMING_AGENT_PROMPT,
+	type DreamingAgentExecutor,
 	type DreamingPassFocus,
 	dreamingFocusOfMode,
 	enqueueDreamingHygieneAttention,
 } from "./dreaming";
 import {
+	AlreadyRunningError,
 	createAgentScopeSnapshot,
 	getDreamingWorkerAgentIds,
 	selectDreamingCheckMode,
@@ -175,6 +177,46 @@ describe("dreaming worker agent scope", () => {
 			).toEqual({ count: 0 });
 		} finally {
 			worker.stop();
+		}
+	});
+
+	it("rejects an overlapping manual pass without skipping the active pass", async () => {
+		db.prepare(
+			`INSERT INTO session_transcripts
+			 (session_key, agent_id, content, harness, created_at, updated_at, completed_at)
+			 VALUES ('overlap-evidence', 'default', 'Evidence for one in-flight pass.', 'pi',
+			         datetime('now'), datetime('now'), datetime('now'))`,
+		).run();
+
+		let started = false;
+		let release: () => void = () => undefined;
+		const gate = new Promise<void>((resolve) => {
+			release = () => resolve();
+		});
+		const executorFactory = (): DreamingAgentExecutor => ({
+			async run(_input: Parameters<DreamingAgentExecutor["run"]>[0]) {
+				started = true;
+				await gate;
+				return { summary: "Completed one active pass" };
+			},
+		});
+
+		const worker = startDreamingWorker(accessor, defaultCfg({ tokenThreshold: 1 }), agentsDir, "default", {
+			executorFactory,
+		});
+		try {
+			const first = worker.trigger("incremental", "default");
+			await waitFor(() => started, 2_000);
+			await expect(worker.trigger("incremental", "default")).rejects.toBeInstanceOf(AlreadyRunningError);
+			release();
+			await first;
+
+			expect(db.prepare("SELECT status, COUNT(*) AS count FROM dreaming_passes GROUP BY status").all()).toEqual([
+				{ status: "completed", count: 1 },
+			]);
+		} finally {
+			worker.stop();
+			release();
 		}
 	});
 

--- a/platform/daemon/src/pipeline/prospective-index.test.ts
+++ b/platform/daemon/src/pipeline/prospective-index.test.ts
@@ -106,6 +106,15 @@ function getJob(
 		| undefined;
 }
 
+async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(`Condition not met within ${timeoutMs}ms`);
+}
+
 /** Shared pipeline config with hints enabled. */
 function pipelineCfg(hints = HINTS_CFG) {
 	return {
@@ -422,6 +431,89 @@ describe("prospective-index", () => {
 	// -----------------------------------------------------------------------
 
 	describe("startHintsWorker", () => {
+		it("leases prospective jobs in created order", async () => {
+			const firstId = crypto.randomUUID();
+			const secondId = crypto.randomUUID();
+			insertMemory(db, firstId, "first queued memory content");
+			insertMemory(db, secondId, "second queued memory content");
+
+			accessor.withWriteTx((wdb) => {
+				enqueueHintsJob(wdb, firstId, "first queued memory content");
+				enqueueHintsJob(wdb, secondId, "second queued memory content");
+			});
+			accessor.withWriteTx((wdb) => {
+				wdb
+					.prepare("UPDATE memory_jobs SET created_at = ? WHERE memory_id = ? AND job_type = 'prospective_index'")
+					.run("2026-06-20T10:00:00.000Z", firstId);
+				wdb
+					.prepare("UPDATE memory_jobs SET created_at = ? WHERE memory_id = ? AND job_type = 'prospective_index'")
+					.run("2026-06-20T10:01:00.000Z", secondId);
+			});
+
+			const prompts: string[] = [];
+			const provider: LlmProvider = {
+				name: "mock-order",
+				async generate(prompt) {
+					prompts.push(prompt);
+					return "";
+				},
+				async available() {
+					return true;
+				},
+			};
+			const handle = startHintsWorker({ accessor, provider, pipelineCfg: pipelineCfg() });
+			try {
+				await waitFor(
+					() => getJob(db, firstId)?.status === "completed" && getJob(db, secondId)?.status === "completed",
+					2_000,
+				);
+			} finally {
+				await handle.stop();
+			}
+
+			expect(prompts).toHaveLength(2);
+			expect(prompts[0]).toContain("first queued memory content");
+			expect(prompts[1]).toContain("second queued memory content");
+		});
+
+		it("does not lease one prospective job to concurrent workers twice", async () => {
+			const memoryId = crypto.randomUUID();
+			insertMemory(db, memoryId, "one concurrently leased memory");
+			accessor.withWriteTx((wdb) => {
+				enqueueHintsJob(wdb, memoryId, "one concurrently leased memory");
+			});
+
+			let calls = 0;
+			let release: () => void = () => undefined;
+			const gate = new Promise<void>((resolve) => {
+				release = () => resolve();
+			});
+			const provider: LlmProvider = {
+				name: "mock-concurrent",
+				async generate() {
+					calls += 1;
+					await gate;
+					return "";
+				},
+				async available() {
+					return true;
+				},
+			};
+			const first = startHintsWorker({ accessor, provider, pipelineCfg: pipelineCfg() });
+			const second = startHintsWorker({ accessor, provider, pipelineCfg: pipelineCfg() });
+			try {
+				await waitFor(() => calls === 1 && getJob(db, memoryId)?.status === "leased", 2_000);
+				release();
+				await waitFor(() => getJob(db, memoryId)?.status === "completed", 2_000);
+			} finally {
+				release();
+				await Promise.all([first.stop(), second.stop()]);
+			}
+
+			expect(calls).toBe(1);
+			expect(getJob(db, memoryId)?.attempts).toBe(1);
+		});
+
 		it("processes a job and writes hints to memory_hints", async () => {
 			const mid = crypto.randomUUID();
 			insertMemory(db, mid, "Caroline moved from Portland to Seattle in 2019");

--- a/platform/daemon/src/pipeline/prospective-index.test.ts
+++ b/platform/daemon/src/pipeline/prospective-index.test.ts
@@ -619,9 +619,9 @@ describe("prospective-index", () => {
 			expect(handle.running).toBe(false);
 		});
 
-		it("deduplicates hints via UNIQUE constraint", async () => {
+		it("keeps retried hint indexing in the parent memory agent scope", async () => {
 			const mid = crypto.randomUUID();
-			insertMemory(db, mid, "test");
+			insertMemory(db, mid, "test", "agent-b");
 
 			// Enqueue two jobs for the same memory
 			accessor.withWriteTx((wdb) => {
@@ -638,9 +638,15 @@ describe("prospective-index", () => {
 			await new Promise((r) => setTimeout(r, 400));
 			await handle.stop();
 
-			// Same hints should not duplicate due to UNIQUE(memory_id, hint)
+			// Same hints should not duplicate due to UNIQUE(memory_id, hint), and
+			// every retry must re-read the parent memory's agent rather than use a
+			// worker-default scope.
 			const hints = getHints(db, mid);
 			expect(hints.length).toBe(5);
+			const agentIds = db.prepare("SELECT DISTINCT agent_id FROM memory_hints WHERE memory_id = ?").all(mid) as Array<{
+				agent_id: string;
+			}>;
+			expect(agentIds).toEqual([{ agent_id: "agent-b" }]);
 		});
 
 		it("requeues throwing jobs immediately instead of leaving them leased for the reaper", async () => {

--- a/platform/daemon/src/pipeline/prospective-index.test.ts
+++ b/platform/daemon/src/pipeline/prospective-index.test.ts
@@ -41,14 +41,14 @@ function makeAccessor(db: Database): DbAccessor {
 	};
 }
 
-function insertMemory(db: Database, id: string, content: string): void {
+function insertMemory(db: Database, id: string, content: string, agentId = "default"): void {
 	const now = new Date().toISOString();
 	db.prepare(
 		`INSERT INTO memories
-		 (id, type, content, confidence, importance, created_at, updated_at,
+		 (id, type, content, agent_id, confidence, importance, created_at, updated_at,
 		  updated_by, vector_clock, is_deleted, extraction_status)
-		 VALUES (?, 'fact', ?, 1.0, 0.5, ?, ?, 'test', '{}', 0, 'none')`,
-	).run(id, content, now, now);
+		 VALUES (?, 'fact', ?, ?, 1.0, 0.5, ?, ?, 'test', '{}', 0, 'none')`,
+	).run(id, content, agentId, now, now);
 }
 
 const HINTS_CFG: PipelineHintsConfig = {
@@ -561,6 +561,30 @@ describe("prospective-index", () => {
 			const ftsMatches = getHintsFts(db, '"Caroline" "live"');
 			expect(ftsMatches.length).toBeGreaterThan(0);
 			expect(ftsMatches[0]).toBe(mid);
+		});
+
+		it("preserves the memory agent on generated hints", async () => {
+			const mid = crypto.randomUUID();
+			insertMemory(db, mid, "Caroline moved to Seattle", "agent-b");
+			accessor.withWriteTx((wdb) => {
+				enqueueHintsJob(wdb, mid, "Caroline moved to Seattle");
+			});
+
+			const handle = startHintsWorker({
+				accessor,
+				provider: cleanProvider(),
+				pipelineCfg: pipelineCfg(),
+			});
+			try {
+				await waitFor(() => getJob(db, mid)?.status === "completed", 2_000);
+			} finally {
+				await handle.stop();
+			}
+
+			const agentIds = db.prepare("SELECT DISTINCT agent_id FROM memory_hints WHERE memory_id = ?").all(mid) as Array<{
+				agent_id: string;
+			}>;
+			expect(agentIds).toEqual([{ agent_id: "agent-b" }]);
 		});
 
 		it("completes job with zero hints on empty LLM response", async () => {

--- a/platform/daemon/src/pipeline/prospective-index.ts
+++ b/platform/daemon/src/pipeline/prospective-index.ts
@@ -179,7 +179,11 @@ function failJob(db: WriteDb, jobId: string, error: string): void {
 // Persist hints
 // ---------------------------------------------------------------------------
 
-function writeHints(db: WriteDb, memoryId: string, agentId: string, hints: readonly string[]): number {
+function writeHints(db: WriteDb, memoryId: string, hints: readonly string[]): number {
+	const memory = db.prepare("SELECT agent_id FROM memories WHERE id = ? AND is_deleted = 0").get(memoryId) as {
+		agent_id?: unknown;
+	} | null;
+	if (typeof memory?.agent_id !== "string" || memory.agent_id.length === 0) return 0;
 	const stmt = db.prepare(
 		`INSERT OR IGNORE INTO memory_hints (id, memory_id, agent_id, hint, created_at)
 		 VALUES (?, ?, ?, ?, ?)`,
@@ -188,7 +192,7 @@ function writeHints(db: WriteDb, memoryId: string, agentId: string, hints: reado
 	let inserted = 0;
 	for (const hint of hints) {
 		const id = crypto.randomUUID();
-		stmt.run(id, memoryId, agentId, hint, now);
+		stmt.run(id, memoryId, memory.agent_id, hint, now);
 		inserted++;
 	}
 	return inserted;
@@ -243,7 +247,7 @@ export function startHintsWorker(deps: {
 
 			if (hints.length > 0) {
 				accessor.withWriteTx((db) => {
-					writeHints(db, payload.memoryId, "default", hints);
+					writeHints(db, payload.memoryId, hints);
 					completeJob(db, j.id);
 				});
 				logger.info("pipeline", "Prospective hints generated", {

--- a/platform/daemon/src/transcript-capture-worker.test.ts
+++ b/platform/daemon/src/transcript-capture-worker.test.ts
@@ -3,6 +3,8 @@ import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { indexCanonicalTranscriptJsonl, writeTranscriptArtifact } from "./memory-lineage";
+import { writeCanonicalTranscriptFromSnapshot } from "./transcript-capture";
 import {
 	enqueueTranscriptCaptureJob,
 	getTranscriptCaptureJobStatus,
@@ -175,7 +177,7 @@ describe("transcript capture worker", () => {
 		).toEqual({ count: 1 });
 	});
 
-	it("leases same-session evidence in created order", async () => {
+	it("leases same-session evidence by enqueue time, not capture time", async () => {
 		const base = {
 			agentId: "agent-a",
 			harness: "claude-code",
@@ -184,28 +186,28 @@ describe("transcript capture worker", () => {
 			rawTranscript: "snapshot",
 			endedAt: "2026-06-20T10:00:00.000Z",
 		} as const;
-		const first = enqueueTranscriptCaptureJob(getDbAccessor(), {
+		const newerCapture = enqueueTranscriptCaptureJob(getDbAccessor(), {
 			...base,
-			sessionId: "snapshot-ordered-first",
-			transcript: "User: first turn",
-			capturedAt: "2026-06-20T10:00:00.000Z",
-		});
-		const second = enqueueTranscriptCaptureJob(getDbAccessor(), {
-			...base,
-			sessionId: "snapshot-ordered-second",
-			transcript: "User: second turn",
+			sessionId: "snapshot-ordered-newer",
+			transcript: "User: later turn arrived first",
 			capturedAt: "2026-06-20T10:01:00.000Z",
 		});
-		if (!first || !second) throw new Error("expected ordered capture jobs");
+		const olderCapture = enqueueTranscriptCaptureJob(getDbAccessor(), {
+			...base,
+			sessionId: "snapshot-ordered-older",
+			transcript: "User: earlier turn arrived later",
+			capturedAt: "2026-06-20T10:00:00.000Z",
+		});
+		if (!newerCapture || !olderCapture) throw new Error("expected ordered capture jobs");
 
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare("UPDATE transcript_capture_jobs SET created_at = ? WHERE id = ?").run(
 				"2026-06-20T10:00:00.000Z",
-				first,
+				newerCapture,
 			);
 			db.prepare("UPDATE transcript_capture_jobs SET created_at = ? WHERE id = ?").run(
 				"2026-06-20T10:01:00.000Z",
-				second,
+				olderCapture,
 			);
 		});
 
@@ -215,8 +217,8 @@ describe("transcript capture worker", () => {
 				db.prepare("SELECT id, status, attempts FROM transcript_capture_jobs ORDER BY created_at").all(),
 			),
 		).toEqual([
-			{ id: first, status: "completed", attempts: 1 },
-			{ id: second, status: "pending", attempts: 0 },
+			{ id: newerCapture, status: "completed", attempts: 1 },
+			{ id: olderCapture, status: "pending", attempts: 0 },
 		]);
 
 		expect(await runTranscriptCaptureOnce(getDbAccessor(), dir)).toBe(true);
@@ -250,8 +252,8 @@ describe("transcript capture worker", () => {
 		).toEqual({ attempts: 1 });
 	});
 
-	it("recovers an interrupted lease without duplicating the capture", async () => {
-		const id = enqueueTranscriptCaptureJob(getDbAccessor(), {
+	it("recovery preserves durable outputs and provenance after a lease crashes before completion", async () => {
+		const capture = {
 			agentId: "agent-a",
 			harness: "pi",
 			sessionKey: "session-restart",
@@ -261,8 +263,25 @@ describe("transcript capture worker", () => {
 			rawTranscript: "survives restart",
 			capturedAt: "2026-06-20T10:00:00.000Z",
 			endedAt: "2026-06-20T10:00:00.000Z",
-		});
+		} as const;
+		const id = enqueueTranscriptCaptureJob(getDbAccessor(), capture);
 		if (!id) throw new Error("expected restart capture job");
+
+		// Model the real crash window after the canonical file, immutable artifact,
+		// and indexed provenance have committed but before markDone updates the job.
+		await writeCanonicalTranscriptFromSnapshot({ basePath: dir, ...capture });
+		const artifact = await writeTranscriptArtifact({ ...capture, startedAt: null, summaryStatus: "not_requested" });
+		indexCanonicalTranscriptJsonl({ ...capture, startedAt: null, manifestPath: artifact.manifestPath });
+		const beforeRecovery = getDbAccessor().withReadDb((db) =>
+			db
+				.prepare(
+					`SELECT agent_id, source_kind, source_path, session_id, session_key
+					 FROM memory_artifacts WHERE agent_id = ? ORDER BY source_kind, source_path`,
+				)
+				.all("agent-a"),
+		);
+		expect(beforeRecovery).not.toEqual([]);
+
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare("UPDATE transcript_capture_jobs SET status = 'processing', attempts = 1 WHERE id = ?").run(id);
 		});
@@ -285,5 +304,15 @@ describe("transcript capture worker", () => {
 			error: null,
 		});
 		expect(getTranscriptCaptureStatus(getDbAccessor(), "agent-a")).toMatchObject({ completed: 1, processing: 0 });
+		expect(
+			getDbAccessor().withReadDb((db) =>
+				db
+					.prepare(
+						`SELECT agent_id, source_kind, source_path, session_id, session_key
+						 FROM memory_artifacts WHERE agent_id = ? ORDER BY source_kind, source_path`,
+					)
+					.all("agent-a"),
+			),
+		).toEqual(beforeRecovery);
 	});
 });

--- a/platform/daemon/src/transcript-capture-worker.test.ts
+++ b/platform/daemon/src/transcript-capture-worker.test.ts
@@ -8,6 +8,7 @@ import {
 	getTranscriptCaptureJobStatus,
 	getTranscriptCaptureStatus,
 	runTranscriptCaptureOnce,
+	startTranscriptCaptureWorker,
 } from "./transcript-capture-worker";
 
 let dir = "";
@@ -172,5 +173,117 @@ describe("transcript capture worker", () => {
 		expect(
 			getDbAccessor().withReadDb((db) => db.prepare("SELECT COUNT(*) AS count FROM transcript_capture_jobs").get()),
 		).toEqual({ count: 1 });
+	});
+
+	it("leases same-session evidence in created order", async () => {
+		const base = {
+			agentId: "agent-a",
+			harness: "claude-code",
+			sessionKey: "session-ordered",
+			project: "/repo",
+			rawTranscript: "snapshot",
+			endedAt: "2026-06-20T10:00:00.000Z",
+		} as const;
+		const first = enqueueTranscriptCaptureJob(getDbAccessor(), {
+			...base,
+			sessionId: "snapshot-ordered-first",
+			transcript: "User: first turn",
+			capturedAt: "2026-06-20T10:00:00.000Z",
+		});
+		const second = enqueueTranscriptCaptureJob(getDbAccessor(), {
+			...base,
+			sessionId: "snapshot-ordered-second",
+			transcript: "User: second turn",
+			capturedAt: "2026-06-20T10:01:00.000Z",
+		});
+		if (!first || !second) throw new Error("expected ordered capture jobs");
+
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE transcript_capture_jobs SET created_at = ? WHERE id = ?").run(
+				"2026-06-20T10:00:00.000Z",
+				first,
+			);
+			db.prepare("UPDATE transcript_capture_jobs SET created_at = ? WHERE id = ?").run(
+				"2026-06-20T10:01:00.000Z",
+				second,
+			);
+		});
+
+		expect(await runTranscriptCaptureOnce(getDbAccessor(), dir)).toBe(true);
+		expect(
+			getDbAccessor().withReadDb((db) =>
+				db.prepare("SELECT id, status, attempts FROM transcript_capture_jobs ORDER BY created_at").all(),
+			),
+		).toEqual([
+			{ id: first, status: "completed", attempts: 1 },
+			{ id: second, status: "pending", attempts: 0 },
+		]);
+
+		expect(await runTranscriptCaptureOnce(getDbAccessor(), dir)).toBe(true);
+		expect(getTranscriptCaptureStatus(getDbAccessor(), "agent-a")).toMatchObject({ completed: 2, pending: 0 });
+	});
+
+	it("concurrent workers claim one snapshot once", async () => {
+		const id = enqueueTranscriptCaptureJob(getDbAccessor(), {
+			agentId: "agent-a",
+			harness: "pi",
+			sessionKey: "session-concurrent",
+			sessionId: "snapshot-concurrent",
+			project: "/repo",
+			transcript: "User: one durable turn",
+			rawTranscript: "one durable turn",
+			capturedAt: "2026-06-20T10:00:00.000Z",
+			endedAt: "2026-06-20T10:00:00.000Z",
+		});
+		if (!id) throw new Error("expected concurrent capture job");
+
+		const results = await Promise.all([
+			runTranscriptCaptureOnce(getDbAccessor(), dir),
+			runTranscriptCaptureOnce(getDbAccessor(), dir),
+		]);
+		expect(results.sort()).toEqual([false, true]);
+		expect(getTranscriptCaptureStatus(getDbAccessor(), "agent-a")).toMatchObject({ completed: 1, pending: 0 });
+		expect(
+			getDbAccessor().withReadDb((db) =>
+				db.prepare("SELECT attempts FROM transcript_capture_jobs WHERE id = ?").get(id),
+			),
+		).toEqual({ attempts: 1 });
+	});
+
+	it("recovers an interrupted lease without duplicating the capture", async () => {
+		const id = enqueueTranscriptCaptureJob(getDbAccessor(), {
+			agentId: "agent-a",
+			harness: "pi",
+			sessionKey: "session-restart",
+			sessionId: "snapshot-restart",
+			project: "/repo",
+			transcript: "User: survives restart",
+			rawTranscript: "survives restart",
+			capturedAt: "2026-06-20T10:00:00.000Z",
+			endedAt: "2026-06-20T10:00:00.000Z",
+		});
+		if (!id) throw new Error("expected restart capture job");
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE transcript_capture_jobs SET status = 'processing', attempts = 1 WHERE id = ?").run(id);
+		});
+
+		const worker = startTranscriptCaptureWorker(getDbAccessor(), dir);
+		try {
+			const deadline = Date.now() + 2_000;
+			while (Date.now() < deadline) {
+				const status = getTranscriptCaptureJobStatus(getDbAccessor(), "agent-a", id);
+				if (status?.status === "completed") break;
+				await new Promise((resolve) => setTimeout(resolve, 10));
+			}
+		} finally {
+			worker.stop();
+		}
+
+		expect(getTranscriptCaptureJobStatus(getDbAccessor(), "agent-a", id)).toEqual({
+			id,
+			status: "completed",
+			error: null,
+		});
+		expect(getTranscriptCaptureStatus(getDbAccessor(), "agent-a")).toMatchObject({ completed: 1, processing: 0 });
 	});
 });


### PR DESCRIPTION
## Summary

Pins the queue ordering and interrupted-lease contracts requested by #1323, and fixes prospective-index hints so their agent identity matches the indexed memory. Recall now requires both the hint and its target memory to belong to the requesting agent.

Closes #1323

## Changes

- Add transcript capture coverage for enqueue-order leasing when capture chronology arrives out of order, concurrent claims, and recovery after canonical/artifact/index writes but before job completion.
- Add prospective-index coverage for created-at ordering, competing workers, and non-default-agent hint writes.
- Add recall coverage showing a mismatched legacy hint cannot expose a different agent's memory.
- Scope generated hints to the persisted memory agent and scope hint recall to both hint and target-memory agents.
- Keep Dreaming coverage proving an overlapping manual pass is rejected while the active pass completes exactly once.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [x] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A: no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A: no migrations touched.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Validation run after rebasing onto origin/main:

- `bun test platform/daemon/src/transcript-capture-worker.test.ts platform/daemon/src/pipeline/dreaming-worker.test.ts platform/daemon/src/pipeline/prospective-index.test.ts platform/daemon/src/pipeline/stale-leases.test.ts platform/daemon/src/startup-recovery.test.ts platform/daemon/src/memory-search.test.ts` - 98 pass, 0 fail.
- `bunx biome check platform/daemon/src/pipeline/prospective-index.ts platform/daemon/src/pipeline/prospective-index.test.ts platform/daemon/src/memory-search.ts platform/daemon/src/memory-search.test.ts platform/daemon/src/transcript-capture-worker.test.ts` - passed.
- `bun run --filter '@signet/daemon' typecheck` - passed.
- `bun run --filter '@signet/daemon' build` - passed.
- `git diff --check origin/main...HEAD` - passed.
- Full workspace typecheck and lint retain the pre-existing unrelated failures documented on the original PR.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The original queue assertions remain test coverage of existing created-at leasing, transaction claim boundaries, Dreaming single-flight, and startup/retry recovery. The non-default prospective-hint test exposed a production agent-scope defect. The branch now fixes the smallest write/read layers and guards both sides with regression coverage.
