### PR TITLE
fix(embedding): reconcile failed vector writes

### DIFF
--- a/platform/daemon/src/db-helpers.ts
+++ b/platform/daemon/src/db-helpers.ts
@@ -59,7 +59,7 @@ function invalidateUmapCache(db: WriteDb): void {
 function vecTableExists(db: WriteDb): boolean {
 	try {
 		const row = db.prepare("SELECT name FROM sqlite_master WHERE name = 'vec_embeddings' AND type = 'table'").get();
-		return row !== undefined;
+		return row != null;
 	} catch {
 		return false;
 	}
@@ -102,19 +102,21 @@ export function syncVecInsert(db: WriteDb, embeddingId: string, vector: readonly
 
 /**
  * Remove rows from vec_embeddings that match embedding ids.
- * Call after deleting from the embeddings table.
+ * Call before deleting from the embeddings table so a failed derived-index
+ * write leaves the canonical row available for retry.
  */
-export function syncVecDeleteByEmbeddingIds(db: WriteDb, embeddingIds: readonly string[]): void {
-	if (embeddingIds.length === 0) return;
+export function syncVecDeleteByEmbeddingIds(db: WriteDb, embeddingIds: readonly string[]): boolean {
+	if (embeddingIds.length === 0) return true;
 	invalidateUmapCache(db);
-	if (!vecTableExists(db)) return;
+	if (!vecTableExists(db)) return true;
 	try {
 		const stmt = db.prepare("DELETE FROM vec_embeddings WHERE id = ?");
 		for (const id of embeddingIds) {
 			stmt.run(id);
 		}
+		return true;
 	} catch {
-		// non-fatal
+		return false;
 	}
 }
 

--- a/platform/daemon/src/embedding-index-migration.test.ts
+++ b/platform/daemon/src/embedding-index-migration.test.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
 import { findSqliteVecExtension } from "@signet/core";
 import { up as embeddingIndexGenerations } from "../../core/src/migrations/091-embedding-index-generations";
-import { type DbAccessor, DbWriteQueueFullError, type ReadDb, type WriteDb } from "./db-accessor";
+import { type DbAccessor, DbWriteQueueFullError, type ReadDb, type SqliteStatement, type WriteDb } from "./db-accessor";
 import {
 	promoteStagingIndex,
 	stageEmbeddingBatch,
@@ -12,6 +12,34 @@ import {
 import { beginEmbeddingIndexBuild, ensureEmbeddingIndexState, readEmbeddingIndexState } from "./embedding-index-state";
 
 const VEC_EXTENSION = findSqliteVecExtension();
+
+function failIndexStateUpdateOnce(raw: Database): WriteDb {
+	let failed = false;
+	return {
+		exec(sql: string): void {
+			raw.exec(sql);
+		},
+		prepare(sql: string): SqliteStatement {
+			const statement = raw.prepare(sql) as unknown as SqliteStatement;
+			if (!sql.includes("UPDATE embedding_index_state")) return statement;
+			return {
+				run(...params: unknown[]) {
+					if (!failed) {
+						failed = true;
+						throw new Error("simulated index-state update failure");
+					}
+					return statement.run(...params);
+				},
+				get(...params: unknown[]) {
+					return statement.get(...params);
+				},
+				all<Row = unknown>(...params: unknown[]) {
+					return statement.all<Row>(...params);
+				},
+			};
+		},
+	};
+}
 
 describe("staging embedding coverage", () => {
 	it("requires every active row, including source chunks, at the staged dimensions", () => {
@@ -375,6 +403,72 @@ describe("staging promotion", () => {
 			.prepare("SELECT id FROM vec_embeddings WHERE embedding MATCH ? AND k = 1")
 			.get(new Float32Array([0, 1, 0]));
 		expect(nearest).toEqual({ id: "new" });
+	});
+
+	it("rolls back vec rebuild when index state commit fails after vector insertion", () => {
+		if (!VEC_EXTENSION) return;
+		const raw = new Database(":memory:");
+		raw.loadExtension(VEC_EXTENSION);
+		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);
+		raw.exec(`
+			CREATE TABLE memories (id TEXT PRIMARY KEY, embedding_model TEXT);
+			CREATE TABLE embeddings (id TEXT, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER, source_type TEXT, source_id TEXT, created_at TEXT);
+			CREATE TABLE embeddings_staging (id TEXT, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER, source_type TEXT, source_id TEXT, created_at TEXT);
+			CREATE VIRTUAL TABLE vec_embeddings USING vec0(id TEXT PRIMARY KEY, embedding FLOAT[3] distance_metric=cosine);
+			CREATE VIRTUAL TABLE vec_embeddings_staging USING vec0(id TEXT PRIMARY KEY, embedding FLOAT[3] distance_metric=cosine);
+		`);
+		const db = raw as unknown as WriteDb;
+		const active = {
+			provider: "ollama",
+			model: "nomic-embed-text",
+			dimensions: 3,
+			base_url: "http://127.0.0.1:11434",
+		} as const;
+		const staged = { ...active, model: "qwen3-embedding:0.6b" };
+		ensureEmbeddingIndexState(db, active);
+		beginEmbeddingIndexBuild(db, staged);
+		raw.exec(`
+			INSERT INTO memories VALUES ('memory-1', 'nomic-embed-text');
+			INSERT INTO embeddings VALUES ('old', 'shared-content', X'0000803F0000000000000000', 3, 'memory', 'memory-1', '2026-01-01');
+			INSERT INTO embeddings_staging VALUES ('new', 'shared-content', X'000000000000803F00000000', 3, 'memory', 'memory-1', '2026-01-01');
+		`);
+		raw.prepare("INSERT INTO vec_embeddings (id, embedding) VALUES (?, ?)").run("old", new Float32Array([1, 0, 0]));
+		raw
+			.prepare("INSERT INTO vec_embeddings_staging (id, embedding) VALUES (?, ?)")
+			.run("new", new Float32Array([0, 1, 0]));
+
+		const failingDb = failIndexStateUpdateOnce(raw);
+		const accessor: DbAccessor = {
+			withWriteTx: (fn) => {
+				raw.exec("BEGIN IMMEDIATE");
+				try {
+					const result = fn(failingDb);
+					raw.exec("COMMIT");
+					return result;
+				} catch (error) {
+					raw.exec("ROLLBACK");
+					throw error;
+				}
+			},
+			withReadDb: (fn) => fn(raw as unknown as ReadDb),
+			close: () => undefined,
+		};
+
+		expect(() => promoteStagingIndex(accessor)).toThrow("simulated index-state update failure");
+		expect(readEmbeddingIndexState(raw as unknown as ReadDb)?.state).toBe("building");
+		expect(raw.prepare("SELECT id, content_hash FROM embeddings").get()).toEqual({
+			id: "old",
+			content_hash: "shared-content",
+		});
+		expect(raw.prepare("SELECT id, content_hash FROM embeddings_staging").get()).toEqual({
+			id: "new",
+			content_hash: "shared-content",
+		});
+		expect(raw.prepare("SELECT id FROM vec_embeddings").get()).toEqual({ id: "old" });
+		expect(raw.prepare("SELECT id FROM vec_embeddings_staging").get()).toEqual({ id: "new" });
+		expect(raw.prepare("SELECT embedding_model FROM memories WHERE id = 'memory-1'").get()).toEqual({
+			embedding_model: "nomic-embed-text",
+		});
 	});
 });
 

--- a/platform/daemon/src/imported-source-lifecycle.test.ts
+++ b/platform/daemon/src/imported-source-lifecycle.test.ts
@@ -226,4 +226,91 @@ describe("imported source lifecycle", () => {
 			),
 		).toEqual({ kind: "hygiene", subject_ref: `source:${sourceId}` });
 	});
+
+	it("keeps imported evidence and canonical embeddings retryable when vec cleanup fails", () => {
+		const sourceId = "source-import-vec-failure";
+		const agentId = "lifecycle-test-agent";
+		const otherAgentId = "other-agent";
+		const now = new Date().toISOString();
+		indexExternalMemoryArtifact({
+			agentId,
+			sourcePath: "imports/source-import-vec-failure/notes.json",
+			sourceKind: "source_import_json_projection",
+			harness: "dashboard-import",
+			content: "Retryable imported evidence",
+			sourceMtimeMs: Date.now(),
+			sourceId,
+			sourceRoot: "notes.json",
+			sourceExternalId: "hash-vec-failure",
+			sourceMeta: { representation: "structured-json-projection" },
+		});
+		getDbAccessor().withWriteTx((db) => {
+			// Replace the migration's virtual table with a regular test double so a
+			// trigger can inject a derived-index delete failure deterministically.
+			db.exec("DROP TABLE vec_embeddings");
+			db.exec("CREATE TABLE vec_embeddings (id TEXT PRIMARY KEY, embedding BLOB NOT NULL)");
+			db.prepare(
+				`INSERT INTO embeddings
+				 (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+				 VALUES (?, ?, ?, 3, 'source_chunk', ?, ?, ?, ?)`,
+			).run(
+				"embedding-owned",
+				"hash-owned",
+				Buffer.from(new Float32Array([1, 2, 3]).buffer),
+				`${sourceId}:notes.json#1`,
+				"owned",
+				now,
+				agentId,
+			);
+			db.prepare(
+				`INSERT INTO embeddings
+				 (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+				 VALUES (?, ?, ?, 3, 'source_chunk', ?, ?, ?, ?)`,
+			).run(
+				"embedding-other",
+				"hash-other",
+				Buffer.from(new Float32Array([4, 5, 6]).buffer),
+				`${sourceId}:other.json#1`,
+				"other",
+				now,
+				otherAgentId,
+			);
+			db.prepare("INSERT INTO vec_embeddings (id, embedding) VALUES (?, ?)").run(
+				"embedding-owned",
+				Buffer.from(new Float32Array([1, 2, 3]).buffer),
+			);
+			db.prepare("INSERT INTO vec_embeddings (id, embedding) VALUES (?, ?)").run(
+				"embedding-other",
+				Buffer.from(new Float32Array([4, 5, 6]).buffer),
+			);
+			db.exec(
+				"CREATE TRIGGER reject_vec_delete BEFORE DELETE ON vec_embeddings BEGIN SELECT RAISE(ABORT, 'injected vec delete failure'); END",
+			);
+		});
+
+		expect(() => markImportedSourceUnsupported({ sourceId, agentId })).toThrow(
+			"failed to reconcile vec_embeddings before imported-source cleanup",
+		);
+
+		const afterFailure = getDbAccessor().withReadDb((db) => ({
+			artifact: db
+				.prepare("SELECT source_id FROM memory_artifacts WHERE source_id = ? AND agent_id = ?")
+				.get(sourceId, agentId),
+			ownedEmbedding: db.prepare("SELECT id FROM embeddings WHERE id = ?").get("embedding-owned"),
+			ownedVector: db.prepare("SELECT id FROM vec_embeddings WHERE id = ?").get("embedding-owned"),
+			lifecycle: db
+				.prepare("SELECT id FROM imported_source_lifecycle WHERE source_id = ? AND agent_id = ?")
+				.get(sourceId, agentId),
+			otherEmbedding: db
+				.prepare("SELECT id FROM embeddings WHERE id = ? AND agent_id = ?")
+				.get("embedding-other", otherAgentId),
+			otherVector: db.prepare("SELECT id FROM vec_embeddings WHERE id = ?").get("embedding-other"),
+		}));
+		expect(afterFailure.artifact).toEqual({ source_id: sourceId });
+		expect(afterFailure.ownedEmbedding).toEqual({ id: "embedding-owned" });
+		expect(afterFailure.ownedVector).toEqual({ id: "embedding-owned" });
+		expect(afterFailure.lifecycle).toBeNull();
+		expect(afterFailure.otherEmbedding).toEqual({ id: "embedding-other" });
+		expect(afterFailure.otherVector).toEqual({ id: "embedding-other" });
+	});
 });

--- a/platform/daemon/src/imported-source-lifecycle.ts
+++ b/platform/daemon/src/imported-source-lifecycle.ts
@@ -64,7 +64,9 @@ export function markImportedSourceUnsupported(
 			)
 			.all(agentId, SOURCE_CHUNK_SOURCE_TYPE, prefix, `${prefix}\uffff`) as Array<{ id: string }>;
 		const embeddingIds = embeddingRows.map((row) => row.id);
-		syncVecDeleteByEmbeddingIds(db, embeddingIds);
+		if (!syncVecDeleteByEmbeddingIds(db, embeddingIds)) {
+			throw new Error("failed to reconcile vec_embeddings before imported-source cleanup");
+		}
 		if (embeddingIds.length > 0) {
 			const stmt = db.prepare("DELETE FROM embeddings WHERE id = ?");
 			for (const id of embeddingIds) stmt.run(id);

--- a/platform/daemon/src/obsidian-source-embeddings.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.ts
@@ -281,7 +281,9 @@ export async function indexObsidianSourceEmbeddings(
 					| { content_hash: string }
 					| undefined;
 				if (existingForId && existingForId.content_hash !== contentHash) {
-					syncVecDeleteByEmbeddingIds(db, [embId]);
+					if (!syncVecDeleteByEmbeddingIds(db, [embId])) {
+						throw new Error("failed to reconcile vec_embeddings before replacing source embedding");
+					}
 					db.prepare("DELETE FROM embeddings WHERE id = ?").run(embId);
 				}
 				db.prepare(
@@ -349,7 +351,9 @@ export async function indexObsidianSourceEmbeddings(
 			.filter((row) => row.source_type === LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE || !currentHashes.has(row.content_hash))
 			.map((row) => row.id);
 		if (staleIds.length > 0) {
-			syncVecDeleteByEmbeddingIds(db, staleIds);
+			if (!syncVecDeleteByEmbeddingIds(db, staleIds)) {
+				throw new Error("failed to reconcile vec_embeddings before removing stale source embeddings");
+			}
 			const stmt = db.prepare("DELETE FROM embeddings WHERE id = ?");
 			for (const id of staleIds) stmt.run(id);
 		}
@@ -386,20 +390,27 @@ function purgeEmbeddingsBySourceIdPrefix(prefix: string, agentId?: string): numb
 	return getDbAccessor().withWriteTx((db) => {
 		const agentWhere = agentId ? " AND agent_id = ?" : "";
 		const upper = prefixUpperBound(prefix);
-		const ids: string[] = [];
 		let changes = 0;
 		for (const sourceType of OBSIDIAN_CHUNK_SOURCE_TYPES) {
 			const args = agentId ? [sourceType, prefix, upper, agentId] : [sourceType, prefix, upper];
 			const rows = db
 				.prepare(`SELECT id FROM embeddings WHERE source_type = ? AND source_id >= ? AND source_id < ?${agentWhere}`)
 				.all(...args) as Array<{ id: string }>;
-			ids.push(...rows.map((row) => row.id));
+			// Derived vectors must be removed before their canonical embedding rows.
+			// Throwing rolls back the whole source purge and leaves it retryable.
+			if (
+				!syncVecDeleteByEmbeddingIds(
+					db,
+					rows.map((row) => row.id),
+				)
+			) {
+				throw new Error("failed to reconcile vec_embeddings before purging source embeddings");
+			}
 			const result = db
 				.prepare(`DELETE FROM embeddings WHERE source_type = ? AND source_id >= ? AND source_id < ?${agentWhere}`)
 				.run(...args);
 			changes += result.changes;
 		}
-		syncVecDeleteByEmbeddingIds(db, ids);
 		return changes;
 	});
 }

--- a/platform/daemon/src/pipeline/retention-worker.test.ts
+++ b/platform/daemon/src/pipeline/retention-worker.test.ts
@@ -321,17 +321,35 @@ describe("retention worker", () => {
 		).run("emb-survivor", "hash-survivor", vectorToBlob([4, 5, 6]), 3, "mem-survivor", "survivor", now, "agent-b");
 		db.prepare("INSERT INTO vec_embeddings (id, embedding) VALUES (?, ?)").run("emb-expired", vectorToBlob([1, 2, 3]));
 		db.prepare("INSERT INTO vec_embeddings (id, embedding) VALUES (?, ?)").run("emb-survivor", vectorToBlob([4, 5, 6]));
+		db.prepare(
+			`INSERT INTO entities (id, agent_id, name, canonical_name, entity_type, mentions, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
+		).run("entity-expired", "agent-a", "Expired", "expired", "concept", now, now);
+		db.prepare("INSERT INTO memory_entity_mentions (memory_id, entity_id) VALUES (?, ?)").run(
+			"mem-expired",
+			"entity-expired",
+		);
 
 		const failingAccessor = makeAccessor(db, failVectorDeleteOnce(db));
 		const failingHandle = startRetentionWorker(failingAccessor, testRetentionConfig());
 		expect(() => failingHandle.sweep()).toThrow("failed to reconcile vec_embeddings");
 		failingHandle.stop();
 
-		// The failed derived-index step rolls back its transaction and prevents
-		// both canonical embedding and tombstone deletion from becoming partial.
+		// The failed derived-index step rolls back graph/provenance cleanup,
+		// canonical deletion, tombstoning, and cold archival as one retryable unit.
 		expect(db.prepare("SELECT id FROM memories WHERE id = ?").get("mem-expired")).toBeTruthy();
 		expect(db.prepare("SELECT id FROM embeddings WHERE id = ?").get("emb-expired")).toBeTruthy();
 		expect(db.prepare("SELECT id FROM vec_embeddings WHERE id = ?").get("emb-expired")).toBeTruthy();
+		expect(
+			db.prepare("SELECT memory_id, entity_id FROM memory_entity_mentions WHERE memory_id = ?").get("mem-expired"),
+		).toEqual({
+			memory_id: "mem-expired",
+			entity_id: "entity-expired",
+		});
+		expect(db.prepare("SELECT id, mentions FROM entities WHERE id = ?").get("entity-expired")).toEqual({
+			id: "entity-expired",
+			mentions: 1,
+		});
 		expect(db.prepare("SELECT memory_id FROM memories_cold WHERE memory_id = ?").get("mem-expired")).toBeNull();
 
 		const retryHandle = startRetentionWorker(failingAccessor, testRetentionConfig());
@@ -346,6 +364,10 @@ describe("retention worker", () => {
 		expect(db.prepare("SELECT id FROM memories WHERE id = ?").get("mem-expired")).toBeNull();
 		expect(db.prepare("SELECT id FROM embeddings WHERE id = ?").get("emb-expired")).toBeNull();
 		expect(db.prepare("SELECT id FROM vec_embeddings WHERE id = ?").get("emb-expired")).toBeNull();
+		expect(
+			db.prepare("SELECT memory_id FROM memory_entity_mentions WHERE memory_id = ?").get("mem-expired"),
+		).toBeNull();
+		expect(db.prepare("SELECT id FROM entities WHERE id = ?").get("entity-expired")).toBeNull();
 		expect(db.prepare("SELECT id, agent_id FROM memories WHERE id = ?").get("mem-survivor")).toEqual({
 			id: "mem-survivor",
 			agent_id: "agent-b",

--- a/platform/daemon/src/pipeline/retention-worker.test.ts
+++ b/platform/daemon/src/pipeline/retention-worker.test.ts
@@ -1,15 +1,16 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { runMigrations } from "../../../core/src/migrations";
-import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
+import type { DbAccessor, ReadDb, SqliteStatement, WriteDb } from "../db-accessor";
+import { vectorToBlob } from "../db-helpers";
 import { type RetentionConfig, startRetentionWorker } from "./retention-worker";
 
-function makeAccessor(db: Database): DbAccessor {
+function makeAccessor(db: Database, writeDb: WriteDb = db as unknown as WriteDb): DbAccessor {
 	return {
 		withWriteTx<T>(fn: (db: WriteDb) => T): T {
 			db.exec("BEGIN IMMEDIATE");
 			try {
-				const result = fn(db as unknown as WriteDb);
+				const result = fn(writeDb);
 				db.exec("COMMIT");
 				return result;
 			} catch (err) {
@@ -22,6 +23,34 @@ function makeAccessor(db: Database): DbAccessor {
 		},
 		close() {
 			db.close();
+		},
+	};
+}
+
+function failVectorDeleteOnce(db: Database): WriteDb {
+	let failed = false;
+	return {
+		exec(sql: string): void {
+			db.exec(sql);
+		},
+		prepare(sql: string): SqliteStatement {
+			const statement = db.prepare(sql) as unknown as SqliteStatement;
+			if (sql !== "DELETE FROM vec_embeddings WHERE id = ?") return statement;
+			return {
+				run(...params: unknown[]) {
+					if (!failed) {
+						failed = true;
+						throw new Error("simulated vec delete failure");
+					}
+					return statement.run(...params);
+				},
+				get(...params: unknown[]) {
+					return statement.get(...params);
+				},
+				all<Row = unknown>(...params: unknown[]) {
+					return statement.all<Row>(...params);
+				},
+			};
 		},
 	};
 }
@@ -265,6 +294,71 @@ describe("retention worker", () => {
 			mentions: number;
 		};
 		expect(survivor.mentions).toBe(2);
+	});
+
+	it("keeps tombstones and canonical embeddings when vec deletion fails, then retries atomically", () => {
+		const now = new Date().toISOString();
+		db.exec("CREATE TABLE vec_embeddings (id TEXT PRIMARY KEY, embedding BLOB NOT NULL)");
+		db.prepare(
+			`INSERT INTO memories
+				(id, content, content_hash, type, agent_id, is_deleted, deleted_at, created_at, updated_at, updated_by)
+			 VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?)`,
+		).run("mem-expired", "expired", "hash-expired", "fact", "agent-a", daysAgo(35), now, now, "test");
+		db.prepare(
+			`INSERT INTO memories
+				(id, content, content_hash, type, agent_id, created_at, updated_at, updated_by)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run("mem-survivor", "survivor", "hash-survivor", "fact", "agent-b", now, now, "test");
+		db.prepare(
+			`INSERT INTO embeddings
+				(id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+			 VALUES (?, ?, ?, ?, 'memory', ?, ?, ?, ?)`,
+		).run("emb-expired", "hash-expired", vectorToBlob([1, 2, 3]), 3, "mem-expired", "expired", now, "agent-a");
+		db.prepare(
+			`INSERT INTO embeddings
+				(id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+			 VALUES (?, ?, ?, ?, 'memory', ?, ?, ?, ?)`,
+		).run("emb-survivor", "hash-survivor", vectorToBlob([4, 5, 6]), 3, "mem-survivor", "survivor", now, "agent-b");
+		db.prepare("INSERT INTO vec_embeddings (id, embedding) VALUES (?, ?)").run("emb-expired", vectorToBlob([1, 2, 3]));
+		db.prepare("INSERT INTO vec_embeddings (id, embedding) VALUES (?, ?)").run("emb-survivor", vectorToBlob([4, 5, 6]));
+
+		const failingAccessor = makeAccessor(db, failVectorDeleteOnce(db));
+		const failingHandle = startRetentionWorker(failingAccessor, testRetentionConfig());
+		expect(() => failingHandle.sweep()).toThrow("failed to reconcile vec_embeddings");
+		failingHandle.stop();
+
+		// The failed derived-index step rolls back its transaction and prevents
+		// both canonical embedding and tombstone deletion from becoming partial.
+		expect(db.prepare("SELECT id FROM memories WHERE id = ?").get("mem-expired")).toBeTruthy();
+		expect(db.prepare("SELECT id FROM embeddings WHERE id = ?").get("emb-expired")).toBeTruthy();
+		expect(db.prepare("SELECT id FROM vec_embeddings WHERE id = ?").get("emb-expired")).toBeTruthy();
+		expect(db.prepare("SELECT memory_id FROM memories_cold WHERE memory_id = ?").get("mem-expired")).toBeNull();
+
+		const retryHandle = startRetentionWorker(failingAccessor, testRetentionConfig());
+		const retry = retryHandle.sweep();
+		const repeat = retryHandle.sweep();
+		retryHandle.stop();
+
+		expect(retry.embeddingsPurged).toBe(1);
+		expect(retry.tombstonesPurged).toBe(1);
+		expect(repeat.embeddingsPurged).toBe(0);
+		expect(repeat.tombstonesPurged).toBe(0);
+		expect(db.prepare("SELECT id FROM memories WHERE id = ?").get("mem-expired")).toBeNull();
+		expect(db.prepare("SELECT id FROM embeddings WHERE id = ?").get("emb-expired")).toBeNull();
+		expect(db.prepare("SELECT id FROM vec_embeddings WHERE id = ?").get("emb-expired")).toBeNull();
+		expect(db.prepare("SELECT id, agent_id FROM memories WHERE id = ?").get("mem-survivor")).toEqual({
+			id: "mem-survivor",
+			agent_id: "agent-b",
+		});
+		expect(db.prepare("SELECT id, agent_id FROM embeddings WHERE id = ?").get("emb-survivor")).toEqual({
+			id: "emb-survivor",
+			agent_id: "agent-b",
+		});
+		expect(db.prepare("SELECT id FROM vec_embeddings WHERE id = ?").get("emb-survivor")).toBeTruthy();
+		const cold = db
+			.prepare("SELECT memory_id, agent_id, archived_reason FROM memories_cold WHERE memory_id = ?")
+			.get("mem-expired");
+		expect(cold).toMatchObject({ memory_id: "mem-expired", agent_id: "agent-a", archived_reason: "retention_decay" });
 	});
 
 	it("returns zero counts when nothing to purge", () => {

--- a/platform/daemon/src/pipeline/retention-worker.ts
+++ b/platform/daemon/src/pipeline/retention-worker.ts
@@ -152,10 +152,13 @@ function purgeEmbeddings(db: WriteDb, cutoff: string, limit: number): number {
 			 WHERE source_type = 'memory' AND source_id IN (${placeholders})`,
 		)
 		.all(...ids) as Array<{ id: string }>;
-	syncVecDeleteByEmbeddingIds(
+	const vectorsDeleted = syncVecDeleteByEmbeddingIds(
 		db,
 		embRows.map((r) => r.id),
 	);
+	if (!vectorsDeleted) {
+		throw new Error("failed to reconcile vec_embeddings before retention purge");
+	}
 
 	const result = db
 		.prepare(

--- a/platform/daemon/src/pipeline/retention-worker.ts
+++ b/platform/daemon/src/pipeline/retention-worker.ts
@@ -369,20 +369,21 @@ export function runRetentionSweepOnce(
 	const completedJobCutoff = new Date(now - normalizedCfg.completedJobRetentionMs).toISOString();
 	const deadJobCutoff = new Date(now - normalizedCfg.deadJobRetentionMs).toISOString();
 
-	// Step 1: graph links for expired tombstones + entity decrement
-	const graphResult = accessor.withWriteTx((db) => purgeGraphLinks(db, tombstoneCutoff, normalizedCfg.batchLimit));
-	const graphLinksPurged = graphResult.mentionsPurged;
-	const entitiesOrphaned = graphResult.entitiesOrphaned;
+	// A retention batch has dependent graph, vector, canonical, and archival
+	// writes. Keep them together so a vec failure cannot commit irreversible
+	// provenance cleanup while leaving the canonical embedding retryable.
+	const retentionResult = accessor.withWriteTx((db) => {
+		const graph = purgeGraphLinks(db, tombstoneCutoff, normalizedCfg.batchLimit);
+		const embeddingsPurged = purgeEmbeddings(db, tombstoneCutoff, normalizedCfg.batchLimit);
+		const tombstonesPurged = purgeTombstones(db, tombstoneCutoff, normalizedCfg.batchLimit);
+		return { ...graph, embeddingsPurged, tombstonesPurged };
+	});
+	const graphLinksPurged = retentionResult.mentionsPurged;
+	const entitiesOrphaned = retentionResult.entitiesOrphaned;
+	const embeddingsPurged = retentionResult.embeddingsPurged;
+	const tombstonesPurged = retentionResult.tombstonesPurged;
 
-	if (entitiesOrphaned > 0) {
-		invalidateTraversalCache();
-	}
-
-	// Step 2: embeddings for expired tombstones
-	const embeddingsPurged = accessor.withWriteTx((db) => purgeEmbeddings(db, tombstoneCutoff, normalizedCfg.batchLimit));
-
-	// Step 3: hard-delete tombstoned rows (FTS cleanup via memories_ad trigger)
-	const tombstonesPurged = accessor.withWriteTx((db) => purgeTombstones(db, tombstoneCutoff, normalizedCfg.batchLimit));
+	if (entitiesOrphaned > 0) invalidateTraversalCache();
 
 	// Step 4: old history events
 	const historyPurged = accessor.withWriteTx((db) => purgeHistory(db, historyCutoff, normalizedCfg.batchLimit));

--- a/platform/daemon/src/pipeline/skill-graph.ts
+++ b/platform/daemon/src/pipeline/skill-graph.ts
@@ -304,10 +304,14 @@ export async function installSkillNode(
 				.all(entityId) as Array<{ id: string }>;
 
 			if (oldEmbs.length > 0) {
-				syncVecDeleteByEmbeddingIds(
-					db,
-					oldEmbs.map((e) => e.id),
-				);
+				if (
+					!syncVecDeleteByEmbeddingIds(
+						db,
+						oldEmbs.map((e) => e.id),
+					)
+				) {
+					throw new Error("failed to reconcile vec_embeddings before replacing skill embedding");
+				}
 				db.prepare(`DELETE FROM embeddings WHERE source_type = 'skill' AND source_id = ?`).run(entityId);
 			}
 
@@ -377,10 +381,14 @@ export function uninstallSkillNode(input: SkillUninstallInput, accessor: DbAcces
 			.all(entityId) as Array<{ id: string }>;
 
 		if (embRows.length > 0) {
-			syncVecDeleteByEmbeddingIds(
-				db,
-				embRows.map((e) => e.id),
-			);
+			if (
+				!syncVecDeleteByEmbeddingIds(
+					db,
+					embRows.map((e) => e.id),
+				)
+			) {
+				throw new Error("failed to reconcile vec_embeddings before uninstalling skill");
+			}
 			db.prepare(`DELETE FROM embeddings WHERE source_type = 'skill' AND source_id = ?`).run(entityId);
 		}
 

--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -925,6 +925,49 @@ describe("reembedMissingMemories", () => {
 		db.close();
 	});
 
+	it("preserves a committed memory when embedding persistence fails, then retries idempotently", async () => {
+		insertMemory(db, "mem-write-failure");
+		let failWrite = true;
+		const flakyAccessor: DbAccessor = {
+			...accessor,
+			withWriteTx<T>(fn: (wdb: WriteDb) => T): T {
+				if (failWrite) {
+					failWrite = false;
+					throw new Error("simulated embedding persistence failure");
+				}
+				return accessor.withWriteTx(fn);
+			},
+		};
+
+		const first = reembedMissingMemories(
+			flakyAccessor,
+			TEST_CFG,
+			CTX_OPERATOR,
+			createRateLimiter(),
+			async () => [0.1, 0.2, 0.3],
+			TEST_EMBEDDING_CFG,
+			1,
+			false,
+		);
+		await expect(first).rejects.toThrow("simulated embedding persistence failure");
+		expect(db.prepare("SELECT id FROM memories WHERE id = ?").get("mem-write-failure")).toBeTruthy();
+		expect(db.prepare("SELECT id FROM embeddings WHERE source_id = ?").get("mem-write-failure")).toBeNull();
+
+		const second = await reembedMissingMemories(
+			accessor,
+			TEST_CFG,
+			CTX_OPERATOR,
+			createRateLimiter(),
+			async () => [0.1, 0.2, 0.3],
+			TEST_EMBEDDING_CFG,
+			1,
+			false,
+		);
+		expect(second.success).toBe(true);
+		expect(second.affected).toBe(1);
+		expect(db.prepare("SELECT id FROM embeddings WHERE source_id = ?").get("mem-write-failure")).toBeTruthy();
+	});
+
 	it("repairs memories even when content_hash is NULL", async () => {
 		insertMemory(db, "mem-null-hash");
 

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -1079,7 +1079,9 @@ export function cleanOrphanedEmbeddings(
 		if (orphans.length === 0) return 0;
 
 		const ids = orphans.map((r) => r.id);
-		syncVecDeleteByEmbeddingIds(db, ids);
+		if (!syncVecDeleteByEmbeddingIds(db, ids)) {
+			throw new Error("failed to reconcile vec_embeddings before orphan cleanup");
+		}
 
 		const placeholders = ids.map(() => "?").join(", ");
 		const result = db.prepare(`DELETE FROM embeddings WHERE id IN (${placeholders})`).run(...ids);

--- a/platform/daemon/src/source-purge.ts
+++ b/platform/daemon/src/source-purge.ts
@@ -38,7 +38,9 @@ export function purgeSourceOwnedRows(input: PurgeSourceOwnedRowsInput): number {
 			id: string;
 		}>;
 		const embeddingIds = embeddingRows.map((row) => row.id);
-		syncVecDeleteByEmbeddingIds(db, embeddingIds);
+		if (!syncVecDeleteByEmbeddingIds(db, embeddingIds)) {
+			throw new Error("failed to reconcile vec_embeddings before source purge");
+		}
 		let purged = embeddingIds.length;
 		if (embeddingIds.length > 0) {
 			const stmt = db.prepare("DELETE FROM embeddings WHERE id = ?");

--- a/platform/daemon/src/source-snapshots.ts
+++ b/platform/daemon/src/source-snapshots.ts
@@ -290,7 +290,9 @@ function purgeImportScopeChunks(db: Database, sourceId: string, agentId: string,
 		chunk_text: string | null;
 	}>;
 	const ids = rows.filter((row) => includeLocalDiscord || !isLocalDiscordChunk(row)).map((row) => row.id);
-	syncVecDeleteByEmbeddingIds(db as WriteDb, ids);
+	if (!syncVecDeleteByEmbeddingIds(db as WriteDb, ids)) {
+		throw new Error("failed to reconcile vec_embeddings before source snapshot replacement");
+	}
 	const stmt = db.prepare("DELETE FROM embeddings WHERE id = ?");
 	for (const id of ids) stmt.run(id);
 }

--- a/platform/daemon/src/transactions.test.ts
+++ b/platform/daemon/src/transactions.test.ts
@@ -153,6 +153,31 @@ describe("transactions: txModifyMemory + txForgetMemory + txRecoverMemory", () =
 		expect(history.reason).toBe("manual correction");
 	});
 
+	it("rolls back an ingest before memory commit without losing existing durable state", () => {
+		insertMemory(db, {
+			id: "mem-existing",
+			content: "Existing durable memory",
+			contentHash: "hash-existing",
+		});
+
+		db.exec("BEGIN IMMEDIATE");
+		try {
+			insertMemory(db, {
+				id: "mem-aborted",
+				content: "Should not commit",
+				contentHash: "hash-aborted",
+			});
+			throw new Error("simulated failure before memory commit");
+		} catch (error) {
+			db.exec("ROLLBACK");
+			expect(error).toEqual(new Error("simulated failure before memory commit"));
+		}
+
+		expect(db.prepare("SELECT id FROM memories WHERE id = ?").get("mem-existing")).toBeTruthy();
+		expect(db.prepare("SELECT id FROM memories WHERE id = ?").get("mem-aborted")).toBeNull();
+		expect(db.prepare("SELECT id FROM memory_history WHERE memory_id = ?").get("mem-aborted")).toBeNull();
+	});
+
 	it("keeps a materialized semantic claim on the ontology write path", () => {
 		insertMemory(db, {
 			id: "semantic-claim",


### PR DESCRIPTION
## Summary

Proves embedding reconciliation across the four requested mid-write failure points and prevents retention/orphan cleanup from deleting canonical embedding rows when vec-index deletion fails. The retention owner now aborts its transaction and retries atomically, preserving tombstone provenance and agent-scoped durable state.

## Changes

- Return explicit success from `syncVecDeleteByEmbeddingIds` and use the cross-runtime-safe `row != null` table check.
- Abort retention embedding purge and orphan cleanup when derived vec deletion cannot be reconciled.
- Add failure-injection coverage for pre-commit ingest rollback, committed-memory embedding retry, sqlite-vec promotion rollback after vector insertion, and retention retry/idempotency/scoping/provenance.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A: no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations touched.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Targeted verification completed:

- `bun test platform/daemon/src/pipeline/retention-worker.test.ts platform/daemon/src/repair-actions.test.ts platform/daemon/src/embedding-index-migration.test.ts platform/daemon/src/transactions.test.ts platform/daemon/src/embedding-tracker.test.ts platform/daemon/src/embedding-index-state.test.ts` (109 passed, 0 failed, 454 expects)
- `bun run --filter '@signet/daemon' typecheck`
- `bunx biome check` on all seven changed files
- `bun run --filter '@signet/daemon' build`
- `git diff --check`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

No live embedding provider or network-backed test was added. The retention failure test verifies that a failed vec deletion leaves the tombstone, canonical embedding, and derived row intact; the next sweep removes them exactly once while preserving another agent's memory, embedding, vec row, and the expired memory's cold archive provenance.
