### PR TITLE
fix(daemon): back off ACPX sterile retries

### DIFF
--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -21,6 +21,7 @@ import {
 	calculateAcpxRetryDelayMs,
 	configureLlmConcurrency,
 	createAcpxProvider,
+	getLlmConcurrencyStatus,
 } from "./provider";
 
 // ---------------------------------------------------------------------------
@@ -372,6 +373,55 @@ fi
 			await expect(first).resolves.toBe("first recovered");
 		} finally {
 			configureLlmConcurrency(2);
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("does not let a queued ACPX attempt succeed after its caller deadline", async () => {
+		const root = join(tmpdir(), `signet-acpx-queued-deadline-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const bin = join(root, "fake-acpx-queued-deadline.sh");
+		const holderSeenPath = join(root, "holder-seen");
+		const queuedPidPath = join(root, "queued.pid");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+prompt=$(cat)
+if [[ "$prompt" == "holder" ]]; then
+  touch ${JSON.stringify(holderSeenPath)}
+  sleep 0.12
+  printf 'holder answer\\n'
+else
+  printf '%s' "$$" > ${JSON.stringify(queuedPidPath)}
+  sleep 0.12
+  printf 'queued answer\\n'
+fi
+`,
+		);
+		chmodSync(bin, 0o755);
+		const originalLimit = getLlmConcurrencyStatus().limit;
+		configureLlmConcurrency(1);
+		try {
+			const config = {
+				agent: "codex" as const,
+				bin,
+				permissions: "deny-all" as const,
+				hooks: "disabled" as const,
+				allowedTools: [] as const,
+				emptyResponseRetries: 0,
+			};
+			const holder = createAcpxProvider(config).generate("holder", { timeoutMs: 1_000 });
+			await waitForPath(holderSeenPath);
+			const queued = createAcpxProvider(config).generate("queued", { timeoutMs: 180 });
+
+			await expect(queued).rejects.toThrow(/codex via ACPX timeout after/);
+			await expect(holder).resolves.toBe("holder answer");
+			if (existsSync(queuedPidPath)) {
+				expect(await waitForProcessExit(Number(readFileSync(queuedPidPath, "utf8")))).toBe(true);
+			}
+			expect(getLlmConcurrencyStatus()).toEqual({ limit: 1, pending: 0, running: 0 });
+		} finally {
+			configureLlmConcurrency(originalLimit);
 			rmSync(root, { recursive: true, force: true });
 		}
 	});

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -18,6 +18,8 @@ import {
 	LlmConcurrencySemaphore,
 	SemaphoreTimeoutError,
 	awaitSubprocessWithDeadline,
+	calculateAcpxRetryDelayMs,
+	configureLlmConcurrency,
 	createAcpxProvider,
 } from "./provider";
 
@@ -57,11 +59,26 @@ async function waitForProcessExit(pid: number): Promise<boolean> {
 	return false;
 }
 
+async function waitForPath(path: string): Promise<void> {
+	for (let i = 0; i < 100; i += 1) {
+		if (existsSync(path)) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(`path was not created: ${path}`);
+}
+
 // ---------------------------------------------------------------------------
 // ACPX harness-subprocess provider
 // ---------------------------------------------------------------------------
 
 describe("createAcpxProvider", () => {
+	it("calculates bounded exponential sterile-response backoff with deterministic jitter", () => {
+		expect(calculateAcpxRetryDelayMs(0, () => 0)).toBe(50);
+		expect(calculateAcpxRetryDelayMs(0, () => 1)).toBe(100);
+		expect(calculateAcpxRetryDelayMs(1, () => 0.5)).toBe(150);
+		expect(calculateAcpxRetryDelayMs(20, () => 1)).toBe(2_000);
+	});
+
 	it("runs ACPX one-shot exec with pinned version-compatible args and sterile hook env", async () => {
 		const root = join(tmpdir(), `signet-acpx-provider-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		mkdirSync(root, { recursive: true });
@@ -201,9 +218,11 @@ printf 'ok\\n'
 		const bin = join(root, "fake-acpx-empty-then-valid.sh");
 		const countPath = join(root, "count.txt");
 		const argsPath = join(root, "args.txt");
+		const timesPath = join(root, "times.txt");
 		writeFileSync(
 			bin,
 			`#!/usr/bin/env bash
+printf '%s\n' "$(date +%s%3N)" >> ${JSON.stringify(timesPath)}
 count=0
 [[ -f ${JSON.stringify(countPath)} ]] && count=$(cat ${JSON.stringify(countPath)})
 count=$((count + 1))
@@ -232,9 +251,127 @@ fi
 
 			await expect(provider.generate("retry me", { timeoutMs: 2000 })).resolves.toBe("recovered answer");
 			expect(readFileSync(countPath, "utf8")).toBe("2");
+			const times = readFileSync(timesPath, "utf8").trim().split("\n").map(Number);
+			expect(times).toHaveLength(2);
+			expect(times[1] - times[0]).toBeGreaterThanOrEqual(40);
 			const args = readFileSync(argsPath, "utf8").trim().split("\n");
 			expect(args.filter((arg) => arg === "persistent-background")).toHaveLength(1);
 		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("caps sterile retries at the caller deadline instead of launching another process", async () => {
+		const root = join(tmpdir(), `signet-acpx-empty-deadline-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const bin = join(root, "fake-acpx-always-empty.sh");
+		const countPath = join(root, "count.txt");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+count=0
+[[ -f ${JSON.stringify(countPath)} ]] && count=$(cat ${JSON.stringify(countPath)})
+printf '%s' "$((count + 1))" > ${JSON.stringify(countPath)}
+sleep 0.08
+cat >/dev/null
+printf '\\n'
+`,
+		);
+		chmodSync(bin, 0o755);
+		const previousProcRoot = process.env.SIGNET_ACPX_PROC_ROOT;
+		process.env.SIGNET_ACPX_PROC_ROOT = join(root, "missing-proc");
+		try {
+			const provider = createAcpxProvider({
+				agent: "codex",
+				bin,
+				permissions: "deny-all",
+				hooks: "disabled",
+				allowedTools: [],
+				emptyResponseRetries: 1,
+			});
+			await expect(provider.generate("deadline", { timeoutMs: 120 })).rejects.toThrow(/retryCount=0/);
+			expect(readFileSync(countPath, "utf8")).toBe("1");
+		} finally {
+			if (previousProcRoot === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PROC_ROOT");
+			else process.env.SIGNET_ACPX_PROC_ROOT = previousProcRoot;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("cancels a sterile retry while waiting for backoff", async () => {
+		const root = join(tmpdir(), `signet-acpx-empty-cancel-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const bin = join(root, "fake-acpx-empty.sh");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+cat >/dev/null
+printf '\\n'
+`,
+		);
+		chmodSync(bin, 0o755);
+		try {
+			const controller = new AbortController();
+			const provider = createAcpxProvider({
+				agent: "codex",
+				bin,
+				permissions: "deny-all",
+				hooks: "disabled",
+				allowedTools: [],
+				emptyResponseRetries: 1,
+			});
+			const result = provider.generate("cancel", { timeoutMs: 1_000, signal: controller.signal });
+			setTimeout(() => controller.abort(), 20).unref?.();
+			await expect(result).rejects.toThrow("codex via ACPX aborted");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("releases the concurrency slot while a sterile caller backs off", async () => {
+		const root = join(tmpdir(), `signet-acpx-empty-concurrent-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const bin = join(root, "fake-acpx-concurrent.sh");
+		const firstCountPath = join(root, "first-count.txt");
+		const firstSeenPath = join(root, "first-seen");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+prompt=$(cat)
+if [[ "$prompt" == "first" ]]; then
+  count=0
+  [[ -f ${JSON.stringify(firstCountPath)} ]] && count=$(cat ${JSON.stringify(firstCountPath)})
+  count=$((count + 1))
+  printf '%s' "$count" > ${JSON.stringify(firstCountPath)}
+  if [[ "$count" -eq 1 ]]; then
+    touch ${JSON.stringify(firstSeenPath)}
+    printf '\\n'
+  else
+    printf 'first recovered\\n'
+  fi
+else
+  printf 'second answer\\n'
+fi
+`,
+		);
+		chmodSync(bin, 0o755);
+		configureLlmConcurrency(1);
+		try {
+			const config = {
+				agent: "codex" as const,
+				bin,
+				permissions: "deny-all" as const,
+				hooks: "disabled" as const,
+				allowedTools: [] as const,
+				emptyResponseRetries: 1,
+			};
+			const first = createAcpxProvider(config).generate("first", { timeoutMs: 1_000 });
+			await waitForPath(firstSeenPath);
+			await expect(createAcpxProvider(config).generate("second", { timeoutMs: 1_000 })).resolves.toBe("second answer");
+			expect(readFileSync(firstCountPath, "utf8")).toBe("1");
+			await expect(first).resolves.toBe("first recovered");
+		} finally {
+			configureLlmConcurrency(2);
 			rmSync(root, { recursive: true, force: true });
 		}
 	});

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -703,6 +703,8 @@ export interface AcpxProviderConfig {
 const DEFAULT_ACPX_VERSION = "0.12.0";
 const DEFAULT_ACPX_EMPTY_RESPONSE_RETRIES = 1;
 const MAX_ACPX_EMPTY_RESPONSE_RETRIES = 3;
+const DEFAULT_ACPX_EMPTY_RESPONSE_RETRY_DELAY_MS = 100;
+const MAX_ACPX_EMPTY_RESPONSE_RETRY_DELAY_MS = 2_000;
 
 function normalizeAcpxAgent(agent: string): string {
 	return agent === "claude-code" ? "claude" : agent;
@@ -1135,6 +1137,40 @@ function resolveEmptyResponseRetries(config: AcpxProviderConfig): number {
 	return Math.min(MAX_ACPX_EMPTY_RESPONSE_RETRIES, Math.max(0, Math.floor(configured)));
 }
 
+export function calculateAcpxRetryDelayMs(retryIndex: number, random: () => number = Math.random): number {
+	const exponent = Math.min(
+		MAX_ACPX_EMPTY_RESPONSE_RETRY_DELAY_MS,
+		DEFAULT_ACPX_EMPTY_RESPONSE_RETRY_DELAY_MS * 2 ** Math.max(0, Math.floor(retryIndex)),
+	);
+	const jitter = Math.min(1, Math.max(0, random()));
+	return Math.max(1, Math.floor(exponent * (0.5 + jitter * 0.5)));
+}
+
+async function waitForAcpxRetry(
+	agent: string,
+	delayMs: number,
+	deadline: number,
+	signal: AbortSignal | undefined,
+): Promise<void> {
+	if (signal?.aborted) throw new Error(`${agent} via ACPX aborted`);
+	const remainingMs = deadline - performance.now();
+	if (remainingMs <= 0) return;
+	const waitMs = Math.min(delayMs, remainingMs);
+	await new Promise<void>((resolve, reject) => {
+		let settled = false;
+		const finish = (fn: () => void): void => {
+			if (settled) return;
+			settled = true;
+			signal?.removeEventListener("abort", onAbort);
+			fn();
+		};
+		const onAbort = (): void => finish(() => reject(new Error(`${agent} via ACPX aborted`)));
+		signal?.addEventListener("abort", onAbort, { once: true });
+		const timer = setTimeout(() => finish(resolve), waitMs);
+		timer.unref?.();
+	});
+}
+
 function quietUsage(stderr: string): string | undefined {
 	return stderr.match(/^\[acpx\] tokens: (.+)$/m)?.[1]?.slice(0, 300);
 }
@@ -1271,50 +1307,51 @@ export function createAcpxProvider(config: AcpxProviderConfig): LlmProvider {
 			const timeoutMs = opts?.timeoutMs ?? config.timeoutMs ?? 60_000;
 			const deadline = performance.now() + timeoutMs;
 			const signal = generateSignal(opts);
-			return withLlmConcurrency(
-				async () => {
-					const retries = isSterileAcpxTarget(config) ? resolveEmptyResponseRetries(config) : 0;
-					const startedAt = performance.now();
-					let lastEmpty: AcpxEmptyResponseError | undefined;
-					for (let attempt = 0; attempt <= retries; attempt += 1) {
-						const remainingMs = deadline - performance.now();
-						if (remainingMs <= 0) {
-							if (lastEmpty) {
-								throw formatEmptyResponseError(
-									config.agent,
-									lastEmpty.diagnostics,
-									attempt - 1,
-									performance.now() - startedAt,
-								);
-							}
-							throw new Error(
-								`${config.agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`,
-							);
-						}
-						const attemptConfig = attempt === 0 ? config : { ...config, mode: "exec" as const, session: undefined };
-						try {
-							return await runAcpxAttempt(attemptConfig, prompt, remainingMs, signal);
-						} catch (error) {
-							if (!(error instanceof AcpxEmptyResponseError)) throw error;
-							lastEmpty = error;
-							if (attempt >= retries) {
-								throw formatEmptyResponseError(config.agent, error.diagnostics, attempt, performance.now() - startedAt);
-							}
-							logger.warn("inference", "Retrying sterile ACPX empty response", {
-								agent: config.agent,
-								attempt: attempt + 1,
-								format: error.diagnostics.format,
-								sessionId: error.diagnostics.sessionId ?? "unknown",
-								stopReason: error.diagnostics.stopReason ?? "unknown",
-							});
-						}
+			const retries = isSterileAcpxTarget(config) ? resolveEmptyResponseRetries(config) : 0;
+			const startedAt = performance.now();
+			let lastEmpty: AcpxEmptyResponseError | undefined;
+			for (let attempt = 0; attempt <= retries; attempt += 1) {
+				const remainingMs = deadline - performance.now();
+				if (remainingMs <= 1) {
+					if (lastEmpty) {
+						throw formatEmptyResponseError(
+							config.agent,
+							lastEmpty.diagnostics,
+							attempt - 1,
+							performance.now() - startedAt,
+						);
 					}
-					throw new Error(`${config.agent} via ACPX retry loop exhausted`);
-				},
-				timeoutMs,
-				"acpx",
-				signal,
-			);
+					throw new Error(
+						`${config.agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`,
+					);
+				}
+				const attemptConfig = attempt === 0 ? config : { ...config, mode: "exec" as const, session: undefined };
+				try {
+					return await withLlmConcurrency(
+						() => runAcpxAttempt(attemptConfig, prompt, remainingMs, signal),
+						remainingMs,
+						"acpx",
+						signal,
+					);
+				} catch (error) {
+					if (!(error instanceof AcpxEmptyResponseError)) throw error;
+					lastEmpty = error;
+					if (attempt >= retries) {
+						throw formatEmptyResponseError(config.agent, error.diagnostics, attempt, performance.now() - startedAt);
+					}
+					const delayMs = calculateAcpxRetryDelayMs(attempt);
+					logger.warn("inference", "Retrying sterile ACPX empty response", {
+						agent: config.agent,
+						attempt: attempt + 1,
+						delayMs,
+						format: error.diagnostics.format,
+						sessionId: error.diagnostics.sessionId ?? "unknown",
+						stopReason: error.diagnostics.stopReason ?? "unknown",
+					});
+					await waitForAcpxRetry(config.agent, delayMs, deadline, signal);
+				}
+			}
+			throw new Error(`${config.agent} via ACPX retry loop exhausted`);
 		},
 		async available(): Promise<boolean> {
 			const bin = config.bin ?? "npx";

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -1328,7 +1328,23 @@ export function createAcpxProvider(config: AcpxProviderConfig): LlmProvider {
 				const attemptConfig = attempt === 0 ? config : { ...config, mode: "exec" as const, session: undefined };
 				try {
 					return await withLlmConcurrency(
-						() => runAcpxAttempt(attemptConfig, prompt, remainingMs, signal),
+						() => {
+							const acquiredRemainingMs = deadline - performance.now();
+							if (acquiredRemainingMs <= 1) {
+								if (lastEmpty) {
+									throw formatEmptyResponseError(
+										config.agent,
+										lastEmpty.diagnostics,
+										attempt - 1,
+										performance.now() - startedAt,
+									);
+								}
+								throw new Error(
+									`${config.agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`,
+								);
+							}
+							return runAcpxAttempt(attemptConfig, prompt, acquiredRemainingMs, signal);
+						},
 						remainingMs,
 						"acpx",
 						signal,


### PR DESCRIPTION
## Summary

Fixes #1331 by adding bounded, jittered backoff between ACPX sterile-response retries. Retry waits are capped by the caller deadline and abort signal, and the LLM concurrency slot is released while waiting so other callers can proceed.

## Changes

- Add deterministic bounded exponential retry-delay calculation: 50-100 ms, 100-200 ms, then capped at 2 seconds.
- Cap retry waiting by the existing caller deadline and preserve sterile-response diagnostics on budget exhaustion.
- Cancel retry waits through the caller AbortSignal and keep subprocess cleanup/error behavior unchanged.
- Acquire the global LLM concurrency permit per subprocess attempt instead of holding it during backoff.
- Add regression coverage for jitter bounds, timing, deadline exhaustion, cancellation, concurrent callers, diagnostics, and cleanup.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A: no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A: no migrations.

## Testing

- [x] `bun test` passes (targeted `platform/daemon/src/pipeline/provider.test.ts`: 37 passed)
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused checks passed:

- `bunx biome check platform/daemon/src/pipeline/provider.ts platform/daemon/src/pipeline/provider.test.ts`
- `git diff --check`
- `bun run --filter '@signet/core' build`
- `bun run --filter '@signet/daemon' build`
- `bun run --filter '@signet/daemon' typecheck`

The full root `bun run typecheck` currently reports unrelated pre-existing connector package errors (connector-forge, connector-pi, connector-oh-my-pi, connector-gemini, connector-openclaw, connector-opencode, and connector-codex); the changed daemon package typecheck passes after rebuilding core.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The implementation intentionally keeps the existing sterile-target gate and retry count. Ordinary ACPX errors and observable JSON tool activity are not retried.
