### PR TITLE
feat(daemon): bounded resource telemetry

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -79,7 +79,7 @@ paths, or user identity.
 | `first.remember` / `first.recall` | first successful remember / recall per install, exactly once | `version`, `platform` |
 | `daemon.started` | daemon boot | `version`, `platform`, `uptimeMs` |
 | `daemon.previous_exit` | next successful boot reconciles the prior lifecycle record, exactly once when one exists | `classification` (`clean` / `error` / `unrecorded`), `reasonCategory`, `exitCode`, `previousVersion`, `previousUptimeMs`, `restartDelayMs` |
-| `daemon.heartbeat` | every 5 minutes | `uptimeMs`, `memoryCount`, `connectorsActive`, `pipelineMode`, `extractionProvider`, `embeddingProvider`, bounded runtime-pressure buckets |
+| `daemon.heartbeat` | every 5 minutes | `version`, `platform`, `uptimeMs`, `memoryCount`, `connectorsActive`, `pipelineMode`, `extractionProvider`, `embeddingProvider`, bounded runtime-pressure and process resource-utilization buckets |
 | `telemetry.health` | every scheduled telemetry flush | `status`, `deliveryConfigured`, queue/buffer counts, unsent and delivery age buckets, recent success/failure counts, backoff state, dropped-event count, `flushIntervalMs` |
 | `session.start` | real session start (deduped; stubs and clear/reset paths don't count) | `harness`, `sessionHash` |
 | `session.turn` | every non-boundary `session-end` hook call (per turn, see notes) | `harness`, `promptCount`, `sessionHash` |
@@ -239,6 +239,26 @@ Notes on individual events:
   provider work. `recoveryOutcome` is
   `still_degraded` during an episode, `recovered` after the pressure state
   clears, and `restarted` on the first heartbeat after an abnormal prior exit.
+- **Process resource-utilization buckets (#1424)** — the existing five-minute
+  `daemon.heartbeat` is the only fleet sample boundary. It carries
+  `resourceTelemetryVersion: 1`, `resourceScope: process`, and these fixed
+  buckets: CPU `unavailable`, `zero`, `1-25%`, `26-75%`, `76-100%`,
+  `101-200%`, `201+%`; RSS, heap-used, and macOS physical footprint
+  `unavailable`, `zero`, `1-64MiB`, `65-128MiB`, `129-256MiB`, `257-512MiB`,
+  `513-1024MiB`, `1025+MiB`. CPU is process utilization and may exceed 100%
+  on a multicore machine. These fields never represent host-wide capacity.
+  A missing physical-footprint reading is `unavailable`, not zero. The
+  workload class is `normal`, `dreaming`, or `critical_pressure`, using the
+  active Dreaming pass and existing pressure state at that heartbeat; critical
+  pressure takes precedence. Local resource-monitor logs retain detailed raw
+  measurements. Local `/api/telemetry/stats` reports bounded bucket totals
+  from persisted heartbeat events. Platform, version, and existing provider
+  fields remain available for grouping; no model or new workload classifier is
+  inferred at this boundary.
+- The process CPU bucket is the bounded `process.cpuUsage()` delta since the
+  previous local resource snapshot. Other local health or diagnostics polls
+  can shorten that sampling window; the fleet event still emits only the
+  resulting bucket, never the duration or raw CPU value.
 - **`recall.attempted` / `recall.outcome`** — the bounded retrieval-outcome
   contract (#1277). Attempts are recorded once at each supported recall
   surface. Outcomes separate empty, non-empty, truncated, and error results
@@ -282,6 +302,13 @@ Notes on individual events:
   messages, queue errors, payloads, source names, paths, PIDs, or additional
   stack data. The existing once-per-10-minute `EventLoopLag` rate limit applies
   to the complete event, including its pressure envelope.
+- **Process resource privacy.** Resource utilization telemetry sends only the
+  documented process-level buckets above, plus the existing platform, version,
+  provider, workload, and pressure dimensions. It never sends raw CPU, RSS,
+  heap, physical-footprint values, host capacity, host inventory, usernames,
+  paths, process lists, environment variables, or memory contents. It is
+  emitted only with the existing five-minute heartbeat. Opt-out and the
+  per-install identity path are unchanged.
 - **Agent ids in `inference.*` are hashed.** Inference events carry
   `agentId` as a SHA-256 hash salted with the per-install install id (16 hex
   chars). Stable within an install (per-agent analysis still works), not
@@ -454,6 +481,7 @@ vault mirrors the key PostHog aggregates for daily review via
 | Unreleased | Bounded recall attempt and delivery outcomes by surface, without query or prompt content (#1277) |
 | Unreleased | First-run activation funnel: `first.remember` / `first.recall`, exactly once per install (#1202) |
 | Unreleased | `pipeline.embedding` cost rates and collector-derived session token/cost totals (#1201) |
+| Unreleased | Bounded process CPU and memory utilization buckets on the existing daemon heartbeat, with local stats aggregation (#1424) |
 
 Related: #1026 (original rollout), #1200 (IP capture, dev tagging),
 #1201-#1207 (event-scoped follow-ups), #1212 (session.end rename — resolved).

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -101,6 +101,7 @@ import {
 	startFdPollMonitor,
 	stopResourceMonitors,
 } from "./resource-monitor";
+import { buildResourceUtilizationTelemetry } from "./resource-telemetry";
 import {
 	AGENTS_DIR,
 	BIND_HOST,
@@ -164,7 +165,7 @@ import {
 } from "./source-index-progress";
 import { recordSourceConnected, recordSourceIndexOperation, sourceFailureClass } from "./source-lifecycle-telemetry";
 import { runStartupRecovery } from "./startup-recovery";
-import { getPressureRecoveryOutcome, reportStartupGrace } from "./system-pressure";
+import { getPressureRecoveryOutcome, getSystemPressure, reportStartupGrace } from "./system-pressure";
 import {
 	type TelemetryCollector,
 	type TelemetryConfigSnapshot,
@@ -2166,10 +2167,16 @@ async function main() {
 					});
 					const connectors = listConnectors(getDbAccessor());
 					let runtimePressure: ReturnType<typeof buildRuntimePressureEnvelope> | undefined;
+					let resourceTelemetry: ReturnType<typeof buildResourceUtilizationTelemetry> | undefined;
 					try {
 						const queue = getDbAccessor().withReadDb((db) => getQueuePressureSnapshot(db));
 						const workers = getPipelineWorkerStatus();
 						const resources = getResourceSnapshot();
+						resourceTelemetry = buildResourceUtilizationTelemetry(
+							resources,
+							getSystemPressure(),
+							dreamingWorkerHandle?.running === true,
+						);
 						const recoveryOutcome: PressureRecoveryOutcome = restartedHeartbeatPending
 							? "restarted"
 							: getPressureRecoveryOutcome();
@@ -2201,12 +2208,15 @@ async function main() {
 					}
 					telemetryRef.record("daemon.heartbeat", {
 						uptimeMs: Date.now() - daemonStartTime,
+						version: CURRENT_VERSION,
+						platform: process.platform,
 						memoryCount,
 						connectorsActive: countConnectorsActive(connectors),
 						pipelineMode: readPipelineMode(liveCfg.pipelineV2),
 						extractionProvider: providerRuntimeResolution.extraction.effective,
 						embeddingProvider: liveCfg.embedding.provider,
 						...(runtimePressure ?? {}),
+						...(resourceTelemetry ?? {}),
 					});
 					if (runtimePressure?.recoveryOutcome === "restarted") {
 						restartedHeartbeatPending = false;

--- a/platform/daemon/src/resource-telemetry.test.ts
+++ b/platform/daemon/src/resource-telemetry.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test";
+import type { ResourceSnapshot } from "./resource-monitor";
+import {
+	RESOURCE_CPU_BUCKETS,
+	RESOURCE_MEMORY_BUCKETS,
+	RESOURCE_TELEMETRY_MAX_CADENCE_MS,
+	RESOURCE_WORKLOAD_CLASSES,
+	addResourceUtilizationSample,
+	buildResourceUtilizationTelemetry,
+	emptyResourceUtilizationStats,
+} from "./resource-telemetry";
+
+function snapshot(overrides: Partial<ResourceSnapshot> = {}): ResourceSnapshot {
+	return {
+		total: 10,
+		memoryMd: 1,
+		sockets: 2,
+		inotify: 1,
+		pipes: 1,
+		db: 1,
+		other: 4,
+		rss: 100,
+		heapUsed: 200,
+		physicalFootprint: 300,
+		peakPhysicalFootprint: 400,
+		cpuPercent: 50,
+		...overrides,
+	};
+}
+
+describe("buildResourceUtilizationTelemetry", () => {
+	it("uses the existing heartbeat cadence and never adds a high-frequency timer", () => {
+		expect(RESOURCE_TELEMETRY_MAX_CADENCE_MS).toBe(5 * 60 * 1000);
+	});
+
+	it("maps CPU boundaries, including process values above one host core", () => {
+		const values: ReadonlyArray<[number | null, string]> = [
+			[null, "unavailable"],
+			[0, "zero"],
+			[25, "1-25%"],
+			[25.1, "26-75%"],
+			[75, "26-75%"],
+			[75.1, "76-100%"],
+			[100, "76-100%"],
+			[100.1, "101-200%"],
+			[200, "101-200%"],
+			[200.1, "201+%"],
+		];
+		for (const [cpuPercent, expected] of values) {
+			expect(
+				buildResourceUtilizationTelemetry(snapshot({ cpuPercent }), "normal", false).processCpuUtilizationBucket,
+			).toBe(expected);
+		}
+	});
+
+	it("maps memory boundaries consistently for RSS, heap, and physical footprint", () => {
+		const values: ReadonlyArray<[number | null, string]> = [
+			[null, "unavailable"],
+			[0, "zero"],
+			[64, "1-64MiB"],
+			[64.1, "65-128MiB"],
+			[128, "65-128MiB"],
+			[128.1, "129-256MiB"],
+			[256, "129-256MiB"],
+			[256.1, "257-512MiB"],
+			[512, "257-512MiB"],
+			[512.1, "513-1024MiB"],
+			[1024, "513-1024MiB"],
+			[1024.1, "1025+MiB"],
+		];
+		for (const [memory, expected] of values) {
+			const result = buildResourceUtilizationTelemetry(
+				snapshot({ rss: memory, heapUsed: memory, physicalFootprint: memory }),
+				"normal",
+				false,
+			);
+			expect(result.processRssBucket).toBe(expected);
+			expect(result.processHeapUsedBucket).toBe(expected);
+			expect(result.processPhysicalFootprintBucket).toBe(expected);
+		}
+	});
+
+	it("distinguishes unavailable macOS physical footprint from a measured zero", () => {
+		expect(
+			buildResourceUtilizationTelemetry(snapshot({ physicalFootprint: null }), "normal", false)
+				.processPhysicalFootprintBucket,
+		).toBe("unavailable");
+		expect(
+			buildResourceUtilizationTelemetry(snapshot({ physicalFootprint: 0 }), "normal", false)
+				.processPhysicalFootprintBucket,
+		).toBe("zero");
+	});
+
+	it("uses existing workload context with critical pressure taking precedence", () => {
+		expect(buildResourceUtilizationTelemetry(snapshot(), "normal", false).resourceWorkloadClass).toBe("normal");
+		expect(buildResourceUtilizationTelemetry(snapshot(), "elevated", true).resourceWorkloadClass).toBe("dreaming");
+		expect(buildResourceUtilizationTelemetry(snapshot(), "critical", true).resourceWorkloadClass).toBe(
+			"critical_pressure",
+		);
+		expect(buildResourceUtilizationTelemetry(snapshot(), "critical", false).resourcePressureState).toBe("critical");
+	});
+
+	it("emits only bounded process telemetry fields", () => {
+		const result = buildResourceUtilizationTelemetry(snapshot(), "normal", false);
+		expect(result).toEqual({
+			resourceTelemetryVersion: 1,
+			resourceScope: "process",
+			processCpuUtilizationBucket: "26-75%",
+			processRssBucket: "65-128MiB",
+			processHeapUsedBucket: "129-256MiB",
+			processPhysicalFootprintBucket: "257-512MiB",
+			resourceWorkloadClass: "normal",
+			resourcePressureState: "normal",
+		});
+		expect(Object.keys(result)).not.toContain("rss");
+		expect(Object.keys(result)).not.toContain("heapUsed");
+		expect(Object.keys(result)).not.toContain("cpuPercent");
+		expect(Object.keys(result)).not.toContain("physicalFootprint");
+		expect(RESOURCE_CPU_BUCKETS).toContain(result.processCpuUtilizationBucket);
+		expect(RESOURCE_MEMORY_BUCKETS).toContain(result.processRssBucket);
+		expect(RESOURCE_WORKLOAD_CLASSES).toContain(result.resourceWorkloadClass);
+	});
+});
+
+describe("resource utilization aggregation", () => {
+	it("counts only complete, versioned process samples", () => {
+		const stats = emptyResourceUtilizationStats();
+		const properties = buildResourceUtilizationTelemetry(snapshot(), "elevated", true);
+		addResourceUtilizationSample(stats, properties);
+		addResourceUtilizationSample(stats, { ...properties, resourceTelemetryVersion: 2 });
+		addResourceUtilizationSample(stats, { ...properties, resourceScope: "host" });
+		addResourceUtilizationSample(stats, { ...properties, processRssBucket: "not-a-bucket" });
+		expect(stats.samples).toBe(1);
+		expect(stats.byCpuBucket["26-75%"]).toBe(1);
+		expect(stats.byWorkloadClass.dreaming).toBe(1);
+		expect(stats.byPressureState.elevated).toBe(1);
+	});
+});

--- a/platform/daemon/src/resource-telemetry.ts
+++ b/platform/daemon/src/resource-telemetry.ts
@@ -1,0 +1,146 @@
+/**
+ * Privacy-safe resource telemetry derived from local process measurements.
+ *
+ * Raw resource snapshots stay local to diagnostics. This module is the only
+ * projection used by fleet telemetry and deliberately emits stable buckets,
+ * not measurements or host capacity.
+ */
+import type { ResourceSnapshot } from "./resource-monitor";
+import type { PressureLevel } from "./system-pressure";
+
+export const RESOURCE_TELEMETRY_VERSION = 1;
+/** Resource telemetry is emitted only from the existing daemon heartbeat. */
+export const RESOURCE_TELEMETRY_MAX_CADENCE_MS = 5 * 60 * 1000;
+
+export const RESOURCE_CPU_BUCKETS = ["unavailable", "zero", "1-25%", "26-75%", "76-100%", "101-200%", "201+%"] as const;
+export type ResourceCpuBucket = (typeof RESOURCE_CPU_BUCKETS)[number];
+
+export const RESOURCE_MEMORY_BUCKETS = [
+	"unavailable",
+	"zero",
+	"1-64MiB",
+	"65-128MiB",
+	"129-256MiB",
+	"257-512MiB",
+	"513-1024MiB",
+	"1025+MiB",
+] as const;
+export type ResourceMemoryBucket = (typeof RESOURCE_MEMORY_BUCKETS)[number];
+
+export const RESOURCE_WORKLOAD_CLASSES = ["normal", "dreaming", "critical_pressure"] as const;
+export type ResourceWorkloadClass = (typeof RESOURCE_WORKLOAD_CLASSES)[number];
+
+export const RESOURCE_PRESSURE_STATES = ["normal", "elevated", "critical"] as const;
+export type ResourcePressureState = (typeof RESOURCE_PRESSURE_STATES)[number];
+
+export interface ResourceUtilizationTelemetry {
+	readonly resourceTelemetryVersion: number;
+	readonly resourceScope: "process";
+	readonly processCpuUtilizationBucket: ResourceCpuBucket;
+	readonly processRssBucket: ResourceMemoryBucket;
+	readonly processHeapUsedBucket: ResourceMemoryBucket;
+	readonly processPhysicalFootprintBucket: ResourceMemoryBucket;
+	readonly resourceWorkloadClass: ResourceWorkloadClass;
+	readonly resourcePressureState: ResourcePressureState;
+}
+
+export interface ResourceUtilizationStats {
+	samples: number;
+	byCpuBucket: Record<ResourceCpuBucket, number>;
+	byRssBucket: Record<ResourceMemoryBucket, number>;
+	byHeapUsedBucket: Record<ResourceMemoryBucket, number>;
+	byPhysicalFootprintBucket: Record<ResourceMemoryBucket, number>;
+	byWorkloadClass: Record<ResourceWorkloadClass, number>;
+	byPressureState: Record<ResourcePressureState, number>;
+}
+
+function emptyCounts<const T extends string>(values: readonly T[]): Record<T, number> {
+	return Object.fromEntries(values.map((value) => [value, 0])) as Record<T, number>;
+}
+
+function bucketCpu(value: number | null): ResourceCpuBucket {
+	if (value === null || !Number.isFinite(value) || value < 0) return "unavailable";
+	if (value === 0) return "zero";
+	if (value <= 25) return "1-25%";
+	if (value <= 75) return "26-75%";
+	if (value <= 100) return "76-100%";
+	if (value <= 200) return "101-200%";
+	return "201+%";
+}
+
+function bucketMemory(value: number | null): ResourceMemoryBucket {
+	if (value === null || !Number.isFinite(value) || value < 0) return "unavailable";
+	if (value === 0) return "zero";
+	if (value <= 64) return "1-64MiB";
+	if (value <= 128) return "65-128MiB";
+	if (value <= 256) return "129-256MiB";
+	if (value <= 512) return "257-512MiB";
+	if (value <= 1024) return "513-1024MiB";
+	return "1025+MiB";
+}
+
+function workloadClass(pressure: PressureLevel, dreamingActive: boolean): ResourceWorkloadClass {
+	if (pressure === "critical") return "critical_pressure";
+	if (dreamingActive) return "dreaming";
+	return "normal";
+}
+
+export function buildResourceUtilizationTelemetry(
+	snapshot: ResourceSnapshot,
+	pressure: PressureLevel,
+	dreamingActive: boolean,
+): ResourceUtilizationTelemetry {
+	return {
+		resourceTelemetryVersion: RESOURCE_TELEMETRY_VERSION,
+		resourceScope: "process",
+		processCpuUtilizationBucket: bucketCpu(snapshot.cpuPercent),
+		processRssBucket: bucketMemory(snapshot.rss),
+		processHeapUsedBucket: bucketMemory(snapshot.heapUsed),
+		processPhysicalFootprintBucket: bucketMemory(snapshot.physicalFootprint),
+		resourceWorkloadClass: workloadClass(pressure, dreamingActive),
+		resourcePressureState: pressure,
+	};
+}
+
+export function emptyResourceUtilizationStats(): ResourceUtilizationStats {
+	return {
+		samples: 0,
+		byCpuBucket: emptyCounts(RESOURCE_CPU_BUCKETS),
+		byRssBucket: emptyCounts(RESOURCE_MEMORY_BUCKETS),
+		byHeapUsedBucket: emptyCounts(RESOURCE_MEMORY_BUCKETS),
+		byPhysicalFootprintBucket: emptyCounts(RESOURCE_MEMORY_BUCKETS),
+		byWorkloadClass: emptyCounts(RESOURCE_WORKLOAD_CLASSES),
+		byPressureState: emptyCounts(RESOURCE_PRESSURE_STATES),
+	};
+}
+
+function isOneOf<T extends string>(value: unknown, values: readonly T[]): value is T {
+	return typeof value === "string" && values.includes(value as T);
+}
+
+export function addResourceUtilizationSample(
+	stats: ResourceUtilizationStats,
+	properties: Readonly<Record<string, unknown>>,
+): void {
+	if (properties.resourceTelemetryVersion !== RESOURCE_TELEMETRY_VERSION) return;
+	if (properties.resourceScope !== "process") return;
+	const cpu = properties.processCpuUtilizationBucket;
+	const rss = properties.processRssBucket;
+	const heap = properties.processHeapUsedBucket;
+	const physical = properties.processPhysicalFootprintBucket;
+	const workload = properties.resourceWorkloadClass;
+	const pressure = properties.resourcePressureState;
+	if (!isOneOf(cpu, RESOURCE_CPU_BUCKETS)) return;
+	if (!isOneOf(rss, RESOURCE_MEMORY_BUCKETS)) return;
+	if (!isOneOf(heap, RESOURCE_MEMORY_BUCKETS)) return;
+	if (!isOneOf(physical, RESOURCE_MEMORY_BUCKETS)) return;
+	if (!isOneOf(workload, RESOURCE_WORKLOAD_CLASSES)) return;
+	if (!isOneOf(pressure, RESOURCE_PRESSURE_STATES)) return;
+	stats.samples++;
+	stats.byCpuBucket[cpu]++;
+	stats.byRssBucket[rss]++;
+	stats.byHeapUsedBucket[heap]++;
+	stats.byPhysicalFootprintBucket[physical]++;
+	stats.byWorkloadClass[workload]++;
+	stats.byPressureState[pressure]++;
+}

--- a/platform/daemon/src/routes/telemetry-routes.ts
+++ b/platform/daemon/src/routes/telemetry-routes.ts
@@ -8,6 +8,7 @@ import { getDbAccessor } from "../db-accessor.js";
 import { getDiagnostics } from "../diagnostics.js";
 import { type LogCategory, type LogEntry, logger } from "../logger.js";
 import { listMemorySearchTelemetry } from "../memory-search-telemetry.js";
+import { addResourceUtilizationSample, emptyResourceUtilizationStats } from "../resource-telemetry.js";
 import { getCheckpointsByProject, getCheckpointsBySession, redactCheckpointRow } from "../session-checkpoints.js";
 import type { TelemetryEventType } from "../telemetry.js";
 import { type TimelineSources, buildTimeline } from "../timeline.js";
@@ -347,9 +348,13 @@ export function registerTelemetryRoutes(app: Hono): void {
 		const embeddingCoverage = emptyAccountingCoverage();
 		const dreamingCoverage = emptyAccountingCoverage();
 		const sessionCoverage = emptyAccountingCoverage();
+		const resourceUtilization = emptyResourceUtilizationStats();
 		const latencies: number[] = [];
 
 		for (const e of events) {
+			if (e.event === "daemon.heartbeat") {
+				addResourceUtilizationSample(resourceUtilization, e.properties);
+			}
 			if (e.event === "llm.generate") {
 				llmCalls++;
 				if (typeof e.properties.inputTokens === "number") totalInputTokens += e.properties.inputTokens;
@@ -642,6 +647,7 @@ export function registerTelemetryRoutes(app: Hono): void {
 			pipelineErrorsByStage: Object.fromEntries(pipelineErrorsByStage),
 			pipelineErrorsByCode: Object.fromEntries(pipelineErrorsByCode),
 			pipelineOperations,
+			resourceUtilization,
 		});
 	});
 


### PR DESCRIPTION
## Summary

Implements #1424 by adding bounded process CPU and memory utilization telemetry to the existing five-minute `daemon.heartbeat` event. Raw resource measurements remain local-only; PostHog and local stats receive stable buckets and bounded workload/pressure dimensions.

## Changes

- Add versioned process CPU, RSS, heap-used, and macOS physical-footprint buckets with explicit `unavailable` versus `zero` semantics.
- Classify samples from existing pressure state and the actual in-flight Dreaming pass, with critical pressure taking precedence.
- Add bounded resource bucket aggregation to `/api/telemetry/stats`.
- Add platform/version fields to heartbeat payloads for existing safe grouping dimensions.
- Document the event contract, cadence, CPU sampling-window behavior, privacy boundary, and local-versus-PostHog detail.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migration. Resource telemetry uses the existing heartbeat and telemetry tables.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused verification passed:

- `bun test platform/daemon/src/resource-telemetry.test.ts platform/daemon/src/resource-monitor.test.ts platform/daemon/src/runtime-pressure.test.ts platform/daemon/src/telemetry.test.ts platform/daemon/src/routes/telemetry-routes.test.ts` (64 passed, 0 failed)
- `bunx tsc --noEmit` from `platform/daemon` (passed)
- `bun run --filter '@signet/daemon' build` (passed)
- Targeted Biome and `git diff --check` (passed)

The full-repo `bun run typecheck` and `bun run lint` remain blocked by pre-existing connector-package export, generated-bundle, and formatting diagnostics outside this change. The docs drift check likewise reports pre-existing route, migration, and package-table drift.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The security checklist item is satisfied because this PR adds no admin or mutation endpoint. The readiness checks refer to the affected daemon package: its focused tests, production build/typecheck, and targeted Biome checks pass locally. The existing EventLoopLag wedge path and its ten-minute rate limit are unchanged. The independent adversarial review found no CRITICAL or HIGH findings and returned SHIP. No model field is added because no model context exists at the existing heartbeat sampling boundary.