### PR TITLE
fix(dreaming): track evidence delivery

### DIFF
--- a/platform/core/src/migrations/131-dreaming-evidence-consumption.ts
+++ b/platform/core/src/migrations/131-dreaming-evidence-consumption.ts
@@ -1,0 +1,24 @@
+/** Migration 131: durable Dreaming delivery frontier per immutable evidence revision. */
+import type { MigrationDb } from "./index";
+
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS dreaming_evidence_consumption (
+			agent_id TEXT NOT NULL,
+			source_kind TEXT NOT NULL CHECK (source_kind IN ('memory', 'artifact', 'transcript', 'summary')),
+			source_id TEXT NOT NULL,
+			source_captured_at TEXT NOT NULL,
+			source_entry_id TEXT NOT NULL DEFAULT '',
+			source_revision TEXT NOT NULL,
+			delivered_offset INTEGER NOT NULL CHECK (delivered_offset >= 0),
+			source_length INTEGER NOT NULL CHECK (source_length >= 0),
+			pass_id TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			PRIMARY KEY (agent_id, source_kind, source_id, source_captured_at, source_entry_id, source_revision)
+		);
+		CREATE INDEX IF NOT EXISTS idx_dreaming_evidence_consumption_source
+			ON dreaming_evidence_consumption(agent_id, source_entry_id, source_kind, source_revision);
+		CREATE INDEX IF NOT EXISTS idx_dreaming_evidence_consumption_pending
+			ON dreaming_evidence_consumption(agent_id, source_kind, source_id, source_captured_at, source_revision, delivered_offset, source_length);
+	`);
+}

--- a/platform/core/src/migrations/131-dreaming-evidence-consumption.ts
+++ b/platform/core/src/migrations/131-dreaming-evidence-consumption.ts
@@ -20,5 +20,7 @@ export function up(db: MigrationDb): void {
 			ON dreaming_evidence_consumption(agent_id, source_entry_id, source_kind, source_revision);
 		CREATE INDEX IF NOT EXISTS idx_dreaming_evidence_consumption_pending
 			ON dreaming_evidence_consumption(agent_id, source_kind, source_id, source_captured_at, source_revision, delivered_offset, source_length);
+		CREATE INDEX IF NOT EXISTS idx_dreaming_evidence_consumption_continuation
+			ON dreaming_evidence_consumption(agent_id, pass_id, delivered_offset, source_length);
 	`);
 }

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -136,6 +136,7 @@ import { up as ontologyContradictions } from "./127-ontology-contradictions";
 import { up as boundedQueueDiagnostics } from "./128-bounded-queue-diagnostics";
 import { up as retireStructuralJobs } from "./129-retire-structural-jobs";
 import { up as embeddingRepairState } from "./130-embedding-repair-state";
+import { up as dreamingEvidenceConsumption } from "./131-dreaming-evidence-consumption";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1211,6 +1212,12 @@ export const MIGRATIONS: readonly Migration[] = [
 		name: "embedding-repair-state",
 		up: embeddingRepairState,
 		artifacts: { tables: ["embedding_repair_budget", "embedding_repair_backoff"] },
+	},
+	{
+		version: 131,
+		name: "dreaming-evidence-consumption",
+		up: dreamingEvidenceConsumption,
+		artifacts: { tables: ["dreaming_evidence_consumption"] },
 	},
 ];
 

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -317,6 +317,9 @@ describe("migration framework", () => {
 		// v99 keeps Pi Dreaming capability traces local and pass-scoped.
 		expect(tableNames).toContain("dreaming_tool_calls");
 
+		// v131 records successful source-fragment delivery independently of the time watermark.
+		expect(tableNames).toContain("dreaming_evidence_consumption");
+
 		// v14 tables
 		expect(tableNames).toContain("telemetry_events");
 

--- a/platform/daemon/src/episodic-sources.test.ts
+++ b/platform/daemon/src/episodic-sources.test.ts
@@ -340,6 +340,60 @@ describe("episodic source selection", () => {
 		]);
 	});
 
+	it("keeps content-identical artifacts distinct across configured sources", () => {
+		getDbAccessor().withWriteTx((db) => {
+			for (const [sourceId, sourcePath] of [
+				["import-a", "imports/a.md"],
+				["import-b", "imports/b.md"],
+			] as const) {
+				db.prepare(
+					`INSERT INTO memory_artifacts
+					 (agent_id, source_path, source_sha256, source_kind, source_id, session_id, session_token,
+					  captured_at, content, updated_at, is_deleted)
+					 VALUES ('ant', ?, 'same-content', 'source_markdown', ?, 'session-a', 'token-a',
+					  '2026-08-01T11:00:00.000Z', 'Shared source evidence', '2026-08-01T11:00:00.000Z', 0)`,
+				).run(sourcePath, sourceId);
+			}
+		});
+
+		const matches = getDbAccessor().withReadDb((db) =>
+			searchEpisodicSources(db, { agentId: "ant", query: "Shared source evidence" }),
+		);
+		expect(matches.map((match) => ({ id: match.id, sourceEntryId: match.sourceEntryId }))).toEqual([
+			{ id: "imports/a.md", sourceEntryId: "import-a" },
+			{ id: "imports/b.md", sourceEntryId: "import-b" },
+		]);
+	});
+
+	it("re-lists an artifact revision when its captured time is unchanged", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memory_artifacts
+				 (agent_id, source_path, source_sha256, source_kind, source_id, session_id, session_token,
+				  captured_at, content, updated_at, is_deleted)
+				 VALUES ('ant', 'imports/revised.md', 'sha-old', 'source_markdown', 'import-a', 'session-a', 'token-a',
+				  '2026-08-01T11:00:00.000Z', 'Old fact', '2026-08-01T11:00:00.000Z', 0)`,
+			).run();
+			db.prepare(
+				`INSERT INTO dreaming_evidence_consumption
+				 (agent_id, source_kind, source_id, source_captured_at, source_entry_id, source_revision,
+				  delivered_offset, source_length, pass_id, updated_at)
+				 VALUES ('ant', 'artifact', 'imports/revised.md', '2026-08-01T11:00:00.000Z', 'import-a',
+				  'sha-old', 8, 8, 'pass-old', '2026-08-01T11:01:00.000Z')`,
+			).run();
+			db.prepare(
+				`UPDATE memory_artifacts
+				 SET source_sha256 = 'sha-new', content = 'New fact', updated_at = '2026-08-01T12:00:00.000Z'
+				 WHERE agent_id = 'ant' AND source_path = 'imports/revised.md'`,
+			).run();
+		});
+
+		const matches = getDbAccessor().withReadDb((db) =>
+			searchEpisodicSources(db, { agentId: "ant", query: "", kind: "artifact", excludeDelivered: true }),
+		);
+		expect(matches).toMatchObject([{ id: "imports/revised.md", sourceRevision: "sha-new", content: "New fact" }]);
+	});
+
 	it("re-lists corrupt pre-epoch artifacts behind the since watermark (#1149)", () => {
 		// Regression for #1149: artifacts stamped with the DOS-epoch sentinel
 		// (1980, from timestamp-stripping filesystems) can never be reached

--- a/platform/daemon/src/episodic-sources.ts
+++ b/platform/daemon/src/episodic-sources.ts
@@ -49,6 +49,12 @@ export interface EpisodicSourceRecord {
 	 * node/session id in `sourceId`.
 	 */
 	readonly sourceEntryId: string | null;
+	/**
+	 * Stable content revision for the delivery frontier. Artifacts use their
+	 * source hash when available because a path may be re-indexed without a
+	 * different captured_at value; other immutable rows use capturedAt.
+	 */
+	readonly sourceRevision?: string;
 	readonly project: string | null;
 	readonly harness: string | null;
 	readonly capturedAt: string;
@@ -230,7 +236,7 @@ export function readEpisodicArtifact(db: ReadDb, agentId: string, id: string): E
 	const placeholders = ids.map(() => "?").join(", ");
 	const row = db
 		.prepare(
-			`SELECT source_path, source_kind, source_id, source_node_id, session_id, session_key, session_token,
+			`SELECT source_path, source_sha256, source_kind, source_id, source_node_id, session_id, session_key, session_token,
 			        project, harness, content, captured_at, updated_at
 			 FROM memory_artifacts
 			 WHERE agent_id = ?
@@ -248,6 +254,7 @@ export function readEpisodicArtifact(db: ReadDb, agentId: string, id: string): E
 		.get(agentId, id, ...ids, ...ids, ...ids, ...ids) as
 		| {
 				readonly source_path: string;
+				readonly source_sha256: string | null;
 				readonly source_kind: string;
 				readonly source_id: string | null;
 				readonly source_node_id: string | null;
@@ -274,6 +281,7 @@ export function readEpisodicArtifact(db: ReadDb, agentId: string, id: string): E
 		sourceKind: row.source_kind,
 		sourceId: row.source_node_id ?? row.session_key ?? row.session_id ?? row.session_token,
 		sourceEntryId: readNonEmptyTrimmed(row.source_id),
+		sourceRevision: readNonEmptyTrimmed(row.source_sha256) ?? row.captured_at ?? row.updated_at,
 		sourcePath: row.source_path,
 		project: row.project,
 		harness: row.harness,
@@ -500,7 +508,7 @@ export function readRecentEpisodicSources(
 	const artifacts: EpisodicSourceRecord[] = wants("artifact")
 		? db
 				.prepare(
-					`SELECT source_path, source_kind, source_id, source_node_id, session_id, session_key, session_token,
+					`SELECT source_path, source_sha256, source_kind, source_id, source_node_id, session_id, session_key, session_token,
 			        project, harness, content, captured_at, updated_at
 			 FROM memory_artifacts AS ma
 			 WHERE ma.agent_id = ? AND COALESCE(ma.is_deleted, 0) = 0
@@ -542,6 +550,7 @@ export function readRecentEpisodicSources(
 				.map((row) => {
 					const artifact = row as {
 						readonly source_path: string;
+						readonly source_sha256: string | null;
 						readonly source_kind: string;
 						readonly source_id: string | null;
 						readonly source_node_id: string | null;
@@ -561,6 +570,7 @@ export function readRecentEpisodicSources(
 						sourceKind: artifact.source_kind,
 						sourceId: artifact.source_node_id ?? artifact.session_key ?? artifact.session_id ?? artifact.session_token,
 						sourceEntryId: readNonEmptyTrimmed(artifact.source_id),
+						sourceRevision: readNonEmptyTrimmed(artifact.source_sha256) ?? artifact.captured_at ?? artifact.updated_at,
 						sourcePath: artifact.source_path,
 						project: artifact.project,
 						harness: artifact.harness,
@@ -796,6 +806,8 @@ export function searchEpisodicSources(
 		readonly since?: string;
 		readonly before?: string;
 		readonly kind?: "memory" | "artifact" | "transcript" | "summary";
+		/** Scan-first delivery drains only records whose current revision is not complete. */
+		readonly excludeDelivered?: boolean;
 		readonly limit?: number;
 	},
 ): EpisodicSourceRecord[] {
@@ -814,6 +826,27 @@ export function searchEpisodicSources(
 	// forever.
 	const sinceArgs: unknown[] = params.since !== undefined ? [params.since, EPISODIC_CAPTURED_AT_FLOOR] : [];
 	const beforeArgs: unknown[] = params.before !== undefined ? [params.before] : [];
+	const deliveredFilterEnabled =
+		params.excludeDelivered === true &&
+		db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'dreaming_evidence_consumption'").get() !=
+			null;
+	const deliveredPredicate = (
+		kind: EpisodicSourceKind,
+		id: string,
+		capturedAt: string,
+		sourceEntryId: string,
+		sourceRevision: string,
+	): string =>
+		deliveredFilterEnabled
+			? `AND NOT EXISTS (
+				SELECT 1 FROM dreaming_evidence_consumption dec
+				 WHERE dec.agent_id = ? AND dec.source_kind = '${kind}' AND dec.source_id = ${id}
+				   AND dec.source_captured_at = ${capturedAt} AND dec.source_entry_id = ${sourceEntryId}
+				   AND dec.source_revision = ${sourceRevision}
+				   AND dec.delivered_offset >= dec.source_length
+			)`
+			: "";
+	const deliveredArgs = deliveredFilterEnabled ? [params.agentId] : [];
 	const transcriptSearchTime = tableHasColumn(db, "session_transcripts", "updated_at")
 		? "COALESCE(updated_at, created_at)"
 		: "created_at";
@@ -830,31 +863,34 @@ export function searchEpisodicSources(
 			        AND COALESCE(is_deleted, 0) = 0 AND visibility != 'archived' AND scope IS NULL
 			        AND COALESCE(type, '') != 'session_summary' AND content LIKE ?
 			        ${params.since ? "AND (julianday(created_at) >= julianday(?) OR julianday(created_at) < julianday(?))" : ""}
-			        ${params.before ? "AND julianday(created_at) <= julianday(?)" : ""}`,
-			args: [params.agentId, like, ...sinceArgs, ...beforeArgs],
+			        ${params.before ? "AND julianday(created_at) <= julianday(?)" : ""}
+			        ${deliveredPredicate("memory", "id", "created_at", "''", "created_at")}`,
+			args: [params.agentId, like, ...sinceArgs, ...beforeArgs, ...deliveredArgs],
 		});
 	}
 	if (params.kind === undefined || params.kind === "artifact") {
 		branches.push({
-			// Artifacts are deduped by content hash: content-identical files
-			// across vault paths collapse to one canonical row (most recent
-			// captured_at; tie-break by path). Empty placeholder artifacts are
-			// excluded entirely.
+			// Artifacts are deduped by content hash within their configured source:
+			// content-identical paths in one source collapse to one canonical row,
+			// but independently imported sources must each retain their own durable
+			// delivery frontier. Empty placeholder artifacts are excluded entirely.
 			sql: `SELECT 'artifact' AS kind, ma.source_path AS id, ma.captured_at AS captured_at
 			      FROM memory_artifacts ma
 			      WHERE ma.agent_id = ? AND COALESCE(ma.is_deleted, 0) = 0
 			        AND length(ma.content) > 0 AND ma.content LIKE ?
 			        ${params.since ? "AND (julianday(ma.captured_at) >= julianday(?) OR julianday(ma.captured_at) < julianday(?))" : ""}
 			        ${params.before ? "AND julianday(ma.captured_at) <= julianday(?)" : ""}
+			        ${deliveredPredicate("artifact", "ma.source_path", "ma.captured_at", "COALESCE(ma.source_id, '')", "CASE WHEN ma.source_sha256 IS NULL OR ma.source_sha256 = '' THEN ma.captured_at ELSE ma.source_sha256 END")}
 			        AND (ma.source_sha256 IS NULL OR ma.source_sha256 = ''
 			             OR (ma.agent_id, ma.source_path) = (
 			               SELECT ma2.agent_id, ma2.source_path FROM memory_artifacts ma2
 			               WHERE ma2.agent_id = ma.agent_id AND COALESCE(ma2.is_deleted, 0) = 0
 			                 AND ma2.source_sha256 = ma.source_sha256
+			                 AND COALESCE(ma2.source_id, '') = COALESCE(ma.source_id, '')
 			               ORDER BY ma2.captured_at DESC, ma2.source_path ASC
 			               LIMIT 1
 			             ))`,
-			args: [params.agentId, like, ...sinceArgs, ...beforeArgs],
+			args: [params.agentId, like, ...sinceArgs, ...beforeArgs, ...deliveredArgs],
 		});
 	}
 	if (params.kind === undefined || params.kind === "transcript") {
@@ -863,8 +899,9 @@ export function searchEpisodicSources(
 			      FROM session_transcripts
 			      WHERE agent_id = ? AND ${transcriptCompleted} AND content LIKE ?
 			        ${params.since ? `AND (julianday(${transcriptSearchTime}) >= julianday(?) OR julianday(${transcriptSearchTime}) < julianday(?))` : ""}
-			        ${params.before ? `AND julianday(${transcriptSearchTime}) <= julianday(?)` : ""}`,
-			args: [params.agentId, like, ...sinceArgs, ...beforeArgs],
+			        ${params.before ? `AND julianday(${transcriptSearchTime}) <= julianday(?)` : ""}
+			        ${deliveredPredicate("transcript", "session_key", transcriptSearchTime, "''", transcriptSearchTime)}`,
+			args: [params.agentId, like, ...sinceArgs, ...beforeArgs, ...deliveredArgs],
 		});
 	}
 	if (params.kind === "summary") {
@@ -875,8 +912,9 @@ export function searchEpisodicSources(
 			        AND COALESCE(source_type, 'summary') IN ('summary', 'compaction', 'checkpoint')
 			        AND content LIKE ?
 			        ${params.since ? "AND (julianday(latest_at) >= julianday(?) OR julianday(latest_at) < julianday(?))" : ""}
-			        ${params.before ? "AND julianday(latest_at) <= julianday(?)" : ""}`,
-			args: [params.agentId, like, ...sinceArgs, ...beforeArgs],
+			        ${params.before ? "AND julianday(latest_at) <= julianday(?)" : ""}
+			        ${deliveredPredicate("summary", "id", "latest_at", "''", "latest_at")}`,
+			args: [params.agentId, like, ...sinceArgs, ...beforeArgs, ...deliveredArgs],
 		});
 	}
 

--- a/platform/daemon/src/imported-source-lifecycle.test.ts
+++ b/platform/daemon/src/imported-source-lifecycle.test.ts
@@ -48,6 +48,11 @@ describe("imported source lifecycle", () => {
 		});
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
+				`INSERT INTO dreaming_evidence_consumption
+				 (agent_id, source_kind, source_id, source_captured_at, source_entry_id, source_revision, delivered_offset, source_length, pass_id, updated_at)
+				 VALUES (?, 'artifact', 'imports/source-import-1/notes.json', '2026-08-11T00:00:00.000Z', ?, 'hash-1', 20, 20, 'pass-1', '2026-08-11T00:00:00.000Z')`,
+			).run(agentId, sourceId);
+			db.prepare(
 				`INSERT INTO derived_memory_sources
 				 (derived_memory_id, source_kind, source_id, source_path, agent_id, created_at)
 				 VALUES (?, ?, ?, ?, ?, ?)`,
@@ -136,6 +141,16 @@ describe("imported source lifecycle", () => {
 			getDbAccessor().withReadDb(
 				(db) =>
 					db.prepare("SELECT COUNT(*) AS count FROM memory_artifacts WHERE source_id = ?").get(sourceId) as {
+						count: number;
+					},
+			).count,
+		).toBe(0);
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare("SELECT COUNT(*) AS count FROM dreaming_evidence_consumption WHERE source_entry_id = ?")
+						.get(sourceId) as {
 						count: number;
 					},
 			).count,

--- a/platform/daemon/src/imported-source-lifecycle.ts
+++ b/platform/daemon/src/imported-source-lifecycle.ts
@@ -56,6 +56,13 @@ export function markImportedSourceUnsupported(
 		const artifacts = countChanges(
 			db.prepare("DELETE FROM memory_artifacts WHERE agent_id = ? AND source_id = ?").run(agentId, sourceId),
 		);
+		// Consumption rows describe the removed source's old artifact revisions.
+		// Delete them in the same lifecycle transaction so a re-import starts
+		// cleanly instead of inheriting a stale delivered frontier.
+		db.prepare("DELETE FROM dreaming_evidence_consumption WHERE agent_id = ? AND source_entry_id = ?").run(
+			agentId,
+			sourceId,
+		);
 		const prefix = `${sourceId}:`;
 		const embeddingRows = db
 			.prepare(

--- a/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
@@ -245,14 +245,11 @@ describe("dreaming-agent-tools", () => {
 		expect(JSON.stringify(entity).length).toBeLessThan(10_000);
 	});
 
-	it("search_evidence defaults since to the scope's evidence watermark when omitted (#1149)", async () => {
-		// Regression for #1149: the scan-first listing used to anchor `since`
-		// to pass-start (read off the runbook), so evidence captured between
-		// the last watermark and pass start was never listed. An omitted
-		// `since` must fall back to dreaming_state.last_pass_at — the
-		// frontier the last pass actually surfaced — so the unprocessed
-		// window is listed, and an explicit earlier `since` still reaches
-		// older evidence.
+	it("search_evidence scan-first ignores the time watermark and lists incomplete evidence (#1430)", async () => {
+		// Regression for #1430: a time watermark is only a newness frontier.
+		// A scan-first call must instead drain every source revision whose
+		// delivered offset is incomplete, including evidence older than the
+		// watermark. An explicit historical range stays available as well.
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare("INSERT INTO dreaming_state (agent_id, last_pass_at) VALUES (?, ?)").run(
 				"owner",
@@ -282,7 +279,7 @@ describe("dreaming-agent-tools", () => {
 		);
 		const refs = (listed.items as Array<{ sourceRef: string }>).map((item) => item.sourceRef);
 		expect(refs).toContain("memory:mem-new");
-		expect(refs).not.toContain("memory:mem-old");
+		expect(refs).toContain("memory:mem-old");
 
 		const explicit = readResult(
 			await findTool(tools, "search_evidence").execute(

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -29,6 +29,7 @@ import { detectProspectiveContradictionRisk } from "./antonyms";
 import { getDreamingAttentionAcrossScopes, getDreamingAttentionScoped } from "./dreaming-attention";
 import { nextDreamingEvidenceFragment, renderDreamingEvidence } from "./dreaming-evidence";
 import type { DreamingAgentEvidence } from "./dreaming-evidence";
+import { deliveredOffsetForSource } from "./dreaming-evidence-consumption";
 import { DREAMING_ONTOLOGY_OPERATION_SCHEMA } from "./dreaming-operation-contract";
 import {
 	type ApplyDreamingOperationsResult,
@@ -87,11 +88,11 @@ function filterDreamingAttributes(
 
 /**
  * The scope's evidence watermark (`dreaming_state.last_pass_at`): the
- * frontier the last pass actually surfaced. `search_evidence` anchors its
- * scan-first listing here (when the agent omits `since`) so the unprocessed
- * window is listed instead of pass-start (#1149). Missing on first run, an
- * old workspace, or a scope that never passed: returns null so the listing
- * falls back to unbounded.
+ * frontier the last pass actually surfaced. It limits historical searches
+ * that omit `since`; scan-first delivery deliberately ignores it and drains
+ * source revisions from their durable delivered offsets (#1430). Missing on
+ * first run, an old workspace, or a scope that never passed: returns null so
+ * historical searches fall back to unbounded.
  */
 function readEvidenceWatermark(db: ReadDb, agentId: string): string | null {
 	try {
@@ -139,6 +140,7 @@ function projectEvidenceItem(
 		sourceId: source.sourceId,
 		sourcePath: source.sourcePath,
 		sourceEntryId: source.sourceEntryId,
+		sourceRevision: source.sourceRevision ?? source.capturedAt,
 		project: source.project,
 		harness: source.harness,
 		capturedAt: source.capturedAt,
@@ -498,7 +500,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"search_evidence",
 			"Search episodic evidence",
-			"Full-text search immutable episodic memories, artifacts, and transcripts in one agent scope. Historical summary records can be requested explicitly with kind=summary, but are not part of the default Dreaming delivery path. Results contain exact bounded excerpts of the rendered evidence with contentOffset/contentLength; use sourceRef for citations, which are validated against the complete canonical source. Each record carries completed: memory, artifact, and summary records are settled captures (true); a transcript is true only after the session-end machinery writes its completion marker, and false while the session is still running — do not file claims from a still-growing transcript, since its states may be contradicted by the session's end. If contentTruncated is true, page exact fragments with the same sourceRef and chunkSize: start at offset=0 when contentHasPrevious is true, then use offset=contentOffset+content.length from the fragment just returned until contentHasNext is false. Omit the query AND since to list the unprocessed window: the listing starts at the scope's evidence watermark (the last pass's surfaced frontier), so the newest unseen sources come first. Narrow with a query if the list is large; pass an explicit earlier since only when you need older history. Artifacts are deduped by content hash: content-identical files across vault paths collapse to one canonical entry.",
+			"Full-text search immutable episodic memories, artifacts, and transcripts in one agent scope. Historical summary records can be requested explicitly with kind=summary, but are not part of the default Dreaming delivery path. Results contain exact bounded excerpts of the rendered evidence with contentOffset/contentLength; use sourceRef for citations, which are validated against the complete canonical source. Each record carries completed: memory, artifact, and summary records are settled captures (true); a transcript is true only after the session-end machinery writes its completion marker, and false while the session is still running — do not file claims from a still-growing transcript, since its states may be contradicted by the session's end. If contentTruncated is true, page exact fragments with the same sourceRef and chunkSize: start at offset=0 when contentHasPrevious is true, then use offset=contentOffset+content.length from the fragment just returned until contentHasNext is false. Omit query, since, and before to drain the durable delivery queue: it lists every incomplete source revision and resumes at its delivered offset, regardless of time watermark. Narrow with a query if the list is large; pass an explicit earlier since only when you need older history. Artifacts are deduped by content hash: content-identical files across vault paths collapse to one canonical entry.",
 			true,
 			z.object({
 				agentId: z.string().min(1),
@@ -528,21 +530,31 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 							? { ok: false, error: "Evidence fragment offset is outside the source" }
 							: { ok: true, items: [fragment] };
 					}
-					// The scan-first listing omits `since`; anchor it to the
-					// scope's evidence watermark instead of pass-start so the
-					// unprocessed window [last surfaced frontier -> now] is
-					// listed, never the fresh minutes after pass start only
-					// (#1149).
-					const effectiveSince = since ?? readEvidenceWatermark(db, scopeId);
+					// A scan-first call is the delivery queue. It ignores the time
+					// watermark for selection, drains only incomplete evidence revisions,
+					// and resumes each source at its persisted delivered offset.
+					const scanFirst = query === undefined && since === undefined && before === undefined;
+					const effectiveSince = scanFirst ? undefined : (since ?? readEvidenceWatermark(db, scopeId) ?? undefined);
 					const sources = searchEpisodicSources(db, {
 						agentId: scopeId,
 						query: query ?? "",
-						since: effectiveSince ?? undefined,
+						since: effectiveSince,
 						before,
 						kind,
+						excludeDelivered: scanFirst,
 						limit,
 					});
-					return { ok: true, items: projectEvidence(sources, query ?? "") };
+					const items = scanFirst
+						? sources.flatMap((source) => {
+								const fragment = projectEvidenceFragment(
+									source,
+									deliveredOffsetForSource(db, scopeId, source),
+									MAX_EVIDENCE_EXCERPT_CHARS,
+								);
+								return fragment === null ? [] : [fragment];
+							})
+						: projectEvidence(sources, query ?? "");
+					return { ok: true, items };
 				}),
 		),
 		capability(
@@ -627,12 +639,24 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 		capability(
 			"runbook_write",
 			"Write Dreaming runbook",
-			"Before finishing a Dreaming pass, store one short structured note for future passes to review.",
+			"Before finishing a Dreaming pass, store one short structured note for future passes to review. Deferred evidence in another scope must include its agentId.",
 			false,
 			z.object({
 				summary: z.string().trim().min(1).max(2_000),
 				openQuestions: z.array(z.string().trim().min(1).max(500)).max(20).default([]),
 				deferred: z.array(z.string().trim().min(1).max(500)).max(20).default([]),
+				deferredEvidence: z
+					.array(
+						z.union([
+							z.string().regex(/^(memory|artifact|transcript|summary):.+$/),
+							z.object({
+								agentId: z.string().trim().min(1),
+								sourceRef: z.string().regex(/^(memory|artifact|transcript|summary):.+$/),
+							}),
+						]),
+					)
+					.max(20)
+					.default([]),
 			}),
 			async (entry) => {
 				if (!params.passId) return { ok: false, error: "Runbook writes require a live Dreaming pass" };

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -29,7 +29,7 @@ import { detectProspectiveContradictionRisk } from "./antonyms";
 import { getDreamingAttentionAcrossScopes, getDreamingAttentionScoped } from "./dreaming-attention";
 import { nextDreamingEvidenceFragment, renderDreamingEvidence } from "./dreaming-evidence";
 import type { DreamingAgentEvidence } from "./dreaming-evidence";
-import { deliveredOffsetForSource } from "./dreaming-evidence-consumption";
+import { deliveredOffsetForSource, pendingDreamingEvidenceContinuations } from "./dreaming-evidence-consumption";
 import { DREAMING_ONTOLOGY_OPERATION_SCHEMA } from "./dreaming-operation-contract";
 import {
 	type ApplyDreamingOperationsResult,
@@ -535,15 +535,19 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 					// and resumes each source at its persisted delivered offset.
 					const scanFirst = query === undefined && since === undefined && before === undefined;
 					const effectiveSince = scanFirst ? undefined : (since ?? readEvidenceWatermark(db, scopeId) ?? undefined);
-					const sources = searchEpisodicSources(db, {
-						agentId: scopeId,
-						query: query ?? "",
-						since: effectiveSince,
-						before,
-						kind,
-						excludeDelivered: scanFirst,
-						limit,
-					});
+					const continuations = scanFirst ? pendingDreamingEvidenceContinuations(db, scopeId, limit ?? 20, kind) : [];
+					const sources =
+						continuations.length > 0
+							? continuations
+							: searchEpisodicSources(db, {
+									agentId: scopeId,
+									query: query ?? "",
+									since: effectiveSince,
+									before,
+									kind,
+									excludeDelivered: scanFirst,
+									limit,
+								});
 					const items = scanFirst
 						? sources.flatMap((source) => {
 								const fragment = projectEvidenceFragment(

--- a/platform/daemon/src/pipeline/dreaming-evidence-consumption.ts
+++ b/platform/daemon/src/pipeline/dreaming-evidence-consumption.ts
@@ -18,6 +18,15 @@ function tableExists(db: ReadDb, table: string): boolean {
 	return db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(table) != null;
 }
 
+function tableHasColumn(db: ReadDb, table: string, column: string): boolean {
+	try {
+		const rows = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;
+		return rows.some((row) => row.name === column);
+	} catch {
+		return false;
+	}
+}
+
 function record(value: unknown): Record<string, unknown> | null {
 	return typeof value === "object" && value !== null && !Array.isArray(value)
 		? (value as Record<string, unknown>)
@@ -220,6 +229,9 @@ export function pendingDreamingEvidenceContinuations(
 ): readonly EpisodicSourceRecord[] {
 	if (!tableExists(db, "dreaming_evidence_consumption")) return [];
 	const boundedLimit = Math.min(Math.max(Math.floor(limit), 1), 50);
+	const transcriptUpdatedAt = tableHasColumn(db, "session_transcripts", "updated_at") ? "st.updated_at" : "NULL";
+	const transcriptCompletedAt = tableHasColumn(db, "session_transcripts", "completed_at") ? "st.completed_at" : "NULL";
+	const transcriptRevision = `COALESCE(${transcriptCompletedAt}, ${transcriptUpdatedAt}, st.created_at)`;
 	const rows = db
 		.prepare(
 			`SELECT dec.source_kind AS kind, dec.source_id AS id, dec.source_captured_at AS capturedAt,
@@ -229,28 +241,63 @@ export function pendingDreamingEvidenceContinuations(
 			 WHERE dec.agent_id = ?
 			   AND dec.delivered_offset > 0 AND dec.delivered_offset < dec.source_length
 			   AND (? IS NULL OR dec.source_kind = ?)
-			 ORDER BY pass.rowid ASC, dec.source_kind ASC, dec.source_id ASC, dec.source_captured_at ASC`,
+			   AND (
+			     (dec.source_kind = 'memory' AND EXISTS (
+			       SELECT 1 FROM memories m
+			       WHERE m.agent_id = dec.agent_id AND m.id = dec.source_id
+			         AND m.memory_kind = 'episodic' AND COALESCE(m.is_deleted, 0) = 0
+			         AND m.visibility != 'archived' AND m.scope IS NULL
+			         AND COALESCE(m.type, '') != 'session_summary'
+			         AND dec.source_captured_at = m.created_at AND dec.source_entry_id = ''
+			         AND dec.source_revision = m.created_at
+			     ))
+			     OR (dec.source_kind = 'artifact' AND EXISTS (
+			       SELECT 1 FROM memory_artifacts ma
+			       WHERE ma.agent_id = dec.agent_id AND ma.source_path = dec.source_id
+			         AND COALESCE(ma.is_deleted, 0) = 0 AND length(ma.content) > 0
+			         AND dec.source_captured_at = ma.captured_at
+			         AND dec.source_entry_id = COALESCE(ma.source_id, '')
+			         AND dec.source_revision = CASE
+			           WHEN ma.source_sha256 IS NULL OR ma.source_sha256 = '' THEN ma.captured_at
+			           ELSE ma.source_sha256
+			         END
+			     ))
+			     OR (dec.source_kind = 'transcript' AND EXISTS (
+			       SELECT 1 FROM session_transcripts st
+			       WHERE st.agent_id = dec.agent_id AND st.session_key = dec.source_id
+			         AND dec.source_captured_at = ${transcriptRevision}
+			         AND dec.source_entry_id = '' AND dec.source_revision = ${transcriptRevision}
+			     ))
+			     OR (dec.source_kind = 'summary' AND EXISTS (
+			       SELECT 1 FROM session_summaries ss
+			       WHERE ss.agent_id = dec.agent_id AND ss.id = dec.source_id
+			         AND ss.depth = 0
+			         AND COALESCE(ss.source_type, 'summary') IN ('summary', 'compaction', 'checkpoint')
+			         AND dec.source_captured_at = ss.latest_at
+			         AND dec.source_entry_id = '' AND dec.source_revision = ss.latest_at
+			     ))
+			   )
+			 ORDER BY pass.rowid ASC, dec.source_kind ASC, dec.source_id ASC, dec.source_captured_at ASC
+			 LIMIT ?`,
 		)
-		.all(agentId, kind ?? null, kind ?? null) as Array<{
+		.all(agentId, kind ?? null, kind ?? null, boundedLimit) as Array<{
 		kind: EpisodicSourceKind;
 		id: string;
 		capturedAt: string;
 		sourceEntryId: string;
 		sourceRevision: string;
 	}>;
-	return rows
-		.flatMap((row) => {
-			const source = readEpisodicSource(db, { agentId, from: `${row.kind}:${row.id}` });
-			if (
-				source === null ||
-				source.capturedAt !== row.capturedAt ||
-				sourceIdentity(source) !== row.sourceEntryId ||
-				sourceRevision(source) !== row.sourceRevision
-			)
-				return [];
-			return [source];
-		})
-		.slice(0, boundedLimit);
+	return rows.flatMap((row) => {
+		const source = readEpisodicSource(db, { agentId, from: `${row.kind}:${row.id}` });
+		if (
+			source === null ||
+			source.capturedAt !== row.capturedAt ||
+			sourceIdentity(source) !== row.sourceEntryId ||
+			sourceRevision(source) !== row.sourceRevision
+		)
+			return [];
+		return [source];
+	});
 }
 
 /** Narrow truthful completion query for one configured source. */

--- a/platform/daemon/src/pipeline/dreaming-evidence-consumption.ts
+++ b/platform/daemon/src/pipeline/dreaming-evidence-consumption.ts
@@ -1,0 +1,212 @@
+import type { ReadDb, WriteDb } from "../db-accessor";
+import { type EpisodicSourceKind, type EpisodicSourceRecord, readEpisodicSource } from "../episodic-sources";
+import { renderDreamingEvidence } from "./dreaming-evidence";
+
+export interface DreamingEvidenceDelivery {
+	readonly agentId: string;
+	readonly kind: EpisodicSourceKind;
+	readonly id: string;
+	readonly capturedAt: string;
+	readonly sourceRevision: string;
+	readonly start: number;
+	readonly end: number;
+	readonly length: number;
+	readonly content: string;
+}
+
+function tableExists(db: ReadDb, table: string): boolean {
+	return db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(table) != null;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function text(value: unknown): string | null {
+	return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function sourceIdentity(source: EpisodicSourceRecord): string {
+	return source.sourceEntryId ?? "";
+}
+
+function sourceRevision(source: EpisodicSourceRecord): string {
+	return source.sourceRevision ?? source.capturedAt;
+}
+
+function sourceRef(value: string): { readonly kind: EpisodicSourceKind; readonly id: string } | null {
+	const separator = value.indexOf(":");
+	if (separator <= 0) return null;
+	const kind = value.slice(0, separator);
+	const id = value.slice(separator + 1);
+	if (!id || !["memory", "artifact", "transcript", "summary"].includes(kind)) return null;
+	return { kind: kind as EpisodicSourceKind, id };
+}
+
+/** Parse exact fragments persisted in Dreaming tool-call output. Invalid rows never acknowledge evidence. */
+export function persistedEvidenceDeliveries(db: ReadDb, passId: string): readonly DreamingEvidenceDelivery[] {
+	if (!tableExists(db, "dreaming_tool_calls")) return [];
+	const rows = db
+		.prepare(
+			`SELECT input_json AS inputJson, output_json AS outputJson
+			 FROM dreaming_tool_calls
+			 WHERE pass_id = ? AND tool_name = 'search_evidence' ORDER BY sequence ASC`,
+		)
+		.all(passId) as Array<{ inputJson: string; outputJson: string }>;
+	return rows.flatMap(({ inputJson, outputJson }) => {
+		let input: unknown;
+		let output: unknown;
+		try {
+			input = JSON.parse(inputJson);
+			output = JSON.parse(outputJson);
+		} catch {
+			return [];
+		}
+		const agentId = text(record(input)?.agentId);
+		const data = record(output);
+		if (!agentId || data?.ok !== true || !Array.isArray(data.items)) return [];
+		return data.items.flatMap((item) => {
+			const row = record(item);
+			const ref = text(row?.sourceRef);
+			const parsed = ref ? sourceRef(ref) : null;
+			const capturedAt = text(row?.capturedAt);
+			const sourceRevision = text(row?.sourceRevision);
+			const start =
+				typeof row?.contentOffset === "number" && Number.isSafeInteger(row.contentOffset) ? row.contentOffset : null;
+			const content = text(row?.content);
+			const length =
+				typeof row?.contentLength === "number" && Number.isSafeInteger(row.contentLength) ? row.contentLength : null;
+			if (
+				!parsed ||
+				!capturedAt ||
+				!sourceRevision ||
+				start === null ||
+				!content ||
+				length === null ||
+				start < 0 ||
+				length < start
+			)
+				return [];
+			const end = start + content.length;
+			if (end > length) return [];
+			return [{ agentId, kind: parsed.kind, id: parsed.id, capturedAt, sourceRevision, start, end, length, content }];
+		});
+	});
+}
+
+function verifiedDelivery(db: ReadDb, delivery: DreamingEvidenceDelivery): EpisodicSourceRecord | null {
+	const source = readEpisodicSource(db, { agentId: delivery.agentId, from: `${delivery.kind}:${delivery.id}` });
+	if (
+		source === null ||
+		source.capturedAt !== delivery.capturedAt ||
+		sourceRevision(source) !== delivery.sourceRevision
+	)
+		return null;
+	const rendered = renderDreamingEvidence(source);
+	if (
+		rendered.length !== delivery.length ||
+		delivery.end > rendered.length ||
+		rendered.slice(delivery.start, delivery.end) !== delivery.content
+	) {
+		return null;
+	}
+	return source;
+}
+
+/** Advance only contiguous delivery. A fragment after a gap is durable audit evidence but never a completion acknowledgement. */
+export function recordDreamingEvidenceConsumptionInTx(
+	db: WriteDb,
+	params: { readonly passId: string; readonly deferredEvidence: ReadonlySet<string> },
+): void {
+	if (!tableExists(db, "dreaming_evidence_consumption")) return;
+	const deliveries = persistedEvidenceDeliveries(db, params.passId)
+		.filter((delivery) => !params.deferredEvidence.has(`${delivery.agentId}\u0000${delivery.kind}:${delivery.id}`))
+		.sort(
+			(a, b) =>
+				a.agentId.localeCompare(b.agentId) ||
+				a.kind.localeCompare(b.kind) ||
+				a.id.localeCompare(b.id) ||
+				a.capturedAt.localeCompare(b.capturedAt) ||
+				a.start - b.start ||
+				a.end - b.end,
+		);
+	const select = db.prepare(
+		`SELECT delivered_offset AS deliveredOffset FROM dreaming_evidence_consumption
+		 WHERE agent_id = ? AND source_kind = ? AND source_id = ? AND source_captured_at = ? AND source_entry_id = ? AND source_revision = ?`,
+	);
+	const upsert = db.prepare(
+		`INSERT INTO dreaming_evidence_consumption
+		 (agent_id, source_kind, source_id, source_captured_at, source_entry_id, source_revision, delivered_offset, source_length, pass_id, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+		 ON CONFLICT(agent_id, source_kind, source_id, source_captured_at, source_entry_id, source_revision) DO UPDATE SET
+		   delivered_offset = excluded.delivered_offset,
+		   source_length = excluded.source_length,
+		   pass_id = excluded.pass_id,
+		   updated_at = excluded.updated_at`,
+	);
+	for (const delivery of deliveries) {
+		const source = verifiedDelivery(db, delivery);
+		if (source === null) continue;
+		const identity = sourceIdentity(source);
+		const revision = sourceRevision(source);
+		const row = select.get(delivery.agentId, delivery.kind, delivery.id, delivery.capturedAt, identity, revision) as {
+			deliveredOffset: number;
+		} | null;
+		const current = row?.deliveredOffset ?? 0;
+		if (delivery.start > current) continue;
+		const next = Math.max(current, delivery.end);
+		if (next <= current && row != null) continue;
+		upsert.run(
+			delivery.agentId,
+			delivery.kind,
+			delivery.id,
+			delivery.capturedAt,
+			identity,
+			revision,
+			Math.min(next, delivery.length),
+			delivery.length,
+			params.passId,
+		);
+	}
+}
+
+export function deliveredOffsetForSource(db: ReadDb, agentId: string, source: EpisodicSourceRecord): number {
+	if (!tableExists(db, "dreaming_evidence_consumption")) return 0;
+	const row = db
+		.prepare(
+			`SELECT delivered_offset AS deliveredOffset FROM dreaming_evidence_consumption
+		 WHERE agent_id = ? AND source_kind = ? AND source_id = ? AND source_captured_at = ? AND source_entry_id = ? AND source_revision = ?`,
+		)
+		.get(agentId, source.kind, source.id, source.capturedAt, sourceIdentity(source), sourceRevision(source)) as {
+		deliveredOffset: number;
+	} | null;
+	return Math.max(0, row?.deliveredOffset ?? 0);
+}
+
+/** Narrow truthful completion query for one configured source. */
+export function sourceHasEligibleUnconsumedEvidence(db: ReadDb, agentId: string, sourceEntryId: string): boolean {
+	if (!tableExists(db, "dreaming_evidence_consumption")) return true;
+	const rows = db
+		.prepare(
+			`SELECT ma.source_path FROM memory_artifacts ma
+			 WHERE ma.agent_id = ? AND ma.source_id = ? AND COALESCE(ma.is_deleted, 0) = 0
+			   AND length(ma.content) > 0
+			   AND (ma.source_sha256 IS NULL OR ma.source_sha256 = ''
+			        OR (ma.agent_id, ma.source_path) = (
+			          SELECT ma2.agent_id, ma2.source_path FROM memory_artifacts ma2
+			          WHERE ma2.agent_id = ma.agent_id AND COALESCE(ma2.is_deleted, 0) = 0
+			            AND ma2.source_sha256 = ma.source_sha256
+			            AND COALESCE(ma2.source_id, '') = COALESCE(ma.source_id, '')
+			          ORDER BY ma2.captured_at DESC, ma2.source_path ASC
+			          LIMIT 1
+			        ))
+			 ORDER BY ma.source_path ASC`,
+		)
+		.all(agentId, sourceEntryId) as Array<{ source_path: string }>;
+	return rows.some((row) => {
+		const source = readEpisodicSource(db, { agentId, from: `artifact:${row.source_path}` });
+		return source !== null && deliveredOffsetForSource(db, agentId, source) < renderDreamingEvidence(source).length;
+	});
+}

--- a/platform/daemon/src/pipeline/dreaming-evidence-consumption.ts
+++ b/platform/daemon/src/pipeline/dreaming-evidence-consumption.ts
@@ -206,10 +206,11 @@ export function hasDreamingEvidenceContinuation(db: ReadDb, agentId: string, pas
 }
 
 /**
- * Keep the frontier that made the last successful bounded delivery ahead of
- * newer evidence. A scan-first pass receives these sources before consulting
- * the ordinary newest-first queue, so a busy stream cannot strand an older
- * partial revision below its next page.
+ * Return a bounded fair slice of every incomplete current revision. Earlier
+ * delivery passes go first, so advancing one capped subset cannot strand the
+ * rest of an older subset behind the most recent pass. A scan-first pass
+ * receives these sources before consulting the ordinary newest-first queue,
+ * so a busy stream cannot strand partial evidence below its next page.
  */
 export function pendingDreamingEvidenceContinuations(
 	db: ReadDb,
@@ -223,32 +224,33 @@ export function pendingDreamingEvidenceContinuations(
 		.prepare(
 			`SELECT dec.source_kind AS kind, dec.source_id AS id, dec.source_captured_at AS capturedAt,
 			        dec.source_entry_id AS sourceEntryId, dec.source_revision AS sourceRevision
-			 FROM dreaming_state state
-			 INNER JOIN dreaming_evidence_consumption dec
-			   ON dec.agent_id = state.agent_id AND dec.pass_id = state.last_pass_id
-			 WHERE state.agent_id = ?
+			 FROM dreaming_evidence_consumption dec
+			 INNER JOIN dreaming_passes pass ON pass.id = dec.pass_id AND pass.agent_id = dec.agent_id
+			 WHERE dec.agent_id = ?
 			   AND dec.delivered_offset > 0 AND dec.delivered_offset < dec.source_length
 			   AND (? IS NULL OR dec.source_kind = ?)
-			 LIMIT ?`,
+			 ORDER BY pass.rowid ASC, dec.source_kind ASC, dec.source_id ASC, dec.source_captured_at ASC`,
 		)
-		.all(agentId, kind ?? null, kind ?? null, boundedLimit) as Array<{
+		.all(agentId, kind ?? null, kind ?? null) as Array<{
 		kind: EpisodicSourceKind;
 		id: string;
 		capturedAt: string;
 		sourceEntryId: string;
 		sourceRevision: string;
 	}>;
-	return rows.flatMap((row) => {
-		const source = readEpisodicSource(db, { agentId, from: `${row.kind}:${row.id}` });
-		if (
-			source === null ||
-			source.capturedAt !== row.capturedAt ||
-			sourceIdentity(source) !== row.sourceEntryId ||
-			sourceRevision(source) !== row.sourceRevision
-		)
-			return [];
-		return [source];
-	});
+	return rows
+		.flatMap((row) => {
+			const source = readEpisodicSource(db, { agentId, from: `${row.kind}:${row.id}` });
+			if (
+				source === null ||
+				source.capturedAt !== row.capturedAt ||
+				sourceIdentity(source) !== row.sourceEntryId ||
+				sourceRevision(source) !== row.sourceRevision
+			)
+				return [];
+			return [source];
+		})
+		.slice(0, boundedLimit);
 }
 
 /** Narrow truthful completion query for one configured source. */

--- a/platform/daemon/src/pipeline/dreaming-evidence-consumption.ts
+++ b/platform/daemon/src/pipeline/dreaming-evidence-consumption.ts
@@ -185,14 +185,47 @@ export function deliveredOffsetForSource(db: ReadDb, agentId: string, source: Ep
 	return Math.max(0, row?.deliveredOffset ?? 0);
 }
 
+/**
+ * A completed content pass made bounded progress and left one of its delivered
+ * source revisions incomplete. The worker uses this only to schedule the next
+ * regular sweep: a later no-progress pass has a different id, so it cannot
+ * create a self-sustaining retry loop.
+ */
+export function hasDreamingEvidenceContinuation(db: ReadDb, agentId: string, passId: string | null): boolean {
+	if (!passId || !tableExists(db, "dreaming_evidence_consumption")) return false;
+	return (
+		db
+			.prepare(
+				`SELECT 1 FROM dreaming_evidence_consumption
+				 WHERE agent_id = ? AND pass_id = ?
+				   AND delivered_offset > 0 AND delivered_offset < source_length
+				 LIMIT 1`,
+			)
+			.get(agentId, passId) != null
+	);
+}
+
 /** Narrow truthful completion query for one configured source. */
-export function sourceHasEligibleUnconsumedEvidence(db: ReadDb, agentId: string, sourceEntryId: string): boolean {
+export function sourceHasEligibleUnconsumedEvidence(
+	db: ReadDb,
+	agentId: string,
+	sourceEntryId: string,
+	legacyObsidianRoot?: string,
+): boolean {
 	if (!tableExists(db, "dreaming_evidence_consumption")) return true;
+	const legacyRootPrefix = legacyObsidianRoot?.replace(/\\/g, "/").replace(/\/$/, "");
 	const rows = db
 		.prepare(
 			`SELECT ma.source_path FROM memory_artifacts ma
-			 WHERE ma.agent_id = ? AND ma.source_id = ? AND COALESCE(ma.is_deleted, 0) = 0
+			 WHERE ma.agent_id = ? AND COALESCE(ma.is_deleted, 0) = 0
 			   AND length(ma.content) > 0
+			   AND (
+			     ma.source_id = ?
+			     OR (
+			       ? IS NOT NULL AND ma.harness = 'obsidian' AND ma.source_id IS NULL
+			       AND ma.source_path >= ? AND ma.source_path < ?
+			     )
+			   )
 			   AND (ma.source_sha256 IS NULL OR ma.source_sha256 = ''
 			        OR (ma.agent_id, ma.source_path) = (
 			          SELECT ma2.agent_id, ma2.source_path FROM memory_artifacts ma2
@@ -204,7 +237,13 @@ export function sourceHasEligibleUnconsumedEvidence(db: ReadDb, agentId: string,
 			        ))
 			 ORDER BY ma.source_path ASC`,
 		)
-		.all(agentId, sourceEntryId) as Array<{ source_path: string }>;
+		.all(
+			agentId,
+			sourceEntryId,
+			legacyRootPrefix ?? null,
+			legacyRootPrefix ?? "",
+			`${legacyRootPrefix ?? ""}/\uffff`,
+		) as Array<{ source_path: string }>;
 	return rows.some((row) => {
 		const source = readEpisodicSource(db, { agentId, from: `artifact:${row.source_path}` });
 		return source !== null && deliveredOffsetForSource(db, agentId, source) < renderDreamingEvidence(source).length;

--- a/platform/daemon/src/pipeline/dreaming-evidence-consumption.ts
+++ b/platform/daemon/src/pipeline/dreaming-evidence-consumption.ts
@@ -205,6 +205,52 @@ export function hasDreamingEvidenceContinuation(db: ReadDb, agentId: string, pas
 	);
 }
 
+/**
+ * Keep the frontier that made the last successful bounded delivery ahead of
+ * newer evidence. A scan-first pass receives these sources before consulting
+ * the ordinary newest-first queue, so a busy stream cannot strand an older
+ * partial revision below its next page.
+ */
+export function pendingDreamingEvidenceContinuations(
+	db: ReadDb,
+	agentId: string,
+	limit: number,
+	kind?: EpisodicSourceKind,
+): readonly EpisodicSourceRecord[] {
+	if (!tableExists(db, "dreaming_evidence_consumption")) return [];
+	const boundedLimit = Math.min(Math.max(Math.floor(limit), 1), 50);
+	const rows = db
+		.prepare(
+			`SELECT dec.source_kind AS kind, dec.source_id AS id, dec.source_captured_at AS capturedAt,
+			        dec.source_entry_id AS sourceEntryId, dec.source_revision AS sourceRevision
+			 FROM dreaming_state state
+			 INNER JOIN dreaming_evidence_consumption dec
+			   ON dec.agent_id = state.agent_id AND dec.pass_id = state.last_pass_id
+			 WHERE state.agent_id = ?
+			   AND dec.delivered_offset > 0 AND dec.delivered_offset < dec.source_length
+			   AND (? IS NULL OR dec.source_kind = ?)
+			 LIMIT ?`,
+		)
+		.all(agentId, kind ?? null, kind ?? null, boundedLimit) as Array<{
+		kind: EpisodicSourceKind;
+		id: string;
+		capturedAt: string;
+		sourceEntryId: string;
+		sourceRevision: string;
+	}>;
+	return rows.flatMap((row) => {
+		const source = readEpisodicSource(db, { agentId, from: `${row.kind}:${row.id}` });
+		if (
+			source === null ||
+			source.capturedAt !== row.capturedAt ||
+			sourceIdentity(source) !== row.sourceEntryId ||
+			sourceRevision(source) !== row.sourceRevision
+		)
+			return [];
+		return [source];
+	});
+}
+
 /** Narrow truthful completion query for one configured source. */
 export function sourceHasEligibleUnconsumedEvidence(
 	db: ReadDb,

--- a/platform/daemon/src/pipeline/dreaming-runbook.ts
+++ b/platform/daemon/src/pipeline/dreaming-runbook.ts
@@ -6,10 +6,19 @@
 import type { DbAccessor, WriteDb } from "../db-accessor";
 import type { DreamingAgentEvidence } from "./dreaming-evidence";
 
+export interface DreamingDeferredEvidence {
+	readonly agentId: string;
+	readonly sourceRef: string;
+}
+
+export type DreamingDeferredEvidenceEntry = string | DreamingDeferredEvidence;
+
 export interface DreamingRunbookEntry {
 	readonly summary: string;
 	readonly openQuestions: readonly string[];
 	readonly deferred: readonly string[];
+	/** Canonical source refs deliberately deferred, never acknowledged as consumed. */
+	readonly deferredEvidence: readonly DreamingDeferredEvidenceEntry[];
 }
 
 export interface DreamingEvidenceWindow {
@@ -60,6 +69,23 @@ function parseTextList(value: unknown): readonly string[] {
 	return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
 }
 
+function parseDeferredEvidenceList(value: unknown): readonly DreamingDeferredEvidenceEntry[] {
+	if (!Array.isArray(value)) return [];
+	const entries: DreamingDeferredEvidenceEntry[] = [];
+	for (const item of value) {
+		if (typeof item === "string") {
+			entries.push(item);
+			continue;
+		}
+		if (typeof item !== "object" || item === null || Array.isArray(item)) continue;
+		const entry = item as Record<string, unknown>;
+		if (typeof entry.agentId === "string" && typeof entry.sourceRef === "string") {
+			entries.push({ agentId: entry.agentId, sourceRef: entry.sourceRef });
+		}
+	}
+	return entries;
+}
+
 function parseRunbook(value: string | null): DreamingRunbookEntry | null {
 	const row = parseRecord(value);
 	if (!row || typeof row.summary !== "string") return null;
@@ -67,6 +93,7 @@ function parseRunbook(value: string | null): DreamingRunbookEntry | null {
 		summary: row.summary,
 		openQuestions: parseTextList(row.openQuestions),
 		deferred: parseTextList(row.deferred),
+		deferredEvidence: parseDeferredEvidenceList(row.deferredEvidence),
 	};
 }
 

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -483,6 +483,51 @@ describe("Dreaming", () => {
 		expect(isDreamingHaltActive(accessor, AGENT)).toBe(true);
 	});
 
+	it("schedules a near-term continuation only after the latest capped content delivery (#1430)", () => {
+		const now = Date.now();
+		const capturedAt = new Date(now).toISOString();
+		const passId = "partial-content-pass";
+		seedTranscript(db, "continuation-transcript", "x".repeat(5_000), capturedAt);
+		accessor.withWriteTx((tx) => {
+			tx.prepare(
+				`INSERT INTO dreaming_state (agent_id, last_pass_at, last_pass_id, last_pass_mode)
+				 VALUES (?, ?, ?, 'incremental-content')`,
+			).run(AGENT, capturedAt, passId);
+			tx.prepare(
+				`INSERT INTO dreaming_evidence_consumption
+				 (agent_id, source_kind, source_id, source_captured_at, source_entry_id, source_revision,
+				  delivered_offset, source_length, pass_id, updated_at)
+				 VALUES (?, 'transcript', 'continuation-transcript', ?, '', ?, 2_000, 5_000, ?, ?)`,
+			).run(AGENT, capturedAt, capturedAt, passId, capturedAt);
+		});
+		const cfg = defaultCfg({ tokenThreshold: 100_000, backfillOnFirstRun: false });
+		expect(shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(true);
+
+		// A subsequent no-progress pass gets a new id. It may be retried later
+		// through the normal threshold/interval policy, but it cannot spin here.
+		accessor.withWriteTx((tx) => {
+			tx.prepare("UPDATE dreaming_state SET last_pass_id = ? WHERE agent_id = ?").run("no-progress-pass", AGENT);
+		});
+		expect(shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(false);
+
+		// Completion clears the continuation even when it was the latest pass.
+		accessor.withWriteTx((tx) => {
+			tx.prepare("UPDATE dreaming_state SET last_pass_id = ? WHERE agent_id = ?").run(passId, AGENT);
+			tx.prepare("UPDATE dreaming_evidence_consumption SET delivered_offset = source_length WHERE pass_id = ?").run(
+				passId,
+			);
+		});
+		expect(shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(false);
+
+		// Scheduler failure backoff gates a partial continuation like every other
+		// automatic pass. It cannot bypass error recovery or the failure halt.
+		accessor.withWriteTx((tx) => {
+			tx.prepare("UPDATE dreaming_evidence_consumption SET delivered_offset = 2_000 WHERE pass_id = ?").run(passId);
+		});
+		recordDreamingFailure(accessor, AGENT);
+		expect(shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(false);
+	});
+
 	it("runs a low-volume episodic backlog once its maximum wait elapses", () => {
 		const now = Date.now();
 		seedSummary(db, "trickle", "small episodic source", 10);

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -581,6 +581,66 @@ describe("Dreaming", () => {
 		expect(shouldTriggerDreaming(accessor, cfg, AGENT, now + 21_000)).toBe(true);
 	}, 15_000);
 
+	it("rotates every capped partial frontier before revisiting a newer subset (#1430)", async () => {
+		// Regression for #1434: when 50 source revisions were partial and a
+		// 20-source page advanced, selecting only last_pass_id made the other
+		// 30 older rows unreachable. The scan must choose an unadvanced prior
+		// subset even while the newer partial rows still exist.
+		const capturedAt = "2026-08-11T00:00:00.000Z";
+		const priorPassId = "prior-partial-pass";
+		const newerPassId = "newer-partial-pass";
+		accessor.withWriteTx((tx) => {
+			tx.prepare(
+				"INSERT INTO dreaming_passes (id, agent_id, mode, status) VALUES (?, ?, 'incremental-content', 'completed')",
+			).run(priorPassId, AGENT);
+			tx.prepare(
+				"INSERT INTO dreaming_passes (id, agent_id, mode, status) VALUES (?, ?, 'incremental-content', 'completed')",
+			).run(newerPassId, AGENT);
+			tx.prepare("INSERT INTO dreaming_state (agent_id, last_pass_at, last_pass_id) VALUES (?, ?, ?)").run(
+				AGENT,
+				capturedAt,
+				newerPassId,
+			);
+			const insertConsumption = tx.prepare(
+				`INSERT INTO dreaming_evidence_consumption
+				 (agent_id, source_kind, source_id, source_captured_at, source_entry_id, source_revision,
+				  delivered_offset, source_length, pass_id, updated_at)
+				 VALUES (?, 'transcript', ?, ?, '', ?, 10, 100, ?, ?)`,
+			);
+			for (let index = 0; index < 50; index += 1) {
+				const id = `${index < 20 ? "newer" : "prior"}-partial-${index.toString().padStart(2, "0")}`;
+				seedTranscript(db, id, "x".repeat(100), capturedAt);
+				insertConsumption.run(AGENT, id, capturedAt, capturedAt, index < 20 ? newerPassId : priorPassId, capturedAt);
+			}
+		});
+
+		const result = await runDreamingAgentPass(
+			accessor,
+			{
+				async run(input) {
+					const search = input.tools.find((tool) => tool.name === "search_evidence");
+					if (!search) throw new Error("Missing search_evidence");
+					await search.execute("call", { agentId: AGENT, limit: 20 }, undefined, undefined, {} as never);
+					return { summary: "Rotated capped evidence frontiers" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT],
+			"incremental-content",
+		);
+		const delivery = getDreamingToolCalls(accessor, AGENT, result.passId).find(
+			(call) => call.toolName === "search_evidence",
+		);
+		const refs = ((delivery?.output as { items?: Array<{ sourceRef?: string }> } | undefined)?.items ?? []).map(
+			(item) => item.sourceRef,
+		);
+		expect(refs).toHaveLength(20);
+		expect(refs.every((ref) => ref?.startsWith("transcript:prior-partial-"))).toBe(true);
+		expect(refs).not.toContain("transcript:newer-partial-00");
+	}, 15_000);
+
 	it("indexes continuation lookup by agent and pass (#1430)", () => {
 		const plan = db
 			.prepare(

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -528,6 +528,71 @@ describe("Dreaming", () => {
 		expect(shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(false);
 	});
 
+	it("pins a capped frontier ahead of newer evidence on its next pass (#1430)", async () => {
+		const now = Date.now();
+		const cfg = defaultCfg({ tokenThreshold: 100_000, backfillOnFirstRun: false });
+		seedTranscript(db, "partial-frontier", "x".repeat(5_000), new Date(now).toISOString());
+		const run = async () =>
+			runDreamingAgentPass(
+				accessor,
+				{
+					async run(input) {
+						const search = input.tools.find((tool) => tool.name === "search_evidence");
+						if (!search) throw new Error("Missing search_evidence");
+						await search.execute("call", { agentId: AGENT }, undefined, undefined, {} as never);
+						return { summary: "Delivered current evidence page" };
+					},
+				},
+				cfg,
+				"/tmp",
+				AGENT,
+				[AGENT],
+				"incremental-content",
+			);
+
+		const first = await run();
+		for (let index = 0; index < 20; index += 1) {
+			seedTranscript(
+				db,
+				`newer-${index}`,
+				"New evidence that would fill the ordinary newest-first page.",
+				new Date(now + (index + 1) * 1_000).toISOString(),
+			);
+		}
+		expect(shouldTriggerDreaming(accessor, cfg, AGENT, now + 21_000)).toBe(true);
+
+		const second = await run();
+		const delivery = getDreamingToolCalls(accessor, AGENT, second.passId).find(
+			(call) => call.toolName === "search_evidence",
+		);
+		expect(delivery?.output).toMatchObject({
+			items: [expect.objectContaining({ sourceRef: "transcript:partial-frontier", contentOffset: 2_000 })],
+		});
+		expect(
+			db
+				.prepare(
+					"SELECT pass_id AS passId, delivered_offset AS offset FROM dreaming_evidence_consumption WHERE source_id = ?",
+				)
+				.get("partial-frontier"),
+		).toEqual({ passId: second.passId, offset: 4_000 });
+		// The progression moved to the second pass, so the final page remains a
+		// bounded continuation rather than falling behind the newer evidence.
+		expect(second.passId).not.toBe(first.passId);
+		expect(shouldTriggerDreaming(accessor, cfg, AGENT, now + 21_000)).toBe(true);
+	}, 15_000);
+
+	it("indexes continuation lookup by agent and pass (#1430)", () => {
+		const plan = db
+			.prepare(
+				`EXPLAIN QUERY PLAN SELECT 1 FROM dreaming_evidence_consumption
+				 WHERE agent_id = ? AND pass_id = ?
+				   AND delivered_offset > 0 AND delivered_offset < source_length
+				 LIMIT 1`,
+			)
+			.all(AGENT, "partial-content-pass") as Array<{ detail: string }>;
+		expect(plan.map((row) => row.detail).join("\n")).toContain("idx_dreaming_evidence_consumption_continuation");
+	});
+
 	it("runs a low-volume episodic backlog once its maximum wait elapses", () => {
 		const now = Date.now();
 		seedSummary(db, "trickle", "small episodic source", 10);

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -90,13 +90,39 @@ function captureTelemetry(): { readonly collector: TelemetryCollector; readonly 
 	return { collector, events };
 }
 
-function seedTranscript(db: Database, id: string, content: string, capturedAt?: string): void {
+function seedTranscript(db: Database, id: string, content: string, capturedAt?: string, agentId = AGENT): void {
 	const timestamp = capturedAt ?? (db.prepare("SELECT datetime('now') AS now").get() as { now: string }).now;
 	db.prepare(
 		`INSERT INTO session_transcripts
 		 (session_key, content, agent_id, created_at, updated_at, completed_at)
 		 VALUES (?, ?, ?, ?, ?, ?)`,
-	).run(id, content, AGENT, timestamp, timestamp, timestamp);
+	).run(id, content, agentId, timestamp, timestamp, timestamp);
+}
+
+function seedArtifact(
+	db: Database,
+	path: string,
+	content: string,
+	revision: string,
+	capturedAt: string,
+	agentId = AGENT,
+): void {
+	db.prepare(
+		`INSERT INTO memory_artifacts
+		 (agent_id, source_path, source_sha256, source_kind, session_id, session_key, session_token,
+		  captured_at, content, updated_at, is_deleted)
+		 VALUES (?, ?, ?, 'source_obsidian_markdown', ?, ?, ?, ?, ?, ?, 0)`,
+	).run(
+		agentId,
+		path,
+		revision,
+		`session-${path}`,
+		`session-${path}`,
+		`token-${path}`,
+		capturedAt,
+		content,
+		capturedAt,
+	);
 }
 
 function seedSummary(db: Database, id: string, content: string, tokens: number, agentId = AGENT): void {
@@ -149,35 +175,181 @@ describe("Dreaming", () => {
 		).toEqual({ capturedAt: "2026-03-01T00:00:00.000Z", kind: "summary", id: "fragment" });
 	});
 
-	it("uses the fixed agent prompt and resets the evidence backlog to the surfaced frontier", async () => {
-		seedSummary(db, "s1", "durable episodic evidence for the backlog.", 500);
+	it("drains oversized evidence only after every delivered fragment completes (#1430)", async () => {
+		seedTranscript(db, "s1", "x".repeat(5_000));
 		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
 		let prompt = "";
-		const result = await runDreamingAgentPass(
+		const run = async () =>
+			runDreamingAgentPass(
+				accessor,
+				{
+					async run(input) {
+						prompt = input.prompt;
+						// The scan-first listing surfaces the pending evidence, so
+						// the pass-end watermark legitimately advances to it and
+						// the same evidence must not re-trigger the next pass.
+						const search = input.tools.find((tool) => tool.name === "search_evidence");
+						if (!search) throw new Error("Missing search_evidence");
+						await search.execute("call", { agentId: AGENT }, undefined, undefined, {} as never);
+						return { summary: "Done" };
+					},
+				},
+				defaultCfg(),
+				"/tmp",
+				AGENT,
+				[AGENT],
+				"incremental",
+			);
+		const result = await run();
+		expect(result.summary).toBe("Done");
+		expect(prompt).toBe(DREAMING_AGENT_PROMPT);
+		const firstDelivery = getDreamingToolCalls(accessor, AGENT, result.passId).find(
+			(call) => call.toolName === "search_evidence",
+		);
+		expect(firstDelivery?.output).toMatchObject({
+			items: [expect.objectContaining({ sourceRef: "transcript:s1", contentOffset: 0, contentLength: 5_000 })],
+		});
+		const partial = db
+			.prepare(
+				"SELECT delivered_offset AS offset, source_length AS length FROM dreaming_evidence_consumption WHERE source_id = ?",
+			)
+			.get("s1") as { offset: number; length: number } | null;
+		expect(partial).toEqual(expect.objectContaining({ length: 5_000 }));
+		expect(partial?.offset).toBeGreaterThan(0);
+		expect(partial?.offset).toBeLessThan(partial?.length ?? 0);
+		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+
+		const second = await run();
+		const secondDelivery = getDreamingToolCalls(accessor, AGENT, second.passId).find(
+			(call) => call.toolName === "search_evidence",
+		);
+		expect(secondDelivery?.output).toMatchObject({
+			items: [expect.objectContaining({ sourceRef: "transcript:s1", contentOffset: 2_000, contentLength: 5_000 })],
+		});
+		// The second pass records the next contiguous fragment; the final
+		// 1,000-character fragment remains pending until a third pass.
+		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+		await run();
+		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBe(0);
+	}, 15_000);
+
+	it("does not consume evidence delivered by a failed pass (#1430)", async () => {
+		seedTranscript(db, "failed-delivery", "Evidence must survive an interrupted pass.");
+		await expect(
+			runDreamingAgentPass(
+				accessor,
+				{
+					async run(input) {
+						const search = input.tools.find((tool) => tool.name === "search_evidence");
+						if (!search) throw new Error("Missing search_evidence");
+						await search.execute("call", { agentId: AGENT }, undefined, undefined, {} as never);
+						throw new Error("interrupted after delivery");
+					},
+				},
+				defaultCfg(),
+				"/tmp",
+				AGENT,
+				[AGENT],
+				"incremental-content",
+			),
+		).rejects.toThrow("interrupted after delivery");
+		expect(
+			(
+				db
+					.prepare("SELECT COUNT(*) AS count FROM dreaming_evidence_consumption WHERE source_id = ?")
+					.get("failed-delivery") as {
+					count: number;
+				}
+			).count,
+		).toBe(0);
+		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+	});
+
+	it("does not acknowledge an artifact revision replaced during a pass (#1430)", async () => {
+		const capturedAt = "2026-08-11T00:00:00.000Z";
+		seedArtifact(db, "sources/revised.md", "The old revision was delivered.", "sha-old", capturedAt);
+		await runDreamingAgentPass(
 			accessor,
 			{
 				async run(input) {
-					prompt = input.prompt;
-					// The scan-first listing surfaces the pending evidence, so
-					// the pass-end watermark legitimately advances to it and
-					// the same evidence must not re-trigger the next pass.
 					const search = input.tools.find((tool) => tool.name === "search_evidence");
 					if (!search) throw new Error("Missing search_evidence");
 					await search.execute("call", { agentId: AGENT }, undefined, undefined, {} as never);
-					return { summary: "Done" };
+					db.prepare("UPDATE memory_artifacts SET content = ?, source_sha256 = ? WHERE source_path = ?").run(
+						"The replacement revision must be delivered again.",
+						"sha-new",
+						"sources/revised.md",
+					);
+					return { summary: "Source changed while this pass ran" };
 				},
 			},
 			defaultCfg(),
 			"/tmp",
 			AGENT,
 			[AGENT],
-			"incremental",
+			"incremental-content",
 		);
-		expect(result.summary).toBe("Done");
-		expect(prompt).toBe(DREAMING_AGENT_PROMPT);
-		// The evidence queue resets to the surfaced frontier: the same
-		// evidence must not re-trigger the next pass.
-		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBe(0);
+		expect(
+			(
+				db
+					.prepare(
+						"SELECT COUNT(*) AS count FROM dreaming_evidence_consumption WHERE source_id = ? AND source_revision = ?",
+					)
+					.get("sources/revised.md", "sha-new") as { count: number }
+			).count,
+		).toBe(0);
+		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+	});
+
+	it("keeps deferred delivery pending in its owning agent scope (#1430)", async () => {
+		const otherAgent = "other";
+		seedTranscript(db, "deferred-delivery", "Default scope may acknowledge the matching ref.", undefined, AGENT);
+		seedTranscript(db, "deferred-delivery", "Evidence the agent names as deferred.", undefined, otherAgent);
+		await runDreamingAgentPass(
+			accessor,
+			{
+				async run(input) {
+					const search = input.tools.find((tool) => tool.name === "search_evidence");
+					const write = input.tools.find((tool) => tool.name === "runbook_write");
+					if (!search || !write) throw new Error("Missing Dreaming delivery tools");
+					await search.execute("call", { agentId: AGENT }, undefined, undefined, {} as never);
+					await search.execute("call", { agentId: otherAgent }, undefined, undefined, {} as never);
+					await write.execute(
+						"call",
+						{
+							summary: "## Deferred\n- transcript:deferred-delivery remains mid-stream",
+							deferredEvidence: [{ agentId: otherAgent, sourceRef: "transcript:deferred-delivery" }],
+						},
+						undefined,
+						undefined,
+						{} as never,
+					);
+					return { summary: "Deferred source" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT, otherAgent],
+			"incremental-content",
+		);
+		expect(
+			(
+				db
+					.prepare("SELECT COUNT(*) AS count FROM dreaming_evidence_consumption WHERE agent_id = ?")
+					.get(otherAgent) as {
+					count: number;
+				}
+			).count,
+		).toBe(0);
+		expect(
+			(
+				db.prepare("SELECT COUNT(*) AS count FROM dreaming_evidence_consumption WHERE agent_id = ?").get(AGENT) as {
+					count: number;
+				}
+			).count,
+		).toBe(1);
+		expect(getDreamingEpisodicTokenBacklog(accessor, otherAgent)).toBeGreaterThan(0);
 	});
 
 	it("replaces a historical summary DAG row with the direct transcript projection", async () => {
@@ -989,8 +1161,10 @@ describe("Dreaming", () => {
 			accessor,
 			{
 				async run(input) {
+					const search = input.tools.find((tool) => tool.name === "search_evidence");
 					const apply = input.tools.find((tool) => tool.name === "apply_ontology_ops");
-					if (!apply) throw new Error("Missing apply_ontology_ops");
+					if (!search || !apply) throw new Error("Missing Dreaming delivery tools");
+					await search.execute("call", { agentId: AGENT }, undefined, undefined, {} as never);
 					await apply.execute(
 						"call",
 						{
@@ -1015,6 +1189,15 @@ describe("Dreaming", () => {
 			"incremental",
 		);
 		expect(result).toMatchObject({ applied: 0, failed: 1 });
+		expect(
+			(
+				db
+					.prepare("SELECT COUNT(*) AS count FROM dreaming_evidence_consumption WHERE source_id = ?")
+					.get("rejected-summary") as {
+					count: number;
+				}
+			).count,
+		).toBe(0);
 	});
 
 	it("records empty and failed bounded-agent passes honestly", async () => {
@@ -1286,6 +1469,48 @@ describe("Dreaming", () => {
 			[AGENT],
 			"incremental-content",
 		);
+		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBe(0);
+	});
+
+	it("acknowledges evidence that arrives during a content-attention pass without advancing the watermark (#1430)", async () => {
+		accessor.withWriteTx((tx) => {
+			enqueueDreamingAttentionInTx(tx, {
+				agentId: AGENT,
+				kind: "surprisal",
+				subjectRef: "memory:mid-pass-arrival",
+			});
+		});
+
+		await runDreamingAgentPass(
+			accessor,
+			{
+				async run(input) {
+					seedTranscript(db, "mid-pass-arrival", "Evidence arrived while this content pass was already running.");
+					const search = input.tools.find((tool) => tool.name === "search_evidence");
+					if (!search) throw new Error("Missing search_evidence");
+					await search.execute("call", { agentId: AGENT }, undefined, undefined, {} as never);
+					return { summary: "Reviewed late evidence" };
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT],
+			"incremental-content",
+		);
+
+		// The time watermark remains a pass-start discovery boundary, but the
+		// returned late source is durably consumed and leaves no episodic backlog.
+		expect(getDreamingState(accessor, AGENT).lastPassAt).toBeNull();
+		expect(
+			(
+				db
+					.prepare("SELECT COUNT(*) AS count FROM dreaming_evidence_consumption WHERE source_id = ?")
+					.get("mid-pass-arrival") as {
+					count: number;
+				}
+			).count,
+		).toBe(1);
 		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBe(0);
 	});
 

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import type { DreamingConfig } from "@signet/core";
 import { runMigrations } from "../../../core/src/migrations";
-import type { DbAccessor } from "../db-accessor";
+import type { DbAccessor, ReadDb } from "../db-accessor";
 import { type TelemetryCollector, type TelemetryEvent, setActiveTelemetry } from "../telemetry";
 import {
 	DREAMING_AGENT_PROMPT,
@@ -33,6 +33,7 @@ import {
 	getDreamingAttentionSnapshots,
 	resolveDreamingAttentionInTx,
 } from "./dreaming-attention";
+import { pendingDreamingEvidenceContinuations } from "./dreaming-evidence-consumption";
 import {
 	autoRequeueRepairedDreamingEvidence,
 	collectRejectedDreamingEvidence,
@@ -640,6 +641,79 @@ describe("Dreaming", () => {
 		expect(refs.every((ref) => ref?.startsWith("transcript:prior-partial-"))).toBe(true);
 		expect(refs).not.toContain("transcript:newer-partial-00");
 	}, 15_000);
+
+	it("keeps continuation selection SQL-bounded while skipping stale revisions (#1434)", () => {
+		const capturedAt = "2026-08-11T00:00:00.000Z";
+		const stalePassId = "stale-partial-pass";
+		const priorPassId = "prior-partial-pass";
+		const newerPassId = "newer-partial-pass";
+		accessor.withWriteTx((tx) => {
+			for (const passId of [stalePassId, priorPassId, newerPassId]) {
+				tx.prepare(
+					"INSERT INTO dreaming_passes (id, agent_id, mode, status) VALUES (?, ?, 'incremental-content', 'completed')",
+				).run(passId, AGENT);
+			}
+			const insertConsumption = tx.prepare(
+				`INSERT INTO dreaming_evidence_consumption
+				 (agent_id, source_kind, source_id, source_captured_at, source_entry_id, source_revision,
+				  delivered_offset, source_length, pass_id, updated_at)
+				 VALUES (?, 'transcript', ?, ?, '', ?, 10, 100, ?, ?)`,
+			);
+			for (let index = 0; index < 200; index += 1) {
+				insertConsumption.run(AGENT, `stale-partial-${index}`, capturedAt, capturedAt, stalePassId, capturedAt);
+			}
+			for (let index = 0; index < 30; index += 1) {
+				const id = `prior-partial-${index.toString().padStart(2, "0")}`;
+				seedTranscript(db, id, "x".repeat(100), capturedAt);
+				insertConsumption.run(AGENT, id, capturedAt, capturedAt, priorPassId, capturedAt);
+			}
+			for (let index = 0; index < 20; index += 1) {
+				const id = `newer-partial-${index.toString().padStart(2, "0")}`;
+				seedTranscript(db, id, "x".repeat(100), capturedAt);
+				insertConsumption.run(AGENT, id, capturedAt, capturedAt, newerPassId, capturedAt);
+			}
+		});
+
+		const continuationQueries: string[] = [];
+		const continuationArgs: unknown[][] = [];
+		const tracedDb = {
+			prepare(sql: string) {
+				const statement = db.prepare(sql);
+				if (!sql.includes("FROM dreaming_evidence_consumption dec")) return statement;
+				continuationQueries.push(sql);
+				return new Proxy(statement, {
+					get(target, property, receiver) {
+						const value = Reflect.get(target, property, receiver);
+						if (property === "all") {
+							return (...args: unknown[]) => {
+								continuationArgs.push(args);
+								return Reflect.apply(target.all, target, args);
+							};
+						}
+						return typeof value === "function" ? value.bind(target) : value;
+					},
+				});
+			},
+		} as unknown as ReadDb;
+		const first = pendingDreamingEvidenceContinuations(tracedDb, AGENT, 20);
+		expect(continuationQueries).toHaveLength(1);
+		expect(continuationQueries[0]).toContain("LIMIT ?");
+		expect(continuationArgs).toEqual([[AGENT, null, null, 20]]);
+		expect(first.map((source) => source.id)).toEqual(
+			Array.from({ length: 20 }, (_, index) => `prior-partial-${index.toString().padStart(2, "0")}`),
+		);
+
+		accessor.withWriteTx((tx) => {
+			tx.prepare(
+				"UPDATE dreaming_evidence_consumption SET delivered_offset = source_length WHERE pass_id = ? AND source_id < ?",
+			).run(priorPassId, "prior-partial-20");
+		});
+		const second = pendingDreamingEvidenceContinuations(db as unknown as ReadDb, AGENT, 20);
+		expect(second.map((source) => source.id)).toEqual([
+			...Array.from({ length: 10 }, (_, index) => `prior-partial-${(index + 20).toString().padStart(2, "0")}`),
+			...Array.from({ length: 10 }, (_, index) => `newer-partial-${index.toString().padStart(2, "0")}`),
+		]);
+	});
 
 	it("indexes continuation lookup by agent and pass (#1430)", () => {
 		const plan = db

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -28,6 +28,7 @@ import {
 	type EpisodicSourceRecord,
 	readEpisodicSource,
 	readRecentEpisodicSources,
+	searchEpisodicSources,
 	timestampMillis,
 } from "../episodic-sources";
 import { type GraphHygieneCaps, getDreamingHygieneCandidatesInDb } from "../knowledge-graph-hygiene";
@@ -57,6 +58,7 @@ import {
 	nextDreamingEvidenceFragment,
 	renderDreamingEvidence,
 } from "./dreaming-evidence";
+import { deliveredOffsetForSource, recordDreamingEvidenceConsumptionInTx } from "./dreaming-evidence-consumption";
 import {
 	type RejectedDreamingEvidence,
 	autoRequeueRepairedDreamingEvidence,
@@ -290,6 +292,20 @@ const DREAMING_WORKLOAD_CLASS = "memory_extraction";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function deferredEvidenceKeys(value: unknown, primaryAgentId: string): ReadonlySet<string> | null {
+	if (!isRecord(value) || !Array.isArray(value.deferredEvidence)) return new Set();
+	const keys = new Set<string>();
+	for (const item of value.deferredEvidence) {
+		if (typeof item === "string") {
+			keys.add(`${primaryAgentId}\u0000${item}`);
+			continue;
+		}
+		if (!isRecord(item) || typeof item.agentId !== "string" || typeof item.sourceRef !== "string") return null;
+		keys.add(`${item.agentId}\u0000${item.sourceRef}`);
+	}
+	return keys;
 }
 
 // ---------------------------------------------------------------------------
@@ -1547,12 +1563,27 @@ export async function runDreamingAgentPass(
 				passId,
 			);
 			recordRejectedDreamingEvidenceInTx(db, passId, rejectedEvidence);
-			// The evidence queue resets to the pass watermark for EVERY scope
-			// the pass consumed evidence for: the next pass's backlog counts
-			// only sources captured after the surfaced frontier. A hygiene
+			if (mode !== "incremental-hygiene" && failed === 0) {
+				const runbook = db
+					.prepare("SELECT runbook_json AS runbookJson FROM dreaming_passes WHERE id = ?")
+					.get(passId) as {
+					runbookJson: string | null;
+				} | null;
+				let deferredEvidence: ReadonlySet<string> | null = new Set();
+				try {
+					deferredEvidence = deferredEvidenceKeys(JSON.parse(runbook?.runbookJson ?? "{}"), agentId);
+				} catch {
+					deferredEvidence = null;
+				}
+				// A malformed runbook is never permission to acknowledge evidence.
+				if (deferredEvidence !== null) recordDreamingEvidenceConsumptionInTx(db, { passId, deferredEvidence });
+			}
+			// The time watermark preserves chronological discovery and mid-pass
+			// catch-up. Durable delivery offsets independently decide whether an
+			// individual immutable source revision is still backlog. A hygiene
 			// pass consumes no evidence, so it must not advance the watermark —
-			// advancing it would hide the unprocessed backlog from the next
-			// content pass and starve content again (#1098).
+			// advancing it would hide unprocessed sources from the next content
+			// pass and starve content again (#1098).
 			if (dreamingModeAdvancesEvidence(mode, totalBacklog > 0)) {
 				for (const scope of scopes) {
 					if ((backlogByScope.get(scope) ?? 0) === 0) continue;
@@ -1753,6 +1784,21 @@ export function getDreamingEpisodicTokenBacklog(accessor: DbAccessor, agentId: s
 }
 
 export function getDreamingEpisodicTokenBacklogInDb(db: ReadDb, agentId: string): number {
+	const hasConsumption =
+		db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'dreaming_evidence_consumption'").get() !=
+		null;
+	if (hasConsumption) {
+		const queued = searchEpisodicSources(db, {
+			agentId,
+			query: "",
+			excludeDelivered: true,
+			limit: 50,
+		});
+		return queued.reduce((total, source) => {
+			const remaining = renderDreamingEvidence(source).slice(deliveredOffsetForSource(db, agentId, source));
+			return total + countTokens(remaining);
+		}, 0);
+	}
 	const state = readDreamingState(db, agentId);
 	const queued = readRecentEpisodicSources(
 		db,

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -58,7 +58,11 @@ import {
 	nextDreamingEvidenceFragment,
 	renderDreamingEvidence,
 } from "./dreaming-evidence";
-import { deliveredOffsetForSource, recordDreamingEvidenceConsumptionInTx } from "./dreaming-evidence-consumption";
+import {
+	deliveredOffsetForSource,
+	hasDreamingEvidenceContinuation,
+	recordDreamingEvidenceConsumptionInTx,
+} from "./dreaming-evidence-consumption";
 import {
 	type RejectedDreamingEvidence,
 	autoRequeueRepairedDreamingEvidence,
@@ -1844,7 +1848,8 @@ export function shouldTriggerDreaming(
 	// First run only backfills actual episodic evidence, except for explicit
 	// scoped attention that has been queued for a Dreaming review.
 	if (cfg.backfillOnFirstRun && state.lastPassAt === null) return episodicTokens > 0 || hasAttention;
-	if (hasAttention || episodicTokens >= cfg.tokenThreshold) return true;
+	const hasContinuation = accessor.withReadDb((db) => hasDreamingEvidenceContinuation(db, agentId, state.lastPassId));
+	if (hasAttention || episodicTokens >= cfg.tokenThreshold || hasContinuation) return true;
 
 	// A low-volume stream must not wait indefinitely for the batch ceiling.
 	// This is deliberately a maximum wait rather than an unconditional cron:

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -581,7 +581,7 @@ describe("Sources routes", () => {
 			artifacts: 1,
 			chunks: 1,
 			indexed: 1,
-			hasEligibleUnconsumedEvidence: false,
+			hasEligibleUnconsumedEvidence: true,
 		});
 		expect(body.sources[0]?.health).toMatchObject({
 			status: "healthy",

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -573,11 +573,16 @@ describe("Sources routes", () => {
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as {
 			sources: Array<{
-				stats?: { artifacts: number; chunks: number; indexed: number };
+				stats?: { artifacts: number; chunks: number; indexed: number; hasEligibleUnconsumedEvidence: boolean };
 				health?: { status?: string; purge?: { orphanChunks?: number } };
 			}>;
 		};
-		expect(body.sources[0]?.stats).toEqual({ artifacts: 1, chunks: 1, indexed: 1 });
+		expect(body.sources[0]?.stats).toEqual({
+			artifacts: 1,
+			chunks: 1,
+			indexed: 1,
+			hasEligibleUnconsumedEvidence: false,
+		});
 		expect(body.sources[0]?.health).toMatchObject({
 			status: "healthy",
 			purge: { orphanChunks: 0 },
@@ -631,9 +636,42 @@ describe("Sources routes", () => {
 		const res = await makeApp().request("/api/sources");
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as {
-			sources: Array<{ stats?: { artifacts: number; chunks: number; indexed: number } }>;
+			sources: Array<{
+				stats?: { artifacts: number; chunks: number; indexed: number; hasEligibleUnconsumedEvidence: boolean };
+			}>;
 		};
-		expect(body.sources[0]?.stats).toEqual({ artifacts: 1, chunks: 1, indexed: 1 });
+		expect(body.sources[0]?.stats).toEqual({
+			artifacts: 1,
+			chunks: 1,
+			indexed: 1,
+			hasEligibleUnconsumedEvidence: true,
+		});
+
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO dreaming_evidence_consumption
+				 (agent_id, source_kind, source_id, source_captured_at, source_entry_id, source_revision, delivered_offset, source_length, pass_id, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"default",
+				"artifact",
+				"discord://guild/123456789012345678",
+				"2026-01-01T00:00:00.000Z",
+				added.source.id,
+				"sha",
+				"Guild".length,
+				"Guild".length,
+				"pass-complete",
+				"2026-01-01T00:00:00.000Z",
+			);
+		});
+		const completed = await makeApp().request("/api/sources");
+		const completedBody = (await completed.json()) as {
+			sources: Array<{
+				stats?: { artifacts: number; chunks: number; indexed: number; hasEligibleUnconsumedEvidence: boolean };
+			}>;
+		};
+		expect(completedBody.sources[0]?.stats?.hasEligibleUnconsumedEvidence).toBe(false);
 	});
 
 	it("exports source snapshots while excluding local Discord cache DMs by default", async () => {

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -29,6 +29,7 @@ import {
 	resolveEmbeddingBridgeOptions,
 	startNativeMemoryBridge,
 } from "../native-memory-sources";
+import { sourceHasEligibleUnconsumedEvidence } from "../pipeline/dreaming-evidence-consumption";
 import {
 	type SourceIndexJob,
 	beginSourceIndexJob,
@@ -736,6 +737,8 @@ interface SourceStats {
 	readonly artifacts: number;
 	readonly chunks: number;
 	readonly indexed: number;
+	/** Whether canonical visible source evidence still has an eligible undelivered fragment. */
+	readonly hasEligibleUnconsumedEvidence: boolean;
 }
 
 interface SourceHealth {
@@ -822,10 +825,15 @@ function sourceStats(source: SignetSourceEntry, agentId: string): SourceStats {
 						`${chunkPrefix}\uffff`,
 					),
 			);
-			return { artifacts, chunks, indexed: artifacts };
+			return {
+				artifacts,
+				chunks,
+				indexed: artifacts,
+				hasEligibleUnconsumedEvidence: sourceHasEligibleUnconsumedEvidence(db, agentId, source.id),
+			};
 		});
 	} catch {
-		return { artifacts: 0, chunks: 0, indexed: 0 };
+		return { artifacts: 0, chunks: 0, indexed: 0, hasEligibleUnconsumedEvidence: false };
 	}
 }
 

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -829,7 +829,12 @@ function sourceStats(source: SignetSourceEntry, agentId: string): SourceStats {
 				artifacts,
 				chunks,
 				indexed: artifacts,
-				hasEligibleUnconsumedEvidence: sourceHasEligibleUnconsumedEvidence(db, agentId, source.id),
+				hasEligibleUnconsumedEvidence: sourceHasEligibleUnconsumedEvidence(
+					db,
+					agentId,
+					source.id,
+					source.kind === "obsidian" ? source.root : undefined,
+				),
 			};
 		});
 	} catch {


### PR DESCRIPTION
## Summary

Fixes #1430 by separating Dreaming's durable evidence-delivery frontier from its time-based newness watermark. Large sources now resume from their last delivered fragment instead of being skipped after a capped pass advances the timestamp. A partial successful delivery now schedules the next regular five-minute sweep instead of waiting for the six-hour low-volume interval.

## Changes

- Add migration 129 and an agent/source/revision-scoped delivered-offset table.
- Persist only exact `search_evidence` fragments from a completed, non-failed content pass, advancing each source revision only through contiguous delivered content.
- Keep deferred sources pending, reject stale mid-pass source revisions, preserve agent isolation, and remove delivery state with an imported source.
- Make scan-first evidence searches and backlog scheduling drain incomplete revisions; expose `stats.hasEligibleUnconsumedEvidence` through the existing source status response.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

Migration 129 is additive. Existing revisions have no consumption row after upgrade and are intentionally treated as unconsumed so the daemon can drain them safely. Removing an imported source deletes its matching consumption rows in the existing lifecycle transaction; a re-import starts with a clean frontier.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused verification:

- `bun test platform/core/src/migrations/migrations.test.ts platform/daemon/src/episodic-sources.test.ts platform/daemon/src/imported-source-lifecycle.test.ts platform/daemon/src/routes/sources-routes.test.ts platform/daemon/src/pipeline/dreaming-agent-tools.test.ts platform/daemon/src/pipeline/dreaming.test.ts` (173 pass, 0 fail)
- `bun run --filter '@signet/core' build`
- `bun run --filter '@signet/daemon' typecheck`
- `bunx biome check` across all 14 touched TypeScript files
- `git diff --check origin/main...HEAD`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Repair follow-up: a continuation is eligible only when the current evidence-updating pass itself left a delivered offset strictly between zero and the source length. A later no-progress pass has a new pass id, while completed delivery, scheduler failure backoff, the pressure gate, and the existing check cadence all continue to stop automatic looping. Sources status now applies its legacy Obsidian root fallback consistently when reporting eligible unconsumed evidence.

In-loop adversarial review found a same-timestamp source-revision race: a source changed after delivery but before pass completion could otherwise acknowledge its replacement revision. The persisted output now carries `sourceRevision`, and completion re-reads and verifies the live revision before acknowledging it. The independent delegated review attempts timed out without a verdict, so they are not counted as review approval.