### PR TITLE
docs: refresh operator runbooks

### DIFF
--- a/web/docs/src/content/docs/analytics.md
+++ b/web/docs/src/content/docs/analytics.md
@@ -1,279 +1,70 @@
 ---
 title: "Analytics"
-description: "Usage analytics, timeline, and metrics."
+description: "Operational metrics, telemetry audit data, logs, and incident investigation endpoints."
 ---
 
-The Signet [Daemon](/daemon/) exposes real-time operational visibility through three
-subsystems: an in-memory analytics accumulator, an incident timeline
-builder, and a health [Diagnostics](/diagnostics/) scorer. Together they let operators
-understand what the daemon is doing right now, reconstruct what happened
-to a specific memory or request, and get a structured assessment of
-overall system health.
+Analytics is the daemon's current operational view. It is not a replacement for source data, workspace backups, or a monitoring system.
 
+## Operational endpoints
 
-## Overview
+These endpoints require analytics permission in authenticated deployments:
 
-Analytics counters are entirely ephemeral. They reset when the daemon
-restarts. This is intentional — durable history already exists in the
-`memory_history` table and structured logs, so the analytics layer
-doesn't need to duplicate that. Its job is to give you fast, in-process
-counts and latency distributions for the current daemon lifetime without
-any write overhead.
+| Endpoint                               | Use                                                     |
+| -------------------------------------- | ------------------------------------------------------- |
+| `GET /api/analytics/usage`             | Request, actor, provider, and connector counters.       |
+| `GET /api/analytics/errors`            | Recent errors; supports stage, time, and limit filters. |
+| `GET /api/analytics/latency`           | Latency summary.                                        |
+| `GET /api/analytics/logs`              | Recent structured daemon log entries.                   |
+| `GET /api/analytics/memory-safety`     | Memory safety metrics.                                  |
+| `GET /api/analytics/continuity`        | Continuity state.                                       |
+| `GET /api/analytics/continuity/latest` | Latest continuity summary.                              |
+| `GET /api/telemetry/events`            | Recorded telemetry event view.                          |
+| `GET /api/telemetry/health`            | Telemetry collector state.                              |
+| `GET /api/timeline/*`                  | Timeline investigation routes.                          |
 
-If you need to track trends across restarts, read from `memory_history`
-and the log files directly. The analytics endpoints are a real-time
-operational view, not a database replacement. For the complete endpoint
-reference, see [Api](/api/).
+Start with a bounded query and correlate it with daemon status and diagnostics:
 
-
-## Usage Counters
-
-`GET /api/analytics/usage` returns a `UsageCounters` object with four
-maps, each keyed by a string identifier.
-
-**Endpoint stats** are keyed by `"METHOD /path"` (e.g.,
-`"POST /api/memory/remember"`). Each entry tracks the total request
-count, the number of responses with status >= 400, and the cumulative
-latency in milliseconds. Divide `totalLatencyMs` by `count` for a
-rough average latency per endpoint.
-
-**Actor stats** are keyed by actor identity — either the `x-signet-actor`
-request header or the `sub` field from a bearer token, whichever is
-present. Each actor entry counts total `requests`, plus broken-out
-counts for `remembers`, `recalls`, and `mutations`. The classification
-is path-based: paths containing `/remember` or `/save` count as
-remembers; `/recall`, `/search`, or `/similar` count as recalls;
-`/modify`, `/forget`, or `/recover` count as mutations; everything else
-increments `requests`.
-
-**Provider stats** track LLM/embedding provider calls by provider name
-(e.g., `"ollama"`). Each entry has `calls`, `failures`, and
-`totalLatencyMs`. The `failures` count increments when `recordProvider`
-is called with `success: false`.
-
-**Connector stats** are keyed by connector ID and track `syncs`,
-`errors`, and `documentsProcessed` — coarse throughput metrics for each
-registered harness connector.
-
-
-## Error Taxonomy
-
-Errors are captured in a ring buffer (default capacity: 500 entries)
-and organized by pipeline stage. The taxonomy is fixed:
-
-- **extraction**: `EXTRACTION_TIMEOUT`, `EXTRACTION_PARSE_FAIL`
-- **decision**: `DECISION_TIMEOUT`, `DECISION_INVALID`
-- **embedding**: `EMBEDDING_PROVIDER_DOWN`, `EMBEDDING_TIMEOUT`
-- **mutation**: `MUTATION_CONFLICT`, `MUTATION_SCOPE_DENIED`
-- **connector**: `CONNECTOR_SYNC_FAIL`, `CONNECTOR_AUTH_FAIL`
-
-Each error entry includes a timestamp, stage, code, message, and
-optional `requestId`, `memoryId`, and `actor` fields for correlation.
-When the buffer is full, the oldest entry is evicted to make room.
-
-`GET /api/analytics/errors` returns recent errors. You can filter by
-`stage` (query param) and `since` (ISO timestamp), and limit the
-number of results returned.
-
-
-## Latency Histograms
-
-Four operations are tracked: `remember`, `recall`, `mutate`, and `jobs`.
-Each maintains a rolling window of the last 1,000 samples. When the
-window is full, the oldest sample is dropped.
-
-`GET /api/analytics/latency` returns a snapshot for each operation with
-`p50`, `p95`, `p99`, `count`, and `mean` in milliseconds. If a histogram
-has no samples yet, all values are zero. The percentile calculation sorts
-the sample window on demand, so there's a small sort cost on the first
-read after new samples are recorded.
-
-
-## Timeline
-
-The timeline builder answers the question "what happened to this thing?"
-Given any entity ID — a memory ID, a job ID, a request ID, or a session
-ID — it assembles a chronological list of everything the system recorded
-about that entity.
-
-Entity detection works by probing the database in order: first
-`memory_history` by `memory_id`, then `memories` by `id`, then
-`memory_jobs` by job `id` (which resolves to the associated `memory_id`).
-If the ID doesn't match anything in the database, the entity type is
-marked `"unknown"` — which can happen for request IDs and session IDs
-that exist only in logs and the error buffer.
-
-Once the entity type is resolved, the builder collects four kinds of
-events:
-
-**History events** come from `memory_history`. Each row produces one
-event with the history event name (e.g., `"created"`, `"updated"`,
-`"deleted"`, `"recovered"`), the actor that made the change, and flags
-indicating whether old and new content were present.
-
-**Job lifecycle events** come from `memory_jobs`. Each job row can
-produce up to four events: `job:<type>:created`, `job:<type>:leased`,
-`job:<type>:completed`, and `job:<type>:failed`, depending on which
-timestamp columns are non-null.
-
-**Log events** are drawn from the in-memory log ring buffer (up to 500
-recent entries). A log entry matches if the entity ID appears anywhere
-in `entry.message` or in any string value of `entry.data`.
-
-**Error events** are drawn from the analytics error buffer (up to 500
-recent entries). An error matches if `entry.memoryId`, `entry.requestId`,
-or `entry.message` contains the entity ID.
-
-All events from all sources are merged and sorted by timestamp before
-being returned.
-
-`GET /api/timeline/:id` — build a timeline for any entity ID.
-
-`GET /api/timeline/:id/export` — same data in an export-friendly format.
-
-
-## Diagnostics
-
-The diagnostics subsystem produces a structured health report across six
-domains. Each domain returns a score from 0 to 1 and a status string
-(`"healthy"`, `"degraded"`, or `"unhealthy"`). Status thresholds are:
-healthy >= 0.8, degraded >= 0.5, unhealthy < 0.5.
-
-**Queue** (weight 0.28) examines `memory_jobs` for the pending job depth,
-the age of the oldest pending job, the dead-job rate over the last 24
-hours, and the count of jobs stuck in `"leased"` status for more than
-10 minutes. Penalties: depth > 50 (-0.3), dead rate > 1% (-0.3), oldest
-job age > 300 seconds (-0.2), lease anomalies present (-0.2).
-
-**Storage** (weight 0.14) looks at total memory rows and the tombstone
-ratio (soft-deleted rows / total rows). A tombstone ratio above 30%
-deducts 0.3. The `dbSizeBytes` field is always 0 from a read connection
-— it's present in the type for future use.
-
-**Index** (weight 0.19) compares the physical FTS5 document count against
-canonical memory rows, including retained tombstones, and measures embedding coverage —
-the fraction of active memories that have an `embedding_model` set (see
-[Memory](/memory/) for how memories are stored). FTS mismatch deducts 0.5.
-Embedding
-coverage below 80% deducts 0.3.
-
-**Provider** (weight 0.24) uses a separate in-memory ring buffer
-(`ProviderTracker`) that records the last 100 provider call outcomes
-(`success`, `failure`, `timeout`). The score equals the availability
-rate (successes / total). With no data yet, the rate defaults to 1.0.
-
-**Mutation** (weight 0.10) queries `memory_history` for `recovered` and
-`deleted` events in the last 7 days. More than 5 recoveries in that
-window suggests repeated wrong-target deletes and deducts 0.3.
-
-**Connector** (weight 0.05) reads the [Connectors](/connectors/) table for total
-connector count, how many are currently syncing, how many have a
-non-null `last_error`, and the age of the oldest unresolved error.
-Any errors deduct 0.3; an error older than 24 hours deducts an
-additional 0.2. If the `connectors` table doesn't exist (older
-database), the domain scores a perfect 1.0.
-
-The composite score is a weighted average of all six domain scores,
-clamped to [0, 1].
-
-
-## Diagnostics API
-
-`GET /api/diagnostics` — full report with composite score and all six
-domain health objects.
-
-`GET /api/diagnostics/:domain` — single domain detail. Valid domain
-names: `queue`, `storage`, `index`, `provider`, `mutation`, `connector`.
-
-`GET /api/analytics/memory-safety` — mutation health metrics (alias
-into the mutation domain for memory integrity monitoring).
-
-`GET /api/analytics/logs` — alias for structured log access.
-
-
-## PostHog Telemetry
-
-Separate from the in-memory analytics above, the daemon ships an
-anonymous telemetry collector for understanding install and usage
-patterns (see [Configuration](/configuration/)). It buffers events to SQLite and
-flushes them in batches to a PostHog instance when both `posthogHost`
-and `posthogApiKey` are configured (`telemetryEnabled` defaults to
-true; set it to `false` to opt out). The dashboard Settings → Advanced → Privacy
-section exposes the same setting, with a confirmation warning before disabling
-it.
-
-The event catalog, privacy contract, the open JSONL audit log, and how to
-query the project live in **[TELEMETRY.md](https://github.com/Signet-AI/signetai/blob/main/docs/TELEMETRY.md)** — the single
-telemetry reference. Telemetry carries no memory content, user identity,
-agent ids, or file paths; each install uses a random persisted anonymous id
-and every event is mirrored to the auditable JSONL log. `pipeline.error` is
-emitted for categorized extraction, decision, and embedding failures with
-stage/code-only properties. `pipeline.operation` adds one bounded summary per
-logical indexing, memory-capture, recall, or dreaming operation, so dashboards
-can distinguish raw failed attempts from completed/failed operations without
-counting every source chunk as a separate incident.
-
-Source lifecycle telemetry uses fixed source classes and bounded lifecycle
-summaries. Local-only hashed state correlates first indexed, searchable, and
-first-recall milestones; the hash itself is never sent.
-
-Privacy contract:
-
-- Events carry no memory content, user identity, agent ids, or file paths.
-- Each install gets a random anonymous id (persisted in the workspace
-  database) used as the PostHog `distinct_id`, so installs are countable
-  but not identifiable.
-- Telemetry is on by default and can be disabled with
-  `telemetryEnabled: false`.
-- Every recorded event is mirrored to an open, inspectable JSONL log at
-  `<agentsDir>/.daemon/telemetry/events.jsonl`, so users can audit
-  exactly what was sent. CLI `command.invoked` events are also queued in the
-  workspace database when remote delivery is configured and a telemetry SQLite
-  database is available, then flushed to PostHog in bounded, best-effort
-  batches without awaiting the command. Fresh workspaces without that database
-  remain local-only; the CLI reads the same persisted install id as the daemon.
-
-Events recorded: `daemon.heartbeat` (every 5 minutes), the `inference.*`
-lifecycle (`route`, `execute`, `stream`, `fallback`), `llm.generate`
-(provider, latency, token and cost counts when reported, success — never
-prompt text), `session.start` / `session.end` (harness and prompt count),
-the lifecycle events `daemon.started`, `command.invoked`,
-`error.occurred` (sanitized crash report — truncated message with user
-paths stripped, top stack frames with home directories removed, uptime;
-plus rate-limited `EventLoopLag` reports with measured lag), and
-`version.upgraded`, `install.activated` (first daemon run of a new
-install — covers bun/desktop installs the npm postinstall ping never
-sees), and `config.snapshot` (first-run feature flags, embedding provider
-and model, local/remote inference mode, and configured harnesses). The
-per-install harness mix is queryable from `session.start.harness` events
-because they share the same anonymous `distinct_id`. `pipeline.embedding`
-(tokens, provider, sourceKind — memory capture / artifact index / recall /
-dreaming), and `dreaming.pass`
-(provider-reported input/output/cache tokens and cost per agentic
-pass, fixed routed workload class `memory_extraction`, plus the bounded
-successful-target `provider` and configured `model` when available, request
-cache coverage/counters when the provider reports cache fields, outcomes and
-content-free artifact, durable-effect, tool-call, and duration counters).
-`dreaming.pass` never includes artifact
-names, memory text, prompts, tool arguments, source paths, or raw agent
-identities; unavailable provider usage remains null rather than inferred zero
-usage. The remaining `pipeline.*` event types are declared
-for future use but not yet emitted.
-
-## Release Download Stats
-
-GitHub tracks download counts per release asset. Unlike npm download totals —
-which include CI pipelines, `npx` one-offs, and version-update churn — each
-release asset download is a real binary or connector-tarball fetch, so it is
-the cleaner install signal (issue #1026 Phase 3).
-
-```sh
-bun scripts/release-download-stats.ts              # markdown table
-bun scripts/release-download-stats.ts --json       # NDJSON for dashboards
-bun scripts/release-download-stats.ts --releases 5 # last N releases
+```bash
+curl -fsS http://127.0.0.1:3850/api/analytics/errors?limit=20
+curl -fsS http://127.0.0.1:3850/api/analytics/latency
+curl -fsS http://127.0.0.1:3850/api/diagnostics
 ```
 
-The script queries the public GitHub REST API for `Signet-AI/signetai`
-releases (no auth required; unauthenticated rate limit of 60 req/hr is
-plenty) and aggregates `download_count` per release and per asset, sorted
-by downloads descending. Output includes the total across the window.
+Counters and in-memory buffers are runtime observations. They can reset when the daemon restarts. Use durable logs, database state, and the affected source when investigating a persistent incident.
+
+## Telemetry
+
+Telemetry is configured at `memory.pipelineV2.telemetryEnabled` and defaults to enabled. Persistently opt out with:
+
+```yaml
+memory:
+  pipelineV2:
+    telemetryEnabled: false
+```
+
+For a process-local opt-out without editing configuration:
+
+```bash
+SIGNET_TELEMETRY_OPTOUT=1 signet daemon start
+```
+
+The daemon writes recorded telemetry events to:
+
+```text
+$SIGNET_WORKSPACE/.daemon/telemetry/events.jsonl
+```
+
+PostHog delivery is best-effort and depends on telemetry configuration. The local JSONL audit is the inspection surface; it lets an operator see what was recorded without treating a remote dashboard as the source of truth.
+
+Telemetry is designed to avoid memory content, user identity, file paths, and raw secrets. The audit log is still workspace-private operational data: do not commit it or paste it into a public issue without review.
+
+## Investigation workflow
+
+1. Check daemon state and `/health/ready`.
+2. Pull a bounded recent error and latency view.
+3. Identify the affected request, session, source, provider, or queue.
+4. Inspect the original source and daemon logs.
+5. Use [Diagnostics](/diagnostics/) for health or repair decisions.
+6. Re-run the same bounded query after a change to verify the outcome.
+
+Related: [Daemon](/daemon/), [Diagnostics](/diagnostics/), [Configuration](/configuration/).

--- a/web/docs/src/content/docs/configuration.md
+++ b/web/docs/src/content/docs/configuration.md
@@ -1,22 +1,25 @@
 ---
 title: "Configuration"
-description: "Complete configuration reference for Signet."
+description: "Operator configuration for a Signet workspace and daemon."
 ---
 
-Complete configuration reference for Signet.
+Signet reads workspace configuration from `agent.yaml`. Start with `signet setup`, keep credentials in [Secrets](/secrets/), and restart the daemon after an operational change:
 
-Complete reference for all Signet configuration options. For initial setup,
-see [Quickstart](/quickstart/). For the [Daemon](/daemon/) runtime, see [Architecture](/architecture/).
+```bash
+signet daemon restart
+signet daemon status --json
+```
+
+The running daemon is the authority for operational state. Use [Diagnostics](/diagnostics/) and `/health/ready` to verify a change rather than assuming a YAML edit was applied.
 
 ## In this section
 
-- [Workspace and identity](/configuration/workspace-identity/)
-  Configure the Signet workspace, agent identity, and primary agent.yaml fields.
-- [Inference and routing](/configuration/inference-routing/)
-  Configure inference accounts, targets, policies, workloads, and agent routes.
-- [Pipeline configuration](/configuration/pipeline/)
-  Configure extraction, synthesis, graph, search, continuity, and pipeline workers.
-- [Security and lifecycle](/configuration/security-lifecycle/)
-  Configure authentication, retention, hooks, and environment variables.
-- [Files and integrations](/configuration/files-integrations/)
-  Configure identity files, storage, harnesses, and Git integration.
+- [Workspace and identity](/configuration/workspace-identity/): workspace selection, identity files, embeddings, and safe configuration shape.
+- [Inference and routing](/configuration/inference-routing/): canonical targets, policies, workloads, and routes.
+- [Pipeline configuration](/configuration/pipeline/): runtime controls, maintenance, documents, continuity, and telemetry.
+- [Security and lifecycle](/configuration/security-lifecycle/): authentication, lifecycle behavior, and environment overrides.
+- [Files and integrations](/configuration/files-integrations/): managed workspace files, local state, harnesses, and source control.
+
+## Operator rule
+
+Do not restore retired configuration blocks from old examples. In particular, `memory.synthesis` is rejected by the current loader. Keep model selection in the canonical inference routing configuration, and use the current daemon error or [Upgrading](/upgrading/) when an older workspace no longer loads.

--- a/web/docs/src/content/docs/configuration/files-integrations.md
+++ b/web/docs/src/content/docs/configuration/files-integrations.md
@@ -1,186 +1,59 @@
 ---
 title: "Files and integrations"
-description: "Configure identity files, storage, harnesses, and Git integration."
+description: "Managed workspace files, daemon-owned state, harness integration, and source-control boundaries."
 ---
 
-## AGENTS.md
+## Managed files
 
-The main agent identity file. Synced to all configured harnesses on
-change (2-second debounce). Write it in plain markdown — there is no
-required structure, but a typical layout looks like this:
+Keep the workspace readable and separate authored context from daemon-owned state.
 
-```markdown
-# Agent Name
+| Path                                | Use                                                                          |
+| ----------------------------------- | ---------------------------------------------------------------------------- |
+| `AGENTS.md`                         | Operating rules for an agent or project.                                     |
+| `SOUL.md`, `IDENTITY.md`, `USER.md` | Identity, tone, and user context where the active identity preset uses them. |
+| `MEMORY.md`                         | Generated working-memory summary. Do not hand-edit.                          |
+| `agent.yaml`                        | Operator configuration.                                                      |
+| `memory/memories.db`                | SQLite database owned by the daemon.                                         |
+| `.daemon/`                          | PID, logs, auth material, telemetry audit data, and other runtime state.     |
+| `.secrets/`                         | Encrypted secrets. Never commit this directory.                              |
 
-Short introduction paragraph.
+Use [Workspace and identity](/configuration/workspace-identity/) for workspace resolution and [Secrets](/secrets/) for credential storage.
 
-## SOUL.md
+## Harness integration
 
-Optional personality file for deeper character definition. Loaded by
-harnesses that support separate personality and instruction files.
+Install or refresh harness integrations with the Signet setup and connector flows. Do not copy legacy Python hook snippets or generated plugin files from old documentation: connector packages and the CLI own their managed harness configuration.
 
-```markdown
-# Soul
+For a remote harness, create a narrowly scoped API key, install the matching connector, and start a fresh harness session. See [Remote Harness Connectors](/remote-connectors/).
 
-## MEMORY.md
+For local configuration, run setup first and inspect the resulting harness configuration before changing it:
 
-Auto-generated working memory summary. Updated by the synthesis system.
-Do not edit by hand — changes will be overwritten on the next synthesis
-run. Loaded at session start when `hooks.sessionStart.includeRecentContext`
-is `true`.
-
-## Database Schema
-
-The SQLite database at `memory/memories.db` contains three main tables.
-
-### memories
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | TEXT | Primary key (UUID) |
-| `content` | TEXT | Memory content |
-| `type` | TEXT | `fact`, `preference`, `decision`, `daily-log`, `episodic`, `procedural`, `semantic`, `system` |
-| `source` | TEXT | Source system or harness |
-| `importance` | REAL | 0-1 score, decays over time |
-| `tags` | TEXT | Comma-separated tags |
-| `who` | TEXT | Source harness name |
-| `pinned` | INTEGER | 1 if critical/pinned (never decays) |
-| `is_deleted` | INTEGER | 1 if soft-deleted (tombstone) |
-| `deleted_at` | TEXT | ISO timestamp of soft-delete |
-| `created_at` | TEXT | ISO timestamp |
-| `updated_at` | TEXT | ISO timestamp |
-| `last_accessed` | TEXT | Last access timestamp |
-| `access_count` | INTEGER | Number of times recalled |
-| `confidence` | REAL | Extraction confidence (0-1) |
-| `version` | INTEGER | Optimistic concurrency version |
-| `manual_override` | INTEGER | 1 if user has manually edited |
-
-### embeddings
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | TEXT | Primary key (UUID) |
-| `content_hash` | TEXT | SHA-256 hash of embedded text |
-| `vector` | BLOB | Float32 array (raw bytes) |
-| `dimensions` | INTEGER | Vector size (e.g. 768) |
-| `source_type` | TEXT | `memory`, `conversation`, etc. |
-| `source_id` | TEXT | Reference to parent memory UUID |
-| `chunk_text` | TEXT | The text that was embedded |
-| `created_at` | TEXT | ISO timestamp |
-
-### memories_fts
-
-FTS5 virtual table for keyword search over `content`, backed by the
-`memories` table and created with the `unicode61` tokenizer. Triggers
-keep the index in sync when rows are inserted, deleted, or updated.
-
-## Harness-Specific Configuration
-
-### Claude Code
-
-Location: `~/.claude/`
-
-`settings.json` installs hooks that fire at session lifecycle events:
-
-```json
-{
-  "hooks": {
-    "SessionStart": [{
-      "hooks": [{
-        "type": "command",
-        "command": "python3 $SIGNET_WORKSPACE/memory/scripts/memory.py load --mode session-start",
-        "timeout": 3000
-      }]
-    }],
-    "UserPromptSubmit": [{
-      "hooks": [{
-        "type": "command",
-        "command": "python3 $SIGNET_WORKSPACE/memory/scripts/memory.py load --mode prompt",
-        "timeout": 2000
-      }]
-    }],
-    "SessionEnd": [{
-      "hooks": [{
-        "type": "command",
-        "command": "python3 $SIGNET_WORKSPACE/memory/scripts/memory.py save --mode auto",
-        "timeout": 10000
-      }]
-    }]
-  }
-}
+```bash
+signet setup
+signet daemon status --json
 ```
 
-### OpenCode
+A daemon restart or fresh harness session may be necessary after a connector or identity change.
 
-Location: `~/.config/opencode/plugins/`
+## Source control and backups
 
-`signet.mjs` is a bundled OpenCode plugin installed by
-`@signet/connector-opencode` that exposes `/remember` and `/recall`
-as native tools within the harness.
-
-> **Note:** Legacy `memory.mjs` installations are automatically migrated
-> to `~/.config/opencode/plugins/signet.mjs` on reconnect.
-
-### OpenClaw
-
-Location: `$SIGNET_WORKSPACE/hooks/agent-memory/` (hook directory)
-
-Also configures the OpenClaw workspace in `~/.openclaw/openclaw.json`
-(and compatible `clawdbot` / `moltbot` config locations):
-
-```json
-{
-  "agents": {
-    "defaults": {
-      "workspace": "$SIGNET_WORKSPACE"
-    }
-  }
-}
-```
-
-See [HARNESSES.md](/harnesses/) for the full OpenClaw adapter docs.
-
-## Git Integration
-
-If your Signet workspace is a git repository, the daemon auto-commits file changes
-with a 5-second debounce after the last detected change. Commit messages
-use the format `YYYY-MM-DDTHH-MM-SS_auto_<filename>`. The setup wizard
-offers to initialize git on first run and creates a backup commit before
-making any changes.
-
-Recommended `.gitignore` for your workspace:
+Treat the workspace as a mix of durable authored files and private runtime state. A conservative `.gitignore` includes:
 
 ```text
 .daemon/
 .secrets/
-__pycache__/
-*.pyc
 *.log
 ```
 
-### Watcher ignore file
+Do not commit a database copy, secret store, auth secret, or generated runtime log to a shared repository. If you need a backup, stop or quiesce the daemon and back up the workspace with its private state using your approved encrypted backup system. See [Self-Hosting](/self-hosting/) for the Docker volume path and upgrade flow.
 
-Create `$SIGNET_WORKSPACE/.sigignore` to keep local runtime files in the
-Signet workspace without triggering daemon watcher work or git auto-commits.
-Patterns are matched relative to the workspace root and support common
-gitignore-style globs such as `*`, `?`, `**`, directory prefixes, comments
-with `#`, and later `!` negation inside the same file.
+## Troubleshooting boundary
 
-When no `.sigignore` exists, the daemon creates one with sensible defaults
-covering known runtime artifacts (for example Fly harness homes). Example:
+Do not repair the database by editing tables, deleting a PID file, or copying a generated harness config from another machine as a first response. Check the daemon's current state, diagnostics, and logs first:
 
-```text
-# Harness runtimes and sockets
-agents/*/.fly-*-home/
-*.sock
-
-# Keep a specific socket visible to the watcher
-!agents/<agent-name>/keep.sock
+```bash
+signet daemon status --json
+curl -fsS http://127.0.0.1:3850/health/ready
+curl -fsS http://127.0.0.1:3850/api/diagnostics
 ```
 
-The `.sigignore` file itself is still watched, and new ignore patterns take
-effect without a daemon restart. If you remove a pattern that previously hid a
-whole existing directory, restart the daemon to guarantee that subtree is added
-back to the watcher. Signet also always ignores its managed source checkout,
-memory database files, generated memory artifacts, and per-agent generated
-`workspace/AGENTS.md`.
+Related: [Daemon](/daemon/), [Diagnostics](/diagnostics/), [Remote Harness Connectors](/remote-connectors/).

--- a/web/docs/src/content/docs/configuration/pipeline.md
+++ b/web/docs/src/content/docs/configuration/pipeline.md
@@ -1,487 +1,70 @@
 ---
 title: "Pipeline configuration"
-description: "Configure extraction, synthesis, graph, search, continuity, and pipeline workers."
+description: "Operator controls for the daemon's memory, document, maintenance, continuity, and telemetry work."
 ---
 
-## Pipeline V2 Config
+Pipeline settings live under `memory.pipelineV2` in `agent.yaml`. Inference target choice belongs in [Inference and routing](/configuration/inference-routing/). Do not add the retired `memory.synthesis` block: the current loader rejects it.
 
-The V2 [memory pipeline](/pipeline/) lives at `platform/daemon/src/pipeline/`. It runs
-LLM-based fact extraction against incoming conversation text, then decides
-whether to write new memories, update existing ones, or skip. Config lives
-under `memory.pipelineV2` in `agent.yaml`.
+Restart the daemon after a pipeline configuration change. Long-running workers are started with a configuration snapshot, so editing YAML alone is not a reliable apply operation.
 
-Inference selection for extraction is configured through the top-level
-`inference.workloads.memoryExtraction` binding. Session processing follows that
-route and is not independently configurable. Legacy provider/model/endpoint
-fields under `memory.pipelineV2` are retired and rejected by the strict loader.
+```bash
+signet daemon restart
+signet daemon status --json
+```
 
-The config uses a nested structure with grouped sub-objects. Operation tuning
-such as timeouts, confidence thresholds, and rate limits remains under
-`memory.pipelineV2`; provider selection belongs in `inference`.
-
-Enable the pipeline:
+## Safe operational baseline
 
 ```yaml
 memory:
   pipelineV2:
-    enabled: true
-    shadowMode: true        # extract without writing — safe first step
-```
-
-
-### Control flags
-
-These top-level boolean fields gate major pipeline behaviors.
-
-| Field | Default | Description |
-|-------|---------|-------------|
-| `enabled` | `true` | Master switch. Pipeline does nothing when false. |
-| `shadowMode` | `false` | Extract facts but skip writes. Useful for evaluation. |
-| `mutationsFrozen` | `false` | Allow reads; block all writes. Overrides `shadowMode`. |
-| `semanticContradictionEnabled` | `true` | Enable LLM-based semantic contradiction detection for UPDATE/DELETE proposals. |
-| `telemetryEnabled` | `true` | Enable anonymous telemetry reporting (set `false` to opt out). |
-
-The relationship between `shadowMode` and `mutationsFrozen` matters:
-`shadowMode` suppresses writes from the normal extraction path only;
-`mutationsFrozen` is a harder freeze that blocks all write paths
-including repairs and graph updates.
-
-
-### Extraction tuning
-
-Provider and model selection are no longer configured under
-`memory.pipelineV2.extraction`. Configure the canonical
-`inference.workloads.memoryExtraction` binding instead:
-
-```yaml
-inference:
-  targets:
-    background:
-      executor: ollama
-      models:
-        default:
-          model: qwen3:4b
-  policies:
-    background:
-      mode: automatic
-      defaultTargets: [background/default]
-      fallbackTargets: [background/default]
-  defaultPolicy: background
-  taskClasses:
-    memory_extraction:
-      reasoning: medium
-      toolsRequired: true
-      privacy: restricted_remote
-  workloads:
-    memoryExtraction:
-      target: background/default
-      taskClass: memory_extraction
-```
-
-The remaining `memory.pipelineV2.extraction` fields are operation tuning only:
-
-| Field | Default | Range | Description |
-|-------|---------|-------|-------------|
-| `timeout` | `90000` | 5000-300000 ms | Extraction call timeout |
-| `minConfidence` | `0.7` | 0.0-1.0 | Confidence threshold; facts below this are dropped |
-| `structuredOutput` | `true` | — | Send JSON schema in the `format` field of inference requests |
-| `rateLimit.maxCallsPerHour` | `200` when configured | 0-10000 | Max extraction calls per hour; set `0` to disable rate limiting |
-| `rateLimit.burstSize` | `20` when configured | 1-1000 | Max burst size before throttling begins |
-| `rateLimit.waitTimeoutMs` | `5000` when configured | 0-60000 ms | How long to wait for a rate-limit token |
-
-`provider`, `model`, `endpoint`, `baseUrl`, `fallbackProvider`, and `command`
-are retired under this block. The daemon rejects them after migration rather
-than silently choosing a fallback. See [upgrading](/upgrading/) for the
-reconfiguration path.
-
-`rateLimit` is opt-in and applies only to remote or paid inference targets.
-Ollama and local OpenAI-compatible targets are exempt. Rate-limiter state is
-in-memory and resets after a daemon restart.
-
-Set `memory.pipelineV2.enabled: false` to disable extraction entirely. Remote
-API extraction can accumulate extreme fees quickly because the pipeline runs
-continuously in the background.
-
-### MEMORY.md synthesis (`synthesis`)
-
-Session synthesis provider/model/endpoint routing is retired. Session processing
-follows the `memoryExtraction` inference workload, while the MEMORY.md worker
-uses the daemon's canonical inference route. Do not add a `memory.pipelineV2.synthesis`
-block or provider fields under it; those fields are rejected during config load.
-
-The worker's remaining operational settings, when supported by the installed
-release, are tuning-only. Completed transcripts are delivered directly to
-Dreaming through the content pass.
-
-
-### Claude Code background environment (`claudeCode`)
-
-Applies whenever legacy pipeline extraction, synthesis, or an explicit
-inference route uses the `claude-code` provider.
-
-| Field | Default | Range | Description |
-|-------|---------|-------|-------------|
-| `allowApiKeyEnv` | `false` | — | When `false`, daemon-spawned `claude -p` calls strip ambient `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN`. Set `true` only when background pipeline jobs should inherit those env credentials. Legacy unshipped `billingMode: api-key` is accepted as an alias for `true`; `billingMode: subscription` maps to `false`. |
-| `maxBudgetUsd` | unset | 0.01-1000 | Optional per-invocation spend cap passed to Claude Code print mode as `--max-budget-usd`. Omitted by default because Claude Code documents no default limit for this flag and forcing one could change CLI behavior. |
-| `cooldownMs` | `300000` | 1000-3600000 ms | Daemon-wide Claude Code circuit cooldown opened after Claude Code reports quota, usage-limit, credit, billing, or auth failures. Calls during cooldown fail before spawning `claude`. Interactive and background `claude-code` providers in the daemon share this circuit and config snapshot. |
-
-```yaml
-memory:
-  pipelineV2:
-    claudeCode:
-      allowApiKeyEnv: false
-      cooldownMs: 300000
-```
-
-Only opt into ambient API-key/token inheritance when you intentionally want
-background pipeline jobs to use the Anthropic credentials already present in
-the daemon environment:
-
-```yaml
-memory:
-  pipelineV2:
-    claudeCode:
-      allowApiKeyEnv: true
-      maxBudgetUsd: 0.25
-```
-
-Anthropic's Claude Code CLI reference lists `--max-budget-usd` as a
-print-mode-only API-call budget flag:
-<https://docs.anthropic.com/en/docs/claude-code/cli-reference>. Anthropic's
-Claude Code cost docs describe Claude Code charges in terms of API token
-consumption and subscription plan pricing separately:
-<https://docs.anthropic.com/en/docs/claude-code/costs>. Anthropic support docs
-also state that paid Claude subscriptions and Claude Console/API usage are
-separate products:
-<https://support.anthropic.com/en/articles/9876003-i-subscribe-to-claude-pro-why-do-i-have-to-pay-separately-for-api-usage-on-console>.
-Signet does not verify the billing account selected by a persisted
-`claude auth login --console` session; it only controls whether the daemon
-subprocess inherits ambient Anthropic API key/token environment variables.
-
-### Worker (`worker`)
-
-The pipeline processes jobs through a queue with lease-based concurrency
-control.
-
-| Field | Default | Range | Description |
-|-------|---------|-------|-------------|
-| `maxRetries` | `3` | 1-10 | Max retry attempts before a job goes to dead-letter |
-| `leaseTimeoutMs` | `300000` | 10000-600000 ms | Time before an uncompleted job lease expires |
-| `maxLlmConcurrency` | `2` | 1-16 | Shared cap for live LLM calls across extraction, synthesis, reranking, inference streaming, and daemon route provider calls such as skills, ontology consolidation, and diagnostics greetings. `SIGNET_MAX_LLM_CONCURRENCY` overrides YAML when set, matching the TypeScript daemon behavior for wired provider paths. |
-
-A job that exceeds `maxRetries` moves to dead-letter status and is
-eventually purged by the retention worker.
-The standalone extraction worker was retired under the Dreaming cutover
-(#946); its former `pollMs`, `maxLoadPerCpu`, `overloadBackoffMs`, and
-`threadedExtraction` knobs are no longer read from configuration (legacy
-YAML values are ignored).
-
-
-### Knowledge Graph (`graph`)
-
-When `graph.enabled: true`, the pipeline builds entity-relationship links
-from extracted facts and uses them to boost search relevance.
-
-| Field | Default | Range | Description |
-|-------|---------|-------|-------------|
-| `enabled` | `true` | — | Enable knowledge graph building and querying |
-| `boostWeight` | `0.15` | 0.0-1.0 | Weight applied to graph-neighbor score boost |
-| `boostTimeoutMs` | `500` | 50-5000 ms | Timeout for graph lookup during search |
-
-
-### Hints (`hints`)
-
-Prospective indexing generates hypothetical future queries at write
-time. These "hints" are indexed in FTS5 so memories match by
-anticipated cue, not just stored content. For example, a memory about
-"switched from PostgreSQL to SQLite" might generate hints like
-"database migration", "why SQLite", and "storage engine decision" —
-queries the user is likely to ask later.
-
-| Field | Default | Range | Description |
-|-------|---------|-------|-------------|
-| `enabled` | `true` | — | Enable prospective indexing |
-| `max` | `5` | 1-20 | Maximum hints generated per memory |
-| `timeout` | `30000` | 5000-120000 ms | Hint generation LLM timeout |
-| `maxTokens` | `256` | 32-1024 | Max tokens for hint generation |
-| `poll` | `5000` | 1000-60000 ms | Job polling interval |
-
-```yaml
-memory:
-  pipelineV2:
-    hints:
+    telemetryEnabled: true
+    autonomous:
       enabled: true
-      max: 5
-      timeout: 30000
-      maxTokens: 256
-      poll: 5000
-```
-
-
-### Traversal (`traversal`)
-
-Graph traversal controls how the knowledge graph is walked during
-retrieval. When `primary: true`, graph traversal produces the base
-candidate pool and flat search fills gaps. When `primary: false`,
-traditional hybrid search runs first with graph boost as
-supplementary.
-
-| Field | Default | Range | Description |
-|-------|---------|-------|-------------|
-| `enabled` | `true` | — | Enable graph traversal |
-| `primary` | `true` | — | Use traversal as primary retrieval strategy |
-| `maxAspectsPerEntity` | `20` | 1-50 | Max aspects to collect per entity (read cap) |
-| `maxAttributesPerAspect` | `50` | 1-100 | Max attributes per aspect (read cap) |
-| `maxWriteAspectsPerEntity` | `20` | 1-50 | Max active aspects per entity before create_aspect is rejected |
-| `maxWriteAttributesPerAspect` | `50` | 1-100 | Max active attributes per aspect before add_claim_value is rejected |
-| `maxDependencyHops` | `10` | 1-50 | Max hops for dependency walking |
-| `minDependencyStrength` | `0.3` | 0.0-1.0 | Minimum edge strength to follow |
-| `maxBranching` | `4` | 1-20 | Max branching factor during traversal |
-| `maxTraversalPaths` | `50` | 1-500 | Max paths to explore |
-| `minConfidence` | `0.5` | 0.0-1.0 | Minimum confidence for results |
-| `timeoutMs` | `500` | 50-5000 ms | Traversal timeout |
-| `boostWeight` | `0.2` | 0.0-1.0 | Weight for traversal boost in hybrid search |
-| `constraintBudgetChars` | `1000` | 100-10000 | Character budget for constraint injection |
-
-```yaml
-memory:
-  pipelineV2:
-    traversal:
+      frozen: false
+      maintenanceIntervalMs: 1800000
+      maintenanceMode: execute
+    documents:
+      workerIntervalMs: 10000
+      chunkSize: 2000
+      chunkOverlap: 200
+      maxContentBytes: 10485760
+    continuity:
       enabled: true
-      primary: true
-      maxAspectsPerEntity: 20
-      maxAttributesPerAspect: 50
-      maxWriteAspectsPerEntity: 20
-      maxWriteAttributesPerAspect: 50
-      maxDependencyHops: 10
-      minDependencyStrength: 0.3
-      maxBranching: 4
-      maxTraversalPaths: 50
-      minConfidence: 0.5
-      timeoutMs: 500
-      boostWeight: 0.2
-      constraintBudgetChars: 1000
+      promptInterval: 10
+      timeIntervalMs: 900000
+      retentionDays: 7
 ```
 
-The `primary` flag determines the retrieval strategy. In primary mode,
-entities are extracted from the query, the graph is walked to collect
-related memories, and flat hybrid search only runs to fill remaining
-slots. In supplementary mode (`primary: false`), the standard hybrid
-search runs first and traversal results are blended in using
-`boostWeight`. Primary mode is faster for entity-dense queries;
-supplementary mode is more conservative and better for freeform text.
+Omit settings you do not need. The daemon supplies bounded defaults and clamps accepted numeric values while loading configuration.
 
+## Controls
 
-### Reranker (`reranker`)
+`telemetryEnabled` defaults to `true`. Set it to `false` to opt out persistently; `SIGNET_TELEMETRY_OPTOUT=1` disables telemetry for the process without changing YAML. See [Analytics](/analytics/) for the local audit path and privacy boundary.
 
-An optional reranking pass that runs after initial retrieval. An
-embedding-based reranker is built in (uses cached vectors, no extra
-LLM calls). Optionally, reranking can call the active extraction
-provider model.
+`autonomous.enabled` controls autonomous maintenance. `autonomous.frozen` pauses autonomous writes without deleting configuration. `autonomous.maintenanceMode` is `observe` or `execute`. Use `observe` while evaluating a new deployment; use the repair endpoints only with an authenticated operator or admin principal where applicable.
 
-| Field | Default | Range | Description |
-|-------|---------|-------|-------------|
-| `enabled` | `true` | — | Enable the reranking pass |
-| `model` | `""` | — | Model name for the reranker (empty uses embedding-based) |
-| `useExtractionModel` | `false` | — | When `true`, use the extraction provider LLM for reranking and emit a synthesized summary card |
-| `topN` | `20` | 1-100 | Number of candidates to pass to the reranker |
-| `timeoutMs` | `2000` | 100-30000 ms | Timeout for the reranking call |
+The `repair` object bounds maintenance work with cooldowns and hourly budgets. Its current keys include re-embed, requeue, and deduplication cooldown and budget settings. Keep those limits conservative when a remote provider is involved.
 
+## Documents and continuity
 
-### Autonomous (`autonomous`)
+`documents` controls the daemon document worker: poll interval, chunk target, overlap, and maximum accepted content bytes. These are processing limits, not a replacement for upload policy. See [Sources](/sources/) for ingest behavior.
 
-Controls autonomous maintenance, repair, and mutation behavior.
+`continuity` controls checkpoint cadence, retention, and recovery-budget limits. It is independent of ordinary recall. Tune it only when you have a concrete recovery or storage requirement.
 
-| Field | Default | Description |
-|-------|---------|-------------|
-| `enabled` | `true` | Allow autonomous pipeline operations (maintenance, repair). |
-| `frozen` | `false` | Block autonomous writes; autonomous reads still allowed. |
-| `allowUpdateDelete` | `true` | Permit the pipeline to update or delete existing memories. |
-| `maintenanceIntervalMs` | `1800000` | How often maintenance runs (30 min). Range: 60s-24h. |
-| `maintenanceMode` | `"execute"` | `"observe"` logs issues; `"execute"` attempts repairs. |
+`embeddingTracker` controls the bounded background pass that detects missing or stale embeddings. `guardrails` bounds stored and injected text. `subagents` controls parent-context inheritance for supported harness flows. Leave defaults in place unless a measured issue requires a change.
 
-In `"observe"` mode the worker emits structured log events but makes no
-changes. When `frozen` is true, the maintenance interval never starts,
-though the worker's `tick()` method remains callable for on-demand
-inspection.
+## Concurrency and provider behavior
 
+`worker.maxLlmConcurrency` sets a shared cap for active LLM work. `SIGNET_MAX_LLM_CONCURRENCY` overrides it for the process when it is a positive integer. Do not set this from a guess: provider quota, local GPU memory, and latency are deployment-specific.
 
-### Repair budgets (`repair`)
+For canonical model selection, create or edit a routing target and bind the workload. See [Inference and routing](/configuration/inference-routing/). A legacy provider/model field in an old workspace is not a safe substitute for a workload binding.
 
-Repair sub-workers limit how aggressively they re-embed, re-queue, or
-deduplicate items to avoid overloading providers.
+## Verify
 
-| Field | Default | Range | Description |
-|-------|---------|-------|-------------|
-| `reembedCooldownMs` | `300000` | 10s-1h | Min time between re-embed batches |
-| `reembedHourlyBudget` | `10` | 1-1000 | Max re-embed operations per hour |
-| `requeueCooldownMs` | `60000` | 5s-1h | Min time between re-queue batches |
-| `requeueHourlyBudget` | `50` | 1-1000 | Max re-queue operations per hour |
-| `dedupCooldownMs` | `600000` | 10s-1h | Min time between dedup batches |
-| `dedupHourlyBudget` | `3` | 1-100 | Max dedup operations per hour |
-| `dedupSemanticThreshold` | `0.92` | 0.0-1.0 | Cosine similarity threshold for semantic dedup |
-| `dedupBatchSize` | `100` | 10-1000 | Max candidates evaluated per dedup batch |
-
-
-### Document ingest (`documents`)
-
-Controls chunking for ingesting large documents into the memory store.
-
-| Field | Default | Range | Description |
-|-------|---------|-------|-------------|
-| `workerIntervalMs` | `10000` | 1s-300s | Poll interval for pending document jobs |
-| `chunkSize` | `2000` | 200-50000 | Target chunk size in characters |
-| `chunkOverlap` | `200` | 0-10000 | Overlap between adjacent chunks (chars) |
-| `maxContentBytes` | `10485760` | 1 KB-100 MB | Max document size accepted |
-
-Chunk overlap ensures context is not lost at chunk boundaries. A value of
-10-15% of `chunkSize` is a reasonable starting point.
-
-
-### Guardrails (`guardrails`)
-
-Content size limits applied during extraction and recall to prevent
-oversized content from degrading pipeline performance.
-
-| Field | Default | Range | Description |
-|-------|---------|-------|-------------|
-| `maxContentChars` | `500` | 50-100000 | Max characters stored per memory |
-| `chunkTargetChars` | `300` | 50-50000 | Target chunk size for content splitting |
-| `recallTruncateChars` | `500` | 50-100000 | Max characters returned per memory in recall results |
-
-These limits are enforced at the pipeline level. Content exceeding
-`maxContentChars` is truncated before storage. Recall results are
-truncated at `recallTruncateChars` to keep session context budgets
-predictable.
-
-
-### Continuity (`continuity`)
-
-Session checkpoint configuration for continuity recovery. Checkpoints
-capture periodic snapshots of session state (focus, prompts, memory
-activity) to aid recovery after context compaction or session restart.
-
-| Field | Default | Range | Description |
-|-------|---------|-------|-------------|
-| `enabled` | `true` | — | Master switch for session checkpoints |
-| `promptInterval` | `10` | 1-1000 | Prompts between periodic checkpoints |
-| `timeIntervalMs` | `900000` | 60s-1h | Time between periodic checkpoints (15 min default) |
-| `maxCheckpointsPerSession` | `50` | 1-500 | Per-session checkpoint cap (oldest pruned) |
-| `retentionDays` | `7` | 1-90 | Days before old checkpoints are hard-deleted |
-| `recoveryBudgetChars` | `2000` | 200-10000 | Max characters for recovery digest |
-
-Checkpoints are triggered by five events: `periodic`, `pre_compaction`,
-`session_end`, `agent`, and `explicit`. Secrets are redacted before
-storage.
-
-
-### Sub-agents (`subagents`)
-
-Controls deterministic parent-session context inherited by sub-agent sessions
-at `session-start`. This uses stored active transcripts and checkpoints; it
-does not make an LLM call.
-
-| Field | Default | Range | Description |
-|-------|---------|-------|-------------|
-| `inheritContext` | `true` | — | Inject a compact parent context block when parent lineage is available |
-| `tailChars` | `3000` | 0-20000 | Max transcript tail characters included from the parent session |
-
-```yaml
-memory:
-  pipelineV2:
-    subagents:
-      inheritContext: true
-      tailChars: 3000
+```bash
+signet daemon status --json
+curl -fsS http://127.0.0.1:3850/api/pipeline/status
+curl -fsS http://127.0.0.1:3850/health/ready
 ```
 
-Set `inheritContext: false` to disable automatic inherited context while
-leaving the explicit `session_search` MCP/API surface available.
-
-
-### Telemetry (`telemetry`)
-
-Anonymous usage telemetry. On by default; set `telemetryEnabled: false`
-to opt out. Events are batched and flushed periodically. Sending requires
-both `posthogHost` and `posthogApiKey`. Each install gets a random
-anonymous id (persisted in the workspace database) used as the PostHog
-`distinct_id`, so installs stay countable without being identifiable.
-
-**See [TELEMETRY.md](https://github.com/Signet-AI/signetai/blob/main/docs/TELEMETRY.md)** — the single reference for the
-event catalog, privacy contract, the open JSONL audit log, runtime opt-out
-(`SIGNET_TELEMETRY_OPTOUT=1`), and how to query the data.
-
-**Disclosure (issue #1026):** `signet setup` tells users telemetry is on
-by default and asks whether to disable it, including sharing top-level CLI
-command names with PostHog. Declining writes `telemetryEnabled: false`;
-non-interactive/CI setups keep the default (enabled).
-
-**Runtime opt-out:** setting `SIGNET_TELEMETRY_OPTOUT=1` in the daemon or CLI
-process environment disables telemetry without touching config — the same knob
-the install ping honors. CI runners, containers, and scripted environments
-should set it in every process so automated daemon boots and CLI invocations do
-not count as installs or usage.
-
-**Open telemetry log:** every recorded event is appended as one JSON line
-to `<agentsDir>/.daemon/telemetry/events.jsonl` — the single inspectable
-audit surface for exactly what was recorded (daemon events and CLI
-`command.invoked` lines). CLI command events are also queued in the workspace
-database when remote delivery is configured and a telemetry SQLite database is
-available, then flushed to PostHog in bounded, best-effort batches without
-awaiting the command. Fresh workspaces without that database remain local-only.
-The CLI and daemon use the same persisted install id.
-No memory content, code, file paths, or personal
-data are ever included.
-
-Lifecycle events: `daemon.started` (version, platform,
-uptime), `command.invoked` (command name only, never arguments),
-`error.occurred` (sanitized crash report — truncated message with user paths
-stripped, top stack frames with home directories removed, uptime, and
-rate-limited `EventLoopLag` reports with measured lag), `version.upgraded`
-(from, to), and `version.observed` (from, to for any observed daemon-start
-transition).
-
-**Development fleet marker:** setting `SIGNET_TELEMETRY_ENV=dev` keeps operator
-development checkouts in the dataset while making them filterable. The daemon
-adds `deployment: dev` to its local and PostHog events, while the CLI adds it
-to its local and PostHog command events. The native install ping applies the marker
-and `-dev` version suffix when the environment is present. The daemon and CLI
-`bun run dev` scripts set this marker automatically. The marker does not
-disable telemetry; use `SIGNET_TELEMETRY_OPTOUT=1` when development or
-automated events should be silenced entirely.
-
-Every daemon and CLI event carries `deploymentRole` and `installChannel`.
-Both default to `unknown` and are populated only from the explicit config
-keys below or `SIGNET_TELEMETRY_DEPLOYMENT_ROLE` and
-`SIGNET_TELEMETRY_INSTALL_CHANNEL`. The `SIGNET_TELEMETRY_ENV=dev` marker
-remains compatible and maps the role to `development`.
-| Field | Default | Range | Description |
-|-------|---------|-------|-------------|
-| `posthogHost` | `https://us.i.posthog.com` | — | PostHog instance URL (empty disables) |
-| `posthogApiKey` | `phc_mLsvJmbmp6e9UarrX9Cq5QtTjVNiiphM9mvi5Xnddd8Q` | — | PostHog project API key. Public ingest key by design; shared by daemon and CLI |
-| `flushIntervalMs` | `60000` | 5s-10min | Time between event flushes |
-| `flushBatchSize` | `50` | 1-500 | Max events per flush batch |
-| `retentionDays` | `90` | 1-365 | Days before local telemetry data is purged |
-| `deploymentRole` | `unknown` | `personal`, `service`, `automation`, `development`, `ci`, `unknown` | Explicit deployment role |
-| `installChannel` | `unknown` | `desktop`, `package-manager`, `source`, `container`, `unknown` | Explicit installation provenance |
-| `memorySearchQaEnabled` | `false` | boolean | Capture local-only recall QA rows with query text and result snapshots |
-
-`memorySearchQaEnabled` is separate from anonymous telemetry. It writes a
-local review ledger to SQLite and intentionally includes recall query text
-and recalled result content, so it is exposed only through analytics-gated
-endpoints and is never sent to PostHog.
-
-
-### Embedding tracker (`embeddingTracker`)
-
-Background polling loop that detects stale or missing embeddings and
-refreshes them in small batches. Runs alongside the extraction pipeline.
-
-| Field | Default | Range | Description |
-|-------|---------|-------|-------------|
-| `enabled` | `true` | — | Master switch |
-| `pollMs` | `5000` | 1s-60s | Polling interval between refresh cycles |
-| `batchSize` | `8` | 1-20 | Max embeddings refreshed per cycle |
-
-The tracker detects embeddings that are missing, have a stale content
-hash, or were produced by a different model than the currently configured
-one. It uses `setTimeout` chains for natural backpressure.
+Use [Diagnostics](/diagnostics/) when a queue, embedding, or maintenance problem persists. Do not infer worker health from a successful configuration write.

--- a/web/docs/src/content/docs/configuration/workspace-identity.md
+++ b/web/docs/src/content/docs/configuration/workspace-identity.md
@@ -1,90 +1,55 @@
 ---
 title: "Workspace and identity"
-description: "Configure the Signet workspace, agent identity, and primary agent.yaml fields."
+description: "Workspace resolution, managed identity files, and the safe agent.yaml baseline."
 ---
 
-## Configuration Files
+## Workspace selection
 
-All files live in your active Signet workspace.
+A Signet workspace owns its configuration, identity files, database, daemon state, and generated artifacts.
 
-- Default workspace: `~/.agents/`
-- Persisted workspace setting: `~/.config/signet/workspace.json`
-- Override for a single process: `SIGNET_PATH=/some/path`
+Resolution is, in order:
 
-| File | Purpose |
-|------|---------|
-| `agent.yaml` | Main configuration and manifest |
-| `AGENTS.md` | Agent-managed operating rules and instructions (synced to harnesses) |
-| `DREAMING.md` | Dreaming/reflection prompt used only for dreaming sessions; not loaded during normal startup |
-| `HEARTBEAT.md` | Heartbeat/background-check prompt used only for heartbeat sessions |
-| `BOOTSTRAP.md` | Bootstrap/setup prompt used only for first-run/bootstrap sessions |
-| `SOUL.md` | Agent-managed personality, tone, values, and temperament |
-| `MEMORY.md` | System-managed working memory summary (auto-generated, do not edit manually) |
-| `IDENTITY.md` | Agent-managed identity metadata |
-| `USER.md` | Agent-managed user profile and relationship context |
+1. An explicit CLI `--path` value.
+2. `SIGNET_PATH` for the current process.
+3. The persisted workspace selection.
+4. `~/.agents/`.
 
-The loader checks `agent.yaml`, `AGENT.yaml`, and `config.yaml` in that
-order, using the first file it finds. All sections are optional; omitting
-a section falls back to the documented defaults.
-
-## Workspace selection and persistence
-
-Use the CLI to inspect or change the default workspace path:
+Inspect or change the persisted selection with:
 
 ```bash
 signet workspace status
-signet workspace set ~/.openclaw/workspace
+signet workspace set /path/to/workspace
 ```
 
-`signet workspace set` is idempotent. It safely migrates files, stores the
-new default workspace in `~/.config/signet/workspace.json`, and updates
-detected OpenClaw-family configs to keep `agents.defaults.workspace` aligned.
+Use `SIGNET_PATH` for a one-off daemon, test, or service invocation. Do not point two writable daemons at the same workspace.
 
-Resolution order for the effective workspace is:
+## Workspace files
 
-1. `--path` CLI option
-2. `SIGNET_PATH` environment variable
-3. Stored CLI workspace setting (`~/.config/signet/workspace.json`)
-4. Default `~/.agents/`
+| File or directory                                | Ownership                                                                    |
+| ------------------------------------------------ | ---------------------------------------------------------------------------- |
+| `agent.yaml`                                     | Operator configuration.                                                      |
+| `AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md` | Agent and user context. Preserve these as source material.                   |
+| `MEMORY.md`                                      | Generated working-memory projection. Do not hand-edit it.                    |
+| `DREAMING.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`    | Prompts for their named special flows, not ordinary startup context.         |
+| `memory/memories.db`                             | Daemon-owned SQLite state. Do not edit with SQL while the daemon is running. |
+| `.daemon/`                                       | Runtime state, logs, auth material, and telemetry audit data.                |
+| `.secrets/`                                      | Encrypted secret storage. Keep it out of source control.                     |
 
-## agent.yaml
+The configuration loader accepts the first present of `agent.yaml`, `AGENT.yaml`, or `config.yaml`, in that order. Prefer `agent.yaml` for new workspaces.
 
-The primary configuration file. Created by `signet setup` and editable
-via `signet configure` or the dashboard's config editor.
+## Minimal baseline
+
+`signet setup` produces the right starting point for the installed release. A small hand-maintained configuration can look like this:
 
 ```yaml
-version: 1
-schema: signet/v1
-
 agent:
   name: "My Agent"
-  description: "Personal AI assistant"
-  created: "2025-02-17T00:00:00Z"
-  updated: "2025-02-17T00:00:00Z"
-
-owner:
-  address: "0x..."
-  localId: "user123"
-  ens: "user.eth"
-  name: "User Name"
-
-harnesses:
-  - claude-code
-  - openclaw
-  - opencode
+  description: "Personal assistant"
 
 embedding:
   provider: ollama
   model: nomic-embed-text
-  dimensions: 768
-  base_url: http://localhost:11434
-  promptSubmitTimeoutMs: 1000
-  # llama.cpp only: truncate inputs to stay below its physical batch limit
-  llamaCppMaxInputTokens: 1400
-  # USD per million input tokens; local providers default to zero
-  costRates:
-    openai: 0.02
-    openrouter: 0.004
+  base_url: http://127.0.0.1:11434
 
 search:
   alpha: 0.7
@@ -92,246 +57,40 @@ search:
   min_score: 0.3
 
 memory:
-  database: memory/memories.db
-  session_budget: 2000
-  decay_rate: 0.95
-  synthesis:
-    harness: openclaw
-    model: sonnet
-    schedule: daily
-    max_tokens: 4000
   pipelineV2:
-    enabled: true
-    shadowMode: false
-    extraction:
-      provider: llama-cpp
-      model: qwen3:4b
-    synthesis:
-      enabled: true
-      provider: ollama
-      model: qwen3:4b
-    graph:
-      enabled: true
+    telemetryEnabled: true
     autonomous:
       enabled: true
+      frozen: false
       maintenanceMode: execute
-
-identity:
-  preset: minimal
-  startup:
-    load:
-      - path: AGENTS.md
-        role: operating_instructions
-        budget: 12000
-  special:
-    - path: DREAMING.md
-      kind: dreaming
-      role: dreaming_prompt
-      budget: 4000
-
-hooks:
-  sessionStart:
-    recallLimit: 10
-    includeIdentity: true
-    includeRecentContext: true
-    recencyBias: 0.7
-  userPromptSubmit:
-    enabled: true
-    recallLimit: 10
-    maxInjectChars: 500
-    minScore: 0.8
-  preCompaction:
-    includeRecentMemories: true
-    memoryLimit: 5
 
 auth:
   mode: local
-  defaultTokenTtlSeconds: 604800
-  sessionTokenTtlSeconds: 86400
-  login:
-    password:
-      username: admin
-      passwordHash: null
-    sso:
-      enabled: false
-    saml:
-      enabled: false
 
-trust:
-  verification: none
+network:
+  mode: localhost
 ```
 
+This is a baseline, not a schema dump. Add only the options you operate. Configure model targets and workload bindings in [Inference and routing](/configuration/inference-routing/), not by reviving legacy `memory.synthesis` fields.
 
-### agent
+## Embeddings and search
 
-Core agent identity metadata.
+The embedding provider, model, dimensions, endpoint, and optional `api_key` belong under `embedding`. Supported embedding providers include native, llama.cpp, Ollama, and OpenAI-compatible remote providers. Store remote credentials through [Secrets](/secrets/) and reference them with `$secret:NAME` rather than writing a key into YAML.
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `name` | string | yes | Agent display name |
-| `description` | string | no | Short description |
-| `created` | string | yes | ISO 8601 creation timestamp |
-| `updated` | string | yes | ISO 8601 last update timestamp |
+Changing an embedding profile initiates an index migration. Confirm its progress from the daemon status and embedding status endpoints before retiring the old provider or model.
 
+`search.alpha` controls hybrid retrieval weighting. `top_k` and `min_score` bound candidate collection and returned results. Change search tuning deliberately and verify representative recall queries after restart.
 
-### owner
+## Applying a change
 
-Optional owner identification. Reserved for future cryptographic identity
-verification.
+Most long-running workers receive configuration at pipeline start. Restart after changing embedding, inference, pipeline, auth, or network settings:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `address` | string | Cryptographic identity address or external identity ID, reserved for future use |
-| `localId` | string | Local user identifier |
-| `ens` | string | Optional ENS or human-friendly identity alias |
-| `name` | string | Human-readable name |
-
-
-### harnesses
-
-List of AI platforms to integrate with. Valid values: `claude-code`,
-`opencode`, `openclaw`, `codex`, `gemini`, `oh-my-pi`, `pi`, and
-`hermes-agent`. Support for `cursor`, `windsurf`, and `chatgpt` is planned.
-
-
-### embedding
-
-Vector embedding configuration for semantic memory search.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `provider` | string | `"ollama"` | `"ollama"` or `"openai"` |
-| `model` | string | `"nomic-embed-text"` | Embedding model name |
-| `dimensions` | number | `768` | Output vector dimensions |
-| `base_url` | string | `"http://localhost:11434"` | Ollama API base URL |
-| `api_key` | string | — | API key or `$secret:NAME` reference |
-| `promptSubmitTimeoutMs` | number | `1000` | Explicit recall embedding timeout retained for compatibility, range 1000-300000 ms |
-| `warmNative` | boolean | `true` | Kill-switch for the native ONNX embedding path. Set `false` to never warm or route to native — useful on Intel Macs where the native ONNX runtime can wedge (see #1073). Callers fall through to the llama.cpp/ollama fallback chain. Env override: `SIGNET_EMBEDDING_WARM_NATIVE=0`. |
-| `costRates` | object | provider defaults | USD per million input tokens by billing provider; local provider defaults are zero. |
-
-Increase the embedding timeout when local embedding models are slow to
-cold-load. For example, Ollama with `mxbai-embed-large` may need `10000` ms
-to avoid aborted explicit recall embeddings.
-
-Changing the embedding provider, model, dimensions, or base URL starts a
-background index migration. Existing semantic recall remains on the active
-index until Signet has re-embedded every active memory and source chunk with
-the new index; rows that the target provider permanently rejects are durably
-quarantined and reported in staging coverage so they do not block promotion. Check
-`GET /api/embeddings/status` for the active/staging profile and migration
-coverage. If the daemon restarts, the incomplete staged build resumes; a
-failed build leaves the active index unchanged.
-
-Recommended Ollama models:
-
-| Model | Dimensions | Notes |
-|-------|------------|-------|
-| `nomic-embed-text` | 768 | Default; good quality/speed balance |
-| `all-minilm` | 384 | Faster, smaller vectors |
-| `mxbai-embed-large` | 1024 | Better quality, more resource usage |
-
-Recommended OpenAI models:
-
-| Model | Dimensions | Notes |
-|-------|------------|-------|
-| `text-embedding-3-small` | 1536 | Cost-effective |
-| `text-embedding-3-large` | 3072 | Highest quality |
-
-Rather than putting an API key in plain text, store it with
-`signet secret put OPENAI_API_KEY` and reference it as:
-
-```yaml
-api_key: $secret:OPENAI_API_KEY
+```bash
+signet daemon restart
+signet daemon status --json
+curl -fsS http://127.0.0.1:3850/health/ready
 ```
 
+If a configuration error prevents startup, use the exact daemon error as the migration guide. Do not delete legacy keys blindly; preserve a backup of `agent.yaml`, make the smallest correction, then restart.
 
-### search
-
-Hybrid search tuning. Controls the blend between semantic (vector) and
-keyword (BM25) retrieval.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `alpha` | number | `0.7` | Vector weight 0-1. Higher = more semantic. |
-| `top_k` | number | `20` | Candidate count fetched from each source |
-| `min_score` | number | `0.3` | Minimum combined score to return a result |
-| `temporal_prior_enabled` | boolean | `true` | Enable the freshness-aware rehearsal boost for explicit recency queries (`current`, `latest`, `recent`, `today`, …). Default-on is deliberate for the #903 fix: the bounded boost only breaks near-ties; set `false` to preserve unshaped ranking. |
-| `temporal_prior_weight` | number | `0.15` | Maximum `created_at` recency boost for freshness queries (0-1) |
-| `temporal_prior_half_life_days` | number | `14` | Freshness-query recency half-life in days (1-365) |
-
-At `alpha: 0.9` results are heavily semantic, suitable for conceptual
-queries. At `alpha: 0.3` results skew toward keyword matching, better for
-exact-phrase lookups. The default of `0.7` works well generally.
-
-
-### memory
-
-Memory system settings.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `database` | string | `"memory/memories.db"` | SQLite path (relative to the active workspace) |
-| `session_budget` | number | `2000` | Character limit for session context injection |
-| `decay_rate` | number | `0.95` | Daily importance decay factor for non-pinned memories |
-
-Non-pinned memories lose importance over time using the formula:
-
-```
-importance(t) = base_importance × decay_rate^days_since_access
-```
-
-Accessing a memory resets the decay timer.
-
-
-### identity
-
-Identity loading is configurable. Presets choose which Markdown files load
-into normal startup context and which files are reserved for special sessions.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `preset` | string | `minimal` | One of `minimal`, `hermes`, `openclaw`, or `custom` |
-| `startup.load` | array | preset-defined | Ordered files loaded into normal startup/static fallback context |
-| `special` | array | preset-defined | Prompt files used only for special sessions, such as dreaming |
-
-Built-in presets:
-
-- `minimal` — startup loads only `AGENTS.md`; `DREAMING.md` is still created
-  and available for dreaming sessions, but is not loaded every turn.
-- `hermes` — startup loads `SOUL.md` then `AGENTS.md`, matching Hermes'
-  current SOUL-primary identity plus project-context convention.
-- `openclaw` — rich startup stack: `AGENTS.md`, `SOUL.md`, `IDENTITY.md`,
-  `USER.md`, and `MEMORY.md`, with `HEARTBEAT.md`, `DREAMING.md`, and
-  `BOOTSTRAP.md` reserved as special-session prompts.
-- `custom` — explicit ordered startup list chosen by the user.
-
-Example custom order:
-
-```yaml
-identity:
-  preset: custom
-  startup:
-    load:
-      - path: USER.md
-        role: user_profile
-        budget: 6000
-      - path: AGENTS.md
-        role: operating_instructions
-        budget: 12000
-  special:
-    - path: DREAMING.md
-      kind: dreaming
-      role: dreaming_prompt
-      budget: 4000
-```
-
-Special session files are not startup context. `DREAMING.md` is the prompt for
-reflection/consolidation runs and costs zero tokens in ordinary sessions.
-
-
-### MEMORY.md synthesis
-
-`MEMORY.md` regeneration is driven by session lifecycle and the internal
-synthesis worker. Its model selection follows the canonical
-`inference.workloads.memoryExtraction` route; the retired `memory.synthesis`
-configuration is rejected during config loading.
+Related: [Daemon](/daemon/), [Pipeline configuration](/configuration/pipeline/), [Authentication](/auth/), [Upgrading](/upgrading/).

--- a/web/docs/src/content/docs/daemon.md
+++ b/web/docs/src/content/docs/daemon.md
@@ -1,481 +1,97 @@
 ---
 title: "Daemon"
-description: "Background service for file watching and HTTP API."
+description: "Operate the Signet daemon: lifecycle, network binding, health, logs, and runtime boundaries."
 ---
 
-The Signet daemon is a background service that provides the [HTTP API](/api/),
-serves the [Dashboard](/dashboard/), watches config files for changes, manages
-[harness](/harnesses/) synchronization, and exposes an [MCP server](/mcp/) for
-native tool access. It also runs the [memory pipeline](/pipeline/) and a
-suite of subsystem workers for ingestion, retention, maintenance,
-[Analytics](/analytics/), and [Diagnostics](/diagnostics/).
+The Signet daemon owns the HTTP API, dashboard, workspace database, background workers, scheduler, diagnostics, telemetry, and harness-facing services. Its default local address is `http://127.0.0.1:3850`.
 
-The daemon runs on `http://localhost:3850` by default.
-
-
-## Starting and Stopping
-
-### Via CLI
+## Lifecycle
 
 ```bash
-signet daemon start    # Start the daemon
-signet daemon stop     # Stop the daemon
-signet daemon restart  # Restart the daemon
-signet status          # Check status
-```
-
-Top-level aliases `signet start`, `signet stop`, and `signet restart`
-still exist, but `signet daemon ...` is the preferred command surface.
-
-### Death evidence and the lifecycle record
-
-The daemon writes its state to `<workspace>/.daemon/lifecycle.json`: `starting`
-at boot, `running` once the HTTP server is ready, and a terminal `clean` or
-`error` record (with exit path, exit code, and timestamp) on every catchable
-exit — SIGTERM/SIGINT shutdowns and fatal errors. The record is written
-synchronously and atomically, and the daemon flushes its log buffer before
-exiting so the final log lines are never lost.
-
-A process that is killed with SIGKILL, OOM-killed, or hard-crashed cannot write
-a terminal record, so the file stays at `starting`/`running` — that stuck state
-is the signal. `signet status` and `signet doctor` read the record whenever the
-daemon is down and surface the distinction:
-
-- `Last daemon exit was clean` (info) — the daemon shut down normally.
-- `Daemon exited after an internal error` (error) — a fatal error with the
-  message, worth reporting upstream.
-- `Previous daemon exit was not recorded as clean` (warn) — killed or crashed.
-  The finding points at the daemon log tail and, on Linux systemd launches, the
-  transient unit's journald exit status (`journalctl --user -u
-  signet-daemon-<pid>`), which distinguishes signals, core dumps, and OOM.
-
-A concurrency load test for the bot-startup traffic profile (session-start
-hooks, secrets, recall, status, optional writes) ships at
-`scripts/load-test-daemon.ts`; run it against a live or scratch daemon with
-`bun scripts/load-test-daemon.ts --port <port> [--writes]`.
-
-### Via System Service
-
-The daemon can be installed as a system service for auto-start on boot.
-
-**macOS (launchd):**
-```bash
-cd platform/daemon
-bun run install:service
-
-launchctl load ~/Library/LaunchAgents/ai.signet.daemon.plist
-launchctl unload ~/Library/LaunchAgents/ai.signet.daemon.plist
-```
-
-**Linux (systemd):**
-```bash
-cd platform/daemon
-bun run install:service
-
-systemctl --user start signet.service
-systemctl --user stop signet.service
-systemctl --user status signet.service
-systemctl --user enable signet.service   # enable on boot
-```
-
-
-## Configuration
-
-### Runtime
-
-The daemon is a single TypeScript/Bun runtime (`@signet/daemon`). The
-experimental Rust daemon rewrite (`platform/daemon-rs`) and the
-`SIGNET_DAEMON_RUNTIME` selector have been removed; Rust is used only for
-native accelerators (`@signet/native`), which load transparently with a
-TypeScript fallback.
-
-### Environment Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `SIGNET_PORT` | `3850` | HTTP server port |
-| `SIGNET_HOST` | `127.0.0.1` | Daemon host used for local calls |
-| `SIGNET_BIND` | network mode bind | Explicit bind address override; defaults to `127.0.0.1` in localhost mode and `0.0.0.0` in tailscale mode |
-| `SIGNET_PATH` | `~/.agents` | Runtime override for the agents directory |
-| `SIGNET_LOG_FILE` | — | Optional explicit log file path |
-| `SIGNET_LOG_DIR` | `$SIGNET_WORKSPACE/.daemon/logs` | Optional log directory override |
-| `SIGNET_SQLITE_PATH` | — | macOS explicit SQLite dylib override used before Bun opens the database |
-
-### Files
-
-When log path overrides are set:
-- `SIGNET_LOG_FILE` takes highest precedence and points to the exact file.
-- Else `SIGNET_LOG_DIR` overrides the default log directory.
-- Else the default `$SIGNET_WORKSPACE/.daemon/logs/` paths below apply.
-
-| File | Description |
-|------|-------------|
-| `$SIGNET_WORKSPACE/.daemon/pid` | Process ID file |
-| `$SIGNET_WORKSPACE/.daemon/logs/` | Log directory |
-| `$SIGNET_WORKSPACE/.daemon/logs/signet-YYYY-MM-DD.log` | Daily log file |
-| `$SIGNET_WORKSPACE/.daemon/logs/daemon.out.log` | stdout capture |
-| `$SIGNET_WORKSPACE/.daemon/logs/daemon.err.log` | stderr capture |
-
-
-## Subsystems
-
-The daemon starts several concurrent workers when it initializes. Each
-worker runs its own loop and stops cleanly when the daemon shuts down.
-
-### Pipeline Workers
-
-The pipeline lives at `platform/daemon/src/pipeline/` and is managed
-by `startPipeline()` / `stopPipeline()`. The standalone extraction
-worker (`worker.ts`) and its decision/escalation stages were retired
-under the Dreaming cutover (#946); Dreaming now owns semantic writes.
-The remaining workers run in parallel:
-
-**Document worker** (`document-worker.ts`) polls `memory_jobs` for
-`document_ingest` jobs. It fetches remote URLs if needed, chunks the
-content hierarchically, embeds each chunk, and links chunks to their
-source document via `document_memories`. The same transaction
-discipline applies: no provider calls inside write locks.
-
-**Retention worker** (`retention-worker.ts`) runs on a periodic timer
-and purges memories that have decayed below their retention threshold.
-It can also be triggered manually by the maintenance worker.
-
-**Maintenance worker** (`maintenance-worker.ts`) runs diagnostics on
-a configurable interval and, depending on `maintenanceMode`, either
-logs recommendations (`observe`) or executes repair actions
-(`execute`). It tracks consecutive ineffective repairs and halts a
-given repair action after three failed attempts to avoid thrashing.
-Requires `autonomousEnabled: true` and `autonomousFrozen: false` in
-pipeline config to activate the timed loop; otherwise it is passive
-and can be triggered via the API.
-
-Pipeline config modes:
-
-| Mode flag | Effect |
-|-----------|--------|
-| `shadowMode` | Extract memories but do not write them |
-| `mutationsFrozen` | Read-only; no writes at all |
-| `graph.enabled` | Enable knowledge graph traversal on recall |
-| `autonomous.enabled` | Allow the maintenance worker to run repairs |
-| `autonomous.frozen` | Pause autonomous repairs without disabling |
-| `autonomous.maintenanceMode` | `"observe"` (log only) or `"execute"` (act) |
-
-### Session Tracker
-
-The session tracker (`session-tracker.ts`) enforces a mutex on the
-runtime path per session. Connectors send an `x-signet-runtime-path`
-header with each hook request — either `"plugin"` or `"legacy"`. Once
-a session is claimed by one path, any request arriving from the other
-path receives a `409 Conflict`. Stale sessions expire after 4 hours
-and are cleaned up every 15 minutes.
-
-### Auth Middleware
-
-The daemon supports three deployment modes: `local` (default, no
-authentication required), `team` (all requests require a bearer
-token), and `hybrid` (localhost requests bypass auth, remote requests
-require a token). Token roles are `admin`, `operator`, `agent`, and
-`readonly`, each with a different permission set. Rate limiting is
-applied per token. See [authentication guide](/auth/) for full details on
-configuration, token creation, and permission scopes.
-
-### Analytics
-
-The analytics collector (`analytics.ts`) accumulates ephemeral
-in-memory counters for the lifetime of the daemon process. Nothing
-is persisted to disk — the structured logs and `memory_history` table
-provide durable backing. The collector tracks:
-
-- **Usage counters** — per-endpoint call counts, error counts, and
-  total latency; per-actor request/remember/recall/mutation counts;
-  per-provider call counts and latency; per-connector sync counts.
-- **Error ring buffer** — a fixed-size circular buffer of recent
-  errors keyed by stage (`extraction`, `decision`, `embedding`,
-  `mutation`, `connector`).
-- **Latency histograms** — bucketed latency distributions per stage,
-  useful for spotting tail latency without external tooling.
-
-All counters reset on daemon restart. See [analytics reference](/analytics/)
-for the API endpoints and data shapes.
-
-### Timeline
-
-The timeline builder (`timeline.ts`) reconstructs a chronological
-incident trace for a given entity ID — a memory ID, request ID, or
-session ID. It joins across `memory_history`, `memory_jobs`, the
-in-process log buffer, and the error ring buffer to produce an ordered
-list of events. This is primarily a debugging tool for tracing what
-happened to a specific memory across extraction, decision, embedding,
-and mutation phases. See [analytics reference](/analytics/) for
-details on the timeline endpoint.
-
-### Diagnostics
-
-The diagnostics module (`diagnostics.ts`) evaluates six health
-domains and returns a composite score:
-
-| Domain | What it measures |
-|--------|-----------------|
-| `queue` | Job queue depth, dead job rate, stale leases |
-| `storage` | Total memories, tombstone ratio, database size |
-| `index` | Physical FTS document count vs canonical memories, embedding coverage |
-| `provider` | Ollama availability rate, recent timeouts and failures |
-| `mutation` | Recent recover and delete event rates |
-| `connector` | Active connector count, sync errors, error age |
-
-Each domain produces a `score` (0–1) and a `status` of `healthy`,
-`degraded`, or `unhealthy`. The composite score is a weighted average
-across all six. The maintenance worker uses this report to decide
-which repair actions to invoke. See [diagnostics guide](/diagnostics/)
-for the full report schema and repair action catalog.
-
-
-## HTTP API
-
-The daemon exposes endpoints across these domains: memory, skills,
-secrets, hooks, harnesses, auth, documents, connectors, diagnostics,
-pipeline, repair, analytics, telemetry, timeline, git sync, update,
-tasks, and logs. The table below lists the major groups. See
-[HTTP API reference](/api/) for the full reference including
-request/response schemas.
-
-| Group | Base path | Description |
-|-------|-----------|-------------|
-| Health | `/health`, `/health/live`, `/health/ready` | Liveness and readiness probes, daemon status |
-| Auth | `/api/auth/*` | Token issuance, validation, rate limit status |
-| Config | `/api/config` | Read and write identity files |
-| Identity | `/api/identity` | Parsed identity fields |
-| Memories | `/api/memories`, `/memory/*` | List, search, similarity, remember, recall |
-| Embeddings | `/api/embeddings` | Export embedding vectors |
-| Documents | `/api/documents/*` | Document ingest and chunk retrieval |
-| Connectors | `/api/connectors/*` | Connector registry, status, cursor updates |
-| Skills | `/api/skills` | List installed skills |
-| Harnesses | `/api/harnesses` | List harnesses, regenerate configs |
-| Secrets | `/api/secrets` | List, get, set, delete secrets |
-| Hooks | `/api/hooks/*` | Session start/stop, synthesis hooks |
-| Git | `/api/git/*` | Commit history, sync status |
-| Update | `/api/update` | Version check |
-| Diagnostics | `/api/diagnostics` | Live health report across all domains |
-| Repair | `/api/repair/*` | Manually trigger repair actions |
-| Analytics | `/api/analytics` | Usage counters, error buffer, histograms |
-| Timeline | `/api/timeline/:id` | Incident reconstruction by entity ID |
-| Logs | `/api/logs` | Recent in-process log entries |
-| MCP | `/mcp` | Model Context Protocol server (Streamable HTTP) |
-
-### Health Check
-
-```http
-GET /health
-```
-
-```json
-{
-  "status": "healthy",
-  "uptime": 3600,
-  "pid": 12345,
-  "version": "0.124.3",
-  "port": 3850,
-  "agentsDir": "/home/user/.agents",
-  "db": true,
-  "dbWriter": {
-    "queued": 0,
-    "maxQueue": 64,
-    "oldestWaitMs": null,
-    "lastDurationMs": 2.1
-  },
-  "shuttingDown": false,
-  "updateAvailable": false,
-  "pendingRestart": false,
-  "resources": { "...": "..." }
-}
-```
-
-`GET /health` remains the legacy health check. `dbWriter` is local writer-pressure diagnostics: `queued` counts waiting writes, `oldestWaitMs` reports the oldest wait, and `lastDurationMs` reports the last completed write. Async write paths are admitted through a bounded queue; when `queued` reaches `maxQueue`, callers receive a retryable `DB_WRITE_QUEUE_FULL` error instead of adding unbounded work. The legacy synchronous transaction API remains available for startup and atomic control-plane operations.
-
-For orchestration and monitoring, prefer the dedicated probes: `GET /health/live`
-is a cheap liveness probe that
-never touches the database or subsystems (always 200 while the process is up),
-and `GET /health/ready` returns 200 only when the database, migrations,
-embedding, inference, and queue gates all pass — 503 with a `reasons` list
-otherwise. See [Health and status API](/api/health-status/).
-
-### Daemon Status
-
-```http
-GET /api/status
-```
-
-```json
-{
-  "status": "running",
-  "version": "0.124.3",
-  "pid": 12345,
-  "uptime": 3600,
-  "startedAt": "2025-02-17T16:00:00.000Z",
-  "port": 3850,
-  "host": "127.0.0.1",
-  "bindHost": "127.0.0.1",
-  "networkMode": "localhost",
-  "agentsDir": "/home/user/.agents",
-  "memoryDb": true,
-  "pipelineV2": { "...": "..." },
-  "pipeline": { "extraction": { "...": "..." } },
-  "providerResolution": { "extraction": { "...": "..." } },
-  "logging": {
-    "logDir": "/home/user/.agents/.daemon/logs",
-    "logFile": "/home/user/.agents/.daemon/logs/signet-2026-04-29.log"
-  },
-  "activeSessions": 0,
-  "bypassedSessions": 0,
-  "agentCreatedAt": "2025-02-17T16:00:00.000Z",
-  "update": { "...": "..." },
-  "embedding": { "...": "..." }
-}
-```
-
-
-## File Watcher
-
-The daemon watches these paths with chokidar:
-
-- `$SIGNET_WORKSPACE/agent.yaml`
-- `$SIGNET_WORKSPACE/AGENTS.md`
-- `$SIGNET_WORKSPACE/SOUL.md`
-- `$SIGNET_WORKSPACE/MEMORY.md`
-- `$SIGNET_WORKSPACE/IDENTITY.md`
-- `$SIGNET_WORKSPACE/USER.md`
-- `$SIGNET_WORKSPACE/memory/` (entire directory)
-- `~/.claude/projects/*/memory/MEMORY.md` (Claude Code project memories)
-
-### Auto-Ingestion
-
-When memory markdown files are created or modified, the daemon
-automatically ingests them using hierarchical chunking to preserve
-section structure. Each chunk includes its section header for context.
-A SHA-256 hash prevents re-processing unchanged files. Ingestion runs
-on startup and on file change.
-
-| File pattern | Who | Tags |
-|--------------|-----|------|
-| `$SIGNET_WORKSPACE/memory/*.md` (not MEMORY.md) | `openclaw-memory` | `openclaw`, `memory-log`, date |
-| `~/.claude/projects/*/memory/MEMORY.md` | `claude-code` | `claude-code`, `claude-project-memory`, project ID |
-
-### Auto Git Commit
-
-When a watched file changes, the daemon waits 5 seconds (debounce),
-checks whether `$SIGNET_WORKSPACE/` is a git repository, stages all changes
-with `git add -A`, and commits with a message in the form
-`YYYY-MM-DDTHH-MM-SS_auto_<filename>`.
-
-### Harness Sync
-
-When `AGENTS.md` changes, the daemon waits 2 seconds, then
-regenerates harness configuration files. It writes to:
-
-- `~/.claude/CLAUDE.md` (if `~/.claude/` exists)
-- `~/.config/opencode/AGENTS.md` (if `~/.config/opencode/` exists)
-
-Each generated file includes a header noting the source path and
-timestamp.
-
-
-## Security
-
-### Network Binding
-
-The daemon binds to loopback by default and is not reachable from
-other machines. Set `network.mode: tailscale` or `SIGNET_BIND` to expose it
-on a broader interface, but pair that with auth mode `team` or `hybrid`.
-
-### Auth Modes
-
-In `local` mode (the default), no credentials are required. This is
-fine for single-user local use. For any networked or shared
-deployment, switch to `team` or `hybrid` mode. See
-[authentication guide](/auth/) for setup instructions.
-
-### File Permissions
-
-The daemon reads and writes only files accessible to the running user.
-It does not escalate privileges.
-
-
-## Logging
-
-Logs are written to the console and to a daily file at
-`$SIGNET_WORKSPACE/.daemon/logs/signet-YYYY-MM-DD.log` by default. When
-`SIGNET_LOG_FILE` is set, logs are written to that exact file.
-When `SIGNET_LOG_DIR` is set (and `SIGNET_LOG_FILE` is unset), daily
-logs are written under `$SIGNET_LOG_DIR/`.
-
-```
-[2025-02-17T18:00:00.000Z] [INFO] Message here
-[2025-02-17T18:00:01.000Z] [WARN] Warning message
-[2025-02-17T18:00:02.000Z] [ERROR] Error message
-```
-
-Log levels: `INFO` for normal operations, `WARN` for non-fatal issues,
-`ERROR` for errors that do not crash the daemon.
-
-
-## Troubleshooting
-
-### Daemon won't start
-
-Check whether port 3850 is already in use:
-```bash
-lsof -i :3850
-```
-
-Remove a stale PID file if present:
-```bash
-rm $SIGNET_WORKSPACE/.daemon/pid
 signet daemon start
+signet daemon stop
+signet daemon restart
+signet daemon status --json
+signet daemon logs
 ```
 
-Read the error log:
+Top-level `signet start`, `signet stop`, `signet restart`, and `signet logs` remain aliases. Prefer the `signet daemon` form in automation and operator runbooks.
+
+A successful process start is not readiness. Verify both process state and readiness after a restart:
+
 ```bash
-cat "${SIGNET_LOG_FILE:-$HOME/.agents/.daemon/logs/daemon.err.log}"
+signet daemon status --json
+curl -fsS http://127.0.0.1:3850/health/live
+curl -fsS http://127.0.0.1:3850/health/ready
 ```
 
-### Daemon keeps crashing
+`/health/live` is a cheap process liveness probe. `/health/ready` includes readiness gates and can return a non-success response while the daemon is still starting or a required subsystem is unavailable.
 
-Check for syntax errors in config:
+## Network binding
+
+`SIGNET_PORT` defaults to `3850`. `SIGNET_BIND` controls the listening interface. `SIGNET_HOST` is the daemon's local-call host. `SIGNET_PATH` selects the workspace for the process.
+
+The default network mode is loopback-only. For a trusted tailnet or private LAN, configure the workspace and restart:
+
+```yaml
+network:
+  mode: tailscale
+```
+
 ```bash
-cat $SIGNET_WORKSPACE/agent.yaml
+signet daemon restart
+signet daemon status --json
 ```
 
-Verify database integrity:
+A deployment manager can override the bind address explicitly:
+
 ```bash
-sqlite3 $SIGNET_WORKSPACE/memory/memories.db "PRAGMA integrity_check;"
+SIGNET_BIND=0.0.0.0 SIGNET_PORT=3850 signet daemon start
 ```
 
-### Dashboard not loading
+An exposed interface is not an authentication setting. Use `auth.mode: team` for an untrusted or Internet-facing deployment. `hybrid` is convenient for a trusted workstation, but is not a public reverse-proxy security boundary. See [Authentication](/auth/) and [Self-Hosting](/self-hosting/).
 
-Confirm the daemon is running and the dashboard was built:
+## Runtime configuration
+
+The daemon loads `agent.yaml` from the selected workspace. Some files and service settings can be observed after startup, but long-running pipeline workers begin from a configuration snapshot. Restart after changing pipeline, embedding, inference, auth, or network configuration.
+
 ```bash
-signet status
-curl http://localhost:3850/health
-curl http://localhost:3850/health/ready
-ls surfaces/dashboard/build/
+signet daemon restart
+signet daemon status --json
 ```
 
-### File changes not syncing
+Do not assume a file watcher makes every configuration key live. Use `/api/status`, `/api/pipeline/status`, readiness, and representative operator checks to confirm the intended effect.
 
-Check the watcher logs, confirm the git repository exists, and verify
-file permissions:
+## Operator endpoints
+
+| Endpoint                                                  | Purpose                                                   |
+| --------------------------------------------------------- | --------------------------------------------------------- |
+| `/health`, `/health/live`, `/health/ready`                | Liveness and readiness probes.                            |
+| `/api/status`                                             | Daemon, binding, workspace, runtime, and update state.    |
+| `/api/pipeline/status`                                    | Pipeline state and runtime configuration summary.         |
+| `/api/diagnostics`                                        | Health report for authenticated operators where required. |
+| `/api/repair/*`                                           | Explicit repair actions with admin protection.            |
+| `/api/tasks/*`                                            | Scheduled task configuration, runs, and output stream.    |
+| `/api/analytics/*`, `/api/telemetry/*`, `/api/timeline/*` | Operational metrics and investigation surfaces.           |
+
+The full request and response surface is in [HTTP API](/api/). Do not automate against a dashboard rendering when an API endpoint exists.
+
+## Logs and local state
+
+Runtime state lives under `$SIGNET_WORKSPACE/.daemon/`. By default, daemon logs are written there; `SIGNET_LOG_FILE` can select an explicit log file and `SIGNET_LOG_DIR` can select a log directory. Use the CLI first:
+
 ```bash
-ls $SIGNET_WORKSPACE/.git
+signet daemon logs
 ```
 
-### Pipeline jobs stuck
+If the daemon will not start, capture the exact validation error and preserve the workspace before changing data. Do not delete the SQLite database, auth secret, or PID file as a routine recovery step.
 
-Check diagnostics for queue health and dead job rates:
-```bash
-curl http://localhost:3850/api/diagnostics
-```
+## Scheduler
 
-If the dead job rate is high, trigger a repair manually:
-```bash
-curl -X POST http://localhost:3850/api/repair/requeue-dead-jobs
-```
+The daemon scheduler evaluates recurring tasks and starts the configured local harness command. It supports Claude Code, Codex, and OpenCode task harnesses, limits concurrent runs, and marks interrupted runs failed during daemon startup recovery. See [Scheduled Tasks](/scheduling/).
+
+## Persistent deployment
+
+The CLI manages daemon lifecycle; first-party persistent container deployment is documented in [Self-Hosting](/self-hosting/). If you run a host service manager, make it own a single daemon process, set `SIGNET_PATH` and networking explicitly, and verify restart behavior with health probes. Do not point multiple writers at one workspace.
+
+Related: [Diagnostics](/diagnostics/), [Analytics](/analytics/), [Authentication](/auth/), [Upgrading](/upgrading/).

--- a/web/docs/src/content/docs/diagnostics.md
+++ b/web/docs/src/content/docs/diagnostics.md
@@ -1,409 +1,91 @@
 ---
 title: "Diagnostics"
-description: "Health scoring and system diagnostics."
+description: "Inspect daemon health and run bounded repair actions with evidence."
 ---
 
-The [Daemon](/daemon/) continuously monitors the health of the [memory pipeline](/pipeline/)
-through a read-only diagnostics system and a set of policy-gated repair actions.
-An optional maintenance worker ties them together, running repairs autonomously
-on a schedule.
+Diagnostics are the operator surface for queue, storage, index, provider, mutation, connector, and update health. Treat them as evidence, not a license to reset state.
 
-Source files:
-- `platform/daemon/src/diagnostics.ts`
-- `platform/daemon/src/repair-actions.ts`
-- `platform/daemon/src/pipeline/maintenance-worker.ts`
-
-
-## Health Domains
-
-Every diagnostic report scores seven independent domains. Each domain returns
-a score between 0 and 1, and a status derived from that score:
-
-- `healthy` — score >= 0.8
-- `degraded` — score >= 0.5
-- `unhealthy` — score < 0.5
-
-All domain functions are read-only. They accept a `ReadDb` handle or a
-`ProviderTracker` and return plain data structs with no side effects.
-
-### queue
-
-Reflects the state of `memory_jobs`, the live durable work queue for
-document/index maintenance. Historical `summary_jobs` rows are retired and are
-excluded from queue counts and readiness checks; the API may expose an empty
-summary compatibility object for older clients.
-
-Signals measured:
-
-- `depth` — count of pending jobs. More than 50 pending jobs deducts 0.3.
-- `deadRate` — ratio of dead-letter jobs to completed+dead in the last 24
-  hours. Exceeding 1% deducts 0.3.
-- `oldestAgeSec` — age in seconds of the oldest pending job. Over 5 minutes
-  deducts 0.2.
-- `leaseAnomalies` — count of jobs still in `leased` status but created more
-  than 10 minutes ago. Any anomaly deducts 0.2.
-
-A perfect queue scores 1.0. All deductions are cumulative and clamped to
-the [0, 1] range.
-
-### storage
-
-Reflects the state of the `memories` table.
-
-- `totalMemories` — total row count including tombstones.
-- `deletedTombstones` — count of soft-deleted rows (`is_deleted = 1`).
-- `dbSizeBytes` — reported as 0 on read connections (file stat unavailable).
-
-If deleted tombstones exceed 30% of total rows, the score drops by 0.3.
-
-### index
-
-Reflects the quality of the FTS5 full-text index and embedding coverage.
-
-- `memoriesRowCount` — count of active (non-deleted) memories.
-- `ftsRowCount` — row count from `memories_fts`. Because FTS5 external
-  content tables include tombstone rows, a mismatch is flagged only when
-  the FTS count exceeds the active count by more than 10%.
-- `ftsMismatch` — boolean. When true, the score drops by 0.5.
-- `embeddingCoverage` — fraction of active memories that have an embedding
-  model assigned. Below 80% coverage deducts 0.3.
-
-### provider
-
-Reflects recent LLM call reliability via `ProviderTracker`, an in-memory
-ring buffer that holds the last 100 outcomes.
-
-```typescript
-type Outcome = "success" | "failure" | "timeout";
-```
-
-The ring buffer evicts the oldest entry when it reaches capacity, maintaining
-an O(1) running tally. If the buffer is empty (no calls yet), the system
-assumes healthy and returns 1.0.
-
-- `availabilityRate` — `successes / total`. This is used directly as the
-  score, so a 100% success rate is 1.0 and any failures or timeouts reduce
-  it proportionally.
-- `recentTotal`, `recentSuccesses`, `recentFailures`, `recentTimeouts` are
-  also returned for inspection.
-
-### mutation
-
-Reflects write reliability over the last 7 days from `memory_history`.
-
-- `recentRecovers` — count of `recovered` events. More than 5 recoveries
-  suggests that deletes are regularly being undone, which deducts 0.3.
-- `recentDeletes` — informational count of `deleted` events.
-
-### connector
-
-Reflects the sync state of installed harness connectors from the
-`connectors` table.
-
-- `connectorCount`, `syncingCount`, `errorCount` are counted directly.
-- `oldestErrorAge` — milliseconds since the oldest unresolved connector
-  error. Over 24 hours deducts an additional 0.2 on top of the 0.3 deducted
-  for any error being present.
-
-If the `connectors` table does not exist (older databases), this domain
-returns a perfect score of 1.0 rather than failing.
-
-### update
-
-Reflects the state of the auto-update system.
-
-- `autoInstallEnabled` — whether unattended installs are configured.
-- `lastCheckSucceeded` — whether the most recent update check completed
-  without error.
-- `lastCheckAgeHours` — hours since the last successful check. Zero if
-  no check has run yet.
-- `pendingRestart` — whether a version has been installed but the daemon
-  has not yet been restarted to activate it.
-- `lastError` — the error string from the most recent failed check, or
-  `null`.
-
-Scoring: starts at 1.0. Deducts 0.1 if `autoInstallEnabled` is false
-and an update is available. Deducts 0.2 if `pendingRestart` is true.
-Additional deductions apply if the last check failed or is stale.
-
-
-## Composite Scoring
-
-The seven domain scores are combined into a single weighted average:
-
-| Domain    | Weight |
-|-----------|--------|
-| queue     | 0.25   |
-| provider  | 0.22   |
-| index     | 0.17   |
-| storage   | 0.12   |
-| mutation  | 0.08   |
-| connector | 0.05   |
-| update    | 0.11   |
-
-The result is clamped to [0, 1] and assigned the same status thresholds as
-individual domains. Queue and provider carry the most weight because
-queue failures cascade — a stuck queue or an unavailable LLM will stall
-pipeline work entirely.
-
-
-## API Endpoints
-
-Both endpoints require the `diagnostics` permission. In local [Auth](/auth/) mode
-this is always granted. With token auth, the token must include the
-`diagnostics` scope. See [Api](/api/) for the full endpoint reference.
-
-### GET /api/diagnostics
-
-Returns a full `DiagnosticsReport` with all seven domains and the composite.
-
-```json
-{
-  "timestamp": "2026-02-21T12:00:00.000Z",
-  "composite": { "score": 0.91, "status": "healthy" },
-  "queue": {
-    "score": 1.0,
-    "status": "healthy",
-    "depth": 2,
-    "oldestAgeSec": 4,
-    "deadRate": 0,
-    "leaseAnomalies": 0
-  },
-  "storage": { ... },
-  "index": { ... },
-  "provider": { ... },
-  "mutation": { ... },
-  "connector": { ... }
-}
-```
-
-### GET /api/diagnostics/:domain
-
-Returns the health object for a single domain. Valid values for `:domain`
-are: `queue`, `storage`, `index`, `provider`, `mutation`, `connector`, `update`.
-Returns 400 if the domain name is unrecognized.
+## Start with status and readiness
 
 ```bash
-curl http://localhost:3850/api/diagnostics/queue
-curl http://localhost:3850/api/diagnostics/provider
+signet daemon status --json
+curl -fsS http://127.0.0.1:3850/health/live
+curl -fsS http://127.0.0.1:3850/health/ready
+curl -fsS http://127.0.0.1:3850/api/diagnostics
 ```
 
+`/health/live` answers whether the process is up. `/health/ready` includes readiness gates. `/api/diagnostics` returns the detailed report. In authenticated deployments, diagnostics require the appropriate operator or admin permission.
 
-## Repair Actions
+Use the report to identify the failing domain before taking action. Do not treat a low composite score as a diagnosis by itself.
 
-Repair endpoints require the `admin` permission. All actions pass through two
-gates before executing: the policy gate and the rate limiter.
+## Useful investigations
 
-### Policy gate
+| Symptom                            | First evidence                                                                |
+| ---------------------------------- | ----------------------------------------------------------------------------- |
+| Daemon unreachable                 | `signet daemon status --json`, `/health/live`, bind address and service logs. |
+| Daemon up but not usable           | `/health/ready`, `/api/status`, and the exact readiness reasons.              |
+| Work backlog or repeated failures  | `/api/diagnostics`, then the queue and pipeline status.                       |
+| Search looks incomplete            | diagnostics plus the embedding/index status before changing models.           |
+| Recent deployment changed behavior | `/api/status`, update status, and daemon logs.                                |
+| Provider trouble                   | provider diagnostics, configured routing target, and provider reachability.   |
 
-The policy gate checks two config flags in order:
+## Repair actions
 
-1. `autonomousFrozen` — if true, all repairs are blocked regardless of actor.
-2. `autonomousEnabled` — if false, repairs requested by `agent` actors are
-   blocked. Operators and the daemon itself bypass this check.
+Repair endpoints are privileged. They are for a diagnosed condition, not first-line recovery. Back up private workspace state before a destructive or broad action.
 
-The actor type is read from the `x-signet-actor-type` request header. Valid
-values are `operator`, `agent`, and `daemon`. Defaults to `operator`.
+Current repair routes include:
 
-### Rate limiter
+```text
+GET  /api/repair/integrity-check
+POST /api/repair/requeue-dead
+POST /api/repair/release-leases
+POST /api/repair/check-fts
+POST /api/repair/retention-sweep
+```
 
-Each action tracks its last run timestamp and an hourly invocation count.
-Two thresholds control it: a cooldown (minimum gap between runs) and a
-hourly budget (maximum runs per rolling hour window). If either threshold is
-violated, the endpoint returns 429 with a reason string.
-
-### Repair context headers
-
-All repair endpoints read optional headers to populate the audit log:
-
-| Header                  | Default              | Description                  |
-|-------------------------|----------------------|------------------------------|
-| `x-signet-reason`       | `"manual repair"`    | Why the repair was triggered |
-| `x-signet-actor`        | `"operator"`         | Who triggered it             |
-| `x-signet-actor-type`   | `"operator"`         | Actor type for policy check  |
-| `x-signet-request-id`   | random UUID          | For tracing across logs      |
-
-Every successful repair writes an audit entry to `memory_history` with
-`event = "none"` and a `metadata` field containing the action name,
-affected count, and message.
-
-### GET /api/repair/integrity-check
-
-Runs both SQLite integrity modes and returns the existing top-level `ok` and
-`messages` fields for compatibility, plus separate `quickCheck` and
-`fullCheck` results. `quickCheck` is a broad, inexpensive check; `fullCheck`
-is authoritative for index consistency. The daemon also runs these checks at
-startup, then transactionally rebuilds the disposable telemetry indexes when
-only `telemetry_events` is corrupt. A failed repair prevents background workers
-from starting and is reported by `/health` and `/health/ready`. If the audit store itself prevents
-committing a verified repair, the default remains fail-closed. An operator doing
-an explicitly unaudited emergency recovery can set
-`SIGNET_ALLOW_UNAUDITED_TELEMETRY_REPAIR=1` for one daemon start; the verified
-telemetry repair is logged as unaudited and the flag should then be removed.
+Examples:
 
 ```bash
-SIGNET_ALLOW_UNAUDITED_TELEMETRY_REPAIR=1 signet daemon start
+# Read-only integrity evidence
+curl -fsS http://127.0.0.1:3850/api/repair/integrity-check
+
+# Requeue dead work only after identifying why it died
+curl -fsS -X POST http://127.0.0.1:3850/api/repair/requeue-dead
+
+# Release stale leases only after checking the worker is not still active
+curl -fsS -X POST http://127.0.0.1:3850/api/repair/release-leases
 ```
 
-```bash
-curl http://localhost:3850/api/repair/integrity-check
-```
+Rate limits and maintenance policy protect repairs from repeated automated retries. A rejected repair is a signal to inspect the root cause, not a reason to loop the request.
 
-### POST /api/repair/requeue-dead
+The retired transcript backfill route is not a recovery path. Current transcript delivery goes directly to Dreaming; do not build automation around an older backfill endpoint.
 
-Resets up to 50 dead-letter jobs back to `pending` with `attempts = 0`,
-allowing them to be retried. (Under the Dreaming cutover, the standalone
-extraction worker is retired; requeued legacy `extract` jobs are handled
-by the cutover sweep rather than a live worker.)
+## Maintenance configuration
 
-- Cooldown: `repairRequeueCooldownMs` (default: 1 minute)
-- Hourly budget: `repairRequeueHourlyBudget` (default: 50)
-
-```bash
-curl -X POST http://localhost:3850/api/repair/requeue-dead \
-  -H "x-signet-reason: dead rate spiked after model timeout"
-```
-
-### POST /api/repair/release-leases
-
-Releases jobs stuck in `leased` status past the lease timeout. Jobs with
-remaining retries move back to `pending`. Jobs whose `attempts` already meet
-or exceed `max_attempts` are dead-lettered instead. The cutoff is
-`now - leaseTimeoutMs` (default: 5 minutes).
-
-- Cooldown: `repairRequeueCooldownMs` (default: 1 minute)
-- Hourly budget: `repairRequeueHourlyBudget` (default: 50)
-
-```bash
-curl -X POST http://localhost:3850/api/repair/release-leases
-```
-
-### POST /api/repair/check-fts
-
-Verifies that the physical FTS5 index document count is consistent with the
-canonical memory count, including retained tombstones, and that `memories_fts`
-is using the canonical `unicode61` tokenizer.
-Pass `{ "repair": true }` in the JSON body to request a full repair:
-row-count mismatches rebuild the index, while tokenizer drift recreates
-`memories_fts` and backfills it from `memories`. Without that flag, the
-endpoint checks and reports only. Rebuilds are confirmed for autonomous
-callers and admitted through the async write queue.
-
-FTS rebuilds are expensive. This action uses a separate, stricter rate limit:
-
-- Cooldown: `repairReembedCooldownMs` (default: 5 minutes)
-- Hourly budget: 5 (hardcoded)
-
-```bash
-# Check only
-curl -X POST http://localhost:3850/api/repair/check-fts
-
-# Check and rebuild if mismatched
-curl -X POST http://localhost:3850/api/repair/check-fts \
-  -H "Content-Type: application/json" \
-  -d '{"repair": true}'
-```
-
-### POST /api/repair/retention-sweep
-
-Triggers an immediate retention purge instead of waiting for the next
-scheduled sweep. This is useful when tombstone accumulation is causing
-storage health to degrade.
-
-- Cooldown: `repairRequeueCooldownMs` (default: 1 minute)
-- Hourly budget: `repairRequeueHourlyBudget` (default: 50)
-
-Note: this endpoint returns 501 if the pipeline has not been started and
-the retention worker handle is unavailable.
-
-```bash
-curl -X POST http://localhost:3850/api/repair/retention-sweep
-```
-
-### Response shape
-
-All repair endpoints return the same structure:
-
-```json
-{
-  "action": "requeueDeadJobs",
-  "success": true,
-  "affected": 12,
-  "message": "requeued 12 dead job(s) to pending"
-}
-```
-
-A failed gate check returns the same shape with `success: false` and a
-`message` explaining which gate blocked it, with HTTP 429.
-
-
-## Maintenance Worker
-
-The maintenance worker runs on a timer and combines diagnostics with repair
-to close the loop autonomously. It starts only when `autonomousEnabled` is
-true and `autonomousFrozen` is false.
-
-### Modes
-
-The worker operates in one of two modes, controlled by `maintenanceMode`:
-
-**observe** (default) — the worker runs diagnostics and logs recommendations
-but does not execute any repairs. This lets you see what would happen before
-committing to autonomous execution.
-
-**execute** — the worker runs diagnostics, builds recommendations, and calls
-the appropriate repair actions automatically. The actor type is `"daemon"`,
-which bypasses the `autonomousEnabled` agent check.
-
-### Recommendation engine
-
-After each diagnostic run, the worker maps degraded signals to specific
-repair actions:
-
-| Condition | Action |
-|-----------|--------|
-| `queue.deadRate > 1%` | `requeueDeadJobs` |
-| `queue.leaseAnomalies > 0` | `releaseStaleLeases` |
-| `index.ftsMismatch` | `checkFtsConsistency` (with rebuild) |
-| tombstone ratio > 30% | `triggerRetentionSweep` |
-
-### Halt tracker
-
-Each repair action has an independent consecutive-failure counter. When an
-action is executed `MAX_INEFFECTIVE_RUNS` (3) times in a row without
-improving the composite score, it is halted. The halt clears if any
-subsequent diagnostic cycle finds no recommendations, at which point the
-counters reset entirely.
-
-This prevents the worker from hammering a repair that isn't helping — for
-example, repeatedly requeuing dead jobs when the root cause is an
-unavailable LLM provider.
-
-### Configuration
-
-These settings live under the `pipelineV2` block in `$SIGNET_WORKSPACE/agent.yaml`:
-
-| Key | Default | Description |
-|-----|---------|-------------|
-| `autonomousEnabled` | `false` | Enables autonomous mode and repair agent access |
-| `autonomousFrozen` | `false` | Hard freeze — blocks all repairs regardless of actor |
-| `maintenanceMode` | `"observe"` | `"observe"` or `"execute"` |
-| `maintenanceIntervalMs` | `1800000` (30 min) | How often the worker runs. Min 60s, max 24h |
-| `repairRequeueCooldownMs` | `60000` (1 min) | Cooldown for requeue/lease/sweep actions |
-| `repairRequeueHourlyBudget` | `50` | Max invocations per hour for those actions |
-| `repairReembedCooldownMs` | `300000` (5 min) | Cooldown for FTS consistency check |
-| `repairReembedHourlyBudget` | `10` | Max FTS checks per hour |
-| `leaseTimeoutMs` | `300000` (5 min) | Age at which a leased job is considered stale |
-
-Example configuration to enable execute mode with a 15-minute cycle:
+Autonomous maintenance is configured under `memory.pipelineV2.autonomous`:
 
 ```yaml
-pipelineV2:
-  autonomousEnabled: true
-  maintenanceMode: execute
-  maintenanceIntervalMs: 900000
+memory:
+  pipelineV2:
+    autonomous:
+      enabled: true
+      frozen: false
+      maintenanceIntervalMs: 1800000
+      maintenanceMode: observe
 ```
 
-Changes to these values take effect on the next pipeline restart. The
-maintenance worker captures config at startup and does not hot-reload, which
-ensures the rate limiter's cooldown windows remain consistent across a cycle.
+Use `observe` when introducing a deployment or investigating an incident. Set `frozen: true` to stop autonomous writes while preserving the configuration. The `repair` subobject sets cooldowns and hourly budgets for re-embed, requeue, and deduplication work.
+
+Restart after changing these values because pipeline workers are long-running.
+
+## Escalation order
+
+1. Capture status, readiness, diagnostics, and relevant daemon logs.
+2. Correct an unavailable provider, invalid config, network bind, or permission issue.
+3. Restart only when the evidence supports it.
+4. Use one narrow repair action if its precondition is satisfied.
+5. Re-run the same health checks and record the result.
+
+Never delete the database, auth secret, or workspace to make a health check go green. Preserve evidence and restore from a verified backup when integrity is actually compromised.
+
+Related: [Daemon](/daemon/), [Analytics](/analytics/), [Self-Hosting](/self-hosting/).

--- a/web/docs/src/content/docs/scheduling.md
+++ b/web/docs/src/content/docs/scheduling.md
@@ -1,281 +1,82 @@
 ---
 title: "Scheduled Tasks"
-description: "Schedule recurring agent prompts via cron-based daemon tasks."
+description: "Schedule recurring local harness prompts through the daemon."
 ---
 
-Schedule recurring agent prompts that the Signet [Daemon](/daemon/) executes
-automatically via Claude Code or OpenCode [CLI](/cli/).
+Scheduled tasks are daemon-owned cron jobs. A task stores a prompt, cron expression, harness, optional working directory, and optional skill settings; the daemon starts the configured local harness when it becomes due.
 
-## Overview
+## Create a task
 
-Scheduled tasks let you automate recurring agent workflows — PR
-reviews, code linting, status summaries, dependency checks, etc.
-The daemon evaluates cron expressions and spawns CLI processes on
-schedule.
-
-Source code: `platform/daemon/src/scheduler/`
-
-## Creating Tasks
-
-### Via Dashboard
-
-1. Open the Signet [Dashboard](/dashboard/) (http://localhost:3850)
-2. Navigate to the **Tasks** tab
-3. Click **+ New Task**
-4. Fill in the form:
-   - **Name**: descriptive label (e.g. "Review open PRs")
-   - **Prompt**: what the agent should do
-   - **Harness**: Claude Code or OpenCode
-   - **Schedule**: pick a preset or enter a custom cron expression
-   - **Working Directory**: optional project path for context
-5. Click **Create Task**
-
-### Via API
+Use the Dashboard Tasks surface or `POST /api/tasks`:
 
 ```bash
-curl -X POST http://localhost:3850/api/tasks \
+curl -X POST http://127.0.0.1:3850/api/tasks \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "Daily PR review",
-    "prompt": "Review all open pull requests and summarize findings",
+    "name": "Daily repository check",
+    "prompt": "Run the repository health check and report only actionable failures.",
     "cronExpression": "0 9 * * *",
-    "harness": "claude-code",
-    "workingDirectory": "/home/user/my-project"
+    "harness": "codex",
+    "workingDirectory": "/home/user/project"
   }'
 ```
 
-Required fields: `name`, `prompt`, `cronExpression`, `harness`.
+Required fields are `name`, `prompt`, `cronExpression`, and `harness`. Current task harnesses are `claude-code`, `codex`, and `opencode`.
 
-Optional fields: `workingDirectory`.
+Cron expressions use five fields: `minute hour day-of-month month day-of-week`.
 
-Supported harness values: `claude-code`, `opencode`.
+## Execution behavior
 
-## Cron Expressions
+- The scheduler polls for due tasks every 15 seconds.
+- It runs at most three tasks concurrently.
+- Each run receives an id and records captured output and terminal status.
+- Default runtime limit is 10 minutes.
+- Output is bounded to 1,048,576 characters.
+- A task already running is not started again.
+- On daemon startup, pending and running task records are marked failed with `daemon_restart` so they cannot block the next run.
 
-Standard 5-field cron syntax: `minute hour day-of-month month day-of-week`
+The spawned commands are intentionally non-interactive:
 
-### Presets
+| Harness     | Invocation shape                                    |
+| ----------- | --------------------------------------------------- |
+| Claude Code | `claude --dangerously-skip-permissions -p <prompt>` |
+| Codex       | `codex exec --skip-git-repo-check --json <prompt>`  |
+| OpenCode    | `opencode run --format json <prompt>`               |
 
-The dashboard offers these built-in presets (defined in
-`platform/daemon/src/scheduler/cron.ts`):
+The daemon verifies the harness binary is on `PATH`, removes `CLAUDECODE`, and sets `SIGNET_NO_HOOKS=1` for the child to prevent recursive hook activity. On timeout it sends termination and makes a second termination attempt five seconds later. Do not rely on task runs to clean up external work started by a prompt.
 
-| Preset | Expression |
-|--------|-----------|
-| Every 15 min | `*/15 * * * *` |
-| Hourly | `0 * * * *` |
-| Daily 9am | `0 9 * * *` |
-| Weekly Mon 9am | `0 9 * * 1` |
-
-Custom expressions are validated before saving using `cron-parser`.
-The `validateCron()` function returns `true` for valid expressions
-and `false` otherwise — invalid expressions are rejected at creation
-time.
-
-## Execution Model
-
-- The daemon polls every 15 seconds for due tasks
-- Maximum 3 concurrent task processes
-- Each run gets a unique UUID and captures stdout/stderr
-- Output is capped at 1 MB per stream (1,048,576 characters)
-- Default timeout: 10 minutes per task
-- Tasks that are already running are skipped (no double-execution)
-- On daemon restart, any in-progress runs are marked as failed
-
-### Process Commands
-
-The `spawnTask()` function in `platform/daemon/src/scheduler/spawn.ts`
-builds the CLI command based on the harness:
-
-- **Claude Code**: `claude --dangerously-skip-permissions -p "<prompt>"`
-- **OpenCode**: `opencode run --format json "<prompt>"`
-
-Before spawning, the function checks that the CLI binary exists on
-PATH via `Bun.which()`. If the binary isn't found, the run fails
-immediately with a `"CLI binary not found on PATH"` error.
-
-### Environment Isolation
-
-Spawned processes inherit the daemon's environment with two modifications:
-
-- `CLAUDECODE` is stripped to avoid nested-session detection
-- `SIGNET_NO_HOOKS` is set to `"1"` to prevent hook loops (Signet harness
-  integrations treat the spawned agent as a sterile background process)
-
-### Timeout Behavior
-
-When a task exceeds its timeout:
-
-1. `SIGTERM` is sent to the process
-2. After 5 additional seconds, `SIGKILL` is sent if still alive
-3. The run is recorded with `timedOut: true` and an error message
-
-### Startup Recovery
-
-When the daemon starts, the scheduler marks all `pending` and `running`
-task runs as `failed` with error `"daemon_restart"`. This prevents
-orphaned runs from blocking future executions.
-
-## Task Streaming
-
-The daemon provides real-time output streaming for running tasks via
-Server-Sent Events (SSE).
-
-### Endpoint
-
-```
-GET /api/tasks/:id/stream
-```
-
-Returns an SSE stream with the following event types:
-
-### Event Types
-
-**`connected`** — Sent immediately on connection.
-
-```json
-{
-  "type": "connected",
-  "taskId": "abc-123",
-  "timestamp": "2026-03-01T10:00:00.000Z"
-}
-```
-
-**`run-started`** — A new run has begun. Also sent as a replay if a
-run is already in progress when the client connects.
-
-```json
-{
-  "type": "run-started",
-  "taskId": "abc-123",
-  "runId": "def-456",
-  "startedAt": "2026-03-01T10:00:01.000Z",
-  "timestamp": "2026-03-01T10:00:01.000Z"
-}
-```
-
-**`run-output`** — A chunk of stdout or stderr from the running process.
-
-```json
-{
-  "type": "run-output",
-  "taskId": "abc-123",
-  "runId": "def-456",
-  "stream": "stdout",
-  "chunk": "Analyzing pull requests...\n",
-  "timestamp": "2026-03-01T10:00:05.000Z"
-}
-```
-
-**`run-completed`** — The run has finished.
-
-```json
-{
-  "type": "run-completed",
-  "taskId": "abc-123",
-  "runId": "def-456",
-  "status": "completed",
-  "completedAt": "2026-03-01T10:05:00.000Z",
-  "exitCode": 0,
-  "error": null,
-  "timestamp": "2026-03-01T10:05:00.000Z"
-}
-```
-
-### Replay on Connect
-
-When a client connects while a task is already running, the stream
-replays the current run state: a `run-started` event followed by
-buffered stdout/stderr chunks (up to 200,000 characters per stream).
-This lets late-joining clients catch up without missing output.
-
-### Buffer Management
-
-The in-memory buffer retains the most recent 200,000 characters per
-stream (stdout and stderr independently). When the buffer exceeds this
-limit, the oldest chunks are trimmed from the front. The buffer is
-cleared when a run completes.
-
-## API Endpoints
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/tasks` | GET | List all tasks with last run status |
-| `/api/tasks` | POST | Create a new task |
-| `/api/tasks/:id` | GET | Get task details + recent runs |
-| `/api/tasks/:id` | PATCH | Update task fields (name, prompt, cron, enabled, etc.) |
-| `/api/tasks/:id` | DELETE | Delete a task and its run history |
-| `/api/tasks/:id/run` | POST | Trigger immediate execution |
-| `/api/tasks/:id/runs` | GET | Paginated run history (`?limit=&offset=`) |
-| `/api/tasks/:id/stream` | GET | SSE stream of real-time task output |
-
-## Managing Tasks
-
-### Enable/Disable
-
-Toggle the switch on any task card in the dashboard, or via API:
+## Observe and operate
 
 ```bash
-curl -X PATCH http://localhost:3850/api/tasks/<id> \
+# List tasks
+curl -fsS http://127.0.0.1:3850/api/tasks
+
+# Inspect a task and recent runs
+curl -fsS http://127.0.0.1:3850/api/tasks/<id>
+
+# Trigger a run now
+curl -fsS -X POST http://127.0.0.1:3850/api/tasks/<id>/run
+
+# Disable a task
+curl -fsS -X PATCH http://127.0.0.1:3850/api/tasks/<id> \
   -H "Content-Type: application/json" \
-  -d '{"enabled": false}'
+  -d '{"enabled":false}'
 ```
 
-### Manual Run
+`GET /api/tasks/:id/stream` provides an SSE stream for the currently running task. `GET /api/tasks/:id/runs` returns run history with pagination.
 
-Trigger a task immediately without waiting for the next scheduled
-time. Click "Run Now" in the task detail panel or:
+## Security and safety
 
-```bash
-curl -X POST http://localhost:3850/api/tasks/<id>/run
-```
+Tasks run with the daemon's operating-system permissions. Claude Code tasks use its non-interactive permission bypass. Treat the prompt, working directory, installed harness, and daemon environment as part of the execution boundary.
 
-### Viewing Run History
-
-Click any task card in the dashboard to see its run history with
-stdout/stderr output. Or via API:
-
-```bash
-curl http://localhost:3850/api/tasks/<id>/runs?limit=20&offset=0
-```
-
-## Error Handling and Retry
-
-Tasks do **not** automatically retry on failure. Each run is a
-one-shot execution. If a run fails:
-
-1. The run status is set to `"failed"`
-2. The `error` field captures the reason (timeout, non-zero exit, spawn error)
-3. The task's `next_run_at` is still advanced to the next cron tick
-4. The task remains enabled and will execute again at the next scheduled time
-
-A run is considered failed when:
-- The process exits with a non-zero exit code
-- The `error` field on the `SpawnResult` is non-null (binary not found, spawn error)
-- The process times out
-
-Successful runs have `status: "completed"` and `exitCode: 0`.
-
-## Security
-
-Claude Code runs with `--dangerously-skip-permissions`, meaning
-tasks execute without user approval gates. The dashboard displays
-a warning when creating Claude Code tasks.
-
-Only schedule tasks you trust. The daemon runs them with the same
-permissions as the daemon process itself.
+Use an explicit working directory, a narrow prompt, and a named task. Do not schedule commands that require secrets in prompts or expect a human approval dialog. Prefer a connector, secret-managed service account, or an operator-run workflow for privileged external actions.
 
 ## Troubleshooting
 
-**Task not running?**
-- Check that the daemon is running (`signet status`)
-- Verify the CLI binary is on PATH (`which claude` or `which opencode`)
-- Check the task is enabled in the dashboard
+1. Check `signet daemon status --json` and task `enabled` state.
+2. Check the exact harness binary is on the daemon's `PATH`.
+3. Inspect the task's most recent run output and error.
+4. Confirm the working directory exists and the daemon user can access it.
+5. Verify the cron expression against the intended machine timezone.
 
-**Task failing?**
-- Open the task detail to view stdout/stderr from the last run
-- Check for timeout issues (default 10 minutes)
-- Verify the working directory exists and is accessible
-
-**Daemon restart clears running tasks?**
-- This is expected — in-progress runs are marked as failed on restart
-- The task will be picked up again at the next scheduled time
+Related: [Daemon](/daemon/), [Diagnostics](/diagnostics/), [Secrets](/secrets/).

--- a/web/docs/src/content/docs/secrets.md
+++ b/web/docs/src/content/docs/secrets.md
@@ -1,328 +1,77 @@
 ---
 title: "Secrets"
-description: "Encrypted storage for API keys and sensitive values."
+description: "Store and use sensitive values without writing them into configuration or prompts."
 ---
 
-Encrypted storage for API keys and sensitive values. Agents can *use*
-secrets without being able to read or expose them. The capability is owned by
-the bundled `signet.secrets` core plugin.
+Signet secrets are daemon-managed encrypted values. The CLI and API deliberately expose names and status, not raw stored values.
 
----
-
-## How It Works
-
-The core problem with AI agents and secrets: if an agent can read `OPENAI_API_KEY` from the environment, a prompt injection attack or a careless response could leak it.
-
-Signet's solution: secrets are encrypted at rest, and agents never receive
-decrypted values. When a secret is needed (for embeddings, tool calls, etc.),
-the [Daemon](/daemon/) resolves it internally, either by using the value directly in
-API calls or by injecting it into a subprocess environment that the agent
-cannot inspect.
-
-`signet.secrets` is the privileged core plugin for the capability. In V1 it
-registers plugin diagnostics, surface metadata, and a local provider that
-adopts the existing encrypted store in place. Secret operations emit
-structured daemon diagnostics such as `secret.listed`, `secret.stored`,
-`secret.deleted`, `secret.resolved_for_exec`, `secret.exec_started`, and
-`secret.exec_completed`; payloads include names or counts where current API
-policy already exposes them, but never raw values. Plugin lifecycle,
-capability-denial, and secret-provider events are also appended to
-`$SIGNET_WORKSPACE/.daemon/plugins/audit-v1.ndjson` with sensitive fields
-redacted before storage.
-
-Secrets API routes are guarded by the plugin registry. If `signet.secrets`
-is disabled, blocked, or missing the required grant for a route, the daemon
-returns a structured plugin-capability error. Stored secret files are left
-in place.
-
-### Setup defaults
-
-Existing installs default to Signet Secrets enabled, even if they do not yet
-have a plugin registry file. New interactive installs include a **Core
-plugins** step that explains what Signet Secrets stores, how it connects to
-Signet's encrypted local store and compatible 1Password references, which
-value-safe surfaces it enables, and why that is safer than putting credentials
-in prompts, shell history, logs, or source files.
-
-For non-interactive setup, Signet Secrets is enabled by default. Use
-`signet setup --disable-signet-secrets` to leave the bundled plugin installed
-but disabled. Disabling the plugin blocks secret API routes and tool surfaces
-without deleting existing encrypted secret files.
-
----
-
-## Storage
-
-```
-$SIGNET_WORKSPACE/
-└── .secrets/
-    └── secrets.enc     # Encrypted secret store (JSON, mode 0600)
-```
-
-The `secrets.enc` file is JSON, but every value is encrypted individually. It's readable by humans as a list of names and metadata, but the actual values are ciphertext.
-
-The local provider keeps this file format unchanged. Existing
-`$SIGNET_WORKSPACE/.secrets/secrets.enc` files remain valid without
-migration, re-encryption, relocation, or user action. Bare secret names are
-compatibility aliases for local references:
-
-```text
-OPENAI_API_KEY == local://OPENAI_API_KEY
-```
-
-### Encryption
-
-- **Algorithm:** XSalsa20-Poly1305 via libsodium (`crypto_secretbox_easy`)
-- **Key derivation:** BLAKE2b hash of `signet:secrets:<machine-id>` stretched to 32 bytes
-- **Machine ID:** reads `/etc/machine-id` (Linux) or `IOPlatformUUID` (macOS); falls back to `hostname-username`
-- **Nonces:** random, prepended to each ciphertext
-- **File permissions:** `0600` (owner read/write only)
-
-The master key is bound to the machine, so the encrypted file cannot be decrypted on another computer without the same machine ID.
-
----
-
-## [CLI](/cli/) Commands
-
-### Add a secret
+## Basic commands
 
 ```bash
+# Prompt for a value without echoing it
 signet secret put OPENAI_API_KEY
-# Prompts: Enter value: ••••••••
-# ✓ Secret OPENAI_API_KEY saved
-```
 
-The value is never echoed. Prompt input is hidden.
-
-### List secrets
-
-```bash
+# Names only
 signet secret list
-# OPENAI_API_KEY
-# ANTHROPIC_API_KEY
-# GITHUB_TOKEN
-```
-
-Only names are shown — never values.
-
-### Check if a secret exists
-
-```bash
 signet secret has OPENAI_API_KEY
-# true
+
+# Confirmation is required
+signet secret delete OPENAI_API_KEY
 ```
 
-### Delete a secret
-
-```bash
-signet secret delete GITHUB_TOKEN
-# ✓ Secret GITHUB_TOKEN deleted
-```
-
-### 1Password integration
-
-```bash
-# Connect using a service account token (prompted if omitted)
-signet secret onepassword connect
-
-# Check status and list vaults
-signet secret onepassword status
-signet secret onepassword vaults
-
-# Import password-like fields from selected vaults
-signet secret onepassword import --vault Engineering --prefix OP
-
-# Disconnect and remove stored service account token
-signet secret onepassword disconnect
-```
-
-Imported values are stored as regular Signet secrets with generated names,
-and `secret_exec` can also reference 1Password secrets directly via
-`op://vault/item/field` when connected.
-
-
-### Bitwarden provider
-
-Bitwarden is opt-in. By default, Signet continues to use the existing local encrypted `secrets.enc` store. After connecting Bitwarden, you can either keep using local Signet secrets or make Bitwarden the active provider for future `put`, `list`, `delete`, config resolution, and secret exec references.
-
-Signet uses the official Bitwarden CLI session model: log in/unlock with `bw`, then hand Signet the short-lived session token.
-
-```bash
-# One-time Bitwarden CLI login outside Signet
-bw login
-
-# Connect but keep the local Signet store active. The session token is read
-# from stdin so it is not written to shell history or process argv.
-bw unlock --raw | signet secret bitwarden connect --session-stdin
-
-# Connect and immediately make Bitwarden the active backing store
-bw unlock --raw | signet secret bitwarden connect --session-stdin --activate
-
-# Switch providers later without losing either store
-signet secret bitwarden use bitwarden
-signet secret bitwarden use local
-
-# Copy existing local Signet secrets into Bitwarden
-signet secret bitwarden migrate          # dry run
-signet secret bitwarden migrate --write  # copy, keep local copies
-signet secret bitwarden migrate --write --delete-local
-```
-
-When Bitwarden is active, Signet stores new secrets as Bitwarden login items and resolves bare `$secret:NAME` references from Bitwarden first, falling back to local Signet secrets for backwards compatibility. Explicit `bw://name/NAME` and `bw://item/ITEM_ID/password` references are also accepted. Internal Signet provider credentials remain in the local encrypted store so connecting Bitwarden does not create a circular dependency.
-
-### Export / import (planned)
-
-```bash
-signet secret export > secrets.enc.backup
-signet secret import < secrets.enc.backup
-```
-
----
-
-## Dashboard UI
-
-The [Dashboard](/dashboard/)'s **Settings -> Secrets** panel lets you:
-
-- View all secret names (values always masked as `•••••`)
-- Add new secrets via an input form
-- Delete secrets
-- Connect/disconnect a 1Password service account token
-- Select vaults and import password-like fields into Signet secrets
-
-There is intentionally no "reveal" button — the UI never has access to secret values.
-
----
-
-## Using Secrets in Config
-
-Reference a stored secret in `agent.yaml` with the `$secret:NAME` syntax:
+Use a stored value from `agent.yaml` by reference:
 
 ```yaml
 embedding:
-  provider: openai
-  model: text-embedding-3-small
   api_key: $secret:OPENAI_API_KEY
 ```
 
-The daemon resolves `$secret:NAME` references internally when making API calls. The actual value never appears in the config file or the agent's context.
+Do not place provider keys directly in YAML, shell history, screenshots, task prompts, or source control.
 
----
+## Use a secret in a command
 
-## Executing Commands with Secrets
+`signet secret exec` queues a command with selected secrets injected into the child environment. The command must name each injected secret before the command token:
 
-The daemon queues a subprocess with secrets injected into its environment. The agent provides references (names), not values.
-
-**HTTP API:**
-
-```http
-POST /api/secrets/exec
-Content-Type: application/json
-
-{
-  "command": "curl https://api.openai.com/v1/models",
-  "secrets": {
-    "OPENAI_API_KEY": "OPENAI_API_KEY",
-    "DB_PASSWORD": "op://Engineering/Prod DB/password"
-  }
-}
+```bash
+signet secret exec --secret OPENAI_API_KEY \
+  curl https://api.openai.com/v1/models
 ```
 
-The map is `{ env_var_name: secret_reference }` where a reference can be a
-stored Signet secret name, a Bitwarden `bw://...` reference, or a 1Password `op://...` reference. The daemon:
-1. Resolves each secret reference to its value
-2. Queues the subprocess with the resolved values in the environment
-3. Enforces a bounded timeout (5 minutes by default, max 30 minutes)
-4. Returns HTTP `202` immediately with a job id
-5. Exposes redacted stdout/stderr and exit code through `GET /api/secrets/exec/:jobId`
+The CLI returns a job id. Inspect it with:
 
-Secret exec is always queued; there is no synchronous request mode. This keeps
-large jobs such as SSH/rsync transfers from tying daemon request handling to
-subprocess lifetime. Pass optional `"timeoutMs"` to bound the background job.
-The daemon also bounds the secret exec worker pool and pending queue, terminates
-the subprocess process group on timeout, and redacts output before truncating it.
-
-**Queued response:**
-
-```json
-{
-  "id": "uuid",
-  "status": "queued",
-  "createdAt": "...",
-  "timeoutMs": 300000
-}
+```bash
+signet secret exec-status <job-id>
 ```
 
-When the job completes, if a secret value appears anywhere in stdout or stderr, it is replaced with `[REDACTED]`.
+The command line is constructed so shell-level secret expansion is not used. Treat the child process, its output, and its working directory as sensitive anyway: a process that can read an injected environment variable can disclose it.
 
-Provider-qualified local refs are accepted wherever secret references are
-accepted:
+## External providers
 
-```json
-{
-  "OPENAI_API_KEY": "local://OPENAI_API_KEY"
-}
+The current CLI supports 1Password and Bitwarden integrations in addition to the local encrypted provider.
+
+```bash
+# 1Password service-account flow
+signet secret onepassword connect
+signet secret onepassword status
+signet secret onepassword vaults
+
+# Bitwarden session flow
+bw unlock --raw | signet secret bitwarden connect --session-stdin
+signet secret bitwarden status
+signet secret bitwarden use local
+signet secret bitwarden use bitwarden
 ```
 
----
+Use an integration only when its access boundary matches the deployment. Keep its service token or session token out of process arguments and committed files.
 
-## Security Model
+## Storage and recovery
 
-**What the daemon does:**
-- Reads the machine ID from `/etc/machine-id` or equivalent
-- Derives a 32-byte master key using BLAKE2b
-- Encrypts each secret value with a random nonce
-- Stores ciphertext in `$SIGNET_WORKSPACE/.secrets/secrets.enc` at `0600`
+Local secret state is kept under `$SIGNET_WORKSPACE/.secrets/`. Keep this directory private and out of source control. Secret values are intentionally not available through a `get` command; `signet secret get NAME` explains how to use an existing reference instead.
 
-**What agents can't do:**
-- Read secret values from config files or environment
-- Inspect subprocess environments
-- Enumerate secret values through the API (only names)
-- Access the `GET /api/secrets/:name` route (there is none — only `POST`, `DELETE`, and `GET /api/secrets` for names)
-- Retrieve raw values through SDK, MCP, dashboard, connector, or plugin
-  diagnostics responses
+Moving a workspace to a different machine or restoring it from backup is a security-sensitive operation. Verify the recovered secret provider state before restarting automation. Do not hand-copy ciphertext or reset secret files to troubleshoot a provider issue.
 
-**What you should know:**
-- The master key is machine-bound, not passphrase-protected by default. If someone has shell access as your user, they can derive the key.
-- Passphrase-protected keys are planned for a future version.
-- Don't commit `$SIGNET_WORKSPACE/.secrets/` to version control. Add it to `.gitignore`.
-- Secrets are zeroed from memory (best-effort in JavaScript) after use.
+## API boundary
 
----
+The daemon exposes list, store, delete, execution, and external-provider status routes under `/api/secrets`. These routes are permission-protected in authenticated deployments. Use the CLI for ordinary operation and the [HTTP API](/api/) when building a controlled integration.
 
-## API Reference
-
-The full secrets API is documented in the
-[Runtime extensions API](/api/runtime-extensions/#secrets). Summary:
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/secrets` | GET | List secret names |
-| `/api/secrets/:name` | POST | Store a secret |
-| `/api/secrets/:name` | DELETE | Delete a secret |
-| `/api/secrets/exec` | POST | Queue command with one or more secrets injected |
-| `/api/secrets/exec/:jobId` | GET | Inspect queued secret exec job status |
-| `/api/secrets/:name/exec` | POST | Legacy single-secret queued exec |
-| `/api/secrets/bitwarden/status` | GET | Bitwarden provider status |
-| `/api/secrets/bitwarden/connect` | POST | Connect/save Bitwarden CLI session |
-| `/api/secrets/bitwarden/connect` | DELETE | Disconnect/remove stored Bitwarden session |
-| `/api/secrets/bitwarden/provider` | POST | Switch active provider (`local` or `bitwarden`) |
-| `/api/secrets/bitwarden/folders` | GET | List Bitwarden folders |
-| `/api/secrets/bitwarden/migrate` | POST | Copy local Signet secrets into Bitwarden |
-| `/api/secrets/1password/status` | GET | 1Password integration status |
-| `/api/secrets/1password/connect` | POST | Connect/save service account token |
-| `/api/secrets/1password/connect` | DELETE | Disconnect/remove stored token |
-| `/api/secrets/1password/vaults` | GET | List accessible 1Password vaults |
-| `/api/secrets/1password/import` | POST | Import vault secrets into Signet |
-| `/api/plugins` | GET | List plugin registry records, including `signet.secrets` |
-| `/api/plugins/audit` | GET | List redacted durable plugin audit events |
-| `/api/plugins/signet.secrets/diagnostics` | GET | Inspect Secrets plugin diagnostics and surface metadata |
-
----
-
-## Planned Improvements
-
-- **Passphrase protection** — optional user passphrase added to key derivation (Argon2)
-- **OS keychain backend** — macOS Keychain, GNOME Keyring, Windows Credential Manager
-- **Export/import** — encrypted backup bundles for moving between machines
-- **Team secrets** — shared encrypted secrets via asymmetric encryption
-- **Audit log** — log of secret usage (not values)
+Related: [Authentication](/auth/), [Self-Hosting](/self-hosting/), [Remote Harness Connectors](/remote-connectors/).

--- a/web/docs/src/content/docs/self-hosting.md
+++ b/web/docs/src/content/docs/self-hosting.md
@@ -1,48 +1,11 @@
 ---
 title: "Self-Hosting"
-description: "Self-hosting the Signet daemon."
+description: "Run Signet with the first-party Docker deployment and secure the daemon boundary."
 ---
 
-The Signet [Daemon](/daemon/) is a Hono HTTP server that runs as a background service,
-providing [Memory](/memory/) storage, search, and the web [Dashboard](/dashboard/). By default it
-binds to `localhost:3850` and requires no [authentication](/auth/). This document
-covers everything needed to run it persistently, expose it to a team, and
-keep it healthy in production.
+Use the first-party Docker deployment when you need a persistent, self-hosted Signet daemon. It includes the daemon, Caddy reverse proxy, persistent volumes, health checks, and a team-auth bootstrap.
 
-
-## Overview
-
-The daemon process is a single Bun-targeted binary at
-`platform/daemon/dist/daemon.js`. It owns two things: the SQLite database
-at `$SIGNET_WORKSPACE/memory/memories.db` and the config directory at `$SIGNET_WORKSPACE/`.
-Everything else — file watching, the memory pipeline, the dashboard —
-runs inside that one process.
-
-Environment variables control the network address:
-
-- `SIGNET_HOST` — daemon host for local calls and default bind address (default: `127.0.0.1`)
-- `SIGNET_BIND` — explicit bind address override (default: `SIGNET_HOST`)
-- `SIGNET_PORT` — port to listen on (default: `3850`)
-- `SIGNET_PATH` — override the data directory (default: `$SIGNET_WORKSPACE/`)
-- `SIGNET_LOG_FILE` — optional explicit daemon log file path
-- `SIGNET_SQLITE_PATH` — macOS explicit override for a custom `libsqlite3.dylib`
-
-Bun is a hard requirement. The daemon uses `bun:sqlite` directly and will
-refuse to start under Node.
-
-On macOS, `SIGNET_SQLITE_PATH` is authoritative when set. If it points
-at a missing file, Signet refuses fallback so the misconfiguration is
-obvious. If it is unset, Signet checks
-`$SIGNET_WORKSPACE/libsqlite3.dylib`, where the workspace resolves from
-`SIGNET_PATH`, then `~/.config/signet/workspace.json`, then the default
-`~/.agents`, and then standard Homebrew SQLite paths so `sqlite-vec`
-can load before the first Bun connection opens.
-
-
-## Docker Compose (first-party)
-
-Signet now ships a first-party Docker stack in `deploy/docker/` for
-self-hosted daemon deployments:
+## Docker Compose quick start
 
 ```bash
 cd deploy/docker
@@ -50,503 +13,81 @@ cp .env.example .env
 docker compose up -d --build
 ```
 
-This stack includes:
+The stack stores the Signet workspace in the `signet_data` volume at `/data/agents` in the container and publishes Caddy on ports 80 and 443 by default. Open the health endpoint locally:
 
-- `signet` service (daemon runtime)
-- `caddy` reverse proxy (TLS-capable, SSE-safe)
-- named Docker volumes for persistent workspace and proxy state
+```bash
+curl -fsS http://localhost/health
+```
 
-The container entrypoint creates `$SIGNET_WORKSPACE/agent.yaml` with
-`auth.mode: team` on first start when no config exists. To generate an
-initial admin token from the auth secret, run:
+The supplied compose configuration binds the daemon inside the stack and Caddy is the published entry point. Do not publish port 3850 directly unless you have an explicit private-network design and matching authentication.
+
+## First admin credential
+
+The container entrypoint initializes `auth.mode: team` on first run when no configuration exists. Mint an initial admin token inside the running service:
 
 ```bash
 docker compose exec signet \
   bun /app/deploy/docker/scripts/create-token.mjs --role admin --sub bootstrap
 ```
 
-The command prints a bearer token to stdout. Store it securely and use it
-for admin API calls (for example `/api/auth/token` to mint scoped
-operator/agent tokens).
+The token is printed once. Store it in an approved secret manager, then create narrowly scoped keys or tokens for real clients. See [Authentication](/auth/) and [Remote Harness Connectors](/remote-connectors/).
 
-By default, Compose publishes Caddy on ports 80/443. Override
-`SIGNET_HTTP_PORT` and `SIGNET_HTTPS_PORT` in `.env` when those ports are
-already occupied.
+## Configure the proxy
 
-
-## Running as a Service
-
-The easiest path is the CLI:
-
-```bash
-signet daemon install   # installs and starts the service
-signet daemon uninstall # stops and removes it
-```
-
-The install command detects the platform and writes the appropriate service
-definition, then starts it. Under the hood, it generates the unit file from
-the actual runtime path (`which bun`) and the installed daemon path, so the
-service file always reflects the current installation.
-
-### systemd (Linux)
-
-The CLI writes a user-level unit file to
-`~/.config/systemd/user/signet.service` with `Restart=on-failure` and
-`RestartSec=5`. The unit looks like this:
-
-```ini
-[Unit]
-Description=Signet Daemon
-After=network.target
-
-[Service]
-Type=simple
-ExecStart=/usr/bin/bun /path/to/daemon.js
-Environment=SIGNET_PORT=3850
-Environment=SIGNET_PATH=/home/you/.agents
-WorkingDirectory=/home/you/.agents
-Restart=on-failure
-RestartSec=5
-StandardOutput=append:/home/you/.agents/.daemon/logs/daemon.out.log
-StandardError=append:/home/you/.agents/.daemon/logs/daemon.err.log
-
-[Install]
-WantedBy=default.target
-```
-
-To manage it manually after installation:
-
-```bash
-systemctl --user status signet.service
-systemctl --user restart signet.service
-journalctl --user -u signet.service -f
-```
-
-For the service to survive logout on headless servers, you need lingering
-enabled for your user:
-
-```bash
-loginctl enable-linger $USER
-```
-
-### launchd (macOS)
-
-The CLI writes a plist to
-`~/Library/LaunchAgents/ai.signet.daemon.plist` with `KeepAlive` and
-`RunAtLoad` set to true, so it starts at login and restarts on crash.
-Stdout and stderr go to `$SIGNET_WORKSPACE/.daemon/logs/`.
-
-```bash
-launchctl list ai.signet.daemon   # check status
-launchctl unload ~/Library/LaunchAgents/ai.signet.daemon.plist
-launchctl load ~/Library/LaunchAgents/ai.signet.daemon.plist
-```
-
-The generated plist hard-codes the Bun path as `/opt/homebrew/bin/bun` for
-Apple Silicon. If Bun is installed elsewhere, either re-run
-`signet daemon install` after updating `PATH`, or edit the plist manually.
-
-
-## Team Mode Deployment
-
-By default the daemon runs in `local` mode: no authentication, no rate
-limiting, localhost only. For shared deployments you switch to `team` mode,
-which requires a bearer token on every request.
-
-Add an `auth` block to `$SIGNET_WORKSPACE/agent.yaml`:
-
-```yaml
-auth:
-  mode: team
-```
-
-Then restart the daemon. On first start with a non-local mode, the daemon
-generates a 32-byte HMAC secret at `$SIGNET_WORKSPACE/.daemon/auth-secret` with
-permissions `0600`. All tokens are signed against this secret. Rotating the
-secret invalidates all existing tokens.
-
-### Generating tokens
-
-Tokens are created via the API. In `team` mode you need an existing admin
-token to create more; on first setup, you can temporarily switch to
-`hybrid` mode (which grants full access from localhost without a token) to
-bootstrap.
-
-```bash
-curl -s -X POST http://localhost:3850/api/auth/token \
-  -H "Content-Type: application/json" \
-  -d '{
-    "role": "agent",
-    "sub": "ci-runner",
-    "ttlSeconds": 2592000
-  }'
-```
-
-The response contains a `token` field. Distribute this string to the
-consumer. All subsequent requests must include it as a bearer token:
-
-```
-Authorization: Bearer <token>
-```
-
-Tokens carry a `sub` (subject identifier), a `role`, a `scope`, and an
-expiry. The token format is `{base64url(claims)}.{base64url(hmac-sha256)}`
-— no external JWT library, no key infrastructure needed beyond the secret
-file.
-
-### Roles and permissions
-
-Four roles are supported. Each grants a fixed set of permissions:
-
-| Role       | Permissions |
-|------------|-------------|
-| `admin`    | all, including token creation and admin operations |
-| `operator` | remember, recall, modify, forget, recover, documents, connectors, diagnostics, analytics |
-| `agent`    | remember, recall, modify, forget, recover, documents |
-| `readonly` | recall only |
-
-Scope restrictions can narrow a token further. A token scoped to
-`project: acme` will be rejected when accessing memories tagged to a
-different project. Admin tokens bypass all scope checks.
-
-```bash
-# Scoped token for a specific agent
-curl -s -X POST http://localhost:3850/api/auth/token \
-  -H "Authorization: Bearer <admin-token>" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "role": "agent",
-    "sub": "claude-code:acme",
-    "scope": { "project": "acme" },
-    "ttlSeconds": 86400
-  }'
-```
-
-Default token TTL is 7 days. Session tokens (issued by hook endpoints) are
-24 hours. Both are configurable in `agent.yaml`:
-
-```yaml
-auth:
-  mode: team
-  defaultTokenTtlSeconds: 604800   # 7 days
-  sessionTokenTtlSeconds: 86400    # 24 hours
-```
-
-### Rate limits
-
-In `team` and `hybrid` modes, destructive operations are rate-limited per
-actor (the token's `sub` field) using an in-memory sliding window. Defaults:
-
-| Operation    | Window | Max requests |
-|--------------|--------|--------------|
-| `forget`     | 60s    | 30           |
-| `modify`     | 60s    | 60           |
-| `batchForget`| 60s    | 5            |
-| `forceDelete`| 60s    | 3            |
-| `admin`      | 60s    | 10           |
-| `inferenceExplain` | 60s | 120        |
-| `inferenceExecute` | 60s | 20         |
-| `inferenceGateway` | 60s | 30         |
-| `recallLlm`  | 60s    | 60           |
-
-These can be overridden in `agent.yaml`:
-
-```yaml
-auth:
-  mode: team
-  rateLimits:
-    forget:
-      windowMs: 60000
-      max: 10
-```
-
-Rate limit state is in-memory and resets on daemon restart.
-
-
-## Hybrid Mode
-
-`hybrid` mode gives you the convenience of `local` mode for local tooling
-while requiring tokens from remote clients. Requests arriving with a
-TCP peer address of `127.0.0.1`, `::1`, or `::ffff:127.0.0.1` bypass
-authentication entirely and receive full admin-equivalent access. All
-other clients must present a valid bearer token.
-
-```yaml
-auth:
-  mode: hybrid
-```
-
-This is a practical default for development machines where you want the
-local dashboard and CLI to work without tokens, but also want to call the
-daemon from CI pipelines or remote agents. The localhost bypass is checked
-against the actual socket peer address, not the `Host` header. For
-anything exposed to untrusted networks, use `team` mode with a reverse
-proxy.
-
-
-## Network Configuration
-
-The daemon is HTTP-only. TLS must be terminated upstream.
-
-To bind to all interfaces (required when using a reverse proxy on the same
-host, or when hosting on a VM):
-
-```bash
-SIGNET_HOST=0.0.0.0 SIGNET_PORT=3850 bun daemon.js
-```
-
-Or set it in the systemd unit:
-
-```ini
-Environment=SIGNET_HOST=0.0.0.0
-Environment=SIGNET_PORT=3850
-```
-
-Never expose port 3850 directly to the internet in `local` or `hybrid`
-mode. Use `team` mode plus a reverse proxy that terminates TLS.
-
-
-## Reverse Proxy
-
-### nginx
-
-```nginx
-server {
-    listen 443 ssl;
-    server_name signet.example.com;
-
-    ssl_certificate     /etc/letsencrypt/live/signet.example.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/signet.example.com/privkey.pem;
-
-    location / {
-        proxy_pass         http://127.0.0.1:3850;
-        proxy_set_header   Host $host;
-        proxy_set_header   X-Real-IP $remote_addr;
-        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Proto $scheme;
-
-        # SSE support
-        proxy_buffering    off;
-        proxy_read_timeout 3600s;
-    }
-}
-```
-
-### Caddy
+Set these values in `deploy/docker/.env` before production use:
 
 ```text
-signet.example.com {
-    reverse_proxy localhost:3850 {
-        flush_interval -1
-    }
-}
+SIGNET_DOMAIN=signet.example.com
+SIGNET_IMAGE_TAG=latest
+SIGNET_HTTP_PORT=80
+SIGNET_HTTPS_PORT=443
 ```
 
-Caddy handles TLS automatically via Let's Encrypt. The `flush_interval -1`
-directive is needed for the `/sse` endpoint to stream events correctly
-without buffering.
+Caddy terminates TLS for a real public domain. Keep `auth.mode: team` for a public or shared deployment. `hybrid` is for trusted local workflows and should not be used as the only boundary behind a reverse proxy.
 
-In both cases, set `auth.mode: team` in `agent.yaml` before exposing the
-daemon. Hybrid mode's localhost bypass does not apply when the request
-arrives through a proxy — the `Host` header will be the public hostname,
-not `localhost`.
+Provider credentials are optional compose environment values. Prefer the Signet secret store and `$secret:NAME` configuration references for durable operator configuration; do not commit a populated `.env` file.
 
-
-## Backup and Restore
-
-All persistent state lives in two places:
-
-- `$SIGNET_WORKSPACE/memory/memories.db` — the SQLite database
-- `$SIGNET_WORKSPACE/` — config files, secrets, skills
-
-The database runs in WAL mode, which makes it safe to copy while the
-daemon is running. A simple backup:
+## Health and operations
 
 ```bash
-cp $SIGNET_WORKSPACE/memory/memories.db /backup/memories-$(date +%Y%m%d).db
+docker compose ps
+docker compose logs -f signet
+curl -fsS http://localhost/health
 ```
 
-For a full backup including config and the auth secret:
+For deeper readiness and diagnostics, authenticate as needed and use the daemon endpoints documented in [Daemon](/daemon/) and [Diagnostics](/diagnostics/).
+
+## Backup and upgrade
+
+Back up the named workspace volume before a major version change. The Docker deployment keeps configuration, the database, and daemon state under `/data/agents`.
 
 ```bash
-rsync -a $SIGNET_WORKSPACE/ /backup/agents-$(date +%Y%m%d)/
+# Pull the configured image tag and recreate services
+docker compose pull
+docker compose up -d
 ```
 
-The auth secret lives at `$SIGNET_WORKSPACE/.daemon/auth-secret` (binary, 32
-bytes, mode `0600`). Back it up with your config. Losing it invalidates all
-issued tokens.
+Follow the release-specific checks in [Upgrading](/upgrading/) and confirm readiness after restart. Do not discard the volume to work around a migration error.
 
-To restore, stop the daemon, copy the files back, and restart:
+## Host-managed deployments
+
+A host service manager can run the daemon directly, but it must provide a stable runtime, one writer per workspace, explicit `SIGNET_PATH`, explicit bind behavior, and restart-safe health checks. The CLI lifecycle commands are:
 
 ```bash
-systemctl --user stop signet.service
-rsync -a /backup/agents-20260101/ $SIGNET_WORKSPACE/
-systemctl --user start signet.service
+signet daemon start
+signet daemon stop
+signet daemon restart
+signet daemon status --json
 ```
 
-For scheduled backups, a daily cron that copies the database and rotates
-old copies is sufficient. Incremental WAL checkpoints happen automatically
-during normal operation.
+Use a service supervisor you already operate rather than copying an outdated unit file. Verify `/health/live` and `/health/ready` after every deployment.
 
+## Security checklist
 
-## Monitoring
+- Bind to loopback by default. Use `network.mode: tailscale` or an explicit `SIGNET_BIND` only for a trusted network design.
+- Use `auth.mode: team` for shared, proxied, or public access.
+- Use one named API key per connector or automation client, then revoke it when the client is retired.
+- Keep the workspace volume, `.daemon/`, and `.secrets/` private and backed up.
+- Do not put raw tokens, passwords, or provider keys in source control, issue trackers, or screenshots.
 
-### Health check
-
-```
-GET /health
-```
-
-Returns HTTP 200 with JSON `{ status: "healthy", uptime: <seconds>, pid: <int> }`.
-Use this for load balancer health checks and uptime monitors. It has no
-authentication requirement regardless of auth mode.
-
-### Diagnostics
-
-```
-GET /api/diagnostics
-```
-
-Returns a scored health report covering database integrity, FTS consistency,
-embedding provider status, memory pipeline state, and mutation health.
-Requires the `diagnostics` permission (available to `admin` and `operator`
-roles).
-
-### Analytics
-
-```
-GET /api/analytics/usage    # request counts by route and method
-GET /api/analytics/errors   # pipeline errors, filterable by stage
-GET /api/analytics/latency  # p50/p95/p99 latency histograms
-GET /api/analytics/logs     # recent structured log entries
-```
-
-All analytics endpoints require the `analytics` permission. Data is
-collected in-memory and resets on daemon restart. For durable metrics,
-scrape these endpoints on a schedule and push to your monitoring stack.
-
-A quick check to confirm the daemon is healthy and the pipeline is running:
-
-```bash
-curl -s http://localhost:3850/health | jq .
-curl -s http://localhost:3850/api/diagnostics | jq '.score'
-```
-
-
-## Troubleshooting
-
-### Daemon won't start
-
-Check whether the port is already in use:
-
-```bash
-ss -tlnp | grep 3850
-lsof -i :3850
-```
-
-If another process holds the port, either stop it or change `SIGNET_PORT`.
-If the daemon starts then immediately exits, check the log file:
-
-```bash
-tail -50 $SIGNET_WORKSPACE/.daemon/logs/daemon.out.log
-tail -50 $SIGNET_WORKSPACE/.daemon/logs/daemon.err.log
-```
-
-The most common cause is Bun not being found. The systemd unit and launchd
-plist hard-code the Bun path detected at install time. If Bun was moved or
-reinstalled, re-run `signet daemon install` to regenerate the service file.
-
-### Auth issues
-
-If requests return `401 authentication required`, confirm the auth mode:
-
-```bash
-curl -s http://localhost:3850/api/auth/status | jq .mode
-```
-
-If the mode is `team` or `hybrid`, the request needs a valid bearer token.
-Tokens expire — check the `exp` field by base64-decoding the first segment
-of the token:
-
-```bash
-TOKEN="<your-token>"
-echo "${TOKEN%%.*}" | base64 -d 2>/dev/null | jq .exp
-```
-
-Compare the epoch value against `date +%s`. If expired, generate a new
-token. If you've lost all admin tokens, temporarily set `auth.mode: local`
-in `agent.yaml`, restart the daemon, generate a new admin token, then
-switch back to `team` mode.
-
-### Pipeline not processing
-
-First check whether extraction is intentionally disabled:
-
-```yaml
-memory:
-  pipelineV2:
-    enabled: false
-    extraction:
-      provider: none
-```
-
-If `provider: none` is set, or `enabled: false`, the pipeline staying
-idle is expected. This is the recommended configuration for VPS installs
-that should not make background LLM calls.
-
-If extraction is enabled and using Ollama, confirm the server is
-running and the model is pulled:
-
-```bash
-curl -s http://localhost:11434/api/tags | jq '.models[].name'
-```
-
-The recommended local model is `nemotron-3-nano:4b`. `qwen3:4b` is deprecated — Nemotron's superior reasoning produces better extraction quality and `qwen3:4b` will be removed in a future update. If neither is listed:
-
-```bash
-ollama pull qwen3:4b
-# or
-ollama pull nemotron-3-nano:4b
-```
-
-If Ollama is running but the pipeline is still idle, check whether it is
-enabled in `agent.yaml`:
-
-```yaml
-memory:
-  pipelineV2:
-    enabled: true
-```
-
-`shadowMode: true` means the pipeline extracts but does not write to the
-database — useful for testing, but memories will not persist. Set it to
-`false` for production operation.
-
-Cost warning: the intended extraction setups are Claude Code on Haiku,
-Codex CLI on gpt-5.4-mini with a Pro/Max subscription, or local Ollama.
-Remote API extraction can create extreme fees quickly if left running in
-the background.
-
-### High memory usage
-
-If the daemon process grows unboundedly, retention is likely not running or
-the embedding index has accumulated too many orphaned entries. Check
-diagnostics:
-
-```bash
-curl -s http://localhost:3850/api/diagnostics | jq '{score, memory, mutation}'
-```
-
-A low score in the `memory` domain often means retention sweeps have
-stopped. Restarting the daemon triggers a fresh sweep on startup. If the
-issue persists, check for stale job leases in the pipeline queue — the
-`GET /api/diagnostics` response includes queue depth and lease counts.
-
-For embeddings specifically: each memory stores a vector, and deleted
-memories leave tombstones until the next retention run. If tombstone count
-is high, trigger a repair manually:
-
-```bash
-curl -s -X POST http://localhost:3850/api/repair/requeue-dead-jobs \
-  -H "Authorization: Bearer <admin-token>"
-```
+Related: [Daemon](/daemon/), [Authentication](/auth/), [Remote Harness Connectors](/remote-connectors/), [Diagnostics](/diagnostics/).

--- a/web/docs/src/content/docs/upgrading.md
+++ b/web/docs/src/content/docs/upgrading.md
@@ -1,139 +1,66 @@
 ---
 title: "Upgrading"
-description: "Signet documentation: Upgrading."
+description: "Update Signet, preserve workspace state, and verify the running daemon."
 ---
 
-**Breaking change.** This release replaces Signet's hand-rolled inference
-providers with two backends: **Pi** (`@earendil-works/pi-ai`) for every direct
-API call, and **ACPX** for harness subprocess calls. Existing installs **must
-verify their background pipeline still functions after updating.**
+Upgrade the installed Signet distribution through the daemon-aware update commands when they are available:
 
-If you are upgrading from a release before this change, read this entire page.
-
-## What changed
-
-Before this release, Signet shipped six hand-rolled LLM providers in a
-4,000-line `provider.ts`: Claude Code (subprocess), OpenCode (HTTP server),
-Codex (subprocess), a generic command-line provider, and direct HTTP for
-Anthropic / OpenAI-compatible / Ollama / llama.cpp / OpenRouter.
-
-After this release there are exactly **two backends** behind the same
-`LlmProvider` interface:
-
-- **Pi** (`pi-ai`) — every direct API call: Anthropic, OpenAI (incl. Codex),
-  Google, Bedrock, Mistral, Azure, Cloudflare, Copilot, OpenRouter, and all
-  OpenAI-compatible local servers (LM Studio, Ollama, llama.cpp).
-- **ACPX** — the retained harness-subprocess backend, now a bundled dependency
-  (`acpx@0.12.0`) and a first-class peer endpoint in the routing registry. It
-  drives Claude Code, Codex, OpenCode, Gemini, and the rest of the ACP agent
-  family, plus a `--agent <binary>` escape hatch for custom harnesses.
-
-The following routing executors have been **removed** and will now fail with a
-structured error pointing at this page:
-
-| Removed executor | Replace with |
-|---|---|
-| `claude-code` | `acpx` (agent: `claude`), or `anthropic` for direct API |
-| `codex` | `acpx` (agent: `codex`), or `openrouter`/`openai-compatible` for direct API |
-| `opencode` | `acpx` (agent: `opencode`), or an OpenAI-compatible direct target |
-| `command` | `acpx` with `--agent <binary>`, or re-implement as an OpenAI-compatible target |
-| `anthropic` | unchanged (now Pi-backed; same config) |
-| `openrouter` | unchanged (now Pi-backed) |
-| `ollama` | unchanged (now Pi-backed via OpenAI-compatible) |
-| `llama-cpp` | unchanged (now Pi-backed via OpenAI-compatible) |
-| `openai-compatible` | unchanged (now Pi-backed) |
-
-`memory.pipelineV2.extraction.provider: command` is also retired. Configure a
-canonical `inference.workloads.memoryExtraction` target instead; the daemon
-will reject the retired command configuration rather than silently falling
-back to another provider.
-
-## Memory pipeline routing migration
-
-On startup, the config migrator advances eligible `agent.yaml` files through
-`configVersion: 9`. It removes the obsolete `memory.synthesis` and
-`memory.pipelineV2.synthesis` blocks and removes provider/model/endpoint fields
-that can be migrated safely. It also removes retired extraction-writer settings
-left behind by older migrations. Version 9 repairs workspaces that were already
-stamped `configVersion: 8` before those cleanups were added. The migration is
-atomic and idempotent.
-
-If a legacy provider cannot be mapped to a supported inference executor, its
-routing fields are preserved and the strict loader stops with an actionable
-`is retired` error. Configure an `inference.targets` entry and bind it to
-`inference.workloads.memoryExtraction`; do not delete the fields by hand before
-reading the error, because they identify what needs reconfiguration.
-
-The old provider-safety API and rollback route are removed. Config writes now
-save YAML directly, subject to the normal guarded-file permission checks.
-
-## Action required after updating
-
-1. **Check the daemon log on first start.** If your `agent.yaml` references a
-   removed executor, the daemon logs a structured error naming the target and
-   the executor to replace. Background extraction/synthesis will not run until
-   you fix it.
-2. **Reconfigure the target.** In nearly every case the replacement is a
-   one-line edit: change `executor: claude-code` to `executor: acpx` (and add
-   `acpx: { agent: claude }`), or `executor: codex` to `executor: acpx`
-   (with `acpx: { agent: codex }`). Direct-API targets (`anthropic`,
-   `openrouter`, `ollama`, `llama-cpp`, `openai-compatible`) keep working as-is
-   — only the underlying engine changed.
-3. **Verify a background call.** Trigger a Dreaming pass or session summary
-   (`signet memory ingest ...`, or send a session through the pipeline) and
-   confirm it completes.
-4. **Verify aggregate recall** if you use it: `signet recall "<query>" --aggregate`.
-   It now flows through pi-ai; latency is unchanged (verified at ~200–500ms for
-   synthesis-sized calls on a local model).
-
-## Behavioral changes to expect
-
-These are intentional consequences of the cutover, not bugs:
-
-- **OpenRouter reasoning controls.** The `{ enabled, maxTokens }` reasoning
-  block is now translated by pi-ai into its own `{ effort }` abstraction
-  (omitted entirely when reasoning is disabled) rather than forwarded verbatim.
-  pi-ai owns the reasoning wire format now.
-- **Keyless local servers** (LM Studio, Ollama, llama.cpp) receive a placeholder
-  `Authorization` header. pi-ai's credential resolver requires a non-empty API
-  key; local servers ignore it. No real credential is sent.
-- **Availability probes.** Each target now does a `/models` reachability check
-  so the router can skip unreachable targets before attempting a real call
-  (this also makes fallback attribution correct).
-
-## ACPX as a harness replacement
-
-ACPX is bundled with the daemon (no separate install, no `npx` fetch). It
-replaces the removed harness subprocess providers. Verified to drive each:
-
-- `acpx claude` — replaces `executor: claude-code`
-- `acpx codex` — replaces `executor: codex`
-- `acpx opencode` — replaces `executor: opencode`
-- `acpx --agent <binary>` — replaces `executor: command`
-
-Configure it as a routing target:
-
-```yaml
-inference:
-  targets:
-    claude-harness:
-      executor: acpx
-      acpx:
-        agent: claude        # or codex, opencode, gemini, ...
-      models:
-        default:
-          model: claude-sonnet-4
+```bash
+signet update check
+signet update install
+signet update status
+signet update channel
 ```
 
-## daemon-rs removed
+An installed update can require a daemon restart before it is active:
 
-The experimental Rust daemon rewrite (`platform/daemon-rs`) and its shadow
-proxy, CLI runtime switch (`SIGNET_DAEMON_RUNTIME`), and route-parity harness
-have been removed. The TypeScript/Bun daemon is the sole runtime. Rust
-accelerators (`@signet/native`) are unaffected.
+```bash
+signet daemon restart
+signet daemon status --json
+curl -fsS http://127.0.0.1:3850/health/ready
+```
 
-## Need help
+## Before updating
 
-If a background pipeline operation does not resume after updating, run
-`signet doctor` and check the daemon log for the structured "folded executor"
-error — it names the exact target and executor to change.
+1. Record the installed version and daemon status.
+2. Back up the private workspace state using your approved encrypted backup process.
+3. Preserve `agent.yaml` before correcting a configuration migration error.
+4. Do not delete the database, auth secret, or secret store to force an upgrade through.
+
+For the first-party Docker deployment, pull the configured image and recreate the services:
+
+```bash
+cd deploy/docker
+docker compose pull
+docker compose up -d
+```
+
+See [Self-Hosting](/self-hosting/) for the persistent volume and initial auth boundary.
+
+## Configuration migration
+
+Current configuration uses the workspace `agent.yaml`, with canonical inference routing for model selection. `memory.synthesis` is retired and rejected by the loader. If an old workspace fails to start after an update:
+
+1. Preserve the exact daemon error.
+2. Make the smallest source-backed change to the named configuration key.
+3. Restart the daemon.
+4. Verify status, readiness, and the affected workflow.
+
+Do not revive removed provider or synthesis configuration just because an old guide mentions it. Use [Inference and routing](/configuration/inference-routing/) for current target and workload bindings.
+
+## After updating
+
+```bash
+signet daemon status --json
+curl -fsS http://127.0.0.1:3850/health/live
+curl -fsS http://127.0.0.1:3850/health/ready
+curl -fsS http://127.0.0.1:3850/api/diagnostics
+```
+
+Then test the feature you depend on: a bounded recall, a provider route, a remote connector authentication check, or a scheduled task dry run. A green version command does not prove the daemon's workspace, migration, inference route, or connector are healthy.
+
+## Rollback and incident handling
+
+If a release fails after a verified backup, stop the daemon, preserve logs and the workspace, and follow the deployment mechanism's rollback procedure. Restore private state only from a known-good backup. File deletion is not a migration strategy.
+
+Related: [Daemon](/daemon/), [Diagnostics](/diagnostics/), [Configuration](/configuration/).


### PR DESCRIPTION
## Summary

Refreshes the owned operator documentation for configuration, daemon lifecycle, diagnostics, deployment, scheduling, telemetry, secrets, and upgrades. The guidance is source-backed and makes daemon versus CLI boundaries, restart semantics, limits, and recovery actions explicit.

## Changes

- Replaces retired or contradicted configuration, daemon, diagnostics, scheduling, secrets, self-hosting, analytics, and upgrade guidance.
- Aligns operator instructions with the current CLI, daemon, scheduler, Docker, route, telemetry, and secret-management behavior.
- Keeps the documentation lean while preserving the current operational boundaries and recovery flow.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [x] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [x] `@signet/web`
- [ ] `predictor`
- [ ] Other

## Screenshots

Not applicable: documentation-only change.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable: no migrations changed.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A (documentation-only; see additional verification below)

Additional verification:

- `cd web/docs && bun scripts/validate-content.ts` (90 public docs pages and 90 routes)
- `cd web/docs && bun run check` (0 errors, 0 warnings, 0 hints)
- `cd web/docs && bun run build` (92 pages)
- `bunx prettier --check` for all 11 changed Markdown files
- `bun run --filter '@signet/core' build`
- `bun test platform/daemon/src/routes/secrets-routes.test.ts platform/daemon/src/scheduler/worker.test.ts` (15 pass, 0 fail)
- `git diff --check origin/main..HEAD`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

`bun scripts/doc-drift.ts` still reports pre-existing, out-of-scope gaps for unowned API routes and package-table inventory. This change does not add scoped drift. The readiness items concerning queries, validation, errors, security, and regression tests were reviewed as non-code contracts for this documentation-only change; no runtime implementation or bug fix was added. The original commit contains `Assisted-by: OpenAI-Codex:gpt-5.6-terra`; this checklist repair and verification used OpenAI Codex (gpt-5.6-luna).
