### PR TITLE
docs: refresh dashboard and source contracts

### DIFF
--- a/web/docs/scripts/anchor-regression.test.ts
+++ b/web/docs/scripts/anchor-regression.test.ts
@@ -1,0 +1,18 @@
+/// <reference types="bun-types" />
+
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const CONTENT = join(import.meta.dir, "../src/content/docs");
+const API_ANCHOR = "post-api-sources-discord";
+
+test("Discord source API links target an explicit stable anchor", () => {
+	const api = readFileSync(join(CONTENT, "api/documents-sources.md"), "utf8");
+	expect(api).toContain(`<a id="${API_ANCHOR}"></a>\n\n### POST /api/sources/discord`);
+
+	for (const page of ["dashboard.md", "sources.md"]) {
+		const source = readFileSync(join(CONTENT, page), "utf8");
+		expect(source).toContain(`/api/documents-sources/#${API_ANCHOR}`);
+	}
+});

--- a/web/docs/src/content/docs/api/documents-sources.md
+++ b/web/docs/src/content/docs/api/documents-sources.md
@@ -16,8 +16,9 @@ All document endpoints require `documents` permission.
 ### POST /api/documents
 
 Submit a document for ingestion. The document is queued and processed
-asynchronously. Returns `201` on success, or the existing document's ID and
-status if a duplicate URL is detected.
+asynchronously. A new request returns `201` with the queued document and job
+IDs. A duplicate URL returns the existing document's ID and its real current
+status when it is already active in the same agent and project scope.
 
 **Request body**
 
@@ -28,7 +29,7 @@ status if a duplicate URL is detected.
   "title": "My Document",
   "content_type": "text/plain",
   "connector_id": null,
-  "metadata": { "author": "nicholai" }
+  "metadata": { "author": "example" }
 }
 ```
 
@@ -48,13 +49,13 @@ required for `text`. `url` is required for `url`.
 **Response**
 
 ```json
-{ "id": "uuid", "status": "queued" }
+{ "id": "uuid", "status": "queued", "jobId": "memory-job-uuid" }
 ```
 
 Or if deduplicated:
 
 ```json
-{ "id": "existing-uuid", "status": "processing", "deduplicated": true }
+{ "id": "existing-uuid", "status": "chunking", "deduplicated": true }
 ```
 
 ### GET /api/documents
@@ -65,7 +66,7 @@ List all documents with optional status filter.
 
 | Parameter | Description                              |
 |-----------|------------------------------------------|
-| `status`  | Filter by status (`queued`, `processing`, `done`, `failed`, `deleted`) |
+| `status`  | Filter by lifecycle status (`queued`, `extracting`, `chunking`, `embedding`, `indexing`, `done`, `failed`, `deleted`) |
 | `limit`   | Page size (default: 50, max: 500)        |
 | `offset`  | Pagination offset (default: 0)           |
 
@@ -100,7 +101,7 @@ List the memory records derived from this document, ordered by chunk index.
     {
       "id": "memory-uuid",
       "content": "Chunk text...",
-      "type": "fact",
+      "type": "document_chunk",
       "created_at": "2026-02-21T10:00:00.000Z",
       "chunk_index": 0
     }
@@ -111,8 +112,11 @@ List the memory records derived from this document, ordered by chunk index.
 
 ### DELETE /api/documents/:id
 
-Soft-delete a document and all its derived memory records. Memories linked to
-the document are soft-deleted one at a time with audit history.
+Soft-delete a document and its unshared derived memory records. The document is
+marked `deleted` and any pending document-ingest job is completed. A linked
+memory is soft-deleted with audit history only when no other non-deleted
+document still references it; shared memories remain available to their other
+documents.
 
 **Query parameters**
 
@@ -125,6 +129,9 @@ the document are soft-deleted one at a time with audit history.
 ```json
 { "deleted": true, "memoriesRemoved": 12 }
 ```
+
+`memoriesRemoved` is the number of memories actually soft-deleted, not the
+number of chunk links on the document.
 
 
 ## Sources

--- a/web/docs/src/content/docs/api/documents-sources.md
+++ b/web/docs/src/content/docs/api/documents-sources.md
@@ -300,6 +300,8 @@ chunk embeddings to its own database.
 }
 ```
 
+<a id="post-api-sources-discord"></a>
+
 ### POST /api/sources/discord
 
 Add or update a Discord source and queue a shared source index job. REST and

--- a/web/docs/src/content/docs/api/route-inventory.md
+++ b/web/docs/src/content/docs/api/route-inventory.md
@@ -51,6 +51,7 @@ silently disappear from the API reference.
 | GET | `/api/synthesis/status` | platform/daemon/src/routes/hooks-routes.ts |
 | GET | `/api/sources` | platform/daemon/src/routes/sources-routes.ts |
 | POST | `/api/sources/pick-directory` | platform/daemon/src/routes/sources-routes.ts |
+| POST | `/api/sources/pick-files` | platform/daemon/src/routes/sources-routes.ts (loopback-only; returns local paths for a subsequent paths-based import) |
 | POST | `/api/sources/obsidian` | platform/daemon/src/routes/sources-routes.ts |
 | POST | `/api/sources/discord` | platform/daemon/src/routes/sources-routes.ts |
 | POST | `/api/sources/import` | platform/daemon/src/routes/import-routes.ts |
@@ -161,9 +162,11 @@ the limit is the daemon-wide client/process budget.
 
 ### GET /
 
-Serves the SvelteKit dashboard as a single-page application. Static files are
-served from the built dashboard directory. Any path without a file extension
-falls back to `index.html` for client-side routing.
+Serves the React/Vite dashboard as a generic single-page application. Static
+assets are served from the built dashboard directory or, when available, the
+packaged embedded dashboard assets. The dashboard handler passes `/api/*`,
+`/health`, and `/sse` through; remaining paths without a file extension fall
+back to `index.html` for client-side routing.
 
 If the dashboard build is not found, a minimal HTML fallback page is served
 with links to key API endpoints.

--- a/web/docs/src/content/docs/connectors.md
+++ b/web/docs/src/content/docs/connectors.md
@@ -3,11 +3,7 @@ title: "Connectors"
 description: "Platform-specific connector framework."
 ---
 
-Connectors let Signet pull content from external sources — local
-filesystems, documentation repos, cloud drives — and ingest that
-content into the memory store as searchable [Documents](/documents/). Each connector
-follows a consistent register-sync-health lifecycle managed through
-the [Daemon](/daemon/)'s [HTTP API](/api/).
+Connectors are the daemon’s API-level framework for synchronizing provider resources into the document pipeline. They are distinct from the Dashboard **Sources** workflow: use [Sources](/sources/) to connect an Obsidian vault, GitHub repository, or Discord guild from the current Dashboard, or to import files as durable source-backed artifacts.
 
 This page covers document-source connectors. If you want to install a harness
 adapter on another machine and point it at a remote Signet daemon, see

--- a/web/docs/src/content/docs/dashboard.md
+++ b/web/docs/src/content/docs/dashboard.md
@@ -1,348 +1,72 @@
 ---
 title: "Dashboard"
-description: "Web dashboard for monitoring and management."
+description: "Use the local Signet dashboard to inspect memory, sources, graph, Dreams, secrets, and runtime settings."
 ---
 
-The Signet dashboard is a Svelte 5 + Vite static app served by the [Daemon](/daemon/) at
-`http://localhost:3850`. It is a supplementary visual interface — useful
-for browsing [Memory](/memory/), editing config files, and inspecting daemon state,
-but not the primary way to interact with Signet. The [CLI](/cli/) and
-[harness](/harnesses/) integrations are the primary interfaces.
+The Signet dashboard is a React 19 + Vite single-page application served by the local daemon. It is a visual interface for the same local daemon API used by the CLI and integrations.
 
-
-## Accessing the Dashboard
-
-The daemon must be running first:
+Start the daemon, then open the dashboard:
 
 ```bash
 signet daemon start
-```
-
-Then visit `http://localhost:3850` in your browser, or run:
-
-```bash
 signet dashboard
 ```
 
-The `signet dashboard` command opens your default browser. If the daemon
-is not already running, it starts it first.
+The default URL is `http://localhost:3850`. If you set `SIGNET_PORT`, use that port instead.
 
+## Current navigation
 
-## Layout
+The dashboard uses hash routes. These routes are available in the current application:
 
-The dashboard is a single-page app with a collapsible left navigation rail and
-a main workspace.
+| Route | Surface | What it is for |
+|---|---|---|
+| `#home` | Home | Daemon and workspace overview. |
+| `#memory` | Memory | Browse and search stored memory. |
+| `#sources` | Sources | Connect supported sources, import files, inspect source health, re-index, snapshot, or remove a source. |
+| `#graph` | Graph | Inspect the knowledge graph. |
+| `#dreaming` | Dreams | Inspect Dreaming status and attention. |
+| `#secrets` | Secrets | Inspect stored secret names and manage secrets without exposing their values. |
 
-- **Left navigation rail** — Overview, Ontology, Tasks, Audit, Secrets,
-  Skills, Sources, Settings, theme toggle, and project/release access.
-- **Main workspace** — lazy-loaded dashboard surfaces for the selected area.
+Unknown hashes fall back to the current/default view rather than opening a legacy route.
 
-The sidebar footer shows the daemon version and pending restart state when
-available.
+`Agents` and `Skills` are visible as disabled “Coming soon” navigation rows in the current build. They are not finished management surfaces. The retired Overview, Ontology, Tasks, and Audit tabs are not part of this dashboard.
 
+## Settings
 
-## Left Sidebar
+Select the gear in the lower-left account row to open the settings modal. The current modal groups controls into:
 
-The sidebar is intentionally navigation-only. Identity, harness, config,
-pipeline, connector, and log details live inside Overview, Ontology, Settings,
-and Audit surfaces rather than as separate sidebar panels.
+- Network: local daemon address and sync settings.
+- Inference: provider accounts, model routing, embedding configuration, and route checks.
+- Logs: runtime log controls.
+- Advanced: additional daemon configuration.
 
+Settings are a modal, not a hash-routed dashboard tab. Treat the daemon and configuration references as the authority for operational behavior.
 
-## Tabs
+## Sources and imports
 
-**Overview** — Home surface for daemon status, memory health, harness state,
-marketplace spotlights, pinned entity clusters, and upgrade/restart signals.
+Open `#sources` to work with source-backed recall:
 
-**Ontology** — Unified memory workspace. It combines memory search, timeline,
-knowledge/entity inspection, and constellation/embedding exploration behind
-the `cortex-memory` route. Legacy hashes such as `#memory`, `#embeddings`,
-and `#knowledge` redirect here.
+- **Connect a source** offers the dashboard’s basic Obsidian, GitHub, and Discord forms.
+- **Import files** uploads text, Markdown, JSON, HTML, CSV, and supported document formats as durable source artifacts.
+- Existing source cards show health and index status and provide re-index, snapshot, and remove actions.
 
-**Settings** — Form-driven configuration editor for identity, embedding,
-memory, pipeline, connector, and review settings. Changes are saved to the
-resolved config files under `$SIGNET_WORKSPACE/`.
+The dashboard connect form intentionally exposes only a small set of fields. In particular, Discord uses a guild ID, optional display name, and a secret reference for its bot token. Advanced Discord options such as sync mode, filters, cache paths, and bounded indexing settings belong in the [Discord source API reference](/api/documents-sources/#post-api-sources-discord), not in the dashboard form.
 
-**Memory search** — Browse and search your memory database from the ontology
-workspace. Search runs hybrid (semantic + keyword) lookup. You can filter by
-type, tags, source harness, pinned status, importance score, and date. Each
-memory card has a "Find Similar" action that runs vector similarity search.
-The count shown reflects your current filter state.
+For the source lifecycle and import behavior, see [Sources](/sources/). For HTTP request and response shapes, see [Documents and sources API](/api/documents-sources/).
 
-**Embeddings / Constellation** — A 3D force-directed graph of your memory space
-(powered by `3d-force-graph` / Three.js). Memories with vector
-embeddings appear as nodes; edges connect k-nearest neighbors.
+## Serving behavior
 
-Coordinates are computed server-side via UMAP dimensionality reduction
-(`GET /api/embeddings/projection`) and cached until the embedding count
-changes. The server returns both 2D and 3D projections; the dashboard
-uses the 3D variant. Node positions are scaled by a factor of 52 and
-seeded from the UMAP coordinates; the force simulation refines layout
-from there.
+The daemon serves the built dashboard as a generic static SPA. Its dashboard handler passes `/api/*`, `/health`, and `/sse` through to their own handlers; remaining extensionless paths fall back to `index.html`.
 
-Nodes are colored by source (the `who` field). Node size scales with
-importance (base 0.6, up to 2.0). Click a node to inspect the memory
-and view its nearest neighbors in a side panel. Hovering a node shows
-a tooltip with the source and a truncated content label.
-
-Filter presets let you slice the graph by source, memory type, or
-importance range. Preset selections are persisted to `localStorage`.
-
-**Cluster lens mode** highlights a selected node's neighborhood:
-when active, only nodes in the `lensIds` set are rendered at full
-opacity while the rest are dimmed. Edges are similarly filtered.
-Pinned memories are visually distinguished.
-
-The `EmbeddingCanvas3D` component exposes `focusNode(id)` to animate
-the camera toward a specific node, and `refreshAppearance()` to
-re-apply color/opacity changes without rebuilding the graph.
-
-**Constellation View — Entity Overlay**
-
-The Embeddings tab's constellation view renders a 4-tier D3 force
-simulation that layers the knowledge graph on top of the memory space:
-
-- **Entities** (hexagons, 10–22px) — gravitational centers, sized by
-  mention density
-- **Aspects** (circles, 5–8px) — orbit their parent entity
-- **Attributes** (small circles, 3–4px) — orbit their parent aspect
-- **Memories** (dots, 2px) — leaf nodes, orbit their parent attribute
-
-Performance caps keep the simulation responsive:
-- Zero-mention entities are excluded unless pinned by the user
-- Maximum 500 entities, ordered by pinned status then mention count
-- Memory leaf nodes are dropped entirely if total node count exceeds 3,000
-
-Clicking an entity node opens an inspector panel showing the entity type,
-aspects list, dependency edges, and memory count. Clicking a memory node
-opens the existing memory detail panel.
-
-**Predictor Placeholders**
-
-The dashboard does not currently ship a standalone Predictor tab. Legacy
-`#predictor` hashes resolve to Settings, and the Knowledge view includes
-placeholder predictor slices that stay empty until scorer comparison rows exist
-in the daemon database.
-
-
-**Pipeline — Active Sessions**
-
-The Settings pipeline section includes active-session controls with per-session
-bypass toggles. Each row shows the session key, harness name, runtime path, and
-a Switch control to enable or disable bypass. Toggling the switch calls
-`POST /api/sessions/:key/bypass` (see [Sessions and hooks API](/api/sessions-hooks/#sessions)). When bypass
-is on, all hooks for that session return empty no-op responses — MCP
-tools still work normally.
-
-The session list auto-refreshes every 30 seconds and is only visible
-when at least one session is active.
-
-**Audit** — Diagnostics and logs. The log view streams daemon events via Server-Sent Events
-(`/api/logs/stream`). A Live/Stop toggle controls the stream.
-Entries are color-coded by level (`debug`, `info`, `warn`, `error`)
-and labeled by category: `daemon`, `api`, `memory`, `sync`, `git`,
-`watcher`, `embedding`, `harness`, `system`, `hooks`, `pipeline`,
-`skills`, `secrets`, `auth`, and `session-tracker`,
-`document-worker`, `maintenance`, `retention`, `llm`. Click an
-entry to open a split detail panel with the full JSON payload,
-duration display, and a copy-to-clipboard button.
-
-**Secrets**: Shows stored secret names. Values are always masked. This
-surface is owned by the `signet.secrets` core plugin, backed by the local
-encrypted provider and 1Password compatibility flow. You can add new
-secrets (via a password input) or delete existing ones. For CLI use,
-prefer `signet secret put <NAME>`.
-
-**Skills** — Lists installed skills and marketplace catalog entries from
-Signet, skills.sh, and ClawHub sources. Click a skill name to read details
-before installing. Already-installed skills are marked.
-
-The Skills tab also includes **Plugins**, a registry view for core and
-installed Signet extensions. It shows plugin state, health, capability
-grants, declared surfaces, prompt contribution diagnostics, and recent
-plugin audit events. Core plugins such as `signet.secrets` can be
-enabled or disabled there; disabling Signet Secrets blocks secret-owned
-surfaces but does not delete encrypted secrets from disk.
-
-
-## API-Only Fallback
-
-If the dashboard build is missing (e.g., running the daemon from source
-without building the frontend), visiting `http://localhost:3850` shows
-a minimal HTML page listing available API endpoints instead.
-
-Build the dashboard to restore the full UI:
-
-```bash
-cd surfaces/dashboard
-bun run build
-```
-
+A packaged daemon can also serve embedded dashboard assets. If neither a built nor embedded dashboard is available, `/` shows a small API-only fallback page rather than a dashboard.
 
 ## Development
 
-To run the dashboard in dev mode with hot reload:
+The dashboard source lives in `surfaces/dashboard/` and uses React, Vite, Tailwind, and shadcn/ui. Run its development server from that package:
 
 ```bash
 cd surfaces/dashboard
-bun install
 bun run dev
 ```
 
-This starts a Vite dev server at `http://localhost:5173`. The daemon
-must still be running at port 3850 for API calls to work.
-
-
-## Tasks Tab
-
-The Tasks tab shows a kanban board for scheduled agent prompts. Four
-columns display task state:
-
-- **Scheduled** — Enabled tasks waiting for their next run
-- **Running** — Currently executing tasks with elapsed timer
-- **Completed** — Recent successful runs
-- **Failed** — Recent failed runs with error summary
-
-Each card shows the task name, harness badge, cron schedule, and
-next/last run time. Click a card to open the detail sheet with full
-run history and stdout/stderr logs.
-
-Use the **+ New Task** button to create tasks. The form includes
-cron presets, harness selection, and a security warning for Claude
-Code's `--dangerously-skip-permissions` flag.
-
-Tasks can be enabled/disabled via the toggle switch on each card,
-or triggered for an immediate manual run.
-
-
-## Port Configuration
-
-The default port is 3850. To change it:
-
-```bash
-SIGNET_PORT=4000 signet daemon start
-```
-
-The dashboard URL changes accordingly.
-
-
-## Development Conventions
-
-These conventions apply to all dashboard UI work.
-
-### Stack
-
-- **Framework**: Svelte 5 (runes: `$props`, `$state`, `$derived`, `$effect`)
-- **Styling**: Tailwind CSS v4 (via `@tailwindcss/vite` plugin, no `tailwind.config`)
-- **UI primitives**: shadcn-svelte (https://www.shadcn-svelte.com)
-- **Icons**: Lucide (`@lucide/svelte/icons/<name>`)
-- **Visualization**: 3d-force-graph, D3, CodeMirror 6
-- **Build**: Vite + SvelteKit static adapter
-
-### Component Organization
-
-```
-surfaces/dashboard/src/lib/
-  components/
-    ui/           # shadcn-svelte primitives (button, card, tabs, etc.)
-    memory/       # Memory feature components
-    embeddings/   # Constellation / canvas views
-    config/       # Config editor components (FormField, FormSection)
-    sessions/     # Session management and bypass toggle
-    skills/       # Skills marketplace components
-    tasks/        # Task scheduler components
-    app-sidebar.svelte   # Main navigation sidebar
-    CodeEditor.svelte    # CodeMirror wrapper
-    ToastContainer.svelte
-  stores/         # Svelte 5 rune stores (*.svelte.ts)
-  api.ts          # Daemon API client
-```
-
-- Always use existing shadcn-svelte components from
-  `$lib/components/ui/` when possible. Do not recreate primitives.
-- Feature components go in their domain subdirectory (e.g. `memory/`,
-  `skills/`, `tasks/`).
-- Component naming: PascalCase for feature components (`SkillCard.svelte`),
-  kebab-case for shadcn primitives (`button.svelte`).
-- Props use Svelte 5 `$props()` with explicit TypeScript interfaces.
-- Import shadcn components via barrel: `$lib/components/ui/card/index.js`
-
-### Design Tokens
-
-Tokens are CSS custom properties defined in
-`surfaces/dashboard/src/app.css`. Dark theme is the default;
-light activates via `data-theme="light"` on `<html>`.
-
-**Never hardcode hex colors.** Always use token variables:
-
-| Purpose | Token |
-|---------|-------|
-| Page background | `var(--sig-bg)` / `bg-background` |
-| Card surface | `var(--sig-surface)` / `bg-card` |
-| Raised surface | `var(--sig-surface-raised)` / `bg-secondary` |
-| Primary text | `var(--sig-text)` / `text-foreground` |
-| Bright text | `var(--sig-text-bright)` / `text-primary` |
-| Muted text | `var(--sig-text-muted)` / `text-muted-foreground` |
-| Border | `var(--sig-border)` / `border-border` |
-| Strong border | `var(--sig-border-strong)` / `border-input` |
-| Accent | `var(--sig-accent)` |
-| Danger | `var(--sig-danger)` / `bg-destructive` |
-| Success | `var(--sig-success)` |
-
-**Spacing scale**: `--space-xs` (4px), `--space-sm` (8px),
-`--space-md` (16px), `--space-lg` (24px), `--space-xl` (48px),
-`--space-2xl` (80px).
-
-**Typography**: Display font `var(--font-display)` (Diamond Grotesk /
-Chakra Petch) for headings. Monospace `var(--font-mono)` (Geist Mono /
-IBM Plex Mono) for body text and UI. Base font size is 13px.
-
-**Font sizes**: `--font-size-xs` (10px), `--font-size-sm` (11px),
-`--font-size-base` (13px), `--font-size-lg` (15px).
-
-**Utility classes**: `sig-label` (11px muted), `sig-eyebrow` (10px
-uppercase), `sig-heading` (11px bold uppercase), `sig-meta` (9px),
-`sig-badge` (9px rounded), `sig-micro` (8px uppercase).
-
-### Styling Rules
-
-- Use Tailwind utility classes mapped through the `@theme inline`
-  block in `app.css` (e.g. `bg-card`, `text-muted-foreground`,
-  `border-border`).
-- For Signet-specific tokens not in the Tailwind theme, use
-  `style="color: var(--sig-accent)"` or arbitrary values
-  `text-[var(--sig-accent)]`.
-- Transitions use `var(--dur)` (0.2s) and `var(--ease)`
-  (cubic-bezier). The grain overlay and scrollbar styles are global.
-- Headings are uppercase with letter-spacing. Use `sig-heading` class
-  or match the pattern: `font-display font-bold uppercase tracking-wider`.
-- Respect `prefers-reduced-motion` — the global CSS disables
-  animations when active.
-
-### Icon System
-
-- All icons come from `@lucide/svelte/icons/<icon-name>`.
-  Import individually, not from the barrel.
-  ```svelte
-  import Brain from "@lucide/svelte/icons/brain";
-  ```
-- Do not import or add new icon packages. If a design requires an
-  icon not in Lucide, flag it.
-- Icon color backgrounds use `--sig-icon-bg-1` through `--sig-icon-bg-6`
-  with `--sig-icon-fg` foreground and `--sig-icon-border` stroke.
-
-### State Management
-
-- Stores are Svelte 5 rune-based files at `$lib/stores/*.svelte.ts`.
-- Navigation uses `$lib/stores/navigation.svelte.ts` (hash-based tabs).
-- API calls go through `$lib/api.ts` which talks to the daemon at
-  `localhost:3850`.
-- Use `$state()`, `$derived()`, `$effect()` — not legacy stores.
-
-### Svelte 5 Conventions
-
-- Use `$props()` with destructured interface, not `export let`.
-- Use `{@render children()}` for slot content, not `<slot>`.
-- Event handlers: `onclick`, `onkeydown` (lowercase), not `on:click`.
-- Use `$effect()` for side effects, not `afterUpdate`.
-- Wrap mutable external references in `$state.raw()` or
-  `untrack()` where needed to prevent infinite reactivity loops.
+The development server serves the frontend separately from the daemon. Start a daemon as well when you need live API data.

--- a/web/docs/src/content/docs/documents.md
+++ b/web/docs/src/content/docs/documents.md
@@ -1,257 +1,83 @@
 ---
 title: "Documents"
-description: "Document ingest and retrieval system."
+description: "Ingest documents into linked, searchable memory chunks."
 ---
 
-The document ingest subsystem lets you push arbitrary text content or URLs
-into Signet's [Memory](/memory/) store. Documents are split into overlapping chunks,
-each chunk is embedded and written as a `document_chunk` memory, and the
-whole set is linked back to the originating document record. Once indexed,
-chunks participate in hybrid search alongside any other memory type.
+The documents API accepts text, URLs, and file references for background ingestion. A document is stored first, then processed into linked `document_chunk` memories that participate in search. For source-backed file uploads through the Dashboard, see [Sources](/sources/); for exact HTTP shapes, see [Documents and sources API](/api/documents-sources/).
 
-This doc covers the ingest API, processing lifecycle, chunking mechanics,
-and worker [Configuration](/configuration/). For full endpoint signatures and auth details,
-see [Api](/api/).
+## Submit a document
 
+`POST /api/documents` accepts `text`, `url`, and `file` source types. Text requests include `content`; URL requests include `url` and are fetched by the worker.
 
-## Source Types
-
-Every document submission declares a `source_type`:
-
-- `text` — raw string content supplied directly in the request body.
-- `url` — a remote URL the daemon fetches and extracts text from.
-- `file` — a local or remote file path (URL field used for path reference).
-
-For `url` sources, content is fetched at processing time by the worker,
-not at submission time. The title field is also populated from the page
-`<title>` if not supplied in the request.
-
-
-## API Endpoints
-
-### POST /api/documents
-
-Submits a document for ingestion. The document is written to the database
-with status `queued` and a background job is enqueued immediately.
-
-Request body:
+A successful new request returns `201 Created` after the document and its queued job have been recorded:
 
 ```json
 {
-  "source_type": "text",
-  "title": "Optional title",
-  "content": "The full document text.",
-  "content_type": "text/plain",
-  "metadata": { "arbitrary": "key-value pairs" }
+  "id": "<document-id>",
+  "status": "queued",
+  "jobId": "<memory-job-id>"
 }
 ```
 
-For `url` source type, replace `content` with `url`:
+The worker owns later processing. Poll `GET /api/documents/:id` for the document record, or use the job ID with `GET /api/memory/jobs/:id` when you need job-level state.
 
-```json
-{
-  "source_type": "url",
-  "url": "https://example.com/article",
-  "title": "Optional override title"
-}
-```
+URL and file submissions deduplicate by source URL within the same agent and project scope while the existing document is not `failed` or `deleted`. A deduplicated request returns `200` with the existing document ID, its real current status, and `deduplicated: true`; it does not pretend the document is in a generic `processing` state.
 
-Response on success (`201 Created`):
+## Lifecycle
 
-```json
-{ "id": "<uuid>", "status": "queued" }
-```
+A document moves through these states:
 
-If the same URL is already tracked in a non-failed, non-deleted state,
-the endpoint returns the existing record instead of creating a duplicate:
-
-```json
-{ "id": "<existing-uuid>", "status": "done", "deduplicated": true }
-```
-
-### GET /api/documents
-
-Lists all documents, ordered by creation date descending.
-
-Query parameters:
-
-- `status` — filter by lifecycle status (e.g. `?status=done`).
-- `limit` — page size, default `50`, maximum `500`.
-- `offset` — pagination offset, default `0`.
-
-Response:
-
-```json
-{
-  "documents": [ /* document rows */ ],
-  "total": 42,
-  "limit": 50,
-  "offset": 0
-}
-```
-
-### GET /api/documents/:id
-
-Returns the full document row for the given ID, including status, chunk
-count, memory count, error message if any, and raw metadata.
-
-Returns `404` if the ID is not found.
-
-### GET /api/documents/:id/chunks
-
-Returns all memory entries linked to a document, ordered by chunk index.
-Only returns chunks where `is_deleted = 0`.
-
-Response:
-
-```json
-{
-  "chunks": [
-    {
-      "id": "<memory-uuid>",
-      "content": "chunk text...",
-      "type": "document_chunk",
-      "created_at": "2025-01-01T00:00:00.000Z",
-      "chunk_index": 0
-    }
-  ],
-  "count": 7
-}
-```
-
-### DELETE /api/documents/:id
-
-Soft-deletes the document and all linked memories. Requires a `reason`
-query parameter (`?reason=outdated`). Each linked memory gets its
-`is_deleted` flag set to `1` and a deletion event is appended to
-`memory_history`. The document row is set to status `deleted`.
-
-Response:
-
-```json
-{ "deleted": true, "memoriesRemoved": 7 }
-```
-
-
-## Status Lifecycle
-
-A document moves through these statuses during processing:
-
-```
+```text
 queued → extracting → chunking → embedding → indexing → done
 ```
 
-At any stage the worker may transition the document to `failed` if an
-unrecoverable error occurs. Deleted documents land in `deleted` status
-after a DELETE request.
+`extracting` is used while the worker fetches a URL. The worker can end the document in `failed`; deletion marks it `deleted`. There is no document status named `processing`.
 
-| Status       | Meaning                                              |
-|--------------|------------------------------------------------------|
-| `queued`     | Job enqueued, worker has not picked it up yet.       |
-| `extracting` | Fetching remote content (URL sources only).          |
-| `chunking`   | Splitting content into chunks.                       |
-| `embedding`  | Requesting embedding vectors for each chunk.         |
-| `indexing`   | Final writes — memory records and FTS index update.  |
-| `done`       | All chunks embedded and indexed.                     |
-| `failed`     | Processing error. See `error` field on the document. |
-| `deleted`    | Document removed via DELETE endpoint.                |
+Each completed chunk is a memory with `type: "document_chunk"`, connected through `document_memories` with a sequential `chunk_index`. `GET /api/documents/:id/chunks` returns active linked chunks in chunk-index order.
 
-Status transitions are written inside write transactions so reads always
-see a consistent state.
+## Chunking
 
+The worker splits content by characters with overlap. Whitespace-only chunks are skipped. The defaults are:
 
-## Chunking Strategy
+| Setting | Default | Accepted range |
+|---|---:|---:|
+| Chunk size | 2,000 characters | 200–50,000 |
+| Chunk overlap | 200 characters | 0–10,000 |
+| Worker interval | 10,000 ms | 1,000–300,000 ms |
+| Maximum content | 10 MiB | 1 KiB–100 MiB |
 
-Text is split into fixed-size windows with a configurable overlap. The
-overlap ensures that context spanning a chunk boundary is not silently
-dropped at retrieval time.
+Identical chunk content can be shared by more than one document in the same scope. The relationship is represented by multiple document-to-memory links, not by duplicating a memory record.
 
-The splitter is character-based, not token-based. Given `chunkSize = 2000`
-and `chunkOverlap = 200`:
+## Delete a document
 
-- Chunk 0 covers characters `0..2000`.
-- Chunk 1 covers characters `1800..3800`.
-- Chunk 2 covers characters `3600..5600`.
-- And so on until the end of the document.
+`DELETE /api/documents/:id?reason=<reason>` marks the document `deleted`, completes any still-pending document-ingest job, and returns:
 
-Documents shorter than `chunkSize` are stored as a single chunk. Empty
-chunks (whitespace only) are skipped and do not produce memory entries.
+```json
+{ "deleted": true, "memoriesRemoved": 3 }
+```
 
-Default values:
-
-| Parameter           | Default | Min  | Max        |
-|---------------------|---------|------|------------|
-| `documentChunkSize` | `2000`  | `200`| `50000`    |
-| `documentChunkOverlap` | `200` | `0` | `10000`    |
-| `documentMaxContentBytes` | `10 MB` | `1 KB` | `100 MB` |
-
-See the Configuration section below for how to override these.
-
-
-## Document-to-Memory Linking
-
-Each chunk that passes the dedup check becomes an entry in the `memories`
-table with `type = "document_chunk"`. Two join tables connect the pieces:
-
-- `document_memories` — links a `document_id` to a `memory_id` with the
-  chunk's sequential `chunk_index`. This is the primary join for retrieval
-  by document.
-- `embeddings` — stores the vector blob for each chunk, keyed on
-  `content_hash`. If two documents share identical chunk text they will
-  share the same embedding row.
-
-Deduplication happens at the chunk level: before writing a new memory the
-worker checks whether a non-deleted memory with the same content hash is
-already linked to the document. Matching chunks are silently skipped.
-
-Tags on chunk memories take the form `document:<title>`, making it easy to
-filter hybrid search results by source document.
-
-
-## Worker Model
-
-`startDocumentWorker()` runs a polling loop inside the [Daemon](/daemon/) process. It
-shares the same lease-based job table (`memory_jobs`) used by the
-extraction worker. The job type is `document_ingest`.
-
-On each tick the worker:
-
-1. Atomically claims one pending job by setting its status to `leased`
-   and incrementing `attempts`.
-2. Looks up the associated document row.
-3. Runs it through the full `extracting → chunking → embedding → indexing`
-   sequence, updating document status at each stage.
-4. Marks the job `completed` and the document `done`.
-
-If processing throws, the job is retried up to `workerMaxRetries` times
-(default `3`). After exhausting retries the job moves to `dead` and the
-document to `failed`.
-
-Embedding calls are intentionally made *outside* write transactions to
-avoid holding a SQLite write lock during network I/O. Each chunk's memory
-write is its own short transaction.
-
-The worker is started alongside the extraction pipeline in
-`platform/daemon/src/pipeline/index.ts` and stops cleanly when the daemon
-shuts down.
-
+`memoriesRemoved` is the number of linked memories that this deletion actually soft-deleted. It is not the document’s chunk count. A linked memory is preserved when another non-deleted document still references it, so deleting one document never destroys a shared chunk that another active document needs.
 
 ## Configuration
 
-Document worker settings live under the `pipeline` key in `agent.yaml`
-(or the equivalent daemon config). All values are validated and clamped
-on load.
+Document settings belong under `memory.pipelineV2.documents` in `agent.yaml`:
 
 ```yaml
-pipeline:
-  documentChunkSize: 2000          # chars per chunk
-  documentChunkOverlap: 200        # overlap between adjacent chunks
-  documentWorkerIntervalMs: 10000  # polling interval in milliseconds
-  documentMaxContentBytes: 10485760  # max fetched content for URL sources
+memory:
+  pipelineV2:
+    documents:
+      chunkSize: 2000
+      chunkOverlap: 200
+      workerIntervalMs: 10000
+      maxContentBytes: 10485760
 ```
 
-`documentWorkerIntervalMs` controls how frequently the worker polls for
-new jobs. The minimum is `1000 ms`; the maximum is `300000 ms` (5 min).
+The daemon validates and clamps these values when it loads configuration. The legacy flat document keys, if used, are still inside `memory.pipelineV2`; there is no supported top-level `pipeline` document configuration.
 
-Changes to chunk size do not retroactively re-chunk existing documents.
-To re-process a document with new chunk settings, delete it and resubmit.
+Changing chunk settings affects future ingestion only. To apply new chunking to an existing document, delete it and submit it again.
+
+## Worker behavior
+
+The document worker polls `memory_jobs` for `document_ingest` work. It claims a job, updates document lifecycle state as it processes the content, writes chunks and their embeddings, then marks the document complete. Network embedding calls happen outside write transactions, while each memory write remains a short transaction.
+
+For endpoint permissions, request fields, list pagination, source types, and response fields, use the [Documents and sources API](/api/documents-sources/).

--- a/web/docs/src/content/docs/sources.md
+++ b/web/docs/src/content/docs/sources.md
@@ -22,6 +22,32 @@ Use Sources when you want Signet to recall from:
 
 A source hit is marked as source-backed recall, not as a native saved memory. Obsidian recall results include a canonical `source_path` so agents and tools can inspect the original file directly.
 
+## Use the Dashboard
+
+Open the [Dashboard](/dashboard/) and select **Sources**. The current Sources surface starts with **Connect a source** for Obsidian, GitHub, or Discord, and **Import files** for durable, read-only file imports. Connected-source cards show artifact, chunk, and indexed counts plus source health; they also support re-indexing, snapshot download, and removal.
+
+The Dashboard dialog deliberately collects the basic fields only:
+
+| Kind | Required dashboard input | Optional input |
+|---|---|---|
+| Obsidian | Absolute vault path | Display name |
+| GitHub | `owner/repo` or `owner/*` | Display name and token secret reference |
+| Discord | Guild ID and bot-token secret reference | Display name |
+
+For an Obsidian vault, **Browse** asks the local daemon to open a folder picker. The desktop shell can use its native picker; browser/dev mode may need a pasted absolute path when no native picker is available.
+
+The Dashboard does not expose Discord mode selectors, channel filters, cache paths, or Gateway-tail controls. Use the CLI or the [Discord source API](/api/documents-sources/#post-api-sources-discord) for those advanced settings. Store tokens in Signet Secrets or another secret reference; do not place raw tokens in source configuration.
+
+### Import files
+
+Choose **Import files**, select one or more files, choose how duplicates should be handled, then select **Import & index**. The importer accepts text, Markdown, JSON, HTML, CSV, and AnyDoc-supported document formats: `doc`, `docx`, `docm`, `odt`, `rtf`, `pdf`, `ppt`, `pptx`, `ppsx`, `odp`, `epub`, `xls`, `xlsx`, `xlsm`, and `ods`.
+
+The current bounds are 25 files per batch, 25 MiB per file, and 100 MiB per batch. Results are reported per file, so a malformed or unsupported file does not hide successful imports from the same batch. Choose **Skip duplicate** to keep the existing import, **Replace and re-index** to replace it and queue indexing again, or **Import as a new source** to retain a second source for the same content.
+
+In a desktop-local session, **Choose from desktop** can return local paths to a loopback daemon. Remote clients must upload file bytes; a remote daemon never treats a path string as permission to read the client’s filesystem.
+
+> TODO: add dark-mode screenshots for the Connect a source and Import files dialogs after capture against a controlled, non-private daemon fixture. This worktree has no such fixture, so no mock or private-path imagery is published here.
+
 ## Discord v1
 
 Discord Sources v1 indexes bot-accessible guild context through Discord REST API v10 and local Discord Desktop cache artifacts:


### PR DESCRIPTION
## Summary

Refresh public Dashboard, Sources, Documents, and API reference pages against the current React/Vite dashboard and daemon contracts. This is documentation-only: no application behavior changes.

## Changes

- Replaced retired Svelte dashboard claims with the current React/Vite shell, current hash views, settings modal, and daemon SPA behavior.
- Documented the Dashboard's basic Sources dialog, the real file-import flow, and the boundary to advanced Discord CLI/API configuration.
- Corrected document ingestion lifecycle, `document_chunk` records, shared-memory deletion semantics, and `memory.pipelineV2.documents` configuration.
- Added the loopback-only `POST /api/sources/pick-files` route to the public route inventory and clarified connector versus Dashboard Sources boundaries.
- Added an explicit stable `post-api-sources-discord` anchor for the Discord API section and a regression test for both public links that target it.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [x] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: public documentation (`web/docs`)

## Screenshots

Not applicable: this PR changes documentation only and does not change dashboard code. The refreshed Sources page includes a clear TODO for dark-mode dialog screenshots; no controlled, non-private daemon fixture exists in this worktree, so this PR deliberately publishes no mock or private-path imagery.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations.

## Testing

- [x] `bun test` passes: `bun test web/docs/scripts/anchor-regression.test.ts`
- [x] `bun run typecheck` passes: `bun run --cwd web/docs check`
- [x] `bun run lint` passes: `bunx biome check web/docs/scripts/anchor-regression.test.ts`
- [ ] Tested against running daemon
- [x] N/A

Additional local verification after rebase:

- `bun run --cwd web/docs validate:content` — 90 public docs pages and 90 routes validated
- `bun run --cwd web/docs build` — 92 pages built
- `git diff --check origin/main..HEAD` — clean
- Generated HTML proof: `id="post-api-sources-discord"` appears in `/api/documents-sources/`; both `/dashboard/` and `/sources/` contain links to that fragment.
- Regression sabotage proof: removing the explicit anchor made the test fail with status 1; restoring it made the test pass.

`bun scripts/doc-drift.ts --markdown` still reports seven unrelated missing API-reference routes and 21 missing package-table entries in each of `AGENTS.md` and `README.md`; this PR does not expand into that baseline cleanup.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The repair was rebased onto current `origin/main` at `a7884b04bb885d31ac203eca69bdd856334878b`. The unchecked daemon item is not applicable because this PR changes only public documentation and its docs regression test; the mandatory checks marked N/A above likewise have no runtime/data-query/config/endpoints to exercise. The final repair commit is `db9f9791520696fafddf846b7740fa22677376bb`.
