### PR TITLE
docs(web): refresh SDK and harness interfaces

### DIFF
--- a/web/docs/src/content/docs/harnesses/claude-code.md
+++ b/web/docs/src/content/docs/harnesses/claude-code.md
@@ -5,94 +5,37 @@ description: "Connect Signet to Claude Code."
 
 ## Claude Code
 
-Claude Code is Anthropic's official CLI for Claude. It reads configuration from `~/.claude/`.
+The Claude Code connector installs Signet lifecycle hooks, a skills symlink, and an MCP registration. Run `signet setup` and select Claude Code, or rerun the Claude Code connector after an upgrade.
 
 ### Files managed by Signet
 
-| File | Description |
-|------|-------------|
-| `~/.claude/CLAUDE.md` | Auto-synced from `$SIGNET_WORKSPACE/AGENTS.md` |
-| `~/.claude/settings.json` | Hook configuration (written once during setup) |
+| Location | Purpose |
+|---|---|
+| `~/.claude/settings.json` | Signet hook configuration |
+| `~/.claude.json` | Top-level `mcpServers.signet` registration |
+| `~/.claude/skills` | Symlink to the Signet workspace skills directory |
 
-### Memory hooks
+Signet no longer generates `~/.claude/CLAUDE.md`. Identity and memory context are delivered by the session-start hook. During installation, Signet removes only a stale `CLAUDE.md` that it can identify as previously generated; it does not replace user-authored files.
 
-Signet writes [Hooks](/hooks/) to `~/.claude/settings.json` that fire at session lifecycle events. The hooks call the Signet [CLI](/cli/), which routes requests through the daemon HTTP API:
+### Hook behavior and timeouts
 
-```json
-{
-  "hooks": {
-    "SessionStart": [{
-      "hooks": [{
-        "type": "command",
-        "command": "signet hook session-start -H claude-code --project \"$(pwd)\"",
-        "timeout": 3000
-      }]
-    }],
-    "UserPromptSubmit": [{
-      "hooks": [{
-        "type": "command",
-        "command": "signet hook user-prompt-submit -H claude-code --project \"$(pwd)\"",
-        "timeout": 7000
-      }]
-    }],
-    "SessionEnd": [{
-      "hooks": [{
-        "type": "command",
-        "command": "signet hook session-end -H claude-code",
-        "timeout": 15000
-      }]
-    }]
-  }
-}
-```
+The connector writes hooks to `~/.claude/settings.json`:
 
-Prompt-submit timeout note: `SIGNET_PROMPT_SUBMIT_TIMEOUT` defaults to
-`5000` (daemon wait budget). Claude Code hook config adds a `+2000ms`
-grace buffer when written to `settings.json`, so the installed
-`UserPromptSubmit` timeout default is `7000`.
+| Hook | Signet command | Installed timeout |
+|---|---|---|
+| `SessionStart` | `signet hook session-start -H claude-code --project "$(pwd)"` | resolved session-start budget plus 2 seconds |
+| `UserPromptSubmit` | `signet hook user-prompt-submit -H claude-code --project "$(pwd)"` | resolved prompt-submit budget plus 2 seconds |
+| `PreToolUse` | `signet hook notifications -H claude-code --hook PreToolUse --project "$(pwd)" --hook-json` | 3 seconds |
+| `PreCompact` | `signet hook pre-compaction -H claude-code --project "$(pwd)"` | 3 seconds |
+| `SessionEnd` | `signet hook session-end -H claude-code` | 15 seconds |
 
-Upgrade note: Claude Code hook timeouts are written to
-`~/.claude/settings.json` at install/update time. Existing installs keep
-their previous timeout values until you rerun `signet connect
-claude-code` (or `signet setup`) to rewrite hook config.
+The default daemon session-start budget is 15 seconds, so the default installed `SessionStart` timeout is 17 seconds. The connector computes this when it writes the configuration from `SIGNET_SESSION_START_TIMEOUT` (or the compatibility fetch-timeout variable). It does not assume a home directory or bake a personal path into the hook command.
 
-**SessionStart** — loads memories and context, outputs them as text that Claude Code injects into the system prompt.
+Likewise, the prompt-submit hook uses the resolved `SIGNET_PROMPT_SUBMIT_TIMEOUT` plus two seconds. Existing settings are not changed until setup or connector installation runs again.
 
-**UserPromptSubmit** — optionally loads per-prompt context (lighter weight than session start).
+### MCP tools
 
-**SessionEnd** — automatically saves a session summary to memory.
-
-### Native memory bridge
-
-Signet indexes Claude Code-owned memdir artifacts without rewriting them or
-turning them into Signet-authored rows. The daemon watches Claude Code
-entrypoint indexes and memory files under `~/.claude/projects/*/memory/`,
-session memory under `~/.claude/session-memory/`, and agent-scoped memory
-under `~/.claude/agent-memory/` and `~/.claude/agent-memory-local/`. Matching
-content is exposed through Signet recall as `native_memory` results with
-Claude Code provenance. Removed native files are soft-deleted from active
-recall while preserving their artifact rows for lineage.
-
-This replaces the older daemon-local Claude watcher that only read
-`~/.claude/projects/*/memory/MEMORY.md` and pushed chunks back through
-`/api/memory/remember`. Claude Code remains the owner of those native files;
-Signet indexes them as artifacts.
-
-### Using /remember and /recall
-
-In Claude Code sessions, use these commands directly:
-
-```
-/remember nicholai prefers bun over npm
-/recall coding preferences
-```
-
-These work via the built-in skills in `$SIGNET_WORKSPACE/skills/`. The skill instructions tell Claude how to call the Signet daemon API.
-
-### MCP Tools
-
-Claude Code also gets native MCP tool access to Signet memory via the
-`signet-mcp` stdio server, registered in `~/.claude/settings.json`:
+The connector writes the stdio server to `~/.claude.json`, not `~/.claude/settings.json`:
 
 ```json
 {
@@ -100,19 +43,30 @@ Claude Code also gets native MCP tool access to Signet memory via the
     "signet": {
       "type": "stdio",
       "command": "signet-mcp",
-      "args": []
+      "args": [],
+      "env": {}
     }
   }
 }
 ```
 
-This gives Claude Code direct access to `memory_search`, `session_search`,
-`memory_store`, `memory_get`, `memory_list`, `memory_modify`, and
-`memory_forget` tools.
+See the [MCP server reference](/mcp/) for the current tool schemas. Hooks supply automatic lifecycle context; MCP tools are for agent-initiated operations.
+
+### Native memory bridge
+
+Signet indexes Claude Code-owned memory artifacts without rewriting them into Signet-authored files. Recall surfaces expose matching entries with Claude Code provenance. Removing a native file removes it from active recall while preserving the artifact record for lineage.
+
+### Commands in a session
+
+When the matching skills are installed, Claude Code can use:
+
+```text
+/remember a durable preference or decision
+/recall the decision about the deployment workflow
+```
 
 ### Prerequisites
 
-- Claude Code installed and in `PATH`
-- `~/.claude/` directory exists
-
----
+- Claude Code is installed and available in `PATH`.
+- The Signet daemon is running.
+- The connector is installed through `signet setup` or the Claude Code connector command.

--- a/web/docs/src/content/docs/harnesses/hermes-agent.md
+++ b/web/docs/src/content/docs/harnesses/hermes-agent.md
@@ -5,62 +5,32 @@ description: "Connect Signet to Hermes Agent."
 
 ## Hermes Agent
 
-Hermes Agent is an open-source terminal AI agent by Nous Research. Signet
-integrates as a pluggable memory provider via Hermes's `MemoryProvider` ABC,
-deploying a Python plugin that bridges all Signet daemon hooks into the
-Hermes lifecycle.
+Signet integrates with Hermes Agent through a Python `MemoryProvider` plugin. The connector installs the provider in the user plugin directory and, when a Hermes checkout is discovered, can also install its repo plugin copy. It configures `memory.provider: signet` and the daemon connection variables in the Hermes home.
 
-### Files managed by Signet
+### Managed files
 
-| Location | Description |
-|----------|-------------|
-| `~/.hermes/plugins/signet/__init__.py` | User-level Signet `MemoryProvider` implementation |
-| `~/.hermes/plugins/signet/client.py` | User-level HTTP client for the Signet daemon API |
-| `~/.hermes/plugins/signet/plugin.yaml` | User-level plugin metadata |
-| `~/.hermes/plugins/signet/signet.install.json` | Install marker with connector version and plugin source hash |
-| `<hermes-repo>/plugins/memory/signet/__init__.py` | Signet `MemoryProvider` implementation |
-| `<hermes-repo>/plugins/memory/signet/client.py` | HTTP client for the Signet daemon API |
-| `<hermes-repo>/plugins/memory/signet/plugin.yaml` | Plugin metadata |
-| `<hermes-repo>/plugins/memory/signet/signet.install.json` | Install marker with connector version and plugin source hash |
-| `~/.hermes/config.yaml` | `memory.provider: signet` activation |
-| `~/.hermes/.env` | Daemon connection environment variables |
+| Location | Purpose |
+|---|---|
+| `~/.hermes/plugins/signet/` | User-level Signet provider files and install marker |
+| `<hermes-repo>/plugins/memory/signet/` | Optional repo-plugin copy when a checkout is discovered |
+| `~/.hermes/config.yaml` | Enables `memory.provider: signet` |
+| `~/.hermes/.env` | Non-secret daemon connection configuration |
 
-### How it works
+### Lifecycle behavior
 
-1. `signet setup` (with `hermes-agent` selected) copies the Python plugin
-   into both `~/.hermes/plugins/signet/` and, when discovered,
-   `<hermes-repo>/plugins/memory/signet/`.
-2. The connector writes install markers, daemon connection env vars to
-   `~/.hermes/.env`, and activates the provider by setting
-   `memory.provider: signet` in Hermes config.
-3. At session start, Hermes calls `initialize()` on the plugin, which fires
-   `POST /api/hooks/session-start` to load identity, memories, and system
-   prompt injection from the daemon.
-4. On each user turn, `queue_prefetch()` fires
-   `POST /api/hooks/user-prompt-submit` for entity current-view context when
-   the prompt mentions a known entity or active alias.
-5. At session end, `on_session_end()` sends the accumulated transcript via
-   `POST /api/hooks/session-end` for async pipeline extraction.
-6. Committed Hermes built-in memory writes are mirrored through a serialized
-   FIFO queue so add/replace/remove callbacks retain their batch order.
+The provider calls the Signet hook API at session start, before relevant user turns, compaction boundaries, delegation, and session end. Those hooks provide automatic context and capture evidence. The provider's tools are separate, on-demand operations.
+
+Committed Hermes built-in memory writes are mirrored through a serialized FIFO queue so add, replace, and remove callbacks retain their batch order.
 
 ### Built-in memory mirror semantics
 
-The Hermes connector uses synchronization rather than leaving Signet with an
-add-only copy of Hermes memory:
+The Hermes connector uses synchronization rather than leaving Signet with an add-only copy of Hermes memory:
 
 - `add` creates immutable episodic evidence in Signet.
-- `replace` creates a new row and atomically supersedes the row matched by
-  Hermes's `old_text`.
+- `replace` creates a new row and atomically supersedes the row matched by Hermes's `old_text`.
 - `remove` soft-deletes the matched row.
 
-Superseded and deleted rows remain available for provenance and audit history,
-but current Signet recall and list views exclude them. Mirror rows are tagged
-with their Hermes target and use Signet's default `global` visibility, matching
-the connector's existing write contract. They carry agent, project, session,
-source, and a deterministic idempotency key. Retrying a callback is therefore
-safe, and a missing or ambiguous mirrored match is never treated as permission
-to mutate an unrelated Signet memory.
+Superseded and deleted rows remain available for provenance and audit history, but current Signet recall and list views exclude them. Mirror rows are tagged with their Hermes target and use Signet's default `global` visibility, matching the connector's existing write contract. They carry agent, project, session, source, and a deterministic idempotency key. Retrying a callback is therefore safe, and a missing or ambiguous mirrored match is never treated as permission to mutate an unrelated Signet memory.
 
 ### Native memory bridge
 
@@ -78,41 +48,23 @@ soft-deleted and excluded from active recall. Artifacts remain scoped to the
 current Signet agent, and an exact current `hermes-memory-write` mirror is not
 returned a second time during recall.
 
-### Tools exposed to the agent
+### Tools exposed to Hermes
 
-| Tool | Description |
-|------|-------------|
-| `memory_search` | Hybrid memory search (keyword + semantic + knowledge graph) |
-| `signet_session_search` | Search active or completed session transcripts |
-| `memory_store` | Store a fact/preference/decision with auto entity extraction |
-| `memory_get` | Retrieve a memory by ID |
-| `memory_list` | List memories with optional filters |
-| `memory_modify` | Edit an existing memory |
-| `memory_forget` | Soft-delete a memory |
-| `recall` / `remember` | Compatibility aliases for search/store |
+| Tool | Purpose |
+|---|---|
+| `memory_search` | Hybrid memory recall |
+| `signet_session_search` | Search Signet session transcripts |
+| `memory_store` | Store a durable memory |
+| `memory_get`, `memory_list` | Inspect memory records |
+| `memory_modify`, `memory_forget` | Edit or soft-delete a memory |
+| `recall`, `remember` | Compatibility aliases |
 
-### Supported hooks
+`signet_session_search` is intentionally namespaced. Hermes already has a built-in `session_search` tool, so registering the Signet transcript tool under that bare name would collide and be dropped. Use `signet_session_search` when the task needs Signet-managed transcript evidence; Hermes's built-in `session_search` remains its own surface.
 
-| Hook | Supported |
-|------|-----------|
-| session-start | yes — identity + memories via `system_prompt_block()` |
-| user-prompt-submit | yes — entity current-view context via `queue_prefetch()` / `prefetch()` |
-| pre-compaction | yes — daemon-generated summary guidelines via `on_pre_compress()` |
-| compaction-complete | yes — saves summary as session memory via `on_compaction_complete()` |
-| checkpoint-extract | yes — periodic mid-session delta extraction every 30 turns |
-| session-end | yes — transcript extraction via `on_session_end()` |
+### Verify installation
 
-### Delegation support
+```bash
+signet doctor hermes
+```
 
-When Hermes delegates to subagents, the parent's `on_delegation()` hook
-stores the task+result pair as a Signet memory tagged `["delegation", "subagent"]`.
-
-### Prerequisites
-
-- Hermes Agent installed (repo with `plugins/memory/` directory)
-- Signet daemon running (`signet start`)
-- `signet setup --harness hermes-agent`
-- `signet doctor hermes` reports daemon health, plugin freshness, config
-  activation, and Hermes tool routing
-
----
+The diagnostic checks provider activation, plugin freshness, daemon reachability, and the registered Signet tool names. It does not replace normal Hermes diagnostics for unrelated configuration problems.

--- a/web/docs/src/content/docs/mcp.md
+++ b/web/docs/src/content/docs/mcp.md
@@ -91,6 +91,16 @@ Common refinements:
 | `since` | string | no | Only include memories created after this date |
 | `until` | string | no | Only include memories created before this date |
 
+Context and temporal controls:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `time` | object | no | Temporal range with optional `start`, `end`, `facets` (`captured`, `session`, `source`, `observed`, `occurred`, `valid`), and mode (`auto`, `timeline`, or `filter`) |
+| `session_key` | string | no | Session key used for per-context recall deduplication |
+| `agent_id` | string | no | Agent scope for the recall request |
+| `include_recalled` | boolean | no | Include rows already recalled in this context |
+| `scope` | `"global" \| "agent" \| "session"` | no | Constrain recall to that memory scope |
+
 Advanced controls:
 
 | Name | Type | Required | Description |
@@ -143,7 +153,7 @@ hints, and transcripts are forwarded as request metadata.
 | `importance` | number | no | Importance score 0–1 |
 | `tags` | string | no | Comma-separated tags for categorization |
 | `pinned` | boolean | no | Pin this memory so it bypasses decay |
-| `hints` | string[] | no | Prospective recall hints and alternate phrasings |
+| `hints` | string[] | yes | At least one non-empty prospective recall hint or alternate phrasing |
 | `transcript` | string | no | Raw source text to preserve alongside the extracted memory |
 | `structured` | object | no | Pre-extracted entity/aspect/attribute data retained as episodic evidence alongside the content; not applied directly to the knowledge graph from this tool |
 | `reviewAfter` | string | no | ISO timestamp after which Dreaming should surface the memory for temporal review |
@@ -156,7 +166,8 @@ hints, and transcripts are forwarded as request metadata.
 {
   "content": "User prefers Bun over npm for package management",
   "importance": 0.8,
-  "tags": "preference,tooling"
+  "tags": "preference,tooling",
+  "hints": ["package manager preference", "Bun versus npm"]
 }
 ```
 
@@ -531,9 +542,9 @@ explicitly, or `op://...` for 1Password compatibility references.
 
 ```json
 {
-  "command": "curl -H \"Authorization: Bearer $OPENAI_API_KEY\" https://api.openai.com/v1/models",
+  "command": "node ./sync.js",
   "secrets": {
-    "OPENAI_API_KEY": "OPENAI_API_KEY"
+    "SYNC_SERVICE_TOKEN": "SYNC_SERVICE_TOKEN"
   }
 }
 ```
@@ -599,10 +610,10 @@ accepts optional `depth` and `direction` (`forward`, `backward`, or `both`).
 
 AI harnesses discover Signet's MCP server in one of two ways:
 
-### Automatic (via `signet install`)
+### Automatic (via `signet setup` or the harness connector)
 
 The connector for each harness registers the MCP server in the harness's
-configuration file during installation. No manual steps needed.
+configuration file during setup. No manual steps are needed.
 
 ### Manual discovery
 
@@ -660,8 +671,10 @@ SIGNET_PORT         # Override daemon port (default: 3850)
 
 ### Claude Code
 
-The Claude Code connector registers the MCP server in
-`~/.claude/settings.json` during `signet install`:
+The Claude Code connector registers the MCP server in the top-level
+`~/.claude.json` user configuration during setup. Hook configuration remains
+in `~/.claude/settings.json`; Claude Code does not read `mcpServers` from that
+file.
 
 ```json
 {

--- a/web/docs/src/content/docs/memory-skills.md
+++ b/web/docs/src/content/docs/memory-skills.md
@@ -1,302 +1,37 @@
 ---
 title: "Memory Skills"
-description: "Built-in memory management skills."
+description: "Use Signet memory skills and their CLI equivalents."
 ---
 
-> **Status:** Implemented
->
-> The `remember` and `recall` commands work via the Signet [CLI](/cli/) (`signet remember`,
-> `signet recall`) which calls the daemon HTTP API.
+Signet's memory skills provide agent-facing instructions for storing and recalling durable context. The corresponding CLI commands are `signet remember` and `signet recall`; both call the daemon's memory API.
 
----
-
-Signet ships with three core [Skills](/skills/) for [Memory](/memory/) management: `remember`, `recall`, and `memory-debug`. These integrate directly with the Signet [Daemon](/daemon/).
-
-## Overview
-
-| Skill | CLI Command | Harness Command | Purpose |
-|-------|-------------|-----------------|---------|
-| remember | `signet remember <content>` | `/remember <content>` | Save to persistent memory |
-| recall | `signet recall <query>` | `/recall <query>` | Search persistent memory |
-| memory-debug | diagnostic checks | `/memory-debug [symptom]` | Diagnose memory failures and quality issues |
-
-These are the primary interface between agents and the memory system.
-
-## remember
-
-### Syntax
+## Remember
 
 ```bash
-# CLI
-signet remember <content>
-signet remember <content> --critical
-signet remember <content> -t tag1,tag2
-
-# In harness
-/remember <content>
-/remember critical: <content>
-/remember [tag1,tag2]: <content>
+signet remember "The project uses Bun for package scripts"
+signet remember "Never put credentials in public issue bodies" --critical
+signet remember "Use the release checklist" -t release,workflow
 ```
 
-### Features
+Harnesses that expose the installed skills can provide equivalent `/remember` usage. Use it for durable facts, preferences, and decisions, not transient task progress.
 
-- **Auto-embedding**: Content is vectorized for semantic search
-- **Type inference**: Detects preferences, decisions, facts, etc.
-- **Critical marking**: `--critical` flag or `critical:` prefix pins memories (never decay)
-- **Tagging**: `-t` flag or `[tag1,tag2]:` prefix adds explicit tags
-- **Cross-harness**: Memories shared across all AI tools
-
-### Examples
+## Recall
 
 ```bash
-signet remember "nicholai prefers tabs over spaces"
-signet remember "never push directly to main branch" --critical
-signet remember "agent profile lives at $SIGNET_WORKSPACE/" -t signet,architecture
+signet recall "package manager preference"
+signet recall "release workflow" -l 5 --type decision --tags workflow
+signet recall "what did we decide about migrations?" --aggregate --aggregate-budget small
 ```
 
-### Implementation
+Recall accepts a natural-language query and optional filters. An aggregate recall synthesizes from bounded retrieved evidence; use `--no-save-aggregate` when that synthesis should not become a normal memory row.
 
-The CLI calls the daemon HTTP API:
+## Diagnostic posture
+
+When recall or storage behaves unexpectedly, first check daemon availability and then use the narrowest relevant command:
 
 ```bash
-# CLI (preferred)
-signet remember "content to save" -w claude-code
-
-# Direct API call
-curl -X POST http://localhost:3850/api/memory/remember \
-  -H "Content-Type: application/json" \
-  -d '{"content": "content to save", "who": "claude-code"}'
+signet status
+signet recall "a known fact" --json
 ```
 
-The daemon handles:
-1. Parsing prefixes (critical:, [tags]:)
-2. Inferring memory type from content
-3. Generating embedding via configured provider
-4. Storing in SQLite + vector store
-5. Returning confirmation
-
-### Response Format
-
-After saving, the agent should confirm:
-
-```
-✓ Saved: "nicholai prefers tabs over spaces"
-  type: preference | tags: [coding] | embedded
-```
-
-For critical:
-```
-✓ Saved (pinned): "never push directly to main"
-  type: rule | importance: 1.0 | embedded
-```
-
-## recall
-
-### Syntax
-
-```bash
-# CLI
-signet recall <query>
-signet recall <query> -l 5
-signet recall <query> --type decision --tags project
-signet recall <query> --aggregate --aggregate-budget small
-signet recall <query> --aggregate --no-save-aggregate
-
-# In harness
-/recall <query>
-```
-
-### Features
-
-- **Hybrid search**: Combines vector similarity (70%) + keyword matching (30%)
-- **Score display**: Shows relevance scores for transparency
-- **Rich results**: Content, tags, source, type, timestamps
-- **Filters**: Filter by type (`--type`), tags (`--tags`), who (`--who`)
-- **Aggregate recall**: `--aggregate` synthesizes one answer from bounded
-  evidence and saves it as a normal memory by default
-
-### Examples
-
-```bash
-signet recall "signet architecture"
-signet recall "preferences" -l 5
-signet recall "API" --type decision --tags project
-signet recall "bun vs npm" --json
-signet recall "what did we decide about aggregate recall?" --aggregate
-```
-
-### Implementation
-
-The CLI calls the daemon HTTP API:
-
-```bash
-# CLI (preferred)
-signet recall "search query" -l 10
-
-# Direct API call
-curl -X POST http://localhost:3850/api/memory/recall \
-  -H "Content-Type: application/json" \
-  -d '{"query": "search query", "limit": 10, "aggregate": true}'
-```
-
-### Response Format
-
-```
-[0.92|hybrid] Agent profile lives at $SIGNET_WORKSPACE/ [signet,architecture] [pinned]
-       type: fact | who: claude-code | Feb 15
-
-[0.78|hybrid] Signet uses SQLite for memory storage
-       type: fact | who: opencode | Feb 14
-
-[0.65|vector] Memory system supports hybrid search
-       type: fact | who: claude-code | Feb 12
-```
-
-Score breakdown:
-- `[0.92|hybrid]` - Combined score, search method
-- `[pinned]` - Critical/pinned memory
-- Individual components available: `vec: 0.88, bm25: 0.95`
-
-## Configuration
-
-### Embedding Provider
-
-In `$SIGNET_WORKSPACE/agent.yaml`:
-
-```yaml
-embedding:
-  provider: ollama          # or 'openai'
-  model: nomic-embed-text   # or 'text-embedding-3-small'
-  dimensions: 768           # or 1536 for OpenAI
-```
-
-### Search Tuning
-
-```yaml
-search:
-  alpha: 0.7        # Vector weight (0-1, higher = more semantic)
-  top_k: 20         # Candidates per search method
-  min_score: 0.3    # Minimum score threshold
-```
-
-## Memory Types
-
-The system auto-infers types from content:
-
-| Type | Triggered by | Example |
-|------|--------------|---------|
-| preference | "prefers", "likes", "wants" | "nicholai prefers dark mode" |
-| decision | "decided", "agreed", "will" | "decided to use bun" |
-| fact | default | "signet stores data in SQLite" |
-| rule | "never", "always", "must" | "never commit secrets" |
-| learning | "learned", "discovered", "TIL" | "learned that X causes Y" |
-| issue | "bug", "problem", "broken" | "auth is broken on Safari" |
-
-## Importance Decay
-
-Non-pinned memories decay over time:
-
-```
-importance(t) = base_importance × decay_factor^(days_since_access)
-```
-
-- `decay_factor`: 0.99 (1% decay per day)
-- Accessing a memory resets its decay
-- Pinned memories (`critical:`) never decay
-
-## Daemon Integration
-
-When Signet daemon is running, the skills talk directly to the daemon API:
-
-```
-POST /api/memory/save
-  { content, who, project, importance?, tags?, pinned? }
-  → { id, embedded: true/false }
-
-GET /api/memory/search?q=<query>&limit=10&type=&tags=
-  → { results: [...] }
-
-GET /api/memory/similar?id=<memory_id>&k=5
-  → { results: [...] }
-```
-
-This is faster and more reliable than spawning Python subprocesses.
-
-## SKILL.md Files
-
-The skills ship as standard SKILL.md files in `$SIGNET_WORKSPACE/skills/`:
-
-### remember/SKILL.md
-
-## ```markdown
-name: remember
-description: Save to persistent memory with auto-embedding
-user_invocable: true
-arg_hint: "[critical:] [tags]: content"
-## builtin: true
-
-# /remember
-
-[Full documentation...]
-```
-
-### recall/SKILL.md
-
-## ```markdown
-name: recall
-description: Query persistent memory using hybrid search
-user_invocable: true
-arg_hint: "search query"
-## builtin: true
-
-# /recall
-
-[Full documentation...]
-```
-
-The `builtin: true` frontmatter indicates these ship with Signet and integrate with the daemon directly.
-
-## Migration Path
-
-### Completed: Daemon-Native Hooks
-
-All memory hooks now route through the daemon HTTP API. The migration from Python subprocess calls to daemon-native operations is complete:
-
-- Memory operations handled by daemon (TypeScript)
-- Skills call daemon HTTP API via `signet remember` / `signet recall`
-- No Python dependency for core functionality
-- Python scripts remain as optional batch tools (reindexing, export, migration)
-
-## Error Handling
-
-### remember errors
-
-```
-✗ Failed to save: embedding provider unavailable
-  Memory saved without embedding (keyword search only)
-```
-
-```
-✗ Failed to save: database locked
-  Retry in a moment
-```
-
-### recall errors
-
-```
-No results found for "obscure query"
-Try broader terms or check /memory in dashboard
-```
-
-```
-✗ Search failed: daemon not running
-  Start with: signet daemon start
-```
-
----
-
-## See Also
-
-- [Architecture](/architecture/) - Technical deep dive
-- [Configuration](/configuration/) - All config options
-- [Skills](/skills/) - Full skills system design
+The exact skill files and harness exposure differ by installation. Use `signet skill list` and `signet skill show <name>` to inspect the skills actually installed in the current workspace.

--- a/web/docs/src/content/docs/sdk.md
+++ b/web/docs/src/content/docs/sdk.md
@@ -1,16 +1,16 @@
 ---
 title: "SDK"
-description: "Integration SDK for third-party applications."
+description: "Typed TypeScript client for the Signet daemon."
 ---
 
-Integration SDK for third-party applications.
+`@signet/sdk` is the typed HTTP client for the Signet daemon. It has no SQLite dependency and exports four public entry points:
 
-`@signet/sdk` is a typed TypeScript HTTP client for the Signet [Daemon](/daemon/)
-[API](/api/). It has no native dependencies — no SQLite, no `@signet/core` —
-making it suitable for embedding in any Node.js, Bun, or browser environment
-that can reach the daemon over HTTP.
-
-Install with:
+| Import | Surface |
+|---|---|
+| `@signet/sdk` | `SignetClient`, errors, and public types |
+| `@signet/sdk/react` | React provider and memory hooks |
+| `@signet/sdk/ai-sdk` | Vercel AI SDK adapters |
+| `@signet/sdk/openai` | OpenAI function-tool adapters |
 
 ```bash
 bun add @signet/sdk
@@ -20,15 +20,9 @@ npm install @signet/sdk
 
 ## In this section
 
-- [SDK quickstart](/sdk/getting-started/)
-  Install, configure, and make the first typed Signet SDK calls.
-- [Core client](/sdk/core-client/)
-  Use client methods, jobs, sessions, scheduling, Git, secrets, and typed errors.
-- [SDK integrations](/sdk/integrations/)
-  Integrate Signet with React, Vercel AI SDK, OpenAI SDK, connectors, and hooks.
-- [Operations SDK](/sdk/operations/)
-  Use plugin diagnostics, skills, analytics, repair, pipeline, config, and embedding APIs.
-- [Knowledge and agents](/sdk/knowledge-agents/)
-  Use knowledge graph, cross-agent messaging, predictor, and timeline APIs.
-- [Helpers, types, and migration](/sdk/types-migration/)
-  Use helper methods, TypeScript types, error contracts, and migration guidance.
+- [SDK quickstart](/sdk/getting-started/): construct the client and make a first memory call.
+- [Core client](/sdk/core-client/): memory operations, auth, and queued secret execution.
+- [SDK integrations](/sdk/integrations/): React, AI SDK, OpenAI, lifecycle hooks, and connectors.
+- [Operations SDK](/sdk/operations/): plugins, skills, telemetry, repair, configuration, and embeddings.
+- [Knowledge and agents](/sdk/knowledge-agents/): knowledge graph and cross-agent coordination.
+- [Helpers, types, and migration](/sdk/types-migration/): supported helpers, exported types, errors, and version guidance.

--- a/web/docs/src/content/docs/sdk/core-client.md
+++ b/web/docs/src/content/docs/sdk/core-client.md
@@ -1,635 +1,74 @@
 ---
 title: "Core client"
-description: "Use client methods, jobs, sessions, scheduling, Git, secrets, and typed errors."
+description: "Use core memory operations, token auth, and queued secret execution."
 ---
 
-## Client Methods
-
-### Memory
-
-**`remember(content, opts?)`** — Save a memory to the daemon.
+## Construct a client
 
 ```typescript
-const result = await signet.remember("Prefers TypeScript over JavaScript", {
-  type: "preference",
-  importance: 0.9,
-  tags: "language,tooling",
-  pinned: false,
-  occurredAt: "2026-05-13T18:00:00Z",
-  reviewAfter: "2026-08-03T00:00:00.000Z",
-  mode: "sync",         // "auto" | "sync" | "async"
-  idempotencyKey: "pref-ts-001",
-});
-// result.id — assigned memory ID
-// result.deduped — true if an existing memory was reused
-```
+import { SignetClient } from "@signet/sdk";
 
-**`recall(query, opts?)`** — Hybrid search across memories using both
-vector similarity and keyword matching.
-
-A good default posture is:
-
-- start with `query`
-- add `limit`, `project`, or `expand` when you need more control
-- reach for the other filters only when you know why you want them
-
-```typescript
-const { results, query, method, meta } = await signet.recall("language preferences", {
-  project: "/home/user/myapp",
-  limit: 10,
-  time: { start: "2026-05-13T00:00:00Z", end: "2026-05-14T00:00:00Z" },
-  expand: true,
-  scope: "world:alpha",
-});
-// Omitted limits are sent as 10; request limits are bounded to 1..100
-// scope is an exact daemon memory-scope string; use agentId/sessionKey for isolation
-// meta.timings?.stages — daemon-side recall stages and durations
-// meta.temporal — resolved temporal window when date recall is active
-```
-
-You can refine further when needed:
-
-```typescript
-const result = await signet.recall("language preferences", {
-  keywordQuery: "\"language preferences\" OR tooling",
-  project: "/home/user/myapp",
-  type: "preference",
-  importance_min: 0.5,
-  minScore: 0.3,
-  since: "2025-01-01T00:00:00Z",
-  until: "2026-01-01T00:00:00Z",
-});
-// result.results[n].score — relevance score
-// result.results[n].source — "hybrid" | "vector" | "keyword" | "llm_summary"
-// result.results[n].supplementary — true for supporting context like summary cards
-// result.query — normalized query used by the daemon
-// result.method — "hybrid" | "keyword"
-// result.meta.totalReturned — result count after the daemon threshold (also re-applied defensively by the SDK)
-// result.meta.timings — present when the daemon returns recall stage timings
-```
-
-`recall()` and `recallOrThrow()` use the canonical Signet request builder, so
-they share default, bound, alias, omission, session, agent, scope, and aggregate
-semantics with runtime integrations. `minScore` is applied at the daemon
-response boundary and re-applied defensively by the SDK, preserving compatibility
-for existing SDK callers that already rely on score thresholding.
-
-Explicit aggregate recall is available through the same method:
-
-```typescript
-const aggregate = await signet.recall("what did we decide about onboarding?", {
-  aggregate: true,
-  aggregateBudget: "small",
-  saveAggregate: false,
-});
-// aggregate.results[0] — synthesized aggregate row when evidence exists
-// aggregate.aggregate?.queries — recall queries used during aggregation
-// aggregate.aggregate?.usage — provider-reported token/cost totals when available
-// aggregate.meta.timings?.stages — aggregate planning/synthesis timings
-```
-
-**`getMemory(id)`** — Fetch a single memory record by ID.
-
-```typescript
-const memory = await signet.getMemory("mem_abc123");
-// Returns a full MemoryRecord including version, access_count, etc.
-```
-
-**`listMemories(opts?)`** — List memories with optional pagination and
-type filter.
-
-```typescript
-const { memories, stats } = await signet.listMemories({
-  limit: 50,
-  offset: 0,
-  type: "preference",
-});
-// stats.total — total count across all pages
-// stats.critical — count of pinned/critical memories
-```
-
-**`modifyMemory(id, patch)`** — Update a memory's content or metadata.
-Requires a `reason` field for audit trail purposes. Supports optimistic
-concurrency via `ifVersion`.
-
-```typescript
-const result = await signet.modifyMemory("mem_abc123", {
-  content: "Prefers Bun over Node.js for new projects",
-  importance: 0.95,
-  reason: "Updated based on conversation",
-  ifVersion: 3,  // fails with version_conflict if current version differs
-});
-// result.status — "updated" | "no_changes" | "version_conflict" | ...
-```
-
-**`forgetMemory(id, opts)`** — Soft-delete a single memory. Pinned
-memories require `force: true`.
-
-```typescript
-await signet.forgetMemory("mem_abc123", {
-  reason: "No longer relevant",
-  force: false,
-  ifVersion: 4,
-});
-// result.status — "deleted" | "pinned_requires_force" | "version_conflict"
-```
-
-**`batchForget(opts)`** — Bulk soft-delete with a two-phase preview/execute
-flow. Call with `mode: "preview"` first to see what would be deleted and
-receive a `confirmToken`. Pass that token back with `mode: "execute"` to
-commit.
-
-```typescript
-// Phase 1: preview
-const preview = await signet.batchForget({
-  mode: "preview",
-  query: "outdated project notes",
-  type: "note",
-});
-// preview.confirmToken — pass this to the execute call
-
-// Phase 2: execute
-const result = await signet.batchForget({
-  mode: "execute",
-  query: "outdated project notes",
-  type: "note",
-  confirm_token: preview.confirmToken,
-  reason: "Cleaning up stale notes",
-});
-// result.deleted — number actually deleted
-// result.pinned — number skipped due to pinning
-```
-
-**`batchModify(patches, opts?)`** — Apply multiple memory patches in one
-request. Each patch requires a `reason`.
-
-```typescript
-const { results } = await signet.batchModify([
-  { id: "mem_1", importance: 0.8, reason: "Recalibrate importance" },
-  { id: "mem_2", tags: "archived", reason: "Tag for archival" },
-]);
-```
-
-**`getHistory(memoryId, opts?)`** — Retrieve the full audit trail for a
-memory: all create, update, and delete events.
-
-```typescript
-const { history } = await signet.getHistory("mem_abc123", { limit: 20 });
-// history[n].event — event type string
-// history[n].old_content / new_content — diff
-// history[n].changed_by — actor identity
-```
-
-**`recoverMemory(id, opts?)`** — Restore a soft-deleted memory.
-
-```typescript
-const result = await signet.recoverMemory("mem_abc123", {
-  reason: "Accidentally deleted",
-});
-// result.status — "recovered" | "not_found" | "not_deleted"
-// result.retentionDays — how long before permanent deletion
-```
-
-
-### Jobs
-
-**`getJob(jobId)`** — Check the status of an async pipeline job. When
-`remember` is called with `mode: "async"`, the response includes a job
-ID that you can poll here.
-
-```typescript
-const job = await signet.getJob("job_xyz");
-// job.status — "pending" | "leased" | "retry_scheduled" | "failed" | "completed" | "done" | "dead"
-// job.last_error — error message if the job failed
-```
-
-
-### Documents
-
-Documents are ingested content units (text, URLs, or files). The daemon
-chunks and embeds them, then links the resulting memories back to the
-source document.
-
-**`createDocument(opts)`** — Ingest a new document.
-
-```typescript
-const result = await signet.createDocument({
-  source_type: "text",
-  content: "Full text of a design doc...",
-  title: "Q1 Architecture Proposal",
-  content_type: "text/plain",
-  metadata: { project: "signet", version: "2.0" },
-});
-// result.id — document ID
-// result.deduplicated — true if the same content already exists
-// result.jobId — optional job id for async ingest tracking
-```
-
-**`getDocument(id)`** — Fetch a document record including chunk and
-memory counts.
-
-**`listDocuments(opts?)`** — List documents with status filter and
-pagination.
-
-```typescript
-const { documents } = await signet.listDocuments({
-  status: "processed",
-  limit: 20,
-  offset: 0,
+const client = new SignetClient({
+  daemonUrl: "http://localhost:3850",
+  token: process.env.SIGNET_TOKEN,
+  actor: "my-integration",
+  actorType: "service",
 });
 ```
 
-**`getDocumentChunks(id)`** — Get the individual chunks that were
-extracted from a document during ingestion.
+The constructor defaults to `http://localhost:3850`, a 10-second request timeout, and two retries for GET requests. Mutation requests are not retried automatically.
+
+## Memory lifecycle
 
 ```typescript
-const { chunks } = await signet.getDocumentChunks("doc_abc");
-// chunks[n].chunk_index — ordering within the document
-// chunks[n].content — raw chunk text
+const remembered = await client.remember("The project uses Bun", {
+  type: "fact",
+  importance: 0.8,
+  tags: "tooling,project",
+  mode: "sync",
+});
+
+const recalled = await client.recall("package manager", {
+  limit: 5,
+  type: "fact",
+  agentId: "my-agent",
+  sessionKey: "session-123",
+});
+
+await client.modifyMemory(remembered.id, { content: "The project uses Bun for scripts", reason: "Clarified scope" });
 ```
 
-**`deleteDocument(id, reason)`** — Delete a document and remove all
-associated memories.
+SDK method names are camelCase. The transport maps established wire aliases where required; pass the TypeScript shape shown above rather than copying raw endpoint field names.
+
+## Token creation
+
+`createToken` calls the admin-protected token endpoint. The daemon accepts the roles `admin`, `operator`, `agent`, and `readonly`.
 
 ```typescript
-const result = await signet.deleteDocument("doc_abc", "Project closed");
-// result.memoriesRemoved — count of memories cleaned up
-```
-
-
-### Health and Status
-
-**`health()`** — Lightweight liveness check. Returns uptime, PID,
-version, and port. Suitable for polling.
-
-**`status()`** — Full daemon status including pipeline V2 configuration,
-embedding provider details, and an overall health score.
-
-**`diagnostics(domain?)`** — Health scoring by subsystem. Pass a domain
-string (e.g. `"memory"`, `"pipeline"`) to scope the report, or omit it
-for a full system diagnostic. The response shape is open-ended and may
-vary by daemon version.
-
-
-### Auth
-
-Auth methods are only relevant when the daemon runs in a mode that
-requires token-based access.
-
-**`createToken(opts)`** — Generate a signed auth token scoped to a role,
-project, agent, or user. Requires the calling token to have sufficient
-privileges.
-
-```typescript
-const { token, expiresAt } = await signet.createToken({
-  role: "reader",
-  scope: { project: "signet", agent: "my-bot" },
+const issued = await client.createToken({
+  role: "readonly",
+  scope: { project: "my-project", agent: "reporter" },
   ttlSeconds: 3600,
 });
+
+const caller = await client.whoami();
 ```
 
-**`whoami()`** — Inspect the claims of the currently configured token.
+Keep issued tokens out of source control and logs. `reader` is not a valid role value.
+
+## Secret execution is asynchronous
+
+`execWithSecrets` queues a daemon-owned job. It returns a `SecretExecJob`, not process output. Poll `getSecretExecJob(job.id)` until the job reaches a terminal status, then read its redacted result fields.
 
 ```typescript
-const { authenticated, claims } = await signet.whoami();
-```
+const job = await client.execWithSecrets("node ./sync.js", {
+  API_TOKEN: "SYNC_SERVICE_TOKEN",
+});
 
-## Error Handling
-
-All errors thrown by `SignetClient` are instances of `SignetError` or
-one of its subclasses, exported from `@signet/sdk`.
-
-- `SignetApiError` — The daemon responded with a non-2xx status. Has
-  `.status` (HTTP code) and `.body` (parsed response). The message is
-  taken from the `error` field of the response body when present.
-- `SignetNetworkError` — Fetch failed at the network level (connection
-  refused, DNS failure, etc.). Has `.cause` pointing to the underlying
-  `Error`.
-- `SignetTimeoutError` — A subclass of `SignetNetworkError` raised when
-  a request exceeds `timeoutMs`.
-
-```typescript
-import { SignetApiError, SignetNetworkError } from "@signet/sdk";
-
-try {
-  await signet.getMemory("mem_nonexistent");
-} catch (err) {
-  if (err instanceof SignetApiError && err.status === 404) {
-    // memory not found — handle gracefully
-  } else if (err instanceof SignetNetworkError) {
-    // daemon unreachable
-  } else {
-    throw err;
-  }
+const status = await client.getSecretExecJob(job.id);
+if (status.status === "completed") {
+  console.log(status.result?.stdout, status.result?.stderr, status.result?.code);
 }
 ```
 
-GET requests are retried up to `retries` times (default 2) on network
-errors. API errors (4xx/5xx responses) are never retried.
-
-## Examples
-
-### Chat agent saving conversation memories
-
-A pattern for agents that summarize and retain information across
-sessions. Call `remember` after each assistant turn with a condensed
-takeaway.
-
-```typescript
-import { SignetClient } from "@signet/sdk";
-
-const signet = new SignetClient({
-  daemonUrl: "http://localhost:3850",
-  actor: "chat-agent",
-  actorType: "llm",
-});
-
-async function onAssistantTurn(userMessage: string, reply: string) {
-  const summary = extractKeyFact(userMessage, reply);
-  if (!summary) return;
-
-  await signet.remember(summary, {
-    type: "conversation",
-    importance: 0.7,
-    mode: "async",   // non-blocking — pipeline runs in background
-  });
-}
-
-async function buildSystemPrompt(topic: string): Promise<string> {
-  const { results } = await signet.recall(topic, { limit: 5 });
-  const context = results.map((r) => `- ${r.content}`).join("\n");
-  return `Relevant context:\n${context}`;
-}
-```
-
-
-### Coding agent injecting recalled context
-
-A pattern for code-generation agents that need to surface relevant
-architectural notes or preferences before producing output.
-
-```typescript
-import { SignetClient } from "@signet/sdk";
-import { SignetApiError } from "@signet/sdk";
-
-const signet = new SignetClient({ daemonUrl: "http://localhost:3850" });
-
-async function getContextForTask(taskDescription: string): Promise<string[]> {
-  try {
-    const { results, meta } = await signet.recall(taskDescription, {
-      limit: 8,
-      importance_min: 0.6,
-      minScore: 0.4,
-    });
-    console.log(`recall returned ${meta.totalReturned} usable results`);
-    return results.map((r) => r.content);
-  } catch (err) {
-    if (err instanceof SignetApiError) {
-      console.warn("Signet unavailable, proceeding without context");
-      return [];
-    }
-    throw err;
-  }
-}
-
-async function generateCode(task: string): Promise<string> {
-  const context = await getContextForTask(task);
-  const prompt = context.length > 0
-    ? `Context:\n${context.join("\n")}\n\nTask: ${task}`
-    : `Task: ${task}`;
-
-  return callLLM(prompt);
-}
-```
-
-## Sessions & Bypass
-
-Manage active sessions and per-session bypass mode.
-
-**`listSessions()`** — List all active sessions with bypass status.
-
-```typescript
-const sessions = await signet.listSessions();
-// sessions[n].key — session identifier
-// sessions[n].bypassed — whether hooks are disabled for this session
-// sessions[n].createdAt — session start time
-```
-
-**`getSession(key)`** — Get details for a specific session.
-
-```typescript
-const session = await signet.getSession("sess-abc-123");
-console.log(session.bypassed); // true | false
-```
-
-**`setSessionBypass(key, enabled)`** — Toggle bypass mode for a session.
-
-```typescript
-// Enable bypass (disable all hooks for this session)
-await signet.setSessionBypass("sess-abc-123", true);
-
-// Disable bypass (re-enable hooks)
-await signet.setSessionBypass("sess-abc-123", false);
-```
-
-Bypass mode is useful for:
-- Running one-off commands without triggering memory extraction
-- Testing without polluting the knowledge base
-- Performing maintenance operations that shouldn't create memories
-
-## Tasks & Scheduling
-
-Create, manage, and run scheduled tasks (cron jobs, one-off tasks).
-
-**`listTasks()`** — List all configured tasks.
-
-```typescript
-const { tasks, presets } = await signet.listTasks();
-// tasks[n].cron_expression — cron schedule
-// tasks[n].enabled — whether task is active
-// presets — built-in cron presets (e.g. "@hourly")
-```
-
-**`createTask(opts)`** — Create a new scheduled task.
-
-```typescript
-const task = await signet.createTask({
-  name: "Daily Summary",
-  prompt: "Generate daily summary of memories",
-  cronExpression: "0 9 * * *",  // Daily at 9 AM
-  harness: "claude-code",       // "claude-code" | "codex" | "opencode"
-  workingDirectory: "/home/user/project",
-  skillName: "reporter",
-  skillMode: "inject",          // "inject" | "slash"
-});
-// task.id — assigned task ID
-// task.nextRunAt — ISO timestamp for next scheduled run
-```
-
-**`getTask(id)`** — Fetch a single task by ID.
-
-```typescript
-const { task, runs } = await signet.getTask("task-abc-123");
-console.log(task.name, runs[0]?.status);
-```
-
-**`updateTask(id, opts)`** — Update task configuration.
-
-```typescript
-await signet.updateTask("task-abc-123", {
-  cronExpression: "0 10 * * *",  // Change to 10 AM
-  enabled: false,  // Disable the task
-});
-```
-
-**`deleteTask(id)`** — Delete a task.
-
-```typescript
-await signet.deleteTask("task-abc-123");
-```
-
-**`runTask(id)`** — Trigger immediate task execution.
-
-```typescript
-const run = await signet.runTask("task-abc-123");
-// run.runId — run identifier
-// run.status — "running"
-```
-
-**`listTaskRuns(id)`** — Get execution history for a task.
-
-```typescript
-const runs = await signet.listTaskRuns("task-abc-123", {
-  limit: 10,
-  offset: 0,
-});
-// runs.runs[n].status — execution outcome
-// runs.runs[n].started_at — when run started
-// runs.runs[n].completed_at — when run finished
-// runs.total — total run count
-// runs.hasMore — whether additional pages exist
-```
-
-## Git Synchronization
-
-Manage automatic git sync with remote repositories.
-
-**`getGitStatus()`** — Get current sync status.
-
-```typescript
-const status = await signet.getGitStatus();
-// status.branch — current branch name
-// status.ahead — commits not pushed
-// status.behind — commits not pulled
-// status.last_sync — timestamp of last successful sync
-// status.conflicts — any merge conflicts
-```
-
-**`gitPull()`** — Pull from remote.
-
-```typescript
-const result = await signet.gitPull();
-// result.success — true if pull succeeded
-// result.commits — number of commits pulled
-// result.conflicts — any conflicts detected
-```
-
-**`gitPush()`** — Push to remote.
-
-```typescript
-const result = await signet.gitPush();
-// result.success — true if push succeeded
-// result.commits — number of commits pushed
-```
-
-**`gitSync()`** — Pull then push (sync).
-
-```typescript
-const result = await signet.gitSync();
-// Combines pull + push in one call
-// Handles merge automatically
-```
-
-**`getGitConfig()`** — Get git sync configuration.
-
-```typescript
-const config = await signet.getGitConfig();
-// config.remote — configured remote (if any)
-// config.branch — branch to sync
-// config.autoSync — whether auto-sync is enabled
-// config.syncInterval — sync interval in seconds
-```
-
-**`updateGitConfig(opts)`** — Configure git sync.
-
-```typescript
-await signet.updateGitConfig({
-  remote: "git@github.com:user/memories.git",
-  branch: "main",
-  autoSync: true,
-  syncInterval: 300,
-});
-```
-
-## Secrets Management
-
-Store secrets securely, list names, and inject values into subprocesses.
-Ordinary SDK calls do not retrieve raw secret values. The `signet.secrets`
-core plugin owns these helpers and keeps compatibility with the local
-encrypted store plus 1Password import flow.
-
-**`listSecrets()`** — List all secret names (not values).
-
-```typescript
-const { secrets } = await signet.listSecrets();
-// secrets[n] — secret name (e.g., "OPENAI_API_KEY")
-```
-
-**`storeSecret(name, value)`**: Store a secret.
-
-```typescript
-await signet.storeSecret("ANTHROPIC_API_KEY", "sk-ant-...");
-```
-
-**`deleteSecret(name)`** — Delete a secret.
-
-```typescript
-await signet.deleteSecret("OLD_API_KEY");
-```
-
-**`execWithSecrets(opts)`** — Run command with secrets injected as env vars.
-
-```typescript
-const result = await signet.execWithSecrets("curl https://api.openai.com/v1/models", {
-  OPENAI_API_KEY: "OPENAI_API_KEY",  // Bare name maps to local://OPENAI_API_KEY
-});
-// result.stdout — command output
-// result.stderr — error output
-// result.code: process exit code
-```
-
-### 1Password Integration
-
-**`connectOnePassword(token)`**: Connect to 1Password using service account.
-
-```typescript
-await signet.connectOnePassword("ops_...");
-```
-
-**`listOnePasswordVaults()`**: List available 1Password vaults.
-
-```typescript
-const { vaults } = await signet.listOnePasswordVaults();
-// vaults[n].id — vault identifier
-// vaults[n].name — vault name
-```
-
-**`import1PasswordSecrets(opts)`** — Import secrets from 1Password.
-
-```typescript
-await signet.import1PasswordSecrets({
-  vaults: ["Private"],
-  prefix: "OP",
-  overwrite: false,
-});
-```
+Secret values are not returned by `listSecrets`, and execution output is redacted by the daemon. Do not put real tokens in examples or use a queued job as if it had already completed.

--- a/web/docs/src/content/docs/sdk/integrations.md
+++ b/web/docs/src/content/docs/sdk/integrations.md
@@ -1,325 +1,76 @@
 ---
 title: "SDK integrations"
-description: "Integrate Signet with React, Vercel AI SDK, OpenAI SDK, connectors, and hooks."
+description: "Use React, AI SDK, OpenAI, lifecycle hooks, and connectors through the current SDK surface."
 ---
 
-## React Hooks
+## React
 
-`@signet/sdk/react` (imported from `react.tsx`) ships React bindings
-built on top of `SignetClient`. They require React 18+ and must be used
-inside a `SignetProvider`.
-
-```typescript
-import { SignetProvider, useSignet, useMemorySearch, useMemory }
-  from "@signet/sdk/react";
-```
-
-**`SignetProvider`** — Wrap your app or subtree. Runs a health check on
-mount and exposes `connected` and `error` via context.
+`@signet/sdk/react` provides `SignetProvider`, `useSignet`, `useMemorySearch`, and `useMemory`.
 
 ```tsx
-<SignetProvider config={{ daemonUrl: "http://localhost:3850" }}>
-  <App />
-</SignetProvider>
+import { SignetProvider, useMemorySearch } from "@signet/sdk/react";
+
+function Preferences() {
+  const { data, loading, error } = useMemorySearch("user preferences", {
+    limit: 5,
+    type: "preference",
+  });
+  if (loading) return <p>Loading…</p>;
+  if (error) return <p>{error.message}</p>;
+  return <ul>{data?.map((memory) => <li key={memory.id}>{memory.content}</li>)}</ul>;
+}
+
+export function App() {
+  return <SignetProvider config={{ daemonUrl: "http://localhost:3850" }}><Preferences /></SignetProvider>;
+}
 ```
 
-You can also pass a pre-constructed `client` instance if you need to
-share it outside React.
+`useMemorySearch(null)` and `useMemory(null)` suppress their request. `SignetProvider` checks `health()` on mount and exposes `connected` and `error` through `useSignet()`.
 
-**`useSignet()`** — Access the raw context: `{ client, connected, error }`.
-Throws if called outside a `SignetProvider`.
+## Vercel AI SDK and OpenAI tools
 
-**`useMemorySearch(query, opts?)`** — Reactive recall. Re-runs whenever
-`query` changes. Returns `{ data, loading, error }`. Pass `null` to
-suppress the search.
-
-```tsx
-const { data: results, loading } = useMemorySearch("user preferences", {
-  limit: 5,
-  type: "preference",
-  aggregate: true,
-  aggregateBudget: "small",
-});
-```
-
-**`useMemory(id)`** — Fetch a single memory by ID reactively. Returns
-`{ data, loading, error }`. Pass `null` to suppress.
-
-```tsx
-const { data: memory, error } = useMemory(selectedId);
-```
-
-Both hooks clean up in-flight requests on unmount via `AbortController`.
-
-## Vercel AI SDK Integration
-
-`@signet/sdk/ai-sdk` provides tool definitions and context injection
-compatible with the Vercel AI SDK (`ai` package from sdk.vercel.ai).
-Requires `zod` as a peer dependency (already present if you use the AI
-SDK).
-
-**`memoryTools(client)`** — Returns an object of tool definitions
-(`memory_search`, `memory_store`, `memory_modify`, `memory_forget`)
-that can be passed directly to the `tools` parameter of `generateText`
-or `streamText`.
+The SDK exports four memory tools: `memory_search`, `memory_store`, `memory_modify`, and `memory_forget`.
 
 ```typescript
 import { SignetClient } from "@signet/sdk";
 import { memoryTools } from "@signet/sdk/ai-sdk";
 import { generateText } from "ai";
 
-const signet = new SignetClient();
-const tools = await memoryTools(signet);
-
-const result = await generateText({
-  model: yourModel,
-  tools,
-  prompt: "What do you know about the user's coding preferences?",
-});
+const client = new SignetClient();
+const result = await generateText({ model, tools: await memoryTools(client), prompt: "Find relevant preferences." });
 ```
 
-Each tool is a standard Vercel AI SDK tool with `description`,
-`parameters` (zod schema), and `execute` function.
-The `memory_search` tool accepts `aggregate`, `aggregateBudget`, and
-`saveAggregate` for explicit aggregate recall.
+For OpenAI function calling, use `memoryToolDefinitions()` to construct the tool list and `executeMemoryTool(client, name, parsedArgs)` to dispatch a returned function call. Both adapters use camelCase arguments such as `aggregateBudget`, `sessionKey`, and `agentId` because they call the TypeScript client, not the raw daemon wire schema.
 
-**`getMemoryContext(client, userMessage, opts?)`** — Convenience helper
-that runs a recall search and formats the results as a markdown string
-suitable for injecting into a system prompt.
+## Lifecycle hooks
+
+The SDK uses camelCase request fields. The daemon may accept compatibility wire aliases, but SDK callers should use the exported TypeScript shape.
 
 ```typescript
-import { getMemoryContext } from "@signet/sdk/ai-sdk";
+import { SignetClient } from "@signet/sdk";
 
-const context = await getMemoryContext(signet, userMessage, {
-  limit: 5,
-  minScore: 0.3,
-});
-// Returns "" if no results survive score filtering,
-// or "## Relevant Memories\n- ..." otherwise
+const client = new SignetClient();
+await client.sessionStart({ sessionKey: "session-123", harness: "my-harness", project: "/workspace/app" });
+const context = await client.userPromptSubmit({ sessionKey: "session-123", prompt: "Review the migration", project: "/workspace/app" });
+await client.sessionEnd({ sessionKey: "session-123", harness: "my-harness", transcript: "…", project: "/workspace/app" });
+await client.preCompaction({ sessionKey: "session-123", context: "Current session summary", project: "/workspace/app" });
+await client.compactionComplete({ sessionKey: "session-123", summary: "Compacted summary", project: "/workspace/app" });
+await client.synthesisComplete({ content: "Memory summary", project: "/workspace/app" });
 ```
 
-## OpenAI SDK Integration
-
-`@signet/sdk/openai` provides tool definitions and a dispatcher
-compatible with OpenAI's function calling format.
-
-**`memoryToolDefinitions()`** — Returns an array of OpenAI-format tool
-definitions (`memory_search`, `memory_store`, `memory_modify`,
-`memory_forget`) ready for the `tools` parameter of
-`openai.chat.completions.create`.
-
-```typescript
-import { memoryToolDefinitions, executeMemoryTool } from "@signet/sdk/openai";
-
-const tools = memoryToolDefinitions();
-
-const response = await openai.chat.completions.create({
-  model: "gpt-4o",
-  tools,
-  messages,
-});
-```
-
-**`executeMemoryTool(client, toolName, args)`** — Dispatches a tool call
-to the corresponding `SignetClient` method. Pass the function name and
-parsed arguments from an OpenAI tool call response.
-
-```typescript
-for (const call of response.choices[0].message.tool_calls ?? []) {
-  const result = await executeMemoryTool(
-    signet,
-    call.function.name,
-    JSON.parse(call.function.arguments),
-  );
-}
-```
-
-## Hooks & Synthesis
-
-Session lifecycle hooks for context injection and memory extraction.
-
-**Session Lifecycle Hooks**
-
-**`sessionStart(opts)`** — Inject context at session start.
-
-```typescript
-await signet.sessionStart({
-  project: "/home/user/myapp",
-  harness: "claude-code",
-  sessionKey: "sess-abc-123",
-});
-```
-
-**`userPromptSubmit(opts)`** — Load context before each user prompt.
-
-```typescript
-const context = await signet.userPromptSubmit({
-  prompt: "How do I implement authentication?",
-  project: "/home/user/myapp",
-  sessionKey: "sess-abc-123",
-});
-// context.context — injected prompt context
-```
-
-**`sessionEnd(opts)`** — Extract memories at session end.
-
-```typescript
-await signet.sessionEnd({
-  sessionKey: "sess-abc-123",
-  project: "/home/user/myapp",
-  summary: "Implemented JWT authentication with refresh tokens",
-});
-```
-
-**Memory Operation Hooks**
-
-**`hookRemember(opts)`** — Save memory via hook (with session context).
-
-```typescript
-await signet.hookRemember({
-  content: "User prefers functional components over class components",
-  type: "preference",
-  sessionKey: "sess-abc-123",
-  runtimePath: "plugin",
-});
-```
-
-`rememberHook(opts)` remains available as a deprecated compatibility alias.
-
-**`hookRecall(opts)`** — Recall via hook (with session context).
-
-```typescript
-const result = await signet.hookRecall({
-  query: "component preferences",
-  project: "/home/user/myapp",
-  type: "preference",
-  tags: "ui,components",
-  since: "2026-01-01T00:00:00Z",
-  sessionKey: "sess-abc-123",
-  runtimePath: "plugin",
-});
-// result.results — recall rows
-// result.memories — deprecated alias of result.results
-// result.count — deprecated alias of result.results.length
-// result.meta.noHits — true when recall succeeded but found nothing
-// result.bypassed — true when the session is bypassed
-// result.internal — true for no-hook internal calls
-```
-
-`recallHook(opts)` remains available as a deprecated compatibility alias.
-
-**Compaction Hooks**
-
-**`preCompaction(opts)`** — Get instructions before context compaction.
-
-```typescript
-const instructions = await signet.preCompaction({
-  session_key: "sess-abc-123",
-  tokens_used: 95000,
-  tokens_max: 100000,
-});
-// instructions.guidance — what to preserve in summary
-```
-
-**`compactionComplete(opts)`** — Save compaction summary.
-
-```typescript
-await signet.compactionComplete({
-  session_key: "sess-abc-123",
-  summary: "Discussed React hooks patterns and authentication implementation",
-  preserved_memories: ["mem-1", "mem-2"],
-});
-```
-
-**Synthesis Hooks**
-
-**`getSynthesisConfig()`** — Get MEMORY.md synthesis configuration.
-
-```typescript
-const config = await signet.getSynthesisConfig();
-// config.enabled — whether synthesis is enabled
-// config.frequency — how often to run
-```
-
-**`requestSynthesis(opts)`** — Request MEMORY.md synthesis.
-
-```typescript
-await signet.requestSynthesis({
-  project: "/home/user/myapp",
-  reason: "Major architectural decisions made",
-});
-```
-
-**`completeSynthesis(opts)`** — Save synthesized MEMORY.md.
-
-```typescript
-await signet.completeSynthesis({
-  project: "/home/user/myapp",
-  content: "# Project Memory\n\n...",
-  session_key: "sess-abc-123",
-});
-```
+`sessionEnd` requires `sessionKey` and `harness`; it does not take a `summary` field. `synthesisComplete` is the exported method name, not `completeSynthesis`.
 
 ## Connectors
 
-Manage external data source connectors (filesystem, APIs, databases).
-
-**`listConnectors()`** — List all registered connectors.
-
 ```typescript
-const connectors = await signet.listConnectors();
-// connectors[n].id — connector identifier
-// connectors[n].provider — connector type (filesystem, github, etc.)
-// connectors[n].status — "active" | "error" | "paused"
-// connectors[n].last_sync — last successful sync time
-```
-
-**`createConnector(opts)`** — Register a new connector.
-
-```typescript
-const connector = await signet.createConnector({
+const created = await client.createConnector({
   provider: "filesystem",
-  config: {
-    path: "/home/user/notes",
-    file_patterns: ["*.md", "*.txt"],
-  },
-  sync_interval: 300,  // Sync every 5 minutes
+  displayName: "Project notes",
+  settings: { rootPath: "/workspace/notes" },
 });
-// connector.id — assigned connector ID
+
+await client.syncConnector(created.id);
+const health = await client.getConnectorHealth(created.id);
 ```
 
-**`getConnector(id)`** — Get connector details.
-
-```typescript
-const connector = await signet.getConnector("conn-abc-123");
-console.log(connector.status, connector.last_sync);
-```
-
-**`syncConnector(id)`** — Trigger incremental sync.
-
-```typescript
-await signet.syncConnector("conn-abc-123");
-// Syncs only new/changed files since last sync
-```
-
-**`fullSyncConnector(id)`** — Trigger full re-sync.
-
-```typescript
-await signet.fullSyncConnector("conn-abc-123");
-// Re-ingests all files (useful after config changes)
-```
-
-**`deleteConnector(id)`** — Delete a connector.
-
-```typescript
-await signet.deleteConnector("conn-abc-123");
-```
-
-**`checkConnectorHealth(id)`** — Check connector health status.
-
-```typescript
-const health = await signet.checkConnectorHealth("conn-abc-123");
-// health.status — "healthy" | "degraded" | "failed"
-// health.last_error — recent error message (if any)
-// health.metrics — connector-specific metrics
-```
+Supported `createConnector` providers are `filesystem`, `github-docs`, and `gdrive`. Use `settings`, not retired `config`, and use `getConnectorHealth`, not `checkConnectorHealth`.

--- a/web/docs/src/content/docs/sdk/knowledge-agents.md
+++ b/web/docs/src/content/docs/sdk/knowledge-agents.md
@@ -1,292 +1,49 @@
 ---
 title: "Knowledge and agents"
-description: "Use knowledge graph, cross-agent messaging, predictor, and timeline APIs."
+description: "Query the knowledge graph and coordinate scoped agent sessions."
 ---
 
-## Knowledge Graph
+## Knowledge graph
 
-Query the knowledge graph (entities, aspects, attributes).
-
-**`listEntities()`** — List knowledge entities.
+The current SDK methods use explicit knowledge names:
 
 ```typescript
-const entities = await signet.listEntities({
-  limit: 50,
-  type: "person",  // Optional: filter by entity type
+const entities = await client.listKnowledgeEntities({ query: "Signet", limit: 20, agentId: "research" });
+const entity = await client.getKnowledgeEntity("entity-id", { agentId: "research" });
+const aspects = await client.getEntityAspects("entity-id", { agentId: "research" });
+const attributes = await client.getAspectAttributes("entity-id", "aspect-id", {
+  agentId: "research",
+  kind: "attribute",
+  status: "active",
 });
-// entities[n].id — entity identifier
-// entities[n].name — entity name
-// entities[n].type — entity type
-// entities[n].mention_count — number of times mentioned
+const dependencies = await client.getEntityDependencies("entity-id", { agentId: "research" });
+const pinned = await client.getPinnedEntities({ agentId: "research" });
 ```
 
-**`getEntity(id)`** — Get entity details.
+Other available read operations are `getKnowledgeStats()`, `getTraversalStatus()`, and `getConstellation()`. Pinning is agent-scoped:
 
 ```typescript
-const entity = await signet.getEntity("ent-abc-123");
-// entity.id — entity identifier
-// entity.name — entity name
-// entity.type — entity type
-// entity.created_at — when entity was created
-// entity.metadata — entity-specific metadata
+await client.pinEntity("entity-id", { agentId: "research" });
+await client.unpinEntity("entity-id", { agentId: "research" });
 ```
 
-**`pinEntity(id)`** — Pin an entity (keep in working context).
+Do not use retired names such as `listEntities`, `getEntity`, or `listPinnedEntities` for the SDK client.
+
+## Cross-agent coordination
 
 ```typescript
-await signet.pinEntity("ent-abc-123");
-```
-
-**`unpinEntity(id)`** — Unpin an entity.
-
-```typescript
-await signet.unpinEntity("ent-abc-123");
-```
-
-**`listPinnedEntities()`** — List all pinned entities.
-
-```typescript
-const pinned = await signet.listPinnedEntities();
-// pinned[n].id — entity ID
-// pinned[n].name — entity name
-// pinned[n].pinned_at — when pinned
-```
-
-**`getEntityHealth()`** — Get entity graph health metrics.
-
-```typescript
-const health = await signet.getEntityHealth();
-// health.total_entities — total entity count
-// health.singleton_entities — entities with single mention
-// health.orphaned_entities — entities with no relationships
-// health.avg_mentions — average mentions per entity
-```
-
-**`getEntityAspects(id)`** — Get aspects for an entity.
-
-```typescript
-const aspects = await signet.getEntityAspects("ent-abc-123");
-// aspects[n].id — aspect identifier
-// aspects[n].name — aspect name
-// aspects[n].mention_count — times this aspect mentioned
-```
-
-**`getEntityAttributes(entityId, aspectId)`** — Get attributes for an aspect.
-
-```typescript
-const attrs = await signet.getEntityAttributes("ent-abc", "asp-xyz");
-// attrs[n].key — attribute key
-// attrs[n].value — attribute value
-// attrs[n].confidence — confidence score
-```
-
-**`getEntityDependencies(id)`** — Get entity dependency graph.
-
-```typescript
-const deps = await signet.getEntityDependencies("ent-abc-123");
-// deps.related — related entities
-// deps.depends_on — entities this depends on
-// deps.depended_by — entities depending on this
-```
-
-**`getKnowledgeStats()`** — Get knowledge graph statistics.
-
-```typescript
-const stats = await signet.getKnowledgeStats();
-// stats.total_entities — entity count
-// stats.total_aspects — aspect count
-// stats.total_attributes — attribute count
-// stats.total_mentions — mention count
-```
-
-**`getTraversalStatus()`** — Get graph traversal cache status.
-
-```typescript
-const status = await signet.getTraversalStatus();
-// status.last_update — when cache was last updated
-// status.cache_size — cache size in bytes
-// status.hit_rate — cache hit rate
-```
-
-**`getConstellation()`** — Get constellation visualization data.
-
-```typescript
-const constellation = await signet.getConstellation({
-  dimensions: 2,  // 2D or 3D projection
-  limit: 100,  // Max entities to include
-});
-// constellation.nodes — entity nodes
-// constellation.edges — relationship edges
-// constellation.positions — UMAP positions
-```
-
-## Cross-Agent Messaging
-
-Presence and messaging for multi-agent coordination.
-
-**`listPresence()`** — List active agent sessions.
-
-```typescript
-const presence = await signet.listPresence();
-// presence[n].agent_id — agent identifier
-// presence[n].session_key — session key
-// presence[n].project — current project
-// presence[n].last_seen — last activity timestamp
-```
-
-**`updatePresence(opts)`** — Update agent presence.
-
-```typescript
-await signet.updatePresence({
-  agent_id: "agent-abc",
-  session_key: "sess-123",
-  project: "/home/user/myapp",
-});
-```
-
-**`removePresence(sessionKey)`** — Remove agent presence.
-
-```typescript
-await signet.removePresence("sess-123");
-```
-
-**`listMessages(opts)`** — List cross-agent messages.
-
-```typescript
-const messages = await signet.listMessages({
-  agent_id: "agent-abc",
-  limit: 20,
-  include_sent: true,
-});
-// messages[n].from_agent_id — sender
-// messages[n].to_agent_id — recipient
-// messages[n].type — message type
-// messages[n].content — message content
-// messages[n].timestamp — when sent
-```
-
-**`sendMessage(opts)`** — Send message to another agent.
-
-```typescript
-await signet.sendMessage({
-  from_agent_id: "agent-abc",
-  to_agent_id: "agent-xyz",
+const presence = await client.listAgentPresence({ project: "/workspace/app", includeSelf: false });
+const sent = await client.sendAgentMessage({
+  toAgentId: "reviewer",
   type: "question",
-  content: "Have you seen the latest architecture decisions?",
+  content: "Can you review the migration boundary?",
 });
+const inbox = await client.listAgentMessages({ agentId: "reviewer", unreadOnly: true, limit: 25 });
+await client.acknowledgeAgentMessage(inbox.items[0].id, { agentId: "reviewer" });
 ```
 
-**`streamEvents()`** — SSE stream of cross-agent events.
+`sendAgentMessage` supports a local delivery path and an optional ACP relay. An indeterminate ACP message can be retried with `retryAgentMessage(messageId, { agentId })`; delivery remains agent-scoped.
 
-```typescript
-const stream = await signet.streamEvents();
-stream.onmessage = (event) => {
-  const msg = JSON.parse(event.data);
-  console.log(`[${msg.type}] ${msg.from_agent_id}: ${msg.content}`);
-};
-```
+## Predictor APIs are retired
 
-## Predictor Training
-
-Train and query the predictive memory scorer.
-
-**`getPredictorStatus()`** — Get predictor status.
-
-```typescript
-const status = await signet.getPredictorStatus();
-// status.enabled — whether predictor is enabled
-// status.model_loaded — whether model is loaded
-// status.training_runs — number of training runs
-// status.last_training — last training timestamp
-```
-
-**`getPredictorComparisons()`** — Get recent comparisons.
-
-```typescript
-const comparisons = await signet.getPredictorComparisons({
-  limit: 50,
-});
-// comparisons[n].entity_id — entity compared
-// comparisons[n].baseline_score — baseline relevance
-// comparisons[n].predictor_score — predicted relevance
-// comparisons[n].actual_relevance — ground truth
-```
-
-**`getComparisonsByProject(project)`** — Get comparisons for a project.
-
-```typescript
-const comparisons = await signet.getComparisonsByProject("/home/user/myapp");
-```
-
-**`getComparisonsByEntity(entityId)`** — Get comparisons for an entity.
-
-```typescript
-const comparisons = await signet.getComparisonsByEntity("ent-abc-123");
-```
-
-**`listTrainingRuns()`** — List training runs.
-
-```typescript
-const runs = await signet.listTrainingRuns();
-// runs[n].id — run identifier
-// runs[n].timestamp — when run occurred
-// runs[n].epochs — number of epochs
-// runs[n].final_loss — training loss
-// runs[n].accuracy — validation accuracy
-```
-
-**`getTrainingPairsCount()`** — Count available training pairs.
-
-```typescript
-const count = await signet.getTrainingPairsCount();
-// count.total — total training pairs
-// count.positive — positive examples
-// count.negative — negative examples
-```
-
-**`trainPredictor(opts)`** — Trigger training run.
-
-```typescript
-const run = await signet.trainPredictor({
-  epochs: 10,
-  learning_rate: 0.001,
-  batch_size: 32,
-});
-// run.id — training run ID
-// run.status — "running" | "completed" | "failed"
-```
-
-**`exportTrainingTelemetry()`** — Export training telemetry.
-
-```typescript
-const data = await signet.exportTrainingTelemetry({
-  since: "2025-01-01T00:00:00Z",
-});
-// data — NDJSON telemetry events
-```
-
-## Timeline Export
-
-Export entity event timelines.
-
-**`getTimeline(id)`** — Get entity timeline.
-
-```typescript
-const events = await signet.getTimeline("ent-abc-123");
-// events[n].timestamp — event timestamp
-// events[n].event_type — event type
-// events[n].description — event description
-// events[n].metadata — event metadata
-```
-
-**`exportTimeline(id)`** — Export timeline with metadata.
-
-```typescript
-const exported = await signet.exportTimeline("ent-abc-123", {
-  format: "json",  // "json" | "csv"
-  include_metadata: true,
-});
-// exported.data — exported timeline data
-// exported.format — export format
-// exported.generated_at — export timestamp
-```
+Predictor methods remain as deprecated SDK tombstones only for clear migration failures. They throw an error stating that predictor APIs were removed in v0.112. Do not call or build new integrations around predictor training, comparisons, or status methods. Use memory-search telemetry and pipeline diagnostics instead.

--- a/web/docs/src/content/docs/sdk/operations.md
+++ b/web/docs/src/content/docs/sdk/operations.md
@@ -1,421 +1,62 @@
 ---
 title: "Operations SDK"
-description: "Use plugin diagnostics, skills, analytics, repair, pipeline, config, and embedding APIs."
+description: "Use the current SDK operations for plugins, skills, analytics, repair, and runtime status."
 ---
 
-## Plugin Diagnostics
-
-Inspect the Plugin SDK V1 registry and active prompt contributions.
-
-**`listPlugins()`**: List registered daemon plugins.
+## Plugins and skills
 
 ```typescript
-const { plugins } = await signet.listPlugins();
-const secretsPlugin = plugins.find((plugin) => plugin.id === "signet.secrets");
-const graphiqPlugin = plugins.find((plugin) => plugin.id === "signet.graphiq");
+const plugins = await client.listPlugins();
+const diagnostics = await client.getPluginDiagnostics("signet.secrets");
+const audit = await client.listPluginAuditEvents({ pluginId: "signet.secrets", limit: 20 });
+
+const installed = await client.listSkills();
+const browse = await client.browseSkills();
+const search = await client.searchSkills("git");
+const skill = await client.getSkill("recall");
+await client.installSkill("owner/repository");
+await client.uninstallSkill("owner/repository");
 ```
 
-**`getPlugin(id)`**: Get one plugin registry record.
+`browseSkills()` takes no arguments. `installSkill(name, source?)` and `getSkill(name, source?)` take positional arguments, not object payloads.
+
+## Analytics and runtime status
 
 ```typescript
-const plugin = await signet.getPlugin("signet.secrets");
-console.log(plugin.state);
+const usage = await client.getUsageCounters();
+const errors = await client.getErrors({ stage: "mutation", limit: 50 });
+const latency = await client.getLatency();
+const logs = await client.getAnalyticsLogs({ level: "warn", limit: 50 });
+const safety = await client.getMemorySafety();
+const continuity = await client.getContinuity({ project: "/workspace/app", limit: 20 });
+const pipeline = await client.getPipelineStatus();
+const diagnostic = await client.diagnostics("memory");
 ```
 
-**`getPluginDiagnostics(id)`**: Get manifest, surface, and validation
-diagnostics for one plugin.
+The matching public method names are `getUsageCounters`, `getErrors`, `getLatency`, `getAnalyticsLogs`, `getMemorySafety`, `getContinuity`, and `diagnostics`. Retired documentation names such as `getUsageAnalytics` and `getDiagnostics` are not SDK methods.
+
+## Repair and embeddings
 
 ```typescript
-const diagnostics = await signet.getPluginDiagnostics("signet.secrets");
-console.log(diagnostics.plugin.activeSurfaces.sdkClients);
-console.log(diagnostics.plugin.promptContributionDiagnostics);
+await client.requeueDeadJobs();
+await client.releaseStaleLeases();
+await client.checkFts({ repair: true });
+await client.triggerRetentionSweep();
+await client.reembedMissing({ limit: 100 });
+
+const embedding = await client.getEmbeddingStatus();
+const health = await client.getEmbeddingHealth();
+const projection = await client.getEmbeddingProjection({ dimensions: 2 });
 ```
 
-The optional GraphIQ plugin is registered as `signet.graphiq`. It is disabled
-by default, can be enabled during setup, and contributes CLI/MCP/prompt
-surfaces for generic code retrieval after `signet index <path>` activates a
-project.
+Repair calls can mutate daemon state. Invoke them deliberately and inspect their typed result. The FTS method is `checkFts({ repair? })`, not `checkFtsConsistency()`.
 
-**`listPluginPromptContributions()`**: List active plugin prompt
-contributions.
+## Configuration and identity
 
 ```typescript
-const { contributions } = await signet.listPluginPromptContributions();
+const config = await client.listConfig();
+await client.writeConfig("USER.md", "# User");
+const identity = await client.getIdentity();
 ```
 
-**`listPluginAuditEvents(opts?)`**: List durable plugin audit events.
-Sensitive fields are redacted by the daemon.
-
-```typescript
-const audit = await signet.listPluginAuditEvents({
-  pluginId: "signet.secrets",
-  event: "plugin.capability_denied",
-  limit: 20,
-});
-console.log(audit.events[0]?.result);
-```
-
-## Skills Marketplace
-
-Browse, install, and manage agent skills from skills.sh.
-
-**`listSkills()`** — List installed skills.
-
-```typescript
-const skills = await signet.listSkills();
-// skills[n].name — skill name
-// skills[n].version — installed version
-// skills[n].description — skill description
-// skills[n].source — installation source (local | registry)
-```
-
-**`browseSkills(opts?)`** — Browse available skills from marketplace.
-
-```typescript
-const available = await signet.browseSkills({
-  category: "development",
-  limit: 20,
-});
-// available[n].name — skill name
-// available[n].description — skill description
-// available[n].author — skill author
-// available[n].downloads — download count
-```
-
-**`searchSkills(query)`** — Search for skills by keyword.
-
-```typescript
-const results = await signet.searchSkills("git workflow");
-// results[n].name — matching skill
-// results[n].relevance — search score
-```
-
-**`getSkill(name)`** — Get details for a specific skill.
-
-```typescript
-const skill = await signet.getSkill("git-workflow");
-// skill.name — skill name
-// skill.readme — full documentation
-// skill.examples — usage examples
-// skill.dependencies — required dependencies
-```
-
-**`installSkill(opts)`** — Install a skill from marketplace or URL.
-
-```typescript
-await signet.installSkill({
-  name: "code-review",  // From registry
-  // OR
-  url: "https://github.com/user/custom-skill",  // From git
-});
-```
-
-**`uninstallSkill(name)`** — Remove an installed skill.
-
-```typescript
-await signet.uninstallSkill("old-workflow");
-```
-
-## Analytics & Telemetry
-
-Query usage analytics and performance metrics.
-
-**`getTelemetryEvents(opts?)`** — Query telemetry events.
-
-```typescript
-const events = await signet.getTelemetryEvents({
-  event: "llm.generate",
-  since: "2025-01-01T00:00:00Z",
-  limit: 100,
-});
-// events.enabled — false when telemetry is disabled
-// events.events — event list
-```
-
-**`getTelemetryStats(opts?)`** — Get aggregated telemetry stats.
-
-```typescript
-const stats = await signet.getTelemetryStats({ since: "2025-01-01T00:00:00Z" });
-if (stats.enabled) {
-  console.log(stats.llm.calls, stats.pipelineErrors);
-}
-```
-
-**`exportTelemetry(opts?)`** — Export telemetry as NDJSON text.
-
-```typescript
-const ndjson = await signet.exportTelemetry({ limit: 1000 });
-// ndjson — raw newline-delimited JSON string
-```
-
-**`getUsageAnalytics()`** — Get usage counters.
-
-```typescript
-const usage = await signet.getUsageAnalytics();
-// usage.memories_created — total memories created
-// usage.memories_recalled — recall operations performed
-// usage.documents_ingested — documents processed
-// usage.queries_total — total queries made
-```
-
-**`getErrorAnalytics()`** — Get recent error events.
-
-```typescript
-const errors = await signet.getErrorAnalytics({
-  since: "2025-01-01T00:00:00Z",
-  limit: 100,
-});
-// errors[n].timestamp — when error occurred
-// errors[n].operation — which operation failed
-// errors[n].error — error message
-// errors[n].stack — stack trace (if available)
-```
-
-**`getLatencyAnalytics()`** — Get latency histograms.
-
-```typescript
-const latency = await signet.getLatencyAnalytics();
-// latency.embedding_ms — embedding latency stats
-// latency.recall_ms — recall latency stats
-// latency.extraction_ms — extraction latency stats
-```
-
-**`getLogAnalytics()`** — Get structured log entries.
-
-```typescript
-const logs = await signet.getLogAnalytics({
-  level: "warn",
-  since: "2025-01-01T00:00:00Z",
-  limit: 50,
-});
-// logs[n].timestamp — log timestamp
-// logs[n].level — log level
-// logs[n].message — log message
-// logs[n].metadata — structured metadata
-```
-
-**`getMemorySafetyAnalytics()`** — Get mutation diagnostics.
-
-```typescript
-const safety = await signet.getMemorySafetyAnalytics();
-// safety.mutations_total — total mutation operations
-// safety.mutations_blocked — blocked mutations (frozen mode, etc.)
-// safety.conflicts_detected — concurrent modification conflicts
-```
-
-**`getContinuityAnalytics()`** — Get session continuity scores over time.
-
-```typescript
-const continuity = await signet.getContinuityAnalytics({
-  since: "2025-01-01T00:00:00Z",
-});
-// continuity[n].timestamp — measurement time
-// continuity[n].project — project path
-// continuity[n].score — continuity score (0-1)
-// continuity[n].memories_injected — context size
-```
-
-**`getLatestContinuity()`** — Get latest continuity score per project.
-
-```typescript
-const latest = await signet.getLatestContinuity();
-// latest[n].project — project path
-// latest[n].score — latest continuity score
-// latest[n].timestamp — when measured
-```
-
-## Repair & Maintenance
-
-Repair actions for broken state and maintenance operations.
-
-**`requeueDeadJobs()`** — Requeue dead-letter jobs.
-
-```typescript
-const result = await signet.requeueDeadJobs();
-// result.requeued — number of jobs requeued
-// result.failed — jobs that couldn't be requeued
-```
-
-**`releaseStaleLeases()`** — Release stale job leases.
-
-```typescript
-const result = await signet.releaseStaleLeases();
-// result.released — number of leases released
-```
-
-**`checkFtsConsistency()`** — Check/repair FTS consistency.
-
-```typescript
-const result = await signet.checkFtsConsistency();
-// result.inconsistencies — found inconsistencies
-// result.repaired — whether repairs were made
-```
-
-**`triggerRetentionSweep()`** — Trigger retention policy sweep.
-
-```typescript
-await signet.triggerRetentionSweep();
-// Removes memories past retention period
-```
-
-**`getEmbeddingGaps()`** — Count unembedded memories.
-
-```typescript
-const gaps = await signet.getEmbeddingGaps();
-// gaps.total — total memories without embeddings
-// gaps.by_type — breakdown by memory type
-```
-
-**`reembedMissing()`** — Re-embed memories without vectors.
-
-```typescript
-const result = await signet.reembedMissing({
-  batch_size: 100,
-});
-// result.processed — memories re-embedded
-// result.failed — failures
-```
-
-**`resyncVectorIndex()`** — Resync entire vector index.
-
-```typescript
-await signet.resyncVectorIndex();
-// Rebuilds vector index from scratch
-```
-
-**`cleanOrphanedEmbeddings()`** — Remove orphaned embeddings.
-
-```typescript
-const result = await signet.cleanOrphanedEmbeddings();
-// result.removed — orphaned embeddings deleted
-```
-
-**`getDedupStats()`** — Get deduplication statistics.
-
-```typescript
-const stats = await signet.getDedupStats();
-// stats.duplicates_found — duplicate groups detected
-// stats.space_saved — bytes saved by deduplication
-```
-
-**`deduplicateMemories()`** — Deduplicate memories.
-
-```typescript
-const result = await signet.deduplicateMemories({
-  min_similarity: 0.95,
-  mode: "execute",  // "preview" | "execute"
-});
-// result.duplicates_found — duplicates detected
-// result.merged — memories merged (execute mode)
-```
-
-**`pruneChunkGroups()`** — Prune chunk_group entities.
-
-```typescript
-const result = await signet.pruneChunkGroups();
-// result.pruned — chunk groups removed
-```
-
-**`pruneSingletonEntities()`** — Prune singleton extracted entities.
-
-```typescript
-const result = await signet.pruneSingletonEntities();
-// result.pruned — singleton entities removed
-```
-
-## Pipeline & Diagnostics
-
-Monitor pipeline status and system diagnostics.
-
-**`getPipelineStatus()`** — Get pipeline worker status.
-
-```typescript
-const status = await signet.getPipelineStatus();
-// status.extraction — extraction worker status
-// status.ingestion — document ingestion status
-// status.graph — knowledge graph status
-// status.retention — retention worker status
-// status.jobs_pending — pending job count
-```
-
-**`getDiagnostics(domain?)`** — Get health diagnostics.
-
-```typescript
-const all = await signet.getDiagnostics();
-// all.overall_score — overall health score (0-100)
-// all.domains — per-domain breakdown
-
-const embeddings = await signet.getDiagnostics("embeddings");
-// embeddings.score — embeddings health score
-// embeddings.issues — detected issues
-// embeddings.recommendations — repair recommendations
-```
-
-## Config & Identity
-
-Read and write daemon configuration and identity files.
-
-**`getConfig()`** — Read daemon configuration.
-
-```typescript
-const config = await signet.getConfig();
-// config — parsed agent.yaml contents
-```
-
-**`setConfig(opts)`** — Write daemon configuration.
-
-```typescript
-await signet.setConfig({
-  content: yaml.stringify(newConfig),
-  reason: "Updated embedding model",
-});
-```
-
-**`getIdentity()`** — Read identity files.
-
-```typescript
-const identity = await signet.getIdentity({
-  files: ["AGENTS.md", "USER.md"],
-});
-// identity.AGENTS.md — file contents
-// identity.USER.md — file contents
-```
-
-## Embeddings
-
-Monitor embedding status and health.
-
-**`getEmbeddingStatus()`** — Get embedding processing status.
-
-```typescript
-const status = await signet.getEmbeddingStatus();
-// status.provider — "native" | "ollama" | "openai" | "none"
-// status.model — embedding model name
-// status.available — provider availability
-// status.base_url — provider URL
-// status.checkedAt — last check timestamp
-```
-
-**`getEmbeddingHealth()`** — Get embedding health metrics.
-
-```typescript
-const health = await signet.getEmbeddingHealth();
-// health.totalMemories — total memories
-// health.embeddedCount — memories with vectors
-// health.unembeddedCount — memories missing vectors
-// health.coveragePercent — embedding coverage
-```
-
-**`getEmbeddingProjection(opts)`** — Get UMAP projection for visualization.
-
-```typescript
-const projection = await signet.getEmbeddingProjection({
-  dimensions: 2,  // 2D or 3D
-});
-if (projection.status === "ready") {
-  // projection.nodes[n].id — memory ID
-  // projection.nodes[n].x, .y, .z — coordinates
-  // projection.edges — graph edges
-}
-// projection.status may also be "computing" or "error"
-```
+These methods are distinct from daemon operator workflows. The SDK does not expose retired `getConfig`, `setConfig`, or `getIdentity({ files })` signatures.

--- a/web/docs/src/content/docs/sdk/types-migration.md
+++ b/web/docs/src/content/docs/sdk/types-migration.md
@@ -1,143 +1,34 @@
 ---
 title: "Helpers, types, and migration"
-description: "Use helper methods, TypeScript types, error contracts, and migration guidance."
+description: "Use public helpers, types, error contracts, and current SDK version guidance."
 ---
 
-## Helper Methods
+## Helpers and errors
 
-Convenience methods that combine multiple operations.
-
-**`waitForJob(jobId, opts?)`** — Poll job until completion.
+`SignetClient` includes helpers such as `waitForJob`, `recallOrThrow`, `getMemoryOrThrow`, `getDocumentOrThrow`, `createAndIngestDocument`, and `batchModifyWithProgress`.
 
 ```typescript
-const job = await signet.waitForJob("job-123", {
-  timeout: 60_000,  // 1 minute timeout
-  interval: 500,    // Poll every 500ms
-});
-// job.status — "completed" | "failed" | "done" | "dead"
-// job.result — job result (if completed)
-```
+import { SignetApiError, SignetClient, SignetNetworkError } from "@signet/sdk";
 
-**`createAndIngestDocument(opts)`** — Create and wait for ingestion.
-
-```typescript
-const doc = await signet.createAndIngestDocument({
-  source_type: "url",
-  url: "https://example.com/article",
-  title: "Example Article",
-});
-// Document is fully ingested and ready
-// doc.status — "done"
-```
-
-**`recallOrThrow(query, opts?)`** — Recall that throws if no results.
-
-```typescript
+const client = new SignetClient();
 try {
-  const { results, meta } = await signet.recallOrThrow("user preferences", {
-    type: "preference",
-    limit: 5,
-    minScore: 0.5, // applied at the daemon response boundary; also checked locally
-    agentId: "my-agent",
-  });
-  // Guaranteed to have at least one result
-  // meta.totalReturned matches the filtered result count
-} catch (err) {
-  console.log("No preferences found");
+  const result = await client.recallOrThrow("deployment preferences", { limit: 5, minScore: 0.5 });
+  console.log(result.results);
+} catch (error) {
+  if (error instanceof SignetApiError) console.error(error.status, error.body);
+  else if (error instanceof SignetNetworkError) console.error("Daemon unavailable");
+  else throw error;
 }
 ```
 
-**`getMemoryOrThrow(id)`** — Get memory with 404 handling.
+Import public response and record types directly from `@signet/sdk` when a function signature needs them. Use the generated declaration files shipped with the installed SDK as the authoritative type reference for the installed version.
 
-```typescript
-const memory = await signet.getMemoryOrThrow("mem-abc-123");
-// Throws if not found
-```
+## Version guidance
 
-**`getDocumentOrThrow(id)`** — Get document with 404 handling.
-
-```typescript
-const doc = await signet.getDocumentOrThrow("doc-123");
-// Throws if not found
-```
-
-**`batchModifyWithProgress(patches, onProgress?)`** — Batch modify with progress.
-
-```typescript
-const result = await signet.batchModifyWithProgress(
-  [
-    { id: "m1", reason: "fix typo", content: "corrected" },
-    { id: "m2", reason: "update", content: "updated" },
-  ],
-  (progress) => {
-    console.log(`${progress.done}/${progress.total} complete`);
-  },
-);
-// result.success — successful modifications
-// result.failed — failed modifications
-```
-
-## Error Handling
-
-All methods throw `SignetApiError` for HTTP failures and `SignetNetworkError`
-for connection issues.
-
-```typescript
-import { SignetApiError, SignetNetworkError } from "@signet/sdk";
-
-try {
-  await signet.remember("important fact");
-} catch (err) {
-  if (err instanceof SignetApiError) {
-    console.error(`API error ${err.status}: ${err.message}`);
-    // err.status — HTTP status code
-    // err.endpoint — failing endpoint
-    // err.details — additional error details
-  } else if (err instanceof SignetNetworkError) {
-    console.error(`Network error: ${err.message}`);
-    // Daemon unreachable
-  } else {
-    throw err;
-  }
-}
-```
-
-## TypeScript Support
-
-The SDK is written in TypeScript and provides full type definitions.
-
-```typescript
-import type {
-  MemoryRecord,
-  RecallResponse,
-  JobStatus,
-  DocumentRecord,
-  ConnectorRecord,
-  TaskRecord,
-  SessionRecord,
-  // ... and 100+ more types
-} from "@signet/sdk";
-```
-
-All types are exported from the main entry point and can be imported directly.
-
-## Migration Guide
-
-### Upgrading from 0.x to 1.0
-
-**No breaking changes** — The 1.0 SDK is fully backward compatible with 0.x.
-
-Key improvements in 1.0:
-- 148 daemon endpoints covered (vs. ~25 in 0.x)
-- Comprehensive helper methods
-- Full TypeScript coverage
-- Improved error types
-- Better documentation
-
-To upgrade:
+The published SDK is currently on the 0.x release line. There is no released 1.0 SDK and no blanket 0.x-to-1.0 compatibility promise. Pin and upgrade against a version that exists in the registry, then use TypeScript to identify signature changes:
 
 ```bash
-npm install @signet/sdk@latest
+bun add @signet/sdk@latest
 ```
 
-No code changes required. All existing method signatures remain unchanged.
+For migration, replace retired method names with the current client surface documented in this section. In particular, predictor APIs were removed in v0.112 and are deprecated methods that throw instead of working runtime endpoints.

--- a/web/docs/src/content/docs/skills.md
+++ b/web/docs/src/content/docs/skills.md
@@ -1,274 +1,64 @@
 ---
 title: "Skills"
-description: "Install, manage, and discover agent skills."
+description: "Install, inspect, search, and remove agent skills."
 ---
 
-Install, manage, and discover agent skills. Skills are packaged instructions that extend what your agent can do.
+Skills are directories under `$SIGNET_WORKSPACE/skills/` with a `SKILL.md` instruction file. A harness can surface installed skills to an agent, but the skill remains instructions: it does not grant commands or permissions by itself.
 
----
+## CLI commands
 
-## What Are Skills?
-
-A skill is a directory inside `$SIGNET_WORKSPACE/skills/` containing at minimum a `SKILL.md` file. That file describes what the skill does and how the agent should use it. Skills are markdown — they contain *instructions*, not executable code.
-
-```
-$SIGNET_WORKSPACE/skills/
-├── remember/
-│   └── SKILL.md          # /remember command
-├── recall/
-│   └── SKILL.md          # /recall command
-├── browser-use/
-│   └── SKILL.md          # browser automation
-└── github/
-    └── SKILL.md          # GitHub CLI operations
-```
-
-When a [harness](/harnesses/) loads your agent, the installed skills are included in the system prompt (via the `<available_skills>` section in AGENTS.md). The agent reads the relevant SKILL.md and follows its instructions.
-
----
-
-## CLI Commands
+The current `signet skill` command set is intentionally small:
 
 ```bash
 # List installed skills
 signet skill list
 
-# Search the skills.sh registry
+# Search installed skills and the registry
 signet skill search browser
 
-# Install from skills.sh
-signet skill install browser-use
+# Install a registry entry or an owner/repository reference
+signet skill install owner/repository
 
-# Show details about a skill
-signet skill info browser-use
+# Print an installed SKILL.md
+signet skill show browser-use
 
-# Remove a skill
-signet skill remove weather
-
-# Update all installed skills
-signet skill update
-
-# Update a specific skill
-signet skill update github
-
-# Create a new skill (scaffolding)
-signet skill create my-tool
+# Remove an installed skill
+signet skill uninstall browser-use
+# `remove` is an alias for `uninstall`
 ```
 
+`info`, `update`, `create`, and `publish` are not registered Signet CLI commands. Create or edit a local skill directory with your normal editor and publish it through the registry or repository workflow that owns it, rather than treating those retired commands as supported Signet behavior.
+
+## Install and search behavior
+
+When the daemon is available, list, show, install, and remove use its skills API. When the daemon is unavailable, the CLI can list local directories, show local `SKILL.md` files, install through the configured skills runner, and search local plus public registry results. Registry results are discovery aids: inspect the source before installing an unfamiliar skill.
+
+```text
+$SIGNET_WORKSPACE/skills/
+└── release-notes/
+    └── SKILL.md
+```
+
+## SKILL.md shape
+
+A skill is ordinary Markdown with optional YAML frontmatter. Keep the frontmatter truthful and the body specific about when to use the skill, expected inputs, boundaries, and verification.
+
+```markdown
 ---
-
-## Built-in Skills
-
-Signet ships with three built-in skills that integrate directly with the [Memory](/memory/) system (see [Memory Skills](/memory-skills/) for full details):
-
-### `/remember`
-
-Save information to persistent memory. Content is embedded automatically for semantic search.
-
-```bash
-# CLI
-signet remember "nicholai prefers bun over npm"
-signet remember "critical memory" --critical
-signet remember "tagged memory" -t tag1,tag2
-
-# In harness
-/remember nicholai prefers bun over npm
-/remember critical: never push directly to main
-/remember [tag1,tag2]: tagged content here
-```
-
-Prefixes:
-- `critical:` or `--critical` — pins the memory (never decays, always included in session context)
-- `[tag1,tag2]:` or `-t tag1,tag2` — adds searchable tags
-
-See [MEMORY.md](/memory/) for full details.
-
-### `/recall`
-
-Search memories with hybrid semantic + keyword search.
-
-```bash
-# CLI
-signet recall "coding preferences"
-signet recall "signet architecture" --type decision -l 5
-
-# In harness
-/recall coding preferences
-/recall signet architecture
-/recall what did we decide about auth
-```
-
-See [MEMORY.md](/memory/) for full details.
-
-### `/memory-debug`
-
-Diagnose memory issues end-to-end (daemon health, remember/write path, recall/read path, embedding health, and API checks).
-
-```bash
-# In harness
-/memory-debug
-/memory-debug recall is empty
-
-# Core checks it should run
-signet status
-signet remember "memory-debug smoke test" -t debug,smoke
-signet recall "memory-debug smoke test" --json
-```
-
-Use this when memory results are missing, low quality, or inconsistent across sessions.
-
----
-
-## SKILL.md Format
-
-Skills are defined with YAML frontmatter followed by markdown content.
-
-## ```markdown
-name: example-skill
-description: Brief description for skill listings
-version: 1.0.0
-author: username
-homepage: https://github.com/user/skill-repo
-dependencies:
-  bins: [some-cli]            # Required CLI tools
-  skills: [other-skill]       # Required other skills
-user_invocable: true          # Can be triggered with /skill-name
-arg_hint: "<query>"           # Help text for args
-## builtin: false                # true for Signet built-ins
-
-# Skill Name
-
-What this skill does and when to use it.
-
-## Usage
-
-```
-/skill-name some argument
-```
-
-## Examples
-
-...
-
-## Implementation
-
-Instructions for the agent on how to carry out this skill...
-```
-
-The `user_invocable: true` flag means users can trigger the skill with `/skill-name` in their harness. The `builtin: true` flag marks skills that integrate directly with the Signet daemon API (like remember and recall).
-
----
-
-## skills.sh Integration
-
-[skills.sh](https://skills.sh) is a public registry of agent skills. Signet searches and installs from it via the `npx skills` CLI.
-
-### How install works
-
-1. `signet skill install <name>` calls `npx skills add <name> --global --yes`
-2. The skill is installed to `$SIGNET_WORKSPACE/skills/<name>/`
-3. The SKILL.md file is parsed for metadata
-4. The harness config is updated to include the new skill
-
-### How search works
-
-1. `signet skill search <query>` calls `npx skills search <query>`
-2. Results show name, description, and install count
-3. Already-installed skills are marked
-
----
-
-## Dashboard
-
-The [Dashboard](/dashboard/)'s **Skills** panel provides a UI for everything the CLI does:
-
-- **Installed tab** — lists skills with name, description, version
-- **Browse tab** — search skills.sh, install with one click
-- **Detail view** — shows the full SKILL.md content
-
----
-
-## Creating Custom Skills
-
-```bash
-signet skill create my-tool
-```
-
-This creates `$SIGNET_WORKSPACE/skills/my-tool/SKILL.md` with a starter template. Edit it to describe what the skill does.
-
-### Example: a custom deployment skill
-
-## ```markdown
-name: deploy-staging
-description: Deploy the current project to staging
+name: release-notes
+description: Draft release notes from merged pull requests.
 version: 0.1.0
-author: nicholai
 user_invocable: true
-## arg_hint: "[service-name]"
-
-# deploy-staging
-
-Deploys the current project to the staging environment.
-
-## Usage
-
-```
-/deploy-staging
-/deploy-staging api-service
-```
-
-## Implementation
-
-1. Check that you're on a clean git branch (no uncommitted changes)
-2. Run `bun run build` to build the project
-3. Run the project's deploy script: `./scripts/deploy.sh staging`
-4. Report the deployment URL when complete
-
-If there are uncommitted changes, stop and ask the user if they want to commit first.
-```
-
+arg_hint: "<release range>"
 ---
 
-## Harness Integration
+# Release notes
 
-### Claude Code and OpenCode
-
-An `<available_skills>` section is generated in the AGENTS.md copy for each harness, listing installed skills by name and description. The agent uses this to know which skills are available.
-
-### OpenClaw
-
-Skills are referenced in the `skills.entries` section of the OpenClaw workspace config, pointing to the `$SIGNET_WORKSPACE/skills/` directory.
-
----
-
-## Security
-
-Skills are markdown files — they're instructions, not code. A skill only does what the agent chooses to do after reading it. However:
-
-- A malicious skill could instruct the agent to do harmful things.
-- Only install skills from sources you trust.
-- Skill signing and verification is planned for a future release.
-
----
-
-## Publishing a Skill
-
-To share a skill on skills.sh:
-
-```bash
-cd $SIGNET_WORKSPACE/skills/my-skill
-signet skill publish
+Use when the caller asks for release-note drafting.
 ```
 
-Requirements:
-- Valid SKILL.md with required frontmatter (`name`, `description`, `version`, `author`)
-- Unique skill name on skills.sh
-- skills.sh account (authenticate via `signet auth`)
+## Safety
 
----
+Skills can contain untrusted instructions. Install only sources you trust, review a skill before use, and do not treat a skill as authorization to access secrets, alter accounts, or run destructive commands.
 
-## Versioning
-
-Skills use semver in the `version` frontmatter field. `signet skill update` compares the installed version against the registry and replaces if newer.
-
-User-created skills (no registry source) are never auto-updated.
+For memory-specific skills, see [Memory skills](/memory-skills/).


### PR DESCRIPTION
## Summary

Refreshes public SDK, MCP, skills, and harness interface documentation against the current source contracts.

## Changes

- Corrects Claude Code config locations and resolved hook timeout behavior.
- Documents Hermes's namespaced `signet_session_search` tool and preserves the current memory-mirror lifecycle semantics.
- Updates MCP temporal/session controls and makes `memory_store.hints` required in docs and examples.
- Replaces stale SDK surface, connector, lifecycle, operations, skills, and predictor guidance with current signatures.
- Removes unsupported skill CLI commands and the nonexistent SDK 1.0 compatibility claim.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [x] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [x] `@signet/sdk`
- [x] `@signet/connector-*`
- [x] `@signet/web`
- [ ] `predictor`
- [ ] Other

## Screenshots

Not applicable: documentation-only change.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) (reviewed; this documentation-only change does not alter a spec contract)
- [x] Agent scoping verified on all new/changed data queries (no data-query implementation changed; refreshed docs retain agent and session scoping)
- [x] Input/config validation and bounds checks added (not applicable to docs-only code; documented existing source contracts)
- [x] Error handling and fallback paths tested (no silent swallow) (not applicable to docs-only code; examples were checked against source)
- [x] Security checks applied to admin/mutation endpoints (reviewed token-role and queued secret-execution documentation; no endpoint changed)
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix (not applicable: no bug-fix implementation)
- [x] Lint/typecheck/tests pass locally (content validation, Astro check, and static build)

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

No migration changed.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A (documentation-only; ran `bun run validate:content`, `bun run check`, and `bun run build`)

Additional verification:

- Parsed 16 TypeScript/TSX documentation snippets.
- Verified the rebased Hermes docs retain both the current memory-mirror semantics and the `signet_session_search` collision correction.
- `git diff --check origin/main...HEAD`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

`bun scripts/doc-drift.ts` still reports unrelated global route/package inventory drift outside this documentation refresh; migration references are clean.