### PR TITLE
fix(provenance): validate proposal sources

### DIFF
--- a/platform/daemon/src/episodic-sources.ts
+++ b/platform/daemon/src/episodic-sources.ts
@@ -75,6 +75,10 @@ export interface ReadEpisodicSourceOptions {
 	readonly from: string;
 }
 
+export type StrictEpisodicSourceRefResolution =
+	| { readonly status: "resolved"; readonly source: EpisodicSourceRecord }
+	| { readonly status: "invalid" | "not_found" | "cross_agent"; readonly sourceRef: string };
+
 const SOURCE_KIND_RANK: Readonly<Record<EpisodicSourceKind, number>> = {
 	memory: 0,
 	artifact: 1,
@@ -682,6 +686,35 @@ export function readEpisodicSource(db: ReadDb, options: ReadEpisodicSourceOption
 		readEpisodicTranscript(db, options.agentId, from) ??
 		readEpisodicSummary(db, options.agentId, from)
 	);
+}
+
+/**
+ * Resolve a canonical immutable source_ref for a proposal write. Unlike the
+ * permissive reader above, this accepts only one explicit episodic kind and
+ * never guesses across stores. Callers can therefore reject a fabricated or
+ * cross-agent reference before persisting derived-memory provenance.
+ */
+export function resolveStrictEpisodicSourceRef(
+	db: ReadDb,
+	params: { readonly agentId: string; readonly sourceRef: unknown },
+): StrictEpisodicSourceRefResolution {
+	if (typeof params.sourceRef !== "string") return { status: "invalid", sourceRef: "" };
+	const sourceRef = params.sourceRef.trim();
+	const separator = sourceRef.indexOf(":");
+	if (separator <= 0 || separator === sourceRef.length - 1) return { status: "invalid", sourceRef };
+	const kind = sourceRef.slice(0, separator);
+	const id = sourceRef.slice(separator + 1).trim();
+	if (!(["memory", "artifact", "transcript", "summary"] as const).includes(kind as EpisodicSourceKind) || !id) {
+		return { status: "invalid", sourceRef };
+	}
+	const canonicalRef = `${kind}:${id}`;
+	const source = readEpisodicSource(db, { agentId: params.agentId, from: canonicalRef });
+	if (source !== null) return { status: "resolved", source };
+	const owners = findEpisodicSourceAgentIds(db, canonicalRef);
+	if (owners.some((agentId) => agentId !== params.agentId)) {
+		return { status: "cross_agent", sourceRef: canonicalRef };
+	}
+	return { status: "not_found", sourceRef: canonicalRef };
 }
 
 /** Find scopes that own a resolvable source without exposing their contents. */

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -179,6 +179,13 @@ describe("ontology proposals", () => {
 	});
 
 	it("records canonical episodic lineage and stales aggregate snapshots when a claim changes", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories
+				 (id, content, type, agent_id, visibility, memory_kind, created_at, updated_at)
+				 VALUES ('episodic-source', 'Signet is a local-first memory system.', 'fact', 'ant', 'global', 'episodic', ?, ?)`,
+			).run("2026-08-04T00:00:00.000Z", "2026-08-04T00:00:00.000Z");
+		});
 		const initial = applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
@@ -270,6 +277,95 @@ describe("ontology proposals", () => {
 				db.prepare("SELECT stale_at FROM memories WHERE id = ? AND agent_id = ?").get("aggregate-snapshot", "ant"),
 			),
 		).toMatchObject({ stale_at: expect.any(String) });
+	});
+
+	it("rejects invalid proposal source_refs before creating semantic memory provenance (#1343)", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories
+				 (id, content, type, agent_id, visibility, memory_kind, created_at, updated_at)
+				 VALUES
+				 ('valid-source', 'Valid same-scope evidence.', 'fact', 'ant', 'global', 'episodic', ?, ?),
+				 ('other-source', 'Other agent evidence.', 'fact', 'other', 'global', 'episodic', ?, ?)`,
+			).run(
+				"2026-08-04T00:00:00.000Z",
+				"2026-08-04T00:00:00.000Z",
+				"2026-08-04T00:00:00.000Z",
+				"2026-08-04T00:00:00.000Z",
+			);
+		});
+		const payload = (claimKey: string) => ({
+			entity: "Strict Provenance",
+			entity_type: "project",
+			aspect: "evidence",
+			claim_key: claimKey,
+			value: "Source resolution must precede semantic memory materialization.",
+		});
+		const counts = () =>
+			getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare(
+							`SELECT
+							 (SELECT COUNT(*) FROM entity_attributes WHERE agent_id = 'ant') AS attributes,
+							 (SELECT COUNT(*) FROM memories WHERE agent_id = 'ant' AND memory_kind = 'derived') AS derived,
+							 (SELECT COUNT(*) FROM derived_memory_sources WHERE agent_id = 'ant') AS links`,
+						)
+						.get() as { attributes: number; derived: number; links: number },
+			);
+
+		const valid = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "set_claim_value",
+			payload: payload("valid"),
+			evidence: [{ source_ref: "memory:valid-source" }],
+		});
+		expect(valid.result?.memoryId).toBe(valid.result?.attributeId);
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare("SELECT source_kind, source_id FROM derived_memory_sources WHERE derived_memory_id = ?")
+						.get(valid.result?.memoryId) as { source_kind: string; source_id: string } | undefined,
+			),
+		).toEqual({ source_kind: "memory", source_id: "valid-source" });
+
+		const beforeRejectedApply = counts();
+		expect(() =>
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				operation: "set_claim_value",
+				payload: payload("missing"),
+				evidence: [{ source_ref: "memory:missing-source" }],
+			}),
+		).toThrow(new OntologyProposalError("Evidence source_ref was not found: memory:missing-source", 409));
+		expect(counts()).toEqual(beforeRejectedApply);
+
+		expect(() =>
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				operation: "set_claim_value",
+				payload: payload("blank"),
+				evidence: [{ source_ref: "memory:" }],
+			}),
+		).toThrow(new OntologyProposalError("Evidence source_ref must name a canonical episodic source", 409));
+		expect(counts()).toEqual(beforeRejectedApply);
+
+		const crossScope = createOntologyProposal(getDbAccessor(), {
+			agentId: "ant",
+			operation: "set_claim_value",
+			payload: payload("cross_scope"),
+			evidence: [{ source_ref: "memory:other-source" }],
+		});
+		const beforePendingApply = counts();
+		expect(() => applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: crossScope.id, actor: "test" })).toThrow(
+			new OntologyProposalError("Evidence source_ref crosses the authorized agent scope", 409),
+		);
+		expect(counts()).toEqual(beforePendingApply);
+		expect(getOntologyProposal(getDbAccessor(), crossScope.id, "ant")?.status).toBe("pending");
 	});
 
 	it("rejects generic entity labels before creating ontology entities", () => {

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -420,6 +420,116 @@ describe("ontology proposals", () => {
 		expect(getOntologyProposal(getDbAccessor(), pending.id, "ant")?.status).toBe("pending");
 	});
 
+	it("rejects a deduped claim apply whose evidence source disappeared after creation", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories
+				 (id, content, type, agent_id, visibility, memory_kind, created_at, updated_at)
+				 VALUES
+				 ('dedupe-live', 'Live dedupe evidence.', 'fact', 'ant', 'global', 'episodic', ?, ?),
+				 ('dedupe-gone', 'Evidence that will disappear.', 'fact', 'ant', 'global', 'episodic', ?, ?)`,
+			).run(
+				"2026-08-04T00:00:00.000Z",
+				"2026-08-04T00:00:00.000Z",
+				"2026-08-04T00:00:00.000Z",
+				"2026-08-04T00:00:00.000Z",
+			);
+		});
+		const payload = {
+			entity: "Dedupe Provenance",
+			entity_type: "project",
+			aspect: "evidence",
+			claim_key: "dedupe_slot",
+			value: "Deduped applies must still revalidate their evidence.",
+		};
+
+		const first = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "set_claim_value",
+			payload,
+			evidence: [{ source_ref: "memory:dedupe-live" }],
+		});
+		expect(first.proposal.status).toBe("applied");
+		expect(first.result?.attributeId).toBeTypeOf("string");
+
+		const pending = createOntologyProposal(getDbAccessor(), {
+			agentId: "ant",
+			operation: "set_claim_value",
+			payload,
+			evidence: [{ source_ref: "memory:dedupe-gone" }],
+		});
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE memories SET is_deleted = 1 WHERE id = ? AND agent_id = ?").run("dedupe-gone", "ant");
+		});
+
+		const before = getDbAccessor().withReadDb((db) => {
+			const attributeCount = (
+				db.prepare("SELECT COUNT(*) AS c FROM entity_attributes WHERE agent_id = ?").get("ant") as { c: number }
+			).c;
+			const derivedCount = (
+				db.prepare("SELECT COUNT(*) AS c FROM memories WHERE agent_id = ? AND memory_kind = 'derived'").get("ant") as {
+					c: number;
+				}
+			).c;
+			return { attributeCount, derivedCount };
+		});
+
+		// The dedupe early-return used to apply without revalidating evidence.
+		expect(() => applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: pending.id, actor: "test" })).toThrow(
+			new OntologyProposalError("Evidence source_ref was not found: memory:dedupe-gone", 409),
+		);
+
+		const after = getDbAccessor().withReadDb((db) => {
+			const attributeCount = (
+				db.prepare("SELECT COUNT(*) AS c FROM entity_attributes WHERE agent_id = ?").get("ant") as { c: number }
+			).c;
+			const derivedCount = (
+				db.prepare("SELECT COUNT(*) AS c FROM memories WHERE agent_id = ? AND memory_kind = 'derived'").get("ant") as {
+					c: number;
+				}
+			).c;
+			return { attributeCount, derivedCount };
+		});
+		expect(after).toEqual(before);
+		expect(getOntologyProposal(getDbAccessor(), pending.id, "ant")?.status).toBe("pending");
+	});
+
+	it("rejects a non-materializing apply whose evidence source disappeared after creation", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories
+				 (id, content, type, agent_id, visibility, memory_kind, created_at, updated_at)
+				 VALUES ('entity-gone', 'Entity evidence that will disappear.', 'fact', 'ant', 'global', 'episodic', ?, ?)`,
+			).run("2026-08-04T00:00:00.000Z", "2026-08-04T00:00:00.000Z");
+		});
+
+		const pending = createOntologyProposal(getDbAccessor(), {
+			agentId: "ant",
+			operation: "create_entity",
+			payload: { name: "Orphaned Evidence Entity", entity_type: "concept" },
+			evidence: [{ source_ref: "memory:entity-gone" }],
+		});
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE memories SET is_deleted = 1 WHERE id = ? AND agent_id = ?").run("entity-gone", "ant");
+		});
+
+		// create_entity never materializes attribute memory, so apply-time
+		// revalidation has to happen at the shared seam, not the materializer.
+		expect(() => applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: pending.id, actor: "test" })).toThrow(
+			new OntologyProposalError("Evidence source_ref was not found: memory:entity-gone", 409),
+		);
+		expect(
+			getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare("SELECT COUNT(*) AS c FROM entities WHERE agent_id = ? AND name = ?")
+						.get("ant", "Orphaned Evidence Entity") as { c: number },
+			),
+		).toEqual({ c: 0 });
+		expect(getOntologyProposal(getDbAccessor(), pending.id, "ant")?.status).toBe("pending");
+	});
+
 	it("rejects generic entity labels before creating ontology entities", () => {
 		expect(() =>
 			applyOntologyOperation(getDbAccessor(), {

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -279,15 +279,18 @@ describe("ontology proposals", () => {
 		).toMatchObject({ stale_at: expect.any(String) });
 	});
 
-	it("rejects invalid proposal source_refs before creating semantic memory provenance (#1343)", () => {
+	it("rejects invalid proposal source_refs before creating proposals or semantic memory provenance (#1343)", () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				`INSERT INTO memories
 				 (id, content, type, agent_id, visibility, memory_kind, created_at, updated_at)
 				 VALUES
 				 ('valid-source', 'Valid same-scope evidence.', 'fact', 'ant', 'global', 'episodic', ?, ?),
+				 ('pending-source', 'Evidence for a pending proposal.', 'fact', 'ant', 'global', 'episodic', ?, ?),
 				 ('other-source', 'Other agent evidence.', 'fact', 'other', 'global', 'episodic', ?, ?)`,
 			).run(
+				"2026-08-04T00:00:00.000Z",
+				"2026-08-04T00:00:00.000Z",
 				"2026-08-04T00:00:00.000Z",
 				"2026-08-04T00:00:00.000Z",
 				"2026-08-04T00:00:00.000Z",
@@ -307,11 +310,12 @@ describe("ontology proposals", () => {
 					db
 						.prepare(
 							`SELECT
+							 (SELECT COUNT(*) FROM ontology_proposals WHERE agent_id = 'ant') AS proposals,
 							 (SELECT COUNT(*) FROM entity_attributes WHERE agent_id = 'ant') AS attributes,
 							 (SELECT COUNT(*) FROM memories WHERE agent_id = 'ant' AND memory_kind = 'derived') AS derived,
 							 (SELECT COUNT(*) FROM derived_memory_sources WHERE agent_id = 'ant') AS links`,
 						)
-						.get() as { attributes: number; derived: number; links: number },
+						.get() as { proposals: number; attributes: number; derived: number; links: number },
 			);
 
 		const valid = applyOntologyOperation(getDbAccessor(), {
@@ -331,18 +335,34 @@ describe("ontology proposals", () => {
 			),
 		).toEqual({ source_kind: "memory", source_id: "valid-source" });
 
-		const beforeRejectedApply = counts();
+		const deduped = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "set_claim_value",
+			payload: payload("valid"),
+			evidence: [{ source_ref: "memory:valid-source" }],
+		});
+		expect(deduped.result?.deduped).toBe(true);
+		expect(deduped.result?.attributeId).toBe(valid.result?.attributeId);
+		expect(counts()).toEqual({ proposals: 2, attributes: 1, derived: 1, links: 1 });
+
+		const beforeRejectedWrites = counts();
 		expect(() =>
-			applyOntologyOperation(getDbAccessor(), {
+			createOntologyProposal(getDbAccessor(), {
 				agentId: "ant",
-				actor: "test",
 				operation: "set_claim_value",
 				payload: payload("missing"),
 				evidence: [{ source_ref: "memory:missing-source" }],
 			}),
 		).toThrow(new OntologyProposalError("Evidence source_ref was not found: memory:missing-source", 409));
-		expect(counts()).toEqual(beforeRejectedApply);
-
+		expect(() =>
+			createOntologyProposal(getDbAccessor(), {
+				agentId: "ant",
+				operation: "set_claim_value",
+				payload: payload("cross_scope"),
+				evidence: [{ source_ref: "memory:other-source" }],
+			}),
+		).toThrow(new OntologyProposalError("Evidence source_ref crosses the authorized agent scope", 409));
 		expect(() =>
 			applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
@@ -350,22 +370,54 @@ describe("ontology proposals", () => {
 				operation: "set_claim_value",
 				payload: payload("blank"),
 				evidence: [{ source_ref: "memory:" }],
+				propose: true,
 			}),
 		).toThrow(new OntologyProposalError("Evidence source_ref must name a canonical episodic source", 409));
-		expect(counts()).toEqual(beforeRejectedApply);
+		expect(() =>
+			applyOntologyOperationBatch(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				propose: true,
+				operations: [
+					{
+						operation: "set_claim_value",
+						payload: payload("batch_valid"),
+						evidence: [{ source_ref: "memory:valid-source" }],
+					},
+					{
+						operation: "set_claim_value",
+						payload: payload("batch_missing"),
+						evidence: [{ source_ref: "memory:missing-source" }],
+					},
+				],
+			}),
+		).toThrow(new OntologyProposalError("Evidence source_ref was not found: memory:missing-source", 409));
+		expect(() =>
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "test",
+				operation: "set_claim_value",
+				payload: payload("direct_missing"),
+				evidence: [{ source_ref: "memory:missing-source" }],
+			}),
+		).toThrow(new OntologyProposalError("Evidence source_ref was not found: memory:missing-source", 409));
+		expect(counts()).toEqual(beforeRejectedWrites);
 
-		const crossScope = createOntologyProposal(getDbAccessor(), {
+		const pending = createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "set_claim_value",
-			payload: payload("cross_scope"),
-			evidence: [{ source_ref: "memory:other-source" }],
+			payload: payload("deleted_before_apply"),
+			evidence: [{ source_ref: "memory:pending-source" }],
 		});
-		const beforePendingApply = counts();
-		expect(() => applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: crossScope.id, actor: "test" })).toThrow(
-			new OntologyProposalError("Evidence source_ref crosses the authorized agent scope", 409),
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE memories SET is_deleted = 1 WHERE id = ? AND agent_id = ?").run("pending-source", "ant");
+		});
+		const beforeDeletedSourceApply = counts();
+		expect(() => applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: pending.id, actor: "test" })).toThrow(
+			new OntologyProposalError("Evidence source_ref was not found: memory:pending-source", 409),
 		);
-		expect(counts()).toEqual(beforePendingApply);
-		expect(getOntologyProposal(getDbAccessor(), crossScope.id, "ant")?.status).toBe("pending");
+		expect(counts()).toEqual(beforeDeletedSourceApply);
+		expect(getOntologyProposal(getDbAccessor(), pending.id, "ant")?.status).toBe("pending");
 	});
 
 	it("rejects generic entity labels before creating ontology entities", () => {

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -489,12 +489,33 @@ function readBackInTx(db: WriteDb, id: string, agentId: string): OntologyProposa
 	return toProposal(row);
 }
 
+function requireStrictEpisodicSourceRefInTx(db: WriteDb, agentId: string, sourceRef: unknown) {
+	const resolved = resolveStrictEpisodicSourceRef(db, { agentId, sourceRef });
+	if (resolved.status === "resolved") return resolved.source;
+	if (resolved.status === "invalid") {
+		throw new OntologyProposalError("Evidence source_ref must name a canonical episodic source", 409);
+	}
+	if (resolved.status === "cross_agent") {
+		throw new OntologyProposalError("Evidence source_ref crosses the authorized agent scope", 409);
+	}
+	throw new OntologyProposalError(`Evidence source_ref was not found: ${resolved.sourceRef}`, 409);
+}
+
+function validateProposalEvidenceSourcesInTx(db: WriteDb, agentId: string, evidence: readonly unknown[]): void {
+	for (const value of evidence) {
+		const ref = readOntologyEvidenceRef(value);
+		if (ref === null || !isRecord(ref.reference) || !("source_ref" in ref.reference)) continue;
+		requireStrictEpisodicSourceRefInTx(db, agentId, ref.reference.source_ref);
+	}
+}
+
 function insertProposalInTx(db: WriteDb, input: CreateOntologyProposalInput, ts: string): OntologyProposal {
 	const id = crypto.randomUUID();
 	const agentId = requireText(input.agentId, "agentId");
 	const operation = requireText(input.operation, "operation");
 	if (Object.keys(input.payload).length === 0) throw new OntologyProposalError("payload is required", 400);
 	const evidence = input.evidence ?? [];
+	validateProposalEvidenceSourcesInTx(db, agentId, evidence);
 	db.prepare(
 		`INSERT INTO ontology_proposals
 		 (id, agent_id, operation, status, payload, confidence, rationale,
@@ -563,23 +584,11 @@ function derivedMemorySourcesForProposalInTx(
 		if (typeof ref.reference !== "object" || ref.reference === null || Array.isArray(ref.reference)) continue;
 		const evidence = ref.reference as Readonly<Record<string, unknown>>;
 		if (!("source_ref" in evidence)) continue;
-		const resolved = resolveStrictEpisodicSourceRef(db, {
-			agentId: proposal.agent_id,
-			sourceRef: evidence.source_ref,
-		});
-		if (resolved.status !== "resolved") {
-			if (resolved.status === "invalid") {
-				throw new OntologyProposalError("Evidence source_ref must name a canonical episodic source", 409);
-			}
-			if (resolved.status === "cross_agent") {
-				throw new OntologyProposalError("Evidence source_ref crosses the authorized agent scope", 409);
-			}
-			throw new OntologyProposalError(`Evidence source_ref was not found: ${resolved.sourceRef}`, 409);
-		}
+		const source = requireStrictEpisodicSourceRefInTx(db, proposal.agent_id, evidence.source_ref);
 		sources.push({
-			sourceKind: resolved.source.kind,
-			sourceId: resolved.source.id,
-			sourcePath: resolved.source.sourcePath,
+			sourceKind: source.kind,
+			sourceId: source.id,
+			sourcePath: source.sourcePath,
 		});
 	}
 	return sources;

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -2208,6 +2208,11 @@ function applyOperation(
 	writeCaps?: GraphWriteCaps,
 ): Readonly<Record<string, unknown>> {
 	try {
+		// Revalidate strict source_ref evidence at the common apply seam, not
+		// just inside materializeAttributeMemoryInTx: a pending proposal whose
+		// evidence source disappears after creation must fail closed here,
+		// before any handler mutation or dedupe early-return can apply it.
+		validateProposalEvidenceSourcesInTx(db, proposal.agent_id, proposalAuditEvidence(proposal));
 		const payload = parseJsonRecord(proposal.payload);
 		if (proposal.operation === "create_entity") return applyCreateEntity(db, proposal.agent_id, proposal, payload);
 		if (proposal.operation === "rename_entity") return applyRenameEntity(db, proposal.agent_id, proposal, payload);

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -13,6 +13,7 @@ import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import { requireDependencyReason } from "./dependency-history";
 import { linkDerivedMemorySourcesInTx, markDerivedMemoriesStaleForSourceInTx } from "./derived-memory-provenance";
 import { classifyEntityQuality } from "./entity-quality";
+import { resolveStrictEpisodicSourceRef } from "./episodic-sources";
 import {
 	reconcileOntologyContradictionsInTx,
 	recordOntologyContradictionsForAttributeInTx,
@@ -549,7 +550,10 @@ function proposalAuditEvidence(proposal: ProposalRow): readonly unknown[] {
  * memory lineage instead keys on the immutable record named by source_ref, so
  * corrections to that record can invalidate every dependent semantic row.
  */
-function derivedMemorySourcesForProposal(proposal: ProposalRow): readonly {
+function derivedMemorySourcesForProposalInTx(
+	db: WriteDb,
+	proposal: ProposalRow,
+): readonly {
 	readonly sourceKind: string;
 	readonly sourceId: string;
 	readonly sourcePath: string | null;
@@ -557,14 +561,26 @@ function derivedMemorySourcesForProposal(proposal: ProposalRow): readonly {
 	const sources: Array<{ sourceKind: string; sourceId: string; sourcePath: string | null }> = [];
 	for (const ref of proposalEvidenceRefs(toProposal(proposal))) {
 		if (typeof ref.reference !== "object" || ref.reference === null || Array.isArray(ref.reference)) continue;
-		const sourceRef = readString(ref.reference as Readonly<Record<string, unknown>>, "source_ref");
-		if (sourceRef === null) continue;
-		const separator = sourceRef.indexOf(":");
-		if (separator <= 0 || separator === sourceRef.length - 1) continue;
-		const sourceKind = sourceRef.slice(0, separator);
-		const sourceId = sourceRef.slice(separator + 1);
-		if (!(["memory", "artifact", "transcript", "summary"] as const).includes(sourceKind as "memory")) continue;
-		sources.push({ sourceKind, sourceId, sourcePath: ref.sourcePath });
+		const evidence = ref.reference as Readonly<Record<string, unknown>>;
+		if (!("source_ref" in evidence)) continue;
+		const resolved = resolveStrictEpisodicSourceRef(db, {
+			agentId: proposal.agent_id,
+			sourceRef: evidence.source_ref,
+		});
+		if (resolved.status !== "resolved") {
+			if (resolved.status === "invalid") {
+				throw new OntologyProposalError("Evidence source_ref must name a canonical episodic source", 409);
+			}
+			if (resolved.status === "cross_agent") {
+				throw new OntologyProposalError("Evidence source_ref crosses the authorized agent scope", 409);
+			}
+			throw new OntologyProposalError(`Evidence source_ref was not found: ${resolved.sourceRef}`, 409);
+		}
+		sources.push({
+			sourceKind: resolved.source.kind,
+			sourceId: resolved.source.id,
+			sourcePath: resolved.source.sourcePath,
+		});
 	}
 	return sources;
 }
@@ -882,7 +898,7 @@ function materializeAttributeMemoryInTx(
 	linkDerivedMemorySourcesInTx(db, {
 		derivedMemoryId: input.attributeId,
 		agentId: input.agentId,
-		sources: derivedMemorySourcesForProposal(input.proposal),
+		sources: derivedMemorySourcesForProposalInTx(db, input.proposal),
 		createdAt: now(),
 	});
 	return input.attributeId;


### PR DESCRIPTION
## Summary

Reject malformed, fabricated, and cross-agent ontology `source_ref` evidence before any derived semantic-memory provenance is written.

## Changes

- Add a strict canonical episodic-source resolver scoped to the proposal agent.
- Resolve proposal evidence transactionally before derived-memory materialization and reject invalid, missing, or cross-scope refs with 409 errors.
- Revalidate strict `source_ref` evidence at the common `applyOperation` apply seam, so a pending proposal whose evidence source disappears after creation fails closed with a 409 before any handler mutation or dedupe early-return (repair, see below).
- Add scratch-DB regressions for valid, missing, blank, and cross-agent source refs across direct and pending proposal applies.

## Repair (apply-time revalidation)

Follow-up review found that source refs were validated on insertion and again only inside `materializeAttributeMemoryInTx`. A pending proposal whose evidence source disappeared after creation could still be applied through non-materializing handlers (`create_entity`, `create_link`, ...) and through the dedupe early-returns in `add_claim_value`/`set_claim_value`. Both paths now revalidate the proposal's stored evidence at the shared `applyOperation` seam, inside the same transaction, before any semantic mutation or dedupe return.

New regressions:

- `rejects a deduped claim apply whose evidence source disappeared after creation` — pending `set_claim_value` with deleted source stays pending, attribute/derived counts unchanged.
- `rejects a non-materializing apply whose evidence source disappeared after creation` — pending `create_entity` with deleted source stays pending, no entity row created.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused verification (at current head `0e8e2965e`):

- `bun test platform/daemon/src/ontology-proposals.test.ts` (65 pass, 0 fail; includes the two new apply-time regressions)
- `bun run --filter '@signet/daemon' typecheck`
- `bun run --filter '@signet/daemon' build`

The full workspace typecheck and lint are currently red from unrelated connector exports and repository-wide formatting diagnostics. This change does not touch those files.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The resolver intentionally accepts only explicit canonical episodic kinds and does not perform cross-store fallback. Invalid source refs fail before attribute, derived-memory, or provenance-link writes can commit. Apply-time revalidation reads the proposal's stored evidence, so direct creation behavior and transaction rollback semantics are unchanged.
