### PR TITLE
fix(core): retire obsolete structural jobs

### DIFF
--- a/platform/core/src/migrations/129-retire-structural-jobs.ts
+++ b/platform/core/src/migrations/129-retire-structural-jobs.ts
@@ -24,7 +24,10 @@ export function up(db: MigrationDb): void {
 		throw new Error("job_cancellations table missing; cannot retire structural jobs without an audit trail");
 	}
 
-	db.exec(`
+	// Execute the audit through a prepared statement. bun:sqlite's multi-statement
+	// exec can continue after an INSERT trigger aborts; this throws before the
+	// cancellation statement and lets the runner's savepoint restore all state.
+	db.prepare(`
 		INSERT INTO job_cancellations (
 			id, source_table, source_id, status_before, payload_json,
 			reason, actor, actor_type, request_id, created_at
@@ -59,7 +62,9 @@ export function up(db: MigrationDb): void {
 		FROM memory_jobs
 		WHERE job_type IN ('structural_classify', 'structural_dependency')
 		  AND status IN ('pending', 'leased');
+	`).run();
 
+	db.exec(`
 		UPDATE memory_jobs
 		SET status = 'cancelled', updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 		WHERE job_type IN ('structural_classify', 'structural_dependency')

--- a/platform/core/src/migrations/129-retire-structural-jobs.ts
+++ b/platform/core/src/migrations/129-retire-structural-jobs.ts
@@ -1,0 +1,68 @@
+import type { MigrationDb } from "./index";
+
+function tableExists(db: MigrationDb, table: string): boolean {
+	return db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(table) != null;
+}
+
+/**
+ * Migration 129: retire the structural queues removed by the Dreaming cutover
+ * (#1391).
+ *
+ * `structural_classify` and `structural_dependency` no longer have workers or
+ * producers. Pending and leased rows cannot make progress, but they still make
+ * queue health look unhealthy and indefinitely defer automatic Dreaming. Keep
+ * the source rows for operator provenance: copy each original row into the
+ * existing cancellation audit before marking it cancelled. Terminal rows and
+ * every other job type are intentionally untouched.
+ *
+ * The migration runner wraps this complete audit-and-cancel operation in one
+ * savepoint, so an audit write failure rolls back the status change too.
+ */
+export function up(db: MigrationDb): void {
+	if (!tableExists(db, "memory_jobs")) return;
+	if (!tableExists(db, "job_cancellations")) {
+		throw new Error("job_cancellations table missing; cannot retire structural jobs without an audit trail");
+	}
+
+	db.exec(`
+		INSERT INTO job_cancellations (
+			id, source_table, source_id, status_before, payload_json,
+			reason, actor, actor_type, request_id, created_at
+		)
+		SELECT
+			'retire-structural-jobs-129:' || id,
+			'memory_jobs',
+			id,
+			status,
+			json_object(
+				'id', id,
+				'memory_id', memory_id,
+				'document_id', document_id,
+				'job_type', job_type,
+				'status', status,
+				'payload', payload,
+				'result', result,
+				'attempts', attempts,
+				'max_attempts', max_attempts,
+				'leased_at', leased_at,
+				'completed_at', completed_at,
+				'failed_at', failed_at,
+				'error', error,
+				'created_at', created_at,
+				'updated_at', updated_at
+			),
+			'retired structural queue after Dreaming cutover',
+			'migration:129',
+			'system',
+			NULL,
+			strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+		FROM memory_jobs
+		WHERE job_type IN ('structural_classify', 'structural_dependency')
+		  AND status IN ('pending', 'leased');
+
+		UPDATE memory_jobs
+		SET status = 'cancelled', updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+		WHERE job_type IN ('structural_classify', 'structural_dependency')
+		  AND status IN ('pending', 'leased');
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -134,6 +134,7 @@ import { up as memoryContentSafety } from "./125-memory-content-safety";
 import { up as dreamingSurprisalAttention } from "./126-dreaming-surprisal-attention";
 import { up as ontologyContradictions } from "./127-ontology-contradictions";
 import { up as boundedQueueDiagnostics } from "./128-bounded-queue-diagnostics";
+import { up as retireStructuralJobs } from "./129-retire-structural-jobs";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1198,6 +1199,11 @@ export const MIGRATIONS: readonly Migration[] = [
 		version: 128,
 		name: "bounded-queue-diagnostics",
 		up: boundedQueueDiagnostics,
+	},
+	{
+		version: 129,
+		name: "retire-structural-jobs",
+		up: retireStructuralJobs,
 	},
 ];
 

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -1090,6 +1090,40 @@ describe("migration framework", () => {
 		).toBe(1);
 	});
 
+	test("migration 129 keeps structural jobs and its marker when the cancellation audit aborts", () => {
+		db = createFreshDb();
+		runMigrations(db);
+
+		db.prepare(
+			`INSERT INTO memory_jobs
+			 (id, memory_id, job_type, status, payload, attempts, max_attempts, created_at, updated_at)
+			 VALUES ('structural-pending', 'memory-pending', 'structural_classify', 'pending', NULL, 0, 3, ?, ?)`,
+		).run("2026-03-28T10:00:00.000Z", "2026-03-28T10:00:00.000Z");
+		db.prepare("DELETE FROM schema_migrations WHERE version = 129").run();
+		db.exec(`
+			CREATE TRIGGER reject_structural_cancellation_audit
+			BEFORE INSERT ON job_cancellations
+			WHEN new.actor = 'migration:129'
+			BEGIN
+				SELECT RAISE(ABORT, 'audit fault');
+			END;
+		`);
+
+		expect(() => runMigrations(db)).toThrow("audit fault");
+		expect(
+			db.query<{ status: string }, []>("SELECT status FROM memory_jobs WHERE id = 'structural-pending'").get()?.status,
+		).toBe("pending");
+		expect(
+			db
+				.query<{ count: number }, []>("SELECT COUNT(*) AS count FROM job_cancellations WHERE actor = 'migration:129'")
+				.get()?.count,
+		).toBe(0);
+		expect(
+			db.query<{ count: number }, []>("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 129").get()
+				?.count,
+		).toBe(0);
+	});
+
 	test("migration 048 treats source_ref=session_key as session-scoped lane", () => {
 		db = createFreshDb();
 		db.exec(`

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -978,6 +978,118 @@ describe("migration framework", () => {
 		expect(indexColumns.map((column) => column.name)).toEqual(["agent_id", "completed_at"]);
 	});
 
+	test("migration 129 retires only legacy pending and leased structural jobs with an audit trail", () => {
+		db = createFreshDb();
+		runMigrations(db);
+
+		const insert = db.prepare(
+			`INSERT INTO memory_jobs
+			 (id, memory_id, job_type, status, payload, attempts, max_attempts, leased_at, error, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		);
+		const createdAt = "2026-03-28T10:00:00.000Z";
+		insert.run(
+			"structural-pending",
+			"memory-pending",
+			"structural_classify",
+			"pending",
+			'{"entity_id":"entity-a"}',
+			0,
+			3,
+			null,
+			"Unable to connect",
+			createdAt,
+			createdAt,
+		);
+		insert.run(
+			"structural-leased",
+			"memory-leased",
+			"structural_dependency",
+			"leased",
+			'{"entity_id":"entity-b"}',
+			2,
+			3,
+			"2026-03-28T10:05:00.000Z",
+			null,
+			createdAt,
+			createdAt,
+		);
+		insert.run(
+			"structural-completed",
+			"memory-completed",
+			"structural_classify",
+			"completed",
+			null,
+			1,
+			3,
+			null,
+			null,
+			createdAt,
+			createdAt,
+		);
+		insert.run(
+			"structural-dead",
+			"memory-dead",
+			"structural_dependency",
+			"dead",
+			null,
+			3,
+			3,
+			null,
+			"legacy failure",
+			createdAt,
+			createdAt,
+		);
+		insert.run("active-extract", "memory-extract", "extract", "pending", null, 0, 3, null, null, createdAt, createdAt);
+
+		// Simulate an upgrade from the immediately preceding schema version.
+		db.prepare("DELETE FROM schema_migrations WHERE version = 129").run();
+		runMigrations(db);
+
+		const statuses = db
+			.query<{ id: string; status: string; attempts: number }, []>(
+				"SELECT id, status, attempts FROM memory_jobs ORDER BY id",
+			)
+			.all();
+		expect(statuses).toEqual([
+			{ id: "active-extract", status: "pending", attempts: 0 },
+			{ id: "structural-completed", status: "completed", attempts: 1 },
+			{ id: "structural-dead", status: "dead", attempts: 3 },
+			{ id: "structural-leased", status: "cancelled", attempts: 2 },
+			{ id: "structural-pending", status: "cancelled", attempts: 0 },
+		]);
+
+		const audits = db
+			.query<{ source_id: string; status_before: string; payload_json: string; reason: string; actor: string }, []>(
+				"SELECT source_id, status_before, payload_json, reason, actor FROM job_cancellations WHERE actor = 'migration:129' ORDER BY source_id",
+			)
+			.all();
+		expect(audits.map((audit) => ({ source_id: audit.source_id, status_before: audit.status_before }))).toEqual([
+			{ source_id: "structural-leased", status_before: "leased" },
+			{ source_id: "structural-pending", status_before: "pending" },
+		]);
+		const pendingAudit = audits.find((audit) => audit.source_id === "structural-pending");
+		expect(pendingAudit?.reason).toBe("retired structural queue after Dreaming cutover");
+		expect(JSON.parse(pendingAudit?.payload_json ?? "{}")).toMatchObject({
+			id: "structural-pending",
+			job_type: "structural_classify",
+			status: "pending",
+			error: "Unable to connect",
+		});
+
+		const auditCount = audits.length;
+		runMigrations(db);
+		expect(
+			db
+				.query<{ count: number }, []>("SELECT COUNT(*) AS count FROM job_cancellations WHERE actor = 'migration:129'")
+				.get()?.count,
+		).toBe(auditCount);
+		expect(
+			db.query<{ count: number }, []>("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 129").get()
+				?.count,
+		).toBe(1);
+	});
+
 	test("migration 048 treats source_ref=session_key as session-scoped lane", () => {
 		db = createFreshDb();
 		db.exec(`


### PR DESCRIPTION
## Summary

Fixes #1391 by retiring only the two structural queue types that no current worker can consume. The migration preserves a full cancellation audit before changing job status, so obsolete rows stop indefinitely blocking Dreaming without losing operator provenance.

## Changes

- Add core migration 129 to audit and soft-cancel `pending` or `leased` `structural_classify` and `structural_dependency` rows.
- Leave every terminal structural row and all other job types unchanged. No age threshold, requeue, or revival path is introduced.
- Add sequential-upgrade and rerun coverage for the audit payload, status boundaries, and migration idempotency.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

Migration 129 runs under the runner's existing savepoint. It first inserts a full `memory_jobs` snapshot into `job_cancellations`, then changes only the matching source rows to `cancelled`. If the audit table is absent or the audit write fails, the migration fails closed and the savepoint rolls back the status change.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused proof passed:

- `bun test platform/core/src/migrations/migrations.test.ts` (67 pass)
- `bunx biome check platform/core/src/migrations/129-retire-structural-jobs.ts platform/core/src/migrations/index.ts platform/core/src/migrations/migrations.test.ts`
- `bun run --filter '@signet/core' build`
- `bun run --filter '@signet/core' typecheck`

The full workspace typecheck and lint remain red on current `origin/main`, outside this diff: connector packages reference missing or removed connector-base exports, and Biome reports pre-existing repository-wide formatting violations. They were rerun after `bun install`; the touched core package and files pass.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The mandatory readiness items are checked after review. Items with no migration-specific surface are N/A after inspection; the scoped core checks passed while full-repository lint/typecheck remain red on untouched current-main connector and formatting failures.

Independent adversarial review: SHIP. No correctness findings. The review noted only two non-blocking items: migration timestamps now use ISO-8601 `strftime` formatting consistent with application-written audit rows, and this data-only migration adds no schema artifact to declare.

