### PR TITLE
fix(doctor): report readiness truthfully

### DIFF
--- a/platform/daemon/src/pipeline/dreaming-worker.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import type { DreamingConfig } from "@signet/core";
 import { runMigrations } from "../../../core/src/migrations";
 import type { DbAccessor } from "../db-accessor";
+import { reportEventLoopLag, resetPressureState } from "../system-pressure";
 import {
 	DREAMING_AGENT_PROMPT,
 	type DreamingAgentExecutor,
@@ -76,6 +77,7 @@ describe("dreaming worker agent scope", () => {
 	});
 
 	afterEach(() => {
+		resetPressureState();
 		rmSync(agentsDir, { recursive: true, force: true });
 		db.close();
 	});
@@ -172,6 +174,28 @@ describe("dreaming worker agent scope", () => {
 			expect(worker.scheduler).toEqual({
 				status: "deferred",
 				reason: "queue_pressure",
+				checkedAt: expect.any(String),
+			});
+		} finally {
+			worker.stop();
+		}
+	});
+
+	it("reports system pressure when both system and queue pressure defer a sweep (#1446)", async () => {
+		const now = new Date().toISOString();
+		for (let index = 0; index <= 50; index += 1) {
+			db.prepare(
+				`INSERT INTO memory_jobs (id, memory_id, job_type, status, created_at, updated_at)
+				 VALUES (?, ?, 'index', 'pending', ?, ?)`,
+			).run(`combined-pressure-${index}`, `combined-memory-${index}`, now, now);
+		}
+		reportEventLoopLag(600);
+		const worker = startDreamingWorker(accessor, defaultCfg(), agentsDir, "default", { checkIntervalMs: 10 });
+		try {
+			await waitFor(() => worker.scheduler.reason === "system_pressure", 2_000);
+			expect(worker.scheduler).toEqual({
+				status: "deferred",
+				reason: "system_pressure",
 				checkedAt: expect.any(String),
 			});
 		} finally {

--- a/platform/daemon/src/pipeline/dreaming-worker.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.test.ts
@@ -158,6 +158,27 @@ describe("dreaming worker agent scope", () => {
 		expect(shouldDeferDreamingSweep(accessor)).toBe(true);
 	});
 
+	it("reports queue pressure only after the scheduler defers a sweep (#1393)", async () => {
+		const now = new Date().toISOString();
+		for (let index = 0; index <= 50; index += 1) {
+			db.prepare(
+				`INSERT INTO memory_jobs (id, memory_id, job_type, status, created_at, updated_at)
+				 VALUES (?, ?, 'index', 'pending', ?, ?)`,
+			).run(`scheduler-pressure-${index}`, `scheduler-memory-${index}`, now, now);
+		}
+		const worker = startDreamingWorker(accessor, defaultCfg(), agentsDir, "default", { checkIntervalMs: 10 });
+		try {
+			await waitFor(() => worker.scheduler.reason === "queue_pressure", 2_000);
+			expect(worker.scheduler).toEqual({
+				status: "deferred",
+				reason: "queue_pressure",
+				checkedAt: expect.any(String),
+			});
+		} finally {
+			worker.stop();
+		}
+	});
+
 	it("writes manual async trigger passes to the requested agent", async () => {
 		const worker = startDreamingWorker(accessor, defaultCfg(), agentsDir, "default");
 		try {

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -58,6 +58,19 @@ export interface DreamingWorkerHandle {
 	 * Await this (with a timeout) during shutdown before closing the DB.
 	 */
 	readonly activePass: Promise<unknown> | null;
+	/** Latest periodic-sweep decision. This is intentionally separate from a manual pass. */
+	readonly scheduler: DreamingSchedulerStatus;
+}
+
+/**
+ * The periodic scheduler's last decision. Queue pressure is reported only
+ * when the scheduler itself yielded to queue pressure, not when another
+ * readiness gate happened to be degraded.
+ */
+export interface DreamingSchedulerStatus {
+	readonly status: "idle" | "deferred";
+	readonly reason: "queue_pressure" | "system_pressure" | null;
+	readonly checkedAt: string | null;
 }
 
 export interface DreamingWorkerOptions {
@@ -185,6 +198,7 @@ export function startDreamingWorker(
 	let activeAgent: string | null = null;
 	let stopped = false;
 	let activePassPromise: Promise<unknown> | null = null;
+	let scheduler: DreamingSchedulerStatus = { status: "idle", reason: null, checkedAt: null };
 	// The last focused runbook the periodic sweep scheduled, used to
 	// alternate hygiene → content → hygiene → … when both kinds of work are
 	// pending (#1098). Explicit triggers do not touch it.
@@ -306,11 +320,17 @@ export function startDreamingWorker(
 
 	async function check(): Promise<void> {
 		if (stopped || active) return;
-		if (isSystemPressureHigh()) return;
+		const checkedAt = new Date().toISOString();
+		if (isSystemPressureHigh()) {
+			scheduler = { status: "deferred", reason: "system_pressure", checkedAt };
+			return;
+		}
 		if (shouldDeferDreamingSweep(accessor)) {
+			scheduler = { status: "deferred", reason: "queue_pressure", checkedAt };
 			logger.info("dreaming-worker", "Deferring dreaming sweep while queues are under pressure");
 			return;
 		}
+		scheduler = { status: "idle", reason: null, checkedAt };
 
 		// One Dreaming universe: a single pass covers every agent scope. The
 		// sweep runs one pass when any scope has attention or a backlog; the
@@ -490,6 +510,9 @@ export function startDreamingWorker(
 
 		get activePass() {
 			return activePassPromise;
+		},
+		get scheduler() {
+			return scheduler;
 		},
 	};
 }

--- a/platform/daemon/src/pipeline/index.ts
+++ b/platform/daemon/src/pipeline/index.ts
@@ -53,7 +53,7 @@ export {
 } from "./dreaming";
 export { getDreamingAttention } from "./dreaming-attention";
 export { getDreamingQualityReport } from "./dreaming-quality";
-export type { DreamingWorkerHandle } from "./dreaming-worker";
+export type { DreamingSchedulerStatus, DreamingWorkerHandle } from "./dreaming-worker";
 
 /** Get the active synthesis worker handle (for API routes). */
 export function getSynthesisWorker(): SynthesisWorkerHandle | null {

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -328,6 +328,7 @@ export function registerPipelineRoutes(app: Hono): void {
 			pipelineV2: config.pipelineV2,
 			pipeline: {
 				queue: pipelineQueueBlock(),
+				dreaming: getDreamingWorker()?.scheduler ?? null,
 			},
 			providerResolution: { ...providerRuntimeResolution, extraction: extractionWorkload },
 			logging: {
@@ -677,6 +678,7 @@ export function registerPipelineRoutes(app: Hono): void {
 				active: worker?.activeAgentId === agentId,
 				activeAgentId: worker?.activeAgentId ?? null,
 			},
+			scheduler: worker?.scheduler ?? null,
 			state,
 			episodicTokensPending,
 			config: {

--- a/surfaces/cli/src/features/health.test.ts
+++ b/surfaces/cli/src/features/health.test.ts
@@ -22,6 +22,7 @@ afterEach(() => {
 	} else {
 		process.env.OPENCLAW_CONFIG_PATH = originalOpenClawConfig;
 	}
+	process.exitCode = 0;
 });
 
 function depsFor(basePath: string) {
@@ -1022,19 +1023,54 @@ describe("dead-job backlog surfacing (#1048)", () => {
 		}
 	});
 
+	it("doctor reports degraded readiness as non-success and names a queue-caused Dreaming deferral (#1393)", async () => {
+		const root = mkdtempSync(join(tmpdir(), "doctor-readiness-"));
+		try {
+			const workspace = createDoctorWorkspace(root);
+			const jsonOut = await captureDoctorJson(
+				async () => ({
+					...(await deadBacklogDeps(root, false).getDaemonStatus()),
+					health: { score: 0.91, status: "degraded" },
+					queue: {
+						memory: {
+							...queueFixture.memory,
+							pending: 4,
+							dead: 0,
+							oldestAgeSec: 11_698_968,
+							lastError: "Unable to connect to the configured inference endpoint.",
+						},
+						summary: { ...queueFixture.summary, dead: 0, lastError: null },
+					},
+					probe: {
+						status: "degraded" as const,
+						detail: "/health responded; readiness degraded",
+						url: "http://127.0.0.1:3850",
+						listenerPresent: true,
+						processPid: 42,
+						stalePid: null,
+						readinessReasons: ["queue oldest pending job age 11698968s exceeds 300s"],
+					},
+				}),
+				workspace,
+			);
+			expect(jsonOut.ok).toBe(false);
+			expect(jsonOut.status).toBe("degraded");
+			expect(jsonOut.exitCode).toBe(2);
+			expect(jsonOut.findings).toContainEqual(
+				expect.objectContaining({
+					code: "dreaming_deferred_queue_pressure",
+					message: expect.stringContaining("Automatic Dreaming is deferred by queue pressure"),
+				}),
+			);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("doctor stays ok for a running daemon with clean queues", async () => {
 		const root = mkdtempSync(join(tmpdir(), "doctor-clean-"));
 		try {
-			const workspace = join(root, "agents");
-			mkdirSync(workspace, { recursive: true });
-			writeFileSync(join(workspace, "agent.yaml"), "version: 1\n");
-			writeFileSync(join(workspace, "SOUL.md"), "soul\n");
-			writeFileSync(join(workspace, "IDENTITY.md"), "identity\n");
-			writeFileSync(join(workspace, "USER.md"), "user\n");
-			writeFileSync(join(workspace, "MEMORY.md"), "memory\n");
-			writeFileSync(join(workspace, "AGENTS.md"), "# agents\n");
-			mkdirSync(join(workspace, "memory"), { recursive: true });
-			writeFileSync(join(workspace, "memory", "memories.db"), "sqlite");
+			const workspace = createDoctorWorkspace(root);
 			process.env.HOME = root;
 
 			const base = deadBacklogDeps(workspace);
@@ -1046,7 +1082,10 @@ describe("dead-job backlog surfacing (#1048)", () => {
 					summary: { ...queueFixture.summary, dead: 0, lastError: null },
 				},
 			});
-			const jsonOut = await captureDoctorJson(base.getDaemonStatus);
+			const jsonOut = await captureDoctorJson(base.getDaemonStatus, workspace);
+			expect(jsonOut.ok).toBe(true);
+			expect(jsonOut.status).toBe("healthy");
+			expect(jsonOut.exitCode).toBe(0);
 			expect(jsonOut.findings.some((f) => f.code === "dead_jobs_backlog")).toBe(false);
 			expect(jsonOut.findings.some((f) => f.code === "daemon_unhealthy")).toBe(false);
 		} finally {
@@ -1056,9 +1095,29 @@ describe("dead-job backlog surfacing (#1048)", () => {
 	});
 });
 
+function createDoctorWorkspace(root: string): string {
+	const workspace = join(root, "agents");
+	mkdirSync(workspace, { recursive: true });
+	writeFileSync(join(workspace, "agent.yaml"), "version: 1\n");
+	writeFileSync(join(workspace, "SOUL.md"), "soul\n");
+	writeFileSync(join(workspace, "IDENTITY.md"), "identity\n");
+	writeFileSync(join(workspace, "USER.md"), "user\n");
+	writeFileSync(join(workspace, "MEMORY.md"), "memory\n");
+	writeFileSync(join(workspace, "AGENTS.md"), "# agents\n");
+	mkdirSync(join(workspace, "memory"), { recursive: true });
+	writeFileSync(join(workspace, "memory", "memories.db"), "sqlite");
+	return workspace;
+}
+
 async function captureDoctorJson(
 	getDaemonStatus: () => Promise<Record<string, unknown>>,
-): Promise<{ ok: boolean; findings: Array<{ code?: string; level: string; message: string; fix?: string }> }> {
+	agentsDir = "/tmp/agents",
+): Promise<{
+	ok: boolean;
+	status: "healthy" | "degraded" | "unavailable";
+	exitCode: number;
+	findings: Array<{ code?: string; level: string; message: string; fix?: string }>;
+}> {
 	const lines: string[] = [];
 	const oldLog = console.log;
 	console.log = (...args: unknown[]) => {
@@ -1068,7 +1127,7 @@ async function captureDoctorJson(
 		await showDoctor(
 			{ json: true },
 			{
-				agentsDir: "/tmp/agents",
+				agentsDir,
 				defaultPort: 3850,
 				detectExistingSetup: () => ({
 					agentsDir: true,
@@ -1078,7 +1137,7 @@ async function captureDoctorJson(
 				}),
 				extractPathOption: () => null,
 				formatUptime: () => "0s",
-				getDaemonStatus,
+				getDaemonStatus: getDaemonStatus as never,
 				normalizeAgentPath: (pathValue: string) => pathValue,
 				parseIntegerValue: (value: unknown) => (typeof value === "number" ? value : null),
 				signetLogo: () => "signet",
@@ -1089,6 +1148,8 @@ async function captureDoctorJson(
 	}
 	return JSON.parse(lines.join("")) as {
 		ok: boolean;
+		status: "healthy" | "degraded" | "unavailable";
+		exitCode: number;
 		findings: Array<{ code?: string; level: string; message: string; fix?: string }>;
 	};
 }

--- a/surfaces/cli/src/features/health.test.ts
+++ b/surfaces/cli/src/features/health.test.ts
@@ -1041,6 +1041,11 @@ describe("dead-job backlog surfacing (#1048)", () => {
 						},
 						summary: { ...queueFixture.summary, dead: 0, lastError: null },
 					},
+					scheduler: {
+						status: "deferred" as const,
+						reason: "queue_pressure" as const,
+						checkedAt: "2026-08-11T15:00:00Z",
+					},
 					probe: {
 						status: "degraded" as const,
 						detail: "/health responded; readiness degraded",
@@ -1062,6 +1067,49 @@ describe("dead-job backlog surfacing (#1048)", () => {
 					message: expect.stringContaining("Automatic Dreaming is deferred by queue pressure"),
 				}),
 			);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("does not call a queue-caused Dreaming deferral when system pressure won the scheduler decision (#1446)", async () => {
+		const root = mkdtempSync(join(tmpdir(), "doctor-system-pressure-"));
+		try {
+			const workspace = createDoctorWorkspace(root);
+			const jsonOut = await captureDoctorJson(
+				async () => ({
+					...(await deadBacklogDeps(root, false).getDaemonStatus()),
+					health: { score: 0.91, status: "degraded" },
+					queue: {
+						memory: {
+							...queueFixture.memory,
+							pending: 51,
+							dead: 0,
+							oldestAgeSec: 11_698_968,
+							lastError: "Unable to connect to the configured inference endpoint.",
+						},
+						summary: { ...queueFixture.summary, dead: 0, lastError: null },
+					},
+					scheduler: {
+						status: "deferred" as const,
+						reason: "system_pressure" as const,
+						checkedAt: "2026-08-11T15:00:00Z",
+					},
+					probe: {
+						status: "degraded" as const,
+						detail: "/health responded; readiness degraded",
+						url: "http://127.0.0.1:3850",
+						listenerPresent: true,
+						processPid: 42,
+						stalePid: null,
+						readinessReasons: ["queue oldest pending job age 11698968s exceeds 300s"],
+					},
+				}),
+				workspace,
+			);
+			expect(jsonOut.status).toBe("degraded");
+			expect(jsonOut.exitCode).toBe(2);
+			expect(jsonOut.findings.some((finding) => finding.code === "dreaming_deferred_queue_pressure")).toBe(false);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/surfaces/cli/src/features/health.ts
+++ b/surfaces/cli/src/features/health.ts
@@ -81,6 +81,11 @@ interface DaemonStatus {
 			readonly lastError: string | null;
 		} | null;
 	} | null;
+	readonly scheduler?: {
+		readonly status: "idle" | "deferred";
+		readonly reason: "queue_pressure" | "system_pressure" | null;
+		readonly checkedAt: string | null;
+	} | null;
 	readonly probe?: {
 		readonly status: "healthy" | "degraded" | "listener-unhealthy" | "process-unhealthy" | "stale-artifact" | "absent";
 		readonly detail: string;
@@ -656,28 +661,30 @@ function addDaemonProbeFindings(report: StatusReport, findings: DoctorFinding[])
 
 function addReadinessFindings(report: StatusReport, findings: DoctorFinding[]): void {
 	const probe = report.daemon.probe;
-	if (!report.daemon.running || probe?.status !== "degraded") return;
-	const reasons = probe.readinessReasons ?? [];
-	const reasonText = reasons.length > 0 ? reasons.join("; ") : "the readiness probe returned not_ready";
-	findings.push({
-		level: "warn",
-		code: "daemon_readiness_degraded",
-		message: `Daemon readiness is degraded: ${reasonText}.`,
-		fix: "Inspect `signet status` and the failing readiness check before relying on automatic maintenance.",
-	});
+	if (report.daemon.running && probe?.status === "degraded") {
+		const reasons = probe.readinessReasons ?? [];
+		const reasonText = reasons.length > 0 ? reasons.join("; ") : "the readiness probe returned not_ready";
+		findings.push({
+			level: "warn",
+			code: "daemon_readiness_degraded",
+			message: `Daemon readiness is degraded: ${reasonText}.`,
+			fix: "Inspect `signet status` and the failing readiness check before relying on automatic maintenance.",
+		});
+	}
 
-	// This mirrors the worker's actual scheduling gate: `getQueueHealth` is
-	// the only readiness source that makes Dreaming defer a sweep. Do not
-	// infer a Dreaming deferral from migration, database, embedding, or
-	// inference reasons that merely share the readiness envelope.
-	if (!reasons.some((reason) => reason.startsWith("queue "))) return;
+	// Readiness is a composite signal. The scheduler alone knows whether its
+	// latest deferred sweep yielded to queue pressure or higher-priority system
+	// pressure, so never infer its cause from readiness reasons or queue counts.
+	const scheduler = report.daemon.scheduler;
+	if (scheduler?.status !== "deferred" || scheduler.reason !== "queue_pressure") return;
 	const memory = report.daemon.queue?.memory;
-	if (!memory) return;
-	const lastError = memory.lastError ? ` Last error: ${memory.lastError.slice(0, 160)}` : "";
+	const detail = memory
+		? `: memory queue has ${memory.pending} pending job(s), oldest age ${formatAge(memory.oldestAgeSec)}.${memory.lastError ? ` Last error: ${memory.lastError.slice(0, 160)}` : ""}`
+		: ".";
 	findings.push({
 		level: "warn",
 		code: "dreaming_deferred_queue_pressure",
-		message: `Automatic Dreaming is deferred by queue pressure: memory queue has ${memory.pending} pending job(s), oldest age ${formatAge(memory.oldestAgeSec)}.${lastError}`,
+		message: `Automatic Dreaming is deferred by queue pressure${detail}`,
 		fix: "Inspect the queue in `signet status`; repair only identified jobs with `signet repair queue requeue --apply` or retire obsolete jobs with `signet repair queue cancel --apply`.",
 	});
 }

--- a/surfaces/cli/src/features/health.ts
+++ b/surfaces/cli/src/features/health.ts
@@ -142,6 +142,8 @@ interface DoctorFinding {
 	readonly fix?: string;
 }
 
+type DoctorStatus = "healthy" | "degraded" | "unavailable";
+
 const HIGH_PHYSICAL_MEMORY_MIB = 1024;
 
 interface StatusDeps {
@@ -539,10 +541,13 @@ export async function showDoctor(
 	const report = await getStatusReport(basePath, deps);
 	const installations = (deps.detectInstallations ?? detectSignetInstallations)();
 	const findings = getDoctorFindings(report, installations);
-	const ok = findings.every((finding) => finding.level !== "error");
+	const status = getDoctorStatus(report, findings);
+	const ok = status === "healthy";
+	const exitCode = status === "healthy" ? 0 : status === "degraded" ? 2 : 1;
+	process.exitCode = exitCode;
 
 	if (options.json) {
-		console.log(JSON.stringify({ ok, report, installations, findings }, null, 2));
+		console.log(JSON.stringify({ ok, status, exitCode, report, installations, findings }, null, 2));
 		return;
 	}
 
@@ -566,8 +571,10 @@ export async function showDoctor(
 	}
 
 	console.log();
-	if (ok) {
+	if (status === "healthy") {
 		console.log(chalk.yellow("  Signet can run, but there's a bit of duct tape showing."));
+	} else if (status === "degraded") {
+		console.log(chalk.yellow("  The daemon is reachable, but it is not ready for all automatic work."));
 	} else {
 		console.log(chalk.red("  Fix the errors above before trusting the CLI to behave."));
 	}
@@ -645,6 +652,34 @@ function addDaemonProbeFindings(report: StatusReport, findings: DoctorFinding[])
 	}
 
 	addDaemonLifecycleExitFindings(probe, findings);
+}
+
+function addReadinessFindings(report: StatusReport, findings: DoctorFinding[]): void {
+	const probe = report.daemon.probe;
+	if (!report.daemon.running || probe?.status !== "degraded") return;
+	const reasons = probe.readinessReasons ?? [];
+	const reasonText = reasons.length > 0 ? reasons.join("; ") : "the readiness probe returned not_ready";
+	findings.push({
+		level: "warn",
+		code: "daemon_readiness_degraded",
+		message: `Daemon readiness is degraded: ${reasonText}.`,
+		fix: "Inspect `signet status` and the failing readiness check before relying on automatic maintenance.",
+	});
+
+	// This mirrors the worker's actual scheduling gate: `getQueueHealth` is
+	// the only readiness source that makes Dreaming defer a sweep. Do not
+	// infer a Dreaming deferral from migration, database, embedding, or
+	// inference reasons that merely share the readiness envelope.
+	if (!reasons.some((reason) => reason.startsWith("queue "))) return;
+	const memory = report.daemon.queue?.memory;
+	if (!memory) return;
+	const lastError = memory.lastError ? ` Last error: ${memory.lastError.slice(0, 160)}` : "";
+	findings.push({
+		level: "warn",
+		code: "dreaming_deferred_queue_pressure",
+		message: `Automatic Dreaming is deferred by queue pressure: memory queue has ${memory.pending} pending job(s), oldest age ${formatAge(memory.oldestAgeSec)}.${lastError}`,
+		fix: "Inspect the queue in `signet status`; repair only identified jobs with `signet repair queue requeue --apply` or retire obsolete jobs with `signet repair queue cancel --apply`.",
+	});
 }
 
 /**
@@ -827,6 +862,23 @@ function addQueueBacklogFindings(report: StatusReport, findings: DoctorFinding[]
 	}
 }
 
+function getDoctorStatus(report: StatusReport, findings: readonly DoctorFinding[]): DoctorStatus {
+	const hasAgentYaml = report.files.find((file) => file.name === "agent.yaml")?.exists ?? false;
+	const daemon = report.daemon;
+	const probe = daemon.probe;
+	const requiredDaemonUnavailable =
+		!daemon.running ||
+		probe === undefined ||
+		probe.status === "listener-unhealthy" ||
+		probe.status === "process-unhealthy" ||
+		probe.status === "stale-artifact" ||
+		probe.status === "absent";
+	const configurationInvalid = !report.installed || !report.validIdentity || !hasAgentYaml || !report.db.exists;
+	if (requiredDaemonUnavailable || configurationInvalid) return "unavailable";
+	if (probe.status === "degraded" || findings.some((finding) => finding.level === "error")) return "degraded";
+	return "healthy";
+}
+
 function getDoctorFindings(report: StatusReport, installations: SignetInstallationReport): DoctorFinding[] {
 	const findings: DoctorFinding[] = [];
 	addConcurrentInstallationFindings(installations, findings);
@@ -898,6 +950,7 @@ function getDoctorFindings(report: StatusReport, installations: SignetInstallati
 	addOpenClawRuntimeFindings(report, findings);
 	addOpenClawHeartbeatFindings(report, findings);
 	addPhysicalMemoryFinding(report, findings);
+	addReadinessFindings(report, findings);
 	addQueueBacklogFindings(report, findings);
 
 	if (report.openclawWorkspaceUnprotected) {

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -497,7 +497,9 @@ describe("getDaemonStatus", () => {
 							blockedReason: null,
 						},
 					},
-					pipeline: {},
+					pipeline: {
+						dreaming: { status: "deferred", reason: "system_pressure", checkedAt: "2026-08-11T15:00:00.000Z" },
+					},
 				});
 			}
 			return new Response("not found", { status: 404 });
@@ -508,6 +510,11 @@ describe("getDaemonStatus", () => {
 		// The mock has no /health/ready route (older daemon): readiness is unknown, not a regression.
 		expect(status.probe.status).toBe("healthy");
 		expect(status.probe.readinessReasons).toBeUndefined();
+		expect(status.scheduler).toEqual({
+			status: "deferred",
+			reason: "system_pressure",
+			checkedAt: "2026-08-11T15:00:00.000Z",
+		});
 		expect(status.extraction).toEqual({
 			configured: "claude-code",
 			resolved: "claude-code",

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -124,8 +124,16 @@ interface DaemonInstance {
 		readonly memory: QueueCountsFromStatus | null;
 		readonly summary: QueueCountsFromStatus | null;
 	} | null;
+	/** Latest periodic Dreaming scheduler decision reported by `/api/status`. */
+	readonly scheduler: DreamingSchedulerStatusFromStatus | null;
 	readonly probe: DaemonHealthProbe;
 	readonly openclaw: DaemonOpenClawHealthSummary | null;
+}
+
+interface DreamingSchedulerStatusFromStatus {
+	readonly status: "idle" | "deferred";
+	readonly reason: "queue_pressure" | "system_pressure" | null;
+	readonly checkedAt: string | null;
 }
 
 interface QueueCountsFromStatus {
@@ -461,6 +469,8 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 					const pipelineRaw = data.pipeline;
 					const queueRaw =
 						typeof pipelineRaw === "object" && pipelineRaw !== null ? Reflect.get(pipelineRaw, "queue") : undefined;
+					const dreamingRaw =
+						typeof pipelineRaw === "object" && pipelineRaw !== null ? Reflect.get(pipelineRaw, "dreaming") : undefined;
 					const health =
 						typeof healthRaw === "object" && healthRaw !== null
 							? {
@@ -481,6 +491,7 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 									summary: normalizeQueueCountsFromStatus(Reflect.get(queueRaw, "summary")),
 								}
 							: null;
+					const scheduler = normalizeDreamingSchedulerFromStatus(dreamingRaw);
 					return {
 						baseUrl,
 						pid: data.pid ?? null,
@@ -531,6 +542,7 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 							: null,
 						health,
 						queue,
+						scheduler,
 						probe: reachableDaemonProbe(baseUrl, data.pid ?? null, readiness),
 						openclaw: summarizeOpenClawHealth(openclawReport),
 					};
@@ -552,6 +564,7 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 				transcripts: null,
 				health: null,
 				queue: null,
+				scheduler: null,
 				probe: reachableDaemonProbe(
 					baseUrl,
 					null,
@@ -599,6 +612,20 @@ function normalizeQueueCountsFromStatus(value: unknown): QueueCountsFromStatus |
 		oldestAgeSec: toNumber("oldestAgeSec"),
 		oldestDeadAgeSec: toNumber("oldestDeadAgeSec"),
 		lastError: typeof lastErrorRaw === "string" && lastErrorRaw.trim().length > 0 ? lastErrorRaw : null,
+	};
+}
+
+function normalizeDreamingSchedulerFromStatus(value: unknown): DreamingSchedulerStatusFromStatus | null {
+	if (typeof value !== "object" || value === null) return null;
+	const record = value as Record<string, unknown>;
+	const status = record.status;
+	if (status !== "idle" && status !== "deferred") return null;
+	const reason = record.reason;
+	const checkedAt = record.checkedAt;
+	return {
+		status,
+		reason: reason === "queue_pressure" || reason === "system_pressure" ? reason : null,
+		checkedAt: typeof checkedAt === "string" && checkedAt.trim().length > 0 ? checkedAt : null,
 	};
 }
 
@@ -725,6 +752,7 @@ export async function getDaemonStatus(): Promise<{
 	transcripts: DaemonInstance["transcripts"];
 	health: DaemonInstance["health"];
 	queue: DaemonInstance["queue"];
+	scheduler: DaemonInstance["scheduler"];
 	probe: DaemonHealthProbe;
 	openclaw: DaemonOpenClawHealthSummary | null;
 }> {
@@ -745,6 +773,7 @@ export async function getDaemonStatus(): Promise<{
 			transcripts: preferred.transcripts,
 			health: preferred.health,
 			queue: preferred.queue,
+			scheduler: preferred.scheduler,
 			probe: {
 				...preferred.probe,
 				processPid: preferred.probe.processPid ?? fallbackPid,
@@ -767,6 +796,7 @@ export async function getDaemonStatus(): Promise<{
 		transcripts: null,
 		health: null,
 		queue: null,
+		scheduler: null,
 		probe,
 		openclaw: null,
 	};

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -511,6 +511,11 @@ export interface DreamQuality {
 
 export interface DreamStatus {
 	worker: { running: boolean; active: boolean; activeAgentId: string | null };
+	scheduler: {
+		status: "idle" | "deferred";
+		reason: "queue_pressure" | "system_pressure" | null;
+		checkedAt: string | null;
+	} | null;
 	state: {
 		consecutiveFailures: number;
 		lastFailureAt: string | null;

--- a/surfaces/dashboard/src/lib/demo.ts
+++ b/surfaces/dashboard/src/lib/demo.ts
@@ -481,6 +481,7 @@ const demoSecrets: { secrets: string[]; provider: string } = {
 
 const demoDreamStatus: DreamStatus = {
 	worker: { running: false, active: false, activeAgentId: null },
+	scheduler: null,
 	state: {
 		consecutiveFailures: 0,
 		lastFailureAt: null,

--- a/surfaces/dashboard/src/views/dreaming.test.tsx
+++ b/surfaces/dashboard/src/views/dreaming.test.tsx
@@ -7,6 +7,7 @@ import { DreamsView } from "./dreaming";
 
 const DREAM_STATUS = {
 	worker: { running: true, active: false, activeAgentId: null },
+	scheduler: { status: "deferred", reason: "queue_pressure", checkedAt: "2026-08-10T14:14:11.000Z" },
 	state: {
 		consecutiveFailures: 0,
 		lastFailureAt: null,
@@ -92,6 +93,7 @@ describe("dreaming summary layout", () => {
 		expect(summary).not.toBeNull();
 		expect(summary?.className).toContain("min-h-0");
 		expect(summary?.className).toContain("overflow-y-auto");
+		expect(container.textContent).toContain("automatic Dreaming deferred: queue pressure");
 
 		await act(async () => {
 			root.unmount();

--- a/surfaces/dashboard/src/views/dreaming.tsx
+++ b/surfaces/dashboard/src/views/dreaming.tsx
@@ -217,6 +217,8 @@ export function DreamsView() {
 	const pendingAttention = status.data?.attention ?? [];
 	const failures = status.data?.state.consecutiveFailures ?? 0;
 	const running = Boolean(activePass);
+	const scheduler = status.data?.scheduler ?? null;
+	const queueDeferred = scheduler?.status === "deferred" && scheduler.reason === "queue_pressure";
 	const elapsedMs = activePass ? Math.max(0, now - (parseDate(activePass.startedAt ?? "")?.getTime() ?? now)) : 0;
 	const passDurationMs = lastPass
 		? Math.max(
@@ -246,9 +248,19 @@ export function DreamsView() {
 				<Stat label="backlog" value={fmtTokens(status.data?.episodicTokensPending ?? null)} />
 				<Stat label="failures" value={failures > 0 ? String(failures) : "0"} tone={failures > 0 ? "warn" : "ok"} />
 				<span className="ml-auto flex shrink-0 items-center gap-3">
-					<span className="flex items-center gap-1.5 font-mono text-[10px] text-slate-500 dark:text-slate-400">
-						<span className="size-1.5 rounded-full bg-success shadow-[0_0_6px_color-mix(in_oklch,var(--success)_70%,transparent)]" />
-						daemon healthy
+					<span
+						className={cn(
+							"flex items-center gap-1.5 font-mono text-[10px] text-slate-500 dark:text-slate-400",
+							queueDeferred && "text-[oklch(0.8_0.14_80)]",
+						)}
+					>
+						<span
+							className={cn(
+								"size-1.5 rounded-full bg-success shadow-[0_0_6px_color-mix(in_oklch,var(--success)_70%,transparent)]",
+								queueDeferred && "bg-[oklch(0.8_0.14_80)] shadow-none",
+							)}
+						/>
+						{queueDeferred ? "automatic Dreaming deferred: queue pressure" : "daemon reachable"}
 					</span>
 					<TriggerControl running={running} refresh={status.refresh} />
 				</span>

--- a/web/docs/src/content/docs/api/health-status.md
+++ b/web/docs/src/content/docs/api/health-status.md
@@ -164,6 +164,15 @@ and one entry per failing gate in `reasons`:
 }
 ```
 
+`signet doctor` consumes this probe as its runtime contract: `healthy` means
+`/health/ready` returned `ready` and local installation checks passed (`ok: true`,
+exit 0); `degraded` means the daemon is reachable but returned `not_ready`
+(`ok: false`, exit 2); `unavailable` means the required daemon or local
+installation is unavailable or invalid (`ok: false`, exit 1). A queue-caused
+readiness failure includes an explicit Automatic Dreaming deferral finding with
+the queue age and last error. Other readiness failures do not claim that
+Dreaming was deferred by the queue.
+
 ### GET /api/status
 
 Full daemon status including pipeline config, embedding provider, and a
@@ -305,8 +314,12 @@ extraction provider is unavailable or routed to a fallback target.
 When extraction is blocked, `providerResolution.extraction.blockedBy` contains
 the first routing candidate's policy and runtime gate reasons in evaluation
 order. The array is empty for non-blocked states.
-`pipeline.queue` exposes per-queue counts (memory / summary);
-the retired worker's load/overload telemetry is no longer reported.
+`pipeline.queue` exposes per-queue counts (memory / summary).
+`pipeline.dreaming` records the latest periodic Dreaming scheduler decision.
+It is `null` before the worker starts. A `deferred` result with
+`reason: "queue_pressure"` means the scheduler itself yielded that sweep to
+queue health. It does not infer a queue deferral from another readiness gate.
+The retired worker's load/overload telemetry is no longer reported.
 `transcripts.capture` exposes compact durable transcript-capture queue counts;
 use `GET /api/diagnostics/transcripts` for detailed artifact/audit diagnostics.
 Use `GET /api/inference/status` for the shared inference control plane status.

--- a/web/docs/src/content/docs/api/health-status.md
+++ b/web/docs/src/content/docs/api/health-status.md
@@ -169,9 +169,10 @@ and one entry per failing gate in `reasons`:
 exit 0); `degraded` means the daemon is reachable but returned `not_ready`
 (`ok: false`, exit 2); `unavailable` means the required daemon or local
 installation is unavailable or invalid (`ok: false`, exit 1). A queue-caused
-readiness failure includes an explicit Automatic Dreaming deferral finding with
-the queue age and last error. Other readiness failures do not claim that
-Dreaming was deferred by the queue.
+periodic scheduler decision deferred for queue pressure includes an explicit
+Automatic Dreaming deferral finding with the queue age and last error. A queue
+readiness failure alone does not claim that Dreaming was deferred by the queue:
+the scheduler can instead defer for higher-priority system pressure.
 
 ### GET /api/status
 


### PR DESCRIPTION
## Summary

Make `signet doctor --json` report daemon readiness truthfully. A reachable but not-ready daemon now returns `ok: false`, `status: "degraded"`, and exit code 2 instead of a false success.

## Changes

- Add explicit periodic Dreaming scheduler status and expose it in daemon status and Dreaming status responses.
- Report Automatic Dreaming queue deferral only when the scheduler actually deferred a sweep for queue pressure.
- Add healthy, degraded, and unavailable doctor statuses with documented exit codes.
- Replace the dashboard's unconditional "daemon healthy" label with causal queue-deferral visibility.
- Add regression coverage and update health-status documentation.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [x] `@signet/web`
- [ ] `predictor`
- [ ] Other

## Screenshots

No screenshot included. The dashboard change is a status-label correction covered by `dreaming.test.tsx`; a production dashboard build passes. A screenshot against a synthetic daemon state was not fabricated.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations are changed.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused proof on rebased head:

- `platform/daemon`: `bun test src/pipeline/dreaming-worker.test.ts src/routes/health.test.ts` (22 pass), `bun run typecheck`, and `bun run build`.
- `surfaces/cli`: `bun test src/features/health.test.ts` (31 pass), plus a direct production bundle with `bun build ./src/cli.ts --outdir /tmp/signet-cli-1393-build --target node --external better-sqlite3`.
- `surfaces/dashboard`: `bun test src/views/dreaming.test.tsx` (1 pass) and `bun run build`.
- `web/docs`: `bun run build`.
- Touched-file `bunx biome check` and `git diff --check origin/main...HEAD` pass.

The package script `bun run --filter '@signet/cli' build` still fails before this change's code can run because its current build invocation uses `--outfile` while bundling emits multiple assets. The direct output-directory production bundle above passes.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

`/health` and `/health/live` are unchanged. The UI intentionally avoids treating other readiness reasons, such as database, migrations, embeddings, or inference, as queue-caused Dreaming deferrals.
