### PR TITLE
fix(daemon): persist embedding repair budget

### DIFF
--- a/platform/core/src/migrations/130-embedding-repair-state.ts
+++ b/platform/core/src/migrations/130-embedding-repair-state.ts
@@ -30,5 +30,18 @@ export function up(db: MigrationDb): void {
 		);
 		CREATE INDEX IF NOT EXISTS idx_embedding_repair_backoff_retry
 			ON embedding_repair_backoff(model, retry_at);
+
+		-- Backoff is derived state. Retire it when the source memory disappears
+		-- or moves to a new hash so stale retry keys cannot accumulate forever.
+		CREATE TRIGGER IF NOT EXISTS embedding_repair_backoff_memory_deleted
+		AFTER DELETE ON memories BEGIN
+			DELETE FROM embedding_repair_backoff WHERE memory_id = OLD.id;
+		END;
+		CREATE TRIGGER IF NOT EXISTS embedding_repair_backoff_content_hash_changed
+		AFTER UPDATE OF content_hash ON memories
+		WHEN OLD.content_hash IS NOT NEW.content_hash BEGIN
+			DELETE FROM embedding_repair_backoff
+			 WHERE memory_id = OLD.id AND content_hash IS NOT NEW.content_hash;
+		END;
 	`);
 }

--- a/platform/core/src/migrations/130-embedding-repair-state.ts
+++ b/platform/core/src/migrations/130-embedding-repair-state.ts
@@ -1,0 +1,34 @@
+import type { MigrationDb } from "./index";
+
+/**
+ * Migration 129: durable admission and retry state for incremental embedding
+ * repair. The tracker is intentionally a singleton budget plus per-memory
+ * backoff rows, not a second queue or owner for embedding writes.
+ */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS embedding_repair_budget (
+			id INTEGER PRIMARY KEY CHECK (id = 1),
+			window_started_at TEXT NOT NULL,
+			batches_started INTEGER NOT NULL DEFAULT 0 CHECK (batches_started >= 0),
+			last_completed_at TEXT,
+			last_affected INTEGER NOT NULL DEFAULT 0 CHECK (last_affected >= 0),
+			lease_id TEXT,
+			lease_expires_at TEXT,
+			last_error TEXT,
+			updated_at TEXT NOT NULL
+		);
+
+		CREATE TABLE IF NOT EXISTS embedding_repair_backoff (
+			memory_id TEXT NOT NULL,
+			content_hash TEXT NOT NULL,
+			model TEXT NOT NULL,
+			attempts INTEGER NOT NULL DEFAULT 1 CHECK (attempts > 0),
+			retry_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			PRIMARY KEY (memory_id, content_hash, model)
+		);
+		CREATE INDEX IF NOT EXISTS idx_embedding_repair_backoff_retry
+			ON embedding_repair_backoff(model, retry_at);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -135,6 +135,7 @@ import { up as dreamingSurprisalAttention } from "./126-dreaming-surprisal-atten
 import { up as ontologyContradictions } from "./127-ontology-contradictions";
 import { up as boundedQueueDiagnostics } from "./128-bounded-queue-diagnostics";
 import { up as retireStructuralJobs } from "./129-retire-structural-jobs";
+import { up as embeddingRepairState } from "./130-embedding-repair-state";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1204,6 +1205,12 @@ export const MIGRATIONS: readonly Migration[] = [
 		version: 129,
 		name: "retire-structural-jobs",
 		up: retireStructuralJobs,
+	},
+	{
+		version: 130,
+		name: "embedding-repair-state",
+		up: embeddingRepairState,
+		artifacts: { tables: ["embedding_repair_budget", "embedding_repair_backoff"] },
 	},
 ];
 

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1605,6 +1605,7 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 			getDbAccessor(),
 			activeEmbeddingCfg,
 			memoryCfg.pipelineV2.embeddingTracker,
+			memoryCfg.pipelineV2.repair,
 			fetchEmbedding,
 			checkEmbeddingProvider,
 		);

--- a/platform/daemon/src/embedding-coverage.ts
+++ b/platform/daemon/src/embedding-coverage.ts
@@ -127,15 +127,23 @@ export function listUnembeddedMemories(db: ReadDb, limit: number): ReadonlyArray
 		.all(limit) as UnembeddedRow[];
 }
 
-export function listStaleEmbeddingRows(db: ReadDb, model: string, limit: number): ReadonlyArray<StaleEmbeddingRow> {
+export function listStaleEmbeddingRows(
+	db: ReadDb,
+	model: string,
+	limit: number,
+	now = new Date().toISOString(),
+): ReadonlyArray<StaleEmbeddingRow> {
 	return db
 		.prepare(
 			`SELECT m.id, m.content, m.content_hash AS contentHash,
 			        m.embedding_model AS currentModel
 			 FROM memories m
+			 LEFT JOIN embedding_repair_backoff b
+			   ON b.memory_id = m.id AND b.content_hash = m.content_hash AND b.model = ?
 			 WHERE m.is_deleted = 0
 			   AND m.content_hash IS NOT NULL
 			   AND trim(m.content_hash) <> ''
+			   AND (b.retry_at IS NULL OR b.retry_at <= ?)
 			   AND (
 			     (
 			       NOT EXISTS (
@@ -158,5 +166,5 @@ export function listStaleEmbeddingRows(db: ReadDb, model: string, limit: number)
 			 ORDER BY m.updated_at DESC
 			 LIMIT ?`,
 		)
-		.all(model, limit) as StaleEmbeddingRow[];
+		.all(model, now, model, limit) as StaleEmbeddingRow[];
 }

--- a/platform/daemon/src/embedding-repair-state.test.ts
+++ b/platform/daemon/src/embedding-repair-state.test.ts
@@ -1,0 +1,161 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it } from "bun:test";
+import { runMigrations } from "../../core/src/migrations";
+import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
+import { listStaleEmbeddingRows } from "./embedding-coverage";
+import {
+	acquireEmbeddingRepairLease,
+	finishEmbeddingRepairLease,
+	loadEmbeddingRepairFailures,
+	readEmbeddingRepairState,
+} from "./embedding-repair-state";
+
+function asAccessor(db: Database): DbAccessor {
+	return {
+		withWriteTx<T>(fn: (wdb: WriteDb) => T): T {
+			db.exec("BEGIN IMMEDIATE");
+			try {
+				const result = fn(db as unknown as WriteDb);
+				db.exec("COMMIT");
+				return result;
+			} catch (error) {
+				db.exec("ROLLBACK");
+				throw error;
+			}
+		},
+		withReadDb<T>(fn: (rdb: ReadDb) => T): T {
+			return fn(db as unknown as ReadDb);
+		},
+		close(): void {
+			db.close();
+		},
+	};
+}
+
+describe("embedding repair state", () => {
+	it("consumes a durable budget slot before work so restart recovery cannot replay unlimited batches", () => {
+		const db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		const accessor = asAccessor(db);
+		const now = Date.parse("2026-08-11T12:00:00.000Z");
+
+		const first = acquireEmbeddingRepairLease(accessor, 60_000, 2, now);
+		expect(first.allowed).toBe(true);
+		// A second worker cannot claim the active batch.
+		expect(acquireEmbeddingRepairLease(accessor, 60_000, 2, now + 1_000)).toMatchObject({
+			allowed: false,
+			reason: "embedding repair already in progress",
+		});
+
+		// A restart remains blocked for the full hourly accounting window. Once
+		// it expires, a fresh process can begin the next hourly window.
+		expect(acquireEmbeddingRepairLease(accessor, 60_000, 2, now + 30 * 60_000)).toMatchObject({
+			allowed: false,
+			reason: "embedding repair already in progress",
+		});
+		const resumed = acquireEmbeddingRepairLease(accessor, 60_000, 2, now + 60 * 60_000 + 1);
+		expect(resumed.allowed).toBe(true);
+		expect(acquireEmbeddingRepairLease(accessor, 60_000, 2, now + 60 * 60_000 + 2)).toMatchObject({
+			allowed: false,
+			reason: "embedding repair already in progress",
+		});
+		expect(readEmbeddingRepairState(accessor)).toMatchObject({ batchesStarted: 1 });
+		db.close();
+	});
+
+	it("resets a corrupted future budget window instead of extending its quota", () => {
+		const db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		const accessor = asAccessor(db);
+		const now = Date.parse("2026-08-11T12:00:00.000Z");
+		const initialLease = acquireEmbeddingRepairLease(accessor, 0, 5, now).lease;
+		if (initialLease === undefined) throw new Error("expected initial lease");
+		finishEmbeddingRepairLease(
+			accessor,
+			initialLease,
+			{ successful: [], failed: [], model: "test-model", pollMs: 1_000 },
+			now,
+		);
+		db.prepare("UPDATE embedding_repair_budget SET window_started_at = ?, batches_started = 5 WHERE id = 1").run(
+			new Date(now + 30 * 60_000).toISOString(),
+		);
+
+		const admission = acquireEmbeddingRepairLease(accessor, 0, 5, now + 1);
+		expect(admission.allowed).toBe(true);
+		expect(readEmbeddingRepairState(accessor)).toMatchObject({
+			windowStartedAt: new Date(now + 1).toISOString(),
+			batchesStarted: 1,
+		});
+		db.close();
+	});
+
+	it("persists provider failure backoff across a restart and clears it only after a committed success", async () => {
+		const db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		const accessor = asAccessor(db);
+		const now = Date.parse("2026-08-11T12:00:00.000Z");
+		const key = { id: "memory-1", contentHash: "hash-1" };
+		const lease = acquireEmbeddingRepairLease(accessor, 60_000, 5, now).lease;
+		expect(lease).toBeDefined();
+		if (lease === undefined) throw new Error("expected repair lease");
+
+		finishEmbeddingRepairLease(
+			accessor,
+			lease,
+			{ successful: [], failed: [key], model: "test-model", pollMs: 1_000 },
+			now + 1,
+		);
+		const persisted = loadEmbeddingRepairFailures(accessor, [key], "test-model");
+		expect(persisted.get("memory-1:hash-1:test-model")).toMatchObject({ attempts: 1, retryAt: now + 60_001 });
+
+		const resumedLease = acquireEmbeddingRepairLease(accessor, 60_000, 5, now + 60_001).lease;
+		expect(resumedLease).toBeDefined();
+		if (resumedLease === undefined) throw new Error("expected resumed lease");
+		finishEmbeddingRepairLease(
+			accessor,
+			resumedLease,
+			{ successful: [key], failed: [], model: "test-model", pollMs: 1_000 },
+			now + 60_002,
+		);
+		const remaining = loadEmbeddingRepairFailures(accessor, [key], "test-model");
+		expect(remaining).toEqual(new Map());
+		db.close();
+	});
+
+	it("skips a persisted-backoff row so it cannot starve newer eligible repair work", () => {
+		const db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		const accessor = asAccessor(db);
+		const now = Date.parse("2026-08-11T12:00:00.000Z");
+		const older = new Date(now - 1_000).toISOString();
+		const newer = new Date(now).toISOString();
+		db.prepare(
+			`INSERT INTO memories (id, content, content_hash, type, created_at, updated_at, updated_by)
+			 VALUES (?, ?, ?, 'fact', ?, ?, 'test')`,
+		).run("eligible", "eligible", "hash-eligible", older, older);
+		db.prepare(
+			`INSERT INTO memories (id, content, content_hash, type, created_at, updated_at, updated_by)
+			 VALUES (?, ?, ?, 'fact', ?, ?, 'test')`,
+		).run("deferred", "deferred", "hash-deferred", newer, newer);
+
+		const lease = acquireEmbeddingRepairLease(accessor, 60_000, 5, now).lease;
+		if (lease === undefined) throw new Error("expected repair lease");
+		finishEmbeddingRepairLease(
+			accessor,
+			lease,
+			{
+				successful: [],
+				failed: [{ id: "deferred", contentHash: "hash-deferred" }],
+				model: "test-model",
+				pollMs: 1_000,
+			},
+			now + 1,
+		);
+
+		const selected = accessor.withReadDb((db) =>
+			listStaleEmbeddingRows(db, "test-model", 1, new Date(now + 2).toISOString()),
+		);
+		expect(selected.map((row) => row.id)).toEqual(["eligible"]);
+		db.close();
+	});
+});

--- a/platform/daemon/src/embedding-repair-state.test.ts
+++ b/platform/daemon/src/embedding-repair-state.test.ts
@@ -73,11 +73,87 @@ describe("embedding repair state", () => {
 			finishEmbeddingRepairLease(
 				accessor,
 				resumed.lease,
-				{ successful: [], failed: [], model: "test-model", pollMs: 1_000, eligibility: true },
+				{
+					successful: [{ id: "memory-1", contentHash: "hash-1" }],
+					failed: [],
+					model: "test-model",
+					pollMs: 1_000,
+					eligibility: true,
+				},
 				now + 60 * 60_000 + 2,
 			),
 		).toBe(true);
-		expect(readEmbeddingRepairState(accessor)).toMatchObject({ batchesStarted: 1 });
+		expect(readEmbeddingRepairState(accessor)).toMatchObject({ batchesStarted: 1, lastAffected: 1 });
+		db.close();
+	});
+
+	it("does not charge durable budget when pressure aborts a batch before any embedding persists", () => {
+		const db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		const accessor = asAccessor(db);
+		const now = Date.parse("2026-08-11T12:00:00.000Z");
+		const failedKey = { id: "memory-1", contentHash: "hash-1" };
+		const lease = acquireEmbeddingRepairLease(accessor, 0, 1, now).lease;
+		if (lease === undefined) throw new Error("expected repair lease");
+
+		expect(
+			finishEmbeddingRepairLease(
+				accessor,
+				lease,
+				{
+					successful: [],
+					failed: [failedKey],
+					model: "test-model",
+					pollMs: 1_000,
+					eligibility: true,
+					error: "system pressure became high before embedding persistence",
+				},
+				now + 1,
+			),
+		).toBe(true);
+		expect(readEmbeddingRepairState(accessor)).toMatchObject({ batchesStarted: 0, lastAffected: 0 });
+		expect(loadEmbeddingRepairFailures(accessor, [failedKey], "test-model")).toHaveLength(1);
+		expect(acquireEmbeddingRepairLease(accessor, 0, 1, now + 2).allowed).toBe(true);
+		db.close();
+	});
+
+	it("removes backoff rows after a memory is deleted or receives a new content hash", () => {
+		const db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		const accessor = asAccessor(db);
+		const now = Date.parse("2026-08-11T12:00:00.000Z");
+		const original = { id: "memory-1", contentHash: "hash-1" };
+		const replacement = { id: "memory-1", contentHash: "hash-2" };
+		db.prepare(
+			`INSERT INTO memories (id, content, content_hash, type, created_at, updated_at, updated_by)
+			 VALUES (?, ?, ?, 'fact', ?, ?, 'test')`,
+		).run(original.id, "original", original.contentHash, new Date(now).toISOString(), new Date(now).toISOString());
+
+		const firstLease = acquireEmbeddingRepairLease(accessor, 0, 5, now).lease;
+		if (firstLease === undefined) throw new Error("expected first repair lease");
+		finishEmbeddingRepairLease(
+			accessor,
+			firstLease,
+			{ successful: [], failed: [original], model: "test-model", pollMs: 1_000, eligibility: true },
+			now + 1,
+		);
+		expect(loadEmbeddingRepairFailures(accessor, [original], "test-model")).toHaveLength(1);
+
+		db.prepare("UPDATE memories SET content_hash = ? WHERE id = ?").run(replacement.contentHash, replacement.id);
+		expect(loadEmbeddingRepairFailures(accessor, [original], "test-model")).toHaveLength(0);
+
+		const secondLease = acquireEmbeddingRepairLease(accessor, 0, 5, now + 2).lease;
+		if (secondLease === undefined) throw new Error("expected second repair lease");
+		finishEmbeddingRepairLease(
+			accessor,
+			secondLease,
+			{ successful: [], failed: [replacement], model: "test-model", pollMs: 1_000, eligibility: true },
+			now + 3,
+		);
+		expect(loadEmbeddingRepairFailures(accessor, [replacement], "test-model")).toHaveLength(1);
+
+		db.prepare("DELETE FROM memories WHERE id = ?").run(replacement.id);
+		expect(loadEmbeddingRepairFailures(accessor, [replacement], "test-model")).toHaveLength(0);
 		db.close();
 	});
 
@@ -91,7 +167,13 @@ describe("embedding repair state", () => {
 		finishEmbeddingRepairLease(
 			accessor,
 			initialLease,
-			{ successful: [], failed: [], model: "test-model", pollMs: 1_000, eligibility: true },
+			{
+				successful: [{ id: "memory-1", contentHash: "hash-1" }],
+				failed: [],
+				model: "test-model",
+				pollMs: 1_000,
+				eligibility: true,
+			},
 			now,
 		);
 		db.prepare("UPDATE embedding_repair_budget SET window_started_at = ?, batches_started = 5 WHERE id = 1").run(
@@ -104,7 +186,13 @@ describe("embedding repair state", () => {
 		finishEmbeddingRepairLease(
 			accessor,
 			admission.lease,
-			{ successful: [], failed: [], model: "test-model", pollMs: 1_000, eligibility: true },
+			{
+				successful: [{ id: "memory-1", contentHash: "hash-1" }],
+				failed: [],
+				model: "test-model",
+				pollMs: 1_000,
+				eligibility: true,
+			},
 			now + 1,
 		);
 		expect(readEmbeddingRepairState(accessor)).toMatchObject({
@@ -200,7 +288,7 @@ describe("embedding repair state", () => {
 					accessor,
 					lease,
 					{
-						successful: [],
+						successful: [key],
 						failed: [],
 						model: activeConfig.model,
 						pollMs: 1_000,

--- a/platform/daemon/src/embedding-repair-state.test.ts
+++ b/platform/daemon/src/embedding-repair-state.test.ts
@@ -4,11 +4,18 @@ import { runMigrations } from "../../core/src/migrations";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import { listStaleEmbeddingRows } from "./embedding-coverage";
 import {
+	beginEmbeddingIndexBuild,
+	ensureEmbeddingIndexState,
+	isActiveEmbeddingConfig,
+	resolveActiveEmbeddingConfig,
+} from "./embedding-index-state";
+import {
 	acquireEmbeddingRepairLease,
 	finishEmbeddingRepairLease,
 	loadEmbeddingRepairFailures,
 	readEmbeddingRepairState,
 } from "./embedding-repair-state";
+import type { EmbeddingConfig } from "./memory-config";
 
 function asAccessor(db: Database): DbAccessor {
 	return {
@@ -33,7 +40,7 @@ function asAccessor(db: Database): DbAccessor {
 }
 
 describe("embedding repair state", () => {
-	it("consumes a durable budget slot before work so restart recovery cannot replay unlimited batches", () => {
+	it("holds a durable lease before work and charges its slot only after an eligible completion", () => {
 		const db = new Database(":memory:");
 		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
 		const accessor = asAccessor(db);
@@ -48,7 +55,8 @@ describe("embedding repair state", () => {
 		});
 
 		// A restart remains blocked for the full hourly accounting window. Once
-		// it expires, a fresh process can begin the next hourly window.
+		// it expires, a fresh process can begin the next hourly window without
+		// charging the crashed work as a completed repair.
 		expect(acquireEmbeddingRepairLease(accessor, 60_000, 2, now + 30 * 60_000)).toMatchObject({
 			allowed: false,
 			reason: "embedding repair already in progress",
@@ -59,6 +67,16 @@ describe("embedding repair state", () => {
 			allowed: false,
 			reason: "embedding repair already in progress",
 		});
+		expect(readEmbeddingRepairState(accessor)).toMatchObject({ batchesStarted: 0 });
+		if (resumed.lease === undefined) throw new Error("expected resumed lease");
+		expect(
+			finishEmbeddingRepairLease(
+				accessor,
+				resumed.lease,
+				{ successful: [], failed: [], model: "test-model", pollMs: 1_000, eligibility: true },
+				now + 60 * 60_000 + 2,
+			),
+		).toBe(true);
 		expect(readEmbeddingRepairState(accessor)).toMatchObject({ batchesStarted: 1 });
 		db.close();
 	});
@@ -73,7 +91,7 @@ describe("embedding repair state", () => {
 		finishEmbeddingRepairLease(
 			accessor,
 			initialLease,
-			{ successful: [], failed: [], model: "test-model", pollMs: 1_000 },
+			{ successful: [], failed: [], model: "test-model", pollMs: 1_000, eligibility: true },
 			now,
 		);
 		db.prepare("UPDATE embedding_repair_budget SET window_started_at = ?, batches_started = 5 WHERE id = 1").run(
@@ -82,6 +100,13 @@ describe("embedding repair state", () => {
 
 		const admission = acquireEmbeddingRepairLease(accessor, 0, 5, now + 1);
 		expect(admission.allowed).toBe(true);
+		if (admission.lease === undefined) throw new Error("expected repaired-window lease");
+		finishEmbeddingRepairLease(
+			accessor,
+			admission.lease,
+			{ successful: [], failed: [], model: "test-model", pollMs: 1_000, eligibility: true },
+			now + 1,
+		);
 		expect(readEmbeddingRepairState(accessor)).toMatchObject({
 			windowStartedAt: new Date(now + 1).toISOString(),
 			batchesStarted: 1,
@@ -102,7 +127,7 @@ describe("embedding repair state", () => {
 		finishEmbeddingRepairLease(
 			accessor,
 			lease,
-			{ successful: [], failed: [key], model: "test-model", pollMs: 1_000 },
+			{ successful: [], failed: [key], model: "test-model", pollMs: 1_000, eligibility: true },
 			now + 1,
 		);
 		const persisted = loadEmbeddingRepairFailures(accessor, [key], "test-model");
@@ -114,11 +139,82 @@ describe("embedding repair state", () => {
 		finishEmbeddingRepairLease(
 			accessor,
 			resumedLease,
-			{ successful: [key], failed: [], model: "test-model", pollMs: 1_000 },
+			{ successful: [key], failed: [], model: "test-model", pollMs: 1_000, eligibility: true },
 			now + 60_002,
 		);
 		const remaining = loadEmbeddingRepairFailures(accessor, [key], "test-model");
 		expect(remaining).toEqual(new Map());
+		db.close();
+	});
+
+	it("does not let ten superseded-profile batches consume the promoted profile's ten-slot budget", () => {
+		const db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		const accessor = asAccessor(db);
+		const now = Date.parse("2026-08-11T12:00:00.000Z");
+		const oldConfig: EmbeddingConfig = {
+			provider: "ollama",
+			model: "custom-old",
+			dimensions: 3,
+			base_url: "http://127.0.0.1:11434",
+		};
+		const promotedConfig: EmbeddingConfig = { ...oldConfig, model: "custom-new" };
+		accessor.withWriteTx((db) => {
+			ensureEmbeddingIndexState(db, oldConfig);
+			beginEmbeddingIndexBuild(db, promotedConfig);
+			db.prepare(
+				"UPDATE embedding_index_state SET active_profile_json = staging_profile_json, staging_profile_json = NULL, state = 'ready' WHERE id = 1",
+			).run();
+		});
+		const activeConfig = accessor.withReadDb((db) => resolveActiveEmbeddingConfig(db, promotedConfig));
+		const key = { id: "old-memory", contentHash: "old-hash" };
+
+		for (let index = 0; index < 10; index++) {
+			const at = now + index;
+			const lease = acquireEmbeddingRepairLease(accessor, 0, 10, at).lease;
+			if (lease === undefined) throw new Error("expected superseded-profile lease");
+			expect(
+				finishEmbeddingRepairLease(
+					accessor,
+					lease,
+					{
+						successful: [],
+						failed: [key],
+						model: oldConfig.model,
+						pollMs: 1_000,
+						eligibility: (db) => isActiveEmbeddingConfig(db, oldConfig),
+					},
+					at,
+				),
+			).toBe(false);
+		}
+		expect(readEmbeddingRepairState(accessor)).toMatchObject({ batchesStarted: 0 });
+		expect(db.prepare("SELECT COUNT(*) AS n FROM embedding_repair_backoff").get() as { n: number }).toEqual({ n: 0 });
+
+		for (let index = 0; index < 10; index++) {
+			const at = now + 100 + index;
+			const lease = acquireEmbeddingRepairLease(accessor, 0, 10, at).lease;
+			if (lease === undefined) throw new Error("expected promoted-profile lease");
+			expect(
+				finishEmbeddingRepairLease(
+					accessor,
+					lease,
+					{
+						successful: [],
+						failed: [],
+						model: activeConfig.model,
+						pollMs: 1_000,
+						eligibility: (db) => isActiveEmbeddingConfig(db, activeConfig),
+					},
+					at,
+				),
+			).toBe(true);
+		}
+		expect(readEmbeddingRepairState(accessor)).toMatchObject({ batchesStarted: 10 });
+		expect(acquireEmbeddingRepairLease(accessor, 0, 10, now + 200)).toMatchObject({
+			allowed: false,
+			reason: "embedding repair hourly budget exhausted (10 batches/hr)",
+		});
 		db.close();
 	});
 
@@ -148,6 +244,7 @@ describe("embedding repair state", () => {
 				failed: [{ id: "deferred", contentHash: "hash-deferred" }],
 				model: "test-model",
 				pollMs: 1_000,
+				eligibility: true,
 			},
 			now + 1,
 		);

--- a/platform/daemon/src/embedding-repair-state.ts
+++ b/platform/daemon/src/embedding-repair-state.ts
@@ -1,0 +1,219 @@
+import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
+
+const HOUR_MS = 60 * 60 * 1000;
+// A batch can make sequential provider calls. Keep the owner lease alive for
+// the whole hourly accounting window so a slow but healthy batch cannot be
+// duplicated by a restarted daemon halfway through that work.
+const MIN_LEASE_MS = HOUR_MS;
+
+export interface EmbeddingRepairKey {
+	readonly id: string;
+	readonly contentHash: string;
+}
+
+export interface EmbeddingRepairLease {
+	readonly id: string;
+}
+
+export interface EmbeddingRepairAdmission {
+	readonly allowed: boolean;
+	readonly lease?: EmbeddingRepairLease;
+	readonly reason?: string;
+}
+
+export interface EmbeddingRepairFailure {
+	readonly attempts: number;
+	readonly retryAt: number;
+}
+
+export interface EmbeddingRepairState {
+	readonly windowStartedAt: string;
+	readonly batchesStarted: number;
+	readonly lastCompletedAt: string | null;
+	readonly lastAffected: number;
+	readonly leaseExpiresAt: string | null;
+	readonly lastError: string | null;
+}
+
+interface BudgetRow {
+	readonly window_started_at: string;
+	readonly batches_started: number;
+	readonly last_completed_at: string | null;
+	readonly last_affected: number;
+	readonly lease_id: string | null;
+	readonly lease_expires_at: string | null;
+	readonly last_error: string | null;
+}
+
+interface FailureRow {
+	readonly memory_id: string;
+	readonly content_hash: string;
+	readonly attempts: number;
+	readonly retry_at: string;
+}
+
+function iso(now: number): string {
+	return new Date(now).toISOString();
+}
+
+function parseMs(value: string | null): number | null {
+	if (value === null) return null;
+	const parsed = Date.parse(value);
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+function readBudget(db: ReadDb): BudgetRow | null {
+	return (
+		(db
+			.prepare(
+				"SELECT window_started_at, batches_started, last_completed_at, last_affected, lease_id, lease_expires_at, last_error FROM embedding_repair_budget WHERE id = 1",
+			)
+			.get() as unknown as BudgetRow | null) ?? null
+	);
+}
+
+function ensureBudget(db: WriteDb, now: number): BudgetRow {
+	const nowIso = iso(now);
+	db.prepare(
+		`INSERT OR IGNORE INTO embedding_repair_budget
+		 (id, window_started_at, batches_started, last_completed_at, last_affected, lease_id, lease_expires_at, last_error, updated_at)
+		 VALUES (1, ?, 0, NULL, 0, NULL, NULL, NULL, ?)`,
+	).run(nowIso, nowIso);
+	const row = readBudget(db);
+	if (row == null) throw new Error("embedding repair budget was not initialized");
+	return row;
+}
+
+function validWindowStart(value: string, now: number): number | null {
+	const parsed = Date.parse(value);
+	return Number.isFinite(parsed) && parsed <= now ? parsed : null;
+}
+
+export function acquireEmbeddingRepairLease(
+	accessor: DbAccessor,
+	cooldownMs: number,
+	hourlyBudget: number,
+	now = Date.now(),
+): EmbeddingRepairAdmission {
+	return accessor.withWriteTx((db) => {
+		const row = ensureBudget(db, now);
+		const leaseExpiry = parseMs(row.lease_expires_at);
+		if (row.lease_id !== null && leaseExpiry !== null && leaseExpiry > now) {
+			return { allowed: false, reason: "embedding repair already in progress" };
+		}
+
+		const lastCompletedAt = parseMs(row.last_completed_at);
+		if (lastCompletedAt !== null && now - lastCompletedAt < cooldownMs) {
+			return {
+				allowed: false,
+				reason: `embedding repair cooldown active, ${cooldownMs - (now - lastCompletedAt)}ms remaining`,
+			};
+		}
+
+		const windowStartedAt = validWindowStart(row.window_started_at, now);
+		const inWindow = windowStartedAt !== null && now - windowStartedAt < HOUR_MS;
+		const batchesStarted = inWindow ? row.batches_started : 0;
+		if (batchesStarted >= hourlyBudget) {
+			return { allowed: false, reason: `embedding repair hourly budget exhausted (${hourlyBudget} batches/hr)` };
+		}
+
+		const lease: EmbeddingRepairLease = { id: crypto.randomUUID() };
+		const windowStart = inWindow ? row.window_started_at : iso(now);
+		const leaseMs = Math.max(MIN_LEASE_MS, cooldownMs);
+		db.prepare(
+			`UPDATE embedding_repair_budget
+			 SET window_started_at = ?, batches_started = ?, lease_id = ?, lease_expires_at = ?, last_error = NULL, updated_at = ?
+			 WHERE id = 1`,
+		).run(windowStart, batchesStarted + 1, lease.id, iso(now + leaseMs), iso(now));
+		return { allowed: true, lease };
+	});
+}
+
+export function readEmbeddingRepairState(accessor: DbAccessor): EmbeddingRepairState | null {
+	return accessor.withReadDb((db) => {
+		const row = readBudget(db);
+		if (row == null) return null;
+		return {
+			windowStartedAt: row.window_started_at,
+			batchesStarted: row.batches_started,
+			lastCompletedAt: row.last_completed_at,
+			lastAffected: row.last_affected,
+			leaseExpiresAt: row.lease_expires_at,
+			lastError: row.last_error,
+		};
+	});
+}
+
+export function loadEmbeddingRepairFailures(
+	accessor: DbAccessor,
+	keys: readonly EmbeddingRepairKey[],
+	model: string,
+): ReadonlyMap<string, EmbeddingRepairFailure> {
+	if (keys.length === 0) return new Map();
+	return accessor.withReadDb((db) => {
+		const failures = new Map<string, EmbeddingRepairFailure>();
+		const query = db.prepare(
+			"SELECT memory_id, content_hash, attempts, retry_at FROM embedding_repair_backoff WHERE memory_id = ? AND content_hash = ? AND model = ?",
+		);
+		for (const key of keys) {
+			const row = query.get(key.id, key.contentHash, model) as unknown as FailureRow | null;
+			const retryAt = row == null ? null : parseMs(row.retry_at);
+			if (row != null && retryAt !== null)
+				failures.set(`${key.id}:${key.contentHash}:${model}`, { attempts: row.attempts, retryAt });
+		}
+		return failures;
+	});
+}
+
+export function finishEmbeddingRepairLease(
+	accessor: DbAccessor,
+	lease: EmbeddingRepairLease,
+	outcome: {
+		readonly successful: readonly EmbeddingRepairKey[];
+		readonly failed: readonly EmbeddingRepairKey[];
+		readonly model: string;
+		readonly pollMs: number;
+		readonly error?: string;
+	},
+	now = Date.now(),
+): void {
+	accessor.withWriteTx((db) => {
+		const current = readBudget(db);
+		if (current == null || current.lease_id !== lease.id) return;
+
+		const deleteFailure = db.prepare(
+			"DELETE FROM embedding_repair_backoff WHERE memory_id = ? AND content_hash = ? AND model = ?",
+		);
+		const readFailure = db.prepare(
+			"SELECT attempts FROM embedding_repair_backoff WHERE memory_id = ? AND content_hash = ? AND model = ?",
+		);
+		const writeFailure = db.prepare(
+			`INSERT INTO embedding_repair_backoff (memory_id, content_hash, model, attempts, retry_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)
+			 ON CONFLICT(memory_id, content_hash, model) DO UPDATE SET
+			   attempts = excluded.attempts, retry_at = excluded.retry_at, updated_at = excluded.updated_at`,
+		);
+
+		for (const key of outcome.successful) deleteFailure.run(key.id, key.contentHash, outcome.model);
+		for (const key of outcome.failed) {
+			const previous = readFailure.get(key.id, key.contentHash, outcome.model) as { attempts: number } | null;
+			const attempts = (previous?.attempts ?? 0) + 1;
+			const retryMs = computeRetryBackoffMs(attempts, outcome.pollMs);
+			writeFailure.run(key.id, key.contentHash, outcome.model, attempts, iso(now + retryMs), iso(now));
+		}
+
+		const error = outcome.error ?? (outcome.failed.length > 0 ? "embedding provider returned no vector" : null);
+		db.prepare(
+			`UPDATE embedding_repair_budget
+			 SET last_completed_at = ?, last_affected = ?, lease_id = NULL, lease_expires_at = NULL, last_error = ?, updated_at = ?
+			 WHERE id = 1 AND lease_id = ?`,
+		).run(iso(now), outcome.successful.length, error, iso(now), lease.id);
+	});
+}
+
+export function computeRetryBackoffMs(attempts: number, pollMs: number): number {
+	if (attempts <= 1) return Math.max(pollMs * 5, 60_000);
+	if (attempts === 2) return Math.max(pollMs * 25, 5 * 60_000);
+	if (attempts === 3) return Math.max(pollMs * 150, 30 * 60_000);
+	return Math.max(pollMs * 300, 60 * 60_000);
+}

--- a/platform/daemon/src/embedding-repair-state.ts
+++ b/platform/daemon/src/embedding-repair-state.ts
@@ -26,6 +26,8 @@ export interface EmbeddingRepairFailure {
 	readonly retryAt: number;
 }
 
+export type EmbeddingRepairEligibility = boolean | ((db: WriteDb) => boolean);
+
 export interface EmbeddingRepairState {
 	readonly windowStartedAt: string;
 	readonly batchesStarted: number;
@@ -117,6 +119,8 @@ export function acquireEmbeddingRepairLease(
 			return { allowed: false, reason: `embedding repair hourly budget exhausted (${hourlyBudget} batches/hr)` };
 		}
 
+		// A lease serializes provider work. The hourly slot is charged only when
+		// finishEmbeddingRepairLease can persist an outcome for the active profile.
 		const lease: EmbeddingRepairLease = { id: crypto.randomUUID() };
 		const windowStart = inWindow ? row.window_started_at : iso(now);
 		const leaseMs = Math.max(MIN_LEASE_MS, cooldownMs);
@@ -124,7 +128,7 @@ export function acquireEmbeddingRepairLease(
 			`UPDATE embedding_repair_budget
 			 SET window_started_at = ?, batches_started = ?, lease_id = ?, lease_expires_at = ?, last_error = NULL, updated_at = ?
 			 WHERE id = 1`,
-		).run(windowStart, batchesStarted + 1, lease.id, iso(now + leaseMs), iso(now));
+		).run(windowStart, batchesStarted, lease.id, iso(now + leaseMs), iso(now));
 		return { allowed: true, lease };
 	});
 }
@@ -173,13 +177,23 @@ export function finishEmbeddingRepairLease(
 		readonly failed: readonly EmbeddingRepairKey[];
 		readonly model: string;
 		readonly pollMs: number;
+		readonly eligibility: EmbeddingRepairEligibility;
 		readonly error?: string;
 	},
 	now = Date.now(),
-): void {
-	accessor.withWriteTx((db) => {
+): boolean {
+	return accessor.withWriteTx((db) => {
 		const current = readBudget(db);
-		if (current == null || current.lease_id !== lease.id) return;
+		if (current == null || current.lease_id !== lease.id) return false;
+		const eligible = typeof outcome.eligibility === "function" ? outcome.eligibility(db) : outcome.eligibility;
+		if (!eligible) {
+			db.prepare(
+				`UPDATE embedding_repair_budget
+				 SET lease_id = NULL, lease_expires_at = NULL, updated_at = ?
+				 WHERE id = 1 AND lease_id = ?`,
+			).run(iso(now), lease.id);
+			return false;
+		}
 
 		const deleteFailure = db.prepare(
 			"DELETE FROM embedding_repair_backoff WHERE memory_id = ? AND content_hash = ? AND model = ?",
@@ -202,12 +216,25 @@ export function finishEmbeddingRepairLease(
 			writeFailure.run(key.id, key.contentHash, outcome.model, attempts, iso(now + retryMs), iso(now));
 		}
 
+		const windowStartedAt = validWindowStart(current.window_started_at, now);
+		const inWindow = windowStartedAt !== null && now - windowStartedAt < HOUR_MS;
+		const batchesStarted = inWindow ? current.batches_started : 0;
 		const error = outcome.error ?? (outcome.failed.length > 0 ? "embedding provider returned no vector" : null);
 		db.prepare(
 			`UPDATE embedding_repair_budget
-			 SET last_completed_at = ?, last_affected = ?, lease_id = NULL, lease_expires_at = NULL, last_error = ?, updated_at = ?
+			 SET window_started_at = ?, batches_started = ?, last_completed_at = ?, last_affected = ?,
+			     lease_id = NULL, lease_expires_at = NULL, last_error = ?, updated_at = ?
 			 WHERE id = 1 AND lease_id = ?`,
-		).run(iso(now), outcome.successful.length, error, iso(now), lease.id);
+		).run(
+			inWindow ? current.window_started_at : iso(now),
+			batchesStarted + 1,
+			iso(now),
+			outcome.successful.length,
+			error,
+			iso(now),
+			lease.id,
+		);
+		return true;
 	});
 }
 

--- a/platform/daemon/src/embedding-repair-state.ts
+++ b/platform/daemon/src/embedding-repair-state.ts
@@ -219,6 +219,10 @@ export function finishEmbeddingRepairLease(
 		const windowStartedAt = validWindowStart(current.window_started_at, now);
 		const inWindow = windowStartedAt !== null && now - windowStartedAt < HOUR_MS;
 		const batchesStarted = inWindow ? current.batches_started : 0;
+		// A lease serializes attempted work, but the hourly budget represents
+		// completed repair work. A pressure abort can still persist failure
+		// backoff while releasing its lease without spending a batch slot.
+		const charged = outcome.successful.length > 0;
 		const error = outcome.error ?? (outcome.failed.length > 0 ? "embedding provider returned no vector" : null);
 		db.prepare(
 			`UPDATE embedding_repair_budget
@@ -227,7 +231,7 @@ export function finishEmbeddingRepairLease(
 			 WHERE id = 1 AND lease_id = ?`,
 		).run(
 			inWindow ? current.window_started_at : iso(now),
-			batchesStarted + 1,
+			batchesStarted + (charged ? 1 : 0),
 			iso(now),
 			outcome.successful.length,
 			error,

--- a/platform/daemon/src/embedding-tracker.ts
+++ b/platform/daemon/src/embedding-tracker.ts
@@ -214,9 +214,9 @@ export function startEmbeddingTracker(
 			lastCycleAt = new Date(now).toISOString();
 			if (readyRows.length === 0) return;
 
-			// The durable lease counts a batch before provider calls. A crash or a
-			// second daemon therefore consumes the same budget instead of replaying
-			// work indefinitely after each restart.
+			// The durable lease serializes provider calls before they begin. The
+			// hourly budget is charged only after at least one active-profile
+			// embedding persists, so an abort cannot spend a repair slot.
 			const admission = acquireEmbeddingRepairLease(
 				accessor,
 				repairCfg.reembedCooldownMs,

--- a/platform/daemon/src/embedding-tracker.ts
+++ b/platform/daemon/src/embedding-tracker.ts
@@ -249,6 +249,7 @@ export function startEmbeddingTracker(
 						failed: cycle.failedRows,
 						model: embeddingCfg.model,
 						pollMs: trackerCfg.pollMs,
+						eligibility: (db) => isActiveEmbeddingConfig(db, embeddingCfg),
 						error: "system pressure became high before embedding persistence",
 					});
 					return;
@@ -290,6 +291,7 @@ export function startEmbeddingTracker(
 					failed: cycle.failedRows.map((row) => ({ id: row.id, contentHash: row.contentHash })),
 					model: embeddingCfg.model,
 					pollMs: trackerCfg.pollMs,
+					eligibility: applied || ((db) => isActiveEmbeddingConfig(db, embeddingCfg)),
 					...(applied || cycle.results.length === 0 ? {} : { error: "embedding profile changed before persistence" }),
 				});
 				logger.debug("embedding-tracker", `Refreshed ${applied ? cycle.results.length : 0} embeddings`);
@@ -299,6 +301,7 @@ export function startEmbeddingTracker(
 					failed: [],
 					model: embeddingCfg.model,
 					pollMs: trackerCfg.pollMs,
+					eligibility: (db) => isActiveEmbeddingConfig(db, embeddingCfg),
 					error: error instanceof Error ? error.message : String(error),
 				});
 				throw error;

--- a/platform/daemon/src/embedding-tracker.ts
+++ b/platform/daemon/src/embedding-tracker.ts
@@ -7,11 +7,17 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { PipelineEmbeddingTrackerConfig } from "@signet/core";
+import type { PipelineEmbeddingTrackerConfig, PipelineRepairConfig } from "@signet/core";
 import type { DbAccessor } from "./db-accessor";
 import { syncVecDeleteBySourceExceptHash, syncVecInsert, vectorToBlob } from "./db-helpers";
 import { listStaleEmbeddingRows } from "./embedding-coverage";
 import { isActiveEmbeddingConfig } from "./embedding-index-state";
+import {
+	acquireEmbeddingRepairLease,
+	computeRetryBackoffMs,
+	finishEmbeddingRepairLease,
+	loadEmbeddingRepairFailures,
+} from "./embedding-repair-state";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
 import { isSystemPressureHigh } from "./system-pressure";
@@ -62,14 +68,12 @@ interface CycleSuccess {
 interface CycleResult {
 	readonly queueDepth: number;
 	readonly failed: number;
+	readonly failedRows: readonly StaleRow[];
 	readonly results: readonly CycleSuccess[];
 }
 
 export function computeEmbeddingRetryBackoffMs(count: number, pollMs: number): number {
-	if (count <= 1) return Math.max(pollMs * 5, 60_000);
-	if (count === 2) return Math.max(pollMs * 25, 5 * 60_000);
-	if (count === 3) return Math.max(pollMs * 150, 30 * 60_000);
-	return Math.max(pollMs * 300, 60 * 60_000);
+	return computeRetryBackoffMs(count, pollMs);
 }
 
 function failureKey(row: StaleRow, model: string): string {
@@ -100,11 +104,20 @@ export async function processEmbeddingCycle(
 	});
 
 	const results: CycleSuccess[] = [];
+	const failedRows: StaleRow[] = [];
 	let failed = 0;
 
 	for (const row of readyRows) {
 		const key = failureKey(row, embeddingCfg.model);
-		const vec = await fetchEmbeddingFn(row.content, embeddingCfg);
+		let vec: number[] | null = null;
+		try {
+			vec = await fetchEmbeddingFn(row.content, embeddingCfg);
+		} catch (error) {
+			logger.warn("embedding-tracker", "Embedding refresh request failed", {
+				memoryId: row.id,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
 		if (vec !== null) {
 			clearRowFailures(failures, row, embeddingCfg.model);
 			results.push({ row, vector: vec, contentHash: row.contentHash });
@@ -112,6 +125,7 @@ export async function processEmbeddingCycle(
 		}
 
 		failed++;
+		failedRows.push(row);
 		const next = (failures.get(key)?.count ?? 0) + 1;
 		const wait = computeEmbeddingRetryBackoffMs(next, pollMs);
 		failures.set(key, {
@@ -129,6 +143,7 @@ export async function processEmbeddingCycle(
 	return {
 		queueDepth: readyRows.length,
 		failed,
+		failedRows,
 		results,
 	};
 }
@@ -141,6 +156,7 @@ export function startEmbeddingTracker(
 	accessor: DbAccessor,
 	embeddingCfg: EmbeddingConfig,
 	trackerCfg: PipelineEmbeddingTrackerConfig,
+	repairCfg: PipelineRepairConfig,
 	fetchEmbeddingFn: (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>,
 	checkProviderFn: (cfg: EmbeddingConfig) => Promise<{ available: boolean }>,
 ): EmbeddingTrackerHandle {
@@ -170,65 +186,123 @@ export function startEmbeddingTracker(
 				return;
 			}
 
-			// 2. Query stale/missing embeddings (read-only)
+			// 2. Query stale/missing embeddings (read-only), then merge durable
+			// failure backoff so restarting the daemon cannot immediately replay a
+			// poison row against the provider.
+			const now = Date.now();
 			const staleRows = accessor.withReadDb((db) => {
-				return listStaleEmbeddingRows(db, embeddingCfg.model, trackerCfg.batchSize) as StaleRow[];
+				return listStaleEmbeddingRows(
+					db,
+					embeddingCfg.model,
+					trackerCfg.batchSize,
+					new Date(now).toISOString(),
+				) as StaleRow[];
 			});
-			const cycle = await processEmbeddingCycle(staleRows, failures, embeddingCfg, trackerCfg.pollMs, fetchEmbeddingFn);
+			const persistedFailures = loadEmbeddingRepairFailures(
+				accessor,
+				staleRows.map((row) => ({ id: row.id, contentHash: row.contentHash })),
+				embeddingCfg.model,
+			);
+			for (const [key, state] of persistedFailures) {
+				failures.set(key, { count: state.attempts, retryAt: state.retryAt });
+			}
+			const readyRows = staleRows.filter((row) => {
+				const state = failures.get(failureKey(row, embeddingCfg.model));
+				return state === undefined || state.retryAt <= now;
+			});
+			lastQueueDepth = readyRows.length;
+			lastCycleAt = new Date(now).toISOString();
+			if (readyRows.length === 0) return;
 
-			lastQueueDepth = cycle.queueDepth;
-			lastCycleAt = new Date().toISOString();
-
-			failed += cycle.failed;
-
-			if (cycle.results.length === 0) return;
-
-			// 4. Re-check pressure after the async embedding work — the event loop
-			// may have degraded during the awaits above.
-			if (isSystemPressureHigh()) {
+			// The durable lease counts a batch before provider calls. A crash or a
+			// second daemon therefore consumes the same budget instead of replaying
+			// work indefinitely after each restart.
+			const admission = acquireEmbeddingRepairLease(
+				accessor,
+				repairCfg.reembedCooldownMs,
+				repairCfg.reembedHourlyBudget,
+				now,
+			);
+			if (!admission.allowed || admission.lease === undefined) {
 				skippedCycles++;
 				return;
 			}
 
-			// 5. Batch write in a single write transaction
-			accessor.withWriteTx((db) => {
-				// A promotion may commit while this batch is encoding. Never let a
-				// tracker closed over the previous generation overwrite its vectors.
-				if (!isActiveEmbeddingConfig(db, embeddingCfg)) return;
-				for (const { row, vector, contentHash } of cycle.results) {
-					// Delete stale embeddings for this source
-					syncVecDeleteBySourceExceptHash(db, "memory", row.id, contentHash);
+			try {
+				const cycle = await processEmbeddingCycle(
+					readyRows,
+					failures,
+					embeddingCfg,
+					trackerCfg.pollMs,
+					fetchEmbeddingFn,
+					now,
+				);
+				failed += cycle.failed;
 
-					// Upsert embedding row
-					const embId = randomUUID();
-					db.prepare(
-						`INSERT INTO embeddings
-						   (id, source_type, source_id, content_hash, vector, dimensions, chunk_text, created_at)
-						 VALUES (?, 'memory', ?, ?, ?, ?, ?, datetime('now'))
-						 ON CONFLICT(content_hash) DO UPDATE SET
-						   vector = excluded.vector,
-						   dimensions = excluded.dimensions,
-						   chunk_text = excluded.chunk_text,
-						   created_at = excluded.created_at`,
-					).run(embId, row.id, contentHash, vectorToBlob(vector), vector.length, row.content);
-
-					// Sync vec table -- grab the actual id (may be existing on conflict)
-					const actualRow = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(contentHash) as
-						| { id: string }
-						| undefined;
-
-					if (actualRow) {
-						syncVecInsert(db, actualRow.id, vector);
-					}
-
-					// Update embedding_model on the memory row
-					db.prepare("UPDATE memories SET embedding_model = ? WHERE id = ?").run(embeddingCfg.model, row.id);
-
-					processed++;
+				// Re-check pressure after the async embedding work — the event loop
+				// may have degraded during the awaits above. The lease still closes so
+				// another process cannot pick up the same batch concurrently.
+				if (isSystemPressureHigh()) {
+					skippedCycles++;
+					finishEmbeddingRepairLease(accessor, admission.lease, {
+						successful: [],
+						failed: cycle.failedRows,
+						model: embeddingCfg.model,
+						pollMs: trackerCfg.pollMs,
+						error: "system pressure became high before embedding persistence",
+					});
+					return;
 				}
-			});
 
-			logger.debug("embedding-tracker", `Refreshed ${cycle.results.length} embeddings`);
+				let applied = false;
+				if (cycle.results.length > 0) {
+					// Batch write in a single write transaction. A promotion may commit
+					// while this batch is encoding, so never let a tracker closed over
+					// the previous generation overwrite its vectors.
+					applied = accessor.withWriteTx((db) => {
+						if (!isActiveEmbeddingConfig(db, embeddingCfg)) return false;
+						for (const { row, vector, contentHash } of cycle.results) {
+							syncVecDeleteBySourceExceptHash(db, "memory", row.id, contentHash);
+							const embId = randomUUID();
+							db.prepare(
+								`INSERT INTO embeddings
+								   (id, source_type, source_id, content_hash, vector, dimensions, chunk_text, created_at)
+								 VALUES (?, 'memory', ?, ?, ?, ?, ?, datetime('now'))
+								 ON CONFLICT(content_hash) DO UPDATE SET
+								   vector = excluded.vector,
+								   dimensions = excluded.dimensions,
+								   chunk_text = excluded.chunk_text,
+								   created_at = excluded.created_at`,
+							).run(embId, row.id, contentHash, vectorToBlob(vector), vector.length, row.content);
+							const actualRow = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(contentHash) as
+								| { id: string }
+								| undefined;
+							if (actualRow) syncVecInsert(db, actualRow.id, vector);
+							db.prepare("UPDATE memories SET embedding_model = ? WHERE id = ?").run(embeddingCfg.model, row.id);
+							processed++;
+						}
+						return true;
+					});
+				}
+
+				finishEmbeddingRepairLease(accessor, admission.lease, {
+					successful: applied ? cycle.results.map(({ row }) => ({ id: row.id, contentHash: row.contentHash })) : [],
+					failed: cycle.failedRows.map((row) => ({ id: row.id, contentHash: row.contentHash })),
+					model: embeddingCfg.model,
+					pollMs: trackerCfg.pollMs,
+					...(applied || cycle.results.length === 0 ? {} : { error: "embedding profile changed before persistence" }),
+				});
+				logger.debug("embedding-tracker", `Refreshed ${applied ? cycle.results.length : 0} embeddings`);
+			} catch (error) {
+				finishEmbeddingRepairLease(accessor, admission.lease, {
+					successful: [],
+					failed: [],
+					model: embeddingCfg.model,
+					pollMs: trackerCfg.pollMs,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				throw error;
+			}
 		} catch (err) {
 			logger.warn("embedding-tracker", "Cycle error", err instanceof Error ? err : new Error(String(err)));
 		}

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -35,6 +35,7 @@ import {
 } from "./embedding-coverage";
 import { type EmbeddingMigrationCoverage, stagingCoverage } from "./embedding-index-migration";
 import { readEmbeddingIndexState } from "./embedding-index-state";
+import { type EmbeddingRepairState, readEmbeddingRepairState } from "./embedding-repair-state";
 import { classifyEntityQuality } from "./entity-quality";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
@@ -600,9 +601,12 @@ export interface EmbeddingGapStats {
 	readonly complete: boolean;
 	readonly coverage: string;
 	readonly staging: EmbeddingMigrationCoverage | null;
+	/** Durable autonomous-tracker admission and completion state. */
+	readonly repair: EmbeddingRepairState | null;
 }
 
 export function getEmbeddingGapStats(accessor: DbAccessor): EmbeddingGapStats {
+	const repair = readEmbeddingRepairState(accessor);
 	return accessor.withReadDb((db) => {
 		const totalRow = db.prepare("SELECT COUNT(*) as n FROM memories WHERE is_deleted = 0").get() as { n: number };
 		const total = totalRow.n;
@@ -627,6 +631,7 @@ export function getEmbeddingGapStats(accessor: DbAccessor): EmbeddingGapStats {
 			complete,
 			coverage: `${displayed.toFixed(1)}%`,
 			staging,
+			repair,
 		};
 	});
 }

--- a/web/docs/src/content/docs/architecture/platform-services.md
+++ b/web/docs/src/content/docs/architecture/platform-services.md
@@ -146,6 +146,14 @@ this), then a rate limiter with per-action cooldown and hourly budget.
 Each successful repair writes an audit event to `memory_history` with
 `memory_id = 'system'`.
 
+**Embedding refresh tracker** (`embedding-tracker.ts`): the existing
+incremental tracker owns stale and missing-memory vector writes. It does not
+create a second repair queue. Before a provider batch, it acquires a durable
+SQLite lease and consumes one `repair.reembedHourlyBudget` slot. Per-memory
+provider failures retain exponential retry deadlines across daemon restarts;
+the lease, completed batch count, and last error are returned with
+`GET /api/repair/embedding-gaps`.
+
 **Maintenance worker** (`pipeline/maintenance-worker.ts`): runs on a
 configurable interval. Each cycle calls `getDiagnostics`, builds repair
 recommendations from the report, and either logs them (`observe` mode)

--- a/web/docs/src/content/docs/pipeline/workers-maintenance.md
+++ b/web/docs/src/content/docs/pipeline/workers-maintenance.md
@@ -285,10 +285,12 @@ Each cycle:
    by `updated_at DESC` and capped at `batchSize`.
 
 3. **Durable admission** — before provider work, the tracker claims a singleton
-   SQLite lease and increments the shared hourly batch budget. The lease spans
-   the accounting window, so daemon restarts cannot reset the budget or cause a
-   slow batch to run twice. The existing repair cooldown and hourly budget
-   control this admission.
+   SQLite lease. When the batch has an outcome eligible to persist for the
+   active embedding profile, the finishing transaction atomically charges the
+   shared hourly batch budget and writes any failure backoff. A superseded
+   profile releases its lease without consuming the promoted profile's budget.
+   The lease spans the accounting window, so a slow batch cannot run twice;
+   the existing repair cooldown and hourly budget control admission.
 
 4. **Sequential embedding fetch** — each stale row's content is embedded
    one at a time, outside any transaction. Failed fetches increment the

--- a/web/docs/src/content/docs/pipeline/workers-maintenance.md
+++ b/web/docs/src/content/docs/pipeline/workers-maintenance.md
@@ -280,13 +280,22 @@ Each cycle:
    - The embedding's `content_hash` differs from the memory's (stale)
    - The memory's `embedding_model` differs from the configured model
      (model switch)
-   Results are ordered by `updated_at DESC` and capped at `batchSize`.
+   Rows with a persisted provider-failure backoff are excluded until their retry
+   time, so a poison row cannot starve other eligible work. Results are ordered
+   by `updated_at DESC` and capped at `batchSize`.
 
-3. **Sequential embedding fetch** — each stale row's content is embedded
+3. **Durable admission** — before provider work, the tracker claims a singleton
+   SQLite lease and increments the shared hourly batch budget. The lease spans
+   the accounting window, so daemon restarts cannot reset the budget or cause a
+   slow batch to run twice. The existing repair cooldown and hourly budget
+   control this admission.
+
+4. **Sequential embedding fetch** — each stale row's content is embedded
    one at a time, outside any transaction. Failed fetches increment the
-   `failed` counter without aborting the cycle.
+   `failed` counter without aborting the cycle. Their retry state is persisted
+   by memory id, content hash, and embedding model.
 
-4. **Batch write** — all successful embeddings are upserted in a single
+5. **Batch write** — all successful embeddings are upserted in a single
    `withWriteTx` call. For each result: stale embeddings are deleted by
    source (except the new hash), the new embedding row is upserted on
    `content_hash` conflict, the `vec_embeddings` virtual table is synced,

--- a/web/docs/src/content/docs/pipeline/workers-maintenance.md
+++ b/web/docs/src/content/docs/pipeline/workers-maintenance.md
@@ -285,10 +285,10 @@ Each cycle:
    by `updated_at DESC` and capped at `batchSize`.
 
 3. **Durable admission** — before provider work, the tracker claims a singleton
-   SQLite lease. When the batch has an outcome eligible to persist for the
-   active embedding profile, the finishing transaction atomically charges the
-   shared hourly batch budget and writes any failure backoff. A superseded
-   profile releases its lease without consuming the promoted profile's budget.
+   SQLite lease. When at least one embedding persists for the active profile,
+   the finishing transaction atomically charges the shared hourly batch budget
+   and writes any failure backoff. A superseded profile or pressure-aborted
+   batch releases its lease without consuming the promoted profile's budget.
    The lease spans the accounting window, so a slow batch cannot run twice;
    the existing repair cooldown and hourly budget control admission.
 


### PR DESCRIPTION
## Summary

Make the incremental embedding refresh tracker restart-safe. Its existing repair ownership remains intact, while its batch admission and per-row provider backoff now survive daemon restart.

## Changes

- Add migration 130 with a singleton durable repair budget/lease and per-memory, content-hash, and model retry state.
- Acquire a durable lease before provider work, then atomically charge the shared budget and failure backoff only when the outcome is eligible for the active embedding profile.
- Prevent temporarily backed-off rows from starving other eligible stale embeddings.
- Surface repair state through embedding-gap diagnostics and document the autonomous refresh behavior in the maintenance and platform-service references.
- Add regression coverage for restart budget persistence, full-window lease exclusivity, corrupted future budget timestamps, persisted backoff cleanup, backoff-selection starvation, and a direct ten-slot embedding-promotion repro.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [x] `@signet/web`
- [ ] `predictor`
- [ ] Other: 

## Screenshots

Not applicable. No UI change.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

Migration 130 creates only additive durable tracker state. Older databases receive it on normal startup. Rolling back code leaves the two unused tables harmless; no existing memory, embedding, or repair records are rewritten.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Passed:

- `bun test platform/daemon/src/embedding-repair-state.test.ts platform/daemon/src/embedding-coverage.test.ts platform/daemon/src/embedding-tracker.test.ts`
- `bun test platform/daemon/src/repair-actions.test.ts platform/core/src/migrations/migrations.test.ts`
- `bun run --filter '@signet/core' build`
- `bun run --filter '@signet/daemon' build`
- Targeted Biome check on all changed TypeScript files

Repository-wide gates are currently red outside this change: `bun run typecheck` fails in existing connector packages due missing `@signet/connector-base` exports and generated bundle files; `bun run lint` reports broad existing formatting drift; `bun test` reports 214 unrelated failures including the pre-existing VISION.md budget and content-index mismatch.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The global budget state is deliberately not agent-scoped because embeddings and the active vector index are workspace-wide. The tracker uses the existing refresh path rather than adding a second autonomous repair executor.
