### PR TITLE
fix(desktop): validate staged Bun runtime

### DIFF
--- a/surfaces/desktop/scripts/stage-runtime.mjs
+++ b/surfaces/desktop/scripts/stage-runtime.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { execFileSync, execSync } from "node:child_process";
-import { chmodSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { chmodSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { basename, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -32,14 +32,83 @@ function bunRuntime() {
 	const candidates = [process.env.BUN_RUNTIME, process.execPath, pathLookup("bun")].filter(Boolean);
 	for (const candidate of candidates) {
 		const name = basename(candidate).toLowerCase();
-		if ((name === "bun" || name === "bun.exe") && existsSync(candidate)) return candidate;
+		if ((name === "bun" || name === "bun.exe") && existsSync(candidate)) return resolve(candidate);
 	}
 	throw new Error("Unable to locate Bun runtime. Run this script with bun or set BUN_RUNTIME.");
 }
 
-function platformVecPackage() {
+function normalizeArch(value) {
+	if (value === "arm") return "arm64";
+	if (value === "arm64" || value === "x64" || value === "ia32") return value;
+	throw new Error(`Unsupported desktop build architecture: ${value}`);
+}
+
+function normalizePlatform(value) {
+	if (value === "mac") return "darwin";
+	if (value === "windows") return "win32";
+	if (value === "darwin" || value === "linux" || value === "win32") return value;
+	throw new Error(`Unsupported desktop build platform: ${value}`);
+}
+
+function targetArch() {
+	return normalizeArch(process.env.ELECTRON_BUILDER_ARCH ?? process.env.npm_config_arch ?? process.arch);
+}
+
+function targetPlatform() {
+	return normalizePlatform(process.env.ELECTRON_BUILDER_PLATFORM ?? process.platform);
+}
+
+function probeBunRuntime(runtimePath) {
+	const output = execFileSync(
+		runtimePath,
+		["-e", "console.log(JSON.stringify({ platform: process.platform, arch: process.arch }))"],
+		{ encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+	);
+	const result = JSON.parse(output.trim());
+	if (
+		typeof result !== "object" ||
+		result === null ||
+		typeof result.platform !== "string" ||
+		typeof result.arch !== "string"
+	) {
+		throw new Error("Bun runtime probe returned an invalid result");
+	}
+	return { platform: normalizePlatform(result.platform), arch: normalizeArch(result.arch) };
+}
+
+export function assertBunRuntime(
+	runtimePath,
+	expectedArch,
+	expectedPlatform = process.platform,
+	probe = probeBunRuntime,
+) {
+	if (!existsSync(runtimePath) || !statSync(runtimePath).isFile()) {
+		throw new Error(`Bun runtime is not a regular file: ${runtimePath}`);
+	}
+	if (process.platform !== "win32" && (statSync(runtimePath).mode & 0o111) === 0) {
+		throw new Error(`Bun runtime is not executable: ${runtimePath}`);
+	}
+
+	let runtime;
+	try {
+		runtime = probe(runtimePath);
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		throw new Error(`Unable to execute Bun runtime at ${runtimePath}: ${detail}`);
+	}
+
+	const arch = normalizeArch(expectedArch);
+	const platform = normalizePlatform(expectedPlatform);
+	if (runtime.platform !== platform) {
+		throw new Error(`Bun runtime platform mismatch: expected ${platform}, got ${runtime.platform} (${runtimePath})`);
+	}
+	if (runtime.arch !== arch) {
+		throw new Error(`Bun runtime architecture mismatch: expected ${arch}, got ${runtime.arch} (${runtimePath})`);
+	}
+}
+
+function platformVecPackage(arch) {
 	const os = process.platform === "win32" ? "windows" : process.platform;
-	const arch = process.arch === "x64" ? "x64" : process.arch;
 	return `sqlite-vec-${os}-${arch}`;
 }
 
@@ -47,44 +116,51 @@ function pkgVersion(pkg, name) {
 	return pkg.dependencies?.[name] ?? pkg.optionalDependencies?.[name] ?? pkg.devDependencies?.[name] ?? null;
 }
 
-rmSync(resources, { recursive: true, force: true });
-mkdirSync(daemonOut, { recursive: true });
-mkdirSync(runtimeOut, { recursive: true });
+export function stageRuntime() {
+	const bunSrc = bunRuntime();
+	const bunArch = targetArch();
+	assertBunRuntime(bunSrc, bunArch, targetPlatform());
 
-const bunSrc = bunRuntime();
-const bunDest = resolve(runtimeOut, win ? "bun.exe" : "bun");
-cpSync(bunSrc, bunDest);
-if (!win) chmodSync(bunDest, 0o755);
+	rmSync(resources, { recursive: true, force: true });
+	mkdirSync(daemonOut, { recursive: true });
+	mkdirSync(runtimeOut, { recursive: true });
 
-mkdirSync(resolve(daemonOut, "dist"), { recursive: true });
-for (const name of ["daemon.js", "mcp-stdio.js", "index.js", "synthesis-render-worker.js"]) {
-	cpSync(resolve(repoRoot, "platform/daemon/dist", name), resolve(daemonOut, "dist", name));
+	const bunDest = resolve(runtimeOut, win ? "bun.exe" : "bun");
+	cpSync(bunSrc, bunDest);
+	if (!win) chmodSync(bunDest, 0o755);
+
+	mkdirSync(resolve(daemonOut, "dist"), { recursive: true });
+	for (const name of ["daemon.js", "mcp-stdio.js", "index.js", "synthesis-render-worker.js"]) {
+		cpSync(resolve(repoRoot, "platform/daemon/dist", name), resolve(daemonOut, "dist", name));
+	}
+	cpSync(resolve(repoRoot, "platform/daemon/dashboard"), resolve(daemonOut, "dashboard"), { recursive: true });
+	cpSync(resolve(repoRoot, "platform/daemon/skills"), resolve(daemonOut, "skills"), { recursive: true });
+
+	const daemonPkg = readJson(daemonPkgPath);
+	const corePkg = readJson(corePkgPath);
+	const vecPkg = platformVecPackage(bunArch);
+	const dependencies = {};
+	for (const name of ["@1password/sdk", "@huggingface/transformers", "onnxruntime-node"]) {
+		const version = pkgVersion(daemonPkg, name);
+		if (version) dependencies[name] = version;
+	}
+	for (const name of ["sqlite-vec", vecPkg]) {
+		const version = pkgVersion(corePkg, name);
+		if (version) dependencies[name] = version;
+	}
+
+	writeFileSync(
+		resolve(daemonOut, "package.json"),
+		`${JSON.stringify({ private: true, type: "module", dependencies }, null, "	")}\n`,
+	);
+
+	execFileSync(bunSrc, ["install", "--production"], {
+		cwd: daemonOut,
+		stdio: "inherit",
+		env: { ...process.env, npm_config_audit: "false", npm_config_fund: "false" },
+	});
+
+	console.log(`Staged Electron desktop resources in ${resources}`);
 }
-cpSync(resolve(repoRoot, "platform/daemon/dashboard"), resolve(daemonOut, "dashboard"), { recursive: true });
-cpSync(resolve(repoRoot, "platform/daemon/skills"), resolve(daemonOut, "skills"), { recursive: true });
 
-const daemonPkg = readJson(daemonPkgPath);
-const corePkg = readJson(corePkgPath);
-const vecPkg = platformVecPackage();
-const dependencies = {};
-for (const name of ["@1password/sdk", "@huggingface/transformers", "onnxruntime-node"]) {
-	const version = pkgVersion(daemonPkg, name);
-	if (version) dependencies[name] = version;
-}
-for (const name of ["sqlite-vec", vecPkg]) {
-	const version = pkgVersion(corePkg, name);
-	if (version) dependencies[name] = version;
-}
-
-writeFileSync(
-	resolve(daemonOut, "package.json"),
-	`${JSON.stringify({ private: true, type: "module", dependencies }, null, "\t")}\n`,
-);
-
-execSync("bun install --production", {
-	cwd: daemonOut,
-	stdio: "inherit",
-	env: { ...process.env, npm_config_audit: "false", npm_config_fund: "false" },
-});
-
-console.log(`Staged Electron desktop resources in ${resources}`);
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) stageRuntime();

--- a/surfaces/desktop/scripts/stage-runtime.test.mjs
+++ b/surfaces/desktop/scripts/stage-runtime.test.mjs
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { assertBunRuntime } from "./stage-runtime.mjs";
+
+describe("stage-runtime Bun validation", () => {
+	it("rejects an architecture-mismatched staged runtime", () => {
+		const directory = mkdtempSync(join(tmpdir(), "signet-stage-runtime-"));
+		const runtimePath = join(directory, "bun");
+		try {
+			writeFileSync(runtimePath, "fake bun runtime\n");
+			chmodSync(runtimePath, 0o755);
+
+			expect(() => assertBunRuntime(runtimePath, "arm64", "linux", () => ({ platform: "linux", arch: "x64" }))).toThrow(
+				"Bun runtime architecture mismatch: expected arm64, got x64",
+			);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #1466. Desktop runtime staging now resolves Bun once, verifies that it is executable and reports the target platform and architecture, and uses that exact runtime for the production dependency install. A mismatched staged Bun fails before packaging can continue.

## Changes

- Validate the resolved `BUN_RUNTIME`/Bun executable against `ELECTRON_BUILDER_PLATFORM` and `ELECTRON_BUILDER_ARCH` (with host defaults).
- Use the resolved absolute Bun path for `bun install --production` instead of the PATH command.
- Select the platform sqlite-vec package from the validated build architecture.
- Add a regression test for an architecture-mismatched staged runtime.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `@signet/desktop`

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations are touched.

## Testing

- [x] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused proof:

- `bun run --filter '@signet/desktop' test` passes, 22 tests across 7 files.
- `bun run --filter '@signet/desktop' typecheck` passes.
- `bun run --filter '@signet/core' build` passes.
- `bun run --filter '@signet/daemon' build` passes.
- `bunx biome check surfaces/desktop/scripts/stage-runtime.mjs surfaces/desktop/scripts/stage-runtime.test.mjs` passes.
- `git diff --check` passes.
- Ran `stage-runtime.mjs` with an explicit absolute `BUN_RUNTIME` while removing Bun from PATH. It completed staging and installed the production dependencies with the resolved runtime.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The full root `bun run typecheck` and `bun run lint` remain red on the rebased base for unrelated pre-existing connector/package formatting and generated-bundle issues. The affected desktop package checks and touched-file Biome check pass. This PR does not touch signing or notarization (#1460).
