### PR TITLE
fix(desktop): fail closed on macOS signing

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -56,15 +56,28 @@ jobs:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_KEYCHAIN: ${{ secrets.APPLE_KEYCHAIN }}
+          APPLE_KEYCHAIN_PROFILE: ${{ secrets.APPLE_KEYCHAIN_PROFILE }}
           WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
           WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
         run: |
           set -euo pipefail
           mode="${SIGNING_MODE_INPUT}"
           runner="${{ matrix.runner }}"
+          is_release=0
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            is_release=1
+          fi
           has_official=0
           requires_signing=0
           missing=()
+          notarization_missing=()
 
           require_secret() {
             name="$1"
@@ -79,13 +92,27 @@ jobs:
             require_secret APPLE_CERTIFICATE "${APPLE_CERTIFICATE:-}"
             require_secret APPLE_CERTIFICATE_PASSWORD "${APPLE_CERTIFICATE_PASSWORD:-}"
             require_secret APPLE_SIGNING_IDENTITY "${APPLE_SIGNING_IDENTITY:-}"
+
+            if [ -n "${APPLE_ID:-}" ] || [ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]; then
+              [ -n "${APPLE_ID:-}" ] || notarization_missing+=("APPLE_ID")
+              [ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ] || notarization_missing+=("APPLE_APP_SPECIFIC_PASSWORD")
+              [ -n "${APPLE_TEAM_ID:-}" ] || notarization_missing+=("APPLE_TEAM_ID")
+            elif [ -n "${APPLE_API_KEY:-}" ] || [ -n "${APPLE_API_KEY_ID:-}" ] || [ -n "${APPLE_API_ISSUER:-}" ]; then
+              [ -n "${APPLE_API_KEY:-}" ] || notarization_missing+=("APPLE_API_KEY")
+              [ -n "${APPLE_API_KEY_ID:-}" ] || notarization_missing+=("APPLE_API_KEY_ID")
+              [ -n "${APPLE_API_ISSUER:-}" ] || notarization_missing+=("APPLE_API_ISSUER")
+            elif [ -n "${APPLE_KEYCHAIN_PROFILE:-}" ]; then
+              :
+            else
+              notarization_missing+=("APPLE_API_KEY + APPLE_API_KEY_ID + APPLE_API_ISSUER (or APPLE_ID + APPLE_APP_SPECIFIC_PASSWORD + APPLE_TEAM_ID)")
+            fi
           elif [ "${runner}" = "windows-latest" ]; then
             requires_signing=1
             require_secret WINDOWS_CERTIFICATE "${WINDOWS_CERTIFICATE:-}"
             require_secret WINDOWS_CERTIFICATE_PASSWORD "${WINDOWS_CERTIFICATE_PASSWORD:-}"
           fi
 
-          if [ "${requires_signing}" -eq 1 ] && [ "${#missing[@]}" -eq 0 ]; then
+          if [ "${requires_signing}" -eq 1 ] && [ "${#missing[@]}" -eq 0 ] && [ "${#notarization_missing[@]}" -eq 0 ]; then
             has_official=1
           fi
 
@@ -95,17 +122,25 @@ jobs:
           fi
 
           if [ "${mode}" = "official" ] && [ "${requires_signing}" -eq 1 ] && [ "${has_official}" -ne 1 ]; then
-            printf '::error::signing_mode=official but required signing secrets are missing: %s\n' "${missing[*]}"
+            printf '::error::signing_mode=official but required signing/notarization secrets are missing: %s %s\n' "${missing[*]}" "${notarization_missing[*]}"
             exit 1
           fi
 
           if [ "${mode}" = "auto" ]; then
             if [ "${has_official}" -eq 1 ]; then
               mode="official"
+            elif [[ "${runner}" == macos-* && "${is_release}" -eq 1 ]]; then
+              printf '::error::macOS tag releases require Developer ID signing and notarization; missing: %s %s\n' "${missing[*]}" "${notarization_missing[*]}"
+              exit 1
             else
               mode="self-signed"
-              printf '::warning::Official signing secrets missing, falling back to self-signed mode: %s\n' "${missing[*]}"
+              printf '::warning::Official signing secrets missing; using self-signed mode for this non-release build: %s %s\n' "${missing[*]}" "${notarization_missing[*]}"
             fi
+          fi
+
+          if [[ "${runner}" == macos-* && "${is_release}" -eq 1 && "${mode}" != "official" ]]; then
+            echo "::error::Stable macOS releases cannot use unsigned or self-signed artifacts"
+            exit 1
           fi
           if [ "${mode}" != "official" ] && [ "${mode}" != "self-signed" ]; then
             echo "::error::Invalid signing mode: ${mode}"
@@ -121,6 +156,14 @@ jobs:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_KEYCHAIN: ${{ secrets.APPLE_KEYCHAIN }}
+          APPLE_KEYCHAIN_PROFILE: ${{ secrets.APPLE_KEYCHAIN_PROFILE }}
           WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
           WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
         run: |
@@ -140,6 +183,14 @@ jobs:
             write_env CSC_LINK "${APPLE_CERTIFICATE}"
             write_env CSC_KEY_PASSWORD "${APPLE_CERTIFICATE_PASSWORD}"
             write_env CSC_NAME "${APPLE_SIGNING_IDENTITY}"
+            write_env APPLE_ID "${APPLE_ID:-}"
+            write_env APPLE_APP_SPECIFIC_PASSWORD "${APPLE_APP_SPECIFIC_PASSWORD:-}"
+            write_env APPLE_TEAM_ID "${APPLE_TEAM_ID:-}"
+            write_env APPLE_API_KEY "${APPLE_API_KEY:-}"
+            write_env APPLE_API_KEY_ID "${APPLE_API_KEY_ID:-}"
+            write_env APPLE_API_ISSUER "${APPLE_API_ISSUER:-}"
+            write_env APPLE_KEYCHAIN "${APPLE_KEYCHAIN:-}"
+            write_env APPLE_KEYCHAIN_PROFILE "${APPLE_KEYCHAIN_PROFILE:-}"
           elif [ "${{ matrix.runner }}" = "windows-latest" ]; then
             write_env CSC_LINK "${WINDOWS_CERTIFICATE}"
             write_env CSC_KEY_PASSWORD "${WINDOWS_CERTIFICATE_PASSWORD}"
@@ -170,6 +221,13 @@ jobs:
 
           echo "::error::Electron desktop build failed after 3 attempts"
           exit 1
+
+      - name: Verify macOS signing, notarization, and Gatekeeper state
+        if: startsWith(matrix.runner, 'macos-') && steps.signing.outputs.mode == 'official'
+        run: |
+          set -euo pipefail
+          cd surfaces/desktop
+          bun run verify:macos
 
       - name: Generate AUR metadata
         if: matrix.runner == 'ubuntu-22.04' && startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -93,16 +93,48 @@ jobs:
             require_secret APPLE_CERTIFICATE_PASSWORD "${APPLE_CERTIFICATE_PASSWORD:-}"
             require_secret APPLE_SIGNING_IDENTITY "${APPLE_SIGNING_IDENTITY:-}"
 
-            if [ -n "${APPLE_ID:-}" ] || [ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]; then
-              [ -n "${APPLE_ID:-}" ] || notarization_missing+=("APPLE_ID")
-              [ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ] || notarization_missing+=("APPLE_APP_SPECIFIC_PASSWORD")
-              [ -n "${APPLE_TEAM_ID:-}" ] || notarization_missing+=("APPLE_TEAM_ID")
-            elif [ -n "${APPLE_API_KEY:-}" ] || [ -n "${APPLE_API_KEY_ID:-}" ] || [ -n "${APPLE_API_ISSUER:-}" ]; then
-              [ -n "${APPLE_API_KEY:-}" ] || notarization_missing+=("APPLE_API_KEY")
-              [ -n "${APPLE_API_KEY_ID:-}" ] || notarization_missing+=("APPLE_API_KEY_ID")
-              [ -n "${APPLE_API_ISSUER:-}" ] || notarization_missing+=("APPLE_API_ISSUER")
-            elif [ -n "${APPLE_KEYCHAIN_PROFILE:-}" ]; then
-              :
+            apple_id_present=0
+            apple_id_complete=0
+            api_key_present=0
+            api_key_complete=0
+            if [ -n "${APPLE_ID:-}" ] || [ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ] || [ -n "${APPLE_TEAM_ID:-}" ]; then
+              apple_id_present=1
+              if [ -n "${APPLE_ID:-}" ] && [ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ] && [ -n "${APPLE_TEAM_ID:-}" ]; then
+                apple_id_complete=1
+              fi
+            fi
+            if [ -n "${APPLE_API_KEY:-}" ] || [ -n "${APPLE_API_KEY_ID:-}" ] || [ -n "${APPLE_API_ISSUER:-}" ]; then
+              api_key_present=1
+              if [ -n "${APPLE_API_KEY:-}" ] && [ -n "${APPLE_API_KEY_ID:-}" ] && [ -n "${APPLE_API_ISSUER:-}" ]; then
+                api_key_complete=1
+              fi
+            fi
+            if [ -n "${APPLE_KEYCHAIN_PROFILE:-}" ]; then
+              if [ "${apple_id_complete}" -eq 0 ] && [ "${api_key_complete}" -eq 0 ]; then
+                if [ "${apple_id_present}" -eq 1 ]; then
+                  [ -n "${APPLE_ID:-}" ] || notarization_missing+=("APPLE_ID")
+                  [ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ] || notarization_missing+=("APPLE_APP_SPECIFIC_PASSWORD")
+                  [ -n "${APPLE_TEAM_ID:-}" ] || notarization_missing+=("APPLE_TEAM_ID")
+                elif [ "${api_key_present}" -eq 1 ]; then
+                  [ -n "${APPLE_API_KEY:-}" ] || notarization_missing+=("APPLE_API_KEY")
+                  [ -n "${APPLE_API_KEY_ID:-}" ] || notarization_missing+=("APPLE_API_KEY_ID")
+                  [ -n "${APPLE_API_ISSUER:-}" ] || notarization_missing+=("APPLE_API_ISSUER")
+                else
+                  notarization_missing+=("APPLE_KEYCHAIN_PROFILE requires a complete Apple ID or App Store Connect API key set for provisioning")
+                fi
+              fi
+            elif [ "${apple_id_present}" -eq 1 ]; then
+              [ "${apple_id_complete}" -eq 1 ] || {
+                [ -n "${APPLE_ID:-}" ] || notarization_missing+=("APPLE_ID")
+                [ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ] || notarization_missing+=("APPLE_APP_SPECIFIC_PASSWORD")
+                [ -n "${APPLE_TEAM_ID:-}" ] || notarization_missing+=("APPLE_TEAM_ID")
+              }
+            elif [ "${api_key_present}" -eq 1 ]; then
+              [ "${api_key_complete}" -eq 1 ] || {
+                [ -n "${APPLE_API_KEY:-}" ] || notarization_missing+=("APPLE_API_KEY")
+                [ -n "${APPLE_API_KEY_ID:-}" ] || notarization_missing+=("APPLE_API_KEY_ID")
+                [ -n "${APPLE_API_ISSUER:-}" ] || notarization_missing+=("APPLE_API_ISSUER")
+              }
             else
               notarization_missing+=("APPLE_API_KEY + APPLE_API_KEY_ID + APPLE_API_ISSUER (or APPLE_ID + APPLE_APP_SPECIFIC_PASSWORD + APPLE_TEAM_ID)")
             fi
@@ -183,14 +215,41 @@ jobs:
             write_env CSC_LINK "${APPLE_CERTIFICATE}"
             write_env CSC_KEY_PASSWORD "${APPLE_CERTIFICATE_PASSWORD}"
             write_env CSC_NAME "${APPLE_SIGNING_IDENTITY}"
-            write_env APPLE_ID "${APPLE_ID:-}"
-            write_env APPLE_APP_SPECIFIC_PASSWORD "${APPLE_APP_SPECIFIC_PASSWORD:-}"
-            write_env APPLE_TEAM_ID "${APPLE_TEAM_ID:-}"
-            write_env APPLE_API_KEY "${APPLE_API_KEY:-}"
-            write_env APPLE_API_KEY_ID "${APPLE_API_KEY_ID:-}"
-            write_env APPLE_API_ISSUER "${APPLE_API_ISSUER:-}"
-            write_env APPLE_KEYCHAIN "${APPLE_KEYCHAIN:-}"
-            write_env APPLE_KEYCHAIN_PROFILE "${APPLE_KEYCHAIN_PROFILE:-}"
+            api_key_path=""
+            if [ -n "${APPLE_API_KEY:-}" ] && [ -n "${APPLE_API_KEY_ID:-}" ] && [ -n "${APPLE_API_ISSUER:-}" ]; then
+              api_key_path="${RUNNER_TEMP}/signet-apple-api-key.p8"
+              printf '%s\n' "${APPLE_API_KEY}" > "${api_key_path}"
+              chmod 600 "${api_key_path}"
+            fi
+            if [ -n "${APPLE_KEYCHAIN_PROFILE:-}" ]; then
+              store_credentials=(notarytool store-credentials "${APPLE_KEYCHAIN_PROFILE}")
+              if [ -n "${api_key_path}" ]; then
+                store_credentials+=(--key "${api_key_path}" --key-id "${APPLE_API_KEY_ID}" --issuer "${APPLE_API_ISSUER}")
+              else
+                store_credentials+=(--apple-id "${APPLE_ID}" --password "${APPLE_APP_SPECIFIC_PASSWORD}" --team-id "${APPLE_TEAM_ID}")
+              fi
+              if [ -n "${APPLE_KEYCHAIN:-}" ]; then
+                store_credentials+=(--keychain "${APPLE_KEYCHAIN}")
+              fi
+              xcrun "${store_credentials[@]}"
+              write_env APPLE_ID ""
+              write_env APPLE_APP_SPECIFIC_PASSWORD ""
+              write_env APPLE_TEAM_ID ""
+              write_env APPLE_API_KEY ""
+              write_env APPLE_API_KEY_ID ""
+              write_env APPLE_API_ISSUER ""
+              write_env APPLE_KEYCHAIN "${APPLE_KEYCHAIN:-}"
+              write_env APPLE_KEYCHAIN_PROFILE "${APPLE_KEYCHAIN_PROFILE}"
+            else
+              write_env APPLE_ID "${APPLE_ID:-}"
+              write_env APPLE_APP_SPECIFIC_PASSWORD "${APPLE_APP_SPECIFIC_PASSWORD:-}"
+              write_env APPLE_TEAM_ID "${APPLE_TEAM_ID:-}"
+              write_env APPLE_API_KEY "${api_key_path}"
+              write_env APPLE_API_KEY_ID "${APPLE_API_KEY_ID:-}"
+              write_env APPLE_API_ISSUER "${APPLE_API_ISSUER:-}"
+              write_env APPLE_KEYCHAIN "${APPLE_KEYCHAIN:-}"
+              write_env APPLE_KEYCHAIN_PROFILE ""
+            fi
           elif [ "${{ matrix.runner }}" = "windows-latest" ]; then
             write_env CSC_LINK "${WINDOWS_CERTIFICATE}"
             write_env CSC_KEY_PASSWORD "${WINDOWS_CERTIFICATE_PASSWORD}"
@@ -230,7 +289,7 @@ jobs:
           bun run verify:macos
 
       - name: Generate AUR metadata
-        if: matrix.runner == 'ubuntu-22.04' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.runner == 'ubuntu-22.04' && startsWith(github.ref, 'refs/tags/v')
         run: |
           set -euo pipefail
           APPIMAGE="$(find surfaces/desktop/release -name '*.AppImage' | head -n 1)"
@@ -258,7 +317,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload AUR metadata
-        if: matrix.runner == 'ubuntu-22.04' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.runner == 'ubuntu-22.04' && startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-artifact@v4
         with:
           name: aur-metadata
@@ -268,7 +327,7 @@ jobs:
           include-hidden-files: true
 
       - name: Publish release assets
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           files: |
@@ -282,7 +341,7 @@ jobs:
 
   validate-aur:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/docs/specs/approved/desktop-packaging-distribution.md
+++ b/docs/specs/approved/desktop-packaging-distribution.md
@@ -80,10 +80,14 @@ Arch.
   `APPLE_SIGNING_IDENTITY`) plus one supported notarytool credential set:
   App Store Connect API key (`APPLE_API_KEY`, `APPLE_API_KEY_ID`, and
   `APPLE_API_ISSUER`), Apple ID/app-specific password/team ID, or a notarytool
-  keychain profile. Without these credentials, the macOS tag job fails before
-  build or publish. Local Linux verification cannot prove the Apple signing,
-  notarization, or Gatekeeper steps; the macOS CI runner is the verification
-  environment.
+  keychain profile. `APPLE_API_KEY` contains the `.p8` key contents and CI
+  writes it to an absolute temporary path before invoking electron-builder.
+  Keychain-profile mode also requires one complete Apple ID or App Store
+  Connect API-key set so CI can provision the profile with
+  `xcrun notarytool store-credentials` on the fresh hosted runner. Without
+  these credentials, the macOS tag job fails before build or publish. Local
+  Linux verification cannot prove the Apple signing, notarization, or
+  Gatekeeper steps; the macOS CI runner is the verification environment.
 - The desktop packaging verifier checks the signed app bundle with
   `codesign`, validates the stapled ticket with `xcrun stapler`, and runs a
   quarantined copy through `spctl` before upload. Electron-builder's

--- a/docs/specs/approved/desktop-packaging-distribution.md
+++ b/docs/specs/approved/desktop-packaging-distribution.md
@@ -42,8 +42,14 @@ Arch.
 2. Electron desktop runtime startup must support a bundled Bun daemon
    fallback path when system runtimes are unavailable.
 3. Release workflows must resolve signing mode before publish:
-   - official signing when certificate secrets are present
-   - self-signed fallback when official signing is unavailable
+   - macOS tag releases require Developer ID signing and notarization credentials
+     and fail closed when either is unavailable
+   - macOS non-release manual builds may use self-signed mode for local testing,
+     but self-signed macOS artifacts must never be published as stable releases
+   - Windows may use official signing when certificate secrets are present and
+     self-signed fallback otherwise
+   - macOS official builds must pass codesign, stapler, and quarantined
+     Gatekeeper assessment before artifacts are uploaded or published
 4. AUR metadata generation must be deterministic from version, AppImage
    URL, and checksum.
 5. Arch packaging must be validated in CI by building from the generated
@@ -67,7 +73,21 @@ Arch.
 - Desktop packaging remains independent of npm release train mechanics.
 - The CLI source-build path uses the already-pulled Signet checkout. It must
   not clone over local work or silently switch branches.
-- Generated AUR metadata is emitted as CI artifacts and can be pushed by
-  a separate credentialed job.
+- Generated AUR metadata is emitted as CI artifacts and can be pushed by a
+  separate credentialed job.
+- macOS stable releases require repository secrets for the Developer ID
+  certificate (`APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, and
+  `APPLE_SIGNING_IDENTITY`) plus one supported notarytool credential set:
+  App Store Connect API key (`APPLE_API_KEY`, `APPLE_API_KEY_ID`, and
+  `APPLE_API_ISSUER`), Apple ID/app-specific password/team ID, or a notarytool
+  keychain profile. Without these credentials, the macOS tag job fails before
+  build or publish. Local Linux verification cannot prove the Apple signing,
+  notarization, or Gatekeeper steps; the macOS CI runner is the verification
+  environment.
+- The desktop packaging verifier checks the signed app bundle with
+  `codesign`, validates the stapled ticket with `xcrun stapler`, and runs a
+  quarantined copy through `spctl` before upload. Electron-builder's
+  pre-notarization Gatekeeper assessment stays disabled so the post-notarization
+  verifier is the authoritative Gatekeeper check.
 - `platform/daemon-rs` remains the shadow daemon rewrite. Desktop sidecar usage is intentionally bound to the current Bun daemon.
   `daemon-rs` remains separate parity work until cutover is approved.

--- a/surfaces/desktop/build/entitlements.mac.inherit.plist
+++ b/surfaces/desktop/build/entitlements.mac.inherit.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/surfaces/desktop/build/entitlements.mac.plist
+++ b/surfaces/desktop/build/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/surfaces/desktop/package.json
+++ b/surfaces/desktop/package.json
@@ -13,6 +13,7 @@
 		"build:daemon": "cd ../../platform/daemon && bun run build",
 		"build:main": "tsc -p tsconfig.json",
 		"stage:runtime": "node scripts/stage-runtime.mjs",
+		"verify:macos": "node scripts/verify-macos-release.mjs release",
 		"build": "bun run build:main",
 		"build:desktop": "bun run build:core && bun run build:tray && bun run build:daemon && bun run stage:runtime && bun run build:main && electron-builder --publish never",
 		"dev": "bun run build:tray && bun run build:dashboard && bun run build:main && electron .",
@@ -57,7 +58,13 @@
 			"target": [
 				"dmg",
 				"zip"
-			]
+			],
+			"hardenedRuntime": true,
+			"gatekeeperAssess": false,
+			"strictVerify": true,
+			"entitlements": "build/entitlements.mac.plist",
+			"entitlementsInherit": "build/entitlements.mac.inherit.plist",
+			"notarize": true
 		},
 		"win": {
 			"icon": "icons/icon.ico",

--- a/surfaces/desktop/scripts/verify-macos-release.mjs
+++ b/surfaces/desktop/scripts/verify-macos-release.mjs
@@ -1,0 +1,66 @@
+import { cpSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const releaseDirectory = resolve(process.argv[2] ?? join(scriptDirectory, "..", "release"));
+
+function fail(message) {
+	throw new Error(`[macOS release verification] ${message}`);
+}
+
+function run(command, args) {
+	const result = spawnSync(command, args, { encoding: "utf8" });
+	const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+	if (result.error) fail(`${command} could not be executed: ${result.error.message}`);
+	if (result.status !== 0) {
+		fail(`${command} ${args.join(" ")} failed with exit ${result.status ?? "unknown"}\n${output.trim()}`);
+	}
+	return output;
+}
+
+function findApp(directory) {
+	const entries = readdirSync(directory, { withFileTypes: true });
+	for (const entry of entries) {
+		const entryPath = join(directory, entry.name);
+		if (entry.isDirectory() && entry.name.endsWith(".app")) return entryPath;
+		if (entry.isDirectory()) {
+			const nested = findApp(entryPath);
+			if (nested) return nested;
+		}
+	}
+	return null;
+}
+
+if (process.platform !== "darwin") {
+	fail(`must run on macOS; current platform is ${process.platform}`);
+}
+
+const appPath = findApp(releaseDirectory);
+if (!appPath) fail(`no .app bundle found under ${releaseDirectory}`);
+
+console.log(`Verifying signed app bundle: ${appPath}`);
+run("codesign", ["--verify", "--deep", "--strict", "--verbose=2", appPath]);
+const signature = run("codesign", ["--display", "--verbose=4", appPath]);
+if (signature.includes("Signature=adhoc")) fail("app has an ad-hoc signature, not a Developer ID signature");
+if (!signature.includes("Authority=Developer ID Application:")) {
+	fail("app is not signed by a Developer ID Application identity");
+}
+if (!signature.includes("TeamIdentifier=")) fail("signed app is missing a TeamIdentifier");
+
+run("xcrun", ["stapler", "validate", appPath]);
+
+const quarantineDirectory = mkdtempSync(join(process.env.TMPDIR ?? "/tmp", "signet-macos-quarantine-"));
+const quarantinedAppPath = join(quarantineDirectory, "Signet.app");
+try {
+	cpSync(appPath, quarantinedAppPath, { recursive: true });
+	run("xattr", ["-w", "com.apple.quarantine", "0081;00000000;Signet;Signet.app", quarantinedAppPath]);
+	const quarantine = run("xattr", ["-p", "com.apple.quarantine", quarantinedAppPath]).trim();
+	if (!quarantine) fail("could not confirm com.apple.quarantine on the Gatekeeper test copy");
+	run("spctl", ["--assess", "--type", "execute", "--verbose=4", quarantinedAppPath]);
+} finally {
+	rmSync(quarantineDirectory, { recursive: true, force: true });
+}
+
+console.log("macOS release verification passed: Developer ID signature, stapled notarization ticket, and quarantined Gatekeeper assessment are valid.");

--- a/surfaces/desktop/scripts/verify-macos-release.mjs
+++ b/surfaces/desktop/scripts/verify-macos-release.mjs
@@ -63,4 +63,6 @@ try {
 	rmSync(quarantineDirectory, { recursive: true, force: true });
 }
 
-console.log("macOS release verification passed: Developer ID signature, stapled notarization ticket, and quarantined Gatekeeper assessment are valid.");
+console.log(
+	"macOS release verification passed: Developer ID signature, stapled notarization ticket, and quarantined Gatekeeper assessment are valid.",
+);

--- a/surfaces/desktop/src/desktop-updates.test.ts
+++ b/surfaces/desktop/src/desktop-updates.test.ts
@@ -46,6 +46,42 @@ describe("desktop update packaging", () => {
 		expect(workflow).toContain("surfaces/desktop/release/latest*.yml");
 	});
 
+	test("fails closed for stable macOS artifacts without notarization", () => {
+		const packageJson = JSON.parse(readFileSync(join(desktopRoot, "package.json"), "utf8"));
+		const mac = packageJson.build.mac;
+		expect(mac.hardenedRuntime).toBe(true);
+		expect(mac.gatekeeperAssess).toBe(false);
+		expect(mac.strictVerify).toBe(true);
+		expect(mac.notarize).toBe(true);
+		expect(mac.entitlements).toBe("build/entitlements.mac.plist");
+		expect(mac.entitlementsInherit).toBe("build/entitlements.mac.inherit.plist");
+
+		for (const name of ["entitlements.mac.plist", "entitlements.mac.inherit.plist"]) {
+			const entitlements = readFileSync(join(desktopRoot, "build", name), "utf8");
+			expect(entitlements).toContain("com.apple.security.cs.allow-jit");
+			expect(entitlements).toContain("com.apple.security.cs.disable-library-validation");
+		}
+
+		const workflow = readFileSync(join(desktopRoot, "..", "..", ".github", "workflows", "desktop-build.yml"), "utf8");
+		for (const secret of [
+			"APPLE_ID",
+			"APPLE_APP_SPECIFIC_PASSWORD",
+			"APPLE_TEAM_ID",
+			"APPLE_API_KEY",
+			"APPLE_API_KEY_ID",
+			"APPLE_API_ISSUER",
+			"APPLE_KEYCHAIN_PROFILE",
+		]) {
+			expect(workflow).toContain(`secrets.${secret}`);
+		}
+		expect(workflow).toContain("macOS tag releases require Developer ID signing and notarization");
+		expect(workflow).toContain("Stable macOS releases cannot use unsigned or self-signed artifacts");
+		expect(workflow).toContain("bun run verify:macos");
+		const verifier = readFileSync(join(desktopRoot, "scripts", "verify-macos-release.mjs"), "utf8");
+		expect(verifier).toContain('run("xcrun", ["stapler", "validate"');
+		expect(verifier).toContain('run("spctl", ["--assess", "--type", "execute"');
+	});
+
 	test("uses a Linux-safe Electron executable name", () => {
 		const packageJson = JSON.parse(readFileSync(join(desktopRoot, "package.json"), "utf8"));
 		expect(packageJson.build.executableName).toBe("signet");

--- a/surfaces/desktop/src/desktop-updates.test.ts
+++ b/surfaces/desktop/src/desktop-updates.test.ts
@@ -82,6 +82,26 @@ describe("desktop update packaging", () => {
 		expect(verifier).toContain('run("spctl", ["--assess", "--type", "execute"');
 	});
 
+	test("materializes API keys, provisions keychain profiles, and publishes only stable v tags", () => {
+		const workflow = readFileSync(join(desktopRoot, "..", "..", ".github", "workflows", "desktop-build.yml"), "utf8");
+		const configureStart = workflow.indexOf("      - name: Configure Electron signing");
+		const installStart = workflow.indexOf("      - name: Install dependencies", configureStart);
+		const configure = workflow.slice(configureStart, installStart);
+
+		expect(configure).toContain('api_key_path="${RUNNER_TEMP}/signet-apple-api-key.p8"');
+		expect(configure).toContain('printf \'%s\\n\' "${APPLE_API_KEY}" > "${api_key_path}"');
+		expect(configure).toContain('write_env APPLE_API_KEY "${api_key_path}"');
+		expect(configure).toContain("notarytool store-credentials");
+		expect(configure).toContain('xcrun "${store_credentials[@]}"');
+		expect(configure).toContain('write_env APPLE_API_KEY ""');
+
+		const publishStart = workflow.indexOf("      - name: Publish release assets");
+		const validateStart = workflow.indexOf("\n\n  validate-aur:", publishStart);
+		const publish = workflow.slice(publishStart, validateStart);
+		expect(publish).toContain("if: startsWith(github.ref, 'refs/tags/v')");
+		expect(publish).not.toContain("if: startsWith(github.ref, 'refs/tags/')");
+	});
+
 	test("uses a Linux-safe Electron executable name", () => {
 		const packageJson = JSON.parse(readFileSync(join(desktopRoot, "package.json"), "utf8"));
 		expect(packageJson.build.executableName).toBe("signet");


### PR DESCRIPTION
1|## Summary
2|
3|Closes #1460. macOS tag builds now fail closed unless Developer ID signing and notarization credentials are present, and successful official builds are verified through codesign, stapling, and a quarantined Gatekeeper assessment before artifacts are uploaded or published.
4|
5|## Changes
6|
7|- Added electron-builder hardened runtime, entitlements, strict signing checks, and automatic notarytool integration.
8|- Added macOS entitlement files for the app and inherited Electron child bundles.
9|- Added explicit Apple notarization secret handling for API key, Apple ID, and keychain-profile flows.
10|- Kept self-signed mode for non-release manual builds, but reject unsigned/self-signed macOS tag releases.
11|- Added `verify-macos-release.mjs` and run it before macOS artifacts are uploaded.
12|- Updated the approved desktop packaging contract with the credential requirement and verification boundary.
13|
14|## Type
15|
16|- [ ] `feat` — new user-facing feature (bumps minor)
17|- [x] `fix` — bug fix
18|- [ ] `refactor` — restructure without behavior change
19|- [ ] `chore` — build, deps, config, docs
20|- [ ] `perf` — performance improvement
21|- [ ] `test` — test coverage
22|
23|## Packages affected
24|
25|- [ ] `@signet/core`
26|- [ ] `@signet/daemon`
27|- [ ] `@signet/cli` / dashboard
28|- [ ] `@signet/sdk`
29|- [ ] `@signet/connector-*`
30|- [ ] `@signet/web`
31|- [ ] `predictor`
32|- [x] Other: `@signet/desktop`, desktop release workflow, approved packaging spec
33|
34|## Screenshots
35|
36|N/A. This change is packaging and release automation only.
37|
38|## PR Readiness (MANDATORY)
39|
40|- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
41|- [x] Agent scoping verified on all new/changed data queries
42|- [x] Input/config validation and bounds checks added
43|- [x] Error handling and fallback paths tested (no silent swallow)
44|- [x] Security checks applied to admin/mutation endpoints
45|- [x] Docs updated for API/spec/status changes
46|- [x] Regression tests added for each bug fix
47|- [x] Lint/typecheck/tests pass locally
48|
49|## Migration Notes (if applicable)
50|
51|Not applicable. No migrations were touched.
52|
53|## Testing
54|
55|- [ ] `bun test` passes
56|- [ ] `bun run typecheck` passes
57|- [ ] `bun run lint` passes
58|- [ ] Tested against running daemon
59|- [ ] N/A
60|
61|Exact scoped proof:
62|
63|- `bun test surfaces/desktop/src/desktop-updates.test.ts` passed: 7 tests, 37 expectations.
64|- `bun run --filter '@signet/desktop' typecheck` passed.
65|- `bun run --filter '@signet/desktop' build` passed.
66|- `bunx biome check surfaces/desktop/src/desktop-updates.test.ts surfaces/desktop/package.json` passed.
67|- `node --check surfaces/desktop/scripts/verify-macos-release.mjs` passed.
68|- Desktop workflow YAML parsed successfully and `git diff --check` passed.
69|- The verifier correctly fails on this Linux host with: `must run on macOS; current platform is linux`.
70|- The signing resolver was exercised with empty credentials: macOS tag mode failed with the explicit Developer ID/notarization error, while a non-release manual build selected self-signed mode.
71|
72|The Apple Developer account, certificate, notarytool credentials, macOS runner, and Gatekeeper verification remain unverified locally because this Linux host cannot execute macOS signing tools. The macOS CI jobs are the required end-to-end verification environment.
73|
74|## AI disclosure
75|
76|- [ ] No AI tools were used in this PR
77|- [x] AI tools were used (see `Assisted-by` tags in commits)
78|
79|## Notes
80|
81|The workflow accepts one complete electron-builder notarytool credential set: `APPLE_API_KEY` + `APPLE_API_KEY_ID` + `APPLE_API_ISSUER`, `APPLE_ID` + `APPLE_APP_SPECIFIC_PASSWORD` + `APPLE_TEAM_ID`, or `APPLE_KEYCHAIN_PROFILE`. The stable macOS path never falls back to self-signed output. #1466 is not touched because this change does not modify `stage-runtime.mjs`.
82|