### PR TITLE
fix(cli): persist native install PATH

### DIFF
--- a/surfaces/cli/src/features/native-install.test.ts
+++ b/surfaces/cli/src/features/native-install.test.ts
@@ -105,6 +105,26 @@ describe("persistNativeInstallPath", () => {
 		expect(readFileSync(profilePath, "utf8")).toBe('# existing profile\nexport PATH="$HOME/.local/bin:$PATH"\n');
 	});
 
+	test("does not treat a near-prefix profile PATH entry as the requested directory", () => {
+		const home = makeHome();
+		homes.push(home);
+		const binDir = "/custom/bin";
+		const profilePath = join(home, ".bash_profile");
+		writeFileSync(profilePath, 'export PATH="/custom/bin-old:$PATH"\n', "utf8");
+
+		const result = persistNativeInstallPath(binDir, {
+			home,
+			platform: "linux",
+			shell: "/bin/bash",
+			pathValue: "/usr/bin:/bin",
+		});
+
+		expect(result).toEqual({ profilePath, persisted: true });
+		expect(readFileSync(profilePath, "utf8")).toBe(
+			`export PATH="/custom/bin-old:$PATH"\nexport PATH="${binDir}:$PATH"\n`,
+		);
+	});
+
 	test("skips persistence when PATH already contains the directory", () => {
 		const home = makeHome();
 		homes.push(home);

--- a/surfaces/cli/src/features/native-install.test.ts
+++ b/surfaces/cli/src/features/native-install.test.ts
@@ -105,12 +105,12 @@ describe("persistNativeInstallPath", () => {
 		expect(readFileSync(profilePath, "utf8")).toBe('# existing profile\nexport PATH="$HOME/.local/bin:$PATH"\n');
 	});
 
-	test("does not treat a near-prefix profile PATH entry as the requested directory", () => {
+	test("does not treat a near-prefix default alias as the requested directory", () => {
 		const home = makeHome();
 		homes.push(home);
-		const binDir = "/custom/bin";
+		const binDir = join(home, ".local", "bin");
 		const profilePath = join(home, ".bash_profile");
-		writeFileSync(profilePath, 'export PATH="/custom/bin-old:$PATH"\n', "utf8");
+		writeFileSync(profilePath, 'export PATH="$HOME/.local/bin-old:$PATH"\n', "utf8");
 
 		const result = persistNativeInstallPath(binDir, {
 			home,
@@ -121,7 +121,7 @@ describe("persistNativeInstallPath", () => {
 
 		expect(result).toEqual({ profilePath, persisted: true });
 		expect(readFileSync(profilePath, "utf8")).toBe(
-			`export PATH="/custom/bin-old:$PATH"\nexport PATH="${binDir}:$PATH"\n`,
+			`export PATH="$HOME/.local/bin-old:$PATH"\nexport PATH="$HOME/.local/bin:$PATH"\n`,
 		);
 	});
 

--- a/surfaces/cli/src/features/native-install.test.ts
+++ b/surfaces/cli/src/features/native-install.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { persistNativeInstallPath, printNativeInstallResult } from "./native-install.js";
@@ -64,6 +64,45 @@ describe("persistNativeInstallPath", () => {
 
 		expect(result).toEqual({ profilePath: join(home, ".bash_profile"), persisted: true });
 		expect(readFileSync(join(home, ".bash_profile"), "utf8")).toBe('export PATH="$HOME/.local/bin:$PATH"\n');
+	});
+
+	test("persists a custom bin directory even when the profile has the default alias", () => {
+		const home = makeHome();
+		homes.push(home);
+		const binDir = join(home, "custom", "bin");
+		const profilePath = join(home, ".bash_profile");
+		writeFileSync(profilePath, 'export PATH="$HOME/.local/bin:$PATH"\n', "utf8");
+
+		const result = persistNativeInstallPath(binDir, {
+			home,
+			platform: "linux",
+			shell: "/bin/bash",
+			pathValue: "/usr/bin:/bin",
+		});
+
+		expect(result).toEqual({ profilePath, persisted: true });
+		expect(readFileSync(profilePath, "utf8")).toBe(
+			`export PATH="$HOME/.local/bin:$PATH"\nexport PATH="${binDir}:$PATH"\n`,
+		);
+	});
+
+	test("updates the first existing bash startup file instead of creating .bash_profile", () => {
+		const home = makeHome();
+		homes.push(home);
+		const binDir = join(home, ".local", "bin");
+		const profilePath = join(home, ".profile");
+		writeFileSync(profilePath, "# existing profile\n", "utf8");
+
+		const result = persistNativeInstallPath(binDir, {
+			home,
+			platform: "linux",
+			shell: "/bin/bash",
+			pathValue: "/usr/bin:/bin",
+		});
+
+		expect(result).toEqual({ profilePath, persisted: true });
+		expect(existsSync(join(home, ".bash_profile"))).toBe(false);
+		expect(readFileSync(profilePath, "utf8")).toBe('# existing profile\nexport PATH="$HOME/.local/bin:$PATH"\n');
 	});
 
 	test("skips persistence when PATH already contains the directory", () => {

--- a/surfaces/cli/src/features/native-install.test.ts
+++ b/surfaces/cli/src/features/native-install.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { persistNativeInstallPath } from "./native-install.js";
+
+function makeHome(): string {
+	return mkdtempSync(join(tmpdir(), "signet-native-install-"));
+}
+
+const homes: string[] = [];
+
+afterEach(() => {
+	for (const home of homes.splice(0)) rmSync(home, { force: true, recursive: true });
+});
+
+describe("persistNativeInstallPath", () => {
+	test("persists the macOS zsh PATH entry in .zprofile", () => {
+		const home = makeHome();
+		homes.push(home);
+		const binDir = join(home, ".local", "bin");
+
+		const result = persistNativeInstallPath(binDir, {
+			home,
+			platform: "darwin",
+			shell: "/bin/zsh",
+			pathValue: "/usr/bin:/bin",
+		});
+
+		expect(result).toEqual({ profilePath: join(home, ".zprofile"), persisted: true });
+		expect(readFileSync(join(home, ".zprofile"), "utf8")).toBe('export PATH="$HOME/.local/bin:$PATH"\n');
+	});
+
+	test("does not duplicate a persisted PATH entry", () => {
+		const home = makeHome();
+		homes.push(home);
+		const binDir = join(home, ".local", "bin");
+		const profilePath = join(home, ".zprofile");
+		persistNativeInstallPath(binDir, { home, platform: "darwin", shell: "/bin/zsh", pathValue: "/usr/bin" });
+		const first = readFileSync(profilePath, "utf8");
+
+		const result = persistNativeInstallPath(binDir, {
+			home,
+			platform: "darwin",
+			shell: "/bin/zsh",
+			pathValue: "/usr/bin",
+		});
+
+		expect(result).toEqual({ profilePath, persisted: true });
+		expect(readFileSync(profilePath, "utf8")).toBe(first);
+	});
+
+	test("persists the bash PATH entry in .bash_profile", () => {
+		const home = makeHome();
+		homes.push(home);
+		const binDir = join(home, ".local", "bin");
+
+		const result = persistNativeInstallPath(binDir, {
+			home,
+			platform: "darwin",
+			shell: "/bin/bash",
+			pathValue: "/usr/bin:/bin",
+		});
+
+		expect(result).toEqual({ profilePath: join(home, ".bash_profile"), persisted: true });
+		expect(readFileSync(join(home, ".bash_profile"), "utf8")).toBe('export PATH="$HOME/.local/bin:$PATH"\n');
+	});
+
+	test("skips persistence when PATH already contains the directory", () => {
+		const home = makeHome();
+		homes.push(home);
+		const binDir = join(home, ".local", "bin");
+		const result = persistNativeInstallPath(binDir, {
+			home,
+			platform: "darwin",
+			shell: "/bin/bash",
+			pathValue: `${binDir}:/usr/bin`,
+		});
+
+		expect(result).toEqual({ profilePath: null, persisted: false });
+		expect(existsSync(join(home, ".bash_profile"))).toBe(false);
+	});
+});

--- a/surfaces/cli/src/features/native-install.test.ts
+++ b/surfaces/cli/src/features/native-install.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { persistNativeInstallPath } from "./native-install.js";
+import { persistNativeInstallPath, printNativeInstallResult } from "./native-install.js";
 
 function makeHome(): string {
 	return mkdtempSync(join(tmpdir(), "signet-native-install-"));
@@ -79,5 +79,26 @@ describe("persistNativeInstallPath", () => {
 
 		expect(result).toEqual({ profilePath: null, persisted: false });
 		expect(existsSync(join(home, ".bash_profile"))).toBe(false);
+	});
+
+	test("prints the shell reload step after configuring PATH", () => {
+		const lines: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => lines.push(args.map(String).join(" "));
+		try {
+			printNativeInstallResult({
+				source: "/tmp/signet",
+				target: "/home/test/.local/bin/signet",
+				installed: true,
+				pathHint: null,
+				pathProfile: "/home/test/.zprofile",
+				pathPersisted: true,
+				connectorAssetsDir: null,
+			});
+		} finally {
+			console.log = originalLog;
+		}
+
+		expect(lines.join("\n")).toContain("Open a new shell or run `source /home/test/.zprofile`");
 	});
 });

--- a/surfaces/cli/src/features/native-install.ts
+++ b/surfaces/cli/src/features/native-install.ts
@@ -62,7 +62,13 @@ function shellProfilePath(home: string, shell: string | undefined, platform: Nod
 	if (platform === "win32") return null;
 	const shellName = shell ? basename(shell).toLowerCase() : "";
 	if (shellName === "zsh") return join(home, ".zprofile");
-	if (shellName === "bash") return join(home, ".bash_profile");
+	if (shellName === "bash") {
+		const bashProfiles = [".bash_profile", ".bash_login", ".profile"];
+		return (
+			bashProfiles.map((profile) => join(home, profile)).find((profile) => existsSync(profile)) ??
+			join(home, ".bash_profile")
+		);
+	}
 	if (platform === "darwin" && shellName === "") return join(home, ".zprofile");
 	return null;
 }
@@ -75,17 +81,15 @@ function shellPathEntry(binDir: string, home: string, platform: NodeJS.Platform)
 
 function profileContainsPath(contents: string, binDir: string, home: string, platform: NodeJS.Platform): boolean {
 	const normalizedDir = normalizePathEntry(binDir, platform);
-	const homeRelativeDir = normalizePathEntry(join(home, ".local", "bin"), platform);
+	const isDefaultBinDir = normalizedDir === normalizePathEntry(join(home, ".local", "bin"), platform);
 	return contents.split(/\r?\n/).some((line) => {
 		const trimmed = line.trim();
 		if (trimmed.startsWith("#") || !/^(?:export\s+)?PATH\s*=/.test(trimmed)) return false;
+		const containsRequestedDir = line.includes(binDir) || line.includes(normalizedDir);
+		if (containsRequestedDir) return true;
 		return (
-			line.includes(binDir) ||
-			line.includes(normalizedDir) ||
-			line.includes("$HOME/.local/bin") ||
-			line.includes("${HOME}/.local/bin") ||
-			line.includes("~/.local/bin") ||
-			line.includes(homeRelativeDir)
+			isDefaultBinDir &&
+			(line.includes("$HOME/.local/bin") || line.includes("${HOME}/.local/bin") || line.includes("~/.local/bin"))
 		);
 	});
 }

--- a/surfaces/cli/src/features/native-install.ts
+++ b/surfaces/cli/src/features/native-install.ts
@@ -85,12 +85,13 @@ function profileContainsPath(contents: string, binDir: string, home: string, pla
 	return contents.split(/\r?\n/).some((line) => {
 		const trimmed = line.trim();
 		if (trimmed.startsWith("#") || !/^(?:export\s+)?PATH\s*=/.test(trimmed)) return false;
-		const containsRequestedDir = line.includes(binDir) || line.includes(normalizedDir);
+		const assignment = trimmed.replace(/^(?:export\s+)?PATH\s*=\s*/, "").replace(/^["']|["']$/g, "");
+		const containsRequestedDir = assignment
+			.split(":")
+			.some((entry) => normalizePathEntry(entry.trim(), platform) === normalizedDir);
 		if (containsRequestedDir) return true;
-		return (
-			isDefaultBinDir &&
-			(line.includes("$HOME/.local/bin") || line.includes("${HOME}/.local/bin") || line.includes("~/.local/bin"))
-		);
+		const homeBinDirAliases = ["$HOME/.local/bin", "$" + "{HOME}/.local/bin", "~/.local/bin"];
+		return isDefaultBinDir && homeBinDirAliases.some((alias) => line.includes(alias));
 	});
 }
 

--- a/surfaces/cli/src/features/native-install.ts
+++ b/surfaces/cli/src/features/native-install.ts
@@ -26,6 +26,8 @@ export interface NativeInstallResult {
 	readonly target: string;
 	readonly installed: boolean;
 	readonly pathHint: string | null;
+	readonly pathProfile: string | null;
+	readonly pathPersisted: boolean;
 	readonly connectorAssetsDir: string | null;
 }
 
@@ -45,12 +47,84 @@ function binaryName(): string {
 	return process.platform === "win32" ? "signet.exe" : "signet";
 }
 
-function pathContains(dir: string): boolean {
-	const pathValue = process.env.PATH ?? "";
-	const separator = process.platform === "win32" ? ";" : ":";
-	const normalize = (value: string): string =>
-		process.platform === "win32" ? value.replaceAll("\\", "/").toLowerCase() : value.replaceAll("\\", "/");
+function normalizePathEntry(value: string, platform: NodeJS.Platform): string {
+	const normalized = platform === "win32" ? value.replaceAll("\\", "/").toLowerCase() : value.replaceAll("\\", "/");
+	return normalized.replace(/\/+$/, "");
+}
+
+function pathContains(dir: string, pathValue = process.env.PATH ?? "", platform = process.platform): boolean {
+	const separator = platform === "win32" ? ";" : ":";
+	const normalize = (value: string): string => normalizePathEntry(value, platform);
 	return pathValue.split(separator).some((entry) => normalize(entry) === normalize(dir));
+}
+
+function shellProfilePath(home: string, shell: string | undefined, platform: NodeJS.Platform): string | null {
+	if (platform === "win32") return null;
+	const shellName = shell ? basename(shell).toLowerCase() : "";
+	if (shellName === "zsh") return join(home, ".zprofile");
+	if (shellName === "bash") return join(home, ".bash_profile");
+	if (platform === "darwin" && shellName === "") return join(home, ".zprofile");
+	return null;
+}
+
+function shellPathEntry(binDir: string, home: string, platform: NodeJS.Platform): string {
+	const homeBinDir = join(home, ".local", "bin");
+	if (normalizePathEntry(binDir, platform) === normalizePathEntry(homeBinDir, platform)) return "$HOME/.local/bin";
+	return binDir.replaceAll('"', '\\"');
+}
+
+function profileContainsPath(contents: string, binDir: string, home: string, platform: NodeJS.Platform): boolean {
+	const normalizedDir = normalizePathEntry(binDir, platform);
+	const homeRelativeDir = normalizePathEntry(join(home, ".local", "bin"), platform);
+	return contents.split(/\r?\n/).some((line) => {
+		const trimmed = line.trim();
+		if (trimmed.startsWith("#") || !/^(?:export\s+)?PATH\s*=/.test(trimmed)) return false;
+		return (
+			line.includes(binDir) ||
+			line.includes(normalizedDir) ||
+			line.includes("$HOME/.local/bin") ||
+			line.includes("${HOME}/.local/bin") ||
+			line.includes("~/.local/bin") ||
+			line.includes(homeRelativeDir)
+		);
+	});
+}
+
+export interface NativeInstallPathOptions {
+	readonly home?: string;
+	readonly shell?: string;
+	readonly platform?: NodeJS.Platform;
+	readonly pathValue?: string;
+}
+
+export interface NativeInstallPathResult {
+	readonly profilePath: string | null;
+	readonly persisted: boolean;
+}
+
+export function persistNativeInstallPath(
+	binDir: string,
+	options: NativeInstallPathOptions = {},
+): NativeInstallPathResult {
+	const home = options.home ?? homedir();
+	const platform = options.platform ?? process.platform;
+	const profilePath = shellProfilePath(home, options.shell ?? process.env.SHELL, platform);
+	if (pathContains(binDir, options.pathValue, platform) || profilePath === null) {
+		return { profilePath: null, persisted: false };
+	}
+
+	let contents = "";
+	try {
+		if (existsSync(profilePath)) contents = readFileSync(profilePath, "utf8");
+		if (!profileContainsPath(contents, binDir, home, platform)) {
+			const entry = shellPathEntry(binDir, home, platform);
+			const prefix = contents.length > 0 && !contents.endsWith("\n") ? "\n" : "";
+			writeFileSync(profilePath, `${contents}${prefix}export PATH="${entry}:$PATH"\n`, "utf8");
+		}
+		return { profilePath, persisted: true };
+	} catch {
+		return { profilePath, persisted: false };
+	}
 }
 
 function verifySha256(path: string, expected: string): void {
@@ -130,13 +204,22 @@ export function installNativeBinary(options: NativeInstallOptions = {}): NativeI
 
 	const binDir = options.binDir ?? defaultBinDir();
 	const target = join(binDir, binaryName());
-	const pathHint = pathContains(binDir) ? null : binDir;
 
 	if (existsSync(target) && !options.force) {
 		const connectorAssetsDir = options.connectorAssets
 			? installConnectorAssetsFromManifest(options.connectorAssets, binDir)
 			: null;
-		return { source, target, installed: false, pathHint, connectorAssetsDir };
+		const pathPersistence = persistNativeInstallPath(binDir);
+		const pathHint = pathPersistence.persisted || pathContains(binDir) ? null : binDir;
+		return {
+			source,
+			target,
+			installed: false,
+			pathHint,
+			pathProfile: pathPersistence.profilePath,
+			pathPersisted: pathPersistence.persisted,
+			connectorAssetsDir,
+		};
 	}
 
 	// Validate and extract companion assets before replacing an existing
@@ -174,7 +257,17 @@ export function installNativeBinary(options: NativeInstallOptions = {}): NativeI
 		rmSync(tmp, { force: true });
 	}
 
-	return { source, target, installed: true, pathHint, connectorAssetsDir };
+	const pathPersistence = persistNativeInstallPath(binDir);
+	const pathHint = pathPersistence.persisted || pathContains(binDir) ? null : binDir;
+	return {
+		source,
+		target,
+		installed: true,
+		pathHint,
+		pathProfile: pathPersistence.profilePath,
+		pathPersisted: pathPersistence.persisted,
+		connectorAssetsDir,
+	};
 }
 
 export function printNativeInstallResult(result: NativeInstallResult, json = false): void {
@@ -194,7 +287,19 @@ export function printNativeInstallResult(result: NativeInstallResult, json = fal
 		console.log(chalk.green(`Installed connector assets to ${result.connectorAssetsDir}`));
 	}
 
+	if (result.pathPersisted && result.pathProfile) {
+		console.log(
+			chalk.green(
+				`PATH is configured in ${result.pathProfile}. Open a new shell or run \`source ${result.pathProfile}\`.`,
+			),
+		);
+	}
+
 	if (result.pathHint) {
-		console.log(chalk.yellow(`Add ${result.pathHint} to PATH if \`signet\` is not found.`));
+		if (result.pathProfile) {
+			console.log(chalk.yellow(`Could not update ${result.pathProfile}. Add ${result.pathHint} to PATH manually.`));
+		} else {
+			console.log(chalk.yellow(`Add ${result.pathHint} to PATH if \`signet\` is not found.`));
+		}
 	}
 }

--- a/surfaces/cli/src/features/native-install.ts
+++ b/surfaces/cli/src/features/native-install.ts
@@ -91,7 +91,10 @@ function profileContainsPath(contents: string, binDir: string, home: string, pla
 			.some((entry) => normalizePathEntry(entry.trim(), platform) === normalizedDir);
 		if (containsRequestedDir) return true;
 		const homeBinDirAliases = ["$HOME/.local/bin", "$" + "{HOME}/.local/bin", "~/.local/bin"];
-		return isDefaultBinDir && homeBinDirAliases.some((alias) => line.includes(alias));
+		return (
+			isDefaultBinDir &&
+			homeBinDirAliases.some((alias) => assignment.split(":").some((entry) => entry.trim() === alias))
+		);
 	});
 }
 


### PR DESCRIPTION
## Summary

Persist the native install directory in the user's shell profile when it is not already on PATH. This makes `signet install` usable from new macOS zsh and bash sessions instead of only printing a manual hint.

Fixes #1478.

## Changes

- Add idempotent PATH persistence to `~/.zprofile` for zsh and `~/.bash_profile` for bash.
- Skip profile changes when the install directory is already on PATH or already configured in the profile.
- Report the profile update and shell reload command, with a manual fallback when the profile cannot be updated.
- Add regression coverage for zsh, bash, duplicate prevention, and existing PATH entries.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A. This changes CLI output and shell-profile persistence, not a graphical UI.

## PR Readiness (MANDATORY)

- [ ] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [ ] Agent scoping verified on all new/changed data queries
- [ ] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [ ] Security checks applied to admin/mutation endpoints
- [ ] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable.

## Testing

- [x] `bun test surfaces/cli/src/features/native-install.test.ts`
- [x] `bunx biome check surfaces/cli/src/features/native-install.ts surfaces/cli/src/features/native-install.test.ts`
- [x] `git diff --check`
- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The focused regression test and Biome checks pass. The full CLI build is currently blocked by the repository's existing Bun bundler error (`cannot write multiple output files without an output directory`), and the root typecheck has pre-existing core/daemon export mismatches unrelated to this change. The implementation does not touch `web/marketing/public/install.sh`, so it does not overlap with the zsh compatibility work tracked in #1469.
