### PR TITLE
fix(daemon): retain one migration backup

### DIFF
--- a/platform/daemon/src/db-accessor.test.ts
+++ b/platform/daemon/src/db-accessor.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for the DB accessor (singleton read/write transaction wrapper).
  */
+import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -43,6 +44,33 @@ describe("DbAccessor", () => {
 		initDbAccessor(dbPath);
 		const acc = getDbAccessor();
 		expect(acc).toBeTruthy();
+		expect(readdirSync(join(dbPath, "..")).filter((name) => name.includes(".bak-v"))).toEqual([]);
+	});
+
+	test("retains the pre-migration backup when migration fails", () => {
+		const dbPath = tmpDbPath();
+		cleanupDirs.push(join(dbPath, ".."));
+
+		initDbAccessor(dbPath);
+		closeDbAccessor();
+
+		const db = new Database(dbPath);
+		try {
+			db.exec("DELETE FROM schema_migrations WHERE version = 128");
+			db.exec("DROP INDEX IF EXISTS idx_memory_jobs_diagnostics_status_created_at");
+			db.exec("DROP INDEX IF EXISTS idx_memory_jobs_diagnostics_error_updated_at");
+			db.exec("ALTER TABLE memory_jobs RENAME TO memory_jobs_original");
+			db.exec("CREATE TABLE memory_jobs (id TEXT PRIMARY KEY)");
+			db.exec("DROP TABLE memory_jobs_original");
+		} finally {
+			db.close();
+		}
+
+		expect(() => initDbAccessor(dbPath)).toThrow();
+
+		const backupNames = readdirSync(join(dbPath, "..")).filter((name) => name.includes(".bak-v"));
+		expect(backupNames).toHaveLength(1);
+		expect(statSync(join(dbPath, "..", backupNames[0])).size).toBe(statSync(dbPath).size);
 	});
 
 	test("withWriteTx provides working write access", () => {
@@ -234,14 +262,9 @@ describe("DbAccessor", () => {
 			log: () => {},
 		});
 
-		expect(operations[0]).toBe("unlink:test.db.bak-v58-1000");
-		expect(Array.from(files.keys()).sort()).toEqual([
-			"test.db.bak-v59-2000",
-			"test.db.bak-v60-3000",
-			"test.db.bak-v61-4000",
-			"test.db.bak-v62-5000",
-			"test.db.bak-v62-6000",
-		]);
+		expect(operations[0]).toBe("unlink:test.db.bak-v61-4000");
+		expect(Array.from(files.keys()).sort()).toEqual(["test.db.bak-v62-6000"]);
+		expect(files.size).toBe(1);
 	});
 
 	test("prunes oldest migration backup for disk headroom below retention cap", () => {
@@ -282,13 +305,13 @@ describe("DbAccessor", () => {
 			log: () => {},
 		});
 
-		expect(operations[0]).toBe("unlink:test.db.bak-v60-3000");
-		expect(Array.from(files.keys()).sort()).toEqual([
-			"test.db",
-			"test.db.bak-v61-4000",
-			"test.db.bak-v62-5000",
-			"test.db.bak-v63-6000",
-		]);
+		expect(operations[0]).toBe("unlink:test.db.bak-v61-4000");
+		expect(Array.from(files.keys()).sort()).toEqual(["test.db", "test.db.bak-v63-6000"]);
+		expect(
+			Array.from(files.entries())
+				.filter(([name]) => name.includes(".bak-v"))
+				.reduce((total, [, file]) => total + file.size, 0),
+		).toBe(8);
 	});
 
 	test("ignores migration backups removed during metadata collection", () => {

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -514,7 +514,7 @@ export function isVectorRuntimeUsable(): boolean {
 	return vecLoaded && vecLoadError === null;
 }
 
-const MAX_MIGRATION_BACKUPS = 5;
+const MAX_MIGRATION_BACKUPS = 1;
 
 interface MigrationBackupDeps {
 	readonly copyFileSync: (source: string, destination: string) => void;
@@ -632,7 +632,7 @@ export function backupBeforeMigration(
 	dbPath: string,
 	schemaVersion: number,
 	deps: MigrationBackupDeps = migrationBackupDeps,
-): void {
+): string {
 	prepareMigrationBackup(db, dbPath, deps);
 	const backupDest = migrationBackupDestination(dbPath, schemaVersion, deps);
 	try {
@@ -642,6 +642,7 @@ export function backupBeforeMigration(
 		throw migrationBackupError(backupDest, err);
 	}
 	finishMigrationBackup(dbPath, backupDest, deps);
+	return backupDest;
 }
 
 export async function backupBeforeMigrationAsync(
@@ -649,7 +650,7 @@ export async function backupBeforeMigrationAsync(
 	dbPath: string,
 	schemaVersion: number,
 	deps: MigrationBackupDeps = migrationBackupDeps,
-): Promise<void> {
+): Promise<string> {
 	prepareMigrationBackup(db, dbPath, deps);
 	const backupDest = migrationBackupDestination(dbPath, schemaVersion, deps);
 	try {
@@ -663,6 +664,7 @@ export async function backupBeforeMigrationAsync(
 		throw migrationBackupError(backupDest, err);
 	}
 	finishMigrationBackup(dbPath, backupDest, deps);
+	return backupDest;
 }
 
 function prepareMigrationBackup(db: { exec(sql: string): unknown }, dbPath: string, deps: MigrationBackupDeps): void {
@@ -676,10 +678,10 @@ function prepareMigrationBackup(db: { exec(sql: string): unknown }, dbPath: stri
 	// Make room for the incoming backup first. Otherwise retention only helps
 	// after copy succeeds, which can brick daemon startup on ENOSPC when older
 	// database-sized backups are present but still below the retention cap.
-	pruneMigrationBackups(dbPath, MAX_MIGRATION_BACKUPS - 1, deps);
+	pruneMigrationBackups(dbPath, MAX_MIGRATION_BACKUPS, deps);
 	const requiredBytes = fileSize(dbPath, deps);
 	if (requiredBytes !== null) {
-		pruneMigrationBackupsForHeadroom(dbPath, requiredBytes, 1, deps);
+		pruneMigrationBackupsForHeadroom(dbPath, requiredBytes, MAX_MIGRATION_BACKUPS, deps);
 	}
 }
 
@@ -717,6 +719,24 @@ function finishMigrationBackup(dbPath: string, backupDest: string, deps: Migrati
 	pruneMigrationBackups(dbPath, MAX_MIGRATION_BACKUPS, deps);
 }
 
+function verifyPostMigrationIntegrity(writeConn: SqliteDatabase): void {
+	const rows = writeConn.prepare("PRAGMA integrity_check").all() as ReadonlyArray<Record<string, unknown>>;
+	const messages = rows.map((row) => String(row.integrity_check ?? ""));
+	if (messages.length === 1 && messages[0] === "ok") return;
+	throw new Error(`Post-migration integrity check failed: ${messages.join("; ") || "no result"}`);
+}
+
+function cleanupMigrationBackupAfterSuccess(backupDest: string, deps: MigrationBackupDeps): void {
+	try {
+		deps.unlinkSync(backupDest);
+		deps.log(`[db-accessor] Removed verified migration backup: ${backupDest}`);
+	} catch (err) {
+		if (!isMissingPathError(err)) {
+			deps.log(`[db-accessor] Retained verified migration backup after cleanup failure: ${backupDest}`);
+		}
+	}
+}
+
 /**
  * Initialise the singleton accessor. Must be called once at daemon startup
  * before any route handler runs. Ensures the memory directory exists, opens
@@ -724,14 +744,14 @@ function finishMigrationBackup(dbPath: string, backupDest: string, deps: Migrati
  */
 export function initDbAccessor(path: string, opts?: { readonly agentsDir?: string }): void {
 	const writeConn = openDbAccessorConnection(path, opts);
-	backupBeforePendingMigrations(writeConn, path);
-	finishDbAccessorInit(writeConn, opts);
+	const migrationBackup = backupBeforePendingMigrations(writeConn, path);
+	finishDbAccessorInit(writeConn, opts, migrationBackup);
 }
 
 export async function initDbAccessorAsync(path: string, opts?: { readonly agentsDir?: string }): Promise<void> {
 	const writeConn = openDbAccessorConnection(path, opts);
-	await backupBeforePendingMigrationsAsync(writeConn, path);
-	finishDbAccessorInit(writeConn, opts);
+	const migrationBackup = await backupBeforePendingMigrationsAsync(writeConn, path);
+	finishDbAccessorInit(writeConn, opts, migrationBackup);
 }
 
 function openDbAccessorConnection(path: string, opts?: { readonly agentsDir?: string }): SqliteDatabase {
@@ -761,22 +781,34 @@ function readCurrentSchemaVersion(writeConn: SqliteDatabase): number {
 	return row && typeof row.version === "number" ? row.version : 0;
 }
 
-function backupBeforePendingMigrations(writeConn: SqliteDatabase, path: string): void {
+function backupBeforePendingMigrations(writeConn: SqliteDatabase, path: string): string | null {
 	if (existsSync(path) && hasPendingMigrations(toMigrationDb(writeConn))) {
-		backupBeforeMigration(writeConn, path, readCurrentSchemaVersion(writeConn));
+		return backupBeforeMigration(writeConn, path, readCurrentSchemaVersion(writeConn));
 	}
+	return null;
 }
 
-async function backupBeforePendingMigrationsAsync(writeConn: SqliteDatabase, path: string): Promise<void> {
+async function backupBeforePendingMigrationsAsync(writeConn: SqliteDatabase, path: string): Promise<string | null> {
 	if (existsSync(path) && hasPendingMigrations(toMigrationDb(writeConn))) {
-		await backupBeforeMigrationAsync(writeConn, path, readCurrentSchemaVersion(writeConn));
+		return await backupBeforeMigrationAsync(writeConn, path, readCurrentSchemaVersion(writeConn));
 	}
+	return null;
 }
 
-function finishDbAccessorInit(writeConn: SqliteDatabase, opts?: { readonly agentsDir?: string }): void {
+function finishDbAccessorInit(
+	writeConn: SqliteDatabase,
+	opts?: { readonly agentsDir?: string },
+	migrationBackup?: string | null,
+): void {
 	// Run schema migrations — this is the sole schema authority.
 	// Failures here are fatal: the daemon must not start on bad schema.
 	runMigrations(toMigrationDb(writeConn));
+	if (migrationBackup !== null && migrationBackup !== undefined) {
+		// Keep the rollback point until migration and a full integrity check both
+		// succeed. Any thrown error leaves it available for recovery.
+		verifyPostMigrationIntegrity(writeConn);
+		cleanupMigrationBackupAfterSuccess(migrationBackup, migrationBackupDeps);
+	}
 
 	// Record one-time conversion state only after migrations have succeeded.
 	// The conversion itself is deliberately post-ready because VACUUM can


### PR DESCRIPTION
## Summary

Fixes #1493 by keeping exactly one last-known-good pre-migration backup while migrations run, verifying database integrity afterward, and deleting the backup only after successful verification.

## Changes

- Retain one `.bak-v*` generation through migration and post-migration integrity verification.
- Prune older generations before each backup copy and enforce the existing `MAX_MIGRATION_BACKUPS` cap plus disk-headroom behavior.
- Preserve the backup when migration or integrity verification fails.
- Add byte-size and retention assertions for successful, failed, and disk-headroom paths.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [ ] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [ ] Agent scoping verified on all new/changed data queries
- [ ] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [ ] Security checks applied to admin/mutation endpoints
- [ ] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. This changes the backup lifecycle around existing migrations and does not add or alter a schema migration.

## Testing

- [x] `bun test platform/daemon/src/db-accessor.test.ts` passes: 27 pass, 0 fail, 50 expectations.
- [x] `bun run --filter '@signet/daemon' typecheck` passes.
- [x] `bun run --filter '@signet/core' build` passes.
- [x] `bun run --filter '@signet/daemon' build` passes.
- [x] `bunx biome check platform/daemon/src/db-accessor.ts platform/daemon/src/db-accessor.test.ts` passes with one pre-existing unused-function warning.
- [x] `git diff --check origin/main...HEAD` passes.
- [ ] `bun run lint` passes. The full repository lint still reports pre-existing diagnostics in unrelated files. The changed files pass the targeted Biome check above.
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The successful-init regression asserts that verified backups are removed. The failed-migration regression intentionally breaks migration 128 and asserts that exactly one backup remains with the same byte size as the database.

The `checklist-exception` label is applied because the remaining unchecked readiness items are not applicable to this daemon backup-lifecycle fix: it adds no spec/status change, data query, input/config surface, admin or mutation endpoint, or documentation contract. The full repository lint also remains blocked by unrelated pre-existing diagnostics, while the affected package typecheck, both affected builds, focused test suite, targeted Biome check, and diff check pass.

The branch was rebased from `5900cf92e15940bde6d8c31ce433b5cbaf0473fa` onto current `origin/main` at `35a3571f2bf48fba476ab1d9ff287514a13feba5`, producing current head `0f8ed5d0d68f1b77e6de0f3bb46a1235e5934f9d`. No code changes were made during the repair.
