### PR TITLE
fix(daemon): preflight database disk space

### DIFF
--- a/platform/daemon/src/db-accessor.test.ts
+++ b/platform/daemon/src/db-accessor.test.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, wri
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	DbSpacePreflightError,
 	DbWriteQueueFullError,
 	MAX_WRITE_QUEUE,
 	backupBeforeMigration,
@@ -267,53 +268,38 @@ describe("DbAccessor", () => {
 		expect(files.size).toBe(1);
 	});
 
-	test("prunes oldest migration backup for disk headroom below retention cap", () => {
+	test("blocks a migration backup before deleting retained backups when headroom is insufficient", () => {
 		const dbPath = tmpDbPath();
 		cleanupDirs.push(join(dbPath, ".."));
 		const dbDir = join(dbPath, "..");
 		writeFileSync(dbPath, "database");
 
-		let freeBytes = 4;
 		const files = new Map<string, { readonly mtimeMs: number; readonly size: number }>([
-			["test.db", { mtimeMs: 0, size: 8 }],
-			["test.db.bak-v60-3000", { mtimeMs: 3000, size: 8 }],
-			["test.db.bak-v61-4000", { mtimeMs: 4000, size: 8 }],
 			["test.db.bak-v62-5000", { mtimeMs: 5000, size: 8 }],
 		]);
 		const operations: string[] = [];
 
-		backupBeforeMigration({ exec: () => {} }, dbPath, 63, {
-			copyFileSync: (_source, dest) => {
-				operations.push(`copy:${String(dest).slice(dbDir.length + 1)}`);
-				expect(operations).toContain("unlink:test.db.bak-v60-3000");
-				files.set(String(dest).slice(dbDir.length + 1), { mtimeMs: 6000, size: 8 });
-				freeBytes -= 8;
-			},
-			readdirSync: () => Array.from(files.keys()).filter((name) => name !== "test.db"),
-			statSync: (path) => {
-				const name = String(path).slice(dbDir.length + 1);
-				return files.get(name) ?? { mtimeMs: 0, size: 0 };
-			},
-			statfsSync: () => ({ bavail: freeBytes, bsize: 1 }),
-			unlinkSync: (path) => {
-				const name = String(path).slice(dbDir.length + 1);
-				operations.push(`unlink:${name}`);
-				freeBytes += files.get(name)?.size ?? 0;
-				files.delete(name);
-			},
-			now: () => 6000,
-			log: () => {},
-		});
-
-		expect(operations[0]).toBe("unlink:test.db.bak-v61-4000");
-		expect(Array.from(files.keys()).sort()).toEqual(["test.db", "test.db.bak-v63-6000"]);
-		expect(
-			Array.from(files.entries())
-				.filter(([name]) => name.includes(".bak-v"))
-				.reduce((total, [, file]) => total + file.size, 0),
-		).toBe(8);
+		expect(() =>
+			backupBeforeMigration({ exec: () => {} }, dbPath, 63, {
+				copyFileSync: () => {
+					operations.push("copy");
+				},
+				readdirSync: () => Array.from(files.keys()),
+				statSync: (path) => {
+					const name = String(path).slice(dbDir.length + 1);
+					return files.get(name) ?? { mtimeMs: 0, size: 8 };
+				},
+				statfsSync: () => ({ bavail: 4, bsize: 1 }),
+				unlinkSync: (path) => {
+					operations.push(`unlink:${String(path).slice(dbDir.length + 1)}`);
+				},
+				now: () => 6000,
+				log: () => {},
+			}),
+		).toThrow(DbSpacePreflightError);
+		expect(operations).toEqual([]);
+		expect(Array.from(files.keys())).toEqual(["test.db.bak-v62-5000"]);
 	});
-
 	test("ignores migration backups removed during metadata collection", () => {
 		const dbPath = tmpDbPath();
 		cleanupDirs.push(join(dbPath, ".."));

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -30,10 +30,14 @@ import {
 	recreateMemoriesFts,
 	runMigrations,
 } from "@signet/core";
-import { convertToIncrementalVacuum, ensureVacuumConversionState } from "./db-vacuum";
+import { convertToIncrementalVacuum, DbSpacePreflightError, ensureVacuumConversionState } from "./db-vacuum";
+import type { DbSpaceMetrics } from "./db-vacuum";
+
 import { ensureEmbeddingIndexState } from "./embedding-index-state";
 import { loadMemoryConfig } from "./memory-config";
 import { observeDbLatency } from "./runtime-pressure";
+
+export { DbSpacePreflightError };
 
 const isBun = typeof (globalThis as Record<string, unknown>).Bun !== "undefined";
 const require = createRequire(import.meta.url);
@@ -596,36 +600,43 @@ function fileSize(path: string, deps: MigrationBackupDeps): number | null {
 	}
 }
 
-function pruneMigrationBackupsForHeadroom(
-	dbPath: string,
-	requiredBytes: number,
-	minimumRetainedBackups: number,
-	deps: MigrationBackupDeps,
-): void {
-	const dir = dirname(dbPath);
-	let free = availableBytes(dir, deps);
-	if (free === null || free >= requiredBytes) return;
+function isDbFullError(err: unknown): boolean {
+	if (!(err instanceof Error)) return false;
+	const code = "code" in err ? err.code : undefined;
+	return (
+		code === "ENOSPC" ||
+		code === "SQLITE_FULL" ||
+		err.message.includes("ENOSPC") ||
+		err.message.includes("SQLITE_FULL") ||
+		err.message.toLowerCase().includes("no space left on device") ||
+		err.message.toLowerCase().includes("database or disk is full")
+	);
+}
 
-	const backups = migrationBackups(dbPath, deps);
-	let retained = backups.length;
-	for (const old of [...backups].reverse()) {
-		if (free >= requiredBytes || retained <= minimumRetainedBackups) break;
-		try {
-			deps.unlinkSync(join(dir, old.name));
-			retained -= 1;
-			free = availableBytes(dir, deps) ?? free + old.size;
-			deps.log(`[db-accessor] Pruned old backup for migration headroom: ${old.name}`);
-		} catch {
-			// Best effort.
-		}
-	}
+function preflightMigrationBackupSpace(dbPath: string, deps: MigrationBackupDeps): DbSpaceMetrics | null {
+	const dbBytes = fileSize(dbPath, deps);
+	const freeBytes = availableBytes(dirname(dbPath), deps);
+	if (dbBytes === null || freeBytes === null) return null;
+	const metrics = { dbBytes, freeBytes, requiredBytes: dbBytes };
+	if (freeBytes < dbBytes) throw new DbSpacePreflightError("migration_backup", metrics);
+	return metrics;
+}
+
+function migrationBackupSpaceError(
+	dbPath: string,
+	metrics: DbSpaceMetrics,
+	deps: MigrationBackupDeps,
+	err: unknown,
+): DbSpacePreflightError {
+	const freeBytes = availableBytes(dirname(dbPath), deps) ?? metrics.freeBytes;
+	return new DbSpacePreflightError("migration_backup", { ...metrics, freeBytes }, err);
 }
 
 /**
  * Back up the database file before running migrations.
  * Flushes WAL first, then copies the main file. Prunes old
- * backups before copying so a full backup set does not require
- * temporary disk headroom for one extra database-sized file.
+ * backups after the space preflight, so a failed preflight keeps existing
+ * recovery backups intact.
  */
 export function backupBeforeMigration(
 	db: { exec(sql: string): unknown },
@@ -633,12 +644,15 @@ export function backupBeforeMigration(
 	schemaVersion: number,
 	deps: MigrationBackupDeps = migrationBackupDeps,
 ): string {
-	prepareMigrationBackup(db, dbPath, deps);
+	const space = prepareMigrationBackup(db, dbPath, deps);
 	const backupDest = migrationBackupDestination(dbPath, schemaVersion, deps);
 	try {
 		deps.copyFileSync(dbPath, backupDest);
 	} catch (err) {
 		cleanupPartialMigrationBackup(backupDest, deps);
+		if (isDbFullError(err) && space !== null) {
+			throw migrationBackupSpaceError(dbPath, space, deps, err);
+		}
 		throw migrationBackupError(backupDest, err);
 	}
 	finishMigrationBackup(dbPath, backupDest, deps);
@@ -651,7 +665,7 @@ export async function backupBeforeMigrationAsync(
 	schemaVersion: number,
 	deps: MigrationBackupDeps = migrationBackupDeps,
 ): Promise<string> {
-	prepareMigrationBackup(db, dbPath, deps);
+	const space = prepareMigrationBackup(db, dbPath, deps);
 	const backupDest = migrationBackupDestination(dbPath, schemaVersion, deps);
 	try {
 		if (deps === migrationBackupDeps) {
@@ -661,28 +675,34 @@ export async function backupBeforeMigrationAsync(
 		}
 	} catch (err) {
 		await cleanupPartialMigrationBackupAsync(backupDest, deps);
+		if (isDbFullError(err) && space !== null) {
+			throw migrationBackupSpaceError(dbPath, space, deps, err);
+		}
 		throw migrationBackupError(backupDest, err);
 	}
 	finishMigrationBackup(dbPath, backupDest, deps);
 	return backupDest;
 }
 
-function prepareMigrationBackup(db: { exec(sql: string): unknown }, dbPath: string, deps: MigrationBackupDeps): void {
-	// Flush WAL so the .db file is self-contained.
+function prepareMigrationBackup(
+	db: { exec(sql: string): unknown },
+	dbPath: string,
+	deps: MigrationBackupDeps,
+): DbSpaceMetrics | null {
+	// Flush WAL so the .db file is self-contained before measuring the copy.
 	try {
 		db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
 	} catch {
 		// Non-fatal — backup still useful even with WAL.
 	}
 
-	// Make room for the incoming backup first. Otherwise retention only helps
-	// after copy succeeds, which can brick daemon startup on ENOSPC when older
-	// database-sized backups are present but still below the retention cap.
+	// Check space before pruning or copying. A failed preflight must not remove
+	// the only retained backup that the operator may need for recovery.
+	const space = preflightMigrationBackupSpace(dbPath, deps);
+
+	// Make room for the incoming backup only after the preflight has passed.
 	pruneMigrationBackups(dbPath, MAX_MIGRATION_BACKUPS, deps);
-	const requiredBytes = fileSize(dbPath, deps);
-	if (requiredBytes !== null) {
-		pruneMigrationBackupsForHeadroom(dbPath, requiredBytes, MAX_MIGRATION_BACKUPS, deps);
-	}
+	return space;
 }
 
 function migrationBackupDestination(dbPath: string, schemaVersion: number, deps: MigrationBackupDeps): string {
@@ -1165,7 +1185,9 @@ function createAccessor(writeConn: SqliteDatabase): DbAccessor {
 	}
 
 	function runVacuumConversion(): boolean {
-		return runWriteOperation(() => convertToIncrementalVacuum(toMigrationDb(writeConn)));
+		return runWriteOperation(() =>
+			convertToIncrementalVacuum(toMigrationDb(writeConn), { dbPath: dbPath ?? undefined }),
+		);
 	}
 
 	function enqueueWrite<T>(run: () => T): Promise<T> {

--- a/platform/daemon/src/db-vacuum.test.ts
+++ b/platform/daemon/src/db-vacuum.test.ts
@@ -178,6 +178,45 @@ describe("db-vacuum (#1139)", () => {
 		expect(operations).toContain("VACUUM");
 	});
 
+	it("normalizes SQLite FULL errors when the post-failure space probe fails", () => {
+		let statfsCalls = 0;
+		const error = Object.assign(new Error("database or disk is full"), { code: "SQLITE_FULL" });
+		const pragmaDb = {
+			exec(sql: string): void {
+				if (sql === "VACUUM") throw error;
+			},
+			prepare(sql: string) {
+				return {
+					get: () => (sql === "PRAGMA auto_vacuum" ? { auto_vacuum: 0 } : { freelist_count: 0 }),
+					all: () => [],
+					run: () => undefined,
+				};
+			},
+		};
+
+		let thrown: unknown;
+		try {
+			convertToIncrementalVacuum(pragmaDb, {
+				dbPath: "/tmp/test.db",
+				deps: {
+					statSync: () => ({ size: 8 }),
+					statfsSync: () => {
+						statfsCalls += 1;
+						if (statfsCalls === 2) throw new Error("statfs unavailable");
+						return { bavail: 16, bsize: 1 };
+					},
+				},
+			});
+		} catch (caught) {
+			thrown = caught;
+		}
+
+		expect(thrown).toBeInstanceOf(DbSpacePreflightError);
+		expect((thrown as DbSpacePreflightError).cause).toBe(error);
+		expect((thrown as DbSpacePreflightError).metrics.requiredBytes).toBe(16);
+		expect(statfsCalls).toBe(2);
+	});
+
 	it("convertToIncrementalVacuum is idempotent (does not re-run VACUUM)", () => {
 		// First conversion.
 		expect(convertToIncrementalVacuum(toPragmaDb(db))).toBe(true);

--- a/platform/daemon/src/db-vacuum.test.ts
+++ b/platform/daemon/src/db-vacuum.test.ts
@@ -17,6 +17,7 @@ import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import {
 	convertToIncrementalVacuum,
+	DbSpacePreflightError,
 	getFreePageRatio,
 	getVacuumConversionStatus,
 	startVacuumConversionWorker,
@@ -113,6 +114,68 @@ describe("db-vacuum (#1139)", () => {
 
 		// Silence unused warnings.
 		expect(freeBefore).toBeDefined();
+	});
+
+	it("does not run VACUUM when two database copies do not fit", () => {
+		const operations: string[] = [];
+		const pragmaDb = {
+			exec(sql: string): void {
+				operations.push(sql);
+			},
+			prepare(sql: string) {
+				return {
+					get: () => (sql === "PRAGMA auto_vacuum" ? { auto_vacuum: 0 } : { freelist_count: 0 }),
+					all: () => [],
+					run: () => undefined,
+				};
+			},
+		};
+		expect(() =>
+			convertToIncrementalVacuum(pragmaDb, {
+				dbPath: "/tmp/test.db",
+				deps: {
+					statSync: () => ({ size: 8 }),
+					statfsSync: () => ({ bavail: 8, bsize: 1 }),
+				},
+			}),
+		).toThrow(DbSpacePreflightError);
+		expect(operations).toEqual([]);
+	});
+
+	it("normalizes SQLite FULL errors from VACUUM", () => {
+		const operations: string[] = [];
+		const error = Object.assign(new Error("database or disk is full"), { code: "SQLITE_FULL" });
+		const pragmaDb = {
+			exec(sql: string): void {
+				operations.push(sql);
+				if (sql === "VACUUM") throw error;
+			},
+			prepare(sql: string) {
+				return {
+					get: () => (sql === "PRAGMA auto_vacuum" ? { auto_vacuum: 0 } : { freelist_count: 0 }),
+					all: () => [],
+					run: () => undefined,
+				};
+			},
+		};
+
+		let thrown: unknown;
+		try {
+			convertToIncrementalVacuum(pragmaDb, {
+				dbPath: "/tmp/test.db",
+				deps: {
+					statSync: () => ({ size: 8 }),
+					statfsSync: () => ({ bavail: 16, bsize: 1 }),
+				},
+			});
+		} catch (caught) {
+			thrown = caught;
+		}
+		expect(thrown).toBeInstanceOf(DbSpacePreflightError);
+		expect((thrown as DbSpacePreflightError).operation).toBe("vacuum");
+		expect((thrown as DbSpacePreflightError).metrics.requiredBytes).toBe(16);
+		expect((thrown as DbSpacePreflightError).message).toContain("Cause: database or disk is full");
+		expect(operations).toContain("VACUUM");
 	});
 
 	it("convertToIncrementalVacuum is idempotent (does not re-run VACUUM)", () => {

--- a/platform/daemon/src/db-vacuum.ts
+++ b/platform/daemon/src/db-vacuum.ts
@@ -7,6 +7,8 @@
  * runs after the daemon is ready and is single-flight across the worker.
  */
 
+import { statSync, statfsSync } from "node:fs";
+import { dirname } from "node:path";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import { logger } from "./logger";
 
@@ -14,6 +16,69 @@ import { logger } from "./logger";
 const VACUUM_CONVERSION_TABLE = "_signet_vacuum_converted";
 const VACUUM_CONVERSION_STATE_TABLE = "_signet_vacuum_conversion";
 const MAX_CONVERSION_ATTEMPTS = 3;
+
+export type DbSpaceOperation = "migration_backup" | "vacuum";
+
+export interface DbSpaceMetrics {
+	readonly dbBytes: number;
+	readonly freeBytes: number;
+	readonly requiredBytes: number;
+}
+
+export class DbSpacePreflightError extends Error {
+	readonly code = "DB_SPACE_PREFLIGHT_FAILED" as const;
+
+	constructor(
+		readonly operation: DbSpaceOperation,
+		readonly metrics: DbSpaceMetrics,
+		cause?: unknown,
+	) {
+		const label = operation === "migration_backup" ? "migration backup" : "VACUUM scratch space";
+		super(
+			`[${operation}] ${label} blocked: insufficient disk space. Database size: ${metrics.dbBytes} bytes; free: ${metrics.freeBytes} bytes; required: ${metrics.requiredBytes} bytes. Free disk space and retry.${cause === undefined ? "" : ` Cause: ${cause instanceof Error ? cause.message : String(cause)}`}`,
+		);
+		this.name = "DbSpacePreflightError";
+	}
+}
+
+export interface DbSpaceDeps {
+	readonly statSync: (path: string) => { readonly size: number };
+	readonly statfsSync: (path: string) => { readonly bavail: number; readonly bsize: number };
+}
+
+const dbSpaceDeps: DbSpaceDeps = { statSync, statfsSync };
+
+function isDbFullError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const code = "code" in error ? error.code : undefined;
+	return (
+		code === "ENOSPC" ||
+		code === "SQLITE_FULL" ||
+		error.message.includes("ENOSPC") ||
+		error.message.includes("SQLITE_FULL") ||
+		error.message.toLowerCase().includes("no space left on device") ||
+		error.message.toLowerCase().includes("database or disk is full")
+	);
+}
+
+function measureDbSpace(dbPath: string, deps: DbSpaceDeps): DbSpaceMetrics | null {
+	try {
+		const dbBytes = deps.statSync(dbPath).size;
+		const directory = dirname(dbPath);
+		const stats = deps.statfsSync(directory);
+		const freeBytes = stats.bavail * stats.bsize;
+		// SQLite's VACUUM documentation says that as much as twice the original
+		// database size may be required while the rebuilt file is in progress.
+		return { dbBytes, freeBytes, requiredBytes: dbBytes * 2 };
+	} catch {
+		return null;
+	}
+}
+
+function assertDbSpace(operation: DbSpaceOperation, dbPath: string, deps: DbSpaceDeps): void {
+	const metrics = measureDbSpace(dbPath, deps);
+	if (metrics && metrics.freeBytes < metrics.requiredBytes) throw new DbSpacePreflightError(operation, metrics);
+}
 
 /** Read-only pragma surface. */
 export interface PragmaReadDb {
@@ -266,12 +331,17 @@ export function getFreePageRatio(db: PragmaReadDb): number {
  * This function must only be called by the post-ready worker. It deliberately
  * does not run from either synchronous or asynchronous DB initialization.
  */
-export function convertToIncrementalVacuum(db: PragmaDb): boolean {
+export function convertToIncrementalVacuum(
+	db: PragmaDb,
+	options: { readonly dbPath?: string; readonly deps?: DbSpaceDeps } = {},
+): boolean {
 	const mode = getAutoVacuumMode(db);
 
 	// 2 = INCREMENTAL. Already converted or fresh DB created after the fix.
 	if (mode === 2) return false;
 	if (hasTable(db, VACUUM_CONVERSION_TABLE)) return false;
+
+	if (options.dbPath) assertDbSpace("vacuum", options.dbPath, options.deps ?? dbSpaceDeps);
 
 	// Set the desired mode BEFORE VACUUM so the rebuilt file uses it.
 	db.exec("PRAGMA auto_vacuum = INCREMENTAL");
@@ -286,7 +356,15 @@ export function convertToIncrementalVacuum(db: PragmaDb): boolean {
 	logger.info("db-vacuum", "Running one-time VACUUM after readiness; large databases may take several minutes");
 
 	const startedAt = Date.now();
-	db.exec("VACUUM");
+	try {
+		db.exec("VACUUM");
+	} catch (error) {
+		if (options.dbPath && isDbFullError(error)) {
+			const metrics = measureDbSpace(options.dbPath, options.deps ?? dbSpaceDeps);
+			if (metrics) throw new DbSpacePreflightError("vacuum", metrics, error);
+		}
+		throw error;
+	}
 	const elapsedMs = Date.now() - startedAt;
 
 	const freelistAfter = db.prepare("PRAGMA freelist_count").get() as { freelist_count?: number } | undefined;

--- a/platform/daemon/src/db-vacuum.ts
+++ b/platform/daemon/src/db-vacuum.ts
@@ -36,6 +36,7 @@ export class DbSpacePreflightError extends Error {
 		const label = operation === "migration_backup" ? "migration backup" : "VACUUM scratch space";
 		super(
 			`[${operation}] ${label} blocked: insufficient disk space. Database size: ${metrics.dbBytes} bytes; free: ${metrics.freeBytes} bytes; required: ${metrics.requiredBytes} bytes. Free disk space and retry.${cause === undefined ? "" : ` Cause: ${cause instanceof Error ? cause.message : String(cause)}`}`,
+			cause === undefined ? undefined : { cause },
 		);
 		this.name = "DbSpacePreflightError";
 	}
@@ -75,10 +76,13 @@ function measureDbSpace(dbPath: string, deps: DbSpaceDeps): DbSpaceMetrics | nul
 	}
 }
 
-function assertDbSpace(operation: DbSpaceOperation, dbPath: string, deps: DbSpaceDeps): void {
+function assertDbSpace(operation: DbSpaceOperation, dbPath: string, deps: DbSpaceDeps): DbSpaceMetrics | null {
 	const metrics = measureDbSpace(dbPath, deps);
 	if (metrics && metrics.freeBytes < metrics.requiredBytes) throw new DbSpacePreflightError(operation, metrics);
+	return metrics;
 }
+
+const UNKNOWN_DB_SPACE_METRICS: DbSpaceMetrics = { dbBytes: 0, freeBytes: 0, requiredBytes: 0 };
 
 /** Read-only pragma surface. */
 export interface PragmaReadDb {
@@ -341,7 +345,7 @@ export function convertToIncrementalVacuum(
 	if (mode === 2) return false;
 	if (hasTable(db, VACUUM_CONVERSION_TABLE)) return false;
 
-	if (options.dbPath) assertDbSpace("vacuum", options.dbPath, options.deps ?? dbSpaceDeps);
+	const preflightMetrics = options.dbPath ? assertDbSpace("vacuum", options.dbPath, options.deps ?? dbSpaceDeps) : null;
 
 	// Set the desired mode BEFORE VACUUM so the rebuilt file uses it.
 	db.exec("PRAGMA auto_vacuum = INCREMENTAL");
@@ -360,8 +364,9 @@ export function convertToIncrementalVacuum(
 		db.exec("VACUUM");
 	} catch (error) {
 		if (options.dbPath && isDbFullError(error)) {
-			const metrics = measureDbSpace(options.dbPath, options.deps ?? dbSpaceDeps);
-			if (metrics) throw new DbSpacePreflightError("vacuum", metrics, error);
+			const metrics =
+				measureDbSpace(options.dbPath, options.deps ?? dbSpaceDeps) ?? preflightMetrics ?? UNKNOWN_DB_SPACE_METRICS;
+			throw new DbSpacePreflightError("vacuum", metrics, error);
 		}
 		throw error;
 	}


### PR DESCRIPTION
## Summary

Prevent startup from attempting migration backups or the one-time VACUUM when the database directory does not have enough free space for a database-sized temporary copy. Fail with a typed, actionable error instead of pruning recovery backups or entering an opaque startup failure path.

## Changes

- Add statfs-backed database/free/required byte measurements and `DbSpacePreflightError`.
- Preflight migration backup space before pruning or copying, preserving the main database and retained backups when blocked.
- Preflight VACUUM scratch space before changing `auto_vacuum`, and normalize runtime ENOSPC failures into the same actionable error shape.
- Add regression coverage for blocked migration copies, blocked VACUUM, and clear ENOSPC diagnostics.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No schema migration files are touched. This changes only pre-migration backup and post-migration VACUUM startup behavior.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Targeted proof run locally:

- `bun test platform/daemon/src/db-accessor.test.ts platform/daemon/src/db-vacuum.test.ts` (34 pass, 0 fail)
- `bun run --filter '@signet/core' build` (pass)
- `bun run --filter '@signet/daemon' build` (pass)
- `bun run --filter '@signet/daemon' typecheck` (pass)
- `bunx biome check platform/daemon/src/db-accessor.ts platform/daemon/src/db-vacuum.ts platform/daemon/src/db-accessor.test.ts platform/daemon/src/db-vacuum.test.ts` (pass)
- `git diff --check` (pass)

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The branch was rebased onto current `origin/main` before push. The daemon startup path already records fatal initialization errors in its lifecycle artifact; the new typed error supplies database size, free space, required space, operation, and remediation text for CLI/operator diagnostics. The checked PR-readiness items that do not apply to this internal database startup path were validated as not applicable: no new data queries, admin/mutation endpoints, or public API/spec surface are introduced. The full root test suite and live daemon path were not run in this worker.
