### PR TITLE
fix(daemon): defer legacy VACUUM conversion

### DIFF
--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -50,6 +50,7 @@ import {
 import { listConnectors } from "./connectors/registry";
 import { clearAllPresence, reconcileAcpDeliveries } from "./cross-agent";
 import { closeDbAccessor, getDbAccessor, getVectorRuntimeStatus, initDbAccessorAsync } from "./db-accessor";
+import { type VacuumConversionHandle, startVacuumConversionWorker } from "./db-vacuum";
 import { getQueueDiagnosticsSnapshot, getQueuePressureSnapshot } from "./diagnostics-queue";
 import { fetchEmbedding } from "./embedding-fetch";
 import { type EmbeddingIndexMigrationHandle, startEmbeddingIndexMigration } from "./embedding-index-migration";
@@ -253,6 +254,7 @@ let dreamingWorkerHandle: DreamingWorkerHandle | null = null;
 let reflectionWorkerHandle: ReflectionWorkerHandle | null = null;
 let embeddingTrackerHandle: EmbeddingTrackerHandle | null = null;
 let embeddingIndexMigrationHandle: EmbeddingIndexMigrationHandle | null = null;
+let vacuumConversionHandle: VacuumConversionHandle | null = null;
 let embeddingPromotionRestart: Promise<void> | null = null;
 let skillReconcilerHandle: ReturnType<typeof startReconciler> | null = null;
 let schedulerHandle: { stop(): Promise<void> } | null = null;
@@ -1270,6 +1272,10 @@ function readPipelineMode(cfg: ResolvedMemoryConfig["pipelineV2"]): string {
 }
 
 async function stopPipelineRuntime(): Promise<void> {
+	if (vacuumConversionHandle) {
+		vacuumConversionHandle.stop();
+		vacuumConversionHandle = null;
+	}
 	if (skillReconcilerHandle) {
 		try {
 			await Promise.resolve(skillReconcilerHandle.stop());
@@ -2347,6 +2353,7 @@ async function main() {
 		logger.info("daemon", "Daemon ready");
 		logFdSnapshot("server-ready");
 		writeDaemonLifecycle(AGENTS_DIR, buildLifecycleRecord("running"));
+		vacuumConversionHandle = startVacuumConversionWorker(getDbAccessor());
 
 		const healthStampPath = join(DAEMON_DIR, "last-healthy-start");
 		try {

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -30,7 +30,7 @@ import {
 	recreateMemoriesFts,
 	runMigrations,
 } from "@signet/core";
-import { convertToIncrementalVacuum } from "./db-vacuum";
+import { convertToIncrementalVacuum, ensureVacuumConversionState } from "./db-vacuum";
 import { ensureEmbeddingIndexState } from "./embedding-index-state";
 import { loadMemoryConfig } from "./memory-config";
 import { observeDbLatency } from "./runtime-pressure";
@@ -167,6 +167,9 @@ export interface DbAccessor {
 	/** Admit incremental vacuum through the bounded async writer queue. */
 	incrementalVacuumAsync?(): Promise<number>;
 
+	/** Run the one-time legacy auto_vacuum conversion outside a transaction. */
+	vacuumConversion?(): boolean;
+
 	/** Return bounded local diagnostics for the writer admission path. */
 	getWritePressure?(): WritePressure;
 
@@ -212,8 +215,8 @@ let vecLoadError: string | null = null;
 
 function configurePragmas(db: SqliteDatabase): void {
 	// Set auto_vacuum = INCREMENTAL before any tables are created. This only
-	// affects fresh databases; existing databases are converted by
-	// convertToIncrementalVacuum in finishDbAccessorInit (#1139).
+	// affects fresh databases; existing databases are converted by the
+	// post-ready vacuum worker after finishDbAccessorInit (#1139, #1493).
 	db.exec("PRAGMA auto_vacuum = INCREMENTAL");
 	db.exec("PRAGMA journal_mode = WAL");
 	db.exec("PRAGMA busy_timeout = 5000");
@@ -775,11 +778,10 @@ function finishDbAccessorInit(writeConn: SqliteDatabase, opts?: { readonly agent
 	// Failures here are fatal: the daemon must not start on bad schema.
 	runMigrations(toMigrationDb(writeConn));
 
-	// One-time conversion of legacy databases (auto_vacuum = 0) to
-	// incremental mode. Runs VACUUM outside any transaction. New databases
-	// already have auto_vacuum = INCREMENTAL from configurePragmas, so this
-	// is a no-op for them (#1139).
-	convertToIncrementalVacuum(toMigrationDb(writeConn));
+	// Record one-time conversion state only after migrations have succeeded.
+	// The conversion itself is deliberately post-ready because VACUUM can
+	// block the event loop for minutes on a large legacy database (#1493).
+	ensureVacuumConversionState(toMigrationDb(writeConn));
 
 	// Ensure FTS5 virtual table exists — may be missing on upgrades from
 	// older installs where the table was dropped or never created.
@@ -1130,6 +1132,10 @@ function createAccessor(writeConn: SqliteDatabase): DbAccessor {
 		});
 	}
 
+	function runVacuumConversion(): boolean {
+		return runWriteOperation(() => convertToIncrementalVacuum(toMigrationDb(writeConn)));
+	}
+
 	function enqueueWrite<T>(run: () => T): Promise<T> {
 		if (closed) return Promise.reject(new Error("DbAccessor is closed"));
 		if (writeQueue.length >= MAX_WRITE_QUEUE) return Promise.reject(new DbWriteQueueFullError());
@@ -1188,6 +1194,11 @@ function createAccessor(writeConn: SqliteDatabase): DbAccessor {
 
 		incrementalVacuumAsync(): Promise<number> {
 			return enqueueWrite(runIncrementalVacuum);
+		},
+
+		vacuumConversion(): boolean {
+			if (closed) throw new Error("DbAccessor is closed");
+			return runVacuumConversion();
 		},
 
 		getWritePressure(): WritePressure {

--- a/platform/daemon/src/db-vacuum.test.ts
+++ b/platform/daemon/src/db-vacuum.test.ts
@@ -11,7 +11,16 @@
 
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { convertToIncrementalVacuum, getFreePageRatio } from "./db-vacuum";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import {
+	convertToIncrementalVacuum,
+	getFreePageRatio,
+	getVacuumConversionStatus,
+	startVacuumConversionWorker,
+} from "./db-vacuum";
 
 // The functions accept a narrower interface; bun:sqlite.Database satisfies it.
 type PragmaDb = Parameters<typeof convertToIncrementalVacuum>[0];
@@ -124,5 +133,94 @@ describe("db-vacuum (#1139)", () => {
 			.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = '_signet_vacuum_converted'")
 			.get();
 		expect(marker).toBeNull();
+	});
+});
+
+function legacyDbPath(): { readonly dir: string; readonly path: string } {
+	const dir = mkdtempSync(join(tmpdir(), "signet-vacuum-test-"));
+	const path = join(dir, "memories.db");
+	const db = new Database(path);
+	db.exec("PRAGMA auto_vacuum = NONE; CREATE TABLE legacy_data (value TEXT); INSERT INTO legacy_data VALUES ('keep');");
+	db.close();
+	return { dir, path };
+}
+
+describe("deferred vacuum conversion (#1493)", () => {
+	let dir = "";
+
+	afterEach(() => {
+		closeDbAccessor();
+		if (dir) rmSync(dir, { recursive: true, force: true });
+		dir = "";
+	});
+
+	it("normal initialization records pending work without running VACUUM", () => {
+		const db = legacyDbPath();
+		dir = db.dir;
+		initDbAccessor(db.path);
+
+		expect(getVacuumConversionStatus(getDbAccessor())).toMatchObject({
+			state: "pending",
+			attempts: 0,
+		});
+		const mode = getDbAccessor().withReadDb((readDb) => {
+			return (readDb.prepare("PRAGMA auto_vacuum").get() as { auto_vacuum: number }).auto_vacuum;
+		});
+		expect(mode).toBe(0);
+	});
+
+	it("conversion completes exactly once through the post-ready worker", async () => {
+		const db = legacyDbPath();
+		dir = db.dir;
+		initDbAccessor(db.path);
+		const worker = startVacuumConversionWorker(getDbAccessor(), { startImmediately: false });
+
+		const completed = await worker.run();
+		expect(completed.state).toBe("completed");
+		expect(completed.attempts).toBe(1);
+		expect(await worker.run()).toMatchObject({ state: "completed", attempts: 1 });
+
+		const markerCount = getDbAccessor().withReadDb(
+			(readDb) =>
+				(readDb.prepare("SELECT COUNT(*) AS count FROM _signet_vacuum_converted").get() as { count: number }).count,
+		);
+		expect(markerCount).toBe(1);
+	});
+
+	it("a killed or failed conversion remains retryable without blocking initialization", async () => {
+		const db = legacyDbPath();
+		dir = db.dir;
+		initDbAccessor(db.path);
+		getDbAccessor().withWriteTx((writeDb) => {
+			writeDb
+				.prepare(
+					"UPDATE _signet_vacuum_conversion SET state = 'running', attempts = 1, started_at = ?, updated_at = ? WHERE id = 1",
+				)
+				.run(new Date().toISOString(), new Date().toISOString());
+		});
+		closeDbAccessor();
+		initDbAccessor(db.path);
+		expect(getVacuumConversionStatus(getDbAccessor())).toMatchObject({ state: "pending", attempts: 1 });
+
+		const accessor = getDbAccessor();
+		const originalConversion = accessor.vacuumConversion;
+		accessor.vacuumConversion = () => {
+			throw new Error("simulated conversion failure");
+		};
+		const worker = startVacuumConversionWorker(accessor, { startImmediately: false });
+		const failed = await worker.run();
+		accessor.vacuumConversion = originalConversion;
+		expect(failed).toMatchObject({ state: "failed", attempts: 2, lastError: "simulated conversion failure" });
+
+		closeDbAccessor();
+		initDbAccessor(db.path);
+		expect(getVacuumConversionStatus(getDbAccessor())).toMatchObject({ state: "pending", attempts: 2 });
+
+		getDbAccessor().withWriteTx((writeDb) => {
+			writeDb.prepare("UPDATE _signet_vacuum_conversion SET state = 'running', attempts = 3 WHERE id = 1").run();
+		});
+		closeDbAccessor();
+		initDbAccessor(db.path);
+		expect(getVacuumConversionStatus(getDbAccessor())).toMatchObject({ state: "failed", attempts: 3 });
 	});
 });

--- a/platform/daemon/src/db-vacuum.ts
+++ b/platform/daemon/src/db-vacuum.ts
@@ -1,26 +1,22 @@
 /**
  * SQLite free-page reclamation (#1139).
  *
- * Without auto_vacuum or periodic VACUUM, free pages from DROP/DELETE/migration
- * operations accumulate forever. A workspace with 5k memories grew to 29GB.
- *
- * Strategy:
- * 1. New databases get PRAGMA auto_vacuum = INCREMENTAL in configurePragmas.
- * 2. Existing databases (auto_vacuum = 0) get a one-time VACUUM to convert
- *    them to incremental mode. This is expensive but bounded and runs once.
- * 3. After free-page-heavy operations (embedding index promotion), run
- *    PRAGMA incremental_vacuum to reclaim pages immediately.
- * 4. The maintenance worker periodically checks freelist_count and runs
- *    incremental_vacuum when free pages exceed 20% of total pages.
+ * Existing databases need a one-time VACUUM to switch from the legacy
+ * auto_vacuum=0 mode to incremental mode. That rebuild can take minutes on a
+ * large database, so startup only records durable work state. The conversion
+ * runs after the daemon is ready and is single-flight across the worker.
  */
 
+import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import { logger } from "./logger";
 
 /** Marker table name for the one-time VACUUM conversion. */
 const VACUUM_CONVERSION_TABLE = "_signet_vacuum_converted";
+const VACUUM_CONVERSION_STATE_TABLE = "_signet_vacuum_conversion";
+const MAX_CONVERSION_ATTEMPTS = 3;
 
 /** Read-only pragma surface. */
-interface PragmaReadDb {
+export interface PragmaReadDb {
 	prepare(sql: string): {
 		get(...args: unknown[]): Record<string, unknown> | undefined;
 		all(...args: unknown[]): Record<string, unknown>[];
@@ -28,7 +24,7 @@ interface PragmaReadDb {
 }
 
 /** Read/write pragma surface for conversion operations. */
-interface PragmaDb extends PragmaReadDb {
+export interface PragmaDb extends PragmaReadDb {
 	exec(sql: string): void;
 	prepare(sql: string): {
 		run(...args: unknown[]): unknown;
@@ -37,10 +33,223 @@ interface PragmaDb extends PragmaReadDb {
 	};
 }
 
-/** Check whether the database has incremental auto_vacuum enabled. */
+export type VacuumConversionState = "not_required" | "pending" | "running" | "completed" | "failed";
+
+export interface VacuumConversionStatus {
+	readonly state: VacuumConversionState;
+	readonly attempts: number;
+	readonly maxAttempts: number;
+	readonly requestedAt: string | null;
+	readonly startedAt: string | null;
+	readonly completedAt: string | null;
+	readonly updatedAt: string | null;
+	readonly lastError: string | null;
+}
+
+export interface VacuumConversionHandle {
+	readonly running: boolean;
+	stop(): void;
+	run(): Promise<VacuumConversionStatus>;
+}
+
+const STATE_TABLE_SQL = `
+	CREATE TABLE IF NOT EXISTS ${VACUUM_CONVERSION_STATE_TABLE} (
+		id INTEGER PRIMARY KEY CHECK (id = 1),
+		state TEXT NOT NULL CHECK (state IN ('pending', 'running', 'completed', 'failed')),
+		attempts INTEGER NOT NULL DEFAULT 0,
+		requested_at TEXT NOT NULL,
+		started_at TEXT,
+		completed_at TEXT,
+		updated_at TEXT NOT NULL,
+		last_error TEXT
+	)
+`;
+
+function now(): string {
+	return new Date().toISOString();
+}
+
+function stringValue(value: unknown): string | null {
+	return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function numberValue(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0;
+}
+
+function hasTable(db: PragmaReadDb, name: string): boolean {
+	return db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").all(name).length > 0;
+}
+
 function getAutoVacuumMode(db: PragmaReadDb): number {
 	const row = db.prepare("PRAGMA auto_vacuum").get() as { auto_vacuum?: number } | undefined;
 	return typeof row?.auto_vacuum === "number" ? row.auto_vacuum : 0;
+}
+
+function stateFromRow(row: Record<string, unknown> | undefined): VacuumConversionStatus {
+	if (!row) {
+		return {
+			state: "not_required",
+			attempts: 0,
+			maxAttempts: MAX_CONVERSION_ATTEMPTS,
+			requestedAt: null,
+			startedAt: null,
+			completedAt: null,
+			updatedAt: null,
+			lastError: null,
+		};
+	}
+	const rawState = row.state;
+	const state: VacuumConversionState =
+		rawState === "pending" || rawState === "running" || rawState === "completed" || rawState === "failed"
+			? rawState
+			: "failed";
+	return {
+		state,
+		attempts: numberValue(row.attempts),
+		maxAttempts: MAX_CONVERSION_ATTEMPTS,
+		requestedAt: stringValue(row.requested_at),
+		startedAt: stringValue(row.started_at),
+		completedAt: stringValue(row.completed_at),
+		updatedAt: stringValue(row.updated_at),
+		lastError: stringValue(row.last_error),
+	};
+}
+
+function readStateRow(db: PragmaReadDb): Record<string, unknown> | undefined {
+	if (!hasTable(db, VACUUM_CONVERSION_STATE_TABLE)) return undefined;
+	return db.prepare(`SELECT * FROM ${VACUUM_CONVERSION_STATE_TABLE} WHERE id = 1`).get();
+}
+
+function readStatusFromDb(db: PragmaReadDb): VacuumConversionStatus {
+	return stateFromRow(readStateRow(db));
+}
+
+function toPragmaReadDb(db: ReadDb): PragmaReadDb {
+	return {
+		prepare(sql: string) {
+			const stmt = db.prepare(sql);
+			return {
+				get(...args: unknown[]): Record<string, unknown> | undefined {
+					return stmt.get(...args);
+				},
+				all(...args: unknown[]): Record<string, unknown>[] {
+					return stmt.all<Record<string, unknown>>(...args);
+				},
+			};
+		},
+	};
+}
+
+function toPragmaDb(db: WriteDb): PragmaDb {
+	return {
+		exec(sql: string): void {
+			db.exec(sql);
+		},
+		prepare(sql: string) {
+			const stmt = db.prepare(sql);
+			return {
+				run(...args: unknown[]): unknown {
+					return stmt.run(...args);
+				},
+				get(...args: unknown[]): Record<string, unknown> | undefined {
+					return stmt.get(...args);
+				},
+				all(...args: unknown[]): Record<string, unknown>[] {
+					return stmt.all<Record<string, unknown>>(...args);
+				},
+			};
+		},
+	};
+}
+
+function writeState(
+	db: PragmaDb,
+	state: "pending" | "running" | "completed" | "failed",
+	fields: {
+		readonly attempts: number;
+		readonly requestedAt: string;
+		readonly startedAt: string | null;
+		readonly completedAt: string | null;
+		readonly lastError: string | null;
+	},
+): void {
+	const updatedAt = now();
+	db.prepare(
+		`INSERT INTO ${VACUUM_CONVERSION_STATE_TABLE}
+			(id, state, attempts, requested_at, started_at, completed_at, updated_at, last_error)
+			VALUES (1, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(id) DO UPDATE SET
+				state = excluded.state,
+				attempts = excluded.attempts,
+				requested_at = excluded.requested_at,
+				started_at = excluded.started_at,
+				completed_at = excluded.completed_at,
+				updated_at = excluded.updated_at,
+				last_error = excluded.last_error`,
+	).run(state, fields.attempts, fields.requestedAt, fields.startedAt, fields.completedAt, updatedAt, fields.lastError);
+}
+
+/**
+ * Create and reconcile the durable conversion state after schema migrations.
+ * A killed conversion is made pending on the next boot. Failed conversions
+ * retry only while the bounded attempt budget remains, preventing a crash loop.
+ */
+export function ensureVacuumConversionState(db: PragmaDb): VacuumConversionStatus {
+	db.exec(STATE_TABLE_SQL);
+	const mode = getAutoVacuumMode(db);
+	const legacyMarker = hasTable(db, VACUUM_CONVERSION_TABLE);
+	const existing = stateFromRow(readStateRow(db));
+
+	if (mode === 2 || legacyMarker) {
+		if (existing.state !== "completed") {
+			writeState(db, "completed", {
+				attempts: existing.attempts,
+				requestedAt: existing.requestedAt ?? now(),
+				startedAt: existing.startedAt,
+				completedAt: existing.completedAt ?? now(),
+				lastError: null,
+			});
+		}
+		return readStatusFromDb(db);
+	}
+
+	if (existing.state === "running") {
+		const interruptedState = existing.attempts >= MAX_CONVERSION_ATTEMPTS ? "failed" : "pending";
+		writeState(db, interruptedState, {
+			attempts: existing.attempts,
+			requestedAt: existing.requestedAt ?? now(),
+			startedAt: null,
+			completedAt: null,
+			lastError:
+				existing.attempts >= MAX_CONVERSION_ATTEMPTS
+					? "Conversion attempt budget exhausted after an interrupted conversion"
+					: "Previous conversion did not complete; retrying after restart",
+		});
+	} else if (existing.state === "failed" && existing.attempts < MAX_CONVERSION_ATTEMPTS) {
+		writeState(db, "pending", {
+			attempts: existing.attempts,
+			requestedAt: existing.requestedAt ?? now(),
+			startedAt: null,
+			completedAt: null,
+			lastError: existing.lastError,
+		});
+	} else if (existing.state === "not_required") {
+		writeState(db, "pending", {
+			attempts: 0,
+			requestedAt: now(),
+			startedAt: null,
+			completedAt: null,
+			lastError: null,
+		});
+	}
+
+	return readStatusFromDb(db);
+}
+
+/** Read durable conversion state for status and readiness diagnostics. */
+export function getVacuumConversionStatus(accessor: Pick<DbAccessor, "withReadDb">): VacuumConversionStatus {
+	return accessor.withReadDb((db) => readStatusFromDb(toPragmaReadDb(db)));
 }
 
 /** Get the free-page ratio (freelist_count / page_count). */
@@ -53,30 +262,16 @@ export function getFreePageRatio(db: PragmaReadDb): number {
 }
 
 /**
- * One-time conversion of existing databases to incremental auto_vacuum mode.
- *
- * PRAGMA auto_vacuum only takes effect on a fresh DB or after VACUUM. For
- * databases created before this fix (auto_vacuum = 0), run VACUUM to rebuild
- * the file and flip the mode. The conversion marker prevents re-running.
- *
- * VACUUM requires temporary disk space roughly equal to the database size.
- * On a 29GB bloated DB this is dramatic but transforms it to ~200MB. After
- * conversion, incremental_vacuum keeps the file compact without full rebuilds.
- *
- * Must be called outside a transaction (VACUUM cannot run inside BEGIN/COMMIT).
- * Returns true if the conversion ran.
+ * One-time conversion of an existing database to incremental auto_vacuum.
+ * This function must only be called by the post-ready worker. It deliberately
+ * does not run from either synchronous or asynchronous DB initialization.
  */
 export function convertToIncrementalVacuum(db: PragmaDb): boolean {
 	const mode = getAutoVacuumMode(db);
 
 	// 2 = INCREMENTAL. Already converted or fresh DB created after the fix.
 	if (mode === 2) return false;
-
-	// Check if already converted via marker table.
-	const tables = db
-		.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
-		.all(VACUUM_CONVERSION_TABLE);
-	if (tables.length > 0) return false;
+	if (hasTable(db, VACUUM_CONVERSION_TABLE)) return false;
 
 	// Set the desired mode BEFORE VACUUM so the rebuilt file uses it.
 	db.exec("PRAGMA auto_vacuum = INCREMENTAL");
@@ -88,7 +283,7 @@ export function convertToIncrementalVacuum(db: PragmaDb): boolean {
 		"db-vacuum",
 		`Converting database to incremental auto_vacuum (current mode: ${mode}, free pages: ${freeBefore})`,
 	);
-	logger.info("db-vacuum", "Running one-time VACUUM — this may take several minutes on large databases");
+	logger.info("db-vacuum", "Running one-time VACUUM after readiness; large databases may take several minutes");
 
 	const startedAt = Date.now();
 	db.exec("VACUUM");
@@ -105,7 +300,119 @@ export function convertToIncrementalVacuum(db: PragmaDb): boolean {
 
 	// Write marker so we never re-run VACUUM on this database.
 	db.exec(`CREATE TABLE IF NOT EXISTS ${VACUUM_CONVERSION_TABLE} (converted_at TEXT)`);
-	db.prepare(`INSERT INTO ${VACUUM_CONVERSION_TABLE} (converted_at) VALUES (?)`).run(new Date().toISOString());
-
+	db.prepare(`INSERT INTO ${VACUUM_CONVERSION_TABLE} (converted_at) VALUES (?)`).run(now());
 	return true;
+}
+
+/**
+ * Start the post-ready one-shot conversion worker. The timer yields once so
+ * the listening callback can return and readiness can be recorded before work
+ * begins.
+ */
+export function startVacuumConversionWorker(
+	accessor: DbAccessor,
+	opts: { readonly startImmediately?: boolean } = {},
+): VacuumConversionHandle {
+	let active = true;
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let inFlight: Promise<VacuumConversionStatus> | null = null;
+
+	async function run(): Promise<VacuumConversionStatus> {
+		if (inFlight) return inFlight;
+		const cycle = (async (): Promise<VacuumConversionStatus> => {
+			const before = getVacuumConversionStatus(accessor);
+			if (before.state !== "pending" || before.attempts >= before.maxAttempts) return before;
+
+			accessor.withWriteTx((db) => {
+				const state = stateFromRow(
+					toPragmaReadDb(db).prepare(`SELECT * FROM ${VACUUM_CONVERSION_STATE_TABLE} WHERE id = 1`).get(),
+				);
+				if (state.state !== "pending") return;
+				const requestedAt = state.requestedAt ?? now();
+				writeState(toPragmaDb(db), "running", {
+					attempts: state.attempts + 1,
+					requestedAt,
+					startedAt: now(),
+					completedAt: null,
+					lastError: null,
+				});
+			});
+
+			const running = getVacuumConversionStatus(accessor);
+			if (running.state !== "running") return running;
+			logger.info("db-vacuum", "Post-ready conversion worker started", {
+				attempt: running.attempts,
+				maxAttempts: running.maxAttempts,
+			});
+
+			try {
+				if (!accessor.vacuumConversion) throw new Error("VACUUM conversion operation is unavailable");
+				accessor.vacuumConversion();
+				accessor.withWriteTx((db) => {
+					const state = stateFromRow(
+						toPragmaReadDb(db).prepare(`SELECT * FROM ${VACUUM_CONVERSION_STATE_TABLE} WHERE id = 1`).get(),
+					);
+					writeState(toPragmaDb(db), "completed", {
+						attempts: state.attempts,
+						requestedAt: state.requestedAt ?? now(),
+						startedAt: state.startedAt,
+						completedAt: now(),
+						lastError: null,
+					});
+				});
+				logger.info("db-vacuum", "Post-ready conversion worker completed");
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				accessor.withWriteTx((db) => {
+					const state = stateFromRow(
+						toPragmaReadDb(db).prepare(`SELECT * FROM ${VACUUM_CONVERSION_STATE_TABLE} WHERE id = 1`).get(),
+					);
+					writeState(toPragmaDb(db), "failed", {
+						attempts: state.attempts,
+						requestedAt: state.requestedAt ?? now(),
+						startedAt: state.startedAt,
+						completedAt: null,
+						lastError: message.slice(0, 500),
+					});
+				});
+				logger.error(
+					"db-vacuum",
+					"Post-ready conversion worker failed; retry is available on a later startup while the attempt budget remains",
+					error instanceof Error ? error : undefined,
+				);
+			}
+			return getVacuumConversionStatus(accessor);
+		})();
+		inFlight = cycle;
+		void cycle.then(
+			() => {
+				if (inFlight === cycle) inFlight = null;
+			},
+			() => {
+				if (inFlight === cycle) inFlight = null;
+			},
+		);
+		return cycle;
+	}
+
+	if (opts.startImmediately !== false) {
+		timer = setTimeout(() => {
+			if (!active) return;
+			void run().catch((error) => {
+				logger.error("db-vacuum", "Post-ready conversion worker crashed", error instanceof Error ? error : undefined);
+			});
+		}, 0);
+	}
+
+	return {
+		get running(): boolean {
+			return active;
+		},
+		stop(): void {
+			active = false;
+			if (timer) clearTimeout(timer);
+			timer = null;
+		},
+		run,
+	};
 }

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -5,6 +5,7 @@ import type { Context, Hono } from "hono";
 import { resolveAgentId, resolveDaemonAgentId } from "../agent-id.js";
 import { requirePermission, requireRateLimit } from "../auth";
 import { getDbAccessor } from "../db-accessor.js";
+import { getVacuumConversionStatus } from "../db-vacuum.js";
 import { type QueueCounts, getQueueDiagnosticsSnapshot } from "../diagnostics-queue.js";
 import { readEmbeddingUsageSummary } from "../embedding-usage";
 import { getInferenceRouterOrNull } from "../inference-router.js";
@@ -569,6 +570,9 @@ export function registerPipelineRoutes(app: Hono): void {
 
 		return c.json({
 			workers,
+			databaseMaintenance: {
+				vacuumConversion: getVacuumConversionStatus(accessor),
+			},
 			providerResolution: {
 				...providerRuntimeResolution,
 				extraction: getExtractionWorkloadState({

--- a/web/docs/src/content/docs/api/operations.md
+++ b/web/docs/src/content/docs/api/operations.md
@@ -581,7 +581,7 @@ count that would remain if the preview were applied.
 ### GET /api/pipeline/status
 
 Composite pipeline status snapshot for dashboard visualization. Returns
-worker status, job queue counts (memory and summary), diagnostics, latency
+worker status, database maintenance state, job queue counts (memory and summary), diagnostics, latency
 histograms, error summary, and the current pipeline mode.
 
 Known `mode` values: `controlled-write`, `shadow`, `frozen`, `paused`,
@@ -592,6 +592,18 @@ Known `mode` values: `controlled-write`, `shadow`, `frozen`, `paused`,
 ```json
 {
   "workers": { ... },
+  "databaseMaintenance": {
+    "vacuumConversion": {
+      "state": "pending",
+      "attempts": 0,
+      "maxAttempts": 3,
+      "requestedAt": "2026-08-11T23:00:00.000Z",
+      "startedAt": null,
+      "completedAt": null,
+      "updatedAt": "2026-08-11T23:00:00.000Z",
+      "lastError": null
+    }
+  },
   "queues": {
     "memory": { "pending": 3, "leased": 1, "completed": 200, "failed": 0, "dead": 0 },
     "summary": { "pending": 0, "leased": 0, "completed": 5, "failed": 0, "dead": 0 }
@@ -604,6 +616,13 @@ Known `mode` values: `controlled-write`, `shadow`, `frozen`, `paused`,
 ```
 
 Mode is one of: `disabled`, `frozen`, `shadow`, `paused`, `controlled-write`.
+
+`databaseMaintenance.vacuumConversion` reports the durable legacy SQLite
+conversion state. Existing databases enter `pending` after migrations and are
+converted by a single-flight worker after readiness. A restart changes an
+interrupted `running` conversion back to `pending`; failures retain
+`lastError` and retry only within the reported attempt budget. Fresh or already
+converted databases report `not_required` or `completed`.
 
 ### POST /api/pipeline/pause
 


### PR DESCRIPTION
## Summary

Move the legacy SQLite auto-vacuum conversion out of synchronous database initialization. Startup now records durable pending state after migrations, reports readiness, and runs the full VACUUM through a single-flight post-ready worker.

## Changes

- Removed the full legacy VACUUM from `finishDbAccessorInit` while preserving migration gating.
- Added durable conversion state with pending, running, completed, and bounded failed states.
- Started the conversion worker after daemon readiness and stopped its timer during runtime shutdown.
- Added conversion status to `GET /api/pipeline/status` and documented the response.
- Added regression coverage for startup behavior, exactly-once conversion, interrupted conversion recovery, and bounded failures.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: daemon operations documentation

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migration file was added. The durable state table is created after existing migrations complete, so schema migration failure still blocks startup before the new maintenance state is recorded.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused verification completed locally:

- `bun test platform/daemon/src/db-vacuum.test.ts platform/daemon/src/db-accessor.test.ts` passed: 35 tests, 68 expectations.
- `bun run --filter '@signet/core' build` passed.
- `bun run --filter '@signet/daemon' typecheck` passed.
- `bun run --filter '@signet/daemon' build` passed.
- `bunx biome check` passed for all changed TypeScript files.
- `git diff --check` passed.

The full root test, typecheck, and lint commands were not run. The existing `platform/daemon/src/pipeline/maintenance-worker.test.ts` suite has five baseline failures at `origin/main`, confirmed separately against a clean HEAD checkout.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The conversion is still a synchronous SQLite VACUUM on the existing database connection, but it starts only after readiness is recorded and is protected by durable single-flight state. During conversion, database and event-loop latency can increase. A maximum of three attempts is persisted. Interrupted or failed attempts retry on later startup while budget remains; exhausted attempts remain visibly failed instead of creating an unbounded startup retry loop.
