### PR TITLE
fix(wrapper): warn on blocked asset install

### DIFF
--- a/dist/signetai/bin/launch.js
+++ b/dist/signetai/bin/launch.js
@@ -13,6 +13,7 @@ const require = createRequire(import.meta.url);
 const binaryName = process.platform === "win32" ? "signet.exe" : "signet";
 const binaryPath = join(packageDir, "native", binaryName);
 const connectorAssetsPath = join(packageDir, "runtime", "connectors");
+const connectorMarkerPath = join(connectorAssetsPath, ".signet-connectors-version");
 
 function resolveNativePackageBinaryPath() {
 	const platform = detectNativePlatform();
@@ -34,29 +35,31 @@ function resolveBinaryPath() {
 	return null;
 }
 
-function hasConnectorAssets() {
+function loadNativeManifest() {
 	try {
-		return (
-			existsSync(connectorAssetsPath) &&
-			existsSync(join(connectorAssetsPath, ".signet-connectors-version")) &&
-			readFileSync(join(connectorAssetsPath, ".signet-connectors-version"), "utf8").trim().length > 0
-		);
+		const manifest = JSON.parse(readFileSync(join(packageDir, "native-manifest.json"), "utf8"));
+		if (typeof manifest !== "object" || manifest === null) return null;
+		return manifest;
 	} catch {
-		return false;
+		return null;
 	}
 }
 
-function connectorAssetsRequired() {
+function connectorComponent(manifest) {
+	if (typeof manifest.components !== "object" || manifest.components === null) return null;
+	const component = manifest.components.connectors;
+	if (typeof component !== "object" || component === null) return null;
+	if (typeof manifest.version !== "string" || typeof component.sha256 !== "string") return null;
+	return component;
+}
+
+function hasConnectorAssets(manifest) {
+	const component = connectorComponent(manifest);
+	if (!existsSync(connectorAssetsPath) || !existsSync(connectorMarkerPath)) return false;
+
 	try {
-		const manifest = JSON.parse(readFileSync(join(packageDir, "native-manifest.json"), "utf8"));
-		return (
-			typeof manifest === "object" &&
-			manifest !== null &&
-			"components" in manifest &&
-			typeof manifest.components === "object" &&
-			manifest.components !== null &&
-			"connectors" in manifest.components
-		);
+		const marker = JSON.parse(readFileSync(connectorMarkerPath, "utf8"));
+		return marker.version === manifest.version && marker.sha256.toLowerCase() === component.sha256.toLowerCase();
 	} catch {
 		return false;
 	}
@@ -65,7 +68,10 @@ function connectorAssetsRequired() {
 function warnIfInstallAssetsMissing(resolvedBinaryPath) {
 	const missing = [];
 	if (resolvedBinaryPath !== binaryPath) missing.push("native/");
-	if (connectorAssetsRequired() && !hasConnectorAssets()) missing.push("runtime/connectors/");
+	const manifest = loadNativeManifest();
+	if (manifest !== null && connectorComponent(manifest) !== null && !hasConnectorAssets(manifest)) {
+		missing.push("runtime/connectors/");
+	}
 	if (missing.length === 0) return;
 
 	console.error(`Signet install assets are incomplete: missing ${missing.join(" and ")}.`);

--- a/dist/signetai/bin/launch.js
+++ b/dist/signetai/bin/launch.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,6 +12,7 @@ const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
 const require = createRequire(import.meta.url);
 const binaryName = process.platform === "win32" ? "signet.exe" : "signet";
 const binaryPath = join(packageDir, "native", binaryName);
+const connectorAssetsPath = join(packageDir, "runtime", "connectors");
 
 function resolveNativePackageBinaryPath() {
 	const platform = detectNativePlatform();
@@ -33,6 +34,50 @@ function resolveBinaryPath() {
 	return null;
 }
 
+function hasConnectorAssets() {
+	try {
+		return (
+			existsSync(connectorAssetsPath) &&
+			existsSync(join(connectorAssetsPath, ".signet-connectors-version")) &&
+			readFileSync(join(connectorAssetsPath, ".signet-connectors-version"), "utf8").trim().length > 0
+		);
+	} catch {
+		return false;
+	}
+}
+
+function connectorAssetsRequired() {
+	try {
+		const manifest = JSON.parse(readFileSync(join(packageDir, "native-manifest.json"), "utf8"));
+		return (
+			typeof manifest === "object" &&
+			manifest !== null &&
+			"components" in manifest &&
+			typeof manifest.components === "object" &&
+			manifest.components !== null &&
+			"connectors" in manifest.components
+		);
+	} catch {
+		return false;
+	}
+}
+
+function warnIfInstallAssetsMissing(resolvedBinaryPath) {
+	const missing = [];
+	if (resolvedBinaryPath !== binaryPath) missing.push("native/");
+	if (connectorAssetsRequired() && !hasConnectorAssets()) missing.push("runtime/connectors/");
+	if (missing.length === 0) return;
+
+	console.error(`Signet install assets are incomplete: missing ${missing.join(" and ")}.`);
+	if (resolvedBinaryPath !== binaryPath) {
+		console.error("The platform native package is installed, but Signet's postinstall did not finish linking the wrapper assets.");
+	} else {
+		console.error("Signet's postinstall did not finish installing all required wrapper assets.");
+	}
+	console.error("If Bun blocked the lifecycle script, run `bun pm -g untrusted`, trust Signet's postinstall, then reinstall with `bun add -g signetai`.");
+	console.error("If the postinstall failed, reinstall with npm or use the official installer from https://signetai.sh/install.sh.");
+}
+
 export function launchSignet() {
 	const resolvedBinaryPath = resolveBinaryPath();
 	if (!resolvedBinaryPath) {
@@ -41,6 +86,8 @@ export function launchSignet() {
 		console.error("The npm package should install the matching native optional dependency for your platform.");
 		process.exit(1);
 	}
+
+	warnIfInstallAssetsMissing(resolvedBinaryPath);
 
 	// Point the binary at the wrapper's installed runtime tree so the
 	// connector's `getPluginSourceDir()` `SIGNET_DIR/runtime/connectors/...`

--- a/dist/signetai/scripts/install-native.js
+++ b/dist/signetai/scripts/install-native.js
@@ -238,9 +238,16 @@ async function installConnectorAssets() {
 
 	const targetDir = join(packageDir, "runtime", "connectors");
 	const targetMarker = join(targetDir, ".signet-connectors-version");
+	let installedMarker = null;
+	try {
+		installedMarker = JSON.parse(readFileSync(targetMarker, "utf8"));
+	} catch {
+		// Reinstall legacy or malformed markers instead of trusting stale assets.
+	}
 	if (
 		existsSync(targetMarker) &&
-		readFileSync(targetMarker, "utf8").trim() === manifest.version
+		installedMarker?.version === manifest.version &&
+		installedMarker?.sha256?.toLowerCase() === component.sha256.toLowerCase()
 	) {
 		// Already extracted for this version. Skip to keep postinstall fast
 		// and to avoid clobbering user-tweaked assets.
@@ -273,7 +280,10 @@ async function installConnectorAssets() {
 		if (result.status !== 0) {
 			throw new Error(`tar extraction failed with status ${result.status ?? "unknown"}`);
 		}
-		writeFileSync(targetMarker, `${manifest.version}\n`);
+		writeFileSync(
+			targetMarker,
+			`${JSON.stringify({ version: manifest.version, sha256: component.sha256 })}\n`,
+		);
 		console.log(`Installed connector assets to ${targetDir}`);
 	} finally {
 		rmSync(tempPath, { force: true });

--- a/dist/signetai/scripts/install-native.js
+++ b/dist/signetai/scripts/install-native.js
@@ -208,6 +208,16 @@ function verifySha256(path, expected) {
 	}
 }
 
+function isConnectorMarker(value) {
+	if (typeof value !== "object" || value === null) return false;
+	return (
+		typeof value.version === "string" &&
+		value.version.length > 0 &&
+		typeof value.sha256 === "string" &&
+		/^[a-f0-9]{64}$/i.test(value.sha256)
+	);
+}
+
 function nativePackageVersion() {
 	try {
 		return JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8")).version;
@@ -246,8 +256,9 @@ async function installConnectorAssets() {
 	}
 	if (
 		existsSync(targetMarker) &&
-		installedMarker?.version === manifest.version &&
-		installedMarker?.sha256?.toLowerCase() === component.sha256.toLowerCase()
+		isConnectorMarker(installedMarker) &&
+		installedMarker.version === manifest.version &&
+		installedMarker.sha256.toLowerCase() === component.sha256.toLowerCase()
 	) {
 		// Already extracted for this version. Skip to keep postinstall fast
 		// and to avoid clobbering user-tweaked assets.

--- a/scripts/native-install-smoke.test.ts
+++ b/scripts/native-install-smoke.test.ts
@@ -380,6 +380,63 @@ describe("native install smoke", () => {
 		expect(result.stderr).toContain("missing runtime/connectors/");
 	});
 
+	test("postinstall reinstalls a valid-JSON marker with a non-string SHA-256", async () => {
+		if (process.platform === "win32") return;
+
+		const version = "0.0.0-smoke-malformed-marker";
+		const tarball = buildFakeConnectorTarball();
+		const release = await serveConnectorRelease(tarball, version);
+
+		const dir = tempDir();
+		const packageDir = join(dir, "signetai");
+		const platform = platformKey();
+		const nativePackageName = `signetai-${platform}`;
+		const nativePackageDir = join(packageDir, "node_modules", nativePackageName);
+		const nativePackageBin = join(nativePackageDir, "bin", "signet");
+		mkdirSync(packageDir, { recursive: true });
+		mkdirSync(join(nativePackageDir, "bin"), { recursive: true });
+		cpSync(join(root, "dist", "signetai", "scripts"), join(packageDir, "scripts"), { recursive: true });
+		cpSync(join(root, "dist", "signetai", "bin"), join(packageDir, "bin"), { recursive: true });
+		writeFileSync(
+			join(packageDir, "native-manifest.json"),
+			JSON.stringify({
+				schemaVersion: 1,
+				version,
+				assets: [],
+				components: {
+					connectors: {
+						url: `signet-connectors-${version}.tar.gz`,
+						sha256: createHash("sha256").update(tarball).digest("hex"),
+						size: tarball.length,
+					},
+				},
+			}),
+		);
+		writeFileSync(
+			join(nativePackageDir, "package.json"),
+			JSON.stringify({ name: nativePackageName, version, type: "module" }),
+		);
+		writeFileSync(nativePackageBin, "");
+		chmodSync(nativePackageBin, 0o755);
+		const connectorDir = join(packageDir, "runtime", "connectors");
+		mkdirSync(connectorDir, { recursive: true });
+		writeFileSync(join(connectorDir, ".signet-connectors-version"), JSON.stringify({ version, sha256: 123 }));
+
+		const result = await runCommand("node", [join(packageDir, "scripts", "install-native.js")], {
+			...process.env,
+			SIGNET_DOWNLOAD_BASE: release.downloadBase,
+			SIGNET_TELEMETRY_OPTOUT: "1",
+		});
+
+		if (result.status !== 0) throw new Error(result.stderr);
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("Installed connector assets to");
+		expect(JSON.parse(readFileSync(join(connectorDir, ".signet-connectors-version"), "utf8"))).toEqual({
+			version,
+			sha256: createHash("sha256").update(tarball).digest("hex"),
+		});
+	});
+
 	test("postinstall extracts connector assets from a manifest-aware release", async () => {
 		if (process.platform === "win32") return;
 

--- a/scripts/native-install-smoke.test.ts
+++ b/scripts/native-install-smoke.test.ts
@@ -307,7 +307,10 @@ function stageWrapperInstall(
 	if (options.connectorAssetsInstalled) {
 		const connectorDir = join(packageDir, "runtime", "connectors");
 		mkdirSync(connectorDir, { recursive: true });
-		writeFileSync(join(connectorDir, ".signet-connectors-version"), "0.0.0\n");
+		writeFileSync(
+			join(connectorDir, ".signet-connectors-version"),
+			`${JSON.stringify({ version: "0.0.0", sha256: "0".repeat(64) })}\n`,
+		);
 	}
 }
 
@@ -344,6 +347,37 @@ describe("native install smoke", () => {
 		expect(result.status).toBe(0);
 		expect(result.stdout).toContain("fake native signet --version");
 		expect(result.stderr).toBe("");
+	});
+
+	test("warns when an upgrade leaves stale connector assets behind", async () => {
+		if (process.platform === "win32") return;
+
+		const dir = tempDir();
+		const packageDir = join(dir, "signetai");
+		stageWrapperInstall(packageDir, { nativeInstalled: true, connectorAssetsInstalled: true });
+		writeFileSync(
+			join(packageDir, "native-manifest.json"),
+			JSON.stringify({
+				schemaVersion: 1,
+				version: "0.0.1",
+				assets: [],
+				components: {
+					connectors: {
+						url: "signet-connectors-0.0.1.tar.gz",
+						sha256: "1".repeat(64),
+						size: 1,
+					},
+				},
+			}),
+		);
+
+		const result = await runCommand("node", [join(packageDir, "bin", "signet.js"), "--version"], {
+			...process.env,
+		});
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("fake native signet --version");
+		expect(result.stderr).toContain("missing runtime/connectors/");
 	});
 
 	test("postinstall extracts connector assets from a manifest-aware release", async () => {
@@ -409,9 +443,12 @@ describe("native install smoke", () => {
 		expect(existsSync(join(extractedDir, "__init__.py"))).toBe(true);
 		expect(existsSync(join(extractedDir, "plugin.yaml"))).toBe(true);
 		expect(readFileSync(join(extractedDir, "__init__.py"), "utf8")).toContain("Smoke test plugin for issue #831");
-		expect(readFileSync(join(packageDir, "runtime", "connectors", ".signet-connectors-version"), "utf8").trim()).toBe(
+		expect(
+			JSON.parse(readFileSync(join(packageDir, "runtime", "connectors", ".signet-connectors-version"), "utf8")),
+		).toEqual({
 			version,
-		);
+			sha256: createHash("sha256").update(tarball).digest("hex"),
+		});
 	});
 
 	test("postinstall rejects a tarball whose SHA-256 does not match the manifest", async () => {

--- a/scripts/native-install-smoke.test.ts
+++ b/scripts/native-install-smoke.test.ts
@@ -260,7 +260,92 @@ function buildFakeConnectorTarball(): Buffer {
 	return buf;
 }
 
+function stageWrapperInstall(
+	packageDir: string,
+	options: { readonly nativeInstalled: boolean; readonly connectorAssetsInstalled: boolean },
+): void {
+	const platform = platformKey();
+	const nativePackageName = `signetai-${platform}`;
+	const nativePackageDir = join(packageDir, "node_modules", nativePackageName);
+	const nativePackageBin = join(nativePackageDir, "bin", "signet");
+	mkdirSync(join(nativePackageDir, "bin"), { recursive: true });
+	cpSync(join(root, "dist", "signetai", "scripts"), join(packageDir, "scripts"), { recursive: true });
+	cpSync(join(root, "dist", "signetai", "bin"), join(packageDir, "bin"), { recursive: true });
+	writeFileSync(
+		join(packageDir, "package.json"),
+		JSON.stringify({ name: "signetai", version: "0.0.0", type: "module" }),
+	);
+	writeFileSync(
+		join(nativePackageDir, "package.json"),
+		JSON.stringify({ name: nativePackageName, version: "0.0.0", type: "module" }),
+	);
+	writeFileSync(nativePackageBin, fakeNativeBinary());
+	chmodSync(nativePackageBin, 0o755);
+
+	if (options.nativeInstalled) {
+		mkdirSync(join(packageDir, "native"), { recursive: true });
+		cpSync(nativePackageBin, join(packageDir, "native", "signet"));
+		chmodSync(join(packageDir, "native", "signet"), 0o755);
+	}
+
+	writeFileSync(
+		join(packageDir, "native-manifest.json"),
+		JSON.stringify({
+			schemaVersion: 1,
+			version: "0.0.0",
+			assets: [],
+			components: {
+				connectors: {
+					url: "signet-connectors-0.0.0.tar.gz",
+					sha256: "0".repeat(64),
+					size: 1,
+				},
+			},
+		}),
+	);
+
+	if (options.connectorAssetsInstalled) {
+		const connectorDir = join(packageDir, "runtime", "connectors");
+		mkdirSync(connectorDir, { recursive: true });
+		writeFileSync(join(connectorDir, ".signet-connectors-version"), "0.0.0\n");
+	}
+}
+
 describe("native install smoke", () => {
+	test("warns when Bun blocked postinstall leaves native and connector assets absent", async () => {
+		if (process.platform === "win32") return;
+
+		const dir = tempDir();
+		const packageDir = join(dir, "signetai");
+		stageWrapperInstall(packageDir, { nativeInstalled: false, connectorAssetsInstalled: false });
+
+		const result = await runCommand("node", [join(packageDir, "bin", "signet.js"), "--version"], {
+			...process.env,
+		});
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("fake native signet --version");
+		expect(result.stderr).toContain("missing native/ and runtime/connectors/");
+		expect(result.stderr).toContain("The platform native package is installed");
+		expect(result.stderr).toContain("bun pm -g untrusted");
+	});
+
+	test("stays silent when native and connector assets are installed", async () => {
+		if (process.platform === "win32") return;
+
+		const dir = tempDir();
+		const packageDir = join(dir, "signetai");
+		stageWrapperInstall(packageDir, { nativeInstalled: true, connectorAssetsInstalled: true });
+
+		const result = await runCommand("node", [join(packageDir, "bin", "signet.js"), "--version"], {
+			...process.env,
+		});
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("fake native signet --version");
+		expect(result.stderr).toBe("");
+	});
+
 	test("postinstall extracts connector assets from a manifest-aware release", async () => {
 		if (process.platform === "win32") return;
 


### PR DESCRIPTION
## Summary

Warn users immediately when Bun or another package manager skipped Signet's postinstall and the wrapper did not receive its native and connector assets. The existing dynamic optional native-package resolution and `signet --version` behavior remain intact.

## Changes

- Add launch-time verification for the wrapper-local `native/` binary and manifest-declared `runtime/connectors/` assets.
- Emit actionable remediation guidance distinguishing a missing wrapper link from a blocked or failed postinstall.
- Add smoke coverage for blocked postinstall and healthy installed-asset states.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `dist/signetai` wrapper and install smoke tests

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused proof:

- `bun test scripts/native-install-smoke.test.ts`: 9 passed.
- `bun test scripts/install-copy-regression.test.ts --test-name-pattern 'keeps the npm package as a native binary wrapper|keeps the postinstall telemetry ping anonymous and opt-out|curl installer downloads and verifies'`: 3 passed.
- `bun test scripts/check-publish-manifests.test.ts`: 23 passed.
- `bunx --package @biomejs/biome@2.5.8 biome check dist/signetai/bin/launch.js scripts/native-install-smoke.test.ts`: passed.
- `git diff --check` and `node --check dist/signetai/bin/launch.js`: passed.
- Full `bun run typecheck` is currently blocked by pre-existing missing workspace dependencies and unrelated package errors in the fresh checkout. `bun run build:signetai` is blocked by the missing `typebox` dependency during the generated MCP bundle prebuild.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The guard only requires connector assets when `native-manifest.json` declares a `components.connectors` entry, preserving compatibility with releases that do not publish connector payloads. The warning is non-fatal so the existing dynamic `signetai-<platform>` package fallback continues to work.
