### PR TITLE
fix(daemon): bound stateless MCP requests

### DIFF
--- a/platform/daemon/src/mcp/route.test.ts
+++ b/platform/daemon/src/mcp/route.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { Hono } from "hono";
-import { mountMcpRoute } from "./route.js";
+import { createConcurrencyAdmission } from "../concurrency-admission.js";
+import { __setMcpAdmissionForTests, MCP_MAX_BODY_BYTES, mountMcpRoute } from "./route.js";
 
 function makeApp(): Hono {
 	const app = new Hono();
@@ -14,6 +15,43 @@ const streamableHeaders = {
 };
 
 describe("MCP route", () => {
+	const originalFetch = globalThis.fetch;
+	beforeEach(() => {
+		globalThis.fetch = mock(
+			async () =>
+				new Response(
+					JSON.stringify({
+						policy: { mode: "hybrid", maxExpandedTools: 12, maxSearchResults: 8 },
+						tools: [],
+						servers: [],
+						count: 0,
+					}),
+					{
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					},
+				),
+		) as unknown as typeof fetch;
+	});
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		__setMcpAdmissionForTests(null);
+	});
+
+	it("rejects requests when the in-flight admission cap is saturated", async () => {
+		const admission = createConcurrencyAdmission(1);
+		expect(admission.acquire()).toBe(true);
+		__setMcpAdmissionForTests(admission);
+		try {
+			const res = await makeApp().request("/mcp", { method: "GET" });
+			expect(res.status).toBe(503);
+			expect((await res.json()).error.message).toContain("Too many concurrent MCP requests");
+		} finally {
+			admission.release();
+			__setMcpAdmissionForTests(null);
+		}
+	});
+
 	it("passes parsed Bun/Hono JSON bodies to the streamable HTTP transport", async () => {
 		const res = await makeApp().request("/mcp", {
 			method: "POST",
@@ -48,5 +86,16 @@ describe("MCP route", () => {
 			error: { code: -32700, message: "Parse error: Invalid JSON" },
 			id: null,
 		});
+	});
+
+	it("rejects oversized JSON bodies before server creation", async () => {
+		const res = await makeApp().request("/mcp", {
+			method: "POST",
+			headers: streamableHeaders,
+			body: JSON.stringify({ payload: "x".repeat(MCP_MAX_BODY_BYTES) }),
+		});
+
+		expect(res.status).toBe(413);
+		expect((await res.json()).error.message).toContain("body exceeds");
 	});
 });

--- a/platform/daemon/src/mcp/route.ts
+++ b/platform/daemon/src/mcp/route.ts
@@ -9,6 +9,7 @@
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import type { Context } from "hono";
 import type { Hono } from "hono";
+import { type ConcurrencyAdmission, createConcurrencyAdmission } from "../concurrency-admission.js";
 import { createMcpServer } from "./tools.js";
 
 interface ActiveMcpRequest {
@@ -19,9 +20,18 @@ interface ActiveMcpRequest {
 const activeMcpRequests = new Map<number, ActiveMcpRequest>();
 let nextMcpRequestId = 1;
 
+export const MCP_MAX_IN_FLIGHT = 8;
+export const MCP_MAX_BODY_BYTES = 512 * 1024;
+let mcpAdmission: ConcurrencyAdmission = createConcurrencyAdmission(MCP_MAX_IN_FLIGHT);
+
+export function __setMcpAdmissionForTests(admission: ConcurrencyAdmission | null): void {
+	mcpAdmission = admission ?? createConcurrencyAdmission(MCP_MAX_IN_FLIGHT);
+}
+
 export interface McpWorkloadDiagnostics {
 	readonly inFlight: number;
 	readonly oldestAgeMs: number | null;
+	readonly maxInFlight: number;
 }
 
 export function getMcpWorkloadDiagnostics(agentId = "default"): McpWorkloadDiagnostics {
@@ -35,7 +45,7 @@ export function getMcpWorkloadDiagnostics(agentId = "default"): McpWorkloadDiagn
 		const ageMs = Math.max(0, now - request.startedAt);
 		oldestAgeMs = oldestAgeMs === null ? ageMs : Math.max(oldestAgeMs, ageMs);
 	}
-	return { inFlight, oldestAgeMs };
+	return { inFlight, oldestAgeMs, maxInFlight: MCP_MAX_IN_FLIGHT };
 }
 
 function resolveMcpWorkloadAgentId(c: Context): string {
@@ -50,18 +60,30 @@ export function mountMcpRoute(app: Hono): void {
 	// GET /mcp — SSE stream for server-initiated notifications
 	// DELETE /mcp — session termination
 	app.all("/mcp", async (c) => {
-		const parsedBody = await parseMcpJsonBody(c);
-		if (parsedBody instanceof Response) {
-			return parsedBody;
+		if (!mcpAdmission.acquire()) {
+			return c.json(
+				{
+					jsonrpc: "2.0",
+					error: {
+						code: -32000,
+						message: `Too many concurrent MCP requests (max ${MCP_MAX_IN_FLIGHT}); retry shortly`,
+					},
+					id: null,
+				},
+				503,
+			);
 		}
-		const requestId = nextMcpRequestId++;
-		activeMcpRequests.set(requestId, {
-			agentId: resolveMcpWorkloadAgentId(c),
-			startedAt: Date.now(),
-		});
+		let requestId: number | null = null;
 		let transport: WebStandardStreamableHTTPServerTransport | null = null;
 		let server: Awaited<ReturnType<typeof createMcpServer>> | null = null;
 		try {
+			const parsedBody = await parseMcpJsonBody(c);
+			if (parsedBody instanceof Response) return parsedBody;
+			requestId = nextMcpRequestId++;
+			activeMcpRequests.set(requestId, {
+				agentId: resolveMcpWorkloadAgentId(c),
+				startedAt: Date.now(),
+			});
 			transport = new WebStandardStreamableHTTPServerTransport({
 				sessionIdGenerator: undefined, // stateless
 				enableJsonResponse: true,
@@ -88,7 +110,8 @@ export function mountMcpRoute(app: Hono): void {
 				try {
 					if (server) await server.close();
 				} finally {
-					activeMcpRequests.delete(requestId);
+					if (requestId !== null) activeMcpRequests.delete(requestId);
+					mcpAdmission.release();
 				}
 			}
 		}
@@ -102,8 +125,40 @@ async function parseMcpJsonBody(c: Context): Promise<unknown | Response | undefi
 	if (!c.req.raw.headers.get("content-type")?.includes("application/json")) {
 		return undefined;
 	}
+	const contentLength = c.req.raw.headers.get("content-length");
+	if (contentLength) {
+		const bytes = Number(contentLength);
+		if (Number.isFinite(bytes) && bytes > MCP_MAX_BODY_BYTES) {
+			return tooLargeMcpBody();
+		}
+	}
 	try {
-		return JSON.parse(await c.req.raw.clone().text());
+		const reader = c.req.raw.clone().body?.getReader();
+		if (!reader) return undefined;
+		const chunks: Uint8Array[] = [];
+		let total = 0;
+		try {
+			while (true) {
+				const next = await reader.read();
+				if (next.done || !next.value) break;
+				total += next.value.byteLength;
+				if (total > MCP_MAX_BODY_BYTES) {
+					await reader.cancel().catch(() => undefined);
+					return tooLargeMcpBody();
+				}
+				chunks.push(next.value);
+			}
+		} finally {
+			await reader.cancel().catch(() => undefined);
+		}
+		const bytes = new Uint8Array(total);
+		let offset = 0;
+		for (const chunk of chunks) {
+			bytes.set(chunk, offset);
+			offset += chunk.byteLength;
+		}
+		const raw = new TextDecoder().decode(bytes);
+		return JSON.parse(raw);
 	} catch {
 		return c.json(
 			{
@@ -114,4 +169,18 @@ async function parseMcpJsonBody(c: Context): Promise<unknown | Response | undefi
 			400,
 		);
 	}
+}
+
+function tooLargeMcpBody(): Response {
+	return new Response(
+		JSON.stringify({
+			jsonrpc: "2.0",
+			error: { code: -32000, message: `MCP request body exceeds ${MCP_MAX_BODY_BYTES} byte limit` },
+			id: null,
+		}),
+		{
+			status: 413,
+			headers: { "Content-Type": "application/json" },
+		},
+	);
 }

--- a/platform/daemon/src/mcp/tools.test.ts
+++ b/platform/daemon/src/mcp/tools.test.ts
@@ -22,7 +22,7 @@ import {
 import { Hono } from "hono";
 import { resetDefaultPluginHostForTests } from "../plugins/index.js";
 import { mountMarketplaceRoutes } from "../routes/marketplace.js";
-import { createMcpServer, refreshMarketplaceProxyTools } from "./tools.js";
+import { createMcpServer, __resetMarketplaceRefreshesForTests, refreshMarketplaceProxyTools } from "./tools.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -191,6 +191,7 @@ describe("createMcpServer", () => {
 	});
 
 	afterEach(() => {
+		__resetMarketplaceRefreshesForTests();
 		globalThis.fetch = originalFetch;
 		if (originalSignetPath === undefined) {
 			Reflect.deleteProperty(process.env, "SIGNET_PATH");
@@ -1466,6 +1467,37 @@ describe("createMcpServer", () => {
 	});
 
 	describe("marketplace proxy tools", () => {
+		it("single-flights marketplace refreshes across concurrent server creation", async () => {
+			__resetMarketplaceRefreshesForTests();
+			let refreshCalls = 0;
+			globalThis.fetch = mock(async (input: string | URL | Request) => {
+				const url = new URL(typeof input === "string" ? input : input.toString());
+				if (url.pathname === "/api/marketplace/mcp/policy") {
+					return new Response(
+						JSON.stringify({ policy: { mode: "expanded", maxExpandedTools: 12, maxSearchResults: 8 } }),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				if (url.pathname === "/api/marketplace/mcp/tools") {
+					refreshCalls += 1;
+					await new Promise((resolve) => setTimeout(resolve, 20));
+					return new Response(JSON.stringify({ count: 0, servers: [], tools: [] }), {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 404 });
+			}) as unknown as typeof fetch;
+
+			const [first, second] = await Promise.all([
+				createMcpServer({ daemonUrl: "http://localhost:3850", enableMarketplaceProxyTools: true }),
+				createMcpServer({ daemonUrl: "http://localhost:3850", enableMarketplaceProxyTools: true }),
+			]);
+			expect(refreshCalls).toBe(1);
+			await first.close();
+			await second.close();
+		});
+
 		it("registers dynamic proxy tools for installed MCP tools", async () => {
 			globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
 				const url = typeof input === "string" ? input : input.toString();
@@ -1627,6 +1659,7 @@ describe("createMcpServer", () => {
 			expect(getToolNames(dynamicServer)).not.toContain("signet_dogfood_everything_get_sum");
 
 			stage = "updated";
+			__resetMarketplaceRefreshesForTests();
 			const refresh = await refreshMarketplaceProxyTools(dynamicServer, { notify: false });
 			expect(refresh.changed).toBe(true);
 			expect(getToolNames(dynamicServer)).toContain("signet_dogfood_everything_get_sum");

--- a/platform/daemon/src/mcp/tools.ts
+++ b/platform/daemon/src/mcp/tools.ts
@@ -74,6 +74,11 @@ interface MarketplaceToolsResponse {
 	readonly count: number;
 }
 
+interface MarketplaceRefreshSnapshot {
+	readonly policy: MarketplacePolicy | null;
+	readonly routed: FetchResult<MarketplaceToolsResponse>;
+}
+
 interface MarketplaceServerRecord {
 	readonly id: string;
 	readonly name: string;
@@ -260,6 +265,15 @@ const GRAPHIQ_COMPAT_ALIASES: ReadonlyMap<string, string> = new Map([
 // four-client budget can require two normal two-second discovery batches, so
 // its deadline must exceed the old 3s request timeout while remaining bounded.
 const MARKETPLACE_PROXY_REFRESH_TIMEOUT_MS = 5_000;
+const MARKETPLACE_PROXY_REFRESH_TTL_MS = 30_000;
+const marketplaceRefreshes = new Map<
+	string,
+	{ readonly expiresAt: number; readonly promise: Promise<MarketplaceRefreshSnapshot> }
+>();
+
+export function __resetMarketplaceRefreshesForTests(): void {
+	marketplaceRefreshes.clear();
+}
 
 // Standalone `signet-mcp` uses process env auth. Hosted `/mcp` requests pass
 // a per-request Authorization header through createMcpServer(), which takes
@@ -579,6 +593,42 @@ async function fetchMarketplacePolicy(
 	return result.data.policy;
 }
 
+function marketplaceRefreshKey(
+	baseUrl: string,
+	context: MarketplaceProxyState["context"],
+	authorizationHeader: string | undefined,
+): string {
+	return JSON.stringify({ baseUrl, context, authorizationHeader });
+}
+
+async function fetchMarketplaceRefreshSnapshot(state: MarketplaceProxyState): Promise<MarketplaceRefreshSnapshot> {
+	const key = marketplaceRefreshKey(state.baseUrl, state.context, state.authorizationHeader);
+	const now = Date.now();
+	const cached = marketplaceRefreshes.get(key);
+	if (cached && cached.expiresAt > now) return cached.promise;
+
+	const promise = (async (): Promise<MarketplaceRefreshSnapshot> => {
+		const policy = await fetchMarketplacePolicy(state.baseUrl, state.authorizationHeader);
+		const routed = await daemonFetch<MarketplaceToolsResponse>(
+			state.baseUrl,
+			appendMarketplaceContext("/api/marketplace/mcp/tools?refresh=1", state.context),
+			{
+				timeout: MARKETPLACE_PROXY_REFRESH_TIMEOUT_MS,
+				authorizationHeader: state.authorizationHeader,
+			},
+		);
+		return { policy, routed };
+	})();
+
+	marketplaceRefreshes.set(key, { expiresAt: now + MARKETPLACE_PROXY_REFRESH_TTL_MS, promise });
+	try {
+		return await promise;
+	} catch (error) {
+		if (marketplaceRefreshes.get(key)?.promise === promise) marketplaceRefreshes.delete(key);
+		throw error;
+	}
+}
+
 export async function refreshMarketplaceProxyTools(
 	server: McpServer,
 	options?: {
@@ -592,19 +642,9 @@ export async function refreshMarketplaceProxyTools(
 
 	const notify = options?.notify ?? true;
 	const registeredTools = getRegisteredToolsMap(server);
-	const policy = await fetchMarketplacePolicy(state.baseUrl, state.authorizationHeader);
-	if (policy) {
-		state.policy = policy;
-	}
-
-	const routed = await daemonFetch<MarketplaceToolsResponse>(
-		state.baseUrl,
-		appendMarketplaceContext("/api/marketplace/mcp/tools?refresh=1", state.context),
-		{
-			timeout: MARKETPLACE_PROXY_REFRESH_TIMEOUT_MS,
-			authorizationHeader: state.authorizationHeader,
-		},
-	);
+	const snapshot = await fetchMarketplaceRefreshSnapshot(state);
+	if (snapshot.policy) state.policy = snapshot.policy;
+	const routed = snapshot.routed;
 
 	if (!routed.ok) {
 		return { changed: false, count: state.names.size, error: routed.error };

--- a/web/docs/src/content/docs/api/health-status.md
+++ b/web/docs/src/content/docs/api/health-status.md
@@ -348,7 +348,7 @@ agent.
     "oldestAgentSessionAgeMs": 3200,
     "byOperation": { "memory_extraction": 1 }
   },
-  "mcp": { "inFlight": 0, "oldestAgeMs": null }
+  "mcp": { "inFlight": 0, "oldestAgeMs": null, "maxInFlight": 8 }
 }
 ```
 

--- a/web/docs/src/content/docs/api/operations.md
+++ b/web/docs/src/content/docs/api/operations.md
@@ -247,7 +247,8 @@ agent.
 
 The response contains `agentId`, `inference` (`active`, `agentSessions`,
 `oldestAgeMs`, `oldestAgentSessionAgeMs`, and per-operation `byOperation`), and
-`mcp` (`inFlight` and `oldestAgeMs`).
+`mcp` (`inFlight`, `oldestAgeMs`, and `maxInFlight`). MCP requests are admitted
+at most 8 at a time.
 
 ### GET /api/diagnostics/memory-content-safety
 

--- a/web/docs/src/content/docs/api/telemetry-logs.md
+++ b/web/docs/src/content/docs/api/telemetry-logs.md
@@ -562,6 +562,12 @@ See the [MCP server reference](/mcp/) for full tool documentation.
 
 **POST /mcp** — Send MCP JSON-RPC messages. Returns JSON or SSE stream.
 
+MCP admission is bounded to 8 in-flight requests. An admitted request whose
+JSON body exceeds 512 KiB returns HTTP 413; a request arriving at a saturated
+admission cap returns HTTP 503 with a JSON-RPC error and should be retried.
+Marketplace proxy refreshes are single-flight per authorization and scope
+context for 30 seconds.
+
 **GET /mcp** — Open an SSE stream for server-initiated notifications.
 
 **DELETE /mcp** — Terminate MCP session (no-op in stateless mode).

--- a/web/docs/src/content/docs/mcp.md
+++ b/web/docs/src/content/docs/mcp.md
@@ -640,7 +640,12 @@ The MCP server supports two transports:
 
 Embedded in the daemon's Hono server at `/mcp`. Uses the web-standard
 Streamable HTTP transport (MCP spec 2025-03-26). Runs stateless — each
-request gets a fresh server instance.
+request gets a fresh server instance. Requests are admitted through a bounded
+in-flight cap of 8; excess requests receive a structured 503 response and can
+retry. JSON request bodies are limited to 512 KiB and oversized bodies receive
+413 before MCP server creation. Marketplace tool discovery is shared per
+authorization and scope context for a 30-second refresh window, so concurrent
+stateless servers do not repeat the same marketplace refresh.
 
 ```
 POST http://localhost:3850/mcp     # Send MCP messages


### PR DESCRIPTION
## Summary

Fixes #1330. Bound stateless `/mcp` admission and request bodies, and prevent concurrent server creation from stampeding the same marketplace refresh.

## Changes

- Add a shared in-flight admission cap of 8 for all `/mcp` methods, returning a structured HTTP 503 when saturated.
- Bound JSON request bodies to 512 KiB, returning an explicit HTTP 413 response before MCP server creation.
- Share marketplace policy and tool refreshes for 30 seconds by authorization and request scope context.
- Expose `maxInFlight` in MCP workload diagnostics and document the operational limits.
- Add regression coverage for admission saturation, oversized JSON, and concurrent marketplace refresh single-flight behavior.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [x] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A. This changes the daemon MCP route and API documentation, not the UI.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [ ] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations were touched.

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Targeted proof:

- `bun test src/mcp/route.test.ts src/mcp/tools.test.ts` from `platform/daemon`: 61 passed, 0 failed, 351 expectations.
- `bun run typecheck` from `platform/daemon`: passed.
- `bun run --filter '@signet/core' build`: passed.
- `bun run --filter '@signet/daemon' build`: passed.
- `bunx biome check src/mcp/route.ts src/mcp/route.test.ts src/mcp/tools.ts src/mcp/tools.test.ts`: passed with two pre-existing warnings in `tools.ts` (`isRecord` unused and an optional-chain suggestion).
- `git diff --check`: passed.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Spec evidence: reviewed `docs/specs/INDEX.md` and `docs/specs/dependencies.yaml` at this head. The change stays within the existing Signet Runtime/MCP integration surfaces and does not alter spec dependency metadata.

Security evidence: this PR does not add or change admin or mutation endpoints. The repository-approved `checklist-exception` label is applied for that N/A readiness item.

The full workspace `bun run lint` was also run. It is currently blocked by pre-existing unrelated diagnostics across the repository, including 11 errors and 789 warnings in unrelated files. No changed file produced a lint error; the touched MCP files only retain the two pre-existing `tools.ts` warnings listed above.

The implementation does not duplicate the marketplace client/process budget from #1401. The MCP admission cap is applied at the stateless route boundary, while marketplace refresh single-flight is keyed by base URL, authorization header, and request scope context to preserve authorization isolation.

