### PR TITLE
fix(daemon): converge autonomous embedding repairs

### DIFF
--- a/platform/daemon/src/embedding-coverage.ts
+++ b/platform/daemon/src/embedding-coverage.ts
@@ -87,44 +87,63 @@ function count(db: ReadDb, sql: string, ...args: readonly unknown[]): number {
 	return row?.n ?? 0;
 }
 
-export function countUnembeddedMemories(db: ReadDb): number {
+export function countUnembeddedMemories(db: ReadDb, agentId?: string): number {
+	const scope = agentId === undefined ? "" : " AND COALESCE(NULLIF(m.agent_id, ''), 'default') = ?";
+	const hashScope =
+		agentId === undefined
+			? ""
+			: ` AND EXISTS (
+			     SELECT 1 FROM memories owner
+			     WHERE owner.id = e.source_id
+			       AND COALESCE(NULLIF(owner.agent_id, ''), 'default') = COALESCE(NULLIF(m.agent_id, ''), 'default')
+			   )`;
 	return count(
 		db,
 		`SELECT COUNT(*) AS n FROM memories m
-		 WHERE m.is_deleted = 0
+		 WHERE m.is_deleted = 0${scope}
 		   AND NOT EXISTS (
 		     SELECT 1 FROM embeddings e
 		     WHERE e.source_type = 'memory' AND e.source_id = m.id
 		   )
 		   AND NOT EXISTS (
 		     SELECT 1 FROM embeddings e
-		     WHERE e.source_type = 'memory'
+		     WHERE e.source_type = 'memory'${hashScope}
 		       AND m.content_hash IS NOT NULL
 		       AND e.content_hash = m.content_hash
 		   )`,
+		...(agentId === undefined ? [] : [agentId]),
 	);
 }
 
-export function listUnembeddedMemories(db: ReadDb, limit: number): ReadonlyArray<UnembeddedRow> {
+export function listUnembeddedMemories(db: ReadDb, limit: number, agentId?: string): ReadonlyArray<UnembeddedRow> {
+	const scope = agentId === undefined ? "" : " AND COALESCE(NULLIF(m.agent_id, ''), 'default') = ?";
+	const hashScope =
+		agentId === undefined
+			? ""
+			: ` AND EXISTS (
+			       SELECT 1 FROM memories owner
+			       WHERE owner.id = e.source_id
+			         AND COALESCE(NULLIF(owner.agent_id, ''), 'default') = COALESCE(NULLIF(m.agent_id, ''), 'default')
+			     )`;
 	return db
 		.prepare(
 			`SELECT m.id, m.content, m.content_hash AS contentHash
 			 FROM memories m
-			 WHERE m.is_deleted = 0
+			 WHERE m.is_deleted = 0${scope}
 			   AND NOT EXISTS (
 			     SELECT 1 FROM embeddings e
 			     WHERE e.source_type = 'memory' AND e.source_id = m.id
 			   )
 			   AND NOT EXISTS (
 			     SELECT 1 FROM embeddings e
-			     WHERE e.source_type = 'memory'
+			     WHERE e.source_type = 'memory'${hashScope}
 			       AND m.content_hash IS NOT NULL
 			       AND e.content_hash = m.content_hash
 			   )
 			 ORDER BY m.created_at ASC
 			 LIMIT ?`,
 		)
-		.all(limit) as UnembeddedRow[];
+		.all(...(agentId === undefined ? [limit] : [agentId, limit])) as UnembeddedRow[];
 }
 
 export function listStaleEmbeddingRows(

--- a/platform/daemon/src/embedding-coverage.ts
+++ b/platform/daemon/src/embedding-coverage.ts
@@ -25,7 +25,7 @@ export interface MigrationEmbeddingSource {
 	readonly count: number;
 }
 
-const migrationWhere = `m.agent_id = ? AND m.is_deleted = 0 AND m.content_hash IS NOT NULL AND trim(m.content_hash) <> ''
+const migrationWhere = `COALESCE(NULLIF(m.agent_id, ''), 'default') = ? AND m.is_deleted = 0 AND m.content_hash IS NOT NULL AND trim(m.content_hash) <> ''
 			 AND (? = 1 OR m.embedding_model IS NULL OR m.embedding_model <> ? OR NOT EXISTS (
 			 SELECT 1 FROM embeddings e WHERE e.source_type = 'memory' AND e.source_id = m.id AND e.dimensions = ?))`;
 

--- a/platform/daemon/src/embedding-coverage.ts
+++ b/platform/daemon/src/embedding-coverage.ts
@@ -39,7 +39,7 @@ export function listEmbeddingMigrationRows(
 ): ReadonlyArray<MigrationEmbeddingRow> {
 	return db
 		.prepare(
-			`SELECT m.id, m.content, m.content_hash AS contentHash, m.embedding_model AS currentModel,
+			`SELECT m.id, m.content, m.content_hash AS contentHash, m.agent_id AS agentId, m.embedding_model AS currentModel,
 				(SELECT e.dimensions FROM embeddings e WHERE e.source_type = 'memory' AND e.source_id = m.id LIMIT 1) AS currentDimensions
 			 FROM memories m WHERE ${migrationWhere}
 			 ORDER BY m.updated_at ASC LIMIT ?`,

--- a/platform/daemon/src/embedding-coverage.ts
+++ b/platform/daemon/src/embedding-coverage.ts
@@ -4,6 +4,7 @@ export interface UnembeddedRow {
 	readonly id: string;
 	readonly content: string;
 	readonly contentHash: string | null;
+	readonly agentId: string | null;
 }
 
 export interface StaleEmbeddingRow {
@@ -127,7 +128,7 @@ export function listUnembeddedMemories(db: ReadDb, limit: number, agentId?: stri
 			     )`;
 	return db
 		.prepare(
-			`SELECT m.id, m.content, m.content_hash AS contentHash
+			`SELECT m.id, m.content, m.content_hash AS contentHash, m.agent_id AS agentId
 			 FROM memories m
 			 WHERE m.is_deleted = 0${scope}
 			   AND NOT EXISTS (

--- a/platform/daemon/src/embedding-repair-state.ts
+++ b/platform/daemon/src/embedding-repair-state.ts
@@ -174,6 +174,8 @@ export function finishEmbeddingRepairLease(
 	lease: EmbeddingRepairLease,
 	outcome: {
 		readonly successful: readonly EmbeddingRepairKey[];
+		/** Number of committed rows when the caller uses a bounded repair action. */
+		readonly affected?: number;
 		readonly failed: readonly EmbeddingRepairKey[];
 		readonly model: string;
 		readonly pollMs: number;
@@ -222,7 +224,7 @@ export function finishEmbeddingRepairLease(
 		// A lease serializes attempted work, but the hourly budget represents
 		// completed repair work. A pressure abort can still persist failure
 		// backoff while releasing its lease without spending a batch slot.
-		const charged = outcome.successful.length > 0;
+		const charged = outcome.successful.length > 0 || (outcome.affected ?? 0) > 0;
 		const error = outcome.error ?? (outcome.failed.length > 0 ? "embedding provider returned no vector" : null);
 		db.prepare(
 			`UPDATE embedding_repair_budget
@@ -233,7 +235,7 @@ export function finishEmbeddingRepairLease(
 			inWindow ? current.window_started_at : iso(now),
 			batchesStarted + (charged ? 1 : 0),
 			iso(now),
-			outcome.successful.length,
+			outcome.affected ?? outcome.successful.length,
 			error,
 			iso(now),
 			lease.id,

--- a/platform/daemon/src/pipeline/index.ts
+++ b/platform/daemon/src/pipeline/index.ts
@@ -179,7 +179,20 @@ export function startPipeline(
 
 	// Maintenance worker (F3) — runs alongside retention
 	if (!maintenanceHandle && providerTracker) {
-		maintenanceHandle = startMaintenanceWorker(accessor, pipelineCfg, providerTracker, retentionHandle);
+		maintenanceHandle = startMaintenanceWorker(
+			accessor,
+			pipelineCfg,
+			providerTracker,
+			retentionHandle,
+			embeddingCfg.provider === "none"
+				? undefined
+				: {
+						cfg: embeddingCfg,
+						fetchEmbedding,
+						agentId,
+						batchSize: pipelineCfg.embeddingTracker.batchSize,
+					},
+		);
 	}
 
 	// Document ingest worker runs alongside the pipeline

--- a/platform/daemon/src/pipeline/maintenance-worker.test.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.test.ts
@@ -3,8 +3,9 @@ import { describe, expect, it } from "bun:test";
 import { runMigrations } from "../../../core/src/migrations";
 import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
 import { createProviderTracker } from "../diagnostics";
+import type { EmbeddingConfig, PipelineV2Config } from "../memory-config";
 import { DEFAULT_PIPELINE_V2 } from "../memory-config";
-import type { PipelineV2Config } from "../memory-config";
+import { getEmbeddingGapStats } from "../repair-actions";
 import { startMaintenanceWorker } from "./maintenance-worker";
 
 // ---------------------------------------------------------------------------
@@ -71,6 +72,13 @@ const BASE_CFG: PipelineV2Config = {
 
 const now = new Date().toISOString();
 
+const TEST_EMBEDDING_CFG: EmbeddingConfig = {
+	provider: "ollama",
+	model: "maintenance-test",
+	dimensions: 3,
+	base_url: "http://127.0.0.1:11434",
+};
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -87,6 +95,68 @@ describe("maintenance-worker", () => {
 		expect(result.report.composite.status).toBe("healthy");
 		expect(result.recommendations).toHaveLength(0);
 		expect(result.executed).toHaveLength(0);
+		db.close();
+	});
+
+	it("repairs a bounded missing-embedding batch and records durable progress", async () => {
+		const db = freshDb();
+		const accessor = asAccessor(db);
+		const tracker = createProviderTracker();
+		for (let i = 0; i < 2; i++) {
+			db.prepare(
+				`INSERT INTO memories
+				 (id, type, content, content_hash, embedding_model, confidence, tags, created_at, updated_at, updated_by, version, manual_override, is_deleted, agent_id)
+				 VALUES (?, 'fact', ?, ?, 'maintenance-test', 0.9, '[]', ?, ?, 'test', 1, 0, 0, 'default')`,
+			).run(`missing-maintenance-${i}`, `maintenance repair fixture ${i}`, `hash-maintenance-${i}`, now, now);
+		}
+		const limitedCfg: PipelineV2Config = {
+			...BASE_CFG,
+			repair: { ...BASE_CFG.repair, reembedCooldownMs: 0, reembedHourlyBudget: 1 },
+		};
+
+		const handle = startMaintenanceWorker(accessor, limitedCfg, tracker, null, {
+			cfg: TEST_EMBEDDING_CFG,
+			fetchEmbedding: async () => [0.1, 0.2, 0.3],
+			agentId: "default",
+			batchSize: 1,
+		});
+		handle.stop();
+
+		const result = await handle.tick();
+		expect(result.recommendations.map((recommendation) => recommendation.action)).toContain("repairEmbeddingIndex");
+		expect(result.executed).toContainEqual(
+			expect.objectContaining({
+				action: "repairEmbeddingIndex",
+				success: true,
+				affected: 1,
+				details: expect.objectContaining({ delegatedAction: "reembedMissingMemories" }),
+			}),
+		);
+		expect(getEmbeddingGapStats(accessor).unembedded).toBe(1);
+		expect(getEmbeddingGapStats(accessor).repair).toMatchObject({ batchesStarted: 1, lastAffected: 1 });
+		const capped = await handle.tick();
+		expect(capped.executed).toContainEqual(
+			expect.objectContaining({ action: "repairEmbeddingIndex", success: false, affected: 0 }),
+		);
+		expect(capped.executed[0]?.message).toContain("hourly budget exhausted");
+		db.close();
+	});
+
+	it("does not recommend embedding repair when the index is healthy", async () => {
+		const db = freshDb();
+		const accessor = asAccessor(db);
+		const tracker = createProviderTracker();
+		const handle = startMaintenanceWorker(accessor, BASE_CFG, tracker, null, {
+			cfg: TEST_EMBEDDING_CFG,
+			fetchEmbedding: async () => [0.1, 0.2, 0.3],
+			agentId: "default",
+			batchSize: 1,
+		});
+		handle.stop();
+
+		const result = await handle.tick();
+		expect(result.recommendations.map((recommendation) => recommendation.action)).not.toContain("repairEmbeddingIndex");
+		expect(result.executed.map((execution) => execution.action)).not.toContain("repairEmbeddingIndex");
 		db.close();
 	});
 

--- a/platform/daemon/src/pipeline/maintenance-worker.test.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.test.ts
@@ -142,6 +142,50 @@ describe("maintenance-worker", () => {
 		db.close();
 	});
 
+	it("scopes autonomous missing-vector repair to the maintenance agent", async () => {
+		const db = freshDb();
+		const accessor = asAccessor(db);
+		const tracker = createProviderTracker();
+		for (const [id, agentId] of [
+			["missing-agent-a", "agent-a"],
+			["missing-agent-b", "agent-b"],
+		] as const) {
+			db.prepare(
+				`INSERT INTO memories
+				 (id, type, content, content_hash, embedding_model, confidence, tags, created_at, updated_at, updated_by, version, manual_override, is_deleted, agent_id)
+				 VALUES (?, 'fact', ?, ?, 'maintenance-test', 0.9, '[]', ?, ?, 'test', 1, 0, 0, ?)`,
+			).run(id, `missing vector for ${agentId}`, `hash-${agentId}`, now, now, agentId);
+		}
+
+		const handle = startMaintenanceWorker(accessor, BASE_CFG, tracker, null, {
+			cfg: TEST_EMBEDDING_CFG,
+			fetchEmbedding: async (content) => {
+				expect(content).toContain("agent-a");
+				return [0.1, 0.2, 0.3];
+			},
+			agentId: "agent-a",
+			batchSize: 20,
+		});
+		handle.stop();
+
+		const result = await handle.tick();
+		expect(result.executed).toContainEqual(
+			expect.objectContaining({
+				action: "repairEmbeddingIndex",
+				success: true,
+				affected: 1,
+			}),
+		);
+		expect(getEmbeddingGapStats(accessor, "agent-a").unembedded).toBe(0);
+		expect(getEmbeddingGapStats(accessor, "agent-b").unembedded).toBe(1);
+		expect(
+			(db.prepare("SELECT source_id FROM embeddings WHERE source_type = 'memory'").all() as Array<{ source_id: string }>).map(
+				(row) => row.source_id,
+			),
+		).toEqual(["missing-agent-a"]);
+		db.close();
+	});
+
 	it("does not recommend embedding repair when the index is healthy", async () => {
 		const db = freshDb();
 		const accessor = asAccessor(db);

--- a/platform/daemon/src/pipeline/maintenance-worker.test.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.test.ts
@@ -40,6 +40,20 @@ function asAccessor(db: Database): DbAccessor {
 	};
 }
 
+function ensureVecTable(db: Database): void {
+	try {
+		db.exec("DROP TABLE IF EXISTS vec_embeddings");
+	} catch {
+		// The migration may have created a sqlite-vec virtual table.
+	}
+	db.exec("CREATE TABLE vec_embeddings (id TEXT PRIMARY KEY, embedding BLOB)");
+}
+
+function vectorBlob(values: readonly number[]): Buffer {
+	const f32 = new Float32Array(values);
+	return Buffer.from(f32.buffer.slice(0));
+}
+
 const BASE_CFG: PipelineV2Config = {
 	...DEFAULT_PIPELINE_V2,
 	shadowMode: false,
@@ -179,10 +193,59 @@ describe("maintenance-worker", () => {
 		expect(getEmbeddingGapStats(accessor, "agent-a").unembedded).toBe(0);
 		expect(getEmbeddingGapStats(accessor, "agent-b").unembedded).toBe(1);
 		expect(
-			(db.prepare("SELECT source_id FROM embeddings WHERE source_type = 'memory'").all() as Array<{ source_id: string }>).map(
-				(row) => row.source_id,
-			),
+			(
+				db.prepare("SELECT source_id FROM embeddings WHERE source_type = 'memory'").all() as Array<{
+					source_id: string;
+				}>
+			).map((row) => row.source_id),
 		).toEqual(["missing-agent-a"]);
+		db.close();
+	});
+
+	it("scopes autonomous orphan cleanup to the maintenance agent", async () => {
+		const db = freshDb();
+		const accessor = asAccessor(db);
+		const tracker = createProviderTracker();
+		ensureVecTable(db);
+		const insert = db.prepare(
+			`INSERT INTO embeddings
+			 (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+			 VALUES (?, ?, ?, 3, 'memory', ?, ?, ?, ?)`,
+		);
+		for (const agentId of ["agent-a", "agent-b"] as const) {
+			const embeddingId = `orphan-${agentId}`;
+			insert.run(
+				embeddingId,
+				`hash-${agentId}`,
+				vectorBlob([0.1, 0.2, 0.3]),
+				`missing-${agentId}`,
+				"orphan",
+				now,
+				agentId,
+			);
+			db.prepare("INSERT INTO vec_embeddings (id, embedding) VALUES (?, ?)").run(
+				embeddingId,
+				vectorBlob([0.1, 0.2, 0.3]),
+			);
+		}
+
+		const handle = startMaintenanceWorker(accessor, BASE_CFG, tracker, null, {
+			cfg: TEST_EMBEDDING_CFG,
+			fetchEmbedding: async () => [0.1, 0.2, 0.3],
+			agentId: "agent-a",
+			batchSize: 20,
+		});
+		handle.stop();
+
+		const result = await handle.tick();
+		expect(result.executed).toContainEqual(
+			expect.objectContaining({ action: "repairEmbeddingIndex", success: true, affected: 1 }),
+		);
+		expect(db.prepare("SELECT id FROM embeddings WHERE id = 'orphan-agent-a'").get()).toBeNull();
+		expect(db.prepare("SELECT id FROM embeddings WHERE id = 'orphan-agent-b'").get()).toEqual({ id: "orphan-agent-b" });
+		expect(db.prepare("SELECT id FROM vec_embeddings WHERE id = 'orphan-agent-b'").get()).toEqual({
+			id: "orphan-agent-b",
+		});
 		db.close();
 	});
 

--- a/platform/daemon/src/pipeline/maintenance-worker.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.ts
@@ -230,8 +230,8 @@ async function executeRecommendation(
 								ctx,
 								deps.limiter,
 								batchSize,
-							)
-						: stats.gap.unembedded > 0
+								)
+								: stats.gap.unembedded > 0
 							? await reembedMissingMemories(
 									deps.accessor,
 									deps.cfg,
@@ -240,6 +240,10 @@ async function executeRecommendation(
 									embedding.fetchEmbedding,
 									embedding.cfg,
 									batchSize,
+									false,
+									false,
+									undefined,
+									embedding.agentId,
 								)
 							: await reembedModelMigration(
 									deps.accessor,

--- a/platform/daemon/src/pipeline/maintenance-worker.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.ts
@@ -13,18 +13,25 @@ import type { DbAccessor } from "../db-accessor";
 import { getFreePageRatio } from "../db-vacuum";
 import type { DiagnosticsReport, ProviderTracker } from "../diagnostics";
 import { getDiagnostics } from "../diagnostics";
+import { isActiveEmbeddingConfig } from "../embedding-index-state";
+import { acquireEmbeddingRepairLease, finishEmbeddingRepairLease } from "../embedding-repair-state";
 import { propagateMemoryStatus } from "../knowledge-graph";
 import { logger } from "../logger";
-import type { PipelineV2Config } from "../memory-config";
+import type { EmbeddingConfig, PipelineV2Config } from "../memory-config";
 import {
 	DEAD_MEMORY_DEFAULT_ACCESS_DAYS,
 	DEAD_MEMORY_DEFAULT_CONFIDENCE,
+	type EmbeddingRepairStats,
 	type RateLimiter,
 	type RepairContext,
 	type RepairResult,
 	checkFtsConsistency,
+	cleanOrphanedEmbeddings,
 	createRateLimiter,
 	deduplicateMemories,
+	getEmbeddingRepairStats,
+	reembedMissingMemories,
+	reembedModelMigration,
 	releaseStaleLeases,
 	requeueDeadJobs,
 	triggerRetentionSweep,
@@ -62,8 +69,21 @@ export interface RepairRecommendation {
 // Recommendation engine
 // ---------------------------------------------------------------------------
 
-function buildRecommendations(report: DiagnosticsReport): RepairRecommendation[] {
+function buildRecommendations(
+	report: DiagnosticsReport,
+	embedding: EmbeddingRepairStats | null,
+): RepairRecommendation[] {
 	const recs: RepairRecommendation[] = [];
+
+	if (embedding && (embedding.orphaned > 0 || embedding.migration > 0 || embedding.gap.unembedded > 0)) {
+		const priority =
+			embedding.orphaned > 0 ? "orphan cleanup" : embedding.gap.unembedded > 0 ? "missing vectors" : "model migration";
+		recs.push({
+			domain: "embedding",
+			action: "repairEmbeddingIndex",
+			trigger: `${priority}: ${embedding.gap.unembedded} missing, ${embedding.migration} migration, ${embedding.orphaned} orphaned`,
+		});
+	}
 
 	if (report.queue.deadRate > 0.01) {
 		recs.push({
@@ -135,7 +155,17 @@ interface ExecutionDeps {
 	cfg: PipelineV2Config;
 	limiter: RateLimiter;
 	retentionHandle: { sweep(): unknown } | null;
+	embedding: EmbeddingRepairDeps | null;
 }
+
+export interface EmbeddingRepairDeps {
+	readonly cfg: EmbeddingConfig;
+	readonly fetchEmbedding: (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>;
+	readonly agentId: string;
+	readonly batchSize: number;
+}
+
+const AUTONOMOUS_EMBEDDING_BATCH = 20;
 
 async function executeRecommendation(
 	rec: RepairRecommendation,
@@ -156,6 +186,85 @@ async function executeRecommendation(
 			return null;
 		case "deduplicateMemories":
 			return deduplicateMemories(deps.accessor, deps.cfg, ctx, deps.limiter);
+		case "repairEmbeddingIndex": {
+			if (deps.embedding === null) return null;
+			const embedding = deps.embedding;
+			const admission = acquireEmbeddingRepairLease(
+				deps.accessor,
+				deps.cfg.repair.reembedCooldownMs,
+				deps.cfg.repair.reembedHourlyBudget,
+			);
+			if (!admission.allowed || admission.lease === undefined) {
+				return {
+					action: rec.action,
+					success: false,
+					affected: 0,
+					message: admission.reason ?? "embedding repair admission denied",
+				};
+			}
+			const lease = admission.lease;
+
+			const finish = (affected: number, error?: string): void => {
+				finishEmbeddingRepairLease(deps.accessor, lease, {
+					successful: [],
+					affected,
+					failed: [],
+					model: embedding.cfg.model,
+					pollMs: deps.cfg.embeddingTracker.pollMs,
+					eligibility: (db) => isActiveEmbeddingConfig(db, embedding.cfg),
+					...(error ? { error } : {}),
+				});
+			};
+
+			try {
+				const stats = getEmbeddingRepairStats(deps.accessor, embedding.cfg, embedding.agentId);
+				const batchSize =
+					Number.isFinite(embedding.batchSize) && embedding.batchSize > 0
+						? Math.max(1, Math.min(AUTONOMOUS_EMBEDDING_BATCH, Math.floor(embedding.batchSize)))
+						: 1;
+				const result =
+					stats.orphaned > 0
+						? cleanOrphanedEmbeddings(
+								deps.accessor,
+								deps.cfg,
+								ctx,
+								deps.limiter,
+								batchSize,
+							)
+						: stats.gap.unembedded > 0
+							? await reembedMissingMemories(
+									deps.accessor,
+									deps.cfg,
+									ctx,
+									deps.limiter,
+									embedding.fetchEmbedding,
+									embedding.cfg,
+									batchSize,
+								)
+							: await reembedModelMigration(
+									deps.accessor,
+									deps.cfg,
+									ctx,
+									deps.limiter,
+									embedding.fetchEmbedding,
+									embedding.cfg,
+									embedding.agentId,
+									batchSize,
+								);
+				finish(result.affected, result.success ? undefined : result.message);
+				return {
+					action: rec.action,
+					success: result.success,
+					affected: result.affected,
+					message: `${result.action}: ${result.message}`,
+					details: { delegatedAction: result.action, ...(result.details ?? {}) },
+				};
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				finish(0, message);
+				return { action: rec.action, success: false, affected: 0, message };
+			}
+		}
 		default:
 			return null;
 	}
@@ -200,6 +309,7 @@ export function startMaintenanceWorker(
 	cfg: PipelineV2Config,
 	tracker: ProviderTracker,
 	retentionHandle: { sweep(): unknown } | null,
+	embedding?: EmbeddingRepairDeps,
 ): MaintenanceHandle {
 	let running = true;
 	let timer: ReturnType<typeof setInterval> | null = null;
@@ -215,6 +325,7 @@ export function startMaintenanceWorker(
 		cfg,
 		limiter,
 		retentionHandle,
+		embedding: embedding ?? null,
 	};
 
 	async function doTick(): Promise<MaintenanceCycleResult> {
@@ -224,7 +335,10 @@ export function startMaintenanceWorker(
 		}
 		const report = accessor.withReadDb((db) => getDiagnostics(db, tracker));
 
-		const recommendations = buildRecommendations(report);
+		const embeddingStats = deps.embedding
+			? getEmbeddingRepairStats(accessor, deps.embedding.cfg, deps.embedding.agentId)
+			: null;
+		const recommendations = buildRecommendations(report, embeddingStats);
 		const executed: RepairResult[] = [];
 		let feedbackDecayedAspects = 0;
 		let feedbackPropagatedAttributes = 0;

--- a/platform/daemon/src/pipeline/maintenance-worker.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.ts
@@ -224,14 +224,8 @@ async function executeRecommendation(
 						: 1;
 				const result =
 					stats.orphaned > 0
-						? cleanOrphanedEmbeddings(
-								deps.accessor,
-								deps.cfg,
-								ctx,
-								deps.limiter,
-								batchSize,
-								)
-								: stats.gap.unembedded > 0
+						? cleanOrphanedEmbeddings(deps.accessor, deps.cfg, ctx, deps.limiter, batchSize, embedding.agentId)
+						: stats.gap.unembedded > 0
 							? await reembedMissingMemories(
 									deps.accessor,
 									deps.cfg,

--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -9,6 +9,8 @@ import { runMigrations } from "../../core/src/migrations";
 import { normalizeAndHashContent } from "./content-normalization";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import { toFtsSchemaQueryDb } from "./db-accessor";
+import { ensureEmbeddingIndexState } from "./embedding-index-state";
+import { embeddingProfileFingerprint } from "./embedding-profile";
 import { DEFAULT_PIPELINE_V2 } from "./memory-config";
 import type { EmbeddingConfig, PipelineV2Config } from "./memory-config";
 import {
@@ -966,6 +968,54 @@ describe("reembedMissingMemories", () => {
 		expect(second.success).toBe(true);
 		expect(second.affected).toBe(1);
 		expect(db.prepare("SELECT id FROM embeddings WHERE source_id = ?").get("mem-write-failure")).toBeTruthy();
+	});
+
+	it("skips stale vectors when promotion happens during provider work", async () => {
+		insertMemory(db, "mem-promotion-race");
+		accessor.withWriteTx((writeDb) => ensureEmbeddingIndexState(writeDb, TEST_EMBEDDING_CFG));
+		let providerStarted!: () => void;
+		const providerReady = new Promise<void>((resolve) => {
+			providerStarted = resolve;
+		});
+		let releaseProvider!: () => void;
+		const providerReleased = new Promise<void>((resolve) => {
+			releaseProvider = resolve;
+		});
+
+		const repair = reembedMissingMemories(
+			accessor,
+			TEST_CFG,
+			CTX_DAEMON,
+			createRateLimiter(),
+			async () => {
+				providerStarted();
+				await providerReleased;
+				return [0.1, 0.2, 0.3];
+			},
+			TEST_EMBEDDING_CFG,
+			1,
+		);
+
+		await providerReady;
+		const promoted = { ...TEST_EMBEDDING_CFG, model: "promoted-model" };
+		db.prepare("UPDATE embedding_index_state SET active_profile_json = ? WHERE id = 1").run(
+			JSON.stringify({
+				fingerprint: embeddingProfileFingerprint(promoted),
+				provider: promoted.provider,
+				model: promoted.model,
+				dimensions: promoted.dimensions,
+				baseUrl: promoted.base_url,
+			}),
+		);
+		releaseProvider();
+
+		const result = await repair;
+		expect(result.success).toBe(false);
+		expect(result.message).toMatch(/skipped stale vectors/);
+		expect(db.prepare("SELECT id FROM embeddings WHERE source_id = ?").get("mem-promotion-race")).toBeNull();
+		expect(db.prepare("SELECT embedding_model FROM memories WHERE id = ?").get("mem-promotion-race")).toEqual({
+			embedding_model: null,
+		});
 	});
 
 	it("repairs memories even when content_hash is NULL", async () => {

--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -161,12 +161,12 @@ const CTX_DAEMON = {
 	actorType: "daemon" as const,
 };
 
-function insertMemory(db: Database, id: string): void {
+function insertMemory(db: Database, id: string, agentId?: string, contentHash?: string): void {
 	const now = new Date().toISOString();
 	db.prepare(
-		`INSERT INTO memories (id, content, type, created_at, updated_at, updated_by)
-		 VALUES (?, ?, ?, ?, ?, ?)`,
-	).run(id, `content for ${id}`, "fact", now, now, "test");
+		`INSERT INTO memories (id, content, content_hash, agent_id, type, created_at, updated_at, updated_by)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+	).run(id, `content for ${id}`, contentHash ?? null, agentId ?? null, "fact", now, now, "test");
 }
 
 function repairAuditCount(db: Database, action: string): number {
@@ -970,6 +970,47 @@ describe("reembedMissingMemories", () => {
 		expect(second.success).toBe(true);
 		expect(second.affected).toBe(1);
 		expect(db.prepare("SELECT id FROM embeddings WHERE source_id = ?").get("mem-write-failure")).toBeTruthy();
+	});
+
+	it("does not overwrite another agent's embedding on a hash conflict", async () => {
+		// Regression for cross-agent hash collisions: the embedding hash is
+		// globally unique, but autonomous repair is agent-scoped. Agent A must
+		// not update Agent B's vector or source fields when both memories share a hash.
+		ensureVecTable(db);
+		const sharedHash = "cross-agent-shared-hash";
+		insertMemory(db, "mem-a", "agent-a", sharedHash);
+		insertMemory(db, "mem-b", "agent-b", sharedHash);
+		insertEmbedding(db, {
+			id: "emb-b",
+			contentHash: sharedHash,
+			sourceId: "mem-b",
+			vector: [0.9, 0.8, 0.7],
+			agentId: "agent-b",
+		});
+		const before = db
+			.prepare("SELECT vector, chunk_text, source_id, agent_id, dimensions FROM embeddings WHERE id = 'emb-b'")
+			.get();
+
+		const result = await reembedMissingMemories(
+			accessor,
+			TEST_CFG,
+			CTX_AGENT,
+			createRateLimiter(),
+			async () => [0.1, 0.2, 0.3],
+			TEST_EMBEDDING_CFG,
+			10,
+			false,
+			false,
+			undefined,
+			"agent-a",
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.message).toMatch(/provider returned no vectors/);
+		const after = db
+			.prepare("SELECT vector, chunk_text, source_id, agent_id, dimensions FROM embeddings WHERE id = 'emb-b'")
+			.get();
+		expect(after).toEqual(before);
 	});
 
 	it("skips stale vectors when promotion happens during provider work", async () => {

--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -1057,6 +1057,61 @@ describe("reembedMissingMemories", () => {
 		expect(db.prepare("SELECT id FROM embeddings WHERE source_id = ?").get("mem-content-race")).toBeNull();
 	});
 
+	it("skips stale vectors when ownership changes during provider work", async () => {
+		insertMemory(db, "mem-agent-race", "agent-a");
+		let providerStarted!: () => void;
+		const providerReady = new Promise<void>((resolve) => {
+			providerStarted = resolve;
+		});
+		let releaseProvider!: () => void;
+		const providerReleased = new Promise<void>((resolve) => {
+			releaseProvider = resolve;
+		});
+
+		const repair = reembedMissingMemories(
+			accessor,
+			TEST_CFG,
+			CTX_DAEMON,
+			createRateLimiter(),
+			async () => {
+				providerStarted();
+				await providerReleased;
+				return [0.1, 0.2, 0.3];
+			},
+			TEST_EMBEDDING_CFG,
+			1,
+		);
+
+		await providerReady;
+		db.prepare("UPDATE memories SET agent_id = ? WHERE id = ?").run("agent-b", "mem-agent-race");
+		releaseProvider();
+
+		const result = await repair;
+		expect(result.success).toBe(false);
+		expect(result.affected).toBe(0);
+		expect(result.message).toMatch(/changed during provider work/);
+		expect(db.prepare("SELECT id FROM embeddings WHERE source_id = ?").get("mem-agent-race")).toBeNull();
+	});
+
+	it("normalizes an empty memory agent_id on missing-memory repair", async () => {
+		insertMemory(db, "mem-empty-agent", "");
+
+		const result = await reembedMissingMemories(
+			accessor,
+			TEST_CFG,
+			CTX_DAEMON,
+			createRateLimiter(),
+			async () => [0.1, 0.2, 0.3],
+			TEST_EMBEDDING_CFG,
+			1,
+		);
+
+		expect(result.success).toBe(true);
+		expect(db.prepare("SELECT agent_id FROM embeddings WHERE source_id = ?").get("mem-empty-agent")).toEqual({
+			agent_id: "default",
+		});
+	});
+
 	it("does not overwrite another agent's embedding on migration hash conflict", async () => {
 		const migrationDb = new Database(":memory:");
 		runMigrations(migrationDb as unknown as Parameters<typeof runMigrations>[0]);
@@ -1141,6 +1196,39 @@ describe("reembedMissingMemories", () => {
 		).toEqual({
 			agent_id: "agent-a",
 		});
+		migrationDb.close();
+	});
+
+	it("normalizes an empty memory agent_id on migration repair", async () => {
+		const migrationDb = new Database(":memory:");
+		runMigrations(migrationDb as unknown as Parameters<typeof runMigrations>[0]);
+		ensureVecTable(migrationDb);
+		const migrationAccessor = asAccessor(migrationDb);
+		const now = new Date().toISOString();
+		migrationDb
+			.prepare(
+				`INSERT INTO memories (id, content, content_hash, agent_id, embedding_model, type, created_at, updated_at, updated_by)
+				 VALUES ('migration-empty-agent', 'empty agent content', 'empty-agent-hash', '', 'model-a', 'fact', ?, ?, 'test')`,
+			)
+			.run(now, now);
+		const target = { ...TEST_EMBEDDING_CFG, model: "model-b" };
+		migrationAccessor.withWriteTx((writeDb) => ensureEmbeddingIndexState(writeDb, target));
+
+		const result = await reembedModelMigration(
+			migrationAccessor,
+			TEST_CFG,
+			CTX_DAEMON,
+			createRateLimiter(),
+			async () => [0.1, 0.2, 0.3],
+			target,
+			"default",
+			10,
+		);
+
+		expect(result.success).toBe(true);
+		expect(
+			migrationDb.prepare("SELECT agent_id FROM embeddings WHERE content_hash = ?").get("empty-agent-hash"),
+		).toEqual({ agent_id: "default" });
 		migrationDb.close();
 	});
 

--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -1376,6 +1376,74 @@ describe("reembedModelMigration", () => {
 		db.close();
 	});
 
+	it("skips stale migration vectors when promotion happens during provider work", async () => {
+		const db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		ensureVecTable(db);
+		const accessor = asAccessor(db);
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO memories (id, content, content_hash, embedding_model, type, created_at, updated_at, updated_by) VALUES ('migration-race', 'old vector', 'hash-race', 'model-a', 'fact', ?, ?, 'test')`,
+		).run(now, now);
+		insertEmbedding(db, {
+			id: "emb-race",
+			sourceId: "migration-race",
+			contentHash: "hash-race",
+			vector: [0.1, 0.2, 0.3],
+		});
+		const targetEmbeddingCfg = { ...TEST_EMBEDDING_CFG, model: "model-b" };
+		accessor.withWriteTx((writeDb) => ensureEmbeddingIndexState(writeDb, targetEmbeddingCfg));
+
+		let providerStarted!: () => void;
+		const providerReady = new Promise<void>((resolve) => {
+			providerStarted = resolve;
+		});
+		let releaseProvider!: () => void;
+		const providerReleased = new Promise<void>((resolve) => {
+			releaseProvider = resolve;
+		});
+		const repair = reembedModelMigration(
+			accessor,
+			TEST_CFG,
+			CTX_DAEMON,
+			createRateLimiter(),
+			async () => {
+				providerStarted();
+				await providerReleased;
+				return [0.4, 0.5, 0.6];
+			},
+			targetEmbeddingCfg,
+			"default",
+			10,
+			false,
+			false,
+		);
+
+		await providerReady;
+		const promoted = { ...TEST_EMBEDDING_CFG, model: "promoted-model" };
+		db.prepare("UPDATE embedding_index_state SET active_profile_json = ? WHERE id = 1").run(
+			JSON.stringify({
+				fingerprint: embeddingProfileFingerprint(promoted),
+				provider: promoted.provider,
+				model: promoted.model,
+				dimensions: promoted.dimensions,
+				baseUrl: promoted.base_url,
+			}),
+		);
+		releaseProvider();
+
+		const result = await repair;
+		expect(result.success).toBe(false);
+		expect(result.message).toMatch(/skipped stale migration vectors/);
+		expect(db.prepare("SELECT embedding_model FROM memories WHERE id = 'migration-race'").get()).toEqual({
+			embedding_model: "model-a",
+		});
+		expect(
+			db.prepare("SELECT vector FROM embeddings WHERE source_id = 'migration-race'").get() as { vector: Buffer },
+		).toEqual({ vector: vectorBlob([0.1, 0.2, 0.3]) });
+		db.close();
+	});
+
 	it("survives a per-row write failure, records partial progress, and still returns a structured result", async () => {
 		// Regression guard: without try/catch around withWriteTx, a single
 		// transaction failure (SQLITE_BUSY / disk error) propagated as an

--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -980,6 +980,7 @@ describe("reembedMissingMemories", () => {
 		const sharedHash = "cross-agent-shared-hash";
 		insertMemory(db, "mem-a", "agent-a", sharedHash);
 		insertMemory(db, "mem-b", "agent-b", sharedHash);
+		insertMemory(db, "mem-a-unique", "agent-a", "agent-a-unique-hash");
 		insertEmbedding(db, {
 			id: "emb-b",
 			contentHash: sharedHash,
@@ -1005,8 +1006,10 @@ describe("reembedMissingMemories", () => {
 			"agent-a",
 		);
 
-		expect(result.success).toBe(false);
-		expect(result.message).toMatch(/provider returned no vectors/);
+		expect(result.success).toBe(true);
+		expect(result.affected).toBe(1);
+		const repaired = db.prepare("SELECT agent_id FROM embeddings WHERE content_hash = 'agent-a-unique-hash'").get();
+		expect(repaired).toEqual({ agent_id: "agent-a" });
 		const after = db
 			.prepare("SELECT vector, chunk_text, source_id, agent_id, dimensions FROM embeddings WHERE id = 'emb-b'")
 			.get();

--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -227,12 +227,13 @@ function insertEmbedding(
 		contentHash: string;
 		sourceId: string;
 		vector: readonly number[];
+		agentId?: string;
 	},
 ): void {
 	const now = new Date().toISOString();
 	db.prepare(
-		`INSERT INTO embeddings (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at)
-		 VALUES (?, ?, ?, ?, 'memory', ?, ?, ?)`,
+		`INSERT INTO embeddings (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+		 VALUES (?, ?, ?, ?, 'memory', ?, ?, ?, ?)`,
 	).run(
 		params.id,
 		params.contentHash,
@@ -241,6 +242,7 @@ function insertEmbedding(
 		params.sourceId,
 		`chunk for ${params.sourceId}`,
 		now,
+		params.agentId ?? null,
 	);
 }
 

--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -1016,6 +1016,134 @@ describe("reembedMissingMemories", () => {
 		expect(after).toEqual(before);
 	});
 
+	it("skips stale vectors when content changes during provider work", async () => {
+		insertMemory(db, "mem-content-race");
+		let providerStarted!: () => void;
+		const providerReady = new Promise<void>((resolve) => {
+			providerStarted = resolve;
+		});
+		let releaseProvider!: () => void;
+		const providerReleased = new Promise<void>((resolve) => {
+			releaseProvider = resolve;
+		});
+
+		const repair = reembedMissingMemories(
+			accessor,
+			TEST_CFG,
+			CTX_DAEMON,
+			createRateLimiter(),
+			async () => {
+				providerStarted();
+				await providerReleased;
+				return [0.1, 0.2, 0.3];
+			},
+			TEST_EMBEDDING_CFG,
+			1,
+		);
+
+		await providerReady;
+		const changedHash = normalizeAndHashContent("new content for mem-content-race").contentHash;
+		db.prepare("UPDATE memories SET content = ?, content_hash = ? WHERE id = ?").run(
+			"new content for mem-content-race",
+			changedHash,
+			"mem-content-race",
+		);
+		releaseProvider();
+
+		const result = await repair;
+		expect(result.success).toBe(false);
+		expect(result.affected).toBe(0);
+		expect(result.message).toMatch(/re-embedded 0/);
+		expect(db.prepare("SELECT id FROM embeddings WHERE source_id = ?").get("mem-content-race")).toBeNull();
+	});
+
+	it("does not overwrite another agent's embedding on migration hash conflict", async () => {
+		const migrationDb = new Database(":memory:");
+		runMigrations(migrationDb as unknown as Parameters<typeof runMigrations>[0]);
+		ensureVecTable(migrationDb);
+		const migrationAccessor = asAccessor(migrationDb);
+		const now = new Date().toISOString();
+		migrationDb
+			.prepare(
+				`INSERT INTO memories (id, content, content_hash, agent_id, embedding_model, type, created_at, updated_at, updated_by)
+			 VALUES ('migration-agent-a', 'agent a content', 'shared-migration-hash', 'agent-a', 'model-a', 'fact', ?, ?, 'test')`,
+			)
+			.run(now, now);
+		insertEmbedding(migrationDb, {
+			id: "emb-agent-b",
+			contentHash: "shared-migration-hash",
+			sourceId: "agent-b-memory",
+			vector: [0.9, 0.8, 0.7],
+			agentId: "agent-b",
+		});
+		migrationAccessor.withWriteTx((writeDb) =>
+			ensureEmbeddingIndexState(writeDb, { ...TEST_EMBEDDING_CFG, model: "model-b" }),
+		);
+		const before = migrationDb
+			.prepare("SELECT vector, chunk_text, source_id, agent_id, dimensions FROM embeddings WHERE id = 'emb-agent-b'")
+			.get();
+
+		const result = await reembedModelMigration(
+			migrationAccessor,
+			TEST_CFG,
+			CTX_DAEMON,
+			createRateLimiter(),
+			async () => [0.1, 0.2, 0.3],
+			{ ...TEST_EMBEDDING_CFG, model: "model-b" },
+			"agent-a",
+			10,
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.affected).toBe(0);
+		expect(result.message).toMatch(/cross-agent hash conflict/);
+		expect(migrationDb.prepare("SELECT embedding_model FROM memories WHERE id = 'migration-agent-a'").get()).toEqual({
+			embedding_model: "model-a",
+		});
+		expect(
+			migrationDb
+				.prepare("SELECT vector, chunk_text, source_id, agent_id, dimensions FROM embeddings WHERE id = 'emb-agent-b'")
+				.get(),
+		).toEqual(before);
+		migrationDb.close();
+	});
+
+	it("persists agent_id on new migration embeddings", async () => {
+		const migrationDb = new Database(":memory:");
+		runMigrations(migrationDb as unknown as Parameters<typeof runMigrations>[0]);
+		ensureVecTable(migrationDb);
+		const migrationAccessor = asAccessor(migrationDb);
+		const now = new Date().toISOString();
+		migrationDb
+			.prepare(
+				`INSERT INTO memories (id, content, content_hash, agent_id, embedding_model, type, created_at, updated_at, updated_by)
+			 VALUES ('migration-agent-a-new', 'agent a content', 'agent-a-migration-hash', 'agent-a', 'model-a', 'fact', ?, ?, 'test')`,
+			)
+			.run(now, now);
+		const target = { ...TEST_EMBEDDING_CFG, model: "model-b" };
+		migrationAccessor.withWriteTx((writeDb) => ensureEmbeddingIndexState(writeDb, target));
+
+		const result = await reembedModelMigration(
+			migrationAccessor,
+			TEST_CFG,
+			CTX_DAEMON,
+			createRateLimiter(),
+			async () => [0.1, 0.2, 0.3],
+			target,
+			"agent-a",
+			10,
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.affected).toBe(1);
+		expect(
+			migrationDb.prepare("SELECT agent_id FROM embeddings WHERE content_hash = ?").get("agent-a-migration-hash"),
+		).toEqual({
+			agent_id: "agent-a",
+		});
+		migrationDb.close();
+	});
+
 	it("skips stale vectors when promotion happens during provider work", async () => {
 		insertMemory(db, "mem-promotion-race");
 		accessor.withWriteTx((writeDb) => ensureEmbeddingIndexState(writeDb, TEST_EMBEDDING_CFG));

--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -1444,6 +1444,75 @@ describe("reembedModelMigration", () => {
 		db.close();
 	});
 
+	it("skips stale migration vectors when content changes during provider work", async () => {
+		const db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		ensureVecTable(db);
+		const accessor = asAccessor(db);
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO memories (id, content, content_hash, embedding_model, type, created_at, updated_at, updated_by) VALUES ('content-race', 'old content', 'hash-old', 'model-a', 'fact', ?, ?, 'test')`,
+		).run(now, now);
+		insertEmbedding(db, {
+			id: "emb-content-race",
+			sourceId: "content-race",
+			contentHash: "hash-old",
+			vector: [0.1, 0.2, 0.3],
+		});
+		const targetEmbeddingCfg = { ...TEST_EMBEDDING_CFG, model: "model-b" };
+		accessor.withWriteTx((writeDb) => ensureEmbeddingIndexState(writeDb, targetEmbeddingCfg));
+
+		let providerStarted!: () => void;
+		const providerReady = new Promise<void>((resolve) => {
+			providerStarted = resolve;
+		});
+		let releaseProvider!: () => void;
+		const providerReleased = new Promise<void>((resolve) => {
+			releaseProvider = resolve;
+		});
+		const repair = reembedModelMigration(
+			accessor,
+			TEST_CFG,
+			CTX_DAEMON,
+			createRateLimiter(),
+			async () => {
+				providerStarted();
+				await providerReleased;
+				return [0.4, 0.5, 0.6];
+			},
+			targetEmbeddingCfg,
+			"default",
+			10,
+			false,
+			false,
+		);
+
+		await providerReady;
+		db.prepare("UPDATE memories SET content = ?, content_hash = ? WHERE id = ?").run(
+			"new content",
+			"hash-new",
+			"content-race",
+		);
+		releaseProvider();
+
+		const result = await repair;
+		expect(result.success).toBe(false);
+		expect(result.affected).toBe(0);
+		expect(result.message).toContain("changed during provider work");
+		expect(result.details).toMatchObject({ contentChanged: 1 });
+		expect(db.prepare("SELECT embedding_model FROM memories WHERE id = 'content-race'").get()).toEqual({
+			embedding_model: "model-a",
+		});
+		expect(
+			db.prepare("SELECT content_hash, chunk_text FROM embeddings WHERE source_id = 'content-race'").get(),
+		).toEqual({
+			content_hash: "hash-old",
+			chunk_text: "chunk for content-race",
+		});
+		expect(db.prepare("SELECT id FROM embeddings WHERE content_hash = 'hash-new'").get()).toBeNull();
+		db.close();
+	});
+
 	it("survives a per-row write failure, records partial progress, and still returns a structured result", async () => {
 		// Regression guard: without try/catch around withWriteTx, a single
 		// transaction failure (SQLITE_BUSY / disk error) propagated as an

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -1041,6 +1041,7 @@ export async function reembedModelMigration(
 	}
 	let written = 0;
 	let failed = 0;
+	let profileChanged = false;
 	for (const row of rows) {
 		let vector: number[] | null;
 		try {
@@ -1058,11 +1059,15 @@ export async function reembedModelMigration(
 			continue;
 		}
 		try {
-			const wrote = accessor.withWriteTx((db): boolean => {
+			const writeOutcome = accessor.withWriteTx((db): { wrote: boolean; profileChanged: boolean } => {
+				// Provider work happens outside the transaction. Promotion can therefore
+				// change the active vector space while this row is being encoded.
+				// Never commit a vector or model marker from the superseded profile.
+				if (!isActiveEmbeddingConfig(db, embeddingCfg)) return { wrote: false, profileChanged: true };
 				const current = db.prepare("SELECT content_hash FROM memories WHERE id = ? AND is_deleted = 0").get(row.id) as
 					| { content_hash: string }
 					| undefined;
-				if (!current) return false;
+				if (!current) return { wrote: false, profileChanged: false };
 				const id = crypto.randomUUID();
 				db.prepare(
 					`INSERT INTO embeddings (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at) VALUES (?, ?, ?, ?, 'memory', ?, ?, datetime('now')) ON CONFLICT(content_hash) DO UPDATE SET vector=excluded.vector, dimensions=excluded.dimensions, source_id=excluded.source_id, chunk_text=excluded.chunk_text, created_at=excluded.created_at`,
@@ -1070,12 +1075,16 @@ export async function reembedModelMigration(
 				const embedding = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(current.content_hash) as
 					| { id: string }
 					| undefined;
-				if (!embedding) return false;
+				if (!embedding) return { wrote: false, profileChanged: false };
 				syncVecInsert(db, embedding.id, vector);
 				db.prepare("UPDATE memories SET embedding_model = ? WHERE id = ?").run(embeddingCfg.model, row.id);
-				return true;
+				return { wrote: true, profileChanged: false };
 			});
-			if (wrote) written++;
+			if (writeOutcome.profileChanged) {
+				profileChanged = true;
+				break;
+			}
+			if (writeOutcome.wrote) written++;
 		} catch (error) {
 			failed++;
 			logger.warn("pipeline", "re-embed migration: write failed", {
@@ -1087,6 +1096,16 @@ export async function reembedModelMigration(
 	const message = `re-embedded ${written} of ${rows.length} selected memories${
 		failed > 0 ? ` (${failed} failed)` : ""
 	}`;
+	if (profileChanged) {
+		return {
+			action,
+			success: false,
+			affected: written,
+			message: "embedding profile changed during provider work; skipped stale migration vectors",
+			totalMatching,
+			details: { ...details, failed },
+		};
+	}
 	if (written > 0) {
 		try {
 			accessor.withWriteTx((db) => writeRepairAudit(db, action, ctx, written, message));

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -640,12 +640,18 @@ function listOrphanedEmbeddingIds(db: WriteDb, limit: number): Array<{ id: strin
 		.all(limit) as Array<{ id: string }>;
 }
 
-export function getEmbeddingGapStats(accessor: DbAccessor): EmbeddingGapStats {
+export function getEmbeddingGapStats(accessor: DbAccessor, agentId?: string): EmbeddingGapStats {
 	const repair = readEmbeddingRepairState(accessor);
 	return accessor.withReadDb((db) => {
-		const totalRow = db.prepare("SELECT COUNT(*) as n FROM memories WHERE is_deleted = 0").get() as { n: number };
+		const totalRow = db
+			.prepare(
+				agentId === undefined
+					? "SELECT COUNT(*) as n FROM memories WHERE is_deleted = 0"
+					: "SELECT COUNT(*) as n FROM memories WHERE is_deleted = 0 AND COALESCE(NULLIF(agent_id, ''), 'default') = ?",
+			)
+			.get(...(agentId === undefined ? [] : [agentId])) as { n: number };
 		const total = totalRow.n;
-		const unembedded = countUnembeddedMemories(db);
+		const unembedded = countUnembeddedMemories(db, agentId);
 		const embedded = total - unembedded;
 		const state = tableExists(db, "embedding_index_state") ? readEmbeddingIndexState(db) : null;
 		const staging =
@@ -676,7 +682,7 @@ export function getEmbeddingRepairStats(
 	embeddingCfg: EmbeddingConfig,
 	agentId: string,
 ): EmbeddingRepairStats {
-	const gap = getEmbeddingGapStats(accessor);
+	const gap = getEmbeddingGapStats(accessor, agentId);
 	const migration = accessor.withReadDb((db) =>
 		countEmbeddingMigrationRows(db, embeddingCfg.model, embeddingCfg.dimensions, false, agentId),
 	);
@@ -704,9 +710,10 @@ async function reembedMissingMemoriesBatch(
 	embeddingFn: (content: string, cfg: EmbeddingConfig) => Promise<number[] | null>,
 	embeddingCfg: EmbeddingConfig,
 	batchSize: number,
+	agentId?: string,
 ): Promise<ReembedBatchOutcome> {
 	const unembedded = accessor.withReadDb((db) => {
-		return listUnembeddedMemories(db, batchSize) as UnembeddedRow[];
+		return listUnembeddedMemories(db, batchSize, agentId) as UnembeddedRow[];
 	});
 
 	if (unembedded.length === 0) {
@@ -841,6 +848,7 @@ export async function reembedMissingMemories(
 	dryRun = false,
 	runToCompletion = false,
 	cooldownMsOverride?: number,
+	agentId?: string,
 ): Promise<RepairResult> {
 	const action = "reembedMissingMemories";
 	const effectiveCooldownMs =
@@ -861,7 +869,7 @@ export async function reembedMissingMemories(
 	const normalizedBatchSize =
 		Number.isFinite(batchSize) && batchSize > 0 ? Math.max(1, Math.floor(batchSize)) : DEFAULT_REEMBED_BATCH;
 
-	const initialStats = getEmbeddingGapStats(accessor);
+	const initialStats = getEmbeddingGapStats(accessor, agentId);
 	if (initialStats.unembedded === 0) {
 		return {
 			action,
@@ -898,7 +906,13 @@ export async function reembedMissingMemories(
 		let profileChanged = false;
 
 		while (true) {
-			const outcome = await reembedMissingMemoriesBatch(accessor, embeddingFn, embeddingCfg, normalizedBatchSize);
+			const outcome = await reembedMissingMemoriesBatch(
+				accessor,
+				embeddingFn,
+				embeddingCfg,
+				normalizedBatchSize,
+				agentId,
+			);
 
 			if (outcome.selected === 0) break;
 
@@ -941,7 +955,7 @@ export async function reembedMissingMemories(
 			};
 		}
 
-		const remaining = getEmbeddingGapStats(accessor).unembedded;
+		const remaining = getEmbeddingGapStats(accessor, agentId).unembedded;
 		const scope = runToCompletion ? `across ${batches} batch(es)` : "in one batch";
 		const msg =
 			failed > 0

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -38,8 +38,7 @@ import { readEmbeddingIndexState } from "./embedding-index-state";
 import { type EmbeddingRepairState, readEmbeddingRepairState } from "./embedding-repair-state";
 import { classifyEntityQuality } from "./entity-quality";
 import { logger } from "./logger";
-import type { EmbeddingConfig } from "./memory-config";
-import type { PipelineV2Config } from "./memory-config";
+import type { EmbeddingConfig, PipelineV2Config } from "./memory-config";
 import { recoverStaleLeases } from "./pipeline/stale-leases";
 import { insertHistoryEvent } from "./transactions";
 
@@ -605,6 +604,42 @@ export interface EmbeddingGapStats {
 	readonly repair: EmbeddingRepairState | null;
 }
 
+export interface EmbeddingRepairStats {
+	readonly gap: EmbeddingGapStats;
+	readonly migration: number;
+	readonly orphaned: number;
+}
+
+const orphanedEmbeddingWhere = `e.source_type = 'memory'
+	AND (m.id IS NULL OR m.is_deleted = 1)
+	AND m2.id IS NULL`;
+
+function countOrphanedEmbeddings(db: ReadDb): number {
+	const row = db
+		.prepare(
+			`SELECT COUNT(*) AS n FROM embeddings e
+			 LEFT JOIN memories m ON e.source_type = 'memory' AND e.source_id = m.id
+			 LEFT JOIN memories m2
+			   ON e.source_type = 'memory' AND e.content_hash = m2.content_hash AND m2.is_deleted = 0
+			 WHERE ${orphanedEmbeddingWhere}`,
+		)
+		.get() as { n: number } | undefined;
+	return row?.n ?? 0;
+}
+
+function listOrphanedEmbeddingIds(db: WriteDb, limit: number): Array<{ id: string }> {
+	return db
+		.prepare(
+			`SELECT e.id FROM embeddings e
+			 LEFT JOIN memories m ON e.source_type = 'memory' AND e.source_id = m.id
+			 LEFT JOIN memories m2
+			   ON e.source_type = 'memory' AND e.content_hash = m2.content_hash AND m2.is_deleted = 0
+			 WHERE ${orphanedEmbeddingWhere}
+			 LIMIT ?`,
+		)
+		.all(limit) as Array<{ id: string }>;
+}
+
 export function getEmbeddingGapStats(accessor: DbAccessor): EmbeddingGapStats {
 	const repair = readEmbeddingRepairState(accessor);
 	return accessor.withReadDb((db) => {
@@ -634,6 +669,19 @@ export function getEmbeddingGapStats(accessor: DbAccessor): EmbeddingGapStats {
 			repair,
 		};
 	});
+}
+
+export function getEmbeddingRepairStats(
+	accessor: DbAccessor,
+	embeddingCfg: EmbeddingConfig,
+	agentId: string,
+): EmbeddingRepairStats {
+	const gap = getEmbeddingGapStats(accessor);
+	const migration = accessor.withReadDb((db) =>
+		countEmbeddingMigrationRows(db, embeddingCfg.model, embeddingCfg.dimensions, false, agentId),
+	);
+	const orphaned = accessor.withReadDb((db) => countOrphanedEmbeddings(db));
+	return { gap, migration, orphaned };
 }
 
 // ---------------------------------------------------------------------------
@@ -1053,6 +1101,7 @@ export function cleanOrphanedEmbeddings(
 	cfg: PipelineV2Config,
 	ctx: RepairContext,
 	limiter: RateLimiter,
+	maxBatch = Number.MAX_SAFE_INTEGER,
 ): RepairResult {
 	const action = "cleanOrphanedEmbeddings";
 	const gate = checkRepairGate(cfg, ctx, limiter, action, cfg.repair.requeueCooldownMs, cfg.repair.requeueHourlyBudget);
@@ -1066,20 +1115,9 @@ export function cleanOrphanedEmbeddings(
 		};
 	}
 
+	const limit = Number.isFinite(maxBatch) && maxBatch > 0 ? Math.floor(maxBatch) : Number.MAX_SAFE_INTEGER;
 	const affected = accessor.withWriteTx((db) => {
-		const orphans = db
-			.prepare(
-				`SELECT e.id FROM embeddings e
-				 LEFT JOIN memories m ON e.source_type = 'memory' AND e.source_id = m.id
-				 LEFT JOIN memories m2
-				   ON e.source_type = 'memory'
-				  AND e.content_hash = m2.content_hash
-				  AND m2.is_deleted = 0
-				 WHERE e.source_type = 'memory'
-				   AND (m.id IS NULL OR m.is_deleted = 1)
-				   AND m2.id IS NULL`,
-			)
-			.all() as Array<{ id: string }>;
+		const orphans = listOrphanedEmbeddingIds(db, limit);
 
 		if (orphans.length === 0) return 0;
 

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -785,6 +785,7 @@ async function reembedMissingMemoriesBatch(
 		const checkHash = db.prepare(
 			"SELECT id FROM memories WHERE content_hash = ? AND is_deleted = 0 AND id <> ? LIMIT 1",
 		);
+		const readEmbeddingByHash = db.prepare("SELECT id, agent_id FROM embeddings WHERE content_hash = ? LIMIT 1");
 
 		for (const { memory, vector } of results) {
 			const contentHash =
@@ -801,6 +802,17 @@ async function reembedMissingMemoriesBatch(
 				if (!collision) writeHash.run(contentHash, memory.id);
 			}
 
+			// content_hash is globally unique in the embeddings table, while the
+			// repair selection is agent-scoped. A hash peer owned by another agent
+			// must never be updated by this repair, or its vector and source fields
+			// become cross-agent data corruption.
+			const existing = readEmbeddingByHash.get(contentHash) as { id: string; agent_id: string | null } | undefined;
+			if (existing) {
+				const existingAgentId = existing.agent_id ?? "default";
+				const memoryAgentId = memory.agentId ?? agentId ?? "default";
+				if (existingAgentId !== memoryAgentId) continue;
+			}
+
 			const embId = crypto.randomUUID();
 			const blob = vectorToBlob(vector);
 			syncVecDeleteBySourceExceptHash(db, "memory", memory.id, contentHash);
@@ -813,8 +825,8 @@ async function reembedMissingMemoriesBatch(
 				.prepare(
 					`INSERT INTO embeddings
 					 (id, content_hash, vector, dimensions, source_type,
-					  source_id, chunk_text, created_at)
-					 VALUES (?, ?, ?, ?, 'memory', ?, ?, ?)
+					  source_id, chunk_text, created_at, agent_id)
+					 VALUES (?, ?, ?, ?, 'memory', ?, ?, ?, ?)
 					 ON CONFLICT(content_hash) DO UPDATE SET
 					   vector = excluded.vector,
 					   dimensions = excluded.dimensions,
@@ -822,7 +834,16 @@ async function reembedMissingMemoriesBatch(
 					   chunk_text = excluded.chunk_text,
 					   created_at = excluded.created_at`,
 				)
-				.run(embId, contentHash, blob, vector.length, memory.id, memory.content, now);
+				.run(
+					embId,
+					contentHash,
+					blob,
+					vector.length,
+					memory.id,
+					memory.content,
+					now,
+					memory.agentId ?? agentId ?? null,
+				);
 			// Resolve actual embedding ID (may differ from embId on conflict)
 			const actualRow = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(contentHash) as
 				| { id: string }

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -709,6 +709,11 @@ export function getEmbeddingRepairStats(
 
 const DEFAULT_REEMBED_BATCH = 50;
 
+function normalizeRepairAgentId(agentId: string | null | undefined): string {
+	const trimmed = agentId?.trim();
+	return trimmed && trimmed.length > 0 ? trimmed : "default";
+}
+
 interface ReembedBatchOutcome {
 	readonly selected: number;
 	readonly written: number;
@@ -811,12 +816,16 @@ async function reembedMissingMemoriesBatch(
 				stale++;
 				continue;
 			}
+			if (normalizeRepairAgentId(current.agent_id) !== normalizeRepairAgentId(memory.agentId)) {
+				stale++;
+				continue;
+			}
 
 			const contentHash =
 				typeof current.content_hash === "string" && current.content_hash.trim().length > 0
 					? current.content_hash
 					: normalizeAndHashContent(current.content).contentHash;
-			const memoryAgentId = current.agent_id ?? agentId ?? "default";
+			const memoryAgentId = normalizeRepairAgentId(current.agent_id ?? agentId);
 
 			// Write computed hash back to the memories row when it was NULL.
 			// Without this, the embedding-coverage queries can never use the
@@ -833,7 +842,7 @@ async function reembedMissingMemoriesBatch(
 			// become cross-agent data corruption.
 			const existing = readEmbeddingByHash.get(contentHash) as { id: string; agent_id: string | null } | undefined;
 			if (existing) {
-				const existingAgentId = existing.agent_id ?? "default";
+				const existingAgentId = normalizeRepairAgentId(existing.agent_id);
 				if (existingAgentId !== memoryAgentId) continue;
 			}
 
@@ -858,16 +867,7 @@ async function reembedMissingMemoriesBatch(
 					   chunk_text = excluded.chunk_text,
 					   created_at = excluded.created_at`,
 				)
-				.run(
-					embId,
-					contentHash,
-					blob,
-					vector.length,
-					memory.id,
-					memory.content,
-					now,
-					memory.agentId ?? agentId ?? "default",
-				);
+				.run(embId, contentHash, blob, vector.length, memory.id, memory.content, now, memoryAgentId);
 			// Resolve actual embedding ID (may differ from embId on conflict)
 			const actualRow = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(contentHash) as
 				| { id: string }
@@ -1120,6 +1120,7 @@ export async function reembedModelMigration(
 	let written = 0;
 	let failed = 0;
 	let contentChanged = 0;
+	let ownershipChanged = 0;
 	let crossAgentConflict = 0;
 	let profileChanged = false;
 	for (const row of rows) {
@@ -1140,30 +1141,71 @@ export async function reembedModelMigration(
 		}
 		try {
 			const writeOutcome = accessor.withWriteTx(
-				(db): { wrote: boolean; profileChanged: boolean; contentChanged: boolean; crossAgentConflict: boolean } => {
+				(
+					db,
+				): {
+					wrote: boolean;
+					profileChanged: boolean;
+					contentChanged: boolean;
+					ownershipChanged: boolean;
+					crossAgentConflict: boolean;
+				} => {
 					// Provider work happens outside the transaction. Promotion can therefore
 					// change the active vector space while this row is being encoded.
 					// Never commit a vector or model marker from the superseded profile.
 					if (!isActiveEmbeddingConfig(db, embeddingCfg))
-						return { wrote: false, profileChanged: true, contentChanged: false, crossAgentConflict: false };
+						return {
+							wrote: false,
+							profileChanged: true,
+							contentChanged: false,
+							ownershipChanged: false,
+							crossAgentConflict: false,
+						};
 					const current = db
 						.prepare("SELECT content, content_hash, agent_id FROM memories WHERE id = ? AND is_deleted = 0")
 						.get(row.id) as { content: string; content_hash: string | null; agent_id: string | null } | null;
 					if (!current)
-						return { wrote: false, profileChanged: false, contentChanged: false, crossAgentConflict: false };
+						return {
+							wrote: false,
+							profileChanged: false,
+							contentChanged: false,
+							ownershipChanged: false,
+							crossAgentConflict: false,
+						};
 					// The provider encoded row.content before this transaction. If the
 					// memory changed while it awaited the provider, its vector belongs to
 					// the old row version and must not be committed under the new one.
 					if (current.content_hash !== row.contentHash || current.content !== row.content) {
-						return { wrote: false, profileChanged: false, contentChanged: true, crossAgentConflict: false };
+						return {
+							wrote: false,
+							profileChanged: false,
+							contentChanged: true,
+							ownershipChanged: false,
+							crossAgentConflict: false,
+						};
 					}
-					const memoryAgentId = current.agent_id ?? row.agentId ?? agentId;
+					if (normalizeRepairAgentId(current.agent_id) !== normalizeRepairAgentId(row.agentId)) {
+						return {
+							wrote: false,
+							profileChanged: false,
+							contentChanged: false,
+							ownershipChanged: true,
+							crossAgentConflict: false,
+						};
+					}
+					const memoryAgentId = normalizeRepairAgentId(current.agent_id ?? agentId);
 					const id = crypto.randomUUID();
 					const existing = db
 						.prepare("SELECT agent_id FROM embeddings WHERE content_hash = ? LIMIT 1")
 						.get(current.content_hash) as { agent_id: string | null } | null;
-					if (existing != null && (existing.agent_id ?? "default") !== (memoryAgentId ?? "default"))
-						return { wrote: false, profileChanged: false, contentChanged: false, crossAgentConflict: true };
+					if (existing != null && normalizeRepairAgentId(existing.agent_id) !== memoryAgentId)
+						return {
+							wrote: false,
+							profileChanged: false,
+							contentChanged: false,
+							ownershipChanged: false,
+							crossAgentConflict: true,
+						};
 					db.prepare(
 						`INSERT INTO embeddings (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id) VALUES (?, ?, ?, ?, 'memory', ?, ?, datetime('now'), ?) ON CONFLICT(content_hash) DO UPDATE SET vector=excluded.vector, dimensions=excluded.dimensions, source_id=excluded.source_id, chunk_text=excluded.chunk_text, created_at=excluded.created_at`,
 					).run(id, current.content_hash, vectorToBlob(vector), vector.length, row.id, row.content, memoryAgentId);
@@ -1171,10 +1213,22 @@ export async function reembedModelMigration(
 						| { id: string }
 						| undefined;
 					if (!embedding)
-						return { wrote: false, profileChanged: false, contentChanged: false, crossAgentConflict: false };
+						return {
+							wrote: false,
+							profileChanged: false,
+							contentChanged: false,
+							ownershipChanged: false,
+							crossAgentConflict: false,
+						};
 					syncVecInsert(db, embedding.id, vector);
 					db.prepare("UPDATE memories SET embedding_model = ? WHERE id = ?").run(embeddingCfg.model, row.id);
-					return { wrote: true, profileChanged: false, contentChanged: false, crossAgentConflict: false };
+					return {
+						wrote: true,
+						profileChanged: false,
+						contentChanged: false,
+						ownershipChanged: false,
+						crossAgentConflict: false,
+					};
 				},
 			);
 			if (writeOutcome.profileChanged) {
@@ -1183,6 +1237,10 @@ export async function reembedModelMigration(
 			}
 			if (writeOutcome.contentChanged) {
 				contentChanged++;
+				continue;
+			}
+			if (writeOutcome.ownershipChanged) {
+				ownershipChanged++;
 				continue;
 			}
 			if (writeOutcome.crossAgentConflict) {
@@ -1201,8 +1259,8 @@ export async function reembedModelMigration(
 	const message = `re-embedded ${written} of ${rows.length} selected memories${
 		failed > 0 ? ` (${failed} failed)` : ""
 	}${contentChanged > 0 ? ` (${contentChanged} changed during provider work)` : ""}${
-		crossAgentConflict > 0 ? ` (${crossAgentConflict} cross-agent hash conflict(s) skipped)` : ""
-	}`;
+		ownershipChanged > 0 ? ` (${ownershipChanged} ownership change(s) during provider work)` : ""
+	}${crossAgentConflict > 0 ? ` (${crossAgentConflict} cross-agent hash conflict(s) skipped)` : ""}`;
 	if (profileChanged) {
 		return {
 			action,
@@ -1210,7 +1268,7 @@ export async function reembedModelMigration(
 			affected: written,
 			message: "embedding profile changed during provider work; skipped stale migration vectors",
 			totalMatching,
-			details: { ...details, failed, contentChanged, crossAgentConflict },
+			details: { ...details, failed, contentChanged, ownershipChanged, crossAgentConflict },
 		};
 	}
 	if (written > 0) {
@@ -1227,11 +1285,11 @@ export async function reembedModelMigration(
 	}
 	return {
 		action,
-		success: failed === 0 && contentChanged === 0 && crossAgentConflict === 0,
+		success: failed === 0 && contentChanged === 0 && ownershipChanged === 0 && crossAgentConflict === 0,
 		affected: written,
 		message,
 		totalMatching,
-		details: { ...details, failed, contentChanged },
+		details: { ...details, failed, contentChanged, ownershipChanged, crossAgentConflict },
 	};
 }
 

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -1041,6 +1041,7 @@ export async function reembedModelMigration(
 	}
 	let written = 0;
 	let failed = 0;
+	let contentChanged = 0;
 	let profileChanged = false;
 	for (const row of rows) {
 		let vector: number[] | null;
@@ -1059,30 +1060,43 @@ export async function reembedModelMigration(
 			continue;
 		}
 		try {
-			const writeOutcome = accessor.withWriteTx((db): { wrote: boolean; profileChanged: boolean } => {
-				// Provider work happens outside the transaction. Promotion can therefore
-				// change the active vector space while this row is being encoded.
-				// Never commit a vector or model marker from the superseded profile.
-				if (!isActiveEmbeddingConfig(db, embeddingCfg)) return { wrote: false, profileChanged: true };
-				const current = db.prepare("SELECT content_hash FROM memories WHERE id = ? AND is_deleted = 0").get(row.id) as
-					| { content_hash: string }
-					| undefined;
-				if (!current) return { wrote: false, profileChanged: false };
-				const id = crypto.randomUUID();
-				db.prepare(
-					`INSERT INTO embeddings (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at) VALUES (?, ?, ?, ?, 'memory', ?, ?, datetime('now')) ON CONFLICT(content_hash) DO UPDATE SET vector=excluded.vector, dimensions=excluded.dimensions, source_id=excluded.source_id, chunk_text=excluded.chunk_text, created_at=excluded.created_at`,
-				).run(id, current.content_hash, vectorToBlob(vector), vector.length, row.id, row.content);
-				const embedding = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(current.content_hash) as
-					| { id: string }
-					| undefined;
-				if (!embedding) return { wrote: false, profileChanged: false };
-				syncVecInsert(db, embedding.id, vector);
-				db.prepare("UPDATE memories SET embedding_model = ? WHERE id = ?").run(embeddingCfg.model, row.id);
-				return { wrote: true, profileChanged: false };
-			});
+			const writeOutcome = accessor.withWriteTx(
+				(db): { wrote: boolean; profileChanged: boolean; contentChanged: boolean } => {
+					// Provider work happens outside the transaction. Promotion can therefore
+					// change the active vector space while this row is being encoded.
+					// Never commit a vector or model marker from the superseded profile.
+					if (!isActiveEmbeddingConfig(db, embeddingCfg))
+						return { wrote: false, profileChanged: true, contentChanged: false };
+					const current = db
+						.prepare("SELECT content, content_hash FROM memories WHERE id = ? AND is_deleted = 0")
+						.get(row.id) as { content: string; content_hash: string | null } | null;
+					if (!current) return { wrote: false, profileChanged: false, contentChanged: false };
+					// The provider encoded row.content before this transaction. If the
+					// memory changed while it awaited the provider, its vector belongs to
+					// the old row version and must not be committed under the new one.
+					if (current.content_hash !== row.contentHash || current.content !== row.content) {
+						return { wrote: false, profileChanged: false, contentChanged: true };
+					}
+					const id = crypto.randomUUID();
+					db.prepare(
+						`INSERT INTO embeddings (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at) VALUES (?, ?, ?, ?, 'memory', ?, ?, datetime('now')) ON CONFLICT(content_hash) DO UPDATE SET vector=excluded.vector, dimensions=excluded.dimensions, source_id=excluded.source_id, chunk_text=excluded.chunk_text, created_at=excluded.created_at`,
+					).run(id, current.content_hash, vectorToBlob(vector), vector.length, row.id, row.content);
+					const embedding = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(current.content_hash) as
+						| { id: string }
+						| undefined;
+					if (!embedding) return { wrote: false, profileChanged: false, contentChanged: false };
+					syncVecInsert(db, embedding.id, vector);
+					db.prepare("UPDATE memories SET embedding_model = ? WHERE id = ?").run(embeddingCfg.model, row.id);
+					return { wrote: true, profileChanged: false, contentChanged: false };
+				},
+			);
 			if (writeOutcome.profileChanged) {
 				profileChanged = true;
 				break;
+			}
+			if (writeOutcome.contentChanged) {
+				contentChanged++;
+				continue;
 			}
 			if (writeOutcome.wrote) written++;
 		} catch (error) {
@@ -1095,7 +1109,7 @@ export async function reembedModelMigration(
 	}
 	const message = `re-embedded ${written} of ${rows.length} selected memories${
 		failed > 0 ? ` (${failed} failed)` : ""
-	}`;
+	}${contentChanged > 0 ? ` (${contentChanged} changed during provider work)` : ""}`;
 	if (profileChanged) {
 		return {
 			action,
@@ -1103,7 +1117,7 @@ export async function reembedModelMigration(
 			affected: written,
 			message: "embedding profile changed during provider work; skipped stale migration vectors",
 			totalMatching,
-			details: { ...details, failed },
+			details: { ...details, failed, contentChanged },
 		};
 	}
 	if (written > 0) {
@@ -1120,11 +1134,11 @@ export async function reembedModelMigration(
 	}
 	return {
 		action,
-		success: failed === 0,
+		success: failed === 0 && contentChanged === 0,
 		affected: written,
 		message,
 		totalMatching,
-		details: { ...details, failed },
+		details: { ...details, failed, contentChanged },
 	};
 }
 

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -610,34 +610,47 @@ export interface EmbeddingRepairStats {
 	readonly orphaned: number;
 }
 
-const orphanedEmbeddingWhere = `e.source_type = 'memory'
-	AND (m.id IS NULL OR m.is_deleted = 1)
-	AND m2.id IS NULL`;
+function orphanedEmbeddingQuery(agentId?: string): { join: string; where: string; args: string[] } {
+	const agentScope =
+		agentId === undefined ? "" : " AND COALESCE(NULLIF(e.agent_id, ''), NULLIF(m.agent_id, ''), 'default') = ?";
+	const hashPeerScope =
+		agentId === undefined
+			? ""
+			: " AND COALESCE(NULLIF(m2.agent_id, ''), 'default') = COALESCE(NULLIF(e.agent_id, ''), NULLIF(m.agent_id, ''), 'default')";
+	return {
+		join: `LEFT JOIN memories m2
+			   ON e.source_type = 'memory' AND e.content_hash = m2.content_hash AND m2.is_deleted = 0${hashPeerScope}`,
+		where: `e.source_type = 'memory'
+			AND (m.id IS NULL OR m.is_deleted = 1)
+			AND m2.id IS NULL${agentScope}`,
+		args: agentId === undefined ? [] : [agentId],
+	};
+}
 
-function countOrphanedEmbeddings(db: ReadDb): number {
+function countOrphanedEmbeddings(db: ReadDb, agentId?: string): number {
+	const query = orphanedEmbeddingQuery(agentId);
 	const row = db
 		.prepare(
 			`SELECT COUNT(*) AS n FROM embeddings e
 			 LEFT JOIN memories m ON e.source_type = 'memory' AND e.source_id = m.id
-			 LEFT JOIN memories m2
-			   ON e.source_type = 'memory' AND e.content_hash = m2.content_hash AND m2.is_deleted = 0
-			 WHERE ${orphanedEmbeddingWhere}`,
+			 ${query.join}
+			 WHERE ${query.where}`,
 		)
-		.get() as { n: number } | undefined;
+		.get(...query.args) as { n: number } | undefined;
 	return row?.n ?? 0;
 }
 
-function listOrphanedEmbeddingIds(db: WriteDb, limit: number): Array<{ id: string }> {
+function listOrphanedEmbeddingIds(db: WriteDb, limit: number, agentId?: string): Array<{ id: string }> {
+	const query = orphanedEmbeddingQuery(agentId);
 	return db
 		.prepare(
 			`SELECT e.id FROM embeddings e
 			 LEFT JOIN memories m ON e.source_type = 'memory' AND e.source_id = m.id
-			 LEFT JOIN memories m2
-			   ON e.source_type = 'memory' AND e.content_hash = m2.content_hash AND m2.is_deleted = 0
-			 WHERE ${orphanedEmbeddingWhere}
+			 ${query.join}
+			 WHERE ${query.where}
 			 LIMIT ?`,
 		)
-		.all(limit) as Array<{ id: string }>;
+		.all(...query.args, limit) as Array<{ id: string }>;
 }
 
 export function getEmbeddingGapStats(accessor: DbAccessor, agentId?: string): EmbeddingGapStats {
@@ -686,7 +699,7 @@ export function getEmbeddingRepairStats(
 	const migration = accessor.withReadDb((db) =>
 		countEmbeddingMigrationRows(db, embeddingCfg.model, embeddingCfg.dimensions, false, agentId),
 	);
-	const orphaned = accessor.withReadDb((db) => countOrphanedEmbeddings(db));
+	const orphaned = accessor.withReadDb((db) => countOrphanedEmbeddings(db, agentId));
 	return { gap, migration, orphaned };
 }
 
@@ -1171,6 +1184,7 @@ export function cleanOrphanedEmbeddings(
 	ctx: RepairContext,
 	limiter: RateLimiter,
 	maxBatch = Number.MAX_SAFE_INTEGER,
+	agentId?: string,
 ): RepairResult {
 	const action = "cleanOrphanedEmbeddings";
 	const gate = checkRepairGate(cfg, ctx, limiter, action, cfg.repair.requeueCooldownMs, cfg.repair.requeueHourlyBudget);
@@ -1186,7 +1200,7 @@ export function cleanOrphanedEmbeddings(
 
 	const limit = Number.isFinite(maxBatch) && maxBatch > 0 ? Math.floor(maxBatch) : Number.MAX_SAFE_INTEGER;
 	const affected = accessor.withWriteTx((db) => {
-		const orphans = listOrphanedEmbeddingIds(db, limit);
+		const orphans = listOrphanedEmbeddingIds(db, limit, agentId);
 
 		if (orphans.length === 0) return 0;
 

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -842,7 +842,7 @@ async function reembedMissingMemoriesBatch(
 					memory.id,
 					memory.content,
 					now,
-					memory.agentId ?? agentId ?? null,
+					memory.agentId ?? agentId ?? "default",
 				);
 			// Resolve actual embedding ID (may differ from embId on conflict)
 			const actualRow = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(contentHash) as

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -34,7 +34,7 @@ import {
 	listUnembeddedMemories,
 } from "./embedding-coverage";
 import { type EmbeddingMigrationCoverage, stagingCoverage } from "./embedding-index-migration";
-import { readEmbeddingIndexState } from "./embedding-index-state";
+import { isActiveEmbeddingConfig, readEmbeddingIndexState } from "./embedding-index-state";
 import { type EmbeddingRepairState, readEmbeddingRepairState } from "./embedding-repair-state";
 import { classifyEntityQuality } from "./entity-quality";
 import { logger } from "./logger";
@@ -694,6 +694,7 @@ interface ReembedBatchOutcome {
 	readonly selected: number;
 	readonly written: number;
 	readonly failed: number;
+	readonly profileChanged: boolean;
 }
 
 let reembedInProgress = false;
@@ -713,6 +714,7 @@ async function reembedMissingMemoriesBatch(
 			selected: 0,
 			written: 0,
 			failed: 0,
+			profileChanged: false,
 		};
 	}
 
@@ -740,10 +742,17 @@ async function reembedMissingMemoriesBatch(
 			selected: unembedded.length,
 			written: 0,
 			failed: unembedded.length,
+			profileChanged: false,
 		};
 	}
 
-	const written = accessor.withWriteTx((db) => {
+	const writeOutcome = accessor.withWriteTx((db) => {
+		// Provider work happens outside the transaction. Promotion can therefore
+		// change the active vector space while this batch is being encoded.
+		// Never commit vectors from the superseded profile.
+		if (!isActiveEmbeddingConfig(db, embeddingCfg)) {
+			return { count: 0, profileChanged: true };
+		}
 		const now = new Date().toISOString();
 		let count = 0;
 		// Hoisted outside loop (pattern: db.prepare inside a loop is flagged)
@@ -804,13 +813,14 @@ async function reembedMissingMemoriesBatch(
 			}
 		}
 
-		return count;
+		return { count, profileChanged: false };
 	});
 
 	return {
 		selected: unembedded.length,
-		written,
+		written: writeOutcome.count,
 		failed: unembedded.length - results.length,
+		profileChanged: writeOutcome.profileChanged,
 	};
 }
 
@@ -885,6 +895,7 @@ export async function reembedMissingMemories(
 		let written = 0;
 		let failed = 0;
 		let batches = 0;
+		let profileChanged = false;
 
 		while (true) {
 			const outcome = await reembedMissingMemoriesBatch(accessor, embeddingFn, embeddingCfg, normalizedBatchSize);
@@ -895,6 +906,8 @@ export async function reembedMissingMemories(
 			written += outcome.written;
 			failed += outcome.failed;
 			batches++;
+			profileChanged ||= outcome.profileChanged;
+			if (outcome.profileChanged) break;
 
 			if (!runToCompletion) break;
 			if (outcome.selected < normalizedBatchSize) break;
@@ -907,6 +920,15 @@ export async function reembedMissingMemories(
 				success: true,
 				affected: 0,
 				message: "no unembedded memories found",
+			};
+		}
+
+		if (profileChanged) {
+			return {
+				action,
+				success: false,
+				affected: written,
+				message: "embedding profile changed during provider work; skipped stale vectors",
 			};
 		}
 

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -713,6 +713,7 @@ interface ReembedBatchOutcome {
 	readonly selected: number;
 	readonly written: number;
 	readonly failed: number;
+	readonly stale: number;
 	readonly profileChanged: boolean;
 }
 
@@ -734,6 +735,7 @@ async function reembedMissingMemoriesBatch(
 			selected: 0,
 			written: 0,
 			failed: 0,
+			stale: 0,
 			profileChanged: false,
 		};
 	}
@@ -762,6 +764,7 @@ async function reembedMissingMemoriesBatch(
 			selected: unembedded.length,
 			written: 0,
 			failed: unembedded.length,
+			stale: 0,
 			profileChanged: false,
 		};
 	}
@@ -771,11 +774,15 @@ async function reembedMissingMemoriesBatch(
 		// change the active vector space while this batch is being encoded.
 		// Never commit vectors from the superseded profile.
 		if (!isActiveEmbeddingConfig(db, embeddingCfg)) {
-			return { count: 0, profileChanged: true };
+			return { count: 0, stale: 0, profileChanged: true };
 		}
 		const now = new Date().toISOString();
 		let count = 0;
+		let stale = 0;
 		// Hoisted outside loop (pattern: db.prepare inside a loop is flagged)
+		const readCurrentMemory = db.prepare(
+			"SELECT content, content_hash, agent_id FROM memories WHERE id = ? AND is_deleted = 0",
+		);
 		const writeHash = db.prepare("UPDATE memories SET content_hash = ? WHERE id = ? AND content_hash IS NULL");
 		// Guard against unique constraint violation: idx_memories_content_hash_unique
 		// is a partial unique index on (content_hash) WHERE content_hash IS NOT NULL AND is_deleted = 0.
@@ -788,16 +795,34 @@ async function reembedMissingMemoriesBatch(
 		const readEmbeddingByHash = db.prepare("SELECT id, agent_id FROM embeddings WHERE content_hash = ? LIMIT 1");
 
 		for (const { memory, vector } of results) {
+			const current = readCurrentMemory.get(memory.id) as
+				| { content: string; content_hash: string | null; agent_id: string | null }
+				| null
+				| undefined;
+			if (current == null) {
+				stale++;
+				continue;
+			}
+
+			// Provider work happened before this transaction. Re-read the memory
+			// so a concurrent content mutation cannot receive a vector for its old
+			// content or hash.
+			if (current.content !== memory.content || current.content_hash !== memory.contentHash) {
+				stale++;
+				continue;
+			}
+
 			const contentHash =
-				typeof memory.contentHash === "string" && memory.contentHash.trim().length > 0
-					? memory.contentHash
-					: normalizeAndHashContent(memory.content).contentHash;
+				typeof current.content_hash === "string" && current.content_hash.trim().length > 0
+					? current.content_hash
+					: normalizeAndHashContent(current.content).contentHash;
+			const memoryAgentId = current.agent_id ?? agentId ?? "default";
 
 			// Write computed hash back to the memories row when it was NULL.
 			// Without this, the embedding-coverage queries can never use the
 			// content_hash match branch for these rows, so they keep showing up
 			// as unembedded and the backfill cycles indefinitely.
-			if (!memory.contentHash) {
+			if (current.content_hash == null) {
 				const collision = checkHash.get(contentHash, memory.id) as { id: string } | undefined;
 				if (!collision) writeHash.run(contentHash, memory.id);
 			}
@@ -809,7 +834,6 @@ async function reembedMissingMemoriesBatch(
 			const existing = readEmbeddingByHash.get(contentHash) as { id: string; agent_id: string | null } | undefined;
 			if (existing) {
 				const existingAgentId = existing.agent_id ?? "default";
-				const memoryAgentId = memory.agentId ?? agentId ?? "default";
 				if (existingAgentId !== memoryAgentId) continue;
 			}
 
@@ -854,13 +878,14 @@ async function reembedMissingMemoriesBatch(
 			}
 		}
 
-		return { count, profileChanged: false };
+		return { count, stale, profileChanged: false };
 	});
 
 	return {
 		selected: unembedded.length,
 		written: writeOutcome.count,
 		failed: unembedded.length - results.length,
+		stale: writeOutcome.stale,
 		profileChanged: writeOutcome.profileChanged,
 	};
 }
@@ -936,6 +961,7 @@ export async function reembedMissingMemories(
 		let attempted = 0;
 		let written = 0;
 		let failed = 0;
+		let stale = 0;
 		let batches = 0;
 		let profileChanged = false;
 
@@ -953,6 +979,7 @@ export async function reembedMissingMemories(
 			attempted += outcome.selected;
 			written += outcome.written;
 			failed += outcome.failed;
+			stale += outcome.stale;
 			batches++;
 			profileChanged ||= outcome.profileChanged;
 			if (outcome.profileChanged) break;
@@ -985,7 +1012,10 @@ export async function reembedMissingMemories(
 				action,
 				success: false,
 				affected: 0,
-				message: `embedding provider returned no vectors for ${attempted} memories`,
+				message:
+					stale > 0
+						? `re-embedded 0 of ${attempted} memories because ${stale} changed during provider work`
+						: `embedding provider returned no vectors for ${attempted} memories`,
 			};
 		}
 
@@ -1090,6 +1120,7 @@ export async function reembedModelMigration(
 	let written = 0;
 	let failed = 0;
 	let contentChanged = 0;
+	let crossAgentConflict = 0;
 	let profileChanged = false;
 	for (const row of rows) {
 		let vector: number[] | null;
@@ -1109,33 +1140,41 @@ export async function reembedModelMigration(
 		}
 		try {
 			const writeOutcome = accessor.withWriteTx(
-				(db): { wrote: boolean; profileChanged: boolean; contentChanged: boolean } => {
+				(db): { wrote: boolean; profileChanged: boolean; contentChanged: boolean; crossAgentConflict: boolean } => {
 					// Provider work happens outside the transaction. Promotion can therefore
 					// change the active vector space while this row is being encoded.
 					// Never commit a vector or model marker from the superseded profile.
 					if (!isActiveEmbeddingConfig(db, embeddingCfg))
-						return { wrote: false, profileChanged: true, contentChanged: false };
+						return { wrote: false, profileChanged: true, contentChanged: false, crossAgentConflict: false };
 					const current = db
-						.prepare("SELECT content, content_hash FROM memories WHERE id = ? AND is_deleted = 0")
-						.get(row.id) as { content: string; content_hash: string | null } | null;
-					if (!current) return { wrote: false, profileChanged: false, contentChanged: false };
+						.prepare("SELECT content, content_hash, agent_id FROM memories WHERE id = ? AND is_deleted = 0")
+						.get(row.id) as { content: string; content_hash: string | null; agent_id: string | null } | null;
+					if (!current)
+						return { wrote: false, profileChanged: false, contentChanged: false, crossAgentConflict: false };
 					// The provider encoded row.content before this transaction. If the
 					// memory changed while it awaited the provider, its vector belongs to
 					// the old row version and must not be committed under the new one.
 					if (current.content_hash !== row.contentHash || current.content !== row.content) {
-						return { wrote: false, profileChanged: false, contentChanged: true };
+						return { wrote: false, profileChanged: false, contentChanged: true, crossAgentConflict: false };
 					}
+					const memoryAgentId = current.agent_id ?? row.agentId ?? agentId;
 					const id = crypto.randomUUID();
+					const existing = db
+						.prepare("SELECT agent_id FROM embeddings WHERE content_hash = ? LIMIT 1")
+						.get(current.content_hash) as { agent_id: string | null } | null;
+					if (existing != null && (existing.agent_id ?? "default") !== (memoryAgentId ?? "default"))
+						return { wrote: false, profileChanged: false, contentChanged: false, crossAgentConflict: true };
 					db.prepare(
-						`INSERT INTO embeddings (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at) VALUES (?, ?, ?, ?, 'memory', ?, ?, datetime('now')) ON CONFLICT(content_hash) DO UPDATE SET vector=excluded.vector, dimensions=excluded.dimensions, source_id=excluded.source_id, chunk_text=excluded.chunk_text, created_at=excluded.created_at`,
-					).run(id, current.content_hash, vectorToBlob(vector), vector.length, row.id, row.content);
+						`INSERT INTO embeddings (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id) VALUES (?, ?, ?, ?, 'memory', ?, ?, datetime('now'), ?) ON CONFLICT(content_hash) DO UPDATE SET vector=excluded.vector, dimensions=excluded.dimensions, source_id=excluded.source_id, chunk_text=excluded.chunk_text, created_at=excluded.created_at`,
+					).run(id, current.content_hash, vectorToBlob(vector), vector.length, row.id, row.content, memoryAgentId);
 					const embedding = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(current.content_hash) as
 						| { id: string }
 						| undefined;
-					if (!embedding) return { wrote: false, profileChanged: false, contentChanged: false };
+					if (!embedding)
+						return { wrote: false, profileChanged: false, contentChanged: false, crossAgentConflict: false };
 					syncVecInsert(db, embedding.id, vector);
 					db.prepare("UPDATE memories SET embedding_model = ? WHERE id = ?").run(embeddingCfg.model, row.id);
-					return { wrote: true, profileChanged: false, contentChanged: false };
+					return { wrote: true, profileChanged: false, contentChanged: false, crossAgentConflict: false };
 				},
 			);
 			if (writeOutcome.profileChanged) {
@@ -1144,6 +1183,10 @@ export async function reembedModelMigration(
 			}
 			if (writeOutcome.contentChanged) {
 				contentChanged++;
+				continue;
+			}
+			if (writeOutcome.crossAgentConflict) {
+				crossAgentConflict++;
 				continue;
 			}
 			if (writeOutcome.wrote) written++;
@@ -1157,7 +1200,9 @@ export async function reembedModelMigration(
 	}
 	const message = `re-embedded ${written} of ${rows.length} selected memories${
 		failed > 0 ? ` (${failed} failed)` : ""
-	}${contentChanged > 0 ? ` (${contentChanged} changed during provider work)` : ""}`;
+	}${contentChanged > 0 ? ` (${contentChanged} changed during provider work)` : ""}${
+		crossAgentConflict > 0 ? ` (${crossAgentConflict} cross-agent hash conflict(s) skipped)` : ""
+	}`;
 	if (profileChanged) {
 		return {
 			action,
@@ -1165,7 +1210,7 @@ export async function reembedModelMigration(
 			affected: written,
 			message: "embedding profile changed during provider work; skipped stale migration vectors",
 			totalMatching,
-			details: { ...details, failed, contentChanged },
+			details: { ...details, failed, contentChanged, crossAgentConflict },
 		};
 	}
 	if (written > 0) {
@@ -1182,7 +1227,7 @@ export async function reembedModelMigration(
 	}
 	return {
 		action,
-		success: failed === 0 && contentChanged === 0,
+		success: failed === 0 && contentChanged === 0 && crossAgentConflict === 0,
 		affected: written,
 		message,
 		totalMatching,


### PR DESCRIPTION
## Summary

Autonomous maintenance detected queue, FTS, retention, and deduplication problems, but it could not reach the existing embedding repair actions. This wires degraded embedding health into the maintenance path so an enabled worker makes bounded, durable progress toward convergence without crossing agent boundaries.

## Changes

- Add health-gap diagnostics for missing vectors, model migration rows, and orphaned embeddings.
- Scope autonomous missing-vector counts and selection to the maintenance agent.
- Scope autonomous orphan diagnostics, selection, and cleanup to the maintenance agent (`embedding.agentId`), including same-agent hash-peer matching.
- Add a cross-agent regression proving maintenance for one agent does not mutate another agent's embeddings or vector-index rows.
- Add the `repairEmbeddingIndex` recommendation and execution path to the active maintenance worker.
- Reuse `reembedMissingMemories`, `reembedModelMigration`, and `cleanOrphanedEmbeddings` with orphan cleanup, missing vectors, and model migration prioritization.
- Route real pipeline startup embedding dependencies into maintenance without adding a second repair implementation.
- Clamp autonomous batches to 20 rows, use the existing durable lease and hourly budget, and charge committed row progress correctly.
- Keep promotion-race and content-mutation guards.
- Prevent agent-scoped missing-memory repair from mutating another agent's globally hash-unique embedding on a content-hash conflict.
- Persist `agent_id` when missing-memory repair inserts an embedding.
- Recheck memory ownership after provider work and skip migration vectors when ownership changes.
- Normalize empty memory ownership to the canonical `default` scope on autonomous writes.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations were added.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Passed locally:

- `bun install` in the isolated worktree.
- `bun test platform/daemon/src/repair-actions.test.ts` (72 passed, 0 failed, 286 expect calls), including deterministic ownership-change-during-await and empty-agent_id regressions, plus the earlier promotion, content, scope, hash-conflict, and persistence guards.
- `bun run --filter '@signet/core' build`
- `bun run --filter '@signet/daemon' build` (daemon bundle, TypeScript check, and dashboard production build).
- `bun run --filter '@signet/daemon' typecheck`
- `bunx biome format --write platform/daemon/src/repair-actions.ts platform/daemon/src/repair-actions.test.ts platform/daemon/src/embedding-coverage.ts`
- `bunx biome check platform/daemon/src/repair-actions.ts platform/daemon/src/repair-actions.test.ts platform/daemon/src/embedding-coverage.ts` (no errors; 3 pre-existing warnings remain).
- `git diff --check`

The full root typecheck and lint suites were not run. A running-daemon test was not needed for these focused database-selection and write-integrity regressions.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The implementation deliberately reuses the existing repair actions and the merged embedding-repair lease/budget state from #1447. Autonomous maintenance performs one bounded batch per cycle. Embedding orphan diagnostics and cleanup are evaluated and applied only within the configured maintenance agent scope; operator-triggered cleanup remains unscoped when no agent is supplied. It respects the existing `pipelineV2.autonomous.enabled` and `maintenanceMode` gates, and records committed row progress for durable budget accounting. Provider failures release the lease without charging progress and remain visible through the returned repair result and existing repair logging.

The mandatory readiness items marked complete are either covered by the focused checks above or are not applicable because this repair does not change the public API, schema, or admin route definitions. The full repository gates remain explicitly listed as not run.


