### PR TITLE
fix(daemon): defer startup integrity scan

### DIFF
--- a/platform/daemon/build.ts
+++ b/platform/daemon/build.ts
@@ -27,6 +27,7 @@ const targets: Array<{
 	{ entrypoint: "./src/mcp-stdio.ts", outfile: "./dist/mcp-stdio.js" },
 	{ entrypoint: "./src/index.ts", outfile: "./dist/index.js" },
 	{ entrypoint: "./src/synthesis-render-worker.ts", outfile: "./dist/synthesis-render-worker.js" },
+	{ entrypoint: "./src/database-integrity-worker.ts", outfile: "./dist/database-integrity-worker.js" },
 ];
 
 const forceNodeBuild = process.env.FORCE_NODE_BUILD === "1";

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -2370,18 +2370,22 @@ async function main() {
 					});
 				}
 			},
-		}).then((status) => {
-			if (status.state === "corrupt" || status.state === "unavailable") {
-				logger.error("startup-recovery", "Database integrity failed after readiness", undefined, {
-					state: status.state,
-					phase: status.phase,
-					quickCheck: status.quickCheck.messages,
-					telemetryCheck: status.telemetryCheck.messages,
-					guidance:
-						"Stop the daemon, back up the database, and run the operator integrity repair flow before restarting.",
-				});
-			}
-		});
+		})
+			.then((status) => {
+				if (status.state === "corrupt" || status.state === "unavailable") {
+					logger.error("startup-recovery", "Database integrity failed after readiness", undefined, {
+						state: status.state,
+						phase: status.phase,
+						quickCheck: status.quickCheck.messages,
+						telemetryCheck: status.telemetryCheck.messages,
+						guidance:
+							"Stop the daemon, back up the database, and run the operator integrity repair flow before restarting.",
+					});
+				}
+			})
+			.catch((error) => {
+				logger.error("startup-recovery", "Deferred database integrity check rejected", error);
+			});
 
 		const healthStampPath = join(DAEMON_DIR, "last-healthy-start");
 		try {

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -49,6 +49,7 @@ import {
 } from "./config-migration";
 import { listConnectors } from "./connectors/registry";
 import { clearAllPresence, reconcileAcpDeliveries } from "./cross-agent";
+import { runDeferredIntegrityCheck } from "./database-integrity";
 import { closeDbAccessor, getDbAccessor, getVectorRuntimeStatus, initDbAccessorAsync } from "./db-accessor";
 import { type VacuumConversionHandle, startVacuumConversionWorker } from "./db-vacuum";
 import { getQueueDiagnosticsSnapshot, getQueuePressureSnapshot } from "./diagnostics-queue";
@@ -183,6 +184,7 @@ import {
 	stopActiveTelemetry,
 	telemetryDisabledByEnv,
 } from "./telemetry";
+import { insertHistoryEvent } from "./transactions";
 import { type TranscriptCaptureWorkerHandle, startTranscriptCaptureWorker } from "./transcript-capture-worker";
 import { type TranscriptRecoveryWorkerHandle, startTranscriptRecoveryWorker } from "./transcript-recovery-worker";
 
@@ -2003,19 +2005,10 @@ async function main() {
 	startFdPollMonitor();
 
 	// Clean accumulated crash-loop damage (dead jobs, stagnant staging buffer,
-	// WAL bloat) before any worker starts. Fully synchronous — no yielding to
-	// the event loop — because pending boot operations (plugin init, route
-	// registration) would interfere with the DB write connection if allowed
-	// to run between recovery batches (#1059).
+	// WAL bloat) before any worker starts. Integrity scanning is deliberately
+	// not part of this synchronous phase. The full-database quick_check runs in
+	// a bounded worker after the HTTP server is ready (#1513).
 	const startupRecovery = runStartupRecovery(getDbAccessor());
-	if (
-		startupRecovery.databaseIntegrity.state === "corrupt" ||
-		startupRecovery.databaseIntegrity.state === "unavailable"
-	) {
-		throw new Error(
-			`Database integrity check failed before workers started (${startupRecovery.databaseIntegrity.state}). Resolve the database issue offline; if only the audit store prevents a verified telemetry repair, restart once with SIGNET_ALLOW_UNAUDITED_TELEMETRY_REPAIR=1.`,
-		);
-	}
 
 	// Purge artifacts of sources deleted while the daemon was down (e.g.
 	// crash-loop-disabled sources). This needs the DB accessor, so it runs
@@ -2354,6 +2347,41 @@ async function main() {
 		logFdSnapshot("server-ready");
 		writeDaemonLifecycle(AGENTS_DIR, buildLifecycleRecord("running"));
 		vacuumConversionHandle = startVacuumConversionWorker(getDbAccessor());
+		void runDeferredIntegrityCheck(getDbAccessor(), MEMORY_DB, {
+			timeoutMs: 30_000,
+			audit: (db, indexes) => {
+				try {
+					insertHistoryEvent(db, {
+						memoryId: "system",
+						event: "none",
+						oldContent: null,
+						newContent: null,
+						changedBy: "daemon",
+						reason: "deferred database integrity repair",
+						metadata: JSON.stringify({ repairAction: "reindex-telemetry", indexes }),
+						createdAt: new Date().toISOString(),
+						actorType: "daemon",
+					});
+				} catch (error) {
+					if (process.env.SIGNET_ALLOW_UNAUDITED_TELEMETRY_REPAIR !== "1") throw error;
+					logger.error("startup-recovery", "Telemetry index repair committed without audit", undefined, {
+						error: error instanceof Error ? error.message : String(error),
+						indexes,
+					});
+				}
+			},
+		}).then((status) => {
+			if (status.state === "corrupt" || status.state === "unavailable") {
+				logger.error("startup-recovery", "Database integrity failed after readiness", undefined, {
+					state: status.state,
+					phase: status.phase,
+					quickCheck: status.quickCheck.messages,
+					telemetryCheck: status.telemetryCheck.messages,
+					guidance:
+						"Stop the daemon, back up the database, and run the operator integrity repair flow before restarting.",
+				});
+			}
+		});
 
 		const healthStampPath = join(DAEMON_DIR, "last-healthy-start");
 		try {

--- a/platform/daemon/src/database-integrity-worker.ts
+++ b/platform/daemon/src/database-integrity-worker.ts
@@ -1,5 +1,4 @@
 import { createRequire } from "node:module";
-import { parentPort, workerData } from "node:worker_threads";
 
 const isBun = typeof (globalThis as Record<string, unknown>).Bun !== "undefined";
 const require = createRequire(import.meta.url);
@@ -15,14 +14,31 @@ type WorkerMessage = {
 	readonly result: { readonly quickCheck: IntegrityCheckStatus };
 };
 
-const db = new Database(workerData.dbPath, { readonly: true });
-try {
-	const rows = db.prepare("PRAGMA quick_check").all() as Array<{ quick_check?: unknown }>;
-	const messages = rows.map((row) => String(row.quick_check ?? ""));
-	const quickCheck: IntegrityCheckStatus =
-		messages.length === 1 && messages[0] === "ok" ? { ok: true, messages: [] } : { ok: false, messages };
-	const message: WorkerMessage = { type: "result", result: { quickCheck } };
-	parentPort?.postMessage(message);
-} finally {
-	db.close();
+function quickCheck(dbPath: string): IntegrityCheckStatus {
+	const db = new Database(dbPath, { readonly: true });
+	try {
+		const rows = db.prepare("PRAGMA quick_check").all() as Array<{ quick_check?: unknown }>;
+		const messages = rows.map((row) => String(row.quick_check ?? ""));
+		return messages.length === 1 && messages[0] === "ok" ? { ok: true, messages: [] } : { ok: false, messages };
+	} finally {
+		db.close();
+	}
+}
+
+export function runDatabaseIntegrityWorker(): void {
+	const processDbPath = process.env.SIGNET_DATABASE_INTEGRITY_DB_PATH;
+	if (processDbPath === undefined) throw new Error("database integrity worker requires a database path");
+	process.stdout.write("started\n");
+	const result: WorkerMessage = { type: "result", result: { quickCheck: quickCheck(processDbPath) } };
+	process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+const entrypoint = process.argv[1] ?? "";
+if (
+	process.env.SIGNET_DATABASE_INTEGRITY_DB_PATH !== undefined &&
+	(entrypoint.endsWith("database-integrity-worker.ts") ||
+		entrypoint.endsWith("database-integrity-worker.js") ||
+		entrypoint.endsWith("database-integrity-worker.mjs"))
+) {
+	runDatabaseIntegrityWorker();
 }

--- a/platform/daemon/src/database-integrity-worker.ts
+++ b/platform/daemon/src/database-integrity-worker.ts
@@ -1,0 +1,28 @@
+import { createRequire } from "node:module";
+import { parentPort, workerData } from "node:worker_threads";
+
+const isBun = typeof (globalThis as Record<string, unknown>).Bun !== "undefined";
+const require = createRequire(import.meta.url);
+const Database = isBun ? require("bun:sqlite").Database : require("better-sqlite3");
+
+type IntegrityCheckStatus = {
+	readonly ok: boolean;
+	readonly messages: readonly string[];
+};
+
+type WorkerMessage = {
+	readonly type: "result";
+	readonly result: { readonly quickCheck: IntegrityCheckStatus };
+};
+
+const db = new Database(workerData.dbPath, { readonly: true });
+try {
+	const rows = db.prepare("PRAGMA quick_check").all() as Array<{ quick_check?: unknown }>;
+	const messages = rows.map((row) => String(row.quick_check ?? ""));
+	const quickCheck: IntegrityCheckStatus =
+		messages.length === 1 && messages[0] === "ok" ? { ok: true, messages: [] } : { ok: false, messages };
+	const message: WorkerMessage = { type: "result", result: { quickCheck } };
+	parentPort?.postMessage(message);
+} finally {
+	db.close();
+}

--- a/platform/daemon/src/database-integrity.test.ts
+++ b/platform/daemon/src/database-integrity.test.ts
@@ -1,5 +1,9 @@
+import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, it } from "bun:test";
-import { repairTelemetryIndexes } from "./database-integrity";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { repairTelemetryIndexes, runDeferredIntegrityCheck } from "./database-integrity";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 
 function fakeAccessor(options: { readonly quickMessage?: string; readonly telemetryMessage?: string }): {
@@ -135,5 +139,54 @@ describe("telemetry database integrity recovery (#1360)", () => {
 		expect(result.state).toBe("corrupt");
 		expect(result.quickCheck.ok).toBe(false);
 		expect(reindexed).toEqual([]);
+	});
+});
+
+describe("deferred database integrity recovery (#1513)", () => {
+	it("keeps confirmed corruption fail-closed after the worker reports it", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "integrity-corrupt-"));
+		const workerPath = join(dir, "corrupt-worker.mjs");
+		writeFileSync(
+			workerPath,
+			'import { parentPort } from "node:worker_threads"; parentPort.postMessage({ type: "result", result: { quickCheck: { ok: false, messages: ["database disk image is malformed"] } } });\n',
+		);
+
+		const result = await runDeferredIntegrityCheck(fakeAccessor({}).accessor, "/tmp/not-used.db", {
+			workerPath,
+			timeoutMs: 1000,
+		});
+
+		expect(result.state).toBe("corrupt");
+		expect(result.phase).toBe("complete");
+		expect(result.quickCheck.messages).toEqual(["database disk image is malformed"]);
+		expect(result.repairGuidance).toContain("back up the database");
+	});
+
+	it("uses the bounded worker for a healthy SQLite database", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "integrity-healthy-"));
+		const dbPath = join(dir, "memory.db");
+		const database = new Database(dbPath);
+		database.exec("CREATE TABLE check_me (value TEXT)");
+		database.close();
+
+		const result = await runDeferredIntegrityCheck(fakeAccessor({}).accessor, dbPath, { timeoutMs: 5000 });
+
+		expect(result.state).toBe("healthy");
+		expect(result.phase).toBe("complete");
+		expect(result.quickCheck.ok).toBe(true);
+	});
+
+	it("bounds a worker that does not complete and returns actionable guidance", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "integrity-timeout-"));
+		const workerPath = join(dir, "slow-worker.mjs");
+		writeFileSync(workerPath, "setTimeout(() => {}, 1000);\n");
+		const result = await runDeferredIntegrityCheck(fakeAccessor({}).accessor, "/tmp/not-used.db", {
+			workerPath,
+			timeoutMs: 10,
+		});
+
+		expect(result.state).toBe("unavailable");
+		expect(result.phase).toBe("timed_out");
+		expect(result.repairGuidance).toContain("back up the database");
 	});
 });

--- a/platform/daemon/src/database-integrity.test.ts
+++ b/platform/daemon/src/database-integrity.test.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { repairTelemetryIndexes, runDeferredIntegrityCheck } from "./database-integrity";
@@ -148,7 +148,7 @@ describe("deferred database integrity recovery (#1513)", () => {
 		const workerPath = join(dir, "corrupt-worker.mjs");
 		writeFileSync(
 			workerPath,
-			'import { parentPort } from "node:worker_threads"; parentPort.postMessage({ type: "result", result: { quickCheck: { ok: false, messages: ["database disk image is malformed"] } } });\n',
+			'process.stdout.write(JSON.stringify({ type: "result", result: { quickCheck: { ok: false, messages: ["database disk image is malformed"] } } }) + "\\n");\n',
 		);
 
 		const result = await runDeferredIntegrityCheck(fakeAccessor({}).accessor, "/tmp/not-used.db", {
@@ -174,6 +174,55 @@ describe("deferred database integrity recovery (#1513)", () => {
 		expect(result.state).toBe("healthy");
 		expect(result.phase).toBe("complete");
 		expect(result.quickCheck.ok).toBe(true);
+	});
+
+	it("handles worker construction failures as unavailable", async () => {
+		const result = await runDeferredIntegrityCheck(fakeAccessor({}).accessor, "/tmp/not-used.db", {
+			workerPath: "/tmp/missing-database-integrity-worker.mjs",
+			timeoutMs: 1000,
+		});
+
+		expect(result.state).toBe("unavailable");
+		expect(result.phase).toBe("complete");
+		expect(result.repairGuidance).toContain("back up the database");
+	});
+
+	it("kills a synchronous scan at the deadline on a large fixture", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "integrity-large-"));
+		const dbPath = join(dir, "memory.db");
+		const workerPath = join(dir, "blocking-worker.mjs");
+		const database = new Database(dbPath);
+		database.exec("CREATE TABLE large_fixture (value TEXT)");
+		database.exec(
+			"WITH RECURSIVE numbers(value) AS (SELECT 1 UNION ALL SELECT value + 1 FROM numbers WHERE value < 250000) INSERT INTO large_fixture SELECT printf('fixture-%06d', value) FROM numbers",
+		);
+		database.close();
+		writeFileSync(
+			workerPath,
+			[
+				'import { Database } from "bun:sqlite";',
+				"const dbPath = process.env.SIGNET_DATABASE_INTEGRITY_DB_PATH;",
+				'if (dbPath === undefined) throw new Error("missing database path");',
+				'process.stdout.write("started\\n");',
+				"const database = new Database(dbPath, { readonly: true });",
+				'while (true) database.prepare("PRAGMA quick_check").all();',
+			].join("\n"),
+		);
+
+		const startedAt = Date.now();
+		let scanStarted = false;
+		const result = await runDeferredIntegrityCheck(fakeAccessor({}).accessor, dbPath, {
+			workerPath,
+			timeoutMs: 25,
+			onWorkerStarted: () => {
+				scanStarted = true;
+			},
+		});
+
+		expect(scanStarted).toBe(true);
+		expect(result.phase).toBe("timed_out");
+		expect(Date.now() - startedAt).toBeLessThan(500);
+		rmSync(dir, { recursive: true, force: true });
 	});
 
 	it("bounds a worker that does not complete and returns actionable guidance", async () => {

--- a/platform/daemon/src/database-integrity.ts
+++ b/platform/daemon/src/database-integrity.ts
@@ -7,7 +7,13 @@
  * when SQLite reports an index mismatch.
  */
 
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
+import { logger } from "./logger";
+import { resolveEmbeddedWorkerPath } from "./native-runtime-assets";
 
 export type DatabaseIntegrityState = "unknown" | "healthy" | "repaired" | "corrupt" | "unavailable";
 
@@ -19,19 +25,27 @@ export interface IntegrityCheckStatus {
 export interface DatabaseIntegrityStatus {
 	readonly checkedAt: string;
 	readonly state: DatabaseIntegrityState;
+	readonly phase: "pending" | "running" | "complete" | "timed_out";
 	readonly quickCheck: IntegrityCheckStatus;
 	readonly telemetryCheck: IntegrityCheckStatus;
 	readonly rebuiltIndexes: readonly string[];
+	readonly durationMs: number;
+	readonly repairGuidance: string | null;
 }
 
 const UNKNOWN_CHECK: IntegrityCheckStatus = { ok: false, messages: ["not checked"] };
+const REPAIR_GUIDANCE =
+	"Stop the daemon, back up the database, and run the operator integrity repair flow before restarting.";
 
 let latestStatus: DatabaseIntegrityStatus = {
 	checkedAt: "",
 	state: "unknown",
+	phase: "pending",
 	quickCheck: UNKNOWN_CHECK,
 	telemetryCheck: UNKNOWN_CHECK,
 	rebuiltIndexes: [],
+	durationMs: 0,
+	repairGuidance: null,
 };
 
 function check(db: ReadDb, pragma: "quick_check" | "integrity_check", table?: string): IntegrityCheckStatus {
@@ -61,13 +75,19 @@ function statusWith(
 	quickCheck: IntegrityCheckStatus,
 	telemetryCheck: IntegrityCheckStatus,
 	rebuiltIndexes: readonly string[],
+	phase: DatabaseIntegrityStatus["phase"] = "complete",
+	durationMs = 0,
+	repairGuidance: string | null = state === "corrupt" || state === "unavailable" ? REPAIR_GUIDANCE : null,
 ): DatabaseIntegrityStatus {
 	return {
 		checkedAt: new Date().toISOString(),
 		state,
+		phase,
 		quickCheck,
 		telemetryCheck,
 		rebuiltIndexes,
+		durationMs,
+		repairGuidance,
 	};
 }
 
@@ -82,6 +102,120 @@ export type TelemetryIndexRepairAudit = (
 	detectionMessages: readonly string[],
 ) => void;
 
+export interface DatabaseIntegrityWorkerResult {
+	readonly quickCheck: IntegrityCheckStatus;
+}
+
+export interface DatabaseIntegrityWorkerMessage {
+	readonly type: "result";
+	readonly result: DatabaseIntegrityWorkerResult;
+}
+
+export interface DeferredIntegrityCheckOptions {
+	readonly workerPath: string;
+	readonly timeoutMs?: number;
+	readonly audit?: TelemetryIndexRepairAudit;
+}
+
+const DEFAULT_INTEGRITY_TIMEOUT_MS = 30_000;
+let deferredIntegrityRun: Promise<DatabaseIntegrityStatus> | null = null;
+
+function workerPathFromModule(): string {
+	const moduleDir = dirname(fileURLToPath(import.meta.url));
+	const bundled = join(moduleDir, "database-integrity-worker.js");
+	if (existsSync(bundled)) return bundled;
+	return join(moduleDir, "database-integrity-worker.ts");
+}
+
+/**
+ * Run the global quick_check away from Bun's main event loop after readiness.
+ * SQLite does not expose progress callbacks for this pragma, so the caller
+ * gets a wall-clock deadline and periodic progress logs instead.
+ */
+export function runDeferredIntegrityCheck(
+	accessor: DbAccessor,
+	dbPath: string,
+	options: Partial<DeferredIntegrityCheckOptions> = {},
+): Promise<DatabaseIntegrityStatus> {
+	if (deferredIntegrityRun !== null) return deferredIntegrityRun;
+	const run = runDeferredIntegrityCheckInternal(accessor, dbPath, options);
+	deferredIntegrityRun = run;
+	const clear = (): void => {
+		if (deferredIntegrityRun === run) deferredIntegrityRun = null;
+	};
+	run.then(clear, clear);
+	return run;
+}
+
+async function runDeferredIntegrityCheckInternal(
+	accessor: DbAccessor,
+	dbPath: string,
+	options: Partial<DeferredIntegrityCheckOptions>,
+): Promise<DatabaseIntegrityStatus> {
+	const timeoutMs = options.timeoutMs ?? DEFAULT_INTEGRITY_TIMEOUT_MS;
+	const startedAt = Date.now();
+	latestStatus = statusWith("unknown", UNKNOWN_CHECK, UNKNOWN_CHECK, [], "running", 0);
+	logger.info("startup-recovery", "Deferred database integrity check started", { timeoutMs });
+	const workerPath =
+		options.workerPath ?? resolveEmbeddedWorkerPath("database-integrity-worker") ?? workerPathFromModule();
+	const worker = new Worker(workerPath, { workerData: { dbPath } });
+	let progressTimer: ReturnType<typeof setInterval> | undefined;
+
+	try {
+		const result = await new Promise<DatabaseIntegrityWorkerResult>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				void worker.terminate();
+				reject(new Error(`database integrity check exceeded ${timeoutMs}ms`));
+			}, timeoutMs);
+			progressTimer = setInterval(() => {
+				logger.info("startup-recovery", "Database integrity check in progress", {
+					elapsedMs: Date.now() - startedAt,
+					budgetMs: timeoutMs,
+				});
+			}, 1000);
+			worker.once("message", (message: DatabaseIntegrityWorkerMessage) => {
+				clearTimeout(timer);
+				resolve(message.result);
+			});
+			worker.once("error", (error) => {
+				clearTimeout(timer);
+				reject(error);
+			});
+			worker.once("exit", (code) => {
+				if (code !== 0) {
+					clearTimeout(timer);
+					reject(new Error(`database integrity worker exited with code ${code}`));
+				}
+			});
+		});
+		const databaseIntegrity = repairTelemetryIndexes(accessor, options.audit, { quickCheck: result.quickCheck });
+		latestStatus = { ...databaseIntegrity, durationMs: Date.now() - startedAt };
+		logger.info("startup-recovery", "Deferred database integrity check complete", {
+			state: latestStatus.state,
+			durationMs: latestStatus.durationMs,
+		});
+		return latestStatus;
+	} catch (error) {
+		latestStatus = statusWith(
+			"unavailable",
+			{ ok: false, messages: [error instanceof Error ? error.message : String(error)] },
+			UNKNOWN_CHECK,
+			[],
+			"timed_out",
+			Date.now() - startedAt,
+			REPAIR_GUIDANCE,
+		);
+		logger.error("startup-recovery", "Deferred database integrity check failed", undefined, {
+			error: latestStatus.quickCheck.messages[0],
+			durationMs: latestStatus.durationMs,
+		});
+		return latestStatus;
+	} finally {
+		if (progressTimer !== undefined) clearInterval(progressTimer);
+		await worker.terminate();
+	}
+}
+
 /**
  * Check the database before background workers start and repair only the
  * disposable telemetry indexes when the targeted check identifies damage.
@@ -90,13 +224,14 @@ export type TelemetryIndexRepairAudit = (
 export function repairTelemetryIndexes(
 	accessor: DbAccessor,
 	audit?: TelemetryIndexRepairAudit,
+	options?: { readonly quickCheck?: IntegrityCheckStatus },
 ): DatabaseIntegrityStatus {
 	let quickCheck: IntegrityCheckStatus;
 	let telemetryCheck: IntegrityCheckStatus;
 	let telemetryIndexes: readonly string[];
 	try {
 		const checks = accessor.withReadDb((db) => ({
-			quick: check(db, "quick_check"),
+			quick: options?.quickCheck ?? check(db, "quick_check"),
 			telemetry: check(db, "integrity_check", "telemetry_events"),
 			indexes: listTelemetryIndexes(db),
 		}));

--- a/platform/daemon/src/database-integrity.ts
+++ b/platform/daemon/src/database-integrity.ts
@@ -7,10 +7,10 @@
  * when SQLite reports an index mismatch.
  */
 
+import { type ChildProcess, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { Worker } from "node:worker_threads";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import { logger } from "./logger";
 import { resolveEmbeddedWorkerPath } from "./native-runtime-assets";
@@ -112,9 +112,10 @@ export interface DatabaseIntegrityWorkerMessage {
 }
 
 export interface DeferredIntegrityCheckOptions {
-	readonly workerPath: string;
+	readonly workerPath?: string;
 	readonly timeoutMs?: number;
 	readonly audit?: TelemetryIndexRepairAudit;
+	readonly onWorkerStarted?: () => void;
 }
 
 const DEFAULT_INTEGRITY_TIMEOUT_MS = 30_000;
@@ -129,8 +130,9 @@ function workerPathFromModule(): string {
 
 /**
  * Run the global quick_check away from Bun's main event loop after readiness.
- * SQLite does not expose progress callbacks for this pragma, so the caller
- * gets a wall-clock deadline and periodic progress logs instead.
+ * The scan runs in a child process because SQLite's synchronous PRAGMA cannot
+ * observe Worker.terminate() while native code is running. A child process can
+ * be SIGKILLed at the deadline, so the budget is a real upper bound.
  */
 export function runDeferredIntegrityCheck(
 	accessor: DbAccessor,
@@ -156,37 +158,71 @@ async function runDeferredIntegrityCheckInternal(
 	const startedAt = Date.now();
 	latestStatus = statusWith("unknown", UNKNOWN_CHECK, UNKNOWN_CHECK, [], "running", 0);
 	logger.info("startup-recovery", "Deferred database integrity check started", { timeoutMs });
-	const workerPath =
-		options.workerPath ?? resolveEmbeddedWorkerPath("database-integrity-worker") ?? workerPathFromModule();
-	const worker = new Worker(workerPath, { workerData: { dbPath } });
+	const embeddedWorkerPath = resolveEmbeddedWorkerPath("database-integrity-worker");
+	const workerPath = options.workerPath ?? embeddedWorkerPath ?? workerPathFromModule();
+	const workerArgs = options.workerPath === undefined && embeddedWorkerPath !== null ? [] : [workerPath];
+	let worker: ChildProcess | undefined;
+	let timedOut = false;
 	let progressTimer: ReturnType<typeof setInterval> | undefined;
 
 	try {
+		const child = spawn(process.execPath, workerArgs, {
+			env: {
+				...process.env,
+				SIGNET_DATABASE_INTEGRITY_DB_PATH: dbPath,
+			},
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		worker = child;
 		const result = await new Promise<DatabaseIntegrityWorkerResult>((resolve, reject) => {
 			const timer = setTimeout(() => {
-				void worker.terminate();
+				timedOut = true;
+				child.kill("SIGKILL");
 				reject(new Error(`database integrity check exceeded ${timeoutMs}ms`));
 			}, timeoutMs);
+			let output = "";
+			child.stdout.setEncoding("utf8");
+			child.stdout.on("data", (chunk: string) => {
+				for (const line of `${output}${chunk}`.split("\n").slice(0, -1)) {
+					if (line === "started") {
+						options.onWorkerStarted?.();
+						continue;
+					}
+					if (line.length > 0) {
+						try {
+							const message = JSON.parse(line) as DatabaseIntegrityWorkerMessage;
+							if (message.type === "result") {
+								clearTimeout(timer);
+								resolve(message.result);
+							}
+						} catch {
+							// The close handler reports a malformed or incomplete response.
+						}
+					}
+				}
+				output = `${output}${chunk}`.split("\n").at(-1) ?? "";
+			});
 			progressTimer = setInterval(() => {
 				logger.info("startup-recovery", "Database integrity check in progress", {
 					elapsedMs: Date.now() - startedAt,
 					budgetMs: timeoutMs,
 				});
 			}, 1000);
-			worker.once("message", (message: DatabaseIntegrityWorkerMessage) => {
-				clearTimeout(timer);
-				resolve(message.result);
-			});
-			worker.once("error", (error) => {
+			child.once("error", (error) => {
 				clearTimeout(timer);
 				reject(error);
 			});
-			worker.once("exit", (code) => {
+			child.once("close", (code) => {
+				if (timedOut) return;
 				if (code !== 0) {
 					clearTimeout(timer);
-					reject(new Error(`database integrity worker exited with code ${code}`));
+					reject(new Error(`database integrity worker exited with code ${code ?? "unknown"}`));
+				} else {
+					clearTimeout(timer);
+					reject(new Error("database integrity worker exited without a result"));
 				}
 			});
+			child.stderr.resume();
 		});
 		const databaseIntegrity = repairTelemetryIndexes(accessor, options.audit, { quickCheck: result.quickCheck });
 		latestStatus = { ...databaseIntegrity, durationMs: Date.now() - startedAt };
@@ -201,7 +237,7 @@ async function runDeferredIntegrityCheckInternal(
 			{ ok: false, messages: [error instanceof Error ? error.message : String(error)] },
 			UNKNOWN_CHECK,
 			[],
-			"timed_out",
+			timedOut ? "timed_out" : "complete",
 			Date.now() - startedAt,
 			REPAIR_GUIDANCE,
 		);
@@ -212,7 +248,7 @@ async function runDeferredIntegrityCheckInternal(
 		return latestStatus;
 	} finally {
 		if (progressTimer !== undefined) clearInterval(progressTimer);
-		await worker.terminate();
+		if (worker !== undefined && worker.exitCode === null) worker.kill("SIGKILL");
 	}
 }
 

--- a/platform/daemon/src/routes/health.ts
+++ b/platform/daemon/src/routes/health.ts
@@ -245,7 +245,10 @@ export function mountHealthRoutes(app: Hono): void {
 		const migrationsOk = dbResult?.migrationsOk ?? false;
 		const databaseIntegrity = getDatabaseIntegrityStatus();
 		if (databaseIntegrity.state === "corrupt" || databaseIntegrity.state === "unavailable") {
-			reasons.push(`database integrity ${databaseIntegrity.state}`);
+			reasons.push(
+				databaseIntegrity.repairGuidance ??
+					`database integrity ${databaseIntegrity.state}; stop the daemon, back up the database, and run the operator integrity repair flow`,
+			);
 		}
 		if (dbOk && !migrationsOk) {
 			reasons.push("pending migrations");

--- a/platform/daemon/src/startup-recovery.test.ts
+++ b/platform/daemon/src/startup-recovery.test.ts
@@ -212,6 +212,8 @@ describe("runStartupRecovery", () => {
 		expect(report1.documentLeasesRecovered).toBe(0);
 		expect(report1.stagingRowsCleaned).toBe(0);
 		expect(report1.orphanedPassesSwept).toBe(0);
+		expect(report1.databaseIntegrity.phase).toBe("pending");
+		expect(report1.databaseIntegrity.quickCheck.messages).toEqual(["not checked"]);
 
 		// Run again — still nothing.
 		const report2 = runStartupRecovery(getDbAccessor());

--- a/platform/daemon/src/startup-recovery.ts
+++ b/platform/daemon/src/startup-recovery.ts
@@ -18,11 +18,9 @@
 
 import { reconcileAcpDeliveries } from "./cross-agent";
 import type { DatabaseIntegrityStatus } from "./database-integrity";
-import { repairTelemetryIndexes } from "./database-integrity";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import { logger } from "./logger";
 import { recoverStaleLeases } from "./pipeline/stale-leases";
-import { insertHistoryEvent } from "./transactions";
 
 export interface StartupRecoveryReport {
 	readonly walCheckpointed: boolean;
@@ -39,7 +37,6 @@ const DEAD_JOB_RETENTION_DAYS = 7;
 const BATCH_SIZE = 500;
 const JOB_MAX_TOTAL = 50_000;
 const STAGING_MAX_TOTAL = 200_000;
-const ALLOW_UNAUDITED_TELEMETRY_REPAIR = "1";
 
 /**
  * Synchronous bounded batch drain. No yielding, no pressure checks.
@@ -71,40 +68,19 @@ function drainBatchesSync<Item>(
 export function runStartupRecovery(accessor: DbAccessor): StartupRecoveryReport {
 	const startedAt = Date.now();
 	logger.info("startup-recovery", "Running startup recovery");
-
-	const databaseIntegrity = repairTelemetryIndexes(accessor, (db, indexes) => {
-		try {
-			insertHistoryEvent(db, {
-				memoryId: "system",
-				event: "none",
-				oldContent: null,
-				newContent: null,
-				changedBy: "daemon",
-				reason: "startup database integrity repair",
-				metadata: JSON.stringify({ repairAction: "reindex-telemetry", indexes }),
-				createdAt: new Date().toISOString(),
-				actorType: "daemon",
-			});
-		} catch (error) {
-			if (process.env.SIGNET_ALLOW_UNAUDITED_TELEMETRY_REPAIR !== ALLOW_UNAUDITED_TELEMETRY_REPAIR) throw error;
-			logger.error("startup-recovery", "Telemetry index repair committed without audit", undefined, {
-				error: error instanceof Error ? error.message : String(error),
-				indexes,
-			});
-		}
-	});
-	if (databaseIntegrity.state === "repaired") {
-		logger.warn("startup-recovery", "Rebuilt corrupt telemetry indexes", {
-			indexes: databaseIntegrity.rebuiltIndexes,
-			messages: databaseIntegrity.telemetryCheck.messages,
-		});
-	} else if (databaseIntegrity.state === "corrupt" || databaseIntegrity.state === "unavailable") {
-		logger.error("startup-recovery", "Database integrity check failed", undefined, {
-			state: databaseIntegrity.state,
-			quickCheck: databaseIntegrity.quickCheck.messages,
-			telemetryCheck: databaseIntegrity.telemetryCheck.messages,
-		});
-	}
+	// The full-database quick_check is intentionally deferred until after the
+	// HTTP server is ready. Running it here monopolizes Bun's main thread on
+	// large databases and makes even /health/live unreachable (#1513).
+	const databaseIntegrity: DatabaseIntegrityStatus = {
+		checkedAt: "",
+		state: "unknown",
+		phase: "pending",
+		quickCheck: { ok: false, messages: ["not checked"] },
+		telemetryCheck: { ok: false, messages: ["not checked"] },
+		rebuiltIndexes: [],
+		durationMs: 0,
+		repairGuidance: null,
+	};
 
 	// NOTE: WAL checkpoint intentionally omitted. An explicit
 	// PRAGMA wal_checkpoint(TRUNCATE) during startup blocks the event loop for

--- a/scripts/build-native-bun.ts
+++ b/scripts/build-native-bun.ts
@@ -95,6 +95,7 @@ const hermesPluginDir = join(root, "integrations", "hermes-agent", "connector", 
 
 const workerEntries = [
 	["synthesis-render-worker", "platform/daemon/src/synthesis-render-worker.ts"],
+	["database-integrity-worker", "platform/daemon/src/database-integrity-worker.ts"],
 	// Native ONNX embedding runs in a worker so model download / WASM compile /
 	// inference can never block the daemon's main event loop (see
 	// embedding-worker.ts). Transformers is bundled into this asset; the ONNX

--- a/scripts/build-native-bun.ts
+++ b/scripts/build-native-bun.ts
@@ -334,7 +334,12 @@ if (!process.env.SIGNET_DIR?.trim()) {
 		}
 	}
 }
-await import("../surfaces/cli/src/cli.ts");
+if (process.env.SIGNET_DATABASE_INTEGRITY_DB_PATH) {
+	const { runDatabaseIntegrityWorker } = await import("../platform/daemon/src/database-integrity-worker");
+	runDatabaseIntegrityWorker();
+} else {
+	await import("../surfaces/cli/src/cli.ts");
+}
 `,
 );
 

--- a/web/docs/src/content/docs/diagnostics.md
+++ b/web/docs/src/content/docs/diagnostics.md
@@ -43,6 +43,13 @@ POST /api/repair/check-fts
 POST /api/repair/retention-sweep
 ```
 
+The daemon's full-database integrity scan runs in a single-flight worker after
+HTTP readiness, with a 30-second wall-clock budget and periodic progress logs.
+It transactionally rebuilds disposable telemetry indexes when only
+`telemetry_events` is corrupt. A confirmed failure is reported by `/health` and
+`/health/ready`, with actionable offline repair guidance. If the audit store
+prevents committing a verified repair, the default remains fail-closed.
+
 Examples:
 
 ```bash


### PR DESCRIPTION
## Summary

Move the full SQLite integrity scan out of synchronous daemon startup. Large databases can monopolize Bun's main thread before readiness, so the daemon now reports readiness first and runs the scan in a bounded single-flight worker with observable progress and fail-closed health reporting.

## Changes

- Keep startup recovery limited to bounded cleanup and leave integrity status pending before readiness.
- Run `PRAGMA quick_check` in a bundled worker after the server is ready, with a 30-second deadline and progress logs. The scan runs in a killable child process so the deadline remains hard even while SQLite is executing synchronously.
- Preserve transactional telemetry index repair and fail closed on confirmed corruption, unavailable checks, or failed repair audit.
- Expose phase, duration, and actionable repair guidance through health status.
- Add regression coverage for pending startup state, healthy worker completion, corruption, and timeout behavior.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: daemon diagnostics documentation

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations touched.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Targeted proof:

- `bun test platform/daemon/src/database-integrity.test.ts platform/daemon/src/startup-recovery.test.ts platform/daemon/src/routes/health.test.ts` passes: 25 tests, 0 failures, 100 expectations. This includes a 250,000-row fixture and a child process running a synchronous `PRAGMA quick_check`; the parent observed startup, killed it at the 25 ms deadline, and returned `timed_out` in 75 ms.
- `bun run --filter '@signet/core' build` passes.
- `bun run --filter '@signet/daemon' typecheck` passes after rebuilding the current core package.
- `bun run --filter '@signet/daemon' build` passes and emits `dist/database-integrity-worker.js`.
- `bunx biome check --no-errors-on-unmatched` on the five touched files exits successfully with five pre-existing warnings and no errors.
- `git diff --check` and `git show --check` pass.

Full root test/lint suites were not run.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This preserves the merged deferred vacuum conversion startup worker by launching the integrity worker alongside it after the `Daemon ready` log. The integrity scan now runs in a killable child process, so timeout cannot leave an uninterruptible SQLite call occupying a worker thread. The changed path also handles child startup failures and logs rejected background checks. Confirmed corruption or a timed-out/unavailable check changes readiness to non-ready with offline repair guidance. Background callers should observe `/health/ready` and `/health` rather than treating the initial pending status as corruption.