### PR TITLE
fix(daemon): bound telemetry JSONL

### DIFF
--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -11,7 +11,16 @@
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	rmSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { parseRoutingConfig } from "@signet/core";
 import { type DbAccessor, closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
@@ -25,6 +34,8 @@ import {
 	defaultTelemetryLogPath,
 	nextFlushIntervalMs,
 	parseTelemetryTimestamp,
+	TELEMETRY_LOG_MAX_BYTES,
+	TELEMETRY_LOG_MAX_ROTATED_FILES,
 	sanitizeCrashError,
 	setActiveTelemetry,
 	telemetryDeployment,
@@ -859,7 +870,7 @@ describe("telemetry lifecycle events (issue #1026 Phase 2)", () => {
 		}
 	});
 
-	it("mirrors recorded events to the open JSONL log", () => {
+	it("mirrors recorded events to the open JSONL log", async () => {
 		const collector = createTelemetryCollector(
 			fakeDbAccessor(),
 			{
@@ -876,6 +887,7 @@ describe("telemetry lifecycle events (issue #1026 Phase 2)", () => {
 
 		collector.record("daemon.started", { version: "0.163.15", platform: process.platform, uptimeMs: 0 });
 		collector.record("command.invoked", { command: "status" });
+		await collector.flush();
 
 		expect(existsSync(logPath)).toBe(true);
 		const lines = readFileSync(logPath, "utf-8").trim().split("\n");
@@ -906,13 +918,74 @@ describe("telemetry lifecycle events (issue #1026 Phase 2)", () => {
 			{ telemetryLogPath: logPath },
 		);
 
-		const before = readFileSync(logPath, "utf-8");
+		const before = existsSync(logPath) ? readFileSync(logPath, "utf-8") : "";
 		collector.recordDeferred?.("error.occurred", { type: "EventLoopLag", lagMs: 900 });
+		await collector.flush();
 		const afterRecord = readFileSync(logPath, "utf-8");
 		expect(afterRecord).not.toBe(before);
 		expect(afterRecord).toContain('"event":"error.occurred"');
-		await collector.flush();
 		expect(readFileSync(logPath, "utf-8")).toContain('"event":"error.occurred"');
+	});
+
+	it("writes queued JSONL events asynchronously in record order", async () => {
+		const collector = createTelemetryCollector(fakeDbAccessor(), { ...TELEMETRY_CONFIG, posthogHost: "" }, "0.163.15", {
+			telemetryLogPath: logPath,
+		});
+		collector.record("daemon.started", { marker: "first" });
+		collector.record("command.invoked", { marker: "second" });
+		collector.record("error.occurred", { marker: "third" });
+		await collector.flush();
+
+		const lines = readFileSync(logPath, "utf-8")
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line) as { readonly properties: { readonly marker?: string } });
+		expect(lines.map((line) => line.properties.marker).filter((marker) => marker)).toEqual([
+			"first",
+			"second",
+			"third",
+		]);
+	});
+
+	it("rotates the JSONL log at its size bound and retains only recent files", async () => {
+		const collector = createTelemetryCollector(fakeDbAccessor(), { ...TELEMETRY_CONFIG, posthogHost: "" }, "0.163.15", {
+			telemetryLogPath: logPath,
+			telemetryLogMaxBytes: 500,
+			telemetryLogMaxRotatedFiles: 2,
+		});
+		for (let i = 0; i < 8; i++) {
+			collector.record("command.invoked", { marker: `event-${i}` });
+		}
+		await collector.flush();
+
+		const files = readdirSync(join(dir, ".daemon", "telemetry")).filter((file) => file.endsWith(".jsonl"));
+		const rotated = files.filter((file) => file !== "events.jsonl");
+		expect(rotated.length).toBeLessThanOrEqual(2);
+		expect(files).toContain("events.jsonl");
+		expect(readFileSync(logPath, "utf-8")).toContain('"marker":"event-7"');
+		expect(TELEMETRY_LOG_MAX_BYTES).toBeGreaterThan(0);
+		expect(TELEMETRY_LOG_MAX_ROTATED_FILES).toBeGreaterThan(0);
+	});
+
+	it("removes rotated JSONL files outside the retention window", async () => {
+		const telemetryDir = join(dir, ".daemon", "telemetry");
+		mkdirSync(telemetryDir, { recursive: true });
+		const oldPath = join(telemetryDir, "events.older.jsonl");
+		const recentPath = join(telemetryDir, "events.recent.jsonl");
+		await Bun.write(oldPath, "old\n");
+		await Bun.write(recentPath, "recent\n");
+		const oldTime = new Date(Date.now() - 2 * 24 * 60 * 60 * 1_000);
+		utimesSync(oldPath, oldTime, oldTime);
+
+		const collector = createTelemetryCollector(fakeDbAccessor(), { ...TELEMETRY_CONFIG, posthogHost: "" }, "0.163.15", {
+			telemetryLogPath: logPath,
+			telemetryLogRetentionDays: 1,
+		});
+		collector.record("daemon.started", { marker: "cleanup" });
+		await collector.flush();
+
+		expect(existsSync(oldPath)).toBe(false);
+		expect(existsSync(recentPath)).toBe(true);
 	});
 
 	it("does not write a log when telemetryLogPath is omitted", () => {

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -988,6 +988,29 @@ describe("telemetry lifecycle events (issue #1026 Phase 2)", () => {
 		expect(existsSync(recentPath)).toBe(true);
 	});
 
+	it("counts JSONL events dropped when rotation fails without breaking the hot path", async () => {
+		const collector = createTelemetryCollector(
+			fakeDbAccessor(),
+			{
+				posthogHost: "",
+				posthogApiKey: "",
+				flushIntervalMs: 60000,
+				flushBatchSize: 50,
+				retentionDays: 90,
+				memorySearchQaEnabled: false,
+			},
+			"0.163.15",
+			{
+				telemetryLogPath: "/proc/self/stat",
+				telemetryLogMaxBytes: 1,
+			},
+		);
+
+		expect(() => collector.record("daemon.started", { version: "0.163.15" })).not.toThrow();
+		await collector.flush();
+		expect(collector.deliveryHealth().droppedEventCount).toBeGreaterThan(0);
+	});
+
 	it("does not write a log when telemetryLogPath is omitted", () => {
 		const collector = createTelemetryCollector(
 			fakeDbAccessor(),
@@ -1005,7 +1028,7 @@ describe("telemetry lifecycle events (issue #1026 Phase 2)", () => {
 		expect(existsSync(logPath)).toBe(false);
 	});
 
-	it("tolerates an unwritable log path without throwing", () => {
+	it("counts JSONL events dropped when log preparation fails without breaking the hot path", async () => {
 		const collector = createTelemetryCollector(
 			fakeDbAccessor(),
 			{
@@ -1017,9 +1040,12 @@ describe("telemetry lifecycle events (issue #1026 Phase 2)", () => {
 				memorySearchQaEnabled: false,
 			},
 			"0.163.15",
-			{ telemetryLogPath: "/dev/null/nonexistent/events.jsonl" },
+			{ telemetryLogPath: "/dev/full" },
 		);
+
 		expect(() => collector.record("daemon.started", { version: "0.163.15" })).not.toThrow();
+		await collector.flush();
+		expect(collector.deliveryHealth().droppedEventCount).toBeGreaterThan(0);
 	});
 });
 

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -105,12 +105,26 @@ async function appendToTelemetryLog(
 	let dropped = 0;
 	try {
 		await mkdir(dirname(logPath), { recursive: true });
-		for (const line of lines) {
-			const payload = `${line}\n`;
-			if (Buffer.byteLength(payload) > options.maxBytes) {
-				dropped++;
-				continue;
-			}
+	} catch (error) {
+		// The whole batch is undeliverable when its parent cannot be prepared.
+		// Count it explicitly rather than silently losing the lines removed from
+		// the pending queue. Telemetry must never break the daemon.
+		logger.warn("telemetry", "Failed to prepare JSONL audit log", {
+			dropped: lines.length,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return lines.length;
+	}
+
+	for (let index = 0; index < lines.length; index++) {
+		const line = lines[index];
+		if (line === undefined) continue;
+		const payload = `${line}\n`;
+		if (Buffer.byteLength(payload) > options.maxBytes) {
+			dropped++;
+			continue;
+		}
+		try {
 			let currentSize = 0;
 			try {
 				currentSize = (await stat(logPath)).size;
@@ -124,11 +138,21 @@ async function appendToTelemetryLog(
 				await rename(logPath, rotatedPath);
 			}
 			await appendFile(logPath, payload, "utf-8");
+		} catch (error) {
+			// Do not continue past a failed write or rotation. Writing a later line
+			// would make the JSONL appear reordered relative to this batch. The
+			// failed line and all following lines are dropped and reported together.
+			const remaining = lines.length - index;
+			dropped += remaining;
+			logger.warn("telemetry", "Dropped JSONL audit events after write failure", {
+				dropped: remaining,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			break;
 		}
-		await cleanupTelemetryLog(logPath, options);
-	} catch {
-		// Telemetry must never break the daemon. Best-effort only.
 	}
+
+	await cleanupTelemetryLog(logPath, options);
 	return dropped;
 }
 

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -7,7 +7,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFile, mkdir, readdir, rename, stat, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import {
 	type AccountingProvenance,
@@ -42,14 +42,94 @@ export function parseTelemetryTimestamp(timestamp: string): number {
 	return Date.parse(normalized);
 }
 
-function appendToTelemetryLog(logPath: string | null, line: string): void {
-	if (!logPath) return;
+export const TELEMETRY_LOG_MAX_BYTES = 10 * 1024 * 1024;
+export const TELEMETRY_LOG_MAX_ROTATED_FILES = 5;
+export const TELEMETRY_LOG_RETENTION_DAYS = 90;
+const MAX_PENDING_LOG_LINES = 1_000;
+
+let telemetryLogRotationSequence = 0;
+
+interface TelemetryLogOptions {
+	readonly maxBytes: number;
+	readonly maxRotatedFiles: number;
+	readonly retentionDays: number;
+}
+
+function rotatedTelemetryLogPrefix(logPath: string): string {
+	return `${logPath.slice(0, -".jsonl".length)}.`;
+}
+
+async function cleanupTelemetryLog(logPath: string, options: TelemetryLogOptions): Promise<void> {
+	const directory = dirname(logPath);
+	const basename = logPath.slice(directory.length + 1);
+	const prefix = rotatedTelemetryLogPrefix(basename);
+	let entries: string[];
 	try {
-		mkdirSync(dirname(logPath), { recursive: true });
-		appendFileSync(logPath, `${line}\n`, "utf-8");
+		entries = (await readdir(directory)).filter((entry) => entry.startsWith(prefix) && entry.endsWith(".jsonl"));
+	} catch {
+		return;
+	}
+
+	const cutoff = Date.now() - options.retentionDays * 24 * 60 * 60 * 1_000;
+	const rotated: Array<{ readonly path: string; readonly mtimeMs: number }> = [];
+	for (const entry of entries) {
+		const path = join(directory, entry);
+		try {
+			const metadata = await stat(path);
+			if (metadata.mtimeMs < cutoff) {
+				await unlink(path);
+				continue;
+			}
+			rotated.push({ path, mtimeMs: metadata.mtimeMs });
+		} catch {
+			// Another cleanup or operator action may remove a rotated file first.
+		}
+	}
+
+	rotated.sort((a, b) => b.mtimeMs - a.mtimeMs || b.path.localeCompare(a.path));
+	for (const entry of rotated.slice(Math.max(0, options.maxRotatedFiles))) {
+		try {
+			await unlink(entry.path);
+		} catch {
+			// Best effort retention cleanup.
+		}
+	}
+}
+
+async function appendToTelemetryLog(
+	logPath: string | null,
+	lines: readonly string[],
+	options: TelemetryLogOptions,
+): Promise<number> {
+	if (!logPath) return 0;
+	let dropped = 0;
+	try {
+		await mkdir(dirname(logPath), { recursive: true });
+		for (const line of lines) {
+			const payload = `${line}\n`;
+			if (Buffer.byteLength(payload) > options.maxBytes) {
+				dropped++;
+				continue;
+			}
+			let currentSize = 0;
+			try {
+				currentSize = (await stat(logPath)).size;
+			} catch (error) {
+				if (error && typeof error === "object" && "code" in error && error.code !== "ENOENT") {
+					throw error;
+				}
+			}
+			if (currentSize > 0 && currentSize + Buffer.byteLength(payload) > options.maxBytes) {
+				const rotatedPath = `${rotatedTelemetryLogPrefix(logPath)}${Date.now()}-${telemetryLogRotationSequence++}.jsonl`;
+				await rename(logPath, rotatedPath);
+			}
+			await appendFile(logPath, payload, "utf-8");
+		}
+		await cleanupTelemetryLog(logPath, options);
 	} catch {
 		// Telemetry must never break the daemon. Best-effort only.
 	}
+	return dropped;
 }
 
 // ---------------------------------------------------------------------------
@@ -240,9 +320,9 @@ function sessionCostProperties(cost: SessionCostAccumulator): TelemetryPropertie
 export interface TelemetryCollector {
 	record(event: TelemetryEventType, properties: TelemetryProperties): void;
 	/**
-	 * Record with a bounded synchronous JSONL audit append while deferring
-	 * SQLite persistence. The local line survives a hard process kill; the
-	 * wedge path does not enter SQLite or provider work.
+	 * Record with a bounded asynchronous JSONL audit append while deferring
+	 * SQLite persistence. The local line is best effort and may be dropped
+	 * under pressure; drops are included in delivery health.
 	 */
 	recordDeferred?(event: TelemetryEventType, properties: TelemetryProperties): void;
 	reopenSession(sessionHash: string): void;
@@ -623,12 +703,48 @@ export function createTelemetryCollector(
 	daemonVersion: string,
 	opts: {
 		readonly telemetryLogPath?: string | null;
+		readonly telemetryLogMaxBytes?: number;
+		readonly telemetryLogMaxRotatedFiles?: number;
+		readonly telemetryLogRetentionDays?: number;
 		readonly configSnapshot?: TelemetryConfigSnapshot;
 		readonly env?: NodeJS.ProcessEnv;
 	} = {},
 ): TelemetryCollector {
 	const buffer: TelemetryEvent[] = [];
 	const logPath = opts.telemetryLogPath ?? null;
+	const logOptions: TelemetryLogOptions = {
+		maxBytes: opts.telemetryLogMaxBytes ?? TELEMETRY_LOG_MAX_BYTES,
+		maxRotatedFiles: opts.telemetryLogMaxRotatedFiles ?? TELEMETRY_LOG_MAX_ROTATED_FILES,
+		retentionDays: opts.telemetryLogRetentionDays ?? TELEMETRY_LOG_RETENTION_DAYS,
+	};
+	const pendingLogLines: string[] = [];
+	let logFlushPromise: Promise<void> | null = null;
+
+	function flushLog(): Promise<void> {
+		if (!logPath || logFlushPromise) return logFlushPromise ?? Promise.resolve();
+		logFlushPromise = (async () => {
+			while (pendingLogLines.length > 0) {
+				const lines = pendingLogLines.splice(0, MAX_PENDING_LOG_LINES);
+				const dropped = await appendToTelemetryLog(logPath, lines, logOptions);
+				if (dropped > 0) recordDroppedEvents(dropped);
+			}
+		})()
+			.catch(() => {})
+			.finally(() => {
+				logFlushPromise = null;
+			});
+		return logFlushPromise;
+	}
+
+	function queueLogLine(event: TelemetryEvent): void {
+		if (!logPath) return;
+		if (pendingLogLines.length >= MAX_PENDING_LOG_LINES) {
+			pendingLogLines.shift();
+			recordDroppedEvents(1);
+		}
+		pendingLogLines.push(JSON.stringify(event));
+		void flushLog();
+	}
 	const deployment = telemetryDeployment(opts.env);
 	const reportedVersion = telemetryReportedVersion(daemonVersion, deployment);
 	const deploymentRole = telemetryDeploymentRole(config.deploymentRole, opts.env);
@@ -1078,7 +1194,7 @@ export function createTelemetryCollector(
 			properties: addContext(event, enrichSessionEvent(event, properties)),
 		};
 		buffer.push(next);
-		if (logPath) appendToTelemetryLog(logPath, JSON.stringify(next));
+		queueLogLine(next);
 	}
 
 	function drainBuffer(): void {
@@ -1262,11 +1378,12 @@ export function createTelemetryCollector(
 			if (!event) return;
 			// The database row is durable before the open log mirror is written.
 			// A failed log write must not affect the claim or delivery queue.
-			appendToTelemetryLog(logPath, JSON.stringify(event));
+			queueLogLine(event);
 		},
 
 		async flush(): Promise<void> {
 			await flushInternal(false, true);
+			await flushLog();
 		},
 
 		start(): void {
@@ -1296,11 +1413,13 @@ export function createTelemetryCollector(
 				flushTimer = null;
 			}
 			await flushInternal(true, true);
+			await flushLog();
 			// Stop accepting new events only after the first drain completes,
 			// so events recorded while an outbound request was awaiting are
 			// included in this final serialized drain.
 			recordingStopped = true;
 			await flushInternal(true, true);
+			await flushLog();
 			logger.info("telemetry", "Telemetry collector stopped");
 		},
 


### PR DESCRIPTION
## Summary

Bound the daemon's open telemetry JSONL audit log so high-volume telemetry cannot grow without limit or perform synchronous file I/O on the event hot path.

## Changes

- Replaced synchronous per-event `appendFileSync` with a bounded asynchronous JSONL queue and ordered batched writes.
- Added 10 MiB size-based rotation, five rotated-file retention, and a 90-day rotated-file retention window.
- Counted dropped audit lines when the bounded async queue is under pressure, preserving best-effort telemetry semantics.
- Added regression coverage for asynchronous ordering, size rotation, file-count retention, and age-based cleanup.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations are touched.

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused proof:

- `bun test platform/daemon/src/telemetry.test.ts` passed: 40 tests, 0 failures, 155 assertions.
- `bun run --filter '@signet/daemon' build` passed, including daemon `tsc --noEmit`.
- `bunx biome check platform/daemon/src/telemetry.ts platform/daemon/src/telemetry.test.ts` passed with two pre-existing informational regex suggestions in `telemetry.ts`.
- `git diff --check` passed.
- Full `bun run typecheck` remains blocked by pre-existing connector package errors unrelated to this change. The affected daemon package typecheck passed as part of its build.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The JSONL audit mirror remains best effort. SQLite/PostHog telemetry delivery behavior is unchanged. The default bounds are 10 MiB for the active file, five rotated files, and 90 days for rotated-file age; tests inject smaller bounds to exercise rotation deterministically.
