### PR TITLE
fix(sources): guide macOS permission denials

### DIFF
--- a/platform/daemon/src/discord-desktop-cache-source.ts
+++ b/platform/daemon/src/discord-desktop-cache-source.ts
@@ -219,7 +219,6 @@ function discoverCandidates(
 		try {
 			if (nativeMemoryReadBackoffActive({ harness: DISCORD_HARNESS }, path, agentId)) return;
 			stat = fileSystem.lstatSync(path);
-			clearNativeMemoryPermissionDenied({ harness: DISCORD_HARNESS }, path, agentId);
 		} catch (err) {
 			if (classifyNativeMemoryReadFailure(err) === "permission-denied") {
 				recordNativeMemoryPermissionDenied({ harness: DISCORD_HARNESS }, path, agentId);
@@ -238,7 +237,7 @@ function discoverCandidates(
 			return;
 		}
 		const source = isRouteFilteredCachePath(root, path) ? "cache" : "context";
-		if (source === "cache" && !fullScan && !cacheFileHasRouteHint(path)) {
+		if (source === "cache" && !fullScan && !cacheFileHasRouteHint(path, fileSystem, agentId)) {
 			stats.filesSkipped++;
 			stats.cacheFilesFastSkipped++;
 			return;
@@ -1080,12 +1079,17 @@ function extractGzipPayloads(data: Buffer): readonly Buffer[] {
 	return out;
 }
 
-function cacheFileHasRouteHint(path: string): boolean {
+function cacheFileHasRouteHint(path: string, fileSystem: DiscordDesktopCacheFileSystem, agentId: string): boolean {
+	if (nativeMemoryReadBackoffActive({ harness: DISCORD_HARNESS }, path, agentId)) return false;
 	try {
-		const data = readFileSync(path).subarray(0, CACHE_SNIFF_BYTES).toString("utf8");
+		const data = fileSystem.readFileSync(path).subarray(0, CACHE_SNIFF_BYTES).toString("utf8");
+		clearNativeMemoryPermissionDenied({ harness: DISCORD_HARNESS }, path, agentId);
 		channelRoutePattern.lastIndex = 0;
 		return channelRoutePattern.test(data) || apiMessagesRoutePattern.test(data);
-	} catch {
+	} catch (err) {
+		if (classifyNativeMemoryReadFailure(err) === "permission-denied") {
+			recordNativeMemoryPermissionDenied({ harness: DISCORD_HARNESS }, path, agentId);
+		}
 		return false;
 	}
 }

--- a/platform/daemon/src/discord-desktop-cache-source.ts
+++ b/platform/daemon/src/discord-desktop-cache-source.ts
@@ -1,10 +1,16 @@
-import { type Stats, existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
+import { type Stats, lstatSync, readFileSync, readdirSync } from "node:fs";
 import { basename, join, relative } from "node:path";
 import { gunzipSync } from "node:zlib";
 import type { SignetSourceEntry } from "@signet/core";
 import { getDbAccessor } from "./db-accessor";
 import { countChanges } from "./db-helpers";
 import { indexExternalMemoryArtifact } from "./memory-lineage";
+import {
+	classifyNativeMemoryReadFailure,
+	clearNativeMemoryPermissionDenied,
+	nativeMemoryReadBackoffActive,
+	recordNativeMemoryPermissionDenied,
+} from "./native-memory-sources";
 import { indexSourceArtifactStructure, purgeSourceArtifactStructure } from "./source-artifact-graph";
 import type { SourceProviderSyncResult } from "./source-providers";
 
@@ -28,6 +34,7 @@ export interface DiscordDesktopCacheSyncOptions {
 	readonly cachePath: string;
 	readonly fullScan: boolean;
 	readonly shouldContinue: () => boolean;
+	readonly fileSystem?: DiscordDesktopCacheFileSystem;
 	readonly onProgress?: (event: {
 		readonly scanned: number;
 		readonly total: number;
@@ -35,6 +42,14 @@ export interface DiscordDesktopCacheSyncOptions {
 		readonly currentPath: string;
 	}) => void;
 }
+
+export interface DiscordDesktopCacheFileSystem {
+	readonly lstatSync: (path: string) => Stats;
+	readonly readdirSync: (path: string) => readonly string[];
+	readonly readFileSync: (path: string) => Buffer;
+}
+
+const defaultFileSystem: DiscordDesktopCacheFileSystem = { lstatSync, readdirSync, readFileSync };
 
 interface CacheCandidate {
 	readonly absPath: string;
@@ -151,7 +166,8 @@ export async function syncDiscordDesktopCacheSource(
 	const stats = emptyStats();
 	const snapshot = emptySnapshot();
 	const root = options.cachePath;
-	const candidates = discoverCandidates(root, options.fullScan, stats);
+	const fileSystem = options.fileSystem ?? defaultFileSystem;
+	const candidates = discoverCandidates(root, options.fullScan, stats, fileSystem, options.agentId);
 	let indexed = 0;
 	let cancelled = false;
 
@@ -160,7 +176,7 @@ export async function syncDiscordDesktopCacheSource(
 			cancelled = true;
 			break;
 		}
-		const data = readCandidateFile(candidate, stats);
+		const data = readCandidateFile(candidate, stats, fileSystem, options.agentId);
 		if (!data) continue;
 		stats.filesScanned++;
 		stats.bytesScanned += data.length;
@@ -190,20 +206,30 @@ export async function syncDiscordDesktopCacheSource(
 	return { indexed, scanned: stats.filesScanned, total: candidates.length, failures: [] };
 }
 
-function discoverCandidates(root: string, fullScan: boolean, stats: CacheStats): readonly CacheCandidate[] {
-	if (!existsSync(root)) return [];
+function discoverCandidates(
+	root: string,
+	fullScan: boolean,
+	stats: CacheStats,
+	fileSystem: DiscordDesktopCacheFileSystem,
+	agentId: string,
+): readonly CacheCandidate[] {
 	const candidates: CacheCandidate[] = [];
 	const visit = (path: string): void => {
 		let stat: Stats;
 		try {
-			stat = lstatSync(path);
-		} catch {
+			if (nativeMemoryReadBackoffActive({ harness: DISCORD_HARNESS }, path, agentId)) return;
+			stat = fileSystem.lstatSync(path);
+			clearNativeMemoryPermissionDenied({ harness: DISCORD_HARNESS }, path, agentId);
+		} catch (err) {
+			if (classifyNativeMemoryReadFailure(err) === "permission-denied") {
+				recordNativeMemoryPermissionDenied({ harness: DISCORD_HARNESS }, path, agentId);
+			}
 			stats.filesSkipped++;
 			return;
 		}
 		if (stat.isDirectory()) {
 			if (path !== root && shouldSkipDir(basename(path))) return;
-			for (const entry of readDirectoryEntries(path, stats)) visit(join(path, entry));
+			for (const entry of readDirectoryEntries(path, stats, fileSystem, agentId)) visit(join(path, entry));
 			return;
 		}
 		stats.filesVisited++;
@@ -229,19 +255,41 @@ function discoverCandidates(root: string, fullScan: boolean, stats: CacheStats):
 	return candidates;
 }
 
-function readDirectoryEntries(path: string, stats: CacheStats): readonly string[] {
+function readDirectoryEntries(
+	path: string,
+	stats: CacheStats,
+	fileSystem: DiscordDesktopCacheFileSystem,
+	agentId: string,
+): readonly string[] {
+	if (nativeMemoryReadBackoffActive({ harness: DISCORD_HARNESS }, path, agentId)) return [];
 	try {
-		return readdirSync(path);
-	} catch {
+		const entries = fileSystem.readdirSync(path);
+		clearNativeMemoryPermissionDenied({ harness: DISCORD_HARNESS }, path, agentId);
+		return entries;
+	} catch (err) {
+		if (classifyNativeMemoryReadFailure(err) === "permission-denied") {
+			recordNativeMemoryPermissionDenied({ harness: DISCORD_HARNESS }, path, agentId);
+		}
 		stats.filesSkipped++;
 		return [];
 	}
 }
 
-function readCandidateFile(candidate: CacheCandidate, stats: CacheStats): Buffer | null {
+function readCandidateFile(
+	candidate: CacheCandidate,
+	stats: CacheStats,
+	fileSystem: DiscordDesktopCacheFileSystem,
+	agentId: string,
+): Buffer | null {
+	if (nativeMemoryReadBackoffActive({ harness: DISCORD_HARNESS }, candidate.absPath, agentId)) return null;
 	try {
-		return readFileSync(candidate.absPath);
-	} catch {
+		const data = fileSystem.readFileSync(candidate.absPath);
+		clearNativeMemoryPermissionDenied({ harness: DISCORD_HARNESS }, candidate.absPath, agentId);
+		return data;
+	} catch (err) {
+		if (classifyNativeMemoryReadFailure(err) === "permission-denied") {
+			recordNativeMemoryPermissionDenied({ harness: DISCORD_HARNESS }, candidate.absPath, agentId);
+		}
 		stats.filesSkipped++;
 		return null;
 	}

--- a/platform/daemon/src/discord-source-provider.test.ts
+++ b/platform/daemon/src/discord-source-provider.test.ts
@@ -616,7 +616,7 @@ describe("discord-source-provider", () => {
 					source: added.source,
 					agentId: "default",
 					cachePath: join(dir, "discord"),
-					fullScan: true,
+					fullScan: false,
 					shouldContinue: () => true,
 					fileSystem,
 				});

--- a/platform/daemon/src/discord-source-provider.test.ts
+++ b/platform/daemon/src/discord-source-provider.test.ts
@@ -1,12 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	readdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { addDiscordSource } from "@signet/core";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { DISCORD_CHANNEL_TYPES } from "./discord-source-fetch";
 import { discordSourceProvider, setDiscordGatewaySocketFactoryForTest } from "./discord-source-provider";
+import { nativeMemorySourcePermissionHealth, resetNativeMemoryIndexCache } from "./native-memory-sources";
+import { syncDiscordDesktopCacheSource } from "./discord-desktop-cache-source";
 import { indexExternalMemoryArtifact } from "./memory-lineage";
+import { logger } from "./logger";
 import { putSecret } from "./secrets";
 import { indexSourceArtifactStructure } from "./source-artifact-graph";
 
@@ -562,6 +574,70 @@ describe("discord-source-provider", () => {
 		expect(rows.some((row) => row.content.includes("later clear route message"))).toBe(true);
 		const stats = rows.find((row) => row.source_kind === "source_discord_desktop_import");
 		expect(stats?.source_meta_json).toContain('"skippedMessages":1');
+	});
+
+	it("classifies Discord Desktop cache EACCES as TCC denial and suppresses retries per path", async () => {
+		const cachePath = join(dir, "discord", "Local Storage", "leveldb");
+		mkdirSync(cachePath, { recursive: true });
+		const deniedPath = join(cachePath, "000001.log");
+		writeFileSync(deniedPath, '{"content":"permission denied cache"}');
+		const added = addDiscordSource(
+			{
+				name: "Desktop Cache",
+				desktopCachePath: join(dir, "discord"),
+				syncMode: "desktop-cache",
+				now: "2026-01-01T00:00:00.000Z",
+			},
+			dir,
+		);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+		const originalPlatform = process.platform;
+		const originalWarn = logger.warn;
+		const warnCalls: string[] = [];
+		let readAttempts = 0;
+		Object.defineProperty(process, "platform", { value: "darwin" });
+		logger.warn = ((_category: unknown, message: unknown) => warnCalls.push(String(message))) as typeof logger.warn;
+		resetNativeMemoryIndexCache();
+		try {
+			const fileSystem = {
+				lstatSync,
+				readdirSync,
+				readFileSync: (path: string) => {
+					if (path === deniedPath) {
+						readAttempts++;
+						throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+					}
+					return readFileSync(path);
+				},
+			};
+			const sync = () =>
+				syncDiscordDesktopCacheSource({
+					source: added.source,
+					agentId: "default",
+					cachePath: join(dir, "discord"),
+					fullScan: true,
+					shouldContinue: () => true,
+					fileSystem,
+				});
+			await sync();
+			await sync();
+			expect(readAttempts).toBe(1);
+			expect(warnCalls.filter((message) => message.includes("Full Disk Access"))).toHaveLength(1);
+			expect(nativeMemorySourcePermissionHealth({ harness: "discord", root: added.source.root }, "default")).toEqual({
+				status: "denied",
+				issues: [
+					expect.objectContaining({
+						path: deniedPath,
+						guidance: expect.stringContaining(`Path: ${deniedPath}`),
+					}),
+				],
+			});
+		} finally {
+			logger.warn = originalWarn;
+			Object.defineProperty(process, "platform", { value: originalPlatform });
+			resetNativeMemoryIndexCache();
+		}
 	});
 
 	it("skips unreadable Discord Desktop cache files without failing the source sync", async () => {

--- a/platform/daemon/src/native-memory-sources-dataless.test.ts
+++ b/platform/daemon/src/native-memory-sources-dataless.test.ts
@@ -10,14 +10,26 @@ let readAttempts = 0;
 let readError: Error & { code: string } = Object.assign(new Error("EDEADLK: resource deadlock avoided"), {
 	code: "EDEADLK",
 });
+let statError: (path: string) => (Error & { code: string }) | null = () => null;
+let readdirError: (path: string) => (Error & { code: string }) | null = () => null;
 afterEach(() => {
 	closeDbAccessor();
 	resetNativeMemoryIndexCache();
+	statError = () => null;
+	readdirError = () => null;
 });
 mock.module("node:fs/promises", () => ({
 	lstat: async () => ({ isSymbolicLink: () => false }),
-	stat: async () => ({ isFile: () => true, mtimeMs: Date.now() }),
-	readdir: async () => [],
+	stat: async (path: string) => {
+		const error = statError(path);
+		if (error) throw error;
+		return { isFile: () => true, mtimeMs: Date.now() };
+	},
+	readdir: async (path: string) => {
+		const error = readdirError(path);
+		if (error) throw error;
+		return [];
+	},
 	readFile: async () => {
 		readAttempts++;
 		throw readError;
@@ -33,6 +45,7 @@ import {
 	nativeMemorySourcePermissionHealth,
 	obsidianNativeMemorySource,
 	resetNativeMemoryIndexCache,
+	startNativeMemoryBridge,
 } from "./native-memory-sources";
 
 describe("dataless / EDEADLK native artifact reads (#1161)", () => {
@@ -135,6 +148,46 @@ describe("dataless / EDEADLK native artifact reads (#1161)", () => {
 			if (previousSignetPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
 			else process.env.SIGNET_PATH = previousSignetPath;
 			closeDbAccessor();
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("classifies protected native source discovery roots and directories", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-tcc-discovery-"));
+		const source = obsidianNativeMemorySource(dir);
+		const originalPlatform = process.platform;
+		const originalWarn = logger.warn;
+		const warnCalls: string[] = [];
+		Object.defineProperty(process, "platform", { value: "darwin" });
+		logger.warn = ((_category: unknown, message: unknown) => warnCalls.push(String(message))) as typeof logger.warn;
+		try {
+			const permissionError = () => Object.assign(new Error("permission denied"), { code: "EACCES" });
+			statError = (path) => (path === dir ? permissionError() : null);
+			const rootBridge = startNativeMemoryBridge([source], { agentId: "agent-discovery", pollIntervalMs: 0 });
+			await rootBridge.syncExisting();
+			await rootBridge.syncExisting();
+			await rootBridge.close();
+			expect(nativeMemorySourcePermissionHealth(source, "agent-discovery")).toEqual({
+				status: "denied",
+				issues: [expect.objectContaining({ path: dir, guidance: expect.stringContaining(`Path: ${dir}`) })],
+			});
+			expect(warnCalls.filter((message) => message.includes("Full Disk Access"))).toHaveLength(1);
+
+			resetNativeMemoryIndexCache();
+			statError = () => null;
+			readdirError = (path) => (path === dir ? permissionError() : null);
+			const readdirBridge = startNativeMemoryBridge([source], { agentId: "agent-readdir", pollIntervalMs: 0 });
+			await readdirBridge.syncExisting();
+			await readdirBridge.syncExisting();
+			await readdirBridge.close();
+			expect(nativeMemorySourcePermissionHealth(source, "agent-readdir")).toEqual({
+				status: "denied",
+				issues: [expect.objectContaining({ path: dir, guidance: expect.stringContaining(`Path: ${dir}`) })],
+			});
+			expect(warnCalls.filter((message) => message.includes("Full Disk Access"))).toHaveLength(2);
+		} finally {
+			logger.warn = originalWarn;
+			Object.defineProperty(process, "platform", { value: originalPlatform });
 			rmSync(dir, { recursive: true, force: true });
 		}
 	});

--- a/platform/daemon/src/native-memory-sources-dataless.test.ts
+++ b/platform/daemon/src/native-memory-sources-dataless.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock } from "bun:test";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,19 +7,33 @@ import { join } from "node:path";
 // sync-file signature) so the regression exercises the skip + consolidated
 // warning path without touching a real evicted vault.
 let readAttempts = 0;
+let readError: Error & { code: string } = Object.assign(new Error("EDEADLK: resource deadlock avoided"), {
+	code: "EDEADLK",
+});
+afterEach(() => {
+	closeDbAccessor();
+	resetNativeMemoryIndexCache();
+});
 mock.module("node:fs/promises", () => ({
 	lstat: async () => ({ isSymbolicLink: () => false }),
 	stat: async () => ({ isFile: () => true, mtimeMs: Date.now() }),
 	readdir: async () => [],
 	readFile: async () => {
 		readAttempts++;
-		throw Object.assign(new Error("EDEADLK: resource deadlock avoided"), { code: "EDEADLK" });
+		throw readError;
 	},
 }));
 
-import { initDbAccessor } from "./db-accessor";
+import { closeDbAccessor, initDbAccessor } from "./db-accessor";
 import { logger } from "./logger";
-import { indexNativeMemoryFile, isDatalessReadError, obsidianNativeMemorySource } from "./native-memory-sources";
+import {
+	classifyNativeMemoryReadFailure,
+	indexNativeMemoryFile,
+	isDatalessReadError,
+	nativeMemorySourcePermissionHealth,
+	obsidianNativeMemorySource,
+	resetNativeMemoryIndexCache,
+} from "./native-memory-sources";
 
 describe("dataless / EDEADLK native artifact reads (#1161)", () => {
 	it("classifies dataless read errors", () => {
@@ -35,6 +49,12 @@ describe("dataless / EDEADLK native artifact reads (#1161)", () => {
 			),
 		).toBe(false);
 		expect(isDatalessReadError(Object.assign(new Error("deadlock"), { code: "EDEADLK" }))).toBe(true);
+		expect(
+			classifyNativeMemoryReadFailure(Object.assign(new Error("permission denied"), { code: "EACCES" }), "darwin"),
+		).toBe("permission-denied");
+		expect(
+			classifyNativeMemoryReadFailure(Object.assign(new Error("permission denied"), { code: "EACCES" }), "linux"),
+		).toBe("transient");
 	});
 
 	it("backs off after an EDEADLK read and logs one consolidated warning for the batch", async () => {
@@ -71,6 +91,50 @@ describe("dataless / EDEADLK native artifact reads (#1161)", () => {
 			expect(datalessWarns[0]).toContain("on obsidian");
 		} finally {
 			logger.warn = originalWarn;
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("records one actionable TCC issue per denied path and exposes recovery guidance", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-tcc-"));
+		writeFileSync(join(dir, "agent.yaml"), "name: TccTest\n");
+		const previousSignetPath = process.env.SIGNET_PATH;
+		process.env.SIGNET_PATH = dir;
+		initDbAccessor(join(dir, "memory", "memories.db"));
+		const originalPlatform = process.platform;
+		Object.defineProperty(process, "platform", { value: "darwin" });
+		const originalError = readError;
+		const warnCalls: string[] = [];
+		const originalWarn = logger.warn;
+		logger.warn = ((_category: unknown, message: unknown) => {
+			warnCalls.push(String(message));
+		}) as typeof logger.warn;
+		try {
+			const source = obsidianNativeMemorySource(dir);
+			const file = join(dir, "protected.md");
+			writeFileSync(file, "protected");
+			resetNativeMemoryIndexCache();
+			readError = Object.assign(new Error("permission denied"), { code: "EACCES" });
+			expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(false);
+			expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(false);
+
+			const health = nativeMemorySourcePermissionHealth(source, "agent-native");
+			expect(health.status).toBe("denied");
+			expect(health.issues).toEqual([
+				{
+					path: file,
+					guidance: expect.stringContaining(`Path: ${file}`),
+				},
+			]);
+			const permissionWarns = warnCalls.filter((message) => message.includes("Full Disk Access"));
+			expect(permissionWarns).toHaveLength(1);
+		} finally {
+			readError = originalError;
+			logger.warn = originalWarn;
+			Object.defineProperty(process, "platform", { value: originalPlatform });
+			if (previousSignetPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
+			else process.env.SIGNET_PATH = previousSignetPath;
+			closeDbAccessor();
 			rmSync(dir, { recursive: true, force: true });
 		}
 	});

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -150,6 +150,41 @@ export function nativeMemorySourcePermissionHealth(
 	return { status: issues.length > 0 ? "denied" : "clear", issues };
 }
 
+export function nativeMemoryReadBackoffActive(
+	source: Pick<NativeMemorySource, "harness">,
+	filePath: string,
+	agentId: string,
+): boolean {
+	const cooldownUntil = readFailureBackoffUntil.get(fingerprintKey(source, filePath, agentId));
+	return cooldownUntil !== undefined && Date.now() < cooldownUntil;
+}
+
+export function recordNativeMemoryPermissionDenied(
+	source: Pick<NativeMemorySource, "harness">,
+	filePath: string,
+	agentId: string,
+): void {
+	const key = fingerprintKey(source, filePath, agentId);
+	readFailureBackoffUntil.set(key, Date.now() + READ_FAILURE_BACKOFF_MS);
+	const issue = {
+		path: filePath,
+		guidance: `${TCC_PERMISSION_GUIDANCE} Path: ${filePath}`,
+	};
+	const firstDenied = !permissionDeniedPaths.has(key);
+	permissionDeniedPaths.set(key, issue);
+	if (firstDenied) logger.warn("watcher", issue.guidance, { path: filePath });
+}
+
+export function clearNativeMemoryPermissionDenied(
+	source: Pick<NativeMemorySource, "harness">,
+	filePath: string,
+	agentId: string,
+): void {
+	const key = fingerprintKey(source, filePath, agentId);
+	readFailureBackoffUntil.delete(key);
+	permissionDeniedPaths.delete(key);
+}
+
 export function resetNativeMemoryIndexCache(): void {
 	indexed.clear();
 	readFailureBackoffUntil.clear();
@@ -392,8 +427,8 @@ function activeBridgeSources(
 	return [...byKey.values()];
 }
 
-function fingerprintKey(source: NativeMemorySource, filePath: string, agentId: string): string {
-	return `${agentId}:${source.harness}:${filePath}`;
+function fingerprintKey(source: Pick<NativeMemorySource, "harness">, filePath: string, agentId: string): string {
+	return `${agentId}:${source.harness}:${normalizedRoot(filePath)}`;
 }
 
 function sourceStateKey(source: NativeMemorySource, agentId: string): string {

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -103,8 +103,58 @@ interface IndexedNativeMemory {
 const indexed = new Map<string, IndexedNativeMemory>();
 
 /** Test-only: drop the in-process content-hash cache so scans behave like a fresh daemon. */
+export interface NativeMemorySourcePermissionIssue {
+	readonly path: string;
+	readonly guidance: string;
+}
+
+export interface NativeMemorySourcePermissionHealth {
+	readonly status: "clear" | "denied";
+	readonly issues: readonly NativeMemorySourcePermissionIssue[];
+}
+
+const permissionDeniedPaths = new Map<string, NativeMemorySourcePermissionIssue>();
+const TCC_PERMISSION_GUIDANCE =
+	"Grant Full Disk Access to ai.signet.daemon (or the Signet app) in System Settings → Privacy & Security → Full Disk Access.";
+
+export type NativeMemoryReadFailureClass = "permission-denied" | "missing" | "transient" | "unknown";
+
+export function isDarwinPermissionDenied(err: unknown, platform = process.platform): boolean {
+	if (platform !== "darwin") return false;
+	return typeof err === "object" && err !== null && (err as NodeJS.ErrnoException).code === "EACCES";
+}
+
+export function classifyNativeMemoryReadFailure(
+	err: unknown,
+	platform = process.platform,
+): NativeMemoryReadFailureClass {
+	if (isDarwinPermissionDenied(err, platform)) return "permission-denied";
+	if (isEnoentError(err)) return "missing";
+	if (err instanceof Error || (typeof err === "object" && err !== null)) return "transient";
+	return "unknown";
+}
+
+export function nativeMemorySourcePermissionHealth(
+	source: Pick<NativeMemorySource, "harness" | "root">,
+	agentId: string,
+): NativeMemorySourcePermissionHealth {
+	const prefix = `${agentId}:${source.harness}:`;
+	const root = normalizedRoot(source.root);
+	const issues = [...permissionDeniedPaths.entries()]
+		.filter(([key]) => {
+			if (!key.startsWith(prefix)) return false;
+			const path = key.slice(prefix.length);
+			return path === root || path.startsWith(`${root}/`);
+		})
+		.map(([, issue]) => issue);
+	return { status: issues.length > 0 ? "denied" : "clear", issues };
+}
+
 export function resetNativeMemoryIndexCache(): void {
 	indexed.clear();
+	readFailureBackoffUntil.clear();
+	permissionDeniedPaths.clear();
+	datalessReadFailuresByHarness.clear();
 }
 const DEFAULT_OBSIDIAN_SOURCE_FILE_DELAY_MS = 250;
 
@@ -621,11 +671,23 @@ export async function indexNativeMemoryFile(
 			// same ENOENT on every pass instead of accumulating stale
 			// artifact rows that desync the FTS index (#1142).
 			readFailureBackoffUntil.delete(key);
+			permissionDeniedPaths.delete(key);
 			removeNativeMemoryFile(source, filePath, agentId);
 			logger.debug("watcher", "Dropped vanished native memory artifact", {
 				harness: source.harness,
 				path: filePath,
 			});
+			return false;
+		}
+		if (classifyNativeMemoryReadFailure(err) === "permission-denied") {
+			readFailureBackoffUntil.set(key, Date.now() + READ_FAILURE_BACKOFF_MS);
+			const issue = {
+				path: filePath,
+				guidance: `${TCC_PERMISSION_GUIDANCE} Path: ${filePath}`,
+			};
+			const firstDenied = !permissionDeniedPaths.has(key);
+			permissionDeniedPaths.set(key, issue);
+			if (firstDenied) logger.warn("watcher", issue.guidance, { path: filePath });
 			return false;
 		}
 		// Transient failures (locks, permission flaps) back off instead of
@@ -658,6 +720,7 @@ export async function indexNativeMemoryFile(
 		return false;
 	}
 	readFailureBackoffUntil.delete(key);
+	permissionDeniedPaths.delete(key);
 	if (!content.trim()) {
 		removeNativeMemoryFile(source, filePath, agentId);
 		return false;

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { lstat, readFile, readdir, stat } from "node:fs/promises";
+import type { Dirent } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import {
@@ -224,11 +225,19 @@ function isEnoentError(err: unknown): boolean {
 	return typeof err === "object" && err !== null && (err as NodeJS.ErrnoException).code === "ENOENT";
 }
 
-async function pathExists(path: string): Promise<boolean> {
+async function pathExists(
+	path: string,
+	source: Pick<NativeMemorySource, "harness">,
+	agentId: string,
+): Promise<boolean> {
+	if (nativeMemoryReadBackoffActive(source, path, agentId)) return false;
 	try {
 		await stat(path);
 		return true;
-	} catch {
+	} catch (err) {
+		if (classifyNativeMemoryReadFailure(err) === "permission-denied") {
+			recordNativeMemoryPermissionDenied(source, path, agentId);
+		}
 		return false;
 	}
 }
@@ -351,14 +360,28 @@ export function configuredNativeMemorySources(agentsDir?: string): NativeMemoryS
 	return [codexNativeMemorySource(), claudeCodeNativeMemorySource(), hermesNativeMemorySource(), ...configured];
 }
 
-async function* walkNativeMemoryFiles(dir: string): AsyncGenerator<string> {
-	if (!(await pathExists(dir))) return;
-	const entries = await readdir(dir, { withFileTypes: true });
+async function* walkNativeMemoryFiles(
+	dir: string,
+	source: Pick<NativeMemorySource, "harness">,
+	agentId: string,
+): AsyncGenerator<string> {
+	if (!(await pathExists(dir, source, agentId))) return;
+	if (nativeMemoryReadBackoffActive(source, dir, agentId)) return;
+	let entries: readonly Dirent[];
+	try {
+		entries = await readdir(dir, { withFileTypes: true });
+		clearNativeMemoryPermissionDenied(source, dir, agentId);
+	} catch (err) {
+		if (classifyNativeMemoryReadFailure(err) === "permission-denied") {
+			recordNativeMemoryPermissionDenied(source, dir, agentId);
+		}
+		return;
+	}
 	for (const entry of entries) {
 		if (entry.name === ".git") continue;
 		const path = join(dir, entry.name);
 		if (entry.isDirectory()) {
-			yield* walkNativeMemoryFiles(path);
+			yield* walkNativeMemoryFiles(path, source, agentId);
 		} else if (entry.isFile() && (entry.name.endsWith(".md") || entry.name.endsWith(".jsonl"))) {
 			yield path;
 		}
@@ -986,10 +1009,10 @@ export function startNativeMemoryBridge(
 			let scanned = 0;
 			const key = sourceStateKey(source, agentId);
 			const current = new Set<string>();
-			const rootExists = await pathExists(source.root);
+			const rootExists = await pathExists(source.root, source, agentId);
 			if (rootExists) {
 				const files: string[] = [];
-				for await (const file of walkNativeMemoryFiles(source.root)) {
+				for await (const file of walkNativeMemoryFiles(source.root, source, agentId)) {
 					if (!matchesPattern(source, file)) continue;
 					files.push(file);
 					await yielder();

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -851,8 +851,11 @@ function sourceHealth(source: SignetSourceEntry, agentId: string, stats: SourceS
 	const generatedAt = new Date().toISOString();
 	try {
 		const permission =
-			source.kind === "obsidian"
-				? nativeMemorySourcePermissionHealth({ harness: "obsidian", root: source.root }, agentId)
+			source.kind === "obsidian" || source.kind === "discord"
+				? nativeMemorySourcePermissionHealth(
+						{ harness: source.kind === "discord" ? "discord" : "obsidian", root: source.root },
+						agentId,
+					)
 				: { status: "clear" as const, issues: [] };
 		const artifactSummary = artifactHealthSummary(source, agentId);
 		const discordSummary = discordHealthSummary(source, agentId);

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -25,6 +25,7 @@ import { logger } from "../logger";
 import { loadMemoryConfig } from "../memory-config";
 import {
 	type NativeMemoryBridgeHandle,
+	nativeMemorySourcePermissionHealth,
 	purgeNativeMemorySourceArtifacts,
 	resolveEmbeddingBridgeOptions,
 	startNativeMemoryBridge,
@@ -771,6 +772,10 @@ interface SourceHealth {
 		readonly documentEntityId: string | null;
 	};
 	readonly importExtraction?: ImportExtractionOutcome;
+	readonly permission: {
+		readonly status: "clear" | "denied";
+		readonly issues: readonly { readonly path: string; readonly guidance: string }[];
+	};
 }
 
 function sourceStats(source: SignetSourceEntry, agentId: string): SourceStats {
@@ -845,18 +850,30 @@ function sourceStats(source: SignetSourceEntry, agentId: string): SourceStats {
 function sourceHealth(source: SignetSourceEntry, agentId: string, stats: SourceStats): SourceHealth {
 	const generatedAt = new Date().toISOString();
 	try {
+		const permission =
+			source.kind === "obsidian"
+				? nativeMemorySourcePermissionHealth({ harness: "obsidian", root: source.root }, agentId)
+				: { status: "clear" as const, issues: [] };
 		const artifactSummary = artifactHealthSummary(source, agentId);
 		const discordSummary = discordHealthSummary(source, agentId);
 		const semantic = semanticHealthSummary(source, agentId);
 		const importExtraction = source.kind === "import" ? readImportedSourceOutcome(source.id, agentId) : undefined;
 		const orphanChunks = sourceOrphanChunks(source, agentId);
 		const hasDegradation =
+			permission.status === "denied" ||
 			discordSummary.failures.total > 0 ||
 			discordSummary.checkpoints.partial > 0 ||
 			discordSummary.checkpoints.stale > 0 ||
 			artifactSummary.deletedArtifacts > 0 ||
 			orphanChunks > 0;
-		const status = hasDegradation ? "degraded" : stats.artifacts === 0 && stats.chunks === 0 ? "empty" : "healthy";
+		const status =
+			permission.status === "denied"
+				? "unhealthy"
+				: hasDegradation
+					? "degraded"
+					: stats.artifacts === 0 && stats.chunks === 0
+						? "empty"
+						: "healthy";
 		return {
 			status,
 			generatedAt,
@@ -871,6 +888,7 @@ function sourceHealth(source: SignetSourceEntry, agentId: string, stats: SourceS
 			},
 			semantic,
 			...(importExtraction ? { importExtraction } : {}),
+			permission,
 		};
 	} catch (err) {
 		return {
@@ -892,6 +910,7 @@ function sourceHealth(source: SignetSourceEntry, agentId: string, stats: SourceS
 				total: 0,
 				documentEntityId: null,
 			},
+			permission: { status: "clear", issues: [] },
 		};
 	}
 }

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -381,6 +381,10 @@ export interface SourceHealth {
 		aspectsCreated: number;
 		attributesCreated: number;
 	};
+	permission?: {
+		status: "clear" | "denied";
+		issues: Array<{ path: string; guidance: string }>;
+	};
 }
 
 export interface SignetSource {

--- a/surfaces/dashboard/src/views/sources.tsx
+++ b/surfaces/dashboard/src/views/sources.tsx
@@ -381,6 +381,15 @@ function SourceCard({ source, onMutate }: { source: SignetSource; onMutate: () =
 			</div>
 
 			<PipeStrip job={source.indexJob} health={health} />
+			{source.health?.permission?.status === "denied" && (
+				<div className="rounded-md border border-[oklch(0.7_0.18_25/0.35)] bg-[oklch(0.7_0.18_25/0.08)] px-2 py-1.5 font-mono text-[9.5px] text-[oklch(0.7_0.18_25)]">
+					{source.health.permission.issues.map((issue) => (
+						<div key={issue.path} title={issue.path}>
+							{issue.guidance}
+						</div>
+					))}
+				</div>
+			)}
 
 			<div className="mt-0.5 flex items-center justify-between border-t border-[oklch(1_0_0/0.06)] pt-2 [html:not(.dark)_&]:border-[oklch(0_0_0/0.06)]">
 				{error ? (

--- a/web/docs/src/content/docs/api/documents-sources.md
+++ b/web/docs/src/content/docs/api/documents-sources.md
@@ -180,7 +180,8 @@ agent.
           "communities": 3,
           "total": 26,
           "documentEntityId": null
-        }
+        },
+        "permission": { "status": "clear", "issues": [] }
       }
     }
   ]
@@ -192,6 +193,12 @@ the durable extraction outcome. It reports the source-document entity id plus
 the aspects and attributes created by the import pipeline. This is distinct
 from `health.semantic`, which remains the current source-attributed graph
 diagnostic and can include later Dreaming-derived work.
+
+For macOS sources whose configured paths are protected by TCC, `health.status`
+is `unhealthy` and `health.permission` is `{ "status": "denied", "issues":
+[{ "path": "...", "guidance": "..." }] }`. The guidance names Full Disk
+Access and includes the denied path. The daemon backs off denied paths until
+permission is restored.
 
 ### POST /api/sources/import
 

--- a/web/docs/src/content/docs/sources.md
+++ b/web/docs/src/content/docs/sources.md
@@ -160,6 +160,12 @@ artifact residue, or orphan chunks. If diagnostics cannot read the backing
 tables, the source health reports `unhealthy` with error context rather than
 pretending the source is healthy.
 
+On macOS, a protected source path denied with `EACCES` is reported as a
+permission issue instead of a transient filesystem failure. The source health
+response and dashboard show one actionable Full Disk Access instruction per
+denied path, including the exact path. The daemon backs off that path while
+permission is denied so a TCC denial does not create a retry storm.
+
 Source artifacts are also scanned by the memory-content-safety policy before
 native recall, source-chunk fallback, Dreaming, or other prompt-facing
 projections use them. The raw artifact and provenance remain unchanged when a


### PR DESCRIPTION
## Summary

Treat macOS TCC `EACCES` failures while indexing native source files as persistent permission failures instead of generic transient errors. Report one actionable Full Disk Access recovery message per denied path, back off denied paths to prevent retry storms, and expose the state through source health and the dashboard.

## Changes

- Added Darwin-specific permission failure classification and per-path denied state to native source indexing.
- Added one-time Full Disk Access guidance containing the exact denied path, with normal recovery when reads succeed.
- Exposed permission status in `GET /api/sources` health responses and rendered it in the dashboard source card.
- Added regression coverage for classification, retry suppression, single warning emission, and health recovery guidance.
- Updated source API and user documentation.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: source API documentation

## Screenshots

The dashboard change is an inline permission-health warning on the existing source card. No screenshot captured in this headless verification run.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations touched.

## Testing

- [x] Targeted `bun test platform/daemon/src/native-memory-sources-dataless.test.ts` passes: 3 tests, 0 failures.
- [x] `bun run --filter '@signet/core' build` passes.
- [x] `bun run --filter '@signet/daemon' build` passes after rebuilding `@signet/core`.
- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

The repository's installed Biome binary rejects the checked-in Biome configuration schema before linting files. Full root typecheck/lint were not rerun after the focused build; the affected daemon TypeScript check is included in the daemon build.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Closes #1484. TCC permission state is held in the daemon process and clears as soon as a subsequent read succeeds. Non-Darwin `EACCES` remains on the existing transient path.