### PR TITLE
feat(daemon): expose workload diagnostics

### DIFF
--- a/platform/daemon/src/inference-router.test.ts
+++ b/platform/daemon/src/inference-router.test.ts
@@ -1381,6 +1381,7 @@ describe("InferenceRouter background quiescence", () => {
 				agentSessions: 0,
 				byOperation: { memory_extraction: 1 },
 			});
+			expect(router.getBackgroundWorkloadDiagnostics("default").oldestAgeMs).toBeGreaterThan(0);
 			expect(router.getBackgroundWorkloadDiagnostics("other").active).toBe(0);
 
 			expect(await router.quiesceBackgroundInference(1_000)).toEqual({

--- a/platform/daemon/src/inference-router.test.ts
+++ b/platform/daemon/src/inference-router.test.ts
@@ -37,7 +37,10 @@ function openAiSseResponse(
 	return new Response(chunks.join(""), { status: 200, headers: { "content-type": "text/event-stream" } });
 }
 
-function writeDreamingAcpxAgentFixture(root: string): {
+function writeDreamingAcpxAgentFixture(
+	root: string,
+	holdPath?: string,
+): {
 	readonly argsPath: string;
 	readonly mcpConfigPathPath: string;
 	readonly mcpConfigCopyPath: string;
@@ -47,6 +50,7 @@ function writeDreamingAcpxAgentFixture(root: string): {
 	const argsPath = join(root, "acpx-args.txt");
 	const mcpConfigPathPath = join(root, "acpx-mcp-path.txt");
 	const mcpConfigCopyPath = join(root, "acpx-mcp.json");
+	const holdCommand = holdPath ? `while [ ! -f ${JSON.stringify(holdPath)} ]; do sleep 0.01; done` : ":";
 	writeFileSync(
 		bin,
 		`#!/usr/bin/env bash
@@ -60,6 +64,7 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 cat >/dev/null
+${holdCommand}
 printf 'dreaming agent completed\\n'
 `,
 	);
@@ -251,6 +256,38 @@ describe("InferenceRouter config caching", () => {
 });
 
 describe("InferenceRouter legacy API credentials", () => {
+	it("does not count an in-flight ACPX agent as a Pi session", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-router-dreaming-acpx-diagnostics-"));
+		const releasePath = join(dir, "release");
+		const fixture = writeDreamingAcpxAgentFixture(dir, releasePath);
+		try {
+			const router = getOrCreateInferenceRouter(dir);
+			const run = router.runAgent(
+				{ operation: "memory_extraction", agentId: "agent-a", promptPreview: "diagnostics" },
+				"Use the supplied evidence.",
+				[],
+				{
+					acpxMcp: {
+						agentId: "agent-a",
+						passId: "pass-a",
+						daemonUrl: "http://127.0.0.1:3850",
+					},
+				},
+			);
+			const deadline = Date.now() + 2_000;
+			while (!existsSync(fixture.argsPath) && Date.now() < deadline)
+				await new Promise((resolve) => setTimeout(resolve, 10));
+			expect(existsSync(fixture.argsPath)).toBe(true);
+			expect(router.getBackgroundWorkloadDiagnostics("agent-a")).toMatchObject({ active: 1, agentSessions: 0 });
+			writeFileSync(releasePath, "release");
+			expect((await run).ok).toBe(true);
+		} finally {
+			writeFileSync(releasePath, "release");
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("runs an ACPX agent with one ephemeral agent-scoped Dreaming MCP binding", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "signet-router-dreaming-acpx-"));
 		const fixture = writeDreamingAcpxAgentFixture(dir);

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -395,7 +395,7 @@ export class InferenceRouter {
 			readonly controller: AbortController;
 			readonly operation: RoutingOperationKind;
 			readonly agentId: string;
-			readonly kind: "inference" | "agent";
+			kind: "inference" | "agent" | "pi";
 			readonly startedAt: number;
 		}
 	>();
@@ -483,7 +483,7 @@ export class InferenceRouter {
 			byOperation[execution.operation] = (byOperation[execution.operation] ?? 0) + 1;
 			const ageMs = Math.max(0, now - execution.startedAt);
 			oldestAgeMs = oldestAgeMs === null ? ageMs : Math.max(oldestAgeMs, ageMs);
-			if (execution.kind === "agent") {
+			if (execution.kind === "pi") {
 				agentSessions += 1;
 				oldestAgentSessionAgeMs = oldestAgentSessionAgeMs === null ? ageMs : Math.max(oldestAgentSessionAgeMs, ageMs);
 			}
@@ -497,6 +497,12 @@ export class InferenceRouter {
 		if (this.activeBackgroundExecutions.size !== 0) return;
 		for (const resolve of this.backgroundSettledWaiters) resolve();
 		this.backgroundSettledWaiters.clear();
+	}
+
+	private markBackgroundExecutionAsPi(id: number | undefined): void {
+		if (id === undefined) return;
+		const execution = this.activeBackgroundExecutions.get(id);
+		if (execution) execution.kind = "pi";
 	}
 
 	/**
@@ -1082,6 +1088,7 @@ export class InferenceRouter {
 							},
 						};
 					}
+					this.markBackgroundExecutionAsPi(backgroundExecutionId);
 					const deadlineMs = opts?.timeoutMs ?? provider.agentSessionTimeoutMs;
 					const deadline = deadlineMs > 0 ? performance.now() + deadlineMs : undefined;
 					let sessionUsage: LlmUsage | null = null;

--- a/platform/daemon/src/mcp/route.test.ts
+++ b/platform/daemon/src/mcp/route.test.ts
@@ -114,6 +114,30 @@ describe("MCP route", () => {
 		expect(getMcpWorkloadDiagnostics("agent-a")).toEqual({ inFlight: 0, oldestAgeMs: null, maxInFlight: 8 });
 	});
 
+	it("counts malformed-body requests while the body is still being read", async () => {
+		let releaseGate: (() => void) | undefined;
+		const gateReached = new Promise<void>((resolve) => {
+			__setMcpRequestGateForTests(
+				() =>
+					new Promise<void>((release) => {
+						releaseGate = release;
+						resolve();
+					}),
+			);
+		});
+		const request = makeApp().request("/mcp?agentId=agent-a", {
+			method: "POST",
+			headers: streamableHeaders,
+			body: "{",
+		});
+		await gateReached;
+		expect(getMcpWorkloadDiagnostics("agent-a").inFlight).toBe(1);
+		releaseGate?.();
+		const response = await request;
+		expect(response.status).toBe(400);
+		expect(getMcpWorkloadDiagnostics("agent-a")).toEqual({ inFlight: 0, oldestAgeMs: null, maxInFlight: 8 });
+	});
+
 	it("returns the SDK parse-error shape for malformed JSON", async () => {
 		const res = await makeApp().request("/mcp", {
 			method: "POST",

--- a/platform/daemon/src/mcp/route.test.ts
+++ b/platform/daemon/src/mcp/route.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { Hono } from "hono";
 import { createConcurrencyAdmission } from "../concurrency-admission.js";
-import { __setMcpAdmissionForTests, MCP_MAX_BODY_BYTES, mountMcpRoute } from "./route.js";
+import {
+	__setMcpAdmissionForTests,
+	__setMcpRequestGateForTests,
+	getMcpWorkloadDiagnostics,
+	MCP_MAX_BODY_BYTES,
+	mountMcpRoute,
+} from "./route.js";
 
 function makeApp(): Hono {
 	const app = new Hono();
@@ -36,6 +42,7 @@ describe("MCP route", () => {
 	afterEach(() => {
 		globalThis.fetch = originalFetch;
 		__setMcpAdmissionForTests(null);
+		__setMcpRequestGateForTests(null);
 	});
 
 	it("rejects requests when the in-flight admission cap is saturated", async () => {
@@ -71,6 +78,40 @@ describe("MCP route", () => {
 		expect(res.status).toBe(200);
 		const body = await res.json();
 		expect(body.result.serverInfo.name).toBe("signet");
+	});
+
+	it("reports scoped in-flight MCP count and oldest age", async () => {
+		let releaseGate: (() => void) | undefined;
+		const gateReached = new Promise<void>((resolve) => {
+			__setMcpRequestGateForTests(
+				() =>
+					new Promise<void>((release) => {
+						releaseGate = release;
+						resolve();
+					}),
+			);
+		});
+		const request = makeApp().request("/mcp?agentId=agent-a", {
+			method: "POST",
+			headers: streamableHeaders,
+			body: JSON.stringify({
+				jsonrpc: "2.0",
+				id: 1,
+				method: "initialize",
+				params: {
+					protocolVersion: "2024-11-05",
+					capabilities: {},
+					clientInfo: { name: "route-test", version: "0.1.0" },
+				},
+			}),
+		});
+		await gateReached;
+		expect(getMcpWorkloadDiagnostics("agent-a").inFlight).toBe(1);
+		expect(getMcpWorkloadDiagnostics("agent-a").oldestAgeMs).toBeGreaterThanOrEqual(0);
+		expect(getMcpWorkloadDiagnostics("other")).toEqual({ inFlight: 0, oldestAgeMs: null, maxInFlight: 8 });
+		releaseGate?.();
+		await request;
+		expect(getMcpWorkloadDiagnostics("agent-a")).toEqual({ inFlight: 0, oldestAgeMs: null, maxInFlight: 8 });
 	});
 
 	it("returns the SDK parse-error shape for malformed JSON", async () => {

--- a/platform/daemon/src/mcp/route.ts
+++ b/platform/daemon/src/mcp/route.ts
@@ -23,9 +23,14 @@ let nextMcpRequestId = 1;
 export const MCP_MAX_IN_FLIGHT = 8;
 export const MCP_MAX_BODY_BYTES = 512 * 1024;
 let mcpAdmission: ConcurrencyAdmission = createConcurrencyAdmission(MCP_MAX_IN_FLIGHT);
+let mcpRequestGateForTests: (() => Promise<void>) | null = null;
 
 export function __setMcpAdmissionForTests(admission: ConcurrencyAdmission | null): void {
 	mcpAdmission = admission ?? createConcurrencyAdmission(MCP_MAX_IN_FLIGHT);
+}
+
+export function __setMcpRequestGateForTests(gate: (() => Promise<void>) | null): void {
+	mcpRequestGateForTests = gate;
 }
 
 export interface McpWorkloadDiagnostics {
@@ -84,6 +89,7 @@ export function mountMcpRoute(app: Hono): void {
 				agentId: resolveMcpWorkloadAgentId(c),
 				startedAt: Date.now(),
 			});
+			await mcpRequestGateForTests?.();
 			transport = new WebStandardStreamableHTTPServerTransport({
 				sessionIdGenerator: undefined, // stateless
 				enableJsonResponse: true,

--- a/platform/daemon/src/mcp/route.ts
+++ b/platform/daemon/src/mcp/route.ts
@@ -82,14 +82,14 @@ export function mountMcpRoute(app: Hono): void {
 		let transport: WebStandardStreamableHTTPServerTransport | null = null;
 		let server: Awaited<ReturnType<typeof createMcpServer>> | null = null;
 		try {
-			const parsedBody = await parseMcpJsonBody(c);
-			if (parsedBody instanceof Response) return parsedBody;
 			requestId = nextMcpRequestId++;
 			activeMcpRequests.set(requestId, {
 				agentId: resolveMcpWorkloadAgentId(c),
 				startedAt: Date.now(),
 			});
 			await mcpRequestGateForTests?.();
+			const parsedBody = await parseMcpJsonBody(c);
+			if (parsedBody instanceof Response) return parsedBody;
 			transport = new WebStandardStreamableHTTPServerTransport({
 				sessionIdGenerator: undefined, // stateless
 				enableJsonResponse: true,

--- a/platform/daemon/src/pipeline/dreaming-attention.ts
+++ b/platform/daemon/src/pipeline/dreaming-attention.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
+import { timestampMillis } from "../episodic-sources";
 
 export const DREAMING_ATTENTION_KINDS = [
 	"review_due",
@@ -150,10 +151,10 @@ export function getDreamingAttentionWorkloadDiagnostics(
 		if (!row || row.pending === 0 || row.oldestCreatedAt === null) {
 			return { pending: 0, oldestAgeMs: null };
 		}
-		const oldestMs = Date.parse(row.oldestCreatedAt);
+		const oldestMs = timestampMillis(row.oldestCreatedAt);
 		return {
 			pending: row.pending,
-			oldestAgeMs: Number.isFinite(oldestMs) ? Math.max(0, nowMs - oldestMs) : null,
+			oldestAgeMs: oldestMs > 0 ? Math.max(0, nowMs - oldestMs) : null,
 		};
 	});
 }

--- a/platform/daemon/src/pipeline/dreaming-attention.ts
+++ b/platform/daemon/src/pipeline/dreaming-attention.ts
@@ -29,6 +29,11 @@ export interface DreamingAttentionSnapshot extends DreamingAttention {
 	readonly generation: number;
 }
 
+export interface DreamingAttentionWorkloadDiagnostics {
+	readonly pending: number;
+	readonly oldestAgeMs: number | null;
+}
+
 function parseDetails(value: string): Readonly<Record<string, string>> {
 	try {
 		const parsed: unknown = JSON.parse(value);
@@ -127,6 +132,30 @@ export function getDreamingAttention(
 	limit?: number,
 ): readonly DreamingAttention[] {
 	return accessor.withReadDb((db) => getDreamingAttentionInDb(db, agentId, limit));
+}
+
+export function getDreamingAttentionWorkloadDiagnostics(
+	accessor: DbAccessor,
+	agentId: string,
+	nowMs = Date.now(),
+): DreamingAttentionWorkloadDiagnostics {
+	return accessor.withReadDb((db) => {
+		const row = db
+			.prepare(
+				`SELECT COUNT(*) AS pending, MIN(created_at) AS oldestCreatedAt
+				 FROM dreaming_attention
+				 WHERE agent_id = ? AND resolved_at IS NULL`,
+			)
+			.get(agentId) as { pending: number; oldestCreatedAt: string | null } | undefined;
+		if (!row || row.pending === 0 || row.oldestCreatedAt === null) {
+			return { pending: 0, oldestAgeMs: null };
+		}
+		const oldestMs = Date.parse(row.oldestCreatedAt);
+		return {
+			pending: row.pending,
+			oldestAgeMs: Number.isFinite(oldestMs) ? Math.max(0, nowMs - oldestMs) : null,
+		};
+	});
 }
 
 /** Scoped attention query with kind and resolution filters (attention_list). */

--- a/platform/daemon/src/pipeline/dreaming-worker.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.test.ts
@@ -13,6 +13,7 @@ import {
 	type DreamingPassFocus,
 	dreamingFocusOfMode,
 	enqueueDreamingHygieneAttention,
+	getDreamingWorkloadDiagnostics,
 } from "./dreaming";
 import {
 	AlreadyRunningError,
@@ -225,6 +226,30 @@ describe("dreaming worker agent scope", () => {
 		}
 	});
 
+	it("reports scoped Dreaming pass and attention backlog ages", () => {
+		db.prepare(
+			`INSERT INTO dreaming_passes (id, agent_id, mode, status, started_at, created_at)
+			 VALUES ('active-pass', 'default', 'incremental', 'running', '2026-08-13 10:00:00', '2026-08-13 10:00:00')`,
+		).run();
+		db.prepare(
+			`INSERT INTO dreaming_attention (id, agent_id, kind, subject_ref, details_json, priority, created_at)
+			 VALUES ('pending-attention', 'default', 'review_due', 'subject', '{}', 50, '2026-08-13 09:00:00')`,
+		).run();
+
+		expect(getDreamingWorkloadDiagnostics(accessor, "default", Date.parse("2026-08-13 11:00:00"))).toEqual({
+			activePasses: 1,
+			oldestPassAgeMs: 60 * 60 * 1_000,
+			pendingAttention: 1,
+			oldestAttentionAgeMs: 2 * 60 * 60 * 1_000,
+		});
+		expect(getDreamingWorkloadDiagnostics(accessor, "other", Date.parse("2026-08-13 11:00:00"))).toEqual({
+			activePasses: 0,
+			oldestPassAgeMs: null,
+			pendingAttention: 0,
+			oldestAttentionAgeMs: null,
+		});
+	});
+
 	it("rejects an overlapping manual pass without skipping the active pass", async () => {
 		db.prepare(
 			`INSERT INTO session_transcripts
@@ -252,6 +277,8 @@ describe("dreaming worker agent scope", () => {
 		try {
 			const first = worker.trigger("incremental", "default");
 			await waitFor(() => started, 2_000);
+			expect(worker.running).toBe(true);
+			expect(worker.activeAgentId).toBe("default");
 			await expect(worker.trigger("incremental", "default")).rejects.toBeInstanceOf(AlreadyRunningError);
 			release();
 			await first;

--- a/platform/daemon/src/pipeline/dreaming-worker.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.test.ts
@@ -226,7 +226,7 @@ describe("dreaming worker agent scope", () => {
 		}
 	});
 
-	it("reports scoped Dreaming pass and attention backlog ages", () => {
+	it("reports scoped Dreaming ages using SQLite UTC timestamps", () => {
 		db.prepare(
 			`INSERT INTO dreaming_passes (id, agent_id, mode, status, started_at, created_at)
 			 VALUES ('active-pass', 'default', 'incremental', 'running', '2026-08-13 10:00:00', '2026-08-13 10:00:00')`,
@@ -236,13 +236,14 @@ describe("dreaming worker agent scope", () => {
 			 VALUES ('pending-attention', 'default', 'review_due', 'subject', '{}', 50, '2026-08-13 09:00:00')`,
 		).run();
 
-		expect(getDreamingWorkloadDiagnostics(accessor, "default", Date.parse("2026-08-13 11:00:00"))).toEqual({
+		const nowMs = Date.UTC(2026, 7, 13, 11);
+		expect(getDreamingWorkloadDiagnostics(accessor, "default", nowMs)).toEqual({
 			activePasses: 1,
 			oldestPassAgeMs: 60 * 60 * 1_000,
 			pendingAttention: 1,
 			oldestAttentionAgeMs: 2 * 60 * 60 * 1_000,
 		});
-		expect(getDreamingWorkloadDiagnostics(accessor, "other", Date.parse("2026-08-13 11:00:00"))).toEqual({
+		expect(getDreamingWorkloadDiagnostics(accessor, "other", nowMs)).toEqual({
 			activePasses: 0,
 			oldestPassAgeMs: null,
 			pendingAttention: 0,

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -46,6 +46,7 @@ import {
 	enqueueDreamingAttentionInTx,
 	getDreamingAttention,
 	getDreamingAttentionInDb,
+	getDreamingAttentionWorkloadDiagnostics,
 	getDreamingAttentionSnapshots,
 	hasDreamingAttentionKindInDb,
 	renderDreamingAttentionForPrompt,
@@ -239,6 +240,45 @@ interface DreamingPassRow {
 	readonly mutationsFailed: number | null;
 	readonly summary: string | null;
 	readonly error: string | null;
+}
+
+export interface DreamingWorkloadDiagnostics {
+	readonly activePasses: number;
+	readonly oldestPassAgeMs: number | null;
+	readonly pendingAttention: number;
+	readonly oldestAttentionAgeMs: number | null;
+}
+
+export function getDreamingWorkloadDiagnostics(
+	accessor: DbAccessor,
+	agentId: string,
+	nowMs = Date.now(),
+): DreamingWorkloadDiagnostics {
+	const attention = getDreamingAttentionWorkloadDiagnostics(accessor, agentId, nowMs);
+	return accessor.withReadDb((db) => {
+		const row = db
+			.prepare(
+				`SELECT COUNT(*) AS active, MIN(started_at) AS oldestStartedAt
+				 FROM dreaming_passes
+				 WHERE agent_id = ? AND status = 'running'`,
+			)
+			.get(agentId) as { active: number; oldestStartedAt: string | null } | undefined;
+		if (!row || row.active === 0 || row.oldestStartedAt === null) {
+			return {
+				activePasses: 0,
+				oldestPassAgeMs: null,
+				pendingAttention: attention.pending,
+				oldestAttentionAgeMs: attention.oldestAgeMs,
+			};
+		}
+		const oldestMs = Date.parse(row.oldestStartedAt);
+		return {
+			activePasses: row.active,
+			oldestPassAgeMs: Number.isFinite(oldestMs) ? Math.max(0, nowMs - oldestMs) : null,
+			pendingAttention: attention.pending,
+			oldestAttentionAgeMs: attention.oldestAgeMs,
+		};
+	});
 }
 
 export interface DreamingToolCall {

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -271,10 +271,10 @@ export function getDreamingWorkloadDiagnostics(
 				oldestAttentionAgeMs: attention.oldestAgeMs,
 			};
 		}
-		const oldestMs = Date.parse(row.oldestStartedAt);
+		const oldestMs = timestampMillis(row.oldestStartedAt);
 		return {
 			activePasses: row.active,
-			oldestPassAgeMs: Number.isFinite(oldestMs) ? Math.max(0, nowMs - oldestMs) : null,
+			oldestPassAgeMs: oldestMs > 0 ? Math.max(0, nowMs - oldestMs) : null,
 			pendingAttention: attention.pending,
 			oldestAttentionAgeMs: attention.oldestAgeMs,
 		};

--- a/platform/daemon/src/pipeline/index.ts
+++ b/platform/daemon/src/pipeline/index.ts
@@ -17,11 +17,7 @@ import { getLlmProvider } from "../llm";
 import { logger } from "../logger";
 import type { EmbeddingConfig, MemorySearchConfig, PipelineV2Config } from "../memory-config";
 import type { TelemetryCollector } from "../telemetry";
-import {
-	DOCUMENT_WORK_MAX_IN_FLIGHT,
-	type DocumentWorkerHandle,
-	startDocumentWorker,
-} from "./document-worker";
+import { DOCUMENT_WORK_MAX_IN_FLIGHT, type DocumentWorkerHandle, startDocumentWorker } from "./document-worker";
 import type { DreamingWorkerHandle } from "./dreaming-worker";
 import { type MaintenanceHandle, startMaintenanceWorker } from "./maintenance-worker";
 import { type HintsWorkerHandle, startHintsWorker } from "./prospective-index";
@@ -56,6 +52,7 @@ export {
 	requestDreamingEvidenceRequeue,
 } from "./dreaming";
 export { getDreamingAttention } from "./dreaming-attention";
+export { getDreamingWorkloadDiagnostics } from "./dreaming";
 export { getDreamingQualityReport } from "./dreaming-quality";
 export type { DreamingSchedulerStatus, DreamingWorkerHandle } from "./dreaming-worker";
 

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -420,11 +420,24 @@ fi
 			if (existsSync(queuedPidPath)) {
 				expect(await waitForProcessExit(Number(readFileSync(queuedPidPath, "utf8")))).toBe(true);
 			}
-			expect(getLlmConcurrencyStatus()).toEqual({ limit: 1, pending: 0, running: 0 });
+			expect(getLlmConcurrencyStatus()).toEqual({ limit: 1, pending: 0, running: 0, oldestPendingAgeMs: null });
 		} finally {
 			configureLlmConcurrency(originalLimit);
 			rmSync(root, { recursive: true, force: true });
 		}
+	});
+
+	it("reports the age of the oldest queued provider call", async () => {
+		const semaphore = new LlmConcurrencySemaphore(1);
+		await semaphore.acquire();
+		const queued = semaphore.acquire();
+		await new Promise((resolve) => setTimeout(resolve, 15));
+		expect(semaphore.pending).toBe(1);
+		expect(semaphore.oldestPendingAgeMs).toBeGreaterThan(0);
+		semaphore.release();
+		await queued;
+		semaphore.release();
+		expect(semaphore.oldestPendingAgeMs).toBeNull();
 	});
 
 	it("reports structured diagnostics after repeated empty completions", async () => {

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -63,6 +63,7 @@ export class LlmConcurrencySemaphore {
 	private active = 0;
 	private readonly queue: Array<{
 		readonly start: () => void;
+		readonly queuedAt: number;
 	}> = [];
 	private timers = 0;
 
@@ -90,6 +91,7 @@ export class LlmConcurrencySemaphore {
 				reject(new Error("semaphore acquisition aborted"));
 			};
 			const entry = {
+				queuedAt: Date.now(),
 				start: (): void => {
 					signal?.removeEventListener("abort", onAbort);
 					this.active++;
@@ -130,6 +132,7 @@ export class LlmConcurrencySemaphore {
 				settle(() => reject(new SemaphoreTimeoutError(ms)));
 			}, ms);
 			const entry = {
+				queuedAt: Date.now(),
 				start: (): void => {
 					settle(() => {
 						this.active++;
@@ -152,6 +155,12 @@ export class LlmConcurrencySemaphore {
 
 	get pending(): number {
 		return this.queue.length;
+	}
+
+	get oldestPendingAgeMs(): number | null {
+		if (this.queue.length === 0) return null;
+		const oldestQueuedAt = Math.min(...this.queue.map((entry) => entry.queuedAt));
+		return Math.max(0, Date.now() - oldestQueuedAt);
 	}
 
 	get running(): number {
@@ -199,11 +208,13 @@ export function getLlmConcurrencyStatus(): {
 	readonly running: number;
 	readonly pending: number;
 	readonly limit: number;
+	readonly oldestPendingAgeMs: number | null;
 } {
 	return {
 		running: llmSemaphore.running,
 		pending: llmSemaphore.pending,
 		limit: llmSemaphore.limit,
+		oldestPendingAgeMs: llmSemaphore.oldestPendingAgeMs,
 	};
 }
 

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -12,6 +12,7 @@ import { getInferenceRouterOrNull } from "../inference-router.js";
 import type { BackgroundWorkloadDiagnostics } from "../inference-router.js";
 import { getLlmProvider } from "../llm.js";
 import { getMcpWorkloadDiagnostics } from "../mcp/route.js";
+import { getLlmConcurrencyStatus } from "../pipeline/provider.js";
 import { graphWriteCaps, loadMemoryConfig } from "../memory-config.js";
 import { listMemoryContentSafety, parseMemorySafetyReasons } from "../memory-content-safety.js";
 import {
@@ -23,6 +24,7 @@ import {
 	getDreamingState,
 	getDreamingToolCalls,
 	getDreamingWorker,
+	getDreamingWorkloadDiagnostics,
 	getPipelineWorkerStatus,
 	requestDreamingEvidenceRequeue,
 } from "../pipeline";
@@ -116,6 +118,12 @@ export function pipelineQueueBlock(): PipelineQueueBlock {
 function workloadDiagnosticsSnapshot(agentId: string): {
 	readonly inference: BackgroundWorkloadDiagnostics;
 	readonly mcp: ReturnType<typeof getMcpWorkloadDiagnostics>;
+	readonly pi: {
+		readonly active: number;
+		readonly oldestAgeMs: number | null;
+	};
+	readonly providerSemaphore: ReturnType<typeof getLlmConcurrencyStatus>;
+	readonly dreaming: ReturnType<typeof getDreamingWorkloadDiagnostics>;
 } {
 	const inference: BackgroundWorkloadDiagnostics = getInferenceRouterOrNull()?.getBackgroundWorkloadDiagnostics(
 		agentId,
@@ -126,7 +134,13 @@ function workloadDiagnosticsSnapshot(agentId: string): {
 		oldestAgentSessionAgeMs: null,
 		byOperation: {},
 	};
-	return { inference, mcp: getMcpWorkloadDiagnostics(agentId) };
+	return {
+		inference,
+		mcp: getMcpWorkloadDiagnostics(agentId),
+		pi: { active: inference.agentSessions, oldestAgeMs: inference.oldestAgentSessionAgeMs },
+		providerSemaphore: getLlmConcurrencyStatus(),
+		dreaming: getDreamingWorkloadDiagnostics(getDbAccessor(), agentId),
+	};
 }
 
 function workloadDiagnostics(c: Context): Response {

--- a/web/docs/src/content/docs/api/health-status.md
+++ b/web/docs/src/content/docs/api/health-status.md
@@ -330,11 +330,14 @@ Use `GET /api/inference/status` for the shared inference control plane status.
 
 Returns bounded in-flight workload pressure for one resolved agent. The
 inference snapshot covers background routed work and Pi agent sessions; the
-MCP snapshot covers stateless Streamable HTTP requests. Counts are held in
-memory and ages are calculated from admission time, so this endpoint does not
-scan durable queue tables. `agentId` may be supplied as a query parameter or
-`x-signet-agent-id` header; scoped deployments reject requests for another
-agent.
+MCP snapshot covers stateless Streamable HTTP requests; the provider semaphore
+snapshot covers global LLM permit occupancy; and the Dreaming snapshot covers
+running passes plus pending attention. Counts are held in memory except for
+the Dreaming snapshot, which reads scoped durable rows. Ages are calculated
+from admission or persisted start/creation time, so this endpoint does not
+scan general-purpose durable queue tables. `agentId` may be supplied as a
+query parameter or `x-signet-agent-id` header; scoped deployments reject
+requests for another agent.
 
 **Response**
 
@@ -348,7 +351,15 @@ agent.
     "oldestAgentSessionAgeMs": 3200,
     "byOperation": { "memory_extraction": 1 }
   },
-  "mcp": { "inFlight": 0, "oldestAgeMs": null, "maxInFlight": 8 }
+  "mcp": { "inFlight": 0, "oldestAgeMs": null, "maxInFlight": 8 },
+  "pi": { "active": 1, "oldestAgeMs": 3200 },
+  "providerSemaphore": { "running": 1, "pending": 0, "limit": 2, "oldestPendingAgeMs": null },
+  "dreaming": {
+    "activePasses": 0,
+    "oldestPassAgeMs": null,
+    "pendingAttention": 0,
+    "oldestAttentionAgeMs": null
+  }
 }
 ```
 

--- a/web/docs/src/content/docs/diagnostics.md
+++ b/web/docs/src/content/docs/diagnostics.md
@@ -14,7 +14,7 @@ curl -fsS http://127.0.0.1:3850/health/ready
 curl -fsS http://127.0.0.1:3850/api/diagnostics
 ```
 
-`/health/live` answers whether the process is up. `/health/ready` includes readiness gates. `/api/diagnostics` returns the detailed report. In authenticated deployments, diagnostics require the appropriate operator or admin permission.
+`/health/live` answers whether the process is up. `/health/ready` includes readiness gates. `/api/diagnostics` returns the detailed report. Its `workloads` block is scoped to the requested agent and includes active inference/Pi and MCP requests, provider semaphore running and pending counts, oldest ages, and Dreaming pass and attention backlog counts and ages. The focused `/api/diagnostics/workloads` endpoint returns the same bounded workload snapshot. In authenticated deployments, diagnostics require the appropriate operator or admin permission.
 
 Use the report to identify the failing domain before taking action. Do not treat a low composite score as a diagnosis by itself.
 


### PR DESCRIPTION
## Summary

Adds bounded, agent-scoped workload diagnostics for operators investigating background pressure. The diagnostics surface now reports counts and oldest ages for routed inference and Pi sessions, MCP requests, the provider semaphore, and Dreaming passes and attention.

## Changes

- Track oldest queued provider-permit age alongside running and pending counts.
- Expose scoped MCP in-flight count and oldest request age.
- Expose scoped Dreaming running-pass and pending-attention counts and ages.
- Include the workload envelope in `/api/diagnostics` and add `/api/diagnostics/workloads`.
- Add regression coverage for scoped count/age behavior and update API diagnostics docs.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [x] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A. No migrations.

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused proof:

- `bun test platform/daemon/src/mcp/route.test.ts platform/daemon/src/inference-router.test.ts platform/daemon/src/pipeline/provider.test.ts platform/daemon/src/pipeline/dreaming-worker.test.ts` passed: 82 tests, 0 failures.
- `bun run --filter '@signet/daemon' build` passed.
- `bun run --filter '@signet/daemon' typecheck` passed.
- `git diff --check` passed.
- `bunx biome check` passed with 14 pre-existing warnings and no errors after formatting the touched files.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The provider semaphore is a process-global diagnostic, while inference, Pi, MCP, and Dreaming values are scoped to the resolved agent. Dreaming counts read the bounded diagnostic aggregate from scoped durable rows. This PR adds observability only and does not replace the admission or timeout caps from the preceding hardening work.