### PR TITLE
test(daemon): prove embedding write recovery

### DIFF
--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -972,6 +972,73 @@ describe("reembedMissingMemories", () => {
 		expect(db.prepare("SELECT id FROM embeddings WHERE source_id = ?").get("mem-write-failure")).toBeTruthy();
 	});
 
+	it("reconciles canonical embedding state after a mid-write vector-index failure", async () => {
+		// Proof for #1325: the canonical embedding write and the derived vec
+		// index update are separate failure boundaries. If vec insertion fails
+		// after the canonical row commits, the existing resync owner must make
+		// the derived index converge without re-embedding or changing the source.
+		ensureVecTable(db);
+		insertMemory(db, "mem-mid-write");
+		db.exec(`
+			CREATE TRIGGER reject_vec_insert
+			BEFORE INSERT ON vec_embeddings
+			BEGIN SELECT RAISE(ABORT, 'simulated mid-write vector failure'); END
+		`);
+
+		let providerCalls = 0;
+		const first = await reembedMissingMemories(
+			accessor,
+			TEST_CFG,
+			CTX_OPERATOR,
+			createRateLimiter(),
+			async () => {
+				providerCalls++;
+				return [0.1, 0.2, 0.3];
+			},
+			TEST_EMBEDDING_CFG,
+			1,
+			false,
+		);
+
+		expect(first.success).toBe(true);
+		expect(first.affected).toBe(1);
+		expect(providerCalls).toBe(1);
+		expect(db.prepare("SELECT id FROM memories WHERE id = 'mem-mid-write' AND is_deleted = 0").get()).toBeTruthy();
+		expect(db.prepare("SELECT source_id FROM embeddings WHERE source_id = 'mem-mid-write'").all()).toHaveLength(1);
+		expect(db.prepare("SELECT id FROM vec_embeddings").all()).toHaveLength(0);
+
+		// Reconciliation owns the derived index. It must repair the missing vec
+		// row from the canonical embedding without invoking the provider again.
+		db.exec("DROP TRIGGER reject_vec_insert");
+		const repaired = resyncVectorIndex(accessor, TEST_CFG, CTX_OPERATOR, createRateLimiter());
+		expect(repaired.success).toBe(true);
+		expect(repaired.affected).toBe(1);
+		expect(db.prepare("SELECT id FROM vec_embeddings").all()).toHaveLength(1);
+		expect(db.prepare("SELECT source_id FROM embeddings WHERE source_id = 'mem-mid-write'").all()).toHaveLength(1);
+
+		// The delete boundary must also fail closed. A failed derived delete
+		// rolls back canonical cleanup, so retrying the existing orphan owner is
+		// safe and eventually removes both projections.
+		db.prepare("UPDATE memories SET is_deleted = 1 WHERE id = 'mem-mid-write'").run();
+		db.exec(`
+			CREATE TRIGGER reject_vec_delete
+			BEFORE DELETE ON vec_embeddings
+			BEGIN SELECT RAISE(ABORT, 'simulated mid-write vector delete failure'); END
+		`);
+		expect(() => cleanOrphanedEmbeddings(accessor, TEST_CFG, CTX_OPERATOR, createRateLimiter())).toThrow(
+			"failed to reconcile vec_embeddings before orphan cleanup",
+		);
+		expect(db.prepare("SELECT id FROM embeddings WHERE source_id = 'mem-mid-write'").all()).toHaveLength(1);
+		expect(db.prepare("SELECT id FROM vec_embeddings").all()).toHaveLength(1);
+
+		db.exec("DROP TRIGGER reject_vec_delete");
+		const cleaned = cleanOrphanedEmbeddings(accessor, TEST_CFG, CTX_OPERATOR, createRateLimiter());
+		expect(cleaned.success).toBe(true);
+		expect(cleaned.affected).toBe(1);
+		expect(db.prepare("SELECT id FROM embeddings WHERE source_id = 'mem-mid-write'").all()).toHaveLength(0);
+		expect(db.prepare("SELECT id FROM vec_embeddings").all()).toHaveLength(0);
+	});
+
 	it("does not overwrite another agent's embedding on a hash conflict", async () => {
 		// Regression for cross-agent hash collisions: the embedding hash is
 		// globally unique, but autonomous repair is agent-scoped. Agent A must


### PR DESCRIPTION
## Summary

Adds the focused #1325 failure-boundary proof for embedding repair. It exercises the existing canonical embedding writer, vector-index resynchronizer, and orphan cleanup owner when derived vector writes fail mid-operation.

## Changes

- Add a regression proof for a failed vector-index insert after the canonical embedding commits.
- Prove `resyncVectorIndex` restores the missing derived row without another provider call.
- Prove a failed vector delete preserves both projections for retry, then the existing orphan cleanup converges after the failure clears.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [x] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: none

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations were touched.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Passed locally:

- `bun install`
- `bun run --filter '@signet/core' build`
- `bun test platform/daemon/src/repair-actions.test.ts` (73 passed, 0 failed, 303 expect calls)
- `bun run --filter '@signet/daemon' build` (bundle, TypeScript check, and dashboard production build)
- `bunx biome check platform/daemon/src/repair-actions.test.ts` (no errors; one pre-existing warning at line 300)
- `git diff --check`

The full root test, typecheck, and lint suites were not run. The proof uses the in-memory daemon repair path rather than a running daemon because it injects SQLite failure triggers at the exact derived-write boundaries.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Root cause confirmed in the existing implementation: canonical `embeddings` writes and derived `vec_embeddings` synchronization are separate boundaries. `syncVecInsert` intentionally swallows derived-index failures, while `resyncVectorIndex` is the existing reconciliation owner. The proof pins that a mid-write failure leaves canonical state durable and that the owner converges later, without introducing a parallel embedding writer.

The security and docs readiness items are checked because this test-only change adds no admin or mutation endpoint and changes no API, schema, or user-facing behavior.

Closes #1325.
