### PR TITLE
fix(daemon): validate semantic premise provenance

### DIFF
--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -708,6 +708,28 @@ memory:
 	});
 
 	it("saves ontology claim evidence links without memory-only provenance links", async () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES ('aggregate-entity', 'ARTBAT', 'artbat', 'project', 'agent-a', 1, ?, ?)`,
+			).run("2026-05-20T12:00:00.000Z", "2026-05-20T12:00:00.000Z");
+			db.prepare(
+				`INSERT INTO entity_aspects
+				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES ('aggregate-aspect', 'aggregate-entity', 'agent-a', 'billing_context', 'billing_context', 0.8, ?, ?)`,
+			).run("2026-05-20T12:00:00.000Z", "2026-05-20T12:00:00.000Z");
+			db.prepare(
+				`INSERT INTO entity_attributes
+				 (id, aspect_id, agent_id, kind, content, normalized_content, confidence, importance, status, created_at, updated_at)
+				 VALUES ('attr-artbat-invoice', 'aggregate-aspect', 'agent-a', 'attribute', ?, ?, 0.9, 0.8, 'active', ?, ?)`,
+			).run(
+				"Current ARTBAT invoice is €1,000 and the outstanding 2025 balance is €2,000.",
+				"current artbat invoice is €1,000 and the outstanding 2025 balance is €2,000.",
+				"2026-05-20T12:00:00.000Z",
+				"2026-05-20T12:00:00.000Z",
+			);
+		});
 		const ontologyRow: RecallResult = {
 			id: "ontology-claim:attr-artbat-invoice",
 			content:

--- a/platform/daemon/src/derived-memory-provenance.ts
+++ b/platform/daemon/src/derived-memory-provenance.ts
@@ -1,5 +1,81 @@
 import type { WriteDb } from "./db-accessor";
 
+const SEMANTIC_PREMISE_KIND = "ontology_claim";
+const EPISODIC_SOURCE_KINDS = new Set(["memory", "artifact", "transcript", "summary"]);
+
+function validateSemanticPremise(db: WriteDb, agentId: string, sourceId: string): void {
+	const row = db
+		.prepare(
+			`SELECT attr.agent_id AS attribute_agent_id,
+			        attr.status AS attribute_status,
+			        attr.superseded_by AS attribute_superseded_by,
+			        attr.archived_at AS attribute_archived_at,
+			        aspect.agent_id AS aspect_agent_id,
+			        aspect.status AS aspect_status,
+			        aspect.archived_at AS aspect_archived_at,
+			        entity.agent_id AS entity_agent_id,
+			        entity.status AS entity_status,
+			        entity.archived_at AS entity_archived_at,
+			        memory.agent_id AS memory_agent_id,
+			        memory.is_deleted AS memory_is_deleted,
+			        memory.stale_at AS memory_stale_at,
+			        memory.superseded_by AS memory_superseded_by
+			 FROM entity_attributes attr
+			 JOIN entity_aspects aspect ON aspect.id = attr.aspect_id
+			 JOIN entities entity ON entity.id = aspect.entity_id
+			 LEFT JOIN memories memory ON memory.id = attr.memory_id
+			 WHERE attr.id = ?`,
+		)
+		.get(sourceId) as
+		| {
+				attribute_agent_id: string | null;
+				attribute_status: string | null;
+				attribute_superseded_by: string | null;
+				attribute_archived_at: string | null;
+				aspect_agent_id: string | null;
+				aspect_status: string | null;
+				aspect_archived_at: string | null;
+				entity_agent_id: string | null;
+				entity_status: string | null;
+				entity_archived_at: string | null;
+				memory_agent_id: string | null;
+				memory_is_deleted: number | null;
+				memory_stale_at: string | null;
+				memory_superseded_by: string | null;
+		  }
+		| null
+		| undefined;
+	if (
+		row == null ||
+		row.attribute_agent_id !== agentId ||
+		row.aspect_agent_id !== agentId ||
+		row.entity_agent_id !== agentId ||
+		row.attribute_status !== "active" ||
+		row.attribute_superseded_by !== null ||
+		row.attribute_archived_at !== null ||
+		row.aspect_status !== "active" ||
+		row.aspect_archived_at !== null ||
+		row.entity_status !== "active" ||
+		row.entity_archived_at !== null ||
+		(row.memory_agent_id !== null && row.memory_agent_id !== agentId) ||
+		(row.memory_is_deleted !== null && row.memory_is_deleted !== 0) ||
+		row.memory_stale_at !== null ||
+		row.memory_superseded_by !== null
+	) {
+		throw new Error(`Derived memory provenance semantic premise is not in the authorized agent scope: ${sourceId}`);
+	}
+}
+
+function validateSource(db: WriteDb, agentId: string, sourceKind: string, sourceId: string): void {
+	if (sourceKind === SEMANTIC_PREMISE_KIND) {
+		validateSemanticPremise(db, agentId, sourceId);
+		return;
+	}
+	if (!EPISODIC_SOURCE_KINDS.has(sourceKind)) {
+		throw new Error(`Derived memory provenance source kind is not supported: ${sourceKind}`);
+	}
+}
+
 /** A canonical evidence record used to derive a semantic memory. */
 export interface DerivedMemorySource {
 	readonly sourceKind: string;
@@ -16,8 +92,9 @@ function required(value: string, field: string): string {
 /**
  * Record the immutable evidence identities that a derived memory depends on.
  * Callers use episodic record identity (`memory`, `artifact`, `transcript`,
- * `summary`) rather than an owning connector/source type, which makes a
- * later evidence mutation addressable through the same relation.
+ * `summary`) or a same-agent semantic premise (`ontology_claim`). Semantic
+ * premise rows are checked before the relation is persisted so fabricated and
+ * cross-agent pointers fail closed.
  */
 export function linkDerivedMemorySourcesInTx(
 	db: WriteDb,
@@ -43,6 +120,7 @@ export function linkDerivedMemorySourcesInTx(
 		const key = `${sourceKind}\u0000${sourceId}`;
 		if (seen.has(key)) continue;
 		seen.add(key);
+		validateSource(db, agentId, sourceKind, sourceId);
 		insert.run(derivedMemoryId, sourceKind, sourceId, source.sourcePath?.trim() || null, agentId, createdAt);
 	}
 }

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -420,6 +420,43 @@ describe("ontology proposals", () => {
 		expect(getOntologyProposal(getDbAccessor(), pending.id, "ant")?.status).toBe("pending");
 	});
 
+	it("rejects fabricated and cross-agent semantic premise links before persistence (#1343)", () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES ('foreign-entity', 'Foreign', 'foreign', 'project', 'other', 1, ?, ?)`,
+			).run("2026-08-04T00:00:00.000Z", "2026-08-04T00:00:00.000Z");
+			db.prepare(
+				`INSERT INTO entity_aspects
+				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES ('foreign-aspect', 'foreign-entity', 'other', 'evidence', 'evidence', 0.8, ?, ?)`,
+			).run("2026-08-04T00:00:00.000Z", "2026-08-04T00:00:00.000Z");
+			db.prepare(
+				`INSERT INTO entity_attributes
+				 (id, aspect_id, agent_id, kind, content, normalized_content, confidence, importance, status, created_at, updated_at)
+				 VALUES ('foreign-attribute', 'foreign-aspect', 'other', 'attribute', 'Foreign premise', 'foreign premise', 0.8, 0.7, 'active', ?, ?)`,
+			).run("2026-08-04T00:00:00.000Z", "2026-08-04T00:00:00.000Z");
+		});
+
+		const link = (sourceId: string) =>
+			getDbAccessor().withWriteTx((db) =>
+				linkDerivedMemorySourcesInTx(db, {
+					derivedMemoryId: "derived-premise-target",
+					agentId: "ant",
+					sources: [{ sourceKind: "ontology_claim", sourceId }],
+					createdAt: "2026-08-04T00:00:00.000Z",
+				}),
+			);
+
+		expect(() => link("missing-attribute")).toThrow(
+			"Derived memory provenance semantic premise is not in the authorized agent scope: missing-attribute",
+		);
+		expect(() => link("foreign-attribute")).toThrow(
+			"Derived memory provenance semantic premise is not in the authorized agent scope: foreign-attribute",
+		);
+	});
+
 	it("rejects a deduped claim apply whose evidence source disappeared after creation", () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(

--- a/scripts/claim-trace-eval.ts
+++ b/scripts/claim-trace-eval.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../platform/daemon/src/db-accessor";
 import { createEpistemicAssertionsInTx } from "../platform/daemon/src/ontology-assertions";
+import { linkDerivedMemorySourcesInTx } from "../platform/daemon/src/derived-memory-provenance";
 import {
 	type ClaimTraceResult,
 	OntologyClaimTraceError,
@@ -267,6 +268,30 @@ try {
 		});
 		link(db, "eval-foreign-derived", "memory", "eval-foreign-source");
 
+		db.prepare(
+			`INSERT INTO entities
+			 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+			 VALUES ('eval-foreign-entity', 'Foreign Semantic Entity', 'foreign semantic entity', 'tool', 'other-agent', 1, ?, ?)`,
+		).run(now, now);
+		db.prepare(
+			`INSERT INTO entity_aspects
+			 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+			 VALUES ('eval-foreign-aspect', 'eval-foreign-entity', 'other-agent', 'preferences', 'preferences', 0.8, ?, ?)`,
+		).run(now, now);
+		insertMemory(db, {
+			id: "eval-foreign-semantic-derived",
+			content: "Foreign semantic claim.",
+			agentId: "other-agent",
+			memoryKind: "derived",
+		});
+		db.prepare(
+			`INSERT INTO entity_attributes
+			 (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
+			  status, group_key, claim_key, version, version_root_id, proposal_evidence, created_at, updated_at)
+			 VALUES ('eval-foreign-semantic-attr', 'eval-foreign-aspect', 'other-agent', 'eval-foreign-semantic-derived', 'attribute', 'Foreign semantic claim.', 'foreign semantic claim', 0.9, 0.8,
+			         'active', 'eval', 'foreign_semantic', 1, 'eval-foreign-semantic-attr', '[]', ?, ?)`,
+		).run(now, now);
+
 		insertMemory(db, { id: "eval-fabricated-derived", content: "Fabricated claim.", memoryKind: "derived" });
 		insertClaim(db, {
 			id: "eval-fabricated-attr",
@@ -339,6 +364,67 @@ try {
 		"409",
 		() => explain("fabricated"),
 		(value) => value instanceof OntologyClaimTraceError && value.status === 409,
+	);
+	run(
+		"same-agent semantic premise is persisted once across retries",
+		"one ontology_claim link",
+		() => {
+			getDbAccessor().withWriteTx((db) => {
+				linkDerivedMemorySourcesInTx(db, {
+					derivedMemoryId: "eval-dependent",
+					agentId,
+					sources: [{ sourceKind: "ontology_claim", sourceId: "eval-current" }],
+					createdAt: now,
+				});
+				linkDerivedMemorySourcesInTx(db, {
+					derivedMemoryId: "eval-dependent",
+					agentId,
+					sources: [{ sourceKind: "ontology_claim", sourceId: "eval-current" }],
+					createdAt: now,
+				});
+			});
+			return getDbAccessor().withReadDb(
+				(db) =>
+					(
+						db
+							.prepare(
+								`SELECT COUNT(*) AS count
+							 FROM derived_memory_sources
+							 WHERE derived_memory_id = 'eval-dependent' AND source_kind = 'ontology_claim' AND source_id = 'eval-current'`,
+							)
+							.get() as { count: number }
+					)?.count ?? 0,
+			);
+		},
+		(value) => value === 1,
+	);
+	run(
+		"fabricated semantic premise is rejected before persistence",
+		"fail closed",
+		() =>
+			getDbAccessor().withWriteTx((db) =>
+				linkDerivedMemorySourcesInTx(db, {
+					derivedMemoryId: "eval-dependent",
+					agentId,
+					sources: [{ sourceKind: "ontology_claim", sourceId: "does-not-exist" }],
+					createdAt: now,
+				}),
+			),
+		(value) => value instanceof Error && value.message.includes("not in the authorized agent scope"),
+	);
+	run(
+		"cross-agent semantic premise is rejected before persistence",
+		"fail closed",
+		() =>
+			getDbAccessor().withWriteTx((db) =>
+				linkDerivedMemorySourcesInTx(db, {
+					derivedMemoryId: "eval-dependent",
+					agentId,
+					sources: [{ sourceKind: "ontology_claim", sourceId: "eval-foreign-semantic-attr" }],
+					createdAt: now,
+				}),
+			),
+		(value) => value instanceof Error && value.message.includes("not in the authorized agent scope"),
 	);
 	run(
 		"reverse lineage is bounded",


### PR DESCRIPTION
## Summary

Close #1343 by validating semantic premise links at the shared derived-memory provenance seam. Fabricated, cross-agent, archived, superseded, deleted, and stale ontology premises now fail closed before persistence, while same-agent retries retain existing dedupe behavior.

## Changes

- Add same-agent lifecycle validation for `ontology_claim` provenance sources, including the linked entity, aspect, attribute, and semantic memory rows.
- Reject unsupported provenance source kinds instead of accepting unvalidated links.
- Add daemon regression coverage for fabricated and cross-agent premises, and update the aggregate fixture to use a real ontology claim.
- Extend `scripts/claim-trace-eval.ts` with same-agent retry dedupe plus fabricated and cross-agent semantic premise scenarios.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Targeted proof passed: `bun test platform/daemon/src/ontology-proposals.test.ts platform/daemon/src/aggregate-recall.test.ts platform/daemon/src/ontology-claim-trace.test.ts` (100 pass, 0 fail, 442 expects).
- Evaluation passed: `bun scripts/claim-trace-eval.ts` (11 scenarios, 11 passed, accuracy 1, unsupportedCertainty 1 from the intentional deleted-evidence scenario).
- Package proof passed: `bun run --filter '@signet/daemon' build`.
- Full `bun run typecheck` and `bun run lint` remain red on unrelated pre-existing connector/package formatting and export failures outside this change. The daemon package typecheck/build passes.
- #1313 and #1317 remain open coordination context. This PR keeps immutable evidence, ontology state, proposal/version lifecycle, stale marking, and claim-trace traversal as separate existing layers.
