### PR TITLE
fix(dreaming): avoid synchronous backlog encoding

### DIFF
--- a/platform/daemon/build.ts
+++ b/platform/daemon/build.ts
@@ -28,6 +28,7 @@ const targets: Array<{
 	{ entrypoint: "./src/index.ts", outfile: "./dist/index.js" },
 	{ entrypoint: "./src/synthesis-render-worker.ts", outfile: "./dist/synthesis-render-worker.js" },
 	{ entrypoint: "./src/database-integrity-worker.ts", outfile: "./dist/database-integrity-worker.js" },
+	{ entrypoint: "./src/pipeline/dreaming-token-worker.ts", outfile: "./dist/dreaming-token-worker.js" },
 ];
 
 const forceNodeBuild = process.env.FORCE_NODE_BUILD === "1";

--- a/platform/daemon/src/knowledge-graph-list.test.ts
+++ b/platform/daemon/src/knowledge-graph-list.test.ts
@@ -23,6 +23,10 @@ import {
 	listKnowledgeEntities,
 } from "./knowledge-graph";
 import { applyOntologyOperation } from "./ontology-proposals";
+import { getDreamingEpisodicTokenBacklog } from "./pipeline/dreaming";
+import { countTokens } from "./pipeline/tokenizer";
+import { renderDreamingEvidence } from "./pipeline/dreaming-evidence";
+import { searchEpisodicSources } from "./episodic-sources";
 
 function makeDbPath(): string {
 	const dir = join(tmpdir(), `signet-kg-list-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -350,7 +354,7 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		expect(listEntityAliases(getDbAccessor(), { agentId: "default", entityId: "e-signet" })).toHaveLength(0);
 	});
 
-	test("builds a bounded constellation graph without loading every graph row", () => {
+	test("builds a bounded constellation graph without loading every graph row", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
@@ -441,6 +445,17 @@ describe("listKnowledgeEntities (issue #515)", () => {
 			).run();
 		});
 
+		await getDreamingEpisodicTokenBacklog(getDbAccessor(), "default");
+		const source = getDbAccessor().withReadDb(
+			(db) =>
+				searchEpisodicSources(db, {
+					agentId: "default",
+					query: "",
+					excludeDelivered: true,
+					limit: 50,
+				})[0],
+		);
+		if (source === undefined) throw new Error("test fixture did not create an episodic source");
 		const graph = getKnowledgeGraphForConstellation(getDbAccessor(), "default", {
 			limit: 2,
 			maxAspectsPerEntity: 1,
@@ -460,7 +475,7 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		expect(graph.proposals[0]?.targetAspectName).toBe("alpha");
 		expect(graph.metadata.proposals.pending).toBe(1);
 		expect(graph.metadata.proposals.appliedRecent).toBe(1);
-		expect(graph.metadata.dreaming.episodicTokensPending).toBeGreaterThan(0);
+		expect(graph.metadata.dreaming.episodicTokensPending).toBe(countTokens(renderDreamingEvidence(source)));
 		expect(graph.metadata.dreaming.latestPass?.mutationsApplied).toBe(3);
 	});
 

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -22,7 +22,7 @@ import type {
 } from "@signet/core";
 import { SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES } from "@signet/core";
 import type { DbAccessor, ReadDb } from "./db-accessor";
-import { getDreamingEpisodicTokenBacklogInDb } from "./pipeline/dreaming";
+import { getDreamingEpisodicTokenBacklogCached } from "./pipeline/dreaming";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1877,7 +1877,7 @@ function getConstellationDreamingSummary(db: ReadDb, agentId: string): Constella
 	}
 
 	return {
-		episodicTokensPending: getDreamingEpisodicTokenBacklogInDb(db, agentId),
+		episodicTokensPending: getDreamingEpisodicTokenBacklogCached(agentId),
 		consecutiveFailures: Math.max(0, state?.consecutive_failures ?? 0),
 		lastPassAt: state?.last_pass_at ?? null,
 		lastPassId: state?.last_pass_id ?? null,

--- a/platform/daemon/src/pipeline/dreaming-token-cache.ts
+++ b/platform/daemon/src/pipeline/dreaming-token-cache.ts
@@ -1,0 +1,151 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
+import { resolveEmbeddedWorkerPath } from "../native-runtime-assets";
+
+export interface DreamingBacklogTokenEntry {
+	readonly key: string;
+	readonly text: string;
+}
+
+interface CountResponse {
+	readonly type: "counted";
+	readonly requestId: number;
+	readonly counts: readonly { readonly key: string; readonly count: number }[];
+}
+
+interface PendingRequest {
+	readonly resolve: (counts: readonly { readonly key: string; readonly count: number }[]) => void;
+	readonly reject: (error: Error) => void;
+}
+
+interface DreamingTokenWorkerLike {
+	on(event: "message", listener: (message: CountResponse) => void): unknown;
+	on(event: "error", listener: (error: Error) => void): unknown;
+	on(event: "exit", listener: (code: number) => void): unknown;
+	postMessage(message: unknown): void;
+	terminate(): Promise<number> | number;
+	unref?(): void;
+}
+
+function resolveWorkerPath(): string {
+	const moduleDir = dirname(fileURLToPath(import.meta.url));
+	const bundled = join(moduleDir, "dreaming-token-worker.js");
+	return existsSync(bundled)
+		? bundled
+		: (resolveEmbeddedWorkerPath("dreaming-token-worker") ?? join(moduleDir, "dreaming-token-worker.ts"));
+}
+
+/**
+ * Memoized exact backlog counts. The cache key includes the source and its
+ * delivered offset, while the text comparison catches in-place revisions.
+ * Consumption therefore removes or changes entries on the next refresh
+ * without maintaining a second counter that could drift from the evidence DB.
+ */
+export class DreamingBacklogTokenCache {
+	private readonly values = new Map<string, number>();
+	private readonly entries = new Map<string, DreamingBacklogTokenEntry>();
+	private readonly pending = new Map<number, PendingRequest>();
+	private readonly inflight = new Map<string, Promise<number>>();
+	private worker: DreamingTokenWorkerLike | null = null;
+	private nextRequestId = 1;
+
+	async refresh(agentId: string, entries: readonly DreamingBacklogTokenEntry[]): Promise<number> {
+		const active = this.inflight.get(agentId);
+		if (active !== undefined) return active;
+		const promise = this.refreshNow(agentId, entries);
+		this.inflight.set(agentId, promise);
+		try {
+			return await promise;
+		} finally {
+			this.inflight.delete(agentId);
+		}
+	}
+
+	get(agentId: string): number {
+		return this.values.get(agentId) ?? 0;
+	}
+
+	hasValue(agentId: string): boolean {
+		return this.values.has(agentId);
+	}
+
+	stop(): void {
+		const worker = this.worker;
+		this.worker = null;
+		if (worker !== null) void worker.terminate();
+		for (const pending of this.pending.values()) pending.reject(new Error("Dreaming token worker stopped"));
+		this.pending.clear();
+		this.inflight.clear();
+	}
+
+	private async refreshNow(agentId: string, entries: readonly DreamingBacklogTokenEntry[]): Promise<number> {
+		const nextKeys = new Set(entries.map((entry) => `${agentId}:${entry.key}`));
+		for (const key of this.entries.keys()) {
+			if (key.startsWith(`${agentId}:`) && !nextKeys.has(key)) this.entries.delete(key);
+		}
+
+		const uncached = entries.filter((entry) => {
+			const cached = this.entries.get(`${agentId}:${entry.key}`);
+			return cached === undefined || cached.text !== entry.text;
+		});
+		if (uncached.length > 0) {
+			const counts = await this.count(uncached);
+			for (const entry of uncached) {
+				const result = counts.find((item) => item.key === entry.key);
+				if (result === undefined) throw new Error(`Dreaming token worker omitted ${entry.key}`);
+				this.entries.set(`${agentId}:${entry.key}`, entry);
+				this.values.set(`${agentId}:${entry.key}`, result.count);
+			}
+		}
+
+		let total = 0;
+		for (const entry of entries) {
+			const count = this.values.get(`${agentId}:${entry.key}`);
+			if (count === undefined) throw new Error(`Missing cached Dreaming token count for ${entry.key}`);
+			total += count;
+		}
+		for (const key of this.values.keys()) {
+			if (key.startsWith(`${agentId}:`) && !nextKeys.has(key)) this.values.delete(key);
+		}
+		this.values.set(agentId, total);
+		return total;
+	}
+
+	private count(
+		entries: readonly DreamingBacklogTokenEntry[],
+	): Promise<readonly { readonly key: string; readonly count: number }[]> {
+		const worker = this.ensureWorker();
+		const requestId = this.nextRequestId++;
+		return new Promise((resolve, reject) => {
+			this.pending.set(requestId, { resolve, reject });
+			worker.postMessage({ type: "count", requestId, entries });
+		});
+	}
+
+	private ensureWorker(): DreamingTokenWorkerLike {
+		if (this.worker !== null) return this.worker;
+		const worker = new Worker(resolveWorkerPath()) as unknown as DreamingTokenWorkerLike;
+		worker.unref?.();
+		worker.on("message", (message) => {
+			const pending = this.pending.get(message.requestId);
+			if (pending === undefined) return;
+			this.pending.delete(message.requestId);
+			pending.resolve(message.counts);
+		});
+		const fail = (error: Error): void => {
+			for (const pending of this.pending.values()) pending.reject(error);
+			this.pending.clear();
+			this.worker = null;
+		};
+		worker.on("error", fail);
+		worker.on("exit", (code) => {
+			if (code !== 0) fail(new Error(`Dreaming token worker exited with code ${code}`));
+			if (this.worker === worker) this.worker = null;
+		});
+		this.worker = worker;
+		return worker;
+	}
+}

--- a/platform/daemon/src/pipeline/dreaming-token-cache.ts
+++ b/platform/daemon/src/pipeline/dreaming-token-cache.ts
@@ -41,12 +41,15 @@ function resolveWorkerPath(): string {
 /**
  * Memoized exact backlog counts. The cache key includes the source and its
  * delivered offset, while the text comparison catches in-place revisions.
+ * Entries and counts are nested by agent ID rather than concatenated, so an
+ * agent ID containing ":" cannot collide with a source key or aggregate.
  * Consumption therefore removes or changes entries on the next refresh
  * without maintaining a second counter that could drift from the evidence DB.
  */
 export class DreamingBacklogTokenCache {
 	private readonly values = new Map<string, number>();
-	private readonly entries = new Map<string, DreamingBacklogTokenEntry>();
+	private readonly entries = new Map<string, Map<string, DreamingBacklogTokenEntry>>();
+	private readonly entryValues = new Map<string, Map<string, number>>();
 	private readonly pending = new Map<number, PendingRequest>();
 	private readonly inflight = new Map<string, Promise<number>>();
 	private worker: DreamingTokenWorkerLike | null = null;
@@ -82,13 +85,17 @@ export class DreamingBacklogTokenCache {
 	}
 
 	private async refreshNow(agentId: string, entries: readonly DreamingBacklogTokenEntry[]): Promise<number> {
-		const nextKeys = new Set(entries.map((entry) => `${agentId}:${entry.key}`));
-		for (const key of this.entries.keys()) {
-			if (key.startsWith(`${agentId}:`) && !nextKeys.has(key)) this.entries.delete(key);
+		const nextKeys = new Set(entries.map((entry) => entry.key));
+		const agentEntries = this.entries.get(agentId) ?? new Map<string, DreamingBacklogTokenEntry>();
+		const agentValues = this.entryValues.get(agentId) ?? new Map<string, number>();
+		this.entries.set(agentId, agentEntries);
+		this.entryValues.set(agentId, agentValues);
+		for (const key of agentEntries.keys()) {
+			if (!nextKeys.has(key)) agentEntries.delete(key);
 		}
 
 		const uncached = entries.filter((entry) => {
-			const cached = this.entries.get(`${agentId}:${entry.key}`);
+			const cached = agentEntries.get(entry.key);
 			return cached === undefined || cached.text !== entry.text;
 		});
 		if (uncached.length > 0) {
@@ -96,19 +103,19 @@ export class DreamingBacklogTokenCache {
 			for (const entry of uncached) {
 				const result = counts.find((item) => item.key === entry.key);
 				if (result === undefined) throw new Error(`Dreaming token worker omitted ${entry.key}`);
-				this.entries.set(`${agentId}:${entry.key}`, entry);
-				this.values.set(`${agentId}:${entry.key}`, result.count);
+				agentEntries.set(entry.key, entry);
+				agentValues.set(entry.key, result.count);
 			}
 		}
 
 		let total = 0;
 		for (const entry of entries) {
-			const count = this.values.get(`${agentId}:${entry.key}`);
+			const count = agentValues.get(entry.key);
 			if (count === undefined) throw new Error(`Missing cached Dreaming token count for ${entry.key}`);
 			total += count;
 		}
-		for (const key of this.values.keys()) {
-			if (key.startsWith(`${agentId}:`) && !nextKeys.has(key)) this.values.delete(key);
+		for (const key of agentValues.keys()) {
+			if (!nextKeys.has(key)) agentValues.delete(key);
 		}
 		this.values.set(agentId, total);
 		return total;

--- a/platform/daemon/src/pipeline/dreaming-token-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-token-worker.ts
@@ -1,0 +1,37 @@
+/**
+ * Worker-thread BPE counter for the Dreaming episodic backlog.
+ *
+ * The backlog is used by the scheduler and status surfaces, so replacing the
+ * exact cl100k count with a character estimate changes product behavior. Keep
+ * the expensive encodes in this worker instead of the daemon event loop.
+ */
+
+import { isMainThread, parentPort } from "node:worker_threads";
+import { countTokens } from "./tokenizer";
+
+interface CountRequest {
+	readonly type: "count";
+	readonly requestId: number;
+	readonly entries: readonly { readonly key: string; readonly text: string }[];
+}
+
+interface CountResponse {
+	readonly type: "counted";
+	readonly requestId: number;
+	readonly counts: readonly { readonly key: string; readonly count: number }[];
+}
+
+const port = parentPort;
+if (isMainThread || port === null) {
+	throw new Error("dreaming-token-worker.ts must run in a worker thread");
+}
+
+port.on("message", (message: CountRequest) => {
+	if (message.type !== "count") return;
+	const response: CountResponse = {
+		type: "counted",
+		requestId: message.requestId,
+		counts: message.entries.map((entry) => ({ key: entry.key, count: countTokens(entry.text) })),
+	};
+	port.postMessage(response);
+});

--- a/platform/daemon/src/pipeline/dreaming-worker.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.test.ts
@@ -357,7 +357,7 @@ describe("dreaming worker agent scope", () => {
 		}
 	});
 
-	it("alternates hygiene and content runbooks across sweep checks (#1098)", () => {
+	it("alternates hygiene and content runbooks across sweep checks (#1098)", async () => {
 		// Regression for #1098: with the hygiene queue perpetually full, the
 		// sweep scheduled the combined runbook every cycle and content
 		// ingestion never got budget. When both hygiene and content work are
@@ -377,31 +377,31 @@ describe("dreaming worker agent scope", () => {
 		enqueueDreamingHygieneAttention(accessor, "default");
 
 		let focus: DreamingPassFocus | null = null;
-		const first = selectDreamingCheckMode(accessor, ["default"], focus);
+		const first = await selectDreamingCheckMode(accessor, ["default"], focus);
 		expect(first).toBe("incremental-hygiene");
 		focus = dreamingFocusOfMode(first) ?? focus;
-		const second = selectDreamingCheckMode(accessor, ["default"], focus);
+		const second = await selectDreamingCheckMode(accessor, ["default"], focus);
 		expect(second).toBe("incremental-content");
 		focus = dreamingFocusOfMode(second) ?? focus;
-		expect(selectDreamingCheckMode(accessor, ["default"], focus)).toBe("incremental-hygiene");
+		expect(await selectDreamingCheckMode(accessor, ["default"], focus)).toBe("incremental-hygiene");
 	});
 
-	it("routes pending surprisal hints to a content pass without an evidence backlog", () => {
+	it("routes pending surprisal hints to a content pass without an evidence backlog", async () => {
 		db.prepare(
 			`INSERT INTO dreaming_attention (id, agent_id, kind, subject_ref, details_json, priority)
 			 VALUES ('surprisal-hint', 'default', 'surprisal', 'memory:outlier', '{}', 90)`,
 		).run();
 
-		expect(selectDreamingCheckMode(accessor, ["default"], null)).toBe("incremental-content");
+		expect(await selectDreamingCheckMode(accessor, ["default"], null)).toBe("incremental-content");
 	});
 
-	it("routes pending temporal review attention to a content pass", () => {
+	it("routes pending temporal review attention to a content pass", async () => {
 		db.prepare(
 			`INSERT INTO dreaming_attention (id, agent_id, kind, subject_ref, details_json, priority)
 			 VALUES ('review-hint', 'default', 'review_due', 'memory:temporal', '{}', 90)`,
 		).run();
 
-		expect(selectDreamingCheckMode(accessor, ["default"], null)).toBe("incremental-content");
+		expect(await selectDreamingCheckMode(accessor, ["default"], null)).toBe("incremental-content");
 	});
 
 	it("seeds deterministic hygiene attention for legacy graph rows", () => {

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -170,18 +170,19 @@ export function createAgentScopeSnapshot(
  * kinds are pending so content gets a guaranteed turn even while the hygiene
  * queue stays full. Shared between check() and tests.
  */
-export function selectDreamingCheckMode(
+export async function selectDreamingCheckMode(
 	accessor: DbAccessor,
 	scopes: readonly string[],
 	lastScheduled: DreamingPassFocus | null,
-): DreamingMode {
+): Promise<DreamingMode> {
 	const hasPendingHygieneAttention = scopes.some((scope) =>
 		accessor.withReadDb((db) => hasDreamingAttentionKindInDb(db, scope, ["hygiene"])),
 	);
 	const hasPendingContentAttention = scopes.some((scope) =>
 		accessor.withReadDb((db) => hasDreamingAttentionKindInDb(db, scope, DREAMING_CONTENT_ATTENTION_KINDS)),
 	);
-	const hasBacklog = scopes.some((scope) => getDreamingEpisodicTokenBacklog(accessor, scope) > 0);
+	const backlogs = await Promise.all(scopes.map((scope) => getDreamingEpisodicTokenBacklog(accessor, scope)));
+	const hasBacklog = backlogs.some((backlog) => backlog > 0);
 	return selectDreamingPassMode(lastScheduled, hasPendingHygieneAttention, hasBacklog, hasPendingContentAttention);
 }
 
@@ -352,8 +353,8 @@ export function startDreamingWorker(
 			try {
 				enqueueDreamingHygieneAttention(accessor, scopeId, undefined, caps);
 				enqueueDreamingSurprisalAttention(accessor, scopeId, cfg);
-				const episodicTokens = getDreamingEpisodicTokenBacklog(accessor, scopeId);
-				if (!shouldTriggerDreaming(accessor, cfg, scopeId, Date.now(), episodicTokens)) continue;
+				const episodicTokens = await getDreamingEpisodicTokenBacklog(accessor, scopeId);
+				if (!(await shouldTriggerDreaming(accessor, cfg, scopeId, Date.now(), episodicTokens))) continue;
 				triggered = true;
 				logger.info("dreaming-worker", "Episodic evidence threshold reached, starting dreaming pass", {
 					scopeId,
@@ -375,7 +376,7 @@ export function startDreamingWorker(
 		// content a guaranteed turn: alternate the runbook per check cycle
 		// when both kinds of work are pending; run the only-pending kind
 		// directly otherwise.
-		const mode = selectDreamingCheckMode(accessor, scopes, nextScheduledFocus);
+		const mode = await selectDreamingCheckMode(accessor, scopes, nextScheduledFocus);
 		nextScheduledFocus = dreamingFocusOfMode(mode) ?? nextScheduledFocus;
 		try {
 			await runPass(defaultAgentId, mode, undefined, scopes);

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -4,6 +4,7 @@ import type { DreamingConfig } from "@signet/core";
 import { runMigrations } from "../../../core/src/migrations";
 import type { DbAccessor, ReadDb } from "../db-accessor";
 import { type TelemetryCollector, type TelemetryEvent, setActiveTelemetry } from "../telemetry";
+import { resetTokenizerStats, tokenizerStats } from "../pipeline/tokenizer";
 import {
 	DREAMING_AGENT_PROMPT,
 	DREAMING_CONTENT_AGENT_PROMPT,
@@ -174,6 +175,15 @@ describe("Dreaming", () => {
 				JSON.stringify({ capturedAt: "2026-03-01T00:00:00.000Z", kind: "summary", id: "fragment", fragmentOffset: -1 }),
 			),
 		).toEqual({ capturedAt: "2026-03-01T00:00:00.000Z", kind: "summary", id: "fragment" });
+	});
+
+	it("keeps backlog checks off the synchronous BPE encoder (#1552)", () => {
+		seedTranscript(db, "large-backlog", "pending evidence ".repeat(2_000));
+		resetTokenizerStats();
+
+		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+		expect(tokenizerStats.encodeCalls).toBe(0);
+		expect(tokenizerStats.encodeChars).toBe(0);
 	});
 
 	it("drains oversized evidence only after every delivered fragment completes (#1430)", async () => {

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -202,6 +202,26 @@ describe("Dreaming", () => {
 		expect(tokenizerStats.encodeChars).toBe(0);
 	});
 
+	it("keeps backlog cache entries isolated from colon-containing agent IDs (#1555)", async () => {
+		const leftAgent = "cache-collision-left";
+		const leftSource = "cache-collision-source";
+		const rightAgent = `${leftAgent}:transcript:${leftSource}:0`;
+		seedTranscript(db, leftSource, "The left scope has a distinct exact token count.", undefined, leftAgent);
+		seedTranscript(
+			db,
+			"cache-collision-other",
+			"The right scope must not overwrite the left scope. ".repeat(10),
+			undefined,
+			rightAgent,
+		);
+
+		const leftInitial = await getDreamingEpisodicTokenBacklog(accessor, leftAgent);
+		await getDreamingEpisodicTokenBacklog(accessor, rightAgent);
+
+		expect(rightAgent).toContain(":");
+		expect(await getDreamingEpisodicTokenBacklog(accessor, leftAgent)).toBe(leftInitial);
+	});
+
 	it("keeps the event loop responsive during a large exact-BPE backlog refresh (#1552, #1543)", async () => {
 		for (let i = 0; i < 50; i += 1) {
 			seedTranscript(

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -4,7 +4,7 @@ import type { DreamingConfig } from "@signet/core";
 import { runMigrations } from "../../../core/src/migrations";
 import type { DbAccessor, ReadDb } from "../db-accessor";
 import { type TelemetryCollector, type TelemetryEvent, setActiveTelemetry } from "../telemetry";
-import { resetTokenizerStats, tokenizerStats } from "../pipeline/tokenizer";
+import { countTokens, resetTokenizerStats, tokenizerStats } from "../pipeline/tokenizer";
 import {
 	DREAMING_AGENT_PROMPT,
 	DREAMING_CONTENT_AGENT_PROMPT,
@@ -35,6 +35,8 @@ import {
 	resolveDreamingAttentionInTx,
 } from "./dreaming-attention";
 import { pendingDreamingEvidenceContinuations } from "./dreaming-evidence-consumption";
+import { renderDreamingEvidence } from "./dreaming-evidence";
+import { searchEpisodicSources } from "../episodic-sources";
 import {
 	autoRequeueRepairedDreamingEvidence,
 	collectRejectedDreamingEvidence,
@@ -177,18 +179,75 @@ describe("Dreaming", () => {
 		).toEqual({ capturedAt: "2026-03-01T00:00:00.000Z", kind: "summary", id: "fragment" });
 	});
 
-	it("keeps backlog checks off the synchronous BPE encoder (#1552)", () => {
-		seedTranscript(db, "large-backlog", "pending evidence ".repeat(2_000));
+	it("keeps backlog checks off the synchronous BPE encoder (#1552)", async () => {
+		seedTranscript(
+			db,
+			"large-backlog",
+			"function parseEvidence(input) { return input?.items?.filter((item) => item.active); }\n\n" +
+				"The backlog must preserve exact token semantics for operator-tuned thresholds.",
+		);
+		const source = searchEpisodicSources(db as unknown as ReadDb, {
+			agentId: AGENT,
+			query: "",
+			excludeDelivered: true,
+			limit: 50,
+		})[0];
+		if (source === undefined) throw new Error("test fixture did not create an episodic source");
+		const expected = countTokens(renderDreamingEvidence(source));
 		resetTokenizerStats();
 
-		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+		expect(await getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBe(expected);
+		expect(expected).not.toBe(Math.ceil(renderDreamingEvidence(source).length / 4));
 		expect(tokenizerStats.encodeCalls).toBe(0);
 		expect(tokenizerStats.encodeChars).toBe(0);
 	});
 
+	it("keeps the event loop responsive during a large exact-BPE backlog refresh (#1552, #1543)", async () => {
+		for (let i = 0; i < 50; i += 1) {
+			seedTranscript(
+				db,
+				`large-backlog-${i}`,
+				`function parseEvidence${i}(input) { return input?.items?.filter((item) => item.active); }\n` +
+					"The unreachable provider must not turn exact BPE backlog accounting into a main-thread wedge.\n" +
+					"prose ".repeat(2_000),
+			);
+		}
+
+		const latencies: number[] = [];
+		let measuring = true;
+		const measureLoop = async (): Promise<void> => {
+			while (measuring) {
+				const start = performance.now();
+				await new Promise<void>((resolve) => setImmediate(resolve));
+				latencies.push(performance.now() - start);
+			}
+		};
+		const measurePromise = measureLoop();
+
+		const pass = runDreamingAgentPass(
+			accessor,
+			{
+				async run() {
+					throw new Error("provider unavailable");
+				},
+			},
+			defaultCfg(),
+			"/tmp",
+			AGENT,
+			[AGENT],
+			"incremental",
+		);
+		await expect(pass).rejects.toThrow("provider unavailable");
+		measuring = false;
+		await measurePromise;
+
+		expect(Math.max(...latencies)).toBeLessThan(200);
+		expect(latencies.length).toBeGreaterThan(2);
+	});
+
 	it("drains oversized evidence only after every delivered fragment completes (#1430)", async () => {
 		seedTranscript(db, "s1", "x".repeat(5_000));
-		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+		expect(await getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
 		let prompt = "";
 		const run = async () =>
 			runDreamingAgentPass(
@@ -228,7 +287,7 @@ describe("Dreaming", () => {
 		expect(partial).toEqual(expect.objectContaining({ length: 5_000 }));
 		expect(partial?.offset).toBeGreaterThan(0);
 		expect(partial?.offset).toBeLessThan(partial?.length ?? 0);
-		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+		expect(await getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
 
 		const second = await run();
 		const secondDelivery = getDreamingToolCalls(accessor, AGENT, second.passId).find(
@@ -239,9 +298,9 @@ describe("Dreaming", () => {
 		});
 		// The second pass records the next contiguous fragment; the final
 		// 1,000-character fragment remains pending until a third pass.
-		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+		expect(await getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
 		await run();
-		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBe(0);
+		expect(await getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBe(0);
 	}, 15_000);
 
 	it("does not consume evidence delivered by a failed pass (#1430)", async () => {
@@ -273,7 +332,7 @@ describe("Dreaming", () => {
 				}
 			).count,
 		).toBe(0);
-		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+		expect(await getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
 	});
 
 	it("does not acknowledge an artifact revision replaced during a pass (#1430)", async () => {
@@ -309,7 +368,7 @@ describe("Dreaming", () => {
 					.get("sources/revised.md", "sha-new") as { count: number }
 			).count,
 		).toBe(0);
-		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+		expect(await getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
 	});
 
 	it("keeps deferred delivery pending in its owning agent scope (#1430)", async () => {
@@ -360,7 +419,7 @@ describe("Dreaming", () => {
 				}
 			).count,
 		).toBe(1);
-		expect(getDreamingEpisodicTokenBacklog(accessor, otherAgent)).toBeGreaterThan(0);
+		expect(await getDreamingEpisodicTokenBacklog(accessor, otherAgent)).toBeGreaterThan(0);
 	});
 
 	it("replaces a historical summary DAG row with the direct transcript projection", async () => {
@@ -426,17 +485,17 @@ describe("Dreaming", () => {
 		});
 	});
 
-	it("uses wall-clock backoff independently of later evidence volume", () => {
+	it("uses wall-clock backoff independently of later evidence volume", async () => {
 		seedSummary(db, "first", "episodic source", 10);
 		recordDreamingFailure(accessor, AGENT);
 		const failedAt = Date.parse(getDreamingState(accessor, AGENT).lastFailureAt ?? "");
 		const cfg = defaultCfg({ tokenThreshold: 1, backfillOnFirstRun: false });
-		expect(shouldTriggerDreaming(accessor, cfg, AGENT, failedAt + 10 * 60 * 1000 - 1)).toBe(false);
+		expect(await shouldTriggerDreaming(accessor, cfg, AGENT, failedAt + 10 * 60 * 1000 - 1)).toBe(false);
 		seedSummary(db, "later", "episodic source ".repeat(3_000), 3_000);
-		expect(shouldTriggerDreaming(accessor, cfg, AGENT, failedAt + 10 * 60 * 1000)).toBe(true);
+		expect(await shouldTriggerDreaming(accessor, cfg, AGENT, failedAt + 10 * 60 * 1000)).toBe(true);
 	});
 
-	it("halts automatic scheduling after repeated consecutive failures", () => {
+	it("halts automatic scheduling after repeated consecutive failures", async () => {
 		seedSummary(db, "first", "episodic source", 10);
 		for (let i = 0; i < DREAMING_FAILURE_HALT_THRESHOLD; i += 1) {
 			recordDreamingFailure(accessor, AGENT);
@@ -446,9 +505,9 @@ describe("Dreaming", () => {
 		// Halted: a large backlog and fresh attention must not trigger a pass
 		// inside the cooldown window.
 		seedSummary(db, "later", "episodic source ".repeat(3_000), 3_000);
-		expect(shouldTriggerDreaming(accessor, cfg, AGENT, failedAt + 60 * 1000)).toBe(false);
+		expect(await shouldTriggerDreaming(accessor, cfg, AGENT, failedAt + 60 * 1000)).toBe(false);
 		// Cooldown elapsed: scheduling resumes (the next failure re-halts).
-		expect(shouldTriggerDreaming(accessor, cfg, AGENT, failedAt + DREAMING_HALT_COOLDOWN_MS + 1_000)).toBe(true);
+		expect(await shouldTriggerDreaming(accessor, cfg, AGENT, failedAt + DREAMING_HALT_COOLDOWN_MS + 1_000)).toBe(true);
 	});
 
 	it("isDreamingScopeHalted gates on the failure threshold and cooldown", () => {
@@ -494,7 +553,7 @@ describe("Dreaming", () => {
 		expect(isDreamingHaltActive(accessor, AGENT)).toBe(true);
 	});
 
-	it("schedules a near-term continuation only after the latest capped content delivery (#1430)", () => {
+	it("schedules a near-term continuation only after the latest capped content delivery (#1430)", async () => {
 		const now = Date.now();
 		const capturedAt = new Date(now).toISOString();
 		const passId = "partial-content-pass";
@@ -512,14 +571,14 @@ describe("Dreaming", () => {
 			).run(AGENT, capturedAt, capturedAt, passId, capturedAt);
 		});
 		const cfg = defaultCfg({ tokenThreshold: 100_000, backfillOnFirstRun: false });
-		expect(shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(true);
+		expect(await shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(true);
 
 		// A subsequent no-progress pass gets a new id. It may be retried later
 		// through the normal threshold/interval policy, but it cannot spin here.
 		accessor.withWriteTx((tx) => {
 			tx.prepare("UPDATE dreaming_state SET last_pass_id = ? WHERE agent_id = ?").run("no-progress-pass", AGENT);
 		});
-		expect(shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(false);
+		expect(await shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(false);
 
 		// Completion clears the continuation even when it was the latest pass.
 		accessor.withWriteTx((tx) => {
@@ -528,7 +587,7 @@ describe("Dreaming", () => {
 				passId,
 			);
 		});
-		expect(shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(false);
+		expect(await shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(false);
 
 		// Scheduler failure backoff gates a partial continuation like every other
 		// automatic pass. It cannot bypass error recovery or the failure halt.
@@ -536,7 +595,7 @@ describe("Dreaming", () => {
 			tx.prepare("UPDATE dreaming_evidence_consumption SET delivered_offset = 2_000 WHERE pass_id = ?").run(passId);
 		});
 		recordDreamingFailure(accessor, AGENT);
-		expect(shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(false);
+		expect(await shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(false);
 	});
 
 	it("pins a capped frontier ahead of newer evidence on its next pass (#1430)", async () => {
@@ -570,7 +629,7 @@ describe("Dreaming", () => {
 				new Date(now + (index + 1) * 1_000).toISOString(),
 			);
 		}
-		expect(shouldTriggerDreaming(accessor, cfg, AGENT, now + 21_000)).toBe(true);
+		expect(await shouldTriggerDreaming(accessor, cfg, AGENT, now + 21_000)).toBe(true);
 
 		const second = await run();
 		const delivery = getDreamingToolCalls(accessor, AGENT, second.passId).find(
@@ -589,7 +648,7 @@ describe("Dreaming", () => {
 		// The progression moved to the second pass, so the final page remains a
 		// bounded continuation rather than falling behind the newer evidence.
 		expect(second.passId).not.toBe(first.passId);
-		expect(shouldTriggerDreaming(accessor, cfg, AGENT, now + 21_000)).toBe(true);
+		expect(await shouldTriggerDreaming(accessor, cfg, AGENT, now + 21_000)).toBe(true);
 	}, 15_000);
 
 	it("rotates every capped partial frontier before revisiting a newer subset (#1430)", async () => {
@@ -737,7 +796,7 @@ describe("Dreaming", () => {
 		expect(plan.map((row) => row.detail).join("\n")).toContain("idx_dreaming_evidence_consumption_continuation");
 	});
 
-	it("runs a low-volume episodic backlog once its maximum wait elapses", () => {
+	it("runs a low-volume episodic backlog once its maximum wait elapses", async () => {
 		const now = Date.now();
 		seedSummary(db, "trickle", "small episodic source", 10);
 		accessor.withWriteTx((tx) => {
@@ -747,8 +806,8 @@ describe("Dreaming", () => {
 			).run(AGENT, new Date(now - 6 * 60 * 60 * 1_000).toISOString());
 		});
 		const cfg = defaultCfg({ tokenThreshold: 100_000, maxInterval: 6 * 60 * 60 * 1_000, backfillOnFirstRun: false });
-		expect(shouldTriggerDreaming(accessor, cfg, AGENT, now - 1)).toBe(false);
-		expect(shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(true);
+		expect(await shouldTriggerDreaming(accessor, cfg, AGENT, now - 1)).toBe(false);
+		expect(await shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(true);
 	});
 
 	it("runs a pass when attention is pending and leaves it for the agent to consume", async () => {
@@ -761,7 +820,7 @@ describe("Dreaming", () => {
 				priority: 90,
 			});
 		});
-		expect(shouldTriggerDreaming(accessor, defaultCfg(), AGENT)).toBe(true);
+		expect(await shouldTriggerDreaming(accessor, defaultCfg(), AGENT)).toBe(true);
 
 		let prompt = "";
 		const result = await runDreamingAgentPass(
@@ -797,7 +856,7 @@ describe("Dreaming", () => {
 				priority: 90,
 			});
 		});
-		expect(shouldTriggerDreaming(accessor, defaultCfg(), AGENT)).toBe(true);
+		expect(await shouldTriggerDreaming(accessor, defaultCfg(), AGENT)).toBe(true);
 
 		const result = await runDreamingAgentPass(
 			accessor,
@@ -851,7 +910,7 @@ describe("Dreaming", () => {
 				);
 			}
 		});
-		expect(shouldTriggerDreaming(accessor, defaultCfg(), AGENT)).toBe(true);
+		expect(await shouldTriggerDreaming(accessor, defaultCfg(), AGENT)).toBe(true);
 
 		await runDreamingAgentPass(
 			accessor,
@@ -921,7 +980,7 @@ describe("Dreaming", () => {
 		);
 	});
 
-	it("turns deterministic graph hygiene into scoped attention without episodic evidence", () => {
+	it("turns deterministic graph hygiene into scoped attention without episodic evidence", async () => {
 		db.prepare(
 			`INSERT INTO entities
 			 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
@@ -937,7 +996,7 @@ describe("Dreaming", () => {
 				}),
 			]),
 		);
-		expect(shouldTriggerDreaming(accessor, defaultCfg(), AGENT)).toBe(true);
+		expect(await shouldTriggerDreaming(accessor, defaultCfg(), AGENT)).toBe(true);
 		const snapshots = getDreamingAttentionSnapshots(accessor, AGENT);
 		accessor.withWriteTx((tx) => resolveDreamingAttentionInTx(tx, AGENT, "pass-hygiene", snapshots));
 		enqueueDreamingHygieneAttention(accessor, AGENT);
@@ -1685,7 +1744,7 @@ describe("Dreaming", () => {
 				subjectRef: "entity:legacy-husk",
 			});
 		});
-		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+		expect(await getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
 
 		await runDreamingAgentPass(
 			accessor,
@@ -1702,7 +1761,7 @@ describe("Dreaming", () => {
 		);
 		// The hygiene pass consumed no evidence: the backlog still counts as
 		// new, so the next scheduled content pass gets it.
-		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+		expect(await getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
 
 		await runDreamingAgentPass(
 			accessor,
@@ -1723,7 +1782,7 @@ describe("Dreaming", () => {
 			[AGENT],
 			"incremental-content",
 		);
-		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBe(0);
+		expect(await getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBe(0);
 	});
 
 	it("acknowledges evidence that arrives during a content-attention pass without advancing the watermark (#1430)", async () => {
@@ -1765,7 +1824,7 @@ describe("Dreaming", () => {
 				}
 			).count,
 		).toBe(1);
-		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBe(0);
+		expect(await getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBe(0);
 	});
 
 	it("does not advance the evidence watermark past evidence a content pass never surfaced (#1149)", async () => {
@@ -1792,7 +1851,7 @@ describe("Dreaming", () => {
 			"incremental-content",
 		);
 		expect(getDreamingState(accessor, AGENT).lastPassAt).toBeNull();
-		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+		expect(await getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
 	});
 
 	it("advances the evidence watermark only to the evidence the pass surfaced (#1149)", async () => {
@@ -1840,7 +1899,7 @@ describe("Dreaming", () => {
 		expect(getDreamingState(accessor, AGENT).lastPassAt).toBe("2026-08-06T12:00:00.000Z");
 		// The gap evidence (captured after the surfaced frontier, before pass
 		// start) remains pending for the next scan-first search.
-		expect(getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
+		expect(await getDreamingEpisodicTokenBacklog(accessor, AGENT)).toBeGreaterThan(0);
 		const manifestNodes = accessor.withReadDb(
 			(db) =>
 				db

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -82,7 +82,7 @@ import {
 	type DreamingSurprisalSelection,
 	selectDreamingSurprisalInDb,
 } from "./dreaming-surprisal";
-import { countTokens } from "./tokenizer";
+import { countTokens, estimateTokens } from "./tokenizer";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1840,7 +1840,9 @@ export function getDreamingEpisodicTokenBacklogInDb(db: ReadDb, agentId: string)
 		});
 		return queued.reduce((total, source) => {
 			const remaining = renderDreamingEvidence(source).slice(deliveredOffsetForSource(db, agentId, source));
-			return total + countTokens(remaining);
+			// This is only a trigger estimate. Exact BPE encoding here blocks the
+			// daemon's event loop while scanning every queued source.
+			return total + estimateTokens(remaining);
 		}, 0);
 	}
 	const state = readDreamingState(db, agentId);
@@ -1858,8 +1860,11 @@ export function getDreamingEpisodicTokenBacklogInDb(db: ReadDb, agentId: string)
 			? readEpisodicSource(db, { agentId, from: `${state.evidenceCursor.kind}:${state.evidenceCursor.id}` })
 			: null;
 	const remaining = resumed ? renderDreamingEvidence(resumed).slice(state.evidenceCursor?.fragmentOffset) : "";
+	// This is only a trigger estimate. Exact BPE encoding here blocks the
+	// daemon's event loop while scanning every queued source.
 	return (
-		queued.reduce((total, source) => total + countTokens(renderDreamingEvidence(source)), 0) + countTokens(remaining)
+		queued.reduce((total, source) => total + estimateTokens(renderDreamingEvidence(source)), 0) +
+		estimateTokens(remaining)
 	);
 }
 

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -82,7 +82,8 @@ import {
 	type DreamingSurprisalSelection,
 	selectDreamingSurprisalInDb,
 } from "./dreaming-surprisal";
-import { countTokens, estimateTokens } from "./tokenizer";
+import { DreamingBacklogTokenCache, type DreamingBacklogTokenEntry } from "./dreaming-token-cache";
+import { countTokens } from "./tokenizer";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1406,7 +1407,9 @@ export async function runDreamingAgentPass(
 			accessor.withReadDb((db) => getDreamingAttentionInDb(db, scope, 1).length > 0),
 		);
 		const backlogByScope = new Map(
-			scopes.map((scope) => [scope, getDreamingEpisodicTokenBacklog(accessor, scope)] as const),
+			await Promise.all(
+				scopes.map(async (scope) => [scope, await getDreamingEpisodicTokenBacklog(accessor, scope)] as const),
+			),
 		);
 		const totalBacklog = [...backlogByScope.values()].reduce((total, backlog) => total + backlog, 0);
 		const earlyExitSummary = dreamingEarlyExitSummary(
@@ -1806,6 +1809,7 @@ function writeDreamingTranscriptManifestInTx(
 // on the next forced or post-cooldown pass (#1059).
 export const DREAMING_FAILURE_HALT_THRESHOLD = 5;
 export const DREAMING_HALT_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+const dreamingBacklogTokenCache = new DreamingBacklogTokenCache();
 
 export function isDreamingScopeHalted(state: DreamingState, nowMs = Date.now()): boolean {
 	if (state.consecutiveFailures < DREAMING_FAILURE_HALT_THRESHOLD) return false;
@@ -1818,16 +1822,10 @@ export function isDreamingHaltActive(accessor: DbAccessor, agentId: string, nowM
 	return isDreamingScopeHalted(getDreamingState(accessor, agentId), nowMs);
 }
 
-/**
- * The worker's backlog is the episodic evidence it has not yet reasoned over,
- * not a separately maintained token counter. This keeps the trigger aligned
- * with every supported input source.
- */
-export function getDreamingEpisodicTokenBacklog(accessor: DbAccessor, agentId: string): number {
-	return accessor.withReadDb((db) => getDreamingEpisodicTokenBacklogInDb(db, agentId));
-}
-
-export function getDreamingEpisodicTokenBacklogInDb(db: ReadDb, agentId: string): number {
+function readDreamingEpisodicTokenBacklogEntriesInDb(
+	db: ReadDb,
+	agentId: string,
+): readonly DreamingBacklogTokenEntry[] {
 	const hasConsumption =
 		db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'dreaming_evidence_consumption'").get() !=
 		null;
@@ -1838,12 +1836,12 @@ export function getDreamingEpisodicTokenBacklogInDb(db: ReadDb, agentId: string)
 			excludeDelivered: true,
 			limit: 50,
 		});
-		return queued.reduce((total, source) => {
+		return queued.flatMap((source) => {
 			const remaining = renderDreamingEvidence(source).slice(deliveredOffsetForSource(db, agentId, source));
-			// This is only a trigger estimate. Exact BPE encoding here blocks the
-			// daemon's event loop while scanning every queued source.
-			return total + estimateTokens(remaining);
-		}, 0);
+			return remaining.length === 0
+				? []
+				: [{ key: `${source.kind}:${source.id}:${deliveredOffsetForSource(db, agentId, source)}`, text: remaining }];
+		});
 	}
 	const state = readDreamingState(db, agentId);
 	const queued = readRecentEpisodicSources(
@@ -1859,22 +1857,57 @@ export function getDreamingEpisodicTokenBacklogInDb(db: ReadDb, agentId: string)
 		state.evidenceCursor?.fragmentOffset && state.evidenceCursor.kind !== null
 			? readEpisodicSource(db, { agentId, from: `${state.evidenceCursor.kind}:${state.evidenceCursor.id}` })
 			: null;
-	const remaining = resumed ? renderDreamingEvidence(resumed).slice(state.evidenceCursor?.fragmentOffset) : "";
-	// This is only a trigger estimate. Exact BPE encoding here blocks the
-	// daemon's event loop while scanning every queued source.
-	return (
-		queued.reduce((total, source) => total + estimateTokens(renderDreamingEvidence(source)), 0) +
-		estimateTokens(remaining)
-	);
+	const entries = queued.map((source) => ({
+		key: `${source.kind}:${source.id}:0`,
+		text: renderDreamingEvidence(source),
+	}));
+	if (resumed === null) return entries;
+	const remaining = renderDreamingEvidence(resumed).slice(state.evidenceCursor?.fragmentOffset);
+	return remaining.length === 0
+		? entries
+		: [
+				...entries,
+				{ key: `${resumed.kind}:${resumed.id}:${state.evidenceCursor?.fragmentOffset ?? 0}`, text: remaining },
+			];
 }
 
-export function shouldTriggerDreaming(
+/**
+ * Refresh the exact BPE backlog count without encoding on the daemon thread.
+ * Database reads and evidence rendering stay bounded on the caller; the
+ * worker owns all cl100k encoding and memoizes unchanged source fragments.
+ */
+export function getDreamingEpisodicTokenBacklogInDb(db: ReadDb, agentId: string): Promise<number> {
+	return dreamingBacklogTokenCache.refresh(agentId, readDreamingEpisodicTokenBacklogEntriesInDb(db, agentId));
+}
+
+export async function getDreamingEpisodicTokenBacklog(accessor: DbAccessor, agentId: string): Promise<number> {
+	const entries = accessor.withReadDb((db) => readDreamingEpisodicTokenBacklogEntriesInDb(db, agentId));
+	return dreamingBacklogTokenCache.refresh(agentId, entries);
+}
+
+/** Read the last worker-computed value for synchronous dashboard metadata. */
+export function getDreamingEpisodicTokenBacklogCached(agentId: string): number {
+	return dreamingBacklogTokenCache.get(agentId);
+}
+
+export async function shouldTriggerDreaming(
 	accessor: DbAccessor,
 	cfg: DreamingConfig,
 	agentId: string,
 	nowMs = Date.now(),
-	episodicTokens = getDreamingEpisodicTokenBacklog(accessor, agentId),
-): boolean {
+	episodicTokens?: number,
+): Promise<boolean> {
+	const tokens = episodicTokens ?? (await getDreamingEpisodicTokenBacklog(accessor, agentId));
+	return shouldTriggerDreamingAfterBacklog(accessor, cfg, agentId, nowMs, tokens);
+}
+
+async function shouldTriggerDreamingAfterBacklog(
+	accessor: DbAccessor,
+	cfg: DreamingConfig,
+	agentId: string,
+	nowMs: number,
+	episodicTokens: number,
+): Promise<boolean> {
 	const state = getDreamingState(accessor, agentId);
 	const hasAttention = accessor.withReadDb((db) => getDreamingAttentionInDb(db, agentId, 1).length > 0);
 

--- a/platform/daemon/src/routes/knowledge-routes.ts
+++ b/platform/daemon/src/routes/knowledge-routes.ts
@@ -24,6 +24,7 @@ import {
 	resolveNamedEntity,
 } from "../knowledge-graph";
 import { getKnowledgeHygieneReport } from "../knowledge-graph-hygiene";
+import { getDreamingEpisodicTokenBacklog } from "../pipeline/dreaming";
 import { type ResolvedMemoryConfig, loadMemoryConfig } from "../memory-config";
 import { isMemoryContentContextEligible } from "../memory-content-safety";
 import { OntologyProposalError, applyOntologyOperation } from "../ontology-proposals";
@@ -327,10 +328,12 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		});
 	});
 
-	app.get("/api/knowledge/constellation", (c) => {
+	app.get("/api/knowledge/constellation", async (c) => {
 		const agentId = c.req.query("agent_id") ?? resolveDaemonAgentId();
+		const accessor = getDbAccessor();
+		await getDreamingEpisodicTokenBacklog(accessor, agentId);
 		return c.json(
-			getKnowledgeGraphForConstellation(getDbAccessor(), agentId, {
+			getKnowledgeGraphForConstellation(accessor, agentId, {
 				limit: parseNavigationLimit(c.req.query("limit"), 150, 1000),
 				maxAspectsPerEntity: parseNavigationLimit(c.req.query("max_aspects_per_entity"), 6, 25),
 				maxAttributesPerAspect: parseNavigationLimit(c.req.query("max_attributes_per_aspect"), 4, 250),

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -676,7 +676,7 @@ export function registerPipelineRoutes(app: Hono): void {
 		return requirePermission("admin", authConfig)(c, next);
 	});
 
-	app.get("/api/dream/status", (c) => {
+	app.get("/api/dream/status", async (c) => {
 		const cfg = loadMemoryConfig(AGENTS_DIR);
 		const accessor = getDbAccessor();
 		const scopedAgent = resolveScopedDreamAgent(c);
@@ -684,7 +684,7 @@ export function registerPipelineRoutes(app: Hono): void {
 		const agentId = scopedAgent.agentId;
 
 		const state = getDreamingState(accessor, agentId);
-		const episodicTokensPending = getDreamingEpisodicTokenBacklog(accessor, agentId);
+		const episodicTokensPending = await getDreamingEpisodicTokenBacklog(accessor, agentId);
 		const passes = getDreamingPasses(accessor, agentId, 10);
 		const exclusions = getDreamingEvidenceExclusions(accessor, agentId);
 		const attention = getDreamingAttention(accessor, agentId);

--- a/scripts/build-native-bun.ts
+++ b/scripts/build-native-bun.ts
@@ -102,6 +102,7 @@ const workerEntries = [
 	// .wasm is embedded separately (wasmAssets) and the main thread passes the
 	// materialized wasmDir to the worker via workerData.
 	["embedding-worker", "platform/daemon/src/embedding-worker.ts"],
+	["dreaming-token-worker", "platform/daemon/src/pipeline/dreaming-token-worker.ts"],
 ] as const;
 const nativeExternalArgs = ["--external", "better-sqlite3"] as const;
 


### PR DESCRIPTION
## Summary

Fixes #1552 without changing Dreaming token semantics. The backlog trigger and reported metrics continue to use exact cl100k BPE counts, while a memoized worker-thread cache keeps encoding off the daemon event loop during an unreachable-provider pass. Related architecture issue: #1543.

## Changes

- Reworked `getDreamingEpisodicTokenBacklogInDb` and its accessor path to render a bounded set of active evidence entries, then refresh exact counts through a dedicated `dreaming-token-worker`.
- Memoized counts per source and delivered offset. Removed entries disappear on the next DB-derived refresh, so delivered or consumed evidence invalidates without maintaining a second counter.
- Made Dreaming scheduling and status/knowledge-graph surfaces await the async refresh. The knowledge-graph constellation route warms the cache before returning `episodicTokensPending`.
- Bundled the worker in both the daemon build and native Bun asset build.
- Added regressions for exact BPE counts versus length/4 estimates, trigger scheduling, zero main-thread tokenizer encodes, delivered-fragment invalidation, knowledge-graph metric parity, and event-loop responsiveness during a large backlog with an unavailable provider.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A. No migrations touched.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes for `@signet/daemon`; the full workspace typecheck was not run.
- [x] `bun run lint` passes for the changed files with existing warnings in adjacent files.
- [ ] Tested against running daemon
- [ ] N/A

Focused verification:

- `bun test platform/daemon/src/pipeline/dreaming.test.ts platform/daemon/src/pipeline/dreaming-worker.test.ts platform/daemon/src/knowledge-graph-list.test.ts` passed: 81 tests, 0 failures.
- The exact-BPE regression passed with zero main-thread tokenizer encodes; the large-backlog unavailable-provider event-loop regression passed with max measured latency below 200 ms.
- `bun run --filter '@signet/daemon' typecheck` passed.
- `bun run --filter '@signet/core' build` passed.
- `bun build.ts` and `bun run build:dashboard` passed; the compiled `dist/dreaming-token-worker.js` returned an exact count for a fixture message.
- `bunx biome check` passed with existing warnings; `git diff --check` passed.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The original PR substituted `estimateTokens` for exact BPE counting. This rework does not use a character estimate for either trigger thresholds or `episodicTokensPending`. The before/after is synchronous main-thread `countTokens` per source versus bounded DB/render work followed by memoized exact BPE counting in a worker thread. The cache derives active keys from the evidence DB and delivered offsets on every refresh, preserving backlog semantics while keeping the #1552 unreachable-provider path off the main event loop.
