### PR TITLE
fix(core): restore workspace override precedence

### DIFF
--- a/platform/core/src/workspace.test.ts
+++ b/platform/core/src/workspace.test.ts
@@ -124,6 +124,21 @@ describe("resolveWorkspacePath precedence", () => {
 });
 
 describe("resolveWorkspacePath malformed config", () => {
+	it("keeps the exported config reader strict by default", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-reader-strict-"));
+		try {
+			const configHome = join(home, "config");
+			mkdirSync(join(configHome, "signet"), { recursive: true });
+			writeFileSync(join(configHome, "signet", "workspace.json"), "{not json");
+
+			expect(() => readConfiguredWorkspacePath(makeEnv({ XDG_CONFIG_HOME: configHome }), home)).toThrow(
+				"Invalid Signet workspace config",
+			);
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
 	it("throws instead of falling back when an existing config is malformed", () => {
 		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-malformed-"));
 		try {

--- a/platform/core/src/workspace.test.ts
+++ b/platform/core/src/workspace.test.ts
@@ -154,7 +154,7 @@ describe("resolveWorkspacePath malformed config", () => {
 		}
 	});
 
-	it("does not let an env override hide an existing malformed config", () => {
+	it("uses SIGNET_WORKSPACE when persisted config is malformed", () => {
 		const home = mkdtempSync(join(tmpdir(), "signet-core-ws-malformed-env-"));
 		try {
 			const configHome = join(home, "config");
@@ -163,12 +163,14 @@ describe("resolveWorkspacePath malformed config", () => {
 			mkdirSync(join(configHome, "signet"), { recursive: true });
 			writeFileSync(join(configHome, "signet", "workspace.json"), "{not json");
 
-			expect(() =>
-				resolveWorkspacePath({
-					env: makeEnv({ SIGNET_PATH: envWorkspace, XDG_CONFIG_HOME: configHome }),
-					home,
-				}),
-			).toThrow("Invalid Signet workspace config");
+			const resolved = resolveWorkspacePath({
+				env: makeEnv({ SIGNET_WORKSPACE: envWorkspace, XDG_CONFIG_HOME: configHome }),
+				home,
+			});
+
+			expect(resolved.path).toBe(envWorkspace);
+			expect(resolved.source).toBe("env");
+			expect(resolved.configuredPath).toBeNull();
 		} finally {
 			rmSync(home, { recursive: true, force: true });
 		}

--- a/platform/core/src/workspace.ts
+++ b/platform/core/src/workspace.ts
@@ -51,8 +51,10 @@ export interface ResolveWorkspacePathOptions {
 	readonly home?: string;
 	/**
 	 * Throw on a malformed persisted workspace.json instead of falling back to
-	 * the default. Existing malformed files now always throw; this option is
-	 * retained for source compatibility with explicit install operations.
+	 * the default. Defaults to `true` for canonical workspace resolution so a
+	 * malformed persisted pointer fails loudly when no environment override
+	 * wins. An environment override is always resolved leniently because it has
+	 * higher precedence.
 	 */
 	readonly strict?: boolean;
 	/**
@@ -144,14 +146,15 @@ export function getWorkspaceConfigPath(env: NodeJS.ProcessEnv = process.env, hom
 /**
  * Read the persisted `workspace` value from `workspace.json`.
  *
- * Returns `null` only when the file is absent. An existing malformed file
- * throws instead of silently selecting the default workspace.
+ * Returns `null` when the file is absent or (in non-strict mode) malformed.
+ * In strict mode an existing malformed file throws.
  */
 export function readConfiguredWorkspacePath(
 	env: NodeJS.ProcessEnv = process.env,
 	home = homedir(),
-	_options: { readonly strict?: boolean } = {},
+	options: { readonly strict?: boolean } = {},
 ): string | null {
+	const strict = options.strict ?? false;
 	const configPath = getWorkspaceConfigPath(env, home);
 	if (!existsSync(configPath)) return null;
 
@@ -159,16 +162,19 @@ export function readConfiguredWorkspacePath(
 	try {
 		raw = JSON.parse(readFileSync(configPath, "utf-8"));
 	} catch (err) {
+		if (!strict) return null;
 		const detail = err instanceof Error ? err.message : String(err);
 		throw new Error(`Invalid Signet workspace config at ${configPath}: ${detail}`);
 	}
 
 	if (!isRecord(raw) || !("workspace" in raw)) {
+		if (!strict) return null;
 		throw new Error(`Invalid Signet workspace config at ${configPath}: missing workspace`);
 	}
 
 	const workspace = raw.workspace;
 	if (typeof workspace !== "string" || workspace.trim().length === 0) {
+		if (!strict) return null;
 		throw new Error(`Invalid Signet workspace config at ${configPath}: workspace must be a non-empty string`);
 	}
 
@@ -232,14 +238,16 @@ export function clearConfiguredWorkspacePath(env: NodeJS.ProcessEnv = process.en
 export function resolveWorkspacePath(options: ResolveWorkspacePathOptions = {}): WorkspaceResolution {
 	const env = options.env ?? process.env;
 	const home = options.home ?? homedir();
+	const strict = options.strict ?? true;
 	const requireExistingEnvPath = options.requireExistingEnvPath ?? false;
 
 	const configPath = getWorkspaceConfigPath(env, home);
-	// Resolve the env override first. The persisted config is still read so the
-	// structured result reports it, but an existing malformed config is always an
-	// error rather than a reason to silently select the default workspace.
+	// Resolve the env override first. When it wins, a malformed persisted config
+	// is irrelevant and must not block the explicit override. Without an env
+	// override, keep strict validation so a malformed persisted pointer fails
+	// loudly instead of silently selecting the default workspace.
 	const envPath = resolveEnvWorkspace(env, home, requireExistingEnvPath);
-	const configValue = readConfiguredWorkspacePath(env, home);
+	const configValue = readConfiguredWorkspacePath(env, home, { strict: envPath ? false : strict });
 
 	if (envPath) {
 		return {

--- a/platform/core/src/workspace.ts
+++ b/platform/core/src/workspace.ts
@@ -146,15 +146,16 @@ export function getWorkspaceConfigPath(env: NodeJS.ProcessEnv = process.env, hom
 /**
  * Read the persisted `workspace` value from `workspace.json`.
  *
- * Returns `null` when the file is absent or (in non-strict mode) malformed.
- * In strict mode an existing malformed file throws.
+ * Returns `null` only when the file is absent. By default, an existing
+ * malformed file throws. Pass `strict: false` only when an explicit caller
+ * can safely ignore malformed persisted configuration.
  */
 export function readConfiguredWorkspacePath(
 	env: NodeJS.ProcessEnv = process.env,
 	home = homedir(),
 	options: { readonly strict?: boolean } = {},
 ): string | null {
-	const strict = options.strict ?? false;
+	const strict = options.strict ?? true;
 	const configPath = getWorkspaceConfigPath(env, home);
 	if (!existsSync(configPath)) return null;
 


### PR DESCRIPTION
## Summary

Restores the exported `readConfiguredWorkspacePath` default to strict validation. The internal `resolveWorkspacePath` path still reads malformed persisted configuration leniently only when a valid `SIGNET_PATH` or `SIGNET_WORKSPACE` override wins.

## Changes

- Restored the exported config reader's default malformed-config behavior to throw.
- Kept override-wins precedence lenient through the explicit internal `strict: false` call.
- Added a regression test for the exported reader's strict default.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A. No schema migration.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Exact focused proof run locally:

- `bun test platform/core/src/workspace.test.ts`: 16 passed, 0 failed, 36 expect calls.
- `bunx biome check platform/core/src/workspace.ts platform/core/src/workspace.test.ts`: passed.
- `bun run --filter '@signet/core' typecheck`: passed.
- `bun run --filter '@signet/core' build`: passed.
- `git diff --check`: passed.

The full monorepo `bun run typecheck` and `bun run lint` were also attempted. They remain blocked by pre-existing unrelated workspace errors and formatting diagnostics outside this PR, including missing built workspace package declarations and existing connector/package formatting issues.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The original override-precedence regression remains covered by `resolveWorkspacePath malformed config > uses SIGNET_WORKSPACE when persisted config is malformed`. The added direct-reader regression prevents callers of the exported helper from silently accepting malformed persisted configuration.
