### PR TITLE
fix(daemon): bypass stale MCP refresh snapshots

### DIFF
--- a/platform/daemon/src/mcp/tools.test.ts
+++ b/platform/daemon/src/mcp/tools.test.ts
@@ -1467,6 +1467,55 @@ describe("createMcpServer", () => {
 	});
 
 	describe("marketplace proxy tools", () => {
+		it("forces explicit refresh past the recent snapshot but keeps implicit refresh cached", async () => {
+			__resetMarketplaceRefreshesForTests();
+			let stage: "initial" | "updated" = "initial";
+			const buildTool = (toolName: string) => ({
+				id: `dogfood-everything:${toolName}`,
+				serverId: "dogfood-everything",
+				serverName: "dogfood-everything",
+				toolName,
+				description: `Test ${toolName} tool`,
+				readOnly: false,
+				inputSchema: {},
+			});
+
+			globalThis.fetch = mock(async (input: string | URL | Request) => {
+				const url = new URL(typeof input === "string" ? input : input.toString());
+				if (url.pathname === "/api/marketplace/mcp/policy") {
+					return new Response(
+						JSON.stringify({ policy: { mode: "expanded", maxExpandedTools: 12, maxSearchResults: 8 } }),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				if (url.pathname === "/api/marketplace/mcp/tools") {
+					const tools = stage === "initial" ? [buildTool("echo")] : [buildTool("echo"), buildTool("fresh")];
+					return new Response(JSON.stringify({ count: tools.length, servers: [], tools }), {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 404 });
+			}) as unknown as typeof fetch;
+
+			await server.close();
+			server = await createMcpServer({
+				daemonUrl: "http://localhost:3850",
+				version: "0.0.1-test",
+				enableMarketplaceProxyTools: true,
+			});
+			expect(getToolNames(server)).toContain("signet_dogfood_everything_echo");
+
+			stage = "updated";
+			const implicit = await refreshMarketplaceProxyTools(server, { notify: false });
+			expect(implicit.changed).toBe(false);
+			expect(getToolNames(server)).not.toContain("signet_dogfood_everything_fresh");
+
+			const explicit = await callTool(server, "mcp_server_list", { refresh: true });
+			expect(explicit.isError).toBeUndefined();
+			expect(getToolNames(server)).toContain("signet_dogfood_everything_fresh");
+		});
+
 		it("single-flights marketplace refreshes across concurrent server creation", async () => {
 			__resetMarketplaceRefreshesForTests();
 			let refreshCalls = 0;

--- a/platform/daemon/src/mcp/tools.ts
+++ b/platform/daemon/src/mcp/tools.ts
@@ -269,7 +269,7 @@ const MARKETPLACE_PROXY_REFRESH_TIMEOUT_MS = 5_000;
 const MARKETPLACE_PROXY_REFRESH_TTL_MS = 30_000;
 const marketplaceRefreshes = new Map<
 	string,
-	{ readonly expiresAt: number; readonly promise: Promise<MarketplaceRefreshSnapshot> }
+	{ readonly expiresAt: number; readonly promise: Promise<MarketplaceRefreshSnapshot>; settled: boolean }
 >();
 
 export function __resetMarketplaceRefreshesForTests(): void {
@@ -602,11 +602,15 @@ function marketplaceRefreshKey(
 	return JSON.stringify({ baseUrl, context, authorizationHeader });
 }
 
-async function fetchMarketplaceRefreshSnapshot(state: MarketplaceProxyState): Promise<MarketplaceRefreshSnapshot> {
+async function fetchMarketplaceRefreshSnapshot(
+	state: MarketplaceProxyState,
+	options?: { readonly force?: boolean },
+): Promise<MarketplaceRefreshSnapshot> {
 	const key = marketplaceRefreshKey(state.baseUrl, state.context, state.authorizationHeader);
 	const now = Date.now();
 	const cached = marketplaceRefreshes.get(key);
-	if (cached && cached.expiresAt > now) return cached.promise;
+	const force = options?.force ?? false;
+	if (cached && (!cached.settled || (!force && cached.expiresAt > now))) return cached.promise;
 
 	const promise = (async (): Promise<MarketplaceRefreshSnapshot> => {
 		const policy = await fetchMarketplacePolicy(state.baseUrl, state.authorizationHeader);
@@ -621,7 +625,16 @@ async function fetchMarketplaceRefreshSnapshot(state: MarketplaceProxyState): Pr
 		return { policy, routed };
 	})();
 
-	marketplaceRefreshes.set(key, { expiresAt: now + MARKETPLACE_PROXY_REFRESH_TTL_MS, promise });
+	const entry = { expiresAt: now + MARKETPLACE_PROXY_REFRESH_TTL_MS, promise, settled: false };
+	marketplaceRefreshes.set(key, entry);
+	void promise.then(
+		() => {
+			if (marketplaceRefreshes.get(key)?.promise === promise) entry.settled = true;
+		},
+		() => {
+			if (marketplaceRefreshes.get(key)?.promise === promise) marketplaceRefreshes.delete(key);
+		},
+	);
 	try {
 		return await promise;
 	} catch (error) {
@@ -634,6 +647,8 @@ export async function refreshMarketplaceProxyTools(
 	server: McpServer,
 	options?: {
 		readonly notify?: boolean;
+		/** Bypass a completed snapshot while still coalescing in-flight refreshes. */
+		readonly force?: boolean;
 	},
 ): Promise<{ changed: boolean; count: number; error?: string }> {
 	const state = marketplaceProxyState.get(server);
@@ -643,7 +658,7 @@ export async function refreshMarketplaceProxyTools(
 
 	const notify = options?.notify ?? true;
 	const registeredTools = getRegisteredToolsMap(server);
-	const snapshot = await fetchMarketplaceRefreshSnapshot(state);
+	const snapshot = await fetchMarketplaceRefreshSnapshot(state, { force: options?.force });
 	if (snapshot.policy) state.policy = snapshot.policy;
 	const routed = snapshot.routed;
 
@@ -1865,7 +1880,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		},
 		async ({ refresh }) => {
 			if (refresh && enableMarketplaceProxyTools) {
-				await refreshMarketplaceProxyTools(server, { notify: true });
+				await refreshMarketplaceProxyTools(server, { notify: true, force: true });
 			}
 
 			const path = refresh ? "/api/marketplace/mcp/tools?refresh=1" : "/api/marketplace/mcp/tools";
@@ -1929,7 +1944,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 				}
 				trimHotToolSet(hotSet);
 				hotToolTouchedAt.set(proxyState.contextKey, Date.now());
-				await refreshMarketplaceProxyTools(server, { notify: true });
+				await refreshMarketplaceProxyTools(server, { notify: true, force: refresh === true });
 			}
 
 			return textResult({


### PR DESCRIPTION
## Summary

Explicit `refresh=true` now bypasses the 30s MARKETPLACE_PROXY_REFRESH_TTL snapshot and forces a live refresh. Implicit and background refreshes keep the cache, and single-flight behavior is preserved.

## Changes

- Updated marketplace proxy refresh handling in `platform/daemon/src/mcp/tools.ts`.
- Added a regression covering explicit refresh versus implicit cached refresh in `platform/daemon/src/mcp/tools.test.ts`.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`

## Screenshots

N/A. This change does not modify a user interface.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [ ] Agent scoping verified on all new/changed data queries
- [ ] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [ ] Security checks applied to admin/mutation endpoints
- [ ] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Testing

Focused verification on the rebased head:

- `bun test platform/daemon/src/mcp/tools.test.ts` passed: 58 tests, 347 expectations.
- `bun run --filter '@signet/daemon' typecheck` passed.
- `bun run --filter '@signet/daemon' build` passed.
- `bunx biome check platform/daemon/src/mcp/tools.ts platform/daemon/src/mcp/tools.test.ts` passed with two existing warnings in `tools.ts`.
- `git diff --check` passed.

The full workspace test, typecheck, and lint commands were not run. Running-daemon verification is not applicable to this focused MCP unit regression.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tag in the commit message)

## Notes

The `checklist-exception` label is intentional for the unchecked N/A readiness items. This PR changes no data queries, admin or mutation endpoints, or API/spec/status contract, so the agent-scoping, input/config bounds, security, and docs items do not apply. The readiness workflow bypasses those N/A items through the label.
