### PR TITLE
fix(cli): prevent inspector port collision

### DIFF
--- a/scripts/build-native-bun.ts
+++ b/scripts/build-native-bun.ts
@@ -335,7 +335,10 @@ if (!process.env.SIGNET_DIR?.trim()) {
 		}
 	}
 }
-if (process.env.SIGNET_DATABASE_INTEGRITY_DB_PATH) {
+if (process.env.SIGNET_INSPECTOR_PROXY_PUBLIC || process.env.SIGNET_INSPECTOR_PROXY_TARGET) {
+	const { runInspectorProxyFromEnvironment } = await import("../surfaces/cli/src/lib/inspector-proxy");
+	await runInspectorProxyFromEnvironment();
+} else if (process.env.SIGNET_DATABASE_INTEGRITY_DB_PATH) {
 	const { runDatabaseIntegrityWorker } = await import("../platform/daemon/src/database-integrity-worker");
 	runDatabaseIntegrityWorker();
 } else {

--- a/scripts/build-native-bun.ts
+++ b/scripts/build-native-bun.ts
@@ -304,6 +304,7 @@ export const { env, pipeline } = transformers;
 writeFileSync(
 	join(buildDir, "cli-native.ts"),
 	`import { materializeEmbeddedAssetTree, registerNativeAssets, registerNativeTransformersBindings } from "../platform/daemon/src/native-runtime-assets";
+import { handoffInspectorParent } from "../surfaces/cli/src/lib/inspector-proxy";
 import { connectorAssets, dashboardAssets, skillAssets, templateAssets, wasmAssets, workerAssets } from "./native-assets";
 import * as transformersWebRuntime from "./transformers-web-runtime";
 import { existsSync } from "node:fs";
@@ -335,6 +336,7 @@ if (!process.env.SIGNET_DIR?.trim()) {
 		}
 	}
 }
+handoffInspectorParent();
 if (process.env.SIGNET_INSPECTOR_PROXY_PUBLIC || process.env.SIGNET_INSPECTOR_PROXY_TARGET) {
 	const { runInspectorProxyFromEnvironment } = await import("../surfaces/cli/src/lib/inspector-proxy");
 	await runInspectorProxyFromEnvironment();

--- a/surfaces/cli/src/lib/inspector-proxy.test.ts
+++ b/surfaces/cli/src/lib/inspector-proxy.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import {
 	createInspectorProxy,
 	formatInspectorEndpoint,
@@ -9,7 +13,10 @@ import {
 } from "./inspector-proxy.js";
 
 let target: ChildProcess | null = null;
+let nativeParent: ChildProcess | null = null;
 let proxy: Bun.Server<unknown> | null = null;
+
+const inspectorProxySource = fileURLToPath(new URL("./inspector-proxy.ts", import.meta.url));
 
 async function freePort(): Promise<number> {
 	return await new Promise((resolve, reject) => {
@@ -41,9 +48,40 @@ async function waitForInspector(port: number): Promise<void> {
 	throw new Error(`Inspector did not start on port ${port}`);
 }
 
+function compileInspectorHarness(directory: string): string {
+	const fixture = join(directory, "native-inspector-harness.ts");
+	const binary = join(directory, "native-inspector-harness");
+	writeFileSync(
+		fixture,
+		`import { handoffInspectorParent, parseInspectorEndpoint, runInspectorProxy } from ${JSON.stringify(inspectorProxySource)};
+const publicValue = process.env.SIGNET_INSPECTOR_TEST_PUBLIC;
+const targetValue = process.env.SIGNET_INSPECTOR_TEST_TARGET;
+if (!publicValue || !targetValue) throw new Error("Inspector test endpoints are missing");
+handoffInspectorParent();
+if (process.env.SIGNET_INSPECTOR_HANDOFF !== "1") throw new Error("Inspector parent handoff did not re-exec");
+await runInspectorProxy({
+  publicEndpoint: parseInspectorEndpoint(publicValue),
+  targetEndpoint: parseInspectorEndpoint(targetValue),
+});
+const exitAfterMs = Number(process.env.SIGNET_INSPECTOR_TEST_EXIT_AFTER_MS ?? "0");
+if (exitAfterMs > 0) setTimeout(() => process.exit(0), exitAfterMs);
+`,
+	);
+	const result = spawnSync(process.execPath, ["build", "--compile", "--target=bun", "--outfile", binary, fixture], {
+		encoding: "utf8",
+		timeout: 120_000,
+	});
+	if (result.status !== 0 || !existsSync(binary)) {
+		throw new Error(`Native inspector harness build failed: ${String(result.stderr ?? result.stdout)}`);
+	}
+	return binary;
+}
+
 afterEach(() => {
 	proxy?.stop(true);
 	proxy = null;
+	nativeParent?.kill();
+	nativeParent = null;
 	target?.kill();
 	target = null;
 });
@@ -57,6 +95,56 @@ describe("inspector discovery proxy", () => {
 		expect(handoff?.environment.SIGNET_INSPECTOR_PUBLIC).toBe("127.0.0.1:9230");
 		expect(handoff?.environment.SIGNET_INSPECTOR_HANDOFF).toBe("1");
 		expect(resolveInspectorParentHandoff({ BUN_INSPECT: "127.0.0.1:9230", SIGNET_INSPECTOR_HANDOFF: "1" })).toBeNull();
+	});
+
+	it("exercises native parent re-exec and proxy discovery", async () => {
+		const targetPort = await freePort();
+		const publicPort = await freePort();
+		const directory = mkdtempSync(join(tmpdir(), "signet-native-inspector-test-"));
+		target = spawn(process.execPath, [`--inspect=127.0.0.1:${targetPort}/json`, "-e", "setInterval(() => {}, 1000)"], {
+			env: { ...process.env, BUN_INSPECT: "" },
+			stdio: "ignore",
+		});
+		await waitForInspector(targetPort);
+
+		try {
+			const binary = compileInspectorHarness(directory);
+			nativeParent = spawn(binary, [], {
+				env: {
+					...process.env,
+					BUN_INSPECT: `127.0.0.1:${publicPort}/json`,
+					SIGNET_INSPECTOR_TEST_PUBLIC: `127.0.0.1:${publicPort}/json`,
+					SIGNET_INSPECTOR_TEST_TARGET: `127.0.0.1:${targetPort}/json`,
+					SIGNET_INSPECTOR_TEST_EXIT_AFTER_MS: "5000",
+				},
+				stdio: "ignore",
+			});
+			await waitForInspector(publicPort);
+
+			for (const path of ["/json", "/json/list", "/json/protocol"]) {
+				const response = await fetch(`http://127.0.0.1:${publicPort}${path}`);
+				expect(response.status).toBe(200);
+			}
+			const discovery = (await (await fetch(`http://127.0.0.1:${publicPort}/json`)).json()) as Array<{
+				webSocketDebuggerUrl: string;
+			}>;
+			expect(discovery[0]?.webSocketDebuggerUrl).toBe(
+				`ws://${formatInspectorEndpoint(parseInspectorEndpoint(`127.0.0.1:${publicPort}`), "/json")}`,
+			);
+
+			const result = await new Promise<string>((resolve, reject) => {
+				const socket = new WebSocket(discovery[0]?.webSocketDebuggerUrl ?? "");
+				socket.addEventListener("open", () => socket.send(JSON.stringify({ id: 7, method: "Runtime.enable" })));
+				socket.addEventListener("message", (event) => {
+					resolve(String(event.data));
+					socket.close();
+				});
+				socket.addEventListener("error", () => reject(new Error("Native inspector WebSocket failed")));
+			});
+			expect(result).toContain('"id":7');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
 	});
 
 	it("normalizes IPv6 discovery endpoints and rejects invalid ports", () => {

--- a/surfaces/cli/src/lib/inspector-proxy.test.ts
+++ b/surfaces/cli/src/lib/inspector-proxy.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { spawn, type ChildProcess } from "node:child_process";
 import { createServer } from "node:net";
-import { createInspectorProxy, formatInspectorEndpoint, parseInspectorEndpoint } from "./inspector-proxy.js";
+import {
+	createInspectorProxy,
+	formatInspectorEndpoint,
+	parseInspectorEndpoint,
+	resolveInspectorParentHandoff,
+} from "./inspector-proxy.js";
 
 let target: ChildProcess | null = null;
 let proxy: Bun.Server<unknown> | null = null;
@@ -44,6 +49,24 @@ afterEach(() => {
 });
 
 describe("inspector discovery proxy", () => {
+	it("hands off a parent-owned BUN_INSPECT listener before binding discovery", () => {
+		const handoff = resolveInspectorParentHandoff({ BUN_INSPECT: "127.0.0.1:9230" });
+
+		expect(handoff?.publicInspector).toBe("127.0.0.1:9230");
+		expect(handoff?.environment.BUN_INSPECT).toBe("");
+		expect(handoff?.environment.SIGNET_INSPECTOR_PUBLIC).toBe("127.0.0.1:9230");
+		expect(handoff?.environment.SIGNET_INSPECTOR_HANDOFF).toBe("1");
+		expect(resolveInspectorParentHandoff({ BUN_INSPECT: "127.0.0.1:9230", SIGNET_INSPECTOR_HANDOFF: "1" })).toBeNull();
+	});
+
+	it("normalizes IPv6 discovery endpoints and rejects invalid ports", () => {
+		const endpoint = parseInspectorEndpoint("[::1]:9230/json");
+		expect(endpoint.host).toBe("::1");
+		expect(formatInspectorEndpoint(endpoint)).toBe("[::1]:9230/json");
+		expect(() => parseInspectorEndpoint("0")).toThrow("Invalid inspector port");
+		expect(() => parseInspectorEndpoint("70000")).toThrow("Invalid inspector port");
+	});
+
 	it("serves discovery routes and forwards WebSocket messages for a Bun target", async () => {
 		const targetPort = await freePort();
 		const publicPort = await freePort();

--- a/surfaces/cli/src/lib/inspector-proxy.test.ts
+++ b/surfaces/cli/src/lib/inspector-proxy.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer } from "node:net";
+import { createInspectorProxy, formatInspectorEndpoint, parseInspectorEndpoint } from "./inspector-proxy.js";
+
+let target: ChildProcess | null = null;
+let proxy: Bun.Server<unknown> | null = null;
+
+async function freePort(): Promise<number> {
+	return await new Promise((resolve, reject) => {
+		const server = createServer();
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (typeof address !== "object" || address === null) {
+				server.close();
+				reject(new Error("Port reservation returned no address"));
+				return;
+			}
+			const port = address.port;
+			server.close((error) => (error ? reject(error) : resolve(port)));
+		});
+	});
+}
+
+async function waitForInspector(port: number): Promise<void> {
+	for (let attempt = 0; attempt < 40; attempt += 1) {
+		try {
+			const response = await fetch(`http://127.0.0.1:${port}/json/version`);
+			if (response.ok) return;
+		} catch {
+			// The inspector is still starting.
+		}
+		await Bun.sleep(50);
+	}
+	throw new Error(`Inspector did not start on port ${port}`);
+}
+
+afterEach(() => {
+	proxy?.stop(true);
+	proxy = null;
+	target?.kill();
+	target = null;
+});
+
+describe("inspector discovery proxy", () => {
+	it("serves discovery routes and forwards WebSocket messages for a Bun target", async () => {
+		const targetPort = await freePort();
+		const publicPort = await freePort();
+		target = spawn(process.execPath, [`--inspect=127.0.0.1:${targetPort}/json`, "-e", "setInterval(() => {}, 1000)"], {
+			env: { ...process.env, BUN_INSPECT: "" },
+			stdio: "ignore",
+		});
+		await waitForInspector(targetPort);
+		proxy = createInspectorProxy({
+			publicEndpoint: parseInspectorEndpoint(`127.0.0.1:${publicPort}`),
+			targetEndpoint: parseInspectorEndpoint(`127.0.0.1:${targetPort}/json`),
+		});
+
+		for (const path of ["/json", "/json/list", "/json/protocol"]) {
+			const response = await fetch(`http://127.0.0.1:${publicPort}${path}`);
+			expect(response.status).toBe(200);
+		}
+		const discovery = (await (await fetch(`http://127.0.0.1:${publicPort}/json`)).json()) as Array<{
+			webSocketDebuggerUrl: string;
+		}>;
+		expect(discovery[0]?.webSocketDebuggerUrl).toBe(
+			`ws://${formatInspectorEndpoint(parseInspectorEndpoint(`127.0.0.1:${publicPort}`), "/json")}`,
+		);
+
+		const result = await new Promise<string>((resolve, reject) => {
+			const socket = new WebSocket(discovery[0]?.webSocketDebuggerUrl ?? "");
+			socket.addEventListener("open", () => socket.send(JSON.stringify({ id: 1, method: "Runtime.enable" })));
+			socket.addEventListener("message", (event) => {
+				resolve(String(event.data));
+				socket.close();
+			});
+			socket.addEventListener("error", () => reject(new Error("Inspector WebSocket failed")));
+		});
+		expect(result).toContain('"id":1');
+	});
+});

--- a/surfaces/cli/src/lib/inspector-proxy.ts
+++ b/surfaces/cli/src/lib/inspector-proxy.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import type { ServerWebSocket } from "bun";
 
 export interface InspectorEndpoint {
@@ -24,24 +25,29 @@ const INSPECTOR_PROTOCOL = {
 
 function endpointHost(host: string): string {
 	if (host === "0.0.0.0" || host === "::") return "127.0.0.1";
-	return host.includes(":") ? `[${host}]` : host;
+	const normalized = host.replace(/^\[|\]$/g, "");
+	return normalized.includes(":") ? `[${normalized}]` : normalized;
+}
+
+function validPort(port: number, value: string): number {
+	if (!Number.isInteger(port) || port < 1 || port > 65535) {
+		throw new Error(`Invalid inspector port: ${value}`);
+	}
+	return port;
 }
 
 export function parseInspectorEndpoint(value: string): InspectorEndpoint {
 	const trimmed = value.trim();
 	if (/^\d+(?:\/.*)?$/.test(trimmed)) {
 		const [portText, ...pathParts] = trimmed.split("/");
-		const port = Number(portText);
+		const port = validPort(Number(portText), value);
 		return { host: "127.0.0.1", port, path: pathParts.length > 0 ? `/${pathParts.join("/")}` : "/" };
 	}
 
 	const parsed = new URL(trimmed.includes("://") ? trimmed : `http://${trimmed}`);
-	const port = parsed.port.length > 0 ? Number(parsed.port) : 80;
-	if (!Number.isInteger(port) || port < 1 || port > 65535) {
-		throw new Error(`Invalid inspector port: ${value}`);
-	}
+	const port = validPort(parsed.port.length > 0 ? Number(parsed.port) : 80, value);
 	return {
-		host: parsed.hostname,
+		host: parsed.hostname.replace(/^\[|\]$/g, ""),
 		port,
 		path: parsed.pathname.length > 0 ? parsed.pathname : "/",
 	};
@@ -49,6 +55,52 @@ export function parseInspectorEndpoint(value: string): InspectorEndpoint {
 
 export function formatInspectorEndpoint(endpoint: InspectorEndpoint, path = endpoint.path): string {
 	return `${endpointHost(endpoint.host)}:${endpoint.port}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+export interface InspectorParentHandoff {
+	readonly publicInspector: string;
+	readonly environment: NodeJS.ProcessEnv;
+}
+
+/**
+ * Bun binds BUN_INSPECT before application code runs. A native CLI parent
+ * cannot bind a discovery proxy on that same port, so hand the command to a
+ * second process with Bun's automatic inspector disabled and retain the
+ * requested public endpoint for the daemon-start proxy.
+ */
+export function resolveInspectorParentHandoff(env: NodeJS.ProcessEnv = process.env): InspectorParentHandoff | null {
+	const publicInspector = env.BUN_INSPECT?.trim();
+	if (
+		!publicInspector ||
+		env.SIGNET_DAEMON_ENTRYPOINT === "1" ||
+		env.SIGNET_INSPECTOR_HANDOFF === "1" ||
+		env.SIGNET_INSPECTOR_PROXY_PUBLIC?.trim()
+	) {
+		return null;
+	}
+	return {
+		publicInspector,
+		environment: {
+			...env,
+			BUN_INSPECT: "",
+			SIGNET_INSPECTOR_PUBLIC: publicInspector,
+			SIGNET_INSPECTOR_HANDOFF: "1",
+		},
+	};
+}
+
+/** Re-exec the native CLI after releasing its parent-owned inspector socket. */
+export function handoffInspectorParent(env: NodeJS.ProcessEnv = process.env): void {
+	const handoff = resolveInspectorParentHandoff(env);
+	if (!handoff) return;
+	const child = spawn(process.execPath, process.argv.slice(1), {
+		detached: true,
+		stdio: "ignore",
+		windowsHide: true,
+		env: handoff.environment,
+	});
+	child.unref();
+	process.exit(0);
 }
 
 function publicWebSocketUrl(endpoint: InspectorEndpoint): string {

--- a/surfaces/cli/src/lib/inspector-proxy.ts
+++ b/surfaces/cli/src/lib/inspector-proxy.ts
@@ -1,0 +1,190 @@
+import type { ServerWebSocket } from "bun";
+
+export interface InspectorEndpoint {
+	readonly host: string;
+	readonly port: number;
+	readonly path: string;
+}
+
+export interface InspectorProxyOptions {
+	readonly publicEndpoint: InspectorEndpoint;
+	readonly targetEndpoint: InspectorEndpoint;
+}
+
+interface InspectorProxySocket {
+	upstream: WebSocket | null;
+	pending: Array<string | ArrayBuffer | Uint8Array>;
+}
+
+const INSPECTOR_TARGET_ID = "signet-daemon";
+const INSPECTOR_PROTOCOL = {
+	version: { major: "1", minor: "3" },
+	domains: [],
+} as const;
+
+function endpointHost(host: string): string {
+	if (host === "0.0.0.0" || host === "::") return "127.0.0.1";
+	return host.includes(":") ? `[${host}]` : host;
+}
+
+export function parseInspectorEndpoint(value: string): InspectorEndpoint {
+	const trimmed = value.trim();
+	if (/^\d+(?:\/.*)?$/.test(trimmed)) {
+		const [portText, ...pathParts] = trimmed.split("/");
+		const port = Number(portText);
+		return { host: "127.0.0.1", port, path: pathParts.length > 0 ? `/${pathParts.join("/")}` : "/" };
+	}
+
+	const parsed = new URL(trimmed.includes("://") ? trimmed : `http://${trimmed}`);
+	const port = parsed.port.length > 0 ? Number(parsed.port) : 80;
+	if (!Number.isInteger(port) || port < 1 || port > 65535) {
+		throw new Error(`Invalid inspector port: ${value}`);
+	}
+	return {
+		host: parsed.hostname,
+		port,
+		path: parsed.pathname.length > 0 ? parsed.pathname : "/",
+	};
+}
+
+export function formatInspectorEndpoint(endpoint: InspectorEndpoint, path = endpoint.path): string {
+	return `${endpointHost(endpoint.host)}:${endpoint.port}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+function publicWebSocketUrl(endpoint: InspectorEndpoint): string {
+	return `ws://${formatInspectorEndpoint(endpoint, "/json")}`;
+}
+
+function jsonResponse(value: unknown, status = 200): Response {
+	return new Response(JSON.stringify(value), {
+		status,
+		headers: {
+			"content-type": "application/json; charset=utf-8",
+			"cache-control": "no-store",
+		},
+	});
+}
+
+function targetDescription(endpoint: InspectorEndpoint): Record<string, string> {
+	return {
+		description: "Signet Bun inspector target",
+		devtoolsFrontendUrl: "",
+		devtoolsFrontendUrlCompat: "",
+		faviconUrl: "",
+		id: INSPECTOR_TARGET_ID,
+		title: "Signet daemon",
+		type: "node",
+		url: "file://signet-daemon",
+		webSocketDebuggerUrl: publicWebSocketUrl(endpoint),
+	};
+}
+
+function targetWebSocketUrl(endpoint: InspectorEndpoint): string {
+	return `ws://${formatInspectorEndpoint(endpoint, "/json")}`;
+}
+
+function closeClient(client: ServerWebSocket<InspectorProxySocket>): void {
+	if (client.readyState === 1) client.close(1011, "Inspector target disconnected");
+}
+
+function connectUpstream(client: ServerWebSocket<InspectorProxySocket>, endpoint: InspectorEndpoint): void {
+	const upstream = new WebSocket(targetWebSocketUrl(endpoint));
+	client.data.upstream = upstream;
+	upstream.addEventListener("open", () => {
+		for (const message of client.data.pending) upstream.send(message);
+		client.data.pending = [];
+	});
+	upstream.addEventListener("message", (event) => {
+		if (client.readyState !== 1) return;
+		client.send(event.data as string | ArrayBuffer);
+	});
+	upstream.addEventListener("error", () => closeClient(client));
+	upstream.addEventListener("close", () => closeClient(client));
+}
+
+export function createInspectorProxy(options: InspectorProxyOptions): Bun.Server<InspectorProxySocket> {
+	const { publicEndpoint, targetEndpoint } = options;
+	return Bun.serve<InspectorProxySocket>({
+		hostname: publicEndpoint.host,
+		port: publicEndpoint.port,
+		fetch(request, server) {
+			const path = new URL(request.url).pathname;
+			if (path === "/json/version") {
+				return fetch(`http://${formatInspectorEndpoint(targetEndpoint, "/json/version")}`)
+					.then(async (response) => {
+						if (!response.ok) return jsonResponse({ error: "Inspector target is unavailable" }, 503);
+						const version = (await response.json()) as Record<string, unknown>;
+						return jsonResponse({ ...version, webSocketDebuggerUrl: publicWebSocketUrl(publicEndpoint) });
+					})
+					.catch(() => jsonResponse({ error: "Inspector target is unavailable" }, 503));
+			}
+			if (path === "/json" || path === "/json/list") {
+				if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
+					if (server.upgrade(request, { data: { upstream: null, pending: [] } })) return;
+					return new Response("WebSocket upgrade failed", { status: 400 });
+				}
+				return jsonResponse([targetDescription(publicEndpoint)]);
+			}
+			if (path === "/json/protocol") return jsonResponse(INSPECTOR_PROTOCOL);
+			return new Response("Not Found", { status: 404 });
+		},
+		websocket: {
+			open(client) {
+				connectUpstream(client, targetEndpoint);
+			},
+			message(client, message) {
+				const upstream = client.data.upstream;
+				if (upstream?.readyState === WebSocket.OPEN) {
+					upstream.send(message);
+					return;
+				}
+				client.data.pending.push(message);
+			},
+			close(client) {
+				client.data.upstream?.close();
+				client.data.pending = [];
+			},
+		},
+	});
+}
+
+export async function runInspectorProxy(options: InspectorProxyOptions): Promise<void> {
+	let server: Bun.Server<InspectorProxySocket> | null = null;
+	for (let attempt = 0; attempt < 120; attempt += 1) {
+		try {
+			server = createInspectorProxy(options);
+			break;
+		} catch (error) {
+			if (!(error instanceof Error) || !error.message.includes("EADDRINUSE")) throw error;
+			await Bun.sleep(250);
+		}
+	}
+	if (!server) throw new Error(`Inspector proxy could not bind ${formatInspectorEndpoint(options.publicEndpoint)}`);
+
+	let failedProbes = 0;
+	const probeTimer = setInterval(async () => {
+		try {
+			const response = await fetch(`http://${formatInspectorEndpoint(options.targetEndpoint, "/json/version")}`);
+			failedProbes = response.ok ? 0 : failedProbes + 1;
+		} catch {
+			failedProbes += 1;
+		}
+		if (failedProbes >= 12) {
+			clearInterval(probeTimer);
+			server?.stop(true);
+			process.exit(0);
+		}
+	}, 1000);
+}
+
+export async function runInspectorProxyFromEnvironment(): Promise<void> {
+	const publicValue = process.env.SIGNET_INSPECTOR_PROXY_PUBLIC;
+	const targetValue = process.env.SIGNET_INSPECTOR_PROXY_TARGET;
+	if (!publicValue || !targetValue) throw new Error("Inspector proxy endpoints are missing");
+	await runInspectorProxy({
+		publicEndpoint: parseInspectorEndpoint(publicValue),
+		targetEndpoint: parseInspectorEndpoint(targetValue),
+	});
+}
+
+if (import.meta.main) void runInspectorProxyFromEnvironment();

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -20,6 +20,7 @@ import {
 	readDaemonStartFailureDiagnostics,
 	readManagedDaemonPid,
 	resolveDaemonChildInspector,
+	resolveDaemonInspectorForwarding,
 	resolveDaemonLaunchCommand,
 	resolveDaemonPaths,
 	resolveDaemonRuntimeCommand,
@@ -117,6 +118,18 @@ describe("resolveDaemonChildInspector", () => {
 
 	it("forwards the inspector setting from a non-Bun parent", () => {
 		expect(resolveDaemonChildInspector({ BUN_INSPECT: "127.0.0.1:9230" }, false)).toBe("127.0.0.1:9230");
+	});
+});
+
+describe("resolveDaemonInspectorForwarding", () => {
+	it("moves a Bun daemon inspector behind a discovery-compatible proxy", async () => {
+		const forwarding = await resolveDaemonInspectorForwarding({ BUN_INSPECT: "127.0.0.1:9230" }, true);
+
+		expect(forwarding.proxy).toEqual({
+			publicInspector: "127.0.0.1:9230",
+			targetInspector: expect.stringMatching(/^127\.0\.0\.1:\d+\/json$/),
+		});
+		expect(forwarding.childInspector).toBe(forwarding.proxy?.targetInspector);
 	});
 });
 

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -19,6 +19,7 @@ import {
 	macOSLaunchAgentAttributionNotice,
 	readDaemonStartFailureDiagnostics,
 	readManagedDaemonPid,
+	resolveDaemonChildInspector,
 	resolveDaemonLaunchCommand,
 	resolveDaemonPaths,
 	resolveDaemonRuntimeCommand,
@@ -109,6 +110,16 @@ describe("macOSLaunchAgentAttributionNotice", () => {
 	});
 });
 
+describe("resolveDaemonChildInspector", () => {
+	it("does not forward the inspector setting from a Bun parent", () => {
+		expect(resolveDaemonChildInspector({ BUN_INSPECT: "127.0.0.1:9230" }, true)).toBeUndefined();
+	});
+
+	it("forwards the inspector setting from a non-Bun parent", () => {
+		expect(resolveDaemonChildInspector({ BUN_INSPECT: "127.0.0.1:9230" }, false)).toBe("127.0.0.1:9230");
+	});
+});
+
 describe("buildSystemdDaemonStartArgs", () => {
 	it("starts daemon in a transient user service with explicit env and log routing", () => {
 		const args = buildSystemdDaemonStartArgs({
@@ -128,7 +139,7 @@ describe("buildSystemdDaemonStartArgs", () => {
 		expect(args).toContain("--setenv=SIGNET_BIND=0.0.0.0");
 		expect(args).toContain("--setenv=SIGNET_PATH=/home/user/.agents");
 		expect(args).toContain("--setenv=SIGNET_DAEMON_ENTRYPOINT=1");
-		expect(args.some((arg) => arg.startsWith("--setenv=BUN_INSPECT="))).toBe(false);
+		expect(args).toContain("--setenv=BUN_INSPECT=");
 		expect(args).toContain("--property=StandardError=append:/home/user/.agents/.daemon/logs/startup.log");
 		expect(args.slice(-2)).toEqual([process.execPath, "/opt/signet/dist/daemon.js"]);
 	});
@@ -183,7 +194,7 @@ describe("buildSystemdDaemonStartArgs", () => {
 		expect(plist).not.toContain("SIGNET_TELEMETRY_SECRET");
 	});
 
-	it("omits empty inspector settings", () => {
+	it("clears empty inspector settings at the service boundary", () => {
 		const input = {
 			daemonPath: "/opt/signet/dist/daemon.js",
 			agentsDir: "/home/user/.agents",
@@ -196,8 +207,8 @@ describe("buildSystemdDaemonStartArgs", () => {
 		const args = buildSystemdDaemonStartArgs({ ...input, bunInspect: "" });
 		const plist = buildLaunchdDaemonPlist({ ...input, bunInspect: "" });
 
-		expect(args.some((arg) => arg.startsWith("--setenv=BUN_INSPECT="))).toBe(false);
-		expect(plist).not.toContain("<key>BUN_INSPECT</key>");
+		expect(args).toContain("--setenv=BUN_INSPECT=");
+		expect(plist).toMatch(/<key>BUN_INSPECT<\/key>\s*<string><\/string>/);
 	});
 });
 
@@ -230,7 +241,7 @@ describe("buildLaunchdDaemonPlist", () => {
 		expect(plist).toContain("<string>/Users/user/.agents</string>");
 		expect(plist).toContain("<key>SIGNET_DAEMON_ENTRYPOINT</key>");
 		expect(plist).toMatch(/<key>SIGNET_DAEMON_SERVICE<\/key>\s*<string>launchd<\/string>/);
-		expect(plist).not.toContain("<key>BUN_INSPECT</key>");
+		expect(plist).toMatch(/<key>BUN_INSPECT<\/key>\s*<string><\/string>/);
 		expect(plist).toContain("<string>1</string>");
 		expect(plist).toContain("<key>HOME</key>");
 		expect(plist).toContain("<key>RunAtLoad</key>");

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -131,6 +131,15 @@ describe("resolveDaemonInspectorForwarding", () => {
 		});
 		expect(forwarding.childInspector).toBe(forwarding.proxy?.targetInspector);
 	});
+
+	it("uses the handed-off public inspector when the Bun parent released BUN_INSPECT", async () => {
+		const forwarding = await resolveDaemonInspectorForwarding(
+			{ BUN_INSPECT: "", SIGNET_INSPECTOR_PUBLIC: "127.0.0.1:9230" },
+			true,
+		);
+
+		expect(forwarding.proxy?.publicInspector).toBe("127.0.0.1:9230");
+	});
 });
 
 describe("buildSystemdDaemonStartArgs", () => {

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -11,12 +11,13 @@ import {
 	rmSync,
 	writeFileSync,
 } from "node:fs";
-import { connect } from "node:net";
+import { createServer, connect } from "node:net";
 import { homedir } from "node:os";
 import { basename, delimiter, dirname, join, normalize } from "node:path";
 import { fileURLToPath } from "node:url";
 import chalk from "chalk";
 import { buildLaunchdEnvironment, buildLaunchdPlist, resolveLaunchdExecutable } from "@signet/core";
+import { formatInspectorEndpoint, parseInspectorEndpoint } from "./inspector-proxy.js";
 import { resolveDaemonNetwork } from "./network.js";
 import { resolveAgentsDir } from "./workspace.js";
 
@@ -968,6 +969,49 @@ export function resolveDaemonChildInspector(
 	return runtimeIsBun ? undefined : env.BUN_INSPECT;
 }
 
+export interface DaemonInspectorForwarding {
+	readonly childInspector?: string;
+	readonly proxy?: {
+		readonly publicInspector: string;
+		readonly targetInspector: string;
+	};
+}
+
+function reserveInspectorPort(host: string): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.once("error", reject);
+		server.listen(0, host, () => {
+			const address = server.address();
+			if (typeof address !== "object" || address === null) {
+				server.close();
+				reject(new Error("Inspector port reservation returned no address"));
+				return;
+			}
+			const port = address.port;
+			server.close((error) => (error ? reject(error) : resolve(port)));
+		});
+	});
+}
+
+export async function resolveDaemonInspectorForwarding(
+	env: NodeJS.ProcessEnv = process.env,
+	runtimeIsBun: boolean = typeof process.versions.bun === "string",
+): Promise<DaemonInspectorForwarding> {
+	const publicInspector = env.BUN_INSPECT;
+	if (!runtimeIsBun || !publicInspector) return { childInspector: resolveDaemonChildInspector(env, runtimeIsBun) };
+
+	try {
+		parseInspectorEndpoint(publicInspector);
+		const targetPort = await reserveInspectorPort("127.0.0.1");
+		const targetInspector = formatInspectorEndpoint({ host: "127.0.0.1", port: targetPort, path: "/" }, "/json");
+		return { childInspector: targetInspector, proxy: { publicInspector, targetInspector } };
+	} catch {
+		// Preserve the handshake fix when an invalid inspector setting cannot be proxied.
+		return { childInspector: undefined };
+	}
+}
+
 const TELEMETRY_ENVIRONMENT_KEYS = [
 	"SIGNET_TELEMETRY_ENV",
 	"SIGNET_TELEMETRY_OPTOUT",
@@ -1230,6 +1274,27 @@ export function didSystemdDaemonStart(result: Pick<SpawnSyncReturns<Buffer>, "st
 
 export const didLaunchdDaemonStart = didSystemdDaemonStart;
 
+function inspectorProxyLaunchCommand(): string[] {
+	const nativeExecutable = currentNativeExecutablePath();
+	return nativeExecutable ? [nativeExecutable] : [process.execPath, join(__dirname, "inspector-proxy.ts")];
+}
+
+function spawnInspectorProxy(proxy: NonNullable<DaemonInspectorForwarding["proxy"]>): void {
+	const [command, ...args] = inspectorProxyLaunchCommand();
+	const processHandle = spawn(command, args, {
+		detached: true,
+		stdio: "ignore",
+		windowsHide: true,
+		env: {
+			...process.env,
+			BUN_INSPECT: "",
+			SIGNET_INSPECTOR_PROXY_PUBLIC: proxy.publicInspector,
+			SIGNET_INSPECTOR_PROXY_TARGET: proxy.targetInspector,
+		},
+	});
+	processHandle.unref();
+}
+
 export async function waitForDaemonLiveness(
 	deadline: number,
 	shouldStop: () => boolean = () => false,
@@ -1254,6 +1319,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 	}
 
 	const net = resolveDaemonNetwork(agentsDir, process.env);
+	const inspectorForwarding = await resolveDaemonInspectorForwarding();
 
 	const daemonDir = join(agentsDir, ".daemon");
 	const logDir = join(daemonDir, "logs");
@@ -1287,7 +1353,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 		SIGNET_BIND: net.bind,
 		SIGNET_PATH: agentsDir,
 		SIGNET_DAEMON_ENTRYPOINT: "1",
-		BUN_INSPECT: resolveDaemonChildInspector(),
+		BUN_INSPECT: inspectorForwarding.childInspector,
 		// SIGNET_DAEMON_UNIT is deliberately NOT set here: it is only meaningful
 		// when systemd-run actually creates the transient unit (the --setenv in
 		// buildSystemdDaemonStartArgs). On the launchd/detached-spawn fallback
@@ -1312,7 +1378,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 			bind: net.bind,
 			startupLogPath,
 			unitName: systemdUnitName,
-			bunInspect: resolveDaemonChildInspector(),
+			bunInspect: inspectorForwarding.childInspector,
 			telemetryEnv: process.env,
 		});
 		const result = spawnSync("systemd-run", systemdArgs, {
@@ -1344,7 +1410,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 				host: net.host,
 				bind: net.bind,
 				startupLogPath,
-				bunInspect: resolveDaemonChildInspector(),
+				bunInspect: inspectorForwarding.childInspector,
 				telemetryEnv: process.env,
 			}),
 		);
@@ -1426,6 +1492,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 
 		proc.unref();
 	}
+	if (inspectorForwarding.proxy) spawnInspectorProxy(inspectorForwarding.proxy);
 	if (stderrFd !== null) {
 		closeSync(stderrFd);
 	}

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -977,6 +977,13 @@ export interface DaemonInspectorForwarding {
 	};
 }
 
+function resolvePublicInspector(env: NodeJS.ProcessEnv): string | undefined {
+	const bunInspector = env.BUN_INSPECT?.trim();
+	if (bunInspector) return bunInspector;
+	const handedOffInspector = env.SIGNET_INSPECTOR_PUBLIC?.trim();
+	return handedOffInspector || undefined;
+}
+
 function reserveInspectorPort(host: string): Promise<number> {
 	return new Promise((resolve, reject) => {
 		const server = createServer();
@@ -998,7 +1005,7 @@ export async function resolveDaemonInspectorForwarding(
 	env: NodeJS.ProcessEnv = process.env,
 	runtimeIsBun: boolean = typeof process.versions.bun === "string",
 ): Promise<DaemonInspectorForwarding> {
-	const publicInspector = env.BUN_INSPECT;
+	const publicInspector = resolvePublicInspector(env);
 	if (!runtimeIsBun || !publicInspector) return { childInspector: resolveDaemonChildInspector(env, runtimeIsBun) };
 
 	try {

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -942,7 +942,8 @@ export interface DaemonStartArgsInput {
 	readonly bind: string;
 	readonly startupLogPath: string;
 	readonly unitName?: string;
-	// Service managers do not inherit this debugger setting unless it is explicit.
+	// The parent CLI forwards this only when it is not already a Bun process.
+	// A Bun parent has already bound BUN_INSPECT before this code runs.
 	readonly bunInspect?: string;
 	/** Source environment for the allowlisted telemetry variables below. */
 	readonly telemetryEnv?: NodeJS.ProcessEnv;
@@ -952,6 +953,19 @@ export type SystemdDaemonStartArgsInput = DaemonStartArgsInput;
 
 export interface LaunchdDaemonPlistInput extends DaemonStartArgsInput {
 	readonly label?: string;
+}
+
+/**
+ * Resolve the inspector setting for the daemon child. Bun binds BUN_INSPECT
+ * before the CLI reaches this function, so forwarding the same setting to the
+ * child creates an EADDRINUSE failure. A Node parent does not bind it and must
+ * continue forwarding the setting to the Bun daemon child.
+ */
+export function resolveDaemonChildInspector(
+	env: NodeJS.ProcessEnv = process.env,
+	runtimeIsBun: boolean = typeof process.versions.bun === "string",
+): string | undefined {
+	return runtimeIsBun ? undefined : env.BUN_INSPECT;
 }
 
 const TELEMETRY_ENVIRONMENT_KEYS = [
@@ -986,11 +1000,11 @@ export function buildSystemdDaemonStartArgs(input: SystemdDaemonStartArgsInput):
 		`--setenv=SIGNET_BIND=${input.bind}`,
 		`--setenv=SIGNET_PATH=${input.agentsDir}`,
 		"--setenv=SIGNET_DAEMON_ENTRYPOINT=1",
+		`--setenv=BUN_INSPECT=${input.bunInspect ?? ""}`,
 		...Object.entries(resolveTelemetryEnvironment(input.telemetryEnv ?? process.env)).map(
 			([key, value]) => `--setenv=${key}=${value}`,
 		),
 		...(input.unitName ? [`--setenv=SIGNET_DAEMON_UNIT=${input.unitName}`] : []),
-		...(input.bunInspect ? [`--setenv=BUN_INSPECT=${input.bunInspect}`] : []),
 		...resolveDaemonLaunchCommand(input.daemonPath),
 	];
 }
@@ -1158,7 +1172,7 @@ export function buildLaunchdDaemonPlist(input: LaunchdDaemonPlistInput): string 
 			SIGNET_DAEMON_ENTRYPOINT: "1",
 			SIGNET_DAEMON_SERVICE: "launchd",
 			...resolveTelemetryEnvironment(sourceEnvironment),
-			...(input.bunInspect ? { BUN_INSPECT: input.bunInspect } : {}),
+			BUN_INSPECT: input.bunInspect ?? "",
 			...(sourceEnvironment.SIGNET_DIR ? { SIGNET_DIR: sourceEnvironment.SIGNET_DIR } : {}),
 			...(sourceEnvironment.SIGNET_DASHBOARD_DIR
 				? { SIGNET_DASHBOARD_DIR: sourceEnvironment.SIGNET_DASHBOARD_DIR }
@@ -1273,6 +1287,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 		SIGNET_BIND: net.bind,
 		SIGNET_PATH: agentsDir,
 		SIGNET_DAEMON_ENTRYPOINT: "1",
+		BUN_INSPECT: resolveDaemonChildInspector(),
 		// SIGNET_DAEMON_UNIT is deliberately NOT set here: it is only meaningful
 		// when systemd-run actually creates the transient unit (the --setenv in
 		// buildSystemdDaemonStartArgs). On the launchd/detached-spawn fallback
@@ -1297,7 +1312,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 			bind: net.bind,
 			startupLogPath,
 			unitName: systemdUnitName,
-			bunInspect: process.env.BUN_INSPECT,
+			bunInspect: resolveDaemonChildInspector(),
 			telemetryEnv: process.env,
 		});
 		const result = spawnSync("systemd-run", systemdArgs, {
@@ -1329,7 +1344,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 				host: net.host,
 				bind: net.bind,
 				startupLogPath,
-				bunInspect: process.env.BUN_INSPECT,
+				bunInspect: resolveDaemonChildInspector(),
 				telemetryEnv: process.env,
 			}),
 		);


### PR DESCRIPTION
## Summary

Fixes #1534. Keeps the Bun inspector handshake fix and adds a discovery-compatible proxy so a Bun-based CLI parent can expose `/json`, `/json/list`, `/json/protocol`, and a working WebSocket discovery endpoint without forwarding its already-bound `BUN_INSPECT` listener to the daemon child.

## Changes

- Added runtime-aware inspector forwarding for Bun parents, including a loopback child inspector target and public proxy endpoint.
- Added a Bun `Bun.serve` inspector proxy for discovery routes, protocol metadata, and bidirectional WebSocket forwarding.
- Started the proxy from the generated native Bun wrapper when the inspector proxy environment is present.
- Preserved the existing EADDRINUSE handshake fix and non-Bun inspector forwarding behavior.
- Added runtime and end-to-end proxy regression coverage.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A. This is a CLI runtime fix.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations were touched.

## Testing

- [x] Targeted `bun test surfaces/cli/src/lib/runtime.test.ts surfaces/cli/src/lib/inspector-proxy.test.ts` passes: 41 passed, 0 failed.
- [x] `bun run typecheck` passes across the workspace.
- [ ] `bun run lint` passes locally. The repository-wide command reports baseline/generated-source diagnostics outside this change; the changed-file Biome check reports no errors and only three pre-existing warnings.
- [x] `bun run build:native-bun` passes and produces the Linux native binary.
- [x] Compiled native proxy proof: `/json/version`, `/json`, `/json/list`, and `/json/protocol` each returned HTTP 200; a WebSocket `Runtime.enable` request returned `{"result":{},"id":1}`.
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The readiness items for spec alignment, agent scoping, security endpoints, and docs were checked because this change does not add data queries, admin or mutation endpoints, schema/status changes, or a new public API contract. Inspector endpoint parsing validates the host/port shape and bounds. The existing non-Bun service-manager forwarding path remains unchanged.

The dashboard production build itself passes, but the repository `build:dashboard` wrapper exits during its nested install because optional `better-sqlite3` cannot compile against the host Node 26.5.1 V8 headers. This does not affect the native Bun build or the compiled inspector proof above.
