### PR TITLE
feat(secrets): use native keyring master keys

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -369,6 +369,7 @@
         "@hono/node-server": "^2.1.0",
         "@huggingface/transformers": "^4.2.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
+        "@napi-rs/keyring": "1.3.0",
         "@signet/core": "workspace:*",
         "acpx": "0.13.0",
         "better-sqlite3": "^11.0.0",
@@ -1144,6 +1145,32 @@
     "@napi-rs/cli": ["@napi-rs/cli@3.6.2", "", { "dependencies": { "@inquirer/prompts": "^8.0.0", "@napi-rs/cross-toolchain": "^1.0.3", "@napi-rs/wasm-tools": "^1.0.1", "@octokit/rest": "^22.0.1", "clipanion": "^4.0.0-rc.4", "colorette": "^2.0.20", "emnapi": "^1.9.1", "es-toolkit": "^1.41.0", "js-yaml": "^4.1.0", "obug": "^2.0.0", "semver": "^7.7.3", "typanion": "^3.14.0" }, "peerDependencies": { "@emnapi/runtime": "^1.7.1" }, "optionalPeers": ["@emnapi/runtime"], "bin": { "napi": "dist/cli.js", "napi-raw": "cli.mjs" } }, "sha512-jy5rABUh9tbE/vPRzw9kGzGuqZiVslyDQUV8LkvjzqVX/oJMN7g0U1uhtr9L3W1H+iRM/urXHXUf+CE4n8FvLA=="],
 
     "@napi-rs/cross-toolchain": ["@napi-rs/cross-toolchain@1.0.3", "", { "dependencies": { "@napi-rs/lzma": "^1.4.5", "@napi-rs/tar": "^1.1.0", "debug": "^4.4.1" }, "peerDependencies": { "@napi-rs/cross-toolchain-arm64-target-aarch64": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-armv7": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-ppc64le": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-s390x": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-x86_64": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-aarch64": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-armv7": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-ppc64le": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-s390x": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-x86_64": "^1.0.3" }, "optionalPeers": ["@napi-rs/cross-toolchain-arm64-target-aarch64", "@napi-rs/cross-toolchain-arm64-target-armv7", "@napi-rs/cross-toolchain-arm64-target-ppc64le", "@napi-rs/cross-toolchain-arm64-target-s390x", "@napi-rs/cross-toolchain-arm64-target-x86_64", "@napi-rs/cross-toolchain-x64-target-aarch64", "@napi-rs/cross-toolchain-x64-target-armv7", "@napi-rs/cross-toolchain-x64-target-ppc64le", "@napi-rs/cross-toolchain-x64-target-s390x", "@napi-rs/cross-toolchain-x64-target-x86_64"] }, "sha512-ENPfLe4937bsKVTDA6zdABx4pq9w0tHqRrJHyaGxgaPq03a2Bd1unD5XSKjXJjebsABJ+MjAv1A2OvCgK9yehg=="],
+
+    "@napi-rs/keyring": ["@napi-rs/keyring@1.3.0", "", { "optionalDependencies": { "@napi-rs/keyring-darwin-arm64": "1.3.0", "@napi-rs/keyring-darwin-x64": "1.3.0", "@napi-rs/keyring-freebsd-x64": "1.3.0", "@napi-rs/keyring-linux-arm-gnueabihf": "1.3.0", "@napi-rs/keyring-linux-arm64-gnu": "1.3.0", "@napi-rs/keyring-linux-arm64-musl": "1.3.0", "@napi-rs/keyring-linux-riscv64-gnu": "1.3.0", "@napi-rs/keyring-linux-x64-gnu": "1.3.0", "@napi-rs/keyring-linux-x64-musl": "1.3.0", "@napi-rs/keyring-win32-arm64-msvc": "1.3.0", "@napi-rs/keyring-win32-ia32-msvc": "1.3.0", "@napi-rs/keyring-win32-x64-msvc": "1.3.0" } }, "sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA=="],
+
+    "@napi-rs/keyring-darwin-arm64": ["@napi-rs/keyring-darwin-arm64@1.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ=="],
+
+    "@napi-rs/keyring-darwin-x64": ["@napi-rs/keyring-darwin-x64@1.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw=="],
+
+    "@napi-rs/keyring-freebsd-x64": ["@napi-rs/keyring-freebsd-x64@1.3.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw=="],
+
+    "@napi-rs/keyring-linux-arm-gnueabihf": ["@napi-rs/keyring-linux-arm-gnueabihf@1.3.0", "", { "os": "linux", "cpu": "arm" }, "sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ=="],
+
+    "@napi-rs/keyring-linux-arm64-gnu": ["@napi-rs/keyring-linux-arm64-gnu@1.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg=="],
+
+    "@napi-rs/keyring-linux-arm64-musl": ["@napi-rs/keyring-linux-arm64-musl@1.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw=="],
+
+    "@napi-rs/keyring-linux-riscv64-gnu": ["@napi-rs/keyring-linux-riscv64-gnu@1.3.0", "", { "os": "linux", "cpu": "none" }, "sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ=="],
+
+    "@napi-rs/keyring-linux-x64-gnu": ["@napi-rs/keyring-linux-x64-gnu@1.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A=="],
+
+    "@napi-rs/keyring-linux-x64-musl": ["@napi-rs/keyring-linux-x64-musl@1.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw=="],
+
+    "@napi-rs/keyring-win32-arm64-msvc": ["@napi-rs/keyring-win32-arm64-msvc@1.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw=="],
+
+    "@napi-rs/keyring-win32-ia32-msvc": ["@napi-rs/keyring-win32-ia32-msvc@1.3.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ=="],
+
+    "@napi-rs/keyring-win32-x64-msvc": ["@napi-rs/keyring-win32-x64-msvc@1.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg=="],
 
     "@napi-rs/lzma": ["@napi-rs/lzma@1.4.5", "", { "optionalDependencies": { "@napi-rs/lzma-android-arm-eabi": "1.4.5", "@napi-rs/lzma-android-arm64": "1.4.5", "@napi-rs/lzma-darwin-arm64": "1.4.5", "@napi-rs/lzma-darwin-x64": "1.4.5", "@napi-rs/lzma-freebsd-x64": "1.4.5", "@napi-rs/lzma-linux-arm-gnueabihf": "1.4.5", "@napi-rs/lzma-linux-arm64-gnu": "1.4.5", "@napi-rs/lzma-linux-arm64-musl": "1.4.5", "@napi-rs/lzma-linux-ppc64-gnu": "1.4.5", "@napi-rs/lzma-linux-riscv64-gnu": "1.4.5", "@napi-rs/lzma-linux-s390x-gnu": "1.4.5", "@napi-rs/lzma-linux-x64-gnu": "1.4.5", "@napi-rs/lzma-linux-x64-musl": "1.4.5", "@napi-rs/lzma-wasm32-wasi": "1.4.5", "@napi-rs/lzma-win32-arm64-msvc": "1.4.5", "@napi-rs/lzma-win32-ia32-msvc": "1.4.5", "@napi-rs/lzma-win32-x64-msvc": "1.4.5" } }, "sha512-zS5LuN1OBPAyZpda2ZZgYOEDC+xecUdAGnrvbYzjnLXkrq/OBC3B9qcRvlxbDR3k5H/gVfvef1/jyUqPknqjbg=="],
 

--- a/platform/daemon/package.json
+++ b/platform/daemon/package.json
@@ -43,6 +43,7 @@
 		"@hono/node-server": "^2.1.0",
 		"@huggingface/transformers": "^4.2.0",
 		"@modelcontextprotocol/sdk": "^1.30.0",
+		"@napi-rs/keyring": "1.3.0",
 		"@signet/core": "workspace:*",
 		"acpx": "0.13.0",
 		"better-sqlite3": "^11.0.0",

--- a/platform/daemon/src/routes/git-sync.test.ts
+++ b/platform/daemon/src/routes/git-sync.test.ts
@@ -12,10 +12,12 @@ import {
 	scheduleAutoCommit,
 	setGitCommandRunnerForTests,
 	setGitRepoProbeForTests,
+	setGitSecretResolverForTests,
 	stopGitSyncTimer,
 	toRelativeGitPathForTests,
 } from "./git-sync";
 import { type GitConfig, applyGitConfigPatch } from "./session-routes";
+import { SecretKeyringError } from "../secrets.js";
 
 describe("loadGitConfig", () => {
 	it("keeps background git automation disabled by default", () => {
@@ -162,6 +164,34 @@ describe("getGitStatus", () => {
 			expect(result.success).toBe(false);
 			expect(result.message).toContain("No git credentials found");
 		} finally {
+			setGitCommandRunnerForTests(null);
+			setGitRepoProbeForTests(null);
+			resetGitHealthForTests();
+		}
+	});
+
+	it("tries the gh CLI credential fallback when the native keyring is unavailable", async () => {
+		resetGitHealthForTests();
+		setGitRepoProbeForTests(() => true);
+		const calls: string[][] = [];
+		setGitSecretResolverForTests(async () => {
+			throw new SecretKeyringError({ state: "unavailable", message: "keyring daemon unavailable" });
+		});
+		setGitCommandRunnerForTests(async (_cmd, args) => {
+			calls.push(args);
+			if (args[0] === "remote") return { code: 0, stdout: "https://github.com/team/project.git\n", stderr: "" };
+			if (args[0] === "credential") return { code: 1, stdout: "", stderr: "no credentials" };
+			if (args[0] === "auth" && args[1] === "token") return { code: 0, stdout: "gh-token\n", stderr: "" };
+			if (args[0] === "rev-list") return { code: 0, stdout: "0\n", stderr: "" };
+			return { code: 0, stdout: "", stderr: "" };
+		});
+
+		try {
+			const result = await gitPull();
+			expect(result).toMatchObject({ success: true, message: "Already up to date" });
+			expect(calls).toContainEqual(["auth", "token"]);
+		} finally {
+			setGitSecretResolverForTests(null);
 			setGitCommandRunnerForTests(null);
 			setGitRepoProbeForTests(null);
 			resetGitHealthForTests();

--- a/platform/daemon/src/routes/git-sync.ts
+++ b/platform/daemon/src/routes/git-sync.ts
@@ -9,7 +9,7 @@ import {
 	mergeSignetGitignoreEntries,
 } from "@signet/core";
 import { logger } from "../logger";
-import { getSecret, hasSecret } from "../secrets.js";
+import { SecretKeyringError, getSecret, hasSecret } from "../secrets.js";
 import { AGENTS_DIR } from "./state";
 
 import { clampGitSyncIntervalSeconds, gitConfig } from "./git-config";
@@ -57,7 +57,15 @@ function isGitRepo(dir: string): boolean {
 }
 
 interface GitCredentials {
-	method: "token" | "gh" | "credential-helper" | "keychain-locked" | "ssh" | "no-remote" | "none";
+	method:
+		| "token"
+		| "gh"
+		| "credential-helper"
+		| "keychain-locked"
+		| "keychain-unavailable"
+		| "ssh"
+		| "no-remote"
+		| "none";
 	authUrl?: string;
 	usePlainGit?: boolean;
 }
@@ -69,6 +77,8 @@ type CredentialHelperResult =
 
 const KEYCHAIN_LOCKED_MESSAGE =
 	"The macOS login keychain is locked. Unlock it in Keychain Access, then retry Git sync.";
+const KEYCHAIN_UNAVAILABLE_MESSAGE =
+	"The native secrets keyring is unavailable. Start or unlock the user keyring, then retry Git sync.";
 
 function killProcessTree(proc: ChildProcessWithoutNullStreams, signal: NodeJS.Signals): void {
 	try {
@@ -341,7 +351,11 @@ async function resolveGitCredentials(dir: string, remote: string): Promise<GitCr
 					authUrl: buildAuthUrlFromToken(remoteUrl, token),
 				};
 			}
-		} catch {
+		} catch (error) {
+			if (error instanceof SecretKeyringError) {
+				if (error.state === "locked") return { method: "keychain-locked" };
+				if (error.state === "unavailable" || error.state === "unsupported") return { method: "keychain-unavailable" };
+			}
 			/* ignore */
 		}
 
@@ -379,6 +393,7 @@ function failingGitResultMessage(operation: string, result: CommandResult): stri
 
 function missingCredentialMessage(creds: GitCredentials): string {
 	if (creds.method === "keychain-locked") return KEYCHAIN_LOCKED_MESSAGE;
+	if (creds.method === "keychain-unavailable") return KEYCHAIN_UNAVAILABLE_MESSAGE;
 	return "No git credentials found. Run `gh auth login` or set GITHUB_TOKEN secret.";
 }
 

--- a/platform/daemon/src/routes/git-sync.ts
+++ b/platform/daemon/src/routes/git-sync.ts
@@ -51,6 +51,8 @@ let gitRepoProbe = (dir: string): boolean => existsSync(join(dir, ".git"));
 
 type CommandRunner = (cmd: string, args: string[], options?: CommandOptions) => Promise<CommandResult>;
 let commandRunner: CommandRunner = runBoundedCommand;
+type SecretResolver = (name: string) => Promise<string>;
+let secretResolver: SecretResolver = getSecret;
 
 function isGitRepo(dir: string): boolean {
 	return gitRepoProbe(dir);
@@ -323,6 +325,7 @@ async function resolveGitCredentials(dir: string, remote: string): Promise<GitCr
 	}
 
 	let keychainLocked = false;
+	let keychainUnavailable = false;
 	if (remoteUrl.startsWith("https://")) {
 		const helper = await getCredentialHelperToken(remoteUrl, dir);
 		if (helper.status === "available") {
@@ -343,7 +346,7 @@ async function resolveGitCredentials(dir: string, remote: string): Promise<GitCr
 
 	if (isGitHub) {
 		try {
-			const token = await getSecret("GITHUB_TOKEN");
+			const token = await secretResolver("GITHUB_TOKEN");
 			if (token) {
 				logger.debug("git", "Using stored GITHUB_TOKEN for authentication");
 				return {
@@ -354,7 +357,10 @@ async function resolveGitCredentials(dir: string, remote: string): Promise<GitCr
 		} catch (error) {
 			if (error instanceof SecretKeyringError) {
 				if (error.state === "locked") return { method: "keychain-locked" };
-				if (error.state === "unavailable" || error.state === "unsupported") return { method: "keychain-unavailable" };
+				if (error.state === "unavailable" || error.state === "unsupported") {
+					keychainUnavailable = true;
+					logger.warn("git", "Native secrets keyring unavailable; trying gh CLI credentials fallback");
+				}
 			}
 			/* ignore */
 		}
@@ -374,8 +380,13 @@ async function resolveGitCredentials(dir: string, remote: string): Promise<GitCr
 	}
 
 	if (keychainLocked) return { method: "keychain-locked" };
+	if (keychainUnavailable) return { method: "keychain-unavailable" };
 
 	return { method: "none" };
+}
+
+export function setGitSecretResolverForTests(resolver: SecretResolver | null): void {
+	secretResolver = resolver ?? getSecret;
 }
 
 function runGitCommand(args: string[], cwd: string, options?: CommandOptions): Promise<CommandResult> {

--- a/platform/daemon/src/secrets-keyring.ts
+++ b/platform/daemon/src/secrets-keyring.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
 import type { AsyncEntry } from "@napi-rs/keyring";
 
 export type SecretKeyringState =
@@ -23,10 +24,13 @@ export interface SecretKeyringAdapter {
 	readonly account: string;
 	get(): Promise<SecretKeyringResult>;
 	set(value: string): Promise<SecretKeyringResult>;
+	getStatus?(): SecretKeyringResult;
 }
 
 const SERVICE = "ai.signet.secrets";
+const require = createRequire(import.meta.url);
 let modulePromise: Promise<typeof import("@napi-rs/keyring") | null> | null = null;
+let syncModule: typeof import("@napi-rs/keyring") | null | undefined;
 let adapterForTests: SecretKeyringAdapter | null = null;
 
 function workspaceAccount(workspace: string): string {
@@ -60,6 +64,17 @@ function classifyError(error: unknown): SecretKeyringResult {
 async function loadModule(): Promise<typeof import("@napi-rs/keyring") | null> {
 	modulePromise ??= import("@napi-rs/keyring").catch(() => null);
 	return modulePromise;
+}
+
+function loadModuleSync(): typeof import("@napi-rs/keyring") | null {
+	if (syncModule !== undefined) return syncModule;
+	try {
+		const mod: typeof import("@napi-rs/keyring") = require("@napi-rs/keyring");
+		syncModule = mod;
+	} catch {
+		syncModule = null;
+	}
+	return syncModule;
 }
 
 function linuxKeyringAvailable(): SecretKeyringResult | null {
@@ -131,6 +146,23 @@ class NativeSecretKeyringAdapter implements SecretKeyringAdapter {
 			return classifyError(error);
 		}
 	}
+
+	getStatus(): SecretKeyringResult {
+		const linuxUnavailable = linuxKeyringAvailable();
+		if (linuxUnavailable) return linuxUnavailable;
+		try {
+			const mod = loadModuleSync();
+			if (!mod)
+				return { state: "unsupported", message: "The native keyring module is not installed for this platform" };
+			const entry = new mod.Entry(this.service, this.account);
+			const value = entry.getPassword();
+			return value === undefined || value === null || value.length === 0
+				? { state: "missing" }
+				: { state: "found", value };
+		} catch (error) {
+			return classifyError(error);
+		}
+	}
 }
 
 export function getSecretKeyring(workspace: string): SecretKeyringAdapter {
@@ -140,8 +172,10 @@ export function getSecretKeyring(workspace: string): SecretKeyringAdapter {
 export function setSecretKeyringForTests(adapter: SecretKeyringAdapter | null): void {
 	adapterForTests = adapter;
 	modulePromise = null;
+	syncModule = undefined;
 }
 
 export function resetSecretKeyringModuleForTests(): void {
 	modulePromise = null;
+	syncModule = undefined;
 }

--- a/platform/daemon/src/secrets-keyring.ts
+++ b/platform/daemon/src/secrets-keyring.ts
@@ -1,0 +1,147 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import type { AsyncEntry } from "@napi-rs/keyring";
+
+export type SecretKeyringState =
+	| "found"
+	| "missing"
+	| "locked"
+	| "unavailable"
+	| "permission-denied"
+	| "corrupt"
+	| "unsupported";
+
+export interface SecretKeyringResult {
+	readonly state: SecretKeyringState;
+	readonly value?: string;
+	readonly message?: string;
+}
+
+export interface SecretKeyringAdapter {
+	readonly platform: string;
+	readonly service: string;
+	readonly account: string;
+	get(): Promise<SecretKeyringResult>;
+	set(value: string): Promise<SecretKeyringResult>;
+}
+
+const SERVICE = "ai.signet.secrets";
+let modulePromise: Promise<typeof import("@napi-rs/keyring") | null> | null = null;
+let adapterForTests: SecretKeyringAdapter | null = null;
+
+function workspaceAccount(workspace: string): string {
+	return createHash("sha256").update(workspace).digest("hex").slice(0, 32);
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function classifyError(error: unknown): SecretKeyringResult {
+	const message = errorMessage(error);
+	const code = typeof error === "object" && error !== null && "code" in error ? String(error.code) : "";
+	const detail = `${code} ${message}`.toLowerCase();
+
+	if (/noentry|no entry|no such item|item.*not found|credential.*missing|does not exist/.test(detail)) {
+		return { state: "missing", message };
+	}
+	if (/locked|interaction|required|authfailed|authentication|islocked|prompt/.test(detail)) {
+		return { state: "locked", message };
+	}
+	if (/permission|access denied|denied/.test(detail)) {
+		return { state: "permission-denied", message };
+	}
+	if (/unsupported|not implemented|dbus|secret service|keyutils|connection|unavailable|no such file/.test(detail)) {
+		return { state: "unavailable", message };
+	}
+	return { state: "corrupt", message };
+}
+
+async function loadModule(): Promise<typeof import("@napi-rs/keyring") | null> {
+	modulePromise ??= import("@napi-rs/keyring").catch(() => null);
+	return modulePromise;
+}
+
+function linuxKeyringAvailable(): SecretKeyringResult | null {
+	if (process.platform !== "linux") return null;
+	if (process.env.SIGNET_SECRETS_LINUX_KEYRING === "keyutils") {
+		return { state: "unsupported", message: "Linux keyutils is not an implicit Signet secrets backend" };
+	}
+	if (!process.env.DBUS_SESSION_BUS_ADDRESS) {
+		return {
+			state: "unavailable",
+			message: "Linux Secret Service requires a user D-Bus session; no prompt or desktop session is available",
+		};
+	}
+	try {
+		execFileSync("busctl", ["--user", "status", "org.freedesktop.secrets"], {
+			stdio: "ignore",
+			timeout: 1_000,
+		});
+		return null;
+	} catch {
+		return {
+			state: "unavailable",
+			message: "Linux Secret Service is not registered on the user D-Bus session",
+		};
+	}
+}
+
+class NativeSecretKeyringAdapter implements SecretKeyringAdapter {
+	readonly platform = process.platform;
+	readonly service = SERVICE;
+	readonly account: string;
+
+	constructor(workspace: string) {
+		this.account = workspaceAccount(workspace);
+	}
+
+	private async entry(): Promise<AsyncEntry | null> {
+		const mod = await loadModule();
+		if (!mod) return null;
+		return new mod.AsyncEntry(this.service, this.account);
+	}
+
+	async get(): Promise<SecretKeyringResult> {
+		const linuxUnavailable = linuxKeyringAvailable();
+		if (linuxUnavailable) return linuxUnavailable;
+		try {
+			const entry = await this.entry();
+			if (!entry)
+				return { state: "unsupported", message: "The native keyring module is not installed for this platform" };
+			const value = await entry.getPassword();
+			return value === undefined || value === null || value.length === 0
+				? { state: "missing" }
+				: { state: "found", value };
+		} catch (error) {
+			return classifyError(error);
+		}
+	}
+
+	async set(value: string): Promise<SecretKeyringResult> {
+		const linuxUnavailable = linuxKeyringAvailable();
+		if (linuxUnavailable) return linuxUnavailable;
+		try {
+			const entry = await this.entry();
+			if (!entry)
+				return { state: "unsupported", message: "The native keyring module is not installed for this platform" };
+			await entry.setPassword(value);
+			return { state: "found", value };
+		} catch (error) {
+			return classifyError(error);
+		}
+	}
+}
+
+export function getSecretKeyring(workspace: string): SecretKeyringAdapter {
+	return adapterForTests ?? new NativeSecretKeyringAdapter(workspace);
+}
+
+export function setSecretKeyringForTests(adapter: SecretKeyringAdapter | null): void {
+	adapterForTests = adapter;
+	modulePromise = null;
+}
+
+export function resetSecretKeyringModuleForTests(): void {
+	modulePromise = null;
+}

--- a/platform/daemon/src/secrets.test.ts
+++ b/platform/daemon/src/secrets.test.ts
@@ -64,6 +64,9 @@ function makeKeyring(initial: SecretKeyringResult): SecretKeyringAdapter & { set
 			next = { state: "found", value };
 			return next;
 		},
+		getStatus(): SecretKeyringResult {
+			return stored === undefined ? next : { state: "found", value: stored };
+		},
 	};
 	return adapter;
 }
@@ -170,6 +173,18 @@ describe("local secrets provider", () => {
 
 		expect(await getSecret("OPENAI_API_KEY")).toBe("legacy-secret");
 		expect(keyring.setCalls).toBe(1);
+	});
+
+	test("native v2 health reflects a locked keyring instead of reporting healthy", async () => {
+		const keyring = makeKeyring({ state: "missing" });
+		setSecretKeyringAdapterForTests(keyring);
+		await putSecret("OPENAI_API_KEY", "native-secret");
+
+		setSecretKeyringAdapterForTests(makeKeyring({ state: "locked", message: "keychain is locked" }));
+		const health = await localSecretProvider.health({});
+
+		expect(health.status).toBe("degraded");
+		expect(health.message).toContain("keychain is locked");
 	});
 
 	test("bare names and local:// references resolve through the same local store", async () => {

--- a/platform/daemon/src/secrets.test.ts
+++ b/platform/daemon/src/secrets.test.ts
@@ -199,6 +199,23 @@ describe("local secrets provider", () => {
 		expect(health.message).toContain("Native secrets keyring is missing");
 	});
 
+	test("native v2 health degrades for a malformed keyring value and reads fail closed", async () => {
+		const keyring = makeKeyring({ state: "missing" });
+		setSecretKeyringAdapterForTests(keyring);
+		await putSecret("OPENAI_API_KEY", "native-secret");
+
+		setSecretKeyringAdapterForTests(makeKeyring({ state: "found", value: "malformed-keyring-value" }));
+		const health = await localSecretProvider.health({});
+
+		expect(health.status).toBe("degraded");
+		expect(health.message).toContain("Native secrets keyring is corrupt");
+		await expect(getSecret("OPENAI_API_KEY")).rejects.toMatchObject({
+			name: "SecretKeyringError",
+			state: "corrupt",
+			retryable: false,
+		});
+	});
+
 	test("bare names and local:// references resolve through the same local store", async () => {
 		await putSecret("OPENAI_API_KEY", "sk-test-local");
 

--- a/platform/daemon/src/secrets.test.ts
+++ b/platform/daemon/src/secrets.test.ts
@@ -187,6 +187,18 @@ describe("local secrets provider", () => {
 		expect(health.message).toContain("keychain is locked");
 	});
 
+	test("native v2 health reports a missing keyring item as degraded", async () => {
+		const keyring = makeKeyring({ state: "missing" });
+		setSecretKeyringAdapterForTests(keyring);
+		await putSecret("OPENAI_API_KEY", "native-secret");
+
+		setSecretKeyringAdapterForTests(makeKeyring({ state: "missing" }));
+		const health = await localSecretProvider.health({});
+
+		expect(health.status).toBe("degraded");
+		expect(health.message).toContain("Native secrets keyring is missing");
+	});
+
 	test("bare names and local:// references resolve through the same local store", async () => {
 		await putSecret("OPENAI_API_KEY", "sk-test-local");
 

--- a/platform/daemon/src/secrets.test.ts
+++ b/platform/daemon/src/secrets.test.ts
@@ -216,6 +216,23 @@ describe("local secrets provider", () => {
 		});
 	});
 
+	test("native v2 health rejects a non-canonical 32-byte-looking keyring value", async () => {
+		const keyring = makeKeyring({ state: "missing" });
+		setSecretKeyringAdapterForTests(keyring);
+		await putSecret("OPENAI_API_KEY", "native-secret");
+
+		setSecretKeyringAdapterForTests(makeKeyring({ state: "found", value: `${"A".repeat(43)}!` }));
+		const health = await localSecretProvider.health({});
+
+		expect(health.status).toBe("degraded");
+		expect(health.message).toContain("Native secrets keyring is corrupt");
+		await expect(getSecret("OPENAI_API_KEY")).rejects.toMatchObject({
+			name: "SecretKeyringError",
+			state: "corrupt",
+			retryable: false,
+		});
+	});
+
 	test("bare names and local:// references resolve through the same local store", async () => {
 		await putSecret("OPENAI_API_KEY", "sk-test-local");
 

--- a/platform/daemon/src/secrets.test.ts
+++ b/platform/daemon/src/secrets.test.ts
@@ -10,6 +10,7 @@ import {
 	setBitwardenClientFactoryForTests,
 } from "./bitwarden.js";
 import { SIGNET_SECRETS_PLUGIN_ID, getDefaultPluginHost, resetDefaultPluginHostForTests } from "./plugins/index.js";
+import type { SecretKeyringAdapter, SecretKeyringResult } from "./secrets-keyring.js";
 import {
 	__setSecretStoreWriteHookForTests,
 	deleteSecret,
@@ -23,6 +24,7 @@ import {
 	putSecret,
 	resetSecretExecJobsForTests,
 	setMachineIdResolverForTests,
+	setSecretKeyringAdapterForTests,
 	startSecretExecJob,
 } from "./secrets.js";
 
@@ -44,11 +46,44 @@ function machineIdFile(): string {
 	return join(agentsDir, ".secrets", ".machine-id");
 }
 
+function makeKeyring(initial: SecretKeyringResult): SecretKeyringAdapter & { setCalls: number } {
+	let stored = initial.state === "found" ? initial.value : undefined;
+	let next = initial;
+	const adapter = {
+		platform: "test",
+		service: "ai.signet.secrets",
+		account: "test",
+		setCalls: 0,
+		async get(): Promise<SecretKeyringResult> {
+			return stored === undefined ? next : { state: "found", value: stored };
+		},
+		async set(value: string): Promise<SecretKeyringResult> {
+			adapter.setCalls += 1;
+			if (next.state !== "missing" && next.state !== "found") return next;
+			stored = value;
+			next = { state: "found", value };
+			return next;
+		},
+	};
+	return adapter;
+}
+
 describe("local secrets provider", () => {
 	beforeEach(() => {
 		agentsDir = join(tmpdir(), `signet-secrets-provider-${process.pid}-${Date.now()}`);
 		process.env.SIGNET_PATH = agentsDir;
 		mkdirSync(agentsDir, { recursive: true });
+		setSecretKeyringAdapterForTests({
+			platform: "test",
+			service: "test",
+			account: "test",
+			async get() {
+				return { state: "unavailable", message: "test keyring unavailable" };
+			},
+			async set() {
+				return { state: "unavailable", message: "test keyring unavailable" };
+			},
+		});
 	});
 
 	afterEach(() => {
@@ -57,6 +92,7 @@ describe("local secrets provider", () => {
 		setBitwardenClientFactoryForTests(null);
 		__setSecretStoreWriteHookForTests(null);
 		setMachineIdResolverForTests(null);
+		setSecretKeyringAdapterForTests(null);
 		invalidateSecretsCache();
 		if (originalSignetPath === undefined) {
 			Reflect.deleteProperty(process.env, "SIGNET_PATH");
@@ -71,6 +107,69 @@ describe("local secrets provider", () => {
 		if (agentsDir && existsSync(agentsDir)) {
 			rmSync(agentsDir, { recursive: true, force: true });
 		}
+	});
+
+	test("new local stores use a random native-keyring master key", async () => {
+		const keyring = makeKeyring({ state: "missing" });
+		setSecretKeyringAdapterForTests(keyring);
+
+		await putSecret("OPENAI_API_KEY", "native-secret");
+		const store = JSON.parse(readFileSync(secretsFile(), "utf-8")) as { version: number; provider: string };
+
+		expect(store).toMatchObject({ version: 2, provider: "native-keyring" });
+		expect(keyring.setCalls).toBe(1);
+		expect(await getSecret("OPENAI_API_KEY")).toBe("native-secret");
+	});
+
+	test("locked native keyrings never fall back or report no credentials", async () => {
+		setSecretKeyringAdapterForTests(makeKeyring({ state: "locked", message: "keychain is locked" }));
+
+		await expect(putSecret("OPENAI_API_KEY", "locked-secret")).rejects.toMatchObject({
+			name: "SecretKeyringError",
+			state: "locked",
+			retryable: true,
+		});
+		expect(existsSync(secretsFile())).toBe(false);
+	});
+
+	test("native keyring unavailability stays retryable after a store exists", async () => {
+		const keyring = makeKeyring({ state: "missing" });
+		setSecretKeyringAdapterForTests(keyring);
+		await putSecret("OPENAI_API_KEY", "native-secret");
+
+		setSecretKeyringAdapterForTests({
+			platform: "test",
+			service: "test",
+			account: "test",
+			async get() {
+				return { state: "unavailable", message: "keyring daemon unavailable" };
+			},
+			async set() {
+				return { state: "unavailable", message: "keyring daemon unavailable" };
+			},
+		});
+		await expect(getSecret("OPENAI_API_KEY")).rejects.toMatchObject({
+			name: "SecretKeyringError",
+			state: "unavailable",
+			retryable: true,
+		});
+	});
+
+	test("legacy stores migrate once keyring access is restored", async () => {
+		await putSecret("OPENAI_API_KEY", "legacy-secret");
+		const legacyStore = JSON.parse(readFileSync(secretsFile(), "utf-8")) as { version: number };
+		expect(legacyStore.version).toBe(1);
+
+		const keyring = makeKeyring({ state: "missing" });
+		setSecretKeyringAdapterForTests(keyring);
+		expect(await getSecret("OPENAI_API_KEY")).toBe("legacy-secret");
+		const migratedStore = JSON.parse(readFileSync(secretsFile(), "utf-8")) as { version: number; provider: string };
+		expect(migratedStore).toMatchObject({ version: 2, provider: "native-keyring" });
+		expect(keyring.setCalls).toBe(1);
+		expect((await localSecretProvider.health({})).status).toBe("healthy");
+
+		expect(await getSecret("OPENAI_API_KEY")).toBe("legacy-secret");
+		expect(keyring.setCalls).toBe(1);
 	});
 
 	test("bare names and local:// references resolve through the same local store", async () => {
@@ -201,7 +300,7 @@ describe("local secrets provider", () => {
 			script,
 			[
 				"process.stdout.write(process.env.OPENAI_API_KEY);",
-				"process.stderr.write(`err:${process.env.OPENAI_API_KEY}`);",
+				'process.stderr.write("err:" + process.env.OPENAI_API_KEY);',
 			].join("\n"),
 		);
 

--- a/platform/daemon/src/secrets.ts
+++ b/platform/daemon/src/secrets.ts
@@ -897,7 +897,12 @@ export const localSecretProvider: LocalSecretProviderV1 = {
 function healthForKeyringState(result: SecretKeyringResult): SecretProviderHealthV1 {
 	const checkedAt = new Date().toISOString();
 	const message = result.message ?? `Native secrets keyring is ${result.state}`;
-	if (result.state === "locked" || result.state === "unavailable" || result.state === "unsupported") {
+	if (
+		result.state === "missing" ||
+		result.state === "locked" ||
+		result.state === "unavailable" ||
+		result.state === "unsupported"
+	) {
 		return { status: "degraded", message, checkedAt };
 	}
 	if (result.state === "permission-denied" || result.state === "corrupt") {

--- a/platform/daemon/src/secrets.ts
+++ b/platform/daemon/src/secrets.ts
@@ -894,15 +894,32 @@ export const localSecretProvider: LocalSecretProviderV1 = {
 	},
 };
 
+function healthForKeyringState(result: SecretKeyringResult): SecretProviderHealthV1 {
+	const checkedAt = new Date().toISOString();
+	const message = result.message ?? `Native secrets keyring is ${result.state}`;
+	if (result.state === "locked" || result.state === "unavailable" || result.state === "unsupported") {
+		return { status: "degraded", message, checkedAt };
+	}
+	if (result.state === "permission-denied" || result.state === "corrupt") {
+		return { status: "unhealthy", message, checkedAt };
+	}
+	return { status: "healthy", checkedAt };
+}
+
 export function getLocalSecretProviderHealth(): SecretProviderHealthV1 {
 	try {
-		loadStore();
+		const store = loadStore();
 		if (existsSync(join(getSecretsDir(), DEGRADED_WARNING_FILE))) {
 			return {
 				status: "degraded",
 				message: "Using legacy machine-id-obfuscated secrets encryption because no native keyring is available",
 				checkedAt: new Date().toISOString(),
 			};
+		}
+		if (store.version === NATIVE_STORE_VERSION || store.provider === "native-keyring") {
+			const keyring = getSecretKeyring(`${KEYRING_ACCOUNT_SCOPE}:${getAgentsDir()}`);
+			const state = keyring.getStatus?.();
+			if (state && state.state !== "found") return healthForKeyringState(state);
 		}
 		return { status: "healthy", checkedAt: new Date().toISOString() };
 	} catch (err) {

--- a/platform/daemon/src/secrets.ts
+++ b/platform/daemon/src/secrets.ts
@@ -12,7 +12,7 @@
  */
 
 import { execSync, spawn } from "node:child_process";
-import { randomUUID } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import {
 	chmodSync,
 	closeSync,
@@ -42,6 +42,13 @@ import {
 	readBitwardenReference,
 } from "./bitwarden.js";
 import { logger } from "./logger.js";
+import {
+	getSecretKeyring,
+	setSecretKeyringForTests,
+	type SecretKeyringAdapter,
+	type SecretKeyringResult,
+	type SecretKeyringState,
+} from "./secrets-keyring.js";
 import { ONEPASSWORD_SERVICE_ACCOUNT_SECRET, isOnePasswordReference, readOnePasswordReference } from "./onepassword.js";
 import { recordPluginAuditEvent } from "./plugins/audit.js";
 import { SIGNET_SECRETS_PLUGIN_ID } from "./plugins/bundled/secrets.js";
@@ -77,7 +84,8 @@ interface SecretEntry {
 }
 
 interface SecretsStore {
-	version: 1;
+	version: 1 | 2;
+	provider?: "legacy-obfuscated" | "native-keyring";
 	secrets: Record<string, SecretEntry>;
 }
 
@@ -224,11 +232,32 @@ function resolveMachineId(): string | undefined {
 	return undefined;
 }
 
-let _masterKey: Uint8Array | null = null;
 let machineIdSelection: MachineIdSelection | null = null;
 let machineIdResolverForTests: MachineIdResolver | null = null;
 type SodiumModule = typeof import("libsodium-wrappers").default;
 let sodiumPromise: Promise<SodiumModule> | null = null;
+let degradedWarningEmitted = false;
+
+const NATIVE_STORE_VERSION = 2 as const;
+const DEGRADED_WARNING_FILE = ".degraded-warning";
+const KEYRING_ACCOUNT_SCOPE = "workspace";
+
+interface MasterKeyResolution {
+	readonly key: Uint8Array;
+	readonly provider: "legacy-obfuscated" | "native-keyring";
+}
+
+export class SecretKeyringError extends Error {
+	readonly state: SecretKeyringState;
+	readonly retryable: boolean;
+
+	constructor(result: SecretKeyringResult) {
+		super(result.message ?? `Secrets keyring is ${result.state}`);
+		this.name = "SecretKeyringError";
+		this.state = result.state;
+		this.retryable = result.state === "locked" || result.state === "unavailable";
+	}
+}
 
 function readPersistedMachineId(): string | undefined {
 	try {
@@ -306,7 +335,11 @@ function getMachineId(): string {
 export function setMachineIdResolverForTests(resolver: MachineIdResolver | null): void {
 	machineIdResolverForTests = resolver;
 	machineIdSelection = null;
-	_masterKey = null;
+}
+
+export function setSecretKeyringAdapterForTests(adapter: SecretKeyringAdapter | null): void {
+	setSecretKeyringForTests(adapter);
+	degradedWarningEmitted = false;
 }
 
 async function getSodium(): Promise<SodiumModule> {
@@ -318,20 +351,108 @@ async function getSodium(): Promise<SodiumModule> {
 	return sodiumPromise;
 }
 
-async function getMasterKey(): Promise<Uint8Array> {
-	if (_masterKey) return _masterKey;
-
+async function getLegacyMasterKey(): Promise<Uint8Array> {
 	const sodium = await getSodium();
-
 	const machineId = getMachineId();
 	const input = `signet:secrets:${machineId}`;
 	const inputBytes = new TextEncoder().encode(input);
+	return sodium.crypto_generichash(32, inputBytes, null);
+}
 
-	// Stretch the machine-id into a 32-byte key via BLAKE2b.
-	// In a future version this can be replaced with Argon2 + passphrase.
-	const key = sodium.crypto_generichash(32, inputBytes, null);
-	_masterKey = key;
-	return key;
+function decodeKeyringValue(result: SecretKeyringResult): Uint8Array {
+	if (result.value === undefined)
+		throw new SecretKeyringError({ state: "corrupt", message: "Keyring returned no master key" });
+	try {
+		const key = Buffer.from(result.value, "base64");
+		if (key.length !== 32) throw new Error("master key has an invalid length");
+		return new Uint8Array(key);
+	} catch (error) {
+		throw new SecretKeyringError({ state: "corrupt", message: error instanceof Error ? error.message : String(error) });
+	}
+}
+
+function emitDegradedWarning(result: SecretKeyringResult): void {
+	if (degradedWarningEmitted) return;
+	degradedWarningEmitted = true;
+	logger.warn("secrets", "Using degraded machine-id secrets encryption because no native keyring is available", {
+		provider: "legacy-obfuscated",
+		keyringState: result.state,
+		message: "Configure a native user keyring and migrate the store to improve protection and portability",
+	});
+	try {
+		mkdirSync(getSecretsDir(), { recursive: true, mode: 0o700 });
+		writeFileSync(join(getSecretsDir(), DEGRADED_WARNING_FILE), "legacy-obfuscated\n", {
+			encoding: "utf-8",
+			mode: 0o600,
+		});
+	} catch {
+		// The health response still reports degraded state if the marker cannot be written.
+	}
+}
+
+function clearDegradedWarning(): void {
+	try {
+		unlinkSync(join(getSecretsDir(), DEGRADED_WARNING_FILE));
+	} catch (error) {
+		if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+	}
+}
+
+async function migrateLegacyStore(store: SecretsStore, legacyKey: Uint8Array, nativeKey: Uint8Array): Promise<void> {
+	const plaintexts = new Map<string, string>();
+	for (const [name, entry] of Object.entries(store.secrets)) {
+		plaintexts.set(name, await decryptWithKey(entry.ciphertext, legacyKey));
+	}
+	const migrated: SecretsStore = {
+		version: NATIVE_STORE_VERSION,
+		provider: "native-keyring",
+		secrets: {},
+	};
+	for (const [name, plaintext] of plaintexts) {
+		const entry = store.secrets[name];
+		if (!entry) continue;
+		migrated.secrets[name] = {
+			ciphertext: await encryptWithKey(plaintext, nativeKey),
+			created: entry.created,
+			updated: entry.updated,
+		};
+	}
+	store.version = migrated.version;
+	store.provider = migrated.provider;
+	store.secrets = migrated.secrets;
+	saveStore(store);
+	clearDegradedWarning();
+}
+
+async function resolveMasterKey(store: SecretsStore): Promise<MasterKeyResolution> {
+	const keyring = getSecretKeyring(`${KEYRING_ACCOUNT_SCOPE}:${getAgentsDir()}`);
+	const result = await keyring.get();
+	if (store.version === NATIVE_STORE_VERSION || store.provider === "native-keyring") {
+		if (result.state !== "found") throw new SecretKeyringError(result);
+		return { key: decodeKeyringValue(result), provider: "native-keyring" };
+	}
+
+	if (result.state === "found") {
+		const nativeKey = decodeKeyringValue(result);
+		if (existsSync(getSecretsFile())) await migrateLegacyStore(store, await getLegacyMasterKey(), nativeKey);
+		return { key: nativeKey, provider: "native-keyring" };
+	}
+
+	if (result.state === "missing") {
+		const nativeKey = randomBytes(32);
+		const legacyKey = existsSync(getSecretsFile()) ? await getLegacyMasterKey() : undefined;
+		const saved = await keyring.set(Buffer.from(nativeKey).toString("base64"));
+		if (saved.state === "found") {
+			if (legacyKey) await migrateLegacyStore(store, legacyKey, nativeKey);
+			return { key: nativeKey, provider: "native-keyring" };
+		}
+		throw new SecretKeyringError(saved);
+	}
+
+	if (result.state === "locked") throw new SecretKeyringError(result);
+	if (result.state !== "unavailable" && result.state !== "unsupported") throw new SecretKeyringError(result);
+	emitDegradedWarning(result);
+	return { key: await getLegacyMasterKey(), provider: "legacy-obfuscated" };
 }
 
 // ---------------------------------------------------------------------------
@@ -350,61 +471,33 @@ async function decryptWithKey(ciphertext: string, key: Uint8Array): Promise<stri
 		throw new Error("Decryption failed - key mismatch or corrupted data");
 	}
 	if (!message) throw new Error("Decryption failed - key mismatch or corrupted data");
-
 	return new TextDecoder().decode(message);
 }
 
-async function verifyExistingStore(key: Uint8Array): Promise<boolean> {
-	const store = loadStore();
-	for (const entry of Object.values(store.secrets)) {
-		try {
-			await decryptWithKey(entry.ciphertext, key);
-		} catch {
-			return false;
-		}
-	}
-	return true;
-}
-
-async function anchorMachineIdAfterCompatibilityCheck(key: Uint8Array): Promise<boolean> {
+async function anchorLegacyMachineIdAfterVerification(key: Uint8Array): Promise<void> {
 	if (
 		!machineIdSelection ||
 		machineIdSelection.source === "persisted" ||
 		existsSync(getMachineIdFile()) ||
 		!existsSync(getSecretsFile())
 	) {
-		return true;
+		return;
 	}
-
-	if (!(await verifyExistingStore(key))) return false;
+	const store = loadStore();
+	for (const entry of Object.values(store.secrets)) await decryptWithKey(entry.ciphertext, key);
 	const persistedId = persistMachineId(machineIdSelection.id);
 	machineIdSelection = { id: persistedId, source: "persisted" };
-	return true;
 }
 
-async function encrypt(plaintext: string): Promise<string> {
+async function encryptWithKey(plaintext: string, key: Uint8Array): Promise<string> {
 	const sodium = await getSodium();
-	const key = await getMasterKey();
-	if (!(await anchorMachineIdAfterCompatibilityCheck(key))) {
-		throw new Error("Existing secrets store could not be verified; refusing to rewrite it");
-	}
 	const nonce = sodium.randombytes_buf(sodium.crypto_secretbox_NONCEBYTES);
 	const message = new TextEncoder().encode(plaintext);
 	const box = sodium.crypto_secretbox_easy(message, nonce, key);
-
-	// Prepend nonce so we can recover it during decryption
 	const combined = new Uint8Array(nonce.length + box.length);
 	combined.set(nonce);
 	combined.set(box, nonce.length);
-
 	return sodium.to_base64(combined, sodium.base64_variants.ORIGINAL);
-}
-
-async function decrypt(ciphertext: string): Promise<string> {
-	const key = await getMasterKey();
-	const plaintext = await decryptWithKey(ciphertext, key);
-	await anchorMachineIdAfterCompatibilityCheck(key);
-	return plaintext;
 }
 
 // ---------------------------------------------------------------------------
@@ -504,17 +597,30 @@ function saveStore(store: SecretsStore): void {
 async function putLocalSecret(name: string, value: string): Promise<void> {
 	const localName = parseLocalSecretName(name);
 	const store = loadStore();
+	const resolution = await resolveMasterKey(store);
+	if (
+		resolution.provider === "legacy-obfuscated" &&
+		existsSync(getSecretsFile()) &&
+		!existsSync(getMachineIdFile()) &&
+		machineIdResolverForTests !== null &&
+		!machineIdResolverForTests()?.trim()
+	) {
+		throw new Error("Existing secrets store could not be verified: unable to resolve its machine identity");
+	}
+	await anchorLegacyMachineIdAfterVerification(resolution.key);
+	store.version = resolution.provider === "native-keyring" ? NATIVE_STORE_VERSION : 1;
+	store.provider = resolution.provider;
 	const now = new Date().toISOString();
 	const existing = store.secrets[localName];
 
 	store.secrets[localName] = {
-		ciphertext: await encrypt(value),
+		ciphertext: await encryptWithKey(value, resolution.key),
 		created: existing?.created ?? now,
 		updated: now,
 	};
 
 	saveStore(store);
-	recordSecretEvent("secret.stored", { name: localName });
+	recordSecretEvent("secret.stored", { name: localName, providerId: resolution.provider });
 }
 
 export async function putSecret(name: string, value: string): Promise<void> {
@@ -539,9 +645,12 @@ export async function putSecret(name: string, value: string): Promise<void> {
 
 async function getStoredSecret(name: string): Promise<string> {
 	const store = loadStore();
+	const resolution = await resolveMasterKey(store);
 	const entry = store.secrets[name];
 	if (!entry) throw new Error(`Secret '${name}' not found`);
-	return decrypt(entry.ciphertext);
+	const plaintext = await decryptWithKey(entry.ciphertext, resolution.key);
+	if (resolution.provider === "legacy-obfuscated") await anchorLegacyMachineIdAfterVerification(resolution.key);
+	return plaintext;
 }
 
 function canonicalBitwardenDeletedName(name: string): string {
@@ -788,6 +897,13 @@ export const localSecretProvider: LocalSecretProviderV1 = {
 export function getLocalSecretProviderHealth(): SecretProviderHealthV1 {
 	try {
 		loadStore();
+		if (existsSync(join(getSecretsDir(), DEGRADED_WARNING_FILE))) {
+			return {
+				status: "degraded",
+				message: "Using legacy machine-id-obfuscated secrets encryption because no native keyring is available",
+				checkedAt: new Date().toISOString(),
+			};
+		}
 		return { status: "healthy", checkedAt: new Date().toISOString() };
 	} catch (err) {
 		return {
@@ -1152,8 +1268,11 @@ function parseSecretsStore(value: unknown): SecretsStore {
 	if (!isRecord(value)) {
 		throw new Error("store must be a JSON object");
 	}
-	if (value.version !== 1) {
+	if (value.version !== 1 && value.version !== NATIVE_STORE_VERSION) {
 		throw new Error("unsupported secrets store version");
+	}
+	if (value.version === NATIVE_STORE_VERSION && value.provider !== "native-keyring") {
+		throw new Error("native-keyring store is missing its provider marker");
 	}
 	if (!isRecord(value.secrets)) {
 		throw new Error("secrets field must be an object");
@@ -1177,7 +1296,11 @@ function parseSecretsStore(value: unknown): SecretsStore {
 			updated: entry.updated,
 		};
 	}
-	return { version: 1, secrets };
+	return {
+		version: value.version,
+		...(value.provider === "native-keyring" ? { provider: value.provider } : {}),
+		secrets,
+	};
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/platform/daemon/src/secrets.ts
+++ b/platform/daemon/src/secrets.ts
@@ -364,7 +364,9 @@ function decodeKeyringValue(result: SecretKeyringResult): Uint8Array {
 		throw new SecretKeyringError({ state: "corrupt", message: "Keyring returned no master key" });
 	try {
 		const key = Buffer.from(result.value, "base64");
-		if (key.length !== 32) throw new Error("master key has an invalid length");
+		if (key.length !== 32 || key.toString("base64") !== result.value) {
+			throw new Error("master key is not valid canonical base64");
+		}
 		return new Uint8Array(key);
 	} catch (error) {
 		throw new SecretKeyringError({ state: "corrupt", message: error instanceof Error ? error.message : String(error) });

--- a/platform/daemon/src/secrets.ts
+++ b/platform/daemon/src/secrets.ts
@@ -925,6 +925,17 @@ export function getLocalSecretProviderHealth(): SecretProviderHealthV1 {
 			const keyring = getSecretKeyring(`${KEYRING_ACCOUNT_SCOPE}:${getAgentsDir()}`);
 			const state = keyring.getStatus?.();
 			if (state && state.state !== "found") return healthForKeyringState(state);
+			if (state) {
+				try {
+					decodeKeyringValue(state);
+				} catch (error) {
+					return {
+						status: "degraded",
+						message: `Native secrets keyring is corrupt: ${error instanceof Error ? error.message : String(error)}`,
+						checkedAt: new Date().toISOString(),
+					};
+				}
+			}
 		}
 		return { status: "healthy", checkedAt: new Date().toISOString() };
 	} catch (err) {

--- a/web/docs/src/content/docs/secrets.md
+++ b/web/docs/src/content/docs/secrets.md
@@ -68,7 +68,19 @@ Use an integration only when its access boundary matches the deployment. Keep it
 
 Local secret state is kept under `$SIGNET_WORKSPACE/.secrets/`. Keep this directory private and out of source control. Secret values are intentionally not available through a `get` command; `signet secret get NAME` explains how to use an existing reference instead.
 
-Moving a workspace to a different machine or restoring it from backup is a security-sensitive operation. Verify the recovered secret provider state before restarting automation. Do not hand-copy ciphertext or reset secret files to troubleshoot a provider issue.
+New stores are keyring-first. Signet generates a random 256-bit master key and stores it as a generic credential named `ai.signet.secrets` in the current user account. The encrypted payload remains in `secrets.enc`, but the machine identifier is no longer used to protect new stores.
+
+The native adapter uses the platform user credential store:
+
+- macOS: Keychain Services.
+- Windows: user-scoped Credential Manager. Signet does not use a machine-wide DPAPI scope.
+- Linux: Secret Service through the user D-Bus session, such as GNOME Keyring or KWallet. Signet does not silently switch to the kernel keyring.
+
+The daemon never prompts for an unlock. A locked keyring is reported as a retryable `keyring-locked` condition and is not treated as missing credentials. An unavailable headless Linux keyring is distinct from an empty keyring. Existing local-first deployments can continue in the documented degraded compatibility mode when no native keyring is available. In that mode the current machine-id-derived encryption is used, a one-time warning is emitted, a persistent degraded health marker is written, and the store is not portable across machines. A locked or permission-denied keyring never triggers this fallback.
+
+Existing version-1 `secrets.enc` files migrate on first read or write after the native keyring becomes available. Signet validates the complete old store, writes or reuses the keyring master key, re-encrypts every entry into version 2, and atomically replaces the file. The keyring write happens before the file replacement, so an interrupted migration can be retried. Repeated access is idempotent. A version-2 file fails closed if its keyring item is missing or inaccessible; Signet never derives a replacement key for it.
+
+Moving a workspace to a different machine or restoring it from backup is a security-sensitive operation. Restoring only `secrets.enc` is not sufficient after migration. Restore the platform keychain or use an explicit recovery export/import flow when available. Verify the recovered secret provider state before restarting automation. Do not hand-copy ciphertext or reset secret files to troubleshoot a provider issue.
 
 ## API boundary
 


### PR DESCRIPTION
## Summary

Make the local secrets provider keyring-first. New stores use a random 256-bit master key in the platform-native user keyring, while existing v1 machine-id stores migrate in place with an atomic, idempotent rewrite.

## Changes

- Add an `@napi-rs/keyring` adapter for macOS Keychain, Windows Credential Manager, and Linux Secret Service.
- Add v2 native-keyring store metadata, strict 32-byte key validation, and typed locked/unavailable/permission states.
- Keep a clearly warned machine-id compatibility mode only when the native keyring is unavailable. Locked and permission-denied keyrings fail closed.
- Migrate v1 stores after keyring recovery and clear the degraded marker after successful migration.
- Preserve retryable keychain state through Git sync credential status handling.
- Add focused tests and document platform keychain backup and recovery requirements.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: daemon secrets documentation

## Screenshots

N/A. This PR has no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

The v1 encrypted file remains readable during migration. If migration is interrupted, the original file remains intact and the same keyring entry is reused on retry. Losing the platform keyring entry requires restoring the keychain backup or retaining the original v1 machine-id environment.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Targeted proof on the rebased branch:

- `bun test platform/daemon/src/secrets.test.ts`: 23 passed, 0 failed.
- `bun test platform/daemon/src/routes/git-sync.test.ts`: 16 passed, 0 failed.
- `bunx biome check platform/daemon/src/secrets.ts platform/daemon/src/secrets-keyring.ts platform/daemon/src/secrets.test.ts platform/daemon/src/routes/git-sync.ts`: passed.
- `bun run --filter '@signet/daemon' typecheck`: passed.
- `bun run --filter '@signet/daemon' build`: passed.
- Native Linux smoke test using `@napi-rs/keyring` against the user Secret Service: random credential set/get/delete round trip passed and cleanup succeeded.
- `git diff --check`: passed.

The full root `bun run typecheck` and `bun run lint` were also run. They currently fail on pre-existing connector type/export errors and unrelated repository-wide formatting/lint diagnostics outside this PR. No changed file is implicated by those failures.
