### PR TITLE
fix(release): preserve package manifest formatting

### DIFF
--- a/integrations/claude-code/connector/package.json
+++ b/integrations/claude-code/connector/package.json
@@ -1,57 +1,57 @@
 {
-  "name": "@signet/connector-claude-code",
-  "version": "0.200.27",
-  "description": "Signet connector for Claude Code (Anthropic CLI)",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
-  },
-  "files": [
-    "dist",
-    "bin",
-    "!dist/**/*.test.*",
-    "!dist/**/__tests__/**"
-  ],
-  "scripts": {
-    "build": "bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
-    "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
-    "dev": "bun --watch src/index.ts",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@signet/connector-base": "0.200.27",
-    "@signet/core": "0.200.27"
-  },
-  "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
-  },
-  "keywords": [
-    "signet",
-    "claude-code",
-    "claude",
-    "anthropic",
-    "connector",
-    "ai-memory"
-  ],
-  "license": "Apache-2.0",
-  "bin": {
-    "signet-connector-claude-code": "bin/install.js"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Signet-AI/signetai.git"
-  },
-  "homepage": "https://github.com/Signet-AI/signetai",
-  "bugs": {
-    "url": "https://github.com/Signet-AI/signetai/issues"
-  }
+	"name": "@signet/connector-claude-code",
+	"version": "0.200.27",
+	"description": "Signet connector for Claude Code (Anthropic CLI)",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"files": [
+		"dist",
+		"bin",
+		"!dist/**/*.test.*",
+		"!dist/**/__tests__/**"
+	],
+	"scripts": {
+		"build": "bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
+		"build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
+		"dev": "bun --watch src/index.ts",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@signet/connector-base": "0.200.27",
+		"@signet/core": "0.200.27"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"typescript": "^5.7.0"
+	},
+	"keywords": [
+		"signet",
+		"claude-code",
+		"claude",
+		"anthropic",
+		"connector",
+		"ai-memory"
+	],
+	"license": "Apache-2.0",
+	"bin": {
+		"signet-connector-claude-code": "bin/install.js"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Signet-AI/signetai.git"
+	},
+	"homepage": "https://github.com/Signet-AI/signetai",
+	"bugs": {
+		"url": "https://github.com/Signet-AI/signetai/issues"
+	}
 }

--- a/integrations/codex/connector/package.json
+++ b/integrations/codex/connector/package.json
@@ -1,56 +1,56 @@
 {
-  "name": "@signet/connector-codex",
-  "version": "0.200.27",
-  "description": "Signet connector for Codex CLI",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
-  },
-  "files": [
-    "dist",
-    "bin",
-    "!dist/**/*.test.*",
-    "!dist/**/__tests__/**"
-  ],
-  "scripts": {
-    "build": "bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
-    "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
-    "dev": "bun --watch src/index.ts",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@signet/connector-base": "0.200.27",
-    "@signet/core": "0.200.27"
-  },
-  "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
-  },
-  "keywords": [
-    "signet",
-    "codex",
-    "connector",
-    "ai-memory",
-    "agent-identity"
-  ],
-  "license": "Apache-2.0",
-  "bin": {
-    "signet-connector-codex": "bin/install.js"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Signet-AI/signetai.git"
-  },
-  "homepage": "https://github.com/Signet-AI/signetai",
-  "bugs": {
-    "url": "https://github.com/Signet-AI/signetai/issues"
-  }
+	"name": "@signet/connector-codex",
+	"version": "0.200.27",
+	"description": "Signet connector for Codex CLI",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"files": [
+		"dist",
+		"bin",
+		"!dist/**/*.test.*",
+		"!dist/**/__tests__/**"
+	],
+	"scripts": {
+		"build": "bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
+		"build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
+		"dev": "bun --watch src/index.ts",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@signet/connector-base": "0.200.27",
+		"@signet/core": "0.200.27"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"typescript": "^5.7.0"
+	},
+	"keywords": [
+		"signet",
+		"codex",
+		"connector",
+		"ai-memory",
+		"agent-identity"
+	],
+	"license": "Apache-2.0",
+	"bin": {
+		"signet-connector-codex": "bin/install.js"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Signet-AI/signetai.git"
+	},
+	"homepage": "https://github.com/Signet-AI/signetai",
+	"bugs": {
+		"url": "https://github.com/Signet-AI/signetai/issues"
+	}
 }

--- a/integrations/codex/plugin/package.json
+++ b/integrations/codex/plugin/package.json
@@ -1,39 +1,39 @@
 {
-  "name": "@signet/codex-plugin",
-  "version": "0.200.27",
-  "description": "Native Codex plugin installer for Signet",
-  "type": "module",
-  "bin": {
-    "signet-codex-plugin": "bin/install.js"
-  },
-  "files": [
-    "bin"
-  ],
-  "scripts": {
-    "test": "node bin/install.js --help >/dev/null"
-  },
-  "dependencies": {
-    "@signet/connector-base": "0.200.27",
-    "@signet/connector-codex": "0.200.27"
-  },
-  "keywords": [
-    "signet",
-    "codex",
-    "plugin",
-    "connector",
-    "ai-memory",
-    "agent-identity"
-  ],
-  "license": "Apache-2.0",
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Signet-AI/signetai.git"
-  },
-  "homepage": "https://github.com/Signet-AI/signetai",
-  "bugs": {
-    "url": "https://github.com/Signet-AI/signetai/issues"
-  }
+	"name": "@signet/codex-plugin",
+	"version": "0.200.27",
+	"description": "Native Codex plugin installer for Signet",
+	"type": "module",
+	"bin": {
+		"signet-codex-plugin": "bin/install.js"
+	},
+	"files": [
+		"bin"
+	],
+	"scripts": {
+		"test": "node bin/install.js --help >/dev/null"
+	},
+	"dependencies": {
+		"@signet/connector-base": "0.200.27",
+		"@signet/connector-codex": "0.200.27"
+	},
+	"keywords": [
+		"signet",
+		"codex",
+		"plugin",
+		"connector",
+		"ai-memory",
+		"agent-identity"
+	],
+	"license": "Apache-2.0",
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Signet-AI/signetai.git"
+	},
+	"homepage": "https://github.com/Signet-AI/signetai",
+	"bugs": {
+		"url": "https://github.com/Signet-AI/signetai/issues"
+	}
 }

--- a/integrations/forge/connector/package.json
+++ b/integrations/forge/connector/package.json
@@ -1,57 +1,57 @@
 {
-  "name": "@signet/connector-forge",
-  "version": "0.200.27",
-  "description": "Signet connector for ForgeCode - installs MCP, identity, and skills integration",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
-  },
-  "files": [
-    "dist",
-    "bin",
-    "!dist/**/*.test.*",
-    "!dist/**/__tests__/**"
-  ],
-  "scripts": {
-    "build": "bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
-    "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
-    "dev": "bun --watch src/index.ts",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@signet/connector-base": "0.200.27",
-    "@signet/core": "0.200.27"
-  },
-  "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
-  },
-  "keywords": [
-    "signet",
-    "forge",
-    "forgecode",
-    "connector",
-    "ai-memory",
-    "agent-identity"
-  ],
-  "license": "Apache-2.0",
-  "bin": {
-    "signet-connector-forge": "bin/install.js"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Signet-AI/signetai.git"
-  },
-  "homepage": "https://github.com/Signet-AI/signetai",
-  "bugs": {
-    "url": "https://github.com/Signet-AI/signetai/issues"
-  }
+	"name": "@signet/connector-forge",
+	"version": "0.200.27",
+	"description": "Signet connector for ForgeCode - installs MCP, identity, and skills integration",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"files": [
+		"dist",
+		"bin",
+		"!dist/**/*.test.*",
+		"!dist/**/__tests__/**"
+	],
+	"scripts": {
+		"build": "bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
+		"build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
+		"dev": "bun --watch src/index.ts",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@signet/connector-base": "0.200.27",
+		"@signet/core": "0.200.27"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"typescript": "^5.7.0"
+	},
+	"keywords": [
+		"signet",
+		"forge",
+		"forgecode",
+		"connector",
+		"ai-memory",
+		"agent-identity"
+	],
+	"license": "Apache-2.0",
+	"bin": {
+		"signet-connector-forge": "bin/install.js"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Signet-AI/signetai.git"
+	},
+	"homepage": "https://github.com/Signet-AI/signetai",
+	"bugs": {
+		"url": "https://github.com/Signet-AI/signetai/issues"
+	}
 }

--- a/integrations/gemini/connector/package.json
+++ b/integrations/gemini/connector/package.json
@@ -1,56 +1,56 @@
 {
-  "name": "@signet/connector-gemini",
-  "version": "0.200.27",
-  "description": "Signet connector for Gemini CLI",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
-  },
-  "files": [
-    "dist",
-    "bin",
-    "!dist/**/*.test.*",
-    "!dist/**/__tests__/**"
-  ],
-  "scripts": {
-    "build": "bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
-    "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
-    "dev": "bun --watch src/index.ts",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@signet/connector-base": "0.200.27",
-    "@signet/core": "0.200.27"
-  },
-  "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
-  },
-  "keywords": [
-    "signet",
-    "gemini",
-    "connector",
-    "ai-memory",
-    "agent-identity"
-  ],
-  "license": "Apache-2.0",
-  "bin": {
-    "signet-connector-gemini": "bin/install.js"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Signet-AI/signetai.git"
-  },
-  "homepage": "https://github.com/Signet-AI/signetai",
-  "bugs": {
-    "url": "https://github.com/Signet-AI/signetai/issues"
-  }
+	"name": "@signet/connector-gemini",
+	"version": "0.200.27",
+	"description": "Signet connector for Gemini CLI",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"files": [
+		"dist",
+		"bin",
+		"!dist/**/*.test.*",
+		"!dist/**/__tests__/**"
+	],
+	"scripts": {
+		"build": "bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
+		"build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
+		"dev": "bun --watch src/index.ts",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@signet/connector-base": "0.200.27",
+		"@signet/core": "0.200.27"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"typescript": "^5.7.0"
+	},
+	"keywords": [
+		"signet",
+		"gemini",
+		"connector",
+		"ai-memory",
+		"agent-identity"
+	],
+	"license": "Apache-2.0",
+	"bin": {
+		"signet-connector-gemini": "bin/install.js"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Signet-AI/signetai.git"
+	},
+	"homepage": "https://github.com/Signet-AI/signetai",
+	"bugs": {
+		"url": "https://github.com/Signet-AI/signetai/issues"
+	}
 }

--- a/integrations/hermes-agent/connector/package.json
+++ b/integrations/hermes-agent/connector/package.json
@@ -1,59 +1,59 @@
 {
-  "name": "@signet/connector-hermes-agent",
-  "version": "0.200.27",
-  "description": "Signet connector for Hermes Agent — installs Signet as a pluggable memory provider",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
-  },
-  "files": [
-    "dist",
-    "hermes-plugin",
-    "bin",
-    "!dist/**/*.test.*",
-    "!dist/**/__tests__/**"
-  ],
-  "scripts": {
-    "build": "bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
-    "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
-    "dev": "bun --watch src/index.ts",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@signet/connector-base": "0.200.27",
-    "@signet/core": "0.200.27"
-  },
-  "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
-  },
-  "keywords": [
-    "signet",
-    "hermes",
-    "hermes-agent",
-    "connector",
-    "ai-memory",
-    "agent-identity",
-    "memory-provider"
-  ],
-  "license": "Apache-2.0",
-  "bin": {
-    "signet-connector-hermes-agent": "bin/install.js"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Signet-AI/signetai.git"
-  },
-  "homepage": "https://github.com/Signet-AI/signetai",
-  "bugs": {
-    "url": "https://github.com/Signet-AI/signetai/issues"
-  }
+	"name": "@signet/connector-hermes-agent",
+	"version": "0.200.27",
+	"description": "Signet connector for Hermes Agent — installs Signet as a pluggable memory provider",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"files": [
+		"dist",
+		"hermes-plugin",
+		"bin",
+		"!dist/**/*.test.*",
+		"!dist/**/__tests__/**"
+	],
+	"scripts": {
+		"build": "bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
+		"build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
+		"dev": "bun --watch src/index.ts",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@signet/connector-base": "0.200.27",
+		"@signet/core": "0.200.27"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"typescript": "^5.7.0"
+	},
+	"keywords": [
+		"signet",
+		"hermes",
+		"hermes-agent",
+		"connector",
+		"ai-memory",
+		"agent-identity",
+		"memory-provider"
+	],
+	"license": "Apache-2.0",
+	"bin": {
+		"signet-connector-hermes-agent": "bin/install.js"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Signet-AI/signetai.git"
+	},
+	"homepage": "https://github.com/Signet-AI/signetai",
+	"bugs": {
+		"url": "https://github.com/Signet-AI/signetai/issues"
+	}
 }

--- a/integrations/oh-my-pi/connector/package.json
+++ b/integrations/oh-my-pi/connector/package.json
@@ -1,57 +1,57 @@
 {
-  "name": "@signet/connector-oh-my-pi",
-  "version": "0.200.27",
-  "description": "Signet connector for Oh My Pi",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
-  },
-  "files": [
-    "dist",
-    "bin",
-    "!dist/**/*.test.*",
-    "!dist/**/__tests__/**"
-  ],
-  "scripts": {
-    "build": "bun run build:bundle",
-    "build:bundle": "bun scripts/embed-extension.ts && bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
-    "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
-    "dev": "bun --watch src/index.ts",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@signet/connector-base": "0.200.27",
-    "@signet/core": "0.200.27"
-  },
-  "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
-  },
-  "keywords": [
-    "signet",
-    "oh-my-pi",
-    "connector",
-    "lifecycle",
-    "agent"
-  ],
-  "license": "Apache-2.0",
-  "bin": {
-    "signet-connector-oh-my-pi": "bin/install.js"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Signet-AI/signetai.git"
-  },
-  "homepage": "https://github.com/Signet-AI/signetai",
-  "bugs": {
-    "url": "https://github.com/Signet-AI/signetai/issues"
-  }
+	"name": "@signet/connector-oh-my-pi",
+	"version": "0.200.27",
+	"description": "Signet connector for Oh My Pi",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"files": [
+		"dist",
+		"bin",
+		"!dist/**/*.test.*",
+		"!dist/**/__tests__/**"
+	],
+	"scripts": {
+		"build": "bun run build:bundle",
+		"build:bundle": "bun scripts/embed-extension.ts && bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
+		"build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
+		"dev": "bun --watch src/index.ts",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@signet/connector-base": "0.200.27",
+		"@signet/core": "0.200.27"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"typescript": "^5.7.0"
+	},
+	"keywords": [
+		"signet",
+		"oh-my-pi",
+		"connector",
+		"lifecycle",
+		"agent"
+	],
+	"license": "Apache-2.0",
+	"bin": {
+		"signet-connector-oh-my-pi": "bin/install.js"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Signet-AI/signetai.git"
+	},
+	"homepage": "https://github.com/Signet-AI/signetai",
+	"bugs": {
+		"url": "https://github.com/Signet-AI/signetai/issues"
+	}
 }

--- a/integrations/openclaw/connector/package.json
+++ b/integrations/openclaw/connector/package.json
@@ -1,58 +1,58 @@
 {
-  "name": "@signet/connector-openclaw",
-  "version": "0.200.27",
-  "description": "Signet connector for OpenClaw - configures workspace and memory hooks",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
-  },
-  "files": [
-    "dist",
-    "bin",
-    "!dist/**/*.test.*",
-    "!dist/**/__tests__/**"
-  ],
-  "scripts": {
-    "build": "bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
-    "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
-    "dev": "bun --watch src/index.ts",
-    "typecheck": "tsc --noEmit",
-    "test": "bun test"
-  },
-  "dependencies": {
-    "@signet/connector-base": "0.200.27",
-    "@signet/core": "0.200.27"
-  },
-  "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
-  },
-  "keywords": [
-    "signet",
-    "openclaw",
-    "clawdbot",
-    "connector",
-    "ai-memory",
-    "agent-identity"
-  ],
-  "license": "Apache-2.0",
-  "bin": {
-    "signet-connector-openclaw": "bin/install.js"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Signet-AI/signetai.git"
-  },
-  "homepage": "https://github.com/Signet-AI/signetai",
-  "bugs": {
-    "url": "https://github.com/Signet-AI/signetai/issues"
-  }
+	"name": "@signet/connector-openclaw",
+	"version": "0.200.27",
+	"description": "Signet connector for OpenClaw - configures workspace and memory hooks",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"files": [
+		"dist",
+		"bin",
+		"!dist/**/*.test.*",
+		"!dist/**/__tests__/**"
+	],
+	"scripts": {
+		"build": "bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
+		"build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
+		"dev": "bun --watch src/index.ts",
+		"typecheck": "tsc --noEmit",
+		"test": "bun test"
+	},
+	"dependencies": {
+		"@signet/connector-base": "0.200.27",
+		"@signet/core": "0.200.27"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"typescript": "^5.7.0"
+	},
+	"keywords": [
+		"signet",
+		"openclaw",
+		"clawdbot",
+		"connector",
+		"ai-memory",
+		"agent-identity"
+	],
+	"license": "Apache-2.0",
+	"bin": {
+		"signet-connector-openclaw": "bin/install.js"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Signet-AI/signetai.git"
+	},
+	"homepage": "https://github.com/Signet-AI/signetai",
+	"bugs": {
+		"url": "https://github.com/Signet-AI/signetai/issues"
+	}
 }

--- a/integrations/opencode/connector/package.json
+++ b/integrations/opencode/connector/package.json
@@ -1,58 +1,58 @@
 {
-  "name": "@signet/connector-opencode",
-  "version": "0.200.27",
-  "description": "Signet connector for OpenCode - installs hooks and generates config",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
-  },
-  "files": [
-    "dist",
-    "bin",
-    "!dist/**/*.test.*",
-    "!dist/**/__tests__/**"
-  ],
-  "scripts": {
-    "build": "bun run build:bundle",
-    "build:bundle": "bun scripts/embed-plugin.ts && bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
-    "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
-    "dev": "bun --watch src/index.ts",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@signet/connector-base": "0.200.27",
-    "@signet/core": "0.200.27",
-    "jsonc-parser": "3.3.1"
-  },
-  "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
-  },
-  "keywords": [
-    "signet",
-    "opencode",
-    "connector",
-    "ai-memory",
-    "agent-identity"
-  ],
-  "license": "Apache-2.0",
-  "bin": {
-    "signet-connector-opencode": "bin/install.js"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Signet-AI/signetai.git"
-  },
-  "homepage": "https://github.com/Signet-AI/signetai",
-  "bugs": {
-    "url": "https://github.com/Signet-AI/signetai/issues"
-  }
+	"name": "@signet/connector-opencode",
+	"version": "0.200.27",
+	"description": "Signet connector for OpenCode - installs hooks and generates config",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"files": [
+		"dist",
+		"bin",
+		"!dist/**/*.test.*",
+		"!dist/**/__tests__/**"
+	],
+	"scripts": {
+		"build": "bun run build:bundle",
+		"build:bundle": "bun scripts/embed-plugin.ts && bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
+		"build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
+		"dev": "bun --watch src/index.ts",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@signet/connector-base": "0.200.27",
+		"@signet/core": "0.200.27",
+		"jsonc-parser": "3.3.1"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"typescript": "^5.7.0"
+	},
+	"keywords": [
+		"signet",
+		"opencode",
+		"connector",
+		"ai-memory",
+		"agent-identity"
+	],
+	"license": "Apache-2.0",
+	"bin": {
+		"signet-connector-opencode": "bin/install.js"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Signet-AI/signetai.git"
+	},
+	"homepage": "https://github.com/Signet-AI/signetai",
+	"bugs": {
+		"url": "https://github.com/Signet-AI/signetai/issues"
+	}
 }

--- a/integrations/pi/connector/package.json
+++ b/integrations/pi/connector/package.json
@@ -1,57 +1,57 @@
 {
-  "name": "@signet/connector-pi",
-  "version": "0.200.27",
-  "description": "Signet connector for pi",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
-  },
-  "files": [
-    "dist",
-    "bin",
-    "!dist/**/*.test.*",
-    "!dist/**/__tests__/**"
-  ],
-  "scripts": {
-    "build": "bun run build:bundle",
-    "build:bundle": "bun scripts/embed-extension.ts && bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
-    "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
-    "dev": "bun --watch src/index.ts",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@signet/connector-base": "0.200.27",
-    "@signet/core": "0.200.27"
-  },
-  "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
-  },
-  "keywords": [
-    "signet",
-    "pi",
-    "connector",
-    "lifecycle",
-    "agent"
-  ],
-  "license": "Apache-2.0",
-  "bin": {
-    "signet-connector-pi": "bin/install.js"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Signet-AI/signetai.git"
-  },
-  "homepage": "https://github.com/Signet-AI/signetai",
-  "bugs": {
-    "url": "https://github.com/Signet-AI/signetai/issues"
-  }
+	"name": "@signet/connector-pi",
+	"version": "0.200.27",
+	"description": "Signet connector for pi",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"files": [
+		"dist",
+		"bin",
+		"!dist/**/*.test.*",
+		"!dist/**/__tests__/**"
+	],
+	"scripts": {
+		"build": "bun run build:bundle",
+		"build:bundle": "bun scripts/embed-extension.ts && bun build src/index.ts --outdir dist --target node --external better-sqlite3 && bun run build:types",
+		"build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
+		"dev": "bun --watch src/index.ts",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@signet/connector-base": "0.200.27",
+		"@signet/core": "0.200.27"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"typescript": "^5.7.0"
+	},
+	"keywords": [
+		"signet",
+		"pi",
+		"connector",
+		"lifecycle",
+		"agent"
+	],
+	"license": "Apache-2.0",
+	"bin": {
+		"signet-connector-pi": "bin/install.js"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Signet-AI/signetai.git"
+	},
+	"homepage": "https://github.com/Signet-AI/signetai",
+	"bugs": {
+		"url": "https://github.com/Signet-AI/signetai/issues"
+	}
 }

--- a/libs/connector-base/package.json
+++ b/libs/connector-base/package.json
@@ -1,55 +1,55 @@
 {
-  "name": "@signet/connector-base",
-  "version": "0.200.27",
-  "description": "Base class for Signet harness connectors",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    },
-    "./lenient-json": {
-      "import": "./dist/lenient-json.js",
-      "types": "./dist/lenient-json.d.ts"
-    }
-  },
-  "files": [
-    "dist",
-    "!dist/**/*.test.*",
-    "!dist/**/__tests__/**"
-  ],
-  "scripts": {
-    "build": "bun build ./src/index.ts ./src/lenient-json.ts --outdir ./dist --target node --external better-sqlite3 && bun run build:types",
-    "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@signet/core": "0.200.27",
-    "json5": "^2.2.3",
-    "jsonc-parser": "3.3.1"
-  },
-  "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
-  },
-  "keywords": [
-    "signet",
-    "connector",
-    "ai",
-    "agent"
-  ],
-  "license": "Apache-2.0",
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Signet-AI/signetai.git"
-  },
-  "homepage": "https://github.com/Signet-AI/signetai",
-  "bugs": {
-    "url": "https://github.com/Signet-AI/signetai/issues"
-  }
+	"name": "@signet/connector-base",
+	"version": "0.200.27",
+	"description": "Base class for Signet harness connectors",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		},
+		"./lenient-json": {
+			"import": "./dist/lenient-json.js",
+			"types": "./dist/lenient-json.d.ts"
+		}
+	},
+	"files": [
+		"dist",
+		"!dist/**/*.test.*",
+		"!dist/**/__tests__/**"
+	],
+	"scripts": {
+		"build": "bun build ./src/index.ts ./src/lenient-json.ts --outdir ./dist --target node --external better-sqlite3 && bun run build:types",
+		"build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@signet/core": "0.200.27",
+		"json5": "^2.2.3",
+		"jsonc-parser": "3.3.1"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"typescript": "^5.7.0"
+	},
+	"keywords": [
+		"signet",
+		"connector",
+		"ai",
+		"agent"
+	],
+	"license": "Apache-2.0",
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Signet-AI/signetai.git"
+	},
+	"homepage": "https://github.com/Signet-AI/signetai",
+	"bugs": {
+		"url": "https://github.com/Signet-AI/signetai/issues"
+	}
 }

--- a/scripts/version-sync.test.ts
+++ b/scripts/version-sync.test.ts
@@ -37,7 +37,7 @@ dependencies = [
 		expect(findCargoLockPackageVersion(lock, "signet-native")).toBeNull();
 	});
 
-	test("resolves publishable runtime workspace protocols and exact internal pins without rewriting dev-only links", () => {
+	test("resolves publishable runtime workspace protocols without rewriting dev-only links or breaking Biome formatting", () => {
 		const root = mkdtempSync(join(tmpdir(), "signet-version-sync-publish-"));
 		try {
 			const coreManifest = join(root, "core.package.json");
@@ -72,6 +72,7 @@ dependencies = [
 			);
 
 			expect(resolveWorkspaceProtocols([coreManifest, manifest], "0.115.2", false)).toEqual([manifest]);
+			expect(readFileSync(manifest, "utf8").startsWith('{\n	"name"')).toBe(true);
 			const updated = JSON.parse(readFileSync(manifest, "utf8")) as {
 				dependencies: Record<string, string>;
 				optionalDependencies: Record<string, string>;
@@ -112,6 +113,7 @@ dependencies = [
 			);
 
 			expect(syncSignetNativeOptionalDependencies("0.115.2", false, manifest)).toEqual([manifest]);
+			expect(readFileSync(manifest, "utf8").startsWith('{\n	"name"')).toBe(true);
 			const updated = JSON.parse(readFileSync(manifest, "utf8")) as {
 				optionalDependencies: Record<string, string>;
 			};

--- a/scripts/version-sync.ts
+++ b/scripts/version-sync.ts
@@ -239,6 +239,10 @@ function isPublishablePackage(pkg: Record<string, unknown>): boolean {
 	);
 }
 
+function stringifyPackageJson(pkg: Record<string, unknown>): string {
+	return `${JSON.stringify(pkg, null, "	")}\n`;
+}
+
 export function resolveWorkspaceProtocols(files: readonly string[], version: string, checkOnly: boolean): string[] {
 	const packageJsonByFile = new Map<string, Record<string, unknown>>();
 	const publishablePackageNames = new Set<string>();
@@ -280,7 +284,7 @@ export function resolveWorkspaceProtocols(files: readonly string[], version: str
 		}
 		if (changed) {
 			if (!checkOnly) {
-				writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`);
+				writeFileSync(file, stringifyPackageJson(pkg));
 			}
 			patched.push(file);
 		}
@@ -310,7 +314,7 @@ export function syncSignetNativeOptionalDependencies(
 
 	if (!changed) return [];
 	if (!checkOnly) {
-		writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`);
+		writeFileSync(file, stringifyPackageJson(pkg));
 	}
 	return [file];
 }


### PR DESCRIPTION
## Summary

Fixes the release-tooling regression that reformatted 11 publishable connector manifests with spaces during 0.200.27 version sync. The current `origin/main` Biome gate now passes with the affected manifests restored to the repository's tab formatting.

## Changes

- Added a shared package-manifest serializer in `scripts/version-sync.ts` that writes JSON with tab indentation.
- Applied it to workspace protocol resolution and native optional-dependency synchronization.
- Added regression assertions covering Biome-compatible output from both write paths.
- Reformatted the 11 manifests emitted incorrectly by the 0.200.27 release tooling.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: release version-sync tooling and package manifests

## Screenshots

Not applicable. No UI behavior is changed.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No database migration is included.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused proof:

- `bun test scripts/version-sync.test.ts scripts/biome-baseline-contract.test.ts`: 7 passed, 0 failed.
- `bun run --filter '@signet/core' build`: passed.
- `bun run --filter '@signet/connector-base' build`: passed.
- Embedded connector prerequisite builds for Pi, Oh My Pi, and OpenCode: passed.
- `bun run typecheck`: passed for all workspaces.
- `bun run lint`: passed. The current baseline still reports 643 warnings and 57 infos, but no errors.
- `bun scripts/version-sync.ts --check`: passed with all versions aligned at 0.200.27.
- `git diff --check`: passed.

The full test suite was not run. This change is limited to release manifest serialization and its regression coverage.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Root cause: `resolveWorkspaceProtocols` used `JSON.stringify(pkg, null, 2)` after replacing publish-time workspace dependency specs. The 0.200.27 release exercised that path for exactly 11 publishable connector manifests, converting repository-standard tab indentation to spaces. The fix changes the generator rather than maintaining a one-off output-only workaround, and the existing 11 release artifacts are normalized in this PR.

This is the baseline repair needed before work such as #1540 can merge cleanly against the required Biome gate. No data queries, endpoints, migrations, or runtime behavior changed.
