### PR TITLE
docs(harnesses): add Kimi Code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Signet runs underneath the tools you already use. Run `signet setup` to configur
 |[OpenCode](https://github.com/sst/opencode)|Plugin|
 |[OpenClaw](https://github.com/openclaw/openclaw)|Plugin|
 |[Codex](https://github.com/openai/codex)|Hooks + MCP|
+|[Kimi Code](https://github.com/MoonshotAI/kimi-cli)|Hooks + MCP / ACPX|
 |[Hermes Agent](https://github.com/NousResearch/hermes-agent)|Memory provider plugin|
 |[Pi](https://github.com/mariozechner/pi-coding-agent)|Extension|
 |Oh My Pi|Extension|
@@ -154,7 +155,7 @@ Requirements:
 - Bun for normal repo development
 - Node.js 18+ for Node-targeted package surfaces
 - macOS or Linux
-- Optional for harness integrations: Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, Pi, Oh My Pi, or Hermes Agent
+- Optional for harness integrations: Claude Code, Codex, Kimi Code, OpenCode, OpenClaw, Gemini CLI, Pi, Oh My Pi, or Hermes Agent
 
 ## Contributing
 

--- a/docs/ACP-INTEGRATION.md
+++ b/docs/ACP-INTEGRATION.md
@@ -25,7 +25,7 @@ Terminology
   sessions: prompts, session lifecycle, cancellation, permissions, and
   capability exchange.
 - **ACPX** is the CLI/runtime Signet uses to drive ACP-capable harnesses such
-  as Codex, Claude Code, OpenCode, OpenClaw, Gemini, and others.
+  as Codex, Claude Code, OpenCode, OpenClaw, Gemini, Kimi Code, and others.
 - **Signet inference routing** is Signet's daemon-owned control plane for
   choosing a target/model for workloads such as memory extraction and session
   synthesis.
@@ -245,7 +245,8 @@ field is not a setup marker and is rejected if it remains after migration.
 
 ACPX needs an agent, model, hook mode, permission mode, timeout, and workload
 binding. Those belong in top-level `inference:` routing. Keep the generated
-`inference.targets.*.executor: acpx` block, or write one manually.
+`inference.targets.*.executor: acpx` block, or write one manually. For Kimi
+Code, set `acpx.agent: kimi`.
 
 This is different from old direct providers:
 

--- a/web/docs/astro.config.mjs
+++ b/web/docs/astro.config.mjs
@@ -184,7 +184,7 @@ export default defineConfig({
 							items: [
 								{ label: "Overview", slug: "harnesses" },
 								{ label: "Claude Code", slug: "harnesses/claude-code" },
-								{ label: "Kimi CLI", slug: "harnesses/kimi" },
+								{ label: "Kimi Code", slug: "harnesses/kimi" },
 								{ label: "Codex", slug: "harnesses/codex" },
 								{ label: "OpenCode", slug: "harnesses/opencode" },
 								{ label: "Oh My Pi", slug: "harnesses/oh-my-pi" },

--- a/web/docs/src/content/docs/ai-memory-hermes-openclaw.md
+++ b/web/docs/src/content/docs/ai-memory-hermes-openclaw.md
@@ -11,7 +11,8 @@ memory for Hermes Agent and OpenClaw.
 Signet runs a local daemon, stores memory in SQLite, exposes MCP and HTTP
 APIs, and installs harness-specific adapters so the same agent identity,
 memory, secrets, and skills can follow you across Hermes Agent, OpenClaw,
-Claude Code, OpenCode, Codex, Gemini CLI, Pi, Oh My Pi, and other harnesses.
+Claude Code, OpenCode, Codex, Kimi Code, Gemini CLI, Pi, Oh My Pi, and other
+harnesses.
 
 ## Short Answer
 

--- a/web/docs/src/content/docs/architecture/platform-services.md
+++ b/web/docs/src/content/docs/architecture/platform-services.md
@@ -77,7 +77,7 @@ until a snapshot is requested.
 
 The connector framework manages external data source integrations that
 push documents and memories into the [Pipeline](/pipeline/). It is distinct from the
-[harness connector packages](/harnesses/) (claude-code, opencode, openclaw, oh-my-pi, pi) — those
+[harness connector packages](/harnesses/) (claude-code, codex, kimi, opencode, openclaw, oh-my-pi, pi) — those
 handle platform hook installation; this framework handles ongoing sync.
 
 **Registry** (`connectors/registry.ts`): CRUD operations on the

--- a/web/docs/src/content/docs/cli/getting-started.md
+++ b/web/docs/src/content/docs/cli/getting-started.md
@@ -86,7 +86,7 @@ A `--file` or `--json` plan is for fresh setup. It does not carry credentials fo
 | `--remote-url <url>` | Use a bare remote daemon origin instead of starting a local daemon. |
 | `--deployment-type local|vps|server` | Adjust non-interactive inferred defaults only. |
 
-Current setup accepts `claude-code`, `codex`, `opencode`, `forge`, `openclaw`, `oh-my-pi`, `pi`, `hermes-agent`, and `gemini` harness names. For OpenClaw, `--openclaw-runtime-path plugin|legacy` selects its integration path and `--configure-openclaw-workspace` opts into patching discovered configurations.
+Current setup accepts `claude-code`, `codex`, `kimi`, `opencode`, `forge`, `openclaw`, `oh-my-pi`, `pi`, `hermes-agent`, and `gemini` harness names. Kimi uses the ACPX agent name `kimi`. For OpenClaw, `--openclaw-runtime-path plugin|legacy` selects its integration path and `--configure-openclaw-workspace` opts into patching discovered configurations.
 
 ### Inference and search flags
 

--- a/web/docs/src/content/docs/harnesses.md
+++ b/web/docs/src/content/docs/harnesses.md
@@ -63,8 +63,8 @@ Degraded mode rules:
 
 - [Claude Code](/harnesses/claude-code/)
   Connect Signet to Claude Code.
-- [Kimi CLI](/harnesses/kimi/)
-  Connect Signet to Kimi CLI through ACPX and lifecycle hooks.
+- [Kimi Code (Kimi CLI)](/harnesses/kimi/)
+  Connect Signet to Kimi Code through ACPX, MCP, and lifecycle hooks.
 - [Codex](/harnesses/codex/)
   Connect Signet to Codex.
 - [OpenCode](/harnesses/opencode/)

--- a/web/docs/src/content/docs/harnesses/kimi.md
+++ b/web/docs/src/content/docs/harnesses/kimi.md
@@ -1,25 +1,25 @@
 ---
-title: "Kimi CLI"
-description: "Connect Signet to Kimi CLI through ACPX and lifecycle hooks."
+title: "Kimi Code (Kimi CLI)"
+description: "Connect Signet to Kimi Code through ACPX, MCP, and lifecycle hooks."
 ---
 
-Signet can configure Kimi CLI as an ACPX harness and install lifecycle hooks for session continuity.
+Signet can configure Kimi Code as an ACPX harness and install lifecycle hooks for session continuity.
 
 ## Setup
 
-Select Kimi CLI in the interactive wizard, or run:
+Select Kimi Code in the interactive wizard, or run:
 
 ```bash
 signet setup --harness kimi
 ```
 
-The connector writes Signet-managed entries to the Kimi `config.toml` hook array and merges the Signet MCP server into `mcp.json`. It preserves unrelated TOML sections, user hooks, and other MCP servers. Re-running setup refreshes only Signet-owned entries.
+The connector writes Signet-managed entries to the Kimi `config.toml` hook array, merges the Signet MCP server into `mcp.json`, and links the workspace skills directory into the selected Kimi home. It preserves unrelated TOML sections, user hooks, and other MCP servers. Re-running setup refreshes only Signet-owned entries.
 
-Kimi CLI normally uses `~/.kimi`. Signet also recognizes the legacy `~/.kimi-code` home. `KIMI_SHARE_DIR` and `KIMI_CODE_HOME` can select an explicit home for setup and detection.
+Kimi Code normally uses `~/.kimi`. Signet also recognizes the legacy `~/.kimi-code` home. `KIMI_SHARE_DIR` and `KIMI_CODE_HOME` can select an explicit home for setup and detection.
 
 ## ACPX authentication
 
-Signet routes Kimi inference through ACPX with the `kimi` agent name. Kimi's ACP service still requires its own authentication. If ACPX reports `Authentication required`, authenticate Kimi first and retry the route.
+Signet routes background inference through ACPX with `executor: acpx` and `acpx.agent: kimi`. Kimi's ACP service still requires its own authentication. If ACPX reports `Authentication required`, authenticate Kimi first and retry the route.
 
 The Kimi connector does not write API keys into `config.toml`, hook commands, or `mcp.json`. Remote daemon values are passed through the existing Signet hook environment contract.
 
@@ -35,4 +35,4 @@ Kimi hook commands receive their payload on standard input. Manage identity and 
 
 ## Remove the integration
 
-Run setup again without Kimi selected, or use the connector uninstall command exposed by the connector tooling. Uninstall removes only Signet-owned hooks, the Signet MCP entry, and the Signet skills link.
+Run setup again without Kimi selected, or use the connector uninstall command exposed by the connector tooling. Uninstall removes only Signet-owned hooks, the Signet MCP entry, and the Signet skills link. Kimi is supported for setup, hooks, MCP, and ACPX inference. It is not currently a scheduled-task harness.

--- a/web/docs/src/content/docs/hooks.md
+++ b/web/docs/src/content/docs/hooks.md
@@ -72,6 +72,7 @@ If no messages are unread, the endpoint returns `{ "inject": "" }`. Unsupported 
 |---------|---------------------------|
 | Claude Code | `SessionStart`, `UserPromptSubmit`, `PreToolUse` |
 | Codex | `SessionStart`, `UserPromptSubmit`, `PreToolUse` |
+| Kimi Code | `SessionStart`, `UserPromptSubmit`, `SessionEnd` |
 | OpenCode | `chat.message`, `tool.execute.before`, `experimental.chat.system.transform`, `experimental.chat.messages.transform` |
 | OpenClaw | `message_received`, `before_tool_call`, `before_prompt_build`, `before_agent_start` |
 | pi | `context` |

--- a/web/docs/src/content/docs/mcp.md
+++ b/web/docs/src/content/docs/mcp.md
@@ -713,6 +713,27 @@ The OpenCode connector registers the MCP server in
 This coexists with the plugin (`plugins/signet.mjs`) — the plugin handles
 lifecycle hooks, MCP handles on-demand tool calls.
 
+### Kimi Code
+
+The Kimi connector registers the Signet MCP server in the selected Kimi home,
+normally `~/.kimi/mcp.json` (or the legacy `~/.kimi-code/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "signet": {
+      "command": "signet-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+Install it with `signet setup --harness kimi` or
+`signet connector install kimi`. Kimi lifecycle hooks remain in
+`config.toml`; see [Kimi Code](/harnesses/kimi/) for the hook events and home
+directory environment overrides.
+
 ### OpenClaw
 
 OpenClaw uses the `@signetai/adapter-openclaw` runtime plugin, which already


### PR DESCRIPTION
## Summary

Document Kimi Code as a supported Signet harness now that Phase 1 is merged on main. The docs describe the shipped setup, lifecycle hooks, MCP registration, and ACPX routing without claiming scheduled-task support.

## Changes

- Add Kimi Code to the README harness table and optional integration requirements.
- Update the harness index and Kimi Code page with current setup commands, config homes, hook events, MCP registration, and ACPX authentication/routing details.
- Add Kimi to the CLI setup harness list, hooks compatibility matrix, architecture connector list, MCP per-harness configuration, and ACPX architecture notes.
- Add Kimi Code to the cross-harness overview.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [x] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [x] `@signet/web`
- [ ] `predictor`
- [x] Other: `@signet/docs`, README, `docs/ACP-INTEGRATION.md`

## Screenshots

N/A. Documentation-only change.

## PR Readiness (MANDATORY)

- [ ] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [ ] Agent scoping verified on all new/changed data queries
- [ ] Input/config validation and bounds checks added
- [ ] Error handling and fallback paths tested (no silent swallow)
- [ ] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [ ] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused proof:

- `bun run validate:content` from `web/docs`: validated 91 public docs pages and 91 routes.
- `bun run check` from `web/docs`: Astro check completed with 0 errors, 0 warnings, and 0 hints.
- `bun run build` from `web/docs`: Astro static build completed with 93 pages, including `/harnesses/kimi/`.
- `bun run typecheck`: all workspace typechecks passed.
- `bun run --filter '@signet/connector-kimi' build && bun run --filter '@signet/connector-kimi' typecheck`: passed.
- `bun test integrations/kimi/connector/src/config-toml.test.ts surfaces/cli/src/features/setup-pipeline.test.ts`: 46 passed, 0 failed.
- `bun run format:check -- README.md docs/ACP-INTEGRATION.md web/docs/src/content/docs/ai-memory-hermes-openclaw.md web/docs/src/content/docs/architecture/platform-services.md web/docs/src/content/docs/cli/getting-started.md web/docs/src/content/docs/harnesses.md web/docs/src/content/docs/harnesses/kimi.md web/docs/src/content/docs/hooks.md web/docs/src/content/docs/mcp.md`: passed.
- `git diff --check`: passed.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The merged Phase 1 connector was verified from `integrations/kimi/connector`: setup patches `config.toml` with `SessionStart`, `UserPromptSubmit`, and `SessionEnd` hooks, registers a stdio `mcpServers.signet` entry in `mcp.json`, preserves unrelated config, and links skills. Setup code generates an ACPX target with agent `kimi`. Scheduled tasks remain limited to the existing `TASK_HARNESSES` set, so the docs explicitly do not claim Kimi task-runner support.

A full root `bun run build` was attempted after dependency installation and stopped in the unrelated SDK build at the missing `platform/core/node_modules/better-sqlite3` path. The docs build, full typecheck, Kimi package build/typecheck, focused Kimi/setup tests, and formatting checks all pass.

The remaining unchecked PR Readiness items are not applicable to this documentation-only change. The repository-approved `checklist-exception` label is applied for the N/A data-query, validation, endpoint-security, error-path, and regression-test items.

