### PR TITLE
fix(dreaming): count full evidence backlog

### DIFF
--- a/platform/daemon/src/episodic-sources.ts
+++ b/platform/daemon/src/episodic-sources.ts
@@ -795,8 +795,9 @@ export function findEpisodicSourceAgentIds(db: ReadDb, from: string): readonly s
  *
  * This belongs beside the canonical cross-store reader so every Dreaming
  * caller uses the same provenance, deletion, and source-native boundaries.
- * It deliberately returns complete source records: callers bound the number
- * of matches, never by truncating the evidence a model may cite.
+ * It deliberately returns complete source records. Ordinary callers bound the
+ * number of matches, while aggregate metrics may request the complete set;
+ * neither path truncates the evidence a model may cite.
  */
 export function searchEpisodicSources(
 	db: ReadDb,
@@ -808,11 +809,12 @@ export function searchEpisodicSources(
 		readonly kind?: "memory" | "artifact" | "transcript" | "summary";
 		/** Scan-first delivery drains only records whose current revision is not complete. */
 		readonly excludeDelivered?: boolean;
-		readonly limit?: number;
+		/** `null` requests the complete matching set instead of a bounded page. */
+		readonly limit?: number | null;
 	},
 ): EpisodicSourceRecord[] {
 	const query = params.query.trim();
-	const limit = Math.max(1, Math.min(Math.floor(params.limit ?? 20), 50));
+	const limit = params.limit === null ? null : Math.max(1, Math.min(Math.floor(params.limit ?? 20), 50));
 	const like = `%${query}%`;
 	// An empty query still lists recent sources (runbook cutoff pattern); the
 	// LIKE below degrades to a match-all and the outer ORDER BY picks newest.
@@ -926,9 +928,9 @@ export function searchEpisodicSources(
 			 ${union}
 			 )
 			 ORDER BY julianday(captured_at) DESC, kind ASC, id ASC
-			 LIMIT ?`,
+			 LIMIT ${limit === null ? -1 : "?"}`,
 		)
-		.all(...branches.flatMap((branch) => branch.args), limit) as Array<{
+		.all(...branches.flatMap((branch) => branch.args), ...(limit === null ? [] : [limit])) as Array<{
 		kind: EpisodicSourceKind;
 		id: string;
 	}>;

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -43,6 +43,7 @@ import {
 	resolveRequeuedDreamingEvidenceInTx,
 } from "./dreaming-evidence-retry";
 import { readDreamingRunbook } from "./dreaming-runbook";
+import { countTokens } from "./tokenizer";
 
 const AGENT = "default";
 
@@ -828,6 +829,20 @@ describe("Dreaming", () => {
 		const cfg = defaultCfg({ tokenThreshold: 100_000, maxInterval: 6 * 60 * 60 * 1_000, backfillOnFirstRun: false });
 		expect(await shouldTriggerDreaming(accessor, cfg, AGENT, now - 1)).toBe(false);
 		expect(await shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(true);
+	});
+
+	it("counts the full scan-first episodic backlog beyond one search page (#1559)", () => {
+		const contents = Array.from({ length: 51 }, (_, index) => `pending episodic source ${index}`);
+		for (const [index, content] of contents.entries()) {
+			seedArtifact(db, `imports/pending-${index}.md`, content, `revision-${index}`, "2026-08-01T00:00:00.000Z");
+		}
+		const expected = contents.reduce((total, content) => total + countTokens(content), 0);
+		const backlog = getDreamingEpisodicTokenBacklog(accessor, AGENT);
+
+		expect(backlog).toBe(expected);
+		expect(
+			shouldTriggerDreaming(accessor, defaultCfg({ tokenThreshold: expected, backfillOnFirstRun: false }), AGENT),
+		).toBe(true);
 	});
 
 	it("runs a pass when attention is pending and leaves it for the agent to consume", async () => {

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -43,7 +43,6 @@ import {
 	resolveRequeuedDreamingEvidenceInTx,
 } from "./dreaming-evidence-retry";
 import { readDreamingRunbook } from "./dreaming-runbook";
-import { countTokens } from "./tokenizer";
 
 const AGENT = "default";
 
@@ -831,17 +830,17 @@ describe("Dreaming", () => {
 		expect(await shouldTriggerDreaming(accessor, cfg, AGENT, now)).toBe(true);
 	});
 
-	it("counts the full scan-first episodic backlog beyond one search page (#1559)", () => {
+	it("counts the full scan-first episodic backlog beyond one search page (#1559)", async () => {
 		const contents = Array.from({ length: 51 }, (_, index) => `pending episodic source ${index}`);
 		for (const [index, content] of contents.entries()) {
 			seedArtifact(db, `imports/pending-${index}.md`, content, `revision-${index}`, "2026-08-01T00:00:00.000Z");
 		}
 		const expected = contents.reduce((total, content) => total + countTokens(content), 0);
-		const backlog = getDreamingEpisodicTokenBacklog(accessor, AGENT);
+		const backlog = await getDreamingEpisodicTokenBacklog(accessor, AGENT);
 
 		expect(backlog).toBe(expected);
 		expect(
-			shouldTriggerDreaming(accessor, defaultCfg({ tokenThreshold: expected, backfillOnFirstRun: false }), AGENT),
+			await shouldTriggerDreaming(accessor, defaultCfg({ tokenThreshold: expected, backfillOnFirstRun: false }), AGENT),
 		).toBe(true);
 	});
 

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -1834,7 +1834,10 @@ function readDreamingEpisodicTokenBacklogEntriesInDb(
 			agentId,
 			query: "",
 			excludeDelivered: true,
-			limit: 50,
+			// The trigger metric must include every pending revision. The ordinary
+			// search API is page-bounded, but backlog accounting cannot use a
+			// newest-50 slice without suppressing automatic Dreaming (#1559).
+			limit: null,
 		});
 		return queued.flatMap((source) => {
 			const remaining = renderDreamingEvidence(source).slice(deliveredOffsetForSource(db, agentId, source));


### PR DESCRIPTION
## Summary

Fixes #1559. The Dreaming backlog trigger now requests the complete pending episodic source set instead of the ordinary 50-source search page, so more than 50 pending sources still contribute to the token threshold. This is the existing #1559 fix, rebased onto current `main` and reconciled with merged #1555 token-cache and BPE-worker changes.

## Changes

- Allow `searchEpisodicSources` callers to request an unbounded result set with `limit: null` while preserving the normal 1-50 page bound.
- Use the complete scan-first result set for Dreaming backlog accounting.
- Update the 51-source threshold regression to await the asynchronous #1555 cache-backed backlog refresh and trigger decision.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations touched.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused verification on the rebased head:

- `bun test platform/daemon/src/pipeline/dreaming.test.ts platform/daemon/src/episodic-sources.test.ts` (66 passed, 0 failed)
- `bun run --filter '@signet/daemon' build` (TypeScript check and production build passed)
- `bunx biome check platform/daemon/src/episodic-sources.ts platform/daemon/src/pipeline/dreaming.ts platform/daemon/src/pipeline/dreaming.test.ts` (exit 0; existing warnings in `dreaming.ts`)

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Rebased cleanly from `94f2eea98` onto `origin/main` at `584bd341c` (v0.201.0). The current head includes the compatibility test adjustment required by #1555's asynchronous token-cache API. No rebase conflicts required manual resolution.
