### PR TITLE
fix(release): stage Kimi connector for npm

### DIFF
--- a/scripts/stage-npm-publish.test.ts
+++ b/scripts/stage-npm-publish.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
 
-import { rewritePackageManifest, rewritePackageSpecifiers } from "./stage-npm-publish";
+import {
+	PUBLISH_TARGETS,
+	rewritePackageManifest,
+	rewritePackageSpecifiers,
+	stageNpmPublishPackages,
+} from "./stage-npm-publish";
 
 describe("stage-npm-publish", () => {
 	test("rewrites only staged npm package names and dependencies to the signetai scope", () => {
@@ -15,6 +23,10 @@ describe("stage-npm-publish", () => {
 				devDependencies: {
 					"@signet/sdk": "workspace:*",
 				},
+				repository: {
+					type: "git",
+					url: "https://github.com/Signet-AI/signetai.git",
+				},
 			}),
 		);
 
@@ -22,12 +34,14 @@ describe("stage-npm-publish", () => {
 			name: string;
 			dependencies: Record<string, string>;
 			devDependencies: Record<string, string>;
+			repository: { url: string };
 		};
 		expect(parsed.name).toBe("@signetai/connector-pi");
 		expect(parsed.dependencies["@signetai/connector-base"]).toBe("0.140.1");
 		expect(parsed.dependencies["@signetai/core"]).toBe("0.140.1");
 		expect(parsed.dependencies.zod).toBe("^4.0.0");
 		expect(parsed.devDependencies["@signet/sdk"]).toBe("workspace:*");
+		expect(parsed.repository.url).toBe("git+https://github.com/Signet-AI/signetai.git");
 	});
 
 	test("rewrites staged installer imports and help text", () => {
@@ -42,5 +56,33 @@ describe("stage-npm-publish", () => {
 				"npx -y @signetai/connector-pi install\n" +
 				"`@signetai/connector-${harness}`\n",
 		);
+	});
+
+	test("stages every scoped package listed by the nightly publish step", () => {
+		const root = join(import.meta.dir, "..");
+		const workflow = readFileSync(join(root, ".github", "workflows", "release.yml"), "utf8");
+		const publishNames = Array.from(
+			workflow.matchAll(/publish_npm_package "\$\{STAGED_NPM_ROOT\}\/([^"]+)"/g),
+			(match) => match[1],
+		)
+			.filter((name): name is string => name !== undefined)
+			.sort();
+		const stagingDir = mkdtempSync(join(tmpdir(), "signet-npm-publish-"));
+
+		try {
+			const stagedNames = stageNpmPublishPackages(stagingDir)
+				.map((dir) => basename(dir))
+				.sort();
+			expect(stagedNames).toEqual(publishNames);
+			expect(publishNames).toEqual(PUBLISH_TARGETS.map(([, stageName]) => stageName).sort());
+			for (const name of publishNames) {
+				const manifestFile = join(stagingDir, name, "package.json");
+				expect(existsSync(manifestFile)).toBe(true);
+				const manifest = JSON.parse(readFileSync(manifestFile, "utf8")) as { name?: string };
+				expect(manifest.name).toMatch(/^@signetai\//);
+			}
+		} finally {
+			rmSync(stagingDir, { force: true, recursive: true });
+		}
 	});
 });

--- a/scripts/stage-npm-publish.ts
+++ b/scripts/stage-npm-publish.ts
@@ -11,6 +11,7 @@ export const NPM_PACKAGE_RENAMES: ReadonlyMap<string, string> = new Map([
 	["@signet/connector-forge", "@signetai/connector-forge"],
 	["@signet/connector-gemini", "@signetai/connector-gemini"],
 	["@signet/connector-hermes-agent", "@signetai/connector-hermes-agent"],
+	["@signet/connector-kimi", "@signetai/connector-kimi"],
 	["@signet/connector-oh-my-pi", "@signetai/connector-oh-my-pi"],
 	["@signet/connector-openclaw", "@signetai/connector-openclaw"],
 	["@signet/connector-opencode", "@signetai/connector-opencode"],
@@ -18,7 +19,7 @@ export const NPM_PACKAGE_RENAMES: ReadonlyMap<string, string> = new Map([
 	["@signet/codex-plugin", "@signetai/codex-plugin"],
 ]);
 
-const PUBLISH_TARGETS = [
+export const PUBLISH_TARGETS = [
 	["platform/core", "core"],
 	["libs/connector-base", "connector-base"],
 	["integrations/claude-code/connector", "connector-claude-code"],
@@ -26,6 +27,7 @@ const PUBLISH_TARGETS = [
 	["integrations/forge/connector", "connector-forge"],
 	["integrations/gemini/connector", "connector-gemini"],
 	["integrations/hermes-agent/connector", "connector-hermes-agent"],
+	["integrations/kimi/connector", "connector-kimi"],
 	["integrations/oh-my-pi/connector", "connector-oh-my-pi"],
 	["integrations/openclaw/connector", "connector-openclaw"],
 	["integrations/opencode/connector", "connector-opencode"],
@@ -53,6 +55,13 @@ export function rewritePackageManifest(raw: string): string {
 	const pkg = JSON.parse(raw) as Record<string, unknown>;
 	if (typeof pkg.name === "string") {
 		pkg.name = NPM_PACKAGE_RENAMES.get(pkg.name) ?? pkg.name;
+	}
+	const repository = pkg.repository;
+	if (repository && typeof repository === "object" && !Array.isArray(repository)) {
+		const url = (repository as Record<string, unknown>).url;
+		if (typeof url === "string" && url.startsWith("https://")) {
+			(repository as Record<string, unknown>).url = `git+${url}`;
+		}
 	}
 
 	for (const field of ["dependencies", "optionalDependencies", "peerDependencies", "devDependencies"] as const) {


### PR DESCRIPTION
## Summary

Fixes the Nightly Release npm publish failure from run 31858624031, where the workflow attempted to publish `connector-kimi` but the staging script never copied its package directory. The staging tooling now includes Kimi and normalizes the repository URL that npm was auto-correcting during publish.

## Changes

- Added `integrations/kimi/connector` to the scoped npm staging targets.
- Added the `@signet/connector-kimi` to `@signetai/connector-kimi` package rename.
- Normalized staged repository URLs from `https://` to npm's canonical `git+https://` form.
- Added a regression that compares every scoped package named by the release workflow with the staged directories and verifies each staged manifest is present and scoped for npm.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: release npm staging tooling

## Screenshots

Not applicable. No UI behavior is changed.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No database migration is included.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused proof:

- `bun test scripts/stage-npm-publish.test.ts scripts/check-publish-manifests.test.ts`: 26 passed, 0 failed.
- `SIGNET_SKIP_NATIVE_MANIFEST_CHECK=1 bun scripts/check-publish-manifests.ts`: passed for 15 package manifests.
- `bun scripts/stage-npm-publish.ts /tmp/signet-npm-publish-after`: staged 13 scoped packages, including `connector-kimi/package.json` as `@signetai/connector-kimi`.
- `npm pkg fix --prefix /tmp/signet-npm-publish-after/connector-kimi`: no warnings or changes after staging.
- `bun run typecheck`: passed after the workspace build artifacts were generated.
- `bun run lint`: passed with the existing baseline of 642 warnings and 57 infos.
- `git diff --check`: passed.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Root cause: `.github/workflows/release.yml` already listed `${STAGED_NPM_ROOT}/connector-kimi` at the publish step, but `scripts/stage-npm-publish.ts` had an explicit `PUBLISH_TARGETS` list that stopped at the previously supported connectors. The release reached the publish function and failed while reading the missing staged manifest before npm could publish Kimi.

The source Kimi manifest was structurally valid. The npm warning in the failed run was the same repository URL normalization emitted for the other staged packages, not a Kimi-specific field error. The staging generator now applies npm's canonical `git+https://` repository form to every staged manifest, so the warning is removed without modifying source manifests.

The new regression will fail whenever a scoped package is added to the workflow publish list without being added to the staging target list, and it also verifies that all staged package names use the `@signetai/` publish scope. A future package added only to the workflow would therefore be caught before release.
