### PR TITLE
fix(daemon): back off source embeddings

### DIFF
--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -2450,6 +2450,7 @@ async function main() {
 						total: event.total,
 						indexed: event.changed,
 						currentPath: event.filePath,
+						statusMessage: event.status,
 					});
 				},
 			});

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -1114,6 +1114,58 @@ describe("native memory sources", () => {
 		expect(rows.some((row) => row.chunk_text.includes("heading: Signet Sources"))).toBe(true);
 	});
 
+	it("completes source artifact sync and backoffs embeddings when the provider is down", async () => {
+		const root = join(dir, "provider-down-vault");
+		const file = join(root, "permanent", "Pending.md");
+		mkdirSync(join(root, "permanent"), { recursive: true });
+		writeFileSync(
+			file,
+			"# Pending Embeddings\n\nThe source artifact remains searchable as canonical evidence while its provider-down embedding work waits for retry.\n",
+		);
+		let fetches = 0;
+		let heartbeats = 0;
+		const statuses: string[] = [];
+		const heartbeat = setInterval(() => {
+			heartbeats++;
+		}, 5);
+		const source = obsidianNativeMemorySource(root, "Provider Down Vault", "obsidian:provider-down");
+		const handle = startNativeMemoryBridge([source], {
+			agentId: "agent-native",
+			pollIntervalMs: 0,
+			sourceGraphEnabled: false,
+			embeddingConfig: { provider: "native", model: "down-model", dimensions: 3, base_url: "" },
+			fetchEmbedding: async (_text, _cfg, _role, options) => {
+				fetches++;
+				await new Promise((resolve) => setTimeout(resolve, 25));
+				options?.onFailure?.("provider_unavailable");
+				return null;
+			},
+			onFileIndexed: (event) => {
+				if (event.status) statuses.push(event.status);
+			},
+		});
+		try {
+			expect(await handle.syncExisting()).toBe(1);
+			expect(await handle.syncExisting()).toBe(0);
+			expect(fetches).toBe(1);
+			expect(heartbeats).toBeGreaterThan(0);
+			expect(statuses).toEqual(["embeddings pending - provider down", "embeddings pending - provider down"]);
+
+			const artifact = getDbAccessor().withReadDb(
+				(db) =>
+					db.prepare("SELECT source_path, content FROM memory_artifacts WHERE source_path = ?").get(file) as {
+						source_path: string;
+						content: string;
+					},
+			);
+			expect(artifact.source_path).toBe(file);
+			expect(artifact.content).toContain("canonical evidence");
+		} finally {
+			clearInterval(heartbeat);
+			await handle.close();
+		}
+	});
+
 	it("purges all artifacts below a disconnected Obsidian source root", async () => {
 		const root = join(dir, "vault");
 		const source = obsidianNativeMemorySource(root, "Research Vault");

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -24,6 +24,7 @@ import {
 	indexObsidianSourceEmbeddings,
 	purgeObsidianSourceEmbeddings,
 	purgeObsidianSourceFileEmbeddings,
+	resetObsidianSourceEmbeddingBackoff,
 } from "./obsidian-source-embeddings";
 import {
 	type ObsidianMarkdownPathIndex,
@@ -72,6 +73,7 @@ export interface NativeMemoryBridgeOptions {
 	readonly shouldCleanupSource?: (source: NativeMemorySource) => boolean;
 	readonly sourceGraphEnabled?: boolean;
 	readonly shouldContinue?: (source: NativeMemorySource) => boolean;
+	readonly onEmbeddingStatus?: (status: string | undefined) => void;
 	readonly onFileIndexed?: (event: NativeMemoryFileIndexEvent) => void;
 }
 
@@ -95,6 +97,7 @@ export interface NativeMemoryFileIndexEvent {
 	readonly scanned: number;
 	readonly total: number;
 	readonly changed: number;
+	readonly status?: string;
 }
 
 interface IndexedNativeMemory {
@@ -191,6 +194,7 @@ export function resetNativeMemoryIndexCache(): void {
 	readFailureBackoffUntil.clear();
 	permissionDeniedPaths.clear();
 	datalessReadFailuresByHarness.clear();
+	resetObsidianSourceEmbeddingBackoff();
 }
 const DEFAULT_OBSIDIAN_SOURCE_FILE_DELAY_MS = 250;
 
@@ -697,7 +701,10 @@ export async function indexNativeMemoryFile(
 	source: NativeMemorySource,
 	filePath: string,
 	agentId = resolveDaemonAgentId(),
-	options: Pick<NativeMemoryBridgeOptions, "embeddingConfig" | "fetchEmbedding" | "sourceGraphEnabled"> & {
+	options: Pick<
+		NativeMemoryBridgeOptions,
+		"embeddingConfig" | "fetchEmbedding" | "sourceGraphEnabled" | "onEmbeddingStatus"
+	> & {
 		readonly markdownPathIndex?: ObsidianMarkdownPathIndex;
 	} = {},
 ): Promise<boolean> {
@@ -872,6 +879,13 @@ export async function indexNativeMemoryFile(
 					embeddingConfig: options.embeddingConfig,
 					fetchEmbedding: options.fetchEmbedding,
 				});
+				options.onEmbeddingStatus?.(embeddingResult.status);
+				if (embeddingResult.providerUnavailable) {
+					logger.warn("watcher", "embeddings pending - provider down", {
+						path: filePath,
+						retryAfterMs: embeddingResult.retryAfterMs,
+					});
+				}
 				if (embeddingResult.embedded > 0) {
 					logger.info("watcher", "Embedded Obsidian source chunks", {
 						path: filePath,
@@ -880,7 +894,7 @@ export async function indexNativeMemoryFile(
 						skipped: embeddingResult.skipped,
 					});
 				}
-				semanticIndexed = true;
+				semanticIndexed = !embeddingResult.providerUnavailable;
 			}
 		}
 		indexed.set(key, { contentHash: hash });
@@ -1026,16 +1040,29 @@ export function startNativeMemoryBridge(
 				for (const file of files) {
 					if (options.shouldContinue && !options.shouldContinue(source)) break;
 					scanned++;
+					let embeddingStatus: string | undefined;
 					const changed = await indexNativeMemoryFile(source, file, agentId, {
 						...options,
 						markdownPathIndex,
+						onEmbeddingStatus: (status) => {
+							embeddingStatus = status;
+							options.onEmbeddingStatus?.(status);
+						},
 					});
 					if (changed) {
 						count++;
 						changedCount++;
 					}
 					current.add(file);
-					options.onFileIndexed?.({ source, filePath: file, indexed: changed, scanned, total, changed: changedCount });
+					options.onFileIndexed?.({
+						source,
+						filePath: file,
+						indexed: changed,
+						scanned,
+						total,
+						changed: changedCount,
+						...(embeddingStatus ? { status: embeddingStatus } : {}),
+					});
 					await yielder();
 					await sleep(fileDelayMs);
 				}

--- a/platform/daemon/src/obsidian-source-embeddings.test.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.test.ts
@@ -10,6 +10,7 @@ import {
 	indexObsidianSourceEmbeddings,
 	purgeObsidianSourceEmbeddings,
 	purgeObsidianSourceFileEmbeddings,
+	type SourceEmbeddingFetch,
 } from "./obsidian-source-embeddings";
 
 const embeddingConfig: EmbeddingConfig = {
@@ -142,6 +143,44 @@ describe("Obsidian source embeddings", () => {
 		expect(second.embedded).toBe(0);
 		expect(second.skipped).toBe(first.chunks);
 		expect(fetches).toBe(first.chunks);
+	});
+
+	it("backs off provider-down source embedding attempts instead of retrying every chunk", async () => {
+		const filePath = join(vault, "literature", "provider-down.md");
+		const content =
+			"# Provider Down\n\nThis source note has enough durable content to create multiple chunks while the embedding provider is unavailable.\n\nA second paragraph keeps the scan representative of a real source file.\n";
+		let fetches = 0;
+		const fetchEmbedding: SourceEmbeddingFetch = async (_text, _cfg, _role, opts) => {
+			fetches++;
+			opts?.onFailure?.("provider_unavailable");
+			return null;
+		};
+
+		const first = await indexObsidianSourceEmbeddings({
+			agentId: "obsidian-embedding-agent",
+			sourceId: "obsidian:test-vault",
+			root: vault,
+			filePath,
+			content,
+			embeddingConfig,
+			fetchEmbedding,
+		});
+		const second = await indexObsidianSourceEmbeddings({
+			agentId: "obsidian-embedding-agent",
+			sourceId: "obsidian:test-vault",
+			root: vault,
+			filePath,
+			content,
+			embeddingConfig,
+			fetchEmbedding,
+		});
+
+		expect(first.providerUnavailable).toBe(true);
+		expect(first.status).toBe("embeddings pending - provider down");
+		expect(first.skipped).toBe(first.chunks);
+		expect(second.providerUnavailable).toBe(true);
+		expect(second.status).toBe("embeddings pending - provider down");
+		expect(fetches).toBe(1);
 	});
 
 	it("removes legacy Obsidian chunk rows once generic chunks are refreshed", async () => {

--- a/platform/daemon/src/obsidian-source-embeddings.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.ts
@@ -4,7 +4,9 @@ import { LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE, SOURCE_CHUNK_SOURCE_TYPE } from "@si
 import { yieldEvery } from "./async-yield";
 import { getDbAccessor } from "./db-accessor";
 import { syncVecDeleteByEmbeddingIds, syncVecInsert, vectorToBlob } from "./db-helpers";
+import { computeRetryBackoffMs } from "./embedding-repair-state";
 import type { EmbeddingFetchOptions } from "./embedding-fetch";
+import type { PipelineCauseFamily } from "./pipeline-operation";
 import { isActiveEmbeddingConfig, resolveActiveEmbeddingConfig } from "./embedding-index-state";
 import type { EmbeddingRole } from "./embedding-profile";
 import type { EmbeddingConfig } from "./memory-config";
@@ -45,6 +47,31 @@ export interface IndexObsidianSourceEmbeddingsResult {
 	readonly chunks: number;
 	readonly embedded: number;
 	readonly skipped: number;
+	readonly status?: typeof EMBEDDINGS_PENDING_PROVIDER_DOWN;
+	readonly providerUnavailable: boolean;
+	readonly retryAfterMs?: number;
+}
+
+export const EMBEDDINGS_PENDING_PROVIDER_DOWN = "embeddings pending - provider down";
+
+interface SourceEmbeddingFailureState {
+	readonly attempts: number;
+	readonly retryAt: number;
+}
+
+const SOURCE_EMBEDDING_POLL_MS = 10_000;
+const sourceEmbeddingFailures = new Map<string, SourceEmbeddingFailureState>();
+
+export function resetObsidianSourceEmbeddingBackoff(): void {
+	sourceEmbeddingFailures.clear();
+}
+
+function sourceEmbeddingFailureKey(input: IndexObsidianSourceEmbeddingsInput, model: string): string {
+	return `${input.agentId}:${input.sourceId}:${normalizePath(input.filePath)}:${model}`;
+}
+
+function providerUnavailableCause(cause: PipelineCauseFamily): boolean {
+	return cause === "provider_unavailable" || cause === "timeout";
 }
 
 export interface PurgeObsidianSourceEmbeddingsInput {
@@ -239,15 +266,32 @@ export async function indexObsidianSourceEmbeddings(
 	// Source watchers outlive a config edit. Keep their writes compatible with
 	// active recall while the requested profile is built in the inactive slot.
 	const embeddingConfig = getDbAccessor().withReadDb((db) => resolveActiveEmbeddingConfig(db, input.embeddingConfig));
-	if (embeddingConfig.provider === "none") return { chunks: 0, embedded: 0, skipped: 0 };
+	if (embeddingConfig.provider === "none") return { chunks: 0, embedded: 0, skipped: 0, providerUnavailable: false };
 	const chunks = buildObsidianSourceChunks(input);
+	const failureKey = sourceEmbeddingFailureKey(input, embeddingConfig.model);
+	const failureState = sourceEmbeddingFailures.get(failureKey);
+	if (failureState && failureState.retryAt > Date.now()) {
+		return {
+			chunks: chunks.length,
+			embedded: 0,
+			skipped: chunks.length,
+			status: EMBEDDINGS_PENDING_PROVIDER_DOWN,
+			providerUnavailable: true,
+			retryAfterMs: failureState.retryAt - Date.now(),
+		};
+	}
+	if (failureState) sourceEmbeddingFailures.delete(failureKey);
 	const currentHashes = new Set<string>();
 	const yielder = yieldEvery(1);
 	let embedded = 0;
 	let skipped = 0;
+	let providerUnavailable = false;
+	let retryAfterMs: number | undefined;
 	const now = new Date().toISOString();
 
-	for (const chunk of chunks) {
+	for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex += 1) {
+		const chunk = chunks[chunkIndex];
+		if (!chunk) continue;
 		const contentHash = hash(`${input.agentId}\n${chunk.id}\n${chunk.chunkText}`);
 		const embId = hash(`${OBSIDIAN_CHUNK_SOURCE_TYPE}:${input.agentId}:${chunk.id}`).slice(0, 32);
 		currentHashes.add(contentHash);
@@ -266,28 +310,47 @@ export async function indexObsidianSourceEmbeddings(
 			await sleep(OBSIDIAN_SOURCE_CHUNK_DELAY_MS);
 			continue;
 		}
-		let stored = false;
-		for (let attempt = 0; attempt < 2 && !stored; attempt += 1) {
-			const writeConfig = getDbAccessor().withReadDb((db) => resolveActiveEmbeddingConfig(db, input.embeddingConfig));
-			const vector = await input.fetchEmbedding(chunk.chunkText, writeConfig, "document", {
-				usage: { source: "artifact-index", agentId: input.agentId },
-			});
-			if (!vector || vector.length === 0) break;
-			stored = getDbAccessor().withWriteTx((db) => {
-				// Recheck after the asynchronous provider call: promotion may have
-				// committed a new active space while this chunk was encoding.
-				if (!isActiveEmbeddingConfig(db, writeConfig)) return false;
-				const existingForId = db.prepare("SELECT content_hash FROM embeddings WHERE id = ?").get(embId) as
-					| { content_hash: string }
-					| undefined;
-				if (existingForId && existingForId.content_hash !== contentHash) {
-					if (!syncVecDeleteByEmbeddingIds(db, [embId])) {
-						throw new Error("failed to reconcile vec_embeddings before replacing source embedding");
-					}
-					db.prepare("DELETE FROM embeddings WHERE id = ?").run(embId);
+		const writeConfig = getDbAccessor().withReadDb((db) => resolveActiveEmbeddingConfig(db, input.embeddingConfig));
+		let failureCause: PipelineCauseFamily = "provider_unavailable";
+		const vector = await input.fetchEmbedding(chunk.chunkText, writeConfig, "document", {
+			usage: { source: "artifact-index", agentId: input.agentId },
+			onFailure: (cause) => {
+				failureCause = cause;
+			},
+		});
+		if (!vector || vector.length === 0) {
+			if (providerUnavailableCause(failureCause)) {
+				const attempts = (failureState?.attempts ?? 0) + 1;
+				retryAfterMs = computeRetryBackoffMs(attempts, SOURCE_EMBEDDING_POLL_MS);
+				sourceEmbeddingFailures.set(failureKey, { attempts, retryAt: Date.now() + retryAfterMs });
+				providerUnavailable = true;
+				// Do not probe the same dead provider once per chunk. The source
+				// artifact and graph work above remain committed, while all
+				// embeddings stay pending for the next backoff window.
+				skipped += chunks.length - chunkIndex;
+				break;
+			}
+			skipped++;
+			await yielder();
+			await sleep(OBSIDIAN_SOURCE_CHUNK_DELAY_MS);
+			continue;
+		}
+		sourceEmbeddingFailures.delete(failureKey);
+		const stored = getDbAccessor().withWriteTx((db) => {
+			// Recheck after the asynchronous provider call: promotion may have
+			// committed a new active space while this chunk was encoding.
+			if (!isActiveEmbeddingConfig(db, writeConfig)) return false;
+			const existingForId = db.prepare("SELECT content_hash FROM embeddings WHERE id = ?").get(embId) as
+				| { content_hash: string }
+				| undefined;
+			if (existingForId && existingForId.content_hash !== contentHash) {
+				if (!syncVecDeleteByEmbeddingIds(db, [embId])) {
+					throw new Error("failed to reconcile vec_embeddings before replacing source embedding");
 				}
-				db.prepare(
-					`INSERT INTO embeddings
+				db.prepare("DELETE FROM embeddings WHERE id = ?").run(embId);
+			}
+			db.prepare(
+				`INSERT INTO embeddings
 				 (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
 				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 				 ON CONFLICT(content_hash) DO UPDATE SET
@@ -298,30 +361,29 @@ export async function indexObsidianSourceEmbeddings(
 				   chunk_text = excluded.chunk_text,
 				   created_at = excluded.created_at,
 				   agent_id = excluded.agent_id`,
-				).run(
-					embId,
-					contentHash,
-					vectorToBlob(vector),
-					vector.length,
-					OBSIDIAN_CHUNK_SOURCE_TYPE,
-					chunk.id,
-					chunk.chunkText,
-					now,
-					input.agentId,
-				);
-				upsertMemoryContentSafetyInTx(db, {
-					agentId: input.agentId,
-					sourceKind: "source_chunk",
-					sourceId: embId,
-					content: chunk.chunkText,
-				});
-				const stored = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(contentHash) as
-					| { id: string }
-					| undefined;
-				syncVecInsert(db, stored?.id ?? embId, vector);
-				return true;
+			).run(
+				embId,
+				contentHash,
+				vectorToBlob(vector),
+				vector.length,
+				OBSIDIAN_CHUNK_SOURCE_TYPE,
+				chunk.id,
+				chunk.chunkText,
+				now,
+				input.agentId,
+			);
+			upsertMemoryContentSafetyInTx(db, {
+				agentId: input.agentId,
+				sourceKind: "source_chunk",
+				sourceId: embId,
+				content: chunk.chunkText,
 			});
-		}
+			const stored = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(contentHash) as
+				| { id: string }
+				| undefined;
+			syncVecInsert(db, stored?.id ?? embId, vector);
+			return true;
+		});
 		if (!stored) {
 			skipped++;
 			await yielder();
@@ -333,33 +395,45 @@ export async function indexObsidianSourceEmbeddings(
 		await sleep(OBSIDIAN_SOURCE_CHUNK_DELAY_MS);
 	}
 
-	getDbAccessor().withWriteTx((db) => {
-		const prefix = `${input.sourceId}:${relPath(normalizePath(input.root).replace(/\/$/, ""), normalizePath(input.filePath))}#`;
-		const stale = OBSIDIAN_CHUNK_SOURCE_TYPES.flatMap(
-			(sourceType) =>
-				db
-					.prepare(
-						"SELECT id, source_type, content_hash FROM embeddings WHERE source_type = ? AND source_id >= ? AND source_id < ? AND agent_id = ?",
-					)
-					.all(sourceType, prefix, prefixUpperBound(prefix), input.agentId) as Array<{
-					id: string;
-					source_type: string;
-					content_hash: string;
-				}>,
-		);
-		const staleIds = stale
-			.filter((row) => row.source_type === LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE || !currentHashes.has(row.content_hash))
-			.map((row) => row.id);
-		if (staleIds.length > 0) {
-			if (!syncVecDeleteByEmbeddingIds(db, staleIds)) {
-				throw new Error("failed to reconcile vec_embeddings before removing stale source embeddings");
+	if (!providerUnavailable)
+		getDbAccessor().withWriteTx((db) => {
+			const prefix = `${input.sourceId}:${relPath(normalizePath(input.root).replace(/\/$/, ""), normalizePath(input.filePath))}#`;
+			const stale = OBSIDIAN_CHUNK_SOURCE_TYPES.flatMap(
+				(sourceType) =>
+					db
+						.prepare(
+							"SELECT id, source_type, content_hash FROM embeddings WHERE source_type = ? AND source_id >= ? AND source_id < ? AND agent_id = ?",
+						)
+						.all(sourceType, prefix, prefixUpperBound(prefix), input.agentId) as Array<{
+						id: string;
+						source_type: string;
+						content_hash: string;
+					}>,
+			);
+			const staleIds = stale
+				.filter((row) => row.source_type === LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE || !currentHashes.has(row.content_hash))
+				.map((row) => row.id);
+			if (staleIds.length > 0) {
+				if (!syncVecDeleteByEmbeddingIds(db, staleIds)) {
+					throw new Error("failed to reconcile vec_embeddings before removing stale source embeddings");
+				}
+				const stmt = db.prepare("DELETE FROM embeddings WHERE id = ?");
+				for (const id of staleIds) stmt.run(id);
 			}
-			const stmt = db.prepare("DELETE FROM embeddings WHERE id = ?");
-			for (const id of staleIds) stmt.run(id);
-		}
-	});
+		});
 
-	return { chunks: chunks.length, embedded, skipped };
+	return {
+		chunks: chunks.length,
+		embedded,
+		skipped,
+		...(providerUnavailable
+			? {
+					status: EMBEDDINGS_PENDING_PROVIDER_DOWN as typeof EMBEDDINGS_PENDING_PROVIDER_DOWN,
+					providerUnavailable: true,
+					retryAfterMs,
+				}
+			: { providerUnavailable: false }),
+	};
 }
 
 function sleep(ms: number): Promise<void> {

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -578,6 +578,7 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 					total: event.total,
 					indexed: event.changed,
 					currentPath: event.filePath,
+					statusMessage: event.status,
 				});
 			},
 			shouldContinue: () => isCurrentSourceIndexJob(input.source.id, job.id),

--- a/platform/daemon/src/source-index-progress.test.ts
+++ b/platform/daemon/src/source-index-progress.test.ts
@@ -23,6 +23,26 @@ describe("source index progress", () => {
 		expect(getSourceIndexJob("source-2")?.statusMessage).toBe("embeddings pending - provider down");
 	});
 
+	test("clears degraded embedding status after provider recovery", () => {
+		clearSourceIndexProgressForTests();
+		const job = beginSourceIndexJob("source-recovery");
+		const progress = {
+			scanned: 1,
+			total: 1,
+			indexed: 0,
+			currentPath: "/vault/Recovering.md",
+		};
+		updateSourceIndexJobProgress("source-recovery", job.id, {
+			...progress,
+			statusMessage: "embeddings pending - provider down",
+		});
+		expect(getSourceIndexJob("source-recovery")?.statusMessage).toBe("embeddings pending - provider down");
+
+		updateSourceIndexJobProgress("source-recovery", job.id, progress);
+
+		expect(getSourceIndexJob("source-recovery")?.statusMessage).toBeUndefined();
+	});
+
 	test("does not reopen completed jobs when a duplicate delayed runner fires", () => {
 		clearSourceIndexProgressForTests();
 		const job = beginSourceIndexJob("source-1");

--- a/platform/daemon/src/source-index-progress.test.ts
+++ b/platform/daemon/src/source-index-progress.test.ts
@@ -5,9 +5,24 @@ import {
 	completeSourceIndexJob,
 	getSourceIndexJob,
 	markSourceIndexJobRunning,
+	updateSourceIndexJobProgress,
 } from "./source-index-progress";
 
 describe("source index progress", () => {
+	test("preserves degraded embedding status in job progress", () => {
+		clearSourceIndexProgressForTests();
+		const job = beginSourceIndexJob("source-2");
+		updateSourceIndexJobProgress("source-2", job.id, {
+			scanned: 1,
+			total: 1,
+			indexed: 1,
+			currentPath: "/vault/Pending.md",
+			statusMessage: "embeddings pending - provider down",
+		});
+
+		expect(getSourceIndexJob("source-2")?.statusMessage).toBe("embeddings pending - provider down");
+	});
+
 	test("does not reopen completed jobs when a duplicate delayed runner fires", () => {
 		clearSourceIndexProgressForTests();
 		const job = beginSourceIndexJob("source-1");

--- a/platform/daemon/src/source-index-progress.ts
+++ b/platform/daemon/src/source-index-progress.ts
@@ -70,7 +70,7 @@ export function updateSourceIndexJobProgress(sourceId: string, jobId: string, ev
 		total: event.total,
 		indexed: event.indexed,
 		currentPath: event.currentPath,
-		...(event.statusMessage ? { statusMessage: event.statusMessage } : {}),
+		statusMessage: event.statusMessage,
 	});
 }
 

--- a/platform/daemon/src/source-index-progress.ts
+++ b/platform/daemon/src/source-index-progress.ts
@@ -11,6 +11,7 @@ export interface SourceIndexJob {
 	readonly total?: number;
 	readonly indexed?: number;
 	readonly currentPath?: string;
+	readonly statusMessage?: string;
 	readonly error?: string;
 }
 
@@ -19,6 +20,7 @@ export interface SourceIndexProgressEvent {
 	readonly total: number;
 	readonly indexed: number;
 	readonly currentPath: string;
+	readonly statusMessage?: string;
 }
 
 const sourceIndexJobs = new Map<string, SourceIndexJob>();
@@ -68,6 +70,7 @@ export function updateSourceIndexJobProgress(sourceId: string, jobId: string, ev
 		total: event.total,
 		indexed: event.indexed,
 		currentPath: event.currentPath,
+		...(event.statusMessage ? { statusMessage: event.statusMessage } : {}),
 	});
 }
 

--- a/web/docs/src/content/docs/api/documents-sources.md
+++ b/web/docs/src/content/docs/api/documents-sources.md
@@ -309,6 +309,11 @@ chunk embeddings to its own database.
 }
 ```
 
+When a source artifact is indexed but its embedding provider is unavailable,
+`GET /api/sources` exposes `indexJob.statusMessage` as
+`"embeddings pending - provider down"` while embeddings wait for a bounded
+retry window.
+
 <a id="post-api-sources-discord"></a>
 
 ### POST /api/sources/discord


### PR DESCRIPTION
## Summary

Fixes #1579. Native source sync no longer retries a down embedding provider per chunk and per scan. It completes source artifact work, reports the degraded embedding state, and backs off future embedding attempts.

## Changes

- Reuse the existing bounded `computeRetryBackoffMs` policy for provider-unavailable and timeout failures in Obsidian source embeddings.
- Stop probing remaining chunks after the provider fails, preserve existing vectors, and skip stale-vector cleanup while embeddings are pending.
- Propagate `embeddings pending - provider down` through native source progress and the existing `/api/sources` `indexJob` payload.
- Add regressions for provider-down backoff, non-embedding artifact completion, event-loop heartbeats, and status propagation.
- Document the degraded source-index status.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Exact proof:

- `bun test platform/daemon/src/obsidian-source-embeddings.test.ts platform/daemon/src/native-memory-sources.test.ts platform/daemon/src/source-index-progress.test.ts`: 64 pass, 0 fail, 235 expect calls.
- `bun run --filter '@signet/daemon' typecheck`: exit 0.
- `bun run --filter '@signet/core' build && bun run --filter '@signet/daemon' build`: exit 0.
- `bunx biome check` on all eight changed source/test files: exit 0 with three pre-existing warnings in `daemon.ts`.
- `git diff --check`: exit 0.
- `bun scripts/doc-drift.ts`: pre-existing repository drift remains for seven undocumented routes, migration references, and package tables. No new drift was introduced by this PR.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Root cause was the main-thread path from `native-memory-sources.ts` `syncExisting` (the per-file scan at lines 1029-1064) into `obsidian-source-embeddings.ts` `indexObsidianSourceEmbeddings` (the chunk loop at lines 292-396). The old loop made two immediate fetch attempts per chunk and retried the file on every scan because semantic indexing never completed. The fix records provider failure by agent/source/file/model, applies the #1160 backoff floor and caps, stops the current chunk scan after the first provider failure, and keeps the artifact/graph work completed above it. This is the provider-down degradation requirement cross-linked to #1543 and reuses the #1160 policy.

No migration or new sync DB/native call was added. Existing provider failure callbacks classify the cause; only provider-unavailable and timeout failures enter this backoff path. The running-daemon checkbox is intentionally unchecked because verification used deterministic focused tests and package builds, not a live Ollama outage.
