### PR TITLE
fix(daemon): reap escaped ACPX children on darwin

### DIFF
--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -24,6 +24,7 @@ import {
 	getLlmConcurrencyStatus,
 	withLlmConcurrency,
 } from "./provider";
+import { logger } from "../logger";
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -779,6 +780,211 @@ printf 'ok\\n'
 		const foreignKilled = killLog.some((entry) => entry.startsWith(`${foreignPid}:`));
 		expect(childKilled).toBe(true);
 		expect(foreignKilled).toBe(false);
+	});
+
+	it("fails closed and warns when Darwin ps enumeration fails", async () => {
+		const root = join(tmpdir(), `signet-acpx-darwin-ps-failure-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const fakePs = join(root, "ps");
+		const bin = join(root, "fake-acpx.sh");
+		writeFileSync(
+			fakePs,
+			`#!/usr/bin/env bash
+exit 1
+`,
+		);
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+printf 'ok\\n'
+`,
+		);
+		chmodSync(fakePs, 0o755);
+		chmodSync(bin, 0o755);
+		const previousPlatform = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
+		const previousPs = process.env.SIGNET_ACPX_PS;
+		const previousWarn = logger.warn;
+		const warnCalls: Array<{ message: string; data?: Record<string, unknown> }> = [];
+		const killLog: string[] = [];
+		const previousKill = process.kill;
+		process.env.SIGNET_ACPX_CLEANUP_PLATFORM = "darwin";
+		process.env.SIGNET_ACPX_PS = fakePs;
+		logger.warn = ((_category: unknown, message: unknown, data?: Record<string, unknown>) => {
+			warnCalls.push({ message: String(message), data });
+		}) as typeof logger.warn;
+		process.kill = ((pid: number, signal: NodeJS.Signals) => {
+			killLog.push(`${pid}:${signal}`);
+			return true;
+		}) as typeof process.kill;
+		try {
+			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
+			await expect(provider.generate("hello", { timeoutMs: 1000 })).resolves.toBe("ok");
+		} finally {
+			process.kill = previousKill;
+			logger.warn = previousWarn;
+			if (previousPlatform === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_CLEANUP_PLATFORM");
+			else process.env.SIGNET_ACPX_CLEANUP_PLATFORM = previousPlatform;
+			if (previousPs === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PS");
+			else process.env.SIGNET_ACPX_PS = previousPs;
+			rmSync(root, { recursive: true, force: true });
+		}
+		expect(killLog).toEqual([]);
+		expect(warnCalls.some(({ message }) => message.includes("could not enumerate processes"))).toBe(true);
+	});
+
+	it("counts and logs Darwin procinfo failures without signaling the candidate", async () => {
+		const root = join(
+			tmpdir(),
+			`signet-acpx-darwin-procinfo-failure-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		mkdirSync(root, { recursive: true });
+		const candidatePid = 4244;
+		const fakePs = join(root, "ps");
+		const fakeProcinfo = join(root, "procinfo");
+		const bin = join(root, "fake-acpx.sh");
+		writeFileSync(
+			fakePs,
+			`#!/usr/bin/env bash
+printf '%s\\n' "${candidatePid} /usr/local/bin/codex-acp"
+`,
+		);
+		writeFileSync(
+			fakeProcinfo,
+			`#!/usr/bin/env bash
+exit 1
+`,
+		);
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+printf 'ok\\n'
+`,
+		);
+		chmodSync(fakePs, 0o755);
+		chmodSync(fakeProcinfo, 0o755);
+		chmodSync(bin, 0o755);
+		const previousPlatform = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
+		const previousPs = process.env.SIGNET_ACPX_PS;
+		const previousProcinfo = process.env.SIGNET_ACPX_PROCINFO;
+		const previousWarn = logger.warn;
+		const warnCalls: Array<{ message: string; data?: Record<string, unknown> }> = [];
+		const killLog: string[] = [];
+		const previousKill = process.kill;
+		process.env.SIGNET_ACPX_CLEANUP_PLATFORM = "darwin";
+		process.env.SIGNET_ACPX_PS = fakePs;
+		process.env.SIGNET_ACPX_PROCINFO = fakeProcinfo;
+		logger.warn = ((_category: unknown, message: unknown, data?: Record<string, unknown>) => {
+			warnCalls.push({ message: String(message), data });
+		}) as typeof logger.warn;
+		process.kill = ((pid: number, signal: NodeJS.Signals) => {
+			killLog.push(`${pid}:${signal}`);
+			return true;
+		}) as typeof process.kill;
+		try {
+			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
+			await expect(provider.generate("hello", { timeoutMs: 1000 })).resolves.toBe("ok");
+		} finally {
+			process.kill = previousKill;
+			logger.warn = previousWarn;
+			if (previousPlatform === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_CLEANUP_PLATFORM");
+			else process.env.SIGNET_ACPX_CLEANUP_PLATFORM = previousPlatform;
+			if (previousPs === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PS");
+			else process.env.SIGNET_ACPX_PS = previousPs;
+			if (previousProcinfo === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PROCINFO");
+			else process.env.SIGNET_ACPX_PROCINFO = previousProcinfo;
+			rmSync(root, { recursive: true, force: true });
+		}
+		const ownershipWarning = warnCalls.find(({ message }) => message.includes("could not verify process ownership"));
+		expect(ownershipWarning?.data).toMatchObject({
+			failedChecks: 1,
+			candidateCount: 1,
+			mechanism: "launchctl procinfo",
+		});
+		expect(killLog).toEqual([]);
+	});
+
+	it("bounds Darwin candidate inspection at 128 processes and warns when capped", async () => {
+		const root = join(
+			tmpdir(),
+			`signet-acpx-darwin-candidate-cap-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		mkdirSync(root, { recursive: true });
+		const firstPid = 5000;
+		const fakePs = join(root, "ps");
+		const fakeProcinfo = join(root, "procinfo");
+		const procinfoCalls = join(root, "procinfo-calls.txt");
+		const bin = join(root, "fake-acpx.sh");
+		const candidateLines = Array.from(
+			{ length: 130 },
+			(_, index) => `echo "${firstPid + index} /usr/local/bin/codex-acp"`,
+		).join("\n");
+		writeFileSync(
+			fakePs,
+			`#!/usr/bin/env bash
+if [[ "$1" == "-axo" && "$2" == "pid=,command=" ]]; then
+${candidateLines}
+  exit 0
+fi
+exit 0
+`,
+		);
+		writeFileSync(
+			fakeProcinfo,
+			`#!/usr/bin/env bash
+count=0
+if [[ -f ${JSON.stringify(procinfoCalls)} ]]; then
+  count=$(<${JSON.stringify(procinfoCalls)})
+fi
+echo $((count + 1)) > ${JSON.stringify(procinfoCalls)}
+echo environment:
+echo '  HOME = /Users/tester'
+`,
+		);
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+printf 'ok\\n'
+`,
+		);
+		chmodSync(fakePs, 0o755);
+		chmodSync(fakeProcinfo, 0o755);
+		chmodSync(bin, 0o755);
+		const previousPlatform = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
+		const previousPs = process.env.SIGNET_ACPX_PS;
+		const previousProcinfo = process.env.SIGNET_ACPX_PROCINFO;
+		const previousWarn = logger.warn;
+		const warnCalls: string[] = [];
+		const killLog: string[] = [];
+		const previousKill = process.kill;
+		let procinfoCallCount = 0;
+		process.env.SIGNET_ACPX_CLEANUP_PLATFORM = "darwin";
+		process.env.SIGNET_ACPX_PS = fakePs;
+		process.env.SIGNET_ACPX_PROCINFO = fakeProcinfo;
+		logger.warn = ((_category: unknown, message: unknown) => {
+			warnCalls.push(String(message));
+		}) as typeof logger.warn;
+		process.kill = ((pid: number, signal: NodeJS.Signals) => {
+			killLog.push(`${pid}:${signal}`);
+			return true;
+		}) as typeof process.kill;
+		try {
+			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
+			await expect(provider.generate("hello", { timeoutMs: 5000 })).resolves.toBe("ok");
+			procinfoCallCount = Number(readFileSync(procinfoCalls, "utf-8").trim());
+		} finally {
+			process.kill = previousKill;
+			logger.warn = previousWarn;
+			if (previousPlatform === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_CLEANUP_PLATFORM");
+			else process.env.SIGNET_ACPX_CLEANUP_PLATFORM = previousPlatform;
+			if (previousPs === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PS");
+			else process.env.SIGNET_ACPX_PS = previousPs;
+			if (previousProcinfo === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PROCINFO");
+			else process.env.SIGNET_ACPX_PROCINFO = previousProcinfo;
+			rmSync(root, { recursive: true, force: true });
+		}
+		expect(procinfoCallCount).toBe(128);
+		expect(warnCalls.some((message) => message.includes("reached its candidate cap"))).toBe(true);
+		expect(killLog).toEqual([]);
 	});
 
 	it("treats an unreadable ACPX proc root as best-effort cleanup", async () => {

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -949,6 +949,87 @@ printf 'ok\\n'
 		expect(killLog).toEqual([]);
 	});
 
+	it("hard-kills SIGTERM-resistant ps probes and bounds the total Darwin sweep", async () => {
+		const root = join(
+			tmpdir(),
+			`signet-acpx-darwin-sweep-deadline-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		mkdirSync(root, { recursive: true });
+		const candidateCount = 8;
+		const firstPid = 6000;
+		const fakePs = join(root, "ps");
+		const psPids = join(root, "ps-pids.txt");
+		const bin = join(root, "fake-acpx.sh");
+		const candidateLines = Array.from(
+			{ length: candidateCount },
+			(_, index) => `printf '%s\\n' "${firstPid + index} /usr/local/bin/codex-acp"`,
+		).join("\n");
+		writeFileSync(
+			fakePs,
+			`#!/usr/bin/env bash
+if [[ "$1" == "-axo" && "$2" == "pid=,command=" ]]; then
+${candidateLines}
+  exit 0
+fi
+if [[ "$1" == "-p" ]]; then
+  printf '%s\\n' "$$" >> ${JSON.stringify(psPids)}
+  trap '' TERM
+  while :; do :; done
+fi
+exit 1
+`,
+		);
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+printf 'ok\\n'
+`,
+		);
+		chmodSync(fakePs, 0o755);
+		chmodSync(bin, 0o755);
+		const previousPlatform = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
+		const previousPs = process.env.SIGNET_ACPX_PS;
+		const startedAt = performance.now();
+		let elapsedMs = 0;
+		let spawnedPids: number[] = [];
+		const readSpawnedPids = (): number[] =>
+			existsSync(psPids)
+				? readFileSync(psPids, "utf-8")
+						.trim()
+						.split("\n")
+						.filter(Boolean)
+						.map(Number)
+						.filter((pid) => pid > 0)
+				: [];
+		process.env.SIGNET_ACPX_CLEANUP_PLATFORM = "darwin";
+		process.env.SIGNET_ACPX_PS = fakePs;
+		try {
+			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
+			await expect(provider.generate("hello", { timeoutMs: 5_000 })).resolves.toBe("ok");
+			elapsedMs = performance.now() - startedAt;
+			spawnedPids = readSpawnedPids();
+		} finally {
+			if (spawnedPids.length === 0) spawnedPids = readSpawnedPids();
+			for (const pid of spawnedPids) {
+				if (!(await waitForProcessExit(pid))) {
+					try {
+						process.kill(pid, "SIGKILL");
+					} catch {
+						// Already exited.
+					}
+				}
+			}
+			if (previousPlatform === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_CLEANUP_PLATFORM");
+			else process.env.SIGNET_ACPX_CLEANUP_PLATFORM = previousPlatform;
+			if (previousPs === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PS");
+			else process.env.SIGNET_ACPX_PS = previousPs;
+			rmSync(root, { recursive: true, force: true });
+		}
+		expect(spawnedPids.length).toBeGreaterThan(0);
+		expect(spawnedPids.length).toBeLessThan(candidateCount);
+		expect(elapsedMs).toBeLessThan(3_000);
+	});
+
 	it("treats an unreadable ACPX proc root as best-effort cleanup", async () => {
 		if (process.platform !== "linux") return;
 		const root = join(tmpdir(), `signet-acpx-missing-proc-${Date.now()}-${Math.random().toString(36).slice(2)}`);

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -689,10 +689,10 @@ printf 'ok\\n'
 		const foreignPid = 4243;
 		const runidFile = join(root, "runid.txt");
 		const fakePs = join(root, "ps");
-		const fakeProcinfo = join(root, "procinfo");
 		const bin = join(root, "fake-acpx.sh");
-		// fake ps: the full process listing for `-axo pid=,command=`. Two
-		// same-named agent processes; only one is bound to our run id.
+		// fake ps: the full process listing plus the environment returned by
+		// `ps -p <pid> -E -o command=`. Two same-named agent processes; only one
+		// is bound to our run id.
 		writeFileSync(
 			fakePs,
 			`#!/usr/bin/env bash
@@ -701,29 +701,13 @@ if [[ "$1" == "-axo" && "$2" == "pid=,command=" ]]; then
   printf '%s\\n' "${foreignPid} /usr/local/bin/codex-acp"
   exit 0
 fi
-exit 0
-`,
-		);
-		// fake procinfo: per-pid environment. The child carries the run id (read
-		// from the file the acpx child wrote from its real env); the foreign
-		// same-named process does not, so it must never be signalled.
-		writeFileSync(
-			fakeProcinfo,
-			`#!/usr/bin/env bash
-pid="\${@: -1}"
-if [[ "$pid" == "${childPid}" ]]; then
+if [[ "$1" == "-p" && "$2" == "${childPid}" ]]; then
   runid=""
   if [[ -n "\${SIGNET_ACPX_RUNID_FILE}" && -f "\${SIGNET_ACPX_RUNID_FILE}" ]]; then
     runid="$(cat "\${SIGNET_ACPX_RUNID_FILE}")"
   fi
-  printf 'environment:\\n'
-  printf '  PATH = /usr/bin\\n'
-  printf '  SIGNET_ACPX_RUN_ID = %s\\n' "$runid"
-  printf '  HOME = /Users/tester\\n'
-else
-  printf 'environment:\\n'
-  printf '  PATH = /usr/bin\\n'
-  printf '  HOME = /Users/tester\\n'
+  printf '/usr/local/bin/codex-acp SIGNET_ACPX_RUN_ID=%s\\n' "$runid"
+  exit 0
 fi
 exit 0
 `,
@@ -741,15 +725,12 @@ printf 'ok\\n'
 `,
 		);
 		chmodSync(fakePs, 0o755);
-		chmodSync(fakeProcinfo, 0o755);
 		chmodSync(bin, 0o755);
 		const previousPlatform = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
 		const previousPs = process.env.SIGNET_ACPX_PS;
-		const previousProcinfo = process.env.SIGNET_ACPX_PROCINFO;
 		const previousRunidFile = process.env.SIGNET_ACPX_RUNID_FILE;
 		process.env.SIGNET_ACPX_CLEANUP_PLATFORM = "darwin";
 		process.env.SIGNET_ACPX_PS = fakePs;
-		process.env.SIGNET_ACPX_PROCINFO = fakeProcinfo;
 		process.env.SIGNET_ACPX_RUNID_FILE = runidFile;
 		const killLog: string[] = [];
 		const previousKill = process.kill;
@@ -770,8 +751,6 @@ printf 'ok\\n'
 			else process.env.SIGNET_ACPX_CLEANUP_PLATFORM = previousPlatform;
 			if (previousPs === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PS");
 			else process.env.SIGNET_ACPX_PS = previousPs;
-			if (previousProcinfo === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PROCINFO");
-			else process.env.SIGNET_ACPX_PROCINFO = previousProcinfo;
 			if (previousRunidFile === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_RUNID_FILE");
 			else process.env.SIGNET_ACPX_RUNID_FILE = previousRunidFile;
 			rmSync(root, { recursive: true, force: true });
@@ -832,25 +811,22 @@ printf 'ok\\n'
 		expect(warnCalls.some(({ message }) => message.includes("could not enumerate processes"))).toBe(true);
 	});
 
-	it("counts and logs Darwin procinfo failures without signaling the candidate", async () => {
+	it("counts and logs Darwin ps environment failures without signaling the candidate", async () => {
 		const root = join(
 			tmpdir(),
-			`signet-acpx-darwin-procinfo-failure-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+			`signet-acpx-darwin-ps-environment-failure-${Date.now()}-${Math.random().toString(36).slice(2)}`,
 		);
 		mkdirSync(root, { recursive: true });
 		const candidatePid = 4244;
 		const fakePs = join(root, "ps");
-		const fakeProcinfo = join(root, "procinfo");
 		const bin = join(root, "fake-acpx.sh");
 		writeFileSync(
 			fakePs,
 			`#!/usr/bin/env bash
+if [[ "$1" == "-axo" && "$2" == "pid=,command=" ]]; then
 printf '%s\\n' "${candidatePid} /usr/local/bin/codex-acp"
-`,
-		);
-		writeFileSync(
-			fakeProcinfo,
-			`#!/usr/bin/env bash
+  exit 0
+fi
 exit 1
 `,
 		);
@@ -861,18 +837,15 @@ printf 'ok\\n'
 `,
 		);
 		chmodSync(fakePs, 0o755);
-		chmodSync(fakeProcinfo, 0o755);
 		chmodSync(bin, 0o755);
 		const previousPlatform = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
 		const previousPs = process.env.SIGNET_ACPX_PS;
-		const previousProcinfo = process.env.SIGNET_ACPX_PROCINFO;
 		const previousWarn = logger.warn;
 		const warnCalls: Array<{ message: string; data?: Record<string, unknown> }> = [];
 		const killLog: string[] = [];
 		const previousKill = process.kill;
 		process.env.SIGNET_ACPX_CLEANUP_PLATFORM = "darwin";
 		process.env.SIGNET_ACPX_PS = fakePs;
-		process.env.SIGNET_ACPX_PROCINFO = fakeProcinfo;
 		logger.warn = ((_category: unknown, message: unknown, data?: Record<string, unknown>) => {
 			warnCalls.push({ message: String(message), data });
 		}) as typeof logger.warn;
@@ -890,15 +863,13 @@ printf 'ok\\n'
 			else process.env.SIGNET_ACPX_CLEANUP_PLATFORM = previousPlatform;
 			if (previousPs === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PS");
 			else process.env.SIGNET_ACPX_PS = previousPs;
-			if (previousProcinfo === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PROCINFO");
-			else process.env.SIGNET_ACPX_PROCINFO = previousProcinfo;
 			rmSync(root, { recursive: true, force: true });
 		}
 		const ownershipWarning = warnCalls.find(({ message }) => message.includes("could not verify process ownership"));
 		expect(ownershipWarning?.data).toMatchObject({
 			failedChecks: 1,
 			candidateCount: 1,
-			mechanism: "launchctl procinfo",
+			mechanism: "ps -E",
 		});
 		expect(killLog).toEqual([]);
 	});
@@ -911,8 +882,7 @@ printf 'ok\\n'
 		mkdirSync(root, { recursive: true });
 		const firstPid = 5000;
 		const fakePs = join(root, "ps");
-		const fakeProcinfo = join(root, "procinfo");
-		const procinfoCalls = join(root, "procinfo-calls.txt");
+		const psCalls = join(root, "ps-calls.txt");
 		const bin = join(root, "fake-acpx.sh");
 		const candidateLines = Array.from(
 			{ length: 130 },
@@ -925,19 +895,16 @@ if [[ "$1" == "-axo" && "$2" == "pid=,command=" ]]; then
 ${candidateLines}
   exit 0
 fi
-exit 0
-`,
-		);
-		writeFileSync(
-			fakeProcinfo,
-			`#!/usr/bin/env bash
-count=0
-if [[ -f ${JSON.stringify(procinfoCalls)} ]]; then
-  count=$(<${JSON.stringify(procinfoCalls)})
+if [[ "$1" == "-p" ]]; then
+  count=0
+  if [[ -f ${JSON.stringify(psCalls)} ]]; then
+    count=$(<${JSON.stringify(psCalls)})
+  fi
+  echo $((count + 1)) > ${JSON.stringify(psCalls)}
+  echo '/usr/local/bin/codex-acp'
+  exit 0
 fi
-echo $((count + 1)) > ${JSON.stringify(procinfoCalls)}
-echo environment:
-echo '  HOME = /Users/tester'
+exit 1
 `,
 		);
 		writeFileSync(
@@ -947,19 +914,16 @@ printf 'ok\\n'
 `,
 		);
 		chmodSync(fakePs, 0o755);
-		chmodSync(fakeProcinfo, 0o755);
 		chmodSync(bin, 0o755);
 		const previousPlatform = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
 		const previousPs = process.env.SIGNET_ACPX_PS;
-		const previousProcinfo = process.env.SIGNET_ACPX_PROCINFO;
 		const previousWarn = logger.warn;
 		const warnCalls: string[] = [];
 		const killLog: string[] = [];
 		const previousKill = process.kill;
-		let procinfoCallCount = 0;
+		let psCallCount = 0;
 		process.env.SIGNET_ACPX_CLEANUP_PLATFORM = "darwin";
 		process.env.SIGNET_ACPX_PS = fakePs;
-		process.env.SIGNET_ACPX_PROCINFO = fakeProcinfo;
 		logger.warn = ((_category: unknown, message: unknown) => {
 			warnCalls.push(String(message));
 		}) as typeof logger.warn;
@@ -970,7 +934,7 @@ printf 'ok\\n'
 		try {
 			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
 			await expect(provider.generate("hello", { timeoutMs: 5000 })).resolves.toBe("ok");
-			procinfoCallCount = Number(readFileSync(procinfoCalls, "utf-8").trim());
+			psCallCount = Number(readFileSync(psCalls, "utf-8").trim());
 		} finally {
 			process.kill = previousKill;
 			logger.warn = previousWarn;
@@ -978,11 +942,9 @@ printf 'ok\\n'
 			else process.env.SIGNET_ACPX_CLEANUP_PLATFORM = previousPlatform;
 			if (previousPs === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PS");
 			else process.env.SIGNET_ACPX_PS = previousPs;
-			if (previousProcinfo === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PROCINFO");
-			else process.env.SIGNET_ACPX_PROCINFO = previousProcinfo;
 			rmSync(root, { recursive: true, force: true });
 		}
-		expect(procinfoCallCount).toBe(128);
+		expect(psCallCount).toBe(128);
 		expect(warnCalls.some((message) => message.includes("reached its candidate cap"))).toBe(true);
 		expect(killLog).toEqual([]);
 	});

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -681,6 +681,106 @@ printf 'ok\\n'
 		}
 	});
 
+	it("reaps escaped Codex ACP children on darwin via a bounded ps sweep (#1459)", async () => {
+		const root = join(tmpdir(), `signet-acpx-darwin-sweep-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const childPid = 4242;
+		const foreignPid = 4243;
+		const runidFile = join(root, "runid.txt");
+		const fakePs = join(root, "ps");
+		const fakeProcinfo = join(root, "procinfo");
+		const bin = join(root, "fake-acpx.sh");
+		// fake ps: the full process listing for `-axo pid=,command=`. Two
+		// same-named agent processes; only one is bound to our run id.
+		writeFileSync(
+			fakePs,
+			`#!/usr/bin/env bash
+if [[ "$1" == "-axo" && "$2" == "pid=,command=" ]]; then
+  printf '%s\\n' "${childPid} /usr/local/bin/codex-acp"
+  printf '%s\\n' "${foreignPid} /usr/local/bin/codex-acp"
+  exit 0
+fi
+exit 0
+`,
+		);
+		// fake procinfo: per-pid environment. The child carries the run id (read
+		// from the file the acpx child wrote from its real env); the foreign
+		// same-named process does not, so it must never be signalled.
+		writeFileSync(
+			fakeProcinfo,
+			`#!/usr/bin/env bash
+pid="\${@: -1}"
+if [[ "$pid" == "${childPid}" ]]; then
+  runid=""
+  if [[ -n "\${SIGNET_ACPX_RUNID_FILE}" && -f "\${SIGNET_ACPX_RUNID_FILE}" ]]; then
+    runid="$(cat "\${SIGNET_ACPX_RUNID_FILE}")"
+  fi
+  printf 'environment:\\n'
+  printf '  PATH = /usr/bin\\n'
+  printf '  SIGNET_ACPX_RUN_ID = %s\\n' "$runid"
+  printf '  HOME = /Users/tester\\n'
+else
+  printf 'environment:\\n'
+  printf '  PATH = /usr/bin\\n'
+  printf '  HOME = /Users/tester\\n'
+fi
+exit 0
+`,
+		);
+		// fake acpx: records its own run id (from the real env the provider
+		// passed) so the sweep's environment read matches the actual runtime
+		// value rather than a literal.
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+if [[ -n "\${SIGNET_ACPX_RUNID_FILE}" && -n "\${SIGNET_ACPX_RUN_ID}" ]]; then
+  printf '%s' "\${SIGNET_ACPX_RUN_ID}" > "\${SIGNET_ACPX_RUNID_FILE}"
+fi
+printf 'ok\\n'
+`,
+		);
+		chmodSync(fakePs, 0o755);
+		chmodSync(fakeProcinfo, 0o755);
+		chmodSync(bin, 0o755);
+		const previousPlatform = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
+		const previousPs = process.env.SIGNET_ACPX_PS;
+		const previousProcinfo = process.env.SIGNET_ACPX_PROCINFO;
+		const previousRunidFile = process.env.SIGNET_ACPX_RUNID_FILE;
+		process.env.SIGNET_ACPX_CLEANUP_PLATFORM = "darwin";
+		process.env.SIGNET_ACPX_PS = fakePs;
+		process.env.SIGNET_ACPX_PROCINFO = fakeProcinfo;
+		process.env.SIGNET_ACPX_RUNID_FILE = runidFile;
+		const killLog: string[] = [];
+		const previousKill = process.kill;
+		try {
+			// Record the signals the sweep issues so we can assert it targeted
+			// only the child bound to the run id, not the foreign one.
+			process.kill = ((pid: number, signal: NodeJS.Signals) => {
+				killLog.push(`${pid}:${signal}`);
+				return true;
+			}) as typeof process.kill;
+			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
+			await expect(provider.generate("hello", { timeoutMs: 1000 })).resolves.toBe("ok");
+			// Let the SIGTERM->SIGKILL escalation timers (~1s) fire.
+			await new Promise((resolve) => setTimeout(resolve, 1600));
+		} finally {
+			process.kill = previousKill;
+			if (previousPlatform === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_CLEANUP_PLATFORM");
+			else process.env.SIGNET_ACPX_CLEANUP_PLATFORM = previousPlatform;
+			if (previousPs === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PS");
+			else process.env.SIGNET_ACPX_PS = previousPs;
+			if (previousProcinfo === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PROCINFO");
+			else process.env.SIGNET_ACPX_PROCINFO = previousProcinfo;
+			if (previousRunidFile === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_RUNID_FILE");
+			else process.env.SIGNET_ACPX_RUNID_FILE = previousRunidFile;
+			rmSync(root, { recursive: true, force: true });
+		}
+		const childKilled = killLog.some((entry) => entry.startsWith(`${childPid}:`));
+		const foreignKilled = killLog.some((entry) => entry.startsWith(`${foreignPid}:`));
+		expect(childKilled).toBe(true);
+		expect(foreignKilled).toBe(false);
+	});
+
 	it("treats an unreadable ACPX proc root as best-effort cleanup", async () => {
 		if (process.platform !== "linux") return;
 		const root = join(tmpdir(), `signet-acpx-missing-proc-${Date.now()}-${Math.random().toString(36).slice(2)}`);

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -17,7 +17,7 @@
  */
 // On Windows, use node:child_process spawn with windowsHide to prevent
 // console window flashing. Bun.spawn doesn't support windowsHide.
-import { execFile, spawn as nodeSpawn } from "node:child_process";
+import { spawn as nodeSpawn } from "node:child_process";
 import { mkdirSync } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";
 import { isAbsolute, join, resolve as resolvePath } from "node:path";
@@ -970,21 +970,69 @@ function acpxPsBinary(): string {
 }
 
 const MAX_DARWIN_CLEANUP_CANDIDATES = 128;
+const DARWIN_PS_SOFT_TIMEOUT_MS = 250;
+const DARWIN_PS_HARD_TIMEOUT_MS = 250;
+const DARWIN_CLEANUP_SWEEP_TIMEOUT_MS = 2_000;
 
 interface ProcessCaptureResult {
 	readonly stdout: string;
 	readonly succeeded: boolean;
 }
 
-function runProcessCapture(binary: string, args: readonly string[]): Promise<ProcessCaptureResult> {
+function runProcessCapture(binary: string, args: readonly string[], deadline: number): Promise<ProcessCaptureResult> {
+	const remainingMs = deadline - performance.now();
+	if (remainingMs <= 0) return Promise.resolve({ stdout: "", succeeded: false });
 	return new Promise((resolve) => {
-		execFile(binary, [...args], { timeout: 800, maxBuffer: 4 * 1024 * 1024 }, (error, stdout) => {
-			if (error) {
-				resolve({ stdout: "", succeeded: false });
-				return;
+		let child: ReturnType<typeof nodeSpawn>;
+		try {
+			child = nodeSpawn(binary, [...args], {
+				stdio: ["ignore", "pipe", "ignore"],
+			});
+		} catch {
+			resolve({ stdout: "", succeeded: false });
+			return;
+		}
+		let stdout = "";
+		let settled = false;
+		let softTimer: ReturnType<typeof setTimeout> | undefined;
+		let hardTimer: ReturnType<typeof setTimeout> | undefined;
+		const onData = (chunk: string | Buffer): void => {
+			stdout += String(chunk);
+		};
+		const clearTimers = (): void => {
+			if (softTimer) clearTimeout(softTimer);
+			if (hardTimer) clearTimeout(hardTimer);
+		};
+		const settle = (result: ProcessCaptureResult): void => {
+			if (settled) return;
+			settled = true;
+			clearTimers();
+			child.stdout?.removeListener("data", onData);
+			resolve(result);
+		};
+		const kill = (signal: "SIGTERM" | "SIGKILL"): void => {
+			try {
+				child.kill(signal);
+			} catch {
+				// The process may have exited between the timeout and the signal.
 			}
-			resolve({ stdout, succeeded: true });
-		});
+		};
+		const hardKill = (): void => {
+			kill("SIGKILL");
+			// Do not wait for close. A SIGTERM-resistant process can keep the
+			// stdio pipe open, but SIGKILL has already ended the ps child.
+			settle({ stdout: "", succeeded: false });
+		};
+		const softKill = (): void => {
+			kill("SIGTERM");
+			const hardRemainingMs = Math.min(DARWIN_PS_HARD_TIMEOUT_MS, Math.max(0, deadline - performance.now()));
+			hardTimer = setTimeout(hardKill, hardRemainingMs);
+		};
+		child.stdout?.setEncoding("utf8");
+		child.stdout?.on("data", onData);
+		child.on("error", () => settle({ stdout: "", succeeded: false }));
+		child.on("close", (code) => settle({ stdout, succeeded: code === 0 }));
+		softTimer = setTimeout(softKill, Math.min(DARWIN_PS_SOFT_TIMEOUT_MS, remainingMs));
 	});
 }
 
@@ -1014,7 +1062,8 @@ function psEnvironmentContainsRunId(stdout: string, runId: string): boolean {
  * same-named process from another run or a user tool.
  */
 async function darwinSweepCandidates(basenames: ReadonlySet<string>, runId: string): Promise<number[]> {
-	const listingResult = await runProcessCapture(acpxPsBinary(), ["-axo", "pid=,command="]);
+	const deadline = performance.now() + DARWIN_CLEANUP_SWEEP_TIMEOUT_MS;
+	const listingResult = await runProcessCapture(acpxPsBinary(), ["-axo", "pid=,command="], deadline);
 	if (!listingResult.succeeded) {
 		logger.warn("inference", "ACPX Darwin orphan sweep could not enumerate processes", {
 			mechanism: "ps",
@@ -1043,7 +1092,8 @@ async function darwinSweepCandidates(basenames: ReadonlySet<string>, runId: stri
 	const matched: number[] = [];
 	let environmentFailures = 0;
 	for (const pid of candidates) {
-		const environment = await runProcessCapture(acpxPsBinary(), ["-p", String(pid), "-E", "-o", "command="]);
+		if (performance.now() >= deadline) break;
+		const environment = await runProcessCapture(acpxPsBinary(), ["-p", String(pid), "-E", "-o", "command="], deadline);
 		if (!environment.succeeded) {
 			environmentFailures++;
 			continue;

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -969,10 +969,6 @@ function acpxPsBinary(): string {
 	return process.env.SIGNET_ACPX_PS || "ps";
 }
 
-function acpxProcinfoCommand(): string {
-	return process.env.SIGNET_ACPX_PROCINFO || "launchctl procinfo";
-}
-
 const MAX_DARWIN_CLEANUP_CANDIDATES = 128;
 
 interface ProcessCaptureResult {
@@ -1000,31 +996,22 @@ function commandMatchesAgentBasename(command: string, basenames: ReadonlySet<str
 	return false;
 }
 
-// `launchctl procinfo <pid>` prints an `environment:` block whose lines look
-// like `  NAME = value`. Return true when one of those lines carries the run
-// id exactly. Tolerate a `:` separator too so a variant renderer is not a
-// silent no-op.
-function procinfoEnvironmentContainsRunId(stdout: string, runId: string): boolean {
-	const marker = "SIGNET_ACPX_RUN_ID";
-	for (const rawLine of stdout.split("\n")) {
-		const line = rawLine.trim();
-		if (!line.startsWith(marker)) continue;
-		const rest = line.slice(marker.length).trimStart();
-		if ((rest.startsWith("=") || rest.startsWith(":")) && rest.slice(1).trim() === runId) return true;
-	}
-	return false;
+// macOS ps(1) documents -E as "Display the environment as well". The ACPX
+// children are spawned under the same user as Signet, so this reads their
+// inherited run id without launchctl procinfo or root privileges.
+function psEnvironmentContainsRunId(stdout: string, runId: string): boolean {
+	const marker = `SIGNET_ACPX_RUN_ID=${runId}`;
+	return stdout.split(/\r?\n/).some((line) => line.split(/\s+/).includes(marker));
 }
 
 /**
  * macOS has no /proc, so the Linux sweep cannot enumerate candidate agent
  * processes there. Mirror it with a bounded scan: `ps -axo pid=,command=`
- * lists the full process table; we filter it down to commands whose basename
- * is an agent process, then read only those candidates' environments via
- * `launchctl procinfo` (the standard macOS mechanism for another process's
- * env; `ps` has no such option on BSD) to require the run id. The
- * per-candidate env read keeps the scan bounded the way per-pid /proc reads
- * are bounded on Linux, and it never signals a same-named process from
- * another run or a user tool.
+ * process table; we filter it down to commands whose basename is an agent
+ * process, then read only those candidates' environments via `ps -E` to
+ * require the run id. The per-candidate env read keeps the scan bounded the
+ * way per-pid /proc reads are bounded on Linux, and it never signals a
+ * same-named process from another run or a user tool.
  */
 async function darwinSweepCandidates(basenames: ReadonlySet<string>, runId: string): Promise<number[]> {
 	const listingResult = await runProcessCapture(acpxPsBinary(), ["-axo", "pid=,command="]);
@@ -1054,26 +1041,20 @@ async function darwinSweepCandidates(basenames: ReadonlySet<string>, runId: stri
 		});
 	}
 	const matched: number[] = [];
-	let procinfoFailures = 0;
+	let environmentFailures = 0;
 	for (const pid of candidates) {
-		const procinfo = acpxProcinfoCommand();
-		const [binary, ...leading] = procinfo.trim().split(/\s+/);
-		if (!binary) {
-			procinfoFailures++;
+		const environment = await runProcessCapture(acpxPsBinary(), ["-p", String(pid), "-E", "-o", "command="]);
+		if (!environment.succeeded) {
+			environmentFailures++;
 			continue;
 		}
-		const procinfoResult = await runProcessCapture(binary, [...leading, String(pid)]);
-		if (!procinfoResult.succeeded) {
-			procinfoFailures++;
-			continue;
-		}
-		if (procinfoEnvironmentContainsRunId(procinfoResult.stdout, runId)) matched.push(pid);
+		if (psEnvironmentContainsRunId(environment.stdout, runId)) matched.push(pid);
 	}
-	if (procinfoFailures > 0) {
+	if (environmentFailures > 0) {
 		logger.warn("inference", "ACPX Darwin orphan sweep could not verify process ownership", {
-			failedChecks: procinfoFailures,
+			failedChecks: environmentFailures,
 			candidateCount: candidates.size,
-			mechanism: "launchctl procinfo",
+			mechanism: "ps -E",
 		});
 	}
 	return matched;

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -17,8 +17,8 @@
  */
 // On Windows, use node:child_process spawn with windowsHide to prevent
 // console window flashing. Bun.spawn doesn't support windowsHide.
-import { spawn as nodeSpawn } from "node:child_process";
-import { mkdirSync, readFileSync } from "node:fs";
+import { execFile, spawn as nodeSpawn } from "node:child_process";
+import { mkdirSync } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";
 import { isAbsolute, join, resolve as resolvePath } from "node:path";
 import type { ThinkingLevel } from "@earendil-works/pi-ai";
@@ -957,6 +957,128 @@ function acpxProcRoot(): string {
 	return process.env.SIGNET_ACPX_PROC_ROOT || "/proc";
 }
 
+// Test seam mirroring SIGNET_ACPX_PROC_ROOT: forces a cleanup platform so the
+// darwin sweep is exercisable on Linux CI runners.
+function acpxCleanupPlatform(): NodeJS.Platform {
+	const override = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
+	if (override === "linux" || override === "darwin") return override;
+	return process.platform;
+}
+
+function acpxPsBinary(): string {
+	return process.env.SIGNET_ACPX_PS || "ps";
+}
+
+function acpxProcinfoCommand(): string {
+	return process.env.SIGNET_ACPX_PROCINFO || "launchctl procinfo";
+}
+
+const MAX_DARWIN_CLEANUP_CANDIDATES = 128;
+
+interface ProcessCaptureResult {
+	readonly stdout: string;
+	readonly succeeded: boolean;
+}
+
+function runProcessCapture(binary: string, args: readonly string[]): Promise<ProcessCaptureResult> {
+	return new Promise((resolve) => {
+		execFile(binary, [...args], { timeout: 800, maxBuffer: 4 * 1024 * 1024 }, (error, stdout) => {
+			if (error) {
+				resolve({ stdout: "", succeeded: false });
+				return;
+			}
+			resolve({ stdout, succeeded: true });
+		});
+	});
+}
+
+function commandMatchesAgentBasename(command: string, basenames: ReadonlySet<string>): boolean {
+	for (const arg of command.split(" ")) {
+		const basename = arg.split("/").pop();
+		if (basename !== undefined && basenames.has(basename)) return true;
+	}
+	return false;
+}
+
+// `launchctl procinfo <pid>` prints an `environment:` block whose lines look
+// like `  NAME = value`. Return true when one of those lines carries the run
+// id exactly. Tolerate a `:` separator too so a variant renderer is not a
+// silent no-op.
+function procinfoEnvironmentContainsRunId(stdout: string, runId: string): boolean {
+	const marker = "SIGNET_ACPX_RUN_ID";
+	for (const rawLine of stdout.split("\n")) {
+		const line = rawLine.trim();
+		if (!line.startsWith(marker)) continue;
+		const rest = line.slice(marker.length).trimStart();
+		if ((rest.startsWith("=") || rest.startsWith(":")) && rest.slice(1).trim() === runId) return true;
+	}
+	return false;
+}
+
+/**
+ * macOS has no /proc, so the Linux sweep cannot enumerate candidate agent
+ * processes there. Mirror it with a bounded scan: `ps -axo pid=,command=`
+ * lists the full process table; we filter it down to commands whose basename
+ * is an agent process, then read only those candidates' environments via
+ * `launchctl procinfo` (the standard macOS mechanism for another process's
+ * env; `ps` has no such option on BSD) to require the run id. The
+ * per-candidate env read keeps the scan bounded the way per-pid /proc reads
+ * are bounded on Linux, and it never signals a same-named process from
+ * another run or a user tool.
+ */
+async function darwinSweepCandidates(basenames: ReadonlySet<string>, runId: string): Promise<number[]> {
+	const listingResult = await runProcessCapture(acpxPsBinary(), ["-axo", "pid=,command="]);
+	if (!listingResult.succeeded) {
+		logger.warn("inference", "ACPX Darwin orphan sweep could not enumerate processes", {
+			mechanism: "ps",
+		});
+		return [];
+	}
+	const candidates = new Set<number>();
+	for (const line of listingResult.stdout.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed === "") continue;
+		const separator = trimmed.indexOf(" ");
+		if (separator <= 0) continue;
+		const pid = Number(trimmed.slice(0, separator));
+		const command = trimmed.slice(separator + 1);
+		if (!Number.isFinite(pid) || pid <= 0) continue;
+		if (commandMatchesAgentBasename(command, basenames)) {
+			candidates.add(pid);
+			if (candidates.size >= MAX_DARWIN_CLEANUP_CANDIDATES) break;
+		}
+	}
+	if (candidates.size >= MAX_DARWIN_CLEANUP_CANDIDATES) {
+		logger.warn("inference", "ACPX Darwin orphan sweep reached its candidate cap", {
+			candidateCap: MAX_DARWIN_CLEANUP_CANDIDATES,
+		});
+	}
+	const matched: number[] = [];
+	let procinfoFailures = 0;
+	for (const pid of candidates) {
+		const procinfo = acpxProcinfoCommand();
+		const [binary, ...leading] = procinfo.trim().split(/\s+/);
+		if (!binary) {
+			procinfoFailures++;
+			continue;
+		}
+		const procinfoResult = await runProcessCapture(binary, [...leading, String(pid)]);
+		if (!procinfoResult.succeeded) {
+			procinfoFailures++;
+			continue;
+		}
+		if (procinfoEnvironmentContainsRunId(procinfoResult.stdout, runId)) matched.push(pid);
+	}
+	if (procinfoFailures > 0) {
+		logger.warn("inference", "ACPX Darwin orphan sweep could not verify process ownership", {
+			failedChecks: procinfoFailures,
+			candidateCount: candidates.size,
+			mechanism: "launchctl procinfo",
+		});
+	}
+	return matched;
+}
+
 async function procEnvContainsRunId(procRoot: string, pid: string, runId: string): Promise<boolean> {
 	try {
 		const environ = await readFile(`${procRoot}/${pid}/environ`, "utf8");
@@ -983,23 +1105,37 @@ async function procCommandMatchesAgent(
 }
 
 async function cleanupAcpxAgentProcesses(agent: string, runId: string): Promise<void> {
-	if (process.platform !== "linux") return;
 	const basenames = new Set(acpxAgentProcessBasenames(agent));
 	if (basenames.size === 0) return;
-	const procRoot = acpxProcRoot();
-	let procEntries: string[];
-	try {
-		procEntries = await readdir(procRoot);
-	} catch {
+	const platform = acpxCleanupPlatform();
+	if (platform !== "linux" && platform !== "darwin") return;
+	let pids: number[];
+	if (platform === "linux") {
+		const procRoot = acpxProcRoot();
+		let procEntries: string[];
+		try {
+			procEntries = await readdir(procRoot);
+		} catch {
+			logger.warn("inference", "ACPX Linux orphan sweep could not enumerate /proc", {
+				procRoot,
+			});
+			return;
+		}
+		pids = [];
+		for (const pid of procEntries) {
+			if (!/^\d+$/.test(pid)) continue;
+			if (!(await procCommandMatchesAgent(procRoot, pid, basenames))) continue;
+			if (!(await procEnvContainsRunId(procRoot, pid, runId))) continue;
+			const numericPid = Number(pid);
+			if (Number.isFinite(numericPid) && numericPid > 0) pids.push(numericPid);
+		}
+	} else if (platform === "darwin") {
+		pids = await darwinSweepCandidates(basenames, runId);
+	} else {
+		logger.warn("inference", "ACPX orphan sweep has no supported process enumeration", {
+			platform,
+		});
 		return;
-	}
-	const pids: number[] = [];
-	for (const pid of procEntries) {
-		if (!/^\d+$/.test(pid)) continue;
-		if (!(await procCommandMatchesAgent(procRoot, pid, basenames))) continue;
-		if (!(await procEnvContainsRunId(procRoot, pid, runId))) continue;
-		const numericPid = Number(pid);
-		if (Number.isFinite(numericPid) && numericPid > 0) pids.push(numericPid);
 	}
 	for (const pid of pids) {
 		try {


### PR DESCRIPTION
## Summary

Fixes #1459. ACPX orphan cleanup now covers macOS instead of returning before scanning any processes. The Darwin path uses a bounded `ps` process-table scan, verifies ownership with `launchctl procinfo`, and only signals matching `SIGNET_ACPX_RUN_ID` processes, including detached descendants that escaped the process group.

Related: #1543

## Changes

- Preserve the existing Linux `/proc` sweep.
- Add Darwin `ps` plus `launchctl procinfo` discovery and run-id ownership matching.
- Bound candidate inspection and log when process enumeration or ownership verification is unavailable.
- Add regressions for failed `ps` enumeration, failed `launchctl procinfo` ownership checks, and the 128-candidate cap. These prove failures warn and fail closed, and that candidate inspection remains bounded.
- Preserve the existing happy-path Darwin regression that distinguishes a matching process from a same-named foreign process.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [ ] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [ ] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [ ] Security checks applied to admin/mutation endpoints
- [ ] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused proof:

- `bun test platform/daemon/src/pipeline/provider.test.ts` passed: 44 tests, 0 failures, 147 expectations.
- `bunx biome check platform/daemon/src/pipeline/provider.test.ts platform/daemon/src/pipeline/provider.ts` passed.
- `cd platform/daemon && bun run typecheck` passed.
- `git diff --check` passed.
- `bun run lint` exited 0 with the repository's existing warnings.
- Full `bun run typecheck` remains blocked by unrelated pre-existing connector and lifecycle-proof package errors. The touched daemon package typecheck passes.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The `checklist-exception` label is applied for the PR-readiness entries that are not applicable to this daemon-only cleanup change: no `INDEX.md` or `dependencies.yaml` changes, no data queries, no admin or mutation endpoints, and no API/spec/status behavior change. The applicable input bounds, failure handling, and regression checks are checked above.

The Darwin sweep intentionally matches the run ID after process-table discovery rather than relying only on parentage. This still finds `setsid` or detached grandchildren after they are reparented, while avoiding signals to unrelated `codex-acp` processes. Unsupported enumeration paths fail safe and emit an inference warning.
