### PR TITLE
fix(cli): isolate macOS launchd workspaces

### DIFF
--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -976,7 +976,7 @@ const daemonDeps = {
 	getDaemonStatus,
 	hasDaemonProcess,
 	isDaemonRunning,
-	isLaunchdDaemonLoaded: () => Promise.resolve(isLaunchdDaemonLoaded()),
+	isLaunchdDaemonLoaded: (agentsDir = AGENTS_DIR) => Promise.resolve(isLaunchdDaemonLoaded(agentsDir)),
 	normalizeAgentPath,
 	signetLogo,
 	sleep,

--- a/surfaces/cli/src/features/daemon.test.ts
+++ b/surfaces/cli/src/features/daemon.test.ts
@@ -164,6 +164,29 @@ describe("daemon lifecycle recovery", () => {
 		expect(stopped).toBe(true);
 	});
 
+	it("checks and stops the launchd job for the resolved --path workspace", async () => {
+		let loadedPath: string | undefined;
+		let stoppedPath: string | undefined;
+		const deps = makeDeps({
+			extractPathOption: () => "/tmp/workspace-b",
+			isDaemonRunning: async () => false,
+			hasDaemonProcess: async () => false,
+			isLaunchdDaemonLoaded: async (agentsDir) => {
+				loadedPath = agentsDir;
+				return true;
+			},
+			stopDaemon: async (agentsDir) => {
+				stoppedPath = agentsDir;
+				return true;
+			},
+		});
+
+		await doStop({ path: "/tmp/workspace-b" }, deps);
+
+		expect(loadedPath).toBe("/tmp/workspace-b");
+		expect(stoppedPath).toBe("/tmp/workspace-b");
+	});
+
 	it("stop reports not running when nothing is alive and no launchd agent is loaded", async () => {
 		let stopped = false;
 		const deps = makeDeps({

--- a/surfaces/cli/src/features/daemon.ts
+++ b/surfaces/cli/src/features/daemon.ts
@@ -54,7 +54,7 @@ interface Deps {
 	readonly sleep: (ms: number) => Promise<void>;
 	readonly startDaemon: (agentsDir?: string) => Promise<boolean>;
 	readonly stopDaemon: (agentsDir?: string) => Promise<boolean>;
-	readonly isLaunchdDaemonLoaded?: () => Promise<boolean>;
+	readonly isLaunchdDaemonLoaded?: (agentsDir?: string) => Promise<boolean>;
 	readonly confirmRestartSync?: () => Promise<boolean>;
 	readonly fetch?: FetchLike;
 	readonly isInteractive?: () => boolean;
@@ -233,7 +233,7 @@ export async function doStop(options: PathOptions, deps: Deps): Promise<void> {
 	// Under launchd KeepAlive the daemon respawns on exit, so an unhealthy
 	// daemon still counts as managed: `stop` must boot the job out or the
 	// reported "stop" is silently undone moments later (#1074).
-	const launchdManaged = running ? false : await (deps.isLaunchdDaemonLoaded?.() ?? Promise.resolve(false));
+	const launchdManaged = running ? false : await (deps.isLaunchdDaemonLoaded?.(basePath) ?? Promise.resolve(false));
 	if (!running && !stale && !launchdManaged) {
 		console.log(chalk.yellow("  Daemon is not running"));
 		return;

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -15,10 +15,13 @@ import {
 	isDaemonEntrypointEnvironment,
 	isDaemonRunning,
 	isLaunchdDaemonLoaded,
+	launchdDaemonLegacyPlistPath,
+	launchdDaemonLabel,
 	launchdDaemonPlistPath,
 	macOSLaunchAgentAttributionNotice,
 	readDaemonStartFailureDiagnostics,
 	readManagedDaemonPid,
+	resolveLaunchdDaemonMigration,
 	resolveDaemonChildInspector,
 	resolveDaemonInspectorForwarding,
 	resolveDaemonLaunchCommand,
@@ -307,13 +310,22 @@ describe("buildLaunchdDaemonPlist", () => {
 		expect(strings).toHaveLength(2);
 		expect(strings[0]).toBe(process.execPath);
 		expect(strings[1]).toBe("/opt/signet/dist/daemon.js");
+		expect(plist).toContain(`<string>${launchdDaemonLabel("/Users/user/.agents")}</string>`);
 		expect(strings[0]).toMatch(/^\//);
 	});
 
 	it("uses a persistent user LaunchAgent path", () => {
-		expect(launchdDaemonPlistPath("/Users/user/.agents", "/Users/user")).toBe(
-			"/Users/user/Library/LaunchAgents/ai.signet.daemon.plist",
+		const agentsDir = "/Users/user/.agents";
+		expect(launchdDaemonPlistPath(agentsDir, "/Users/user")).toBe(
+			`/Users/user/Library/LaunchAgents/${launchdDaemonLabel(agentsDir)}.plist`,
 		);
+		expect(launchdDaemonPlistPath("/Users/other/.agents", "/Users/user")).not.toBe(
+			launchdDaemonPlistPath(agentsDir, "/Users/user"),
+		);
+	});
+
+	it("keeps the legacy plist path available for migration", () => {
+		expect(launchdDaemonLegacyPlistPath("/Users/user")).toBe("/Users/user/Library/LaunchAgents/ai.signet.daemon.plist");
 	});
 
 	it("uses launchctl bootstrap against the current user launchd domain", () => {
@@ -324,10 +336,50 @@ describe("buildLaunchdDaemonPlist", () => {
 	});
 
 	it("uses launchctl bootout against the current user launchd service", () => {
-		const args = buildLaunchdDaemonStopArgs();
+		const label = launchdDaemonLabel("/Users/user/.agents");
+		const args = buildLaunchdDaemonStopArgs(label);
 		expect(args[0]).toBe("bootout");
 		expect(args[1]).toStartWith("gui/");
-		expect(args[1]).toEndWith("/ai.signet.daemon");
+		expect(args[1]).toEndWith(`/${label}`);
+	});
+});
+
+describe("resolveLaunchdDaemonMigration", () => {
+	const legacyHome = "/Users/user";
+	const legacyPlistPath = launchdDaemonLegacyPlistPath(legacyHome);
+
+	it("migrates a legacy plist for the same workspace", () => {
+		const migration = resolveLaunchdDaemonMigration("/Users/user/.agents", legacyHome, {
+			existsSync: (path) => path === legacyPlistPath,
+			readFileSync: () => "<key>SIGNET_PATH</key>\n<string>/Users/user/.agents</string>",
+		});
+
+		expect(migration.action).toBe("migrate");
+		expect(migration.legacyWorkspace).toBe("/Users/user/.agents");
+		expect(migration.warning).toBeNull();
+	});
+
+	it("warns and preserves a legacy plist for a different workspace", () => {
+		const migration = resolveLaunchdDaemonMigration("/Users/other/.agents", legacyHome, {
+			existsSync: (path) => path === legacyPlistPath,
+			readFileSync: () => "<key>SIGNET_PATH</key>\n<string>/Users/user/Work &amp; Projects</string>",
+		});
+
+		expect(migration.action).toBe("preserve");
+		expect(migration.legacyWorkspace).toBe("/Users/user/Work & Projects");
+		expect(migration.warning).toContain("points to /Users/user/Work & Projects");
+		expect(migration.warning).toContain("separate per-workspace job");
+	});
+
+	it("replaces an unreadable legacy plist instead of risking duplicate jobs", () => {
+		const migration = resolveLaunchdDaemonMigration("/Users/user/.agents", legacyHome, {
+			existsSync: (path) => path === legacyPlistPath,
+			readFileSync: () => "<plist></plist>",
+		});
+
+		expect(migration.action).toBe("migrate");
+		expect(migration.legacyWorkspace).toBeNull();
+		expect(migration.warning).toContain("no readable SIGNET_PATH");
 	});
 });
 
@@ -809,12 +861,21 @@ describe("isLaunchdDaemonLoaded", () => {
 		expect(spawned).toBe(false);
 	});
 
-	it("reports loaded when launchctl print succeeds", () => {
-		const loaded = isLaunchdDaemonLoaded({
+	it("reports loaded for the requested workspace label", () => {
+		let args: readonly string[] = [];
+		const agentsDir = "/Users/user/.agents";
+		const loaded = isLaunchdDaemonLoaded(agentsDir, {
 			platform: "darwin",
-			spawnSync: () => ({ status: 0 }),
+			spawnSync: (_command, probeArgs) => {
+				args = probeArgs;
+				return { status: 0 };
+			},
 		});
+
 		expect(loaded).toBe(true);
+		expect(args).toContain(
+			`gui/${typeof process.getuid === "function" ? process.getuid() : "user"}/${launchdDaemonLabel(agentsDir)}`,
+		);
 	});
 
 	it("reports not loaded when launchctl print fails (no such job)", () => {

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -12,6 +12,7 @@ import {
 	didLaunchdDaemonStart,
 	didSystemdDaemonStart,
 	getDaemonStatus,
+	getLaunchdDaemonLoadState,
 	isDaemonEntrypointEnvironment,
 	isDaemonRunning,
 	isLaunchdDaemonLoaded,
@@ -371,15 +372,16 @@ describe("resolveLaunchdDaemonMigration", () => {
 		expect(migration.warning).toContain("separate per-workspace job");
 	});
 
-	it("replaces an unreadable legacy plist instead of risking duplicate jobs", () => {
+	it("warns and preserves an unreadable legacy plist instead of risking displacement", () => {
 		const migration = resolveLaunchdDaemonMigration("/Users/user/.agents", legacyHome, {
 			existsSync: (path) => path === legacyPlistPath,
 			readFileSync: () => "<plist></plist>",
 		});
 
-		expect(migration.action).toBe("migrate");
+		expect(migration.action).toBe("preserve");
 		expect(migration.legacyWorkspace).toBeNull();
-		expect(migration.warning).toContain("no readable SIGNET_PATH");
+		expect(migration.warning).toContain("no confirmable SIGNET_PATH");
+		expect(migration.warning).toContain("left untouched");
 	});
 });
 
@@ -884,5 +886,27 @@ describe("isLaunchdDaemonLoaded", () => {
 			spawnSync: () => ({ status: 3 }),
 		});
 		expect(loaded).toBe(false);
+	});
+
+	it("keeps probe errors distinct from a confirmed missing job", () => {
+		const label = launchdDaemonLabel("/Users/user/.agents");
+		expect(
+			getLaunchdDaemonLoadState(label, {
+				platform: "darwin",
+				spawnSync: () => ({ status: null, error: new Error("launchctl timed out") }),
+			}),
+		).toBe("unknown");
+		expect(
+			getLaunchdDaemonLoadState(label, {
+				platform: "darwin",
+				spawnSync: () => ({ status: 1 }),
+			}),
+		).toBe("unknown");
+		expect(
+			getLaunchdDaemonLoadState(label, {
+				platform: "darwin",
+				spawnSync: () => ({ status: 3 }),
+			}),
+		).toBe("not-loaded");
 	});
 });

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -1225,15 +1225,23 @@ interface LaunchdDaemonLoadDeps {
 	readonly spawnSync?: LaunchctlProbeSpawnSync;
 }
 
-function isLaunchdJobLoaded(label: string, deps: LaunchdDaemonLoadDeps = {}): boolean {
-	if ((deps.platform ?? process.platform) !== "darwin") return false;
+export type LaunchdDaemonLoadState = "loaded" | "not-loaded" | "unknown";
+
+export function getLaunchdDaemonLoadState(label: string, deps: LaunchdDaemonLoadDeps = {}): LaunchdDaemonLoadState {
+	if ((deps.platform ?? process.platform) !== "darwin") return "not-loaded";
 	const spawn = deps.spawnSync ?? spawnSync;
-	const result = spawn("launchctl", ["print", `${currentLaunchdDomain()}/${label}`], {
-		stdio: "ignore",
-		windowsHide: true,
-		timeout: 3000,
-	});
-	return result.status === 0;
+	try {
+		const result = spawn("launchctl", ["print", `${currentLaunchdDomain()}/${label}`], {
+			stdio: "ignore",
+			windowsHide: true,
+			timeout: 3000,
+		});
+		if (result.status === 0) return "loaded";
+		if (result.status === 3) return "not-loaded";
+		return "unknown";
+	} catch {
+		return "unknown";
+	}
 }
 
 interface LaunchdDaemonMigrationDeps {
@@ -1298,14 +1306,20 @@ export function resolveLaunchdDaemonMigration(
 		};
 	}
 
+	if (legacyWorkspace === null) {
+		return {
+			action: "preserve",
+			legacyPlistPath,
+			legacyWorkspace: null,
+			warning: `Existing legacy launchd daemon plist ${legacyPlistPath} has no confirmable SIGNET_PATH. It will be left untouched while starting the separate per-workspace job for ${agentsDir}.`,
+		};
+	}
+
 	return {
 		action: "migrate",
 		legacyPlistPath,
 		legacyWorkspace,
-		warning:
-			legacyWorkspace === null
-				? `Existing legacy launchd daemon plist ${legacyPlistPath} has no readable SIGNET_PATH. It will be replaced by the per-workspace job for ${agentsDir}.`
-				: null,
+		warning: null,
 	};
 }
 
@@ -1367,7 +1381,7 @@ export function isLaunchdDaemonLoaded(
 ): boolean {
 	const agentsDir = typeof agentsDirOrDeps === "string" ? agentsDirOrDeps : AGENTS_DIR;
 	const deps = typeof agentsDirOrDeps === "string" ? maybeDeps : agentsDirOrDeps;
-	return isLaunchdJobLoaded(launchdDaemonLabel(agentsDir), deps);
+	return getLaunchdDaemonLoadState(launchdDaemonLabel(agentsDir), deps) === "loaded";
 }
 
 export function didSystemdDaemonStart(result: Pick<SpawnSyncReturns<Buffer>, "status" | "signal" | "error">): boolean {
@@ -1504,7 +1518,17 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 		const migration = resolveLaunchdDaemonMigration(agentsDir);
 		if (migration.warning) console.warn(chalk.yellow(`  Warning: ${migration.warning}`));
 		if (migration.action === "migrate") {
-			if (isLaunchdJobLoaded(LAUNCHD_DAEMON_LABEL)) {
+			const legacyState = getLaunchdDaemonLoadState(LAUNCHD_DAEMON_LABEL);
+			if (legacyState === "unknown") {
+				console.error(
+					chalk.red(
+						"Could not determine whether the legacy global launchd daemon is loaded. Leaving it in place and aborting migration.",
+					),
+				);
+				if (stderrFd !== null) closeSync(stderrFd);
+				return false;
+			}
+			if (legacyState === "loaded") {
 				const legacyBootout = spawnSync("launchctl", buildLaunchdDaemonStopArgs(LAUNCHD_DAEMON_LABEL), {
 					stdio: ["ignore", "ignore", stderrTarget],
 					windowsHide: true,

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -1199,6 +1199,7 @@ export function macOSLaunchAgentAttributionNotice(
 	return `macOS may show a Login Items / Background Activity notification naming ${signer} instead of Signet. This is expected when Signet is started from a source checkout or JavaScript daemon path. The public curl, npm, and Bun installers use the compiled Signet binary instead.`;
 }
 
+/** Base name retained for compatibility with the pre-workspace launchd job. */
 export const LAUNCHD_DAEMON_LABEL = "ai.signet.daemon";
 
 function currentLaunchdDomain(): string {
@@ -1206,12 +1207,110 @@ function currentLaunchdDomain(): string {
 	return uid === null ? "user" : `gui/${uid}`;
 }
 
-export function launchdDaemonPlistPath(_agentsDir: string, home: string = homedir()): string {
+export function launchdDaemonLabel(agentsDir: string): string {
+	const workspaceHash = sha256(Buffer.from(normalize(agentsDir), "utf8")).slice(0, 12);
+	return `${LAUNCHD_DAEMON_LABEL}.${workspaceHash}`;
+}
+
+export function launchdDaemonLegacyPlistPath(home: string = homedir()): string {
 	return join(home, "Library", "LaunchAgents", `${LAUNCHD_DAEMON_LABEL}.plist`);
 }
 
+export function launchdDaemonPlistPath(agentsDir: string, home: string = homedir()): string {
+	return join(home, "Library", "LaunchAgents", `${launchdDaemonLabel(agentsDir)}.plist`);
+}
+
+interface LaunchdDaemonLoadDeps {
+	readonly platform?: NodeJS.Platform;
+	readonly spawnSync?: LaunchctlProbeSpawnSync;
+}
+
+function isLaunchdJobLoaded(label: string, deps: LaunchdDaemonLoadDeps = {}): boolean {
+	if ((deps.platform ?? process.platform) !== "darwin") return false;
+	const spawn = deps.spawnSync ?? spawnSync;
+	const result = spawn("launchctl", ["print", `${currentLaunchdDomain()}/${label}`], {
+		stdio: "ignore",
+		windowsHide: true,
+		timeout: 3000,
+	});
+	return result.status === 0;
+}
+
+interface LaunchdDaemonMigrationDeps {
+	readonly existsSync: (path: string) => boolean;
+	readonly readFileSync: (path: string, encoding: "utf-8") => string;
+}
+
+const launchdDaemonMigrationDeps: LaunchdDaemonMigrationDeps = {
+	existsSync,
+	readFileSync,
+};
+
+export interface LaunchdDaemonMigration {
+	readonly action: "none" | "migrate" | "preserve";
+	readonly legacyPlistPath: string;
+	readonly legacyWorkspace: string | null;
+	readonly warning: string | null;
+}
+
+function decodePlistValue(value: string): string {
+	return value
+		.replaceAll("&lt;", "<")
+		.replaceAll("&gt;", ">")
+		.replaceAll("&quot;", '"')
+		.replaceAll("&apos;", "'")
+		.replaceAll("&amp;", "&");
+}
+
+function readLaunchdWorkspace(plist: string): string | null {
+	const match = plist.match(/<key>SIGNET_PATH<\/key>\s*<string>([\s\S]*?)<\/string>/);
+	return match?.[1] ? decodePlistValue(match[1]) : null;
+}
+
+/**
+ * Decide how to handle the pre-#1479 global launchd plist before creating a
+ * per-workspace job. A legacy job for another workspace is preserved so the
+ * second workspace does not silently stop the first one.
+ */
+export function resolveLaunchdDaemonMigration(
+	agentsDir: string,
+	home: string = homedir(),
+	deps: LaunchdDaemonMigrationDeps = launchdDaemonMigrationDeps,
+): LaunchdDaemonMigration {
+	const legacyPlistPath = launchdDaemonLegacyPlistPath(home);
+	if (!deps.existsSync(legacyPlistPath)) {
+		return { action: "none", legacyPlistPath, legacyWorkspace: null, warning: null };
+	}
+
+	let legacyWorkspace: string | null = null;
+	try {
+		legacyWorkspace = readLaunchdWorkspace(deps.readFileSync(legacyPlistPath, "utf-8"));
+	} catch {
+		// Treat an unreadable plist as an obsolete job that must be replaced.
+	}
+
+	if (legacyWorkspace !== null && normalize(legacyWorkspace) !== normalize(agentsDir)) {
+		return {
+			action: "preserve",
+			legacyPlistPath,
+			legacyWorkspace,
+			warning: `Existing legacy launchd daemon plist ${legacyPlistPath} points to ${legacyWorkspace}. Starting ${agentsDir} will use a separate per-workspace job and leave the existing legacy plist untouched.`,
+		};
+	}
+
+	return {
+		action: "migrate",
+		legacyPlistPath,
+		legacyWorkspace,
+		warning:
+			legacyWorkspace === null
+				? `Existing legacy launchd daemon plist ${legacyPlistPath} has no readable SIGNET_PATH. It will be replaced by the per-workspace job for ${agentsDir}.`
+				: null,
+	};
+}
+
 export function buildLaunchdDaemonPlist(input: LaunchdDaemonPlistInput): string {
-	const label = input.label ?? LAUNCHD_DAEMON_LABEL;
+	const label = input.label ?? launchdDaemonLabel(input.agentsDir);
 	const sourceEnvironment = input.telemetryEnv ?? process.env;
 	const environment = buildLaunchdEnvironment({
 		environment: sourceEnvironment,
@@ -1258,21 +1357,17 @@ type LaunchctlProbeSpawnSync = (
 };
 
 /**
- * Whether launchd currently has the Signet daemon job loaded. Under KeepAlive
- * the job respawns the daemon on exit, so `stop`/`start` must coordinate with
- * it. The check is darwin-only; other platforms return false.
+ * Whether launchd currently has the per-workspace Signet daemon job loaded.
+ * Under KeepAlive the job respawns the daemon on exit, so `stop`/`start` must
+ * coordinate with it. The object overload keeps existing probe callers stable.
  */
 export function isLaunchdDaemonLoaded(
-	deps: { readonly platform?: NodeJS.Platform; readonly spawnSync?: LaunchctlProbeSpawnSync } = {},
+	agentsDirOrDeps: string | LaunchdDaemonLoadDeps = AGENTS_DIR,
+	maybeDeps: LaunchdDaemonLoadDeps = {},
 ): boolean {
-	if ((deps.platform ?? process.platform) !== "darwin") return false;
-	const spawn = deps.spawnSync ?? spawnSync;
-	const result = spawn("launchctl", ["print", `${currentLaunchdDomain()}/${LAUNCHD_DAEMON_LABEL}`], {
-		stdio: "ignore",
-		windowsHide: true,
-		timeout: 3000,
-	});
-	return result.status === 0;
+	const agentsDir = typeof agentsDirOrDeps === "string" ? agentsDirOrDeps : AGENTS_DIR;
+	const deps = typeof agentsDirOrDeps === "string" ? maybeDeps : agentsDirOrDeps;
+	return isLaunchdJobLoaded(launchdDaemonLabel(agentsDir), deps);
 }
 
 export function didSystemdDaemonStart(result: Pick<SpawnSyncReturns<Buffer>, "status" | "signal" | "error">): boolean {
@@ -1406,6 +1501,26 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 			}
 		}
 	} else if (process.platform === "darwin") {
+		const migration = resolveLaunchdDaemonMigration(agentsDir);
+		if (migration.warning) console.warn(chalk.yellow(`  Warning: ${migration.warning}`));
+		if (migration.action === "migrate") {
+			if (isLaunchdJobLoaded(LAUNCHD_DAEMON_LABEL)) {
+				const legacyBootout = spawnSync("launchctl", buildLaunchdDaemonStopArgs(LAUNCHD_DAEMON_LABEL), {
+					stdio: ["ignore", "ignore", stderrTarget],
+					windowsHide: true,
+					env: daemonEnv,
+					timeout: 5000,
+				});
+				if (!didLaunchdDaemonStart(legacyBootout)) {
+					console.error(
+						chalk.red("Could not stop the legacy global launchd daemon. Leaving it in place and aborting migration."),
+					);
+					if (stderrFd !== null) closeSync(stderrFd);
+					return false;
+				}
+			}
+			rmSync(migration.legacyPlistPath, { force: true });
+		}
 		const plistPath = launchdDaemonPlistPath(agentsDir);
 		mkdirSync(dirname(plistPath), { recursive: true });
 		writeFileSync(
@@ -1427,8 +1542,8 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 		// noise, not a start failure. Skip the bootout in that case so the
 		// message never pollutes the startup log (#1074).
 		let bootout: SpawnSyncReturns<Buffer> | null = null;
-		if (isLaunchdDaemonLoaded()) {
-			bootout = spawnSync("launchctl", buildLaunchdDaemonStopArgs(), {
+		if (isLaunchdDaemonLoaded(agentsDir)) {
+			bootout = spawnSync("launchctl", buildLaunchdDaemonStopArgs(launchdDaemonLabel(agentsDir)), {
 				stdio: ["ignore", "ignore", stderrTarget],
 				windowsHide: true,
 				env: daemonEnv,
@@ -1443,7 +1558,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 		});
 		startedByServiceManager = didLaunchdDaemonStart(bootstrap);
 		if (!startedByServiceManager) {
-			const target = buildLaunchdDaemonStopArgs()[1];
+			const target = buildLaunchdDaemonStopArgs(launchdDaemonLabel(agentsDir))[1];
 			const kickstart = spawnSync("launchctl", ["kickstart", "-k", target], {
 				stdio: ["ignore", "ignore", stderrTarget],
 				windowsHide: true,
@@ -1534,7 +1649,16 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 
 export async function stopDaemon(agentsDir: string = AGENTS_DIR, preferredPid?: number): Promise<boolean> {
 	if (process.platform === "darwin") {
-		spawnSync("launchctl", buildLaunchdDaemonStopArgs(), {
+		const migration = resolveLaunchdDaemonMigration(agentsDir);
+		if (migration.action === "migrate") {
+			const legacyBootout = spawnSync("launchctl", buildLaunchdDaemonStopArgs(LAUNCHD_DAEMON_LABEL), {
+				stdio: "ignore",
+				windowsHide: true,
+				timeout: 5000,
+			});
+			if (didLaunchdDaemonStart(legacyBootout)) rmSync(migration.legacyPlistPath, { force: true });
+		}
+		spawnSync("launchctl", buildLaunchdDaemonStopArgs(launchdDaemonLabel(agentsDir)), {
 			stdio: "ignore",
 			windowsHide: true,
 			timeout: 5000,


### PR DESCRIPTION
## Summary

Fixes #1479 by giving each macOS launchd-managed Signet workspace its own job label and plist. The previous global label and plist let a second workspace overwrite and restart the first workspace's daemon.

## Changes

- Hash the normalized agents directory with SHA-256 and use the first 12 hex characters in the launchd label and plist filename: `ai.signet.daemon.<workspace-hash>`.
- Make launchd probes, bootout, bootstrap, kickstart, and stop target the requested workspace label.
- Migrate the legacy `ai.signet.daemon.plist` when it belongs to the workspace being started, booting out the legacy job before creating the per-workspace job.
- Detect a legacy plist for a different workspace, warn clearly, and preserve it while starting the new workspace-specific job.
- Abort migration if the legacy job cannot be booted out, so the old job and new job cannot fight under the same workspace.
- Add regressions for distinct workspace labels and plist paths, legacy migration, duplicate-workspace detection, malformed legacy plists, and workspace-specific launchctl probes.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No database migrations. Existing legacy launchd state is migrated only when its `SIGNET_PATH` matches the workspace being started. A legacy plist for another workspace is preserved and reported instead of being silently displaced.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused proof:

- `bun test surfaces/cli/src/lib/runtime.test.ts` passed: 45 tests, 0 failures, 150 assertions.
- `bunx biome check surfaces/cli/src/lib/runtime.ts surfaces/cli/src/lib/runtime.test.ts` passed.
- `git diff --check` passed.
- Direct CLI bundle proof passed with `bun build surfaces/cli/src/cli.ts --outdir /tmp/signet-cli-build --target node --external better-sqlite3`.
- `bun run --filter '@signet/core' build` passed.
- `bun run --filter '@signet/cli' build` reached the existing CLI bundler failure: `cannot write multiple output files without an output directory`. The direct outdir bundle above passed.
- Full `bun run typecheck` remains red on pre-existing connector errors in connector-forge, connector-gemini, connector-openclaw, connector-opencode, connector-pi, connector-oh-my-pi, and connector-codex. The touched CLI runtime and focused tests pass.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

No macOS host was available for live `launchctl` verification. The regression suite exercises the label, plist path, migration decision, plist parsing, and launchctl argument construction. The branch is based on the current `origin/main` at implementation time.
