### PR TITLE
fix(daemon): make startup recovery async

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,15 +4,15 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 741 sites
-- Synchronous `withWriteTx()` sites: 111
-- Synchronous `withReadDb()` sites: 146
+- Exact ledger inventory: 732 sites
+- Synchronous `withWriteTx()` sites: 106
+- Synchronous `withReadDb()` sites: 142
 - Synchronous filesystem/process sites: 484
-- Compile-visible legacy DB sites remaining: 257
-  - `withWriteTx`: 111
-  - `withReadDb`: 146
+- Compile-visible legacy DB sites remaining: 248
+  - `withWriteTx`: 106
+  - `withReadDb`: 142
 
-The 741-site inventory excludes test, benchmark, generated, and `__tests__` fixtures. The 111 synchronous writes and 146 synchronous reads remain transitional callers for the later migration phase. They are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate 257 database operations.
+The 732-site inventory excludes test, benchmark, generated, and `__tests__` fixtures. The 106 synchronous writes and 142 synchronous reads remain transitional callers for the later migration phase. They are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate 248 database operations.
 
 ## A3 Slice 2 migration notes
 
@@ -29,4 +29,4 @@ The converted async sites are distributed as follows: document-worker (18), drea
 
 The structural boundary makes statically-resolved imports from the production source tree impossible: TypeScript reports TS6059 before aliases or computed member calls can use the compatibility type. The production bundle also only starts from source entrypoints, so this compatibility module is not a shipped production artifact.
 
-A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 257 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 111 write and 146 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.
+A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 248 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 106 write and 142 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -183,7 +183,7 @@ import {
 	sourceFailureClass,
 	trackSourceLifecycleWrite,
 } from "./source-lifecycle-telemetry";
-import { runStartupRecovery } from "./startup-recovery";
+import { getStartupRecoveryCompletion, runStartupRecovery } from "./startup-recovery";
 import { getPressureRecoveryOutcome, getSystemPressure, reportStartupGrace } from "./system-pressure";
 import {
 	type TelemetryCollector,
@@ -2036,7 +2036,7 @@ async function main() {
 	// WAL bloat) before any worker starts. Integrity scanning is deliberately
 	// not part of this synchronous phase. The full-database quick_check runs in
 	// a bounded worker after the HTTP server is ready (#1513).
-	const startupRecovery = runStartupRecovery(getDbAccessor());
+	runStartupRecovery(getDbAccessor());
 
 	// Purge artifacts of sources deleted while the daemon was down (e.g.
 	// crash-loop-disabled sources). This needs the DB accessor, so it runs
@@ -2164,29 +2164,33 @@ async function main() {
 			platform: process.platform,
 			uptimeMs: 0,
 		});
-		// A daemon restart turns any still-running pass into a failed pass. Emit
-		// a bounded, content-free outcome once telemetry is initialized so those
-		// failures are not silently lost at the recovery boundary.
-		for (let index = 0; index < Math.min(startupRecovery.orphanedPassesSwept, 100); index++) {
-			recordDreamingPassTelemetry({
-				mode: "startup-recovery",
-				outcome: "failed",
-				outcomeCode: "error",
-				effects: {
-					artifactsConsidered: 0,
-					memoriesCreated: 0,
-					memoriesUpdated: 0,
-					memoriesSuperseded: 0,
-					memoriesRetired: 0,
-					claimsChanged: 0,
-					relationshipsChanged: 0,
-					provenanceLinksChanged: 0,
-					toolCalls: 0,
-					durationMs: startupRecovery.durationMs,
-				},
-				usage: null,
-			});
-		}
+		// A daemon restart turns any still-running pass into a failed pass. Wait
+		// for the bounded drain to finish before emitting telemetry. The immediate
+		// compatibility report is deliberately marked "draining" and has no final
+		// orphan count yet.
+		void getStartupRecoveryCompletion().then((recovery) => {
+			if (recovery.recoveryPhase !== "complete") return;
+			for (let index = 0; index < Math.min(recovery.orphanedPassesSwept, 100); index++) {
+				recordDreamingPassTelemetry({
+					mode: "startup-recovery",
+					outcome: "failed",
+					outcomeCode: "error",
+					effects: {
+						artifactsConsidered: 0,
+						memoriesCreated: 0,
+						memoriesUpdated: 0,
+						memoriesSuperseded: 0,
+						memoriesRetired: 0,
+						claimsChanged: 0,
+						relationshipsChanged: 0,
+						provenanceLinksChanged: 0,
+						toolCalls: 0,
+						durationMs: recovery.durationMs,
+					},
+					usage: null,
+				});
+			}
+		});
 		for (const source of loadSourcesConfig(AGENTS_DIR).sources) {
 			if (source.enabled) {
 				// Server readiness must not wait on best-effort telemetry, but shutdown must drain it.

--- a/platform/daemon/src/database-integrity.test.ts
+++ b/platform/daemon/src/database-integrity.test.ts
@@ -109,33 +109,11 @@ describe("telemetry database integrity recovery (#1360)", () => {
 	it("runs a Node ESM repair child and verifies its committed indexes", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "integrity-repair-success-"));
 		const dbPath = join(dir, "memory.db");
-		const workerPath = join(dir, "repair-worker.mjs");
 		const database = new Database(dbPath);
 		database.exec(
-			"CREATE TABLE telemetry_events (event TEXT, queue TEXT, timestamp TEXT, unsent INTEGER); CREATE INDEX idx_telemetry_events_event ON telemetry_events(event); CREATE INDEX idx_telemetry_events_queue ON telemetry_events(queue); CREATE INDEX idx_telemetry_events_timestamp ON telemetry_events(timestamp); CREATE INDEX idx_telemetry_events_unsent ON telemetry_events(unsent); CREATE TABLE repair_markers (committed INTEGER NOT NULL)",
+			"CREATE TABLE telemetry_events (event TEXT, queue TEXT, timestamp TEXT, unsent INTEGER); CREATE INDEX idx_telemetry_events_event ON telemetry_events(event); CREATE INDEX idx_telemetry_events_queue ON telemetry_events(queue); CREATE INDEX idx_telemetry_events_timestamp ON telemetry_events(timestamp); CREATE INDEX idx_telemetry_events_unsent ON telemetry_events(unsent)",
 		);
 		database.close();
-		writeFileSync(
-			workerPath,
-			`import { DatabaseSync } from "node:sqlite";
-const database = new DatabaseSync(process.env.SIGNET_DATABASE_INTEGRITY_DB_PATH);
-const indexes = JSON.parse(process.env.SIGNET_DATABASE_INTEGRITY_INDEXES);
-const escaped = (name) => '"' + String(name).replaceAll('"', '""') + '"';
-try {
-  database.exec("BEGIN IMMEDIATE");
-  for (const index of indexes) database.exec("REINDEX " + escaped(index));
-  database.exec("INSERT INTO repair_markers (committed) VALUES (1)");
-  database.exec("COMMIT");
-  process.stdout.write(JSON.stringify({ ok: true }) + "\\n");
-} catch (error) {
-  try { database.exec("ROLLBACK"); } catch {}
-  process.stderr.write(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
-} finally {
-  database.close();
-}
-`,
-		);
 		const { accessor } = fakeAccessor({ telemetryMessage: "index mismatch" });
 
 		const result = await repairTelemetryIndexes(
@@ -145,7 +123,6 @@ try {
 			},
 			{
 				dbPath,
-				repairWorkerPath: workerPath,
 				repairTimeoutMs: 5_000,
 				repairRuntimePath: "node",
 			},
@@ -154,7 +131,6 @@ try {
 		expect(result.state).toBe("repaired");
 		expect(result.rebuiltIndexes).toHaveLength(4);
 		const verification = new Database(dbPath);
-		expect(verification.prepare("SELECT committed FROM repair_markers").all()).toEqual([{ committed: 1 }]);
 		expect(verification.prepare("PRAGMA integrity_check(telemetry_events)").all()).toEqual([{ integrity_check: "ok" }]);
 		verification.close();
 		rmSync(dir, { recursive: true, force: true });

--- a/platform/daemon/src/database-integrity.test.ts
+++ b/platform/daemon/src/database-integrity.test.ts
@@ -136,6 +136,54 @@ describe("telemetry database integrity recovery (#1360)", () => {
 		rmSync(dir, { recursive: true, force: true });
 	});
 
+	it("waits for a concurrent writer before repairing telemetry indexes", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "integrity-repair-busy-"));
+		const dbPath = join(dir, "memory.db");
+		const database = new Database(dbPath);
+		database.exec(
+			"PRAGMA journal_mode = WAL; CREATE TABLE telemetry_events (event TEXT, queue TEXT, timestamp TEXT, unsent INTEGER); CREATE INDEX idx_telemetry_events_event ON telemetry_events(event); CREATE INDEX idx_telemetry_events_queue ON telemetry_events(queue); CREATE INDEX idx_telemetry_events_timestamp ON telemetry_events(timestamp); CREATE INDEX idx_telemetry_events_unsent ON telemetry_events(unsent); BEGIN IMMEDIATE",
+		);
+		database.prepare("INSERT INTO telemetry_events VALUES (?, ?, ?, ?)").run("held", "queue", "now", 0);
+		const holdMs = 400;
+		const startedAt = Date.now();
+		const releaseTimer = setTimeout(() => {
+			database.exec("COMMIT");
+			database.close();
+		}, holdMs);
+
+		try {
+			const result = await repairTelemetryIndexes(
+				fakeAccessor({ telemetryMessage: "index mismatch" }).accessor,
+				(db) => {
+					db.exec("INSERT INTO repair_audit VALUES (1)");
+				},
+				{
+					dbPath,
+					repairTimeoutMs: 5_000,
+					repairRuntimePath: "node",
+				},
+			);
+
+			expect(result.state).toBe("repaired");
+			expect(result.rebuiltIndexes).toHaveLength(4);
+			expect(Date.now() - startedAt).toBeGreaterThanOrEqual(holdMs - 50);
+			const verification = new Database(dbPath, { readonly: true });
+			expect(verification.prepare("PRAGMA integrity_check(telemetry_events)").all()).toEqual([
+				{ integrity_check: "ok" },
+			]);
+			verification.close();
+		} finally {
+			clearTimeout(releaseTimer);
+			try {
+				database.exec("ROLLBACK");
+			} catch {}
+			try {
+				database.close();
+			} catch {}
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("audits the repair inside the write transaction", async () => {
 		const { accessor } = fakeAccessor({ telemetryMessage: "index mismatch" });
 		let auditedIndexes: readonly string[] = [];

--- a/platform/daemon/src/database-integrity.test.ts
+++ b/platform/daemon/src/database-integrity.test.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { repairTelemetryIndexes, runDeferredIntegrityCheck } from "./database-integrity";
@@ -106,20 +106,36 @@ describe("telemetry database integrity recovery (#1360)", () => {
 		]);
 	});
 
-	it("runs the production repair child under Node ESM and verifies its committed indexes", async () => {
+	it("runs a Node ESM repair child and verifies its committed indexes", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "integrity-repair-success-"));
 		const dbPath = join(dir, "memory.db");
-		const requireBase = join(dir, "package.json");
-		const sqliteModule = join(dir, "node_modules", "better-sqlite3");
-		writeFileSync(requireBase, "{}\n");
-		mkdirSync(sqliteModule, { recursive: true });
-		writeFileSync(join(sqliteModule, "package.json"), '{"main":"index.cjs"}\n');
-		writeFileSync(join(sqliteModule, "index.cjs"), "module.exports = class Database { exec() {} close() {} };\n");
+		const workerPath = join(dir, "repair-worker.mjs");
 		const database = new Database(dbPath);
 		database.exec(
-			"CREATE TABLE telemetry_events (event TEXT, queue TEXT, timestamp TEXT, unsent INTEGER); CREATE INDEX idx_telemetry_events_event ON telemetry_events(event); CREATE INDEX idx_telemetry_events_queue ON telemetry_events(queue); CREATE INDEX idx_telemetry_events_timestamp ON telemetry_events(timestamp); CREATE INDEX idx_telemetry_events_unsent ON telemetry_events(unsent)",
+			"CREATE TABLE telemetry_events (event TEXT, queue TEXT, timestamp TEXT, unsent INTEGER); CREATE INDEX idx_telemetry_events_event ON telemetry_events(event); CREATE INDEX idx_telemetry_events_queue ON telemetry_events(queue); CREATE INDEX idx_telemetry_events_timestamp ON telemetry_events(timestamp); CREATE INDEX idx_telemetry_events_unsent ON telemetry_events(unsent); CREATE TABLE repair_markers (committed INTEGER NOT NULL)",
 		);
 		database.close();
+		writeFileSync(
+			workerPath,
+			`import { DatabaseSync } from "node:sqlite";
+const database = new DatabaseSync(process.env.SIGNET_DATABASE_INTEGRITY_DB_PATH);
+const indexes = JSON.parse(process.env.SIGNET_DATABASE_INTEGRITY_INDEXES);
+const escaped = (name) => '"' + String(name).replaceAll('"', '""') + '"';
+try {
+  database.exec("BEGIN IMMEDIATE");
+  for (const index of indexes) database.exec("REINDEX " + escaped(index));
+  database.exec("INSERT INTO repair_markers (committed) VALUES (1)");
+  database.exec("COMMIT");
+  process.stdout.write(JSON.stringify({ ok: true }) + "\\n");
+} catch (error) {
+  try { database.exec("ROLLBACK"); } catch {}
+  process.stderr.write(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+} finally {
+  database.close();
+}
+`,
+		);
 		const { accessor } = fakeAccessor({ telemetryMessage: "index mismatch" });
 
 		const result = await repairTelemetryIndexes(
@@ -127,11 +143,20 @@ describe("telemetry database integrity recovery (#1360)", () => {
 			(db) => {
 				db.exec("INSERT INTO repair_audit VALUES (1)");
 			},
-			{ dbPath, repairTimeoutMs: 5_000, repairRuntimePath: "node", repairRequireBase: requireBase },
+			{
+				dbPath,
+				repairWorkerPath: workerPath,
+				repairTimeoutMs: 5_000,
+				repairRuntimePath: "node",
+			},
 		);
 
 		expect(result.state).toBe("repaired");
 		expect(result.rebuiltIndexes).toHaveLength(4);
+		const verification = new Database(dbPath);
+		expect(verification.prepare("SELECT committed FROM repair_markers").all()).toEqual([{ committed: 1 }]);
+		expect(verification.prepare("PRAGMA integrity_check(telemetry_events)").all()).toEqual([{ integrity_check: "ok" }]);
+		verification.close();
 		rmSync(dir, { recursive: true, force: true });
 	});
 

--- a/platform/daemon/src/database-integrity.test.ts
+++ b/platform/daemon/src/database-integrity.test.ts
@@ -12,78 +12,88 @@ function fakeAccessor(options: { readonly quickMessage?: string; readonly teleme
 } {
 	let repaired = false;
 	const reindexed: string[] = [];
+	const readDb: ReadDb = {
+		prepare(sql: string) {
+			return {
+				run(): { readonly changes: number } {
+					return { changes: 0 };
+				},
+				get(): undefined {
+					return undefined;
+				},
+				all<Row = unknown>(): Row[] {
+					if (sql === "PRAGMA quick_check") return [{ quick_check: options.quickMessage ?? "ok" }] as Row[];
+					if (sql === "PRAGMA integrity_check(telemetry_events)") {
+						return [{ integrity_check: repaired ? "ok" : (options.telemetryMessage ?? "ok") }] as Row[];
+					}
+					if (
+						sql ===
+						"SELECT name FROM sqlite_schema WHERE type = 'index' AND tbl_name = 'telemetry_events' AND sql IS NOT NULL ORDER BY name"
+					) {
+						return [
+							{ name: "idx_telemetry_events_event" },
+							{ name: "idx_telemetry_events_queue" },
+							{ name: "idx_telemetry_events_timestamp" },
+							{ name: "idx_telemetry_events_unsent" },
+						] as Row[];
+					}
+					throw new Error(`unexpected query: ${sql}`);
+				},
+			};
+		},
+	};
+	const writeDb: WriteDb = {
+		exec(sql: string): void {
+			repaired = true;
+			reindexed.push(sql);
+		},
+		prepare(_sql: string) {
+			return {
+				run(): { readonly changes: number } {
+					return { changes: 0 };
+				},
+				get(): undefined {
+					return undefined;
+				},
+				all<Row = unknown>(): Row[] {
+					return [] as Row[];
+				},
+			};
+		},
+	};
 	const accessor: DbAccessor = {
 		withReadDb<T>(fn: (db: ReadDb) => T): T {
-			return fn({
-				prepare(sql: string) {
-					return {
-						run(): { readonly changes: number } {
-							return { changes: 0 };
-						},
-						get(): undefined {
-							return undefined;
-						},
-						all(): unknown[] {
-							if (sql === "PRAGMA quick_check") {
-								return [{ quick_check: options.quickMessage ?? "ok" }];
-							}
-							if (sql === "PRAGMA integrity_check(telemetry_events)") {
-								return [{ integrity_check: repaired ? "ok" : (options.telemetryMessage ?? "ok") }];
-							}
-							if (
-								sql ===
-								"SELECT name FROM sqlite_schema WHERE type = 'index' AND tbl_name = 'telemetry_events' AND sql IS NOT NULL ORDER BY name"
-							) {
-								return [
-									{ name: "idx_telemetry_events_event" },
-									{ name: "idx_telemetry_events_queue" },
-									{ name: "idx_telemetry_events_timestamp" },
-									{ name: "idx_telemetry_events_unsent" },
-								];
-							}
-							throw new Error(`unexpected query: ${sql}`);
-						},
-					};
-				},
-			} as ReadDb);
+			return fn(readDb);
+		},
+		withReadDbAsync<T>(fn: (db: ReadDb) => Promise<T>): Promise<T> {
+			return fn(readDb);
 		},
 		withWriteTx<T>(fn: (db: WriteDb) => T): T {
-			return fn({
-				exec(sql: string): void {
-					repaired = true;
-					reindexed.push(sql);
-				},
-				prepare() {
-					return {
-						run(): { readonly changes: number } {
-							return { changes: 0 };
-						},
-						get(): undefined {
-							return undefined;
-						},
-						all(): unknown[] {
-							return [];
-						},
-					};
-				},
-			} as WriteDb);
+			return fn(writeDb);
+		},
+		withWriteTxAsync<T>(fn: (db: WriteDb) => T): Promise<T> {
+			return Promise.resolve(fn(writeDb));
+		},
+		checkpointWal(): void {},
+		incrementalVacuum(): number {
+			return 0;
 		},
 		close(): void {},
 	};
 	return { accessor, reindexed };
 }
 
-afterEach(() => {
-	repairTelemetryIndexes(fakeAccessor({}).accessor);
+afterEach(async () => {
+	await repairTelemetryIndexes(fakeAccessor({}).accessor);
 });
 
 describe("telemetry database integrity recovery (#1360)", () => {
-	it("rebuilds disposable telemetry indexes after quick_check misses the mismatch", () => {
+	it("rebuilds disposable telemetry indexes after quick_check misses the mismatch", async () => {
 		const { accessor, reindexed } = fakeAccessor({
 			telemetryMessage: "row 111120 missing from index idx_telemetry_events_event",
 		});
 
-		const result = repairTelemetryIndexes(accessor);
+		const result = await repairTelemetryIndexes(accessor);
 
 		expect(result.state).toBe("repaired");
 		expect(result.quickCheck.ok).toBe(true);
@@ -96,12 +106,35 @@ describe("telemetry database integrity recovery (#1360)", () => {
 		]);
 	});
 
-	it("audits the repair inside the write transaction", () => {
+	it("runs the production repair child and verifies its committed indexes", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "integrity-repair-success-"));
+		const dbPath = join(dir, "memory.db");
+		const database = new Database(dbPath);
+		database.exec(
+			"CREATE TABLE telemetry_events (event TEXT, queue TEXT, timestamp TEXT, unsent INTEGER); CREATE INDEX idx_telemetry_events_event ON telemetry_events(event); CREATE INDEX idx_telemetry_events_queue ON telemetry_events(queue); CREATE INDEX idx_telemetry_events_timestamp ON telemetry_events(timestamp); CREATE INDEX idx_telemetry_events_unsent ON telemetry_events(unsent)",
+		);
+		database.close();
+		const { accessor } = fakeAccessor({ telemetryMessage: "index mismatch" });
+
+		const result = await repairTelemetryIndexes(
+			accessor,
+			(db) => {
+				db.exec("INSERT INTO repair_audit VALUES (1)");
+			},
+			{ dbPath, repairTimeoutMs: 5_000 },
+		);
+
+		expect(result.state).toBe("repaired");
+		expect(result.rebuiltIndexes).toHaveLength(4);
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("audits the repair inside the write transaction", async () => {
 		const { accessor } = fakeAccessor({ telemetryMessage: "index mismatch" });
 		let auditedIndexes: readonly string[] = [];
 		let detectionMessages: readonly string[] = [];
 
-		const result = repairTelemetryIndexes(accessor, (_db, indexes, messages) => {
+		const result = await repairTelemetryIndexes(accessor, (_db, indexes, messages) => {
 			auditedIndexes = indexes;
 			detectionMessages = messages;
 		});
@@ -116,10 +149,10 @@ describe("telemetry database integrity recovery (#1360)", () => {
 		expect(detectionMessages).toEqual(["index mismatch"]);
 	});
 
-	it("fails closed when the repair audit cannot be written", () => {
+	it("fails closed when the repair audit cannot be written", async () => {
 		const { accessor } = fakeAccessor({ telemetryMessage: "index mismatch" });
 
-		const result = repairTelemetryIndexes(accessor, () => {
+		const result = await repairTelemetryIndexes(accessor, () => {
 			throw new Error("memory_history unavailable");
 		});
 
@@ -128,13 +161,13 @@ describe("telemetry database integrity recovery (#1360)", () => {
 		expect(result.telemetryCheck.messages).toContain("memory_history unavailable");
 	});
 
-	it("does not rewrite an unrelated database when quick_check fails", () => {
+	it("does not rewrite an unrelated database when quick_check fails", async () => {
 		const { accessor, reindexed } = fakeAccessor({
 			quickMessage: "database disk image is malformed",
 			telemetryMessage: "row 111120 missing from index idx_telemetry_events_event",
 		});
 
-		const result = repairTelemetryIndexes(accessor);
+		const result = await repairTelemetryIndexes(accessor);
 
 		expect(result.state).toBe("corrupt");
 		expect(result.quickCheck.ok).toBe(false);
@@ -237,5 +270,32 @@ describe("deferred database integrity recovery (#1513)", () => {
 		expect(result.state).toBe("unavailable");
 		expect(result.phase).toBe("timed_out");
 		expect(result.repairGuidance).toContain("back up the database");
+	});
+
+	it("kills a telemetry repair child at its deadline without corrupting the database", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "integrity-repair-timeout-"));
+		const dbPath = join(dir, "memory.db");
+		const workerPath = join(dir, "blocking-repair-worker.mjs");
+		const database = new Database(dbPath);
+		database.exec("CREATE TABLE repair_fixture (value TEXT)");
+		database.close();
+		writeFileSync(workerPath, 'process.stdout.write("started\\n"); setTimeout(() => {}, 1000);\n');
+
+		const result = await repairTelemetryIndexes(
+			fakeAccessor({ telemetryMessage: "index mismatch" }).accessor,
+			undefined,
+			{
+				dbPath,
+				repairWorkerPath: workerPath,
+				repairTimeoutMs: 25,
+			},
+		);
+
+		expect(result.state).toBe("unavailable");
+		expect(result.phase).toBe("timed_out");
+		const verified = new Database(dbPath, { readonly: true });
+		expect(verified.prepare("SELECT COUNT(*) AS n FROM repair_fixture").get()).toEqual({ n: 0 });
+		verified.close();
+		rmSync(dir, { recursive: true, force: true });
 	});
 });

--- a/platform/daemon/src/database-integrity.test.ts
+++ b/platform/daemon/src/database-integrity.test.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { repairTelemetryIndexes, runDeferredIntegrityCheck } from "./database-integrity";
@@ -106,9 +106,15 @@ describe("telemetry database integrity recovery (#1360)", () => {
 		]);
 	});
 
-	it("runs the production repair child and verifies its committed indexes", async () => {
+	it("runs the production repair child under Node ESM and verifies its committed indexes", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "integrity-repair-success-"));
 		const dbPath = join(dir, "memory.db");
+		const requireBase = join(dir, "package.json");
+		const sqliteModule = join(dir, "node_modules", "better-sqlite3");
+		writeFileSync(requireBase, "{}\n");
+		mkdirSync(sqliteModule, { recursive: true });
+		writeFileSync(join(sqliteModule, "package.json"), '{"main":"index.cjs"}\n');
+		writeFileSync(join(sqliteModule, "index.cjs"), "module.exports = class Database { exec() {} close() {} };\n");
 		const database = new Database(dbPath);
 		database.exec(
 			"CREATE TABLE telemetry_events (event TEXT, queue TEXT, timestamp TEXT, unsent INTEGER); CREATE INDEX idx_telemetry_events_event ON telemetry_events(event); CREATE INDEX idx_telemetry_events_queue ON telemetry_events(queue); CREATE INDEX idx_telemetry_events_timestamp ON telemetry_events(timestamp); CREATE INDEX idx_telemetry_events_unsent ON telemetry_events(unsent)",
@@ -121,7 +127,7 @@ describe("telemetry database integrity recovery (#1360)", () => {
 			(db) => {
 				db.exec("INSERT INTO repair_audit VALUES (1)");
 			},
-			{ dbPath, repairTimeoutMs: 5_000 },
+			{ dbPath, repairTimeoutMs: 5_000, repairRuntimePath: "node", repairRequireBase: requireBase },
 		);
 
 		expect(result.state).toBe("repaired");
@@ -159,6 +165,35 @@ describe("telemetry database integrity recovery (#1360)", () => {
 		expect(result.state).toBe("corrupt");
 		expect(result.rebuiltIndexes).toEqual([]);
 		expect(result.telemetryCheck.messages).toContain("memory_history unavailable");
+	});
+
+	it("does not start a production repair child when the audit fails", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "integrity-repair-audit-failure-"));
+		const dbPath = join(dir, "memory.db");
+		const markerPath = join(dir, "child-started");
+		const workerPath = join(dir, "marker-worker.mjs");
+		const database = new Database(dbPath);
+		database.exec(
+			"CREATE TABLE telemetry_events (event TEXT); CREATE INDEX idx_telemetry_events_event ON telemetry_events(event)",
+		);
+		database.close();
+		writeFileSync(
+			workerPath,
+			`import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(markerPath)}, "started");\n`,
+		);
+
+		const result = await repairTelemetryIndexes(
+			fakeAccessor({ telemetryMessage: "index mismatch" }).accessor,
+			() => {
+				throw new Error("audit unavailable");
+			},
+			{ dbPath, repairWorkerPath: workerPath, repairRuntimePath: "node", repairTimeoutMs: 5_000 },
+		);
+
+		expect(result.state).toBe("corrupt");
+		expect(result.telemetryCheck.messages).toContain("audit unavailable");
+		expect(existsSync(markerPath)).toBe(false);
+		rmSync(dir, { recursive: true, force: true });
 	});
 
 	it("does not rewrite an unrelated database when quick_check fails", async () => {

--- a/platform/daemon/src/database-integrity.ts
+++ b/platform/daemon/src/database-integrity.ts
@@ -135,7 +135,10 @@ class IntegrityRepairTimeoutError extends Error {
 const REPAIR_WORKER_SOURCE = `
 import { createRequire } from "node:module";
 const load = createRequire(process.env.SIGNET_DATABASE_INTEGRITY_REQUIRE_BASE || process.cwd() + "/package.json");
-const Database = typeof Bun !== "undefined" ? load("bun:sqlite").Database : load("better-sqlite3");
+const Database = (() => {
+  if (typeof Bun !== "undefined") return load("bun:sqlite").Database;
+  try { return load("node:sqlite").DatabaseSync; } catch { return load("better-sqlite3"); }
+})();
 const dbPath = process.env.SIGNET_DATABASE_INTEGRITY_DB_PATH;
 const indexes = JSON.parse(process.env.SIGNET_DATABASE_INTEGRITY_INDEXES || "[]");
 if (typeof dbPath !== "string" || !Array.isArray(indexes)) throw new Error("invalid integrity repair arguments");

--- a/platform/daemon/src/database-integrity.ts
+++ b/platform/daemon/src/database-integrity.ts
@@ -9,8 +9,10 @@
 
 import { type ChildProcess, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import { logger } from "./logger";
 import { resolveEmbeddedWorkerPath } from "./native-runtime-assets";
@@ -121,11 +123,111 @@ export interface DeferredIntegrityCheckOptions {
 const DEFAULT_INTEGRITY_TIMEOUT_MS = 30_000;
 let deferredIntegrityRun: Promise<DatabaseIntegrityStatus> | null = null;
 
+class IntegrityRepairTimeoutError extends Error {
+	readonly timedOut = true;
+
+	constructor(timeoutMs: number) {
+		super(`telemetry index repair exceeded ${timeoutMs}ms`);
+		this.name = "IntegrityRepairTimeoutError";
+	}
+}
+
+const REPAIR_WORKER_SOURCE = `
+const { createRequire } = require("node:module");
+const load = createRequire(process.cwd() + "/package.json");
+const Database = typeof Bun !== "undefined" ? load("bun:sqlite").Database : load("better-sqlite3");
+const dbPath = process.env.SIGNET_DATABASE_INTEGRITY_DB_PATH;
+const indexes = JSON.parse(process.env.SIGNET_DATABASE_INTEGRITY_INDEXES || "[]");
+if (typeof dbPath !== "string" || !Array.isArray(indexes)) throw new Error("invalid integrity repair arguments");
+const escaped = (name) => '"' + String(name).replaceAll('"', '""') + '"';
+const database = new Database(dbPath);
+try {
+  database.exec("BEGIN IMMEDIATE");
+  for (const index of indexes) database.exec("REINDEX " + escaped(index));
+  database.exec("COMMIT");
+  process.stdout.write(JSON.stringify({ ok: true }) + "\\n");
+} catch (error) {
+  try { database.exec("ROLLBACK"); } catch {}
+  process.stderr.write(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+} finally {
+  database.close();
+}
+`;
+
 function workerPathFromModule(): string {
 	const moduleDir = dirname(fileURLToPath(import.meta.url));
 	const bundled = join(moduleDir, "database-integrity-worker.js");
 	if (existsSync(bundled)) return bundled;
 	return join(moduleDir, "database-integrity-worker.ts");
+}
+
+async function runKillableTelemetryRepair(
+	dbPath: string,
+	indexes: readonly string[],
+	timeoutMs: number,
+	workerPath?: string,
+): Promise<void> {
+	const dir = workerPath === undefined ? await mkdtemp(join(tmpdir(), "signet-integrity-repair-")) : null;
+	const scriptPath = workerPath ?? join(dir ?? tmpdir(), "repair.mjs");
+	if (workerPath === undefined) await writeFile(scriptPath, REPAIR_WORKER_SOURCE, "utf8");
+
+	let child: ChildProcess | undefined;
+	try {
+		child = spawn(process.execPath, [scriptPath], {
+			env: {
+				...process.env,
+				SIGNET_DATABASE_INTEGRITY_DB_PATH: dbPath,
+				SIGNET_DATABASE_INTEGRITY_INDEXES: JSON.stringify(indexes),
+			},
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		await new Promise<void>((resolve, reject) => {
+			let settled = false;
+			const timer = setTimeout(() => {
+				if (settled) return;
+				settled = true;
+				child?.kill("SIGKILL");
+				reject(new IntegrityRepairTimeoutError(timeoutMs));
+			}, timeoutMs);
+			let output = "";
+			child?.stdout?.setEncoding("utf8");
+			child?.stdout?.on("data", (chunk: string) => {
+				output += chunk;
+			});
+			child?.once("error", (error) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				reject(error);
+			});
+			child?.once("close", (code) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				if (code !== 0) {
+					reject(new Error(`telemetry index repair worker exited with code ${code ?? "unknown"}`));
+					return;
+				}
+				try {
+					const result = JSON.parse(output.trim()) as { ok?: unknown };
+					if (result.ok !== true) throw new Error("telemetry index repair worker returned an invalid result");
+					resolve();
+				} catch (error) {
+					reject(error);
+				}
+			});
+			child?.stderr?.resume();
+		});
+	} finally {
+		if (child !== undefined && child.exitCode === null) child.kill("SIGKILL");
+		if (dir !== null) await rm(dir, { recursive: true, force: true });
+	}
+}
+
+async function writeAsync<Result>(accessor: DbAccessor, processBatch: (db: WriteDb) => Result): Promise<Result> {
+	if (accessor.withWriteTxAsync) return accessor.withWriteTxAsync(processBatch);
+	return accessor.withWriteTx(processBatch);
 }
 
 /**
@@ -224,7 +326,11 @@ async function runDeferredIntegrityCheckInternal(
 			});
 			child.stderr.resume();
 		});
-		const databaseIntegrity = repairTelemetryIndexes(accessor, options.audit, { quickCheck: result.quickCheck });
+		const databaseIntegrity = await repairTelemetryIndexes(accessor, options.audit, {
+			quickCheck: result.quickCheck,
+			dbPath,
+			repairTimeoutMs: timeoutMs,
+		});
 		latestStatus = { ...databaseIntegrity, durationMs: Date.now() - startedAt };
 		logger.info("startup-recovery", "Deferred database integrity check complete", {
 			state: latestStatus.state,
@@ -253,21 +359,27 @@ async function runDeferredIntegrityCheckInternal(
 }
 
 /**
- * Check the database before background workers start and repair only the
- * disposable telemetry indexes when the targeted check identifies damage.
- * The optional audit runs inside the same write transaction as REINDEX.
+ * Check the database and repair only disposable telemetry indexes when the
+ * targeted check identifies damage. Production REINDEX work runs in a
+ * killable child with a real deadline. The audit is admitted through the
+ * bounded async writer queue after the child commits; test doubles without a
+ * database path use one queued transaction for both operations.
  */
-export function repairTelemetryIndexes(
+export async function repairTelemetryIndexes(
 	accessor: DbAccessor,
 	audit?: TelemetryIndexRepairAudit,
-	options?: { readonly quickCheck?: IntegrityCheckStatus },
-): DatabaseIntegrityStatus {
+	options?: {
+		readonly quickCheck?: IntegrityCheckStatus;
+		readonly dbPath?: string;
+		readonly repairTimeoutMs?: number;
+		readonly repairWorkerPath?: string;
+	},
+): Promise<DatabaseIntegrityStatus> {
 	let quickCheck: IntegrityCheckStatus;
 	let telemetryCheck: IntegrityCheckStatus;
 	let telemetryIndexes: readonly string[];
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const checks = accessor.withReadDb((db: import("./db-accessor").ReadDb) => ({
+		const checks = await accessor.withReadDbAsync(async (db) => ({
 			quick: options?.quickCheck ?? check(db, "quick_check"),
 			telemetry: check(db, "integrity_check", "telemetry_events"),
 			indexes: listTelemetryIndexes(db),
@@ -291,8 +403,7 @@ export function repairTelemetryIndexes(
 	}
 
 	// quick_check covers the whole database. A failed global check is not
-	// safely repairable by rebuilding a telemetry index, even if that index is
-	// also mentioned in the targeted failure.
+	// safely repairable by rebuilding a telemetry index.
 	if (!quickCheck.ok) {
 		latestStatus = statusWith("corrupt", quickCheck, telemetryCheck, []);
 		return latestStatus;
@@ -300,13 +411,24 @@ export function repairTelemetryIndexes(
 
 	if (!telemetryCheck.ok) {
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-			accessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
-				for (const index of telemetryIndexes) db.exec(`REINDEX ${escapedIdentifier(index)}`);
-				audit?.(db, telemetryIndexes, telemetryCheck.messages);
-			});
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const verifiedTelemetry = accessor.withReadDb((db: import("./db-accessor").ReadDb) =>
+			if (options?.dbPath !== undefined) {
+				await runKillableTelemetryRepair(
+					options.dbPath,
+					telemetryIndexes,
+					options.repairTimeoutMs ?? DEFAULT_INTEGRITY_TIMEOUT_MS,
+					options.repairWorkerPath,
+				);
+				if (audit !== undefined) {
+					await writeAsync(accessor, (db) => audit(db, telemetryIndexes, telemetryCheck.messages));
+				}
+			} else {
+				await writeAsync(accessor, (db) => {
+					for (const index of telemetryIndexes) db.exec(`REINDEX ${escapedIdentifier(index)}`);
+					audit?.(db, telemetryIndexes, telemetryCheck.messages);
+				});
+			}
+
+			const verifiedTelemetry = await accessor.withReadDbAsync(async (db) =>
 				check(db, "integrity_check", "telemetry_events"),
 			);
 			if (verifiedTelemetry.ok) {
@@ -315,10 +437,12 @@ export function repairTelemetryIndexes(
 			}
 			telemetryCheck = verifiedTelemetry;
 		} catch (error) {
-			telemetryCheck = {
-				ok: false,
-				messages: [...telemetryCheck.messages, error instanceof Error ? error.message : String(error)],
-			};
+			const message = error instanceof Error ? error.message : String(error);
+			telemetryCheck = { ok: false, messages: [...telemetryCheck.messages, message] };
+			if (error instanceof IntegrityRepairTimeoutError) {
+				latestStatus = statusWith("unavailable", quickCheck, telemetryCheck, [], "timed_out", 0);
+				return latestStatus;
+			}
 		}
 	}
 

--- a/platform/daemon/src/database-integrity.ts
+++ b/platform/daemon/src/database-integrity.ts
@@ -133,8 +133,8 @@ class IntegrityRepairTimeoutError extends Error {
 }
 
 const REPAIR_WORKER_SOURCE = `
-const { createRequire } = require("node:module");
-const load = createRequire(process.cwd() + "/package.json");
+import { createRequire } from "node:module";
+const load = createRequire(process.env.SIGNET_DATABASE_INTEGRITY_REQUIRE_BASE || process.cwd() + "/package.json");
 const Database = typeof Bun !== "undefined" ? load("bun:sqlite").Database : load("better-sqlite3");
 const dbPath = process.env.SIGNET_DATABASE_INTEGRITY_DB_PATH;
 const indexes = JSON.parse(process.env.SIGNET_DATABASE_INTEGRITY_INDEXES || "[]");
@@ -167,6 +167,8 @@ async function runKillableTelemetryRepair(
 	indexes: readonly string[],
 	timeoutMs: number,
 	workerPath?: string,
+	runtimePath?: string,
+	requireBase?: string,
 ): Promise<void> {
 	const dir = workerPath === undefined ? await mkdtemp(join(tmpdir(), "signet-integrity-repair-")) : null;
 	const scriptPath = workerPath ?? join(dir ?? tmpdir(), "repair.mjs");
@@ -174,11 +176,12 @@ async function runKillableTelemetryRepair(
 
 	let child: ChildProcess | undefined;
 	try {
-		child = spawn(process.execPath, [scriptPath], {
+		child = spawn(runtimePath ?? process.execPath, [scriptPath], {
 			env: {
 				...process.env,
 				SIGNET_DATABASE_INTEGRITY_DB_PATH: dbPath,
 				SIGNET_DATABASE_INTEGRITY_INDEXES: JSON.stringify(indexes),
+				SIGNET_DATABASE_INTEGRITY_REQUIRE_BASE: requireBase ?? fileURLToPath(import.meta.url),
 			},
 			stdio: ["ignore", "pipe", "pipe"],
 		});
@@ -361,9 +364,10 @@ async function runDeferredIntegrityCheckInternal(
 /**
  * Check the database and repair only disposable telemetry indexes when the
  * targeted check identifies damage. Production REINDEX work runs in a
- * killable child with a real deadline. The audit is admitted through the
- * bounded async writer queue after the child commits; test doubles without a
- * database path use one queued transaction for both operations.
+ * killable child with a real deadline. Production audits are admitted through
+ * the bounded async writer queue before the child can commit its repair; test
+ * doubles without a database path use one queued transaction for both
+ * operations.
  */
 export async function repairTelemetryIndexes(
 	accessor: DbAccessor,
@@ -373,6 +377,8 @@ export async function repairTelemetryIndexes(
 		readonly dbPath?: string;
 		readonly repairTimeoutMs?: number;
 		readonly repairWorkerPath?: string;
+		readonly repairRuntimePath?: string;
+		readonly repairRequireBase?: string;
 	},
 ): Promise<DatabaseIntegrityStatus> {
 	let quickCheck: IntegrityCheckStatus;
@@ -412,15 +418,17 @@ export async function repairTelemetryIndexes(
 	if (!telemetryCheck.ok) {
 		try {
 			if (options?.dbPath !== undefined) {
+				if (audit !== undefined) {
+					await writeAsync(accessor, (db) => audit(db, telemetryIndexes, telemetryCheck.messages));
+				}
 				await runKillableTelemetryRepair(
 					options.dbPath,
 					telemetryIndexes,
 					options.repairTimeoutMs ?? DEFAULT_INTEGRITY_TIMEOUT_MS,
 					options.repairWorkerPath,
+					options.repairRuntimePath,
+					options.repairRequireBase,
 				);
-				if (audit !== undefined) {
-					await writeAsync(accessor, (db) => audit(db, telemetryIndexes, telemetryCheck.messages));
-				}
 			} else {
 				await writeAsync(accessor, (db) => {
 					for (const index of telemetryIndexes) db.exec(`REINDEX ${escapedIdentifier(index)}`);

--- a/platform/daemon/src/database-integrity.ts
+++ b/platform/daemon/src/database-integrity.ts
@@ -132,6 +132,10 @@ class IntegrityRepairTimeoutError extends Error {
 	}
 }
 
+const REPAIR_BUSY_TIMEOUT_MS = 5_000;
+const REPAIR_BUSY_RETRIES = 3;
+const REPAIR_BUSY_BACKOFF_MS = 50;
+
 const REPAIR_WORKER_SOURCE = `
 import { createRequire } from "node:module";
 const load = createRequire(process.env.SIGNET_DATABASE_INTEGRITY_REQUIRE_BASE || process.cwd() + "/package.json");
@@ -143,11 +147,35 @@ const dbPath = process.env.SIGNET_DATABASE_INTEGRITY_DB_PATH;
 const indexes = JSON.parse(process.env.SIGNET_DATABASE_INTEGRITY_INDEXES || "[]");
 if (typeof dbPath !== "string" || !Array.isArray(indexes)) throw new Error("invalid integrity repair arguments");
 const escaped = (name) => '"' + String(name).replaceAll('"', '""') + '"';
-const database = new Database(dbPath);
+const database = typeof Bun === "undefined"
+  ? new Database(dbPath, { timeout: ${REPAIR_BUSY_TIMEOUT_MS} })
+  : new Database(dbPath);
+database.exec("PRAGMA busy_timeout = ${REPAIR_BUSY_TIMEOUT_MS}");
+const isBusyError = (error) => {
+  const code = error && typeof error === "object" && "code" in error ? error.code : undefined;
+  const message = error instanceof Error ? error.message : String(error);
+  return code === "SQLITE_BUSY" || message.includes("SQLITE_BUSY") || message.includes("database is locked");
+};
+const wait = (milliseconds) => {
+  const signal = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(signal, 0, 0, milliseconds);
+};
+const repair = () => {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      database.exec("BEGIN IMMEDIATE");
+      for (const index of indexes) database.exec("REINDEX " + escaped(index));
+      database.exec("COMMIT");
+      return;
+    } catch (error) {
+      try { database.exec("ROLLBACK"); } catch {}
+      if (!isBusyError(error) || attempt >= ${REPAIR_BUSY_RETRIES}) throw error;
+      wait(${REPAIR_BUSY_BACKOFF_MS} * 2 ** attempt);
+    }
+  }
+};
 try {
-  database.exec("BEGIN IMMEDIATE");
-  for (const index of indexes) database.exec("REINDEX " + escaped(index));
-  database.exec("COMMIT");
+  repair();
   process.stdout.write(JSON.stringify({ ok: true }) + "\\n");
 } catch (error) {
   try { database.exec("ROLLBACK"); } catch {}
@@ -197,9 +225,14 @@ async function runKillableTelemetryRepair(
 				reject(new IntegrityRepairTimeoutError(timeoutMs));
 			}, timeoutMs);
 			let output = "";
+			let errorOutput = "";
 			child?.stdout?.setEncoding("utf8");
 			child?.stdout?.on("data", (chunk: string) => {
 				output += chunk;
+			});
+			child?.stderr?.setEncoding("utf8");
+			child?.stderr?.on("data", (chunk: string) => {
+				errorOutput += chunk;
 			});
 			child?.once("error", (error) => {
 				if (settled) return;
@@ -212,7 +245,12 @@ async function runKillableTelemetryRepair(
 				settled = true;
 				clearTimeout(timer);
 				if (code !== 0) {
-					reject(new Error(`telemetry index repair worker exited with code ${code ?? "unknown"}`));
+					const detail = errorOutput.trim();
+					reject(
+						new Error(
+							`telemetry index repair worker exited with code ${code ?? "unknown"}${detail.length > 0 ? `: ${detail}` : ""}`,
+						),
+					);
 					return;
 				}
 				try {

--- a/platform/daemon/src/database-integrity.ts
+++ b/platform/daemon/src/database-integrity.ts
@@ -229,8 +229,7 @@ async function runKillableTelemetryRepair(
 }
 
 async function writeAsync<Result>(accessor: DbAccessor, processBatch: (db: WriteDb) => Result): Promise<Result> {
-	if (accessor.withWriteTxAsync) return accessor.withWriteTxAsync(processBatch);
-	return accessor.withWriteTx(processBatch);
+	return accessor.withWriteTxAsync(processBatch);
 }
 
 /**

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -271,25 +271,6 @@ export function startDreamingWorker(
 		};
 	};
 
-	// Sweep orphaned passes from unclean shutdown: any 'running' record
-	// was left by a crash or forced stop — mark it failed
-	// so the status API doesn't show a forever-running ghost pass.
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	accessor.withWriteTx((db: import("../db-accessor").WriteDb) => {
-		const orphaned = db
-			.prepare(
-				`UPDATE dreaming_passes
-				 SET status = 'failed',
-				     completed_at = datetime('now'),
-				     error = 'Orphaned by daemon restart'
-				 WHERE status = 'running'`,
-			)
-			.run();
-		if (orphaned.changes > 0) {
-			logger.warn("dreaming-worker", `Swept ${orphaned.changes} orphaned running pass(es) from prior shutdown`);
-		}
-	});
-
 	async function runPass(
 		runAgentId: string,
 		mode: DreamingMode,

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -509,7 +509,7 @@ export async function createDreamingPass(accessor: DbAccessor, agentId: string, 
 	await writeTx(accessor, (db) => {
 		db.prepare(
 			`INSERT INTO dreaming_passes (id, agent_id, mode, status, started_at, created_at)
-			 VALUES (?, ?, ?, 'running', datetime('now'), datetime('now'))`,
+			 VALUES (?, ?, ?, 'running', strftime('%Y-%m-%d %H:%M:%f', 'now'), strftime('%Y-%m-%d %H:%M:%f', 'now'))`,
 		).run(id, agentId, mode);
 	});
 	return id;

--- a/platform/daemon/src/startup-recovery.test.ts
+++ b/platform/daemon/src/startup-recovery.test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { WriteDb } from "./db-accessor";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
-import { runStartupRecovery, runStartupRecoveryAsync } from "./startup-recovery";
+import { getStartupRecoveryCompletion, runStartupRecovery, runStartupRecoveryAsync } from "./startup-recovery";
 
 const dbFiles = ["memories.db", "memories.db-shm", "memories.db-wal"];
 let agentsDir = "";
@@ -203,6 +203,20 @@ describe("runStartupRecovery", () => {
 				(db.prepare("SELECT COUNT(*) AS n FROM dreaming_passes WHERE status = 'failed'").get() as { n: number }).n,
 		);
 		expect(failedCount).toBe(2);
+	});
+
+	it("keeps the immediate report in draining state until orphan telemetry is countable", async () => {
+		getDbAccessor().withWriteTx((db) => {
+			insertPass(db, "running-draining", "running");
+		});
+
+		const immediate = runStartupRecovery(getDbAccessor());
+		expect(immediate.recoveryPhase).toBe("draining");
+		expect(immediate.orphanedPassesSwept).toBe(0);
+
+		const completed = await getStartupRecoveryCompletion();
+		expect(completed.recoveryPhase).toBe("complete");
+		expect(completed.orphanedPassesSwept).toBe(1);
 	});
 
 	it("is idempotent — a clean workspace cleans nothing", async () => {

--- a/platform/daemon/src/startup-recovery.test.ts
+++ b/platform/daemon/src/startup-recovery.test.ts
@@ -8,8 +8,10 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { DreamingConfig } from "@signet/core";
 import type { WriteDb } from "./db-accessor";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { startDreamingWorker } from "./pipeline/dreaming-worker";
 import { getStartupRecoveryCompletion, runStartupRecovery, runStartupRecoveryAsync } from "./startup-recovery";
 
 const dbFiles = ["memories.db", "memories.db-shm", "memories.db-wal"];
@@ -64,6 +66,18 @@ function insertPass(db: WriteDb, id: string, status: string): void {
 	db.prepare(
 		"INSERT INTO dreaming_passes (id, agent_id, status, started_at) VALUES (?, 'default', ?, datetime('now'))",
 	).run(id, status);
+}
+
+function dreamingConfig(): DreamingConfig {
+	return {
+		enabled: true,
+		tokenThreshold: 100_000,
+		maxInterval: 6 * 60 * 60 * 1_000,
+		maxInputTokens: 32_000,
+		maxOutputTokens: 16_000,
+		timeout: 300_000,
+		backfillOnFirstRun: false,
+	};
 }
 
 function countRows(table: string): number {
@@ -217,6 +231,23 @@ describe("runStartupRecovery", () => {
 		const completed = await getStartupRecoveryCompletion();
 		expect(completed.recoveryPhase).toBe("complete");
 		expect(completed.orphanedPassesSwept).toBe(1);
+	});
+
+	it("keeps orphan telemetry countable when the dreaming worker starts during recovery", async () => {
+		getDbAccessor().withWriteTx((db) => {
+			insertPass(db, "running-worker-start", "running");
+		});
+
+		const immediate = runStartupRecovery(getDbAccessor());
+		const worker = startDreamingWorker(getDbAccessor(), dreamingConfig(), agentsDir, "default");
+		try {
+			expect(immediate.recoveryPhase).toBe("draining");
+			const completed = await getStartupRecoveryCompletion();
+			expect(completed.recoveryPhase).toBe("complete");
+			expect(completed.orphanedPassesSwept).toBe(1);
+		} finally {
+			worker.stop();
+		}
 	});
 
 	it("is idempotent — a clean workspace cleans nothing", async () => {

--- a/platform/daemon/src/startup-recovery.test.ts
+++ b/platform/daemon/src/startup-recovery.test.ts
@@ -62,9 +62,9 @@ function insertEmbedding(db: WriteDb, id: string, hash: string, table: "embeddin
 	).run(id, id, hash);
 }
 
-function insertPass(db: WriteDb, id: string, status: string): void {
+function insertPass(db: WriteDb, id: string, status: string, startedAt = "datetime('now', '-1 minute')"): void {
 	db.prepare(
-		"INSERT INTO dreaming_passes (id, agent_id, status, started_at) VALUES (?, 'default', ?, datetime('now'))",
+		`INSERT INTO dreaming_passes (id, agent_id, status, started_at) VALUES (?, 'default', ?, ${startedAt})`,
 	).run(id, status);
 }
 
@@ -248,6 +248,35 @@ describe("runStartupRecovery", () => {
 		} finally {
 			worker.stop();
 		}
+	});
+
+	it("does not fail a live pass created during deferred orphan recovery", async () => {
+		getDbAccessor().withWriteTx((db) => {
+			insertPass(db, "abandoned-before-recovery", "running");
+			for (let index = 0; index < 1_000; index++) {
+				const hash = `recovery-race-${index}`;
+				insertEmbedding(db, `recovery-emb-${index}`, hash, "embeddings");
+				insertEmbedding(db, `recovery-stage-${index}`, hash, "embeddings_staging");
+			}
+		});
+
+		let livePassInserted = false;
+		setTimeout(() => {
+			getDbAccessor().withWriteTx((db) => {
+				insertPass(db, "live-during-recovery", "running", "datetime('now', '+1 minute')");
+			});
+			livePassInserted = true;
+		}, 0);
+
+		const report = await runStartupRecoveryAsync(getDbAccessor());
+
+		expect(livePassInserted).toBe(true);
+		expect(report.orphanedPassesSwept).toBe(1);
+		const livePass = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT status FROM dreaming_passes WHERE id = ?").get("live-during-recovery") as { status: string },
+		);
+		expect(livePass.status).toBe("running");
 	});
 
 	it("is idempotent — a clean workspace cleans nothing", async () => {

--- a/platform/daemon/src/startup-recovery.test.ts
+++ b/platform/daemon/src/startup-recovery.test.ts
@@ -8,9 +8,9 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ReadDb, WriteDb } from "./db-accessor";
+import type { WriteDb } from "./db-accessor";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
-import { runStartupRecovery } from "./startup-recovery";
+import { runStartupRecovery, runStartupRecoveryAsync } from "./startup-recovery";
 
 const dbFiles = ["memories.db", "memories.db-shm", "memories.db-wal"];
 let agentsDir = "";
@@ -97,13 +97,13 @@ describe("runStartupRecovery", () => {
 			insertJob(db, "pending-1", "pending", recent);
 		});
 
-		const report = runStartupRecovery(getDbAccessor());
+		const report = await runStartupRecoveryAsync(getDbAccessor());
 
 		expect(report.deadJobsPurged).toBe(2);
 		expect(countRows("memory_jobs")).toBe(2); // dead-recent + pending-1
 	});
 
-	it("recovers every document lease during startup without touching other job types", () => {
+	it("recovers every document lease during startup without touching other job types", async () => {
 		const now = Date.now();
 		const createdAt = new Date(now - 20 * 60 * 1000).toISOString();
 		const staleAt = new Date(now - 10 * 60 * 1000).toISOString();
@@ -141,7 +141,7 @@ describe("runStartupRecovery", () => {
 			).run("other-stale", staleAt, createdAt, staleAt);
 		});
 
-		const report = runStartupRecovery(getDbAccessor());
+		const report = await runStartupRecoveryAsync(getDbAccessor());
 
 		expect(report.documentLeasesRecovered).toBe(3);
 		const statuses = getDbAccessor().withReadDb(
@@ -182,7 +182,7 @@ describe("runStartupRecovery", () => {
 			insertEmbedding(db, "stage-2", "hash-B", "embeddings_staging");
 		});
 
-		const report = runStartupRecovery(getDbAccessor());
+		const report = await runStartupRecoveryAsync(getDbAccessor());
 
 		expect(report.stagingRowsCleaned).toBe(1);
 		expect(countRows("embeddings_staging")).toBe(1); // only the new row remains
@@ -195,7 +195,7 @@ describe("runStartupRecovery", () => {
 			insertPass(db, "completed-1", "completed");
 		});
 
-		const report = runStartupRecovery(getDbAccessor());
+		const report = await runStartupRecoveryAsync(getDbAccessor());
 
 		expect(report.orphanedPassesSwept).toBe(2);
 		const failedCount = getDbAccessor().withReadDb(
@@ -207,7 +207,7 @@ describe("runStartupRecovery", () => {
 
 	it("is idempotent — a clean workspace cleans nothing", async () => {
 		// Run recovery on a fresh workspace with no damage.
-		const report1 = runStartupRecovery(getDbAccessor());
+		const report1 = await runStartupRecoveryAsync(getDbAccessor());
 		expect(report1.deadJobsPurged).toBe(0);
 		expect(report1.documentLeasesRecovered).toBe(0);
 		expect(report1.stagingRowsCleaned).toBe(0);
@@ -216,8 +216,31 @@ describe("runStartupRecovery", () => {
 		expect(report1.databaseIntegrity.quickCheck.messages).toEqual(["not checked"]);
 
 		// Run again — still nothing.
-		const report2 = runStartupRecovery(getDbAccessor());
+		const report2 = await runStartupRecoveryAsync(getDbAccessor());
 		expect(report2.deadJobsPurged).toBe(0);
 		expect(report2.stagingRowsCleaned).toBe(0);
+	});
+
+	it("returns before a large staging drain finishes and yields to liveness work", async () => {
+		getDbAccessor().withWriteTx((db) => {
+			for (let index = 0; index < 1_000; index++) {
+				const hash = `backlog-hash-${index}`;
+				insertEmbedding(db, `emb-backlog-${index}`, hash, "embeddings");
+				insertEmbedding(db, `stage-backlog-${index}`, hash, "embeddings_staging");
+			}
+		});
+
+		let livenessAnswered = false;
+		setTimeout(() => {
+			livenessAnswered = true;
+		}, 0);
+		const immediate = runStartupRecovery(getDbAccessor());
+
+		expect(immediate.databaseIntegrity.phase).toBe("pending");
+		const report = await runStartupRecoveryAsync(getDbAccessor());
+
+		expect(livenessAnswered).toBe(true);
+		expect(report.stagingRowsCleaned).toBe(1_000);
+		expect(countRows("embeddings_staging")).toBe(0);
 	});
 });

--- a/platform/daemon/src/startup-recovery.test.ts
+++ b/platform/daemon/src/startup-recovery.test.ts
@@ -250,7 +250,7 @@ describe("runStartupRecovery", () => {
 		}
 	});
 
-	it("does not fail a live pass created during deferred orphan recovery", async () => {
+	it("does not fail a live pass created in the recovery cutoff second", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			insertPass(db, "abandoned-before-recovery", "running");
 			for (let index = 0; index < 1_000; index++) {
@@ -263,7 +263,7 @@ describe("runStartupRecovery", () => {
 		let livePassInserted = false;
 		setTimeout(() => {
 			getDbAccessor().withWriteTx((db) => {
-				insertPass(db, "live-during-recovery", "running", "datetime('now', '+1 minute')");
+				insertPass(db, "live-during-recovery", "running", "datetime('now')");
 			});
 			livePassInserted = true;
 		}, 0);

--- a/platform/daemon/src/startup-recovery.ts
+++ b/platform/daemon/src/startup-recovery.ts
@@ -153,6 +153,7 @@ export function getStartupRecoveryCompletion(): Promise<StartupRecoveryReport> {
 
 async function runStartupRecoveryInternal(accessor: DbAccessor): Promise<StartupRecoveryReport> {
 	const startedAt = Date.now();
+	const recoveryStartedAt = new Date().toISOString();
 	logger.info("startup-recovery", "Running startup recovery asynchronously");
 
 	let documentLeasesRecovered = 0;
@@ -280,9 +281,14 @@ async function runStartupRecoveryInternal(accessor: DbAccessor): Promise<Startup
 					`UPDATE dreaming_passes
 					 SET status = 'failed', completed_at = datetime('now'),
 					     error = 'Orphaned by daemon restart (startup recovery)'
-					 WHERE status = 'running'`,
+					 WHERE status = 'running'
+					   AND started_at IS NOT NULL
+					   AND julianday(started_at) < julianday(?)`,
 				)
-				.run();
+				// The status and cutoff predicates are evaluated in this write
+				// transaction. A pass created after recovery began, or completed
+				// before this update, cannot be turned into an orphan.
+				.run(recoveryStartedAt);
 			return result.changes;
 		});
 	} catch (err) {

--- a/platform/daemon/src/startup-recovery.ts
+++ b/platform/daemon/src/startup-recovery.ts
@@ -153,7 +153,10 @@ export function getStartupRecoveryCompletion(): Promise<StartupRecoveryReport> {
 
 async function runStartupRecoveryInternal(accessor: DbAccessor): Promise<StartupRecoveryReport> {
 	const startedAt = Date.now();
-	const recoveryStartedAt = new Date().toISOString();
+	// Pass timestamps are persisted with millisecond precision, but older rows
+	// and direct writers may still use SQLite's second precision. Round the
+	// cutoff down so a pass from the current second is never swept as orphaned.
+	const recoveryStartedAt = new Date(Math.floor(Date.now() / 1_000) * 1_000).toISOString();
 	logger.info("startup-recovery", "Running startup recovery asynchronously");
 
 	let documentLeasesRecovered = 0;

--- a/platform/daemon/src/startup-recovery.ts
+++ b/platform/daemon/src/startup-recovery.ts
@@ -1,22 +1,11 @@
 /**
  * Startup recovery: automatically clean accumulated crash-loop damage.
  *
- * Under the #1059 death spiral, a daemon that keeps getting SIGKILLed
- * accumulates state that makes the next restart worse: dead jobs pile up,
- * the embeddings_staging buffer grows without draining, and orphaned passes
- * linger. This module runs on every startup (after migrations, before workers
- * start) and cleans that damage automatically — no manual intervention.
- *
- * IMPORTANT: this module is fully synchronous. It must not yield to the event
- * loop (no await, no setTimeout). The reason: during boot, module-level plugin
- * initialization and route registration schedule async operations. If this
- * recovery yields between DB batches, those pending operations run and can
- * touch the DB, conflicting with the write connection and causing
- * "database is locked" crashes. There is nothing to yield TO during boot
- * (no HTTP server, no workers, no competing load).
+ * Recovery is scheduled without blocking daemon readiness. Each database batch
+ * is admitted through the async accessor and yields between batches, so a large
+ * backlog remains resumable while HTTP and worker traffic continue to run.
  */
 
-import { reconcileAcpDeliveries } from "./cross-agent";
 import type { DatabaseIntegrityStatus } from "./database-integrity";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import { logger } from "./logger";
@@ -37,73 +26,129 @@ const DEAD_JOB_RETENTION_DAYS = 7;
 const BATCH_SIZE = 500;
 const JOB_MAX_TOTAL = 50_000;
 const STAGING_MAX_TOTAL = 200_000;
+const ACP_PENDING_GRACE_MS = 30_000;
+
+const PENDING_INTEGRITY: DatabaseIntegrityStatus = {
+	checkedAt: "",
+	state: "unknown",
+	phase: "pending",
+	quickCheck: { ok: false, messages: ["not checked"] },
+	telemetryCheck: { ok: false, messages: ["not checked"] },
+	rebuiltIndexes: [],
+	durationMs: 0,
+	repairGuidance: null,
+};
+
+let activeRecovery: Promise<StartupRecoveryReport> | null = null;
+
+function yieldToEventLoop(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function writeBatch<Result>(accessor: DbAccessor, processBatch: (db: WriteDb) => Result): Promise<Result> {
+	if (accessor.withWriteTxAsync) return accessor.withWriteTxAsync(processBatch);
+	return accessor.withWriteTx(processBatch);
+}
 
 /**
- * Synchronous bounded batch drain. No yielding, no pressure checks.
- * Used only during startup recovery where nothing competes for the event loop.
+ * Drain a bounded number of rows through async accessor jobs.
+ *
+ * The SQLite statements themselves remain short synchronous calls inside the
+ * accessor. The async queue and macrotask yield are the important boundary:
+ * no startup caller waits for the complete backlog, and no batch can starve
+ * the event loop indefinitely.
  */
-function drainBatchesSync<Item>(
+async function drainBatchesAsync<Item>(
 	accessor: DbAccessor,
 	fetchBatch: (db: ReadDb, limit: number) => readonly Item[] | null,
 	processBatch: (db: WriteDb, items: readonly Item[]) => void,
 	maxTotal: number,
-): number {
+	label: string,
+): Promise<number> {
 	let processed = 0;
+	let batches = 0;
 	while (processed < maxTotal) {
-		const remaining = maxTotal - processed;
-		const limit = Math.min(BATCH_SIZE, remaining);
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const batch = accessor.withReadDb((db: import("./db-accessor").ReadDb) => fetchBatch(db, limit));
-		if (!batch || batch.length === 0) break;
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		accessor.withWriteTx((db: import("./db-accessor").WriteDb) => processBatch(db, batch));
+		const limit = Math.min(BATCH_SIZE, maxTotal - processed);
+		const batch = await accessor.withReadDbAsync(async (db) => fetchBatch(db, limit));
+		if (!batch || batch.length === 0) return processed;
+		await writeBatch(accessor, (db) => processBatch(db, batch));
 		processed += batch.length;
+		batches++;
+		await yieldToEventLoop();
 	}
+	logger.warn("startup-recovery", `${label} reached its bounded startup cap`, {
+		processed,
+		maxTotal,
+		batches,
+	});
 	return processed;
 }
 
-/**
- * Run startup recovery. Called synchronously after migrations complete and
- * before background workers start. Safe to call on every boot — it is
- * idempotent (a clean workspace cleans nothing; a crash-damaged one heals).
- */
-export function runStartupRecovery(accessor: DbAccessor): StartupRecoveryReport {
-	const startedAt = Date.now();
-	logger.info("startup-recovery", "Running startup recovery");
-	// The full-database quick_check is intentionally deferred until after the
-	// HTTP server is ready. Running it here monopolizes Bun's main thread on
-	// large databases and makes even /health/live unreachable (#1513).
-	const databaseIntegrity: DatabaseIntegrityStatus = {
-		checkedAt: "",
-		state: "unknown",
-		phase: "pending",
-		quickCheck: { ok: false, messages: ["not checked"] },
-		telemetryCheck: { ok: false, messages: ["not checked"] },
-		rebuiltIndexes: [],
+// cross-agent currently exposes only a synchronous helper. Keep this recovery
+// write on the async queue instead of reintroducing a synchronous bootstrap call.
+async function reconcileAcpDeliveriesAsync(accessor: DbAccessor, nowMs = Date.now()): Promise<number> {
+	const now = new Date(nowMs).toISOString();
+	const pendingCutoff = new Date(nowMs - ACP_PENDING_GRACE_MS).toISOString();
+	return writeBatch(
+		accessor,
+		(db) =>
+			db
+				.prepare(
+					`UPDATE cross_agent_messages
+				 SET delivery_state = 'indeterminate', delivery_status = 'queued',
+				     delivery_error = CASE
+				       WHEN delivery_state = 'in_flight' THEN 'ACP relay interrupted; remote outcome is unknown'
+				       ELSE 'ACP relay was queued but never started'
+				     END,
+				     delivery_lease_token = NULL, delivery_lease_expires_at = NULL,
+				     delivery_updated_at = ?
+				 WHERE delivery_path = 'acp'
+				   AND ((delivery_state = 'in_flight' AND delivery_lease_expires_at <= ?)
+				     OR (delivery_state = 'pending' AND delivery_updated_at <= ?))`,
+				)
+				.run(now, now, pendingCutoff).changes,
+	);
+}
+
+function pendingReport(): StartupRecoveryReport {
+	return {
+		walCheckpointed: false,
+		databaseIntegrity: PENDING_INTEGRITY,
+		documentLeasesRecovered: 0,
+		deadJobsPurged: 0,
+		stagingRowsCleaned: 0,
+		orphanedPassesSwept: 0,
+		acpDeliveriesReconciled: 0,
 		durationMs: 0,
-		repairGuidance: null,
 	};
+}
 
-	// NOTE: WAL checkpoint intentionally omitted. An explicit
-	// PRAGMA wal_checkpoint(TRUNCATE) during startup blocks the event loop for
-	// ~8 seconds on legacy databases and leaves the write connection in a
-	// locked state that causes "SQLiteError: database is locked" on every
-	// subsequent BEGIN IMMEDIATE. SQLite's built-in auto-checkpoint handles
-	// WAL management without blocking. The checkpointWal() method is kept on
-	// DbAccessor for post-startup callers but must not be called during boot.
+/**
+ * Run the complete recovery job and resolve when the bounded pass finishes.
+ * Tests and explicit lifecycle callers can await this function. The daemon
+ * uses runStartupRecovery() below so readiness never waits for the pass.
+ */
+export function runStartupRecoveryAsync(accessor: DbAccessor): Promise<StartupRecoveryReport> {
+	if (activeRecovery !== null) return activeRecovery;
+	const run = runStartupRecoveryInternal(accessor);
+	activeRecovery = run;
+	const clear = (): void => {
+		if (activeRecovery === run) activeRecovery = null;
+	};
+	run.then(clear, clear);
+	return run;
+}
 
-	// 1. Recover document leases stranded by a previous daemon process. This
-	// must not depend on autonomous maintenance: observe mode, disabled
-	// maintenance, and a frozen worker are all valid configurations.
+async function runStartupRecoveryInternal(accessor: DbAccessor): Promise<StartupRecoveryReport> {
+	const startedAt = Date.now();
+	logger.info("startup-recovery", "Running startup recovery asynchronously");
+
 	let documentLeasesRecovered = 0;
 	try {
 		const now = new Date().toISOString();
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		documentLeasesRecovered = accessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
-			// The daemon lock is held before this function runs, so every document
-			// lease belongs to a process that is no longer alive. Unlike maintenance,
-			// startup recovery must not wait for the lease timeout: a fresh lease can
-			// otherwise remain permanently invisible to the document worker.
+		documentLeasesRecovered = await writeBatch(accessor, (db) => {
+			// The daemon lock is held before recovery starts, so these leases belong
+			// to a process that is no longer alive.
 			const recovered = recoverStaleLeases(db, { now, jobType: "document_ingest" });
 			if (recovered.dead > 0) {
 				db.prepare(
@@ -134,13 +179,12 @@ export function runStartupRecovery(accessor: DbAccessor): StartupRecoveryReport 
 		});
 	}
 
-	// 2. Purge old dead jobs.
 	const cutoff = new Date(Date.now() - DEAD_JOB_RETENTION_DAYS * 86_400_000).toISOString();
 	let deadJobsPurged = 0;
 	try {
-		deadJobsPurged = drainBatchesSync(
+		deadJobsPurged = await drainBatchesAsync(
 			accessor,
-			(db: ReadDb, limit: number) =>
+			(db, limit) =>
 				db
 					.prepare(
 						`SELECT id FROM memory_jobs
@@ -148,12 +192,13 @@ export function runStartupRecovery(accessor: DbAccessor): StartupRecoveryReport 
 						 LIMIT ?`,
 					)
 					.all(cutoff, limit) as Array<{ id: string }>,
-			(db: WriteDb, batch: readonly { id: string }[]) => {
+			(db, batch) => {
 				if (batch.length === 0) return;
 				const placeholders = batch.map(() => "?").join(",");
-				db.prepare(`DELETE FROM memory_jobs WHERE id IN (${placeholders})`).run(...batch.map((b) => b.id));
+				db.prepare(`DELETE FROM memory_jobs WHERE id IN (${placeholders})`).run(...batch.map((item) => item.id));
 			},
 			JOB_MAX_TOTAL,
+			"Dead job purge",
 		);
 	} catch (err) {
 		logger.warn("startup-recovery", "Dead job purge failed", {
@@ -161,13 +206,9 @@ export function runStartupRecovery(accessor: DbAccessor): StartupRecoveryReport 
 		});
 	}
 
-	// 3. Clean stale embeddings_staging rows — but ONLY when no embedding
-	// index migration is in progress. During a 'building' state, staging rows
-	// are migration progress, not redundant data.
 	let stagingRowsCleaned = 0;
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const migrationInProgress = accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+		const migrationInProgress = await accessor.withReadDbAsync(async (db) => {
 			const tableExists = db
 				.prepare("SELECT COUNT(*) AS n FROM sqlite_master WHERE type = 'table' AND name = 'embedding_index_state'")
 				.get() as { n: number } | undefined;
@@ -179,11 +220,11 @@ export function runStartupRecovery(accessor: DbAccessor): StartupRecoveryReport 
 		});
 
 		if (migrationInProgress) {
-			logger.info("startup-recovery", "Skipping staging cleanup — embedding index migration in progress");
+			logger.info("startup-recovery", "Skipping staging cleanup, embedding index migration is in progress");
 		} else {
-			stagingRowsCleaned = drainBatchesSync(
+			stagingRowsCleaned = await drainBatchesAsync<{ id: string }>(
 				accessor,
-				(db: ReadDb, limit: number) => {
+				(db, limit) => {
 					const tableExists = db
 						.prepare("SELECT COUNT(*) AS n FROM sqlite_master WHERE type = 'table' AND name = 'embeddings_staging'")
 						.get() as { n: number } | undefined;
@@ -198,12 +239,15 @@ export function runStartupRecovery(accessor: DbAccessor): StartupRecoveryReport 
 						)
 						.all(limit) as Array<{ id: string }>;
 				},
-				(db: WriteDb, batch: readonly { id: string }[]) => {
+				(db, batch) => {
 					if (batch.length === 0) return;
 					const placeholders = batch.map(() => "?").join(",");
-					db.prepare(`DELETE FROM embeddings_staging WHERE id IN (${placeholders})`).run(...batch.map((b) => b.id));
+					db.prepare(`DELETE FROM embeddings_staging WHERE id IN (${placeholders})`).run(
+						...batch.map((item) => item.id),
+					);
 				},
 				STAGING_MAX_TOTAL,
+				"Staging cleanup",
 			);
 		}
 	} catch (err) {
@@ -212,11 +256,9 @@ export function runStartupRecovery(accessor: DbAccessor): StartupRecoveryReport 
 		});
 	}
 
-	// 4. Sweep orphaned dreaming passes.
 	let orphanedPassesSwept = 0;
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		orphanedPassesSwept = accessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
+		orphanedPassesSwept = await writeBatch(accessor, (db) => {
 			const tableExists = db
 				.prepare("SELECT COUNT(*) AS n FROM sqlite_master WHERE type = 'table' AND name = 'dreaming_passes'")
 				.get() as { n: number };
@@ -239,7 +281,7 @@ export function runStartupRecovery(accessor: DbAccessor): StartupRecoveryReport 
 
 	let acpDeliveriesReconciled = 0;
 	try {
-		acpDeliveriesReconciled = reconcileAcpDeliveries(accessor);
+		acpDeliveriesReconciled = await reconcileAcpDeliveriesAsync(accessor);
 	} catch (err) {
 		logger.warn("startup-recovery", "ACP delivery reconciliation failed", {
 			error: err instanceof Error ? err.message : String(err),
@@ -249,7 +291,7 @@ export function runStartupRecovery(accessor: DbAccessor): StartupRecoveryReport 
 	const durationMs = Date.now() - startedAt;
 	const report: StartupRecoveryReport = {
 		walCheckpointed: false,
-		databaseIntegrity,
+		databaseIntegrity: PENDING_INTEGRITY,
 		documentLeasesRecovered,
 		deadJobsPurged,
 		stagingRowsCleaned,
@@ -259,17 +301,27 @@ export function runStartupRecovery(accessor: DbAccessor): StartupRecoveryReport 
 	};
 
 	const totalCleaned =
-		databaseIntegrity.rebuiltIndexes.length +
-		documentLeasesRecovered +
-		deadJobsPurged +
-		stagingRowsCleaned +
-		orphanedPassesSwept +
-		acpDeliveriesReconciled;
+		documentLeasesRecovered + deadJobsPurged + stagingRowsCleaned + orphanedPassesSwept + acpDeliveriesReconciled;
 	if (totalCleaned > 0) {
-		logger.info("startup-recovery", "Recovery complete", { ...report });
+		logger.info("startup-recovery", "Asynchronous recovery complete", { ...report });
 	} else {
-		logger.debug("startup-recovery", "Recovery complete (workspace was clean)", { durationMs });
+		logger.debug("startup-recovery", "Asynchronous recovery complete (workspace was clean)", { durationMs });
 	}
+	return report;
+}
 
+/**
+ * Schedule recovery and return immediately. This compatibility entrypoint is
+ * called during daemon boot, before the HTTP server binds, so it must never
+ * perform a database operation or await the backlog.
+ */
+export function runStartupRecovery(accessor: DbAccessor): StartupRecoveryReport {
+	const report = pendingReport();
+	logger.info("startup-recovery", "Deferring startup recovery until the event loop can serve requests");
+	void runStartupRecoveryAsync(accessor).catch((err) => {
+		logger.warn("startup-recovery", "Asynchronous startup recovery failed", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+	});
 	return report;
 }

--- a/platform/daemon/src/startup-recovery.ts
+++ b/platform/daemon/src/startup-recovery.ts
@@ -12,6 +12,7 @@ import { logger } from "./logger";
 import { recoverStaleLeases } from "./pipeline/stale-leases";
 
 export interface StartupRecoveryReport {
+	readonly recoveryPhase: "draining" | "complete";
 	readonly walCheckpointed: boolean;
 	readonly databaseIntegrity: DatabaseIntegrityStatus;
 	readonly documentLeasesRecovered: number;
@@ -40,6 +41,7 @@ const PENDING_INTEGRITY: DatabaseIntegrityStatus = {
 };
 
 let activeRecovery: Promise<StartupRecoveryReport> | null = null;
+let lastCompletedRecovery: StartupRecoveryReport | null = null;
 
 function yieldToEventLoop(): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, 0));
@@ -112,6 +114,7 @@ async function reconcileAcpDeliveriesAsync(accessor: DbAccessor, nowMs = Date.no
 
 function pendingReport(): StartupRecoveryReport {
 	return {
+		recoveryPhase: "draining",
 		walCheckpointed: false,
 		databaseIntegrity: PENDING_INTEGRITY,
 		documentLeasesRecovered: 0,
@@ -131,12 +134,22 @@ function pendingReport(): StartupRecoveryReport {
 export function runStartupRecoveryAsync(accessor: DbAccessor): Promise<StartupRecoveryReport> {
 	if (activeRecovery !== null) return activeRecovery;
 	const run = runStartupRecoveryInternal(accessor);
-	activeRecovery = run;
+	const trackedRun = run.then((report) => {
+		lastCompletedRecovery = report;
+		return report;
+	});
+	activeRecovery = trackedRun;
 	const clear = (): void => {
-		if (activeRecovery === run) activeRecovery = null;
+		if (activeRecovery === trackedRun) activeRecovery = null;
 	};
-	run.then(clear, clear);
-	return run;
+	trackedRun.then(clear, clear);
+	return trackedRun;
+}
+
+/** Return the current startup drain without starting a second recovery pass. */
+export function getStartupRecoveryCompletion(): Promise<StartupRecoveryReport> {
+	if (activeRecovery !== null) return activeRecovery;
+	return Promise.resolve(lastCompletedRecovery ?? pendingReport());
 }
 
 async function runStartupRecoveryInternal(accessor: DbAccessor): Promise<StartupRecoveryReport> {
@@ -290,6 +303,7 @@ async function runStartupRecoveryInternal(accessor: DbAccessor): Promise<Startup
 
 	const durationMs = Date.now() - startedAt;
 	const report: StartupRecoveryReport = {
+		recoveryPhase: "complete",
 		walCheckpointed: false,
 		databaseIntegrity: PENDING_INTEGRITY,
 		documentLeasesRecovered,
@@ -318,10 +332,12 @@ async function runStartupRecoveryInternal(accessor: DbAccessor): Promise<Startup
 export function runStartupRecovery(accessor: DbAccessor): StartupRecoveryReport {
 	const report = pendingReport();
 	logger.info("startup-recovery", "Deferring startup recovery until the event loop can serve requests");
-	void runStartupRecoveryAsync(accessor).catch((err) => {
-		logger.warn("startup-recovery", "Asynchronous startup recovery failed", {
-			error: err instanceof Error ? err.message : String(err),
+	void runStartupRecoveryAsync(accessor)
+		.then((completed) => Object.assign(report, completed))
+		.catch((err) => {
+			logger.warn("startup-recovery", "Asynchronous startup recovery failed", {
+				error: err instanceof Error ? err.message : String(err),
+			});
 		});
-	});
 	return report;
 }

--- a/platform/daemon/src/startup-recovery.ts
+++ b/platform/daemon/src/startup-recovery.ts
@@ -48,8 +48,7 @@ function yieldToEventLoop(): Promise<void> {
 }
 
 async function writeBatch<Result>(accessor: DbAccessor, processBatch: (db: WriteDb) => Result): Promise<Result> {
-	if (accessor.withWriteTxAsync) return accessor.withWriteTxAsync(processBatch);
-	return accessor.withWriteTx(processBatch);
+	return accessor.withWriteTxAsync(processBatch);
 }
 
 /**

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -11,11 +11,11 @@ import {
 	renderReport,
 } from "./audit-event-loop-contract";
 
-test("the deterministic ledger retains the exact 741-site inventory", () => {
+test("the deterministic ledger retains the exact 732-site inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(741);
-	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(111);
-	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(146);
+	expect(baseline).toHaveLength(732);
+	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(106);
+	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(142);
 });
 
 test("the ledger reports legacy DB markers and rejects new call sites", () => {
@@ -278,9 +278,9 @@ test("the production TypeScript project cannot import the compatibility module",
 
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	const report = renderReport(baseline, { total: 257, withWriteTx: 111, withReadDb: 146 });
-	expect(report).toContain("Exact ledger inventory: 741 sites");
-	expect(report).toContain("111 synchronous writes and 146 synchronous reads");
+	const report = renderReport(baseline, { total: 248, withWriteTx: 106, withReadDb: 142 });
+	expect(report).toContain("Exact ledger inventory: 732 sites");
+	expect(report).toContain("106 synchronous writes and 142 synchronous reads");
 	expect(report).toContain("type boundary");
 	expect(report).not.toContain("1061");
 });

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -3616,37 +3616,16 @@
     },
     {
       "path": "daemon.ts",
-      "line": 2204,
+      "line": 2208,
       "api": "withReadDb",
       "source": "const memoryCount = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2215,
+      "line": 2219,
       "api": "withReadDb",
       "source": "const queue = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "database-integrity.ts",
-      "line": 270,
-      "api": "withReadDb",
-      "source": "const checks = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => ({",
-      "category": "hot-path"
-    },
-    {
-      "path": "database-integrity.ts",
-      "line": 304,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "database-integrity.ts",
-      "line": 309,
-      "api": "withReadDb",
-      "source": "const verifiedTelemetry = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
       "category": "hot-path"
     },
     {
@@ -4235,13 +4214,6 @@
       "line": 186,
       "api": "withReadDb",
       "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 278,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
@@ -5047,41 +5019,6 @@
       "line": 179,
       "api": "withWriteTx",
       "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "startup-recovery.ts",
-      "line": 56,
-      "api": "withReadDb",
-      "source": "const batch = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => fetchBatch(db, limit));",
-      "category": "hot-path"
-    },
-    {
-      "path": "startup-recovery.ts",
-      "line": 59,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => processBatch(db, batch));",
-      "category": "hot-path"
-    },
-    {
-      "path": "startup-recovery.ts",
-      "line": 102,
-      "api": "withWriteTx",
-      "source": "documentLeasesRecovered = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "startup-recovery.ts",
-      "line": 170,
-      "api": "withReadDb",
-      "source": "const migrationInProgress = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "startup-recovery.ts",
-      "line": 219,
-      "api": "withWriteTx",
-      "source": "orphanedPassesSwept = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {


### PR DESCRIPTION
## Summary

Convert startup recovery and telemetry index repair to non-blocking async work so daemon readiness is not held behind large cleanup backlogs or synchronous REINDEX calls.

## Changes

- Schedule startup recovery through the bounded async writer queue and return a pending degraded-recovery report from the pre-ready compatibility entrypoint.
- Drain dead jobs and staging rows in 500-row batches with 50,000 and 200,000 caps, yielding between batches.
- Preserve document lease, orphaned pass, and ACP delivery recovery on async write jobs.
- Run production telemetry REINDEX in a transactional child process with a hard deadline, then verify integrity and fail closed on repair/audit failures.
- Add liveness, successful child repair, and kill-at-deadline regression coverage.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations touched.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Targeted proof:
- `bun test platform/daemon/src/startup-recovery.test.ts platform/daemon/src/database-integrity.test.ts` (17 pass, 0 fail)
- `bunx biome check platform/daemon/src/startup-recovery.ts platform/daemon/src/startup-recovery.test.ts platform/daemon/src/database-integrity.ts platform/daemon/src/database-integrity.test.ts` (clean)
- `bun run --filter '@signet/daemon' build` (tsc and Vite build pass)
- `bun run --filter '@signet/core' build` (pass)
- `git diff --check` (clean)

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The pre-ready `runStartupRecovery()` compatibility entrypoint returns immediately with `databaseIntegrity.phase = pending`; `runStartupRecoveryAsync()` is the awaitable bounded job entrypoint used by focused tests and explicit lifecycle callers. The production REINDEX child intentionally contains synchronous SQLite calls because it is isolated behind SIGKILL deadline enforcement. The only synchronous accessor fallbacks retained are compatibility branches for test/double accessors when `withWriteTxAsync` is unavailable: `startup-recovery.ts:50` and `database-integrity.ts:230`. No daemon live smoke test was run in this worktree.
