### PR TITLE
fix(daemon): make telemetry persistence async

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,15 +4,15 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 1,050 sites
-- Synchronous `withWriteTx()` sites: 227
-- Synchronous `withReadDb()` sites: 339
+- Exact ledger inventory: 1,046 sites
+- Synchronous `withWriteTx()` sites: 220
+- Synchronous `withReadDb()` sites: 342
 - Synchronous filesystem/process sites: 484
-- Compile-visible legacy DB sites remaining: 566
-  - `withWriteTx`: 227
-  - `withReadDb`: 339
+- Compile-visible legacy DB sites remaining: 562
+  - `withWriteTx`: 220
+  - `withReadDb`: 342
 
-The 1,050-site inventory excludes test, benchmark, generated, and `__tests__` fixtures. The 227 synchronous writes and 339 synchronous reads remain transitional callers for the later migration phase. They are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate 566 database operations.
+The 1,046-site inventory excludes test, benchmark, generated, and `__tests__` fixtures. The 220 synchronous writes and 342 synchronous reads remain transitional callers for the later migration phase. They are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate 562 database operations.
 
 ## Enforcement boundary
 
@@ -25,4 +25,4 @@ The 1,050-site inventory excludes test, benchmark, generated, and `__tests__` fi
 
 The structural boundary makes statically-resolved imports from the production source tree impossible: TypeScript reports TS6059 before aliases or computed member calls can use the compatibility type. The production bundle also only starts from source entrypoints, so this compatibility module is not a shipped production artifact.
 
-A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 566 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 227 write and 339 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.
+A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 562 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 220 write and 342 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.

--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,15 +4,15 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 1,046 sites
-- Synchronous `withWriteTx()` sites: 220
-- Synchronous `withReadDb()` sites: 342
+- Exact ledger inventory: 1,036 sites
+- Synchronous `withWriteTx()` sites: 217
+- Synchronous `withReadDb()` sites: 335
 - Synchronous filesystem/process sites: 484
-- Compile-visible legacy DB sites remaining: 562
-  - `withWriteTx`: 220
-  - `withReadDb`: 342
+- Compile-visible legacy DB sites remaining: 552
+  - `withWriteTx`: 217
+  - `withReadDb`: 335
 
-The 1,046-site inventory excludes test, benchmark, generated, and `__tests__` fixtures. The 220 synchronous writes and 342 synchronous reads remain transitional callers for the later migration phase. They are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate 562 database operations.
+The 1,036-site inventory excludes test, benchmark, generated, and `__tests__` fixtures. The 217 synchronous writes and 335 synchronous reads remain transitional callers for the later migration phase. They are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate 552 database operations.
 
 ## Enforcement boundary
 
@@ -25,4 +25,4 @@ The 1,046-site inventory excludes test, benchmark, generated, and `__tests__` fi
 
 The structural boundary makes statically-resolved imports from the production source tree impossible: TypeScript reports TS6059 before aliases or computed member calls can use the compatibility type. The production bundle also only starts from source entrypoints, so this compatibility module is not a shipped production artifact.
 
-A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 562 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 220 write and 342 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.
+A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 552 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 217 write and 335 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.

--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -582,7 +582,7 @@ describe("auth guard co-location", () => {
 					timings: { totalMs: 1, stages: [] },
 				},
 			};
-			recordMemorySearchTelemetry(getDbAccessor(), {
+			await recordMemorySearchTelemetry(getDbAccessor(), {
 				route: "GET /api/memory/search",
 				agentId: "telemetry-agent-a",
 				sessionKey: "telemetry-session-a",
@@ -595,7 +595,7 @@ describe("auth guard co-location", () => {
 				response,
 				retentionDays: 90,
 			});
-			recordMemorySearchTelemetry(getDbAccessor(), {
+			await recordMemorySearchTelemetry(getDbAccessor(), {
 				route: "GET /api/memory/search",
 				agentId: "telemetry-agent-b",
 				sessionKey: "telemetry-session-b",

--- a/platform/daemon/src/embedding-usage.test.ts
+++ b/platform/daemon/src/embedding-usage.test.ts
@@ -53,7 +53,7 @@ describe("embedding telemetry (issue #1181)", () => {
 		recordEmbeddingUsage({ provider: "ollama", tokens: 42, source: "dreaming" });
 		await collector.flush();
 
-		const embeddings = collector.query().filter((e) => e.event === "pipeline.embedding");
+		const embeddings = (await collector.query()).filter((e) => e.event === "pipeline.embedding");
 		expect(embeddings).toHaveLength(2);
 		const first = embeddings.find((e) => e.properties.provider === "native");
 		expect(first?.properties.tokens).toBe(128);

--- a/platform/daemon/src/hooks-recall.test.ts
+++ b/platform/daemon/src/hooks-recall.test.ts
@@ -147,7 +147,7 @@ memory:
 			expect(resp.status).toBe(200);
 
 			await collector.flush();
-			const events = collector.query();
+			const events = await collector.query();
 			expect(
 				events.some((event) => event.event === "recall.attempted" && event.properties.surface === "tool_call"),
 			).toBeTrue();
@@ -187,7 +187,7 @@ memory:
 			expect(body.meta).toBeDefined();
 
 			await collector.flush();
-			const events = collector.query();
+			const events = await collector.query();
 			expect(
 				events.some((event) => event.event === "recall.attempted" && event.properties.surface === "tool_call"),
 			).toBeTrue();
@@ -242,7 +242,7 @@ memory:
 			expect(duplicate.status).toBe(200);
 
 			await collector.flush();
-			const events = collector.query();
+			const events = await collector.query();
 			const ends = events.filter((event) => event.event === "session.end");
 			expect(ends).toHaveLength(1);
 			expect(ends[0]?.properties.reason).toBe("session.deleted");

--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -2303,8 +2303,8 @@ memory:
 			await handleSessionEnd({ harness: "test", sessionKey: "sess-turn-b", reason: "session.idle" });
 			await collector.flush();
 
-			const turns = collector.query().filter((e) => e.event === "session.turn");
-			const ends = collector.query().filter((e) => e.event === "session.end");
+			const turns = (await collector.query()).filter((e) => e.event === "session.turn");
+			const ends = (await collector.query()).filter((e) => e.event === "session.end");
 			expect(turns).toHaveLength(3);
 			expect(ends).toHaveLength(0);
 			expect(turns[0]?.properties.harness).toBe("test");
@@ -2336,8 +2336,8 @@ memory:
 			await handleSessionEnd({ harness: "test", sessionKey: "sess-boundary-0", reason: "session.deleted" });
 			await collector.flush();
 
-			const ends = collector.query().filter((e) => e.event === "session.end");
-			const turns = collector.query().filter((e) => e.event === "session.turn");
+			const ends = (await collector.query()).filter((e) => e.event === "session.end");
+			const turns = (await collector.query()).filter((e) => e.event === "session.turn");
 			expect(ends).toHaveLength(reasons.length);
 			expect(ends.map((event) => event.properties.reason).sort()).toEqual([...reasons].sort());
 			expect(turns).toHaveLength(0);
@@ -2358,7 +2358,7 @@ memory:
 			await handleSessionEnd({ harness: "test", sessionKey: "sess-clear-a", reason: "clear" });
 			await collector.flush();
 
-			const ends = collector.query().filter((e) => e.event === "session.end");
+			const ends = (await collector.query()).filter((e) => e.event === "session.end");
 			expect(ends).toHaveLength(1);
 			expect(ends[0]?.properties.reason).toBe("clear");
 			expect(ends[0]?.properties.harness).toBe("test");
@@ -2366,13 +2366,13 @@ memory:
 			// A real session start opens a new lifetime — the next clear counts again.
 			await handleSessionStart({ harness: "test", sessionKey: "sess-clear-a" });
 			await collector.flush();
-			const starts = collector.query().filter((e) => e.event === "session.start");
+			const starts = (await collector.query()).filter((e) => e.event === "session.start");
 			expect(starts).toHaveLength(1);
 			expect(typeof starts[0]?.properties.sessionHash).toBe("string");
 
 			await handleSessionEnd({ harness: "test", sessionKey: "sess-clear-a", reason: "clear" });
 			await collector.flush();
-			expect(collector.query().filter((e) => e.event === "session.end")).toHaveLength(2);
+			expect((await collector.query()).filter((e) => e.event === "session.end")).toHaveLength(2);
 		} finally {
 			setActiveTelemetry(undefined);
 			resetSessionEndTelemetry();
@@ -3218,8 +3218,8 @@ describe("handleSessionStart multi-agent identity", () => {
 					});
 					await collector.flush();
 
-					const ends = collector.query().filter((event) => event.event === "session.end");
-					const turns = collector.query().filter((event) => event.event === "session.turn");
+					const ends = (await collector.query()).filter((event) => event.event === "session.end");
+					const turns = (await collector.query()).filter((event) => event.event === "session.turn");
 					expect(result.closed).toBe(50);
 					expect(result.totalMatching).toBe(50);
 					expect(ends).toHaveLength(50);

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -1491,7 +1491,7 @@ function recordUserPromptRecallTelemetry(input: {
 			},
 		},
 	};
-	recordMemorySearchTelemetry(getDbAccessor(), {
+	void recordMemorySearchTelemetry(getDbAccessor(), {
 		route: "POST /api/hooks/user-prompt-submit",
 		agentId: input.agentId,
 		sessionKey: input.sessionKey ?? null,

--- a/platform/daemon/src/memory-search-telemetry.test.ts
+++ b/platform/daemon/src/memory-search-telemetry.test.ts
@@ -70,8 +70,8 @@ describe("memory search telemetry", () => {
 		};
 	}
 
-	it("stores query text, filters, timings, and result snapshots for QA", () => {
-		recordMemorySearchTelemetry(getDbAccessor(), {
+	it("stores query text, filters, timings, and result snapshots for QA", async () => {
+		await recordMemorySearchTelemetry(getDbAccessor(), {
 			route: "POST /api/memory/recall",
 			agentId: "ant",
 			sessionKey: "sess-1",
@@ -88,7 +88,7 @@ describe("memory search telemetry", () => {
 			retentionDays: 90,
 		});
 
-		const items = listMemorySearchTelemetry(getDbAccessor(), { agentId: "ant" });
+		const items = await listMemorySearchTelemetry(getDbAccessor(), { agentId: "ant" });
 
 		expect(items).toHaveLength(1);
 		expect(items[0]?.query).toBe("what did we decide about recall qa");
@@ -106,7 +106,7 @@ describe("memory search telemetry", () => {
 		expect(resolveMemorySearchTelemetryProject({})).toBeNull();
 	});
 
-	it("filters no-hit rows", () => {
+	it("filters no-hit rows", async () => {
 		const empty: RecallResponse = {
 			query: "nothing here",
 			method: "hybrid",
@@ -119,7 +119,7 @@ describe("memory search telemetry", () => {
 			},
 		};
 
-		recordMemorySearchTelemetry(getDbAccessor(), {
+		await recordMemorySearchTelemetry(getDbAccessor(), {
 			route: "GET /api/memory/search",
 			agentId: "ant",
 			sessionKey: null,
@@ -129,7 +129,7 @@ describe("memory search telemetry", () => {
 			retentionDays: 90,
 		});
 
-		expect(listMemorySearchTelemetry(getDbAccessor(), { noHits: true })).toHaveLength(1);
-		expect(listMemorySearchTelemetry(getDbAccessor(), { noHits: false })).toHaveLength(0);
+		expect(await listMemorySearchTelemetry(getDbAccessor(), { noHits: true })).toHaveLength(1);
+		expect(await listMemorySearchTelemetry(getDbAccessor(), { noHits: false })).toHaveLength(0);
 	});
 });

--- a/platform/daemon/src/memory-search-telemetry.ts
+++ b/platform/daemon/src/memory-search-telemetry.ts
@@ -226,16 +226,23 @@ function rowToItem(row: MemorySearchTelemetryRow): MemorySearchTelemetryItem {
 	};
 }
 
-export function recordMemorySearchTelemetry(db: DbAccessor, input: MemorySearchTelemetryRecordInput): void {
-	try {
-		const createdAt = new Date().toISOString();
-		const cutoff = new Date(Date.now() - input.retentionDays * DAY_MS).toISOString();
-		const results = input.response.results.map(snapshotResult);
-		const filters = buildFilters(input.params);
-		const top = input.response.results[0]?.score ?? null;
+export async function recordMemorySearchTelemetry(
+	db: DbAccessor,
+	input: MemorySearchTelemetryRecordInput,
+): Promise<void> {
+	const withWriteTxAsync = db.withWriteTxAsync;
+	if (!withWriteTxAsync) {
+		logger.warn("memory", "Dropped memory search telemetry: async writer unavailable", { dropped: 1 });
+		return;
+	}
+	const createdAt = new Date().toISOString();
+	const cutoff = new Date(Date.now() - input.retentionDays * DAY_MS).toISOString();
+	const results = input.response.results.map(snapshotResult);
+	const filters = buildFilters(input.params);
+	const top = input.response.results[0]?.score ?? null;
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		db.withWriteTx((w: import("./db-accessor").WriteDb) => {
+	try {
+		await withWriteTxAsync((w) => {
 			w.prepare(
 				`INSERT INTO memory_search_telemetry
 				 (id, created_at, route, agent_id, session_key, project, query,
@@ -264,16 +271,17 @@ export function recordMemorySearchTelemetry(db: DbAccessor, input: MemorySearchT
 			w.prepare("DELETE FROM memory_search_telemetry WHERE created_at < ?").run(cutoff);
 		});
 	} catch (err) {
-		logger.warn("memory", "Failed to record memory search telemetry", {
+		logger.warn("memory", "Dropped memory search telemetry after async write failure", {
+			dropped: 1,
 			error: err instanceof Error ? err.message : String(err),
 		});
 	}
 }
 
-export function listMemorySearchTelemetry(
+export async function listMemorySearchTelemetry(
 	db: DbAccessor,
 	query: MemorySearchTelemetryQuery = {},
-): readonly MemorySearchTelemetryItem[] {
+): Promise<readonly MemorySearchTelemetryItem[]> {
 	const conditions: string[] = [];
 	const args: SQLQueryBindings[] = [];
 
@@ -310,8 +318,7 @@ export function listMemorySearchTelemetry(
 	const limit = query.limit ?? 100;
 	const offset = query.offset ?? 0;
 
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return db.withReadDb((r) => {
+	return db.withReadDbAsync(async (r) => {
 		const rows = r
 			.prepare(
 				`SELECT id, created_at, route, agent_id, session_key, project, query,

--- a/platform/daemon/src/pipeline/dreaming-telemetry.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-telemetry.test.ts
@@ -95,7 +95,7 @@ describe("dreaming telemetry", () => {
 		});
 		await collector.flush();
 
-		const passes = collector.query().filter((e) => e.event === "dreaming.pass");
+		const passes = (await collector.query()).filter((e) => e.event === "dreaming.pass");
 		expect(passes).toHaveLength(2);
 		const full = passes.find((e) => e.properties.mode === "agentic");
 		expect(full?.properties.tokensInput).toBe(384561);

--- a/platform/daemon/src/routes/inference.ts
+++ b/platform/daemon/src/routes/inference.ts
@@ -920,7 +920,7 @@ export function mountInferenceRoutes(app: Hono, opts: InferenceRouteOptions = {}
 		}
 	});
 
-	app.get("/api/inference/history", (c) => {
+	app.get("/api/inference/history", async (c) => {
 		const telemetry = getTelemetry(opts);
 		if (!telemetry?.enabled) {
 			return c.json({ enabled: false, events: [], summary: { total: 0, failures: 0, fallbacks: 0, cancelled: 0 } });
@@ -934,12 +934,13 @@ export function mountInferenceRoutes(app: Hono, opts: InferenceRouteOptions = {}
 			);
 		}
 		const onlyProblems = c.req.query("failures") === "1" || c.req.query("problems") === "1";
-		const rows = telemetry
-			.query({
+		const rows = (
+			await telemetry.query({
 				since: c.req.query("since"),
 				until: c.req.query("until"),
 				limit: Math.min(Math.max(limit * 10, limit), MAX_HISTORY_SCAN_LIMIT),
 			})
+		)
 			.filter((event) => isInferenceTelemetryEvent(event.event))
 			.filter((event) => !eventFilter || event.event === eventFilter)
 			.filter((event) => !onlyProblems || isFailureOrFallback(event))

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -561,7 +561,7 @@ function recordRecallQaTelemetry(input: {
 	readonly cfg: ResolvedMemoryConfig;
 }): void {
 	if (!input.cfg.pipelineV2.telemetry.memorySearchQaEnabled) return;
-	recordMemorySearchTelemetry(getDbAccessor(), {
+	void recordMemorySearchTelemetry(getDbAccessor(), {
 		route: input.route,
 		agentId: input.agentId,
 		sessionKey: input.sessionKey,

--- a/platform/daemon/src/routes/telemetry-routes.ts
+++ b/platform/daemon/src/routes/telemetry-routes.ts
@@ -284,7 +284,7 @@ export function registerTelemetryRoutes(app: Hono): void {
 		return c.json({ scores });
 	});
 
-	app.get("/api/telemetry/events", (c) => {
+	app.get("/api/telemetry/events", async (c) => {
 		if (!telemetryRef) {
 			return c.json({ events: [], enabled: false });
 		}
@@ -292,7 +292,7 @@ export function registerTelemetryRoutes(app: Hono): void {
 		const since = c.req.query("since");
 		const until = c.req.query("until");
 		const limit = boundedTelemetryLimit(c.req.query("limit"), 100, 10_000);
-		const events = telemetryRef.query({ event, since, until, limit });
+		const events = await telemetryRef.query({ event, since, until, limit });
 		return c.json({ events, enabled: true });
 	});
 
@@ -301,7 +301,7 @@ export function registerTelemetryRoutes(app: Hono): void {
 		return c.json({ enabled: true, ...telemetryRef.deliveryHealth() });
 	});
 
-	app.get("/api/telemetry/memory-search", (c) => {
+	app.get("/api/telemetry/memory-search", async (c) => {
 		const agent = resolveScopedAgentId(c, c.req.query("agent_id") ?? c.req.query("agentId"));
 		if (agent.error) return c.json({ error: agent.error }, 403);
 		const project = resolveScopedProject(c, c.req.query("project"));
@@ -310,7 +310,7 @@ export function registerTelemetryRoutes(app: Hono): void {
 		const limitRaw = Number.parseInt(c.req.query("limit") ?? "100", 10);
 		const offsetRaw = Number.parseInt(c.req.query("offset") ?? "0", 10);
 		const noHitsRaw = c.req.query("no_hits");
-		const items = listMemorySearchTelemetry(getDbAccessor(), {
+		const items = await listMemorySearchTelemetry(getDbAccessor(), {
 			agentId: agent.agentId,
 			project: project.project,
 			sessionKey: c.req.query("session_key") ?? c.req.query("sessionKey"),
@@ -329,12 +329,12 @@ export function registerTelemetryRoutes(app: Hono): void {
 		return c.json({ items, count: items.length });
 	});
 
-	app.get("/api/telemetry/stats", (c) => {
+	app.get("/api/telemetry/stats", async (c) => {
 		if (!telemetryRef) {
 			return c.json({ enabled: false });
 		}
 		const since = c.req.query("since");
-		const events = telemetryRef.query({ since, limit: 10000 });
+		const events = await telemetryRef.query({ since, limit: 10000 });
 
 		let totalInputTokens = 0;
 		let totalOutputTokens = 0;
@@ -759,19 +759,19 @@ export function registerTelemetryRoutes(app: Hono): void {
 		});
 	});
 
-	app.get("/api/telemetry/export", (c) => {
+	app.get("/api/telemetry/export", async (c) => {
 		if (!telemetryRef) {
 			return c.text("telemetry not enabled", 404);
 		}
 		const since = c.req.query("since");
 		const limit = boundedTelemetryLimit(c.req.query("limit"), 10_000, 100_000);
-		const events = telemetryRef.query({ since, limit });
+		const events = await telemetryRef.query({ since, limit });
 
 		const lines = events.map((e) => JSON.stringify(e)).join("\n");
 		return c.text(lines, 200, { "Content-Type": "application/x-ndjson" });
 	});
 
-	app.get("/api/telemetry/memory-search/export", (c) => {
+	app.get("/api/telemetry/memory-search/export", async (c) => {
 		const agent = resolveScopedAgentId(c, c.req.query("agent_id") ?? c.req.query("agentId"));
 		if (agent.error) return c.json({ error: agent.error }, 403);
 		const project = resolveScopedProject(c, c.req.query("project"));
@@ -779,7 +779,7 @@ export function registerTelemetryRoutes(app: Hono): void {
 
 		const limitRaw = Number.parseInt(c.req.query("limit") ?? "10000", 10);
 		const noHitsRaw = c.req.query("no_hits");
-		const items = listMemorySearchTelemetry(getDbAccessor(), {
+		const items = await listMemorySearchTelemetry(getDbAccessor(), {
 			agentId: agent.agentId,
 			project: project.project,
 			sessionKey: c.req.query("session_key") ?? c.req.query("sessionKey"),

--- a/platform/daemon/src/session-claims.test.ts
+++ b/platform/daemon/src/session-claims.test.ts
@@ -154,7 +154,7 @@ describe("durable session lifecycle claims (#1228)", () => {
 			expect(restorePersistedSessions()).toMatchObject({ active: 0, expired: 1, ended: 0 });
 			await collector.flush();
 
-			expect(collector.query().filter((event) => event.event === "session.end")).toHaveLength(1);
+			expect((await collector.query()).filter((event) => event.event === "session.end")).toHaveLength(1);
 		} finally {
 			setActiveTelemetry(undefined);
 		}

--- a/platform/daemon/src/session-tracker.test.ts
+++ b/platform/daemon/src/session-tracker.test.ts
@@ -53,12 +53,17 @@ function telemetryTestDb(): DbAccessor {
 			timestamp TEXT NOT NULL,
 			properties TEXT NOT NULL,
 			sent_to_posthog INTEGER NOT NULL DEFAULT 0,
-			created_at TEXT NOT NULL
+			created_at TEXT NOT NULL,
+			source TEXT NOT NULL DEFAULT 'daemon',
+			claim_token TEXT,
+			claimed_at TEXT
 		)`,
 	);
 	return {
 		withWriteTx: (fn: (d: Database) => unknown) => fn(db),
+		withWriteTxAsync: async (fn: (d: Database) => unknown) => fn(db),
 		withReadDb: (fn: (d: Database) => unknown) => fn(db),
+		withReadDbAsync: async (fn: (d: Database) => Promise<unknown>) => fn(db),
 	} as unknown as DbAccessor;
 }
 
@@ -332,7 +337,7 @@ describe("TTL eviction lifecycle handler (#902)", () => {
 				runStaleCleanup();
 				await collector.flush();
 
-				const ends = collector.query().filter((e) => e.event === "session.end");
+				const ends = (await collector.query()).filter((e) => e.event === "session.end");
 				expect(ends).toHaveLength(1);
 				expect(ends[0]?.properties.reason).toBe("expired");
 				expect(ends[0]?.properties.harness).toBe("claude-code");
@@ -344,7 +349,7 @@ describe("TTL eviction lifecycle handler (#902)", () => {
 				_expireSessionForTest("sess-evict");
 				runStaleCleanup();
 				await collector.flush();
-				expect(collector.query().filter((e) => e.event === "session.end")).toHaveLength(1);
+				expect((await collector.query()).filter((e) => e.event === "session.end")).toHaveLength(1);
 			} finally {
 				setActiveTelemetry(undefined);
 			}
@@ -359,7 +364,7 @@ describe("TTL eviction lifecycle handler (#902)", () => {
 				runStaleCleanup();
 				await collector.flush();
 
-				const ends = collector.query().filter((e) => e.event === "session.end");
+				const ends = (await collector.query()).filter((e) => e.event === "session.end");
 				expect(ends).toHaveLength(1);
 				expect(ends[0]?.properties.harness).toBeNull();
 			} finally {
@@ -379,7 +384,7 @@ describe("TTL eviction lifecycle handler (#902)", () => {
 				runStaleCleanup();
 				await collector.flush();
 
-				const ends = collector.query().filter((e) => e.event === "session.end");
+				const ends = (await collector.query()).filter((e) => e.event === "session.end");
 				expect(ends).toHaveLength(1);
 				expect(ends[0]?.properties.harness).toBe("opencode");
 			} finally {
@@ -405,7 +410,7 @@ describe("TTL eviction lifecycle handler (#902)", () => {
 				runStaleCleanup();
 				await collector.flush();
 
-				expect(collector.query().filter((e) => e.event === "session.end")).toHaveLength(0);
+				expect((await collector.query()).filter((e) => e.event === "session.end")).toHaveLength(0);
 			} finally {
 				setActiveTelemetry(undefined);
 			}
@@ -425,7 +430,7 @@ describe("TTL eviction lifecycle handler (#902)", () => {
 				runStaleCleanup();
 				await collector.flush();
 
-				expect(collector.query().filter((e) => e.event === "session.end")).toHaveLength(0);
+				expect((await collector.query()).filter((e) => e.event === "session.end")).toHaveLength(0);
 
 				// And the anonymous hash is joinable across raw/normalized forms.
 				expect(hashSessionKey("session:abc")).toBe(hashSessionKey("abc"));

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -23,7 +23,14 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { parseRoutingConfig } from "@signet/core";
-import { type DbAccessor, type ReadDb, closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import {
+	type DbAccessor,
+	type ReadDb,
+	type WriteDb,
+	closeDbAccessor,
+	getDbAccessor,
+	initDbAccessor,
+} from "./db-accessor";
 import { createRoutingProvider } from "./inference-provider-factory";
 import { generateWithTracking } from "./pipeline/provider";
 import {
@@ -112,6 +119,22 @@ function delayAsyncReads(gate: Promise<void>, started: () => void): DbAccessor {
 				await gate;
 			}
 			return base.withReadDbAsync(fn);
+		},
+	};
+}
+
+function delayAsyncWrites(gate: Promise<void>, started: () => void): DbAccessor {
+	const base = getDbAccessor();
+	let firstWrite = true;
+	return {
+		...base,
+		async withWriteTxAsync<T>(fn: (db: WriteDb) => T): Promise<T> {
+			if (firstWrite) {
+				firstWrite = false;
+				started();
+				await gate;
+			}
+			return base.withWriteTxAsync(fn);
 		},
 	};
 }
@@ -555,6 +578,42 @@ describe("telemetry collector", () => {
 		collector.record("daemon.heartbeat", { uptimeMs: 2 });
 		expect(captured).toHaveLength(0);
 		expect(unsentCount()).toBe(0);
+	});
+
+	it("waits for an in-flight first-use write before completing telemetry opt-out", async () => {
+		let releaseWrite: (() => void) | undefined;
+		const writeGate = new Promise<void>((resolve) => {
+			releaseWrite = resolve;
+		});
+		let signalWriteStarted: (() => void) | undefined;
+		const writeStarted = new Promise<void>((resolve) => {
+			signalWriteStarted = resolve;
+		});
+		const collector = createTelemetryCollector(
+			delayAsyncWrites(writeGate, () => signalWriteStarted?.()),
+			{ ...TELEMETRY_CONFIG, posthogHost: "" },
+			"0.0.0-test",
+		);
+
+		collector.recordFirstUse("remember");
+		await writeStarted;
+
+		let discardResolved = false;
+		const discard = collector.discardPending?.().then(() => {
+			discardResolved = true;
+		});
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+		expect(discardResolved).toBe(false);
+
+		releaseWrite?.();
+		await discard;
+		const row = await getDbAccessor().withReadDbAsync(
+			async (db) =>
+				db.prepare("SELECT COUNT(*) AS count FROM telemetry_events WHERE event = 'first.remember'").get() as {
+					readonly count: number;
+				},
+		);
+		expect(row.count).toBe(0);
 	});
 
 	it("emits one config snapshot alongside install activation", async () => {

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -23,7 +23,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { parseRoutingConfig } from "@signet/core";
-import { type DbAccessor, closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { type DbAccessor, type ReadDb, closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { createRoutingProvider } from "./inference-provider-factory";
 import { generateWithTracking } from "./pipeline/provider";
 import {
@@ -98,6 +98,22 @@ function resetWorkspace(): void {
 
 function makeCollector(configSnapshot?: TelemetryConfigSnapshot): TelemetryCollector {
 	return createTelemetryCollector(getDbAccessor(), TELEMETRY_CONFIG, "0.0.0-test", { configSnapshot });
+}
+
+function delayAsyncReads(gate: Promise<void>, started: () => void): DbAccessor {
+	const base = getDbAccessor();
+	let firstRead = true;
+	return {
+		...base,
+		async withReadDbAsync<T>(fn: (db: ReadDb) => Promise<T>): Promise<T> {
+			if (firstRead) {
+				firstRead = false;
+				started();
+				await gate;
+			}
+			return base.withReadDbAsync(fn);
+		},
+	};
 }
 
 /**
@@ -736,6 +752,47 @@ describe("telemetry collector", () => {
 		expect(nextFlushIntervalMs(60000, 2)).toBe(60000);
 		expect(nextFlushIntervalMs(60000, 3)).toBe(300000);
 		expect(nextFlushIntervalMs(60000, 9)).toBe(300000);
+	});
+
+	it("waits for startup delivery state before sending during backoff", async () => {
+		let releaseReads: (() => void) | undefined;
+		const readsReleased = new Promise<void>((resolve) => {
+			releaseReads = resolve;
+		});
+		let signalReadStarted: (() => void) | undefined;
+		const deliveryStateReadStarted = new Promise<void>((resolve) => {
+			signalReadStarted = resolve;
+		});
+		const now = new Date().toISOString();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE telemetry_delivery_state SET consecutive_failures = 3, last_attempt_at = ? WHERE id = 1").run(
+				now,
+			);
+		});
+
+		const collector = createTelemetryCollector(
+			delayAsyncReads(readsReleased, () => signalReadStarted?.()),
+			{ ...TELEMETRY_CONFIG, flushIntervalMs: 10 },
+			"0.0.0-test",
+		);
+		collector.record("daemon.heartbeat", { uptimeMs: 1 });
+		collector.start();
+		await deliveryStateReadStarted;
+		await new Promise<void>((resolve) => setTimeout(resolve, 30));
+		// The timer has reached the delivery path, but the persisted state is
+		// still loading. It must not send with the in-memory zero-failure state.
+		expect(captured).toHaveLength(0);
+
+		// Make the loaded state represent a recent failure, so the post-load
+		// assertion also proves the backoff is re-checked after the await.
+		const loadedAt = new Date().toISOString();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE telemetry_delivery_state SET last_attempt_at = ? WHERE id = 1").run(loadedAt);
+		});
+		releaseReads?.();
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+		expect(captured).toHaveLength(0);
+		await collector.discardPending?.();
 	});
 
 	it("parses SQLite CURRENT_TIMESTAMP as UTC regardless of host timezone", () => {

--- a/platform/daemon/src/telemetry.test.ts
+++ b/platform/daemon/src/telemetry.test.ts
@@ -108,7 +108,10 @@ function fakeDbAccessor(): DbAccessor {
 	const stmt = { run: () => ({ changes: 1 }), get: () => undefined, all: () => [] };
 	return {
 		withWriteTx: (fn: (db: { prepare(sql: string): typeof stmt }) => unknown) => fn({ prepare: () => stmt }),
+		withWriteTxAsync: async (fn: (db: { prepare(sql: string): typeof stmt }) => unknown) => fn({ prepare: () => stmt }),
 		withReadDb: (fn: (db: { prepare(sql: string): typeof stmt }) => unknown) => fn({ prepare: () => stmt }),
+		withReadDbAsync: async (fn: (db: { prepare(sql: string): typeof stmt }) => Promise<unknown>) =>
+			fn({ prepare: () => stmt }),
 	} as unknown as DbAccessor;
 }
 
@@ -246,7 +249,7 @@ describe("telemetry collector", () => {
 				text: "ok",
 			});
 			await collector.flush();
-			const local = collector.query().find((event) => event.event === "llm.generate");
+			const local = (await collector.query()).find((event) => event.event === "llm.generate");
 			const outbound = captured
 				.flatMap((request) => request.body.batch)
 				.find((event) => event.event === "llm.generate");
@@ -437,11 +440,12 @@ describe("telemetry collector", () => {
 		// buffering its event for a later transaction let a crash permanently
 		// consume the milestone. The event must already be in the durable queue
 		// before the process can terminate.
-		const first = makeCollector();
+		const first = createTelemetryCollector(getDbAccessor(), { ...TELEMETRY_CONFIG, posthogHost: "" }, "0.0.0-test");
 		first.recordFirstUse("remember");
 		first.recordFirstUse("remember");
 		first.recordFirstUse("recall");
 		first.recordFirstUse("recall");
+		await first.flush();
 
 		const beforeRestart = getDbAccessor().withReadDb(
 			(db) =>
@@ -476,7 +480,9 @@ describe("telemetry collector", () => {
 		await restarted.flush();
 		await restarted.flush();
 
-		const delivered = captured.flatMap((request) => request.body.batch.map((event) => event.event));
+		const delivered = captured
+			.flatMap((request) => request.body.batch.map((event) => event.event))
+			.filter((event) => event.startsWith("first."));
 		expect(delivered).toEqual(["first.remember", "first.recall"]);
 		expect(
 			getDbAccessor().withReadDb((db) =>
@@ -695,9 +701,9 @@ describe("telemetry collector", () => {
 		const second = createTelemetryCollector(getDbAccessor(), TELEMETRY_CONFIG, "0.176.9");
 		await second.flush();
 
-		const observed = second.query({ event: "version.observed" })[0];
+		const observed = (await second.query({ event: "version.observed" }))[0];
 		expect(observed?.properties).toMatchObject({ from: "0.176.8", to: "0.176.9" });
-		expect(second.query({ event: "version.upgraded" })).toHaveLength(0);
+		expect(await second.query({ event: "version.upgraded" })).toHaveLength(0);
 	});
 
 	it("keeps an observed prior version raw when the deployment marker changes", async () => {
@@ -708,7 +714,7 @@ describe("telemetry collector", () => {
 		});
 		await second.flush();
 
-		expect(second.query({ event: "version.observed" })[0]?.properties).toMatchObject({
+		expect((await second.query({ event: "version.observed" }))[0]?.properties).toMatchObject({
 			from: "0.176.8",
 			to: "0.176.9-dev",
 		});
@@ -720,7 +726,7 @@ describe("telemetry collector", () => {
 		});
 		collector.record("version.upgraded", { from: "0.176.6", to: "0.176.8" });
 		await collector.flush();
-		const [event] = collector.query({ event: "version.upgraded" });
+		const [event] = await collector.query({ event: "version.upgraded" });
 		expect(event?.properties.from).toBe("0.176.6-dev");
 		expect(event?.properties.to).toBe("0.176.8-dev");
 	});
@@ -774,7 +780,7 @@ describe("telemetry collector", () => {
 		collector.record("daemon.heartbeat", { uptimeMs: 1 });
 		await collector.stop();
 
-		const health = collector.query({ event: "telemetry.health" })[0];
+		const health = (await collector.query({ event: "telemetry.health" }))[0];
 		expect(health).toBeDefined();
 		expect(health?.properties).toMatchObject({
 			queuedUnsentEventCount: 2,
@@ -1071,7 +1077,7 @@ describe("session economics (issue #1201)", () => {
 		collector.record("session.end", { sessionHash: "session-1" });
 		await collector.flush();
 
-		const end = collector.query({ event: "session.end" })[0];
+		const end = (await collector.query({ event: "session.end" }))[0];
 		expect(end?.properties.tokensInput).toBe(2_000_100);
 		expect(end?.properties.tokensOutput).toBe(20);
 		expect(end?.properties.tokensCacheRead).toBe(10);
@@ -1090,7 +1096,7 @@ describe("session economics (issue #1201)", () => {
 		collector.record("session.end", { sessionHash: "session-c" });
 		await collector.flush();
 
-		const ends = collector.query({ event: "session.end" });
+		const ends = await collector.query({ event: "session.end" });
 		const sessionA = ends.find((event) => event.properties.tokensInput === 100);
 		const sessionC = ends.find((event) => event.properties.tokensInput === 200);
 		expect(sessionA?.properties.cost).toBe(0.5);
@@ -1107,7 +1113,7 @@ describe("session economics (issue #1201)", () => {
 		collector.record("session.end", { sessionHash: "session-1" });
 		await collector.flush();
 
-		const ends = collector.query({ event: "session.end" });
+		const ends = await collector.query({ event: "session.end" });
 		const first = ends.find((event) => event.properties.tokensInput === 100);
 		const resumed = ends.find((event) => event.properties.tokensInput === 300);
 		expect(first?.properties.tokensInput).toBe(100);

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -370,7 +370,7 @@ export interface TelemetryCollector {
 		since?: string;
 		until?: string;
 		limit?: number;
-	}): readonly TelemetryEvent[];
+	}): Promise<readonly TelemetryEvent[]>;
 
 	readonly enabled: boolean;
 
@@ -488,8 +488,7 @@ function getOrCreateInstallId(
 	daemonVersion: string,
 ): { readonly id: string; readonly created: boolean; readonly previousVersion?: string } {
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		return db.withWriteTx((w: import("./db-accessor").WriteDb) => {
+		return db.withWriteTx((w) => {
 			const existing = w
 				.prepare("SELECT id, last_seen_version FROM telemetry_install ORDER BY created_at ASC LIMIT 1")
 				.get() as { readonly id: string; readonly last_seen_version?: string | null } | null | undefined;
@@ -528,8 +527,7 @@ function getOrCreateInstallId(
 		// pre-117 telemetry_install shape. Preserve telemetry there without
 		// claiming a transition; the next normal migration adds the column.
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-			return db.withWriteTx((w: import("./db-accessor").WriteDb) => {
+			return db.withWriteTx((w) => {
 				const existing = w.prepare("SELECT id FROM telemetry_install ORDER BY created_at ASC LIMIT 1").get() as
 					| { readonly id: string }
 					| null
@@ -786,16 +784,29 @@ export function createTelemetryCollector(
 	let droppedEventCount = 0;
 	let pendingDroppedEventCount = 0;
 	let flushPromise: Promise<void> | null = null;
+	const pendingAsyncWrites = new Set<Promise<void>>();
 	let deliveryStatePersistenceFailed = false;
+	let deliveryState: TelemetryDeliveryState = {
+		windowStartedAt: new Date().toISOString(),
+		successCount: 0,
+		failureCount: 0,
+		consecutiveFailures: 0,
+		lastAttemptAt: null,
+		lastSuccessAt: null,
+		lastFailureCode: null,
+		droppedEventCount: 0,
+	};
+	let persistedQueueCount = 0;
+	let persistedOldestTimestamp: string | null = null;
+	let lastDaemonEventTimestamp: string | null = null;
 	const { id: installId, created: installActivated, previousVersion } = getOrCreateInstallId(db, daemonVersion);
 
 	const posthogConfigured = config.posthogHost.length > 0 && config.posthogApiKey.length > 0;
 
-	function readDeliveryState(): TelemetryDeliveryState {
+	async function readDeliveryState(): Promise<TelemetryDeliveryState> {
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const row = db.withReadDb(
-				(r: import("./db-accessor").ReadDb) =>
+			const row = await db.withReadDbAsync(
+				async (r) =>
 					r
 						.prepare(
 							`SELECT window_started_at AS windowStartedAt,
@@ -828,6 +839,44 @@ export function createTelemetryCollector(
 		};
 	}
 
+	async function refreshPersistedQueue(): Promise<void> {
+		try {
+			const queue = await db.withReadDbAsync(async (r) => {
+				const pending = r
+					.prepare(
+						`SELECT COUNT(*) AS count, MIN(timestamp) AS oldestTimestamp
+						 FROM telemetry_events WHERE source = 'daemon' AND sent_to_posthog = 0`,
+					)
+					.get() as { count?: number; oldestTimestamp?: string | null } | undefined;
+				const latest = r
+					.prepare(
+						"SELECT MAX(timestamp) AS timestamp FROM telemetry_events WHERE source = 'daemon' AND event <> 'telemetry.health'",
+					)
+					.get() as { timestamp?: string | null } | undefined;
+				return {
+					count: pending?.count ?? 0,
+					oldestTimestamp: pending?.oldestTimestamp ?? null,
+					lastTimestamp: latest?.timestamp ?? null,
+				};
+			});
+			persistedQueueCount = queue.count;
+			persistedOldestTimestamp = queue.oldestTimestamp;
+			lastDaemonEventTimestamp = queue.lastTimestamp;
+		} catch {
+			// Keep local in-memory health available when SQLite is unavailable.
+		}
+	}
+
+	function trackAsyncWrite(work: Promise<void>): void {
+		pendingAsyncWrites.add(work);
+		void work.finally(() => pendingAsyncWrites.delete(work));
+	}
+
+	async function awaitPendingAsyncWrites(): Promise<void> {
+		if (pendingAsyncWrites.size === 0) return;
+		await Promise.all([...pendingAsyncWrites]);
+	}
+
 	function recordDroppedEvents(count: number): void {
 		droppedEventCount += count;
 		pendingDroppedEventCount += count;
@@ -842,13 +891,14 @@ export function createTelemetryCollector(
 		pendingDroppedEventCount = 0;
 	}
 
-	const initialDeliveryState = readDeliveryState();
-	consecutiveFailures = initialDeliveryState.consecutiveFailures;
-	effectiveIntervalMs = nextFlushIntervalMs(config.flushIntervalMs, consecutiveFailures);
-	const lastAttemptMs = initialDeliveryState.lastAttemptAt
-		? parseTelemetryTimestamp(initialDeliveryState.lastAttemptAt)
-		: Number.NaN;
-	if (Number.isFinite(lastAttemptMs)) nextAllowedFlushAt = lastAttemptMs + effectiveIntervalMs;
+	void readDeliveryState().then((state) => {
+		deliveryState = state;
+		consecutiveFailures = state.consecutiveFailures;
+		effectiveIntervalMs = nextFlushIntervalMs(config.flushIntervalMs, consecutiveFailures);
+		const lastAttemptMs = state.lastAttemptAt ? parseTelemetryTimestamp(state.lastAttemptAt) : Number.NaN;
+		if (Number.isFinite(lastAttemptMs)) nextAllowedFlushAt = lastAttemptMs + effectiveIntervalMs;
+	});
+	void refreshPersistedQueue();
 
 	/**
 	 * Claim and persist a first-use event in one transaction. Only the first
@@ -861,7 +911,7 @@ export function createTelemetryCollector(
 	 * UPDATE matches no row and the milestone never fires. Telemetry is
 	 * degraded anyway.
 	 */
-	function persistFirstUse(kind: FirstUseKind): TelemetryEvent | null {
+	async function persistFirstUse(kind: FirstUseKind): Promise<TelemetryEvent | null> {
 		const event: TelemetryEvent = {
 			id: crypto.randomUUID(),
 			event: FIRST_USE_EVENTS[kind],
@@ -873,10 +923,11 @@ export function createTelemetryCollector(
 		};
 
 		try {
+			const withWriteTxAsync = db.withWriteTxAsync;
+			if (!withWriteTxAsync) return null;
 			const column = FIRST_USE_COLUMNS[kind];
 			let claimed = false;
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-			db.withWriteTx((w: import("./db-accessor").WriteDb) => {
+			await withWriteTxAsync((w) => {
 				const result = w
 					.prepare(
 						`UPDATE telemetry_install SET ${column} = ?
@@ -919,11 +970,12 @@ export function createTelemetryCollector(
 		};
 	}
 
-	function writeToDb(events: readonly TelemetryEvent[]): boolean {
+	async function writeToDb(events: readonly TelemetryEvent[]): Promise<boolean> {
 		if (events.length === 0) return true;
+		const withWriteTxAsync = db.withWriteTxAsync;
+		if (!withWriteTxAsync) return false;
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-			db.withWriteTx((w: import("./db-accessor").WriteDb) => {
+			await withWriteTxAsync((w) => {
 				const stmt = w.prepare(
 					`INSERT OR IGNORE INTO telemetry_events
 					 (id, event, timestamp, properties, sent_to_posthog, created_at, source)
@@ -974,12 +1026,13 @@ export function createTelemetryCollector(
 		}
 	}
 
-	function markSent(token: string): void {
+	async function markSent(token: string): Promise<void> {
 		const now = new Date().toISOString();
 		let stateUpdated = false;
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-			db.withWriteTx((w: import("./db-accessor").WriteDb) => {
+			const withWriteTxAsync = db.withWriteTxAsync;
+			if (!withWriteTxAsync) throw new Error("async writer unavailable");
+			await withWriteTxAsync((w) => {
 				w.prepare(
 					"UPDATE telemetry_events SET sent_to_posthog = 1, sent_at = ?, claim_token = NULL, claimed_at = NULL WHERE claim_token = ?",
 				).run(now, token);
@@ -1010,8 +1063,9 @@ export function createTelemetryCollector(
 			// Older/partially migrated workspaces still need the event marked sent
 			// after PostHog accepted it; otherwise the claim would be retried.
 			try {
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-				db.withWriteTx((w: import("./db-accessor").WriteDb) => {
+				const withWriteTxAsync = db.withWriteTxAsync;
+				if (!withWriteTxAsync) throw new Error("async writer unavailable");
+				await withWriteTxAsync((w) => {
 					w.prepare(
 						"UPDATE telemetry_events SET sent_to_posthog = 1, claim_token = NULL, claimed_at = NULL WHERE claim_token = ?",
 					).run(token);
@@ -1020,18 +1074,31 @@ export function createTelemetryCollector(
 				// best effort
 			}
 		}
+		const windowExpired =
+			Date.now() - parseTelemetryTimestamp(deliveryState.windowStartedAt) >= DELIVERY_HEALTH_WINDOW_MS;
+		deliveryState = {
+			...deliveryState,
+			windowStartedAt: windowExpired ? now : deliveryState.windowStartedAt,
+			successCount: windowExpired ? 1 : deliveryState.successCount + 1,
+			failureCount: windowExpired ? 0 : deliveryState.failureCount,
+			consecutiveFailures: 0,
+			lastAttemptAt: now,
+			lastSuccessAt: now,
+			lastFailureCode: null,
+		};
 		deliveryStatePersistenceFailed = !stateUpdated;
 		consecutiveFailures = 0;
 		effectiveIntervalMs = config.flushIntervalMs;
 		nextAllowedFlushAt = 0;
 	}
 
-	function releaseClaim(token: string, failureCode?: string): void {
+	async function releaseClaim(token: string, failureCode?: string): Promise<void> {
 		const now = new Date().toISOString();
 		let stateUpdated = false;
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-			db.withWriteTx((w: import("./db-accessor").WriteDb) => {
+			const withWriteTxAsync = db.withWriteTxAsync;
+			if (!withWriteTxAsync) throw new Error("async writer unavailable");
+			await withWriteTxAsync((w) => {
 				w.prepare(
 					"UPDATE telemetry_events SET last_attempt_at = ?, last_failure_code = ?, claim_token = NULL, claimed_at = NULL WHERE claim_token = ?",
 				).run(now, failureCode?.slice(0, MAX_HEALTH_FAILURE_CODE_LENGTH) ?? "unknown", token);
@@ -1060,8 +1127,9 @@ export function createTelemetryCollector(
 			});
 		} catch {
 			try {
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-				db.withWriteTx((w: import("./db-accessor").WriteDb) => {
+				const withWriteTxAsync = db.withWriteTxAsync;
+				if (!withWriteTxAsync) throw new Error("async writer unavailable");
+				await withWriteTxAsync((w) => {
 					w.prepare("UPDATE telemetry_events SET claim_token = NULL, claimed_at = NULL WHERE claim_token = ?").run(
 						token,
 					);
@@ -1070,19 +1138,32 @@ export function createTelemetryCollector(
 				// Stale claims remain recoverable on a later flush.
 			}
 		}
+		const code = failureCode?.slice(0, MAX_HEALTH_FAILURE_CODE_LENGTH) ?? "unknown";
+		const windowExpired =
+			Date.now() - parseTelemetryTimestamp(deliveryState.windowStartedAt) >= DELIVERY_HEALTH_WINDOW_MS;
+		deliveryState = {
+			...deliveryState,
+			windowStartedAt: windowExpired ? now : deliveryState.windowStartedAt,
+			failureCount: windowExpired ? 1 : deliveryState.failureCount + 1,
+			successCount: windowExpired ? 0 : deliveryState.successCount,
+			consecutiveFailures: consecutiveFailures + 1,
+			lastAttemptAt: now,
+			lastFailureCode: code,
+		};
 		deliveryStatePersistenceFailed = !stateUpdated;
 		consecutiveFailures++;
 		effectiveIntervalMs = nextFlushIntervalMs(config.flushIntervalMs, consecutiveFailures);
 		nextAllowedFlushAt = Date.now() + effectiveIntervalMs;
 	}
 
-	function claimUnsent(limit: number): ClaimedTelemetryEvents | null {
+	async function claimUnsent(limit: number): Promise<ClaimedTelemetryEvents | null> {
 		const token = crypto.randomUUID();
 		const now = new Date();
 		const staleBefore = new Date(now.getTime() - TELEMETRY_CLAIM_TIMEOUT_MS).toISOString();
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-			return db.withWriteTx((w: import("./db-accessor").WriteDb) => {
+			const withWriteTxAsync = db.withWriteTxAsync;
+			if (!withWriteTxAsync) return null;
+			return await withWriteTxAsync((w) => {
 				w.prepare(
 					`UPDATE telemetry_events
 					 SET claim_token = ?, claimed_at = ?
@@ -1125,13 +1206,13 @@ export function createTelemetryCollector(
 		}
 	}
 
-	function pruneOldEvents(): void {
+	async function pruneOldEvents(): Promise<void> {
 		const cutoff = new Date();
 		cutoff.setDate(cutoff.getDate() - config.retentionDays);
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-			db.withWriteTx((w: import("./db-accessor").WriteDb) => {
-				// Never prune a row that is still waiting for remote delivery.
+			const withWriteTxAsync = db.withWriteTxAsync;
+			if (!withWriteTxAsync) return;
+			await withWriteTxAsync((w) => {
 				w.prepare("DELETE FROM telemetry_events WHERE timestamp < ? AND sent_to_posthog = 1").run(cutoff.toISOString());
 			});
 		} catch {
@@ -1146,41 +1227,17 @@ export function createTelemetryCollector(
 	}
 
 	function deliveryHealth(): TelemetryDeliveryHealth {
-		const state = readDeliveryState();
-		let queuedUnsentEventCount = buffer.length;
-		let oldestUnsentTimestamp: string | null = null;
-		let lastDaemonEventTimestamp: string | null = null;
-		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			db.withReadDb((r) => {
-				const queue = r
-					.prepare(
-						`SELECT COUNT(*) AS count, MIN(timestamp) AS oldestTimestamp
-						 FROM telemetry_events WHERE source = 'daemon' AND sent_to_posthog = 0`,
-					)
-					.get() as { count?: number; oldestTimestamp?: string | null } | undefined;
-				queuedUnsentEventCount += queue?.count ?? 0;
-				oldestUnsentTimestamp = queue?.oldestTimestamp ?? null;
-				const latest = r
-					.prepare(
-						"SELECT MAX(timestamp) AS timestamp FROM telemetry_events WHERE source = 'daemon' AND event <> 'telemetry.health'",
-					)
-					.get() as { timestamp?: string | null } | undefined;
-				lastDaemonEventTimestamp = latest?.timestamp ?? null;
-			});
-		} catch {
-			// Keep local in-memory health available when SQLite is unavailable.
-		}
+		const state = deliveryState;
+		let oldestUnsentTimestamp = persistedOldestTimestamp;
+		let latestEventTimestamp = lastDaemonEventTimestamp;
+		const queuedUnsentEventCount = buffer.length + persistedQueueCount;
 		const bufferedOldest = buffer[0]?.timestamp ?? null;
 		if (bufferedOldest && (oldestUnsentTimestamp === null || bufferedOldest.localeCompare(oldestUnsentTimestamp) < 0)) {
 			oldestUnsentTimestamp = bufferedOldest;
 		}
 		const bufferedLatest = buffer.at(-1)?.timestamp ?? null;
-		if (
-			bufferedLatest &&
-			(lastDaemonEventTimestamp === null || bufferedLatest.localeCompare(lastDaemonEventTimestamp) > 0)
-		) {
-			lastDaemonEventTimestamp = bufferedLatest;
+		if (bufferedLatest && (latestEventTimestamp === null || bufferedLatest.localeCompare(latestEventTimestamp) > 0)) {
+			latestEventTimestamp = bufferedLatest;
 		}
 		const windowExpired = Date.now() - parseTelemetryTimestamp(state.windowStartedAt) >= DELIVERY_HEALTH_WINDOW_MS;
 		const recentSuccesses = windowExpired ? 0 : state.successCount;
@@ -1200,7 +1257,7 @@ export function createTelemetryCollector(
 			bufferedEventCount: buffer.length,
 			queuedUnsentEventCount,
 			oldestUnsentEventAgeSec: oldestAge,
-			lastDaemonEventAgeSec: ageSec(lastDaemonEventTimestamp),
+			lastDaemonEventAgeSec: ageSec(latestEventTimestamp),
 			lastAttemptAgeSec: ageSec(state.lastAttemptAt),
 			lastSuccessfulDeliveryAgeSec: ageSec(state.lastSuccessAt),
 			recentDeliverySuccessCount: recentSuccesses,
@@ -1233,9 +1290,12 @@ export function createTelemetryCollector(
 		queueLogLine(next);
 	}
 
-	function drainBuffer(): void {
+	async function drainBuffer(): Promise<void> {
 		const pending = buffer.splice(0, buffer.length);
-		if (writeToDb(pending)) return;
+		if (await writeToDb(pending)) {
+			await refreshPersistedQueue();
+			return;
+		}
 		// Preserve events for a later attempt when SQLite is temporarily locked.
 		buffer.unshift(...pending);
 		if (buffer.length > MAX_BUFFER_EVENTS) {
@@ -1246,19 +1306,19 @@ export function createTelemetryCollector(
 	}
 
 	async function doFlush(emitHealth: boolean, allowRemote = true): Promise<void> {
+		await awaitPendingAsyncWrites();
 		flushCount++;
-		// Drain buffer to SQLite
-		drainBuffer();
+		await drainBuffer();
 		if (emitHealth) {
 			// Snapshot before adding this diagnostic event. Its local value must not
 			// depend on the success of the request that carries the snapshot.
 			appendBufferedEvent("telemetry.health", { ...deliveryHealth() });
-			drainBuffer();
+			await drainBuffer();
 		}
 
 		// Send to PostHog if configured
 		if (allowRemote && posthogConfigured) {
-			const claimed = claimUnsent(config.flushBatchSize);
+			const claimed = await claimUnsent(config.flushBatchSize);
 			if (claimed) {
 				const abortController = new AbortController();
 				flushAbortController = abortController;
@@ -1272,9 +1332,9 @@ export function createTelemetryCollector(
 						abortController.signal,
 					);
 					if (result.ok) {
-						markSent(claimed.token);
+						await markSent(claimed.token);
 					} else {
-						releaseClaim(claimed.token, result.failureCode);
+						await releaseClaim(claimed.token, result.failureCode);
 						if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
 							logger.warn("telemetry", "PostHog unreachable, backing off", {
 								intervalMs: effectiveIntervalMs,
@@ -1289,8 +1349,9 @@ export function createTelemetryCollector(
 
 		// Occasional pruning (every 10th flush, deterministic for tests)
 		if (flushCount % PRUNE_EVERY_N_FLUSHES === 0) {
-			pruneOldEvents();
+			await pruneOldEvents();
 		}
+		await refreshPersistedQueue();
 	}
 
 	function flushInternal(emitHealth: boolean, force = false): Promise<void> {
@@ -1410,11 +1471,20 @@ export function createTelemetryCollector(
 		},
 
 		recordFirstUse(kind): void {
-			const event = persistFirstUse(kind);
-			if (!event) return;
-			// The database row is durable before the open log mirror is written.
-			// A failed log write must not affect the claim or delivery queue.
-			queueLogLine(event);
+			const pending = persistFirstUse(kind)
+				.then((event) => {
+					if (!event) return;
+					// The database row is durable before the open log mirror is written.
+					// A failed log write must not affect the claim or delivery queue.
+					queueLogLine(event);
+				})
+				.catch((error) => {
+					logger.warn("telemetry", "Dropped first-use telemetry event", {
+						dropped: 1,
+						error: error instanceof Error ? error.message : String(error),
+					});
+				});
+			trackAsyncWrite(pending);
 		},
 
 		async flush(): Promise<void> {
@@ -1470,8 +1540,9 @@ export function createTelemetryCollector(
 			flushAbortController?.abort();
 			if (flushPromise) await flushPromise;
 			try {
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-				db.withWriteTx((w: import("./db-accessor").WriteDb) => {
+				const withWriteTxAsync = db.withWriteTxAsync;
+				if (!withWriteTxAsync) throw new Error("async writer unavailable");
+				await withWriteTxAsync((w) => {
 					w.prepare("DELETE FROM telemetry_events WHERE sent_to_posthog = 0").run();
 				});
 			} catch {
@@ -1480,10 +1551,9 @@ export function createTelemetryCollector(
 			logger.info("telemetry", "Telemetry collector disabled");
 		},
 
-		query(opts): readonly TelemetryEvent[] {
+		async query(opts): Promise<readonly TelemetryEvent[]> {
 			try {
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-				return db.withReadDb((r) => {
+				return await db.withReadDbAsync(async (r) => {
 					const conditions: string[] = [];
 					const params: unknown[] = [];
 

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -488,7 +488,8 @@ function getOrCreateInstallId(
 	daemonVersion: string,
 ): { readonly id: string; readonly created: boolean; readonly previousVersion?: string } {
 	try {
-		return db.withWriteTx((w) => {
+		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
+		return db.withWriteTx((w: import("./db-accessor").WriteDb) => {
 			const existing = w
 				.prepare("SELECT id, last_seen_version FROM telemetry_install ORDER BY created_at ASC LIMIT 1")
 				.get() as { readonly id: string; readonly last_seen_version?: string | null } | null | undefined;
@@ -527,7 +528,8 @@ function getOrCreateInstallId(
 		// pre-117 telemetry_install shape. Preserve telemetry there without
 		// claiming a transition; the next normal migration adds the column.
 		try {
-			return db.withWriteTx((w) => {
+			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
+			return db.withWriteTx((w: import("./db-accessor").WriteDb) => {
 				const existing = w.prepare("SELECT id FROM telemetry_install ORDER BY created_at ASC LIMIT 1").get() as
 					| { readonly id: string }
 					| null
@@ -891,7 +893,7 @@ export function createTelemetryCollector(
 		pendingDroppedEventCount = 0;
 	}
 
-	void readDeliveryState().then((state) => {
+	const deliveryStateReady = readDeliveryState().then((state) => {
 		deliveryState = state;
 		consecutiveFailures = state.consecutiveFailures;
 		effectiveIntervalMs = nextFlushIntervalMs(config.flushIntervalMs, consecutiveFailures);
@@ -1305,7 +1307,13 @@ export function createTelemetryCollector(
 		}
 	}
 
-	async function doFlush(emitHealth: boolean, allowRemote = true): Promise<void> {
+	async function doFlush(emitHealth: boolean, allowRemote = true, force = false): Promise<void> {
+		// The persisted delivery state may still be loading when the first timer
+		// fires. Do not let that first delivery bypass a restart backoff, and
+		// re-check the gate after the state has been applied because the caller's
+		// initial check necessarily ran before this await.
+		await deliveryStateReady;
+		if (allowRemote && !force && Date.now() < nextAllowedFlushAt) allowRemote = false;
 		await awaitPendingAsyncWrites();
 		flushCount++;
 		await drainBuffer();
@@ -1360,14 +1368,14 @@ export function createTelemetryCollector(
 			// Backoff suppresses network claims, not local durability. Persist the
 			// in-memory buffer so an outage cannot exhaust RAM or lose events;
 			// retain local health/pruning maintenance while skipping PostHog.
-			flushPromise = doFlush(emitHealth, false)
+			flushPromise = doFlush(emitHealth, false, force)
 				.catch(() => {})
 				.finally(() => {
 					flushPromise = null;
 				});
 			return flushPromise;
 		}
-		flushPromise = doFlush(emitHealth)
+		flushPromise = doFlush(emitHealth, true, force)
 			.catch(() => {
 				// Telemetry must never surface a flush failure to the daemon.
 			})

--- a/platform/daemon/src/telemetry.ts
+++ b/platform/daemon/src/telemetry.ts
@@ -1479,6 +1479,7 @@ export function createTelemetryCollector(
 		},
 
 		recordFirstUse(kind): void {
+			if (recordingStopped) return;
 			const pending = persistFirstUse(kind)
 				.then((event) => {
 					if (!event) return;
@@ -1547,6 +1548,7 @@ export function createTelemetryCollector(
 			buffer.splice(0, buffer.length);
 			flushAbortController?.abort();
 			if (flushPromise) await flushPromise;
+			await awaitPendingAsyncWrites();
 			try {
 				const withWriteTxAsync = db.withWriteTxAsync;
 				if (!withWriteTxAsync) throw new Error("async writer unavailable");

--- a/platform/daemon/src/yielding-writes.test.ts
+++ b/platform/daemon/src/yielding-writes.test.ts
@@ -212,7 +212,7 @@ describe("event-loop wedge telemetry", () => {
 			reportEventLoopLag(1500, t0);
 			reportEventLoopLag(2000, t0 + 1_000); // within cooldown: suppressed
 			await collector.flush();
-			const events = collector.query().filter((e) => e.event === "error.occurred");
+			const events = (await collector.query()).filter((e) => e.event === "error.occurred");
 			expect(events).toHaveLength(1);
 			expect(events[0]?.properties.type).toBe("EventLoopLag");
 			expect(events[0]?.properties.lagMs).toBe(1500);
@@ -225,7 +225,7 @@ describe("event-loop wedge telemetry", () => {
 			// After the cooldown elapses, a new wedge is reported.
 			reportEventLoopLag(999, t0 + 601_000);
 			await collector.flush();
-			const after = collector.query().filter((e) => e.event === "error.occurred");
+			const after = (await collector.query()).filter((e) => e.event === "error.occurred");
 			expect(after).toHaveLength(2);
 		} finally {
 			setActiveTelemetry(undefined);

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -11,11 +11,11 @@ import {
 	renderReport,
 } from "./audit-event-loop-contract";
 
-test("the deterministic ledger retains the exact 1046-site inventory", () => {
+test("the deterministic ledger retains the exact 1036-site inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(1046);
-	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(220);
-	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(342);
+	expect(baseline).toHaveLength(1036);
+	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(217);
+	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(335);
 });
 
 test("the ledger reports legacy DB markers and rejects new call sites", () => {
@@ -278,9 +278,9 @@ test("the production TypeScript project cannot import the compatibility module",
 
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	const report = renderReport(baseline, { total: 562, withWriteTx: 220, withReadDb: 342 });
-	expect(report).toContain("Exact ledger inventory: 1,046 sites");
-	expect(report).toContain("220 synchronous writes and 342 synchronous reads");
+	const report = renderReport(baseline, { total: 552, withWriteTx: 217, withReadDb: 335 });
+	expect(report).toContain("Exact ledger inventory: 1,036 sites");
+	expect(report).toContain("217 synchronous writes and 335 synchronous reads");
 	expect(report).toContain("type boundary");
 	expect(report).not.toContain("1047");
 });

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -11,11 +11,11 @@ import {
 	renderReport,
 } from "./audit-event-loop-contract";
 
-test("the deterministic ledger retains the exact 1050-site inventory", () => {
+test("the deterministic ledger retains the exact 1046-site inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(1050);
-	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(227);
-	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(339);
+	expect(baseline).toHaveLength(1046);
+	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(220);
+	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(342);
 });
 
 test("the ledger reports legacy DB markers and rejects new call sites", () => {
@@ -278,11 +278,11 @@ test("the production TypeScript project cannot import the compatibility module",
 
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	const report = renderReport(baseline, { total: 566, withWriteTx: 227, withReadDb: 339 });
-	expect(report).toContain("Exact ledger inventory: 1,050 sites");
-	expect(report).toContain("227 synchronous writes and 339 synchronous reads");
+	const report = renderReport(baseline, { total: 562, withWriteTx: 220, withReadDb: 342 });
+	expect(report).toContain("Exact ledger inventory: 1,046 sites");
+	expect(report).toContain("220 synchronous writes and 342 synchronous reads");
 	expect(report).toContain("type boundary");
-	expect(report).not.toContain("1,051");
+	expect(report).not.toContain("1047");
 });
 
 // Keep the production/public type distinction visible in source review. The

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -445,7 +445,7 @@
 		},
 		{
 			"path": "daemon.ts",
-			"line": 1421,
+			"line": 1434,
 			"api": "withWriteTx",
 			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
 			"category": "hot-path"
@@ -466,7 +466,7 @@
 		},
 		{
 			"path": "daemon.ts",
-			"line": 1502,
+			"line": 1515,
 			"api": "withReadDb",
 			"source": "const activeEmbeddingCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
 			"category": "hot-path"
@@ -515,14 +515,14 @@
 		},
 		{
 			"path": "daemon.ts",
-			"line": 2175,
+			"line": 2188,
 			"api": "withReadDb",
 			"source": "const memoryCount = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
 			"category": "hot-path"
 		},
 		{
 			"path": "daemon.ts",
-			"line": 2186,
+			"line": 2199,
 			"api": "withReadDb",
 			"source": "const queue = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
 			"category": "hot-path"
@@ -1082,7 +1082,7 @@
 		},
 		{
 			"path": "hooks.ts",
-			"line": 459,
+			"line": 460,
 			"api": "withReadDb",
 			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
 			"category": "hot-path"
@@ -1096,7 +1096,7 @@
 		},
 		{
 			"path": "hooks.ts",
-			"line": 565,
+			"line": 566,
 			"api": "withReadDb",
 			"source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
 			"category": "hot-path"
@@ -1110,21 +1110,21 @@
 		},
 		{
 			"path": "hooks.ts",
-			"line": 774,
+			"line": 775,
 			"api": "withReadDb",
 			"source": "const block = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
 			"category": "hot-path"
 		},
 		{
 			"path": "hooks.ts",
-			"line": 850,
+			"line": 851,
 			"api": "withReadDb",
 			"source": "const focal = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
 			"category": "hot-path"
 		},
 		{
 			"path": "hooks.ts",
-			"line": 864,
+			"line": 865,
 			"api": "withReadDb",
 			"source": "<T>(fn: (db: ReadDb) => T): T => getDbAccessor().withReadDb(fn),",
 			"category": "hot-path"
@@ -1818,14 +1818,14 @@
 		{
 			"path": "memory-head.ts",
 			"line": 165,
-			"api": "writeFileSync",
+			"api": "readFileSync",
 			"source": "writeFileSync(backup, readFileSync(path, \"utf-8\"));",
 			"category": "hot-path"
 		},
 		{
 			"path": "memory-head.ts",
 			"line": 165,
-			"api": "readFileSync",
+			"api": "writeFileSync",
 			"source": "writeFileSync(backup, readFileSync(path, \"utf-8\"));",
 			"category": "hot-path"
 		},
@@ -2034,6 +2034,13 @@
 		},
 		{
 			"path": "memory-lineage.ts",
+			"line": 2201,
+			"api": "rmSync",
+			"source": "rmSync(join(getAgentsDir(), path), { force: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
 			"line": 2213,
 			"api": "withReadDb",
 			"source": "const rows: Array<{ source_path: string }> = getDbAccessor().withReadDb(",
@@ -2044,13 +2051,6 @@
 			"line": 2225,
 			"api": "withWriteTx",
 			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 2201,
-			"api": "rmSync",
-			"source": "rmSync(join(getAgentsDir(), path), { force: true });",
 			"category": "hot-path"
 		},
 		{
@@ -2272,7 +2272,7 @@
 		},
 		{
 			"path": "native-memory-sources.ts",
-			"line": 964,
+			"line": 989,
 			"api": "withWriteTx",
 			"source": "const artifactRows = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
 			"category": "hot-path"
@@ -2419,21 +2419,21 @@
 		},
 		{
 			"path": "obsidian-source-graph.ts",
-			"line": 471,
+			"line": 477,
 			"api": "withWriteTx",
 			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
 			"category": "hot-path"
 		},
 		{
 			"path": "obsidian-source-graph.ts",
-			"line": 690,
+			"line": 696,
 			"api": "withWriteTx",
 			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
 			"category": "hot-path"
 		},
 		{
 			"path": "obsidian-source-graph.ts",
-			"line": 702,
+			"line": 708,
 			"api": "withWriteTx",
 			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
 			"category": "hot-path"
@@ -3560,14 +3560,14 @@
 		},
 		{
 			"path": "pipeline/synthesis-worker.ts",
-			"line": 126,
+			"line": 127,
 			"api": "withReadDb",
 			"source": "const checkpointRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
 			"category": "hot-path"
 		},
 		{
 			"path": "pipeline/synthesis-worker.ts",
-			"line": 152,
+			"line": 153,
 			"api": "withReadDb",
 			"source": "const transcriptRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
 			"category": "hot-path"

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -2061,20 +2061,6 @@
 			"category": "hot-path"
 		},
 		{
-			"path": "memory-search-telemetry.ts",
-			"line": 238,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-search-telemetry.ts",
-			"line": 314,
-			"api": "withReadDb",
-			"source": "return db.withReadDb((r) => {",
-			"category": "hot-path"
-		},
-		{
 			"path": "memory-search.ts",
 			"line": 611,
 			"api": "withReadDb",
@@ -6643,90 +6629,6 @@
 			"line": 532,
 			"api": "withWriteTx",
 			"source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 797,
-			"api": "withReadDb",
-			"source": "const row = db.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 879,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 926,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 982,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 1014,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 1034,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 1064,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 1085,
-			"api": "withWriteTx",
-			"source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 1133,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 1155,
-			"api": "withReadDb",
-			"source": "db.withReadDb((r) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 1474,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 1486,
-			"api": "withReadDb",
-			"source": "return db.withReadDb((r) => {",
 			"category": "hot-path"
 		},
 		{

--- a/scripts/load-test-stale-session-sweep.ts
+++ b/scripts/load-test-stale-session-sweep.ts
@@ -100,8 +100,9 @@ async function main(): Promise<void> {
 			await collector.flush();
 			clearInterval(probe);
 
-			const ends = collector.query().filter((event) => event.event === "session.end");
-			const turns = collector.query().filter((event) => event.event === "session.turn");
+			const events = await collector.query();
+			const ends = events.filter((event) => event.event === "session.end");
+			const turns = events.filter((event) => event.event === "session.turn");
 			const sortedLag = [...lagSamples].sort((a, b) => a - b);
 			const maxLagMs = Math.round(Math.max(...lagSamples, 0));
 			const p95LagMs = Math.round(percentile(sortedLag, 95));


### PR DESCRIPTION
## Summary

Convert daemon telemetry persistence and telemetry-backed reads to the bounded async database APIs so recall and request paths do not perform synchronous SQLite work. Preserve queue bounds, durable first-use recovery, delivery-health accounting, and explicit drop reporting.

## Changes

- Convert `telemetry.ts` persistence, delivery state, queue claims, pruning, discard, query, and health refresh paths to async database operations.
- Keep the install-id bootstrap fallback synchronous because it runs only during collector startup before request handling.
- Convert memory-search telemetry writes and reads to async APIs, with explicit dropped-event accounting when async admission is unavailable or fails.
- Update telemetry-backed routes, hooks, tests, and the stale-session load test for the async query contract.
- Preserve bounded in-memory and persisted queue behavior, including oldest-event drops and delivery-health counters.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations changed.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Verification completed on the daemon path:

- `bun test platform/daemon/src/memory-search-telemetry.test.ts platform/daemon/src/telemetry.test.ts`: 44 passed, 0 failed.
- `bunx tsc --noEmit -p platform/daemon/tsconfig.json`: passed.
- `bun run typecheck`: passed after generating the ignored OpenCode connector bundle required by this fresh worktree.
- `bun run --filter '@signet/daemon' build`: passed.
- `bun run lint`: passed with existing warnings.
- `bunx biome check` on changed files: passed with existing warnings.
- The affected daemon test files were run individually after the multi-file Bun invocation crashed with a Bun 1.3.11 segmentation fault. Each individual command passed, including the session tracker async telemetry regression suite. The no-argument root `bun test` suite was not claimed.
- A full workspace build was attempted and stopped at an unrelated missing `platform/core/node_modules/better-sqlite3`; the daemon package build completed successfully.

The two remaining synchronous `withWriteTx` calls are the install-id bootstrap and legacy-schema fallback inside collector startup only. No synchronous `withReadDb` calls remain in the changed telemetry implementations.
