### PR TITLE
fix(daemon): stream native source imports

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,15 +4,15 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 1060 sites
-- Synchronous `withWriteTx()` sites: 230
-- Synchronous `withReadDb()` sites: 346
+- Exact ledger inventory: 1,050 sites
+- Synchronous `withWriteTx()` sites: 227
+- Synchronous `withReadDb()` sites: 339
 - Synchronous filesystem/process sites: 484
-- Compile-visible legacy DB sites remaining: 576
-  - `withWriteTx`: 230
-  - `withReadDb`: 346
+- Compile-visible legacy DB sites remaining: 566
+  - `withWriteTx`: 227
+  - `withReadDb`: 339
 
-The 1,060-site inventory excludes test, benchmark, generated, and `__tests__` fixtures. The 230 synchronous writes and 346 synchronous reads remain transitional callers for the later migration phase. They are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate 576 database operations.
+The 1,050-site inventory excludes test, benchmark, generated, and `__tests__` fixtures. The 227 synchronous writes and 339 synchronous reads remain transitional callers for the later migration phase. They are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate 566 database operations.
 
 ## Enforcement boundary
 
@@ -25,4 +25,4 @@ The 1,060-site inventory excludes test, benchmark, generated, and `__tests__` fi
 
 The structural boundary makes statically-resolved imports from the production source tree impossible: TypeScript reports TS6059 before aliases or computed member calls can use the compatibility type. The production bundle also only starts from source entrypoints, so this compatibility module is not a shipped production artifact.
 
-A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 576 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 230 write and 346 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.
+A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 566 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 227 write and 339 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -730,7 +730,8 @@ async function readLegacyMarkdownImportState(filePath: string): Promise<{
 	readonly status: string;
 } | null> {
 	try {
-		return await getDbAccessor().withReadDbAsync(async (db) => {			const row = db
+		return await getDbAccessor().withReadDbAsync(async (db) => {
+			const row = db
 				.prepare(
 					`SELECT mtime_ms, ctime_ms, size, content_hash, importer_version, chunk_count, status
 					 FROM legacy_markdown_imports
@@ -779,7 +780,8 @@ async function writeLegacyMarkdownImportState(args: {
 }): Promise<void> {
 	try {
 		const now = new Date().toISOString();
-		await withWriteTxAsync((db) => {			db.prepare(
+		await withWriteTxAsync((db) => {
+			db.prepare(
 				`INSERT INTO legacy_markdown_imports
 				 (path, mtime_ms, ctime_ms, size, content_hash, importer_version, chunk_count,
 				  last_imported_at, last_seen_at, status, error)
@@ -816,7 +818,8 @@ async function writeLegacyMarkdownImportState(args: {
 
 async function legacyMarkdownChunkKnown(filePath: string, chunkHash: string): Promise<boolean> {
 	try {
-		return await getDbAccessor().withReadDbAsync(async (db) => {			const row = db
+		return await getDbAccessor().withReadDbAsync(async (db) => {
+			const row = db
 				.prepare("SELECT 1 FROM legacy_markdown_chunks WHERE file_path = ? AND chunk_hash = ?")
 				.get(filePath, chunkHash);
 			return row != null;
@@ -834,7 +837,8 @@ async function recordLegacyMarkdownChunk(args: {
 	readonly sourceId: string;
 }): Promise<void> {
 	try {
-		await withWriteTxAsync((db) => {			db.prepare(
+		await withWriteTxAsync((db) => {
+			db.prepare(
 				`INSERT INTO legacy_markdown_chunks
 				 (file_path, chunk_hash, chunk_index, memory_id, source_id, created_at)
 				 VALUES (?, ?, ?, ?, ?, ?)

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -7,10 +7,9 @@
 import "./bun-socket-polyfill";
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { realpathSync } from "node:fs";
-import { readFile as readFileAsync, unlink as unlinkAsync } from "node:fs/promises";
-import { readdir } from "node:fs/promises";
+import { opendir, readFile as readFileAsync, stat as statAsync, unlink as unlinkAsync } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -50,7 +49,13 @@ import {
 import { listConnectors } from "./connectors/registry";
 import { clearAllPresence, reconcileAcpDeliveries } from "./cross-agent";
 import { runDeferredIntegrityCheck } from "./database-integrity";
-import { closeDbAccessor, getDbAccessor, getVectorRuntimeStatus, initDbAccessorAsync } from "./db-accessor";
+import {
+	closeDbAccessor,
+	getDbAccessor,
+	getVectorRuntimeStatus,
+	initDbAccessorAsync,
+	type WriteDb,
+} from "./db-accessor";
 import { type VacuumConversionHandle, startVacuumConversionWorker } from "./db-vacuum";
 import { getQueueDiagnosticsSnapshot, getQueuePressureSnapshot } from "./diagnostics-queue";
 import { fetchEmbedding } from "./embedding-fetch";
@@ -700,16 +705,22 @@ interface LegacyMarkdownFileState {
 	readonly size: number;
 }
 
-function legacyMarkdownFileState(filePath: string): LegacyMarkdownFileState | null {
+async function withWriteTxAsync<T>(fn: (db: WriteDb) => T): Promise<T> {
+	const accessor = getDbAccessor();
+	if (!accessor.withWriteTxAsync) throw new Error("Async database writer is unavailable");
+	return accessor.withWriteTxAsync(fn);
+}
+
+async function legacyMarkdownFileState(filePath: string): Promise<LegacyMarkdownFileState | null> {
 	try {
-		const stat = statSync(filePath);
-		return { mtimeMs: Math.round(stat.mtimeMs), ctimeMs: Math.round(stat.ctimeMs), size: stat.size };
+		const fileStat = await statAsync(filePath);
+		return { mtimeMs: Math.round(fileStat.mtimeMs), ctimeMs: Math.round(fileStat.ctimeMs), size: fileStat.size };
 	} catch {
 		return null;
 	}
 }
 
-function readLegacyMarkdownImportState(filePath: string): {
+async function readLegacyMarkdownImportState(filePath: string): Promise<{
 	readonly mtime_ms: number;
 	readonly ctime_ms: number;
 	readonly size: number;
@@ -717,11 +728,9 @@ function readLegacyMarkdownImportState(filePath: string): {
 	readonly importer_version: number;
 	readonly chunk_count: number;
 	readonly status: string;
-} | null {
+} | null> {
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		return getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
-			const row = db
+		return await getDbAccessor().withReadDbAsync(async (db) => {			const row = db
 				.prepare(
 					`SELECT mtime_ms, ctime_ms, size, content_hash, importer_version, chunk_count, status
 					 FROM legacy_markdown_imports
@@ -747,7 +756,7 @@ function readLegacyMarkdownImportState(filePath: string): {
 }
 
 function legacyMarkdownImportIsCurrent(
-	row: ReturnType<typeof readLegacyMarkdownImportState>,
+	row: Awaited<ReturnType<typeof readLegacyMarkdownImportState>>,
 	state: LegacyMarkdownFileState,
 ): boolean {
 	return (
@@ -760,19 +769,17 @@ function legacyMarkdownImportIsCurrent(
 	);
 }
 
-function writeLegacyMarkdownImportState(args: {
+async function writeLegacyMarkdownImportState(args: {
 	readonly filePath: string;
 	readonly state: LegacyMarkdownFileState;
 	readonly contentHash: string;
 	readonly chunkCount: number;
 	readonly status: "imported" | "empty" | "failed";
 	readonly error?: string | null;
-}): void {
+}): Promise<void> {
 	try {
 		const now = new Date().toISOString();
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
-			db.prepare(
+		await withWriteTxAsync((db) => {			db.prepare(
 				`INSERT INTO legacy_markdown_imports
 				 (path, mtime_ms, ctime_ms, size, content_hash, importer_version, chunk_count,
 				  last_imported_at, last_seen_at, status, error)
@@ -807,31 +814,27 @@ function writeLegacyMarkdownImportState(args: {
 	}
 }
 
-function legacyMarkdownChunkKnown(filePath: string, chunkHash: string): boolean {
+async function legacyMarkdownChunkKnown(filePath: string, chunkHash: string): Promise<boolean> {
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		return getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
-			const row = db
+		return await getDbAccessor().withReadDbAsync(async (db) => {			const row = db
 				.prepare("SELECT 1 FROM legacy_markdown_chunks WHERE file_path = ? AND chunk_hash = ?")
 				.get(filePath, chunkHash);
-			return row !== undefined;
+			return row != null;
 		});
 	} catch {
 		return false;
 	}
 }
 
-function recordLegacyMarkdownChunk(args: {
+async function recordLegacyMarkdownChunk(args: {
 	readonly filePath: string;
 	readonly chunkHash: string;
 	readonly chunkIndex: number;
 	readonly memoryId: string | null;
 	readonly sourceId: string;
-}): void {
+}): Promise<void> {
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
-			db.prepare(
+		await withWriteTxAsync((db) => {			db.prepare(
 				`INSERT INTO legacy_markdown_chunks
 				 (file_path, chunk_hash, chunk_index, memory_id, source_id, created_at)
 				 VALUES (?, ?, ?, ?, ?, ?)
@@ -858,15 +861,15 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 	const filenameWithExt = basename(filePath);
 	if (MEMORY_BACKUP_FILENAME_RE.test(filenameWithExt) || ARTIFACT_FILENAME_RE.test(filenameWithExt)) return 0;
 
-	const fileState = legacyMarkdownFileState(filePath);
+	const fileState = await legacyMarkdownFileState(filePath);
 	if (fileState === null) return 0;
 
-	const priorState = readLegacyMarkdownImportState(filePath);
+	const priorState = await readLegacyMarkdownImportState(filePath);
 	if (legacyMarkdownImportIsCurrent(priorState, fileState)) return 0;
 
 	let content: string;
 	try {
-		content = readFileSync(filePath, "utf-8");
+		content = await readFileAsync(filePath, "utf-8");
 	} catch (e) {
 		logger.error("watcher", "Failed to read memory file", undefined, {
 			path: filePath,
@@ -881,7 +884,7 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 		priorState.importer_version === LEGACY_MARKDOWN_IMPORTER_VERSION &&
 		(priorState.status === "imported" || priorState.status === "empty")
 	) {
-		writeLegacyMarkdownImportState({
+		await writeLegacyMarkdownImportState({
 			filePath,
 			state: fileState,
 			contentHash: hash,
@@ -892,7 +895,7 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 	}
 
 	if (!content.trim()) {
-		writeLegacyMarkdownImportState({
+		await writeLegacyMarkdownImportState({
 			filePath,
 			state: fileState,
 			contentHash: hash,
@@ -927,7 +930,7 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 
 		const chunkHash = createHash("sha256").update(chunk.text).digest("hex").slice(0, 16);
 		const chunkKey = `openclaw:${filename}:${chunkHash}`;
-		if (legacyMarkdownChunkKnown(filePath, chunkHash)) {
+		if (await legacyMarkdownChunkKnown(filePath, chunkHash)) {
 			imported++;
 			await yielder();
 			continue;
@@ -963,13 +966,13 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 				} catch {
 					memoryId = null;
 				}
-				recordLegacyMarkdownChunk({ filePath, chunkHash, chunkIndex: i, memoryId, sourceId: chunkKey });
+				await recordLegacyMarkdownChunk({ filePath, chunkHash, chunkIndex: i, memoryId, sourceId: chunkKey });
 				imported++;
 			} else if (response.status === 409) {
 				// Existing historical imports can predate this manifest table. A 409 still
 				// proves this deterministic chunk should not be posted again on every
 				// daemon restart, so persist a manifest row without a memory id.
-				recordLegacyMarkdownChunk({ filePath, chunkHash, chunkIndex: i, memoryId: null, sourceId: chunkKey });
+				await recordLegacyMarkdownChunk({ filePath, chunkHash, chunkIndex: i, memoryId: null, sourceId: chunkKey });
 				imported++;
 				logger.debug("watcher", "Legacy memory chunk already exists", { path: filePath, chunkIndex: i });
 			} else {
@@ -994,7 +997,7 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 
 	if (transientFailures > 0) {
 		ingestedMemoryFiles.delete(filePath);
-		writeLegacyMarkdownImportState({
+		await writeLegacyMarkdownImportState({
 			filePath,
 			state: fileState,
 			contentHash: hash,
@@ -1004,7 +1007,7 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 		});
 	} else {
 		ingestedMemoryFiles.set(filePath, hash);
-		writeLegacyMarkdownImportState({
+		await writeLegacyMarkdownImportState({
 			filePath,
 			state: fileState,
 			contentHash: hash,
@@ -1024,6 +1027,22 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 	return imported;
 }
 
+async function* legacyMarkdownFiles(memoryDir: string): AsyncGenerator<string> {
+	let directory: Awaited<ReturnType<typeof opendir>>;
+	try {
+		directory = await opendir(memoryDir);
+	} catch (error) {
+		const errDetails = error instanceof Error ? { message: error.message } : { error: String(error) };
+		logger.error("daemon", "Failed to read memory directory", undefined, errDetails);
+		return;
+	}
+	for await (const entry of directory) {
+		if (!entry.isFile() || !entry.name.endsWith(".md") || entry.name === "MEMORY.md") continue;
+		if (ARTIFACT_FILENAME_RE.test(entry.name) || MEMORY_BACKUP_FILENAME_RE.test(entry.name)) continue;
+		yield join(memoryDir, entry.name);
+	}
+}
+
 async function importExistingMemoryFiles(): Promise<number> {
 	const memoryDir = join(AGENTS_DIR, "memory");
 	if (!existsSync(memoryDir)) {
@@ -1031,34 +1050,24 @@ async function importExistingMemoryFiles(): Promise<number> {
 		return 0;
 	}
 
-	let files: string[];
-	try {
-		files = (await readdir(memoryDir))
-			.filter((f) => f.endsWith(".md") && f !== "MEMORY.md")
-			.filter((f) => !ARTIFACT_FILENAME_RE.test(f) && !MEMORY_BACKUP_FILENAME_RE.test(f));
-	} catch (e) {
-		const errDetails = e instanceof Error ? { message: e.message } : { error: String(e) };
-		logger.error("daemon", "Failed to read memory directory", undefined, errDetails);
-		return 0;
-	}
-
-	if (files.length === 0) {
-		logger.debug("daemon", "importExistingMemoryFiles: all files are artifacts/backups, skipping");
-		return 0;
-	}
-
 	let totalChunks = 0;
+	let fileCount = 0;
 	const yielder = yieldEvery(10);
-	for (const file of files) {
-		const count = await ingestMemoryMarkdown(join(memoryDir, file));
+	for await (const filePath of legacyMarkdownFiles(memoryDir)) {
+		fileCount++;
+		const count = await ingestMemoryMarkdown(filePath);
 		totalChunks += count;
 		await yielder();
 		if (count > 0) await sleep(MEMORY_IMPORT_FILE_DELAY_MS);
 	}
 
+	if (fileCount === 0) {
+		logger.debug("daemon", "importExistingMemoryFiles: all files are artifacts/backups, skipping");
+		return 0;
+	}
 	if (totalChunks > 0) {
 		logger.info("daemon", "Imported existing memory files", {
-			files: files.length,
+			files: fileCount,
 			chunks: totalChunks,
 		});
 	}

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -707,6 +707,81 @@ describe("native memory sources", () => {
 		}
 	});
 
+	it("does not soft-delete artifacts beyond a capped scan", async () => {
+		const root = join(dir, "vault");
+		const first = join(root, "first.md");
+		const second = join(root, "second.md");
+		mkdirSync(root, { recursive: true });
+		writeFileSync(first, "# First\n\nThe first source document remains active.\n");
+		writeFileSync(second, "# Second\n\nThe second source document remains active.\n");
+		const source = obsidianNativeMemorySource(root, "Capped Vault", "obsidian:capped-vault");
+
+		const initial = startNativeMemoryBridge([source], {
+			agentId: "agent-native",
+			pollIntervalMs: 0,
+			sourceGraphEnabled: false,
+		});
+		try {
+			expect(await initial.syncExisting()).toBe(2);
+		} finally {
+			await initial.close();
+		}
+
+		const capped = startNativeMemoryBridge([source], {
+			agentId: "agent-native",
+			pollIntervalMs: 0,
+			maxFilesPerScan: 1,
+			sourceGraphEnabled: false,
+		});
+		try {
+			expect(await capped.syncExisting()).toBe(0);
+		} finally {
+			await capped.close();
+		}
+
+		const rows = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT source_path, is_deleted FROM memory_artifacts WHERE agent_id = ? ORDER BY source_path")
+					.all("agent-native") as Array<{ source_path: string; is_deleted: number }>,
+		);
+		expect(rows).toEqual([
+			{ source_path: first, is_deleted: 0 },
+			{ source_path: second, is_deleted: 0 },
+		]);
+	});
+
+	it("preserves the Obsidian path index across an async graph-enabled scan", async () => {
+		const root = join(dir, "vault");
+		const sourceFile = join(root, "folder-a", "Source.md");
+		const targetFile = join(root, "folder-b", "Target.md");
+		mkdirSync(join(root, "folder-a"), { recursive: true });
+		mkdirSync(join(root, "folder-b"), { recursive: true });
+		writeFileSync(sourceFile, "# Source\n\nLinks to [[Target]].\n");
+		writeFileSync(targetFile, "# Target\n\nThe cross-folder target is indexed as source graph structure.\n");
+		const source = obsidianNativeMemorySource(root, "Async Graph Vault", "obsidian:async-graph");
+		const handle = startNativeMemoryBridge([source], {
+			agentId: "agent-native",
+			pollIntervalMs: 0,
+			sourceGraphEnabled: true,
+		});
+		try {
+			expect(await handle.syncExisting()).toBe(2);
+		} finally {
+			await handle.close();
+		}
+
+		const target = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT entity_type, source_path FROM entities WHERE agent_id = ? AND canonical_name = ?")
+					.get("agent-native", "obsidian:obsidian:async-graph:document:folder-b/Target.md") as
+					| { entity_type: string; source_path: string }
+					| undefined,
+		);
+		expect(target).toEqual({ entity_type: "source_document", source_path: targetFile });
+	});
+
 	it("can defer stale source cleanup during bridge sync", async () => {
 		const root = join(dir, "vault");
 		const file = join(root, "permanent", "Old.md");

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -1461,6 +1461,33 @@ describe("native memory sources", () => {
 		}
 	});
 
+	it("streams a large source path set without collecting all files first", async () => {
+		const root = join(dir, "large-vault");
+		mkdirSync(root, { recursive: true });
+		for (let index = 0; index < 128; index++) {
+			writeFileSync(join(root, `note-${index}.md`), `# Note ${index}\n\nStreaming source note ${index}.`);
+		}
+		let firstFileSeen = false;
+		let indexed = 0;
+		const handle = startNativeMemoryBridge([obsidianNativeMemorySource(root, "Large Vault", "obsidian:large-vault")], {
+			agentId: "agent-native",
+			pollIntervalMs: 0,
+			sourceFileDelayMs: 0,
+			sourceGraphEnabled: false,
+			onFileIndexed: () => {
+				firstFileSeen = true;
+				indexed++;
+			},
+		});
+		try {
+			expect(await handle.syncExisting()).toBe(128);
+			expect(firstFileSeen).toBe(true);
+			expect(indexed).toBe(128);
+		} finally {
+			await handle.close();
+		}
+	}, 30_000);
+
 	it("coalesces overlapping source sync requests and runs one trailing resync", async () => {
 		const root = join(dir, "vault");
 		const file = join(root, "permanent", "Burst.md");

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -28,6 +28,8 @@ import {
 } from "./obsidian-source-embeddings";
 import {
 	type ObsidianMarkdownPathIndex,
+	addObsidianMarkdownPathIndex,
+	buildObsidianMarkdownPathIndex,
 	indexObsidianSourceStructure,
 	purgeObsidianSourceFileStructure,
 	purgeObsidianSourceStructure,
@@ -71,6 +73,8 @@ export interface NativeMemoryBridgeOptions {
 	readonly sourceCleanupEnabled?: boolean;
 	readonly shouldCleanupSource?: (source: NativeMemorySource) => boolean;
 	readonly sourceGraphEnabled?: boolean;
+	/** Test and bounded-scan override. Production scans use the 50,000-file cap. */
+	readonly maxFilesPerScan?: number;
 	readonly shouldContinue?: (source: NativeMemorySource) => boolean;
 	readonly onEmbeddingStatus?: (status: string | undefined) => void;
 	readonly onFileIndexed?: (event: NativeMemoryFileIndexEvent) => void;
@@ -565,7 +569,8 @@ async function withWriteTxAsync<T>(fn: (db: WriteDb) => T): Promise<T> {
 async function nativeArtifactContentHash(filePath: string, agentId: string): Promise<string | null> {
 	const sourcePath = filePath.replace(/\\/g, "/");
 	try {
-		return await getDbAccessor().withReadDbAsync(async (db) => {			const row = db
+		return await getDbAccessor().withReadDbAsync(async (db) => {
+			const row = db
 				.prepare(
 					"SELECT source_sha256 FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0 LIMIT 1",
 				)
@@ -580,7 +585,8 @@ async function nativeArtifactContentHash(filePath: string, agentId: string): Pro
 async function nativeArtifactCapturedAt(filePath: string, agentId: string): Promise<string | null> {
 	const sourcePath = filePath.replace(/\\/g, "/");
 	try {
-		return await getDbAccessor().withReadDbAsync(async (db) => {			const row = db
+		return await getDbAccessor().withReadDbAsync(async (db) => {
+			const row = db
 				.prepare(
 					"SELECT captured_at FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0 LIMIT 1",
 				)
@@ -608,7 +614,8 @@ async function healSentinelCapturedAt(
 	if (timestampMillis(capturedAt) >= Date.parse(EPISODIC_CAPTURED_AT_FLOOR)) return;
 	try {
 		const stampedAt = new Date().toISOString();
-		await withWriteTxAsync((db) => {			db.prepare(
+		await withWriteTxAsync((db) => {
+			db.prepare(
 				`UPDATE memory_artifacts
 				 SET captured_at = ?, updated_at = ?
 				 WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0`,
@@ -629,7 +636,8 @@ async function healSentinelCapturedAt(
 
 async function obsidianGraphExists(agentId: string, sourceId: string, filePath: string): Promise<boolean> {
 	try {
-		return await getDbAccessor().withReadDbAsync(async (db) => {			const row = db
+		return await getDbAccessor().withReadDbAsync(async (db) => {
+			const row = db
 				.prepare(
 					`SELECT 1 FROM entities
 					 WHERE agent_id = ?
@@ -656,7 +664,8 @@ async function obsidianEmbeddingsExist(input: {
 	const chunks = buildObsidianSourceChunks(input);
 	if (chunks.length === 0) return true;
 	try {
-		return await getDbAccessor().withReadDbAsync(async (db) => {			const rows = db
+		return await getDbAccessor().withReadDbAsync(async (db) => {
+			const rows = db
 				.prepare(
 					`SELECT source_id FROM embeddings
 					 WHERE agent_id = ?
@@ -681,7 +690,8 @@ async function obsidianEmbeddingsExist(input: {
 async function activeNativeArtifactPaths(source: NativeMemorySource, agentId: string): Promise<string[]> {
 	const rootPrefix = `${normalizedRoot(source.root)}/`;
 	try {
-		return await getDbAccessor().withReadDbAsync(async (db) => {			const rows = db
+		return await getDbAccessor().withReadDbAsync(async (db) => {
+			const rows = db
 				.prepare(
 					`SELECT source_path FROM memory_artifacts
 					 WHERE agent_id = ?
@@ -1046,29 +1056,40 @@ export function startNativeMemoryBridge(
 			const key = sourceStateKey(source, agentId);
 			const current = new Set<string>();
 			const rootExists = await pathExists(source.root, source, agentId);
+			const maxFilesPerScan = options.maxFilesPerScan ?? NATIVE_MEMORY_MAX_FILES_PER_SCAN;
+			let scanComplete = true;
+			let scanTruncated = false;
 			if (rootExists) {
 				const fileDelayMs = sourceFileDelayMs(source, options);
 				let total = 0;
+				const markdownPathIndex =
+					source.harness === "obsidian" && (options.sourceGraphEnabled ?? true)
+						? buildObsidianMarkdownPathIndex(source.root, [])
+						: undefined;
 				for await (const file of walkNativeMemoryFiles(source.root, source, agentId)) {
-					if (matchesPattern(source, file)) total++;
-					if (total >= NATIVE_MEMORY_MAX_FILES_PER_SCAN) break;
+					if (!matchesPattern(source, file)) continue;
+					total++;
+					if (total > maxFilesPerScan) {
+						scanComplete = false;
+						scanTruncated = true;
+						break;
+					}
+					if (markdownPathIndex) addObsidianMarkdownPathIndex(markdownPathIndex, source.root, file);
+					await yielder();
 				}
 				// The generator plus awaited indexing below is a one-item bounded work queue.
 				for await (const file of walkNativeMemoryFiles(source.root, source, agentId)) {
-					if (scanned >= NATIVE_MEMORY_MAX_FILES_PER_SCAN) {
-						logger.warn("watcher", "Native memory scan reached its file budget", {
-							harness: source.harness,
-							root: source.root,
-							cap: NATIVE_MEMORY_MAX_FILES_PER_SCAN,
-						});
+					if (scanned >= maxFilesPerScan) break;
+					if (!matchesPattern(source, file)) continue;
+					if (options.shouldContinue && !options.shouldContinue(source)) {
+						scanComplete = false;
 						break;
 					}
-					if (!matchesPattern(source, file)) continue;
-					if (options.shouldContinue && !options.shouldContinue(source)) break;
 					scanned++;
 					let embeddingStatus: string | undefined;
 					const changed = await indexNativeMemoryFile(source, file, agentId, {
 						...options,
+						markdownPathIndex,
 						onEmbeddingStatus: (status) => {
 							embeddingStatus = status;
 							options.onEmbeddingStatus?.(status);
@@ -1091,21 +1112,34 @@ export function startNativeMemoryBridge(
 					await yielder();
 					await sleep(fileDelayMs);
 				}
+				if (scanTruncated) {
+					logger.warn("watcher", "Native memory scan reached its file budget", {
+						harness: source.harness,
+						root: source.root,
+						cap: maxFilesPerScan,
+					});
+				}
 			}
-			if (sourceCleanupEnabledFor(source, options)) {
+			const cleanupAllowed = sourceCleanupEnabledFor(source, options) && (!rootExists || scanComplete);
+			if (cleanupAllowed) {
 				const currentPaths = new Set([...current].map((file) => file.replace(/\\/g, "/")));
 				for (const file of await activeNativeArtifactPaths(source, agentId)) {
 					if (!currentPaths.has(file.replace(/\\/g, "/"))) removeNativeMemoryFile(source, file, agentId);
 				}
 			}
 			const previous = known.get(key);
-			if (previous && sourceCleanupEnabledFor(source, options)) {
+			if (previous && cleanupAllowed) {
 				for (const file of previous) {
 					if (!current.has(file)) removeNativeMemoryFile(source, file, agentId);
 				}
 			}
 			known.set(key, current);
-			if (rootExists && source.sourceId && (!options.shouldContinue || options.shouldContinue(source))) {
+			if (
+				rootExists &&
+				scanComplete &&
+				source.sourceId &&
+				(!options.shouldContinue || options.shouldContinue(source))
+			) {
 				markSourceIndexed(source.sourceId, undefined, options.agentsDir);
 			}
 		}

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
-import { lstat, readFile, readdir, stat } from "node:fs/promises";
-import type { Dirent } from "node:fs";
+import { lstat, opendir, readFile, stat } from "node:fs/promises";
+
 import { homedir } from "node:os";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import {
@@ -13,7 +13,7 @@ import {
 } from "@signet/core";
 import { resolveDaemonAgentId } from "./agent-id";
 import { yieldEvery } from "./async-yield";
-import { getDbAccessor } from "./db-accessor";
+import { getDbAccessor, type WriteDb } from "./db-accessor";
 import { EPISODIC_CAPTURED_AT_FLOOR, timestampMillis } from "./episodic-sources";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
@@ -28,7 +28,6 @@ import {
 } from "./obsidian-source-embeddings";
 import {
 	type ObsidianMarkdownPathIndex,
-	buildObsidianMarkdownPathIndex,
 	indexObsidianSourceStructure,
 	purgeObsidianSourceFileStructure,
 	purgeObsidianSourceStructure,
@@ -197,6 +196,10 @@ export function resetNativeMemoryIndexCache(): void {
 	resetObsidianSourceEmbeddingBackoff();
 }
 const DEFAULT_OBSIDIAN_SOURCE_FILE_DELAY_MS = 250;
+/** A scan keeps at most one discovered file awaiting indexing. */
+export const NATIVE_MEMORY_FILE_QUEUE_CAP = 1;
+const NATIVE_MEMORY_DIRECTORY_YIELD_EVERY = 64;
+const NATIVE_MEMORY_MAX_FILES_PER_SCAN = 50_000;
 
 // Read failures that are not permanent (ENOENT) enter a per-path cooldown so
 // a failing file cannot monopolize the scan loop. ENOENT drops the path from
@@ -371,9 +374,9 @@ async function* walkNativeMemoryFiles(
 ): AsyncGenerator<string> {
 	if (!(await pathExists(dir, source, agentId))) return;
 	if (nativeMemoryReadBackoffActive(source, dir, agentId)) return;
-	let entries: readonly Dirent[];
+	let directory: Awaited<ReturnType<typeof opendir>>;
 	try {
-		entries = await readdir(dir, { withFileTypes: true });
+		directory = await opendir(dir);
 		clearNativeMemoryPermissionDenied(source, dir, agentId);
 	} catch (err) {
 		if (classifyNativeMemoryReadFailure(err) === "permission-denied") {
@@ -381,13 +384,23 @@ async function* walkNativeMemoryFiles(
 		}
 		return;
 	}
-	for (const entry of entries) {
-		if (entry.name === ".git") continue;
-		const path = join(dir, entry.name);
-		if (entry.isDirectory()) {
-			yield* walkNativeMemoryFiles(path, source, agentId);
-		} else if (entry.isFile() && (entry.name.endsWith(".md") || entry.name.endsWith(".jsonl"))) {
-			yield path;
+	let entries = 0;
+	try {
+		for await (const entry of directory) {
+			entries++;
+			if (entries % NATIVE_MEMORY_DIRECTORY_YIELD_EVERY === 0)
+				await new Promise<void>((resolve) => setImmediate(resolve));
+			if (entry.name === ".git") continue;
+			const path = join(dir, entry.name);
+			if (entry.isDirectory()) {
+				yield* walkNativeMemoryFiles(path, source, agentId);
+			} else if (entry.isFile() && (entry.name.endsWith(".md") || entry.name.endsWith(".jsonl"))) {
+				yield path;
+			}
+		}
+	} catch (err) {
+		if (classifyNativeMemoryReadFailure(err) === "permission-denied") {
+			recordNativeMemoryPermissionDenied(source, dir, agentId);
 		}
 	}
 }
@@ -543,12 +556,16 @@ function sleep(ms: number): Promise<void> {
 	return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
 }
 
-function nativeArtifactContentHash(filePath: string, agentId: string): string | null {
+async function withWriteTxAsync<T>(fn: (db: WriteDb) => T): Promise<T> {
+	const accessor = getDbAccessor();
+	if (!accessor.withWriteTxAsync) throw new Error("Async database writer is unavailable");
+	return accessor.withWriteTxAsync(fn);
+}
+
+async function nativeArtifactContentHash(filePath: string, agentId: string): Promise<string | null> {
 	const sourcePath = filePath.replace(/\\/g, "/");
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		return getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
-			const row = db
+		return await getDbAccessor().withReadDbAsync(async (db) => {			const row = db
 				.prepare(
 					"SELECT source_sha256 FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0 LIMIT 1",
 				)
@@ -560,12 +577,10 @@ function nativeArtifactContentHash(filePath: string, agentId: string): string | 
 	}
 }
 
-function nativeArtifactCapturedAt(filePath: string, agentId: string): string | null {
+async function nativeArtifactCapturedAt(filePath: string, agentId: string): Promise<string | null> {
 	const sourcePath = filePath.replace(/\\/g, "/");
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		return getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
-			const row = db
+		return await getDbAccessor().withReadDbAsync(async (db) => {			const row = db
 				.prepare(
 					"SELECT captured_at FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0 LIMIT 1",
 				)
@@ -584,13 +599,16 @@ function nativeArtifactCapturedAt(filePath: string, agentId: string): string | n
  * indexes never mint sentinels (the memory-lineage clamp), so this only fires
  * once per legacy row (#1149).
  */
-function healSentinelCapturedAt(filePath: string, agentId: string, harness: string, capturedAt: string): void {
+async function healSentinelCapturedAt(
+	filePath: string,
+	agentId: string,
+	harness: string,
+	capturedAt: string,
+): Promise<void> {
 	if (timestampMillis(capturedAt) >= Date.parse(EPISODIC_CAPTURED_AT_FLOOR)) return;
 	try {
 		const stampedAt = new Date().toISOString();
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
-			db.prepare(
+		await withWriteTxAsync((db) => {			db.prepare(
 				`UPDATE memory_artifacts
 				 SET captured_at = ?, updated_at = ?
 				 WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0`,
@@ -609,11 +627,9 @@ function healSentinelCapturedAt(filePath: string, agentId: string, harness: stri
 	}
 }
 
-function obsidianGraphExists(agentId: string, sourceId: string, filePath: string): boolean {
+async function obsidianGraphExists(agentId: string, sourceId: string, filePath: string): Promise<boolean> {
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		return getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
-			const row = db
+		return await getDbAccessor().withReadDbAsync(async (db) => {			const row = db
 				.prepare(
 					`SELECT 1 FROM entities
 					 WHERE agent_id = ?
@@ -630,19 +646,17 @@ function obsidianGraphExists(agentId: string, sourceId: string, filePath: string
 	}
 }
 
-function obsidianEmbeddingsExist(input: {
+async function obsidianEmbeddingsExist(input: {
 	readonly agentId: string;
 	readonly sourceId: string;
 	readonly root: string;
 	readonly filePath: string;
 	readonly content: string;
-}): boolean {
+}): Promise<boolean> {
 	const chunks = buildObsidianSourceChunks(input);
 	if (chunks.length === 0) return true;
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		return getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
-			const rows = db
+		return await getDbAccessor().withReadDbAsync(async (db) => {			const rows = db
 				.prepare(
 					`SELECT source_id FROM embeddings
 					 WHERE agent_id = ?
@@ -664,12 +678,10 @@ function obsidianEmbeddingsExist(input: {
 	}
 }
 
-function activeNativeArtifactPaths(source: NativeMemorySource, agentId: string): string[] {
+async function activeNativeArtifactPaths(source: NativeMemorySource, agentId: string): Promise<string[]> {
 	const rootPrefix = `${normalizedRoot(source.root)}/`;
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		return getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
-			const rows = db
+		return await getDbAccessor().withReadDbAsync(async (db) => {			const rows = db
 				.prepare(
 					`SELECT source_path FROM memory_artifacts
 					 WHERE agent_id = ?
@@ -798,7 +810,7 @@ export async function indexNativeMemoryFile(
 	}
 
 	const hash = contentFingerprint(content);
-	const persistedHash = nativeArtifactContentHash(filePath, agentId);
+	const persistedHash = await nativeArtifactContentHash(filePath, agentId);
 	const obsidian = source.harness === "obsidian" && pattern.kind === "source_obsidian_markdown";
 	const hermes = source.harness === "hermes-agent";
 	const sourceId = obsidian ? (source.sourceId ?? sourceIdForObsidianRoot(source.root)) : (source.sourceId ?? null);
@@ -808,17 +820,20 @@ export async function indexNativeMemoryFile(
 		options.embeddingConfig?.provider !== "none" &&
 		options.embeddingConfig !== undefined &&
 		options.fetchEmbedding !== undefined;
-	const semanticComplete =
-		!obsidian ||
-		((!graphRequested || obsidianGraphExists(agentId, sourceId ?? "", filePath)) &&
-			(!embeddingRequested ||
-				obsidianEmbeddingsExist({
-					agentId,
-					sourceId: sourceId ?? "",
-					root: source.root,
-					filePath,
-					content,
-				})));
+	let semanticComplete = true;
+	if (obsidian) {
+		const graphExists = !graphRequested || (await obsidianGraphExists(agentId, sourceId ?? "", filePath));
+		const embeddingsExist =
+			!embeddingRequested ||
+			(await obsidianEmbeddingsExist({
+				agentId,
+				sourceId: sourceId ?? "",
+				root: source.root,
+				filePath,
+				content,
+			}));
+		semanticComplete = graphExists && embeddingsExist;
+	}
 	const cached = indexed.get(key);
 	if (cached?.contentHash === hash) {
 		if (persistedHash === hash && semanticComplete) return false;
@@ -828,9 +843,9 @@ export async function indexNativeMemoryFile(
 		// One-shot heal for legacy rows with a corrupt pre-epoch captured_at:
 		// they stay permanently pending otherwise (no watermark can reach
 		// 1980), keeping content passes from ever early-exiting (#1149).
-		const persistedCapturedAt = nativeArtifactCapturedAt(filePath, agentId);
+		const persistedCapturedAt = await nativeArtifactCapturedAt(filePath, agentId);
 		if (persistedCapturedAt !== null) {
-			healSentinelCapturedAt(filePath, agentId, source.harness, persistedCapturedAt);
+			await healSentinelCapturedAt(filePath, agentId, source.harness, persistedCapturedAt);
 		}
 		indexed.set(key, { contentHash: hash });
 		return false;
@@ -1032,25 +1047,28 @@ export function startNativeMemoryBridge(
 			const current = new Set<string>();
 			const rootExists = await pathExists(source.root, source, agentId);
 			if (rootExists) {
-				const files: string[] = [];
-				for await (const file of walkNativeMemoryFiles(source.root, source, agentId)) {
-					if (!matchesPattern(source, file)) continue;
-					files.push(file);
-					await yielder();
-				}
-				const total = files.length;
 				const fileDelayMs = sourceFileDelayMs(source, options);
-				const markdownPathIndex =
-					source.harness === "obsidian" && (options.sourceGraphEnabled ?? true)
-						? buildObsidianMarkdownPathIndex(source.root, files)
-						: undefined;
-				for (const file of files) {
+				let total = 0;
+				for await (const file of walkNativeMemoryFiles(source.root, source, agentId)) {
+					if (matchesPattern(source, file)) total++;
+					if (total >= NATIVE_MEMORY_MAX_FILES_PER_SCAN) break;
+				}
+				// The generator plus awaited indexing below is a one-item bounded work queue.
+				for await (const file of walkNativeMemoryFiles(source.root, source, agentId)) {
+					if (scanned >= NATIVE_MEMORY_MAX_FILES_PER_SCAN) {
+						logger.warn("watcher", "Native memory scan reached its file budget", {
+							harness: source.harness,
+							root: source.root,
+							cap: NATIVE_MEMORY_MAX_FILES_PER_SCAN,
+						});
+						break;
+					}
+					if (!matchesPattern(source, file)) continue;
 					if (options.shouldContinue && !options.shouldContinue(source)) break;
 					scanned++;
 					let embeddingStatus: string | undefined;
 					const changed = await indexNativeMemoryFile(source, file, agentId, {
 						...options,
-						markdownPathIndex,
 						onEmbeddingStatus: (status) => {
 							embeddingStatus = status;
 							options.onEmbeddingStatus?.(status);
@@ -1076,7 +1094,7 @@ export function startNativeMemoryBridge(
 			}
 			if (sourceCleanupEnabledFor(source, options)) {
 				const currentPaths = new Set([...current].map((file) => file.replace(/\\/g, "/")));
-				for (const file of activeNativeArtifactPaths(source, agentId)) {
+				for (const file of await activeNativeArtifactPaths(source, agentId)) {
 					if (!currentPaths.has(file.replace(/\\/g, "/"))) removeNativeMemoryFile(source, file, agentId);
 				}
 			}

--- a/platform/daemon/src/obsidian-source-graph.ts
+++ b/platform/daemon/src/obsidian-source-graph.ts
@@ -60,9 +60,9 @@ interface HeadingSection {
 }
 
 export interface ObsidianMarkdownPathIndex {
-	readonly byStem: ReadonlyMap<string, string>;
-	readonly byNormalizedStem: ReadonlyMap<string, string>;
-	readonly byRel: ReadonlyMap<string, string>;
+	readonly byStem: Map<string, string>;
+	readonly byNormalizedStem: Map<string, string>;
+	readonly byRel: Map<string, string>;
 }
 
 function normalizedRoot(root: string): string {
@@ -331,21 +331,27 @@ function markdownTarget(target: string): string {
 }
 
 export function buildObsidianMarkdownPathIndex(root: string, files: readonly string[]): ObsidianMarkdownPathIndex {
-	const normalized = normalizedRoot(root);
-	const byStem = new Map<string, string>();
-	const byNormalizedStem = new Map<string, string>();
-	const byRel = new Map<string, string>();
+	const index: ObsidianMarkdownPathIndex = {
+		byStem: new Map(),
+		byNormalizedStem: new Map(),
+		byRel: new Map(),
+	};
 	for (const file of files) {
-		const path = normalizedPath(file);
-		const rel = relPath(normalized, path);
-		if (!rel.endsWith(".md")) continue;
-		byRel.set(rel, path);
-		const stem = displayNameForFile(path);
-		if (!byStem.has(stem)) byStem.set(stem, path);
-		const normalizedStem = slug(stem);
-		if (!byNormalizedStem.has(normalizedStem)) byNormalizedStem.set(normalizedStem, path);
+		addObsidianMarkdownPathIndex(index, root, file);
 	}
-	return { byStem, byNormalizedStem, byRel };
+	return index;
+}
+
+/** Add one discovered Markdown path without materializing the full source tree. */
+export function addObsidianMarkdownPathIndex(index: ObsidianMarkdownPathIndex, root: string, file: string): void {
+	const path = normalizedPath(file);
+	const rel = relPath(normalizedRoot(root), path);
+	if (!rel.endsWith(".md")) return;
+	index.byRel.set(rel, path);
+	const stem = displayNameForFile(path);
+	if (!index.byStem.has(stem)) index.byStem.set(stem, path);
+	const normalizedStem = slug(stem);
+	if (!index.byNormalizedStem.has(normalizedStem)) index.byNormalizedStem.set(normalizedStem, path);
 }
 
 function resolveWikiLinkPath(

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -149,6 +149,12 @@ describe("Sources routes", () => {
 		}
 	});
 
+	it("keeps directory picker process execution asynchronous (#1457)", async () => {
+		const source = await Bun.file(new URL("./sources-routes.ts", import.meta.url)).text();
+		expect(source).toContain("execFile");
+		expect(source).not.toMatch(/\b(?:execSync|spawnSync)\b/);
+	});
+
 	it("lists no configured sources by default", async () => {
 		const res = await makeApp().request("/api/sources");
 		expect(res.status).toBe(200);

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -11,11 +11,11 @@ import {
 	renderReport,
 } from "./audit-event-loop-contract";
 
-test("the deterministic ledger retains the exact 1060-site inventory", () => {
+test("the deterministic ledger retains the exact 1050-site inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(1060);
-	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(230);
-	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(346);
+	expect(baseline).toHaveLength(1050);
+	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(227);
+	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(339);
 });
 
 test("the ledger reports legacy DB markers and rejects new call sites", () => {
@@ -278,11 +278,11 @@ test("the production TypeScript project cannot import the compatibility module",
 
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	const report = renderReport(baseline, { total: 576, withWriteTx: 230, withReadDb: 346 });
-	expect(report).toContain("Exact ledger inventory: 1060 sites");
-	expect(report).toContain("230 synchronous writes and 346 synchronous reads");
+	const report = renderReport(baseline, { total: 566, withWriteTx: 227, withReadDb: 339 });
+	expect(report).toContain("Exact ledger inventory: 1,050 sites");
+	expect(report).toContain("227 synchronous writes and 339 synchronous reads");
 	expect(report).toContain("type boundary");
-	expect(report).not.toContain("1061");
+	expect(report).not.toContain("1,051");
 });
 
 // Keep the production/public type distinction visible in source review. The

--- a/scripts/audit-event-loop-contract.ts
+++ b/scripts/audit-event-loop-contract.ts
@@ -409,23 +409,25 @@ export function writeBaseline(sites: readonly AuditSite[], path = DEFAULT_BASELI
 export function renderReport(baselineSites: readonly AuditSite[], legacyDbAccess: LegacyDbAccessCounts): string {
 	const counts = new Map<SyncApi, number>();
 	for (const site of baselineSites) counts.set(site.api, (counts.get(site.api) ?? 0) + 1);
-	const filesystemProcessCount =
-		baselineSites.length - (counts.get("withReadDb") ?? 0) - (counts.get("withWriteTx") ?? 0);
+	const writeCount = counts.get("withWriteTx") ?? 0;
+	const readCount = counts.get("withReadDb") ?? 0;
+	const filesystemProcessCount = baselineSites.length - writeCount - readCount;
+	const formatCount = (value: number): string => value.toLocaleString("en-US");
 	return `# Event-loop synchronous contract audit
 
 This report is generated from the deterministic migration ledger in \`scripts/event-loop-contract-baseline.json\`. Phase A enforces the type boundary structurally: production code receives an async-only \`DbAccessor\`, while the synchronous compatibility module lives outside the daemon production \`src/\` tree and is rejected by the production TypeScript project's \`rootDir\`. The AST import and call checks remain belt-and-suspenders diagnostics, and new synchronous DB call sites fail closed through exact ledger matching.
 
 ## Current inventory
 
-- Exact ledger inventory: ${baselineSites.length} sites
-- Synchronous \`withWriteTx()\` sites: ${counts.get("withWriteTx") ?? 0}
-- Synchronous \`withReadDb()\` sites: ${counts.get("withReadDb") ?? 0}
-- Synchronous filesystem/process sites: ${filesystemProcessCount}
-- Compile-visible legacy DB sites remaining: ${legacyDbAccess.total}
-  - \`withWriteTx\`: ${legacyDbAccess.withWriteTx}
-  - \`withReadDb\`: ${legacyDbAccess.withReadDb}
+- Exact ledger inventory: ${formatCount(baselineSites.length)} sites
+- Synchronous \`withWriteTx()\` sites: ${formatCount(writeCount)}
+- Synchronous \`withReadDb()\` sites: ${formatCount(readCount)}
+- Synchronous filesystem/process sites: ${formatCount(filesystemProcessCount)}
+- Compile-visible legacy DB sites remaining: ${formatCount(legacyDbAccess.total)}
+  - \`withWriteTx\`: ${formatCount(legacyDbAccess.withWriteTx)}
+  - \`withReadDb\`: ${formatCount(legacyDbAccess.withReadDb)}
 
-The 1,060-site inventory excludes test, benchmark, generated, and \`__tests__\` fixtures. The 230 synchronous writes and 346 synchronous reads remain transitional callers for the later migration phase. They are marked with \`@ts-expect-error LEGACY_SYNC_DB_ACCESS\`, so the compiler reports every remaining site without forcing this phase to migrate 576 database operations.
+The ${formatCount(baselineSites.length)}-site inventory excludes test, benchmark, generated, and \`__tests__\` fixtures. The ${formatCount(writeCount)} synchronous writes and ${formatCount(readCount)} synchronous reads remain transitional callers for the later migration phase. They are marked with \`@ts-expect-error LEGACY_SYNC_DB_ACCESS\`, so the compiler reports every remaining site without forcing this phase to migrate ${formatCount(writeCount + readCount)} database operations.
 
 ## Enforcement boundary
 
@@ -438,7 +440,7 @@ The 1,060-site inventory excludes test, benchmark, generated, and \`__tests__\` 
 
 The structural boundary makes statically-resolved imports from the production source tree impossible: TypeScript reports TS6059 before aliases or computed member calls can use the compatibility type. The production bundle also only starts from source entrypoints, so this compatibility module is not a shipped production artifact.
 
-A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 576 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 230 write and 346 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.
+A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the ${formatCount(legacyDbAccess.total)} transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all ${formatCount(legacyDbAccess.withWriteTx)} write and ${formatCount(legacyDbAccess.withReadDb)} read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.
 `;
 }
 

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -417,34 +417,6 @@
 		},
 		{
 			"path": "daemon.ts",
-			"line": 723,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 774,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 813,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 833,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
 			"line": 865,
 			"api": "readFileSync",
 			"source": "content = readFileSync(filePath, \"utf-8\");",
@@ -2310,48 +2282,6 @@
 			"line": 2965,
 			"api": "withReadDb",
 			"source": "const blocks = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-memory-sources.ts",
-			"line": 550,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-memory-sources.ts",
-			"line": 567,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-memory-sources.ts",
-			"line": 592,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-memory-sources.ts",
-			"line": 615,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-memory-sources.ts",
-			"line": 644,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-memory-sources.ts",
-			"line": 671,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
 			"category": "hot-path"
 		},
 		{


### PR DESCRIPTION
## Summary

Convert native source scanning and the legacy markdown importer to promise-based, bounded flows so large source trees do not materialize complete file lists or block the daemon on synchronous filesystem and database wrappers.

## Changes

- Stream native source traversal with `opendir`, an awaited one-item indexing queue, directory yields, and a 50,000-file scan budget.
- Convert native source probe/heal/cleanup database wrappers to async accessors while preserving source-scoped queries and existing cleanup behavior.
- Convert legacy markdown stat/read, manifest, and chunk checkpoint operations to promises. Iterate importer files with an async generator and preserve sequential chunk/file backpressure.
- Preserve the asynchronous directory picker path for #1457 and add a source regression guard against `execSync` and `spawnSync`.
- Add a 128-file streaming traversal regression.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations touched.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Direct synchronous DB wrapper calls in `native-memory-sources.ts`: 7 before, 1 after. The remaining call is the bulk source-artifact purge path. Seven direct native DB wrappers now use async accessors.
- Legacy importer synchronous DB wrappers: 4 before, 0 after. Importer async DB wrappers: 5. Legacy importer synchronous `statSync`/`readFileSync` calls: 2 before, 0 after. The remaining `existsSync(memoryDir)` at `platform/daemon/src/daemon.ts:1052` is bootstrap-only directory existence detection before opening the async iterator.
- Focused proof: native memory sources 53 pass, sources routes 35 pass, including the large streaming scan and #1457 picker regression. The existing memory-ingest-filter test process crashed inside Bun 1.3.11 before reporting tests; no test assertion ran in that process. The combined multi-file Bun invocation hit the same runner segfault.
- `bun run typecheck`, daemon build, focused Biome, and `bun run lint` pass. Full lint reports the repository's existing warnings but exits successfully.
- The native bridge remains serial at one in-flight file, so indexing applies bounded backpressure. Existing synchronous helper implementations outside the strictly owned files remain unchanged and are called one file at a time; this PR removes the direct synchronous DB wrappers from the owned native source path.
