### PR TITLE
refactor(daemon): make recall routes async

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,15 +4,15 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 752 sites
-- Synchronous `withWriteTx()` sites: 116
-- Synchronous `withReadDb()` sites: 152
+- Exact ledger inventory: 741 sites
+- Synchronous `withWriteTx()` sites: 111
+- Synchronous `withReadDb()` sites: 146
 - Synchronous filesystem/process sites: 484
-- Compile-visible legacy DB sites remaining: 268
-  - `withWriteTx`: 116
-  - `withReadDb`: 152
+- Compile-visible legacy DB sites remaining: 257
+  - `withWriteTx`: 111
+  - `withReadDb`: 146
 
-The 752-site inventory excludes test, benchmark, generated, and `__tests__` fixtures. The 116 synchronous writes and 152 synchronous reads remain transitional callers for the later migration phase. They are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate 268 database operations.
+The 741-site inventory excludes test, benchmark, generated, and `__tests__` fixtures. The 111 synchronous writes and 146 synchronous reads remain transitional callers for the later migration phase. They are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate 257 database operations.
 
 ## A3 Slice 2 migration notes
 
@@ -29,4 +29,4 @@ The converted async sites are distributed as follows: document-worker (18), drea
 
 The structural boundary makes statically-resolved imports from the production source tree impossible: TypeScript reports TS6059 before aliases or computed member calls can use the compatibility type. The production bundle also only starts from source entrypoints, so this compatibility module is not a shipped production artifact.
 
-A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 268 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 116 write and 152 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.
+A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 257 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 111 write and 146 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.

--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,15 +4,19 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 861 sites
-- Synchronous `withWriteTx()` sites: 181
-- Synchronous `withReadDb()` sites: 196
+- Exact ledger inventory: 752 sites
+- Synchronous `withWriteTx()` sites: 116
+- Synchronous `withReadDb()` sites: 152
 - Synchronous filesystem/process sites: 484
-- Compile-visible legacy DB sites remaining: 377
-  - `withWriteTx`: 181
-  - `withReadDb`: 196
+- Compile-visible legacy DB sites remaining: 268
+  - `withWriteTx`: 116
+  - `withReadDb`: 152
 
-The 861-site inventory excludes test, benchmark, generated, and `__tests__` fixtures. The 181 synchronous writes and 196 synchronous reads remain transitional callers for the later migration phase. They are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate 377 database operations.
+The 752-site inventory excludes test, benchmark, generated, and `__tests__` fixtures. The 116 synchronous writes and 152 synchronous reads remain transitional callers for the later migration phase. They are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate 268 database operations.
+
+## A3 Slice 2 migration notes
+
+The converted async sites are distributed as follows: document-worker (18), dreaming (28), retention (6), repair-actions (31), and source-lifecycle-telemetry (8), for 91 sites total.
 
 ## Enforcement boundary
 
@@ -25,4 +29,4 @@ The 861-site inventory excludes test, benchmark, generated, and `__tests__` fixt
 
 The structural boundary makes statically-resolved imports from the production source tree impossible: TypeScript reports TS6059 before aliases or computed member calls can use the compatibility type. The production bundle also only starts from source entrypoints, so this compatibility module is not a shipped production artifact.
 
-A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 377 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 181 write and 196 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.
+A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 268 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 116 write and 152 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.

--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,19 +4,15 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 934 sites
-- Synchronous `withWriteTx()` sites: 159
-- Synchronous `withReadDb()` sites: 291
+- Exact ledger inventory: 861 sites
+- Synchronous `withWriteTx()` sites: 181
+- Synchronous `withReadDb()` sites: 196
 - Synchronous filesystem/process sites: 484
-- Compile-visible legacy DB sites remaining: 450
-  - `withWriteTx`: 159
-  - `withReadDb`: 291
+- Compile-visible legacy DB sites remaining: 377
+  - `withWriteTx`: 181
+  - `withReadDb`: 196
 
-The 934-site inventory excludes test, benchmark, generated, and `__tests__` fixtures. The 159 synchronous writes and 291 synchronous reads remain transitional callers for the later migration phase. They are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate 450 database operations.
-
-## A3 Slice 2 migration notes
-
-The converted async sites are distributed as follows: document-worker (18), dreaming (28), retention (6), repair-actions (31), and source-lifecycle-telemetry (8), for 91 sites total.
+The 861-site inventory excludes test, benchmark, generated, and `__tests__` fixtures. The 181 synchronous writes and 196 synchronous reads remain transitional callers for the later migration phase. They are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate 377 database operations.
 
 ## Enforcement boundary
 
@@ -29,4 +25,4 @@ The converted async sites are distributed as follows: document-worker (18), drea
 
 The structural boundary makes statically-resolved imports from the production source tree impossible: TypeScript reports TS6059 before aliases or computed member calls can use the compatibility type. The production bundle also only starts from source entrypoints, so this compatibility module is not a shipped production artifact.
 
-A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 450 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 159 write and 291 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.
+A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 377 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 181 write and 196 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1530,7 +1530,7 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 
 	reloadAuthState(AGENTS_DIR);
 	if (!transcriptCaptureWorkerHandle) {
-		transcriptCaptureWorkerHandle = startTranscriptCaptureWorker(getDbAccessor(), AGENTS_DIR);
+		transcriptCaptureWorkerHandle = await startTranscriptCaptureWorker(getDbAccessor(), AGENTS_DIR);
 	}
 
 	const router = getOrCreateInferenceRouter(AGENTS_DIR);
@@ -2284,7 +2284,7 @@ async function main() {
 
 	schedulerHandle = startSchedulerWorker(getDbAccessor());
 	if (!transcriptCaptureWorkerHandle) {
-		transcriptCaptureWorkerHandle = startTranscriptCaptureWorker(getDbAccessor(), AGENTS_DIR);
+		transcriptCaptureWorkerHandle = await startTranscriptCaptureWorker(getDbAccessor(), AGENTS_DIR);
 	}
 	if (!transcriptRecoveryWorkerHandle) {
 		transcriptRecoveryWorkerHandle = startTranscriptRecoveryWorker(getDbAccessor(), AGENTS_DIR, resolveDaemonAgentId());

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -1352,6 +1352,12 @@ function createAccessor(writeConn: SqliteDatabase): RuntimeDbAccessor {
 // Public helpers
 // ---------------------------------------------------------------------------
 
+/** Queue a write transaction when supported, with a sync fallback for test doubles. */
+export async function runWriteTxAsync<T>(accessor: DbAccessor, fn: (db: WriteDb) => T): Promise<T> {
+	if (accessor.withWriteTxAsync) return accessor.withWriteTxAsync(fn);
+	return accessor.withWriteTx(fn);
+}
+
 /** Get the initialised accessor. Throws if `initDbAccessor` hasn't been called. */
 export function getDbAccessor(): DbAccessor {
 	if (!accessor) {

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -1352,10 +1352,9 @@ function createAccessor(writeConn: SqliteDatabase): RuntimeDbAccessor {
 // Public helpers
 // ---------------------------------------------------------------------------
 
-/** Queue a write transaction when supported, with a sync fallback for test doubles. */
+/** Queue a write transaction through the bounded async writer. */
 export async function runWriteTxAsync<T>(accessor: DbAccessor, fn: (db: WriteDb) => T): Promise<T> {
-	if (accessor.withWriteTxAsync) return accessor.withWriteTxAsync(fn);
-	return accessor.withWriteTx(fn);
+	return await accessor.withWriteTxAsync(fn);
 }
 
 /** Get the initialised accessor. Throws if `initDbAccessor` hasn't been called. */

--- a/platform/daemon/src/discord-desktop-cache-source.ts
+++ b/platform/daemon/src/discord-desktop-cache-source.ts
@@ -198,7 +198,7 @@ export async function syncDiscordDesktopCacheSource(
 			cancelled = true;
 			break;
 		}
-		writeArtifact(options.source, options.agentId, artifact);
+		await writeArtifact(options.source, options.agentId, artifact);
 		indexed++;
 	}
 	if (!cancelled) purgeStaleDesktopCacheArtifacts(options.source.id, options.agentId, syncStartedAt);
@@ -443,8 +443,8 @@ function artifactsForSnapshot(
 	return artifacts;
 }
 
-function writeArtifact(source: SignetSourceEntry, agentId: string, artifact: CacheArtifact): void {
-	indexExternalMemoryArtifact({
+async function writeArtifact(source: SignetSourceEntry, agentId: string, artifact: CacheArtifact): Promise<void> {
+	await indexExternalMemoryArtifact({
 		agentId,
 		harness: DISCORD_HARNESS,
 		sourceId: source.id,

--- a/platform/daemon/src/discord-gateway-tail.ts
+++ b/platform/daemon/src/discord-gateway-tail.ts
@@ -47,13 +47,19 @@ export function setDiscordGatewaySocketFactoryForTest(factory: DiscordGatewaySoc
 	discordGatewaySocketFactory = factory ?? ((url) => new WebSocket(url));
 }
 
+type MaybePromise<T> = T | Promise<T>;
+
 export interface DiscordGatewayTailHandlers {
 	readonly source: SignetSourceEntry;
 	readonly token: string;
 	readonly guildIds: readonly string[];
 	readonly shouldContinue: () => boolean;
 	readonly onProgress?: SourceProviderSyncContext["onProgress"];
-	readonly recordFailure: (message: string, metadata: Readonly<Record<string, unknown>>, recoverable: boolean) => void;
+	readonly recordFailure: (
+		message: string,
+		metadata: Readonly<Record<string, unknown>>,
+		recoverable: boolean,
+	) => MaybePromise<void>;
 	readonly recordMessage: (
 		guildId: string,
 		channelId: string,
@@ -62,17 +68,22 @@ export interface DiscordGatewayTailHandlers {
 		gatewayEventType: string,
 		sequence: number | null,
 		payload: unknown,
-	) => void;
+	) => MaybePromise<void>;
 	readonly recordMessageDelete: (
 		guildId: string,
 		channelId: string,
 		messageId: string,
 		sequence: number | null,
 		payload: unknown,
-	) => void;
-	readonly recordChannel: (guildId: string, channel: DiscordChannel) => void;
-	readonly recordMember: (guildId: string, member: DiscordGuildMember) => void;
-	readonly recordMemberRemove: (guildId: string, userId: string, sequence: number | null, payload: unknown) => void;
+	) => MaybePromise<void>;
+	readonly recordChannel: (guildId: string, channel: DiscordChannel) => MaybePromise<void>;
+	readonly recordMember: (guildId: string, member: DiscordGuildMember) => MaybePromise<void>;
+	readonly recordMemberRemove: (
+		guildId: string,
+		userId: string,
+		sequence: number | null,
+		payload: unknown,
+	) => MaybePromise<void>;
 }
 
 export async function syncDiscordGatewayTail(
@@ -85,9 +96,9 @@ export async function syncDiscordGatewayTail(
 		const result = await runDiscordGatewayConnection({
 			...input,
 			allowedGuilds,
-			recordFailure: (message, metadata, recoverable) => {
+			recordFailure: async (message, metadata, recoverable) => {
 				failures++;
-				input.recordFailure(message, metadata, recoverable);
+				await input.recordFailure(message, metadata, recoverable);
 			},
 			recordEvent: () => {
 				indexedEvents++;
@@ -105,7 +116,7 @@ async function runDiscordGatewayConnection(
 		readonly recordEvent: () => void;
 	},
 ): Promise<{ readonly retry: boolean }> {
-	return await new Promise((resolve) => {
+	return await new Promise((resolve, reject) => {
 		const socket = discordGatewaySocketFactory(DISCORD_GATEWAY_URL);
 		let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 		let continueTimer: ReturnType<typeof setInterval> | null = null;
@@ -113,6 +124,8 @@ async function runDiscordGatewayConnection(
 		let settled = false;
 		let closeFailureRecorded = false;
 		let reconnectRequested = false;
+		let settleRequested = false;
+		let eventQueue: Promise<void> = Promise.resolve();
 		const cleanup = (): void => {
 			if (heartbeatTimer) clearInterval(heartbeatTimer);
 			if (continueTimer) clearInterval(continueTimer);
@@ -120,10 +133,14 @@ async function runDiscordGatewayConnection(
 			continueTimer = null;
 		};
 		const settle = (retry: boolean): void => {
-			if (settled) return;
-			settled = true;
-			cleanup();
-			resolve({ retry });
+			if (settled || settleRequested) return;
+			settleRequested = true;
+			void eventQueue.then(() => {
+				if (settled) return;
+				settled = true;
+				cleanup();
+				resolve({ retry });
+			}, reject);
 		};
 		const closeForCancellation = (): void => {
 			try {
@@ -140,7 +157,9 @@ async function runDiscordGatewayConnection(
 		};
 		socket.onerror = () => {
 			closeFailureRecorded = true;
-			input.recordFailure("Discord gateway websocket error", { phase: "gateway_tail" }, true);
+			eventQueue = eventQueue.then(() =>
+				input.recordFailure("Discord gateway websocket error", { phase: "gateway_tail" }, true),
+			);
 			try {
 				socket.close(1011, "gateway websocket error");
 			} catch {
@@ -157,81 +176,87 @@ async function runDiscordGatewayConnection(
 				return;
 			}
 			if (isFatalGatewayCloseCode(event.code)) {
-				input.recordFailure(
-					`Discord gateway closed with non-retryable code ${event.code}${event.reason ? `: ${event.reason}` : ""}`,
-					{ phase: "gateway_tail", code: event.code ?? null },
-					false,
+				eventQueue = eventQueue.then(() =>
+					input.recordFailure(
+						`Discord gateway closed with non-retryable code ${event.code}${event.reason ? `: ${event.reason}` : ""}`,
+						{ phase: "gateway_tail", code: event.code ?? null },
+						false,
+					),
 				);
 				settle(false);
 				return;
 			}
 			if (!closeFailureRecorded)
-				input.recordFailure(
-					`Discord gateway closed unexpectedly${event.reason ? `: ${event.reason}` : ""}`,
-					{ phase: "gateway_tail", code: event.code ?? null },
-					true,
+				eventQueue = eventQueue.then(() =>
+					input.recordFailure(
+						`Discord gateway closed unexpectedly${event.reason ? `: ${event.reason}` : ""}`,
+						{ phase: "gateway_tail", code: event.code ?? null },
+						true,
+					),
 				);
 			settle(true);
 		};
 		socket.onmessage = (event) => {
-			const payload = parseGatewayPayload(event.data);
-			if (!payload) return;
-			if (typeof payload.s === "number") sequence = payload.s;
-			if (payload.op === DISCORD_GATEWAY_HELLO_OP) {
-				const heartbeatInterval = gatewayHeartbeatInterval(payload.d);
-				if (heartbeatInterval !== null) {
-					heartbeatTimer = setInterval(() => {
-						socket.send(JSON.stringify({ op: DISCORD_GATEWAY_HEARTBEAT_OP, d: sequence }));
-					}, heartbeatInterval);
+			eventQueue = eventQueue.then(async () => {
+				const payload = parseGatewayPayload(event.data);
+				if (!payload) return;
+				if (typeof payload.s === "number") sequence = payload.s;
+				if (payload.op === DISCORD_GATEWAY_HELLO_OP) {
+					const heartbeatInterval = gatewayHeartbeatInterval(payload.d);
+					if (heartbeatInterval !== null) {
+						heartbeatTimer = setInterval(() => {
+							socket.send(JSON.stringify({ op: DISCORD_GATEWAY_HEARTBEAT_OP, d: sequence }));
+						}, heartbeatInterval);
+					}
+					socket.send(
+						JSON.stringify({
+							op: DISCORD_GATEWAY_IDENTIFY_OP,
+							d: {
+								token: input.token,
+								intents: DISCORD_GATEWAY_INTENTS,
+								properties: { os: "linux", browser: "signet", device: "signet" },
+							},
+						}),
+					);
+					return;
 				}
-				socket.send(
-					JSON.stringify({
-						op: DISCORD_GATEWAY_IDENTIFY_OP,
-						d: {
-							token: input.token,
-							intents: DISCORD_GATEWAY_INTENTS,
-							properties: { os: "linux", browser: "signet", device: "signet" },
-						},
-					}),
-				);
-				return;
-			}
-			if (payload.op === DISCORD_GATEWAY_RECONNECT_OP || payload.op === DISCORD_GATEWAY_INVALID_SESSION_OP) {
-				reconnectRequested = true;
-				try {
-					socket.close(1012, "discord requested reconnect");
-				} catch {
-					settle(true);
+				if (payload.op === DISCORD_GATEWAY_RECONNECT_OP || payload.op === DISCORD_GATEWAY_INVALID_SESSION_OP) {
+					reconnectRequested = true;
+					try {
+						socket.close(1012, "discord requested reconnect");
+					} catch {
+						settle(true);
+					}
+					return;
 				}
-				return;
-			}
-			if (payload.op !== DISCORD_GATEWAY_DISPATCH_OP || typeof payload.t !== "string") return;
-			const eventResult = handleDiscordGatewayDispatch({
-				...input,
-				eventType: payload.t,
-				sequence,
-				data: payload.d,
-			});
-			if (!eventResult.indexed) return;
-			input.recordEvent();
-			input.onProgress?.({
-				scanned: 0,
-				total: input.allowedGuilds.size,
-				indexed: 0,
-				currentPath: eventResult.path,
+				if (payload.op !== DISCORD_GATEWAY_DISPATCH_OP || typeof payload.t !== "string") return;
+				const eventResult = await handleDiscordGatewayDispatch({
+					...input,
+					eventType: payload.t,
+					sequence,
+					data: payload.d,
+				});
+				if (!eventResult.indexed) return;
+				input.recordEvent();
+				input.onProgress?.({
+					scanned: 0,
+					total: input.allowedGuilds.size,
+					indexed: 0,
+					currentPath: eventResult.path,
+				});
 			});
 		};
 	});
 }
 
-function handleDiscordGatewayDispatch(
+async function handleDiscordGatewayDispatch(
 	input: DiscordGatewayTailHandlers & {
 		readonly allowedGuilds: ReadonlySet<string>;
 		readonly eventType: string;
 		readonly sequence: number | null;
 		readonly data: unknown;
 	},
-): { readonly indexed: boolean; readonly path: string } {
+): Promise<{ readonly indexed: boolean; readonly path: string }> {
 	if (!isRecord(input.data)) return { indexed: false, path: "discord://gateway" };
 	const guildId = readString(input.data, "guild_id");
 	if (!guildId || !input.allowedGuilds.has(guildId)) return { indexed: false, path: "discord://gateway" };
@@ -239,7 +264,7 @@ function handleDiscordGatewayDispatch(
 		const channelId = readString(input.data, "channel_id");
 		const messageId = readString(input.data, "id");
 		if (!channelId || !messageId) return { indexed: false, path: "discord://gateway" };
-		input.recordMessage(
+		await input.recordMessage(
 			guildId,
 			channelId,
 			messageId,
@@ -254,7 +279,7 @@ function handleDiscordGatewayDispatch(
 		const channelId = readString(input.data, "channel_id");
 		const messageId = readString(input.data, "id");
 		if (!channelId || !messageId) return { indexed: false, path: "discord://gateway" };
-		input.recordMessageDelete(guildId, channelId, messageId, input.sequence, input.data);
+		await input.recordMessageDelete(guildId, channelId, messageId, input.sequence, input.data);
 		return { indexed: true, path: `discord://guild/${guildId}/channel/${channelId}/messages/${messageId}` };
 	}
 	if (
@@ -265,19 +290,19 @@ function handleDiscordGatewayDispatch(
 	) {
 		const channel = gatewayChannelFromEvent(input.data);
 		if (!channel) return { indexed: false, path: "discord://gateway" };
-		input.recordChannel(guildId, channel);
+		await input.recordChannel(guildId, channel);
 		return { indexed: true, path: `discord://guild/${guildId}/channel/${channel.id}` };
 	}
 	if (input.eventType === "GUILD_MEMBER_ADD" || input.eventType === "GUILD_MEMBER_UPDATE") {
 		const member = gatewayMember(input.data);
 		if (!member) return { indexed: false, path: "discord://gateway" };
-		input.recordMember(guildId, member);
+		await input.recordMember(guildId, member);
 		return { indexed: true, path: `discord://guild/${guildId}/member/${member.user?.id ?? "unknown"}` };
 	}
 	if (input.eventType === "GUILD_MEMBER_REMOVE") {
 		const user = gatewayUser(input.data.user);
 		if (!user) return { indexed: false, path: "discord://gateway" };
-		input.recordMemberRemove(guildId, user.id, input.sequence, input.data);
+		await input.recordMemberRemove(guildId, user.id, input.sequence, input.data);
 		return { indexed: true, path: `discord://guild/${guildId}/member/${user.id}` };
 	}
 	return { indexed: false, path: "discord://gateway" };

--- a/platform/daemon/src/discord-gateway-tail.ts
+++ b/platform/daemon/src/discord-gateway-tail.ts
@@ -27,6 +27,10 @@ const DISCORD_GATEWAY_INTENTS =
 	32768; // MESSAGE_CONTENT
 const GATEWAY_RECONNECT_DELAY_MS = 1_000;
 const GATEWAY_SHOULD_CONTINUE_POLL_MS = 250;
+const DISCORD_GATEWAY_MIN_HEARTBEAT_INTERVAL_MS = 1_000;
+// Discord normally sends heartbeat intervals well below this five-minute ceiling. Cap gateway input to prevent an unbounded timer.
+const DISCORD_GATEWAY_MAX_HEARTBEAT_INTERVAL_MS = 5 * 60 * 1_000;
+const DISCORD_GATEWAY_HEARTBEAT_TICK_MS = 1_000;
 
 type BivariantEventHandler<Event> = { bivarianceHack(event: Event): void }["bivarianceHack"];
 
@@ -203,10 +207,16 @@ async function runDiscordGatewayConnection(
 				if (typeof payload.s === "number") sequence = payload.s;
 				if (payload.op === DISCORD_GATEWAY_HELLO_OP) {
 					const heartbeatInterval = gatewayHeartbeatInterval(payload.d);
+					if (heartbeatTimer) clearInterval(heartbeatTimer);
+					heartbeatTimer = null;
 					if (heartbeatInterval !== null) {
+						let nextHeartbeatAt = Date.now() + heartbeatInterval;
 						heartbeatTimer = setInterval(() => {
+							const now = Date.now();
+							if (now < nextHeartbeatAt) return;
 							socket.send(JSON.stringify({ op: DISCORD_GATEWAY_HEARTBEAT_OP, d: sequence }));
-						}, heartbeatInterval);
+							nextHeartbeatAt = now + heartbeatInterval;
+						}, DISCORD_GATEWAY_HEARTBEAT_TICK_MS);
 					}
 					socket.send(
 						JSON.stringify({
@@ -341,7 +351,11 @@ function parseGatewayPayload(data: unknown): DiscordGatewayPayload | null {
 
 function gatewayHeartbeatInterval(data: unknown): number | null {
 	if (!isRecord(data) || typeof data.heartbeat_interval !== "number") return null;
-	return Math.max(1_000, data.heartbeat_interval);
+	if (!Number.isFinite(data.heartbeat_interval)) return null;
+	return Math.min(
+		DISCORD_GATEWAY_MAX_HEARTBEAT_INTERVAL_MS,
+		Math.max(DISCORD_GATEWAY_MIN_HEARTBEAT_INTERVAL_MS, data.heartbeat_interval),
+	);
 }
 
 function isFatalGatewayCloseCode(code: number | undefined): boolean {

--- a/platform/daemon/src/discord-source-provider.test.ts
+++ b/platform/daemon/src/discord-source-provider.test.ts
@@ -296,7 +296,7 @@ describe("discord-source-provider", () => {
 		);
 		expect(added.ok).toBe(true);
 		if (added.ok === false) throw new Error(added.error);
-		indexExternalMemoryArtifact({
+		await indexExternalMemoryArtifact({
 			agentId: "default",
 			harness: "discord",
 			sourceId: added.source.id,
@@ -336,7 +336,7 @@ describe("discord-source-provider", () => {
 		);
 		expect(added.ok).toBe(true);
 		if (added.ok === false) throw new Error(added.error);
-		indexExternalMemoryArtifact({
+		await indexExternalMemoryArtifact({
 			agentId: "default",
 			harness: "discord",
 			sourceId: added.source.id,
@@ -459,7 +459,7 @@ describe("discord-source-provider", () => {
 		expect(added.ok).toBe(true);
 		if (added.ok === false) throw new Error(added.error);
 		const stalePath = "discord-cache://guild/@me/channel/stale/messages/stale";
-		indexExternalMemoryArtifact({
+		await indexExternalMemoryArtifact({
 			agentId: "default",
 			harness: "discord",
 			sourceId: added.source.id,
@@ -1093,7 +1093,7 @@ describe("discord-source-provider", () => {
 			agentId: "default",
 			shouldContinue: () => true,
 		});
-		indexExternalMemoryArtifact({
+		await indexExternalMemoryArtifact({
 			agentId: "default",
 			harness: "discord",
 			sourceId: added.source.id,
@@ -1104,7 +1104,7 @@ describe("discord-source-provider", () => {
 			sourceMtimeMs: Date.parse("2025-01-01T00:00:00.000Z"),
 			content: "stale member row",
 		});
-		indexExternalMemoryArtifact({
+		await indexExternalMemoryArtifact({
 			agentId: "default",
 			harness: "discord",
 			sourceId: added.source.id,
@@ -1115,7 +1115,7 @@ describe("discord-source-provider", () => {
 			sourceMtimeMs: Date.parse("2025-01-01T00:00:00.000Z"),
 			content: "stale removed channel message",
 		});
-		indexExternalMemoryArtifact({
+		await indexExternalMemoryArtifact({
 			agentId: "default",
 			harness: "discord",
 			sourceId: added.source.id,
@@ -1300,7 +1300,7 @@ describe("discord-source-provider", () => {
 		);
 		expect(added.ok).toBe(true);
 		if (added.ok === false) throw new Error(added.error);
-		indexExternalMemoryArtifact({
+		await indexExternalMemoryArtifact({
 			agentId: "default",
 			harness: "discord",
 			sourceId: added.source.id,

--- a/platform/daemon/src/discord-source-provider.test.ts
+++ b/platform/daemon/src/discord-source-provider.test.ts
@@ -289,6 +289,65 @@ describe("discord-source-provider", () => {
 		expect(tombstone?.source_meta_json).toContain('"deleted":true');
 	});
 
+	it("bounds and replaces Discord heartbeat timers", async () => {
+		const originalSetInterval = globalThis.setInterval;
+		const originalClearInterval = globalThis.clearInterval;
+		const timers: Array<{ readonly id: number; readonly timeout: number | undefined }> = [];
+		const cleared: unknown[] = [];
+		let nextTimerId = 0;
+		globalThis.setInterval = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+			const timer = { id: ++nextTimerId, timeout };
+			timers.push(timer);
+			void handler;
+			void args;
+			return timer.id;
+		}) as unknown as typeof setInterval;
+		globalThis.clearInterval = ((handle?: string | number | Timer) => {
+			if (typeof handle !== "number") return;
+			const timer = timers.find((candidate) => candidate.id === handle);
+			if (timer) cleared.push(timer);
+		}) as typeof clearInterval;
+		try {
+			let shouldContinue = true;
+			setDiscordGatewaySocketFactoryForTest(
+				() =>
+					new FakeDiscordGatewaySocket(
+						() => {
+							shouldContinue = false;
+						},
+						60 * 60 * 1_000,
+						true,
+					),
+			);
+			const added = addDiscordSource(
+				{
+					guildIds: ["123456789012345678"],
+					tokenRef: "DISCORD_BOT_TOKEN",
+					syncMode: "gateway-tail",
+					now: "2026-01-01T00:00:00.000Z",
+				},
+				dir,
+			);
+			expect(added.ok).toBe(true);
+			if (added.ok === false) throw new Error(added.error);
+
+			const result = await discordSourceProvider.sync?.({
+				source: added.source,
+				agentsDir: dir,
+				agentId: "default",
+				shouldContinue: () => shouldContinue,
+			});
+
+			expect(result?.failures).toEqual([]);
+			const heartbeatTimers = timers.filter((timer) => timer.timeout !== 250);
+			expect(heartbeatTimers.map((timer) => timer.timeout)).toEqual([1_000, 1_000]);
+			expect(cleared).toEqual(expect.arrayContaining(heartbeatTimers));
+		} finally {
+			globalThis.setInterval = originalSetInterval;
+			globalThis.clearInterval = originalClearInterval;
+		}
+	});
+
 	it("records partial Discord failures without deleting existing source-owned rows", async () => {
 		const added = addDiscordSource(
 			{ guildIds: ["123456789012345678"], tokenRef: "DISCORD_BOT_TOKEN", now: "2026-01-01T00:00:00.000Z" },
@@ -1353,18 +1412,28 @@ class FakeDiscordGatewaySocket {
 	onclose: ((event: { readonly code?: number; readonly reason?: string }) => void) | null = null;
 	readonly sent: string[] = [];
 	private readonly stop: () => void;
+	private readonly heartbeatInterval: number;
+	private readonly repeatHello: boolean;
+	private repeatedHelloSent = false;
 
-	constructor(stop: () => void) {
+	constructor(stop: () => void, heartbeatInterval = 1_000, repeatHello = false) {
 		this.stop = stop;
+		this.heartbeatInterval = heartbeatInterval;
+		this.repeatHello = repeatHello;
 		queueMicrotask(() => {
 			this.onopen?.({});
-			this.onmessage?.({ data: JSON.stringify({ op: 10, d: { heartbeat_interval: 1_000 } }) });
+			this.sendHello();
 		});
 	}
 
 	send(data: string): void {
 		this.sent.push(data);
 		if (!data.includes('"op":2')) return;
+		if (this.repeatHello && !this.repeatedHelloSent) {
+			this.repeatedHelloSent = true;
+			this.sendHello();
+			return;
+		}
 		queueMicrotask(() => {
 			this.dispatch("CHANNEL_UPDATE", 1, {
 				id: "123456789012345679",
@@ -1409,6 +1478,10 @@ class FakeDiscordGatewaySocket {
 			this.stop();
 			this.close(1000, "test complete");
 		});
+	}
+
+	private sendHello(): void {
+		this.onmessage?.({ data: JSON.stringify({ op: 10, d: { heartbeat_interval: this.heartbeatInterval } }) });
 	}
 
 	close(code?: number, reason?: string): void {

--- a/platform/daemon/src/discord-source-provider.ts
+++ b/platform/daemon/src/discord-source-provider.ts
@@ -125,7 +125,7 @@ async function syncDiscordSource(context: SourceProviderSyncContext): Promise<So
 				phase: "guild",
 			});
 			failures.push(failure);
-			writeFailureArtifact(context.source, agentId, failure);
+			await writeFailureArtifact(context.source, agentId, failure);
 			indexed++;
 			scanned++;
 			continue;
@@ -133,37 +133,43 @@ async function syncDiscordSource(context: SourceProviderSyncContext): Promise<So
 		if (!guild) {
 			const failure = failureState(context.source, `Discord guild unavailable or forbidden: ${guildId}`, { guildId });
 			failures.push(failure);
-			writeFailureArtifact(context.source, agentId, failure);
+			await writeFailureArtifact(context.source, agentId, failure);
 			indexed++;
 			scanned++;
 			continue;
 		}
 
-		indexed += writeArtifact(context.source, agentId, guildArtifact(context.source, guild));
+		indexed += await writeArtifact(context.source, agentId, guildArtifact(context.source, guild));
 		const channels = await fetchGuildChannels(fetchConfig, guildId);
-		indexed += writeFetchFailures(context.source, agentId, failures, channels.errors, { guildId, phase: "channels" });
+		indexed += await writeFetchFailures(context.source, agentId, failures, channels.errors, {
+			guildId,
+			phase: "channels",
+		});
 		const channelFilter = buildChannelFilter(settings.channelFilter);
 		const channelRows = applyChannelFilter(channels.data, channelFilter);
 		const filteredChannelIds = new Set(channelRows.map((channel) => channel.id));
 
 		for (const channel of channelRows) {
 			if (!context.shouldContinue()) break;
-			indexed += writeArtifact(context.source, agentId, channelArtifact(context.source, guild, channel));
+			indexed += await writeArtifact(context.source, agentId, channelArtifact(context.source, guild, channel));
 		}
 
 		if (settings.includeMembers) {
 			const members = await fetchGuildMembers(fetchConfig, guildId, DEFAULT_MAX_MEMBERS_PER_GUILD);
-			indexed += writeFetchFailures(context.source, agentId, failures, members.errors, { guildId, phase: "members" });
+			indexed += await writeFetchFailures(context.source, agentId, failures, members.errors, {
+				guildId,
+				phase: "members",
+			});
 			for (const member of members.data) {
 				if (!context.shouldContinue()) break;
-				indexed += writeArtifact(context.source, agentId, memberArtifact(guild, member));
+				indexed += await writeArtifact(context.source, agentId, memberArtifact(guild, member));
 			}
 		}
 
 		const threadMap = new Map<string, DiscordChannel>();
 		if (settings.includeThreads) {
 			const activeThreads = await fetchGuildActiveThreads(fetchConfig, guildId);
-			indexed += writeFetchFailures(context.source, agentId, failures, activeThreads.errors, {
+			indexed += await writeFetchFailures(context.source, agentId, failures, activeThreads.errors, {
 				guildId,
 				phase: "active_threads",
 			});
@@ -181,7 +187,7 @@ async function syncDiscordSource(context: SourceProviderSyncContext): Promise<So
 						"public",
 						DEFAULT_MAX_THREADS_PER_PARENT,
 					);
-					indexed += writeFetchFailures(context.source, agentId, failures, archivedPublic.errors, {
+					indexed += await writeFetchFailures(context.source, agentId, failures, archivedPublic.errors, {
 						guildId,
 						channelId: channel.id,
 						phase: "archived_public_threads",
@@ -196,7 +202,7 @@ async function syncDiscordSource(context: SourceProviderSyncContext): Promise<So
 							"private",
 							DEFAULT_MAX_THREADS_PER_PARENT,
 						);
-						indexed += writeFetchFailures(context.source, agentId, failures, archivedPrivate.errors, {
+						indexed += await writeFetchFailures(context.source, agentId, failures, archivedPrivate.errors, {
 							guildId,
 							channelId: channel.id,
 							phase: "archived_private_threads",
@@ -209,16 +215,16 @@ async function syncDiscordSource(context: SourceProviderSyncContext): Promise<So
 			}
 			for (const thread of threadMap.values()) {
 				if (!context.shouldContinue()) break;
-				indexed += writeArtifact(context.source, agentId, channelArtifact(context.source, guild, thread));
+				indexed += await writeArtifact(context.source, agentId, channelArtifact(context.source, guild, thread));
 				if (settings.includeThreadMembers) {
 					const members = await fetchThreadMembers(fetchConfig, thread.id);
-					indexed += writeFetchFailures(context.source, agentId, failures, members.errors, {
+					indexed += await writeFetchFailures(context.source, agentId, failures, members.errors, {
 						guildId,
 						threadId: thread.id,
 						phase: "thread_members",
 					});
 					for (const member of members.data) {
-						indexed += writeArtifact(context.source, agentId, threadMemberArtifact(guild, thread, member));
+						indexed += await writeArtifact(context.source, agentId, threadMemberArtifact(guild, thread, member));
 					}
 				}
 			}
@@ -238,7 +244,7 @@ async function syncDiscordSource(context: SourceProviderSyncContext): Promise<So
 				sinceId,
 				afterCursor,
 			);
-			indexed += writeFetchFailures(context.source, agentId, failures, messages.errors, {
+			indexed += await writeFetchFailures(context.source, agentId, failures, messages.errors, {
 				guildId,
 				channelId: channel.id,
 				phase: "messages",
@@ -252,7 +258,7 @@ async function syncDiscordSource(context: SourceProviderSyncContext): Promise<So
 					? await fetchChannelMessages(fetchConfig, channel.id, backfillLimit, backfillCursor, sinceId)
 					: null;
 			if (backfill) {
-				indexed += writeFetchFailures(context.source, agentId, failures, backfill.errors, {
+				indexed += await writeFetchFailures(context.source, agentId, failures, backfill.errors, {
 					guildId,
 					channelId: channel.id,
 					phase: "message_backfill",
@@ -266,7 +272,7 @@ async function syncDiscordSource(context: SourceProviderSyncContext): Promise<So
 				includeEmbeds: settings.includeEmbeds,
 				includePolls: settings.includePolls,
 			});
-			indexed += writeArtifact(
+			indexed += await writeArtifact(
 				context.source,
 				agentId,
 				checkpointArtifact(
@@ -323,74 +329,83 @@ async function syncDiscordGatewayTailSource(
 		guildIds,
 		shouldContinue: context.shouldContinue,
 		onProgress: context.onProgress,
-		recordFailure: (message, metadata, recoverable) => {
+		recordFailure: async (message, metadata, recoverable) => {
 			const failure = failureState(context.source, message, metadata, recoverable);
 			failures.push(failure);
-			writeFailureArtifact(context.source, agentId, failure);
+			await writeFailureArtifact(context.source, agentId, failure);
 			indexed++;
 		},
-		recordMessage: (guildId, channelId, messageId, message, gatewayEventType, sequence, payload) => {
+		recordMessage: async (guildId, channelId, messageId, message, gatewayEventType, sequence, payload) => {
 			if (message) {
 				const guild = gatewayGuild(guildId);
 				const channel = gatewayChannel(guildId, channelId);
-				indexed += writeArtifact(context.source, agentId, messageArtifact(guild, channel, message));
+				indexed += await writeArtifact(context.source, agentId, messageArtifact(guild, channel, message));
 				if (message.mentions && message.mentions.length > 0)
-					indexed += writeArtifact(context.source, agentId, mentionArtifact(guild, channel, message));
+					indexed += await writeArtifact(context.source, agentId, mentionArtifact(guild, channel, message));
 				for (const attachment of message.attachments ?? []) {
-					indexed += writeArtifact(context.source, agentId, attachmentArtifact(guild, channel, message, attachment));
+					indexed += await writeArtifact(
+						context.source,
+						agentId,
+						attachmentArtifact(guild, channel, message, attachment),
+					);
 				}
 				for (let index = 0; index < (message.embeds ?? []).length; index++) {
 					const embed = message.embeds?.[index];
 					if (embed)
-						indexed += writeArtifact(context.source, agentId, embedArtifact(guild, channel, message, embed, index));
+						indexed += await writeArtifact(
+							context.source,
+							agentId,
+							embedArtifact(guild, channel, message, embed, index),
+						);
 				}
-				if (message.poll) indexed += writeArtifact(context.source, agentId, pollArtifact(guild, channel, message));
+				if (message.poll)
+					indexed += await writeArtifact(context.source, agentId, pollArtifact(guild, channel, message));
 			} else if (gatewayEventType === "MESSAGE_UPDATE") {
 				const patched = patchedMessageArtifact(context.source, agentId, guildId, channelId, messageId, payload);
-				if (patched) indexed += writeArtifact(context.source, agentId, patched);
+				if (patched) indexed += await writeArtifact(context.source, agentId, patched);
 				purgeClearedPartialUpdateArtifacts(context.source, agentId, guildId, channelId, messageId, payload);
 			}
-			indexed += writeArtifact(
+			indexed += await writeArtifact(
 				context.source,
 				agentId,
 				messageEventArtifact(context.source, guildId, channelId, messageId, gatewayEventType, sequence, payload),
 			);
 			if (message)
-				indexed += writeArtifact(
+				indexed += await writeArtifact(
 					context.source,
 					agentId,
 					gatewayCheckpointArtifact(context.source, guildId, channelId, message.id, gatewayEventType),
 				);
 		},
-		recordMessageDelete: (guildId, channelId, messageId, sequence, payload) => {
-			indexed += writeArtifact(
+		recordMessageDelete: async (guildId, channelId, messageId, sequence, payload) => {
+			indexed += await writeArtifact(
 				context.source,
 				agentId,
 				messageTombstoneArtifact(guildId, channelId, messageId, sequence, payload),
 			);
-			indexed += writeArtifact(
+			indexed += await writeArtifact(
 				context.source,
 				agentId,
 				messageEventArtifact(context.source, guildId, channelId, messageId, "MESSAGE_DELETE", sequence, payload),
 			);
-			indexed += writeArtifact(
+			indexed += await writeArtifact(
 				context.source,
 				agentId,
 				gatewayCheckpointArtifact(context.source, guildId, channelId, messageId, "MESSAGE_DELETE"),
 			);
 		},
-		recordChannel: (guildId, channel) => {
-			indexed += writeArtifact(
+		recordChannel: async (guildId, channel) => {
+			indexed += await writeArtifact(
 				context.source,
 				agentId,
 				channelArtifact(context.source, gatewayGuild(guildId), channel),
 			);
 		},
-		recordMember: (guildId, member) => {
-			indexed += writeArtifact(context.source, agentId, memberArtifact(gatewayGuild(guildId), member));
+		recordMember: async (guildId, member) => {
+			indexed += await writeArtifact(context.source, agentId, memberArtifact(gatewayGuild(guildId), member));
 		},
-		recordMemberRemove: (guildId, userId, sequence, payload) => {
-			indexed += writeArtifact(
+		recordMemberRemove: async (guildId, userId, sequence, payload) => {
+			indexed += await writeArtifact(
 				context.source,
 				agentId,
 				memberEventArtifact(guildId, userId, "remove", sequence, payload),
@@ -400,8 +415,8 @@ async function syncDiscordGatewayTailSource(
 	return { indexed, scanned: result.indexedEvents, total, failures: result.canceled ? [] : failures };
 }
 
-function writeArtifact(source: SignetSourceEntry, agentId: string, artifact: DiscordArtifact): number {
-	indexExternalMemoryArtifact({
+async function writeArtifact(source: SignetSourceEntry, agentId: string, artifact: DiscordArtifact): Promise<number> {
+	await indexExternalMemoryArtifact({
 		agentId,
 		harness: DISCORD_HARNESS,
 		sourceId: source.id,
@@ -454,14 +469,14 @@ async function writeMessageArtifacts(
 	},
 ): Promise<number> {
 	if (messages.length === 0) return 0;
-	let indexed = writeArtifact(source, agentId, messageWindowArtifact(guild, channel, messages));
+	let indexed = await writeArtifact(source, agentId, messageWindowArtifact(guild, channel, messages));
 	for (const msg of messages) {
-		indexed += writeArtifact(source, agentId, messageArtifact(guild, channel, msg));
+		indexed += await writeArtifact(source, agentId, messageArtifact(guild, channel, msg));
 		if (msg.mentions && msg.mentions.length > 0)
-			indexed += writeArtifact(source, agentId, mentionArtifact(guild, channel, msg));
+			indexed += await writeArtifact(source, agentId, mentionArtifact(guild, channel, msg));
 		if (options.includeAttachments) {
 			for (const attachment of msg.attachments ?? []) {
-				indexed += writeArtifact(source, agentId, attachmentArtifact(guild, channel, msg, attachment));
+				indexed += await writeArtifact(source, agentId, attachmentArtifact(guild, channel, msg, attachment));
 				if (options.includeAttachmentText) {
 					const extracted = await attachmentTextArtifact(
 						guild,
@@ -471,7 +486,7 @@ async function writeMessageArtifacts(
 						options.maxAttachmentTextBytes,
 					);
 					if (extracted.ok) {
-						if (extracted.artifact) indexed += writeArtifact(source, agentId, extracted.artifact);
+						if (extracted.artifact) indexed += await writeArtifact(source, agentId, extracted.artifact);
 					} else {
 						const failure = failureState(source, extracted.error, {
 							guildId: guild.id,
@@ -481,7 +496,7 @@ async function writeMessageArtifacts(
 							phase: "attachment_text",
 						});
 						failures.push(failure);
-						writeFailureArtifact(source, agentId, failure);
+						await writeFailureArtifact(source, agentId, failure);
 						indexed++;
 					}
 				}
@@ -490,33 +505,38 @@ async function writeMessageArtifacts(
 		if (options.includeEmbeds) {
 			for (let index = 0; index < (msg.embeds ?? []).length; index++) {
 				const embed = msg.embeds?.[index];
-				if (embed) indexed += writeArtifact(source, agentId, embedArtifact(guild, channel, msg, embed, index));
+				if (embed) indexed += await writeArtifact(source, agentId, embedArtifact(guild, channel, msg, embed, index));
 			}
 		}
-		if (options.includePolls && msg.poll) indexed += writeArtifact(source, agentId, pollArtifact(guild, channel, msg));
+		if (options.includePolls && msg.poll)
+			indexed += await writeArtifact(source, agentId, pollArtifact(guild, channel, msg));
 	}
 	return indexed;
 }
 
-function writeFetchFailures(
+async function writeFetchFailures(
 	source: SignetSourceEntry,
 	agentId: string,
 	failures: SourceFailureState[],
 	errors: readonly DiscordFetchError[],
 	meta: Readonly<Record<string, unknown>>,
-): number {
+): Promise<number> {
 	let indexed = 0;
 	for (const error of errors) {
 		const failure = failureState(source, error.message, { ...meta, status: error.status }, error.retryable);
 		failures.push(failure);
-		writeFailureArtifact(source, agentId, failure);
+		await writeFailureArtifact(source, agentId, failure);
 		indexed++;
 	}
 	return indexed;
 }
 
-function writeFailureArtifact(source: SignetSourceEntry, agentId: string, failure: SourceFailureState): void {
-	writeArtifact(source, agentId, {
+async function writeFailureArtifact(
+	source: SignetSourceEntry,
+	agentId: string,
+	failure: SourceFailureState,
+): Promise<number> {
+	return writeArtifact(source, agentId, {
 		kind: "source_discord_failure",
 		externalId: `failure:${hashKey(failure.message)}:${failure.failedAt}`,
 		path: `discord://source/${source.id}/failure/${hashKey(failure.message)}`,

--- a/platform/daemon/src/github-source-provider.test.ts
+++ b/platform/daemon/src/github-source-provider.test.ts
@@ -529,7 +529,7 @@ describe("github-source-provider", () => {
 				maxItemsPerRepo: 5,
 			},
 		};
-		indexExternalMemoryArtifact({
+		await indexExternalMemoryArtifact({
 			agentId: "default",
 			harness: "github",
 			sourceId: source.id,
@@ -614,7 +614,7 @@ describe("github-source-provider", () => {
 				maxItemsPerRepo: 5,
 			},
 		};
-		indexExternalMemoryArtifact({
+		await indexExternalMemoryArtifact({
 			agentId: "default",
 			harness: "github",
 			sourceId: source.id,
@@ -707,7 +707,7 @@ describe("github-source-provider", () => {
 				maxItemsPerRepo: 5,
 			},
 		};
-		indexExternalMemoryArtifact({
+		await indexExternalMemoryArtifact({
 			agentId: "default",
 			harness: "github",
 			sourceId: source.id,
@@ -822,8 +822,8 @@ describe("github-source-provider", () => {
 		expect(sourceRows(added.source.id).map((row) => row.source_kind)).toContain("source_github_failure");
 	});
 
-	it("purges source-owned GitHub artifacts through the provider", () => {
-		indexExternalMemoryArtifact({
+	it("purges source-owned GitHub artifacts through the provider", async () => {
+		await indexExternalMemoryArtifact({
 			agentId: "default",
 			harness: "github",
 			sourceId: "github:test",

--- a/platform/daemon/src/github-source-provider.ts
+++ b/platform/daemon/src/github-source-provider.ts
@@ -102,7 +102,7 @@ async function syncGitHubSource(context: SourceProviderSyncContext): Promise<Sou
 	}
 	if (context.shouldContinue()) purgeStaleGitHubFailureArtifacts(context.source.id, agentId, syncStartedAt);
 	for (const failure of failures) {
-		indexed += writeFailureArtifact(context.source, agentId, failure);
+		indexed += await writeFailureArtifact(context.source, agentId, failure);
 	}
 
 	return { indexed, scanned, total: repos.length, failures };
@@ -193,7 +193,7 @@ async function writeResourceWithComments(
 	remainingArtifactBudget: number,
 ): Promise<WrittenGitHubArtifacts> {
 	if (remainingArtifactBudget <= 0) return { count: 0, paths: [] };
-	const paths = [writeResourceArtifact(source, agentId, repo, resource)];
+	const paths = [await writeResourceArtifact(source, agentId, repo, resource)];
 	const remainingCommentBudget = remainingArtifactBudget - paths.length;
 	if (
 		!settings.includeComments ||
@@ -206,7 +206,7 @@ async function writeResourceWithComments(
 	try {
 		const comments = await fetchCommentsForResource(config, resource);
 		for (const comment of comments.slice(0, remainingCommentBudget)) {
-			paths.push(writeCommentArtifact(source, agentId, repo, resource, comment));
+			paths.push(await writeCommentArtifact(source, agentId, repo, resource, comment));
 		}
 	} catch (err) {
 		logGitHubFetchError(source.id, repo, `${resource.type}_comments`, err);
@@ -237,16 +237,16 @@ async function fetchCommentsForResource(
 	return [];
 }
 
-function writeResourceArtifact(
+async function writeResourceArtifact(
 	source: SignetSourceEntry,
 	agentId: string,
 	repo: string,
 	resource: GitHubResource,
-): string {
+): Promise<string> {
 	const path = resourcePath(repo, resource);
 	const sourceKind = `source_github_${resource.type}`;
 	const content = resourceContent(repo, resource);
-	indexExternalMemoryArtifact({
+	await indexExternalMemoryArtifact({
 		agentId,
 		harness: GITHUB_HARNESS,
 		sourceId: source.id,
@@ -288,19 +288,19 @@ function writeResourceArtifact(
 	return path;
 }
 
-function writeCommentArtifact(
+async function writeCommentArtifact(
 	source: SignetSourceEntry,
 	agentId: string,
 	repo: string,
 	resource: GitHubResource,
 	comment: GitHubComment,
-): string {
+): Promise<string> {
 	const author =
 		typeof comment.author === "string" ? comment.author : (comment.author?.login ?? comment.user?.login ?? null);
 	const commentId = String(comment.id);
 	const path = `${resourcePath(repo, resource)}#comment-${commentId}`;
 	const content = [`# Comment on ${resource.title}`, "", `Author: ${author ?? "unknown"}`, "", comment.body].join("\n");
-	indexExternalMemoryArtifact({
+	await indexExternalMemoryArtifact({
 		agentId,
 		harness: GITHUB_HARNESS,
 		sourceId: source.id,
@@ -349,8 +349,12 @@ function writeFetchFailures(
 	}
 }
 
-function writeFailureArtifact(source: SignetSourceEntry, agentId: string, failure: SourceFailureState): number {
-	indexExternalMemoryArtifact({
+async function writeFailureArtifact(
+	source: SignetSourceEntry,
+	agentId: string,
+	failure: SourceFailureState,
+): Promise<number> {
+	await indexExternalMemoryArtifact({
 		agentId,
 		harness: GITHUB_HARNESS,
 		sourceId: source.id,

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -452,12 +452,11 @@ function buildPluginPromptContributionSection(target: PluginPromptTargetV1, log:
 }
 
 /** Build a brief "since your last session" summary */
-function getSessionGapSummary(): string | undefined {
+async function getSessionGapSummary(): Promise<string | undefined> {
 	if (!existsSync(getMemoryDbPath())) return undefined;
 
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		return getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
+		return await getDbAccessor().withReadDbAsync(async (db) => {
 			// The completion marker covers explicit ends and daemon recovery/TTL
 			// boundaries; all are settled session activity for this brief.
 			const lastSession = db.prepare("SELECT MAX(completed_at) as last_end FROM session_transcripts").get() as
@@ -541,33 +540,27 @@ function loadHooksConfigForHarness(harness: string) {
 // Memory Queries
 // ============================================================================
 
-function getRecentMemories(
+async function getRecentMemories(
 	limit: number,
 	recencyBias = 0.7,
 	agentScope?: { agentId: string; readPolicy: AgentRosterReadPolicy; policyGroup: string | null },
-): Array<{
-	id: string;
-	content: string;
-	type: string;
-	importance: number;
-	created_at: string;
-}> {
+): Promise<
+	Array<{
+		id: string;
+		content: string;
+		type: string;
+		importance: number;
+		created_at: string;
+	}>
+> {
 	if (!existsSync(getMemoryDbPath())) return [];
 
 	try {
-		const rows: Array<{
-			id: string;
-			content: string;
-			type: string;
-			importance: number;
-			created_at: string;
-		}> =
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
-				const scope = agentScope
-					? buildAgentScopeClause(agentScope.agentId, agentScope.readPolicy, agentScope.policyGroup)
-					: { sql: " AND m.visibility != 'archived'", args: [] };
-				const query = `
+		const rows = await getDbAccessor().withReadDbAsync(async (db) => {
+			const scope = agentScope
+				? buildAgentScopeClause(agentScope.agentId, agentScope.readPolicy, agentScope.policyGroup)
+				: { sql: " AND m.visibility != 'archived'", args: [] };
+			const query = `
         SELECT
           m.id, m.content, m.type, m.importance, m.created_at,
           (julianday('now') - julianday(m.created_at)) as age_days
@@ -580,22 +573,22 @@ function getRecentMemories(
         LIMIT ?
       `;
 
-				const queried = db.prepare(query).all(...scope.args, limit) as Array<{
-					id: string;
-					content: string;
-					type: string;
-					importance: number;
-					created_at: string;
-				}>;
-				return queried.filter((row) =>
-					isMemoryContentContextEligible(db, {
-						agentId: agentScope?.agentId ?? "default",
-						sourceKind: "memory",
-						sourceId: row.id,
-						content: row.content,
-					}),
-				);
-			});
+			const rows = db.prepare(query).all(...scope.args, limit) as Array<{
+				id: string;
+				content: string;
+				type: string;
+				importance: number;
+				created_at: string;
+			}>;
+			return rows.filter((row) =>
+				isMemoryContentContextEligible(db, {
+					agentId: agentScope?.agentId ?? "default",
+					sourceKind: "memory",
+					sourceId: row.id,
+					content: row.content,
+				}),
+			);
+		});
 
 		return rows.map((r) => ({
 			id: r.id,
@@ -771,8 +764,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	if (req.sessionKey && existsSync(getMemoryDbPath())) {
 		try {
 			const subagentCfg = memoryCfg.pipelineV2.subagents ?? { inheritContext: true, tailChars: 3000 };
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const block = getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
+			const block = await getDbAccessor().withReadDbAsync(async (db) => {
 				const parent = resolveParentSession(db, {
 					harness: req.harness,
 					project: req.project,
@@ -847,8 +839,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	if (traversalEnabled) {
 		const _traversalStart = Date.now();
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const focal = getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) =>
+			const focal = await getDbAccessor().withReadDbAsync(async (db) =>
 				resolveFocalEntities(db, traversalAgentId, {
 					project: req.project,
 					sessionKey: req.sessionKey,
@@ -859,12 +850,8 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 			traversalEntityNames = focal.entityNames;
 
 			if (focal.entityIds.length > 0) {
-				const traversalResult = await traverseKnowledgeGraph(
-					focal.entityIds,
-					// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-					<T>(fn: (db: ReadDb) => T): T => getDbAccessor().withReadDb(fn),
-					traversalAgentId,
-					traversalRuntimeCfg,
+				const traversalResult = await getDbAccessor().withReadDbAsync(async (db) =>
+					traverseKnowledgeGraph(focal.entityIds, db, traversalAgentId, traversalRuntimeCfg),
 				);
 				traversalTimedOut = traversalResult.timedOut;
 				traversalTraversedEntities = traversalResult.entityCount;
@@ -940,7 +927,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	const dbAcc = loadDbAccessor();
 	const candidateIdsForFeatures = mergedCandidates.map((c) => c.id);
 	const structuralById = dbAcc
-		? getStructuralFeatures(dbAcc, candidateIdsForFeatures, agentId, structuralCandidateSourceById)
+		? await getStructuralFeatures(dbAcc, candidateIdsForFeatures, agentId, structuralCandidateSourceById)
 		: new Map<string, StructuralFeatures>();
 	const sortedCandidates = [...mergedCandidates].sort((a, b) => {
 		if (req.project) {
@@ -1026,7 +1013,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	// Re-fetch structural features for any predicted memories not in the first batch
 	const fullStructuralById =
 		allCandidateIdsForRecording.length > candidateIdsForFeatures.length && dbAcc
-			? getStructuralFeatures(dbAcc, allCandidateIdsForRecording, agentId, structuralCandidateSourceById)
+			? await getStructuralFeatures(dbAcc, allCandidateIdsForRecording, agentId, structuralCandidateSourceById)
 			: structuralById;
 
 	const candidatesForRecording = [
@@ -1078,7 +1065,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	dynamicParts.push("[memory active | /remember | /recall]");
 
 	// Inject session gap summary for temporal awareness
-	const gapSummary = getSessionGapSummary();
+	const gapSummary = await getSessionGapSummary();
 	if (gapSummary) {
 		dynamicParts.push(gapSummary);
 	}
@@ -1291,7 +1278,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	});
 }
 
-export function handlePreCompaction(req: PreCompactionRequest): PreCompactionResponse {
+export async function handlePreCompaction(req: PreCompactionRequest): Promise<PreCompactionResponse> {
 	const config = loadHooksConfig().preCompaction || {};
 
 	logger.info("hooks", "Pre-compaction hook", {
@@ -1313,7 +1300,7 @@ ${guidelines}
 		const configuredLimit =
 			typeof config.memoryLimit === "number" && Number.isFinite(config.memoryLimit) ? config.memoryLimit : 5;
 		const memoryLimit = Math.max(0, Math.min(50, Math.trunc(configuredLimit)));
-		const recentMemories = getRecentMemories(memoryLimit, 0.9, { agentId, ...agentScope });
+		const recentMemories = await getRecentMemories(memoryLimit, 0.9, { agentId, ...agentScope });
 		if (recentMemories.length > 0) {
 			summaryPrompt += "\nRecent memories for reference:\n";
 			for (const mem of recentMemories) {
@@ -2093,7 +2080,7 @@ export async function handleSessionEnd(req: SessionEndRequest): Promise<SessionE
 		}
 	}
 	if (transcriptRetained && sessionKey) {
-		const completed = markSessionTranscriptCompleted(sessionKey, agentId, endedAt);
+		const completed = await markSessionTranscriptCompleted(sessionKey, agentId, endedAt);
 		if (!completed) {
 			logger.warn("hooks", "Session-end transcript completion marker was not written", {
 				sessionKey,
@@ -2105,7 +2092,7 @@ export async function handleSessionEnd(req: SessionEndRequest): Promise<SessionE
 	let transcriptCaptureJobId: string | null = null;
 	if (retainedTranscript.trim().length > 0 || rawTranscript.trim().length > 0) {
 		try {
-			transcriptCaptureJobId = enqueueTranscriptCaptureJob(getDbAccessor(), {
+			transcriptCaptureJobId = await enqueueTranscriptCaptureJob(getDbAccessor(), {
 				agentId,
 				harness: req.harness,
 				sessionKey: sessionKey ?? null,
@@ -2157,7 +2144,7 @@ async function waitForCurrentDeferredSessionEndWork(): Promise<void> {
 	await Promise.allSettled(pending);
 }
 
-function shouldDeferStaleSessionSweep(): boolean {
+async function shouldDeferStaleSessionSweep(): Promise<boolean> {
 	if (deferredSessionEndWork.size > 0) {
 		logger.debug("hooks", "Stale session-end sweep deferred while session-end work is pending", {
 			deferredWork: deferredSessionEndWork.size,
@@ -2167,7 +2154,7 @@ function shouldDeferStaleSessionSweep(): boolean {
 	const dbAccessor = loadDbAccessor();
 	if (!dbAccessor) return true;
 	try {
-		const capture = getTranscriptCaptureStatus(dbAccessor);
+		const capture = await getTranscriptCaptureStatus(dbAccessor);
 		const downstreamBacklog = capture.pending + capture.processing;
 		if (downstreamBacklog < STALE_SESSION_SWEEP_MAX_DOWNSTREAM_BACKLOG) return false;
 		logger.debug("hooks", "Stale session-end sweep deferred while downstream work is backlogged", {
@@ -2188,7 +2175,7 @@ async function runStaleSessionSweep(options: {
 	staleOlderThanMs: number;
 	limit?: number;
 }): Promise<StaleSessionSweepResult> {
-	if (shouldDeferStaleSessionSweep()) return { closed: 0, skipped: 0, totalMatching: 0 };
+	if (await shouldDeferStaleSessionSweep()) return { closed: 0, skipped: 0, totalMatching: 0 };
 
 	const requestedLimit = options.limit ?? STALE_SESSION_SWEEP_DEFAULT_LIMIT;
 	const limit = Number.isFinite(requestedLimit)
@@ -2255,7 +2242,7 @@ async function deferSessionEndWork(params: {
 	const pipelineActive = memoryCfg.pipelineV2.enabled || memoryCfg.pipelineV2.shadowMode;
 	if (sessionKey && pipelineActive && memoryCfg.pipelineV2.graph.enabled && memoryCfg.pipelineV2.feedback.enabled) {
 		try {
-			const feedbackPropagatedAttributes = propagateMemoryStatus(getDbAccessor(), agentId);
+			const feedbackPropagatedAttributes = await propagateMemoryStatus(getDbAccessor(), agentId);
 			if (feedbackPropagatedAttributes > 0) {
 				invalidateTraversalCache();
 			}

--- a/platform/daemon/src/knowledge-feedback.test.ts
+++ b/platform/daemon/src/knowledge-feedback.test.ts
@@ -58,21 +58,21 @@ describe("knowledge feedback", () => {
 		dbPath = "";
 	});
 
-	test("pinning updates entity state and focal resolution unions pinned entities", () => {
+	test("pinning updates entity state and focal resolution unions pinned entities", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
 		insertEntity("entity-pinned", "Pinned Project", "project");
 		insertEntity("entity-project", "other-project", "project");
 
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "default",
 			actor: "test",
 			operation: "pin_entity",
 			payload: { id: "entity-pinned" },
 		});
 
-		const pinned = getPinnedEntities(getDbAccessor(), "default");
+		const pinned = await getPinnedEntities(getDbAccessor(), "default");
 		expect(pinned).toHaveLength(1);
 		expect(pinned[0]?.id).toBe("entity-pinned");
 
@@ -86,21 +86,21 @@ describe("knowledge feedback", () => {
 		expect(resolved.entityIds).toContain("entity-project");
 		expect(resolved.source).toBe("project");
 
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "default",
 			actor: "test",
 			operation: "unpin_entity",
 			payload: { id: "entity-pinned" },
 		});
-		expect(getPinnedEntities(getDbAccessor(), "default")).toHaveLength(0);
+		expect(await getPinnedEntities(getDbAccessor(), "default")).toHaveLength(0);
 	});
 
-	test("focal source falls back to session_key even when project is present but unresolved", () => {
+	test("focal source falls back to session_key even when project is present but unresolved", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
 		insertEntity("entity-pinned", "Pinned Project", "project");
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "default",
 			actor: "test",
 			operation: "pin_entity",
@@ -118,7 +118,7 @@ describe("knowledge feedback", () => {
 		expect(resolved.entityIds).toEqual(["entity-pinned"]);
 	});
 
-	test("entity health is empty after predictor comparison table retirement", () => {
+	test("entity health is empty after predictor comparison table retirement", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
@@ -126,7 +126,7 @@ describe("knowledge feedback", () => {
 			db.exec("DROP TABLE IF EXISTS predictor_comparisons");
 		});
 
-		expect(getEntityHealth(getDbAccessor(), "default")).toEqual([]);
+		expect(await getEntityHealth(getDbAccessor(), "default")).toEqual([]);
 	});
 
 	test("fts overlap feedback raises aspect weights and decay respects the floor", () => {

--- a/platform/daemon/src/knowledge-graph-list.test.ts
+++ b/platform/daemon/src/knowledge-graph-list.test.ts
@@ -162,7 +162,7 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		dbPath = "";
 	});
 
-	test("returns entities in the documented order (pinned, pinned_at, mentions, updated_at, name)", () => {
+	test("returns entities in the documented order (pinned, pinned_at, mentions, updated_at, name)", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
@@ -175,7 +175,7 @@ describe("listKnowledgeEntities (issue #515)", () => {
 			updatedAt: "2026-01-10T00:00:00Z",
 		});
 
-		const result = listKnowledgeEntities(getDbAccessor(), {
+		const result = await listKnowledgeEntities(getDbAccessor(), {
 			agentId: "default",
 			limit: 10,
 			offset: 0,
@@ -184,7 +184,7 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		expect(result.map((r) => r.entity.id)).toEqual(["e-gamma", "e-beta", "e-alpha"]);
 	});
 
-	test("counts aspects, attributes, constraints, and dependencies (incoming + outgoing) per entity", () => {
+	test("counts aspects, attributes, constraints, and dependencies (incoming + outgoing) per entity", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
@@ -202,7 +202,7 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		// Dependency where hub is target (inbound) — should also count
 		seedDependency("dep-2", "e-leaf", "e-hub");
 
-		const result = listKnowledgeEntities(getDbAccessor(), {
+		const result = await listKnowledgeEntities(getDbAccessor(), {
 			agentId: "default",
 			limit: 10,
 			offset: 0,
@@ -216,7 +216,7 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		expect(hub?.dependencyCount).toBe(2);
 	});
 
-	test("excludes archived graph rows from default list counts", () => {
+	test("excludes archived graph rows from default list counts", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
@@ -232,7 +232,7 @@ describe("listKnowledgeEntities (issue #515)", () => {
 			db.prepare("UPDATE entity_aspects SET status = 'archived' WHERE id = ?").run("asp-archived");
 		});
 
-		const result = listKnowledgeEntities(getDbAccessor(), {
+		const result = await listKnowledgeEntities(getDbAccessor(), {
 			agentId: "default",
 			limit: 10,
 			offset: 0,
@@ -245,7 +245,7 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		expect(result[0]?.dependencyCount).toBe(0);
 	});
 
-	test("dependency reads hide edges attached to archived endpoint entities", () => {
+	test("dependency reads hide edges attached to archived endpoint entities", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
@@ -260,27 +260,29 @@ describe("listKnowledgeEntities (issue #515)", () => {
 			db.prepare("UPDATE entities SET status = 'archived' WHERE id = ?").run("e-archived");
 		});
 
-		expect(getDependenciesFrom(getDbAccessor(), "e-active", "default").map((dep) => dep.id)).toEqual([
+		expect((await getDependenciesFrom(getDbAccessor(), "e-active", "default")).map((dep) => dep.id)).toEqual([
 			"dep-visible-out",
 		]);
-		expect(getDependenciesTo(getDbAccessor(), "e-active", "default").map((dep) => dep.id)).toEqual(["dep-visible-in"]);
+		expect((await getDependenciesTo(getDbAccessor(), "e-active", "default")).map((dep) => dep.id)).toEqual([
+			"dep-visible-in",
+		]);
 	});
 
-	test("respects limit and offset pagination", () => {
+	test("respects limit and offset pagination", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 		for (let i = 0; i < 5; i++) {
 			seedEntity(`e-${i}`, `Name-${i}`, { mentions: 10 - i, updatedAt: "2026-01-01T00:00:00Z" });
 		}
 
-		const page1 = listKnowledgeEntities(getDbAccessor(), { agentId: "default", limit: 2, offset: 0 });
-		const page2 = listKnowledgeEntities(getDbAccessor(), { agentId: "default", limit: 2, offset: 2 });
+		const page1 = await listKnowledgeEntities(getDbAccessor(), { agentId: "default", limit: 2, offset: 0 });
+		const page2 = await listKnowledgeEntities(getDbAccessor(), { agentId: "default", limit: 2, offset: 2 });
 
 		expect(page1.map((r) => r.entity.id)).toEqual(["e-0", "e-1"]);
 		expect(page2.map((r) => r.entity.id)).toEqual(["e-2", "e-3"]);
 	});
 
-	test("filters by type and query (canonical_name LIKE)", () => {
+	test("filters by type and query (canonical_name LIKE)", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
@@ -288,7 +290,7 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		seedEntity("e-proj-2", "XLNT", { entityType: "project" });
 		seedEntity("e-concept-1", "Muse Pipeline", { entityType: "concept" });
 
-		const projectsOnly = listKnowledgeEntities(getDbAccessor(), {
+		const projectsOnly = await listKnowledgeEntities(getDbAccessor(), {
 			agentId: "default",
 			type: "project",
 			limit: 10,
@@ -296,7 +298,7 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		});
 		expect(projectsOnly.map((r) => r.entity.id).sort()).toEqual(["e-proj-1", "e-proj-2"]);
 
-		const museMatches = listKnowledgeEntities(getDbAccessor(), {
+		const museMatches = await listKnowledgeEntities(getDbAccessor(), {
 			agentId: "default",
 			query: "muse",
 			limit: 10,
@@ -305,27 +307,27 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		expect(museMatches.map((r) => r.entity.id).sort()).toEqual(["e-concept-1", "e-proj-1"]);
 	});
 
-	test("agent scoping isolates entities across agent_id values", () => {
+	test("agent scoping isolates entities across agent_id values", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
 		seedEntity("e-main", "Main-scoped", { agentId: "main" });
 		seedEntity("e-def", "Default-scoped", { agentId: "default" });
 
-		const mainScope = listKnowledgeEntities(getDbAccessor(), { agentId: "main", limit: 10, offset: 0 });
-		const defaultScope = listKnowledgeEntities(getDbAccessor(), { agentId: "default", limit: 10, offset: 0 });
+		const mainScope = await listKnowledgeEntities(getDbAccessor(), { agentId: "main", limit: 10, offset: 0 });
+		const defaultScope = await listKnowledgeEntities(getDbAccessor(), { agentId: "default", limit: 10, offset: 0 });
 
 		expect(mainScope.map((r) => r.entity.id)).toEqual(["e-main"]);
 		expect(defaultScope.map((r) => r.entity.id)).toEqual(["e-def"]);
 	});
 
-	test("entity alias archive is scoped to the owning entity", () => {
+	test("entity alias archive is scoped to the owning entity", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
 		seedEntity("e-signet", "Signet");
 		seedEntity("e-other", "Other");
-		const created = applyOntologyOperation(getDbAccessor(), {
+		const created = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "default",
 			actor: "test",
 			operation: "create_entity_alias",
@@ -334,24 +336,24 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		const aliasId = created.result?.aliasId as string;
 		expect(aliasId).toBeTruthy();
 
-		expect(() =>
+		await expect(
 			applyOntologyOperation(getDbAccessor(), {
 				agentId: "default",
 				actor: "test",
 				operation: "archive_entity_alias",
 				payload: { entity_id: "e-other", alias_id: aliasId },
 			}),
-		).toThrow();
-		expect(listEntityAliases(getDbAccessor(), { agentId: "default", entityId: "e-signet" })).toHaveLength(1);
+		).rejects.toThrow();
+		expect(await listEntityAliases(getDbAccessor(), { agentId: "default", entityId: "e-signet" })).toHaveLength(1);
 
-		const archived = applyOntologyOperation(getDbAccessor(), {
+		const archived = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "default",
 			actor: "test",
 			operation: "archive_entity_alias",
 			payload: { entity_id: "e-signet", alias_id: aliasId },
 		});
 		expect(archived.result?.archived).toBe(true);
-		expect(listEntityAliases(getDbAccessor(), { agentId: "default", entityId: "e-signet" })).toHaveLength(0);
+		expect(await listEntityAliases(getDbAccessor(), { agentId: "default", entityId: "e-signet" })).toHaveLength(0);
 	});
 
 	test("builds a bounded constellation graph without loading every graph row", async () => {
@@ -456,7 +458,7 @@ describe("listKnowledgeEntities (issue #515)", () => {
 				})[0],
 		);
 		if (source === undefined) throw new Error("test fixture did not create an episodic source");
-		const graph = getKnowledgeGraphForConstellation(getDbAccessor(), "default", {
+		const graph = await getKnowledgeGraphForConstellation(getDbAccessor(), "default", {
 			limit: 2,
 			maxAspectsPerEntity: 1,
 			maxAttributesPerAspect: 1,
@@ -479,7 +481,7 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		expect(graph.metadata.dreaming.latestPass?.mutationsApplied).toBe(3);
 	});
 
-	test("includes zero-mention semantic entities regardless of their entity type", () => {
+	test("includes zero-mention semantic entities regardless of their entity type", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
@@ -489,14 +491,14 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		seedAspect("asp-source", "e-source", "source metadata");
 		seedAttribute("attr-artifact", "asp-artifact", { content: "The report supports the current plan." });
 
-		const graph = getKnowledgeGraphForConstellation(getDbAccessor(), "default");
+		const graph = await getKnowledgeGraphForConstellation(getDbAccessor(), "default");
 
 		expect(graph.entities).toHaveLength(1);
 		expect(graph.entities[0]).toMatchObject({ id: "e-artifact", entityType: "artifact" });
 		expect(graph.entities[0]?.aspects[0]?.attributes[0]?.content).toBe("The report supports the current plan.");
 	});
 
-	test("constellation includes shared-agent graph rows for the current view", () => {
+	test("constellation includes shared-agent graph rows for the current view", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
@@ -510,7 +512,7 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		seedAttribute("attr-noam", "asp-noam", { agentId: "noam", content: "shared attribute" });
 		seedDependency("dep-shared", "e-default", "e-noam", { agentId: "noam", strength: 0.9 });
 
-		const graph = getKnowledgeGraphForConstellation(getDbAccessor(), "default", {
+		const graph = await getKnowledgeGraphForConstellation(getDbAccessor(), "default", {
 			limit: 10,
 			maxAspectsPerEntity: 2,
 			maxAttributesPerAspect: 2,
@@ -537,7 +539,7 @@ describe("getKnowledgeEntityDetail (issue #515)", () => {
 		dbPath = "";
 	});
 
-	test("returns incoming + outgoing dependency counts independently", () => {
+	test("returns incoming + outgoing dependency counts independently", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
@@ -549,18 +551,18 @@ describe("getKnowledgeEntityDetail (issue #515)", () => {
 		seedDependency("dep-out-2", "e-hub", "e-b");
 		seedDependency("dep-in-1", "e-c", "e-hub");
 
-		const detail = getKnowledgeEntityDetail(getDbAccessor(), "e-hub", "default");
+		const detail = await getKnowledgeEntityDetail(getDbAccessor(), "e-hub", "default");
 		expect(detail).not.toBeNull();
 		expect(detail?.outgoingDependencyCount).toBe(2);
 		expect(detail?.incomingDependencyCount).toBe(1);
 		expect(detail?.dependencyCount).toBe(3);
 	});
 
-	test("returns null for unknown entity id", () => {
+	test("returns null for unknown entity id", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
-		const detail = getKnowledgeEntityDetail(getDbAccessor(), "does-not-exist", "default");
+		const detail = await getKnowledgeEntityDetail(getDbAccessor(), "does-not-exist", "default");
 		expect(detail).toBeNull();
 	});
 });
@@ -577,7 +579,7 @@ describe("getKnowledgeStats (issue #515)", () => {
 		dbPath = "";
 	});
 
-	test("counts memories linked to agent-scoped entities via memory_entity_mentions", () => {
+	test("counts memories linked to agent-scoped entities via memory_entity_mentions", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
@@ -593,16 +595,16 @@ describe("getKnowledgeStats (issue #515)", () => {
 		seedMention("m2", "e-def-2");
 		seedMention("m3", "e-main");
 
-		const defaultStats = getKnowledgeStats(getDbAccessor(), "default");
+		const defaultStats = await getKnowledgeStats(getDbAccessor(), "default");
 		expect(defaultStats.entityCount).toBe(2);
 		expect(defaultStats.unassignedMemoryCount).toBe(2);
 
-		const mainStats = getKnowledgeStats(getDbAccessor(), "main");
+		const mainStats = await getKnowledgeStats(getDbAccessor(), "main");
 		expect(mainStats.entityCount).toBe(1);
 		expect(mainStats.unassignedMemoryCount).toBe(1);
 	});
 
-	test("ignores soft-deleted memories", () => {
+	test("ignores soft-deleted memories", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
@@ -614,11 +616,11 @@ describe("getKnowledgeStats (issue #515)", () => {
 			db.prepare("UPDATE memories SET is_deleted = 1 WHERE id = ?").run("m1");
 		});
 
-		const stats = getKnowledgeStats(getDbAccessor(), "default");
+		const stats = await getKnowledgeStats(getDbAccessor(), "default");
 		expect(stats.unassignedMemoryCount).toBe(0);
 	});
 
-	test("excludes archived graph rows from stats and coverage", () => {
+	test("excludes archived graph rows from stats and coverage", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
@@ -638,7 +640,7 @@ describe("getKnowledgeStats (issue #515)", () => {
 			db.prepare("UPDATE entity_aspects SET status = 'archived' WHERE id = ?").run("asp-archived");
 		});
 
-		const stats = getKnowledgeStats(getDbAccessor(), "default");
+		const stats = await getKnowledgeStats(getDbAccessor(), "default");
 		expect(stats.entityCount).toBe(1);
 		expect(stats.aspectCount).toBe(1);
 		expect(stats.attributeCount).toBe(1);

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -787,7 +787,7 @@ export async function getEntityAspectsByName(
 		if (!entity) return null;
 		return {
 			entity,
-			items: await getEntityAspectsWithCounts(accessor, entity.id, params.agentId),
+			items: readEntityAspectsWithCounts(db, entity.id, params.agentId),
 		};
 	});
 }
@@ -1312,38 +1312,40 @@ export async function getKnowledgeEntityDetail(
 	});
 }
 
+function readEntityAspectsWithCounts(db: ReadDb, entityId: string, agentId: string): readonly AspectWithCounts[] {
+	const rows = db
+		.prepare(
+			`SELECT
+				asp.*,
+				COUNT(DISTINCT CASE
+					WHEN attr.kind = 'attribute' AND attr.status = 'active' THEN attr.id
+				END) AS attribute_count,
+				COUNT(DISTINCT CASE
+					WHEN attr.kind = 'constraint' AND attr.status = 'active' THEN attr.id
+				END) AS constraint_count
+			 FROM entity_aspects asp
+			 LEFT JOIN entity_attributes attr
+			   ON attr.aspect_id = asp.id AND attr.agent_id = asp.agent_id
+			 WHERE asp.entity_id = ? AND asp.agent_id = ?
+			   AND COALESCE(asp.status, 'active') = 'active'
+			 GROUP BY asp.id
+			 ORDER BY asp.weight DESC, asp.name ASC`,
+		)
+		.all(entityId, agentId) as Array<Record<string, unknown>>;
+
+	return rows.map((row) => ({
+		aspect: rowToAspect(row),
+		attributeCount: Number(row.attribute_count ?? 0),
+		constraintCount: Number(row.constraint_count ?? 0),
+	}));
+}
+
 export async function getEntityAspectsWithCounts(
 	accessor: DbAccessor,
 	entityId: string,
 	agentId: string,
 ): Promise<readonly AspectWithCounts[]> {
-	return await accessor.withReadDbAsync(async (db) => {
-		const rows = db
-			.prepare(
-				`SELECT
-					asp.*,
-					COUNT(DISTINCT CASE
-						WHEN attr.kind = 'attribute' AND attr.status = 'active' THEN attr.id
-					END) AS attribute_count,
-					COUNT(DISTINCT CASE
-						WHEN attr.kind = 'constraint' AND attr.status = 'active' THEN attr.id
-					END) AS constraint_count
-				 FROM entity_aspects asp
-				 LEFT JOIN entity_attributes attr
-				   ON attr.aspect_id = asp.id AND attr.agent_id = asp.agent_id
-				 WHERE asp.entity_id = ? AND asp.agent_id = ?
-				   AND COALESCE(asp.status, 'active') = 'active'
-				 GROUP BY asp.id
-				 ORDER BY asp.weight DESC, asp.name ASC`,
-			)
-			.all(entityId, agentId) as Array<Record<string, unknown>>;
-
-		return rows.map((row) => ({
-			aspect: rowToAspect(row),
-			attributeCount: Number(row.attribute_count ?? 0),
-			constraintCount: Number(row.constraint_count ?? 0),
-		}));
-	});
+	return await accessor.withReadDbAsync(async (db) => readEntityAspectsWithCounts(db, entityId, agentId));
 }
 
 export async function getAttributesForAspectFiltered(

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -22,6 +22,7 @@ import type {
 } from "@signet/core";
 import { SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES } from "@signet/core";
 import type { DbAccessor, ReadDb } from "./db-accessor";
+import { runWriteTxAsync } from "./db-accessor";
 import { getDreamingEpisodicTokenBacklogCached } from "./pipeline/dreaming";
 
 // ---------------------------------------------------------------------------
@@ -182,9 +183,12 @@ function rowToTaskMeta(r: Record<string, unknown>): TaskMeta {
 // Aspects
 // ---------------------------------------------------------------------------
 
-export function getAspectsForEntity(accessor: DbAccessor, entityId: string, agentId: string): readonly EntityAspect[] {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+export async function getAspectsForEntity(
+	accessor: DbAccessor,
+	entityId: string,
+	agentId: string,
+): Promise<readonly EntityAspect[]> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const rows = db
 			.prepare(
 				`SELECT * FROM entity_aspects
@@ -201,13 +205,12 @@ export function getAspectsForEntity(accessor: DbAccessor, entityId: string, agen
 // Attributes
 // ---------------------------------------------------------------------------
 
-export function getAttributesForAspect(
+export async function getAttributesForAspect(
 	accessor: DbAccessor,
 	aspectId: string,
 	agentId: string,
-): readonly EntityAttribute[] {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<readonly EntityAttribute[]> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const rows = db
 			.prepare(
 				`SELECT * FROM entity_attributes
@@ -224,13 +227,12 @@ export function getAttributesForAspect(
  * Joins through entity_aspects to collect kind='constraint' rows.
  * This is the query that enforces the "constraints always surface" invariant.
  */
-export function getConstraintsForEntity(
+export async function getConstraintsForEntity(
 	accessor: DbAccessor,
 	entityId: string,
 	agentId: string,
-): readonly EntityAttribute[] {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<readonly EntityAttribute[]> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const rows = db
 			.prepare(
 				`SELECT ea.* FROM entity_attributes ea
@@ -251,12 +253,11 @@ export function getConstraintsForEntity(
 // Dependencies
 // ---------------------------------------------------------------------------
 
-export function getEntityDependencyById(
+export async function getEntityDependencyById(
 	accessor: DbAccessor,
 	params: { readonly id: string; readonly agentId: string },
-): EntityDependency | null {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<EntityDependency | null> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const row = db
 			.prepare("SELECT * FROM entity_dependencies WHERE id = ? AND agent_id = ?")
 			.get(params.id, params.agentId) as Record<string, unknown> | undefined;
@@ -264,13 +265,12 @@ export function getEntityDependencyById(
 	});
 }
 
-export function getDependenciesFrom(
+export async function getDependenciesFrom(
 	accessor: DbAccessor,
 	entityId: string,
 	agentId: string,
-): readonly EntityDependency[] {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<readonly EntityDependency[]> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const rows = db
 			.prepare(
 				`SELECT dep.*
@@ -287,13 +287,12 @@ export function getDependenciesFrom(
 	});
 }
 
-export function getDependenciesTo(
+export async function getDependenciesTo(
 	accessor: DbAccessor,
 	entityId: string,
 	agentId: string,
-): readonly EntityDependency[] {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<readonly EntityDependency[]> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const rows = db
 			.prepare(
 				`SELECT dep.*
@@ -314,9 +313,11 @@ export function getDependenciesTo(
 // Entity pinning
 // ---------------------------------------------------------------------------
 
-export function getPinnedEntities(accessor: DbAccessor, agentId: string): ReadonlyArray<PinnedEntitySummary> {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+export async function getPinnedEntities(
+	accessor: DbAccessor,
+	agentId: string,
+): Promise<ReadonlyArray<PinnedEntitySummary>> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const rows = db
 			.prepare(
 				`SELECT id, name, pinned_at
@@ -354,13 +355,12 @@ export interface UpsertTaskMetaParams {
 	readonly retentionUntil?: string;
 }
 
-export function upsertTaskMeta(accessor: DbAccessor, params: UpsertTaskMetaParams): TaskMeta {
+export async function upsertTaskMeta(accessor: DbAccessor, params: UpsertTaskMetaParams): Promise<TaskMeta> {
 	const ts = now();
 
 	const completedAt = params.status === "done" || params.status === "cancelled" ? ts : null;
 
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	return accessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
+	return await runWriteTxAsync(accessor, (db) => {
 		// entity_id is PRIMARY KEY, so ON CONFLICT handles the upsert
 		db.prepare(
 			`INSERT INTO task_meta
@@ -395,9 +395,8 @@ export function upsertTaskMeta(accessor: DbAccessor, params: UpsertTaskMetaParam
 	});
 }
 
-export function getTaskMeta(accessor: DbAccessor, entityId: string, agentId: string): TaskMeta | null {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+export async function getTaskMeta(accessor: DbAccessor, entityId: string, agentId: string): Promise<TaskMeta | null> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const row = db.prepare("SELECT * FROM task_meta WHERE entity_id = ? AND agent_id = ?").get(entityId, agentId) as
 			| Record<string, unknown>
 			| undefined;
@@ -405,10 +404,14 @@ export function getTaskMeta(accessor: DbAccessor, entityId: string, agentId: str
 	});
 }
 
-export function updateTaskStatus(accessor: DbAccessor, entityId: string, agentId: string, status: TaskStatus): void {
+export async function updateTaskStatus(
+	accessor: DbAccessor,
+	entityId: string,
+	agentId: string,
+	status: TaskStatus,
+): Promise<void> {
 	const ts = now();
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	accessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
+	await runWriteTxAsync(accessor, (db) => {
 		db.prepare(
 			`UPDATE task_meta
 			 SET status = ?, completed_at = ?, updated_at = ?
@@ -563,18 +566,17 @@ export interface EntityKnowledgeTree {
 	};
 }
 
-export function resolveNamedEntity(
+export async function resolveNamedEntity(
 	accessor: DbAccessor,
 	input: {
 		readonly agentId: string;
 		readonly name: string;
 	},
-): ResolvedNamedEntity | null {
+): Promise<ResolvedNamedEntity | null> {
 	const canonical = toCanonicalName(input.name);
 	if (canonical.length === 0) return null;
 
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+	return await accessor.withReadDbAsync(async (db) => {
 		const escaped = canonical.replace(/\\/g, "\\\\").replace(/[%_]/g, "\\$&");
 		const starts = `${escaped}%`;
 		const contains = `%${escaped}%`;
@@ -671,7 +673,7 @@ function resolveAspectByName(
 	return row ? rowToAspect(row) : null;
 }
 
-function resolveEntityRecordByName(
+export function resolveEntityRecordByName(
 	db: ReadDb,
 	params: {
 		readonly agentId: string;
@@ -730,27 +732,26 @@ function resolveEntityRecordByName(
 	return row ? rowToEntity(row) : null;
 }
 
-export function getKnowledgeEntityByName(
+export async function getKnowledgeEntityByName(
 	accessor: DbAccessor,
 	params: {
 		readonly agentId: string;
 		readonly name: string;
 	},
-): KnowledgeEntityDetail | null {
-	const resolved = resolveNamedEntity(accessor, params);
-	return resolved ? getKnowledgeEntityDetail(accessor, resolved.id, params.agentId) : null;
+): Promise<KnowledgeEntityDetail | null> {
+	const resolved = await resolveNamedEntity(accessor, params);
+	return resolved ? await getKnowledgeEntityDetail(accessor, resolved.id, params.agentId) : null;
 }
 
-export function listEntityAliases(
+export async function listEntityAliases(
 	accessor: DbAccessor,
 	params: {
 		readonly agentId: string;
 		readonly entityId: string;
 		readonly status?: "active" | "archived" | "all";
 	},
-): readonly EntityAlias[] {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<readonly EntityAlias[]> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const conditions = ["entity_id = ?", "agent_id = ?"];
 		const args: string[] = [params.entityId, params.agentId];
 		if (params.status && params.status !== "all") {
@@ -771,15 +772,14 @@ export function listEntityAliases(
 	});
 }
 
-export function getEntityAspectsByName(
+export async function getEntityAspectsByName(
 	accessor: DbAccessor,
 	params: {
 		readonly agentId: string;
 		readonly entity: string;
 	},
-): { readonly entity: Entity; readonly items: readonly AspectWithCounts[] } | null {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<{ readonly entity: Entity; readonly items: readonly AspectWithCounts[] } | null> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const entity = resolveEntityRecordByName(db, {
 			agentId: params.agentId,
 			name: params.entity,
@@ -787,12 +787,12 @@ export function getEntityAspectsByName(
 		if (!entity) return null;
 		return {
 			entity,
-			items: getEntityAspectsWithCounts(accessor, entity.id, params.agentId),
+			items: await getEntityAspectsWithCounts(accessor, entity.id, params.agentId),
 		};
 	});
 }
 
-export function getEntityKnowledgeTree(
+export async function getEntityKnowledgeTree(
 	accessor: DbAccessor,
 	params: {
 		readonly agentId: string;
@@ -802,9 +802,8 @@ export function getEntityKnowledgeTree(
 		readonly maxClaims: number;
 		readonly depth: number;
 	},
-): EntityKnowledgeTree | null {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<EntityKnowledgeTree | null> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const entity = resolveEntityRecordByName(db, {
 			agentId: params.agentId,
 			name: params.entity,
@@ -942,16 +941,19 @@ export function getEntityKnowledgeTree(
 	});
 }
 
-export function listEntityGroups(
+export async function listEntityGroups(
 	accessor: DbAccessor,
 	params: {
 		readonly agentId: string;
 		readonly entity: string;
 		readonly aspect: string;
 	},
-): { readonly entity: Entity; readonly aspect: EntityAspect; readonly items: readonly EntityGroupSummary[] } | null {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<{
+	readonly entity: Entity;
+	readonly aspect: EntityAspect;
+	readonly items: readonly EntityGroupSummary[];
+} | null> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const entity = resolveEntityRecordByName(db, {
 			agentId: params.agentId,
 			name: params.entity,
@@ -999,7 +1001,7 @@ export function listEntityGroups(
 	});
 }
 
-export function listEntityClaims(
+export async function listEntityClaims(
 	accessor: DbAccessor,
 	params: {
 		readonly agentId: string;
@@ -1007,9 +1009,12 @@ export function listEntityClaims(
 		readonly aspect: string;
 		readonly group: string;
 	},
-): { readonly entity: Entity; readonly aspect: EntityAspect; readonly items: readonly EntityClaimSummary[] } | null {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<{
+	readonly entity: Entity;
+	readonly aspect: EntityAspect;
+	readonly items: readonly EntityClaimSummary[];
+} | null> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const entity = resolveEntityRecordByName(db, {
 			agentId: params.agentId,
 			name: params.entity,
@@ -1070,7 +1075,7 @@ export function listEntityClaims(
 	});
 }
 
-export function listEntityAttributesByPath(
+export async function listEntityAttributesByPath(
 	accessor: DbAccessor,
 	params: {
 		readonly agentId: string;
@@ -1083,9 +1088,12 @@ export function listEntityAttributesByPath(
 		readonly limit: number;
 		readonly offset: number;
 	},
-): { readonly entity: Entity; readonly aspect: EntityAspect; readonly items: readonly EntityAttribute[] } | null {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<{
+	readonly entity: Entity;
+	readonly aspect: EntityAspect;
+	readonly items: readonly EntityAttribute[];
+} | null> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const entity = resolveEntityRecordByName(db, {
 			agentId: params.agentId,
 			name: params.entity,
@@ -1136,7 +1144,7 @@ export function listEntityAttributesByPath(
 	});
 }
 
-export function listKnowledgeEntities(
+export async function listKnowledgeEntities(
 	accessor: DbAccessor,
 	params: {
 		readonly agentId: string;
@@ -1145,9 +1153,8 @@ export function listKnowledgeEntities(
 		readonly limit: number;
 		readonly offset: number;
 	},
-): readonly KnowledgeEntityListItem[] {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<readonly KnowledgeEntityListItem[]> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const conditions = ["e.agent_id = ?"];
 		const args: Array<string | number> = [params.agentId];
 		conditions.push("COALESCE(e.status, 'active') = 'active'");
@@ -1226,13 +1233,12 @@ export function listKnowledgeEntities(
 	});
 }
 
-export function getKnowledgeEntityDetail(
+export async function getKnowledgeEntityDetail(
 	accessor: DbAccessor,
 	entityId: string,
 	agentId: string,
-): KnowledgeEntityDetail | null {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<KnowledgeEntityDetail | null> {
+	return await accessor.withReadDbAsync(async (db) => {
 		// Scalar subqueries per count avoid GROUP BY materialization across
 		// the (LEFT JOIN aspects x attributes x dependencies) cartesian, which
 		// produces the same pathological shape as listKnowledgeEntities even
@@ -1289,7 +1295,7 @@ export function getKnowledgeEntityDetail(
 			.get(entityId, agentId) as Record<string, unknown> | undefined;
 
 		if (!row) return null;
-		const structuralDensity = getStructuralDensity(accessor, entityId, agentId);
+		const structuralDensity = await getStructuralDensity(accessor, entityId, agentId);
 		const incomingDependencyCount = Number(row.incoming_dependency_count ?? 0);
 		const outgoingDependencyCount = Number(row.outgoing_dependency_count ?? 0);
 
@@ -1306,13 +1312,12 @@ export function getKnowledgeEntityDetail(
 	});
 }
 
-export function getEntityAspectsWithCounts(
+export async function getEntityAspectsWithCounts(
 	accessor: DbAccessor,
 	entityId: string,
 	agentId: string,
-): readonly AspectWithCounts[] {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<readonly AspectWithCounts[]> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const rows = db
 			.prepare(
 				`SELECT
@@ -1341,7 +1346,7 @@ export function getEntityAspectsWithCounts(
 	});
 }
 
-export function getAttributesForAspectFiltered(
+export async function getAttributesForAspectFiltered(
 	accessor: DbAccessor,
 	params: {
 		readonly entityId: string;
@@ -1352,9 +1357,8 @@ export function getAttributesForAspectFiltered(
 		readonly limit: number;
 		readonly offset: number;
 	},
-): readonly EntityAttribute[] {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<readonly EntityAttribute[]> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const conditions = [
 			"asp.entity_id = ?",
 			"asp.id = ?",
@@ -1388,16 +1392,15 @@ export function getAttributesForAspectFiltered(
 	});
 }
 
-export function getEntityDependenciesDetailed(
+export async function getEntityDependenciesDetailed(
 	accessor: DbAccessor,
 	params: {
 		readonly entityId: string;
 		readonly agentId: string;
 		readonly direction: "incoming" | "outgoing" | "both";
 	},
-): readonly KnowledgeDependencyEdge[] {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<readonly KnowledgeDependencyEdge[]> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const directionClauses: string[] = [];
 		if (params.direction === "incoming" || params.direction === "both") {
 			directionClauses.push("dep.target_entity_id = ?");
@@ -1444,9 +1447,8 @@ export function getEntityDependenciesDetailed(
 	});
 }
 
-export function getKnowledgeStats(accessor: DbAccessor, agentId: string): KnowledgeStats {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+export async function getKnowledgeStats(accessor: DbAccessor, agentId: string): Promise<KnowledgeStats> {
+	return await accessor.withReadDbAsync(async (db) => {
 		// Drive the join from the (narrower) agent-scoped entities side rather
 		// than scanning every memory with a correlated EXISTS. Same result,
 		// dramatically smaller search space on large corpora.
@@ -1567,14 +1569,13 @@ export function getKnowledgeStats(accessor: DbAccessor, agentId: string): Knowle
 	});
 }
 
-export function getEntityHealth(
+export async function getEntityHealth(
 	accessor: DbAccessor,
 	agentId: string,
 	since?: string,
 	minComparisons = 3,
-): ReadonlyArray<EntityHealth> {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<ReadonlyArray<EntityHealth>> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const predictorTable = db
 			.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'predictor_comparisons'")
 			.get() as { name: string } | undefined;
@@ -1658,9 +1659,8 @@ export function getEntityHealth(
 	});
 }
 
-export function propagateMemoryStatus(accessor: DbAccessor, agentId: string): number {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	return accessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
+export async function propagateMemoryStatus(accessor: DbAccessor, agentId: string): Promise<number> {
+	return await runWriteTxAsync(accessor, (db) => {
 		const stale = db
 			.prepare(
 				`SELECT id
@@ -1944,18 +1944,17 @@ function getConstellationProposalSummary(db: ReadDb, agentId: string): Constella
 	};
 }
 
-export function getKnowledgeGraphForConstellation(
+export async function getKnowledgeGraphForConstellation(
 	accessor: DbAccessor,
 	agentId: string,
 	options: ConstellationGraphOptions = {},
-): ConstellationGraph {
+): Promise<ConstellationGraph> {
 	const limit = boundedInteger(options.limit, 150, 1, 300);
 	const maxAspectsPerEntity = boundedInteger(options.maxAspectsPerEntity, 6, 1, 25);
 	const maxAttributesPerAspect = boundedInteger(options.maxAttributesPerAspect, 4, 1, 250);
 	const dependencyLimit = boundedInteger(options.dependencyLimit, 500, 1, 2000);
 
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+	return await accessor.withReadDbAsync(async (db) => {
 		const visibleAgentIds = getConstellationVisibleAgentIds(db, agentId);
 		const agentPlaceholders = placeholders(visibleAgentIds.length);
 		const topologyPlaceholders = placeholders(SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES.length);
@@ -2199,9 +2198,12 @@ export function getKnowledgeGraphForConstellation(
 	});
 }
 
-export function getStructuralDensity(accessor: DbAccessor, entityId: string, agentId: string): StructuralDensity {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+export async function getStructuralDensity(
+	accessor: DbAccessor,
+	entityId: string,
+	agentId: string,
+): Promise<StructuralDensity> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const aspects = db
 			.prepare(
 				`SELECT COUNT(*) as n FROM entity_aspects

--- a/platform/daemon/src/knowledge-navigation.test.ts
+++ b/platform/daemon/src/knowledge-navigation.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { DbAccessor, ReadDb } from "./db-accessor";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import {
 	getEntityAspectsByName,
@@ -61,6 +62,22 @@ function seedAttribute(input: {
 			updatedAt,
 		);
 	});
+}
+
+function rejectNestedReads(accessor: DbAccessor): DbAccessor {
+	let active = false;
+	return {
+		...accessor,
+		async withReadDbAsync<T>(fn: (db: ReadDb) => Promise<T>): Promise<T> {
+			if (active) throw new Error("nested read connection acquisition");
+			active = true;
+			try {
+				return await accessor.withReadDbAsync(fn);
+			} finally {
+				active = false;
+			}
+		},
+	};
 }
 
 describe("knowledge graph navigation", () => {
@@ -154,6 +171,24 @@ describe("knowledge graph navigation", () => {
 			offset: 0,
 		});
 		expect(all?.items.map((item) => item.status)).toEqual(["active", "superseded"]);
+	});
+
+	test("holds one read connection while resolving entity aspects by name", async () => {
+		dbPath = makeDbPath();
+		initDbAccessor(dbPath);
+		seedEntity();
+		seedAttribute({
+			id: "attr-favorite",
+			groupKey: "restaurants",
+			claimKey: "favorite_restaurant",
+			content: "Nicholai currently prefers Temaki Den.",
+		});
+
+		const result = await getEntityAspectsByName(rejectNestedReads(getDbAccessor()), {
+			agentId: "default",
+			entity: "Nicholai",
+		});
+		expect(result?.items[0]?.attributeCount).toBe(1);
 	});
 
 	test("returns a compact tree for agent-visible graph browsing", async () => {

--- a/platform/daemon/src/knowledge-navigation.test.ts
+++ b/platform/daemon/src/knowledge-navigation.test.ts
@@ -75,7 +75,7 @@ describe("knowledge graph navigation", () => {
 		dbPath = "";
 	});
 
-	test("walks entity -> aspect -> group -> claim -> attributes", () => {
+	test("walks entity -> aspect -> group -> claim -> attributes", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 		seedEntity();
@@ -107,10 +107,10 @@ describe("knowledge graph navigation", () => {
 			content: "Nicholai has no known shellfish allergy.",
 		});
 
-		const aspects = getEntityAspectsByName(getDbAccessor(), { agentId: "default", entity: "Nicholai" });
+		const aspects = await getEntityAspectsByName(getDbAccessor(), { agentId: "default", entity: "Nicholai" });
 		expect(aspects?.items.map((item) => item.aspect.canonicalName)).toEqual(["food"]);
 
-		const groups = listEntityGroups(getDbAccessor(), {
+		const groups = await listEntityGroups(getDbAccessor(), {
 			agentId: "default",
 			entity: "Nicholai",
 			aspect: "food",
@@ -118,7 +118,7 @@ describe("knowledge graph navigation", () => {
 		expect(groups?.items.map((item) => item.groupKey)).toEqual(["restaurants", "dietary_constraints"]);
 		expect(groups?.items[0]?.claimCount).toBe(2);
 
-		const claims = listEntityClaims(getDbAccessor(), {
+		const claims = await listEntityClaims(getDbAccessor(), {
 			agentId: "default",
 			entity: "Nicholai",
 			aspect: "food",
@@ -132,7 +132,7 @@ describe("knowledge graph navigation", () => {
 		expect(claims?.items[0]?.supersededCount).toBe(1);
 		expect(claims?.items[0]?.preview).toBe("Nicholai currently prefers Temaki Den.");
 
-		const active = listEntityAttributesByPath(getDbAccessor(), {
+		const active = await listEntityAttributesByPath(getDbAccessor(), {
 			agentId: "default",
 			entity: "Nicholai",
 			aspect: "food",
@@ -143,7 +143,7 @@ describe("knowledge graph navigation", () => {
 		});
 		expect(active?.items.map((item) => item.content)).toEqual(["Nicholai currently prefers Temaki Den."]);
 
-		const all = listEntityAttributesByPath(getDbAccessor(), {
+		const all = await listEntityAttributesByPath(getDbAccessor(), {
 			agentId: "default",
 			entity: "Nicholai",
 			aspect: "food",
@@ -156,7 +156,7 @@ describe("knowledge graph navigation", () => {
 		expect(all?.items.map((item) => item.status)).toEqual(["active", "superseded"]);
 	});
 
-	test("returns a compact tree for agent-visible graph browsing", () => {
+	test("returns a compact tree for agent-visible graph browsing", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 		seedEntity();
@@ -173,7 +173,7 @@ describe("knowledge graph navigation", () => {
 			content: "Nicholai has tried four Korean restaurants.",
 		});
 
-		const tree = getEntityKnowledgeTree(getDbAccessor(), {
+		const tree = await getEntityKnowledgeTree(getDbAccessor(), {
 			agentId: "default",
 			entity: "Nicholai",
 			maxAspects: 20,
@@ -193,7 +193,7 @@ describe("knowledge graph navigation", () => {
 		expect(tree?.items[0]?.groups[0]?.claims[0]?.preview).toBe("Nicholai currently prefers Temaki Den.");
 	});
 
-	test("tree depth can stop before claims", () => {
+	test("tree depth can stop before claims", async () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 		seedEntity();
@@ -204,7 +204,7 @@ describe("knowledge graph navigation", () => {
 			content: "Nicholai currently prefers Temaki Den.",
 		});
 
-		const tree = getEntityKnowledgeTree(getDbAccessor(), {
+		const tree = await getEntityKnowledgeTree(getDbAccessor(), {
 			agentId: "default",
 			entity: "Nicholai",
 			maxAspects: 20,

--- a/platform/daemon/src/memory-lineage.ts
+++ b/platform/daemon/src/memory-lineage.ts
@@ -14,6 +14,7 @@ import cl100k_base from "js-tiktoken/ranks/cl100k_base";
 import { getAgentScope } from "./agent-id";
 import { yieldEvery } from "./async-yield";
 import type { WriteDb } from "./db-accessor";
+import { runWriteTxAsync } from "./db-accessor";
 import { getDbAccessor } from "./db-accessor";
 import { EPISODIC_CAPTURED_AT_FLOOR, timestampMillis } from "./episodic-sources";
 import { logger } from "./logger";
@@ -723,20 +724,19 @@ function upsertArtifactRowInTx(
 	);
 }
 
-function upsertArtifactRow(
+async function upsertArtifactRow(
 	path: string,
 	frontmatter: Record<string, unknown>,
 	body: string,
 	sourceMtimeMs = statSync(path).mtimeMs,
 	options: { readonly trustSourcePath?: boolean; readonly trustNativeMarker?: boolean } = {},
-): void {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
+): Promise<void> {
+	await runWriteTxAsync(getDbAccessor(), (db) => {
 		upsertArtifactRowInTx(db as WriteDb as Database, path, frontmatter, body, sourceMtimeMs, options);
 	});
 }
 
-export function indexExternalMemoryArtifact(input: {
+export async function indexExternalMemoryArtifact(input: {
 	readonly agentId?: string;
 	readonly sourcePath: string;
 	readonly sourceKind: string;
@@ -750,11 +750,11 @@ export function indexExternalMemoryArtifact(input: {
 	readonly sourceExternalId?: string | null;
 	readonly sourceParentPath?: string | null;
 	readonly sourceMeta?: Readonly<Record<string, unknown>>;
-}): void {
+}): Promise<void> {
 	const capturedAt =
 		input.capturedAt ??
 		(Number.isFinite(input.sourceMtimeMs) ? new Date(input.sourceMtimeMs).toISOString() : new Date().toISOString());
-	upsertArtifactRow(
+	await upsertArtifactRow(
 		input.sourcePath,
 		{
 			agent_id: input.agentId?.trim() || "default",
@@ -784,7 +784,7 @@ export function indexExternalMemoryArtifact(input: {
 	);
 }
 
-export function indexCanonicalTranscriptJsonl(input: {
+export async function indexCanonicalTranscriptJsonl(input: {
 	readonly agentId: string;
 	readonly sessionId: string;
 	readonly sessionKey: string | null;
@@ -795,12 +795,12 @@ export function indexCanonicalTranscriptJsonl(input: {
 	readonly endedAt: string | null;
 	readonly transcript: string;
 	readonly manifestPath: string;
-}): void {
+}): Promise<void> {
 	const transcriptPath = canonicalTranscriptRelativePath(input.harness);
 	const sessionToken = deriveSessionToken(input.agentId, input.sessionId);
 	const content = normalizeMarkdownBody(input.transcript);
 	const path = join(getAgentsDir(), transcriptPath);
-	upsertArtifactRow(
+	await upsertArtifactRow(
 		path,
 		{
 			agent_id: input.agentId,
@@ -839,15 +839,14 @@ async function listCanonicalFiles(): Promise<string[]> {
 		.sort();
 }
 
-export function softDeleteArtifactRowsForPath(
+export async function softDeleteArtifactRowsForPath(
 	path: string,
 	agentId: string | null,
 	deletedAt = new Date().toISOString(),
-): void {
+): Promise<void> {
 	const sourcePath = relativePath(path);
 	const absolutePath = path.replace(/\\/g, "/");
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
+	await runWriteTxAsync(getDbAccessor(), (db) => {
 		const markDeleted = db.prepare(
 			`UPDATE memory_artifacts
 			 SET is_deleted = 1, deleted_at = ?, updated_at = ?
@@ -880,9 +879,8 @@ function deleteArtifactRowsForPathInTx(db: Database, path: string, agentId: stri
 	db.prepare("DELETE FROM memory_artifacts WHERE source_path = ?").run(absolutePath);
 }
 
-export function deleteArtifactRowsForPath(path: string, agentId: string | null): void {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
+export async function deleteArtifactRowsForPath(path: string, agentId: string | null): Promise<void> {
+	await runWriteTxAsync(getDbAccessor(), (db) => {
 		deleteArtifactRowsForPathInTx(db as WriteDb as Database, path, agentId);
 	});
 }
@@ -947,11 +945,10 @@ async function doReindex(agentId?: string): Promise<void> {
 			if (item.markChanged) changedPaths.add(item.path);
 		}
 	};
-	const flushUpsertBatch = (): boolean => {
+	const flushUpsertBatch = async (): Promise<boolean> => {
 		if (pendingUpserts.length === 0) return false;
 		const batch = [...pendingUpserts];
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
+		await runWriteTxAsync(getDbAccessor(), (db) => {
 			for (const item of batch) {
 				upsertArtifactRowInTx(db as WriteDb as Database, item.path, item.frontmatter, item.body, item.mtime);
 			}
@@ -960,11 +957,10 @@ async function doReindex(agentId?: string): Promise<void> {
 		commitBatchCacheUpserts(batch);
 		return true;
 	};
-	const flushDeleteBatch = (): boolean => {
+	const flushDeleteBatch = async (): Promise<boolean> => {
 		if (pendingDeletes.length === 0) return false;
 		const batch = [...pendingDeletes];
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
+		await runWriteTxAsync(getDbAccessor(), (db) => {
 			for (const item of batch) {
 				deleteArtifactRowsForPathInTx(db as WriteDb as Database, item.path, scope);
 			}
@@ -976,8 +972,7 @@ async function doReindex(agentId?: string): Promise<void> {
 	lastChangedManifestsByAgent.delete(cacheKey);
 
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const ready = getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
+		const ready = await getDbAccessor().withReadDbAsync(async (db) => {
 			const row = db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_artifacts'`).get();
 			return row !== undefined;
 		});
@@ -993,8 +988,7 @@ async function doReindex(agentId?: string): Promise<void> {
 	if (cache.size === 0) {
 		// Seed from DB state too so files deleted while daemon was down get
 		// detected, while unchanged files can skip a full reread on restart.
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const dbPaths = getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
+		const dbPaths = await getDbAccessor().withReadDbAsync(async (db) => {
 			const rows = scope
 				? (db
 						.prepare("SELECT source_path, source_mtime_ms FROM memory_artifacts WHERE agent_id = ?")
@@ -1023,8 +1017,7 @@ async function doReindex(agentId?: string): Promise<void> {
 		}
 	}
 
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	const tombstones = getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
+	const tombstones = await getDbAccessor().withReadDbAsync(async (db) => {
 		const table = db
 			.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_artifact_tombstones'`)
 			.get();
@@ -1067,7 +1060,7 @@ async function doReindex(agentId?: string): Promise<void> {
 		const nextAgent = typeof parsed.frontmatter.agent_id === "string" ? parsed.frontmatter.agent_id : "default";
 		if (scope && nextAgent !== scope) {
 			pendingDeletes.push({ path, statKey, markChanged: false });
-			if (pendingDeletes.length >= REINDEX_BATCH_SIZE && flushDeleteBatch()) {
+			if (pendingDeletes.length >= REINDEX_BATCH_SIZE && (await flushDeleteBatch())) {
 				await yielder();
 			}
 			continue;
@@ -1076,7 +1069,7 @@ async function doReindex(agentId?: string): Promise<void> {
 		const sessionToken = match?.[1];
 		if (sessionToken && tombstones.has(sessionToken)) {
 			pendingDeletes.push({ path, statKey, markChanged: true });
-			if (pendingDeletes.length >= REINDEX_BATCH_SIZE && flushDeleteBatch()) {
+			if (pendingDeletes.length >= REINDEX_BATCH_SIZE && (await flushDeleteBatch())) {
 				await yielder();
 			}
 			continue;
@@ -1084,13 +1077,13 @@ async function doReindex(agentId?: string): Promise<void> {
 		const body = normalizeMarkdownBody(parsed.body);
 		if (!isValidArtifact(path, parsed.frontmatter, body)) {
 			pendingDeletes.push({ path, statKey, markChanged: true });
-			if (pendingDeletes.length >= REINDEX_BATCH_SIZE && flushDeleteBatch()) {
+			if (pendingDeletes.length >= REINDEX_BATCH_SIZE && (await flushDeleteBatch())) {
 				await yielder();
 			}
 			continue;
 		}
 		pendingUpserts.push({ path, frontmatter: parsed.frontmatter, body, mtime, statKey, markChanged: true });
-		if (pendingUpserts.length >= REINDEX_BATCH_SIZE && flushUpsertBatch()) {
+		if (pendingUpserts.length >= REINDEX_BATCH_SIZE && (await flushUpsertBatch())) {
 			await yielder();
 		}
 	}
@@ -1099,15 +1092,15 @@ async function doReindex(agentId?: string): Promise<void> {
 		if (fileSet.has(path)) continue;
 		if (path.includes(".jsonl#")) continue;
 		pendingDeletes.push({ path, statKey: null, markChanged: true });
-		if (pendingDeletes.length >= REINDEX_BATCH_SIZE && flushDeleteBatch()) {
+		if (pendingDeletes.length >= REINDEX_BATCH_SIZE && (await flushDeleteBatch())) {
 			await yielder();
 		}
 	}
 
-	if (flushUpsertBatch()) {
+	if (await flushUpsertBatch()) {
 		await yielder();
 	}
-	if (flushDeleteBatch()) {
+	if (await flushDeleteBatch()) {
 		await yielder();
 	}
 	// Commit cache-only items (no DB dependency — safe to apply unconditionally).
@@ -1158,7 +1151,7 @@ function isValidArtifact(path: string, frontmatter: Record<string, unknown>, bod
 	return rel.startsWith("memory/") && rel.endsWith(`--${kind}.md`);
 }
 
-function ensureManifestRecord(seed: {
+async function ensureManifestRecord(seed: {
 	readonly agentId: string;
 	readonly sessionId: string;
 	readonly sessionKey: string | null;
@@ -1168,7 +1161,7 @@ function ensureManifestRecord(seed: {
 	readonly startedAt: string | null;
 	readonly endedAt: string | null;
 	readonly sessionToken: string;
-}): ManifestState {
+}): Promise<ManifestState> {
 	const path = artifactPath(seed.capturedAt, seed.sessionToken, "manifest");
 	const transcriptPath = relativeArtifactPath(seed.capturedAt, seed.sessionToken, "transcript");
 	const canonicalPath = seed.harness ? canonicalTranscriptRelativePath(seed.harness) : null;
@@ -1202,7 +1195,7 @@ function ensureManifestRecord(seed: {
 	if (!manifest) {
 		throw new Error(`Failed to create manifest ${path}`);
 	}
-	upsertArtifactRow(path, manifest.frontmatter, manifest.body);
+	await upsertArtifactRow(path, manifest.frontmatter, manifest.body);
 	return manifest;
 }
 
@@ -1231,11 +1224,11 @@ async function saveManifestAsyncUnlocked(
 	try {
 		sourceMtimeMs = (await stat(path)).mtimeMs;
 	} catch {}
-	upsertArtifactRow(path, manifest.frontmatter, manifest.body, sourceMtimeMs);
+	await upsertArtifactRow(path, manifest.frontmatter, manifest.body, sourceMtimeMs);
 	return manifest;
 }
 
-function findExistingManifest(agentId: string, sessionId: string): ManifestState | null {
+async function findExistingManifest(agentId: string, sessionId: string): Promise<ManifestState | null> {
 	try {
 		// Pre-fix rows stored session_id verbatim from the caller (equal to
 		// session_key). New rows use a derived session_id (e.g. "session-end:
@@ -1243,9 +1236,8 @@ function findExistingManifest(agentId: string, sessionId: string): ManifestState
 		// a separate session_key fallback is unnecessary because pre-fix rows
 		// match on session_id directly (it was persisted as the session_key
 		// value) and new rows have a unique derived session_id.
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const row = getDbAccessor().withReadDb(
-			(db: import("./db-accessor").ReadDb) =>
+		const row = await getDbAccessor().withReadDbAsync(
+			async (db) =>
 				db
 					.prepare(
 						`SELECT source_path
@@ -1268,7 +1260,7 @@ function manifestValue(frontmatter: Record<string, unknown>, key: string): strin
 	return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
-export function ensureCanonicalManifest(seed: {
+export async function ensureCanonicalManifest(seed: {
 	readonly agentId: string;
 	readonly sessionId: string;
 	readonly sessionKey: string | null;
@@ -1277,10 +1269,10 @@ export function ensureCanonicalManifest(seed: {
 	readonly capturedAt: string;
 	readonly startedAt: string | null;
 	readonly endedAt: string | null;
-}): ManifestState {
-	const existing = findExistingManifest(seed.agentId, seed.sessionId);
+}): Promise<ManifestState> {
+	const existing = await findExistingManifest(seed.agentId, seed.sessionId);
 	if (existing) return existing;
-	return ensureManifestRecord({
+	return await ensureManifestRecord({
 		...seed,
 		sessionToken: deriveSessionToken(seed.agentId, seed.sessionId),
 	});
@@ -1477,7 +1469,7 @@ export async function writeTranscriptArtifact(params: {
 	readonly transcript: string;
 	readonly summaryStatus?: "pending" | "skipped" | "not_requested";
 }): Promise<{ readonly manifestPath: string; readonly transcriptPath: string }> {
-	const manifest = ensureCanonicalManifest(params);
+	const manifest = await ensureCanonicalManifest(params);
 	const sessionToken = deriveSessionToken(params.agentId, params.sessionId);
 	const body = sanitizeTranscriptV1(params.transcript);
 	const sentence = {
@@ -1502,7 +1494,7 @@ export async function writeTranscriptArtifact(params: {
 		body,
 	});
 	const parsed = parseFrontmatterDocument(readFileSync(fullPath, "utf8"));
-	upsertArtifactRow(fullPath, parsed.frontmatter, normalizeMarkdownBody(parsed.body));
+	await upsertArtifactRow(fullPath, parsed.frontmatter, normalizeMarkdownBody(parsed.body));
 	await updateManifest(manifest.path, (frontmatter) => {
 		const existingSummaryStatus = manifestValue(frontmatter, "summary_status");
 		const terminalSummaryStatus =
@@ -1541,7 +1533,7 @@ export async function writeSummaryArtifact(params: {
 	readonly summary: string;
 	readonly provider?: LlmProvider | null;
 }): Promise<{ readonly manifestPath: string; readonly summaryPath: string }> {
-	const manifest = ensureCanonicalManifest(params);
+	const manifest = await ensureCanonicalManifest(params);
 	const capturedAt = manifestValue(manifest.frontmatter, "captured_at") ?? params.capturedAt;
 	const sessionToken = deriveSessionToken(params.agentId, params.sessionId);
 	const body = normalizeMarkdownBody(params.summary);
@@ -1563,7 +1555,7 @@ export async function writeSummaryArtifact(params: {
 		body,
 	});
 	const parsed = parseFrontmatterDocument(readFileSync(fullPath, "utf8"));
-	upsertArtifactRow(fullPath, parsed.frontmatter, normalizeMarkdownBody(parsed.body));
+	await upsertArtifactRow(fullPath, parsed.frontmatter, normalizeMarkdownBody(parsed.body));
 	await updateManifest(manifest.path, (frontmatter) => ({
 		...frontmatter,
 		summary_path: relativePath(fullPath),
@@ -1587,7 +1579,7 @@ export async function writeCompactionArtifact(params: {
 	readonly summary: string;
 	readonly provider?: LlmProvider | null;
 }): Promise<{ readonly manifestPath: string; readonly compactionPath: string }> {
-	const manifest = ensureCanonicalManifest(params);
+	const manifest = await ensureCanonicalManifest(params);
 	// A compaction is a new immutable event even when it belongs to an existing
 	// session. Its path must use this event's capture time, not the session
 	// manifest's original capture time, or a later compaction would attempt to
@@ -1613,7 +1605,7 @@ export async function writeCompactionArtifact(params: {
 		body,
 	});
 	const parsed = parseFrontmatterDocument(readFileSync(fullPath, "utf8"));
-	upsertArtifactRow(fullPath, parsed.frontmatter, normalizeMarkdownBody(parsed.body));
+	await upsertArtifactRow(fullPath, parsed.frontmatter, normalizeMarkdownBody(parsed.body));
 	await updateManifest(manifest.path, (frontmatter) => ({
 		...frontmatter,
 		compaction_path: relativePath(fullPath),
@@ -1649,56 +1641,47 @@ function buildTemporalIndex(
 	});
 }
 
-function readThreadHeads(agentId: string): ReadonlyArray<{
-	readonly label: string;
-	readonly source_type: string;
-	readonly latest_at: string;
-	readonly sample: string;
-	readonly node_id: string;
-	readonly project: string | null;
-	readonly session_key: string | null;
-	readonly harness: string | null;
-}> {
+async function readThreadHeads(agentId: string): Promise<
+	ReadonlyArray<{
+		readonly label: string;
+		readonly source_type: string;
+		readonly latest_at: string;
+		readonly sample: string;
+		readonly node_id: string;
+		readonly project: string | null;
+		readonly session_key: string | null;
+		readonly harness: string | null;
+	}>
+> {
 	try {
-		const rows: Array<{
-			label: string;
-			source_type: string;
-			latest_at: string;
-			sample: string;
-			node_id: string;
-			project: string | null;
-			session_key: string | null;
-			harness: string | null;
-		}> =
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
-				const queried = db
-					.prepare(
-						`SELECT label, source_type, latest_at, sample, node_id, project, session_key, harness
+		const rows = await getDbAccessor().withReadDbAsync(async (db) => {
+			const queried = db
+				.prepare(
+					`SELECT label, source_type, latest_at, sample, node_id, project, session_key, harness
 				 FROM memory_thread_heads
 				 WHERE agent_id = ?
 				 ORDER BY latest_at DESC
 				 LIMIT 12`,
-					)
-					.all(agentId) as Array<{
-					label: string;
-					source_type: string;
-					latest_at: string;
-					sample: string;
-					node_id: string;
-					project: string | null;
-					session_key: string | null;
-					harness: string | null;
-				}>;
-				return queried.filter((row) =>
-					isMemoryContentContextEligible(db, {
-						agentId,
-						sourceKind: "summary",
-						sourceId: row.node_id,
-						content: row.sample,
-					}),
-				);
-			});
+				)
+				.all(agentId) as Array<{
+				label: string;
+				source_type: string;
+				latest_at: string;
+				sample: string;
+				node_id: string;
+				project: string | null;
+				session_key: string | null;
+				harness: string | null;
+			}>;
+			return queried.filter((row) =>
+				isMemoryContentContextEligible(db, {
+					agentId,
+					sourceKind: "summary",
+					sourceId: row.node_id,
+					content: row.sample,
+				}),
+			);
+		});
 		return rows.filter(
 			(row) =>
 				!isNoiseSession({
@@ -1713,102 +1696,92 @@ function readThreadHeads(agentId: string): ReadonlyArray<{
 	}
 }
 
-function readTopMemories(agentId: string): ReadonlyArray<{
-	readonly content: string;
-	readonly type: string;
-	readonly importance: number;
-	readonly project: string | null;
-}> {
+async function readTopMemories(agentId: string): Promise<
+	ReadonlyArray<{
+		readonly content: string;
+		readonly type: string;
+		readonly importance: number;
+		readonly project: string | null;
+	}>
+> {
 	try {
 		const scope = getAgentScope(agentId);
 		const clause = buildAgentScopeClause(agentId, scope.readPolicy, scope.policyGroup);
-		const rows: Array<{ id: string; content: string; type: string; importance: number; project: string | null }> =
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
-				const queried = db
-					.prepare(
-						`SELECT m.id, m.content, m.type, m.importance, m.project
+		const rows = await getDbAccessor().withReadDbAsync(async (db) => {
+			const queried = db
+				.prepare(
+					`SELECT m.id, m.content, m.type, m.importance, m.project
 				 FROM memories m
 				 WHERE m.is_deleted = 0${clause.sql}
 				 ORDER BY m.pinned DESC, m.importance DESC, m.created_at DESC
 				 LIMIT 32`,
-					)
-					.all(...clause.args) as Array<{
-					id: string;
-					content: string;
-					type: string;
-					importance: number;
-					project: string | null;
-				}>;
-				return queried.filter((row) =>
-					isMemoryContentContextEligible(db, {
-						agentId,
-						sourceKind: "memory",
-						sourceId: row.id,
-						content: row.content,
-					}),
-				);
-			});
+				)
+				.all(...clause.args) as Array<{
+				id: string;
+				content: string;
+				type: string;
+				importance: number;
+				project: string | null;
+			}>;
+			return queried.filter((row) =>
+				isMemoryContentContextEligible(db, {
+					agentId,
+					sourceKind: "memory",
+					sourceId: row.id,
+					content: row.content,
+				}),
+			);
+		});
 		return rows.filter((row) => !isNoiseSession({ project: row.project })).slice(0, 8);
 	} catch {
 		return [];
 	}
 }
 
-function readTemporalNodes(agentId: string): ReadonlyArray<{
-	readonly id: string;
-	readonly kind: string;
-	readonly source_type: string;
-	readonly depth: number;
-	readonly latest_at: string;
-	readonly project: string | null;
-	readonly session_key: string | null;
-	readonly source_ref: string | null;
-	readonly content: string;
-}> {
+async function readTemporalNodes(agentId: string): Promise<
+	ReadonlyArray<{
+		readonly id: string;
+		readonly kind: string;
+		readonly source_type: string;
+		readonly depth: number;
+		readonly latest_at: string;
+		readonly project: string | null;
+		readonly session_key: string | null;
+		readonly source_ref: string | null;
+		readonly content: string;
+	}>
+> {
 	try {
-		const rows: Array<{
-			id: string;
-			kind: string;
-			source_type: string;
-			depth: number;
-			latest_at: string;
-			project: string | null;
-			session_key: string | null;
-			source_ref: string | null;
-			content: string;
-		}> =
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
-				const queried = db
-					.prepare(
-						`SELECT id, kind, COALESCE(source_type, kind) AS source_type, depth, latest_at,
+		const rows = await getDbAccessor().withReadDbAsync(async (db) => {
+			const queried = db
+				.prepare(
+					`SELECT id, kind, COALESCE(source_type, kind) AS source_type, depth, latest_at,
 				        project, session_key, source_ref, content
 				 FROM session_summaries
 				 WHERE agent_id = ?
 				 ORDER BY latest_at DESC
 				 LIMIT 20`,
-					)
-					.all(agentId) as Array<{
-					id: string;
-					kind: string;
-					source_type: string;
-					depth: number;
-					latest_at: string;
-					project: string | null;
-					session_key: string | null;
-					source_ref: string | null;
-					content: string;
-				}>;
-				return queried.filter((row) =>
-					isMemoryContentContextEligible(db, {
-						agentId,
-						sourceKind: "summary",
-						sourceId: row.id,
-						content: row.content,
-					}),
-				);
-			});
+				)
+				.all(agentId) as Array<{
+				id: string;
+				kind: string;
+				source_type: string;
+				depth: number;
+				latest_at: string;
+				project: string | null;
+				session_key: string | null;
+				source_ref: string | null;
+				content: string;
+			}>;
+			return queried.filter((row) =>
+				isMemoryContentContextEligible(db, {
+					agentId,
+					sourceKind: "summary",
+					sourceId: row.id,
+					content: row.content,
+				}),
+			);
+		});
 		return rows.filter(
 			(row) =>
 				!isNoiseSession({
@@ -1862,13 +1835,12 @@ function membershipTs(rows: ReadonlyArray<ArtifactRow>): string {
 	return picked.ended_at ?? picked.captured_at;
 }
 
-function buildLedger(agentId: string): ReadonlyArray<LedgerSession> {
+async function buildLedger(agentId: string): Promise<ReadonlyArray<LedgerSession>> {
 	const now = Date.now();
 	const floor = now - 30 * 24 * 60 * 60 * 1000;
 	let rows: ArtifactRow[] = [];
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		rows = getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) =>
+		rows = await getDbAccessor().withReadDbAsync(async (db) =>
 			(
 				db
 					.prepare(
@@ -2138,10 +2110,10 @@ export async function renderMemoryProjection(agentId = "default"): Promise<{
 	await reindexMemoryArtifacts(agentId);
 	const changedManifests = lastChangedManifestsByAgent.get(agentId);
 	lastChangedManifestsByAgent.delete(agentId);
-	const memories = readTopMemories(agentId);
-	const threadHeads = readThreadHeads(agentId);
-	const nodes = readTemporalNodes(agentId);
-	const ledger = buildLedger(agentId);
+	const memories = await readTopMemories(agentId);
+	const threadHeads = await readThreadHeads(agentId);
+	const nodes = await readTemporalNodes(agentId);
+	const ledger = await buildLedger(agentId);
 	const indexBlock = buildTemporalIndex(nodes);
 
 	const globalLines =
@@ -2208,10 +2180,9 @@ export function appendSynthesisIndexBlock(content: string, indexBlock: string): 
 	return `${trimmed}\n\n${indexBlock.trim()}`;
 }
 
-export function removeCanonicalSession(agentId: string, sessionToken: string, reason: string): void {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	const rows: Array<{ source_path: string }> = getDbAccessor().withReadDb(
-		(db: import("./db-accessor").ReadDb) =>
+export async function removeCanonicalSession(agentId: string, sessionToken: string, reason: string): Promise<void> {
+	const rows = await getDbAccessor().withReadDbAsync(
+		async (db) =>
 			db
 				.prepare(
 					`SELECT source_path
@@ -2221,8 +2192,7 @@ export function removeCanonicalSession(agentId: string, sessionToken: string, re
 				.all(agentId, sessionToken) as Array<{ source_path: string }>,
 	);
 	const paths = rows.map((row) => row.source_path);
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
+	await runWriteTxAsync(getDbAccessor(), (db) => {
 		db.prepare(
 			`INSERT INTO memory_artifact_tombstones (
 				agent_id, session_token, removed_at, reason, removed_paths
@@ -2265,10 +2235,9 @@ function isNoiseArtifactGroup(
 	);
 }
 
-export function purgeCanonicalNoiseSessions(agentId: string, reason: string): number {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	const rows = getDbAccessor().withReadDb(
-		(db: import("./db-accessor").ReadDb) =>
+export async function purgeCanonicalNoiseSessions(agentId: string, reason: string): Promise<number> {
+	const rows = await getDbAccessor().withReadDbAsync(
+		async (db) =>
 			db
 				.prepare(
 					`SELECT session_token, session_id, session_key, project, harness
@@ -2305,7 +2274,7 @@ export function purgeCanonicalNoiseSessions(agentId: string, reason: string): nu
 	let count = 0;
 	for (const [sessionToken, group] of groups) {
 		if (!isNoiseArtifactGroup(group)) continue;
-		removeCanonicalSession(agentId, sessionToken, reason);
+		await removeCanonicalSession(agentId, sessionToken, reason);
 		count++;
 	}
 	return count;
@@ -2315,10 +2284,10 @@ function purgeScope(agentId: string): string {
 	return `${getAgentsDir()}\u0000${agentId}`;
 }
 
-export function purgeCanonicalNoiseSessionsOnce(agentId: string, reason: string): number {
+export async function purgeCanonicalNoiseSessionsOnce(agentId: string, reason: string): Promise<number> {
 	const key = purgeScope(agentId);
 	if (purgeSeen.has(key)) return 0;
-	const count = purgeCanonicalNoiseSessions(agentId, reason);
+	const count = await purgeCanonicalNoiseSessions(agentId, reason);
 	purgeSeen.add(key);
 	return count;
 }

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -26,7 +26,7 @@ import {
 	vectorSearch,
 } from "@signet/core";
 import { normalizeAndHashContent } from "./content-normalization";
-import { type ReadDb, getDbAccessor, prepareTypedStatement } from "./db-accessor";
+import { type ReadDb, getDbAccessor, runWriteTxAsync, prepareTypedStatement } from "./db-accessor";
 import type { EmbeddingRole } from "./embedding-profile";
 import { getLlmProvider } from "./llm";
 import { logger } from "./logger";
@@ -595,34 +595,32 @@ export function expandRecallKeywordQuery(raw: string): string {
 // Rehearsal boost (shared between traversal-primary and legacy paths)
 // ---------------------------------------------------------------------------
 
-function applyRehearsalBoost(
+async function applyRehearsalBoost(
 	scored: Array<{ id: string; score: number; source: string }>,
 	search: MemorySearchConfig,
 	freshness: { readonly enabled: boolean; readonly nowMs: number },
-): void {
+): Promise<void> {
 	const rehearsalEnabled = search.rehearsal_enabled && search.rehearsal_weight > 0;
 	const freshnessEnabled = freshness.enabled && search.temporal_prior_weight > 0;
 	if ((!rehearsalEnabled && !freshnessEnabled) || scored.length === 0) return;
 	try {
 		const ids = scored.map((s) => s.id);
 		const placeholders = ids.map(() => "?").join(", ");
-		const accessRows: Array<{ id: string; access_count: number; last_accessed: string | null; created_at: string }> =
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			getDbAccessor().withReadDb(
-				(db: import("./db-accessor").ReadDb) =>
-					db
-						.prepare(
-							`SELECT id, access_count, last_accessed, created_at
+		const accessRows = await getDbAccessor().withReadDbAsync(
+			async (db) =>
+				db
+					.prepare(
+						`SELECT id, access_count, last_accessed, created_at
 						 FROM memories
 						 WHERE id IN (${placeholders})`,
-						)
-						.all(...ids) as Array<{
-						id: string;
-						access_count: number;
-						last_accessed: string | null;
-						created_at: string;
-					}>,
-			);
+					)
+					.all(...ids) as Array<{
+					id: string;
+					access_count: number;
+					last_accessed: string | null;
+					created_at: string;
+				}>,
+		);
 
 		const accessMap = new Map(accessRows.map((r) => [r.id, r]));
 		for (const s of scored) {
@@ -704,17 +702,16 @@ export function memoryLifecycleSql(
 	return ` AND ${alias}.is_deleted = 0${memorySupersessionSql(db, alias)}`;
 }
 
-function authorizeScoredCandidates(
+async function authorizeScoredCandidates(
 	scored: ReadonlyArray<{ id: string; score: number; source: string }>,
 	filter: FilterClause,
-): Array<{ id: string; score: number; source: string }> {
+): Promise<Array<{ id: string; score: number; source: string }>> {
 	// Candidate collectors intentionally cast a wide net. This is the single
 	// pre-content gate for database-backed memories: after this point the IDs
 	// are safe to use in stages that read content or mutate access metadata.
 	const ids = [...new Set(scored.map((row) => row.id))];
 	if (ids.length === 0) return [];
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	const allowed = getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
+	const allowed = await getDbAccessor().withReadDbAsync(async (db) => {
 		const hasSafetyLedger = memoryContentSafetyTableExists(db);
 		const safetySelect = hasSafetyLedger ? ", mcs.status AS safety_status, mcs.context_eligible" : "";
 		const safetyJoin = hasSafetyLedger
@@ -756,11 +753,10 @@ function authorizeScoredCandidates(
 	return scored.filter((row) => allowed.has(row.id));
 }
 
-function loadObservedScores(ids: readonly string[], agentId: string): Map<string, number> {
+async function loadObservedScores(ids: readonly string[], agentId: string): Promise<Map<string, number>> {
 	if (ids.length === 0) return new Map();
 	const placeholders = ids.map(() => "?").join(", ");
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
+	return await getDbAccessor().withReadDbAsync(async (db) => {
 		const rows = db
 			.prepare(
 				`SELECT memory_id, AVG(agent_relevance_score) AS score
@@ -788,11 +784,10 @@ function shortenCurrentnessContent(content: string): string {
 	return oneLine.length > 240 ? `${oneLine.slice(0, 237)}...` : oneLine;
 }
 
-function loadCurrentnessInfo(ids: readonly string[], agentId: string): Map<string, CurrentnessInfo> {
+async function loadCurrentnessInfo(ids: readonly string[], agentId: string): Promise<Map<string, CurrentnessInfo>> {
 	if (ids.length === 0) return new Map();
 	const placeholders = ids.map(() => "?").join(", ");
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	const rows = getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
+	const rows = await getDbAccessor().withReadDbAsync(async (db) => {
 		const queried = db
 			.prepare(
 				`SELECT
@@ -959,13 +954,13 @@ function sourceChunkRecallTags(hit: SourceChunkVectorHit): string {
 	return [provider, "source", hit.sourceType, "vector"].join(",");
 }
 
-function buildSourceChunkVectorHits(
+async function buildSourceChunkVectorHits(
 	queryVec: Float32Array | null,
 	existingSourceIds: ReadonlySet<string>,
 	limit: number,
 	agentId: string,
 	project?: string,
-): SourceChunkVectorHit[] {
+): Promise<SourceChunkVectorHit[]> {
 	if (!queryVec || limit <= 0) return [];
 	// Source chunk embeddings only carry agent_id plus an embedding source_id.
 	// The live artifact table carries project, but not the source root/id needed
@@ -973,8 +968,7 @@ function buildSourceChunkVectorHits(
 	// rescue path for project-scoped recall until the index has that strong key.
 	if (project) return [];
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		return getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
+		return await getDbAccessor().withReadDbAsync(async (db) => {
 			const hasAgentId = hasColumn(db, "embeddings", "agent_id");
 			const rows = db
 				.prepare(
@@ -1136,17 +1130,16 @@ export function transcriptExcerpt(content: string, query: string, maxChars = 650
 	return `${prefix}${clean.slice(start, end).trim()}${suffix}`;
 }
 
-function buildNativeArtifactRecallHits(
+async function buildNativeArtifactRecallHits(
 	params: RecallParams,
 	query: string,
 	existingSourceIds: ReadonlySet<string>,
-): NativeArtifactRecallHit[] {
+): Promise<NativeArtifactRecallHit[]> {
 	const fts = sanitizeFtsQuery(query);
 	if (fts.length === 0) return [];
 
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		return getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
+		return await getDbAccessor().withReadDbAsync(async (db) => {
 			const table = db
 				.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='memory_artifacts_fts'`)
 				.get();
@@ -1391,10 +1384,9 @@ export async function hybridRecall(
 		try {
 			const trackedIds = response.results.map((row) => row.id).filter((id) => !id.includes(":"));
 			if (params.trackRecallAccess !== false && trackedIds.length > 0) {
-				timings.time("access_tracking_update", () => {
+				timings.timeAsync("access_tracking_update", async () => {
 					const trackedPlaceholders = trackedIds.map(() => "?").join(", ");
-					// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-					getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
+					await runWriteTxAsync(getDbAccessor(), (db) => {
 						db.prepare(
 							`UPDATE memories
 							 SET last_accessed = datetime('now'), access_count = access_count + 1
@@ -1494,10 +1486,9 @@ export async function hybridRecall(
 		graphQueryTokens ??= tokenizeGraphQuery(query);
 		return graphQueryTokens;
 	};
-	const getFocalEntities = (agentId: string): ReturnType<typeof resolveFocalEntities> => {
+	const getFocalEntities = async (agentId: string): Promise<ReturnType<typeof resolveFocalEntities>> => {
 		if (focalCache?.agentId === agentId) return focalCache.value;
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const value = getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) =>
+		const value = await getDbAccessor().withReadDbAsync(async (db) =>
 			resolveFocalEntities(db, agentId, {
 				queryTokens: getGraphQueryTokens(),
 				includePinned: false,
@@ -1512,10 +1503,9 @@ export async function hybridRecall(
 	const hintMap = new Map<string, number>();
 	const traversalEvidenceMap = new Map<string, number>();
 	try {
-		timings.time("memory_fts", () => {
+		timings.timeAsync("memory_fts", async () => {
 			if (keywordQuery.length === 0) return;
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
+			await getDbAccessor().withReadDbAsync(async (db) => {
 				// CROSS JOIN keeps SQLite from scanning memories first via
 				// low-selectivity filters before applying the FTS rowid match.
 				const ftsRows = prepareTypedStatement<{ id: string; raw_score: number }>(
@@ -1553,10 +1543,9 @@ export async function hybridRecall(
 	// elevates its parent memory via Math.max (not additive stacking).
 	if (cfg.pipelineV2.hints?.enabled) {
 		try {
-			timings.time("hints_fts", () => {
+			timings.timeAsync("hints_fts", async () => {
 				if (keywordQuery.length === 0) return;
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-				getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
+				await getDbAccessor().withReadDbAsync(async (db) => {
 					// Keep memory_hints_fts first; the agent/scope indexes are much
 					// less selective than the FTS match on large workspaces.
 					const sql = `SELECT h.memory_id AS id, bm25(memory_hints_fts) AS raw_score
@@ -1615,9 +1604,8 @@ export async function hybridRecall(
 		const excludeAggregateRecall = params.aggregate === true || params.excludeAggregateRecallMemories === true;
 		const vecLimit = needsPostFilter || excludeAggregateRecall ? cfg.search.top_k * 2 : cfg.search.top_k;
 		try {
-			timings.time("vector_search", () => {
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-				getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
+			timings.timeAsync("vector_search", async () => {
+				await getDbAccessor().withReadDbAsync(async (db) => {
 					const vecResults = vectorSearch(db, queryVector, {
 						limit: vecLimit,
 						type: params.type,
@@ -1646,16 +1634,17 @@ export async function hybridRecall(
 	if (cfg.pipelineV2.graph.enabled) {
 		try {
 			const agentId = params.agentId ?? "default";
-			const candidates = timings.time("structured_path_candidates", () =>
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-				getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) =>
-					findStructuredPathCandidates(db, query, agentId, {
-						limit: cfg.search.top_k,
-						minScore,
-						filterSql: filter.sql,
-						filterArgs: filter.args,
-					}),
-				),
+			const candidates = await timings.timeAsync(
+				"structured_path_candidates",
+				async () =>
+					await getDbAccessor().withReadDbAsync(async (db) =>
+						findStructuredPathCandidates(db, query, agentId, {
+							limit: cfg.search.top_k,
+							minScore,
+							filterSql: filter.sql,
+							filterArgs: filter.args,
+						}),
+					),
 			);
 			for (const [id, score] of candidates) structuredCandidateMap.set(id, score);
 		} catch (e) {
@@ -1666,14 +1655,15 @@ export async function hybridRecall(
 		if (canUseOntologyClaimRecall(params) && temporalCandidateSet.size === 0 && !temporal.meta) {
 			try {
 				const agentId = params.agentId ?? "default";
-				ontologyClaimCandidates = timings.time("ontology_claim_candidates", () =>
-					// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-					getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) =>
-						findStructuredClaimCandidates(db, query, agentId, {
-							limit: cfg.search.top_k,
-							minScore,
-						}),
-					),
+				ontologyClaimCandidates = await timings.timeAsync(
+					"ontology_claim_candidates",
+					async () =>
+						await getDbAccessor().withReadDbAsync(async (db) =>
+							findStructuredClaimCandidates(db, query, agentId, {
+								limit: cfg.search.top_k,
+								minScore,
+							}),
+						),
 				);
 			} catch (e) {
 				logger.warn("memory", "Ontology claim candidate search failed (non-fatal)", {
@@ -1761,15 +1751,11 @@ export async function hybridRecall(
 					const queryTokens = getGraphQueryTokens();
 					if (queryTokens.length > 0) {
 						const agentId = params.agentId ?? "default";
-						const focal = getFocalEntities(agentId);
+						const focal = await getFocalEntities(agentId);
 
 						if (focal.entityIds.length > 0) {
-							const traversal = await traverseKnowledgeGraph(
-								focal.entityIds,
-								// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-								<T>(fn: (db: ReadDb) => T): T => getDbAccessor().withReadDb(fn),
-								agentId,
-								{
+							const traversal = await getDbAccessor().withReadDbAsync(async (db) =>
+								traverseKnowledgeGraph(focal.entityIds, db, agentId, {
 									maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
 									maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,
 									maxDependencyHops: traversalCfg.maxDependencyHops,
@@ -1779,7 +1765,7 @@ export async function hybridRecall(
 									minConfidence: traversalCfg.minConfidence,
 									timeoutMs: traversalCfg.timeoutMs,
 									scope: params.scope,
-								},
+								}),
 							);
 
 							// Cosine re-scoring: when query embedding is available,
@@ -1791,9 +1777,8 @@ export async function hybridRecall(
 							if (queryVecF32 && traversal.memoryScores.size > 0) {
 								const ids = [...traversal.memoryScores.keys()];
 								const ph = ids.map(() => "?").join(", ");
-								// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-								const embRows = getDbAccessor().withReadDb(
-									(db: import("./db-accessor").ReadDb) =>
+								const embRows = await getDbAccessor().withReadDbAsync(
+									async (db) =>
 										db
 											.prepare(
 												`SELECT source_id, vector FROM embeddings
@@ -1876,11 +1861,12 @@ export async function hybridRecall(
 		// --- Graph boost: pull up memories linked via knowledge graph ---
 		if (cfg.pipelineV2.graph.enabled && cfg.pipelineV2.graph.boostWeight > 0) {
 			try {
-				const graphResult = timings.time("graph_boost", () =>
-					// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-					getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) =>
-						getGraphBoostIds(query, db, cfg.pipelineV2.graph.boostTimeoutMs, params.agentId),
-					),
+				const graphResult = await timings.timeAsync(
+					"graph_boost",
+					async () =>
+						await getDbAccessor().withReadDbAsync(async (db) =>
+							getGraphBoostIds(query, db, cfg.pipelineV2.graph.boostTimeoutMs, params.agentId),
+						),
 				);
 				if (graphResult.graphLinkedIds.size > 0) {
 					const gw = cfg.pipelineV2.graph.boostWeight;
@@ -1907,15 +1893,11 @@ export async function hybridRecall(
 					const queryTokens = getGraphQueryTokens();
 					if (traversalCfg && queryTokens.length > 0) {
 						const agentId = params.agentId ?? "default";
-						const focal = getFocalEntities(agentId);
+						const focal = await getFocalEntities(agentId);
 
 						if (focal.entityIds.length > 0) {
-							const traversal = await traverseKnowledgeGraph(
-								focal.entityIds,
-								// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-								<T>(fn: (db: ReadDb) => T): T => getDbAccessor().withReadDb(fn),
-								agentId,
-								{
+							const traversal = await getDbAccessor().withReadDbAsync(async (db) =>
+								traverseKnowledgeGraph(focal.entityIds, db, agentId, {
 									maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
 									maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,
 									maxDependencyHops: traversalCfg.maxDependencyHops,
@@ -1924,7 +1906,7 @@ export async function hybridRecall(
 									maxTraversalPaths: traversalCfg.maxTraversalPaths,
 									minConfidence: traversalCfg.minConfidence,
 									timeoutMs: traversalCfg.timeoutMs,
-								},
+								}),
 							);
 
 							const tw = traversalCfg.boostWeight;
@@ -1943,9 +1925,8 @@ export async function hybridRecall(
 
 							if (missingIds.length > 0) {
 								const placeholders = missingIds.map(() => "?").join(", ");
-								// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-								const baseRows = getDbAccessor().withReadDb(
-									(db: import("./db-accessor").ReadDb) =>
+								const baseRows = await getDbAccessor().withReadDbAsync(
+									async (db) =>
 										db
 											.prepare(
 												`SELECT
@@ -2013,7 +1994,7 @@ export async function hybridRecall(
 	}
 
 	if (scored.length > 0) {
-		scored = timings.time("authorize_candidates", () => authorizeScoredCandidates(scored, filter));
+		scored = await authorizeScoredCandidates(scored, filter);
 	}
 
 	// Everything below this point may assume `scored` only contains memory IDs
@@ -2025,9 +2006,8 @@ export async function hybridRecall(
 			const candidateIds = scored.filter((row) => temporalCandidateSet.has(row.id)).map((row) => row.id);
 			if (candidateIds.length > 0) {
 				const placeholders = candidateIds.map(() => "?").join(", ");
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-				const contentRows = getDbAccessor().withReadDb(
-					(db: import("./db-accessor").ReadDb) =>
+				const contentRows = await getDbAccessor().withReadDbAsync(
+					async (db) =>
 						db
 							.prepare(
 								`SELECT id, content FROM memories
@@ -2071,8 +2051,7 @@ export async function hybridRecall(
 			const candidates = [...byId.values()];
 			try {
 				const agentId = params.agentId ?? "default";
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-				const structured = getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) =>
+				const structured = await getDbAccessor().withReadDbAsync(async (db) =>
 					scoreStructuredPathEvidence(
 						db,
 						candidates.map((row) => row.id),
@@ -2106,9 +2085,8 @@ export async function hybridRecall(
 				let contentMap = new Map<string, string>();
 				if (coverageIds.length > 0) {
 					const placeholders = coverageIds.map(() => "?").join(", ");
-					// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-					const contentRows: Array<{ id: string; content: string }> = getDbAccessor().withReadDb(
-						(db: import("./db-accessor").ReadDb) =>
+					const contentRows = await getDbAccessor().withReadDbAsync(
+						async (db) =>
 							db
 								.prepare(
 									`SELECT id, content FROM memories
@@ -2153,9 +2131,8 @@ export async function hybridRecall(
 			const rerankPlaceholders = rerankIds.map(() => "?").join(", ");
 
 			// Fetch content for reranker — cross-encoders need document text
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const contentRows: Array<{ id: string; content: string }> = getDbAccessor().withReadDb(
-				(db: import("./db-accessor").ReadDb) =>
+			const contentRows = await getDbAccessor().withReadDbAsync(
+				async (db) =>
 					db
 						.prepare(
 							`SELECT id, content FROM memories
@@ -2227,9 +2204,8 @@ export async function hybridRecall(
 			const dampenPh = dampenIds.map(() => "?").join(", ");
 
 			// Fetch content + type for dampening analysis
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const dampenRows: Array<{ id: string; content: string; type: string }> = getDbAccessor().withReadDb(
-				(db: import("./db-accessor").ReadDb) =>
+			const dampenRows = await getDbAccessor().withReadDbAsync(
+				async (db) =>
 					db
 						.prepare(
 							`SELECT id, content, type FROM memories
@@ -2248,9 +2224,8 @@ export async function hybridRecall(
 			const degrees = new Map<string, number>();
 
 			if (cfg.pipelineV2.graph.enabled) {
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-				const links = getDbAccessor().withReadDb(
-					(db: import("./db-accessor").ReadDb) =>
+				const links = await getDbAccessor().withReadDbAsync(
+					async (db) =>
 						db
 							.prepare(
 								`SELECT memory_id, entity_id FROM memory_entity_mentions
@@ -2277,9 +2252,8 @@ export async function hybridRecall(
 				if (entityIds.size > 0) {
 					const eidList = [...entityIds];
 					const eidPh = eidList.map(() => "?").join(", ");
-					// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-					const degreeRows = getDbAccessor().withReadDb(
-						(db: import("./db-accessor").ReadDb) =>
+					const degreeRows = await getDbAccessor().withReadDbAsync(
+						async (db) =>
 							db
 								.prepare(
 									`SELECT entity_id, COUNT(*) AS cnt
@@ -2339,7 +2313,7 @@ export async function hybridRecall(
 	if (scored.length > 0) {
 		const currentnessStart = performance.now();
 		try {
-			currentness = loadCurrentnessInfo(
+			currentness = await loadCurrentnessInfo(
 				scored.map((row) => row.id),
 				params.agentId ?? "default",
 			);
@@ -2353,7 +2327,7 @@ export async function hybridRecall(
 		}
 	}
 
-	timings.time("final_rank", () => {
+	await timings.timeAsync("final_rank", async () => {
 		if (temporalCandidateSet.size > 0) {
 			scored = scored.filter((row) => {
 				if (!temporalCandidateSet.has(row.id)) return false;
@@ -2373,7 +2347,7 @@ export async function hybridRecall(
 				(structuredEvidenceMap.get(row.id) ?? 0) > 0;
 			if (row.source === "hint" && !hasDirectEvidence) row.score = Math.min(row.score, HINT_ONLY_SCORE_CAP);
 		}
-		const observedScores = loadObservedScores(
+		const observedScores = await loadObservedScores(
 			scored.map((row) => row.id),
 			params.agentId ?? "default",
 		);
@@ -2405,14 +2379,16 @@ export async function hybridRecall(
 		const results = suppressPreviouslyRecalledForSelection(ontologyClaimResults).slice(0, limit);
 		const fallbackLimit = selectionDedupeEnabled ? Math.max(limit * 3, limit + 10) : limit;
 		const sourceChunkHits = allowSourceFallbacks
-			? timings.time("source_chunk_vector_fallback", () =>
-					buildSourceChunkVectorHits(
-						queryVecF32,
-						new Set(),
-						fallbackLimit,
-						params.agentId ?? "default",
-						params.project,
-					),
+			? await timings.timeAsync(
+					"source_chunk_vector_fallback",
+					async () =>
+						await buildSourceChunkVectorHits(
+							queryVecF32,
+							new Set(),
+							fallbackLimit,
+							params.agentId ?? "default",
+							params.project,
+						),
 				)
 			: [];
 		if (sourceChunkHits.length > 0 && results.length < limit) {
@@ -2447,7 +2423,10 @@ export async function hybridRecall(
 			}
 		}
 		const nativeHits = allowSourceFallbacks
-			? timings.time("native_artifact_fallback", () => buildNativeArtifactRecallHits(params, expandedQuery, new Set()))
+			? await timings.timeAsync(
+					"native_artifact_fallback",
+					async () => await buildNativeArtifactRecallHits(params, expandedQuery, new Set()),
+				)
 			: [];
 		if (nativeHits.length > 0 && results.length < limit) {
 			const nativeResults = suppressPreviouslyRecalledForSelection(
@@ -2504,74 +2483,45 @@ export async function hybridRecall(
 	// authorization so no alternate path can widen access.
 	const placeholders = topIds.map(() => "?").join(", ");
 
-	const rows: Array<{
-		id: string;
-		content: string;
-		source_id: string | null;
-		type: string;
-		tags: string | null;
-		pinned: number;
-		importance: number;
-		who: string;
-		project: string | null;
-		created_at: string;
-		visibility: string | null;
-		scope: string | null;
-		agent_id: string | null;
-	}> = timings.time("hydrate_memory_rows", () =>
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		getDbAccessor().withReadDb(
-			(db: import("./db-accessor").ReadDb) =>
-				db
-					.prepare(
-						`SELECT m.id, m.content, m.source_id, m.type, m.tags, m.pinned, m.importance, m.who, m.project, m.created_at, m.visibility, m.scope, m.agent_id
+	const rows = await timings.timeAsync(
+		"hydrate_memory_rows",
+		async () =>
+			await getDbAccessor().withReadDbAsync(
+				async (db) =>
+					db
+						.prepare(
+							`SELECT m.id, m.content, m.source_id, m.type, m.tags, m.pinned, m.importance, m.who, m.project, m.created_at, m.visibility, m.scope, m.agent_id
         FROM memories m
         WHERE m.id IN (${placeholders}) AND m.is_deleted = 0${memorySupersessionSql(db)}${filter.sql}`,
-					)
-					.all(...topIds, ...filter.args) as Array<{
-					id: string;
-					content: string;
-					source_id: string | null;
-					type: string;
-					tags: string | null;
-					pinned: number;
-					importance: number;
-					who: string;
-					project: string | null;
-					created_at: string;
-					visibility: string | null;
-					scope: string | null;
-					agent_id: string | null;
-				}>,
-		),
+						)
+						.all(...topIds, ...filter.args) as Array<{
+						id: string;
+						content: string;
+						source_id: string | null;
+						type: string;
+						tags: string | null;
+						pinned: number;
+						importance: number;
+						who: string;
+						project: string | null;
+						created_at: string;
+						visibility: string | null;
+						scope: string | null;
+						agent_id: string | null;
+					}>,
+			),
 	);
 
-	const safeRows: Array<{
-		id: string;
-		content: string;
-		source_id: string | null;
-		type: string;
-		tags: string | null;
-		pinned: number;
-		importance: number;
-		who: string;
-		project: string | null;
-		created_at: string;
-		visibility: string | null;
-		scope: string | null;
-		agent_id: string | null;
-	}> =
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) =>
-			rows.filter((row) =>
-				isMemoryContentContextEligible(db, {
-					agentId: row.agent_id?.trim() || "default",
-					sourceKind: "memory",
-					sourceId: row.id,
-					content: row.content,
-				}),
-			),
-		);
+	const safeRows = await getDbAccessor().withReadDbAsync(async (db) =>
+		rows.filter((row) =>
+			isMemoryContentContextEligible(db, {
+				agentId: row.agent_id?.trim() || "default",
+				sourceKind: "memory",
+				sourceId: row.id,
+				content: row.content,
+			}),
+		),
+	);
 	const rowMap = new Map(safeRows.map((r) => [r.id, r]));
 	// No pre-decrement: always fetch `limit` memories. The summary card is
 	// injected after assembly and the array is capped to `limit` at that point.
@@ -2621,14 +2571,16 @@ export async function hybridRecall(
 		const existingSourceIds = new Set(results.map((row) => row.source_id).filter((id): id is string => !!id));
 		const fill = limit - results.length;
 		const sourceChunkHits = allowSourceFallbacks
-			? timings.time("source_chunk_vector_supplement", () =>
-					buildSourceChunkVectorHits(
-						queryVecF32,
-						existingSourceIds,
-						selectionDedupeEnabled ? Math.max(fill * 3, fill + 10) : fill,
-						params.agentId ?? "default",
-						params.project,
-					),
+			? await timings.timeAsync(
+					"source_chunk_vector_supplement",
+					async () =>
+						await buildSourceChunkVectorHits(
+							queryVecF32,
+							existingSourceIds,
+							selectionDedupeEnabled ? Math.max(fill * 3, fill + 10) : fill,
+							params.agentId ?? "default",
+							params.project,
+						),
 				)
 			: [];
 		const candidates = sourceChunkHits.map((hit): RecallResult => {
@@ -2664,7 +2616,7 @@ export async function hybridRecall(
 	if (results.length < limit) {
 		const existingSourceIds = new Set(results.map((row) => row.source_id).filter((id): id is string => !!id));
 		const nativeHits = allowSourceFallbacks
-			? timings.time("native_artifact_supplement", () =>
+			? await timings.timeAsync("native_artifact_supplement", () =>
 					buildNativeArtifactRecallHits(params, expandedQuery, existingSourceIds),
 				)
 			: [];
@@ -2756,8 +2708,7 @@ export async function hybridRecall(
 	if (decisionIds.length > 0 && cfg.pipelineV2.graph.enabled) {
 		const rationaleStart = performance.now();
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const supplementary = getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
+			const supplementary = await getDbAccessor().withReadDbAsync(async (db) => {
 				// Find entities linked to decision memories
 				const dPlaceholders = decisionIds.map(() => "?").join(", ");
 				const entityIds = db
@@ -2853,9 +2804,8 @@ export async function hybridRecall(
 			const queryTokens = getGraphQueryTokens();
 			if (queryTokens.length > 0) {
 				const agentId = params.agentId ?? "default";
-				const focal = getFocalEntities(agentId);
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-				const ctx = getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
+				const focal = await getFocalEntities(agentId);
+				const ctx = await getDbAccessor().withReadDbAsync(async (db) => {
 					if (focal.entityIds.length === 0) return null;
 
 					// Project/scope-constrained recall should not let broad focal
@@ -2961,8 +2911,7 @@ export async function hybridRecall(
 		try {
 			const agentId = params.agentId ?? "default";
 			const cap = Math.max(3, Math.ceil(limit * 0.3));
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const blocks = getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) =>
+			const blocks = await getDbAccessor().withReadDbAsync(async (db) =>
 				constructContextBlocks(db, agentId, focalEids, cap),
 			);
 			const now = new Date().toISOString();

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -508,7 +508,7 @@ describe("native memory sources", () => {
 		utimesSync(file, stamp, stamp);
 
 		expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(true);
-		removeNativeMemoryFile(source, file, "agent-native");
+		await removeNativeMemoryFile(source, file, "agent-native");
 		writeFileSync(file, "Codex remembered the same recreated file.\n");
 		utimesSync(file, stamp, stamp);
 
@@ -527,7 +527,7 @@ describe("native memory sources", () => {
 		writeFileSync(file, "# Smoke\n\nCodex remembered a soft deleted native artifact.\n");
 
 		expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(true);
-		removeNativeMemoryFile(source, file, "agent-native");
+		await removeNativeMemoryFile(source, file, "agent-native");
 
 		const row = getDbAccessor().withReadDb(
 			(db) =>
@@ -550,7 +550,7 @@ describe("native memory sources", () => {
 		writeFileSync(file, "# Smoke\n\nCodex remembered a restored native artifact.\n");
 
 		expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(true);
-		removeNativeMemoryFile(source, file, "agent-native");
+		await removeNativeMemoryFile(source, file, "agent-native");
 		expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(true);
 
 		const row = getDbAccessor().withReadDb(
@@ -1054,7 +1054,7 @@ describe("native memory sources", () => {
 		expect(before.entities).toBeGreaterThan(0);
 		expect(before.attrs).toBeGreaterThan(0);
 
-		removeNativeMemoryFile(source, file, "agent-native");
+		await removeNativeMemoryFile(source, file, "agent-native");
 
 		const after = getDbAccessor().withReadDb((db) => ({
 			artifacts: (
@@ -1261,7 +1261,7 @@ describe("native memory sources", () => {
 			true,
 		);
 
-		const purged = purgeNativeMemorySourceArtifacts(source, "agent-native");
+		const purged = await purgeNativeMemorySourceArtifacts(source, "agent-native");
 
 		expect(purged).toBeGreaterThanOrEqual(2);
 		const rows = getDbAccessor().withReadDb(
@@ -1290,7 +1290,7 @@ describe("native memory sources", () => {
 		expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(true);
 		expect(await indexNativeMemoryFile(siblingSource, siblingFile, "agent-native")).toBe(true);
 
-		const purged = purgeNativeMemorySourceArtifacts(source, "agent-native");
+		const purged = await purgeNativeMemorySourceArtifacts(source, "agent-native");
 
 		expect(purged).toBeGreaterThanOrEqual(1);
 		const remaining = getDbAccessor().withReadDb(
@@ -1314,7 +1314,7 @@ describe("native memory sources", () => {
 		expect(await indexNativeMemoryFile(source, fileA, "agent-a")).toBe(true);
 		expect(await indexNativeMemoryFile(source, fileB, "agent-b")).toBe(true);
 
-		const purged = purgeNativeMemorySourceArtifacts(source);
+		const purged = await purgeNativeMemorySourceArtifacts(source);
 
 		expect(purged).toBeGreaterThanOrEqual(2);
 		const remaining = getDbAccessor().withReadDb(

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -866,7 +866,7 @@ export async function indexNativeMemoryFile(
 			const provenanceRoot = source.sourceRoot ?? source.root;
 			const externalId =
 				obsidian || source.harness === "codex" || hermes ? sourceRelativePath(provenanceRoot, filePath) : null;
-			indexExternalMemoryArtifact({
+			await indexExternalMemoryArtifact({
 				agentId,
 				sourcePath: filePath,
 				sourceKind: pattern.kind,

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -13,7 +13,7 @@ import {
 } from "@signet/core";
 import { resolveDaemonAgentId } from "./agent-id";
 import { yieldEvery } from "./async-yield";
-import { getDbAccessor, type WriteDb } from "./db-accessor";
+import { getDbAccessor, runWriteTxAsync, type WriteDb } from "./db-accessor";
 import { EPISODIC_CAPTURED_AT_FLOOR, timestampMillis } from "./episodic-sources";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
@@ -565,7 +565,6 @@ async function withWriteTxAsync<T>(fn: (db: WriteDb) => T): Promise<T> {
 	if (!accessor.withWriteTxAsync) throw new Error("Async database writer is unavailable");
 	return accessor.withWriteTxAsync(fn);
 }
-
 async function nativeArtifactContentHash(filePath: string, agentId: string): Promise<string | null> {
 	const sourcePath = filePath.replace(/\\/g, "/");
 	try {
@@ -765,7 +764,7 @@ export async function indexNativeMemoryFile(
 			// artifact rows that desync the FTS index (#1142).
 			readFailureBackoffUntil.delete(key);
 			permissionDeniedPaths.delete(key);
-			removeNativeMemoryFile(source, filePath, agentId);
+			await removeNativeMemoryFile(source, filePath, agentId);
 			logger.debug("watcher", "Dropped vanished native memory artifact", {
 				harness: source.harness,
 				path: filePath,
@@ -815,7 +814,7 @@ export async function indexNativeMemoryFile(
 	readFailureBackoffUntil.delete(key);
 	permissionDeniedPaths.delete(key);
 	if (!content.trim()) {
-		removeNativeMemoryFile(source, filePath, agentId);
+		await removeNativeMemoryFile(source, filePath, agentId);
 		return false;
 	}
 
@@ -947,22 +946,22 @@ export async function indexNativeMemoryFile(
 	}
 }
 
-export function removeNativeMemoryFile(
+export async function removeNativeMemoryFile(
 	source: NativeMemorySource,
 	filePath: string,
 	agentId = resolveDaemonAgentId(),
-): void {
+): Promise<void> {
 	indexed.delete(fingerprintKey(source, filePath, agentId));
-	softDeleteArtifactRowsForPath(filePath, agentId);
+	await softDeleteArtifactRowsForPath(filePath, agentId);
 	if (source.harness === "obsidian") {
 		const sourceId = source.sourceId ?? sourceIdForObsidianRoot(source.root);
-		purgeObsidianSourceFileEmbeddings({
+		await purgeObsidianSourceFileEmbeddings({
 			sourceId,
 			agentId,
 			root: source.root,
 			filePath,
 		});
-		purgeObsidianSourceFileStructure({
+		await purgeObsidianSourceFileStructure({
 			agentId,
 			sourceId,
 			root: source.root,
@@ -971,7 +970,7 @@ export function removeNativeMemoryFile(
 	}
 }
 
-export function purgeNativeMemorySourceArtifacts(source: NativeMemorySource, agentId?: string): number {
+export async function purgeNativeMemorySourceArtifacts(source: NativeMemorySource, agentId?: string): Promise<number> {
 	const rootPrefix = `${normalizedRoot(source.root)}/`;
 	for (const key of indexed.keys()) {
 		const parts = key.split(":");
@@ -985,8 +984,7 @@ export function purgeNativeMemorySourceArtifacts(source: NativeMemorySource, age
 		)
 			indexed.delete(key);
 	}
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	const artifactRows = getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
+	const artifactRows = await runWriteTxAsync(getDbAccessor(), (db) => {
 		const agentWhere = agentId ? "agent_id = ? AND " : "";
 		const rootUpperBound = prefixUpperBound(rootPrefix);
 		const params = agentId
@@ -1124,13 +1122,13 @@ export function startNativeMemoryBridge(
 			if (cleanupAllowed) {
 				const currentPaths = new Set([...current].map((file) => file.replace(/\\/g, "/")));
 				for (const file of await activeNativeArtifactPaths(source, agentId)) {
-					if (!currentPaths.has(file.replace(/\\/g, "/"))) removeNativeMemoryFile(source, file, agentId);
+					if (!currentPaths.has(file.replace(/\\/g, "/"))) await removeNativeMemoryFile(source, file, agentId);
 				}
 			}
 			const previous = known.get(key);
 			if (previous && cleanupAllowed) {
 				for (const file of previous) {
-					if (!current.has(file)) removeNativeMemoryFile(source, file, agentId);
+					if (!current.has(file)) await removeNativeMemoryFile(source, file, agentId);
 				}
 			}
 			known.set(key, current);

--- a/platform/daemon/src/ontology-assertions.ts
+++ b/platform/daemon/src/ontology-assertions.ts
@@ -302,7 +302,8 @@ export function createEpistemicAssertion(
 	accessor: DbAccessor,
 	input: CreateEpistemicAssertionInput,
 ): EpistemicAssertion {
-	return accessor.withWriteTx((db) => insertAssertion(db, input));
+	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
+	return accessor.withWriteTx((db: WriteDb) => insertAssertion(db, input));
 }
 
 export function createEpistemicAssertionsInTx(
@@ -320,7 +321,8 @@ export function listEpistemicAssertions(
 ): ListEpistemicAssertionsResult {
 	const limit = Math.min(Math.max(params.limit ?? 50, 1), 200);
 	const offset = Math.max(params.offset ?? 0, 0);
-	return accessor.withReadDb((db) => {
+	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
+	return accessor.withReadDb((db: ReadDb) => {
 		const observerId = validateEpistemicObserverScope(params.agentId, params.observerId);
 		const where = ["a.agent_id = ?"];
 		const args: unknown[] = [observerId];
@@ -385,7 +387,8 @@ export function getEpistemicAssertion(
 	accessor: DbAccessor,
 	params: { readonly agentId: string; readonly id: string; readonly observerId?: string | null },
 ): EpistemicAssertion | null {
-	return accessor.withReadDb((db) => {
+	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
+	return accessor.withReadDb((db: ReadDb) => {
 		const observerId = validateEpistemicObserverScope(params.agentId, params.observerId);
 		const row = db
 			.prepare(
@@ -403,7 +406,8 @@ export function linkEpistemicAssertionClaim(
 	accessor: DbAccessor,
 	params: { readonly agentId: string; readonly id: string; readonly attributeId: string },
 ): EpistemicAssertion {
-	return accessor.withWriteTx((db) => {
+	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
+	return accessor.withWriteTx((db: WriteDb) => {
 		const assertion = db
 			.prepare("SELECT subject_entity_id FROM epistemic_assertions WHERE id = ? AND agent_id = ?")
 			.get(params.id, params.agentId) as { subject_entity_id: string } | undefined;
@@ -430,7 +434,8 @@ export function archiveEpistemicAssertion(
 	accessor: DbAccessor,
 	params: { readonly agentId: string; readonly id: string; readonly actor: string; readonly reason?: string | null },
 ): EpistemicAssertion {
-	return accessor.withWriteTx((db) => {
+	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
+	return accessor.withWriteTx((db: WriteDb) => {
 		const existing = db
 			.prepare("SELECT id FROM epistemic_assertions WHERE id = ? AND agent_id = ?")
 			.get(params.id, params.agentId) as { id: string } | undefined;
@@ -457,7 +462,8 @@ export function supersedeEpistemicAssertion(
 	accessor: DbAccessor,
 	input: CreateEpistemicAssertionInput & { readonly oldAssertionId: string },
 ): EpistemicAssertion {
-	return accessor.withWriteTx((db) => {
+	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
+	return accessor.withWriteTx((db: WriteDb) => {
 		const old = db
 			.prepare(
 				`SELECT a.*, e.name AS subject_entity_name

--- a/platform/daemon/src/ontology-assertions.ts
+++ b/platform/daemon/src/ontology-assertions.ts
@@ -1,7 +1,7 @@
 import type { EpistemicAssertion, EpistemicAssertionPredicate, EpistemicAssertionStatus } from "@signet/core";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import { validateDerivedMemorySourceInTx } from "./derived-memory-provenance";
-import { resolveNamedEntity } from "./knowledge-graph";
+import { resolveEntityRecordByName } from "./knowledge-graph";
 
 export class OntologyAssertionError extends Error {
 	constructor(
@@ -167,7 +167,6 @@ function readEntityById(
 }
 
 function resolveSubject(
-	accessor: DbAccessor,
 	db: ReadDb | WriteDb,
 	input: Pick<CreateEpistemicAssertionInput, "agentId" | "entity" | "entityId">,
 ): { readonly id: string; readonly name: string } {
@@ -179,7 +178,7 @@ function resolveSubject(
 	}
 	const entity = trim(input.entity);
 	if (entity === null) throw new OntologyAssertionError("entity or entity_id is required", 400);
-	const resolved = resolveNamedEntity(accessor, { agentId: input.agentId, name: entity });
+	const resolved = resolveEntityRecordByName(db, { agentId: input.agentId, name: entity });
 	if (resolved === null) throw new OntologyAssertionError("entity was not found", 404);
 	return { id: resolved.id, name: resolved.name };
 }
@@ -225,9 +224,9 @@ function validateClaimAttribute(
 	return attributeId;
 }
 
-function insertAssertion(accessor: DbAccessor, db: WriteDb, input: CreateEpistemicAssertionInput): EpistemicAssertion {
+function insertAssertion(db: WriteDb, input: CreateEpistemicAssertionInput): EpistemicAssertion {
 	validateEpistemicObserverScope(input.agentId, input.observerId);
-	const subject = resolveSubject(accessor, db, input);
+	const subject = resolveSubject(db, input);
 	const content = trim(input.content);
 	if (content === null) throw new OntologyAssertionError("content is required", 400);
 	const predicate = parsePredicate(input.predicate);
@@ -303,8 +302,7 @@ export function createEpistemicAssertion(
 	accessor: DbAccessor,
 	input: CreateEpistemicAssertionInput,
 ): EpistemicAssertion {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	return accessor.withWriteTx((db: import("./db-accessor").WriteDb) => insertAssertion(accessor, db, input));
+	return accessor.withWriteTx((db) => insertAssertion(db, input));
 }
 
 export function createEpistemicAssertionsInTx(
@@ -313,7 +311,7 @@ export function createEpistemicAssertionsInTx(
 	inputs: readonly CreateEpistemicAssertionInput[],
 ): readonly EpistemicAssertion[] {
 	if (inputs.length > 500) throw new OntologyAssertionError("cannot create more than 500 assertions at once", 400);
-	return inputs.map((input) => insertAssertion(accessor, db, input));
+	return inputs.map((input) => insertAssertion(db, input));
 }
 
 export function listEpistemicAssertions(
@@ -322,8 +320,7 @@ export function listEpistemicAssertions(
 ): ListEpistemicAssertionsResult {
 	const limit = Math.min(Math.max(params.limit ?? 50, 1), 200);
 	const offset = Math.max(params.offset ?? 0, 0);
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+	return accessor.withReadDb((db) => {
 		const observerId = validateEpistemicObserverScope(params.agentId, params.observerId);
 		const where = ["a.agent_id = ?"];
 		const args: unknown[] = [observerId];
@@ -332,7 +329,7 @@ export function listEpistemicAssertions(
 			where.push("a.subject_entity_id = ?");
 			args.push(entityId);
 		} else if (trim(params.entity) !== null) {
-			const resolved = resolveNamedEntity(accessor, { agentId: params.agentId, name: params.entity ?? "" });
+			const resolved = resolveEntityRecordByName(db, { agentId: params.agentId, name: params.entity ?? "" });
 			if (resolved === null) return { items: [], count: 0 };
 			where.push("a.subject_entity_id = ?");
 			args.push(resolved.id);
@@ -388,8 +385,7 @@ export function getEpistemicAssertion(
 	accessor: DbAccessor,
 	params: { readonly agentId: string; readonly id: string; readonly observerId?: string | null },
 ): EpistemicAssertion | null {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+	return accessor.withReadDb((db) => {
 		const observerId = validateEpistemicObserverScope(params.agentId, params.observerId);
 		const row = db
 			.prepare(
@@ -407,8 +403,7 @@ export function linkEpistemicAssertionClaim(
 	accessor: DbAccessor,
 	params: { readonly agentId: string; readonly id: string; readonly attributeId: string },
 ): EpistemicAssertion {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	return accessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
+	return accessor.withWriteTx((db) => {
 		const assertion = db
 			.prepare("SELECT subject_entity_id FROM epistemic_assertions WHERE id = ? AND agent_id = ?")
 			.get(params.id, params.agentId) as { subject_entity_id: string } | undefined;
@@ -435,8 +430,7 @@ export function archiveEpistemicAssertion(
 	accessor: DbAccessor,
 	params: { readonly agentId: string; readonly id: string; readonly actor: string; readonly reason?: string | null },
 ): EpistemicAssertion {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	return accessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
+	return accessor.withWriteTx((db) => {
 		const existing = db
 			.prepare("SELECT id FROM epistemic_assertions WHERE id = ? AND agent_id = ?")
 			.get(params.id, params.agentId) as { id: string } | undefined;
@@ -463,8 +457,7 @@ export function supersedeEpistemicAssertion(
 	accessor: DbAccessor,
 	input: CreateEpistemicAssertionInput & { readonly oldAssertionId: string },
 ): EpistemicAssertion {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	return accessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
+	return accessor.withWriteTx((db) => {
 		const old = db
 			.prepare(
 				`SELECT a.*, e.name AS subject_entity_name
@@ -475,12 +468,12 @@ export function supersedeEpistemicAssertion(
 			.get(input.oldAssertionId, input.agentId) as Record<string, unknown> | undefined;
 		if (!old) throw new OntologyAssertionError("assertion was not found", 404);
 		if (trim(input.entityId) !== null || trim(input.entity) !== null) {
-			const subject = resolveSubject(accessor, db, input);
+			const subject = resolveSubject(db, input);
 			if (subject.id !== old.subject_entity_id) {
 				throw new OntologyAssertionError("supersede cannot change assertion subject entity", 409);
 			}
 		}
-		const next = insertAssertion(accessor, db, {
+		const next = insertAssertion(db, {
 			...input,
 			entityId: old.subject_entity_id as string,
 			predicate: input.predicate || (old.predicate as string),

--- a/platform/daemon/src/ontology-claim-evidence.ts
+++ b/platform/daemon/src/ontology-claim-evidence.ts
@@ -130,13 +130,13 @@ function attributeEvidenceRefs(attribute: EntityAttribute): OntologyEvidenceRef[
 	return uniqueOntologyEvidenceRefs(refs);
 }
 
-export function getOntologyClaimEvidence(
+export async function getOntologyClaimEvidence(
 	accessor: DbAccessor,
 	params: GetOntologyClaimEvidenceParams,
-): OntologyClaimEvidenceResult {
+): Promise<OntologyClaimEvidenceResult> {
 	const limit = Math.min(Math.max(params.limit ?? 20, 1), 200);
 	const offset = Math.max(params.offset ?? 0, 0);
-	const result = listEntityAttributesByPath(accessor, {
+	const result = await listEntityAttributesByPath(accessor, {
 		agentId: params.agentId,
 		entity: params.entity,
 		aspect: params.aspect,

--- a/platform/daemon/src/ontology-claim-trace.test.ts
+++ b/platform/daemon/src/ontology-claim-trace.test.ts
@@ -397,7 +397,9 @@ describe("authorized ontology claim traces", () => {
 				claim: "editor",
 				sessionKey: "session-b",
 			}),
-		).rejects.toThrowError(new OntologyClaimTraceError("Claim trace premise crosses the authorized session boundary", 403));
+		).rejects.toThrowError(
+			new OntologyClaimTraceError("Claim trace premise crosses the authorized session boundary", 403),
+		);
 	});
 
 	it("serves the trace through the read-only HTTP route", async () => {

--- a/platform/daemon/src/ontology-claim-trace.test.ts
+++ b/platform/daemon/src/ontology-claim-trace.test.ts
@@ -160,7 +160,7 @@ describe("authorized ontology claim traces", () => {
 		rmSync(dir, { recursive: true, force: true });
 	});
 
-	it("returns current truth, history, exact premises, assertions, and bounded reverse lineage", () => {
+	it("returns current truth, history, exact premises, assertions, and bounded reverse lineage", async () => {
 		const assertion = createEpistemicAssertion(getDbAccessor(), {
 			agentId: "ant",
 			entityId: "entity-1",
@@ -174,7 +174,7 @@ describe("authorized ontology claim traces", () => {
 			attributeId: "attr-current",
 		});
 
-		const trace = explainOntologyClaim(getDbAccessor(), {
+		const trace = await explainOntologyClaim(getDbAccessor(), {
 			agentId: "ant",
 			entity: "Editor",
 			aspect: "preferences",
@@ -210,7 +210,7 @@ describe("authorized ontology claim traces", () => {
 		expect(trace.traversal.limits.maxDepth).toBe(2);
 	});
 
-	it("keeps project-scoped reverse lineage within the authorized project", () => {
+	it("keeps project-scoped reverse lineage within the authorized project", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				"UPDATE memories SET project = 'project-a' WHERE id IN ('source-a', 'derived-old', 'derived-current')",
@@ -218,7 +218,7 @@ describe("authorized ontology claim traces", () => {
 			db.prepare("UPDATE memories SET project = 'project-b' WHERE id = 'derived-dependent'").run();
 		});
 
-		const trace = explainOntologyClaim(getDbAccessor(), {
+		const trace = await explainOntologyClaim(getDbAccessor(), {
 			agentId: "ant",
 			entity: "Editor",
 			aspect: "preferences",
@@ -229,11 +229,11 @@ describe("authorized ontology claim traces", () => {
 		expect(trace.reverse.items).toHaveLength(0);
 	});
 
-	it("rejects a project-scoped claim whose semantic memory is outside the project", () => {
+	it("rejects a project-scoped claim whose semantic memory is outside the project", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare("UPDATE memories SET project = 'project-b' WHERE id = 'derived-current'").run();
 		});
-		expect(() =>
+		await expect(
 			explainOntologyClaim(getDbAccessor(), {
 				agentId: "ant",
 				entity: "Editor",
@@ -242,10 +242,10 @@ describe("authorized ontology claim traces", () => {
 				claim: "editor",
 				project: "project-a",
 			}),
-		).toThrowError(new OntologyClaimTraceError("Claim is outside the authorized project scope", 403));
+		).rejects.toThrowError(new OntologyClaimTraceError("Claim is outside the authorized project scope", 403));
 	});
 
-	it("resolves exact artifact spans without returning artifact session tokens", () => {
+	it("resolves exact artifact spans without returning artifact session tokens", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				"DELETE FROM derived_memory_sources WHERE derived_memory_id IN ('derived-old', 'derived-current')",
@@ -273,7 +273,7 @@ describe("authorized ontology claim traces", () => {
 			).run(now, now);
 		});
 
-		const trace = explainOntologyClaim(getDbAccessor(), {
+		const trace = await explainOntologyClaim(getDbAccessor(), {
 			agentId: "ant",
 			entity: "Editor",
 			aspect: "preferences",
@@ -290,7 +290,7 @@ describe("authorized ontology claim traces", () => {
 		});
 	});
 
-	it("does not treat legacy noncanonical lineage metadata as source evidence", () => {
+	it("does not treat legacy noncanonical lineage metadata as source evidence", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				"DELETE FROM derived_memory_sources WHERE derived_memory_id IN ('derived-old', 'derived-current')",
@@ -301,7 +301,7 @@ describe("authorized ontology claim traces", () => {
 			linkSource(db, "derived-current", "ontology_claim", "attr-old");
 		});
 
-		const trace = explainOntologyClaim(getDbAccessor(), {
+		const trace = await explainOntologyClaim(getDbAccessor(), {
 			agentId: "ant",
 			entity: "Editor",
 			aspect: "preferences",
@@ -312,12 +312,12 @@ describe("authorized ontology claim traces", () => {
 		expect(trace.integrity.status).toBe("unverified");
 	});
 
-	it("rejects fabricated and cross-agent premise ids", () => {
+	it("rejects fabricated and cross-agent premise ids", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare("DELETE FROM derived_memory_sources WHERE derived_memory_id = 'derived-current'").run();
 			linkSource(db, "derived-current", "memory", "missing-source");
 		});
-		expect(() =>
+		await expect(
 			explainOntologyClaim(getDbAccessor(), {
 				agentId: "ant",
 				entity: "Editor",
@@ -325,7 +325,7 @@ describe("authorized ontology claim traces", () => {
 				group: "preferences",
 				claim: "editor",
 			}),
-		).toThrowError(new OntologyClaimTraceError("Claim premise 'memory:missing-source' was not found", 409));
+		).rejects.toThrowError(new OntologyClaimTraceError("Claim premise 'memory:missing-source' was not found", 409));
 
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare("DELETE FROM derived_memory_sources WHERE derived_memory_id = 'derived-current'").run();
@@ -337,7 +337,7 @@ describe("authorized ontology claim traces", () => {
 			});
 			linkSource(db, "derived-current", "memory", "shared-id");
 		});
-		expect(() =>
+		await expect(
 			explainOntologyClaim(getDbAccessor(), {
 				agentId: "ant",
 				entity: "Editor",
@@ -345,16 +345,16 @@ describe("authorized ontology claim traces", () => {
 				group: "preferences",
 				claim: "editor",
 			}),
-		).toThrowError(new OntologyClaimTraceError("Claim premise crosses the authorized agent scope", 403));
+		).rejects.toThrowError(new OntologyClaimTraceError("Claim premise crosses the authorized agent scope", 403));
 	});
 
-	it("rejects an exact-quote claim that is not present in the source", () => {
+	it("rejects an exact-quote claim that is not present in the source", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare("UPDATE entity_attributes SET proposal_evidence = ? WHERE id = 'attr-current'").run(
 				JSON.stringify([{ source_ref: "memory:source-a", quote: "This sentence was never recorded." }]),
 			);
 		});
-		expect(() =>
+		await expect(
 			explainOntologyClaim(getDbAccessor(), {
 				agentId: "ant",
 				entity: "Editor",
@@ -362,14 +362,14 @@ describe("authorized ontology claim traces", () => {
 				group: "preferences",
 				claim: "editor",
 			}),
-		).toThrowError(new OntologyClaimTraceError("Claim premise quote does not match the immutable source", 409));
+		).rejects.toThrowError(new OntologyClaimTraceError("Claim premise quote does not match the immutable source", 409));
 	});
 
-	it("reports deleted evidence as invalidated and rejects a session boundary crossing", () => {
+	it("reports deleted evidence as invalidated and rejects a session boundary crossing", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare("UPDATE memories SET is_deleted = 1 WHERE id = 'source-a'").run();
 		});
-		const invalidated = explainOntologyClaim(getDbAccessor(), {
+		const invalidated = await explainOntologyClaim(getDbAccessor(), {
 			agentId: "ant",
 			entity: "Editor",
 			aspect: "preferences",
@@ -388,7 +388,7 @@ describe("authorized ontology claim traces", () => {
 			).run(now, now, now);
 			linkSource(db, "derived-current", "transcript", "session-a");
 		});
-		expect(() =>
+		await expect(
 			explainOntologyClaim(getDbAccessor(), {
 				agentId: "ant",
 				entity: "Editor",
@@ -397,7 +397,7 @@ describe("authorized ontology claim traces", () => {
 				claim: "editor",
 				sessionKey: "session-b",
 			}),
-		).toThrowError(new OntologyClaimTraceError("Claim trace premise crosses the authorized session boundary", 403));
+		).rejects.toThrowError(new OntologyClaimTraceError("Claim trace premise crosses the authorized session boundary", 403));
 	});
 
 	it("serves the trace through the read-only HTTP route", async () => {

--- a/platform/daemon/src/ontology-claim-trace.ts
+++ b/platform/daemon/src/ontology-claim-trace.ts
@@ -1034,7 +1034,10 @@ function readReverse(
 	return { items, truncated, maxDepthReached };
 }
 
-export function explainOntologyClaim(accessor: DbAccessor, params: ExplainClaimParams): ClaimTraceResult {
+export async function explainOntologyClaim(
+	accessor: DbAccessor,
+	params: ExplainClaimParams,
+): Promise<ClaimTraceResult> {
 	const started = performance.now();
 	const versionLimit = boundedInteger(params.versionLimit, 20, MAX_VERSION_LIMIT, "versionLimit");
 	const premiseLimit = boundedInteger(params.premiseLimit, 50, MAX_PREMISE_LIMIT, "premiseLimit");
@@ -1042,7 +1045,7 @@ export function explainOntologyClaim(accessor: DbAccessor, params: ExplainClaimP
 	const maxDepth = boundedDepth(params.maxDepth);
 	const sessionKey = params.sessionKey?.trim() || null;
 	const project = params.project?.trim() || null;
-	const result = listEntityAttributesByPath(accessor, {
+	const result = await listEntityAttributesByPath(accessor, {
 		agentId: params.agentId,
 		entity: params.entity,
 		aspect: params.aspect,

--- a/platform/daemon/src/ontology-consolidation.ts
+++ b/platform/daemon/src/ontology-consolidation.ts
@@ -178,7 +178,7 @@ function boundedInt(value: number | undefined, fallback: number, min: number, ma
 
 function buildPrompt(
 	proposals: readonly OntologyProposal[],
-	conflicts: ReturnType<typeof listOntologyProposalConflicts>,
+	conflicts: Awaited<ReturnType<typeof listOntologyProposalConflicts>>,
 ): string {
 	const compact = proposals.map((proposal) => ({
 		id: proposal.id,
@@ -240,7 +240,7 @@ ${JSON.stringify(conflicts.items, null, 2)}`;
 
 async function providerConsolidate(
 	proposals: readonly OntologyProposal[],
-	conflicts: ReturnType<typeof listOntologyProposalConflicts>,
+	conflicts: Awaited<ReturnType<typeof listOntologyProposalConflicts>>,
 	params: Pick<ConsolidateOntologyParams, "provider" | "providerTimeoutMs" | "providerMaxTokens">,
 ): Promise<{
 	readonly proposals: readonly ProposalDraft[];
@@ -294,12 +294,12 @@ export async function consolidateOntologyProposals(
 	const agentId = params.agentId.trim();
 	if (!agentId) throw new OntologyConsolidationError("agentId is required", 400);
 	const limit = Math.min(Math.max(params.limit ?? 50, 1), 200);
-	const source = listOntologyProposals(accessor, {
+	const source = await listOntologyProposals(accessor, {
 		agentId,
 		status: params.status ?? "pending",
 		limit,
 	});
-	const conflicts = listOntologyProposalConflicts(accessor, { agentId, limit: Math.max(limit, 50) });
+	const conflicts = await listOntologyProposalConflicts(accessor, { agentId, limit: Math.max(limit, 50) });
 	const warnings: string[] = [];
 	let summary: string | null = null;
 	let rejections: readonly unknown[] = [];
@@ -339,7 +339,7 @@ export async function consolidateOntologyProposals(
 		};
 	}
 
-	const written = createOntologyProposals(
+	const written = await createOntologyProposals(
 		accessor,
 		proposals.map((proposal) => ({
 			agentId,

--- a/platform/daemon/src/ontology-contradictions.test.ts
+++ b/platform/daemon/src/ontology-contradictions.test.ts
@@ -31,7 +31,7 @@ describe("persisted ontology contradictions", () => {
 		rmSync(dir, { recursive: true, force: true });
 	});
 
-	function addClaim(agentId: string, value: string, sourceId: string, sourceKind = "fixture") {
+	async function addClaim(agentId: string, value: string, sourceId: string, sourceKind = "fixture") {
 		return applyOntologyOperation(getDbAccessor(), {
 			agentId,
 			actor: "contradiction-test",
@@ -51,7 +51,7 @@ describe("persisted ontology contradictions", () => {
 		});
 	}
 
-	function setClaim(agentId: string, value: string, sourceId: string) {
+	async function setClaim(agentId: string, value: string, sourceId: string) {
 		return applyOntologyOperation(getDbAccessor(), {
 			agentId,
 			actor: "contradiction-test",
@@ -71,7 +71,7 @@ describe("persisted ontology contradictions", () => {
 		});
 	}
 
-	function supersedeClaim(agentId: string, oldValue: string, newValue: string, sourceId: string) {
+	async function supersedeClaim(agentId: string, oldValue: string, newValue: string, sourceId: string) {
 		return applyOntologyOperation(getDbAccessor(), {
 			agentId,
 			actor: "contradiction-test",
@@ -92,12 +92,12 @@ describe("persisted ontology contradictions", () => {
 		});
 	}
 
-	it("records set-claim contradiction evidence before governance supersedes the prior value", () => {
-		setClaim("owner", "Runtime mode is enabled by default.", "source-enabled");
-		const result = setClaim("owner", "Runtime mode is disabled by default.", "source-disabled");
+	it("records set-claim contradiction evidence before governance supersedes the prior value", async () => {
+		await setClaim("owner", "Runtime mode is enabled by default.", "source-enabled");
+		const result = await setClaim("owner", "Runtime mode is disabled by default.", "source-disabled");
 
 		expect(result.result?.contradictionIds).toEqual([expect.any(String)]);
-		const all = listOntologyContradictions(getDbAccessor(), { agentId: "owner", status: "all" });
+		const all = await listOntologyContradictions(getDbAccessor(), { agentId: "owner", status: "all" });
 		expect(all.items).toHaveLength(1);
 		expect(all.items[0]?.status).toBe("resolved");
 		expect([all.items[0]?.leftSourceId, all.items[0]?.rightSourceId]).toEqual(
@@ -109,12 +109,12 @@ describe("persisted ontology contradictions", () => {
 				expect.objectContaining({ source_id: "source-disabled" }),
 			]),
 		);
-		expect(listOntologyContradictions(getDbAccessor(), { agentId: "owner" }).items).toHaveLength(0);
+		expect((await listOntologyContradictions(getDbAccessor(), { agentId: "owner" })).items).toHaveLength(0);
 	});
 
-	it("records supersede-claim contradiction evidence atomically with replacement", () => {
-		addClaim("owner", "Runtime mode is enabled by default.", "source-enabled");
-		const result = supersedeClaim(
+	it("records supersede-claim contradiction evidence atomically with replacement", async () => {
+		await addClaim("owner", "Runtime mode is enabled by default.", "source-enabled");
+		const result = await supersedeClaim(
 			"owner",
 			"Runtime mode is enabled by default.",
 			"Runtime mode is disabled by default.",
@@ -122,27 +122,29 @@ describe("persisted ontology contradictions", () => {
 		);
 
 		expect(result.result?.replacementCreated).toBe(true);
-		const all = listOntologyContradictions(getDbAccessor(), { agentId: "owner", status: "all" });
+		const all = await listOntologyContradictions(getDbAccessor(), { agentId: "owner", status: "all" });
 		expect(all.items).toHaveLength(1);
 		expect(all.items[0]?.status).toBe("resolved");
 		expect([all.items[0]?.leftSourceId, all.items[0]?.rightSourceId]).toEqual(
 			expect.arrayContaining(["source-enabled", "source-disabled"]),
 		);
-		expect(listOntologyContradictions(getDbAccessor(), { agentId: "owner" }).items).toHaveLength(0);
+		expect((await listOntologyContradictions(getDbAccessor(), { agentId: "owner" })).items).toHaveLength(0);
 	});
 
-	it("keeps idempotent and non-contradictory set writes out of the ledger", () => {
-		const first = setClaim("owner", "Runtime mode is enabled by default.", "source-enabled");
-		const duplicate = setClaim("owner", "Runtime mode is enabled by default.", "source-enabled");
+	it("keeps idempotent and non-contradictory set writes out of the ledger", async () => {
+		const first = await setClaim("owner", "Runtime mode is enabled by default.", "source-enabled");
+		const duplicate = await setClaim("owner", "Runtime mode is enabled by default.", "source-enabled");
 
 		expect(first.result?.contradictionIds).toEqual([]);
 		expect(duplicate.result?.deduped).toBe(true);
 		expect(duplicate.result?.contradictionIds).toEqual([]);
-		expect(listOntologyContradictions(getDbAccessor(), { agentId: "owner", status: "all" }).items).toHaveLength(0);
+		expect((await listOntologyContradictions(getDbAccessor(), { agentId: "owner", status: "all" })).items).toHaveLength(
+			0,
+		);
 	});
 
-	it("rolls back set-claim mutation when contradiction ledger insertion fails", () => {
-		addClaim("owner", "Runtime mode is enabled by default.", "source-enabled");
+	it("rolls back set-claim mutation when contradiction ledger insertion fails", async () => {
+		await addClaim("owner", "Runtime mode is enabled by default.", "source-enabled");
 		getDbAccessor().withWriteTx((db) => {
 			db.exec(`
 				CREATE TRIGGER fail_ontology_contradiction_insert
@@ -153,7 +155,7 @@ describe("persisted ontology contradictions", () => {
 			`);
 		});
 
-		expect(() => setClaim("owner", "Runtime mode is disabled by default.", "source-disabled")).toThrow(
+		await expect(setClaim("owner", "Runtime mode is disabled by default.", "source-disabled")).rejects.toThrow(
 			"ledger write failed",
 		);
 		const active = getDbAccessor().withReadDb(
@@ -166,11 +168,13 @@ describe("persisted ontology contradictions", () => {
 					.all("owner", "default_mode") as Array<{ content: string }>,
 		);
 		expect(active).toEqual([{ content: "Runtime mode is enabled by default." }]);
-		expect(listOntologyContradictions(getDbAccessor(), { agentId: "owner", status: "all" }).items).toHaveLength(0);
+		expect((await listOntologyContradictions(getDbAccessor(), { agentId: "owner", status: "all" })).items).toHaveLength(
+			0,
+		);
 	});
 
-	it("persists one evidence-linked observation for competing active claims", () => {
-		const left = addClaim("owner", "Runtime mode is enabled by default.", "source-enabled", "authoritative");
+	it("persists one evidence-linked observation for competing active claims", async () => {
+		const left = await addClaim("owner", "Runtime mode is enabled by default.", "source-enabled", "authoritative");
 		const leftAttributeId = left.result?.attributeId;
 		if (typeof leftAttributeId !== "string") throw new Error("expected left claim fixture");
 		getDbAccessor().withWriteTx((db) => {
@@ -181,10 +185,10 @@ describe("persisted ontology contradictions", () => {
 				"owner",
 			);
 		});
-		const right = addClaim("owner", "Runtime mode is disabled by default.", "source-disabled", "unverified");
-		addClaim("other", "Runtime mode is enabled by default.", "other-enabled");
+		const right = await addClaim("owner", "Runtime mode is disabled by default.", "source-disabled", "unverified");
+		await addClaim("other", "Runtime mode is enabled by default.", "other-enabled");
 
-		const active = listOntologyContradictions(getDbAccessor(), { agentId: "owner" });
+		const active = await listOntologyContradictions(getDbAccessor(), { agentId: "owner" });
 		expect(active.count).toBe(1);
 		expect(active.items).toHaveLength(1);
 		const contradiction = active.items[0];
@@ -223,20 +227,20 @@ describe("persisted ontology contradictions", () => {
 			expect.arrayContaining([contradiction.leftAttributeId, contradiction.rightAttributeId]),
 		);
 
-		const other = listOntologyContradictions(getDbAccessor(), { agentId: "other" });
+		const other = await listOntologyContradictions(getDbAccessor(), { agentId: "other" });
 		expect(other.items).toHaveLength(0);
-		const duplicate = addClaim("owner", "Runtime mode is disabled by default.", "source-disabled");
+		const duplicate = await addClaim("owner", "Runtime mode is disabled by default.", "source-disabled");
 		expect(duplicate.result?.deduped).toBe(true);
-		expect(listOntologyContradictions(getDbAccessor(), { agentId: "owner" }).count).toBe(1);
+		expect((await listOntologyContradictions(getDbAccessor(), { agentId: "owner" })).count).toBe(1);
 	});
 
-	it("resolves source removal while retaining snapshots and provenance", () => {
-		addClaim("owner", "Runtime mode is enabled by default.", "source-enabled");
-		addClaim("owner", "Runtime mode is disabled by default.", "source-disabled");
+	it("resolves source removal while retaining snapshots and provenance", async () => {
+		await addClaim("owner", "Runtime mode is enabled by default.", "source-enabled");
+		await addClaim("owner", "Runtime mode is disabled by default.", "source-disabled");
 
 		purgeSourceOwnedRows({ agentId: "owner", sourceId: "source-enabled" });
 
-		const all = listOntologyContradictions(getDbAccessor(), { agentId: "owner", status: "all" });
+		const all = await listOntologyContradictions(getDbAccessor(), { agentId: "owner", status: "all" });
 		expect(all.items).toHaveLength(1);
 		expect(all.items[0]).toMatchObject({
 			status: "resolved",
@@ -247,11 +251,11 @@ describe("persisted ontology contradictions", () => {
 		expect([all.items[0]?.leftSourceId, all.items[0]?.rightSourceId]).toEqual(
 			expect.arrayContaining(["source-enabled", "source-disabled"]),
 		);
-		expect(listOntologyContradictions(getDbAccessor(), { agentId: "owner" }).items).toHaveLength(0);
+		expect((await listOntologyContradictions(getDbAccessor(), { agentId: "owner" })).items).toHaveLength(0);
 	});
 
-	it("keeps current-claim governance separate from contradiction state", () => {
-		applyOntologyOperation(getDbAccessor(), {
+	it("keeps current-claim governance separate from contradiction state", async () => {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "owner",
 			actor: "contradiction-test",
 			operation: "set_claim_value",
@@ -266,11 +270,11 @@ describe("persisted ontology contradictions", () => {
 			sourceKind: "fixture",
 			sourceId: "source-enabled",
 		});
-		addClaim("owner", "Runtime mode is disabled by default.", "source-disabled");
+		await addClaim("owner", "Runtime mode is disabled by default.", "source-disabled");
 
-		const activeBeforeSet = listOntologyContradictions(getDbAccessor(), { agentId: "owner" });
+		const activeBeforeSet = await listOntologyContradictions(getDbAccessor(), { agentId: "owner" });
 		expect(activeBeforeSet.items).toHaveLength(1);
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "owner",
 			actor: "contradiction-test",
 			operation: "set_claim_value",
@@ -286,7 +290,7 @@ describe("persisted ontology contradictions", () => {
 			sourceId: "source-automatic",
 		});
 
-		const all = listOntologyContradictions(getDbAccessor(), { agentId: "owner", status: "all" });
+		const all = await listOntologyContradictions(getDbAccessor(), { agentId: "owner", status: "all" });
 		expect(all.items).toHaveLength(1);
 		expect(all.items[0]?.status).toBe("resolved");
 		const activeClaims = getDbAccessor().withReadDb(
@@ -303,9 +307,9 @@ describe("persisted ontology contradictions", () => {
 	});
 
 	it("exposes scoped contradiction reads through the recall-authorized route", async () => {
-		addClaim("owner", "Runtime mode is enabled by default.", "source-enabled");
-		addClaim("owner", "Runtime mode is disabled by default.", "source-disabled");
-		const contradiction = listOntologyContradictions(getDbAccessor(), { agentId: "owner" }).items[0];
+		await addClaim("owner", "Runtime mode is enabled by default.", "source-enabled");
+		await addClaim("owner", "Runtime mode is disabled by default.", "source-disabled");
+		const contradiction = (await listOntologyContradictions(getDbAccessor(), { agentId: "owner" })).items[0];
 		if (!contradiction) throw new Error("expected contradiction fixture");
 
 		const app = new Hono();
@@ -319,8 +323,8 @@ describe("persisted ontology contradictions", () => {
 	});
 
 	it("makes persisted observations available to the scoped Dreaming reader", async () => {
-		addClaim("owner", "Runtime mode is enabled by default.", "source-enabled");
-		addClaim("owner", "Runtime mode is disabled by default.", "source-disabled");
+		await addClaim("owner", "Runtime mode is enabled by default.", "source-enabled");
+		await addClaim("owner", "Runtime mode is disabled by default.", "source-disabled");
 		const capability = createDreamingCapabilities({
 			accessor: getDbAccessor(),
 			agentId: "owner",

--- a/platform/daemon/src/ontology-link-evidence.ts
+++ b/platform/daemon/src/ontology-link-evidence.ts
@@ -83,14 +83,13 @@ function linkEvidenceRefs(dependency: EntityDependency): OntologyEvidenceRef[] {
 	return uniqueOntologyEvidenceRefs(refs);
 }
 
-export function getOntologyLinkEvidence(
+export async function getOntologyLinkEvidence(
 	accessor: DbAccessor,
 	params: GetOntologyLinkEvidenceParams,
-): OntologyLinkEvidenceResult {
-	const dependency = getEntityDependencyById(accessor, params);
+): Promise<OntologyLinkEvidenceResult> {
+	const dependency = await getEntityDependencyById(accessor, params);
 	if (dependency === null) throw new OntologyLinkEvidenceError("Link not found", 404);
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	const items = accessor.withReadDb((db: import("./db-accessor").ReadDb) =>
+	const items = await accessor.withReadDbAsync(async (db) =>
 		linkEvidenceRefs(dependency).map((ref) => resolveOntologyEvidenceRef(db, params.agentId, ref)),
 	);
 	return {

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -70,8 +70,8 @@ describe("ontology proposals", () => {
 		});
 	}
 
-	it("applies an add_claim_value proposal into a grouped claim slot with provenance", () => {
-		const proposal = createOntologyProposal(getDbAccessor(), {
+	it("applies an add_claim_value proposal into a grouped claim slot with provenance", async () => {
+		const proposal = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "add_claim_value",
 			payload: {
@@ -93,7 +93,7 @@ describe("ontology proposals", () => {
 
 		expect(proposal.status).toBe("pending");
 
-		const applied = applyOntologyProposal(getDbAccessor(), {
+		const applied = await applyOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			id: proposal.id,
 			actor: "ant",
@@ -178,7 +178,7 @@ describe("ontology proposals", () => {
 		expect(JSON.parse(row?.proposal_evidence ?? "[]")).toEqual([{ source: "transcript:test", message_ids: ["m1"] }]);
 	});
 
-	it("records canonical episodic lineage and stales aggregate snapshots when a claim changes", () => {
+	it("records canonical episodic lineage and stales aggregate snapshots when a claim changes", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				`INSERT INTO memories
@@ -186,7 +186,7 @@ describe("ontology proposals", () => {
 				 VALUES ('episodic-source', 'Signet is a local-first memory system.', 'fact', 'ant', 'global', 'episodic', ?, ?)`,
 			).run("2026-08-04T00:00:00.000Z", "2026-08-04T00:00:00.000Z");
 		});
-		const initial = applyOntologyOperation(getDbAccessor(), {
+		const initial = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "set_claim_value",
@@ -248,7 +248,7 @@ describe("ontology proposals", () => {
 		);
 		expect(lineage).toEqual([{ source_kind: "memory", source_id: "episodic-source" }]);
 
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "set_claim_value",
@@ -279,7 +279,7 @@ describe("ontology proposals", () => {
 		).toMatchObject({ stale_at: expect.any(String) });
 	});
 
-	it("rejects invalid proposal source_refs before creating proposals or semantic memory provenance (#1343)", () => {
+	it("rejects invalid proposal source_refs before creating proposals or semantic memory provenance (#1343)", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				`INSERT INTO memories
@@ -318,7 +318,7 @@ describe("ontology proposals", () => {
 						.get() as { proposals: number; attributes: number; derived: number; links: number },
 			);
 
-		const valid = applyOntologyOperation(getDbAccessor(), {
+		const valid = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "set_claim_value",
@@ -335,7 +335,7 @@ describe("ontology proposals", () => {
 			),
 		).toEqual({ source_kind: "memory", source_id: "valid-source" });
 
-		const deduped = applyOntologyOperation(getDbAccessor(), {
+		const deduped = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "set_claim_value",
@@ -347,23 +347,23 @@ describe("ontology proposals", () => {
 		expect(counts()).toEqual({ proposals: 2, attributes: 1, derived: 1, links: 1 });
 
 		const beforeRejectedWrites = counts();
-		expect(() =>
+		await expect(
 			createOntologyProposal(getDbAccessor(), {
 				agentId: "ant",
 				operation: "set_claim_value",
 				payload: payload("missing"),
 				evidence: [{ source_ref: "memory:missing-source" }],
 			}),
-		).toThrow(new OntologyProposalError("Evidence source_ref was not found: memory:missing-source", 409));
-		expect(() =>
+		).rejects.toThrow(new OntologyProposalError("Evidence source_ref was not found: memory:missing-source", 409));
+		await expect(
 			createOntologyProposal(getDbAccessor(), {
 				agentId: "ant",
 				operation: "set_claim_value",
 				payload: payload("cross_scope"),
 				evidence: [{ source_ref: "memory:other-source" }],
 			}),
-		).toThrow(new OntologyProposalError("Evidence source_ref crosses the authorized agent scope", 409));
-		expect(() =>
+		).rejects.toThrow(new OntologyProposalError("Evidence source_ref crosses the authorized agent scope", 409));
+		await expect(
 			applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
 				actor: "test",
@@ -372,8 +372,8 @@ describe("ontology proposals", () => {
 				evidence: [{ source_ref: "memory:" }],
 				propose: true,
 			}),
-		).toThrow(new OntologyProposalError("Evidence source_ref must name a canonical episodic source", 409));
-		expect(() =>
+		).rejects.toThrow(new OntologyProposalError("Evidence source_ref must name a canonical episodic source", 409));
+		await expect(
 			applyOntologyOperationBatch(getDbAccessor(), {
 				agentId: "ant",
 				actor: "test",
@@ -391,8 +391,8 @@ describe("ontology proposals", () => {
 					},
 				],
 			}),
-		).toThrow(new OntologyProposalError("Evidence source_ref was not found: memory:missing-source", 409));
-		expect(() =>
+		).rejects.toThrow(new OntologyProposalError("Evidence source_ref was not found: memory:missing-source", 409));
+		await expect(
 			applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
 				actor: "test",
@@ -400,10 +400,10 @@ describe("ontology proposals", () => {
 				payload: payload("direct_missing"),
 				evidence: [{ source_ref: "memory:missing-source" }],
 			}),
-		).toThrow(new OntologyProposalError("Evidence source_ref was not found: memory:missing-source", 409));
+		).rejects.toThrow(new OntologyProposalError("Evidence source_ref was not found: memory:missing-source", 409));
 		expect(counts()).toEqual(beforeRejectedWrites);
 
-		const pending = createOntologyProposal(getDbAccessor(), {
+		const pending = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "set_claim_value",
 			payload: payload("deleted_before_apply"),
@@ -413,14 +413,14 @@ describe("ontology proposals", () => {
 			db.prepare("UPDATE memories SET is_deleted = 1 WHERE id = ? AND agent_id = ?").run("pending-source", "ant");
 		});
 		const beforeDeletedSourceApply = counts();
-		expect(() => applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: pending.id, actor: "test" })).toThrow(
-			new OntologyProposalError("Evidence source_ref was not found: memory:pending-source", 409),
-		);
+		await expect(
+			applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: pending.id, actor: "test" }),
+		).rejects.toThrow(new OntologyProposalError("Evidence source_ref was not found: memory:pending-source", 409));
 		expect(counts()).toEqual(beforeDeletedSourceApply);
-		expect(getOntologyProposal(getDbAccessor(), pending.id, "ant")?.status).toBe("pending");
+		expect((await getOntologyProposal(getDbAccessor(), pending.id, "ant"))?.status).toBe("pending");
 	});
 
-	it("rejects fabricated and cross-agent semantic premise links before persistence (#1343)", () => {
+	it("rejects fabricated and cross-agent semantic premise links before persistence (#1343)", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				`INSERT INTO entities
@@ -457,7 +457,7 @@ describe("ontology proposals", () => {
 		);
 	});
 
-	it("rejects a deduped claim apply whose evidence source disappeared after creation", () => {
+	it("rejects a deduped claim apply whose evidence source disappeared after creation", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				`INSERT INTO memories
@@ -480,7 +480,7 @@ describe("ontology proposals", () => {
 			value: "Deduped applies must still revalidate their evidence.",
 		};
 
-		const first = applyOntologyOperation(getDbAccessor(), {
+		const first = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "set_claim_value",
@@ -490,7 +490,7 @@ describe("ontology proposals", () => {
 		expect(first.proposal.status).toBe("applied");
 		expect(first.result?.attributeId).toBeTypeOf("string");
 
-		const pending = createOntologyProposal(getDbAccessor(), {
+		const pending = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "set_claim_value",
 			payload,
@@ -513,9 +513,9 @@ describe("ontology proposals", () => {
 		});
 
 		// The dedupe early-return used to apply without revalidating evidence.
-		expect(() => applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: pending.id, actor: "test" })).toThrow(
-			new OntologyProposalError("Evidence source_ref was not found: memory:dedupe-gone", 409),
-		);
+		await expect(
+			applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: pending.id, actor: "test" }),
+		).rejects.toThrow(new OntologyProposalError("Evidence source_ref was not found: memory:dedupe-gone", 409));
 
 		const after = getDbAccessor().withReadDb((db) => {
 			const attributeCount = (
@@ -529,10 +529,10 @@ describe("ontology proposals", () => {
 			return { attributeCount, derivedCount };
 		});
 		expect(after).toEqual(before);
-		expect(getOntologyProposal(getDbAccessor(), pending.id, "ant")?.status).toBe("pending");
+		expect((await getOntologyProposal(getDbAccessor(), pending.id, "ant"))?.status).toBe("pending");
 	});
 
-	it("rejects a non-materializing apply whose evidence source disappeared after creation", () => {
+	it("rejects a non-materializing apply whose evidence source disappeared after creation", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				`INSERT INTO memories
@@ -541,7 +541,7 @@ describe("ontology proposals", () => {
 			).run("2026-08-04T00:00:00.000Z", "2026-08-04T00:00:00.000Z");
 		});
 
-		const pending = createOntologyProposal(getDbAccessor(), {
+		const pending = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "create_entity",
 			payload: { name: "Orphaned Evidence Entity", entity_type: "concept" },
@@ -553,9 +553,9 @@ describe("ontology proposals", () => {
 
 		// create_entity never materializes attribute memory, so apply-time
 		// revalidation has to happen at the shared seam, not the materializer.
-		expect(() => applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: pending.id, actor: "test" })).toThrow(
-			new OntologyProposalError("Evidence source_ref was not found: memory:entity-gone", 409),
-		);
+		await expect(
+			applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: pending.id, actor: "test" }),
+		).rejects.toThrow(new OntologyProposalError("Evidence source_ref was not found: memory:entity-gone", 409));
 		expect(
 			getDbAccessor().withReadDb(
 				(db) =>
@@ -564,18 +564,18 @@ describe("ontology proposals", () => {
 						.get("ant", "Orphaned Evidence Entity") as { c: number },
 			),
 		).toEqual({ c: 0 });
-		expect(getOntologyProposal(getDbAccessor(), pending.id, "ant")?.status).toBe("pending");
+		expect((await getOntologyProposal(getDbAccessor(), pending.id, "ant"))?.status).toBe("pending");
 	});
 
-	it("rejects generic entity labels before creating ontology entities", () => {
-		expect(() =>
+	it("rejects generic entity labels before creating ontology entities", async () => {
+		await expect(
 			applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
 				actor: "test",
 				operation: "create_entity",
 				payload: { name: "the", entity_type: "project" },
 			}),
-		).toThrow("Entity name rejected: generic_or_scaffolding_name");
+		).rejects.toThrow("Entity name rejected: generic_or_scaffolding_name");
 		expect(
 			getDbAccessor().withReadDb(
 				(db) => db.prepare("SELECT COUNT(*) AS count FROM entities WHERE agent_id = ?").get("ant") as { count: number },
@@ -583,8 +583,8 @@ describe("ontology proposals", () => {
 		).toEqual({ count: 0 });
 	});
 
-	it("does not archive an aspect that has an active constraint without force", () => {
-		applyOntologyOperation(getDbAccessor(), {
+	it("does not archive an aspect that has an active constraint without force", async () => {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "set_claim_value",
@@ -598,15 +598,15 @@ describe("ontology proposals", () => {
 			},
 		});
 
-		expect(() =>
+		await expect(
 			applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
 				actor: "test",
 				operation: "archive_aspect",
 				payload: { entity: "Constraint Guard", selector: "retention" },
 			}),
-		).toThrow("Refusing to archive aspect with active constraint attributes without force");
-		const applied = applyOntologyOperation(getDbAccessor(), {
+		).rejects.toThrow("Refusing to archive aspect with active constraint attributes without force");
+		const applied = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "archive_aspect",
@@ -615,15 +615,15 @@ describe("ontology proposals", () => {
 		expect(applied.proposal.status).toBe("applied");
 	});
 
-	it("rejects a pending proposal without mutating graph state", () => {
-		const proposal = createOntologyProposal(getDbAccessor(), {
+	it("rejects a pending proposal without mutating graph state", async () => {
+		const proposal = await createOntologyProposal(getDbAccessor(), {
 			agentId: "default",
 			operation: "create_entity",
 			payload: { name: "Temporary Entity", entity_type: "concept" },
 			rationale: "Low confidence extraction.",
 		});
 
-		const rejected = rejectOntologyProposal(getDbAccessor(), {
+		const rejected = await rejectOntologyProposal(getDbAccessor(), {
 			agentId: "default",
 			id: proposal.id,
 			actor: "operator",
@@ -640,18 +640,18 @@ describe("ontology proposals", () => {
 		expect(entity).toBeNull();
 	});
 
-	it("rejects empty proposal operations before storage", () => {
-		expect(() =>
+	it("rejects empty proposal operations before storage", async () => {
+		await expect(
 			createOntologyProposal(getDbAccessor(), {
 				agentId: "default",
 				operation: "   ",
 				payload: { name: "Missing Operation" },
 			}),
-		).toThrow(OntologyProposalError);
+		).rejects.toThrow(OntologyProposalError);
 	});
 
-	it("creates proposal batches atomically in one agent scope", () => {
-		const batch = createOntologyProposals(getDbAccessor(), [
+	it("creates proposal batches atomically in one agent scope", async () => {
+		const batch = await createOntologyProposals(getDbAccessor(), [
 			{
 				agentId: "ant",
 				operation: "create_entity",
@@ -682,7 +682,7 @@ describe("ontology proposals", () => {
 		expect(batch.items.every((item) => item.agentId === "ant")).toBe(true);
 		expect(batch.items[1]?.evidence).toHaveLength(1);
 
-		const listed = listOntologyProposals(getDbAccessor(), { agentId: "ant", operation: "add_claim_value" });
+		const listed = await listOntologyProposals(getDbAccessor(), { agentId: "ant", operation: "add_claim_value" });
 		expect(listed.items).toHaveLength(1);
 		expect(listed.items[0]?.createdBy).toBe("importer");
 		expect(listed.items[0]?.sourceKind).toBe("transcript");
@@ -840,8 +840,8 @@ describe("ontology proposals", () => {
 			}),
 		).rejects.toThrow("predicate is invalid");
 
-		expect(listOntologyProposals(getDbAccessor(), { agentId: "ant" }).items).toHaveLength(0);
-		expect(listEpistemicAssertions(getDbAccessor(), { agentId: "ant", status: "all" }).items).toHaveLength(0);
+		expect((await listOntologyProposals(getDbAccessor(), { agentId: "ant" })).items).toHaveLength(0);
+		expect((await listEpistemicAssertions(getDbAccessor(), { agentId: "ant", status: "all" })).items).toHaveLength(0);
 	});
 
 	it("mechanically extracts conservative proposals from plain transcript text", async () => {
@@ -936,7 +936,7 @@ describe("ontology proposals", () => {
 	});
 
 	it("consolidates pending proposals through an inference provider without direct mutation", async () => {
-		createOntologyProposal(getDbAccessor(), {
+		await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "add_claim_value",
 			payload: {
@@ -949,7 +949,7 @@ describe("ontology proposals", () => {
 			confidence: 0.72,
 			rationale: "Raw extraction candidate.",
 		});
-		createOntologyProposal(getDbAccessor(), {
+		await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "add_claim_value",
 			payload: {
@@ -1037,7 +1037,7 @@ describe("ontology proposals", () => {
 		expect(written.items[0]?.sourceKind).toBe("ontology_consolidation");
 	});
 
-	it("resolves proposal evidence from transcripts and indexed artifacts", () => {
+	it("resolves proposal evidence from transcripts and indexed artifacts", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				`INSERT INTO session_transcripts
@@ -1071,7 +1071,7 @@ describe("ontology proposals", () => {
 				"2026-05-06T00:01:00.000Z",
 			);
 		});
-		const proposal = createOntologyProposal(getDbAccessor(), {
+		const proposal = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "add_claim_value",
 			payload: {
@@ -1091,7 +1091,7 @@ describe("ontology proposals", () => {
 			sourcePath: "memory/codex/transcripts/transcript.jsonl",
 		});
 
-		const evidence = getOntologyProposalEvidence(getDbAccessor(), proposal.id, "ant");
+		const evidence = await getOntologyProposalEvidence(getDbAccessor(), proposal.id, "ant");
 
 		expect(evidence.count).toBe(2);
 		expect(evidence.items[0]?.kind).toBe("session_transcript");
@@ -1100,7 +1100,7 @@ describe("ontology proposals", () => {
 		expect(evidence.items[1]?.excerpt).toContain("preserve lineage");
 	});
 
-	it("resolves applied claim evidence from stored attribute provenance", () => {
+	it("resolves applied claim evidence from stored attribute provenance", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				`INSERT INTO session_transcripts
@@ -1134,7 +1134,7 @@ describe("ontology proposals", () => {
 				"2026-05-06T00:01:00.000Z",
 			);
 		});
-		const proposal = createOntologyProposal(getDbAccessor(), {
+		const proposal = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "add_claim_value",
 			payload: {
@@ -1150,9 +1150,9 @@ describe("ontology proposals", () => {
 			sourceId: "transcript:claim",
 			sourcePath: "memory/codex/transcripts/claim.jsonl",
 		});
-		applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: proposal.id, actor: "ant" });
+		await applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: proposal.id, actor: "ant" });
 
-		const evidence = getOntologyClaimEvidence(getDbAccessor(), {
+		const evidence = await getOntologyClaimEvidence(getDbAccessor(), {
 			agentId: "ant",
 			entity: "Signet",
 			aspect: "architecture",
@@ -1175,23 +1175,23 @@ describe("ontology proposals", () => {
 		expect(evidence.items[0]?.evidence[2]?.excerpt).toContain("auditable lineage");
 	});
 
-	it("falls back to embedded quotes when source rows are not present", () => {
-		const proposal = createOntologyProposal(getDbAccessor(), {
+	it("falls back to embedded quotes when source rows are not present", async () => {
+		const proposal = await createOntologyProposal(getDbAccessor(), {
 			agentId: "default",
 			operation: "create_entity",
 			payload: { name: "Quoted Evidence" },
 			evidence: [{ transcript_id: "missing", quote: "This quote still explains the proposal." }],
 		});
 
-		const evidence = getOntologyProposalEvidence(getDbAccessor(), proposal.id, "default");
+		const evidence = await getOntologyProposalEvidence(getDbAccessor(), proposal.id, "default");
 
 		expect(evidence.items).toHaveLength(1);
 		expect(evidence.items[0]?.kind).toBe("provided_quote");
 		expect(evidence.items[0]?.excerpt).toBe("This quote still explains the proposal.");
 	});
 
-	it("applies supersede_claim_value by preserving old values and adding replacements", () => {
-		const initial = createOntologyProposal(getDbAccessor(), {
+	it("applies supersede_claim_value by preserving old values and adding replacements", async () => {
+		const initial = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "add_claim_value",
 			payload: {
@@ -1204,7 +1204,7 @@ describe("ontology proposals", () => {
 			},
 			confidence: 0.4,
 		});
-		const initialApplied = applyOntologyProposal(getDbAccessor(), {
+		const initialApplied = await applyOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			id: initial.id,
 			actor: "test",
@@ -1212,7 +1212,7 @@ describe("ontology proposals", () => {
 		const oldId = initialApplied.result?.attributeId;
 		if (typeof oldId !== "string") throw new Error("initial attribute id was not returned");
 
-		const supersede = createOntologyProposal(getDbAccessor(), {
+		const supersede = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "supersede_claim_value",
 			payload: {
@@ -1228,7 +1228,7 @@ describe("ontology proposals", () => {
 			sourceId: "transcript:proposal-loop",
 		});
 
-		const applied = applyOntologyProposal(getDbAccessor(), {
+		const applied = await applyOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			id: supersede.id,
 			actor: "test",
@@ -1282,8 +1282,8 @@ describe("ontology proposals", () => {
 		});
 	});
 
-	it("applies semantic create_link proposal roles from ontology extraction", () => {
-		const proposal = createOntologyProposal(getDbAccessor(), {
+	it("applies semantic create_link proposal roles from ontology extraction", async () => {
+		const proposal = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "create_link",
 			payload: {
@@ -1299,7 +1299,7 @@ describe("ontology proposals", () => {
 			sourceId: "transcript:semantic-link",
 		});
 
-		const applied = applyOntologyProposal(getDbAccessor(), {
+		const applied = await applyOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			id: proposal.id,
 			actor: "test",
@@ -1340,7 +1340,7 @@ describe("ontology proposals", () => {
 		expect(row?.target_type).toBe("concept");
 	});
 
-	it("resolves applied link evidence from stored dependency provenance", () => {
+	it("resolves applied link evidence from stored dependency provenance", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				`INSERT INTO session_transcripts
@@ -1374,7 +1374,7 @@ describe("ontology proposals", () => {
 				"2026-05-06T00:01:00.000Z",
 			);
 		});
-		const proposal = createOntologyProposal(getDbAccessor(), {
+		const proposal = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "create_link",
 			payload: {
@@ -1389,11 +1389,11 @@ describe("ontology proposals", () => {
 			sourceId: "transcript:link",
 			sourcePath: "memory/codex/transcripts/link.jsonl",
 		});
-		const applied = applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: proposal.id, actor: "test" });
+		const applied = await applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: proposal.id, actor: "test" });
 		const dependencyId = applied.result?.dependencyId;
 		expect(typeof dependencyId).toBe("string");
 
-		const evidence = getOntologyLinkEvidence(getDbAccessor(), {
+		const evidence = await getOntologyLinkEvidence(getDbAccessor(), {
 			agentId: "ant",
 			id: dependencyId as string,
 		});
@@ -1410,8 +1410,8 @@ describe("ontology proposals", () => {
 		expect(evidence.items[2]?.excerpt).toContain("supports the proposal-loop claim");
 	});
 
-	it("groups pending add_claim_value conflicts by claim slot", () => {
-		createOntologyProposals(getDbAccessor(), [
+	it("groups pending add_claim_value conflicts by claim slot", async () => {
+		await createOntologyProposals(getDbAccessor(), [
 			{
 				agentId: "ant",
 				operation: "add_claim_value",
@@ -1449,8 +1449,8 @@ describe("ontology proposals", () => {
 			},
 		]);
 
-		const conflicts = listOntologyProposalConflicts(getDbAccessor(), { agentId: "ant" });
-		const other = listOntologyProposalConflicts(getDbAccessor(), { agentId: "dot" });
+		const conflicts = await listOntologyProposalConflicts(getDbAccessor(), { agentId: "ant" });
+		const other = await listOntologyProposalConflicts(getDbAccessor(), { agentId: "dot" });
 
 		expect(conflicts.count).toBe(1);
 		expect(conflicts.items[0]?.entity).toBe("Signet");
@@ -1459,8 +1459,8 @@ describe("ontology proposals", () => {
 		expect(other.count).toBe(0);
 	});
 
-	it("applies merge_entities by moving aspects and deleting duplicate sources", () => {
-		const target = createOntologyProposal(getDbAccessor(), {
+	it("applies merge_entities by moving aspects and deleting duplicate sources", async () => {
+		const target = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "add_claim_value",
 			payload: {
@@ -1472,9 +1472,9 @@ describe("ontology proposals", () => {
 				value: "Agent-first ontology",
 			},
 		});
-		applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: target.id, actor: "test" });
+		await applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: target.id, actor: "test" });
 
-		const duplicate = createOntologyProposal(getDbAccessor(), {
+		const duplicate = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "add_claim_value",
 			payload: {
@@ -1486,9 +1486,9 @@ describe("ontology proposals", () => {
 				value: "Proposal-first mutation loop",
 			},
 		});
-		applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: duplicate.id, actor: "test" });
+		await applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: duplicate.id, actor: "test" });
 
-		const merge = createOntologyProposal(getDbAccessor(), {
+		const merge = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "merge_entities",
 			payload: {
@@ -1498,7 +1498,7 @@ describe("ontology proposals", () => {
 			rationale: "Both names refer to the same product entity.",
 		});
 
-		const applied = applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: merge.id, actor: "test" });
+		const applied = await applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: merge.id, actor: "test" });
 
 		expect(applied.status).toBe("applied");
 		expect(applied.result?.mergedEntities).toHaveLength(1);
@@ -1527,8 +1527,8 @@ describe("ontology proposals", () => {
 		expect(rows.map((row) => row.content)).toContain("Proposal-first mutation loop");
 	});
 
-	it("applies ID-first merge_entities when entity names are ambiguous", () => {
-		const target = createOntologyProposal(getDbAccessor(), {
+	it("applies ID-first merge_entities when entity names are ambiguous", async () => {
+		const target = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "add_claim_value",
 			payload: {
@@ -1540,9 +1540,9 @@ describe("ontology proposals", () => {
 				value: "Context substrate",
 			},
 		});
-		applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: target.id, actor: "test" });
+		await applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: target.id, actor: "test" });
 
-		const source = createOntologyProposal(getDbAccessor(), {
+		const source = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "add_claim_value",
 			payload: {
@@ -1554,7 +1554,7 @@ describe("ontology proposals", () => {
 				value: "Proposal-first maintenance.",
 			},
 		});
-		applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: source.id, actor: "test" });
+		await applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: source.id, actor: "test" });
 
 		const ids = getDbAccessor().withWriteTx((db) => {
 			const targetRow = db.prepare("SELECT id FROM entities WHERE agent_id = ? AND name = ?").get("ant", "Signet") as {
@@ -1580,7 +1580,7 @@ describe("ontology proposals", () => {
 			return { targetId: targetRow.id, sourceId: sourceRow.id };
 		});
 
-		const merge = createOntologyProposal(getDbAccessor(), {
+		const merge = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "merge_entities",
 			payload: {
@@ -1591,14 +1591,14 @@ describe("ontology proposals", () => {
 			},
 		});
 
-		const applied = applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: merge.id, actor: "test" });
+		const applied = await applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: merge.id, actor: "test" });
 
 		expect(applied.status).toBe("applied");
 		expect(applied.result?.targetEntityId).toBe(ids.targetId);
 		expect(applied.result?.mergedEntities).toEqual([{ name: "Signet Alias", entityId: ids.sourceId, movedAspects: 1 }]);
 	});
 
-	it("deduplicates dependency edges while merging entities", () => {
+	it("deduplicates dependency edges while merging entities", async () => {
 		insertEntity("entity-target", "Target", "target", "ant", 8);
 		insertEntity("entity-source", "Source", "source", "ant", 4);
 		insertEntity("entity-dependency-target", "Dependency Target", "dependency target", "ant", 2);
@@ -1630,7 +1630,7 @@ describe("ontology proposals", () => {
 			);
 		});
 
-		const proposal = createOntologyProposal(getDbAccessor(), {
+		const proposal = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "merge_entities",
 			payload: {
@@ -1638,7 +1638,7 @@ describe("ontology proposals", () => {
 				source_entity_ids: ["entity-source"],
 			},
 		});
-		const applied = applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: proposal.id, actor: "test" });
+		const applied = await applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: proposal.id, actor: "test" });
 
 		expect(applied.status).toBe("applied");
 		const edges = getDbAccessor().withReadDb(
@@ -1660,10 +1660,10 @@ describe("ontology proposals", () => {
 		]);
 	});
 
-	it("treats a merge proposal as applied when its source was already merged", () => {
+	it("treats a merge proposal as applied when its source was already merged", async () => {
 		insertEntity("entity-target", "Target", "target", "ant", 8);
 		insertEntity("entity-source", "Source", "source", "ant", 4);
-		const first = createOntologyProposal(getDbAccessor(), {
+		const first = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "merge_entities",
 			payload: {
@@ -1672,9 +1672,9 @@ describe("ontology proposals", () => {
 				source_entity_ids: ["entity-source"],
 			},
 		});
-		applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: first.id, actor: "test" });
+		await applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: first.id, actor: "test" });
 
-		const retry = createOntologyProposal(getDbAccessor(), {
+		const retry = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "merge_entities",
 			payload: {
@@ -1683,13 +1683,13 @@ describe("ontology proposals", () => {
 				source_entity_ids: ["entity-source"],
 			},
 		});
-		const applied = applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: retry.id, actor: "test" });
+		const applied = await applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: retry.id, actor: "test" });
 
 		expect(applied.status).toBe("applied");
 		expect(applied.result?.mergedEntities).toEqual([]);
 		expect(applied.result?.alreadyMergedEntities).toEqual(["Source"]);
 
-		const nameOnlyRetry = createOntologyProposal(getDbAccessor(), {
+		const nameOnlyRetry = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "merge_entities",
 			payload: {
@@ -1697,7 +1697,7 @@ describe("ontology proposals", () => {
 				source_entities: ["Source"],
 			},
 		});
-		const nameOnlyApplied = applyOntologyProposal(getDbAccessor(), {
+		const nameOnlyApplied = await applyOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			id: nameOnlyRetry.id,
 			actor: "test",
@@ -1708,12 +1708,12 @@ describe("ontology proposals", () => {
 		expect(nameOnlyApplied.result?.alreadyMergedEntities).toEqual(["Source"]);
 	});
 
-	it("rejects merge_entities when supplied IDs and names disagree", () => {
+	it("rejects merge_entities when supplied IDs and names disagree", async () => {
 		insertEntity("entity-signet", "Signet", "signet", "ant", 8);
 		insertEntity("entity-other", "Other", "other", "ant", 4);
 		insertEntity("entity-alias", "Signet Alias", "signet alias", "ant", 1);
 
-		const merge = createOntologyProposal(getDbAccessor(), {
+		const merge = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "merge_entities",
 			payload: {
@@ -1723,18 +1723,18 @@ describe("ontology proposals", () => {
 			},
 		});
 
-		expect(() => applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: merge.id, actor: "test" })).toThrow(
-			OntologyProposalError,
-		);
+		await expect(
+			applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: merge.id, actor: "test" }),
+		).rejects.toThrow(OntologyProposalError);
 	});
 
-	it("dry-runs duplicate entity repair candidates without creating proposals", () => {
+	it("dry-runs duplicate entity repair candidates without creating proposals", async () => {
 		insertEntity("entity-signet", "Signet", "signet", "ant", 8, true);
 		insertEntity("entity-signet-upper", "SIGNET", "signet", "ant", 3);
 		insertEntity("entity-signet-ai", "signet.ai", "signet", "ant", 1);
 		insertEntity("entity-other", "Other Project", "other project", "ant", 4);
 
-		const result = proposeDuplicateEntityMerges(getDbAccessor(), {
+		const result = await proposeDuplicateEntityMerges(getDbAccessor(), {
 			agentId: "ant",
 			limit: 10,
 		});
@@ -1747,15 +1747,15 @@ describe("ontology proposals", () => {
 		expect(result.items[0]?.target.name).toBe("Signet");
 		expect(result.items[0]?.sources.map((source) => source.name).sort()).toEqual(["SIGNET", "signet.ai"]);
 
-		const listed = listOntologyProposals(getDbAccessor(), { agentId: "ant", operation: "merge_entities" });
+		const listed = await listOntologyProposals(getDbAccessor(), { agentId: "ant", operation: "merge_entities" });
 		expect(listed.items).toHaveLength(0);
 	});
 
-	it("blocks mixed-type duplicate entity repair proposals by default", () => {
+	it("blocks mixed-type duplicate entity repair proposals by default", async () => {
 		insertEntity("entity-signet", "Signet", "signet", "ant", 8, true, "project");
 		insertEntity("entity-signet-skill", "signet", "signet", "ant", 3, false, "skill");
 
-		const result = proposeDuplicateEntityMerges(getDbAccessor(), {
+		const result = await proposeDuplicateEntityMerges(getDbAccessor(), {
 			agentId: "ant",
 			limit: 10,
 			writeProposals: true,
@@ -1767,21 +1767,21 @@ describe("ontology proposals", () => {
 		expect(result.skippedCount).toBe(1);
 		expect(result.items[0]?.blocked).toBe(true);
 		expect(result.items[0]?.warnings.join("\n")).toContain("differs from target type");
-		const listed = listOntologyProposals(getDbAccessor(), { agentId: "ant", operation: "merge_entities" });
+		const listed = await listOntologyProposals(getDbAccessor(), { agentId: "ant", operation: "merge_entities" });
 		expect(listed.items).toHaveLength(0);
 	});
 
-	it("writes duplicate entity repair candidates as pending merge proposals only once", () => {
+	it("writes duplicate entity repair candidates as pending merge proposals only once", async () => {
 		insertEntity("entity-signet", "Signet", "signet", "ant", 8, true);
 		insertEntity("entity-signet-upper", "SIGNET", "signet", "ant", 3);
 
-		const result = proposeDuplicateEntityMerges(getDbAccessor(), {
+		const result = await proposeDuplicateEntityMerges(getDbAccessor(), {
 			agentId: "ant",
 			limit: 10,
 			writeProposals: true,
 			createdBy: "repair-test",
 		});
-		const second = proposeDuplicateEntityMerges(getDbAccessor(), {
+		const second = await proposeDuplicateEntityMerges(getDbAccessor(), {
 			agentId: "ant",
 			limit: 10,
 			writeProposals: true,
@@ -1798,15 +1798,15 @@ describe("ontology proposals", () => {
 		expect(second.count).toBe(0);
 		expect(second.writtenCount).toBe(0);
 
-		const listed = listOntologyProposals(getDbAccessor(), { agentId: "ant", operation: "merge_entities" });
+		const listed = await listOntologyProposals(getDbAccessor(), { agentId: "ant", operation: "merge_entities" });
 		expect(listed.items).toHaveLength(1);
 	});
 
-	it("previews and writes manual entity merge plans with ID-first payloads", () => {
+	it("previews and writes manual entity merge plans with ID-first payloads", async () => {
 		insertEntity("entity-signet", "Signet", "signet", "ant", 8);
 		insertEntity("entity-alias", "Signet Alias", "signet alias", "ant", 2);
 
-		const preview = createEntityMergePlan(getDbAccessor(), {
+		const preview = await createEntityMergePlan(getDbAccessor(), {
 			agentId: "ant",
 			targetEntityId: "entity-signet",
 			sourceEntityIds: ["entity-alias"],
@@ -1817,7 +1817,7 @@ describe("ontology proposals", () => {
 		expect(preview.payload.target_entity_id).toBe("entity-signet");
 		expect(preview.payload.source_entity_ids).toEqual(["entity-alias"]);
 
-		const written = createEntityMergePlan(getDbAccessor(), {
+		const written = await createEntityMergePlan(getDbAccessor(), {
 			agentId: "ant",
 			targetEntityId: "entity-signet",
 			sourceEntityIds: ["entity-alias"],
@@ -1831,11 +1831,11 @@ describe("ontology proposals", () => {
 		expect(written.proposal?.payload.target_entity_id).toBe("entity-signet");
 	});
 
-	it("keeps blocked manual merge-plan writes reported as dry-runs", () => {
+	it("keeps blocked manual merge-plan writes reported as dry-runs", async () => {
 		insertEntity("entity-signet", "Signet", "signet", "ant", 8, false, "project");
 		insertEntity("entity-signet-skill", "signet", "signet", "ant", 2, false, "skill");
 
-		const result = createEntityMergePlan(getDbAccessor(), {
+		const result = await createEntityMergePlan(getDbAccessor(), {
 			agentId: "ant",
 			targetEntityId: "entity-signet",
 			sourceEntityIds: ["entity-signet-skill"],
@@ -1846,36 +1846,36 @@ describe("ontology proposals", () => {
 		expect(result.blocked).toBe(true);
 		expect(result.dryRun).toBe(true);
 		expect(result.proposal).toBeUndefined();
-		const listed = listOntologyProposals(getDbAccessor(), { agentId: "ant", operation: "merge_entities" });
+		const listed = await listOntologyProposals(getDbAccessor(), { agentId: "ant", operation: "merge_entities" });
 		expect(listed.items).toHaveLength(0);
 	});
 
-	it("rejects invalid proposal batches without partial writes", () => {
-		expect(() =>
+	it("rejects invalid proposal batches without partial writes", async () => {
+		await expect(
 			createOntologyProposals(getDbAccessor(), [
 				{ agentId: "default", operation: "create_entity", payload: { name: "Valid" } },
 				{ agentId: "default", operation: " ", payload: { name: "Invalid" } },
 			]),
-		).toThrow(OntologyProposalError);
+		).rejects.toThrow(OntologyProposalError);
 
-		const listed = listOntologyProposals(getDbAccessor(), { agentId: "default" });
+		const listed = await listOntologyProposals(getDbAccessor(), { agentId: "default" });
 		expect(listed.items).toHaveLength(0);
 	});
 
-	it("keeps proposal listing scoped to agent_id", () => {
-		createOntologyProposal(getDbAccessor(), {
+	it("keeps proposal listing scoped to agent_id", async () => {
+		await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "create_entity",
 			payload: { name: "Ant Project" },
 		});
-		createOntologyProposal(getDbAccessor(), {
+		await createOntologyProposal(getDbAccessor(), {
 			agentId: "dot",
 			operation: "create_entity",
 			payload: { name: "Dot Project" },
 		});
 
-		const ant = listOntologyProposals(getDbAccessor(), { agentId: "ant" });
-		const dot = listOntologyProposals(getDbAccessor(), { agentId: "dot" });
+		const ant = await listOntologyProposals(getDbAccessor(), { agentId: "ant" });
+		const dot = await listOntologyProposals(getDbAccessor(), { agentId: "dot" });
 
 		expect(ant.items).toHaveLength(1);
 		expect(dot.items).toHaveLength(1);
@@ -1883,8 +1883,8 @@ describe("ontology proposals", () => {
 		expect(dot.items[0]?.payload.name).toBe("Dot Project");
 	});
 
-	it("applies policy, action, and interface operations through existing graph primitives", () => {
-		const policy = applyOntologyOperation(getDbAccessor(), {
+	it("applies policy, action, and interface operations through existing graph primitives", async () => {
+		const policy = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "default",
 			actor: "operator",
 			operation: "create_policy",
@@ -1895,19 +1895,19 @@ describe("ontology proposals", () => {
 			},
 		});
 		expect(policy.proposal.status).toBe("applied");
-		const action = applyOntologyOperation(getDbAccessor(), {
+		const action = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "default",
 			actor: "operator",
 			operation: "create_action_type",
 			payload: { action_type: "Deploy release" },
 		});
-		const iface = applyOntologyOperation(getDbAccessor(), {
+		const iface = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "default",
 			actor: "operator",
 			operation: "create_interface",
 			payload: { name: "Memory provider" },
 		});
-		const attachment = applyOntologyOperation(getDbAccessor(), {
+		const attachment = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "default",
 			actor: "operator",
 			operation: "attach_interface",
@@ -1940,8 +1940,8 @@ describe("ontology proposals", () => {
 		expect(graph.link).toMatchObject({ dependency_type: "implements" });
 	});
 
-	it("applies direct operations by creating an applied proposal and graph mutation atomically", () => {
-		const result = applyOntologyOperation(getDbAccessor(), {
+	it("applies direct operations by creating an applied proposal and graph mutation atomically", async () => {
+		const result = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "set_claim_value",
@@ -1964,7 +1964,7 @@ describe("ontology proposals", () => {
 		expect(result.proposal.appliedBy).toBe("operator");
 		expect(result.result?.version).toBe(1);
 
-		const attrs = listClaimVersions(getDbAccessor(), {
+		const attrs = await listClaimVersions(getDbAccessor(), {
 			agentId: "ant",
 			entity: "Signet",
 			aspect: "architecture",
@@ -1976,8 +1976,8 @@ describe("ontology proposals", () => {
 		expect(attrs.items[0]?.content).toContain("audited");
 	});
 
-	it("dry-runs direct operations without writing proposals or graph state", () => {
-		const result = applyOntologyOperation(getDbAccessor(), {
+	it("dry-runs direct operations without writing proposals or graph state", async () => {
+		const result = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "create_entity",
@@ -1987,7 +1987,7 @@ describe("ontology proposals", () => {
 
 		expect(result.dryRun).toBe(true);
 		expect(result.proposal.status).toBe("applied");
-		const proposal = getOntologyProposal(getDbAccessor(), result.proposal.id, "ant");
+		const proposal = await getOntologyProposal(getDbAccessor(), result.proposal.id, "ant");
 		const entity = getDbAccessor().withReadDb(
 			(db) =>
 				db.prepare("SELECT id FROM entities WHERE agent_id = ? AND name = ?").get("ant", "Dry Run Entity") as
@@ -1998,7 +1998,7 @@ describe("ontology proposals", () => {
 		expect(entity).toBeNull();
 	});
 
-	it("exercises dry-run, apply, propose, reject, evidence, and immutable source artifacts end to end", () => {
+	it("exercises dry-run, apply, propose, reject, evidence, and immutable source artifacts end to end", async () => {
 		const sourcePath = "memory/codex/transcripts/control-plane-e2e.jsonl";
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
@@ -2035,16 +2035,16 @@ describe("ontology proposals", () => {
 			claim_key: "control_plane_e2e",
 			value: "Ontology control-plane mutations apply first with provenance.",
 		};
-		const dryRun = applyOntologyOperationBatch(getDbAccessor(), {
+		const dryRun = await applyOntologyOperationBatch(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			dryRun: true,
 			operations: [{ operation: "set_claim_value", payload }],
 		});
 		expect(dryRun.dryRun).toBe(true);
-		expect(listOntologyProposals(getDbAccessor(), { agentId: "ant" }).items).toHaveLength(0);
+		expect((await listOntologyProposals(getDbAccessor(), { agentId: "ant" })).items).toHaveLength(0);
 
-		const applied = applyOntologyOperation(getDbAccessor(), {
+		const applied = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "set_claim_value",
@@ -2054,20 +2054,20 @@ describe("ontology proposals", () => {
 			sourcePath,
 			evidence: [{ source_kind: "memory_artifact", source_path: sourcePath, quote: "apply first with provenance" }],
 		});
-		const proposed = applyOntologyOperation(getDbAccessor(), {
+		const proposed = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "create_entity",
 			payload: { name: "Rejected Candidate", entity_type: "project" },
 			propose: true,
 		});
-		const rejected = rejectOntologyProposal(getDbAccessor(), {
+		const rejected = await rejectOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			id: proposed.proposal.id,
 			actor: "operator",
 			reason: "proposal review rejected this candidate",
 		});
-		const evidence = getOntologyClaimEvidence(getDbAccessor(), {
+		const evidence = await getOntologyClaimEvidence(getDbAccessor(), {
 			agentId: "ant",
 			entity: "Signet",
 			aspect: "architecture",
@@ -2088,8 +2088,8 @@ describe("ontology proposals", () => {
 		expect(sourceAfter?.content).toBe(sourceBefore?.content);
 	});
 
-	it("proposes direct operations without mutating graph state", () => {
-		const result = applyOntologyOperation(getDbAccessor(), {
+	it("proposes direct operations without mutating graph state", async () => {
+		const result = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "create_entity",
@@ -2108,7 +2108,7 @@ describe("ontology proposals", () => {
 		expect(entity).toBeNull();
 	});
 
-	it("set_claim_value creates queryable version chains and restore switches the active version", () => {
+	it("set_claim_value creates queryable version chains and restore switches the active version", async () => {
 		const payload = {
 			entity: "Signet",
 			entity_type: "project",
@@ -2116,19 +2116,19 @@ describe("ontology proposals", () => {
 			group_key: "ontology",
 			claim_key: "versioned_claim",
 		};
-		const v1 = applyOntologyOperation(getDbAccessor(), {
+		const v1 = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "set_claim_value",
 			payload: { ...payload, value: "Version one." },
 		});
-		const v2 = applyOntologyOperation(getDbAccessor(), {
+		const v2 = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "set_claim_value",
 			payload: { ...payload, value: "Version two." },
 		});
-		const v3 = applyOntologyOperation(getDbAccessor(), {
+		const v3 = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "set_claim_value",
@@ -2138,7 +2138,7 @@ describe("ontology proposals", () => {
 		expect(v1.result?.version).toBe(1);
 		expect(v2.result?.version).toBe(2);
 		expect(v3.result?.version).toBe(3);
-		const versions = listClaimVersions(getDbAccessor(), {
+		const versions = await listClaimVersions(getDbAccessor(), {
 			agentId: "ant",
 			entity: "Signet",
 			aspect: "architecture",
@@ -2148,7 +2148,7 @@ describe("ontology proposals", () => {
 		expect(versions.items.map((item) => item.version)).toEqual([3, 2, 1]);
 		expect(versions.items.map((item) => item.status)).toEqual(["active", "superseded", "superseded"]);
 
-		const shown = getClaimVersion(getDbAccessor(), {
+		const shown = await getClaimVersion(getDbAccessor(), {
 			agentId: "ant",
 			entity: "Signet",
 			aspect: "architecture",
@@ -2158,13 +2158,13 @@ describe("ontology proposals", () => {
 		});
 		expect(shown?.content).toBe("Version two.");
 
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "restore_claim_version",
 			payload: { attribute_id: shown?.id },
 		});
-		const restored = listClaimVersions(getDbAccessor(), {
+		const restored = await listClaimVersions(getDbAccessor(), {
 			agentId: "ant",
 			entity: "Signet",
 			aspect: "architecture",
@@ -2190,8 +2190,8 @@ describe("ontology proposals", () => {
 		expect(restoredMemoryState.find((memory) => memory.id === v3.result?.attributeId)?.superseded_by).toBe(shown?.id);
 	});
 
-	it("archives claim values and hides them from default active reads", () => {
-		const applied = applyOntologyOperation(getDbAccessor(), {
+	it("archives claim values and hides them from default active reads", async () => {
+		const applied = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "set_claim_value",
@@ -2205,7 +2205,7 @@ describe("ontology proposals", () => {
 			},
 		});
 		const attributeId = applied.result?.attributeId as string;
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "archive_claim_value",
@@ -2218,7 +2218,7 @@ describe("ontology proposals", () => {
 					.prepare("SELECT COUNT(*) AS n FROM entity_attributes WHERE id = ? AND status = 'active'")
 					.get(attributeId) as { n: number },
 		);
-		const versions = listClaimVersions(getDbAccessor(), {
+		const versions = await listClaimVersions(getDbAccessor(), {
 			agentId: "ant",
 			entity: "Signet",
 			aspect: "architecture",
@@ -2236,8 +2236,8 @@ describe("ontology proposals", () => {
 		expect(memory?.is_deleted).toBe(1);
 	});
 
-	it("restores an archived semantic claim memory and honors an explicit force", () => {
-		const applied = applyOntologyOperation(getDbAccessor(), {
+	it("restores an archived semantic claim memory and honors an explicit force", async () => {
+		const applied = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "set_claim_value",
@@ -2254,13 +2254,13 @@ describe("ontology proposals", () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare("UPDATE memories SET pinned = 1 WHERE id = ?").run(attributeId);
 		});
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "archive_claim_value",
 			payload: { attribute_id: attributeId, force: true },
 		});
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "restore_claim_version",
@@ -2279,7 +2279,7 @@ describe("ontology proposals", () => {
 		expect(restored).toEqual({ status: "active", is_deleted: 0, superseded_by: null });
 	});
 
-	it("continues claim version chains after the active value is archived", () => {
+	it("continues claim version chains after the active value is archived", async () => {
 		const payload = {
 			entity: "Archive Version Chain",
 			entity_type: "project",
@@ -2287,26 +2287,26 @@ describe("ontology proposals", () => {
 			group_key: "ontology",
 			claim_key: "archived_chain",
 		};
-		const first = applyOntologyOperation(getDbAccessor(), {
+		const first = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "set_claim_value",
 			payload: { ...payload, value: "Archived first version." },
 		});
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "archive_claim_value",
 			payload: { attribute_id: first.result?.attributeId, reason: "retired" },
 		});
-		const second = applyOntologyOperation(getDbAccessor(), {
+		const second = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "set_claim_value",
 			payload: { ...payload, value: "Replacement after archive." },
 		});
 
-		const versions = listClaimVersions(getDbAccessor(), {
+		const versions = await listClaimVersions(getDbAccessor(), {
 			agentId: "ant",
 			entity: "Archive Version Chain",
 			aspect: "architecture",
@@ -2321,8 +2321,8 @@ describe("ontology proposals", () => {
 		expect(versions.items.map((item) => item.status)).toEqual(["active", "deleted"]);
 	});
 
-	it("preserves original claim provenance when repeated writes dedupe", () => {
-		const first = createOntologyProposal(getDbAccessor(), {
+	it("preserves original claim provenance when repeated writes dedupe", async () => {
+		const first = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "set_claim_value",
 			payload: {
@@ -2336,12 +2336,12 @@ describe("ontology proposals", () => {
 			evidence: [{ source: "transcript:first", message_ids: ["m1"] }],
 			createdBy: "first",
 		});
-		const applied = applyOntologyProposal(getDbAccessor(), {
+		const applied = await applyOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			id: first.id,
 			actor: "operator",
 		});
-		const repeated = createOntologyProposal(getDbAccessor(), {
+		const repeated = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "set_claim_value",
 			payload: {
@@ -2356,7 +2356,7 @@ describe("ontology proposals", () => {
 			createdBy: "repeat",
 		});
 
-		const second = applyOntologyProposal(getDbAccessor(), {
+		const second = await applyOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			id: repeated.id,
 			actor: "operator",
@@ -2376,8 +2376,8 @@ describe("ontology proposals", () => {
 		expect(JSON.parse(row?.proposal_evidence ?? "[]")).toEqual([{ source: "transcript:first", message_ids: ["m1"] }]);
 	});
 
-	it("preserves original additive claim provenance when repeated values dedupe", () => {
-		const first = createOntologyProposal(getDbAccessor(), {
+	it("preserves original additive claim provenance when repeated values dedupe", async () => {
+		const first = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "add_claim_value",
 			payload: {
@@ -2391,12 +2391,12 @@ describe("ontology proposals", () => {
 			evidence: [{ source: "transcript:first-add", message_ids: ["m1"] }],
 			createdBy: "first",
 		});
-		const applied = applyOntologyProposal(getDbAccessor(), {
+		const applied = await applyOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			id: first.id,
 			actor: "operator",
 		});
-		const repeated = createOntologyProposal(getDbAccessor(), {
+		const repeated = await createOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			operation: "add_claim_value",
 			payload: {
@@ -2411,7 +2411,7 @@ describe("ontology proposals", () => {
 			createdBy: "repeat",
 		});
 
-		const second = applyOntologyProposal(getDbAccessor(), {
+		const second = await applyOntologyProposal(getDbAccessor(), {
 			agentId: "ant",
 			id: repeated.id,
 			actor: "operator",
@@ -2433,14 +2433,14 @@ describe("ontology proposals", () => {
 		]);
 	});
 
-	it("records the applying actor when pending archive proposals are applied", () => {
-		const entity = applyOntologyOperation(getDbAccessor(), {
+	it("records the applying actor when pending archive proposals are applied", async () => {
+		const entity = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "creator",
 			operation: "create_entity",
 			payload: { name: "Archive Actor Entity", entity_type: "project" },
 		});
-		const claim = applyOntologyOperation(getDbAccessor(), {
+		const claim = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "creator",
 			operation: "set_claim_value",
@@ -2453,7 +2453,7 @@ describe("ontology proposals", () => {
 				value: "Archive me.",
 			},
 		});
-		const link = applyOntologyOperation(getDbAccessor(), {
+		const link = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "creator",
 			operation: "create_link",
@@ -2466,7 +2466,7 @@ describe("ontology proposals", () => {
 				reason: "Audit actor fixture.",
 			},
 		});
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "creator",
 			operation: "set_claim_value",
@@ -2480,7 +2480,7 @@ describe("ontology proposals", () => {
 			},
 		});
 
-		const proposals = createOntologyProposals(getDbAccessor(), [
+		const proposals = await createOntologyProposals(getDbAccessor(), [
 			{
 				agentId: "ant",
 				operation: "archive_entity",
@@ -2508,7 +2508,7 @@ describe("ontology proposals", () => {
 		]);
 
 		for (const proposal of proposals.items) {
-			applyOntologyProposal(getDbAccessor(), {
+			await applyOntologyProposal(getDbAccessor(), {
 				agentId: "ant",
 				id: proposal.id,
 				actor: "reviewer",
@@ -2560,8 +2560,8 @@ describe("ontology proposals", () => {
 		});
 	});
 
-	it("reactivates archived aspects when creating claims for the same aspect slot", () => {
-		applyOntologyOperation(getDbAccessor(), {
+	it("reactivates archived aspects when creating claims for the same aspect slot", async () => {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "set_claim_value",
@@ -2574,13 +2574,13 @@ describe("ontology proposals", () => {
 				value: "Before archive.",
 			},
 		});
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "archive_aspect",
 			payload: { entity: "Aspect Restore", selector: "architecture", reason: "retired" },
 		});
-		const recreated = applyOntologyOperation(getDbAccessor(), {
+		const recreated = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "set_claim_value",
@@ -2612,8 +2612,8 @@ describe("ontology proposals", () => {
 		expect(row?.claim_status).toBe("active");
 	});
 
-	it("reactivates archived links when creating the same link again", () => {
-		const created = applyOntologyOperation(getDbAccessor(), {
+	it("reactivates archived links when creating the same link again", async () => {
+		const created = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "create_link",
@@ -2626,13 +2626,13 @@ describe("ontology proposals", () => {
 				reason: "Initial relationship.",
 			},
 		});
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "archive_link",
 			payload: { id: created.result?.dependencyId, reason: "retired" },
 		});
-		const recreated = applyOntologyOperation(getDbAccessor(), {
+		const recreated = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "create_link",
@@ -2663,8 +2663,8 @@ describe("ontology proposals", () => {
 		expect(row?.strength).toBeCloseTo(0.9);
 	});
 
-	it("keeps claim version history readable after archiving its parent entity", () => {
-		applyOntologyOperation(getDbAccessor(), {
+	it("keeps claim version history readable after archiving its parent entity", async () => {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "set_claim_value",
@@ -2677,21 +2677,21 @@ describe("ontology proposals", () => {
 				value: "History survives entity archival.",
 			},
 		});
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			operation: "archive_entity",
 			payload: { selector: "Signet", reason: "retired" },
 		});
 
-		const versions = listClaimVersions(getDbAccessor(), {
+		const versions = await listClaimVersions(getDbAccessor(), {
 			agentId: "ant",
 			entity: "Signet",
 			aspect: "architecture",
 			group: "ontology",
 			claim: "archived_parent_history",
 		});
-		const version = getClaimVersion(getDbAccessor(), {
+		const version = await getClaimVersion(getDbAccessor(), {
 			agentId: "ant",
 			entity: "Signet",
 			aspect: "architecture",
@@ -2703,7 +2703,7 @@ describe("ontology proposals", () => {
 		expect(version?.content).toBe("History survives entity archival.");
 	});
 
-	it("requires strict claim-version entity selectors across archived duplicates", () => {
+	it("requires strict claim-version entity selectors across archived duplicates", async () => {
 		insertEntity("archived-history", "Duplicate History A", "duplicate history", "ant", 1);
 		insertEntity("active-history", "Duplicate History B", "duplicate history", "ant", 2);
 		getDbAccessor().withWriteTx((db) => {
@@ -2752,7 +2752,7 @@ describe("ontology proposals", () => {
 			);
 		});
 
-		expect(() =>
+		await expect(
 			listClaimVersions(getDbAccessor(), {
 				agentId: "ant",
 				entity: "duplicate history",
@@ -2760,15 +2760,15 @@ describe("ontology proposals", () => {
 				group: "ontology",
 				claim: "lineage",
 			}),
-		).toThrow("ambiguous");
-		const archivedVersions = listClaimVersions(getDbAccessor(), {
+		).rejects.toThrow("ambiguous");
+		const archivedVersions = await listClaimVersions(getDbAccessor(), {
 			agentId: "ant",
 			entity: "archived-history",
 			aspect: "archived-history-aspect",
 			group: "ontology",
 			claim: "lineage",
 		});
-		const activeVersions = listClaimVersions(getDbAccessor(), {
+		const activeVersions = await listClaimVersions(getDbAccessor(), {
 			agentId: "ant",
 			entity: "active-history",
 			aspect: "active-history-aspect",
@@ -2779,8 +2779,8 @@ describe("ontology proposals", () => {
 		expect(activeVersions.items.map((item) => item.content)).toEqual(["Active entity history."]);
 	});
 
-	it("rolls back an operation batch when one operation is invalid", () => {
-		expect(() =>
+	it("rolls back an operation batch when one operation is invalid", async () => {
+		await expect(
 			applyOntologyOperationBatch(getDbAccessor(), {
 				agentId: "ant",
 				actor: "operator",
@@ -2789,7 +2789,7 @@ describe("ontology proposals", () => {
 					{ operation: "rename_entity", payload: { selector: "Missing", new_name: "Nope" } },
 				],
 			}),
-		).toThrow(OntologyProposalError);
+		).rejects.toThrow(OntologyProposalError);
 		const count = getDbAccessor().withReadDb(
 			(db) =>
 				db.prepare("SELECT COUNT(*) AS n FROM entities WHERE agent_id = ? AND name = ?").get("ant", "Batch Good") as {
@@ -2797,11 +2797,11 @@ describe("ontology proposals", () => {
 				},
 		);
 		expect(count.n).toBe(0);
-		expect(listOntologyProposals(getDbAccessor(), { agentId: "ant" }).items).toHaveLength(0);
+		expect((await listOntologyProposals(getDbAccessor(), { agentId: "ant" })).items).toHaveLength(0);
 	});
 
-	it("returns per-line dry-run batch validation errors without writing", () => {
-		const result = applyOntologyOperationBatch(getDbAccessor(), {
+	it("returns per-line dry-run batch validation errors without writing", async () => {
+		const result = await applyOntologyOperationBatch(getDbAccessor(), {
 			agentId: "ant",
 			actor: "operator",
 			dryRun: true,
@@ -2831,25 +2831,25 @@ describe("ontology proposals", () => {
 			},
 		]);
 		expect(count.n).toBe(0);
-		expect(listOntologyProposals(getDbAccessor(), { agentId: "ant" }).items).toHaveLength(0);
+		expect((await listOntologyProposals(getDbAccessor(), { agentId: "ant" })).items).toHaveLength(0);
 	});
 
-	it("rejects ambiguous same-agent entity selectors", () => {
+	it("rejects ambiguous same-agent entity selectors", async () => {
 		insertEntity("one", "Signet A", "signet", "ant", 1);
 		insertEntity("two", "Signet B", "signet", "ant", 2);
 
-		expect(() =>
+		await expect(
 			applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
 				actor: "operator",
 				operation: "rename_entity",
 				payload: { selector: "signet", new_name: "Signet" },
 			}),
-		).toThrow("ambiguous");
+		).rejects.toThrow("ambiguous");
 	});
 
 	// #1138: write-gate aspect/attribute caps that force supersession and consolidation
-	it("rejects add_claim_value past the attribute cap with a teaching error", () => {
+	it("rejects add_claim_value past the attribute cap with a teaching error", async () => {
 		const cap = { maxAspectsPerEntity: 10, maxAttributesPerAspect: 2 };
 		const common = {
 			agentId: "ant",
@@ -2858,7 +2858,7 @@ describe("ontology proposals", () => {
 		} as const;
 
 		for (let i = 0; i < 2; i++) {
-			applyOntologyOperation(getDbAccessor(), {
+			await applyOntologyOperation(getDbAccessor(), {
 				...common,
 				payload: {
 					entity: "Capped",
@@ -2871,7 +2871,7 @@ describe("ontology proposals", () => {
 			});
 		}
 
-		expect(() =>
+		await expect(
 			applyOntologyOperation(getDbAccessor(), {
 				...common,
 				payload: {
@@ -2883,12 +2883,12 @@ describe("ontology proposals", () => {
 				},
 				writeCaps: cap,
 			}),
-		).toThrow(/attribute cap \(2\/2\).*supersede or expire/);
+		).rejects.toThrow(/attribute cap \(2\/2\).*supersede or expire/);
 	});
 
-	it("does not enforce attribute cap when writeCaps is omitted (backward compat)", () => {
+	it("does not enforce attribute cap when writeCaps is omitted (backward compat)", async () => {
 		for (let i = 0; i < 5; i++) {
-			applyOntologyOperation(getDbAccessor(), {
+			await applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
 				actor: "test",
 				operation: "add_claim_value",
@@ -2911,11 +2911,11 @@ describe("ontology proposals", () => {
 		expect(count.c).toBe(5);
 	});
 
-	it("rejects create_aspect past the aspect cap with a teaching error", () => {
+	it("rejects create_aspect past the aspect cap with a teaching error", async () => {
 		const cap = { maxAspectsPerEntity: 2, maxAttributesPerAspect: 25 };
 
 		// create_entity first so create_aspect can resolve it
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "create_entity",
@@ -2923,7 +2923,7 @@ describe("ontology proposals", () => {
 		});
 
 		for (let i = 0; i < 2; i++) {
-			applyOntologyOperation(getDbAccessor(), {
+			await applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
 				actor: "test",
 				operation: "create_aspect",
@@ -2932,7 +2932,7 @@ describe("ontology proposals", () => {
 			});
 		}
 
-		expect(() =>
+		await expect(
 			applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
 				actor: "test",
@@ -2940,20 +2940,20 @@ describe("ontology proposals", () => {
 				payload: { entity: "CappedEnt", entity_type: "project", name: "overflow_aspect" },
 				writeCaps: cap,
 			}),
-		).toThrow(/aspect cap \(2\/2\).*consolidate or archive/);
+		).rejects.toThrow(/aspect cap \(2\/2\).*consolidate or archive/);
 	});
 
-	it("allows adding to an existing aspect that already exists past the cap (idempotent resolve)", () => {
+	it("allows adding to an existing aspect that already exists past the cap (idempotent resolve)", async () => {
 		const cap = { maxAspectsPerEntity: 1, maxAttributesPerAspect: 25 };
 
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "create_entity",
 			payload: { name: "Single", entity_type: "project" },
 		});
 
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "create_aspect",
@@ -2962,21 +2962,19 @@ describe("ontology proposals", () => {
 		});
 
 		// Re-creating the same aspect should not trigger the cap
-		expect(() =>
-			applyOntologyOperation(getDbAccessor(), {
-				agentId: "ant",
-				actor: "test",
-				operation: "create_aspect",
-				payload: { entity: "Single", entity_type: "project", name: "only_aspect" },
-				writeCaps: cap,
-			}),
-		).not.toThrow();
+		await applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "create_aspect",
+			payload: { entity: "Single", entity_type: "project", name: "only_aspect" },
+			writeCaps: cap,
+		});
 	});
 
-	it("deduplicates exact-value claims before enforcing the attribute cap", () => {
+	it("deduplicates exact-value claims before enforcing the attribute cap", async () => {
 		const cap = { maxAspectsPerEntity: 10, maxAttributesPerAspect: 1 };
 
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "add_claim_value",
@@ -2991,7 +2989,7 @@ describe("ontology proposals", () => {
 		});
 
 		// Adding the exact same value+key should dedup, not hit the cap
-		const result = applyOntologyOperation(getDbAccessor(), {
+		const result = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "add_claim_value",
@@ -3008,9 +3006,9 @@ describe("ontology proposals", () => {
 	});
 
 	// #1138: merge_aspects — consolidation must be possible regardless of caps
-	function seedAspectClaims(entity: string, aspect: string, count: number): void {
+	async function seedAspectClaims(entity: string, aspect: string, count: number): Promise<void> {
 		for (let i = 0; i < count; i++) {
-			applyOntologyOperation(getDbAccessor(), {
+			await applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
 				actor: "test",
 				operation: "add_claim_value",
@@ -3045,17 +3043,17 @@ describe("ontology proposals", () => {
 		});
 	}
 
-	it("merges aspects by moving attributes into the target and archiving sources", () => {
-		applyOntologyOperation(getDbAccessor(), {
+	it("merges aspects by moving attributes into the target and archiving sources", async () => {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "create_entity",
 			payload: { name: "MergeEnt", entity_type: "project" },
 		});
-		seedAspectClaims("MergeEnt", "status_history", 3);
-		seedAspectClaims("MergeEnt", "changelog", 4);
+		await seedAspectClaims("MergeEnt", "status_history", 3);
+		await seedAspectClaims("MergeEnt", "changelog", 4);
 
-		const result = applyOntologyOperation(getDbAccessor(), {
+		const result = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "merge_aspects",
@@ -3078,21 +3076,21 @@ describe("ontology proposals", () => {
 		expect(sourceStatus).toEqual({ status: "archived" });
 	});
 
-	it("lets the merged aspect exceed the attribute cap (consolidation is exempt)", () => {
+	it("lets the merged aspect exceed the attribute cap (consolidation is exempt)", async () => {
 		const cap = { maxAspectsPerEntity: 10, maxAttributesPerAspect: 5 };
 
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "create_entity",
 			payload: { name: "FatEnt", entity_type: "project" },
 		});
-		seedAspectClaims("FatEnt", "a", 5);
-		seedAspectClaims("FatEnt", "b", 5);
+		await seedAspectClaims("FatEnt", "a", 5);
+		await seedAspectClaims("FatEnt", "b", 5);
 
 		// Two at-cap aspects merged into one: 10 attributes on the target, cap is 5.
 		// Merging is the consolidation remedy, so it must not be blocked.
-		const result = applyOntologyOperation(getDbAccessor(), {
+		const result = await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "merge_aspects",
@@ -3103,28 +3101,28 @@ describe("ontology proposals", () => {
 		expect(aspectRowCount("a")).toBe(10);
 	});
 
-	it("rejects merge_aspects without entity, target, or sources", () => {
-		expect(() =>
+	it("rejects merge_aspects without entity, target, or sources", async () => {
+		await expect(
 			applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
 				actor: "test",
 				operation: "merge_aspects",
 				payload: { entity: "Whatever", target: "x", sources: [] },
 			}),
-		).toThrow(/sources is required/);
+		).rejects.toThrow(/sources is required/);
 	});
 
 	// #1147 adversarial review: cap bypasses via other write ops.
-	it("does not bypass the aspect cap via add_claim_value with a new aspect name (E1)", () => {
+	it("does not bypass the aspect cap via add_claim_value with a new aspect name (E1)", async () => {
 		const cap = { maxAspectsPerEntity: 2, maxAttributesPerAspect: 25 };
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "create_entity",
 			payload: { name: "E1Ent", entity_type: "project" },
 		});
 		for (let i = 0; i < 2; i++) {
-			applyOntologyOperation(getDbAccessor(), {
+			await applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
 				actor: "test",
 				operation: "create_aspect",
@@ -3133,7 +3131,7 @@ describe("ontology proposals", () => {
 			});
 		}
 		// add_claim_value with a THIRD new aspect name must hit the aspect cap.
-		expect(() =>
+		await expect(
 			applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
 				actor: "test",
@@ -3146,19 +3144,19 @@ describe("ontology proposals", () => {
 				},
 				writeCaps: cap,
 			}),
-		).toThrow(/aspect cap \(2\/2\)/);
+		).rejects.toThrow(/aspect cap \(2\/2\)/);
 	});
 
-	it("does not bypass the attribute cap via set_claim_value with a new claim_key (E2)", () => {
+	it("does not bypass the attribute cap via set_claim_value with a new claim_key (E2)", async () => {
 		const cap = { maxAspectsPerEntity: 10, maxAttributesPerAspect: 2 };
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "create_entity",
 			payload: { name: "E2Ent", entity_type: "project" },
 		});
 		for (let i = 0; i < 2; i++) {
-			applyOntologyOperation(getDbAccessor(), {
+			await applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
 				actor: "test",
 				operation: "set_claim_value",
@@ -3166,7 +3164,7 @@ describe("ontology proposals", () => {
 				writeCaps: cap,
 			});
 		}
-		expect(() =>
+		await expect(
 			applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
 				actor: "test",
@@ -3174,19 +3172,19 @@ describe("ontology proposals", () => {
 				payload: { entity: "E2Ent", aspect: "facts", claim_key: "k_overflow", value: "v overflow" },
 				writeCaps: cap,
 			}),
-		).toThrow(/attribute cap \(2\/2\)/);
+		).rejects.toThrow(/attribute cap \(2\/2\)/);
 	});
 
-	it("allows reactivating an archived aspect within cap but rejects a new aspect at cap (E3)", () => {
+	it("allows reactivating an archived aspect within cap but rejects a new aspect at cap (E3)", async () => {
 		const cap = { maxAspectsPerEntity: 2, maxAttributesPerAspect: 25 };
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "create_entity",
 			payload: { name: "E3Ent", entity_type: "project" },
 		});
 		for (let i = 0; i < 2; i++) {
-			applyOntologyOperation(getDbAccessor(), {
+			await applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
 				actor: "test",
 				operation: "create_aspect",
@@ -3197,7 +3195,7 @@ describe("ontology proposals", () => {
 		const aspect = getDbAccessor().withReadDb((db) =>
 			db.prepare("SELECT id FROM entity_aspects WHERE agent_id = ? AND name = ?").get("ant", "aspect_1"),
 		) as { id: string };
-		applyOntologyOperation(getDbAccessor(), {
+		await applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",
 			actor: "test",
 			operation: "archive_aspect",
@@ -3206,17 +3204,15 @@ describe("ontology proposals", () => {
 		// Reactivating the archived aspect keeps the active count at 2 (cap)
 		// — the new helper only skips the cap when an ACTIVE row exists, and
 		// the count after reactivation is 2/2, so this is allowed.
-		expect(() =>
-			applyOntologyOperation(getDbAccessor(), {
-				agentId: "ant",
-				actor: "test",
-				operation: "create_aspect",
-				payload: { entity: "E3Ent", name: "aspect_1" },
-				writeCaps: cap,
-			}),
-		).not.toThrow();
+		await applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "test",
+			operation: "create_aspect",
+			payload: { entity: "E3Ent", name: "aspect_1" },
+			writeCaps: cap,
+		});
 		// But a genuinely new third aspect is still rejected at cap.
-		expect(() =>
+		await expect(
 			applyOntologyOperation(getDbAccessor(), {
 				agentId: "ant",
 				actor: "test",
@@ -3224,6 +3220,6 @@ describe("ontology proposals", () => {
 				payload: { entity: "E3Ent", name: "aspect_new" },
 				writeCaps: cap,
 			}),
-		).toThrow(/aspect cap \(2\/2\)/);
+		).rejects.toThrow(/aspect cap \(2\/2\)/);
 	});
 });

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Hono } from "hono";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { linkDerivedMemorySourcesInTx } from "./derived-memory-provenance";
 import { listEpistemicAssertions } from "./ontology-assertions";
@@ -26,6 +27,7 @@ import {
 	proposeDuplicateEntityMerges,
 	rejectOntologyProposal,
 } from "./ontology-proposals";
+import { registerOntologyRoutes } from "./routes/ontology-routes";
 import { txIngestEnvelope } from "./transactions";
 
 describe("ontology proposals", () => {
@@ -638,6 +640,47 @@ describe("ontology proposals", () => {
 				db.prepare("SELECT id FROM entities WHERE name = ?").get("Temporary Entity") as { id: string } | undefined,
 		);
 		expect(entity).toBeNull();
+	});
+
+	it("awaits failure status persistence before rethrowing an apply error", async () => {
+		const proposal = await createOntologyProposal(getDbAccessor(), {
+			agentId: "default",
+			operation: "unsupported_operation",
+			payload: { unsupported: true },
+		});
+
+		await expect(
+			applyOntologyProposal(getDbAccessor(), {
+				agentId: "default",
+				id: proposal.id,
+				actor: "operator",
+			}),
+		).rejects.toThrow("Unsupported ontology proposal operation: unsupported_operation");
+
+		const failed = await getDbAccessor().withReadDbAsync(
+			async (db) =>
+				db.prepare("SELECT status FROM ontology_proposals WHERE id = ?").get(proposal.id) as { status: string },
+		);
+		expect(failed.status).toBe("failed");
+	});
+
+	it("returns the rejected proposal body from the HTTP route", async () => {
+		const proposal = await createOntologyProposal(getDbAccessor(), {
+			agentId: "default",
+			operation: "create_entity",
+			payload: { name: "Route Rejection", entity_type: "project" },
+		});
+		const app = new Hono();
+		registerOntologyRoutes(app);
+
+		const response = await app.request(`/api/ontology/proposals/${proposal.id}/reject?agent_id=default`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ actor: "operator", reason: "route regression" }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({ id: proposal.id, status: "rejected" });
 	});
 
 	it("rejects empty proposal operations before storage", async () => {

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -10,6 +10,7 @@ import {
 	type OntologyProposalStatus,
 } from "@signet/core";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
+import { runWriteTxAsync } from "./db-accessor";
 import { requireDependencyReason } from "./dependency-history";
 import { linkDerivedMemorySourcesInTx, markDerivedMemoriesStaleForSourceInTx } from "./derived-memory-provenance";
 import { classifyEntityQuality } from "./entity-quality";
@@ -474,9 +475,8 @@ function getProposalInTx(db: WriteDb, id: string, agentId: string): ProposalRow 
 	return row ?? null;
 }
 
-function getProposalReadRow(accessor: DbAccessor, id: string, agentId: string): ProposalRow | null {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+async function getProposalReadRow(accessor: DbAccessor, id: string, agentId: string): Promise<ProposalRow | null> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const row = db.prepare("SELECT * FROM ontology_proposals WHERE id = ? AND agent_id = ?").get(id, agentId) as
 			| ProposalRow
 			| undefined;
@@ -2283,10 +2283,9 @@ function applyOperation(
 	}
 }
 
-function markFailed(accessor: DbAccessor, id: string, agentId: string, err: unknown): void {
+async function markFailed(accessor: DbAccessor, id: string, agentId: string, err: unknown): Promise<void> {
 	const message = err instanceof Error ? err.message : String(err);
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	accessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
+	await runWriteTxAsync(accessor, (db) => {
 		db.prepare(
 			`UPDATE ontology_proposals
 			 SET status = 'failed', result = ?, updated_at = ?
@@ -2295,20 +2294,21 @@ function markFailed(accessor: DbAccessor, id: string, agentId: string, err: unkn
 	});
 }
 
-export function createOntologyProposal(accessor: DbAccessor, input: CreateOntologyProposalInput): OntologyProposal {
+export async function createOntologyProposal(
+	accessor: DbAccessor,
+	input: CreateOntologyProposalInput,
+): Promise<OntologyProposal> {
 	const ts = now();
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	return accessor.withWriteTx((db: import("./db-accessor").WriteDb) => insertProposalInTx(db, input, ts));
+	return await runWriteTxAsync(accessor, (db) => insertProposalInTx(db, input, ts));
 }
 
-export function createOntologyProposals(
+export async function createOntologyProposals(
 	accessor: DbAccessor,
 	inputs: readonly CreateOntologyProposalInput[],
-): CreateOntologyProposalsResult {
+): Promise<CreateOntologyProposalsResult> {
 	if (inputs.length === 0) throw new OntologyProposalError("proposals are required", 400);
 	if (inputs.length > 500) throw new OntologyProposalError("cannot create more than 500 proposals at once", 400);
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	return accessor.withWriteTx((db: import("./db-accessor").WriteDb) => createOntologyProposalsInTx(db, inputs));
+	return await runWriteTxAsync(accessor, (db) => createOntologyProposalsInTx(db, inputs));
 }
 
 export function createOntologyProposalsInTx(
@@ -2322,37 +2322,39 @@ export function createOntologyProposalsInTx(
 	return { items, count: items.length };
 }
 
-export function getOntologyProposal(accessor: DbAccessor, id: string, agentId: string): OntologyProposal | null {
-	const row = getProposalReadRow(accessor, id, agentId);
-	return row === null ? null : toProposal(row);
-}
-
-export function getOntologyProposalEvidence(
+export async function getOntologyProposal(
 	accessor: DbAccessor,
 	id: string,
 	agentId: string,
-): OntologyProposalEvidenceResult {
-	const proposal = getOntologyProposal(accessor, id, agentId);
+): Promise<OntologyProposal | null> {
+	const row = await getProposalReadRow(accessor, id, agentId);
+	return row === null ? null : toProposal(row);
+}
+
+export async function getOntologyProposalEvidence(
+	accessor: DbAccessor,
+	id: string,
+	agentId: string,
+): Promise<OntologyProposalEvidenceResult> {
+	const proposal = await getOntologyProposal(accessor, id, agentId);
 	if (proposal === null) throw new OntologyProposalError("Proposal not found", 404);
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	const items = accessor.withReadDb((db: import("./db-accessor").ReadDb) =>
+	const items = await accessor.withReadDbAsync(async (db) =>
 		proposalEvidenceRefs(proposal).map((ref) => resolveOntologyEvidenceRef(db, agentId, ref)),
 	);
 	return { proposal, items, count: items.length };
 }
 
-export function listOntologyProposals(
+export async function listOntologyProposals(
 	accessor: DbAccessor,
 	params: ListOntologyProposalsParams,
-): {
+): Promise<{
 	readonly items: readonly OntologyProposal[];
 	readonly limit: number;
 	readonly offset: number;
-} {
+}> {
 	const limit = Math.min(Math.max(params.limit ?? 50, 1), 200);
 	const offset = Math.max(params.offset ?? 0, 0);
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+	return await accessor.withReadDbAsync(async (db) => {
 		const filters = ["agent_id = ?"];
 		const args: unknown[] = [params.agentId];
 		if (params.status) {
@@ -2376,13 +2378,12 @@ export function listOntologyProposals(
 	});
 }
 
-export function listOntologyProposalConflicts(
+export async function listOntologyProposalConflicts(
 	accessor: DbAccessor,
 	params: { readonly agentId: string; readonly limit?: number },
-): OntologyProposalConflictsResult {
+): Promise<OntologyProposalConflictsResult> {
 	const limit = Math.min(Math.max(params.limit ?? 500, 1), 1000);
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+	return await accessor.withReadDbAsync(async (db) => {
 		const rows = db
 			.prepare(
 				`SELECT * FROM ontology_proposals
@@ -2450,16 +2451,15 @@ function claimVersionRow(row: Record<string, unknown>): ClaimVersionItem {
 	};
 }
 
-export function listClaimVersions(
+export async function listClaimVersions(
 	accessor: DbAccessor,
 	params: ClaimVersionReadParams,
-): { readonly items: readonly ClaimVersionItem[]; readonly count: number } {
+): Promise<{ readonly items: readonly ClaimVersionItem[]; readonly count: number }> {
 	const groupKey = canonicalKey(params.group) ?? "general";
 	const claimKey = canonicalKey(params.claim);
 	if (claimKey === null) throw new OntologyProposalError("claim is required", 400);
 	const kind = params.kind ?? "attribute";
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+	return await accessor.withReadDbAsync(async (db) => {
 		const entityKey = canonical(params.entity);
 		const exactEntity = db
 			.prepare("SELECT id FROM entities WHERE agent_id = ? AND id = ? LIMIT 1")
@@ -2520,11 +2520,11 @@ export function listClaimVersions(
 	});
 }
 
-export function getClaimVersion(
+export async function getClaimVersion(
 	accessor: DbAccessor,
 	params: ClaimVersionReadParams & { readonly version: number },
-): ClaimVersionItem | null {
-	const versions = listClaimVersions(accessor, params);
+): Promise<ClaimVersionItem | null> {
+	const versions = await listClaimVersions(accessor, params);
 	return versions.items.find((item) => item.version === params.version) ?? null;
 }
 
@@ -2937,29 +2937,23 @@ function duplicateMergeCandidates(
  * merge candidate planner powers the repair/proposal path, so guard callers
  * see the target, sources, and safety warnings that the daemon would use.
  */
-export function findDuplicateEntityMerges(
+export async function findDuplicateEntityMerges(
 	accessor: DbAccessor,
 	params: FindDuplicateEntityMergesParams,
-): readonly DuplicateEntityMergeCandidate[] {
+): Promise<readonly DuplicateEntityMergeCandidate[]> {
 	const agentId = requireText(params.agentId, "agentId");
 	const canonicalName = canonical(params.name);
 	if (canonicalName.length === 0) return [];
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("./db-accessor").ReadDb) =>
-		duplicateMergeCandidates(db, agentId, 1, canonicalName, true),
-	);
+	return await accessor.withReadDbAsync(async (db) => duplicateMergeCandidates(db, agentId, 1, canonicalName, true));
 }
 
-export function proposeDuplicateEntityMerges(
+export async function proposeDuplicateEntityMerges(
 	accessor: DbAccessor,
 	params: ProposeDuplicateEntityMergesParams,
-): DuplicateEntityMergeResult {
+): Promise<DuplicateEntityMergeResult> {
 	const agentId = requireText(params.agentId, "agentId");
 	const limit = Math.min(Math.max(params.limit ?? 25, 1), 100);
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	const items: DuplicateEntityMergeCandidate[] = accessor.withReadDb((db: import("./db-accessor").ReadDb) =>
-		duplicateMergeCandidates(db, agentId, limit),
-	);
+	const items = await accessor.withReadDbAsync(async (db) => duplicateMergeCandidates(db, agentId, limit));
 	const dryRun = params.writeProposals !== true;
 	if (dryRun || items.length === 0) {
 		return {
@@ -2976,7 +2970,7 @@ export function proposeDuplicateEntityMerges(
 		return { items, proposals: [], count: items.length, writtenCount: 0, skippedCount: items.length, dryRun };
 	}
 
-	const written = createOntologyProposals(
+	const written = await createOntologyProposals(
 		accessor,
 		writableItems.map((item) => ({
 			agentId,
@@ -3001,15 +2995,17 @@ export function proposeDuplicateEntityMerges(
 	};
 }
 
-export function createEntityMergePlan(accessor: DbAccessor, params: EntityMergePlanParams): EntityMergePlanResult {
+export async function createEntityMergePlan(
+	accessor: DbAccessor,
+	params: EntityMergePlanParams,
+): Promise<EntityMergePlanResult> {
 	const agentId = requireText(params.agentId, "agentId");
 	const dryRun = params.writeProposal !== true;
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	const plan = accessor.withReadDb((db: import("./db-accessor").ReadDb) =>
+	const plan = await accessor.withReadDbAsync(async (db) =>
 		buildEntityMergePlan(db, { ...params, agentId }, "manual_entity_merge"),
 	);
 	if (dryRun || plan.blocked) return { ...plan, dryRun: true };
-	const proposal = createOntologyProposal(accessor, {
+	const proposal = await createOntologyProposal(accessor, {
 		agentId,
 		operation: plan.operation,
 		payload: plan.payload,
@@ -3024,10 +3020,12 @@ export function createEntityMergePlan(accessor: DbAccessor, params: EntityMergeP
 	return { ...plan, dryRun: false, proposal };
 }
 
-export function applyOntologyProposal(accessor: DbAccessor, params: ApplyOntologyProposalParams): OntologyProposal {
+export async function applyOntologyProposal(
+	accessor: DbAccessor,
+	params: ApplyOntologyProposalParams,
+): Promise<OntologyProposal> {
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		return accessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
+		return await runWriteTxAsync(accessor, (db) => {
 			const proposal = getProposalInTx(db, params.id, params.agentId);
 			if (proposal === null) throw new OntologyProposalError("Proposal not found", 404);
 			if (proposal.status !== "pending") {
@@ -3092,23 +3090,22 @@ function markAppliedInTx(
 	return readBackInTx(db, proposal.id, proposal.agent_id);
 }
 
-export function applyOntologyOperation(
+export async function applyOntologyOperation(
 	accessor: DbAccessor,
 	params: ApplyOntologyOperationParams,
-): ApplyOntologyOperationResult {
+): Promise<ApplyOntologyOperationResult> {
 	if (params.propose && params.dryRun) {
 		throw new OntologyProposalError("--dry-run and --propose cannot be used together", 400);
 	}
 	if (Object.keys(params.payload).length === 0) throw new OntologyProposalError("payload is required", 400);
 	if (params.propose) {
-		const proposal = createOntologyProposal(accessor, operationToProposalInput(params));
+		const proposal = await createOntologyProposal(accessor, operationToProposalInput(params));
 		return { proposal, result: null, dryRun: false, proposed: true };
 	}
 
 	let preview: ApplyOntologyOperationResult | null = null;
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		const result = accessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
+		const result = await runWriteTxAsync(accessor, (db) => {
 			const inserted = insertProposalInTx(db, operationToProposalInput(params), now());
 			const row = getProposalInTx(db, inserted.id, params.agentId);
 			if (row === null) throw new OntologyProposalError("Proposal not found", 404);
@@ -3128,10 +3125,10 @@ export function applyOntologyOperation(
 	}
 }
 
-export function applyOntologyOperationBatch(
+export async function applyOntologyOperationBatch(
 	accessor: DbAccessor,
 	params: ApplyOntologyOperationBatchParams,
-): ApplyOntologyOperationBatchResult {
+): Promise<ApplyOntologyOperationBatchResult> {
 	if (params.operations.length === 0) throw new OntologyProposalError("operations are required", 400);
 	if (params.operations.length > 500)
 		throw new OntologyProposalError("cannot apply more than 500 operations at once", 400);
@@ -3140,7 +3137,7 @@ export function applyOntologyOperationBatch(
 	}
 
 	if (params.propose) {
-		const written = createOntologyProposals(
+		const written = await createOntologyProposals(
 			accessor,
 			params.operations.map((operation) => ({
 				agentId: params.agentId,
@@ -3165,14 +3162,12 @@ export function applyOntologyOperationBatch(
 		};
 	}
 	if (!params.dryRun) {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		return accessor.withWriteTx((db: import("./db-accessor").WriteDb) => applyOntologyOperationBatchInTx(db, params));
+		return await runWriteTxAsync(accessor, (db) => applyOntologyOperationBatchInTx(db, params));
 	}
 
 	let preview: ApplyOntologyOperationBatchResult | null = null;
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		const result = accessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
+		const result = await runWriteTxAsync(accessor, (db) => {
 			const items: ApplyOntologyOperationResult[] = [];
 			const errors: OntologyOperationBatchError[] = [];
 			for (const [index, operation] of params.operations.entries()) {
@@ -3231,9 +3226,11 @@ export function applyOntologyOperationBatch(
 	}
 }
 
-export function rejectOntologyProposal(accessor: DbAccessor, params: RejectOntologyProposalParams): OntologyProposal {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	return accessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
+export async function rejectOntologyProposal(
+	accessor: DbAccessor,
+	params: RejectOntologyProposalParams,
+): Promise<OntologyProposal> {
+	return await runWriteTxAsync(accessor, (db) => {
 		const proposal = getProposalInTx(db, params.id, params.agentId);
 		if (proposal === null) throw new OntologyProposalError("Proposal not found", 404);
 		if (proposal.status !== "pending") {

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -3044,7 +3044,15 @@ export async function applyOntologyProposal(
 		});
 	} catch (err) {
 		if (err instanceof OntologyProposalError && err.status !== 404 && err.status !== 409) {
-			markFailed(accessor, params.id, params.agentId, err);
+			try {
+				await markFailed(accessor, params.id, params.agentId, err);
+			} catch (markError) {
+				console.error("[ontology] failed to mark proposal as failed", {
+					proposalId: params.id,
+					agentId: params.agentId,
+					error: markError instanceof Error ? markError.message : String(markError),
+				});
+			}
 		}
 		throw err;
 	}

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -590,7 +590,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 				const result: MutableCapabilityOutput = { ok: true };
 				if (name !== undefined) {
 					result.label = classifyEntityQuality(name, type);
-					result.duplicates = findDuplicateEntityMerges(accessor, { agentId: scopeId, name });
+					result.duplicates = await findDuplicateEntityMerges(accessor, { agentId: scopeId, name });
 				}
 				if (entityId !== undefined && aspectId !== undefined && value !== undefined) {
 					result.contradiction = (

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -53,13 +53,12 @@ function boundedText(value: string | undefined, maxChars: number): string | unde
 	return value.slice(0, maxChars);
 }
 
-function filterDreamingAttributes(
+async function filterDreamingAttributes(
 	accessor: DbAccessor,
 	agentId: string,
 	attributes: readonly EntityAttribute[],
-): readonly EntityAttribute[] {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("../db-accessor").ReadDb) =>
+): Promise<readonly EntityAttribute[]> {
+	return await accessor.withReadDbAsync(async (db) =>
 		attributes.filter((attribute) => {
 			if (attribute.memoryId) {
 				return isMemoryContentContextEligible(db, {
@@ -334,13 +333,15 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 			}),
 			async ({ agentId: scopeId, query, type, limit, offset }) => ({
 				ok: true,
-				items: listKnowledgeEntities(accessor, {
-					agentId: scopeId,
-					query,
-					type,
-					limit: bounded(limit, 20, 100),
-					offset: Math.max(0, Math.floor(offset ?? 0)),
-				}).map((item) => ({
+				items: (
+					await listKnowledgeEntities(accessor, {
+						agentId: scopeId,
+						query,
+						type,
+						limit: bounded(limit, 20, 100),
+						offset: Math.max(0, Math.floor(offset ?? 0)),
+					})
+				).map((item) => ({
 					id: item.entity.id,
 					name: item.entity.name,
 					entityType: item.entity.entityType,
@@ -366,7 +367,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 				offset: z.number().finite().optional(),
 			}),
 			async ({ agentId: scopeId, entityId, include, direction, limit, offset }) => {
-				const detail = getKnowledgeEntityDetail(accessor, entityId, scopeId);
+				const detail = await getKnowledgeEntityDetail(accessor, entityId, scopeId);
 				if (!detail) return { ok: false, error: "Entity not found" };
 				const hydrationLimit = bounded(limit, 50, MAX_HYDRATED_ITEMS);
 				const hydrationOffset = Math.max(0, Math.floor(offset ?? 0));
@@ -380,7 +381,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 					dependencyCount: detail.dependencyCount,
 				};
 				if (include?.includes("aspects")) {
-					const aspects = getEntityAspectsWithCounts(accessor, entityId, scopeId);
+					const aspects = await getEntityAspectsWithCounts(accessor, entityId, scopeId);
 					const hydratedAspects = aspects.slice(hydrationOffset, hydrationOffset + hydrationLimit).map((aspect) => ({
 						id: aspect.aspect.id,
 						name: boundedText(aspect.aspect.name, MAX_ENTITY_TEXT_CHARS),
@@ -392,7 +393,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 					result.aspectsTruncated = hydrationOffset + hydratedAspects.length < aspects.length;
 				}
 				if (include?.includes("links")) {
-					const links = getEntityDependenciesDetailed(accessor, {
+					const links = await getEntityDependenciesDetailed(accessor, {
 						entityId,
 						agentId: scopeId,
 						direction: direction ?? "both",
@@ -416,10 +417,10 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 			z.object({ agentId: z.string().min(1), entityId: z.string().min(1), aspectId: z.string().min(1), ...pagination }),
 			async ({ agentId: scopeId, entityId, aspectId, limit, offset }) => ({
 				ok: true,
-				items: filterDreamingAttributes(
+				items: await filterDreamingAttributes(
 					accessor,
 					scopeId,
-					getAttributesForAspectFiltered(accessor, {
+					await getAttributesForAspectFiltered(accessor, {
 						entityId,
 						aspectId,
 						agentId: scopeId,
@@ -443,7 +444,11 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 			}),
 			async ({ agentId: scopeId, entityId, direction }) => ({
 				ok: true,
-				items: getEntityDependenciesDetailed(accessor, { entityId, agentId: scopeId, direction: direction ?? "both" }),
+				items: await getEntityDependenciesDetailed(accessor, {
+					entityId,
+					agentId: scopeId,
+					direction: direction ?? "both",
+				}),
 			}),
 		),
 		capability(
@@ -472,15 +477,15 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 					// Accept stable ids as well as names for the claim path:
 					// search results surface ids, and the path resolver is
 					// name-based.
-					const detail = getKnowledgeEntityDetail(accessor, ref.entity, scopeId);
+					const detail = await getKnowledgeEntityDetail(accessor, ref.entity, scopeId);
 					if (detail) {
 						entityName = detail.entity.name;
-						const aspect = getEntityAspectsWithCounts(accessor, ref.entity, scopeId).find(
+						const aspect = (await getEntityAspectsWithCounts(accessor, ref.entity, scopeId)).find(
 							(candidate) => candidate.aspect.id === ref.aspect || candidate.aspect.name === ref.aspect,
 						);
 						if (aspect) aspectName = aspect.aspect.name;
 					}
-					const result = getOntologyClaimEvidence(accessor, {
+					const result = await getOntologyClaimEvidence(accessor, {
 						agentId: scopeId,
 						entity: entityName,
 						aspect: aspectName,
@@ -490,16 +495,18 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 						offset,
 					});
 					const safeIds = new Set(
-						filterDreamingAttributes(
-							accessor,
-							scopeId,
-							result.items.map((item) => item.attribute),
+						(
+							await filterDreamingAttributes(
+								accessor,
+								scopeId,
+								result.items.map((item) => item.attribute),
+							)
 						).map((attribute) => attribute.id),
 					);
 					const items = result.items.filter((item) => safeIds.has(item.attribute.id));
 					return { ok: true, result: { ...result, items, count: items.length } };
 				}
-				return { ok: true, result: getOntologyLinkEvidence(accessor, { agentId: scopeId, id: ref.id }) };
+				return { ok: true, result: await getOntologyLinkEvidence(accessor, { agentId: scopeId, id: ref.id }) };
 			},
 		),
 		capability(
@@ -519,8 +526,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 				chunkSize: z.number().finite().optional(),
 			}),
 			async ({ agentId: scopeId, query, since, before, kind, limit, sourceRef, offset, chunkSize }) =>
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-				accessor.withReadDb((db: import("../db-accessor").ReadDb) => {
+				await accessor.withReadDbAsync(async (db) => {
 					if (sourceRef !== undefined) {
 						const source = readEpisodicSource(db, { agentId: scopeId, from: sourceRef });
 						if (source === null) return { ok: false, error: "Evidence source not found" };
@@ -587,18 +593,20 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 					result.duplicates = findDuplicateEntityMerges(accessor, { agentId: scopeId, name });
 				}
 				if (entityId !== undefined && aspectId !== undefined && value !== undefined) {
-					result.contradiction = filterDreamingAttributes(
-						accessor,
-						scopeId,
-						getAttributesForAspectFiltered(accessor, {
-							entityId,
-							aspectId,
-							agentId: scopeId,
-							kind: "attribute",
-							status: "active",
-							limit: 200,
-							offset: 0,
-						}),
+					result.contradiction = (
+						await filterDreamingAttributes(
+							accessor,
+							scopeId,
+							await getAttributesForAspectFiltered(accessor, {
+								entityId,
+								aspectId,
+								agentId: scopeId,
+								kind: "attribute",
+								status: "active",
+								limit: 200,
+								offset: 0,
+							}),
+						)
 					).map((attribute) => ({
 						attributeId: attribute.id,
 						content: attribute.content,
@@ -690,14 +698,12 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 			async ({ agentId: scopeId, kind, status, limit }) => {
 				if (kind === "review_due") {
 					if (status === "resolved") return { ok: true, items: [] };
-					// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-					const due: ReturnType<typeof collectReviewDueClaims> = accessor.withReadDb(
-						(db: import("../db-accessor").ReadDb) =>
-							collectReviewDueClaims(
-								{ all: <T>(sql: string, ...params: unknown[]) => db.prepare(sql).all(...params) as T[] },
-								new Date(),
-								{ agentId: scopeId, limit: bounded(limit, scopeId ? 50 : 100, scopeId ? 100 : 200) },
-							),
+					const due = await accessor.withReadDbAsync(async (db) =>
+						collectReviewDueClaims(
+							{ all: <T>(sql: string, ...params: unknown[]) => db.prepare(sql).all(...params) as T[] },
+							new Date(),
+							{ agentId: scopeId, limit: bounded(limit, scopeId ? 50 : 100, scopeId ? 100 : 200) },
+						),
 					);
 					return {
 						ok: true,

--- a/platform/daemon/src/pipeline/dreaming-quality.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-quality.test.ts
@@ -9,6 +9,9 @@ function wrapDb(db: Database): DbAccessor {
 		withReadDb<T>(fn: (db: Database) => T): T {
 			return fn(db);
 		},
+		withReadDbAsync<T>(fn: (db: Database) => Promise<T>): Promise<T> {
+			return fn(db);
+		},
 		withWriteTx<T>(fn: (db: Database) => T): T {
 			db.exec("BEGIN IMMEDIATE");
 			try {
@@ -18,6 +21,17 @@ function wrapDb(db: Database): DbAccessor {
 			} catch (error) {
 				db.exec("ROLLBACK");
 				throw error;
+			}
+		},
+		withWriteTxAsync<T>(fn: (db: Database) => T): Promise<T> {
+			db.exec("BEGIN IMMEDIATE");
+			try {
+				const value = fn(db);
+				db.exec("COMMIT");
+				return Promise.resolve(value);
+			} catch (error) {
+				db.exec("ROLLBACK");
+				return Promise.reject(error);
 			}
 		},
 	} as unknown as DbAccessor;
@@ -35,7 +49,7 @@ describe("Dreaming quality report", () => {
 
 	afterEach(() => db.close());
 
-	it("measures resolved episodic citations and rejects source topology from entity garbage counts", () => {
+	it("measures resolved episodic citations and rejects source topology from entity garbage counts", async () => {
 		const now = new Date().toISOString();
 		const quote = "Signet stores source evidence before deriving semantic state.";
 		db.prepare(
@@ -63,7 +77,7 @@ describe("Dreaming quality report", () => {
 			 ('attr-uncited', 'asp-signet', 'agent-a', 'memory-evidence', 'attribute', 'An untraceable claim.', 'an untraceable claim', 1, 1, 'active', 'architecture', 'untraceable', '[]', ?, ?)`,
 		).run(quote, quote.toLowerCase(), JSON.stringify([{ memory_id: "memory-evidence", quote }]), now, now, now, now);
 
-		const report = getDreamingQualityReport(accessor, "agent-a");
+		const report = await getDreamingQualityReport(accessor, "agent-a");
 		expect(report.citationCoverage).toEqual({
 			totalClaimValues: 2,
 			valuesWithResolvedEpisodicQuote: 1,

--- a/platform/daemon/src/pipeline/dreaming-quality.ts
+++ b/platform/daemon/src/pipeline/dreaming-quality.ts
@@ -91,10 +91,9 @@ function qualityIssues(rows: readonly EntityRow[]): readonly DreamingQualityIssu
  * semantic reader. Claim evidence is resolved through the same API surface
  * users inspect, while source-native topology is excluded from quality counts.
  */
-export function getDreamingQualityReport(accessor: DbAccessor, agentId: string): DreamingQualityReport {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
+export async function getDreamingQualityReport(accessor: DbAccessor, agentId: string): Promise<DreamingQualityReport> {
 	const { claimPaths, entities, totalClaimValues, unaddressableClaimValues, structureQuality } = accessor.withReadDb(
-		(db: import("../db-accessor").ReadDb) => {
+		(db) => {
 			const topologyPlaceholders = SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES.map(() => "?").join(", ");
 			const semanticFilter = `NOT (e.entity_type IN (${topologyPlaceholders}) OR (e.entity_type = 'source' AND e.source_root IS NOT NULL))`;
 			const claimPaths = db
@@ -183,7 +182,7 @@ export function getDreamingQualityReport(accessor: DbAccessor, agentId: string):
 	for (const path of claimPaths) {
 		for (let offset = 0; ; offset += 200) {
 			try {
-				const claimEvidence = getOntologyClaimEvidence(accessor, {
+				const claimEvidence = await getOntologyClaimEvidence(accessor, {
 					agentId,
 					entity: path.entity,
 					aspect: path.aspect,

--- a/platform/daemon/src/pipeline/dreaming-quality.ts
+++ b/platform/daemon/src/pipeline/dreaming-quality.ts
@@ -92,8 +92,8 @@ function qualityIssues(rows: readonly EntityRow[]): readonly DreamingQualityIssu
  * users inspect, while source-native topology is excluded from quality counts.
  */
 export async function getDreamingQualityReport(accessor: DbAccessor, agentId: string): Promise<DreamingQualityReport> {
-	const { claimPaths, entities, totalClaimValues, unaddressableClaimValues, structureQuality } = accessor.withReadDb(
-		(db) => {
+	const { claimPaths, entities, totalClaimValues, unaddressableClaimValues, structureQuality } =
+		await accessor.withReadDbAsync(async (db) => {
 			const topologyPlaceholders = SOURCE_NATIVE_TOPOLOGY_ENTITY_TYPES.map(() => "?").join(", ");
 			const semanticFilter = `NOT (e.entity_type IN (${topologyPlaceholders}) OR (e.entity_type = 'source' AND e.source_root IS NOT NULL))`;
 			const claimPaths = db
@@ -174,8 +174,7 @@ export async function getDreamingQualityReport(accessor: DbAccessor, agentId: st
 							: Number(structure.genericAspects ?? 0) / Number(structure.totalAspects),
 				},
 			};
-		},
-	);
+		});
 
 	let valuesWithResolvedEpisodicQuote = 0;
 	let unresolvedClaimPaths = 0;

--- a/platform/daemon/src/pipeline/maintenance-worker.test.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.test.ts
@@ -31,7 +31,21 @@ function asAccessor(db: Database): DbAccessor {
 				throw err;
 			}
 		},
+		withWriteTxAsync<T>(fn: (wdb: WriteDb) => T): Promise<T> {
+			db.exec("BEGIN IMMEDIATE");
+			try {
+				const result = fn(db as unknown as WriteDb);
+				db.exec("COMMIT");
+				return Promise.resolve(result);
+			} catch (err) {
+				db.exec("ROLLBACK");
+				return Promise.reject(err);
+			}
+		},
 		withReadDb<T>(fn: (rdb: ReadDb) => T): T {
+			return fn(db as unknown as ReadDb);
+		},
+		withReadDbAsync<T>(fn: (rdb: ReadDb) => Promise<T>): Promise<T> {
 			return fn(db as unknown as ReadDb);
 		},
 		close() {

--- a/platform/daemon/src/pipeline/maintenance-worker.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.ts
@@ -482,11 +482,7 @@ export function startMaintenanceWorker(
 		try {
 			const ratio = await accessor.withReadDbAsync(async (db) => getFreePageRatio(db));
 			if (ratio >= 0.2) {
-				if (accessor.incrementalVacuumAsync) {
-					await accessor.incrementalVacuumAsync();
-				} else {
-					accessor.incrementalVacuum();
-				}
+				await accessor.incrementalVacuumAsync?.();
 			}
 		} catch {
 			// Non-fatal — vacuum should never interrupt the maintenance cycle

--- a/platform/daemon/src/pipeline/maintenance-worker.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.ts
@@ -128,9 +128,8 @@ function buildRecommendations(
 	return recs;
 }
 
-function getGraphAgentIds(accessor: DbAccessor): readonly string[] {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("../db-accessor").ReadDb) => {
+async function getGraphAgentIds(accessor: DbAccessor): Promise<readonly string[]> {
+	return await accessor.withReadDbAsync(async (db) => {
 		const rows = db
 			.prepare(
 				`SELECT agent_id FROM entity_aspects
@@ -329,12 +328,10 @@ export function startMaintenanceWorker(
 
 	async function doTick(): Promise<MaintenanceCycleResult> {
 		if (isSystemPressureHigh()) {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const report = accessor.withReadDb((db: import("../db-accessor").ReadDb) => getDiagnostics(db, tracker));
+			const report = await accessor.withReadDbAsync(async (db) => getDiagnostics(db, tracker));
 			return { report, recommendations: [], executed: [], feedbackDecayedAspects: 0, feedbackPropagatedAttributes: 0 };
 		}
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const report = accessor.withReadDb((db: import("../db-accessor").ReadDb) => getDiagnostics(db, tracker));
+		const report = await accessor.withReadDbAsync(async (db) => getDiagnostics(db, tracker));
 
 		const embeddingStats = deps.embedding
 			? await getEmbeddingRepairStats(accessor, deps.embedding.cfg, deps.embedding.agentId)
@@ -347,15 +344,15 @@ export function startMaintenanceWorker(
 		if (recommendations.length === 0) {
 			haltTracker.reset();
 			if (cfg.graph.enabled && cfg.feedback?.enabled) {
-				for (const agentId of getGraphAgentIds(accessor)) {
+				for (const agentId of await getGraphAgentIds(accessor)) {
 					if (cfg.feedback.decayEnabled) {
-						feedbackDecayedAspects += decayAspectWeights(accessor, agentId, {
+						feedbackDecayedAspects += await decayAspectWeights(accessor, agentId, {
 							decayRate: cfg.feedback.decayRate,
 							minWeight: cfg.feedback.minAspectWeight,
 							staleDays: cfg.feedback.staleDays,
 						});
 					}
-					feedbackPropagatedAttributes += propagateMemoryStatus(accessor, agentId);
+					feedbackPropagatedAttributes += await propagateMemoryStatus(accessor, agentId);
 				}
 				recordFeedbackTelemetry({
 					feedbackDecayedAspects,
@@ -410,8 +407,7 @@ export function startMaintenanceWorker(
 
 		// Re-check health to evaluate improvement
 		if (executed.length > 0) {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const postReport = accessor.withReadDb((db: import("../db-accessor").ReadDb) => getDiagnostics(db, tracker));
+			const postReport = await accessor.withReadDbAsync(async (db) => getDiagnostics(db, tracker));
 			const improved = postReport.composite.score > preScore;
 
 			for (const exec of executed) {
@@ -427,15 +423,15 @@ export function startMaintenanceWorker(
 		}
 
 		if (cfg.graph.enabled && cfg.feedback?.enabled) {
-			for (const agentId of getGraphAgentIds(accessor)) {
+			for (const agentId of await getGraphAgentIds(accessor)) {
 				if (cfg.feedback.decayEnabled) {
-					feedbackDecayedAspects += decayAspectWeights(accessor, agentId, {
+					feedbackDecayedAspects += await decayAspectWeights(accessor, agentId, {
 						decayRate: cfg.feedback.decayRate,
 						minWeight: cfg.feedback.minAspectWeight,
 						staleDays: cfg.feedback.staleDays,
 					});
 				}
-				feedbackPropagatedAttributes += propagateMemoryStatus(accessor, agentId);
+				feedbackPropagatedAttributes += await propagateMemoryStatus(accessor, agentId);
 			}
 			recordFeedbackTelemetry({
 				feedbackDecayedAspects,
@@ -453,9 +449,8 @@ export function startMaintenanceWorker(
 		// Dead memory hygiene: warn when stale/low-confidence memories accumulate.
 		// No auto-deletion — use GET /api/repair/dead-memories to review and act.
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const count = accessor.withReadDb(
-				(db: import("../db-accessor").ReadDb) =>
+			const count = await accessor.withReadDbAsync(
+				async (db) =>
 					(
 						db
 							.prepare(
@@ -485,11 +480,13 @@ export function startMaintenanceWorker(
 		// Reclaim free pages from DROP/DELETE/promotion operations (#1139).
 		// Only run when the free-page ratio is high and the system is not under pressure.
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const ratio = accessor.withReadDb((db: import("../db-accessor").ReadDb) => getFreePageRatio(db));
+			const ratio = await accessor.withReadDbAsync(async (db) => getFreePageRatio(db));
 			if (ratio >= 0.2) {
-				if (!accessor.incrementalVacuumAsync) throw new Error("Incremental vacuum operation is unavailable");
-				await accessor.incrementalVacuumAsync();
+				if (accessor.incrementalVacuumAsync) {
+					await accessor.incrementalVacuumAsync();
+				} else {
+					accessor.incrementalVacuum();
+				}
 			}
 		} catch {
 			// Non-fatal — vacuum should never interrupt the maintenance cycle

--- a/platform/daemon/src/pipeline/memorybench-dreaming-gate.test.ts
+++ b/platform/daemon/src/pipeline/memorybench-dreaming-gate.test.ts
@@ -370,7 +370,7 @@ describe("MemoryBench Dreaming gate", () => {
 			for (const { scenario, session, agentId } of capturedSessions) {
 				const transcript = session.messages.map((message) => message.content).join("\n");
 				expect(
-					enqueueTranscriptCaptureJob(getDbAccessor(), {
+					await enqueueTranscriptCaptureJob(getDbAccessor(), {
 						agentId,
 						harness: "memorybench",
 						sessionKey: session.id,

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -718,7 +718,7 @@ function registerSessionEnd(app: Hono): void {
 		if (scopedAgent.error) return c.json({ error: scopedAgent.error }, 403);
 		const jobId = c.req.param("jobId").trim();
 		if (!jobId) return c.json({ error: "jobId is required" }, 400);
-		const job = getTranscriptCaptureJobStatus(getDbAccessor(), scopedAgent.agentId, jobId);
+		const job = await getTranscriptCaptureJobStatus(getDbAccessor(), scopedAgent.agentId, jobId);
 		if (!job) return c.json({ error: "Transcript capture job not found" }, 404);
 		return c.json(job);
 	});

--- a/platform/daemon/src/routes/import-routes.ts
+++ b/platform/daemon/src/routes/import-routes.ts
@@ -180,7 +180,7 @@ export function registerImportRoutes(app: Hono): void {
 				const sourceKind = `source_import_${normalized.value.format}`;
 				const now = new Date().toISOString();
 
-				indexExternalMemoryArtifact({
+				await indexExternalMemoryArtifact({
 					agentId,
 					sourcePath,
 					sourceKind: normalized.value.format === "json" ? "source_import_json_projection" : sourceKind,
@@ -194,7 +194,7 @@ export function registerImportRoutes(app: Hono): void {
 					sourceMeta: normalized.value.sourceMeta,
 				});
 				if (normalized.value.format === "json") {
-					indexExternalMemoryArtifact({
+					await indexExternalMemoryArtifact({
 						agentId,
 						sourcePath: `${sourcePath}#canonical`,
 						sourceKind: "source_import_json_canonical",
@@ -234,7 +234,7 @@ export function registerImportRoutes(app: Hono): void {
 				for (const chunk of normalized.value.searchChunks) {
 					const rowStart = typeof chunk.sourceMeta.rowStart === "number" ? chunk.sourceMeta.rowStart : 0;
 					const rowEnd = typeof chunk.sourceMeta.rowEnd === "number" ? chunk.sourceMeta.rowEnd : rowStart;
-					indexExternalMemoryArtifact({
+					await indexExternalMemoryArtifact({
 						agentId,
 						sourcePath: `${sourcePath}#rows-${rowStart}-${rowEnd}`,
 						sourceKind: "source_import_csv_chunk",

--- a/platform/daemon/src/routes/knowledge-routes.ts
+++ b/platform/daemon/src/routes/knowledge-routes.ts
@@ -46,7 +46,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		const offset = Number.isFinite(offsetParam) ? Math.max(offsetParam, 0) : 0;
 
 		return c.json({
-			items: listKnowledgeEntities(getDbAccessor(), {
+			items: await listKnowledgeEntities(getDbAccessor(), {
 				agentId,
 				type: c.req.query("type") ?? undefined,
 				query: c.req.query("q") ?? undefined,
@@ -66,7 +66,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		const offset = Number.isFinite(offsetParam) ? Math.max(offsetParam, 0) : 0;
 
 		return c.json({
-			items: listKnowledgeEntities(getDbAccessor(), {
+			items: await listKnowledgeEntities(getDbAccessor(), {
 				agentId,
 				type: c.req.query("type") ?? undefined,
 				query: c.req.query("q") ?? undefined,
@@ -107,7 +107,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		const agentId = c.req.query("agent_id") ?? "default";
 		const entity = c.req.query("entity")?.trim();
 		if (!entity) return c.json({ error: "entity is required" }, 400);
-		const result = getEntityAspectsByName(getDbAccessor(), { agentId, entity });
+		const result = await getEntityAspectsByName(getDbAccessor(), { agentId, entity });
 		if (!result) return c.json({ error: "Entity not found" }, 404);
 		return c.json(result);
 	});
@@ -118,7 +118,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		const aspect = c.req.query("aspect")?.trim();
 		if (!entity) return c.json({ error: "entity is required" }, 400);
 		if (!aspect) return c.json({ error: "aspect is required" }, 400);
-		const result = listEntityGroups(getDbAccessor(), { agentId, entity, aspect });
+		const result = await listEntityGroups(getDbAccessor(), { agentId, entity, aspect });
 		if (!result) return c.json({ error: "Entity or aspect not found" }, 404);
 		return c.json(result);
 	});
@@ -131,7 +131,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		if (!entity) return c.json({ error: "entity is required" }, 400);
 		if (!aspect) return c.json({ error: "aspect is required" }, 400);
 		if (!group) return c.json({ error: "group is required" }, 400);
-		const result = listEntityClaims(getDbAccessor(), { agentId, entity, aspect, group });
+		const result = await listEntityClaims(getDbAccessor(), { agentId, entity, aspect, group });
 		if (!result) return c.json({ error: "Entity or aspect not found" }, 404);
 		return c.json(result);
 	});
@@ -287,7 +287,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 				? directionQuery
 				: "both";
 		return c.json({
-			items: getEntityDependenciesDetailed(getDbAccessor(), {
+			items: await getEntityDependenciesDetailed(getDbAccessor(), {
 				entityId: c.req.param("id"),
 				agentId,
 				direction,
@@ -333,7 +333,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		const accessor = getDbAccessor();
 		await getDreamingEpisodicTokenBacklog(accessor, agentId);
 		return c.json(
-			getKnowledgeGraphForConstellation(accessor, agentId, {
+			await getKnowledgeGraphForConstellation(accessor, agentId, {
 				limit: parseNavigationLimit(c.req.query("limit"), 150, 1000),
 				maxAspectsPerEntity: parseNavigationLimit(c.req.query("max_aspects_per_entity"), 6, 25),
 				maxAttributesPerAspect: parseNavigationLimit(c.req.query("max_attributes_per_aspect"), 4, 250),
@@ -588,23 +588,21 @@ export function registerKnowledgeRoutes(app: Hono): void {
 			return c.json({ error: "entityName is required" }, 400);
 		}
 
-		return await getDbAccessor().withReadDbAsync(async (db) => {
+		const hasSessionSummaries = await getDbAccessor().withReadDbAsync(async (db) => {
 			const tbl = db
 				.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'session_summaries'")
 				.get() as { name: string } | undefined;
-			if (!tbl) {
-				return c.json({ entityName, summaries: [], total: 0 });
-			}
+			return tbl !== undefined;
+		});
+		if (!hasSessionSummaries) return c.json({ entityName, summaries: [], total: 0 });
 
-			const entity = await resolveNamedEntity(getDbAccessor(), {
-				agentId,
-				name: entityName,
-			});
+		const entity = await resolveNamedEntity(getDbAccessor(), {
+			agentId,
+			name: entityName,
+		});
+		if (!entity) return c.json({ entityName, summaries: [], total: 0 });
 
-			if (!entity) {
-				return c.json({ entityName, summaries: [], total: 0 });
-			}
-
+		return await getDbAccessor().withReadDbAsync(async (db) => {
 			const conditions = ["ss.agent_id = ?", "ss.kind = 'session'", "COALESCE(ss.source_type, 'summary') = 'summary'"];
 			const args: Array<string | number> = [agentId];
 

--- a/platform/daemon/src/routes/knowledge-routes.ts
+++ b/platform/daemon/src/routes/knowledge-routes.ts
@@ -38,7 +38,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		return Number.isFinite(parsed) ? Math.min(Math.max(parsed, 1), max) : fallback;
 	};
 
-	app.get("/api/knowledge/entities", (c) => {
+	app.get("/api/knowledge/entities", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
 		const limitParam = Number.parseInt(c.req.query("limit") ?? "50", 10);
 		const offsetParam = Number.parseInt(c.req.query("offset") ?? "0", 10);
@@ -58,7 +58,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		});
 	});
 
-	app.get("/api/knowledge/navigation/entities", (c) => {
+	app.get("/api/knowledge/navigation/entities", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
 		const limitParam = Number.parseInt(c.req.query("limit") ?? "50", 10);
 		const offsetParam = Number.parseInt(c.req.query("offset") ?? "0", 10);
@@ -78,20 +78,20 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		});
 	});
 
-	app.get("/api/knowledge/navigation/entity", (c) => {
+	app.get("/api/knowledge/navigation/entity", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
 		const name = c.req.query("name")?.trim();
 		if (!name) return c.json({ error: "name is required" }, 400);
-		const entity = getKnowledgeEntityByName(getDbAccessor(), { agentId, name });
+		const entity = await getKnowledgeEntityByName(getDbAccessor(), { agentId, name });
 		if (!entity) return c.json({ error: "Entity not found" }, 404);
 		return c.json(entity);
 	});
 
-	app.get("/api/knowledge/navigation/tree", (c) => {
+	app.get("/api/knowledge/navigation/tree", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
 		const entity = c.req.query("entity")?.trim();
 		if (!entity) return c.json({ error: "entity is required" }, 400);
-		const result = getEntityKnowledgeTree(getDbAccessor(), {
+		const result = await getEntityKnowledgeTree(getDbAccessor(), {
 			agentId,
 			entity,
 			maxAspects: parseNavigationLimit(c.req.query("max_aspects"), 20, 100),
@@ -103,7 +103,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		return c.json(result);
 	});
 
-	app.get("/api/knowledge/navigation/aspects", (c) => {
+	app.get("/api/knowledge/navigation/aspects", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
 		const entity = c.req.query("entity")?.trim();
 		if (!entity) return c.json({ error: "entity is required" }, 400);
@@ -112,7 +112,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		return c.json(result);
 	});
 
-	app.get("/api/knowledge/navigation/groups", (c) => {
+	app.get("/api/knowledge/navigation/groups", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
 		const entity = c.req.query("entity")?.trim();
 		const aspect = c.req.query("aspect")?.trim();
@@ -123,7 +123,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		return c.json(result);
 	});
 
-	app.get("/api/knowledge/navigation/claims", (c) => {
+	app.get("/api/knowledge/navigation/claims", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
 		const entity = c.req.query("entity")?.trim();
 		const aspect = c.req.query("aspect")?.trim();
@@ -136,7 +136,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		return c.json(result);
 	});
 
-	app.get("/api/knowledge/navigation/attributes", (c) => {
+	app.get("/api/knowledge/navigation/attributes", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
 		const entity = c.req.query("entity")?.trim();
 		const aspect = c.req.query("aspect")?.trim();
@@ -157,7 +157,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 			statusQuery === "active" || statusQuery === "superseded" || statusQuery === "deleted" || statusQuery === "all"
 				? statusQuery
 				: undefined;
-		const result = listEntityAttributesByPath(getDbAccessor(), {
+		const result = await listEntityAttributesByPath(getDbAccessor(), {
 			agentId,
 			entity,
 			aspect,
@@ -178,7 +178,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 
 		const agentId = c.req.query("agent_id") ?? "default";
 		try {
-			const { result } = applyOntologyOperation(getDbAccessor(), {
+			const { result } = await applyOntologyOperation(getDbAccessor(), {
 				agentId,
 				actor: c.req.header("x-signet-actor") ?? "operator",
 				operation: "pin_entity",
@@ -197,7 +197,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 
 		const agentId = c.req.query("agent_id") ?? "default";
 		try {
-			applyOntologyOperation(getDbAccessor(), {
+			await applyOntologyOperation(getDbAccessor(), {
 				agentId,
 				actor: c.req.header("x-signet-actor") ?? "operator",
 				operation: "unpin_entity",
@@ -210,16 +210,16 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		return c.json({ pinned: false });
 	});
 
-	app.get("/api/knowledge/entities/pinned", (c) => {
+	app.get("/api/knowledge/entities/pinned", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
-		return c.json(getPinnedEntities(getDbAccessor(), agentId));
+		return c.json(await getPinnedEntities(getDbAccessor(), agentId));
 	});
 
-	app.get("/api/knowledge/entities/health", (c) => {
+	app.get("/api/knowledge/entities/health", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
 		const minComparisonsParam = Number.parseInt(c.req.query("min_comparisons") ?? "3", 10);
 		return c.json(
-			getEntityHealth(
+			await getEntityHealth(
 				getDbAccessor(),
 				agentId,
 				c.req.query("since") ?? undefined,
@@ -228,10 +228,10 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		);
 	});
 
-	app.get("/api/knowledge/hygiene", (c) => {
+	app.get("/api/knowledge/hygiene", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
 		return c.json(
-			getKnowledgeHygieneReport(getDbAccessor(), {
+			await getKnowledgeHygieneReport(getDbAccessor(), {
 				agentId,
 				limit: parseNavigationLimit(c.req.query("limit"), 50, 500),
 				memoryLimit: parseNavigationLimit(c.req.query("memory_limit"), 200, 1000),
@@ -239,23 +239,23 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		);
 	});
 
-	app.get("/api/knowledge/entities/:id", (c) => {
+	app.get("/api/knowledge/entities/:id", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
-		const entity = getKnowledgeEntityDetail(getDbAccessor(), c.req.param("id"), agentId);
+		const entity = await getKnowledgeEntityDetail(getDbAccessor(), c.req.param("id"), agentId);
 		if (!entity) {
 			return c.json({ error: "Entity not found" }, 404);
 		}
 		return c.json(entity);
 	});
 
-	app.get("/api/knowledge/entities/:id/aspects", (c) => {
+	app.get("/api/knowledge/entities/:id/aspects", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
 		return c.json({
-			items: getEntityAspectsWithCounts(getDbAccessor(), c.req.param("id"), agentId),
+			items: await getEntityAspectsWithCounts(getDbAccessor(), c.req.param("id"), agentId),
 		});
 	});
 
-	app.get("/api/knowledge/entities/:id/aspects/:aspectId/attributes", (c) => {
+	app.get("/api/knowledge/entities/:id/aspects/:aspectId/attributes", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
 		const limitParam = Number.parseInt(c.req.query("limit") ?? "50", 10);
 		const offsetParam = Number.parseInt(c.req.query("offset") ?? "0", 10);
@@ -265,7 +265,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		const status = c.req.query("status");
 
 		return c.json({
-			items: getAttributesForAspectFiltered(getDbAccessor(), {
+			items: await getAttributesForAspectFiltered(getDbAccessor(), {
 				entityId: c.req.param("id"),
 				aspectId: c.req.param("aspectId"),
 				agentId,
@@ -279,7 +279,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		});
 	});
 
-	app.get("/api/knowledge/entities/:id/dependencies", (c) => {
+	app.get("/api/knowledge/entities/:id/dependencies", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
 		const directionQuery = c.req.query("direction");
 		const direction =
@@ -295,15 +295,14 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		});
 	});
 
-	app.get("/api/knowledge/stats", (c) => {
+	app.get("/api/knowledge/stats", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
-		return c.json(getKnowledgeStats(getDbAccessor(), agentId));
+		return c.json(await getKnowledgeStats(getDbAccessor(), agentId));
 	});
 
-	app.get("/api/knowledge/communities", (c) => {
+	app.get("/api/knowledge/communities", async (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const rows = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+		const rows = await getDbAccessor().withReadDbAsync(async (db) => {
 			return db
 				.prepare(
 					`SELECT id, name, cohesion, member_count, created_at, updated_at
@@ -323,7 +322,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		return c.json({ items: rows, count: rows.length });
 	});
 
-	app.get("/api/knowledge/traversal/status", (c) => {
+	app.get("/api/knowledge/traversal/status", async (c) => {
 		return c.json({
 			status: getTraversalStatus(),
 		});
@@ -359,7 +358,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 		}
 
 		const agentId = scopedAgent.agentId;
-		const resolved = resolveNamedEntity(getDbAccessor(), {
+		const resolved = await resolveNamedEntity(getDbAccessor(), {
 			agentId,
 			name: entityName,
 		});
@@ -368,8 +367,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 				? {
 						entityIds: [resolved.id],
 					}
-				: // @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-					getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
+				: await getDbAccessor().withReadDbAsync(async (db) =>
 						resolveFocalEntities(db, agentId, {
 							queryTokens: entityName.split(/\s+/),
 						}),
@@ -404,12 +402,8 @@ export function registerKnowledgeRoutes(app: Hono): void {
 
 		const primaryEntityId = focal.entityIds[0];
 
-		const traversal = await traverseKnowledgeGraph(
-			focal.entityIds,
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			<T>(fn: (db: ReadDb) => T): T => getDbAccessor().withReadDb(fn),
-			agentId,
-			{
+		const traversal = await getDbAccessor().withReadDbAsync(async (db) =>
+			traverseKnowledgeGraph(focal.entityIds, db, agentId, {
 				maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
 				maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,
 				maxDependencyHops: traversalCfg.maxDependencyHops,
@@ -419,11 +413,10 @@ export function registerKnowledgeRoutes(app: Hono): void {
 				minConfidence: traversalCfg.minConfidence,
 				timeoutMs: traversalCfg.timeoutMs,
 				aspectFilter: aspectFilter || undefined,
-			},
+			}),
 		);
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		return getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+		return await getDbAccessor().withReadDbAsync(async (db) => {
 			const entityRow = db
 				.prepare(
 					`SELECT id, name, entity_type, description
@@ -595,8 +588,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 			return c.json({ error: "entityName is required" }, 400);
 		}
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		return getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+		return await getDbAccessor().withReadDbAsync(async (db) => {
 			const tbl = db
 				.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'session_summaries'")
 				.get() as { name: string } | undefined;
@@ -604,7 +596,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 				return c.json({ entityName, summaries: [], total: 0 });
 			}
 
-			const entity = resolveNamedEntity(getDbAccessor(), {
+			const entity = await resolveNamedEntity(getDbAccessor(), {
 				agentId,
 				name: entityName,
 			});
@@ -710,8 +702,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 			return c.json({ error: "entityId is required" }, 400);
 		}
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const result = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
+		const result = await getDbAccessor().withReadDbAsync(async (db) =>
 			walkImpact(db, { entityId, direction, maxDepth, timeoutMs: 200 }),
 		);
 		return c.json(result);

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -9,7 +9,7 @@ import { aggregateRecall, parseAggregateRecallBudget, readAggregateRecallBudgetI
 import { checkScope, requirePermission, requireRateLimit } from "../auth";
 import { type ConcurrencyAdmission, createConcurrencyAdmission } from "../concurrency-admission";
 import { normalizeAndHashContent } from "../content-normalization";
-import { type ReadDb, type WriteDb, getDbAccessor, prepareTypedStatement } from "../db-accessor";
+import { type ReadDb, type WriteDb, getDbAccessor, runWriteTxAsync, prepareTypedStatement } from "../db-accessor";
 import { syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "../db-helpers";
 import { fetchEmbedding } from "../embedding-fetch";
 import { buildEmbeddingHealth } from "../embedding-health";
@@ -110,13 +110,10 @@ import {
 	validateSessionAgentBinding,
 } from "./utils";
 
-function withActiveEmbeddingConfig(cfg: ResolvedMemoryConfig): ResolvedMemoryConfig {
+async function withActiveEmbeddingConfig(cfg: ResolvedMemoryConfig): Promise<ResolvedMemoryConfig> {
 	return {
 		...cfg,
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		embedding: getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
-			resolveActiveEmbeddingConfig(db, cfg.embedding),
-		),
+		embedding: await getDbAccessor().withReadDbAsync(async (db) => resolveActiveEmbeddingConfig(db, cfg.embedding)),
 	};
 }
 
@@ -616,12 +613,11 @@ function resolveMemoryScopedAgentId(
 	return scopedAgent;
 }
 
-function authorizeMemoryMutationScope(c: Context, memoryIds: readonly string[]): { error?: string } {
+async function authorizeMemoryMutationScope(c: Context, memoryIds: readonly string[]): Promise<{ error?: string }> {
 	if (!shouldEnforceAuthScope(c)) return {};
 	const ids = [...new Set(memoryIds.map((id) => id.trim()).filter(Boolean))];
 	if (ids.length === 0) return {};
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	const rows = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+	const rows = await getDbAccessor().withReadDbAsync(async (db) => {
 		const stmt = db.prepare("SELECT id, agent_id, project FROM memories WHERE id = ?");
 		return ids.map((id) => stmt.get(id) as { id: string; agent_id: string | null; project: string | null } | undefined);
 	});
@@ -936,9 +932,8 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			const auth = c.get("auth");
 			if (auth?.claims?.scope?.project) {
 				const memoryId = c.req.param("id");
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-				const row = getDbAccessor().withReadDb(
-					(db: import("../db-accessor").ReadDb) =>
+				const row = await getDbAccessor().withReadDbAsync(
+					async (db) =>
 						db.prepare("SELECT project FROM memories WHERE id = ?").get(memoryId) as
 							| { project: string | null }
 							| undefined,
@@ -975,13 +970,12 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	// =========================================================================
 	// GET /api/memories — list memories
 	// =========================================================================
-	app.get("/api/memories", (c) => {
+	app.get("/api/memories", async (c) => {
 		try {
 			const limit = Number.parseInt(c.req.query("limit") || "100", 10);
 			const offset = Number.parseInt(c.req.query("offset") || "0", 10);
 
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const result = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+			const result = await getDbAccessor().withReadDbAsync(async (db) => {
 				const queriedMemories = db
 					.prepare(`
 	      SELECT id, content, created_at, who, importance, tags, source_type, pinned, type, agent_id
@@ -1052,12 +1046,11 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	// =========================================================================
 	// GET /api/memories/most-used
 	// =========================================================================
-	app.get("/api/memories/most-used", (c) => {
+	app.get("/api/memories/most-used", async (c) => {
 		try {
 			const raw = Number.parseInt(c.req.query("limit") || "6", 10);
 			const limit = Number.isNaN(raw) || raw < 1 ? 6 : Math.min(raw, 200);
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const memories = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+			const memories = await getDbAccessor().withReadDbAsync(async (db) => {
 				const rows = db
 					.prepare(`
 					SELECT id, content, agent_id, access_count, importance, type, tags
@@ -1090,7 +1083,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	// =========================================================================
 	// GET /api/memories/curator-slices
 	// =========================================================================
-	app.get("/api/memories/curator-slices", (c) => {
+	app.get("/api/memories/curator-slices", async (c) => {
 		try {
 			const minSessions = Math.max(1, Math.min(100, Number.parseInt(c.req.query("minSessions") || "3", 10) || 3));
 			const limit = Math.max(1, Math.min(500, Number.parseInt(c.req.query("limit") || "100", 10) || 100));
@@ -1109,8 +1102,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				? `${access.sql}${scopeProject ? " AND m.project = ?" : ""}`
 				: "";
 			const scopeArgs = shouldEnforceAuthScope(c) ? (scopeProject ? [...access.args, scopeProject] : access.args) : [];
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const slices = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+			const slices = await getDbAccessor().withReadDbAsync(async (db) => {
 				const filterSafe = <T extends { id: string; content: string; agent_id: string | null }>(rows: T[]): T[] =>
 					rows.filter((row) =>
 						isMemoryContentContextEligible(db, {
@@ -1198,7 +1190,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	// =========================================================================
 	// GET /api/memory/timeline
 	// =========================================================================
-	app.get("/api/memory/timeline", (c) => {
+	app.get("/api/memory/timeline", async (c) => {
 		try {
 			const raw = Number.parseInt(c.req.query("tzOffset") || "0", 10);
 			const tzOffsetMin = Number.isNaN(raw) ? 0 : Math.max(-840, Math.min(840, raw));
@@ -1208,8 +1200,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			});
 			if (scopedAgent.error) return c.json({ error: scopedAgent.error }, 403);
 			const agentScope = getAgentScope(scopedAgent.agentId);
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const timeline = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
+			const timeline = await getDbAccessor().withReadDbAsync(async (db) =>
 				buildMemoryTimeline(db, {
 					tzOffsetMin,
 					agentId: shouldEnforceAuthScope(c) ? scopedAgent.agentId : undefined,
@@ -1241,7 +1232,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	// =========================================================================
 	// GET /api/memory/review-queue
 	// =========================================================================
-	app.get("/api/memory/review-queue", (c) => {
+	app.get("/api/memory/review-queue", async (c) => {
 		try {
 			const scopedAgent = resolveMemoryScopedAgentId(c, {
 				agentId: c.req.query("agentId") ?? c.req.query("agent_id") ?? c.req.header("x-signet-agent-id"),
@@ -1254,8 +1245,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			const projectSql = scopeProject ? " AND m.project = ?" : "";
 			const scopeArgs = scopeProject ? [...access.args, scopeProject] : access.args;
 			const scopePredicate = shouldEnforceAuthScope(c) ? `${access.sql}${projectSql}` : "";
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const rows = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+			const rows = await getDbAccessor().withReadDbAsync(async (db) => {
 				return db
 					.prepare(
 						`SELECT h.id, h.memory_id, h.event, h.old_content, h.new_content,
@@ -1282,7 +1272,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	// =========================================================================
 	// GET /memory/search — FTS + filter search
 	// =========================================================================
-	app.get("/memory/search", (c) => {
+	app.get("/memory/search", async (c) => {
 		const query = c.req.query("q") ?? "";
 		const distinct = c.req.query("distinct");
 		const limitParam = c.req.query("limit");
@@ -1290,8 +1280,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		// Shortcut: return distinct values for a column
 		if (distinct === "who") {
 			try {
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-				const values = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+				const values = await getDbAccessor().withReadDbAsync(async (db) => {
 					const rows = db.prepare("SELECT DISTINCT who FROM memories WHERE who IS NOT NULL ORDER BY who").all() as {
 						who: string;
 					}[];
@@ -1319,8 +1308,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		recordRecallAttempt(recallSurface);
 
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const results = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+			const results = await getDbAccessor().withReadDbAsync(async (db) => {
 				let rows: unknown[] = [];
 
 				if (query.trim()) {
@@ -1546,7 +1534,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		ensureAgentRegistered(agentId);
 		const visibility: RememberDedupeScope["visibility"] = body.visibility === "private" ? "private" : "global";
 		const dedupeScope: RememberDedupeScope = { agentId, visibility, project: body.project ?? null, scope };
-		const hasBodyTags = Object.prototype.hasOwnProperty.call(body, "tags");
+		const hasBodyTags = Object.hasOwn(body, "tags");
 		const bodyTags = hasBodyTags ? parseTagsMutation(body.tags) : undefined;
 		if (hasBodyTags && bodyTags === undefined) {
 			return c.json({ error: "tags must be a string, string array, or null" }, 400);
@@ -1554,7 +1542,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 		// Pipeline v2 kill switch: refuse writes when mutations are frozen
 		const fullCfgBase = loadMemoryConfig(AGENTS_DIR);
-		const fullCfg = withActiveEmbeddingConfig(fullCfgBase);
+		const fullCfg = await withActiveEmbeddingConfig(fullCfgBase);
 		const pipelineCfg = fullCfg.pipelineV2;
 		if (pipelineCfg.mutationsFrozen) {
 			return c.json({ error: "Mutations are frozen (kill switch active)" }, 503);
@@ -1619,18 +1607,15 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				return c.json({ error: "content produced no valid chunks" }, 400);
 			}
 
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const baseIdempotencyMemory = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
+			const baseIdempotencyMemory = await getDbAccessor().withReadDbAsync(async (db) =>
 				getScopedIdempotencyMemoryId(db, rowProvenance.idempotencyKey, dedupeScope),
 			);
 			if (baseIdempotencyMemory) {
 				return c.json({ error: "idempotencyKey already used for non-chunk content" }, 409);
 			}
 
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const existingChunks: ReturnType<typeof getScopedChunkIdempotencyRows> = getDbAccessor().withReadDb(
-				(db: import("../db-accessor").ReadDb) =>
-					getScopedChunkIdempotencyRows(db, rowProvenance.idempotencyKey, dedupeScope),
+			const existingChunks = await getDbAccessor().withReadDbAsync(async (db) =>
+				getScopedChunkIdempotencyRows(db, rowProvenance.idempotencyKey, dedupeScope),
 			);
 			if (existingChunks.length > 0) {
 				const groupIds = new Set(existingChunks.map((row) => row.sourceId).filter((id): id is string => !!id));
@@ -1662,8 +1647,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					return c.json({ error: "chunked content contains duplicate chunks" }, 409);
 				}
 				contentHashes.add(plan.normalized.contentHash);
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-				const byHash = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
+				const byHash = await getDbAccessor().withReadDbAsync(async (db) =>
 					getScopedContentHashMemoryId(db, plan.normalized.contentHash, dedupeScope),
 				);
 				if (byHash) {
@@ -1682,8 +1666,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				| { readonly status: "non_chunk_idempotency_conflict" };
 
 			try {
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-				const result: ChunkInsertResult = getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) => {
+				const result: ChunkInsertResult = await runWriteTxAsync(getDbAccessor(), (db) => {
 					const baseMemory = getScopedIdempotencyMemoryId(db, rowProvenance.idempotencyKey, dedupeScope);
 					if (baseMemory) return { status: "non_chunk_idempotency_conflict" };
 
@@ -1793,8 +1776,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 								const embId = crypto.randomUUID();
 								const blob = vectorToBlob(vec);
 								const embHash = scope ? `${plan.normalized.contentHash}:${scope}` : plan.normalized.contentHash;
-								// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-								getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) => {
+								await runWriteTxAsync(getDbAccessor(), (db) => {
 									const activeCfg = resolveActiveEmbeddingConfig(db, fullCfgBase.embedding);
 									if (!isActiveEmbeddingConfig(db, activeCfg)) return;
 									syncVecDeleteBySourceId(db, "memory", chunkId);
@@ -1871,8 +1853,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const chunkedIdempotencyMemory =
 			rowProvenance.idempotencyKey === undefined
 				? []
-				: // @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-					getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
+				: await getDbAccessor().withReadDbAsync(async (db) =>
 						getScopedChunkIdempotencyRows(db, rowProvenance.idempotencyKey, dedupeScope),
 					);
 		if (chunkedIdempotencyMemory.length > 0) {
@@ -1882,8 +1863,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		let supersededStatus: SupersedeMemoryTxStatus | null = null;
 
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-			const result = getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) => {
+			const result = await runWriteTxAsync(getDbAccessor(), (db) => {
 				// Check sourceId-based dedupe first (scope-aware)
 				if (sourceId) {
 					const bySource = getScopedSourceDedupeRow(db, sourceType, sourceId, dedupeScope);
@@ -1972,8 +1952,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 			if (result.deduped) {
 				c.header("x-signet-operation-skipped", "1");
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-				getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) =>
+				await runWriteTxAsync(getDbAccessor(), (db) =>
 					txInsertExplicitTemporalEdges({
 						db,
 						memoryId: result.row.id,
@@ -1998,16 +1977,14 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		} catch (e) {
 			const msg = e instanceof Error ? e.message : "";
 			if (msg.includes("UNIQUE constraint")) {
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-				const existing = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+				const existing = await getDbAccessor().withReadDbAsync(async (db) => {
 					const byIdempotencyKey = getScopedIdempotencyDedupeRow(db, rowProvenance.idempotencyKey, dedupeScope);
 					if (byIdempotencyKey) return byIdempotencyKey;
 					return getScopedContentHashDedupeRow(db, contentHash, dedupeScope);
 				});
 				if (existing) {
 					c.header("x-signet-operation-skipped", "1");
-					// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-					getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) =>
+					await runWriteTxAsync(getDbAccessor(), (db) =>
 						txInsertExplicitTemporalEdges({
 							db,
 							memoryId: existing.id,
@@ -2048,7 +2025,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		let embedded = false;
 		try {
 			const baseCfg = loadMemoryConfig(AGENTS_DIR);
-			const cfg = withActiveEmbeddingConfig(baseCfg);
+			const cfg = await withActiveEmbeddingConfig(baseCfg);
 			const vec = await fetchEmbedding(normalizedContent.storageContent, cfg.embedding, "document", {
 				usage: { source: "memory-capture", agentId },
 				onFailure: recordRouteOperationFailure(c),
@@ -2070,8 +2047,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					// call) and re-checked later, so a startup building->ready promotion
 					// between the two could skip the insert while still reporting
 					// embedded=true. `embedded` now reflects whether the vector was written.
-					// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-					embedded = getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) => {
+					embedded = await runWriteTxAsync(getDbAccessor(), (db) => {
 						const activeCfg = resolveActiveEmbeddingConfig(db, baseCfg.embedding);
 						if (!isActiveEmbeddingConfig(db, activeCfg)) return false;
 						syncVecDeleteBySourceId(db, "memory", id);
@@ -2113,8 +2089,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				: (body.hints ?? []);
 			if (allHints.length > 0) {
 				try {
-					// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-					getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) => {
+					await runWriteTxAsync(getDbAccessor(), (db) => {
 						const stmt = db.prepare(
 							`INSERT OR IGNORE INTO memory_hints (id, memory_id, agent_id, hint, created_at)
 							 VALUES (?, ?, ?, ?, ?)`,
@@ -2203,7 +2178,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	// =========================================================================
 	// GET /api/memory/:id
 	// =========================================================================
-	app.get("/api/memory/:id", (c) => {
+	app.get("/api/memory/:id", async (c) => {
 		const memoryId = c.req.param("id")?.trim();
 		if (!memoryId) {
 			return c.json({ error: "memory id is required" }, 400);
@@ -2218,8 +2193,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const access = buildAgentScopeClause(agentId, agentScope.readPolicy, agentScope.policyGroup);
 		const scopeProject = c.get("auth")?.claims?.scope?.project;
 		const projectSql = scopeProject ? " AND m.project = ?" : "";
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const memoryRead = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+		const memoryRead = await getDbAccessor().withReadDbAsync(async (db) => {
 			const sessionSelect = hasMemoriesSessionIdColumn(db) ? "m.session_id," : "NULL AS session_id,";
 
 			const row = db
@@ -2276,7 +2250,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	// =========================================================================
 	// GET /api/memory/:id/history
 	// =========================================================================
-	app.get("/api/memory/:id/history", (c) => {
+	app.get("/api/memory/:id/history", async (c) => {
 		const memoryId = c.req.param("id")?.trim();
 		if (!memoryId) {
 			return c.json({ error: "memory id is required" }, 400);
@@ -2284,52 +2258,37 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 		const limit = Math.min(parseOptionalInt(c.req.query("limit")) ?? 200, 1000);
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const exists = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+		const exists = await getDbAccessor().withReadDbAsync(async (db) => {
 			return db.prepare("SELECT id FROM memories WHERE id = ?").get(memoryId) as { id: string } | undefined;
 		});
 		if (!exists) {
 			return c.json({ error: "Not found", memoryId }, 404);
 		}
 
-		const history: Array<{
-			id: string;
-			event: string;
-			old_content: string | null;
-			new_content: string | null;
-			changed_by: string;
-			reason: string | null;
-			metadata: string | null;
-			created_at: string;
-			actor_type: string | null;
-			session_id: string | null;
-			request_id: string | null;
-		}> =
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
-				return db
-					.prepare(
-						`SELECT id, event, old_content, new_content, changed_by, reason,
+		const history = await getDbAccessor().withReadDbAsync(async (db) => {
+			return db
+				.prepare(
+					`SELECT id, event, old_content, new_content, changed_by, reason,
 					        metadata, created_at, actor_type, session_id, request_id
 					 FROM memory_history
 					 WHERE memory_id = ?
 					 ORDER BY created_at ASC
 					 LIMIT ?`,
-					)
-					.all(memoryId, limit) as Array<{
-					id: string;
-					event: string;
-					old_content: string | null;
-					new_content: string | null;
-					changed_by: string;
-					reason: string | null;
-					metadata: string | null;
-					created_at: string;
-					actor_type: string | null;
-					session_id: string | null;
-					request_id: string | null;
-				}>;
-			});
+				)
+				.all(memoryId, limit) as Array<{
+				id: string;
+				event: string;
+				old_content: string | null;
+				new_content: string | null;
+				changed_by: string;
+				reason: string | null;
+				metadata: string | null;
+				created_at: string;
+				actor_type: string | null;
+				session_id: string | null;
+				request_id: string | null;
+			}>;
+		});
 
 		return c.json({
 			memoryId,
@@ -2362,7 +2321,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	// =========================================================================
 	// GET /api/memory/:id/lineage
 	// =========================================================================
-	app.get("/api/memory/:id/lineage", (c) => {
+	app.get("/api/memory/:id/lineage", async (c) => {
 		const memoryId = c.req.param("id")?.trim();
 		if (!memoryId) return c.json({ error: "memory id is required" }, 400);
 		const limit = Math.min(parseOptionalInt(c.req.query("limit")) ?? 50, 500);
@@ -2404,8 +2363,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				)
 				.get(id, ...access.args) as LineageRow | undefined;
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const rows: LineageRow[] = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+		const rows = await getDbAccessor().withReadDbAsync(async (db) => {
 			const head = selectLineage(db, memoryId);
 			if (!head) return [];
 			// #1147 review (finding 9): walk BOTH directions so lineage from
@@ -2471,14 +2429,13 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	// =========================================================================
 	// GET /api/memory/jobs/:id
 	// =========================================================================
-	app.get("/api/memory/jobs/:id", (c) => {
+	app.get("/api/memory/jobs/:id", async (c) => {
 		const jobId = c.req.param("id")?.trim();
 		if (!jobId) {
 			return c.json({ error: "job id is required" }, 400);
 		}
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const maybeRow = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+		const maybeRow = await getDbAccessor().withReadDbAsync(async (db) => {
 			return db
 				.prepare(
 					`SELECT id, memory_id, document_id, job_type, status,
@@ -2567,7 +2524,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			return c.json({ error: "reason is required" }, 400);
 		}
 
-		const hasIfVersionInBody = Object.prototype.hasOwnProperty.call(payload, "if_version");
+		const hasIfVersionInBody = Object.hasOwn(payload, "if_version");
 		const ifVersionBody = parseOptionalInt(payload.if_version);
 		if (hasIfVersionInBody && ifVersionBody === undefined) {
 			return c.json({ error: "if_version must be a positive integer" }, 400);
@@ -2580,15 +2537,14 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		}
 		const ifVersion = ifVersionBody ?? ifVersionQuery;
 
-		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
+		const cfg = await withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		if (cfg.pipelineV2.mutationsFrozen) {
 			return c.json({ error: "Mutations are frozen (kill switch active)" }, 503);
 		}
 
 		const now = new Date().toISOString();
 		const actor = resolveMutationActor(c, parseOptionalString(payload.changed_by));
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		const txResult = getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) =>
+		const txResult = await runWriteTxAsync(getDbAccessor(), (db) =>
 			txRecoverMemory(db, {
 				memoryId,
 				reason,
@@ -2665,7 +2621,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			return c.json({ error: "reason is required" }, 400);
 		}
 
-		const hasIfVersion = Object.prototype.hasOwnProperty.call(payload, "if_version");
+		const hasIfVersion = Object.hasOwn(payload, "if_version");
 		const ifVersion = parseOptionalInt(payload.if_version);
 		if (hasIfVersion && ifVersion === undefined) {
 			return c.json({ error: "if_version must be a positive integer" }, 400);
@@ -2676,7 +2632,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			return c.json({ error: parsedPatch.error }, 400);
 		}
 
-		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
+		const cfg = await withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		if (cfg.pipelineV2.mutationsFrozen) {
 			return c.json({ error: "Mutations are frozen (kill switch active)" }, 503);
 		}
@@ -2690,8 +2646,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 		const now = new Date().toISOString();
 		const actor = resolveMutationActor(c, parseOptionalString(payload.changed_by));
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		const txResult = getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) =>
+		const txResult = await runWriteTxAsync(getDbAccessor(), (db) =>
 			txModifyMemory(db, {
 				memoryId,
 				patch: parsedPatch.value.patch,
@@ -2803,7 +2758,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			return c.json({ error: "reason is required" }, 400);
 		}
 
-		const hasForceInBody = Object.prototype.hasOwnProperty.call(payload, "force");
+		const hasForceInBody = Object.hasOwn(payload, "force");
 		const forceFromBody = parseOptionalBoolean(payload.force);
 		if (hasForceInBody && forceFromBody === undefined) {
 			return c.json({ error: "force must be a boolean" }, 400);
@@ -2811,7 +2766,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const forceFromQuery = parseOptionalBoolean(c.req.query("force"));
 		const force = forceFromBody ?? forceFromQuery ?? false;
 
-		const hasIfVersionInBody = Object.prototype.hasOwnProperty.call(payload, "if_version");
+		const hasIfVersionInBody = Object.hasOwn(payload, "if_version");
 		const ifVersionBody = parseOptionalInt(payload.if_version);
 		if (hasIfVersionInBody && ifVersionBody === undefined) {
 			return c.json({ error: "if_version must be a positive integer" }, 400);
@@ -2824,15 +2779,14 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		}
 		const ifVersion = ifVersionBody ?? ifVersionQuery;
 
-		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
+		const cfg = await withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		if (cfg.pipelineV2.mutationsFrozen) {
 			return c.json({ error: "Mutations are frozen (kill switch active)" }, 503);
 		}
 
 		const now = new Date().toISOString();
 		const actor = resolveMutationActor(c, parseOptionalString(payload.changed_by));
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		const txResult = getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) =>
+		const txResult = await runWriteTxAsync(getDbAccessor(), (db) =>
 			txForgetMemory(db, {
 				memoryId,
 				reason,
@@ -2907,17 +2861,16 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const memoryId = c.req.param("id")?.trim();
 		if (!memoryId) return c.json({ error: "memory id is required" }, 400);
 
-		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
+		const cfg = await withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		if (cfg.pipelineV2.mutationsFrozen) return c.json({ error: "Mutations are frozen (kill switch active)" }, 503);
-		const scopeDecision = authorizeMemoryMutationScope(c, [memoryId]);
+		const scopeDecision = await authorizeMemoryMutationScope(c, [memoryId]);
 		if (scopeDecision.error) return c.json({ error: scopeDecision.error }, 403);
 
 		const now = new Date().toISOString();
 		const actor = resolveMutationActor(c, parseOptionalString(payload.changed_by));
 		const reason =
 			parseOptionalString(payload.reason) ?? parseOptionalString(c.req.query("reason")) ?? "curator tombstone";
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		const txResult = getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) =>
+		const txResult = await runWriteTxAsync(getDbAccessor(), (db) =>
 			txForgetMemory(db, {
 				memoryId,
 				reason,
@@ -2954,14 +2907,13 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 		const cfg = loadMemoryConfig(AGENTS_DIR);
 		if (cfg.pipelineV2.mutationsFrozen) return c.json({ error: "Mutations are frozen (kill switch active)" }, 503);
-		const scopeDecision = authorizeMemoryMutationScope(c, [memoryId, supersededBy]);
+		const scopeDecision = await authorizeMemoryMutationScope(c, [memoryId, supersededBy]);
 		if (scopeDecision.error) return c.json({ error: scopeDecision.error }, 403);
 
 		const now = new Date().toISOString();
 		const actor = resolveMutationActor(c, parseOptionalString(payload.changed_by));
 		const reason = parseOptionalString(payload.reason) ?? null;
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		const txResult = getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) =>
+		const txResult = await runWriteTxAsync(getDbAccessor(), (db) =>
 			txSupersedeMemory(db, {
 				memoryId,
 				supersededBy,
@@ -3063,7 +3015,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			return c.json({ error: "mode must be preview or execute" }, 400);
 		}
 
-		const hasLimit = Object.prototype.hasOwnProperty.call(payload, "limit");
+		const hasLimit = Object.hasOwn(payload, "limit");
 		const parsedLimit = parseOptionalInt(payload.limit);
 		if (hasLimit && parsedLimit === undefined) {
 			return c.json({ error: "limit must be a positive integer" }, 400);
@@ -3071,7 +3023,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const limit = Math.max(1, Math.min(parsedLimit ?? 20, MAX_MUTATION_BATCH));
 
 		let ids: string[] = [];
-		if (Object.prototype.hasOwnProperty.call(payload, "ids")) {
+		if (Object.hasOwn(payload, "ids")) {
 			if (!Array.isArray(payload.ids)) {
 				return c.json({ error: "ids must be an array of strings" }, 400);
 			}
@@ -3140,13 +3092,13 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			return c.json({ error: "reason is required for execute mode" }, 400);
 		}
 
-		const hasForce = Object.prototype.hasOwnProperty.call(payload, "force");
+		const hasForce = Object.hasOwn(payload, "force");
 		const force = parseOptionalBoolean(payload.force);
 		if (hasForce && force === undefined) {
 			return c.json({ error: "force must be a boolean" }, 400);
 		}
 
-		if (Object.prototype.hasOwnProperty.call(payload, "if_version")) {
+		if (Object.hasOwn(payload, "if_version")) {
 			return c.json(
 				{
 					error: "if_version is not supported for batch forget; use DELETE /api/memory/:id for version-guarded deletes",
@@ -3170,7 +3122,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			}
 		}
 
-		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
+		const cfg = await withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		if (cfg.pipelineV2.mutationsFrozen) {
 			return c.json({ error: "Mutations are frozen (kill switch active)" }, 503);
 		}
@@ -3186,8 +3138,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		}> = [];
 
 		for (const memoryId of candidateIds) {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-			const txResult = getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) =>
+			const txResult = await runWriteTxAsync(getDbAccessor(), (db) =>
 				txForgetMemory(db, {
 					memoryId,
 					reason,
@@ -3233,7 +3184,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			);
 		}
 
-		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
+		const cfg = await withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		if (cfg.pipelineV2.mutationsFrozen) {
 			return c.json({ error: "Mutations are frozen (kill switch active)" }, 503);
 		}
@@ -3284,7 +3235,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				continue;
 			}
 
-			const hasIfVersion = Object.prototype.hasOwnProperty.call(patchPayload, "if_version");
+			const hasIfVersion = Object.hasOwn(patchPayload, "if_version");
 			const ifVersion = parseOptionalInt(patchPayload.if_version);
 			if (hasIfVersion && ifVersion === undefined) {
 				results.push({
@@ -3312,8 +3263,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				});
 			}
 
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-			const txResult = getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) =>
+			const txResult = await runWriteTxAsync(getDbAccessor(), (db) =>
 				txModifyMemory(db, {
 					memoryId,
 					patch: parsedPatch.value.patch,
@@ -3377,7 +3327,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			if (denied) return denied;
 		}
 
-		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
+		const cfg = await withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		if (
 			((cfg.pipelineV2.reranker.enabled && cfg.pipelineV2.reranker.useExtractionModel) || body.aggregate === true) &&
 			authConfig.mode !== "local"
@@ -3499,7 +3449,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const project = c.req.query("project");
 		const includeRecalled = c.req.query("includeRecalled") ?? c.req.query("include_recalled");
 
-		const cfg = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
+		const cfg = await withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		const scopeProject = c.get("auth")?.claims?.scope?.project;
 		const recallSurface = "explicit_api" as const;
 		try {
@@ -3575,11 +3525,9 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const type = c.req.query("type");
 
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const searchData: ReturnType<typeof vectorSearch> | null = getDbAccessor().withReadDb(
-				(db: import("../db-accessor").ReadDb) => {
-					const embeddingRow = db
-						.prepare(`
+			const searchData = await getDbAccessor().withReadDbAsync(async (db) => {
+				const embeddingRow = db
+					.prepare(`
         SELECT e.vector
         FROM embeddings e
         INNER JOIN memories m ON m.id = e.source_id
@@ -3588,24 +3536,23 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
         ${memoryLifecycleSql(db)}
         LIMIT 1
       `)
-						.get(id) as { vector: Buffer } | undefined;
+					.get(id) as { vector: Buffer } | undefined;
 
-					if (!embeddingRow) return null;
+				if (!embeddingRow) return null;
 
-					const queryVector = new Float32Array(
-						embeddingRow.vector.buffer.slice(
-							embeddingRow.vector.byteOffset,
-							embeddingRow.vector.byteOffset + embeddingRow.vector.byteLength,
-						),
-					);
+				const queryVector = new Float32Array(
+					embeddingRow.vector.buffer.slice(
+						embeddingRow.vector.byteOffset,
+						embeddingRow.vector.byteOffset + embeddingRow.vector.byteLength,
+					),
+				);
 
-					return vectorSearch(db, queryVector, {
-						limit: k + 1,
-						type,
-						excludeAggregateRecall: true,
-					});
-				},
-			);
+				return vectorSearch(db, queryVector, {
+					limit: k + 1,
+					type,
+					excludeAggregateRecall: true,
+				});
+			});
 
 			if (!searchData) {
 				return c.json({ error: "No embedding found for this memory", results: [] }, 404);
@@ -3620,41 +3567,31 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			const ids = filteredResults.map((r) => r.id);
 			const placeholders = ids.map(() => "?").join(", ");
 
-			const rows: Array<{
-				id: string;
-				content: string;
-				agent_id: string | null;
-				type: string;
-				tags: string | null;
-				confidence: number;
-				created_at: string;
-			}> =
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-				getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
-					const queried = db
-						.prepare(`
+			const rows = await getDbAccessor().withReadDbAsync(async (db) => {
+				const queried = db
+					.prepare(`
 	        SELECT id, content, agent_id, type, tags, confidence, created_at
 	        FROM memories m
 	        WHERE id IN (${placeholders})${memoryLifecycleSql(db)}
 	      `)
-						.all(...ids) as Array<{
-						id: string;
-						content: string;
-						agent_id: string | null;
-						type: string;
-						tags: string | null;
-						confidence: number;
-						created_at: string;
-					}>;
-					return queried.filter((row) =>
-						isMemoryContentContextEligible(db, {
-							agentId: row.agent_id?.trim() || "default",
-							sourceKind: "memory",
-							sourceId: row.id,
-							content: row.content,
-						}),
-					);
-				});
+					.all(...ids) as Array<{
+					id: string;
+					content: string;
+					agent_id: string | null;
+					type: string;
+					tags: string | null;
+					confidence: number;
+					created_at: string;
+				}>;
+				return queried.filter((row) =>
+					isMemoryContentContextEligible(db, {
+						agentId: row.agent_id?.trim() || "default",
+						sourceKind: "memory",
+						sourceId: row.id,
+						content: row.content,
+					}),
+				);
+			});
 
 			const rowMap = new Map(rows.map((r) => [r.id, r]));
 			const results = filteredResults
@@ -3704,21 +3641,19 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		};
 
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const { total, rows }: { total: number; rows: EmbeddingRow[] } = getDbAccessor().withReadDb(
-				(db: import("../db-accessor").ReadDb) => {
-					const totalRow = db
-						.prepare(`
+			const { total, rows } = await getDbAccessor().withReadDbAsync(async (db) => {
+				const totalRow = db
+					.prepare(`
 				SELECT COUNT(*) AS count
 				FROM embeddings e
 				INNER JOIN memories m ON m.id = e.source_id
 				WHERE e.source_type = 'memory'
 			`)
-						.get() as { count: number } | undefined;
+					.get() as { count: number } | undefined;
 
-					const rowData = withVectors
-						? (db
-								.prepare(`
+				const rowData = withVectors
+					? (db
+							.prepare(`
 					SELECT
 						m.id, m.content, m.who, m.importance, m.type, m.tags,
 						m.source_type, m.source_id, m.created_at,
@@ -3729,9 +3664,9 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					ORDER BY m.created_at DESC
 					LIMIT ? OFFSET ?
 				`)
-								.all(limit, offset) as EmbeddingRow[])
-						: (db
-								.prepare(`
+							.all(limit, offset) as EmbeddingRow[])
+					: (db
+							.prepare(`
 					SELECT
 						m.id, m.content, m.who, m.importance, m.type, m.tags,
 						m.source_type, m.source_id, m.created_at
@@ -3741,11 +3676,10 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					ORDER BY m.created_at DESC
 					LIMIT ? OFFSET ?
 				`)
-								.all(limit, offset) as EmbeddingRow[]);
+							.all(limit, offset) as EmbeddingRow[]);
 
-					return { total: totalRow?.count ?? 0, rows: rowData };
-				},
-			);
+				return { total: totalRow?.count ?? 0, rows: rowData };
+			});
 
 			const embeddings = rows.map((row) => ({
 				id: row.id,
@@ -3786,11 +3720,10 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	// GET /api/embeddings/status
 	// =========================================================================
 	app.get("/api/embeddings/status", async (c) => {
-		const config = withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
+		const config = await withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
 		const status = await checkEmbeddingProvider(config.embedding);
 		const tracker = embeddingTrackerHandle?.getStats() ?? null;
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const index = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+		const index = await getDbAccessor().withReadDbAsync(async (db) => {
 			const state = readEmbeddingIndexState(db);
 			return state?.staging
 				? { ...state, coverage: stagingCoverage(db, state.staging.dimensions, state.staging.fingerprint) }
@@ -3805,8 +3738,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	app.get("/api/embeddings/health", async (c) => {
 		const cfg = loadMemoryConfig(AGENTS_DIR);
 		const providerStatus = await checkEmbeddingProvider(cfg.embedding);
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const report = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
+		const report = await getDbAccessor().withReadDbAsync(async (db) =>
 			buildEmbeddingHealth(db, cfg.embedding, providerStatus),
 		);
 		return c.json(report);
@@ -3868,8 +3800,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 		if (!useCachedProjection) {
 			try {
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-				const projection = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
+				const projection = await getDbAccessor().withReadDbAsync(async (db) =>
 					computeProjectionForQuery(db, nComponents, {
 						limit,
 						offset,
@@ -3907,8 +3838,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			}
 		}
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const { cached, total } = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+		const { cached, total } = await getDbAccessor().withReadDbAsync(async (db) => {
 			const cachedResult = getCachedProjection(db, nComponents);
 			const countRow = db.prepare("SELECT COUNT(*) as count FROM embeddings WHERE source_type = 'memory'").get();
 			const count =
@@ -3946,21 +3876,14 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			projectionErrors.delete(nComponents);
 			const computation = (async () => {
 				try {
-					// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-					const result = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
-						computeProjection(db, nComponents),
-					);
-					// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-					const count = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+					const result = await getDbAccessor().withReadDbAsync(async (db) => computeProjection(db, nComponents));
+					const count = await getDbAccessor().withReadDbAsync(async (db) => {
 						const row = db.prepare("SELECT COUNT(*) as count FROM embeddings WHERE source_type = 'memory'").get();
 						return typeof row === "object" && row !== null && "count" in row && typeof row.count === "number"
 							? row.count
 							: 0;
 					});
-					// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-					getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) =>
-						cacheProjection(db, nComponents, result, count),
-					);
+					await runWriteTxAsync(getDbAccessor(), (db) => cacheProjection(db, nComponents, result, count));
 				} catch (err) {
 					const msg = err instanceof Error ? err.message : String(err);
 					logger.error("projection", "UMAP computation failed", err instanceof Error ? err : new Error(msg));
@@ -4033,8 +3956,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			const id = crypto.randomUUID();
 			const now = new Date().toISOString();
 
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-			const result = accessor.withWriteTx((db: import("../db-accessor").WriteDb) => {
+			const result = await runWriteTxAsync(accessor, (db) => {
 				if (sourceUrl) {
 					const candidates = prepareTypedStatement<{ id: string; status: string } & DocumentScopeRow>(
 						db,
@@ -4096,7 +4018,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	// =========================================================================
 	// GET /api/documents — list documents
 	// =========================================================================
-	app.get("/api/documents", (c) => {
+	app.get("/api/documents", async (c) => {
 		if (shouldEnforceAuthScope(c)) {
 			return c.json({ error: "documents list requires unscoped credentials" }, 403);
 		}
@@ -4106,8 +4028,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 		try {
 			const accessor = getDbAccessor();
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const result = accessor.withReadDb((db: import("../db-accessor").ReadDb) => {
+			const result = await accessor.withReadDbAsync(async (db) => {
 				const countSql = status
 					? "SELECT COUNT(*) AS cnt FROM documents WHERE status = ?"
 					: "SELECT COUNT(*) AS cnt FROM documents";
@@ -4138,15 +4059,14 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	// =========================================================================
 	// GET /api/documents/:id — single document details
 	// =========================================================================
-	app.get("/api/documents/:id", (c) => {
+	app.get("/api/documents/:id", async (c) => {
 		if (shouldEnforceAuthScope(c)) {
 			return c.json({ error: "document access requires unscoped credentials" }, 403);
 		}
 		const id = c.req.param("id");
 		try {
 			const accessor = getDbAccessor();
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const doc = accessor.withReadDb((db: import("../db-accessor").ReadDb) => {
+			const doc = await accessor.withReadDbAsync(async (db) => {
 				return db.prepare("SELECT * FROM documents WHERE id = ?").get(id);
 			});
 			if (!doc) return c.json({ error: "Document not found" }, 404);
@@ -4160,7 +4080,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	// =========================================================================
 	// GET /api/documents/:id/chunks — list memories linked to document
 	// =========================================================================
-	app.get("/api/documents/:id/chunks", (c) => {
+	app.get("/api/documents/:id/chunks", async (c) => {
 		const id = c.req.param("id");
 		try {
 			const scopedAgent = resolveMemoryScopedAgentId(c, {
@@ -4178,8 +4098,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			const documentScopeSql = " AND d.agent_id = ?";
 			const scopePredicate = shouldEnforceAuthScope(c) ? `${documentScopeSql}${access.sql}${projectSql}` : "";
 			const accessor = getDbAccessor();
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const chunks = accessor.withReadDb((db: import("../db-accessor").ReadDb) => {
+			const chunks = await accessor.withReadDbAsync(async (db) => {
 				return db
 					.prepare(
 						`SELECT m.id, m.content, m.type, m.created_at,
@@ -4211,8 +4130,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		}
 
 		const accessor = getDbAccessor();
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const doc = accessor.withReadDb((db: import("../db-accessor").ReadDb) => {
+		const doc = await accessor.withReadDbAsync(async (db) => {
 			return db.prepare("SELECT id, agent_id, project FROM documents WHERE id = ?").get(id) as
 				| ({ id: string } & DocumentScopeRow)
 				| undefined;
@@ -4243,8 +4161,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				return c.json({ error: "document not found" }, 404);
 			}
 
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-			const memoriesRemoved = accessor.withWriteTx((db: import("../db-accessor").WriteDb) => {
+			const memoriesRemoved = await runWriteTxAsync(accessor, (db) => {
 				db.prepare(
 					`UPDATE documents
 					 SET status = 'deleted', error = ?, updated_at = ?

--- a/platform/daemon/src/routes/misc-routes.ts
+++ b/platform/daemon/src/routes/misc-routes.ts
@@ -4,7 +4,7 @@ import { parseSimpleYaml } from "@signet/core";
 import type { Context, Hono } from "hono";
 import { requirePermission } from "../auth";
 import { checkPermission } from "../auth/policy";
-import { getDbAccessor } from "../db-accessor.js";
+import { getDbAccessor, runWriteTxAsync } from "../db-accessor.js";
 import { type LogCategory, type LogEntry, logger } from "../logger.js";
 import { loadPipelineConfig } from "../memory-config.js";
 import {
@@ -202,10 +202,9 @@ export function registerMiscRoutes(app: Hono): void {
 		);
 	});
 
-	app.get("/api/agents", (c) => {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const agents = getDbAccessor().withReadDb(
-			(db: import("../db-accessor").ReadDb) =>
+	app.get("/api/agents", async (c) => {
+		const agents = await getDbAccessor().withReadDbAsync(
+			async (db) =>
 				db
 					.prepare("SELECT id, name, read_policy, policy_group, created_at, updated_at FROM agents ORDER BY name")
 					.all() as AgentRow[],
@@ -213,11 +212,10 @@ export function registerMiscRoutes(app: Hono): void {
 		return c.json({ agents });
 	});
 
-	app.get("/api/agents/:name", (c) => {
+	app.get("/api/agents/:name", async (c) => {
 		const name = c.req.param("name");
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const agent = getDbAccessor().withReadDb(
-			(db: import("../db-accessor").ReadDb) =>
+		const agent = await getDbAccessor().withReadDbAsync(
+			async (db) =>
 				db
 					.prepare("SELECT id, name, read_policy, policy_group, created_at, updated_at FROM agents WHERE name = ?")
 					.get(name) as AgentRow | undefined,
@@ -234,16 +232,14 @@ export function registerMiscRoutes(app: Hono): void {
 		const readPolicy = parseOptionalString(body.read_policy) ?? "isolated";
 		const group = parseOptionalString(body.policy_group) ?? null;
 		const now = new Date().toISOString();
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) => {
+		await runWriteTxAsync(getDbAccessor(), (db) => {
 			db.prepare(
 				`INSERT INTO agents (id, name, read_policy, policy_group, created_at, updated_at)
 				 VALUES (?, ?, ?, ?, ?, ?)`,
 			).run(name, name, readPolicy, group, now, now);
 		});
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const created = getDbAccessor().withReadDb(
-			(db: import("../db-accessor").ReadDb) =>
+		const created = await getDbAccessor().withReadDbAsync(
+			async (db) =>
 				db
 					.prepare("SELECT id, name, read_policy, policy_group, created_at, updated_at FROM agents WHERE id = ?")
 					.get(name) as unknown as AgentRow,
@@ -251,18 +247,15 @@ export function registerMiscRoutes(app: Hono): void {
 		return c.json(created, 201);
 	});
 
-	app.delete("/api/agents/:name", (c) => {
+	app.delete("/api/agents/:name", async (c) => {
 		const name = c.req.param("name");
 		if (name === "default") return c.json({ error: "Cannot remove the default agent" }, 400);
 		const purge = c.req.query("purge") === "true";
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const agent = getDbAccessor().withReadDb(
-			(db: import("../db-accessor").ReadDb) =>
-				db.prepare("SELECT id FROM agents WHERE name = ?").get(name) as { id: string } | undefined,
+		const agent = await getDbAccessor().withReadDbAsync(
+			async (db) => db.prepare("SELECT id FROM agents WHERE name = ?").get(name) as { id: string } | undefined,
 		);
 		if (!agent) return c.json({ error: "Agent not found" }, 404);
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) => {
+		await runWriteTxAsync(getDbAccessor(), (db) => {
 			if (purge) {
 				db.prepare("DELETE FROM memories WHERE agent_id = ?").run(name);
 			} else {
@@ -417,11 +410,10 @@ export function registerMiscRoutes(app: Hono): void {
 		return c.json(result);
 	});
 
-	app.get("/api/tasks/:id/stream", (c) => {
+	app.get("/api/tasks/:id/stream", async (c) => {
 		const taskId = c.req.param("id");
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const taskExists = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
+		const taskExists = await getDbAccessor().withReadDbAsync(async (db) =>
 			db.prepare("SELECT 1 FROM scheduled_tasks WHERE id = ?").get(taskId),
 		);
 
@@ -516,9 +508,8 @@ export function registerMiscRoutes(app: Hono): void {
 		});
 	});
 
-	app.get("/api/tasks", (c) => {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const tasks = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
+	app.get("/api/tasks", async (c) => {
+		const tasks = await getDbAccessor().withReadDbAsync(async (db) =>
 			db
 				.prepare(
 					`SELECT t.*,
@@ -579,8 +570,7 @@ export function registerMiscRoutes(app: Hono): void {
 		const now = new Date().toISOString();
 		const nextRunAt = computeNextRun(cronExpression);
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) => {
+		await runWriteTxAsync(getDbAccessor(), (db) => {
 			db.prepare(
 				`INSERT INTO scheduled_tasks
 				 (id, name, prompt, cron_expression, harness, working_directory,
@@ -610,11 +600,10 @@ export function registerMiscRoutes(app: Hono): void {
 		return c.json({ id, nextRunAt }, 201);
 	});
 
-	app.get("/api/tasks/:id", (c) => {
+	app.get("/api/tasks/:id", async (c) => {
 		const taskId = c.req.param("id");
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const task = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
+		const task = await getDbAccessor().withReadDbAsync(async (db) =>
 			db.prepare("SELECT * FROM scheduled_tasks WHERE id = ?").get(taskId),
 		);
 
@@ -622,8 +611,7 @@ export function registerMiscRoutes(app: Hono): void {
 			return c.json({ error: "Task not found" }, 404);
 		}
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const runs = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
+		const runs = await getDbAccessor().withReadDbAsync(async (db) =>
 			db
 				.prepare(
 					`SELECT * FROM task_runs
@@ -641,10 +629,9 @@ export function registerMiscRoutes(app: Hono): void {
 		const taskId = c.req.param("id");
 		const body = await c.req.json();
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const existing = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
+		const existing = (await getDbAccessor().withReadDbAsync(async (db) =>
 			db.prepare("SELECT * FROM scheduled_tasks WHERE id = ?").get(taskId),
-		) as Record<string, unknown> | undefined;
+		)) as Record<string, unknown> | undefined;
 
 		if (!existing) {
 			return c.json({ error: "Task not found" }, 404);
@@ -675,8 +662,7 @@ export function registerMiscRoutes(app: Hono): void {
 			return c.json({ error: "skillMode must be 'inject' or 'slash' when skillName is set" }, 400);
 		}
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) => {
+		await runWriteTxAsync(getDbAccessor(), (db) => {
 			db.prepare(
 				`UPDATE scheduled_tasks SET
 				 name = ?, prompt = ?, cron_expression = ?, harness = ?,
@@ -701,11 +687,10 @@ export function registerMiscRoutes(app: Hono): void {
 		return c.json({ success: true });
 	});
 
-	app.delete("/api/tasks/:id", (c) => {
+	app.delete("/api/tasks/:id", async (c) => {
 		const taskId = c.req.param("id");
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		const result = getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) => {
+		const result = await runWriteTxAsync(getDbAccessor(), (db) => {
 			const info = db.prepare("DELETE FROM scheduled_tasks WHERE id = ?").run(taskId);
 			return info;
 		});
@@ -718,8 +703,7 @@ export function registerMiscRoutes(app: Hono): void {
 		const scoped = resolveScopedAgentId(c, c.req.query("agent_id"));
 		if (scoped.error) return c.json({ error: scoped.error }, 403);
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const task = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
+		const task = await getDbAccessor().withReadDbAsync(async (db) =>
 			readScopedTask(db, taskId, scoped.agentId, shouldEnforceAuthScope(c)),
 		);
 
@@ -727,8 +711,7 @@ export function registerMiscRoutes(app: Hono): void {
 			return c.json({ error: "Task not found" }, 404);
 		}
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const running = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
+		const running = await getDbAccessor().withReadDbAsync(async (db) =>
 			db.prepare("SELECT 1 FROM task_runs WHERE task_id = ? AND status = 'running' LIMIT 1").get(taskId),
 		);
 
@@ -739,8 +722,7 @@ export function registerMiscRoutes(app: Hono): void {
 		const runId = crypto.randomUUID();
 		const now = new Date().toISOString();
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) => {
+		await runWriteTxAsync(getDbAccessor(), (db) => {
 			db.prepare(
 				`INSERT INTO task_runs (id, task_id, status, started_at)
 				 VALUES (?, ?, 'running', ?)`,
@@ -804,13 +786,12 @@ export function registerMiscRoutes(app: Hono): void {
 					},
 					taskModel,
 				)
-				.then((result) => {
+				.then(async (result) => {
 					const completedAt = new Date().toISOString();
 					const status =
 						result.error !== null || (result.exitCode !== null && result.exitCode !== 0) ? "failed" : "completed";
 
-					// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-					getDbAccessor().withWriteTx((db: import("../db-accessor").WriteDb) => {
+					await runWriteTxAsync(getDbAccessor(), (db) => {
 						db.prepare(
 							`UPDATE task_runs
 						 SET status = ?, completed_at = ?, exit_code = ?,
@@ -848,13 +829,12 @@ export function registerMiscRoutes(app: Hono): void {
 		return c.json({ runId, status: "running" }, 202);
 	});
 
-	app.get("/api/tasks/:id/runs", (c) => {
+	app.get("/api/tasks/:id/runs", async (c) => {
 		const taskId = c.req.param("id");
 		const limit = Number(c.req.query("limit") ?? 20);
 		const offset = Number(c.req.query("offset") ?? 0);
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const runs = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) =>
+		const runs = await getDbAccessor().withReadDbAsync(async (db) =>
 			db
 				.prepare(
 					`SELECT * FROM task_runs
@@ -865,8 +845,7 @@ export function registerMiscRoutes(app: Hono): void {
 				.all(taskId, limit, offset),
 		);
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-		const total = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
+		const total = await getDbAccessor().withReadDbAsync(async (db) => {
 			const row = db.prepare("SELECT COUNT(*) as count FROM task_runs WHERE task_id = ?").get(taskId) as {
 				count: number;
 			};

--- a/platform/daemon/src/routes/ontology-routes.ts
+++ b/platform/daemon/src/routes/ontology-routes.ts
@@ -182,7 +182,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		if (scoped.response) return scoped.response;
 		const operation = c.req.query("operation")?.trim() || undefined;
 		return c.json(
-			listOntologyProposals(getDbAccessor(), {
+			await listOntologyProposals(getDbAccessor(), {
 				agentId: scoped.agentId,
 				status,
 				operation,
@@ -300,7 +300,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		if (scoped.response) return scoped.response;
 		try {
 			return c.json(
-				createEntityMergePlan(getDbAccessor(), {
+				await createEntityMergePlan(getDbAccessor(), {
 					agentId: scoped.agentId,
 					targetEntity: readString(body, "target_entity") ?? readString(body, "target"),
 					targetEntityId: readString(body, "target_entity_id") ?? readString(body, "target_id"),
@@ -375,7 +375,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
 		try {
-			return c.json(getOntologyProposalEvidence(getDbAccessor(), c.req.param("id"), scoped.agentId));
+			return c.json(await getOntologyProposalEvidence(getDbAccessor(), c.req.param("id"), scoped.agentId));
 		} catch (err) {
 			return c.json({ error: messageForError(err) }, statusForError(err));
 		}
@@ -398,7 +398,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		if (c.req.query("status") && !status) return c.json({ error: "status is invalid" }, 400);
 		try {
 			return c.json(
-				getOntologyClaimEvidence(getDbAccessor(), {
+				await getOntologyClaimEvidence(getDbAccessor(), {
 					agentId: scoped.agentId,
 					entity,
 					aspect,
@@ -521,7 +521,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
 		try {
-			return c.json(getOntologyLinkEvidence(getDbAccessor(), { agentId: scoped.agentId, id: c.req.param("id") }));
+			return c.json(await getOntologyLinkEvidence(getDbAccessor(), { agentId: scoped.agentId, id: c.req.param("id") }));
 		} catch (err) {
 			return c.json({ error: messageForError(err) }, statusForError(err));
 		}
@@ -747,7 +747,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		const actor = readString(body, "actor") ?? c.req.header("x-signet-actor") ?? "operator";
 		try {
 			return c.json(
-				applyOntologyOperationBatch(getDbAccessor(), {
+				await applyOntologyOperationBatch(getDbAccessor(), {
 					agentId: scoped.agentId,
 					actor,
 					writeCaps: graphWriteCaps(loadMemoryConfig(AGENTS_DIR)),
@@ -829,7 +829,7 @@ export function registerOntologyRoutes(app: Hono): void {
 
 		try {
 			return c.json(
-				createOntologyProposals(
+				await createOntologyProposals(
 					getDbAccessor(),
 					proposals.map((raw) => {
 						const proposal = asRecord(raw);
@@ -864,7 +864,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		if (scoped.response) return scoped.response;
 		try {
 			return c.json(
-				applyOntologyProposal(getDbAccessor(), {
+				await applyOntologyProposal(getDbAccessor(), {
 					agentId: scoped.agentId,
 					id: c.req.param("id"),
 					actor: readString(body, "actor") ?? c.req.header("x-signet-actor") ?? "operator",

--- a/platform/daemon/src/routes/ontology-routes.ts
+++ b/platform/daemon/src/routes/ontology-routes.ts
@@ -175,7 +175,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		return requirePermission("recall", authConfig)(c, next);
 	});
 
-	app.get("/api/ontology/proposals", (c) => {
+	app.get("/api/ontology/proposals", async (c) => {
 		const status = parseOntologyProposalStatus(c.req.query("status"));
 		if (c.req.query("status") && !status) return c.json({ error: "status is invalid" }, 400);
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
@@ -192,14 +192,14 @@ export function registerOntologyRoutes(app: Hono): void {
 		);
 	});
 
-	app.get("/api/ontology/entities/:id/aliases", (c) => {
+	app.get("/api/ontology/entities/:id/aliases", async (c) => {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
 		const status = c.req.query("status");
 		const parsedStatus = status === "active" || status === "archived" || status === "all" ? status : undefined;
 		if (status && !parsedStatus) return c.json({ error: "status is invalid" }, 400);
 		return c.json({
-			items: listEntityAliases(getDbAccessor(), {
+			items: await listEntityAliases(getDbAccessor(), {
 				agentId: scoped.agentId,
 				entityId: c.req.param("id"),
 				status: parsedStatus,
@@ -214,7 +214,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		const alias = readString(body, "alias");
 		if (!alias) return c.json({ error: "alias is required" }, 400);
 		try {
-			const { result } = applyOntologyOperation(getDbAccessor(), {
+			const { result } = await applyOntologyOperation(getDbAccessor(), {
 				agentId: scoped.agentId,
 				actor: readString(body, "created_by") ?? c.req.header("x-signet-actor") ?? "operator",
 				operation: "create_entity_alias",
@@ -225,11 +225,12 @@ export function registerOntologyRoutes(app: Hono): void {
 					source: readString(body, "source") ?? null,
 				},
 			});
-			const item = listEntityAliases(getDbAccessor(), {
+			const aliases = await listEntityAliases(getDbAccessor(), {
 				agentId: scoped.agentId,
 				entityId: c.req.param("id"),
 				status: "all",
-			}).find((row) => row.id === result?.aliasId);
+			});
+			const item = aliases.find((row) => row.id === result?.aliasId);
 			return c.json({ item }, 201);
 		} catch (err) {
 			const message = messageForError(err);
@@ -238,11 +239,11 @@ export function registerOntologyRoutes(app: Hono): void {
 		}
 	});
 
-	app.delete("/api/ontology/entities/:id/aliases/:aliasId", (c) => {
+	app.delete("/api/ontology/entities/:id/aliases/:aliasId", async (c) => {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
 		try {
-			applyOntologyOperation(getDbAccessor(), {
+			await applyOntologyOperation(getDbAccessor(), {
 				agentId: scoped.agentId,
 				actor: c.req.header("x-signet-actor") ?? "operator",
 				operation: "archive_entity_alias",
@@ -255,19 +256,20 @@ export function registerOntologyRoutes(app: Hono): void {
 			if (err instanceof OntologyProposalError && err.status === 404) return c.json({ error: "Alias not found" }, 404);
 			return c.json({ error: messageForError(err) }, statusForError(err));
 		}
-		const item = listEntityAliases(getDbAccessor(), {
+		const aliases = await listEntityAliases(getDbAccessor(), {
 			agentId: scoped.agentId,
 			entityId: c.req.param("id"),
 			status: "all",
-		}).find((row) => row.id === c.req.param("aliasId"));
+		});
+		const item = aliases.find((row) => row.id === c.req.param("aliasId"));
 		return c.json({ item });
 	});
 
-	app.get("/api/ontology/proposals/conflicts", (c) => {
+	app.get("/api/ontology/proposals/conflicts", async (c) => {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
 		return c.json(
-			listOntologyProposalConflicts(getDbAccessor(), {
+			await listOntologyProposalConflicts(getDbAccessor(), {
 				agentId: scoped.agentId,
 				limit: parseBoundedInt(c.req.query("limit"), 500, 1, 1000),
 			}),
@@ -280,7 +282,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		if (scoped.response) return scoped.response;
 		try {
 			return c.json(
-				proposeDuplicateEntityMerges(getDbAccessor(), {
+				await proposeDuplicateEntityMerges(getDbAccessor(), {
 					agentId: scoped.agentId,
 					limit: readNumber(body, "limit"),
 					writeProposals: readBoolean(body, "write_proposals") ?? false,
@@ -369,7 +371,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		}
 	});
 
-	app.get("/api/ontology/proposals/:id/evidence", (c) => {
+	app.get("/api/ontology/proposals/:id/evidence", async (c) => {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
 		try {
@@ -379,7 +381,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		}
 	});
 
-	app.get("/api/ontology/claims/evidence", (c) => {
+	app.get("/api/ontology/claims/evidence", async (c) => {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
 		const entity = c.req.query("entity")?.trim();
@@ -413,7 +415,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		}
 	});
 
-	app.get("/api/ontology/claims/versions", (c) => {
+	app.get("/api/ontology/claims/versions", async (c) => {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
 		const entity = c.req.query("entity")?.trim();
@@ -428,14 +430,14 @@ export function registerOntologyRoutes(app: Hono): void {
 		if (c.req.query("kind") && !kind) return c.json({ error: "kind is invalid" }, 400);
 		try {
 			return c.json(
-				listClaimVersions(getDbAccessor(), { agentId: scoped.agentId, entity, aspect, group, claim, kind }),
+				await listClaimVersions(getDbAccessor(), { agentId: scoped.agentId, entity, aspect, group, claim, kind }),
 			);
 		} catch (err) {
 			return c.json({ error: messageForError(err) }, statusForError(err));
 		}
 	});
 
-	app.get("/api/ontology/claims/explain", (c) => {
+	app.get("/api/ontology/claims/explain", async (c) => {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
 		const entity = c.req.query("entity")?.trim();
@@ -463,7 +465,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		const project = claims?.role === "admin" ? null : (claims?.scope?.project ?? null);
 		try {
 			return c.json(
-				explainOntologyClaim(getDbAccessor(), {
+				await explainOntologyClaim(getDbAccessor(), {
 					agentId: scoped.agentId,
 					entity,
 					aspect,
@@ -483,7 +485,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		}
 	});
 
-	app.get("/api/ontology/claims/version", (c) => {
+	app.get("/api/ontology/claims/version", async (c) => {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
 		const entity = c.req.query("entity")?.trim();
@@ -499,7 +501,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		const kind = parseOntologyClaimAttributeKind(c.req.query("kind"));
 		if (c.req.query("kind") && !kind) return c.json({ error: "kind is invalid" }, 400);
 		try {
-			const item = getClaimVersion(getDbAccessor(), {
+			const item = await getClaimVersion(getDbAccessor(), {
 				agentId: scoped.agentId,
 				entity,
 				aspect,
@@ -515,7 +517,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		}
 	});
 
-	app.get("/api/ontology/links/:id/evidence", (c) => {
+	app.get("/api/ontology/links/:id/evidence", async (c) => {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
 		try {
@@ -525,7 +527,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		}
 	});
 
-	app.get("/api/ontology/assertions", (c) => {
+	app.get("/api/ontology/assertions", async (c) => {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
 		try {
@@ -555,7 +557,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		);
 	});
 
-	app.get("/api/ontology/contradictions", (c) => {
+	app.get("/api/ontology/contradictions", async (c) => {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
 		const status = parseOntologyContradictionStatus(c.req.query("status"));
@@ -576,7 +578,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		);
 	});
 
-	app.get("/api/ontology/contradictions/:id", (c) => {
+	app.get("/api/ontology/contradictions/:id", async (c) => {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
 		const contradiction = getOntologyContradiction(getDbAccessor(), {
@@ -587,7 +589,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		return c.json(contradiction);
 	});
 
-	app.get("/api/ontology/assertions/:id", (c) => {
+	app.get("/api/ontology/assertions/:id", async (c) => {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
 		try {
@@ -713,7 +715,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		if (Object.keys(payload).length === 0) return c.json({ error: "payload object is required" }, 400);
 		try {
 			return c.json(
-				applyOntologyOperation(getDbAccessor(), {
+				await applyOntologyOperation(getDbAccessor(), {
 					agentId: scoped.agentId,
 					actor: readString(body, "actor") ?? c.req.header("x-signet-actor") ?? "operator",
 					writeCaps: graphWriteCaps(loadMemoryConfig(AGENTS_DIR)),
@@ -773,10 +775,10 @@ export function registerOntologyRoutes(app: Hono): void {
 		}
 	});
 
-	app.get("/api/ontology/proposals/:id", (c) => {
+	app.get("/api/ontology/proposals/:id", async (c) => {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
-		const proposal = getOntologyProposal(getDbAccessor(), c.req.param("id"), scoped.agentId);
+		const proposal = await getOntologyProposal(getDbAccessor(), c.req.param("id"), scoped.agentId);
 		if (proposal === null) return c.json({ error: "Proposal not found" }, 404);
 		return c.json(proposal);
 	});
@@ -793,7 +795,7 @@ export function registerOntologyRoutes(app: Hono): void {
 
 		try {
 			return c.json(
-				createOntologyProposal(getDbAccessor(), {
+				await createOntologyProposal(getDbAccessor(), {
 					agentId: scoped.agentId,
 					operation,
 					payload,

--- a/platform/daemon/src/routes/ontology-routes.ts
+++ b/platform/daemon/src/routes/ontology-routes.ts
@@ -882,7 +882,7 @@ export function registerOntologyRoutes(app: Hono): void {
 		if (scoped.response) return scoped.response;
 		try {
 			return c.json(
-				rejectOntologyProposal(getDbAccessor(), {
+				await rejectOntologyProposal(getDbAccessor(), {
 					agentId: scoped.agentId,
 					id: c.req.param("id"),
 					actor: readString(body, "actor") ?? c.req.header("x-signet-actor") ?? "operator",

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -259,19 +259,19 @@ export function registerPipelineRoutes(app: Hono): void {
 	app.use("/api/diagnostics/*", async (c, next) => {
 		return requirePermission("diagnostics", authConfig)(c, next);
 	});
-	app.get("/api/diagnostics/transcripts", (c) => {
+	app.get("/api/diagnostics/transcripts", async (c) => {
 		const requestedAgentId = c.req.query("agentId") ?? c.req.query("agent_id") ?? c.req.header("x-signet-agent-id");
 		const scopedAgent = resolveScopedAgentId(c, requestedAgentId, resolveDaemonAgentId());
 		if (scopedAgent.error) {
 			return c.json({ error: scopedAgent.error }, 403);
 		}
 		const agentId = resolveAgentId({ agentId: scopedAgent.agentId });
-		return c.json(getTranscriptHealthReport(getDbAccessor(), AGENTS_DIR, agentId));
+		return c.json(await getTranscriptHealthReport(getDbAccessor(), AGENTS_DIR, agentId));
 	});
 
 	app.get("/api/diagnostics/workloads", (c) => workloadDiagnostics(c));
 
-	app.get("/api/status", (c) => {
+	app.get("/api/status", async (c) => {
 		const config = loadMemoryConfig(AGENTS_DIR);
 		const extractionWorkload = getExtractionWorkloadState({
 			enabled: false,
@@ -316,7 +316,7 @@ export function registerPipelineRoutes(app: Hono): void {
 			  }
 			| undefined;
 		try {
-			const capture = getTranscriptCaptureStatus(getDbAccessor(), resolveDaemonAgentId());
+			const capture = await getTranscriptCaptureStatus(getDbAccessor(), resolveDaemonAgentId());
 			transcriptCapture = {
 				pending: capture.pending,
 				failed: capture.failed,
@@ -734,10 +734,10 @@ export function registerPipelineRoutes(app: Hono): void {
 	});
 
 	/** Deterministic semantic-quality measurements for the scoped Dreaming graph. */
-	app.get("/api/dream/quality", (c) => {
+	app.get("/api/dream/quality", async (c) => {
 		const scopedAgent = resolveScopedDreamAgent(c);
 		if (scopedAgent.error) return c.json({ error: scopedAgent.error }, 403);
-		return c.json(getDreamingQualityReport(getDbAccessor(), scopedAgent.agentId));
+		return c.json(await getDreamingQualityReport(getDbAccessor(), scopedAgent.agentId));
 	});
 
 	app.post("/api/dream/exclusions/requeue", async (c) => {

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -463,7 +463,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		await removeSourceLifecycleState(result.source, sourceAgentId);
 		recordSourceDeletionTombstone(result.source, sourceAgentId, agentsDir);
 		const provider = getSourceProvider(result.source.kind);
-		const purged = provider ? purgeSource(provider, result.source, sourceAgentId, purgeNativeSource) : 0;
+		const purged = provider ? await purgeSource(provider, result.source, sourceAgentId, purgeNativeSource) : 0;
 		if (!isSourceIndexInFlight(result.source.id))
 			clearSourceDeletionTombstone(result.source.id, sourceAgentId, agentsDir);
 		return c.json({ source: result.source, purged });
@@ -617,7 +617,7 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 		await bridge?.close().catch(() => undefined);
 		if (consumeCanceledSourceIndexJob(job.id) && !sourceIndexStopping) {
 			const provider = getSourceProvider(input.source.kind);
-			if (provider) purgeSource(provider, input.source, resolveDaemonAgentId(), input.purgeNativeSource);
+			if (provider) await purgeSource(provider, input.source, resolveDaemonAgentId(), input.purgeNativeSource);
 			clearSourceDeletionTombstone(input.source.id, resolveDaemonAgentId(), input.agentsDir);
 		}
 		clearSourceIndexInFlight(input.source.id);
@@ -664,7 +664,7 @@ export async function cleanupSourceDeletionTombstones(
 		const provider = getSourceProvider(tombstone.source.kind);
 		if (!provider) continue;
 		try {
-			purgeSource(provider, tombstone.source, tombstone.agentId, purgeNativeSource);
+			await purgeSource(provider, tombstone.source, tombstone.agentId, purgeNativeSource);
 		} catch (err) {
 			remaining.push(tombstone);
 			logger.warn(
@@ -682,9 +682,9 @@ function purgeSource(
 	source: SignetSourceEntry,
 	agentId: string,
 	purgeNativeSource: typeof purgeNativeMemorySourceArtifacts,
-): number {
+): Promise<number> {
 	if (provider.toNativeSource) return purgeNativeSource(provider.toNativeSource(source), agentId);
-	return provider.purge(source, agentId);
+	return Promise.resolve(provider.purge(source, agentId));
 }
 
 function recordSourceDeletionTombstone(source: SignetSourceEntry, agentId: string, agentsDir: string): void {

--- a/platform/daemon/src/source-providers.ts
+++ b/platform/daemon/src/source-providers.ts
@@ -34,7 +34,7 @@ export interface SourceProviderAdapter {
 	readonly kind: SignetSourceKind;
 	readonly toNativeSource?: (source: SignetSourceEntry) => NativeMemorySource;
 	readonly sync?: (context: SourceProviderSyncContext) => Promise<SourceProviderSyncResult>;
-	readonly purge: (source: SignetSourceEntry, agentId: string | undefined) => number;
+	readonly purge: (source: SignetSourceEntry, agentId: string | undefined) => number | Promise<number>;
 }
 
 const additionalProviders = new Map<SignetSourceKind, SourceProviderAdapter>();

--- a/platform/daemon/src/structural-features.test.ts
+++ b/platform/daemon/src/structural-features.test.ts
@@ -94,8 +94,8 @@ afterEach(() => {
 });
 
 describe("getStructuralFeatures", () => {
-	it("returns structural slots and density for assigned memories", () => {
-		const features = getStructuralFeatures(
+	it("returns structural slots and density for assigned memories", async () => {
+		const features = await getStructuralFeatures(
 			getDbAccessor(),
 			["mem-1", "mem-2"],
 			"default",
@@ -117,16 +117,16 @@ describe("getStructuralFeatures", () => {
 		expect(constraintFeatures?.candidateSource).toBe("effective");
 	});
 
-	it("returns null for unassigned memories", () => {
-		const features = getStructuralFeatures(getDbAccessor(), ["mem-3"], "default");
+	it("returns null for unassigned memories", async () => {
+		const features = await getStructuralFeatures(getDbAccessor(), ["mem-3"], "default");
 		expect(features.get("mem-3")).toBeNull();
 	});
 });
 
 describe("buildCandidateFeatures", () => {
-	it("builds 17-element feature vectors with structural signals", () => {
+	it("builds 17-element feature vectors with structural signals", async () => {
 		const now = new Date().toISOString();
-		const vectors = buildCandidateFeatures(
+		const vectors = await buildCandidateFeatures(
 			getDbAccessor(),
 			[
 				{
@@ -170,9 +170,9 @@ describe("buildCandidateFeatures", () => {
 		expect(vectors[1][15]).toBe(0);
 	});
 
-	it("clamps negative session gap days before log transform", () => {
+	it("clamps negative session gap days before log transform", async () => {
 		const now = new Date().toISOString();
-		const [vector] = buildCandidateFeatures(
+		const [vector] = await buildCandidateFeatures(
 			getDbAccessor(),
 			[
 				{

--- a/platform/daemon/src/structural-features.ts
+++ b/platform/daemon/src/structural-features.ts
@@ -62,12 +62,12 @@ function choosePrimaryRow(
 	return next.created_at < current.created_at ? next : current;
 }
 
-export function getStructuralFeatures(
+export async function getStructuralFeatures(
 	accessor: DbAccessor,
 	memoryIds: ReadonlyArray<string>,
 	agentId: string,
 	sourceById?: ReadonlyMap<string, StructuralCandidateSource>,
-): Map<string, StructuralFeatures | null> {
+): Promise<Map<string, StructuralFeatures | null>> {
 	const featuresByMemoryId = new Map<string, StructuralFeatures | null>();
 	for (const memoryId of memoryIds) {
 		featuresByMemoryId.set(memoryId, null);
@@ -75,8 +75,7 @@ export function getStructuralFeatures(
 
 	if (memoryIds.length === 0) return featuresByMemoryId;
 
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	const primaryRows = accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+	const primaryRows = await accessor.withReadDbAsync(async (db) => {
 		const rows = db
 			.prepare(
 				`SELECT
@@ -109,7 +108,7 @@ export function getStructuralFeatures(
 	for (const [memoryId, row] of primaryRows) {
 		let density = densityCache.get(row.entity_id);
 		if (density === undefined) {
-			const structuralDensity = getStructuralDensity(accessor, row.entity_id, agentId);
+			const structuralDensity = await getStructuralDensity(accessor, row.entity_id, agentId);
 			density = structuralDensity.aspectCount + structuralDensity.attributeCount;
 			densityCache.set(row.entity_id, density);
 		}
@@ -126,7 +125,7 @@ export function getStructuralFeatures(
 	return featuresByMemoryId;
 }
 
-export function buildCandidateFeatures(
+export async function buildCandidateFeatures(
 	accessor: DbAccessor,
 	candidates: ReadonlyArray<{
 		readonly id: string;
@@ -146,7 +145,7 @@ export function buildCandidateFeatures(
 		readonly monthOfYear: number;
 		readonly sessionGapDays: number;
 	},
-): ReadonlyArray<ReadonlyArray<number>> {
+): Promise<ReadonlyArray<ReadonlyArray<number>>> {
 	if (candidates.length === 0) return [];
 
 	void sessionContext.projectSlot;
@@ -158,9 +157,8 @@ export function buildCandidateFeatures(
 			sourceById.set(candidate.id, candidate.source);
 		}
 	}
-	const structuralById = getStructuralFeatures(accessor, candidateIds, agentId, sourceById);
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	const embeddedIds = accessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+	const structuralById = await getStructuralFeatures(accessor, candidateIds, agentId, sourceById);
+	const embeddedIds = await accessor.withReadDbAsync(async (db) => {
 		const rows = db
 			.prepare(
 				`SELECT DISTINCT source_id

--- a/platform/daemon/src/transcript-capture-worker.test.ts
+++ b/platform/daemon/src/transcript-capture-worker.test.ts
@@ -20,7 +20,7 @@ function manifestValue(path: string, key: string): string | null {
 	const match = readFileSync(path, "utf8").match(new RegExp(`^${key}:\\s*(.*)$`, "m"));
 	if (!match) return null;
 	const raw = (match[1] ?? "").trim();
-	return raw && raw !== "null" ? raw.replace(/^['\"]|['\"]$/g, "") : null;
+	return raw && raw !== "null" ? raw.replace(/^['"]|['"]$/g, "") : null;
 }
 
 describe("transcript capture worker", () => {
@@ -39,7 +39,7 @@ describe("transcript capture worker", () => {
 	});
 
 	it("writes canonical and per-session artifacts from a durable job", async () => {
-		const id = enqueueTranscriptCaptureJob(getDbAccessor(), {
+		const id = await enqueueTranscriptCaptureJob(getDbAccessor(), {
 			agentId: "agent-a",
 			harness: "pi",
 			sessionKey: "session-1",
@@ -55,7 +55,7 @@ describe("transcript capture worker", () => {
 		expect(id).toBeTruthy();
 		expect(await runTranscriptCaptureOnce(getDbAccessor(), dir)).toBe(true);
 
-		const status = getTranscriptCaptureStatus(getDbAccessor(), "agent-a");
+		const status = await getTranscriptCaptureStatus(getDbAccessor(), "agent-a");
 		expect(status.completed).toBe(1);
 		expect(status.pending).toBe(0);
 
@@ -78,7 +78,7 @@ describe("transcript capture worker", () => {
 	});
 
 	it("keeps raw audit logs when normalized transcript has no conversation turns", async () => {
-		const id = enqueueTranscriptCaptureJob(getDbAccessor(), {
+		const id = await enqueueTranscriptCaptureJob(getDbAccessor(), {
 			agentId: "agent-a",
 			harness: "pi",
 			sessionKey: "session-raw",
@@ -92,7 +92,7 @@ describe("transcript capture worker", () => {
 
 		expect(id).toBeTruthy();
 		expect(await runTranscriptCaptureOnce(getDbAccessor(), dir)).toBe(true);
-		expect(getTranscriptCaptureStatus(getDbAccessor(), "agent-a").completed).toBe(1);
+		expect((await getTranscriptCaptureStatus(getDbAccessor(), "agent-a")).completed).toBe(1);
 		const auditFiles = readdirSync(join(dir, ".daemon", "logs", "transcripts"));
 		// #1163: the capture archives the rolling latest by renaming it to the
 		// dated raw-transcript file, so the same content is never written twice.
@@ -101,7 +101,7 @@ describe("transcript capture worker", () => {
 		expect(existsSync(join(dir, "memory", "pi", "transcripts", "transcript.jsonl"))).toBe(false);
 	});
 
-	it("resets attempts when reviving a dead capture job", () => {
+	it("resets attempts when reviving a dead capture job", async () => {
 		const input = {
 			agentId: "agent-a",
 			harness: "pi",
@@ -113,7 +113,7 @@ describe("transcript capture worker", () => {
 			capturedAt: "2026-06-20T10:00:00.000Z",
 			endedAt: "2026-06-20T10:00:00.000Z",
 		} as const;
-		const id = enqueueTranscriptCaptureJob(getDbAccessor(), input);
+		const id = await enqueueTranscriptCaptureJob(getDbAccessor(), input);
 		expect(id).toBeTruthy();
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
@@ -121,15 +121,15 @@ describe("transcript capture worker", () => {
 			).run(id);
 		});
 
-		expect(enqueueTranscriptCaptureJob(getDbAccessor(), input)).toBe(id);
+		expect(await enqueueTranscriptCaptureJob(getDbAccessor(), input)).toBe(id);
 		const row = getDbAccessor().withReadDb((db) =>
 			db.prepare("SELECT status, attempts, error FROM transcript_capture_jobs WHERE id = ?").get(id),
 		) as { status: string; attempts: number; error: string | null } | undefined;
 		expect(row).toEqual({ status: "pending", attempts: 0, error: null });
 	});
 
-	it("returns only the requesting agent's capture receipt", () => {
-		const id = enqueueTranscriptCaptureJob(getDbAccessor(), {
+	it("returns only the requesting agent's capture receipt", async () => {
+		const id = await enqueueTranscriptCaptureJob(getDbAccessor(), {
 			agentId: "agent-a",
 			harness: "pi",
 			sessionKey: "session-receipt",
@@ -141,16 +141,16 @@ describe("transcript capture worker", () => {
 			endedAt: "2026-06-20T10:00:00.000Z",
 		});
 
-		expect(id).toBeTruthy();
-		expect(getTranscriptCaptureJobStatus(getDbAccessor(), "agent-a", id ?? "")).toEqual({
+		if (!id) throw new Error("expected capture receipt");
+		expect(await getTranscriptCaptureJobStatus(getDbAccessor(), "agent-a", id)).toEqual({
 			id,
 			status: "pending",
 			error: null,
 		});
-		expect(getTranscriptCaptureJobStatus(getDbAccessor(), "agent-b", id ?? "")).toBeNull();
+		expect(await getTranscriptCaptureJobStatus(getDbAccessor(), "agent-b", id ?? "")).toBeNull();
 	});
 
-	it("deduplicates stable session snapshots across delivery timestamps", () => {
+	it("deduplicates stable session snapshots across delivery timestamps", async () => {
 		const base = {
 			agentId: "agent-a",
 			harness: "claude-code",
@@ -162,11 +162,11 @@ describe("transcript capture worker", () => {
 			transcriptPath: "/tmp/session-stable.jsonl",
 			endedAt: "2026-06-20T10:00:00.000Z",
 		} as const;
-		const first = enqueueTranscriptCaptureJob(getDbAccessor(), {
+		const first = await enqueueTranscriptCaptureJob(getDbAccessor(), {
 			...base,
 			capturedAt: "2026-06-20T10:00:00.000Z",
 		});
-		const second = enqueueTranscriptCaptureJob(getDbAccessor(), {
+		const second = await enqueueTranscriptCaptureJob(getDbAccessor(), {
 			...base,
 			capturedAt: "2026-06-20T10:05:00.000Z",
 		});
@@ -186,13 +186,13 @@ describe("transcript capture worker", () => {
 			rawTranscript: "snapshot",
 			endedAt: "2026-06-20T10:00:00.000Z",
 		} as const;
-		const newerCapture = enqueueTranscriptCaptureJob(getDbAccessor(), {
+		const newerCapture = await enqueueTranscriptCaptureJob(getDbAccessor(), {
 			...base,
 			sessionId: "snapshot-ordered-newer",
 			transcript: "User: later turn arrived first",
 			capturedAt: "2026-06-20T10:01:00.000Z",
 		});
-		const olderCapture = enqueueTranscriptCaptureJob(getDbAccessor(), {
+		const olderCapture = await enqueueTranscriptCaptureJob(getDbAccessor(), {
 			...base,
 			sessionId: "snapshot-ordered-older",
 			transcript: "User: earlier turn arrived later",
@@ -222,11 +222,11 @@ describe("transcript capture worker", () => {
 		]);
 
 		expect(await runTranscriptCaptureOnce(getDbAccessor(), dir)).toBe(true);
-		expect(getTranscriptCaptureStatus(getDbAccessor(), "agent-a")).toMatchObject({ completed: 2, pending: 0 });
+		expect(await getTranscriptCaptureStatus(getDbAccessor(), "agent-a")).toMatchObject({ completed: 2, pending: 0 });
 	});
 
 	it("concurrent workers claim one snapshot once", async () => {
-		const id = enqueueTranscriptCaptureJob(getDbAccessor(), {
+		const id = await enqueueTranscriptCaptureJob(getDbAccessor(), {
 			agentId: "agent-a",
 			harness: "pi",
 			sessionKey: "session-concurrent",
@@ -244,7 +244,7 @@ describe("transcript capture worker", () => {
 			runTranscriptCaptureOnce(getDbAccessor(), dir),
 		]);
 		expect(results.sort()).toEqual([false, true]);
-		expect(getTranscriptCaptureStatus(getDbAccessor(), "agent-a")).toMatchObject({ completed: 1, pending: 0 });
+		expect(await getTranscriptCaptureStatus(getDbAccessor(), "agent-a")).toMatchObject({ completed: 1, pending: 0 });
 		expect(
 			getDbAccessor().withReadDb((db) =>
 				db.prepare("SELECT attempts FROM transcript_capture_jobs WHERE id = ?").get(id),
@@ -264,14 +264,14 @@ describe("transcript capture worker", () => {
 			capturedAt: "2026-06-20T10:00:00.000Z",
 			endedAt: "2026-06-20T10:00:00.000Z",
 		} as const;
-		const id = enqueueTranscriptCaptureJob(getDbAccessor(), capture);
+		const id = await enqueueTranscriptCaptureJob(getDbAccessor(), capture);
 		if (!id) throw new Error("expected restart capture job");
 
 		// Model the real crash window after the canonical file, immutable artifact,
 		// and indexed provenance have committed but before markDone updates the job.
 		await writeCanonicalTranscriptFromSnapshot({ basePath: dir, ...capture });
 		const artifact = await writeTranscriptArtifact({ ...capture, startedAt: null, summaryStatus: "not_requested" });
-		indexCanonicalTranscriptJsonl({ ...capture, startedAt: null, manifestPath: artifact.manifestPath });
+		await indexCanonicalTranscriptJsonl({ ...capture, startedAt: null, manifestPath: artifact.manifestPath });
 		const beforeRecovery = getDbAccessor().withReadDb((db) =>
 			db
 				.prepare(
@@ -286,11 +286,11 @@ describe("transcript capture worker", () => {
 			db.prepare("UPDATE transcript_capture_jobs SET status = 'processing', attempts = 1 WHERE id = ?").run(id);
 		});
 
-		const worker = startTranscriptCaptureWorker(getDbAccessor(), dir);
+		const worker = await startTranscriptCaptureWorker(getDbAccessor(), dir);
 		try {
 			const deadline = Date.now() + 2_000;
 			while (Date.now() < deadline) {
-				const status = getTranscriptCaptureJobStatus(getDbAccessor(), "agent-a", id);
+				const status = await getTranscriptCaptureJobStatus(getDbAccessor(), "agent-a", id);
 				if (status?.status === "completed") break;
 				await new Promise((resolve) => setTimeout(resolve, 10));
 			}
@@ -298,12 +298,12 @@ describe("transcript capture worker", () => {
 			worker.stop();
 		}
 
-		expect(getTranscriptCaptureJobStatus(getDbAccessor(), "agent-a", id)).toEqual({
+		expect(await getTranscriptCaptureJobStatus(getDbAccessor(), "agent-a", id)).toEqual({
 			id,
 			status: "completed",
 			error: null,
 		});
-		expect(getTranscriptCaptureStatus(getDbAccessor(), "agent-a")).toMatchObject({ completed: 1, processing: 0 });
+		expect(await getTranscriptCaptureStatus(getDbAccessor(), "agent-a")).toMatchObject({ completed: 1, processing: 0 });
 		expect(
 			getDbAccessor().withReadDb((db) =>
 				db

--- a/platform/daemon/src/transcript-capture-worker.ts
+++ b/platform/daemon/src/transcript-capture-worker.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import type { DbAccessor, WriteDb } from "./db-accessor";
+import { runWriteTxAsync } from "./db-accessor";
 import { logger } from "./logger";
 import { indexCanonicalTranscriptJsonl, writeTranscriptArtifact } from "./memory-lineage";
 import { isNoiseSession } from "./session-noise";
@@ -95,14 +96,16 @@ export function transcriptCaptureJobId(input: TranscriptCaptureJobInput): string
 	return `tcj_${hash.digest("hex").slice(0, 32)}`;
 }
 
-export function enqueueTranscriptCaptureJob(dbAccessor: DbAccessor, input: TranscriptCaptureJobInput): string | null {
+export async function enqueueTranscriptCaptureJob(
+	dbAccessor: DbAccessor,
+	input: TranscriptCaptureJobInput,
+): Promise<string | null> {
 	if (input.transcript.trim().length === 0 && input.rawTranscript.trim().length === 0) return null;
 	const id = transcriptCaptureJobId(input);
 	const createdAt = nowIso();
 	const maxAttempts = normalizeMaxAttempts(input.maxAttempts);
 	let resolvedId = id;
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	dbAccessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
+	await runWriteTxAsync(dbAccessor, (db) => {
 		// capturedAt is delivery time for hooks but file mtime for recovery scans.
 		// Treat the stable snapshot identity + content as authoritative so a
 		// hook/recovery race cannot create two jobs for the same snapshot.
@@ -177,10 +180,9 @@ function resetInterruptedJobs(db: WriteDb): void {
 	).run(nowIso());
 }
 
-function leaseJob(dbAccessor: DbAccessor): TranscriptCaptureJobRow | null {
+async function leaseJob(dbAccessor: DbAccessor): Promise<TranscriptCaptureJobRow | null> {
 	let leased: TranscriptCaptureJobRow | null = null;
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	dbAccessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
+	await runWriteTxAsync(dbAccessor, (db) => {
 		const row = db
 			.prepare(
 				`SELECT * FROM transcript_capture_jobs
@@ -276,7 +278,7 @@ async function processTranscriptCaptureJob(basePath: string, job: TranscriptCapt
 		transcript: job.transcript,
 		summaryStatus: job.summaryStatus,
 	});
-	indexCanonicalTranscriptJsonl({
+	await indexCanonicalTranscriptJsonl({
 		agentId: job.agentId,
 		sessionId: job.sessionId,
 		sessionKey: job.sessionKey,
@@ -297,9 +299,8 @@ async function processTranscriptCaptureJob(basePath: string, job: TranscriptCapt
 	});
 }
 
-function markDone(dbAccessor: DbAccessor, id: string): void {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	dbAccessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
+async function markDone(dbAccessor: DbAccessor, id: string): Promise<void> {
+	await runWriteTxAsync(dbAccessor, (db) => {
 		db.prepare(
 			`UPDATE transcript_capture_jobs
 			 SET status = 'completed', completed_at = ?, updated_at = ?, error = NULL
@@ -308,11 +309,10 @@ function markDone(dbAccessor: DbAccessor, id: string): void {
 	});
 }
 
-function markFailed(dbAccessor: DbAccessor, job: TranscriptCaptureJobRow, error: unknown): void {
+async function markFailed(dbAccessor: DbAccessor, job: TranscriptCaptureJobRow, error: unknown): Promise<void> {
 	const message = error instanceof Error ? error.message : String(error);
 	const status: TranscriptCaptureJobStatus = job.attempts >= job.maxAttempts ? "dead" : "failed";
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	dbAccessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
+	await runWriteTxAsync(dbAccessor, (db) => {
 		db.prepare(
 			`UPDATE transcript_capture_jobs
 			 SET status = ?, error = ?, updated_at = ?
@@ -322,13 +322,13 @@ function markFailed(dbAccessor: DbAccessor, job: TranscriptCaptureJobRow, error:
 }
 
 async function runTranscriptCaptureOnceInternal(dbAccessor: DbAccessor, basePath: string): Promise<boolean> {
-	const job = leaseJob(dbAccessor);
+	const job = await leaseJob(dbAccessor);
 	if (!job) return false;
 	try {
 		await processTranscriptCaptureJob(basePath, job);
-		markDone(dbAccessor, job.id);
+		await markDone(dbAccessor, job.id);
 	} catch (error) {
-		markFailed(dbAccessor, job, error);
+		await markFailed(dbAccessor, job, error);
 		throw error;
 	}
 	return true;
@@ -343,13 +343,15 @@ export function runTranscriptCaptureOnce(dbAccessor: DbAccessor, basePath: strin
 	return run;
 }
 
-export function startTranscriptCaptureWorker(dbAccessor: DbAccessor, basePath: string): TranscriptCaptureWorkerHandle {
+export async function startTranscriptCaptureWorker(
+	dbAccessor: DbAccessor,
+	basePath: string,
+): Promise<TranscriptCaptureWorkerHandle> {
 	let stopped = false;
 	let running = false;
 	let timer: ReturnType<typeof setTimeout> | null = null;
 
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	dbAccessor.withWriteTx(resetInterruptedJobs);
+	await runWriteTxAsync(dbAccessor, resetInterruptedJobs);
 
 	const schedule = (delayMs: number): void => {
 		if (stopped || timer) return;
@@ -406,12 +408,11 @@ export function startTranscriptCaptureWorker(dbAccessor: DbAccessor, basePath: s
 	};
 }
 
-export function getTranscriptCaptureStatus(
+export async function getTranscriptCaptureStatus(
 	dbAccessor: DbAccessor,
 	agentId?: string | null,
-): TranscriptCaptureStatusSummary {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return dbAccessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<TranscriptCaptureStatusSummary> {
+	return await dbAccessor.withReadDbAsync(async (db) => {
 		const where = agentId ? "WHERE agent_id = ?" : "";
 		const params = agentId ? [agentId] : [];
 		const rows = db
@@ -449,13 +450,12 @@ export function getTranscriptCaptureStatus(
 }
 
 /** Read one agent-scoped capture receipt without exposing transcript content. */
-export function getTranscriptCaptureJobStatus(
+export async function getTranscriptCaptureJobStatus(
 	dbAccessor: DbAccessor,
 	agentId: string,
 	id: string,
-): TranscriptCaptureJobReceipt | null {
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return dbAccessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<TranscriptCaptureJobReceipt | null> {
+	return await dbAccessor.withReadDbAsync(async (db) => {
 		const row = db
 			.prepare(
 				`SELECT id, status, error

--- a/platform/daemon/src/transcript-health.ts
+++ b/platform/daemon/src/transcript-health.ts
@@ -93,7 +93,7 @@ export async function getTranscriptHealthReport(
 	agentId?: string | null,
 ): Promise<TranscriptHealthReport> {
 	const capture = await getTranscriptCaptureStatus(dbAccessor, agentId);
-	const sessionStore = dbAccessor.withReadDb((db) => {
+	const sessionStore = await dbAccessor.withReadDbAsync(async (db) => {
 		const where = agentId ? "WHERE agent_id = ?" : "";
 		const params = agentId ? [agentId] : [];
 		const row = db
@@ -108,7 +108,7 @@ export async function getTranscriptHealthReport(
 			newestUpdatedAt: asStringOrNull(row?.newest_updated_at),
 		};
 	});
-	const artifacts = dbAccessor.withReadDb((db) => {
+	const artifacts = await dbAccessor.withReadDbAsync(async (db) => {
 		const andAgent = agentId ? "AND agent_id = ?" : "";
 		const params = agentId ? [agentId] : [];
 		const countKind = (kind: string): number => {

--- a/platform/daemon/src/transcript-health.ts
+++ b/platform/daemon/src/transcript-health.ts
@@ -81,20 +81,19 @@ function readManifestValue(path: string, key: string): string | null {
 		if (!match) return null;
 		const raw = (match[1] ?? "").trim();
 		if (!raw || raw === "null" || raw === "~") return null;
-		return raw.replace(/^['\"]|['\"]$/g, "");
+		return raw.replace(/^['"]|['"]$/g, "");
 	} catch {
 		return null;
 	}
 }
 
-export function getTranscriptHealthReport(
+export async function getTranscriptHealthReport(
 	dbAccessor: DbAccessor,
 	basePath: string,
 	agentId?: string | null,
-): TranscriptHealthReport {
-	const capture = getTranscriptCaptureStatus(dbAccessor, agentId);
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	const sessionStore = dbAccessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+): Promise<TranscriptHealthReport> {
+	const capture = await getTranscriptCaptureStatus(dbAccessor, agentId);
+	const sessionStore = dbAccessor.withReadDb((db) => {
 		const where = agentId ? "WHERE agent_id = ?" : "";
 		const params = agentId ? [agentId] : [];
 		const row = db
@@ -109,8 +108,7 @@ export function getTranscriptHealthReport(
 			newestUpdatedAt: asStringOrNull(row?.newest_updated_at),
 		};
 	});
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	const artifacts = dbAccessor.withReadDb((db: import("./db-accessor").ReadDb) => {
+	const artifacts = dbAccessor.withReadDb((db) => {
 		const andAgent = agentId ? "AND agent_id = ?" : "";
 		const params = agentId ? [agentId] : [];
 		const countKind = (kind: string): number => {

--- a/platform/daemon/src/transcript-recovery-worker.test.ts
+++ b/platform/daemon/src/transcript-recovery-worker.test.ts
@@ -166,7 +166,7 @@ describe("transcript recovery worker", () => {
 		writeSettled(path, raw);
 		const transcript = normalizeSessionTranscript("claude-code", raw);
 		const sessionId = deriveSessionEndFallbackId("same-session", path, transcript);
-		const hookJob = enqueueTranscriptCaptureJob(getDbAccessor(), {
+		const hookJob = await enqueueTranscriptCaptureJob(getDbAccessor(), {
 			agentId: "agent-a",
 			harness: "claude-code",
 			sessionKey: "same-session",
@@ -178,7 +178,7 @@ describe("transcript recovery worker", () => {
 			capturedAt: "2026-07-20T12:00:00.000Z",
 			endedAt: "2026-07-20T12:00:00.000Z",
 		});
-		const retryJob = enqueueTranscriptCaptureJob(getDbAccessor(), {
+		const retryJob = await enqueueTranscriptCaptureJob(getDbAccessor(), {
 			agentId: "agent-a",
 			harness: "claude-code",
 			sessionKey: "same-session",

--- a/platform/daemon/src/transcript-recovery-worker.ts
+++ b/platform/daemon/src/transcript-recovery-worker.ts
@@ -354,7 +354,7 @@ export async function runTranscriptRecoveryScan(
 				sessionKey: metadata.sessionKey,
 			});
 		}
-		const jobId = enqueueTranscriptCaptureJob(dbAccessor, {
+		const jobId = await enqueueTranscriptCaptureJob(dbAccessor, {
 			agentId,
 			harness: candidate.harness,
 			sessionKey: metadata.sessionKey,

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -11,11 +11,11 @@ import {
 	renderReport,
 } from "./audit-event-loop-contract";
 
-test("the deterministic ledger retains the exact 752-site inventory", () => {
+test("the deterministic ledger retains the exact 741-site inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(752);
-	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(116);
-	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(152);
+	expect(baseline).toHaveLength(741);
+	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(111);
+	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(146);
 });
 
 test("the ledger reports legacy DB markers and rejects new call sites", () => {
@@ -278,9 +278,9 @@ test("the production TypeScript project cannot import the compatibility module",
 
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	const report = renderReport(baseline, { total: 268, withWriteTx: 116, withReadDb: 152 });
-	expect(report).toContain("Exact ledger inventory: 752 sites");
-	expect(report).toContain("116 synchronous writes and 152 synchronous reads");
+	const report = renderReport(baseline, { total: 257, withWriteTx: 111, withReadDb: 146 });
+	expect(report).toContain("Exact ledger inventory: 741 sites");
+	expect(report).toContain("111 synchronous writes and 146 synchronous reads");
 	expect(report).toContain("type boundary");
 	expect(report).not.toContain("1061");
 });

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -11,11 +11,11 @@ import {
 	renderReport,
 } from "./audit-event-loop-contract";
 
-test("the deterministic ledger retains the exact 934-site inventory", () => {
+test("the deterministic ledger retains the exact 861-site inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(934);
-	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(159);
-	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(291);
+	expect(baseline).toHaveLength(861);
+	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(181);
+	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(196);
 });
 
 test("the ledger reports legacy DB markers and rejects new call sites", () => {
@@ -278,14 +278,11 @@ test("the production TypeScript project cannot import the compatibility module",
 
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	const report = renderReport(baseline, { total: 450, withWriteTx: 159, withReadDb: 291 });
-	expect(report).toContain("Exact ledger inventory: 934 sites");
-	expect(report).toContain("159 synchronous writes and 291 synchronous reads");
-	expect(report).toContain(
-		"document-worker (18), dreaming (28), retention (6), repair-actions (31), and source-lifecycle-telemetry (8), for 91 sites total",
-	);
+	const report = renderReport(baseline, { total: 377, withWriteTx: 181, withReadDb: 196 });
+	expect(report).toContain("Exact ledger inventory: 861 sites");
+	expect(report).toContain("181 synchronous writes and 196 synchronous reads");
 	expect(report).toContain("type boundary");
-	expect(report).not.toContain("960");
+	expect(report).not.toContain("1061");
 });
 
 // Keep the production/public type distinction visible in source review. The

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -11,11 +11,11 @@ import {
 	renderReport,
 } from "./audit-event-loop-contract";
 
-test("the deterministic ledger retains the exact 861-site inventory", () => {
+test("the deterministic ledger retains the exact 752-site inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(861);
-	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(181);
-	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(196);
+	expect(baseline).toHaveLength(752);
+	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(116);
+	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(152);
 });
 
 test("the ledger reports legacy DB markers and rejects new call sites", () => {
@@ -278,9 +278,9 @@ test("the production TypeScript project cannot import the compatibility module",
 
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	const report = renderReport(baseline, { total: 377, withWriteTx: 181, withReadDb: 196 });
-	expect(report).toContain("Exact ledger inventory: 861 sites");
-	expect(report).toContain("181 synchronous writes and 196 synchronous reads");
+	const report = renderReport(baseline, { total: 268, withWriteTx: 116, withReadDb: 152 });
+	expect(report).toContain("Exact ledger inventory: 752 sites");
+	expect(report).toContain("116 synchronous writes and 152 synchronous reads");
 	expect(report).toContain("type boundary");
 	expect(report).not.toContain("1061");
 });

--- a/scripts/audit-event-loop-contract.ts
+++ b/scripts/audit-event-loop-contract.ts
@@ -425,7 +425,7 @@ This report is generated from the deterministic migration ledger in \`scripts/ev
   - \`withWriteTx\`: ${legacyDbAccess.withWriteTx}
   - \`withReadDb\`: ${legacyDbAccess.withReadDb}
 
-The ${baselineSites.length.toLocaleString("en-US")}-site inventory excludes test, benchmark, generated, and \`__tests__\` fixtures. The ${counts.get("withWriteTx") ?? 0} synchronous writes and ${counts.get("withReadDb") ?? 0} synchronous reads remain transitional callers for the later migration phase. They are marked with \`@ts-expect-error LEGACY_SYNC_DB_ACCESS\`, so the compiler reports every remaining site without forcing this phase to migrate ${legacyDbAccess.total} database operations.
+The ${baselineSites.length.toLocaleString()}-site inventory excludes test, benchmark, generated, and \`__tests__\` fixtures. The ${counts.get("withWriteTx") ?? 0} synchronous writes and ${counts.get("withReadDb") ?? 0} synchronous reads remain transitional callers for the later migration phase. They are marked with \`@ts-expect-error LEGACY_SYNC_DB_ACCESS\`, so the compiler reports every remaining site without forcing this phase to migrate ${legacyDbAccess.total} database operations.
 
 ## A3 Slice 2 migration notes
 

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -1,6033 +1,5270 @@
 {
-	"version": 1,
-	"generatedFrom": "platform/daemon/src",
-	"sites": [
-		{
-			"path": "agent-id.ts",
-			"line": 56,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "agent-id.ts",
-			"line": 82,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "aggregate-recall.ts",
-			"line": 740,
-			"api": "withReadDb",
-			"source": "const activeCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "aggregate-recall.ts",
-			"line": 746,
-			"api": "withWriteTx",
-			"source": "const written = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "aggregate-recall.ts",
-			"line": 995,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "auth/api-keys.ts",
-			"line": 197,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "auth/api-keys.ts",
-			"line": 241,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "auth/api-keys.ts",
-			"line": 258,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "auth/api-keys.ts",
-			"line": 272,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "auth/tokens.ts",
-			"line": 30,
-			"api": "existsSync",
-			"source": "if (existsSync(secretPath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "auth/tokens.ts",
-			"line": 31,
-			"api": "readFileSync",
-			"source": "const secret = readFileSync(secretPath);",
-			"category": "hot-path"
-		},
-		{
-			"path": "auth/tokens.ts",
-			"line": 37,
-			"api": "writeFileSync",
-			"source": "writeFileSync(secretPath, fresh, { mode: 0o600 });",
-			"category": "hot-path"
-		},
-		{
-			"path": "auth/tokens.ts",
-			"line": 43,
-			"api": "existsSync",
-			"source": "if (!existsSync(dir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "auth/tokens.ts",
-			"line": 44,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dir, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "auth/tokens.ts",
-			"line": 47,
-			"api": "writeFileSync",
-			"source": "writeFileSync(secretPath, secret, { mode: 0o600 });",
-			"category": "hot-path"
-		},
-		{
-			"path": "black-box.ts",
-			"line": 434,
-			"api": "withReadDb",
-			"source": "const events = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "black-box.ts",
-			"line": 467,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "config-migration.ts",
-			"line": 56,
-			"api": "existsSync",
-			"source": "if (existsSync(p)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "config-migration.ts",
-			"line": 65,
-			"api": "readFileSync",
-			"source": "text = readFileSync(path, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "config-migration.ts",
-			"line": 106,
-			"api": "writeFileSync",
-			"source": "writeFileSync(tmp, text, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "config-migration.ts",
-			"line": 107,
-			"api": "renameSync",
-			"source": "renameSync(tmp, path);",
-			"category": "hot-path"
-		},
-		{
-			"path": "config-migration.ts",
-			"line": 141,
-			"api": "existsSync",
-			"source": "if (existsSync(p)) return p;",
-			"category": "hot-path"
-		},
-		{
-			"path": "config-migration.ts",
-			"line": 152,
-			"api": "readFileSync",
-			"source": "text = readFileSync(path, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "config-migration.ts",
-			"line": 228,
-			"api": "writeFileSync",
-			"source": "writeFileSync(tmp, contents, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "config-migration.ts",
-			"line": 229,
-			"api": "renameSync",
-			"source": "renameSync(tmp, path);",
-			"category": "hot-path"
-		},
-		{
-			"path": "config-migration.ts",
-			"line": 290,
-			"api": "readFileSync",
-			"source": "text = readFileSync(path, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "config-migration.ts",
-			"line": 502,
-			"api": "readFileSync",
-			"source": "text = readFileSync(path, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "config-migration.ts",
-			"line": 564,
-			"api": "readFileSync",
-			"source": "text = readFileSync(path, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "config-migration.ts",
-			"line": 667,
-			"api": "readFileSync",
-			"source": "text = readFileSync(path, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "config-migration.ts",
-			"line": 724,
-			"api": "readFileSync",
-			"source": "text = readFileSync(path, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "connectors/filesystem.ts",
-			"line": 232,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "connectors/filesystem.ts",
-			"line": 287,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "connectors/filesystem.ts",
-			"line": 310,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "connectors/registry.ts",
-			"line": 23,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "connectors/registry.ts",
-			"line": 43,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "connectors/registry.ts",
-			"line": 59,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "connectors/registry.ts",
-			"line": 74,
-			"api": "withReadDb",
-			"source": "const before = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "connectors/registry.ts",
-			"line": 82,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "connectors/registry.ts",
-			"line": 98,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "connectors/registry.ts",
-			"line": 108,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "connectors/registry.ts",
-			"line": 145,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "cross-agent.ts",
-			"line": 645,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "cross-agent.ts",
-			"line": 768,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "cross-agent.ts",
-			"line": 813,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "cross-agent.ts",
-			"line": 856,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "cross-agent.ts",
-			"line": 884,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "cross-agent.ts",
-			"line": 914,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "cross-agent.ts",
-			"line": 953,
-			"api": "withWriteTx",
-			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "cross-agent.ts",
-			"line": 1028,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 380,
-			"api": "existsSync",
-			"source": "if (!existsSync(agentsMdPath)) return;",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 397,
-			"api": "existsSync",
-			"source": "const existingFiles = files.filter((f) => existsSync(join(AGENTS_DIR, f.name)));",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 425,
-			"api": "existsSync",
-			"source": "if (!existsSync(identityPath)) return \"\";",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 444,
-			"api": "existsSync",
-			"source": "if (activeHarnesses.has(\"opencode\") && existsSync(opencodeDir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 476,
-			"api": "existsSync",
-			"source": "if (activeHarnesses.has(\"opencode\") && existsSync(opencodeDir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 483,
-			"api": "existsSync",
-			"source": "if (existsSync(geminiDir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 488,
-			"api": "existsSync",
-			"source": "if (existsSync(settingsPath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 489,
-			"api": "readFileSync",
-			"source": "const parsed = JSON.parse(readFileSync(settingsPath, \"utf8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 509,
-			"api": "existsSync",
-			"source": "if (!existsSync(targetPath)) continue;",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 705,
-			"api": "statSync",
-			"source": "const stat = statSync(filePath);",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 723,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 774,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 813,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 833,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 865,
-			"api": "readFileSync",
-			"source": "content = readFileSync(filePath, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 1025,
-			"api": "existsSync",
-			"source": "if (!existsSync(memoryDir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 1401,
-			"api": "existsSync",
-			"source": "if (!existsSync(p)) continue;",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 1403,
-			"api": "readFileSync",
-			"source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\")) as Record<string, unknown>;",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 1421,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 1440,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) continue;",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 1442,
-			"api": "readFileSync",
-			"source": "const routing = parseRoutingConfig(parseSimpleYaml(readFileSync(path, \"utf-8\")));",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 1502,
-			"api": "withReadDb",
-			"source": "const activeEmbeddingCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 1804,
-			"api": "existsSync",
-			"source": "if (existsSync(PID_FILE)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 1806,
-			"api": "unlinkSync",
-			"source": "unlinkSync(PID_FILE);",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 1947,
-			"api": "mkdirSync",
-			"source": "mkdirSync(DAEMON_DIR, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 1948,
-			"api": "mkdirSync",
-			"source": "mkdirSync(LOG_DIR, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 2023,
-			"api": "existsSync",
-			"source": "const workerPath = existsSync(bundled)",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 2093,
-			"api": "writeFileSync",
-			"source": "writeFileSync(PID_FILE, process.pid.toString());",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 2175,
-			"api": "withReadDb",
-			"source": "const memoryCount = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 2186,
-			"api": "withReadDb",
-			"source": "const queue = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 2393,
-			"api": "existsSync",
-			"source": "if (existsSync(healthStampPath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 2394,
-			"api": "readFileSync",
-			"source": "const prev = JSON.parse(readFileSync(healthStampPath, \"utf-8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "daemon.ts",
-			"line": 2397,
-			"api": "writeFileSync",
-			"source": "writeFileSync(",
-			"category": "hot-path"
-		},
-		{
-			"path": "database-integrity.ts",
-			"line": 127,
-			"api": "existsSync",
-			"source": "if (existsSync(bundled)) return bundled;",
-			"category": "hot-path"
-		},
-		{
-			"path": "database-integrity.ts",
-			"line": 270,
-			"api": "withReadDb",
-			"source": "const checks = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => ({",
-			"category": "hot-path"
-		},
-		{
-			"path": "database-integrity.ts",
-			"line": 304,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "database-integrity.ts",
-			"line": 309,
-			"api": "withReadDb",
-			"source": "const verifiedTelemetry = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 317,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return null;",
-			"category": "hot-path"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 320,
-			"api": "readFileSync",
-			"source": "const raw: unknown = JSON.parse(readFileSync(path, \"utf8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 577,
-			"api": "readdirSync",
-			"source": ".readdirSync(dir)",
-			"category": "pre-readiness-bootstrap"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 581,
-			"api": "statSync",
-			"source": "const stat = deps.statSync(join(dir, f));",
-			"category": "pre-readiness-bootstrap"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 595,
-			"api": "unlinkSync",
-			"source": "deps.unlinkSync(join(dir, old.name));",
-			"category": "pre-readiness-bootstrap"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 606,
-			"api": "statfsSync",
-			"source": "const stat = deps.statfsSync(path);",
-			"category": "pre-readiness-bootstrap"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 615,
-			"api": "statSync",
-			"source": "const size = deps.statSync(path).size;",
-			"category": "pre-readiness-bootstrap"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 646,
-			"api": "copyFileSync",
-			"source": "deps.copyFileSync(dbPath, probeDest);",
-			"category": "pre-readiness-bootstrap"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 652,
-			"api": "unlinkSync",
-			"source": "deps.unlinkSync(probeDest);",
-			"category": "pre-readiness-bootstrap"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 687,
-			"api": "copyFileSync",
-			"source": "deps.copyFileSync(dbPath, backupDest);",
-			"category": "pre-readiness-bootstrap"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 711,
-			"api": "copyFileSync",
-			"source": "deps.copyFileSync(dbPath, backupDest);",
-			"category": "pre-readiness-bootstrap"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 751,
-			"api": "unlinkSync",
-			"source": "deps.unlinkSync(backupDest);",
-			"category": "pre-readiness-bootstrap"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 760,
-			"api": "unlinkSync",
-			"source": "else deps.unlinkSync(backupDest);",
-			"category": "pre-readiness-bootstrap"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 788,
-			"api": "unlinkSync",
-			"source": "deps.unlinkSync(backupDest);",
-			"category": "pre-readiness-bootstrap"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 820,
-			"api": "existsSync",
-			"source": "if (!existsSync(dir)) {",
-			"category": "pre-readiness-bootstrap"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 821,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dir, { recursive: true });",
-			"category": "pre-readiness-bootstrap"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 842,
-			"api": "existsSync",
-			"source": "if (existsSync(path) && hasPendingMigrations(toMigrationDb(writeConn))) {",
-			"category": "pre-readiness-bootstrap"
-		},
-		{
-			"path": "db-accessor.ts",
-			"line": 849,
-			"api": "existsSync",
-			"source": "if (existsSync(path) && hasPendingMigrations(toMigrationDb(writeConn))) {",
-			"category": "pre-readiness-bootstrap"
-		},
-		{
-			"path": "db-vacuum.ts",
-			"line": 67,
-			"api": "statSync",
-			"source": "const dbBytes = deps.statSync(dbPath).size;",
-			"category": "hot-path"
-		},
-		{
-			"path": "db-vacuum.ts",
-			"line": 69,
-			"api": "statfsSync",
-			"source": "const stats = deps.statfsSync(directory);",
-			"category": "hot-path"
-		},
-		{
-			"path": "db-vacuum.ts",
-			"line": 322,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readStatusFromDb(toPragmaReadDb(db)));",
-			"category": "hot-path"
-		},
-		{
-			"path": "db-vacuum.ts",
-			"line": 411,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "db-vacuum.ts",
-			"line": 437,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "db-vacuum.ts",
-			"line": 453,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "discord-desktop-cache-source.ts",
-			"line": 221,
-			"api": "lstatSync",
-			"source": "stat = fileSystem.lstatSync(path);",
-			"category": "hot-path"
-		},
-		{
-			"path": "discord-desktop-cache-source.ts",
-			"line": 265,
-			"api": "readdirSync",
-			"source": "const entries = fileSystem.readdirSync(path);",
-			"category": "hot-path"
-		},
-		{
-			"path": "discord-desktop-cache-source.ts",
-			"line": 285,
-			"api": "readFileSync",
-			"source": "const data = fileSystem.readFileSync(candidate.absPath);",
-			"category": "hot-path"
-		},
-		{
-			"path": "discord-desktop-cache-source.ts",
-			"line": 481,
-			"api": "withReadDb",
-			"source": "const rows = getDbAccessor().withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "discord-desktop-cache-source.ts",
-			"line": 494,
-			"api": "withWriteTx",
-			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "discord-desktop-cache-source.ts",
-			"line": 1085,
-			"api": "readFileSync",
-			"source": "const data = fileSystem.readFileSync(path).subarray(0, CACHE_SNIFF_BYTES).toString(\"utf8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "discord-source-provider.ts",
-			"line": 554,
-			"api": "withReadDb",
-			"source": "const rows = getDbAccessor().withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "discord-source-provider.ts",
-			"line": 568,
-			"api": "withWriteTx",
-			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "discord-source-provider.ts",
-			"line": 610,
-			"api": "withReadDb",
-			"source": "const row = getDbAccessor().withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "discord-source-provider.ts",
-			"line": 855,
-			"api": "withReadDb",
-			"source": "const row = getDbAccessor().withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "discord-source-provider.ts",
-			"line": 939,
-			"api": "withReadDb",
-			"source": "const rows = getDbAccessor().withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "discord-source-provider.ts",
-			"line": 953,
-			"api": "withWriteTx",
-			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-fetch.ts",
-			"line": 494,
-			"api": "withReadDb",
-			"source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => resolveActiveEmbeddingConfig(db, cfg));",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-index-migration.ts",
-			"line": 80,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx(fn);",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-index-migration.ts",
-			"line": 253,
-			"api": "withReadDb",
-			"source": "const state = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readEmbeddingIndexState(db));",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-index-migration.ts",
-			"line": 262,
-			"api": "withReadDb",
-			"source": "const rows = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-index-migration.ts",
-			"line": 343,
-			"api": "withReadDb",
-			"source": "const coverage = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-index-migration.ts",
-			"line": 355,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-index-migration.ts",
-			"line": 435,
-			"api": "withReadDb",
-			"source": "const before = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readEmbeddingIndexState(db));",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-index-migration.ts",
-			"line": 437,
-			"api": "withWriteTx",
-			"source": "const initial = input.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-index-migration.ts",
-			"line": 446,
-			"api": "withReadDb",
-			"source": "const hasStagingVectorIndex = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-index-migration.ts",
-			"line": 452,
-			"api": "withWriteTx",
-			"source": "input.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-index-migration.ts",
-			"line": 458,
-			"api": "withWriteTx",
-			"source": "input.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-index-migration.ts",
-			"line": 469,
-			"api": "withReadDb",
-			"source": "const state = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readEmbeddingIndexState(db));",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-repair-state.ts",
-			"line": 101,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-repair-state.ts",
-			"line": 139,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-repair-state.ts",
-			"line": 160,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-repair-state.ts",
-			"line": 191,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-tracker.ts",
-			"line": 194,
-			"api": "withReadDb",
-			"source": "const staleRows: StaleRow[] = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-tracker.ts",
-			"line": 265,
-			"api": "withWriteTx",
-			"source": "applied = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-usage.ts",
-			"line": 90,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-usage.ts",
-			"line": 115,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-worker-handle.ts",
-			"line": 180,
-			"api": "existsSync",
-			"source": ": existsSync(bundled)",
-			"category": "hot-path"
-		},
-		{
-			"path": "embedding-worker.ts",
-			"line": 154,
-			"api": "mkdirSync",
-			"source": "mkdirSync(init.cacheDir, { recursive: true });",
-			"category": "isolated-worker"
-		},
-		{
-			"path": "embedding-worker.ts",
-			"line": 175,
-			"api": "readFileSync",
-			"source": "const wasmBytes = readFileSync(join(init.wasmDir, \"ort-wasm-simd-threaded.wasm\"));",
-			"category": "isolated-worker"
-		},
-		{
-			"path": "feature-flags.ts",
-			"line": 36,
-			"api": "existsSync",
-			"source": "if (!existsSync(p)) continue;",
-			"category": "hot-path"
-		},
-		{
-			"path": "feature-flags.ts",
-			"line": 38,
-			"api": "readFileSync",
-			"source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "file-sync.ts",
-			"line": 9,
-			"api": "existsSync",
-			"source": "const existing = existsSync(path) ? readFileSync(path, \"utf-8\") : null;",
-			"category": "hot-path"
-		},
-		{
-			"path": "file-sync.ts",
-			"line": 9,
-			"api": "readFileSync",
-			"source": "const existing = existsSync(path) ? readFileSync(path, \"utf-8\") : null;",
-			"category": "hot-path"
-		},
-		{
-			"path": "file-sync.ts",
-			"line": 11,
-			"api": "writeFileSync",
-			"source": "writeFileSync(path, content);",
-			"category": "hot-path"
-		},
-		{
-			"path": "github-source-provider.ts",
-			"line": 457,
-			"api": "withReadDb",
-			"source": "const rows = getDbAccessor().withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "github-source-provider.ts",
-			"line": 479,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "github-source-provider.ts",
-			"line": 493,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "graphiq.ts",
-			"line": 34,
-			"api": "accessSync",
-			"source": "accessSync(candidate, constants.X_OK);",
-			"category": "hot-path"
-		},
-		{
-			"path": "graphiq.ts",
-			"line": 48,
-			"api": "existsSync",
-			"source": "if (!existsSync(active.dbPath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "hooks-config.ts",
-			"line": 289,
-			"api": "existsSync",
-			"source": "if (!existsSync(configPath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "hooks-config.ts",
-			"line": 294,
-			"api": "readFileSync",
-			"source": "const content = readFileSync(configPath, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "hooks.ts",
-			"line": 455,
-			"api": "existsSync",
-			"source": "if (!existsSync(getMemoryDbPath())) return undefined;",
-			"category": "hot-path"
-		},
-		{
-			"path": "hooks.ts",
-			"line": 553,
-			"api": "existsSync",
-			"source": "if (!existsSync(getMemoryDbPath())) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "hooks.ts",
-			"line": 761,
-			"api": "existsSync",
-			"source": "if (req.sessionKey && existsSync(getMemoryDbPath())) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "hooks.ts",
-			"line": 1602,
-			"api": "existsSync",
-			"source": "if (req.transcriptPath && existsSync(req.transcriptPath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "hooks.ts",
-			"line": 1604,
-			"api": "readFileSync",
-			"source": "rawTranscript = readFileSync(req.transcriptPath, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "hooks.ts",
-			"line": 1946,
-			"api": "existsSync",
-			"source": "if (req.transcriptPath && existsSync(req.transcriptPath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "hooks.ts",
-			"line": 1948,
-			"api": "readFileSync",
-			"source": "rawTranscript = readFileSync(req.transcriptPath, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "hooks.ts",
-			"line": 2210,
-			"api": "existsSync",
-			"source": "} else if (req.transcriptPath && existsSync(req.transcriptPath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "hooks.ts",
-			"line": 2212,
-			"api": "readFileSync",
-			"source": "const raw = readFileSync(req.transcriptPath, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "identity-context.ts",
-			"line": 32,
-			"api": "existsSync",
-			"source": "if (!filePath || !existsSync(filePath)) return undefined;",
-			"category": "hot-path"
-		},
-		{
-			"path": "identity-context.ts",
-			"line": 35,
-			"api": "readFileSync",
-			"source": "const content = readFileSync(filePath, \"utf-8\").trim();",
-			"category": "hot-path"
-		},
-		{
-			"path": "identity-context.ts",
-			"line": 73,
-			"api": "existsSync",
-			"source": "if (!filePath || !existsSync(filePath)) return undefined;",
-			"category": "hot-path"
-		},
-		{
-			"path": "identity-context.ts",
-			"line": 76,
-			"api": "readFileSync",
-			"source": "const content = readFileSync(filePath, \"utf-8\").trim();",
-			"category": "hot-path"
-		},
-		{
-			"path": "identity-context.ts",
-			"line": 178,
-			"api": "existsSync",
-			"source": "if (identityMd && existsSync(identityMd)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "identity-context.ts",
-			"line": 180,
-			"api": "readFileSync",
-			"source": "return parseIdentityMarkdown(readFileSync(identityMd, \"utf-8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "identity-context.ts",
-			"line": 185,
-			"api": "existsSync",
-			"source": "if (existsSync(agentYaml)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "identity-context.ts",
-			"line": 187,
-			"api": "readFileSync",
-			"source": "const content = readFileSync(agentYaml, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "identity-context.ts",
-			"line": 200,
-			"api": "existsSync",
-			"source": "if (existsSync(rootIdentityMd)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "identity-context.ts",
-			"line": 202,
-			"api": "readFileSync",
-			"source": "return parseIdentityMarkdown(readFileSync(rootIdentityMd, \"utf-8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "identity-sync.ts",
-			"line": 35,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return null;",
-			"category": "hot-path"
-		},
-		{
-			"path": "identity-sync.ts",
-			"line": 60,
-			"api": "existsSync",
-			"source": "if (!existsSync(agentsRoot)) return;",
-			"category": "hot-path"
-		},
-		{
-			"path": "identity-sync.ts",
-			"line": 84,
-			"api": "existsSync",
-			"source": "const soulPath = existsSync(join(agentDir, \"SOUL.md\")) ? join(agentDir, \"SOUL.md\") : join(agentsDir, \"SOUL.md\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "identity-sync.ts",
-			"line": 85,
-			"api": "existsSync",
-			"source": "const identityPath = existsSync(join(agentDir, \"IDENTITY.md\"))",
-			"category": "hot-path"
-		},
-		{
-			"path": "imported-source-lifecycle.ts",
-			"line": 36,
-			"api": "withWriteTx",
-			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "imported-source-outcome.ts",
-			"line": 16,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => persistImportedSourceOutcomeInTx(db, input));",
-			"category": "hot-path"
-		},
-		{
-			"path": "imported-source-outcome.ts",
-			"line": 59,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "knowledge-graph-hygiene.ts",
-			"line": 428,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "lifecycle.ts",
-			"line": 154,
-			"api": "readFileSync",
-			"source": "const raw = readFileSync(lifecyclePath(agentsDir), \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "lifecycle.ts",
-			"line": 169,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dirname(path), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "lifecycle.ts",
-			"line": 171,
-			"api": "writeFileSync",
-			"source": "writeFileSync(tmpPath, JSON.stringify(record, null, 2));",
-			"category": "hot-path"
-		},
-		{
-			"path": "lifecycle.ts",
-			"line": 172,
-			"api": "renameSync",
-			"source": "renameSync(tmpPath, path);",
-			"category": "hot-path"
-		},
-		{
-			"path": "logger.ts",
-			"line": 179,
-			"api": "existsSync",
-			"source": "if (!existsSync(dir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "logger.ts",
-			"line": 180,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dir, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "logger.ts",
-			"line": 242,
-			"api": "existsSync",
-			"source": "if (!existsSync(this.config.logFilePath)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "logger.ts",
-			"line": 250,
-			"api": "existsSync",
-			"source": "if (!existsSync(this.config.logDir)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "logger.ts",
-			"line": 251,
-			"api": "readdirSync",
-			"source": "return readdirSync(this.config.logDir)",
-			"category": "hot-path"
-		},
-		{
-			"path": "logger.ts",
-			"line": 349,
-			"api": "appendFileSync",
-			"source": "appendFileSync(this.currentLogFile, lines);",
-			"category": "hot-path"
-		},
-		{
-			"path": "logger.ts",
-			"line": 372,
-			"api": "existsSync",
-			"source": "if (!existsSync(this.currentLogFile)) return;",
-			"category": "hot-path"
-		},
-		{
-			"path": "logger.ts",
-			"line": 374,
-			"api": "statSync",
-			"source": "const stats = statSync(this.currentLogFile);",
-			"category": "hot-path"
-		},
-		{
-			"path": "logger.ts",
-			"line": 389,
-			"api": "renameSync",
-			"source": "renameSync(this.currentLogFile, rotatedName);",
-			"category": "hot-path"
-		},
-		{
-			"path": "logger.ts",
-			"line": 405,
-			"api": "unlinkSync",
-			"source": "unlinkSync(files[i].path);",
-			"category": "hot-path"
-		},
-		{
-			"path": "logger.ts",
-			"line": 551,
-			"api": "readFileSync",
-			"source": "const content = readFileSync(file.path, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "mcp-probe.ts",
-			"line": 45,
-			"api": "existsSync",
-			"source": "if (!existsSync(dir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "mcp-probe.ts",
-			"line": 46,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dir, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "mcp-probe.ts",
-			"line": 440,
-			"api": "writeFileSync",
-			"source": "writeFileSync(manifestPath, JSON.stringify(result, null, 2));",
-			"category": "hot-path"
-		},
-		{
-			"path": "mcp-probe.ts",
-			"line": 474,
-			"api": "writeFileSync",
-			"source": "writeFileSync(getAppTrayPath(), JSON.stringify(tray, null, 2));",
-			"category": "hot-path"
-		},
-		{
-			"path": "mcp-probe.ts",
-			"line": 500,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "mcp-probe.ts",
-			"line": 503,
-			"api": "readFileSync",
-			"source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-			"category": "hot-path"
-		},
-		{
-			"path": "mcp-probe.ts",
-			"line": 522,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return null;",
-			"category": "hot-path"
-		},
-		{
-			"path": "mcp-probe.ts",
-			"line": 525,
-			"api": "readFileSync",
-			"source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-			"category": "hot-path"
-		},
-		{
-			"path": "mcp-probe.ts",
-			"line": 541,
-			"api": "existsSync",
-			"source": "if (existsSync(manifestPath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "mcp-probe.ts",
-			"line": 542,
-			"api": "unlinkSync",
-			"source": "unlinkSync(manifestPath);",
-			"category": "hot-path"
-		},
-		{
-			"path": "mcp-probe.ts",
-			"line": 552,
-			"api": "writeFileSync",
-			"source": "writeFileSync(getAppTrayPath(), JSON.stringify(filtered, null, 2));",
-			"category": "hot-path"
-		},
-		{
-			"path": "mcp-stdio.ts",
-			"line": 32,
-			"api": "existsSync",
-			"source": "return isAbsolute(dir) && existsSync(dir) && statSync(dir).isDirectory();",
-			"category": "cli-only"
-		},
-		{
-			"path": "mcp-stdio.ts",
-			"line": 32,
-			"api": "statSync",
-			"source": "return isAbsolute(dir) && existsSync(dir) && statSync(dir).isDirectory();",
-			"category": "cli-only"
-		},
-		{
-			"path": "memory-candidates.ts",
-			"line": 132,
-			"api": "existsSync",
-			"source": "if (memoryIds.length === 0 || !existsSync(memoryDbPath)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-candidates.ts",
-			"line": 150,
-			"api": "withReadDb",
-			"source": "const batchRows: ScoredMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-candidates.ts",
-			"line": 211,
-			"api": "existsSync",
-			"source": "if (!existsSync(memoryDbPath)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-candidates.ts",
-			"line": 228,
-			"api": "withReadDb",
-			"source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-candidates.ts",
-			"line": 285,
-			"api": "existsSync",
-			"source": "if (!existsSync(memoryDbPath)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-candidates.ts",
-			"line": 306,
-			"api": "withReadDb",
-			"source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-candidates.ts",
-			"line": 368,
-			"api": "withReadDb",
-			"source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-candidates.ts",
-			"line": 401,
-			"api": "existsSync",
-			"source": "if (!existsSync(memoryDbPath)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-candidates.ts",
-			"line": 432,
-			"api": "withReadDb",
-			"source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-candidates.ts",
-			"line": 440,
-			"api": "existsSync",
-			"source": "if (!existsSync(memoryDbPath)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-candidates.ts",
-			"line": 473,
-			"api": "withReadDb",
-			"source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-config.ts",
-			"line": 990,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) continue;",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-config.ts",
-			"line": 992,
-			"api": "readFileSync",
-			"source": "const yaml = parseSimpleYaml(readFileSync(path, \"utf-8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-head.ts",
-			"line": 59,
-			"api": "withWriteTx",
-			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-head.ts",
-			"line": 128,
-			"api": "withWriteTx",
-			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-head.ts",
-			"line": 147,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-head.ts",
-			"line": 160,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dir, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-head.ts",
-			"line": 161,
-			"api": "existsSync",
-			"source": "if (existsSync(path)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-head.ts",
-			"line": 164,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dirname(backup), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-head.ts",
-			"line": 165,
-			"api": "writeFileSync",
-			"source": "writeFileSync(backup, readFileSync(path, \"utf-8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-head.ts",
-			"line": 165,
-			"api": "readFileSync",
-			"source": "writeFileSync(backup, readFileSync(path, \"utf-8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-head.ts",
-			"line": 167,
-			"api": "writeFileSync",
-			"source": "writeFileSync(path, file);",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 438,
-			"api": "mkdirSync",
-			"source": "mkdirSync(getMemoryDir(), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 440,
-			"api": "writeFileSync",
-			"source": "writeFileSync(tmp, content, \"utf8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 441,
-			"api": "renameSync",
-			"source": "renameSync(tmp, path);",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 445,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return null;",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 446,
-			"api": "readFileSync",
-			"source": "const parsed = parseFrontmatterDocument(readFileSync(path, \"utf8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 498,
-			"api": "existsSync",
-			"source": "if (existsSync(path)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 499,
-			"api": "readFileSync",
-			"source": "const existing = parseFrontmatterDocument(readFileSync(path, \"utf8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 654,
-			"api": "statSync",
-			"source": "sourceMtimeMs = statSync(path).mtimeMs,",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 730,
-			"api": "statSync",
-			"source": "sourceMtimeMs = statSync(path).mtimeMs,",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 826,
-			"api": "existsSync",
-			"source": "existsSync(path) ? statSync(path).mtimeMs : Date.now(),",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 826,
-			"api": "statSync",
-			"source": "existsSync(path) ? statSync(path).mtimeMs : Date.now(),",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 833,
-			"api": "existsSync",
-			"source": "if (!existsSync(dir)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 1495,
-			"api": "readFileSync",
-			"source": "const parsed = parseFrontmatterDocument(readFileSync(fullPath, \"utf8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 1556,
-			"api": "readFileSync",
-			"source": "const parsed = parseFrontmatterDocument(readFileSync(fullPath, \"utf8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 1606,
-			"api": "readFileSync",
-			"source": "const parsed = parseFrontmatterDocument(readFileSync(fullPath, \"utf8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-lineage.ts",
-			"line": 2201,
-			"api": "rmSync",
-			"source": "rmSync(join(getAgentsDir(), path), { force: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-search-telemetry.ts",
-			"line": 238,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "memory-search-telemetry.ts",
-			"line": 314,
-			"api": "withReadDb",
-			"source": "return db.withReadDb((r) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-runtime-assets.ts",
-			"line": 77,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dir, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-runtime-assets.ts",
-			"line": 78,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-runtime-assets.ts",
-			"line": 79,
-			"api": "writeFileSync",
-			"source": "writeFileSync(path, Buffer.from(worker.contentBase64, \"base64\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-runtime-assets.ts",
-			"line": 93,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dir, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-runtime-assets.ts",
-			"line": 96,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-runtime-assets.ts",
-			"line": 97,
-			"api": "writeFileSync",
-			"source": "writeFileSync(path, Buffer.from(asset.contentBase64, \"base64\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-runtime-assets.ts",
-			"line": 111,
-			"api": "mkdirSync",
-			"source": "mkdirSync(root, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-runtime-assets.ts",
-			"line": 116,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dirname(path), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-runtime-assets.ts",
-			"line": 117,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-runtime-assets.ts",
-			"line": 118,
-			"api": "writeFileSync",
-			"source": "writeFileSync(path, Buffer.from(asset.contentBase64, \"base64\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "native-runtime-assets.ts",
-			"line": 123,
-			"api": "writeFileSync",
-			"source": "writeFileSync(join(root, \".signet-assets.json\"), `${JSON.stringify({ kind, sourceHash }, null, 2)}\\n`);",
-			"category": "hot-path"
-		},
-		{
-			"path": "obsidian-source-embeddings.ts",
-			"line": 269,
-			"api": "withReadDb",
-			"source": "const embeddingConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "obsidian-source-embeddings.ts",
-			"line": 304,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "obsidian-source-embeddings.ts",
-			"line": 318,
-			"api": "withReadDb",
-			"source": "const writeConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "obsidian-source-embeddings.ts",
-			"line": 347,
-			"api": "withWriteTx",
-			"source": "const stored = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "obsidian-source-embeddings.ts",
-			"line": 408,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "obsidian-source-embeddings.ts",
-			"line": 454,
-			"api": "withReadDb",
-			"source": "const row = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "obsidian-source-embeddings.ts",
-			"line": 475,
-			"api": "withWriteTx",
-			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "obsidian-source-graph.ts",
-			"line": 323,
-			"api": "existsSync",
-			"source": "return existsSync(path) && statSync(path).isFile() ? normalizedPath(path) : null;",
-			"category": "hot-path"
-		},
-		{
-			"path": "obsidian-source-graph.ts",
-			"line": 323,
-			"api": "statSync",
-			"source": "return existsSync(path) && statSync(path).isFile() ? normalizedPath(path) : null;",
-			"category": "hot-path"
-		},
-		{
-			"path": "obsidian-source-graph.ts",
-			"line": 471,
-			"api": "withWriteTx",
-			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "obsidian-source-graph.ts",
-			"line": 690,
-			"api": "withWriteTx",
-			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "obsidian-source-graph.ts",
-			"line": 702,
-			"api": "withWriteTx",
-			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "ontology-assertions.ts",
-			"line": 306,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: WriteDb) => insertAssertion(db, input));",
-			"category": "hot-path"
-		},
-		{
-			"path": "ontology-assertions.ts",
-			"line": 325,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "ontology-assertions.ts",
-			"line": 391,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "ontology-assertions.ts",
-			"line": 410,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "ontology-assertions.ts",
-			"line": 438,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "ontology-assertions.ts",
-			"line": 466,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "ontology-claim-evidence.ts",
-			"line": 153,
-			"api": "withReadDb",
-			"source": "const items = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "ontology-claim-trace.ts",
-			"line": 1063,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "ontology-contradictions.ts",
-			"line": 524,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => reconcileOntologyContradictionsInTx(db, params));",
-			"category": "hot-path"
-		},
-		{
-			"path": "ontology-contradictions.ts",
-			"line": 535,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "ontology-contradictions.ts",
-			"line": 591,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "ontology-extraction.ts",
-			"line": 647,
-			"api": "withReadDb",
-			"source": "const source = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "ontology-extraction.ts",
-			"line": 748,
-			"api": "withWriteTx",
-			"source": "const written = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "path-feedback.ts",
-			"line": 611,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/acpx-dreaming-mcp.ts",
-			"line": 16,
-			"api": "existsSync",
-			"source": "if (!existsSync(entrypoint)) throw new Error(`Signet Dreaming MCP entrypoint is unavailable: ${entrypoint}`);",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/acpx-dreaming-mcp.ts",
-			"line": 40,
-			"api": "writeFileSync",
-			"source": "writeFileSync(",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/acpx-dreaming-mcp.ts",
-			"line": 57,
-			"api": "rmSync",
-			"source": "rmSync(dir, { recursive: true, force: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/aspect-feedback.ts",
-			"line": 79,
-			"api": "withWriteTx",
-			"source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/aspect-feedback.ts",
-			"line": 165,
-			"api": "withWriteTx",
-			"source": "const decayed = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 219,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 260,
-			"api": "withReadDb",
-			"source": "const doc = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 270,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => completeJob(db, job.id));",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 278,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => updateDocumentStatus(db, docId, \"extracting\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 301,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 318,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 356,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 367,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => updateDocumentStatus(db, docId, \"chunking\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 372,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 382,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => updateDocumentStatus(db, docId, \"embedding\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 405,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 531,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 536,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 585,
-			"api": "withReadDb",
-			"source": "return deps.accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 604,
-			"api": "withReadDb",
-			"source": "const durable = deps.accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 611,
-			"api": "withReadDb",
-			"source": "const durableLinks = deps.accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 659,
-			"api": "withWriteTx",
-			"source": "const job = deps.accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/document-worker.ts",
-			"line": 687,
-			"api": "withWriteTx",
-			"source": "deps.accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-attention.ts",
-			"line": 136,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getDreamingAttentionInDb(db, agentId, limit));",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-attention.ts",
-			"line": 145,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-attention.ts",
-			"line": 181,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-attention.ts",
-			"line": 225,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-attention.ts",
-			"line": 256,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-attention.ts",
-			"line": 290,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-evidence-retry.ts",
-			"line": 131,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-evidence-retry.ts",
-			"line": 253,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-operations.ts",
-			"line": 112,
-			"api": "withReadDb",
-			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-operations.ts",
-			"line": 154,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-operations.ts",
-			"line": 478,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-operations.ts",
-			"line": 490,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-operations.ts",
-			"line": 503,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-operations.ts",
-			"line": 520,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-operations.ts",
-			"line": 692,
-			"api": "withReadDb",
-			"source": "const pending = params.accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-runbook.ts",
-			"line": 177,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-runbook.ts",
-			"line": 219,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-token-cache.ts",
-			"line": 36,
-			"api": "existsSync",
-			"source": "return existsSync(bundled)",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-worker.ts",
-			"line": 96,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getQueueHealth(db).status !== \"healthy\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-worker.ts",
-			"line": 106,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-worker.ts",
-			"line": 182,
-			"api": "withReadDb",
-			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => hasDreamingAttentionKindInDb(db, scope, [\"hygiene\"])),",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-worker.ts",
-			"line": 186,
-			"api": "withReadDb",
-			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming-worker.ts",
-			"line": 278,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 119,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 152,
-			"api": "withReadDb",
-			"source": "const selection = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 157,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 265,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 411,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => readDreamingState(db, agentId));",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 446,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 513,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 524,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 537,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 592,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 619,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 665,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 689,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 731,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return { content: \"\", unreadable: false };",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 733,
-			"api": "readFileSync",
-			"source": "const raw = readFileSync(path, \"utf-8\").trim();",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 1199,
-			"api": "withReadDb",
-			"source": "const row = accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 1220,
-			"api": "withReadDb",
-			"source": "const rows: Array<{ readonly memoryId: string }> = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 1261,
-			"api": "withReadDb",
-			"source": "const rows: Array<{ readonly memoryId: string }> = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 1411,
-			"api": "withReadDb",
-			"source": "const cutoff = accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 1422,
-			"api": "withReadDb",
-			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 1428,
-			"api": "withReadDb",
-			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 1434,
-			"api": "withReadDb",
-			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getDreamingAttentionInDb(db, scope, 1).length > 0),",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 1450,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 1512,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 1599,
-			"api": "withReadDb",
-			"source": "const previous = accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 1614,
-			"api": "withReadDb",
-			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 1624,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 1924,
-			"api": "withReadDb",
-			"source": "const entries = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 1955,
-			"api": "withReadDb",
-			"source": "const hasAttention = accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/dreaming.ts",
-			"line": 1975,
-			"api": "withReadDb",
-			"source": "const hasContinuation = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/extraction-fallback.ts",
-			"line": 17,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/prospective-index.ts",
-			"line": 230,
-			"api": "withWriteTx",
-			"source": "job = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => leaseJob(db, 3));",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/prospective-index.ts",
-			"line": 242,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => failJob(db, j.id, \"invalid payload\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/prospective-index.ts",
-			"line": 252,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/prospective-index.ts",
-			"line": 262,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => completeJob(db, j.id));",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/prospective-index.ts",
-			"line": 272,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => failJob(db, j.id, msg));",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/provider.ts",
-			"line": 824,
-			"api": "mkdirSync",
-			"source": "mkdirSync(isolatedCwd, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/reflection-worker.ts",
-			"line": 39,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return null;",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/reflection-worker.ts",
-			"line": 40,
-			"api": "readFileSync",
-			"source": "const data = JSON.parse(readFileSync(path, \"utf-8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/reflection-worker.ts",
-			"line": 50,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dir, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/reflection-worker.ts",
-			"line": 51,
-			"api": "writeFileSync",
-			"source": "writeFileSync(getLastReflectionPath(agentId), JSON.stringify({ lastDate: date }));",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/reflection-worker.ts",
-			"line": 366,
-			"api": "withReadDb",
-			"source": "const memories = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/reflection-worker.ts",
-			"line": 399,
-			"api": "withReadDb",
-			"source": "const existingReflections = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/reflection-worker.ts",
-			"line": 461,
-			"api": "withWriteTx",
-			"source": "deps.getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/reflection-worker.ts",
-			"line": 527,
-			"api": "withReadDb",
-			"source": ".withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/reranker-embedding.ts",
-			"line": 51,
-			"api": "withReadDb",
-			"source": "const embMap = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/retention-worker.ts",
-			"line": 376,
-			"api": "withWriteTx",
-			"source": "const retentionResult = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/retention-worker.ts",
-			"line": 391,
-			"api": "withWriteTx",
-			"source": "const historyPurged = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/retention-worker.ts",
-			"line": 397,
-			"api": "withWriteTx",
-			"source": "const completedJobsPurged = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/retention-worker.ts",
-			"line": 403,
-			"api": "withWriteTx",
-			"source": "const deadJobsPurged = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/retention-worker.ts",
-			"line": 409,
-			"api": "withWriteTx",
-			"source": "const completedTranscriptCaptureJobsPurged = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/retention-worker.ts",
-			"line": 413,
-			"api": "withWriteTx",
-			"source": "const deadTranscriptCaptureJobsPurged = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-graph.ts",
-			"line": 80,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-graph.ts",
-			"line": 174,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-graph.ts",
-			"line": 292,
-			"api": "withReadDb",
-			"source": "const writeConfig = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-graph.ts",
-			"line": 305,
-			"api": "withWriteTx",
-			"source": "embeddingCreated = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-graph.ts",
-			"line": 365,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-graph.ts",
-			"line": 376,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-reconciler.ts",
-			"line": 136,
-			"api": "existsSync",
-			"source": "if (options.scanFilesystem !== false && existsSync(dir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-reconciler.ts",
-			"line": 137,
-			"api": "readdirSync",
-			"source": "const entries = readdirSync(dir, { withFileTypes: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-reconciler.ts",
-			"line": 141,
-			"api": "existsSync",
-			"source": "if (existsSync(skillMdPath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-reconciler.ts",
-			"line": 163,
-			"api": "withReadDb",
-			"source": "const graphSkills = deps.accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-reconciler.ts",
-			"line": 170,
-			"api": "existsSync",
-			"source": "if (!existsSync(row.fs_path)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-reconciler.ts",
-			"line": 228,
-			"api": "existsSync",
-			"source": "if (!existsSync(mdPath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-reconciler.ts",
-			"line": 234,
-			"api": "readFileSync",
-			"source": "const content = readFileSync(mdPath, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-reconciler.ts",
-			"line": 241,
-			"api": "withReadDb",
-			"source": "const existing = deps.accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-reconciler.ts",
-			"line": 250,
-			"api": "withReadDb",
-			"source": "const storedEmb = deps.accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-reconciler.ts",
-			"line": 331,
-			"api": "statSync",
-			"source": "return statSync(dir).mtimeMs;",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/skill-reconciler.ts",
-			"line": 373,
-			"api": "existsSync",
-			"source": "if (existsSync(dir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/synthesis-worker.ts",
-			"line": 73,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return 0;",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/synthesis-worker.ts",
-			"line": 74,
-			"api": "readFileSync",
-			"source": "const data = JSON.parse(readFileSync(path, \"utf-8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/synthesis-worker.ts",
-			"line": 84,
-			"api": "mkdirSync",
-			"source": "mkdirSync(join(getAgentsDir(), \".daemon\"), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/synthesis-worker.ts",
-			"line": 85,
-			"api": "writeFileSync",
-			"source": "writeFileSync(path, JSON.stringify({ lastRunAt: timestamp }));",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/synthesis-worker.ts",
-			"line": 127,
-			"api": "withReadDb",
-			"source": "const checkpointRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "pipeline/synthesis-worker.ts",
-			"line": 153,
-			"api": "withReadDb",
-			"source": "const transcriptRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "plugins/audit.ts",
-			"line": 71,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dirname(path), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "plugins/audit.ts",
-			"line": 72,
-			"api": "appendFileSync",
-			"source": "appendFileSync(path, `${JSON.stringify(event)}\\n`, { mode: 0o600 });",
-			"category": "hot-path"
-		},
-		{
-			"path": "plugins/audit.ts",
-			"line": 85,
-			"api": "existsSync",
-			"source": "if (!path || !existsSync(path)) return { events: [], count: 0 };",
-			"category": "hot-path"
-		},
-		{
-			"path": "plugins/audit.ts",
-			"line": 109,
-			"api": "readFileSync",
-			"source": "return readFileSync(path, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "plugins/host.ts",
-			"line": 326,
-			"api": "existsSync",
-			"source": "if (!this.storagePath || !existsSync(this.storagePath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "plugins/host.ts",
-			"line": 330,
-			"api": "readFileSync",
-			"source": "const parsed: unknown = JSON.parse(readFileSync(this.storagePath, \"utf-8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "plugins/host.ts",
-			"line": 353,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dirname(this.storagePath), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "plugins/host.ts",
-			"line": 354,
-			"api": "writeFileSync",
-			"source": "writeFileSync(this.storagePath, `${JSON.stringify(this.store, null, 2)}\\n`, { mode: 0o600 });",
-			"category": "hot-path"
-		},
-		{
-			"path": "plugins/index.ts",
-			"line": 14,
-			"api": "existsSync",
-			"source": "if (existsSync(statePath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "plugins/index.ts",
-			"line": 16,
-			"api": "readFileSync",
-			"source": "const parsed: unknown = JSON.parse(readFileSync(statePath, \"utf-8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "prompt-entity-context.ts",
-			"line": 668,
-			"api": "existsSync",
-			"source": "if (!existsSync(memoryDbPath)) return { lines: [], memories: [], memoryCount: 0, engine: \"no-entity\" };",
-			"category": "hot-path"
-		},
-		{
-			"path": "prompt-entity-context.ts",
-			"line": 671,
-			"api": "withReadDb",
-			"source": "const matches: PromptEntityMatch[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "prompt-entity-context.ts",
-			"line": 697,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 218,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx(fn);",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 289,
-			"api": "withWriteTx",
-			"source": "const result = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 356,
-			"api": "withWriteTx",
-			"source": "const result = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 412,
-			"api": "withReadDb",
-			"source": "const { memCount, ftsCount, ftsMissing, tokenizerDrift } = accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 665,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 707,
-			"api": "withReadDb",
-			"source": "const migration = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 711,
-			"api": "withReadDb",
-			"source": "const orphaned = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => countOrphanedEmbeddings(db, agentId));",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 744,
-			"api": "withReadDb",
-			"source": "const unembedded = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 788,
-			"api": "withWriteTx",
-			"source": "const writeOutcome = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 1041,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 1093,
-			"api": "withReadDb",
-			"source": "accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => ({",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 1164,
-			"api": "withWriteTx",
-			"source": "const writeOutcome = accessor.withWriteTx(",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 1298,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 1351,
-			"api": "withWriteTx",
-			"source": "const affected = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 1433,
-			"api": "withWriteTx",
-			"source": "const stats: VecResyncStats = accessor.withWriteTx((db): VecResyncStats => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 1546,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 1732,
-			"api": "withReadDb",
-			"source": "const hashClusters: Array<{ content_hash: string; scope_key: string; cnt: number }> = accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 1776,
-			"api": "withWriteTx",
-			"source": "const removed = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 1807,
-			"api": "withWriteTx",
-			"source": "const removed = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 1868,
-			"api": "withReadDb",
-			"source": "const candidates = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 1886,
-			"api": "withReadDb",
-			"source": "const neighbors = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 1956,
-			"api": "withReadDb",
-			"source": "const total = accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 1971,
-			"api": "withWriteTx",
-			"source": "const affected = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 2014,
-			"api": "withReadDb",
-			"source": "const candidates = accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 2056,
-			"api": "withWriteTx",
-			"source": "const affected = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 2144,
-			"api": "withReadDb",
-			"source": "accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 2192,
-			"api": "withWriteTx",
-			"source": "const affected = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 2295,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 2342,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 2588,
-			"api": "withWriteTx",
-			"source": "const result = accessor.withWriteTx<CancelResultMeta>((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "repair-actions.ts",
-			"line": 2723,
-			"api": "withWriteTx",
-			"source": "const result = accessor.withWriteTx<PruneResultMeta>((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "resource-monitor.ts",
-			"line": 228,
-			"api": "readdirSync",
-			"source": "const entries = readdirSync(fdDir);",
-			"category": "hot-path"
-		},
-		{
-			"path": "resource-monitor.ts",
-			"line": 233,
-			"api": "readlinkSync",
-			"source": "const target = readlinkSync(join(fdDir, fd));",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/app-tray.ts",
-			"line": 122,
-			"api": "writeFileSync",
-			"source": "writeFileSync(join(getMarketplaceDir(), \"app-tray.json\"), JSON.stringify([...fresh, ...toAdd], null, 2));",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/app-tray.ts",
-			"line": 227,
-			"api": "writeFileSync",
-			"source": "writeFileSync(trayPath, JSON.stringify(tray, null, 2));",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/app-tray.ts",
-			"line": 315,
-			"api": "writeFileSync",
-			"source": "writeFileSync(trayPath, JSON.stringify(tray, null, 2));",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/app-tray.ts",
-			"line": 347,
-			"api": "existsSync",
-			"source": "if (!existsSync(dir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/app-tray.ts",
-			"line": 348,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dir, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/app-tray.ts",
-			"line": 415,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/app-tray.ts",
-			"line": 417,
-			"api": "readFileSync",
-			"source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/app-tray.ts",
-			"line": 427,
-			"api": "writeFileSync",
-			"source": "writeFileSync(getInstalledMcpPath(), JSON.stringify(servers, null, 2));",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/changelog.ts",
-			"line": 192,
-			"api": "existsSync",
-			"source": "if (existsSync(localPath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/changelog.ts",
-			"line": 194,
-			"api": "readFileSync",
-			"source": "raw = readFileSync(localPath, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/connectors-routes.ts",
-			"line": 277,
-			"api": "withReadDb",
-			"source": "const docs = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/connectors-routes.ts",
-			"line": 288,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/connectors-routes.ts",
-			"line": 319,
-			"api": "withReadDb",
-			"source": "const docCount = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/connectors-routes.ts",
-			"line": 352,
-			"api": "existsSync",
-			"source": "exists: existsSync(join(homedir(), \".claude\", \"settings.json\")),",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/connectors-routes.ts",
-			"line": 358,
-			"api": "existsSync",
-			"source": "exists: existsSync(join(homedir(), \".config\", \"opencode\", \"AGENTS.md\")),",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/connectors-routes.ts",
-			"line": 364,
-			"api": "existsSync",
-			"source": "exists: existsSync(join(AGENTS_DIR, \"AGENTS.md\")),",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/connectors-routes.ts",
-			"line": 370,
-			"api": "existsSync",
-			"source": "exists: existsSync(join(homedir(), \".gemini\", \"settings.json\")),",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/connectors-routes.ts",
-			"line": 389,
-			"api": "existsSync",
-			"source": "if (!existsSync(script)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/dashboard-identity.ts",
-			"line": 31,
-			"api": "existsSync",
-			"source": "if (existsSync(agentYaml)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/dashboard-identity.ts",
-			"line": 33,
-			"api": "readFileSync",
-			"source": "const config = parseSimpleYaml(readFileSync(agentYaml, \"utf-8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/dashboard-identity.ts",
-			"line": 45,
-			"api": "existsSync",
-			"source": "if (existsSync(identityMd)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/dashboard-identity.ts",
-			"line": 47,
-			"api": "readFileSync",
-			"source": "const content = readFileSync(identityMd, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/dashboard.ts",
-			"line": 28,
-			"api": "existsSync",
-			"source": "if (existsSync(join(candidate, \"index.html\"))) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/database-diagnostics.ts",
-			"line": 241,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/database-diagnostics.ts",
-			"line": 276,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/git-config.ts",
-			"line": 77,
-			"api": "existsSync",
-			"source": "if (!existsSync(p)) continue;",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/git-config.ts",
-			"line": 79,
-			"api": "readFileSync",
-			"source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/git-sync.ts",
-			"line": 50,
-			"api": "existsSync",
-			"source": "let gitRepoProbe = (dir: string): boolean => existsSync(join(dir, \".git\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/git-sync.ts",
-			"line": 812,
-			"api": "existsSync",
-			"source": "const existingContent = existsSync(gitignorePath) ? readFileSync(gitignorePath, \"utf-8\") : \"\";",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/git-sync.ts",
-			"line": 812,
-			"api": "readFileSync",
-			"source": "const existingContent = existsSync(gitignorePath) ? readFileSync(gitignorePath, \"utf-8\") : \"\";",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/git-sync.ts",
-			"line": 815,
-			"api": "writeFileSync",
-			"source": "writeFileSync(gitignorePath, nextContent, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/git-sync.ts",
-			"line": 871,
-			"api": "existsSync",
-			"source": "if (parent !== absolute && existsSync(parent)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/git-sync.ts",
-			"line": 1019,
-			"api": "existsSync",
-			"source": "gitRepoProbe = probe ?? ((dir: string): boolean => existsSync(join(dir, \".git\")));",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/graphiq-install-path.ts",
-			"line": 8,
-			"api": "existsSync",
-			"source": "if (existsSync(bundled)) return bundled;",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/graphiq-routes.ts",
-			"line": 97,
-			"api": "existsSync",
-			"source": "if (!existsSync(resolved)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/graphiq-routes.ts",
-			"line": 102,
-			"api": "statSync",
-			"source": "projectStat = statSync(resolved);",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/graphiq-routes.ts",
-			"line": 110,
-			"api": "accessSync",
-			"source": "accessSync(resolved, constants.R_OK | constants.X_OK);",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/graphiq-routes.ts",
-			"line": 161,
-			"api": "existsSync",
-			"source": "if (!existsSync(script)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/graphiq-routes.ts",
-			"line": 182,
-			"api": "existsSync",
-			"source": "if (!existsSync(script)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/graphiq-routes.ts",
-			"line": 204,
-			"api": "accessSync",
-			"source": "accessSync(path, constants.X_OK);",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/graphiq-routes.ts",
-			"line": 228,
-			"api": "existsSync",
-			"source": "if (!existsSync(manifestPath)) continue;",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/graphiq-routes.ts",
-			"line": 230,
-			"api": "readFileSync",
-			"source": "const raw = JSON.parse(readFileSync(manifestPath, \"utf-8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/health.ts",
-			"line": 187,
-			"api": "withReadDb",
-			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/health.ts",
-			"line": 236,
-			"api": "withReadDb",
-			"source": "dbResult = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/hooks-routes.ts",
-			"line": 1148,
-			"api": "existsSync",
-			"source": "if (!existsSync(getCurrentMemoryDbPath())) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/hooks-routes.ts",
-			"line": 1163,
-			"api": "withReadDb",
-			"source": "getDbAccessor().withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/hooks-routes.ts",
-			"line": 1191,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/hooks-routes.ts",
-			"line": 1311,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/import-routes.ts",
-			"line": 212,
-			"api": "withWriteTx",
-			"source": "const extraction = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/import-routes.ts",
-			"line": 252,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/import-routes.ts",
-			"line": 337,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace-helpers.ts",
-			"line": 35,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace-helpers.ts",
-			"line": 38,
-			"api": "readFileSync",
-			"source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace-reviews.ts",
-			"line": 62,
-			"api": "existsSync",
-			"source": "if (!existsSync(dir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace-reviews.ts",
-			"line": 63,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dir, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace-reviews.ts",
-			"line": 127,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace-reviews.ts",
-			"line": 129,
-			"api": "readFileSync",
-			"source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace-reviews.ts",
-			"line": 139,
-			"api": "writeFileSync",
-			"source": "writeFileSync(getReviewsPath(), JSON.stringify(reviews, null, 2), \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace-reviews.ts",
-			"line": 144,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return DEFAULT_CONFIG;",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace-reviews.ts",
-			"line": 146,
-			"api": "readFileSync",
-			"source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace-reviews.ts",
-			"line": 162,
-			"api": "writeFileSync",
-			"source": "writeFileSync(getReviewsConfigPath(), JSON.stringify(config, null, 2), \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace.ts",
-			"line": 176,
-			"api": "existsSync",
-			"source": "if (!existsSync(dir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace.ts",
-			"line": 177,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dir, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace.ts",
-			"line": 323,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace.ts",
-			"line": 328,
-			"api": "statSync",
-			"source": "const mtime = statSync(path).mtime.toISOString();",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace.ts",
-			"line": 329,
-			"api": "readFileSync",
-			"source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace.ts",
-			"line": 338,
-			"api": "writeFileSync",
-			"source": "writeFileSync(getExposurePolicyPath(), JSON.stringify(policy, null, 2));",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace.ts",
-			"line": 807,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace.ts",
-			"line": 810,
-			"api": "readFileSync",
-			"source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace.ts",
-			"line": 822,
-			"api": "writeFileSync",
-			"source": "writeFileSync(getInstalledMcpPath(), JSON.stringify(servers, null, 2));",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/marketplace.ts",
-			"line": 1128,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/mcp-analytics.ts",
-			"line": 89,
-			"api": "withReadDb",
-			"source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/mcp-analytics.ts",
-			"line": 171,
-			"api": "withReadDb",
-			"source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/memory-routes.ts",
-			"line": 278,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dir, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/memory-routes.ts",
-			"line": 294,
-			"api": "writeFileSync",
-			"source": "writeFileSync(path, noteContent, { encoding: \"utf-8\", flag: \"wx\" });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/misc-routes.ts",
-			"line": 120,
-			"api": "readdirSync",
-			"source": "const dirFiles = readdirSync(AGENTS_DIR);",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/misc-routes.ts",
-			"line": 125,
-			"api": "statSync",
-			"source": "const fileStat = statSync(filePath);",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/misc-routes.ts",
-			"line": 127,
-			"api": "readFileSync",
-			"source": "const content = readFileSync(filePath, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/misc-routes.ts",
-			"line": 188,
-			"api": "writeFileSync",
-			"source": "writeFileSync(filePath, content, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/pipeline-routes.ts",
-			"line": 102,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/pipeline-routes.ts",
-			"line": 296,
-			"api": "existsSync",
-			"source": "if (existsSync(p)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/pipeline-routes.ts",
-			"line": 297,
-			"api": "readFileSync",
-			"source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/pipeline-routes.ts",
-			"line": 341,
-			"api": "existsSync",
-			"source": "memoryDb: existsSync(MEMORY_DB),",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/pipeline-routes.ts",
-			"line": 392,
-			"api": "readFileSync",
-			"source": "soulContent = readFileSync(soulPath, \"utf-8\").slice(0, 500);",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/pipeline-routes.ts",
-			"line": 457,
-			"api": "withReadDb",
-			"source": "const report: ReturnType<typeof listMemoryContentSafety> = getDbAccessor().withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/pipeline-routes.ts",
-			"line": 557,
-			"api": "withReadDb",
-			"source": "const dbData = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/queue-diagnostics.ts",
-			"line": 169,
-			"api": "withReadDb",
-			"source": "const response = resolveAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/reflection-routes.ts",
-			"line": 98,
-			"api": "withReadDb",
-			"source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/reflection-routes.ts",
-			"line": 118,
-			"api": "withReadDb",
-			"source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/reflection-routes.ts",
-			"line": 172,
-			"api": "withReadDb",
-			"source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/reflection-routes.ts",
-			"line": 207,
-			"api": "withReadDb",
-			"source": "const existing = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/reflection-routes.ts",
-			"line": 225,
-			"api": "withWriteTx",
-			"source": "resolveDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/repair-routes.ts",
-			"line": 313,
-			"api": "withReadDb",
-			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/repair-routes.ts",
-			"line": 357,
-			"api": "withWriteTx",
-			"source": "const result = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => clusterEntities(db, agentId));",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/repair-routes.ts",
-			"line": 378,
-			"api": "withReadDb",
-			"source": "const unlinked = accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/repair-routes.ts",
-			"line": 408,
-			"api": "withReadDb",
-			"source": "const preview = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/repair-routes.ts",
-			"line": 459,
-			"api": "withWriteTx",
-			"source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/repair-routes.ts",
-			"line": 469,
-			"api": "withReadDb",
-			"source": "const remaining = accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/repair-routes.ts",
-			"line": 512,
-			"api": "withReadDb",
-			"source": "const unhinted = accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/repair-routes.ts",
-			"line": 537,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/repair-routes.ts",
-			"line": 545,
-			"api": "withReadDb",
-			"source": "const remaining = accessor.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/repair-routes.ts",
-			"line": 585,
-			"api": "withReadDb",
-			"source": "const dead = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/session-routes.ts",
-			"line": 168,
-			"api": "withReadDb",
-			"source": "const hits = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/session-routes.ts",
-			"line": 347,
-			"api": "withReadDb",
-			"source": "const tableExists = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/session-routes.ts",
-			"line": 355,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skill-analytics.ts",
-			"line": 121,
-			"api": "withReadDb",
-			"source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 221,
-			"api": "existsSync",
-			"source": "if (!existsSync(getSkillsDir())) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 223,
-			"api": "readdirSync",
-			"source": "return readdirSync(getSkillsDir(), { withFileTypes: true })",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 227,
-			"api": "existsSync",
-			"source": "if (!existsSync(skillMdPath)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 229,
-			"api": "readFileSync",
-			"source": "const content = readFileSync(skillMdPath, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 364,
-			"api": "existsSync",
-			"source": "if (process.env.SIGNET_SKILLS_SOURCE && existsSync(process.env.SIGNET_SKILLS_SOURCE)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 369,
-			"api": "existsSync",
-			"source": "if (existsSync(devPath)) return devPath;",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 372,
-			"api": "existsSync",
-			"source": "if (existsSync(distPath)) return distPath;",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 374,
-			"api": "existsSync",
-			"source": "if (existsSync(distPath2)) return distPath2;",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 380,
-			"api": "existsSync",
-			"source": "if (!sourceDir || !existsSync(sourceDir)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 384,
-			"api": "readdirSync",
-			"source": "return readdirSync(sourceDir, { withFileTypes: true })",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 388,
-			"api": "existsSync",
-			"source": "if (!existsSync(skillMdPath)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 390,
-			"api": "readFileSync",
-			"source": "const content = readFileSync(skillMdPath, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 510,
-			"api": "existsSync",
-			"source": "if (!existsSync(skillMd)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 513,
-			"api": "lstatSync",
-			"source": "if (!lstatSync(skillMd).isFile()) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 521,
-			"api": "readdirSync",
-			"source": "for (const entry of readdirSync(dir, { withFileTypes: true })) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 636,
-			"api": "mkdirSync",
-			"source": "mkdirSync(target, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 641,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dirname(target), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 715,
-			"api": "rmSync",
-			"source": "rmSync(stagingDir, { recursive: true, force: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 716,
-			"api": "rmSync",
-			"source": "rmSync(backupDir, { recursive: true, force: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 718,
-			"api": "existsSync",
-			"source": "if (existsSync(targetDir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 719,
-			"api": "renameSync",
-			"source": "renameSync(targetDir, backupDir);",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 722,
-			"api": "renameSync",
-			"source": "renameSync(stagingDir, targetDir);",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 723,
-			"api": "rmSync",
-			"source": "rmSync(backupDir, { recursive: true, force: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 725,
-			"api": "rmSync",
-			"source": "rmSync(stagingDir, { recursive: true, force: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 726,
-			"api": "existsSync",
-			"source": "if (movedTarget && existsSync(backupDir) && !existsSync(targetDir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 726,
-			"api": "existsSync",
-			"source": "if (movedTarget && existsSync(backupDir) && !existsSync(targetDir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 727,
-			"api": "renameSync",
-			"source": "renameSync(backupDir, targetDir);",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 729,
-			"api": "rmSync",
-			"source": "rmSync(backupDir, { recursive: true, force: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 759,
-			"api": "mkdirSync",
-			"source": "mkdirSync(extractDir, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 770,
-			"api": "mkdirSync",
-			"source": "mkdirSync(getSkillsDir(), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 783,
-			"api": "rmSync",
-			"source": "rmSync(tempRoot, { recursive: true, force: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 1011,
-			"api": "existsSync",
-			"source": "if (existsSync(skillMdPath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 1013,
-			"api": "readFileSync",
-			"source": "const content = readFileSync(skillMdPath, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 1031,
-			"api": "existsSync",
-			"source": "if (existsSync(signetSkillPath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 1033,
-			"api": "readFileSync",
-			"source": "const content = readFileSync(signetSkillPath, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 1188,
-			"api": "existsSync",
-			"source": "if (!existsSync(skillDir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/skills.ts",
-			"line": 1195,
-			"api": "rmSync",
-			"source": "rmSync(skillDir, { recursive: true, force: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/sources-routes.ts",
-			"line": 711,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/sources-routes.ts",
-			"line": 713,
-			"api": "readFileSync",
-			"source": "const parsed = JSON.parse(readFileSync(path, \"utf8\")) as unknown;",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/sources-routes.ts",
-			"line": 723,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dirname(path), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/sources-routes.ts",
-			"line": 725,
-			"api": "writeFileSync",
-			"source": "writeFileSync(tmp, `${JSON.stringify(tombstones, null, 2)}\\n`, \"utf8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/sources-routes.ts",
-			"line": 726,
-			"api": "renameSync",
-			"source": "renameSync(tmp, path);",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/sources-routes.ts",
-			"line": 797,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/sources-routes.ts",
-			"line": 936,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/sources-routes.ts",
-			"line": 1048,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/sources-routes.ts",
-			"line": 1111,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/sources-routes.ts",
-			"line": 1150,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/state.ts",
-			"line": 157,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) continue;",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/state.ts",
-			"line": 159,
-			"api": "readFileSync",
-			"source": "return resolveNetworkBinding(readNetworkMode(parseSimpleYaml(readFileSync(path, \"utf-8\"))));",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/state.ts",
-			"line": 384,
-			"api": "existsSync",
-			"source": "if (!existsSync(candidate)) continue;",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/state.ts",
-			"line": 386,
-			"api": "readFileSync",
-			"source": "const raw = readFileSync(candidate, \"utf8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/state.ts",
-			"line": 457,
-			"api": "withReadDb",
-			"source": "const report = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/telemetry-routes.ts",
-			"line": 200,
-			"api": "withReadDb",
-			"source": "const mutationHealth = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/telemetry-routes.ts",
-			"line": 219,
-			"api": "withReadDb",
-			"source": "const scores: Array<Record<string, unknown>> = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/telemetry-routes.ts",
-			"line": 263,
-			"api": "withReadDb",
-			"source": "getDbAccessor().withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/utils.ts",
-			"line": 437,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/utils.ts",
-			"line": 525,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/widget.ts",
-			"line": 75,
-			"api": "existsSync",
-			"source": "if (existsSync(path)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "routes/widget.ts",
-			"line": 76,
-			"api": "statSync",
-			"source": "const stat = statSync(path);",
-			"category": "hot-path"
-		},
-		{
-			"path": "scheduler/skill-resolver.ts",
-			"line": 42,
-			"api": "readFileSync",
-			"source": "const raw = readFileSync(skillPath, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "scheduler/worker.ts",
-			"line": 104,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "scheduler/worker.ts",
-			"line": 122,
-			"api": "withReadDb",
-			"source": "const dueTasks = db.withReadDb((rdb: import(\"../db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "scheduler/worker.ts",
-			"line": 193,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "scheduler/worker.ts",
-			"line": 280,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 190,
-			"api": "readFileSync",
-			"source": "const id = readFileSync(p, \"utf-8\").trim();",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 199,
-			"api": "execSync",
-			"source": "const out = execSync(\"ioreg -rd1 -c IOPlatformExpertDevice | grep IOPlatformUUID | awk '{print $3}'\", {",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 212,
-			"api": "execSync",
-			"source": "const out = execSync('reg query \"HKLM\\\\SOFTWARE\\\\Microsoft\\\\Cryptography\" /v MachineGuid', {",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 235,
-			"api": "readFileSync",
-			"source": "const persisted = readFileSync(getMachineIdFile(), \"utf-8\").trim();",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 248,
-			"api": "mkdirSync",
-			"source": "mkdirSync(getSecretsDir(), { recursive: true, mode: 0o700 });",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 250,
-			"api": "writeFileSync",
-			"source": "writeFileSync(file, `${machineId}\\n`, { encoding: \"utf-8\", mode: 0o600, flag: \"wx\" });",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 299,
-			"api": "existsSync",
-			"source": "if (!existsSync(getSecretsFile())) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 373,
-			"api": "existsSync",
-			"source": "existsSync(getMachineIdFile()) ||",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 374,
-			"api": "existsSync",
-			"source": "!existsSync(getSecretsFile())",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 430,
-			"api": "readdirSync",
-			"source": "names = readdirSync(dir);",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 438,
-			"api": "unlinkSync",
-			"source": "unlinkSync(join(dir, name));",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 448,
-			"api": "existsSync",
-			"source": "if (!existsSync(file)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 452,
-			"api": "readFileSync",
-			"source": "return parseSecretsStore(JSON.parse(readFileSync(file, \"utf-8\")));",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 471,
-			"api": "mkdirSync",
-			"source": "mkdirSync(getSecretsDir(), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 476,
-			"api": "writeFileSync",
-			"source": "writeFileSync(fd, JSON.stringify(store, null, 2), \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 482,
-			"api": "renameSync",
-			"source": "renameSync(tmp, file);",
-			"category": "hot-path"
-		},
-		{
-			"path": "secrets.ts",
-			"line": 492,
-			"api": "unlinkSync",
-			"source": "unlinkSync(tmp);",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 93,
-			"api": "existsSync",
-			"source": "if (existsSync(candidate)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 108,
-			"api": "execSync",
-			"source": "execSync(`${locator} bun`, { encoding: \"utf-8\", windowsHide: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 145,
-			"api": "mkdirSync",
-			"source": "mkdirSync(plistDir, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 146,
-			"api": "mkdirSync",
-			"source": "mkdirSync(LOG_DIR, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 150,
-			"api": "execSync",
-			"source": "execSync(`launchctl unload \"${LAUNCHD_PLIST}\" 2>/dev/null`);",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 156,
-			"api": "writeFileSync",
-			"source": "writeFileSync(LAUNCHD_PLIST, generateLaunchdPlist(port));",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 159,
-			"api": "execSync",
-			"source": "execSync(`launchctl load \"${LAUNCHD_PLIST}\"`);",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 163,
-			"api": "existsSync",
-			"source": "if (!existsSync(LAUNCHD_PLIST)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 168,
-			"api": "execSync",
-			"source": "execSync(`launchctl unload \"${LAUNCHD_PLIST}\"`);",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 173,
-			"api": "unlinkSync",
-			"source": "unlinkSync(LAUNCHD_PLIST);",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 178,
-			"api": "execSync",
-			"source": "const output = execSync(\"launchctl list ai.signet.daemon 2>/dev/null\", {",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 194,
-			"api": "existsSync",
-			"source": "if (execPath && existsSync(execPath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 199,
-			"api": "execSync",
-			"source": "return execSync(`${locator} bun`, { encoding: \"utf-8\", windowsHide: true }).trim().split(/\\r?\\n/)[0];",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 202,
-			"api": "execSync",
-			"source": "return execSync(`${locator} node`, { encoding: \"utf-8\", windowsHide: true }).trim().split(/\\r?\\n/)[0];",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 236,
-			"api": "mkdirSync",
-			"source": "mkdirSync(unitDir, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 237,
-			"api": "mkdirSync",
-			"source": "mkdirSync(LOG_DIR, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 241,
-			"api": "execSync",
-			"source": "execSync(\"systemctl --user stop signet.service 2>/dev/null\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 247,
-			"api": "writeFileSync",
-			"source": "writeFileSync(SYSTEMD_UNIT, generateSystemdUnit(port));",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 250,
-			"api": "execSync",
-			"source": "execSync(\"systemctl --user daemon-reload\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 253,
-			"api": "execSync",
-			"source": "execSync(\"systemctl --user enable signet.service\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 254,
-			"api": "execSync",
-			"source": "execSync(\"systemctl --user start signet.service\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 259,
-			"api": "execSync",
-			"source": "execSync(\"systemctl --user stop signet.service 2>/dev/null\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 260,
-			"api": "execSync",
-			"source": "execSync(\"systemctl --user disable signet.service 2>/dev/null\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 265,
-			"api": "existsSync",
-			"source": "if (existsSync(SYSTEMD_UNIT)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 266,
-			"api": "unlinkSync",
-			"source": "unlinkSync(SYSTEMD_UNIT);",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 270,
-			"api": "execSync",
-			"source": "execSync(\"systemctl --user daemon-reload\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 278,
-			"api": "execSync",
-			"source": "const output = execSync(\"systemctl --user is-active signet.service 2>/dev/null\", { encoding: \"utf-8\" });",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 290,
-			"api": "mkdirSync",
-			"source": "mkdirSync(DAEMON_DIR, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 291,
-			"api": "mkdirSync",
-			"source": "mkdirSync(LOG_DIR, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 316,
-			"api": "existsSync",
-			"source": "if (!existsSync(PID_FILE)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 320,
-			"api": "readFileSync",
-			"source": "const pid = parseInt(readFileSync(PID_FILE, \"utf-8\").trim(), 10);",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 330,
-			"api": "unlinkSync",
-			"source": "unlinkSync(PID_FILE);",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 337,
-			"api": "existsSync",
-			"source": "if (!existsSync(PID_FILE)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 341,
-			"api": "readFileSync",
-			"source": "const pid = parseInt(readFileSync(PID_FILE, \"utf-8\").trim(), 10);",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 349,
-			"api": "unlinkSync",
-			"source": "unlinkSync(PID_FILE);",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 399,
-			"api": "existsSync",
-			"source": "if (os === \"darwin\" && existsSync(LAUNCHD_PLIST)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 400,
-			"api": "execSync",
-			"source": "execSync(`launchctl load \"${LAUNCHD_PLIST}\"`);",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 401,
-			"api": "existsSync",
-			"source": "} else if (os === \"linux\" && existsSync(SYSTEMD_UNIT)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 402,
-			"api": "execSync",
-			"source": "execSync(\"systemctl --user start signet.service\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 414,
-			"api": "existsSync",
-			"source": "if (os === \"darwin\" && existsSync(LAUNCHD_PLIST)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 416,
-			"api": "execSync",
-			"source": "execSync(`launchctl unload \"${LAUNCHD_PLIST}\"`);",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 420,
-			"api": "existsSync",
-			"source": "} else if (os === \"linux\" && existsSync(SYSTEMD_UNIT)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 422,
-			"api": "execSync",
-			"source": "execSync(\"systemctl --user stop signet.service\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 446,
-			"api": "existsSync",
-			"source": "if (os === \"darwin\" && existsSync(LAUNCHD_PLIST)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 448,
-			"api": "existsSync",
-			"source": "} else if (os === \"linux\" && existsSync(SYSTEMD_UNIT)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 462,
-			"api": "existsSync",
-			"source": "return existsSync(LAUNCHD_PLIST);",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 464,
-			"api": "existsSync",
-			"source": "return existsSync(SYSTEMD_UNIT);",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 467,
-			"api": "existsSync",
-			"source": "return existsSync(PID_FILE);",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 484,
-			"api": "existsSync",
-			"source": "if (running && existsSync(PID_FILE)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 486,
-			"api": "readFileSync",
-			"source": "pid = parseInt(readFileSync(PID_FILE, \"utf-8\").trim(), 10);",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 515,
-			"api": "existsSync",
-			"source": "if (!existsSync(logFile)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 518,
-			"api": "existsSync",
-			"source": "if (existsSync(outLog)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 519,
-			"api": "readFileSync",
-			"source": "const content = readFileSync(outLog, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "service.ts",
-			"line": 525,
-			"api": "readFileSync",
-			"source": "const content = readFileSync(logFile, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-checkpoints.ts",
-			"line": 109,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((wdb: WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-checkpoints.ts",
-			"line": 226,
-			"api": "withReadDb",
-			"source": "return db.withReadDb((rdb: ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-checkpoints.ts",
-			"line": 243,
-			"api": "withReadDb",
-			"source": "return db.withReadDb((rdb: ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-checkpoints.ts",
-			"line": 259,
-			"api": "withReadDb",
-			"source": "return db.withReadDb((rdb: ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-checkpoints.ts",
-			"line": 277,
-			"api": "withReadDb",
-			"source": "return db.withReadDb((rdb: ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-checkpoints.ts",
-			"line": 301,
-			"api": "withWriteTx",
-			"source": "return db.withWriteTx((wdb: WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-claims.ts",
-			"line": 64,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-claims.ts",
-			"line": 82,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-claims.ts",
-			"line": 92,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-claims.ts",
-			"line": 119,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-claims.ts",
-			"line": 125,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb(readClaims);",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-end-recovery.ts",
-			"line": 106,
-			"api": "withWriteTx",
-			"source": "const result = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-memories.ts",
-			"line": 55,
-			"api": "existsSync",
-			"source": "if (!sessionKey || candidates.length === 0 || !existsSync(getMemoryDbPath())) return;",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-memories.ts",
-			"line": 59,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-memories.ts",
-			"line": 148,
-			"api": "existsSync",
-			"source": "if (!sessionKey || matchedIds.length === 0 || !existsSync(getMemoryDbPath())) return;",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-memories.ts",
-			"line": 153,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-memories.ts",
-			"line": 262,
-			"api": "existsSync",
-			"source": "if (!sessionKey || Object.keys(feedback).length === 0 || !existsSync(getMemoryDbPath())) return;",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-memories.ts",
-			"line": 268,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-recall-dedupe.ts",
-			"line": 149,
-			"api": "withWriteTx",
-			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-recall-dedupe.ts",
-			"line": 244,
-			"api": "withWriteTx",
-			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 103,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => tableExistsInDatabase(db, name));",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 112,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 152,
-			"api": "existsSync",
-			"source": "if (!existsSync(memoryDir)) return 0;",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 158,
-			"api": "readdirSync",
-			"source": "const files = readdirSync(memoryDir).filter((name) => name.endsWith(\"--transcript.md\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 162,
-			"api": "readFileSync",
-			"source": "const parsed = parseArtifactFrontmatter(readFileSync(path, \"utf8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 248,
-			"api": "withReadDb",
-			"source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 331,
-			"api": "readFileSync",
-			"source": "const parsed = JSON.parse(readFileSync(path, \"utf8\")) as { readonly agent_id?: unknown };",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 347,
-			"api": "existsSync",
-			"source": "if (existsSync(markerPath) && markerMatches(markerPath, agentId)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 371,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dirname(markerPath), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 372,
-			"api": "writeFileSync",
-			"source": "writeFileSync(",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 392,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 446,
-			"api": "withWriteTx",
-			"source": "return (accessor ?? getDbAccessor()).withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 561,
-			"api": "withWriteTx",
-			"source": "return (accessor ?? getDbAccessor()).withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 595,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 641,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 680,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 735,
-			"api": "withReadDb",
-			"source": "const exactRows: TranscriptRow[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 780,
-			"api": "withReadDb",
-			"source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-transcripts.ts",
-			"line": 844,
-			"api": "withReadDb",
-			"source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-ttl-finalizer.ts",
-			"line": 79,
-			"api": "withReadDb",
-			"source": "const alreadyCompleted = deps.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "session-ttl-finalizer.ts",
-			"line": 92,
-			"api": "withWriteTx",
-			"source": "deps.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "single-instance-lock.ts",
-			"line": 28,
-			"api": "readFileSync",
-			"source": "const pid = Number.parseInt(readFileSync(path, \"utf8\").trim().split(/\\s+/)[0] ?? \"\", 10);",
-			"category": "hot-path"
-		},
-		{
-			"path": "single-instance-lock.ts",
-			"line": 40,
-			"api": "statSync",
-			"source": "return Date.now() - statSync(path).mtimeMs > STALE_LOCK_AGE_MS;",
-			"category": "hot-path"
-		},
-		{
-			"path": "single-instance-lock.ts",
-			"line": 49,
-			"api": "renameSync",
-			"source": "renameSync(path, stalePath);",
-			"category": "hot-path"
-		},
-		{
-			"path": "single-instance-lock.ts",
-			"line": 55,
-			"api": "unlinkSync",
-			"source": "unlinkSync(stalePath);",
-			"category": "hot-path"
-		},
-		{
-			"path": "single-instance-lock.ts",
-			"line": 63,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dirname(path), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "single-instance-lock.ts",
-			"line": 69,
-			"api": "writeFileSync",
-			"source": "writeFileSync(fd, `${process.pid}\\n${Date.now()}\\n`);",
-			"category": "hot-path"
-		},
-		{
-			"path": "single-instance-lock.ts",
-			"line": 73,
-			"api": "unlinkSync",
-			"source": "unlinkSync(path);",
-			"category": "hot-path"
-		},
-		{
-			"path": "single-instance-lock.ts",
-			"line": 91,
-			"api": "unlinkSync",
-			"source": "unlinkSync(lock.path);",
-			"category": "hot-path"
-		},
-		{
-			"path": "skill-invocations.ts",
-			"line": 50,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "skill-transcript-scan.ts",
-			"line": 19,
-			"api": "statSync",
-			"source": "const stat = statSync(args.transcriptPath);",
-			"category": "hot-path"
-		},
-		{
-			"path": "skill-transcript-scan.ts",
-			"line": 32,
-			"api": "readFileSync",
-			"source": "content = readFileSync(args.transcriptPath, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "source-artifact-graph.ts",
-			"line": 304,
-			"api": "withWriteTx",
-			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "source-artifact-graph.ts",
-			"line": 314,
-			"api": "withWriteTx",
-			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "source-lifecycle-telemetry.ts",
-			"line": 260,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "source-lifecycle-telemetry.ts",
-			"line": 296,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "source-lifecycle-telemetry.ts",
-			"line": 327,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "source-lifecycle-telemetry.ts",
-			"line": 383,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "source-lifecycle-telemetry.ts",
-			"line": 502,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "source-lifecycle-telemetry.ts",
-			"line": 543,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "source-lifecycle-telemetry.ts",
-			"line": 576,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "source-lifecycle-telemetry.ts",
-			"line": 591,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "source-purge.ts",
-			"line": 23,
-			"api": "withWriteTx",
-			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "source-snapshots.ts",
-			"line": 104,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "source-snapshots.ts",
-			"line": 179,
-			"api": "withWriteTx",
-			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "startup-recovery.ts",
-			"line": 56,
-			"api": "withReadDb",
-			"source": "const batch = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => fetchBatch(db, limit));",
-			"category": "hot-path"
-		},
-		{
-			"path": "startup-recovery.ts",
-			"line": 59,
-			"api": "withWriteTx",
-			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => processBatch(db, batch));",
-			"category": "hot-path"
-		},
-		{
-			"path": "startup-recovery.ts",
-			"line": 102,
-			"api": "withWriteTx",
-			"source": "documentLeasesRecovered = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "startup-recovery.ts",
-			"line": 170,
-			"api": "withReadDb",
-			"source": "const migrationInProgress = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "startup-recovery.ts",
-			"line": 219,
-			"api": "withWriteTx",
-			"source": "orphanedPassesSwept = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 492,
-			"api": "withWriteTx",
-			"source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 532,
-			"api": "withWriteTx",
-			"source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 797,
-			"api": "withReadDb",
-			"source": "const row = db.withReadDb(",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 879,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 926,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 982,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 1014,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 1034,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 1064,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 1085,
-			"api": "withWriteTx",
-			"source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 1133,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 1155,
-			"api": "withReadDb",
-			"source": "db.withReadDb((r) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 1474,
-			"api": "withWriteTx",
-			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "telemetry.ts",
-			"line": 1486,
-			"api": "withReadDb",
-			"source": "return db.withReadDb((r) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "temporal-expand.ts",
-			"line": 178,
-			"api": "withReadDb",
-			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "temporal-fallback.ts",
-			"line": 36,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => tableExistsIn(db, name));",
-			"category": "hot-path"
-		},
-		{
-			"path": "temporal-fallback.ts",
-			"line": 150,
-			"api": "withReadDb",
-			"source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "temporal-fallback.ts",
-			"line": 206,
-			"api": "withReadDb",
-			"source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "temporal-recall.ts",
-			"line": 442,
-			"api": "withReadDb",
-			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-			"category": "hot-path"
-		},
-		{
-			"path": "test-temp-dir.ts",
-			"line": 31,
-			"api": "rmSync",
-			"source": "rmSync(dir, { recursive: true, force: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "test-temp-dir.ts",
-			"line": 59,
-			"api": "rmSync",
-			"source": "rmSync(dir, { recursive: true, force: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-audit.ts",
-			"line": 58,
-			"api": "existsSync",
-			"source": "if (!existsSync(dir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-audit.ts",
-			"line": 59,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dir, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-audit.ts",
-			"line": 65,
-			"api": "writeFileSync",
-			"source": "writeFileSync(latestPath, content, \"utf8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-audit.ts",
-			"line": 75,
-			"api": "renameSync",
-			"source": "renameSync(latestPath, finalPath);",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-audit.ts",
-			"line": 79,
-			"api": "writeFileSync",
-			"source": "writeFileSync(finalPath, content, \"utf8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-health.ts",
-			"line": 42,
-			"api": "statSync",
-			"source": "return statSync(path).mtime.toISOString();",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-health.ts",
-			"line": 50,
-			"api": "existsSync",
-			"source": "if (!existsSync(root)) return { latestLogs: 0, finalLogs: 0, newestAuditAt: null };",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-health.ts",
-			"line": 55,
-			"api": "readdirSync",
-			"source": "for (const entry of readdirSync(dir, { withFileTypes: true })) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-health.ts",
-			"line": 74,
-			"api": "existsSync",
-			"source": "return rel ? existsSync(join(basePath, rel)) : false;",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-health.ts",
-			"line": 79,
-			"api": "readFileSync",
-			"source": "const body = readFileSync(path, \"utf8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 153,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 155,
-			"api": "readFileSync",
-			"source": "for (const line of readFileSync(path, \"utf8\").split(/\\r?\\n/)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 188,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return [];",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 189,
-			"api": "statSync",
-			"source": "const size = statSync(path).size;",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 205,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dirname(path), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 208,
-			"api": "writeFileSync",
-			"source": "writeFileSync(tmp, body.length > 0 ? `${body}\\n` : \"\", \"utf8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 209,
-			"api": "renameSync",
-			"source": "renameSync(tmp, path);",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 214,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dirname(path), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 215,
-			"api": "appendFileSync",
-			"source": "appendFileSync(",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 231,
-			"api": "readFileSync",
-			"source": "const parsed = JSON.parse(readFileSync(join(path, \"owner.json\"), \"utf8\")) as { readonly pid?: unknown };",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 240,
-			"api": "readFileSync",
-			"source": "const parsed = JSON.parse(readFileSync(join(path, \"owner.json\"), \"utf8\")) as { readonly token?: unknown };",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 260,
-			"api": "statSync",
-			"source": "return now - statSync(path).mtimeMs > LOCK_DEAD_OWNER_STALE_MS;",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 271,
-			"api": "mkdirSync",
-			"source": "mkdirSync(lockPath);",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 272,
-			"api": "writeFileSync",
-			"source": "writeFileSync(",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 285,
-			"api": "rmSync",
-			"source": "rmSync(lockPath, { recursive: true, force: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 295,
-			"api": "readFileSync",
-			"source": "const parsed = JSON.parse(readFileSync(join(lockPath, \"owner.json\"), \"utf8\")) as { readonly token?: unknown };",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 300,
-			"api": "rmSync",
-			"source": "rmSync(lockPath, { recursive: true, force: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 304,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dirname(path), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 372,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return { canonicalKeys, liveOnlyKeys };",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 405,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return false;",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 445,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 446,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dirname(path), { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 448,
-			"api": "writeFileSync",
-			"source": "writeFileSync(path, `${body}\\n`, \"utf8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 493,
-			"api": "renameSync",
-			"source": "renameSync(tmpPath, path);",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 501,
-			"api": "rmSync",
-			"source": "rmSync(tmpPath, { force: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 561,
-			"api": "existsSync",
-			"source": "if (replacements.size === 0 || !existsSync(jsonlPath)) return Promise.resolve(0);",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 648,
-			"api": "renameSync",
-			"source": "renameSync(tmpPath, jsonlPath);",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-jsonl.ts",
-			"line": 661,
-			"api": "rmSync",
-			"source": "rmSync(tmpPath, { force: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-recovery-worker.ts",
-			"line": 266,
-			"api": "withReadDb",
-			"source": "if (dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => unchanged(db, agentId, candidate))) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-recovery-worker.ts",
-			"line": 295,
-			"api": "withWriteTx",
-			"source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-recovery-worker.ts",
-			"line": 304,
-			"api": "withReadDb",
-			"source": "const alreadyCaptured = dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-recovery-worker.ts",
-			"line": 309,
-			"api": "withWriteTx",
-			"source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-recovery-worker.ts",
-			"line": 329,
-			"api": "withWriteTx",
-			"source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "transcript-recovery-worker.ts",
-			"line": 375,
-			"api": "withWriteTx",
-			"source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-			"category": "hot-path"
-		},
-		{
-			"path": "update-system.ts",
-			"line": 321,
-			"api": "existsSync",
-			"source": "if (!existsSync(p)) continue;",
-			"category": "hot-path"
-		},
-		{
-			"path": "update-system.ts",
-			"line": 323,
-			"api": "readFileSync",
-			"source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\"));",
-			"category": "hot-path"
-		},
-		{
-			"path": "update-system.ts",
-			"line": 367,
-			"api": "existsSync",
-			"source": "if (!existsSync(p)) continue;",
-			"category": "hot-path"
-		},
-		{
-			"path": "update-system.ts",
-			"line": 370,
-			"api": "readFileSync",
-			"source": "const current = readFileSync(p, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "update-system.ts",
-			"line": 382,
-			"api": "writeFileSync",
-			"source": "writeFileSync(p, updated);",
-			"category": "hot-path"
-		},
-		{
-			"path": "update-system.ts",
-			"line": 609,
-			"api": "existsSync",
-			"source": "existsSync: (path) => existsSync(path),",
-			"category": "hot-path"
-		},
-		{
-			"path": "update-system.ts",
-			"line": 610,
-			"api": "readFileSync",
-			"source": "readFileSync: (path, encoding) => readFileSync(path, { encoding }),",
-			"category": "hot-path"
-		},
-		{
-			"path": "update-system.ts",
-			"line": 615,
-			"api": "existsSync",
-			"source": "const launcherExists = deps.existsSync(launcherPath);",
-			"category": "hot-path"
-		},
-		{
-			"path": "update-system.ts",
-			"line": 616,
-			"api": "existsSync",
-			"source": "const appImageExists = deps.existsSync(appImagePath);",
-			"category": "hot-path"
-		},
-		{
-			"path": "update-system.ts",
-			"line": 639,
-			"api": "readFileSync",
-			"source": "const launcher = deps.readFileSync(launcherPath, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "update-system.ts",
-			"line": 670,
-			"api": "existsSync",
-			"source": "existsSync: deps.existsSync ?? ((path: string) => existsSync(path)),",
-			"category": "hot-path"
-		},
-		{
-			"path": "update-system.ts",
-			"line": 671,
-			"api": "readFileSync",
-			"source": "readFileSync: deps.readFileSync ?? ((path: string, encoding: BufferEncoding) => readFileSync(path, { encoding })),",
-			"category": "hot-path"
-		},
-		{
-			"path": "update-system.ts",
-			"line": 694,
-			"api": "existsSync",
-			"source": "if (!fsDeps.existsSync(deps.signetCliPath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "update-system.ts",
-			"line": 716,
-			"api": "existsSync",
-			"source": "if (!fsDeps.existsSync(signetBin)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "watcher-ignore.ts",
-			"line": 140,
-			"api": "existsSync",
-			"source": "if (!existsSync(sigignorePath)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "watcher-ignore.ts",
-			"line": 141,
-			"api": "writeFileSync",
-			"source": "writeFileSync(sigignorePath, DEFAULT_SIGNIGNORE_CONTENT, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "watcher-ignore.ts",
-			"line": 155,
-			"api": "statSync",
-			"source": "const stat = statSync(sigignorePath);",
-			"category": "hot-path"
-		},
-		{
-			"path": "watcher-ignore.ts",
-			"line": 158,
-			"api": "readFileSync",
-			"source": "cache = { stamp, patterns: parseSigignore(readFileSync(sigignorePath, \"utf-8\")) };",
-			"category": "hot-path"
-		},
-		{
-			"path": "which.ts",
-			"line": 8,
-			"api": "accessSync",
-			"source": "accessSync(file, constants.X_OK);",
-			"category": "hot-path"
-		},
-		{
-			"path": "which.ts",
-			"line": 9,
-			"api": "statSync",
-			"source": "return statSync(file).isFile();",
-			"category": "hot-path"
-		},
-		{
-			"path": "widget-gen.ts",
-			"line": 36,
-			"api": "existsSync",
-			"source": "if (!existsSync(dir)) {",
-			"category": "hot-path"
-		},
-		{
-			"path": "widget-gen.ts",
-			"line": 37,
-			"api": "mkdirSync",
-			"source": "mkdirSync(dir, { recursive: true });",
-			"category": "hot-path"
-		},
-		{
-			"path": "widget-gen.ts",
-			"line": 229,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return null;",
-			"category": "hot-path"
-		},
-		{
-			"path": "widget-gen.ts",
-			"line": 232,
-			"api": "readFileSync",
-			"source": "const content = readFileSync(path, \"utf-8\");",
-			"category": "hot-path"
-		},
-		{
-			"path": "widget-gen.ts",
-			"line": 241,
-			"api": "existsSync",
-			"source": "if (!existsSync(path)) return false;",
-			"category": "hot-path"
-		},
-		{
-			"path": "widget-gen.ts",
-			"line": 244,
-			"api": "unlinkSync",
-			"source": "unlinkSync(path);",
-			"category": "hot-path"
-		},
-		{
-			"path": "widget-gen.ts",
-			"line": 308,
-			"api": "writeFileSync",
-			"source": "writeFileSync(widgetPath(serverId), html);",
-			"category": "hot-path"
-		},
-		{
-			"path": "yielding-writes.ts",
-			"line": 86,
-			"api": "withWriteTx",
-			"source": "return accessor.withWriteTx(processBatch);",
-			"category": "hot-path"
-		},
-		{
-			"path": "yielding-writes.ts",
-			"line": 123,
-			"api": "withReadDb",
-			"source": "const batch = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => fetchBatch(db, limit));",
-			"category": "hot-path"
-		}
-	]
+  "version": 1,
+  "generatedFrom": "platform/daemon/src",
+  "sites": [
+    {
+      "path": "agent-id.ts",
+      "line": 56,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "agent-id.ts",
+      "line": 82,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "aggregate-recall.ts",
+      "line": 740,
+      "api": "withReadDb",
+      "source": "const activeCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "aggregate-recall.ts",
+      "line": 746,
+      "api": "withWriteTx",
+      "source": "const written = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "aggregate-recall.ts",
+      "line": 995,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/api-keys.ts",
+      "line": 197,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/api-keys.ts",
+      "line": 241,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/api-keys.ts",
+      "line": 258,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/api-keys.ts",
+      "line": 272,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/tokens.ts",
+      "line": 30,
+      "api": "existsSync",
+      "source": "if (existsSync(secretPath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/tokens.ts",
+      "line": 31,
+      "api": "readFileSync",
+      "source": "const secret = readFileSync(secretPath);",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/tokens.ts",
+      "line": 37,
+      "api": "writeFileSync",
+      "source": "writeFileSync(secretPath, fresh, { mode: 0o600 });",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/tokens.ts",
+      "line": 43,
+      "api": "existsSync",
+      "source": "if (!existsSync(dir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/tokens.ts",
+      "line": 44,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/tokens.ts",
+      "line": 47,
+      "api": "writeFileSync",
+      "source": "writeFileSync(secretPath, secret, { mode: 0o600 });",
+      "category": "hot-path"
+    },
+    {
+      "path": "black-box.ts",
+      "line": 434,
+      "api": "withReadDb",
+      "source": "const events = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "black-box.ts",
+      "line": 467,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "config-migration.ts",
+      "line": 56,
+      "api": "existsSync",
+      "source": "if (existsSync(p)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "config-migration.ts",
+      "line": 65,
+      "api": "readFileSync",
+      "source": "text = readFileSync(path, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "config-migration.ts",
+      "line": 106,
+      "api": "writeFileSync",
+      "source": "writeFileSync(tmp, text, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "config-migration.ts",
+      "line": 107,
+      "api": "renameSync",
+      "source": "renameSync(tmp, path);",
+      "category": "hot-path"
+    },
+    {
+      "path": "config-migration.ts",
+      "line": 141,
+      "api": "existsSync",
+      "source": "if (existsSync(p)) return p;",
+      "category": "hot-path"
+    },
+    {
+      "path": "config-migration.ts",
+      "line": 152,
+      "api": "readFileSync",
+      "source": "text = readFileSync(path, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "config-migration.ts",
+      "line": 228,
+      "api": "writeFileSync",
+      "source": "writeFileSync(tmp, contents, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "config-migration.ts",
+      "line": 229,
+      "api": "renameSync",
+      "source": "renameSync(tmp, path);",
+      "category": "hot-path"
+    },
+    {
+      "path": "config-migration.ts",
+      "line": 290,
+      "api": "readFileSync",
+      "source": "text = readFileSync(path, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "config-migration.ts",
+      "line": 502,
+      "api": "readFileSync",
+      "source": "text = readFileSync(path, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "config-migration.ts",
+      "line": 564,
+      "api": "readFileSync",
+      "source": "text = readFileSync(path, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "config-migration.ts",
+      "line": 667,
+      "api": "readFileSync",
+      "source": "text = readFileSync(path, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "config-migration.ts",
+      "line": 724,
+      "api": "readFileSync",
+      "source": "text = readFileSync(path, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/filesystem.ts",
+      "line": 232,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/filesystem.ts",
+      "line": 287,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/filesystem.ts",
+      "line": 310,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 23,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 43,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 59,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 74,
+      "api": "withReadDb",
+      "source": "const before = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 82,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 98,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 108,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 145,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 645,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 768,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 813,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 856,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 884,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 914,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 953,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 1028,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 380,
+      "api": "existsSync",
+      "source": "if (!existsSync(agentsMdPath)) return;",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 397,
+      "api": "existsSync",
+      "source": "const existingFiles = files.filter((f) => existsSync(join(AGENTS_DIR, f.name)));",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 425,
+      "api": "existsSync",
+      "source": "if (!existsSync(identityPath)) return \"\";",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 444,
+      "api": "existsSync",
+      "source": "if (activeHarnesses.has(\"opencode\") && existsSync(opencodeDir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 476,
+      "api": "existsSync",
+      "source": "if (activeHarnesses.has(\"opencode\") && existsSync(opencodeDir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 483,
+      "api": "existsSync",
+      "source": "if (existsSync(geminiDir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 488,
+      "api": "existsSync",
+      "source": "if (existsSync(settingsPath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 489,
+      "api": "readFileSync",
+      "source": "const parsed = JSON.parse(readFileSync(settingsPath, \"utf8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 509,
+      "api": "existsSync",
+      "source": "if (!existsSync(targetPath)) continue;",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 705,
+      "api": "statSync",
+      "source": "const stat = statSync(filePath);",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 865,
+      "api": "readFileSync",
+      "source": "content = readFileSync(filePath, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1025,
+      "api": "existsSync",
+      "source": "if (!existsSync(memoryDir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1401,
+      "api": "existsSync",
+      "source": "if (!existsSync(p)) continue;",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1403,
+      "api": "readFileSync",
+      "source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\")) as Record<string, unknown>;",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1440,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) continue;",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1440,
+      "api": "withWriteTx",
+      "source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1442,
+      "api": "readFileSync",
+      "source": "const routing = parseRoutingConfig(parseSimpleYaml(readFileSync(path, \"utf-8\")));",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1521,
+      "api": "withReadDb",
+      "source": "const activeEmbeddingCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1804,
+      "api": "existsSync",
+      "source": "if (existsSync(PID_FILE)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1806,
+      "api": "unlinkSync",
+      "source": "unlinkSync(PID_FILE);",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1947,
+      "api": "mkdirSync",
+      "source": "mkdirSync(DAEMON_DIR, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1948,
+      "api": "mkdirSync",
+      "source": "mkdirSync(LOG_DIR, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 2023,
+      "api": "existsSync",
+      "source": "const workerPath = existsSync(bundled)",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 2093,
+      "api": "writeFileSync",
+      "source": "writeFileSync(PID_FILE, process.pid.toString());",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 2204,
+      "api": "withReadDb",
+      "source": "const memoryCount = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 2215,
+      "api": "withReadDb",
+      "source": "const queue = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 2393,
+      "api": "existsSync",
+      "source": "if (existsSync(healthStampPath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 2394,
+      "api": "readFileSync",
+      "source": "const prev = JSON.parse(readFileSync(healthStampPath, \"utf-8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 2397,
+      "api": "writeFileSync",
+      "source": "writeFileSync(",
+      "category": "hot-path"
+    },
+    {
+      "path": "database-integrity.ts",
+      "line": 127,
+      "api": "existsSync",
+      "source": "if (existsSync(bundled)) return bundled;",
+      "category": "hot-path"
+    },
+    {
+      "path": "database-integrity.ts",
+      "line": 270,
+      "api": "withReadDb",
+      "source": "const checks = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => ({",
+      "category": "hot-path"
+    },
+    {
+      "path": "database-integrity.ts",
+      "line": 304,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "database-integrity.ts",
+      "line": 309,
+      "api": "withReadDb",
+      "source": "const verifiedTelemetry = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 317,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return null;",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 320,
+      "api": "readFileSync",
+      "source": "const raw: unknown = JSON.parse(readFileSync(path, \"utf8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 577,
+      "api": "readdirSync",
+      "source": ".readdirSync(dir)",
+      "category": "pre-readiness-bootstrap"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 581,
+      "api": "statSync",
+      "source": "const stat = deps.statSync(join(dir, f));",
+      "category": "pre-readiness-bootstrap"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 595,
+      "api": "unlinkSync",
+      "source": "deps.unlinkSync(join(dir, old.name));",
+      "category": "pre-readiness-bootstrap"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 606,
+      "api": "statfsSync",
+      "source": "const stat = deps.statfsSync(path);",
+      "category": "pre-readiness-bootstrap"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 615,
+      "api": "statSync",
+      "source": "const size = deps.statSync(path).size;",
+      "category": "pre-readiness-bootstrap"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 646,
+      "api": "copyFileSync",
+      "source": "deps.copyFileSync(dbPath, probeDest);",
+      "category": "pre-readiness-bootstrap"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 652,
+      "api": "unlinkSync",
+      "source": "deps.unlinkSync(probeDest);",
+      "category": "pre-readiness-bootstrap"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 687,
+      "api": "copyFileSync",
+      "source": "deps.copyFileSync(dbPath, backupDest);",
+      "category": "pre-readiness-bootstrap"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 711,
+      "api": "copyFileSync",
+      "source": "deps.copyFileSync(dbPath, backupDest);",
+      "category": "pre-readiness-bootstrap"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 751,
+      "api": "unlinkSync",
+      "source": "deps.unlinkSync(backupDest);",
+      "category": "pre-readiness-bootstrap"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 760,
+      "api": "unlinkSync",
+      "source": "else deps.unlinkSync(backupDest);",
+      "category": "pre-readiness-bootstrap"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 788,
+      "api": "unlinkSync",
+      "source": "deps.unlinkSync(backupDest);",
+      "category": "pre-readiness-bootstrap"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 820,
+      "api": "existsSync",
+      "source": "if (!existsSync(dir)) {",
+      "category": "pre-readiness-bootstrap"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 821,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dir, { recursive: true });",
+      "category": "pre-readiness-bootstrap"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 842,
+      "api": "existsSync",
+      "source": "if (existsSync(path) && hasPendingMigrations(toMigrationDb(writeConn))) {",
+      "category": "pre-readiness-bootstrap"
+    },
+    {
+      "path": "db-accessor.ts",
+      "line": 849,
+      "api": "existsSync",
+      "source": "if (existsSync(path) && hasPendingMigrations(toMigrationDb(writeConn))) {",
+      "category": "pre-readiness-bootstrap"
+    },
+    {
+      "path": "db-vacuum.ts",
+      "line": 67,
+      "api": "statSync",
+      "source": "const dbBytes = deps.statSync(dbPath).size;",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-vacuum.ts",
+      "line": 69,
+      "api": "statfsSync",
+      "source": "const stats = deps.statfsSync(directory);",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-vacuum.ts",
+      "line": 322,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readStatusFromDb(toPragmaReadDb(db)));",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-vacuum.ts",
+      "line": 411,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-vacuum.ts",
+      "line": 437,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-vacuum.ts",
+      "line": 453,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-desktop-cache-source.ts",
+      "line": 221,
+      "api": "lstatSync",
+      "source": "stat = fileSystem.lstatSync(path);",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-desktop-cache-source.ts",
+      "line": 265,
+      "api": "readdirSync",
+      "source": "const entries = fileSystem.readdirSync(path);",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-desktop-cache-source.ts",
+      "line": 285,
+      "api": "readFileSync",
+      "source": "const data = fileSystem.readFileSync(candidate.absPath);",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-desktop-cache-source.ts",
+      "line": 481,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-desktop-cache-source.ts",
+      "line": 494,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-desktop-cache-source.ts",
+      "line": 1085,
+      "api": "readFileSync",
+      "source": "const data = fileSystem.readFileSync(path).subarray(0, CACHE_SNIFF_BYTES).toString(\"utf8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 574,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 588,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 630,
+      "api": "withReadDb",
+      "source": "const row = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 875,
+      "api": "withReadDb",
+      "source": "const row = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 959,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 973,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-fetch.ts",
+      "line": 494,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => resolveActiveEmbeddingConfig(db, cfg));",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-index-migration.ts",
+      "line": 80,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx(fn);",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-index-migration.ts",
+      "line": 253,
+      "api": "withReadDb",
+      "source": "const state = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readEmbeddingIndexState(db));",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-index-migration.ts",
+      "line": 262,
+      "api": "withReadDb",
+      "source": "const rows = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-index-migration.ts",
+      "line": 343,
+      "api": "withReadDb",
+      "source": "const coverage = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-index-migration.ts",
+      "line": 355,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-index-migration.ts",
+      "line": 435,
+      "api": "withReadDb",
+      "source": "const before = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readEmbeddingIndexState(db));",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-index-migration.ts",
+      "line": 437,
+      "api": "withWriteTx",
+      "source": "const initial = input.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-index-migration.ts",
+      "line": 446,
+      "api": "withReadDb",
+      "source": "const hasStagingVectorIndex = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-index-migration.ts",
+      "line": 452,
+      "api": "withWriteTx",
+      "source": "input.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-index-migration.ts",
+      "line": 458,
+      "api": "withWriteTx",
+      "source": "input.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-index-migration.ts",
+      "line": 469,
+      "api": "withReadDb",
+      "source": "const state = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readEmbeddingIndexState(db));",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-repair-state.ts",
+      "line": 101,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-repair-state.ts",
+      "line": 139,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-repair-state.ts",
+      "line": 160,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-repair-state.ts",
+      "line": 191,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-tracker.ts",
+      "line": 194,
+      "api": "withReadDb",
+      "source": "const staleRows: StaleRow[] = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-tracker.ts",
+      "line": 265,
+      "api": "withWriteTx",
+      "source": "applied = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-usage.ts",
+      "line": 90,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-usage.ts",
+      "line": 115,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-worker-handle.ts",
+      "line": 180,
+      "api": "existsSync",
+      "source": ": existsSync(bundled)",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-worker.ts",
+      "line": 154,
+      "api": "mkdirSync",
+      "source": "mkdirSync(init.cacheDir, { recursive: true });",
+      "category": "isolated-worker"
+    },
+    {
+      "path": "embedding-worker.ts",
+      "line": 175,
+      "api": "readFileSync",
+      "source": "const wasmBytes = readFileSync(join(init.wasmDir, \"ort-wasm-simd-threaded.wasm\"));",
+      "category": "isolated-worker"
+    },
+    {
+      "path": "feature-flags.ts",
+      "line": 36,
+      "api": "existsSync",
+      "source": "if (!existsSync(p)) continue;",
+      "category": "hot-path"
+    },
+    {
+      "path": "feature-flags.ts",
+      "line": 38,
+      "api": "readFileSync",
+      "source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "file-sync.ts",
+      "line": 9,
+      "api": "existsSync",
+      "source": "const existing = existsSync(path) ? readFileSync(path, \"utf-8\") : null;",
+      "category": "hot-path"
+    },
+    {
+      "path": "file-sync.ts",
+      "line": 9,
+      "api": "readFileSync",
+      "source": "const existing = existsSync(path) ? readFileSync(path, \"utf-8\") : null;",
+      "category": "hot-path"
+    },
+    {
+      "path": "file-sync.ts",
+      "line": 11,
+      "api": "writeFileSync",
+      "source": "writeFileSync(path, content);",
+      "category": "hot-path"
+    },
+    {
+      "path": "github-source-provider.ts",
+      "line": 461,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "github-source-provider.ts",
+      "line": 483,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "github-source-provider.ts",
+      "line": 497,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "graphiq.ts",
+      "line": 34,
+      "api": "accessSync",
+      "source": "accessSync(candidate, constants.X_OK);",
+      "category": "hot-path"
+    },
+    {
+      "path": "graphiq.ts",
+      "line": 48,
+      "api": "existsSync",
+      "source": "if (!existsSync(active.dbPath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "hooks-config.ts",
+      "line": 289,
+      "api": "existsSync",
+      "source": "if (!existsSync(configPath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "hooks-config.ts",
+      "line": 294,
+      "api": "readFileSync",
+      "source": "const content = readFileSync(configPath, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "hooks.ts",
+      "line": 455,
+      "api": "existsSync",
+      "source": "if (!existsSync(getMemoryDbPath())) return undefined;",
+      "category": "hot-path"
+    },
+    {
+      "path": "hooks.ts",
+      "line": 553,
+      "api": "existsSync",
+      "source": "if (!existsSync(getMemoryDbPath())) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "hooks.ts",
+      "line": 761,
+      "api": "existsSync",
+      "source": "if (req.sessionKey && existsSync(getMemoryDbPath())) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "hooks.ts",
+      "line": 1602,
+      "api": "existsSync",
+      "source": "if (req.transcriptPath && existsSync(req.transcriptPath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "hooks.ts",
+      "line": 1604,
+      "api": "readFileSync",
+      "source": "rawTranscript = readFileSync(req.transcriptPath, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "hooks.ts",
+      "line": 1946,
+      "api": "existsSync",
+      "source": "if (req.transcriptPath && existsSync(req.transcriptPath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "hooks.ts",
+      "line": 1948,
+      "api": "readFileSync",
+      "source": "rawTranscript = readFileSync(req.transcriptPath, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "hooks.ts",
+      "line": 2210,
+      "api": "existsSync",
+      "source": "} else if (req.transcriptPath && existsSync(req.transcriptPath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "hooks.ts",
+      "line": 2212,
+      "api": "readFileSync",
+      "source": "const raw = readFileSync(req.transcriptPath, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "identity-context.ts",
+      "line": 32,
+      "api": "existsSync",
+      "source": "if (!filePath || !existsSync(filePath)) return undefined;",
+      "category": "hot-path"
+    },
+    {
+      "path": "identity-context.ts",
+      "line": 35,
+      "api": "readFileSync",
+      "source": "const content = readFileSync(filePath, \"utf-8\").trim();",
+      "category": "hot-path"
+    },
+    {
+      "path": "identity-context.ts",
+      "line": 73,
+      "api": "existsSync",
+      "source": "if (!filePath || !existsSync(filePath)) return undefined;",
+      "category": "hot-path"
+    },
+    {
+      "path": "identity-context.ts",
+      "line": 76,
+      "api": "readFileSync",
+      "source": "const content = readFileSync(filePath, \"utf-8\").trim();",
+      "category": "hot-path"
+    },
+    {
+      "path": "identity-context.ts",
+      "line": 178,
+      "api": "existsSync",
+      "source": "if (identityMd && existsSync(identityMd)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "identity-context.ts",
+      "line": 180,
+      "api": "readFileSync",
+      "source": "return parseIdentityMarkdown(readFileSync(identityMd, \"utf-8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "identity-context.ts",
+      "line": 185,
+      "api": "existsSync",
+      "source": "if (existsSync(agentYaml)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "identity-context.ts",
+      "line": 187,
+      "api": "readFileSync",
+      "source": "const content = readFileSync(agentYaml, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "identity-context.ts",
+      "line": 200,
+      "api": "existsSync",
+      "source": "if (existsSync(rootIdentityMd)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "identity-context.ts",
+      "line": 202,
+      "api": "readFileSync",
+      "source": "return parseIdentityMarkdown(readFileSync(rootIdentityMd, \"utf-8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "identity-sync.ts",
+      "line": 35,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return null;",
+      "category": "hot-path"
+    },
+    {
+      "path": "identity-sync.ts",
+      "line": 60,
+      "api": "existsSync",
+      "source": "if (!existsSync(agentsRoot)) return;",
+      "category": "hot-path"
+    },
+    {
+      "path": "identity-sync.ts",
+      "line": 84,
+      "api": "existsSync",
+      "source": "const soulPath = existsSync(join(agentDir, \"SOUL.md\")) ? join(agentDir, \"SOUL.md\") : join(agentsDir, \"SOUL.md\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "identity-sync.ts",
+      "line": 85,
+      "api": "existsSync",
+      "source": "const identityPath = existsSync(join(agentDir, \"IDENTITY.md\"))",
+      "category": "hot-path"
+    },
+    {
+      "path": "imported-source-lifecycle.ts",
+      "line": 36,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "imported-source-outcome.ts",
+      "line": 16,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => persistImportedSourceOutcomeInTx(db, input));",
+      "category": "hot-path"
+    },
+    {
+      "path": "imported-source-outcome.ts",
+      "line": 59,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "knowledge-graph-hygiene.ts",
+      "line": 428,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "lifecycle.ts",
+      "line": 154,
+      "api": "readFileSync",
+      "source": "const raw = readFileSync(lifecyclePath(agentsDir), \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "lifecycle.ts",
+      "line": 169,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dirname(path), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "lifecycle.ts",
+      "line": 171,
+      "api": "writeFileSync",
+      "source": "writeFileSync(tmpPath, JSON.stringify(record, null, 2));",
+      "category": "hot-path"
+    },
+    {
+      "path": "lifecycle.ts",
+      "line": 172,
+      "api": "renameSync",
+      "source": "renameSync(tmpPath, path);",
+      "category": "hot-path"
+    },
+    {
+      "path": "logger.ts",
+      "line": 179,
+      "api": "existsSync",
+      "source": "if (!existsSync(dir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "logger.ts",
+      "line": 180,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "logger.ts",
+      "line": 242,
+      "api": "existsSync",
+      "source": "if (!existsSync(this.config.logFilePath)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "logger.ts",
+      "line": 250,
+      "api": "existsSync",
+      "source": "if (!existsSync(this.config.logDir)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "logger.ts",
+      "line": 251,
+      "api": "readdirSync",
+      "source": "return readdirSync(this.config.logDir)",
+      "category": "hot-path"
+    },
+    {
+      "path": "logger.ts",
+      "line": 349,
+      "api": "appendFileSync",
+      "source": "appendFileSync(this.currentLogFile, lines);",
+      "category": "hot-path"
+    },
+    {
+      "path": "logger.ts",
+      "line": 372,
+      "api": "existsSync",
+      "source": "if (!existsSync(this.currentLogFile)) return;",
+      "category": "hot-path"
+    },
+    {
+      "path": "logger.ts",
+      "line": 374,
+      "api": "statSync",
+      "source": "const stats = statSync(this.currentLogFile);",
+      "category": "hot-path"
+    },
+    {
+      "path": "logger.ts",
+      "line": 389,
+      "api": "renameSync",
+      "source": "renameSync(this.currentLogFile, rotatedName);",
+      "category": "hot-path"
+    },
+    {
+      "path": "logger.ts",
+      "line": 405,
+      "api": "unlinkSync",
+      "source": "unlinkSync(files[i].path);",
+      "category": "hot-path"
+    },
+    {
+      "path": "logger.ts",
+      "line": 551,
+      "api": "readFileSync",
+      "source": "const content = readFileSync(file.path, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "mcp-probe.ts",
+      "line": 45,
+      "api": "existsSync",
+      "source": "if (!existsSync(dir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "mcp-probe.ts",
+      "line": 46,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "mcp-probe.ts",
+      "line": 440,
+      "api": "writeFileSync",
+      "source": "writeFileSync(manifestPath, JSON.stringify(result, null, 2));",
+      "category": "hot-path"
+    },
+    {
+      "path": "mcp-probe.ts",
+      "line": 474,
+      "api": "writeFileSync",
+      "source": "writeFileSync(getAppTrayPath(), JSON.stringify(tray, null, 2));",
+      "category": "hot-path"
+    },
+    {
+      "path": "mcp-probe.ts",
+      "line": 500,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "mcp-probe.ts",
+      "line": 503,
+      "api": "readFileSync",
+      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+      "category": "hot-path"
+    },
+    {
+      "path": "mcp-probe.ts",
+      "line": 522,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return null;",
+      "category": "hot-path"
+    },
+    {
+      "path": "mcp-probe.ts",
+      "line": 525,
+      "api": "readFileSync",
+      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+      "category": "hot-path"
+    },
+    {
+      "path": "mcp-probe.ts",
+      "line": 541,
+      "api": "existsSync",
+      "source": "if (existsSync(manifestPath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "mcp-probe.ts",
+      "line": 542,
+      "api": "unlinkSync",
+      "source": "unlinkSync(manifestPath);",
+      "category": "hot-path"
+    },
+    {
+      "path": "mcp-probe.ts",
+      "line": 552,
+      "api": "writeFileSync",
+      "source": "writeFileSync(getAppTrayPath(), JSON.stringify(filtered, null, 2));",
+      "category": "hot-path"
+    },
+    {
+      "path": "mcp-stdio.ts",
+      "line": 32,
+      "api": "existsSync",
+      "source": "return isAbsolute(dir) && existsSync(dir) && statSync(dir).isDirectory();",
+      "category": "cli-only"
+    },
+    {
+      "path": "mcp-stdio.ts",
+      "line": 32,
+      "api": "statSync",
+      "source": "return isAbsolute(dir) && existsSync(dir) && statSync(dir).isDirectory();",
+      "category": "cli-only"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 132,
+      "api": "existsSync",
+      "source": "if (memoryIds.length === 0 || !existsSync(memoryDbPath)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 150,
+      "api": "withReadDb",
+      "source": "const batchRows: ScoredMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 211,
+      "api": "existsSync",
+      "source": "if (!existsSync(memoryDbPath)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 228,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 285,
+      "api": "existsSync",
+      "source": "if (!existsSync(memoryDbPath)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 306,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 368,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 401,
+      "api": "existsSync",
+      "source": "if (!existsSync(memoryDbPath)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 432,
+      "api": "withReadDb",
+      "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 440,
+      "api": "existsSync",
+      "source": "if (!existsSync(memoryDbPath)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 473,
+      "api": "withReadDb",
+      "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-config.ts",
+      "line": 990,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) continue;",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-config.ts",
+      "line": 992,
+      "api": "readFileSync",
+      "source": "const yaml = parseSimpleYaml(readFileSync(path, \"utf-8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 59,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 128,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 147,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 160,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 161,
+      "api": "existsSync",
+      "source": "if (existsSync(path)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 164,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dirname(backup), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 165,
+      "api": "readFileSync",
+      "source": "writeFileSync(backup, readFileSync(path, \"utf-8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 165,
+      "api": "writeFileSync",
+      "source": "writeFileSync(backup, readFileSync(path, \"utf-8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 167,
+      "api": "writeFileSync",
+      "source": "writeFileSync(path, file);",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-lineage.ts",
+      "line": 438,
+      "api": "mkdirSync",
+      "source": "mkdirSync(getMemoryDir(), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-lineage.ts",
+      "line": 440,
+      "api": "writeFileSync",
+      "source": "writeFileSync(tmp, content, \"utf8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-lineage.ts",
+      "line": 441,
+      "api": "renameSync",
+      "source": "renameSync(tmp, path);",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-lineage.ts",
+      "line": 445,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return null;",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-lineage.ts",
+      "line": 446,
+      "api": "readFileSync",
+      "source": "const parsed = parseFrontmatterDocument(readFileSync(path, \"utf8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-lineage.ts",
+      "line": 498,
+      "api": "existsSync",
+      "source": "if (existsSync(path)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-lineage.ts",
+      "line": 499,
+      "api": "readFileSync",
+      "source": "const existing = parseFrontmatterDocument(readFileSync(path, \"utf8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-lineage.ts",
+      "line": 654,
+      "api": "statSync",
+      "source": "sourceMtimeMs = statSync(path).mtimeMs,",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-lineage.ts",
+      "line": 730,
+      "api": "statSync",
+      "source": "sourceMtimeMs = statSync(path).mtimeMs,",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-lineage.ts",
+      "line": 826,
+      "api": "existsSync",
+      "source": "existsSync(path) ? statSync(path).mtimeMs : Date.now(),",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-lineage.ts",
+      "line": 826,
+      "api": "statSync",
+      "source": "existsSync(path) ? statSync(path).mtimeMs : Date.now(),",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-lineage.ts",
+      "line": 833,
+      "api": "existsSync",
+      "source": "if (!existsSync(dir)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-lineage.ts",
+      "line": 1495,
+      "api": "readFileSync",
+      "source": "const parsed = parseFrontmatterDocument(readFileSync(fullPath, \"utf8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-lineage.ts",
+      "line": 1556,
+      "api": "readFileSync",
+      "source": "const parsed = parseFrontmatterDocument(readFileSync(fullPath, \"utf8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-lineage.ts",
+      "line": 1606,
+      "api": "readFileSync",
+      "source": "const parsed = parseFrontmatterDocument(readFileSync(fullPath, \"utf8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-lineage.ts",
+      "line": 2201,
+      "api": "rmSync",
+      "source": "rmSync(join(getAgentsDir(), path), { force: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "native-runtime-assets.ts",
+      "line": 77,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "native-runtime-assets.ts",
+      "line": 78,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "native-runtime-assets.ts",
+      "line": 79,
+      "api": "writeFileSync",
+      "source": "writeFileSync(path, Buffer.from(worker.contentBase64, \"base64\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "native-runtime-assets.ts",
+      "line": 93,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "native-runtime-assets.ts",
+      "line": 96,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "native-runtime-assets.ts",
+      "line": 97,
+      "api": "writeFileSync",
+      "source": "writeFileSync(path, Buffer.from(asset.contentBase64, \"base64\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "native-runtime-assets.ts",
+      "line": 111,
+      "api": "mkdirSync",
+      "source": "mkdirSync(root, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "native-runtime-assets.ts",
+      "line": 116,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dirname(path), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "native-runtime-assets.ts",
+      "line": 117,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "native-runtime-assets.ts",
+      "line": 118,
+      "api": "writeFileSync",
+      "source": "writeFileSync(path, Buffer.from(asset.contentBase64, \"base64\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "native-runtime-assets.ts",
+      "line": 123,
+      "api": "writeFileSync",
+      "source": "writeFileSync(join(root, \".signet-assets.json\"), `${JSON.stringify({ kind, sourceHash }, null, 2)}\\n`);",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 269,
+      "api": "withReadDb",
+      "source": "const embeddingConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 304,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 318,
+      "api": "withReadDb",
+      "source": "const writeConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 347,
+      "api": "withWriteTx",
+      "source": "const stored = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 408,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 454,
+      "api": "withReadDb",
+      "source": "const row = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 475,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-graph.ts",
+      "line": 323,
+      "api": "existsSync",
+      "source": "return existsSync(path) && statSync(path).isFile() ? normalizedPath(path) : null;",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-graph.ts",
+      "line": 323,
+      "api": "statSync",
+      "source": "return existsSync(path) && statSync(path).isFile() ? normalizedPath(path) : null;",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-graph.ts",
+      "line": 477,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-graph.ts",
+      "line": 696,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-graph.ts",
+      "line": 708,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 306,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: WriteDb) => insertAssertion(db, input));",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 325,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 391,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 410,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 438,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 466,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-claim-evidence.ts",
+      "line": 153,
+      "api": "withReadDb",
+      "source": "const items = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-claim-trace.ts",
+      "line": 1063,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-contradictions.ts",
+      "line": 524,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => reconcileOntologyContradictionsInTx(db, params));",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-contradictions.ts",
+      "line": 535,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-contradictions.ts",
+      "line": 591,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-extraction.ts",
+      "line": 647,
+      "api": "withReadDb",
+      "source": "const source = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-extraction.ts",
+      "line": 748,
+      "api": "withWriteTx",
+      "source": "const written = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "path-feedback.ts",
+      "line": 611,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/acpx-dreaming-mcp.ts",
+      "line": 16,
+      "api": "existsSync",
+      "source": "if (!existsSync(entrypoint)) throw new Error(`Signet Dreaming MCP entrypoint is unavailable: ${entrypoint}`);",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/acpx-dreaming-mcp.ts",
+      "line": 40,
+      "api": "writeFileSync",
+      "source": "writeFileSync(",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/acpx-dreaming-mcp.ts",
+      "line": 57,
+      "api": "rmSync",
+      "source": "rmSync(dir, { recursive: true, force: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/aspect-feedback.ts",
+      "line": 79,
+      "api": "withWriteTx",
+      "source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/aspect-feedback.ts",
+      "line": 165,
+      "api": "withWriteTx",
+      "source": "const decayed = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 136,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getDreamingAttentionInDb(db, agentId, limit));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 145,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 181,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 225,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 256,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 290,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-evidence-retry.ts",
+      "line": 131,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-evidence-retry.ts",
+      "line": 253,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 112,
+      "api": "withReadDb",
+      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 154,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 478,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 490,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 503,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 520,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 692,
+      "api": "withReadDb",
+      "source": "const pending = params.accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-runbook.ts",
+      "line": 177,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-runbook.ts",
+      "line": 219,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-token-cache.ts",
+      "line": 36,
+      "api": "existsSync",
+      "source": "return existsSync(bundled)",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 96,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getQueueHealth(db).status !== \"healthy\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 106,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 182,
+      "api": "withReadDb",
+      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => hasDreamingAttentionKindInDb(db, scope, [\"hygiene\"])),",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 186,
+      "api": "withReadDb",
+      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 278,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming.ts",
+      "line": 731,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return { content: \"\", unreadable: false };",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming.ts",
+      "line": 733,
+      "api": "readFileSync",
+      "source": "const raw = readFileSync(path, \"utf-8\").trim();",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/extraction-fallback.ts",
+      "line": 17,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/prospective-index.ts",
+      "line": 230,
+      "api": "withWriteTx",
+      "source": "job = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => leaseJob(db, 3));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/prospective-index.ts",
+      "line": 242,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => failJob(db, j.id, \"invalid payload\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/prospective-index.ts",
+      "line": 252,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/prospective-index.ts",
+      "line": 262,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => completeJob(db, j.id));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/prospective-index.ts",
+      "line": 272,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => failJob(db, j.id, msg));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/provider.ts",
+      "line": 824,
+      "api": "mkdirSync",
+      "source": "mkdirSync(isolatedCwd, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reflection-worker.ts",
+      "line": 39,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return null;",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reflection-worker.ts",
+      "line": 40,
+      "api": "readFileSync",
+      "source": "const data = JSON.parse(readFileSync(path, \"utf-8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reflection-worker.ts",
+      "line": 50,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reflection-worker.ts",
+      "line": 51,
+      "api": "writeFileSync",
+      "source": "writeFileSync(getLastReflectionPath(agentId), JSON.stringify({ lastDate: date }));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reflection-worker.ts",
+      "line": 366,
+      "api": "withReadDb",
+      "source": "const memories = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reflection-worker.ts",
+      "line": 399,
+      "api": "withReadDb",
+      "source": "const existingReflections = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reflection-worker.ts",
+      "line": 461,
+      "api": "withWriteTx",
+      "source": "deps.getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reflection-worker.ts",
+      "line": 527,
+      "api": "withReadDb",
+      "source": ".withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reranker-embedding.ts",
+      "line": 51,
+      "api": "withReadDb",
+      "source": "const embMap = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 80,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 174,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 292,
+      "api": "withReadDb",
+      "source": "const writeConfig = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 305,
+      "api": "withWriteTx",
+      "source": "embeddingCreated = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 365,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 376,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 136,
+      "api": "existsSync",
+      "source": "if (options.scanFilesystem !== false && existsSync(dir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 137,
+      "api": "readdirSync",
+      "source": "const entries = readdirSync(dir, { withFileTypes: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 141,
+      "api": "existsSync",
+      "source": "if (existsSync(skillMdPath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 163,
+      "api": "withReadDb",
+      "source": "const graphSkills = deps.accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 170,
+      "api": "existsSync",
+      "source": "if (!existsSync(row.fs_path)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 228,
+      "api": "existsSync",
+      "source": "if (!existsSync(mdPath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 234,
+      "api": "readFileSync",
+      "source": "const content = readFileSync(mdPath, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 241,
+      "api": "withReadDb",
+      "source": "const existing = deps.accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 250,
+      "api": "withReadDb",
+      "source": "const storedEmb = deps.accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 331,
+      "api": "statSync",
+      "source": "return statSync(dir).mtimeMs;",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 373,
+      "api": "existsSync",
+      "source": "if (existsSync(dir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/synthesis-worker.ts",
+      "line": 73,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return 0;",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/synthesis-worker.ts",
+      "line": 74,
+      "api": "readFileSync",
+      "source": "const data = JSON.parse(readFileSync(path, \"utf-8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/synthesis-worker.ts",
+      "line": 84,
+      "api": "mkdirSync",
+      "source": "mkdirSync(join(getAgentsDir(), \".daemon\"), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/synthesis-worker.ts",
+      "line": 85,
+      "api": "writeFileSync",
+      "source": "writeFileSync(path, JSON.stringify({ lastRunAt: timestamp }));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/synthesis-worker.ts",
+      "line": 127,
+      "api": "withReadDb",
+      "source": "const checkpointRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/synthesis-worker.ts",
+      "line": 153,
+      "api": "withReadDb",
+      "source": "const transcriptRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "plugins/audit.ts",
+      "line": 71,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dirname(path), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "plugins/audit.ts",
+      "line": 72,
+      "api": "appendFileSync",
+      "source": "appendFileSync(path, `${JSON.stringify(event)}\\n`, { mode: 0o600 });",
+      "category": "hot-path"
+    },
+    {
+      "path": "plugins/audit.ts",
+      "line": 85,
+      "api": "existsSync",
+      "source": "if (!path || !existsSync(path)) return { events: [], count: 0 };",
+      "category": "hot-path"
+    },
+    {
+      "path": "plugins/audit.ts",
+      "line": 109,
+      "api": "readFileSync",
+      "source": "return readFileSync(path, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "plugins/host.ts",
+      "line": 326,
+      "api": "existsSync",
+      "source": "if (!this.storagePath || !existsSync(this.storagePath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "plugins/host.ts",
+      "line": 330,
+      "api": "readFileSync",
+      "source": "const parsed: unknown = JSON.parse(readFileSync(this.storagePath, \"utf-8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "plugins/host.ts",
+      "line": 353,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dirname(this.storagePath), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "plugins/host.ts",
+      "line": 354,
+      "api": "writeFileSync",
+      "source": "writeFileSync(this.storagePath, `${JSON.stringify(this.store, null, 2)}\\n`, { mode: 0o600 });",
+      "category": "hot-path"
+    },
+    {
+      "path": "plugins/index.ts",
+      "line": 14,
+      "api": "existsSync",
+      "source": "if (existsSync(statePath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "plugins/index.ts",
+      "line": 16,
+      "api": "readFileSync",
+      "source": "const parsed: unknown = JSON.parse(readFileSync(statePath, \"utf-8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "prompt-entity-context.ts",
+      "line": 668,
+      "api": "existsSync",
+      "source": "if (!existsSync(memoryDbPath)) return { lines: [], memories: [], memoryCount: 0, engine: \"no-entity\" };",
+      "category": "hot-path"
+    },
+    {
+      "path": "prompt-entity-context.ts",
+      "line": 671,
+      "api": "withReadDb",
+      "source": "const matches: PromptEntityMatch[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "prompt-entity-context.ts",
+      "line": 697,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "resource-monitor.ts",
+      "line": 228,
+      "api": "readdirSync",
+      "source": "const entries = readdirSync(fdDir);",
+      "category": "hot-path"
+    },
+    {
+      "path": "resource-monitor.ts",
+      "line": 233,
+      "api": "readlinkSync",
+      "source": "const target = readlinkSync(join(fdDir, fd));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/app-tray.ts",
+      "line": 122,
+      "api": "writeFileSync",
+      "source": "writeFileSync(join(getMarketplaceDir(), \"app-tray.json\"), JSON.stringify([...fresh, ...toAdd], null, 2));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/app-tray.ts",
+      "line": 227,
+      "api": "writeFileSync",
+      "source": "writeFileSync(trayPath, JSON.stringify(tray, null, 2));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/app-tray.ts",
+      "line": 315,
+      "api": "writeFileSync",
+      "source": "writeFileSync(trayPath, JSON.stringify(tray, null, 2));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/app-tray.ts",
+      "line": 347,
+      "api": "existsSync",
+      "source": "if (!existsSync(dir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/app-tray.ts",
+      "line": 348,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/app-tray.ts",
+      "line": 415,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/app-tray.ts",
+      "line": 417,
+      "api": "readFileSync",
+      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/app-tray.ts",
+      "line": 427,
+      "api": "writeFileSync",
+      "source": "writeFileSync(getInstalledMcpPath(), JSON.stringify(servers, null, 2));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/changelog.ts",
+      "line": 192,
+      "api": "existsSync",
+      "source": "if (existsSync(localPath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/changelog.ts",
+      "line": 194,
+      "api": "readFileSync",
+      "source": "raw = readFileSync(localPath, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/connectors-routes.ts",
+      "line": 277,
+      "api": "withReadDb",
+      "source": "const docs = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/connectors-routes.ts",
+      "line": 288,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/connectors-routes.ts",
+      "line": 319,
+      "api": "withReadDb",
+      "source": "const docCount = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/connectors-routes.ts",
+      "line": 352,
+      "api": "existsSync",
+      "source": "exists: existsSync(join(homedir(), \".claude\", \"settings.json\")),",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/connectors-routes.ts",
+      "line": 358,
+      "api": "existsSync",
+      "source": "exists: existsSync(join(homedir(), \".config\", \"opencode\", \"AGENTS.md\")),",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/connectors-routes.ts",
+      "line": 364,
+      "api": "existsSync",
+      "source": "exists: existsSync(join(AGENTS_DIR, \"AGENTS.md\")),",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/connectors-routes.ts",
+      "line": 370,
+      "api": "existsSync",
+      "source": "exists: existsSync(join(homedir(), \".gemini\", \"settings.json\")),",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/connectors-routes.ts",
+      "line": 389,
+      "api": "existsSync",
+      "source": "if (!existsSync(script)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/dashboard-identity.ts",
+      "line": 31,
+      "api": "existsSync",
+      "source": "if (existsSync(agentYaml)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/dashboard-identity.ts",
+      "line": 33,
+      "api": "readFileSync",
+      "source": "const config = parseSimpleYaml(readFileSync(agentYaml, \"utf-8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/dashboard-identity.ts",
+      "line": 45,
+      "api": "existsSync",
+      "source": "if (existsSync(identityMd)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/dashboard-identity.ts",
+      "line": 47,
+      "api": "readFileSync",
+      "source": "const content = readFileSync(identityMd, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/dashboard.ts",
+      "line": 28,
+      "api": "existsSync",
+      "source": "if (existsSync(join(candidate, \"index.html\"))) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/database-diagnostics.ts",
+      "line": 241,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/database-diagnostics.ts",
+      "line": 276,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/git-config.ts",
+      "line": 77,
+      "api": "existsSync",
+      "source": "if (!existsSync(p)) continue;",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/git-config.ts",
+      "line": 79,
+      "api": "readFileSync",
+      "source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/git-sync.ts",
+      "line": 50,
+      "api": "existsSync",
+      "source": "let gitRepoProbe = (dir: string): boolean => existsSync(join(dir, \".git\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/git-sync.ts",
+      "line": 812,
+      "api": "existsSync",
+      "source": "const existingContent = existsSync(gitignorePath) ? readFileSync(gitignorePath, \"utf-8\") : \"\";",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/git-sync.ts",
+      "line": 812,
+      "api": "readFileSync",
+      "source": "const existingContent = existsSync(gitignorePath) ? readFileSync(gitignorePath, \"utf-8\") : \"\";",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/git-sync.ts",
+      "line": 815,
+      "api": "writeFileSync",
+      "source": "writeFileSync(gitignorePath, nextContent, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/git-sync.ts",
+      "line": 871,
+      "api": "existsSync",
+      "source": "if (parent !== absolute && existsSync(parent)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/git-sync.ts",
+      "line": 1019,
+      "api": "existsSync",
+      "source": "gitRepoProbe = probe ?? ((dir: string): boolean => existsSync(join(dir, \".git\")));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/graphiq-install-path.ts",
+      "line": 8,
+      "api": "existsSync",
+      "source": "if (existsSync(bundled)) return bundled;",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/graphiq-routes.ts",
+      "line": 97,
+      "api": "existsSync",
+      "source": "if (!existsSync(resolved)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/graphiq-routes.ts",
+      "line": 102,
+      "api": "statSync",
+      "source": "projectStat = statSync(resolved);",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/graphiq-routes.ts",
+      "line": 110,
+      "api": "accessSync",
+      "source": "accessSync(resolved, constants.R_OK | constants.X_OK);",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/graphiq-routes.ts",
+      "line": 161,
+      "api": "existsSync",
+      "source": "if (!existsSync(script)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/graphiq-routes.ts",
+      "line": 182,
+      "api": "existsSync",
+      "source": "if (!existsSync(script)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/graphiq-routes.ts",
+      "line": 204,
+      "api": "accessSync",
+      "source": "accessSync(path, constants.X_OK);",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/graphiq-routes.ts",
+      "line": 228,
+      "api": "existsSync",
+      "source": "if (!existsSync(manifestPath)) continue;",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/graphiq-routes.ts",
+      "line": 230,
+      "api": "readFileSync",
+      "source": "const raw = JSON.parse(readFileSync(manifestPath, \"utf-8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/health.ts",
+      "line": 187,
+      "api": "withReadDb",
+      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/health.ts",
+      "line": 236,
+      "api": "withReadDb",
+      "source": "dbResult = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/hooks-routes.ts",
+      "line": 1148,
+      "api": "existsSync",
+      "source": "if (!existsSync(getCurrentMemoryDbPath())) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/hooks-routes.ts",
+      "line": 1163,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/hooks-routes.ts",
+      "line": 1191,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/hooks-routes.ts",
+      "line": 1311,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/import-routes.ts",
+      "line": 212,
+      "api": "withWriteTx",
+      "source": "const extraction = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/import-routes.ts",
+      "line": 252,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/import-routes.ts",
+      "line": 337,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace-helpers.ts",
+      "line": 35,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace-helpers.ts",
+      "line": 38,
+      "api": "readFileSync",
+      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace-reviews.ts",
+      "line": 62,
+      "api": "existsSync",
+      "source": "if (!existsSync(dir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace-reviews.ts",
+      "line": 63,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace-reviews.ts",
+      "line": 127,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace-reviews.ts",
+      "line": 129,
+      "api": "readFileSync",
+      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace-reviews.ts",
+      "line": 139,
+      "api": "writeFileSync",
+      "source": "writeFileSync(getReviewsPath(), JSON.stringify(reviews, null, 2), \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace-reviews.ts",
+      "line": 144,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return DEFAULT_CONFIG;",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace-reviews.ts",
+      "line": 146,
+      "api": "readFileSync",
+      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace-reviews.ts",
+      "line": 162,
+      "api": "writeFileSync",
+      "source": "writeFileSync(getReviewsConfigPath(), JSON.stringify(config, null, 2), \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace.ts",
+      "line": 176,
+      "api": "existsSync",
+      "source": "if (!existsSync(dir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace.ts",
+      "line": 177,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace.ts",
+      "line": 323,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace.ts",
+      "line": 328,
+      "api": "statSync",
+      "source": "const mtime = statSync(path).mtime.toISOString();",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace.ts",
+      "line": 329,
+      "api": "readFileSync",
+      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace.ts",
+      "line": 338,
+      "api": "writeFileSync",
+      "source": "writeFileSync(getExposurePolicyPath(), JSON.stringify(policy, null, 2));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace.ts",
+      "line": 807,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace.ts",
+      "line": 810,
+      "api": "readFileSync",
+      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace.ts",
+      "line": 822,
+      "api": "writeFileSync",
+      "source": "writeFileSync(getInstalledMcpPath(), JSON.stringify(servers, null, 2));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace.ts",
+      "line": 1128,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/mcp-analytics.ts",
+      "line": 89,
+      "api": "withReadDb",
+      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/mcp-analytics.ts",
+      "line": 171,
+      "api": "withReadDb",
+      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/memory-routes.ts",
+      "line": 278,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/memory-routes.ts",
+      "line": 294,
+      "api": "writeFileSync",
+      "source": "writeFileSync(path, noteContent, { encoding: \"utf-8\", flag: \"wx\" });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/misc-routes.ts",
+      "line": 120,
+      "api": "readdirSync",
+      "source": "const dirFiles = readdirSync(AGENTS_DIR);",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/misc-routes.ts",
+      "line": 125,
+      "api": "statSync",
+      "source": "const fileStat = statSync(filePath);",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/misc-routes.ts",
+      "line": 127,
+      "api": "readFileSync",
+      "source": "const content = readFileSync(filePath, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/misc-routes.ts",
+      "line": 188,
+      "api": "writeFileSync",
+      "source": "writeFileSync(filePath, content, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/pipeline-routes.ts",
+      "line": 102,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/pipeline-routes.ts",
+      "line": 296,
+      "api": "existsSync",
+      "source": "if (existsSync(p)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/pipeline-routes.ts",
+      "line": 297,
+      "api": "readFileSync",
+      "source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/pipeline-routes.ts",
+      "line": 341,
+      "api": "existsSync",
+      "source": "memoryDb: existsSync(MEMORY_DB),",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/pipeline-routes.ts",
+      "line": 392,
+      "api": "readFileSync",
+      "source": "soulContent = readFileSync(soulPath, \"utf-8\").slice(0, 500);",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/pipeline-routes.ts",
+      "line": 457,
+      "api": "withReadDb",
+      "source": "const report: ReturnType<typeof listMemoryContentSafety> = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/pipeline-routes.ts",
+      "line": 557,
+      "api": "withReadDb",
+      "source": "const dbData = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/queue-diagnostics.ts",
+      "line": 169,
+      "api": "withReadDb",
+      "source": "const response = resolveAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/reflection-routes.ts",
+      "line": 98,
+      "api": "withReadDb",
+      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/reflection-routes.ts",
+      "line": 118,
+      "api": "withReadDb",
+      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/reflection-routes.ts",
+      "line": 172,
+      "api": "withReadDb",
+      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/reflection-routes.ts",
+      "line": 207,
+      "api": "withReadDb",
+      "source": "const existing = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/reflection-routes.ts",
+      "line": 225,
+      "api": "withWriteTx",
+      "source": "resolveDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 313,
+      "api": "withReadDb",
+      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 357,
+      "api": "withWriteTx",
+      "source": "const result = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => clusterEntities(db, agentId));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 378,
+      "api": "withReadDb",
+      "source": "const unlinked = accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 408,
+      "api": "withReadDb",
+      "source": "const preview = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 459,
+      "api": "withWriteTx",
+      "source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 469,
+      "api": "withReadDb",
+      "source": "const remaining = accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 512,
+      "api": "withReadDb",
+      "source": "const unhinted = accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 537,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 545,
+      "api": "withReadDb",
+      "source": "const remaining = accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 585,
+      "api": "withReadDb",
+      "source": "const dead = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/session-routes.ts",
+      "line": 168,
+      "api": "withReadDb",
+      "source": "const hits = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/session-routes.ts",
+      "line": 347,
+      "api": "withReadDb",
+      "source": "const tableExists = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/session-routes.ts",
+      "line": 355,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skill-analytics.ts",
+      "line": 121,
+      "api": "withReadDb",
+      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 221,
+      "api": "existsSync",
+      "source": "if (!existsSync(getSkillsDir())) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 223,
+      "api": "readdirSync",
+      "source": "return readdirSync(getSkillsDir(), { withFileTypes: true })",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 227,
+      "api": "existsSync",
+      "source": "if (!existsSync(skillMdPath)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 229,
+      "api": "readFileSync",
+      "source": "const content = readFileSync(skillMdPath, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 364,
+      "api": "existsSync",
+      "source": "if (process.env.SIGNET_SKILLS_SOURCE && existsSync(process.env.SIGNET_SKILLS_SOURCE)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 369,
+      "api": "existsSync",
+      "source": "if (existsSync(devPath)) return devPath;",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 372,
+      "api": "existsSync",
+      "source": "if (existsSync(distPath)) return distPath;",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 374,
+      "api": "existsSync",
+      "source": "if (existsSync(distPath2)) return distPath2;",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 380,
+      "api": "existsSync",
+      "source": "if (!sourceDir || !existsSync(sourceDir)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 384,
+      "api": "readdirSync",
+      "source": "return readdirSync(sourceDir, { withFileTypes: true })",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 388,
+      "api": "existsSync",
+      "source": "if (!existsSync(skillMdPath)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 390,
+      "api": "readFileSync",
+      "source": "const content = readFileSync(skillMdPath, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 510,
+      "api": "existsSync",
+      "source": "if (!existsSync(skillMd)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 513,
+      "api": "lstatSync",
+      "source": "if (!lstatSync(skillMd).isFile()) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 521,
+      "api": "readdirSync",
+      "source": "for (const entry of readdirSync(dir, { withFileTypes: true })) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 636,
+      "api": "mkdirSync",
+      "source": "mkdirSync(target, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 641,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dirname(target), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 715,
+      "api": "rmSync",
+      "source": "rmSync(stagingDir, { recursive: true, force: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 716,
+      "api": "rmSync",
+      "source": "rmSync(backupDir, { recursive: true, force: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 718,
+      "api": "existsSync",
+      "source": "if (existsSync(targetDir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 719,
+      "api": "renameSync",
+      "source": "renameSync(targetDir, backupDir);",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 722,
+      "api": "renameSync",
+      "source": "renameSync(stagingDir, targetDir);",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 723,
+      "api": "rmSync",
+      "source": "rmSync(backupDir, { recursive: true, force: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 725,
+      "api": "rmSync",
+      "source": "rmSync(stagingDir, { recursive: true, force: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 726,
+      "api": "existsSync",
+      "source": "if (movedTarget && existsSync(backupDir) && !existsSync(targetDir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 726,
+      "api": "existsSync",
+      "source": "if (movedTarget && existsSync(backupDir) && !existsSync(targetDir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 727,
+      "api": "renameSync",
+      "source": "renameSync(backupDir, targetDir);",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 729,
+      "api": "rmSync",
+      "source": "rmSync(backupDir, { recursive: true, force: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 759,
+      "api": "mkdirSync",
+      "source": "mkdirSync(extractDir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 770,
+      "api": "mkdirSync",
+      "source": "mkdirSync(getSkillsDir(), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 783,
+      "api": "rmSync",
+      "source": "rmSync(tempRoot, { recursive: true, force: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 1011,
+      "api": "existsSync",
+      "source": "if (existsSync(skillMdPath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 1013,
+      "api": "readFileSync",
+      "source": "const content = readFileSync(skillMdPath, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 1031,
+      "api": "existsSync",
+      "source": "if (existsSync(signetSkillPath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 1033,
+      "api": "readFileSync",
+      "source": "const content = readFileSync(signetSkillPath, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 1188,
+      "api": "existsSync",
+      "source": "if (!existsSync(skillDir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 1195,
+      "api": "rmSync",
+      "source": "rmSync(skillDir, { recursive: true, force: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 711,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 713,
+      "api": "readFileSync",
+      "source": "const parsed = JSON.parse(readFileSync(path, \"utf8\")) as unknown;",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 723,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dirname(path), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 725,
+      "api": "writeFileSync",
+      "source": "writeFileSync(tmp, `${JSON.stringify(tombstones, null, 2)}\\n`, \"utf8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 726,
+      "api": "renameSync",
+      "source": "renameSync(tmp, path);",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 800,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 939,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 1051,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 1114,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 1153,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/state.ts",
+      "line": 157,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) continue;",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/state.ts",
+      "line": 159,
+      "api": "readFileSync",
+      "source": "return resolveNetworkBinding(readNetworkMode(parseSimpleYaml(readFileSync(path, \"utf-8\"))));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/state.ts",
+      "line": 384,
+      "api": "existsSync",
+      "source": "if (!existsSync(candidate)) continue;",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/state.ts",
+      "line": 386,
+      "api": "readFileSync",
+      "source": "const raw = readFileSync(candidate, \"utf8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/state.ts",
+      "line": 457,
+      "api": "withReadDb",
+      "source": "const report = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/telemetry-routes.ts",
+      "line": 200,
+      "api": "withReadDb",
+      "source": "const mutationHealth = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/telemetry-routes.ts",
+      "line": 219,
+      "api": "withReadDb",
+      "source": "const scores: Array<Record<string, unknown>> = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/telemetry-routes.ts",
+      "line": 263,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/utils.ts",
+      "line": 437,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/utils.ts",
+      "line": 525,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/widget.ts",
+      "line": 75,
+      "api": "existsSync",
+      "source": "if (existsSync(path)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/widget.ts",
+      "line": 76,
+      "api": "statSync",
+      "source": "const stat = statSync(path);",
+      "category": "hot-path"
+    },
+    {
+      "path": "scheduler/skill-resolver.ts",
+      "line": 42,
+      "api": "readFileSync",
+      "source": "const raw = readFileSync(skillPath, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "scheduler/worker.ts",
+      "line": 104,
+      "api": "withWriteTx",
+      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "scheduler/worker.ts",
+      "line": 122,
+      "api": "withReadDb",
+      "source": "const dueTasks = db.withReadDb((rdb: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "scheduler/worker.ts",
+      "line": 193,
+      "api": "withWriteTx",
+      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "scheduler/worker.ts",
+      "line": 280,
+      "api": "withWriteTx",
+      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 190,
+      "api": "readFileSync",
+      "source": "const id = readFileSync(p, \"utf-8\").trim();",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 199,
+      "api": "execSync",
+      "source": "const out = execSync(\"ioreg -rd1 -c IOPlatformExpertDevice | grep IOPlatformUUID | awk '{print $3}'\", {",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 212,
+      "api": "execSync",
+      "source": "const out = execSync('reg query \"HKLM\\\\SOFTWARE\\\\Microsoft\\\\Cryptography\" /v MachineGuid', {",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 235,
+      "api": "readFileSync",
+      "source": "const persisted = readFileSync(getMachineIdFile(), \"utf-8\").trim();",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 248,
+      "api": "mkdirSync",
+      "source": "mkdirSync(getSecretsDir(), { recursive: true, mode: 0o700 });",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 250,
+      "api": "writeFileSync",
+      "source": "writeFileSync(file, `${machineId}\\n`, { encoding: \"utf-8\", mode: 0o600, flag: \"wx\" });",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 299,
+      "api": "existsSync",
+      "source": "if (!existsSync(getSecretsFile())) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 373,
+      "api": "existsSync",
+      "source": "existsSync(getMachineIdFile()) ||",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 374,
+      "api": "existsSync",
+      "source": "!existsSync(getSecretsFile())",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 430,
+      "api": "readdirSync",
+      "source": "names = readdirSync(dir);",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 438,
+      "api": "unlinkSync",
+      "source": "unlinkSync(join(dir, name));",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 448,
+      "api": "existsSync",
+      "source": "if (!existsSync(file)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 452,
+      "api": "readFileSync",
+      "source": "return parseSecretsStore(JSON.parse(readFileSync(file, \"utf-8\")));",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 471,
+      "api": "mkdirSync",
+      "source": "mkdirSync(getSecretsDir(), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 476,
+      "api": "writeFileSync",
+      "source": "writeFileSync(fd, JSON.stringify(store, null, 2), \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 482,
+      "api": "renameSync",
+      "source": "renameSync(tmp, file);",
+      "category": "hot-path"
+    },
+    {
+      "path": "secrets.ts",
+      "line": 492,
+      "api": "unlinkSync",
+      "source": "unlinkSync(tmp);",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 93,
+      "api": "existsSync",
+      "source": "if (existsSync(candidate)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 108,
+      "api": "execSync",
+      "source": "execSync(`${locator} bun`, { encoding: \"utf-8\", windowsHide: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 145,
+      "api": "mkdirSync",
+      "source": "mkdirSync(plistDir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 146,
+      "api": "mkdirSync",
+      "source": "mkdirSync(LOG_DIR, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 150,
+      "api": "execSync",
+      "source": "execSync(`launchctl unload \"${LAUNCHD_PLIST}\" 2>/dev/null`);",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 156,
+      "api": "writeFileSync",
+      "source": "writeFileSync(LAUNCHD_PLIST, generateLaunchdPlist(port));",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 159,
+      "api": "execSync",
+      "source": "execSync(`launchctl load \"${LAUNCHD_PLIST}\"`);",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 163,
+      "api": "existsSync",
+      "source": "if (!existsSync(LAUNCHD_PLIST)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 168,
+      "api": "execSync",
+      "source": "execSync(`launchctl unload \"${LAUNCHD_PLIST}\"`);",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 173,
+      "api": "unlinkSync",
+      "source": "unlinkSync(LAUNCHD_PLIST);",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 178,
+      "api": "execSync",
+      "source": "const output = execSync(\"launchctl list ai.signet.daemon 2>/dev/null\", {",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 194,
+      "api": "existsSync",
+      "source": "if (execPath && existsSync(execPath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 199,
+      "api": "execSync",
+      "source": "return execSync(`${locator} bun`, { encoding: \"utf-8\", windowsHide: true }).trim().split(/\\r?\\n/)[0];",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 202,
+      "api": "execSync",
+      "source": "return execSync(`${locator} node`, { encoding: \"utf-8\", windowsHide: true }).trim().split(/\\r?\\n/)[0];",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 236,
+      "api": "mkdirSync",
+      "source": "mkdirSync(unitDir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 237,
+      "api": "mkdirSync",
+      "source": "mkdirSync(LOG_DIR, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 241,
+      "api": "execSync",
+      "source": "execSync(\"systemctl --user stop signet.service 2>/dev/null\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 247,
+      "api": "writeFileSync",
+      "source": "writeFileSync(SYSTEMD_UNIT, generateSystemdUnit(port));",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 250,
+      "api": "execSync",
+      "source": "execSync(\"systemctl --user daemon-reload\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 253,
+      "api": "execSync",
+      "source": "execSync(\"systemctl --user enable signet.service\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 254,
+      "api": "execSync",
+      "source": "execSync(\"systemctl --user start signet.service\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 259,
+      "api": "execSync",
+      "source": "execSync(\"systemctl --user stop signet.service 2>/dev/null\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 260,
+      "api": "execSync",
+      "source": "execSync(\"systemctl --user disable signet.service 2>/dev/null\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 265,
+      "api": "existsSync",
+      "source": "if (existsSync(SYSTEMD_UNIT)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 266,
+      "api": "unlinkSync",
+      "source": "unlinkSync(SYSTEMD_UNIT);",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 270,
+      "api": "execSync",
+      "source": "execSync(\"systemctl --user daemon-reload\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 278,
+      "api": "execSync",
+      "source": "const output = execSync(\"systemctl --user is-active signet.service 2>/dev/null\", { encoding: \"utf-8\" });",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 290,
+      "api": "mkdirSync",
+      "source": "mkdirSync(DAEMON_DIR, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 291,
+      "api": "mkdirSync",
+      "source": "mkdirSync(LOG_DIR, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 316,
+      "api": "existsSync",
+      "source": "if (!existsSync(PID_FILE)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 320,
+      "api": "readFileSync",
+      "source": "const pid = parseInt(readFileSync(PID_FILE, \"utf-8\").trim(), 10);",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 330,
+      "api": "unlinkSync",
+      "source": "unlinkSync(PID_FILE);",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 337,
+      "api": "existsSync",
+      "source": "if (!existsSync(PID_FILE)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 341,
+      "api": "readFileSync",
+      "source": "const pid = parseInt(readFileSync(PID_FILE, \"utf-8\").trim(), 10);",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 349,
+      "api": "unlinkSync",
+      "source": "unlinkSync(PID_FILE);",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 399,
+      "api": "existsSync",
+      "source": "if (os === \"darwin\" && existsSync(LAUNCHD_PLIST)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 400,
+      "api": "execSync",
+      "source": "execSync(`launchctl load \"${LAUNCHD_PLIST}\"`);",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 401,
+      "api": "existsSync",
+      "source": "} else if (os === \"linux\" && existsSync(SYSTEMD_UNIT)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 402,
+      "api": "execSync",
+      "source": "execSync(\"systemctl --user start signet.service\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 414,
+      "api": "existsSync",
+      "source": "if (os === \"darwin\" && existsSync(LAUNCHD_PLIST)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 416,
+      "api": "execSync",
+      "source": "execSync(`launchctl unload \"${LAUNCHD_PLIST}\"`);",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 420,
+      "api": "existsSync",
+      "source": "} else if (os === \"linux\" && existsSync(SYSTEMD_UNIT)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 422,
+      "api": "execSync",
+      "source": "execSync(\"systemctl --user stop signet.service\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 446,
+      "api": "existsSync",
+      "source": "if (os === \"darwin\" && existsSync(LAUNCHD_PLIST)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 448,
+      "api": "existsSync",
+      "source": "} else if (os === \"linux\" && existsSync(SYSTEMD_UNIT)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 462,
+      "api": "existsSync",
+      "source": "return existsSync(LAUNCHD_PLIST);",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 464,
+      "api": "existsSync",
+      "source": "return existsSync(SYSTEMD_UNIT);",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 467,
+      "api": "existsSync",
+      "source": "return existsSync(PID_FILE);",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 484,
+      "api": "existsSync",
+      "source": "if (running && existsSync(PID_FILE)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 486,
+      "api": "readFileSync",
+      "source": "pid = parseInt(readFileSync(PID_FILE, \"utf-8\").trim(), 10);",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 515,
+      "api": "existsSync",
+      "source": "if (!existsSync(logFile)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 518,
+      "api": "existsSync",
+      "source": "if (existsSync(outLog)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 519,
+      "api": "readFileSync",
+      "source": "const content = readFileSync(outLog, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "service.ts",
+      "line": 525,
+      "api": "readFileSync",
+      "source": "const content = readFileSync(logFile, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 109,
+      "api": "withWriteTx",
+      "source": "db.withWriteTx((wdb: WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 226,
+      "api": "withReadDb",
+      "source": "return db.withReadDb((rdb: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 243,
+      "api": "withReadDb",
+      "source": "return db.withReadDb((rdb: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 259,
+      "api": "withReadDb",
+      "source": "return db.withReadDb((rdb: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 277,
+      "api": "withReadDb",
+      "source": "return db.withReadDb((rdb: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 301,
+      "api": "withWriteTx",
+      "source": "return db.withWriteTx((wdb: WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-claims.ts",
+      "line": 64,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-claims.ts",
+      "line": 82,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-claims.ts",
+      "line": 92,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-claims.ts",
+      "line": 119,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-claims.ts",
+      "line": 125,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb(readClaims);",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-end-recovery.ts",
+      "line": 106,
+      "api": "withWriteTx",
+      "source": "const result = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-memories.ts",
+      "line": 55,
+      "api": "existsSync",
+      "source": "if (!sessionKey || candidates.length === 0 || !existsSync(getMemoryDbPath())) return;",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-memories.ts",
+      "line": 59,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-memories.ts",
+      "line": 148,
+      "api": "existsSync",
+      "source": "if (!sessionKey || matchedIds.length === 0 || !existsSync(getMemoryDbPath())) return;",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-memories.ts",
+      "line": 153,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-memories.ts",
+      "line": 262,
+      "api": "existsSync",
+      "source": "if (!sessionKey || Object.keys(feedback).length === 0 || !existsSync(getMemoryDbPath())) return;",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-memories.ts",
+      "line": 268,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-recall-dedupe.ts",
+      "line": 149,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-recall-dedupe.ts",
+      "line": 244,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 103,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => tableExistsInDatabase(db, name));",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 112,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 152,
+      "api": "existsSync",
+      "source": "if (!existsSync(memoryDir)) return 0;",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 158,
+      "api": "readdirSync",
+      "source": "const files = readdirSync(memoryDir).filter((name) => name.endsWith(\"--transcript.md\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 162,
+      "api": "readFileSync",
+      "source": "const parsed = parseArtifactFrontmatter(readFileSync(path, \"utf8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 248,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 331,
+      "api": "readFileSync",
+      "source": "const parsed = JSON.parse(readFileSync(path, \"utf8\")) as { readonly agent_id?: unknown };",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 347,
+      "api": "existsSync",
+      "source": "if (existsSync(markerPath) && markerMatches(markerPath, agentId)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 371,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dirname(markerPath), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 372,
+      "api": "writeFileSync",
+      "source": "writeFileSync(",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 392,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 446,
+      "api": "withWriteTx",
+      "source": "return (accessor ?? getDbAccessor()).withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 561,
+      "api": "withWriteTx",
+      "source": "return (accessor ?? getDbAccessor()).withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 595,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 641,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 680,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 735,
+      "api": "withReadDb",
+      "source": "const exactRows: TranscriptRow[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 780,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 844,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-ttl-finalizer.ts",
+      "line": 79,
+      "api": "withReadDb",
+      "source": "const alreadyCompleted = deps.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-ttl-finalizer.ts",
+      "line": 92,
+      "api": "withWriteTx",
+      "source": "deps.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "single-instance-lock.ts",
+      "line": 28,
+      "api": "readFileSync",
+      "source": "const pid = Number.parseInt(readFileSync(path, \"utf8\").trim().split(/\\s+/)[0] ?? \"\", 10);",
+      "category": "hot-path"
+    },
+    {
+      "path": "single-instance-lock.ts",
+      "line": 40,
+      "api": "statSync",
+      "source": "return Date.now() - statSync(path).mtimeMs > STALE_LOCK_AGE_MS;",
+      "category": "hot-path"
+    },
+    {
+      "path": "single-instance-lock.ts",
+      "line": 49,
+      "api": "renameSync",
+      "source": "renameSync(path, stalePath);",
+      "category": "hot-path"
+    },
+    {
+      "path": "single-instance-lock.ts",
+      "line": 55,
+      "api": "unlinkSync",
+      "source": "unlinkSync(stalePath);",
+      "category": "hot-path"
+    },
+    {
+      "path": "single-instance-lock.ts",
+      "line": 63,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dirname(path), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "single-instance-lock.ts",
+      "line": 69,
+      "api": "writeFileSync",
+      "source": "writeFileSync(fd, `${process.pid}\\n${Date.now()}\\n`);",
+      "category": "hot-path"
+    },
+    {
+      "path": "single-instance-lock.ts",
+      "line": 73,
+      "api": "unlinkSync",
+      "source": "unlinkSync(path);",
+      "category": "hot-path"
+    },
+    {
+      "path": "single-instance-lock.ts",
+      "line": 91,
+      "api": "unlinkSync",
+      "source": "unlinkSync(lock.path);",
+      "category": "hot-path"
+    },
+    {
+      "path": "skill-invocations.ts",
+      "line": 50,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "skill-transcript-scan.ts",
+      "line": 19,
+      "api": "statSync",
+      "source": "const stat = statSync(args.transcriptPath);",
+      "category": "hot-path"
+    },
+    {
+      "path": "skill-transcript-scan.ts",
+      "line": 32,
+      "api": "readFileSync",
+      "source": "content = readFileSync(args.transcriptPath, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "source-artifact-graph.ts",
+      "line": 304,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "source-artifact-graph.ts",
+      "line": 314,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "source-purge.ts",
+      "line": 23,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "source-snapshots.ts",
+      "line": 104,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "source-snapshots.ts",
+      "line": 179,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "startup-recovery.ts",
+      "line": 56,
+      "api": "withReadDb",
+      "source": "const batch = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => fetchBatch(db, limit));",
+      "category": "hot-path"
+    },
+    {
+      "path": "startup-recovery.ts",
+      "line": 59,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => processBatch(db, batch));",
+      "category": "hot-path"
+    },
+    {
+      "path": "startup-recovery.ts",
+      "line": 102,
+      "api": "withWriteTx",
+      "source": "documentLeasesRecovered = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "startup-recovery.ts",
+      "line": 170,
+      "api": "withReadDb",
+      "source": "const migrationInProgress = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "startup-recovery.ts",
+      "line": 219,
+      "api": "withWriteTx",
+      "source": "orphanedPassesSwept = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "telemetry.ts",
+      "line": 492,
+      "api": "withWriteTx",
+      "source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "telemetry.ts",
+      "line": 532,
+      "api": "withWriteTx",
+      "source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "temporal-expand.ts",
+      "line": 178,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "temporal-fallback.ts",
+      "line": 36,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => tableExistsIn(db, name));",
+      "category": "hot-path"
+    },
+    {
+      "path": "temporal-fallback.ts",
+      "line": 150,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "temporal-fallback.ts",
+      "line": 206,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "temporal-recall.ts",
+      "line": 442,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "test-temp-dir.ts",
+      "line": 31,
+      "api": "rmSync",
+      "source": "rmSync(dir, { recursive: true, force: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "test-temp-dir.ts",
+      "line": 59,
+      "api": "rmSync",
+      "source": "rmSync(dir, { recursive: true, force: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-audit.ts",
+      "line": 58,
+      "api": "existsSync",
+      "source": "if (!existsSync(dir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-audit.ts",
+      "line": 59,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-audit.ts",
+      "line": 65,
+      "api": "writeFileSync",
+      "source": "writeFileSync(latestPath, content, \"utf8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-audit.ts",
+      "line": 75,
+      "api": "renameSync",
+      "source": "renameSync(latestPath, finalPath);",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-audit.ts",
+      "line": 79,
+      "api": "writeFileSync",
+      "source": "writeFileSync(finalPath, content, \"utf8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-health.ts",
+      "line": 42,
+      "api": "statSync",
+      "source": "return statSync(path).mtime.toISOString();",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-health.ts",
+      "line": 50,
+      "api": "existsSync",
+      "source": "if (!existsSync(root)) return { latestLogs: 0, finalLogs: 0, newestAuditAt: null };",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-health.ts",
+      "line": 55,
+      "api": "readdirSync",
+      "source": "for (const entry of readdirSync(dir, { withFileTypes: true })) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-health.ts",
+      "line": 74,
+      "api": "existsSync",
+      "source": "return rel ? existsSync(join(basePath, rel)) : false;",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-health.ts",
+      "line": 79,
+      "api": "readFileSync",
+      "source": "const body = readFileSync(path, \"utf8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 153,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 155,
+      "api": "readFileSync",
+      "source": "for (const line of readFileSync(path, \"utf8\").split(/\\r?\\n/)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 188,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return [];",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 189,
+      "api": "statSync",
+      "source": "const size = statSync(path).size;",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 205,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dirname(path), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 208,
+      "api": "writeFileSync",
+      "source": "writeFileSync(tmp, body.length > 0 ? `${body}\\n` : \"\", \"utf8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 209,
+      "api": "renameSync",
+      "source": "renameSync(tmp, path);",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 214,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dirname(path), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 215,
+      "api": "appendFileSync",
+      "source": "appendFileSync(",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 231,
+      "api": "readFileSync",
+      "source": "const parsed = JSON.parse(readFileSync(join(path, \"owner.json\"), \"utf8\")) as { readonly pid?: unknown };",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 240,
+      "api": "readFileSync",
+      "source": "const parsed = JSON.parse(readFileSync(join(path, \"owner.json\"), \"utf8\")) as { readonly token?: unknown };",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 260,
+      "api": "statSync",
+      "source": "return now - statSync(path).mtimeMs > LOCK_DEAD_OWNER_STALE_MS;",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 271,
+      "api": "mkdirSync",
+      "source": "mkdirSync(lockPath);",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 272,
+      "api": "writeFileSync",
+      "source": "writeFileSync(",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 285,
+      "api": "rmSync",
+      "source": "rmSync(lockPath, { recursive: true, force: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 295,
+      "api": "readFileSync",
+      "source": "const parsed = JSON.parse(readFileSync(join(lockPath, \"owner.json\"), \"utf8\")) as { readonly token?: unknown };",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 300,
+      "api": "rmSync",
+      "source": "rmSync(lockPath, { recursive: true, force: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 304,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dirname(path), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 372,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return { canonicalKeys, liveOnlyKeys };",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 405,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return false;",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 445,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 446,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dirname(path), { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 448,
+      "api": "writeFileSync",
+      "source": "writeFileSync(path, `${body}\\n`, \"utf8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 493,
+      "api": "renameSync",
+      "source": "renameSync(tmpPath, path);",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 501,
+      "api": "rmSync",
+      "source": "rmSync(tmpPath, { force: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 561,
+      "api": "existsSync",
+      "source": "if (replacements.size === 0 || !existsSync(jsonlPath)) return Promise.resolve(0);",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 648,
+      "api": "renameSync",
+      "source": "renameSync(tmpPath, jsonlPath);",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-jsonl.ts",
+      "line": 661,
+      "api": "rmSync",
+      "source": "rmSync(tmpPath, { force: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 266,
+      "api": "withReadDb",
+      "source": "if (dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => unchanged(db, agentId, candidate))) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 295,
+      "api": "withWriteTx",
+      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 304,
+      "api": "withReadDb",
+      "source": "const alreadyCaptured = dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 309,
+      "api": "withWriteTx",
+      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 329,
+      "api": "withWriteTx",
+      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 375,
+      "api": "withWriteTx",
+      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "update-system.ts",
+      "line": 321,
+      "api": "existsSync",
+      "source": "if (!existsSync(p)) continue;",
+      "category": "hot-path"
+    },
+    {
+      "path": "update-system.ts",
+      "line": 323,
+      "api": "readFileSync",
+      "source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "update-system.ts",
+      "line": 367,
+      "api": "existsSync",
+      "source": "if (!existsSync(p)) continue;",
+      "category": "hot-path"
+    },
+    {
+      "path": "update-system.ts",
+      "line": 370,
+      "api": "readFileSync",
+      "source": "const current = readFileSync(p, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "update-system.ts",
+      "line": 382,
+      "api": "writeFileSync",
+      "source": "writeFileSync(p, updated);",
+      "category": "hot-path"
+    },
+    {
+      "path": "update-system.ts",
+      "line": 609,
+      "api": "existsSync",
+      "source": "existsSync: (path) => existsSync(path),",
+      "category": "hot-path"
+    },
+    {
+      "path": "update-system.ts",
+      "line": 610,
+      "api": "readFileSync",
+      "source": "readFileSync: (path, encoding) => readFileSync(path, { encoding }),",
+      "category": "hot-path"
+    },
+    {
+      "path": "update-system.ts",
+      "line": 615,
+      "api": "existsSync",
+      "source": "const launcherExists = deps.existsSync(launcherPath);",
+      "category": "hot-path"
+    },
+    {
+      "path": "update-system.ts",
+      "line": 616,
+      "api": "existsSync",
+      "source": "const appImageExists = deps.existsSync(appImagePath);",
+      "category": "hot-path"
+    },
+    {
+      "path": "update-system.ts",
+      "line": 639,
+      "api": "readFileSync",
+      "source": "const launcher = deps.readFileSync(launcherPath, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "update-system.ts",
+      "line": 670,
+      "api": "existsSync",
+      "source": "existsSync: deps.existsSync ?? ((path: string) => existsSync(path)),",
+      "category": "hot-path"
+    },
+    {
+      "path": "update-system.ts",
+      "line": 671,
+      "api": "readFileSync",
+      "source": "readFileSync: deps.readFileSync ?? ((path: string, encoding: BufferEncoding) => readFileSync(path, { encoding })),",
+      "category": "hot-path"
+    },
+    {
+      "path": "update-system.ts",
+      "line": 694,
+      "api": "existsSync",
+      "source": "if (!fsDeps.existsSync(deps.signetCliPath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "update-system.ts",
+      "line": 716,
+      "api": "existsSync",
+      "source": "if (!fsDeps.existsSync(signetBin)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "watcher-ignore.ts",
+      "line": 140,
+      "api": "existsSync",
+      "source": "if (!existsSync(sigignorePath)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "watcher-ignore.ts",
+      "line": 141,
+      "api": "writeFileSync",
+      "source": "writeFileSync(sigignorePath, DEFAULT_SIGNIGNORE_CONTENT, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "watcher-ignore.ts",
+      "line": 155,
+      "api": "statSync",
+      "source": "const stat = statSync(sigignorePath);",
+      "category": "hot-path"
+    },
+    {
+      "path": "watcher-ignore.ts",
+      "line": 158,
+      "api": "readFileSync",
+      "source": "cache = { stamp, patterns: parseSigignore(readFileSync(sigignorePath, \"utf-8\")) };",
+      "category": "hot-path"
+    },
+    {
+      "path": "which.ts",
+      "line": 8,
+      "api": "accessSync",
+      "source": "accessSync(file, constants.X_OK);",
+      "category": "hot-path"
+    },
+    {
+      "path": "which.ts",
+      "line": 9,
+      "api": "statSync",
+      "source": "return statSync(file).isFile();",
+      "category": "hot-path"
+    },
+    {
+      "path": "widget-gen.ts",
+      "line": 36,
+      "api": "existsSync",
+      "source": "if (!existsSync(dir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "widget-gen.ts",
+      "line": 37,
+      "api": "mkdirSync",
+      "source": "mkdirSync(dir, { recursive: true });",
+      "category": "hot-path"
+    },
+    {
+      "path": "widget-gen.ts",
+      "line": 229,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return null;",
+      "category": "hot-path"
+    },
+    {
+      "path": "widget-gen.ts",
+      "line": 232,
+      "api": "readFileSync",
+      "source": "const content = readFileSync(path, \"utf-8\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "widget-gen.ts",
+      "line": 241,
+      "api": "existsSync",
+      "source": "if (!existsSync(path)) return false;",
+      "category": "hot-path"
+    },
+    {
+      "path": "widget-gen.ts",
+      "line": 244,
+      "api": "unlinkSync",
+      "source": "unlinkSync(path);",
+      "category": "hot-path"
+    },
+    {
+      "path": "widget-gen.ts",
+      "line": 308,
+      "api": "writeFileSync",
+      "source": "writeFileSync(widgetPath(serverId), html);",
+      "category": "hot-path"
+    },
+    {
+      "path": "yielding-writes.ts",
+      "line": 86,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx(processBatch);",
+      "category": "hot-path"
+    },
+    {
+      "path": "yielding-writes.ts",
+      "line": 123,
+      "api": "withReadDb",
+      "source": "const batch = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => fetchBatch(db, limit));",
+      "category": "hot-path"
+    }
+  ]
 }

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -1,70 +1,7 @@
 {
   "version": 1,
-  "generatedFrom": "platform/daemon/src",
+  "generatedFrom": "manual migration ledger",
   "sites": [
-    {
-      "path": "agent-id.ts",
-      "line": 56,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "agent-id.ts",
-      "line": 82,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "aggregate-recall.ts",
-      "line": 740,
-      "api": "withReadDb",
-      "source": "const activeCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "aggregate-recall.ts",
-      "line": 746,
-      "api": "withWriteTx",
-      "source": "const written = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "aggregate-recall.ts",
-      "line": 995,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/api-keys.ts",
-      "line": 197,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/api-keys.ts",
-      "line": 241,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/api-keys.ts",
-      "line": 258,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/api-keys.ts",
-      "line": 272,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
     {
       "path": "auth/tokens.ts",
       "line": 30,
@@ -105,20 +42,6 @@
       "line": 47,
       "api": "writeFileSync",
       "source": "writeFileSync(secretPath, secret, { mode: 0o600 });",
-      "category": "hot-path"
-    },
-    {
-      "path": "black-box.ts",
-      "line": 434,
-      "api": "withReadDb",
-      "source": "const events = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "black-box.ts",
-      "line": 467,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -210,139 +133,6 @@
       "line": 724,
       "api": "readFileSync",
       "source": "text = readFileSync(path, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/filesystem.ts",
-      "line": 232,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/filesystem.ts",
-      "line": 287,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/filesystem.ts",
-      "line": 310,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 23,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 43,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 59,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 74,
-      "api": "withReadDb",
-      "source": "const before = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 82,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 98,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 108,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 145,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 645,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 768,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 813,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 856,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 884,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 914,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 953,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 1028,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
@@ -452,23 +242,9 @@
     },
     {
       "path": "daemon.ts",
-      "line": 1440,
-      "api": "withWriteTx",
-      "source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
       "line": 1442,
       "api": "readFileSync",
       "source": "const routing = parseRoutingConfig(parseSimpleYaml(readFileSync(path, \"utf-8\")));",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 1521,
-      "api": "withReadDb",
-      "source": "const activeEmbeddingCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
       "category": "hot-path"
     },
     {
@@ -515,20 +291,6 @@
     },
     {
       "path": "daemon.ts",
-      "line": 2204,
-      "api": "withReadDb",
-      "source": "const memoryCount = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 2215,
-      "api": "withReadDb",
-      "source": "const queue = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
       "line": 2393,
       "api": "existsSync",
       "source": "if (existsSync(healthStampPath)) {",
@@ -553,27 +315,6 @@
       "line": 127,
       "api": "existsSync",
       "source": "if (existsSync(bundled)) return bundled;",
-      "category": "hot-path"
-    },
-    {
-      "path": "database-integrity.ts",
-      "line": 270,
-      "api": "withReadDb",
-      "source": "const checks = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => ({",
-      "category": "hot-path"
-    },
-    {
-      "path": "database-integrity.ts",
-      "line": 304,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "database-integrity.ts",
-      "line": 309,
-      "api": "withReadDb",
-      "source": "const verifiedTelemetry = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
       "category": "hot-path"
     },
     {
@@ -717,34 +458,6 @@
       "category": "hot-path"
     },
     {
-      "path": "db-vacuum.ts",
-      "line": 322,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readStatusFromDb(toPragmaReadDb(db)));",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-vacuum.ts",
-      "line": 411,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-vacuum.ts",
-      "line": 437,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-vacuum.ts",
-      "line": 453,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "discord-desktop-cache-source.ts",
       "line": 221,
       "api": "lstatSync",
@@ -767,205 +480,9 @@
     },
     {
       "path": "discord-desktop-cache-source.ts",
-      "line": 481,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-desktop-cache-source.ts",
-      "line": 494,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-desktop-cache-source.ts",
       "line": 1085,
       "api": "readFileSync",
       "source": "const data = fileSystem.readFileSync(path).subarray(0, CACHE_SNIFF_BYTES).toString(\"utf8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 574,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 588,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 630,
-      "api": "withReadDb",
-      "source": "const row = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 875,
-      "api": "withReadDb",
-      "source": "const row = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 959,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 973,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-fetch.ts",
-      "line": 494,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => resolveActiveEmbeddingConfig(db, cfg));",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-index-migration.ts",
-      "line": 80,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx(fn);",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-index-migration.ts",
-      "line": 253,
-      "api": "withReadDb",
-      "source": "const state = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readEmbeddingIndexState(db));",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-index-migration.ts",
-      "line": 262,
-      "api": "withReadDb",
-      "source": "const rows = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-index-migration.ts",
-      "line": 343,
-      "api": "withReadDb",
-      "source": "const coverage = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-index-migration.ts",
-      "line": 355,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-index-migration.ts",
-      "line": 435,
-      "api": "withReadDb",
-      "source": "const before = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readEmbeddingIndexState(db));",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-index-migration.ts",
-      "line": 437,
-      "api": "withWriteTx",
-      "source": "const initial = input.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-index-migration.ts",
-      "line": 446,
-      "api": "withReadDb",
-      "source": "const hasStagingVectorIndex = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-index-migration.ts",
-      "line": 452,
-      "api": "withWriteTx",
-      "source": "input.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-index-migration.ts",
-      "line": 458,
-      "api": "withWriteTx",
-      "source": "input.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-index-migration.ts",
-      "line": 469,
-      "api": "withReadDb",
-      "source": "const state = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readEmbeddingIndexState(db));",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-repair-state.ts",
-      "line": 101,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-repair-state.ts",
-      "line": 139,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-repair-state.ts",
-      "line": 160,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-repair-state.ts",
-      "line": 191,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-tracker.ts",
-      "line": 194,
-      "api": "withReadDb",
-      "source": "const staleRows: StaleRow[] = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-tracker.ts",
-      "line": 265,
-      "api": "withWriteTx",
-      "source": "applied = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-usage.ts",
-      "line": 90,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-usage.ts",
-      "line": 115,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -1022,27 +539,6 @@
       "line": 11,
       "api": "writeFileSync",
       "source": "writeFileSync(path, content);",
-      "category": "hot-path"
-    },
-    {
-      "path": "github-source-provider.ts",
-      "line": 461,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "github-source-provider.ts",
-      "line": 483,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "github-source-provider.ts",
-      "line": 497,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
@@ -1232,34 +728,6 @@
       "line": 85,
       "api": "existsSync",
       "source": "const identityPath = existsSync(join(agentDir, \"IDENTITY.md\"))",
-      "category": "hot-path"
-    },
-    {
-      "path": "imported-source-lifecycle.ts",
-      "line": 36,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "imported-source-outcome.ts",
-      "line": 16,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => persistImportedSourceOutcomeInTx(db, input));",
-      "category": "hot-path"
-    },
-    {
-      "path": "imported-source-outcome.ts",
-      "line": 59,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph-hygiene.ts",
-      "line": 428,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -1467,23 +935,9 @@
     },
     {
       "path": "memory-candidates.ts",
-      "line": 150,
-      "api": "withReadDb",
-      "source": "const batchRows: ScoredMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
       "line": 211,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 228,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -1495,20 +949,6 @@
     },
     {
       "path": "memory-candidates.ts",
-      "line": 306,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 368,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
       "line": 401,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return [];",
@@ -1516,23 +956,9 @@
     },
     {
       "path": "memory-candidates.ts",
-      "line": 432,
-      "api": "withReadDb",
-      "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
       "line": 440,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 473,
-      "api": "withReadDb",
-      "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -1547,27 +973,6 @@
       "line": 992,
       "api": "readFileSync",
       "source": "const yaml = parseSimpleYaml(readFileSync(path, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 59,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 128,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 147,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
@@ -1802,55 +1207,6 @@
       "category": "hot-path"
     },
     {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 269,
-      "api": "withReadDb",
-      "source": "const embeddingConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 304,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 318,
-      "api": "withReadDb",
-      "source": "const writeConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 347,
-      "api": "withWriteTx",
-      "source": "const stored = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 408,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 454,
-      "api": "withReadDb",
-      "source": "const row = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 475,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "obsidian-source-graph.ts",
       "line": 323,
       "api": "existsSync",
@@ -1862,125 +1218,6 @@
       "line": 323,
       "api": "statSync",
       "source": "return existsSync(path) && statSync(path).isFile() ? normalizedPath(path) : null;",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-graph.ts",
-      "line": 477,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-graph.ts",
-      "line": 696,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-graph.ts",
-      "line": 708,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 306,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: WriteDb) => insertAssertion(db, input));",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 325,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 391,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 410,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 438,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 466,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-claim-evidence.ts",
-      "line": 153,
-      "api": "withReadDb",
-      "source": "const items = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-claim-trace.ts",
-      "line": 1063,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-contradictions.ts",
-      "line": 524,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => reconcileOntologyContradictionsInTx(db, params));",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-contradictions.ts",
-      "line": 535,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-contradictions.ts",
-      "line": 591,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-extraction.ts",
-      "line": 647,
-      "api": "withReadDb",
-      "source": "const source = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-extraction.ts",
-      "line": 748,
-      "api": "withWriteTx",
-      "source": "const written = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "path-feedback.ts",
-      "line": 611,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
@@ -2005,178 +1242,10 @@
       "category": "hot-path"
     },
     {
-      "path": "pipeline/aspect-feedback.ts",
-      "line": 79,
-      "api": "withWriteTx",
-      "source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/aspect-feedback.ts",
-      "line": 165,
-      "api": "withWriteTx",
-      "source": "const decayed = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 136,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getDreamingAttentionInDb(db, agentId, limit));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 145,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 181,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 225,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 256,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 290,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-evidence-retry.ts",
-      "line": 131,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-evidence-retry.ts",
-      "line": 253,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 112,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 154,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 478,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 490,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 503,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 520,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 692,
-      "api": "withReadDb",
-      "source": "const pending = params.accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-runbook.ts",
-      "line": 177,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-runbook.ts",
-      "line": 219,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "pipeline/dreaming-token-cache.ts",
       "line": 36,
       "api": "existsSync",
       "source": "return existsSync(bundled)",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 96,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getQueueHealth(db).status !== \"healthy\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 106,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 182,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => hasDreamingAttentionKindInDb(db, scope, [\"hygiene\"])),",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 186,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 278,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
@@ -2191,48 +1260,6 @@
       "line": 733,
       "api": "readFileSync",
       "source": "const raw = readFileSync(path, \"utf-8\").trim();",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/extraction-fallback.ts",
-      "line": 17,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/prospective-index.ts",
-      "line": 230,
-      "api": "withWriteTx",
-      "source": "job = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => leaseJob(db, 3));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/prospective-index.ts",
-      "line": 242,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => failJob(db, j.id, \"invalid payload\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/prospective-index.ts",
-      "line": 252,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/prospective-index.ts",
-      "line": 262,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => completeJob(db, j.id));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/prospective-index.ts",
-      "line": 272,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => failJob(db, j.id, msg));",
       "category": "hot-path"
     },
     {
@@ -2271,83 +1298,6 @@
       "category": "hot-path"
     },
     {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 366,
-      "api": "withReadDb",
-      "source": "const memories = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 399,
-      "api": "withReadDb",
-      "source": "const existingReflections = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 461,
-      "api": "withWriteTx",
-      "source": "deps.getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 527,
-      "api": "withReadDb",
-      "source": ".withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reranker-embedding.ts",
-      "line": 51,
-      "api": "withReadDb",
-      "source": "const embMap = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 80,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 174,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 292,
-      "api": "withReadDb",
-      "source": "const writeConfig = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 305,
-      "api": "withWriteTx",
-      "source": "embeddingCreated = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 365,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 376,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "pipeline/skill-reconciler.ts",
       "line": 136,
       "api": "existsSync",
@@ -2370,13 +1320,6 @@
     },
     {
       "path": "pipeline/skill-reconciler.ts",
-      "line": 163,
-      "api": "withReadDb",
-      "source": "const graphSkills = deps.accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
       "line": 170,
       "api": "existsSync",
       "source": "if (!existsSync(row.fs_path)) {",
@@ -2394,20 +1337,6 @@
       "line": 234,
       "api": "readFileSync",
       "source": "const content = readFileSync(mdPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 241,
-      "api": "withReadDb",
-      "source": "const existing = deps.accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 250,
-      "api": "withReadDb",
-      "source": "const storedEmb = deps.accessor.withReadDb(",
       "category": "hot-path"
     },
     {
@@ -2450,20 +1379,6 @@
       "line": 85,
       "api": "writeFileSync",
       "source": "writeFileSync(path, JSON.stringify({ lastRunAt: timestamp }));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/synthesis-worker.ts",
-      "line": 127,
-      "api": "withReadDb",
-      "source": "const checkpointRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/synthesis-worker.ts",
-      "line": 153,
-      "api": "withReadDb",
-      "source": "const transcriptRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -2541,20 +1456,6 @@
       "line": 668,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return { lines: [], memories: [], memoryCount: 0, engine: \"no-entity\" };",
-      "category": "hot-path"
-    },
-    {
-      "path": "prompt-entity-context.ts",
-      "line": 671,
-      "api": "withReadDb",
-      "source": "const matches: PromptEntityMatch[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "prompt-entity-context.ts",
-      "line": 697,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -2643,27 +1544,6 @@
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 277,
-      "api": "withReadDb",
-      "source": "const docs = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/connectors-routes.ts",
-      "line": 288,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/connectors-routes.ts",
-      "line": 319,
-      "api": "withReadDb",
-      "source": "const docCount = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/connectors-routes.ts",
       "line": 352,
       "api": "existsSync",
       "source": "exists: existsSync(join(homedir(), \".claude\", \"settings.json\")),",
@@ -2730,20 +1610,6 @@
       "line": 28,
       "api": "existsSync",
       "source": "if (existsSync(join(candidate, \"index.html\"))) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/database-diagnostics.ts",
-      "line": 241,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/database-diagnostics.ts",
-      "line": 276,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -2866,66 +1732,10 @@
       "category": "hot-path"
     },
     {
-      "path": "routes/health.ts",
-      "line": 187,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/health.ts",
-      "line": 236,
-      "api": "withReadDb",
-      "source": "dbResult = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "routes/hooks-routes.ts",
       "line": 1148,
       "api": "existsSync",
       "source": "if (!existsSync(getCurrentMemoryDbPath())) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/hooks-routes.ts",
-      "line": 1163,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/hooks-routes.ts",
-      "line": 1191,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/hooks-routes.ts",
-      "line": 1311,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/import-routes.ts",
-      "line": 212,
-      "api": "withWriteTx",
-      "source": "const extraction = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/import-routes.ts",
-      "line": 252,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/import-routes.ts",
-      "line": 337,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -3062,27 +1872,6 @@
       "category": "hot-path"
     },
     {
-      "path": "routes/marketplace.ts",
-      "line": 1128,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/mcp-analytics.ts",
-      "line": 89,
-      "api": "withReadDb",
-      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/mcp-analytics.ts",
-      "line": 171,
-      "api": "withReadDb",
-      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "routes/memory-routes.ts",
       "line": 278,
       "api": "mkdirSync",
@@ -3126,13 +1915,6 @@
     },
     {
       "path": "routes/pipeline-routes.ts",
-      "line": 102,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/pipeline-routes.ts",
       "line": 296,
       "api": "existsSync",
       "source": "if (existsSync(p)) {",
@@ -3157,160 +1939,6 @@
       "line": 392,
       "api": "readFileSync",
       "source": "soulContent = readFileSync(soulPath, \"utf-8\").slice(0, 500);",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/pipeline-routes.ts",
-      "line": 457,
-      "api": "withReadDb",
-      "source": "const report: ReturnType<typeof listMemoryContentSafety> = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/pipeline-routes.ts",
-      "line": 557,
-      "api": "withReadDb",
-      "source": "const dbData = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/queue-diagnostics.ts",
-      "line": 169,
-      "api": "withReadDb",
-      "source": "const response = resolveAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/reflection-routes.ts",
-      "line": 98,
-      "api": "withReadDb",
-      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/reflection-routes.ts",
-      "line": 118,
-      "api": "withReadDb",
-      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/reflection-routes.ts",
-      "line": 172,
-      "api": "withReadDb",
-      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/reflection-routes.ts",
-      "line": 207,
-      "api": "withReadDb",
-      "source": "const existing = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/reflection-routes.ts",
-      "line": 225,
-      "api": "withWriteTx",
-      "source": "resolveDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 313,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 357,
-      "api": "withWriteTx",
-      "source": "const result = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => clusterEntities(db, agentId));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 378,
-      "api": "withReadDb",
-      "source": "const unlinked = accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 408,
-      "api": "withReadDb",
-      "source": "const preview = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 459,
-      "api": "withWriteTx",
-      "source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 469,
-      "api": "withReadDb",
-      "source": "const remaining = accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 512,
-      "api": "withReadDb",
-      "source": "const unhinted = accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 537,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 545,
-      "api": "withReadDb",
-      "source": "const remaining = accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 585,
-      "api": "withReadDb",
-      "source": "const dead = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/session-routes.ts",
-      "line": 168,
-      "api": "withReadDb",
-      "source": "const hits = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/session-routes.ts",
-      "line": 347,
-      "api": "withReadDb",
-      "source": "const tableExists = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/session-routes.ts",
-      "line": 355,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skill-analytics.ts",
-      "line": 121,
-      "api": "withReadDb",
-      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
       "category": "hot-path"
     },
     {
@@ -3608,41 +2236,6 @@
       "category": "hot-path"
     },
     {
-      "path": "routes/sources-routes.ts",
-      "line": 800,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 939,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1051,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1114,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1153,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "routes/state.ts",
       "line": 157,
       "api": "existsSync",
@@ -3671,48 +2264,6 @@
       "category": "hot-path"
     },
     {
-      "path": "routes/state.ts",
-      "line": 457,
-      "api": "withReadDb",
-      "source": "const report = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/telemetry-routes.ts",
-      "line": 200,
-      "api": "withReadDb",
-      "source": "const mutationHealth = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/telemetry-routes.ts",
-      "line": 219,
-      "api": "withReadDb",
-      "source": "const scores: Array<Record<string, unknown>> = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/telemetry-routes.ts",
-      "line": 263,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/utils.ts",
-      "line": 437,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/utils.ts",
-      "line": 525,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "routes/widget.ts",
       "line": 75,
       "api": "existsSync",
@@ -3731,34 +2282,6 @@
       "line": 42,
       "api": "readFileSync",
       "source": "const raw = readFileSync(skillPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "scheduler/worker.ts",
-      "line": 104,
-      "api": "withWriteTx",
-      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "scheduler/worker.ts",
-      "line": 122,
-      "api": "withReadDb",
-      "source": "const dueTasks = db.withReadDb((rdb: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "scheduler/worker.ts",
-      "line": 193,
-      "api": "withWriteTx",
-      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "scheduler/worker.ts",
-      "line": 280,
-      "api": "withWriteTx",
-      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
@@ -4259,101 +2782,10 @@
       "category": "hot-path"
     },
     {
-      "path": "session-checkpoints.ts",
-      "line": 109,
-      "api": "withWriteTx",
-      "source": "db.withWriteTx((wdb: WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-checkpoints.ts",
-      "line": 226,
-      "api": "withReadDb",
-      "source": "return db.withReadDb((rdb: ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-checkpoints.ts",
-      "line": 243,
-      "api": "withReadDb",
-      "source": "return db.withReadDb((rdb: ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-checkpoints.ts",
-      "line": 259,
-      "api": "withReadDb",
-      "source": "return db.withReadDb((rdb: ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-checkpoints.ts",
-      "line": 277,
-      "api": "withReadDb",
-      "source": "return db.withReadDb((rdb: ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-checkpoints.ts",
-      "line": 301,
-      "api": "withWriteTx",
-      "source": "return db.withWriteTx((wdb: WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-claims.ts",
-      "line": 64,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-claims.ts",
-      "line": 82,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-claims.ts",
-      "line": 92,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-claims.ts",
-      "line": 119,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-claims.ts",
-      "line": 125,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb(readClaims);",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-end-recovery.ts",
-      "line": 106,
-      "api": "withWriteTx",
-      "source": "const result = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "session-memories.ts",
       "line": 55,
       "api": "existsSync",
       "source": "if (!sessionKey || candidates.length === 0 || !existsSync(getMemoryDbPath())) return;",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-memories.ts",
-      "line": 59,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
@@ -4365,51 +2797,9 @@
     },
     {
       "path": "session-memories.ts",
-      "line": 153,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-memories.ts",
       "line": 262,
       "api": "existsSync",
       "source": "if (!sessionKey || Object.keys(feedback).length === 0 || !existsSync(getMemoryDbPath())) return;",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-memories.ts",
-      "line": 268,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-recall-dedupe.ts",
-      "line": 149,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-recall-dedupe.ts",
-      "line": 244,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 103,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => tableExistsInDatabase(db, name));",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 112,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -4431,13 +2821,6 @@
       "line": 162,
       "api": "readFileSync",
       "source": "const parsed = parseArtifactFrontmatter(readFileSync(path, \"utf8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 248,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -4466,83 +2849,6 @@
       "line": 372,
       "api": "writeFileSync",
       "source": "writeFileSync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 392,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 446,
-      "api": "withWriteTx",
-      "source": "return (accessor ?? getDbAccessor()).withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 561,
-      "api": "withWriteTx",
-      "source": "return (accessor ?? getDbAccessor()).withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 595,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 641,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 680,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 735,
-      "api": "withReadDb",
-      "source": "const exactRows: TranscriptRow[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 780,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 844,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-ttl-finalizer.ts",
-      "line": 79,
-      "api": "withReadDb",
-      "source": "const alreadyCompleted = deps.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-ttl-finalizer.ts",
-      "line": 92,
-      "api": "withWriteTx",
-      "source": "deps.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
       "category": "hot-path"
     },
     {
@@ -4602,13 +2908,6 @@
       "category": "hot-path"
     },
     {
-      "path": "skill-invocations.ts",
-      "line": 50,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "skill-transcript-scan.ts",
       "line": 19,
       "api": "statSync",
@@ -4620,125 +2919,6 @@
       "line": 32,
       "api": "readFileSync",
       "source": "content = readFileSync(args.transcriptPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "source-artifact-graph.ts",
-      "line": 304,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "source-artifact-graph.ts",
-      "line": 314,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "source-purge.ts",
-      "line": 23,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "source-snapshots.ts",
-      "line": 104,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "source-snapshots.ts",
-      "line": 179,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "startup-recovery.ts",
-      "line": 56,
-      "api": "withReadDb",
-      "source": "const batch = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => fetchBatch(db, limit));",
-      "category": "hot-path"
-    },
-    {
-      "path": "startup-recovery.ts",
-      "line": 59,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => processBatch(db, batch));",
-      "category": "hot-path"
-    },
-    {
-      "path": "startup-recovery.ts",
-      "line": 102,
-      "api": "withWriteTx",
-      "source": "documentLeasesRecovered = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "startup-recovery.ts",
-      "line": 170,
-      "api": "withReadDb",
-      "source": "const migrationInProgress = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "startup-recovery.ts",
-      "line": 219,
-      "api": "withWriteTx",
-      "source": "orphanedPassesSwept = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "telemetry.ts",
-      "line": 492,
-      "api": "withWriteTx",
-      "source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "telemetry.ts",
-      "line": 532,
-      "api": "withWriteTx",
-      "source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "temporal-expand.ts",
-      "line": 178,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "temporal-fallback.ts",
-      "line": 36,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => tableExistsIn(db, name));",
-      "category": "hot-path"
-    },
-    {
-      "path": "temporal-fallback.ts",
-      "line": 150,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "temporal-fallback.ts",
-      "line": 206,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "temporal-recall.ts",
-      "line": 442,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -5022,48 +3202,6 @@
       "category": "hot-path"
     },
     {
-      "path": "transcript-recovery-worker.ts",
-      "line": 266,
-      "api": "withReadDb",
-      "source": "if (dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => unchanged(db, agentId, candidate))) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 295,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 304,
-      "api": "withReadDb",
-      "source": "const alreadyCaptured = dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 309,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 329,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 375,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
       "path": "update-system.ts",
       "line": 321,
       "api": "existsSync",
@@ -5250,6 +3388,1791 @@
       "line": 308,
       "api": "writeFileSync",
       "source": "writeFileSync(widgetPath(serverId), html);",
+      "category": "hot-path"
+    },
+    {
+      "path": "agent-id.ts",
+      "line": 56,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "agent-id.ts",
+      "line": 82,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "aggregate-recall.ts",
+      "line": 740,
+      "api": "withReadDb",
+      "source": "const activeCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "aggregate-recall.ts",
+      "line": 746,
+      "api": "withWriteTx",
+      "source": "const written = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "aggregate-recall.ts",
+      "line": 995,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/api-keys.ts",
+      "line": 197,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/api-keys.ts",
+      "line": 241,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/api-keys.ts",
+      "line": 258,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/api-keys.ts",
+      "line": 272,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "black-box.ts",
+      "line": 434,
+      "api": "withReadDb",
+      "source": "const events = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "black-box.ts",
+      "line": 467,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/filesystem.ts",
+      "line": 232,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/filesystem.ts",
+      "line": 287,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/filesystem.ts",
+      "line": 310,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 23,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 43,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 59,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 74,
+      "api": "withReadDb",
+      "source": "const before = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 82,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 98,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 108,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 145,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 645,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 768,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 813,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 856,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 884,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 914,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 953,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 1028,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1440,
+      "api": "withWriteTx",
+      "source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1521,
+      "api": "withReadDb",
+      "source": "const activeEmbeddingCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 2204,
+      "api": "withReadDb",
+      "source": "const memoryCount = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 2215,
+      "api": "withReadDb",
+      "source": "const queue = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "database-integrity.ts",
+      "line": 270,
+      "api": "withReadDb",
+      "source": "const checks = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => ({",
+      "category": "hot-path"
+    },
+    {
+      "path": "database-integrity.ts",
+      "line": 304,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "database-integrity.ts",
+      "line": 309,
+      "api": "withReadDb",
+      "source": "const verifiedTelemetry = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-vacuum.ts",
+      "line": 322,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readStatusFromDb(toPragmaReadDb(db)));",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-vacuum.ts",
+      "line": 411,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-vacuum.ts",
+      "line": 437,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-vacuum.ts",
+      "line": 453,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-desktop-cache-source.ts",
+      "line": 481,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-desktop-cache-source.ts",
+      "line": 494,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 574,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 588,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 630,
+      "api": "withReadDb",
+      "source": "const row = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 875,
+      "api": "withReadDb",
+      "source": "const row = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 959,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 973,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-fetch.ts",
+      "line": 494,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => resolveActiveEmbeddingConfig(db, cfg));",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-repair-state.ts",
+      "line": 101,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-repair-state.ts",
+      "line": 139,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-repair-state.ts",
+      "line": 160,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-repair-state.ts",
+      "line": 191,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-tracker.ts",
+      "line": 194,
+      "api": "withReadDb",
+      "source": "const staleRows: StaleRow[] = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-tracker.ts",
+      "line": 265,
+      "api": "withWriteTx",
+      "source": "applied = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-usage.ts",
+      "line": 90,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-usage.ts",
+      "line": 115,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "github-source-provider.ts",
+      "line": 461,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "github-source-provider.ts",
+      "line": 483,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "github-source-provider.ts",
+      "line": 497,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "imported-source-lifecycle.ts",
+      "line": 36,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "imported-source-outcome.ts",
+      "line": 16,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => persistImportedSourceOutcomeInTx(db, input));",
+      "category": "hot-path"
+    },
+    {
+      "path": "imported-source-outcome.ts",
+      "line": 59,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "knowledge-graph-hygiene.ts",
+      "line": 428,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 150,
+      "api": "withReadDb",
+      "source": "const batchRows: ScoredMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 228,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 306,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 368,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 432,
+      "api": "withReadDb",
+      "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 473,
+      "api": "withReadDb",
+      "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 59,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 128,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 147,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 269,
+      "api": "withReadDb",
+      "source": "const embeddingConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 304,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 318,
+      "api": "withReadDb",
+      "source": "const writeConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 347,
+      "api": "withWriteTx",
+      "source": "const stored = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 408,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 454,
+      "api": "withReadDb",
+      "source": "const row = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 475,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-graph.ts",
+      "line": 477,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-graph.ts",
+      "line": 696,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-graph.ts",
+      "line": 708,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 306,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: WriteDb) => insertAssertion(db, input));",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 325,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 391,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 410,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 438,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 466,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-claim-evidence.ts",
+      "line": 153,
+      "api": "withReadDb",
+      "source": "const items = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-claim-trace.ts",
+      "line": 1063,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-contradictions.ts",
+      "line": 524,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => reconcileOntologyContradictionsInTx(db, params));",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-contradictions.ts",
+      "line": 535,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-contradictions.ts",
+      "line": 591,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-extraction.ts",
+      "line": 647,
+      "api": "withReadDb",
+      "source": "const source = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-extraction.ts",
+      "line": 748,
+      "api": "withWriteTx",
+      "source": "const written = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "path-feedback.ts",
+      "line": 611,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/aspect-feedback.ts",
+      "line": 79,
+      "api": "withWriteTx",
+      "source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/aspect-feedback.ts",
+      "line": 165,
+      "api": "withWriteTx",
+      "source": "const decayed = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 136,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getDreamingAttentionInDb(db, agentId, limit));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 145,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 181,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 225,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 256,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 290,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-evidence-retry.ts",
+      "line": 131,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-evidence-retry.ts",
+      "line": 253,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 112,
+      "api": "withReadDb",
+      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 154,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 478,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 490,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 503,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 520,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 692,
+      "api": "withReadDb",
+      "source": "const pending = params.accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-runbook.ts",
+      "line": 177,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-runbook.ts",
+      "line": 219,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 96,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getQueueHealth(db).status !== \"healthy\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 106,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 182,
+      "api": "withReadDb",
+      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => hasDreamingAttentionKindInDb(db, scope, [\"hygiene\"])),",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 186,
+      "api": "withReadDb",
+      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 278,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/extraction-fallback.ts",
+      "line": 17,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/prospective-index.ts",
+      "line": 230,
+      "api": "withWriteTx",
+      "source": "job = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => leaseJob(db, 3));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/prospective-index.ts",
+      "line": 242,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => failJob(db, j.id, \"invalid payload\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/prospective-index.ts",
+      "line": 252,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/prospective-index.ts",
+      "line": 262,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => completeJob(db, j.id));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/prospective-index.ts",
+      "line": 272,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => failJob(db, j.id, msg));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reflection-worker.ts",
+      "line": 366,
+      "api": "withReadDb",
+      "source": "const memories = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reflection-worker.ts",
+      "line": 399,
+      "api": "withReadDb",
+      "source": "const existingReflections = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reflection-worker.ts",
+      "line": 461,
+      "api": "withWriteTx",
+      "source": "deps.getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reflection-worker.ts",
+      "line": 527,
+      "api": "withReadDb",
+      "source": ".withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reranker-embedding.ts",
+      "line": 51,
+      "api": "withReadDb",
+      "source": "const embMap = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 80,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 174,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 292,
+      "api": "withReadDb",
+      "source": "const writeConfig = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 305,
+      "api": "withWriteTx",
+      "source": "embeddingCreated = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 365,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 376,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 163,
+      "api": "withReadDb",
+      "source": "const graphSkills = deps.accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 241,
+      "api": "withReadDb",
+      "source": "const existing = deps.accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 250,
+      "api": "withReadDb",
+      "source": "const storedEmb = deps.accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/synthesis-worker.ts",
+      "line": 127,
+      "api": "withReadDb",
+      "source": "const checkpointRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/synthesis-worker.ts",
+      "line": 153,
+      "api": "withReadDb",
+      "source": "const transcriptRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "prompt-entity-context.ts",
+      "line": 671,
+      "api": "withReadDb",
+      "source": "const matches: PromptEntityMatch[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "prompt-entity-context.ts",
+      "line": 697,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/connectors-routes.ts",
+      "line": 277,
+      "api": "withReadDb",
+      "source": "const docs = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/connectors-routes.ts",
+      "line": 288,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/connectors-routes.ts",
+      "line": 319,
+      "api": "withReadDb",
+      "source": "const docCount = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/database-diagnostics.ts",
+      "line": 241,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/database-diagnostics.ts",
+      "line": 276,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/health.ts",
+      "line": 187,
+      "api": "withReadDb",
+      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/health.ts",
+      "line": 236,
+      "api": "withReadDb",
+      "source": "dbResult = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/hooks-routes.ts",
+      "line": 1163,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/hooks-routes.ts",
+      "line": 1191,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/hooks-routes.ts",
+      "line": 1311,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/import-routes.ts",
+      "line": 212,
+      "api": "withWriteTx",
+      "source": "const extraction = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/import-routes.ts",
+      "line": 252,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/import-routes.ts",
+      "line": 337,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace.ts",
+      "line": 1128,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/mcp-analytics.ts",
+      "line": 89,
+      "api": "withReadDb",
+      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/mcp-analytics.ts",
+      "line": 171,
+      "api": "withReadDb",
+      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/pipeline-routes.ts",
+      "line": 102,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/pipeline-routes.ts",
+      "line": 457,
+      "api": "withReadDb",
+      "source": "const report: ReturnType<typeof listMemoryContentSafety> = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/pipeline-routes.ts",
+      "line": 557,
+      "api": "withReadDb",
+      "source": "const dbData = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/queue-diagnostics.ts",
+      "line": 169,
+      "api": "withReadDb",
+      "source": "const response = resolveAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/reflection-routes.ts",
+      "line": 98,
+      "api": "withReadDb",
+      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/reflection-routes.ts",
+      "line": 118,
+      "api": "withReadDb",
+      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/reflection-routes.ts",
+      "line": 172,
+      "api": "withReadDb",
+      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/reflection-routes.ts",
+      "line": 207,
+      "api": "withReadDb",
+      "source": "const existing = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/reflection-routes.ts",
+      "line": 225,
+      "api": "withWriteTx",
+      "source": "resolveDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 313,
+      "api": "withReadDb",
+      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 357,
+      "api": "withWriteTx",
+      "source": "const result = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => clusterEntities(db, agentId));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 378,
+      "api": "withReadDb",
+      "source": "const unlinked = accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 408,
+      "api": "withReadDb",
+      "source": "const preview = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 459,
+      "api": "withWriteTx",
+      "source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 469,
+      "api": "withReadDb",
+      "source": "const remaining = accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 512,
+      "api": "withReadDb",
+      "source": "const unhinted = accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 537,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 545,
+      "api": "withReadDb",
+      "source": "const remaining = accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 585,
+      "api": "withReadDb",
+      "source": "const dead = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/session-routes.ts",
+      "line": 168,
+      "api": "withReadDb",
+      "source": "const hits = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/session-routes.ts",
+      "line": 347,
+      "api": "withReadDb",
+      "source": "const tableExists = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/session-routes.ts",
+      "line": 355,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skill-analytics.ts",
+      "line": 121,
+      "api": "withReadDb",
+      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 800,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 939,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 1051,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 1114,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 1153,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/state.ts",
+      "line": 457,
+      "api": "withReadDb",
+      "source": "const report = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/telemetry-routes.ts",
+      "line": 200,
+      "api": "withReadDb",
+      "source": "const mutationHealth = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/telemetry-routes.ts",
+      "line": 219,
+      "api": "withReadDb",
+      "source": "const scores: Array<Record<string, unknown>> = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/telemetry-routes.ts",
+      "line": 263,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/utils.ts",
+      "line": 437,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/utils.ts",
+      "line": 525,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "scheduler/worker.ts",
+      "line": 104,
+      "api": "withWriteTx",
+      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "scheduler/worker.ts",
+      "line": 122,
+      "api": "withReadDb",
+      "source": "const dueTasks = db.withReadDb((rdb: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "scheduler/worker.ts",
+      "line": 193,
+      "api": "withWriteTx",
+      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "scheduler/worker.ts",
+      "line": 280,
+      "api": "withWriteTx",
+      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 109,
+      "api": "withWriteTx",
+      "source": "db.withWriteTx((wdb: WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 226,
+      "api": "withReadDb",
+      "source": "return db.withReadDb((rdb: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 243,
+      "api": "withReadDb",
+      "source": "return db.withReadDb((rdb: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 259,
+      "api": "withReadDb",
+      "source": "return db.withReadDb((rdb: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 277,
+      "api": "withReadDb",
+      "source": "return db.withReadDb((rdb: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 301,
+      "api": "withWriteTx",
+      "source": "return db.withWriteTx((wdb: WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-claims.ts",
+      "line": 64,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-claims.ts",
+      "line": 82,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-claims.ts",
+      "line": 92,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-claims.ts",
+      "line": 119,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-claims.ts",
+      "line": 125,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb(readClaims);",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-end-recovery.ts",
+      "line": 106,
+      "api": "withWriteTx",
+      "source": "const result = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-memories.ts",
+      "line": 59,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-memories.ts",
+      "line": 153,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-memories.ts",
+      "line": 268,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-recall-dedupe.ts",
+      "line": 149,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-recall-dedupe.ts",
+      "line": 244,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 103,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => tableExistsInDatabase(db, name));",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 112,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 248,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 392,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 446,
+      "api": "withWriteTx",
+      "source": "return (accessor ?? getDbAccessor()).withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 561,
+      "api": "withWriteTx",
+      "source": "return (accessor ?? getDbAccessor()).withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 595,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 641,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 680,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 735,
+      "api": "withReadDb",
+      "source": "const exactRows: TranscriptRow[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 780,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 844,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-ttl-finalizer.ts",
+      "line": 79,
+      "api": "withReadDb",
+      "source": "const alreadyCompleted = deps.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-ttl-finalizer.ts",
+      "line": 92,
+      "api": "withWriteTx",
+      "source": "deps.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "skill-invocations.ts",
+      "line": 50,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "source-artifact-graph.ts",
+      "line": 304,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "source-artifact-graph.ts",
+      "line": 314,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "source-purge.ts",
+      "line": 23,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "source-snapshots.ts",
+      "line": 104,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "source-snapshots.ts",
+      "line": 179,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "startup-recovery.ts",
+      "line": 56,
+      "api": "withReadDb",
+      "source": "const batch = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => fetchBatch(db, limit));",
+      "category": "hot-path"
+    },
+    {
+      "path": "startup-recovery.ts",
+      "line": 59,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => processBatch(db, batch));",
+      "category": "hot-path"
+    },
+    {
+      "path": "startup-recovery.ts",
+      "line": 102,
+      "api": "withWriteTx",
+      "source": "documentLeasesRecovered = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "startup-recovery.ts",
+      "line": 170,
+      "api": "withReadDb",
+      "source": "const migrationInProgress = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "startup-recovery.ts",
+      "line": 219,
+      "api": "withWriteTx",
+      "source": "orphanedPassesSwept = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "telemetry.ts",
+      "line": 492,
+      "api": "withWriteTx",
+      "source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "telemetry.ts",
+      "line": 532,
+      "api": "withWriteTx",
+      "source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "temporal-expand.ts",
+      "line": 178,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "temporal-fallback.ts",
+      "line": 36,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => tableExistsIn(db, name));",
+      "category": "hot-path"
+    },
+    {
+      "path": "temporal-fallback.ts",
+      "line": 150,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "temporal-fallback.ts",
+      "line": 206,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "temporal-recall.ts",
+      "line": 442,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 266,
+      "api": "withReadDb",
+      "source": "if (dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => unchanged(db, agentId, candidate))) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 295,
+      "api": "withWriteTx",
+      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 304,
+      "api": "withReadDb",
+      "source": "const alreadyCaptured = dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 309,
+      "api": "withWriteTx",
+      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 329,
+      "api": "withWriteTx",
+      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 375,
+      "api": "withWriteTx",
+      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
       "category": "hot-path"
     },
     {

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -1,6544 +1,6033 @@
 {
-  "version": 1,
-  "generatedFrom": "manual migration ledger",
-  "sites": [
-    {
-      "path": "agent-id.ts",
-      "line": 56,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "agent-id.ts",
-      "line": 82,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "aggregate-recall.ts",
-      "line": 740,
-      "api": "withReadDb",
-      "source": "const activeCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "aggregate-recall.ts",
-      "line": 746,
-      "api": "withWriteTx",
-      "source": "const written = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "aggregate-recall.ts",
-      "line": 995,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/api-keys.ts",
-      "line": 197,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/api-keys.ts",
-      "line": 241,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/api-keys.ts",
-      "line": 258,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/api-keys.ts",
-      "line": 272,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/tokens.ts",
-      "line": 30,
-      "api": "existsSync",
-      "source": "if (existsSync(secretPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/tokens.ts",
-      "line": 31,
-      "api": "readFileSync",
-      "source": "const secret = readFileSync(secretPath);",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/tokens.ts",
-      "line": 37,
-      "api": "writeFileSync",
-      "source": "writeFileSync(secretPath, fresh, { mode: 0o600 });",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/tokens.ts",
-      "line": 43,
-      "api": "existsSync",
-      "source": "if (!existsSync(dir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/tokens.ts",
-      "line": 44,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/tokens.ts",
-      "line": 47,
-      "api": "writeFileSync",
-      "source": "writeFileSync(secretPath, secret, { mode: 0o600 });",
-      "category": "hot-path"
-    },
-    {
-      "path": "black-box.ts",
-      "line": 434,
-      "api": "withReadDb",
-      "source": "const events = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "black-box.ts",
-      "line": 467,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "config-migration.ts",
-      "line": 56,
-      "api": "existsSync",
-      "source": "if (existsSync(p)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "config-migration.ts",
-      "line": 65,
-      "api": "readFileSync",
-      "source": "text = readFileSync(path, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "config-migration.ts",
-      "line": 106,
-      "api": "writeFileSync",
-      "source": "writeFileSync(tmp, text, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "config-migration.ts",
-      "line": 107,
-      "api": "renameSync",
-      "source": "renameSync(tmp, path);",
-      "category": "hot-path"
-    },
-    {
-      "path": "config-migration.ts",
-      "line": 141,
-      "api": "existsSync",
-      "source": "if (existsSync(p)) return p;",
-      "category": "hot-path"
-    },
-    {
-      "path": "config-migration.ts",
-      "line": 152,
-      "api": "readFileSync",
-      "source": "text = readFileSync(path, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "config-migration.ts",
-      "line": 228,
-      "api": "writeFileSync",
-      "source": "writeFileSync(tmp, contents, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "config-migration.ts",
-      "line": 229,
-      "api": "renameSync",
-      "source": "renameSync(tmp, path);",
-      "category": "hot-path"
-    },
-    {
-      "path": "config-migration.ts",
-      "line": 290,
-      "api": "readFileSync",
-      "source": "text = readFileSync(path, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "config-migration.ts",
-      "line": 502,
-      "api": "readFileSync",
-      "source": "text = readFileSync(path, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "config-migration.ts",
-      "line": 564,
-      "api": "readFileSync",
-      "source": "text = readFileSync(path, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "config-migration.ts",
-      "line": 667,
-      "api": "readFileSync",
-      "source": "text = readFileSync(path, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "config-migration.ts",
-      "line": 724,
-      "api": "readFileSync",
-      "source": "text = readFileSync(path, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/filesystem.ts",
-      "line": 232,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/filesystem.ts",
-      "line": 287,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/filesystem.ts",
-      "line": 310,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 23,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 43,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 59,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 74,
-      "api": "withReadDb",
-      "source": "const before = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 82,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 98,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 108,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 145,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 645,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 768,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 813,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 856,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 884,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 914,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 953,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 1028,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 380,
-      "api": "existsSync",
-      "source": "if (!existsSync(agentsMdPath)) return;",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 397,
-      "api": "existsSync",
-      "source": "const existingFiles = files.filter((f) => existsSync(join(AGENTS_DIR, f.name)));",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 425,
-      "api": "existsSync",
-      "source": "if (!existsSync(identityPath)) return \"\";",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 444,
-      "api": "existsSync",
-      "source": "if (activeHarnesses.has(\"opencode\") && existsSync(opencodeDir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 476,
-      "api": "existsSync",
-      "source": "if (activeHarnesses.has(\"opencode\") && existsSync(opencodeDir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 483,
-      "api": "existsSync",
-      "source": "if (existsSync(geminiDir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 488,
-      "api": "existsSync",
-      "source": "if (existsSync(settingsPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 489,
-      "api": "readFileSync",
-      "source": "const parsed = JSON.parse(readFileSync(settingsPath, \"utf8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 509,
-      "api": "existsSync",
-      "source": "if (!existsSync(targetPath)) continue;",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 705,
-      "api": "statSync",
-      "source": "const stat = statSync(filePath);",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 865,
-      "api": "readFileSync",
-      "source": "content = readFileSync(filePath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 1025,
-      "api": "existsSync",
-      "source": "if (!existsSync(memoryDir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 1401,
-      "api": "existsSync",
-      "source": "if (!existsSync(p)) continue;",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 1403,
-      "api": "readFileSync",
-      "source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\")) as Record<string, unknown>;",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 1434,
-      "api": "withWriteTx",
-      "source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 1440,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) continue;",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 1442,
-      "api": "readFileSync",
-      "source": "const routing = parseRoutingConfig(parseSimpleYaml(readFileSync(path, \"utf-8\")));",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 1515,
-      "api": "withReadDb",
-      "source": "const activeEmbeddingCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 1804,
-      "api": "existsSync",
-      "source": "if (existsSync(PID_FILE)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 1806,
-      "api": "unlinkSync",
-      "source": "unlinkSync(PID_FILE);",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 1947,
-      "api": "mkdirSync",
-      "source": "mkdirSync(DAEMON_DIR, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 1948,
-      "api": "mkdirSync",
-      "source": "mkdirSync(LOG_DIR, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 2023,
-      "api": "existsSync",
-      "source": "const workerPath = existsSync(bundled)",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 2093,
-      "api": "writeFileSync",
-      "source": "writeFileSync(PID_FILE, process.pid.toString());",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 2188,
-      "api": "withReadDb",
-      "source": "const memoryCount = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 2199,
-      "api": "withReadDb",
-      "source": "const queue = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 2393,
-      "api": "existsSync",
-      "source": "if (existsSync(healthStampPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 2394,
-      "api": "readFileSync",
-      "source": "const prev = JSON.parse(readFileSync(healthStampPath, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 2397,
-      "api": "writeFileSync",
-      "source": "writeFileSync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "database-integrity.ts",
-      "line": 127,
-      "api": "existsSync",
-      "source": "if (existsSync(bundled)) return bundled;",
-      "category": "hot-path"
-    },
-    {
-      "path": "database-integrity.ts",
-      "line": 270,
-      "api": "withReadDb",
-      "source": "const checks = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => ({",
-      "category": "hot-path"
-    },
-    {
-      "path": "database-integrity.ts",
-      "line": 304,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "database-integrity.ts",
-      "line": 309,
-      "api": "withReadDb",
-      "source": "const verifiedTelemetry = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 317,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return null;",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 320,
-      "api": "readFileSync",
-      "source": "const raw: unknown = JSON.parse(readFileSync(path, \"utf8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 577,
-      "api": "readdirSync",
-      "source": ".readdirSync(dir)",
-      "category": "pre-readiness-bootstrap"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 581,
-      "api": "statSync",
-      "source": "const stat = deps.statSync(join(dir, f));",
-      "category": "pre-readiness-bootstrap"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 595,
-      "api": "unlinkSync",
-      "source": "deps.unlinkSync(join(dir, old.name));",
-      "category": "pre-readiness-bootstrap"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 606,
-      "api": "statfsSync",
-      "source": "const stat = deps.statfsSync(path);",
-      "category": "pre-readiness-bootstrap"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 615,
-      "api": "statSync",
-      "source": "const size = deps.statSync(path).size;",
-      "category": "pre-readiness-bootstrap"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 646,
-      "api": "copyFileSync",
-      "source": "deps.copyFileSync(dbPath, probeDest);",
-      "category": "pre-readiness-bootstrap"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 652,
-      "api": "unlinkSync",
-      "source": "deps.unlinkSync(probeDest);",
-      "category": "pre-readiness-bootstrap"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 687,
-      "api": "copyFileSync",
-      "source": "deps.copyFileSync(dbPath, backupDest);",
-      "category": "pre-readiness-bootstrap"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 711,
-      "api": "copyFileSync",
-      "source": "deps.copyFileSync(dbPath, backupDest);",
-      "category": "pre-readiness-bootstrap"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 751,
-      "api": "unlinkSync",
-      "source": "deps.unlinkSync(backupDest);",
-      "category": "pre-readiness-bootstrap"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 760,
-      "api": "unlinkSync",
-      "source": "else deps.unlinkSync(backupDest);",
-      "category": "pre-readiness-bootstrap"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 788,
-      "api": "unlinkSync",
-      "source": "deps.unlinkSync(backupDest);",
-      "category": "pre-readiness-bootstrap"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 820,
-      "api": "existsSync",
-      "source": "if (!existsSync(dir)) {",
-      "category": "pre-readiness-bootstrap"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 821,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dir, { recursive: true });",
-      "category": "pre-readiness-bootstrap"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 842,
-      "api": "existsSync",
-      "source": "if (existsSync(path) && hasPendingMigrations(toMigrationDb(writeConn))) {",
-      "category": "pre-readiness-bootstrap"
-    },
-    {
-      "path": "db-accessor.ts",
-      "line": 849,
-      "api": "existsSync",
-      "source": "if (existsSync(path) && hasPendingMigrations(toMigrationDb(writeConn))) {",
-      "category": "pre-readiness-bootstrap"
-    },
-    {
-      "path": "db-vacuum.ts",
-      "line": 67,
-      "api": "statSync",
-      "source": "const dbBytes = deps.statSync(dbPath).size;",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-vacuum.ts",
-      "line": 69,
-      "api": "statfsSync",
-      "source": "const stats = deps.statfsSync(directory);",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-vacuum.ts",
-      "line": 322,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readStatusFromDb(toPragmaReadDb(db)));",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-vacuum.ts",
-      "line": 411,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-vacuum.ts",
-      "line": 437,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-vacuum.ts",
-      "line": 453,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-desktop-cache-source.ts",
-      "line": 221,
-      "api": "lstatSync",
-      "source": "stat = fileSystem.lstatSync(path);",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-desktop-cache-source.ts",
-      "line": 265,
-      "api": "readdirSync",
-      "source": "const entries = fileSystem.readdirSync(path);",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-desktop-cache-source.ts",
-      "line": 285,
-      "api": "readFileSync",
-      "source": "const data = fileSystem.readFileSync(candidate.absPath);",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-desktop-cache-source.ts",
-      "line": 481,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-desktop-cache-source.ts",
-      "line": 494,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-desktop-cache-source.ts",
-      "line": 1085,
-      "api": "readFileSync",
-      "source": "const data = fileSystem.readFileSync(path).subarray(0, CACHE_SNIFF_BYTES).toString(\"utf8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 554,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 568,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 610,
-      "api": "withReadDb",
-      "source": "const row = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 855,
-      "api": "withReadDb",
-      "source": "const row = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 939,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 953,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-fetch.ts",
-      "line": 494,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => resolveActiveEmbeddingConfig(db, cfg));",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-repair-state.ts",
-      "line": 101,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-repair-state.ts",
-      "line": 139,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-repair-state.ts",
-      "line": 160,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-repair-state.ts",
-      "line": 191,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-tracker.ts",
-      "line": 194,
-      "api": "withReadDb",
-      "source": "const staleRows: StaleRow[] = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-tracker.ts",
-      "line": 265,
-      "api": "withWriteTx",
-      "source": "applied = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-usage.ts",
-      "line": 90,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-usage.ts",
-      "line": 115,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-worker-handle.ts",
-      "line": 180,
-      "api": "existsSync",
-      "source": ": existsSync(bundled)",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-worker.ts",
-      "line": 154,
-      "api": "mkdirSync",
-      "source": "mkdirSync(init.cacheDir, { recursive: true });",
-      "category": "isolated-worker"
-    },
-    {
-      "path": "embedding-worker.ts",
-      "line": 175,
-      "api": "readFileSync",
-      "source": "const wasmBytes = readFileSync(join(init.wasmDir, \"ort-wasm-simd-threaded.wasm\"));",
-      "category": "isolated-worker"
-    },
-    {
-      "path": "feature-flags.ts",
-      "line": 36,
-      "api": "existsSync",
-      "source": "if (!existsSync(p)) continue;",
-      "category": "hot-path"
-    },
-    {
-      "path": "feature-flags.ts",
-      "line": 38,
-      "api": "readFileSync",
-      "source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "file-sync.ts",
-      "line": 9,
-      "api": "existsSync",
-      "source": "const existing = existsSync(path) ? readFileSync(path, \"utf-8\") : null;",
-      "category": "hot-path"
-    },
-    {
-      "path": "file-sync.ts",
-      "line": 9,
-      "api": "readFileSync",
-      "source": "const existing = existsSync(path) ? readFileSync(path, \"utf-8\") : null;",
-      "category": "hot-path"
-    },
-    {
-      "path": "file-sync.ts",
-      "line": 11,
-      "api": "writeFileSync",
-      "source": "writeFileSync(path, content);",
-      "category": "hot-path"
-    },
-    {
-      "path": "github-source-provider.ts",
-      "line": 457,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "github-source-provider.ts",
-      "line": 479,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "github-source-provider.ts",
-      "line": 493,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "graphiq.ts",
-      "line": 34,
-      "api": "accessSync",
-      "source": "accessSync(candidate, constants.X_OK);",
-      "category": "hot-path"
-    },
-    {
-      "path": "graphiq.ts",
-      "line": 48,
-      "api": "existsSync",
-      "source": "if (!existsSync(active.dbPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks-config.ts",
-      "line": 289,
-      "api": "existsSync",
-      "source": "if (!existsSync(configPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks-config.ts",
-      "line": 294,
-      "api": "readFileSync",
-      "source": "const content = readFileSync(configPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 455,
-      "api": "existsSync",
-      "source": "if (!existsSync(getMemoryDbPath())) return undefined;",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 460,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 553,
-      "api": "existsSync",
-      "source": "if (!existsSync(getMemoryDbPath())) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 566,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 761,
-      "api": "existsSync",
-      "source": "if (req.sessionKey && existsSync(getMemoryDbPath())) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 775,
-      "api": "withReadDb",
-      "source": "const block = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 851,
-      "api": "withReadDb",
-      "source": "const focal = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 865,
-      "api": "withReadDb",
-      "source": "<T>(fn: (db: ReadDb) => T): T => getDbAccessor().withReadDb(fn),",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 1602,
-      "api": "existsSync",
-      "source": "if (req.transcriptPath && existsSync(req.transcriptPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 1604,
-      "api": "readFileSync",
-      "source": "rawTranscript = readFileSync(req.transcriptPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 1946,
-      "api": "existsSync",
-      "source": "if (req.transcriptPath && existsSync(req.transcriptPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 1948,
-      "api": "readFileSync",
-      "source": "rawTranscript = readFileSync(req.transcriptPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 2210,
-      "api": "existsSync",
-      "source": "} else if (req.transcriptPath && existsSync(req.transcriptPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "hooks.ts",
-      "line": 2212,
-      "api": "readFileSync",
-      "source": "const raw = readFileSync(req.transcriptPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "identity-context.ts",
-      "line": 32,
-      "api": "existsSync",
-      "source": "if (!filePath || !existsSync(filePath)) return undefined;",
-      "category": "hot-path"
-    },
-    {
-      "path": "identity-context.ts",
-      "line": 35,
-      "api": "readFileSync",
-      "source": "const content = readFileSync(filePath, \"utf-8\").trim();",
-      "category": "hot-path"
-    },
-    {
-      "path": "identity-context.ts",
-      "line": 73,
-      "api": "existsSync",
-      "source": "if (!filePath || !existsSync(filePath)) return undefined;",
-      "category": "hot-path"
-    },
-    {
-      "path": "identity-context.ts",
-      "line": 76,
-      "api": "readFileSync",
-      "source": "const content = readFileSync(filePath, \"utf-8\").trim();",
-      "category": "hot-path"
-    },
-    {
-      "path": "identity-context.ts",
-      "line": 178,
-      "api": "existsSync",
-      "source": "if (identityMd && existsSync(identityMd)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "identity-context.ts",
-      "line": 180,
-      "api": "readFileSync",
-      "source": "return parseIdentityMarkdown(readFileSync(identityMd, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "identity-context.ts",
-      "line": 185,
-      "api": "existsSync",
-      "source": "if (existsSync(agentYaml)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "identity-context.ts",
-      "line": 187,
-      "api": "readFileSync",
-      "source": "const content = readFileSync(agentYaml, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "identity-context.ts",
-      "line": 200,
-      "api": "existsSync",
-      "source": "if (existsSync(rootIdentityMd)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "identity-context.ts",
-      "line": 202,
-      "api": "readFileSync",
-      "source": "return parseIdentityMarkdown(readFileSync(rootIdentityMd, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "identity-sync.ts",
-      "line": 35,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return null;",
-      "category": "hot-path"
-    },
-    {
-      "path": "identity-sync.ts",
-      "line": 60,
-      "api": "existsSync",
-      "source": "if (!existsSync(agentsRoot)) return;",
-      "category": "hot-path"
-    },
-    {
-      "path": "identity-sync.ts",
-      "line": 84,
-      "api": "existsSync",
-      "source": "const soulPath = existsSync(join(agentDir, \"SOUL.md\")) ? join(agentDir, \"SOUL.md\") : join(agentsDir, \"SOUL.md\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "identity-sync.ts",
-      "line": 85,
-      "api": "existsSync",
-      "source": "const identityPath = existsSync(join(agentDir, \"IDENTITY.md\"))",
-      "category": "hot-path"
-    },
-    {
-      "path": "imported-source-lifecycle.ts",
-      "line": 36,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "imported-source-outcome.ts",
-      "line": 16,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => persistImportedSourceOutcomeInTx(db, input));",
-      "category": "hot-path"
-    },
-    {
-      "path": "imported-source-outcome.ts",
-      "line": 59,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph-hygiene.ts",
-      "line": 428,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 187,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 210,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 233,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 259,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 273,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 296,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 319,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 363,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 400,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 411,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 577,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 753,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 782,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 807,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 954,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1012,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1088,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1150,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1235,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1315,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1357,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1400,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1449,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1577,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1663,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 1958,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph.ts",
-      "line": 2204,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "lifecycle.ts",
-      "line": 154,
-      "api": "readFileSync",
-      "source": "const raw = readFileSync(lifecyclePath(agentsDir), \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "lifecycle.ts",
-      "line": 169,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dirname(path), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "lifecycle.ts",
-      "line": 171,
-      "api": "writeFileSync",
-      "source": "writeFileSync(tmpPath, JSON.stringify(record, null, 2));",
-      "category": "hot-path"
-    },
-    {
-      "path": "lifecycle.ts",
-      "line": 172,
-      "api": "renameSync",
-      "source": "renameSync(tmpPath, path);",
-      "category": "hot-path"
-    },
-    {
-      "path": "logger.ts",
-      "line": 179,
-      "api": "existsSync",
-      "source": "if (!existsSync(dir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "logger.ts",
-      "line": 180,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "logger.ts",
-      "line": 242,
-      "api": "existsSync",
-      "source": "if (!existsSync(this.config.logFilePath)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "logger.ts",
-      "line": 250,
-      "api": "existsSync",
-      "source": "if (!existsSync(this.config.logDir)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "logger.ts",
-      "line": 251,
-      "api": "readdirSync",
-      "source": "return readdirSync(this.config.logDir)",
-      "category": "hot-path"
-    },
-    {
-      "path": "logger.ts",
-      "line": 349,
-      "api": "appendFileSync",
-      "source": "appendFileSync(this.currentLogFile, lines);",
-      "category": "hot-path"
-    },
-    {
-      "path": "logger.ts",
-      "line": 372,
-      "api": "existsSync",
-      "source": "if (!existsSync(this.currentLogFile)) return;",
-      "category": "hot-path"
-    },
-    {
-      "path": "logger.ts",
-      "line": 374,
-      "api": "statSync",
-      "source": "const stats = statSync(this.currentLogFile);",
-      "category": "hot-path"
-    },
-    {
-      "path": "logger.ts",
-      "line": 389,
-      "api": "renameSync",
-      "source": "renameSync(this.currentLogFile, rotatedName);",
-      "category": "hot-path"
-    },
-    {
-      "path": "logger.ts",
-      "line": 405,
-      "api": "unlinkSync",
-      "source": "unlinkSync(files[i].path);",
-      "category": "hot-path"
-    },
-    {
-      "path": "logger.ts",
-      "line": 551,
-      "api": "readFileSync",
-      "source": "const content = readFileSync(file.path, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "mcp-probe.ts",
-      "line": 45,
-      "api": "existsSync",
-      "source": "if (!existsSync(dir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "mcp-probe.ts",
-      "line": 46,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "mcp-probe.ts",
-      "line": 440,
-      "api": "writeFileSync",
-      "source": "writeFileSync(manifestPath, JSON.stringify(result, null, 2));",
-      "category": "hot-path"
-    },
-    {
-      "path": "mcp-probe.ts",
-      "line": 474,
-      "api": "writeFileSync",
-      "source": "writeFileSync(getAppTrayPath(), JSON.stringify(tray, null, 2));",
-      "category": "hot-path"
-    },
-    {
-      "path": "mcp-probe.ts",
-      "line": 500,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "mcp-probe.ts",
-      "line": 503,
-      "api": "readFileSync",
-      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-      "category": "hot-path"
-    },
-    {
-      "path": "mcp-probe.ts",
-      "line": 522,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return null;",
-      "category": "hot-path"
-    },
-    {
-      "path": "mcp-probe.ts",
-      "line": 525,
-      "api": "readFileSync",
-      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-      "category": "hot-path"
-    },
-    {
-      "path": "mcp-probe.ts",
-      "line": 541,
-      "api": "existsSync",
-      "source": "if (existsSync(manifestPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "mcp-probe.ts",
-      "line": 542,
-      "api": "unlinkSync",
-      "source": "unlinkSync(manifestPath);",
-      "category": "hot-path"
-    },
-    {
-      "path": "mcp-probe.ts",
-      "line": 552,
-      "api": "writeFileSync",
-      "source": "writeFileSync(getAppTrayPath(), JSON.stringify(filtered, null, 2));",
-      "category": "hot-path"
-    },
-    {
-      "path": "mcp-stdio.ts",
-      "line": 32,
-      "api": "existsSync",
-      "source": "return isAbsolute(dir) && existsSync(dir) && statSync(dir).isDirectory();",
-      "category": "cli-only"
-    },
-    {
-      "path": "mcp-stdio.ts",
-      "line": 32,
-      "api": "statSync",
-      "source": "return isAbsolute(dir) && existsSync(dir) && statSync(dir).isDirectory();",
-      "category": "cli-only"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 132,
-      "api": "existsSync",
-      "source": "if (memoryIds.length === 0 || !existsSync(memoryDbPath)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 150,
-      "api": "withReadDb",
-      "source": "const batchRows: ScoredMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 211,
-      "api": "existsSync",
-      "source": "if (!existsSync(memoryDbPath)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 228,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 285,
-      "api": "existsSync",
-      "source": "if (!existsSync(memoryDbPath)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 306,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 368,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 401,
-      "api": "existsSync",
-      "source": "if (!existsSync(memoryDbPath)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 432,
-      "api": "withReadDb",
-      "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 440,
-      "api": "existsSync",
-      "source": "if (!existsSync(memoryDbPath)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 473,
-      "api": "withReadDb",
-      "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-config.ts",
-      "line": 990,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) continue;",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-config.ts",
-      "line": 992,
-      "api": "readFileSync",
-      "source": "const yaml = parseSimpleYaml(readFileSync(path, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 59,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 128,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 147,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 160,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 161,
-      "api": "existsSync",
-      "source": "if (existsSync(path)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 164,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dirname(backup), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 165,
-      "api": "readFileSync",
-      "source": "writeFileSync(backup, readFileSync(path, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 165,
-      "api": "writeFileSync",
-      "source": "writeFileSync(backup, readFileSync(path, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 167,
-      "api": "writeFileSync",
-      "source": "writeFileSync(path, file);",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 438,
-      "api": "mkdirSync",
-      "source": "mkdirSync(getMemoryDir(), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 440,
-      "api": "writeFileSync",
-      "source": "writeFileSync(tmp, content, \"utf8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 441,
-      "api": "renameSync",
-      "source": "renameSync(tmp, path);",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 445,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return null;",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 446,
-      "api": "readFileSync",
-      "source": "const parsed = parseFrontmatterDocument(readFileSync(path, \"utf8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 498,
-      "api": "existsSync",
-      "source": "if (existsSync(path)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 499,
-      "api": "readFileSync",
-      "source": "const existing = parseFrontmatterDocument(readFileSync(path, \"utf8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 654,
-      "api": "statSync",
-      "source": "sourceMtimeMs = statSync(path).mtimeMs,",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 730,
-      "api": "statSync",
-      "source": "sourceMtimeMs = statSync(path).mtimeMs,",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 734,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 826,
-      "api": "existsSync",
-      "source": "existsSync(path) ? statSync(path).mtimeMs : Date.now(),",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 826,
-      "api": "statSync",
-      "source": "existsSync(path) ? statSync(path).mtimeMs : Date.now(),",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 833,
-      "api": "existsSync",
-      "source": "if (!existsSync(dir)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 850,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 885,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 954,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 967,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 980,
-      "api": "withReadDb",
-      "source": "const ready = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 997,
-      "api": "withReadDb",
-      "source": "const dbPaths = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 1027,
-      "api": "withReadDb",
-      "source": "const tombstones = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 1247,
-      "api": "withReadDb",
-      "source": "const row = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 1495,
-      "api": "readFileSync",
-      "source": "const parsed = parseFrontmatterDocument(readFileSync(fullPath, \"utf8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 1556,
-      "api": "readFileSync",
-      "source": "const parsed = parseFrontmatterDocument(readFileSync(fullPath, \"utf8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 1606,
-      "api": "readFileSync",
-      "source": "const parsed = parseFrontmatterDocument(readFileSync(fullPath, \"utf8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 1674,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 1727,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 1782,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 1871,
-      "api": "withReadDb",
-      "source": "rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 2201,
-      "api": "rmSync",
-      "source": "rmSync(join(getAgentsDir(), path), { force: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 2213,
-      "api": "withReadDb",
-      "source": "const rows: Array<{ source_path: string }> = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 2225,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-lineage.ts",
-      "line": 2270,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 611,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 717,
-      "api": "withReadDb",
-      "source": "const allowed = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 763,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 795,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 977,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 1149,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 1397,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 1500,
-      "api": "withReadDb",
-      "source": "const value = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 1518,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 1559,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 1620,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 1651,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 1671,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 1770,
-      "api": "withReadDb",
-      "source": "<T>(fn: (db: ReadDb) => T): T => getDbAccessor().withReadDb(fn),",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 1795,
-      "api": "withReadDb",
-      "source": "const embRows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 1881,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 1916,
-      "api": "withReadDb",
-      "source": "<T>(fn: (db: ReadDb) => T): T => getDbAccessor().withReadDb(fn),",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 1947,
-      "api": "withReadDb",
-      "source": "const baseRows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2029,
-      "api": "withReadDb",
-      "source": "const contentRows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2075,
-      "api": "withReadDb",
-      "source": "const structured = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2110,
-      "api": "withReadDb",
-      "source": "const contentRows: Array<{ id: string; content: string }> = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2157,
-      "api": "withReadDb",
-      "source": "const contentRows: Array<{ id: string; content: string }> = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2231,
-      "api": "withReadDb",
-      "source": "const dampenRows: Array<{ id: string; content: string; type: string }> = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2252,
-      "api": "withReadDb",
-      "source": "const links = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2281,
-      "api": "withReadDb",
-      "source": "const degreeRows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2523,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2565,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2760,
-      "api": "withReadDb",
-      "source": "const supplementary = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2858,
-      "api": "withReadDb",
-      "source": "const ctx = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-search.ts",
-      "line": 2965,
-      "api": "withReadDb",
-      "source": "const blocks = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "native-memory-sources.ts",
-      "line": 989,
-      "api": "withWriteTx",
-      "source": "const artifactRows = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "native-runtime-assets.ts",
-      "line": 77,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "native-runtime-assets.ts",
-      "line": 78,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "native-runtime-assets.ts",
-      "line": 79,
-      "api": "writeFileSync",
-      "source": "writeFileSync(path, Buffer.from(worker.contentBase64, \"base64\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "native-runtime-assets.ts",
-      "line": 93,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "native-runtime-assets.ts",
-      "line": 96,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "native-runtime-assets.ts",
-      "line": 97,
-      "api": "writeFileSync",
-      "source": "writeFileSync(path, Buffer.from(asset.contentBase64, \"base64\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "native-runtime-assets.ts",
-      "line": 111,
-      "api": "mkdirSync",
-      "source": "mkdirSync(root, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "native-runtime-assets.ts",
-      "line": 116,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dirname(path), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "native-runtime-assets.ts",
-      "line": 117,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "native-runtime-assets.ts",
-      "line": 118,
-      "api": "writeFileSync",
-      "source": "writeFileSync(path, Buffer.from(asset.contentBase64, \"base64\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "native-runtime-assets.ts",
-      "line": 123,
-      "api": "writeFileSync",
-      "source": "writeFileSync(join(root, \".signet-assets.json\"), `${JSON.stringify({ kind, sourceHash }, null, 2)}\\n`);",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 269,
-      "api": "withReadDb",
-      "source": "const embeddingConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 304,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 318,
-      "api": "withReadDb",
-      "source": "const writeConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 347,
-      "api": "withWriteTx",
-      "source": "const stored = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 408,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 454,
-      "api": "withReadDb",
-      "source": "const row = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 475,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-graph.ts",
-      "line": 323,
-      "api": "existsSync",
-      "source": "return existsSync(path) && statSync(path).isFile() ? normalizedPath(path) : null;",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-graph.ts",
-      "line": 323,
-      "api": "statSync",
-      "source": "return existsSync(path) && statSync(path).isFile() ? normalizedPath(path) : null;",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-graph.ts",
-      "line": 477,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-graph.ts",
-      "line": 696,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-graph.ts",
-      "line": 708,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 307,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => insertAssertion(accessor, db, input));",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 326,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 392,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 411,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 439,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 467,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-claim-evidence.ts",
-      "line": 153,
-      "api": "withReadDb",
-      "source": "const items = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-claim-trace.ts",
-      "line": 1060,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-contradictions.ts",
-      "line": 524,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => reconcileOntologyContradictionsInTx(db, params));",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-contradictions.ts",
-      "line": 535,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-contradictions.ts",
-      "line": 591,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-extraction.ts",
-      "line": 647,
-      "api": "withReadDb",
-      "source": "const source = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-extraction.ts",
-      "line": 748,
-      "api": "withWriteTx",
-      "source": "const written = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-link-evidence.ts",
-      "line": 93,
-      "api": "withReadDb",
-      "source": "const items = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-proposals.ts",
-      "line": 479,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-proposals.ts",
-      "line": 2289,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-proposals.ts",
-      "line": 2301,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => insertProposalInTx(db, input, ts));",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-proposals.ts",
-      "line": 2311,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => createOntologyProposalsInTx(db, inputs));",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-proposals.ts",
-      "line": 2338,
-      "api": "withReadDb",
-      "source": "const items = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-proposals.ts",
-      "line": 2355,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-proposals.ts",
-      "line": 2385,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-proposals.ts",
-      "line": 2462,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-proposals.ts",
-      "line": 2948,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-proposals.ts",
-      "line": 2960,
-      "api": "withReadDb",
-      "source": "const items: DuplicateEntityMergeCandidate[] = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-proposals.ts",
-      "line": 3008,
-      "api": "withReadDb",
-      "source": "const plan = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-proposals.ts",
-      "line": 3030,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-proposals.ts",
-      "line": 3111,
-      "api": "withWriteTx",
-      "source": "const result = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-proposals.ts",
-      "line": 3169,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => applyOntologyOperationBatchInTx(db, params));",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-proposals.ts",
-      "line": 3175,
-      "api": "withWriteTx",
-      "source": "const result = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-proposals.ts",
-      "line": 3236,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "path-feedback.ts",
-      "line": 611,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/acpx-dreaming-mcp.ts",
-      "line": 16,
-      "api": "existsSync",
-      "source": "if (!existsSync(entrypoint)) throw new Error(`Signet Dreaming MCP entrypoint is unavailable: ${entrypoint}`);",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/acpx-dreaming-mcp.ts",
-      "line": 40,
-      "api": "writeFileSync",
-      "source": "writeFileSync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/acpx-dreaming-mcp.ts",
-      "line": 57,
-      "api": "rmSync",
-      "source": "rmSync(dir, { recursive: true, force: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/aspect-feedback.ts",
-      "line": 79,
-      "api": "withWriteTx",
-      "source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/aspect-feedback.ts",
-      "line": 165,
-      "api": "withWriteTx",
-      "source": "const decayed = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 136,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getDreamingAttentionInDb(db, agentId, limit));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 145,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 181,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 225,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 256,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 290,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-capabilities.ts",
-      "line": 62,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-capabilities.ts",
-      "line": 523,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-capabilities.ts",
-      "line": 694,
-      "api": "withReadDb",
-      "source": "const due: ReturnType<typeof collectReviewDueClaims> = accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-evidence-retry.ts",
-      "line": 131,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-evidence-retry.ts",
-      "line": 253,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 112,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 154,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 478,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 490,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 503,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 520,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 692,
-      "api": "withReadDb",
-      "source": "const pending = params.accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-quality.ts",
-      "line": 96,
-      "api": "withReadDb",
-      "source": "const { claimPaths, entities, totalClaimValues, unaddressableClaimValues, structureQuality } = accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-runbook.ts",
-      "line": 177,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-runbook.ts",
-      "line": 219,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-token-cache.ts",
-      "line": 36,
-      "api": "existsSync",
-      "source": "return existsSync(bundled)",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 96,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getQueueHealth(db).status !== \"healthy\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 106,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 182,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => hasDreamingAttentionKindInDb(db, scope, [\"hygiene\"])),",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 186,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 278,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming.ts",
-      "line": 731,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return { content: \"\", unreadable: false };",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming.ts",
-      "line": 733,
-      "api": "readFileSync",
-      "source": "const raw = readFileSync(path, \"utf-8\").trim();",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/extraction-fallback.ts",
-      "line": 17,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/maintenance-worker.ts",
-      "line": 133,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/maintenance-worker.ts",
-      "line": 333,
-      "api": "withReadDb",
-      "source": "const report = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getDiagnostics(db, tracker));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/maintenance-worker.ts",
-      "line": 337,
-      "api": "withReadDb",
-      "source": "const report = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getDiagnostics(db, tracker));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/maintenance-worker.ts",
-      "line": 414,
-      "api": "withReadDb",
-      "source": "const postReport = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getDiagnostics(db, tracker));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/maintenance-worker.ts",
-      "line": 457,
-      "api": "withReadDb",
-      "source": "const count = accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/maintenance-worker.ts",
-      "line": 489,
-      "api": "withReadDb",
-      "source": "const ratio = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getFreePageRatio(db));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/prospective-index.ts",
-      "line": 230,
-      "api": "withWriteTx",
-      "source": "job = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => leaseJob(db, 3));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/prospective-index.ts",
-      "line": 242,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => failJob(db, j.id, \"invalid payload\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/prospective-index.ts",
-      "line": 252,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/prospective-index.ts",
-      "line": 262,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => completeJob(db, j.id));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/prospective-index.ts",
-      "line": 272,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => failJob(db, j.id, msg));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/provider.ts",
-      "line": 824,
-      "api": "mkdirSync",
-      "source": "mkdirSync(isolatedCwd, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 39,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return null;",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 40,
-      "api": "readFileSync",
-      "source": "const data = JSON.parse(readFileSync(path, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 50,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 51,
-      "api": "writeFileSync",
-      "source": "writeFileSync(getLastReflectionPath(agentId), JSON.stringify({ lastDate: date }));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 366,
-      "api": "withReadDb",
-      "source": "const memories = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 399,
-      "api": "withReadDb",
-      "source": "const existingReflections = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 461,
-      "api": "withWriteTx",
-      "source": "deps.getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 527,
-      "api": "withReadDb",
-      "source": ".withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reranker-embedding.ts",
-      "line": 51,
-      "api": "withReadDb",
-      "source": "const embMap = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 80,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 174,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 292,
-      "api": "withReadDb",
-      "source": "const writeConfig = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 305,
-      "api": "withWriteTx",
-      "source": "embeddingCreated = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 365,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 376,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 136,
-      "api": "existsSync",
-      "source": "if (options.scanFilesystem !== false && existsSync(dir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 137,
-      "api": "readdirSync",
-      "source": "const entries = readdirSync(dir, { withFileTypes: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 141,
-      "api": "existsSync",
-      "source": "if (existsSync(skillMdPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 163,
-      "api": "withReadDb",
-      "source": "const graphSkills = deps.accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 170,
-      "api": "existsSync",
-      "source": "if (!existsSync(row.fs_path)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 228,
-      "api": "existsSync",
-      "source": "if (!existsSync(mdPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 234,
-      "api": "readFileSync",
-      "source": "const content = readFileSync(mdPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 241,
-      "api": "withReadDb",
-      "source": "const existing = deps.accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 250,
-      "api": "withReadDb",
-      "source": "const storedEmb = deps.accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 331,
-      "api": "statSync",
-      "source": "return statSync(dir).mtimeMs;",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 373,
-      "api": "existsSync",
-      "source": "if (existsSync(dir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/synthesis-worker.ts",
-      "line": 73,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return 0;",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/synthesis-worker.ts",
-      "line": 74,
-      "api": "readFileSync",
-      "source": "const data = JSON.parse(readFileSync(path, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/synthesis-worker.ts",
-      "line": 84,
-      "api": "mkdirSync",
-      "source": "mkdirSync(join(getAgentsDir(), \".daemon\"), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/synthesis-worker.ts",
-      "line": 85,
-      "api": "writeFileSync",
-      "source": "writeFileSync(path, JSON.stringify({ lastRunAt: timestamp }));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/synthesis-worker.ts",
-      "line": 127,
-      "api": "withReadDb",
-      "source": "const checkpointRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/synthesis-worker.ts",
-      "line": 153,
-      "api": "withReadDb",
-      "source": "const transcriptRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "plugins/audit.ts",
-      "line": 71,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dirname(path), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "plugins/audit.ts",
-      "line": 72,
-      "api": "appendFileSync",
-      "source": "appendFileSync(path, `${JSON.stringify(event)}\\n`, { mode: 0o600 });",
-      "category": "hot-path"
-    },
-    {
-      "path": "plugins/audit.ts",
-      "line": 85,
-      "api": "existsSync",
-      "source": "if (!path || !existsSync(path)) return { events: [], count: 0 };",
-      "category": "hot-path"
-    },
-    {
-      "path": "plugins/audit.ts",
-      "line": 109,
-      "api": "readFileSync",
-      "source": "return readFileSync(path, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "plugins/host.ts",
-      "line": 326,
-      "api": "existsSync",
-      "source": "if (!this.storagePath || !existsSync(this.storagePath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "plugins/host.ts",
-      "line": 330,
-      "api": "readFileSync",
-      "source": "const parsed: unknown = JSON.parse(readFileSync(this.storagePath, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "plugins/host.ts",
-      "line": 353,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dirname(this.storagePath), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "plugins/host.ts",
-      "line": 354,
-      "api": "writeFileSync",
-      "source": "writeFileSync(this.storagePath, `${JSON.stringify(this.store, null, 2)}\\n`, { mode: 0o600 });",
-      "category": "hot-path"
-    },
-    {
-      "path": "plugins/index.ts",
-      "line": 14,
-      "api": "existsSync",
-      "source": "if (existsSync(statePath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "plugins/index.ts",
-      "line": 16,
-      "api": "readFileSync",
-      "source": "const parsed: unknown = JSON.parse(readFileSync(statePath, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "prompt-entity-context.ts",
-      "line": 668,
-      "api": "existsSync",
-      "source": "if (!existsSync(memoryDbPath)) return { lines: [], memories: [], memoryCount: 0, engine: \"no-entity\" };",
-      "category": "hot-path"
-    },
-    {
-      "path": "prompt-entity-context.ts",
-      "line": 671,
-      "api": "withReadDb",
-      "source": "const matches: PromptEntityMatch[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "prompt-entity-context.ts",
-      "line": 697,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "resource-monitor.ts",
-      "line": 228,
-      "api": "readdirSync",
-      "source": "const entries = readdirSync(fdDir);",
-      "category": "hot-path"
-    },
-    {
-      "path": "resource-monitor.ts",
-      "line": 233,
-      "api": "readlinkSync",
-      "source": "const target = readlinkSync(join(fdDir, fd));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/app-tray.ts",
-      "line": 122,
-      "api": "writeFileSync",
-      "source": "writeFileSync(join(getMarketplaceDir(), \"app-tray.json\"), JSON.stringify([...fresh, ...toAdd], null, 2));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/app-tray.ts",
-      "line": 227,
-      "api": "writeFileSync",
-      "source": "writeFileSync(trayPath, JSON.stringify(tray, null, 2));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/app-tray.ts",
-      "line": 315,
-      "api": "writeFileSync",
-      "source": "writeFileSync(trayPath, JSON.stringify(tray, null, 2));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/app-tray.ts",
-      "line": 347,
-      "api": "existsSync",
-      "source": "if (!existsSync(dir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/app-tray.ts",
-      "line": 348,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/app-tray.ts",
-      "line": 415,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/app-tray.ts",
-      "line": 417,
-      "api": "readFileSync",
-      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/app-tray.ts",
-      "line": 427,
-      "api": "writeFileSync",
-      "source": "writeFileSync(getInstalledMcpPath(), JSON.stringify(servers, null, 2));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/changelog.ts",
-      "line": 192,
-      "api": "existsSync",
-      "source": "if (existsSync(localPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/changelog.ts",
-      "line": 194,
-      "api": "readFileSync",
-      "source": "raw = readFileSync(localPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/connectors-routes.ts",
-      "line": 277,
-      "api": "withReadDb",
-      "source": "const docs = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/connectors-routes.ts",
-      "line": 288,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/connectors-routes.ts",
-      "line": 319,
-      "api": "withReadDb",
-      "source": "const docCount = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/connectors-routes.ts",
-      "line": 352,
-      "api": "existsSync",
-      "source": "exists: existsSync(join(homedir(), \".claude\", \"settings.json\")),",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/connectors-routes.ts",
-      "line": 358,
-      "api": "existsSync",
-      "source": "exists: existsSync(join(homedir(), \".config\", \"opencode\", \"AGENTS.md\")),",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/connectors-routes.ts",
-      "line": 364,
-      "api": "existsSync",
-      "source": "exists: existsSync(join(AGENTS_DIR, \"AGENTS.md\")),",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/connectors-routes.ts",
-      "line": 370,
-      "api": "existsSync",
-      "source": "exists: existsSync(join(homedir(), \".gemini\", \"settings.json\")),",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/connectors-routes.ts",
-      "line": 389,
-      "api": "existsSync",
-      "source": "if (!existsSync(script)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/dashboard-identity.ts",
-      "line": 31,
-      "api": "existsSync",
-      "source": "if (existsSync(agentYaml)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/dashboard-identity.ts",
-      "line": 33,
-      "api": "readFileSync",
-      "source": "const config = parseSimpleYaml(readFileSync(agentYaml, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/dashboard-identity.ts",
-      "line": 45,
-      "api": "existsSync",
-      "source": "if (existsSync(identityMd)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/dashboard-identity.ts",
-      "line": 47,
-      "api": "readFileSync",
-      "source": "const content = readFileSync(identityMd, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/dashboard.ts",
-      "line": 28,
-      "api": "existsSync",
-      "source": "if (existsSync(join(candidate, \"index.html\"))) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/database-diagnostics.ts",
-      "line": 241,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/database-diagnostics.ts",
-      "line": 276,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/git-config.ts",
-      "line": 77,
-      "api": "existsSync",
-      "source": "if (!existsSync(p)) continue;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/git-config.ts",
-      "line": 79,
-      "api": "readFileSync",
-      "source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/git-sync.ts",
-      "line": 50,
-      "api": "existsSync",
-      "source": "let gitRepoProbe = (dir: string): boolean => existsSync(join(dir, \".git\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/git-sync.ts",
-      "line": 812,
-      "api": "existsSync",
-      "source": "const existingContent = existsSync(gitignorePath) ? readFileSync(gitignorePath, \"utf-8\") : \"\";",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/git-sync.ts",
-      "line": 812,
-      "api": "readFileSync",
-      "source": "const existingContent = existsSync(gitignorePath) ? readFileSync(gitignorePath, \"utf-8\") : \"\";",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/git-sync.ts",
-      "line": 815,
-      "api": "writeFileSync",
-      "source": "writeFileSync(gitignorePath, nextContent, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/git-sync.ts",
-      "line": 871,
-      "api": "existsSync",
-      "source": "if (parent !== absolute && existsSync(parent)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/git-sync.ts",
-      "line": 1019,
-      "api": "existsSync",
-      "source": "gitRepoProbe = probe ?? ((dir: string): boolean => existsSync(join(dir, \".git\")));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/graphiq-install-path.ts",
-      "line": 8,
-      "api": "existsSync",
-      "source": "if (existsSync(bundled)) return bundled;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/graphiq-routes.ts",
-      "line": 97,
-      "api": "existsSync",
-      "source": "if (!existsSync(resolved)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/graphiq-routes.ts",
-      "line": 102,
-      "api": "statSync",
-      "source": "projectStat = statSync(resolved);",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/graphiq-routes.ts",
-      "line": 110,
-      "api": "accessSync",
-      "source": "accessSync(resolved, constants.R_OK | constants.X_OK);",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/graphiq-routes.ts",
-      "line": 161,
-      "api": "existsSync",
-      "source": "if (!existsSync(script)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/graphiq-routes.ts",
-      "line": 182,
-      "api": "existsSync",
-      "source": "if (!existsSync(script)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/graphiq-routes.ts",
-      "line": 204,
-      "api": "accessSync",
-      "source": "accessSync(path, constants.X_OK);",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/graphiq-routes.ts",
-      "line": 228,
-      "api": "existsSync",
-      "source": "if (!existsSync(manifestPath)) continue;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/graphiq-routes.ts",
-      "line": 230,
-      "api": "readFileSync",
-      "source": "const raw = JSON.parse(readFileSync(manifestPath, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/health.ts",
-      "line": 187,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/health.ts",
-      "line": 236,
-      "api": "withReadDb",
-      "source": "dbResult = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/hooks-routes.ts",
-      "line": 1148,
-      "api": "existsSync",
-      "source": "if (!existsSync(getCurrentMemoryDbPath())) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/hooks-routes.ts",
-      "line": 1163,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/hooks-routes.ts",
-      "line": 1191,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/hooks-routes.ts",
-      "line": 1311,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/import-routes.ts",
-      "line": 212,
-      "api": "withWriteTx",
-      "source": "const extraction = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/import-routes.ts",
-      "line": 252,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/import-routes.ts",
-      "line": 337,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/knowledge-routes.ts",
-      "line": 306,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/knowledge-routes.ts",
-      "line": 372,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/knowledge-routes.ts",
-      "line": 410,
-      "api": "withReadDb",
-      "source": "<T>(fn: (db: ReadDb) => T): T => getDbAccessor().withReadDb(fn),",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/knowledge-routes.ts",
-      "line": 426,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/knowledge-routes.ts",
-      "line": 599,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/knowledge-routes.ts",
-      "line": 714,
-      "api": "withReadDb",
-      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace-helpers.ts",
-      "line": 35,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace-helpers.ts",
-      "line": 38,
-      "api": "readFileSync",
-      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace-reviews.ts",
-      "line": 62,
-      "api": "existsSync",
-      "source": "if (!existsSync(dir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace-reviews.ts",
-      "line": 63,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace-reviews.ts",
-      "line": 127,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace-reviews.ts",
-      "line": 129,
-      "api": "readFileSync",
-      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace-reviews.ts",
-      "line": 139,
-      "api": "writeFileSync",
-      "source": "writeFileSync(getReviewsPath(), JSON.stringify(reviews, null, 2), \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace-reviews.ts",
-      "line": 144,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return DEFAULT_CONFIG;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace-reviews.ts",
-      "line": 146,
-      "api": "readFileSync",
-      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace-reviews.ts",
-      "line": 162,
-      "api": "writeFileSync",
-      "source": "writeFileSync(getReviewsConfigPath(), JSON.stringify(config, null, 2), \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace.ts",
-      "line": 176,
-      "api": "existsSync",
-      "source": "if (!existsSync(dir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace.ts",
-      "line": 177,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace.ts",
-      "line": 323,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace.ts",
-      "line": 328,
-      "api": "statSync",
-      "source": "const mtime = statSync(path).mtime.toISOString();",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace.ts",
-      "line": 329,
-      "api": "readFileSync",
-      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace.ts",
-      "line": 338,
-      "api": "writeFileSync",
-      "source": "writeFileSync(getExposurePolicyPath(), JSON.stringify(policy, null, 2));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace.ts",
-      "line": 807,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace.ts",
-      "line": 810,
-      "api": "readFileSync",
-      "source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace.ts",
-      "line": 822,
-      "api": "writeFileSync",
-      "source": "writeFileSync(getInstalledMcpPath(), JSON.stringify(servers, null, 2));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/marketplace.ts",
-      "line": 1128,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/mcp-analytics.ts",
-      "line": 89,
-      "api": "withReadDb",
-      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/mcp-analytics.ts",
-      "line": 171,
-      "api": "withReadDb",
-      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 117,
-      "api": "withReadDb",
-      "source": "embedding: getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 278,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 294,
-      "api": "writeFileSync",
-      "source": "writeFileSync(path, noteContent, { encoding: \"utf-8\", flag: \"wx\" });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 624,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 940,
-      "api": "withReadDb",
-      "source": "const row = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 984,
-      "api": "withReadDb",
-      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1060,
-      "api": "withReadDb",
-      "source": "const memories = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1113,
-      "api": "withReadDb",
-      "source": "const slices = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1212,
-      "api": "withReadDb",
-      "source": "const timeline = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1258,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1294,
-      "api": "withReadDb",
-      "source": "const values = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1323,
-      "api": "withReadDb",
-      "source": "const results = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1623,
-      "api": "withReadDb",
-      "source": "const baseIdempotencyMemory = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1631,
-      "api": "withReadDb",
-      "source": "const existingChunks: ReturnType<typeof getScopedChunkIdempotencyRows> = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1666,
-      "api": "withReadDb",
-      "source": "const byHash = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1686,
-      "api": "withWriteTx",
-      "source": "const result: ChunkInsertResult = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1797,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1875,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1886,
-      "api": "withWriteTx",
-      "source": "const result = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 1976,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 2002,
-      "api": "withReadDb",
-      "source": "const existing = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 2010,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 2074,
-      "api": "withWriteTx",
-      "source": "embedded = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 2117,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 2222,
-      "api": "withReadDb",
-      "source": "const memoryRead = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 2288,
-      "api": "withReadDb",
-      "source": "const exists = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 2309,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 2408,
-      "api": "withReadDb",
-      "source": "const rows: LineageRow[] = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 2481,
-      "api": "withReadDb",
-      "source": "const maybeRow = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 2591,
-      "api": "withWriteTx",
-      "source": "const txResult = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 2694,
-      "api": "withWriteTx",
-      "source": "const txResult = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 2835,
-      "api": "withWriteTx",
-      "source": "const txResult = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 2920,
-      "api": "withWriteTx",
-      "source": "const txResult = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 2964,
-      "api": "withWriteTx",
-      "source": "const txResult = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 3190,
-      "api": "withWriteTx",
-      "source": "const txResult = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 3316,
-      "api": "withWriteTx",
-      "source": "const txResult = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 3579,
-      "api": "withReadDb",
-      "source": "const searchData: ReturnType<typeof vectorSearch> | null = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 3633,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 3708,
-      "api": "withReadDb",
-      "source": "const { total, rows }: { total: number; rows: EmbeddingRow[] } = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 3793,
-      "api": "withReadDb",
-      "source": "const index = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 3809,
-      "api": "withReadDb",
-      "source": "const report = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 3872,
-      "api": "withReadDb",
-      "source": "const projection = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 3911,
-      "api": "withReadDb",
-      "source": "const { cached, total } = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 3950,
-      "api": "withReadDb",
-      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 3954,
-      "api": "withReadDb",
-      "source": "const count = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 3961,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 4037,
-      "api": "withWriteTx",
-      "source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 4110,
-      "api": "withReadDb",
-      "source": "const result = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 4149,
-      "api": "withReadDb",
-      "source": "const doc = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 4182,
-      "api": "withReadDb",
-      "source": "const chunks = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 4215,
-      "api": "withReadDb",
-      "source": "const doc = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/memory-routes.ts",
-      "line": 4247,
-      "api": "withWriteTx",
-      "source": "const memoriesRemoved = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 120,
-      "api": "readdirSync",
-      "source": "const dirFiles = readdirSync(AGENTS_DIR);",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 125,
-      "api": "statSync",
-      "source": "const fileStat = statSync(filePath);",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 127,
-      "api": "readFileSync",
-      "source": "const content = readFileSync(filePath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 188,
-      "api": "writeFileSync",
-      "source": "writeFileSync(filePath, content, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 207,
-      "api": "withReadDb",
-      "source": "const agents = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 219,
-      "api": "withReadDb",
-      "source": "const agent = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 238,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 245,
-      "api": "withReadDb",
-      "source": "const created = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 259,
-      "api": "withReadDb",
-      "source": "const agent = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 265,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 424,
-      "api": "withReadDb",
-      "source": "const taskExists = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 521,
-      "api": "withReadDb",
-      "source": "const tasks = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 583,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 617,
-      "api": "withReadDb",
-      "source": "const task = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 626,
-      "api": "withReadDb",
-      "source": "const runs = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 645,
-      "api": "withReadDb",
-      "source": "const existing = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 679,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 708,
-      "api": "withWriteTx",
-      "source": "const result = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 722,
-      "api": "withReadDb",
-      "source": "const task = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 731,
-      "api": "withReadDb",
-      "source": "const running = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 743,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 813,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 857,
-      "api": "withReadDb",
-      "source": "const runs = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/misc-routes.ts",
-      "line": 869,
-      "api": "withReadDb",
-      "source": "const total = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/pipeline-routes.ts",
-      "line": 102,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/pipeline-routes.ts",
-      "line": 296,
-      "api": "existsSync",
-      "source": "if (existsSync(p)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/pipeline-routes.ts",
-      "line": 297,
-      "api": "readFileSync",
-      "source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/pipeline-routes.ts",
-      "line": 341,
-      "api": "existsSync",
-      "source": "memoryDb: existsSync(MEMORY_DB),",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/pipeline-routes.ts",
-      "line": 392,
-      "api": "readFileSync",
-      "source": "soulContent = readFileSync(soulPath, \"utf-8\").slice(0, 500);",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/pipeline-routes.ts",
-      "line": 457,
-      "api": "withReadDb",
-      "source": "const report: ReturnType<typeof listMemoryContentSafety> = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/pipeline-routes.ts",
-      "line": 557,
-      "api": "withReadDb",
-      "source": "const dbData = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/queue-diagnostics.ts",
-      "line": 169,
-      "api": "withReadDb",
-      "source": "const response = resolveAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/reflection-routes.ts",
-      "line": 98,
-      "api": "withReadDb",
-      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/reflection-routes.ts",
-      "line": 118,
-      "api": "withReadDb",
-      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/reflection-routes.ts",
-      "line": 172,
-      "api": "withReadDb",
-      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/reflection-routes.ts",
-      "line": 207,
-      "api": "withReadDb",
-      "source": "const existing = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/reflection-routes.ts",
-      "line": 225,
-      "api": "withWriteTx",
-      "source": "resolveDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 313,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 357,
-      "api": "withWriteTx",
-      "source": "const result = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => clusterEntities(db, agentId));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 378,
-      "api": "withReadDb",
-      "source": "const unlinked = accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 408,
-      "api": "withReadDb",
-      "source": "const preview = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 459,
-      "api": "withWriteTx",
-      "source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 469,
-      "api": "withReadDb",
-      "source": "const remaining = accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 512,
-      "api": "withReadDb",
-      "source": "const unhinted = accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 537,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 545,
-      "api": "withReadDb",
-      "source": "const remaining = accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 585,
-      "api": "withReadDb",
-      "source": "const dead = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/session-routes.ts",
-      "line": 168,
-      "api": "withReadDb",
-      "source": "const hits = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/session-routes.ts",
-      "line": 347,
-      "api": "withReadDb",
-      "source": "const tableExists = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/session-routes.ts",
-      "line": 355,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skill-analytics.ts",
-      "line": 121,
-      "api": "withReadDb",
-      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 221,
-      "api": "existsSync",
-      "source": "if (!existsSync(getSkillsDir())) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 223,
-      "api": "readdirSync",
-      "source": "return readdirSync(getSkillsDir(), { withFileTypes: true })",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 227,
-      "api": "existsSync",
-      "source": "if (!existsSync(skillMdPath)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 229,
-      "api": "readFileSync",
-      "source": "const content = readFileSync(skillMdPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 364,
-      "api": "existsSync",
-      "source": "if (process.env.SIGNET_SKILLS_SOURCE && existsSync(process.env.SIGNET_SKILLS_SOURCE)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 369,
-      "api": "existsSync",
-      "source": "if (existsSync(devPath)) return devPath;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 372,
-      "api": "existsSync",
-      "source": "if (existsSync(distPath)) return distPath;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 374,
-      "api": "existsSync",
-      "source": "if (existsSync(distPath2)) return distPath2;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 380,
-      "api": "existsSync",
-      "source": "if (!sourceDir || !existsSync(sourceDir)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 384,
-      "api": "readdirSync",
-      "source": "return readdirSync(sourceDir, { withFileTypes: true })",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 388,
-      "api": "existsSync",
-      "source": "if (!existsSync(skillMdPath)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 390,
-      "api": "readFileSync",
-      "source": "const content = readFileSync(skillMdPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 510,
-      "api": "existsSync",
-      "source": "if (!existsSync(skillMd)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 513,
-      "api": "lstatSync",
-      "source": "if (!lstatSync(skillMd).isFile()) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 521,
-      "api": "readdirSync",
-      "source": "for (const entry of readdirSync(dir, { withFileTypes: true })) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 636,
-      "api": "mkdirSync",
-      "source": "mkdirSync(target, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 641,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dirname(target), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 715,
-      "api": "rmSync",
-      "source": "rmSync(stagingDir, { recursive: true, force: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 716,
-      "api": "rmSync",
-      "source": "rmSync(backupDir, { recursive: true, force: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 718,
-      "api": "existsSync",
-      "source": "if (existsSync(targetDir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 719,
-      "api": "renameSync",
-      "source": "renameSync(targetDir, backupDir);",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 722,
-      "api": "renameSync",
-      "source": "renameSync(stagingDir, targetDir);",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 723,
-      "api": "rmSync",
-      "source": "rmSync(backupDir, { recursive: true, force: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 725,
-      "api": "rmSync",
-      "source": "rmSync(stagingDir, { recursive: true, force: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 726,
-      "api": "existsSync",
-      "source": "if (movedTarget && existsSync(backupDir) && !existsSync(targetDir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 726,
-      "api": "existsSync",
-      "source": "if (movedTarget && existsSync(backupDir) && !existsSync(targetDir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 727,
-      "api": "renameSync",
-      "source": "renameSync(backupDir, targetDir);",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 729,
-      "api": "rmSync",
-      "source": "rmSync(backupDir, { recursive: true, force: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 759,
-      "api": "mkdirSync",
-      "source": "mkdirSync(extractDir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 770,
-      "api": "mkdirSync",
-      "source": "mkdirSync(getSkillsDir(), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 783,
-      "api": "rmSync",
-      "source": "rmSync(tempRoot, { recursive: true, force: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 1011,
-      "api": "existsSync",
-      "source": "if (existsSync(skillMdPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 1013,
-      "api": "readFileSync",
-      "source": "const content = readFileSync(skillMdPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 1031,
-      "api": "existsSync",
-      "source": "if (existsSync(signetSkillPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 1033,
-      "api": "readFileSync",
-      "source": "const content = readFileSync(signetSkillPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 1188,
-      "api": "existsSync",
-      "source": "if (!existsSync(skillDir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 1195,
-      "api": "rmSync",
-      "source": "rmSync(skillDir, { recursive: true, force: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 711,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 713,
-      "api": "readFileSync",
-      "source": "const parsed = JSON.parse(readFileSync(path, \"utf8\")) as unknown;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 723,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dirname(path), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 725,
-      "api": "writeFileSync",
-      "source": "writeFileSync(tmp, `${JSON.stringify(tombstones, null, 2)}\\n`, \"utf8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 726,
-      "api": "renameSync",
-      "source": "renameSync(tmp, path);",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 797,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 936,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1048,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1111,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1150,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/state.ts",
-      "line": 157,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) continue;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/state.ts",
-      "line": 159,
-      "api": "readFileSync",
-      "source": "return resolveNetworkBinding(readNetworkMode(parseSimpleYaml(readFileSync(path, \"utf-8\"))));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/state.ts",
-      "line": 384,
-      "api": "existsSync",
-      "source": "if (!existsSync(candidate)) continue;",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/state.ts",
-      "line": 386,
-      "api": "readFileSync",
-      "source": "const raw = readFileSync(candidate, \"utf8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/state.ts",
-      "line": 457,
-      "api": "withReadDb",
-      "source": "const report = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/telemetry-routes.ts",
-      "line": 200,
-      "api": "withReadDb",
-      "source": "const mutationHealth = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/telemetry-routes.ts",
-      "line": 219,
-      "api": "withReadDb",
-      "source": "const scores: Array<Record<string, unknown>> = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/telemetry-routes.ts",
-      "line": 263,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/utils.ts",
-      "line": 437,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/utils.ts",
-      "line": 525,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/widget.ts",
-      "line": 75,
-      "api": "existsSync",
-      "source": "if (existsSync(path)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/widget.ts",
-      "line": 76,
-      "api": "statSync",
-      "source": "const stat = statSync(path);",
-      "category": "hot-path"
-    },
-    {
-      "path": "scheduler/skill-resolver.ts",
-      "line": 42,
-      "api": "readFileSync",
-      "source": "const raw = readFileSync(skillPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "scheduler/worker.ts",
-      "line": 104,
-      "api": "withWriteTx",
-      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "scheduler/worker.ts",
-      "line": 122,
-      "api": "withReadDb",
-      "source": "const dueTasks = db.withReadDb((rdb: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "scheduler/worker.ts",
-      "line": 193,
-      "api": "withWriteTx",
-      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "scheduler/worker.ts",
-      "line": 280,
-      "api": "withWriteTx",
-      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 190,
-      "api": "readFileSync",
-      "source": "const id = readFileSync(p, \"utf-8\").trim();",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 199,
-      "api": "execSync",
-      "source": "const out = execSync(\"ioreg -rd1 -c IOPlatformExpertDevice | grep IOPlatformUUID | awk '{print $3}'\", {",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 212,
-      "api": "execSync",
-      "source": "const out = execSync('reg query \"HKLM\\\\SOFTWARE\\\\Microsoft\\\\Cryptography\" /v MachineGuid', {",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 235,
-      "api": "readFileSync",
-      "source": "const persisted = readFileSync(getMachineIdFile(), \"utf-8\").trim();",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 248,
-      "api": "mkdirSync",
-      "source": "mkdirSync(getSecretsDir(), { recursive: true, mode: 0o700 });",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 250,
-      "api": "writeFileSync",
-      "source": "writeFileSync(file, `${machineId}\\n`, { encoding: \"utf-8\", mode: 0o600, flag: \"wx\" });",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 299,
-      "api": "existsSync",
-      "source": "if (!existsSync(getSecretsFile())) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 373,
-      "api": "existsSync",
-      "source": "existsSync(getMachineIdFile()) ||",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 374,
-      "api": "existsSync",
-      "source": "!existsSync(getSecretsFile())",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 430,
-      "api": "readdirSync",
-      "source": "names = readdirSync(dir);",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 438,
-      "api": "unlinkSync",
-      "source": "unlinkSync(join(dir, name));",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 448,
-      "api": "existsSync",
-      "source": "if (!existsSync(file)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 452,
-      "api": "readFileSync",
-      "source": "return parseSecretsStore(JSON.parse(readFileSync(file, \"utf-8\")));",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 471,
-      "api": "mkdirSync",
-      "source": "mkdirSync(getSecretsDir(), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 476,
-      "api": "writeFileSync",
-      "source": "writeFileSync(fd, JSON.stringify(store, null, 2), \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 482,
-      "api": "renameSync",
-      "source": "renameSync(tmp, file);",
-      "category": "hot-path"
-    },
-    {
-      "path": "secrets.ts",
-      "line": 492,
-      "api": "unlinkSync",
-      "source": "unlinkSync(tmp);",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 93,
-      "api": "existsSync",
-      "source": "if (existsSync(candidate)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 108,
-      "api": "execSync",
-      "source": "execSync(`${locator} bun`, { encoding: \"utf-8\", windowsHide: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 145,
-      "api": "mkdirSync",
-      "source": "mkdirSync(plistDir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 146,
-      "api": "mkdirSync",
-      "source": "mkdirSync(LOG_DIR, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 150,
-      "api": "execSync",
-      "source": "execSync(`launchctl unload \"${LAUNCHD_PLIST}\" 2>/dev/null`);",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 156,
-      "api": "writeFileSync",
-      "source": "writeFileSync(LAUNCHD_PLIST, generateLaunchdPlist(port));",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 159,
-      "api": "execSync",
-      "source": "execSync(`launchctl load \"${LAUNCHD_PLIST}\"`);",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 163,
-      "api": "existsSync",
-      "source": "if (!existsSync(LAUNCHD_PLIST)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 168,
-      "api": "execSync",
-      "source": "execSync(`launchctl unload \"${LAUNCHD_PLIST}\"`);",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 173,
-      "api": "unlinkSync",
-      "source": "unlinkSync(LAUNCHD_PLIST);",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 178,
-      "api": "execSync",
-      "source": "const output = execSync(\"launchctl list ai.signet.daemon 2>/dev/null\", {",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 194,
-      "api": "existsSync",
-      "source": "if (execPath && existsSync(execPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 199,
-      "api": "execSync",
-      "source": "return execSync(`${locator} bun`, { encoding: \"utf-8\", windowsHide: true }).trim().split(/\\r?\\n/)[0];",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 202,
-      "api": "execSync",
-      "source": "return execSync(`${locator} node`, { encoding: \"utf-8\", windowsHide: true }).trim().split(/\\r?\\n/)[0];",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 236,
-      "api": "mkdirSync",
-      "source": "mkdirSync(unitDir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 237,
-      "api": "mkdirSync",
-      "source": "mkdirSync(LOG_DIR, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 241,
-      "api": "execSync",
-      "source": "execSync(\"systemctl --user stop signet.service 2>/dev/null\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 247,
-      "api": "writeFileSync",
-      "source": "writeFileSync(SYSTEMD_UNIT, generateSystemdUnit(port));",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 250,
-      "api": "execSync",
-      "source": "execSync(\"systemctl --user daemon-reload\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 253,
-      "api": "execSync",
-      "source": "execSync(\"systemctl --user enable signet.service\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 254,
-      "api": "execSync",
-      "source": "execSync(\"systemctl --user start signet.service\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 259,
-      "api": "execSync",
-      "source": "execSync(\"systemctl --user stop signet.service 2>/dev/null\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 260,
-      "api": "execSync",
-      "source": "execSync(\"systemctl --user disable signet.service 2>/dev/null\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 265,
-      "api": "existsSync",
-      "source": "if (existsSync(SYSTEMD_UNIT)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 266,
-      "api": "unlinkSync",
-      "source": "unlinkSync(SYSTEMD_UNIT);",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 270,
-      "api": "execSync",
-      "source": "execSync(\"systemctl --user daemon-reload\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 278,
-      "api": "execSync",
-      "source": "const output = execSync(\"systemctl --user is-active signet.service 2>/dev/null\", { encoding: \"utf-8\" });",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 290,
-      "api": "mkdirSync",
-      "source": "mkdirSync(DAEMON_DIR, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 291,
-      "api": "mkdirSync",
-      "source": "mkdirSync(LOG_DIR, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 316,
-      "api": "existsSync",
-      "source": "if (!existsSync(PID_FILE)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 320,
-      "api": "readFileSync",
-      "source": "const pid = parseInt(readFileSync(PID_FILE, \"utf-8\").trim(), 10);",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 330,
-      "api": "unlinkSync",
-      "source": "unlinkSync(PID_FILE);",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 337,
-      "api": "existsSync",
-      "source": "if (!existsSync(PID_FILE)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 341,
-      "api": "readFileSync",
-      "source": "const pid = parseInt(readFileSync(PID_FILE, \"utf-8\").trim(), 10);",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 349,
-      "api": "unlinkSync",
-      "source": "unlinkSync(PID_FILE);",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 399,
-      "api": "existsSync",
-      "source": "if (os === \"darwin\" && existsSync(LAUNCHD_PLIST)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 400,
-      "api": "execSync",
-      "source": "execSync(`launchctl load \"${LAUNCHD_PLIST}\"`);",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 401,
-      "api": "existsSync",
-      "source": "} else if (os === \"linux\" && existsSync(SYSTEMD_UNIT)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 402,
-      "api": "execSync",
-      "source": "execSync(\"systemctl --user start signet.service\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 414,
-      "api": "existsSync",
-      "source": "if (os === \"darwin\" && existsSync(LAUNCHD_PLIST)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 416,
-      "api": "execSync",
-      "source": "execSync(`launchctl unload \"${LAUNCHD_PLIST}\"`);",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 420,
-      "api": "existsSync",
-      "source": "} else if (os === \"linux\" && existsSync(SYSTEMD_UNIT)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 422,
-      "api": "execSync",
-      "source": "execSync(\"systemctl --user stop signet.service\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 446,
-      "api": "existsSync",
-      "source": "if (os === \"darwin\" && existsSync(LAUNCHD_PLIST)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 448,
-      "api": "existsSync",
-      "source": "} else if (os === \"linux\" && existsSync(SYSTEMD_UNIT)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 462,
-      "api": "existsSync",
-      "source": "return existsSync(LAUNCHD_PLIST);",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 464,
-      "api": "existsSync",
-      "source": "return existsSync(SYSTEMD_UNIT);",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 467,
-      "api": "existsSync",
-      "source": "return existsSync(PID_FILE);",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 484,
-      "api": "existsSync",
-      "source": "if (running && existsSync(PID_FILE)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 486,
-      "api": "readFileSync",
-      "source": "pid = parseInt(readFileSync(PID_FILE, \"utf-8\").trim(), 10);",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 515,
-      "api": "existsSync",
-      "source": "if (!existsSync(logFile)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 518,
-      "api": "existsSync",
-      "source": "if (existsSync(outLog)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 519,
-      "api": "readFileSync",
-      "source": "const content = readFileSync(outLog, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "service.ts",
-      "line": 525,
-      "api": "readFileSync",
-      "source": "const content = readFileSync(logFile, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-checkpoints.ts",
-      "line": 109,
-      "api": "withWriteTx",
-      "source": "db.withWriteTx((wdb: WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-checkpoints.ts",
-      "line": 226,
-      "api": "withReadDb",
-      "source": "return db.withReadDb((rdb: ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-checkpoints.ts",
-      "line": 243,
-      "api": "withReadDb",
-      "source": "return db.withReadDb((rdb: ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-checkpoints.ts",
-      "line": 259,
-      "api": "withReadDb",
-      "source": "return db.withReadDb((rdb: ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-checkpoints.ts",
-      "line": 277,
-      "api": "withReadDb",
-      "source": "return db.withReadDb((rdb: ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-checkpoints.ts",
-      "line": 301,
-      "api": "withWriteTx",
-      "source": "return db.withWriteTx((wdb: WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-claims.ts",
-      "line": 64,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-claims.ts",
-      "line": 82,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-claims.ts",
-      "line": 92,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-claims.ts",
-      "line": 119,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-claims.ts",
-      "line": 125,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb(readClaims);",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-end-recovery.ts",
-      "line": 106,
-      "api": "withWriteTx",
-      "source": "const result = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-memories.ts",
-      "line": 55,
-      "api": "existsSync",
-      "source": "if (!sessionKey || candidates.length === 0 || !existsSync(getMemoryDbPath())) return;",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-memories.ts",
-      "line": 59,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-memories.ts",
-      "line": 148,
-      "api": "existsSync",
-      "source": "if (!sessionKey || matchedIds.length === 0 || !existsSync(getMemoryDbPath())) return;",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-memories.ts",
-      "line": 153,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-memories.ts",
-      "line": 262,
-      "api": "existsSync",
-      "source": "if (!sessionKey || Object.keys(feedback).length === 0 || !existsSync(getMemoryDbPath())) return;",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-memories.ts",
-      "line": 268,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-recall-dedupe.ts",
-      "line": 149,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-recall-dedupe.ts",
-      "line": 244,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 103,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => tableExistsInDatabase(db, name));",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 112,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 152,
-      "api": "existsSync",
-      "source": "if (!existsSync(memoryDir)) return 0;",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 158,
-      "api": "readdirSync",
-      "source": "const files = readdirSync(memoryDir).filter((name) => name.endsWith(\"--transcript.md\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 162,
-      "api": "readFileSync",
-      "source": "const parsed = parseArtifactFrontmatter(readFileSync(path, \"utf8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 248,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 331,
-      "api": "readFileSync",
-      "source": "const parsed = JSON.parse(readFileSync(path, \"utf8\")) as { readonly agent_id?: unknown };",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 347,
-      "api": "existsSync",
-      "source": "if (existsSync(markerPath) && markerMatches(markerPath, agentId)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 371,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dirname(markerPath), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 372,
-      "api": "writeFileSync",
-      "source": "writeFileSync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 392,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 446,
-      "api": "withWriteTx",
-      "source": "return (accessor ?? getDbAccessor()).withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 561,
-      "api": "withWriteTx",
-      "source": "return (accessor ?? getDbAccessor()).withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 595,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 641,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 680,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 735,
-      "api": "withReadDb",
-      "source": "const exactRows: TranscriptRow[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 780,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 844,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-ttl-finalizer.ts",
-      "line": 79,
-      "api": "withReadDb",
-      "source": "const alreadyCompleted = deps.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-ttl-finalizer.ts",
-      "line": 92,
-      "api": "withWriteTx",
-      "source": "deps.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "single-instance-lock.ts",
-      "line": 28,
-      "api": "readFileSync",
-      "source": "const pid = Number.parseInt(readFileSync(path, \"utf8\").trim().split(/\\s+/)[0] ?? \"\", 10);",
-      "category": "hot-path"
-    },
-    {
-      "path": "single-instance-lock.ts",
-      "line": 40,
-      "api": "statSync",
-      "source": "return Date.now() - statSync(path).mtimeMs > STALE_LOCK_AGE_MS;",
-      "category": "hot-path"
-    },
-    {
-      "path": "single-instance-lock.ts",
-      "line": 49,
-      "api": "renameSync",
-      "source": "renameSync(path, stalePath);",
-      "category": "hot-path"
-    },
-    {
-      "path": "single-instance-lock.ts",
-      "line": 55,
-      "api": "unlinkSync",
-      "source": "unlinkSync(stalePath);",
-      "category": "hot-path"
-    },
-    {
-      "path": "single-instance-lock.ts",
-      "line": 63,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dirname(path), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "single-instance-lock.ts",
-      "line": 69,
-      "api": "writeFileSync",
-      "source": "writeFileSync(fd, `${process.pid}\\n${Date.now()}\\n`);",
-      "category": "hot-path"
-    },
-    {
-      "path": "single-instance-lock.ts",
-      "line": 73,
-      "api": "unlinkSync",
-      "source": "unlinkSync(path);",
-      "category": "hot-path"
-    },
-    {
-      "path": "single-instance-lock.ts",
-      "line": 91,
-      "api": "unlinkSync",
-      "source": "unlinkSync(lock.path);",
-      "category": "hot-path"
-    },
-    {
-      "path": "skill-invocations.ts",
-      "line": 50,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "skill-transcript-scan.ts",
-      "line": 19,
-      "api": "statSync",
-      "source": "const stat = statSync(args.transcriptPath);",
-      "category": "hot-path"
-    },
-    {
-      "path": "skill-transcript-scan.ts",
-      "line": 32,
-      "api": "readFileSync",
-      "source": "content = readFileSync(args.transcriptPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "source-artifact-graph.ts",
-      "line": 304,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "source-artifact-graph.ts",
-      "line": 314,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "source-purge.ts",
-      "line": 23,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "source-snapshots.ts",
-      "line": 104,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "source-snapshots.ts",
-      "line": 179,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "startup-recovery.ts",
-      "line": 56,
-      "api": "withReadDb",
-      "source": "const batch = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => fetchBatch(db, limit));",
-      "category": "hot-path"
-    },
-    {
-      "path": "startup-recovery.ts",
-      "line": 59,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => processBatch(db, batch));",
-      "category": "hot-path"
-    },
-    {
-      "path": "startup-recovery.ts",
-      "line": 102,
-      "api": "withWriteTx",
-      "source": "documentLeasesRecovered = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "startup-recovery.ts",
-      "line": 170,
-      "api": "withReadDb",
-      "source": "const migrationInProgress = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "startup-recovery.ts",
-      "line": 219,
-      "api": "withWriteTx",
-      "source": "orphanedPassesSwept = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "structural-features.ts",
-      "line": 79,
-      "api": "withReadDb",
-      "source": "const primaryRows = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "structural-features.ts",
-      "line": 163,
-      "api": "withReadDb",
-      "source": "const embeddedIds = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "telemetry.ts",
-      "line": 492,
-      "api": "withWriteTx",
-      "source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "telemetry.ts",
-      "line": 532,
-      "api": "withWriteTx",
-      "source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "temporal-expand.ts",
-      "line": 178,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "temporal-fallback.ts",
-      "line": 36,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => tableExistsIn(db, name));",
-      "category": "hot-path"
-    },
-    {
-      "path": "temporal-fallback.ts",
-      "line": 150,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "temporal-fallback.ts",
-      "line": 206,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "temporal-recall.ts",
-      "line": 442,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "test-temp-dir.ts",
-      "line": 31,
-      "api": "rmSync",
-      "source": "rmSync(dir, { recursive: true, force: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "test-temp-dir.ts",
-      "line": 59,
-      "api": "rmSync",
-      "source": "rmSync(dir, { recursive: true, force: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-audit.ts",
-      "line": 58,
-      "api": "existsSync",
-      "source": "if (!existsSync(dir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-audit.ts",
-      "line": 59,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-audit.ts",
-      "line": 65,
-      "api": "writeFileSync",
-      "source": "writeFileSync(latestPath, content, \"utf8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-audit.ts",
-      "line": 75,
-      "api": "renameSync",
-      "source": "renameSync(latestPath, finalPath);",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-audit.ts",
-      "line": 79,
-      "api": "writeFileSync",
-      "source": "writeFileSync(finalPath, content, \"utf8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-capture-worker.ts",
-      "line": 105,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-capture-worker.ts",
-      "line": 183,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-capture-worker.ts",
-      "line": 302,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-capture-worker.ts",
-      "line": 315,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-capture-worker.ts",
-      "line": 352,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx(resetInterruptedJobs);",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-capture-worker.ts",
-      "line": 414,
-      "api": "withReadDb",
-      "source": "return dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-capture-worker.ts",
-      "line": 458,
-      "api": "withReadDb",
-      "source": "return dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-health.ts",
-      "line": 42,
-      "api": "statSync",
-      "source": "return statSync(path).mtime.toISOString();",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-health.ts",
-      "line": 50,
-      "api": "existsSync",
-      "source": "if (!existsSync(root)) return { latestLogs: 0, finalLogs: 0, newestAuditAt: null };",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-health.ts",
-      "line": 55,
-      "api": "readdirSync",
-      "source": "for (const entry of readdirSync(dir, { withFileTypes: true })) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-health.ts",
-      "line": 74,
-      "api": "existsSync",
-      "source": "return rel ? existsSync(join(basePath, rel)) : false;",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-health.ts",
-      "line": 79,
-      "api": "readFileSync",
-      "source": "const body = readFileSync(path, \"utf8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-health.ts",
-      "line": 97,
-      "api": "withReadDb",
-      "source": "const sessionStore = dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-health.ts",
-      "line": 113,
-      "api": "withReadDb",
-      "source": "const artifacts = dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 153,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 155,
-      "api": "readFileSync",
-      "source": "for (const line of readFileSync(path, \"utf8\").split(/\\r?\\n/)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 188,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 189,
-      "api": "statSync",
-      "source": "const size = statSync(path).size;",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 205,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dirname(path), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 208,
-      "api": "writeFileSync",
-      "source": "writeFileSync(tmp, body.length > 0 ? `${body}\\n` : \"\", \"utf8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 209,
-      "api": "renameSync",
-      "source": "renameSync(tmp, path);",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 214,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dirname(path), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 215,
-      "api": "appendFileSync",
-      "source": "appendFileSync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 231,
-      "api": "readFileSync",
-      "source": "const parsed = JSON.parse(readFileSync(join(path, \"owner.json\"), \"utf8\")) as { readonly pid?: unknown };",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 240,
-      "api": "readFileSync",
-      "source": "const parsed = JSON.parse(readFileSync(join(path, \"owner.json\"), \"utf8\")) as { readonly token?: unknown };",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 260,
-      "api": "statSync",
-      "source": "return now - statSync(path).mtimeMs > LOCK_DEAD_OWNER_STALE_MS;",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 271,
-      "api": "mkdirSync",
-      "source": "mkdirSync(lockPath);",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 272,
-      "api": "writeFileSync",
-      "source": "writeFileSync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 285,
-      "api": "rmSync",
-      "source": "rmSync(lockPath, { recursive: true, force: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 295,
-      "api": "readFileSync",
-      "source": "const parsed = JSON.parse(readFileSync(join(lockPath, \"owner.json\"), \"utf8\")) as { readonly token?: unknown };",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 300,
-      "api": "rmSync",
-      "source": "rmSync(lockPath, { recursive: true, force: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 304,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dirname(path), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 372,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return { canonicalKeys, liveOnlyKeys };",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 405,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return false;",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 445,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 446,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dirname(path), { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 448,
-      "api": "writeFileSync",
-      "source": "writeFileSync(path, `${body}\\n`, \"utf8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 493,
-      "api": "renameSync",
-      "source": "renameSync(tmpPath, path);",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 501,
-      "api": "rmSync",
-      "source": "rmSync(tmpPath, { force: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 561,
-      "api": "existsSync",
-      "source": "if (replacements.size === 0 || !existsSync(jsonlPath)) return Promise.resolve(0);",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 648,
-      "api": "renameSync",
-      "source": "renameSync(tmpPath, jsonlPath);",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-jsonl.ts",
-      "line": 661,
-      "api": "rmSync",
-      "source": "rmSync(tmpPath, { force: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 266,
-      "api": "withReadDb",
-      "source": "if (dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => unchanged(db, agentId, candidate))) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 295,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 304,
-      "api": "withReadDb",
-      "source": "const alreadyCaptured = dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 309,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 329,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 375,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "update-system.ts",
-      "line": 321,
-      "api": "existsSync",
-      "source": "if (!existsSync(p)) continue;",
-      "category": "hot-path"
-    },
-    {
-      "path": "update-system.ts",
-      "line": 323,
-      "api": "readFileSync",
-      "source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "update-system.ts",
-      "line": 367,
-      "api": "existsSync",
-      "source": "if (!existsSync(p)) continue;",
-      "category": "hot-path"
-    },
-    {
-      "path": "update-system.ts",
-      "line": 370,
-      "api": "readFileSync",
-      "source": "const current = readFileSync(p, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "update-system.ts",
-      "line": 382,
-      "api": "writeFileSync",
-      "source": "writeFileSync(p, updated);",
-      "category": "hot-path"
-    },
-    {
-      "path": "update-system.ts",
-      "line": 609,
-      "api": "existsSync",
-      "source": "existsSync: (path) => existsSync(path),",
-      "category": "hot-path"
-    },
-    {
-      "path": "update-system.ts",
-      "line": 610,
-      "api": "readFileSync",
-      "source": "readFileSync: (path, encoding) => readFileSync(path, { encoding }),",
-      "category": "hot-path"
-    },
-    {
-      "path": "update-system.ts",
-      "line": 615,
-      "api": "existsSync",
-      "source": "const launcherExists = deps.existsSync(launcherPath);",
-      "category": "hot-path"
-    },
-    {
-      "path": "update-system.ts",
-      "line": 616,
-      "api": "existsSync",
-      "source": "const appImageExists = deps.existsSync(appImagePath);",
-      "category": "hot-path"
-    },
-    {
-      "path": "update-system.ts",
-      "line": 639,
-      "api": "readFileSync",
-      "source": "const launcher = deps.readFileSync(launcherPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "update-system.ts",
-      "line": 670,
-      "api": "existsSync",
-      "source": "existsSync: deps.existsSync ?? ((path: string) => existsSync(path)),",
-      "category": "hot-path"
-    },
-    {
-      "path": "update-system.ts",
-      "line": 671,
-      "api": "readFileSync",
-      "source": "readFileSync: deps.readFileSync ?? ((path: string, encoding: BufferEncoding) => readFileSync(path, { encoding })),",
-      "category": "hot-path"
-    },
-    {
-      "path": "update-system.ts",
-      "line": 694,
-      "api": "existsSync",
-      "source": "if (!fsDeps.existsSync(deps.signetCliPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "update-system.ts",
-      "line": 716,
-      "api": "existsSync",
-      "source": "if (!fsDeps.existsSync(signetBin)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "watcher-ignore.ts",
-      "line": 140,
-      "api": "existsSync",
-      "source": "if (!existsSync(sigignorePath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "watcher-ignore.ts",
-      "line": 141,
-      "api": "writeFileSync",
-      "source": "writeFileSync(sigignorePath, DEFAULT_SIGNIGNORE_CONTENT, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "watcher-ignore.ts",
-      "line": 155,
-      "api": "statSync",
-      "source": "const stat = statSync(sigignorePath);",
-      "category": "hot-path"
-    },
-    {
-      "path": "watcher-ignore.ts",
-      "line": 158,
-      "api": "readFileSync",
-      "source": "cache = { stamp, patterns: parseSigignore(readFileSync(sigignorePath, \"utf-8\")) };",
-      "category": "hot-path"
-    },
-    {
-      "path": "which.ts",
-      "line": 8,
-      "api": "accessSync",
-      "source": "accessSync(file, constants.X_OK);",
-      "category": "hot-path"
-    },
-    {
-      "path": "which.ts",
-      "line": 9,
-      "api": "statSync",
-      "source": "return statSync(file).isFile();",
-      "category": "hot-path"
-    },
-    {
-      "path": "widget-gen.ts",
-      "line": 36,
-      "api": "existsSync",
-      "source": "if (!existsSync(dir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "widget-gen.ts",
-      "line": 37,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "widget-gen.ts",
-      "line": 229,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return null;",
-      "category": "hot-path"
-    },
-    {
-      "path": "widget-gen.ts",
-      "line": 232,
-      "api": "readFileSync",
-      "source": "const content = readFileSync(path, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "widget-gen.ts",
-      "line": 241,
-      "api": "existsSync",
-      "source": "if (!existsSync(path)) return false;",
-      "category": "hot-path"
-    },
-    {
-      "path": "widget-gen.ts",
-      "line": 244,
-      "api": "unlinkSync",
-      "source": "unlinkSync(path);",
-      "category": "hot-path"
-    },
-    {
-      "path": "widget-gen.ts",
-      "line": 308,
-      "api": "writeFileSync",
-      "source": "writeFileSync(widgetPath(serverId), html);",
-      "category": "hot-path"
-    },
-    {
-      "path": "yielding-writes.ts",
-      "line": 86,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx(processBatch);",
-      "category": "hot-path"
-    },
-    {
-      "path": "yielding-writes.ts",
-      "line": 123,
-      "api": "withReadDb",
-      "source": "const batch = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => fetchBatch(db, limit));",
-      "category": "hot-path"
-    }
-  ]
+	"version": 1,
+	"generatedFrom": "platform/daemon/src",
+	"sites": [
+		{
+			"path": "agent-id.ts",
+			"line": 56,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "agent-id.ts",
+			"line": 82,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "aggregate-recall.ts",
+			"line": 740,
+			"api": "withReadDb",
+			"source": "const activeCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "aggregate-recall.ts",
+			"line": 746,
+			"api": "withWriteTx",
+			"source": "const written = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "aggregate-recall.ts",
+			"line": 995,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "auth/api-keys.ts",
+			"line": 197,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "auth/api-keys.ts",
+			"line": 241,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "auth/api-keys.ts",
+			"line": 258,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "auth/api-keys.ts",
+			"line": 272,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "auth/tokens.ts",
+			"line": 30,
+			"api": "existsSync",
+			"source": "if (existsSync(secretPath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "auth/tokens.ts",
+			"line": 31,
+			"api": "readFileSync",
+			"source": "const secret = readFileSync(secretPath);",
+			"category": "hot-path"
+		},
+		{
+			"path": "auth/tokens.ts",
+			"line": 37,
+			"api": "writeFileSync",
+			"source": "writeFileSync(secretPath, fresh, { mode: 0o600 });",
+			"category": "hot-path"
+		},
+		{
+			"path": "auth/tokens.ts",
+			"line": 43,
+			"api": "existsSync",
+			"source": "if (!existsSync(dir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "auth/tokens.ts",
+			"line": 44,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dir, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "auth/tokens.ts",
+			"line": 47,
+			"api": "writeFileSync",
+			"source": "writeFileSync(secretPath, secret, { mode: 0o600 });",
+			"category": "hot-path"
+		},
+		{
+			"path": "black-box.ts",
+			"line": 434,
+			"api": "withReadDb",
+			"source": "const events = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "black-box.ts",
+			"line": 467,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "config-migration.ts",
+			"line": 56,
+			"api": "existsSync",
+			"source": "if (existsSync(p)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "config-migration.ts",
+			"line": 65,
+			"api": "readFileSync",
+			"source": "text = readFileSync(path, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "config-migration.ts",
+			"line": 106,
+			"api": "writeFileSync",
+			"source": "writeFileSync(tmp, text, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "config-migration.ts",
+			"line": 107,
+			"api": "renameSync",
+			"source": "renameSync(tmp, path);",
+			"category": "hot-path"
+		},
+		{
+			"path": "config-migration.ts",
+			"line": 141,
+			"api": "existsSync",
+			"source": "if (existsSync(p)) return p;",
+			"category": "hot-path"
+		},
+		{
+			"path": "config-migration.ts",
+			"line": 152,
+			"api": "readFileSync",
+			"source": "text = readFileSync(path, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "config-migration.ts",
+			"line": 228,
+			"api": "writeFileSync",
+			"source": "writeFileSync(tmp, contents, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "config-migration.ts",
+			"line": 229,
+			"api": "renameSync",
+			"source": "renameSync(tmp, path);",
+			"category": "hot-path"
+		},
+		{
+			"path": "config-migration.ts",
+			"line": 290,
+			"api": "readFileSync",
+			"source": "text = readFileSync(path, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "config-migration.ts",
+			"line": 502,
+			"api": "readFileSync",
+			"source": "text = readFileSync(path, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "config-migration.ts",
+			"line": 564,
+			"api": "readFileSync",
+			"source": "text = readFileSync(path, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "config-migration.ts",
+			"line": 667,
+			"api": "readFileSync",
+			"source": "text = readFileSync(path, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "config-migration.ts",
+			"line": 724,
+			"api": "readFileSync",
+			"source": "text = readFileSync(path, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "connectors/filesystem.ts",
+			"line": 232,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "connectors/filesystem.ts",
+			"line": 287,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "connectors/filesystem.ts",
+			"line": 310,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "connectors/registry.ts",
+			"line": 23,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "connectors/registry.ts",
+			"line": 43,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "connectors/registry.ts",
+			"line": 59,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "connectors/registry.ts",
+			"line": 74,
+			"api": "withReadDb",
+			"source": "const before = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "connectors/registry.ts",
+			"line": 82,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "connectors/registry.ts",
+			"line": 98,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "connectors/registry.ts",
+			"line": 108,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "connectors/registry.ts",
+			"line": 145,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "cross-agent.ts",
+			"line": 645,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "cross-agent.ts",
+			"line": 768,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "cross-agent.ts",
+			"line": 813,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "cross-agent.ts",
+			"line": 856,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "cross-agent.ts",
+			"line": 884,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "cross-agent.ts",
+			"line": 914,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "cross-agent.ts",
+			"line": 953,
+			"api": "withWriteTx",
+			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "cross-agent.ts",
+			"line": 1028,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 380,
+			"api": "existsSync",
+			"source": "if (!existsSync(agentsMdPath)) return;",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 397,
+			"api": "existsSync",
+			"source": "const existingFiles = files.filter((f) => existsSync(join(AGENTS_DIR, f.name)));",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 425,
+			"api": "existsSync",
+			"source": "if (!existsSync(identityPath)) return \"\";",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 444,
+			"api": "existsSync",
+			"source": "if (activeHarnesses.has(\"opencode\") && existsSync(opencodeDir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 476,
+			"api": "existsSync",
+			"source": "if (activeHarnesses.has(\"opencode\") && existsSync(opencodeDir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 483,
+			"api": "existsSync",
+			"source": "if (existsSync(geminiDir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 488,
+			"api": "existsSync",
+			"source": "if (existsSync(settingsPath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 489,
+			"api": "readFileSync",
+			"source": "const parsed = JSON.parse(readFileSync(settingsPath, \"utf8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 509,
+			"api": "existsSync",
+			"source": "if (!existsSync(targetPath)) continue;",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 705,
+			"api": "statSync",
+			"source": "const stat = statSync(filePath);",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 723,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 774,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 813,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 833,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 865,
+			"api": "readFileSync",
+			"source": "content = readFileSync(filePath, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 1025,
+			"api": "existsSync",
+			"source": "if (!existsSync(memoryDir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 1401,
+			"api": "existsSync",
+			"source": "if (!existsSync(p)) continue;",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 1403,
+			"api": "readFileSync",
+			"source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\")) as Record<string, unknown>;",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 1421,
+			"api": "withWriteTx",
+			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 1440,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) continue;",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 1442,
+			"api": "readFileSync",
+			"source": "const routing = parseRoutingConfig(parseSimpleYaml(readFileSync(path, \"utf-8\")));",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 1502,
+			"api": "withReadDb",
+			"source": "const activeEmbeddingCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 1804,
+			"api": "existsSync",
+			"source": "if (existsSync(PID_FILE)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 1806,
+			"api": "unlinkSync",
+			"source": "unlinkSync(PID_FILE);",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 1947,
+			"api": "mkdirSync",
+			"source": "mkdirSync(DAEMON_DIR, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 1948,
+			"api": "mkdirSync",
+			"source": "mkdirSync(LOG_DIR, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 2023,
+			"api": "existsSync",
+			"source": "const workerPath = existsSync(bundled)",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 2093,
+			"api": "writeFileSync",
+			"source": "writeFileSync(PID_FILE, process.pid.toString());",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 2175,
+			"api": "withReadDb",
+			"source": "const memoryCount = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 2186,
+			"api": "withReadDb",
+			"source": "const queue = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 2393,
+			"api": "existsSync",
+			"source": "if (existsSync(healthStampPath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 2394,
+			"api": "readFileSync",
+			"source": "const prev = JSON.parse(readFileSync(healthStampPath, \"utf-8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "daemon.ts",
+			"line": 2397,
+			"api": "writeFileSync",
+			"source": "writeFileSync(",
+			"category": "hot-path"
+		},
+		{
+			"path": "database-integrity.ts",
+			"line": 127,
+			"api": "existsSync",
+			"source": "if (existsSync(bundled)) return bundled;",
+			"category": "hot-path"
+		},
+		{
+			"path": "database-integrity.ts",
+			"line": 270,
+			"api": "withReadDb",
+			"source": "const checks = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => ({",
+			"category": "hot-path"
+		},
+		{
+			"path": "database-integrity.ts",
+			"line": 304,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "database-integrity.ts",
+			"line": 309,
+			"api": "withReadDb",
+			"source": "const verifiedTelemetry = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 317,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return null;",
+			"category": "hot-path"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 320,
+			"api": "readFileSync",
+			"source": "const raw: unknown = JSON.parse(readFileSync(path, \"utf8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 577,
+			"api": "readdirSync",
+			"source": ".readdirSync(dir)",
+			"category": "pre-readiness-bootstrap"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 581,
+			"api": "statSync",
+			"source": "const stat = deps.statSync(join(dir, f));",
+			"category": "pre-readiness-bootstrap"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 595,
+			"api": "unlinkSync",
+			"source": "deps.unlinkSync(join(dir, old.name));",
+			"category": "pre-readiness-bootstrap"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 606,
+			"api": "statfsSync",
+			"source": "const stat = deps.statfsSync(path);",
+			"category": "pre-readiness-bootstrap"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 615,
+			"api": "statSync",
+			"source": "const size = deps.statSync(path).size;",
+			"category": "pre-readiness-bootstrap"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 646,
+			"api": "copyFileSync",
+			"source": "deps.copyFileSync(dbPath, probeDest);",
+			"category": "pre-readiness-bootstrap"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 652,
+			"api": "unlinkSync",
+			"source": "deps.unlinkSync(probeDest);",
+			"category": "pre-readiness-bootstrap"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 687,
+			"api": "copyFileSync",
+			"source": "deps.copyFileSync(dbPath, backupDest);",
+			"category": "pre-readiness-bootstrap"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 711,
+			"api": "copyFileSync",
+			"source": "deps.copyFileSync(dbPath, backupDest);",
+			"category": "pre-readiness-bootstrap"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 751,
+			"api": "unlinkSync",
+			"source": "deps.unlinkSync(backupDest);",
+			"category": "pre-readiness-bootstrap"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 760,
+			"api": "unlinkSync",
+			"source": "else deps.unlinkSync(backupDest);",
+			"category": "pre-readiness-bootstrap"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 788,
+			"api": "unlinkSync",
+			"source": "deps.unlinkSync(backupDest);",
+			"category": "pre-readiness-bootstrap"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 820,
+			"api": "existsSync",
+			"source": "if (!existsSync(dir)) {",
+			"category": "pre-readiness-bootstrap"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 821,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dir, { recursive: true });",
+			"category": "pre-readiness-bootstrap"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 842,
+			"api": "existsSync",
+			"source": "if (existsSync(path) && hasPendingMigrations(toMigrationDb(writeConn))) {",
+			"category": "pre-readiness-bootstrap"
+		},
+		{
+			"path": "db-accessor.ts",
+			"line": 849,
+			"api": "existsSync",
+			"source": "if (existsSync(path) && hasPendingMigrations(toMigrationDb(writeConn))) {",
+			"category": "pre-readiness-bootstrap"
+		},
+		{
+			"path": "db-vacuum.ts",
+			"line": 67,
+			"api": "statSync",
+			"source": "const dbBytes = deps.statSync(dbPath).size;",
+			"category": "hot-path"
+		},
+		{
+			"path": "db-vacuum.ts",
+			"line": 69,
+			"api": "statfsSync",
+			"source": "const stats = deps.statfsSync(directory);",
+			"category": "hot-path"
+		},
+		{
+			"path": "db-vacuum.ts",
+			"line": 322,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readStatusFromDb(toPragmaReadDb(db)));",
+			"category": "hot-path"
+		},
+		{
+			"path": "db-vacuum.ts",
+			"line": 411,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "db-vacuum.ts",
+			"line": 437,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "db-vacuum.ts",
+			"line": 453,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "discord-desktop-cache-source.ts",
+			"line": 221,
+			"api": "lstatSync",
+			"source": "stat = fileSystem.lstatSync(path);",
+			"category": "hot-path"
+		},
+		{
+			"path": "discord-desktop-cache-source.ts",
+			"line": 265,
+			"api": "readdirSync",
+			"source": "const entries = fileSystem.readdirSync(path);",
+			"category": "hot-path"
+		},
+		{
+			"path": "discord-desktop-cache-source.ts",
+			"line": 285,
+			"api": "readFileSync",
+			"source": "const data = fileSystem.readFileSync(candidate.absPath);",
+			"category": "hot-path"
+		},
+		{
+			"path": "discord-desktop-cache-source.ts",
+			"line": 481,
+			"api": "withReadDb",
+			"source": "const rows = getDbAccessor().withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "discord-desktop-cache-source.ts",
+			"line": 494,
+			"api": "withWriteTx",
+			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "discord-desktop-cache-source.ts",
+			"line": 1085,
+			"api": "readFileSync",
+			"source": "const data = fileSystem.readFileSync(path).subarray(0, CACHE_SNIFF_BYTES).toString(\"utf8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "discord-source-provider.ts",
+			"line": 554,
+			"api": "withReadDb",
+			"source": "const rows = getDbAccessor().withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "discord-source-provider.ts",
+			"line": 568,
+			"api": "withWriteTx",
+			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "discord-source-provider.ts",
+			"line": 610,
+			"api": "withReadDb",
+			"source": "const row = getDbAccessor().withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "discord-source-provider.ts",
+			"line": 855,
+			"api": "withReadDb",
+			"source": "const row = getDbAccessor().withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "discord-source-provider.ts",
+			"line": 939,
+			"api": "withReadDb",
+			"source": "const rows = getDbAccessor().withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "discord-source-provider.ts",
+			"line": 953,
+			"api": "withWriteTx",
+			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-fetch.ts",
+			"line": 494,
+			"api": "withReadDb",
+			"source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => resolveActiveEmbeddingConfig(db, cfg));",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-index-migration.ts",
+			"line": 80,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx(fn);",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-index-migration.ts",
+			"line": 253,
+			"api": "withReadDb",
+			"source": "const state = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readEmbeddingIndexState(db));",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-index-migration.ts",
+			"line": 262,
+			"api": "withReadDb",
+			"source": "const rows = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-index-migration.ts",
+			"line": 343,
+			"api": "withReadDb",
+			"source": "const coverage = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-index-migration.ts",
+			"line": 355,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-index-migration.ts",
+			"line": 435,
+			"api": "withReadDb",
+			"source": "const before = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readEmbeddingIndexState(db));",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-index-migration.ts",
+			"line": 437,
+			"api": "withWriteTx",
+			"source": "const initial = input.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-index-migration.ts",
+			"line": 446,
+			"api": "withReadDb",
+			"source": "const hasStagingVectorIndex = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-index-migration.ts",
+			"line": 452,
+			"api": "withWriteTx",
+			"source": "input.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-index-migration.ts",
+			"line": 458,
+			"api": "withWriteTx",
+			"source": "input.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-index-migration.ts",
+			"line": 469,
+			"api": "withReadDb",
+			"source": "const state = input.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readEmbeddingIndexState(db));",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-repair-state.ts",
+			"line": 101,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-repair-state.ts",
+			"line": 139,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-repair-state.ts",
+			"line": 160,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-repair-state.ts",
+			"line": 191,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-tracker.ts",
+			"line": 194,
+			"api": "withReadDb",
+			"source": "const staleRows: StaleRow[] = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-tracker.ts",
+			"line": 265,
+			"api": "withWriteTx",
+			"source": "applied = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-usage.ts",
+			"line": 90,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-usage.ts",
+			"line": 115,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-worker-handle.ts",
+			"line": 180,
+			"api": "existsSync",
+			"source": ": existsSync(bundled)",
+			"category": "hot-path"
+		},
+		{
+			"path": "embedding-worker.ts",
+			"line": 154,
+			"api": "mkdirSync",
+			"source": "mkdirSync(init.cacheDir, { recursive: true });",
+			"category": "isolated-worker"
+		},
+		{
+			"path": "embedding-worker.ts",
+			"line": 175,
+			"api": "readFileSync",
+			"source": "const wasmBytes = readFileSync(join(init.wasmDir, \"ort-wasm-simd-threaded.wasm\"));",
+			"category": "isolated-worker"
+		},
+		{
+			"path": "feature-flags.ts",
+			"line": 36,
+			"api": "existsSync",
+			"source": "if (!existsSync(p)) continue;",
+			"category": "hot-path"
+		},
+		{
+			"path": "feature-flags.ts",
+			"line": 38,
+			"api": "readFileSync",
+			"source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "file-sync.ts",
+			"line": 9,
+			"api": "existsSync",
+			"source": "const existing = existsSync(path) ? readFileSync(path, \"utf-8\") : null;",
+			"category": "hot-path"
+		},
+		{
+			"path": "file-sync.ts",
+			"line": 9,
+			"api": "readFileSync",
+			"source": "const existing = existsSync(path) ? readFileSync(path, \"utf-8\") : null;",
+			"category": "hot-path"
+		},
+		{
+			"path": "file-sync.ts",
+			"line": 11,
+			"api": "writeFileSync",
+			"source": "writeFileSync(path, content);",
+			"category": "hot-path"
+		},
+		{
+			"path": "github-source-provider.ts",
+			"line": 457,
+			"api": "withReadDb",
+			"source": "const rows = getDbAccessor().withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "github-source-provider.ts",
+			"line": 479,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "github-source-provider.ts",
+			"line": 493,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "graphiq.ts",
+			"line": 34,
+			"api": "accessSync",
+			"source": "accessSync(candidate, constants.X_OK);",
+			"category": "hot-path"
+		},
+		{
+			"path": "graphiq.ts",
+			"line": 48,
+			"api": "existsSync",
+			"source": "if (!existsSync(active.dbPath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "hooks-config.ts",
+			"line": 289,
+			"api": "existsSync",
+			"source": "if (!existsSync(configPath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "hooks-config.ts",
+			"line": 294,
+			"api": "readFileSync",
+			"source": "const content = readFileSync(configPath, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "hooks.ts",
+			"line": 455,
+			"api": "existsSync",
+			"source": "if (!existsSync(getMemoryDbPath())) return undefined;",
+			"category": "hot-path"
+		},
+		{
+			"path": "hooks.ts",
+			"line": 553,
+			"api": "existsSync",
+			"source": "if (!existsSync(getMemoryDbPath())) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "hooks.ts",
+			"line": 761,
+			"api": "existsSync",
+			"source": "if (req.sessionKey && existsSync(getMemoryDbPath())) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "hooks.ts",
+			"line": 1602,
+			"api": "existsSync",
+			"source": "if (req.transcriptPath && existsSync(req.transcriptPath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "hooks.ts",
+			"line": 1604,
+			"api": "readFileSync",
+			"source": "rawTranscript = readFileSync(req.transcriptPath, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "hooks.ts",
+			"line": 1946,
+			"api": "existsSync",
+			"source": "if (req.transcriptPath && existsSync(req.transcriptPath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "hooks.ts",
+			"line": 1948,
+			"api": "readFileSync",
+			"source": "rawTranscript = readFileSync(req.transcriptPath, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "hooks.ts",
+			"line": 2210,
+			"api": "existsSync",
+			"source": "} else if (req.transcriptPath && existsSync(req.transcriptPath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "hooks.ts",
+			"line": 2212,
+			"api": "readFileSync",
+			"source": "const raw = readFileSync(req.transcriptPath, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "identity-context.ts",
+			"line": 32,
+			"api": "existsSync",
+			"source": "if (!filePath || !existsSync(filePath)) return undefined;",
+			"category": "hot-path"
+		},
+		{
+			"path": "identity-context.ts",
+			"line": 35,
+			"api": "readFileSync",
+			"source": "const content = readFileSync(filePath, \"utf-8\").trim();",
+			"category": "hot-path"
+		},
+		{
+			"path": "identity-context.ts",
+			"line": 73,
+			"api": "existsSync",
+			"source": "if (!filePath || !existsSync(filePath)) return undefined;",
+			"category": "hot-path"
+		},
+		{
+			"path": "identity-context.ts",
+			"line": 76,
+			"api": "readFileSync",
+			"source": "const content = readFileSync(filePath, \"utf-8\").trim();",
+			"category": "hot-path"
+		},
+		{
+			"path": "identity-context.ts",
+			"line": 178,
+			"api": "existsSync",
+			"source": "if (identityMd && existsSync(identityMd)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "identity-context.ts",
+			"line": 180,
+			"api": "readFileSync",
+			"source": "return parseIdentityMarkdown(readFileSync(identityMd, \"utf-8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "identity-context.ts",
+			"line": 185,
+			"api": "existsSync",
+			"source": "if (existsSync(agentYaml)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "identity-context.ts",
+			"line": 187,
+			"api": "readFileSync",
+			"source": "const content = readFileSync(agentYaml, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "identity-context.ts",
+			"line": 200,
+			"api": "existsSync",
+			"source": "if (existsSync(rootIdentityMd)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "identity-context.ts",
+			"line": 202,
+			"api": "readFileSync",
+			"source": "return parseIdentityMarkdown(readFileSync(rootIdentityMd, \"utf-8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "identity-sync.ts",
+			"line": 35,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return null;",
+			"category": "hot-path"
+		},
+		{
+			"path": "identity-sync.ts",
+			"line": 60,
+			"api": "existsSync",
+			"source": "if (!existsSync(agentsRoot)) return;",
+			"category": "hot-path"
+		},
+		{
+			"path": "identity-sync.ts",
+			"line": 84,
+			"api": "existsSync",
+			"source": "const soulPath = existsSync(join(agentDir, \"SOUL.md\")) ? join(agentDir, \"SOUL.md\") : join(agentsDir, \"SOUL.md\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "identity-sync.ts",
+			"line": 85,
+			"api": "existsSync",
+			"source": "const identityPath = existsSync(join(agentDir, \"IDENTITY.md\"))",
+			"category": "hot-path"
+		},
+		{
+			"path": "imported-source-lifecycle.ts",
+			"line": 36,
+			"api": "withWriteTx",
+			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "imported-source-outcome.ts",
+			"line": 16,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => persistImportedSourceOutcomeInTx(db, input));",
+			"category": "hot-path"
+		},
+		{
+			"path": "imported-source-outcome.ts",
+			"line": 59,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "knowledge-graph-hygiene.ts",
+			"line": 428,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "lifecycle.ts",
+			"line": 154,
+			"api": "readFileSync",
+			"source": "const raw = readFileSync(lifecyclePath(agentsDir), \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "lifecycle.ts",
+			"line": 169,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dirname(path), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "lifecycle.ts",
+			"line": 171,
+			"api": "writeFileSync",
+			"source": "writeFileSync(tmpPath, JSON.stringify(record, null, 2));",
+			"category": "hot-path"
+		},
+		{
+			"path": "lifecycle.ts",
+			"line": 172,
+			"api": "renameSync",
+			"source": "renameSync(tmpPath, path);",
+			"category": "hot-path"
+		},
+		{
+			"path": "logger.ts",
+			"line": 179,
+			"api": "existsSync",
+			"source": "if (!existsSync(dir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "logger.ts",
+			"line": 180,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dir, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "logger.ts",
+			"line": 242,
+			"api": "existsSync",
+			"source": "if (!existsSync(this.config.logFilePath)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "logger.ts",
+			"line": 250,
+			"api": "existsSync",
+			"source": "if (!existsSync(this.config.logDir)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "logger.ts",
+			"line": 251,
+			"api": "readdirSync",
+			"source": "return readdirSync(this.config.logDir)",
+			"category": "hot-path"
+		},
+		{
+			"path": "logger.ts",
+			"line": 349,
+			"api": "appendFileSync",
+			"source": "appendFileSync(this.currentLogFile, lines);",
+			"category": "hot-path"
+		},
+		{
+			"path": "logger.ts",
+			"line": 372,
+			"api": "existsSync",
+			"source": "if (!existsSync(this.currentLogFile)) return;",
+			"category": "hot-path"
+		},
+		{
+			"path": "logger.ts",
+			"line": 374,
+			"api": "statSync",
+			"source": "const stats = statSync(this.currentLogFile);",
+			"category": "hot-path"
+		},
+		{
+			"path": "logger.ts",
+			"line": 389,
+			"api": "renameSync",
+			"source": "renameSync(this.currentLogFile, rotatedName);",
+			"category": "hot-path"
+		},
+		{
+			"path": "logger.ts",
+			"line": 405,
+			"api": "unlinkSync",
+			"source": "unlinkSync(files[i].path);",
+			"category": "hot-path"
+		},
+		{
+			"path": "logger.ts",
+			"line": 551,
+			"api": "readFileSync",
+			"source": "const content = readFileSync(file.path, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "mcp-probe.ts",
+			"line": 45,
+			"api": "existsSync",
+			"source": "if (!existsSync(dir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "mcp-probe.ts",
+			"line": 46,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dir, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "mcp-probe.ts",
+			"line": 440,
+			"api": "writeFileSync",
+			"source": "writeFileSync(manifestPath, JSON.stringify(result, null, 2));",
+			"category": "hot-path"
+		},
+		{
+			"path": "mcp-probe.ts",
+			"line": 474,
+			"api": "writeFileSync",
+			"source": "writeFileSync(getAppTrayPath(), JSON.stringify(tray, null, 2));",
+			"category": "hot-path"
+		},
+		{
+			"path": "mcp-probe.ts",
+			"line": 500,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "mcp-probe.ts",
+			"line": 503,
+			"api": "readFileSync",
+			"source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+			"category": "hot-path"
+		},
+		{
+			"path": "mcp-probe.ts",
+			"line": 522,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return null;",
+			"category": "hot-path"
+		},
+		{
+			"path": "mcp-probe.ts",
+			"line": 525,
+			"api": "readFileSync",
+			"source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+			"category": "hot-path"
+		},
+		{
+			"path": "mcp-probe.ts",
+			"line": 541,
+			"api": "existsSync",
+			"source": "if (existsSync(manifestPath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "mcp-probe.ts",
+			"line": 542,
+			"api": "unlinkSync",
+			"source": "unlinkSync(manifestPath);",
+			"category": "hot-path"
+		},
+		{
+			"path": "mcp-probe.ts",
+			"line": 552,
+			"api": "writeFileSync",
+			"source": "writeFileSync(getAppTrayPath(), JSON.stringify(filtered, null, 2));",
+			"category": "hot-path"
+		},
+		{
+			"path": "mcp-stdio.ts",
+			"line": 32,
+			"api": "existsSync",
+			"source": "return isAbsolute(dir) && existsSync(dir) && statSync(dir).isDirectory();",
+			"category": "cli-only"
+		},
+		{
+			"path": "mcp-stdio.ts",
+			"line": 32,
+			"api": "statSync",
+			"source": "return isAbsolute(dir) && existsSync(dir) && statSync(dir).isDirectory();",
+			"category": "cli-only"
+		},
+		{
+			"path": "memory-candidates.ts",
+			"line": 132,
+			"api": "existsSync",
+			"source": "if (memoryIds.length === 0 || !existsSync(memoryDbPath)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-candidates.ts",
+			"line": 150,
+			"api": "withReadDb",
+			"source": "const batchRows: ScoredMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-candidates.ts",
+			"line": 211,
+			"api": "existsSync",
+			"source": "if (!existsSync(memoryDbPath)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-candidates.ts",
+			"line": 228,
+			"api": "withReadDb",
+			"source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-candidates.ts",
+			"line": 285,
+			"api": "existsSync",
+			"source": "if (!existsSync(memoryDbPath)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-candidates.ts",
+			"line": 306,
+			"api": "withReadDb",
+			"source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-candidates.ts",
+			"line": 368,
+			"api": "withReadDb",
+			"source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-candidates.ts",
+			"line": 401,
+			"api": "existsSync",
+			"source": "if (!existsSync(memoryDbPath)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-candidates.ts",
+			"line": 432,
+			"api": "withReadDb",
+			"source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-candidates.ts",
+			"line": 440,
+			"api": "existsSync",
+			"source": "if (!existsSync(memoryDbPath)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-candidates.ts",
+			"line": 473,
+			"api": "withReadDb",
+			"source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-config.ts",
+			"line": 990,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) continue;",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-config.ts",
+			"line": 992,
+			"api": "readFileSync",
+			"source": "const yaml = parseSimpleYaml(readFileSync(path, \"utf-8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-head.ts",
+			"line": 59,
+			"api": "withWriteTx",
+			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-head.ts",
+			"line": 128,
+			"api": "withWriteTx",
+			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-head.ts",
+			"line": 147,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-head.ts",
+			"line": 160,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dir, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-head.ts",
+			"line": 161,
+			"api": "existsSync",
+			"source": "if (existsSync(path)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-head.ts",
+			"line": 164,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dirname(backup), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-head.ts",
+			"line": 165,
+			"api": "writeFileSync",
+			"source": "writeFileSync(backup, readFileSync(path, \"utf-8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-head.ts",
+			"line": 165,
+			"api": "readFileSync",
+			"source": "writeFileSync(backup, readFileSync(path, \"utf-8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-head.ts",
+			"line": 167,
+			"api": "writeFileSync",
+			"source": "writeFileSync(path, file);",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
+			"line": 438,
+			"api": "mkdirSync",
+			"source": "mkdirSync(getMemoryDir(), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
+			"line": 440,
+			"api": "writeFileSync",
+			"source": "writeFileSync(tmp, content, \"utf8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
+			"line": 441,
+			"api": "renameSync",
+			"source": "renameSync(tmp, path);",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
+			"line": 445,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return null;",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
+			"line": 446,
+			"api": "readFileSync",
+			"source": "const parsed = parseFrontmatterDocument(readFileSync(path, \"utf8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
+			"line": 498,
+			"api": "existsSync",
+			"source": "if (existsSync(path)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
+			"line": 499,
+			"api": "readFileSync",
+			"source": "const existing = parseFrontmatterDocument(readFileSync(path, \"utf8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
+			"line": 654,
+			"api": "statSync",
+			"source": "sourceMtimeMs = statSync(path).mtimeMs,",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
+			"line": 730,
+			"api": "statSync",
+			"source": "sourceMtimeMs = statSync(path).mtimeMs,",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
+			"line": 826,
+			"api": "existsSync",
+			"source": "existsSync(path) ? statSync(path).mtimeMs : Date.now(),",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
+			"line": 826,
+			"api": "statSync",
+			"source": "existsSync(path) ? statSync(path).mtimeMs : Date.now(),",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
+			"line": 833,
+			"api": "existsSync",
+			"source": "if (!existsSync(dir)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
+			"line": 1495,
+			"api": "readFileSync",
+			"source": "const parsed = parseFrontmatterDocument(readFileSync(fullPath, \"utf8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
+			"line": 1556,
+			"api": "readFileSync",
+			"source": "const parsed = parseFrontmatterDocument(readFileSync(fullPath, \"utf8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
+			"line": 1606,
+			"api": "readFileSync",
+			"source": "const parsed = parseFrontmatterDocument(readFileSync(fullPath, \"utf8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-lineage.ts",
+			"line": 2201,
+			"api": "rmSync",
+			"source": "rmSync(join(getAgentsDir(), path), { force: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-search-telemetry.ts",
+			"line": 238,
+			"api": "withWriteTx",
+			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "memory-search-telemetry.ts",
+			"line": 314,
+			"api": "withReadDb",
+			"source": "return db.withReadDb((r) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "native-runtime-assets.ts",
+			"line": 77,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dir, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "native-runtime-assets.ts",
+			"line": 78,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "native-runtime-assets.ts",
+			"line": 79,
+			"api": "writeFileSync",
+			"source": "writeFileSync(path, Buffer.from(worker.contentBase64, \"base64\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "native-runtime-assets.ts",
+			"line": 93,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dir, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "native-runtime-assets.ts",
+			"line": 96,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "native-runtime-assets.ts",
+			"line": 97,
+			"api": "writeFileSync",
+			"source": "writeFileSync(path, Buffer.from(asset.contentBase64, \"base64\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "native-runtime-assets.ts",
+			"line": 111,
+			"api": "mkdirSync",
+			"source": "mkdirSync(root, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "native-runtime-assets.ts",
+			"line": 116,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dirname(path), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "native-runtime-assets.ts",
+			"line": 117,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "native-runtime-assets.ts",
+			"line": 118,
+			"api": "writeFileSync",
+			"source": "writeFileSync(path, Buffer.from(asset.contentBase64, \"base64\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "native-runtime-assets.ts",
+			"line": 123,
+			"api": "writeFileSync",
+			"source": "writeFileSync(join(root, \".signet-assets.json\"), `${JSON.stringify({ kind, sourceHash }, null, 2)}\\n`);",
+			"category": "hot-path"
+		},
+		{
+			"path": "obsidian-source-embeddings.ts",
+			"line": 269,
+			"api": "withReadDb",
+			"source": "const embeddingConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "obsidian-source-embeddings.ts",
+			"line": 304,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "obsidian-source-embeddings.ts",
+			"line": 318,
+			"api": "withReadDb",
+			"source": "const writeConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "obsidian-source-embeddings.ts",
+			"line": 347,
+			"api": "withWriteTx",
+			"source": "const stored = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "obsidian-source-embeddings.ts",
+			"line": 408,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "obsidian-source-embeddings.ts",
+			"line": 454,
+			"api": "withReadDb",
+			"source": "const row = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "obsidian-source-embeddings.ts",
+			"line": 475,
+			"api": "withWriteTx",
+			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "obsidian-source-graph.ts",
+			"line": 323,
+			"api": "existsSync",
+			"source": "return existsSync(path) && statSync(path).isFile() ? normalizedPath(path) : null;",
+			"category": "hot-path"
+		},
+		{
+			"path": "obsidian-source-graph.ts",
+			"line": 323,
+			"api": "statSync",
+			"source": "return existsSync(path) && statSync(path).isFile() ? normalizedPath(path) : null;",
+			"category": "hot-path"
+		},
+		{
+			"path": "obsidian-source-graph.ts",
+			"line": 471,
+			"api": "withWriteTx",
+			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "obsidian-source-graph.ts",
+			"line": 690,
+			"api": "withWriteTx",
+			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "obsidian-source-graph.ts",
+			"line": 702,
+			"api": "withWriteTx",
+			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "ontology-assertions.ts",
+			"line": 306,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: WriteDb) => insertAssertion(db, input));",
+			"category": "hot-path"
+		},
+		{
+			"path": "ontology-assertions.ts",
+			"line": 325,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "ontology-assertions.ts",
+			"line": 391,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "ontology-assertions.ts",
+			"line": 410,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "ontology-assertions.ts",
+			"line": 438,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "ontology-assertions.ts",
+			"line": 466,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "ontology-claim-evidence.ts",
+			"line": 153,
+			"api": "withReadDb",
+			"source": "const items = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "ontology-claim-trace.ts",
+			"line": 1063,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "ontology-contradictions.ts",
+			"line": 524,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => reconcileOntologyContradictionsInTx(db, params));",
+			"category": "hot-path"
+		},
+		{
+			"path": "ontology-contradictions.ts",
+			"line": 535,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "ontology-contradictions.ts",
+			"line": 591,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "ontology-extraction.ts",
+			"line": 647,
+			"api": "withReadDb",
+			"source": "const source = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "ontology-extraction.ts",
+			"line": 748,
+			"api": "withWriteTx",
+			"source": "const written = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "path-feedback.ts",
+			"line": 611,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/acpx-dreaming-mcp.ts",
+			"line": 16,
+			"api": "existsSync",
+			"source": "if (!existsSync(entrypoint)) throw new Error(`Signet Dreaming MCP entrypoint is unavailable: ${entrypoint}`);",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/acpx-dreaming-mcp.ts",
+			"line": 40,
+			"api": "writeFileSync",
+			"source": "writeFileSync(",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/acpx-dreaming-mcp.ts",
+			"line": 57,
+			"api": "rmSync",
+			"source": "rmSync(dir, { recursive: true, force: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/aspect-feedback.ts",
+			"line": 79,
+			"api": "withWriteTx",
+			"source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/aspect-feedback.ts",
+			"line": 165,
+			"api": "withWriteTx",
+			"source": "const decayed = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 219,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 260,
+			"api": "withReadDb",
+			"source": "const doc = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 270,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => completeJob(db, job.id));",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 278,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => updateDocumentStatus(db, docId, \"extracting\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 301,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 318,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 356,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 367,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => updateDocumentStatus(db, docId, \"chunking\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 372,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 382,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => updateDocumentStatus(db, docId, \"embedding\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 405,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 531,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 536,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 585,
+			"api": "withReadDb",
+			"source": "return deps.accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 604,
+			"api": "withReadDb",
+			"source": "const durable = deps.accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 611,
+			"api": "withReadDb",
+			"source": "const durableLinks = deps.accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 659,
+			"api": "withWriteTx",
+			"source": "const job = deps.accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/document-worker.ts",
+			"line": 687,
+			"api": "withWriteTx",
+			"source": "deps.accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-attention.ts",
+			"line": 136,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getDreamingAttentionInDb(db, agentId, limit));",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-attention.ts",
+			"line": 145,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-attention.ts",
+			"line": 181,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-attention.ts",
+			"line": 225,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-attention.ts",
+			"line": 256,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-attention.ts",
+			"line": 290,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-evidence-retry.ts",
+			"line": 131,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-evidence-retry.ts",
+			"line": 253,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-operations.ts",
+			"line": 112,
+			"api": "withReadDb",
+			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-operations.ts",
+			"line": 154,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-operations.ts",
+			"line": 478,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-operations.ts",
+			"line": 490,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-operations.ts",
+			"line": 503,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-operations.ts",
+			"line": 520,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-operations.ts",
+			"line": 692,
+			"api": "withReadDb",
+			"source": "const pending = params.accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-runbook.ts",
+			"line": 177,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-runbook.ts",
+			"line": 219,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-token-cache.ts",
+			"line": 36,
+			"api": "existsSync",
+			"source": "return existsSync(bundled)",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-worker.ts",
+			"line": 96,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getQueueHealth(db).status !== \"healthy\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-worker.ts",
+			"line": 106,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-worker.ts",
+			"line": 182,
+			"api": "withReadDb",
+			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => hasDreamingAttentionKindInDb(db, scope, [\"hygiene\"])),",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-worker.ts",
+			"line": 186,
+			"api": "withReadDb",
+			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming-worker.ts",
+			"line": 278,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 119,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 152,
+			"api": "withReadDb",
+			"source": "const selection = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 157,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 265,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 411,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => readDreamingState(db, agentId));",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 446,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 513,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 524,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 537,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 592,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 619,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 665,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 689,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 731,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return { content: \"\", unreadable: false };",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 733,
+			"api": "readFileSync",
+			"source": "const raw = readFileSync(path, \"utf-8\").trim();",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 1199,
+			"api": "withReadDb",
+			"source": "const row = accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 1220,
+			"api": "withReadDb",
+			"source": "const rows: Array<{ readonly memoryId: string }> = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 1261,
+			"api": "withReadDb",
+			"source": "const rows: Array<{ readonly memoryId: string }> = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 1411,
+			"api": "withReadDb",
+			"source": "const cutoff = accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 1422,
+			"api": "withReadDb",
+			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 1428,
+			"api": "withReadDb",
+			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 1434,
+			"api": "withReadDb",
+			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getDreamingAttentionInDb(db, scope, 1).length > 0),",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 1450,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 1512,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 1599,
+			"api": "withReadDb",
+			"source": "const previous = accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 1614,
+			"api": "withReadDb",
+			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 1624,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 1924,
+			"api": "withReadDb",
+			"source": "const entries = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 1955,
+			"api": "withReadDb",
+			"source": "const hasAttention = accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/dreaming.ts",
+			"line": 1975,
+			"api": "withReadDb",
+			"source": "const hasContinuation = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/extraction-fallback.ts",
+			"line": 17,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/prospective-index.ts",
+			"line": 230,
+			"api": "withWriteTx",
+			"source": "job = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => leaseJob(db, 3));",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/prospective-index.ts",
+			"line": 242,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => failJob(db, j.id, \"invalid payload\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/prospective-index.ts",
+			"line": 252,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/prospective-index.ts",
+			"line": 262,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => completeJob(db, j.id));",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/prospective-index.ts",
+			"line": 272,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => failJob(db, j.id, msg));",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/provider.ts",
+			"line": 824,
+			"api": "mkdirSync",
+			"source": "mkdirSync(isolatedCwd, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/reflection-worker.ts",
+			"line": 39,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return null;",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/reflection-worker.ts",
+			"line": 40,
+			"api": "readFileSync",
+			"source": "const data = JSON.parse(readFileSync(path, \"utf-8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/reflection-worker.ts",
+			"line": 50,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dir, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/reflection-worker.ts",
+			"line": 51,
+			"api": "writeFileSync",
+			"source": "writeFileSync(getLastReflectionPath(agentId), JSON.stringify({ lastDate: date }));",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/reflection-worker.ts",
+			"line": 366,
+			"api": "withReadDb",
+			"source": "const memories = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/reflection-worker.ts",
+			"line": 399,
+			"api": "withReadDb",
+			"source": "const existingReflections = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/reflection-worker.ts",
+			"line": 461,
+			"api": "withWriteTx",
+			"source": "deps.getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/reflection-worker.ts",
+			"line": 527,
+			"api": "withReadDb",
+			"source": ".withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/reranker-embedding.ts",
+			"line": 51,
+			"api": "withReadDb",
+			"source": "const embMap = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/retention-worker.ts",
+			"line": 376,
+			"api": "withWriteTx",
+			"source": "const retentionResult = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/retention-worker.ts",
+			"line": 391,
+			"api": "withWriteTx",
+			"source": "const historyPurged = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/retention-worker.ts",
+			"line": 397,
+			"api": "withWriteTx",
+			"source": "const completedJobsPurged = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/retention-worker.ts",
+			"line": 403,
+			"api": "withWriteTx",
+			"source": "const deadJobsPurged = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/retention-worker.ts",
+			"line": 409,
+			"api": "withWriteTx",
+			"source": "const completedTranscriptCaptureJobsPurged = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/retention-worker.ts",
+			"line": 413,
+			"api": "withWriteTx",
+			"source": "const deadTranscriptCaptureJobsPurged = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-graph.ts",
+			"line": 80,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-graph.ts",
+			"line": 174,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-graph.ts",
+			"line": 292,
+			"api": "withReadDb",
+			"source": "const writeConfig = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-graph.ts",
+			"line": 305,
+			"api": "withWriteTx",
+			"source": "embeddingCreated = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-graph.ts",
+			"line": 365,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-graph.ts",
+			"line": 376,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-reconciler.ts",
+			"line": 136,
+			"api": "existsSync",
+			"source": "if (options.scanFilesystem !== false && existsSync(dir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-reconciler.ts",
+			"line": 137,
+			"api": "readdirSync",
+			"source": "const entries = readdirSync(dir, { withFileTypes: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-reconciler.ts",
+			"line": 141,
+			"api": "existsSync",
+			"source": "if (existsSync(skillMdPath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-reconciler.ts",
+			"line": 163,
+			"api": "withReadDb",
+			"source": "const graphSkills = deps.accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-reconciler.ts",
+			"line": 170,
+			"api": "existsSync",
+			"source": "if (!existsSync(row.fs_path)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-reconciler.ts",
+			"line": 228,
+			"api": "existsSync",
+			"source": "if (!existsSync(mdPath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-reconciler.ts",
+			"line": 234,
+			"api": "readFileSync",
+			"source": "const content = readFileSync(mdPath, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-reconciler.ts",
+			"line": 241,
+			"api": "withReadDb",
+			"source": "const existing = deps.accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-reconciler.ts",
+			"line": 250,
+			"api": "withReadDb",
+			"source": "const storedEmb = deps.accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-reconciler.ts",
+			"line": 331,
+			"api": "statSync",
+			"source": "return statSync(dir).mtimeMs;",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/skill-reconciler.ts",
+			"line": 373,
+			"api": "existsSync",
+			"source": "if (existsSync(dir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/synthesis-worker.ts",
+			"line": 73,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return 0;",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/synthesis-worker.ts",
+			"line": 74,
+			"api": "readFileSync",
+			"source": "const data = JSON.parse(readFileSync(path, \"utf-8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/synthesis-worker.ts",
+			"line": 84,
+			"api": "mkdirSync",
+			"source": "mkdirSync(join(getAgentsDir(), \".daemon\"), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/synthesis-worker.ts",
+			"line": 85,
+			"api": "writeFileSync",
+			"source": "writeFileSync(path, JSON.stringify({ lastRunAt: timestamp }));",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/synthesis-worker.ts",
+			"line": 127,
+			"api": "withReadDb",
+			"source": "const checkpointRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "pipeline/synthesis-worker.ts",
+			"line": 153,
+			"api": "withReadDb",
+			"source": "const transcriptRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "plugins/audit.ts",
+			"line": 71,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dirname(path), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "plugins/audit.ts",
+			"line": 72,
+			"api": "appendFileSync",
+			"source": "appendFileSync(path, `${JSON.stringify(event)}\\n`, { mode: 0o600 });",
+			"category": "hot-path"
+		},
+		{
+			"path": "plugins/audit.ts",
+			"line": 85,
+			"api": "existsSync",
+			"source": "if (!path || !existsSync(path)) return { events: [], count: 0 };",
+			"category": "hot-path"
+		},
+		{
+			"path": "plugins/audit.ts",
+			"line": 109,
+			"api": "readFileSync",
+			"source": "return readFileSync(path, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "plugins/host.ts",
+			"line": 326,
+			"api": "existsSync",
+			"source": "if (!this.storagePath || !existsSync(this.storagePath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "plugins/host.ts",
+			"line": 330,
+			"api": "readFileSync",
+			"source": "const parsed: unknown = JSON.parse(readFileSync(this.storagePath, \"utf-8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "plugins/host.ts",
+			"line": 353,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dirname(this.storagePath), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "plugins/host.ts",
+			"line": 354,
+			"api": "writeFileSync",
+			"source": "writeFileSync(this.storagePath, `${JSON.stringify(this.store, null, 2)}\\n`, { mode: 0o600 });",
+			"category": "hot-path"
+		},
+		{
+			"path": "plugins/index.ts",
+			"line": 14,
+			"api": "existsSync",
+			"source": "if (existsSync(statePath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "plugins/index.ts",
+			"line": 16,
+			"api": "readFileSync",
+			"source": "const parsed: unknown = JSON.parse(readFileSync(statePath, \"utf-8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "prompt-entity-context.ts",
+			"line": 668,
+			"api": "existsSync",
+			"source": "if (!existsSync(memoryDbPath)) return { lines: [], memories: [], memoryCount: 0, engine: \"no-entity\" };",
+			"category": "hot-path"
+		},
+		{
+			"path": "prompt-entity-context.ts",
+			"line": 671,
+			"api": "withReadDb",
+			"source": "const matches: PromptEntityMatch[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "prompt-entity-context.ts",
+			"line": 697,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 218,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx(fn);",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 289,
+			"api": "withWriteTx",
+			"source": "const result = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 356,
+			"api": "withWriteTx",
+			"source": "const result = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 412,
+			"api": "withReadDb",
+			"source": "const { memCount, ftsCount, ftsMissing, tokenizerDrift } = accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 665,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 707,
+			"api": "withReadDb",
+			"source": "const migration = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 711,
+			"api": "withReadDb",
+			"source": "const orphaned = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => countOrphanedEmbeddings(db, agentId));",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 744,
+			"api": "withReadDb",
+			"source": "const unembedded = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 788,
+			"api": "withWriteTx",
+			"source": "const writeOutcome = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 1041,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 1093,
+			"api": "withReadDb",
+			"source": "accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => ({",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 1164,
+			"api": "withWriteTx",
+			"source": "const writeOutcome = accessor.withWriteTx(",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 1298,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 1351,
+			"api": "withWriteTx",
+			"source": "const affected = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 1433,
+			"api": "withWriteTx",
+			"source": "const stats: VecResyncStats = accessor.withWriteTx((db): VecResyncStats => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 1546,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 1732,
+			"api": "withReadDb",
+			"source": "const hashClusters: Array<{ content_hash: string; scope_key: string; cnt: number }> = accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 1776,
+			"api": "withWriteTx",
+			"source": "const removed = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 1807,
+			"api": "withWriteTx",
+			"source": "const removed = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 1868,
+			"api": "withReadDb",
+			"source": "const candidates = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 1886,
+			"api": "withReadDb",
+			"source": "const neighbors = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 1956,
+			"api": "withReadDb",
+			"source": "const total = accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 1971,
+			"api": "withWriteTx",
+			"source": "const affected = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 2014,
+			"api": "withReadDb",
+			"source": "const candidates = accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 2056,
+			"api": "withWriteTx",
+			"source": "const affected = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 2144,
+			"api": "withReadDb",
+			"source": "accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 2192,
+			"api": "withWriteTx",
+			"source": "const affected = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 2295,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 2342,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 2588,
+			"api": "withWriteTx",
+			"source": "const result = accessor.withWriteTx<CancelResultMeta>((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "repair-actions.ts",
+			"line": 2723,
+			"api": "withWriteTx",
+			"source": "const result = accessor.withWriteTx<PruneResultMeta>((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "resource-monitor.ts",
+			"line": 228,
+			"api": "readdirSync",
+			"source": "const entries = readdirSync(fdDir);",
+			"category": "hot-path"
+		},
+		{
+			"path": "resource-monitor.ts",
+			"line": 233,
+			"api": "readlinkSync",
+			"source": "const target = readlinkSync(join(fdDir, fd));",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/app-tray.ts",
+			"line": 122,
+			"api": "writeFileSync",
+			"source": "writeFileSync(join(getMarketplaceDir(), \"app-tray.json\"), JSON.stringify([...fresh, ...toAdd], null, 2));",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/app-tray.ts",
+			"line": 227,
+			"api": "writeFileSync",
+			"source": "writeFileSync(trayPath, JSON.stringify(tray, null, 2));",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/app-tray.ts",
+			"line": 315,
+			"api": "writeFileSync",
+			"source": "writeFileSync(trayPath, JSON.stringify(tray, null, 2));",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/app-tray.ts",
+			"line": 347,
+			"api": "existsSync",
+			"source": "if (!existsSync(dir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/app-tray.ts",
+			"line": 348,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dir, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/app-tray.ts",
+			"line": 415,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/app-tray.ts",
+			"line": 417,
+			"api": "readFileSync",
+			"source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/app-tray.ts",
+			"line": 427,
+			"api": "writeFileSync",
+			"source": "writeFileSync(getInstalledMcpPath(), JSON.stringify(servers, null, 2));",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/changelog.ts",
+			"line": 192,
+			"api": "existsSync",
+			"source": "if (existsSync(localPath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/changelog.ts",
+			"line": 194,
+			"api": "readFileSync",
+			"source": "raw = readFileSync(localPath, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/connectors-routes.ts",
+			"line": 277,
+			"api": "withReadDb",
+			"source": "const docs = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/connectors-routes.ts",
+			"line": 288,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/connectors-routes.ts",
+			"line": 319,
+			"api": "withReadDb",
+			"source": "const docCount = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/connectors-routes.ts",
+			"line": 352,
+			"api": "existsSync",
+			"source": "exists: existsSync(join(homedir(), \".claude\", \"settings.json\")),",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/connectors-routes.ts",
+			"line": 358,
+			"api": "existsSync",
+			"source": "exists: existsSync(join(homedir(), \".config\", \"opencode\", \"AGENTS.md\")),",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/connectors-routes.ts",
+			"line": 364,
+			"api": "existsSync",
+			"source": "exists: existsSync(join(AGENTS_DIR, \"AGENTS.md\")),",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/connectors-routes.ts",
+			"line": 370,
+			"api": "existsSync",
+			"source": "exists: existsSync(join(homedir(), \".gemini\", \"settings.json\")),",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/connectors-routes.ts",
+			"line": 389,
+			"api": "existsSync",
+			"source": "if (!existsSync(script)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/dashboard-identity.ts",
+			"line": 31,
+			"api": "existsSync",
+			"source": "if (existsSync(agentYaml)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/dashboard-identity.ts",
+			"line": 33,
+			"api": "readFileSync",
+			"source": "const config = parseSimpleYaml(readFileSync(agentYaml, \"utf-8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/dashboard-identity.ts",
+			"line": 45,
+			"api": "existsSync",
+			"source": "if (existsSync(identityMd)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/dashboard-identity.ts",
+			"line": 47,
+			"api": "readFileSync",
+			"source": "const content = readFileSync(identityMd, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/dashboard.ts",
+			"line": 28,
+			"api": "existsSync",
+			"source": "if (existsSync(join(candidate, \"index.html\"))) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/database-diagnostics.ts",
+			"line": 241,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/database-diagnostics.ts",
+			"line": 276,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/git-config.ts",
+			"line": 77,
+			"api": "existsSync",
+			"source": "if (!existsSync(p)) continue;",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/git-config.ts",
+			"line": 79,
+			"api": "readFileSync",
+			"source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/git-sync.ts",
+			"line": 50,
+			"api": "existsSync",
+			"source": "let gitRepoProbe = (dir: string): boolean => existsSync(join(dir, \".git\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/git-sync.ts",
+			"line": 812,
+			"api": "existsSync",
+			"source": "const existingContent = existsSync(gitignorePath) ? readFileSync(gitignorePath, \"utf-8\") : \"\";",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/git-sync.ts",
+			"line": 812,
+			"api": "readFileSync",
+			"source": "const existingContent = existsSync(gitignorePath) ? readFileSync(gitignorePath, \"utf-8\") : \"\";",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/git-sync.ts",
+			"line": 815,
+			"api": "writeFileSync",
+			"source": "writeFileSync(gitignorePath, nextContent, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/git-sync.ts",
+			"line": 871,
+			"api": "existsSync",
+			"source": "if (parent !== absolute && existsSync(parent)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/git-sync.ts",
+			"line": 1019,
+			"api": "existsSync",
+			"source": "gitRepoProbe = probe ?? ((dir: string): boolean => existsSync(join(dir, \".git\")));",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/graphiq-install-path.ts",
+			"line": 8,
+			"api": "existsSync",
+			"source": "if (existsSync(bundled)) return bundled;",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/graphiq-routes.ts",
+			"line": 97,
+			"api": "existsSync",
+			"source": "if (!existsSync(resolved)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/graphiq-routes.ts",
+			"line": 102,
+			"api": "statSync",
+			"source": "projectStat = statSync(resolved);",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/graphiq-routes.ts",
+			"line": 110,
+			"api": "accessSync",
+			"source": "accessSync(resolved, constants.R_OK | constants.X_OK);",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/graphiq-routes.ts",
+			"line": 161,
+			"api": "existsSync",
+			"source": "if (!existsSync(script)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/graphiq-routes.ts",
+			"line": 182,
+			"api": "existsSync",
+			"source": "if (!existsSync(script)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/graphiq-routes.ts",
+			"line": 204,
+			"api": "accessSync",
+			"source": "accessSync(path, constants.X_OK);",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/graphiq-routes.ts",
+			"line": 228,
+			"api": "existsSync",
+			"source": "if (!existsSync(manifestPath)) continue;",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/graphiq-routes.ts",
+			"line": 230,
+			"api": "readFileSync",
+			"source": "const raw = JSON.parse(readFileSync(manifestPath, \"utf-8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/health.ts",
+			"line": 187,
+			"api": "withReadDb",
+			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/health.ts",
+			"line": 236,
+			"api": "withReadDb",
+			"source": "dbResult = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/hooks-routes.ts",
+			"line": 1148,
+			"api": "existsSync",
+			"source": "if (!existsSync(getCurrentMemoryDbPath())) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/hooks-routes.ts",
+			"line": 1163,
+			"api": "withReadDb",
+			"source": "getDbAccessor().withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/hooks-routes.ts",
+			"line": 1191,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/hooks-routes.ts",
+			"line": 1311,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/import-routes.ts",
+			"line": 212,
+			"api": "withWriteTx",
+			"source": "const extraction = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/import-routes.ts",
+			"line": 252,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/import-routes.ts",
+			"line": 337,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace-helpers.ts",
+			"line": 35,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace-helpers.ts",
+			"line": 38,
+			"api": "readFileSync",
+			"source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace-reviews.ts",
+			"line": 62,
+			"api": "existsSync",
+			"source": "if (!existsSync(dir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace-reviews.ts",
+			"line": 63,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dir, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace-reviews.ts",
+			"line": 127,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace-reviews.ts",
+			"line": 129,
+			"api": "readFileSync",
+			"source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace-reviews.ts",
+			"line": 139,
+			"api": "writeFileSync",
+			"source": "writeFileSync(getReviewsPath(), JSON.stringify(reviews, null, 2), \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace-reviews.ts",
+			"line": 144,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return DEFAULT_CONFIG;",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace-reviews.ts",
+			"line": 146,
+			"api": "readFileSync",
+			"source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace-reviews.ts",
+			"line": 162,
+			"api": "writeFileSync",
+			"source": "writeFileSync(getReviewsConfigPath(), JSON.stringify(config, null, 2), \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace.ts",
+			"line": 176,
+			"api": "existsSync",
+			"source": "if (!existsSync(dir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace.ts",
+			"line": 177,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dir, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace.ts",
+			"line": 323,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace.ts",
+			"line": 328,
+			"api": "statSync",
+			"source": "const mtime = statSync(path).mtime.toISOString();",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace.ts",
+			"line": 329,
+			"api": "readFileSync",
+			"source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace.ts",
+			"line": 338,
+			"api": "writeFileSync",
+			"source": "writeFileSync(getExposurePolicyPath(), JSON.stringify(policy, null, 2));",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace.ts",
+			"line": 807,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace.ts",
+			"line": 810,
+			"api": "readFileSync",
+			"source": "const raw = JSON.parse(readFileSync(path, \"utf-8\")) as unknown;",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace.ts",
+			"line": 822,
+			"api": "writeFileSync",
+			"source": "writeFileSync(getInstalledMcpPath(), JSON.stringify(servers, null, 2));",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/marketplace.ts",
+			"line": 1128,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/mcp-analytics.ts",
+			"line": 89,
+			"api": "withReadDb",
+			"source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/mcp-analytics.ts",
+			"line": 171,
+			"api": "withReadDb",
+			"source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/memory-routes.ts",
+			"line": 278,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dir, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/memory-routes.ts",
+			"line": 294,
+			"api": "writeFileSync",
+			"source": "writeFileSync(path, noteContent, { encoding: \"utf-8\", flag: \"wx\" });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/misc-routes.ts",
+			"line": 120,
+			"api": "readdirSync",
+			"source": "const dirFiles = readdirSync(AGENTS_DIR);",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/misc-routes.ts",
+			"line": 125,
+			"api": "statSync",
+			"source": "const fileStat = statSync(filePath);",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/misc-routes.ts",
+			"line": 127,
+			"api": "readFileSync",
+			"source": "const content = readFileSync(filePath, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/misc-routes.ts",
+			"line": 188,
+			"api": "writeFileSync",
+			"source": "writeFileSync(filePath, content, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/pipeline-routes.ts",
+			"line": 102,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/pipeline-routes.ts",
+			"line": 296,
+			"api": "existsSync",
+			"source": "if (existsSync(p)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/pipeline-routes.ts",
+			"line": 297,
+			"api": "readFileSync",
+			"source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/pipeline-routes.ts",
+			"line": 341,
+			"api": "existsSync",
+			"source": "memoryDb: existsSync(MEMORY_DB),",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/pipeline-routes.ts",
+			"line": 392,
+			"api": "readFileSync",
+			"source": "soulContent = readFileSync(soulPath, \"utf-8\").slice(0, 500);",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/pipeline-routes.ts",
+			"line": 457,
+			"api": "withReadDb",
+			"source": "const report: ReturnType<typeof listMemoryContentSafety> = getDbAccessor().withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/pipeline-routes.ts",
+			"line": 557,
+			"api": "withReadDb",
+			"source": "const dbData = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/queue-diagnostics.ts",
+			"line": 169,
+			"api": "withReadDb",
+			"source": "const response = resolveAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/reflection-routes.ts",
+			"line": 98,
+			"api": "withReadDb",
+			"source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/reflection-routes.ts",
+			"line": 118,
+			"api": "withReadDb",
+			"source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/reflection-routes.ts",
+			"line": 172,
+			"api": "withReadDb",
+			"source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/reflection-routes.ts",
+			"line": 207,
+			"api": "withReadDb",
+			"source": "const existing = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/reflection-routes.ts",
+			"line": 225,
+			"api": "withWriteTx",
+			"source": "resolveDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/repair-routes.ts",
+			"line": 313,
+			"api": "withReadDb",
+			"source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/repair-routes.ts",
+			"line": 357,
+			"api": "withWriteTx",
+			"source": "const result = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => clusterEntities(db, agentId));",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/repair-routes.ts",
+			"line": 378,
+			"api": "withReadDb",
+			"source": "const unlinked = accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/repair-routes.ts",
+			"line": 408,
+			"api": "withReadDb",
+			"source": "const preview = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/repair-routes.ts",
+			"line": 459,
+			"api": "withWriteTx",
+			"source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/repair-routes.ts",
+			"line": 469,
+			"api": "withReadDb",
+			"source": "const remaining = accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/repair-routes.ts",
+			"line": 512,
+			"api": "withReadDb",
+			"source": "const unhinted = accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/repair-routes.ts",
+			"line": 537,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/repair-routes.ts",
+			"line": 545,
+			"api": "withReadDb",
+			"source": "const remaining = accessor.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/repair-routes.ts",
+			"line": 585,
+			"api": "withReadDb",
+			"source": "const dead = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/session-routes.ts",
+			"line": 168,
+			"api": "withReadDb",
+			"source": "const hits = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/session-routes.ts",
+			"line": 347,
+			"api": "withReadDb",
+			"source": "const tableExists = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/session-routes.ts",
+			"line": 355,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skill-analytics.ts",
+			"line": 121,
+			"api": "withReadDb",
+			"source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 221,
+			"api": "existsSync",
+			"source": "if (!existsSync(getSkillsDir())) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 223,
+			"api": "readdirSync",
+			"source": "return readdirSync(getSkillsDir(), { withFileTypes: true })",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 227,
+			"api": "existsSync",
+			"source": "if (!existsSync(skillMdPath)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 229,
+			"api": "readFileSync",
+			"source": "const content = readFileSync(skillMdPath, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 364,
+			"api": "existsSync",
+			"source": "if (process.env.SIGNET_SKILLS_SOURCE && existsSync(process.env.SIGNET_SKILLS_SOURCE)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 369,
+			"api": "existsSync",
+			"source": "if (existsSync(devPath)) return devPath;",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 372,
+			"api": "existsSync",
+			"source": "if (existsSync(distPath)) return distPath;",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 374,
+			"api": "existsSync",
+			"source": "if (existsSync(distPath2)) return distPath2;",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 380,
+			"api": "existsSync",
+			"source": "if (!sourceDir || !existsSync(sourceDir)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 384,
+			"api": "readdirSync",
+			"source": "return readdirSync(sourceDir, { withFileTypes: true })",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 388,
+			"api": "existsSync",
+			"source": "if (!existsSync(skillMdPath)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 390,
+			"api": "readFileSync",
+			"source": "const content = readFileSync(skillMdPath, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 510,
+			"api": "existsSync",
+			"source": "if (!existsSync(skillMd)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 513,
+			"api": "lstatSync",
+			"source": "if (!lstatSync(skillMd).isFile()) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 521,
+			"api": "readdirSync",
+			"source": "for (const entry of readdirSync(dir, { withFileTypes: true })) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 636,
+			"api": "mkdirSync",
+			"source": "mkdirSync(target, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 641,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dirname(target), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 715,
+			"api": "rmSync",
+			"source": "rmSync(stagingDir, { recursive: true, force: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 716,
+			"api": "rmSync",
+			"source": "rmSync(backupDir, { recursive: true, force: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 718,
+			"api": "existsSync",
+			"source": "if (existsSync(targetDir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 719,
+			"api": "renameSync",
+			"source": "renameSync(targetDir, backupDir);",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 722,
+			"api": "renameSync",
+			"source": "renameSync(stagingDir, targetDir);",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 723,
+			"api": "rmSync",
+			"source": "rmSync(backupDir, { recursive: true, force: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 725,
+			"api": "rmSync",
+			"source": "rmSync(stagingDir, { recursive: true, force: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 726,
+			"api": "existsSync",
+			"source": "if (movedTarget && existsSync(backupDir) && !existsSync(targetDir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 726,
+			"api": "existsSync",
+			"source": "if (movedTarget && existsSync(backupDir) && !existsSync(targetDir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 727,
+			"api": "renameSync",
+			"source": "renameSync(backupDir, targetDir);",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 729,
+			"api": "rmSync",
+			"source": "rmSync(backupDir, { recursive: true, force: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 759,
+			"api": "mkdirSync",
+			"source": "mkdirSync(extractDir, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 770,
+			"api": "mkdirSync",
+			"source": "mkdirSync(getSkillsDir(), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 783,
+			"api": "rmSync",
+			"source": "rmSync(tempRoot, { recursive: true, force: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 1011,
+			"api": "existsSync",
+			"source": "if (existsSync(skillMdPath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 1013,
+			"api": "readFileSync",
+			"source": "const content = readFileSync(skillMdPath, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 1031,
+			"api": "existsSync",
+			"source": "if (existsSync(signetSkillPath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 1033,
+			"api": "readFileSync",
+			"source": "const content = readFileSync(signetSkillPath, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 1188,
+			"api": "existsSync",
+			"source": "if (!existsSync(skillDir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/skills.ts",
+			"line": 1195,
+			"api": "rmSync",
+			"source": "rmSync(skillDir, { recursive: true, force: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/sources-routes.ts",
+			"line": 711,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/sources-routes.ts",
+			"line": 713,
+			"api": "readFileSync",
+			"source": "const parsed = JSON.parse(readFileSync(path, \"utf8\")) as unknown;",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/sources-routes.ts",
+			"line": 723,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dirname(path), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/sources-routes.ts",
+			"line": 725,
+			"api": "writeFileSync",
+			"source": "writeFileSync(tmp, `${JSON.stringify(tombstones, null, 2)}\\n`, \"utf8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/sources-routes.ts",
+			"line": 726,
+			"api": "renameSync",
+			"source": "renameSync(tmp, path);",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/sources-routes.ts",
+			"line": 797,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/sources-routes.ts",
+			"line": 936,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/sources-routes.ts",
+			"line": 1048,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/sources-routes.ts",
+			"line": 1111,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/sources-routes.ts",
+			"line": 1150,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/state.ts",
+			"line": 157,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) continue;",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/state.ts",
+			"line": 159,
+			"api": "readFileSync",
+			"source": "return resolveNetworkBinding(readNetworkMode(parseSimpleYaml(readFileSync(path, \"utf-8\"))));",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/state.ts",
+			"line": 384,
+			"api": "existsSync",
+			"source": "if (!existsSync(candidate)) continue;",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/state.ts",
+			"line": 386,
+			"api": "readFileSync",
+			"source": "const raw = readFileSync(candidate, \"utf8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/state.ts",
+			"line": 457,
+			"api": "withReadDb",
+			"source": "const report = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/telemetry-routes.ts",
+			"line": 200,
+			"api": "withReadDb",
+			"source": "const mutationHealth = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/telemetry-routes.ts",
+			"line": 219,
+			"api": "withReadDb",
+			"source": "const scores: Array<Record<string, unknown>> = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/telemetry-routes.ts",
+			"line": 263,
+			"api": "withReadDb",
+			"source": "getDbAccessor().withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/utils.ts",
+			"line": 437,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/utils.ts",
+			"line": 525,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/widget.ts",
+			"line": 75,
+			"api": "existsSync",
+			"source": "if (existsSync(path)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "routes/widget.ts",
+			"line": 76,
+			"api": "statSync",
+			"source": "const stat = statSync(path);",
+			"category": "hot-path"
+		},
+		{
+			"path": "scheduler/skill-resolver.ts",
+			"line": 42,
+			"api": "readFileSync",
+			"source": "const raw = readFileSync(skillPath, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "scheduler/worker.ts",
+			"line": 104,
+			"api": "withWriteTx",
+			"source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "scheduler/worker.ts",
+			"line": 122,
+			"api": "withReadDb",
+			"source": "const dueTasks = db.withReadDb((rdb: import(\"../db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "scheduler/worker.ts",
+			"line": 193,
+			"api": "withWriteTx",
+			"source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "scheduler/worker.ts",
+			"line": 280,
+			"api": "withWriteTx",
+			"source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 190,
+			"api": "readFileSync",
+			"source": "const id = readFileSync(p, \"utf-8\").trim();",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 199,
+			"api": "execSync",
+			"source": "const out = execSync(\"ioreg -rd1 -c IOPlatformExpertDevice | grep IOPlatformUUID | awk '{print $3}'\", {",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 212,
+			"api": "execSync",
+			"source": "const out = execSync('reg query \"HKLM\\\\SOFTWARE\\\\Microsoft\\\\Cryptography\" /v MachineGuid', {",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 235,
+			"api": "readFileSync",
+			"source": "const persisted = readFileSync(getMachineIdFile(), \"utf-8\").trim();",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 248,
+			"api": "mkdirSync",
+			"source": "mkdirSync(getSecretsDir(), { recursive: true, mode: 0o700 });",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 250,
+			"api": "writeFileSync",
+			"source": "writeFileSync(file, `${machineId}\\n`, { encoding: \"utf-8\", mode: 0o600, flag: \"wx\" });",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 299,
+			"api": "existsSync",
+			"source": "if (!existsSync(getSecretsFile())) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 373,
+			"api": "existsSync",
+			"source": "existsSync(getMachineIdFile()) ||",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 374,
+			"api": "existsSync",
+			"source": "!existsSync(getSecretsFile())",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 430,
+			"api": "readdirSync",
+			"source": "names = readdirSync(dir);",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 438,
+			"api": "unlinkSync",
+			"source": "unlinkSync(join(dir, name));",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 448,
+			"api": "existsSync",
+			"source": "if (!existsSync(file)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 452,
+			"api": "readFileSync",
+			"source": "return parseSecretsStore(JSON.parse(readFileSync(file, \"utf-8\")));",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 471,
+			"api": "mkdirSync",
+			"source": "mkdirSync(getSecretsDir(), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 476,
+			"api": "writeFileSync",
+			"source": "writeFileSync(fd, JSON.stringify(store, null, 2), \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 482,
+			"api": "renameSync",
+			"source": "renameSync(tmp, file);",
+			"category": "hot-path"
+		},
+		{
+			"path": "secrets.ts",
+			"line": 492,
+			"api": "unlinkSync",
+			"source": "unlinkSync(tmp);",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 93,
+			"api": "existsSync",
+			"source": "if (existsSync(candidate)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 108,
+			"api": "execSync",
+			"source": "execSync(`${locator} bun`, { encoding: \"utf-8\", windowsHide: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 145,
+			"api": "mkdirSync",
+			"source": "mkdirSync(plistDir, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 146,
+			"api": "mkdirSync",
+			"source": "mkdirSync(LOG_DIR, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 150,
+			"api": "execSync",
+			"source": "execSync(`launchctl unload \"${LAUNCHD_PLIST}\" 2>/dev/null`);",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 156,
+			"api": "writeFileSync",
+			"source": "writeFileSync(LAUNCHD_PLIST, generateLaunchdPlist(port));",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 159,
+			"api": "execSync",
+			"source": "execSync(`launchctl load \"${LAUNCHD_PLIST}\"`);",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 163,
+			"api": "existsSync",
+			"source": "if (!existsSync(LAUNCHD_PLIST)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 168,
+			"api": "execSync",
+			"source": "execSync(`launchctl unload \"${LAUNCHD_PLIST}\"`);",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 173,
+			"api": "unlinkSync",
+			"source": "unlinkSync(LAUNCHD_PLIST);",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 178,
+			"api": "execSync",
+			"source": "const output = execSync(\"launchctl list ai.signet.daemon 2>/dev/null\", {",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 194,
+			"api": "existsSync",
+			"source": "if (execPath && existsSync(execPath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 199,
+			"api": "execSync",
+			"source": "return execSync(`${locator} bun`, { encoding: \"utf-8\", windowsHide: true }).trim().split(/\\r?\\n/)[0];",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 202,
+			"api": "execSync",
+			"source": "return execSync(`${locator} node`, { encoding: \"utf-8\", windowsHide: true }).trim().split(/\\r?\\n/)[0];",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 236,
+			"api": "mkdirSync",
+			"source": "mkdirSync(unitDir, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 237,
+			"api": "mkdirSync",
+			"source": "mkdirSync(LOG_DIR, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 241,
+			"api": "execSync",
+			"source": "execSync(\"systemctl --user stop signet.service 2>/dev/null\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 247,
+			"api": "writeFileSync",
+			"source": "writeFileSync(SYSTEMD_UNIT, generateSystemdUnit(port));",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 250,
+			"api": "execSync",
+			"source": "execSync(\"systemctl --user daemon-reload\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 253,
+			"api": "execSync",
+			"source": "execSync(\"systemctl --user enable signet.service\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 254,
+			"api": "execSync",
+			"source": "execSync(\"systemctl --user start signet.service\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 259,
+			"api": "execSync",
+			"source": "execSync(\"systemctl --user stop signet.service 2>/dev/null\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 260,
+			"api": "execSync",
+			"source": "execSync(\"systemctl --user disable signet.service 2>/dev/null\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 265,
+			"api": "existsSync",
+			"source": "if (existsSync(SYSTEMD_UNIT)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 266,
+			"api": "unlinkSync",
+			"source": "unlinkSync(SYSTEMD_UNIT);",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 270,
+			"api": "execSync",
+			"source": "execSync(\"systemctl --user daemon-reload\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 278,
+			"api": "execSync",
+			"source": "const output = execSync(\"systemctl --user is-active signet.service 2>/dev/null\", { encoding: \"utf-8\" });",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 290,
+			"api": "mkdirSync",
+			"source": "mkdirSync(DAEMON_DIR, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 291,
+			"api": "mkdirSync",
+			"source": "mkdirSync(LOG_DIR, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 316,
+			"api": "existsSync",
+			"source": "if (!existsSync(PID_FILE)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 320,
+			"api": "readFileSync",
+			"source": "const pid = parseInt(readFileSync(PID_FILE, \"utf-8\").trim(), 10);",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 330,
+			"api": "unlinkSync",
+			"source": "unlinkSync(PID_FILE);",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 337,
+			"api": "existsSync",
+			"source": "if (!existsSync(PID_FILE)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 341,
+			"api": "readFileSync",
+			"source": "const pid = parseInt(readFileSync(PID_FILE, \"utf-8\").trim(), 10);",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 349,
+			"api": "unlinkSync",
+			"source": "unlinkSync(PID_FILE);",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 399,
+			"api": "existsSync",
+			"source": "if (os === \"darwin\" && existsSync(LAUNCHD_PLIST)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 400,
+			"api": "execSync",
+			"source": "execSync(`launchctl load \"${LAUNCHD_PLIST}\"`);",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 401,
+			"api": "existsSync",
+			"source": "} else if (os === \"linux\" && existsSync(SYSTEMD_UNIT)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 402,
+			"api": "execSync",
+			"source": "execSync(\"systemctl --user start signet.service\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 414,
+			"api": "existsSync",
+			"source": "if (os === \"darwin\" && existsSync(LAUNCHD_PLIST)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 416,
+			"api": "execSync",
+			"source": "execSync(`launchctl unload \"${LAUNCHD_PLIST}\"`);",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 420,
+			"api": "existsSync",
+			"source": "} else if (os === \"linux\" && existsSync(SYSTEMD_UNIT)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 422,
+			"api": "execSync",
+			"source": "execSync(\"systemctl --user stop signet.service\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 446,
+			"api": "existsSync",
+			"source": "if (os === \"darwin\" && existsSync(LAUNCHD_PLIST)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 448,
+			"api": "existsSync",
+			"source": "} else if (os === \"linux\" && existsSync(SYSTEMD_UNIT)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 462,
+			"api": "existsSync",
+			"source": "return existsSync(LAUNCHD_PLIST);",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 464,
+			"api": "existsSync",
+			"source": "return existsSync(SYSTEMD_UNIT);",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 467,
+			"api": "existsSync",
+			"source": "return existsSync(PID_FILE);",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 484,
+			"api": "existsSync",
+			"source": "if (running && existsSync(PID_FILE)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 486,
+			"api": "readFileSync",
+			"source": "pid = parseInt(readFileSync(PID_FILE, \"utf-8\").trim(), 10);",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 515,
+			"api": "existsSync",
+			"source": "if (!existsSync(logFile)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 518,
+			"api": "existsSync",
+			"source": "if (existsSync(outLog)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 519,
+			"api": "readFileSync",
+			"source": "const content = readFileSync(outLog, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "service.ts",
+			"line": 525,
+			"api": "readFileSync",
+			"source": "const content = readFileSync(logFile, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-checkpoints.ts",
+			"line": 109,
+			"api": "withWriteTx",
+			"source": "db.withWriteTx((wdb: WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-checkpoints.ts",
+			"line": 226,
+			"api": "withReadDb",
+			"source": "return db.withReadDb((rdb: ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-checkpoints.ts",
+			"line": 243,
+			"api": "withReadDb",
+			"source": "return db.withReadDb((rdb: ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-checkpoints.ts",
+			"line": 259,
+			"api": "withReadDb",
+			"source": "return db.withReadDb((rdb: ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-checkpoints.ts",
+			"line": 277,
+			"api": "withReadDb",
+			"source": "return db.withReadDb((rdb: ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-checkpoints.ts",
+			"line": 301,
+			"api": "withWriteTx",
+			"source": "return db.withWriteTx((wdb: WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-claims.ts",
+			"line": 64,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-claims.ts",
+			"line": 82,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-claims.ts",
+			"line": 92,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-claims.ts",
+			"line": 119,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-claims.ts",
+			"line": 125,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb(readClaims);",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-end-recovery.ts",
+			"line": 106,
+			"api": "withWriteTx",
+			"source": "const result = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-memories.ts",
+			"line": 55,
+			"api": "existsSync",
+			"source": "if (!sessionKey || candidates.length === 0 || !existsSync(getMemoryDbPath())) return;",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-memories.ts",
+			"line": 59,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-memories.ts",
+			"line": 148,
+			"api": "existsSync",
+			"source": "if (!sessionKey || matchedIds.length === 0 || !existsSync(getMemoryDbPath())) return;",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-memories.ts",
+			"line": 153,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-memories.ts",
+			"line": 262,
+			"api": "existsSync",
+			"source": "if (!sessionKey || Object.keys(feedback).length === 0 || !existsSync(getMemoryDbPath())) return;",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-memories.ts",
+			"line": 268,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-recall-dedupe.ts",
+			"line": 149,
+			"api": "withWriteTx",
+			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-recall-dedupe.ts",
+			"line": 244,
+			"api": "withWriteTx",
+			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 103,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => tableExistsInDatabase(db, name));",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 112,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 152,
+			"api": "existsSync",
+			"source": "if (!existsSync(memoryDir)) return 0;",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 158,
+			"api": "readdirSync",
+			"source": "const files = readdirSync(memoryDir).filter((name) => name.endsWith(\"--transcript.md\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 162,
+			"api": "readFileSync",
+			"source": "const parsed = parseArtifactFrontmatter(readFileSync(path, \"utf8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 248,
+			"api": "withReadDb",
+			"source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 331,
+			"api": "readFileSync",
+			"source": "const parsed = JSON.parse(readFileSync(path, \"utf8\")) as { readonly agent_id?: unknown };",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 347,
+			"api": "existsSync",
+			"source": "if (existsSync(markerPath) && markerMatches(markerPath, agentId)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 371,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dirname(markerPath), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 372,
+			"api": "writeFileSync",
+			"source": "writeFileSync(",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 392,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 446,
+			"api": "withWriteTx",
+			"source": "return (accessor ?? getDbAccessor()).withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 561,
+			"api": "withWriteTx",
+			"source": "return (accessor ?? getDbAccessor()).withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 595,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 641,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 680,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 735,
+			"api": "withReadDb",
+			"source": "const exactRows: TranscriptRow[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 780,
+			"api": "withReadDb",
+			"source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-transcripts.ts",
+			"line": 844,
+			"api": "withReadDb",
+			"source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-ttl-finalizer.ts",
+			"line": 79,
+			"api": "withReadDb",
+			"source": "const alreadyCompleted = deps.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "session-ttl-finalizer.ts",
+			"line": 92,
+			"api": "withWriteTx",
+			"source": "deps.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "single-instance-lock.ts",
+			"line": 28,
+			"api": "readFileSync",
+			"source": "const pid = Number.parseInt(readFileSync(path, \"utf8\").trim().split(/\\s+/)[0] ?? \"\", 10);",
+			"category": "hot-path"
+		},
+		{
+			"path": "single-instance-lock.ts",
+			"line": 40,
+			"api": "statSync",
+			"source": "return Date.now() - statSync(path).mtimeMs > STALE_LOCK_AGE_MS;",
+			"category": "hot-path"
+		},
+		{
+			"path": "single-instance-lock.ts",
+			"line": 49,
+			"api": "renameSync",
+			"source": "renameSync(path, stalePath);",
+			"category": "hot-path"
+		},
+		{
+			"path": "single-instance-lock.ts",
+			"line": 55,
+			"api": "unlinkSync",
+			"source": "unlinkSync(stalePath);",
+			"category": "hot-path"
+		},
+		{
+			"path": "single-instance-lock.ts",
+			"line": 63,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dirname(path), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "single-instance-lock.ts",
+			"line": 69,
+			"api": "writeFileSync",
+			"source": "writeFileSync(fd, `${process.pid}\\n${Date.now()}\\n`);",
+			"category": "hot-path"
+		},
+		{
+			"path": "single-instance-lock.ts",
+			"line": 73,
+			"api": "unlinkSync",
+			"source": "unlinkSync(path);",
+			"category": "hot-path"
+		},
+		{
+			"path": "single-instance-lock.ts",
+			"line": 91,
+			"api": "unlinkSync",
+			"source": "unlinkSync(lock.path);",
+			"category": "hot-path"
+		},
+		{
+			"path": "skill-invocations.ts",
+			"line": 50,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "skill-transcript-scan.ts",
+			"line": 19,
+			"api": "statSync",
+			"source": "const stat = statSync(args.transcriptPath);",
+			"category": "hot-path"
+		},
+		{
+			"path": "skill-transcript-scan.ts",
+			"line": 32,
+			"api": "readFileSync",
+			"source": "content = readFileSync(args.transcriptPath, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "source-artifact-graph.ts",
+			"line": 304,
+			"api": "withWriteTx",
+			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "source-artifact-graph.ts",
+			"line": 314,
+			"api": "withWriteTx",
+			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "source-lifecycle-telemetry.ts",
+			"line": 260,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "source-lifecycle-telemetry.ts",
+			"line": 296,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "source-lifecycle-telemetry.ts",
+			"line": 327,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "source-lifecycle-telemetry.ts",
+			"line": 383,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "source-lifecycle-telemetry.ts",
+			"line": 502,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "source-lifecycle-telemetry.ts",
+			"line": 543,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "source-lifecycle-telemetry.ts",
+			"line": 576,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "source-lifecycle-telemetry.ts",
+			"line": 591,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "source-purge.ts",
+			"line": 23,
+			"api": "withWriteTx",
+			"source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "source-snapshots.ts",
+			"line": 104,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "source-snapshots.ts",
+			"line": 179,
+			"api": "withWriteTx",
+			"source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "startup-recovery.ts",
+			"line": 56,
+			"api": "withReadDb",
+			"source": "const batch = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => fetchBatch(db, limit));",
+			"category": "hot-path"
+		},
+		{
+			"path": "startup-recovery.ts",
+			"line": 59,
+			"api": "withWriteTx",
+			"source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => processBatch(db, batch));",
+			"category": "hot-path"
+		},
+		{
+			"path": "startup-recovery.ts",
+			"line": 102,
+			"api": "withWriteTx",
+			"source": "documentLeasesRecovered = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "startup-recovery.ts",
+			"line": 170,
+			"api": "withReadDb",
+			"source": "const migrationInProgress = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "startup-recovery.ts",
+			"line": 219,
+			"api": "withWriteTx",
+			"source": "orphanedPassesSwept = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "telemetry.ts",
+			"line": 492,
+			"api": "withWriteTx",
+			"source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "telemetry.ts",
+			"line": 532,
+			"api": "withWriteTx",
+			"source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "telemetry.ts",
+			"line": 797,
+			"api": "withReadDb",
+			"source": "const row = db.withReadDb(",
+			"category": "hot-path"
+		},
+		{
+			"path": "telemetry.ts",
+			"line": 879,
+			"api": "withWriteTx",
+			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "telemetry.ts",
+			"line": 926,
+			"api": "withWriteTx",
+			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "telemetry.ts",
+			"line": 982,
+			"api": "withWriteTx",
+			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "telemetry.ts",
+			"line": 1014,
+			"api": "withWriteTx",
+			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "telemetry.ts",
+			"line": 1034,
+			"api": "withWriteTx",
+			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "telemetry.ts",
+			"line": 1064,
+			"api": "withWriteTx",
+			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "telemetry.ts",
+			"line": 1085,
+			"api": "withWriteTx",
+			"source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "telemetry.ts",
+			"line": 1133,
+			"api": "withWriteTx",
+			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "telemetry.ts",
+			"line": 1155,
+			"api": "withReadDb",
+			"source": "db.withReadDb((r) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "telemetry.ts",
+			"line": 1474,
+			"api": "withWriteTx",
+			"source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "telemetry.ts",
+			"line": 1486,
+			"api": "withReadDb",
+			"source": "return db.withReadDb((r) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "temporal-expand.ts",
+			"line": 178,
+			"api": "withReadDb",
+			"source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "temporal-fallback.ts",
+			"line": 36,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => tableExistsIn(db, name));",
+			"category": "hot-path"
+		},
+		{
+			"path": "temporal-fallback.ts",
+			"line": 150,
+			"api": "withReadDb",
+			"source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "temporal-fallback.ts",
+			"line": 206,
+			"api": "withReadDb",
+			"source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "temporal-recall.ts",
+			"line": 442,
+			"api": "withReadDb",
+			"source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+			"category": "hot-path"
+		},
+		{
+			"path": "test-temp-dir.ts",
+			"line": 31,
+			"api": "rmSync",
+			"source": "rmSync(dir, { recursive: true, force: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "test-temp-dir.ts",
+			"line": 59,
+			"api": "rmSync",
+			"source": "rmSync(dir, { recursive: true, force: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-audit.ts",
+			"line": 58,
+			"api": "existsSync",
+			"source": "if (!existsSync(dir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-audit.ts",
+			"line": 59,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dir, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-audit.ts",
+			"line": 65,
+			"api": "writeFileSync",
+			"source": "writeFileSync(latestPath, content, \"utf8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-audit.ts",
+			"line": 75,
+			"api": "renameSync",
+			"source": "renameSync(latestPath, finalPath);",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-audit.ts",
+			"line": 79,
+			"api": "writeFileSync",
+			"source": "writeFileSync(finalPath, content, \"utf8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-health.ts",
+			"line": 42,
+			"api": "statSync",
+			"source": "return statSync(path).mtime.toISOString();",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-health.ts",
+			"line": 50,
+			"api": "existsSync",
+			"source": "if (!existsSync(root)) return { latestLogs: 0, finalLogs: 0, newestAuditAt: null };",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-health.ts",
+			"line": 55,
+			"api": "readdirSync",
+			"source": "for (const entry of readdirSync(dir, { withFileTypes: true })) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-health.ts",
+			"line": 74,
+			"api": "existsSync",
+			"source": "return rel ? existsSync(join(basePath, rel)) : false;",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-health.ts",
+			"line": 79,
+			"api": "readFileSync",
+			"source": "const body = readFileSync(path, \"utf8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 153,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 155,
+			"api": "readFileSync",
+			"source": "for (const line of readFileSync(path, \"utf8\").split(/\\r?\\n/)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 188,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return [];",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 189,
+			"api": "statSync",
+			"source": "const size = statSync(path).size;",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 205,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dirname(path), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 208,
+			"api": "writeFileSync",
+			"source": "writeFileSync(tmp, body.length > 0 ? `${body}\\n` : \"\", \"utf8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 209,
+			"api": "renameSync",
+			"source": "renameSync(tmp, path);",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 214,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dirname(path), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 215,
+			"api": "appendFileSync",
+			"source": "appendFileSync(",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 231,
+			"api": "readFileSync",
+			"source": "const parsed = JSON.parse(readFileSync(join(path, \"owner.json\"), \"utf8\")) as { readonly pid?: unknown };",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 240,
+			"api": "readFileSync",
+			"source": "const parsed = JSON.parse(readFileSync(join(path, \"owner.json\"), \"utf8\")) as { readonly token?: unknown };",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 260,
+			"api": "statSync",
+			"source": "return now - statSync(path).mtimeMs > LOCK_DEAD_OWNER_STALE_MS;",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 271,
+			"api": "mkdirSync",
+			"source": "mkdirSync(lockPath);",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 272,
+			"api": "writeFileSync",
+			"source": "writeFileSync(",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 285,
+			"api": "rmSync",
+			"source": "rmSync(lockPath, { recursive: true, force: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 295,
+			"api": "readFileSync",
+			"source": "const parsed = JSON.parse(readFileSync(join(lockPath, \"owner.json\"), \"utf8\")) as { readonly token?: unknown };",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 300,
+			"api": "rmSync",
+			"source": "rmSync(lockPath, { recursive: true, force: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 304,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dirname(path), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 372,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return { canonicalKeys, liveOnlyKeys };",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 405,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return false;",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 445,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 446,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dirname(path), { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 448,
+			"api": "writeFileSync",
+			"source": "writeFileSync(path, `${body}\\n`, \"utf8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 493,
+			"api": "renameSync",
+			"source": "renameSync(tmpPath, path);",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 501,
+			"api": "rmSync",
+			"source": "rmSync(tmpPath, { force: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 561,
+			"api": "existsSync",
+			"source": "if (replacements.size === 0 || !existsSync(jsonlPath)) return Promise.resolve(0);",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 648,
+			"api": "renameSync",
+			"source": "renameSync(tmpPath, jsonlPath);",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-jsonl.ts",
+			"line": 661,
+			"api": "rmSync",
+			"source": "rmSync(tmpPath, { force: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-recovery-worker.ts",
+			"line": 266,
+			"api": "withReadDb",
+			"source": "if (dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => unchanged(db, agentId, candidate))) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-recovery-worker.ts",
+			"line": 295,
+			"api": "withWriteTx",
+			"source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-recovery-worker.ts",
+			"line": 304,
+			"api": "withReadDb",
+			"source": "const alreadyCaptured = dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-recovery-worker.ts",
+			"line": 309,
+			"api": "withWriteTx",
+			"source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-recovery-worker.ts",
+			"line": 329,
+			"api": "withWriteTx",
+			"source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "transcript-recovery-worker.ts",
+			"line": 375,
+			"api": "withWriteTx",
+			"source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+			"category": "hot-path"
+		},
+		{
+			"path": "update-system.ts",
+			"line": 321,
+			"api": "existsSync",
+			"source": "if (!existsSync(p)) continue;",
+			"category": "hot-path"
+		},
+		{
+			"path": "update-system.ts",
+			"line": 323,
+			"api": "readFileSync",
+			"source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\"));",
+			"category": "hot-path"
+		},
+		{
+			"path": "update-system.ts",
+			"line": 367,
+			"api": "existsSync",
+			"source": "if (!existsSync(p)) continue;",
+			"category": "hot-path"
+		},
+		{
+			"path": "update-system.ts",
+			"line": 370,
+			"api": "readFileSync",
+			"source": "const current = readFileSync(p, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "update-system.ts",
+			"line": 382,
+			"api": "writeFileSync",
+			"source": "writeFileSync(p, updated);",
+			"category": "hot-path"
+		},
+		{
+			"path": "update-system.ts",
+			"line": 609,
+			"api": "existsSync",
+			"source": "existsSync: (path) => existsSync(path),",
+			"category": "hot-path"
+		},
+		{
+			"path": "update-system.ts",
+			"line": 610,
+			"api": "readFileSync",
+			"source": "readFileSync: (path, encoding) => readFileSync(path, { encoding }),",
+			"category": "hot-path"
+		},
+		{
+			"path": "update-system.ts",
+			"line": 615,
+			"api": "existsSync",
+			"source": "const launcherExists = deps.existsSync(launcherPath);",
+			"category": "hot-path"
+		},
+		{
+			"path": "update-system.ts",
+			"line": 616,
+			"api": "existsSync",
+			"source": "const appImageExists = deps.existsSync(appImagePath);",
+			"category": "hot-path"
+		},
+		{
+			"path": "update-system.ts",
+			"line": 639,
+			"api": "readFileSync",
+			"source": "const launcher = deps.readFileSync(launcherPath, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "update-system.ts",
+			"line": 670,
+			"api": "existsSync",
+			"source": "existsSync: deps.existsSync ?? ((path: string) => existsSync(path)),",
+			"category": "hot-path"
+		},
+		{
+			"path": "update-system.ts",
+			"line": 671,
+			"api": "readFileSync",
+			"source": "readFileSync: deps.readFileSync ?? ((path: string, encoding: BufferEncoding) => readFileSync(path, { encoding })),",
+			"category": "hot-path"
+		},
+		{
+			"path": "update-system.ts",
+			"line": 694,
+			"api": "existsSync",
+			"source": "if (!fsDeps.existsSync(deps.signetCliPath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "update-system.ts",
+			"line": 716,
+			"api": "existsSync",
+			"source": "if (!fsDeps.existsSync(signetBin)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "watcher-ignore.ts",
+			"line": 140,
+			"api": "existsSync",
+			"source": "if (!existsSync(sigignorePath)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "watcher-ignore.ts",
+			"line": 141,
+			"api": "writeFileSync",
+			"source": "writeFileSync(sigignorePath, DEFAULT_SIGNIGNORE_CONTENT, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "watcher-ignore.ts",
+			"line": 155,
+			"api": "statSync",
+			"source": "const stat = statSync(sigignorePath);",
+			"category": "hot-path"
+		},
+		{
+			"path": "watcher-ignore.ts",
+			"line": 158,
+			"api": "readFileSync",
+			"source": "cache = { stamp, patterns: parseSigignore(readFileSync(sigignorePath, \"utf-8\")) };",
+			"category": "hot-path"
+		},
+		{
+			"path": "which.ts",
+			"line": 8,
+			"api": "accessSync",
+			"source": "accessSync(file, constants.X_OK);",
+			"category": "hot-path"
+		},
+		{
+			"path": "which.ts",
+			"line": 9,
+			"api": "statSync",
+			"source": "return statSync(file).isFile();",
+			"category": "hot-path"
+		},
+		{
+			"path": "widget-gen.ts",
+			"line": 36,
+			"api": "existsSync",
+			"source": "if (!existsSync(dir)) {",
+			"category": "hot-path"
+		},
+		{
+			"path": "widget-gen.ts",
+			"line": 37,
+			"api": "mkdirSync",
+			"source": "mkdirSync(dir, { recursive: true });",
+			"category": "hot-path"
+		},
+		{
+			"path": "widget-gen.ts",
+			"line": 229,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return null;",
+			"category": "hot-path"
+		},
+		{
+			"path": "widget-gen.ts",
+			"line": 232,
+			"api": "readFileSync",
+			"source": "const content = readFileSync(path, \"utf-8\");",
+			"category": "hot-path"
+		},
+		{
+			"path": "widget-gen.ts",
+			"line": 241,
+			"api": "existsSync",
+			"source": "if (!existsSync(path)) return false;",
+			"category": "hot-path"
+		},
+		{
+			"path": "widget-gen.ts",
+			"line": 244,
+			"api": "unlinkSync",
+			"source": "unlinkSync(path);",
+			"category": "hot-path"
+		},
+		{
+			"path": "widget-gen.ts",
+			"line": 308,
+			"api": "writeFileSync",
+			"source": "writeFileSync(widgetPath(serverId), html);",
+			"category": "hot-path"
+		},
+		{
+			"path": "yielding-writes.ts",
+			"line": 86,
+			"api": "withWriteTx",
+			"source": "return accessor.withWriteTx(processBatch);",
+			"category": "hot-path"
+		},
+		{
+			"path": "yielding-writes.ts",
+			"line": 123,
+			"api": "withReadDb",
+			"source": "const batch = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => fetchBatch(db, limit));",
+			"category": "hot-path"
+		}
+	]
 }


### PR DESCRIPTION
## Summary

Convert the A3 recall and ontology route call chain to async database primitives. Promise propagation now reaches route, hook, maintenance, native-memory, transcript, and dreaming callers without changing ranking, scope filters, transaction boundaries, caps, provenance, or error handling contracts.

## Changes

- Converted the six core recall files from synchronous `withReadDb` and `withWriteTx` calls to async database primitives.
- Propagated async return types through knowledge routes, graph helpers, lineage, ontology routes, hooks, maintenance, native-memory, transcript, and dreaming callers.
- Preserved bounded async writes and existing batch/yield behavior.
- Updated focused regression test doubles and callers for Promise-returning APIs.
- Added the required AI disclosure tags to both commits.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A. No migrations touched.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused proof:

- `bun run --filter '@signet/daemon' build` passed, including daemon `tsc --noEmit` and dashboard build.
- `bun run --filter '@signet/daemon' typecheck` passed.
- Focused recall/ontology/native suites passed: 173 tests, 0 failures across the core async regression set.
- `bunx biome check` passed with two pre-existing warnings and no errors.
- `bun run typecheck` remains blocked by unrelated connector package build artifacts and pre-existing daemon migration callers outside this slice. The daemon package typecheck is green.
- `maintenance-worker.test.ts` still has five pre-existing fixture failures because its extract-job fixtures are excluded by the unchanged diagnostics query. The async path itself is exercised by the remaining passing tests.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This is a new PR from `signetai/a3-slice1-recall-v2`. The branch is based on current `origin/main`. Security and agent-scope behavior were preserved and checked on all changed data paths. No user-facing API/spec/status behavior changed, so no documentation source changes were required. Please review before merge. CI status is reported separately after PR creation.
