### PR TITLE
feat(memorybench): add dreaming parity profile

### DIFF
--- a/scripts/bench-memory.test.ts
+++ b/scripts/bench-memory.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_DREAMING, DEFAULT_PIPELINE_V2, loadMemoryConfig } from "../platform/daemon/src/memory-config";
+import { writeIsolatedWorkspace } from "./bench-memory";
+
+const workspaces: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(workspaces.splice(0).map((workspace) => rm(workspace, { recursive: true, force: true })));
+});
+
+describe("MemoryBench dreaming profiles", () => {
+	test("dreaming-parity writes production dreaming and pipeline defaults", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "signet-memorybench-profile-"));
+		workspaces.push(workspace);
+
+		writeIsolatedWorkspace(workspace, "dreaming-parity", "on", "fixture-model", "http://127.0.0.1:8000/v1");
+
+		const config = loadMemoryConfig(workspace);
+		const yaml = await readFile(join(workspace, "agent.yaml"), "utf8");
+
+		expect(config.dreaming.tokenThreshold).toBe(DEFAULT_DREAMING.tokenThreshold);
+		expect(config.dreaming.maxInputTokens).toBe(DEFAULT_DREAMING.maxInputTokens);
+		expect(config.dreaming.maxOutputTokens).toBe(DEFAULT_DREAMING.maxOutputTokens);
+		expect(config.pipelineV2.enabled).toBe(DEFAULT_PIPELINE_V2.enabled);
+		expect(config.pipelineV2.graph.enabled).toBe(DEFAULT_PIPELINE_V2.graph.enabled);
+		expect(config.pipelineV2.traversal.enabled).toBe(DEFAULT_PIPELINE_V2.traversal.enabled);
+		expect(yaml).toContain("tokenThreshold: 100000");
+		expect(yaml).toContain("maxInputTokens: 128000");
+		expect(yaml).toContain("maxOutputTokens: 16000");
+		expect(yaml).toContain("  pipelineV2:\n    enabled: true");
+	});
+
+	test("the default dreaming profile retains the faster bench configuration", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "signet-memorybench-profile-"));
+		workspaces.push(workspace);
+
+		writeIsolatedWorkspace(workspace, "dreaming", "on", "fixture-model", "http://127.0.0.1:8000/v1");
+
+		const config = loadMemoryConfig(workspace);
+
+		expect(config.dreaming.tokenThreshold).toBe(1_000_000);
+		expect(config.dreaming.maxInputTokens).toBe(64_000);
+		expect(config.dreaming.maxOutputTokens).toBe(32_000);
+		expect(config.pipelineV2.enabled).toBe(false);
+	});
+});

--- a/scripts/bench-memory.ts
+++ b/scripts/bench-memory.ts
@@ -23,6 +23,12 @@ const memorybenchCommands = new Set([
 	"help",
 ]);
 
+export type BenchProfile = "rules" | "dreaming" | "dreaming-parity" | "supermemory-parity";
+
+function isBenchProfile(value: string | undefined): value is BenchProfile {
+	return value === "rules" || value === "dreaming" || value === "dreaming-parity" || value === "supermemory-parity";
+}
+
 interface ParsedArgs {
 	passthrough: string[];
 	build: boolean;
@@ -32,7 +38,7 @@ interface ParsedArgs {
 	keepWorkspace: boolean;
 	graph: "on" | "off";
 	port?: number;
-	profile: "rules" | "dreaming" | "supermemory-parity";
+	profile: BenchProfile;
 	reset: boolean;
 	workspace?: string;
 }
@@ -46,12 +52,14 @@ function parseArgs(raw: string[]): ParsedArgs {
 	let keepWorkspace = process.env.SIGNET_BENCH_KEEP_WORKSPACE === "1";
 	let graph: "on" | "off" = process.env.SIGNET_BENCH_GRAPH === "off" ? "off" : "on";
 	let port: number | undefined;
-	let profile: "rules" | "dreaming" | "supermemory-parity" =
+	let profile: BenchProfile =
 		process.env.SIGNET_BENCH_PROFILE === "supermemory-parity"
 			? "supermemory-parity"
-			: process.env.SIGNET_BENCH_PROFILE === "dreaming"
-				? "dreaming"
-				: "rules";
+			: process.env.SIGNET_BENCH_PROFILE === "dreaming-parity"
+				? "dreaming-parity"
+				: process.env.SIGNET_BENCH_PROFILE === "dreaming"
+					? "dreaming"
+					: "rules";
 	let reset = process.env.SIGNET_BENCH_RESUME !== "1";
 	let workspace: string | undefined;
 
@@ -85,8 +93,8 @@ function parseArgs(raw: string[]): ParsedArgs {
 			port = parsed;
 		} else if (arg === "--profile") {
 			const next = raw[++i];
-			if (next !== "rules" && next !== "dreaming" && next !== "supermemory-parity") {
-				throw new Error("--profile must be rules, dreaming, or supermemory-parity");
+			if (!isBenchProfile(next)) {
+				throw new Error("--profile must be rules, dreaming, dreaming-parity, or supermemory-parity");
 			}
 			profile = next;
 		} else if (arg === "--reset") {
@@ -220,9 +228,9 @@ function readPositiveIntEnv(name: string, fallback: number): number {
 	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-function writeIsolatedWorkspace(
+export function writeIsolatedWorkspace(
 	dir: string,
-	profile: ParsedArgs["profile"],
+	profile: BenchProfile,
 	graph: ParsedArgs["graph"],
 	dreamingModel?: string,
 	dreamingEndpoint?: string,
@@ -240,17 +248,22 @@ function writeIsolatedWorkspace(
 	writeFileSync(join(dir, "MEMORY.md"), "# MemoryBench Working Memory\n\nNo production memory is mounted here.\n");
 
 	const embeddingProvider = process.env.SIGNET_BENCH_EMBEDDING_PROVIDER || "native";
-	const dreamingConfig =
-		profile === "dreaming"
-			? dreamingEndpoint
-				? dreamingCredentialRef
-					? `
+	const isDreamingProfile = profile === "dreaming" || profile === "dreaming-parity";
+	const isDreamingParity = profile === "dreaming-parity";
+	const dreamingTokenThreshold = isDreamingParity ? 100000 : 1000000;
+	const dreamingMaxInputTokens = isDreamingParity ? 128000 : 64000;
+	const dreamingOutputTokens = isDreamingParity ? 16000 : dreamingMaxOutputTokens;
+	const dreamingTimeout = isDreamingParity ? 1200000 : dreamingTimeoutMs;
+	const dreamingConfig = isDreamingProfile
+		? dreamingEndpoint
+			? dreamingCredentialRef
+				? `
   dreaming:
     enabled: true
-    tokenThreshold: 1000000
-    maxInputTokens: 64000
-    maxOutputTokens: ${dreamingMaxOutputTokens}
-    timeout: ${dreamingTimeoutMs}
+    tokenThreshold: ${dreamingTokenThreshold}
+    maxInputTokens: ${dreamingMaxInputTokens}
+    maxOutputTokens: ${dreamingOutputTokens}
+    timeout: ${dreamingTimeout}
 
 inference:
   defaultPolicy: memorybench-dreaming
@@ -279,13 +292,13 @@ inference:
     memoryExtraction:
       policy: memorybench-dreaming
 `
-					: `
+				: `
   dreaming:
     enabled: true
-    tokenThreshold: 1000000
-    maxInputTokens: 64000
-    maxOutputTokens: ${dreamingMaxOutputTokens}
-    timeout: ${dreamingTimeoutMs}
+    tokenThreshold: ${dreamingTokenThreshold}
+    maxInputTokens: ${dreamingMaxInputTokens}
+    maxOutputTokens: ${dreamingOutputTokens}
+    timeout: ${dreamingTimeout}
 
 inference:
   defaultPolicy: memorybench-dreaming
@@ -307,13 +320,13 @@ inference:
     memoryExtraction:
       policy: memorybench-dreaming
 `
-				: `
+			: `
   dreaming:
     enabled: true
-    tokenThreshold: 1000000
-    maxInputTokens: 64000
-    maxOutputTokens: ${dreamingMaxOutputTokens}
-    timeout: ${dreamingTimeoutMs}
+    tokenThreshold: ${dreamingTokenThreshold}
+    maxInputTokens: ${dreamingMaxInputTokens}
+    maxOutputTokens: ${dreamingOutputTokens}
+    timeout: ${dreamingTimeout}
 
 inference:
   defaultPolicy: memorybench-dreaming
@@ -340,10 +353,44 @@ inference:
     memoryExtraction:
       policy: memorybench-dreaming
 `
-			: "";
+		: "";
+	const pipelineConfig = isDreamingParity
+		? `  pipelineV2:
+    enabled: true
+    graph:
+      enabled: ${graph === "on"}
+    traversal:
+      enabled: ${graph === "on"}
+`
+		: `  pipelineV2:
+    enabled: false
+    graph:
+      enabled: ${graph === "on"}
+      extractionWritesEnabled: false
+    traversal:
+      enabled: ${graph === "on"}
+    structural:
+      enabled: false
+      synthesisEnabled: false
+      supersessionSweepEnabled: false
+    reranker:
+      enabled: false
+    autonomous:
+      enabled: false
+    procedural:
+      enabled: false
+    predictor:
+      enabled: false
+    hints:
+      enabled: true
+    guardrails:
+      maxContentChars: 100000
+      chunkTargetChars: 50000
+      recallTruncateChars: 20000
+`;
 	writeFileSync(
 		join(dir, "agent.yaml"),
-		`configVersion: 2\n\nagent:\n  name: memorybench\n\nauth:\n  mode: local\n\nembedding:\n  provider: ${embeddingProvider}\n  model: ${process.env.SIGNET_BENCH_EMBEDDING_MODEL || "nomic-embed-text-v1.5"}\n  dimensions: ${process.env.SIGNET_BENCH_EMBEDDING_DIMENSIONS || "768"}\n\nsearch:\n  alpha: 0.7\n  top_k: 20\n  min_score: 0.1\n  rehearsal_enabled: false\n\nmemory:\n  pipelineV2:\n    enabled: false\n    graph:\n      enabled: ${graph === "on"}\n      extractionWritesEnabled: false\n    traversal:\n      enabled: ${graph === "on"}\n    structural:\n      enabled: false\n      synthesisEnabled: false\n      supersessionSweepEnabled: false\n    reranker:\n      enabled: false\n    autonomous:\n      enabled: false\n    synthesis:\n      enabled: false\n    procedural:\n      enabled: false\n    predictor:\n      enabled: false\n    hints:\n      enabled: true\n    guardrails:\n      maxContentChars: 100000\n      chunkTargetChars: 50000\n      recallTruncateChars: 20000\n${dreamingConfig}`,
+		`configVersion: 2\n\nagent:\n  name: memorybench\n\nauth:\n  mode: local\n\nembedding:\n  provider: ${embeddingProvider}\n  model: ${process.env.SIGNET_BENCH_EMBEDDING_MODEL || "nomic-embed-text-v1.5"}\n  dimensions: ${process.env.SIGNET_BENCH_EMBEDDING_DIMENSIONS || "768"}\n\nsearch:\n  alpha: 0.7\n  top_k: 20\n  min_score: 0.1\n  rehearsal_enabled: false\n\nmemory:\n${pipelineConfig}${dreamingConfig}`,
 	);
 }
 
@@ -391,7 +438,7 @@ function buildMemoryBenchArgs(
 	const provider =
 		profile === "supermemory-parity"
 			? "signet-supermemory-parity"
-			: profile === "dreaming"
+			: profile === "dreaming" || profile === "dreaming-parity"
 				? "signet-dreaming"
 				: "signet";
 	const continuation = isContinuationCommand(command, args);
@@ -448,14 +495,15 @@ async function main(): Promise<void> {
 	const dreamingCredentialRef = process.env.SIGNET_BENCH_DREAMING_CREDENTIAL_REF?.trim();
 	const dreamingProviderFamily = process.env.SIGNET_BENCH_DREAMING_PROVIDER_FAMILY?.trim() || "openai-compatible";
 	const dreamingApiKey = process.env.SIGNET_BENCH_DREAMING_API_KEY?.trim();
-	if (parsed.profile === "dreaming" && !dreamingModel) {
+	const isDreamingProfile = parsed.profile === "dreaming" || parsed.profile === "dreaming-parity";
+	if (isDreamingProfile && !dreamingModel) {
 		throw new Error("Dreaming benchmark requires SIGNET_BENCH_DREAMING_MODEL (an OpenRouter model id)");
 	}
-	if (parsed.profile === "dreaming" && !dreamingEndpoint && !process.env.OPENROUTER_API_KEY?.trim()) {
+	if (isDreamingProfile && !dreamingEndpoint && !process.env.OPENROUTER_API_KEY?.trim()) {
 		throw new Error("Dreaming benchmark requires SIGNET_BENCH_DREAMING_ENDPOINT or OPENROUTER_API_KEY");
 	}
 	if (
-		parsed.profile === "dreaming" &&
+		isDreamingProfile &&
 		dreamingEndpoint &&
 		!isLocalEndpoint(dreamingEndpoint) &&
 		!dreamingApiKey &&
@@ -473,8 +521,11 @@ async function main(): Promise<void> {
 		dreamingEndpoint,
 		dreamingCredentialRef || (dreamingApiKey ? "SIGNET_BENCH_DREAMING_API_KEY" : undefined),
 		dreamingProviderFamily,
-		readPositiveIntEnv("SIGNET_BENCH_DREAMING_TIMEOUT_MS", 600_000),
-		readPositiveIntEnv("SIGNET_BENCH_DREAMING_MAX_OUTPUT_TOKENS", 32_000),
+		readPositiveIntEnv("SIGNET_BENCH_DREAMING_TIMEOUT_MS", parsed.profile === "dreaming-parity" ? 1_200_000 : 600_000),
+		readPositiveIntEnv(
+			"SIGNET_BENCH_DREAMING_MAX_OUTPUT_TOKENS",
+			parsed.profile === "dreaming-parity" ? 16_000 : 32_000,
+		),
 	);
 
 	const usesDefaultSample = defaultedDevSample(parsed.passthrough, parsed.full);
@@ -554,7 +605,9 @@ async function main(): Promise<void> {
 	}
 }
 
-main().catch((error) => {
-	console.error(error instanceof Error ? error.message : String(error));
-	process.exit(1);
-});
+if (import.meta.main) {
+	main().catch((error) => {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	});
+}

--- a/web/docs/src/content/docs/benchmarking.md
+++ b/web/docs/src/content/docs/benchmarking.md
@@ -207,11 +207,12 @@ has ingested data that should be preserved.
 
 ## Benchmark profiles
 
-The wrapper supports two explicit Signet profiles:
+The wrapper supports explicit Signet profiles:
 
 ```bash
 bun run bench -- --profile rules
 bun run bench -- --profile supermemory-parity
+bun run bench -- --profile dreaming-parity
 ```
 
 `rules` is the default. It uses the `signet` provider and follows the common
@@ -246,6 +247,39 @@ Keep results from these profiles separate. A `supermemory-parity` result answers
 "how does Signet perform when given Supermemory's adapter advantage?" A `rules`
 result answers "how does Signet perform under the harness contract we intend to
 publish?"
+
+### Dreaming parity profile
+
+`dreaming-parity` is an opt-in, higher-cost profile for measuring the canonical
+Dreaming pass with the production default configuration. It uses the same
+`signet-dreaming` provider as `dreaming`, but writes these production-equivalent
+values into the isolated workspace:
+
+| Setting | Default `dreaming` profile | `dreaming-parity` |
+| --- | ---: | ---: |
+| `memory.dreaming.tokenThreshold` | `1000000` | `100000` |
+| `memory.dreaming.maxInputTokens` | `64000` | `128000` |
+| `memory.dreaming.maxOutputTokens` | `32000` | `16000` |
+| `memory.pipelineV2.enabled` | `false` | `true` |
+| Graph and traversal defaults | reduced | production defaults |
+
+The parity profile still uses one explicit `mode: incremental` trigger after
+the fixture is ingested. This is deliberate: the benchmark needs a bounded,
+reproducible pass. Production runs reach the same pass through the periodic
+five-minute worker and `selectDreamingCheckMode`, so scheduler firing,
+alternating focus selection, and queue-pressure deferral remain a known delta
+outside this profile. The pass itself remains canonical:
+`triggerAsync` → `runPass` → `runDreamingAgentPass`.
+
+Because the profile raises the input budget and enables the production pipeline,
+it can consume more inference time and tokens. Keep `dreaming` as the default
+for fast local iteration, and label parity results separately from the cheaper
+bench profile. The profile requires the same explicit Dreaming model and
+endpoint configuration as `dreaming`. This profile addresses the bench realism
+concern in [#1543](https://github.com/Signet-AI/signetai/issues/1543) and is
+compatible with the deterministic Dreaming gate tracked in
+[#1326](https://github.com/Signet-AI/signetai/issues/1326) and
+[#1558](https://github.com/Signet-AI/signetai/issues/1558).
 
 ## Supermemory adapter contract violation
 


### PR DESCRIPTION
## Summary

Adds an opt-in `dreaming-parity` MemoryBench profile that writes the production Dreaming and pipeline defaults into the isolated benchmark workspace. The existing `dreaming` profile remains the faster default for local iteration.

## Changes

- Add `--profile dreaming-parity` and `SIGNET_BENCH_PROFILE=dreaming-parity`.
- Match production Dreaming values: token threshold `100000`, max input `128000`, and max output `16000`.
- Enable production `memory.pipelineV2` defaults for parity runs while preserving the reduced non-parity configuration.
- Remove the retired `memory.pipelineV2.synthesis` key from the reduced benchmark config so the default Dreaming profile remains compatible with current daemon config loading.
- Add regression coverage for both parity and default Dreaming profiles.
- Document the intentional trigger delta and cross-link issues #1543, #1326, and #1558.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: MemoryBench wrapper and benchmark documentation

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [ ] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations touched.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Targeted proof:

- `bun test memorybench/src/providers/signet/index.test.ts memorybench/src/benchmarks/dreaming-scenarios/index.test.ts scripts/bench-memory.test.ts`: 15 passed, 0 failed, 54 expect calls.
- `bun run --filter '@signet/core' build` and `bun run --filter '@signet/daemon' build`: passed.
- Targeted TypeScript compilation, touched-file Biome error-level check, and `git diff --check`: passed.
- Both profiles were run against the committed `dreaming-scenarios` fixed fixture through the real isolated daemon path. The default profile showed the benchmark threshold `1000000`; the parity profile showed `100000` and started the production pipeline. Both runs reached the canonical Dreaming trigger but stopped before scoring because the configured OpenRouter account returned `401 User not found`. No score delta is claimed because the provider failed before results were produced.
- The documented trigger delta is intentional: the benchmark uses one bounded explicit incremental trigger, while production reaches the same canonical pass through the periodic five-minute worker and `selectDreamingCheckMode`.
- Full repository typecheck remains blocked by unrelated pre-existing connector errors (`@signet/connector-pi`, `@signet/connector-oh-my-pi`, `@signet/connector-openclaw`, `@signet/connector-gemini`, `@signet/connector-forge`, `@signet/connector-opencode`, and `@signet/connector-codex`). `bun run lint` exits 0 but reports pre-existing repository warnings; the touched files pass the targeted error-level check. The unchecked aggregate gate is covered by the `checklist-exception` label rather than claiming a false full-suite pass.
- Spec alignment was reviewed against `docs/specs/INDEX.md` and `docs/specs/dependencies.yaml`; the change is an opt-in benchmark profile exercising the documented Memory Pipeline v2 and Dreaming consolidation path.
- No new or changed data queries were introduced. The benchmark workspace and fixture agent scopes remain isolated, covered by the passing scope tests above.
- No admin or mutation endpoints were changed. The security checklist item is N/A and covered by the `checklist-exception` label.
- The PR branch was rebased from `734cc2d5bfb71baf2b6f547051fbadb98d5db4e5` onto current `origin/main` (`13a07317a`), producing final head `f02be0709` before push. The three implementation files are byte-identical to the original PR commit; the pre-existing `integrations/codex/connector/src/index.ts:493` Biome baseline is outside this diff and was not changed.
- Readiness workflow re-triggered after applying the `checklist-exception` label.
