### PR TITLE
fix(daemon): resolve active embedding profile before backfill writes

### DIFF
--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -986,6 +986,57 @@ describe("reembedMissingMemories", () => {
 		expect(db.prepare("SELECT id FROM embeddings WHERE source_id = ?").get("mem-write-failure")).toBeTruthy();
 	});
 
+	it("resolves the active profile before writing, instead of comparing the raw configured fingerprint", async () => {
+		// Regression: a prior --model-mismatch migration promotes the durable
+		// active generation with a *named* profile (e.g. "nomic-embed-text-v1.5"),
+		// persisted in embedding_index_state.active_profile_json. The route's
+		// raw `embeddingCfg` (loaded straight from agent.yaml) carries no
+		// `profile` field. Before the fix, isActiveEmbeddingConfig compared the
+		// raw config's identity fingerprint against that named-profile
+		// fingerprint on every batch — a permanent mismatch, not a race — so
+		// `signet embed backfill` failed 100% of the time with "embedding
+		// profile changed during provider work", even though nothing changed
+		// concurrently.
+		insertMemory(db, "mem-named-profile");
+		const rawCfg: EmbeddingConfig = { ...TEST_EMBEDDING_CFG, model: "nomic-embed-text:v1.5" };
+		accessor.withWriteTx((writeDb) => {
+			ensureEmbeddingIndexState(writeDb, rawCfg);
+			const namedProfile = {
+				fingerprint: embeddingProfileFingerprint({ ...rawCfg, profile: "nomic-embed-text-v1.5" }),
+				provider: rawCfg.provider,
+				model: rawCfg.model,
+				dimensions: rawCfg.dimensions,
+				baseUrl: rawCfg.base_url,
+				profile: "nomic-embed-text-v1.5",
+			};
+			writeDb
+				.prepare("UPDATE embedding_index_state SET active_profile_json = ? WHERE id = 1")
+				.run(JSON.stringify(namedProfile));
+		});
+
+		const seenCfgs: EmbeddingConfig[] = [];
+		const result = await reembedMissingMemories(
+			accessor,
+			TEST_CFG,
+			CTX_OPERATOR,
+			createRateLimiter(),
+			async (_content, cfg) => {
+				seenCfgs.push(cfg);
+				return [0.1, 0.2, 0.3];
+			},
+			rawCfg,
+			10,
+			false,
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.affected).toBe(1);
+		expect(db.prepare("SELECT id FROM embeddings WHERE source_id = 'mem-named-profile'").get()).toBeTruthy();
+		// The embedding call must use the resolved (named) profile, not the raw
+		// identity config, so its formatting matches the rest of the active index.
+		expect(seenCfgs[0]?.profile).toBe("nomic-embed-text-v1.5");
+	});
+
 	it("reconciles canonical embedding state after a mid-write vector-index failure", async () => {
 		// Proof for #1325: the canonical embedding write and the derived vec
 		// index update are separate failure boundaries. If vec insertion fails

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -34,7 +34,11 @@ import {
 	listUnembeddedMemories,
 } from "./embedding-coverage";
 import { type EmbeddingMigrationCoverage, stagingCoverage } from "./embedding-index-migration";
-import { isActiveEmbeddingConfig, readEmbeddingIndexState } from "./embedding-index-state";
+import {
+	isActiveEmbeddingConfig,
+	readEmbeddingIndexState,
+	resolveActiveEmbeddingConfig,
+} from "./embedding-index-state";
 import { type EmbeddingRepairState, readEmbeddingRepairState } from "./embedding-repair-state";
 import { classifyEntityQuality } from "./entity-quality";
 import { logger } from "./logger";
@@ -928,6 +932,20 @@ export async function reembedMissingMemories(
 	const normalizedBatchSize =
 		Number.isFinite(batchSize) && batchSize > 0 ? Math.max(1, Math.floor(batchSize)) : DEFAULT_REEMBED_BATCH;
 
+	// `embeddingCfg` is the raw configured value (e.g. from agent.yaml), which
+	// carries no `profile`. The durable active generation may have been
+	// promoted with a named profile (e.g. by a prior --model-mismatch
+	// migration), so its persisted fingerprint includes that profile id.
+	// Comparing the raw config's identity fingerprint against that persisted
+	// fingerprint in isActiveEmbeddingConfig always mismatches — not a race,
+	// a permanent false positive that fails every batch with "embedding
+	// profile changed during provider work" (issue: reembed never resolves
+	// the active profile before writing). Resolve once, matching the same
+	// profile the durable index actually owns, before doing any work.
+	const resolvedEmbeddingCfg = await accessor.withReadDbAsync(async (db) =>
+		resolveActiveEmbeddingConfig(db, embeddingCfg),
+	);
+
 	const initialStats = await getEmbeddingGapStats(accessor, agentId);
 	if (initialStats.unembedded === 0) {
 		return {
@@ -969,7 +987,7 @@ export async function reembedMissingMemories(
 			const outcome = await reembedMissingMemoriesBatch(
 				accessor,
 				embeddingFn,
-				embeddingCfg,
+				resolvedEmbeddingCfg,
 				normalizedBatchSize,
 				agentId,
 			);


### PR DESCRIPTION
1|Fixes #1598
2|
3|## Problem
4|
5|`signet embed backfill` (`/api/repair/re-embed`) fails every batch with `"embedding profile changed during provider work; skipped stale vectors"`, `affected: 0`, regardless of batch size — permanently, not intermittently, once any prior `--model-mismatch` migration has promoted a named profile.
6|
7|## Root cause
8|
9|`reembedMissingMemories` passes the raw configured `EmbeddingConfig` (from `agent.yaml`, no `profile` field) straight to `isActiveEmbeddingConfig`, which fingerprints it via `identityProfile` and compares against the persisted active generation's fingerprint. Once a migration has promoted a *named* profile (e.g. `"nomic-embed-text-v1.5"`), that persisted fingerprint always differs from the raw config's identity fingerprint — a permanent mismatch, not the concurrent-write race the check is meant to guard.
10|
11|`resolveActiveEmbeddingConfig(db, configured)` already exists in `embedding-index-state.ts` for exactly this reconciliation; `reembedMissingMemories` just never called it.
12|
13|## Fix
14|
15|```diff
16|+	const resolvedEmbeddingCfg = await accessor.withReadDbAsync(async (db) =>
17|+		resolveActiveEmbeddingConfig(db, embeddingCfg),
18|+	);
19|+
20| 	const initialStats = await getEmbeddingGapStats(accessor, agentId);
21| 	...
22| 		const outcome = await reembedMissingMemoriesBatch(
23| 			accessor,
24| 			embeddingFn,
25|-			embeddingCfg,
26|+			resolvedEmbeddingCfg,
27| 			normalizedBatchSize,
28| 			agentId,
29| 		);
30|```
31|
32|Resolved once before the loop (the active profile can't change mid-loop without a promotion, which the existing per-batch `isActiveEmbeddingConfig` recheck still catches correctly).
33|
34|This also fixes a related correctness bug: without resolution, embeddings committed via this path were formatted with `identityProfile` (no prefix) instead of the model's real profile formatter (e.g. nomic's `"search_document: "` prefix) — silently inconsistent with the rest of the active vector space.
35|
36|## Tests
37|
38|Added a regression test: seeds `embedding_index_state` with a named active profile (simulating a prior migration), then asserts `reembedMissingMemories` with the *raw* (profile-less) config still succeeds, and that the embedding call receives the resolved profile (`cfg.profile === "nomic-embed-text-v1.5"`) — covering both the fingerprint fix and the formatting correctness fix.
39|
40|```
41|bun test platform/daemon/src/repair-actions.test.ts
42|74 pass, 0 fail, 307 expect() calls
43|```
44|
45|## Validation against production data
46|
47|Ran the fix against a live production database (43,260 memories, prior `--model-mismatch` migration already active) by pointing a source-built daemon at the real `~/.agents` dir on a real backup-protected copy:
48|
49|| | before | after |
50||---|---|---|
51|| `embed backfill` (any batch size) | `affected: 0`, fails every time | 37 of 60 stuck memories embedded across 2 batches |
52|| remaining unembedded | 60 | 23 (all independently oversized for the provider's context limit — already correctly isolated per-item, unrelated to this bug) |
53|
54|## Scope
55|
56|Touches only `reembedMissingMemories` (the plain backfill path exercised by `signet embed backfill` without `--model-mismatch`/`--all`). Did not touch `reembedModelMigration` — its `embeddingCfg` is the migration target by construction, so it isn't subject to the same mismatch; happy to look at it separately if maintainers think it's affected too.
57|
58|## PR Readiness (MANDATORY)
59|
60|The repository-approved `checklist-exception` label is applied for the readiness items that are not applicable to this focused daemon repair. The applicable checks are verified below.
61|
62|- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
63|- [x] Agent scoping verified on all new/changed data queries
64|- [ ] Input/config validation and bounds checks added
65|- [x] Error handling and fallback paths tested (no silent swallow)
66|- [ ] Security checks applied to admin/mutation endpoints
67|- [ ] Docs updated for API/spec/status changes
68|- [x] Regression tests added for each bug fix
69|- [x] Lint/typecheck/tests pass locally
70|
71|## Notes
72|
73|- Spec alignment was reviewed against `docs/specs/INDEX.md` and `docs/specs/dependencies.yaml`. This is a repair to the existing Memory Pipeline v2 embedding backfill path, not a new spec or dependency contract.
74|- No new unscoped data query was introduced. The existing agent-scoped repair path remains covered by the repair regression and cross-agent embedding protection tests; active embedding profile resolution reads the workspace index state through the existing async read accessor.
75|- No new input/config boundary, admin endpoint, mutation endpoint, API/spec/status contract, or migration was added. The `checklist-exception` label covers these N/A readiness items.
76|- Focused proof on the rebased PR head: `bun test platform/daemon/src/repair-actions.test.ts` passed with 74 tests, 0 failures, and 307 expectations. It includes the named-profile regression, stale-vector promotion guard, cross-agent protection, and async DB boundary coverage.
77|- `bun run --filter '@signet/core' build` passed; `bun run --filter '@signet/daemon' build` passed; `bun run --filter '@signet/daemon' typecheck` passed; `bun run lint` passed with existing repository warnings; targeted Biome check passed with three warnings and no errors; `git diff --check origin/main...HEAD` passed.
78|- No implementation files were changed during this repair. The branch was fetched at the exact original head, rebased onto current `origin/main`, and pushed unchanged apart from the rebase.
79|