### PR TITLE
fix(daemon): bound database admission

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,15 +4,15 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 732 sites
+- Exact ledger inventory: 730 sites
 - Synchronous `withWriteTx()` sites: 106
-- Synchronous `withReadDb()` sites: 142
+- Synchronous `withReadDb()` sites: 140
 - Synchronous filesystem/process sites: 484
-- Compile-visible legacy DB sites remaining: 248
+- Compile-visible legacy DB sites remaining: 246
   - `withWriteTx`: 106
-  - `withReadDb`: 142
+  - `withReadDb`: 140
 
-The 732-site inventory excludes test, benchmark, generated, and `__tests__` fixtures. The 106 synchronous writes and 142 synchronous reads remain transitional callers for the later migration phase. They are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate 248 database operations.
+The 730-site inventory excludes test, benchmark, generated, and `__tests__` fixtures. The 106 synchronous writes and 140 synchronous reads remain transitional callers for the later migration phase. They are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate 246 database operations.
 
 ## A3 Slice 2 migration notes
 
@@ -29,4 +29,4 @@ The converted async sites are distributed as follows: document-worker (18), drea
 
 The structural boundary makes statically-resolved imports from the production source tree impossible: TypeScript reports TS6059 before aliases or computed member calls can use the compatibility type. The production bundle also only starts from source entrypoints, so this compatibility module is not a shipped production artifact.
 
-A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 248 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 106 write and 142 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.
+A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 246 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 106 write and 140 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.

--- a/platform/daemon/src/db-accessor.test.ts
+++ b/platform/daemon/src/db-accessor.test.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import {
 	DbSpacePreflightError,
 	DbReadAdmissionCancelledError,
+	DbReadAdmissionRejectedError,
 	DbReadAdmissionTimeoutError,
 	DbWriteQueueFullError,
 	MAX_READ_CONNECTIONS,
@@ -244,6 +245,32 @@ describe("DbAccessor", () => {
 		releaseReaders();
 		await Promise.all(heldReaders);
 		expect(acc.getReadPressure?.().activeLeases).toBe(0);
+	});
+
+	test("synchronous legacy reads expose structured admission rejection at the cap", async () => {
+		const dbPath = tmpDbPath();
+		cleanupDirs.push(join(dbPath, ".."));
+		initDbAccessor(dbPath);
+		const acc = getDbAccessor();
+		const sync = acc as unknown as {
+			withReadDb<T>(fn: (db: import("./db-accessor").ReadDb) => T): T;
+		};
+		let releaseReaders: () => void = () => undefined;
+		const readersReleased = new Promise<void>((resolve) => {
+			releaseReaders = resolve;
+		});
+		const heldReaders = Array.from({ length: MAX_READ_CONNECTIONS }, () =>
+			acc.withReadDbAsync(async () => {
+				await readersReleased;
+			}),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(() => sync.withReadDb(() => undefined)).toThrow(DbReadAdmissionRejectedError);
+		expect(acc.getReadPressure?.()).toMatchObject({ rejected: 1, syncRejected: 1 });
+
+		releaseReaders();
+		await Promise.all(heldReaders);
 	});
 
 	test("close rejects queued async writes", async () => {

--- a/platform/daemon/src/db-accessor.test.ts
+++ b/platform/daemon/src/db-accessor.test.ts
@@ -8,7 +8,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	DbSpacePreflightError,
+	DbReadAdmissionCancelledError,
+	DbReadAdmissionTimeoutError,
 	DbWriteQueueFullError,
+	MAX_READ_CONNECTIONS,
 	MAX_WRITE_QUEUE,
 	backupBeforeMigration,
 	closeDbAccessor,
@@ -207,6 +210,40 @@ describe("DbAccessor", () => {
 		const rejected = enqueue(() => undefined);
 		await expect(rejected).rejects.toBeInstanceOf(DbWriteQueueFullError);
 		await Promise.all(pending);
+	});
+
+	test("read admission waits FIFO and records timeout/cancellation pressure", async () => {
+		const dbPath = tmpDbPath();
+		cleanupDirs.push(join(dbPath, ".."));
+		initDbAccessor(dbPath);
+		const acc = getDbAccessor();
+		let releaseReaders: () => void = () => undefined;
+		const readersReleased = new Promise<void>((resolve) => {
+			releaseReaders = resolve;
+		});
+		const heldReaders = Array.from({ length: MAX_READ_CONNECTIONS }, () =>
+			acc.withReadDbAsync(async () => {
+				await readersReleased;
+			}),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		const timedOut = acc.withReadDbAsync(async () => undefined, { timeoutMs: 25, operation: "test.timeout" });
+		await expect(timedOut).rejects.toBeInstanceOf(DbReadAdmissionTimeoutError);
+		expect(acc.getReadPressure?.().timedOut).toBe(1);
+
+		const controller = new AbortController();
+		const cancelled = acc.withReadDbAsync(async () => undefined, {
+			signal: controller.signal,
+			operation: "test.cancel",
+		});
+		controller.abort();
+		await expect(cancelled).rejects.toBeInstanceOf(DbReadAdmissionCancelledError);
+		expect(acc.getReadPressure?.().cancelled).toBe(1);
+
+		releaseReaders();
+		await Promise.all(heldReaders);
+		expect(acc.getReadPressure?.().activeLeases).toBe(0);
 	});
 
 	test("close rejects queued async writes", async () => {

--- a/platform/daemon/src/db-accessor.test.ts
+++ b/platform/daemon/src/db-accessor.test.ts
@@ -10,7 +10,6 @@ import {
 	DbSpacePreflightError,
 	DbReadAdmissionCancelledError,
 	DbReadAdmissionRejectedError,
-	DbReadAdmissionTimeoutError,
 	DbWriteQueueFullError,
 	MAX_READ_CONNECTIONS,
 	MAX_WRITE_QUEUE,
@@ -213,41 +212,54 @@ describe("DbAccessor", () => {
 		await Promise.all(pending);
 	});
 
-	test("read admission waits FIFO and records timeout/cancellation pressure", async () => {
+	test("releases the read lease before an async callback continuation", async () => {
 		const dbPath = tmpDbPath();
 		cleanupDirs.push(join(dbPath, ".."));
 		initDbAccessor(dbPath);
 		const acc = getDbAccessor();
-		let releaseReaders: () => void = () => undefined;
-		const readersReleased = new Promise<void>((resolve) => {
-			releaseReaders = resolve;
+		let callbackStarted = () => undefined;
+		const started = new Promise<void>((resolve) => {
+			callbackStarted = resolve;
 		});
-		const heldReaders = Array.from({ length: MAX_READ_CONNECTIONS }, () =>
-			acc.withReadDbAsync(async () => {
-				await readersReleased;
-			}),
+		let continueCallback = () => undefined;
+		const continuation = new Promise<void>((resolve) => {
+			continueCallback = resolve;
+		});
+
+		const pending = acc.withReadDbAsync(
+			async (db) => {
+				db.prepare("SELECT 1").get();
+				callbackStarted();
+				await continuation;
+				return true;
+			},
+			{ operation: "test.async-release" },
 		);
 
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		const timedOut = acc.withReadDbAsync(async () => undefined, { timeoutMs: 25, operation: "test.timeout" });
-		await expect(timedOut).rejects.toBeInstanceOf(DbReadAdmissionTimeoutError);
-		expect(acc.getReadPressure?.().timedOut).toBe(1);
-
-		const controller = new AbortController();
-		const cancelled = acc.withReadDbAsync(async () => undefined, {
-			signal: controller.signal,
-			operation: "test.cancel",
-		});
-		controller.abort();
-		await expect(cancelled).rejects.toBeInstanceOf(DbReadAdmissionCancelledError);
-		expect(acc.getReadPressure?.().cancelled).toBe(1);
-
-		releaseReaders();
-		await Promise.all(heldReaders);
+		await started;
 		expect(acc.getReadPressure?.().activeLeases).toBe(0);
+		continueCallback();
+		await expect(pending).resolves.toBe(true);
 	});
 
-	test("synchronous legacy reads expose structured admission rejection at the cap", async () => {
+	test("read admission rejects pre-cancelled requests without acquiring a lease", async () => {
+		const dbPath = tmpDbPath();
+		cleanupDirs.push(join(dbPath, ".."));
+		initDbAccessor(dbPath);
+		const acc = getDbAccessor();
+		const controller = new AbortController();
+		controller.abort();
+
+		await expect(
+			acc.withReadDbAsync(() => undefined, {
+				signal: controller.signal,
+				operation: "test.cancel",
+			}),
+		).rejects.toBeInstanceOf(DbReadAdmissionCancelledError);
+		expect(acc.getReadPressure?.().cancelled).toBe(1);
+	});
+
+	test("synchronous legacy reads expose structured admission rejection at the cap", () => {
 		const dbPath = tmpDbPath();
 		cleanupDirs.push(join(dbPath, ".."));
 		initDbAccessor(dbPath);
@@ -255,22 +267,13 @@ describe("DbAccessor", () => {
 		const sync = acc as unknown as {
 			withReadDb<T>(fn: (db: import("./db-accessor").ReadDb) => T): T;
 		};
-		let releaseReaders: () => void = () => undefined;
-		const readersReleased = new Promise<void>((resolve) => {
-			releaseReaders = resolve;
-		});
-		const heldReaders = Array.from({ length: MAX_READ_CONNECTIONS }, () =>
-			acc.withReadDbAsync(async () => {
-				await readersReleased;
-			}),
-		);
+		const acquireNestedReads = (remaining: number): void => {
+			if (remaining === 0) return;
+			sync.withReadDb(() => acquireNestedReads(remaining - 1));
+		};
 
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		expect(() => sync.withReadDb(() => undefined)).toThrow(DbReadAdmissionRejectedError);
-		expect(acc.getReadPressure?.()).toMatchObject({ rejected: 1, syncRejected: 1 });
-
-		releaseReaders();
-		await Promise.all(heldReaders);
+		expect(() => sync.withReadDb(() => acquireNestedReads(MAX_READ_CONNECTIONS))).toThrow(DbReadAdmissionRejectedError);
+		expect(acc.getReadPressure?.()).toMatchObject({ rejected: 1, syncRejected: 1, activeLeases: 0 });
 	});
 
 	test("close rejects queued async writes", async () => {

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -36,6 +36,14 @@ import type { DbSpaceMetrics } from "./db-vacuum";
 
 import { ensureEmbeddingIndexState } from "./embedding-index-state";
 import { loadMemoryConfig } from "./memory-config";
+import {
+	getDbRuntimeMetrics,
+	recordDbOperation,
+	resetDbObservability,
+	setDbQueueTelemetry,
+	type DbOperationOutcome,
+	type DbRuntimeMetrics,
+} from "./db-observability";
 import { observeDbLatency } from "./runtime-pressure";
 
 export { DbSpacePreflightError };
@@ -142,6 +150,62 @@ export interface WritePressure {
 	readonly oldestWaitMs: number | null;
 	/** Duration of the most recently completed write operation. */
 	readonly lastDurationMs: number | null;
+	/** Number of write transactions currently executing. */
+	readonly active: boolean;
+	/** Operation label of the oldest queued job, if any. */
+	readonly oldestOperation: string | null;
+	/** Number of queued jobs rejected because admission was full. */
+	readonly rejected: number;
+	/** Number of queued jobs cancelled before execution. */
+	readonly cancelled: number;
+	/** Number of jobs that missed their deadline before execution. */
+	readonly timedOut: number;
+	/** Queue wait for the most recently started job. */
+	readonly lastQueueWaitMs: number | null;
+}
+
+export interface ReadPressure {
+	/** Number of active read leases. */
+	readonly activeLeases: number;
+	/** Maximum number of read connections, including non-pooled leases. */
+	readonly maxConnections: number;
+	/** Number of callers waiting for a read lease. */
+	readonly queued: number;
+	/** Maximum number of queued read callers. */
+	readonly maxQueue: number;
+	/** Age of the oldest waiting caller, or null when empty. */
+	readonly oldestWaitMs: number | null;
+	/** Most recent read lease wait. */
+	readonly lastWaitMs: number | null;
+	readonly rejected: number;
+	readonly cancelled: number;
+	readonly timedOut: number;
+}
+
+export interface ReadAdmissionOptions {
+	/** Maximum time to wait for a connection. Default 5 seconds. */
+	readonly timeoutMs?: number;
+	/** Abort a queued request without affecting other readers. */
+	readonly signal?: AbortSignal;
+	/** Stable diagnostic label for the owner boundary. */
+	readonly operation?: string;
+}
+
+export interface WriteAdmissionOptions {
+	/** Stable diagnostic label for the owner boundary. */
+	readonly operation?: string;
+	/** Maximum time a queued job may wait before it is rejected. */
+	readonly deadlineMs?: number;
+	/** Estimated work units for diagnostics and scheduling. */
+	readonly estimatedWorkUnits?: number;
+	/** Abort a queued job before it starts. */
+	readonly signal?: AbortSignal;
+}
+
+export interface DbRuntimePressure {
+	readonly writer: WritePressure;
+	readonly reader: ReadPressure;
+	readonly runtime: DbRuntimeMetrics;
 }
 
 export class DbWriteQueueFullError extends Error {
@@ -150,6 +214,51 @@ export class DbWriteQueueFullError extends Error {
 	constructor() {
 		super("Database write queue is full; retry after write pressure clears");
 		this.name = "DbWriteQueueFullError";
+	}
+}
+
+export class DbReadQueueFullError extends Error {
+	readonly code = "DB_READ_QUEUE_FULL" as const;
+
+	constructor() {
+		super("Database read admission queue is full; retry after read pressure clears");
+		this.name = "DbReadQueueFullError";
+	}
+}
+
+export class DbReadAdmissionTimeoutError extends Error {
+	readonly code = "DB_READ_ADMISSION_TIMEOUT" as const;
+
+	constructor(timeoutMs: number) {
+		super(`Database read admission timed out after ${timeoutMs}ms`);
+		this.name = "DbReadAdmissionTimeoutError";
+	}
+}
+
+export class DbReadAdmissionCancelledError extends Error {
+	readonly code = "DB_READ_ADMISSION_CANCELLED" as const;
+
+	constructor() {
+		super("Database read admission was cancelled before a connection became available");
+		this.name = "DbReadAdmissionCancelledError";
+	}
+}
+
+export class DbWriteAdmissionCancelledError extends Error {
+	readonly code = "DB_WRITE_ADMISSION_CANCELLED" as const;
+
+	constructor() {
+		super("Database write admission was cancelled before execution");
+		this.name = "DbWriteAdmissionCancelledError";
+	}
+}
+
+export class DbWriteAdmissionTimeoutError extends Error {
+	readonly code = "DB_WRITE_ADMISSION_TIMEOUT" as const;
+
+	constructor() {
+		super("Database write admission deadline exceeded");
+		this.name = "DbWriteAdmissionTimeoutError";
 	}
 }
 
@@ -162,7 +271,7 @@ export class DbWriteQueueFullError extends Error {
  */
 export interface AsyncDbAccessor {
 	/** Admit a write transaction through the bounded async writer queue. */
-	withWriteTxAsync<T>(fn: (db: WriteDb) => T): Promise<T>;
+	withWriteTxAsync<T>(fn: (db: WriteDb) => T, options?: WriteAdmissionOptions): Promise<T>;
 
 	/** Admit a WAL checkpoint through the bounded async writer queue. */
 	checkpointWalAsync?(): Promise<void>;
@@ -177,11 +286,15 @@ export interface AsyncDbAccessor {
 	/** Return bounded local diagnostics for the writer admission path. */
 	getWritePressure?(): WritePressure;
 
-	/** Async variant of withReadDb. The connection stays checked out of the
-	 *  read pool for the whole `fn`, including across event-loop yields, so
-	 *  long readers can breathe without starving other readers (the pool
-	 *  grows on demand up to the connection limit). */
-	withReadDbAsync<T>(fn: (db: ReadDb) => Promise<T>): Promise<T>;
+	/** Return bounded local diagnostics for the read admission path. */
+	getReadPressure?(): ReadPressure;
+
+	/** Return the combined database-owner diagnostics envelope. */
+	getDbRuntimePressure?(): DbRuntimePressure;
+
+	/** Async variant of withReadDb. The connection is held only for the
+	 * callback's database work and is admitted through a FIFO lease queue. */
+	withReadDbAsync<T>(fn: (db: ReadDb) => Promise<T>, options?: ReadAdmissionOptions): Promise<T>;
 
 	/** Close all held connections. Safe to call multiple times. */
 	close(): void;
@@ -1128,14 +1241,34 @@ function backfillVecEmbeddings(db: SqliteDatabase, expectedDimensions: number): 
 // ---------------------------------------------------------------------------
 
 const READ_POOL_SIZE = 4;
-const MAX_READ_CONNECTIONS = 16;
+export const MAX_READ_CONNECTIONS = 16;
+export const MAX_READ_WAITERS = 64;
+export const DEFAULT_READ_WAIT_TIMEOUT_MS = 5_000;
 export const MAX_WRITE_QUEUE = 64;
 
 type WriteJob<T> = {
 	readonly run: () => T;
 	readonly queuedAt: number;
+	readonly operation: string;
+	readonly deadlineAt: number | null;
+	readonly estimatedWorkUnits: number | null;
+	readonly signal: AbortSignal | undefined;
+	readonly onAbort: () => void;
+	readonly transactional: boolean;
+	cancellation: "pending" | "requested" | "started";
 	readonly resolve: (value: T | PromiseLike<T>) => void;
 	readonly reject: (reason?: unknown) => void;
+};
+
+type ReadWaiter = {
+	readonly enqueuedAt: number;
+	readonly operation: string;
+	readonly timeoutMs: number;
+	readonly signal: AbortSignal | undefined;
+	readonly resolve: (lease: { readonly conn: SqliteDatabase; readonly waitMs: number }) => void;
+	readonly reject: (reason?: unknown) => void;
+	readonly onAbort: () => void;
+	readonly timer: ReturnType<typeof setTimeout>;
 };
 
 function yieldToEventLoop(): Promise<void> {
@@ -1145,51 +1278,217 @@ function yieldToEventLoop(): Promise<void> {
 function createAccessor(writeConn: SqliteDatabase): RuntimeDbAccessor {
 	let closed = false;
 	let writeDraining = false;
+	let writeActive = false;
 	let lastWriteDurationMs: number | null = null;
+	let lastWriteQueueWaitMs: number | null = null;
+	let writeRejected = 0;
+	let writeCancelled = 0;
+	let writeTimedOut = 0;
 	const writeQueue: WriteJob<unknown>[] = [];
 	// Small pool of reusable read connections. Recall does 3 reads per
 	// request so opening/closing every time adds measurable overhead.
 	const readPool: SqliteDatabase[] = [];
 	const readInUse = new Set<SqliteDatabase>();
+	const readWaiters: ReadWaiter[] = [];
+	let lastReadWaitMs: number | null = null;
+	let readRejected = 0;
+	let readCancelled = 0;
+	let readTimedOut = 0;
 
-	function acquireRead(): SqliteDatabase {
+	function updateQueueTelemetry(): void {
+		const oldestRead = readWaiters[0];
+		const oldestWrite = writeQueue[0];
+		setDbQueueTelemetry({
+			readDepth: readWaiters.length,
+			readMaxDepth: MAX_READ_WAITERS,
+			readOldestAgeMs: oldestRead ? Math.max(0, performance.now() - oldestRead.enqueuedAt) : null,
+			readActiveLeases: readInUse.size,
+			writeDepth: writeQueue.length,
+			writeMaxDepth: MAX_WRITE_QUEUE,
+			writeOldestAgeMs: oldestWrite ? Math.max(0, performance.now() - oldestWrite.queuedAt) : null,
+			writeActive,
+		});
+	}
+
+	function openReadConnection(): SqliteDatabase {
 		if (dbPath === null) throw new Error("DbAccessor not initialised");
-		const pooled = readPool.pop();
-		if (pooled) {
-			readInUse.add(pooled);
-			return pooled;
-		}
-		if (readInUse.size >= MAX_READ_CONNECTIONS) {
-			console.warn(`[db] Read connection limit exceeded (${readInUse.size}/${MAX_READ_CONNECTIONS})`);
-			throw new Error("Read connection limit exceeded");
-		}
 		const conn = new Database(dbPath, { readonly: true });
 		conn.exec("PRAGMA busy_timeout = 5000");
 		loadVecExtension(conn);
 		readInUse.add(conn);
+		updateQueueTelemetry();
 		return conn;
+	}
+
+	function acquireReadSync(operation: string): SqliteDatabase {
+		const pooled = readPool.pop();
+		if (pooled) {
+			readInUse.add(pooled);
+			updateQueueTelemetry();
+			return pooled;
+		}
+		if (readInUse.size >= MAX_READ_CONNECTIONS) {
+			readRejected++;
+			recordDbOperation({
+				owner: "read",
+				operation,
+				durationMs: 0,
+				queueWaitMs: 0,
+				queueDepth: readWaiters.length,
+				queueAgeMs: readWaiters[0] ? performance.now() - readWaiters[0].enqueuedAt : null,
+				estimatedWorkUnits: null,
+				outcome: "rejected",
+			});
+			throw new DbReadQueueFullError();
+		}
+		return openReadConnection();
+	}
+
+	function acquireRead(
+		options: ReadAdmissionOptions = {},
+	): Promise<{ readonly conn: SqliteDatabase; readonly waitMs: number }> {
+		const operation = options.operation ?? "db.read";
+		const timeoutMs =
+			typeof options.timeoutMs === "number" && Number.isFinite(options.timeoutMs) && options.timeoutMs > 0
+				? options.timeoutMs
+				: DEFAULT_READ_WAIT_TIMEOUT_MS;
+		if (closed) return Promise.reject(new Error("DbAccessor is closed"));
+		if (options.signal?.aborted) {
+			readCancelled++;
+			recordDbOperation({
+				owner: "read",
+				operation,
+				durationMs: 0,
+				queueWaitMs: 0,
+				queueDepth: readWaiters.length,
+				queueAgeMs: null,
+				estimatedWorkUnits: null,
+				outcome: "cancelled",
+			});
+			return Promise.reject(new DbReadAdmissionCancelledError());
+		}
+		const pooled = readPool.pop();
+		if (pooled) {
+			readInUse.add(pooled);
+			updateQueueTelemetry();
+			return Promise.resolve({ conn: pooled, waitMs: 0 });
+		}
+		if (readInUse.size < MAX_READ_CONNECTIONS) return Promise.resolve({ conn: openReadConnection(), waitMs: 0 });
+		if (readWaiters.length >= MAX_READ_WAITERS) {
+			readRejected++;
+			recordDbOperation({
+				owner: "read",
+				operation,
+				durationMs: 0,
+				queueWaitMs: 0,
+				queueDepth: readWaiters.length,
+				queueAgeMs: readWaiters[0] ? performance.now() - readWaiters[0].enqueuedAt : null,
+				estimatedWorkUnits: null,
+				outcome: "rejected",
+			});
+			return Promise.reject(new DbReadQueueFullError());
+		}
+
+		return new Promise((resolve, reject) => {
+			let settled = false;
+			const enqueuedAt = performance.now();
+			const waiter = {} as ReadWaiter;
+			const rejectQueued = (error: Error, outcome: DbOperationOutcome): void => {
+				if (settled) return;
+				settled = true;
+				const index = readWaiters.indexOf(waiter);
+				if (index >= 0) readWaiters.splice(index, 1);
+				if (outcome === "cancelled") readCancelled++;
+				else readTimedOut++;
+				const waitMs = Math.max(0, performance.now() - enqueuedAt);
+				recordDbOperation({
+					owner: "read",
+					operation,
+					durationMs: 0,
+					queueWaitMs: waitMs,
+					queueDepth: readWaiters.length,
+					queueAgeMs: waitMs,
+					estimatedWorkUnits: null,
+					outcome,
+				});
+				clearTimeout(waiter.timer);
+				options.signal?.removeEventListener("abort", waiter.onAbort);
+				reject(error);
+				updateQueueTelemetry();
+			};
+			const onAbort = (): void => rejectQueued(new DbReadAdmissionCancelledError(), "cancelled");
+			const timer = setTimeout(() => rejectQueued(new DbReadAdmissionTimeoutError(timeoutMs), "timed_out"), timeoutMs);
+			Object.assign(waiter, {
+				enqueuedAt,
+				operation,
+				timeoutMs,
+				signal: options.signal,
+				resolve,
+				reject,
+				onAbort,
+				timer,
+			});
+			readWaiters.push(waiter);
+			options.signal?.addEventListener("abort", onAbort, { once: true });
+			updateQueueTelemetry();
+		});
 	}
 
 	function releaseRead(conn: SqliteDatabase): void {
 		readInUse.delete(conn);
-		if (readPool.length < READ_POOL_SIZE) {
-			readPool.push(conn);
-		} else {
-			conn.close();
+		const waiter = readWaiters.shift();
+		if (waiter) {
+			clearTimeout(waiter.timer);
+			waiter.signal?.removeEventListener("abort", waiter.onAbort);
+			const waitMs = Math.max(0, performance.now() - waiter.enqueuedAt);
+			lastReadWaitMs = waitMs;
+			readInUse.add(conn);
+			waiter.resolve({ conn, waitMs });
+			updateQueueTelemetry();
+			return;
 		}
+		if (readPool.length < READ_POOL_SIZE) readPool.push(conn);
+		else conn.close();
+		updateQueueTelemetry();
 	}
 
-	function runWriteOperation<T>(fn: () => T): T {
+	function runWriteOperation<T>(
+		fn: () => T,
+		meta: {
+			readonly operation: string;
+			readonly queuedAt?: number;
+			readonly queueDepth?: number;
+			readonly queueAgeMs?: number | null;
+			readonly estimatedWorkUnits?: number | null;
+		},
+	): T {
 		const startedAt = performance.now();
+		let outcome: DbOperationOutcome = "completed";
 		try {
 			return fn();
+		} catch (error) {
+			outcome = "failed";
+			throw error;
 		} finally {
 			lastWriteDurationMs = performance.now() - startedAt;
+			lastWriteQueueWaitMs = meta.queuedAt === undefined ? 0 : Math.max(0, startedAt - meta.queuedAt);
 			observeDbLatency(lastWriteDurationMs);
+			recordDbOperation({
+				owner: "write",
+				operation: meta.operation,
+				durationMs: lastWriteDurationMs,
+				queueWaitMs: lastWriteQueueWaitMs,
+				queueDepth: meta.queueDepth ?? writeQueue.length,
+				queueAgeMs: meta.queueAgeMs ?? (meta.queuedAt === undefined ? null : lastWriteQueueWaitMs),
+				estimatedWorkUnits: meta.estimatedWorkUnits ?? null,
+				outcome,
+			});
 		}
 	}
 
-	function runWriteTx<T>(fn: (db: WriteDb) => T): T {
+	type WriteOperationMeta = Parameters<typeof runWriteOperation>[1];
+
+	function runWriteTx<T>(fn: (db: WriteDb) => T, meta: WriteOperationMeta = { operation: "db.write" }): T {
 		return runWriteOperation(() => {
 			writeConn.exec("BEGIN IMMEDIATE");
 			try {
@@ -1200,39 +1499,102 @@ function createAccessor(writeConn: SqliteDatabase): RuntimeDbAccessor {
 				writeConn.exec("ROLLBACK");
 				throw err;
 			}
-		});
+		}, meta);
 	}
 
 	function runCheckpointWal(): void {
-		runWriteOperation(() => {
-			writeConn.exec("PRAGMA wal_checkpoint(TRUNCATE)");
-		});
+		writeConn.exec("PRAGMA wal_checkpoint(TRUNCATE)");
 	}
 
 	function runIncrementalVacuum(): number {
-		return runWriteOperation(() => {
-			writeConn.exec("PRAGMA incremental_vacuum");
-			const row = writeConn.prepare("PRAGMA freelist_count").get() as { freelist_count?: number } | undefined;
-			return typeof row?.freelist_count === "number" ? row.freelist_count : 0;
-		});
+		writeConn.exec("PRAGMA incremental_vacuum");
+		const row = writeConn.prepare("PRAGMA freelist_count").get() as { freelist_count?: number } | undefined;
+		return typeof row?.freelist_count === "number" ? row.freelist_count : 0;
 	}
 
 	function runVacuumConversion(): boolean {
-		return runWriteOperation(() =>
-			convertToIncrementalVacuum(toMigrationDb(writeConn), { dbPath: dbPath ?? undefined }),
-		);
+		return convertToIncrementalVacuum(toMigrationDb(writeConn), { dbPath: dbPath ?? undefined });
 	}
 
-	function enqueueWrite<T>(run: () => T): Promise<T> {
+	function enqueueWrite<T>(run: () => T, options: WriteAdmissionOptions = {}, transactional = true): Promise<T> {
+		const operation = options.operation ?? "db.write";
 		if (closed) return Promise.reject(new Error("DbAccessor is closed"));
-		if (writeQueue.length >= MAX_WRITE_QUEUE) return Promise.reject(new DbWriteQueueFullError());
+		if (options.signal?.aborted) {
+			writeCancelled++;
+			recordDbOperation({
+				owner: "write",
+				operation,
+				durationMs: 0,
+				queueWaitMs: 0,
+				queueDepth: writeQueue.length,
+				queueAgeMs: null,
+				estimatedWorkUnits: options.estimatedWorkUnits ?? null,
+				outcome: "cancelled",
+			});
+			return Promise.reject(new DbWriteAdmissionCancelledError());
+		}
+		if (writeQueue.length >= MAX_WRITE_QUEUE) {
+			writeRejected++;
+			recordDbOperation({
+				owner: "write",
+				operation,
+				durationMs: 0,
+				queueWaitMs: 0,
+				queueDepth: writeQueue.length,
+				queueAgeMs: writeQueue[0] ? performance.now() - writeQueue[0].queuedAt : null,
+				estimatedWorkUnits: options.estimatedWorkUnits ?? null,
+				outcome: "rejected",
+			});
+			return Promise.reject(new DbWriteQueueFullError());
+		}
 		return new Promise<T>((resolve, reject) => {
-			writeQueue.push({
+			const queuedAt = performance.now();
+			const job = {} as WriteJob<unknown>;
+			const onAbort = (): void => {
+				const index = writeQueue.indexOf(job);
+				if (index < 0) {
+					job.cancellation = "requested";
+					return;
+				}
+				writeQueue.splice(index, 1);
+				job.cancellation = "requested";
+				writeCancelled++;
+				const waitMs = Math.max(0, performance.now() - queuedAt);
+				recordDbOperation({
+					owner: "write",
+					operation,
+					durationMs: 0,
+					queueWaitMs: waitMs,
+					queueDepth: writeQueue.length,
+					queueAgeMs: waitMs,
+					estimatedWorkUnits: job.estimatedWorkUnits,
+					outcome: "cancelled",
+				});
+				reject(new DbWriteAdmissionCancelledError());
+				updateQueueTelemetry();
+			};
+			Object.assign(job, {
 				run,
-				queuedAt: performance.now(),
-				resolve: (value) => resolve(value as T),
+				queuedAt,
+				operation,
+				deadlineAt:
+					typeof options.deadlineMs === "number" && Number.isFinite(options.deadlineMs) && options.deadlineMs > 0
+						? queuedAt + options.deadlineMs
+						: null,
+				estimatedWorkUnits:
+					typeof options.estimatedWorkUnits === "number" && Number.isFinite(options.estimatedWorkUnits)
+						? Math.max(0, options.estimatedWorkUnits)
+						: null,
+				signal: options.signal,
+				onAbort,
+				transactional,
+				cancellation: "pending",
+				resolve: (value: T | PromiseLike<T>) => resolve(value),
 				reject,
 			});
+			writeQueue.push(job);
+			options.signal?.addEventListener("abort", onAbort, { once: true });
+			updateQueueTelemetry();
 			drainWriteQueue();
 		});
 	}
@@ -1244,22 +1606,70 @@ function createAccessor(writeConn: SqliteDatabase): RuntimeDbAccessor {
 			const job = writeQueue.shift();
 			if (!job) {
 				writeDraining = false;
+				updateQueueTelemetry();
 				return;
 			}
+			job.signal?.removeEventListener("abort", job.onAbort);
 			if (closed) {
 				job.reject(new Error("DbAccessor is closed"));
-				setTimeout(next, 0);
+				void yieldToEventLoop().then(next);
 				return;
 			}
+			const now = performance.now();
+			if (job.signal?.aborted) {
+				job.cancellation = "requested";
+				writeCancelled++;
+				job.reject(new DbWriteAdmissionCancelledError());
+				void yieldToEventLoop().then(next);
+				return;
+			}
+			if (job.deadlineAt !== null && now >= job.deadlineAt) {
+				writeTimedOut++;
+				recordDbOperation({
+					owner: "write",
+					operation: job.operation,
+					durationMs: 0,
+					queueWaitMs: Math.max(0, now - job.queuedAt),
+					queueDepth: writeQueue.length,
+					queueAgeMs: Math.max(0, now - job.queuedAt),
+					estimatedWorkUnits: job.estimatedWorkUnits,
+					outcome: "timed_out",
+				});
+				job.reject(new DbWriteAdmissionTimeoutError());
+				void yieldToEventLoop().then(next);
+				return;
+			}
+			job.cancellation = "started";
+			writeActive = true;
+			updateQueueTelemetry();
 			try {
-				job.resolve(job.run());
+				job.resolve(
+					job.transactional
+						? runWriteTx(() => job.run(), {
+								operation: job.operation,
+								queuedAt: job.queuedAt,
+								queueDepth: writeQueue.length,
+								queueAgeMs: Math.max(0, now - job.queuedAt),
+								estimatedWorkUnits: job.estimatedWorkUnits,
+							})
+						: runWriteOperation(job.run, {
+								operation: job.operation,
+								queuedAt: job.queuedAt,
+								queueDepth: writeQueue.length,
+								queueAgeMs: Math.max(0, now - job.queuedAt),
+								estimatedWorkUnits: job.estimatedWorkUnits,
+							}),
+				);
 			} catch (err) {
 				job.reject(err);
+			} finally {
+				writeActive = false;
 			}
-			if (writeQueue.length > 0) {
-				void yieldToEventLoop().then(next);
-			} else {
+			updateQueueTelemetry();
+			if (writeQueue.length > 0) void yieldToEventLoop().then(next);
+			else {
 				writeDraining = false;
+				updateQueueTelemetry();
 			}
 		};
 		void yieldToEventLoop().then(next);
@@ -1271,35 +1681,35 @@ function createAccessor(writeConn: SqliteDatabase): RuntimeDbAccessor {
 			return runWriteTx(fn);
 		},
 
-		withWriteTxAsync<T>(fn: (db: WriteDb) => T): Promise<T> {
-			return enqueueWrite(() => runWriteTx(fn));
+		withWriteTxAsync<T>(fn: (db: WriteDb) => T, options?: WriteAdmissionOptions): Promise<T> {
+			return enqueueWrite(() => fn(writeConn), options);
 		},
 
 		checkpointWalAsync(): Promise<void> {
-			return enqueueWrite(runCheckpointWal);
+			return enqueueWrite(runCheckpointWal, { operation: "db.checkpoint_wal" }, false);
 		},
 
 		incrementalVacuumAsync(): Promise<number> {
-			return enqueueWrite(runIncrementalVacuum);
+			return enqueueWrite(runIncrementalVacuum, { operation: "db.incremental_vacuum" }, false);
 		},
 
 		vacuumConversionAsync(): Promise<boolean> {
-			return enqueueWrite(runVacuumConversion);
+			return enqueueWrite(runVacuumConversion, { operation: "db.vacuum_conversion" }, false);
 		},
 
 		checkpointWal(): void {
 			if (closed) throw new Error("DbAccessor is closed");
-			runCheckpointWal();
+			runWriteOperation(runCheckpointWal, { operation: "db.checkpoint_wal" });
 		},
 
 		incrementalVacuum(): number {
 			if (closed) throw new Error("DbAccessor is closed");
-			return runIncrementalVacuum();
+			return runWriteOperation(runIncrementalVacuum, { operation: "db.incremental_vacuum" });
 		},
 
 		vacuumConversion(): boolean {
 			if (closed) throw new Error("DbAccessor is closed");
-			return runVacuumConversion();
+			return runWriteOperation(runVacuumConversion, { operation: "db.vacuum_conversion" });
 		},
 
 		getWritePressure(): WritePressure {
@@ -1309,30 +1719,88 @@ function createAccessor(writeConn: SqliteDatabase): RuntimeDbAccessor {
 				maxQueue: MAX_WRITE_QUEUE,
 				oldestWaitMs: oldest ? Math.max(0, performance.now() - oldest.queuedAt) : null,
 				lastDurationMs: lastWriteDurationMs,
+				active: writeActive,
+				oldestOperation: oldest?.operation ?? null,
+				rejected: writeRejected,
+				cancelled: writeCancelled,
+				timedOut: writeTimedOut,
+				lastQueueWaitMs: lastWriteQueueWaitMs,
 			};
+		},
+
+		getReadPressure(): ReadPressure {
+			const oldest = readWaiters[0];
+			return {
+				activeLeases: readInUse.size,
+				maxConnections: MAX_READ_CONNECTIONS,
+				queued: readWaiters.length,
+				maxQueue: MAX_READ_WAITERS,
+				oldestWaitMs: oldest ? Math.max(0, performance.now() - oldest.enqueuedAt) : null,
+				lastWaitMs: lastReadWaitMs,
+				rejected: readRejected,
+				cancelled: readCancelled,
+				timedOut: readTimedOut,
+			};
+		},
+
+		getDbRuntimePressure(): DbRuntimePressure {
+			updateQueueTelemetry();
+			const self = this as unknown as { getWritePressure: () => WritePressure; getReadPressure: () => ReadPressure };
+			return { writer: self.getWritePressure(), reader: self.getReadPressure(), runtime: getDbRuntimeMetrics() };
 		},
 
 		withReadDb<T>(fn: (db: ReadDb) => T): T {
 			if (closed) throw new Error("DbAccessor is closed");
 			const startedAt = performance.now();
-			const conn = acquireRead();
+			const conn = acquireReadSync("db.read.sync");
+			let outcome: DbOperationOutcome = "completed";
 			try {
 				return fn(conn);
+			} catch (error) {
+				outcome = "failed";
+				throw error;
 			} finally {
 				releaseRead(conn);
-				observeDbLatency(performance.now() - startedAt);
+				const durationMs = performance.now() - startedAt;
+				observeDbLatency(durationMs);
+				recordDbOperation({
+					owner: "read",
+					operation: "db.read.sync",
+					durationMs,
+					queueWaitMs: 0,
+					queueDepth: readWaiters.length,
+					queueAgeMs: null,
+					estimatedWorkUnits: null,
+					outcome,
+				});
 			}
 		},
 
-		async withReadDbAsync<T>(fn: (db: ReadDb) => Promise<T>): Promise<T> {
+		async withReadDbAsync<T>(fn: (db: ReadDb) => Promise<T>, options?: ReadAdmissionOptions): Promise<T> {
 			if (closed) throw new Error("DbAccessor is closed");
 			const startedAt = performance.now();
-			const conn = acquireRead();
+			const lease = await acquireRead(options);
+			let outcome: DbOperationOutcome = "completed";
 			try {
-				return await fn(conn);
+				return await fn(lease.conn);
+			} catch (error) {
+				outcome = "failed";
+				throw error;
 			} finally {
-				releaseRead(conn);
-				observeDbLatency(performance.now() - startedAt);
+				releaseRead(lease.conn);
+				const durationMs = performance.now() - startedAt;
+				lastReadWaitMs = lease.waitMs;
+				observeDbLatency(durationMs);
+				recordDbOperation({
+					owner: "read",
+					operation: options?.operation ?? "db.read",
+					durationMs,
+					queueWaitMs: lease.waitMs,
+					queueDepth: readWaiters.length,
+					queueAgeMs: lease.waitMs,
+					estimatedWorkUnits: null,
+					outcome,
+				});
 			}
 		},
 
@@ -1342,8 +1810,15 @@ function createAccessor(writeConn: SqliteDatabase): RuntimeDbAccessor {
 			writeConn.close();
 			for (const conn of readPool) conn.close();
 			for (const conn of readInUse) conn.close();
+			for (const waiter of readWaiters) {
+				clearTimeout(waiter.timer);
+				waiter.signal?.removeEventListener("abort", waiter.onAbort);
+				waiter.reject(new Error("DbAccessor is closed"));
+			}
+			readWaiters.length = 0;
 			readPool.length = 0;
 			readInUse.clear();
+			updateQueueTelemetry();
 		},
 	};
 }
@@ -1382,4 +1857,5 @@ export function closeDbAccessor(): void {
 	vecLoaded = false;
 	vecLoadError = null;
 	vecExtPath = undefined;
+	resetDbObservability();
 }

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -303,10 +303,10 @@ export interface AsyncDbAccessor {
 	/** Return the combined database-owner diagnostics envelope. */
 	getDbRuntimePressure?(): DbRuntimePressure;
 
-	/** Async variant of withReadDb. The connection is held only for the
-	 * callback's database work and is admitted through a FIFO lease queue.
-	 * Callbacks that need unrelated async work must return their database result
-	 * first, then await that work after this method resolves. */
+	/** Async variant of withReadDb. The connection is held only while the
+	 * callback's synchronous database work runs and is admitted through a FIFO
+	 * lease queue. If the callback returns a promise, its continuation runs
+	 * after the lease is released and must not use the database connection. */
 	withReadDbAsync<T>(fn: (db: ReadDb) => T | Promise<T>, options?: ReadAdmissionOptions): Promise<T>;
 
 	/** Close all held connections. Safe to call multiple times. */
@@ -1797,13 +1797,37 @@ function createAccessor(writeConn: SqliteDatabase): RuntimeDbAccessor {
 			const startedAt = performance.now();
 			const lease = await acquireRead(options);
 			let outcome: DbOperationOutcome = "completed";
+			let result: T | Promise<T>;
 			try {
-				return await fn(lease.conn);
+				// Invoke the callback before releasing the lease so its synchronous
+				// query work runs against the admitted connection. Do not await a
+				// returned promise here: unrelated async work must not retain it.
+				result = fn(lease.conn);
+			} catch (error) {
+				outcome = "failed";
+				releaseRead(lease.conn);
+				const durationMs = performance.now() - startedAt;
+				lastReadWaitMs = lease.waitMs;
+				observeDbLatency(durationMs);
+				recordDbOperation({
+					owner: "read",
+					operation: options?.operation ?? "db.read",
+					durationMs,
+					queueWaitMs: lease.waitMs,
+					queueDepth: readWaiters.length,
+					queueAgeMs: lease.waitMs,
+					estimatedWorkUnits: null,
+					outcome,
+				});
+				throw error;
+			}
+			releaseRead(lease.conn);
+			try {
+				return await result;
 			} catch (error) {
 				outcome = "failed";
 				throw error;
 			} finally {
-				releaseRead(lease.conn);
 				const durationMs = performance.now() - startedAt;
 				lastReadWaitMs = lease.waitMs;
 				observeDbLatency(durationMs);

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -178,6 +178,8 @@ export interface ReadPressure {
 	/** Most recent read lease wait. */
 	readonly lastWaitMs: number | null;
 	readonly rejected: number;
+	/** Number of synchronous legacy reads rejected at the connection cap. */
+	readonly syncRejected: number;
 	readonly cancelled: number;
 	readonly timedOut: number;
 }
@@ -223,6 +225,15 @@ export class DbReadQueueFullError extends Error {
 	constructor() {
 		super("Database read admission queue is full; retry after read pressure clears");
 		this.name = "DbReadQueueFullError";
+	}
+}
+
+export class DbReadAdmissionRejectedError extends Error {
+	readonly code = "DB_READ_ADMISSION_REJECTED" as const;
+
+	constructor(operation: string) {
+		super(`Database read admission rejected for ${operation}; retry after read pressure clears`);
+		this.name = "DbReadAdmissionRejectedError";
 	}
 }
 
@@ -293,8 +304,10 @@ export interface AsyncDbAccessor {
 	getDbRuntimePressure?(): DbRuntimePressure;
 
 	/** Async variant of withReadDb. The connection is held only for the
-	 * callback's database work and is admitted through a FIFO lease queue. */
-	withReadDbAsync<T>(fn: (db: ReadDb) => Promise<T>, options?: ReadAdmissionOptions): Promise<T>;
+	 * callback's database work and is admitted through a FIFO lease queue.
+	 * Callbacks that need unrelated async work must return their database result
+	 * first, then await that work after this method resolves. */
+	withReadDbAsync<T>(fn: (db: ReadDb) => T | Promise<T>, options?: ReadAdmissionOptions): Promise<T>;
 
 	/** Close all held connections. Safe to call multiple times. */
 	close(): void;
@@ -1292,6 +1305,7 @@ function createAccessor(writeConn: SqliteDatabase): RuntimeDbAccessor {
 	const readWaiters: ReadWaiter[] = [];
 	let lastReadWaitMs: number | null = null;
 	let readRejected = 0;
+	let readSyncRejected = 0;
 	let readCancelled = 0;
 	let readTimedOut = 0;
 
@@ -1329,6 +1343,7 @@ function createAccessor(writeConn: SqliteDatabase): RuntimeDbAccessor {
 		}
 		if (readInUse.size >= MAX_READ_CONNECTIONS) {
 			readRejected++;
+			readSyncRejected++;
 			recordDbOperation({
 				owner: "read",
 				operation,
@@ -1339,7 +1354,7 @@ function createAccessor(writeConn: SqliteDatabase): RuntimeDbAccessor {
 				estimatedWorkUnits: null,
 				outcome: "rejected",
 			});
-			throw new DbReadQueueFullError();
+			throw new DbReadAdmissionRejectedError(operation);
 		}
 		return openReadConnection();
 	}
@@ -1738,6 +1753,7 @@ function createAccessor(writeConn: SqliteDatabase): RuntimeDbAccessor {
 				oldestWaitMs: oldest ? Math.max(0, performance.now() - oldest.enqueuedAt) : null,
 				lastWaitMs: lastReadWaitMs,
 				rejected: readRejected,
+				syncRejected: readSyncRejected,
 				cancelled: readCancelled,
 				timedOut: readTimedOut,
 			};
@@ -1776,7 +1792,7 @@ function createAccessor(writeConn: SqliteDatabase): RuntimeDbAccessor {
 			}
 		},
 
-		async withReadDbAsync<T>(fn: (db: ReadDb) => Promise<T>, options?: ReadAdmissionOptions): Promise<T> {
+		async withReadDbAsync<T>(fn: (db: ReadDb) => T | Promise<T>, options?: ReadAdmissionOptions): Promise<T> {
 			if (closed) throw new Error("DbAccessor is closed");
 			const startedAt = performance.now();
 			const lease = await acquireRead(options);

--- a/platform/daemon/src/db-observability.test.ts
+++ b/platform/daemon/src/db-observability.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	getDbRuntimeMetrics,
+	getEventLoopLiveness,
+	recordDbOperation,
+	recordEventLoopLag,
+	resetDbObservability,
+	setDbQueueTelemetry,
+} from "./db-observability";
+
+afterEach(() => {
+	resetDbObservability();
+});
+
+describe("database owner observability", () => {
+	test("reports bounded operation percentiles and queue wait separately", () => {
+		for (const durationMs of [4, 8, 12, 20]) {
+			recordDbOperation({
+				owner: "write",
+				operation: "test.write",
+				durationMs,
+				queueWaitMs: durationMs / 2,
+				queueDepth: 2,
+				queueAgeMs: durationMs,
+				estimatedWorkUnits: 1,
+				outcome: "completed",
+			});
+		}
+		setDbQueueTelemetry({
+			readDepth: 3,
+			readMaxDepth: 64,
+			readOldestAgeMs: 10,
+			readActiveLeases: 4,
+			writeDepth: 2,
+			writeMaxDepth: 64,
+			writeOldestAgeMs: 20,
+			writeActive: true,
+		});
+
+		const metrics = getDbRuntimeMetrics();
+		expect(metrics.operations.write.p95Ms).toBe(20);
+		expect(metrics.queueWait.write.p50Ms).toBe(4);
+		expect(metrics.queue.writeActive).toBe(true);
+		expect(metrics.completed).toBe(4);
+	});
+
+	test("event-loop liveness is independent of database queue state", () => {
+		setDbQueueTelemetry({
+			readDepth: 64,
+			readMaxDepth: 64,
+			readOldestAgeMs: 5_000,
+			readActiveLeases: 16,
+			writeDepth: 64,
+			writeMaxDepth: 64,
+			writeOldestAgeMs: 5_000,
+			writeActive: true,
+		});
+		recordEventLoopLag(100);
+		expect(getEventLoopLiveness().status).toBe("healthy");
+		recordEventLoopLag(2_500);
+		expect(getEventLoopLiveness().status).toBe("degraded");
+	});
+});

--- a/platform/daemon/src/db-observability.ts
+++ b/platform/daemon/src/db-observability.ts
@@ -1,0 +1,184 @@
+/**
+ * Bounded, process-local observability for database-owner boundaries.
+ *
+ * The accessor owns SQLite execution. This module records only bounded numeric
+ * samples and stable operation labels, so diagnostics never need to query the
+ * database or retain user data while the event loop is under pressure.
+ */
+
+export type DbOwner = "read" | "write";
+export type DbOperationOutcome = "completed" | "failed" | "cancelled" | "rejected" | "timed_out";
+
+export interface DbOperationSample {
+	readonly owner: DbOwner;
+	readonly operation: string;
+	readonly durationMs: number;
+	readonly queueWaitMs: number;
+	readonly queueDepth: number;
+	readonly queueAgeMs: number | null;
+	readonly estimatedWorkUnits: number | null;
+	readonly outcome: DbOperationOutcome;
+}
+
+export interface DbPercentiles {
+	readonly count: number;
+	readonly p50Ms: number | null;
+	readonly p95Ms: number | null;
+	readonly p99Ms: number | null;
+	readonly maxMs: number | null;
+}
+
+export interface DbQueueTelemetry {
+	readonly readDepth: number;
+	readonly readMaxDepth: number;
+	readonly readOldestAgeMs: number | null;
+	readonly readActiveLeases: number;
+	readonly writeDepth: number;
+	readonly writeMaxDepth: number;
+	readonly writeOldestAgeMs: number | null;
+	readonly writeActive: boolean;
+}
+
+export interface DbRuntimeMetrics {
+	readonly version: 1;
+	readonly operations: {
+		readonly read: DbPercentiles;
+		readonly write: DbPercentiles;
+	};
+	readonly queueWait: {
+		readonly read: DbPercentiles;
+		readonly write: DbPercentiles;
+	};
+	readonly queue: DbQueueTelemetry;
+	readonly cancelled: number;
+	readonly rejected: number;
+	readonly timedOut: number;
+	readonly failed: number;
+	readonly completed: number;
+	readonly eventLoopLag: DbPercentiles;
+}
+
+const MAX_SAMPLES = 512;
+const operationSamples: DbOperationSample[] = [];
+const eventLoopLagSamples: number[] = [];
+let queue: DbQueueTelemetry = {
+	readDepth: 0,
+	readMaxDepth: 0,
+	readOldestAgeMs: null,
+	readActiveLeases: 0,
+	writeDepth: 0,
+	writeMaxDepth: 0,
+	writeOldestAgeMs: null,
+	writeActive: false,
+};
+let cancelled = 0;
+let rejected = 0;
+let timedOut = 0;
+let failed = 0;
+let completed = 0;
+
+function appendBounded<T>(items: T[], value: T): void {
+	items.push(value);
+	if (items.length > MAX_SAMPLES) items.shift();
+}
+
+function finite(value: number | null): value is number {
+	return value !== null && Number.isFinite(value) && value >= 0;
+}
+
+function percentiles(values: readonly number[]): DbPercentiles {
+	if (values.length === 0) return { count: 0, p50Ms: null, p95Ms: null, p99Ms: null, maxMs: null };
+	const sorted = [...values].sort((a, b) => a - b);
+	const pick = (fraction: number): number =>
+		sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * fraction) - 1)] ?? 0;
+	return {
+		count: sorted.length,
+		p50Ms: pick(0.5),
+		p95Ms: pick(0.95),
+		p99Ms: pick(0.99),
+		maxMs: sorted[sorted.length - 1] ?? null,
+	};
+}
+
+export function recordDbOperation(sample: DbOperationSample): void {
+	if (!finite(sample.durationMs) || !finite(sample.queueWaitMs)) return;
+	appendBounded(operationSamples, sample);
+	if (sample.outcome === "cancelled") cancelled++;
+	else if (sample.outcome === "rejected") rejected++;
+	else if (sample.outcome === "timed_out") timedOut++;
+	else if (sample.outcome === "failed") failed++;
+	else completed++;
+}
+
+export function recordEventLoopLag(lagMs: number): void {
+	if (!finite(lagMs)) return;
+	appendBounded(eventLoopLagSamples, lagMs);
+}
+
+export function setDbQueueTelemetry(snapshot: DbQueueTelemetry): void {
+	queue = snapshot;
+}
+
+export function getDbRuntimeMetrics(): DbRuntimeMetrics {
+	return {
+		version: 1,
+		operations: {
+			read: percentiles(
+				operationSamples.filter((sample) => sample.owner === "read").map((sample) => sample.durationMs),
+			),
+			write: percentiles(
+				operationSamples.filter((sample) => sample.owner === "write").map((sample) => sample.durationMs),
+			),
+		},
+		queueWait: {
+			read: percentiles(
+				operationSamples.filter((sample) => sample.owner === "read").map((sample) => sample.queueWaitMs),
+			),
+			write: percentiles(
+				operationSamples.filter((sample) => sample.owner === "write").map((sample) => sample.queueWaitMs),
+			),
+		},
+		queue,
+		cancelled,
+		rejected,
+		timedOut,
+		failed,
+		completed,
+		eventLoopLag: percentiles(eventLoopLagSamples),
+	};
+}
+
+/** A cheap probe for liveness routes. It never reads database state. */
+export function getEventLoopLiveness(): {
+	readonly status: "healthy" | "degraded";
+	readonly lagP95Ms: number | null;
+	readonly lagP99Ms: number | null;
+} {
+	const lag = percentiles(eventLoopLagSamples);
+	return {
+		status: lag.p99Ms !== null && lag.p99Ms > 2_000 ? "degraded" : "healthy",
+		lagP95Ms: lag.p95Ms,
+		lagP99Ms: lag.p99Ms,
+	};
+}
+
+/** Reset bounded process-local state between daemon test cases. */
+export function resetDbObservability(): void {
+	operationSamples.length = 0;
+	eventLoopLagSamples.length = 0;
+	cancelled = 0;
+	rejected = 0;
+	timedOut = 0;
+	failed = 0;
+	completed = 0;
+	queue = {
+		readDepth: 0,
+		readMaxDepth: 0,
+		readOldestAgeMs: null,
+		readActiveLeases: 0,
+		writeDepth: 0,
+		writeMaxDepth: 0,
+		writeOldestAgeMs: null,
+		writeActive: false,
+	};
+}

--- a/platform/daemon/src/knowledge-graph-list.test.ts
+++ b/platform/daemon/src/knowledge-graph-list.test.ts
@@ -12,7 +12,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { closeDbAccessor, getDbAccessor, initDbAccessor, MAX_READ_CONNECTIONS } from "./db-accessor";
 import {
 	getDependenciesFrom,
 	getDependenciesTo,
@@ -556,6 +556,28 @@ describe("getKnowledgeEntityDetail (issue #515)", () => {
 		expect(detail?.outgoingDependencyCount).toBe(2);
 		expect(detail?.incomingDependencyCount).toBe(1);
 		expect(detail?.dependencyCount).toBe(3);
+	});
+
+	test("releases the detail lease before nested structural reads", async () => {
+		dbPath = makeDbPath();
+		initDbAccessor(dbPath);
+		seedEntity("e-hub", "Hub");
+
+		const requests = Array.from({ length: MAX_READ_CONNECTIONS }, () =>
+			getKnowledgeEntityDetail(getDbAccessor(), "e-hub", "default"),
+		);
+		const completed = await Promise.race([
+			Promise.all(requests).then(
+				() => true,
+				() => false,
+			),
+			new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 500)),
+		]);
+		if (!completed) {
+			closeDbAccessor();
+			await Promise.allSettled(requests);
+		}
+		expect(completed).toBe(true);
 	});
 
 	test("returns null for unknown entity id", async () => {

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -1238,12 +1238,12 @@ export async function getKnowledgeEntityDetail(
 	entityId: string,
 	agentId: string,
 ): Promise<KnowledgeEntityDetail | null> {
-	return await accessor.withReadDbAsync(async (db) => {
+	const row = await accessor.withReadDbAsync((db) => {
 		// Scalar subqueries per count avoid GROUP BY materialization across
 		// the (LEFT JOIN aspects x attributes x dependencies) cartesian, which
 		// produces the same pathological shape as listKnowledgeEntities even
 		// when filtered to a single entity id. See Signet-AI/signetai#515.
-		const row = db
+		return db
 			.prepare(
 				`SELECT
 					e.*,
@@ -1293,23 +1293,23 @@ export async function getKnowledgeEntityDetail(
 				   AND COALESCE(e.status, 'active') = 'active'`,
 			)
 			.get(entityId, agentId) as Record<string, unknown> | undefined;
-
-		if (!row) return null;
-		const structuralDensity = await getStructuralDensity(accessor, entityId, agentId);
-		const incomingDependencyCount = Number(row.incoming_dependency_count ?? 0);
-		const outgoingDependencyCount = Number(row.outgoing_dependency_count ?? 0);
-
-		return {
-			entity: rowToEntity(row),
-			aspectCount: Number(row.aspect_count ?? 0),
-			attributeCount: Number(row.attribute_count ?? 0),
-			constraintCount: Number(row.constraint_count ?? 0),
-			dependencyCount: incomingDependencyCount + outgoingDependencyCount,
-			structuralDensity,
-			incomingDependencyCount,
-			outgoingDependencyCount,
-		};
 	});
+
+	if (!row) return null;
+	const structuralDensity = await getStructuralDensity(accessor, entityId, agentId);
+	const incomingDependencyCount = Number(row.incoming_dependency_count ?? 0);
+	const outgoingDependencyCount = Number(row.outgoing_dependency_count ?? 0);
+
+	return {
+		entity: rowToEntity(row),
+		aspectCount: Number(row.aspect_count ?? 0),
+		attributeCount: Number(row.attribute_count ?? 0),
+		constraintCount: Number(row.constraint_count ?? 0),
+		dependencyCount: incomingDependencyCount + outgoingDependencyCount,
+		structuralDensity,
+		incomingDependencyCount,
+		outgoingDependencyCount,
+	};
 }
 
 function readEntityAspectsWithCounts(db: ReadDb, entityId: string, agentId: string): readonly AspectWithCounts[] {
@@ -2205,7 +2205,7 @@ export async function getStructuralDensity(
 	entityId: string,
 	agentId: string,
 ): Promise<StructuralDensity> {
-	return await accessor.withReadDbAsync(async (db) => {
+	return await accessor.withReadDbAsync((db) => {
 		const aspects = db
 			.prepare(
 				`SELECT COUNT(*) as n FROM entity_aspects

--- a/platform/daemon/src/resource-monitor.ts
+++ b/platform/daemon/src/resource-monitor.ts
@@ -5,6 +5,7 @@ import { dlopen, ptr, read } from "bun:ffi";
 import { readdirSync, readlinkSync } from "node:fs";
 import { join } from "node:path";
 import { performance } from "node:perf_hooks";
+import { recordEventLoopLag } from "./db-observability";
 import { logger } from "./logger";
 import { reportEventLoopLag, tickPressureState } from "./system-pressure";
 
@@ -387,6 +388,7 @@ export function startEventLoopMonitor(intervalMs = 2000): void {
 		const lag = now - lastTick - intervalMs;
 		// Feed the pressure signal so background write loops can yield/pause.
 		reportEventLoopLag(lag);
+		recordEventLoopLag(lag);
 		// Advance the pressure state machine on the monitor's own cadence so
 		// reads (isSystemPressureHigh) stay pure and never clear the signal.
 		tickPressureState();

--- a/platform/daemon/src/routes/health.test.ts
+++ b/platform/daemon/src/routes/health.test.ts
@@ -3,13 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
-import {
-	DbReadAdmissionTimeoutError,
-	MAX_READ_CONNECTIONS,
-	closeDbAccessor,
-	getDbAccessor,
-	initDbAccessor,
-} from "../db-accessor";
+import { MAX_READ_CONNECTIONS, closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 import { mountHealthRoutes } from "./health";
 
 /**
@@ -89,25 +83,25 @@ describe("GET /health/live", () => {
 	});
 
 	test("stays responsive while the read lease pool is saturated", async () => {
-		let releaseReaders: () => void = () => undefined;
-		const readersReleased = new Promise<void>((resolve) => {
-			releaseReaders = resolve;
-		});
-		const heldReaders = Array.from({ length: MAX_READ_CONNECTIONS }, () =>
-			getDbAccessor().withReadDbAsync(async () => {
-				await readersReleased;
-			}),
-		);
-
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		const sync = getDbAccessor() as unknown as {
+			withReadDb<T>(fn: (db: import("../db-accessor").ReadDb) => T): T;
+		};
 		const app = makeApp();
-		const liveResponse = await app.request("http://localhost/health/live");
-		expect(liveResponse.status).toBe(200);
+		let livePromise: Promise<Response> | null = null;
+		const acquireNestedReads = (remaining: number): void => {
+			if (remaining === 0) {
+				livePromise = Promise.resolve(app.request("http://localhost/health/live"));
+				return;
+			}
+			sync.withReadDb(() => acquireNestedReads(remaining - 1));
+		};
+		acquireNestedReads(MAX_READ_CONNECTIONS);
+		const pending = livePromise;
+		if (pending === null) throw new Error("liveness request was not started");
 
-		const timedOutRead = getDbAccessor().withReadDbAsync(async () => undefined, { timeoutMs: 25 });
-		await expect(timedOutRead).rejects.toBeInstanceOf(DbReadAdmissionTimeoutError);
-		releaseReaders();
-		await Promise.all(heldReaders);
+		const liveResponse = await pending;
+		expect(liveResponse.status).toBe(200);
+		expect(getDbAccessor().getReadPressure?.().activeLeases).toBe(0);
 	});
 });
 

--- a/platform/daemon/src/routes/health.test.ts
+++ b/platform/daemon/src/routes/health.test.ts
@@ -222,6 +222,14 @@ describe("GET /health (back-compat)", () => {
 		expect(typeof dbWriter.maxQueue).toBe("number");
 		expect(dbWriter.oldestWaitMs === null || typeof dbWriter.oldestWaitMs === "number").toBe(true);
 		expect(dbWriter.lastDurationMs === null || typeof dbWriter.lastDurationMs === "number").toBe(true);
+		const dbReader = body.dbReader as Record<string, unknown>;
+		expect(typeof dbReader.activeLeases).toBe("number");
+		expect(typeof dbReader.maxConnections).toBe("number");
+		expect(typeof dbReader.rejected).toBe("number");
+		expect(typeof dbReader.syncRejected).toBe("number");
+		const dbRuntime = body.dbRuntime as Record<string, unknown>;
+		expect(dbRuntime.queue).toBeDefined();
+		expect(dbRuntime.eventLoopLag).toBeDefined();
 		const resources = body.resources as Record<string, unknown>;
 		expect(typeof resources.rss).toBe("number");
 		expect(typeof resources.heapUsed).toBe("number");

--- a/platform/daemon/src/routes/health.test.ts
+++ b/platform/daemon/src/routes/health.test.ts
@@ -3,7 +3,13 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
-import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
+import {
+	DbReadAdmissionTimeoutError,
+	MAX_READ_CONNECTIONS,
+	closeDbAccessor,
+	getDbAccessor,
+	initDbAccessor,
+} from "../db-accessor";
 import { mountHealthRoutes } from "./health";
 
 /**
@@ -80,6 +86,28 @@ describe("GET /health/live", () => {
 		expect(typeof body.uptime).toBe("number");
 		expect(typeof body.pid).toBe("number");
 		expect(typeof body.version).toBe("string");
+	});
+
+	test("stays responsive while the read lease pool is saturated", async () => {
+		let releaseReaders: () => void = () => undefined;
+		const readersReleased = new Promise<void>((resolve) => {
+			releaseReaders = resolve;
+		});
+		const heldReaders = Array.from({ length: MAX_READ_CONNECTIONS }, () =>
+			getDbAccessor().withReadDbAsync(async () => {
+				await readersReleased;
+			}),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		const app = makeApp();
+		const liveResponse = await app.request("http://localhost/health/live");
+		expect(liveResponse.status).toBe(200);
+
+		const timedOutRead = getDbAccessor().withReadDbAsync(async () => undefined, { timeoutMs: 25 });
+		await expect(timedOutRead).rejects.toBeInstanceOf(DbReadAdmissionTimeoutError);
+		releaseReaders();
+		await Promise.all(heldReaders);
 	});
 });
 

--- a/platform/daemon/src/routes/health.ts
+++ b/platform/daemon/src/routes/health.ts
@@ -178,7 +178,7 @@ function checkInference(): { ok: boolean; detail: InferenceCheck; reason: string
 }
 
 export function mountHealthRoutes(app: Hono): void {
-	app.get("/health", (c) => {
+	app.get("/health", async (c) => {
 		const us = getUpdateState();
 		let dbOk = false;
 		let dbWriter: WritePressure | null = null;
@@ -187,11 +187,13 @@ export function mountHealthRoutes(app: Hono): void {
 		try {
 			const accessor = getDbAccessor();
 			try {
-				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-				accessor.withReadDb((db: ReadDb) => {
-					db.prepare("SELECT 1").get();
-					dbOk = true;
-				});
+				await accessor.withReadDbAsync(
+					(db: ReadDb) => {
+						db.prepare("SELECT 1").get();
+						dbOk = true;
+					},
+					{ operation: "health" },
+				);
 			} catch {
 				// Keep the structured admission outcome visible below.
 			}

--- a/platform/daemon/src/routes/health.ts
+++ b/platform/daemon/src/routes/health.ts
@@ -2,7 +2,7 @@ import type { SQLQueryBindings } from "bun:sqlite";
 import { type MigrationDb, hasPendingMigrations } from "@signet/core";
 import type { Hono } from "hono";
 import { getDatabaseIntegrityStatus } from "../database-integrity";
-import { type ReadDb, type WritePressure, getDbAccessor } from "../db-accessor";
+import { type ReadDb, type ReadPressure, type WritePressure, getDbAccessor } from "../db-accessor";
 import { getDbRuntimeMetrics, getEventLoopLiveness } from "../db-observability";
 import {
 	QUEUE_MAX_DEAD_RATE,
@@ -182,15 +182,21 @@ export function mountHealthRoutes(app: Hono): void {
 		const us = getUpdateState();
 		let dbOk = false;
 		let dbWriter: WritePressure | null = null;
+		let dbReader: ReadPressure | null = null;
 		let dbRuntime = getDbRuntimeMetrics();
 		try {
 			const accessor = getDbAccessor();
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			accessor.withReadDb((db: import("../db-accessor").ReadDb) => {
-				db.prepare("SELECT 1").get();
-				dbOk = true;
-			});
+			try {
+				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
+				accessor.withReadDb((db: ReadDb) => {
+					db.prepare("SELECT 1").get();
+					dbOk = true;
+				});
+			} catch {
+				// Keep the structured admission outcome visible below.
+			}
 			dbWriter = accessor.getWritePressure?.() ?? null;
+			dbReader = accessor.getReadPressure?.() ?? null;
 			dbRuntime = accessor.getDbRuntimePressure?.().runtime ?? dbRuntime;
 		} catch {}
 
@@ -208,6 +214,7 @@ export function mountHealthRoutes(app: Hono): void {
 			agentsDir: AGENTS_DIR,
 			db: dbOk,
 			dbWriter,
+			dbReader,
 			dbRuntime,
 			databaseIntegrity,
 			shuttingDown,
@@ -236,17 +243,31 @@ export function mountHealthRoutes(app: Hono): void {
 
 		// db, migrations, and queue share one readonly connection.
 		let dbResult: { readonly migrationsOk: boolean; readonly queueHealth: QueueHealth } | null = null;
+		let dbReader: ReadPressure | null = null;
+		let dbRuntime = getDbRuntimeMetrics();
 		try {
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			dbResult = getDbAccessor().withReadDb((db: import("../db-accessor").ReadDb) => {
-				db.prepare("SELECT 1").get();
-				return {
-					migrationsOk: !hasPendingMigrations(readDbAsMigrationDb(db)),
-					queueHealth: getQueueHealth(db),
-				};
-			});
+			const accessor = getDbAccessor();
+			dbResult = await accessor.withReadDbAsync(
+				(db: ReadDb) => {
+					db.prepare("SELECT 1").get();
+					return {
+						migrationsOk: !hasPendingMigrations(readDbAsMigrationDb(db)),
+						queueHealth: getQueueHealth(db),
+					};
+				},
+				{ operation: "health.ready" },
+			);
+			dbReader = accessor.getReadPressure?.() ?? null;
+			dbRuntime = accessor.getDbRuntimePressure?.().runtime ?? dbRuntime;
 		} catch (err) {
 			reasons.push(`database unavailable: ${err instanceof Error ? err.message : String(err)}`);
+			try {
+				const accessor = getDbAccessor();
+				dbReader = accessor.getReadPressure?.() ?? null;
+				dbRuntime = accessor.getDbRuntimePressure?.().runtime ?? dbRuntime;
+			} catch {
+				// The accessor may be unavailable while the database check fails.
+			}
 		}
 		const dbOk = dbResult !== null;
 		const migrationsOk = dbResult?.migrationsOk ?? false;
@@ -292,6 +313,8 @@ export function mountHealthRoutes(app: Hono): void {
 				shuttingDown,
 				checks: {
 					db: dbOk,
+					dbReader,
+					dbRuntime,
 					migrations: migrationsOk,
 					databaseIntegrity,
 					embedding: embedding.detail,

--- a/platform/daemon/src/routes/health.ts
+++ b/platform/daemon/src/routes/health.ts
@@ -3,6 +3,7 @@ import { type MigrationDb, hasPendingMigrations } from "@signet/core";
 import type { Hono } from "hono";
 import { getDatabaseIntegrityStatus } from "../database-integrity";
 import { type ReadDb, type WritePressure, getDbAccessor } from "../db-accessor";
+import { getDbRuntimeMetrics, getEventLoopLiveness } from "../db-observability";
 import {
 	QUEUE_MAX_DEAD_RATE,
 	QUEUE_MAX_DEPTH,
@@ -181,6 +182,7 @@ export function mountHealthRoutes(app: Hono): void {
 		const us = getUpdateState();
 		let dbOk = false;
 		let dbWriter: WritePressure | null = null;
+		let dbRuntime = getDbRuntimeMetrics();
 		try {
 			const accessor = getDbAccessor();
 			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
@@ -189,6 +191,7 @@ export function mountHealthRoutes(app: Hono): void {
 				dbOk = true;
 			});
 			dbWriter = accessor.getWritePressure?.() ?? null;
+			dbRuntime = accessor.getDbRuntimePressure?.().runtime ?? dbRuntime;
 		} catch {}
 
 		const databaseIntegrity = getDatabaseIntegrityStatus();
@@ -205,6 +208,7 @@ export function mountHealthRoutes(app: Hono): void {
 			agentsDir: AGENTS_DIR,
 			db: dbOk,
 			dbWriter,
+			dbRuntime,
 			databaseIntegrity,
 			shuttingDown,
 			updateAvailable: us.lastCheck?.updateAvailable ?? false,
@@ -222,6 +226,7 @@ export function mountHealthRoutes(app: Hono): void {
 			version: CURRENT_VERSION,
 			port: PORT,
 			shuttingDown,
+			eventLoop: getEventLoopLiveness(),
 		});
 	});
 

--- a/platform/daemon/src/yielding-writes.test.ts
+++ b/platform/daemon/src/yielding-writes.test.ts
@@ -91,6 +91,40 @@ describe("drainWriteBatches", () => {
 		expect(remaining).toBe(0);
 	});
 
+	it("checkpoints by byte budget and reports committed progress", async () => {
+		getDbAccessor().withWriteTx((db) => {
+			const stmt = db.prepare("INSERT INTO work (id, payload) VALUES (?, ?)");
+			for (let i = 0; i < 3; i++) stmt.run(i, `item-${i}`);
+		});
+		const checkpoints: Array<{ processed: number; rows: number; bytes: number }> = [];
+
+		const result = await drainWriteBatches(
+			getDbAccessor(),
+			(db: ReadDb, limit: number) =>
+				db
+					.prepare("SELECT id FROM work WHERE id NOT IN (SELECT id FROM items) ORDER BY id LIMIT ?")
+					.all(limit) as Array<{ id: number }>,
+			(db: WriteDb, batch: readonly { id: number }[]) => {
+				for (const item of batch) db.prepare("INSERT INTO items (id) VALUES (?)").run(item.id);
+			},
+			{
+				label: "byte-checkpoint",
+				maxPerTx: 3,
+				maxBytes: 5,
+				estimateBytes: () => 4,
+				checkpoint: ({ processed, rows, bytes }) => checkpoints.push({ processed, rows, bytes }),
+			},
+		);
+
+		expect(result.processed).toBe(3);
+		expect(result.batches).toBe(3);
+		expect(checkpoints).toEqual([
+			{ processed: 1, rows: 1, bytes: 4 },
+			{ processed: 2, rows: 1, bytes: 4 },
+			{ processed: 3, rows: 1, bytes: 4 },
+		]);
+	});
+
 	it("yields to the event loop between batches", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			const stmt = db.prepare("INSERT INTO work (id, payload) VALUES (?, ?)");

--- a/platform/daemon/src/yielding-writes.ts
+++ b/platform/daemon/src/yielding-writes.ts
@@ -34,6 +34,12 @@ export interface DrainOptions {
 	readonly label: string;
 	/** Maximum items processed per write transaction. Default 50. */
 	readonly maxPerTx?: number;
+	/** Maximum rows/items in one checkpoint. Defaults to maxPerTx. */
+	readonly maxRows?: number;
+	/** Maximum estimated bytes in one checkpoint. The first item is always admitted. */
+	readonly maxBytes?: number;
+	/** Estimate an item's contribution to the checkpoint byte budget. */
+	readonly estimateBytes?: (item: unknown) => number;
 	/**
 	 * Yield after every N batches even when pressure is normal, so long
 	 * drains don't starve lower-priority work. Default 1 (yield every batch).
@@ -44,6 +50,16 @@ export interface DrainOptions {
 	/** Skip pressure checks entirely (for startup recovery where no workers
 	 *  or HTTP handlers are running to compete with). Default false. */
 	readonly skipPressure?: boolean;
+	/** Called after each committed checkpoint. */
+	readonly checkpoint?: (state: BatchCheckpoint) => void;
+}
+
+export interface BatchCheckpoint {
+	readonly processed: number;
+	readonly batches: number;
+	readonly rows: number;
+	readonly bytes: number;
+	readonly elapsedMs: number;
 }
 
 export interface DrainResult {
@@ -58,6 +74,12 @@ export interface RunWriteOptions {
 	readonly label: string;
 	/** Maximum items processed per write transaction. Default 50. */
 	readonly maxPerTx?: number;
+	/** Maximum rows/items in one checkpoint. Defaults to maxPerTx. */
+	readonly maxRows?: number;
+	/** Maximum estimated bytes in one checkpoint. The first item is always admitted. */
+	readonly maxBytes?: number;
+	/** Estimate an item's contribution to the checkpoint byte budget. */
+	readonly estimateBytes?: (item: unknown) => number;
 	/** Stop adding items to a transaction after this processing budget. */
 	readonly maxTxDurationMs?: number;
 	/** Yield after every N transactions. Default 1. */
@@ -66,6 +88,8 @@ export interface RunWriteOptions {
 	readonly maxTotal?: number;
 	/** Skip pressure checks entirely. Default false. */
 	readonly skipPressure?: boolean;
+	/** Called after each committed checkpoint. */
+	readonly checkpoint?: (state: BatchCheckpoint) => void;
 }
 
 export interface RunWriteResult<Result> {
@@ -78,9 +102,14 @@ export interface RunWriteResult<Result> {
 	readonly error?: string;
 }
 
-async function writeBatch<Result>(accessor: DbAccessor, processBatch: (db: WriteDb) => Result): Promise<Result> {
+async function writeBatch<Result>(
+	accessor: DbAccessor,
+	processBatch: (db: WriteDb) => Result,
+	label: string,
+	estimatedWorkUnits: number,
+): Promise<Result> {
 	if (accessor.withWriteTxAsync) {
-		return accessor.withWriteTxAsync(processBatch);
+		return accessor.withWriteTxAsync(processBatch, { operation: `db.batch.${label}`, estimatedWorkUnits });
 	}
 	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
 	return accessor.withWriteTx(processBatch);
@@ -108,22 +137,35 @@ export async function drainWriteBatches<Item>(
 	options: DrainOptions,
 ): Promise<DrainResult> {
 	const maxPerTx = options.maxPerTx ?? 50;
+	const maxRows = options.maxRows ?? maxPerTx;
+	const maxBytes = options.maxBytes ?? Number.POSITIVE_INFINITY;
 	const yieldEvery = options.yieldEvery ?? 1;
 	const maxTotal = options.maxTotal ?? 10_000;
 
 	let processed = 0;
 	let batches = 0;
 	let paused = 0;
+	const startedAt = performance.now();
 
 	while (processed < maxTotal) {
 		// 1. Fetch next batch (read-only, non-blocking for WAL readers).
 		const remaining = maxTotal - processed;
-		const limit = Math.min(maxPerTx, remaining);
+		const limit = Math.min(maxPerTx, maxRows, remaining);
 		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
 		const batch = accessor.withReadDb((db: import("./db-accessor").ReadDb) => fetchBatch(db, limit));
 		if (!batch || batch.length === 0) {
 			return { processed, batches, paused, stopped: "exhausted" };
 		}
+		const checkpointBatch: Item[] = [];
+		let checkpointBytes = 0;
+		for (const item of batch) {
+			const estimatedBytes = options.estimateBytes?.(item) ?? 0;
+			const bytes = Number.isFinite(estimatedBytes) ? Math.max(0, estimatedBytes) : 0;
+			if (checkpointBatch.length > 0 && checkpointBytes + bytes > maxBytes) break;
+			checkpointBatch.push(item);
+			checkpointBytes += bytes;
+		}
+		if (checkpointBatch.length === 0) checkpointBatch.push(batch[0] as Item);
 
 		// 2. Check pressure — pause background work if the event loop is degraded.
 		if (!options.skipPressure && isSystemPressureHigh()) {
@@ -132,10 +174,17 @@ export async function drainWriteBatches<Item>(
 		}
 
 		// 3. Process in one short transaction through bounded writer admission.
-		await writeBatch(accessor, (db) => processBatch(db, batch));
+		await writeBatch(accessor, (db) => processBatch(db, checkpointBatch), options.label, checkpointBatch.length);
 
-		processed += batch.length;
+		processed += checkpointBatch.length;
 		batches++;
+		options.checkpoint?.({
+			processed,
+			batches,
+			rows: checkpointBatch.length,
+			bytes: checkpointBytes,
+			elapsedMs: performance.now() - startedAt,
+		});
 
 		// 4. Yield between batches so HTTP handlers and the event-loop monitor run.
 		if (batches % yieldEvery === 0) {
@@ -167,6 +216,14 @@ export async function runWriteBatches<Item, Result>(
 		typeof options.maxPerTx === "number" && Number.isFinite(options.maxPerTx)
 			? Math.max(1, Math.floor(options.maxPerTx))
 			: 50;
+	const maxRows =
+		typeof options.maxRows === "number" && Number.isFinite(options.maxRows)
+			? Math.max(1, Math.floor(options.maxRows))
+			: maxPerTx;
+	const maxBytes =
+		typeof options.maxBytes === "number" && Number.isFinite(options.maxBytes)
+			? Math.max(1, options.maxBytes)
+			: Number.POSITIVE_INFINITY;
 	const maxTxDurationMs =
 		typeof options.maxTxDurationMs === "number" && Number.isFinite(options.maxTxDurationMs)
 			? Math.max(1, options.maxTxDurationMs)
@@ -186,6 +243,7 @@ export async function runWriteBatches<Item, Result>(
 	let processed = 0;
 	let batches = 0;
 	let paused = 0;
+	const startedAt = performance.now();
 
 	while (processed < maxTotal) {
 		if (!options.skipPressure && isSystemPressureHigh()) {
@@ -194,17 +252,30 @@ export async function runWriteBatches<Item, Result>(
 		}
 
 		let batch: readonly Result[];
+		let batchBytes = 0;
 		try {
-			batch = await writeBatch(accessor, (db) => {
-				const startedAt = performance.now();
-				const batchResults: Result[] = [];
-				for (const item of items.slice(processed, maxTotal)) {
-					batchResults.push(processItem(db, item));
-					if (batchResults.length >= maxPerTx) break;
-					if (performance.now() - startedAt >= maxTxDurationMs) break;
-				}
-				return batchResults;
-			});
+			const committed = await writeBatch(
+				accessor,
+				(db) => {
+					const startedAt = performance.now();
+					const batchResults: Result[] = [];
+					let bytes = 0;
+					for (const item of items.slice(processed, maxTotal)) {
+						const estimatedBytes = options.estimateBytes?.(item) ?? 0;
+						const itemBytes = Number.isFinite(estimatedBytes) ? Math.max(0, estimatedBytes) : 0;
+						if (batchResults.length > 0 && bytes + itemBytes > maxBytes) break;
+						batchResults.push(processItem(db, item));
+						bytes += itemBytes;
+						if (batchResults.length >= Math.min(maxPerTx, maxRows)) break;
+						if (performance.now() - startedAt >= maxTxDurationMs) break;
+					}
+					return { results: batchResults, bytes };
+				},
+				options.label,
+				Math.min(maxPerTx, maxRows),
+			);
+			batch = committed.results;
+			batchBytes = committed.bytes;
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			logger.warn("yielding-writes", `${options.label}: write batch failed after ${processed} committed items`, {
@@ -219,6 +290,13 @@ export async function runWriteBatches<Item, Result>(
 		results.push(...batch);
 		processed += batch.length;
 		batches++;
+		options.checkpoint?.({
+			processed,
+			batches,
+			rows: batch.length,
+			bytes: batchBytes,
+			elapsedMs: performance.now() - startedAt,
+		});
 
 		if (batches % yieldEvery === 0) await yieldToEventLoop();
 	}

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -11,11 +11,11 @@ import {
 	renderReport,
 } from "./audit-event-loop-contract";
 
-test("the deterministic ledger retains the exact 732-site inventory", () => {
+test("the deterministic ledger retains the exact 730-site inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(732);
+	expect(baseline).toHaveLength(730);
 	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(106);
-	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(142);
+	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(140);
 });
 
 test("the ledger reports legacy DB markers and rejects new call sites", () => {
@@ -278,9 +278,9 @@ test("the production TypeScript project cannot import the compatibility module",
 
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	const report = renderReport(baseline, { total: 248, withWriteTx: 106, withReadDb: 142 });
-	expect(report).toContain("Exact ledger inventory: 732 sites");
-	expect(report).toContain("106 synchronous writes and 142 synchronous reads");
+	const report = renderReport(baseline, { total: 246, withWriteTx: 106, withReadDb: 140 });
+	expect(report).toContain("Exact ledger inventory: 730 sites");
+	expect(report).toContain("106 synchronous writes and 140 synchronous reads");
 	expect(report).toContain("type boundary");
 	expect(report).not.toContain("1061");
 });

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -4420,20 +4420,6 @@
       "category": "hot-path"
     },
     {
-      "path": "routes/health.ts",
-      "line": 187,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/health.ts",
-      "line": 236,
-      "api": "withReadDb",
-      "source": "dbResult = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "routes/hooks-routes.ts",
       "line": 1163,
       "api": "withReadDb",
@@ -5114,14 +5100,14 @@
     },
     {
       "path": "yielding-writes.ts",
-      "line": 86,
+      "line": 115,
       "api": "withWriteTx",
       "source": "return accessor.withWriteTx(processBatch);",
       "category": "hot-path"
     },
     {
       "path": "yielding-writes.ts",
-      "line": 123,
+      "line": 155,
       "api": "withReadDb",
       "source": "const batch = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => fetchBatch(db, limit));",
       "category": "hot-path"

--- a/web/docs/src/content/docs/api/health-status.md
+++ b/web/docs/src/content/docs/api/health-status.md
@@ -38,6 +38,18 @@ and `GET /health/ready` for readiness.
     "timedOut": 0,
     "lastQueueWaitMs": 0
   },
+  "dbReader": {
+    "activeLeases": 2,
+    "maxConnections": 16,
+    "queued": 0,
+    "maxQueue": 64,
+    "oldestWaitMs": null,
+    "lastWaitMs": 0.4,
+    "rejected": 0,
+    "syncRejected": 0,
+    "cancelled": 0,
+    "timedOut": 0
+  },
   "dbRuntime": {
     "operations": {
       "read": { "count": 10, "p50Ms": 1.2, "p95Ms": 4.5, "p99Ms": 5.1, "maxMs": 5.1 },
@@ -51,7 +63,24 @@ and `GET /health/ready` for readiness.
     "rejected": 0,
     "timedOut": 0,
     "failed": 0,
-    "completed": 14
+    "completed": 14,
+    "eventLoopLag": {
+      "count": 20,
+      "p50Ms": 1.1,
+      "p95Ms": 3.2,
+      "p99Ms": 8.0,
+      "maxMs": 8.0
+    },
+    "queue": {
+      "readDepth": 0,
+      "readMaxDepth": 64,
+      "readOldestAgeMs": null,
+      "readActiveLeases": 2,
+      "writeDepth": 0,
+      "writeMaxDepth": 64,
+      "writeOldestAgeMs": null,
+      "writeActive": false
+    }
   },
   "shuttingDown": false,
   "updateAvailable": false,
@@ -71,6 +100,12 @@ and `GET /health/ready` for readiness.
   }
 }
 ```
+
+`dbReader` reports active read leases, FIFO waiter depth and age, bounded
+admission limits, and cancellation/rejection counts. `syncRejected` counts
+legacy synchronous read attempts rejected at the hard connection cap. The
+`dbRuntime.queue` snapshot reports current read/write depth, queue age, and
+active leases; `eventLoopLag` is the bounded independent event-loop sample.
 
 Memory resource values are MiB. On macOS, `physicalFootprint` and
 `peakPhysicalFootprint` come from `proc_pid_rusage` and include compressed
@@ -137,6 +172,30 @@ with a human-readable `reasons` list. Gates:
   "shuttingDown": false,
   "checks": {
     "db": true,
+    "dbReader": {
+      "activeLeases": 1,
+      "maxConnections": 16,
+      "queued": 0,
+      "maxQueue": 64,
+      "oldestWaitMs": null,
+      "lastWaitMs": 0.4,
+      "rejected": 0,
+      "syncRejected": 0,
+      "cancelled": 0,
+      "timedOut": 0
+    },
+    "dbRuntime": {
+      "queue": {
+        "readDepth": 0,
+        "readMaxDepth": 64,
+        "readOldestAgeMs": null,
+        "readActiveLeases": 1,
+        "writeDepth": 0,
+        "writeMaxDepth": 64,
+        "writeOldestAgeMs": null,
+        "writeActive": false
+      }
+    },
     "migrations": true,
     "embedding": {
       "provider": "ollama",

--- a/web/docs/src/content/docs/api/health-status.md
+++ b/web/docs/src/content/docs/api/health-status.md
@@ -30,7 +30,28 @@ and `GET /health/ready` for readiness.
     "queued": 0,
     "maxQueue": 64,
     "oldestWaitMs": null,
-    "lastDurationMs": 2.1
+    "lastDurationMs": 2.1,
+    "active": false,
+    "oldestOperation": null,
+    "rejected": 0,
+    "cancelled": 0,
+    "timedOut": 0,
+    "lastQueueWaitMs": 0
+  },
+  "dbRuntime": {
+    "operations": {
+      "read": { "count": 10, "p50Ms": 1.2, "p95Ms": 4.5, "p99Ms": 5.1, "maxMs": 5.1 },
+      "write": { "count": 4, "p50Ms": 2.1, "p95Ms": 8.0, "p99Ms": 8.0, "maxMs": 8.0 }
+    },
+    "queueWait": {
+      "read": { "count": 10, "p50Ms": 0, "p95Ms": 12, "p99Ms": 12, "maxMs": 12 },
+      "write": { "count": 4, "p50Ms": 0, "p95Ms": 25, "p99Ms": 25, "maxMs": 25 }
+    },
+    "cancelled": 0,
+    "rejected": 0,
+    "timedOut": 0,
+    "failed": 0,
+    "completed": 14
   },
   "shuttingDown": false,
   "updateAvailable": false,
@@ -71,11 +92,19 @@ subsystem, and always returns 200 while the process is alive.
   "pid": 12345,
   "version": "0.124.5",
   "port": 3850,
-  "shuttingDown": false
+  "shuttingDown": false,
+  "eventLoop": {
+    "status": "healthy",
+    "lagP95Ms": 3,
+    "lagP99Ms": 8
+  }
 }
 ```
 
-`status` is `"healthy"`, or `"shutting_down"` once shutdown has begun.
+`status` is `"healthy"`, or `"shutting_down"` once shutdown has begun. The
+`eventLoop` block is diagnostic only and does not make this independent probe
+depend on database availability. It reports bounded event-loop lag samples and
+may report `"degraded"` while the process still returns 200.
 
 The `@signet/daemon` service-management API uses this liveness endpoint for
 `getDaemonStatus()` with a 1.2-second deadline. Its returned `status` is


### PR DESCRIPTION
## Summary

Phase B for #1543 bounds database admission and makes pressure observable without putting the liveness probe behind the database. Read leases now use FIFO admission with a hard connection cap, bounded waiters, timeout, and cancellation. Write jobs carry operation metadata and cooperative deadlines, and batch helpers expose bounded checkpoints.

## Changes

- Added bounded read admission: four pooled connections, 16 maximum active connections, 64 FIFO waiters, timeout, cancellation, and pressure counters.
- Extended the write queue with operation name, enqueue/deadline metadata, estimated work units, cancellation, completion outcome, and queue age telemetry. The existing depth 64 cap remains the admission boundary.
- Added bounded operation and queue-wait percentiles plus event-loop lag telemetry at the database owner boundary.
- Added row, byte, and checkpoint callbacks to yielding write helpers. Existing `maxTxDurationMs` remains a cooperative checkpoint budget rather than a hard kill.
- Added independent `/health/live` event-loop diagnostics and database runtime pressure fields to `/health`.
- Documented the new health response fields.
- Added regression coverage for saturated read admission, timeout/cancellation, event-loop liveness, bounded checkpoints, byte budgets, and yielding.

## Type

<!-- Check one. -->

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

<!-- Check all that apply. -->

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `web/docs`

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

<!-- Derived from AGENTS.md recurring review failures. These checks are
     required and enforced by CI. -->

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations were added.

## Testing

<!-- How did you verify this works? -->

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused verification passed:

- `bun install --frozen-lockfile`
- `bun run --filter '@signet/core' build`
- `bun run --filter '@signet/daemon' build`
- `bun run --filter '@signet/docs' typecheck`
- `bun test platform/daemon/src/db-observability.test.ts platform/daemon/src/routes/health.test.ts platform/daemon/src/yielding-writes.test.ts` (20 passed, 0 failed)
- `bunx biome check` on all changed TypeScript files (0 errors, 3 pre-existing warnings)
- `git diff --check`

The changed packages pass their local lint, typecheck/build, and focused tests. The broader `bun run typecheck` remains blocked by pre-existing connector package export/type failures outside this change. The broader `db-accessor.test.ts` run has one pre-existing sqlite-construction ordering failure because `database-integrity-worker.ts` and `database-integrity.ts` already contain `new Database(` on the base branch. The new admission test and all focused tests pass.

## AI disclosure

<!-- See AI_POLICY.md for the full policy. The short version:

  Use AI freely, but understand everything you ship. AI is your hands,
  not your brain. Unreviewed AI output will be closed.

  If AI was used, include Assisted-by tags in your commit messages:

    Assisted-by: Claude-Code:claude-opus-4-6
    Assisted-by: Cursor:claude-sonnet-4-5 biome

  If no AI was used, check the box and move on.
-->

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- This is Phase B only. The actual off-main-thread SQLite/native owner boundary remains Phase C work.
- Async read callbacks still retain their lease for the callback lifetime. Future call-site migration should keep database leases around short database operations rather than unrelated awaits.
- Telemetry is bounded and process-local. It is intended for diagnosis, not durable accounting.
