### PR TITLE
feat(cli): attach to live Dreaming passes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,8 +52,8 @@
         "signet-connector-claude-code": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.200.7",
-        "@signet/core": "0.200.7",
+        "@signet/connector-base": "0.204.4",
+        "@signet/core": "0.204.4",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -67,8 +67,8 @@
         "signet-connector-codex": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.200.7",
-        "@signet/core": "0.200.7",
+        "@signet/connector-base": "0.204.4",
+        "@signet/core": "0.204.4",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -93,8 +93,8 @@
         "signet-connector-forge": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.200.7",
-        "@signet/core": "0.200.7",
+        "@signet/connector-base": "0.204.4",
+        "@signet/core": "0.204.4",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -108,8 +108,8 @@
         "signet-connector-gemini": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.200.7",
-        "@signet/core": "0.200.7",
+        "@signet/connector-base": "0.204.4",
+        "@signet/core": "0.204.4",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -123,8 +123,8 @@
         "signet-connector-hermes-agent": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.200.7",
-        "@signet/core": "0.200.7",
+        "@signet/connector-base": "0.204.4",
+        "@signet/core": "0.204.4",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -138,8 +138,8 @@
         "signet-connector-kimi": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "workspace:*",
-        "@signet/core": "workspace:*",
+        "@signet/connector-base": "0.204.4",
+        "@signet/core": "0.204.4",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -153,8 +153,8 @@
         "signet-connector-oh-my-pi": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.200.7",
-        "@signet/core": "0.200.7",
+        "@signet/connector-base": "0.204.4",
+        "@signet/core": "0.204.4",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -181,8 +181,8 @@
         "signet-connector-openclaw": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.200.7",
-        "@signet/core": "0.200.7",
+        "@signet/connector-base": "0.204.4",
+        "@signet/core": "0.204.4",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -214,8 +214,8 @@
         "signet-connector-opencode": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.200.7",
-        "@signet/core": "0.200.7",
+        "@signet/connector-base": "0.204.4",
+        "@signet/core": "0.204.4",
         "jsonc-parser": "3.3.1",
       },
       "devDependencies": {
@@ -246,8 +246,8 @@
         "signet-connector-pi": "bin/install.js",
       },
       "dependencies": {
-        "@signet/connector-base": "0.200.7",
-        "@signet/core": "0.200.7",
+        "@signet/connector-base": "0.204.4",
+        "@signet/core": "0.204.4",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -284,7 +284,7 @@
       "name": "@signet/connector-base",
       "version": "0.204.5",
       "dependencies": {
-        "@signet/core": "0.200.7",
+        "@signet/core": "0.204.4",
         "json5": "^2.2.3",
         "jsonc-parser": "3.3.1",
       },
@@ -361,6 +361,12 @@
         "sqlite-vec-linux-x64": "^0.1.7-alpha.2",
         "sqlite-vec-windows-x64": "^0.1.7-alpha.2",
       },
+      "peerDependencies": {
+        "better-sqlite3": "*",
+      },
+      "optionalPeers": [
+        "better-sqlite3",
+      ],
     },
     "platform/daemon": {
       "name": "@signet/daemon",
@@ -426,6 +432,7 @@
       "bin": "./dist/cli.js",
       "dependencies": {
         "@earendil-works/pi-ai": "0.83.0",
+        "@earendil-works/pi-tui": "0.83.0",
         "@inquirer/prompts": "^7.0.0",
         "@signet/connector-claude-code": "workspace:*",
         "@signet/connector-codex": "workspace:*",
@@ -2474,7 +2481,7 @@
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
-    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
@@ -3874,8 +3881,6 @@
 
     "@earendil-works/pi-coding-agent/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
-    "@earendil-works/pi-tui/get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
-
     "@electron/asar/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
 
     "@electron/asar/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
@@ -4268,6 +4273,8 @@
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
+    "string-width/get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
+
     "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -4614,8 +4621,6 @@
 
     "@astrojs/check/yargs/cliui/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
-    "@astrojs/check/yargs/string-width/get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
-
     "@astrojs/react/vite/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
 
     "@astrojs/react/vite/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg=="],
@@ -4785,6 +4790,8 @@
     "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@astrojs/check/yargs/cliui/string-width/get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
     "@astrojs/check/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 

--- a/docs/dreaming-skill-runbook.md
+++ b/docs/dreaming-skill-runbook.md
@@ -22,6 +22,27 @@ signet dream trigger
 signet dream trigger --compact
 ```
 
+For a live, read-only view of an in-flight pass, use:
+
+```bash
+signet dream attach
+signet dream attach --pass-id <pass-id>
+```
+
+`dream attach` selects the sole active pass for the current agent context. It
+refuses to guess when there are multiple active passes and lists their IDs,
+agents, modes, and start times; use `--pass-id` to choose one. With no active
+pass it exits non-zero and points back to `signet dream status`. The daemon
+owns the Pi session and the CLI only follows its scoped SSE event stream, so
+the attach view has no chat input, steering, retry, cancellation, or mutation
+control. Press **Ctrl+C** to detach without affecting the pass. Press
+**Ctrl+V** to toggle the in-place raw verbose view; raw prompts, instructions,
+reasoning, evidence, and tool payloads may be visible in that mode. Toggling
+the mode briefly reconnects the same SSE stream with the raw-data opt-in; the
+default transport omits those fields. The stream reconnects from its bounded
+cursor when possible and reports a replay gap when older events are no longer
+available.
+
 Invalid or rejected operations are recorded without stalling the selected
 evidence cursor. Use an ontology proposal only for broad or explicitly reviewed
 semantic refactors.

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -1,6 +1,6 @@
 import { readFile as readFileAsync, stat as statAsync } from "node:fs/promises";
 import { isAbsolute, join, normalize, resolve } from "node:path";
-import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import type { AgentSessionEvent, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type {
 	AcpxModelSelection,
 	LlmGenerateResult,
@@ -1029,6 +1029,14 @@ export class InferenceRouter {
 			readonly timeoutMs?: number;
 			readonly maxTokens?: number;
 			readonly refresh?: boolean;
+			/** Synchronous observer for the in-process Pi session event stream. */
+			readonly onEvent?: (event: AgentSessionEvent) => void;
+			/** Synchronous observer for the session's non-message context. */
+			readonly onSessionInfo?: (info: {
+				readonly sessionId?: string;
+				readonly model?: string;
+				readonly systemPrompt?: string;
+			}) => void;
 			readonly acpxMcp?: {
 				readonly agentId: string;
 				readonly passId: string;
@@ -1106,6 +1114,7 @@ export class InferenceRouter {
 						throw error;
 					}
 					let session: PiAgentSession | undefined;
+					let unsubscribeSessionEvents: (() => void) | undefined;
 					let releaseDeferred = false;
 					const remainingBeforeInitialization = deadline === undefined ? undefined : deadline - performance.now();
 					const initializationController = new AbortController();
@@ -1140,6 +1149,25 @@ export class InferenceRouter {
 							throw initializationTimeout ?? new PiAgentSessionTimeoutError(deadlineMs, Promise.resolve());
 						if (initializationTimer) clearTimeout(initializationTimer);
 						initializationTimer = undefined;
+						if (opts?.onSessionInfo) {
+							try {
+								opts.onSessionInfo({
+									sessionId: session.getSessionId?.(),
+									model: session.getModelName?.(),
+									systemPrompt: session.getSystemPrompt?.(),
+								});
+							} catch {
+								// Observers cannot change the provider/session result.
+							}
+						}
+						if (opts?.onEvent && session.subscribe) {
+							try {
+								unsubscribeSessionEvents = session.subscribe(opts.onEvent);
+							} catch {
+								// Event observation is optional; keep the Pi run usable when
+								// an older provider wrapper lacks the subscription seam.
+							}
+						}
 						// AgentSession owns an internal model loop, so acquire the
 						// process-wide permit before initialization and hold it until
 						// the whole session is disposed. This prevents tool-driven
@@ -1177,6 +1205,11 @@ export class InferenceRouter {
 						);
 					} finally {
 						if (initializationTimer) clearTimeout(initializationTimer);
+						try {
+							unsubscribeSessionEvents?.();
+						} finally {
+							unsubscribeSessionEvents = undefined;
+						}
 						if (!releaseDeferred) {
 							try {
 								session?.dispose();

--- a/platform/daemon/src/pipeline/dreaming-live-events.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-live-events.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+import {
+	DREAMING_LIVE_MAX_EVENTS,
+	DREAMING_LIVE_MAX_EVENT_CHARS,
+	DREAMING_LIVE_MAX_RAW_CHARS,
+	DreamingLiveEventHub,
+	boundDreamingLiveValue,
+	publishDreamingAgentEvent,
+	publishDreamingSessionInfo,
+} from "./dreaming-live-events";
+
+describe("Dreaming live event hub", () => {
+	it("keeps cursors monotonic and delivers terminal state to subscribers", () => {
+		const hub = new DreamingLiveEventHub();
+		hub.startPass({ passId: "pass-1", agentId: "agent-a", mode: "incremental" });
+		const received: number[] = [];
+		const subscription = hub.subscribe("pass-1", 0, (event) => received.push(event.cursor));
+
+		expect(subscription?.replay.map((event) => event.type)).toEqual(["pass_started"]);
+		hub.publish("pass-1", "assistant_delta", { delta: "hello" });
+		hub.finish("pass-1", "completed", { summary: "done" });
+
+		expect(received).toEqual([2, 3]);
+		expect(hub.getSnapshot("pass-1")).toEqual(
+			expect.objectContaining({ status: "completed", summary: "done", cursor: 3 }),
+		);
+		expect(hub.getSubscriberCount("pass-1")).toBe(1);
+		subscription?.unsubscribe();
+		expect(hub.getSubscriberCount("pass-1")).toBe(0);
+	});
+
+	it("reports a replay gap after the bounded buffer is exhausted", () => {
+		const hub = new DreamingLiveEventHub();
+		hub.startPass({ passId: "pass-2", agentId: "agent-a", mode: "incremental" });
+		for (let index = 0; index < DREAMING_LIVE_MAX_EVENTS + 20; index += 1) {
+			hub.publish("pass-2", "lifecycle", { index });
+		}
+
+		const subscription = hub.subscribe("pass-2", 0, () => {});
+		expect(subscription?.gap).toEqual(expect.objectContaining({ requestedCursor: 0, reason: "buffer_exhausted" }));
+		expect(subscription?.replay.length).toBe(DREAMING_LIVE_MAX_EVENTS);
+		expect(subscription?.replay[0]?.cursor).toBeGreaterThan(1);
+		subscription?.unsubscribe();
+	});
+
+	it("bounds raw payloads and translates Pi lifecycle events without awaiting", () => {
+		const hub = new DreamingLiveEventHub();
+		hub.startPass({ passId: "pass-3", agentId: "agent-a", mode: "incremental" });
+		const events: Array<{ type: string; data: Readonly<Record<string, unknown>> }> = [];
+		const subscription = hub.subscribe("pass-3", null, (event) => events.push(event));
+
+		publishDreamingAgentEvent(
+			"pass-3",
+			{
+				type: "tool_execution_start",
+				toolCallId: "tool-1",
+				toolName: "search_evidence",
+				arguments: "x".repeat(DREAMING_LIVE_MAX_RAW_CHARS * 2),
+			},
+			hub,
+		);
+		publishDreamingSessionInfo("pass-3", { sessionId: "session-1", systemPrompt: "system".repeat(10_000) }, hub);
+
+		const raw = events.find((event) => event.type === "tool_start")?.data.raw;
+		const sessionRaw = events.find((event) => event.type === "session_info")?.data.raw;
+		expect(JSON.stringify(raw).length).toBeLessThanOrEqual(DREAMING_LIVE_MAX_RAW_CHARS + 100);
+		expect(JSON.stringify(sessionRaw).length).toBeLessThanOrEqual(DREAMING_LIVE_MAX_RAW_CHARS + 100);
+		for (const event of events)
+			expect(JSON.stringify(event.data).length).toBeLessThanOrEqual(DREAMING_LIVE_MAX_EVENT_CHARS);
+		expect(boundDreamingLiveValue("x".repeat(DREAMING_LIVE_MAX_RAW_CHARS * 2))).toEqual(
+			expect.objectContaining({ truncated: true }),
+		);
+		subscription?.unsubscribe();
+	});
+});

--- a/platform/daemon/src/pipeline/dreaming-live-events.ts
+++ b/platform/daemon/src/pipeline/dreaming-live-events.ts
@@ -1,0 +1,535 @@
+/**
+ * Ephemeral live-event bridge for an in-flight Dreaming pass.
+ *
+ * The database remains the durable source of pass and tool-call audit data.
+ * This module only keeps a small in-process replay window for read-only
+ * observers. Event delivery is deliberately synchronous: a subscriber must
+ * enqueue or drop its own notification and must never perform awaited work in
+ * the Dreaming agent's event callback.
+ */
+
+export const DREAMING_LIVE_MAX_EVENTS = 256;
+export const DREAMING_LIVE_MAX_SUBSCRIBERS = 16;
+export const DREAMING_LIVE_MAX_PASSES = 32;
+export const DREAMING_LIVE_MAX_EVENT_CHARS = 48_000;
+export const DREAMING_LIVE_MAX_RAW_CHARS = 16_000;
+export const DREAMING_LIVE_HEARTBEAT_MS = 15_000;
+export const DREAMING_LIVE_TERMINAL_RETENTION_MS = 10 * 60_000;
+
+export type DreamingLiveEventType =
+	| "pass_started"
+	| "session_info"
+	| "agent_start"
+	| "agent_end"
+	| "turn_start"
+	| "turn_end"
+	| "message_start"
+	| "message_update"
+	| "message_end"
+	| "assistant_delta"
+	| "thinking_delta"
+	| "tool_start"
+	| "tool_progress"
+	| "tool_end"
+	| "tool_trace"
+	| "lifecycle"
+	| "pass_completed"
+	| "pass_failed";
+
+export interface DreamingLiveEvent {
+	readonly passId: string;
+	readonly agentId: string;
+	readonly cursor: number;
+	readonly timestamp: string;
+	readonly type: DreamingLiveEventType;
+	readonly data: Readonly<Record<string, unknown>>;
+}
+
+export interface DreamingLivePassInput {
+	readonly passId: string;
+	readonly agentId: string;
+	readonly mode: string;
+	readonly startedAt?: string;
+}
+
+export interface DreamingLivePassMetadata {
+	readonly passId: string;
+	readonly agentId: string;
+	readonly mode: string;
+	readonly status: string;
+	readonly startedAt: string;
+	readonly completedAt: string | null;
+	readonly summary: string | null;
+	readonly error: string | null;
+}
+
+export interface DreamingLivePassSnapshot extends DreamingLivePassMetadata {
+	readonly cursor: number;
+	readonly replayFrom: number | null;
+	readonly replayTo: number | null;
+}
+
+export interface DreamingLiveGap {
+	readonly requestedCursor: number;
+	readonly availableFrom: number | null;
+	readonly availableTo: number;
+	readonly reason: "buffer_exhausted" | "cursor_ahead";
+}
+
+export interface DreamingLiveSubscription {
+	readonly snapshot: DreamingLivePassSnapshot;
+	readonly replay: readonly DreamingLiveEvent[];
+	readonly gap: DreamingLiveGap | null;
+	readonly unsubscribe: () => void;
+}
+
+export type DreamingLiveEventListener = (event: DreamingLiveEvent) => void;
+
+interface LivePass {
+	metadata: DreamingLivePassMetadata;
+	nextCursor: number;
+	events: DreamingLiveEvent[];
+	subscribers: Set<DreamingLiveEventListener>;
+	lastTouchedAt: number;
+}
+
+function nowIso(): string {
+	return new Date().toISOString();
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? { ...(value as Record<string, unknown>) }
+		: {};
+}
+
+function safeJson(value: unknown): string {
+	try {
+		const json = JSON.stringify(value);
+		return json === undefined ? "null" : json;
+	} catch (error) {
+		return JSON.stringify({ serializationError: error instanceof Error ? error.message : String(error) });
+	}
+}
+
+function truncatedJsonValue(serialized: string, maxChars: number): Readonly<Record<string, unknown>> {
+	const base = { truncated: true, originalChars: serialized.length };
+	let preview = serialized.slice(0, Math.max(0, maxChars - safeJson(base).length - 16));
+	let result = { ...base, preview };
+	while (safeJson(result).length > maxChars && preview.length > 0) {
+		preview = preview.slice(0, Math.max(0, preview.length - Math.max(1, Math.ceil(preview.length / 10))));
+		result = { ...base, preview };
+	}
+	return result;
+}
+
+/** Bound a raw Pi object before it enters the replay buffer or SSE payload. */
+export function boundDreamingLiveValue(value: unknown, maxChars = DREAMING_LIVE_MAX_RAW_CHARS): unknown {
+	const json = safeJson(value);
+	if (json.length <= maxChars) return value;
+	return truncatedJsonValue(json, maxChars);
+}
+
+function boundString(value: string, maxChars: number): string {
+	return value.length <= maxChars ? value : `${value.slice(0, maxChars)}…`;
+}
+
+function boundMetadataString(value: string, maxChars = 512): string {
+	return boundString(value, maxChars);
+}
+
+function boundNullableMetadataString(value: string | null | undefined, maxChars: number): string | null {
+	return value == null ? null : boundString(value, maxChars);
+}
+
+function boundEventData(value: Readonly<Record<string, unknown>>): Readonly<Record<string, unknown>> {
+	const data: Record<string, unknown> = {};
+	for (const [key, rawValue] of Object.entries(value)) {
+		if (key === "raw") {
+			data[key] = boundDreamingLiveValue(rawValue, DREAMING_LIVE_MAX_RAW_CHARS);
+		} else if (typeof rawValue === "string") {
+			data[key] = boundString(rawValue, 12_000);
+		} else {
+			data[key] = boundDreamingLiveValue(rawValue, 12_000);
+		}
+	}
+
+	const serialized = safeJson(data);
+	if (serialized.length <= DREAMING_LIVE_MAX_EVENT_CHARS) return data;
+	const compact: Record<string, unknown> = {};
+	for (const [key, rawValue] of Object.entries(data)) {
+		if (key === "raw") {
+			compact[key] = boundDreamingLiveValue(rawValue, 4_000);
+		} else if (typeof rawValue === "string") {
+			compact[key] = boundString(rawValue, 2_000);
+		} else {
+			compact[key] = boundDreamingLiveValue(rawValue, 4_000);
+		}
+	}
+	const compactSerialized = safeJson(compact);
+	if (compactSerialized.length <= DREAMING_LIVE_MAX_EVENT_CHARS) return compact;
+	return truncatedJsonValue(serialized, DREAMING_LIVE_MAX_EVENT_CHARS);
+}
+
+function metadataFromInput(input: DreamingLivePassInput): DreamingLivePassMetadata {
+	return {
+		passId: boundMetadataString(input.passId),
+		agentId: boundMetadataString(input.agentId),
+		mode: boundMetadataString(input.mode),
+		status: "running",
+		startedAt: boundMetadataString(input.startedAt ?? nowIso(), 128),
+		completedAt: null,
+		summary: null,
+		error: null,
+	};
+}
+
+function isTerminal(status: string): boolean {
+	return status !== "running";
+}
+
+function isTerminalEvent(event: DreamingLiveEvent): boolean {
+	return event.type === "pass_completed" || event.type === "pass_failed";
+}
+
+/** In-memory bounded event hub shared by the daemon's Dreaming worker/routes. */
+export class DreamingLiveEventHub {
+	private readonly passes = new Map<string, LivePass>();
+
+	startPass(input: DreamingLivePassInput): void {
+		this.prune();
+		const existing = this.passes.get(input.passId);
+		if (existing) {
+			existing.metadata = {
+				...existing.metadata,
+				agentId: boundMetadataString(input.agentId),
+				mode: boundMetadataString(input.mode),
+				startedAt: boundMetadataString(input.startedAt ?? existing.metadata.startedAt, 128),
+			};
+			existing.lastTouchedAt = Date.now();
+			return;
+		}
+		// Live observation is optional. If every retained pass is actively
+		// viewed, decline this in-process registration rather than growing the
+		// map or displacing another operator's stream.
+		if (this.passes.size >= DREAMING_LIVE_MAX_PASSES) return;
+
+		const pass: LivePass = {
+			metadata: metadataFromInput(input),
+			nextCursor: 1,
+			events: [],
+			subscribers: new Set(),
+			lastTouchedAt: Date.now(),
+		};
+		this.passes.set(input.passId, pass);
+		this.append(pass, "pass_started", {
+			agentId: input.agentId,
+			mode: input.mode,
+			startedAt: pass.metadata.startedAt,
+		});
+	}
+
+	/** Create route visibility for a pass recovered from the durable database. */
+	ensurePass(
+		input: DreamingLivePassInput & Partial<Omit<DreamingLivePassMetadata, keyof DreamingLivePassInput>>,
+	): void {
+		const existing = this.passes.get(input.passId);
+		if (!existing) {
+			this.startPass(input);
+			const created = this.passes.get(input.passId);
+			if (created) {
+				created.metadata = {
+					...created.metadata,
+					status: boundMetadataString(input.status ?? created.metadata.status),
+					completedAt: boundNullableMetadataString(input.completedAt ?? created.metadata.completedAt, 128),
+					summary: boundNullableMetadataString(input.summary ?? created.metadata.summary, 12_000),
+					error: boundNullableMetadataString(input.error ?? created.metadata.error, 12_000),
+				};
+				this.appendRecoveredTerminal(created);
+			}
+			return;
+		}
+		// A route lookup can observe the durable row just before the worker
+		// publishes its terminal event. Never let that stale running row reopen
+		// an already-finished in-memory pass on reconnect.
+		if (isTerminal(existing.metadata.status) && (input.status === undefined || input.status === "running")) {
+			existing.lastTouchedAt = Date.now();
+			return;
+		}
+		existing.metadata = {
+			...existing.metadata,
+			status: boundMetadataString(input.status ?? existing.metadata.status),
+			completedAt: boundNullableMetadataString(input.completedAt ?? existing.metadata.completedAt, 128),
+			summary: boundNullableMetadataString(input.summary ?? existing.metadata.summary, 12_000),
+			error: boundNullableMetadataString(input.error ?? existing.metadata.error, 12_000),
+		};
+		existing.lastTouchedAt = Date.now();
+		this.appendRecoveredTerminal(existing);
+	}
+
+	publish(passId: string, type: DreamingLiveEventType, data: Readonly<Record<string, unknown>> = {}): void {
+		const pass = this.passes.get(passId);
+		if (!pass || (isTerminal(pass.metadata.status) && type !== "pass_completed" && type !== "pass_failed")) return;
+		this.append(pass, type, data);
+	}
+
+	finish(
+		passId: string,
+		status: "completed" | "failed" | "cancelled",
+		data: { readonly summary?: string | null; readonly error?: string | null; readonly [key: string]: unknown } = {},
+	): void {
+		const pass = this.passes.get(passId);
+		if (!pass) return;
+		if (isTerminal(pass.metadata.status)) return;
+		const completedAt = nowIso();
+		const summary = typeof data.summary === "string" ? boundString(data.summary, 12_000) : null;
+		const error = typeof data.error === "string" ? boundString(data.error, 12_000) : null;
+		pass.metadata = { ...pass.metadata, status, completedAt, summary, error };
+		this.append(pass, status === "completed" ? "pass_completed" : "pass_failed", {
+			...data,
+			status,
+			completedAt,
+			...(summary === null ? {} : { summary }),
+			...(error === null ? {} : { error }),
+		});
+	}
+
+	getSnapshot(passId: string): DreamingLivePassSnapshot | null {
+		const pass = this.passes.get(passId);
+		if (!pass) return null;
+		return this.snapshot(pass);
+	}
+
+	subscribe(
+		passId: string,
+		afterCursor: number | null,
+		listener: DreamingLiveEventListener,
+	): DreamingLiveSubscription | null {
+		const pass = this.passes.get(passId);
+		if (!pass) return null;
+		if (pass.subscribers.size >= DREAMING_LIVE_MAX_SUBSCRIBERS) {
+			throw new Error("Too many viewers are attached to this Dreaming pass");
+		}
+
+		pass.subscribers.add(listener);
+		pass.lastTouchedAt = Date.now();
+		const requested = afterCursor ?? 0;
+		const latest = pass.nextCursor - 1;
+		const first = pass.events[0]?.cursor ?? null;
+		let gap: DreamingLiveGap | null = null;
+		if (requested > latest) {
+			gap = {
+				requestedCursor: requested,
+				availableFrom: first,
+				availableTo: latest,
+				reason: "cursor_ahead",
+			};
+		} else if (first !== null && requested < first - 1) {
+			gap = {
+				requestedCursor: requested,
+				availableFrom: first,
+				availableTo: latest,
+				reason: "buffer_exhausted",
+			};
+		}
+		const replay = pass.events.filter((event) => event.cursor > requested);
+		let subscribed = true;
+		return {
+			snapshot: this.snapshot(pass),
+			replay,
+			gap,
+			unsubscribe: () => {
+				if (!subscribed) return;
+				subscribed = false;
+				pass.subscribers.delete(listener);
+				pass.lastTouchedAt = Date.now();
+			},
+		};
+	}
+
+	getSubscriberCount(passId?: string): number {
+		if (passId === undefined)
+			return [...this.passes.values()].reduce((total, pass) => total + pass.subscribers.size, 0);
+		return this.passes.get(passId)?.subscribers.size ?? 0;
+	}
+
+	reset(): void {
+		this.passes.clear();
+	}
+
+	private append(pass: LivePass, type: DreamingLiveEventType, input: Readonly<Record<string, unknown>>): void {
+		const event: DreamingLiveEvent = {
+			passId: pass.metadata.passId,
+			agentId: pass.metadata.agentId,
+			cursor: pass.nextCursor++,
+			timestamp: nowIso(),
+			type,
+			data: boundEventData(asRecord(input)),
+		};
+		pass.events.push(event);
+		if (pass.events.length > DREAMING_LIVE_MAX_EVENTS)
+			pass.events.splice(0, pass.events.length - DREAMING_LIVE_MAX_EVENTS);
+		pass.lastTouchedAt = Date.now();
+		for (const listener of [...pass.subscribers]) {
+			try {
+				listener(event);
+			} catch {
+				// A disconnected or malformed viewer must not affect Dreaming.
+			}
+		}
+	}
+
+	private snapshot(pass: LivePass): DreamingLivePassSnapshot {
+		return {
+			...pass.metadata,
+			cursor: pass.nextCursor - 1,
+			replayFrom: pass.events[0]?.cursor ?? null,
+			replayTo: pass.events.at(-1)?.cursor ?? null,
+		};
+	}
+
+	private appendRecoveredTerminal(pass: LivePass): void {
+		if (!isTerminal(pass.metadata.status) || pass.events.some((event) => isTerminalEvent(event))) return;
+		this.append(pass, pass.metadata.status === "completed" ? "pass_completed" : "pass_failed", {
+			status: pass.metadata.status,
+			completedAt: pass.metadata.completedAt,
+			...(pass.metadata.summary === null ? {} : { summary: pass.metadata.summary }),
+			...(pass.metadata.error === null ? {} : { error: pass.metadata.error }),
+		});
+	}
+
+	private prune(): void {
+		const cutoff = Date.now() - DREAMING_LIVE_TERMINAL_RETENTION_MS;
+		for (const [passId, pass] of this.passes) {
+			if (pass.subscribers.size === 0 && isTerminal(pass.metadata.status) && pass.lastTouchedAt < cutoff) {
+				this.passes.delete(passId);
+			}
+		}
+		if (this.passes.size < DREAMING_LIVE_MAX_PASSES) return;
+		const candidates = [...this.passes.entries()]
+			.filter(([, pass]) => pass.subscribers.size === 0)
+			.sort(([, left], [, right]) => {
+				const leftTerminal = isTerminal(left.metadata.status) ? 0 : 1;
+				const rightTerminal = isTerminal(right.metadata.status) ? 0 : 1;
+				return leftTerminal - rightTerminal || left.lastTouchedAt - right.lastTouchedAt;
+			});
+		for (const [passId] of candidates) {
+			if (this.passes.size < DREAMING_LIVE_MAX_PASSES) break;
+			this.passes.delete(passId);
+		}
+	}
+}
+
+export const dreamingLiveEvents = new DreamingLiveEventHub();
+
+function textFromContent(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (Array.isArray(value))
+		return value
+			.map((item) => textFromContent(item))
+			.filter(Boolean)
+			.join("");
+	if (typeof value !== "object" || value === null) return "";
+	const record = value as Record<string, unknown>;
+	if (typeof record.text === "string") return record.text;
+	if (typeof record.content === "string") return record.content;
+	return textFromContent(record.content);
+}
+
+function rawEventData(event: Record<string, unknown>): Record<string, unknown> {
+	return { raw: boundDreamingLiveValue(event) };
+}
+
+/** Translate Pi AgentSession events into the stable remote Dreaming event model. */
+export function publishDreamingAgentEvent(passId: string, input: unknown, hub = dreamingLiveEvents): void {
+	const event = asRecord(input);
+	const type = typeof event.type === "string" ? event.type : "unknown";
+	const raw = rawEventData(event);
+	switch (type) {
+		case "message_update": {
+			const assistantEvent = asRecord(event.assistantMessageEvent);
+			if (assistantEvent.type === "text_delta") {
+				hub.publish(passId, "assistant_delta", { delta: assistantEvent.delta ?? "", ...raw });
+				return;
+			}
+			if (assistantEvent.type === "thinking_delta") {
+				hub.publish(passId, "thinking_delta", { delta: assistantEvent.delta ?? "", ...raw });
+				return;
+			}
+			hub.publish(passId, "message_update", { eventType: assistantEvent.type ?? "unknown", ...raw });
+			return;
+		}
+		case "tool_execution_start":
+			hub.publish(passId, "tool_start", {
+				toolCallId: event.toolCallId ?? null,
+				toolName: event.toolName ?? "unknown",
+				...raw,
+			});
+			return;
+		case "tool_execution_update":
+			hub.publish(passId, "tool_progress", {
+				toolCallId: event.toolCallId ?? null,
+				toolName: event.toolName ?? "unknown",
+				...raw,
+			});
+			return;
+		case "tool_execution_end":
+			hub.publish(passId, "tool_end", {
+				toolCallId: event.toolCallId ?? null,
+				toolName: event.toolName ?? "unknown",
+				success: event.isError !== true,
+				...raw,
+			});
+			return;
+		case "agent_start":
+			hub.publish(passId, "agent_start", raw);
+			return;
+		case "agent_end":
+			hub.publish(passId, "agent_end", raw);
+			return;
+		case "turn_start":
+			hub.publish(passId, "turn_start", raw);
+			return;
+		case "turn_end":
+			hub.publish(passId, "turn_end", raw);
+			return;
+		case "message_start":
+		case "message_end": {
+			const message = asRecord(event.message);
+			const role = typeof message.role === "string" ? message.role : "unknown";
+			const text = textFromContent(message.content);
+			const data = { role, ...(role === "assistant" && text ? { text } : {}), ...raw };
+			hub.publish(passId, type, data);
+			return;
+		}
+		default:
+			hub.publish(passId, "lifecycle", { eventType: type, ...raw });
+	}
+}
+
+export function publishDreamingSessionInfo(
+	passId: string,
+	info: { readonly sessionId?: string; readonly model?: string; readonly systemPrompt?: string },
+	hub = dreamingLiveEvents,
+): void {
+	hub.publish(passId, "session_info", {
+		...(info.sessionId ? { sessionId: info.sessionId } : {}),
+		...(info.model ? { model: info.model } : {}),
+		// The prompt is intentionally present only in the opt-in raw channel.
+		raw: boundDreamingLiveValue({ systemPrompt: info.systemPrompt ?? "" }),
+	});
+}
+
+export function publishDreamingToolTrace(
+	passId: string,
+	trace: { readonly toolCallId: string; readonly tool: string; readonly output: unknown; readonly latencyMs: number },
+	hub = dreamingLiveEvents,
+): void {
+	hub.publish(passId, "tool_trace", {
+		toolCallId: trace.toolCallId,
+		toolName: trace.tool,
+		success: asRecord(trace.output).ok === true,
+		latencyMs: Math.max(0, Math.floor(trace.latencyMs)),
+		raw: boundDreamingLiveValue(trace),
+	});
+}

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -238,6 +238,8 @@ export function startDreamingWorker(
 					{
 						timeoutMs: input.timeoutMs,
 						maxTokens: input.maxTokens,
+						onEvent: input.onEvent,
+						onSessionInfo: input.onSessionInfo,
 						...(options.acpxMcp
 							? {
 									acpxMcp: {

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -83,6 +83,13 @@ import {
 	selectDreamingSurprisalInDb,
 } from "./dreaming-surprisal";
 import { DreamingBacklogTokenCache, type DreamingBacklogTokenEntry } from "./dreaming-token-cache";
+import {
+	dreamingLiveEvents,
+	publishDreamingAgentEvent,
+	publishDreamingSessionInfo,
+	publishDreamingToolTrace,
+	type DreamingLiveEventHub,
+} from "./dreaming-live-events";
 import { countTokens } from "./tokenizer";
 
 async function writeTx<T>(accessor: DbAccessor, fn: (db: WriteDb) => T): Promise<T> {
@@ -229,7 +236,7 @@ export function _testParseEpisodicCursor(value: string | null): EpisodicCursor |
 	return parseEpisodicCursor(value);
 }
 
-interface DreamingPassRow {
+export interface DreamingPassRow {
 	readonly id: string;
 	readonly mode: string;
 	readonly status: string;
@@ -324,6 +331,12 @@ export interface DreamingAgentExecutor {
 		readonly tools: ReturnType<typeof createDreamingAgentTools>;
 		readonly timeoutMs: number;
 		readonly maxTokens: number;
+		readonly onEvent?: (event: unknown) => void;
+		readonly onSessionInfo?: (info: {
+			readonly sessionId?: string;
+			readonly model?: string;
+			readonly systemPrompt?: string;
+		}) => void;
 	}): Promise<{
 		readonly summary?: string;
 		readonly usage?: LlmUsage | null;
@@ -512,6 +525,7 @@ export async function createDreamingPass(accessor: DbAccessor, agentId: string, 
 			 VALUES (?, ?, ?, 'running', strftime('%Y-%m-%d %H:%M:%f', 'now'), strftime('%Y-%m-%d %H:%M:%f', 'now'))`,
 		).run(id, agentId, mode);
 	});
+	dreamingLiveEvents.startPass({ passId: id, agentId, mode });
 	return id;
 }
 
@@ -551,6 +565,52 @@ export async function getDreamingPasses(
 			)
 			.all(agentId, limit) as DreamingPassRow[];
 	});
+}
+
+export interface DreamingPassScope extends DreamingPassRow {
+	readonly agentId: string;
+}
+
+function dreamingPassSelect(includeAgent = false): string {
+	return `SELECT ${includeAgent ? "agent_id AS agentId, " : ""}id, mode, status, started_at AS startedAt,
+				completed_at AS completedAt, tokens_consumed AS tokensConsumed,
+				tokens_input AS tokensInput, tokens_output AS tokensOutput,
+				tokens_cache_read AS tokensCacheRead, tokens_cache_write AS tokensCacheWrite,
+				tokens_cost AS tokensCost,
+				mutations_applied AS mutationsApplied,
+				mutations_skipped AS mutationsSkipped,
+				mutations_failed AS mutationsFailed,
+				summary, error
+			 FROM dreaming_passes`;
+}
+
+export async function getDreamingPass(
+	accessor: DbAccessor,
+	agentId: string,
+	passId: string,
+): Promise<DreamingPassScope | null> {
+	return readDb(
+		accessor,
+		(db) =>
+			(db.prepare(`${dreamingPassSelect(true)} WHERE agent_id = ? AND id = ? LIMIT 1`).get(agentId, passId) as
+				| DreamingPassScope
+				| undefined) ?? null,
+	);
+}
+
+export async function getActiveDreamingPasses(
+	accessor: DbAccessor,
+	agentId: string,
+): Promise<readonly DreamingPassScope[]> {
+	return readDb(
+		accessor,
+		(db) =>
+			db
+				.prepare(
+					`${dreamingPassSelect(true)} WHERE agent_id = ? AND status = 'running' ORDER BY started_at ASC, id ASC`,
+				)
+				.all(agentId) as DreamingPassScope[],
+	);
 }
 
 const MAX_DREAMING_TOOL_TRACE_JSON_CHARS = 128_000;
@@ -1029,6 +1089,11 @@ export function selectDreamingPassMode(
  * exclusion/cursor bookkeeping, tool construction, and audited writes.
  */
 
+export interface DreamingPassLiveOptions {
+	/** Test seam; production uses the process-local ephemeral event hub. */
+	readonly hub?: DreamingLiveEventHub;
+}
+
 /**
  * Anonymous telemetry for a completed agentic dreaming pass: provider-reported
  * token usage and cost so dreaming economics show up in PostHog alongside
@@ -1390,8 +1455,12 @@ export async function runDreamingAgentPass(
 	mode: DreamingMode,
 	existingPassId?: string,
 	writeCaps?: GraphWriteCaps,
+	liveOptions?: DreamingPassLiveOptions,
 ): Promise<{ passId: string; applied: number; skipped: number; failed: number; summary: string }> {
 	const passId = existingPassId ?? (await createDreamingPass(accessor, agentId, mode));
+	const live = liveOptions?.hub ?? dreamingLiveEvents;
+	live.startPass({ passId, agentId, mode });
+	live.publish(passId, "lifecycle", { phase: "preparing", mode });
 	const passStartedAtMs = Date.now();
 	const effects = createDreamingPassEffectState();
 	let toolCallSequence = 0;
@@ -1476,6 +1545,7 @@ export async function runDreamingAgentPass(
 				durationMs: Date.now() - passStartedAtMs,
 				queueAgeMs: 0,
 			});
+			live.finish(passId, "completed", { summary: earlyExitSummary, outcome: "no_work" });
 			return { passId, applied: 0, skipped: 0, failed: 0, summary: earlyExitSummary };
 		}
 
@@ -1506,6 +1576,7 @@ export async function runDreamingAgentPass(
 				rejectedEvidence.push(...collectRejectedDreamingEvidence(accessor, scopeId, result, operations));
 			},
 			async onToolCall(trace) {
+				publishDreamingToolTrace(passId, trace, live);
 				await recordDreamingToolCall(accessor, agentId, passId, ++toolCallSequence, trace);
 				if (trace.tool === "search_evidence" && trace.output.ok === true && Array.isArray(trace.output.items)) {
 					const input = isRecord(trace.input) ? trace.input : null;
@@ -1573,6 +1644,8 @@ export async function runDreamingAgentPass(
 			tools,
 			timeoutMs: cfg.timeout,
 			maxTokens: cfg.maxOutputTokens,
+			onEvent: (event) => publishDreamingAgentEvent(passId, event, live),
+			onSessionInfo: (info) => publishDreamingSessionInfo(passId, info, live),
 		});
 		const summary = `${executorResult.summary?.trim() || "Agentic Dreaming pass completed"}`;
 		const attribution = executorResult.attribution ?? null;
@@ -1698,6 +1771,12 @@ export async function runDreamingAgentPass(
 			durationMs: Date.now() - passStartedAtMs,
 			queueAgeMs: 0,
 		});
+		live.finish(passId, "completed", {
+			summary,
+			applied,
+			failed,
+			outcome,
+		});
 
 		return { passId, applied, skipped: 0, failed, summary };
 	} catch (error) {
@@ -1707,6 +1786,7 @@ export async function runDreamingAgentPass(
 		try {
 			await failDreamingPass(accessor, passId, message);
 		} finally {
+			live.finish(passId, isDreamingPassCancellation(error) ? "cancelled" : "failed", { error: message });
 			recordDreamingPassTelemetry({
 				mode,
 				outcome: isDreamingPassCancellation(error) ? "cancelled" : "failed",

--- a/platform/daemon/src/pipeline/index.ts
+++ b/platform/daemon/src/pipeline/index.ts
@@ -48,6 +48,8 @@ export {
 	getDreamingToolCalls,
 	getDreamingState,
 	getDreamingPasses,
+	getDreamingPass,
+	getActiveDreamingPasses,
 	recordDreamingFailure,
 	requestDreamingEvidenceRequeue,
 } from "./dreaming";
@@ -55,6 +57,14 @@ export { getDreamingAttention } from "./dreaming-attention";
 export { getDreamingWorkloadDiagnostics } from "./dreaming";
 export { getDreamingQualityReport } from "./dreaming-quality";
 export type { DreamingSchedulerStatus, DreamingWorkerHandle } from "./dreaming-worker";
+export {
+	dreamingLiveEvents,
+	DreamingLiveEventHub,
+	DREAMING_LIVE_HEARTBEAT_MS,
+	type DreamingLiveEvent,
+	type DreamingLivePassSnapshot,
+	type DreamingLiveGap,
+} from "./dreaming-live-events";
 
 /** Get the active synthesis worker handle (for API routes). */
 export function getSynthesisWorker(): SynthesisWorkerHandle | null {

--- a/platform/daemon/src/pipeline/pi-provider.ts
+++ b/platform/daemon/src/pipeline/pi-provider.ts
@@ -22,6 +22,7 @@ import {
 	DefaultResourceLoader,
 	ModelRuntime,
 	SessionManager,
+	type AgentSessionEvent,
 	type SessionStats,
 	SettingsManager,
 	type ToolDefinition,
@@ -112,6 +113,12 @@ export interface PiAgentSession {
 	prompt(text: string): Promise<void>;
 	abort(): Promise<void>;
 	dispose(): void;
+	/** Forward the underlying Pi event stream without making it durable. */
+	subscribe?(listener: (event: AgentSessionEvent) => void): () => void;
+	/** Session context used by the opt-in Dreaming live viewer. */
+	getSystemPrompt?(): string;
+	getSessionId?(): string;
+	getModelName?(): string | undefined;
 	getActiveToolNames(): readonly string[];
 	getFailureMessage(): string | undefined;
 	/**
@@ -746,6 +753,10 @@ export function createPiModelProvider(
 				prompt: (text) => session.prompt(text),
 				abort: () => session.abort(),
 				dispose: () => session.dispose(),
+				subscribe: (listener) => session.subscribe(listener),
+				getSystemPrompt: () => session.systemPrompt,
+				getSessionId: () => session.sessionId,
+				getModelName: () => session.model?.id,
 				getActiveToolNames: () => session.getActiveToolNames(),
 				getStats: () => session.getSessionStats(),
 				getRequestUsages: () =>

--- a/platform/daemon/src/routes/pipeline-routes-dreaming-live.test.ts
+++ b/platform/daemon/src/routes/pipeline-routes-dreaming-live.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Hono } from "hono";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
+import { dreamingLiveEvents, publishDreamingAgentEvent } from "../pipeline/dreaming-live-events";
+import { registerPipelineRoutes } from "./pipeline-routes";
+
+const originalAgentId = process.env.SIGNET_AGENT_ID;
+
+describe("Dreaming live routes", () => {
+	let agentsDir = "";
+
+	beforeEach(() => {
+		agentsDir = mkdtempSync(join(tmpdir(), "signet-dreaming-live-route-"));
+		mkdirSync(join(agentsDir, "memory"), { recursive: true });
+		initDbAccessor(join(agentsDir, "memory", "memories.db"), { agentsDir });
+		process.env.SIGNET_AGENT_ID = "agent-a";
+		getDbAccessor().withWriteTx((db) => {
+			for (const [id, agentId, mode] of [
+				["live-pass-a", "agent-a", "incremental"],
+				["live-pass-b", "agent-b", "compact"],
+			] as const) {
+				db.prepare(
+					`INSERT INTO dreaming_passes (id, agent_id, mode, status, started_at, created_at)
+					 VALUES (?, ?, ?, 'running', '2026-08-05 00:00:00', '2026-08-05 00:00:00')`,
+				).run(id, agentId, mode);
+			}
+		});
+		dreamingLiveEvents.reset();
+	});
+
+	afterEach(() => {
+		dreamingLiveEvents.reset();
+		closeDbAccessor();
+		rmSync(agentsDir, { recursive: true, force: true });
+		if (originalAgentId === undefined) Reflect.deleteProperty(process.env, "SIGNET_AGENT_ID");
+		else process.env.SIGNET_AGENT_ID = originalAgentId;
+	});
+
+	it("lists only the current agent's active passes and rejects another agent's stream", async () => {
+		const app = new Hono();
+		registerPipelineRoutes(app);
+
+		const activeResponse = await app.request("/api/dream/passes/active");
+		expect(activeResponse.status).toBe(200);
+		expect(await activeResponse.json()).toMatchObject({
+			agentId: "agent-a",
+			items: [{ id: "live-pass-a", agentId: "agent-a", mode: "incremental", status: "running" }],
+		});
+
+		const crossAgentResponse = await app.request("/api/dream/passes/live-pass-b/events");
+		expect(crossAgentResponse.status).toBe(404);
+	});
+
+	it("emits an initial snapshot over the scoped SSE stream", async () => {
+		const app = new Hono();
+		registerPipelineRoutes(app);
+		const response = await app.request("/api/dream/passes/live-pass-a/events");
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toContain("text/event-stream");
+		const reader = response.body?.getReader();
+		if (!reader) throw new Error("SSE response did not expose a body");
+		const first = await reader.read();
+		await reader.cancel();
+		const text = new TextDecoder().decode(first.value);
+		expect(text.startsWith("event: snapshot\n")).toBe(true);
+		expect(text).toContain("event: snapshot");
+		expect(text).toContain('"passId":"live-pass-a"');
+	});
+
+	it("keeps raw payloads out of concise transport until verbose mode is requested", async () => {
+		const app = new Hono();
+		registerPipelineRoutes(app);
+		dreamingLiveEvents.startPass({ passId: "live-pass-a", agentId: "agent-a", mode: "incremental" });
+		publishDreamingAgentEvent(
+			"live-pass-a",
+			{ type: "tool_execution_start", toolCallId: "tool-1", toolName: "search_evidence", secret: "raw-secret" },
+			dreamingLiveEvents,
+		);
+		publishDreamingAgentEvent(
+			"live-pass-a",
+			{ type: "message_update", assistantMessageEvent: { type: "thinking_delta", delta: "raw-reasoning" } },
+			dreamingLiveEvents,
+		);
+
+		const readChunks = async (response: Response, needle: string): Promise<string> => {
+			const reader = response.body?.getReader();
+			if (!reader) throw new Error("SSE response did not expose a body");
+			let text = "";
+			for (let index = 0; index < 4 && !text.includes(needle); index += 1) {
+				const chunk = await reader.read();
+				if (chunk.done) break;
+				text += new TextDecoder().decode(chunk.value);
+			}
+			await reader.cancel();
+			return text;
+		};
+
+		const concise = await readChunks(
+			await app.request("/api/dream/passes/live-pass-a/events?after=1"),
+			"event: tool_start",
+		);
+		const conciseReasoning = await readChunks(
+			await app.request("/api/dream/passes/live-pass-a/events?after=2"),
+			"event: thinking_delta",
+		);
+		const verbose = await readChunks(
+			await app.request("/api/dream/passes/live-pass-a/events?after=1&verbose=1"),
+			"event: tool_start",
+		);
+		expect(concise).toContain("event: tool_start");
+		expect(concise).not.toContain("raw-secret");
+		expect(conciseReasoning).not.toContain("raw-reasoning");
+		expect(verbose).toContain("raw-secret");
+	});
+});

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -20,6 +20,8 @@ import {
 	getDreamingEpisodicTokenBacklog,
 	getDreamingEvidenceExclusions,
 	getDreamingPasses,
+	getDreamingPass,
+	getActiveDreamingPasses,
 	getDreamingQualityReport,
 	getDreamingState,
 	getDreamingToolCalls,
@@ -28,6 +30,11 @@ import {
 	getPipelineWorkerStatus,
 	requestDreamingEvidenceRequeue,
 } from "../pipeline";
+import {
+	DREAMING_LIVE_HEARTBEAT_MS,
+	dreamingLiveEvents,
+	type DreamingLiveEvent,
+} from "../pipeline/dreaming-live-events";
 import { getFeedbackTelemetry } from "../pipeline/aspect-feedback.js";
 import { getDreamingCapability, getDreamingCapabilityManifest } from "../pipeline/dreaming-capabilities.js";
 import { DREAMING_MAX_OPERATIONS_PER_REQUEST, applyDreamingOperations } from "../pipeline/dreaming-operations.js";
@@ -210,6 +217,35 @@ function resolveScopedDreamAgent(
 ): { readonly agentId: string; readonly error?: string } {
 	return resolveScopedAgentId(c, requestedDreamAgentId(c, body), resolveDaemonAgentId());
 }
+
+function parseDreamingCursor(value: string | undefined): number | null | "invalid" {
+	if (value === undefined || value.trim() === "") return null;
+	if (!/^\d+$/.test(value.trim())) return "invalid";
+	const cursor = Number.parseInt(value, 10);
+	return Number.isSafeInteger(cursor) && cursor >= 0 ? cursor : "invalid";
+}
+
+function sseEncode(eventName: string, data: unknown, cursor?: number): Uint8Array {
+	const id = cursor === undefined ? "" : `id: ${cursor}\n`;
+	return new TextEncoder().encode(`${id}event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+function isTerminalDreamingEvent(event: DreamingLiveEvent): boolean {
+	return event.type === "pass_completed" || event.type === "pass_failed";
+}
+
+function dreamingEventForTransport(event: DreamingLiveEvent, verbose: boolean): DreamingLiveEvent {
+	if (verbose) return event;
+	if (event.type === "thinking_delta") return { ...event, data: { redacted: true } };
+	if (!("raw" in event.data)) return event;
+	const { raw: _raw, ...conciseData } = event.data;
+	return { ...event, data: conciseData };
+}
+
+// A ReadableStream will otherwise keep accepting chunks while a client is
+// paused. Closing a full stream lets the viewer reconnect from its last SSE id
+// instead of allowing one slow terminal to accumulate an unbounded queue.
+const DREAMING_LIVE_STREAM_QUEUE_SIZE = 64;
 
 async function togglePipelinePause(c: Context, paused: boolean): Promise<Response> {
 	if (pipelineTransition) {
@@ -687,10 +723,10 @@ export function registerPipelineRoutes(app: Hono): void {
 		if (scopedAgent.error) return c.json({ error: scopedAgent.error }, 403);
 		const agentId = scopedAgent.agentId;
 
-		const state = getDreamingState(accessor, agentId);
+		const state = await getDreamingState(accessor, agentId);
 		const episodicTokensPending = await getDreamingEpisodicTokenBacklog(accessor, agentId);
-		const passes = getDreamingPasses(accessor, agentId, 10);
-		const exclusions = getDreamingEvidenceExclusions(accessor, agentId);
+		const passes = await getDreamingPasses(accessor, agentId, 10);
+		const exclusions = await getDreamingEvidenceExclusions(accessor, agentId);
 		const attention = getDreamingAttention(accessor, agentId);
 		const worker = getDreamingWorker();
 
@@ -717,11 +753,155 @@ export function registerPipelineRoutes(app: Hono): void {
 		});
 	});
 
+	/** List active passes for read-only attach selection in one agent scope. */
+	app.get("/api/dream/passes/active", async (c) => {
+		const scopedAgent = resolveScopedDreamAgent(c);
+		if (scopedAgent.error) return c.json({ error: scopedAgent.error }, 403);
+		return c.json({
+			agentId: scopedAgent.agentId,
+			items: await getActiveDreamingPasses(getDbAccessor(), scopedAgent.agentId),
+		});
+	});
+
+	/**
+	 * Stream one scoped Dreaming pass. The stream is observation-only: it has
+	 * no request body and no action that can steer, abort, or retry the pass.
+	 */
+	app.get("/api/dream/passes/:passId/events", async (c) => {
+		const scopedAgent = resolveScopedDreamAgent(c);
+		if (scopedAgent.error) return c.json({ error: scopedAgent.error }, 403);
+		const passId = c.req.param("passId").trim();
+		if (!passId) return c.json({ error: "Missing Dreaming pass id" }, 400);
+		const pass = await getDreamingPass(getDbAccessor(), scopedAgent.agentId, passId);
+		if (!pass) return c.json({ error: "Dreaming pass not found" }, 404);
+
+		const cursorValue = c.req.query("after") ?? c.req.header("last-event-id");
+		const afterCursor = parseDreamingCursor(cursorValue);
+		if (afterCursor === "invalid") return c.json({ error: "after/Last-Event-ID must be a non-negative integer" }, 400);
+		const verbose = c.req.query("verbose") === "1" || c.req.query("verbose") === "true";
+
+		dreamingLiveEvents.ensurePass({
+			passId: pass.id,
+			agentId: pass.agentId,
+			mode: pass.mode,
+			startedAt: pass.startedAt,
+			status: pass.status,
+			completedAt: pass.completedAt,
+			summary: pass.summary,
+			error: pass.error,
+		});
+
+		const encoder = new TextEncoder();
+		let closed = false;
+		let heartbeat: ReturnType<typeof setInterval> | undefined;
+		let subscription: ReturnType<typeof dreamingLiveEvents.subscribe> | null = null;
+		let controllerRef: ReadableStreamDefaultController<Uint8Array> | undefined;
+		const requestSignal = c.req.raw.signal;
+		const close = (): void => {
+			if (closed) return;
+			closed = true;
+			if (heartbeat) clearInterval(heartbeat);
+			subscription?.unsubscribe();
+			requestSignal.removeEventListener("abort", close);
+			try {
+				controllerRef?.close();
+			} catch {
+				// The client may already have cancelled the stream.
+			}
+		};
+		const write = (eventName: string, data: unknown, cursor?: number): void => {
+			if (closed || !controllerRef) return;
+			if (controllerRef.desiredSize !== null && controllerRef.desiredSize <= 0) {
+				close();
+				return;
+			}
+			try {
+				controllerRef.enqueue(sseEncode(eventName, data, cursor));
+			} catch {
+				close();
+			}
+		};
+
+		const stream = new ReadableStream<Uint8Array>(
+			{
+				start(controller) {
+					controllerRef = controller;
+					requestSignal.addEventListener("abort", close, { once: true });
+					if (requestSignal.aborted) {
+						close();
+						return;
+					}
+					const writeLiveEvent = (event: DreamingLiveEvent): void => {
+						const transported = dreamingEventForTransport(event, verbose);
+						write(transported.type, transported, transported.cursor);
+						if (isTerminalDreamingEvent(event)) close();
+					};
+					try {
+						subscription = dreamingLiveEvents.subscribe(passId, afterCursor, (event) => {
+							writeLiveEvent(event);
+						});
+					} catch (error) {
+						write("error", { error: error instanceof Error ? error.message : String(error) });
+						close();
+						return;
+					}
+					if (!subscription) {
+						write("error", { error: "Dreaming pass live stream is unavailable" });
+						close();
+						return;
+					}
+					// Snapshot/gap frames describe state but do not claim the replay
+					// cursor. Replay and live event ids must remain the only resume
+					// checkpoints so a disconnect cannot skip older replay frames.
+					write("snapshot", { type: "snapshot", passId, snapshot: subscription.snapshot });
+					if (subscription.gap) {
+						write("gap", { type: "gap", passId, gap: subscription.gap });
+					}
+					for (const event of subscription.replay) {
+						writeLiveEvent(event);
+					}
+					if (closed || requestSignal.aborted) {
+						close();
+						return;
+					}
+					if (subscription.snapshot.status !== "running") {
+						close();
+						return;
+					}
+					heartbeat = setInterval(() => {
+						if (closed || !controllerRef) return;
+						if (controllerRef.desiredSize !== null && controllerRef.desiredSize <= 0) {
+							close();
+							return;
+						}
+						try {
+							controllerRef.enqueue(encoder.encode(`: heartbeat ${Date.now()}\n\n`));
+						} catch {
+							close();
+						}
+					}, DREAMING_LIVE_HEARTBEAT_MS);
+					heartbeat.unref?.();
+				},
+				cancel: close,
+			},
+			{ highWaterMark: DREAMING_LIVE_STREAM_QUEUE_SIZE, size: () => 1 },
+		);
+
+		return new Response(stream, {
+			headers: {
+				"Content-Type": "text/event-stream",
+				"Cache-Control": "no-cache, no-transform",
+				Connection: "keep-alive",
+				"X-Accel-Buffering": "no",
+			},
+		});
+	});
+
 	/**
 	 * Review the exact capability calls a Pi Dreaming agent made during one
 	 * scoped pass. The trace is local, agent-scoped, and never written to logs.
 	 */
-	app.get("/api/dream/passes/:passId/tools", (c) => {
+	app.get("/api/dream/passes/:passId/tools", async (c) => {
 		const scopedAgent = resolveScopedDreamAgent(c);
 		if (scopedAgent.error) return c.json({ error: scopedAgent.error }, 403);
 		const passId = c.req.param("passId").trim();
@@ -729,7 +909,7 @@ export function registerPipelineRoutes(app: Hono): void {
 		return c.json({
 			agentId: scopedAgent.agentId,
 			passId,
-			items: getDreamingToolCalls(getDbAccessor(), scopedAgent.agentId, passId),
+			items: await getDreamingToolCalls(getDbAccessor(), scopedAgent.agentId, passId),
 		});
 	});
 

--- a/scripts/evals/dream-attach.ts
+++ b/scripts/evals/dream-attach.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env bun
+/**
+ * Deterministic Dreaming attach eval (#1601).
+ *
+ * Exercises the bounded daemon event bridge and the read-only CLI stream
+ * consumer with fixed local inputs. It fails if replay cursors are not
+ * monotonic, raw payloads escape their bound, the viewer cannot resume from a
+ * cursor, or the concise/raw and detach controls are not isolated.
+ */
+
+import {
+	DREAMING_LIVE_MAX_EVENTS,
+	DREAMING_LIVE_MAX_EVENT_CHARS,
+	DREAMING_LIVE_MAX_RAW_CHARS,
+	DreamingLiveEventHub,
+	publishDreamingAgentEvent,
+} from "../../platform/daemon/src/pipeline/dreaming-live-events";
+import type { DaemonStreamResult } from "../../surfaces/cli/src/lib/daemon";
+import { DreamingAttachView, followDreamingPass } from "../../surfaces/cli/src/lib/dream-attach";
+
+function streamResult(body: string): DaemonStreamResult {
+	return { ok: true, response: new Response(body, { headers: { "content-type": "text/event-stream" } }) };
+}
+
+const hub = new DreamingLiveEventHub();
+hub.startPass({ passId: "eval-pass", agentId: "eval-agent", mode: "incremental" });
+for (let index = 0; index < DREAMING_LIVE_MAX_EVENTS + 8; index += 1) {
+	hub.publish("eval-pass", "lifecycle", { index });
+}
+const replay = hub.subscribe("eval-pass", 0, () => {});
+const replayCursors = replay?.replay.map((event) => event.cursor) ?? [];
+const monotonicReplay = replayCursors.every((cursor, index) => index === 0 || cursor > (replayCursors[index - 1] ?? 0));
+const boundedEvents = replayCursors.length <= DREAMING_LIVE_MAX_EVENTS && replay?.gap?.reason === "buffer_exhausted";
+replay?.unsubscribe();
+
+const rawHub = new DreamingLiveEventHub();
+rawHub.startPass({ passId: "eval-raw", agentId: "eval-agent", mode: "incremental" });
+publishDreamingAgentEvent(
+	"eval-raw",
+	{
+		type: "tool_execution_start",
+		toolCallId: "tool-1",
+		toolName: "search_evidence",
+		arguments: "raw-argument-".repeat(DREAMING_LIVE_MAX_RAW_CHARS),
+	},
+	rawHub,
+);
+const rawEvents = rawHub.subscribe("eval-raw", 0, () => {})?.replay ?? [];
+const rawPayload = rawEvents.find((event) => event.type === "tool_start")?.data;
+const boundedRaw = rawPayload !== undefined && JSON.stringify(rawPayload).length <= DREAMING_LIVE_MAX_EVENT_CHARS;
+
+let detached = false;
+const view = new DreamingAttachView(() => {
+	detached = true;
+});
+view.applySnapshot({
+	passId: "eval-stream",
+	agentId: "eval-agent",
+	mode: "incremental",
+	status: "running",
+	startedAt: new Date(Date.now() - 2_000).toISOString(),
+	completedAt: null,
+	summary: null,
+	error: null,
+	cursor: 1,
+	replayFrom: 1,
+	replayTo: 1,
+});
+view.applyEvent({
+	passId: "eval-stream",
+	agentId: "eval-agent",
+	cursor: 2,
+	timestamp: new Date().toISOString(),
+	type: "tool_start",
+	data: { toolName: "search_evidence", raw: { secret: "operator-opt-in" } },
+});
+const concise = view.render(120).join("\n");
+view.handleInput("\u0016");
+const verbose = view.render(120).join("\n");
+view.handleInput("\u0003");
+
+const paths: string[] = [];
+const streamView = new DreamingAttachView(() => {});
+const terminal = await followDreamingPass({
+	passId: "eval-stream",
+	fetchStream: async (path): Promise<DaemonStreamResult> => {
+		paths.push(path);
+		return streamResult(
+			[
+				`event: snapshot\ndata: ${JSON.stringify({
+					type: "snapshot",
+					passId: "eval-stream",
+					snapshot: {
+						passId: "eval-stream",
+						agentId: "eval-agent",
+						mode: "incremental",
+						status: "running",
+						startedAt: new Date().toISOString(),
+						completedAt: null,
+						summary: null,
+						error: null,
+						cursor: 1,
+						replayFrom: 1,
+						replayTo: 1,
+					},
+				})}\n\n`,
+				`id: 2\nevent: pass_completed\ndata: ${JSON.stringify({
+					type: "pass_completed",
+					passId: "eval-stream",
+					agentId: "eval-agent",
+					cursor: 2,
+					timestamp: new Date().toISOString(),
+					data: { status: "completed", summary: "eval complete" },
+				})}\n\n`,
+			].join(""),
+		);
+	},
+	view: streamView,
+	signal: new AbortController().signal,
+	maxReconnects: 1,
+	sleep: async () => {},
+});
+
+const checks = {
+	monotonicReplay,
+	boundedEvents,
+	boundedRaw,
+	conciseHidesRaw: !concise.includes("operator-opt-in"),
+	verboseShowsRaw: verbose.includes("operator-opt-in"),
+	ctrlCDetaches: detached,
+	terminalEventCompletes: terminal && streamView.cursor === 2,
+	resumesFromInitialCursor: paths[0] === "/api/dream/passes/eval-stream/events",
+};
+const verdict = Object.values(checks).every(Boolean) ? "pass" : "fail";
+const report = {
+	verdict,
+	checks,
+	replayEvents: replayCursors.length,
+	maxReplayEvents: DREAMING_LIVE_MAX_EVENTS,
+	maxRawChars: DREAMING_LIVE_MAX_RAW_CHARS,
+};
+console.log(JSON.stringify(report, null, 2));
+process.exit(verdict === "pass" ? 0 : 1);

--- a/surfaces/cli/package.json
+++ b/surfaces/cli/package.json
@@ -44,6 +44,7 @@
 	"dependencies": {
 		"@signet/core": "workspace:*",
 		"@earendil-works/pi-ai": "0.83.0",
+		"@earendil-works/pi-tui": "0.83.0",
 		"@signet/connector-claude-code": "workspace:*",
 		"@signet/connector-codex": "workspace:*",
 		"@signet/connector-forge": "workspace:*",

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -1079,7 +1079,10 @@ async function ensureDaemonForSecrets(): Promise<boolean> {
 	return ensureDaemonRunning(isDaemonRunning);
 }
 
-const { fetchFromDaemon, fetchDaemonResult, secretApiCall } = createDaemonClient(DEFAULT_PORT, AGENTS_DIR);
+const { fetchFromDaemon, fetchDaemonResult, fetchDaemonStream, secretApiCall } = createDaemonClient(
+	DEFAULT_PORT,
+	AGENTS_DIR,
+);
 const offlineSecretApiCall = createOfflineSecretApiCall();
 const secretCommandApiCall = async (
 	method: string,
@@ -1221,6 +1224,7 @@ registerSessionCommands(program, {
 registerDreamCommands(program, {
 	fetchFromDaemon,
 	fetchDaemonResult,
+	fetchDaemonStream,
 });
 
 // ============================================================================

--- a/surfaces/cli/src/commands/dream.test.ts
+++ b/surfaces/cli/src/commands/dream.test.ts
@@ -355,3 +355,55 @@ describe("dream trigger pass diagnostics", () => {
 		}
 	});
 });
+
+describe("dream attach selection", () => {
+	it("refuses to open an empty view when no pass is active", async () => {
+		const calls: string[] = [];
+		const fetchDaemonResult = mockFetch(async (path: string) => {
+			calls.push(path);
+			return okResult({ agentId: "default", items: [] });
+		});
+		const program = new Command();
+		registerDreamCommands(program, { ...makeDeps(), fetchDaemonResult });
+		const capture = captureOutput();
+		const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("EXIT_1");
+		});
+		try {
+			await expect(program.parseAsync(["node", "test", "dream", "attach"])).rejects.toThrow("EXIT_1");
+			expect(calls).toEqual(["/api/dream/passes/active"]);
+			expect(capture.errorLines.join("\n")).toContain("signet dream status");
+		} finally {
+			exitSpy.mockRestore();
+			capture.restore();
+		}
+	});
+
+	it("requires explicit selection when multiple passes are active", async () => {
+		const fetchDaemonResult = mockFetch(async () =>
+			okResult({
+				agentId: "default",
+				items: [
+					{ id: "pass-a", mode: "incremental", status: "running", startedAt: "2026-08-05T00:00:00.000Z" },
+					{ id: "pass-b", mode: "compact", status: "running", startedAt: "2026-08-05T00:01:00.000Z" },
+				],
+			}),
+		);
+		const program = new Command();
+		registerDreamCommands(program, { ...makeDeps(), fetchDaemonResult });
+		const capture = captureOutput();
+		const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("EXIT_1");
+		});
+		try {
+			await expect(program.parseAsync(["node", "test", "dream", "attach"])).rejects.toThrow("EXIT_1");
+			const output = capture.errorLines.join("\n");
+			expect(output).toContain("--pass-id");
+			expect(output).toContain("pass-a");
+			expect(output).toContain("pass-b");
+		} finally {
+			exitSpy.mockRestore();
+			capture.restore();
+		}
+	});
+});

--- a/surfaces/cli/src/commands/dream.ts
+++ b/surfaces/cli/src/commands/dream.ts
@@ -1,6 +1,12 @@
 import chalk from "chalk";
 import type { Command } from "commander";
-import type { DaemonFetch, DaemonFetchFailure, DaemonFetchResult } from "../lib/daemon.js";
+import type { DaemonFetch, DaemonFetchFailure, DaemonFetchResult, DaemonStreamResult } from "../lib/daemon.js";
+import {
+	createDreamingAttachTui,
+	DreamingAttachError,
+	DreamingAttachView,
+	followDreamingPass,
+} from "../lib/dream-attach.js";
 
 interface DreamDeps {
 	readonly fetchFromDaemon: DaemonFetch;
@@ -8,6 +14,7 @@ interface DreamDeps {
 		path: string,
 		opts?: RequestInit & { timeout?: number },
 	) => Promise<DaemonFetchResult<T>>;
+	readonly fetchDaemonStream?: (path: string, opts?: RequestInit & { timeout?: number }) => Promise<DaemonStreamResult>;
 	/** Poll cadence for `dream trigger` (test seams; defaults match production). */
 	readonly pollIntervalMs?: number;
 	readonly minWaitMs?: number;
@@ -51,6 +58,15 @@ interface DreamStatus {
 		readonly backfillOnFirstRun: boolean;
 	};
 	readonly passes: readonly DreamPass[];
+}
+
+interface ActiveDreamPass extends DreamPass {
+	readonly agentId: string;
+}
+
+interface ActiveDreamingResponse {
+	readonly agentId: string;
+	readonly items: readonly ActiveDreamPass[];
 }
 
 interface TriggerAccepted {
@@ -249,6 +265,93 @@ export function registerDreamCommands(program: Command, deps: DreamDeps): void {
 				}
 			}
 			console.log();
+		});
+
+	dream
+		.command("attach")
+		.description("Attach a read-only live view to a running Dreaming pass (Ctrl+V toggles raw mode; Ctrl+C detaches)")
+		.option("--pass-id <id>", "Explicit Dreaming pass id when more than one pass is active")
+		.action(async (options: { passId?: string }) => {
+			let passId = options.passId?.trim() || undefined;
+			if (!passId) {
+				const activeResult = await deps.fetchDaemonResult<ActiveDreamingResponse>("/api/dream/passes/active");
+				if (!activeResult.ok) {
+					if (activeResult.reason === "http" && activeResult.error) {
+						console.error(chalk.red(`Failed to find an active Dreaming pass: ${activeResult.error}`));
+					} else {
+						reportDaemonUnavailable(activeResult.reason, activeResult.status, "Failed to find an active Dreaming pass");
+					}
+					process.exit(1);
+					return;
+				}
+				if (activeResult.data.items.length === 0) {
+					console.error(chalk.yellow("No Dreaming pass is currently active."));
+					console.error(chalk.dim("  Run `signet dream status` to inspect recent passes."));
+					process.exit(1);
+					return;
+				}
+				if (activeResult.data.items.length > 1) {
+					console.error(chalk.yellow("Multiple Dreaming passes are active; choose one with --pass-id:"));
+					for (const pass of activeResult.data.items) {
+						console.error(`  ${pass.id}  agent=${pass.agentId}  mode=${pass.mode}  started=${pass.startedAt}`);
+					}
+					process.exit(1);
+					return;
+				}
+				passId = activeResult.data.items[0]?.id;
+			}
+			if (!passId) {
+				console.error(chalk.red("No Dreaming pass id was selected."));
+				process.exit(1);
+				return;
+			}
+			if (!deps.fetchDaemonStream) {
+				console.error(chalk.red("Live Dreaming attach is unavailable in this CLI build."));
+				process.exit(1);
+				return;
+			}
+			if (!process.stdin.isTTY || !process.stdout.isTTY) {
+				console.error(chalk.red("`signet dream attach` requires an interactive terminal."));
+				console.error(chalk.dim("  Use `signet dream status` for a non-interactive snapshot."));
+				process.exit(1);
+				return;
+			}
+
+			const abortController = new AbortController();
+			const detach = () => abortController.abort();
+			let requestRender = () => {};
+			const liveView = new DreamingAttachView(detach, () => requestRender());
+			const ui = createDreamingAttachTui(liveView);
+			requestRender = () => ui.tui.requestRender();
+			const onSignal = () => abortController.abort();
+			process.once("SIGINT", onSignal);
+			process.once("SIGTERM", onSignal);
+			try {
+				ui.tui.start();
+				await followDreamingPass({
+					passId,
+					fetchStream: deps.fetchDaemonStream,
+					view: liveView,
+					signal: abortController.signal,
+				});
+			} catch (error) {
+				if (!abortController.signal.aborted) {
+					const message =
+						error instanceof DreamingAttachError
+							? error.message
+							: error instanceof Error
+								? error.message
+								: String(error);
+					console.error(chalk.red(`Dreaming attach failed: ${message}`));
+					process.exitCode = 1;
+				}
+			} finally {
+				abortController.abort();
+				process.removeListener("SIGINT", onSignal);
+				process.removeListener("SIGTERM", onSignal);
+				ui.tui.stop();
+				await ui.terminal.drainInput(1_000, 50).catch(() => undefined);
+			}
 		});
 
 	dream

--- a/surfaces/cli/src/lib/daemon.ts
+++ b/surfaces/cli/src/lib/daemon.ts
@@ -19,6 +19,16 @@ export type DaemonFetchResult<T> =
 			readonly body?: unknown;
 	  };
 
+export type DaemonStreamResult =
+	| { readonly ok: true; readonly response: Response }
+	| {
+			readonly ok: false;
+			readonly reason: DaemonFetchFailure;
+			readonly status?: number;
+			readonly error?: string;
+			readonly body?: unknown;
+	  };
+
 export type DaemonApiCall = (
 	method: string,
 	path: string,
@@ -68,6 +78,27 @@ function withAuthHeaders(headers?: HeadersInit): Headers {
 	return merged;
 }
 
+function createStreamAbortSignal(
+	callerSignal: AbortSignal | undefined,
+	timeoutMs: number | undefined,
+): { readonly signal: AbortSignal | undefined; readonly cleanup: () => void } {
+	if (!callerSignal && !(timeoutMs && timeoutMs > 0)) return { signal: undefined, cleanup: () => {} };
+	if (!timeoutMs || timeoutMs <= 0) return { signal: callerSignal, cleanup: () => {} };
+
+	const controller = new AbortController();
+	const abortFromCaller = () => controller.abort(callerSignal?.reason);
+	if (callerSignal?.aborted) abortFromCaller();
+	else callerSignal?.addEventListener("abort", abortFromCaller, { once: true });
+	const timeout = setTimeout(() => controller.abort(new DOMException("Request timed out", "TimeoutError")), timeoutMs);
+	return {
+		signal: controller.signal,
+		cleanup: () => {
+			clearTimeout(timeout);
+			callerSignal?.removeEventListener("abort", abortFromCaller);
+		},
+	};
+}
+
 export function createDaemonClient(
 	port: number,
 	agentsDir?: string,
@@ -78,6 +109,7 @@ export function createDaemonClient(
 		path: string,
 		opts?: RequestInit & { timeout?: number },
 	) => Promise<DaemonFetchResult<T>>;
+	readonly fetchDaemonStream: (path: string, opts?: RequestInit & { timeout?: number }) => Promise<DaemonStreamResult>;
 	readonly secretApiCall: DaemonApiCall;
 } {
 	const url = resolveDaemonClientUrl(port, agentsDir);
@@ -112,6 +144,35 @@ export function createDaemonClient(
 				return { ok: false, reason: "timeout" };
 			}
 			return { ok: false, reason: "offline" };
+		}
+	};
+
+	const fetchDaemonStream = async (
+		path: string,
+		opts?: RequestInit & { timeout?: number },
+	): Promise<DaemonStreamResult> => {
+		const { timeout, ...fetchOpts } = opts || {};
+		// Bound only the initial HTTP handshake. Once headers arrive, the SSE
+		// body is intentionally long-lived and is cancelled by the caller's
+		// attachment signal instead.
+		const streamSignal = createStreamAbortSignal(fetchOpts.signal ?? undefined, timeout ?? 5_000);
+		try {
+			const res = await fetch(`${url}${path}`, {
+				...fetchOpts,
+				headers: withAuthHeaders(fetchOpts.headers),
+				signal: streamSignal.signal,
+			});
+			if (!res.ok) {
+				const response = await readHttpErrorBody(res);
+				return { ok: false, reason: "http", status: res.status, ...response };
+			}
+			if (!res.body) return { ok: false, reason: "invalid-json", status: res.status };
+			return { ok: true, response: res };
+		} catch (err) {
+			if (isTimeoutError(err)) return { ok: false, reason: "timeout" };
+			return { ok: false, reason: "offline" };
+		} finally {
+			streamSignal.cleanup();
 		}
 	};
 
@@ -163,6 +224,7 @@ export function createDaemonClient(
 		url,
 		fetchFromDaemon,
 		fetchDaemonResult,
+		fetchDaemonStream,
 		secretApiCall,
 	};
 }

--- a/surfaces/cli/src/lib/dream-attach.test.ts
+++ b/surfaces/cli/src/lib/dream-attach.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "bun:test";
+import type { DaemonStreamResult } from "./daemon.js";
+import {
+	DreamingAttachError,
+	DreamingAttachView,
+	followDreamingPass,
+	parseDreamingAttachEnvelope,
+	parseSseEventBlock,
+	readSseStream,
+} from "./dream-attach.js";
+
+function streamResult(body: string): DaemonStreamResult {
+	return { ok: true, response: new Response(body, { headers: { "content-type": "text/event-stream" } }) };
+}
+
+describe("Dreaming attach stream", () => {
+	it("parses comments, ids, and multiline SSE data", () => {
+		const parsed = parseSseEventBlock(': heartbeat\nid: 7\nevent: snapshot\ndata: {\ndata: "ok": true\ndata: }\n\n');
+		if (!parsed) throw new Error("expected an SSE event");
+		expect(parsed).toEqual({ event: "snapshot", id: "7", data: '{\n"ok": true\n}' });
+		expect(parseDreamingAttachEnvelope(parsed)).toEqual({ ok: true });
+	});
+
+	it("renders concise output by default and exposes raw data after Ctrl+V", () => {
+		const view = new DreamingAttachView(() => {});
+		view.applySnapshot({
+			passId: "pass-1",
+			agentId: "agent-a",
+			mode: "incremental",
+			status: "running",
+			startedAt: "2026-08-05T00:00:00.000Z",
+			completedAt: null,
+			summary: null,
+			error: null,
+			cursor: 1,
+			replayFrom: 1,
+			replayTo: 1,
+		});
+		view.applyEvent({
+			passId: "pass-1",
+			agentId: "agent-a",
+			cursor: 2,
+			timestamp: "2026-08-05T00:00:01.000Z",
+			type: "tool_start",
+			data: { toolName: "search_evidence", secret: "raw-payload" },
+		});
+		const concise = view.render(120).join("\n");
+		expect(concise).toContain("tool search_evidence started");
+		expect(concise).not.toContain("raw-payload");
+		view.handleInput("\u0016");
+		expect(view.isVerbose).toBe(true);
+		expect(view.render(120).join("\n")).toContain("raw-payload");
+	});
+
+	it("reconnects from the latest cursor and stops on the terminal event", async () => {
+		const paths: string[] = [];
+		const view = new DreamingAttachView(() => {});
+		const controller = new AbortController();
+		const fetchStream = async (path: string): Promise<DaemonStreamResult> => {
+			paths.push(path);
+			if (paths.length === 1) {
+				return streamResult(
+					[
+						`event: snapshot\ndata: ${JSON.stringify({
+							type: "snapshot",
+							passId: "pass-1",
+							snapshot: {
+								passId: "pass-1",
+								agentId: "agent-a",
+								mode: "incremental",
+								status: "running",
+								startedAt: "2026-08-05T00:00:00.000Z",
+								completedAt: null,
+								summary: null,
+								error: null,
+								cursor: 1,
+								replayFrom: 1,
+								replayTo: 1,
+							},
+						})}\n\n`,
+						`id: 2\nevent: assistant_delta\ndata: ${JSON.stringify({
+							type: "assistant_delta",
+							passId: "pass-1",
+							cursor: 2,
+							agentId: "agent-a",
+							timestamp: "2026-08-05T00:00:01.000Z",
+							data: { delta: "hello" },
+						})}\n\n`,
+					].join(""),
+				);
+			}
+			return streamResult(
+				`id: 3\nevent: pass_completed\ndata: ${JSON.stringify({
+					type: "pass_completed",
+					passId: "pass-1",
+					cursor: 3,
+					agentId: "agent-a",
+					timestamp: "2026-08-05T00:00:02.000Z",
+					data: { status: "completed", summary: "done" },
+				})}\n\n`,
+			);
+		};
+
+		const terminal = await followDreamingPass({
+			passId: "pass-1",
+			fetchStream,
+			view,
+			signal: controller.signal,
+			maxReconnects: 1,
+			sleep: async () => {},
+		});
+
+		expect(terminal).toBe(true);
+		expect(paths).toEqual(["/api/dream/passes/pass-1/events", "/api/dream/passes/pass-1/events?after=2"]);
+		expect(view.cursor).toBe(3);
+	});
+
+	it("does not block on a chunked SSE body", async () => {
+		const chunks = ['event: lifecycle\ndata: {"type":"lifecycle",', '"passId":"pass-1"}\n\n'];
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(new TextEncoder().encode(chunk));
+				controller.close();
+			},
+		});
+		const records: string[] = [];
+		await readSseStream(body, (record) => records.push(record.data), new AbortController().signal);
+		expect(records).toEqual(['{"type":"lifecycle","passId":"pass-1"}']);
+	});
+
+	it("cancels a pending read when Ctrl+C aborts the attachment", async () => {
+		const controller = new AbortController();
+		let cancelled = false;
+		const body = new ReadableStream<Uint8Array>({
+			cancel() {
+				cancelled = true;
+			},
+		});
+		const pending = readSseStream(body, () => {}, controller.signal);
+		setTimeout(() => controller.abort(), 5);
+		await pending;
+		expect(cancelled).toBe(true);
+	});
+
+	it("bounds repeated successful stream terminations", async () => {
+		const view = new DreamingAttachView(() => {});
+		let attempts = 0;
+		await expect(
+			followDreamingPass({
+				passId: "pass-1",
+				fetchStream: async () => {
+					attempts += 1;
+					return streamResult("");
+				},
+				view,
+				signal: new AbortController().signal,
+				maxReconnects: 2,
+				sleep: async () => {},
+			}),
+		).rejects.toBeInstanceOf(DreamingAttachError);
+		expect(attempts).toBe(3);
+	});
+
+	it("reconnects the same SSE transport when verbose mode is toggled", async () => {
+		const view = new DreamingAttachView(() => {});
+		const paths: string[] = [];
+		const fetchStream = async (path: string): Promise<DaemonStreamResult> => {
+			paths.push(path);
+			if (paths.length === 1) {
+				return {
+					ok: true,
+					response: new Response(new ReadableStream<Uint8Array>()),
+				};
+			}
+			return streamResult(
+				`event: pass_completed\ndata: ${JSON.stringify({
+					type: "pass_completed",
+					passId: "pass-1",
+					agentId: "agent-a",
+					cursor: 1,
+					timestamp: new Date().toISOString(),
+					data: { status: "completed" },
+				})}\n\n`,
+			);
+		};
+		const follow = followDreamingPass({
+			passId: "pass-1",
+			fetchStream,
+			view,
+			signal: new AbortController().signal,
+			maxReconnects: 2,
+			sleep: async () => {},
+		});
+		setTimeout(() => view.handleInput("\u0016"), 5);
+
+		expect(await follow).toBe(true);
+		expect(paths).toEqual(["/api/dream/passes/pass-1/events", "/api/dream/passes/pass-1/events?verbose=1"]);
+		expect(view.isVerbose).toBe(true);
+	});
+});

--- a/surfaces/cli/src/lib/dream-attach.ts
+++ b/surfaces/cli/src/lib/dream-attach.ts
@@ -1,0 +1,490 @@
+import { Key, ProcessTerminal, TUI, matchesKey, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import type { Component } from "@earendil-works/pi-tui";
+import type { DaemonStreamResult } from "./daemon.js";
+
+const MAX_VIEW_LINE_CHARS = 16_000;
+
+export interface DreamingAttachSnapshot {
+	readonly passId: string;
+	readonly agentId: string;
+	readonly mode: string;
+	readonly status: string;
+	readonly startedAt: string;
+	readonly completedAt: string | null;
+	readonly summary: string | null;
+	readonly error: string | null;
+	readonly cursor: number;
+	readonly replayFrom: number | null;
+	readonly replayTo: number | null;
+}
+
+export interface DreamingAttachEvent {
+	readonly passId: string;
+	readonly agentId: string;
+	readonly cursor: number;
+	readonly timestamp: string;
+	readonly type: string;
+	readonly data: Readonly<Record<string, unknown>>;
+}
+
+export interface DreamingAttachGap {
+	readonly requestedCursor: number;
+	readonly availableFrom: number | null;
+	readonly availableTo: number;
+	readonly reason: string;
+}
+
+export interface DreamingAttachEnvelope {
+	readonly type?: string;
+	readonly passId?: string;
+	readonly agentId?: string;
+	readonly cursor?: number;
+	readonly timestamp?: string;
+	readonly data?: Readonly<Record<string, unknown>>;
+	readonly snapshot?: DreamingAttachSnapshot;
+	readonly event?: DreamingAttachEvent;
+	readonly gap?: DreamingAttachGap;
+}
+
+export interface ParsedSseEvent {
+	readonly event: string;
+	readonly id: string | null;
+	readonly data: string;
+}
+
+export function parseSseEventBlock(block: string): ParsedSseEvent | null {
+	let event = "message";
+	let id: string | null = null;
+	const data: string[] = [];
+	for (const rawLine of block.replace(/\r/g, "").split("\n")) {
+		if (rawLine.startsWith(":")) continue;
+		const separator = rawLine.indexOf(":");
+		const field = separator === -1 ? rawLine : rawLine.slice(0, separator);
+		let value = separator === -1 ? "" : rawLine.slice(separator + 1);
+		if (value.startsWith(" ")) value = value.slice(1);
+		if (field === "event") event = value;
+		else if (field === "id") id = value;
+		else if (field === "data") data.push(value);
+	}
+	if (data.length === 0) return null;
+	return { event, id, data: data.join("\n") };
+}
+
+export function parseDreamingAttachEnvelope(record: ParsedSseEvent): DreamingAttachEnvelope | null {
+	try {
+		const parsed: unknown = JSON.parse(record.data);
+		if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+		return parsed as DreamingAttachEnvelope;
+	} catch {
+		return null;
+	}
+}
+
+function eventFromEnvelope(envelope: DreamingAttachEnvelope, sseEventName: string): DreamingAttachEvent | undefined {
+	if (envelope.event) return envelope.event;
+	if (
+		sseEventName !== "snapshot" &&
+		sseEventName !== "gap" &&
+		sseEventName !== "error" &&
+		typeof envelope.passId === "string" &&
+		typeof envelope.agentId === "string" &&
+		typeof envelope.cursor === "number" &&
+		typeof envelope.timestamp === "string" &&
+		envelope.data !== undefined
+	) {
+		return envelope as DreamingAttachEvent;
+	}
+	return undefined;
+}
+
+function textValue(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function eventData(event: DreamingAttachEvent, key: string): unknown {
+	return event.data[key];
+}
+
+function safeJson(value: unknown): string {
+	try {
+		return JSON.stringify(value) ?? "null";
+	} catch {
+		return "[unserializable]";
+	}
+}
+
+function wrappedLines(value: string, width: number): string[] {
+	return value.split("\n").flatMap((line) => wrapTextWithAnsi(line, Math.max(1, width)));
+}
+
+function formatTimestamp(value: string): string {
+	const timestamp = Date.parse(value.replace(" ", "T") + (value.includes("Z") ? "" : "Z"));
+	if (!Number.isFinite(timestamp)) return value;
+	return new Date(timestamp).toLocaleTimeString();
+}
+
+function formatElapsed(startedAt: string): string {
+	const timestamp = Date.parse(startedAt.replace(" ", "T") + (startedAt.includes("Z") ? "" : "Z"));
+	if (!Number.isFinite(timestamp)) return "?";
+	const elapsedSeconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1_000));
+	const hours = Math.floor(elapsedSeconds / 3_600);
+	const minutes = Math.floor((elapsedSeconds % 3_600) / 60);
+	const seconds = elapsedSeconds % 60;
+	return hours > 0
+		? `${hours}h${String(minutes).padStart(2, "0")}m`
+		: `${minutes}m${String(seconds).padStart(2, "0")}s`;
+}
+
+/** Read-only Pi TUI component used by dream attach. It intentionally has no editor/input child. */
+export class DreamingAttachView implements Component {
+	private snapshot: DreamingAttachSnapshot | undefined;
+	private readonly events: DreamingAttachEvent[] = [];
+	private readonly lines: string[] = [];
+	private verbose = false;
+	private lastCursor = 0;
+	private snapshotCursor = 0;
+	private phase = "connecting";
+	private model: string | undefined;
+	private modeChangeHandler: (verbose: boolean) => void;
+
+	constructor(
+		private readonly onDetach: () => void,
+		private readonly onChange: () => void = () => {},
+		onModeChange: (verbose: boolean) => void = () => {},
+	) {
+		this.modeChangeHandler = onModeChange;
+	}
+
+	setModeChangeHandler(handler: (verbose: boolean) => void): void {
+		this.modeChangeHandler = handler;
+	}
+
+	get isVerbose(): boolean {
+		return this.verbose;
+	}
+
+	get cursor(): number {
+		return this.lastCursor;
+	}
+
+	applySnapshot(snapshot: DreamingAttachSnapshot): void {
+		this.snapshot = snapshot;
+		this.snapshotCursor = Math.max(this.snapshotCursor, snapshot.cursor);
+		this.phase = snapshot.status;
+		this.addLine(`Connected to pass ${snapshot.passId} (${snapshot.agentId}, ${snapshot.mode})`);
+		if (snapshot.status !== "running") {
+			this.addLine(`Pass is already ${snapshot.status}.`);
+			if (snapshot.summary) this.addLine(`Summary: ${snapshot.summary}`);
+			if (snapshot.error) this.addLine(`Error: ${snapshot.error}`);
+		}
+		this.invalidateAndRender();
+	}
+
+	applyGap(gap: DreamingAttachGap): void {
+		this.addLine(
+			`Replay gap (${gap.reason}): cursor ${gap.requestedCursor} is not fully available; showing a fresh snapshot and live events.`,
+		);
+		this.invalidateAndRender();
+	}
+
+	applyEvent(event: DreamingAttachEvent): void {
+		this.lastCursor = Math.max(this.lastCursor, event.cursor);
+		this.events.push(event);
+		if (this.events.length > 160) this.events.splice(0, this.events.length - 160);
+
+		const type = event.type;
+		if (type === "assistant_delta") {
+			this.phase = "assistant";
+			const delta = textValue(eventData(event, "delta")) ?? "";
+			if (delta) {
+				const previous = this.lines.at(-1);
+				if (previous?.startsWith("assistant: "))
+					this.lines[this.lines.length - 1] = `${previous}${delta}`.slice(0, MAX_VIEW_LINE_CHARS);
+				else this.addLine(`assistant: ${delta}`);
+			}
+		} else if (type === "thinking_delta") {
+			this.phase = "reasoning";
+			if (this.verbose) this.addLine(`reasoning: ${textValue(eventData(event, "delta")) ?? ""}`);
+		} else if (type === "tool_start") {
+			const tool = textValue(eventData(event, "toolName")) ?? "unknown";
+			this.phase = `tool:${tool}`;
+			this.addLine(`tool ${tool} started`);
+		} else if (type === "tool_progress") {
+			if (this.verbose) this.addLine(`tool progress: ${safeJson(event.data)}`);
+		} else if (type === "tool_end") {
+			const tool = textValue(eventData(event, "toolName")) ?? "unknown";
+			const success = eventData(event, "success") === true;
+			this.phase = "running";
+			this.addLine(`tool ${tool} ${success ? "completed" : "failed"}`);
+		} else if (type === "tool_trace") {
+			const tool = textValue(eventData(event, "toolName")) ?? "unknown";
+			const success = eventData(event, "success") === true;
+			this.addLine(`tool ${tool} trace ${success ? "ok" : "failed"}`);
+		} else if (type === "session_info") {
+			this.model = textValue(eventData(event, "model"));
+			this.addLine(`Pi session ready${this.model ? ` (${this.model})` : ""}`);
+		} else if (type === "lifecycle") {
+			this.phase = textValue(eventData(event, "phase")) ?? type;
+		} else if (type === "pass_completed" || type === "pass_failed") {
+			const status = textValue(eventData(event, "status")) ?? (type === "pass_completed" ? "completed" : "failed");
+			this.phase = status;
+			this.addLine(`Dreaming pass ${status}`);
+			const summary = textValue(eventData(event, "summary")) ?? "";
+			const error = textValue(eventData(event, "error")) ?? "";
+			if (summary) this.addLine(`Summary: ${summary}`);
+			if (error) this.addLine(`Error: ${error}`);
+		} else if (type === "gap") {
+			this.addLine("The stream reported a replay gap; the snapshot is authoritative.");
+		} else if (type !== "message_update") {
+			this.addLine(type.replaceAll("_", " "));
+		}
+		this.invalidateAndRender();
+	}
+
+	applyMalformedEvent(): void {
+		this.addLine("Received a malformed live event; continuing with the next event.");
+		this.invalidateAndRender();
+	}
+
+	addConnectionMessage(message: string): void {
+		this.addLine(message);
+		this.invalidateAndRender();
+	}
+
+	handleInput(data: string): void {
+		if (matchesKey(data, Key.ctrl("c"))) {
+			this.onDetach();
+			return;
+		}
+		if (matchesKey(data, Key.ctrl("v"))) {
+			this.verbose = !this.verbose;
+			this.modeChangeHandler(this.verbose);
+			this.addLine(this.verbose ? "Verbose raw mode enabled" : "Concise mode enabled");
+			this.invalidateAndRender();
+			return;
+		}
+		// All other input is intentionally ignored: this is not a chat/editor UI.
+	}
+
+	render(width: number): string[] {
+		const snapshot = this.snapshot;
+		const header = snapshot
+			? `Dreaming attach ${this.verbose ? "[RAW VERBOSE]" : "[concise]"} | pass ${snapshot.passId} | agent ${snapshot.agentId} | model ${this.model ?? "pending"} | mode ${snapshot.mode} | phase ${this.phase} | elapsed ${formatElapsed(snapshot.startedAt)} | cursor ${Math.max(this.lastCursor, this.snapshotCursor)}`
+			: "Dreaming attach [connecting]";
+		const help = "Ctrl+V toggle raw verbose • Ctrl+C detach (the pass keeps running)";
+		const source = this.verbose
+			? this.events
+					.slice(-80)
+					.map((event) => `${formatTimestamp(event.timestamp)} ${event.type}: ${safeJson(event.data)}`)
+			: this.lines.slice(-80);
+		const output = [header, help, "", ...source];
+		return output.flatMap((line) => wrappedLines(truncateToWidth(line, Math.max(1, width), "…"), width));
+	}
+
+	invalidate(): void {}
+
+	private invalidateAndRender(): void {
+		this.onChange();
+	}
+
+	private addLine(line: string): void {
+		this.lines.push(line.slice(0, MAX_VIEW_LINE_CHARS));
+		if (this.lines.length > 160) this.lines.splice(0, this.lines.length - 160);
+	}
+}
+
+export interface FollowDreamingPassOptions {
+	readonly passId: string;
+	readonly fetchStream: (path: string, opts?: RequestInit & { timeout?: number }) => Promise<DaemonStreamResult>;
+	readonly view: DreamingAttachView;
+	readonly signal: AbortSignal;
+	readonly maxReconnects?: number;
+	readonly sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
+}
+
+function waitFor(ms: number, signal: AbortSignal): Promise<void> {
+	if (signal.aborted) return Promise.resolve();
+	return new Promise((resolve) => {
+		const timer = setTimeout(resolve, ms);
+		const abort = () => {
+			clearTimeout(timer);
+			resolve();
+		};
+		signal.addEventListener("abort", abort, { once: true });
+		setTimeout(() => signal.removeEventListener("abort", abort), ms + 1);
+	});
+}
+
+export async function readSseStream(
+	body: ReadableStream<Uint8Array>,
+	onEvent: (event: ParsedSseEvent) => void,
+	signal: AbortSignal,
+): Promise<void> {
+	const reader = body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+	const cancelOnAbort = (): void => {
+		void reader.cancel().catch(() => undefined);
+	};
+	if (signal.aborted) cancelOnAbort();
+	else signal.addEventListener("abort", cancelOnAbort, { once: true });
+	const consume = (flush: boolean): void => {
+		buffer = buffer.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+		let boundary = buffer.indexOf("\n\n");
+		while (boundary !== -1) {
+			const block = buffer.slice(0, boundary);
+			buffer = buffer.slice(boundary + 2);
+			const event = parseSseEventBlock(block);
+			if (event) onEvent(event);
+			boundary = buffer.indexOf("\n\n");
+		}
+		if (flush && buffer.trim()) {
+			const event = parseSseEventBlock(buffer);
+			if (event) onEvent(event);
+			buffer = "";
+		}
+	};
+	try {
+		while (!signal.aborted) {
+			const result = await reader.read();
+			if (result.done) break;
+			buffer += decoder.decode(result.value, { stream: true });
+			consume(false);
+		}
+		buffer += decoder.decode();
+		consume(true);
+	} finally {
+		signal.removeEventListener("abort", cancelOnAbort);
+		try {
+			await reader.cancel();
+		} catch {
+			// The daemon may already have closed the response.
+		}
+		reader.releaseLock();
+	}
+}
+
+export class DreamingAttachError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "DreamingAttachError";
+	}
+}
+
+export async function followDreamingPass(options: FollowDreamingPassOptions): Promise<boolean> {
+	const maxReconnects = options.maxReconnects ?? 5;
+	const sleep = options.sleep ?? waitFor;
+	let cursor = options.view.cursor;
+	let reconnects = 0;
+	let terminal = false;
+	let connectionAbort: AbortController | undefined;
+	options.view.setModeChangeHandler(() => connectionAbort?.abort());
+	try {
+		while (!options.signal.aborted && !terminal) {
+			const currentConnection = new AbortController();
+			connectionAbort = currentConnection;
+			const relayAbort = () => currentConnection.abort();
+			options.signal.addEventListener("abort", relayAbort, { once: true });
+			const query = new URLSearchParams();
+			if (cursor > 0) query.set("after", String(cursor));
+			if (options.view.isVerbose) query.set("verbose", "1");
+			const queryString = query.toString();
+			const path = `/api/dream/passes/${encodeURIComponent(options.passId)}/events${queryString ? `?${queryString}` : ""}`;
+			let result: DaemonStreamResult;
+			try {
+				result = await options.fetchStream(path, {
+					signal: currentConnection.signal,
+					headers: { Accept: "text/event-stream" },
+				});
+			} catch (error) {
+				options.signal.removeEventListener("abort", relayAbort);
+				if (connectionAbort === currentConnection) connectionAbort = undefined;
+				if (options.signal.aborted) break;
+				if (reconnects >= maxReconnects) {
+					throw new DreamingAttachError(error instanceof Error ? error.message : String(error));
+				}
+				reconnects++;
+				options.view.addConnectionMessage(`Live stream error; reconnecting (${reconnects}/${maxReconnects})...`);
+				await sleep(Math.min(4_000, 250 * 2 ** (reconnects - 1)), options.signal);
+				continue;
+			}
+			if (!result.ok) {
+				options.signal.removeEventListener("abort", relayAbort);
+				if (connectionAbort === currentConnection) connectionAbort = undefined;
+				if (options.signal.aborted) break;
+				if (reconnects >= maxReconnects) throw new DreamingAttachError(result.error ?? "Dreaming live stream failed");
+				reconnects++;
+				options.view.addConnectionMessage(`Live stream disconnected; reconnecting (${reconnects}/${maxReconnects})...`);
+				await sleep(Math.min(4_000, 250 * 2 ** (reconnects - 1)), options.signal);
+				continue;
+			}
+			if (!result.response.body) {
+				options.signal.removeEventListener("abort", relayAbort);
+				if (connectionAbort === currentConnection) connectionAbort = undefined;
+				throw new DreamingAttachError("Dreaming live stream returned no body");
+			}
+
+			let streamError: unknown;
+			try {
+				await readSseStream(
+					result.response.body,
+					(record) => {
+						const envelope = parseDreamingAttachEnvelope(record);
+						if (!envelope) {
+							options.view.applyMalformedEvent();
+							return;
+						}
+						if (envelope.snapshot) {
+							options.view.applySnapshot(envelope.snapshot);
+							if (envelope.snapshot.status !== "running") terminal = true;
+						}
+						if (envelope.gap) options.view.applyGap(envelope.gap);
+						const event = eventFromEnvelope(envelope, record.event);
+						if (event) {
+							options.view.applyEvent(event);
+							if (event.type === "pass_completed" || event.type === "pass_failed") terminal = true;
+						}
+						const parsedCursor = record.id === null ? 0 : Number.parseInt(record.id, 10);
+						if (Number.isSafeInteger(parsedCursor) && parsedCursor > cursor) cursor = parsedCursor;
+					},
+					currentConnection.signal,
+				);
+			} catch (error) {
+				streamError = error;
+			}
+			options.signal.removeEventListener("abort", relayAbort);
+			if (connectionAbort === currentConnection) connectionAbort = undefined;
+			if (options.signal.aborted || terminal) break;
+			if (reconnects >= maxReconnects) {
+				throw new DreamingAttachError(
+					streamError instanceof Error ? streamError.message : "Dreaming live stream ended unexpectedly",
+				);
+			}
+			reconnects++;
+			const modeChanged = currentConnection.signal.aborted;
+			options.view.addConnectionMessage(
+				modeChanged
+					? `Switching to ${options.view.isVerbose ? "raw verbose" : "concise"} mode...`
+					: streamError
+						? `Live stream error; reconnecting (${reconnects}/${maxReconnects})...`
+						: `Live stream ended; reconnecting (${reconnects}/${maxReconnects})...`,
+			);
+			await sleep(Math.min(4_000, 250 * 2 ** (reconnects - 1)), options.signal);
+		}
+	} finally {
+		options.view.setModeChangeHandler(() => {});
+		connectionAbort?.abort();
+	}
+	return terminal;
+}
+
+export function createDreamingAttachTui(view: DreamingAttachView): {
+	readonly tui: TUI;
+	readonly terminal: ProcessTerminal;
+} {
+	const terminal = new ProcessTerminal();
+	const tui = new TUI(terminal);
+	tui.addChild(view);
+	tui.setFocus(view);
+	return { tui, terminal };
+}

--- a/web/docs/src/content/docs/api/knowledge-ontology.md
+++ b/web/docs/src/content/docs/api/knowledge-ontology.md
@@ -538,6 +538,69 @@ leaves everything pending. The worker can run for pending attention even
 when no new episodic evidence has arrived, while normal failure backoff still
 applies.
 
+### GET /api/dream/passes/active
+
+List the currently running passes in the resolved agent scope. This is the
+selection endpoint used by `signet dream attach`: the CLI attaches implicitly
+only when this list contains exactly one item. Requires `admin` permission.
+
+```json
+{
+  "agentId": "noam",
+  "items": [
+    {
+      "id": "pass-uuid",
+      "mode": "incremental",
+      "status": "running",
+      "startedAt": "2026-04-01 12:00:00",
+      "completedAt": null,
+      "summary": null,
+      "error": null
+    }
+  ]
+}
+```
+
+The response is always scoped to the daemon's current agent context unless an
+agent selector is supplied through the existing scoped-agent headers/query
+parameters. A pass ID from another agent is never accepted by the live stream
+route.
+
+### GET /api/dream/passes/:passId/events
+
+Open a read-only Server-Sent Events (SSE) stream for one agent-scoped pass.
+Requires `admin` permission. The optional `after` query parameter, or the
+`Last-Event-ID` header, resumes after a non-negative event cursor:
+
+```text
+GET /api/dream/passes/pass-uuid/events?after=42
+Accept: text/event-stream
+```
+
+Set `verbose=1` (or `verbose=true`) when the operator has opted into raw
+debugging data. The default stream omits `raw` fields; the CLI reconnects on
+the same SSE transport when **Ctrl+V** toggles this mode.
+
+The first event is a `snapshot` whose data contains the current pass metadata
+and replay window. Subsequent events carry a monotonic `id` and include
+assistant deltas, reasoning deltas, Pi lifecycle transitions, tool start/
+progress/end events, detailed `tool_trace` events, session metadata, and a
+terminal `pass_completed` or `pass_failed` event. Tool traces and Pi events remain ephemeral; the durable
+`dreaming_passes` and `dreaming_tool_calls` rows are the audit source.
+
+When the requested cursor is outside the bounded in-memory replay window, the
+stream sends a `gap` event with `requestedCursor`, `availableFrom`,
+`availableTo`, and `reason`. The snapshot is authoritative and the client can
+continue from the latest cursor. Heartbeats are sent as SSE comments so idle
+connections remain detectable. Slow viewers are disconnected once their
+bounded stream queue fills and can reconnect from the last delivered cursor.
+
+The verbose event data includes bounded `raw` fields for the opt-in terminal
+view. These may contain prompts, system/developer instructions, model
+reasoning, evidence, tool arguments, and tool results. The daemon does not
+persist a second transcript for attachment and the stream exposes no control
+or prompt-submission action.
+
 ### POST /api/dream/exclusions/requeue
 
 Request one quarantined evidence source be considered again after correcting
@@ -678,7 +741,8 @@ Returns `202 Accepted` immediately and runs the pass in the background
 Returns 409 if a pass is already running. Returns 503 if the
 dreaming worker is not started.
 
-Poll `GET /api/dream/status` and check `passes[0].status` for completion.
+Poll `GET /api/dream/status` and check `passes[0].status` for completion, or
+use `GET /api/dream/passes/:passId/events` for a live read-only view.
 
 **Request body**
 


### PR DESCRIPTION
## Summary

Adds the read-only `signet dream attach` workflow from issue #1601. The daemon owns a scoped, bounded SSE event stream for a Dreaming pass, while the CLI renders it in a Pi TUI without prompt editing, steering, aborting, retrying, or creating a second transcript.

Closes #1601

## Changes

- Added daemon-owned Dreaming live-event hub with monotonic cursors, bounded replay/subscribers/payloads, terminal retention, gap signaling, heartbeat, and agent-scope enforcement.
- Added `/api/dream/passes/active` and scoped `/api/dream/passes/:passId/events` SSE routes with concise redaction and opt-in `verbose=1` raw payloads.
- Added `signet dream attach [--pass-id]` with active-pass selection, reconnects, cursor resume, Ctrl+C detach, and Ctrl+V concise/raw transport toggle.
- Added Pi session lifecycle/assistant/tool event forwarding, focused regression tests, a runnable eval, and Dreaming API/runbook documentation.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/core`
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: Dreaming docs and runnable eval

## Screenshots

N/A — this is a terminal Pi TUI, not a dashboard/web/extension surface.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no database migration or durable transcript schema was added.

## Testing

- [x] `bun test` passes — feature-focused command passes: 25 tests, 0 failures, 72 expectations; the full `platform/daemon` package suite also passes.
- [x] `bun run typecheck` passes — `bun run --filter '*' typecheck` passes.
- [x] `bun run lint` passes — `bun run lint:check` exits 0; the repository still reports 625 pre-existing warnings and 48 infos.
- [ ] Tested against running daemon
- [x] N/A — no external model/provider credentials were available for a live LLM pass; real Hono route/SSE integration is covered by the daemon route tests.

Additional passing checks:

- `bun run build`
- `bun run build:cli`
- `bun install --frozen-lockfile`
- `bun scripts/evals/dream-attach.ts` (all checks pass; replay is bounded at 256 events and raw payloads at 16,000 characters)
- `git diff --check`

Known unrelated suite failures:

- The full `surfaces/cli` suite reported 567 passing, 10 failing, 1 error out of 577 tests. The failures are outside the changed Dream attach paths: pipeline-pause fallback configuration, five Linux desktop install/AppImage environment tests on macOS arm64, ForgeCode detection, setup headless plan timeout, and route-doctor `process.exitCode`. The Dream attach tests all pass; I am not claiming the full CLI suite is green.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- Ctrl+C only detaches the viewer. The daemon pass continues and durable DB audit records remain the source of truth.
- The default stream omits raw prompts/system/developer/reasoning/evidence/tool payloads; Ctrl+V reconnects the same SSE transport with `verbose=1`.
