### PR TITLE
fix(cli): fall back for headless secret exec

### DIFF
--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -106,7 +106,7 @@ import { copyDirRecursive, syncBuiltinSkills, syncTemplates } from "./features/s
 import { flushCliTelemetry, recordCommandInvoked } from "./features/telemetry.js";
 import { signetBanner } from "./lib/banner.js";
 import { createDaemonClient, ensureDaemonRunning } from "./lib/daemon.js";
-import { createOfflineSecretApiCall } from "./lib/secrets.js";
+import { createOfflineSecretApiCall, createSecretCommandApiCall } from "./lib/secrets.js";
 import { gitAddAndCommit, gitInit, isGitRepo } from "./lib/git.js";
 import {
 	acquireNativeSyncLock,
@@ -1084,15 +1084,12 @@ const { fetchFromDaemon, fetchDaemonResult, fetchDaemonStream, secretApiCall } =
 	AGENTS_DIR,
 );
 const offlineSecretApiCall = createOfflineSecretApiCall();
-const secretCommandApiCall = async (
-	method: string,
-	path: string,
-	body?: unknown,
-	timeoutMs?: number,
-): Promise<{ readonly ok: boolean; readonly data: unknown }> =>
-	(await isDaemonRunning())
-		? secretApiCall(method, path, body, timeoutMs)
-		: offlineSecretApiCall(method, path, body, timeoutMs);
+const secretCommandApiCall = createSecretCommandApiCall({
+	daemonApiCall: secretApiCall,
+	offlineApiCall: offlineSecretApiCall,
+	isDaemonRunning,
+	agentsDir: AGENTS_DIR,
+});
 const SKILLS_DIR = join(AGENTS_DIR, "skills");
 
 registerRepairQueueCommands(program, {

--- a/surfaces/cli/src/lib/secrets.test.ts
+++ b/surfaces/cli/src/lib/secrets.test.ts
@@ -4,9 +4,10 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { __setSecretStoreLockHookForTests, getLocalSecretValue, setSecretKeyringAdapterForTests } from "@signet/core";
-import { createOfflineSecretApiCall } from "./secrets.js";
+import { createOfflineSecretApiCall, createSecretCommandApiCall } from "./secrets.js";
 
 const originalSignetPath = process.env.SIGNET_PATH;
+const originalDbusSessionBusAddress = process.env.DBUS_SESSION_BUS_ADDRESS;
 let workspace = "";
 let writerScript = "";
 
@@ -53,6 +54,8 @@ afterEach(() => {
 	setSecretKeyringAdapterForTests(null);
 	if (originalSignetPath === undefined) delete process.env.SIGNET_PATH;
 	else process.env.SIGNET_PATH = originalSignetPath;
+	if (originalDbusSessionBusAddress === undefined) delete process.env.DBUS_SESSION_BUS_ADDRESS;
+	else process.env.DBUS_SESSION_BUS_ADDRESS = originalDbusSessionBusAddress;
 	if (workspace) rmSync(workspace, { recursive: true, force: true });
 	workspace = "";
 	if (writerScript) rmSync(writerScript, { force: true });
@@ -119,6 +122,70 @@ describe("daemonless secret API", () => {
 		if (!response.ok) return;
 		expect(response.data.result.stdout).not.toContain("x");
 		expect(response.data.result.stdout).toBe("[REDACTED]");
+	});
+
+	test("falls back to synchronous encrypted-store exec when D-Bus is absent", async () => {
+		workspace = mkdtempSync(join(tmpdir(), "signet-headless-secret-exec-"));
+		process.env.SIGNET_PATH = workspace;
+		delete process.env.DBUS_SESSION_BUS_ADDRESS;
+		const offline = createOfflineSecretApiCall();
+		await offline("POST", "/api/secrets/HEADLESS_KEY", { value: "headless-value" });
+		const script = join(workspace, "print-headless-secret.mjs");
+		writeFileSync(script, "process.stdout.write(process.env.HEADLESS_KEY ?? '');\n");
+		let daemonCalls = 0;
+		const api = createSecretCommandApiCall({
+			daemonApiCall: async () => {
+				daemonCalls += 1;
+				return { ok: true, data: { daemon: true } };
+			},
+			offlineApiCall: offline,
+			isDaemonRunning: async () => true,
+			agentsDir: workspace,
+		});
+
+		const response = await api("POST", "/api/secrets/exec", {
+			command: `bun ${script}`,
+			secrets: { HEADLESS_KEY: "HEADLESS_KEY" },
+		});
+
+		expect(daemonCalls).toBe(0);
+		expect(response.ok).toBe(true);
+		if (!response.ok) return;
+		expect(response.data.result.stdout).toBe("[REDACTED]");
+		expect(response.data.result.stdout).not.toContain("headless-value");
+	});
+
+	test("keeps daemon keyring preference and fail-closed keyring classifications", async () => {
+		workspace = mkdtempSync(join(tmpdir(), "signet-keyring-preference-"));
+		const offline = createOfflineSecretApiCall();
+		let daemonCalls = 0;
+		const daemon = async () => {
+			daemonCalls += 1;
+			return { ok: true, data: { daemon: true } };
+		};
+
+		const foundApi = createSecretCommandApiCall({
+			daemonApiCall: daemon,
+			offlineApiCall: offline,
+			isDaemonRunning: async () => true,
+			agentsDir: workspace,
+			readKeyring: async () => ({ state: "found", value: "not-used-by-test" }),
+		});
+		expect(await foundApi("GET", "/api/secrets")).toEqual({ ok: true, data: { daemon: true } });
+		expect(daemonCalls).toBe(1);
+
+		const lockedApi = createSecretCommandApiCall({
+			daemonApiCall: daemon,
+			offlineApiCall: offline,
+			isDaemonRunning: async () => true,
+			agentsDir: workspace,
+			readKeyring: async () => ({ state: "locked", message: "keyring is locked" }),
+		});
+		expect(await lockedApi("POST", "/api/secrets/exec", { command: "true", secrets: { X: "X" } })).toEqual({
+			ok: true,
+			data: { daemon: true },
+		});
+		expect(daemonCalls).toBe(2);
 	});
 
 	test("serializes racing CLI and daemon store writers", async () => {

--- a/surfaces/cli/src/lib/secrets.ts
+++ b/surfaces/cli/src/lib/secrets.ts
@@ -1,11 +1,13 @@
 import {
 	deleteLocalSecret,
 	execWithSecrets,
+	getSecretKeyring,
 	listLocalSecretNames,
 	normalizeSecretExecTimeoutMs,
 	parseLocalSecretName,
 	putLocalSecret,
 	type DaemonApiCall,
+	type SecretKeyringResult,
 } from "@signet/core";
 
 function errorResponse(error: string): { readonly ok: false; readonly data: { readonly error: string } } {
@@ -85,5 +87,50 @@ export function createOfflineSecretApiCall(): DaemonApiCall {
 		}
 
 		return errorResponse("This secret operation requires a running Signet daemon");
+	};
+}
+
+interface SecretCommandApiOptions {
+	readonly daemonApiCall: DaemonApiCall;
+	readonly offlineApiCall: DaemonApiCall;
+	readonly isDaemonRunning: () => Promise<boolean>;
+	readonly agentsDir: string;
+	readonly readKeyring?: () => Promise<SecretKeyringResult>;
+}
+
+function isLocalSecretOperation(method: string, path: string): boolean {
+	if (method === "GET" && path === "/api/secrets") return true;
+	if (method === "POST" && path === "/api/secrets/exec") return true;
+	return (method === "POST" || method === "DELETE") && /^\/api\/secrets\/[^/]+$/.test(path);
+}
+
+function isUnavailableKeyring(result: SecretKeyringResult): boolean {
+	return result.state === "unavailable" || result.state === "unsupported";
+}
+
+/**
+ * Prefer the daemon and its native keyring, but use the shared encrypted store
+ * for local operations when the native keyring cannot exist in this session.
+ * Locked, corrupt, and permission-denied keyrings stay on the daemon path so
+ * they retain their existing fail-closed classifications.
+ */
+export function createSecretCommandApiCall(options: SecretCommandApiOptions): DaemonApiCall {
+	const readKeyring = options.readKeyring ?? (() => getSecretKeyring(`workspace:${options.agentsDir}`).get());
+
+	return async (method, path, body, timeoutMs) => {
+		if (!(await options.isDaemonRunning())) return options.offlineApiCall(method, path, body, timeoutMs);
+		if (!isLocalSecretOperation(method, path)) return options.daemonApiCall(method, path, body, timeoutMs);
+
+		let keyring: SecretKeyringResult | null = null;
+		try {
+			keyring = await readKeyring();
+		} catch {
+			// Let the daemon preserve its established error classification if the
+			// local availability probe itself cannot complete.
+		}
+		if (keyring !== null && isUnavailableKeyring(keyring)) {
+			return options.offlineApiCall(method, path, body, timeoutMs);
+		}
+		return options.daemonApiCall(method, path, body, timeoutMs);
 	};
 }

--- a/web/docs/src/content/docs/cli/integrations-security.md
+++ b/web/docs/src/content/docs/cli/integrations-security.md
@@ -21,9 +21,11 @@ signet sync
 
 ## `signet secret`
 
-Manage encrypted [Secrets](/secrets/). Local secret operations use the shared
-encrypted store directly and work without a running daemon. 1Password, Bitwarden,
-and daemon queue-status operations require the daemon.
+Manage encrypted [Secrets](/secrets/). Local secret operations prefer the daemon
+and native keyring when available, then use the shared encrypted store directly
+when the daemon or keyring is unavailable. This keeps local exec usable in
+headless cron and systemd sessions without bypassing locked or corrupt keyrings.
+1Password, Bitwarden, and daemon queue-status operations require the daemon.
 
 ```bash
 signet secret put OPENAI_API_KEY

--- a/web/docs/src/content/docs/secrets.md
+++ b/web/docs/src/content/docs/secrets.md
@@ -30,7 +30,7 @@ Do not place provider keys directly in YAML, shell history, screenshots, task pr
 
 ## Use a secret in a command
 
-`signet secret exec` injects selected secrets into the child environment. When the daemon is running, it keeps the existing asynchronous queue and returns a job id. When the daemon is not running, the CLI executes the command synchronously in-process and returns the command result. The command must name each injected secret before the command token:
+`signet secret exec` injects selected secrets into the child environment. When the daemon and native keyring are available, it keeps the existing asynchronous queue and returns a job id. When the daemon or the native keyring is unavailable, local commands use the same encrypted store directly, execute synchronously in-process, and return the command result. This fallback is intended for headless cron and systemd sessions and does not bypass locked, corrupt, or permission-denied keyrings. The command must name each injected secret before the command token:
 
 ```bash
 signet secret exec --secret OPENAI_API_KEY \


### PR DESCRIPTION
## Summary

Fix `signet secret exec` in headless sessions where the daemon is running but Linux Secret Service is unavailable. Local secret operations now use the shared encrypted store synchronously in that case, while retaining the daemon path whenever the native keyring is available or reports a fail-closed error state.

## Changes

- Added CLI routing that probes native keyring availability for local secret operations.
- Falls back to the existing core encrypted-store APIs only for unavailable or unsupported keyrings.
- Preserved daemon handling for locked, corrupt, permission-denied, and other classified keyring states.
- Added regressions for headless D-Bus fallback, daemon preference, short-secret redaction, and existing lock behavior.
- Updated secret and CLI security documentation.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [x] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A. This changes CLI routing and documentation, not a visual frontend surface.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations were touched.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Targeted proof:

- `bun test surfaces/cli/src/lib/secrets.test.ts`: 8 passed, 0 failed.
- `bun test platform/daemon/src/secrets.test.ts`: 27 passed, 0 failed.
- `bun run --filter '@signet/core' build`: passed.
- `bun run --filter '@signet/cli' build`: passed.
- Headless CLI smoke test with D-Bus unset: `secret put` followed by `secret exec --secret ... printenv ...` returned `[REDACTED]` and did not expose the stored value.
- Full `bun run typecheck`: passed.
- Full `bun run lint`: exit 0 with pre-existing repository warnings.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Closes #1606. Related to #1593 and #1454.

The fallback still uses the shared encrypted store and existing atomic lock/redaction behavior. It does not turn a locked, corrupt, permission-denied, or otherwise classified keyring failure into a legacy-store fallback.
