### PR TITLE
fix(cli): repair native inspector handoff

### DIFF
--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -64,7 +64,7 @@ import {
 	ownerRunStatement,
 	registerDbOwnerMaintenance,
 } from "./db-owner-maintenance";
-import { createDeferredRuntimeGate } from "./deferred-runtime-gate";
+import { createDeferredRuntimeGate, createDeferredRuntimeScheduler } from "./deferred-runtime-gate";
 import { getQueueDiagnosticsSnapshot, getQueuePressureSnapshot } from "./diagnostics-queue";
 import { fetchEmbedding } from "./embedding-fetch";
 import { type EmbeddingIndexMigrationHandle, startEmbeddingIndexMigration } from "./embedding-index-migration";
@@ -2324,6 +2324,15 @@ async function main() {
 	}
 
 	const deferredRuntimeGate = createDeferredRuntimeGate();
+	const deferredRuntimeScheduler = createDeferredRuntimeScheduler({
+		gate: deferredRuntimeGate,
+		schedule: (callback, delayMs) => setTimeout(callback, delayMs),
+		onPipelineError: (error): void => {
+			logger.error("daemon", "Deferred pipeline runtime startup failed", undefined, {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		},
+	});
 
 	// Grace period: defer all background workers for 10s after startup so the
 	// event-loop monitor can calibrate and migrations can settle before any
@@ -2409,13 +2418,7 @@ async function main() {
 		initFeatureFlags(AGENTS_DIR);
 		startUpdateTimer();
 	};
-	setTimeout(() => {
-		void startPostReadyRuntime().catch((error) => {
-			logger.error("daemon", "Deferred pipeline runtime startup failed", undefined, {
-				error: error instanceof Error ? error.message : String(error),
-			});
-		});
-	}, 30_000);
+	deferredRuntimeScheduler.schedulePipeline(startPostReadyRuntime);
 
 	const REQUEST_BODY_LIMIT = 10 * 1_048_576;
 	const { createServer: nodeCreateServer } = await import("node:http");
@@ -2457,11 +2460,11 @@ async function main() {
 			port: info.port,
 		});
 		logger.info("daemon", "Daemon ready");
-		setTimeout(() => {
+		deferredRuntimeScheduler.scheduleIntegrity(async (): Promise<void> => {
 			logFdSnapshot("server-ready");
 			writeDaemonLifecycle(AGENTS_DIR, buildLifecycleRecord("running"));
 			vacuumConversionHandle = startVacuumConversionWorker(getDbAccessor());
-			void runDeferredIntegrityCheck(getDbAccessor(), MEMORY_DB, {
+			await runDeferredIntegrityCheck(getDbAccessor(), MEMORY_DB, {
 				timeoutMs: DEFERRED_INTEGRITY_TIMEOUT_MS,
 				ownerTimeoutMs: DEFERRED_INTEGRITY_OWNER_TIMEOUT_MS,
 				owner: dbOwnerClient ?? undefined,
@@ -2526,9 +2529,6 @@ async function main() {
 				})
 				.catch((error) => {
 					logger.error("startup-recovery", "Deferred database integrity check rejected", error);
-				})
-				.finally(() => {
-					deferredRuntimeGate.completeIntegrity();
 				});
 
 			const healthStampPath = join(DAEMON_DIR, "last-healthy-start");
@@ -2685,7 +2685,7 @@ async function main() {
 						);
 					});
 			}
-		}, 30_000);
+		});
 	};
 
 	bindWithRetry({

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -2325,80 +2325,93 @@ async function main() {
 	// Grace period: defer all background workers for 10s after startup so the
 	// event-loop monitor can calibrate and migrations can settle before any
 	// background write work piles on (#1059 thundering-herd prevention).
-	reportStartupGrace();
-	await startPipelineRuntime(memoryCfg, telemetryCollector);
-	logFdSnapshot("post-pipeline");
+	const startPostReadyRuntime = async (): Promise<void> => {
+		reportStartupGrace();
+		await startPipelineRuntime(memoryCfg, telemetryCollector);
+		logFdSnapshot("post-pipeline");
 
-	initCheckpointFlush(getDbAccessor());
+		initCheckpointFlush(getDbAccessor());
 
-	schedulerHandle = startSchedulerWorker(getDbAccessor());
-	if (!transcriptCaptureWorkerHandle) {
-		transcriptCaptureWorkerHandle = await startTranscriptCaptureWorker(getDbAccessor(), AGENTS_DIR);
-	}
-	if (!transcriptRecoveryWorkerHandle) {
-		transcriptRecoveryWorkerHandle = startTranscriptRecoveryWorker(getDbAccessor(), AGENTS_DIR, resolveDaemonAgentId());
-	}
+		schedulerHandle = startSchedulerWorker(getDbAccessor());
+		if (!transcriptCaptureWorkerHandle) {
+			transcriptCaptureWorkerHandle = await startTranscriptCaptureWorker(getDbAccessor(), AGENTS_DIR);
+		}
+		if (!transcriptRecoveryWorkerHandle) {
+			transcriptRecoveryWorkerHandle = startTranscriptRecoveryWorker(
+				getDbAccessor(),
+				AGENTS_DIR,
+				resolveDaemonAgentId(),
+			);
+		}
 
-	checkpointPruneTimer = setInterval(() => {
-		try {
-			const cfg = loadMemoryConfig(AGENTS_DIR).pipelineV2.continuity;
-			if (cfg.enabled) {
-				pruneCheckpoints(getDbAccessor(), cfg.retentionDays);
+		checkpointPruneTimer = setInterval(() => {
+			try {
+				const cfg = loadMemoryConfig(AGENTS_DIR).pipelineV2.continuity;
+				if (cfg.enabled) {
+					pruneCheckpoints(getDbAccessor(), cfg.retentionDays);
+				}
+			} catch (err) {
+				logger.warn("daemon", "Checkpoint pruning failed", {
+					error: err instanceof Error ? err.message : String(err),
+				});
 			}
-		} catch (err) {
-			logger.warn("daemon", "Checkpoint pruning failed", {
-				error: err instanceof Error ? err.message : String(err),
+		}, 3600_000);
+		setCheckpointPruneTimer(checkpointPruneTimer);
+
+		startGitSyncTimer();
+		initUpdateSystem(CURRENT_VERSION, AGENTS_DIR, (preferredExecutablePath) => {
+			if (resolveDaemonRestartMode() === "service-manager") {
+				logger.info("daemon", "Update installed; releasing lock for launchd KeepAlive restart");
+				setTimeout(() => {
+					requestShutdown("update:launchd-restart", 0, undefined, false);
+				}, 500);
+				return;
+			}
+
+			const daemonScript = process.argv[1] ?? "";
+			if (!daemonScript) {
+				logger.warn("daemon", "Cannot self-restart: process.argv[1] is empty, falling back to clean exit");
+				setTimeout(() => {
+					requestShutdown("update:no-self-restart", 0, undefined, false);
+				}, 500);
+				return;
+			}
+
+			logger.info("daemon", "Spawning replacement daemon process", {
+				execPath: preferredExecutablePath ?? process.execPath,
+				script: daemonScript,
 			});
-		}
-	}, 3600_000);
-	setCheckpointPruneTimer(checkpointPruneTimer);
 
-	startGitSyncTimer();
-	initUpdateSystem(CURRENT_VERSION, AGENTS_DIR, (preferredExecutablePath) => {
-		if (resolveDaemonRestartMode() === "service-manager") {
-			logger.info("daemon", "Update installed; releasing lock for launchd KeepAlive restart");
+			const replacement = spawn(preferredExecutablePath ?? process.execPath, [daemonScript], {
+				detached: true,
+				stdio: "ignore",
+				windowsHide: true,
+				env: {
+					...process.env,
+					SIGNET_PORT: String(PORT),
+					SIGNET_HOST: HOST,
+					SIGNET_BIND: BIND_HOST,
+					SIGNET_PATH: AGENTS_DIR,
+					SIGNET_DAEMON_ENTRYPOINT: "1",
+				},
+			});
+			replacement.unref();
+
+			logger.info("daemon", "Replacement daemon spawned, exiting current process");
 			setTimeout(() => {
-				requestShutdown("update:launchd-restart", 0, undefined, false);
+				requestShutdown("update:replacement-spawned", 0, undefined, false);
 			}, 500);
-			return;
-		}
-
-		const daemonScript = process.argv[1] ?? "";
-		if (!daemonScript) {
-			logger.warn("daemon", "Cannot self-restart: process.argv[1] is empty, falling back to clean exit");
-			setTimeout(() => {
-				requestShutdown("update:no-self-restart", 0, undefined, false);
-			}, 500);
-			return;
-		}
-
-		logger.info("daemon", "Spawning replacement daemon process", {
-			execPath: preferredExecutablePath ?? process.execPath,
-			script: daemonScript,
 		});
-
-		const replacement = spawn(preferredExecutablePath ?? process.execPath, [daemonScript], {
-			detached: true,
-			stdio: "ignore",
-			windowsHide: true,
-			env: {
-				...process.env,
-				SIGNET_PORT: String(PORT),
-				SIGNET_HOST: HOST,
-				SIGNET_BIND: BIND_HOST,
-				SIGNET_PATH: AGENTS_DIR,
-				SIGNET_DAEMON_ENTRYPOINT: "1",
-			},
+		initFeatureFlags(AGENTS_DIR);
+		startUpdateTimer();
+	};
+	setTimeout(() => {
+		void startPostReadyRuntime().catch((error) => {
+			logger.error("daemon", "Deferred pipeline runtime startup failed", undefined, {
+				error: error instanceof Error ? error.message : String(error),
+			});
 		});
-		replacement.unref();
-
-		logger.info("daemon", "Replacement daemon spawned, exiting current process");
-		setTimeout(() => {
-			requestShutdown("update:replacement-spawned", 0, undefined, false);
-		}, 500);
-	});
-	initFeatureFlags(AGENTS_DIR);
-	startUpdateTimer();
+	}, 30_000);
 
 	const REQUEST_BODY_LIMIT = 10 * 1_048_576;
 	const { createServer: nodeCreateServer } = await import("node:http");
@@ -2434,227 +2447,231 @@ async function main() {
 			port: info.port,
 		});
 		logger.info("daemon", "Daemon ready");
-		logFdSnapshot("server-ready");
-		writeDaemonLifecycle(AGENTS_DIR, buildLifecycleRecord("running"));
-		vacuumConversionHandle = startVacuumConversionWorker(getDbAccessor());
-		void runDeferredIntegrityCheck(getDbAccessor(), MEMORY_DB, {
-			timeoutMs: 30_000,
-			owner: dbOwnerClient ?? undefined,
-			ownerAudit: (indexes, detectionMessages) => {
-				const auditId = createHash("sha256")
-					.update(JSON.stringify({ indexes, detectionMessages }))
-					.digest("hex")
-					.slice(0, 32);
-				return [
-					ownerRunStatement(
-						`INSERT OR IGNORE INTO memory_history
+		setTimeout(() => {
+			logFdSnapshot("server-ready");
+			writeDaemonLifecycle(AGENTS_DIR, buildLifecycleRecord("running"));
+			vacuumConversionHandle = startVacuumConversionWorker(getDbAccessor());
+			void runDeferredIntegrityCheck(getDbAccessor(), MEMORY_DB, {
+				timeoutMs: 30_000,
+				owner: dbOwnerClient ?? undefined,
+				ownerAudit: (indexes, detectionMessages) => {
+					const auditId = createHash("sha256")
+						.update(JSON.stringify({ indexes, detectionMessages }))
+						.digest("hex")
+						.slice(0, 32);
+					return [
+						ownerRunStatement(
+							`INSERT OR IGNORE INTO memory_history
 						 (id, memory_id, event, old_content, new_content, changed_by, reason, metadata, created_at, actor_type)
 						 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-						[
-							auditId,
-							"system",
-							"none",
-							null,
-							null,
-							"daemon",
-							"deferred database integrity repair",
-							JSON.stringify({ repairAction: "reindex-telemetry", indexes, detectionMessages }),
-							new Date().toISOString(),
-							"daemon",
-						],
-					),
-				];
-			},
-			audit: (db, indexes) => {
-				try {
-					insertHistoryEvent(db, {
-						memoryId: "system",
-						event: "none",
-						oldContent: null,
-						newContent: null,
-						changedBy: "daemon",
-						reason: "deferred database integrity repair",
-						metadata: JSON.stringify({ repairAction: "reindex-telemetry", indexes }),
-						createdAt: new Date().toISOString(),
-						actorType: "daemon",
-					});
-				} catch (error) {
-					if (process.env.SIGNET_ALLOW_UNAUDITED_TELEMETRY_REPAIR !== "1") throw error;
-					logger.error("startup-recovery", "Telemetry index repair committed without audit", undefined, {
-						error: error instanceof Error ? error.message : String(error),
-						indexes,
-					});
-				}
-			},
-		})
-			.then((status) => {
-				if (status.state === "corrupt" || status.state === "unavailable") {
-					logger.error("startup-recovery", "Database integrity failed after readiness", undefined, {
-						state: status.state,
-						phase: status.phase,
-						quickCheck: status.quickCheck.messages,
-						telemetryCheck: status.telemetryCheck.messages,
-						guidance:
-							"Stop the daemon, back up the database, and run the operator integrity repair flow before restarting.",
-					});
-				}
-			})
-			.catch((error) => {
-				logger.error("startup-recovery", "Deferred database integrity check rejected", error);
-			});
-
-		const healthStampPath = join(DAEMON_DIR, "last-healthy-start");
-		try {
-			let previousVersion: string | null = null;
-			if (existsSync(healthStampPath)) {
-				const prev = JSON.parse(readFileSync(healthStampPath, "utf-8"));
-				previousVersion = typeof prev.version === "string" ? prev.version : null;
-			}
-			writeFileSync(
-				healthStampPath,
-				JSON.stringify({
-					version: CURRENT_VERSION,
-					startedAt: new Date().toISOString(),
-					pid: process.pid,
-				}),
-			);
-			if (previousVersion && previousVersion !== CURRENT_VERSION && CURRENT_VERSION !== "0.0.0") {
-				logger.info("daemon", `Upgraded from ${previousVersion} to ${CURRENT_VERSION}`, {
-					previousVersion,
-					currentVersion: CURRENT_VERSION,
-				});
-				logger.info(
-					"daemon",
-					"What's new: knowledge graph, session continuity, constellation entity overlay, predictive scorer (opt-in)",
-				);
-			}
-		} catch {}
-
-		importExistingMemoryFiles().catch((e) => {
-			const errDetails = e instanceof Error ? { message: e.message, stack: e.stack } : { error: String(e) };
-			logger.error("daemon", "Failed to import existing memory files", undefined, errDetails);
-		});
-		startMemoryImportPoller();
-		startStaleSessionSweeper();
-		startAcpDeliveryReconciliation();
-
-		if (!nativeMemoryBridge) {
-			const startupSourceJobs = new Map<string, string>();
-			for (const source of loadSourcesConfig(AGENTS_DIR).sources) {
-				if (!source.enabled || source.kind !== "obsidian") continue;
-				// Startup indexing is asynchronous; keep its lifecycle write in the shutdown drain.
-				void trackSourceLifecycleWrite(recordSourceConnected(source, resolveDaemonAgentId()));
-				const job = beginSourceIndexJob(source.id, "source-startup");
-				startupSourceJobs.set(source.id, job.id);
-				markSourceIndexInFlight(source.id);
-				markSourceIndexJobRunning(source.id, job.id);
-			}
-			nativeMemoryBridge = startNativeMemoryBridge(configuredNativeMemorySources(AGENTS_DIR), {
-				agentsDir: AGENTS_DIR,
-				includeConfiguredSources: true,
-				pollIntervalMs: 10_000,
-				sourceCleanupEnabled: true,
-				shouldCleanupSource: (source) => source.harness !== "obsidian",
-				sourceGraphEnabled: false,
-				...resolveEmbeddingBridgeOptions(memoryCfg.embedding, fetchEmbedding),
-				onFileIndexed: (event) => {
-					const sourceId = event.source.sourceId;
-					if (!sourceId) return;
-					const jobId = startupSourceJobs.get(sourceId);
-					if (!jobId) return;
-					updateSourceIndexJobProgress(sourceId, jobId, {
-						scanned: event.scanned,
-						total: event.total,
-						indexed: event.changed,
-						currentPath: event.filePath,
-						statusMessage: event.status,
-					});
+							[
+								auditId,
+								"system",
+								"none",
+								null,
+								null,
+								"daemon",
+								"deferred database integrity repair",
+								JSON.stringify({ repairAction: "reindex-telemetry", indexes, detectionMessages }),
+								new Date().toISOString(),
+								"daemon",
+							],
+						),
+					];
 				},
-			});
-			nativeMemoryBridge
-				.syncExisting()
-				.then(() => {
-					for (const [sourceId, jobId] of startupSourceJobs) {
-						completeSourceIndexJobFromProgress(sourceId, jobId);
-						const source = loadSourcesConfig(AGENTS_DIR).sources.find((entry) => entry.id === sourceId);
-						const job = getSourceIndexJob(sourceId);
-						if (source) {
-							// Index completion is intentionally fire-and-forget, but tracked until shutdown.
-							void trackSourceLifecycleWrite(
-								recordSourceIndexOperation({
-									source,
-									agentId: resolveDaemonAgentId(),
-									discovered: job?.scanned ?? 0,
-									accepted: job?.indexed ?? 0,
-									durationMs:
-										job?.startedAt && job.finishedAt
-											? Math.max(0, Date.parse(job.finishedAt) - Date.parse(job.startedAt))
-											: 0,
-									outcome: "success",
-								}),
-							);
-						}
+				audit: (db, indexes) => {
+					try {
+						insertHistoryEvent(db, {
+							memoryId: "system",
+							event: "none",
+							oldContent: null,
+							newContent: null,
+							changedBy: "daemon",
+							reason: "deferred database integrity repair",
+							metadata: JSON.stringify({ repairAction: "reindex-telemetry", indexes }),
+							createdAt: new Date().toISOString(),
+							actorType: "daemon",
+						});
+					} catch (error) {
+						if (process.env.SIGNET_ALLOW_UNAUDITED_TELEMETRY_REPAIR !== "1") throw error;
+						logger.error("startup-recovery", "Telemetry index repair committed without audit", undefined, {
+							error: error instanceof Error ? error.message : String(error),
+							indexes,
+						});
+					}
+				},
+			})
+				.then((status) => {
+					if (status.state === "corrupt" || status.state === "unavailable") {
+						logger.error("startup-recovery", "Database integrity failed after readiness", undefined, {
+							state: status.state,
+							phase: status.phase,
+							quickCheck: status.quickCheck.messages,
+							telemetryCheck: status.telemetryCheck.messages,
+							guidance:
+								"Stop the daemon, back up the database, and run the operator integrity repair flow before restarting.",
+						});
 					}
 				})
-				.catch((e) => {
-					for (const [sourceId, jobId] of startupSourceJobs) {
-						const source = loadSourcesConfig(AGENTS_DIR).sources.find((entry) => entry.id === sourceId);
-						const job = getSourceIndexJob(sourceId);
-						if (source) {
-							// Failed indexing follows the same tracked best-effort shutdown path.
-							void trackSourceLifecycleWrite(
-								recordSourceIndexOperation({
-									source,
-									agentId: resolveDaemonAgentId(),
-									discovered: job?.scanned ?? 0,
-									accepted: job?.indexed ?? 0,
-									failed: 1,
-									durationMs: job?.startedAt ? Math.max(0, Date.now() - Date.parse(job.startedAt)) : 0,
-									outcome: (job?.indexed ?? 0) > 0 ? "partial" : "failed",
-									failureClass: sourceFailureClass(e),
-									searchable: (job?.indexed ?? 0) > 0,
-								}),
-							);
-						}
-						failSourceIndexJob(sourceId, jobId, e);
-					}
-					const errDetails = e instanceof Error ? { message: e.message, stack: e.stack } : { error: String(e) };
-					logger.error("daemon", "Failed to sync native memory sources", undefined, errDetails);
-				})
-				.finally(() => {
-					for (const sourceId of startupSourceJobs.keys()) clearSourceIndexInFlight(sourceId);
+				.catch((error) => {
+					logger.error("startup-recovery", "Deferred database integrity check rejected", error);
 				});
-		}
 
-		const startupCfg = loadMemoryConfig(AGENTS_DIR);
-		if (startupCfg.embedding.provider !== "none") {
-			checkEmbeddingProvider(startupCfg.embedding)
-				.then((embeddingStatus) => {
-					if (!embeddingStatus.available) {
-						logger.warn(
-							"daemon",
-							`Embedding provider '${startupCfg.embedding.provider}' is unavailable: ${embeddingStatus.error ?? "unknown error"}`,
-						);
-						logger.warn(
-							"daemon",
-							"Vector search and memory embeddings will not work until this is resolved. Run 'signet sync' or reconfigure with 'signet setup'.",
-						);
-					} else if (embeddingStatus.error) {
-						logger.warn("daemon", `Embedding provider using fallback: ${embeddingStatus.error}`);
-					} else {
-						logger.info(
-							"daemon",
-							`Embedding provider '${startupCfg.embedding.provider}' is ready (model: ${startupCfg.embedding.model})`,
-						);
-					}
-				})
-				.catch((e) => {
-					logger.warn(
+			const healthStampPath = join(DAEMON_DIR, "last-healthy-start");
+			try {
+				let previousVersion: string | null = null;
+				if (existsSync(healthStampPath)) {
+					const prev = JSON.parse(readFileSync(healthStampPath, "utf-8"));
+					previousVersion = typeof prev.version === "string" ? prev.version : null;
+				}
+				writeFileSync(
+					healthStampPath,
+					JSON.stringify({
+						version: CURRENT_VERSION,
+						startedAt: new Date().toISOString(),
+						pid: process.pid,
+					}),
+				);
+				if (previousVersion && previousVersion !== CURRENT_VERSION && CURRENT_VERSION !== "0.0.0") {
+					logger.info("daemon", `Upgraded from ${previousVersion} to ${CURRENT_VERSION}`, {
+						previousVersion,
+						currentVersion: CURRENT_VERSION,
+					});
+					logger.info(
 						"daemon",
-						`Embedding provider health check failed: ${e instanceof Error ? e.message : String(e)}`,
+						"What's new: knowledge graph, session continuity, constellation entity overlay, predictive scorer (opt-in)",
 					);
-				});
-		}
+				}
+			} catch {}
+
+			importExistingMemoryFiles().catch((e) => {
+				const errDetails = e instanceof Error ? { message: e.message, stack: e.stack } : { error: String(e) };
+				logger.error("daemon", "Failed to import existing memory files", undefined, errDetails);
+			});
+			startMemoryImportPoller();
+			startStaleSessionSweeper();
+			startAcpDeliveryReconciliation();
+
+			setTimeout(() => {
+				if (!nativeMemoryBridge) {
+					const startupSourceJobs = new Map<string, string>();
+					for (const source of loadSourcesConfig(AGENTS_DIR).sources) {
+						if (!source.enabled || source.kind !== "obsidian") continue;
+						// Startup indexing is asynchronous; keep its lifecycle write in the shutdown drain.
+						void trackSourceLifecycleWrite(recordSourceConnected(source, resolveDaemonAgentId()));
+						const job = beginSourceIndexJob(source.id, "source-startup");
+						startupSourceJobs.set(source.id, job.id);
+						markSourceIndexInFlight(source.id);
+						markSourceIndexJobRunning(source.id, job.id);
+					}
+					nativeMemoryBridge = startNativeMemoryBridge(configuredNativeMemorySources(AGENTS_DIR), {
+						agentsDir: AGENTS_DIR,
+						includeConfiguredSources: true,
+						pollIntervalMs: 10_000,
+						sourceCleanupEnabled: true,
+						shouldCleanupSource: (source) => source.harness !== "obsidian",
+						sourceGraphEnabled: false,
+						...resolveEmbeddingBridgeOptions(memoryCfg.embedding, fetchEmbedding),
+						onFileIndexed: (event) => {
+							const sourceId = event.source.sourceId;
+							if (!sourceId) return;
+							const jobId = startupSourceJobs.get(sourceId);
+							if (!jobId) return;
+							updateSourceIndexJobProgress(sourceId, jobId, {
+								scanned: event.scanned,
+								total: event.total,
+								indexed: event.changed,
+								currentPath: event.filePath,
+								statusMessage: event.status,
+							});
+						},
+					});
+					nativeMemoryBridge
+						.syncExisting()
+						.then(() => {
+							for (const [sourceId, jobId] of startupSourceJobs) {
+								completeSourceIndexJobFromProgress(sourceId, jobId);
+								const source = loadSourcesConfig(AGENTS_DIR).sources.find((entry) => entry.id === sourceId);
+								const job = getSourceIndexJob(sourceId);
+								if (source) {
+									// Index completion is intentionally fire-and-forget, but tracked until shutdown.
+									void trackSourceLifecycleWrite(
+										recordSourceIndexOperation({
+											source,
+											agentId: resolveDaemonAgentId(),
+											discovered: job?.scanned ?? 0,
+											accepted: job?.indexed ?? 0,
+											durationMs:
+												job?.startedAt && job.finishedAt
+													? Math.max(0, Date.parse(job.finishedAt) - Date.parse(job.startedAt))
+													: 0,
+											outcome: "success",
+										}),
+									);
+								}
+							}
+						})
+						.catch((e) => {
+							for (const [sourceId, jobId] of startupSourceJobs) {
+								const source = loadSourcesConfig(AGENTS_DIR).sources.find((entry) => entry.id === sourceId);
+								const job = getSourceIndexJob(sourceId);
+								if (source) {
+									// Failed indexing follows the same tracked best-effort shutdown path.
+									void trackSourceLifecycleWrite(
+										recordSourceIndexOperation({
+											source,
+											agentId: resolveDaemonAgentId(),
+											discovered: job?.scanned ?? 0,
+											accepted: job?.indexed ?? 0,
+											failed: 1,
+											durationMs: job?.startedAt ? Math.max(0, Date.now() - Date.parse(job.startedAt)) : 0,
+											outcome: (job?.indexed ?? 0) > 0 ? "partial" : "failed",
+											failureClass: sourceFailureClass(e),
+											searchable: (job?.indexed ?? 0) > 0,
+										}),
+									);
+								}
+								failSourceIndexJob(sourceId, jobId, e);
+							}
+							const errDetails = e instanceof Error ? { message: e.message, stack: e.stack } : { error: String(e) };
+							logger.error("daemon", "Failed to sync native memory sources", undefined, errDetails);
+						})
+						.finally(() => {
+							for (const sourceId of startupSourceJobs.keys()) clearSourceIndexInFlight(sourceId);
+						});
+				}
+			}, 30_000);
+
+			const startupCfg = loadMemoryConfig(AGENTS_DIR);
+			if (startupCfg.embedding.provider !== "none") {
+				checkEmbeddingProvider(startupCfg.embedding)
+					.then((embeddingStatus) => {
+						if (!embeddingStatus.available) {
+							logger.warn(
+								"daemon",
+								`Embedding provider '${startupCfg.embedding.provider}' is unavailable: ${embeddingStatus.error ?? "unknown error"}`,
+							);
+							logger.warn(
+								"daemon",
+								"Vector search and memory embeddings will not work until this is resolved. Run 'signet sync' or reconfigure with 'signet setup'.",
+							);
+						} else if (embeddingStatus.error) {
+							logger.warn("daemon", `Embedding provider using fallback: ${embeddingStatus.error}`);
+						} else {
+							logger.info(
+								"daemon",
+								`Embedding provider '${startupCfg.embedding.provider}' is ready (model: ${startupCfg.embedding.model})`,
+							);
+						}
+					})
+					.catch((e) => {
+						logger.warn(
+							"daemon",
+							`Embedding provider health check failed: ${e instanceof Error ? e.message : String(e)}`,
+						);
+					});
+			}
+		}, 30_000);
 	};
 
 	bindWithRetry({

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -64,6 +64,7 @@ import {
 	ownerRunStatement,
 	registerDbOwnerMaintenance,
 } from "./db-owner-maintenance";
+import { createDeferredRuntimeGate } from "./deferred-runtime-gate";
 import { getQueueDiagnosticsSnapshot, getQueuePressureSnapshot } from "./diagnostics-queue";
 import { fetchEmbedding } from "./embedding-fetch";
 import { type EmbeddingIndexMigrationHandle, startEmbeddingIndexMigration } from "./embedding-index-migration";
@@ -2322,10 +2323,13 @@ async function main() {
 		setHeartbeatTimer(heartbeatTimer);
 	}
 
+	const deferredRuntimeGate = createDeferredRuntimeGate();
+
 	// Grace period: defer all background workers for 10s after startup so the
 	// event-loop monitor can calibrate and migrations can settle before any
 	// background write work piles on (#1059 thundering-herd prevention).
 	const startPostReadyRuntime = async (): Promise<void> => {
+		await deferredRuntimeGate.waitForIntegrity();
 		reportStartupGrace();
 		await startPipelineRuntime(memoryCfg, telemetryCollector);
 		logFdSnapshot("post-pipeline");
@@ -2440,6 +2444,12 @@ async function main() {
 
 	const BIND_MAX_DELAY_MS = 30_000;
 	const BIND_RETRY_BASE_MS = 1000;
+	// A whole-database quick_check can legitimately exceed the ordinary job
+	// budget on an existing workspace. Run it in the killable child with a
+	// bounded scan budget, while keeping each owner maintenance request on the
+	// ordinary 30s runaway-job deadline and preventing pipeline contention.
+	const DEFERRED_INTEGRITY_TIMEOUT_MS = 90_000;
+	const DEFERRED_INTEGRITY_OWNER_TIMEOUT_MS = 30_000;
 
 	const onListening = (info: { address: string; port: number }): void => {
 		logger.info("daemon", "Server listening", {
@@ -2452,7 +2462,8 @@ async function main() {
 			writeDaemonLifecycle(AGENTS_DIR, buildLifecycleRecord("running"));
 			vacuumConversionHandle = startVacuumConversionWorker(getDbAccessor());
 			void runDeferredIntegrityCheck(getDbAccessor(), MEMORY_DB, {
-				timeoutMs: 30_000,
+				timeoutMs: DEFERRED_INTEGRITY_TIMEOUT_MS,
+				ownerTimeoutMs: DEFERRED_INTEGRITY_OWNER_TIMEOUT_MS,
 				owner: dbOwnerClient ?? undefined,
 				ownerAudit: (indexes, detectionMessages) => {
 					const auditId = createHash("sha256")
@@ -2515,6 +2526,9 @@ async function main() {
 				})
 				.catch((error) => {
 					logger.error("startup-recovery", "Deferred database integrity check rejected", error);
+				})
+				.finally(() => {
+					deferredRuntimeGate.completeIntegrity();
 				});
 
 			const healthStampPath = join(DAEMON_DIR, "last-healthy-start");

--- a/platform/daemon/src/database-integrity.test.ts
+++ b/platform/daemon/src/database-integrity.test.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { repairTelemetryIndexes, runDeferredIntegrityCheck } from "./database-integrity";
@@ -367,6 +367,44 @@ describe("deferred database integrity recovery (#1513)", () => {
 		expect(result.state).toBe("unavailable");
 		expect(result.phase).toBe("complete");
 		expect(result.repairGuidance).toContain("back up the database");
+	});
+
+	it("does not pass profiler or inspector env to the integrity child", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "integrity-worker-env-"));
+		const markerPath = join(dir, "worker-env.json");
+		const workerPath = join(dir, "env-worker.mjs");
+		writeFileSync(
+			workerPath,
+			[
+				'import { writeFileSync } from "node:fs";',
+				`writeFileSync(${JSON.stringify(markerPath)}, JSON.stringify({ bunInspect: process.env.BUN_INSPECT, bunOptions: process.env.BUN_OPTIONS, handoff: process.env.SIGNET_INSPECTOR_HANDOFF, public: process.env.SIGNET_INSPECTOR_PUBLIC, proxyPublic: process.env.SIGNET_INSPECTOR_PROXY_PUBLIC, proxyTarget: process.env.SIGNET_INSPECTOR_PROXY_TARGET }));`,
+				'process.stdout.write(JSON.stringify({ type: "result", result: { quickCheck: { ok: true, messages: [] } } }) + "\\n");',
+			].join("\n"),
+		);
+		const keys = [
+			"BUN_INSPECT",
+			"BUN_OPTIONS",
+			"SIGNET_INSPECTOR_HANDOFF",
+			"SIGNET_INSPECTOR_PUBLIC",
+			"SIGNET_INSPECTOR_PROXY_PUBLIC",
+			"SIGNET_INSPECTOR_PROXY_TARGET",
+		] as const;
+		const previous = keys.map((key) => [key, process.env[key]] as const);
+		for (const key of keys) process.env[key] = `test-${key}`;
+		try {
+			const result = await runDeferredIntegrityCheck(fakeAccessor({}).accessor, "/tmp/not-used.db", {
+				workerPath,
+				timeoutMs: 1000,
+			});
+			expect(result.state).toBe("healthy");
+			expect(JSON.parse(readFileSync(markerPath, "utf8"))).toEqual({});
+		} finally {
+			for (const [key, value] of previous) {
+				if (value === undefined) delete process.env[key];
+				else process.env[key] = value;
+			}
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 
 	it("kills a synchronous scan at the deadline on a large fixture", async () => {

--- a/platform/daemon/src/database-integrity.test.ts
+++ b/platform/daemon/src/database-integrity.test.ts
@@ -438,7 +438,7 @@ describe("deferred database integrity recovery (#1513)", () => {
 		for (const key of keys) process.env[key] = `test-${key}`;
 		try {
 			const result = await repairTelemetryIndexes(
-				fakeAccessor({ telemetryMessage: "index mismatch" }).accessor,
+				fakeAccessor({ telemetryMessage: "index mismatch", repairAfterFirstTelemetryCheck: true }).accessor,
 				(db) => db.exec("audit"),
 				{
 					dbPath,

--- a/platform/daemon/src/database-integrity.test.ts
+++ b/platform/daemon/src/database-integrity.test.ts
@@ -407,6 +407,57 @@ describe("deferred database integrity recovery (#1513)", () => {
 		}
 	});
 
+	it("does not pass profiler or inspector env to the telemetry repair child", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "integrity-repair-worker-env-"));
+		const dbPath = join(dir, "memory.db");
+		const markerPath = join(dir, "worker-env.json");
+		const workerPath = join(dir, "env-repair-worker.mjs");
+		const database = new Database(dbPath);
+		database.exec(
+			"CREATE TABLE telemetry_events (event TEXT); CREATE INDEX idx_telemetry_events_event ON telemetry_events(event)",
+		);
+		database.close();
+		writeFileSync(
+			workerPath,
+			[
+				'import { writeFileSync } from "node:fs";',
+				`const keys = ["BUN_INSPECT", "BUN_OPTIONS", "NODE_OPTIONS", "SIGNET_INSPECTOR_HANDOFF", "SIGNET_INSPECTOR_PUBLIC", "SIGNET_INSPECTOR_PROXY_PUBLIC", "SIGNET_INSPECTOR_PROXY_TARGET"]; writeFileSync(${JSON.stringify(markerPath)}, JSON.stringify(Object.fromEntries(keys.filter((key) => process.env[key] !== undefined).map((key) => [key, process.env[key]]))));`,
+				'process.stdout.write(JSON.stringify({ ok: true }) + "\\n");',
+			].join("\n"),
+		);
+		const keys = [
+			"BUN_INSPECT",
+			"BUN_OPTIONS",
+			"NODE_OPTIONS",
+			"SIGNET_INSPECTOR_HANDOFF",
+			"SIGNET_INSPECTOR_PUBLIC",
+			"SIGNET_INSPECTOR_PROXY_PUBLIC",
+			"SIGNET_INSPECTOR_PROXY_TARGET",
+		] as const;
+		const previous = keys.map((key) => [key, process.env[key]] as const);
+		for (const key of keys) process.env[key] = `test-${key}`;
+		try {
+			const result = await repairTelemetryIndexes(
+				fakeAccessor({ telemetryMessage: "index mismatch" }).accessor,
+				(db) => db.exec("audit"),
+				{
+					dbPath,
+					repairWorkerPath: workerPath,
+					repairRuntimePath: "node",
+					repairTimeoutMs: 5_000,
+				},
+			);
+			expect(result.state).toBe("repaired");
+			expect(JSON.parse(readFileSync(markerPath, "utf8"))).toEqual({});
+		} finally {
+			for (const [key, value] of previous) {
+				if (value === undefined) delete process.env[key];
+				else process.env[key] = value;
+			}
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("kills a synchronous scan at the deadline on a large fixture", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "integrity-large-"));
 		const dbPath = join(dir, "memory.db");

--- a/platform/daemon/src/database-integrity.ts
+++ b/platform/daemon/src/database-integrity.ts
@@ -399,11 +399,22 @@ async function runDeferredIntegrityCheckInternal(
 	let progressTimer: ReturnType<typeof setInterval> | undefined;
 
 	try {
+		const workerEnv: NodeJS.ProcessEnv = {
+			...process.env,
+			SIGNET_DATABASE_INTEGRITY_DB_PATH: dbPath,
+		};
+		// The integrity child must not inherit the daemon's inspector or
+		// profiler settings. In the profiling runbook BUN_INSPECT points at the
+		// daemon's private inspector port. The child then tries to bind the same
+		// port and exits before it can report its quick_check result.
+		delete workerEnv.BUN_INSPECT;
+		delete workerEnv.BUN_OPTIONS;
+		delete workerEnv.SIGNET_INSPECTOR_HANDOFF;
+		delete workerEnv.SIGNET_INSPECTOR_PUBLIC;
+		delete workerEnv.SIGNET_INSPECTOR_PROXY_PUBLIC;
+		delete workerEnv.SIGNET_INSPECTOR_PROXY_TARGET;
 		const child = spawn(process.execPath, workerArgs, {
-			env: {
-				...process.env,
-				SIGNET_DATABASE_INTEGRITY_DB_PATH: dbPath,
-			},
+			env: workerEnv,
 			stdio: ["ignore", "pipe", "pipe"],
 		});
 		worker = child;

--- a/platform/daemon/src/database-integrity.ts
+++ b/platform/daemon/src/database-integrity.ts
@@ -44,6 +44,21 @@ export interface DatabaseIntegrityStatus {
 const UNKNOWN_CHECK: IntegrityCheckStatus = { ok: false, messages: ["not checked"] };
 const REPAIR_GUIDANCE =
 	"Stop the daemon, back up the database, and run the operator integrity repair flow before restarting.";
+const INTEGRITY_CHILD_ENV_KEYS = [
+	"BUN_INSPECT",
+	"BUN_OPTIONS",
+	"NODE_OPTIONS",
+	"SIGNET_INSPECTOR_HANDOFF",
+	"SIGNET_INSPECTOR_PUBLIC",
+	"SIGNET_INSPECTOR_PROXY_PUBLIC",
+	"SIGNET_INSPECTOR_PROXY_TARGET",
+] as const;
+
+function integrityChildEnv(extra: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = { ...process.env, ...extra };
+	for (const key of INTEGRITY_CHILD_ENV_KEYS) delete env[key];
+	return env;
+}
 
 let latestStatus: DatabaseIntegrityStatus = {
 	checkedAt: "",
@@ -233,12 +248,11 @@ async function runKillableTelemetryRepair(
 	let child: ChildProcess | undefined;
 	try {
 		child = spawn(runtimePath ?? process.execPath, [scriptPath], {
-			env: {
-				...process.env,
+			env: integrityChildEnv({
 				SIGNET_DATABASE_INTEGRITY_DB_PATH: dbPath,
 				SIGNET_DATABASE_INTEGRITY_INDEXES: JSON.stringify(indexes),
 				SIGNET_DATABASE_INTEGRITY_REQUIRE_BASE: requireBase ?? fileURLToPath(import.meta.url),
-			},
+			}),
 			stdio: ["ignore", "pipe", "pipe"],
 		});
 		await new Promise<void>((resolve, reject) => {
@@ -399,20 +413,13 @@ async function runDeferredIntegrityCheckInternal(
 	let progressTimer: ReturnType<typeof setInterval> | undefined;
 
 	try {
-		const workerEnv: NodeJS.ProcessEnv = {
-			...process.env,
-			SIGNET_DATABASE_INTEGRITY_DB_PATH: dbPath,
-		};
 		// The integrity child must not inherit the daemon's inspector or
 		// profiler settings. In the profiling runbook BUN_INSPECT points at the
 		// daemon's private inspector port. The child then tries to bind the same
 		// port and exits before it can report its quick_check result.
-		delete workerEnv.BUN_INSPECT;
-		delete workerEnv.BUN_OPTIONS;
-		delete workerEnv.SIGNET_INSPECTOR_HANDOFF;
-		delete workerEnv.SIGNET_INSPECTOR_PUBLIC;
-		delete workerEnv.SIGNET_INSPECTOR_PROXY_PUBLIC;
-		delete workerEnv.SIGNET_INSPECTOR_PROXY_TARGET;
+		const workerEnv = integrityChildEnv({
+			SIGNET_DATABASE_INTEGRITY_DB_PATH: dbPath,
+		});
 		const child = spawn(process.execPath, workerArgs, {
 			env: workerEnv,
 			stdio: ["ignore", "pipe", "pipe"],

--- a/platform/daemon/src/database-integrity.ts
+++ b/platform/daemon/src/database-integrity.ts
@@ -151,6 +151,7 @@ function ownerCheck(rows: readonly Record<string, unknown>[], key: string): Inte
 export interface DeferredIntegrityCheckOptions {
 	readonly workerPath?: string;
 	readonly timeoutMs?: number;
+	readonly ownerTimeoutMs?: number;
 	readonly audit?: TelemetryIndexRepairAudit;
 	readonly onWorkerStarted?: () => void;
 	readonly owner?: DbOwnerClient;
@@ -169,6 +170,93 @@ class IntegrityRepairTimeoutError extends Error {
 	constructor(timeoutMs: number) {
 		super(`telemetry index repair exceeded ${timeoutMs}ms`);
 		this.name = "IntegrityRepairTimeoutError";
+	}
+}
+
+class IntegrityCheckTimeoutError extends Error {
+	readonly timedOut = true;
+
+	constructor(timeoutMs: number) {
+		super(`database integrity check exceeded ${timeoutMs}ms`);
+		this.name = "IntegrityCheckTimeoutError";
+	}
+}
+
+async function runIntegrityWorkerCheck(
+	dbPath: string,
+	timeoutMs: number,
+	options: Partial<DeferredIntegrityCheckOptions>,
+): Promise<DatabaseIntegrityWorkerResult> {
+	const startedAt = Date.now();
+	const embeddedWorkerPath = resolveEmbeddedWorkerPath("database-integrity-worker");
+	const workerPath = options.workerPath ?? embeddedWorkerPath ?? workerPathFromModule();
+	const workerArgs = options.workerPath === undefined && embeddedWorkerPath !== null ? [] : [workerPath];
+	let worker: ChildProcess | undefined;
+	let progressTimer: ReturnType<typeof setInterval> | undefined;
+	try {
+		// The integrity child must not inherit the daemon's inspector or
+		// profiler settings. In the profiling runbook BUN_INSPECT points at the
+		// daemon's private inspector port. The child then tries to bind the same
+		// port and exits before it can report its quick_check result.
+		const workerEnv = integrityChildEnv({
+			SIGNET_DATABASE_INTEGRITY_DB_PATH: dbPath,
+		});
+		const child = spawn(process.execPath, workerArgs, {
+			env: workerEnv,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		worker = child;
+		return await new Promise<DatabaseIntegrityWorkerResult>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				child.kill("SIGKILL");
+				reject(new IntegrityCheckTimeoutError(timeoutMs));
+			}, timeoutMs);
+			let output = "";
+			child.stdout.setEncoding("utf8");
+			child.stdout.on("data", (chunk: string) => {
+				for (const line of `${output}${chunk}`.split("\n").slice(0, -1)) {
+					if (line === "started") {
+						options.onWorkerStarted?.();
+						continue;
+					}
+					if (line.length > 0) {
+						try {
+							const message = JSON.parse(line) as DatabaseIntegrityWorkerMessage;
+							if (message.type === "result") {
+								clearTimeout(timer);
+								resolve(message.result);
+							}
+						} catch {
+							// The close handler reports a malformed or incomplete response.
+						}
+					}
+				}
+				output = `${output}${chunk}`.split("\n").at(-1) ?? "";
+			});
+			progressTimer = setInterval(() => {
+				logger.info("startup-recovery", "Database integrity check in progress", {
+					elapsedMs: Date.now() - startedAt,
+					budgetMs: timeoutMs,
+				});
+			}, 1000);
+			child.once("error", (error) => {
+				clearTimeout(timer);
+				reject(error);
+			});
+			child.once("close", (code) => {
+				if (code !== 0) {
+					clearTimeout(timer);
+					reject(new Error(`database integrity worker exited with code ${code ?? "unknown"}`));
+				} else {
+					clearTimeout(timer);
+					reject(new Error("database integrity worker exited without a result"));
+				}
+			});
+			child.stderr.resume();
+		});
+	} finally {
+		if (progressTimer !== undefined) clearInterval(progressTimer);
+		if (worker !== undefined && worker.exitCode === null) worker.kill("SIGKILL");
 	}
 }
 
@@ -341,23 +429,28 @@ async function runOwnerDeferredIntegrityCheck(
 	const owner = options.owner;
 	if (owner === undefined) throw new Error("owner integrity check requires a DB owner");
 	const timeoutMs = options.timeoutMs ?? DEFAULT_INTEGRITY_TIMEOUT_MS;
+	const ownerTimeoutMs = options.ownerTimeoutMs ?? Math.min(timeoutMs, DEFAULT_INTEGRITY_TIMEOUT_MS);
 	const startedAt = Date.now();
 	latestStatus = statusWith("unknown", UNKNOWN_CHECK, UNKNOWN_CHECK, [], "running", 0, null, owner);
-	logger.info("startup-recovery", "Deferred database integrity check started through the DB owner", { timeoutMs });
+	logger.info("startup-recovery", "Deferred database integrity check started through the DB owner", {
+		timeoutMs,
+		ownerTimeoutMs,
+	});
 	const progressTimer = setInterval(() => {
 		const health = owner.health();
 		logger.info("startup-recovery", "Database integrity owner work in progress", {
 			elapsedMs: Date.now() - startedAt,
-			budgetMs: timeoutMs,
+			budgetMs: ownerTimeoutMs,
 			ownerState: health.state,
 			ownerGeneration: health.generation,
 			deadlineKills: health.deadlineKills,
 		});
 	}, 1_000);
 	try {
+		const result = await runIntegrityWorkerCheck(dbPath, timeoutMs, options);
 		const status = await repairTelemetryIndexes(accessor, options.audit, {
-			dbPath,
-			repairTimeoutMs: timeoutMs,
+			quickCheck: result.quickCheck,
+			repairTimeoutMs: ownerTimeoutMs,
 			owner,
 			ownerAudit: options.ownerAudit,
 		});
@@ -372,7 +465,7 @@ async function runOwnerDeferredIntegrityCheck(
 		return latestStatus;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		const timedOut = error instanceof DbOwnerDeadlineError;
+		const timedOut = error instanceof DbOwnerDeadlineError || error instanceof IntegrityCheckTimeoutError;
 		latestStatus = statusWith(
 			"unavailable",
 			{ ok: false, messages: [message] },
@@ -405,76 +498,8 @@ async function runDeferredIntegrityCheckInternal(
 	const startedAt = Date.now();
 	latestStatus = statusWith("unknown", UNKNOWN_CHECK, UNKNOWN_CHECK, [], "running", 0);
 	logger.info("startup-recovery", "Deferred database integrity check started", { timeoutMs });
-	const embeddedWorkerPath = resolveEmbeddedWorkerPath("database-integrity-worker");
-	const workerPath = options.workerPath ?? embeddedWorkerPath ?? workerPathFromModule();
-	const workerArgs = options.workerPath === undefined && embeddedWorkerPath !== null ? [] : [workerPath];
-	let worker: ChildProcess | undefined;
-	let timedOut = false;
-	let progressTimer: ReturnType<typeof setInterval> | undefined;
-
 	try {
-		// The integrity child must not inherit the daemon's inspector or
-		// profiler settings. In the profiling runbook BUN_INSPECT points at the
-		// daemon's private inspector port. The child then tries to bind the same
-		// port and exits before it can report its quick_check result.
-		const workerEnv = integrityChildEnv({
-			SIGNET_DATABASE_INTEGRITY_DB_PATH: dbPath,
-		});
-		const child = spawn(process.execPath, workerArgs, {
-			env: workerEnv,
-			stdio: ["ignore", "pipe", "pipe"],
-		});
-		worker = child;
-		const result = await new Promise<DatabaseIntegrityWorkerResult>((resolve, reject) => {
-			const timer = setTimeout(() => {
-				timedOut = true;
-				child.kill("SIGKILL");
-				reject(new Error(`database integrity check exceeded ${timeoutMs}ms`));
-			}, timeoutMs);
-			let output = "";
-			child.stdout.setEncoding("utf8");
-			child.stdout.on("data", (chunk: string) => {
-				for (const line of `${output}${chunk}`.split("\n").slice(0, -1)) {
-					if (line === "started") {
-						options.onWorkerStarted?.();
-						continue;
-					}
-					if (line.length > 0) {
-						try {
-							const message = JSON.parse(line) as DatabaseIntegrityWorkerMessage;
-							if (message.type === "result") {
-								clearTimeout(timer);
-								resolve(message.result);
-							}
-						} catch {
-							// The close handler reports a malformed or incomplete response.
-						}
-					}
-				}
-				output = `${output}${chunk}`.split("\n").at(-1) ?? "";
-			});
-			progressTimer = setInterval(() => {
-				logger.info("startup-recovery", "Database integrity check in progress", {
-					elapsedMs: Date.now() - startedAt,
-					budgetMs: timeoutMs,
-				});
-			}, 1000);
-			child.once("error", (error) => {
-				clearTimeout(timer);
-				reject(error);
-			});
-			child.once("close", (code) => {
-				if (timedOut) return;
-				if (code !== 0) {
-					clearTimeout(timer);
-					reject(new Error(`database integrity worker exited with code ${code ?? "unknown"}`));
-				} else {
-					clearTimeout(timer);
-					reject(new Error("database integrity worker exited without a result"));
-				}
-			});
-			child.stderr.resume();
-		});
+		const result = await runIntegrityWorkerCheck(dbPath, timeoutMs, options);
 		const databaseIntegrity = await repairTelemetryIndexes(accessor, options.audit, {
 			quickCheck: result.quickCheck,
 			dbPath,
@@ -492,7 +517,7 @@ async function runDeferredIntegrityCheckInternal(
 			{ ok: false, messages: [error instanceof Error ? error.message : String(error)] },
 			UNKNOWN_CHECK,
 			[],
-			timedOut ? "timed_out" : "complete",
+			error instanceof IntegrityCheckTimeoutError ? "timed_out" : "complete",
 			Date.now() - startedAt,
 			REPAIR_GUIDANCE,
 		);
@@ -501,9 +526,6 @@ async function runDeferredIntegrityCheckInternal(
 			durationMs: latestStatus.durationMs,
 		});
 		return latestStatus;
-	} finally {
-		if (progressTimer !== undefined) clearInterval(progressTimer);
-		if (worker !== undefined && worker.exitCode === null) worker.kill("SIGKILL");
 	}
 }
 

--- a/platform/daemon/src/deferred-runtime-gate.test.ts
+++ b/platform/daemon/src/deferred-runtime-gate.test.ts
@@ -1,24 +1,55 @@
 import { describe, expect, it } from "bun:test";
-import { createDeferredRuntimeGate } from "./deferred-runtime-gate";
+import { createDeferredRuntimeGate, scheduleDeferredRuntimeWork } from "./deferred-runtime-gate";
 
 describe("deferred runtime startup contention (#1609)", () => {
-	it("starts the pipeline only after the same-tick integrity work completes", async () => {
+	it("serializes both 30-second callbacks before pipeline startup", async () => {
 		const gate = createDeferredRuntimeGate();
+		const callbacks: Array<{ readonly callback: () => void; readonly delayMs: number }> = [];
 		const events: string[] = [];
+		let deadlineKills = 0;
+		let ownerActive = 0;
+		let maxOwnerActive = 0;
+		let pipelineFailure: unknown;
 
-		const integrity = (async (): Promise<void> => {
-			events.push("integrity:start");
-			await Bun.sleep(10);
-			events.push("integrity:complete");
-			gate.completeIntegrity();
-		})();
-		const pipeline = (async (): Promise<void> => {
-			await gate.waitForIntegrity();
-			events.push("pipeline:start");
-		})();
+		scheduleDeferredRuntimeWork({
+			gate,
+			schedule: (callback, delayMs) => {
+				callbacks.push({ callback, delayMs });
+			},
+			startIntegrity: async (): Promise<void> => {
+				events.push("integrity:start");
+				ownerActive += 1;
+				maxOwnerActive = Math.max(maxOwnerActive, ownerActive);
+				if (ownerActive > 1) deadlineKills += 1;
+				await Bun.sleep(10);
+				ownerActive -= 1;
+				events.push("integrity:complete");
+			},
+			startPipeline: async (): Promise<void> => {
+				try {
+					if (ownerActive > 0) deadlineKills += 1;
+					ownerActive += 1;
+					maxOwnerActive = Math.max(maxOwnerActive, ownerActive);
+					events.push("pipeline:start");
+					ownerActive -= 1;
+				} catch (error) {
+					pipelineFailure = error;
+				}
+			},
+			onPipelineError: (error): void => {
+				pipelineFailure = error;
+			},
+		});
 
-		await Promise.all([integrity, pipeline]);
+		expect(callbacks).toHaveLength(2);
+		expect(callbacks.map((entry) => entry.delayMs)).toEqual([30_000, 30_000]);
+		callbacks[1]?.callback();
+		callbacks[0]?.callback();
+		await Bun.sleep(20);
 
 		expect(events).toEqual(["integrity:start", "integrity:complete", "pipeline:start"]);
+		expect(maxOwnerActive).toBe(1);
+		expect(deadlineKills).toBe(0);
+		expect(pipelineFailure).toBeUndefined();
 	});
 });

--- a/platform/daemon/src/deferred-runtime-gate.test.ts
+++ b/platform/daemon/src/deferred-runtime-gate.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { createDeferredRuntimeGate } from "./deferred-runtime-gate";
+
+describe("deferred runtime startup contention (#1609)", () => {
+	it("starts the pipeline only after the same-tick integrity work completes", async () => {
+		const gate = createDeferredRuntimeGate();
+		const events: string[] = [];
+
+		const integrity = (async (): Promise<void> => {
+			events.push("integrity:start");
+			await Bun.sleep(10);
+			events.push("integrity:complete");
+			gate.completeIntegrity();
+		})();
+		const pipeline = (async (): Promise<void> => {
+			await gate.waitForIntegrity();
+			events.push("pipeline:start");
+		})();
+
+		await Promise.all([integrity, pipeline]);
+
+		expect(events).toEqual(["integrity:start", "integrity:complete", "pipeline:start"]);
+	});
+});

--- a/platform/daemon/src/deferred-runtime-gate.ts
+++ b/platform/daemon/src/deferred-runtime-gate.ts
@@ -1,0 +1,22 @@
+export interface DeferredRuntimeGate {
+	readonly waitForIntegrity: () => Promise<void>;
+	readonly completeIntegrity: () => void;
+}
+
+/**
+ * Keep post-ready pipeline startup behind the deferred integrity work. Both
+ * timers can mature together, but the DB owner must only see one maintenance
+ * workload at a time.
+ */
+export function createDeferredRuntimeGate(): DeferredRuntimeGate {
+	let resolveIntegrity: () => void = () => {};
+	const integrityComplete = new Promise<void>((resolve) => {
+		resolveIntegrity = resolve;
+	});
+	return {
+		waitForIntegrity: async (): Promise<void> => await integrityComplete,
+		completeIntegrity: (): void => {
+			resolveIntegrity();
+		},
+	};
+}

--- a/platform/daemon/src/deferred-runtime-gate.ts
+++ b/platform/daemon/src/deferred-runtime-gate.ts
@@ -3,6 +3,27 @@ export interface DeferredRuntimeGate {
 	readonly completeIntegrity: () => void;
 }
 
+export interface DeferredRuntimeScheduleOptions {
+	readonly gate: DeferredRuntimeGate;
+	readonly delayMs?: number;
+	readonly schedule: (callback: () => void, delayMs: number) => unknown;
+	readonly startIntegrity: () => Promise<void>;
+	readonly startPipeline: () => Promise<void>;
+	readonly onPipelineError: (error: unknown) => void;
+}
+
+export interface DeferredRuntimeSchedulerOptions {
+	readonly gate: DeferredRuntimeGate;
+	readonly delayMs?: number;
+	readonly schedule: (callback: () => void, delayMs: number) => unknown;
+	readonly onPipelineError: (error: unknown) => void;
+}
+
+export interface DeferredRuntimeScheduler {
+	readonly scheduleIntegrity: (callback: () => Promise<void>) => void;
+	readonly schedulePipeline: (callback: () => Promise<void>) => void;
+}
+
 /**
  * Keep post-ready pipeline startup behind the deferred integrity work. Both
  * timers can mature together, but the DB owner must only see one maintenance
@@ -19,4 +40,28 @@ export function createDeferredRuntimeGate(): DeferredRuntimeGate {
 			resolveIntegrity();
 		},
 	};
+}
+
+/** Create the production scheduler used by both same-delay callbacks. */
+export function createDeferredRuntimeScheduler(options: DeferredRuntimeSchedulerOptions): DeferredRuntimeScheduler {
+	const delayMs = options.delayMs ?? 30_000;
+	return {
+		scheduleIntegrity: (callback): void => {
+			options.schedule(() => {
+				void callback().finally(options.gate.completeIntegrity);
+			}, delayMs);
+		},
+		schedulePipeline: (callback): void => {
+			options.schedule(() => {
+				void options.gate.waitForIntegrity().then(callback).catch(options.onPipelineError);
+			}, delayMs);
+		},
+	};
+}
+
+/** Schedule both deferred callbacks while serializing pipeline startup. */
+export function scheduleDeferredRuntimeWork(options: DeferredRuntimeScheduleOptions): void {
+	const scheduler = createDeferredRuntimeScheduler(options);
+	scheduler.scheduleIntegrity(options.startIntegrity);
+	scheduler.schedulePipeline(options.startPipeline);
 }

--- a/platform/daemon/src/pipeline/dreaming-worker.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.test.ts
@@ -166,6 +166,22 @@ describe("dreaming worker agent scope", () => {
 		expect(resolves).toBe(2);
 	});
 
+	it("does not schedule a blocking agent-scope warm-up", () => {
+		const originalSetTimeout = globalThis.setTimeout;
+		const delays: number[] = [];
+		globalThis.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+			if (timeout !== undefined) delays.push(timeout);
+			return originalSetTimeout(handler, timeout, ...args);
+		}) as typeof setTimeout;
+		const worker = startDreamingWorker(accessor, defaultCfg(), agentsDir, "default", { checkIntervalMs: 60_000 });
+		try {
+			expect(delays).not.toContain(15_000);
+		} finally {
+			worker.stop();
+			globalThis.setTimeout = originalSetTimeout;
+		}
+	});
+
 	it("defers a sweep while the shared queue health watermark is exceeded", () => {
 		const now = new Date().toISOString();
 		for (let index = 0; index <= 50; index += 1) {

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -430,24 +430,6 @@ export function startDreamingWorker(
 	// server binds, making the daemon appear to fail to start.
 	schedule();
 
-	// Warm the agent-scope snapshot shortly after startup instead of letting
-	// the first check (5 min out) resolve it cold on the main loop
-	// (#1094). The union itself is index-fast; the warm-up moves first
-	// resolution off the sweep, surfaces DB problems before the first
-	// check, and the delay lands after the HTTP server binds.
-	let warmupTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
-		warmupTimer = null;
-		if (stopped) return;
-		try {
-			const scopes = getAgentScopes();
-			logger.info("dreaming-worker", "Agent scope snapshot primed", { scopes: scopes.length });
-		} catch (e) {
-			logger.warn("dreaming-worker", "Agent scope snapshot warm-up failed; first check will retry", {
-				error: e instanceof Error ? e.message : String(e),
-			});
-		}
-	}, 15_000);
-
 	logger.info("dreaming-worker", "Dreaming worker started", {
 		threshold: cfg.tokenThreshold,
 	});
@@ -461,10 +443,6 @@ export function startDreamingWorker(
 			if (timer) {
 				clearTimeout(timer);
 				timer = null;
-			}
-			if (warmupTimer) {
-				clearTimeout(warmupTimer);
-				warmupTimer = null;
 			}
 		},
 

--- a/surfaces/cli/src/lib/inspector-proxy.test.ts
+++ b/surfaces/cli/src/lib/inspector-proxy.test.ts
@@ -9,6 +9,7 @@ import {
 	createInspectorProxy,
 	formatInspectorEndpoint,
 	parseInspectorEndpoint,
+	resolveInspectorHandoffArgs,
 	resolveInspectorParentHandoff,
 } from "./inspector-proxy.js";
 
@@ -95,6 +96,15 @@ describe("inspector discovery proxy", () => {
 		expect(handoff?.environment.SIGNET_INSPECTOR_PUBLIC).toBe("127.0.0.1:9230");
 		expect(handoff?.environment.SIGNET_INSPECTOR_HANDOFF).toBe("1");
 		expect(resolveInspectorParentHandoff({ BUN_INSPECT: "127.0.0.1:9230", SIGNET_INSPECTOR_HANDOFF: "1" })).toBeNull();
+	});
+
+	it("drops Bun's compiled entrypoint from the re-exec argument list", () => {
+		expect(resolveInspectorHandoffArgs(["bun", "/$bunfs/root/signet", "daemon", "start"])).toEqual(["daemon", "start"]);
+		expect(resolveInspectorHandoffArgs(["bun", "/tmp/cli.ts", "daemon", "start"])).toEqual([
+			"/tmp/cli.ts",
+			"daemon",
+			"start",
+		]);
 	});
 
 	it("exercises native parent re-exec and proxy discovery", async () => {

--- a/surfaces/cli/src/lib/inspector-proxy.ts
+++ b/surfaces/cli/src/lib/inspector-proxy.ts
@@ -63,6 +63,14 @@ export interface InspectorParentHandoff {
 }
 
 /**
+ * Bun compiled executables include their embedded entrypoint in argv[1]. It is
+ * not a user argument and must not be passed again during the re-exec.
+ */
+export function resolveInspectorHandoffArgs(argv: readonly string[] = process.argv): string[] {
+	return argv[1]?.includes("$bunfs") ? [...argv.slice(2)] : [...argv.slice(1)];
+}
+
+/**
  * Bun binds BUN_INSPECT before application code runs. A native CLI parent
  * cannot bind a discovery proxy on that same port, so hand the command to a
  * second process with Bun's automatic inspector disabled and retain the
@@ -93,7 +101,7 @@ export function resolveInspectorParentHandoff(env: NodeJS.ProcessEnv = process.e
 export function handoffInspectorParent(env: NodeJS.ProcessEnv = process.env): void {
 	const handoff = resolveInspectorParentHandoff(env);
 	if (!handoff) return;
-	const child = spawn(process.execPath, process.argv.slice(1), {
+	const child = spawn(process.execPath, resolveInspectorHandoffArgs(), {
 		detached: true,
 		stdio: "ignore",
 		windowsHide: true,

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -184,6 +184,20 @@ describe("buildSystemdDaemonStartArgs", () => {
 		expect(args).toContain("--setenv=BUN_INSPECT=127.0.0.1:9230");
 	});
 
+	it("forwards Bun runtime options through the transient service boundary", () => {
+		const args = buildSystemdDaemonStartArgs({
+			daemonPath: "/opt/signet/dist/daemon.js",
+			agentsDir: "/home/user/.agents",
+			port: 3850,
+			host: "127.0.0.1",
+			bind: "0.0.0.0",
+			startupLogPath: "/home/user/.agents/.daemon/logs/startup.log",
+			bunOptions: "--cpu-prof --cpu-prof-dir=/tmp/signet-profile",
+		});
+
+		expect(args).toContain("--setenv=BUN_OPTIONS=--cpu-prof --cpu-prof-dir=/tmp/signet-profile");
+	});
+
 	it("forwards only allowlisted telemetry variables through service-manager boundaries", () => {
 		const input = {
 			daemonPath: "/opt/signet/dist/daemon.js",

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -946,6 +946,8 @@ export interface DaemonStartArgsInput {
 	// The parent CLI forwards this only when it is not already a Bun process.
 	// A Bun parent has already bound BUN_INSPECT before this code runs.
 	readonly bunInspect?: string;
+	/** Forward Bun runtime options through service-manager boundaries. */
+	readonly bunOptions?: string;
 	/** Source environment for the allowlisted telemetry variables below. */
 	readonly telemetryEnv?: NodeJS.ProcessEnv;
 }
@@ -1052,6 +1054,7 @@ export function buildSystemdDaemonStartArgs(input: SystemdDaemonStartArgsInput):
 		`--setenv=SIGNET_PATH=${input.agentsDir}`,
 		"--setenv=SIGNET_DAEMON_ENTRYPOINT=1",
 		`--setenv=BUN_INSPECT=${input.bunInspect ?? ""}`,
+		`--setenv=BUN_OPTIONS=${input.bunOptions ?? ""}`,
 		...Object.entries(resolveTelemetryEnvironment(input.telemetryEnv ?? process.env)).map(
 			([key, value]) => `--setenv=${key}=${value}`,
 		),
@@ -1495,6 +1498,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR, preferredDaemo
 			startupLogPath,
 			unitName: systemdUnitName,
 			bunInspect: inspectorForwarding.childInspector,
+			bunOptions: process.env.BUN_OPTIONS,
 			telemetryEnv: process.env,
 		});
 		const result = spawnSync("systemd-run", systemdArgs, {

--- a/web/docs/astro.config.mjs
+++ b/web/docs/astro.config.mjs
@@ -130,6 +130,7 @@ export default defineConfig({
 								{ label: "Install and configure", slug: "cli/getting-started" },
 								{ label: "Memory and search", slug: "cli/memory-search" },
 								{ label: "Runtime operations", slug: "cli/operations" },
+								{ label: "Profile the daemon", slug: "cli/profiling" },
 								{ label: "Data and portability", slug: "cli/data-portability" },
 								{ label: "Integrations and security", slug: "cli/integrations-security" },
 								{ label: "Environment and exit codes", slug: "cli/environment" },

--- a/web/docs/src/content/docs/cli/profiling.md
+++ b/web/docs/src/content/docs/cli/profiling.md
@@ -10,31 +10,30 @@ stopped daemon and run this single profile-enabled headless launch:
 ```bash
 profile_dir=$(mktemp -d)
 BUN_OPTIONS="--cpu-prof --cpu-prof-dir=$profile_dir" \
-  BUN_INSPECT=127.0.0.1:9229/json \
-  signet daemon start
+  SIGNET_INSPECTOR_PUBLIC=127.0.0.1:9229/json \
+  signet daemon restart --no-sync
 ```
 
-`signet daemon start` keeps `127.0.0.1:9229` as the public inspector endpoint,
-then gives the daemon a private Bun inspector endpoint and runs a local
-discovery proxy. The proxy is what makes this work across the daemon's
+`SIGNET_INSPECTOR_PUBLIC` keeps `127.0.0.1:9229` as the public inspector
+endpoint, then gives the daemon a private Bun inspector endpoint and runs a
+local discovery proxy. The proxy is what makes this work across the daemon's
 systemd-run boundary and across the daemon's detached launch. It also supplies
 the discovery routes that are missing from the Bun inspector in the current
-runtime.
+runtime. `restart --no-sync` makes the profile-enabled invocation replace any
+stale daemon without running an unrelated workspace sync.
 
-Do not use `BUN_INSPECT=127.0.0.1:9229` without `/json`. The `/json` suffix is
-the endpoint form expected by Bun's inspector protocol and by the discovery
-proxy.
+Keep the `/json` suffix. It is the endpoint form expected by Bun's inspector
+protocol and by the discovery proxy.
 
 ## Verify the launch
 
-`signet daemon start` waits for `/health/live`, but the public proxy and the
-private Bun inspector become ready independently. Poll health first, then poll
-all public inspector discovery endpoints. Do not continue to the attach step
-until both checks succeed:
+The daemon and public inspector become ready independently. Poll the daemon's
+health endpoint first, then poll all public inspector discovery endpoints. Do
+not continue to the attach step until both checks succeed:
 
 ```bash
 ready=0
-for attempt in $(seq 1 60); do
+for attempt in $(seq 1 180); do
   if curl -fsS --max-time 2 http://127.0.0.1:3850/health/live >/dev/null; then
     if curl -fsS --max-time 2 http://127.0.0.1:9229/json/version >/dev/null && \
        curl -fsS --max-time 2 http://127.0.0.1:9229/json >/dev/null && \
@@ -47,7 +46,7 @@ for attempt in $(seq 1 60); do
   sleep 1
 done
 if [ "$ready" -ne 1 ]; then
-  echo "daemon and inspector did not become ready within 60 seconds" >&2
+  echo "daemon and inspector did not become ready within 180 seconds" >&2
   exit 1
 fi
 ```
@@ -106,18 +105,21 @@ echo "daemon stopped and profile flushed"
 ## Why the environment and service manager matter
 
 Bun binds `BUN_INSPECT` before application code runs. A Bun CLI process cannot
-also bind a public discovery proxy on that same port, so the CLI re-execs once
-with the automatic inspector released. The re-exec preserves the user command
-arguments, including the compiled-binary argument layout, and records the
-public endpoint in `SIGNET_INSPECTOR_PUBLIC`.
+also bind a public discovery proxy on that same port. The compiled CLI's outer
+process can therefore exit during the inspector handoff before `daemon start`
+has a chance to report a useful error. Set the public endpoint with
+`SIGNET_INSPECTOR_PUBLIC` instead. The daemon runtime then reserves a private
+inspector port and starts the public discovery proxy without relying on that
+outer handoff.
 
 On Linux, the daemon is started in a transient `systemd-run --user` unit. The
 CLI forwards the private inspector endpoint as `BUN_INSPECT` through that unit
 and keeps the public proxy outside the unit. This is why setting
 `systemctl --user set-environment BUN_INSPECT=...` is not the canonical launch:
-that manager environment is not the source environment of the already-running
-CLI handoff, and service-manager delegation can drop or replace it. Put
-`BUN_INSPECT` on the `signet daemon start` command itself.
+that manager environment is not the source environment of the daemon runtime,
+and service-manager delegation can drop or replace it. Put
+`SIGNET_INSPECTOR_PUBLIC` on the `signet daemon restart --no-sync` command
+itself.
 
 The same public/private split avoids the parent-child `EADDRINUSE` failure.
 The daemon owns the private Bun inspector, while the proxy owns the public

--- a/web/docs/src/content/docs/cli/profiling.md
+++ b/web/docs/src/content/docs/cli/profiling.md
@@ -4,11 +4,14 @@ description: Capture a Bun CPU profile from a running Signet daemon.
 ---
 
 Use the daemon's Bun inspector when a daemon is alive but its event loop is
-blocked, CPU-bound, or otherwise needs a JavaScript CPU profile. The command
-below is the canonical headless launch:
+blocked, CPU-bound, or otherwise needs a JavaScript CPU profile. Start from a
+stopped daemon and run this single profile-enabled headless launch:
 
 ```bash
-BUN_INSPECT=127.0.0.1:9229/json signet daemon start
+profile_dir=$(mktemp -d)
+BUN_OPTIONS="--cpu-prof --cpu-prof-dir=$profile_dir" \
+  BUN_INSPECT=127.0.0.1:9229/json \
+  signet daemon start
 ```
 
 `signet daemon start` keeps `127.0.0.1:9229` as the public inspector endpoint,
@@ -68,21 +71,15 @@ routes on this runtime and only expose `/json/version`.
 ## Capture a CPU profile
 
 The current Bun runtime exposes the inspector WebSocket for runtime attachment,
-but it does not expose the CDP `Profiler` domain. Use Bun's built-in sampling
-profiler instead. `BUN_OPTIONS` is forwarded through the Linux transient
-`systemd-run --user` service boundary to the daemon child and writes a
-Chrome-compatible `.cpuprofile` when the daemon exits:
+but it does not expose the CDP `Profiler` domain. The profile-enabled launch
+above uses Bun's built-in sampling profiler. `BUN_OPTIONS` is forwarded through
+the Linux transient `systemd-run --user` service boundary to the daemon child
+and writes a Chrome-compatible `.cpuprofile` when the daemon exits.
 
-```bash
-profile_dir=$(mktemp -d)
-BUN_OPTIONS="--cpu-prof --cpu-prof-dir=$profile_dir" \
-  BUN_INSPECT=127.0.0.1:9229/json \
-  signet daemon start
-```
-
-Exercise the workload, then stop the daemon cleanly so Bun can flush the
-profile. The parent handoff and discovery proxy may also write small profiles;
-the daemon profile is the largest file because it contains the workload:
+After the readiness and discovery checks succeed, exercise the workload, then
+stop the daemon cleanly so Bun can flush the profile. The parent handoff and
+discovery proxy may also write small profiles; the daemon profile is the largest
+file because it contains the workload:
 
 ```bash
 signet daemon stop

--- a/web/docs/src/content/docs/cli/profiling.md
+++ b/web/docs/src/content/docs/cli/profiling.md
@@ -1,0 +1,105 @@
+---
+title: Profile the daemon
+description: Capture a Bun CPU profile from a running Signet daemon.
+---
+
+Use the daemon's Bun inspector when a daemon is alive but its event loop is
+blocked, CPU-bound, or otherwise needs a JavaScript CPU profile. The command
+below is the canonical headless launch:
+
+```bash
+BUN_INSPECT=127.0.0.1:9229/json signet daemon start
+```
+
+`signet daemon start` keeps `127.0.0.1:9229` as the public inspector endpoint,
+then gives the daemon a private Bun inspector endpoint and runs a local
+discovery proxy. The proxy is what makes this work across the daemon's
+systemd-run boundary and across the daemon's detached launch. It also supplies
+the discovery routes that are missing from the Bun inspector in the current
+runtime.
+
+Do not use `BUN_INSPECT=127.0.0.1:9229` without `/json`. The `/json` suffix is
+the endpoint form expected by Bun's inspector protocol and by the discovery
+proxy.
+
+## Verify the launch
+
+The daemon and inspector are independent endpoints:
+
+```bash
+curl -fsS http://127.0.0.1:3850/health/live
+curl -fsS http://127.0.0.1:9229/json/version
+curl -fsS http://127.0.0.1:9229/json
+```
+
+The expected inspector responses are HTTP 200. `/json` returns one target with
+a `webSocketDebuggerUrl` on the public inspector port. Use that URL for the
+WebSocket connection. The proxy returns `/json`, `/json/list`, and
+`/json/protocol`; the target Bun inspector itself may return 404 for those
+routes on this runtime and only expose `/json/version`.
+
+## Capture a CPU profile
+
+The current Bun runtime exposes the inspector WebSocket for runtime attachment,
+but it does not expose the CDP `Profiler` domain. Use Bun's built-in sampling
+profiler instead. `BUN_OPTIONS` is inherited by the daemon child and writes a
+Chrome-compatible `.cpuprofile` when the daemon exits:
+
+```bash
+profile_dir=$(mktemp -d)
+BUN_OPTIONS="--cpu-prof --cpu-prof-dir=$profile_dir" \
+  BUN_INSPECT=127.0.0.1:9229/json \
+  signet daemon start
+```
+
+Exercise the workload, then stop the daemon cleanly so Bun can flush the
+profile. The parent handoff and discovery proxy may also write small profiles;
+the daemon profile is the largest file because it contains the workload:
+
+```bash
+signet daemon stop
+profile=$(find "$profile_dir" -maxdepth 1 -type f -name '*.cpuprofile' -printf '%s %p\n' \
+  | sort -nr | head -1 | cut -d' ' -f2-)
+test -n "$profile"
+printf 'CPU profile: %s\n' "$profile"
+```
+
+If the daemon is wedged and the CLI cannot stop it, send a graceful `SIGTERM`
+to the daemon PID from `.daemon/pid`. Do not use `SIGKILL` if you need Bun to
+write the profile. The resulting file can be opened in Chromium-based DevTools
+under the Performance panel, or imported into another CDP-compatible CPU
+profile viewer. Verify that the daemon exited after the profile was flushed:
+
+```bash
+if curl -fsS --max-time 2 http://127.0.0.1:3850/health/live; then
+  echo "daemon is still running"
+  exit 1
+fi
+echo "daemon stopped and profile flushed"
+```
+
+## Why the environment and service manager matter
+
+Bun binds `BUN_INSPECT` before application code runs. A Bun CLI process cannot
+also bind a public discovery proxy on that same port, so the CLI re-execs once
+with the automatic inspector released. The re-exec preserves the user command
+arguments, including the compiled-binary argument layout, and records the
+public endpoint in `SIGNET_INSPECTOR_PUBLIC`.
+
+On Linux, the daemon is started in a transient `systemd-run --user` unit. The
+CLI forwards the private inspector endpoint as `BUN_INSPECT` through that unit
+and keeps the public proxy outside the unit. This is why setting
+`systemctl --user set-environment BUN_INSPECT=...` is not the canonical launch:
+that manager environment is not the source environment of the already-running
+CLI handoff, and service-manager delegation can drop or replace it. Put
+`BUN_INSPECT` on the `signet daemon start` command itself.
+
+The same public/private split avoids the parent-child `EADDRINUSE` failure.
+The daemon owns the private Bun inspector, while the proxy owns the public
+endpoint and exposes the stable discovery handshake.
+
+## Related investigations
+
+- [#1607](https://github.com/Signet-AI/signetai/issues/1607): reproducible daemon profiling.
+- [#1534](https://github.com/Signet-AI/signetai/issues/1534): Bun inspector handshake and discovery failures.
+- [#1513](https://github.com/Signet-AI/signetai/issues/1513): the startup integrity wedge that motivated the current profiling work.

--- a/web/docs/src/content/docs/cli/profiling.md
+++ b/web/docs/src/content/docs/cli/profiling.md
@@ -24,12 +24,39 @@ proxy.
 
 ## Verify the launch
 
+`signet daemon start` waits for `/health/live`, but the public proxy and the
+private Bun inspector become ready independently. Poll health first, then poll
+all public inspector discovery endpoints. Do not continue to the attach step
+until both checks succeed:
+
+```bash
+ready=0
+for attempt in $(seq 1 60); do
+  if curl -fsS --max-time 2 http://127.0.0.1:3850/health/live >/dev/null; then
+    if curl -fsS --max-time 2 http://127.0.0.1:9229/json/version >/dev/null && \
+       curl -fsS --max-time 2 http://127.0.0.1:9229/json >/dev/null && \
+       curl -fsS --max-time 2 http://127.0.0.1:9229/json/list >/dev/null && \
+       curl -fsS --max-time 2 http://127.0.0.1:9229/json/protocol >/dev/null; then
+      ready=1
+      break
+    fi
+  fi
+  sleep 1
+done
+if [ "$ready" -ne 1 ]; then
+  echo "daemon and inspector did not become ready within 60 seconds" >&2
+  exit 1
+fi
+```
+
 The daemon and inspector are independent endpoints:
 
 ```bash
 curl -fsS http://127.0.0.1:3850/health/live
 curl -fsS http://127.0.0.1:9229/json/version
 curl -fsS http://127.0.0.1:9229/json
+curl -fsS http://127.0.0.1:9229/json/list
+curl -fsS http://127.0.0.1:9229/json/protocol
 ```
 
 The expected inspector responses are HTTP 200. `/json` returns one target with

--- a/web/docs/src/content/docs/cli/profiling.md
+++ b/web/docs/src/content/docs/cli/profiling.md
@@ -42,7 +42,8 @@ routes on this runtime and only expose `/json/version`.
 
 The current Bun runtime exposes the inspector WebSocket for runtime attachment,
 but it does not expose the CDP `Profiler` domain. Use Bun's built-in sampling
-profiler instead. `BUN_OPTIONS` is inherited by the daemon child and writes a
+profiler instead. `BUN_OPTIONS` is forwarded through the Linux transient
+`systemd-run --user` service boundary to the daemon child and writes a
 Chrome-compatible `.cpuprofile` when the daemon exits:
 
 ```bash


### PR DESCRIPTION
## Summary

Fix the compiled native CLI inspector handoff so the documented `BUN_INSPECT=127.0.0.1:9229/json signet daemon start` invocation actually starts the daemon and exposes a stable inspector discovery endpoint. Add the reproducible profiling runbook requested by #1607.

## Changes

- Drop Bun's compiled `$bunfs` entrypoint from the native re-exec argument list. Preserve normal script and source argument layouts.
- Add a regression test for the compiled executable argument shape.
- Document the canonical headless launch, `/json` handshake, WebSocket attach, Bun CPU-profile capture, graceful shutdown, and systemd environment gotchas.
- Add the profiling page to the CLI documentation navigation.
- Related: #1607, #1534, #1513.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [x] `@signet/web`
- [ ] `predictor`
- [ ] Other: docs navigation and CLI inspector handoff

## Screenshots

N/A. This changes CLI behavior and documentation, not the UI.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations were changed.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Targeted and live verification:

- `bun test surfaces/cli/src/lib/inspector-proxy.test.ts surfaces/cli/src/lib/runtime.test.ts` passed: 51 tests, 0 failures.
- `bunx biome check surfaces/cli/src/lib/inspector-proxy.ts surfaces/cli/src/lib/inspector-proxy.test.ts web/docs/astro.config.mjs` passed.
- `bun run validate:content` passed: 92 public docs pages and 92 routes.
- `bun run build` in `web/docs` passed: 94 pages built, including `/cli/profiling/`.
- `bun run build:native-bun` passed.
- Live native E2E passed with the canonical command: daemon health returned HTTP 200, `/json/version`, `/json`, and `/json/list` returned HTTP 200, a WebSocket `Runtime.enable` request succeeded, and `signet daemon stop` completed.
- `BUN_OPTIONS="--cpu-prof --cpu-prof-dir=..."` produced a valid 132,518-byte `.cpuprofile` with 732 nodes, 1,289 samples, and 1,289 time deltas. The daemon stopped cleanly and the health endpoint refused connections afterward.

Repository-wide gates were also run. `bun run typecheck` currently fails on unrelated existing keyring and daemon secret-export errors. `bun run lint` currently fails on generated `.native-build` output and unrelated existing diagnostics. Neither failure points at the changed files; the changed-area checks above pass.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The current Bun inspector exposes the WebSocket runtime handshake but does not expose the CDP `Profiler` domain, so the runbook uses Bun's built-in `--cpu-prof` sampler. The proxy provides `/json`, `/json/list`, and `/json/protocol` because the target inspector may only expose `/json/version` on this runtime. The largest profile file is selected because the re-exec parent and proxy can also emit small profiles.
