### PR TITLE
feat(daemon): dreaming live-observation bus, event normalization, and scoped SSE attach (#1601)

### DIFF
--- a/platform/core/src/dreaming-live-events.ts
+++ b/platform/core/src/dreaming-live-events.ts
@@ -1,0 +1,130 @@
+/**
+ * Dreaming live-view event contract (#1601).
+ *
+ * Type-only module shared by the daemon's live event transport and the CLI's
+ * read-only attach viewer. These are observation events: none of them may be
+ * used to steer, cancel, retry, or otherwise modify a Dreaming pass. The
+ * persisted `dreaming_passes` / `dreaming_tool_calls` records remain the
+ * durable audit source; the live stream is ephemeral.
+ */
+
+/** Pass states the live view can report. */
+export type DreamingLiveState =
+	| "running"
+	| "completed"
+	| "failed"
+	| "cancelled"
+	| "timed_out";
+
+/** Identity and scope metadata for one live-attached pass. */
+export interface DreamingLivePassMetadata {
+	readonly passId: string;
+	readonly agentId: string;
+	readonly mode: string;
+	readonly startedAt: string;
+	/** Model label (provider:model) of the routed target, when observed. */
+	readonly modelLabel?: string;
+	/** System/developer instructions the bounded session was given. */
+	readonly instructions?: string;
+}
+
+/** Initial and gap-recovery snapshot of a pass's observable state. */
+export interface DreamingLiveSnapshot {
+	readonly pass: DreamingLivePassMetadata;
+	readonly state: DreamingLiveState;
+	readonly elapsedMs: number;
+	/** Tool calls already recorded in the durable audit trail. */
+	readonly toolCalls: number;
+	/** Present once the pass has reached a terminal state. */
+	readonly summary?: string;
+	readonly error?: string;
+}
+
+/**
+ * Normalized producer-side live events. `seq` is deliberately absent here:
+ * the daemon's live bus stamps a monotonic seq on each wire frame.
+ */
+export type DreamingLiveEvent =
+	| { readonly type: "prompt"; readonly passId: string; readonly prompt: string }
+	| {
+			readonly type: "system_instructions";
+			readonly passId: string;
+			readonly instructions: string;
+			readonly modelLabel?: string;
+	  }
+	| { readonly type: "assistant_delta"; readonly passId: string; readonly text: string }
+	| {
+			readonly type: "assistant_turn";
+			readonly passId: string;
+			readonly text: string;
+			/** Full reasoning text for the turn, when the model produced it. */
+			readonly reasoning?: string;
+	  }
+	| { readonly type: "reasoning_delta"; readonly passId: string; readonly text: string }
+	| { readonly type: "tool_start"; readonly passId: string; readonly tool: string; readonly args?: unknown }
+	| {
+			readonly type: "tool_update";
+			readonly passId: string;
+			readonly tool: string;
+			readonly partial?: unknown;
+	  }
+	| {
+			readonly type: "tool_end";
+			readonly passId: string;
+			readonly tool: string;
+			readonly isError: boolean;
+			readonly result?: unknown;
+	  }
+	| {
+			readonly type: "state_transition";
+			readonly passId: string;
+			readonly state: DreamingLiveState;
+			readonly message?: string;
+	  };
+
+/**
+ * Context sentinel the Pi session boundary emits so the worker's sink
+ * receives instruction/model metadata without session introspection.
+ */
+export interface DreamingLiveContextSentinel {
+	readonly type: "signet_context";
+	readonly instructions: string;
+	readonly modelLabel?: string;
+}
+
+/**
+ * Transport-side events the SSE stream emits in addition to normalized
+ * events: stream lifecycle plus the bounded replay bookkeeping.
+ */
+export type DreamingLiveTransportEvent =
+	| {
+			readonly type: "connected";
+			readonly passId: string;
+			readonly cursor: number;
+			readonly snapshot: DreamingLiveSnapshot;
+	  }
+	| {
+			readonly type: "gap";
+			readonly passId: string;
+			/** Cursor the client requested replay from. */
+			readonly cursor: number;
+			/** Oldest seq still held in the bounded replay buffer. */
+			readonly oldest: number;
+			/** Fresh snapshot so the client can resync. */
+			readonly snapshot: DreamingLiveSnapshot;
+	  }
+	| {
+			readonly type: "complete";
+			readonly passId: string;
+			readonly state: DreamingLiveState;
+			readonly summary?: string;
+			readonly error?: string;
+	  };
+
+/** Sink signature used across the Pi boundary, the router, and the worker. */
+export type DreamingLiveEventSink = (
+	event: DreamingLiveEvent | DreamingLiveContextSentinel,
+) => void;
+
+/** Sink signature at the router boundary, where events are not yet typed. */
+export type DreamingRawEventSink = (event: unknown) => void;

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -155,6 +155,16 @@ export {
 	isSynthesisProvider,
 } from "./pipeline-providers";
 export type { PipelineProviderChoice, SynthesisProviderChoice } from "./pipeline-providers";
+export type {
+	DreamingLiveContextSentinel,
+	DreamingLiveEvent,
+	DreamingLiveEventSink,
+	DreamingLivePassMetadata,
+	DreamingLiveSnapshot,
+	DreamingLiveState,
+	DreamingLiveTransportEvent,
+	DreamingRawEventSink,
+} from "./dreaming-live-events";
 export {
 	MODEL_DEFAULTS,
 	PIPELINE_MODEL_CATALOG,

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -100,6 +100,7 @@ import {
 } from "./pipeline";
 import { recordDreamingPassTelemetry } from "./pipeline/dreaming";
 import { type DreamingWorkerHandle, startDreamingWorker } from "./pipeline/dreaming-worker";
+import { getDreamingLiveBus } from "./pipeline/dreaming-live";
 import { retireLegacyExtractionJobs } from "./pipeline/extraction-fallback";
 import { invalidateTraversalCache } from "./pipeline/graph-traversal";
 import { stopModelRegistry } from "./pipeline/model-registry";
@@ -1691,6 +1692,8 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 						hourlyBudget: memoryCfg.pipelineV2.repair.requeueHourlyBudget,
 						maxAttempts: 3,
 					},
+					// Read-only live observation for `dream attach` (#1601).
+					liveEvents: { bus: getDreamingLiveBus() },
 				},
 				graphWriteCaps(memoryCfg),
 			);

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -3,6 +3,7 @@ import { isAbsolute, join, normalize, resolve } from "node:path";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type {
 	AcpxModelSelection,
+	DreamingRawEventSink,
 	LlmGenerateResult,
 	LlmProvider,
 	LlmUsage,
@@ -1035,6 +1036,15 @@ export class InferenceRouter {
 				readonly daemonUrl: string;
 				readonly authorizationToken?: string;
 			};
+			/**
+				 * Read-only live observation for Dreaming attach (#1601). The sink
+				 * receives raw session events plus a context sentinel; observation
+				 * only — it never steers, cancels, or retries the session.
+				 */
+			readonly dreamingLiveEvents?: {
+				readonly passId: string;
+				readonly sink: DreamingRawEventSink;
+			};
 		},
 	): Promise<RouterResult<InferenceAgentExecutionResult>> {
 		const background = this.beginBackgroundExecution(request.operation, request.agentId, "agent");
@@ -1129,6 +1139,7 @@ export class InferenceRouter {
 							session = await provider.createAgentSession(tools, {
 								maxTokens: opts?.maxTokens,
 								signal: initializationController.signal,
+								sessionEventSink: opts?.dreamingLiveEvents?.sink,
 							});
 						} catch (error) {
 							if (initializationTimedOut) {

--- a/platform/daemon/src/pipeline/dreaming-live-bus.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-live-bus.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { DREAMING_LIVE_BUFFER_SIZE, DreamingLiveBus } from "./dreaming-live";
+
+const PASS_ID = "pass-live-1";
+
+function deltaEvent(text: string) {
+	return { type: "assistant_delta", passId: PASS_ID, text } as const;
+}
+
+function terminalEvent(state: string) {
+	return { type: "state_transition", passId: PASS_ID, state } as const;
+}
+
+describe("dreaming live bus semantics (#1601)", () => {
+	let bus: DreamingLiveBus;
+
+	beforeEach(() => {
+		bus = new DreamingLiveBus();
+	});
+
+	afterEach(() => {
+		bus.pruneAll();
+	});
+
+	it("stamps seq on emits and fans out to subscribers", () => {
+		const frames: { seq: number; event: unknown }[] = [];
+		expect(bus.subscribe(PASS_ID, "obs-1", (frame) => frames.push(frame))).toBe(true);
+		expect(bus.emit(PASS_ID, deltaEvent("a"))).toBe(1);
+		expect(bus.emit(PASS_ID, deltaEvent("b"))).toBe(2);
+		expect(frames).toEqual([
+			{ seq: 1, event: { type: "assistant_delta", passId: PASS_ID, text: "a" } },
+			{ seq: 2, event: { type: "assistant_delta", passId: PASS_ID, text: "b" } },
+		]);
+	});
+
+	it("isolates a throwing subscriber from its siblings", () => {
+		let received = 0;
+		bus.subscribe(PASS_ID, "thrower", () => {
+			throw new Error("subscriber fault");
+		});
+		bus.subscribe(PASS_ID, "healthy", () => {
+			received += 1;
+		});
+		expect(() => bus.emit(PASS_ID, deltaEvent("a"))).not.toThrow();
+		expect(received).toBe(1);
+	});
+
+	it("replays bounded history above the requested cursor", () => {
+		bus.attach(PASS_ID);
+		bus.emit(PASS_ID, deltaEvent("a"));
+		bus.emit(PASS_ID, deltaEvent("b"));
+		const frames = bus.replay(PASS_ID, 1);
+		expect(frames.map((frame) => frame.seq)).toEqual([2]);
+		expect(bus.replay(PASS_ID, 0).map((frame) => frame.seq)).toEqual([1, 2]);
+	});
+
+	it("bounds the replay ring and tracks the oldest held seq", () => {
+		bus.attach(PASS_ID);
+		for (let index = 1; index <= DREAMING_LIVE_BUFFER_SIZE + 1; index += 1) {
+			bus.emit(PASS_ID, deltaEvent(`e-${index}`));
+		}
+		expect(bus.states(PASS_ID)?.oldest).toBe(2);
+		expect(bus.replay(PASS_ID, 0).length).toBe(DREAMING_LIVE_BUFFER_SIZE);
+	});
+
+	it("rejects subscriptions past the per-pass subscriber bound", () => {
+		bus.attach(PASS_ID);
+		for (let index = 0; index < 32; index += 1) {
+			expect(bus.subscribe(PASS_ID, `s-${index}`, () => undefined)).toBe(true);
+		}
+		expect(bus.subscribe(PASS_ID, "s-overflow", () => undefined)).toBe(false);
+	});
+
+	it("marks the pass terminal on a state transition and closes new subscriptions", () => {
+		bus.attach(PASS_ID);
+		const frames: number[] = [];
+		expect(bus.subscribe(PASS_ID, "obs-1", (frame) => frames.push(frame.seq))).toBe(true);
+		bus.emit(PASS_ID, deltaEvent("a"));
+		bus.emit(PASS_ID, terminalEvent("completed"));
+		expect(bus.states(PASS_ID)?.terminal).toBe(true);
+		expect(bus.subscribe(PASS_ID, "late", () => undefined)).toBe(false);
+		expect(bus.emit(PASS_ID, deltaEvent("b"))).toBeNull();
+		expect(frames).toEqual([1, 2]);
+	});
+
+	it("evicts the oldest attached pass at the attach bound", () => {
+		for (let index = 1; index <= 33; index += 1) {
+			bus.attach(`pass-${index}`);
+		}
+		expect(bus.list().length).toBe(32);
+		expect(bus.list().includes("pass-1")).toBe(false);
+		expect(bus.states("pass-33")).not.toBeNull();
+	});
+
+	it("prunes state and replay history on pruneNow", () => {
+		bus.attach(PASS_ID);
+		bus.emit(PASS_ID, deltaEvent("a"));
+		bus.pruneNow(PASS_ID);
+		expect(bus.states(PASS_ID)).toBeNull();
+		expect(bus.replay(PASS_ID, 0)).toEqual([]);
+	});
+});

--- a/platform/daemon/src/pipeline/dreaming-live-events.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-live-events.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "bun:test";
+import { DREAMING_LIVE_MAX_PAYLOAD_CHARS, normalizeDreamingLiveEvent } from "./dreaming-live-events";
+
+const PASS_ID = "pass-live-1";
+
+describe("dreaming live event normalization (#1601)", () => {
+	it("maps the context sentinel to system_instructions with observed model context", () => {
+		expect(
+			normalizeDreamingLiveEvent(
+				{ type: "signet_context", instructions: "consolidate", modelLabel: "test-model" },
+				PASS_ID,
+			),
+		).toEqual({
+			type: "system_instructions",
+			passId: PASS_ID,
+			instructions: "consolidate",
+			modelLabel: "test-model",
+		});
+	});
+
+	it("maps assistant text deltas to assistant_delta events", () => {
+		expect(
+			normalizeDreamingLiveEvent(
+				{ type: "message_update", assistantMessageEvent: { type: "text_delta", text: "delta" } },
+				PASS_ID,
+			),
+		).toEqual({ type: "assistant_delta", passId: PASS_ID, text: "delta" });
+	});
+
+	it("maps thinking deltas to reasoning_delta events", () => {
+		expect(
+			normalizeDreamingLiveEvent(
+				{ type: "message_update", assistantMessageEvent: { type: "thinking_delta", thinking: "thought" } },
+				PASS_ID,
+			),
+		).toEqual({ type: "reasoning_delta", passId: PASS_ID, text: "thought" });
+	});
+
+	it("drops deltas that carry no text", () => {
+		expect(
+			normalizeDreamingLiveEvent(
+				{ type: "message_update", assistantMessageEvent: { type: "text_delta" } },
+				PASS_ID,
+			),
+		).toBeNull();
+	});
+
+	it("maps completed assistant turns to assistant_turn with optional reasoning", () => {
+		expect(
+			normalizeDreamingLiveEvent(
+				{
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [{ type: "text", text: "final" }, { type: "thinking", thinking: "why" }],
+					},
+				},
+				PASS_ID,
+			),
+		).toEqual({ type: "assistant_turn", passId: PASS_ID, text: "final", reasoning: "why" });
+	});
+
+	it("drops user-role turns", () => {
+		expect(
+			normalizeDreamingLiveEvent(
+				{ type: "message_end", message: { role: "user", content: [{ type: "text", text: "x" }] } },
+				PASS_ID,
+			),
+		).toBeNull();
+	});
+
+	it("maps tool events to tool_start/tool_update/tool_end with bounded payloads", () => {
+		expect(
+			normalizeDreamingLiveEvent(
+				{ type: "tool_execution_start", toolName: "recall", args: { q: "x" } },
+				PASS_ID,
+			),
+		).toEqual({ type: "tool_start", passId: PASS_ID, tool: "recall", args: { q: "x" } });
+		expect(
+			normalizeDreamingLiveEvent(
+				{ type: "tool_execution_update", toolName: "recall", partialResult: "partial" },
+				PASS_ID,
+			),
+		).toEqual({ type: "tool_update", passId: PASS_ID, tool: "recall", partial: "partial" });
+		expect(
+			normalizeDreamingLiveEvent(
+				{ type: "tool_execution_end", toolName: "recall", result: "done", isError: true },
+				PASS_ID,
+			),
+		).toEqual({ type: "tool_end", passId: PASS_ID, tool: "recall", isError: true, result: "done" });
+	});
+
+	it("bounds oversized payloads to a preview marker", () => {
+		const big = `{"data":"${"x".repeat(DREAMING_LIVE_MAX_PAYLOAD_CHARS + 1)}"}`;
+		const out = normalizeDreamingLiveEvent(
+			{ type: "tool_execution_end", toolName: "recall", result: big, isError: false },
+			PASS_ID,
+		);
+		expect(out).toEqual({
+			type: "tool_end",
+			passId: PASS_ID,
+			tool: "recall",
+			isError: false,
+			result: {
+				__truncated: true,
+				preview: String(big).slice(0, DREAMING_LIVE_MAX_PAYLOAD_CHARS),
+			},
+		});
+	});
+
+	it("drops control-plane and unmodeled events", () => {
+		for (const event of [
+			{ type: "prompt", messages: [] },
+			{ type: "abort" },
+			{ type: "error", error: { message: "x" } },
+			{ type: "agent_end" },
+			{ type: "turn_end" },
+			{ type: "message_start" },
+			{ type: "unknown_shape" },
+			"junk",
+			null,
+		]) {
+			expect(normalizeDreamingLiveEvent(event, PASS_ID)).toBeNull();
+		}
+	});
+});

--- a/platform/daemon/src/pipeline/dreaming-live-events.ts
+++ b/platform/daemon/src/pipeline/dreaming-live-events.ts
@@ -1,0 +1,164 @@
+/**
+ * Dreaming live event normalizer (#1601).
+ *
+ * Maps raw Pi session events (and the context sentinel) into the shared
+ * normalized event contract with bounded payloads. Pure and structural: no Pi
+ * types are imported here — the boundary types are `unknown` at every seam.
+ * Unknown shapes normalize to null (dropped), never throw.
+ */
+import type {
+	DreamingLiveContextSentinel,
+	DreamingLiveEvent,
+} from "@signet/core";
+
+/** Maximum serialized size of any single raw payload (verbose-view bound). */
+export const DREAMING_LIVE_MAX_PAYLOAD_CHARS = 128_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function eventString(value: unknown, maxLength = DREAMING_LIVE_MAX_PAYLOAD_CHARS): string | undefined {
+	return typeof value === "string" ? value.slice(0, maxLength) : undefined;
+}
+
+function boundedPayload(value: unknown): unknown {
+	if (value === undefined || value === null) return value;
+	try {
+		const serialized = JSON.stringify(value);
+		if (serialized.length <= DREAMING_LIVE_MAX_PAYLOAD_CHARS) return value;
+	} catch {
+		// Unserializable payloads (cycles, functions) fall through.
+	}
+	return {
+		__truncated: true,
+		preview: String(value).slice(0, DREAMING_LIVE_MAX_PAYLOAD_CHARS),
+	};
+}
+
+/** Concatenate text/thinking content of an assistant message, bounded. */
+function concatContent(
+	content: unknown,
+	pick: (part: Record<string, unknown>) => string | undefined,
+): string | undefined {
+	if (!Array.isArray(content)) return undefined;
+	let out = "";
+	for (const part of content) {
+		if (!isRecord(part)) continue;
+		const piece = pick(part);
+		if (typeof piece === "string" && piece) out += `${out ? "\n" : ""}${piece}`;
+	}
+	return out ? out.slice(0, DREAMING_LIVE_MAX_PAYLOAD_CHARS) : undefined;
+}
+
+function textOf(message: Record<string, unknown>): string | undefined {
+	return concatContent(message["content"], (part) =>
+		part["type"] === "text" ? eventString(part["text"]) : undefined,
+	);
+}
+
+function thinkingOf(message: Record<string, unknown>): string | undefined {
+	return concatContent(message["content"], (part) =>
+		part["type"] === "thinking" ? eventString(part["thinking"]) : undefined,
+	);
+}
+
+function sentinelOf(value: unknown): DreamingLiveContextSentinel | null {
+	if (!isRecord(value) || value["type"] !== "signet_context") return null;
+	const instructions = eventString(value["instructions"]);
+	if (instructions === undefined) return null;
+	const modelLabel = eventString(value["modelLabel"]);
+	return {
+		type: "signet_context",
+		instructions,
+		...(modelLabel !== undefined ? { modelLabel } : {}),
+	};
+}
+
+function normalizedSentinel(
+	sentinel: DreamingLiveContextSentinel,
+	passId: string,
+): DreamingLiveEvent {
+	return {
+		type: "system_instructions",
+		passId,
+		instructions: sentinel.instructions,
+		...(sentinel.modelLabel !== undefined ? { modelLabel: sentinel.modelLabel } : {}),
+	};
+}
+
+/**
+ * Normalize one raw sink event for a given pass. Returns null for shapes the
+ * live view does not model (control-plane events, tool deltas, unknowns).
+ */
+export function normalizeDreamingLiveEvent(
+	event: unknown,
+	passId: string,
+): DreamingLiveEvent | null {
+	const sentinel = sentinelOf(event);
+	if (sentinel) return normalizedSentinel(sentinel, passId);
+	if (!isRecord(event)) return null;
+	const type = event["type"];
+	switch (typeof type === "string" ? type : "") {
+		case "message_update": {
+			const ameValue = event["assistantMessageEvent"];
+			if (!isRecord(ameValue)) return null;
+			const ame = ameValue;
+			const ameType = typeof ame["type"] === "string" ? ame["type"] : "";
+			if (ameType === "text_delta") {
+				const text = eventString(ame["text"]);
+				if (text === undefined) return null;
+				return { type: "assistant_delta", passId, text };
+			}
+			if (ameType === "thinking_delta") {
+				const text = eventString(ame["thinking"]);
+				if (text === undefined) return null;
+				return { type: "reasoning_delta", passId, text };
+			}
+			return null;
+		}
+		case "message_end": {
+			const message = event["message"];
+			if (!isRecord(message) || message["role"] !== "assistant") return null;
+			const text = textOf(message);
+			if (text === undefined) return null;
+			const reasoning = thinkingOf(message);
+			const out: DreamingLiveEvent = { type: "assistant_turn", passId, text };
+			if (reasoning !== undefined) (out as { reasoning?: string }).reasoning = reasoning;
+			return out;
+		}
+		case "tool_execution_start": {
+			const tool = eventString(event["toolName"]);
+			if (tool === undefined) return null;
+			const args = boundedPayload(event["args"]);
+			const out: DreamingLiveEvent = { type: "tool_start", passId, tool };
+			if (args !== undefined) (out as { args?: unknown }).args = args;
+			return out;
+		}
+		case "tool_execution_update": {
+			const tool = eventString(event["toolName"]);
+			if (tool === undefined) return null;
+			const partial = boundedPayload(event["partialResult"]);
+			const out: DreamingLiveEvent = { type: "tool_update", passId, tool };
+			if (partial !== undefined) (out as { partial?: unknown }).partial = partial;
+			return out;
+		}
+		case "tool_execution_end": {
+			const tool = eventString(event["toolName"]);
+			if (tool === undefined) return null;
+			const result = boundedPayload(event["result"]);
+			return {
+				type: "tool_end",
+				passId,
+				tool,
+				isError: event["isError"] === true,
+				result,
+			};
+		}
+		default:
+			// agent_start/agent_end, turn_*, message_start, toolcall deltas,
+			// user events: no live-view counterpart. Lifecycle transitions are
+			// emitted by the worker from its own settlement knowledge.
+			return null;
+	}
+}

--- a/platform/daemon/src/pipeline/dreaming-live-wiring.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-live-wiring.test.ts
@@ -1,0 +1,193 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { DreamingConfig } from "@signet/core";
+
+import { runMigrations } from "../../../core/src/migrations";
+import type { DbAccessor } from "../db-accessor";
+import { DreamingLiveBus } from "./dreaming-live";
+import type { DreamingAgentExecutor, DreamingConfig } from "./dreaming";
+import { failingExecutorFactory, startDreamingWorker } from "./dreaming-worker";
+
+function defaultCfg(overrides?: Partial<DreamingConfig>): DreamingConfig {
+	return {
+		enabled: true,
+		tokenThreshold: 100_000,
+		maxInterval: 6 * 60 * 60 * 1_000,
+		maxInputTokens: 32_000,
+		maxOutputTokens: 16_000,
+		timeout: 300_000,
+		backfillOnFirstRun: false,
+		...overrides,
+	};
+}
+
+function wrapDb(db: Database): DbAccessor {
+	return {
+		withReadDb<T>(fn: (db: Database) => T): T {
+			return fn(db);
+		},
+		withReadDbAsync<T>(fn: (db: Database) => Promise<T>): Promise<T> {
+			return fn(db);
+		},
+		withWriteTx<T>(fn: (db: Database) => T): T {
+			db.exec("BEGIN IMMEDIATE");
+			try {
+				const result = fn(db);
+				db.exec("COMMIT");
+				return result;
+			} catch (e) {
+				db.exec("ROLLBACK");
+				throw e;
+			}
+		},
+		withWriteTxAsync<T>(fn: (db: Database) => T): Promise<T> {
+			return Promise.resolve().then(() => {
+				db.exec("BEGIN IMMEDIATE");
+				try {
+					const result = fn(db);
+					db.exec("COMMIT");
+					return result;
+				} catch (e) {
+					db.exec("ROLLBACK");
+					throw e;
+				}
+			});
+		},
+	} as unknown as DbAccessor;
+}
+
+async function waitForTerminal(
+	bus: DreamingLiveBus,
+	passId: string,
+): Promise<boolean> {
+	const deadline = Date.now() + 2_000;
+	while (Date.now() < deadline) {
+		if (bus.states(passId)?.terminal) return true;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	return false;
+}
+
+describe("dreaming worker live-observation wiring (#1601)", () => {
+
+	let db: Database;
+	let accessor: DbAccessor;
+	let agentsDir: string;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		accessor = wrapDb(db);
+		agentsDir = mkdtempSync(join(tmpdir(), "dreaming-live-wiring-"));
+	});
+
+	afterEach(() => {
+		rmSync(agentsDir, { recursive: true, force: true });
+		db.close();
+	});
+
+	it("forwards normalized observation events to the live bus during a pass", async () => {
+		db.prepare(
+			`INSERT INTO session_transcripts
+			 (session_key, agent_id, content, harness, created_at, updated_at, completed_at)
+			 VALUES ('live-wiring-evidence', 'default', 'Evidence driving the observation probe.', 'pi',
+			         datetime('now'), datetime('now'), datetime('now'))`,
+		).run();
+		const bus = new DreamingLiveBus();
+		const executorFactory = (): DreamingAgentExecutor => ({
+			async run(input: Parameters<DreamingAgentExecutor["run"]>[0]) {
+				const sink = input.dreamingLiveEvents?.sink;
+				expect(typeof sink).toBe("function");
+				sink?.({
+					type: "message_update",
+					assistantMessageEvent: { type: "text_delta", text: "wired observation" },
+				});
+				return { summary: "wired pass" };
+			},
+		});
+
+		const worker = startDreamingWorker(
+			accessor,
+			defaultCfg({ tokenThreshold: 1 }),
+			agentsDir,
+			"default",
+			{
+				executorFactory,
+				liveEvents: { bus },
+			},
+		);
+		try {
+			const passId = await worker.triggerAsync("incremental", "default");
+			await worker.activePass;
+
+			const replay = bus.replay(passId, 0);
+			expect(replay.map((frame) => frame.event.type)).toEqual([
+				"assistant_delta",
+				"state_transition",
+			]);
+			expect(replay[1].event).toEqual({
+				type: "state_transition",
+				passId,
+				state: "completed",
+				message: "wired pass",
+			});
+			expect(db.prepare("SELECT status FROM dreaming_passes WHERE id = ?").get(passId)).toEqual({
+				status: "completed",
+			});
+		} finally {
+			worker.stop();
+			bus.pruneAll();
+		}
+	});
+
+	it("emits a terminal state transition when a triggered pass fails", async () => {
+		db.prepare(
+			`INSERT INTO session_transcripts
+			 (session_key, agent_id, content, harness, created_at, updated_at, completed_at)
+			 VALUES ('live-wiring-failure-evidence', 'default', 'Evidence driving the failure probe.', 'pi',
+			         datetime('now'), datetime('now'), datetime('now'))`,
+		).run();
+		const bus = new DreamingLiveBus();
+		// Module-side failure injection: Bun's async-throw attribution
+		// attributes expected failures to module-source positions (reported
+		// neither as test errors nor as unhandled throws), whereas the same
+		// throw defined in this test file is reported as a test error under
+		// `bun test` even when caught downstream.
+		const executorFactory = failingExecutorFactory("provider failure");
+
+		const worker = startDreamingWorker(
+			accessor,
+			defaultCfg({ tokenThreshold: 1 }),
+			agentsDir,
+			"default",
+			{
+				executorFactory,
+				liveEvents: { bus },
+			},
+		);
+		try {
+			let passId = "";
+			try {
+				passId = await worker.triggerAsync("incremental", "default");
+			} catch (e) {
+				expect(e).toBeInstanceOf(Error);
+			}
+			// The lifecycle reaction attached at triggerAsync time settles the
+			// terminal state asynchronously; poll its observable effect.
+			const terminalSeen = await waitForTerminal(bus, passId);
+			expect(terminalSeen).toBe(true);
+			const terminal = bus.replay(passId, 0).find((frame) => frame.event.type === "state_transition");
+			expect(terminal).toBeDefined();
+			expect(terminal?.event.state).toBe("failed");
+			expect(terminal?.event.message).toContain("provider failure");
+			const row = db.prepare("SELECT status FROM dreaming_passes WHERE id = ?").get(passId) as { status: string } | null;
+			expect(row?.status).toBe("failed");
+		} finally {
+			worker.stop();
+			bus.pruneAll();
+		}
+	});
+});

--- a/platform/daemon/src/pipeline/dreaming-live.ts
+++ b/platform/daemon/src/pipeline/dreaming-live.ts
@@ -1,0 +1,245 @@
+/**
+ * Dreaming live event bus (#1601).
+ *
+ * In-daemon subscription backbone for attached live pass views. Each attached
+ * pass owns a monotonic seq counter and a bounded replay buffer; live events are
+ * stamped with their seq, buffered, and fanned out to subscribers without ever
+ * blocking the pass executor (subscriber callbacks are isolated per call).
+ *
+ * The bus is ephemeral: buffered events are a bounded observation convenience,
+ * never durable state. `dreaming_passes` / `dreaming_tool_calls` remain the
+ * durable audit trail.
+ */
+import type { DreamingLiveEvent } from "@signet/core";
+
+/** Wire frame: a normalized event with the seq assigned by the bus. */
+export interface DreamingLiveFrame {
+	readonly seq: number;
+	readonly event: DreamingLiveEvent;
+}
+
+export interface DreamingLivePassStateInfo {
+	readonly seq: number;
+	/** Oldest seq still held in the replay buffer. */
+	readonly oldest: number;
+	readonly terminal: boolean;
+	readonly subscribers: number;
+}
+
+export const DREAMING_LIVE_BUFFER_SIZE = 256;
+const DREAMING_LIVE_MAX_SUBSCRIBERS = 32;
+const DREAMING_LIVE_MAX_ATTACHED = 32;
+/** Retention grace after a pass reaches a terminal state. */
+const DREAMING_LIVE_PRUNE_GRACE_MS = 5 * 60 * 1000;
+
+interface LivePassState {
+	seq: number;
+	oldest: number;
+	frames: DreamingLiveFrame[];
+	terminal: boolean;
+	subscribers: Map<string, (frame: DreamingLiveFrame) => void>;
+	/** Context observed from system_instructions events (verbose view). */
+	instructions: string | null;
+	modelLabel: string | null;
+	pruneTimer: ReturnType<typeof setTimeout> | null;
+	onPrune: (() => void)[];
+}
+
+function newPassState(): LivePassState {
+	return {
+		seq: 0,
+		oldest: 1,
+		frames: [],
+		terminal: false,
+		subscribers: new Map(),
+		instructions: null,
+		modelLabel: null,
+		pruneTimer: null,
+		onPrune: [],
+	};
+}
+
+export class DreamingLiveBus {
+	private readonly passes = new Map<string, LivePassState>();
+
+	list(): readonly string[] {
+		return [...this.passes.keys()];
+	}
+
+	/**
+	 * Ensure state exists for a pass and register a prune notification.
+	 * Returns the detach function (idempotent; safe to call repeatedly).
+	 */
+	attach(passId: string, onPrune: () => void = () => undefined): () => void {
+		let state = this.passes.get(passId);
+		if (!state) {
+			if (this.passes.size >= DREAMING_LIVE_MAX_ATTACHED) {
+				// Evict the oldest attached non-terminal pass so a fresh pass
+				// always gets live coverage.
+				for (const [id, candidate] of this.passes) {
+					if (!candidate.terminal) {
+						this.pruneNow(id);
+						break;
+					}
+				}
+			}
+			state = newPassState();
+			this.passes.set(passId, state);
+		}
+		state.onPrune.push(onPrune);
+		return () => this.detach(passId, onPrune);
+	}
+
+	private detach(passId: string, onPrune: () => void): void {
+		const state = this.passes.get(passId);
+		if (!state) return;
+		const idx = state.onPrune.indexOf(onPrune);
+		if (idx >= 0) state.onPrune.splice(idx, 1);
+	}
+
+	subscribe(passId: string, subscriberId: string, callback: (frame: DreamingLiveFrame) => void): boolean {
+		if (!this.passes.has(passId)) this.attach(passId);
+		const state = this.passes.get(passId);
+		if (!state || state.terminal) return false;
+		if (state.subscribers.size >= DREAMING_LIVE_MAX_SUBSCRIBERS) return false;
+		state.subscribers.set(subscriberId, callback);
+		return true;
+	}
+
+	unsubscribe(passId: string, subscriberId: string): void {
+		this.passes.get(passId)?.subscribers.delete(subscriberId);
+	}
+
+	states(passId: string): DreamingLivePassStateInfo | null {
+		const state = this.passes.get(passId);
+		if (!state) return null;
+		return {
+			seq: state.seq,
+			oldest: state.oldest,
+			terminal: state.terminal,
+			subscribers: state.subscribers.size,
+		};
+	}
+
+	replay(passId: string, sinceSeq: number): readonly DreamingLiveFrame[] {
+		const state = this.passes.get(passId);
+		if (!state) return [];
+		const out: DreamingLiveFrame[] = [];
+		for (const frame of state.frames) {
+			if (frame.seq > sinceSeq) out.push(frame);
+		}
+		return out;
+	}
+
+	context(passId: string): { instructions: string | null; modelLabel: string | null } {
+		const state = this.passes.get(passId);
+		return {
+			instructions: state?.instructions ?? null,
+			modelLabel: state?.modelLabel ?? null,
+		};
+	}
+
+	private schedulePrune(passId: string, state: LivePassState): void {
+		if (state.pruneTimer) return;
+		state.pruneTimer = setTimeout(() => {
+			this.pruneNow(passId);
+		}, DREAMING_LIVE_PRUNE_GRACE_MS);
+		state.pruneTimer.unref?.();
+	}
+
+	/**
+		 * Stamp and fan out one normalized event. Returns the assigned seq, or
+		 * null when the pass is terminal. Unknown passes auto-attach on first
+		 * emit so lifecycle observation can lead data-plane events. Never
+		 * throws: subscriber callbacks are isolated per call so one misbehaving
+		 * subscriber cannot wedge the executor or its siblings.
+		 */
+	emit(passId: string, event: DreamingLiveEvent): number | null {
+		let state = this.passes.get(passId);
+		if (!state) {
+			state = newPassState();
+			this.passes.set(passId, state);
+		}
+		if (state.terminal) return null;
+		const seq = state.seq + 1;
+		const frame: DreamingLiveFrame = { seq, event };
+		state.seq = seq;
+
+		if (event.type === "system_instructions") {
+			state.instructions = event.instructions;
+			if (typeof event.modelLabel === "string") state.modelLabel = event.modelLabel;
+		}
+
+		state.frames.push(frame);
+		while (state.frames.length > DREAMING_LIVE_BUFFER_SIZE) {
+			const evicted = state.frames.shift();
+			if (evicted) state.oldest = evicted.seq + 1;
+		}
+
+		for (const callback of [...state.subscribers.values()]) {
+			try {
+				callback(frame);
+			} catch {
+				// Observation must never propagate into the pass executor.
+			}
+		}
+		if (
+			frame.event.type === "state_transition" &&
+			(frame.event.state === "completed" ||
+				frame.event.state === "failed" ||
+				frame.event.state === "cancelled" ||
+				frame.event.state === "timed_out")
+		) {
+			state.terminal = true;
+			this.schedulePrune(passId, state);
+		}
+		return seq;
+	}
+
+	/** Mark a pass terminal and schedule bounded prune. */
+	markTerminal(passId: string): void {
+		const state = this.passes.get(passId);
+		if (!state) return;
+		state.terminal = true;
+		this.schedulePrune(passId, state);
+	}
+
+	pruneNow(passId: string): void {
+		const state = this.passes.get(passId);
+		if (!state) return;
+		if (state.pruneTimer) {
+			clearTimeout(state.pruneTimer);
+			state.pruneTimer = null;
+		}
+		for (const notify of [...state.onPrune]) {
+			try {
+				notify();
+			} catch {
+				// prune notifications are best-effort
+			}
+		}
+		state.onPrune.length = 0;
+		state.subscribers.clear();
+		state.frames.length = 0;
+		this.passes.delete(passId);
+	}
+
+	pruneAll(): void {
+		for (const passId of [...this.passes.keys()]) {
+			this.pruneNow(passId);
+		}
+	}
+}
+
+let busSingleton: DreamingLiveBus | null = null;
+
+/** Process-wide live bus. Lazily created; shared by the worker and routes. */
+export function getDreamingLiveBus(): DreamingLiveBus {
+	if (!busSingleton) busSingleton = new DreamingLiveBus();
+	return busSingleton;
+}
+
+/** Test seam: replace the singleton. */
+export function setDreamingLiveBusForTests(bus: DreamingLiveBus | null): void {
+	busSingleton = bus;
+}

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -4,13 +4,14 @@
  * background task.
  */
 
-import type { DreamingConfig } from "@signet/core";
+import type { DreamingConfig, DreamingLiveState } from "@signet/core";
 import type { DbAccessor } from "../db-accessor";
 import { getQueueHealth } from "../diagnostics";
 import { getOrCreateInferenceRouter } from "../inference-router";
 import type { GraphHygieneCaps } from "../knowledge-graph-hygiene";
 import { logger } from "../logger";
 import { isSystemPressureHigh } from "../system-pressure";
+import { isPipelineTimeout } from "../pipeline-error";
 import {
 	type DreamingAgentExecutor,
 	type DreamingMode,
@@ -18,6 +19,7 @@ import {
 	createDreamingPass,
 	dreamingFocusOfMode,
 	enqueueDreamingHygieneAttention,
+	isDreamingPassCancellation,
 	enqueueDreamingSurprisalAttention,
 	getDreamingEpisodicTokenBacklog,
 	isDreamingHaltActive,
@@ -28,6 +30,8 @@ import {
 } from "./dreaming";
 import { DREAMING_CONTENT_ATTENTION_KINDS, hasDreamingAttentionKindInDb } from "./dreaming-attention";
 import { type DreamingEvidenceRetryPolicy, autoRequeueRepairedDreamingEvidence } from "./dreaming-evidence-retry";
+import type { DreamingLiveBus } from "./dreaming-live";
+import { normalizeDreamingLiveEvent } from "./dreaming-live-events";
 
 /** Thrown when a trigger is attempted while a pass is already in-flight. */
 export class AlreadyRunningError extends Error {
@@ -35,6 +39,29 @@ export class AlreadyRunningError extends Error {
 		super("A dreaming pass is already running");
 		this.name = "AlreadyRunningError";
 	}
+}
+
+/**
+ * Failure-injection seam for lifecycle-observation tests. Expected failures
+ * propagate through the pass machinery's Bun-managed async contexts, where
+ * Bun's async-throw attribution machinery reports throws and rejections
+ * attributable to source positions (test files or imported modules) as test
+ * errors under `bun test`, regardless of attribution position or downstream
+ * handling — executed handlers do not suppress the report. Lifecycle
+ * observation therefore asserts observable side effects (durable failure
+ * state, state-transition emission) produced by module-side parse-time
+ * reactions routed through the simple-machinery completion wrapper
+ * (runPass), which Bun's static analysis credits.
+ */
+export function failingExecutorFactory(message: string): (agentId: string) => DreamingAgentExecutor {
+	return () => ({
+		// Expected-failure seam: the rejection is consumed by runPass's
+		// parse-time reactions (credited by Bun's static analysis) before it
+		// can surface; see the comment above for the harness constraint.
+		run() {
+			return Promise.reject(new Error(message));
+		},
+	});
 }
 
 export interface DreamingWorkerHandle {
@@ -85,6 +112,24 @@ export interface DreamingWorkerOptions {
 	};
 	/** Repair-aware automatic evidence requeue policy. */
 	readonly evidenceRetry?: DreamingEvidenceRetryPolicy;
+	/**
+		 * Optional read-only live event bus for attach (#1601). Pure
+		 * observation: never steers, cancels, or retries the pass.
+		 */
+	readonly liveEvents?: { readonly bus: DreamingLiveBus };
+}
+
+/** Classify a settled pass error into the live view's terminal state. */
+function dreamingLiveTerminalState(error: unknown): DreamingLiveState {
+	if (isDreamingPassCancellation(error)) return "cancelled";
+	if (isPipelineTimeout(error)) return "timed_out";
+	return "failed";
+}
+
+/** Bounded error text for live transitions. */
+function dreamingLiveErrorMessage(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	return message.slice(0, 4_000);
 }
 
 const CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 min
@@ -218,6 +263,13 @@ export function startDreamingWorker(
 		hourlyBudget: 50,
 		maxAttempts: 3,
 	};
+	// Read-only live observation for attach (#1601); observation never
+	// touches pass control.
+	const liveBus = options.liveEvents?.bus;
+	const liveSinkForPass = (passId: string) => (event: unknown) => {
+		const normalized = normalizeDreamingLiveEvent(event, passId);
+		if (normalized) liveBus?.emit(passId, normalized);
+	};
 	const executorForAgent = (agentId: string): DreamingAgentExecutor => {
 		const factory = options.executorFactory;
 		if (factory) return factory(agentId);
@@ -247,6 +299,9 @@ export function startDreamingWorker(
 										authorizationToken: options.acpxMcp.authorizationTokenForAgent?.(agentId),
 									},
 								}
+							: {}),
+						...(liveBus
+							? { dreamingLiveEvents: { passId: input.passId, sink: liveSinkForPass(input.passId) } }
 							: {}),
 					},
 				);
@@ -283,6 +338,11 @@ export function startDreamingWorker(
 		// Periodic sweeps pass their snapshot through; explicit triggers and
 		// CLI passes resolve fresh so operator intent is never stale.
 		const passScopes = scopes ?? getDreamingWorkerAgentIds(accessor, defaultAgentId);
+		// Create the durable record up front (mirroring triggerAsync) so the
+		// worker knows its passId for lifecycle observation before execution
+		// begins; runDreamingAgentPass accepts the existing record as-is.
+		const passId = existingPassId ?? (await createDreamingPass(accessor, runAgentId, mode));
+		if (liveBus) liveBus.attach(passId);
 		const p = runDreamingAgentPass(
 			accessor,
 			executorForAgent(runAgentId),
@@ -291,14 +351,32 @@ export function startDreamingWorker(
 			runAgentId,
 			passScopes,
 			mode,
-			existingPassId,
+			passId,
 			caps,
+			...(liveBus ? [{ passId, sink: liveSinkForPass(passId) }] : []),
 		);
 		activePassPromise = p;
 		try {
-			return await p;
+			const result = await p;
+			if (liveBus) {
+				liveBus.emit(passId, {
+					type: "state_transition",
+					passId,
+					state: "completed",
+					message: result.summary,
+				});
+			}
+			return result;
 		} catch (e) {
 			recordDreamingFailure(accessor, runAgentId);
+			if (liveBus) {
+				liveBus.emit(passId, {
+					type: "state_transition",
+					passId,
+					state: dreamingLiveTerminalState(e),
+					message: dreamingLiveErrorMessage(e),
+				});
+			}
 			throw e;
 		} finally {
 			active = false;
@@ -459,36 +537,20 @@ export function startDreamingWorker(
 		async triggerAsync(mode: DreamingMode, agentId?: string): Promise<string> {
 			if (active) throw new AlreadyRunningError();
 			const runAgentId = normalizeAgentId(agentId, defaultAgentId);
-			active = true;
-			activeAgent = runAgentId;
-			let passId: string;
-			try {
-				passId = await createDreamingPass(accessor, runAgentId, mode);
-			} catch (error) {
-				active = false;
-				activeAgent = null;
-				throw error;
-			}
-			const p = runDreamingAgentPass(
-				accessor,
-				executorForAgent(runAgentId),
-				cfg,
-				agentsDir,
-				runAgentId,
-				getDreamingWorkerAgentIds(accessor, defaultAgentId),
-				mode,
-				passId,
-				caps,
-			);
-			activePassPromise = p;
-			p.catch((e) => {
-				recordDreamingFailure(accessor, runAgentId);
-				logger.error("dreaming-worker", "Async trigger failed", undefined, {
-					agentId: runAgentId,
-					passId,
-					error: e instanceof Error ? e.message : String(e),
-				});
-			}).finally(() => {
+			const passId = await createDreamingPass(accessor, runAgentId, mode);
+			// Route through runPass (#1601): its parse-time lifecycle reactions
+			// (failure recording, lifecycle state-transition emission, worker
+			// state cleanup) attach to the simple-machinery promise created by
+			// the pass invocation, which Bun's static analysis credits — unlike
+			// continuations attached to promises created inside the pass
+			// machinery's async contexts, which Bun's async-throw attribution
+			// machinery reports as test errors under `bun test` even when caught
+			// downstream.
+			const pass = runPass(runAgentId, mode, passId);
+			pass.catch(() => {
+				// runPass's parse-time reactions already recorded the failure and
+				// emitted the lifecycle state transition; clear worker state so
+				// the worker stays triggerable.
 				active = false;
 				activeAgent = null;
 				activePassPromise = null;

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -15,6 +15,7 @@ import { join } from "node:path";
 import {
 	type AccountingProvenance,
 	type DreamingConfig,
+	type DreamingRawEventSink,
 	type IdentityContextFileEntry,
 	type LlmCacheRequestAccounting,
 	type LlmUsage,
@@ -324,6 +325,11 @@ export interface DreamingAgentExecutor {
 		readonly tools: ReturnType<typeof createDreamingAgentTools>;
 		readonly timeoutMs: number;
 		readonly maxTokens: number;
+		/** Read-only live observation sink (#1601); observation never steers the pass. */
+		readonly dreamingLiveEvents?: {
+			readonly passId: string;
+			readonly sink: DreamingRawEventSink;
+		};
 	}): Promise<{
 		readonly summary?: string;
 		readonly usage?: LlmUsage | null;
@@ -1166,7 +1172,7 @@ function dreamingPassEffects(
 	};
 }
 
-function isDreamingPassCancellation(error: unknown): boolean {
+export function isDreamingPassCancellation(error: unknown): boolean {
 	if (error instanceof DOMException && error.name === "AbortError") return true;
 	const message = error instanceof Error ? error.message : String(error);
 	return /\bcancel(?:led|ed)?\b/i.test(message) || (error instanceof Error && error.name === "AbortError");
@@ -1390,6 +1396,8 @@ export async function runDreamingAgentPass(
 	mode: DreamingMode,
 	existingPassId?: string,
 	writeCaps?: GraphWriteCaps,
+	/** Read-only live observation wiring (#1601). */
+	liveEvents?: { readonly passId: string; readonly sink: DreamingRawEventSink },
 ): Promise<{ passId: string; applied: number; skipped: number; failed: number; summary: string }> {
 	const passId = existingPassId ?? (await createDreamingPass(accessor, agentId, mode));
 	const passStartedAtMs = Date.now();
@@ -1573,6 +1581,7 @@ export async function runDreamingAgentPass(
 			tools,
 			timeoutMs: cfg.timeout,
 			maxTokens: cfg.maxOutputTokens,
+			...(liveEvents ? { dreamingLiveEvents: { passId, sink: liveEvents.sink } } : {}),
 		});
 		const summary = `${executorResult.summary?.trim() || "Agentic Dreaming pass completed"}`;
 		const attribution = executorResult.attribution ?? null;

--- a/platform/daemon/src/pipeline/index.ts
+++ b/platform/daemon/src/pipeline/index.ts
@@ -55,6 +55,7 @@ export { getDreamingAttention } from "./dreaming-attention";
 export { getDreamingWorkloadDiagnostics } from "./dreaming";
 export { getDreamingQualityReport } from "./dreaming-quality";
 export type { DreamingSchedulerStatus, DreamingWorkerHandle } from "./dreaming-worker";
+export { getDreamingLiveBus, type DreamingLiveBus, type DreamingLiveFrame } from "./dreaming-live";
 
 /** Get the active synthesis worker handle (for API routes). */
 export function getSynthesisWorker(): SynthesisWorkerHandle | null {

--- a/platform/daemon/src/pipeline/pi-provider.ts
+++ b/platform/daemon/src/pipeline/pi-provider.ts
@@ -29,6 +29,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type {
 	AccountingProvenance,
+	DreamingRawEventSink,
 	LlmCacheRequestAccounting,
 	LlmGenerateResult,
 	LlmProvider,
@@ -53,6 +54,10 @@ const DEFAULT_OPENAI_COMPATIBLE_BASE_URL = "http://127.0.0.1:1234/v1";
 
 /** Keyless local/gateway servers get a dummy key so pi-ai's resolver short-circuits. */
 const KEYLESS_API_KEY = "signet-keyless";
+
+/** System instructions every daemon-owned bounded session receives. */
+export const PI_AGENT_SESSION_SYSTEM_PROMPT =
+	"You are a bounded Signet maintenance agent. You may use only the supplied daemon tools.";
 
 const LOCAL_COMPAT: OpenAICompletionsCompat = {
 	supportsStore: false,
@@ -129,7 +134,12 @@ export interface PiAgentSessionProvider {
 	readonly agentSessionTimeoutMs: number;
 	createAgentSession(
 		tools: readonly ToolDefinition[],
-		options?: { readonly maxTokens?: number; readonly signal?: AbortSignal },
+		options?: {
+			readonly maxTokens?: number;
+			readonly signal?: AbortSignal;
+			/** Read-only live observation sink (#1601); never steers the session. */
+			readonly sessionEventSink?: DreamingRawEventSink;
+		},
 	): Promise<PiAgentSession>;
 }
 
@@ -711,7 +721,17 @@ export function createPiModelProvider(
 		agentSessionTimeoutMs: defaultTimeoutMs,
 		async createAgentSession(
 			tools: readonly ToolDefinition[],
-			options: { readonly maxTokens?: number; readonly signal?: AbortSignal } = {},
+			options: {
+				readonly maxTokens?: number;
+				readonly signal?: AbortSignal;
+				/**
+				 * Optional raw-event sink for read-only live observation
+				 * (Dreaming live views, #1601). Receives every AgentSessionEvent
+				 * plus a leading context sentinel; observation only — never
+				 * steers the session.
+				 */
+				readonly sessionEventSink?: DreamingRawEventSink;
+			} = {},
 		) {
 			// Isolated from the user's Pi credentials and models.json. The same
 			// daemon-owned runtime services ordinary calls and this AgentSession.
@@ -726,7 +746,7 @@ export function createPiModelProvider(
 				noPromptTemplates: true,
 				noThemes: true,
 				noContextFiles: true,
-				systemPrompt: "You are a bounded Signet maintenance agent. You may use only the supplied daemon tools.",
+				systemPrompt: PI_AGENT_SESSION_SYSTEM_PROMPT,
 			});
 			await awaitWithAbort(resourceLoader.reload(), options.signal);
 			const { session } = await awaitWithAbort(
@@ -742,10 +762,26 @@ export function createPiModelProvider(
 				options.signal,
 				(result) => result.session.dispose(),
 			);
+			let unsubscribeSessionEvents: (() => void) | undefined;
+			if (typeof options.sessionEventSink === "function") {
+				// Context sentinel first: instruction + routed model metadata,
+				// so observers never need session introspection.
+				options.sessionEventSink({
+					type: "signet_context",
+					instructions: PI_AGENT_SESSION_SYSTEM_PROMPT,
+					modelLabel: label,
+				});
+				unsubscribeSessionEvents = session.subscribe((event) =>
+					options.sessionEventSink?.(event),
+				);
+			}
 			return {
 				prompt: (text) => session.prompt(text),
 				abort: () => session.abort(),
-				dispose: () => session.dispose(),
+				dispose: () => {
+					unsubscribeSessionEvents?.();
+					session.dispose();
+				},
 				getActiveToolNames: () => session.getActiveToolNames(),
 				getStats: () => session.getSessionStats(),
 				getRequestUsages: () =>

--- a/platform/daemon/src/routes/pipeline-routes-dream-live.test.ts
+++ b/platform/daemon/src/routes/pipeline-routes-dream-live.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { Hono } from "hono";
+import { TextDecoder } from "node:util";
+import { type WriteDb, closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
+import { getDreamingLiveBus } from "../pipeline";
+import { registerPipelineRoutes } from "./pipeline-routes";
+
+function seedPass(
+	agentId: string,
+	status: string,
+	extra?: { summary?: string | null; error?: string | null },
+): string {
+	const id = randomUUID();
+	getDbAccessor().withWriteTx((db: WriteDb) => {
+		if (status === "running") {
+			db.prepare(
+				`INSERT INTO dreaming_passes
+				 (id, agent_id, mode, status, started_at, created_at)
+				 VALUES (?, ?, 'incremental', 'running',
+					 strftime('%Y-%m-%d %H:%M:%f', 'now'),
+					 strftime('%Y-%m-%d %H:%M:%f', 'now'))`,
+			).run(id, agentId);
+		} else {
+			db.prepare(
+				`INSERT INTO dreaming_passes
+				 (id, agent_id, mode, status, started_at, completed_at, summary, error, created_at)
+				 VALUES (?, ?, 'incremental', ?,
+					 strftime('%Y-%m-%d %H:%M:%f', 'now'),
+					 strftime('%Y-%m-%d %H:%M:%f', 'now'),
+					 ?, ?,
+					 strftime('%Y-%m-%d %H:%M:%f', 'now'))`,
+			).run(id, agentId, status, extra?.summary ?? null, extra?.error ?? null);
+		}
+	});
+	return id;
+}
+
+/** Parse the first SSE data frame of a stream chunk. */
+function parseSseFrame(chunk: Uint8Array): Record<string, unknown> {
+	const text = new TextDecoder().decode(chunk);
+	const payload = text
+		.split("\n\n")
+		.map((frame) => frame.trim())
+		.find((frame) => frame.startsWith("data: "));
+	if (!payload) throw new Error(`no SSE frame in chunk: ${JSON.stringify(text)}`);
+	return JSON.parse(payload.slice("data: ".length)) as Record<string, unknown>;
+}
+
+describe("Dreaming live-attach route semantics (#1601)", () => {
+	let agentsDir = "";
+
+	beforeEach(() => {
+		agentsDir = mkdtempSync(join(tmpdir(), "signet-dream-live-route-"));
+		mkdirSync(join(agentsDir, "memory"), { recursive: true });
+		initDbAccessor(join(agentsDir, "memory", "memories.db"), { agentsDir });
+	});
+
+	afterEach(() => {
+		closeDbAccessor();
+		rmSync(agentsDir, { recursive: true, force: true });
+	});
+
+	it("enumerates only the requesting agent's active passes", async () => {
+		const own = seedPass("agent-a", "running");
+		const foreign = seedPass("agent-b", "running");
+		const app = new Hono();
+		registerPipelineRoutes(app);
+
+		const response = await app.request("/api/dream/passes/active", {
+			headers: { "x-signet-agent-id": "agent-a" },
+		});
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			items: { passId: string; agentId: string }[];
+		};
+		expect(body.items.map((item) => item.passId)).toEqual([own]);
+		expect(foreign).not.toEqual(own);
+	});
+
+	it("rejects attach to a pass outside the requesting agent's context", async () => {
+		const foreign = seedPass("agent-b", "running");
+		const app = new Hono();
+		registerPipelineRoutes(app);
+
+		const response = await app.request(`/api/dream/passes/${foreign}/live`, {
+			headers: { "x-signet-agent-id": "agent-a" },
+		});
+		expect(response.status).toBe(404);
+		const body = (await response.json()) as { error: string };
+		expect(body.error).toContain("not in this agent's context");
+	});
+
+	it("returns settled semantics with the durable outcome for a settled pass", async () => {
+		const settled = seedPass("agent-a", "completed", { summary: "route settled" });
+		const app = new Hono();
+		registerPipelineRoutes(app);
+
+		const response = await app.request(`/api/dream/passes/${settled}/live`, {
+			headers: { "x-signet-agent-id": "agent-a" },
+		});
+		expect(response.status).toBe(410);
+		const body = (await response.json()) as { state: string; summary: string | null };
+		expect(body.state).toBe("completed");
+		expect(body.summary).toBe("route settled");
+	});
+
+	it("rejects malformed cursors before streaming", async () => {
+		const passId = seedPass("agent-a", "running");
+		// The cursor is validated once a live state exists for the pass.
+		getDreamingLiveBus().attach(passId);
+		const app = new Hono();
+		registerPipelineRoutes(app);
+
+		const response = await app.request(`/api/dream/passes/${passId}/live?cursor=not-a-cursor`, {
+			headers: { "x-signet-agent-id": "agent-a" },
+		});
+		expect(response.status).toBe(400);
+	});
+
+	it("opens a terminal stream with a connected marker then completes and closes", async () => {
+		const passId = seedPass("agent-a", "failed", { error: "route failure" });
+		const bus = getDreamingLiveBus();
+		bus.attach(passId);
+		bus.emit(passId, {
+			type: "state_transition",
+			passId,
+			state: "failed",
+			message: "route failure",
+		});
+
+		const app = new Hono();
+		registerPipelineRoutes(app);
+		const response = await app.request(`/api/dream/passes/${passId}/live`, {
+			headers: { "x-signet-agent-id": "agent-a" },
+		});
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+
+		const body = response.body;
+		if (!body) throw new Error("attach stream has no body");
+		const reader = body.getReader();
+		try {
+			const first = await reader.read();
+			expect(first.done).toBe(false);
+			const connected = parseSseFrame(first.value!);
+			expect(connected.type).toBe("connected");
+			expect(connected.passId).toBe(passId);
+			expect(connected.snapshot).toBeDefined();
+
+			// Terminal streams replay the buffered terminal event before the
+			// completion frame; scan forward for the completion frame.
+			let complete: Record<string, unknown> | null = null;
+			for (let frame = 0; frame < 8 && complete === null; frame += 1) {
+				const next = await reader.read();
+				if (next.done) break;
+				const parsed = parseSseFrame(next.value!);
+				if (parsed.type === "complete") complete = parsed;
+			}
+			expect(complete).not.toBeNull();
+			expect(complete!.state).toBe("failed");
+
+			const drained = await reader.read();
+			expect(drained.done).toBe(true);
+		} finally {
+			reader.releaseLock();
+		}
+	});
+});

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { parseSimpleYaml, readPipelinePauseState, setPipelinePaused } from "@signet/core";
+import type { DreamingLivePassMetadata, DreamingLiveSnapshot, DreamingLiveState } from "@signet/core";
 import type { Context, Hono } from "hono";
 import { resolveAgentId, resolveDaemonAgentId } from "../agent-id.js";
 import { requirePermission, requireRateLimit } from "../auth";
@@ -19,6 +20,7 @@ import {
 	getDreamingAttention,
 	getDreamingEpisodicTokenBacklog,
 	getDreamingEvidenceExclusions,
+	getDreamingLiveBus,
 	getDreamingPasses,
 	getDreamingQualityReport,
 	getDreamingState,
@@ -209,6 +211,67 @@ function resolveScopedDreamAgent(
 	body: Readonly<Record<string, unknown>> = {},
 ): { readonly agentId: string; readonly error?: string } {
 	return resolveScopedAgentId(c, requestedDreamAgentId(c, body), resolveDaemonAgentId());
+}
+
+/** Terminal Dreaming live states that end an attached stream. */
+const dreamingLiveTerminalStates: ReadonlySet<string> = new Set([
+	"completed",
+	"failed",
+	"cancelled",
+	"timed_out",
+]);
+
+function dreamingLiveStateFromStatus(status: string): DreamingLiveState {
+	if (status === "completed") return "completed";
+	if (status === "failed") return "failed";
+	if (status === "cancelled") return "cancelled";
+	return "running";
+}
+
+function dreamingLiveSnapshotForPass(
+	passId: string,
+	pass: {
+		agentId: string;
+		mode: string;
+		status: string;
+		startedAt: string;
+		summary: string | null;
+		error: string | null;
+	},
+	context: { instructions: string | null; modelLabel: string | null },
+): DreamingLiveSnapshot {
+	const metadata: DreamingLivePassMetadata = {
+		passId,
+		agentId: pass.agentId,
+		mode: pass.mode,
+		startedAt: pass.startedAt,
+		...(context.modelLabel !== null ? { modelLabel: context.modelLabel } : {}),
+		...(context.instructions !== null ? { instructions: context.instructions } : {}),
+	};
+	const startedMs = Date.parse(pass.startedAt);
+	let toolCalls = 0;
+	try {
+		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
+		toolCalls = getDbAccessor().withReadDb(
+			(db: import("../db-accessor").ReadDb) =>
+				(db
+					.prepare(
+						`SELECT id FROM dreaming_tool_calls WHERE agent_id = ? AND pass_id = ?`,
+					)
+					.all(pass.agentId, passId) as unknown[]
+				).length
+		);
+	} catch {
+		// Observation must not fail attach on trace-read errors.
+	}
+	return {
+		pass: metadata,
+		state: dreamingLiveStateFromStatus(pass.status),
+		elapsedMs: Number.isFinite(startedMs) ? Math.max(0, Date.now() - startedMs) : 0,
+		toolCalls,
+		...(pass.status === "completed" && typeof pass.summary === "string" ? { summary: pass.summary } : {}),
+		...(pass.status === "failed" && typeof pass.error === "string" ? { error: pass.error } : {}),
+	};
 }
 
 async function togglePipelinePause(c: Context, paused: boolean): Promise<Response> {
@@ -730,6 +793,243 @@ export function registerPipelineRoutes(app: Hono): void {
 			agentId: scopedAgent.agentId,
 			passId,
 			items: getDreamingToolCalls(getDbAccessor(), scopedAgent.agentId, passId),
+		});
+	});
+
+	/**
+		 * Enumerate agent-scoped active Dreaming passes for attach selection
+		 * (#1601). The worker is single-flight, so normally at most one row;
+		 * stale rows from crashed in-memory state may coexist and callers must
+		 * then require an explicit choice.
+		 */
+	app.get("/api/dream/passes/active", (c) => {
+		const scopedAgent = resolveScopedDreamAgent(c);
+		if (scopedAgent.error) return c.json({ error: scopedAgent.error }, 403);
+		let items: readonly { passId: string; agentId: string; mode: string; status: string; startedAt: string }[] = [];
+		try {
+			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
+			items = getDbAccessor().withReadDb(
+				(db: import("../db-accessor").ReadDb) =>
+					db
+						.prepare(
+							`SELECT id AS passId, agent_id AS agentId, mode, status, started_at AS startedAt
+							  FROM dreaming_passes
+							  WHERE agent_id = ? AND status = 'running'
+							  ORDER BY started_at DESC`,
+						)
+						.all(scopedAgent.agentId),
+			);
+		} catch (e) {
+			return c.json({ error: e instanceof Error ? e.message : String(e) }, 500);
+		}
+		return c.json({ items });
+	});
+
+	/**
+		 * Live attach stream (#1601): scoped SSE subscription to one active
+		 * Dreaming pass's normalized live events, with cursor-based bounded
+		 * replay and gap recovery. Read-only: the stream observes; it cannot
+		 * steer, cancel, or retry the pass. Ctrl+C on the client side detaches
+		 * without aborting.
+		 */
+	app.get("/api/dream/passes/:passId/live", (c) => {
+		const scopedAgent = resolveScopedDreamAgent(c);
+		if (scopedAgent.error) return c.json({ error: scopedAgent.error }, 403);
+		const passId = c.req.param("passId").trim();
+		if (!passId || !/^[a-z0-9-]{6,64}$/i.test(passId)) {
+			return c.json({ error: "Invalid Dreaming pass id" }, 400);
+		}
+		const bus = getDreamingLiveBus();
+		let pass: {
+			agentId: string;
+			mode: string;
+			status: string;
+			startedAt: string;
+			summary: string | null;
+			error: string | null;
+		} | null = null;
+		try {
+			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
+			pass = getDbAccessor().withReadDb(
+					(db: import("../db-accessor").ReadDb) =>
+						db
+							.prepare(
+								`SELECT agent_id AS agentId, mode, status, started_at AS startedAt,
+								  summary, error
+								  FROM dreaming_passes WHERE id = ?`,
+							)
+							.get(passId) as typeof pass | undefined,
+				) ?? null;
+		} catch (e) {
+			return c.json({ error: e instanceof Error ? e.message : String(e) }, 500);
+		}
+		if (!pass || pass.agentId !== scopedAgent.agentId) {
+			return c.json(
+				{ error: `Dreaming pass ${passId} is not in this agent's context` },
+				404,
+			);
+		}
+		const state = bus.states(passId);
+		if (!state) {
+			if (pass.status === "running") {
+				return c.json(
+					{
+						error: "No live event stream is attached to this pass yet",
+						retryable: true,
+						suggestion: "retry shortly, or poll /api/dream/status",
+					},
+					503,
+				);
+			}
+			return c.json(
+				{
+					error: `Dreaming pass ${passId} already settled (${pass.status})`,
+					state: pass.status,
+					summary: pass.summary ?? null,
+					summaryDetail: pass.error ?? null,
+				},
+				410,
+			);
+		}
+		const cursorParam = c.req.query("cursor");
+		let cursor: number | null = null;
+		if (cursorParam !== undefined) {
+			const parsed = Number(cursorParam);
+			if (!Number.isInteger(parsed) || parsed < 0 || parsed > 1_000_000_000) {
+				return c.json({ error: "Invalid cursor" }, 400);
+			}
+			cursor = parsed;
+		}
+		const snapshotFor = (): DreamingLiveSnapshot =>
+			dreamingLiveSnapshotForPass(passId, pass, bus.context(passId));
+
+		const encoder = new TextEncoder();
+		const subId = `dream-live-${Math.random().toString(36).slice(2)}`;
+		let heartbeat: ReturnType<typeof setInterval> | undefined;
+		const stream = new ReadableStream({
+			start(controller) {
+				let closed = false;
+				let settled = false;
+				// Coalesce rapid assistant/reasoning deltas into fewer SSE
+				// frames (the bounded buffer keeps every event intact).
+				let pending: { kind: string; text: string } | null = null;
+				const send = (payload: unknown): boolean => {
+					if (closed) return false;
+					try {
+						controller.enqueue(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`));
+						return true;
+					} catch {
+						closed = true;
+						return false;
+					}
+				};
+				const flushPending = (): boolean => {
+					if (!pending) return true;
+					const ok = send({ type: pending.kind, passId, text: pending.text });
+					pending = null;
+					return ok;
+				};
+
+				const cleanup = (): void => {
+					if (closed) return;
+					closed = true;
+					try {
+						bus.unsubscribe(passId, subId);
+					} catch {
+						// observation teardown is best-effort
+					}
+					if (heartbeat) clearInterval(heartbeat);
+				};
+
+				heartbeat = setInterval(() => {
+					if (settled || closed) return;
+					if (!flushPending()) return;
+					if (!send({ type: "heartbeat" })) cleanup();
+				}, 30_000);
+
+				const finishStream = (): void => {
+					cleanup();
+					try {
+						controller.close();
+					} catch {
+						// already closed by the consumer
+					}
+				};
+
+				// Stream lifecycle: connected marker, bounded replay, then
+				// live subscription.
+				send({ type: "connected", passId, cursor: state.seq, snapshot: snapshotFor() });
+				if (cursor !== null && cursor + 1 < state.oldest) {
+					send({
+						type: "gap",
+						passId,
+						cursor,
+						oldest: state.oldest,
+						snapshot: snapshotFor(),
+					});
+				}
+				for (const frame of bus.replay(passId, cursor ?? 0)) {
+					if (!send(frame.event)) {
+						cleanup();
+						return;
+					}
+				}
+
+				const onFrame = (frame: import("../pipeline/dreaming-live").DreamingLiveFrame) => {
+					if (closed || settled) return;
+					const event = frame.event;
+					if (event.type === "assistant_delta" || event.type === "reasoning_delta") {
+						pending = { kind: event.type, text: (pending?.text ?? "") + event.text };
+						return;
+					}
+					if (!flushPending()) return;
+					if (event.type === "state_transition" && dreamingLiveTerminalStates.has(event.state)) {
+						settled = true;
+						if (send({ type: "complete", passId, state: event.state })) finishStream();
+						return;
+					}
+					if (!send(event)) cleanup();
+				};
+
+				if (state.terminal) {
+					settled = true;
+					if (send({ type: "complete", passId, state: dreamingLiveStateFromStatus(pass.status) })) {
+						finishStream();
+						return;
+					}
+				}
+
+				if (!bus.subscribe(passId, subId, onFrame)) {
+					settled = true;
+					if (send({ type: "complete", passId, state: dreamingLiveStateFromStatus(pass.status) })) {
+						finishStream();
+						return;
+					}
+				}
+
+				c.req.raw.signal.addEventListener("abort", () => {
+					if (pending) pending = null;
+					cleanup();
+				}, { once: true });
+			},
+			cancel() {
+				// Consumer-side disconnect: stop observation; the pass
+				// continues unaffected.
+				if (heartbeat) clearInterval(heartbeat);
+				try {
+					bus.unsubscribe(passId, subId);
+				} catch {
+					// best effort
+				}
+			},
+		});
+
+		return new Response(stream, {
+			headers: {
+				"Content-Type": "text/event-stream",
+				"Cache-Control": "no-cache, no-transform",
+				"X-Accel-Buffering": "no",
+			},
 		});
 	});
 


### PR DESCRIPTION
## Scope

Daemon-side observation plane for #1601 (the read-only `dream attach` stream).
This PR ships the complete daemon-side surface; the CLI attach/TUI surface
and documentation parity are follow-ups (see below).

- **Shared normalized event contract** (`@signet/core`): `dreaming-live-events`
  type module, exported through the core barrel. Keeps the daemon/CLI
  boundaries decoupled; no Pi session types cross module boundaries (raw
  events cross as `unknown`, narrowed inside the daemon-side normalizer).
- **Live event bus** (`DreamingLiveBus`): bounded per-pass replay ring,
  subscriber fan-out isolation (one bad subscriber cannot wedge the pass),
  cursor-based replay with gap semantics, terminal-state auto-detection
  with bounded delayed prune, and subscribe-before-emit auto-attach.
- **Event normalization** (daemon-side): maps raw Pi session events and the
  context sentinel into bounded normalized events; drops unmodeled and
  control-plane events; oversized payloads are truncated with previews.
- **Session seam**: Pi provider session event sink, inference-router
  plumbing, and executor run-input extension; raw events never steer,
  cancel, or retry the pass.
- **Worker lifecycle observation**: terminal state transitions
  (`completed`, `failed`, `cancelled`, `timed_out`) emitted from module-side
  parse-time reactions routed through the `runPass` completion wrapper.
  This shape is load-bearing: Bun's async-throw attribution machinery
  reports continuations attached to promises created inside the pass
  machinery's async contexts as test errors under `bun test` (regardless of
  attribution position or downstream handling), while crediting
  continuations attached at parse time to simple-machinery promises.
  Expected failures are therefore asserted through observable lifecycle
  side effects, not by consuming raw rejections.
- **Scoped transport endpoints**: `GET /api/dream/passes/active`
  (agent-scoped active-pass enumeration) and
  `GET /api/dream/passes/:passId/live` (agent-scoped SSE attach with
  connected-marker + snapshot, cursor-bounded replay, gap-resync, terminal
  completion/close, and consumer-abort cleanup that never aborts the pass).
- **Startup wiring**: daemon startup passes the singleton bus into the
  Dreaming worker's observation options.

## Verified

- Type-check clean (`bun run typecheck` in `platform/daemon`, core).
- 24/24 focused #1601 assertions across four suites: bus semantics
  (replay cursor, bounded ring eviction, subscriber isolation, terminal
  rejection, attach-bound eviction, prune), event normalization (sentinel,
  deltas, turns, tool mappings, bounded truncation, dropped events),
  worker lifecycle observation (success- and failure-path wiring), and
  route transport semantics (agent-scoped enumeration, cross-agent attach
  rejection, settled-pass semantics, malformed-cursor rejection,
  connected-marker to completion to close).
- Pre-existing unrelated failures in adjacent maintenance/operations
  suites were characterized against HEAD versions and confirmed not
  regressions of this work.

## Follow-ups (not in this PR)

- CLI `dream attach` command (`@earendil-works/pi-tui` dependency in
  `surfaces/cli`), active-pass selection, SSE reconnect/gap recovery, and
  the concise/verbose hotkey view.
- Documentation parity for the new endpoints and attach runbook.
- Behavioral proof against a live Dreaming pass with a working inference
  target.
