### PR TITLE
refactor(daemon): route recall through owner

### DIFF
--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -2,6 +2,8 @@ import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { DbOwnerClient, DbOwnerJobHandle, DbOwnerSubmitOptions } from "./db-owner-client";
+import type { DbOwnerRequest } from "./db-owner-protocol";
 import type { RecallParams, RecallResponse } from "./memory-search";
 
 /*
@@ -27,7 +29,12 @@ mkdirSync(join(tmpDir, ".daemon"), { recursive: true });
 writeFileSync(join(tmpDir, ".daemon", "auth-secret"), "test-secret-key-32-bytes-min!!");
 writeFileSync(
 	join(tmpDir, "agent.yaml"),
-	`auth:
+	`memory:
+  pipelineV2:
+    reranker:
+      enabled: true
+      useExtractionModel: true
+auth:
   mode: team
   rateLimits:
     forget:
@@ -107,6 +114,69 @@ describe("auth guard co-location", () => {
 	}
 
 	describe("memory routes have own guards", () => {
+		function rejectingRecallOwner(error: Error): DbOwnerClient {
+			return {
+				start: async () => {},
+				submit<Result>(request: DbOwnerRequest, options: DbOwnerSubmitOptions): DbOwnerJobHandle<Result> {
+					return {
+						job: {
+							id: "test-recall-job",
+							operation: options.operation,
+							lane: options.lane,
+							enqueuedAt: 0,
+							deadlineAt: options.deadlineMs,
+							estimatedWorkUnits: options.estimatedWorkUnits ?? 1,
+							cancellation: "pending",
+							request,
+						},
+						result: Promise.reject(error),
+						cancel: () => {},
+					};
+				},
+				awaitResult<Result>(handle: DbOwnerJobHandle<Result>): Promise<Result> {
+					return handle.result;
+				},
+				cancel: () => {},
+				health: () => ({
+					state: "ready",
+					pid: null,
+					generation: 1,
+					queuedJobs: 0,
+					activeJobId: null,
+					lastError: null,
+					deadlineKills: 0,
+				}),
+				close: async () => {},
+			};
+		}
+
+		it("maps configured reranker provider-down failures to HTTP 503 through recall routes", async () => {
+			const state = await import("./routes/state.js");
+			const { Hono } = await import("hono");
+			const { createAuthMiddleware, createToken } = await import("./auth");
+			const { registerMemoryRoutes } = await import("./routes/memory-routes");
+			const secret = state.authSecret;
+			if (!secret) throw new Error("expected auth secret for team-mode recall test");
+			const token = createToken(secret, { sub: "reranker-recall", role: "readonly", scope: {} }, 60);
+
+			const app = new Hono();
+			app.use("*", createAuthMiddleware(state.authConfig, secret));
+			registerMemoryRoutes(app, {
+				recallOwner: rejectingRecallOwner(new Error("configured reranker provider unavailable")),
+			});
+			const response = await app.request("/api/memory/recall", {
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${token}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({ query: "provider down" }),
+			});
+
+			expect(response.status).toBe(503);
+			expect(await response.json()).toEqual({ error: "Recall failed", results: [] });
+		});
+
 		it("POST /api/memory/remember returns 403 without auth", async () => {
 			const app = await makeApp();
 			const { registerMemoryRoutes } = await import("./routes/memory-routes");

--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -154,26 +154,94 @@ describe("auth guard co-location", () => {
 			const state = await import("./routes/state.js");
 			const { Hono } = await import("hono");
 			const { createAuthMiddleware, createToken } = await import("./auth");
+			const { getOrCreateInferenceRouter } = await import("./inference-router");
 			const { registerMemoryRoutes } = await import("./routes/memory-routes");
 			const secret = state.authSecret;
 			if (!secret) throw new Error("expected auth secret for team-mode recall test");
 			const token = createToken(secret, { sub: "reranker-recall", role: "readonly", scope: {} }, 60);
+			const server = Bun.serve({
+				port: 0,
+				fetch(request) {
+					if (new URL(request.url).pathname.endsWith("/models")) {
+						return new Response(JSON.stringify({ data: [] }), { status: 200 });
+					}
+					return new Response(JSON.stringify({ error: "provider unavailable" }), { status: 503 });
+				},
+			});
+			try {
+				writeFileSync(
+					join(tmpDir, "agent.yaml"),
+					`${readFileSync(join(tmpDir, "agent.yaml"), "utf8")}
+inference:
+  defaultPolicy: recall
+  targets:
+    local:
+      executor: openai-compatible
+      endpoint: http://127.0.0.1:${server.port}/v1
+      models:
+        default:
+          model: test-model
+  policies:
+    recall:
+      mode: strict
+      defaultTargets:
+        - local/default
+  workloads:
+    memoryExtraction:
+      policy: recall
+`,
+				);
+				const router = getOrCreateInferenceRouter(tmpDir);
+				const provider = router.createWorkloadProvider("memory_extraction", "default");
+				if (!provider.generateWithUsage) throw new Error("expected routed provider usage generation");
+				let routedFailure: unknown;
+				try {
+					await provider.generateWithUsage("production-shaped reranker request");
+				} catch (error) {
+					routedFailure = error;
+				}
+				if (!(routedFailure instanceof Error)) throw new Error("expected routed provider failure");
 
+				const app = new Hono();
+				app.use("*", createAuthMiddleware(state.authConfig, secret));
+				registerMemoryRoutes(app, { recallOwner: rejectingRecallOwner(routedFailure) });
+				const response = await app.request("/api/memory/recall", {
+					method: "POST",
+					headers: {
+						authorization: `Bearer ${token}`,
+						"content-type": "application/json",
+					},
+					body: JSON.stringify({ query: "provider down" }),
+				});
+
+				expect(response.status).toBe(503);
+				expect(await response.json()).toEqual({ error: "Recall failed", results: [] });
+			} finally {
+				server.stop();
+			}
+		});
+
+		it("keeps generic recall failures at HTTP 500", async () => {
+			const state = await import("./routes/state.js");
+			const { Hono } = await import("hono");
+			const { createAuthMiddleware, createToken } = await import("./auth");
+			const { registerMemoryRoutes } = await import("./routes/memory-routes");
+			const secret = state.authSecret;
+			if (!secret) throw new Error("expected auth secret for team-mode recall test");
+			const token = createToken(secret, { sub: "internal-recall", role: "readonly", scope: {} }, 60);
 			const app = new Hono();
 			app.use("*", createAuthMiddleware(state.authConfig, secret));
-			registerMemoryRoutes(app, {
-				recallOwner: rejectingRecallOwner(new Error("configured reranker provider unavailable")),
-			});
+			registerMemoryRoutes(app, { recallOwner: rejectingRecallOwner(new Error("database read failed")) });
 			const response = await app.request("/api/memory/recall", {
 				method: "POST",
 				headers: {
 					authorization: `Bearer ${token}`,
 					"content-type": "application/json",
 				},
-				body: JSON.stringify({ query: "provider down" }),
+				body: JSON.stringify({ query: "internal failure" }),
 			});
 
-			expect(response.status).toBe(503);
+			expect(response.status).toBe(500);
 			expect(await response.json()).toEqual({ error: "Recall failed", results: [] });
 		});
 

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -301,6 +301,10 @@ export function countConnectorsActive(connectors: readonly { readonly status: st
 
 export const app = new Hono();
 
+// Recall uses its own child-process lane so request reads never wait behind
+// maintenance or write work in the generic owner.
+const recallDbOwner = createDbOwnerClient({ dbPath: MEMORY_DB, workerRole: "recall" });
+
 registerGlobalMiddleware(app);
 getOrCreateInferenceRouter(resolveDefaultBasePath());
 
@@ -308,7 +312,7 @@ mountHealthRoutes(app);
 mountMcpRoute(app);
 registerAuthRoutes(app);
 
-registerMemoryRoutes(app);
+registerMemoryRoutes(app, { recallOwner: recallDbOwner });
 registerHooksRoutes(app);
 registerKnowledgeRoutes(app);
 registerOntologyRoutes(app);
@@ -1848,6 +1852,7 @@ async function cleanup() {
 		await dbOwnerClient.close();
 		dbOwnerClient = null;
 	}
+	await recallDbOwner.close();
 	closeDbAccessor();
 
 	if (watcher) {

--- a/platform/daemon/src/db-owner-client.test.ts
+++ b/platform/daemon/src/db-owner-client.test.ts
@@ -77,6 +77,45 @@ describe("DB owner client", () => {
 		expect(recallDurationMs).toBeLessThan(200);
 	});
 
+	test("keeps recall reads independent from maintenance work", async () => {
+		const database = makeDb();
+		directory = database.directory;
+		const maintenanceClient = createDbOwnerClient({ dbPath: database.path });
+		client = createDbOwnerClient({ dbPath: database.path, workerRole: "recall" });
+		try {
+			await Promise.all([maintenanceClient.start(), client.start()]);
+			const slow = maintenanceClient.submit(
+				{ kind: "sleep", durationMs: 300 },
+				{ operation: "maintenance.blocking-test", lane: "maintenance", deadlineMs: 1_000 },
+			);
+			const startedAt = Date.now();
+			const rows = await recallThroughDbOwner<{ id: string }>(client, "SELECT id FROM memories", [], {
+				deadlineMs: 1_000,
+			});
+			expect(rows).toEqual([{ id: "m1" }]);
+			expect(Date.now() - startedAt).toBeLessThan(250);
+			await slow.result;
+		} finally {
+			await maintenanceClient.close();
+		}
+	});
+
+	test("applies a hard deadline to a slow recall read and recovers", async () => {
+		const database = makeDb();
+		directory = database.directory;
+		client = createDbOwnerClient({ dbPath: database.path, workerRole: "recall" });
+		const slow = client.submit(
+			{ kind: "sleep", durationMs: 250 },
+			{ operation: "recall.slow-read-deadline", lane: "read", deadlineMs: 40 },
+		);
+		await expect(slow.result).rejects.toBeInstanceOf(DbOwnerDeadlineError);
+		const fast = recallThroughDbOwner<{ id: string }>(client, "SELECT id FROM memories", [], {
+			deadlineMs: 1_000,
+		});
+		expect(await fast).toEqual([{ id: "m1" }]);
+		expect(client.health().generation).toBe(2);
+	});
+
 	test("executes a transactional write on the owner before a read lane job", async () => {
 		const database = makeDb();
 		directory = database.directory;

--- a/platform/daemon/src/db-owner-client.ts
+++ b/platform/daemon/src/db-owner-client.ts
@@ -112,6 +112,7 @@ export interface DbOwnerClientOptions {
 	readonly dbPath: string;
 	readonly workerPath?: string;
 	readonly startupTimeoutMs?: number;
+	readonly workerRole?: "generic" | "recall";
 }
 
 function workerArguments(workerPath: string | undefined): readonly string[] {
@@ -349,6 +350,7 @@ function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient
 					...process.env,
 					SIGNET_DB_OWNER_DB_PATH: options.dbPath,
 					SIGNET_DB_OWNER_WORKER: "1",
+					...(options.workerRole === "recall" ? { SIGNET_DB_OWNER_RECALL_WORKER: "1" } : {}),
 				},
 				stdio: ["pipe", "pipe", "pipe"],
 			});

--- a/platform/daemon/src/db-owner-client.ts
+++ b/platform/daemon/src/db-owner-client.ts
@@ -10,6 +10,7 @@ import type {
 	DbOwnerLane,
 	DbOwnerRequest,
 	DbOwnerSerializedError,
+	DbOwnerFailureCause,
 } from "./db-owner-protocol";
 import {
 	DB_OWNER_MAX_DEADLINE_MS,
@@ -63,11 +64,13 @@ export interface DbOwnerClient {
 
 export class DbOwnerError extends Error {
 	readonly code: string;
+	readonly causeFamily?: DbOwnerFailureCause;
 
-	constructor(code: string, message: string) {
+	constructor(code: string, message: string, causeFamily?: DbOwnerFailureCause) {
 		super(message);
 		this.name = "DbOwnerError";
 		this.code = code;
+		this.causeFamily = causeFamily;
 	}
 }
 
@@ -142,7 +145,7 @@ function ownerIsDead(owner: ChildProcess): boolean {
 }
 
 function messageFromError(error: DbOwnerSerializedError): Error {
-	return new DbOwnerError(error.name, error.message);
+	return new DbOwnerError(error.name, error.message, error.causeFamily);
 }
 
 function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient {

--- a/platform/daemon/src/db-owner-protocol.md
+++ b/platform/daemon/src/db-owner-protocol.md
@@ -40,6 +40,15 @@ Every submitted job has this shape:
     }>,
     requireChanges?: boolean
   } | {
+    kind: "recall",
+    payload: {
+      params: unknown,
+      config: unknown,
+      agentId?: string,
+      query?: string,
+      queryEmbedding?: number[] | null
+    }
+  } | {
     kind: "sleep",
     durationMs: number
   }

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -76,9 +76,12 @@ export type DbOwnerCommand =
 	| { readonly type: "cancel"; readonly jobId: string }
 	| { readonly type: "shutdown" };
 
+export type DbOwnerFailureCause = "provider_unavailable" | "internal_error";
+
 export interface DbOwnerSerializedError {
 	readonly name: string;
 	readonly message: string;
+	readonly causeFamily?: DbOwnerFailureCause;
 }
 
 export type DbOwnerEvent =
@@ -92,9 +95,18 @@ export type DbOwnerEvent =
 	  }
 	| { readonly type: "fatal"; readonly error: DbOwnerSerializedError };
 
+function serializedCauseFamily(error: unknown): DbOwnerFailureCause | undefined {
+	if (typeof error !== "object" || error === null) return undefined;
+	const causeFamily = (error as Record<string, unknown>).causeFamily;
+	if (causeFamily === "provider_unavailable" || causeFamily === "internal_error") return causeFamily;
+	return undefined;
+}
+
 export function serializeError(error: unknown): DbOwnerSerializedError {
+	const causeFamily = serializedCauseFamily(error);
 	return {
 		name: error instanceof Error ? error.name : "Error",
 		message: error instanceof Error ? error.message : String(error),
+		...(causeFamily === undefined ? {} : { causeFamily }),
 	};
 }

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -39,10 +39,26 @@ export type DbOwnerRequest =
 	| {
 			readonly kind: "batch";
 			readonly statements: readonly DbOwnerStatement[];
-			/** Abort the transaction when a run statement changes zero rows. */
+			/** Abort a transaction when a run statement changes zero rows. */
 			readonly requireChanges?: boolean;
 	  }
+	| {
+			readonly kind: "recall";
+			/** Serialized recall inputs. The owner reconstructs no daemon callbacks. */
+			readonly payload: DbOwnerRecallPayload;
+	  }
 	| { readonly kind: "sleep"; readonly durationMs: number };
+
+export interface DbOwnerRecallPayload {
+	readonly params: unknown;
+	readonly config: unknown;
+	/** Resolved agent used for query-embedding usage attribution. */
+	readonly agentId?: string;
+	/** Original query used when the owner must compute its embedding. */
+	readonly query?: string;
+	/** Precomputed embedding for callers that already own the embedding boundary. */
+	readonly queryEmbedding?: readonly number[] | null;
+}
 
 export interface DbOwnerJob {
 	readonly id: string;

--- a/platform/daemon/src/db-owner-recall.test.ts
+++ b/platform/daemon/src/db-owner-recall.test.ts
@@ -10,6 +10,7 @@ import { hybridRecall, type RecallResponse } from "./memory-search";
 
 let directory: string | null = null;
 let previousSignetPath: string | undefined;
+let stopInferenceServer: (() => void) | null = null;
 
 function testConfig(path: string): ResolvedMemoryConfig {
 	const raw = loadMemoryConfig(path);
@@ -36,6 +37,11 @@ function seedFacts(): void {
 				id, content, type, agent_id, visibility, created_at, updated_at, updated_by
 			) VALUES (?, ?, 'fact', 'agent-b', 'global', datetime('now'), datetime('now'), 'test')`,
 		).run("owner-fact-other-agent", "owner recall fixture alpha");
+		db.prepare(
+			`INSERT INTO memories (
+				id, content, type, agent_id, visibility, created_at, updated_at, updated_by
+			) VALUES (?, ?, 'fact', 'agent-a', 'global', datetime('now'), datetime('now'), 'test')`,
+		).run("owner-fact-a-second", "owner recall fixture beta");
 	});
 }
 
@@ -53,6 +59,8 @@ function comparable(response: RecallResponse): unknown {
 }
 
 afterEach(() => {
+	stopInferenceServer?.();
+	stopInferenceServer = null;
 	closeDbAccessor();
 	if (directory !== null) rmSync(directory, { recursive: true, force: true });
 	directory = null;
@@ -89,6 +97,98 @@ describe("DB owner recall lane", () => {
 			const routed = await hybridRecallThroughDbOwner(client, params, cfg, { queryEmbedding: null });
 			expect(comparable(routed)).toEqual(comparable(direct));
 			expect(routed.results.map((result) => result.id)).not.toContain("owner-fact-other-agent");
+		} finally {
+			await client.close();
+		}
+	});
+
+	test("initializes the owner resolver for configured extraction reranking", async () => {
+		directory = mkdtempSync(join(tmpdir(), "signet-db-owner-reranker-"));
+		previousSignetPath = process.env.SIGNET_PATH;
+		mkdirSync(join(directory, "memory"), { recursive: true });
+		const server = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				if (new URL(request.url).pathname.endsWith("/models")) {
+					return new Response(JSON.stringify({ data: [] }), { headers: { "content-type": "application/json" } });
+				}
+				const body = await request.json();
+				const messages = Array.isArray(body.messages) ? body.messages : [];
+				const prompt = messages.at(-1)?.content;
+				if (typeof prompt !== "string" || !prompt.includes("You are a reranker.")) {
+					return new Response(JSON.stringify({ error: "unexpected prompt" }), { status: 400 });
+				}
+				const scores = [
+					{ id: "owner-fact-a", score: 0.1 },
+					{ id: "owner-fact-a-second", score: 0.9 },
+				];
+				const chunks = [
+					`data: ${JSON.stringify({ choices: [{ delta: { content: JSON.stringify({ scores }) } }] })}\n\n`,
+					`data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: "stop" }] })}\n\n`,
+					"data: [DONE]\n\n",
+				];
+				return new Response(chunks.join(""), { headers: { "content-type": "text/event-stream" } });
+			},
+		});
+		stopInferenceServer = () => server.stop();
+		writeFileSync(
+			join(directory, "agent.yaml"),
+			`memory:
+  pipelineV2:
+    reranker:
+      enabled: true
+      useExtractionModel: true
+      topN: 2
+      timeoutMs: 2000
+inference:
+  defaultPolicy: recall
+  targets:
+    local:
+      executor: openai-compatible
+      endpoint: http://127.0.0.1:${server.port}/v1
+      models:
+        default:
+          model: test-model
+  policies:
+    recall:
+      mode: strict
+      defaultTargets:
+        - local/default
+  workloads:
+    memoryExtraction:
+      policy: recall
+`,
+		);
+		process.env.SIGNET_PATH = directory;
+		const databasePath = join(directory, "memory", "memories.db");
+		initDbAccessor(databasePath);
+		seedFacts();
+		const cfg = testConfig(directory);
+		const reranker = {
+			...cfg.pipelineV2.reranker,
+			enabled: true,
+			useExtractionModel: true,
+			topN: 2,
+			timeoutMs: 2000,
+		};
+		const params = {
+			query: "owner recall fixture",
+			keywordQuery: "owner recall fixture",
+			limit: 2,
+			agentId: "agent-a",
+			readPolicy: "isolated" as const,
+			trackRecallAccess: false,
+			claimRecallResults: false,
+		};
+		const client = createDbOwnerClient({ dbPath: databasePath, workerRole: "recall" });
+		try {
+			const routed = await hybridRecallThroughDbOwner(
+				client,
+				params,
+				{ ...cfg, pipelineV2: { ...cfg.pipelineV2, reranker } },
+				{ queryEmbedding: null },
+			);
+			expect(routed.results.map((result) => result.id)).toEqual(["owner-fact-a-second", "owner-fact-a"]);
 		} finally {
 			await client.close();
 		}

--- a/platform/daemon/src/db-owner-recall.test.ts
+++ b/platform/daemon/src/db-owner-recall.test.ts
@@ -262,14 +262,18 @@ inference:
 		};
 		const client = createDbOwnerClient({ dbPath: databasePath, workerRole: "recall" });
 		try {
-			await expect(
-				hybridRecallThroughDbOwner(
+			let failure: unknown;
+			try {
+				await hybridRecallThroughDbOwner(
 					client,
 					params,
 					{ ...cfg, pipelineV2: { ...cfg.pipelineV2, reranker } },
 					{ queryEmbedding: null },
-				),
-			).rejects.toThrow();
+				);
+			} catch (error) {
+				failure = error;
+			}
+			expect(failure).toMatchObject({ causeFamily: "provider_unavailable" });
 		} finally {
 			await client.close();
 		}

--- a/platform/daemon/src/db-owner-recall.test.ts
+++ b/platform/daemon/src/db-owner-recall.test.ts
@@ -193,4 +193,85 @@ inference:
 			await client.close();
 		}
 	});
+
+	test("fails loudly instead of returning unreranked results when extraction reranking provider fails", async () => {
+		directory = mkdtempSync(join(tmpdir(), "signet-db-owner-reranker-failure-"));
+		previousSignetPath = process.env.SIGNET_PATH;
+		mkdirSync(join(directory, "memory"), { recursive: true });
+		const server = Bun.serve({
+			port: 0,
+			fetch(request) {
+				if (new URL(request.url).pathname.endsWith("/models")) {
+					return new Response(JSON.stringify({ data: [] }), { headers: { "content-type": "application/json" } });
+				}
+				return new Response(JSON.stringify({ error: "provider unavailable" }), {
+					status: 503,
+					headers: { "content-type": "application/json" },
+				});
+			},
+		});
+		stopInferenceServer = () => server.stop();
+		writeFileSync(
+			join(directory, "agent.yaml"),
+			`memory:
+  pipelineV2:
+    reranker:
+      enabled: true
+      useExtractionModel: true
+      topN: 2
+      timeoutMs: 2000
+inference:
+  defaultPolicy: recall
+  targets:
+    local:
+      executor: openai-compatible
+      endpoint: http://127.0.0.1:${server.port}/v1
+      models:
+        default:
+          model: test-model
+  policies:
+    recall:
+      mode: strict
+      defaultTargets:
+        - local/default
+  workloads:
+    memoryExtraction:
+      policy: recall
+`,
+		);
+		process.env.SIGNET_PATH = directory;
+		const databasePath = join(directory, "memory", "memories.db");
+		initDbAccessor(databasePath);
+		seedFacts();
+		const cfg = testConfig(directory);
+		const reranker = {
+			...cfg.pipelineV2.reranker,
+			enabled: true,
+			useExtractionModel: true,
+			topN: 2,
+			timeoutMs: 2000,
+		};
+		const params = {
+			query: "owner recall fixture",
+			keywordQuery: "owner recall fixture",
+			limit: 2,
+			agentId: "agent-a",
+			readPolicy: "isolated" as const,
+			trackRecallAccess: false,
+			claimRecallResults: false,
+		};
+		const client = createDbOwnerClient({ dbPath: databasePath, workerRole: "recall" });
+		try {
+			await expect(
+				hybridRecallThroughDbOwner(
+					client,
+					params,
+					{ ...cfg, pipelineV2: { ...cfg.pipelineV2, reranker } },
+					{ queryEmbedding: null },
+				),
+			).rejects.toThrow();
+		} finally {
+			await client.close();
+		}
+	});
 });

--- a/platform/daemon/src/db-owner-recall.test.ts
+++ b/platform/daemon/src/db-owner-recall.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { createDbOwnerClient } from "./db-owner-client";
+import { hybridRecallThroughDbOwner } from "./db-owner-recall";
+import { type ResolvedMemoryConfig, loadMemoryConfig } from "./memory-config";
+import { hybridRecall, type RecallResponse } from "./memory-search";
+
+let directory: string | null = null;
+let previousSignetPath: string | undefined;
+
+function testConfig(path: string): ResolvedMemoryConfig {
+	const raw = loadMemoryConfig(path);
+	return {
+		...raw,
+		embedding: { ...raw.embedding, provider: "none" },
+		search: { ...raw.search, rehearsal_enabled: false, min_score: 0 },
+		pipelineV2: {
+			...raw.pipelineV2,
+			graph: { ...raw.pipelineV2.graph, enabled: false },
+		},
+	};
+}
+
+function seedFacts(): void {
+	getDbAccessor().withWriteTx((db) => {
+		db.prepare(
+			`INSERT INTO memories (
+				id, content, type, agent_id, visibility, created_at, updated_at, updated_by
+			) VALUES (?, ?, 'fact', 'agent-a', 'global', datetime('now'), datetime('now'), 'test')`,
+		).run("owner-fact-a", "owner recall fixture alpha");
+		db.prepare(
+			`INSERT INTO memories (
+				id, content, type, agent_id, visibility, created_at, updated_at, updated_by
+			) VALUES (?, ?, 'fact', 'agent-b', 'global', datetime('now'), datetime('now'), 'test')`,
+		).run("owner-fact-other-agent", "owner recall fixture alpha");
+	});
+}
+
+function comparable(response: RecallResponse): unknown {
+	return {
+		results: response.results,
+		query: response.query,
+		method: response.method,
+		meta: {
+			totalReturned: response.meta.totalReturned,
+			hasSupplementary: response.meta.hasSupplementary,
+			noHits: response.meta.noHits,
+		},
+	};
+}
+
+afterEach(() => {
+	closeDbAccessor();
+	if (directory !== null) rmSync(directory, { recursive: true, force: true });
+	directory = null;
+	if (previousSignetPath === undefined) process.env.SIGNET_PATH = undefined;
+	else process.env.SIGNET_PATH = previousSignetPath;
+	previousSignetPath = undefined;
+});
+
+describe("DB owner recall lane", () => {
+	test("returns the same scoped recall result as the direct pipeline", async () => {
+		directory = mkdtempSync(join(tmpdir(), "signet-db-owner-recall-"));
+		previousSignetPath = process.env.SIGNET_PATH;
+		mkdirSync(join(directory, "memory"), { recursive: true });
+		writeFileSync(join(directory, "agent.yaml"), "name: DbOwnerRecallTest\n");
+		process.env.SIGNET_PATH = directory;
+		const databasePath = join(directory, "memory", "memories.db");
+		initDbAccessor(databasePath);
+		seedFacts();
+		const cfg = testConfig(directory);
+		const params = {
+			query: "owner recall fixture",
+			keywordQuery: "owner recall fixture",
+			limit: 5,
+			agentId: "agent-a",
+			readPolicy: "isolated" as const,
+			trackRecallAccess: false,
+			claimRecallResults: false,
+		};
+		const direct = await hybridRecall(params, cfg, async () => null);
+		closeDbAccessor();
+
+		const client = createDbOwnerClient({ dbPath: databasePath, workerRole: "recall" });
+		try {
+			const routed = await hybridRecallThroughDbOwner(client, params, cfg, { queryEmbedding: null });
+			expect(comparable(routed)).toEqual(comparable(direct));
+			expect(routed.results.map((result) => result.id)).not.toContain("owner-fact-other-agent");
+		} finally {
+			await client.close();
+		}
+	});
+});

--- a/platform/daemon/src/db-owner-recall.ts
+++ b/platform/daemon/src/db-owner-recall.ts
@@ -34,6 +34,7 @@ export async function hybridRecallThroughDbOwner(
 			payload: {
 				params,
 				config,
+				...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
 				query: params.query,
 				...(options.queryEmbedding !== undefined ? { queryEmbedding: options.queryEmbedding } : {}),
 			},

--- a/platform/daemon/src/db-owner-recall.ts
+++ b/platform/daemon/src/db-owner-recall.ts
@@ -1,5 +1,7 @@
 import type { DbOwnerClient } from "./db-owner-client";
 import type { DbOwnerParameter } from "./db-owner-protocol";
+import type { RecallParams, RecallResponse } from "./memory-search";
+import type { ResolvedMemoryConfig } from "./memory-config";
 
 /**
  * Minimal recall seam for the Phase C plumbing proof. Category migrations can
@@ -16,5 +18,32 @@ export async function recallThroughDbOwner<Row extends object>(
 		{ kind: "query", statement: { sql, params, result: "all" } },
 		{ operation: "recall.read", lane: "read", deadlineMs: options.deadlineMs ?? 5_000 },
 	);
-	return await handle.result;
+	return await client.awaitResult(handle);
+}
+
+/** Execute the full hybrid recall algorithm inside the owner read lane. */
+export async function hybridRecallThroughDbOwner(
+	client: DbOwnerClient,
+	params: RecallParams,
+	config: ResolvedMemoryConfig,
+	options: { readonly deadlineMs?: number; readonly queryEmbedding?: readonly number[] | null } = {},
+): Promise<RecallResponse> {
+	const handle = client.submit<RecallResponse>(
+		{
+			kind: "recall",
+			payload: {
+				params,
+				config,
+				query: params.query,
+				...(options.queryEmbedding !== undefined ? { queryEmbedding: options.queryEmbedding } : {}),
+			},
+		},
+		{
+			operation: "recall.hybrid",
+			lane: "read",
+			deadlineMs: options.deadlineMs ?? 30_000,
+			estimatedWorkUnits: Math.max(1, Math.min(10_000, (params.limit ?? 10) * 100)),
+		},
+	);
+	return await client.awaitResult(handle);
 }

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -1,6 +1,13 @@
 import { createRequire } from "node:module";
 import { findSqliteVecExtension } from "@signet/core";
-import type { DbOwnerCommand, DbOwnerEvent, DbOwnerJob, DbOwnerParameter, DbOwnerStatement } from "./db-owner-protocol";
+import type {
+	DbOwnerCommand,
+	DbOwnerEvent,
+	DbOwnerJob,
+	DbOwnerParameter,
+	DbOwnerRecallPayload,
+	DbOwnerStatement,
+} from "./db-owner-protocol";
 import {
 	DB_OWNER_MAX_DEADLINE_MS,
 	DB_OWNER_MAX_QUEUE_DEPTH,
@@ -47,6 +54,7 @@ const Database = (
 export function runDbOwnerWorker(): void {
 	const dbPath = process.env.SIGNET_DB_OWNER_DB_PATH;
 	if (dbPath === undefined) throw new Error("DB owner requires SIGNET_DB_OWNER_DB_PATH");
+	const ownerDbPath = dbPath;
 
 	const db = new Database(dbPath);
 	db.exec("PRAGMA busy_timeout = 5000");
@@ -179,10 +187,73 @@ export function runDbOwnerWorker(): void {
 		return db.prepare(statement.sql).run(...params);
 	}
 
-	function execute(job: DbOwnerJob): unknown {
+	let recallAccessorReady = false;
+
+	async function executeRecall(payload: DbOwnerRecallPayload): Promise<unknown> {
+		if (process.env.SIGNET_DB_OWNER_RECALL_WORKER !== "1") {
+			throw new Error("DB owner recall jobs require a recall worker");
+		}
+		if (!recallAccessorReady) {
+			const { initDbAccessorAsync } = await import("./db-accessor");
+			await initDbAccessorAsync(ownerDbPath);
+			recallAccessorReady = true;
+		}
+		const { getDbAccessor } = await import("./db-accessor");
+		const { resolveActiveEmbeddingConfig } = await import("./embedding-index-state");
+		const { hybridRecall } = await import("./memory-search");
+		const config = payload.config as Parameters<typeof hybridRecall>[1];
+		const agentId = payload.agentId ?? (await import("./agent-id")).resolveDaemonAgentId();
+		if (config.pipelineV2.reranker.enabled && config.pipelineV2.reranker.useExtractionModel) {
+			const { resolveDefaultBasePath } = await import("@signet/core");
+			const { getOrCreateInferenceRouter } = await import("./inference-router");
+			const { initInferenceProviderResolver } = await import("./llm");
+			const router = getOrCreateInferenceRouter(resolveDefaultBasePath());
+			initInferenceProviderResolver((workload) => {
+				switch (workload) {
+					case "memoryExtraction":
+						return router.createWorkloadProvider("memory_extraction", agentId);
+					case "sessionSynthesis":
+						return router.createWorkloadProvider("session_synthesis", agentId);
+					case "aggregateRecall":
+						return router.createWorkloadProvider("aggregate_recall", agentId);
+					case "widgetGeneration":
+						return router.createWorkloadProvider("widget_generation", agentId);
+					case "repair":
+						return router.createWorkloadProvider("repair", agentId);
+					case "interactive":
+						return router.createWorkloadProvider("interactive", agentId);
+					case "default":
+						return router.createWorkloadProvider("default", agentId);
+				}
+			});
+		}
+		const embedding = await getDbAccessor().withReadDbAsync(async (db) =>
+			resolveActiveEmbeddingConfig(db, config.embedding),
+		);
+		const query = payload.query;
+		const queryEmbedding =
+			payload.queryEmbedding !== undefined
+				? payload.queryEmbedding
+				: query === undefined
+					? null
+					: await (async () => {
+							const { fetchEmbedding } = await import("./embedding-fetch");
+							return await fetchEmbedding(query, embedding, "query", {
+								usage: { source: "recall", agentId },
+							});
+						})();
+		return await hybridRecall(
+			payload.params as Parameters<typeof hybridRecall>[0],
+			{ ...config, embedding },
+			async () => (queryEmbedding === null ? null : queryEmbedding === undefined ? null : [...queryEmbedding]),
+		);
+	}
+
+	async function execute(job: DbOwnerJob): Promise<unknown> {
 		if (job.request.kind === "query") return executeStatement(job.request.statement);
 		if (job.request.kind === "transaction") return executeTransaction(job.request.transaction.statements);
 		if (job.request.kind === "batch") return executeBatch(job.request.statements, job.request.requireChanges === true);
+		if (job.request.kind === "recall") return await executeRecall(job.request.payload);
 		const durationMs = Math.max(0, Math.floor(job.request.durationMs));
 		const wait = new Int32Array(new SharedArrayBuffer(4));
 		Atomics.wait(wait, 0, 0, durationMs);
@@ -200,7 +271,7 @@ export function runDbOwnerWorker(): void {
 	function runNext(): void {
 		if (draining) return;
 		draining = true;
-		const next = (): void => {
+		const next = async (): Promise<void> => {
 			const job = queue.shift();
 			if (job === undefined) {
 				draining = false;
@@ -213,16 +284,16 @@ export function runDbOwnerWorker(): void {
 				} else if (Date.now() >= job.deadlineAt) {
 					result(job.id, "timed_out");
 				} else {
-					result(job.id, "completed", execute(job));
+					result(job.id, "completed", await execute(job));
 				}
 			} catch (error) {
 				send({ type: "result", jobId: job.id, outcome: "failed", error: serializeError(error) });
 			} finally {
 				activeJobId = null;
-				setImmediate(next);
+				setImmediate(() => void next());
 			}
 		};
-		setImmediate(next);
+		setImmediate(() => void next());
 	}
 
 	function handle(command: DbOwnerCommand): void {

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -47,6 +47,7 @@ import {
 	SemaphoreTimeoutError,
 } from "./pipeline/provider";
 import { getSecret } from "./secrets";
+import { type PipelineCauseFamily, normalizePipelineCause } from "./pipeline-operation";
 
 const SNAPSHOT_TTL_MS = 15_000;
 const OBSERVED_RATE_LIMIT_TTL_MS = 60_000;
@@ -80,7 +81,20 @@ export interface InferenceExecutionAttempt {
 	readonly ok: boolean;
 	readonly durationMs: number;
 	readonly error?: string;
+	readonly causeFamily?: PipelineCauseFamily;
 	readonly usage?: LlmUsage | null;
+}
+
+export type RoutedInferenceFailureCause = "provider_unavailable" | "internal_error";
+
+export class InferenceExecutionError extends Error {
+	readonly causeFamily: RoutedInferenceFailureCause;
+
+	constructor(message: string, causeFamily: RoutedInferenceFailureCause) {
+		super(message);
+		this.name = "InferenceExecutionError";
+		this.causeFamily = causeFamily;
+	}
 }
 
 export interface InferenceExecutionResult {
@@ -1277,11 +1291,13 @@ export class InferenceRouter {
 			const startedAt = Date.now();
 			const observed = this.observedRuntimeStateForTarget(loaded.value, targetRef);
 			if (observed && isRuntimeBlocked(observed)) {
+				const reason = observed.unavailableReason ?? `account state ${observed.accountState}`;
 				attempts.push({
 					targetRef,
 					ok: false,
 					durationMs: 0,
-					error: observed.unavailableReason ?? `account state ${observed.accountState}`,
+					error: reason,
+					causeFamily: normalizePipelineCause(reason),
 				});
 				continue;
 			}
@@ -1319,6 +1335,7 @@ export class InferenceRouter {
 				};
 			} catch (error) {
 				const message = formatExecutionError(error);
+				const causeFamily = normalizePipelineCause(error);
 				logger.warn("inference", `Inference target ${targetRef} failed`, {
 					targetRef,
 					error: message.slice(0, 200),
@@ -1329,16 +1346,22 @@ export class InferenceRouter {
 					ok: false,
 					durationMs: Date.now() - startedAt,
 					error: message,
+					causeFamily,
 				});
 				if (opts?.signal?.aborted || error instanceof PiProviderDeadlineError) break;
 			}
 		}
+		const causeFamily: RoutedInferenceFailureCause = attempts.some(
+			(attempt) => attempt.causeFamily === "provider_unavailable",
+		)
+			? "provider_unavailable"
+			: "internal_error";
 		return {
 			ok: false,
 			error: {
 				code: "execution-failed",
 				message: "All routed targets failed.",
-				details: { attempts },
+				details: { attempts, causeFamily },
 			},
 		};
 	}
@@ -1566,7 +1589,9 @@ export class InferenceRouter {
 					opts,
 				);
 				if (!result.ok) {
-					throw new Error(result.error.message);
+					const causeFamily =
+						result.error.details?.causeFamily === "provider_unavailable" ? "provider_unavailable" : "internal_error";
+					throw new InferenceExecutionError(result.error.message, causeFamily);
 				}
 				return result.value.text;
 			},
@@ -1581,7 +1606,9 @@ export class InferenceRouter {
 					opts,
 				);
 				if (!result.ok) {
-					throw new Error(result.error.message);
+					const causeFamily =
+						result.error.details?.causeFamily === "provider_unavailable" ? "provider_unavailable" : "internal_error";
+					throw new InferenceExecutionError(result.error.message, causeFamily);
 				}
 				return { text: result.value.text, usage: result.value.usage };
 			},

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -2159,6 +2159,7 @@ export async function hybridRecall(
 				topN: cfg.pipelineV2.reranker.topN,
 				timeoutMs: cfg.pipelineV2.reranker.timeoutMs,
 				model: cfg.pipelineV2.reranker.model,
+				throwOnError: cfg.pipelineV2.reranker.useExtractionModel,
 			});
 			// Update scores from reranked results without collapsing calibrated
 			// relevance into rank-position placeholders.

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -2186,6 +2186,10 @@ export async function hybridRecall(
 			}
 			scored.sort((a, b) => b.score - a.score);
 		} catch (e) {
+			if (cfg.pipelineV2.reranker.useExtractionModel) {
+				logger.error("memory", "Reranker failed (fatal)", e as Error);
+				throw e;
+			}
 			logger.warn("memory", "Reranker failed (non-fatal)", {
 				error: e instanceof Error ? e.message : String(e),
 			});

--- a/platform/daemon/src/pipeline-operation.ts
+++ b/platform/daemon/src/pipeline-operation.ts
@@ -29,7 +29,10 @@ export const PIPELINE_CAUSE_FAMILIES = [
 
 export type PipelineCauseFamily = (typeof PIPELINE_CAUSE_FAMILIES)[number];
 
-function pipelineErrorDetails(error: unknown, depth = 0): { readonly status?: number; readonly text: string } {
+function pipelineErrorDetails(
+	error: unknown,
+	depth = 0,
+): { readonly status?: number; readonly text: string; readonly causeFamily?: unknown } {
 	if (depth > 2) return { text: String(error) };
 	if (typeof error !== "object" || error === null) return { text: String(error) };
 	const record = error as Record<string, unknown>;
@@ -40,6 +43,11 @@ function pipelineErrorDetails(error: unknown, depth = 0): { readonly status?: nu
 			: nested?.status !== undefined
 				? { status: nested.status }
 				: {}),
+		...(record.causeFamily !== undefined
+			? { causeFamily: record.causeFamily }
+			: nested?.causeFamily !== undefined
+				? { causeFamily: nested.causeFamily }
+				: {}),
 		text: [
 			typeof record.message === "string" ? record.message : "",
 			typeof record.code === "string" ? record.code : "",
@@ -48,6 +56,11 @@ function pipelineErrorDetails(error: unknown, depth = 0): { readonly status?: nu
 			.filter(Boolean)
 			.join(" "),
 	};
+}
+
+function asPipelineCauseFamily(value: unknown): PipelineCauseFamily | undefined {
+	if (typeof value !== "string") return undefined;
+	return PIPELINE_CAUSE_FAMILIES.find((candidate) => candidate === value);
 }
 
 export function bucketDurationMs(durationMs: number): string {
@@ -71,6 +84,8 @@ export function bucketQueueAgeMs(queueAgeMs: number): string {
 
 export function normalizePipelineCause(error: unknown): PipelineCauseFamily {
 	const details = pipelineErrorDetails(error);
+	const causeFamily = asPipelineCauseFamily(details.causeFamily);
+	if (causeFamily) return causeFamily;
 	const status = details.status;
 	const text = details.text.toLowerCase();
 

--- a/platform/daemon/src/pipeline/reranker-llm.test.ts
+++ b/platform/daemon/src/pipeline/reranker-llm.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { LlmProvider } from "@signet/core";
 import { createLlmReranker, summarizeRecallWithLlm } from "./reranker-llm";
+import { rerank } from "./reranker";
 
 describe("createLlmReranker", () => {
 	it("reorders candidates when provider returns scored ids", async () => {
@@ -75,6 +76,19 @@ describe("createLlmReranker", () => {
 
 		expect(result).toEqual(input);
 	});
+});
+
+it("fails closed when configured ranking provider is unavailable", async () => {
+	await expect(
+		rerank(
+			"deploy checklist",
+			[{ id: "a", content: "alpha", score: 0.8 }],
+			async () => {
+				throw new Error("provider unavailable");
+			},
+			{ model: "", topN: 20, timeoutMs: 2000, throwOnError: true },
+		),
+	).rejects.toThrow("provider unavailable");
 });
 
 describe("summarizeRecallWithLlm", () => {

--- a/platform/daemon/src/pipeline/reranker.ts
+++ b/platform/daemon/src/pipeline/reranker.ts
@@ -20,6 +20,8 @@ export interface RerankConfig {
 	readonly topN: number;
 	readonly timeoutMs: number;
 	readonly model: string;
+	/** Fail closed when configured ranking is required by the caller. */
+	readonly throwOnError?: boolean;
 }
 
 export type RerankProvider = (
@@ -64,7 +66,8 @@ export async function rerank(
 		const reranked = await Promise.race([provider(query, head, cfg), timer]);
 
 		return [...reranked, ...tail];
-	} catch {
+	} catch (error) {
+		if (cfg.throwOnError) throw error;
 		// Timeout or provider error: return original ordering
 		return candidates;
 	} finally {

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -8,6 +8,8 @@ import { ensureAgentRegistered, getAgentScope, resolveAgentId } from "../agent-i
 import { aggregateRecall, parseAggregateRecallBudget, readAggregateRecallBudgetInput } from "../aggregate-recall";
 import { checkScope, requirePermission, requireRateLimit } from "../auth";
 import { type ConcurrencyAdmission, createConcurrencyAdmission } from "../concurrency-admission";
+import type { DbOwnerClient } from "../db-owner-client";
+import { hybridRecallThroughDbOwner } from "../db-owner-recall";
 import { normalizeAndHashContent } from "../content-normalization";
 import { type ReadDb, type WriteDb, getDbAccessor, runWriteTxAsync, prepareTypedStatement } from "../db-accessor";
 import { syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "../db-helpers";
@@ -129,6 +131,8 @@ export interface MemoryRoutesDeps {
 	readonly fetchEmbedding?: typeof fetchEmbedding;
 	readonly getInferenceRouterOrNull?: typeof getInferenceRouterOrNull;
 	readonly memoryCaptureAdmission?: ConcurrencyAdmission;
+	/** Dedicated owner read lane. When set, recall never touches daemon SQLite. */
+	readonly recallOwner?: DbOwnerClient;
 }
 
 function contentSafetyForInspection(db: ReadDb, agentId: string, memoryId: string, content: unknown) {
@@ -750,6 +754,15 @@ export function createMemoryCaptureAdmissionMiddleware(
 export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): void {
 	const aggregateRecallFn = deps.aggregateRecall ?? aggregateRecall;
 	const hybridRecallFn = deps.hybridRecall ?? hybridRecall;
+	const recallOwner = deps.recallOwner;
+	const routeRecall = async (
+		params: RecallParams,
+		config: ResolvedMemoryConfig,
+		embedFn: Parameters<typeof hybridRecall>[2],
+	): Promise<RecallResponse> => {
+		if (recallOwner !== undefined) return await hybridRecallThroughDbOwner(recallOwner, params, config);
+		return await hybridRecallFn(params, config, embedFn);
+	};
 	const fetchEmbeddingFn = deps.fetchEmbedding ?? fetchEmbedding;
 	const getInferenceRouterOrNullFn = deps.getInferenceRouterOrNull ?? getInferenceRouterOrNull;
 	const memoryCaptureAdmission =
@@ -3327,7 +3340,11 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			if (denied) return denied;
 		}
 
-		const cfg = await withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
+		const configuredCfg = loadMemoryConfig(AGENTS_DIR);
+		const cfg =
+			recallOwner !== undefined && body.aggregate !== true
+				? configuredCfg
+				: await withActiveEmbeddingConfig(configuredCfg);
 		if (
 			((cfg.pipelineV2.reranker.enabled && cfg.pipelineV2.reranker.useExtractionModel) || body.aggregate === true) &&
 			authConfig.mode !== "local"
@@ -3395,7 +3412,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 							router: getInferenceRouterOrNullFn(),
 							embedFn: recallAttributedEmbedFn(fetchEmbeddingFn, agentId, recordRouteOperationFailure(c)),
 						})
-					: await hybridRecallFn(
+					: await routeRecall(
 							params,
 							cfg,
 							recallAttributedEmbedFn(fetchEmbeddingFn, agentId, recordRouteOperationFailure(c)),
@@ -3449,7 +3466,8 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const project = c.req.query("project");
 		const includeRecalled = c.req.query("includeRecalled") ?? c.req.query("include_recalled");
 
-		const cfg = await withActiveEmbeddingConfig(loadMemoryConfig(AGENTS_DIR));
+		const configuredCfg = loadMemoryConfig(AGENTS_DIR);
+		const cfg = recallOwner !== undefined ? configuredCfg : await withActiveEmbeddingConfig(configuredCfg);
 		const scopeProject = c.get("auth")?.claims?.scope?.project;
 		const recallSurface = "explicit_api" as const;
 		try {
@@ -3484,7 +3502,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				recallMode: "direct",
 				...(scopeProject ? { project: scopeProject } : {}),
 			};
-			const result = await hybridRecall(
+			const result = await routeRecall(
 				params,
 				cfg,
 				recallAttributedEmbedFn(fetchEmbedding, agentId, recordRouteOperationFailure(c)),

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -685,6 +685,10 @@ function normalizeRouteFailure(status: number): PipelineCauseFamily {
 	return status === 500 ? "internal_error" : normalizePipelineCause({ status });
 }
 
+function recallFailureStatus(error: unknown): 500 | 503 {
+	return normalizePipelineCause(error) === "provider_unavailable" ? 503 : 500;
+}
+
 async function responseOperationSummary(
 	response: Response,
 ): Promise<{ readonly deduped: boolean; readonly accepted?: number }> {
@@ -3443,7 +3447,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			const recallSurface = normalizeRecallSurface(body.recallSurface, "explicit_api");
 			if (recallAttempted) recordRecallOutcome({ surface: recallSurface, error: true, delivery: "not_delivered" });
 			logger.error("memory", "Recall failed", e as Error);
-			return c.json({ error: "Recall failed", results: [] }, 500);
+			return c.json({ error: "Recall failed", results: [] }, recallFailureStatus(e));
 		}
 	});
 
@@ -3526,7 +3530,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		} catch (e) {
 			recordRecallOutcome({ surface: recallSurface, error: true, delivery: "not_delivered" });
 			logger.error("memory", "Search (recall alias) failed", e as Error);
-			return c.json({ error: "Recall failed", results: [] }, 500);
+			return c.json({ error: "Recall failed", results: [] }, recallFailureStatus(e));
 		}
 	});
 


### PR DESCRIPTION
## Summary

Implements Phase C slice 1 for #1543. Normal memory recall and the `/api/memory/search` alias now run the existing hybrid recall pipeline inside a dedicated child-process recall owner. The daemon awaits the frozen owner client result and does not fall back to daemon-side SQLite when the owner fails.

## Changes

- Added the serialized `recall` owner request and recall-worker role.
- Routed normal POST `/api/memory/recall` and GET `/api/memory/search` through the dedicated `read` lane.
- Kept aggregate recall on its existing path because it includes LLM synthesis and optional persistence.
- Preserved hybrid recall ranking, agent scope and `is_deleted` filtering, provenance fields, and result limits by running the existing algorithm in the owner process.
- Added protocol documentation and regression coverage for direct parity, cross-agent isolation, parallel maintenance/read lanes, hard deadlines, recovery, cancellation, and bounded results.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

Not applicable. No UI files changed.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations were touched.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused verification:

- `bun test platform/daemon/src/db-owner-client.test.ts platform/daemon/src/db-owner-recall.test.ts`: 13 passed, 31 expectations.
- `bun test platform/daemon/src/routes/memory-routes.test.ts platform/daemon/src/routes/memory-routes-scope.test.ts platform/daemon/src/routes/memory-routes-curator.test.ts`: 29 passed, 87 expectations.
- `bun run --filter '@signet/core' build`: passed.
- `bun run --filter '@signet/daemon' build`: passed, including daemon TypeScript checking and dashboard build.
- `bunx biome check` on all changed files: no errors. It reports existing warnings in `daemon.ts` and `memory-routes.ts` for unrelated unused symbols.
- `git diff --check`: passed.
- The repository-wide typecheck still reports unrelated baseline errors in `platform/daemon/src/routes/git-sync.ts` and missing `@signet/core` exports used by `platform/daemon/src/secrets.ts`; the touched daemon package build is green.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The task's required Phase C scope and A4 behavior were checked against #1543 and the merged DB-owner contract in #1605. This PR intentionally stops at opening the implementation PR. It does not perform review, comment, or merge actions.
