### PR TITLE
fix(daemon): route integrity through owner

### DIFF
--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -57,6 +57,8 @@ import {
 	type WriteDb,
 } from "./db-accessor";
 import { type VacuumConversionHandle, startVacuumConversionWorker } from "./db-vacuum";
+import { createDbOwnerClient, type DbOwnerClient } from "./db-owner-client";
+import { ownerRunStatement } from "./db-owner-maintenance";
 import { getQueueDiagnosticsSnapshot, getQueuePressureSnapshot } from "./diagnostics-queue";
 import { fetchEmbedding } from "./embedding-fetch";
 import { type EmbeddingIndexMigrationHandle, startEmbeddingIndexMigration } from "./embedding-index-migration";
@@ -263,6 +265,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 let httpServer: import("node:net").Server | null = null;
+let dbOwnerClient: DbOwnerClient | null = null;
 let dreamingWorkerHandle: DreamingWorkerHandle | null = null;
 let reflectionWorkerHandle: ReflectionWorkerHandle | null = null;
 let embeddingTrackerHandle: EmbeddingTrackerHandle | null = null;
@@ -1821,6 +1824,10 @@ async function cleanup() {
 		});
 	}
 
+	if (dbOwnerClient !== null) {
+		await dbOwnerClient.close();
+		dbOwnerClient = null;
+	}
 	closeDbAccessor();
 
 	if (watcher) {
@@ -2032,11 +2039,10 @@ async function main() {
 	startEventLoopMonitor();
 	startFdPollMonitor();
 
-	// Clean accumulated crash-loop damage (dead jobs, stagnant staging buffer,
-	// WAL bloat) before any worker starts. Integrity scanning is deliberately
-	// not part of this synchronous phase. The full-database quick_check runs in
-	// a bounded worker after the HTTP server is ready (#1513).
-	runStartupRecovery(getDbAccessor());
+	dbOwnerClient = createDbOwnerClient({ dbPath: MEMORY_DB });
+	// Clean accumulated crash-loop damage through the owner. This remains a
+	// deferred call, so owner startup and the bounded drain never delay readiness.
+	runStartupRecovery(getDbAccessor(), { owner: dbOwnerClient });
 
 	// Purge artifacts of sources deleted while the daemon was down (e.g.
 	// crash-loop-disabled sources). This needs the DB accessor, so it runs
@@ -2394,6 +2400,32 @@ async function main() {
 		vacuumConversionHandle = startVacuumConversionWorker(getDbAccessor());
 		void runDeferredIntegrityCheck(getDbAccessor(), MEMORY_DB, {
 			timeoutMs: 30_000,
+			owner: dbOwnerClient ?? undefined,
+			ownerAudit: (indexes, detectionMessages) => {
+				const auditId = createHash("sha256")
+					.update(JSON.stringify({ indexes, detectionMessages }))
+					.digest("hex")
+					.slice(0, 32);
+				return [
+					ownerRunStatement(
+						`INSERT OR IGNORE INTO memory_history
+						 (id, memory_id, event, old_content, new_content, changed_by, reason, metadata, created_at, actor_type)
+						 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+						[
+							auditId,
+							"system",
+							"none",
+							null,
+							null,
+							"daemon",
+							"deferred database integrity repair",
+							JSON.stringify({ repairAction: "reindex-telemetry", indexes, detectionMessages }),
+							new Date().toISOString(),
+							"daemon",
+						],
+					),
+				];
+			},
 			audit: (db, indexes) => {
 				try {
 					insertHistoryEvent(db, {

--- a/platform/daemon/src/database-integrity.test.ts
+++ b/platform/daemon/src/database-integrity.test.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { repairTelemetryIndexes, runDeferredIntegrityCheck } from "./database-integrity";
+import { createDbOwnerClient } from "./db-owner-client";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 
 function fakeAccessor(options: { readonly quickMessage?: string; readonly telemetryMessage?: string }): {
@@ -88,6 +89,32 @@ afterEach(async () => {
 });
 
 describe("telemetry database integrity recovery (#1360)", () => {
+	it("runs quick_check and telemetry verification through the DB owner", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "integrity-owner-"));
+		const dbPath = join(dir, "memory.db");
+		const database = new Database(dbPath);
+		database.exec(
+			"CREATE TABLE telemetry_events (event TEXT, queue TEXT, timestamp TEXT, unsent INTEGER); CREATE INDEX idx_telemetry_events_event ON telemetry_events(event)",
+		);
+		database.close();
+		const owner = createDbOwnerClient({ dbPath });
+		try {
+			const result = await repairTelemetryIndexes(fakeAccessor({}).accessor, undefined, {
+				owner,
+				repairTimeoutMs: 5_000,
+			});
+			expect(result.state).toBe("healthy");
+			expect(result.quickCheck.ok).toBe(true);
+			expect(result.telemetryCheck.ok).toBe(true);
+			expect(result.ownerState).toBe("ready");
+			expect(result.ownerGeneration).toBe(1);
+			expect(result.deadlineKills).toBe(0);
+		} finally {
+			await owner.close();
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("rebuilds disposable telemetry indexes after quick_check misses the mismatch", async () => {
 		const { accessor, reindexed } = fakeAccessor({
 			telemetryMessage: "row 111120 missing from index idx_telemetry_events_event",

--- a/platform/daemon/src/database-integrity.ts
+++ b/platform/daemon/src/database-integrity.ts
@@ -14,6 +14,9 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
+import { DbOwnerDeadlineError, type DbOwnerClient } from "./db-owner-client";
+import { ownerQueryAll, ownerRunStatement, ownerTransaction } from "./db-owner-maintenance";
+import type { DbOwnerStatement } from "./db-owner-protocol";
 import { logger } from "./logger";
 import { resolveEmbeddedWorkerPath } from "./native-runtime-assets";
 
@@ -33,6 +36,9 @@ export interface DatabaseIntegrityStatus {
 	readonly rebuiltIndexes: readonly string[];
 	readonly durationMs: number;
 	readonly repairGuidance: string | null;
+	readonly ownerState: string | null;
+	readonly ownerGeneration: number | null;
+	readonly deadlineKills: number;
 }
 
 const UNKNOWN_CHECK: IntegrityCheckStatus = { ok: false, messages: ["not checked"] };
@@ -48,6 +54,9 @@ let latestStatus: DatabaseIntegrityStatus = {
 	rebuiltIndexes: [],
 	durationMs: 0,
 	repairGuidance: null,
+	ownerState: null,
+	ownerGeneration: null,
+	deadlineKills: 0,
 };
 
 function check(db: ReadDb, pragma: "quick_check" | "integrity_check", table?: string): IntegrityCheckStatus {
@@ -80,7 +89,9 @@ function statusWith(
 	phase: DatabaseIntegrityStatus["phase"] = "complete",
 	durationMs = 0,
 	repairGuidance: string | null = state === "corrupt" || state === "unavailable" ? REPAIR_GUIDANCE : null,
+	owner?: DbOwnerClient,
 ): DatabaseIntegrityStatus {
+	const health = owner?.health();
 	return {
 		checkedAt: new Date().toISOString(),
 		state,
@@ -90,6 +101,9 @@ function statusWith(
 		rebuiltIndexes,
 		durationMs,
 		repairGuidance,
+		ownerState: health?.state ?? null,
+		ownerGeneration: health?.generation ?? null,
+		deadlineKills: health?.deadlineKills ?? 0,
 	};
 }
 
@@ -113,11 +127,22 @@ export interface DatabaseIntegrityWorkerMessage {
 	readonly result: DatabaseIntegrityWorkerResult;
 }
 
+function ownerCheck(rows: readonly Record<string, unknown>[], key: string): IntegrityCheckStatus {
+	const messages = rows.map((row) => String(row[key] ?? ""));
+	if (messages.length === 1 && messages[0] === "ok") return { ok: true, messages: [] };
+	return { ok: false, messages };
+}
+
 export interface DeferredIntegrityCheckOptions {
 	readonly workerPath?: string;
 	readonly timeoutMs?: number;
 	readonly audit?: TelemetryIndexRepairAudit;
 	readonly onWorkerStarted?: () => void;
+	readonly owner?: DbOwnerClient;
+	readonly ownerAudit?: (
+		indexes: readonly string[],
+		detectionMessages: readonly string[],
+	) => readonly DbOwnerStatement[];
 }
 
 const DEFAULT_INTEGRITY_TIMEOUT_MS = 30_000;
@@ -294,11 +319,74 @@ export function runDeferredIntegrityCheck(
 	return run;
 }
 
+async function runOwnerDeferredIntegrityCheck(
+	accessor: DbAccessor,
+	dbPath: string,
+	options: Partial<DeferredIntegrityCheckOptions>,
+): Promise<DatabaseIntegrityStatus> {
+	const owner = options.owner;
+	if (owner === undefined) throw new Error("owner integrity check requires a DB owner");
+	const timeoutMs = options.timeoutMs ?? DEFAULT_INTEGRITY_TIMEOUT_MS;
+	const startedAt = Date.now();
+	latestStatus = statusWith("unknown", UNKNOWN_CHECK, UNKNOWN_CHECK, [], "running", 0, null, owner);
+	logger.info("startup-recovery", "Deferred database integrity check started through the DB owner", { timeoutMs });
+	const progressTimer = setInterval(() => {
+		const health = owner.health();
+		logger.info("startup-recovery", "Database integrity owner work in progress", {
+			elapsedMs: Date.now() - startedAt,
+			budgetMs: timeoutMs,
+			ownerState: health.state,
+			ownerGeneration: health.generation,
+			deadlineKills: health.deadlineKills,
+		});
+	}, 1_000);
+	try {
+		const status = await repairTelemetryIndexes(accessor, options.audit, {
+			dbPath,
+			repairTimeoutMs: timeoutMs,
+			owner,
+			ownerAudit: options.ownerAudit,
+		});
+		latestStatus = { ...status, durationMs: Date.now() - startedAt };
+		logger.info("startup-recovery", "Deferred database integrity check complete through the DB owner", {
+			state: latestStatus.state,
+			durationMs: latestStatus.durationMs,
+			ownerState: latestStatus.ownerState,
+			ownerGeneration: latestStatus.ownerGeneration,
+			deadlineKills: latestStatus.deadlineKills,
+		});
+		return latestStatus;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const timedOut = error instanceof DbOwnerDeadlineError;
+		latestStatus = statusWith(
+			"unavailable",
+			{ ok: false, messages: [message] },
+			UNKNOWN_CHECK,
+			[],
+			timedOut ? "timed_out" : "complete",
+			Date.now() - startedAt,
+			REPAIR_GUIDANCE,
+			owner,
+		);
+		logger.error("startup-recovery", "Owner-routed database integrity check failed", undefined, {
+			error: message,
+			ownerState: latestStatus.ownerState,
+			ownerGeneration: latestStatus.ownerGeneration,
+			deadlineKills: latestStatus.deadlineKills,
+		});
+		return latestStatus;
+	} finally {
+		clearInterval(progressTimer);
+	}
+}
+
 async function runDeferredIntegrityCheckInternal(
 	accessor: DbAccessor,
 	dbPath: string,
 	options: Partial<DeferredIntegrityCheckOptions>,
 ): Promise<DatabaseIntegrityStatus> {
+	if (options.owner !== undefined) return await runOwnerDeferredIntegrityCheck(accessor, dbPath, options);
 	const timeoutMs = options.timeoutMs ?? DEFAULT_INTEGRITY_TIMEOUT_MS;
 	const startedAt = Date.now();
 	latestStatus = statusWith("unknown", UNKNOWN_CHECK, UNKNOWN_CHECK, [], "running", 0);
@@ -409,27 +497,76 @@ async function runDeferredIntegrityCheckInternal(
  * doubles without a database path use one queued transaction for both
  * operations.
  */
+export interface IntegrityRepairOptions {
+	readonly quickCheck?: IntegrityCheckStatus;
+	readonly dbPath?: string;
+	readonly repairTimeoutMs?: number;
+	readonly repairWorkerPath?: string;
+	readonly repairRuntimePath?: string;
+	readonly repairRequireBase?: string;
+	readonly owner?: DbOwnerClient;
+	readonly ownerAudit?: (
+		indexes: readonly string[],
+		detectionMessages: readonly string[],
+	) => readonly DbOwnerStatement[];
+}
+
+async function readIntegrityChecks(
+	accessor: DbAccessor,
+	options: IntegrityRepairOptions | undefined,
+): Promise<{
+	readonly quick: IntegrityCheckStatus;
+	readonly telemetry: IntegrityCheckStatus;
+	readonly indexes: readonly string[];
+}> {
+	if (options?.owner === undefined) {
+		return await accessor.withReadDbAsync(async (db) => ({
+			quick: options?.quickCheck ?? check(db, "quick_check"),
+			telemetry: check(db, "integrity_check", "telemetry_events"),
+			indexes: listTelemetryIndexes(db),
+		}));
+	}
+	const deadlineMs = options.repairTimeoutMs ?? DEFAULT_INTEGRITY_TIMEOUT_MS;
+	const quick =
+		options.quickCheck ??
+		ownerCheck(
+			await ownerQueryAll<Record<string, unknown>>(options.owner, "integrity.quick-check", "PRAGMA quick_check", [], {
+				deadlineMs,
+			}),
+			"quick_check",
+		);
+	const telemetry = ownerCheck(
+		await ownerQueryAll<Record<string, unknown>>(
+			options.owner,
+			"integrity.telemetry-check",
+			"PRAGMA integrity_check(telemetry_events)",
+			[],
+			{ deadlineMs },
+		),
+		"integrity_check",
+	);
+	const indexes = (
+		await ownerQueryAll<{ name?: unknown }>(
+			options.owner,
+			"integrity.telemetry-indexes",
+			"SELECT name FROM sqlite_schema WHERE type = 'index' AND tbl_name = 'telemetry_events' AND sql IS NOT NULL ORDER BY name",
+			[],
+			{ deadlineMs },
+		)
+	).flatMap((row) => (typeof row.name === "string" ? [row.name] : []));
+	return { quick, telemetry, indexes };
+}
+
 export async function repairTelemetryIndexes(
 	accessor: DbAccessor,
 	audit?: TelemetryIndexRepairAudit,
-	options?: {
-		readonly quickCheck?: IntegrityCheckStatus;
-		readonly dbPath?: string;
-		readonly repairTimeoutMs?: number;
-		readonly repairWorkerPath?: string;
-		readonly repairRuntimePath?: string;
-		readonly repairRequireBase?: string;
-	},
+	options?: IntegrityRepairOptions,
 ): Promise<DatabaseIntegrityStatus> {
 	let quickCheck: IntegrityCheckStatus;
 	let telemetryCheck: IntegrityCheckStatus;
 	let telemetryIndexes: readonly string[];
 	try {
-		const checks = await accessor.withReadDbAsync(async (db) => ({
-			quick: options?.quickCheck ?? check(db, "quick_check"),
-			telemetry: check(db, "integrity_check", "telemetry_events"),
-			indexes: listTelemetryIndexes(db),
-		}));
+		const checks = await readIntegrityChecks(accessor, options);
 		quickCheck = checks.quick;
 		telemetryCheck = checks.telemetry;
 		telemetryIndexes = checks.indexes;
@@ -439,25 +576,48 @@ export async function repairTelemetryIndexes(
 			{ ok: false, messages: [error instanceof Error ? error.message : String(error)] },
 			UNKNOWN_CHECK,
 			[],
+			"complete",
+			0,
+			REPAIR_GUIDANCE,
+			options?.owner,
 		);
 		return latestStatus;
 	}
 
 	if (quickCheck.ok && telemetryCheck.ok) {
-		latestStatus = statusWith("healthy", quickCheck, telemetryCheck, []);
+		latestStatus = statusWith("healthy", quickCheck, telemetryCheck, [], "complete", 0, null, options?.owner);
 		return latestStatus;
 	}
 
 	// quick_check covers the whole database. A failed global check is not
 	// safely repairable by rebuilding a telemetry index.
 	if (!quickCheck.ok) {
-		latestStatus = statusWith("corrupt", quickCheck, telemetryCheck, []);
+		latestStatus = statusWith(
+			"corrupt",
+			quickCheck,
+			telemetryCheck,
+			[],
+			"complete",
+			0,
+			REPAIR_GUIDANCE,
+			options?.owner,
+		);
 		return latestStatus;
 	}
 
 	if (!telemetryCheck.ok) {
 		try {
-			if (options?.dbPath !== undefined) {
+			if (options?.owner !== undefined) {
+				const statements = [
+					...(options.ownerAudit?.(telemetryIndexes, telemetryCheck.messages) ?? []),
+					...telemetryIndexes.map((index) => ownerRunStatement(`REINDEX ${escapedIdentifier(index)}`)),
+				];
+				if (statements.length === 0) throw new Error("telemetry repair has no owner statements");
+				await ownerTransaction(options.owner, "integrity.repair", statements, {
+					deadlineMs: options.repairTimeoutMs ?? DEFAULT_INTEGRITY_TIMEOUT_MS,
+					estimatedWorkUnits: Math.max(1, statements.length),
+				});
+			} else if (options?.dbPath !== undefined) {
 				if (audit !== undefined) {
 					await writeAsync(accessor, (db) => audit(db, telemetryIndexes, telemetryCheck.messages));
 				}
@@ -476,24 +636,52 @@ export async function repairTelemetryIndexes(
 				});
 			}
 
-			const verifiedTelemetry = await accessor.withReadDbAsync(async (db) =>
-				check(db, "integrity_check", "telemetry_events"),
-			);
+			const verifiedTelemetry =
+				options?.owner === undefined
+					? await accessor.withReadDbAsync(async (db) => check(db, "integrity_check", "telemetry_events"))
+					: ownerCheck(
+							await ownerQueryAll<Record<string, unknown>>(
+								options.owner,
+								"integrity.telemetry-verify",
+								"PRAGMA integrity_check(telemetry_events)",
+								[],
+								{ deadlineMs: options.repairTimeoutMs ?? DEFAULT_INTEGRITY_TIMEOUT_MS },
+							),
+							"integrity_check",
+						);
 			if (verifiedTelemetry.ok) {
-				latestStatus = statusWith("repaired", quickCheck, verifiedTelemetry, [...telemetryIndexes]);
+				latestStatus = statusWith(
+					"repaired",
+					quickCheck,
+					verifiedTelemetry,
+					[...telemetryIndexes],
+					"complete",
+					0,
+					null,
+					options?.owner,
+				);
 				return latestStatus;
 			}
 			telemetryCheck = verifiedTelemetry;
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			telemetryCheck = { ok: false, messages: [...telemetryCheck.messages, message] };
-			if (error instanceof IntegrityRepairTimeoutError) {
-				latestStatus = statusWith("unavailable", quickCheck, telemetryCheck, [], "timed_out", 0);
+			if (error instanceof IntegrityRepairTimeoutError || error instanceof DbOwnerDeadlineError) {
+				latestStatus = statusWith(
+					"unavailable",
+					quickCheck,
+					telemetryCheck,
+					[],
+					"timed_out",
+					0,
+					REPAIR_GUIDANCE,
+					options?.owner,
+				);
 				return latestStatus;
 			}
 		}
 	}
 
-	latestStatus = statusWith("corrupt", quickCheck, telemetryCheck, []);
+	latestStatus = statusWith("corrupt", quickCheck, telemetryCheck, [], "complete", 0, REPAIR_GUIDANCE, options?.owner);
 	return latestStatus;
 }

--- a/platform/daemon/src/db-owner-client.test.ts
+++ b/platform/daemon/src/db-owner-client.test.ts
@@ -78,6 +78,29 @@ describe("DB owner client", () => {
 		expect(rows).toEqual([{ id: "m1" }, { id: "m2" }]);
 	});
 
+	test("waits through a busy writer instead of failing the owner transaction", async () => {
+		const database = makeDb();
+		directory = database.directory;
+		const blocker = new Database(database.path);
+		blocker.exec("BEGIN IMMEDIATE");
+		client = createDbOwnerClient({ dbPath: database.path });
+		const write = client.submit<{ readonly changes: number }>(
+			{
+				kind: "query",
+				statement: {
+					sql: "INSERT INTO memories (id, content) VALUES (?, ?)",
+					params: ["busy-writer", "waited for the writer"],
+					result: "run",
+				},
+			},
+			{ operation: "integrity.busy-writer", lane: "maintenance", deadlineMs: 2_000 },
+		);
+		await new Promise((resolve) => setTimeout(resolve, 150));
+		blocker.exec("ROLLBACK");
+		blocker.close();
+		expect((await write.result).changes).toBe(1);
+	});
+
 	test("detects an owner crash and recovers with a fresh owner", async () => {
 		const database = makeDb();
 		directory = database.directory;
@@ -105,6 +128,7 @@ describe("DB owner client", () => {
 		);
 		await expect(slow.result).rejects.toBeInstanceOf(DbOwnerDeadlineError);
 		await waitFor(() => client?.health().state === "dead");
+		expect(client.health().deadlineKills).toBe(1);
 		const fast = client.submit<unknown[]>(
 			{ kind: "query", statement: { sql: "SELECT 1 AS value", result: "all" } },
 			{ operation: "recall.read", lane: "read", deadlineMs: 1_000 },

--- a/platform/daemon/src/db-owner-client.ts
+++ b/platform/daemon/src/db-owner-client.ts
@@ -35,6 +35,8 @@ export interface DbOwnerHealth {
 	readonly queuedJobs: number;
 	readonly activeJobId: string | null;
 	readonly lastError: string | null;
+	/** Number of owner processes SIGKILLed by a hard job deadline. */
+	readonly deadlineKills: number;
 }
 
 export interface DbOwnerSubmitOptions {
@@ -153,6 +155,7 @@ export function createDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClien
 	let pid: number | null = null;
 	let activeJobId: string | null = null;
 	let lastError: string | null = null;
+	let deadlineKills = 0;
 	let sequence = 0;
 	let input = "";
 	const pending = new Map<string, PendingJob<unknown>>();
@@ -165,6 +168,7 @@ export function createDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClien
 			queuedJobs: pending.size,
 			activeJobId,
 			lastError,
+			deadlineKills,
 		};
 	}
 
@@ -471,6 +475,7 @@ export function createDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClien
 				const entry = pending.get(job.id);
 				if (entry === undefined || entry.settled) return;
 				lastError = `deadline exceeded for ${job.id}`;
+				deadlineKills++;
 				settle(job.id, (settledJob) => {
 					if (!settledJob.settled) {
 						settledJob.settled = true;

--- a/platform/daemon/src/db-owner-maintenance.ts
+++ b/platform/daemon/src/db-owner-maintenance.ts
@@ -1,0 +1,109 @@
+import { DbOwnerDiedError, type DbOwnerClient, type DbOwnerJobHandle } from "./db-owner-client";
+import type { DbOwnerParameter, DbOwnerRequest, DbOwnerStatement } from "./db-owner-protocol";
+
+export interface DbOwnerMaintenanceOptions {
+	readonly deadlineMs?: number;
+	readonly estimatedWorkUnits?: number;
+}
+
+const DEFAULT_DEADLINE_MS = 5_000;
+
+function submitOptions(
+	operation: string,
+	lane: "read" | "write" | "maintenance",
+	options: DbOwnerMaintenanceOptions,
+): {
+	readonly operation: string;
+	readonly lane: "read" | "write" | "maintenance";
+	readonly deadlineMs: number;
+	readonly estimatedWorkUnits?: number;
+} {
+	return {
+		operation,
+		lane,
+		deadlineMs: options.deadlineMs ?? DEFAULT_DEADLINE_MS,
+		estimatedWorkUnits: options.estimatedWorkUnits,
+	};
+}
+
+async function runOwnerJob<Result>(
+	owner: DbOwnerClient,
+	request: DbOwnerRequest,
+	operation: string,
+	lane: "read" | "write" | "maintenance",
+	options: DbOwnerMaintenanceOptions = {},
+): Promise<Result> {
+	const handle: DbOwnerJobHandle<Result> = owner.submit<Result>(request, submitOptions(operation, lane, options));
+	return await handle.result;
+}
+
+/** Run an idempotent maintenance request once more after an owner crash. */
+export async function runOwnerMaintenanceWithRetry<Result>(
+	owner: DbOwnerClient,
+	request: DbOwnerRequest,
+	operation: string,
+	options: DbOwnerMaintenanceOptions = {},
+): Promise<Result> {
+	try {
+		return await runOwnerJob(owner, request, operation, "maintenance", options);
+	} catch (error) {
+		if (!(error instanceof DbOwnerDiedError)) throw error;
+		await owner.start();
+		return await runOwnerJob(owner, request, operation, "maintenance", options);
+	}
+}
+
+export async function ownerQueryAll<Row extends object>(
+	owner: DbOwnerClient,
+	operation: string,
+	sql: string,
+	params: readonly DbOwnerParameter[] = [],
+	options: DbOwnerMaintenanceOptions = {},
+): Promise<readonly Row[]> {
+	return await runOwnerMaintenanceWithRetry<readonly Row[]>(
+		owner,
+		{ kind: "query", statement: { sql, params, result: "all" } },
+		operation,
+		options,
+	);
+}
+
+export async function ownerQueryOne<Row extends object>(
+	owner: DbOwnerClient,
+	operation: string,
+	sql: string,
+	params: readonly DbOwnerParameter[] = [],
+	options: DbOwnerMaintenanceOptions = {},
+): Promise<Row | undefined> {
+	const result = await runOwnerMaintenanceWithRetry<Row | null | undefined>(
+		owner,
+		{ kind: "query", statement: { sql, params, result: "get" } },
+		operation,
+		options,
+	);
+	return result ?? undefined;
+}
+
+export async function ownerTransaction(
+	owner: DbOwnerClient,
+	operation: string,
+	statements: readonly DbOwnerStatement[],
+	options: DbOwnerMaintenanceOptions = {},
+): Promise<readonly unknown[]> {
+	return await runOwnerMaintenanceWithRetry<readonly unknown[]>(
+		owner,
+		{ kind: "transaction", transaction: { statements } },
+		operation,
+		options,
+	);
+}
+
+export function ownerRunStatement(sql: string, params: readonly DbOwnerParameter[] = []): DbOwnerStatement {
+	return { sql, params, result: "run" };
+}
+
+export function ownerChanges(result: unknown): number {
+	if (typeof result !== "object" || result === null || !("changes" in result)) return 0;
+	const changes = result.changes;
+	return typeof changes === "number" && Number.isFinite(changes) ? changes : 0;
+}

--- a/platform/daemon/src/db-owner-protocol.md
+++ b/platform/daemon/src/db-owner-protocol.md
@@ -25,6 +25,11 @@ Every submitted job has this shape:
       transactional?: boolean
     }
   } | {
+    kind: "transaction",
+    transaction: {
+      statements: Array<Statement>
+    }
+  } | {
     kind: "sleep",
     durationMs: number
   }
@@ -54,7 +59,7 @@ The owner sends:
 
 ## Execution and cancellation
 
-The first implementation has one FIFO process. `read` jobs and `write` or `maintenance` jobs are still tagged separately, preserving the lane split for a future transport with parallel readers and one writer. A `run` statement is wrapped in `BEGIN IMMEDIATE`/`COMMIT` unless `transactional: false` is explicit. Read statements do not open a transaction.
+The first implementation has one FIFO process. `read` jobs and `write` or `maintenance` jobs are still tagged separately, preserving the lane split for a future transport with parallel readers and one writer. A `run` statement is wrapped in `BEGIN IMMEDIATE`/`COMMIT` unless `transactional: false` is explicit. A transaction request wraps all of its statements in one `BEGIN IMMEDIATE`/`COMMIT` and rolls back the complete batch on any failure. Read statements do not open a transaction.
 
 A queued cancellation is removed from the client pending map, clears its deadline timer, and is removed from the owner's queue before execution. A cancellation received while synchronous native SQLite work is running is best effort because the owner cannot observe stdin until that call returns. A deadline is different: the client kills the entire child with `SIGKILL` at the absolute deadline. The subsequent owner death fails all other in-flight and queued jobs closed.
 
@@ -69,6 +74,7 @@ Construction failure, malformed protocol input, owner exit, deadline kill, and j
 - `awaitResult(handle, timeoutMs?)` awaits a result and cancels on the optional caller timeout.
 - `cancel(jobId)` requests cancellation.
 - `health()` returns owner state, PID, generation, queued count, active job, and last error without touching SQLite.
+- `health()` also reports hard-deadline kills, so maintenance pressure is visible without touching SQLite.
 - `close()` sends shutdown and is idempotent.
 
 No callback receives a database handle. No synchronous SQLite symbol is exported by the client or the recall seam. The owner module is the sanctioned synchronous site.

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -13,6 +13,7 @@ export const DB_OWNER_MAX_QUEUE_DEPTH = 64;
 export const DB_OWNER_MAX_WORK_UNITS = 10_000;
 export const DB_OWNER_MAX_DEADLINE_MS = 60_000;
 export const DB_OWNER_MAX_RESULT_BYTES = 1_048_576;
+export const DB_OWNER_MAX_TRANSACTION_STATEMENTS = 128;
 export type DbOwnerCancellation = "pending" | "requested" | "started";
 export type DbOwnerOutcome = "completed" | "cancelled" | "timed_out" | "failed" | "owner_died";
 
@@ -27,8 +28,13 @@ export interface DbOwnerStatement {
 	readonly transactional?: boolean;
 }
 
+export interface DbOwnerTransaction {
+	readonly statements: readonly DbOwnerStatement[];
+}
+
 export type DbOwnerRequest =
 	| { readonly kind: "query"; readonly statement: DbOwnerStatement }
+	| { readonly kind: "transaction"; readonly transaction: DbOwnerTransaction }
 	| { readonly kind: "sleep"; readonly durationMs: number };
 
 export interface DbOwnerJob {

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -4,6 +4,7 @@ import {
 	DB_OWNER_MAX_DEADLINE_MS,
 	DB_OWNER_MAX_QUEUE_DEPTH,
 	DB_OWNER_MAX_RESULT_BYTES,
+	DB_OWNER_MAX_TRANSACTION_STATEMENTS,
 	DB_OWNER_MAX_WORK_UNITS,
 	serializeError,
 } from "./db-owner-protocol";
@@ -29,7 +30,13 @@ const require = createRequire(import.meta.url);
 const Database = (
 	typeof (globalThis as Record<string, unknown>).Bun !== "undefined"
 		? require("bun:sqlite").Database
-		: require("better-sqlite3")
+		: (() => {
+				try {
+					return require("node:sqlite").DatabaseSync;
+				} catch {
+					return require("better-sqlite3");
+				}
+			})()
 ) as new (
 	path: string,
 	options?: Record<string, unknown>,
@@ -41,6 +48,36 @@ export function runDbOwnerWorker(): void {
 
 	const db = new Database(dbPath);
 	db.exec("PRAGMA busy_timeout = 5000");
+
+	const BUSY_RETRIES = 3;
+	const BUSY_BACKOFF_MS = 50;
+	const isBusyError = (error: unknown): boolean => {
+		const code = error !== null && typeof error === "object" && "code" in error ? error.code : undefined;
+		const message = error instanceof Error ? error.message : String(error);
+		return code === "SQLITE_BUSY" || message.includes("SQLITE_BUSY") || message.includes("database is locked");
+	};
+	const wait = (milliseconds: number): void => {
+		const signal = new Int32Array(new SharedArrayBuffer(4));
+		Atomics.wait(signal, 0, 0, milliseconds);
+	};
+	const withBusyRetry = <Result>(operation: () => Result): Result => {
+		for (let attempt = 0; ; attempt += 1) {
+			try {
+				db.exec("BEGIN IMMEDIATE");
+				const result = operation();
+				db.exec("COMMIT");
+				return result;
+			} catch (error) {
+				try {
+					db.exec("ROLLBACK");
+				} catch {
+					// Preserve the original SQLite error.
+				}
+				if (!isBusyError(error) || attempt >= BUSY_RETRIES) throw error;
+				wait(BUSY_BACKOFF_MS * 2 ** attempt);
+			}
+		}
+	};
 
 	const cancelled = new Set<string>();
 	const queue: DbOwnerJob[] = [];
@@ -90,24 +127,22 @@ export function runDbOwnerWorker(): void {
 		if (statement.result === "get") return enforceResultLimit(statement, prepared.get(...params));
 		if (statement.transactional === false) return enforceResultLimit(statement, prepared.run(...params));
 
-		db.exec("BEGIN IMMEDIATE");
-		try {
-			const result = prepared.run(...params);
-			const boundedResult = enforceResultLimit(statement, result);
-			db.exec("COMMIT");
-			return boundedResult;
-		} catch (error) {
-			try {
-				db.exec("ROLLBACK");
-			} catch {
-				// The original error is the actionable failure.
-			}
-			throw error;
+		return withBusyRetry(() => enforceResultLimit(statement, prepared.run(...params)));
+	}
+
+	function executeTransaction(statements: readonly DbOwnerStatement[]): readonly unknown[] {
+		if (statements.length === 0 || statements.length > DB_OWNER_MAX_TRANSACTION_STATEMENTS) {
+			throw new Error(`DB owner transaction must contain 1 to ${DB_OWNER_MAX_TRANSACTION_STATEMENTS} statements`);
 		}
+		return withBusyRetry(() => {
+			const results = statements.map((statement) => executeStatement({ ...statement, transactional: false }));
+			return enforceResultLimit({ sql: "DB_OWNER_TRANSACTION", result: "all" }, results) as readonly unknown[];
+		});
 	}
 
 	function execute(job: DbOwnerJob): unknown {
 		if (job.request.kind === "query") return executeStatement(job.request.statement);
+		if (job.request.kind === "transaction") return executeTransaction(job.request.transaction.statements);
 		const durationMs = Math.max(0, Math.floor(job.request.durationMs));
 		const wait = new Int32Array(new SharedArrayBuffer(4));
 		Atomics.wait(wait, 0, 0, durationMs);

--- a/platform/daemon/src/startup-recovery.test.ts
+++ b/platform/daemon/src/startup-recovery.test.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import type { DreamingConfig } from "@signet/core";
 import type { WriteDb } from "./db-accessor";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { createDbOwnerClient } from "./db-owner-client";
 import { startDreamingWorker } from "./pipeline/dreaming-worker";
 import { getStartupRecoveryCompletion, runStartupRecovery, runStartupRecoveryAsync } from "./startup-recovery";
 
@@ -115,6 +116,21 @@ describe("runStartupRecovery", () => {
 
 		expect(report.deadJobsPurged).toBe(2);
 		expect(countRows("memory_jobs")).toBe(2); // dead-recent + pending-1
+	});
+
+	it("routes startup cleanup through the DB owner without blocking the caller", async () => {
+		const old = new Date(Date.now() - 10 * 86_400_000).toISOString();
+		getDbAccessor().withWriteTx((db) => insertJob(db, "owner-dead-old", "dead", old));
+		const owner = createDbOwnerClient({ dbPath: join(agentsDir, "memory", "memories.db") });
+		try {
+			const report = await runStartupRecoveryAsync(getDbAccessor(), { owner });
+			expect(report.deadJobsPurged).toBe(1);
+			expect(owner.health().state).toBe("ready");
+			expect(owner.health().generation).toBe(1);
+			expect(countRows("memory_jobs")).toBe(0);
+		} finally {
+			await owner.close();
+		}
 	});
 
 	it("recovers every document lease during startup without touching other job types", async () => {

--- a/platform/daemon/src/startup-recovery.ts
+++ b/platform/daemon/src/startup-recovery.ts
@@ -8,6 +8,14 @@
 
 import type { DatabaseIntegrityStatus } from "./database-integrity";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
+import type { DbOwnerClient } from "./db-owner-client";
+import {
+	ownerChanges,
+	ownerQueryAll,
+	ownerQueryOne,
+	ownerRunStatement,
+	ownerTransaction,
+} from "./db-owner-maintenance";
 import { logger } from "./logger";
 import { recoverStaleLeases } from "./pipeline/stale-leases";
 
@@ -21,6 +29,21 @@ export interface StartupRecoveryReport {
 	readonly orphanedPassesSwept: number;
 	readonly acpDeliveriesReconciled: number;
 	readonly durationMs: number;
+}
+
+export interface StartupRecoveryOptions {
+	readonly owner?: DbOwnerClient;
+}
+
+export interface StartupRecoveryProgress {
+	readonly phase: "pending" | "draining" | "complete" | "failed";
+	readonly operation: string;
+	readonly processed: number;
+	readonly batches: number;
+	readonly deadlineKills: number;
+	readonly ownerState: string | null;
+	readonly ownerGeneration: number | null;
+	readonly updatedAt: string;
 }
 
 const DEAD_JOB_RETENTION_DAYS = 7;
@@ -38,6 +61,9 @@ const PENDING_INTEGRITY: DatabaseIntegrityStatus = {
 	rebuiltIndexes: [],
 	durationMs: 0,
 	repairGuidance: null,
+	ownerState: null,
+	ownerGeneration: null,
+	deadlineKills: 0,
 };
 
 let activeRecovery: Promise<StartupRecoveryReport> | null = null;
@@ -111,6 +137,232 @@ async function reconcileAcpDeliveriesAsync(accessor: DbAccessor, nowMs = Date.no
 	);
 }
 
+async function runOwnerStartupRecovery(owner: DbOwnerClient): Promise<StartupRecoveryReport> {
+	const startedAt = Date.now();
+	const recoveryStartedAt = new Date(Math.floor(startedAt / 1_000) * 1_000).toISOString();
+	logger.info("startup-recovery", "Running startup recovery through the DB owner");
+	const logProgress = (operation: string, processed: number): void => {
+		const health = owner.health();
+		logger.info("startup-recovery", "Owner startup recovery progress", {
+			operation,
+			processed,
+			ownerState: health.state,
+			ownerGeneration: health.generation,
+			deadlineKills: health.deadlineKills,
+		});
+	};
+
+	let documentLeasesRecovered = 0;
+	try {
+		const now = new Date().toISOString();
+		const results = await ownerTransaction(
+			owner,
+			"startup-recovery.document-leases",
+			[
+				ownerRunStatement(
+					`UPDATE memory_jobs
+					 SET status = 'dead', leased_at = NULL, failed_at = ?,
+					     error = COALESCE(error, ?), updated_at = ?
+					 WHERE status = 'leased' AND job_type = 'document_ingest'
+					   AND attempts >= max_attempts`,
+					[now, "lease expired before completion", now],
+				),
+				ownerRunStatement(
+					`UPDATE memory_jobs
+					 SET status = 'pending', leased_at = NULL, updated_at = ?
+					 WHERE status = 'leased' AND job_type = 'document_ingest'
+					   AND attempts < max_attempts`,
+					[now],
+				),
+				ownerRunStatement(
+					`UPDATE documents
+					 SET status = 'failed',
+					     error = COALESCE(error, ?), updated_at = ?
+					 WHERE id IN (
+					     SELECT DISTINCT document_id FROM memory_jobs
+					      WHERE job_type = 'document_ingest' AND status = 'dead'
+					        AND failed_at = ? AND document_id IS NOT NULL
+					 ) AND status != 'deleted'`,
+					["Document ingest lease expired before completion", now, now],
+				),
+			],
+			{ estimatedWorkUnits: 3 },
+		);
+		documentLeasesRecovered = ownerChanges(results[0]) + ownerChanges(results[1]);
+		if (documentLeasesRecovered > 0) {
+			logger.info("startup-recovery", "Recovered document ingest leases through the DB owner", {
+				count: documentLeasesRecovered,
+			});
+		}
+		logProgress("document-leases", documentLeasesRecovered);
+	} catch (error) {
+		logger.warn("startup-recovery", "Owner document lease recovery failed", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		logProgress("document-leases", documentLeasesRecovered);
+	}
+
+	const cutoff = new Date(startedAt - DEAD_JOB_RETENTION_DAYS * 86_400_000).toISOString();
+	let deadJobsPurged = 0;
+	try {
+		while (deadJobsPurged < JOB_MAX_TOTAL) {
+			const batch = await ownerQueryAll<{ id: string }>(
+				owner,
+				"startup-recovery.dead-jobs.select",
+				`SELECT id FROM memory_jobs WHERE status = 'dead' AND created_at < ? LIMIT ?`,
+				[cutoff, Math.min(BATCH_SIZE, JOB_MAX_TOTAL - deadJobsPurged)],
+				{ estimatedWorkUnits: BATCH_SIZE },
+			);
+			if (batch.length === 0) break;
+			const placeholders = batch.map(() => "?").join(",");
+			const results = await ownerTransaction(owner, "startup-recovery.dead-jobs.delete", [
+				ownerRunStatement(
+					`DELETE FROM memory_jobs WHERE id IN (${placeholders})`,
+					batch.map((item) => item.id),
+				),
+			]);
+			const removed = ownerChanges(results[0]);
+			deadJobsPurged += removed;
+			await yieldToEventLoop();
+			if (removed === 0) break;
+			if (batch.length < BATCH_SIZE) break;
+		}
+		logProgress("dead-jobs", deadJobsPurged);
+	} catch (error) {
+		logger.warn("startup-recovery", "Owner dead job purge failed", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		logProgress("dead-jobs", deadJobsPurged);
+	}
+
+	let stagingRowsCleaned = 0;
+	try {
+		const migrationTable = await ownerQueryOne<{ present: number }>(
+			owner,
+			"startup-recovery.embedding-migration-state",
+			"SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'embedding_index_state'",
+		);
+		const migration =
+			migrationTable === undefined
+				? undefined
+				: await ownerQueryOne<{ state: string }>(
+						owner,
+						"startup-recovery.embedding-migration-state",
+						"SELECT state FROM embedding_index_state WHERE id = 1",
+					);
+		const stagingTable = await ownerQueryOne<{ present: number }>(
+			owner,
+			"startup-recovery.staging-table",
+			"SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'embeddings_staging'",
+		);
+		if (stagingTable === undefined) {
+			logger.debug("startup-recovery", "Skipping staging cleanup, staging table is not present");
+		} else if (migration?.state === "building") {
+			logger.info("startup-recovery", "Skipping staging cleanup, embedding index migration is in progress");
+		} else {
+			while (stagingRowsCleaned < STAGING_MAX_TOTAL) {
+				const batch = await ownerQueryAll<{ id: string }>(
+					owner,
+					"startup-recovery.staging.select",
+					`SELECT s.id FROM embeddings_staging s
+					 WHERE EXISTS (SELECT 1 FROM embeddings e WHERE e.content_hash = s.content_hash)
+					 LIMIT ?`,
+					[Math.min(BATCH_SIZE, STAGING_MAX_TOTAL - stagingRowsCleaned)],
+					{ estimatedWorkUnits: BATCH_SIZE },
+				);
+				if (batch.length === 0) break;
+				const placeholders = batch.map(() => "?").join(",");
+				const results = await ownerTransaction(owner, "startup-recovery.staging.delete", [
+					ownerRunStatement(
+						`DELETE FROM embeddings_staging WHERE id IN (${placeholders})`,
+						batch.map((item) => item.id),
+					),
+				]);
+				const removed = ownerChanges(results[0]);
+				stagingRowsCleaned += removed;
+				await yieldToEventLoop();
+				if (removed === 0) break;
+				if (batch.length < BATCH_SIZE) break;
+			}
+		}
+		logProgress("staging", stagingRowsCleaned);
+	} catch (error) {
+		logger.warn("startup-recovery", "Owner staging cleanup failed", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		logProgress("staging", stagingRowsCleaned);
+	}
+
+	let orphanedPassesSwept = 0;
+	try {
+		const table = await ownerQueryOne<{ present: number }>(
+			owner,
+			"startup-recovery.dreaming-table",
+			"SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'dreaming_passes'",
+		);
+		if (table !== undefined) {
+			const results = await ownerTransaction(owner, "startup-recovery.orphaned-passes", [
+				ownerRunStatement(
+					`UPDATE dreaming_passes
+						 SET status = 'failed', completed_at = datetime('now'),
+						     error = 'Orphaned by daemon restart (startup recovery)'
+						 WHERE status = 'running' AND started_at IS NOT NULL
+						   AND julianday(started_at) < julianday(?)`,
+					[recoveryStartedAt],
+				),
+			]);
+			orphanedPassesSwept = ownerChanges(results[0]);
+		}
+		logProgress("orphaned-passes", orphanedPassesSwept);
+	} catch (error) {
+		logger.warn("startup-recovery", "Owner orphaned pass sweep failed", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		logProgress("orphaned-passes", orphanedPassesSwept);
+	}
+
+	let acpDeliveriesReconciled = 0;
+	try {
+		const now = new Date().toISOString();
+		const pendingCutoff = new Date(Date.now() - ACP_PENDING_GRACE_MS).toISOString();
+		const results = await ownerTransaction(owner, "startup-recovery.acp-deliveries", [
+			ownerRunStatement(
+				`UPDATE cross_agent_messages
+					 SET delivery_state = 'indeterminate', delivery_status = 'queued',
+					     delivery_error = CASE
+					       WHEN delivery_state = 'in_flight' THEN 'ACP relay interrupted; remote outcome is unknown'
+					       ELSE 'ACP relay was queued but never started'
+					     END,
+					     delivery_lease_token = NULL, delivery_lease_expires_at = NULL,
+					     delivery_updated_at = ?
+					 WHERE delivery_path = 'acp'
+					   AND ((delivery_state = 'in_flight' AND delivery_lease_expires_at <= ?)
+					     OR (delivery_state = 'pending' AND delivery_updated_at <= ?))`,
+				[now, now, pendingCutoff],
+			),
+		]);
+		acpDeliveriesReconciled = ownerChanges(results[0]);
+		logProgress("acp-deliveries", acpDeliveriesReconciled);
+	} catch (error) {
+		logger.warn("startup-recovery", "Owner ACP delivery reconciliation failed", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		logProgress("acp-deliveries", acpDeliveriesReconciled);
+	}
+
+	return {
+		recoveryPhase: "complete",
+		walCheckpointed: false,
+		databaseIntegrity: PENDING_INTEGRITY,
+		documentLeasesRecovered,
+		deadJobsPurged,
+		stagingRowsCleaned,
+		orphanedPassesSwept,
+		acpDeliveriesReconciled,
+		durationMs: Date.now() - startedAt,
+	};
+}
+
 function pendingReport(): StartupRecoveryReport {
 	return {
 		recoveryPhase: "draining",
@@ -130,9 +382,12 @@ function pendingReport(): StartupRecoveryReport {
  * Tests and explicit lifecycle callers can await this function. The daemon
  * uses runStartupRecovery() below so readiness never waits for the pass.
  */
-export function runStartupRecoveryAsync(accessor: DbAccessor): Promise<StartupRecoveryReport> {
+export function runStartupRecoveryAsync(
+	accessor: DbAccessor,
+	options: StartupRecoveryOptions = {},
+): Promise<StartupRecoveryReport> {
 	if (activeRecovery !== null) return activeRecovery;
-	const run = runStartupRecoveryInternal(accessor);
+	const run = runStartupRecoveryInternal(accessor, options.owner);
 	const trackedRun = run.then((report) => {
 		lastCompletedRecovery = report;
 		return report;
@@ -151,7 +406,8 @@ export function getStartupRecoveryCompletion(): Promise<StartupRecoveryReport> {
 	return Promise.resolve(lastCompletedRecovery ?? pendingReport());
 }
 
-async function runStartupRecoveryInternal(accessor: DbAccessor): Promise<StartupRecoveryReport> {
+async function runStartupRecoveryInternal(accessor: DbAccessor, owner?: DbOwnerClient): Promise<StartupRecoveryReport> {
+	if (owner !== undefined) return await runOwnerStartupRecovery(owner);
 	const startedAt = Date.now();
 	// Pass timestamps are persisted with millisecond precision, but older rows
 	// and direct writers may still use SQLite's second precision. Round the
@@ -337,10 +593,10 @@ async function runStartupRecoveryInternal(accessor: DbAccessor): Promise<Startup
  * called during daemon boot, before the HTTP server binds, so it must never
  * perform a database operation or await the backlog.
  */
-export function runStartupRecovery(accessor: DbAccessor): StartupRecoveryReport {
+export function runStartupRecovery(accessor: DbAccessor, options: StartupRecoveryOptions = {}): StartupRecoveryReport {
 	const report = pendingReport();
 	logger.info("startup-recovery", "Deferring startup recovery until the event loop can serve requests");
-	void runStartupRecoveryAsync(accessor)
+	void runStartupRecoveryAsync(accessor, options)
 		.then((completed) => Object.assign(report, completed))
 		.catch((err) => {
 			logger.warn("startup-recovery", "Asynchronous startup recovery failed", {


### PR DESCRIPTION
## Summary

Routes deferred startup recovery and database integrity maintenance through the Phase C DB owner. The pre-ready wrapper still returns immediately, while the owner handles bounded cleanup, quick checks, telemetry verification, audited REINDEX repair, crash retry, and deadline telemetry.

## Changes

- Added owner transaction requests with bounded statement counts, Node `node:sqlite` first selection with `better-sqlite3` fallback, busy timeout, and bounded busy retries.
- Routed startup lease recovery, dead-job/staging cleanup, orphaned-pass recovery, and ACP delivery reconciliation through idempotent owner maintenance helpers.
- Routed deferred `quick_check`, telemetry integrity checks, audit writes, REINDEX repair, and post-repair verification through the owner when available.
- Preserved hard owner deadlines and SIGKILL behavior, with visible owner generation and deadline-kill telemetry plus progress logs.
- Added regressions for owner routing, busy writers, deadline-kill recovery, Bun owner maintenance, Node owner-worker transactions, and the existing killable Node repair path.
- Part of #1543 Phase C. Generalizes the killable-child semantics from #1514 into the owner maintenance lane.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations are touched.

## Testing

- [x] `bun test platform/daemon/src/db-owner-client.test.ts platform/daemon/src/startup-recovery.test.ts platform/daemon/src/database-integrity.test.ts` passes: 35 tests, 0 failures.
- [x] `bun run --filter '@signet/daemon' typecheck` passes.
- [x] `bun run --filter '@signet/daemon' build` passes.
- [x] `bun scripts/audit-event-loop-contract.ts` passes: 730-site inventory, 246 transitional legacy DB sites.
- [x] `bun test scripts/audit-event-loop-contract.test.ts` passes: 13 tests, 0 failures.
- [x] Node 26 direct smoke against the built `db-owner-worker.js` completes an owner transaction and verifies the committed row with Bun SQLite.
- [ ] Tested against running daemon
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The full repository typecheck was also run. It remains blocked by pre-existing errors in connector-oh-my-pi, connector-gemini, connector-openclaw, connector-pi, connector-forge, connector-opencode, and connector-codex; the changed daemon package typecheck is green. Biome reports three pre-existing unused-symbol warnings in daemon.ts and no errors. This PR stops before review, comments, or merge as required.
