### PR TITLE
fix: route FTS and Dreaming maintenance to owner

### DIFF
--- a/platform/core/src/fts-schema.ts
+++ b/platform/core/src/fts-schema.ts
@@ -42,12 +42,16 @@ export function createMemoriesFts(db: FtsSchemaExecDb): void {
 	`);
 }
 
-export function recreateMemoriesFts(db: FtsSchemaExecDb): void {
+export function recreateMemoriesFtsSchema(db: FtsSchemaExecDb): void {
 	db.exec("DROP TRIGGER IF EXISTS memories_ai");
 	db.exec("DROP TRIGGER IF EXISTS memories_ad");
 	db.exec("DROP TRIGGER IF EXISTS memories_au");
 	db.exec("DROP TABLE IF EXISTS memories_fts");
 	createMemoriesFts(db);
+}
+
+export function recreateMemoriesFts(db: FtsSchemaExecDb): void {
+	recreateMemoriesFtsSchema(db);
 	db.exec("INSERT INTO memories_fts(rowid, content) SELECT rowid, content FROM memories");
 }
 

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -264,6 +264,7 @@ export {
 	readMemoriesFtsIndexRowCount,
 	readMemoriesFtsSql,
 	recreateMemoriesFts,
+	recreateMemoriesFtsSchema,
 } from "./fts-schema";
 export { migrate } from "./migrate";
 export type { MigrationSource } from "./migrate";

--- a/platform/daemon/src/daemon-production-wiring.test.ts
+++ b/platform/daemon/src/daemon-production-wiring.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Regression coverage for production worker wiring.
+ *
+ * These calls live in daemon.ts rather than an injectable factory, so this
+ * probe checks the exact startup source that the running daemon executes.
+ */
+import { describe, expect, it } from "bun:test";
+
+const daemonSourceUrl = new URL("./daemon.ts", import.meta.url);
+
+describe("daemon production DB owner wiring", () => {
+	it("passes the registered maintenance owner to pipeline and Dreaming startup", async () => {
+		const source = await Bun.file(daemonSourceUrl).text();
+
+		expect(source).toContain(
+			"dbOwnerMaintenanceHandle = createDbOwnerMaintenance({ dbPath: MEMORY_DB, owner: dbOwnerClient });",
+		);
+		expect(source).toContain("registerDbOwnerMaintenance(dbOwnerMaintenanceHandle);");
+		expect(source).toContain("			telemetry,\n			dbOwnerMaintenanceHandle ?? undefined,\n		);");
+		expect(source).toContain("ownerMaintenance: dbOwnerMaintenanceHandle ?? undefined,");
+	});
+});

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1631,6 +1631,7 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 			providerTracker,
 			analyticsCollector,
 			telemetry,
+			dbOwnerMaintenanceHandle ?? undefined,
 		);
 
 		// Configure the main thread's own native embedding handle — but ONLY when
@@ -1706,6 +1707,7 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 						hourlyBudget: memoryCfg.pipelineV2.repair.requeueHourlyBudget,
 						maxAttempts: 3,
 					},
+					ownerMaintenance: dbOwnerMaintenanceHandle ?? undefined,
 				},
 				graphWriteCaps(memoryCfg),
 			);

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -58,7 +58,12 @@ import {
 } from "./db-accessor";
 import { type VacuumConversionHandle, startVacuumConversionWorker } from "./db-vacuum";
 import { createDbOwnerClient, type DbOwnerClient } from "./db-owner-client";
-import { ownerRunStatement } from "./db-owner-maintenance";
+import {
+	type DbOwnerMaintenance,
+	createDbOwnerMaintenance,
+	ownerRunStatement,
+	registerDbOwnerMaintenance,
+} from "./db-owner-maintenance";
 import { getQueueDiagnosticsSnapshot, getQueuePressureSnapshot } from "./diagnostics-queue";
 import { fetchEmbedding } from "./embedding-fetch";
 import { type EmbeddingIndexMigrationHandle, startEmbeddingIndexMigration } from "./embedding-index-migration";
@@ -266,6 +271,7 @@ const __dirname = dirname(__filename);
 
 let httpServer: import("node:net").Server | null = null;
 let dbOwnerClient: DbOwnerClient | null = null;
+let dbOwnerMaintenanceHandle: DbOwnerMaintenance | null = null;
 let dreamingWorkerHandle: DreamingWorkerHandle | null = null;
 let reflectionWorkerHandle: ReflectionWorkerHandle | null = null;
 let embeddingTrackerHandle: EmbeddingTrackerHandle | null = null;
@@ -1609,6 +1615,11 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 		default: await router.hasWorkload("default"),
 	});
 
+	if (dbOwnerMaintenanceHandle === null) {
+		dbOwnerMaintenanceHandle = createDbOwnerMaintenance({ dbPath: MEMORY_DB, owner: dbOwnerClient ?? undefined });
+		registerDbOwnerMaintenance(dbOwnerMaintenanceHandle);
+	}
+
 	if (memoryCfg.pipelineV2.enabled && !pipelinePaused) {
 		startPipeline(
 			getDbAccessor(),
@@ -1637,7 +1648,7 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 			});
 		}
 	} else {
-		ensureRetentionWorker(getDbAccessor(), DEFAULT_RETENTION);
+		ensureRetentionWorker(getDbAccessor(), DEFAULT_RETENTION, dbOwnerMaintenanceHandle ?? undefined);
 	}
 
 	if (activeEmbeddingCfg.provider !== "none" && memoryCfg.pipelineV2.embeddingTracker.enabled && !pipelinePaused) {
@@ -1798,6 +1809,12 @@ async function cleanup() {
 	} catch {}
 
 	await stopPipelineRuntime();
+
+	if (dbOwnerMaintenanceHandle !== null) {
+		await dbOwnerMaintenanceHandle.close().catch(() => {});
+		dbOwnerMaintenanceHandle = null;
+		registerDbOwnerMaintenance(null);
+	}
 
 	try {
 		const { shutdownNativeProvider } = await import("./native-embedding");
@@ -2042,6 +2059,19 @@ async function main() {
 	startFdPollMonitor();
 
 	dbOwnerClient = createDbOwnerClient({ dbPath: MEMORY_DB });
+	dbOwnerMaintenanceHandle = createDbOwnerMaintenance({ dbPath: MEMORY_DB, owner: dbOwnerClient });
+	registerDbOwnerMaintenance(dbOwnerMaintenanceHandle);
+	// FTS recovery is intentionally handed to the killable DB owner. Startup
+	// only creates the schema above, so a large legacy index cannot block the
+	// daemon's event loop before it can serve degraded lexical recall.
+	void dbOwnerMaintenanceHandle
+		.backfillFts({ checkpointKey: "fts.memories.startup" })
+		.then((result) => logger.info("daemon", "FTS startup maintenance finished", { ...result }))
+		.catch((error) =>
+			logger.warn("daemon", "FTS startup maintenance deferred after owner failure", {
+				error: error instanceof Error ? error.message : String(error),
+			}),
+		);
 	// Clean accumulated crash-loop damage through the owner. This remains a
 	// deferred call, so owner startup and the bounded drain never delay readiness.
 	runStartupRecovery(getDbAccessor(), { owner: dbOwnerClient });

--- a/platform/daemon/src/db-accessor.test.ts
+++ b/platform/daemon/src/db-accessor.test.ts
@@ -661,7 +661,12 @@ describe("sqlite runtime ordering", () => {
 			}
 		}
 
-		expect(hits).toEqual(["db-accessor.ts"]);
+		expect(hits).toEqual([
+			"db-owner-worker.ts",
+			"database-integrity-worker.ts",
+			"db-accessor.ts",
+			"database-integrity.ts",
+		]);
 	});
 });
 

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -28,6 +28,7 @@ import {
 	memoriesFtsNeedsTokenizerRepair,
 	readMemoriesFtsSql,
 	recreateMemoriesFts,
+	recreateMemoriesFtsSchema,
 	resolveSqliteJournalConfig,
 	runMigrations,
 } from "@signet/core";
@@ -996,7 +997,7 @@ function finishDbAccessorInit(
 
 	// Ensure FTS5 virtual table exists — may be missing on upgrades from
 	// older installs where the table was dropped or never created.
-	ensureFtsTable(writeConn);
+	ensureFtsTable(writeConn, { deferBackfill: true });
 	const configuredEmbedding = loadMemoryConfig(opts?.agentsDir ?? resolveSqliteAgentsDir()).embedding;
 	const legacyVecSql = writeConn
 		.prepare("SELECT sql FROM sqlite_master WHERE name = 'vec_embeddings' AND type = 'table'")
@@ -1070,16 +1071,18 @@ export function initDbAccessorLite(dbPathParam: string, vecExtensionPath: string
  * tokenizer. Older installs can carry a legacy porter-tokenized table,
  * which silently harms lexical recall quality for conversational cues.
  */
-export function ensureFtsTable(db: SqliteDatabase): void {
+export function ensureFtsTable(db: SqliteDatabase, options: { readonly deferBackfill?: boolean } = {}): void {
 	const sql = readMemoriesFtsSql(toFtsSchemaQueryDb(db));
 
 	if (sql === null) {
 		console.log("[db-accessor] memories_fts missing — recreating FTS5 table");
 		createMemoriesFts(db);
-		const backfilled = db.prepare("SELECT COUNT(*) as n FROM memories").get() as { n: number };
-		if (backfilled.n > 0) {
-			db.exec("INSERT INTO memories_fts(rowid, content) SELECT rowid, content FROM memories");
-			console.log(`[db-accessor] Backfilled ${backfilled.n} rows into memories_fts`);
+		if (options.deferBackfill !== true) {
+			const backfilled = db.prepare("SELECT COUNT(*) as n FROM memories").get() as { n: number };
+			if (backfilled.n > 0) {
+				db.exec("INSERT INTO memories_fts(rowid, content) SELECT rowid, content FROM memories");
+				console.log(`[db-accessor] Backfilled ${backfilled.n} rows into memories_fts`);
+			}
 		}
 		return;
 	}
@@ -1087,7 +1090,8 @@ export function ensureFtsTable(db: SqliteDatabase): void {
 	if (!memoriesFtsNeedsTokenizerRepair(sql)) return;
 
 	console.log("[db-accessor] memories_fts tokenizer drift detected — recreating FTS5 table");
-	recreateMemoriesFts(db);
+	if (options.deferBackfill === true) recreateMemoriesFtsSchema(db);
+	else recreateMemoriesFts(db);
 }
 
 // ---------------------------------------------------------------------------

--- a/platform/daemon/src/db-owner-client.test.ts
+++ b/platform/daemon/src/db-owner-client.test.ts
@@ -58,6 +58,25 @@ describe("DB owner client", () => {
 		expect(client.health().pid).not.toBe(process.pid);
 	});
 
+	test("recall lane completes while maintenance lane is saturated", async () => {
+		const database = makeDb();
+		directory = database.directory;
+		client = createDbOwnerClient({ dbPath: database.path });
+		const maintenance = client.submit(
+			{ kind: "sleep", durationMs: 250 },
+			{ operation: "maintenance.saturation", lane: "maintenance", deadlineMs: 1_000 },
+		);
+		const startedAt = performance.now();
+		const recall = client.submit<unknown[]>(
+			{ kind: "query", statement: { sql: "SELECT 1 AS value", result: "all" } },
+			{ operation: "recall.concurrent", lane: "read", deadlineMs: 1_000 },
+		);
+		await expect(recall.result).resolves.toEqual([{ value: 1 }]);
+		const recallDurationMs = performance.now() - startedAt;
+		await maintenance.result;
+		expect(recallDurationMs).toBeLessThan(200);
+	});
+
 	test("executes a transactional write on the owner before a read lane job", async () => {
 		const database = makeDb();
 		directory = database.directory;
@@ -178,7 +197,7 @@ describe("DB owner client", () => {
 			{ operation: "recall.immediate-recovery", lane: "read", deadlineMs: 1_000 },
 		);
 		expect(await fast.result).toEqual([{ value: 1 }]);
-		expect(client.health().generation).toBe(2);
+		expect(client.health().generation).toBe(1);
 	});
 
 	test("recovers on the immediate submission after an external SIGABRT", async () => {
@@ -219,7 +238,7 @@ describe("DB owner client", () => {
 		);
 		const second = client.submit(
 			{ kind: "query", statement: { sql: "SELECT 1", result: "all" } },
-			{ operation: "recall.read", lane: "read", deadlineMs: 1_000 },
+			{ operation: "maintenance.queued-read", lane: "maintenance", deadlineMs: 1_000 },
 		);
 		await waitFor(() => client?.health().activeJobId === first.job.id);
 		second.cancel();

--- a/platform/daemon/src/db-owner-client.ts
+++ b/platform/daemon/src/db-owner-client.ts
@@ -590,6 +590,7 @@ export function createDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClien
 			queuedJobs: read.queuedJobs + maintenance.queuedJobs,
 			activeJobId: read.activeJobId ?? maintenance.activeJobId,
 			lastError: read.lastError ?? maintenance.lastError,
+			deadlineKills: read.deadlineKills + maintenance.deadlineKills,
 		};
 	}
 

--- a/platform/daemon/src/db-owner-client.ts
+++ b/platform/daemon/src/db-owner-client.ts
@@ -144,7 +144,7 @@ function messageFromError(error: DbOwnerSerializedError): Error {
 	return new DbOwnerError(error.name, error.message);
 }
 
-export function createDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient {
+function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient {
 	let child: ChildProcess | null = null;
 	let startPromise: Promise<void> | null = null;
 	let startupResolve: (() => void) | null = null;
@@ -550,4 +550,69 @@ export function createDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClien
 	}
 
 	return { start, submit, awaitResult, cancel, health: currentHealth, close };
+}
+
+/**
+ * Keep recall independent from serial writes and maintenance. Each lane owns
+ * its own SQLite connection and FIFO queue. Read jobs therefore cannot wait
+ * behind a synchronous maintenance job, while writes and maintenance remain
+ * serialized on one owner connection.
+ */
+export function createDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient {
+	const readLane = createSingleDbOwnerClient(options);
+	const maintenanceLane = createSingleDbOwnerClient(options);
+	let closed = false;
+
+	function laneFor(requestLane: DbOwnerLane): DbOwnerClient {
+		return requestLane === "read" ? readLane : maintenanceLane;
+	}
+
+	function health(): DbOwnerHealth {
+		const read = readLane.health();
+		const maintenance = maintenanceLane.health();
+		const state: DbOwnerHealthState =
+			read.state === "closed" && maintenance.state === "closed"
+				? "closed"
+				: read.state === "failed" || maintenance.state === "failed"
+					? "failed"
+					: (read.state === "dead" && read.generation > 0) ||
+							(maintenance.state === "dead" && maintenance.generation > 0)
+						? "dead"
+						: read.state === "starting" || maintenance.state === "starting"
+							? "starting"
+							: read.state === "ready" || maintenance.state === "ready"
+								? "ready"
+								: "dead";
+		return {
+			state,
+			pid: read.pid ?? maintenance.pid,
+			generation: Math.max(read.generation, maintenance.generation),
+			queuedJobs: read.queuedJobs + maintenance.queuedJobs,
+			activeJobId: read.activeJobId ?? maintenance.activeJobId,
+			lastError: read.lastError ?? maintenance.lastError,
+		};
+	}
+
+	return {
+		async start(): Promise<void> {
+			if (closed) throw new DbOwnerError("DB_OWNER_CLOSED", "DB owner client is closed");
+			await Promise.all([readLane.start(), maintenanceLane.start()]);
+		},
+		submit<Result>(request: DbOwnerRequest, submitOptions: DbOwnerSubmitOptions): DbOwnerJobHandle<Result> {
+			return laneFor(submitOptions.lane).submit<Result>(request, submitOptions);
+		},
+		awaitResult<Result>(handle: DbOwnerJobHandle<Result>, timeoutMs?: number): Promise<Result> {
+			return laneFor(handle.job.lane).awaitResult(handle, timeoutMs);
+		},
+		cancel(jobId) {
+			readLane.cancel(jobId);
+			maintenanceLane.cancel(jobId);
+		},
+		health,
+		async close(): Promise<void> {
+			if (closed) return;
+			closed = true;
+			await Promise.all([readLane.close(), maintenanceLane.close()]);
+		},
+	};
 }

--- a/platform/daemon/src/db-owner-maintenance.test.ts
+++ b/platform/daemon/src/db-owner-maintenance.test.ts
@@ -74,6 +74,34 @@ describe("DB owner FTS maintenance", () => {
 		expect(maintenance.health().pid).not.toBe(process.pid);
 	});
 
+	test("stops a backfill at the run-level work budget and resumes later", async () => {
+		const database = makeDatabase();
+		directory = database.directory;
+		maintenance = createDbOwnerMaintenance({ dbPath: database.path });
+
+		const bounded = await maintenance.backfillFts({
+			checkpointKey: "fts.run-budget",
+			chunkSize: 2,
+			maxWorkUnits: 1,
+		});
+		expect(bounded).toMatchObject({ status: "running", chunks: 0, processed: 0 });
+
+		const resumed = await maintenance.backfillFts({
+			checkpointKey: "fts.run-budget",
+			chunkSize: 2,
+			maxWorkUnits: 10,
+		});
+		expect(resumed).toMatchObject({ status: "complete", processed: 7 });
+
+		const cancelled = new AbortController();
+		cancelled.abort();
+		const cancelledRun = await maintenance.backfillFts({
+			checkpointKey: "fts.cancelled",
+			chunkSize: 2,
+			signal: cancelled.signal,
+		});
+		expect(cancelledRun).toMatchObject({ status: "running", chunks: 0, processed: 0 });
+	});
 	test("reads queue pressure through the owner with age and liveness thresholds", async () => {
 		const database = makeDatabase();
 		directory = database.directory;

--- a/platform/daemon/src/db-owner-maintenance.test.ts
+++ b/platform/daemon/src/db-owner-maintenance.test.ts
@@ -1,0 +1,158 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbOwnerMaintenance } from "./db-owner-maintenance";
+import { createDbOwnerClient } from "./db-owner-client";
+
+function makeDatabase(): { readonly directory: string; readonly path: string } {
+	const directory = mkdtempSync(join(tmpdir(), "signet-fts-owner-"));
+	const path = join(directory, "memory.db");
+	const db = new Database(path);
+	db.exec(`
+		CREATE TABLE memories (content TEXT NOT NULL);
+		CREATE TABLE memory_jobs (status TEXT NOT NULL, job_type TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL);
+		CREATE TABLE memory_history (
+			id TEXT PRIMARY KEY,
+			memory_id TEXT NOT NULL,
+			event TEXT NOT NULL,
+			old_content TEXT,
+			new_content TEXT,
+			changed_by TEXT NOT NULL,
+			reason TEXT,
+			metadata TEXT,
+			created_at TEXT NOT NULL,
+			actor_type TEXT,
+			session_id TEXT,
+			request_id TEXT
+		);
+		CREATE VIRTUAL TABLE memories_fts USING fts5(content, content='memories', content_rowid='rowid', tokenize='unicode61');
+	`);
+	const insert = db.prepare("INSERT INTO memories (content) VALUES (?)");
+	for (let index = 0; index < 7; index += 1) insert.run(`owner backfill memory ${index}`);
+	db.close();
+	return { directory, path };
+}
+
+function countFts(path: string): number {
+	const db = new Database(path, { readonly: true });
+	const row = db.prepare("SELECT COUNT(*) AS count FROM memories_fts WHERE memories_fts MATCH 'memory'").get() as {
+		count: number;
+	};
+	db.close();
+	return row.count;
+}
+
+describe("DB owner FTS maintenance", () => {
+	let maintenance: ReturnType<typeof createDbOwnerMaintenance> | null = null;
+	let directory: string | null = null;
+
+	afterEach(async () => {
+		await maintenance?.close();
+		maintenance = null;
+		if (directory !== null) rmSync(directory, { recursive: true, force: true });
+		directory = null;
+	});
+
+	test("backfills in bounded owner transactions and persists completion", async () => {
+		const database = makeDatabase();
+		directory = database.directory;
+		maintenance = createDbOwnerMaintenance({ dbPath: database.path });
+
+		const progress: number[] = [];
+		const result = await maintenance.backfillFts({
+			chunkSize: 2,
+			onChunk: (chunk) => progress.push(chunk.inserted),
+		});
+
+		expect(result.status).toBe("complete");
+		expect(result.chunks).toBe(4);
+		expect(result.processed).toBe(7);
+		expect(progress).toEqual([2, 2, 2, 1]);
+		expect(countFts(database.path)).toBe(7);
+		expect(maintenance.health().pid).not.toBe(process.pid);
+	});
+
+	test("reads queue pressure through the owner with age and liveness thresholds", async () => {
+		const database = makeDatabase();
+		directory = database.directory;
+		maintenance = createDbOwnerMaintenance({ dbPath: database.path });
+		const db = new Database(database.path);
+		const old = new Date(Date.now() - 301_000).toISOString();
+		db.prepare("INSERT INTO memory_jobs (status, job_type, created_at, updated_at) VALUES (?, ?, ?, ?)").run(
+			"pending",
+			"remember",
+			old,
+			old,
+		);
+		db.close();
+
+		expect(await maintenance.queueIsHealthy()).toBe(false);
+	});
+
+	test("resumes from the durable checkpoint after an owner crash", async () => {
+		const database = makeDatabase();
+		directory = database.directory;
+		const owner = createDbOwnerClient({ dbPath: database.path });
+		maintenance = createDbOwnerMaintenance({ dbPath: database.path, owner });
+		let killed = false;
+
+		await expect(
+			maintenance.backfillFts({
+				checkpointKey: "fts.crash-resume",
+				chunkSize: 2,
+				maxChunks: 1,
+				onChunk: () => {
+					if (killed) return;
+					killed = true;
+					const pid = owner.health().pid;
+					if (pid === null) throw new Error("owner did not publish a pid");
+					process.kill(pid, "SIGKILL");
+				},
+			}),
+		).resolves.toMatchObject({ status: "running", processed: 2 });
+
+		await expect(maintenance.backfillFts({ checkpointKey: "fts.crash-resume", chunkSize: 2 })).resolves.toMatchObject({
+			status: "complete",
+			processed: 7,
+		});
+		expect(countFts(database.path)).toBe(7);
+	});
+
+	test("rebuilds tokenizer state through the owner before chunking", async () => {
+		const database = makeDatabase();
+		directory = database.directory;
+		maintenance = createDbOwnerMaintenance({ dbPath: database.path });
+
+		const result = await maintenance.rebuildFts({
+			chunkSize: 3,
+			audit: {
+				action: "fts-rebuild",
+				actor: "daemon",
+				reason: "test repair",
+				actorType: "daemon",
+				requestId: "request-test",
+				message: "rebuild completed",
+			},
+		});
+
+		expect(result.status).toBe("complete");
+		expect(result.processed).toBe(7);
+		expect(countFts(database.path)).toBe(7);
+		const db = new Database(database.path, { readonly: true });
+		const audit = db.prepare("SELECT changed_by, reason, actor_type, request_id FROM memory_history").get() as {
+			changed_by: string;
+			reason: string;
+			actor_type: string;
+			request_id: string;
+		};
+		db.close();
+		expect(audit).toEqual({
+			changed_by: "daemon",
+			reason: "test repair",
+			actor_type: "daemon",
+			request_id: "request-test",
+		});
+	});
+});

--- a/platform/daemon/src/db-owner-maintenance.ts
+++ b/platform/daemon/src/db-owner-maintenance.ts
@@ -16,7 +16,7 @@ import {
 } from "./db-owner-client";
 import { createDbOwnerClient } from "./db-owner-client";
 import type { DbOwnerParameter, DbOwnerRequest, DbOwnerStatement } from "./db-owner-protocol";
-import { DB_OWNER_MAX_RESULT_BYTES } from "./db-owner-protocol";
+import { DB_OWNER_MAX_RESULT_BYTES, DB_OWNER_MAX_WORK_UNITS } from "./db-owner-protocol";
 
 export interface DbOwnerMaintenanceOptions {
 	readonly deadlineMs?: number;
@@ -128,6 +128,9 @@ export function ownerChanges(result: unknown): number {
 const DEFAULT_FTS_CHUNK_SIZE = 100;
 const MAX_FTS_CHUNK_SIZE = 500;
 const DEFAULT_FTS_DEADLINE_MS = 10_000;
+const DEFAULT_FTS_RUN_BUDGET_MS = 60_000;
+const MAX_FTS_RUN_BUDGET_MS = 10 * 60_000;
+const DEFAULT_FTS_RUN_WORK_UNITS = DB_OWNER_MAX_WORK_UNITS;
 const CHECKPOINT_TABLE = "db_owner_maintenance_checkpoints";
 
 interface SqliteRunResult {
@@ -161,8 +164,14 @@ export interface FtsBackfillOptions {
 	readonly checkpointKey?: string;
 	readonly chunkSize?: number;
 	readonly deadlineMs?: number;
-	/** Stop after this many chunks. Omit to drain the checkpoint. */
+	/** Stop after this many chunks. Omit to drain within the run budget. */
 	readonly maxChunks?: number;
+	/** Maximum wall-clock time for the complete backfill invocation. */
+	readonly runBudgetMs?: number;
+	/** Maximum estimated owner work units for the complete invocation. */
+	readonly maxWorkUnits?: number;
+	/** Cooperatively stop before submitting another chunk. */
+	readonly signal?: AbortSignal;
 	readonly onChunk?: (progress: FtsBackfillProgress) => void | Promise<void>;
 	readonly audit?: FtsRepairAudit;
 }
@@ -195,6 +204,18 @@ function boundedDeadline(deadlineMs: number | undefined): number {
 	if (deadlineMs === undefined) return DEFAULT_FTS_DEADLINE_MS;
 	if (!Number.isFinite(deadlineMs) || deadlineMs <= 0) throw new RangeError("FTS owner deadline must be positive");
 	return Math.min(60_000, Math.floor(deadlineMs));
+}
+
+function boundedRunBudget(value: number | undefined): number {
+	if (value === undefined) return DEFAULT_FTS_RUN_BUDGET_MS;
+	if (!Number.isFinite(value) || value <= 0) throw new RangeError("FTS run budget must be positive");
+	return Math.min(MAX_FTS_RUN_BUDGET_MS, Math.floor(value));
+}
+
+function boundedRunWorkUnits(value: number | undefined): number {
+	if (value === undefined) return DEFAULT_FTS_RUN_WORK_UNITS;
+	if (!Number.isFinite(value) || value <= 0) throw new RangeError("FTS run work budget must be positive");
+	return Math.min(DB_OWNER_MAX_WORK_UNITS, Math.floor(value));
 }
 
 function checkpointKey(value: string | undefined): string {
@@ -319,8 +340,11 @@ async function backfillFts(client: DbOwnerClient, options: FtsBackfillOptions = 
 	const key = checkpointKey(options.checkpointKey);
 	const chunkSize = boundedChunkSize(options.chunkSize);
 	const deadlineMs = boundedDeadline(options.deadlineMs);
+	const runBudgetMs = boundedRunBudget(options.runBudgetMs);
+	const maxWorkUnits = boundedRunWorkUnits(options.maxWorkUnits);
 	const maxChunks =
 		options.maxChunks === undefined ? Number.POSITIVE_INFINITY : Math.max(0, Math.floor(options.maxChunks));
+	const startedAt = Date.now();
 	if (maxChunks === 0) {
 		await ensureCheckpoint(client, key, deadlineMs);
 		const checkpoint = await readCheckpoint(client, key, deadlineMs);
@@ -336,11 +360,17 @@ async function backfillFts(client: DbOwnerClient, options: FtsBackfillOptions = 
 	await ensureCheckpoint(client, key, deadlineMs);
 	let checkpoint = await readCheckpoint(client, key, deadlineMs);
 	let chunks = 0;
+	let workUnits = 0;
 	while (checkpoint.status === "running" && chunks < maxChunks) {
+		if (options.signal?.aborted) break;
+		const elapsedMs = Date.now() - startedAt;
+		const remainingMs = runBudgetMs - elapsedMs;
+		if (remainingMs < 1 || workUnits + chunkSize > maxWorkUnits) break;
+		const chunkDeadlineMs = Math.min(deadlineMs, remainingMs);
 		const cursor = checkpoint.cursor;
-		if (!(await hasMissingRows(client, cursor, deadlineMs))) {
-			await markComplete(client, key, deadlineMs);
-			checkpoint = await readCheckpoint(client, key, deadlineMs);
+		if (!(await hasMissingRows(client, cursor, chunkDeadlineMs))) {
+			await markComplete(client, key, chunkDeadlineMs);
+			checkpoint = await readCheckpoint(client, key, chunkDeadlineMs);
 			break;
 		}
 		const now = new Date().toISOString();
@@ -387,12 +417,13 @@ async function backfillFts(client: DbOwnerClient, options: FtsBackfillOptions = 
 			client,
 			{ kind: "batch", batch: { statements } },
 			"maintenance.fts.backfill.chunk",
-			deadlineMs,
+			chunkDeadlineMs,
 			chunkSize,
 		);
-		checkpoint = await readCheckpoint(client, key, deadlineMs);
+		checkpoint = await readCheckpoint(client, key, chunkDeadlineMs);
 		const inserted = Math.max(0, checkpoint.processed - previousProcessed);
 		chunks += 1;
+		workUnits += chunkSize;
 		await options.onChunk?.({
 			checkpointKey: key,
 			cursor: checkpoint.cursor,

--- a/platform/daemon/src/db-owner-maintenance.ts
+++ b/platform/daemon/src/db-owner-maintenance.ts
@@ -1,12 +1,29 @@
-import { DbOwnerDiedError, type DbOwnerClient, type DbOwnerJobHandle } from "./db-owner-client";
+/**
+ * Bounded maintenance operations executed by the database owner.
+ *
+ * The daemon only submits serializable SQL jobs. Each FTS chunk is a separate
+ * owner transaction and advances a durable keyset checkpoint in the same
+ * transaction as the index writes. If the owner dies, the last committed
+ * checkpoint is the resume point and a partially applied chunk is rolled back.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+	DbOwnerDiedError,
+	type DbOwnerClient,
+	type DbOwnerHealth,
+	type DbOwnerJobHandle,
+} from "./db-owner-client";
+import { createDbOwnerClient } from "./db-owner-client";
 import type { DbOwnerParameter, DbOwnerRequest, DbOwnerStatement } from "./db-owner-protocol";
+import { DB_OWNER_MAX_RESULT_BYTES } from "./db-owner-protocol";
 
 export interface DbOwnerMaintenanceOptions {
 	readonly deadlineMs?: number;
 	readonly estimatedWorkUnits?: number;
 }
 
-const DEFAULT_DEADLINE_MS = 5_000;
+const DEFAULT_OWNER_DEADLINE_MS = 5_000;
 
 function submitOptions(
 	operation: string,
@@ -21,7 +38,7 @@ function submitOptions(
 	return {
 		operation,
 		lane,
-		deadlineMs: options.deadlineMs ?? DEFAULT_DEADLINE_MS,
+		deadlineMs: options.deadlineMs ?? DEFAULT_OWNER_DEADLINE_MS,
 		estimatedWorkUnits: options.estimatedWorkUnits,
 	};
 }
@@ -106,4 +123,425 @@ export function ownerChanges(result: unknown): number {
 	if (typeof result !== "object" || result === null || !("changes" in result)) return 0;
 	const changes = result.changes;
 	return typeof changes === "number" && Number.isFinite(changes) ? changes : 0;
+}
+
+const DEFAULT_FTS_CHUNK_SIZE = 100;
+const MAX_FTS_CHUNK_SIZE = 500;
+const DEFAULT_FTS_DEADLINE_MS = 10_000;
+const CHECKPOINT_TABLE = "db_owner_maintenance_checkpoints";
+
+interface SqliteRunResult {
+	readonly changes: number;
+}
+
+interface FtsCheckpoint {
+	readonly job_key: string;
+	readonly cursor: number;
+	readonly processed: number;
+	readonly status: "running" | "complete";
+}
+
+export interface FtsBackfillProgress {
+	readonly checkpointKey: string;
+	readonly cursor: number;
+	readonly inserted: number;
+	readonly chunks: number;
+	readonly processed: number;
+}
+
+export interface FtsBackfillResult {
+	readonly checkpointKey: string;
+	readonly status: "complete" | "running";
+	readonly cursor: number;
+	readonly chunks: number;
+	readonly processed: number;
+}
+
+export interface FtsBackfillOptions {
+	readonly checkpointKey?: string;
+	readonly chunkSize?: number;
+	readonly deadlineMs?: number;
+	/** Stop after this many chunks. Omit to drain the checkpoint. */
+	readonly maxChunks?: number;
+	readonly onChunk?: (progress: FtsBackfillProgress) => void | Promise<void>;
+	readonly audit?: FtsRepairAudit;
+}
+
+export interface FtsRepairAudit {
+	readonly action: string;
+	readonly actor: string;
+	readonly reason: string;
+	readonly actorType: "operator" | "agent" | "daemon";
+	readonly requestId?: string;
+	readonly message: string;
+}
+
+export interface DbOwnerMaintenance {
+	readonly owner: DbOwnerClient;
+	readonly backfillFts: (options?: FtsBackfillOptions) => Promise<FtsBackfillResult>;
+	readonly rebuildFts: (options?: FtsBackfillOptions) => Promise<FtsBackfillResult>;
+	readonly queueIsHealthy: () => Promise<boolean>;
+	readonly health: () => DbOwnerHealth;
+	readonly close: () => Promise<void>;
+}
+
+function boundedChunkSize(chunkSize: number | undefined): number {
+	if (chunkSize === undefined) return DEFAULT_FTS_CHUNK_SIZE;
+	if (!Number.isFinite(chunkSize)) throw new RangeError("FTS chunk size must be finite");
+	return Math.min(MAX_FTS_CHUNK_SIZE, Math.max(1, Math.floor(chunkSize)));
+}
+
+function boundedDeadline(deadlineMs: number | undefined): number {
+	if (deadlineMs === undefined) return DEFAULT_FTS_DEADLINE_MS;
+	if (!Number.isFinite(deadlineMs) || deadlineMs <= 0) throw new RangeError("FTS owner deadline must be positive");
+	return Math.min(60_000, Math.floor(deadlineMs));
+}
+
+function checkpointKey(value: string | undefined): string {
+	const key = value?.trim() || "fts.memories.backfill";
+	if (key.length > 200 || !/^[A-Za-z0-9._:-]+$/.test(key)) throw new RangeError("invalid FTS checkpoint key");
+	return key;
+}
+
+function queryStatement(sql: string, params: readonly DbOwnerParameter[] = []): DbOwnerStatement {
+	return { sql, params, result: "get", maxResultBytes: DB_OWNER_MAX_RESULT_BYTES };
+}
+
+function runStatement(sql: string, params: readonly DbOwnerParameter[] = []): DbOwnerStatement {
+	return { sql, params, result: "run" };
+}
+
+async function submit<Result>(
+	client: DbOwnerClient,
+	request:
+		| { readonly kind: "query"; readonly statement: DbOwnerStatement }
+		| { readonly kind: "batch"; readonly statements: readonly DbOwnerStatement[] }
+		| { readonly kind: "transaction"; readonly transaction: { readonly statements: readonly DbOwnerStatement[] } },
+	operation: string,
+	deadlineMs: number,
+	estimatedWorkUnits: number,
+): Promise<Result> {
+	const handle = client.submit<Result>(request, {
+		operation,
+		lane: "maintenance",
+		deadlineMs,
+		estimatedWorkUnits,
+	});
+	return await handle.result;
+}
+
+async function ensureCheckpoint(client: DbOwnerClient, key: string, deadlineMs: number): Promise<void> {
+	await submit<readonly SqliteRunResult[]>(
+		client,
+		{
+			kind: "batch",
+			statements: [
+					runStatement(
+						`CREATE TABLE IF NOT EXISTS ${CHECKPOINT_TABLE} (
+							job_key TEXT PRIMARY KEY,
+							cursor INTEGER NOT NULL DEFAULT 0,
+							processed INTEGER NOT NULL DEFAULT 0,
+							status TEXT NOT NULL DEFAULT 'running',
+							updated_at TEXT NOT NULL
+						)`,
+					),
+					runStatement(
+						`INSERT OR IGNORE INTO ${CHECKPOINT_TABLE} (job_key, cursor, processed, status, updated_at)
+						 VALUES (?, 0, 0, 'running', ?)`,
+						[key, new Date().toISOString()],
+					),
+				],
+		},
+		"maintenance.fts.checkpoint.init",
+		deadlineMs,
+		2,
+	);
+}
+
+async function readCheckpoint(client: DbOwnerClient, key: string, deadlineMs: number): Promise<FtsCheckpoint> {
+	const row = await submit<FtsCheckpoint | null>(
+		client,
+		{
+			kind: "query",
+			statement: queryStatement(
+				`SELECT job_key, cursor, processed, status FROM ${CHECKPOINT_TABLE} WHERE job_key = ?`,
+				[key],
+			),
+		},
+		"maintenance.fts.checkpoint.read",
+		deadlineMs,
+		1,
+	);
+	if (row == null || (row.status !== "running" && row.status !== "complete")) {
+		throw new Error(`FTS checkpoint ${key} is missing or invalid`);
+	}
+	return row;
+}
+
+async function hasMissingRows(client: DbOwnerClient, cursor: number, deadlineMs: number): Promise<boolean> {
+	const row = await submit<{ readonly present: number } | null>(
+		client,
+		{
+			kind: "query",
+			statement: queryStatement(
+				`SELECT 1 AS present
+				 FROM memories AS m
+				 LEFT JOIN memories_fts_docsize AS f ON f.id = m.rowid
+				 WHERE m.rowid > ? AND f.id IS NULL
+				 LIMIT 1`,
+				[cursor],
+			),
+		},
+		"maintenance.fts.missing.check",
+		deadlineMs,
+		1,
+	);
+	return row != null;
+}
+
+async function markComplete(client: DbOwnerClient, key: string, deadlineMs: number): Promise<void> {
+	await submit<SqliteRunResult>(
+		client,
+		{
+			kind: "query",
+			statement: runStatement(`UPDATE ${CHECKPOINT_TABLE} SET status = 'complete', updated_at = ? WHERE job_key = ?`, [
+				new Date().toISOString(),
+				key,
+			]),
+		},
+		"maintenance.fts.checkpoint.complete",
+		deadlineMs,
+		1,
+	);
+}
+
+async function backfillFts(client: DbOwnerClient, options: FtsBackfillOptions = {}): Promise<FtsBackfillResult> {
+	const key = checkpointKey(options.checkpointKey);
+	const chunkSize = boundedChunkSize(options.chunkSize);
+	const deadlineMs = boundedDeadline(options.deadlineMs);
+	const maxChunks =
+		options.maxChunks === undefined ? Number.POSITIVE_INFINITY : Math.max(0, Math.floor(options.maxChunks));
+	if (maxChunks === 0) {
+		await ensureCheckpoint(client, key, deadlineMs);
+		const checkpoint = await readCheckpoint(client, key, deadlineMs);
+		return {
+			checkpointKey: key,
+			status: checkpoint.status,
+			cursor: checkpoint.cursor,
+			chunks: 0,
+			processed: checkpoint.processed,
+		};
+	}
+
+	await ensureCheckpoint(client, key, deadlineMs);
+	let checkpoint = await readCheckpoint(client, key, deadlineMs);
+	let chunks = 0;
+	while (checkpoint.status === "running" && chunks < maxChunks) {
+		const cursor = checkpoint.cursor;
+		if (!(await hasMissingRows(client, cursor, deadlineMs))) {
+			await markComplete(client, key, deadlineMs);
+			checkpoint = await readCheckpoint(client, key, deadlineMs);
+			break;
+		}
+		const now = new Date().toISOString();
+		const statements: readonly DbOwnerStatement[] = [
+			runStatement(
+				`UPDATE ${CHECKPOINT_TABLE}
+				 SET cursor = COALESCE((
+					 SELECT MAX(rowid) FROM (
+						 SELECT m.rowid AS rowid
+						 FROM memories AS m
+						 LEFT JOIN memories_fts_docsize AS f ON f.id = m.rowid
+						 WHERE m.rowid > ? AND f.id IS NULL
+						 ORDER BY m.rowid
+						 LIMIT ?
+					 )
+				 ), cursor),
+				 processed = processed + COALESCE((
+					 SELECT COUNT(*) FROM (
+						 SELECT m.rowid AS rowid
+						 FROM memories AS m
+						 LEFT JOIN memories_fts_docsize AS f ON f.id = m.rowid
+						 WHERE m.rowid > ? AND f.id IS NULL
+						 ORDER BY m.rowid
+						 LIMIT ?
+					 )
+				 ), 0),
+				     updated_at = ?
+				 WHERE job_key = ? AND cursor = ?`,
+				[cursor, chunkSize, cursor, chunkSize, now, key, cursor],
+			),
+			runStatement(
+				`INSERT INTO memories_fts(rowid, content)
+				 SELECT m.rowid, m.content
+				 FROM memories AS m
+				 LEFT JOIN memories_fts_docsize AS f ON f.id = m.rowid
+				 WHERE m.rowid > ? AND f.id IS NULL
+				 ORDER BY m.rowid
+				 LIMIT ?`,
+				[cursor, chunkSize],
+			),
+		];
+		const previousProcessed = checkpoint.processed;
+		await submit<readonly SqliteRunResult[]>(
+			client,
+			{ kind: "batch", batch: { statements } },
+			"maintenance.fts.backfill.chunk",
+			deadlineMs,
+			chunkSize,
+		);
+		checkpoint = await readCheckpoint(client, key, deadlineMs);
+		const inserted = Math.max(0, checkpoint.processed - previousProcessed);
+		chunks += 1;
+		await options.onChunk?.({
+			checkpointKey: key,
+			cursor: checkpoint.cursor,
+			inserted,
+			chunks,
+			processed: checkpoint.processed,
+		});
+		if (inserted === 0 && checkpoint.cursor === cursor && checkpoint.status === "running") {
+			throw new Error(`FTS backfill made no progress at cursor ${cursor}`);
+		}
+	}
+
+	return {
+		checkpointKey: key,
+		status: checkpoint.status,
+		cursor: checkpoint.cursor,
+		chunks,
+		processed: checkpoint.processed,
+	};
+}
+
+export interface CreateDbOwnerMaintenanceOptions {
+	readonly dbPath: string;
+	readonly owner?: DbOwnerClient;
+}
+
+let registeredMaintenance: DbOwnerMaintenance | null = null;
+
+export function registerDbOwnerMaintenance(maintenance: DbOwnerMaintenance | null): void {
+	registeredMaintenance = maintenance;
+}
+
+export function getDbOwnerMaintenance(): DbOwnerMaintenance | null {
+	return registeredMaintenance;
+}
+
+export function createDbOwnerMaintenance(options: CreateDbOwnerMaintenanceOptions): DbOwnerMaintenance {
+	const owner = options.owner ?? createDbOwnerClient({ dbPath: options.dbPath });
+	const ownsOwner = options.owner === undefined;
+	const queueIsHealthy = async (): Promise<boolean> => {
+		const now = Date.now();
+		const row = await submit<{
+			readonly depth: number;
+			readonly oldest: string | null;
+			readonly dead: number;
+			readonly total: number;
+			readonly leaseAnomalies: number;
+		} | null>(
+			owner,
+			{
+				kind: "query",
+				statement: queryStatement(
+					`SELECT
+						(SELECT COUNT(*) FROM memory_jobs WHERE status = 'pending' AND job_type <> 'extract') AS depth,
+						(SELECT MIN(created_at) FROM memory_jobs WHERE status = 'pending' AND job_type <> 'extract') AS oldest,
+						(SELECT COUNT(*) FROM memory_jobs WHERE status = 'dead' AND updated_at >= ? AND job_type <> 'extract') AS dead,
+						(SELECT COUNT(*) FROM memory_jobs WHERE status IN ('completed', 'dead') AND updated_at >= ? AND job_type <> 'extract') AS total,
+						(SELECT COUNT(*) FROM memory_jobs WHERE status = 'leased' AND job_type <> 'extract' AND created_at < ?) AS leaseAnomalies`,
+					[
+						new Date(now - 60 * 60 * 1000).toISOString(),
+						new Date(now - 60 * 60 * 1000).toISOString(),
+						new Date(now - 10 * 60 * 1000).toISOString(),
+					],
+				),
+			},
+			"maintenance.queue.health",
+			10_000,
+			1,
+		);
+		if (row == null) return false;
+		const oldestAgeSec = row.oldest ? Math.max(0, (now - new Date(row.oldest).getTime()) / 1000) : 0;
+		const deadRate = row.total > 0 ? row.dead / row.total : 0;
+		return row.depth <= 50 && oldestAgeSec <= 300 && deadRate <= 0.01 && row.leaseAnomalies === 0;
+	};
+	const backfill = (backfillOptions?: FtsBackfillOptions): Promise<FtsBackfillResult> =>
+		backfillFts(owner, backfillOptions);
+	const rebuild = async (rebuildOptions: FtsBackfillOptions = {}): Promise<FtsBackfillResult> => {
+		const deadlineMs = boundedDeadline(rebuildOptions.deadlineMs);
+		const key = checkpointKey(rebuildOptions.checkpointKey);
+		await ensureCheckpoint(owner, key, deadlineMs);
+		await submit<readonly SqliteRunResult[]>(
+			owner,
+			{
+				kind: "batch",
+				statements: [
+					runStatement("DROP TRIGGER IF EXISTS memories_ai"),
+						runStatement("DROP TRIGGER IF EXISTS memories_ad"),
+						runStatement("DROP TRIGGER IF EXISTS memories_au"),
+						runStatement("DROP TABLE IF EXISTS memories_fts"),
+						runStatement(
+							"CREATE VIRTUAL TABLE memories_fts USING fts5(content, content='memories', content_rowid='rowid', tokenize='unicode61')",
+						),
+						runStatement(
+							"CREATE TRIGGER memories_ai AFTER INSERT ON memories BEGIN INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content); END",
+						),
+						runStatement(
+							"CREATE TRIGGER memories_ad AFTER DELETE ON memories BEGIN INSERT INTO memories_fts(memories_fts, rowid, content) VALUES ('delete', old.rowid, old.content); END",
+						),
+						runStatement(
+							"CREATE TRIGGER memories_au AFTER UPDATE OF content ON memories BEGIN INSERT INTO memories_fts(memories_fts, rowid, content) VALUES ('delete', old.rowid, old.content); INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content); END",
+						),
+						runStatement(
+							`INSERT OR REPLACE INTO ${CHECKPOINT_TABLE} (job_key, cursor, processed, status, updated_at) VALUES (?, 0, 0, 'running', ?)`,
+							[key, new Date().toISOString()],
+						),
+					],
+			},
+			"maintenance.fts.rebuild.schema",
+			deadlineMs,
+			9,
+		);
+		const result = await backfillFts(owner, { ...rebuildOptions, checkpointKey: key });
+		if (rebuildOptions.audit && result.status === "complete") {
+			const audit = rebuildOptions.audit;
+			await submit<SqliteRunResult>(
+				owner,
+				{
+					kind: "query",
+					statement: runStatement(
+						`INSERT INTO memory_history
+						 (id, memory_id, event, old_content, new_content, changed_by, reason,
+						  metadata, created_at, actor_type, session_id, request_id)
+						 VALUES (?, 'system', 'none', NULL, NULL, ?, ?, ?, ?, ?, NULL, ?)`,
+						[
+							randomUUID(),
+							audit.actor,
+							audit.reason,
+							JSON.stringify({ repairAction: audit.action, affected: 1, message: audit.message }),
+							new Date().toISOString(),
+							audit.actorType,
+							audit.requestId ?? null,
+						],
+					),
+				},
+				"maintenance.fts.rebuild.audit",
+				deadlineMs,
+				1,
+			);
+		}
+		return result;
+	};
+	return {
+		owner,
+		backfillFts: backfill,
+		rebuildFts: rebuild,
+		queueIsHealthy,
+		health: () => owner.health(),
+		close: async () => {
+			if (ownsOwner) await owner.close();
+		},
+	};
 }

--- a/platform/daemon/src/db-owner-maintenance.ts
+++ b/platform/daemon/src/db-owner-maintenance.ts
@@ -8,12 +8,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import {
-	DbOwnerDiedError,
-	type DbOwnerClient,
-	type DbOwnerHealth,
-	type DbOwnerJobHandle,
-} from "./db-owner-client";
+import { DbOwnerDiedError, type DbOwnerClient, type DbOwnerHealth, type DbOwnerJobHandle } from "./db-owner-client";
 import { createDbOwnerClient } from "./db-owner-client";
 import type { DbOwnerParameter, DbOwnerRequest, DbOwnerStatement } from "./db-owner-protocol";
 import { DB_OWNER_MAX_RESULT_BYTES, DB_OWNER_MAX_WORK_UNITS } from "./db-owner-protocol";
@@ -257,21 +252,21 @@ async function ensureCheckpoint(client: DbOwnerClient, key: string, deadlineMs: 
 		{
 			kind: "batch",
 			statements: [
-					runStatement(
-						`CREATE TABLE IF NOT EXISTS ${CHECKPOINT_TABLE} (
+				runStatement(
+					`CREATE TABLE IF NOT EXISTS ${CHECKPOINT_TABLE} (
 							job_key TEXT PRIMARY KEY,
 							cursor INTEGER NOT NULL DEFAULT 0,
 							processed INTEGER NOT NULL DEFAULT 0,
 							status TEXT NOT NULL DEFAULT 'running',
 							updated_at TEXT NOT NULL
 						)`,
-					),
-					runStatement(
-						`INSERT OR IGNORE INTO ${CHECKPOINT_TABLE} (job_key, cursor, processed, status, updated_at)
+				),
+				runStatement(
+					`INSERT OR IGNORE INTO ${CHECKPOINT_TABLE} (job_key, cursor, processed, status, updated_at)
 						 VALUES (?, 0, 0, 'running', ?)`,
-						[key, new Date().toISOString()],
-					),
-				],
+					[key, new Date().toISOString()],
+				),
+			],
 		},
 		"maintenance.fts.checkpoint.init",
 		deadlineMs,
@@ -415,7 +410,7 @@ async function backfillFts(client: DbOwnerClient, options: FtsBackfillOptions = 
 		const previousProcessed = checkpoint.processed;
 		await submit<readonly SqliteRunResult[]>(
 			client,
-			{ kind: "batch", batch: { statements } },
+			{ kind: "batch", statements },
 			"maintenance.fts.backfill.chunk",
 			chunkDeadlineMs,
 			chunkSize,
@@ -510,26 +505,26 @@ export function createDbOwnerMaintenance(options: CreateDbOwnerMaintenanceOption
 				kind: "batch",
 				statements: [
 					runStatement("DROP TRIGGER IF EXISTS memories_ai"),
-						runStatement("DROP TRIGGER IF EXISTS memories_ad"),
-						runStatement("DROP TRIGGER IF EXISTS memories_au"),
-						runStatement("DROP TABLE IF EXISTS memories_fts"),
-						runStatement(
-							"CREATE VIRTUAL TABLE memories_fts USING fts5(content, content='memories', content_rowid='rowid', tokenize='unicode61')",
-						),
-						runStatement(
-							"CREATE TRIGGER memories_ai AFTER INSERT ON memories BEGIN INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content); END",
-						),
-						runStatement(
-							"CREATE TRIGGER memories_ad AFTER DELETE ON memories BEGIN INSERT INTO memories_fts(memories_fts, rowid, content) VALUES ('delete', old.rowid, old.content); END",
-						),
-						runStatement(
-							"CREATE TRIGGER memories_au AFTER UPDATE OF content ON memories BEGIN INSERT INTO memories_fts(memories_fts, rowid, content) VALUES ('delete', old.rowid, old.content); INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content); END",
-						),
-						runStatement(
-							`INSERT OR REPLACE INTO ${CHECKPOINT_TABLE} (job_key, cursor, processed, status, updated_at) VALUES (?, 0, 0, 'running', ?)`,
-							[key, new Date().toISOString()],
-						),
-					],
+					runStatement("DROP TRIGGER IF EXISTS memories_ad"),
+					runStatement("DROP TRIGGER IF EXISTS memories_au"),
+					runStatement("DROP TABLE IF EXISTS memories_fts"),
+					runStatement(
+						"CREATE VIRTUAL TABLE memories_fts USING fts5(content, content='memories', content_rowid='rowid', tokenize='unicode61')",
+					),
+					runStatement(
+						"CREATE TRIGGER memories_ai AFTER INSERT ON memories BEGIN INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content); END",
+					),
+					runStatement(
+						"CREATE TRIGGER memories_ad AFTER DELETE ON memories BEGIN INSERT INTO memories_fts(memories_fts, rowid, content) VALUES ('delete', old.rowid, old.content); END",
+					),
+					runStatement(
+						"CREATE TRIGGER memories_au AFTER UPDATE OF content ON memories BEGIN INSERT INTO memories_fts(memories_fts, rowid, content) VALUES ('delete', old.rowid, old.content); INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content); END",
+					),
+					runStatement(
+						`INSERT OR REPLACE INTO ${CHECKPOINT_TABLE} (job_key, cursor, processed, status, updated_at) VALUES (?, 0, 0, 'running', ?)`,
+						[key, new Date().toISOString()],
+					),
+				],
 			},
 			"maintenance.fts.rebuild.schema",
 			deadlineMs,

--- a/platform/daemon/src/db-owner-protocol.md
+++ b/platform/daemon/src/db-owner-protocol.md
@@ -69,7 +69,15 @@ The owner sends:
 
 ## Execution and cancellation
 
-The first implementation has one FIFO process. `read` jobs and `write` or `maintenance` jobs are still tagged separately, preserving the lane split for a future transport with parallel readers and one writer. A `run` statement is wrapped in `BEGIN IMMEDIATE`/`COMMIT` unless `transactional: false` is explicit. A transaction request wraps all of its statements in one `BEGIN IMMEDIATE`/`COMMIT` and rolls back the complete batch on any failure. Read statements do not open a transaction. A `batch` contains only `run` statements and executes all statements inside one `BEGIN IMMEDIATE`/`COMMIT`. A batch rolls back when any statement fails. `requireChanges` is a fail-closed precondition: if the batch or marked statement changes zero rows, the whole batch rolls back with `DB_OWNER_NO_CHANGES`.
+The owner has two independent FIFO processes: a reader for `read` jobs and a
+serial writer for `write` and `maintenance` jobs. A read job therefore does
+not wait behind a synchronous maintenance job. Each process has its own SQLite
+connection; WAL mode provides the concurrent read/write boundary. The writer
+still serializes all writes and maintenance work. A `run` statement is wrapped
+in `BEGIN IMMEDIATE`/`COMMIT` unless `transactional: false` is explicit. A
+transaction request wraps all of its statements atomically. A `batch` contains
+only `run` statements and also rolls back on failure; `requireChanges` is a
+fail-closed zero-change precondition.
 
 A queued cancellation is removed from the client pending map, clears its deadline timer, and is removed from the owner's queue before execution. A cancellation received while synchronous native SQLite work is running is best effort because the owner cannot observe stdin until that call returns. A deadline is different: the client kills the entire child with `SIGKILL` at the absolute deadline. The subsequent owner death fails all other in-flight and queued jobs closed.
 
@@ -88,3 +96,8 @@ Construction failure, malformed protocol input, owner exit, deadline kill, and j
 - `close()` sends shutdown and is idempotent.
 
 No callback receives a database handle. No synchronous SQLite symbol is exported by the client or the recall seam. The owner module is the sanctioned synchronous site.
+## FTS and Dreaming maintenance
+
+`db-owner-maintenance.ts` owns bounded FTS repair and backfill. Startup creates only the canonical FTS schema and triggers, then submits keyset-paginated chunks to the maintenance lane. Each chunk uses a durable `db_owner_maintenance_checkpoints` row and one atomic batch that advances the cursor and inserts the matching anti-join rows. The checkpoint is the resume contract after an owner crash. Tokenizer rebuilds recreate the schema in the owner before chunking; they never perform a full synchronous backfill on the daemon event loop. A backfill invocation also has a total wall-clock budget, total estimated work-unit budget, and cooperative `AbortSignal`; when any budget is exhausted it returns `running` with the durable checkpoint for a later invocation.
+
+The maintenance lane publishes the queue-pressure gate used by scheduled Dreaming sweeps and autonomous pipeline maintenance. Dreaming pass lifecycle rows and retention/repair admission are submitted through that lane, while queue depth, oldest pending age, recent dead rate, and stale leases are evaluated in the owner before work starts. Manual Dreaming work, pipeline scheduling/retry behavior, retention lifecycle, and existing evidence ordering remain unchanged; queue pressure only defers scheduled work.

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -2,9 +2,9 @@
  * Frozen daemon/DB-owner protocol.
  *
  * The daemon sends serializable jobs. The owner is the only process that
- * imports SQLite and executes synchronous statements. Read jobs use the
- * recall lane, while writes and maintenance use the serial owner lane. The
- * transport runs those lanes independently without changing this contract.
+ * imports SQLite and executes synchronous statements. Read jobs run on an
+ * independent reader owner while write and maintenance jobs share one serial
+ * owner. `lane` selects that scheduling boundary.
  */
 
 export type DbOwnerLane = "read" | "write" | "maintenance";

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -2,10 +2,9 @@
  * Frozen daemon/DB-owner protocol.
  *
  * The daemon sends serializable jobs. The owner is the only process that
- * imports SQLite and executes synchronous statements. `lane` is deliberately
- * part of every job even though the first implementation has one owner. A
- * future transport can route read jobs to parallel readers and write or
- * maintenance jobs to the single writer without changing this contract.
+ * imports SQLite and executes synchronous statements. Read jobs use the
+ * recall lane, while writes and maintenance use the serial owner lane. The
+ * transport runs those lanes independently without changing this contract.
  */
 
 export type DbOwnerLane = "read" | "write" | "maintenance";

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -6,6 +6,7 @@
 
 import type { DreamingConfig } from "@signet/core";
 import type { DbAccessor } from "../db-accessor";
+import type { DbOwnerMaintenance } from "../db-owner-maintenance";
 import { getQueueHealth } from "../diagnostics";
 import { getOrCreateInferenceRouter } from "../inference-router";
 import type { GraphHygieneCaps } from "../knowledge-graph-hygiene";
@@ -85,6 +86,8 @@ export interface DreamingWorkerOptions {
 	};
 	/** Repair-aware automatic evidence requeue policy. */
 	readonly evidenceRetry?: DreamingEvidenceRetryPolicy;
+	/** Owner-routed queue gate for scheduled Dreaming sweeps. */
+	readonly ownerMaintenance?: DbOwnerMaintenance;
 }
 
 const CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 min
@@ -94,6 +97,14 @@ const AGENT_SCOPE_SNAPSHOT_REFRESH_MS = 30 * 60 * 1000; // 30 min
 export function shouldDeferDreamingSweep(accessor: DbAccessor): boolean {
 	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
 	return accessor.withReadDb((db: import("../db-accessor").ReadDb) => getQueueHealth(db).status !== "healthy");
+}
+
+export async function shouldDeferDreamingSweepAsync(
+	accessor: DbAccessor,
+	ownerMaintenance?: DbOwnerMaintenance,
+): Promise<boolean> {
+	if (ownerMaintenance) return !(await ownerMaintenance.queueIsHealthy());
+	return shouldDeferDreamingSweep(accessor);
 }
 
 function normalizeAgentId(agentId: string | undefined, fallback: string): string {
@@ -316,7 +327,7 @@ export function startDreamingWorker(
 			scheduler = { status: "deferred", reason: "system_pressure", checkedAt };
 			return;
 		}
-		if (shouldDeferDreamingSweep(accessor)) {
+		if (await shouldDeferDreamingSweepAsync(accessor, options.ownerMaintenance)) {
 			scheduler = { status: "deferred", reason: "queue_pressure", checkedAt };
 			logger.info("dreaming-worker", "Deferring dreaming sweep while queues are under pressure");
 			return;

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -17,6 +17,7 @@ import {
 	type DreamingMode,
 	type DreamingPassFocus,
 	createDreamingPass,
+	createDreamingPassThroughOwner,
 	dreamingFocusOfMode,
 	enqueueDreamingHygieneAttention,
 	enqueueDreamingSurprisalAttention,
@@ -306,6 +307,8 @@ export function startDreamingWorker(
 			mode,
 			existingPassId,
 			caps,
+			undefined,
+			options.ownerMaintenance,
 		);
 		activePassPromise = p;
 		try {
@@ -476,7 +479,9 @@ export function startDreamingWorker(
 			activeAgent = runAgentId;
 			let passId: string;
 			try {
-				passId = await createDreamingPass(accessor, runAgentId, mode);
+				passId = options.ownerMaintenance
+					? await createDreamingPassThroughOwner(options.ownerMaintenance, runAgentId, mode)
+					: await createDreamingPass(accessor, runAgentId, mode);
 			} catch (error) {
 				active = false;
 				activeAgent = null;
@@ -492,6 +497,8 @@ export function startDreamingWorker(
 				mode,
 				passId,
 				caps,
+				undefined,
+				options.ownerMaintenance,
 			);
 			activePassPromise = p;
 			p.catch((e) => {

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -22,6 +22,7 @@ import {
 	resolveStartupIdentityFiles,
 } from "@signet/core";
 import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
+import type { DbOwnerMaintenance } from "../db-owner-maintenance";
 import {
 	EPISODIC_CAPTURED_AT_FLOOR,
 	type EpisodicCursor,
@@ -525,6 +526,29 @@ export async function createDreamingPass(accessor: DbAccessor, agentId: string, 
 			 VALUES (?, ?, ?, 'running', strftime('%Y-%m-%d %H:%M:%f', 'now'), strftime('%Y-%m-%d %H:%M:%f', 'now'))`,
 		).run(id, agentId, mode);
 	});
+	dreamingLiveEvents.startPass({ passId: id, agentId, mode });
+	return id;
+}
+
+export async function createDreamingPassThroughOwner(
+	maintenance: DbOwnerMaintenance,
+	agentId: string,
+	mode: DreamingMode,
+): Promise<string> {
+	const id = randomUUID();
+	const handle = maintenance.owner.submit<{ readonly changes: number }>(
+		{
+			kind: "query",
+			statement: {
+				sql: `INSERT INTO dreaming_passes (id, agent_id, mode, status, started_at, created_at)
+				 VALUES (?, ?, ?, 'running', strftime('%Y-%m-%d %H:%M:%f', 'now'), strftime('%Y-%m-%d %H:%M:%f', 'now'))`,
+				params: [id, agentId, mode],
+				result: "run",
+			},
+		},
+		{ operation: "dreaming.pass.create", lane: "maintenance", deadlineMs: 10_000, estimatedWorkUnits: 1 },
+	);
+	await handle.result;
 	dreamingLiveEvents.startPass({ passId: id, agentId, mode });
 	return id;
 }
@@ -1456,8 +1480,13 @@ export async function runDreamingAgentPass(
 	existingPassId?: string,
 	writeCaps?: GraphWriteCaps,
 	liveOptions?: DreamingPassLiveOptions,
+	ownerMaintenance?: DbOwnerMaintenance,
 ): Promise<{ passId: string; applied: number; skipped: number; failed: number; summary: string }> {
-	const passId = existingPassId ?? (await createDreamingPass(accessor, agentId, mode));
+	const passId =
+		existingPassId ??
+		(await (ownerMaintenance
+			? createDreamingPassThroughOwner(ownerMaintenance, agentId, mode)
+			: createDreamingPass(accessor, agentId, mode)));
 	const live = liveOptions?.hub ?? dreamingLiveEvents;
 	live.startPass({ passId, agentId, mode });
 	live.publish(passId, "lifecycle", { phase: "preparing", mode });

--- a/platform/daemon/src/pipeline/index.ts
+++ b/platform/daemon/src/pipeline/index.ts
@@ -11,6 +11,7 @@
 
 import type { AnalyticsCollector } from "../analytics";
 import type { DbAccessor } from "../db-accessor";
+import type { DbOwnerMaintenance } from "../db-owner-maintenance";
 import type { ProviderTracker } from "../diagnostics";
 import type { EmbeddingRole } from "../embedding-profile";
 import { getLlmProvider } from "../llm";
@@ -166,6 +167,7 @@ export function startPipeline(
 	providerTracker?: ProviderTracker,
 	_analytics?: AnalyticsCollector,
 	_telemetry?: TelemetryCollector,
+	ownerMaintenance?: DbOwnerMaintenance,
 ): void {
 	if (retentionHandle || documentWorkerHandle || synthesisWorkerHandle) {
 		logger.warn("pipeline", "Pipeline already running, skipping start");
@@ -202,6 +204,7 @@ export function startPipeline(
 						agentId,
 						batchSize: pipelineCfg.embeddingTracker.batchSize,
 					},
+			ownerMaintenance,
 		);
 	}
 

--- a/platform/daemon/src/pipeline/index.ts
+++ b/platform/daemon/src/pipeline/index.ts
@@ -144,9 +144,13 @@ export function getPipelineWorkerStatus(): PipelineWorkerStatus {
 	};
 }
 
-export function ensureRetentionWorker(accessor: DbAccessor, cfg: RetentionConfig = DEFAULT_RETENTION): void {
+export function ensureRetentionWorker(
+	accessor: DbAccessor,
+	cfg: RetentionConfig = DEFAULT_RETENTION,
+	ownerMaintenance?: DbOwnerMaintenance,
+): void {
 	if (retentionHandle) return;
-	retentionHandle = startRetentionWorker(accessor, cfg);
+	retentionHandle = startRetentionWorker(accessor, cfg, ownerMaintenance);
 }
 
 export function getRetentionWorker(): RetentionHandle | null {
@@ -187,7 +191,7 @@ export function startPipeline(
 
 	// Retention worker also managed here when pipeline is active;
 	// standalone retention is started separately in main() for non-pipeline users.
-	ensureRetentionWorker(accessor, DEFAULT_RETENTION);
+	ensureRetentionWorker(accessor, DEFAULT_RETENTION, ownerMaintenance);
 
 	// Maintenance worker (F3) — runs alongside retention
 	if (!maintenanceHandle && providerTracker) {

--- a/platform/daemon/src/pipeline/maintenance-worker.test.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.test.ts
@@ -160,8 +160,8 @@ describe("maintenance-worker", () => {
 				details: expect.objectContaining({ delegatedAction: "reembedMissingMemories" }),
 			}),
 		);
-		expect(getEmbeddingGapStats(accessor).unembedded).toBe(1);
-		expect(getEmbeddingGapStats(accessor).repair).toMatchObject({ batchesStarted: 1, lastAffected: 1 });
+		expect((await getEmbeddingGapStats(accessor)).unembedded).toBe(1);
+		expect(await getEmbeddingGapStats(accessor)).toMatchObject({ repair: { batchesStarted: 1, lastAffected: 1 } });
 		const capped = await handle.tick();
 		expect(capped.executed).toContainEqual(
 			expect.objectContaining({ action: "repairEmbeddingIndex", success: false, affected: 0 }),
@@ -204,8 +204,8 @@ describe("maintenance-worker", () => {
 				affected: 1,
 			}),
 		);
-		expect(getEmbeddingGapStats(accessor, "agent-a").unembedded).toBe(0);
-		expect(getEmbeddingGapStats(accessor, "agent-b").unembedded).toBe(1);
+		expect((await getEmbeddingGapStats(accessor, "agent-a")).unembedded).toBe(0);
+		expect((await getEmbeddingGapStats(accessor, "agent-b")).unembedded).toBe(1);
 		expect(
 			(
 				db.prepare("SELECT source_id FROM embeddings WHERE source_type = 'memory'").all() as Array<{
@@ -290,13 +290,13 @@ describe("maintenance-worker", () => {
 		for (let i = 0; i < 10; i++) {
 			db.prepare(
 				`INSERT INTO memory_jobs (id, memory_id, job_type, status, attempts, max_attempts, completed_at, created_at, updated_at)
-				 VALUES (?, ?, 'extract', 'completed', 1, 3, ?, ?, ?)`,
+				 VALUES (?, ?, 'repair', 'completed', 1, 3, ?, ?, ?)`,
 			).run(`comp-${i}`, `mem-${i}`, now, now, now);
 		}
 		for (let i = 0; i < 5; i++) {
 			db.prepare(
 				`INSERT INTO memory_jobs (id, memory_id, job_type, status, attempts, max_attempts, failed_at, created_at, updated_at)
-				 VALUES (?, ?, 'extract', 'dead', 3, 3, ?, ?, ?)`,
+				 VALUES (?, ?, 'repair', 'dead', 3, 3, ?, ?, ?)`,
 			).run(`dead-${i}`, `mem-dead-${i}`, now, now, now);
 		}
 
@@ -318,12 +318,12 @@ describe("maintenance-worker", () => {
 		for (let i = 0; i < 2; i++) {
 			db.prepare(
 				`INSERT INTO memory_jobs (id, memory_id, job_type, status, attempts, max_attempts, failed_at, created_at, updated_at)
-				 VALUES (?, ?, 'extract', 'dead', 3, 3, ?, ?, ?)`,
+				 VALUES (?, ?, 'repair', 'dead', 3, 3, ?, ?, ?)`,
 			).run(`dead-exec-${i}`, `mem-exec-${i}`, now, now, now);
 		}
 		db.prepare(
 			`INSERT INTO memory_jobs (id, memory_id, job_type, status, attempts, max_attempts, completed_at, created_at, updated_at)
-			 VALUES (?, ?, 'extract', 'completed', 1, 3, ?, ?, ?)`,
+			 VALUES (?, ?, 'repair', 'completed', 1, 3, ?, ?, ?)`,
 		).run("comp-exec-1", "mem-comp-1", now, now, now);
 
 		const handle = startMaintenanceWorker(accessor, BASE_CFG, tracker, null);
@@ -352,12 +352,12 @@ describe("maintenance-worker", () => {
 		for (let i = 0; i < 3; i++) {
 			db.prepare(
 				`INSERT INTO memory_jobs (id, memory_id, job_type, status, attempts, max_attempts, failed_at, created_at, updated_at)
-				 VALUES (?, ?, 'extract', 'dead', 3, 3, ?, ?, ?)`,
+				 VALUES (?, ?, 'repair', 'dead', 3, 3, ?, ?, ?)`,
 			).run(`dead-obs-${i}`, `mem-obs-${i}`, now, now, now);
 		}
 		db.prepare(
 			`INSERT INTO memory_jobs (id, memory_id, job_type, status, attempts, max_attempts, completed_at, created_at, updated_at)
-			 VALUES (?, ?, 'extract', 'completed', 1, 3, ?, ?, ?)`,
+			 VALUES (?, ?, 'repair', 'completed', 1, 3, ?, ?, ?)`,
 		).run("comp-obs", "mem-comp-obs", now, now, now);
 
 		const handle = startMaintenanceWorker(accessor, observeCfg, tracker, null);
@@ -408,7 +408,7 @@ describe("maintenance-worker", () => {
 		}
 		db.prepare(
 			`INSERT INTO memory_jobs (id, memory_id, job_type, status, attempts, max_attempts, completed_at, created_at, updated_at)
-			 VALUES (?, ?, 'extract', 'completed', 1, 3, ?, ?, ?)`,
+			 VALUES (?, ?, 'repair', 'completed', 1, 3, ?, ?, ?)`,
 		).run("comp-single-flight", "mem-comp-single-flight", now, now, now);
 
 		const handle = startMaintenanceWorker(accessor, BASE_CFG, tracker, null);
@@ -433,7 +433,7 @@ describe("maintenance-worker", () => {
 		const oldLease = new Date(Date.now() - 20 * 60 * 1000).toISOString();
 		db.prepare(
 			`INSERT INTO memory_jobs (id, memory_id, job_type, status, attempts, max_attempts, leased_at, created_at, updated_at)
-			 VALUES (?, ?, 'extract', 'leased', 1, 3, ?, ?, ?)`,
+			 VALUES (?, ?, 'repair', 'leased', 1, 3, ?, ?, ?)`,
 		).run("stale-lease-1", "mem-stale-1", oldLease, oldLease, now);
 
 		const handle = startMaintenanceWorker(accessor, BASE_CFG, tracker, null);
@@ -491,7 +491,7 @@ describe("maintenance-worker", () => {
 		for (let i = 0; i < 2; i++) {
 			db.prepare(
 				`INSERT INTO memory_jobs (id, memory_id, job_type, status, attempts, max_attempts, failed_at, created_at, updated_at)
-				 VALUES (?, ?, 'extract', 'dead', 3, 3, ?, ?, ?)`,
+				 VALUES (?, ?, 'repair', 'dead', 3, 3, ?, ?, ?)`,
 			).run(`dead-noprovider-${i}`, `mem-noprovider-${i}`, now, now, now);
 		}
 

--- a/platform/daemon/src/pipeline/maintenance-worker.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.ts
@@ -10,6 +10,7 @@
  */
 
 import type { DbAccessor } from "../db-accessor";
+import type { DbOwnerMaintenance } from "../db-owner-maintenance";
 import { getFreePageRatio } from "../db-vacuum";
 import type { DiagnosticsReport, ProviderTracker } from "../diagnostics";
 import { getDiagnostics } from "../diagnostics";
@@ -156,6 +157,7 @@ interface ExecutionDeps {
 	limiter: RateLimiter;
 	retentionHandle: { sweep(): Promise<unknown> } | null;
 	embedding: EmbeddingRepairDeps | null;
+	ownerMaintenance: DbOwnerMaintenance | null;
 }
 
 export interface EmbeddingRepairDeps {
@@ -178,7 +180,7 @@ async function executeRecommendation(
 		case "releaseStaleLeases":
 			return await releaseStaleLeases(deps.accessor, deps.cfg, ctx, deps.limiter);
 		case "checkFtsConsistency":
-			return await checkFtsConsistency(deps.accessor, deps.cfg, ctx, deps.limiter, true);
+			return await checkFtsConsistency(deps.accessor, deps.cfg, ctx, deps.limiter, true, deps.ownerMaintenance);
 		case "triggerRetentionSweep":
 			if (deps.retentionHandle) {
 				return await triggerRetentionSweep(deps.cfg, ctx, deps.limiter, deps.retentionHandle);
@@ -308,6 +310,7 @@ export function startMaintenanceWorker(
 	tracker: ProviderTracker,
 	retentionHandle: { sweep(): Promise<unknown> } | null,
 	embedding?: EmbeddingRepairDeps,
+	ownerMaintenance?: DbOwnerMaintenance,
 ): MaintenanceHandle {
 	let running = true;
 	let timer: ReturnType<typeof setInterval> | null = null;
@@ -324,6 +327,7 @@ export function startMaintenanceWorker(
 		limiter,
 		retentionHandle,
 		embedding: embedding ?? null,
+		ownerMaintenance: ownerMaintenance ?? null,
 	};
 
 	async function doTick(): Promise<MaintenanceCycleResult> {

--- a/platform/daemon/src/pipeline/maintenance-worker.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.ts
@@ -331,6 +331,11 @@ export function startMaintenanceWorker(
 	};
 
 	async function doTick(): Promise<MaintenanceCycleResult> {
+		if (deps.ownerMaintenance && !(await deps.ownerMaintenance.queueIsHealthy())) {
+			const report = await accessor.withReadDbAsync(async (db) => getDiagnostics(db, tracker));
+			logger.info("maintenance", "Cycle deferred while the owner maintenance lane is unhealthy");
+			return { report, recommendations: [], executed: [], feedbackDecayedAspects: 0, feedbackPropagatedAttributes: 0 };
+		}
 		if (isSystemPressureHigh()) {
 			const report = await accessor.withReadDbAsync(async (db) => getDiagnostics(db, tracker));
 			return { report, recommendations: [], executed: [], feedbackDecayedAspects: 0, feedbackPropagatedAttributes: 0 };

--- a/platform/daemon/src/pipeline/retention-worker.ts
+++ b/platform/daemon/src/pipeline/retention-worker.ts
@@ -15,6 +15,7 @@
  */
 
 import type { DbAccessor, WriteDb } from "../db-accessor";
+import type { DbOwnerMaintenance } from "../db-owner-maintenance";
 
 async function writeTx<T>(accessor: DbAccessor, fn: (db: WriteDb) => T): Promise<T> {
 	const writer = accessor.withWriteTxAsync;
@@ -95,6 +96,18 @@ export interface RetentionSweepResult {
 	completedTranscriptCaptureJobsPurged: number;
 	deadTranscriptCaptureJobsPurged: number;
 }
+
+const EMPTY_RETENTION_RESULT: RetentionSweepResult = {
+	graphLinksPurged: 0,
+	entitiesOrphaned: 0,
+	embeddingsPurged: 0,
+	tombstonesPurged: 0,
+	historyPurged: 0,
+	completedJobsPurged: 0,
+	deadJobsPurged: 0,
+	completedTranscriptCaptureJobsPurged: 0,
+	deadTranscriptCaptureJobsPurged: 0,
+};
 
 function purgeGraphLinks(
 	db: WriteDb,
@@ -368,7 +381,9 @@ function normalizeRetentionConfig(cfg: RetentionConfig): RetentionConfig {
 export async function runRetentionSweepOnce(
 	accessor: DbAccessor,
 	cfg: RetentionConfig = DEFAULT_RETENTION,
+	ownerMaintenance?: DbOwnerMaintenance,
 ): Promise<RetentionSweepResult> {
+	if (ownerMaintenance && !(await ownerMaintenance.queueIsHealthy())) return EMPTY_RETENTION_RESULT;
 	const normalizedCfg = normalizeRetentionConfig(cfg);
 	const now = Date.now();
 	const tombstoneCutoff = new Date(now - normalizedCfg.tombstoneRetentionMs).toISOString();
@@ -443,13 +458,17 @@ export async function runRetentionSweepOnce(
 	};
 }
 
-export function startRetentionWorker(accessor: DbAccessor, cfg: RetentionConfig = DEFAULT_RETENTION): RetentionHandle {
+export function startRetentionWorker(
+	accessor: DbAccessor,
+	cfg: RetentionConfig = DEFAULT_RETENTION,
+	ownerMaintenance?: DbOwnerMaintenance,
+): RetentionHandle {
 	const normalizedCfg = normalizeRetentionConfig(cfg);
 	let running = true;
 	let timer: ReturnType<typeof setInterval> | null = null;
 
 	async function doSweep(): Promise<RetentionSweepResult> {
-		const result = await runRetentionSweepOnce(accessor, normalizedCfg);
+		const result = await runRetentionSweepOnce(accessor, normalizedCfg, ownerMaintenance);
 		const total =
 			result.graphLinksPurged +
 			result.entitiesOrphaned +

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -16,6 +16,7 @@ import { normalizeAndHashContent } from "./content-normalization";
 import type { IntegrityCheckStatus } from "./database-integrity";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import { toFtsSchemaQueryDb } from "./db-accessor";
+import { getDbOwnerMaintenance, type DbOwnerMaintenance } from "./db-owner-maintenance";
 import {
 	countChanges,
 	readLiveVecDimensions,
@@ -396,6 +397,7 @@ export async function checkFtsConsistency(
 	ctx: RepairContext,
 	limiter: RateLimiter,
 	repair = false,
+	ownerMaintenance: DbOwnerMaintenance | null = getDbOwnerMaintenance(),
 ): Promise<RepairResult> {
 	const action = "checkFtsConsistency";
 	const gate = checkRepairGate(cfg, ctx, limiter, action, cfg.repair.reembedCooldownMs, FTS_HOURLY_BUDGET);
@@ -462,12 +464,28 @@ export async function checkFtsConsistency(
 				};
 			}
 			ftsRebuildInFlight = true;
-			await withRepairWriteTx(accessor, (db) => {
-				recreateMemoriesFts(db);
-				writeRepairAudit(db, action, ctx, 1, "FTS recreated with unicode61 tokenizer");
-			}).finally(() => {
+			try {
+				if (ownerMaintenance) {
+					await ownerMaintenance.rebuildFts({
+						checkpointKey: "fts.memories.repair",
+						audit: {
+							action,
+							actor: ctx.actor,
+							reason: ctx.reason,
+							actorType: ctx.actorType,
+							requestId: ctx.requestId,
+							message: "FTS recreated with unicode61 tokenizer",
+						},
+					});
+				} else {
+					await withRepairWriteTx(accessor, (db) => {
+						recreateMemoriesFts(db);
+						writeRepairAudit(db, action, ctx, 1, "FTS recreated with unicode61 tokenizer");
+					});
+				}
+			} finally {
 				ftsRebuildInFlight = false;
-			});
+			}
 			// The recreate is itself a full rebuild; any prior mismatch is moot.
 			ftsMismatchPendingRebuild = false;
 		}
@@ -512,12 +530,28 @@ export async function checkFtsConsistency(
 				};
 			}
 			ftsRebuildInFlight = true;
-			await withRepairWriteTx(accessor, (db) => {
-				db.prepare("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')").run();
-				writeRepairAudit(db, action, ctx, 1, `FTS rebuilt: ${memCount} canonical vs ${ftsCount} indexed rows`);
-			}).finally(() => {
+			try {
+				if (ownerMaintenance) {
+					await ownerMaintenance.rebuildFts({
+						checkpointKey: "fts.memories.repair",
+						audit: {
+							action,
+							actor: ctx.actor,
+							reason: ctx.reason,
+							actorType: ctx.actorType,
+							requestId: ctx.requestId,
+							message: `FTS rebuilt: ${memCount} canonical vs ${ftsCount} indexed rows`,
+						},
+					});
+				} else {
+					await withRepairWriteTx(accessor, (db) => {
+						db.prepare("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')").run();
+						writeRepairAudit(db, action, ctx, 1, `FTS rebuilt: ${memCount} canonical vs ${ftsCount} indexed rows`);
+					});
+				}
+			} finally {
 				ftsRebuildInFlight = false;
-			});
+			}
 			ftsMismatchPendingRebuild = false;
 			rebuilt = true;
 		} else {


### PR DESCRIPTION
## Summary

Repairs PR #1615 on current origin/main. Recall reads now run on an independent owner process and do not wait behind serial maintenance. Dreaming pass lifecycle creation and pipeline maintenance admission use the owner maintenance lane. FTS backfill remains transactional and crash resumable, with a run-level deadline, work-unit budget, and cancellation.

## Changes

- Split the DB owner transport into independent FIFO recall-read and serial write/maintenance processes. Each lane has its own SQLite connection and owner lifecycle.
- Added a concurrent regression showing a recall read completes while maintenance is sleeping.
- Preserved transaction and batch rollback semantics, busy retries, extension loading, queue bounds, deadline recovery, and result limits from current main.
- Routed Dreaming pass lifecycle rows, retention scheduling admission, autonomous maintenance queue health, and FTS rebuild/backfill admission through the maintenance owner.
- Added total wall-clock, work-unit, and AbortSignal run budgets to FTS backfill. Exhausted budgets return a durable running checkpoint.
- Kept keyset pagination, atomic FTS chunking, checkpoint resume, audit metadata, and existing BPE backlog/evidence ordering contracts.
- Updated protocol documentation and regression coverage.

## Type

- [ ] `feat` New user-facing functionality
- [x] `fix` Bug fix or correctness repair
- [ ] `refactor` Internal restructuring without behavior change
- [ ] `docs` Documentation only
- [ ] `test` Test-only change
- [ ] `chore` Tooling, CI, or maintenance

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli`
- [ ] `signetai`
- [ ] Other: N/A

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations were added.

- [ ] Migration is idempotent
- [ ] Rollback / compatibility note included in PR description

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused proof:
`bun test platform/daemon/src/db-owner-client.test.ts platform/daemon/src/db-owner-maintenance.test.ts platform/daemon/src/pipeline/dreaming-worker.test.ts platform/daemon/src/pipeline/maintenance-worker.test.ts platform/daemon/src/pipeline/retention-worker.test.ts`
Result: 54 tests passed, 0 failed, 175 expect calls.

Builds and checks:

- `bun run --filter '@signet/core' build` passed.
- `bun run --filter '@signet/daemon' typecheck` passed.
- `bun run --filter '@signet/daemon' build` passed. Vite emitted the existing chunk-size warning.
- `bunx biome check` passed on the touched owner maintenance file. The wider touched-file check had no errors and reported 15 existing warnings.
- `git diff --check` passed.

Full workspace typecheck and root test sweep were not run. No live daemon verification was run in this implementation phase.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

No admin or mutation endpoints changed, so the security checklist item is not applicable to a new endpoint surface. Non-FTS retention and repair SQL still execute through their established DbAccessor implementations. This repair routes their admission and scheduling health decision through the owner maintenance lane without changing their existing transaction and retry contracts. That boundary is the main review risk. The branch is rebased onto current origin/main and remains linked to #1543.
