### PR TITLE
fix(daemon): order telemetry repair audit

### DIFF
--- a/platform/daemon/src/database-integrity.test.ts
+++ b/platform/daemon/src/database-integrity.test.ts
@@ -7,11 +7,16 @@ import { repairTelemetryIndexes, runDeferredIntegrityCheck } from "./database-in
 import { createDbOwnerClient } from "./db-owner-client";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 
-function fakeAccessor(options: { readonly quickMessage?: string; readonly telemetryMessage?: string }): {
+function fakeAccessor(options: {
+	readonly quickMessage?: string;
+	readonly telemetryMessage?: string;
+	readonly repairAfterFirstTelemetryCheck?: boolean;
+}): {
 	readonly accessor: DbAccessor;
 	readonly reindexed: string[];
 } {
 	let repaired = false;
+	let telemetryChecks = 0;
 	const reindexed: string[] = [];
 	const readDb: ReadDb = {
 		prepare(sql: string) {
@@ -25,7 +30,11 @@ function fakeAccessor(options: { readonly quickMessage?: string; readonly teleme
 				all<Row = unknown>(): Row[] {
 					if (sql === "PRAGMA quick_check") return [{ quick_check: options.quickMessage ?? "ok" }] as Row[];
 					if (sql === "PRAGMA integrity_check(telemetry_events)") {
-						return [{ integrity_check: repaired ? "ok" : (options.telemetryMessage ?? "ok") }] as Row[];
+						telemetryChecks += 1;
+						const externallyRepaired = options.repairAfterFirstTelemetryCheck === true && telemetryChecks > 1;
+						return [
+							{ integrity_check: repaired || externallyRepaired ? "ok" : (options.telemetryMessage ?? "ok") },
+						] as Row[];
 					}
 					if (
 						sql ===
@@ -141,11 +150,13 @@ describe("telemetry database integrity recovery (#1360)", () => {
 			"CREATE TABLE telemetry_events (event TEXT, queue TEXT, timestamp TEXT, unsent INTEGER); CREATE INDEX idx_telemetry_events_event ON telemetry_events(event); CREATE INDEX idx_telemetry_events_queue ON telemetry_events(queue); CREATE INDEX idx_telemetry_events_timestamp ON telemetry_events(timestamp); CREATE INDEX idx_telemetry_events_unsent ON telemetry_events(unsent)",
 		);
 		database.close();
-		const { accessor } = fakeAccessor({ telemetryMessage: "index mismatch" });
+		const { accessor } = fakeAccessor({ telemetryMessage: "index mismatch", repairAfterFirstTelemetryCheck: true });
+		let auditCalls = 0;
 
 		const result = await repairTelemetryIndexes(
 			accessor,
 			(db) => {
+				auditCalls += 1;
 				db.exec("INSERT INTO repair_audit VALUES (1)");
 			},
 			{
@@ -157,6 +168,7 @@ describe("telemetry database integrity recovery (#1360)", () => {
 
 		expect(result.state).toBe("repaired");
 		expect(result.rebuiltIndexes).toHaveLength(4);
+		expect(auditCalls).toBe(1);
 		const verification = new Database(dbPath);
 		expect(verification.prepare("PRAGMA integrity_check(telemetry_events)").all()).toEqual([{ integrity_check: "ok" }]);
 		verification.close();
@@ -180,7 +192,7 @@ describe("telemetry database integrity recovery (#1360)", () => {
 
 		try {
 			const result = await repairTelemetryIndexes(
-				fakeAccessor({ telemetryMessage: "index mismatch" }).accessor,
+				fakeAccessor({ telemetryMessage: "index mismatch", repairAfterFirstTelemetryCheck: true }).accessor,
 				(db) => {
 					db.exec("INSERT INTO repair_audit VALUES (1)");
 				},
@@ -243,7 +255,7 @@ describe("telemetry database integrity recovery (#1360)", () => {
 		expect(result.telemetryCheck.messages).toContain("memory_history unavailable");
 	});
 
-	it("does not start a production repair child when the audit fails", async () => {
+	it("fails closed when a production repair audit fails after verification", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "integrity-repair-audit-failure-"));
 		const dbPath = join(dir, "memory.db");
 		const markerPath = join(dir, "child-started");
@@ -255,11 +267,11 @@ describe("telemetry database integrity recovery (#1360)", () => {
 		database.close();
 		writeFileSync(
 			workerPath,
-			`import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(markerPath)}, "started");\n`,
+			`import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(markerPath)}, "started"); process.stdout.write(JSON.stringify({ ok: true }) + "\\n");\n`,
 		);
 
 		const result = await repairTelemetryIndexes(
-			fakeAccessor({ telemetryMessage: "index mismatch" }).accessor,
+			fakeAccessor({ telemetryMessage: "index mismatch", repairAfterFirstTelemetryCheck: true }).accessor,
 			() => {
 				throw new Error("audit unavailable");
 			},
@@ -268,7 +280,33 @@ describe("telemetry database integrity recovery (#1360)", () => {
 
 		expect(result.state).toBe("corrupt");
 		expect(result.telemetryCheck.messages).toContain("audit unavailable");
-		expect(existsSync(markerPath)).toBe(false);
+		expect(existsSync(markerPath)).toBe(true);
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("does not audit a failed production repair child", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "integrity-repair-child-failure-"));
+		const dbPath = join(dir, "memory.db");
+		const workerPath = join(dir, "failed-repair-worker.mjs");
+		const database = new Database(dbPath);
+		database.exec(
+			"CREATE TABLE telemetry_events (event TEXT); CREATE INDEX idx_telemetry_events_event ON telemetry_events(event)",
+		);
+		database.close();
+		writeFileSync(workerPath, 'process.stderr.write("repair failed"); process.exitCode = 1;\n');
+		let auditCalls = 0;
+
+		const result = await repairTelemetryIndexes(
+			fakeAccessor({ telemetryMessage: "index mismatch" }).accessor,
+			() => {
+				auditCalls += 1;
+			},
+			{ dbPath, repairWorkerPath: workerPath, repairRuntimePath: "node", repairTimeoutMs: 5_000 },
+		);
+
+		expect(result.state).toBe("corrupt");
+		expect(result.telemetryCheck.messages).toContain("telemetry index repair worker exited with code 1: repair failed");
+		expect(auditCalls).toBe(0);
 		rmSync(dir, { recursive: true, force: true });
 	});
 

--- a/platform/daemon/src/database-integrity.ts
+++ b/platform/daemon/src/database-integrity.ts
@@ -493,9 +493,10 @@ async function runDeferredIntegrityCheckInternal(
  * Check the database and repair only disposable telemetry indexes when the
  * targeted check identifies damage. Production REINDEX work runs in a
  * killable child with a real deadline. Production audits are admitted through
- * the bounded async writer queue before the child can commit its repair; test
- * doubles without a database path use one queued transaction for both
- * operations.
+ * the bounded async writer queue only after the child commits and verification
+ * succeeds. Owner-routed repairs keep their audit statement in the same
+ * transaction as REINDEX; test doubles without a database path use one queued
+ * transaction for both operations.
  */
 export interface IntegrityRepairOptions {
 	readonly quickCheck?: IntegrityCheckStatus;
@@ -618,9 +619,6 @@ export async function repairTelemetryIndexes(
 					estimatedWorkUnits: Math.max(1, statements.length),
 				});
 			} else if (options?.dbPath !== undefined) {
-				if (audit !== undefined) {
-					await writeAsync(accessor, (db) => audit(db, telemetryIndexes, telemetryCheck.messages));
-				}
 				await runKillableTelemetryRepair(
 					options.dbPath,
 					telemetryIndexes,
@@ -650,6 +648,9 @@ export async function repairTelemetryIndexes(
 							"integrity_check",
 						);
 			if (verifiedTelemetry.ok) {
+				if (options?.dbPath !== undefined && audit !== undefined) {
+					await writeAsync(accessor, (db) => audit(db, telemetryIndexes, telemetryCheck.messages));
+				}
 				latestStatus = statusWith(
 					"repaired",
 					quickCheck,


### PR DESCRIPTION
## Summary

Fixes #1617. Telemetry repair audits are now written only after the killable repair child succeeds and the post-repair integrity check passes. Failed, timed-out, and unverifiable production repairs cannot leave a durable success audit.

## Changes

- Move the production telemetry audit callback after child completion and post-repair verification.
- Add regression coverage for a repair worker exiting with code 1 and assert that the audit callback is not called.
- Assert that a successful verified production repair still audits.
- Preserve the DB-owner pre-commit audit transaction and the no-db-path REINDEX fallback.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

Not applicable. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

Not applicable. No migrations were touched.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused verification:

- `bun test platform/daemon/src/database-integrity.test.ts` passes: 15 tests, 0 failures.
- `bunx biome check platform/daemon/src/database-integrity.ts platform/daemon/src/database-integrity.test.ts` passes.
- `git diff --check` passes.
- `bun run typecheck` passes across all workspaces.
- `bun run lint` exits 0. The repository reports pre-existing warnings and infos outside the changed files.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The production path still uses the killable repair child and bounded timeout. The owner-routed path retains its audit statement before REINDEX in the same transaction, which is a separate invariant from this fix. The branch was based on current `origin/main` at commit `6b43846d193dc3d40ade4bf22796d99fa8509f81`.
