### PR TITLE
fix(daemon): defer startup tombstone cleanup

### DIFF
--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -366,6 +366,7 @@ export {
 	parseDiscordSettings,
 	parseGitHubSettings,
 	removeSource,
+	removeSourceIfGeneration,
 	saveSourcesConfig,
 } from "./sources-config";
 export type {

--- a/platform/core/src/sources-config.test.ts
+++ b/platform/core/src/sources-config.test.ts
@@ -17,6 +17,7 @@ import {
 	parseDiscordSettings,
 	parseGitHubSettings,
 	removeSource,
+	removeSourceIfGeneration,
 } from "./sources-config";
 
 let dir = "";
@@ -470,6 +471,25 @@ describe("sources-config", () => {
 		if (removed.ok === false) throw new Error(removed.error);
 		expect(removed.source.id).toBe(added.source.id);
 		expect(loadSourcesConfig(agentsDir).sources).toEqual([]);
+	});
+
+	it("does not remove a re-added source when the old generation is stale", () => {
+		const agentsDir = tmp();
+		const vault = join(agentsDir, "vault");
+		mkdirSync(vault, { recursive: true });
+		const first = addObsidianSource({ root: vault, name: "Vault A", now: "2026-01-01T00:00:00.000Z" }, agentsDir);
+		expect(first.ok).toBe(true);
+		if (first.ok === false) throw new Error(first.error);
+		const removed = removeSource(first.source.id, agentsDir);
+		expect(removed.ok).toBe(true);
+		const readded = addObsidianSource({ root: vault, name: "Vault A2", now: "2026-01-02T00:00:00.000Z" }, agentsDir);
+		expect(readded.ok).toBe(true);
+		if (readded.ok === false) throw new Error(readded.error);
+
+		const stale = removeSourceIfGeneration(first.source.id, first.source.generation, agentsDir);
+
+		expect(stale).toEqual({ ok: true, removed: false, source: readded.source });
+		expect(loadSourcesConfig(agentsDir).sources).toEqual([readded.source]);
 	});
 
 	it("uses unique temp files and leaves no stale lock or tmp files after sequential mutations", () => {

--- a/platform/core/src/sources-config.test.ts
+++ b/platform/core/src/sources-config.test.ts
@@ -450,7 +450,10 @@ describe("sources-config", () => {
 		};
 		writeFileSync(getSourcesConfigPath(agentsDir), `${JSON.stringify({ version: 1, sources: [source] })}\n`);
 
-		expect(loadSourcesConfig(agentsDir).sources).toEqual([source]);
+		const loaded = loadSourcesConfig(agentsDir).sources;
+		expect(loaded).toHaveLength(1);
+		expect(loaded[0]).toMatchObject(source);
+		expect(loaded[0]?.generation).toBe("legacy:discord:test:2026-01-01T00:00:00.000Z:2026-01-01T00:00:00.000Z");
 	});
 
 	it("removes a source by id from the config", () => {

--- a/platform/core/src/sources-config.ts
+++ b/platform/core/src/sources-config.ts
@@ -138,6 +138,11 @@ export type RemoveSourceResult =
 	| { readonly ok: true; readonly source: SignetSourceEntry }
 	| { readonly ok: false; readonly error: string };
 
+export type RemoveSourceIfGenerationResult =
+	| { readonly ok: true; readonly removed: true; readonly source: SignetSourceEntry }
+	| { readonly ok: true; readonly removed: false; readonly source: SignetSourceEntry | undefined }
+	| { readonly ok: false; readonly error: string };
+
 const SOURCES_CONFIG_VERSION = 1;
 export const DEFAULT_DISCORD_MAX_MESSAGES_PER_CHANNEL = 1000;
 export const MAX_DISCORD_MAX_MESSAGES_PER_CHANNEL = 10_000;
@@ -715,6 +720,31 @@ function markSourceIndexedUnlocked(
 
 export function removeSource(sourceId: string, agentsDir = getAgentsDir()): RemoveSourceResult {
 	return withSourcesConfigLock(agentsDir, () => removeSourceUnlocked(sourceId, agentsDir));
+}
+
+/** Remove a source only while the captured lifecycle generation is still live. */
+export function removeSourceIfGeneration(
+	sourceId: string,
+	generation: string | undefined,
+	agentsDir = getAgentsDir(),
+): RemoveSourceIfGenerationResult {
+	return withSourcesConfigLock(agentsDir, () => {
+		try {
+			const id = sourceId.trim();
+			if (!id) return { ok: false, error: "Source id is required" };
+			const cfg = loadSourcesConfigForWrite(agentsDir);
+			const source = cfg.sources.find((entry) => entry.id === id);
+			if (!source || source.generation !== generation) return { ok: true, removed: false, source };
+			saveSourcesConfig(
+				{ version: SOURCES_CONFIG_VERSION, sources: cfg.sources.filter((entry) => entry !== source) },
+				agentsDir,
+			);
+			return { ok: true, removed: true, source };
+		} catch (err) {
+			const detail = err instanceof Error ? err.message : String(err);
+			return { ok: false, error: detail };
+		}
+	});
 }
 
 function removeSourceUnlocked(sourceId: string, agentsDir = getAgentsDir()): RemoveSourceResult {

--- a/platform/core/src/sources-config.ts
+++ b/platform/core/src/sources-config.ts
@@ -167,10 +167,14 @@ export function loadSourcesConfig(agentsDir = getAgentsDir()): SignetSourcesConf
 		if (!isRecord(parsed) || parsed.version !== SOURCES_CONFIG_VERSION || !Array.isArray(parsed.sources)) {
 			return emptyConfig();
 		}
-		return {
+		const sources = parsed.sources.filter(isSourceEntry).map(normalizeSourceEntry);
+		const config: SignetSourcesConfig = {
 			version: SOURCES_CONFIG_VERSION,
-			sources: parsed.sources.filter(isSourceEntry),
+			sources,
 		};
+		if (parsed.sources.some((source) => isSourceEntry(source) && source.generation === undefined))
+			saveSourcesConfig(config, agentsDir);
+		return config;
 	} catch {
 		return emptyConfig();
 	}

--- a/platform/core/src/sources-config.ts
+++ b/platform/core/src/sources-config.ts
@@ -9,6 +9,8 @@ export type SignetSourceProviderSettings = Readonly<Record<string, unknown>>;
 
 export interface SignetSourceEntry {
 	readonly id: string;
+	/** Unique lifecycle epoch. Unlike updatedAt, this is never reused. */
+	readonly generation?: string;
 	readonly kind: SignetSourceKind;
 	readonly name: string;
 	readonly root: string;
@@ -198,7 +200,17 @@ function loadSourcesConfigForWrite(agentsDir = getAgentsDir()): SignetSourcesCon
 	if (!parsed.sources.every(isSourceEntry)) {
 		throw new Error(`Sources config contains invalid source entries; refusing to overwrite ${path}`);
 	}
-	return { version: SOURCES_CONFIG_VERSION, sources: parsed.sources };
+	return { version: SOURCES_CONFIG_VERSION, sources: parsed.sources.map(normalizeSourceEntry) };
+}
+
+function newSourceGeneration(): string {
+	return randomUUID();
+}
+
+function normalizeSourceEntry(source: SignetSourceEntry): SignetSourceEntry {
+	return source.generation
+		? source
+		: { ...source, generation: `legacy:${source.id}:${source.createdAt}:${source.updatedAt}` };
 }
 
 export function addObsidianSource(input: AddObsidianSourceInput, agentsDir = getAgentsDir()): AddSourceResult {
@@ -243,6 +255,7 @@ export function addImportedSource(input: AddImportedSourceInput, agentsDir = get
 				: `import:${contentHash.slice(0, 16)}${mode === "reimport" ? `:${randomUUID().slice(0, 8)}` : ownerSuffix}`;
 		const source: SignetSourceEntry = {
 			id: sourceId,
+			generation: newSourceGeneration(),
 			kind: "import",
 			name: basename(fileName),
 			root: basename(fileName),
@@ -297,6 +310,7 @@ function addDiscordSourceChecked(input: AddDiscordSourceInput, agentsDir = getAg
 			root,
 			enabled: true,
 			providerSettings: discordSettingsProviderSettings(settings),
+			generation: newSourceGeneration(),
 			updatedAt: now,
 		};
 		saveSourcesConfig(
@@ -311,6 +325,7 @@ function addDiscordSourceChecked(input: AddDiscordSourceInput, agentsDir = getAg
 
 	const source: SignetSourceEntry = {
 		id: sourceId,
+		generation: newSourceGeneration(),
 		kind: "discord",
 		name: cleanName(input.name) ?? "Discord Source",
 		root,
@@ -353,6 +368,7 @@ function addGitHubSourceChecked(input: AddGitHubSourceInput, agentsDir = getAgen
 			root,
 			enabled: true,
 			providerSettings: githubSettingsProviderSettings(updatedSettings),
+			generation: newSourceGeneration(),
 			updatedAt: now,
 		};
 		saveSourcesConfig(
@@ -367,6 +383,7 @@ function addGitHubSourceChecked(input: AddGitHubSourceInput, agentsDir = getAgen
 
 	const source: SignetSourceEntry = {
 		id: sourceId,
+		generation: newSourceGeneration(),
 		kind: "github",
 		name: cleanName(input.name) ?? settings.repos[0] ?? "GitHub Source",
 		root,
@@ -641,6 +658,7 @@ function addObsidianSourceChecked(input: AddObsidianSourceInput, agentsDir = get
 				? mergeDefaultObsidianExcludeGlobs(input.excludeGlobs)
 				: (existing.excludeGlobs ?? [...DEFAULT_OBSIDIAN_EXCLUDE_GLOBS]),
 			enabled: true,
+			generation: newSourceGeneration(),
 			updatedAt: now,
 		};
 		saveSourcesConfig(
@@ -655,6 +673,7 @@ function addObsidianSourceChecked(input: AddObsidianSourceInput, agentsDir = get
 
 	const source: SignetSourceEntry = {
 		id: `obsidian:${createHash("sha256").update(root).digest("hex").slice(0, 16)}`,
+		generation: newSourceGeneration(),
 		kind: "obsidian",
 		name: cleanName(input.name) ?? "Obsidian Vault",
 		root,

--- a/platform/core/src/sources-config.ts
+++ b/platform/core/src/sources-config.ts
@@ -162,22 +162,19 @@ export function getSourcesConfigPath(agentsDir = getAgentsDir()): string {
 export function loadSourcesConfig(agentsDir = getAgentsDir()): SignetSourcesConfig {
 	const path = getSourcesConfigPath(agentsDir);
 	if (!existsSync(path)) return emptyConfig();
+	let parsed: unknown;
 	try {
-		const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
-		if (!isRecord(parsed) || parsed.version !== SOURCES_CONFIG_VERSION || !Array.isArray(parsed.sources)) {
-			return emptyConfig();
-		}
-		const sources = parsed.sources.filter(isSourceEntry).map(normalizeSourceEntry);
-		const config: SignetSourcesConfig = {
-			version: SOURCES_CONFIG_VERSION,
-			sources,
-		};
-		if (parsed.sources.some((source) => isSourceEntry(source) && source.generation === undefined))
-			saveSourcesConfig(config, agentsDir);
-		return config;
+		parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
 	} catch {
 		return emptyConfig();
 	}
+	if (!isRecord(parsed) || parsed.version !== SOURCES_CONFIG_VERSION || !Array.isArray(parsed.sources))
+		return emptyConfig();
+	const sources = parsed.sources.filter(isSourceEntry).map(normalizeSourceEntry);
+	const config: SignetSourcesConfig = { version: SOURCES_CONFIG_VERSION, sources };
+	if (parsed.sources.some((source) => isSourceEntry(source) && source.generation === undefined))
+		saveSourcesConfig(config, agentsDir);
+	return config;
 }
 
 export function saveSourcesConfig(config: SignetSourcesConfig, agentsDir = getAgentsDir()): void {

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -2074,19 +2074,9 @@ async function main() {
 	// deferred call, so owner startup and the bounded drain never delay readiness.
 	runStartupRecovery(getDbAccessor(), { owner: dbOwnerClient });
 
-	// Purge artifacts of sources deleted while the daemon was down (e.g.
-	// crash-loop-disabled sources). This needs the DB accessor, so it runs
-	// here in the startup sequence — not at route registration, which
-	// executes before DB init and crashed the daemon whenever a tombstone
-	// existed at boot (#1143). Failures are tolerated inside the cleanup;
-	// failed purges defer to the next boot.
-	try {
-		await cleanupSourceDeletionTombstones(AGENTS_DIR);
-	} catch (err) {
-		logger.warn("daemon", "Source-deletion tombstone cleanup failed; continuing startup", {
-			error: err instanceof Error ? err.message : String(err),
-		});
-	}
+	// Source-deletion cleanup runs in the post-ready deferred lane below. Do not
+	// put it before binding the HTTP server: its lifecycle-state delete uses the
+	// bounded async writer and must not make readiness depend on that queue.
 
 	const { extensionPath } = getVectorRuntimeStatus();
 	const bundled = join(__dirname, "synthesis-render-worker.js");
@@ -2335,6 +2325,16 @@ async function main() {
 	// background write work piles on (#1059 thundering-herd prevention).
 	const startPostReadyRuntime = async (): Promise<void> => {
 		await deferredRuntimeGate.waitForIntegrity();
+		// Tombstone cleanup uses the bounded async writer. Keep it in this
+		// serialized post-ready lane, before pipeline startup, so readiness is
+		// already published while lifecycle deletion still avoids write contention.
+		try {
+			await cleanupSourceDeletionTombstones(AGENTS_DIR);
+		} catch (error) {
+			logger.error("daemon", "Deferred source-deletion tombstone cleanup failed; retry remains available", undefined, {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
 		reportStartupGrace();
 		await startPipelineRuntime(memoryCfg, telemetryCollector);
 		logFdSnapshot("post-pipeline");

--- a/platform/daemon/src/routes/import-routes.ts
+++ b/platform/daemon/src/routes/import-routes.ts
@@ -1,6 +1,6 @@
 import { readFile, stat } from "node:fs/promises";
 import { basename } from "node:path";
-import { addImportedSource, loadSourcesConfig, markSourceIndexed, removeSource } from "@signet/core";
+import { addImportedSource, loadSourcesConfig, markSourceIndexed, removeSourceIfGeneration } from "@signet/core";
 import type { Context } from "hono";
 import type { Hono } from "hono";
 import { resolveDaemonAgentId } from "../agent-id";
@@ -271,7 +271,7 @@ export function registerImportRoutes(app: Hono): void {
 							error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
 						});
 					}
-					const removed = removeSource(replacedSource.id, agentsDir);
+					const removed = removeSourceIfGeneration(replacedSource.id, replacedSource.generation, agentsDir);
 					if (removed.ok === false)
 						logger.warn("documents", "Replaced dashboard import config cleanup failed", {
 							sourceId: replacedSource.id,
@@ -296,7 +296,7 @@ export function registerImportRoutes(app: Hono): void {
 				if (added.created) {
 					try {
 						purgeSourceOwnedRows({ sourceId: added.source.id, agentId: resolveDaemonAgentId() });
-						removeSource(added.source.id, process.env.SIGNET_PATH);
+						removeSourceIfGeneration(added.source.id, added.source.generation, process.env.SIGNET_PATH);
 					} catch (cleanupError) {
 						logger.warn("documents", "Dashboard import cleanup failed", {
 							sourceId: added.source.id,

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -293,11 +293,12 @@ describe("Sources routes", () => {
 			)}\n`,
 		);
 
-		const second = addObsidianSource({ root: vault, name: "Generation Two", now: "2026-08-16T19:00:00.000Z" }, dir);
+		const second = addObsidianSource({ root: vault, name: "Generation Two", now: "2026-08-16T18:00:00.000Z" }, dir);
 		expect(second.ok).toBe(true);
 		if (second.ok === false) throw new Error(second.error);
 		expect(second.source.id).toBe(first.source.id);
-		expect(second.source.updatedAt).not.toBe(first.source.updatedAt);
+		expect(second.source.updatedAt).toBe(first.source.updatedAt);
+		expect(second.source.generation).not.toBe(first.source.generation);
 
 		let purges = 0;
 		await cleanupSourceDeletionTombstones(dir, () => {

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -163,12 +163,20 @@ describe("Sources routes", () => {
 		expect(source).not.toMatch(/\b(?:execSync|spawnSync)\b/);
 	});
 
-	it("tracks recurring lifecycle writes and awaits startup tombstone cleanup (#1590)", async () => {
+	it("defers startup tombstone cleanup to the post-ready lane (#1630)", async () => {
 		const routeSource = await Bun.file(new URL("./sources-routes.ts", import.meta.url)).text();
 		const daemonSource = await Bun.file(new URL("../daemon.ts", import.meta.url)).text();
 		expect(routeSource).toContain("trackSourceLifecycleWrite(recordSourceReadiness(input.source, agentId))");
 		expect(routeSource).toContain("trackSourceLifecycleWrite(recordSourceFreshness(input.source, agentId))");
-		expect(daemonSource).toContain("await cleanupSourceDeletionTombstones(AGENTS_DIR)");
+		const runtimeStartIndex = daemonSource.indexOf("const startPostReadyRuntime = async (): Promise<void> => {");
+		const runtimeEndIndex = daemonSource.indexOf("deferredRuntimeScheduler.schedulePipeline(startPostReadyRuntime);");
+		const cleanupIndex = daemonSource.indexOf("await cleanupSourceDeletionTombstones(AGENTS_DIR);");
+		const pipelineIndex = daemonSource.indexOf("await startPipelineRuntime(memoryCfg, telemetryCollector);");
+		expect(runtimeStartIndex).toBeGreaterThanOrEqual(0);
+		expect(cleanupIndex).toBeGreaterThan(runtimeStartIndex);
+		expect(cleanupIndex).toBeLessThan(pipelineIndex);
+		expect(pipelineIndex).toBeLessThan(runtimeEndIndex);
+		expect(daemonSource).toContain("Deferred source-deletion tombstone cleanup failed; retry remains available");
 	});
 
 	it("lists no configured sources by default", async () => {
@@ -623,6 +631,65 @@ describe("Sources routes", () => {
 		expect(JSON.parse(readFileSync(tombstonePath, "utf8"))).toHaveLength(0);
 	});
 
+	it("keeps post-ready startup responsive while tombstone lifecycle cleanup waits for the writer (#1630)", async () => {
+		const tombstonePath = join(dir, ".daemon", "source-deletion-tombstones.json");
+		mkdirSync(join(dir, ".daemon"), { recursive: true });
+		writeFileSync(
+			tombstonePath,
+			`${JSON.stringify(
+				[
+					{
+						id: "tombstone-blocked-writer",
+						source: { id: "blocked-writer-vault", name: "Blocked Writer Vault", kind: "obsidian", root: vault },
+						agentId: "test-agent",
+						deletedAt: new Date().toISOString(),
+					},
+				],
+				null,
+				2,
+			)}\n`,
+		);
+
+		const accessor = getDbAccessor();
+		const originalAsync = accessor.withWriteTxAsync;
+		if (!originalAsync) throw new Error("async write API is unavailable");
+		const injectable = accessor as {
+			withWriteTxAsync: <T>(fn: (db: import("../db-accessor").WriteDb) => T) => Promise<T>;
+		};
+		let releaseWriter = () => {};
+		const writerGate = new Promise<void>((resolve) => {
+			releaseWriter = resolve;
+		});
+		let purges = 0;
+		let settled = false;
+		injectable.withWriteTxAsync = async (fn) => {
+			await writerGate;
+			return originalAsync(fn);
+		};
+
+		try {
+			const cleanup = cleanupSourceDeletionTombstones(dir, () => {
+				purges++;
+				return 1;
+			});
+			void cleanup.then(() => {
+				settled = true;
+			});
+
+			await Bun.sleep(50);
+			expect(cleanup instanceof Promise).toBe(true);
+			expect(settled).toBe(false);
+			expect(purges).toBe(0);
+
+			releaseWriter();
+			await cleanup;
+			expect(settled).toBe(true);
+			expect(purges).toBe(1);
+			expect(JSON.parse(readFileSync(tombstonePath, "utf8"))).toHaveLength(0);
+		} finally {
+			injectable.withWriteTxAsync = originalAsync;
+		}
+	});
 	it("reports source chunk stats using source-owned chunk id prefixes", async () => {
 		const added = addObsidianSource({ root: vault, name: "Stats Vault" }, dir);
 		expect(added.ok).toBe(true);

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -339,10 +339,11 @@ describe("Sources routes", () => {
 			])}\n`,
 		);
 
-		await cleanupSourceDeletionTombstones(dir, () => {
-			throw new Error("ambiguous legacy tombstones must not purge the live re-add");
-		});
-		expect(loadSourcesConfig(dir).sources[0]?.generation).toBeString();
+		const readded = addObsidianSource({ root: vault, name: "True Re-add", now: "2026-08-16T18:00:00.000Z" }, dir);
+		expect(readded.ok).toBe(true);
+		if (readded.ok === false) throw new Error(readded.error);
+		expect(readded.source.generation).not.toBe(legacySource.generation);
+		await cleanupSourceDeletionTombstones(dir, () => Promise.resolve(1));
 		expect(JSON.parse(readFileSync(tombstonePath, "utf8"))).toHaveLength(0);
 		const listedResponse = await makeApp().request("/api/sources");
 		const listed = (await listedResponse.json()) as { sources: Array<{ id: string }> };

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -185,6 +185,45 @@ describe("Sources routes", () => {
 		expect(await res.json()).toEqual({ version: 1, sources: [] });
 	});
 
+	it("does not serve a tombstoned source while deferred cleanup is pending (#1630)", async () => {
+		const added = addObsidianSource({ root: vault, name: "Pending Cleanup Vault" }, dir);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		const tombstonePath = join(dir, ".daemon", "source-deletion-tombstones.json");
+		mkdirSync(join(dir, ".daemon"), { recursive: true });
+		writeFileSync(
+			tombstonePath,
+			`${JSON.stringify(
+				[
+					{
+						id: "tombstone-pending-cleanup",
+						source: added.source,
+						agentId: "default",
+						deletedAt: new Date().toISOString(),
+					},
+				],
+				null,
+				2,
+			)}\n`,
+		);
+
+		// This app is the production source route registration used after the
+		// daemon is ready. Cleanup is intentionally not run before these reads.
+		const app = makeApp();
+		const list = await app.request("/api/sources");
+		expect(list.status).toBe(200);
+		expect(await list.json()).toEqual({ version: 1, sources: [] });
+
+		for (const path of [
+			`/api/sources/${encodeURIComponent(added.source.id)}/health`,
+			`/api/sources/${encodeURIComponent(added.source.id)}/snapshot`,
+		]) {
+			const response = await app.request(path);
+			expect(response.status).toBe(404);
+		}
+	});
+
 	it("connects an Obsidian source, queues indexing, and records lastIndexedAt after the job finishes", async () => {
 		const res = await makeApp({ indexed: 3 }).request("/api/sources/obsidian", {
 			method: "POST",

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -224,6 +224,52 @@ describe("Sources routes", () => {
 		}
 	});
 
+	it("retains a configured tombstone across restart cleanup until config removal completes (#1630)", async () => {
+		const added = addObsidianSource({ root: vault, name: "Restart Cleanup Vault" }, dir);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		const tombstonePath = join(dir, ".daemon", "source-deletion-tombstones.json");
+		mkdirSync(join(dir, ".daemon"), { recursive: true });
+		writeFileSync(
+			tombstonePath,
+			`${JSON.stringify(
+				[
+					{
+						id: "tombstone-restart-state",
+						source: added.source,
+						agentId: "default",
+						deletedAt: new Date().toISOString(),
+					},
+				],
+				null,
+				2,
+			)}\n`,
+		);
+
+		await cleanupSourceDeletionTombstones(dir, () => {
+			throw new Error("cleanup must not purge a source that is still configured");
+		});
+		expect(JSON.parse(readFileSync(tombstonePath, "utf8"))).toHaveLength(1);
+
+		const app = makeApp();
+		const list = await app.request("/api/sources");
+		expect(list.status).toBe(200);
+		expect(await list.json()).toEqual({ version: 1, sources: [] });
+		for (const path of [
+			`/api/sources/${encodeURIComponent(added.source.id)}/health`,
+			`/api/sources/${encodeURIComponent(added.source.id)}/snapshot`,
+		]) {
+			const response = await app.request(path);
+			expect(response.status).toBe(404);
+		}
+
+		const deleted = await app.request(`/api/sources/${encodeURIComponent(added.source.id)}`, { method: "DELETE" });
+		expect(deleted.status).toBe(200);
+		expect(loadSourcesConfig(dir).sources).toHaveLength(0);
+		expect(JSON.parse(readFileSync(tombstonePath, "utf8"))).toHaveLength(0);
+	});
+
 	it("connects an Obsidian source, queues indexing, and records lastIndexedAt after the job finishes", async () => {
 		const res = await makeApp({ indexed: 3 }).request("/api/sources/obsidian", {
 			method: "POST",

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -270,6 +270,95 @@ describe("Sources routes", () => {
 		expect(JSON.parse(readFileSync(tombstonePath, "utf8"))).toHaveLength(0);
 	});
 
+	it("does not hide a re-added source when restart cleanup sees an older generation tombstone (#1630)", async () => {
+		const first = addObsidianSource({ root: vault, name: "Generation One", now: "2026-08-16T18:00:00.000Z" }, dir);
+		expect(first.ok).toBe(true);
+		if (first.ok === false) throw new Error(first.error);
+
+		const tombstonePath = join(dir, ".daemon", "source-deletion-tombstones.json");
+		mkdirSync(join(dir, ".daemon"), { recursive: true });
+		writeFileSync(
+			tombstonePath,
+			`${JSON.stringify(
+				[
+					{
+						id: "tombstone-generation-one",
+						source: first.source,
+						agentId: "default",
+						deletedAt: new Date().toISOString(),
+					},
+				],
+				null,
+				2,
+			)}\n`,
+		);
+
+		const second = addObsidianSource({ root: vault, name: "Generation Two", now: "2026-08-16T19:00:00.000Z" }, dir);
+		expect(second.ok).toBe(true);
+		if (second.ok === false) throw new Error(second.error);
+		expect(second.source.id).toBe(first.source.id);
+		expect(second.source.updatedAt).not.toBe(first.source.updatedAt);
+
+		let purges = 0;
+		await cleanupSourceDeletionTombstones(dir, () => {
+			purges++;
+			return Promise.resolve(1);
+		});
+		expect(purges).toBe(1);
+		expect(JSON.parse(readFileSync(tombstonePath, "utf8"))).toHaveLength(0);
+
+		const app = makeApp();
+		const list = await app.request("/api/sources");
+		expect(list.status).toBe(200);
+		const listed = (await list.json()) as { sources: Array<{ id: string; updatedAt: string }> };
+		expect(listed.sources).toHaveLength(1);
+		expect(listed.sources[0]).toMatchObject({ id: second.source.id, updatedAt: second.source.updatedAt });
+
+		const health = await app.request(`/api/sources/${encodeURIComponent(second.source.id)}/health`);
+		expect(health.status).toBe(200);
+		const snapshot = await app.request(`/api/sources/${encodeURIComponent(second.source.id)}/snapshot`);
+		expect(snapshot.status).toBe(200);
+	});
+
+	it("keeps an older generation tombstone when deleting the re-added source (#1630)", async () => {
+		const first = addObsidianSource({ root: vault, name: "Generation One", now: "2026-08-16T20:00:00.000Z" }, dir);
+		expect(first.ok).toBe(true);
+		if (first.ok === false) throw new Error(first.error);
+
+		const tombstonePath = join(dir, ".daemon", "source-deletion-tombstones.json");
+		mkdirSync(join(dir, ".daemon"), { recursive: true });
+		writeFileSync(
+			tombstonePath,
+			`${JSON.stringify(
+				[
+					{
+						id: "tombstone-generation-one",
+						source: first.source,
+						agentId: "default",
+						deletedAt: new Date().toISOString(),
+					},
+				],
+				null,
+				2,
+			)}\n`,
+		);
+
+		const second = addObsidianSource({ root: vault, name: "Generation Two", now: "2026-08-16T21:00:00.000Z" }, dir);
+		expect(second.ok).toBe(true);
+		if (second.ok === false) throw new Error(second.error);
+
+		const deleted = await makeApp().request(`/api/sources/${encodeURIComponent(second.source.id)}`, {
+			method: "DELETE",
+		});
+		expect(deleted.status).toBe(200);
+		expect(loadSourcesConfig(dir).sources).toHaveLength(0);
+		const remaining = JSON.parse(readFileSync(tombstonePath, "utf8")) as Array<{
+			source: { id: string; updatedAt: string };
+		}>;
+		expect(remaining).toHaveLength(1);
+		expect(remaining[0]?.source).toEqual({ ...first.source });
+	});
+
 	it("connects an Obsidian source, queues indexing, and records lastIndexedAt after the job finishes", async () => {
 		const res = await makeApp({ indexed: 3 }).request("/api/sources/obsidian", {
 			method: "POST",

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -321,6 +321,35 @@ describe("Sources routes", () => {
 		expect(snapshot.status).toBe(200);
 	});
 
+	it("does not let an unknown legacy tombstone poison a normalized legacy re-add", async () => {
+		const added = addObsidianSource({ root: vault, name: "Legacy Vault", now: "2026-08-16T17:00:00.000Z" }, dir);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+		const configPath = join(dir, "sources.json");
+		const legacySource = { ...added.source } as Record<string, unknown>;
+		delete legacySource.generation;
+		writeFileSync(configPath, `${JSON.stringify({ version: 1, sources: [legacySource] })}\n`);
+		const tombstonePath = join(dir, ".daemon", "source-deletion-tombstones.json");
+		mkdirSync(join(dir, ".daemon"), { recursive: true });
+		const legacyTombstone = { ...legacySource };
+		writeFileSync(
+			tombstonePath,
+			`${JSON.stringify([
+				{ id: "legacy-tombstone", source: legacyTombstone, agentId: "default", deletedAt: new Date().toISOString() },
+			])}\n`,
+		);
+
+		await cleanupSourceDeletionTombstones(dir, () => {
+			throw new Error("ambiguous legacy tombstones must not purge the live re-add");
+		});
+		expect(loadSourcesConfig(dir).sources[0]?.generation).toBeString();
+		expect(JSON.parse(readFileSync(tombstonePath, "utf8"))).toHaveLength(0);
+		const listedResponse = await makeApp().request("/api/sources");
+		const listed = (await listedResponse.json()) as { sources: Array<{ id: string }> };
+		expect(listed.sources.map((source) => source.id)).toContain(added.source.id);
+		expect((await makeApp().request(`/api/sources/${encodeURIComponent(added.source.id)}/health`)).status).toBe(200);
+	});
+
 	it("keeps an older generation tombstone when deleting the re-added source (#1630)", async () => {
 		const first = addObsidianSource({ root: vault, name: "Generation One", now: "2026-08-16T20:00:00.000Z" }, dir);
 		expect(first.ok).toBe(true);

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -189,7 +189,8 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 			sources: config.sources
 				.filter(
 					(source) =>
-						isSourceVisibleToAgent(source, agentId) && !tombstonedSourceGenerations.has(sourceGenerationKey(source)),
+						isSourceVisibleToAgent(source, agentId) &&
+						!isSourceGenerationTombstoned(source, tombstonedSourceGenerations),
 				)
 				.map((source) => {
 					const stats = sourceStats(source, agentId);
@@ -493,20 +494,31 @@ function findConfiguredSource(
 		(source: SignetSourceEntry) =>
 			source.id === sourceId &&
 			isSourceVisibleToAgent(source, agentId) &&
-			(options.includeTombstoned === true || !tombstonedSourceGenerations.has(sourceGenerationKey(source))),
+			(options.includeTombstoned === true || !isSourceGenerationTombstoned(source, tombstonedSourceGenerations)),
 	);
+}
+
+function isSourceGenerationTombstoned(source: SignetSourceEntry, generations: ReadonlySet<string>): boolean {
+	const key = sourceGenerationKey(source);
+	return key !== undefined && generations.has(key);
 }
 
 function loadTombstonedSourceGenerations(agentsDir: string, agentId: string): ReadonlySet<string> {
 	return new Set(
 		loadSourceDeletionTombstones(agentsDir)
 			.filter((tombstone) => tombstone.agentId === agentId)
-			.map((tombstone) => sourceGenerationKey(tombstone.source)),
+			.flatMap((tombstone) => {
+				const key = sourceGenerationKey(tombstone.source);
+				return key === undefined ? [] : [key];
+			}),
 	);
 }
 
-function sourceGenerationKey(source: SignetSourceEntry): string {
-	return `${source.id}\u0000${source.generation ?? `legacy:${source.updatedAt}`}`;
+function sourceGenerationKey(source: SignetSourceEntry): string | undefined {
+	// A missing generation is unknown, not a shared legacy generation. Matching
+	// unknown tombstones to unknown configs permanently poisons source re-adds.
+	if (source.generation === undefined) return undefined;
+	return `${source.id}\u0000${source.generation}`;
 }
 
 function isSourceVisibleToAgent(source: SignetSourceEntry, agentId: string): boolean {
@@ -719,8 +731,9 @@ export async function cleanupSourceDeletionTombstones(
 	for (const tombstone of tombstones) {
 		const configured = configuredSources.get(tombstone.source.id);
 		if (configured !== undefined && tombstone.source.generation === undefined) {
-			// Old tombstones cannot identify their deleted generation safely.
-			// A configured source is a deliberate re-add, so never purge its rows.
+			// Old tombstones cannot identify their deleted generation safely. The
+			// configured source is a live compatibility-normalized re-add. Drop the
+			// ambiguous marker, but do not purge rows belonging to the live source.
 			continue;
 		}
 		if (configured !== undefined && configured.generation === tombstone.source.generation) {

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -13,7 +13,7 @@ import {
 	addObsidianSource,
 	loadSourcesConfig,
 	markSourceIndexed,
-	removeSource,
+	removeSourceIfGeneration,
 } from "@signet/core";
 import type { Context, Hono } from "hono";
 import { resolveDaemonAgentId } from "../agent-id";
@@ -476,10 +476,10 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		await removeSourceLifecycleState(source, sourceAgentId);
 		const provider = getSourceProvider(source.kind);
 		const purged = provider ? await purgeSource(provider, source, sourceAgentId, purgeNativeSource) : 0;
-		const result = removeSource(sourceId, agentsDir);
+		const result = removeSourceIfGeneration(sourceId, source.generation, agentsDir);
 		if (result.ok === false) return c.json({ error: result.error }, 500);
 		if (!isSourceIndexInFlight(source.id)) clearSourceDeletionTombstone(source, sourceAgentId, agentsDir);
-		return c.json({ source: result.source, purged });
+		return c.json({ source: result.source ?? source, purged });
 	});
 }
 

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -506,7 +506,7 @@ function loadTombstonedSourceGenerations(agentsDir: string, agentId: string): Re
 }
 
 function sourceGenerationKey(source: SignetSourceEntry): string {
-	return `${source.id}\u0000${source.updatedAt}`;
+	return `${source.id}\u0000${source.generation ?? `legacy:${source.updatedAt}`}`;
 }
 
 function isSourceVisibleToAgent(source: SignetSourceEntry, agentId: string): boolean {
@@ -718,7 +718,12 @@ export async function cleanupSourceDeletionTombstones(
 	const remaining: SourceDeletionTombstone[] = [];
 	for (const tombstone of tombstones) {
 		const configured = configuredSources.get(tombstone.source.id);
-		if (configured !== undefined && configured.updatedAt === tombstone.source.updatedAt) {
+		if (configured !== undefined && tombstone.source.generation === undefined) {
+			// Old tombstones cannot identify their deleted generation safely.
+			// A configured source is a deliberate re-add, so never purge its rows.
+			continue;
+		}
+		if (configured !== undefined && configured.generation === tombstone.source.generation) {
 			// Config removal is the final deletion-state transition. Keep the
 			// tombstone while this source generation is still non-live.
 			remaining.push(tombstone);
@@ -754,7 +759,7 @@ function recordSourceDeletionTombstone(source: SignetSourceEntry, agentId: strin
 	const tombstones = loadSourceDeletionTombstones(agentsDir);
 	const next = tombstones.filter(
 		(entry) =>
-			entry.source.id !== source.id || entry.agentId !== agentId || entry.source.updatedAt !== source.updatedAt,
+			entry.source.id !== source.id || entry.agentId !== agentId || entry.source.generation !== source.generation,
 	);
 	saveSourceDeletionTombstones(
 		[
@@ -775,11 +780,11 @@ function clearSourceDeletionTombstone(source: SignetSourceEntry, agentId: string
 	// the marker for the same source generation, but allow a deliberate
 	// reconnect to replace that generation and become live again.
 	const configured = loadSourcesConfig(agentsDir).sources.find((entry) => entry.id === source.id);
-	if (configured?.updatedAt === source.updatedAt) return;
+	if (configured?.generation === source.generation) return;
 	const tombstones = loadSourceDeletionTombstones(agentsDir);
 	const next = tombstones.filter(
 		(entry) =>
-			entry.source.id !== source.id || entry.agentId !== agentId || entry.source.updatedAt !== source.updatedAt,
+			entry.source.id !== source.id || entry.agentId !== agentId || entry.source.generation !== source.generation,
 	);
 	if (next.length !== tombstones.length) saveSourceDeletionTombstones(next, agentsDir);
 }

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -183,11 +183,14 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 	app.get("/api/sources", (c) => {
 		const config = loadSourcesConfig(agentsDir);
 		const agentId = resolveDaemonAgentId();
-		const tombstonedSourceIds = loadTombstonedSourceIds(agentsDir, agentId);
+		const tombstonedSourceGenerations = loadTombstonedSourceGenerations(agentsDir, agentId);
 		return c.json({
 			version: config.version,
 			sources: config.sources
-				.filter((source) => isSourceVisibleToAgent(source, agentId) && !tombstonedSourceIds.has(source.id))
+				.filter(
+					(source) =>
+						isSourceVisibleToAgent(source, agentId) && !tombstonedSourceGenerations.has(sourceGenerationKey(source)),
+				)
 				.map((source) => {
 					const stats = sourceStats(source, agentId);
 					return {
@@ -485,21 +488,25 @@ function findConfiguredSource(
 	agentId: string,
 	options: { readonly includeTombstoned?: boolean } = {},
 ): SignetSourceEntry | undefined {
-	const tombstonedSourceIds = loadTombstonedSourceIds(agentsDir, agentId);
+	const tombstonedSourceGenerations = loadTombstonedSourceGenerations(agentsDir, agentId);
 	return loadSourcesConfig(agentsDir).sources.find(
 		(source: SignetSourceEntry) =>
 			source.id === sourceId &&
 			isSourceVisibleToAgent(source, agentId) &&
-			(options.includeTombstoned === true || !tombstonedSourceIds.has(source.id)),
+			(options.includeTombstoned === true || !tombstonedSourceGenerations.has(sourceGenerationKey(source))),
 	);
 }
 
-function loadTombstonedSourceIds(agentsDir: string, agentId: string): ReadonlySet<string> {
+function loadTombstonedSourceGenerations(agentsDir: string, agentId: string): ReadonlySet<string> {
 	return new Set(
 		loadSourceDeletionTombstones(agentsDir)
 			.filter((tombstone) => tombstone.agentId === agentId)
-			.map((tombstone) => tombstone.source.id),
+			.map((tombstone) => sourceGenerationKey(tombstone.source)),
 	);
+}
+
+function sourceGenerationKey(source: SignetSourceEntry): string {
+	return `${source.id}\u0000${source.updatedAt}`;
 }
 
 function isSourceVisibleToAgent(source: SignetSourceEntry, agentId: string): boolean {
@@ -707,12 +714,13 @@ export async function cleanupSourceDeletionTombstones(
 ): Promise<void> {
 	const tombstones = loadSourceDeletionTombstones(agentsDir);
 	if (tombstones.length === 0) return;
-	const configuredIds = new Set(loadSourcesConfig(agentsDir).sources.map((source) => source.id));
+	const configuredSources = new Map(loadSourcesConfig(agentsDir).sources.map((source) => [source.id, source]));
 	const remaining: SourceDeletionTombstone[] = [];
 	for (const tombstone of tombstones) {
-		if (configuredIds.has(tombstone.source.id)) {
+		const configured = configuredSources.get(tombstone.source.id);
+		if (configured !== undefined && configured.updatedAt === tombstone.source.updatedAt) {
 			// Config removal is the final deletion-state transition. Keep the
-			// tombstone while the configured source is still non-live.
+			// tombstone while this source generation is still non-live.
 			remaining.push(tombstone);
 			continue;
 		}
@@ -744,7 +752,10 @@ function purgeSource(
 
 function recordSourceDeletionTombstone(source: SignetSourceEntry, agentId: string, agentsDir: string): void {
 	const tombstones = loadSourceDeletionTombstones(agentsDir);
-	const next = tombstones.filter((entry) => entry.source.id !== source.id || entry.agentId !== agentId);
+	const next = tombstones.filter(
+		(entry) =>
+			entry.source.id !== source.id || entry.agentId !== agentId || entry.source.updatedAt !== source.updatedAt,
+	);
 	saveSourceDeletionTombstones(
 		[
 			...next,
@@ -766,7 +777,10 @@ function clearSourceDeletionTombstone(source: SignetSourceEntry, agentId: string
 	const configured = loadSourcesConfig(agentsDir).sources.find((entry) => entry.id === source.id);
 	if (configured?.updatedAt === source.updatedAt) return;
 	const tombstones = loadSourceDeletionTombstones(agentsDir);
-	const next = tombstones.filter((entry) => entry.source.id !== source.id || entry.agentId !== agentId);
+	const next = tombstones.filter(
+		(entry) =>
+			entry.source.id !== source.id || entry.agentId !== agentId || entry.source.updatedAt !== source.updatedAt,
+	);
 	if (next.length !== tombstones.length) saveSourceDeletionTombstones(next, agentsDir);
 }
 

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -183,10 +183,11 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 	app.get("/api/sources", (c) => {
 		const config = loadSourcesConfig(agentsDir);
 		const agentId = resolveDaemonAgentId();
+		const tombstonedSourceIds = loadTombstonedSourceIds(agentsDir, agentId);
 		return c.json({
 			version: config.version,
 			sources: config.sources
-				.filter((source) => isSourceVisibleToAgent(source, agentId))
+				.filter((source) => isSourceVisibleToAgent(source, agentId) && !tombstonedSourceIds.has(source.id))
 				.map((source) => {
 					const stats = sourceStats(source, agentId);
 					return {
@@ -458,7 +459,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 
 	app.delete("/api/sources/:sourceId", async (c) => {
 		const sourceId = c.req.param("sourceId");
-		const source = findConfiguredSource(sourceId, agentsDir, resolveDaemonAgentId());
+		const source = findConfiguredSource(sourceId, agentsDir, resolveDaemonAgentId(), { includeTombstoned: true });
 		if (source === undefined) return c.json({ error: "Source not found" }, 404);
 		const sourceAgentId = resolveDaemonAgentId();
 		if (source.kind === "import" && source.providerSettings?.agentId !== sourceAgentId)
@@ -478,9 +479,26 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 	});
 }
 
-function findConfiguredSource(sourceId: string, agentsDir: string, agentId: string): SignetSourceEntry | undefined {
+function findConfiguredSource(
+	sourceId: string,
+	agentsDir: string,
+	agentId: string,
+	options: { readonly includeTombstoned?: boolean } = {},
+): SignetSourceEntry | undefined {
+	const tombstonedSourceIds = loadTombstonedSourceIds(agentsDir, agentId);
 	return loadSourcesConfig(agentsDir).sources.find(
-		(source) => source.id === sourceId && isSourceVisibleToAgent(source, agentId),
+		(source: SignetSourceEntry) =>
+			source.id === sourceId &&
+			isSourceVisibleToAgent(source, agentId) &&
+			(options.includeTombstoned === true || !tombstonedSourceIds.has(source.id)),
+	);
+}
+
+function loadTombstonedSourceIds(agentsDir: string, agentId: string): ReadonlySet<string> {
+	return new Set(
+		loadSourceDeletionTombstones(agentsDir)
+			.filter((tombstone) => tombstone.agentId === agentId)
+			.map((tombstone) => tombstone.source.id),
 	);
 }
 

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -675,7 +675,7 @@ function scheduleSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob,
 
 /**
  * Purge artifacts of sources deleted while the daemon was down and drop their
- * tombstones. Runs in the daemon startup sequence AFTER the DB accessor is
+ * tombstones. Runs in the post-ready deferred lane AFTER the DB accessor is
  * initialized (#1143): route registration executes before DB init, so it must
  * not trigger this — the old placement crashed the daemon with "DbAccessor not
  * initialised" whenever a tombstone existed at boot.

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -507,18 +507,16 @@ function loadTombstonedSourceGenerations(agentsDir: string, agentId: string): Re
 	return new Set(
 		loadSourceDeletionTombstones(agentsDir)
 			.filter((tombstone) => tombstone.agentId === agentId)
-			.flatMap((tombstone) => {
-				const key = sourceGenerationKey(tombstone.source);
-				return key === undefined ? [] : [key];
-			}),
+			.map((tombstone) => sourceGenerationKey(tombstone.source)),
 	);
 }
 
-function sourceGenerationKey(source: SignetSourceEntry): string | undefined {
-	// A missing generation is unknown, not a shared legacy generation. Matching
-	// unknown tombstones to unknown configs permanently poisons source re-adds.
-	if (source.generation === undefined) return undefined;
-	return `${source.id}\u0000${source.generation}`;
+function sourceGenerationKey(source: SignetSourceEntry): string {
+	return `${source.id}\u0000${source.generation ?? legacySourceGeneration(source)}`;
+}
+
+function legacySourceGeneration(source: SignetSourceEntry): string {
+	return `legacy:${source.id}:${source.createdAt}:${source.updatedAt}`;
 }
 
 function isSourceVisibleToAgent(source: SignetSourceEntry, agentId: string): boolean {
@@ -726,19 +724,17 @@ export async function cleanupSourceDeletionTombstones(
 ): Promise<void> {
 	const tombstones = loadSourceDeletionTombstones(agentsDir);
 	if (tombstones.length === 0) return;
-	const configuredSources = new Map(loadSourcesConfig(agentsDir).sources.map((source) => [source.id, source]));
+	const configuredSources = loadSourcesConfig(agentsDir).sources;
 	const remaining: SourceDeletionTombstone[] = [];
 	for (const tombstone of tombstones) {
-		const configured = configuredSources.get(tombstone.source.id);
-		if (configured !== undefined && tombstone.source.generation === undefined) {
-			// Old tombstones cannot identify their deleted generation safely. The
-			// configured source is a live compatibility-normalized re-add. Drop the
-			// ambiguous marker, but do not purge rows belonging to the live source.
-			continue;
-		}
-		if (configured !== undefined && configured.generation === tombstone.source.generation) {
+		const configured = configuredSources.find((source: SignetSourceEntry) => source.id === tombstone.source.id);
+		if (
+			configured !== undefined &&
+			configured.generation === (tombstone.source.generation ?? legacySourceGeneration(tombstone.source))
+		) {
 			// Config removal is the final deletion-state transition. Keep the
-			// tombstone while this source generation is still non-live.
+			// tombstone while this source generation is still non-live. This also
+			// preserves a durable barrier for legacy records with no generation.
 			remaining.push(tombstone);
 			continue;
 		}

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -474,7 +474,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		const purged = provider ? await purgeSource(provider, source, sourceAgentId, purgeNativeSource) : 0;
 		const result = removeSource(sourceId, agentsDir);
 		if (result.ok === false) return c.json({ error: result.error }, 500);
-		if (!isSourceIndexInFlight(source.id)) clearSourceDeletionTombstone(source.id, sourceAgentId, agentsDir);
+		if (!isSourceIndexInFlight(source.id)) clearSourceDeletionTombstone(source, sourceAgentId, agentsDir);
 		return c.json({ source: result.source, purged });
 	});
 }
@@ -669,7 +669,7 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 		if (consumeCanceledSourceIndexJob(job.id) && !sourceIndexStopping) {
 			const provider = getSourceProvider(input.source.kind);
 			if (provider) await purgeSource(provider, input.source, resolveDaemonAgentId(), input.purgeNativeSource);
-			clearSourceDeletionTombstone(input.source.id, resolveDaemonAgentId(), input.agentsDir);
+			clearSourceDeletionTombstone(input.source, resolveDaemonAgentId(), input.agentsDir);
 		}
 		clearSourceIndexInFlight(input.source.id);
 	}
@@ -710,7 +710,12 @@ export async function cleanupSourceDeletionTombstones(
 	const configuredIds = new Set(loadSourcesConfig(agentsDir).sources.map((source) => source.id));
 	const remaining: SourceDeletionTombstone[] = [];
 	for (const tombstone of tombstones) {
-		if (configuredIds.has(tombstone.source.id)) continue;
+		if (configuredIds.has(tombstone.source.id)) {
+			// Config removal is the final deletion-state transition. Keep the
+			// tombstone while the configured source is still non-live.
+			remaining.push(tombstone);
+			continue;
+		}
 		const provider = getSourceProvider(tombstone.source.kind);
 		try {
 			await removeSourceLifecycleState(tombstone.source, tombstone.agentId);
@@ -754,9 +759,14 @@ function recordSourceDeletionTombstone(source: SignetSourceEntry, agentId: strin
 	);
 }
 
-function clearSourceDeletionTombstone(sourceId: string, agentId: string, agentsDir: string): void {
+function clearSourceDeletionTombstone(source: SignetSourceEntry, agentId: string, agentsDir: string): void {
+	// The canceled-index cleanup path can run after a failed config write. Keep
+	// the marker for the same source generation, but allow a deliberate
+	// reconnect to replace that generation and become live again.
+	const configured = loadSourcesConfig(agentsDir).sources.find((entry) => entry.id === source.id);
+	if (configured?.updatedAt === source.updatedAt) return;
 	const tombstones = loadSourceDeletionTombstones(agentsDir);
-	const next = tombstones.filter((entry) => entry.source.id !== sourceId || entry.agentId !== agentId);
+	const next = tombstones.filter((entry) => entry.source.id !== source.id || entry.agentId !== agentId);
 	if (next.length !== tombstones.length) saveSourceDeletionTombstones(next, agentsDir);
 }
 


### PR DESCRIPTION
## Summary

Closes #1630. A daemon startup tombstone cleanup can wait on the bounded async DB writer before HTTP binding. This PR moves that cleanup into the serialized post-ready runtime lane so the daemon can publish readiness without waiting on writer availability.

## Changes

- Remove the readiness-critical `await cleanupSourceDeletionTombstones(...)` from the pre-bind startup sequence.
- Run tombstone cleanup after deferred integrity work and before deferred pipeline startup, preserving the existing serialization and retry behavior.
- Log unexpected deferred cleanup failures loudly while retaining tombstones for retry.
- Add the #1630 blocked-writer regression probe and production-wiring assertions.
- Keep tombstoned sources out of the ready daemon's list, health, and snapshot read paths until deferred cleanup completes, while preserving the delete retry handle.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A. No migrations touched.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused proof:

- `bun test platform/daemon/src/routes/sources-routes.test.ts` passed: 40 tests, 233 assertions.
- `bun run --filter '@signet/core' build` passed.
- `bun run --filter '@signet/daemon' build` passed, including daemon `tsc --noEmit`.
- `bun run lint` exited 0 with pre-existing repository warnings.
- `bun run typecheck` remains blocked by unrelated pre-existing connector errors for missing generated bundles and stale `@signet/connector-base` exports; `@signet/daemon` itself passed.
- `git diff --check` passed.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The cleanup still runs and remains in the existing post-ready deferred lane before pipeline startup, so it does not race deferred pipeline writes. A blocked writer leaves the cleanup pending but no longer prevents HTTP readiness; releasing the writer completes the purge and removes the tombstone. Unexpected cleanup rejection is logged by the deferred startup path. Commit: `eb4cf82e5c855726bab8f4734f4792bec31936c9`.

