### PR TITLE
fix(daemon): resume startup FTS recovery

### DIFF
--- a/platform/daemon/src/daemon-production-wiring.test.ts
+++ b/platform/daemon/src/daemon-production-wiring.test.ts
@@ -16,6 +16,8 @@ describe("daemon production DB owner wiring", () => {
 			"dbOwnerMaintenanceHandle = createDbOwnerMaintenance({ dbPath: MEMORY_DB, owner: dbOwnerClient });",
 		);
 		expect(source).toContain("registerDbOwnerMaintenance(dbOwnerMaintenanceHandle);");
+		expect(source).toContain("deferredRuntimeScheduler.scheduleMaintenance(async (): Promise<void> => {");
+		expect(source).toContain("completeFtsStartupRecovery({");
 		expect(source).toContain("			telemetry,\n			dbOwnerMaintenanceHandle ?? undefined,\n		);");
 		expect(source).toContain("ownerMaintenance: dbOwnerMaintenanceHandle ?? undefined,");
 	});

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -69,6 +69,7 @@ import { getQueueDiagnosticsSnapshot, getQueuePressureSnapshot } from "./diagnos
 import { fetchEmbedding } from "./embedding-fetch";
 import { type EmbeddingIndexMigrationHandle, startEmbeddingIndexMigration } from "./embedding-index-migration";
 import { resolveActiveEmbeddingConfig } from "./embedding-index-state";
+import { completeFtsStartupRecovery } from "./fts-startup-recovery";
 import { type EmbeddingTrackerHandle, startEmbeddingTracker } from "./embedding-tracker";
 import { initFeatureFlags } from "./feature-flags";
 import { writeFileIfChangedAsync } from "./file-sync";
@@ -2069,17 +2070,6 @@ async function main() {
 	dbOwnerClient = createDbOwnerClient({ dbPath: MEMORY_DB });
 	dbOwnerMaintenanceHandle = createDbOwnerMaintenance({ dbPath: MEMORY_DB, owner: dbOwnerClient });
 	registerDbOwnerMaintenance(dbOwnerMaintenanceHandle);
-	// FTS recovery is intentionally handed to the killable DB owner. Startup
-	// only creates the schema above, so a large legacy index cannot block the
-	// daemon's event loop before it can serve degraded lexical recall.
-	void dbOwnerMaintenanceHandle
-		.backfillFts({ checkpointKey: "fts.memories.startup" })
-		.then((result) => logger.info("daemon", "FTS startup maintenance finished", { ...result }))
-		.catch((error) =>
-			logger.warn("daemon", "FTS startup maintenance deferred after owner failure", {
-				error: error instanceof Error ? error.message : String(error),
-			}),
-		);
 	// Clean accumulated crash-loop damage through the owner. This remains a
 	// deferred call, so owner startup and the bounded drain never delay readiness.
 	runStartupRecovery(getDbAccessor(), { owner: dbOwnerClient });
@@ -2332,6 +2322,12 @@ async function main() {
 				error: error instanceof Error ? error.message : String(error),
 			});
 		},
+		onMaintenanceError: (error): void => {
+			logger.warn("daemon", "Deferred FTS startup maintenance failed", {
+				error: error instanceof Error ? error.message : String(error),
+				cause: "fts_index_incomplete",
+			});
+		},
 	});
 
 	// Grace period: defer all background workers for 10s after startup so the
@@ -2460,6 +2456,19 @@ async function main() {
 			port: info.port,
 		});
 		logger.info("daemon", "Daemon ready");
+		deferredRuntimeScheduler.scheduleMaintenance(async (): Promise<void> => {
+			const maintenance = dbOwnerMaintenanceHandle;
+			if (maintenance === null) throw new Error("DB owner maintenance is unavailable for FTS startup recovery");
+			const result = await completeFtsStartupRecovery({
+				backfill: maintenance.backfillFts,
+				backfillOptions: { checkpointKey: "fts.memories.startup" },
+				scheduleContinuation: (callback): void => {
+					const timer = setTimeout(callback, 0);
+					timer.unref?.();
+				},
+			});
+			logger.info("daemon", "FTS startup maintenance finished", { ...result });
+		});
 		deferredRuntimeScheduler.scheduleIntegrity(async (): Promise<void> => {
 			logFdSnapshot("server-ready");
 			writeDaemonLifecycle(AGENTS_DIR, buildLifecycleRecord("running"));

--- a/platform/daemon/src/db-owner-maintenance.test.ts
+++ b/platform/daemon/src/db-owner-maintenance.test.ts
@@ -6,8 +6,9 @@ import { join } from "node:path";
 import { createDbOwnerMaintenance } from "./db-owner-maintenance";
 import { createDbOwnerClient } from "./db-owner-client";
 import { isFtsIndexIncomplete, setFtsIndexIncomplete } from "./fts-index-state";
+import { completeFtsStartupRecovery } from "./fts-startup-recovery";
 
-function makeDatabase(): { readonly directory: string; readonly path: string } {
+function makeDatabase(memoryCount = 7): { readonly directory: string; readonly path: string } {
 	const directory = mkdtempSync(join(tmpdir(), "signet-fts-owner-"));
 	const path = join(directory, "memory.db");
 	const db = new Database(path);
@@ -31,7 +32,7 @@ function makeDatabase(): { readonly directory: string; readonly path: string } {
 		CREATE VIRTUAL TABLE memories_fts USING fts5(content, content='memories', content_rowid='rowid', tokenize='unicode61');
 	`);
 	const insert = db.prepare("INSERT INTO memories (content) VALUES (?)");
-	for (let index = 0; index < 7; index += 1) insert.run(`owner backfill memory ${index}`);
+	for (let index = 0; index < memoryCount; index++) insert.run(`owner backfill memory ${index}`);
 	db.close();
 	return { directory, path };
 }
@@ -90,7 +91,9 @@ describe("DB owner FTS maintenance", () => {
 		const progress: number[] = [];
 		const result = await maintenance.backfillFts({
 			chunkSize: 2,
-			onChunk: (chunk) => progress.push(chunk.inserted),
+			onChunk: (chunk): void => {
+				progress.push(chunk.inserted);
+			},
 		});
 
 		expect(result.status).toBe("complete");
@@ -114,6 +117,31 @@ describe("DB owner FTS maintenance", () => {
 		const complete = await maintenance.backfillFts({ checkpointKey: "fts.cache", chunkSize: 2 });
 		expect(complete.status).toBe("complete");
 		expect(isFtsIndexIncomplete()).toBe(false);
+	});
+
+	test("resumes startup FTS recovery after the 10,000-unit cap (#1631)", async () => {
+		const database = makeDatabase(10_001);
+		directory = database.directory;
+		maintenance = createDbOwnerMaintenance({ dbPath: database.path });
+		setFtsIndexIncomplete(false);
+		const passes: Array<{ readonly status: string; readonly processed: number; readonly incomplete: boolean }> = [];
+
+		const result = await completeFtsStartupRecovery({
+			backfill: maintenance.backfillFts,
+			backfillOptions: { checkpointKey: "fts.memories.startup" },
+			scheduleContinuation: (callback): void => {
+				const timer = setTimeout(callback, 0);
+				timer.unref?.();
+			},
+			onPass: (pass) =>
+				passes.push({ status: pass.status, processed: pass.processed, incomplete: isFtsIndexIncomplete() }),
+		});
+
+		expect(passes[0]).toMatchObject({ status: "running", processed: 10_000, incomplete: true });
+		expect(result).toMatchObject({ status: "complete", processed: 10_001 });
+		expect(isFtsIndexIncomplete()).toBe(false);
+		expect(readFtsState(database.path)).toEqual({ memoryCount: 10_001, indexedCount: 10_001, physicalCount: 10_001 });
+		expect(countFtsMatches(database.path, "10000")).toBe(1);
 	});
 
 	test("converges after deleting a row below the active backfill cursor", async () => {

--- a/platform/daemon/src/deferred-runtime-gate.test.ts
+++ b/platform/daemon/src/deferred-runtime-gate.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { createDeferredRuntimeGate, scheduleDeferredRuntimeWork } from "./deferred-runtime-gate";
+import {
+	createDeferredRuntimeGate,
+	createDeferredRuntimeScheduler,
+	scheduleDeferredRuntimeWork,
+} from "./deferred-runtime-gate";
 
 describe("deferred runtime startup contention (#1609)", () => {
 	it("serializes both 30-second callbacks before pipeline startup", async () => {
@@ -51,5 +55,30 @@ describe("deferred runtime startup contention (#1609)", () => {
 		expect(maxOwnerActive).toBe(1);
 		expect(deadlineKills).toBe(0);
 		expect(pipelineFailure).toBeUndefined();
+	});
+
+	it("keeps FTS maintenance behind the deferred integrity gate", async () => {
+		const gate = createDeferredRuntimeGate();
+		const callbacks: Array<() => void> = [];
+		const events: string[] = [];
+
+		const scheduler = createDeferredRuntimeScheduler({
+			gate,
+			schedule: (callback) => callbacks.push(callback),
+			onPipelineError: (error) => events.push(`pipeline-error:${String(error)}`),
+			onMaintenanceError: (error) => events.push(`maintenance-error:${String(error)}`),
+		});
+		scheduler.scheduleMaintenance(async () => {
+			events.push("maintenance:start");
+		});
+
+		expect(callbacks).toHaveLength(1);
+		callbacks[0]?.();
+		await Bun.sleep(0);
+		expect(events).toEqual([]);
+
+		gate.completeIntegrity();
+		await Bun.sleep(0);
+		expect(events).toEqual(["maintenance:start"]);
 	});
 });

--- a/platform/daemon/src/deferred-runtime-gate.ts
+++ b/platform/daemon/src/deferred-runtime-gate.ts
@@ -10,6 +10,7 @@ export interface DeferredRuntimeScheduleOptions {
 	readonly startIntegrity: () => Promise<void>;
 	readonly startPipeline: () => Promise<void>;
 	readonly onPipelineError: (error: unknown) => void;
+	readonly onMaintenanceError?: (error: unknown) => void;
 }
 
 export interface DeferredRuntimeSchedulerOptions {
@@ -17,11 +18,13 @@ export interface DeferredRuntimeSchedulerOptions {
 	readonly delayMs?: number;
 	readonly schedule: (callback: () => void, delayMs: number) => unknown;
 	readonly onPipelineError: (error: unknown) => void;
+	readonly onMaintenanceError: (error: unknown) => void;
 }
 
 export interface DeferredRuntimeScheduler {
 	readonly scheduleIntegrity: (callback: () => Promise<void>) => void;
 	readonly schedulePipeline: (callback: () => Promise<void>) => void;
+	readonly scheduleMaintenance: (callback: () => Promise<void>) => void;
 }
 
 /**
@@ -56,12 +59,20 @@ export function createDeferredRuntimeScheduler(options: DeferredRuntimeScheduler
 				void options.gate.waitForIntegrity().then(callback).catch(options.onPipelineError);
 			}, delayMs);
 		},
+		scheduleMaintenance: (callback): void => {
+			options.schedule(() => {
+				void options.gate.waitForIntegrity().then(callback).catch(options.onMaintenanceError);
+			}, delayMs);
+		},
 	};
 }
 
 /** Schedule both deferred callbacks while serializing pipeline startup. */
 export function scheduleDeferredRuntimeWork(options: DeferredRuntimeScheduleOptions): void {
-	const scheduler = createDeferredRuntimeScheduler(options);
+	const scheduler = createDeferredRuntimeScheduler({
+		...options,
+		onMaintenanceError: options.onMaintenanceError ?? options.onPipelineError,
+	});
 	scheduler.scheduleIntegrity(options.startIntegrity);
 	scheduler.schedulePipeline(options.startPipeline);
 }

--- a/platform/daemon/src/fts-startup-recovery.ts
+++ b/platform/daemon/src/fts-startup-recovery.ts
@@ -1,0 +1,36 @@
+/**
+ * Resume bounded FTS owner work without keeping startup or the event loop busy.
+ *
+ * Each pass is capped by the owner maintenance implementation. Continuations
+ * are scheduled as separate callbacks so other deferred work can run between
+ * passes while the persistent checkpoint remains the source of truth.
+ */
+
+import type { FtsBackfillOptions, FtsBackfillResult } from "./db-owner-maintenance";
+
+export interface FtsStartupRecoveryOptions {
+	readonly backfill: (options?: FtsBackfillOptions) => Promise<FtsBackfillResult>;
+	readonly backfillOptions?: FtsBackfillOptions;
+	readonly scheduleContinuation: (callback: () => void) => void;
+	readonly onPass?: (result: FtsBackfillResult) => void;
+}
+
+function scheduleBackfillPass(options: FtsStartupRecoveryOptions): Promise<FtsBackfillResult> {
+	return new Promise<FtsBackfillResult>((resolve, reject) => {
+		options.scheduleContinuation(() => {
+			void options.backfill(options.backfillOptions).then(resolve, reject);
+		});
+	});
+}
+
+export async function completeFtsStartupRecovery(options: FtsStartupRecoveryOptions): Promise<FtsBackfillResult> {
+	let result = await options.backfill(options.backfillOptions);
+	options.onPass?.(result);
+
+	while (result.status === "running") {
+		result = await scheduleBackfillPass(options);
+		options.onPass?.(result);
+	}
+
+	return result;
+}


### PR DESCRIPTION
## Summary

Fixes startup FTS recovery for databases larger than the default 10,000 owner work-unit budget. The recovery now runs in the post-ready deferred maintenance lane and automatically resumes bounded owner passes until the durable checkpoint reaches `complete`.

closes #1631

## Changes

- Added a deferred FTS startup recovery loop that schedules each continuation as a separate callback.
- Added `scheduleMaintenance` to the deferred runtime gate so FTS work waits for integrity startup work and does not delay readiness.
- Kept the existing `fts_index_incomplete` signal active through every partial pass and surfaced owner failures loudly.
- Added the 10,001-row regression probe, including the incomplete degradation window, final FTS docsize count, and lexical MATCH result.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations touched.

## Testing

- [x] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused proof:

- `bun test platform/daemon/src/deferred-runtime-gate.test.ts platform/daemon/src/db-owner-maintenance.test.ts platform/daemon/src/daemon-production-wiring.test.ts` passed: 14 tests, 0 failures.
- `bun run --filter '@signet/daemon' typecheck` passed.
- `bun run --filter '@signet/daemon' build` passed.
- `bunx biome check` passed with three pre-existing unused-symbol warnings in `daemon.ts` and no errors.
- `git diff --check` passed.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The full root `bun run typecheck` was also run and remains blocked by unrelated pre-existing errors in connector packages, including `@signet/connector-base` export mismatches and missing generated connector bundles. No connector files were changed by this PR. The commit includes `Assisted-by: Hermes-Agent:gpt-5.6-luna`.

