### PR TITLE
feat(hermes): explicit target resolution and connector primitives

### DIFF
--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -4,7 +4,7 @@ import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rm
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { HermesAgentConnector, diagnoseHermesIntegration } from "./src/index.js";
+import { HermesAgentConnector, diagnoseHermesIntegration, ensureNamedAgentRegistered } from "./src/index.js";
 
 const originalEnv = {
 	HOME: process.env.HOME,
@@ -349,6 +349,28 @@ describe("HermesAgentConnector.isInstalled()", () => {
 			expect(existsSync(join(profileHome, ".env"))).toBe(true);
 			expect(existsSync(join(ambientHome, "plugins"))).toBe(false);
 			expect(process.env.HERMES_HOME).toBeUndefined();
+		});
+
+		it("does not mutate ambient AGENTS.md during a profile install", async () => {
+			const ambientAgents = join(tmpRoot, "AGENTS.md");
+			const original = "ambient\n<!-- SIGNET:START -->\nkeep\n<!-- SIGNET:END -->\n";
+			writeFileSync(ambientAgents, original);
+			const profileHome = join(tmpRoot, "profiles", "bot");
+			const result = await new HermesAgentConnector({ target: { kind: "profile", profile: "bot", home: profileHome } }).install(tmpRoot);
+			expect(result.success).toBe(true);
+			expect(readFileSync(ambientAgents, "utf-8")).toBe(original);
+		});
+
+		it("rejects a symlinked profile ancestor without writing outside the target root", async () => {
+			const outside = mkdtempSync(join(tmpdir(), "hermes-outside-"));
+			const link = join(tmpRoot, "profiles", "bot");
+			mkdirSync(join(tmpRoot, "profiles"), { recursive: true });
+			// Symlink creation is supported by the test platform and models the escape.
+			await Bun.write(join(tmpRoot, "profiles", "placeholder"), "");
+			const { symlinkSync } = await import("node:fs");
+			symlinkSync(outside, link);
+			await expect(new HermesAgentConnector({ target: { kind: "profile", profile: "bot", home: link } }).install(tmpRoot)).rejects.toThrow("symlinked");
+			expect(existsSync(join(outside, "plugins"))).toBe(false);
 		});
 	});
 	describe("HermesAgentConnector.install()", () => {
@@ -924,6 +946,54 @@ describe("HermesAgentConnector.isInstalled()", () => {
 		} finally {
 			globalThis.fetch = originalFetch;
 		}
+	});
+});
+
+describe("ensureNamedAgentRegistered result contract", () => {
+	const run = async (response: (url: string, init?: RequestInit) => Response | Promise<Response>, options: Parameters<typeof ensureNamedAgentRegistered>[1] = { agentId: "dot", strict: true }) => {
+		const originalFetch = globalThis.fetch;
+		const previousSkip = process.env.SIGNET_SKIP_AGENT_REGISTER;
+		delete process.env.SIGNET_SKIP_AGENT_REGISTER;
+		const warnings: string[] = [];
+		globalThis.fetch = (async (url, init) => response(String(url), init)) as typeof fetch;
+		try {
+			return { result: await ensureNamedAgentRegistered("http://daemon.test", options, warnings), warnings };
+		} finally {
+			globalThis.fetch = originalFetch;
+			if (previousSkip === undefined) delete process.env.SIGNET_SKIP_AGENT_REGISTER;
+			else process.env.SIGNET_SKIP_AGENT_REGISTER = previousSkip;
+		}
+	};
+
+	it("reuses an existing agent without POST", async () => {
+		const calls: string[] = [];
+		const { result } = await run((url) => { calls.push(url); return new Response(JSON.stringify({ id: "dot" }), { status: 200 }); });
+		expect(result).toEqual({ ok: true, created: false, agentId: "dot" });
+		expect(calls).toEqual(["http://daemon.test/api/agents/dot"]);
+	});
+
+	it("creates after a typed 404", async () => {
+		const calls: string[] = [];
+		const { result } = await run((url) => { calls.push(url); return new Response(url.endsWith("/dot") ? "missing" : JSON.stringify({ id: "dot" }), { status: url.endsWith("/dot") ? 404 : 201 }); });
+		expect(result).toEqual({ ok: true, created: true, agentId: "dot" });
+		expect(calls).toEqual(["http://daemon.test/api/agents/dot", "http://daemon.test/api/agents"]);
+	});
+
+	it("rejects invalid policy without POST", async () => {
+		process.env.SIGNET_AGENT_READ_POLICY = "bogus";
+		const calls: string[] = [];
+		const { result } = await run((url) => { calls.push(url); return new Response("missing", { status: 404 }); });
+		expect(result.ok).toBe(false);
+		expect(result).toHaveProperty("error", expect.stringContaining("invalid"));
+		expect(calls).toHaveLength(1);
+	});
+
+	it("returns actionable daemon failure without POST", async () => {
+		const calls: string[] = [];
+		const { result } = await run((url) => { calls.push(url); throw new Error("connection refused"); });
+		expect(result.ok).toBe(false);
+		expect(result).toHaveProperty("error", expect.stringContaining("unreachable"));
+		expect(calls).toHaveLength(1);
 	});
 });
 

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -334,7 +334,24 @@ describe("HermesAgentConnector.isInstalled()", () => {
 	});
 });
 
-describe("HermesAgentConnector.install()", () => {
+	describe("explicit Hermes targets", () => {
+		it("writes profile files only below the selected target home", async () => {
+			const profileHome = join(tmpRoot, "profiles", "bot");
+			const ambientHome = join(tmpRoot, ".hermes");
+			const connector = new HermesAgentConnector({
+				target: { kind: "profile", profile: "bot", home: profileHome },
+				agentId: "bot",
+			});
+			const result = await connector.install(tmpRoot);
+
+			expect(result.success).toBe(true);
+			expect(existsSync(join(profileHome, "plugins", "signet", "__init__.py"))).toBe(true);
+			expect(existsSync(join(profileHome, ".env"))).toBe(true);
+			expect(existsSync(join(ambientHome, "plugins"))).toBe(false);
+			expect(process.env.HERMES_HOME).toBeUndefined();
+		});
+	});
+	describe("HermesAgentConnector.install()", () => {
 	it("copies plugin files into both user and repo plugin locations when HERMES_REPO is set", async () => {
 		const hermesRepo = join(tmpRoot, "hermes-agent");
 		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -1751,6 +1751,19 @@ assert gets[0][0] == "/api/memory/search?q=new%20preference&limit=10&tags=hermes
 });
 
 describe("HermesAgentConnector.uninstall()", () => {
+	it("rejects a symlinked profile ancestor before uninstall can mutate an outside .env", async () => {
+		const outside = join(tmpRoot, "outside-profile");
+		const profiles = join(tmpRoot, "profiles");
+		mkdirSync(outside, { recursive: true });
+		symlinkSync(outside, profiles, "dir");
+		const outsideEnv = join(outside, ".env");
+		writeFileSync(outsideEnv, "KEEP=yes\nSIGNET_AGENT_ID=bot\n");
+
+		const connector = new HermesAgentConnector({ home: join(profiles, "bot"), kind: "profile" });
+		await expect(connector.uninstall()).rejects.toThrow(/symlinked|escapes validated root/);
+		expect(readFileSync(outsideEnv, "utf-8")).toBe("KEEP=yes\nSIGNET_AGENT_ID=bot\n");
+	});
+
 	it("removes the plugin directory and reports it in filesRemoved", async () => {
 		const hermesRepo = join(tmpRoot, "hermes-agent");
 		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -1,8 +1,8 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { BaseConnector, type InstallResult, type UninstallResult, resolveSignetApiKey } from "@signet/connector-base";
 import { expandHome, resolveHermesHomePath, resolveHermesRepoPath, type HermesTarget } from "@signet/core";
@@ -99,6 +99,21 @@ interface HermesProbeResult {
 	readonly error: string | null;
 }
 
+function assertContainedTargetPath(targetPath: string, targetRoot: string): void {
+	let rootPath = targetRoot;
+	while (!existsSync(rootPath)) {
+		const parent = dirname(rootPath);
+		if (parent === rootPath) throw new Error(`Hermes target root does not exist: ${targetRoot}`);
+		rootPath = parent;
+	}
+	const root = realpathSync(rootPath);
+	const candidate = existsSync(targetPath) ? realpathSync(targetPath) : join(root, relative(root, targetPath));
+	const rel = relative(root, candidate);
+	if (rel.startsWith("..") || isAbsolute(rel)) {
+		throw new Error(`Hermes target path escapes validated root: ${targetPath}`);
+	}
+}
+
 function getRepoPluginTargetDir(hermesRepo: string): string {
 	return join(hermesRepo, "plugins", "memory", "signet");
 }
@@ -112,7 +127,8 @@ function getProviderBackupPath(hermesHome: string): string {
 }
 
 /** Copy the Signet memory plugin into a Hermes plugin directory. */
-function installPlugin(targetDir: string, targetKind: InstallMarker["targetKind"]): string[] {
+function installPlugin(targetDir: string, targetKind: InstallMarker["targetKind"], targetRoot?: string): string[] {
+	if (targetRoot) assertContainedTargetPath(targetDir, targetRoot);
 	const sourceDir = getPluginSourceDir();
 
 	mkdirSync(targetDir, { recursive: true });
@@ -134,14 +150,12 @@ function installPlugin(targetDir: string, targetKind: InstallMarker["targetKind"
 
 /** Remove the Signet memory plugin from the Hermes plugins directory. */
 function uninstallPlugin(targetDir: string): string[] {
-	const removed: string[] = [];
-
-	if (existsSync(targetDir)) {
-		rmSync(targetDir, { recursive: true, force: true });
-		removed.push(targetDir);
+	if (!existsSync(targetDir)) return [];
+	if (!readInstallMarker(targetDir)) {
+		throw new Error(`Refusing to uninstall unowned Hermes plugin path: ${targetDir} (missing or invalid ${INSTALL_MARKER_FILE})`);
 	}
-
-	return removed;
+	rmSync(targetDir, { recursive: true, force: true });
+	return [targetDir];
 }
 
 // ---------------------------------------------------------------------------
@@ -808,6 +822,7 @@ export class HermesAgentConnector extends BaseConnector {
 		super();
 		if (options && "home" in options) {
 			this.target = options;
+			this.registration = { agentId: "", strict: options.kind === "profile" };
 		} else {
 			this.target = options?.target;
 			this.registration = options
@@ -821,6 +836,7 @@ export class HermesAgentConnector extends BaseConnector {
 	}
 
 	private getHermesRepo(): string | null {
+		if (this.target?.kind === "profile") return null;
 		return resolveHermesRepoPath();
 	}
 
@@ -839,13 +855,14 @@ export class HermesAgentConnector extends BaseConnector {
 		}
 
 		const hermesHome = this.getHermesHome();
+		if (this.target?.kind === "profile") assertContainedTargetPath(hermesHome, this.target.home);
 		const hermesRepo = this.getHermesRepo();
 		let userPluginInstalled = false;
 		let repoPluginInstalled = false;
 
 		// 1. Install the Python plugin into the current user-plugin location.
 		try {
-			const pluginFiles = installPlugin(getUserPluginTargetDir(hermesHome), "user");
+			const pluginFiles = installPlugin(getUserPluginTargetDir(hermesHome), "user", hermesHome);
 			filesWritten.push(...pluginFiles);
 			userPluginInstalled = true;
 		} catch (e) {
@@ -858,7 +875,7 @@ export class HermesAgentConnector extends BaseConnector {
 		// cannot shadow the fixed Signet provider.
 		if (hermesRepo) {
 			try {
-				const pluginFiles = installPlugin(getRepoPluginTargetDir(hermesRepo), "repo");
+				const pluginFiles = installPlugin(getRepoPluginTargetDir(hermesRepo), "repo", hermesRepo);
 				filesWritten.push(...pluginFiles);
 				repoPluginInstalled = true;
 			} catch (e) {

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -100,6 +100,9 @@ interface HermesProbeResult {
 }
 
 function resolveContainedWritePath(targetPath: string, targetRoot: string): string {
+	if (existsSync(targetRoot) && realpathSync(targetRoot) !== targetRoot) {
+		throw new Error(`Hermes target root is symlinked and cannot be used for writes: ${targetRoot}`);
+	}
 	let rootPath = targetRoot;
 	while (!existsSync(rootPath)) {
 		const parent = dirname(rootPath);
@@ -706,11 +709,13 @@ export type AgentRegistrationResult =
 	| { readonly ok: true; readonly created: boolean; readonly agentId: string }
 	| { readonly ok: false; readonly agentId: string; readonly error: string };
 
-function configuredAgentReadPolicy(warnings: string[]): AgentReadPolicy {
+function configuredAgentReadPolicy(warnings: string[], strict = false): AgentReadPolicy | null {
 	const raw = sanitizedEnv("SIGNET_AGENT_READ_POLICY") || sanitizedEnv("SIGNET_AGENT_MEMORY_POLICY");
 	if (!raw) return "shared";
 	if (raw === "isolated" || raw === "shared" || raw === "group") return raw;
-	warnings.push(`Ignoring unsupported SIGNET_AGENT_READ_POLICY '${raw}'. Expected one of: isolated, shared, group.`);
+	const error = `Unsupported SIGNET_AGENT_READ_POLICY '${raw}'. Expected one of: isolated, shared, group.`;
+	if (strict) return null;
+	warnings.push(`Ignoring ${error}`);
 	return "shared";
 }
 
@@ -745,7 +750,7 @@ async function resolveDaemonAgentId(daemonUrl: string): Promise<string | null> {
 	}
 }
 
-async function ensureNamedAgentRegistered(
+export async function ensureNamedAgentRegistered(
 	daemonUrl: string,
 	agentIdOrOptions: string | AgentRegistrationOptions,
 	warnings: string[],
@@ -781,11 +786,16 @@ async function ensureNamedAgentRegistered(
 				`Could not check Signet agent '${agentId}' before registration: HTTP ${getResp.status} ${body.slice(0, 200)}`,
 			);
 		}
-	} catch {
+	} catch (e) {
 		// Daemon may be offline; the POST below will produce the user-facing warning.
+		if (strict) {
+			const msg = e instanceof Error ? e.message : String(e);
+			return fail(`Could not check Signet agent '${agentId}' because the daemon was unreachable. (${msg})`);
+		}
 	}
 
-	const readPolicy = options.readPolicy ?? configuredAgentReadPolicy(warnings);
+	const readPolicy = options.readPolicy ?? configuredAgentReadPolicy(warnings, strict);
+	if (readPolicy === null) return fail(`Could not register Signet agent '${agentId}' because its read policy is invalid.`);
 	const policyGroup =
 		options.policyGroup !== undefined
 			? options.policyGroup

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -99,7 +99,7 @@ interface HermesProbeResult {
 	readonly error: string | null;
 }
 
-function assertContainedTargetPath(targetPath: string, targetRoot: string): void {
+function resolveContainedWritePath(targetPath: string, targetRoot: string): string {
 	let rootPath = targetRoot;
 	while (!existsSync(rootPath)) {
 		const parent = dirname(rootPath);
@@ -107,11 +107,24 @@ function assertContainedTargetPath(targetPath: string, targetRoot: string): void
 		rootPath = parent;
 	}
 	const root = realpathSync(rootPath);
-	const candidate = existsSync(targetPath) ? realpathSync(targetPath) : join(root, relative(root, targetPath));
+	let existing = targetPath;
+	const missing: string[] = [];
+	while (!existsSync(existing)) {
+		const parent = dirname(existing);
+		if (parent === existing) throw new Error(`Hermes target path does not have an existing ancestor: ${targetPath}`);
+		missing.unshift(existing.slice(parent.length + 1));
+		existing = parent;
+	}
+	const candidate = join(realpathSync(existing), ...missing);
 	const rel = relative(root, candidate);
 	if (rel.startsWith("..") || isAbsolute(rel)) {
 		throw new Error(`Hermes target path escapes validated root: ${targetPath}`);
 	}
+	return candidate;
+}
+
+function assertContainedTargetPath(targetPath: string, targetRoot: string): void {
+	resolveContainedWritePath(targetPath, targetRoot);
 }
 
 function getRepoPluginTargetDir(hermesRepo: string): string {
@@ -128,22 +141,22 @@ function getProviderBackupPath(hermesHome: string): string {
 
 /** Copy the Signet memory plugin into a Hermes plugin directory. */
 function installPlugin(targetDir: string, targetKind: InstallMarker["targetKind"], targetRoot?: string): string[] {
-	if (targetRoot) assertContainedTargetPath(targetDir, targetRoot);
+	const writeDir = targetRoot ? resolveContainedWritePath(targetDir, targetRoot) : targetDir;
 	const sourceDir = getPluginSourceDir();
 
-	mkdirSync(targetDir, { recursive: true });
+	mkdirSync(writeDir, { recursive: true });
 
 	const written: string[] = [];
 
 	for (const file of PLUGIN_FILES) {
 		const src = join(sourceDir, file);
-		const dst = join(targetDir, file);
+		const dst = join(writeDir, file);
 		if (existsSync(src)) {
 			writeFileSync(dst, readFileSync(src));
 			written.push(dst);
 		}
 	}
-	written.push(writeInstallMarker(targetDir, targetKind));
+	written.push(writeInstallMarker(writeDir, targetKind));
 
 	return written;
 }
@@ -152,7 +165,9 @@ function installPlugin(targetDir: string, targetKind: InstallMarker["targetKind"
 function uninstallPlugin(targetDir: string): string[] {
 	if (!existsSync(targetDir)) return [];
 	if (!readInstallMarker(targetDir)) {
-		throw new Error(`Refusing to uninstall unowned Hermes plugin path: ${targetDir} (missing or invalid ${INSTALL_MARKER_FILE})`);
+		throw new Error(
+			`Refusing to uninstall unowned Hermes plugin path: ${targetDir} (missing or invalid ${INSTALL_MARKER_FILE})`,
+		);
 	}
 	rmSync(targetDir, { recursive: true, force: true });
 	return [targetDir];
@@ -289,12 +304,13 @@ function setDottedProviderLine(lines: string[], line: number, value: string): vo
 
 function writeProviderBackup(
 	hermesHome: string,
+	targetRoot: string,
 	configPath: string,
 	providerKind: ProviderBackup["providerKind"],
 	previousProvider: string,
 ): string | null {
 	if (previousProvider === "signet") return null;
-	const backupPath = getProviderBackupPath(hermesHome);
+	const backupPath = resolveContainedWritePath(getProviderBackupPath(hermesHome), targetRoot);
 	if (existsSync(backupPath)) return null;
 	const backup: ProviderBackup = {
 		schemaVersion: 1,
@@ -365,8 +381,9 @@ function isProviderConfigured(hermesHome: string): boolean {
 function configureProvider(
 	hermesHome: string,
 	warnings: string[],
+	targetRoot: string = hermesHome,
 ): { configPath: string | null; backupPath: string | null } {
-	const configPath = resolveConfigPath(hermesHome);
+	const configPath = resolveContainedWritePath(resolveConfigPath(hermesHome), targetRoot);
 	let content = "";
 	if (existsSync(configPath)) {
 		try {
@@ -388,6 +405,7 @@ function configureProvider(
 		if (!dottedWasSignet) {
 			backupPath = writeProviderBackup(
 				hermesHome,
+				targetRoot,
 				configPath,
 				"dotted",
 				parseDottedProviderLine(lines[dottedProvider] ?? "") ?? "",
@@ -399,6 +417,7 @@ function configureProvider(
 			if (dottedWasSignet) {
 				const nestedBackupPath = writeProviderBackup(
 					hermesHome,
+					targetRoot,
 					configPath,
 					"nested",
 					parseProviderLine(lines[block.provider] ?? "") ?? "",
@@ -424,6 +443,7 @@ function configureProvider(
 		if (providerLineIsSignet(lines[block.provider] ?? "")) return { configPath: null, backupPath: null };
 		backupPath = writeProviderBackup(
 			hermesHome,
+			targetRoot,
 			configPath,
 			"nested",
 			parseProviderLine(lines[block.provider] ?? "") ?? "",
@@ -757,16 +777,21 @@ async function ensureNamedAgentRegistered(
 		if (getResp.ok) return { ok: true, created: false, agentId };
 		if (getResp.status !== 404) {
 			const body = await getResp.text();
-			return fail(`Could not check Signet agent '${agentId}' before registration: HTTP ${getResp.status} ${body.slice(0, 200)}`);
+			return fail(
+				`Could not check Signet agent '${agentId}' before registration: HTTP ${getResp.status} ${body.slice(0, 200)}`,
+			);
 		}
 	} catch {
 		// Daemon may be offline; the POST below will produce the user-facing warning.
 	}
 
 	const readPolicy = options.readPolicy ?? configuredAgentReadPolicy(warnings);
-	const policyGroup = options.policyGroup !== undefined
-		? options.policyGroup
-		: readPolicy === "group" ? sanitizedEnv("SIGNET_AGENT_POLICY_GROUP") || null : null;
+	const policyGroup =
+		options.policyGroup !== undefined
+			? options.policyGroup
+			: readPolicy === "group"
+				? sanitizedEnv("SIGNET_AGENT_POLICY_GROUP") || null
+				: null;
 	if (readPolicy === "group" && !policyGroup) {
 		if (strict) return fail(`Agent '${agentId}' requested group policy but no policy group was provided.`);
 		warnings.push(
@@ -792,12 +817,16 @@ async function ensureNamedAgentRegistered(
 		});
 		if (!resp.ok) {
 			const body = await resp.text();
-			return fail(`Could not register Signet agent '${agentId}' with ${effectiveReadPolicy} memory policy: ${body.slice(0, 200)}. ${policyHint}`);
+			return fail(
+				`Could not register Signet agent '${agentId}' with ${effectiveReadPolicy} memory policy: ${body.slice(0, 200)}. ${policyHint}`,
+			);
 		}
 		return { ok: true, created: true, agentId };
 	} catch (e) {
 		const msg = e instanceof Error ? e.message : String(e);
-		return fail(`Could not register Signet agent '${agentId}' because the daemon was unreachable. ${policyHint} (${msg})`);
+		return fail(
+			`Could not register Signet agent '${agentId}' because the daemon was unreachable. ${policyHint} (${msg})`,
+		);
 	}
 }
 
@@ -826,7 +855,12 @@ export class HermesAgentConnector extends BaseConnector {
 		} else {
 			this.target = options?.target;
 			this.registration = options
-				? { agentId: options.agentId ?? "", readPolicy: options.readPolicy, policyGroup: options.policyGroup, strict: options.target?.kind === "profile" }
+				? {
+						agentId: options.agentId ?? "",
+						readPolicy: options.readPolicy,
+						policyGroup: options.policyGroup,
+						strict: options.target?.kind === "profile",
+					}
 				: undefined;
 		}
 	}
@@ -849,12 +883,13 @@ export class HermesAgentConnector extends BaseConnector {
 		const configsPatched: string[] = [];
 		const warnings: string[] = [];
 		const expandedBasePath = expandHome(basePath || join(homedir(), ".agents"));
-		const strippedAgentsPath = this.stripLegacySignetBlock(expandedBasePath);
+		const hermesHome = this.getHermesHome();
+		const legacyAgentsBasePath = this.target?.kind === "profile" ? hermesHome : expandedBasePath;
+		const strippedAgentsPath = this.stripLegacySignetBlock(legacyAgentsBasePath);
 		if (strippedAgentsPath !== null) {
 			filesWritten.push(strippedAgentsPath);
 		}
 
-		const hermesHome = this.getHermesHome();
 		if (this.target?.kind === "profile") assertContainedTargetPath(hermesHome, this.target.home);
 		const hermesRepo = this.getHermesRepo();
 		let userPluginInstalled = false;
@@ -896,8 +931,10 @@ export class HermesAgentConnector extends BaseConnector {
 			};
 		}
 
-		// 2. Write env config for the Signet daemon connection
-		const envPath = join(hermesHome, ".env");
+		const envPath =
+			this.target?.kind === "profile"
+				? resolveContainedWritePath(join(hermesHome, ".env"), this.target.home)
+				: join(hermesHome, ".env");
 		let configuredSignetAgentId = "default";
 		const configuredDaemonUrl = (process.env.SIGNET_DAEMON_URL?.trim() || "http://127.0.0.1:3850").replace(
 			/[\r\n]+/g,
@@ -1007,7 +1044,11 @@ export class HermesAgentConnector extends BaseConnector {
 		}
 
 		// 3. Activate Signet as the external Hermes memory provider.
-		const providerConfig = configureProvider(hermesHome, warnings);
+		const providerConfig = configureProvider(
+			hermesHome,
+			warnings,
+			this.target?.kind === "profile" ? this.target.home : hermesHome,
+		);
 		if (providerConfig.configPath) {
 			configsPatched.push(providerConfig.configPath);
 		}

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -100,10 +100,16 @@ interface HermesProbeResult {
 }
 
 function resolveContainedWritePath(targetPath: string, targetRoot: string): string {
-	if (existsSync(targetRoot) && realpathSync(targetRoot) !== targetRoot) {
+	let rootPath = targetRoot;
+	while (!existsSync(rootPath)) {
+		const parent = dirname(rootPath);
+		if (parent === rootPath) throw new Error(`Hermes target root does not exist: ${targetRoot}`);
+		rootPath = parent;
+	}
+	if (realpathSync(rootPath) !== rootPath) {
 		throw new Error(`Hermes target root is symlinked and cannot be used for writes: ${targetRoot}`);
 	}
-	let rootPath = targetRoot;
+	rootPath = targetRoot;
 	while (!existsSync(rootPath)) {
 		const parent = dirname(rootPath);
 		if (parent === rootPath) throw new Error(`Hermes target root does not exist: ${targetRoot}`);
@@ -165,14 +171,15 @@ function installPlugin(targetDir: string, targetKind: InstallMarker["targetKind"
 }
 
 /** Remove the Signet memory plugin from the Hermes plugins directory. */
-function uninstallPlugin(targetDir: string): string[] {
+function uninstallPlugin(targetDir: string, targetRoot?: string): string[] {
 	if (!existsSync(targetDir)) return [];
-	if (!readInstallMarker(targetDir)) {
+	const safeTargetDir = targetRoot ? resolveContainedWritePath(targetDir, targetRoot) : targetDir;
+	if (!readInstallMarker(safeTargetDir)) {
 		throw new Error(
 			`Refusing to uninstall unowned Hermes plugin path: ${targetDir} (missing or invalid ${INSTALL_MARKER_FILE})`,
 		);
 	}
-	rmSync(targetDir, { recursive: true, force: true });
+	rmSync(safeTargetDir, { recursive: true, force: true });
 	return [targetDir];
 }
 
@@ -347,8 +354,10 @@ function readProviderBackup(hermesHome: string): ProviderBackup | null {
 	}
 }
 
-function removeProviderBackup(hermesHome: string): string | null {
-	const backupPath = getProviderBackupPath(hermesHome);
+function removeProviderBackup(hermesHome: string, targetRoot?: string): string | null {
+	const backupPath = targetRoot
+		? resolveContainedWritePath(getProviderBackupPath(hermesHome), targetRoot)
+		: getProviderBackupPath(hermesHome);
 	if (!existsSync(backupPath)) return null;
 	rmSync(backupPath, { force: true });
 	return backupPath;
@@ -464,9 +473,16 @@ function configureProvider(
 	return { configPath, backupPath };
 }
 
-function restoreOrClearProvider(hermesHome: string): { configPath: string | null; backupPath: string | null } {
+function restoreOrClearProvider(
+	hermesHome: string,
+	targetRoot?: string,
+): { configPath: string | null; backupPath: string | null } {
+	const safeConfigPath = targetRoot
+		? resolveContainedWritePath(resolveConfigPath(hermesHome), targetRoot)
+		: resolveConfigPath(hermesHome);
 	const config = readConfigYaml(hermesHome);
-	if (!config) return { configPath: null, backupPath: removeProviderBackup(hermesHome) };
+	if (!config) return { configPath: null, backupPath: removeProviderBackup(hermesHome, targetRoot) };
+	resolveContainedWritePath(config.path, targetRoot ?? hermesHome);
 	const lines = config.content.replace(/\r\n/g, "\n").split("\n");
 	const block = findMemoryBlock(lines);
 	const dottedProvider = findDottedProvider(lines);
@@ -496,11 +512,11 @@ function restoreOrClearProvider(hermesHome: string): { configPath: string | null
 		configChanged = true;
 	}
 	if (configChanged) {
-		writeFileSync(config.path, `${lines.join("\n").replace(/\n+$/g, "")}\n`);
+		writeFileSync(safeConfigPath, `${lines.join("\n").replace(/\n+$/g, "")}\n`);
 	}
 	return {
-		configPath: configChanged ? config.path : null,
-		backupPath: removeProviderBackup(hermesHome),
+		configPath: configChanged ? safeConfigPath : null,
+		backupPath: removeProviderBackup(hermesHome, targetRoot),
 	};
 }
 
@@ -1106,16 +1122,18 @@ export class HermesAgentConnector extends BaseConnector {
 
 		const hermesRepo = this.getHermesRepo();
 		if (hermesRepo) {
-			const removed = uninstallPlugin(getRepoPluginTargetDir(hermesRepo));
+			const removed = uninstallPlugin(getRepoPluginTargetDir(hermesRepo), hermesRepo);
 			filesRemoved.push(...removed);
 		}
 
 		// Clean up env vars
 		const hermesHome = this.getHermesHome();
-		const userPluginRemoved = uninstallPlugin(getUserPluginTargetDir(hermesHome));
+		const targetRoot = this.target?.kind === "profile" ? this.target.home : undefined;
+		if (targetRoot) assertContainedTargetPath(hermesHome, targetRoot);
+		const userPluginRemoved = uninstallPlugin(getUserPluginTargetDir(hermesHome), targetRoot);
 		filesRemoved.push(...userPluginRemoved);
 
-		const providerConfig = restoreOrClearProvider(hermesHome);
+		const providerConfig = restoreOrClearProvider(hermesHome, targetRoot);
 		if (providerConfig.configPath) {
 			configsPatched.push(providerConfig.configPath);
 		}
@@ -1123,7 +1141,9 @@ export class HermesAgentConnector extends BaseConnector {
 			filesRemoved.push(providerConfig.backupPath);
 		}
 
-		const envPath = join(hermesHome, ".env");
+		const envPath = targetRoot
+			? resolveContainedWritePath(join(hermesHome, ".env"), targetRoot)
+			: join(hermesHome, ".env");
 		if (existsSync(envPath)) {
 			try {
 				let envContent = readFileSync(envPath, "utf-8");

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -5,7 +5,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { BaseConnector, type InstallResult, type UninstallResult, resolveSignetApiKey } from "@signet/connector-base";
-import { expandHome, resolveHermesHomePath, resolveHermesRepoPath } from "@signet/core";
+import { expandHome, resolveHermesHomePath, resolveHermesRepoPath, type HermesTarget } from "@signet/core";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -660,6 +660,18 @@ function trustedOriginForDaemonUrl(daemonUrl: string): string | null {
 
 type AgentReadPolicy = "isolated" | "shared" | "group";
 
+export interface AgentRegistrationOptions {
+	readonly agentId: string;
+	readonly readPolicy?: AgentReadPolicy;
+	readonly policyGroup?: string | null;
+	/** Requested profile provisioning must fail closed instead of warning. */
+	readonly strict?: boolean;
+}
+
+export type AgentRegistrationResult =
+	| { readonly ok: true; readonly created: boolean; readonly agentId: string }
+	| { readonly ok: false; readonly agentId: string; readonly error: string };
+
 function configuredAgentReadPolicy(warnings: string[]): AgentReadPolicy {
 	const raw = sanitizedEnv("SIGNET_AGENT_READ_POLICY") || sanitizedEnv("SIGNET_AGENT_MEMORY_POLICY");
 	if (!raw) return "shared";
@@ -699,9 +711,23 @@ async function resolveDaemonAgentId(daemonUrl: string): Promise<string | null> {
 	}
 }
 
-async function ensureNamedAgentRegistered(daemonUrl: string, agentId: string, warnings: string[]): Promise<void> {
-	if (!agentId || agentId === "default" || agentId === "hermes-agent") return;
-	if (process.env.SIGNET_SKIP_AGENT_REGISTER === "1") return;
+async function ensureNamedAgentRegistered(
+	daemonUrl: string,
+	agentIdOrOptions: string | AgentRegistrationOptions,
+	warnings: string[],
+): Promise<AgentRegistrationResult> {
+	const options: AgentRegistrationOptions =
+		typeof agentIdOrOptions === "string" ? { agentId: agentIdOrOptions } : agentIdOrOptions;
+	const { agentId } = options;
+	const strict = options.strict === true;
+	const fail = (error: string): AgentRegistrationResult => {
+		if (!strict) warnings.push(error);
+		return { ok: false, agentId, error };
+	};
+	if (!agentId || agentId === "default" || agentId === "hermes-agent") {
+		return { ok: true, created: false, agentId };
+	}
+	if (process.env.SIGNET_SKIP_AGENT_REGISTER === "1") return { ok: true, created: false, agentId };
 
 	const baseUrl = trimTrailingSlashes(daemonUrl);
 	const token = sanitizedAuthTokenEnv();
@@ -714,21 +740,21 @@ async function ensureNamedAgentRegistered(daemonUrl: string, agentId: string, wa
 			headers,
 			signal: AbortSignal.timeout(1_000),
 		});
-		if (getResp.ok) return;
+		if (getResp.ok) return { ok: true, created: false, agentId };
 		if (getResp.status !== 404) {
 			const body = await getResp.text();
-			warnings.push(
-				`Could not check Signet agent '${agentId}' before registration: HTTP ${getResp.status} ${body.slice(0, 200)}`,
-			);
-			return;
+			return fail(`Could not check Signet agent '${agentId}' before registration: HTTP ${getResp.status} ${body.slice(0, 200)}`);
 		}
 	} catch {
 		// Daemon may be offline; the POST below will produce the user-facing warning.
 	}
 
-	const readPolicy = configuredAgentReadPolicy(warnings);
-	const policyGroup = readPolicy === "group" ? sanitizedEnv("SIGNET_AGENT_POLICY_GROUP") || null : null;
+	const readPolicy = options.readPolicy ?? configuredAgentReadPolicy(warnings);
+	const policyGroup = options.policyGroup !== undefined
+		? options.policyGroup
+		: readPolicy === "group" ? sanitizedEnv("SIGNET_AGENT_POLICY_GROUP") || null : null;
 	if (readPolicy === "group" && !policyGroup) {
+		if (strict) return fail(`Agent '${agentId}' requested group policy but no policy group was provided.`);
 		warnings.push(
 			`SIGNET_AGENT_READ_POLICY=group requires SIGNET_AGENT_POLICY_GROUP. Registering '${agentId}' with isolated memory instead.`,
 		);
@@ -752,15 +778,12 @@ async function ensureNamedAgentRegistered(daemonUrl: string, agentId: string, wa
 		});
 		if (!resp.ok) {
 			const body = await resp.text();
-			warnings.push(
-				`Could not register Signet agent '${agentId}' with ${effectiveReadPolicy} memory policy: ${body.slice(0, 200)}. ${policyHint}`,
-			);
+			return fail(`Could not register Signet agent '${agentId}' with ${effectiveReadPolicy} memory policy: ${body.slice(0, 200)}. ${policyHint}`);
 		}
+		return { ok: true, created: true, agentId };
 	} catch (e) {
 		const msg = e instanceof Error ? e.message : String(e);
-		warnings.push(
-			`Could not register Signet agent '${agentId}' because the daemon was unreachable. ` + `${policyHint} (${msg})`,
-		);
+		return fail(`Could not register Signet agent '${agentId}' because the daemon was unreachable. ${policyHint} (${msg})`);
 	}
 }
 
@@ -768,12 +791,33 @@ async function ensureNamedAgentRegistered(daemonUrl: string, agentId: string, wa
 // Connector
 // ---------------------------------------------------------------------------
 
+export interface HermesConnectorOptions {
+	readonly target?: HermesTarget;
+	readonly agentId?: string;
+	readonly readPolicy?: AgentReadPolicy;
+	readonly policyGroup?: string | null;
+}
+
 export class HermesAgentConnector extends BaseConnector {
 	readonly name = "Hermes Agent";
 	readonly harnessId = "hermes-agent";
+	private readonly target?: HermesTarget;
+	private readonly registration?: AgentRegistrationOptions;
+
+	constructor(options?: HermesTarget | HermesConnectorOptions) {
+		super();
+		if (options && "home" in options) {
+			this.target = options;
+		} else {
+			this.target = options?.target;
+			this.registration = options
+				? { agentId: options.agentId ?? "", readPolicy: options.readPolicy, policyGroup: options.policyGroup, strict: options.target?.kind === "profile" }
+				: undefined;
+		}
+	}
 
 	private getHermesHome(): string {
-		return resolveHermesHomePath();
+		return this.target?.home ?? resolveHermesHomePath();
 	}
 
 	private getHermesRepo(): string | null {
@@ -861,7 +905,7 @@ export class HermesAgentConnector extends BaseConnector {
 			// then "default" for the default workspace. The harness name
 			// ("hermes-agent") is provenance, never an agent id — a stale value
 			// from an older install is healed instead of honored.
-			let signetAgentId = sanitizedEnv("SIGNET_AGENT_ID");
+			let signetAgentId = this.registration?.agentId || sanitizedEnv("SIGNET_AGENT_ID");
 			if (signetAgentId === "hermes-agent") {
 				warnings.push(
 					"SIGNET_AGENT_ID='hermes-agent' is the harness name, not an agent scope. Re-resolving from the daemon.",
@@ -931,7 +975,19 @@ export class HermesAgentConnector extends BaseConnector {
 			warnings.push(`Failed to update .env: ${msg}`);
 		}
 
-		await ensureNamedAgentRegistered(configuredDaemonUrl, configuredSignetAgentId, warnings);
+		const registration = this.registration
+			? { ...this.registration, agentId: this.registration.agentId || configuredSignetAgentId }
+			: configuredSignetAgentId;
+		const registrationResult = await ensureNamedAgentRegistered(configuredDaemonUrl, registration, warnings);
+		if (!registrationResult.ok && this.target?.kind === "profile") {
+			return {
+				success: false,
+				message: registrationResult.error,
+				filesWritten,
+				configsPatched,
+				warnings,
+			};
+		}
 
 		// 3. Activate Signet as the external Hermes memory provider.
 		const providerConfig = configureProvider(hermesHome, warnings);

--- a/libs/connector-base/src/index.ts
+++ b/libs/connector-base/src/index.ts
@@ -33,7 +33,7 @@
  */
 
 import { randomBytes } from "node:crypto";
-import { existsSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative, sep } from "node:path";
 import {
@@ -118,6 +118,14 @@ export abstract class BaseConnector {
 		const raw = readFileSync(agentsPath, "utf-8");
 		const cleaned = stripSignetBlock(raw);
 		if (cleaned === raw) return null;
+		// Validate the final destination before creating the temporary file. This
+		// is also what protects symlinked ancestors from escaping basePath.
+		const root = realpathSync(basePath);
+		const parent = realpathSync(dirname(agentsPath));
+		const rel = relative(root, join(parent, "AGENTS.md"));
+		if (rel.startsWith("..") || isAbsolute(rel)) {
+			throw new Error(`Target path escapes validated root: ${agentsPath}`);
+		}
 		const tmp = join(basePath, `.${randomBytes(6).toString("hex")}.tmp`);
 		try {
 			writeFileSync(tmp, cleaned, "utf-8");

--- a/platform/core/src/__tests__/identity.test.ts
+++ b/platform/core/src/__tests__/identity.test.ts
@@ -8,6 +8,8 @@ import {
 	detectExistingSetup,
 	loadIdentityMode,
 	readStaticIdentity,
+	resolveHermesHomePath,
+	resolveHermesTarget,
 	resolvePromptSubmitTimeoutMs,
 	resolveSessionStartTimeoutMs,
 	resolveStartupIdentityFiles,
@@ -195,6 +197,29 @@ describe("readStaticIdentity", () => {
 		const result = readStaticIdentity(TMP) ?? "";
 		expect(result.indexOf("## About Your User")).toBeLessThan(result.indexOf("## Agent Instructions"));
 	});
+});
+
+describe("resolveHermesTarget", () => {
+	test("resolves ambient and isolated profile homes without changing env", () => {
+		process.env.HOME = TMP;
+		process.env.HERMES_HOME = join(TMP, "hermes");
+		const before = process.env.HERMES_HOME;
+		expect(resolveHermesTarget()).toEqual({ kind: "ambient", home: join(TMP, "hermes") });
+		expect(resolveHermesTarget("bot")).toEqual({
+			kind: "profile",
+			profile: "bot",
+			home: join(TMP, "hermes", "profiles", "bot"),
+		});
+		expect(resolveHermesHomePath()).toBe(before);
+		expect(process.env.HERMES_HOME).toBe(before);
+	});
+
+	for (const profile of ["../escape", "..", "/tmp/absolute", "a/b", "a\\\\b", ""]) {
+		if (profile === "") continue;
+		test(`rejects invalid profile '${profile}'`, () => {
+			expect(() => resolveHermesTarget(profile)).toThrow("Invalid Hermes profile name");
+		});
+	}
 });
 
 describe("parseSimpleYaml", () => {

--- a/platform/core/src/identity.ts
+++ b/platform/core/src/identity.ts
@@ -318,9 +318,37 @@ function isBinaryOnPath(bin: string): boolean {
 		.some((directory) => directory.length > 0 && existsSync(join(directory, bin)));
 }
 
+export interface HermesTarget {
+	readonly kind: "ambient" | "profile";
+	readonly home: string;
+	readonly profile?: string;
+}
+
+const HERMES_PROFILE_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/** Resolve the ambient Hermes home without mutating process.env. */
 export function resolveHermesHomePath(): string {
 	const hermesHome = process.env.HERMES_HOME?.trim();
 	return hermesHome || join(userHome(), ".hermes");
+}
+
+/**
+ * Resolve an explicit Hermes target. Named profiles are isolated directories
+ * below the ambient Hermes home; profile names never accept path separators,
+ * traversal, or absolute paths.
+ */
+export function resolveHermesTarget(profile?: string): HermesTarget {
+	if (profile === undefined || profile === "") {
+		return { kind: "ambient", home: resolveHermesHomePath() };
+	}
+	if (!HERMES_PROFILE_NAME.test(profile) || profile === "." || profile === "..") {
+		throw new Error(`Invalid Hermes profile name '${profile}'. Use letters, numbers, '.', '_' or '-' only.`);
+	}
+	return {
+		kind: "profile",
+		profile,
+		home: join(resolveHermesHomePath(), "profiles", profile),
+	};
 }
 
 /**

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -452,6 +452,7 @@ export {
 	STATIC_IDENTITY_SESSION_START_TIMEOUT_STATUS,
 	resolveAgentBasePath,
 	resolveHermesHomePath,
+	resolveHermesTarget,
 	resolveHermesRepoPath,
 	resolveKimiHomePath,
 	resolveHermesRepoPluginPath,
@@ -470,6 +471,7 @@ export type {
 	IdentityFile,
 	IdentityMap,
 	SetupDetection,
+	HermesTarget,
 } from "./identity";
 
 export {


### PR DESCRIPTION
## Summary

Repairs explicit Hermes profile installs after re-review:

- Resolves write paths through the nearest existing ancestor and rejects symlink escapes for plugins, environment, provider config, and backups.
- Restricts legacy AGENTS.md migration to the selected profile when an explicit target is used.
- Preserves strict typed registration failures for requested profile provisioning.

## Verification

- `bun install` at repository root
- `bun test integrations/hermes-agent/connector/index.test.ts`: 81 passed
- `bunx tsc --noEmit -p integrations/hermes-agent/connector/tsconfig.json`: passed
- `git diff --check`: passed

Assisted-by: Hermes-Agent:gpt-5.6-luna