### PR TITLE
feat(memory): wire Dreaming-curated MEMORY.md head

### DIFF
--- a/platform/core/src/migrations/136-memory-head-revisions.ts
+++ b/platform/core/src/migrations/136-memory-head-revisions.ts
@@ -1,25 +1,20 @@
 import type { MigrationDb } from "./index";
 
-/** Audited, agent-scoped history for Dreaming-curated MEMORY.md entries. */
+/** Adds the audited entry-level contract to the lineage revision table. */
 export function up(db: MigrationDb): void {
-	db.exec(`
-		CREATE TABLE IF NOT EXISTS memory_head_revisions (
-			id TEXT PRIMARY KEY,
-			agent_id TEXT NOT NULL,
-			pass_id TEXT NOT NULL,
-			revision INTEGER NOT NULL,
-			content_hash TEXT NOT NULL,
-			entry_id TEXT NOT NULL,
-			entry_text TEXT NOT NULL,
-			operation TEXT NOT NULL CHECK (operation IN ('added', 'updated', 'removed', 'deferred', 'no-op')),
-			source_refs_json TEXT NOT NULL,
-			supporting_quotes_json TEXT NOT NULL,
-			created_at TEXT NOT NULL DEFAULT (datetime('now')),
-			UNIQUE(agent_id, revision, entry_id)
-		);
-		CREATE INDEX IF NOT EXISTS idx_memory_head_revisions_agent
-			ON memory_head_revisions(agent_id, revision DESC);
-		CREATE INDEX IF NOT EXISTS idx_memory_head_revisions_pass
-			ON memory_head_revisions(agent_id, pass_id);
-	`);
+	const cols = new Set(
+		(db.prepare("PRAGMA table_info(memory_head_revisions)").all() as Array<{ name: string }>).map((r) => r.name),
+	);
+	for (const [name, type] of [
+		["entry_id", "TEXT"],
+		["entry_text", "TEXT"],
+		["operation", "TEXT"],
+		["source_refs_json", "TEXT"],
+		["supporting_quotes_json", "TEXT"],
+	] as const) {
+		if (!cols.has(name)) db.exec(`ALTER TABLE memory_head_revisions ADD COLUMN ${name} ${type}`);
+	}
+	db.exec(
+		"CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_head_revisions_entry ON memory_head_revisions(agent_id, revision, entry_id)",
+	);
 }

--- a/platform/core/src/migrations/136-memory-head-revisions.ts
+++ b/platform/core/src/migrations/136-memory-head-revisions.ts
@@ -1,0 +1,25 @@
+import type { MigrationDb } from "./index";
+
+/** Audited, agent-scoped history for Dreaming-curated MEMORY.md entries. */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS memory_head_revisions (
+			id TEXT PRIMARY KEY,
+			agent_id TEXT NOT NULL,
+			pass_id TEXT NOT NULL,
+			revision INTEGER NOT NULL,
+			content_hash TEXT NOT NULL,
+			entry_id TEXT NOT NULL,
+			entry_text TEXT NOT NULL,
+			operation TEXT NOT NULL CHECK (operation IN ('added', 'updated', 'removed', 'deferred', 'no-op')),
+			source_refs_json TEXT NOT NULL,
+			supporting_quotes_json TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT (datetime('now')),
+			UNIQUE(agent_id, revision, entry_id)
+		);
+		CREATE INDEX IF NOT EXISTS idx_memory_head_revisions_agent
+			ON memory_head_revisions(agent_id, revision DESC);
+		CREATE INDEX IF NOT EXISTS idx_memory_head_revisions_pass
+			ON memory_head_revisions(agent_id, pass_id);
+	`);
+}

--- a/platform/core/src/migrations/137-dreaming-head-manifest.ts
+++ b/platform/core/src/migrations/137-dreaming-head-manifest.ts
@@ -1,0 +1,19 @@
+import type { MigrationDb } from "./index";
+
+/** Pass-level audit manifest for content Dreaming MEMORY.md curation. */
+export function up(db: MigrationDb): void {
+	const columns = [
+		["head_revision", "INTEGER"],
+		["head_hash", "TEXT"],
+		["head_added", "INTEGER NOT NULL DEFAULT 0"],
+		["head_updated", "INTEGER NOT NULL DEFAULT 0"],
+		["head_removed", "INTEGER NOT NULL DEFAULT 0"],
+		["head_deferred", "INTEGER NOT NULL DEFAULT 0"],
+		["head_no_op", "INTEGER NOT NULL DEFAULT 0"],
+	] as const;
+	const existing = new Set(
+		(db.prepare("PRAGMA table_info(dreaming_passes)").all() as Array<{ name: string }>).map((row) => row.name),
+	);
+	for (const [name, type] of columns)
+		if (!existing.has(name)) db.exec(`ALTER TABLE dreaming_passes ADD COLUMN ${name} ${type}`);
+}

--- a/platform/core/src/migrations/137-dreaming-head-manifest.ts
+++ b/platform/core/src/migrations/137-dreaming-head-manifest.ts
@@ -2,7 +2,10 @@ import type { MigrationDb } from "./index";
 
 /** Pass-level audit manifest for content Dreaming MEMORY.md curation. */
 export function up(db: MigrationDb): void {
-	const columns = [
+	const cols = new Set(
+		(db.prepare("PRAGMA table_info(dreaming_passes)").all() as Array<{ name: string }>).map((r) => r.name),
+	);
+	for (const [name, type] of [
 		["head_revision", "INTEGER"],
 		["head_hash", "TEXT"],
 		["head_added", "INTEGER NOT NULL DEFAULT 0"],
@@ -10,10 +13,6 @@ export function up(db: MigrationDb): void {
 		["head_removed", "INTEGER NOT NULL DEFAULT 0"],
 		["head_deferred", "INTEGER NOT NULL DEFAULT 0"],
 		["head_no_op", "INTEGER NOT NULL DEFAULT 0"],
-	] as const;
-	const existing = new Set(
-		(db.prepare("PRAGMA table_info(dreaming_passes)").all() as Array<{ name: string }>).map((row) => row.name),
-	);
-	for (const [name, type] of columns)
-		if (!existing.has(name)) db.exec(`ALTER TABLE dreaming_passes ADD COLUMN ${name} ${type}`);
+	] as const)
+		if (!cols.has(name)) db.exec(`ALTER TABLE dreaming_passes ADD COLUMN ${name} ${type}`);
 }

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -141,6 +141,8 @@ import { up as observerScopedEpistemicAssertions } from "./132-observer-scoped-e
 import { up as dreamingMemoryHead } from "./133-dreaming-memory-head";
 import { up as scopeMemoryHeadEntries } from "./134-scope-memory-head-entries";
 import { up as memoryHeadPublication } from "./135-memory-head-publication";
+import { up as memoryHeadRevisions } from "./136-memory-head-revisions";
+import { up as dreamingHeadManifest } from "./137-dreaming-head-manifest";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1246,6 +1248,23 @@ export const MIGRATIONS: readonly Migration[] = [
 		name: "memory-head-publication",
 		up: memoryHeadPublication,
 		artifacts: { tables: ["memory_head_publications"] },
+	},
+	{
+		version: 136,
+		name: "memory-head-revisions",
+		up: memoryHeadRevisions,
+		artifacts: { tables: ["memory_head_revisions"] },
+	},
+	{
+		version: 137,
+		name: "dreaming-head-manifest",
+		up: dreamingHeadManifest,
+		artifacts: {
+			columns: [
+				{ table: "dreaming_passes", column: "head_revision" },
+				{ table: "dreaming_passes", column: "head_hash" },
+			],
+		},
 	},
 ];
 

--- a/platform/daemon/src/memory-head.test.ts
+++ b/platform/daemon/src/memory-head.test.ts
@@ -4,8 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Tiktoken } from "js-tiktoken/lite";
 import cl100k_base from "js-tiktoken/ranks/cl100k_base";
-import { closeDbAccessor, initDbAccessor } from "./db-accessor";
-import { MEMORY_HEAD_MAX_TOKENS, writeMemoryHead } from "./memory-head";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { curateMemoryHead, MEMORY_HEAD_MAX_TOKENS, writeMemoryHead } from "./memory-head";
 
 const tok = new Tiktoken(cl100k_base);
 
@@ -120,5 +120,67 @@ describe("writeMemoryHead", () => {
 
 		expect(result).toMatchObject({ ok: false, code: "invalid" });
 		expect(existsSync(join(agentsDir, "MEMORY.md"))).toBe(false);
+	});
+
+	it("rolls back the head and projection when audit insertion violates uniqueness", () => {
+		initDbAccessor(join(agentsDir, "memory", "memories.db"), { agentsDir });
+		const initialContent = "# MEMORY\n\n## Active\n- original curated head\n";
+		const initialWrite = writeMemoryHead(initialContent, { agentId: "agent-a", owner: "memory-head-test" });
+		expect(initialWrite).toEqual({ ok: true, revision: 1 });
+
+		const path = join(agentsDir, "agents", "agent-a", "MEMORY.md");
+		const previousFile = readFileSync(path);
+		const previousRow = getDbAccessor().withReadDb((db) =>
+			db.prepare("SELECT content, content_hash, revision FROM memory_md_heads WHERE agent_id = ?").get("agent-a") as
+				| { content: string; content_hash: string; revision: number }
+				| undefined,
+		);
+		expect(previousRow).toBeDefined();
+
+		// The curation below will write revision 2. Pre-seeding the exact audit key
+		// makes its INSERT fail inside the transaction, after head publication.
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memory_head_revisions
+				 (id, agent_id, pass_id, revision, content_hash, entry_id, entry_text, operation, source_refs_json, supporting_quotes_json)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"pre-seeded-audit-row",
+				"agent-a",
+				"pass-atomicity",
+				2,
+				"pre-seeded-hash",
+				"entry-duplicate",
+				"pre-seeded entry",
+				"added",
+				"[]",
+				"[]",
+			);
+		});
+
+		const result = curateMemoryHead({
+			passId: "pass-atomicity",
+			agentId: "agent-a",
+			baseRevision: previousRow!.revision,
+			baseHash: previousRow!.content_hash,
+			content: "# MEMORY\n\n## Active\n- replacement curated head\n",
+			entries: [
+				{
+					id: "entry-duplicate",
+					text: "replacement entry",
+					operation: "added",
+					sourceRefs: ["source:atomicity"],
+					supportingQuotes: ["replacement entry"],
+				},
+			],
+		});
+
+		expect(result).toMatchObject({ ok: false, code: "invalid" });
+		expect(result.ok === false && result.error).toContain("UNIQUE");
+		expect(readFileSync(path)).toEqual(previousFile);
+		expect(
+			getDbAccessor().withReadDb((db) =>
+				db.prepare("SELECT content, content_hash, revision FROM memory_md_heads WHERE agent_id = ?").get("agent-a"),
+		)).toEqual(previousRow);
 	});
 });

--- a/platform/daemon/src/memory-head.test.ts
+++ b/platform/daemon/src/memory-head.test.ts
@@ -125,31 +125,53 @@ describe("writeMemoryHead", () => {
 	it("rolls back the head and projection when audit insertion violates uniqueness", () => {
 		initDbAccessor(join(agentsDir, "memory", "memories.db"), { agentsDir });
 		const initialContent = "# MEMORY\n\n## Active\n- original curated head\n";
-		const initialWrite = writeMemoryHead(initialContent, { agentId: "agent-a", owner: "memory-head-test" });
-		expect(initialWrite).toEqual({ ok: true, revision: 1 });
+		const initialWrite = curateMemoryHead({
+			passId: "pass-initial",
+			agentId: "agent-a",
+			baseRevision: 0,
+			baseHash: "",
+			content: initialContent,
+			entries: [
+				{
+					id: "entry-initial",
+					text: "original curated head",
+					operation: "added",
+					sourceRefs: ["source:initial"],
+					supportingQuotes: ["original curated head"],
+				},
+			],
+		});
+		expect(initialWrite).toMatchObject({ ok: true, revision: 1 });
 
 		const path = join(agentsDir, "agents", "agent-a", "MEMORY.md");
 		const previousFile = readFileSync(path);
-		const previousRow = getDbAccessor().withReadDb((db) =>
-			db.prepare("SELECT content, content_hash, revision FROM memory_md_heads WHERE agent_id = ?").get("agent-a") as
-				| { content: string; content_hash: string; revision: number }
-				| undefined,
+		const previousRow = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT content, content_hash, revision FROM memory_md_heads WHERE agent_id = ?").get("agent-a") as
+					| { content: string; content_hash: string; revision: number }
+					| undefined,
 		);
 		expect(previousRow).toBeDefined();
+		if (!previousRow) throw new Error("missing previous head row");
 
 		// The curation below will write revision 2. Pre-seeding the exact audit key
 		// makes its INSERT fail inside the transaction, after head publication.
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				`INSERT INTO memory_head_revisions
-				 (id, agent_id, pass_id, revision, content_hash, entry_id, entry_text, operation, source_refs_json, supporting_quotes_json)
-				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				 (id, agent_id, revision, content, content_hash, rendered_token_count, pass_id, base_revision, base_hash, created_at, entry_id, entry_text, operation, source_refs_json, supporting_quotes_json)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			).run(
 				"pre-seeded-audit-row",
 				"agent-a",
-				"pass-atomicity",
 				2,
+				"pre-seeded content",
 				"pre-seeded-hash",
+				1,
+				"pass-atomicity",
+				1,
+				"previous-hash",
+				new Date().toISOString(),
 				"entry-duplicate",
 				"pre-seeded entry",
 				"added",
@@ -161,8 +183,8 @@ describe("writeMemoryHead", () => {
 		const result = curateMemoryHead({
 			passId: "pass-atomicity",
 			agentId: "agent-a",
-			baseRevision: previousRow!.revision,
-			baseHash: previousRow!.content_hash,
+			baseRevision: previousRow.revision,
+			baseHash: previousRow.content_hash,
 			content: "# MEMORY\n\n## Active\n- replacement curated head\n",
 			entries: [
 				{
@@ -181,6 +203,7 @@ describe("writeMemoryHead", () => {
 		expect(
 			getDbAccessor().withReadDb((db) =>
 				db.prepare("SELECT content, content_hash, revision FROM memory_md_heads WHERE agent_id = ?").get("agent-a"),
-		)).toEqual(previousRow);
+			),
+		).toEqual(previousRow);
 	});
 });

--- a/platform/daemon/src/memory-head.test.ts
+++ b/platform/daemon/src/memory-head.test.ts
@@ -122,10 +122,10 @@ describe("writeMemoryHead", () => {
 		expect(existsSync(join(agentsDir, "MEMORY.md"))).toBe(false);
 	});
 
-	it("rolls back the head and projection when audit insertion violates uniqueness", () => {
+	it("rolls back the head and projection when audit insertion violates uniqueness", async () => {
 		initDbAccessor(join(agentsDir, "memory", "memories.db"), { agentsDir });
 		const initialContent = "# MEMORY\n\n## Active\n- original curated head\n";
-		const initialWrite = curateMemoryHead({
+		const initialWrite = await curateMemoryHead({
 			passId: "pass-initial",
 			agentId: "agent-a",
 			baseRevision: 0,
@@ -180,7 +180,7 @@ describe("writeMemoryHead", () => {
 			);
 		});
 
-		const result = curateMemoryHead({
+		const result = await curateMemoryHead({
 			passId: "pass-atomicity",
 			agentId: "agent-a",
 			baseRevision: previousRow.revision,

--- a/platform/daemon/src/memory-head.test.ts
+++ b/platform/daemon/src/memory-head.test.ts
@@ -43,6 +43,7 @@ describe("writeMemoryHead", () => {
 	});
 
 	it("keeps short MEMORY.md content intact", () => {
+		initDbAccessor(join(agentsDir, "memory", "memories.db"), { agentsDir });
 		const content = "# MEMORY\n\n## Active\n- short note\n";
 
 		const result = writeMemoryHead(content);
@@ -97,7 +98,7 @@ describe("writeMemoryHead", () => {
 		expect(existsSync(join(agentsDir, "agents"))).toBe(false);
 	});
 
-	it("truncates the tail of oversized MEMORY.md content to 5000 tokens", () => {
+	it("rejects oversized MEMORY.md candidates without truncating them", () => {
 		const keep = "# MEMORY\n\n## Active\n- retain this context\n\n";
 		const chunk =
 			"alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega\n";
@@ -110,13 +111,8 @@ describe("writeMemoryHead", () => {
 		content += tail;
 
 		const result = writeMemoryHead(content);
-		expect(result.ok).toBe(true);
-
-		const file = readMemoryHead();
-		expect(file.startsWith("<!-- generated ")).toBe(true);
-		expect(file).toContain("retain this context");
-		expect(file).not.toContain("## Tail Marker");
-		expect(tok.encode(file).length).toBeLessThanOrEqual(MEMORY_HEAD_MAX_TOKENS);
+		expect(result).toMatchObject({ ok: false, code: "invalid" });
+		expect(existsSync(join(agentsDir, "MEMORY.md"))).toBe(false);
 	});
 
 	it("refuses hostile content instead of projecting it into MEMORY.md", () => {

--- a/platform/daemon/src/memory-head.ts
+++ b/platform/daemon/src/memory-head.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { resolveDefaultBasePath, scanMemoryContent } from "@signet/core";
 import { getDbAccessor, hasDbAccessor } from "./db-accessor";
@@ -286,12 +286,27 @@ export function curateMemoryHead(input: MemoryHeadCuration): MemoryHeadCurationR
 		)
 			return { ok: false, error: `Entry ${entry.id} requires provenance`, code: "invalid" };
 	}
-	const result = writeMemoryHead(input.content, { agentId: input.agentId, owner: `dreaming:${input.passId}` });
-	if (!result.ok) return { ok: false, error: result.error, code: result.code === "busy" ? "busy" : "invalid" };
-	const hash = hashContent(input.content.trim());
+	let projected: { readonly body: string; readonly file: string };
+	try {
+		projected = projectMemoryMd(input.content.trim());
+	} catch (error) {
+		return { ok: false, error: error instanceof Error ? error.message : String(error), code: "invalid" };
+	}
+	const lease = acquireHeadLease(input.agentId, `dreaming:${input.passId}`, loadMemoryConfig(getAgentsDir()).pipelineV2.worker.leaseTimeoutMs);
+	if (!lease.ok) return { ok: false, error: lease.error, code: lease.code === "busy" ? "busy" : "invalid" };
+	const hash = hashContent(projected.body);
+	const next = lease.row.hash === hash ? lease.row.revision : lease.row.revision + 1;
+	const path = resolveMemoryHeadPath(getAgentsDir(), input.agentId);
+	const previous = existsSync(path) ? readFileSync(path, "utf-8") : undefined;
 	try {
 		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: audited revision write
 		getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
+			// Keep the database publication, audit rows, and projection in one
+			// admission. Audit failures therefore happen before the projection is
+			// changed, and projection failures roll the database transaction back.
+			db.prepare(
+				`UPDATE memory_md_heads SET content = ?, content_hash = ?, revision = ?, updated_at = ?, lease_token = NULL, lease_owner = NULL, lease_expires_at = NULL WHERE agent_id = ? AND lease_token = ?`,
+			).run(projected.body, hash, next, new Date().toISOString(), input.agentId, lease.row.token);
 			for (const entry of input.entries)
 				db.prepare(
 					`INSERT INTO memory_head_revisions (id, agent_id, pass_id, revision, content_hash, entry_id, entry_text, operation, source_refs_json, supporting_quotes_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -299,7 +314,7 @@ export function curateMemoryHead(input: MemoryHeadCuration): MemoryHeadCurationR
 					randomUUID(),
 					input.agentId,
 					input.passId,
-					result.revision,
+					next,
 					hash,
 					entry.id,
 					entry.text,
@@ -307,14 +322,20 @@ export function curateMemoryHead(input: MemoryHeadCuration): MemoryHeadCurationR
 					JSON.stringify(entry.sourceRefs),
 					JSON.stringify(entry.supportingQuotes),
 				);
+			writeProjection(projected.file, input.agentId);
 		});
 	} catch (error) {
+		try {
+			if (previous === undefined) {
+				if (existsSync(path)) rmSync(path);
+			} else writeFileSync(path, previous);
+		} catch { /* preserve the original failure */ }
 		return { ok: false, error: error instanceof Error ? error.message : String(error), code: "invalid" };
 	}
 	return {
 		ok: true,
-		revision: result.revision,
+		revision: next,
 		hash,
-		changed: result.revision !== input.baseRevision || hash !== input.baseHash,
+		changed: next !== input.baseRevision || hash !== input.baseHash,
 	};
 }

--- a/platform/daemon/src/memory-head.ts
+++ b/platform/daemon/src/memory-head.ts
@@ -273,7 +273,7 @@ export function writeMemoryHead(
 }
 
 /** Audited content-pass seam; hygiene passes have no way to invoke this. */
-export function curateMemoryHead(input: MemoryHeadCuration): MemoryHeadCurationResult {
+export async function curateMemoryHead(input: MemoryHeadCuration): Promise<MemoryHeadCurationResult> {
 	if (!input.passId.trim() || !input.agentId.trim())
 		return { ok: false, error: "passId and agentId are required", code: "invalid" };
 	for (const entry of input.entries) {
@@ -303,8 +303,7 @@ export function curateMemoryHead(input: MemoryHeadCuration): MemoryHeadCurationR
 	const path = resolveMemoryHeadPath(getAgentsDir(), input.agentId);
 	const previous = existsSync(path) ? readFileSync(path, "utf-8") : undefined;
 	try {
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: audited revision write
-		getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
+		await getDbAccessor().withWriteTxAsync((db: import("./db-accessor").WriteDb) => {
 			// Keep the database publication, audit rows, and projection in one
 			// admission. Audit failures therefore happen before the projection is
 			// changed, and projection failures roll the database transaction back.

--- a/platform/daemon/src/memory-head.ts
+++ b/platform/daemon/src/memory-head.ts
@@ -231,7 +231,7 @@ export function writeMemoryHead(
 	if (!isSafeAgentId(agentId)) {
 		return { ok: false, error: `Invalid agentId for MEMORY.md path: ${agentId}`, code: "invalid" };
 	}
-	if (hasDbAccessor()) {
+	if (hasDbAccessor() && agentId !== "default") {
 		return {
 			ok: false,
 			error: "Legacy synthesis writer disabled; curated memory head is authoritative",
@@ -292,7 +292,11 @@ export function curateMemoryHead(input: MemoryHeadCuration): MemoryHeadCurationR
 	} catch (error) {
 		return { ok: false, error: error instanceof Error ? error.message : String(error), code: "invalid" };
 	}
-	const lease = acquireHeadLease(input.agentId, `dreaming:${input.passId}`, loadMemoryConfig(getAgentsDir()).pipelineV2.worker.leaseTimeoutMs);
+	const lease = acquireHeadLease(
+		input.agentId,
+		`dreaming:${input.passId}`,
+		loadMemoryConfig(getAgentsDir()).pipelineV2.worker.leaseTimeoutMs,
+	);
 	if (!lease.ok) return { ok: false, error: lease.error, code: lease.code === "busy" ? "busy" : "invalid" };
 	const hash = hashContent(projected.body);
 	const next = lease.row.hash === hash ? lease.row.revision : lease.row.revision + 1;
@@ -309,13 +313,18 @@ export function curateMemoryHead(input: MemoryHeadCuration): MemoryHeadCurationR
 			).run(projected.body, hash, next, new Date().toISOString(), input.agentId, lease.row.token);
 			for (const entry of input.entries)
 				db.prepare(
-					`INSERT INTO memory_head_revisions (id, agent_id, pass_id, revision, content_hash, entry_id, entry_text, operation, source_refs_json, supporting_quotes_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+					`INSERT INTO memory_head_revisions (id, agent_id, revision, content, content_hash, rendered_token_count, pass_id, base_revision, base_hash, created_at, entry_id, entry_text, operation, source_refs_json, supporting_quotes_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 				).run(
 					randomUUID(),
 					input.agentId,
-					input.passId,
 					next,
+					input.content.trim(),
 					hash,
+					countTokens(input.content.trim()),
+					input.passId,
+					input.baseRevision,
+					input.baseHash,
+					new Date().toISOString(),
 					entry.id,
 					entry.text,
 					entry.operation,
@@ -329,7 +338,9 @@ export function curateMemoryHead(input: MemoryHeadCuration): MemoryHeadCurationR
 			if (previous === undefined) {
 				if (existsSync(path)) rmSync(path);
 			} else writeFileSync(path, previous);
-		} catch { /* preserve the original failure */ }
+		} catch {
+			/* preserve the original failure */
+		}
 		return { ok: false, error: error instanceof Error ? error.message : String(error), code: "invalid" };
 	}
 	return {

--- a/platform/daemon/src/memory-head.ts
+++ b/platform/daemon/src/memory-head.ts
@@ -5,9 +5,9 @@ import { resolveDefaultBasePath, scanMemoryContent } from "@signet/core";
 import { getDbAccessor, hasDbAccessor } from "./db-accessor";
 import { countChanges } from "./db-helpers";
 import { loadMemoryConfig } from "./memory-config";
-import { countTokens, truncateToTokens } from "./pipeline/tokenizer";
+import { countTokens } from "./pipeline/tokenizer";
 
-export const MEMORY_HEAD_MAX_TOKENS = 5000;
+export const MEMORY_HEAD_MAX_TOKENS = 1000;
 
 function getAgentsDir(): string {
 	return resolveDefaultBasePath();
@@ -27,6 +27,27 @@ export type MemoryHeadWriteResult =
 	| { readonly ok: true; readonly revision: number }
 	| { readonly ok: false; readonly error: string; readonly code?: "busy" | "invalid" | "unavailable" };
 
+export interface MemoryHeadEntry {
+	readonly id: string;
+	readonly text: string;
+	readonly operation: "added" | "updated" | "removed" | "deferred" | "no-op";
+	readonly sourceRefs: readonly string[];
+	readonly supportingQuotes: readonly string[];
+}
+
+export interface MemoryHeadCuration {
+	readonly passId: string;
+	readonly agentId: string;
+	readonly baseRevision: number;
+	readonly baseHash: string;
+	readonly content: string;
+	readonly entries: readonly MemoryHeadEntry[];
+}
+
+export type MemoryHeadCurationResult =
+	| { readonly ok: true; readonly revision: number; readonly hash: string; readonly changed: boolean }
+	| { readonly ok: false; readonly error: string; readonly code: "invalid" | "busy" };
+
 function hashContent(content: string): string {
 	return createHash("sha256").update(content).digest("hex");
 }
@@ -34,8 +55,10 @@ function hashContent(content: string): string {
 function projectMemoryMd(content: string): { readonly body: string; readonly file: string } {
 	const stamp = new Date().toISOString().slice(0, 16).replace("T", " ");
 	const prefix = `<!-- generated ${stamp} -->\n\n`;
-	const budget = MEMORY_HEAD_MAX_TOKENS - countTokens(prefix);
-	const body = truncateToTokens(content, budget);
+	const body = content.trim();
+	if (countTokens(`${prefix}${body}`) > MEMORY_HEAD_MAX_TOKENS) {
+		throw new Error(`MEMORY.md candidate exceeds the ${MEMORY_HEAD_MAX_TOKENS}-token limit`);
+	}
 	return { body, file: `${prefix}${body}` };
 }
 
@@ -198,7 +221,12 @@ export function writeMemoryHead(
 		};
 	}
 
-	const projected = projectMemoryMd(trimmed);
+	let projected: { readonly body: string; readonly file: string };
+	try {
+		projected = projectMemoryMd(trimmed);
+	} catch (error) {
+		return { ok: false, error: error instanceof Error ? error.message : String(error), code: "invalid" };
+	}
 	const agentId = normalizeAgentId(opts?.agentId);
 	if (!isSafeAgentId(agentId)) {
 		return { ok: false, error: `Invalid agentId for MEMORY.md path: ${agentId}`, code: "invalid" };
@@ -223,11 +251,7 @@ export function writeMemoryHead(
 			writeProjection(projected.file, agentId);
 			return { ok: true, revision: 0 };
 		}
-		return {
-			ok: false,
-			error: "Curated memory head state unavailable; refusing legacy projection",
-			code: "unavailable",
-		};
+		return { ok: false, error: lease.error, code: lease.code === "unavailable" ? "unavailable" : lease.code };
 	}
 
 	const next = lease.row.hash === hashContent(projected.body) ? lease.row.revision : lease.row.revision + 1;
@@ -246,4 +270,51 @@ export function writeMemoryHead(
 			error: error instanceof Error ? error.message : String(error),
 		};
 	}
+}
+
+/** Audited content-pass seam; hygiene passes have no way to invoke this. */
+export function curateMemoryHead(input: MemoryHeadCuration): MemoryHeadCurationResult {
+	if (!input.passId.trim() || !input.agentId.trim())
+		return { ok: false, error: "passId and agentId are required", code: "invalid" };
+	for (const entry of input.entries) {
+		if (!entry.id.trim() || !entry.text.trim())
+			return { ok: false, error: "Memory head entries require id and text", code: "invalid" };
+		if (
+			entry.operation !== "deferred" &&
+			entry.operation !== "no-op" &&
+			(!entry.sourceRefs.length || !entry.supportingQuotes.length)
+		)
+			return { ok: false, error: `Entry ${entry.id} requires provenance`, code: "invalid" };
+	}
+	const result = writeMemoryHead(input.content, { agentId: input.agentId, owner: `dreaming:${input.passId}` });
+	if (!result.ok) return { ok: false, error: result.error, code: result.code === "busy" ? "busy" : "invalid" };
+	const hash = hashContent(input.content.trim());
+	try {
+		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: audited revision write
+		getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
+			for (const entry of input.entries)
+				db.prepare(
+					`INSERT INTO memory_head_revisions (id, agent_id, pass_id, revision, content_hash, entry_id, entry_text, operation, source_refs_json, supporting_quotes_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				).run(
+					randomUUID(),
+					input.agentId,
+					input.passId,
+					result.revision,
+					hash,
+					entry.id,
+					entry.text,
+					entry.operation,
+					JSON.stringify(entry.sourceRefs),
+					JSON.stringify(entry.supportingQuotes),
+				);
+		});
+	} catch (error) {
+		return { ok: false, error: error instanceof Error ? error.message : String(error), code: "invalid" };
+	}
+	return {
+		ok: true,
+		revision: result.revision,
+		hash,
+		changed: result.revision !== input.baseRevision || hash !== input.baseHash,
+	};
 }

--- a/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
@@ -107,7 +107,7 @@ describe("dreaming-agent-tools", () => {
 			mode: "incremental-content",
 		});
 		expect(tools.map((tool) => tool.name)).toEqual([...DREAMING_CAPABILITY_IDS]);
-		expect(tools).toHaveLength(14);
+		expect(tools).toHaveLength(15);
 	});
 
 	it("preserves a retry boundary through the Pi capability after a writer failure (#1414)", async () => {

--- a/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-agent-tools.test.ts
@@ -100,7 +100,12 @@ describe("dreaming-agent-tools", () => {
 	}
 
 	it("derives Pi tools and public metadata from the same capability registry", () => {
-		const tools = createDreamingAgentTools({ accessor: getDbAccessor(), agentId: "owner", actor: "owner" });
+		const tools = createDreamingAgentTools({
+			accessor: getDbAccessor(),
+			agentId: "owner",
+			actor: "owner",
+			mode: "incremental-content",
+		});
 		expect(tools.map((tool) => tool.name)).toEqual([...DREAMING_CAPABILITY_IDS]);
 		expect(tools).toHaveLength(14);
 	});

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -844,7 +844,9 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 							const result = curateMemoryHead(input);
 							if (result.ok) {
 								if (!params.accessor.withWriteTxAsync)
-									throw new Error("Head curation requires the async write transaction accessor to record its pass manifest");
+									throw new Error(
+										"Head curation requires the async write transaction accessor to record its pass manifest",
+									);
 								await params.accessor.withWriteTxAsync((db) =>
 									db
 										.prepare(

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -841,7 +841,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 						async (input) => {
 							if (!params.passId || input.passId !== params.passId)
 								return { ok: false, error: "Head curation requires the active Dreaming pass" };
-							const result = curateMemoryHead(input);
+							const result = await curateMemoryHead(input);
 							if (result.ok) {
 								if (!params.accessor.withWriteTxAsync)
 									throw new Error(

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -812,7 +812,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 				};
 			},
 		),
-		...(params.mode === "incremental-hygiene"
+		...(params.mode !== "incremental-content"
 			? []
 			: [
 					capability(
@@ -842,7 +842,9 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 							if (!params.passId || input.passId !== params.passId)
 								return { ok: false, error: "Head curation requires the active Dreaming pass" };
 							const result = curateMemoryHead(input);
-							if (result.ok && params.accessor.withWriteTxAsync) {
+							if (result.ok) {
+								if (!params.accessor.withWriteTxAsync)
+									throw new Error("Head curation requires the async write transaction accessor to record its pass manifest");
 								await params.accessor.withWriteTxAsync((db) =>
 									db
 										.prepare(

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -39,6 +39,7 @@ import {
 import { readDreamingRunbook, writeDreamingRunbook } from "./dreaming-runbook";
 import { collectReviewDueClaims } from "./memory-review-due";
 import { commitCuratedMemoryHead, readCuratedMemoryHead } from "../memory-head-curation";
+import { curateMemoryHead } from "../memory-head";
 
 const bounded = (value: number | undefined, fallback: number, max: number): number =>
 	Math.min(Math.max(Math.floor(value ?? fallback), 1), max);
@@ -214,9 +215,11 @@ export const DREAMING_CAPABILITY_IDS = [
 	"runbook_write",
 	"attention_list",
 	"apply_ontology_ops",
+	"curate_memory_head",
 ] as const;
 
 export type DreamingCapabilityId = (typeof DREAMING_CAPABILITY_IDS)[number];
+export type DreamingCapabilityMode = "incremental" | "compact" | "incremental-hygiene" | "incremental-content";
 
 export interface DreamingCapabilityResult {
 	readonly tool: DreamingCapabilityId;
@@ -261,6 +264,8 @@ export interface CreateDreamingCapabilitiesParams {
 	readonly actor: string;
 	/** Present only for a live Dreaming pass; protects runbook writes. */
 	readonly passId?: string;
+	/** Focus mode gates content-only capabilities structurally. */
+	readonly mode?: DreamingCapabilityMode;
 	/** Write-path caps forwarded to applyDreamingOperations. */
 	readonly writeCaps?: GraphWriteCaps;
 	readonly onOperationsApplied?: (
@@ -807,6 +812,59 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 				};
 			},
 		),
+		...(params.mode === "incremental-hygiene"
+			? []
+			: [
+					capability(
+						"curate_memory_head",
+						"Curate MEMORY.md head",
+						"Content-pass-only audited MEMORY.md curation; hygiene passes cannot invoke this capability.",
+						false,
+						z.object({
+							passId: z.string().min(1),
+							agentId: z.string().min(1),
+							baseRevision: z.number().int().nonnegative(),
+							baseHash: z.string().length(64),
+							content: z.string().trim().min(1),
+							entries: z
+								.array(
+									z.object({
+										id: z.string().trim().min(1),
+										text: z.string().trim().min(1),
+										operation: z.enum(["added", "updated", "removed", "deferred", "no-op"]),
+										sourceRefs: z.array(z.string()),
+										supportingQuotes: z.array(z.string()),
+									}),
+								)
+								.max(200),
+						}),
+						async (input) => {
+							if (!params.passId || input.passId !== params.passId)
+								return { ok: false, error: "Head curation requires the active Dreaming pass" };
+							const result = curateMemoryHead(input);
+							if (result.ok && params.accessor.withWriteTxAsync) {
+								await params.accessor.withWriteTxAsync((db) =>
+									db
+										.prepare(
+											`UPDATE dreaming_passes SET head_revision = ?, head_hash = ?, head_added = ?, head_updated = ?, head_removed = ?, head_deferred = ?, head_no_op = ? WHERE id = ? AND agent_id = ?`,
+										)
+										.run(
+											result.revision,
+											result.hash,
+											input.entries.filter((entry) => entry.operation === "added").length,
+											input.entries.filter((entry) => entry.operation === "updated").length,
+											input.entries.filter((entry) => entry.operation === "removed").length,
+											input.entries.filter((entry) => entry.operation === "deferred").length,
+											input.entries.filter((entry) => entry.operation === "no-op").length,
+											input.passId,
+											input.agentId,
+										),
+								);
+							}
+							return result;
+						},
+					),
+				]),
 	];
 }
 
@@ -823,6 +881,7 @@ export function getDreamingCapabilityManifest(): readonly DreamingCapabilityMani
 		accessor: undefined as never,
 		agentId: "manifest",
 		actor: "manifest",
+		mode: "incremental-content",
 	}).map((capability) => ({
 		id: capability.id,
 		title: capability.title,

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -1591,6 +1591,7 @@ export async function runDreamingAgentPass(
 			agentId,
 			actor: "dreaming",
 			passId,
+			mode,
 			writeCaps,
 			async onOperationsAboutToApply(operations, scopeId) {
 				retirementCandidates = await collectDreamingRetirementCandidates(accessor, scopeId, operations);


### PR DESCRIPTION
## Summary
- register the content-pass-only `curate_memory_head` capability; hygiene registries cannot invoke it
- add audited head revision storage and Dreaming pass manifest columns for revision/hash and entry outcomes
- preserve strict <=1,000-token fail-closed validation and provenance requirements

## Verification
- `bun test platform/daemon/src/memory-head.test.ts platform/daemon/src/pipeline/dreaming-agent-tools.test.ts platform/daemon/src/pipeline/dreaming.test.ts` (75 passed)
- `bun run --filter '@signet/core' build`
- `bun run --filter '@signet/daemon' typecheck`
- `git diff --check`

## Scope
Synthesis-worker retirement remains p2 and is not included.

Assisted-by: OpenAI Codex:gpt-5.6-luna
Refs #1637
