### PR TITLE
feat(cli): connect and disconnect Hermes profiles

### DIFF
--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -197,32 +197,19 @@ function writeHermesMemoryFixture(hermesRepo: string): void {
 beforeEach(() => {
 	tmpRoot = mkdtempSync(join(tmpdir(), "signet-hermes-connector-"));
 	process.env.HOME = tmpRoot;
-	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.PYTHON;
-	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.HERMES_REPO;
-	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.HERMES_HOME;
-	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_AGENT_ID;
-	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_AGENT_WORKSPACE;
-	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_DAEMON_URL;
-	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_TRUSTED_DAEMON_ORIGINS;
-	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_TOKEN;
-	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_AGENT_READ_POLICY;
-	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_AGENT_MEMORY_POLICY;
-	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_AGENT_POLICY_GROUP;
 	process.env.SIGNET_SKIP_AGENT_REGISTER = "1";
-	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_DIR;
-	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_CONNECTOR_ASSETS_DIR;
 });
 
@@ -779,7 +766,6 @@ describe("HermesAgentConnector.install()", () => {
 			const hermesHome = join(tmpRoot, ".hermes");
 			process.env.HERMES_REPO = hermesRepo;
 			process.env.HERMES_HOME = hermesHome;
-			// biome-ignore lint/performance/noDelete: exercise the daemon-resolved fallback
 			delete process.env.SIGNET_AGENT_ID;
 
 			const result = await new HermesAgentConnector().install(tmpRoot);
@@ -795,7 +781,7 @@ describe("HermesAgentConnector.install()", () => {
 
 	it("writes SIGNET_AGENT_ID=default, never the harness name, when the daemon is unreachable (#1084)", async () => {
 		const originalFetch = globalThis.fetch;
-		globalThis.fetch = (async (url: string | URL | Request, _init?: RequestInit): Promise<Response> => {
+		globalThis.fetch = (async (_url: string | URL | Request, _init?: RequestInit): Promise<Response> => {
 			throw new TypeError("fetch failed");
 		}) as typeof fetch;
 
@@ -805,7 +791,6 @@ describe("HermesAgentConnector.install()", () => {
 			const hermesHome = join(tmpRoot, ".hermes");
 			process.env.HERMES_REPO = hermesRepo;
 			process.env.HERMES_HOME = hermesHome;
-			// biome-ignore lint/performance/noDelete: exercise the default fallback
 			delete process.env.SIGNET_AGENT_ID;
 
 			const result = await new HermesAgentConnector().install(tmpRoot);
@@ -866,11 +851,9 @@ describe("HermesAgentConnector.install()", () => {
 			process.env.HERMES_REPO = hermesRepo;
 			process.env.HERMES_HOME = hermesHome;
 			process.env.SIGNET_AGENT_ID = "dot";
-			// biome-ignore lint/performance/noDelete: exercise the SIGNET_TOKEN fallback without a stale API key
 			delete process.env.SIGNET_API_KEY;
 			process.env.SIGNET_TOKEN = " test-token \n";
 			process.env.SIGNET_AGENT_READ_POLICY = "isolated";
-			// biome-ignore lint/performance/noDelete: this test exercises registration
 			delete process.env.SIGNET_SKIP_AGENT_REGISTER;
 
 			const result = await new HermesAgentConnector().install(tmpRoot);
@@ -905,7 +888,6 @@ describe("HermesAgentConnector.install()", () => {
 			process.env.HERMES_REPO = hermesRepo;
 			process.env.HERMES_HOME = hermesHome;
 			process.env.SIGNET_AGENT_ID = "dot";
-			// biome-ignore lint/performance/noDelete: this test exercises registration
 			delete process.env.SIGNET_SKIP_AGENT_REGISTER;
 
 			const result = await new HermesAgentConnector().install(tmpRoot);
@@ -941,7 +923,7 @@ describe("Hermes Agent bundled plugin", () => {
 	it("matches the shared recall request vectors exposed by Hermes", () => {
 		const clientPath = join(import.meta.dir, "hermes-plugin", "client.py");
 		const contractPath = join(import.meta.dir, "../../../platform/core/contracts/recall-request-v1.json");
-		const script = String.raw`
+		const script = `
 import importlib.util
 import json
 import sys
@@ -1069,7 +1051,7 @@ assert module.SignetClient().base_url == "http://127.0.0.1:3850"
 
 	it("serializes claim-only session-start recovery for the daemon (#1243)", () => {
 		const clientPath = join(import.meta.dir, "hermes-plugin", "client.py");
-		const script = String.raw`
+		const script = `
 import importlib.util
 import sys
 
@@ -1537,7 +1519,7 @@ assert calls == [{
 
 	it("sends mirror lineage, visibility, and audit provenance to the daemon", () => {
 		const clientPath = join(import.meta.dir, "hermes-plugin", "client.py");
-		const script = String.raw`
+		const script = `
 import importlib.util
 
 spec = importlib.util.spec_from_file_location("signet_client", __import__("sys").argv[1])
@@ -1934,7 +1916,6 @@ describe("HermesAgentConnector — native bundle (SIGNET_DIR) plugin resolution"
 		process.env.SIGNET_DIR = signetDir;
 		const hermesHome = join(tmpRoot, ".hermes");
 		process.env.HERMES_HOME = hermesHome;
-		// biome-ignore lint/performance/noDelete: ensure no repo path
 		delete process.env.HERMES_REPO;
 
 		const result = await new HermesAgentConnector().install(tmpRoot);
@@ -1973,7 +1954,6 @@ describe("HermesAgentConnector — native bundle (SIGNET_DIR) plugin resolution"
 
 		process.env.SIGNET_DIR = signetDir;
 		process.env.HERMES_HOME = join(tmpRoot, ".hermes");
-		// biome-ignore lint/performance/noDelete: ensure no repo path
 		delete process.env.HERMES_REPO;
 
 		const result = await new HermesAgentConnector().install(tmpRoot);
@@ -1991,7 +1971,6 @@ describe("HermesAgentConnector — native bundle (SIGNET_DIR) plugin resolution"
 
 		process.env.SIGNET_DIR = signetDir;
 		process.env.HERMES_HOME = join(tmpRoot, ".hermes");
-		// biome-ignore lint/performance/noDelete: ensure no repo path
 		delete process.env.HERMES_REPO;
 
 		const result = await new HermesAgentConnector().install(tmpRoot);
@@ -2013,7 +1992,6 @@ describe("HermesAgentConnector — native bundle (SIGNET_DIR) plugin resolution"
 
 		process.env.SIGNET_DIR = signetDir;
 		process.env.HERMES_HOME = join(tmpRoot, ".hermes");
-		// biome-ignore lint/performance/noDelete: ensure no repo path
 		delete process.env.HERMES_REPO;
 
 		try {
@@ -2040,7 +2018,6 @@ describe("HermesAgentConnector — native bundle (SIGNET_DIR) plugin resolution"
 		process.env.HERMES_HOME = hermesHome;
 		process.env.HERMES_REPO = hermesRepo;
 		process.env.PATH = pythonBinDir;
-		// biome-ignore lint/performance/noDelete: exercise the python3 default
 		delete process.env.PYTHON;
 
 		await new HermesAgentConnector().install(tmpRoot);
@@ -2066,7 +2043,6 @@ describe("HermesAgentConnector — native bundle (SIGNET_DIR) plugin resolution"
 		process.env.HERMES_HOME = hermesHome;
 		process.env.HERMES_REPO = hermesRepo;
 		process.env.PATH = pythonBinDir;
-		// biome-ignore lint/performance/noDelete: exercise the python fallback
 		delete process.env.PYTHON;
 
 		await new HermesAgentConnector().install(tmpRoot);

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -1,10 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	cpSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { HermesAgentConnector, diagnoseHermesIntegration, ensureNamedAgentRegistered } from "./src/index.js";
+import { HermesAgentConnector, diagnoseHermesIntegration } from "./src/index.js";
 
 const originalEnv = {
 	HOME: process.env.HOME,
@@ -334,46 +344,7 @@ describe("HermesAgentConnector.isInstalled()", () => {
 	});
 });
 
-	describe("explicit Hermes targets", () => {
-		it("writes profile files only below the selected target home", async () => {
-			const profileHome = join(tmpRoot, "profiles", "bot");
-			const ambientHome = join(tmpRoot, ".hermes");
-			const connector = new HermesAgentConnector({
-				target: { kind: "profile", profile: "bot", home: profileHome },
-				agentId: "bot",
-			});
-			const result = await connector.install(tmpRoot);
-
-			expect(result.success).toBe(true);
-			expect(existsSync(join(profileHome, "plugins", "signet", "__init__.py"))).toBe(true);
-			expect(existsSync(join(profileHome, ".env"))).toBe(true);
-			expect(existsSync(join(ambientHome, "plugins"))).toBe(false);
-			expect(process.env.HERMES_HOME).toBeUndefined();
-		});
-
-		it("does not mutate ambient AGENTS.md during a profile install", async () => {
-			const ambientAgents = join(tmpRoot, "AGENTS.md");
-			const original = "ambient\n<!-- SIGNET:START -->\nkeep\n<!-- SIGNET:END -->\n";
-			writeFileSync(ambientAgents, original);
-			const profileHome = join(tmpRoot, "profiles", "bot");
-			const result = await new HermesAgentConnector({ target: { kind: "profile", profile: "bot", home: profileHome } }).install(tmpRoot);
-			expect(result.success).toBe(true);
-			expect(readFileSync(ambientAgents, "utf-8")).toBe(original);
-		});
-
-		it("rejects a symlinked profile ancestor without writing outside the target root", async () => {
-			const outside = mkdtempSync(join(tmpdir(), "hermes-outside-"));
-			const link = join(tmpRoot, "profiles", "bot");
-			mkdirSync(join(tmpRoot, "profiles"), { recursive: true });
-			// Symlink creation is supported by the test platform and models the escape.
-			await Bun.write(join(tmpRoot, "profiles", "placeholder"), "");
-			const { symlinkSync } = await import("node:fs");
-			symlinkSync(outside, link);
-			await expect(new HermesAgentConnector({ target: { kind: "profile", profile: "bot", home: link } }).install(tmpRoot)).rejects.toThrow("symlinked");
-			expect(existsSync(join(outside, "plugins"))).toBe(false);
-		});
-	});
-	describe("HermesAgentConnector.install()", () => {
+describe("HermesAgentConnector.install()", () => {
 	it("copies plugin files into both user and repo plugin locations when HERMES_REPO is set", async () => {
 		const hermesRepo = join(tmpRoot, "hermes-agent");
 		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
@@ -946,54 +917,6 @@ describe("HermesAgentConnector.isInstalled()", () => {
 		} finally {
 			globalThis.fetch = originalFetch;
 		}
-	});
-});
-
-describe("ensureNamedAgentRegistered result contract", () => {
-	const run = async (response: (url: string, init?: RequestInit) => Response | Promise<Response>, options: Parameters<typeof ensureNamedAgentRegistered>[1] = { agentId: "dot", strict: true }) => {
-		const originalFetch = globalThis.fetch;
-		const previousSkip = process.env.SIGNET_SKIP_AGENT_REGISTER;
-		delete process.env.SIGNET_SKIP_AGENT_REGISTER;
-		const warnings: string[] = [];
-		globalThis.fetch = (async (url, init) => response(String(url), init)) as typeof fetch;
-		try {
-			return { result: await ensureNamedAgentRegistered("http://daemon.test", options, warnings), warnings };
-		} finally {
-			globalThis.fetch = originalFetch;
-			if (previousSkip === undefined) delete process.env.SIGNET_SKIP_AGENT_REGISTER;
-			else process.env.SIGNET_SKIP_AGENT_REGISTER = previousSkip;
-		}
-	};
-
-	it("reuses an existing agent without POST", async () => {
-		const calls: string[] = [];
-		const { result } = await run((url) => { calls.push(url); return new Response(JSON.stringify({ id: "dot" }), { status: 200 }); });
-		expect(result).toEqual({ ok: true, created: false, agentId: "dot" });
-		expect(calls).toEqual(["http://daemon.test/api/agents/dot"]);
-	});
-
-	it("creates after a typed 404", async () => {
-		const calls: string[] = [];
-		const { result } = await run((url) => { calls.push(url); return new Response(url.endsWith("/dot") ? "missing" : JSON.stringify({ id: "dot" }), { status: url.endsWith("/dot") ? 404 : 201 }); });
-		expect(result).toEqual({ ok: true, created: true, agentId: "dot" });
-		expect(calls).toEqual(["http://daemon.test/api/agents/dot", "http://daemon.test/api/agents"]);
-	});
-
-	it("rejects invalid policy without POST", async () => {
-		process.env.SIGNET_AGENT_READ_POLICY = "bogus";
-		const calls: string[] = [];
-		const { result } = await run((url) => { calls.push(url); return new Response("missing", { status: 404 }); });
-		expect(result.ok).toBe(false);
-		expect(result).toHaveProperty("error", expect.stringContaining("invalid"));
-		expect(calls).toHaveLength(1);
-	});
-
-	it("returns actionable daemon failure without POST", async () => {
-		const calls: string[] = [];
-		const { result } = await run((url) => { calls.push(url); throw new Error("connection refused"); });
-		expect(result.ok).toBe(false);
-		expect(result).toHaveProperty("error", expect.stringContaining("unreachable"));
-		expect(calls).toHaveLength(1);
 	});
 });
 
@@ -1750,20 +1673,39 @@ assert gets[0][0] == "/api/memory/search?q=new%20preference&limit=10&tags=hermes
 	});
 });
 
-describe("HermesAgentConnector.uninstall()", () => {
-	it("rejects a symlinked profile ancestor before uninstall can mutate an outside .env", async () => {
-		const outside = join(tmpRoot, "outside-profile");
-		const profiles = join(tmpRoot, "profiles");
-		mkdirSync(outside, { recursive: true });
-		symlinkSync(outside, profiles, "dir");
-		const outsideEnv = join(outside, ".env");
-		writeFileSync(outsideEnv, "KEEP=yes\nSIGNET_AGENT_ID=bot\n");
-
-		const connector = new HermesAgentConnector({ home: join(profiles, "bot"), kind: "profile" });
-		await expect(connector.uninstall()).rejects.toThrow(/symlinked|escapes validated root/);
-		expect(readFileSync(outsideEnv, "utf-8")).toBe("KEEP=yes\nSIGNET_AGENT_ID=bot\n");
+describe("HermesAgentConnector profile ownership boundaries", () => {
+	it("rejects a symlinked profile home before touching the victim directory", async () => {
+		const home = join(tmpRoot, "profile-home");
+		const victim = join(tmpRoot, "victim");
+		mkdirSync(join(home, ".hermes", "profiles"), { recursive: true });
+		mkdirSync(victim, { recursive: true });
+		symlinkSync(victim, join(home, ".hermes", "profiles", "escape"));
+		process.env.HOME = home;
+		process.env.HERMES_HOME = undefined;
+		await expect(new HermesAgentConnector().install(join(home, ".agents"), { profile: "escape" })).rejects.toThrow(
+			/(symlinked|escapes validated root)/,
+		);
+		expect(existsSync(join(victim, "plugins"))).toBe(false);
 	});
 
+	it("does not mutate an unowned profile during disconnect", async () => {
+		const home = join(tmpRoot, "profile-home-unowned");
+		const profile = join(home, ".hermes", "profiles", "unowned");
+		mkdirSync(profile, { recursive: true });
+		const config = "memory:\n  provider: signet\nother: keep\n";
+		const env = "UNRELATED=keep\nSIGNET_AGENT_ID=preserve\n";
+		writeFileSync(join(profile, "config.yaml"), config);
+		writeFileSync(join(profile, ".env"), env);
+		process.env.HOME = home;
+		process.env.HERMES_HOME = undefined;
+		const result = await new HermesAgentConnector().uninstall({ profile: "unowned" });
+		expect(result.filesRemoved).toEqual([]);
+		expect(readFileSync(join(profile, "config.yaml"), "utf8")).toBe(config);
+		expect(readFileSync(join(profile, ".env"), "utf8")).toBe(env);
+	});
+});
+
+describe("HermesAgentConnector.uninstall()", () => {
 	it("removes the plugin directory and reports it in filesRemoved", async () => {
 		const hermesRepo = join(tmpRoot, "hermes-agent");
 		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -5,7 +5,7 @@ import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { BaseConnector, type InstallResult, type UninstallResult, resolveSignetApiKey } from "@signet/connector-base";
-import { expandHome, resolveHermesHomePath, resolveHermesRepoPath, type HermesTarget } from "@signet/core";
+import { expandHome, resolveHermesHomePath, resolveHermesRepoPath } from "@signet/core";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -116,12 +116,6 @@ function resolveContainedWritePath(targetPath: string, targetRoot: string): stri
 	if (realpathSync(rootPath) !== rootPath) {
 		throw new Error(`Hermes target root is symlinked and cannot be used for writes: ${targetRoot}`);
 	}
-	rootPath = targetRoot;
-	while (!existsSync(rootPath)) {
-		const parent = dirname(rootPath);
-		if (parent === rootPath) throw new Error(`Hermes target root does not exist: ${targetRoot}`);
-		rootPath = parent;
-	}
 	const root = realpathSync(rootPath);
 	let existing = targetPath;
 	const missing: string[] = [];
@@ -137,10 +131,6 @@ function resolveContainedWritePath(targetPath: string, targetRoot: string): stri
 		throw new Error(`Hermes target path escapes validated root: ${targetPath}`);
 	}
 	return candidate;
-}
-
-function assertContainedTargetPath(targetPath: string, targetRoot: string): void {
-	resolveContainedWritePath(targetPath, targetRoot);
 }
 
 function getRepoPluginTargetDir(hermesRepo: string): string {
@@ -321,13 +311,12 @@ function setDottedProviderLine(lines: string[], line: number, value: string): vo
 
 function writeProviderBackup(
 	hermesHome: string,
-	targetRoot: string,
 	configPath: string,
 	providerKind: ProviderBackup["providerKind"],
 	previousProvider: string,
 ): string | null {
 	if (previousProvider === "signet") return null;
-	const backupPath = resolveContainedWritePath(getProviderBackupPath(hermesHome), targetRoot);
+	const backupPath = getProviderBackupPath(hermesHome);
 	if (existsSync(backupPath)) return null;
 	const backup: ProviderBackup = {
 		schemaVersion: 1,
@@ -400,9 +389,8 @@ function isProviderConfigured(hermesHome: string): boolean {
 function configureProvider(
 	hermesHome: string,
 	warnings: string[],
-	targetRoot: string = hermesHome,
 ): { configPath: string | null; backupPath: string | null } {
-	const configPath = resolveContainedWritePath(resolveConfigPath(hermesHome), targetRoot);
+	const configPath = resolveConfigPath(hermesHome);
 	let content = "";
 	if (existsSync(configPath)) {
 		try {
@@ -424,7 +412,6 @@ function configureProvider(
 		if (!dottedWasSignet) {
 			backupPath = writeProviderBackup(
 				hermesHome,
-				targetRoot,
 				configPath,
 				"dotted",
 				parseDottedProviderLine(lines[dottedProvider] ?? "") ?? "",
@@ -436,7 +423,6 @@ function configureProvider(
 			if (dottedWasSignet) {
 				const nestedBackupPath = writeProviderBackup(
 					hermesHome,
-					targetRoot,
 					configPath,
 					"nested",
 					parseProviderLine(lines[block.provider] ?? "") ?? "",
@@ -462,7 +448,6 @@ function configureProvider(
 		if (providerLineIsSignet(lines[block.provider] ?? "")) return { configPath: null, backupPath: null };
 		backupPath = writeProviderBackup(
 			hermesHome,
-			targetRoot,
 			configPath,
 			"nested",
 			parseProviderLine(lines[block.provider] ?? "") ?? "",
@@ -489,7 +474,7 @@ function restoreOrClearProvider(
 		: resolveConfigPath(hermesHome);
 	const config = readConfigYaml(hermesHome);
 	if (!config) return { configPath: null, backupPath: removeProviderBackup(hermesHome, targetRoot) };
-	resolveContainedWritePath(config.path, targetRoot ?? hermesHome);
+	if (targetRoot) resolveContainedWritePath(config.path, targetRoot);
 	const lines = config.content.replace(/\r\n/g, "\n").split("\n");
 	const block = findMemoryBlock(lines);
 	const dottedProvider = findDottedProvider(lines);
@@ -720,25 +705,12 @@ function trustedOriginForDaemonUrl(daemonUrl: string): string | null {
 
 type AgentReadPolicy = "isolated" | "shared" | "group";
 
-export interface AgentRegistrationOptions {
-	readonly agentId: string;
-	readonly readPolicy?: AgentReadPolicy;
-	readonly policyGroup?: string | null;
-	/** Requested profile provisioning must fail closed instead of warning. */
-	readonly strict?: boolean;
-}
-
-export type AgentRegistrationResult =
-	| { readonly ok: true; readonly created: boolean; readonly agentId: string }
-	| { readonly ok: false; readonly agentId: string; readonly error: string };
-
-function configuredAgentReadPolicy(warnings: string[], strict = false): AgentReadPolicy | null {
+function configuredAgentReadPolicy(warnings: string[], options: HermesConnectorOptions = {}): AgentReadPolicy {
+	if (options.memoryPolicy) return options.memoryPolicy;
 	const raw = sanitizedEnv("SIGNET_AGENT_READ_POLICY") || sanitizedEnv("SIGNET_AGENT_MEMORY_POLICY");
 	if (!raw) return "shared";
 	if (raw === "isolated" || raw === "shared" || raw === "group") return raw;
-	const error = `Unsupported SIGNET_AGENT_READ_POLICY '${raw}'. Expected one of: isolated, shared, group.`;
-	if (strict) return null;
-	warnings.push(`Ignoring ${error}`);
+	warnings.push(`Ignoring unsupported SIGNET_AGENT_READ_POLICY '${raw}'. Expected one of: isolated, shared, group.`);
 	return "shared";
 }
 
@@ -773,23 +745,14 @@ async function resolveDaemonAgentId(daemonUrl: string): Promise<string | null> {
 	}
 }
 
-export async function ensureNamedAgentRegistered(
+async function ensureNamedAgentRegistered(
 	daemonUrl: string,
-	agentIdOrOptions: string | AgentRegistrationOptions,
+	agentId: string,
 	warnings: string[],
-): Promise<AgentRegistrationResult> {
-	const options: AgentRegistrationOptions =
-		typeof agentIdOrOptions === "string" ? { agentId: agentIdOrOptions } : agentIdOrOptions;
-	const { agentId } = options;
-	const strict = options.strict === true;
-	const fail = (error: string): AgentRegistrationResult => {
-		if (!strict) warnings.push(error);
-		return { ok: false, agentId, error };
-	};
-	if (!agentId || agentId === "default" || agentId === "hermes-agent") {
-		return { ok: true, created: false, agentId };
-	}
-	if (process.env.SIGNET_SKIP_AGENT_REGISTER === "1") return { ok: true, created: false, agentId };
+	options: HermesConnectorOptions = {},
+): Promise<string | null> {
+	if (!agentId || agentId === "default" || agentId === "hermes-agent") return null;
+	if (process.env.SIGNET_SKIP_AGENT_REGISTER === "1") return null;
 
 	const baseUrl = trimTrailingSlashes(daemonUrl);
 	const token = sanitizedAuthTokenEnv();
@@ -802,36 +765,25 @@ export async function ensureNamedAgentRegistered(
 			headers,
 			signal: AbortSignal.timeout(1_000),
 		});
-		if (getResp.ok) return { ok: true, created: false, agentId };
+		if (getResp.ok) return null;
 		if (getResp.status !== 404) {
 			const body = await getResp.text();
-			return fail(
+			warnings.push(
 				`Could not check Signet agent '${agentId}' before registration: HTTP ${getResp.status} ${body.slice(0, 200)}`,
 			);
+			return null;
 		}
-	} catch (e) {
+	} catch {
 		// Daemon may be offline; the POST below will produce the user-facing warning.
-		if (strict) {
-			const msg = e instanceof Error ? e.message : String(e);
-			return fail(`Could not check Signet agent '${agentId}' because the daemon was unreachable. (${msg})`);
-		}
 	}
 
-	const readPolicy = options.readPolicy ?? configuredAgentReadPolicy(warnings, strict);
-	if (readPolicy === null) return fail(`Could not register Signet agent '${agentId}' because its read policy is invalid.`);
+	const readPolicy = configuredAgentReadPolicy(warnings, options);
 	const policyGroup =
-		options.policyGroup !== undefined
-			? options.policyGroup
-			: readPolicy === "group"
-				? sanitizedEnv("SIGNET_AGENT_POLICY_GROUP") || null
-				: null;
+		readPolicy === "group" ? options.policyGroup?.trim() || sanitizedEnv("SIGNET_AGENT_POLICY_GROUP") || null : null;
 	if (readPolicy === "group" && !policyGroup) {
-		if (strict) return fail(`Agent '${agentId}' requested group policy but no policy group was provided.`);
-		warnings.push(
-			`SIGNET_AGENT_READ_POLICY=group requires SIGNET_AGENT_POLICY_GROUP. Registering '${agentId}' with isolated memory instead.`,
-		);
+		return `Group memory policy for '${agentId}' requires --group or SIGNET_AGENT_POLICY_GROUP.`;
 	}
-	const effectiveReadPolicy: AgentReadPolicy = readPolicy === "group" && !policyGroup ? "isolated" : readPolicy;
+	const effectiveReadPolicy: AgentReadPolicy = readPolicy;
 	const policyHint =
 		effectiveReadPolicy === "shared"
 			? `Run: signet agent create ${agentId} --memory shared, or use --memory isolated for private memory.`
@@ -850,60 +802,38 @@ export async function ensureNamedAgentRegistered(
 		});
 		if (!resp.ok) {
 			const body = await resp.text();
-			return fail(
-				`Could not register Signet agent '${agentId}' with ${effectiveReadPolicy} memory policy: ${body.slice(0, 200)}. ${policyHint}`,
-			);
+			return `Could not register Signet agent '${agentId}' with ${effectiveReadPolicy} memory policy: ${body.slice(0, 200)}. ${policyHint}`;
 		}
-		return { ok: true, created: true, agentId };
 	} catch (e) {
 		const msg = e instanceof Error ? e.message : String(e);
-		return fail(
-			`Could not register Signet agent '${agentId}' because the daemon was unreachable. ${policyHint} (${msg})`,
-		);
+		return `Could not register Signet agent '${agentId}' because the daemon was unreachable. ${policyHint} (${msg})`;
 	}
+	return null;
 }
 
 // ---------------------------------------------------------------------------
 // Connector
 // ---------------------------------------------------------------------------
 
-export interface HermesConnectorOptions {
-	readonly target?: HermesTarget;
-	readonly agentId?: string;
-	readonly readPolicy?: AgentReadPolicy;
-	readonly policyGroup?: string | null;
-}
-
 export class HermesAgentConnector extends BaseConnector {
 	readonly name = "Hermes Agent";
 	readonly harnessId = "hermes-agent";
-	private readonly target?: HermesTarget;
-	private readonly registration?: AgentRegistrationOptions;
-
-	constructor(options?: HermesTarget | HermesConnectorOptions) {
-		super();
-		if (options && "home" in options) {
-			this.target = options;
-			this.registration = { agentId: "", strict: options.kind === "profile" };
-		} else {
-			this.target = options?.target;
-			this.registration = options
-				? {
-						agentId: options.agentId ?? "",
-						readPolicy: options.readPolicy,
-						policyGroup: options.policyGroup,
-						strict: options.target?.kind === "profile",
-					}
-				: undefined;
-		}
-	}
+	private targetOptions: HermesConnectorOptions = {};
 
 	private getHermesHome(): string {
-		return this.target?.home ?? resolveHermesHomePath();
+		if (this.targetOptions.profile) {
+			if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(this.targetOptions.profile)) {
+				throw new Error("Invalid Hermes profile name; use 1-64 letters, numbers, '.', '_' or '-'.");
+			}
+			const userHome = process.env.HOME?.trim() || homedir();
+			const profileHome = join(userHome, ".hermes", "profiles", this.targetOptions.profile);
+			return resolveContainedWritePath(profileHome, join(userHome, ".hermes", "profiles"));
+		}
+		return resolveHermesHomePath();
 	}
 
 	private getHermesRepo(): string | null {
-		if (this.target?.kind === "profile") return null;
+		if (this.targetOptions.profile) return null;
 		return resolveHermesRepoPath();
 	}
 
@@ -917,21 +847,23 @@ export class HermesAgentConnector extends BaseConnector {
 		const configsPatched: string[] = [];
 		const warnings: string[] = [];
 		const expandedBasePath = expandHome(basePath || join(homedir(), ".agents"));
-		const hermesHome = this.getHermesHome();
-		const legacyAgentsBasePath = this.target?.kind === "profile" ? hermesHome : expandedBasePath;
-		const strippedAgentsPath = this.stripLegacySignetBlock(legacyAgentsBasePath);
+		const strippedAgentsPath = options.profile ? null : this.stripLegacySignetBlock(expandedBasePath);
 		if (strippedAgentsPath !== null) {
 			filesWritten.push(strippedAgentsPath);
 		}
 
-		if (this.target?.kind === "profile") assertContainedTargetPath(hermesHome, this.target.home);
+		const hermesHome = this.getHermesHome();
 		const hermesRepo = this.getHermesRepo();
 		let userPluginInstalled = false;
 		let repoPluginInstalled = false;
 
 		// 1. Install the Python plugin into the current user-plugin location.
 		try {
-			const pluginFiles = installPlugin(getUserPluginTargetDir(hermesHome), "user", hermesHome);
+			const pluginFiles = installPlugin(
+				getUserPluginTargetDir(hermesHome),
+				"user",
+				options.profile ? hermesHome : undefined,
+			);
 			filesWritten.push(...pluginFiles);
 			userPluginInstalled = true;
 		} catch (e) {
@@ -944,7 +876,7 @@ export class HermesAgentConnector extends BaseConnector {
 		// cannot shadow the fixed Signet provider.
 		if (hermesRepo) {
 			try {
-				const pluginFiles = installPlugin(getRepoPluginTargetDir(hermesRepo), "repo", hermesRepo);
+				const pluginFiles = installPlugin(getRepoPluginTargetDir(hermesRepo), "repo");
 				filesWritten.push(...pluginFiles);
 				repoPluginInstalled = true;
 			} catch (e) {
@@ -965,10 +897,8 @@ export class HermesAgentConnector extends BaseConnector {
 			};
 		}
 
-		const envPath =
-			this.target?.kind === "profile"
-				? resolveContainedWritePath(join(hermesHome, ".env"), this.target.home)
-				: join(hermesHome, ".env");
+		// 2. Write env config for the Signet daemon connection
+		const envPath = join(hermesHome, ".env");
 		let configuredSignetAgentId = "default";
 		const configuredDaemonUrl = (process.env.SIGNET_DAEMON_URL?.trim() || "http://127.0.0.1:3850").replace(
 			/[\r\n]+/g,
@@ -993,7 +923,7 @@ export class HermesAgentConnector extends BaseConnector {
 			// then "default" for the default workspace. The harness name
 			// ("hermes-agent") is provenance, never an agent id — a stale value
 			// from an older install is healed instead of honored.
-			let signetAgentId = this.registration?.agentId || sanitizedEnv("SIGNET_AGENT_ID");
+			let signetAgentId = sanitizedEnv("SIGNET_AGENT_ID");
 			if (signetAgentId === "hermes-agent") {
 				warnings.push(
 					"SIGNET_AGENT_ID='hermes-agent' is the harness name, not an agent scope. Re-resolving from the daemon.",
@@ -1063,26 +993,18 @@ export class HermesAgentConnector extends BaseConnector {
 			warnings.push(`Failed to update .env: ${msg}`);
 		}
 
-		const registration = this.registration
-			? { ...this.registration, agentId: this.registration.agentId || configuredSignetAgentId }
-			: configuredSignetAgentId;
-		const registrationResult = await ensureNamedAgentRegistered(configuredDaemonUrl, registration, warnings);
-		if (!registrationResult.ok && this.target?.kind === "profile") {
-			return {
-				success: false,
-				message: registrationResult.error,
-				filesWritten,
-				configsPatched,
-				warnings,
-			};
+		const registrationError = await ensureNamedAgentRegistered(
+			configuredDaemonUrl,
+			configuredSignetAgentId,
+			warnings,
+			options,
+		);
+		if (registrationError) {
+			return { success: false, message: registrationError, filesWritten, configsPatched, warnings };
 		}
 
 		// 3. Activate Signet as the external Hermes memory provider.
-		const providerConfig = configureProvider(
-			hermesHome,
-			warnings,
-			this.target?.kind === "profile" ? this.target.home : hermesHome,
-		);
+		const providerConfig = configureProvider(hermesHome, warnings);
 		if (providerConfig.configPath) {
 			configsPatched.push(providerConfig.configPath);
 		}
@@ -1131,18 +1053,19 @@ export class HermesAgentConnector extends BaseConnector {
 
 		const hermesRepo = this.getHermesRepo();
 		if (hermesRepo) {
-			const removed = uninstallPlugin(getRepoPluginTargetDir(hermesRepo), hermesRepo);
+			const removed = uninstallPlugin(getRepoPluginTargetDir(hermesRepo));
 			filesRemoved.push(...removed);
 		}
 
-		// Clean up env vars
 		const hermesHome = this.getHermesHome();
-		const targetRoot = this.target?.kind === "profile" ? this.target.home : undefined;
-		if (targetRoot) assertContainedTargetPath(hermesHome, targetRoot);
-		const userPluginRemoved = uninstallPlugin(getUserPluginTargetDir(hermesHome), targetRoot);
+		const userPluginTarget = getUserPluginTargetDir(hermesHome);
+		if (options.profile && (!existsSync(userPluginTarget) || readInstallMarker(userPluginTarget) === null)) {
+			return { filesRemoved, configsPatched };
+		}
+		const userPluginRemoved = uninstallPlugin(userPluginTarget, options.profile ? hermesHome : undefined);
 		filesRemoved.push(...userPluginRemoved);
 
-		const providerConfig = restoreOrClearProvider(hermesHome, targetRoot);
+		const providerConfig = restoreOrClearProvider(hermesHome, options.profile ? hermesHome : undefined);
 		if (providerConfig.configPath) {
 			configsPatched.push(providerConfig.configPath);
 		}
@@ -1150,9 +1073,7 @@ export class HermesAgentConnector extends BaseConnector {
 			filesRemoved.push(providerConfig.backupPath);
 		}
 
-		const envPath = targetRoot
-			? resolveContainedWritePath(join(hermesHome, ".env"), targetRoot)
-			: join(hermesHome, ".env");
+		const envPath = join(hermesHome, ".env");
 		if (existsSync(envPath)) {
 			try {
 				let envContent = readFileSync(envPath, "utf-8");

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -156,7 +156,7 @@ function installPlugin(targetDir: string, targetKind: InstallMarker["targetKind"
 
 	for (const file of PLUGIN_FILES) {
 		const src = join(sourceDir, file);
-		const dst = join(writeDir, file);
+		const dst = targetRoot ? resolveContainedWritePath(join(writeDir, file), targetRoot) : join(writeDir, file);
 		if (existsSync(src)) {
 			writeFileSync(dst, readFileSync(src));
 			written.push(dst);
@@ -184,19 +184,21 @@ function uninstallPlugin(targetDir: string, targetRoot?: string): string[] {
 // Config patching
 // ---------------------------------------------------------------------------
 
-function getConfigCandidates(hermesHome: string): string[] {
-	return [join(hermesHome, "config.yaml"), join(hermesHome, "cli-config.yaml")];
+function getConfigCandidates(hermesHome: string, targetRoot?: string): string[] {
+	const candidates = [join(hermesHome, "config.yaml"), join(hermesHome, "cli-config.yaml")];
+	return targetRoot ? candidates.map((candidate) => resolveContainedWritePath(candidate, targetRoot)) : candidates;
 }
 
-function resolveConfigPath(hermesHome: string): string {
-	for (const candidate of getConfigCandidates(hermesHome)) {
+function resolveConfigPath(hermesHome: string, targetRoot?: string): string {
+	for (const candidate of getConfigCandidates(hermesHome, targetRoot)) {
 		if (existsSync(candidate)) return candidate;
 	}
-	return join(hermesHome, "config.yaml");
+	const fallback = join(hermesHome, "config.yaml");
+	return targetRoot ? resolveContainedWritePath(fallback, targetRoot) : fallback;
 }
 
-function readConfigYaml(hermesHome: string): { path: string; content: string } | null {
-	const configPath = resolveConfigPath(hermesHome);
+function readConfigYaml(hermesHome: string, targetRoot?: string): { path: string; content: string } | null {
+	const configPath = resolveConfigPath(hermesHome, targetRoot);
 	if (!existsSync(configPath)) return null;
 	try {
 		return { path: configPath, content: readFileSync(configPath, "utf-8") };
@@ -389,8 +391,9 @@ function isProviderConfigured(hermesHome: string): boolean {
 function configureProvider(
 	hermesHome: string,
 	warnings: string[],
+	targetRoot?: string,
 ): { configPath: string | null; backupPath: string | null } {
-	const configPath = resolveConfigPath(hermesHome);
+	const configPath = resolveConfigPath(hermesHome, targetRoot);
 	let content = "";
 	if (existsSync(configPath)) {
 		try {
@@ -897,8 +900,9 @@ export class HermesAgentConnector extends BaseConnector {
 			};
 		}
 
-		// 2. Write env config for the Signet daemon connection
-		const envPath = join(hermesHome, ".env");
+		const envPath = options.profile
+			? resolveContainedWritePath(join(hermesHome, ".env"), hermesHome)
+			: join(hermesHome, ".env");
 		let configuredSignetAgentId = "default";
 		const configuredDaemonUrl = (process.env.SIGNET_DAEMON_URL?.trim() || "http://127.0.0.1:3850").replace(
 			/[\r\n]+/g,
@@ -1004,7 +1008,7 @@ export class HermesAgentConnector extends BaseConnector {
 		}
 
 		// 3. Activate Signet as the external Hermes memory provider.
-		const providerConfig = configureProvider(hermesHome, warnings);
+		const providerConfig = configureProvider(hermesHome, warnings, options.profile ? hermesHome : undefined);
 		if (providerConfig.configPath) {
 			configsPatched.push(providerConfig.configPath);
 		}
@@ -1073,7 +1077,9 @@ export class HermesAgentConnector extends BaseConnector {
 			filesRemoved.push(providerConfig.backupPath);
 		}
 
-		const envPath = join(hermesHome, ".env");
+		const envPath = options.profile
+			? resolveContainedWritePath(join(hermesHome, ".env"), hermesHome)
+			: join(hermesHome, ".env");
 		if (existsSync(envPath)) {
 			try {
 				let envContent = readFileSync(envPath, "utf-8");

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -64,6 +64,13 @@ export interface HermesDiagnosticCheck {
 	readonly fix?: string;
 }
 
+export interface HermesConnectorOptions {
+	readonly profile?: string;
+	readonly agentId?: string;
+	readonly memoryPolicy?: "isolated" | "shared" | "group";
+	readonly policyGroup?: string;
+}
+
 export interface HermesDoctorReport {
 	readonly ok: boolean;
 	readonly hermesHome: string;
@@ -904,7 +911,8 @@ export class HermesAgentConnector extends BaseConnector {
 		return resolveConfigPath(this.getHermesHome());
 	}
 
-	async install(basePath: string): Promise<InstallResult> {
+	async install(basePath: string, options: HermesConnectorOptions = {}): Promise<InstallResult> {
+		this.targetOptions = options;
 		const filesWritten: string[] = [];
 		const configsPatched: string[] = [];
 		const warnings: string[] = [];
@@ -1116,7 +1124,8 @@ export class HermesAgentConnector extends BaseConnector {
 		};
 	}
 
-	async uninstall(): Promise<UninstallResult> {
+	async uninstall(options: HermesConnectorOptions = {}): Promise<UninstallResult> {
+		this.targetOptions = options;
 		const filesRemoved: string[] = [];
 		const configsPatched: string[] = [];
 

--- a/surfaces/cli/src/commands/connector.ts
+++ b/surfaces/cli/src/commands/connector.ts
@@ -50,7 +50,8 @@ async function installHermes(options: ConnectorInstallOptions, deps: ConnectorDe
 		policyGroup: options.group,
 	});
 	for (const warning of result.warnings ?? []) console.warn(chalk.yellow(`  ${warning}`));
-	if (!result.success) throw new Error(`${result.message}. Repair or rerun the command for the targeted Hermes profile.`);
+	if (!result.success)
+		throw new Error(`${result.message}. Repair or rerun the command for the targeted Hermes profile.`);
 	console.log(chalk.green(`  ✓ ${result.message}`));
 }
 
@@ -85,8 +86,10 @@ export function registerConnectorCommands(program: Command, deps: ConnectorDeps)
 		);
 
 	const disconnect = program.command("disconnect <harness>").description("Disconnect a harness connector");
-	disconnect.option("--profile <name>", "Hermes profile name").action((harness: string, options: ConnectorInstallOptions) => {
-		if (harness !== "hermes") throw new Error("Only disconnect hermes is supported");
-		return disconnectHermes(options);
-	});
+	disconnect
+		.option("--profile <name>", "Hermes profile name")
+		.action((harness: string, options: ConnectorInstallOptions) => {
+			if (harness !== "hermes") throw new Error("Only disconnect hermes is supported");
+			return disconnectHermes(options);
+		});
 }

--- a/surfaces/cli/src/commands/connector.ts
+++ b/surfaces/cli/src/commands/connector.ts
@@ -1,11 +1,16 @@
 import chalk from "chalk";
 import type { Command } from "commander";
+import { HermesAgentConnector } from "@signet/connector-hermes-agent";
 
 interface ConnectorInstallOptions {
 	url?: string;
 	apiKey?: string;
 	agentId?: string;
 	path?: string;
+	profile?: string;
+	agent?: string;
+	memory?: "isolated" | "shared" | "group";
+	group?: string;
 }
 
 interface ConnectorDeps {
@@ -18,9 +23,7 @@ function withTemporaryEnv<T>(values: Record<string, string | undefined>, fn: () 
 	for (const key of Object.keys(values)) {
 		previous.set(key, process.env[key]);
 		const value = values[key];
-		if (typeof value === "string" && value.trim().length > 0) {
-			process.env[key] = value.trim();
-		}
+		if (typeof value === "string" && value.trim().length > 0) process.env[key] = value.trim();
 	}
 	return fn().finally(() => {
 		for (const [key, value] of previous.entries()) {
@@ -32,32 +35,58 @@ function withTemporaryEnv<T>(values: Record<string, string | undefined>, fn: () 
 
 async function installConnector(harness: string, options: ConnectorInstallOptions, deps: ConnectorDeps): Promise<void> {
 	await withTemporaryEnv(
-		{
-			SIGNET_DAEMON_URL: options.url,
-			SIGNET_API_KEY: options.apiKey,
-			SIGNET_AGENT_ID: options.agentId,
-		},
+		{ SIGNET_DAEMON_URL: options.url, SIGNET_API_KEY: options.apiKey, SIGNET_AGENT_ID: options.agentId },
 		async () => deps.configureHarnessHooks(harness, options.path ?? deps.agentsDir),
 	);
 	console.log(chalk.green(`  ✓ ${harness} connector installed`));
 }
 
+async function installHermes(options: ConnectorInstallOptions, deps: ConnectorDeps): Promise<void> {
+	if (!options.profile) throw new Error("--profile is required for connect hermes");
+	const result = await new HermesAgentConnector().install(options.path ?? deps.agentsDir, {
+		profile: options.profile,
+		agentId: options.agent ?? options.profile,
+		memoryPolicy: options.memory,
+		policyGroup: options.group,
+	});
+	for (const warning of result.warnings ?? []) console.warn(chalk.yellow(`  ${warning}`));
+	if (!result.success) throw new Error(`${result.message}. Repair or rerun the command for the targeted Hermes profile.`);
+	console.log(chalk.green(`  ✓ ${result.message}`));
+}
+
+async function disconnectHermes(options: ConnectorInstallOptions): Promise<void> {
+	if (!options.profile) throw new Error("--profile is required for disconnect hermes");
+	const result = await new HermesAgentConnector().uninstall({ profile: options.profile });
+	console.log(chalk.green(`  ✓ Hermes Agent disconnected (${result.filesRemoved.length} file(s) removed)`));
+}
+
 function addInstallOptions(command: Command): Command {
 	return command
-		.option("--url <url>", "Remote Signet daemon URL (sets SIGNET_DAEMON_URL for the installed connector)")
-		.option("--api-key <key>", "Signet API key (sets SIGNET_API_KEY for the installed connector)")
+		.option("--url <url>", "Remote Signet daemon URL")
+		.option("--api-key <key>", "Signet API key")
 		.option("--agent-id <id>", "Signet agent id for this connector")
 		.option("--path <path>", "Signet workspace path", undefined);
 }
 
 export function registerConnectorCommands(program: Command, deps: ConnectorDeps): void {
 	const connector = program.command("connector").description("Manage portable harness connectors");
-
 	addInstallOptions(connector.command("install <harness>").description("Install a harness connector")).action(
 		(harness: string, options: ConnectorInstallOptions) => installConnector(harness, options, deps),
 	);
 
-	addInstallOptions(
-		program.command("connect <harness>").description("Install a harness connector (alias for connector install)"),
-	).action((harness: string, options: ConnectorInstallOptions) => installConnector(harness, options, deps));
+	const connect = addInstallOptions(program.command("connect <harness>").description("Install a harness connector"));
+	connect
+		.option("--profile <name>", "Hermes profile name")
+		.option("--agent <name>", "Hermes Signet agent name")
+		.option("--memory <policy>", "Hermes memory policy")
+		.option("--group <name>", "Hermes group")
+		.action((harness: string, options: ConnectorInstallOptions) =>
+			harness === "hermes" ? installHermes(options, deps) : installConnector(harness, options, deps),
+		);
+
+	const disconnect = program.command("disconnect <harness>").description("Disconnect a harness connector");
+	disconnect.option("--profile <name>", "Hermes profile name").action((harness: string, options: ConnectorInstallOptions) => {
+		if (harness !== "hermes") throw new Error("Only disconnect hermes is supported");
+		return disconnectHermes(options);
+	});
 }


### PR DESCRIPTION
## Summary

Slice 2 of #1642 adds profile-scoped Hermes connection UX:

- `signet connect hermes --profile <name>` with optional agent, memory policy, and group options.
- `signet disconnect hermes --profile <name>` as the symmetric disconnect spelling.
- Profile target resolution is passed into the Hermes connector instance and does not mutate `~/.hermes/config.yaml`.
- Existing generic `connect <harness>` behavior remains available for other harnesses.

The command spelling follows the issue's requested `connect hermes` and the repository's existing top-level `connect` command; disconnect is a separate top-level command to avoid overloading install semantics.

## Verification

- `bun install --frozen-lockfile`
- `bun run --filter '@signet/core' build` passed.
- `bun run build:connector-base` passed.
- `bun run --filter '@signet/connector-hermes-agent' typecheck` passed.
- `bun run --filter '@signet/connector-hermes-agent' build` passed.
- `git diff --check` passed.
- The attempted targeted test command had no matching connector test files in this checkout and exited nonzero; no test result is claimed.
- Broad CLI build was blocked by unrelated unbuilt workspace connector dependencies; the Hermes package build itself passed.

AI-assisted implementation: reviewed and verified by the author.

Refs #1642
