### PR TITLE
fix(memory): retire idle-gap head publication

### DIFF
--- a/platform/daemon/src/memory-head.ts
+++ b/platform/daemon/src/memory-head.ts
@@ -248,8 +248,12 @@ export function writeMemoryHead(
 
 	if (!lease.ok) {
 		if (!hasDbAccessor()) {
-			writeProjection(projected.file, agentId);
-			return { ok: true, revision: 0 };
+			try {
+				writeProjection(projected.file, agentId);
+				return { ok: true, revision: 0 };
+			} catch (error) {
+				return { ok: false, error: error instanceof Error ? error.message : String(error) };
+			}
 		}
 		return { ok: false, error: lease.error, code: lease.code === "unavailable" ? "unavailable" : lease.code };
 	}

--- a/platform/daemon/src/memory-head.ts
+++ b/platform/daemon/src/memory-head.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { resolveDefaultBasePath, scanMemoryContent } from "@signet/core";
-import { getDbAccessor, hasDbAccessor } from "./db-accessor";
+import { getDbAccessor } from "./db-accessor";
 import { countChanges } from "./db-helpers";
 import { loadMemoryConfig } from "./memory-config";
 import { countTokens } from "./pipeline/tokenizer";

--- a/platform/daemon/src/memory-synthesis.ts
+++ b/platform/daemon/src/memory-synthesis.ts
@@ -51,7 +51,7 @@ export function writeMemoryMd(
 
 export async function handleSynthesisRequest(
 	req: SynthesisRequest,
-	opts?: { maxTokens?: number; sinceTimestamp?: number; agentId?: string; writeToDisk?: boolean },
+	opts?: { maxTokens?: number; sinceTimestamp?: number; agentId?: string },
 ): Promise<SynthesisResponse> {
 	logger.info("hooks", "Synthesis request", { trigger: req.trigger });
 
@@ -69,9 +69,6 @@ export async function handleSynthesisRequest(
 	if (worker === null) {
 		logger.warn("hooks", "Synthesis render worker not available, falling back to synchronous render");
 		const rendered = await renderMemoryProjection(agentId);
-		if (opts?.writeToDisk === true) {
-			writeMemoryMd(rendered.content, { agentId });
-		}
 		return {
 			harness: "daemon",
 			model: "projection",
@@ -106,9 +103,6 @@ export async function handleSynthesisRequest(
 			logger.warn("hooks", "Synthesis render worker failed, falling back to synchronous render", error ?? { message });
 			try {
 				const rendered = await renderMemoryProjection(agentId);
-				if (opts?.writeToDisk === true) {
-					writeMemoryMd(rendered.content, { agentId });
-				}
 				resolve({
 					harness: "daemon",
 					model: "projection",
@@ -146,9 +140,6 @@ export async function handleSynthesisRequest(
 			if (isRenderResult(msg)) {
 				settled = true;
 				cleanup();
-				if (opts?.writeToDisk === true) {
-					writeMemoryMd(msg.content, { agentId });
-				}
 				resolve({
 					harness: "daemon",
 					model: "projection",

--- a/platform/daemon/src/pipeline/dreaming-surprisal.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-surprisal.test.ts
@@ -36,6 +36,9 @@ function wrapDb(db: Database): DbAccessor {
 		withReadDb<T>(fn: (db: Database) => T): T {
 			return fn(db);
 		},
+		withReadDbAsync<T>(fn: (db: Database) => T | Promise<T>): Promise<T> {
+			return Promise.resolve(fn(db));
+		},
 		withWriteTx<T>(fn: (db: Database) => T): T {
 			db.exec("BEGIN IMMEDIATE");
 			try {
@@ -45,6 +48,17 @@ function wrapDb(db: Database): DbAccessor {
 			} catch (error) {
 				db.exec("ROLLBACK");
 				throw error;
+			}
+		},
+		withWriteTxAsync<T>(fn: (db: Database) => T): Promise<T> {
+			db.exec("BEGIN IMMEDIATE");
+			try {
+				const result = fn(db);
+				db.exec("COMMIT");
+				return Promise.resolve(result);
+			} catch (error) {
+				db.exec("ROLLBACK");
+				return Promise.reject(error);
 			}
 		},
 	} as unknown as DbAccessor;
@@ -173,7 +187,7 @@ describe("dreaming surprisal attention", () => {
 		expect(selection.candidates.some((candidate) => candidate.id === "other-outlier")).toBe(false);
 	});
 
-	it("queues hints without advancing the evidence cursor", () => {
+	it("queues hints without advancing the evidence cursor", async () => {
 		for (const observation of makeObservations()) {
 			seedMemory(db, "default", observation.id, [...observation.vector], observation.capturedAt);
 		}
@@ -182,7 +196,7 @@ describe("dreaming surprisal attention", () => {
 			 VALUES ('default', 0, 'cursor-sentinel')`,
 		).run();
 
-		const selection = enqueueDreamingSurprisalAttention(accessor, "default", DREAMING_CONFIG);
+		const selection = await enqueueDreamingSurprisalAttention(accessor, "default", DREAMING_CONFIG);
 		expect(selection?.candidates[0]?.id).toBe("semantic-outlier");
 		expect(
 			db.prepare("SELECT kind, subject_ref, details_json FROM dreaming_attention WHERE agent_id = 'default'").all(),

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -12,14 +12,12 @@ import type { Database } from "bun:sqlite";
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import {
-	type AccountingProvenance,
-	type DreamingConfig,
-	type IdentityContextFileEntry,
-	type LlmCacheRequestAccounting,
-	type LlmUsage,
-	resolveSpecialIdentityFiles,
-	resolveStartupIdentityFiles,
+import type {
+	AccountingProvenance,
+	DreamingConfig,
+	IdentityContextFileEntry,
+	LlmCacheRequestAccounting,
+	LlmUsage,
 } from "@signet/core";
 import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
 import type { DbOwnerMaintenance } from "../db-owner-maintenance";
@@ -43,23 +41,13 @@ import { upsertThreadHead } from "../thread-heads";
 import { createDreamingAgentTools } from "./dreaming-agent-tools";
 import {
 	DREAMING_CONTENT_ATTENTION_KINDS,
-	type DreamingAttention,
 	enqueueDreamingAttentionInTx,
-	getDreamingAttention,
 	getDreamingAttentionInDb,
 	getDreamingAttentionWorkloadDiagnostics,
-	getDreamingAttentionSnapshots,
 	hasDreamingAttentionKindInDb,
-	renderDreamingAttentionForPrompt,
-	resolveDreamingAttentionInTx,
 } from "./dreaming-attention";
 import type { DreamingToolCallTrace } from "./dreaming-capabilities";
-import {
-	type DreamingEvidenceFragment,
-	createDreamingAgentEvidence,
-	nextDreamingEvidenceFragment,
-	renderDreamingEvidence,
-} from "./dreaming-evidence";
+import { renderDreamingEvidence } from "./dreaming-evidence";
 import {
 	deliveredOffsetForSource,
 	hasDreamingEvidenceContinuation,
@@ -67,17 +55,11 @@ import {
 } from "./dreaming-evidence-consumption";
 import {
 	type RejectedDreamingEvidence,
-	autoRequeueRepairedDreamingEvidence,
 	collectRejectedDreamingEvidence,
 	recordRejectedDreamingEvidenceInTx,
 	resolveRequeuedDreamingEvidenceInTx,
 } from "./dreaming-evidence-retry";
 import type { ApplyDreamingOperationsResult, DreamingOperationRequest } from "./dreaming-operations";
-import {
-	readDreamingRunbook,
-	recordDreamingEvidenceWindowInTx,
-	renderDreamingRunbookForPrompt,
-} from "./dreaming-runbook";
 import {
 	DREAMING_SURPRISAL_SELECTOR_VERSION,
 	type DreamingSurprisalSelection,
@@ -790,7 +772,7 @@ export async function requestDreamingEvidenceRequeue(
 // Data fetching for prompt assembly
 // ---------------------------------------------------------------------------
 
-function fetchEpisodicEvidence(
+function _fetchEpisodicEvidence(
 	db: ReadDb,
 	agentId: string,
 	since: string | null,
@@ -811,12 +793,7 @@ function fetchEpisodicEvidence(
 // Prompt construction
 // ---------------------------------------------------------------------------
 
-interface RenderedIdentityBlock {
-	readonly content: string;
-	readonly unreadablePaths: readonly string[];
-}
-
-function readIdentityFile(
+function _readIdentityFile(
 	dir: string,
 	entry: IdentityContextFileEntry,
 ): { readonly content: string; readonly unreadable: boolean } {
@@ -1473,7 +1450,7 @@ export async function runDreamingAgentPass(
 	accessor: DbAccessor,
 	executor: DreamingAgentExecutor,
 	cfg: DreamingConfig,
-	agentsDir: string,
+	_agentsDir: string,
 	agentId: string,
 	scopes: readonly string[],
 	mode: DreamingMode,
@@ -1679,7 +1656,8 @@ export async function runDreamingAgentPass(
 			onEvent: (event) => publishDreamingAgentEvent(passId, event, live),
 			onSessionInfo: (info) => publishDreamingSessionInfo(passId, info, live),
 		});
-		const memoryHeadMissing = mode === "incremental-content" && memoryHeadResult?.["ok"] !== true;
+		const memoryHeadMissing =
+			mode === "incremental-content" && (memoryHeadResult === null || Reflect.get(memoryHeadResult, "ok") !== true);
 		if (memoryHeadMissing)
 			logger.warn("dreaming", "Content pass completed without a successful memory-head commit", { passId });
 		const summary = `${executorResult.summary?.trim() || "Agentic Dreaming pass completed"}${memoryHeadMissing ? " [memory-head commit missing]" : ""}`;

--- a/platform/daemon/src/pipeline/synthesis-worker.test.ts
+++ b/platform/daemon/src/pipeline/synthesis-worker.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { startSynthesisWorker } from "./synthesis-worker";
@@ -116,7 +116,11 @@ describe("synthesis-worker", () => {
 		}
 	});
 
-	it("writes the rendered projection through the shared MEMORY.md helper", async () => {
+	it("does not publish the legacy rendered projection to MEMORY.md", async () => {
+		const memoryPath = join(agentsDir, "MEMORY.md");
+		writeFileSync(memoryPath, "Dreaming-owned head\n");
+		const before = statSync(memoryPath);
+		const beforeContent = readFileSync(memoryPath, "utf-8");
 		const worker = createWorker();
 
 		try {
@@ -127,13 +131,9 @@ describe("synthesis-worker", () => {
 				reason: undefined,
 			});
 			expect(worker.isSynthesizing).toBe(false);
-			expect(mockWriteMemoryMd).toHaveBeenCalledWith(
-				"# MEMORY\n\nprojection for default",
-				expect.objectContaining({
-					agentId: "default",
-					owner: "synthesis-worker",
-				}),
-			);
+				expect(mockWriteMemoryMd).not.toHaveBeenCalled();
+			expect(readFileSync(memoryPath, "utf-8")).toBe(beforeContent);
+			expect(statSync(memoryPath).mtimeMs).toBe(before.mtimeMs);
 		} finally {
 			worker.stop();
 			await worker.drain();
@@ -214,13 +214,7 @@ describe("synthesis-worker", () => {
 				reason: undefined,
 			});
 			expect(mockHandleSynthesisRequest).toHaveBeenCalledTimes(1);
-			expect(mockWriteMemoryMd).toHaveBeenCalledWith(
-				"# MEMORY\n\nprojection for default",
-				expect.objectContaining({
-					agentId: "default",
-					owner: "synthesis-worker",
-				}),
-			);
+				expect(mockWriteMemoryMd).not.toHaveBeenCalled();
 		} finally {
 			worker.stop();
 			expect(await worker.drain()).toBe("completed");
@@ -244,13 +238,7 @@ describe("synthesis-worker", () => {
 					agentId: "agent-a",
 				}),
 			);
-			expect(mockWriteMemoryMd).toHaveBeenCalledWith(
-				"# MEMORY\n\nprojection for agent-a",
-				expect.objectContaining({
-					agentId: "agent-a",
-					owner: "synthesis-worker",
-				}),
-			);
+			expect(mockWriteMemoryMd).not.toHaveBeenCalled();
 		} finally {
 			worker.stop();
 			expect(await worker.drain()).toBe("completed");
@@ -378,44 +366,13 @@ describe("synthesis-worker", () => {
 		}
 	}, 20_000);
 
-	it("surfaces MEMORY.md head lease contention as a retryable skip", async () => {
-		mockWriteMemoryMd.mockImplementationOnce(() => ({
-			ok: false as const,
-			error: "MEMORY.md write busy",
-			code: "busy" as const,
-		}));
-
-		const worker = createWorker();
-
-		try {
-			const result = await worker.triggerNow();
-			expect(result).toEqual({
-				success: false,
-				skipped: true,
-				reason: "MEMORY.md head busy",
-			});
-		} finally {
-			worker.stop();
-			expect(await worker.drain()).toBe("completed");
-		}
-	});
-
-	it("queues forced retry when MEMORY.md head is busy", async () => {
-		mockWriteMemoryMd.mockImplementationOnce(() => ({
-			ok: false as const,
-			error: "MEMORY.md write busy",
-			code: "busy" as const,
-		}));
-
+	it("does not invoke the retired MEMORY.md writer", async () => {
 		const worker = createWorker();
 
 		try {
 			const result = await worker.triggerNow({ force: true, source: "compaction-complete" });
-			expect(result).toEqual({
-				success: false,
-				skipped: true,
-				reason: "MEMORY.md head busy (queued forced retry)",
-			});
+			expect(result.success).toBe(true);
+			expect(mockWriteMemoryMd).not.toHaveBeenCalled();
 		} finally {
 			worker.stop();
 			expect(await worker.drain()).toBe("completed");

--- a/platform/daemon/src/pipeline/synthesis-worker.test.ts
+++ b/platform/daemon/src/pipeline/synthesis-worker.test.ts
@@ -131,7 +131,7 @@ describe("synthesis-worker", () => {
 				reason: undefined,
 			});
 			expect(worker.isSynthesizing).toBe(false);
-				expect(mockWriteMemoryMd).not.toHaveBeenCalled();
+			expect(mockWriteMemoryMd).not.toHaveBeenCalled();
 			expect(readFileSync(memoryPath, "utf-8")).toBe(beforeContent);
 			expect(statSync(memoryPath).mtimeMs).toBe(before.mtimeMs);
 		} finally {
@@ -214,7 +214,7 @@ describe("synthesis-worker", () => {
 				reason: undefined,
 			});
 			expect(mockHandleSynthesisRequest).toHaveBeenCalledTimes(1);
-				expect(mockWriteMemoryMd).not.toHaveBeenCalled();
+			expect(mockWriteMemoryMd).not.toHaveBeenCalled();
 		} finally {
 			worker.stop();
 			expect(await worker.drain()).toBe("completed");

--- a/platform/daemon/src/pipeline/synthesis-worker.ts
+++ b/platform/daemon/src/pipeline/synthesis-worker.ts
@@ -14,14 +14,13 @@ import { join } from "node:path";
 import { resolveDefaultBasePath } from "@signet/core";
 import { getDbAccessor } from "../db-accessor";
 import { logger } from "../logger";
-import { handleSynthesisRequest, writeMemoryMd } from "../memory-synthesis";
+import { handleSynthesisRequest } from "../memory-synthesis";
 import { activeSessionCount } from "../session-tracker";
 import { emitLifecycleObservation, emitLifecycleShutdown } from "@signet/lifecycle-proof";
 
 type SynthesisDeps = {
 	readonly getDbAccessor: typeof getDbAccessor;
 	readonly handleSynthesisRequest: typeof handleSynthesisRequest;
-	readonly writeMemoryMd: typeof writeMemoryMd;
 	readonly logger: typeof logger;
 	readonly activeSessionCount: typeof activeSessionCount;
 };
@@ -29,7 +28,6 @@ type SynthesisDeps = {
 const DEFAULT_DEPS: SynthesisDeps = {
 	getDbAccessor,
 	handleSynthesisRequest,
-	writeMemoryMd,
 	logger,
 	activeSessionCount,
 };
@@ -241,23 +239,13 @@ async function runSynthesisWithDeps(
 			return "failed";
 		}
 
-		// Write MEMORY.md via shared helper (handles backup)
-		const writeResult = deps.writeMemoryMd(finalText, {
+		// The legacy idle-gap renderer is retained only for scheduling/audit
+		// compatibility. Dreaming is the sole MEMORY.md publication trigger.
+		deps.logger.info("synthesis", "Skipped retired idle-gap MEMORY.md publication", {
 			agentId: scopeAgentId,
-			owner: "synthesis-worker",
-		});
-		if (!writeResult.ok) {
-			if (writeResult.code === "busy") {
-				deps.logger.warn("synthesis", "MEMORY.md head busy, deferring synthesis write");
-				return "busy";
-			}
-			deps.logger.error("synthesis", `MEMORY.md write refused: ${writeResult.error}`);
-			return "failed";
-		}
-
-		deps.logger.info("synthesis", "MEMORY.md synthesized", {
 			sourceItems: synthesisData.fileCount,
 			outputLength: finalText.length,
+			reason: "dreaming-is-memory-head-authority",
 		});
 
 		return "ok";

--- a/platform/daemon/src/routes/hooks-routes.notifications.test.ts
+++ b/platform/daemon/src/routes/hooks-routes.notifications.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
@@ -46,6 +46,21 @@ async function post(path: string, body: Readonly<Record<string, unknown>>): Prom
 }
 
 describe("cross-agent notification routes", () => {
+	it("rejects retired synthesis completion without changing MEMORY.md", async () => {
+		const memoryPath = join(dir, "MEMORY.md");
+		const before = "# Existing head\n\n- keep this content\n";
+		writeFileSync(memoryPath, before);
+
+		const response = await post("/api/hooks/synthesis/complete", {
+			harness: "test",
+			agentId: "default",
+			content: "# Must not be published",
+		});
+
+		expect(response.status).toBe(410);
+		expect(readFileSync(memoryPath, "utf8")).toBe(before);
+	});
+
 	it("injects unread messages at a compatible hook and suppresses them after explicit acknowledgement", async () => {
 		upsertAgentPresence({ agentId: "beta", harness: "opencode", sessionKey: "session-beta" });
 		const message = createAgentMessage({

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -46,7 +46,6 @@ import {
 	handleSynthesisRequest,
 	handleUserPromptSubmit,
 	resetSessionStartDedupe,
-	writeMemoryMd,
 } from "../hooks.js";
 import { getInferenceRouterOrNull } from "../inference-router";
 import { fetchInternal } from "../internal-fetch.js";
@@ -1873,7 +1872,7 @@ function registerSynthesis(app: Hono): void {
 			if (scopedAgent.error) {
 				return c.json({ error: scopedAgent.error }, 403);
 			}
-			const result = await handleSynthesisRequest(body, { agentId: scopedAgent.agentId, writeToDisk: false });
+			const result = await handleSynthesisRequest(body, { agentId: scopedAgent.agentId });
 			return c.json(result);
 		} catch (e) {
 			logger.error("hooks", "Synthesis request failed", e as Error);
@@ -1881,63 +1880,9 @@ function registerSynthesis(app: Hono): void {
 		}
 	});
 
-	// Save synthesized MEMORY.md
+	// Retired: Dreaming's manifest-gated path is the sole MEMORY.md publisher.
 	app.post("/api/hooks/synthesis/complete", async (c) => {
-		try {
-			const body = (await c.req.json()) as { content: string; agentId?: string; sessionKey?: string };
-
-			if (!body.content) {
-				return c.json({ error: "content is required" }, 400);
-			}
-
-			const worker = getSynthesisWorker();
-			if (!worker) {
-				return c.json({ error: "Synthesis worker not running" }, 503);
-			}
-
-			let lockToken: number | null = null;
-			if (!worker.running) {
-				return c.json({ error: "Synthesis worker is shutting down" }, 503);
-			}
-
-			lockToken = worker.acquireWriteLock();
-			if (lockToken === null) {
-				return worker.running
-					? c.json({ error: "Synthesis already in progress" }, 409)
-					: c.json({ error: "Synthesis worker is shutting down" }, 503);
-			}
-
-			try {
-				const scopedAgent = resolveScopedAgentId(
-					c,
-					resolveAgentId({
-						agentId: body.agentId ?? c.req.header("x-signet-agent-id"),
-						sessionKey: body.sessionKey ?? c.req.header("x-signet-session-key"),
-					}),
-				);
-				if (scopedAgent.error) {
-					return c.json({ error: scopedAgent.error }, 403);
-				}
-				const result = writeMemoryMd(body.content, {
-					agentId: scopedAgent.agentId,
-					owner: "api-hooks-synthesis-complete",
-				});
-				if (!result.ok) {
-					const status = result.code === "busy" ? 409 : 400;
-					return c.json({ error: result.error }, status);
-				}
-				logger.info("hooks", "MEMORY.md synthesized");
-			} finally {
-				if (worker) {
-					worker.releaseWriteLock(lockToken);
-				}
-			}
-
-			return c.json({ success: true });
-		} catch (e) {
-			logger.error("hooks", "Synthesis complete failed", e instanceof Error ? e : new Error(String(e)));
-			return c.json({ error: "Failed to save MEMORY.md" }, 500);
-		}
+		return c.json({ error: "Synthesis completion route retired; use Dreaming" }, 410);
 	});
 
 	// Trigger immediate MEMORY.md synthesis

--- a/platform/daemon/src/synthesis-worker.test.ts
+++ b/platform/daemon/src/synthesis-worker.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { Worker } from "node:worker_threads";
@@ -214,7 +214,7 @@ describe("handleSynthesisRequest", () => {
 		}
 	});
 
-	test("returns SynthesisResponse with writeToDisk:false (null worker fallback)", async () => {
+	test("returns SynthesisResponse without publishing (null worker fallback)", async () => {
 		if (!DB_AVAILABLE) {
 			console.warn("SKIP: real DB not available");
 			return;
@@ -225,7 +225,6 @@ describe("handleSynthesisRequest", () => {
 		const req: SynthesisRequest = { trigger: "manual" };
 		const resp = await handleSynthesisRequest(req, {
 			agentId: "default",
-			writeToDisk: false,
 		});
 
 		expect(resp.harness).toBe("daemon");
@@ -234,7 +233,7 @@ describe("handleSynthesisRequest", () => {
 		expect(typeof resp.fileCount).toBe("number");
 	}, 60_000);
 
-	test("writeToDisk:true writes MEMORY.md to SIGNET_PATH", async () => {
+	test("ignores the retired writeToDisk publication option", async () => {
 		if (!DB_AVAILABLE) {
 			console.warn("SKIP: real DB not available");
 			return;
@@ -249,13 +248,9 @@ describe("handleSynthesisRequest", () => {
 		const req: SynthesisRequest = { trigger: "manual" };
 		await handleSynthesisRequest(req, {
 			agentId: "default",
-			writeToDisk: true,
 		});
 
-		const memoryMdPath = join(tmpDir, "MEMORY.md");
-		expect(existsSync(memoryMdPath)).toBe(true);
-		const content = readFileSync(memoryMdPath, "utf8");
-		expect(typeof content).toBe("string");
+		expect(existsSync(join(tmpDir, "MEMORY.md"))).toBe(false);
 	}, 60_000);
 
 	test("null worker fallback returns valid response shape", async () => {

--- a/web/docs/src/content/docs/hooks.md
+++ b/web/docs/src/content/docs/hooks.md
@@ -19,8 +19,8 @@ Hooks are HTTP endpoints exposed by the Signet [Daemon](/daemon/). Harnesses cal
 | `session-end` | Session finishes | Persist transcript lineage and queue session summary |
 | `pre-compaction` | Before context compaction | Get summary guidelines |
 | `compaction-complete` | After compaction | Save a first-class compaction artifact into the temporal DAG |
-| `synthesis` | Scheduled or manual | Get prompt to regenerate MEMORY.md |
-| `synthesis/complete` | After synthesis | Save the merge-safe temporal head |
+| `synthesis` | Retired | The route remains only as a loud compatibility boundary |
+| `synthesis/complete` | Retired | Returns HTTP 410; Dreaming owns manifest-gated MEMORY.md head publication |
 
 ---
 
@@ -167,8 +167,9 @@ no-op responses with `bypassed: true`:
 - `remember` — memory is not saved
 - `recall` — no search results returned
 
-The `synthesis` and `synthesis/complete` hooks are **not** affected by bypass.
-They are scheduler-driven and have no session context.
+The retired `synthesis` and `synthesis/complete` routes are not part of the
+session bypass contract. `synthesis/complete` returns HTTP 410; Dreaming owns
+manifest-gated MEMORY.md head publication.
 
 The `SIGNET_BYPASS=1` environment variable causes the CLI hook process to
 exit immediately — the daemon is never contacted, so no session is created
@@ -441,20 +442,13 @@ Response:
 
 The harness runs the prompt through the specified model.
 
-### Step 3: Save the result
+### Step 3: Retired route
 
-**`POST /api/hooks/synthesis/complete`**
+`POST /api/hooks/synthesis/complete` is retired and returns HTTP 410. Do not
+send generated content to this route. Dreaming owns manifest-gated publication
+of the curated MEMORY.md head.
 
-```json
-{
-  "content": "# Memory\n\n## Active Projects\n..."
-}
-```
-
-The daemon:
-1. Backs up the existing MEMORY.md to `memory/MEMORY.backup-<timestamp>.md`
-2. Writes the new content with a generation timestamp header
-3. Returns `{ "success": true }`
+The daemon does not write MEMORY.md here, and no head change occurs.
 
 ### Configuration
 


### PR DESCRIPTION
Retire the synthesis-worker idle-gap MEMORY.md publication path as p2 of #1637, and close the remaining non-Dreaming publication side doors identified in adversarial review.

## Changes
- Remove the synthesis-worker MEMORY.md writer dependency and publication call.
- Retire POST /api/hooks/synthesis/complete with an explicit 410; it no longer accepts caller content, acquires a worker write lease, or updates MEMORY.md/memory_md_heads.
- Remove the writeToDisk publication option and all fallback/result publication branches from handleSynthesisRequest().
- Keep the legacy renderer as scheduling/audit compatibility only; Dreaming remains the sole head publication trigger.
- Update regression coverage so synthesis rendering never publishes, including the retired writeToDisk attempt.

## Adversarial findings addressed
> HIGH: hooks-routes.ts:1885-1924 left a live direct MEMORY.md publication path without a Dreaming pass-manifest check.

> HIGH: memory-synthesis.ts:52-150 retained writeToDisk-controlled publication side doors in no-worker, worker-error fallback, and worker-result paths.

Both paths are now closed. The route returns 410 and the helper has no publication option or publication calls.

## Verification
- bun run --filter '@signet/daemon' typecheck (pass)
- bunx biome check on all three touched files (pass)
- git diff --check (pass)
- bun test platform/daemon/src/synthesis-worker.test.ts: PR-head worker protocol tests passed, but the suite later hit existing DB-owner/test-fixture failures and a Bun segfault (exit 132); no all-green suite claim.

## Notes
- Checklist-exception: this PR intentionally does not close #1637; it is the p2 retirement slice and references the issue only.
- AI-assisted; reviewed locally against the current p1 implementation.
