### PR TITLE
feat(agent): enforce memory policy mutations

### DIFF
--- a/platform/core/src/agents.test.ts
+++ b/platform/core/src/agents.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { resolveAgentMemoryPolicy } from "./agents";
+
+describe("resolveAgentMemoryPolicy", () => {
+	test.each([
+		["isolated", undefined, "agent"],
+		["shared", undefined, "global"],
+		["group", "writers", "group"],
+	] as const)("accepts %s policy", (readPolicy, policyGroup, effectiveScope) => {
+		expect(resolveAgentMemoryPolicy(readPolicy, policyGroup)).toMatchObject({
+			readPolicy,
+			policyGroup: policyGroup ?? null,
+			effectiveScope,
+		});
+	});
+
+	test.each([
+		[undefined, undefined],
+		["unknown", undefined],
+		[123, undefined],
+		["group", undefined],
+		["isolated", "extra"],
+		["shared", 123],
+	])("rejects invalid policy combinations", (readPolicy, policyGroup) => {
+		expect(() => resolveAgentMemoryPolicy(readPolicy, policyGroup)).toThrow();
+	});
+});

--- a/platform/core/src/agents.ts
+++ b/platform/core/src/agents.ts
@@ -22,7 +22,8 @@ export function resolveAgentMemoryPolicy(readPolicy: unknown, policyGroup: unkno
 		throw new Error("memory must be one of: isolated, shared, group");
 	}
 	if (readPolicy === "group") {
-		if (typeof policyGroup !== "string" || policyGroup.length === 0) throw new Error("group is required when memory is group");
+		if (typeof policyGroup !== "string" || policyGroup.length === 0)
+			throw new Error("group is required when memory is group");
 		return { readPolicy, policyGroup, effectiveScope: "group" };
 	}
 	if (policyGroup !== undefined && policyGroup !== null) throw new Error("group is only valid when memory is group");

--- a/platform/core/src/agents.ts
+++ b/platform/core/src/agents.ts
@@ -11,6 +11,24 @@ import type { AgentDefinition, ReadPolicy } from "./types";
 
 export type AgentRosterReadPolicy = "isolated" | "shared" | "group";
 
+export interface ResolvedAgentMemoryPolicy {
+	readonly readPolicy: AgentRosterReadPolicy;
+	readonly policyGroup: string | null;
+	readonly effectiveScope: "agent" | "global" | "group";
+}
+
+export function resolveAgentMemoryPolicy(readPolicy: unknown, policyGroup: unknown): ResolvedAgentMemoryPolicy {
+	if (readPolicy !== "isolated" && readPolicy !== "shared" && readPolicy !== "group") {
+		throw new Error("memory must be one of: isolated, shared, group");
+	}
+	if (readPolicy === "group") {
+		if (typeof policyGroup !== "string" || policyGroup.length === 0) throw new Error("group is required when memory is group");
+		return { readPolicy, policyGroup, effectiveScope: "group" };
+	}
+	if (policyGroup !== undefined && policyGroup !== null) throw new Error("group is only valid when memory is group");
+	return { readPolicy, policyGroup: null, effectiveScope: readPolicy === "shared" ? "global" : "agent" };
+}
+
 export interface NormalizedAgentRosterEntry {
 	readonly name: string;
 	readonly readPolicy: AgentRosterReadPolicy;

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -501,9 +501,10 @@ export {
 	getAgentIdentityFiles,
 	resolveAgentSkills,
 	buildAgentMemoryConfig,
+	resolveAgentMemoryPolicy,
 	normalizeAgentRosterEntry,
 } from "./agents";
-export type { AgentRosterReadPolicy, NormalizedAgentRosterEntry } from "./agents";
+export type { AgentRosterReadPolicy, NormalizedAgentRosterEntry, ResolvedAgentMemoryPolicy } from "./agents";
 
 // Skills unification
 export {

--- a/platform/daemon/src/agent-routes-policy.test.ts
+++ b/platform/daemon/src/agent-routes-policy.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const workspace = join(tmpdir(), `signet-agent-routes-${Date.now()}`);
+mkdirSync(join(workspace, "memory"), { recursive: true });
+process.env.SIGNET_PATH = workspace;
+
+let closeDb: (() => void) | undefined;
+let app: InstanceType<typeof import("hono").Hono>;
+
+beforeAll(async () => {
+	await import("./daemon");
+	const { Hono } = await import("hono");
+	const db = await import("./db-accessor");
+	db.closeDbAccessor();
+	db.initDbAccessor(join(workspace, "memory", "memories.db"));
+	closeDb = db.closeDbAccessor;
+	const { registerMiscRoutes } = await import("./routes/misc-routes");
+	app = new Hono();
+	registerMiscRoutes(app);
+});
+
+afterAll(() => {
+	closeDb?.();
+	rmSync(workspace, { recursive: true, force: true });
+});
+
+async function request(method: string, path: string, body?: unknown) {
+	return app.request(path, {
+		method,
+		headers: body === undefined ? undefined : { "content-type": "application/json" },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	});
+}
+
+describe("agent route memory policy contracts", () => {
+	it("POST distinguishes omitted, invalid, and valid policy fields", async () => {
+		expect((await request("POST", "/api/agents", { name: "omitted" })).status).toBe(201);
+		expect((await request("POST", "/api/agents", { name: "number", read_policy: 123 })).status).toBe(400);
+		expect((await request("POST", "/api/agents", { name: "bogus", read_policy: "bogus" })).status).toBe(400);
+		expect((await request("POST", "/api/agents", { name: "shared", read_policy: "shared" })).status).toBe(201);
+		expect((await request("POST", "/api/agents", { name: "group-no-name", read_policy: "group" })).status).toBe(400);
+		expect(
+			(await request("POST", "/api/agents", { name: "group", read_policy: "group", policy_group: "team" })).status,
+		).toBe(201);
+	});
+
+	it("GET returns a structured error for a legacy invalid persisted policy", async () => {
+		const { getDbAccessor, runWriteTxAsync } = await import("./db-accessor");
+		await runWriteTxAsync(getDbAccessor(), (db) => {
+			db.prepare(
+				`INSERT INTO agents (id, name, read_policy, policy_group, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?)`,
+			).run("legacy", "legacy", "bogus", null, new Date().toISOString(), new Date().toISOString());
+		});
+		const response = await request("GET", "/api/agents/legacy");
+		expect(response.status).toBe(500);
+		expect(await response.json()).toEqual({
+			error: "Invalid persisted memory policy: memory must be one of: isolated, shared, group",
+		});
+	});
+
+	it("PATCH distinguishes omitted, invalid, and valid policy fields", async () => {
+		expect((await request("PATCH", "/api/agents/omitted", {})).status).toBe(200);
+		expect((await request("PATCH", "/api/agents/omitted", { read_policy: 123 })).status).toBe(400);
+		expect((await request("PATCH", "/api/agents/omitted", { read_policy: "bogus" })).status).toBe(400);
+		expect((await request("PATCH", "/api/agents/omitted", { read_policy: "shared" })).status).toBe(200);
+		expect((await request("PATCH", "/api/agents/omitted", { read_policy: "group" })).status).toBe(400);
+		expect((await request("PATCH", "/api/agents/omitted", { read_policy: "group", policy_group: "team" })).status).toBe(
+			200,
+		);
+		expect((await request("PATCH", "/api/agents/not-found", {})).status).toBe(404);
+	});
+});

--- a/platform/daemon/src/routes/misc-routes.ts
+++ b/platform/daemon/src/routes/misc-routes.ts
@@ -1,7 +1,7 @@
 import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseSimpleYaml, resolveAgentMemoryPolicy } from "@signet/core";
-import type { Context, Hono } from "hono";
+import type { Hono } from "hono";
 import { requirePermission } from "../auth";
 import { checkPermission } from "../auth/policy";
 import { getDbAccessor, runWriteTxAsync } from "../db-accessor.js";
@@ -221,8 +221,20 @@ export function registerMiscRoutes(app: Hono): void {
 					.get(name) as AgentRow | undefined,
 		);
 		if (!agent) return c.json({ error: "Agent not found" }, 404);
-		const resolved = resolveAgentMemoryPolicy(agent.read_policy, agent.policy_group);
-		return c.json({ ...agent, effective_scope: resolved.effectiveScope });
+		try {
+			const resolved = resolveAgentMemoryPolicy(agent.read_policy, agent.policy_group);
+			return c.json({ ...agent, effective_scope: resolved.effectiveScope });
+		} catch (error) {
+			return c.json(
+				{
+					error:
+						error instanceof Error
+							? `Invalid persisted memory policy: ${error.message}`
+							: "Invalid persisted memory policy",
+				},
+				500,
+			);
+		}
 	});
 
 	app.post("/api/agents", async (c) => {
@@ -265,11 +277,22 @@ export function registerMiscRoutes(app: Hono): void {
 		} catch (error) {
 			return c.json({ error: error instanceof Error ? error.message : "Invalid memory policy" }, 400);
 		}
-		const existing = await getDbAccessor().withReadDbAsync(async (db) => db.prepare("SELECT id FROM agents WHERE name = ?").get(name) as { id: string } | undefined);
+		const existing = await getDbAccessor().withReadDbAsync(
+			async (db) => db.prepare("SELECT id FROM agents WHERE name = ?").get(name) as { id: string } | undefined,
+		);
 		if (!existing) return c.json({ error: "Agent not found" }, 404);
 		const now = new Date().toISOString();
-		await runWriteTxAsync(getDbAccessor(), (db) => db.prepare("UPDATE agents SET read_policy = ?, policy_group = ?, updated_at = ? WHERE id = ?").run(resolved.readPolicy, resolved.policyGroup, now, existing.id));
-		const updated = await getDbAccessor().withReadDbAsync(async (db) => db.prepare("SELECT id, name, read_policy, policy_group, created_at, updated_at FROM agents WHERE id = ?").get(existing.id) as unknown as AgentRow);
+		await runWriteTxAsync(getDbAccessor(), (db) =>
+			db
+				.prepare("UPDATE agents SET read_policy = ?, policy_group = ?, updated_at = ? WHERE id = ?")
+				.run(resolved.readPolicy, resolved.policyGroup, now, existing.id),
+		);
+		const updated = await getDbAccessor().withReadDbAsync(
+			async (db) =>
+				db
+					.prepare("SELECT id, name, read_policy, policy_group, created_at, updated_at FROM agents WHERE id = ?")
+					.get(existing.id) as unknown as AgentRow,
+		);
 		return c.json({ ...updated, effective_scope: resolved.effectiveScope });
 	});
 
@@ -716,7 +739,7 @@ export function registerMiscRoutes(app: Hono): void {
 	app.delete("/api/tasks/:id", async (c) => {
 		const taskId = c.req.param("id");
 
-		const result = await runWriteTxAsync(getDbAccessor(), (db) => {
+		await runWriteTxAsync(getDbAccessor(), (db) => {
 			const info = db.prepare("DELETE FROM scheduled_tasks WHERE id = ?").run(taskId);
 			return info;
 		});

--- a/platform/daemon/src/routes/misc-routes.ts
+++ b/platform/daemon/src/routes/misc-routes.ts
@@ -244,7 +244,15 @@ export function registerMiscRoutes(app: Hono): void {
 		if (!name) return c.json({ error: "name is required" }, 400);
 		let resolved: ReturnType<typeof resolveAgentMemoryPolicy>;
 		try {
-			resolved = resolveAgentMemoryPolicy(parseOptionalString(body.read_policy) ?? "isolated", body.policy_group);
+			const rawPolicy = Object.hasOwn(body, "read_policy") ? body.read_policy : undefined;
+			const rawGroup = Object.hasOwn(body, "policy_group") ? body.policy_group : undefined;
+			if (rawPolicy !== undefined && typeof rawPolicy !== "string") {
+				return c.json({ error: "memory must be one of: isolated, shared, group" }, 400);
+			}
+			if (rawGroup !== undefined && typeof rawGroup !== "string") {
+				return c.json({ error: "group must be a string" }, 400);
+			}
+			resolved = resolveAgentMemoryPolicy(rawPolicy ?? "isolated", rawGroup);
 		} catch (error) {
 			return c.json({ error: error instanceof Error ? error.message : "Invalid memory policy" }, 400);
 		}
@@ -271,16 +279,35 @@ export function registerMiscRoutes(app: Hono): void {
 		if (name === "default") return c.json({ error: "Cannot modify the default agent" }, 400);
 		const body = toRecord(await c.req.json().catch(() => null));
 		if (!body) return c.json({ error: "Invalid JSON body" }, 400);
+		const existing = await getDbAccessor().withReadDbAsync(
+			async (db) =>
+				db.prepare("SELECT id, read_policy, policy_group FROM agents WHERE name = ?").get(name) as
+					| { id: string; read_policy: string; policy_group: string | null }
+					| undefined,
+		);
+		if (!existing) return c.json({ error: "Agent not found" }, 404);
 		let resolved: ReturnType<typeof resolveAgentMemoryPolicy>;
 		try {
-			resolved = resolveAgentMemoryPolicy(body.memory ?? body.read_policy, body.group ?? body.policy_group);
+			const rawPolicy = Object.hasOwn(body, "memory")
+				? body.memory
+				: Object.hasOwn(body, "read_policy")
+					? body.read_policy
+					: existing.read_policy;
+			const rawGroup = Object.hasOwn(body, "group")
+				? body.group
+				: Object.hasOwn(body, "policy_group")
+					? body.policy_group
+					: existing.policy_group;
+			if (typeof rawPolicy !== "string") {
+				return c.json({ error: "memory must be one of: isolated, shared, group" }, 400);
+			}
+			if (rawGroup !== null && rawGroup !== undefined && typeof rawGroup !== "string") {
+				return c.json({ error: "group must be a string" }, 400);
+			}
+			resolved = resolveAgentMemoryPolicy(rawPolicy, rawGroup);
 		} catch (error) {
 			return c.json({ error: error instanceof Error ? error.message : "Invalid memory policy" }, 400);
 		}
-		const existing = await getDbAccessor().withReadDbAsync(
-			async (db) => db.prepare("SELECT id FROM agents WHERE name = ?").get(name) as { id: string } | undefined,
-		);
-		if (!existing) return c.json({ error: "Agent not found" }, 404);
 		const now = new Date().toISOString();
 		await runWriteTxAsync(getDbAccessor(), (db) =>
 			db

--- a/platform/daemon/src/routes/misc-routes.ts
+++ b/platform/daemon/src/routes/misc-routes.ts
@@ -1,6 +1,6 @@
 import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { parseSimpleYaml } from "@signet/core";
+import { parseSimpleYaml, resolveAgentMemoryPolicy } from "@signet/core";
 import type { Context, Hono } from "hono";
 import { requirePermission } from "../auth";
 import { checkPermission } from "../auth/policy";
@@ -221,7 +221,8 @@ export function registerMiscRoutes(app: Hono): void {
 					.get(name) as AgentRow | undefined,
 		);
 		if (!agent) return c.json({ error: "Agent not found" }, 404);
-		return c.json(agent);
+		const resolved = resolveAgentMemoryPolicy(agent.read_policy, agent.policy_group);
+		return c.json({ ...agent, effective_scope: resolved.effectiveScope });
 	});
 
 	app.post("/api/agents", async (c) => {
@@ -229,8 +230,14 @@ export function registerMiscRoutes(app: Hono): void {
 		if (!body) return c.json({ error: "Invalid JSON body" }, 400);
 		const name = parseOptionalString(body.name);
 		if (!name) return c.json({ error: "name is required" }, 400);
-		const readPolicy = parseOptionalString(body.read_policy) ?? "isolated";
-		const group = parseOptionalString(body.policy_group) ?? null;
+		let resolved: ReturnType<typeof resolveAgentMemoryPolicy>;
+		try {
+			resolved = resolveAgentMemoryPolicy(parseOptionalString(body.read_policy) ?? "isolated", body.policy_group);
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : "Invalid memory policy" }, 400);
+		}
+		const readPolicy = resolved.readPolicy;
+		const group = resolved.policyGroup;
 		const now = new Date().toISOString();
 		await runWriteTxAsync(getDbAccessor(), (db) => {
 			db.prepare(
@@ -245,6 +252,25 @@ export function registerMiscRoutes(app: Hono): void {
 					.get(name) as unknown as AgentRow,
 		);
 		return c.json(created, 201);
+	});
+
+	app.patch("/api/agents/:name", async (c) => {
+		const name = c.req.param("name");
+		if (name === "default") return c.json({ error: "Cannot modify the default agent" }, 400);
+		const body = toRecord(await c.req.json().catch(() => null));
+		if (!body) return c.json({ error: "Invalid JSON body" }, 400);
+		let resolved: ReturnType<typeof resolveAgentMemoryPolicy>;
+		try {
+			resolved = resolveAgentMemoryPolicy(body.memory ?? body.read_policy, body.group ?? body.policy_group);
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : "Invalid memory policy" }, 400);
+		}
+		const existing = await getDbAccessor().withReadDbAsync(async (db) => db.prepare("SELECT id FROM agents WHERE name = ?").get(name) as { id: string } | undefined);
+		if (!existing) return c.json({ error: "Agent not found" }, 404);
+		const now = new Date().toISOString();
+		await runWriteTxAsync(getDbAccessor(), (db) => db.prepare("UPDATE agents SET read_policy = ?, policy_group = ?, updated_at = ? WHERE id = ?").run(resolved.readPolicy, resolved.policyGroup, now, existing.id));
+		const updated = await getDbAccessor().withReadDbAsync(async (db) => db.prepare("SELECT id, name, read_policy, policy_group, created_at, updated_at FROM agents WHERE id = ?").get(existing.id) as unknown as AgentRow);
+		return c.json({ ...updated, effective_scope: resolved.effectiveScope });
 	});
 
 	app.delete("/api/agents/:name", async (c) => {

--- a/surfaces/cli/src/commands/agent.test.ts
+++ b/surfaces/cli/src/commands/agent.test.ts
@@ -68,4 +68,36 @@ describe("registerAgentCommands", () => {
 			true,
 		);
 	});
+
+	test("agent set sends the exact daemon PATCH shape", async () => {
+		console.log = () => {};
+		const calls: Array<{ url: string; init?: RequestInit }> = [];
+		const program = new Command();
+		registerAgentCommands(program, {
+			AGENTS_DIR: mkdtempSync(join(tmpdir(), "signet-agent-command-")),
+			fetchFromDaemon: async <T>(url: string, init?: RequestInit) => {
+				calls.push({ url, init });
+				return { read_policy: "group" } as T;
+			},
+		});
+		await program.parseAsync(["node", "test", "agent", "set", "writer", "--memory", "group", "--group", "writers"]);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.url).toBe("/api/agents/writer");
+		expect(calls[0]?.init?.method).toBe("PATCH");
+		expect(calls[0]?.init?.body).toBe(JSON.stringify({ memory: "group", group: "writers" }));
+	});
+
+	test("agent show renders daemon-backed scope", async () => {
+		const lines: string[] = [];
+		console.log = (line?: unknown) => lines.push(String(line ?? ""));
+		const program = new Command();
+		registerAgentCommands(program, {
+			AGENTS_DIR: mkdtempSync(join(tmpdir(), "signet-agent-command-")),
+			fetchFromDaemon: async <T>() => ({ name: "writer", read_policy: "shared", effective_scope: "global" }) as T,
+		});
+		await program.parseAsync(["node", "test", "agent", "show", "writer"]);
+		expect(lines).toContain("  Agent: writer");
+		expect(lines).toContain("  Read policy: shared");
+		expect(lines).toContain("  Effective scope: global");
+	});
 });

--- a/surfaces/cli/src/commands/agent.ts
+++ b/surfaces/cli/src/commands/agent.ts
@@ -360,8 +360,14 @@ export function registerAgentCommands(program: Command, deps: AgentDeps): void {
 		.description("Show daemon-backed agent policy and scope")
 		.action(async (name: string) => {
 			const data = await deps.fetchFromDaemon<Record<string, unknown>>(`/api/agents/${encodeURIComponent(name)}`);
-			if (!data) { console.log(chalk.red("  Daemon unavailable")); process.exit(1); }
-			if (data && typeof data.error === "string") { console.log(chalk.red(`  ${data.error}`)); process.exit(1); }
+			if (!data) {
+				console.log(chalk.red("  Daemon unavailable"));
+				process.exit(1);
+			}
+			if (data && typeof data.error === "string") {
+				console.log(chalk.red(`  ${data.error}`));
+				process.exit(1);
+			}
 			console.log(`  Agent: ${String(data?.name ?? name)}`);
 			console.log(`  Read policy: ${String(data?.read_policy ?? "isolated")}`);
 			if (data?.policy_group) console.log(`  Policy group: ${String(data.policy_group)}`);
@@ -376,12 +382,22 @@ export function registerAgentCommands(program: Command, deps: AgentDeps): void {
 		.option("--group <group>", "Policy group name (required when --memory=group)")
 		.action(async (name: string, options: { memory: string; group?: string }) => {
 			const err = validateName(name);
-			if (err) { console.log(chalk.red(`  ${err}`)); process.exit(1); }
+			if (err) {
+				console.log(chalk.red(`  ${err}`));
+				process.exit(1);
+			}
 			const result = await deps.fetchFromDaemon<Record<string, unknown>>(`/api/agents/${encodeURIComponent(name)}`, {
-				method: "PATCH", headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ memory: options.memory, ...(options.group !== undefined ? { group: options.group } : {}) }),
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					memory: options.memory,
+					...(options.group !== undefined ? { group: options.group } : {}),
+				}),
 			});
-			if (!result || typeof result.error === "string") { console.log(chalk.red(`  ${typeof result?.error === "string" ? result.error : "Daemon unavailable"}`)); process.exit(1); }
+			if (!result || typeof result.error === "string") {
+				console.log(chalk.red(`  ${typeof result?.error === "string" ? result.error : "Daemon unavailable"}`));
+				process.exit(1);
+			}
 			console.log(`  Agent ${name} policy set to ${String(result.read_policy)}`);
 		});
 }

--- a/surfaces/cli/src/commands/agent.ts
+++ b/surfaces/cli/src/commands/agent.ts
@@ -353,4 +353,35 @@ export function registerAgentCommands(program: Command, deps: AgentDeps): void {
 			}
 			console.log();
 		});
+
+	// `show` is the canonical name; retain `info` above for compatibility.
+	agentCmd
+		.command("show <name>")
+		.description("Show daemon-backed agent policy and scope")
+		.action(async (name: string) => {
+			const data = await deps.fetchFromDaemon<Record<string, unknown>>(`/api/agents/${encodeURIComponent(name)}`);
+			if (!data) { console.log(chalk.red("  Daemon unavailable")); process.exit(1); }
+			if (data && typeof data.error === "string") { console.log(chalk.red(`  ${data.error}`)); process.exit(1); }
+			console.log(`  Agent: ${String(data?.name ?? name)}`);
+			console.log(`  Read policy: ${String(data?.read_policy ?? "isolated")}`);
+			if (data?.policy_group) console.log(`  Policy group: ${String(data.policy_group)}`);
+			if (data?.effective_scope) console.log(`  Effective scope: ${String(data.effective_scope)}`);
+			if (typeof data?.memory_count === "number") console.log(`  Memory count: ${data.memory_count}`);
+		});
+
+	agentCmd
+		.command("set <name>")
+		.description("Set an agent's daemon-backed memory policy")
+		.requiredOption("--memory <policy>", "Memory read policy: isolated|shared|group")
+		.option("--group <group>", "Policy group name (required when --memory=group)")
+		.action(async (name: string, options: { memory: string; group?: string }) => {
+			const err = validateName(name);
+			if (err) { console.log(chalk.red(`  ${err}`)); process.exit(1); }
+			const result = await deps.fetchFromDaemon<Record<string, unknown>>(`/api/agents/${encodeURIComponent(name)}`, {
+				method: "PATCH", headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ memory: options.memory, ...(options.group !== undefined ? { group: options.group } : {}) }),
+			});
+			if (!result || typeof result.error === "string") { console.log(chalk.red(`  ${typeof result?.error === "string" ? result.error : "Daemon unavailable"}`)); process.exit(1); }
+			console.log(`  Agent ${name} policy set to ${String(result.read_policy)}`);
+		});
 }

--- a/web/docs/src/content/docs/api.md
+++ b/web/docs/src/content/docs/api.md
@@ -107,3 +107,8 @@ Mutations blocked by the kill switch return `503`.
 Route details live in `docs/api/` so the root API page stays readable. When
 adding or changing daemon routes, update the matching reference file and run
 `bun scripts/doc-drift.ts --markdown`.
+
+
+## Agent policy
+
+`GET /api/agents/:name` returns the agent's `read_policy`, optional `policy_group`, timestamps, and resolved `effective_scope` (`agent`, `global`, or `group`). `POST /api/agents` and `PATCH /api/agents/:name` accept `isolated`, `shared`, or `group`; `group` requires a group name and the other policies reject one. The daemon validates at the boundary and never falls back to local `agent.yaml` state. `signet agent set` uses PATCH, `signet agent show` uses GET, and `signet agent info` remains a compatibility alias.


### PR DESCRIPTION
## Summary
Implements issue #1642 slice 3 agent policy mutation and introspection.

- Adds daemon PATCH `/api/agents/:name` with strict centralized policy validation.
- Adds `signet agent set` and canonical `signet agent show`; retains `info`.
- Returns resolved effective scope and prevents local `agent.yaml` fallback for mutation.
- Routes existing agent creation through the same validator.
- Updates API documentation.

## POST validation decision
Changing POST validation is backward-compatible for valid requests and intentionally rejects malformed policy/group combinations that previously persisted invalid state. This is required so all daemon entry points enforce the same invariant; callers already using isolated/shared policies without a group are unchanged.

## Verification
- `bun install` passed: 3056 packages installed.
- `bun run --filter '@signet/core' build` passed.
- `bun run --filter '@signet/daemon' build` passed, including `tsc --noEmit` and Vite dashboard build.
- `bun run --filter '@signet/cli' build` passed.
- `git diff --check` passed.

AI usage disclosed per `AI_POLICY.md`; commit includes Assisted-by metadata.