### PR TITLE
fix(cli): honor Hermes profile targets

### DIFF
--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -1664,7 +1664,7 @@ describe("HermesAgentConnector profile ownership boundaries", () => {
 		symlinkSync(victim, join(home, ".hermes", "profiles", "escape"));
 		process.env.HOME = home;
 		process.env.HERMES_HOME = undefined;
-		await expect(new HermesAgentConnector().install(join(home, ".agents"), { profile: "escape" })).rejects.toThrow(
+		await expect(new HermesAgentConnector({ profile: "escape" }).install(join(home, ".agents"))).rejects.toThrow(
 			/(symlinked|escapes validated root)/,
 		);
 		expect(existsSync(join(victim, "plugins"))).toBe(false);
@@ -1680,7 +1680,7 @@ describe("HermesAgentConnector profile ownership boundaries", () => {
 		writeFileSync(join(profile, ".env"), env);
 		process.env.HOME = home;
 		process.env.HERMES_HOME = undefined;
-		const result = await new HermesAgentConnector().uninstall({ profile: "unowned" });
+		const result = await new HermesAgentConnector({ profile: "unowned" }).uninstall();
 		expect(result.filesRemoved).toEqual([]);
 		expect(readFileSync(join(profile, "config.yaml"), "utf8")).toBe(config);
 		expect(readFileSync(join(profile, ".env"), "utf8")).toBe(env);

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -71,6 +71,10 @@ export interface HermesConnectorOptions {
 	readonly policyGroup?: string;
 }
 
+export interface HermesConnectorTarget {
+	readonly profile?: string;
+}
+
 export interface HermesDoctorReport {
 	readonly ok: boolean;
 	readonly hermesHome: string;
@@ -821,22 +825,27 @@ async function ensureNamedAgentRegistered(
 export class HermesAgentConnector extends BaseConnector {
 	readonly name = "Hermes Agent";
 	readonly harnessId = "hermes-agent";
-	private targetOptions: HermesConnectorOptions = {};
+	private readonly target?: HermesConnectorTarget;
+
+	constructor(target?: HermesConnectorTarget) {
+		super();
+		this.target = target;
+	}
 
 	private getHermesHome(): string {
-		if (this.targetOptions.profile) {
-			if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(this.targetOptions.profile)) {
+		if (this.target?.profile) {
+			if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(this.target.profile)) {
 				throw new Error("Invalid Hermes profile name; use 1-64 letters, numbers, '.', '_' or '-'.");
 			}
 			const userHome = process.env.HOME?.trim() || homedir();
-			const profileHome = join(userHome, ".hermes", "profiles", this.targetOptions.profile);
+			const profileHome = join(userHome, ".hermes", "profiles", this.target.profile);
 			return resolveContainedWritePath(profileHome, join(userHome, ".hermes", "profiles"));
 		}
 		return resolveHermesHomePath();
 	}
 
 	private getHermesRepo(): string | null {
-		if (this.targetOptions.profile) return null;
+		if (this.target?.profile) return null;
 		return resolveHermesRepoPath();
 	}
 
@@ -845,12 +854,11 @@ export class HermesAgentConnector extends BaseConnector {
 	}
 
 	async install(basePath: string, options: HermesConnectorOptions = {}): Promise<InstallResult> {
-		this.targetOptions = options;
 		const filesWritten: string[] = [];
 		const configsPatched: string[] = [];
 		const warnings: string[] = [];
 		const expandedBasePath = expandHome(basePath || join(homedir(), ".agents"));
-		const strippedAgentsPath = options.profile ? null : this.stripLegacySignetBlock(expandedBasePath);
+		const strippedAgentsPath = this.target?.profile ? null : this.stripLegacySignetBlock(expandedBasePath);
 		if (strippedAgentsPath !== null) {
 			filesWritten.push(strippedAgentsPath);
 		}
@@ -1050,8 +1058,7 @@ export class HermesAgentConnector extends BaseConnector {
 		};
 	}
 
-	async uninstall(options: HermesConnectorOptions = {}): Promise<UninstallResult> {
-		this.targetOptions = options;
+	async uninstall(): Promise<UninstallResult> {
 		const filesRemoved: string[] = [];
 		const configsPatched: string[] = [];
 
@@ -1063,13 +1070,13 @@ export class HermesAgentConnector extends BaseConnector {
 
 		const hermesHome = this.getHermesHome();
 		const userPluginTarget = getUserPluginTargetDir(hermesHome);
-		if (options.profile && (!existsSync(userPluginTarget) || readInstallMarker(userPluginTarget) === null)) {
+		if (this.target?.profile && (!existsSync(userPluginTarget) || readInstallMarker(userPluginTarget) === null)) {
 			return { filesRemoved, configsPatched };
 		}
-		const userPluginRemoved = uninstallPlugin(userPluginTarget, options.profile ? hermesHome : undefined);
+		const userPluginRemoved = uninstallPlugin(userPluginTarget, this.target?.profile ? hermesHome : undefined);
 		filesRemoved.push(...userPluginRemoved);
 
-		const providerConfig = restoreOrClearProvider(hermesHome, options.profile ? hermesHome : undefined);
+		const providerConfig = restoreOrClearProvider(hermesHome, this.target?.profile ? hermesHome : undefined);
 		if (providerConfig.configPath) {
 			configsPatched.push(providerConfig.configPath);
 		}
@@ -1077,7 +1084,7 @@ export class HermesAgentConnector extends BaseConnector {
 			filesRemoved.push(providerConfig.backupPath);
 		}
 
-		const envPath = options.profile
+		const envPath = this.target?.profile
 			? resolveContainedWritePath(join(hermesHome, ".env"), hermesHome)
 			: join(hermesHome, ".env");
 		if (existsSync(envPath)) {

--- a/surfaces/cli/src/commands/connector.ts
+++ b/surfaces/cli/src/commands/connector.ts
@@ -43,8 +43,7 @@ async function installConnector(harness: string, options: ConnectorInstallOption
 
 async function installHermes(options: ConnectorInstallOptions, deps: ConnectorDeps): Promise<void> {
 	if (!options.profile) throw new Error("--profile is required for connect hermes");
-	const result = await new HermesAgentConnector().install(options.path ?? deps.agentsDir, {
-		profile: options.profile,
+	const result = await new HermesAgentConnector({ profile: options.profile }).install(options.path ?? deps.agentsDir, {
 		agentId: options.agent ?? options.profile,
 		memoryPolicy: options.memory,
 		policyGroup: options.group,
@@ -57,7 +56,7 @@ async function installHermes(options: ConnectorInstallOptions, deps: ConnectorDe
 
 async function disconnectHermes(options: ConnectorInstallOptions): Promise<void> {
 	if (!options.profile) throw new Error("--profile is required for disconnect hermes");
-	const result = await new HermesAgentConnector().uninstall({ profile: options.profile });
+	const result = await new HermesAgentConnector({ profile: options.profile }).uninstall();
 	console.log(chalk.green(`  ✓ Hermes Agent disconnected (${result.filesRemoved.length} file(s) removed)`));
 }
 


### PR DESCRIPTION
Fixes #1654

## Problem

`connect hermes --profile <name>` and `disconnect hermes --profile <name>` passed the profile in the install/uninstall options bag, but the connector resolved its Hermes home from its constructed target. The profile was therefore ignored and the ambient Hermes profile could be mutated.

## Approach

- Construct `HermesAgentConnector` with the validated profile target at both CLI call sites.
- Keep install/uninstall operation options for registration and policy data only; profile resolution is owned by connector construction.
- Update the existing profile ownership regressions to exercise the constructor target path.

## Verification

- `bun test integrations/hermes-agent/connector/index.test.ts`: 82 pass, 0 fail.
- `bun run --filter '@signet/connector-hermes-agent' typecheck`: pass.
- `bunx biome check integrations/hermes-agent/connector/src/index.ts integrations/hermes-agent/connector/index.test.ts surfaces/cli/src/commands/connector.ts`: pass.
- `git diff --check`: pass.
- CLI package build was attempted but is blocked by the worktree's missing workspace packages and missing `@napi-rs/keyring` declarations, unrelated to this diff.

## Risk

Scoped to Hermes connector profile target selection. Ambient installs remain unchanged; explicit profile installs and disconnects now resolve under `~/.hermes/profiles/<name>`.

<!-- checklist-exception: CLI build is blocked by missing pre-existing workspace dependencies in this worktree; focused connector gates are green. -->

Assisted-by: OpenAI Codex: gpt-5.6-luna