### PR TITLE
fix(synthesis): retire remaining completion callers

### DIFF
--- a/libs/sdk/src/client-p2.ts
+++ b/libs/sdk/src/client-p2.ts
@@ -45,7 +45,6 @@ import type {
 	SessionEndResponse,
 	// Hooks
 	SessionStartResponse,
-	SynthesisCompleteResponse,
 	SynthesisConfigResponse,
 	SynthesisRequestResponse,
 	TraversalStatusResponse,
@@ -275,19 +274,6 @@ export class SignetClientP2 {
 		readonly force?: boolean;
 	}): Promise<SynthesisRequestResponse> {
 		return this.transport.post<SynthesisRequestResponse>("/api/hooks/synthesis", opts ?? {});
-	}
-
-	/**
-	 * @example
-	 * const result = await client.synthesisComplete({
-	 *   content: '# MEMORY.md\n...'
-	 * });
-	 */
-	async synthesisComplete(opts: {
-		readonly content: string;
-		readonly project?: string;
-	}): Promise<SynthesisCompleteResponse> {
-		return this.transport.post<SynthesisCompleteResponse>("/api/hooks/synthesis/complete", opts);
 	}
 
 	// --- Connectors ---

--- a/libs/sdk/src/generated/client.ts
+++ b/libs/sdk/src/generated/client.ts
@@ -297,9 +297,7 @@ export class GeneratedClient {
 		return this.transport.post<unknown>("/api/hooks/synthesis", opts);
 	}
 
-	async postApiHooksSynthesisComplete(opts?: Record<string, unknown>): Promise<unknown> {
-		return this.transport.post<unknown>("/api/hooks/synthesis/complete", opts);
-	}
+
 
 	async postApiSynthesisTrigger(opts?: Record<string, unknown>): Promise<unknown> {
 		return this.transport.post<unknown>("/api/synthesis/trigger", opts);

--- a/libs/sdk/src/types-p2.ts
+++ b/libs/sdk/src/types-p2.ts
@@ -119,10 +119,6 @@ export interface SynthesisRequestResponse {
 	readonly triggered: boolean;
 }
 
-export interface SynthesisCompleteResponse {
-	readonly message: string;
-}
-
 // ============================================================================
 // Connectors types
 // ============================================================================

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -1267,7 +1267,6 @@ export type {
 	CompactionCompleteResponse,
 	SynthesisConfigResponse,
 	SynthesisRequestResponse,
-	SynthesisCompleteResponse,
 	// Connectors
 	ConnectorRecord,
 	ConnectorListResponse,

--- a/platform/daemon/src/memory-synthesis.ts
+++ b/platform/daemon/src/memory-synthesis.ts
@@ -31,7 +31,7 @@ export function getSynthesisWorker(): Worker | null {
 
 /**
  * Write MEMORY.md with backup of previous version.
- * Shared by the synthesis-complete endpoint and the synthesis worker.
+ * Shared by the synthesis worker and legacy internal callers.
  */
 export function writeMemoryMd(
 	content: string,

--- a/platform/daemon/src/routes/hooks-routes.notifications.test.ts
+++ b/platform/daemon/src/routes/hooks-routes.notifications.test.ts
@@ -1,10 +1,11 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
 import { createAgentMessage, resetCrossAgentStateForTest, upsertAgentPresence } from "../cross-agent";
+import { getSynthesisWorker } from "../hooks";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 
 const previousSignetPath = process.env.SIGNET_PATH;
@@ -46,7 +47,7 @@ async function post(path: string, body: Readonly<Record<string, unknown>>): Prom
 }
 
 describe("cross-agent notification routes", () => {
-	it("rejects retired synthesis completion without changing MEMORY.md", async () => {
+	it("rejects retired synthesis completion with its structured contract and without changing MEMORY.md", async () => {
 		const memoryPath = join(dir, "MEMORY.md");
 		const before = "# Existing head\n\n- keep this content\n";
 		writeFileSync(memoryPath, before);
@@ -58,7 +59,17 @@ describe("cross-agent notification routes", () => {
 		});
 
 		expect(response.status).toBe(410);
+		expect(await response.json()).toEqual({
+			error: "Synthesis completion route retired; use Dreaming",
+			code: "SYNTHESIS_COMPLETION_RETIRED",
+			version: 1,
+			deprecatedRoute: "/api/hooks/synthesis/complete",
+			replacement: { method: "POST", path: "/api/synthesis/trigger" },
+			migration: "Dreaming owns manifest-gated MEMORY.md head publication; do not submit content directly.",
+		});
 		expect(readFileSync(memoryPath, "utf8")).toBe(before);
+		expect(existsSync(join(dir, "agents", "default", "MEMORY.md"))).toBe(false);
+		expect(getSynthesisWorker()).toBeNull();
 	});
 
 	it("injects unread messages at a compatible hook and suppresses them after explicit acknowledgement", async () => {

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -1882,7 +1882,17 @@ function registerSynthesis(app: Hono): void {
 
 	// Retired: Dreaming's manifest-gated path is the sole MEMORY.md publisher.
 	app.post("/api/hooks/synthesis/complete", async (c) => {
-		return c.json({ error: "Synthesis completion route retired; use Dreaming" }, 410);
+		return c.json(
+			{
+				error: "Synthesis completion route retired; use Dreaming",
+				code: "SYNTHESIS_COMPLETION_RETIRED",
+				version: 1,
+				deprecatedRoute: "/api/hooks/synthesis/complete",
+				replacement: { method: "POST", path: "/api/synthesis/trigger" },
+				migration: "Dreaming owns manifest-gated MEMORY.md head publication; do not submit content directly.",
+			},
+			410,
+		);
 	});
 
 	// Trigger immediate MEMORY.md synthesis

--- a/surfaces/cli/src/commands/hook.ts
+++ b/surfaces/cli/src/commands/hook.ts
@@ -443,28 +443,6 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 			console.log(chalk.dim(`Session files: ${data?.fileCount ?? 0}\n`));
 			if (data?.prompt) console.log(data.prompt);
 		});
-
-	hookCmd
-		.command("synthesis-complete")
-		.description("Save synthesized MEMORY.md content")
-		.requiredOption("-c, --content <content>", "Synthesized MEMORY.md content")
-		.action(async (options) => {
-			const data = await fetchHookData<{ success?: boolean; error?: string }>(
-				deps,
-				"synthesis-complete",
-				"/api/hooks/synthesis/complete",
-				{
-					method: "POST",
-					body: JSON.stringify({ content: options.content }),
-				},
-			);
-			if (!data) return;
-			if (data?.error) {
-				console.error(chalk.red(`Error: ${data.error}`));
-				process.exit(1);
-			}
-			if (data?.success) console.log(chalk.green("✓ MEMORY.md synthesized"));
-		});
 }
 
 export function shouldReadCompactionInput(

--- a/web/docs/src/content/docs/api/sessions-hooks.md
+++ b/web/docs/src/content/docs/api/sessions-hooks.md
@@ -393,30 +393,11 @@ the correct agent-scoped head.
 
 ### POST /api/hooks/synthesis/complete
 
-Write a newly synthesized `MEMORY.md`. Backs up the existing file before
-overwriting and records DB-backed head metadata used for same-agent
-merge protection.
+Retired. This compatibility boundary returns HTTP 410 with a structured,
+versioned migration payload. Dreaming owns manifest-gated `MEMORY.md` head
+publication; callers must not submit generated content directly.
 
-**Request body**
-
-```json
-{
-  "content": "# Memory\n\n...",
-  "agentId": "optional-agent-id",
-  "sessionKey": "optional-session-key"
-}
-```
-
-`content` is required.
-
-If another writer currently holds the active `MEMORY.md` lease for the same
-agent head, this route returns `409`.
-
-**Response**
-
-```json
-{ "success": true }
-```
+Use `POST /api/synthesis/trigger` to request the supported Dreaming flow.
 
 
 ## Sessions

--- a/web/docs/src/content/docs/cli/integrations-security.md
+++ b/web/docs/src/content/docs/cli/integrations-security.md
@@ -204,6 +204,11 @@ Subcommands:
 | `signet hook pre-compaction` | Get summary instructions before compaction |
 | `signet hook compaction-complete` | Save session summary after compaction |
 | `signet hook synthesis` | Get the MEMORY.md synthesis prompt |
+
+API/migration endpoint:
+
+| Endpoint | Description |
+|----------|-------------|
 | `POST /api/synthesis/trigger` | Trigger Dreaming's manifest-gated MEMORY.md publication |
 
 Most subcommands require `-H, --harness <harness>` identifying the calling

--- a/web/docs/src/content/docs/cli/integrations-security.md
+++ b/web/docs/src/content/docs/cli/integrations-security.md
@@ -191,7 +191,7 @@ signet hook session-end --harness claude-code
 signet hook pre-compaction --harness claude-code
 signet hook compaction-complete --harness claude-code --summary "..."
 signet hook synthesis
-signet hook synthesis-complete --content "..."
+
 ```
 
 Subcommands:
@@ -204,7 +204,7 @@ Subcommands:
 | `signet hook pre-compaction` | Get summary instructions before compaction |
 | `signet hook compaction-complete` | Save session summary after compaction |
 | `signet hook synthesis` | Get the MEMORY.md synthesis prompt |
-| `signet hook synthesis-complete` | Save synthesized MEMORY.md content |
+| `POST /api/synthesis/trigger` | Trigger Dreaming's manifest-gated MEMORY.md publication |
 
 Most subcommands require `-H, --harness <harness>` identifying the calling
 platform (e.g. `claude-code`, `opencode`, `openclaw`). If the daemon is

--- a/web/docs/src/content/docs/harnesses/openclaw.md
+++ b/web/docs/src/content/docs/harnesses/openclaw.md
@@ -111,9 +111,9 @@ The daemon synthesis worker is the primary runtime path for keeping
 1. Calls `GET /api/hooks/synthesis/config` to check if synthesis should run
 2. Calls `POST /api/hooks/synthesis` to get the synthesis prompt
 3. Runs the prompt through the configured model
-4. Posts the result to `POST /api/hooks/synthesis/complete`
+4. Does not post generated content to the retired completion hook; Dreaming owns manifest-gated publication
 
-Both paths write through the same merge-safe head record, so the rendered
+The supported path writes through Dreaming's merge-safe manifest head, so the rendered
 `MEMORY.md` stays shared across harnesses instead of becoming
 OpenClaw-specific.
 

--- a/web/docs/src/content/docs/hooks.md
+++ b/web/docs/src/content/docs/hooks.md
@@ -20,7 +20,7 @@ Hooks are HTTP endpoints exposed by the Signet [Daemon](/daemon/). Harnesses cal
 | `pre-compaction` | Before context compaction | Get summary guidelines |
 | `compaction-complete` | After compaction | Save a first-class compaction artifact into the temporal DAG |
 | `synthesis` | Retired | The route remains only as a loud compatibility boundary |
-| `synthesis/complete` | Retired | Returns HTTP 410; Dreaming owns manifest-gated MEMORY.md head publication |
+| `synthesis/complete` | Retired | Returns HTTP 410 with a structured payload; Dreaming owns manifest-gated MEMORY.md head publication |
 
 ---
 
@@ -442,11 +442,12 @@ Response:
 
 The harness runs the prompt through the specified model.
 
-### Step 3: Retired route
+### Step 3: Retired completion route
 
-`POST /api/hooks/synthesis/complete` is retired and returns HTTP 410. Do not
-send generated content to this route. Dreaming owns manifest-gated publication
-of the curated MEMORY.md head.
+`POST /api/hooks/synthesis/complete` is retired and returns HTTP 410 with a structured
+deprecation payload. Do not send generated content to this route. Dreaming
+owns manifest-gated publication of the curated `MEMORY.md` head. Use
+`POST /api/synthesis/trigger` to request the supported flow.
 
 The daemon does not write MEMORY.md here, and no head change occurs.
 

--- a/web/docs/src/content/docs/sdk/integrations.md
+++ b/web/docs/src/content/docs/sdk/integrations.md
@@ -55,10 +55,10 @@ const context = await client.userPromptSubmit({ sessionKey: "session-123", promp
 await client.sessionEnd({ sessionKey: "session-123", harness: "my-harness", transcript: "…", project: "/workspace/app" });
 await client.preCompaction({ sessionKey: "session-123", context: "Current session summary", project: "/workspace/app" });
 await client.compactionComplete({ sessionKey: "session-123", summary: "Compacted summary", project: "/workspace/app" });
-await client.synthesisComplete({ content: "Memory summary", project: "/workspace/app" });
+await client.requestSynthesis({ project: "/workspace/app" });
 ```
 
-`sessionEnd` requires `sessionKey` and `harness`; it does not take a `summary` field. `synthesisComplete` is the exported method name, not `completeSynthesis`.
+`sessionEnd` requires `sessionKey` and `harness`; it does not take a `summary` field. Synthesis is Dreaming-owned and manifest-gated; callers request a run with `requestSynthesis` and must not submit generated MEMORY.md content.
 
 ## Connectors
 


### PR DESCRIPTION
## Summary
Fixes #1656 by removing shipped callers to the retired synthesis completion contract instead of reopening the publication side door.

## Migration map
- `surfaces/cli/src/commands/hook.ts`: removed `signet hook synthesis-complete`; use Dreaming via the synthesis trigger flow.
- `libs/sdk/src/client-p2.ts`: removed `synthesisComplete()`; use `requestSynthesis()`.
- `libs/sdk/src/generated/client.ts`: removed generated retired-route method.
- OpenClaw/public docs: describe Dreaming-owned manifest-gated publication and the migration boundary.
- `POST /api/hooks/synthesis/complete`: remains HTTP 410 with versioned machine-readable replacement metadata.

## Verification
- `bun test surfaces/cli/src/commands/hook.test.ts` (43 pass)
- `bun run --filter @signet/core build` (pass)
- `bun run --filter @signet/sdk build` (pass before workspace native dependency refresh; daemon build remains blocked by missing `better-sqlite3` native package)
- Biome on touched TypeScript files (pass)
- `git diff --check` (pass)
- Repository grep leaves only the intentional retired boundary and migration documentation references.

## Checklist
- [x] AI-assisted changes disclosed in commit metadata
- [x] Public docs updated
- [x] No direct MEMORY.md publication remains in the retired route
- [x] checklist-exception: no repository PR template was present; equivalent scope, verification, and migration checklist included here
