### PR TITLE
fix(daemon): accept null policy_group on POST /api/agents

### DIFF
--- a/platform/daemon/src/agent-routes-policy.test.ts
+++ b/platform/daemon/src/agent-routes-policy.test.ts
@@ -71,6 +71,12 @@ describe("agent route memory policy contracts", () => {
 		expect((await request("PATCH", "/api/agents/omitted", { read_policy: "group", policy_group: "team" })).status).toBe(
 			200,
 		);
+		expect((await request("PATCH", "/api/agents/omitted", { read_policy: "group", policy_group: "" })).status).toBe(
+			400,
+		);
+		expect(
+			(await request("PATCH", "/api/agents/omitted", { read_policy: "group", policy_group: "x".repeat(129) })).status,
+		).toBe(400);
 		expect((await request("PATCH", "/api/agents/not-found", {})).status).toBe(404);
 	});
 });

--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -643,6 +643,32 @@ inference:
 			});
 			expect(readFileSync(join(tmpDir, "agent.yaml"), "utf-8")).toBe(original);
 		});
+		it("POST /api/agents distinguishes omitted, null, valid, and invalid policy_group", async () => {
+			const app = await makeApp();
+			const { registerMiscRoutes } = await import("./routes/misc-routes");
+			registerMiscRoutes(app);
+			const cases = [
+				[{ name: "agent-omitted" }, 201],
+				[{ name: "agent-null-isolated", read_policy: "isolated", policy_group: null }, 201],
+				[{ name: "agent-null-shared", read_policy: "shared", policy_group: null }, 201],
+				[{ name: "agent-valid", read_policy: "group", policy_group: "workers" }, 201],
+				[{ name: "agent-number", policy_group: 42 }, 400],
+				[{ name: "agent-empty", policy_group: "" }, 400],
+				[{ name: "agent-oversize", policy_group: "x".repeat(129) }, 400],
+			] as const;
+			for (const [body, expectedStatus] of cases) {
+				const response = await app.request("/api/agents", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify(body),
+				});
+				expect(response.status).toBe(expectedStatus);
+				if (expectedStatus === 201) {
+					const created = (await response.json()) as { policy_group: string | null };
+					expect(created.policy_group).toBe((body as { policy_group?: string | null }).policy_group ?? null);
+				}
+			}
+		});
 	});
 
 	describe("knowledge routes need guards", () => {

--- a/platform/daemon/src/routes/misc-routes.ts
+++ b/platform/daemon/src/routes/misc-routes.ts
@@ -35,6 +35,17 @@ import { parseOptionalString, resolveScopedAgentId, shouldEnforceAuthScope, toRe
 const GUARDED_CONFIG_FILES_CI = new Set(["agent.yaml", "config.yaml"]);
 
 const MAX_CONFIG_BYTES = 1_048_576;
+const MAX_POLICY_GROUP_LENGTH = 128;
+
+function validatePolicyGroup(rawGroup: unknown): string | null | undefined {
+	if (rawGroup !== undefined && rawGroup !== null && typeof rawGroup !== "string") {
+		throw new Error("group must be a string");
+	}
+	if (typeof rawGroup === "string" && (rawGroup.length === 0 || rawGroup.length > MAX_POLICY_GROUP_LENGTH)) {
+		throw new Error(`group must be between 1 and ${MAX_POLICY_GROUP_LENGTH} characters`);
+	}
+	return rawGroup;
+}
 
 interface AgentRow {
 	id: string;
@@ -249,13 +260,7 @@ export function registerMiscRoutes(app: Hono): void {
 			if (rawPolicy !== undefined && typeof rawPolicy !== "string") {
 				return c.json({ error: "memory must be one of: isolated, shared, group" }, 400);
 			}
-			if (rawGroup !== undefined && rawGroup !== null && typeof rawGroup !== "string") {
-				return c.json({ error: "group must be a string" }, 400);
-			}
-			if (typeof rawGroup === "string" && (rawGroup.length === 0 || rawGroup.length > 128)) {
-				return c.json({ error: "group must be between 1 and 128 characters" }, 400);
-			}
-			resolved = resolveAgentMemoryPolicy(rawPolicy ?? "isolated", rawGroup);
+			resolved = resolveAgentMemoryPolicy(rawPolicy ?? "isolated", validatePolicyGroup(rawGroup));
 		} catch (error) {
 			return c.json({ error: error instanceof Error ? error.message : "Invalid memory policy" }, 400);
 		}
@@ -304,10 +309,7 @@ export function registerMiscRoutes(app: Hono): void {
 			if (typeof rawPolicy !== "string") {
 				return c.json({ error: "memory must be one of: isolated, shared, group" }, 400);
 			}
-			if (rawGroup !== null && rawGroup !== undefined && typeof rawGroup !== "string") {
-				return c.json({ error: "group must be a string" }, 400);
-			}
-			resolved = resolveAgentMemoryPolicy(rawPolicy, rawGroup);
+			resolved = resolveAgentMemoryPolicy(rawPolicy, validatePolicyGroup(rawGroup));
 		} catch (error) {
 			return c.json({ error: error instanceof Error ? error.message : "Invalid memory policy" }, 400);
 		}

--- a/platform/daemon/src/routes/misc-routes.ts
+++ b/platform/daemon/src/routes/misc-routes.ts
@@ -249,8 +249,11 @@ export function registerMiscRoutes(app: Hono): void {
 			if (rawPolicy !== undefined && typeof rawPolicy !== "string") {
 				return c.json({ error: "memory must be one of: isolated, shared, group" }, 400);
 			}
-			if (rawGroup !== undefined && typeof rawGroup !== "string") {
+			if (rawGroup !== undefined && rawGroup !== null && typeof rawGroup !== "string") {
 				return c.json({ error: "group must be a string" }, 400);
+			}
+			if (typeof rawGroup === "string" && (rawGroup.length === 0 || rawGroup.length > 128)) {
+				return c.json({ error: "group must be between 1 and 128 characters" }, 400);
 			}
 			resolved = resolveAgentMemoryPolicy(rawPolicy ?? "isolated", rawGroup);
 		} catch (error) {


### PR DESCRIPTION
## Summary

Fixes #1653.

The POST `/api/agents` validator now distinguishes an omitted `policy_group` from an explicit `null`: both persist as no group, while non-null non-string, empty, and oversized values remain invalid. This restores the nullable REST contract without loosening validation.

## Evidence

- Regression matrix covers omitted, explicit null for isolated and shared policies, valid group, number, empty string, and 129-character oversize input.
- Focused daemon route suite: 38 passed, 0 failed, 82 expectations.
- Daemon typecheck: passed.
- `git diff --check`: passed.

## Checklist exception

- [x] Tests added for the regression matrix
- [x] Focused tests and typecheck passed
- [x] Biome checked touched files; existing warnings in `misc-routes.ts` remain unrelated (`Context` import and pre-existing unused `result`)


