### PR TITLE
fix(dreaming): publish head and manifest atomically

### DIFF
--- a/platform/daemon/src/memory-head.test.ts
+++ b/platform/daemon/src/memory-head.test.ts
@@ -124,6 +124,11 @@ describe("writeMemoryHead", () => {
 
 	it("rolls back the head and projection when audit insertion violates uniqueness", async () => {
 		initDbAccessor(join(agentsDir, "memory", "memories.db"), { agentsDir });
+		await getDbAccessor().withWriteTxAsync((db) => {
+			db.prepare(
+				"INSERT INTO dreaming_passes (id, agent_id, mode, status) VALUES (?, ?, 'incremental-content', 'running')",
+			).run("pass-initial", "agent-a");
+		});
 		const initialContent = "# MEMORY\n\n## Active\n- original curated head\n";
 		const initialWrite = await curateMemoryHead({
 			passId: "pass-initial",
@@ -205,5 +210,35 @@ describe("writeMemoryHead", () => {
 				db.prepare("SELECT content, content_hash, revision FROM memory_md_heads WHERE agent_id = ?").get("agent-a"),
 			),
 		).toEqual(previousRow);
+	});
+
+	it("rolls back head publication when the pass manifest update fails", async () => {
+		initDbAccessor(join(agentsDir, "memory", "memories.db"), { agentsDir });
+		const result = await curateMemoryHead({
+			passId: "missing-manifest-pass",
+			agentId: "agent-a",
+			baseRevision: 0,
+			baseHash: "",
+			content: "# MEMORY\n\n## Active\n- must not publish\n",
+			entries: [
+				{
+					id: "entry-missing-manifest",
+					text: "must not publish",
+					operation: "added",
+					sourceRefs: ["source:missing-manifest"],
+					supportingQuotes: ["must not publish"],
+				},
+			],
+		});
+
+		expect(result).toMatchObject({ ok: false });
+		if (result.ok) throw new Error("expected manifest failure");
+		expect(result.error).toContain("manifest row is missing");
+		expect(existsSync(join(agentsDir, "agents", "agent-a", "MEMORY.md"))).toBe(false);
+		expect(
+			await getDbAccessor().withReadDbAsync((db) =>
+				db.prepare("SELECT revision, content FROM memory_md_heads WHERE agent_id = ?").get("agent-a"),
+			),
+		).toEqual({ revision: 0, content: "" });
 	});
 });

--- a/platform/daemon/src/memory-head.ts
+++ b/platform/daemon/src/memory-head.ts
@@ -334,6 +334,25 @@ export async function curateMemoryHead(input: MemoryHeadCuration): Promise<Memor
 					JSON.stringify(entry.sourceRefs),
 					JSON.stringify(entry.supportingQuotes),
 				);
+			const manifestUpdate = db
+				.prepare(
+					`UPDATE dreaming_passes
+					 SET head_revision = ?, head_hash = ?, head_added = ?, head_updated = ?,
+					     head_removed = ?, head_deferred = ?, head_no_op = ?
+					 WHERE id = ? AND agent_id = ?`,
+				)
+				.run(
+					next,
+					hash,
+					input.entries.filter((entry) => entry.operation === "added").length,
+					input.entries.filter((entry) => entry.operation === "updated").length,
+					input.entries.filter((entry) => entry.operation === "removed").length,
+					input.entries.filter((entry) => entry.operation === "deferred").length,
+					input.entries.filter((entry) => entry.operation === "no-op").length,
+					input.passId,
+					input.agentId,
+				);
+			if (manifestUpdate.changes !== 1) throw new Error("Dreaming pass manifest row is missing");
 			writeProjection(projected.file, input.agentId);
 		});
 	} catch (error) {

--- a/platform/daemon/src/pipeline/dreaming-capabilities.ts
+++ b/platform/daemon/src/pipeline/dreaming-capabilities.ts
@@ -841,31 +841,7 @@ export function createDreamingCapabilities(params: CreateDreamingCapabilitiesPar
 						async (input) => {
 							if (!params.passId || input.passId !== params.passId)
 								return { ok: false, error: "Head curation requires the active Dreaming pass" };
-							const result = await curateMemoryHead(input);
-							if (result.ok) {
-								if (!params.accessor.withWriteTxAsync)
-									throw new Error(
-										"Head curation requires the async write transaction accessor to record its pass manifest",
-									);
-								await params.accessor.withWriteTxAsync((db) =>
-									db
-										.prepare(
-											`UPDATE dreaming_passes SET head_revision = ?, head_hash = ?, head_added = ?, head_updated = ?, head_removed = ?, head_deferred = ?, head_no_op = ? WHERE id = ? AND agent_id = ?`,
-										)
-										.run(
-											result.revision,
-											result.hash,
-											input.entries.filter((entry) => entry.operation === "added").length,
-											input.entries.filter((entry) => entry.operation === "updated").length,
-											input.entries.filter((entry) => entry.operation === "removed").length,
-											input.entries.filter((entry) => entry.operation === "deferred").length,
-											input.entries.filter((entry) => entry.operation === "no-op").length,
-											input.passId,
-											input.agentId,
-										),
-								);
-							}
-							return result;
+							return await curateMemoryHead(input);
 						},
 					),
 				]),


### PR DESCRIPTION
## Summary

Fixes #1652.

The regression was real: `curateMemoryHead()` admitted the head rows, revision audit, and projection in one writer transaction, but the capability handler updated `dreaming_passes` in a second transaction. A failure in that second write left the durable head and pass manifest inconsistent.

This change moves the pass manifest update into the same `withWriteTxAsync` callback as head publication, revision audit, and projection admission. A missing or failed manifest update now throws inside that transaction, so the head state and audit rows roll back together. The capability handler no longer opens a second transaction.

## Test evidence

- `bun test platform/daemon/src/memory-head.test.ts` -> 8 pass, 0 fail
- Regression covers a missing manifest row and verifies no published head/projection remains
- Existing audit-insert rollback regression remains green
- `bunx biome check platform/daemon/src/memory-head.ts platform/daemon/src/pipeline/dreaming-capabilities.ts platform/daemon/src/memory-head.test.ts` -> clean
- `bun run --filter '@signet/core' build` -> pass
- `bun run --filter '@signet/daemon' build` -> pass

## Scope

No migration or API contract changes. The unrelated whole-repository dashboard CI failures are outside this change.

<!-- checklist-exception: requested for this focused regression fix; focused tests, Biome, core build, and daemon build are recorded above. -->