### PR TITLE
fix(daemon): make embedding provider failures durable

### DIFF
--- a/platform/daemon/src/embedding-index-migration.ts
+++ b/platform/daemon/src/embedding-index-migration.ts
@@ -10,7 +10,13 @@ import {
 	type PersistedEmbeddingProfile,
 	readEmbeddingIndexState,
 } from "./embedding-index-state";
-import { beginEmbeddingIndexBuild, failEmbeddingIndexBuild } from "./embedding-index-state";
+import {
+	beginEmbeddingIndexBuild,
+	failEmbeddingIndexBuild,
+	MAX_CONSECUTIVE_PROVIDER_FAILURES,
+	MAX_PROVIDER_BACKOFF_MS,
+	persistEmbeddingIndexFailure,
+} from "./embedding-index-state";
 import { embeddingProfileFingerprint, recommendedEmbeddingProfileId, type EmbeddingRole } from "./embedding-profile";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
@@ -21,13 +27,6 @@ const ACTIVE_VECTOR_TABLE = "vec_embeddings";
 const VECTOR_REBUILD_BATCH_SIZE = 50;
 const VECTOR_REBUILD_RETRY_DELAY_MS = 100;
 const MAX_VECTOR_REBUILD_RETRIES_WITHOUT_CANCELLATION = 3;
-
-// #1160: after this many consecutive provider-unavailable checks the build is
-// aborted (state='failed') instead of retrying forever; the daemon restarts
-// the build on the next config change / daemon restart.
-const MAX_CONSECUTIVE_PROVIDER_FAILURES = 6;
-// Backoff grows pollMs * 2^n between failed checks, capped at this delay.
-const MAX_PROVIDER_BACKOFF_MS = 60_000;
 
 interface ActiveEmbeddingRow {
 	readonly content_hash: string;
@@ -1212,14 +1211,26 @@ export async function startEmbeddingIndexMigration(input: {
 				if (consecutiveFailures >= MAX_CONSECUTIVE_PROVIDER_FAILURES) {
 					const message = `Embedding provider unavailable after ${consecutiveFailures} consecutive checks; aborting the build`;
 					logger.error("embedding", message);
+					const nextAttemptAt = new Date(
+						Date.now() + Math.min(input.pollMs * 2 ** Math.min(consecutiveFailures, 6), MAX_PROVIDER_BACKOFF_MS),
+					).toISOString();
 					if (input.owner)
 						await ownerRun(
 							input.owner,
 							"UPDATE embedding_index_state SET state = 'failed', last_error = ?, updated_at = ? WHERE id = 1",
-							[message, new Date().toISOString()],
+							[
+								persistEmbeddingIndexFailure(message, { cause: "provider-unavailable", nextAttemptAt }),
+								new Date().toISOString(),
+							],
 							ownerMaintenanceOptions("embedding-index.fail"),
 						);
-					else await withQueuedWrite(input.accessor, (db) => failEmbeddingIndexBuild(db, message));
+					else
+						await withQueuedWrite(input.accessor, (db) =>
+							failEmbeddingIndexBuild(db, message, new Date().toISOString(), {
+								cause: "provider-unavailable",
+								nextAttemptAt,
+							}),
+						);
 					running = false;
 					return;
 				}

--- a/platform/daemon/src/embedding-index-state.test.ts
+++ b/platform/daemon/src/embedding-index-state.test.ts
@@ -68,6 +68,43 @@ describe("embedding index state", () => {
 		expect(ensureEmbeddingIndexState(db, config).active).toEqual(active.active);
 	});
 
+	it("keeps provider-unavailable failure durable across restart until its retry time", () => {
+		const raw = new Database(":memory:");
+		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);
+		raw.exec(
+			"CREATE TABLE embeddings_staging (id TEXT PRIMARY KEY, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER)",
+		);
+		const db = raw as unknown as WriteDb;
+		const staged = beginEmbeddingIndexBuild(db, {
+			...config,
+			provider: "ollama",
+			model: "qwen3-embedding:0.6b",
+			dimensions: 1024,
+		});
+		db.prepare(
+			"INSERT INTO embeddings_staging (id, content_hash, vector, dimensions) VALUES ('s1', 'h1', X'00', 1024)",
+		).run();
+		failEmbeddingIndexBuild(db, "provider unavailable", "2026-01-01T00:00:00.000Z", {
+			cause: "provider-unavailable",
+			nextAttemptAt: "2026-01-02T00:00:00.000Z",
+		});
+		const resumed = beginEmbeddingIndexBuild(
+			db,
+			{ ...config, provider: "ollama", model: "qwen3-embedding:0.6b", dimensions: 1024 },
+			"2026-01-01T12:00:00.000Z",
+		);
+		expect(resumed.state).toBe("failed");
+		expect(db.prepare("SELECT COUNT(*) AS n FROM embeddings_staging").get()).toEqual({ n: 1 });
+		expect(
+			beginEmbeddingIndexBuild(
+				db,
+				{ ...config, provider: "ollama", model: "qwen3-embedding:0.6b", dimensions: 1024 },
+				"2026-01-02T00:00:00.000Z",
+			).state,
+		).toBe("building");
+		expect(staged.staging?.fingerprint).toBe(resumed.staging?.fingerprint);
+	});
+
 	it("stages unknown model changes with identity formatting instead of silently skipping them", () => {
 		const raw = new Database(":memory:");
 		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);

--- a/platform/daemon/src/embedding-index-state.test.ts
+++ b/platform/daemon/src/embedding-index-state.test.ts
@@ -1,5 +1,8 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { up as embeddingIndexGenerations } from "../../core/src/migrations/091-embedding-index-generations";
 import {
 	beginEmbeddingIndexBuild,
@@ -68,41 +71,67 @@ describe("embedding index state", () => {
 		expect(ensureEmbeddingIndexState(db, config).active).toEqual(active.active);
 	});
 
-	it("keeps provider-unavailable failure durable across restart until its retry time", () => {
-		const raw = new Database(":memory:");
-		embeddingIndexGenerations(raw as unknown as Parameters<typeof embeddingIndexGenerations>[0]);
-		raw.exec(
-			"CREATE TABLE embeddings_staging (id TEXT PRIMARY KEY, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER)",
-		);
-		const db = raw as unknown as WriteDb;
-		const staged = beginEmbeddingIndexBuild(db, {
-			...config,
-			provider: "ollama",
-			model: "qwen3-embedding:0.6b",
-			dimensions: 1024,
-		});
-		db.prepare(
-			"INSERT INTO embeddings_staging (id, content_hash, vector, dimensions) VALUES ('s1', 'h1', X'00', 1024)",
-		).run();
-		failEmbeddingIndexBuild(db, "provider unavailable", "2026-01-01T00:00:00.000Z", {
-			cause: "provider-unavailable",
-			nextAttemptAt: "2026-01-02T00:00:00.000Z",
-		});
-		const resumed = beginEmbeddingIndexBuild(
-			db,
-			{ ...config, provider: "ollama", model: "qwen3-embedding:0.6b", dimensions: 1024 },
-			"2026-01-01T12:00:00.000Z",
-		);
-		expect(resumed.state).toBe("failed");
-		expect(db.prepare("SELECT COUNT(*) AS n FROM embeddings_staging").get()).toEqual({ n: 1 });
-		expect(
-			beginEmbeddingIndexBuild(
-				db,
+	it("keeps provider-unavailable failure durable across a file-backed restart until its retry time", () => {
+		const dir = mkdtempSync(join(tmpdir(), "embedding-index-state-restart-"));
+		const dbPath = join(dir, "memory.db");
+		try {
+			const first = new Database(dbPath);
+			embeddingIndexGenerations(first as unknown as Parameters<typeof embeddingIndexGenerations>[0]);
+			first.exec(
+				"CREATE TABLE embeddings_staging (id TEXT PRIMARY KEY, content_hash TEXT UNIQUE, vector BLOB, dimensions INTEGER)",
+			);
+			const staged = beginEmbeddingIndexBuild(first as unknown as WriteDb, {
+				...config,
+				provider: "ollama",
+				model: "qwen3-embedding:0.6b",
+				dimensions: 1024,
+			});
+			first
+				.prepare(
+					"INSERT INTO embeddings_staging (id, content_hash, vector, dimensions) VALUES ('s1', 'h1', X'00', 1024)",
+				)
+				.run();
+			failEmbeddingIndexBuild(first as unknown as WriteDb, "provider unavailable", "2026-01-01T00:00:00.000Z", {
+				cause: "provider-unavailable",
+				nextAttemptAt: "2026-01-02T00:00:00.000Z",
+			});
+			first.close();
+
+			const reopened = new Database(dbPath);
+			const reopenedDb = reopened as unknown as WriteDb;
+			const persisted = readEmbeddingIndexState(reopenedDb);
+			expect(persisted?.state).toBe("failed");
+			expect(persisted?.staging?.fingerprint).toBe(staged.staging?.fingerprint);
+			expect(
+				JSON.parse(
+					(
+						reopened.prepare("SELECT last_error FROM embedding_index_state WHERE id = 1").get() as {
+							last_error: string;
+						}
+					).last_error,
+				).nextAttemptAt,
+			).toBe("2026-01-02T00:00:00.000Z");
+			expect(reopened.prepare("SELECT COUNT(*) AS n FROM embeddings_staging").get()).toEqual({ n: 1 });
+			expect(
+				beginEmbeddingIndexBuild(
+					reopenedDb,
+					{ ...config, provider: "ollama", model: "qwen3-embedding:0.6b", dimensions: 1024 },
+					"2026-01-01T12:00:00.000Z",
+				).state,
+			).toBe("failed");
+			reopened.close();
+
+			const afterDeadline = new Database(dbPath);
+			const resumed = beginEmbeddingIndexBuild(
+				afterDeadline as unknown as WriteDb,
 				{ ...config, provider: "ollama", model: "qwen3-embedding:0.6b", dimensions: 1024 },
 				"2026-01-02T00:00:00.000Z",
-			).state,
-		).toBe("building");
-		expect(staged.staging?.fingerprint).toBe(resumed.staging?.fingerprint);
+			);
+			expect(resumed.state).toBe("building");
+			afterDeadline.close();
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 
 	it("stages unknown model changes with identity formatting instead of silently skipping them", () => {

--- a/platform/daemon/src/embedding-index-state.ts
+++ b/platform/daemon/src/embedding-index-state.ts
@@ -6,6 +6,9 @@ import type { EmbeddingConfig } from "./memory-config";
 export type EmbeddingIndexBuildState = "ready" | "building" | "failed";
 export type EmbeddingProjectionSlot = "active" | "staging";
 
+export const MAX_CONSECUTIVE_PROVIDER_FAILURES = 6;
+export const MAX_PROVIDER_BACKOFF_MS = 60_000;
+
 export interface PersistedEmbeddingProfile {
 	readonly fingerprint: string;
 	readonly provider: EmbeddingConfig["provider"];
@@ -31,6 +34,35 @@ export interface EmbeddingIndexStateRow {
 	readonly staging_profile_json: string | null;
 	readonly state: EmbeddingIndexBuildState;
 	readonly last_error: string | null;
+}
+
+type PersistedFailure = {
+	readonly message: string;
+	readonly cause?: "provider-unavailable";
+	readonly nextAttemptAt?: string;
+};
+
+function parseFailure(value: string | null): PersistedFailure | null {
+	if (!value) return null;
+	try {
+		const parsed = JSON.parse(value) as Partial<PersistedFailure>;
+		return typeof parsed.message === "string"
+			? {
+					message: parsed.message,
+					...(parsed.cause === "provider-unavailable" ? { cause: parsed.cause } : {}),
+					...(typeof parsed.nextAttemptAt === "string" ? { nextAttemptAt: parsed.nextAttemptAt } : {}),
+				}
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+export function persistEmbeddingIndexFailure(
+	error: string,
+	options?: { cause?: "provider-unavailable"; nextAttemptAt?: string },
+): string {
+	return JSON.stringify({ message: error, ...options });
 }
 
 function profileForStorage(cfg: EmbeddingConfig): PersistedEmbeddingProfile {
@@ -183,6 +215,15 @@ export function beginEmbeddingIndexBuild(
 		projectionSlot: current.active.projectionSlot === "staging" ? ("active" as const) : ("staging" as const),
 	};
 	if (current.state === "building" && current.staging?.fingerprint === staging.fingerprint) return current;
+	const failure = parseFailure(current.lastError);
+	if (
+		current.state === "failed" &&
+		current.staging?.fingerprint === staging.fingerprint &&
+		failure?.cause === "provider-unavailable" &&
+		failure.nextAttemptAt !== undefined &&
+		now < failure.nextAttemptAt
+	)
+		return current;
 	if (current.active.fingerprint === staging.fingerprint) {
 		// The configured profile IS the active generation: nothing to build.
 		// If a build of a different generation is in flight (the live config
@@ -209,9 +250,14 @@ export function beginEmbeddingIndexBuild(
 	return { active: current.active, staging, state: "building", lastError: null };
 }
 
-export function failEmbeddingIndexBuild(db: WriteDb, error: string, now = new Date().toISOString()): void {
+export function failEmbeddingIndexBuild(
+	db: WriteDb,
+	error: string,
+	now = new Date().toISOString(),
+	options?: { cause?: "provider-unavailable"; nextAttemptAt?: string },
+): void {
 	db.prepare("UPDATE embedding_index_state SET state = 'failed', last_error = ?, updated_at = ? WHERE id = 1").run(
-		error,
+		persistEmbeddingIndexFailure(error, options),
 		now,
 	);
 }


### PR DESCRIPTION
Fixes #1664

## Root cause
`beginEmbeddingIndexBuild` did not handle persisted `state = failed`, so startup fell through to staging deletion and restarted the full build. The provider-failure counter was also process-local.

## Fix
Persist provider-unavailable failures in `last_error` with a cause marker and `nextAttemptAt`, and keep the matching failed build durable until that time. At or after the retry time, the existing build resumes; config changes and non-provider failures retain existing retry semantics. The existing provider failure threshold and capped backoff constants are shared from the embedding-index state module.

## Regression evidence
- Focused state + migration suite: 28 pass, 0 fail, 109 expect calls.
- Regression covers restart before retry time, staging preservation, and resume at retry time.
- Biome check on touched files: pass.
- Daemon typecheck/build remain blocked by pre-existing workspace dependency/type errors: missing `@signet/lifecycle-proof` and existing dashboard Hono type mismatch.

## Companion
#1665 remains separate and is not implemented here; the shared failure threshold/backoff design remains compatible with that future circuit-breaker work.

Assisted-by: Hermes Agent:gpt-5.6-luna