### PR TITLE
fix(daemon): isolate dashboard HTTP from DB starvation

### DIFF
--- a/platform/daemon/src/daemon-status.test.ts
+++ b/platform/daemon/src/daemon-status.test.ts
@@ -18,6 +18,15 @@ async function waitForMarker(path: string): Promise<void> {
 	expect(existsSync(path)).toBe(true);
 }
 
+function _streamFromString(value: string): ReadableStream<Uint8Array> {
+	return new ReadableStream({
+		start(controller) {
+			controller.enqueue(new TextEncoder().encode(value));
+			controller.close();
+		},
+	});
+}
+
 describe("daemon status contract", () => {
 	beforeAll(async () => {
 		prev = process.env.SIGNET_PATH;
@@ -171,6 +180,38 @@ describe("daemon status contract", () => {
 		} finally {
 			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: regression probes retired sync path
 			accessor.withReadDb = originalWithReadDb;
+		}
+	});
+
+	it("keeps the real HTTP listener responsive during an active DB-owner VACUUM window", async () => {
+		const { createDbOwnerClient } = await import("./db-owner-client");
+		const owner = createDbOwnerClient({ dbPath: join(dir, "memory", "memories.db") });
+		const previousPause = process.env.SIGNET_TEST_DB_OWNER_VACUUM_PAUSE_MS;
+		process.env.SIGNET_TEST_DB_OWNER_VACUUM_PAUSE_MS = "1000";
+		const server = Bun.serve({ port: 0, fetch: app.fetch });
+		try {
+			await owner.start();
+			const job = owner.submit(
+				{ kind: "vacuum_conversion" },
+				{ operation: "db.vacuum_conversion", lane: "maintenance", deadlineMs: 5000, estimatedWorkUnits: 1 },
+			);
+			const deadline = Date.now() + 2000;
+			while (owner.health().activeJobId === null && Date.now() < deadline) await Bun.sleep(5);
+			expect(owner.health().activeJobId).not.toBeNull();
+			const started = performance.now();
+			const [live, status] = await Promise.all([
+				fetch(`http://127.0.0.1:${server.port}/health/live`),
+				fetch(`http://127.0.0.1:${server.port}/api/status`),
+			]);
+			expect(performance.now() - started).toBeLessThan(250);
+			expect(live.status).toBe(200);
+			expect(status.status).toBe(200);
+			await owner.awaitResult(job, 5000).catch(() => undefined);
+		} finally {
+			server.stop(true);
+			await owner.close().catch(() => undefined);
+			if (previousPause === undefined) Reflect.deleteProperty(process.env, "SIGNET_TEST_DB_OWNER_VACUUM_PAUSE_MS");
+			else process.env.SIGNET_TEST_DB_OWNER_VACUUM_PAUSE_MS = previousPause;
 		}
 	});
 

--- a/platform/daemon/src/daemon-status.test.ts
+++ b/platform/daemon/src/daemon-status.test.ts
@@ -150,6 +150,30 @@ describe("daemon status contract", () => {
 		).toBe(true);
 	});
 
+	it("serves status without synchronously reading SQLite when the event loop is under pressure", async () => {
+		const { getDbAccessor } = await import("./db-accessor");
+		const accessor = getDbAccessor();
+		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: regression probes retired sync path
+		const originalWithReadDb = accessor.withReadDb;
+		let syncReadCalled = false;
+		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: regression probes retired sync path
+		accessor.withReadDb = () => {
+			syncReadCalled = true;
+			throw new Error("synthetic blocked status read");
+		};
+
+		try {
+			const res = await app.request("http://localhost/api/status");
+			expect(res.status).toBe(200);
+			const agentsRes = await app.request("http://localhost/api/agents");
+			expect(agentsRes.status).toBe(200);
+			expect(syncReadCalled).toBe(false);
+		} finally {
+			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: regression probes retired sync path
+			accessor.withReadDb = originalWithReadDb;
+		}
+	});
+
 	it("reports unknown queue completeness when the status read fails", async () => {
 		const { getDbAccessor } = await import("./db-accessor");
 		const { pipelineQueueBlock } = await import("./routes/pipeline-routes");

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -2481,7 +2481,7 @@ async function main() {
 		deferredRuntimeScheduler.scheduleIntegrity(async (): Promise<void> => {
 			logFdSnapshot("server-ready");
 			writeDaemonLifecycle(AGENTS_DIR, buildLifecycleRecord("running"));
-			vacuumConversionHandle = startVacuumConversionWorker(getDbAccessor());
+			vacuumConversionHandle = startVacuumConversionWorker(getDbAccessor(), { owner: dbOwnerClient ?? undefined });
 			await runDeferredIntegrityCheck(getDbAccessor(), MEMORY_DB, {
 				timeoutMs: DEFERRED_INTEGRITY_TIMEOUT_MS,
 				ownerTimeoutMs: DEFERRED_INTEGRITY_OWNER_TIMEOUT_MS,

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -65,7 +65,7 @@ import {
 	registerDbOwnerMaintenance,
 } from "./db-owner-maintenance";
 import { createDeferredRuntimeGate, createDeferredRuntimeScheduler } from "./deferred-runtime-gate";
-import { getQueueDiagnosticsSnapshot, getQueuePressureSnapshot } from "./diagnostics-queue";
+import { getQueuePressureSnapshot } from "./diagnostics-queue";
 import { fetchEmbedding } from "./embedding-fetch";
 import { type EmbeddingIndexMigrationHandle, startEmbeddingIndexMigration } from "./embedding-index-migration";
 import { resolveActiveEmbeddingConfig } from "./embedding-index-state";
@@ -143,9 +143,7 @@ import {
 	invalidateDiagnosticsCache,
 	providerRuntimeResolution,
 	providerTracker,
-	readEnvTrimmed,
 	reloadAuthState,
-	repairLimiter,
 	setCheckpointPruneTimer,
 	setEmbeddingTrackerHandle,
 	setHeartbeatTimer,
@@ -1419,8 +1417,6 @@ function restartAfterEmbeddingPromotion(telemetry?: TelemetryCollector): void {
 export async function stopDaemonRuntimeForTests(): Promise<void> {
 	await stopPipelineRuntime();
 }
-
-type RouterHandle = ReturnType<typeof getOrCreateInferenceRouter>;
 
 function executorForTargetRef(
 	statusValue: InferenceStatusSummary,

--- a/platform/daemon/src/db-owner-client.ts
+++ b/platform/daemon/src/db-owner-client.ts
@@ -14,6 +14,7 @@ import type {
 } from "./db-owner-protocol";
 import {
 	DB_OWNER_MAX_DEADLINE_MS,
+	DB_OWNER_MAX_MAINTENANCE_DEADLINE_MS,
 	DB_OWNER_MAX_QUEUE_DEPTH,
 	DB_OWNER_MAX_RESULT_BYTES,
 	DB_OWNER_MAX_WORK_UNITS,
@@ -441,10 +442,12 @@ function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient
 		if (!Number.isFinite(submitOptions.deadlineMs) || submitOptions.deadlineMs <= 0) {
 			throw new RangeError("DB owner deadlineMs must be a positive finite number");
 		}
-		if (submitOptions.deadlineMs > MAX_DB_OWNER_DEADLINE_MS) {
+		const maxDeadlineMs =
+			submitOptions.lane === "maintenance" ? DB_OWNER_MAX_MAINTENANCE_DEADLINE_MS : MAX_DB_OWNER_DEADLINE_MS;
+		if (submitOptions.deadlineMs > maxDeadlineMs) {
 			throw new DbOwnerAdmissionError(
 				"DB_OWNER_WORK_BUDGET",
-				`DB owner deadlineMs exceeds the ${MAX_DB_OWNER_DEADLINE_MS}ms admission limit`,
+				`DB owner deadlineMs exceeds the ${maxDeadlineMs}ms admission limit for the ${submitOptions.lane} lane`,
 			);
 		}
 		const estimatedWorkUnits = submitOptions.estimatedWorkUnits ?? 1;

--- a/platform/daemon/src/db-owner-protocol.md
+++ b/platform/daemon/src/db-owner-protocol.md
@@ -49,13 +49,15 @@ Every submitted job has this shape:
       queryEmbedding?: number[] | null
     }
   } | {
+    kind: "vacuum_conversion"
+  } | {
     kind: "sleep",
     durationMs: number
   }
 }
 ```
 
-`enqueuedAt` and `deadlineAt` use Unix milliseconds. `deadlineAt` is an absolute deadline, so queue wait and execution consume the same budget. Admission is bounded at 64 pending jobs, 10,000 estimated work units per job, and a 60-second deadline. `maxResultBytes` is bounded at 1 MiB. A result above that limit is rejected with `DB_OWNER_RESULT_TOO_LARGE`; callers must page the SQL query or select fewer columns. The owner never emits an unbounded result line. `estimatedWorkUnits` is admission and telemetry metadata, not permission to exceed the deadline. The `sleep` request exists only for lifecycle and deadline tests and is not a production database operation.
+`enqueuedAt` and `deadlineAt` use Unix milliseconds. `deadlineAt` is an absolute deadline, so queue wait and execution consume the same budget. Admission is bounded at 64 pending jobs, 10,000 estimated work units per job, and a 60-second deadline for read/write jobs. Maintenance jobs may use a 15-minute deadline for bounded, killable operations such as the one-time VACUUM conversion. `maxResultBytes` is bounded at 1 MiB. A result above that limit is rejected with `DB_OWNER_RESULT_TOO_LARGE`; callers must page the SQL query or select fewer columns. The owner never emits an unbounded result line. `estimatedWorkUnits` is admission and telemetry metadata, not permission to exceed the deadline. The `sleep` request exists only for lifecycle and deadline tests and is not a production database operation.
 
 ## Wire messages
 

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -145,6 +145,7 @@ export type DbOwnerRequest =
 	| { readonly kind: "source_artifact_upsert"; readonly input: DbOwnerSourceArtifactUpsert }
 	| { readonly kind: "source_artifact_upsert_batch"; readonly input: readonly DbOwnerSourceArtifactUpsert[] }
 	| { readonly kind: "vacuum_conversion" }
+	| { readonly kind: "incremental_vacuum"; readonly pages: number }
 	| { readonly kind: "sleep"; readonly durationMs: number };
 
 export interface DbOwnerRecallPayload {

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -11,6 +11,7 @@ export type DbOwnerLane = "read" | "write" | "maintenance";
 export const DB_OWNER_MAX_QUEUE_DEPTH = 64;
 export const DB_OWNER_MAX_WORK_UNITS = 10_000;
 export const DB_OWNER_MAX_DEADLINE_MS = 60_000;
+export const DB_OWNER_MAX_MAINTENANCE_DEADLINE_MS = 15 * 60_000;
 export const DB_OWNER_MAX_RESULT_BYTES = 1_048_576;
 export const DB_OWNER_MAX_TRANSACTION_STATEMENTS = 128;
 export type DbOwnerCancellation = "pending" | "requested" | "started";
@@ -143,6 +144,7 @@ export type DbOwnerRequest =
 	| { readonly kind: "source_graph_purge"; readonly input: DbOwnerSourceGraphPurge }
 	| { readonly kind: "source_artifact_upsert"; readonly input: DbOwnerSourceArtifactUpsert }
 	| { readonly kind: "source_artifact_upsert_batch"; readonly input: readonly DbOwnerSourceArtifactUpsert[] }
+	| { readonly kind: "vacuum_conversion" }
 	| { readonly kind: "sleep"; readonly durationMs: number };
 
 export interface DbOwnerRecallPayload {

--- a/platform/daemon/src/db-owner-runtime.ts
+++ b/platform/daemon/src/db-owner-runtime.ts
@@ -137,6 +137,22 @@ export async function dbOwnerBatch(
 	return await submitWithAdmission<readonly unknown[]>(owner, { kind: "batch", statements }, options);
 }
 
+export async function dbOwnerVacuumConversion(
+	owner: DbOwnerClient,
+	options: { readonly deadlineMs?: number } = {},
+): Promise<{ readonly converted: boolean }> {
+	return await submitWithAdmission<{ readonly converted: boolean }>(
+		owner,
+		{ kind: "vacuum_conversion" },
+		{
+			operation: "vacuum.conversion",
+			lane: "maintenance",
+			deadlineMs: options.deadlineMs ?? 15 * 60_000,
+			estimatedWorkUnits: 1,
+		},
+	);
+}
+
 /** Execute read-modify-write statements atomically on the serialized owner. */
 export async function dbOwnerTransaction(
 	statements: readonly DbOwnerStatement[],

--- a/platform/daemon/src/db-owner-runtime.ts
+++ b/platform/daemon/src/db-owner-runtime.ts
@@ -153,6 +153,24 @@ export async function dbOwnerVacuumConversion(
 	);
 }
 
+export async function dbOwnerIncrementalVacuum(
+	owner: DbOwnerClient,
+	pages: number,
+	options: { readonly deadlineMs?: number } = {},
+): Promise<number> {
+	const boundedPages = Math.max(1, Math.min(10_000, Math.trunc(pages)));
+	return await submitWithAdmission<number>(
+		owner,
+		{ kind: "incremental_vacuum", pages: boundedPages },
+		{
+			operation: "vacuum.incremental",
+			lane: "maintenance",
+			deadlineMs: options.deadlineMs ?? 60_000,
+			estimatedWorkUnits: boundedPages,
+		},
+	);
+}
+
 /** Execute read-modify-write statements atomically on the serialized owner. */
 export async function dbOwnerTransaction(
 	statements: readonly DbOwnerStatement[],

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -391,6 +391,12 @@ export function runDbOwnerWorker(): void {
 				}),
 			};
 		}
+		if (job.request.kind === "incremental_vacuum") {
+			const pages = Math.max(1, Math.min(10_000, Math.trunc(job.request.pages)));
+			db.exec(`PRAGMA incremental_vacuum(${pages})`);
+			const row = db.prepare("PRAGMA freelist_count").get() as { freelist_count?: number } | undefined;
+			return typeof row?.freelist_count === "number" ? row.freelist_count : 0;
+		}
 		if (job.request.kind === "recall") return await executeRecall(job.request.payload);
 		const durationMs = Math.max(0, Math.floor(job.request.durationMs));
 		const wait = new Int32Array(new SharedArrayBuffer(4));

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -374,16 +374,20 @@ export function runDbOwnerWorker(): void {
 		)
 			return executeSourceGraph(job.request);
 		if (job.request.kind === "vacuum_conversion") {
-			const pauseMs = Number.parseInt(process.env.SIGNET_TEST_DB_OWNER_VACUUM_PAUSE_MS ?? "0", 10);
-			if (Number.isFinite(pauseMs) && pauseMs > 0) {
-				const wait = new Int32Array(new SharedArrayBuffer(4));
-				Atomics.wait(wait, 0, 0, Math.min(pauseMs, 60_000));
-			}
 			const { convertToIncrementalVacuum } = await import("./db-vacuum");
+			const pauseMs = Number.parseInt(process.env.SIGNET_TEST_DB_OWNER_VACUUM_PAUSE_MS ?? "0", 10);
+			const activeFile = process.env.SIGNET_TEST_DB_OWNER_VACUUM_ACTIVE_FILE;
 			return {
 				converted: convertToIncrementalVacuum(db as unknown as import("./db-vacuum").PragmaDb, {
 					dbPath: ownerDbPath,
 					log: () => {},
+					beforeVacuum: () => {
+						if (activeFile) writeFileSync(activeFile, `${Date.now()}\n`);
+						if (Number.isFinite(pauseMs) && pauseMs > 0) {
+							const wait = new Int32Array(new SharedArrayBuffer(4));
+							Atomics.wait(wait, 0, 0, Math.min(pauseMs, 60_000));
+						}
+					},
 				}),
 			};
 		}

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -374,6 +374,11 @@ export function runDbOwnerWorker(): void {
 		)
 			return executeSourceGraph(job.request);
 		if (job.request.kind === "vacuum_conversion") {
+			const pauseMs = Number.parseInt(process.env.SIGNET_TEST_DB_OWNER_VACUUM_PAUSE_MS ?? "0", 10);
+			if (Number.isFinite(pauseMs) && pauseMs > 0) {
+				const wait = new Int32Array(new SharedArrayBuffer(4));
+				Atomics.wait(wait, 0, 0, Math.min(pauseMs, 60_000));
+			}
 			const { convertToIncrementalVacuum } = await import("./db-vacuum");
 			return {
 				converted: convertToIncrementalVacuum(db as unknown as import("./db-vacuum").PragmaDb, {

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -20,6 +20,7 @@ import type {
 } from "./db-owner-protocol";
 import {
 	DB_OWNER_MAX_DEADLINE_MS,
+	DB_OWNER_MAX_MAINTENANCE_DEADLINE_MS,
 	DB_OWNER_MAX_QUEUE_DEPTH,
 	DB_OWNER_MAX_RESULT_BYTES,
 	DB_OWNER_MAX_TRANSACTION_STATEMENTS,
@@ -372,6 +373,15 @@ export function runDbOwnerWorker(): void {
 			job.request.kind === "source_graph_purge"
 		)
 			return executeSourceGraph(job.request);
+		if (job.request.kind === "vacuum_conversion") {
+			const { convertToIncrementalVacuum } = await import("./db-vacuum");
+			return {
+				converted: convertToIncrementalVacuum(db as unknown as import("./db-vacuum").PragmaDb, {
+					dbPath: ownerDbPath,
+					log: () => {},
+				}),
+			};
+		}
 		if (job.request.kind === "recall") return await executeRecall(job.request.payload);
 		const durationMs = Math.max(0, Math.floor(job.request.durationMs));
 		const wait = new Int32Array(new SharedArrayBuffer(4));
@@ -425,8 +435,10 @@ export function runDbOwnerWorker(): void {
 			cancelled.add(command.jobId);
 			return;
 		}
-		if (command.job.deadlineAt - command.job.enqueuedAt > DB_OWNER_MAX_DEADLINE_MS) {
-			failed(command.job.id, "DB_OWNER_WORK_BUDGET", `DB owner deadline exceeds ${DB_OWNER_MAX_DEADLINE_MS}ms`);
+		const maxDeadlineMs =
+			command.job.lane === "maintenance" ? DB_OWNER_MAX_MAINTENANCE_DEADLINE_MS : DB_OWNER_MAX_DEADLINE_MS;
+		if (command.job.deadlineAt - command.job.enqueuedAt > maxDeadlineMs) {
+			failed(command.job.id, "DB_OWNER_WORK_BUDGET", `DB owner deadline exceeds ${maxDeadlineMs}ms`);
 			return;
 		}
 		if (

--- a/platform/daemon/src/db-vacuum.test.ts
+++ b/platform/daemon/src/db-vacuum.test.ts
@@ -11,7 +11,7 @@
 
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
@@ -312,21 +312,27 @@ describe("deferred vacuum conversion (#1493)", () => {
 		initDbAccessor(db.path);
 		const owner = createDbOwnerClient({ dbPath: db.path });
 		const previousPause = process.env.SIGNET_TEST_DB_OWNER_VACUUM_PAUSE_MS;
+		const previousActiveFile = process.env.SIGNET_TEST_DB_OWNER_VACUUM_ACTIVE_FILE;
+		const activeFile = join(db.dir, "vacuum-active");
 		process.env.SIGNET_TEST_DB_OWNER_VACUUM_PAUSE_MS = "5000";
+		process.env.SIGNET_TEST_DB_OWNER_VACUUM_ACTIVE_FILE = activeFile;
 		await owner.start();
 		try {
 			const worker = startVacuumConversionWorker(getDbAccessor(), { owner, startImmediately: false });
 			const running = worker.run();
 			const deadline = Date.now() + 2000;
-			while (owner.health().activeJobId === null && Date.now() < deadline) await Bun.sleep(5);
+			while (!existsSync(activeFile) && Date.now() < deadline) await Bun.sleep(5);
 			const pid = owner.health().pid;
-			expect(owner.health().activeJobId).not.toBeNull();
+			expect(existsSync(activeFile)).toBe(true);
 			expect(pid).not.toBeNull();
 			process.kill(pid as number, "SIGKILL");
 			await Promise.race([running.catch(() => undefined), Bun.sleep(100)]);
 		} finally {
 			if (previousPause === undefined) Reflect.deleteProperty(process.env, "SIGNET_TEST_DB_OWNER_VACUUM_PAUSE_MS");
 			else process.env.SIGNET_TEST_DB_OWNER_VACUUM_PAUSE_MS = previousPause;
+			if (previousActiveFile === undefined)
+				Reflect.deleteProperty(process.env, "SIGNET_TEST_DB_OWNER_VACUUM_ACTIVE_FILE");
+			else process.env.SIGNET_TEST_DB_OWNER_VACUUM_ACTIVE_FILE = previousActiveFile;
 			await Promise.race([owner.close().catch(() => undefined), Bun.sleep(250)]);
 		}
 

--- a/platform/daemon/src/db-vacuum.test.ts
+++ b/platform/daemon/src/db-vacuum.test.ts
@@ -15,6 +15,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { createDbOwnerClient } from "./db-owner-client";
 import { getSyncDbAccessor } from "../legacy-sync/db-accessor-sync";
 import {
 	convertToIncrementalVacuum,
@@ -288,6 +289,21 @@ describe("deferred vacuum conversion (#1493)", () => {
 				(readDb.prepare("SELECT COUNT(*) AS count FROM _signet_vacuum_converted").get() as { count: number }).count,
 		);
 		expect(markerCount).toBe(1);
+	});
+
+	it("runs production conversion through the DB owner child", async () => {
+		const db = legacyDbPath();
+		dir = db.dir;
+		initDbAccessor(db.path);
+		const owner = createDbOwnerClient({ dbPath: db.path });
+		await owner.start();
+		try {
+			const worker = startVacuumConversionWorker(getDbAccessor(), { owner, startImmediately: false });
+			await expect(worker.run()).resolves.toMatchObject({ state: "completed", attempts: 1 });
+			expect(owner.health().state).toBe("ready");
+		} finally {
+			await owner.close();
+		}
 	});
 
 	it("a killed or failed conversion remains retryable without blocking initialization", async () => {

--- a/platform/daemon/src/db-vacuum.test.ts
+++ b/platform/daemon/src/db-vacuum.test.ts
@@ -306,6 +306,48 @@ describe("deferred vacuum conversion (#1493)", () => {
 		}
 	});
 
+	it("recovers safely when the real VACUUM owner is SIGKILLed", async () => {
+		const db = legacyDbPath();
+		dir = db.dir;
+		initDbAccessor(db.path);
+		const owner = createDbOwnerClient({ dbPath: db.path });
+		const previousPause = process.env.SIGNET_TEST_DB_OWNER_VACUUM_PAUSE_MS;
+		process.env.SIGNET_TEST_DB_OWNER_VACUUM_PAUSE_MS = "5000";
+		await owner.start();
+		try {
+			const worker = startVacuumConversionWorker(getDbAccessor(), { owner, startImmediately: false });
+			const running = worker.run();
+			const deadline = Date.now() + 2000;
+			while (owner.health().activeJobId === null && Date.now() < deadline) await Bun.sleep(5);
+			const pid = owner.health().pid;
+			expect(owner.health().activeJobId).not.toBeNull();
+			expect(pid).not.toBeNull();
+			process.kill(pid as number, "SIGKILL");
+			await Promise.race([running.catch(() => undefined), Bun.sleep(100)]);
+		} finally {
+			if (previousPause === undefined) Reflect.deleteProperty(process.env, "SIGNET_TEST_DB_OWNER_VACUUM_PAUSE_MS");
+			else process.env.SIGNET_TEST_DB_OWNER_VACUUM_PAUSE_MS = previousPause;
+			await Promise.race([owner.close().catch(() => undefined), Bun.sleep(250)]);
+		}
+
+		const integrity = new Database(db.path, { readonly: true });
+		expect((integrity.prepare("PRAGMA integrity_check").get() as { integrity_check: string }).integrity_check).toBe(
+			"ok",
+		);
+		integrity.close();
+		closeDbAccessor();
+		initDbAccessor(db.path);
+		expect(getVacuumConversionStatus(getDbAccessor()).state).toBe("pending");
+		const nextOwner = createDbOwnerClient({ dbPath: db.path });
+		await nextOwner.start();
+		try {
+			const resumed = startVacuumConversionWorker(getDbAccessor(), { owner: nextOwner, startImmediately: false });
+			expect(await resumed.run()).toMatchObject({ state: "completed", attempts: 2 });
+		} finally {
+			await nextOwner.close();
+		}
+	});
+
 	it("a killed or failed conversion remains retryable without blocking initialization", async () => {
 		const db = legacyDbPath();
 		dir = db.dir;

--- a/platform/daemon/src/db-vacuum.test.ts
+++ b/platform/daemon/src/db-vacuum.test.ts
@@ -22,6 +22,7 @@ import {
 	DbSpacePreflightError,
 	getFreePageRatio,
 	getVacuumConversionStatus,
+	reclaimIncrementalVacuum,
 	startVacuumConversionWorker,
 } from "./db-vacuum";
 
@@ -389,5 +390,76 @@ describe("deferred vacuum conversion (#1493)", () => {
 		closeDbAccessor();
 		initDbAccessor(db.path);
 		expect(getVacuumConversionStatus(getDbAccessor())).toMatchObject({ state: "failed", attempts: 3 });
+	});
+});
+
+describe("integrated incremental reclaim resume (#1667)", () => {
+	it("observes owner batches and resumes from the durable checkpoint after SIGKILL", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "signet-vacuum-reclaim-test-"));
+		const dbPath = join(directory, "memories.db");
+		const seed = new Database(dbPath);
+		seed.exec("PRAGMA auto_vacuum = INCREMENTAL; CREATE TABLE reclaim_bloat (data BLOB)");
+		const insert = seed.prepare("INSERT INTO reclaim_bloat (data) VALUES (?)");
+		for (let index = 0; index < 100; index++) insert.run(Buffer.alloc(4096, 0x42));
+		seed.exec("DROP TABLE reclaim_bloat");
+		const freeBefore = (seed.prepare("PRAGMA freelist_count").get() as { freelist_count: number }).freelist_count;
+		seed.close();
+		expect(freeBefore).toBeGreaterThan(2);
+
+		const owner = createDbOwnerClient({ dbPath });
+		const accessor = {} as Parameters<typeof reclaimIncrementalVacuum>[0];
+		const checkpoints: Array<{ reclaimed: number; remaining: number }> = [];
+		let killed = false;
+		try {
+			await owner.start();
+			await reclaimIncrementalVacuum(accessor, {
+				owner,
+				batchPages: 1,
+				checkpointKey: "test.integrated-reclaim",
+				maxBatches: 1,
+				onCheckpoint: (reclaimed, remaining) => {
+					checkpoints.push({ reclaimed, remaining });
+					if (!killed && checkpoints.length === 1 && remaining > 0) {
+						killed = true;
+						const pid = owner.health().pid;
+						if (pid === null) throw new Error("owner did not publish a pid");
+						process.kill(pid, "SIGKILL");
+					}
+				},
+			});
+			expect(killed).toBe(true);
+			expect(checkpoints).toHaveLength(1);
+			expect(checkpoints[0].remaining).toBeGreaterThan(0);
+		} finally {
+			await owner.close().catch(() => undefined);
+		}
+
+		const integrityAfterKill = new Database(dbPath, { readonly: true });
+		expect(
+			(integrityAfterKill.prepare("PRAGMA integrity_check").get() as { integrity_check: string }).integrity_check,
+		).toBe("ok");
+		integrityAfterKill.close();
+
+		const resumedOwner = createDbOwnerClient({ dbPath });
+		try {
+			await resumedOwner.start();
+			const resumed = await reclaimIncrementalVacuum(accessor, {
+				owner: resumedOwner,
+				batchPages: 1,
+				checkpointKey: "test.integrated-reclaim",
+				maxBatches: 200,
+				onCheckpoint: (reclaimed, remaining) => checkpoints.push({ reclaimed, remaining }),
+			});
+			expect(resumed.remaining).toBe(0);
+			expect(checkpoints.length).toBeGreaterThan(1);
+			expect(checkpoints.at(-1)).toEqual(expect.objectContaining({ remaining: 0 }));
+		} finally {
+			await resumedOwner.close();
+		}
+
+		const finalDb = new Database(dbPath, { readonly: true });
+		expect((finalDb.prepare("PRAGMA integrity_check").get() as { integrity_check: string }).integrity_check).toBe("ok");
+		finalDb.close();
+		rmSync(directory, { recursive: true, force: true });
 	});
 });

--- a/platform/daemon/src/db-vacuum.ts
+++ b/platform/daemon/src/db-vacuum.ts
@@ -13,7 +13,7 @@ import { statSync, statfsSync } from "node:fs";
 import { dirname } from "node:path";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import type { DbOwnerClient } from "./db-owner-client";
-import { dbOwnerVacuumConversion } from "./db-owner-runtime";
+import { dbOwnerIncrementalVacuum, dbOwnerVacuumConversion } from "./db-owner-runtime";
 import { logger } from "./logger";
 
 /** Marker table name for the one-time VACUUM conversion. */
@@ -396,6 +396,42 @@ export function convertToIncrementalVacuum(db: PragmaDb, options: VacuumConversi
 	db.exec(`CREATE TABLE IF NOT EXISTS ${VACUUM_CONVERSION_TABLE} (converted_at TEXT)`);
 	db.prepare(`INSERT INTO ${VACUUM_CONVERSION_TABLE} (converted_at) VALUES (?)`).run(now());
 	return true;
+}
+
+export interface IncrementalReclaimOptions {
+	readonly owner?: DbOwnerClient;
+	readonly batchPages?: number;
+	readonly maxBatches?: number;
+	readonly onCheckpoint?: (reclaimed: number, remaining: number) => void;
+}
+
+/** Reclaim free pages in bounded, resumable batches. Conversion remains monolithic. */
+export async function reclaimIncrementalVacuum(
+	accessor: DbAccessor,
+	opts: IncrementalReclaimOptions = {},
+): Promise<{ readonly reclaimed: number; readonly remaining: number }> {
+	const batchPages = Math.max(1, Math.min(10_000, Math.trunc(opts.batchPages ?? 1_000)));
+	const maxBatches = Math.max(1, Math.min(100_000, Math.trunc(opts.maxBatches ?? 100_000)));
+	let remaining = 0;
+	// The checkpoint is durable SQLite state: a crash leaves the freelist itself
+	// intact, so the next invocation resumes from the current count.
+	let reclaimed = 0;
+	let previousRemaining: number | null = null;
+	for (let batch = 0; batch < maxBatches; batch += 1) {
+		if (opts.owner) remaining = await dbOwnerIncrementalVacuum(opts.owner, batchPages);
+		else {
+			if (!accessor.incrementalVacuumAsync) throw new Error("incremental vacuum operation is unavailable");
+			remaining = await accessor.incrementalVacuumAsync();
+		}
+		const progressed =
+			previousRemaining === null ? Math.max(0, batchPages) : Math.max(0, previousRemaining - remaining);
+		reclaimed += progressed;
+		previousRemaining = remaining;
+		opts.onCheckpoint?.(reclaimed, remaining);
+		if (remaining <= 0 || progressed <= 0) break;
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+	}
+	return { reclaimed, remaining };
 }
 
 /**

--- a/platform/daemon/src/db-vacuum.ts
+++ b/platform/daemon/src/db-vacuum.ts
@@ -4,12 +4,16 @@
  * Existing databases need a one-time VACUUM to switch from the legacy
  * auto_vacuum=0 mode to incremental mode. That rebuild can take minutes on a
  * large database, so startup only records durable work state. The conversion
- * runs after the daemon is ready and is single-flight across the worker.
+ * runs after the daemon is ready and is single-flight across the worker. In
+ * production the VACUUM executes in the DB-owner child so the rebuild cannot
+ * block HTTP callbacks on the daemon event loop.
  */
 
 import { statSync, statfsSync } from "node:fs";
 import { dirname } from "node:path";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
+import type { DbOwnerClient } from "./db-owner-client";
+import { dbOwnerVacuumConversion } from "./db-owner-runtime";
 import { logger } from "./logger";
 
 /** Marker table name for the one-time VACUUM conversion. */
@@ -45,6 +49,12 @@ export class DbSpacePreflightError extends Error {
 export interface DbSpaceDeps {
 	readonly statSync: (path: string) => { readonly size: number };
 	readonly statfsSync: (path: string) => { readonly bavail: number; readonly bsize: number };
+}
+
+export interface VacuumConversionOptions {
+	readonly dbPath?: string;
+	readonly deps?: DbSpaceDeps;
+	readonly log?: (message: string) => void;
 }
 
 const dbSpaceDeps: DbSpaceDeps = { statSync, statfsSync };
@@ -336,11 +346,9 @@ export function getFreePageRatio(db: PragmaReadDb): number {
  * This function must only be called by the post-ready worker. It deliberately
  * does not run from either synchronous or asynchronous DB initialization.
  */
-export function convertToIncrementalVacuum(
-	db: PragmaDb,
-	options: { readonly dbPath?: string; readonly deps?: DbSpaceDeps } = {},
-): boolean {
+export function convertToIncrementalVacuum(db: PragmaDb, options: VacuumConversionOptions = {}): boolean {
 	const mode = getAutoVacuumMode(db);
+	const writeLog = options.log ?? ((message: string): void => logger.info("db-vacuum", message));
 
 	// 2 = INCREMENTAL. Already converted or fresh DB created after the fix.
 	if (mode === 2) return false;
@@ -354,11 +362,8 @@ export function convertToIncrementalVacuum(
 	const freelistBefore = db.prepare("PRAGMA freelist_count").get() as { freelist_count?: number } | undefined;
 	const freeBefore = typeof freelistBefore?.freelist_count === "number" ? freelistBefore.freelist_count : 0;
 
-	logger.info(
-		"db-vacuum",
-		`Converting database to incremental auto_vacuum (current mode: ${mode}, free pages: ${freeBefore})`,
-	);
-	logger.info("db-vacuum", "Running one-time VACUUM after readiness; large databases may take several minutes");
+	writeLog(`Converting database to incremental auto_vacuum (current mode: ${mode}, free pages: ${freeBefore})`);
+	writeLog("Running one-time VACUUM after readiness; large databases may take several minutes");
 
 	const startedAt = Date.now();
 	try {
@@ -377,8 +382,7 @@ export function convertToIncrementalVacuum(
 	const freeAfter = typeof freelistAfter?.freelist_count === "number" ? freelistAfter.freelist_count : 0;
 	const modeAfter = getAutoVacuumMode(db);
 
-	logger.info(
-		"db-vacuum",
+	writeLog(
 		`VACUUM complete in ${Math.round(elapsedMs / 1000)}s — free pages: ${freeBefore} -> ${freeAfter}, auto_vacuum: ${mode} -> ${modeAfter}`,
 	);
 
@@ -395,7 +399,7 @@ export function convertToIncrementalVacuum(
  */
 export function startVacuumConversionWorker(
 	accessor: DbAccessor,
-	opts: { readonly startImmediately?: boolean } = {},
+	opts: { readonly startImmediately?: boolean; readonly owner?: DbOwnerClient } = {},
 ): VacuumConversionHandle {
 	let active = true;
 	let timer: ReturnType<typeof setTimeout> | null = null;
@@ -431,8 +435,12 @@ export function startVacuumConversionWorker(
 			});
 
 			try {
-				if (!accessor.vacuumConversionAsync) throw new Error("VACUUM conversion operation is unavailable");
-				await accessor.vacuumConversionAsync();
+				if (opts.owner !== undefined) {
+					await dbOwnerVacuumConversion(opts.owner);
+				} else {
+					if (!accessor.vacuumConversionAsync) throw new Error("VACUUM conversion operation is unavailable");
+					await accessor.vacuumConversionAsync();
+				}
 				// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
 				accessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
 					const state = stateFromRow(

--- a/platform/daemon/src/db-vacuum.ts
+++ b/platform/daemon/src/db-vacuum.ts
@@ -13,6 +13,7 @@ import { statSync, statfsSync } from "node:fs";
 import { dirname } from "node:path";
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import type { DbOwnerClient } from "./db-owner-client";
+import { ownerQueryOne, ownerTransaction, ownerRunStatement } from "./db-owner-maintenance";
 import { dbOwnerIncrementalVacuum, dbOwnerVacuumConversion } from "./db-owner-runtime";
 import { logger } from "./logger";
 
@@ -402,31 +403,53 @@ export interface IncrementalReclaimOptions {
 	readonly owner?: DbOwnerClient;
 	readonly batchPages?: number;
 	readonly maxBatches?: number;
+	readonly checkpointKey?: string;
 	readonly onCheckpoint?: (reclaimed: number, remaining: number) => void;
 }
 
-/** Reclaim free pages in bounded, resumable batches. Conversion remains monolithic. */
+/** Reclaim free pages in bounded batches with a real durable resume record. Conversion remains monolithic. */
 export async function reclaimIncrementalVacuum(
 	accessor: DbAccessor,
 	opts: IncrementalReclaimOptions = {},
 ): Promise<{ readonly reclaimed: number; readonly remaining: number }> {
 	const batchPages = Math.max(1, Math.min(10_000, Math.trunc(opts.batchPages ?? 1_000)));
 	const maxBatches = Math.max(1, Math.min(100_000, Math.trunc(opts.maxBatches ?? 100_000)));
-	let remaining = 0;
-	// The checkpoint is durable SQLite state: a crash leaves the freelist itself
-	// intact, so the next invocation resumes from the current count.
+	const key = opts.checkpointKey ?? "vacuum.incremental-reclaim";
 	let reclaimed = 0;
-	let previousRemaining: number | null = null;
+	let remaining = 0;
+	if (opts.owner) {
+		await ownerTransaction(opts.owner, "maintenance.vacuum.checkpoint.ensure", [
+			ownerRunStatement(
+				"CREATE TABLE IF NOT EXISTS db_vacuum_reclaim_checkpoints (checkpoint_key TEXT PRIMARY KEY, reclaimed INTEGER NOT NULL, remaining INTEGER NOT NULL, updated_at TEXT NOT NULL)",
+			),
+		]);
+		const saved = await ownerQueryOne<{ reclaimed: number; remaining: number }>(
+			opts.owner,
+			"maintenance.vacuum.checkpoint.read",
+			"SELECT reclaimed, remaining FROM db_vacuum_reclaim_checkpoints WHERE checkpoint_key = ?",
+			[key],
+		);
+		reclaimed = saved?.reclaimed ?? 0;
+		remaining = saved?.remaining ?? 0;
+	}
+	let previousRemaining: number | null = remaining > 0 ? remaining : null;
 	for (let batch = 0; batch < maxBatches; batch += 1) {
+		const before = previousRemaining;
 		if (opts.owner) remaining = await dbOwnerIncrementalVacuum(opts.owner, batchPages);
 		else {
 			if (!accessor.incrementalVacuumAsync) throw new Error("incremental vacuum operation is unavailable");
 			remaining = await accessor.incrementalVacuumAsync();
 		}
-		const progressed =
-			previousRemaining === null ? Math.max(0, batchPages) : Math.max(0, previousRemaining - remaining);
+		const progressed = before === null ? Math.max(0, batchPages) : Math.max(0, before - remaining);
 		reclaimed += progressed;
 		previousRemaining = remaining;
+		if (opts.owner)
+			await ownerTransaction(opts.owner, "maintenance.vacuum.checkpoint.write", [
+				ownerRunStatement(
+					"INSERT INTO db_vacuum_reclaim_checkpoints (checkpoint_key, reclaimed, remaining, updated_at) VALUES (?, ?, ?, datetime('now')) ON CONFLICT(checkpoint_key) DO UPDATE SET reclaimed=excluded.reclaimed, remaining=excluded.remaining, updated_at=excluded.updated_at",
+					[key, reclaimed, remaining],
+				),
+			]);
 		opts.onCheckpoint?.(reclaimed, remaining);
 		if (remaining <= 0 || progressed <= 0) break;
 		await new Promise<void>((resolve) => setTimeout(resolve, 0));

--- a/platform/daemon/src/db-vacuum.ts
+++ b/platform/daemon/src/db-vacuum.ts
@@ -55,6 +55,8 @@ export interface VacuumConversionOptions {
 	readonly dbPath?: string;
 	readonly deps?: DbSpaceDeps;
 	readonly log?: (message: string) => void;
+	/** Test-only seam at the real VACUUM conversion boundary. */
+	readonly beforeVacuum?: () => void;
 }
 
 const dbSpaceDeps: DbSpaceDeps = { statSync, statfsSync };
@@ -367,6 +369,10 @@ export function convertToIncrementalVacuum(db: PragmaDb, options: VacuumConversi
 
 	const startedAt = Date.now();
 	try {
+		// This is deliberately adjacent to the real SQLite statement, not in the
+		// owner job dispatcher. Tests may pause here, proving they reached the
+		// conversion boundary rather than an artificial pre-VACUUM hole.
+		options.beforeVacuum?.();
 		db.exec("VACUUM");
 	} catch (error) {
 		if (options.dbPath && isDbFullError(error)) {

--- a/platform/daemon/src/embedding-usage.ts
+++ b/platform/daemon/src/embedding-usage.ts
@@ -118,6 +118,8 @@ export interface EmbeddingUsageSummary {
 	readonly byProvider: ReadonlyArray<{ readonly provider: string; readonly requests: number; readonly tokens: number }>;
 }
 
+let cachedEmbeddingUsageSummary: EmbeddingUsageSummary | null = null;
+
 /**
  * Aggregate the daily table into totals, today's totals, and per-source /
  * per-provider breakdowns for /api/status. Returns null when the table is
@@ -128,7 +130,7 @@ export async function readEmbeddingUsageSummary(
 	now: Date = new Date(),
 ): Promise<EmbeddingUsageSummary | null> {
 	try {
-		return await accessor.withReadDbAsync((db: import("./db-accessor").ReadDb) => {
+		const summary = await accessor.withReadDbAsync((db: import("./db-accessor").ReadDb) => {
 			const day = todayKey(now);
 			const totals = db
 				.prepare(
@@ -154,12 +156,19 @@ export async function readEmbeddingUsageSummary(
 				.all() as Array<{ provider: string; requests: number; tokens: number }>;
 			return { total: totals, today, bySource, byProvider };
 		});
+		cachedEmbeddingUsageSummary = summary;
+		return summary;
 	} catch (e) {
 		logger.warn("embedding", "Failed to read embedding usage summary", {
 			error: e instanceof Error ? e.message : String(e),
 		});
 		return null;
 	}
+}
+
+/** Return the last usage aggregate without synchronously reading SQLite. */
+export function getCachedEmbeddingUsageSummary(): EmbeddingUsageSummary | null {
+	return cachedEmbeddingUsageSummary;
 }
 
 export type { EmbeddingUsageRow };

--- a/platform/daemon/src/pipeline/maintenance-worker.ts
+++ b/platform/daemon/src/pipeline/maintenance-worker.ts
@@ -11,7 +11,7 @@
 
 import type { DbAccessor } from "../db-accessor";
 import type { DbOwnerMaintenance } from "../db-owner-maintenance";
-import { getFreePageRatio } from "../db-vacuum";
+import { getFreePageRatio, reclaimIncrementalVacuum } from "../db-vacuum";
 import type { DiagnosticsReport, ProviderTracker } from "../diagnostics";
 import { getDiagnostics } from "../diagnostics";
 import { isActiveEmbeddingConfig } from "../embedding-index-state";
@@ -491,7 +491,7 @@ export function startMaintenanceWorker(
 		try {
 			const ratio = await accessor.withReadDbAsync(async (db) => getFreePageRatio(db));
 			if (ratio >= 0.2) {
-				await accessor.incrementalVacuumAsync?.();
+				await reclaimIncrementalVacuum(accessor, { owner: deps.ownerMaintenance?.owner });
 			}
 		} catch {
 			// Non-fatal — vacuum should never interrupt the maintenance cycle

--- a/platform/daemon/src/resource-monitor.ts
+++ b/platform/daemon/src/resource-monitor.ts
@@ -289,6 +289,29 @@ export interface ResourceSnapshot {
 	cpuPercent: number | null;
 }
 
+function processOnlyResourceSnapshot(): ResourceSnapshot {
+	const mem = process.memoryUsage();
+	return {
+		total: null,
+		memoryMd: null,
+		sockets: null,
+		inotify: null,
+		pipes: null,
+		db: null,
+		other: null,
+		rss: Math.round(mem.rss / 1024 / 1024),
+		heapUsed: Math.round(mem.heapUsed / 1024 / 1024),
+		physicalFootprint: null,
+		peakPhysicalFootprint: null,
+		cpuPercent: null,
+	};
+}
+
+// HTTP diagnostics read this bounded snapshot. The full /proc walk is
+// performed at daemon startup and by the diagnostic poller, never as part of
+// a request that is meant to prove liveness.
+let cachedResourceSnapshot: ResourceSnapshot = processOnlyResourceSnapshot();
+
 let lastCpuUsage: NodeJS.CpuUsage | null = null;
 let lastCpuSampleAt: number | null = null;
 
@@ -349,11 +372,19 @@ function snapshotResources(readPhysicalMemory: PhysicalMemoryReader = readMacOsP
 }
 
 export function getResourceSnapshot(readPhysicalMemory?: PhysicalMemoryReader): ResourceSnapshot {
-	return snapshotResources(readPhysicalMemory);
+	const snapshot = snapshotResources(readPhysicalMemory);
+	if (readPhysicalMemory === undefined) cachedResourceSnapshot = snapshot;
+	return snapshot;
+}
+
+/** Return the most recent bounded resource sample without touching /proc. */
+export function getCachedResourceSnapshot(): ResourceSnapshot {
+	return cachedResourceSnapshot;
 }
 
 export function logFdSnapshot(stage: string): ResourceSnapshot {
 	const snap = snapshotResources();
+	cachedResourceSnapshot = snap;
 	logger.info("resources", `[${stage}]`, {
 		total: snap.total,
 		memoryMd: snap.memoryMd,
@@ -406,9 +437,14 @@ export function startFdPollMonitor(intervalMs = 30_000): void {
 	if (fdPollTimer) {
 		clearInterval(fdPollTimer);
 	}
-	let prev: ResourceSnapshot | null = null;
+	// Prime the cache before the HTTP server is bound. Subsequent status and
+	// health requests use this value instead of repeating the synchronous FD
+	// walk on the request path.
+	let prev: ResourceSnapshot | null = snapshotResources();
+	cachedResourceSnapshot = prev;
 	fdPollTimer = setInterval(() => {
 		const snap = snapshotResources();
+		cachedResourceSnapshot = snap;
 		const delta = prev
 			? {
 					total: snap.total !== null && prev.total !== null ? snap.total - prev.total : null,

--- a/platform/daemon/src/routes/health.ts
+++ b/platform/daemon/src/routes/health.ts
@@ -13,7 +13,7 @@ import {
 } from "../diagnostics";
 import { getAllFeatureFlags } from "../feature-flags";
 import { loadMemoryConfig } from "../memory-config";
-import { getResourceSnapshot } from "../resource-monitor";
+import { getCachedResourceSnapshot } from "../resource-monitor";
 import { getUpdateState } from "../update-system";
 import {
 	AGENTS_DIR,
@@ -222,7 +222,7 @@ export function mountHealthRoutes(app: Hono): void {
 			shuttingDown,
 			updateAvailable: us.lastCheck?.updateAvailable ?? false,
 			pendingRestart: us.pendingRestartVersion !== null,
-			resources: getResourceSnapshot(),
+			resources: getCachedResourceSnapshot(),
 		});
 	});
 

--- a/platform/daemon/src/routes/health.ts
+++ b/platform/daemon/src/routes/health.ts
@@ -22,7 +22,6 @@ import {
 	authConfig,
 	getCurrentAgentsDir,
 	getExtractionWorkloadState,
-	providerRuntimeResolution,
 	shuttingDown,
 } from "./state.js";
 import { checkEmbeddingProvider } from "./utils";

--- a/platform/daemon/src/routes/misc-routes.ts
+++ b/platform/daemon/src/routes/misc-routes.ts
@@ -5,6 +5,7 @@ import type { Hono } from "hono";
 import { requirePermission } from "../auth";
 import { checkPermission } from "../auth/policy";
 import { getDbAccessor, runWriteTxAsync } from "../db-accessor.js";
+import { dbOwnerQuery } from "../db-owner-runtime.js";
 import { type LogCategory, type LogEntry, logger } from "../logger.js";
 import { loadPipelineConfig } from "../memory-config.js";
 import {
@@ -214,23 +215,35 @@ export function registerMiscRoutes(app: Hono): void {
 	});
 
 	app.get("/api/agents", async (c) => {
-		const agents = await getDbAccessor().withReadDbAsync(
-			async (db) =>
-				db
-					.prepare("SELECT id, name, read_policy, policy_group, created_at, updated_at FROM agents ORDER BY name")
-					.all() as AgentRow[],
-		);
-		return c.json({ agents });
+		try {
+			const agents = await dbOwnerQuery<AgentRow[]>(
+				{
+					sql: "SELECT id, name, read_policy, policy_group, created_at, updated_at FROM agents ORDER BY name",
+					result: "all",
+				},
+				{ operation: "agents.list", lane: "read", deadlineMs: 2_000 },
+			);
+			return c.json({ agents });
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : "Database unavailable" }, 503);
+		}
 	});
 
 	app.get("/api/agents/:name", async (c) => {
 		const name = c.req.param("name");
-		const agent = await getDbAccessor().withReadDbAsync(
-			async (db) =>
-				db
-					.prepare("SELECT id, name, read_policy, policy_group, created_at, updated_at FROM agents WHERE name = ?")
-					.get(name) as AgentRow | undefined,
-		);
+		let agent: AgentRow | undefined;
+		try {
+			agent = await dbOwnerQuery<AgentRow | undefined>(
+				{
+					sql: "SELECT id, name, read_policy, policy_group, created_at, updated_at FROM agents WHERE name = ?",
+					params: [name],
+					result: "get",
+				},
+				{ operation: "agents.get", lane: "read", deadlineMs: 2_000 },
+			);
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : "Database unavailable" }, 503);
+		}
 		if (!agent) return c.json({ error: "Agent not found" }, 404);
 		try {
 			const resolved = resolveAgentMemoryPolicy(agent.read_policy, agent.policy_group);

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -7,7 +7,7 @@ import { requirePermission, requireRateLimit } from "../auth";
 import { getDbAccessor } from "../db-accessor.js";
 import { getVacuumConversionStatus } from "../db-vacuum.js";
 import { type QueueCounts, getQueueDiagnosticsSnapshot } from "../diagnostics-queue.js";
-import { readEmbeddingUsageSummary } from "../embedding-usage";
+import { getCachedEmbeddingUsageSummary, readEmbeddingUsageSummary } from "../embedding-usage";
 import { getInferenceRouterOrNull } from "../inference-router.js";
 import type { BackgroundWorkloadDiagnostics } from "../inference-router.js";
 import { getLlmProvider } from "../llm.js";
@@ -46,7 +46,7 @@ import {
 	getRegistryStatus,
 	refreshRegistry,
 } from "../pipeline/model-registry.js";
-import { getResourceSnapshot } from "../resource-monitor.js";
+import { getCachedResourceSnapshot } from "../resource-monitor.js";
 import { activeSessionCount, getBypassedSessionKeys, getSessionTrackerStats } from "../session-tracker.js";
 import { getTranscriptCaptureStatus } from "../transcript-capture-worker.js";
 import { getTranscriptHealthReport } from "../transcript-health.js";
@@ -64,6 +64,7 @@ import {
 	authConfig,
 	buildOpenClawHealth,
 	getCachedDiagnosticsReport,
+	getCachedDiagnosticsReportIfFresh,
 	getExtractionWorkloadState,
 	getUpdateState,
 	invalidateDiagnosticsCache,
@@ -102,7 +103,14 @@ const UNKNOWN_QUEUE_COUNTS_SHAPE: QueueCounts = {
 	completeness: "unknown",
 };
 
-export function pipelineQueueBlock(): PipelineQueueBlock {
+export function pipelineQueueBlock(options: { readonly allowSynchronousRead?: boolean } = {}): PipelineQueueBlock {
+	if (options.allowSynchronousRead === false) {
+		return {
+			memory: { ...UNKNOWN_QUEUE_COUNTS_SHAPE },
+			summary: { ...UNKNOWN_QUEUE_COUNTS_SHAPE },
+			oldestDeadSummaryJob: null,
+		};
+	}
 	try {
 		const accessor = getDbAccessor();
 		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
@@ -319,8 +327,8 @@ export function registerPipelineRoutes(app: Hono): void {
 
 		let health: { score: number; status: string } | undefined;
 		try {
-			const report = getCachedDiagnosticsReport();
-			health = report.composite;
+			const report = getCachedDiagnosticsReportIfFresh();
+			if (report !== null) health = report.composite;
 		} catch {
 			// DB not ready yet — omit health
 		}
@@ -376,10 +384,13 @@ export function registerPipelineRoutes(app: Hono): void {
 			agentId: resolveDaemonAgentId(),
 			agentsDir: AGENTS_DIR,
 			memoryDb: existsSync(MEMORY_DB),
-			resources: getResourceSnapshot(),
+			resources: getCachedResourceSnapshot(),
 			pipelineV2: config.pipelineV2,
 			pipeline: {
-				queue: pipelineQueueBlock(),
+				// A status request is a liveness surface. Do not synchronously scan
+				// memory_jobs when the diagnostics cache is cold or the DB is under
+				// pressure; the dedicated diagnostics route owns that work.
+				queue: pipelineQueueBlock({ allowSynchronousRead: false }),
 				dreaming: getDreamingWorker()?.scheduler ?? null,
 			},
 			providerResolution: { ...providerRuntimeResolution, extraction: extractionWorkload },

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -192,7 +192,7 @@ function readNumber(record: Readonly<Record<string, unknown>>, key: string): num
 	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
-function readBoolean(record: Readonly<Record<string, unknown>>, key: string): boolean | undefined {
+function _readBoolean(record: Readonly<Record<string, unknown>>, key: string): boolean | undefined {
 	const value = record[key];
 	if (typeof value === "boolean") return value;
 	if (value === "true") return true;
@@ -559,7 +559,6 @@ export function registerPipelineRoutes(app: Hono): void {
 			return c.json({ error: "pluginVersion (string) is required" }, 400);
 		}
 		const prev = openClawHeartbeat?.data;
-		const { logger } = await import("../logger.js");
 		const newData: import("./state.js").OpenClawHeartbeatData = {
 			pluginVersion: b.pluginVersion.slice(0, 128),
 			hooksRegistered: Array.isArray(b.hooksRegistered)

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -7,7 +7,7 @@ import { requirePermission, requireRateLimit } from "../auth";
 import { getDbAccessor } from "../db-accessor.js";
 import { getVacuumConversionStatus } from "../db-vacuum.js";
 import { type QueueCounts, getQueueDiagnosticsSnapshot } from "../diagnostics-queue.js";
-import { getCachedEmbeddingUsageSummary, readEmbeddingUsageSummary } from "../embedding-usage";
+import { readEmbeddingUsageSummary } from "../embedding-usage";
 import { getInferenceRouterOrNull } from "../inference-router.js";
 import type { BackgroundWorkloadDiagnostics } from "../inference-router.js";
 import { getLlmProvider } from "../llm.js";

--- a/platform/daemon/src/routes/state.ts
+++ b/platform/daemon/src/routes/state.ts
@@ -9,7 +9,7 @@ import {
 	resolveDefaultBasePath,
 	resolveNetworkBinding,
 } from "@signet/core";
-import { type AnalyticsCollector, createAnalyticsCollector } from "../analytics";
+import { createAnalyticsCollector } from "../analytics";
 import { type AuthConfig, AuthRateLimiter, loadOrCreateSecret, parseAuthConfig } from "../auth";
 import { getDbAccessor } from "../db-accessor";
 import { type DiagnosticsOptions, type DiagnosticsReport, createProviderTracker, getDiagnostics } from "../diagnostics";

--- a/platform/daemon/src/routes/state.ts
+++ b/platform/daemon/src/routes/state.ts
@@ -464,6 +464,18 @@ export function getCachedDiagnosticsReport(): DiagnosticsReport {
 	return report;
 }
 
+/**
+ * Read the diagnostics cache without running its synchronous database query.
+ *
+ * Lightweight status and liveness routes must not turn a cache miss into a
+ * main-loop database scan while the daemon is already under pressure. The
+ * full getter remains available to the bounded diagnostics surface.
+ */
+export function getCachedDiagnosticsReportIfFresh(): DiagnosticsReport | null {
+	const now = Date.now();
+	return diagnosticsCache !== null && diagnosticsCache.expiresAt > now ? diagnosticsCache.report : null;
+}
+
 export function setPipelineTransition(value: boolean): void {
 	pipelineTransition = value;
 }

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -5069,6 +5069,300 @@
       "api": "withReadDb",
       "source": "const batch = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => fetchBatch(db, limit));",
       "category": "hot-path"
+    },
+    {
+      "path": "aggregate-recall.ts",
+      "line": 740,
+      "api": "withReadDb",
+      "source": "const activeCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "aggregate-recall.ts",
+      "line": 746,
+      "api": "withWriteTx",
+      "source": "const written = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "aggregate-recall.ts",
+      "line": 995,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1440,
+      "api": "withWriteTx",
+      "source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1521,
+      "api": "withReadDb",
+      "source": "const activeEmbeddingCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 2208,
+      "api": "withReadDb",
+      "source": "const memoryCount = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 2219,
+      "api": "withReadDb",
+      "source": "const queue = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-fetch.ts",
+      "line": 494,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => resolveActiveEmbeddingConfig(db, cfg));",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-usage.ts",
+      "line": 90,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-usage.ts",
+      "line": 117,
+      "api": "withReadDb",
+      "source": "const summary = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 59,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 128,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 147,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 269,
+      "api": "withReadDb",
+      "source": "const embeddingConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 304,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 318,
+      "api": "withReadDb",
+      "source": "const writeConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 347,
+      "api": "withWriteTx",
+      "source": "const stored = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 408,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 454,
+      "api": "withReadDb",
+      "source": "const row = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 475,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-graph.ts",
+      "line": 696,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 96,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getQueueHealth(db).status !== \"healthy\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 106,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 182,
+      "api": "withReadDb",
+      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => hasDreamingAttentionKindInDb(db, scope, [\"hygiene\"])),",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 186,
+      "api": "withReadDb",
+      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/synthesis-worker.ts",
+      "line": 127,
+      "api": "withReadDb",
+      "source": "const checkpointRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/synthesis-worker.ts",
+      "line": 153,
+      "api": "withReadDb",
+      "source": "const transcriptRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/hooks-routes.ts",
+      "line": 1163,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/hooks-routes.ts",
+      "line": 1191,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/hooks-routes.ts",
+      "line": 1311,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/import-routes.ts",
+      "line": 337,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/pipeline-routes.ts",
+      "line": 102,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/pipeline-routes.ts",
+      "line": 457,
+      "api": "withReadDb",
+      "source": "const report: ReturnType<typeof listMemoryContentSafety> = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/pipeline-routes.ts",
+      "line": 557,
+      "api": "withReadDb",
+      "source": "const dbData = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 800,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 939,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 1051,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 1114,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 1153,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "source-snapshots.ts",
+      "line": 104,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-graph.ts",
+      "line": 694,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-graph.ts",
+      "line": 703,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
     }
   ]
 }

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -3,69 +3,6 @@
   "generatedFrom": "manual migration ledger",
   "sites": [
     {
-      "path": "agent-id.ts",
-      "line": 56,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "agent-id.ts",
-      "line": 82,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "aggregate-recall.ts",
-      "line": 744,
-      "api": "withReadDb",
-      "source": "const activeCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "aggregate-recall.ts",
-      "line": 750,
-      "api": "withWriteTx",
-      "source": "const written = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "aggregate-recall.ts",
-      "line": 1011,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/api-keys.ts",
-      "line": 197,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/api-keys.ts",
-      "line": 241,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/api-keys.ts",
-      "line": 258,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "auth/api-keys.ts",
-      "line": 272,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "auth/tokens.ts",
       "line": 30,
       "api": "existsSync",
@@ -105,20 +42,6 @@
       "line": 47,
       "api": "writeFileSync",
       "source": "writeFileSync(secretPath, secret, { mode: 0o600 });",
-      "category": "hot-path"
-    },
-    {
-      "path": "black-box.ts",
-      "line": 434,
-      "api": "withReadDb",
-      "source": "const events = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "black-box.ts",
-      "line": 467,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -210,139 +133,6 @@
       "line": 724,
       "api": "readFileSync",
       "source": "text = readFileSync(path, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/filesystem.ts",
-      "line": 232,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/filesystem.ts",
-      "line": 287,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/filesystem.ts",
-      "line": 310,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 23,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 43,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 59,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 74,
-      "api": "withReadDb",
-      "source": "const before = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 82,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 98,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 108,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "connectors/registry.ts",
-      "line": 145,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 645,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 768,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 813,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 856,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 884,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 914,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 953,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 1028,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
@@ -459,20 +249,6 @@
     },
     {
       "path": "daemon.ts",
-      "line": 1455,
-      "api": "withWriteTx",
-      "source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 1536,
-      "api": "withReadDb",
-      "source": "const activeEmbeddingCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
       "line": 1804,
       "api": "existsSync",
       "source": "if (existsSync(PID_FILE)) {",
@@ -511,20 +287,6 @@
       "line": 2093,
       "api": "writeFileSync",
       "source": "writeFileSync(PID_FILE, process.pid.toString());",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 2234,
-      "api": "withReadDb",
-      "source": "const memoryCount = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 2245,
-      "api": "withReadDb",
-      "source": "const queue = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
       "category": "hot-path"
     },
     {
@@ -696,34 +458,6 @@
       "category": "hot-path"
     },
     {
-      "path": "db-vacuum.ts",
-      "line": 322,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readStatusFromDb(toPragmaReadDb(db)));",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-vacuum.ts",
-      "line": 411,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-vacuum.ts",
-      "line": 437,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-vacuum.ts",
-      "line": 453,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "discord-desktop-cache-source.ts",
       "line": 221,
       "api": "lstatSync",
@@ -746,114 +480,9 @@
     },
     {
       "path": "discord-desktop-cache-source.ts",
-      "line": 481,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-desktop-cache-source.ts",
-      "line": 494,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-desktop-cache-source.ts",
       "line": 1085,
       "api": "readFileSync",
       "source": "const data = fileSystem.readFileSync(path).subarray(0, CACHE_SNIFF_BYTES).toString(\"utf8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 574,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 588,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 630,
-      "api": "withReadDb",
-      "source": "const row = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 875,
-      "api": "withReadDb",
-      "source": "const row = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 959,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "discord-source-provider.ts",
-      "line": 973,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-fetch.ts",
-      "line": 495,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => resolveActiveEmbeddingConfig(db, cfg));",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-repair-state.ts",
-      "line": 101,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-repair-state.ts",
-      "line": 139,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-repair-state.ts",
-      "line": 160,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-repair-state.ts",
-      "line": 191,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-tracker.ts",
-      "line": 194,
-      "api": "withReadDb",
-      "source": "const staleRows: StaleRow[] = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-tracker.ts",
-      "line": 265,
-      "api": "withWriteTx",
-      "source": "applied = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
@@ -910,27 +539,6 @@
       "line": 11,
       "api": "writeFileSync",
       "source": "writeFileSync(path, content);",
-      "category": "hot-path"
-    },
-    {
-      "path": "github-source-provider.ts",
-      "line": 461,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "github-source-provider.ts",
-      "line": 483,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "github-source-provider.ts",
-      "line": 497,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
@@ -1120,34 +728,6 @@
       "line": 85,
       "api": "existsSync",
       "source": "const identityPath = existsSync(join(agentDir, \"IDENTITY.md\"))",
-      "category": "hot-path"
-    },
-    {
-      "path": "imported-source-lifecycle.ts",
-      "line": 36,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "imported-source-outcome.ts",
-      "line": 16,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => persistImportedSourceOutcomeInTx(db, input));",
-      "category": "hot-path"
-    },
-    {
-      "path": "imported-source-outcome.ts",
-      "line": 59,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "knowledge-graph-hygiene.ts",
-      "line": 428,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -1355,23 +935,9 @@
     },
     {
       "path": "memory-candidates.ts",
-      "line": 150,
-      "api": "withReadDb",
-      "source": "const batchRows: ScoredMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
       "line": 211,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 228,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -1383,20 +949,6 @@
     },
     {
       "path": "memory-candidates.ts",
-      "line": 306,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 368,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
       "line": 401,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return [];",
@@ -1404,23 +956,9 @@
     },
     {
       "path": "memory-candidates.ts",
-      "line": 432,
-      "api": "withReadDb",
-      "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
       "line": 440,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return [];",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 473,
-      "api": "withReadDb",
-      "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -1435,20 +973,6 @@
       "line": 992,
       "api": "readFileSync",
       "source": "const yaml = parseSimpleYaml(readFileSync(path, \"utf-8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 82,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 151,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
@@ -1491,13 +1015,6 @@
       "line": 167,
       "api": "writeFileSync",
       "source": "writeFileSync(path, file);",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 170,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
@@ -1690,55 +1207,6 @@
       "category": "hot-path"
     },
     {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 544,
-      "api": "withReadDb",
-      "source": "const embeddingConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 579,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 593,
-      "api": "withReadDb",
-      "source": "const writeConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 622,
-      "api": "withWriteTx",
-      "source": "const stored = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 683,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 729,
-      "api": "withReadDb",
-      "source": "const row = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 750,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "obsidian-source-graph.ts",
       "line": 323,
       "api": "existsSync",
@@ -1750,125 +1218,6 @@
       "line": 323,
       "api": "statSync",
       "source": "return existsSync(path) && statSync(path).isFile() ? normalizedPath(path) : null;",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-graph.ts",
-      "line": 686,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-graph.ts",
-      "line": 695,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-graph.ts",
-      "line": 778,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 306,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: WriteDb) => insertAssertion(db, input));",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 325,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 391,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 410,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 438,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-assertions.ts",
-      "line": 466,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-claim-evidence.ts",
-      "line": 153,
-      "api": "withReadDb",
-      "source": "const items = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-claim-trace.ts",
-      "line": 1063,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-contradictions.ts",
-      "line": 524,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => reconcileOntologyContradictionsInTx(db, params));",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-contradictions.ts",
-      "line": 535,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-contradictions.ts",
-      "line": 591,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-extraction.ts",
-      "line": 647,
-      "api": "withReadDb",
-      "source": "const source = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "ontology-extraction.ts",
-      "line": 748,
-      "api": "withWriteTx",
-      "source": "const written = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "path-feedback.ts",
-      "line": 611,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
@@ -1893,171 +1242,10 @@
       "category": "hot-path"
     },
     {
-      "path": "pipeline/aspect-feedback.ts",
-      "line": 79,
-      "api": "withWriteTx",
-      "source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/aspect-feedback.ts",
-      "line": 165,
-      "api": "withWriteTx",
-      "source": "const decayed = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 136,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getDreamingAttentionInDb(db, agentId, limit));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 145,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 181,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 225,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 256,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-attention.ts",
-      "line": 290,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-evidence-retry.ts",
-      "line": 131,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-evidence-retry.ts",
-      "line": 253,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 112,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 154,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 478,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 490,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 503,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 520,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-operations.ts",
-      "line": 692,
-      "api": "withReadDb",
-      "source": "const pending = params.accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-runbook.ts",
-      "line": 177,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-runbook.ts",
-      "line": 219,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "pipeline/dreaming-token-cache.ts",
       "line": 36,
       "api": "existsSync",
       "source": "return existsSync(bundled)",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 100,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getQueueHealth(db).status !== \"healthy\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 118,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 194,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => hasDreamingAttentionKindInDb(db, scope, [\"hygiene\"])),",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 198,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
       "category": "hot-path"
     },
     {
@@ -2072,48 +1260,6 @@
       "line": 733,
       "api": "readFileSync",
       "source": "const raw = readFileSync(path, \"utf-8\").trim();",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/extraction-fallback.ts",
-      "line": 17,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/prospective-index.ts",
-      "line": 230,
-      "api": "withWriteTx",
-      "source": "job = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => leaseJob(db, 3));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/prospective-index.ts",
-      "line": 242,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => failJob(db, j.id, \"invalid payload\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/prospective-index.ts",
-      "line": 252,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/prospective-index.ts",
-      "line": 262,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => completeJob(db, j.id));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/prospective-index.ts",
-      "line": 272,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => failJob(db, j.id, msg));",
       "category": "hot-path"
     },
     {
@@ -2152,83 +1298,6 @@
       "category": "hot-path"
     },
     {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 366,
-      "api": "withReadDb",
-      "source": "const memories = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 399,
-      "api": "withReadDb",
-      "source": "const existingReflections = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 461,
-      "api": "withWriteTx",
-      "source": "deps.getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reflection-worker.ts",
-      "line": 527,
-      "api": "withReadDb",
-      "source": ".withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/reranker-embedding.ts",
-      "line": 51,
-      "api": "withReadDb",
-      "source": "const embMap = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 80,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 174,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 292,
-      "api": "withReadDb",
-      "source": "const writeConfig = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 305,
-      "api": "withWriteTx",
-      "source": "embeddingCreated = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 365,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 376,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "pipeline/skill-reconciler.ts",
       "line": 136,
       "api": "existsSync",
@@ -2251,13 +1320,6 @@
     },
     {
       "path": "pipeline/skill-reconciler.ts",
-      "line": 163,
-      "api": "withReadDb",
-      "source": "const graphSkills = deps.accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
       "line": 170,
       "api": "existsSync",
       "source": "if (!existsSync(row.fs_path)) {",
@@ -2275,20 +1337,6 @@
       "line": 234,
       "api": "readFileSync",
       "source": "const content = readFileSync(mdPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 241,
-      "api": "withReadDb",
-      "source": "const existing = deps.accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 250,
-      "api": "withReadDb",
-      "source": "const storedEmb = deps.accessor.withReadDb(",
       "category": "hot-path"
     },
     {
@@ -2331,20 +1379,6 @@
       "line": 85,
       "api": "writeFileSync",
       "source": "writeFileSync(path, JSON.stringify({ lastRunAt: timestamp }));",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/synthesis-worker.ts",
-      "line": 125,
-      "api": "withReadDb",
-      "source": "const checkpointRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/synthesis-worker.ts",
-      "line": 151,
-      "api": "withReadDb",
-      "source": "const transcriptRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -2422,20 +1456,6 @@
       "line": 668,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return { lines: [], memories: [], memoryCount: 0, engine: \"no-entity\" };",
-      "category": "hot-path"
-    },
-    {
-      "path": "prompt-entity-context.ts",
-      "line": 671,
-      "api": "withReadDb",
-      "source": "const matches: PromptEntityMatch[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "prompt-entity-context.ts",
-      "line": 697,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -2524,27 +1544,6 @@
     },
     {
       "path": "routes/connectors-routes.ts",
-      "line": 277,
-      "api": "withReadDb",
-      "source": "const docs = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/connectors-routes.ts",
-      "line": 288,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/connectors-routes.ts",
-      "line": 319,
-      "api": "withReadDb",
-      "source": "const docCount = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/connectors-routes.ts",
       "line": 352,
       "api": "existsSync",
       "source": "exists: existsSync(join(homedir(), \".claude\", \"settings.json\")),",
@@ -2611,20 +1610,6 @@
       "line": 28,
       "api": "existsSync",
       "source": "if (existsSync(join(candidate, \"index.html\"))) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/database-diagnostics.ts",
-      "line": 241,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/database-diagnostics.ts",
-      "line": 276,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -2751,34 +1736,6 @@
       "line": 1148,
       "api": "existsSync",
       "source": "if (!existsSync(getCurrentMemoryDbPath())) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/hooks-routes.ts",
-      "line": 1180,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/hooks-routes.ts",
-      "line": 1208,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/hooks-routes.ts",
-      "line": 1328,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/import-routes.ts",
-      "line": 334,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -2915,27 +1872,6 @@
       "category": "hot-path"
     },
     {
-      "path": "routes/marketplace.ts",
-      "line": 1128,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/mcp-analytics.ts",
-      "line": 89,
-      "api": "withReadDb",
-      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/mcp-analytics.ts",
-      "line": 171,
-      "api": "withReadDb",
-      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "routes/memory-routes.ts",
       "line": 278,
       "api": "mkdirSync",
@@ -2979,13 +1915,6 @@
     },
     {
       "path": "routes/pipeline-routes.ts",
-      "line": 109,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/pipeline-routes.ts",
       "line": 296,
       "api": "existsSync",
       "source": "if (existsSync(p)) {",
@@ -3010,160 +1939,6 @@
       "line": 392,
       "api": "readFileSync",
       "source": "soulContent = readFileSync(soulPath, \"utf-8\").slice(0, 500);",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/pipeline-routes.ts",
-      "line": 493,
-      "api": "withReadDb",
-      "source": "const report: ReturnType<typeof listMemoryContentSafety> = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/pipeline-routes.ts",
-      "line": 593,
-      "api": "withReadDb",
-      "source": "const dbData = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/queue-diagnostics.ts",
-      "line": 169,
-      "api": "withReadDb",
-      "source": "const response = resolveAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/reflection-routes.ts",
-      "line": 98,
-      "api": "withReadDb",
-      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/reflection-routes.ts",
-      "line": 118,
-      "api": "withReadDb",
-      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/reflection-routes.ts",
-      "line": 172,
-      "api": "withReadDb",
-      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/reflection-routes.ts",
-      "line": 207,
-      "api": "withReadDb",
-      "source": "const existing = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/reflection-routes.ts",
-      "line": 225,
-      "api": "withWriteTx",
-      "source": "resolveDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 313,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 357,
-      "api": "withWriteTx",
-      "source": "const result = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => clusterEntities(db, agentId));",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 378,
-      "api": "withReadDb",
-      "source": "const unlinked = accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 408,
-      "api": "withReadDb",
-      "source": "const preview = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 459,
-      "api": "withWriteTx",
-      "source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 469,
-      "api": "withReadDb",
-      "source": "const remaining = accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 512,
-      "api": "withReadDb",
-      "source": "const unhinted = accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 537,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 545,
-      "api": "withReadDb",
-      "source": "const remaining = accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/repair-routes.ts",
-      "line": 585,
-      "api": "withReadDb",
-      "source": "const dead = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/session-routes.ts",
-      "line": 168,
-      "api": "withReadDb",
-      "source": "const hits = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/session-routes.ts",
-      "line": 347,
-      "api": "withReadDb",
-      "source": "const tableExists = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/session-routes.ts",
-      "line": 355,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skill-analytics.ts",
-      "line": 121,
-      "api": "withReadDb",
-      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
       "category": "hot-path"
     },
     {
@@ -3461,41 +2236,6 @@
       "category": "hot-path"
     },
     {
-      "path": "routes/sources-routes.ts",
-      "line": 883,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1022,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1134,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1197,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1236,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "routes/state.ts",
       "line": 157,
       "api": "existsSync",
@@ -3524,48 +2264,6 @@
       "category": "hot-path"
     },
     {
-      "path": "routes/state.ts",
-      "line": 457,
-      "api": "withReadDb",
-      "source": "const report = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/telemetry-routes.ts",
-      "line": 200,
-      "api": "withReadDb",
-      "source": "const mutationHealth = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/telemetry-routes.ts",
-      "line": 219,
-      "api": "withReadDb",
-      "source": "const scores: Array<Record<string, unknown>> = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/telemetry-routes.ts",
-      "line": 263,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/utils.ts",
-      "line": 437,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/utils.ts",
-      "line": 525,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "routes/widget.ts",
       "line": 75,
       "api": "existsSync",
@@ -3584,34 +2282,6 @@
       "line": 42,
       "api": "readFileSync",
       "source": "const raw = readFileSync(skillPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "scheduler/worker.ts",
-      "line": 104,
-      "api": "withWriteTx",
-      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "scheduler/worker.ts",
-      "line": 122,
-      "api": "withReadDb",
-      "source": "const dueTasks = db.withReadDb((rdb: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "scheduler/worker.ts",
-      "line": 193,
-      "api": "withWriteTx",
-      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "scheduler/worker.ts",
-      "line": 280,
-      "api": "withWriteTx",
-      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
@@ -4112,101 +2782,10 @@
       "category": "hot-path"
     },
     {
-      "path": "session-checkpoints.ts",
-      "line": 109,
-      "api": "withWriteTx",
-      "source": "db.withWriteTx((wdb: WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-checkpoints.ts",
-      "line": 226,
-      "api": "withReadDb",
-      "source": "return db.withReadDb((rdb: ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-checkpoints.ts",
-      "line": 243,
-      "api": "withReadDb",
-      "source": "return db.withReadDb((rdb: ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-checkpoints.ts",
-      "line": 259,
-      "api": "withReadDb",
-      "source": "return db.withReadDb((rdb: ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-checkpoints.ts",
-      "line": 277,
-      "api": "withReadDb",
-      "source": "return db.withReadDb((rdb: ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-checkpoints.ts",
-      "line": 301,
-      "api": "withWriteTx",
-      "source": "return db.withWriteTx((wdb: WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-claims.ts",
-      "line": 64,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-claims.ts",
-      "line": 82,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-claims.ts",
-      "line": 92,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-claims.ts",
-      "line": 119,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-claims.ts",
-      "line": 125,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb(readClaims);",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-end-recovery.ts",
-      "line": 106,
-      "api": "withWriteTx",
-      "source": "const result = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "session-memories.ts",
       "line": 55,
       "api": "existsSync",
       "source": "if (!sessionKey || candidates.length === 0 || !existsSync(getMemoryDbPath())) return;",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-memories.ts",
-      "line": 59,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
@@ -4218,51 +2797,9 @@
     },
     {
       "path": "session-memories.ts",
-      "line": 153,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-memories.ts",
       "line": 262,
       "api": "existsSync",
       "source": "if (!sessionKey || Object.keys(feedback).length === 0 || !existsSync(getMemoryDbPath())) return;",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-memories.ts",
-      "line": 268,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-recall-dedupe.ts",
-      "line": 149,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-recall-dedupe.ts",
-      "line": 244,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 103,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => tableExistsInDatabase(db, name));",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 112,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -4284,13 +2821,6 @@
       "line": 162,
       "api": "readFileSync",
       "source": "const parsed = parseArtifactFrontmatter(readFileSync(path, \"utf8\"));",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 248,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -4319,83 +2849,6 @@
       "line": 372,
       "api": "writeFileSync",
       "source": "writeFileSync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 392,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 446,
-      "api": "withWriteTx",
-      "source": "return (accessor ?? getDbAccessor()).withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 561,
-      "api": "withWriteTx",
-      "source": "return (accessor ?? getDbAccessor()).withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 595,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 641,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 680,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 735,
-      "api": "withReadDb",
-      "source": "const exactRows: TranscriptRow[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 780,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-transcripts.ts",
-      "line": 844,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-ttl-finalizer.ts",
-      "line": 79,
-      "api": "withReadDb",
-      "source": "const alreadyCompleted = deps.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "session-ttl-finalizer.ts",
-      "line": 92,
-      "api": "withWriteTx",
-      "source": "deps.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
       "category": "hot-path"
     },
     {
@@ -4455,13 +2908,6 @@
       "category": "hot-path"
     },
     {
-      "path": "skill-invocations.ts",
-      "line": 50,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
       "path": "skill-transcript-scan.ts",
       "line": 19,
       "api": "statSync",
@@ -4473,76 +2919,6 @@
       "line": 32,
       "api": "readFileSync",
       "source": "content = readFileSync(args.transcriptPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "source-artifact-graph.ts",
-      "line": 304,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "source-artifact-graph.ts",
-      "line": 314,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "source-snapshots.ts",
-      "line": 106,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "telemetry.ts",
-      "line": 492,
-      "api": "withWriteTx",
-      "source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "telemetry.ts",
-      "line": 532,
-      "api": "withWriteTx",
-      "source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "temporal-expand.ts",
-      "line": 178,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "temporal-fallback.ts",
-      "line": 36,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => tableExistsIn(db, name));",
-      "category": "hot-path"
-    },
-    {
-      "path": "temporal-fallback.ts",
-      "line": 150,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "temporal-fallback.ts",
-      "line": 206,
-      "api": "withReadDb",
-      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "temporal-recall.ts",
-      "line": 442,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
@@ -4826,48 +3202,6 @@
       "category": "hot-path"
     },
     {
-      "path": "transcript-recovery-worker.ts",
-      "line": 266,
-      "api": "withReadDb",
-      "source": "if (dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => unchanged(db, agentId, candidate))) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 295,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 304,
-      "api": "withReadDb",
-      "source": "const alreadyCaptured = dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 309,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 329,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 375,
-      "api": "withWriteTx",
-      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
       "path": "update-system.ts",
       "line": 321,
       "api": "existsSync",
@@ -5057,6 +3391,1672 @@
       "category": "hot-path"
     },
     {
+      "path": "agent-id.ts",
+      "line": 56,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "agent-id.ts",
+      "line": 82,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "aggregate-recall.ts",
+      "line": 744,
+      "api": "withReadDb",
+      "source": "const activeCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "aggregate-recall.ts",
+      "line": 750,
+      "api": "withWriteTx",
+      "source": "const written = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "aggregate-recall.ts",
+      "line": 1011,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/api-keys.ts",
+      "line": 197,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/api-keys.ts",
+      "line": 241,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/api-keys.ts",
+      "line": 258,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "auth/api-keys.ts",
+      "line": 272,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "black-box.ts",
+      "line": 434,
+      "api": "withReadDb",
+      "source": "const events = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "black-box.ts",
+      "line": 467,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/filesystem.ts",
+      "line": 232,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/filesystem.ts",
+      "line": 287,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/filesystem.ts",
+      "line": 310,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 23,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 43,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 59,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 74,
+      "api": "withReadDb",
+      "source": "const before = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 82,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 98,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 108,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "connectors/registry.ts",
+      "line": 145,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 645,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 768,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 813,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 856,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 884,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 914,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 953,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "cross-agent.ts",
+      "line": 1028,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1451,
+      "api": "withWriteTx",
+      "source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 1532,
+      "api": "withReadDb",
+      "source": "const activeEmbeddingCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 2238,
+      "api": "withReadDb",
+      "source": "const memoryCount = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "daemon.ts",
+      "line": 2249,
+      "api": "withReadDb",
+      "source": "const queue = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-vacuum.ts",
+      "line": 335,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => readStatusFromDb(toPragmaReadDb(db)));",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-vacuum.ts",
+      "line": 480,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-vacuum.ts",
+      "line": 510,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-vacuum.ts",
+      "line": 526,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-desktop-cache-source.ts",
+      "line": 481,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-desktop-cache-source.ts",
+      "line": 494,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 574,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 588,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 630,
+      "api": "withReadDb",
+      "source": "const row = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 875,
+      "api": "withReadDb",
+      "source": "const row = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 959,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "discord-source-provider.ts",
+      "line": 973,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-fetch.ts",
+      "line": 495,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => resolveActiveEmbeddingConfig(db, cfg));",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-repair-state.ts",
+      "line": 101,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-repair-state.ts",
+      "line": 139,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-repair-state.ts",
+      "line": 160,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-repair-state.ts",
+      "line": 191,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-tracker.ts",
+      "line": 200,
+      "api": "withReadDb",
+      "source": "const staleRows: StaleRow[] = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "embedding-tracker.ts",
+      "line": 271,
+      "api": "withWriteTx",
+      "source": "applied = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "github-source-provider.ts",
+      "line": 461,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "github-source-provider.ts",
+      "line": 483,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "github-source-provider.ts",
+      "line": 497,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "imported-source-lifecycle.ts",
+      "line": 36,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "imported-source-outcome.ts",
+      "line": 16,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => persistImportedSourceOutcomeInTx(db, input));",
+      "category": "hot-path"
+    },
+    {
+      "path": "imported-source-outcome.ts",
+      "line": 59,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "knowledge-graph-hygiene.ts",
+      "line": 428,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 150,
+      "api": "withReadDb",
+      "source": "const batchRows: ScoredMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 228,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 306,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 368,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 432,
+      "api": "withReadDb",
+      "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-candidates.ts",
+      "line": 473,
+      "api": "withReadDb",
+      "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 82,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 151,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "memory-head.ts",
+      "line": 170,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 578,
+      "api": "withReadDb",
+      "source": "const embeddingConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 613,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 627,
+      "api": "withReadDb",
+      "source": "const writeConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 660,
+      "api": "withWriteTx",
+      "source": "const stored = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 721,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 767,
+      "api": "withReadDb",
+      "source": "const row = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-embeddings.ts",
+      "line": 788,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-graph.ts",
+      "line": 686,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-graph.ts",
+      "line": 695,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "obsidian-source-graph.ts",
+      "line": 778,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 306,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: WriteDb) => insertAssertion(db, input));",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 325,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 391,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 410,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 438,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-assertions.ts",
+      "line": 466,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-claim-evidence.ts",
+      "line": 153,
+      "api": "withReadDb",
+      "source": "const items = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-claim-trace.ts",
+      "line": 1063,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-contradictions.ts",
+      "line": 524,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => reconcileOntologyContradictionsInTx(db, params));",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-contradictions.ts",
+      "line": 535,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-contradictions.ts",
+      "line": 591,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-extraction.ts",
+      "line": 647,
+      "api": "withReadDb",
+      "source": "const source = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "ontology-extraction.ts",
+      "line": 748,
+      "api": "withWriteTx",
+      "source": "const written = accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "path-feedback.ts",
+      "line": 611,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/aspect-feedback.ts",
+      "line": 79,
+      "api": "withWriteTx",
+      "source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/aspect-feedback.ts",
+      "line": 165,
+      "api": "withWriteTx",
+      "source": "const decayed = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 136,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getDreamingAttentionInDb(db, agentId, limit));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 145,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 181,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 225,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 256,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-attention.ts",
+      "line": 290,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-evidence-retry.ts",
+      "line": 131,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-evidence-retry.ts",
+      "line": 253,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 112,
+      "api": "withReadDb",
+      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 154,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 478,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 490,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 503,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 520,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-operations.ts",
+      "line": 692,
+      "api": "withReadDb",
+      "source": "const pending = params.accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-runbook.ts",
+      "line": 177,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-runbook.ts",
+      "line": 219,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 100,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getQueueHealth(db).status !== \"healthy\");",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 118,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 194,
+      "api": "withReadDb",
+      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => hasDreamingAttentionKindInDb(db, scope, [\"hygiene\"])),",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/dreaming-worker.ts",
+      "line": 198,
+      "api": "withReadDb",
+      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/extraction-fallback.ts",
+      "line": 17,
+      "api": "withWriteTx",
+      "source": "return accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/prospective-index.ts",
+      "line": 230,
+      "api": "withWriteTx",
+      "source": "job = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => leaseJob(db, 3));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/prospective-index.ts",
+      "line": 242,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => failJob(db, j.id, \"invalid payload\"));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/prospective-index.ts",
+      "line": 252,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/prospective-index.ts",
+      "line": 262,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => completeJob(db, j.id));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/prospective-index.ts",
+      "line": 272,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => failJob(db, j.id, msg));",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reflection-worker.ts",
+      "line": 366,
+      "api": "withReadDb",
+      "source": "const memories = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reflection-worker.ts",
+      "line": 399,
+      "api": "withReadDb",
+      "source": "const existingReflections = dbAccessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reflection-worker.ts",
+      "line": 461,
+      "api": "withWriteTx",
+      "source": "deps.getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reflection-worker.ts",
+      "line": 527,
+      "api": "withReadDb",
+      "source": ".withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/reranker-embedding.ts",
+      "line": 51,
+      "api": "withReadDb",
+      "source": "const embMap = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 80,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 174,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 292,
+      "api": "withReadDb",
+      "source": "const writeConfig = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 305,
+      "api": "withWriteTx",
+      "source": "embeddingCreated = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 365,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-graph.ts",
+      "line": 376,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 163,
+      "api": "withReadDb",
+      "source": "const graphSkills = deps.accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 241,
+      "api": "withReadDb",
+      "source": "const existing = deps.accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/skill-reconciler.ts",
+      "line": 250,
+      "api": "withReadDb",
+      "source": "const storedEmb = deps.accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/synthesis-worker.ts",
+      "line": 125,
+      "api": "withReadDb",
+      "source": "const checkpointRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "pipeline/synthesis-worker.ts",
+      "line": 151,
+      "api": "withReadDb",
+      "source": "const transcriptRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "prompt-entity-context.ts",
+      "line": 671,
+      "api": "withReadDb",
+      "source": "const matches: PromptEntityMatch[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "prompt-entity-context.ts",
+      "line": 697,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/connectors-routes.ts",
+      "line": 277,
+      "api": "withReadDb",
+      "source": "const docs = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/connectors-routes.ts",
+      "line": 288,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/connectors-routes.ts",
+      "line": 319,
+      "api": "withReadDb",
+      "source": "const docCount = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/database-diagnostics.ts",
+      "line": 241,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/database-diagnostics.ts",
+      "line": 276,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/hooks-routes.ts",
+      "line": 1180,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/hooks-routes.ts",
+      "line": 1208,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/hooks-routes.ts",
+      "line": 1328,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/import-routes.ts",
+      "line": 334,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/marketplace.ts",
+      "line": 1128,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/mcp-analytics.ts",
+      "line": 89,
+      "api": "withReadDb",
+      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/mcp-analytics.ts",
+      "line": 171,
+      "api": "withReadDb",
+      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/pipeline-routes.ts",
+      "line": 117,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/pipeline-routes.ts",
+      "line": 504,
+      "api": "withReadDb",
+      "source": "const report: ReturnType<typeof listMemoryContentSafety> = getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/pipeline-routes.ts",
+      "line": 603,
+      "api": "withReadDb",
+      "source": "const dbData = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/queue-diagnostics.ts",
+      "line": 169,
+      "api": "withReadDb",
+      "source": "const response = resolveAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/reflection-routes.ts",
+      "line": 98,
+      "api": "withReadDb",
+      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/reflection-routes.ts",
+      "line": 118,
+      "api": "withReadDb",
+      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/reflection-routes.ts",
+      "line": 172,
+      "api": "withReadDb",
+      "source": "const rows = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/reflection-routes.ts",
+      "line": 207,
+      "api": "withReadDb",
+      "source": "const existing = resolveDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/reflection-routes.ts",
+      "line": 225,
+      "api": "withWriteTx",
+      "source": "resolveDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 313,
+      "api": "withReadDb",
+      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 357,
+      "api": "withWriteTx",
+      "source": "const result = getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => clusterEntities(db, agentId));",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 378,
+      "api": "withReadDb",
+      "source": "const unlinked = accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 408,
+      "api": "withReadDb",
+      "source": "const preview = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 459,
+      "api": "withWriteTx",
+      "source": "const result = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 469,
+      "api": "withReadDb",
+      "source": "const remaining = accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 512,
+      "api": "withReadDb",
+      "source": "const unhinted = accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 537,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 545,
+      "api": "withReadDb",
+      "source": "const remaining = accessor.withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/repair-routes.ts",
+      "line": 585,
+      "api": "withReadDb",
+      "source": "const dead = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/session-routes.ts",
+      "line": 168,
+      "api": "withReadDb",
+      "source": "const hits = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/session-routes.ts",
+      "line": 347,
+      "api": "withReadDb",
+      "source": "const tableExists = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/session-routes.ts",
+      "line": 355,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skill-analytics.ts",
+      "line": 121,
+      "api": "withReadDb",
+      "source": "const result = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 883,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 1022,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 1134,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 1197,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/sources-routes.ts",
+      "line": 1236,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/state.ts",
+      "line": 457,
+      "api": "withReadDb",
+      "source": "const report = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/telemetry-routes.ts",
+      "line": 200,
+      "api": "withReadDb",
+      "source": "const mutationHealth = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/telemetry-routes.ts",
+      "line": 219,
+      "api": "withReadDb",
+      "source": "const scores: Array<Record<string, unknown>> = getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/telemetry-routes.ts",
+      "line": 263,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb(",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/utils.ts",
+      "line": 437,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/utils.ts",
+      "line": 525,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "scheduler/worker.ts",
+      "line": 104,
+      "api": "withWriteTx",
+      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "scheduler/worker.ts",
+      "line": 122,
+      "api": "withReadDb",
+      "source": "const dueTasks = db.withReadDb((rdb: import(\"../db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "scheduler/worker.ts",
+      "line": 193,
+      "api": "withWriteTx",
+      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "scheduler/worker.ts",
+      "line": 280,
+      "api": "withWriteTx",
+      "source": "db.withWriteTx((wdb: import(\"../db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 109,
+      "api": "withWriteTx",
+      "source": "db.withWriteTx((wdb: WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 226,
+      "api": "withReadDb",
+      "source": "return db.withReadDb((rdb: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 243,
+      "api": "withReadDb",
+      "source": "return db.withReadDb((rdb: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 259,
+      "api": "withReadDb",
+      "source": "return db.withReadDb((rdb: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 277,
+      "api": "withReadDb",
+      "source": "return db.withReadDb((rdb: ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-checkpoints.ts",
+      "line": 301,
+      "api": "withWriteTx",
+      "source": "return db.withWriteTx((wdb: WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-claims.ts",
+      "line": 64,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-claims.ts",
+      "line": 82,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-claims.ts",
+      "line": 92,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-claims.ts",
+      "line": 119,
+      "api": "withWriteTx",
+      "source": "accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-claims.ts",
+      "line": 125,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb(readClaims);",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-end-recovery.ts",
+      "line": 106,
+      "api": "withWriteTx",
+      "source": "const result = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-memories.ts",
+      "line": 59,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-memories.ts",
+      "line": 153,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-memories.ts",
+      "line": 268,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-recall-dedupe.ts",
+      "line": 149,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-recall-dedupe.ts",
+      "line": 244,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 103,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => tableExistsInDatabase(db, name));",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 112,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 248,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 392,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 446,
+      "api": "withWriteTx",
+      "source": "return (accessor ?? getDbAccessor()).withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 561,
+      "api": "withWriteTx",
+      "source": "return (accessor ?? getDbAccessor()).withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 595,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 641,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 680,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 735,
+      "api": "withReadDb",
+      "source": "const exactRows: TranscriptRow[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 780,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-transcripts.ts",
+      "line": 844,
+      "api": "withReadDb",
+      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-ttl-finalizer.ts",
+      "line": 79,
+      "api": "withReadDb",
+      "source": "const alreadyCompleted = deps.accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "session-ttl-finalizer.ts",
+      "line": 92,
+      "api": "withWriteTx",
+      "source": "deps.accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "skill-invocations.ts",
+      "line": 50,
+      "api": "withWriteTx",
+      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "source-artifact-graph.ts",
+      "line": 304,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "source-artifact-graph.ts",
+      "line": 314,
+      "api": "withWriteTx",
+      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "source-snapshots.ts",
+      "line": 106,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "telemetry.ts",
+      "line": 492,
+      "api": "withWriteTx",
+      "source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "telemetry.ts",
+      "line": 532,
+      "api": "withWriteTx",
+      "source": "return db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "temporal-expand.ts",
+      "line": 178,
+      "api": "withReadDb",
+      "source": "return accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "temporal-fallback.ts",
+      "line": 36,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => tableExistsIn(db, name));",
+      "category": "hot-path"
+    },
+    {
+      "path": "temporal-fallback.ts",
+      "line": 150,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "temporal-fallback.ts",
+      "line": 206,
+      "api": "withReadDb",
+      "source": "const rows = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "temporal-recall.ts",
+      "line": 442,
+      "api": "withReadDb",
+      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 266,
+      "api": "withReadDb",
+      "source": "if (dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => unchanged(db, agentId, candidate))) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 295,
+      "api": "withWriteTx",
+      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 304,
+      "api": "withReadDb",
+      "source": "const alreadyCaptured = dbAccessor.withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 309,
+      "api": "withWriteTx",
+      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 329,
+      "api": "withWriteTx",
+      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 375,
+      "api": "withWriteTx",
+      "source": "dbAccessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
+      "category": "hot-path"
+    },
+    {
       "path": "yielding-writes.ts",
       "line": 115,
       "api": "withWriteTx",
@@ -5068,300 +5068,6 @@
       "line": 155,
       "api": "withReadDb",
       "source": "const batch = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => fetchBatch(db, limit));",
-      "category": "hot-path"
-    },
-    {
-      "path": "aggregate-recall.ts",
-      "line": 740,
-      "api": "withReadDb",
-      "source": "const activeCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "aggregate-recall.ts",
-      "line": 746,
-      "api": "withWriteTx",
-      "source": "const written = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "aggregate-recall.ts",
-      "line": 995,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 1440,
-      "api": "withWriteTx",
-      "source": "db.withWriteTx((w: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 1521,
-      "api": "withReadDb",
-      "source": "const activeEmbeddingCfg = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 2208,
-      "api": "withReadDb",
-      "source": "const memoryCount = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 2219,
-      "api": "withReadDb",
-      "source": "const queue = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-fetch.ts",
-      "line": 494,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => resolveActiveEmbeddingConfig(db, cfg));",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-usage.ts",
-      "line": 90,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "embedding-usage.ts",
-      "line": 117,
-      "api": "withReadDb",
-      "source": "const summary = accessor.withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 59,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 128,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-head.ts",
-      "line": 147,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 269,
-      "api": "withReadDb",
-      "source": "const embeddingConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 304,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 318,
-      "api": "withReadDb",
-      "source": "const writeConfig = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 347,
-      "api": "withWriteTx",
-      "source": "const stored = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 408,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 454,
-      "api": "withReadDb",
-      "source": "const row = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-embeddings.ts",
-      "line": 475,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-graph.ts",
-      "line": 696,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 96,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => getQueueHealth(db).status !== \"healthy\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 106,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 182,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => hasDreamingAttentionKindInDb(db, scope, [\"hygiene\"])),",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/dreaming-worker.ts",
-      "line": 186,
-      "api": "withReadDb",
-      "source": "accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/synthesis-worker.ts",
-      "line": 127,
-      "api": "withReadDb",
-      "source": "const checkpointRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/synthesis-worker.ts",
-      "line": 153,
-      "api": "withReadDb",
-      "source": "const transcriptRow = deps.getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/hooks-routes.ts",
-      "line": 1163,
-      "api": "withReadDb",
-      "source": "getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/hooks-routes.ts",
-      "line": 1191,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/hooks-routes.ts",
-      "line": 1311,
-      "api": "withWriteTx",
-      "source": "getDbAccessor().withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/import-routes.ts",
-      "line": 337,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/pipeline-routes.ts",
-      "line": 102,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/pipeline-routes.ts",
-      "line": 457,
-      "api": "withReadDb",
-      "source": "const report: ReturnType<typeof listMemoryContentSafety> = getDbAccessor().withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/pipeline-routes.ts",
-      "line": 557,
-      "api": "withReadDb",
-      "source": "const dbData = accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 800,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 939,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1051,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1114,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/sources-routes.ts",
-      "line": 1153,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "source-snapshots.ts",
-      "line": 104,
-      "api": "withReadDb",
-      "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-graph.ts",
-      "line": 694,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
-      "category": "hot-path"
-    },
-    {
-      "path": "obsidian-source-graph.ts",
-      "line": 703,
-      "api": "withWriteTx",
-      "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) =>",
       "category": "hot-path"
     }
   ]


### PR DESCRIPTION
## Summary

Addresses #1662 by removing the main-thread starvation paths used by dashboard liveness and post-ready database maintenance. The one-shot legacy SQLite VACUUM conversion now executes in the killable DB-owner child instead of the daemon event loop.

## Changes

- Move post-ready VACUUM conversion through the DB-owner protocol and maintenance lane.
- Allow maintenance jobs a bounded 15-minute deadline while retaining the 60-second limit for read/write jobs.
- Keep conversion state durable and retryable after owner failure.
- Prevent conversion logging from corrupting the owner's newline-delimited JSON protocol.
- Make `/api/status`, `/health`, and `/api/agents` avoid synchronous request-path database/resource scans.
- Add regressions for the owner-backed conversion, protocol safety, status liveness, resource snapshots, and agent routes.
- Document the new owner protocol operation and its maintenance deadline.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A. This changes daemon routes and database-owner execution; no frontend source was changed.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

The protocol addition is additive and wire-compatible. Existing databases retain the durable conversion state table. If the owner is killed or the conversion fails, the existing retry budget and state machine remain in control; no migration rollback is required.

## Testing

- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused verification passed:

- `bun run --filter '@signet/daemon' build`
- `bunx tsc -p platform/daemon/tsconfig.json --noEmit`
- `bun test platform/daemon/src/db-vacuum.test.ts` (13 passed)
- `bun test platform/daemon/src/resource-monitor.test.ts platform/daemon/src/routes/misc-routes.test.ts` (18 passed)
- #1662 status regression test (1 passed)
- `git diff --check`

`bun run build` was attempted after generating the connector bundles, but the repository build stopped at `@signet/sdk` because `platform/core/node_modules/better-sqlite3` is unavailable in this worktree. The daemon production build passed independently.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The implementation is an incremental slice of the broader DB-owner architecture tracked by #1543. It specifically removes the unbounded VACUUM conversion from the daemon event loop and hardens the lightweight dashboard surfaces; background source-sync legacy write migrations remain follow-up work under the parent architecture.
