### PR TITLE
fix(daemon): share embedding provider circuit breaker

### DIFF
--- a/platform/daemon/src/embedding-circuit-breaker.test.ts
+++ b/platform/daemon/src/embedding-circuit-breaker.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	awaitEmbeddingProviderAvailable,
+	recordEmbeddingProviderFailure,
+	resetEmbeddingCircuitBreakers,
+	shouldEmitEmbeddingProviderNotice,
+} from "./embedding-circuit-breaker";
+
+describe("embedding provider circuit breaker", () => {
+	afterEach(() => resetEmbeddingCircuitBreakers());
+
+	it("single-flights overlapping provider checks", async () => {
+		let calls = 0;
+		let release!: (available: boolean) => void;
+		const check = () => {
+			calls++;
+			return new Promise<boolean>((resolve) => {
+				release = resolve;
+			});
+		};
+		const first = awaitEmbeddingProviderAvailable("native:test", check, 10_000);
+		const second = awaitEmbeddingProviderAvailable("native:test", check, 10_000);
+		release(true);
+		expect(await Promise.all([first, second])).toEqual([{ available: true }, { available: true }]);
+		expect(calls).toBe(1);
+	});
+
+	it("emits one notice per active provider-down window", () => {
+		recordEmbeddingProviderFailure("native:test", 10_000);
+		expect(shouldEmitEmbeddingProviderNotice("native:test", Date.now())).toBe(true);
+		expect(shouldEmitEmbeddingProviderNotice("native:test", Date.now())).toBe(false);
+	});
+});

--- a/platform/daemon/src/embedding-circuit-breaker.test.ts
+++ b/platform/daemon/src/embedding-circuit-breaker.test.ts
@@ -30,4 +30,18 @@ describe("embedding provider circuit breaker", () => {
 		expect(shouldEmitEmbeddingProviderNotice("native:test", Date.now())).toBe(true);
 		expect(shouldEmitEmbeddingProviderNotice("native:test", Date.now())).toBe(false);
 	});
+
+	it("does not let a reset circuit be clobbered by a stale check", async () => {
+		let release!: (available: boolean) => void;
+		const slow = awaitEmbeddingProviderAvailable(
+			"native:stale",
+			() => new Promise<boolean>((resolve) => (release = resolve)),
+			10_000,
+		);
+		resetEmbeddingCircuitBreakers();
+		expect(await awaitEmbeddingProviderAvailable("native:stale", async () => true, 10_000)).toEqual({ available: true });
+		release(false);
+		expect(await slow).toEqual({ available: true });
+		expect(await awaitEmbeddingProviderAvailable("native:stale", async () => true, 10_000)).toEqual({ available: true });
+	});
 });

--- a/platform/daemon/src/embedding-circuit-breaker.test.ts
+++ b/platform/daemon/src/embedding-circuit-breaker.test.ts
@@ -39,9 +39,13 @@ describe("embedding provider circuit breaker", () => {
 			10_000,
 		);
 		resetEmbeddingCircuitBreakers();
-		expect(await awaitEmbeddingProviderAvailable("native:stale", async () => true, 10_000)).toEqual({ available: true });
+		expect(await awaitEmbeddingProviderAvailable("native:stale", async () => true, 10_000)).toEqual({
+			available: true,
+		});
 		release(false);
 		expect(await slow).toEqual({ available: true });
-		expect(await awaitEmbeddingProviderAvailable("native:stale", async () => true, 10_000)).toEqual({ available: true });
+		expect(await awaitEmbeddingProviderAvailable("native:stale", async () => true, 10_000)).toEqual({
+			available: true,
+		});
 	});
 });

--- a/platform/daemon/src/embedding-circuit-breaker.ts
+++ b/platform/daemon/src/embedding-circuit-breaker.ts
@@ -3,8 +3,13 @@ import { computeRetryBackoffMs } from "./embedding-repair-state";
 export const MAX_CONSECUTIVE_PROVIDER_FAILURES = 6;
 export const MAX_PROVIDER_BACKOFF_MS = 60_000;
 
-interface CircuitState { failures: number; retryAt: number; lastNoticeAt: number }
+interface CircuitState {
+	failures: number;
+	retryAt: number;
+	lastNoticeAt: number;
+}
 const circuits = new Map<string, CircuitState>();
+const inFlightChecks = new Map<string, Promise<EmbeddingProviderGateResult>>();
 
 export interface EmbeddingProviderGateResult {
 	readonly available: boolean;
@@ -22,6 +27,22 @@ export async function awaitEmbeddingProviderAvailable(
 	check: () => Promise<boolean>,
 	pollMs: number,
 ): Promise<EmbeddingProviderGateResult> {
+	const inFlight = inFlightChecks.get(key);
+	if (inFlight) return inFlight;
+	const flight = checkEmbeddingProviderAvailable(key, check, pollMs);
+	inFlightChecks.set(key, flight);
+	try {
+		return await flight;
+	} finally {
+		if (inFlightChecks.get(key) === flight) inFlightChecks.delete(key);
+	}
+}
+
+async function checkEmbeddingProviderAvailable(
+	key: string,
+	check: () => Promise<boolean>,
+	pollMs: number,
+): Promise<EmbeddingProviderGateResult> {
 	const state = stateFor(key);
 	const now = Date.now();
 	if (state.retryAt > now) return { available: false, retryAfterMs: state.retryAt - now };
@@ -29,6 +50,7 @@ export async function awaitEmbeddingProviderAvailable(
 	if (available) {
 		state.failures = 0;
 		state.retryAt = 0;
+		state.lastNoticeAt = 0;
 		return { available: true };
 	}
 	state.failures = Math.min(state.failures + 1, MAX_CONSECUTIVE_PROVIDER_FAILURES);
@@ -47,9 +69,12 @@ export function recordEmbeddingProviderFailure(key: string, pollMs: number): num
 
 export function shouldEmitEmbeddingProviderNotice(key: string, now = Date.now()): boolean {
 	const state = stateFor(key);
-	if (state.lastNoticeAt > now) return false;
-	state.lastNoticeAt = state.retryAt;
+	if (state.retryAt <= now || state.lastNoticeAt > 0) return false;
+	state.lastNoticeAt = now;
 	return true;
 }
 
-export function resetEmbeddingCircuitBreakers(): void { circuits.clear(); }
+export function resetEmbeddingCircuitBreakers(): void {
+	circuits.clear();
+	inFlightChecks.clear();
+}

--- a/platform/daemon/src/embedding-circuit-breaker.ts
+++ b/platform/daemon/src/embedding-circuit-breaker.ts
@@ -10,6 +10,7 @@ interface CircuitState {
 }
 const circuits = new Map<string, CircuitState>();
 const inFlightChecks = new Map<string, Promise<EmbeddingProviderGateResult>>();
+let circuitGeneration = 0;
 
 export interface EmbeddingProviderGateResult {
 	readonly available: boolean;
@@ -26,10 +27,11 @@ export async function awaitEmbeddingProviderAvailable(
 	key: string,
 	check: () => Promise<boolean>,
 	pollMs: number,
+	onProviderUnavailable?: () => void,
 ): Promise<EmbeddingProviderGateResult> {
 	const inFlight = inFlightChecks.get(key);
 	if (inFlight) return inFlight;
-	const flight = checkEmbeddingProviderAvailable(key, check, pollMs);
+	const flight = checkEmbeddingProviderAvailable(key, check, pollMs, onProviderUnavailable);
 	inFlightChecks.set(key, flight);
 	try {
 		return await flight;
@@ -42,11 +44,14 @@ async function checkEmbeddingProviderAvailable(
 	key: string,
 	check: () => Promise<boolean>,
 	pollMs: number,
+	onProviderUnavailable?: () => void,
 ): Promise<EmbeddingProviderGateResult> {
+	const generation = circuitGeneration;
 	const state = stateFor(key);
 	const now = Date.now();
 	if (state.retryAt > now) return { available: false, retryAfterMs: state.retryAt - now };
 	const available = await check();
+	if (generation !== circuitGeneration) return { available: true };
 	if (available) {
 		state.failures = 0;
 		state.retryAt = 0;
@@ -56,6 +61,7 @@ async function checkEmbeddingProviderAvailable(
 	state.failures = Math.min(state.failures + 1, MAX_CONSECUTIVE_PROVIDER_FAILURES);
 	const delay = Math.min(computeRetryBackoffMs(state.failures, pollMs), MAX_PROVIDER_BACKOFF_MS);
 	state.retryAt = Date.now() + delay;
+	if (onProviderUnavailable && shouldEmitEmbeddingProviderNotice(key)) onProviderUnavailable();
 	return { available: false, retryAfterMs: delay };
 }
 
@@ -75,6 +81,7 @@ export function shouldEmitEmbeddingProviderNotice(key: string, now = Date.now())
 }
 
 export function resetEmbeddingCircuitBreakers(): void {
+	circuitGeneration += 1;
 	circuits.clear();
 	inFlightChecks.clear();
 }

--- a/platform/daemon/src/embedding-circuit-breaker.ts
+++ b/platform/daemon/src/embedding-circuit-breaker.ts
@@ -1,0 +1,55 @@
+import { computeRetryBackoffMs } from "./embedding-repair-state";
+
+export const MAX_CONSECUTIVE_PROVIDER_FAILURES = 6;
+export const MAX_PROVIDER_BACKOFF_MS = 60_000;
+
+interface CircuitState { failures: number; retryAt: number; lastNoticeAt: number }
+const circuits = new Map<string, CircuitState>();
+
+export interface EmbeddingProviderGateResult {
+	readonly available: boolean;
+	readonly retryAfterMs?: number;
+}
+
+function stateFor(key: string): CircuitState {
+	const state = circuits.get(key) ?? { failures: 0, retryAt: 0, lastNoticeAt: 0 };
+	circuits.set(key, state);
+	return state;
+}
+
+export async function awaitEmbeddingProviderAvailable(
+	key: string,
+	check: () => Promise<boolean>,
+	pollMs: number,
+): Promise<EmbeddingProviderGateResult> {
+	const state = stateFor(key);
+	const now = Date.now();
+	if (state.retryAt > now) return { available: false, retryAfterMs: state.retryAt - now };
+	const available = await check();
+	if (available) {
+		state.failures = 0;
+		state.retryAt = 0;
+		return { available: true };
+	}
+	state.failures = Math.min(state.failures + 1, MAX_CONSECUTIVE_PROVIDER_FAILURES);
+	const delay = Math.min(computeRetryBackoffMs(state.failures, pollMs), MAX_PROVIDER_BACKOFF_MS);
+	state.retryAt = Date.now() + delay;
+	return { available: false, retryAfterMs: delay };
+}
+
+export function recordEmbeddingProviderFailure(key: string, pollMs: number): number {
+	const state = stateFor(key);
+	state.failures = Math.min(state.failures + 1, MAX_CONSECUTIVE_PROVIDER_FAILURES);
+	const delay = Math.min(computeRetryBackoffMs(state.failures, pollMs), MAX_PROVIDER_BACKOFF_MS);
+	state.retryAt = Date.now() + delay;
+	return delay;
+}
+
+export function shouldEmitEmbeddingProviderNotice(key: string, now = Date.now()): boolean {
+	const state = stateFor(key);
+	if (state.lastNoticeAt > now) return false;
+	state.lastNoticeAt = state.retryAt;
+	return true;
+}
+
+export function resetEmbeddingCircuitBreakers(): void { circuits.clear(); }

--- a/platform/daemon/src/embedding-circuit-breaker.ts
+++ b/platform/daemon/src/embedding-circuit-breaker.ts
@@ -25,7 +25,7 @@ function stateFor(key: string): CircuitState {
 
 export async function awaitEmbeddingProviderAvailable(
 	key: string,
-	check: () => Promise<boolean>,
+	check: (() => Promise<boolean>) | undefined,
 	pollMs: number,
 	onProviderUnavailable?: () => void,
 ): Promise<EmbeddingProviderGateResult> {
@@ -42,7 +42,7 @@ export async function awaitEmbeddingProviderAvailable(
 
 async function checkEmbeddingProviderAvailable(
 	key: string,
-	check: () => Promise<boolean>,
+	check: (() => Promise<boolean>) | undefined,
 	pollMs: number,
 	onProviderUnavailable?: () => void,
 ): Promise<EmbeddingProviderGateResult> {
@@ -50,7 +50,7 @@ async function checkEmbeddingProviderAvailable(
 	const state = stateFor(key);
 	const now = Date.now();
 	if (state.retryAt > now) return { available: false, retryAfterMs: state.retryAt - now };
-	const available = await check();
+	const available = check ? await check() : state.retryAt <= Date.now();
 	if (generation !== circuitGeneration) return { available: true };
 	if (available) {
 		state.failures = 0;

--- a/platform/daemon/src/embedding-index-migration.ts
+++ b/platform/daemon/src/embedding-index-migration.ts
@@ -21,6 +21,7 @@ import { embeddingProfileFingerprint, recommendedEmbeddingProfileId, type Embedd
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
 import type { PipelineCauseFamily } from "./pipeline-operation";
+import { awaitEmbeddingProviderAvailable } from "./embedding-circuit-breaker";
 
 const STAGING_VECTOR_TABLE = "vec_embeddings_staging";
 const ACTIVE_VECTOR_TABLE = "vec_embeddings";
@@ -1205,7 +1206,13 @@ export async function startEmbeddingIndexMigration(input: {
 				return;
 			}
 			const providerCfg = configForProfile(state.staging, configured);
-			if (!(await input.checkProvider(providerCfg)).available) {
+			const providerKey = `${providerCfg.provider}:${providerCfg.model}:${providerCfg.base_url ?? ""}`;
+			const gate = await awaitEmbeddingProviderAvailable(
+				providerKey,
+				async () => (await input.checkProvider(providerCfg)).available,
+				input.pollMs,
+			);
+			if (!gate.available) {
 				consecutiveFailures++;
 				failed++;
 				if (consecutiveFailures >= MAX_CONSECUTIVE_PROVIDER_FAILURES) {

--- a/platform/daemon/src/embedding-index-migration.ts
+++ b/platform/daemon/src/embedding-index-migration.ts
@@ -1211,6 +1211,7 @@ export async function startEmbeddingIndexMigration(input: {
 				providerKey,
 				async () => (await input.checkProvider(providerCfg)).available,
 				input.pollMs,
+				() => logger.warn("embedding", "Embedding provider unavailable; retrying index migration"),
 			);
 			if (!gate.available) {
 				consecutiveFailures++;

--- a/platform/daemon/src/embedding-tracker.ts
+++ b/platform/daemon/src/embedding-tracker.ts
@@ -21,6 +21,7 @@ import {
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
 import { isSystemPressureHigh } from "./system-pressure";
+import { awaitEmbeddingProviderAvailable } from "./embedding-circuit-breaker";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -180,8 +181,12 @@ export function startEmbeddingTracker(
 
 		try {
 			// 1. Check provider health (uses existing 30s cache)
-			const health = await checkProviderFn(embeddingCfg);
-			if (!health.available) {
+			const gate = await awaitEmbeddingProviderAvailable(
+				`${embeddingCfg.provider}:${embeddingCfg.model}:${embeddingCfg.base_url ?? ""}`,
+				async () => (await checkProviderFn(embeddingCfg)).available,
+				trackerCfg.pollMs,
+			);
+			if (!gate.available) {
 				skippedCycles++;
 				return;
 			}

--- a/platform/daemon/src/embedding-tracker.ts
+++ b/platform/daemon/src/embedding-tracker.ts
@@ -185,6 +185,7 @@ export function startEmbeddingTracker(
 				`${embeddingCfg.provider}:${embeddingCfg.model}:${embeddingCfg.base_url ?? ""}`,
 				async () => (await checkProviderFn(embeddingCfg)).available,
 				trackerCfg.pollMs,
+				() => logger.warn("embedding", "Embedding provider unavailable; retrying tracker cycle"),
 			);
 			if (!gate.available) {
 				skippedCycles++;

--- a/platform/daemon/src/memory-lineage.test.ts
+++ b/platform/daemon/src/memory-lineage.test.ts
@@ -18,6 +18,7 @@ import {
 } from "./memory-lineage";
 import { NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID } from "./native-memory-constants";
 import { cleanupTestTempDir, createTestTempDir } from "./test-temp-dir";
+import { recordEmbeddingProviderFailure, resetEmbeddingCircuitBreakers } from "./embedding-circuit-breaker";
 
 const tok = new Tiktoken(cl100k_base);
 
@@ -68,6 +69,7 @@ describe("memory-lineage", () => {
 
 	beforeEach(async () => {
 		await resetWorkspace();
+		resetEmbeddingCircuitBreakers();
 	});
 
 	afterAll(() => {
@@ -363,6 +365,24 @@ describe("memory-lineage", () => {
 	});
 
 	describe("reindexMemoryArtifacts incremental", () => {
+		it("halts a small scan before accumulating or flushing when the shared provider circuit is already open", async () => {
+			await addSummary({ sessionId: "seed-open", project: "/home/nicholai/signet/signetai", minutesAgo: 1 });
+			getDbAccessor().withWriteTx((db) => {
+				db.prepare("DELETE FROM memory_artifacts WHERE agent_id = ?").run("default");
+			});
+			recordEmbeddingProviderFailure("native:nomic-embed-text-v1.5:", 10_000);
+
+			await reindexMemoryArtifacts("default");
+
+			const count = getDbAccessor().withReadDb(
+				(db) =>
+					db.prepare("SELECT COUNT(*) AS count FROM memory_artifacts WHERE agent_id = ?").get("default") as {
+						count: number;
+					},
+			);
+			expect(count.count).toBe(0);
+		});
+
 		it("first boot: empty cache + empty DB → full scan", async () => {
 			await addSummary({ sessionId: "scan-a", project: "/home/nicholai/signet/signetai", minutesAgo: 1 });
 			await addSummary({ sessionId: "scan-b", project: "/home/nicholai/signet/signetai", minutesAgo: 2 });

--- a/platform/daemon/src/memory-lineage.ts
+++ b/platform/daemon/src/memory-lineage.ts
@@ -923,6 +923,14 @@ export async function reindexMemoryArtifacts(agentId?: string): Promise<void> {
 
 async function doReindex(agentId?: string): Promise<void> {
 	const scope = agentId?.trim() || null;
+	let breakerOpen = false;
+	const embedding = loadMemoryConfig(getAgentsDir()).embedding;
+	const providerKey = `${embedding.provider}:${embedding.model}:${embedding.base_url ?? ""}`;
+	const initialGate = await awaitEmbeddingProviderAvailable(providerKey, undefined, 1000);
+	if (!initialGate.available) {
+		breakerOpen = true;
+		return;
+	}
 	const files = await listCanonicalFiles();
 	const t0 = performance.now();
 	const stopTimer = logger.time("resources", "reindexMemoryArtifacts");
@@ -1076,11 +1084,8 @@ async function doReindex(agentId?: string): Promise<void> {
 	}
 
 	const fileSet = new Set(files);
-	const embedding = loadMemoryConfig(getAgentsDir()).embedding;
-	const providerKey = `${embedding.provider}:${embedding.model}:${embedding.base_url ?? ""}`;
 	const baseYielder = yieldEvery(REINDEX_BATCH_SIZE);
 	let itemsSinceYield = 0;
-	let breakerOpen = false;
 	const yielder = async (): Promise<void> => {
 		itemsSinceYield += 1;
 		if (itemsSinceYield < REINDEX_BATCH_SIZE) return;

--- a/platform/daemon/src/memory-lineage.ts
+++ b/platform/daemon/src/memory-lineage.ts
@@ -31,6 +31,7 @@ import { buildAgentScopeClause } from "./memory-search";
 import { NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID } from "./native-memory-constants";
 import { isNoiseSession, isTempProject } from "./session-noise";
 import { canonicalTranscriptRelativePath } from "./transcript-jsonl";
+import { awaitPressureClear, isSystemPressureHigh } from "./system-pressure";
 
 function getAgentsDir(): string {
 	return resolveDefaultBasePath();
@@ -1073,7 +1074,15 @@ async function doReindex(agentId?: string): Promise<void> {
 	}
 
 	const fileSet = new Set(files);
-	const yielder = yieldEvery(REINDEX_BATCH_SIZE);
+	const baseYielder = yieldEvery(REINDEX_BATCH_SIZE);
+	let itemsSinceYield = 0;
+	const yielder = async (): Promise<void> => {
+		itemsSinceYield += 1;
+		if (itemsSinceYield < REINDEX_BATCH_SIZE) return;
+		itemsSinceYield = 0;
+		if (isSystemPressureHigh()) await awaitPressureClear();
+		await baseYielder();
+	};
 	for (const path of files) {
 		let statKey: string;
 		let mtime: number;

--- a/platform/daemon/src/memory-lineage.ts
+++ b/platform/daemon/src/memory-lineage.ts
@@ -32,6 +32,8 @@ import { NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID } from "./native-memory-constants";
 import { isNoiseSession, isTempProject } from "./session-noise";
 import { canonicalTranscriptRelativePath } from "./transcript-jsonl";
 import { awaitPressureClear, isSystemPressureHigh } from "./system-pressure";
+import { awaitEmbeddingProviderAvailable } from "./embedding-circuit-breaker";
+import { loadMemoryConfig } from "./memory-config";
 
 function getAgentsDir(): string {
 	return resolveDefaultBasePath();
@@ -1076,14 +1078,20 @@ async function doReindex(agentId?: string): Promise<void> {
 	const fileSet = new Set(files);
 	const baseYielder = yieldEvery(REINDEX_BATCH_SIZE);
 	let itemsSinceYield = 0;
+	let breakerOpen = false;
+	const embedding = loadMemoryConfig(getAgentsDir()).embedding;
+	const providerKey = `${embedding.provider}:${embedding.model}:${embedding.base_url ?? ""}`;
 	const yielder = async (): Promise<void> => {
 		itemsSinceYield += 1;
 		if (itemsSinceYield < REINDEX_BATCH_SIZE) return;
 		itemsSinceYield = 0;
 		if (isSystemPressureHigh()) await awaitPressureClear();
+		const gate = await awaitEmbeddingProviderAvailable(providerKey, async () => true, 10_000);
+		if (!gate.available) breakerOpen = true;
 		await baseYielder();
 	};
 	for (const path of files) {
+		if (breakerOpen) break;
 		let statKey: string;
 		let mtime: number;
 		try {

--- a/platform/daemon/src/memory-lineage.ts
+++ b/platform/daemon/src/memory-lineage.ts
@@ -32,7 +32,7 @@ import { NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID } from "./native-memory-constants";
 import { isNoiseSession, isTempProject } from "./session-noise";
 import { canonicalTranscriptRelativePath } from "./transcript-jsonl";
 import { awaitPressureClear, isSystemPressureHigh } from "./system-pressure";
-import { awaitEmbeddingProviderAvailable } from "./embedding-circuit-breaker";
+
 import { loadMemoryConfig } from "./memory-config";
 
 function getAgentsDir(): string {
@@ -1078,20 +1078,14 @@ async function doReindex(agentId?: string): Promise<void> {
 	const fileSet = new Set(files);
 	const baseYielder = yieldEvery(REINDEX_BATCH_SIZE);
 	let itemsSinceYield = 0;
-	let breakerOpen = false;
-	const embedding = loadMemoryConfig(getAgentsDir()).embedding;
-	const providerKey = `${embedding.provider}:${embedding.model}:${embedding.base_url ?? ""}`;
 	const yielder = async (): Promise<void> => {
 		itemsSinceYield += 1;
 		if (itemsSinceYield < REINDEX_BATCH_SIZE) return;
 		itemsSinceYield = 0;
 		if (isSystemPressureHigh()) await awaitPressureClear();
-		const gate = await awaitEmbeddingProviderAvailable(providerKey, async () => true, 10_000);
-		if (!gate.available) breakerOpen = true;
 		await baseYielder();
 	};
 	for (const path of files) {
-		if (breakerOpen) break;
 		let statKey: string;
 		let mtime: number;
 		try {

--- a/platform/daemon/src/memory-lineage.ts
+++ b/platform/daemon/src/memory-lineage.ts
@@ -32,8 +32,8 @@ import { NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID } from "./native-memory-constants";
 import { isNoiseSession, isTempProject } from "./session-noise";
 import { canonicalTranscriptRelativePath } from "./transcript-jsonl";
 import { awaitPressureClear, isSystemPressureHigh } from "./system-pressure";
-
 import { loadMemoryConfig } from "./memory-config";
+import { awaitEmbeddingProviderAvailable } from "./embedding-circuit-breaker";
 
 function getAgentsDir(): string {
 	return resolveDefaultBasePath();
@@ -1076,16 +1076,22 @@ async function doReindex(agentId?: string): Promise<void> {
 	}
 
 	const fileSet = new Set(files);
+	const embedding = loadMemoryConfig(getAgentsDir()).embedding;
+	const providerKey = `${embedding.provider}:${embedding.model}:${embedding.base_url ?? ""}`;
 	const baseYielder = yieldEvery(REINDEX_BATCH_SIZE);
 	let itemsSinceYield = 0;
+	let breakerOpen = false;
 	const yielder = async (): Promise<void> => {
 		itemsSinceYield += 1;
 		if (itemsSinceYield < REINDEX_BATCH_SIZE) return;
 		itemsSinceYield = 0;
 		if (isSystemPressureHigh()) await awaitPressureClear();
+		const gate = await awaitEmbeddingProviderAvailable(providerKey, undefined, 1000);
+		breakerOpen = !gate.available;
 		await baseYielder();
 	};
 	for (const path of files) {
+		if (breakerOpen) break;
 		let statKey: string;
 		let mtime: number;
 		try {
@@ -1136,8 +1142,9 @@ async function doReindex(agentId?: string): Promise<void> {
 			continue;
 		}
 		pendingUpserts.push({ path, frontmatter: parsed.frontmatter, body, mtime, statKey, markChanged: true });
-		if (pendingUpserts.length >= REINDEX_BATCH_SIZE && (await flushUpsertBatch())) {
+		if (pendingUpserts.length >= REINDEX_BATCH_SIZE) {
 			await yielder();
+			if (!breakerOpen) await flushUpsertBatch();
 		}
 	}
 
@@ -1150,7 +1157,7 @@ async function doReindex(agentId?: string): Promise<void> {
 		}
 	}
 
-	if (await flushUpsertBatch()) {
+	if (!breakerOpen && (await flushUpsertBatch())) {
 		await yielder();
 	}
 	if (await flushDeleteBatch()) {
@@ -1934,7 +1941,7 @@ async function buildLedger(agentId: string): Promise<ReadonlyArray<LedgerSession
 		const stamp = Date.parse(membershipTs(group));
 		if (!Number.isFinite(stamp) || stamp < floor || stamp > now) continue;
 		const picked = chooseSentence(group);
-		if (!picked || !picked.memory_sentence) continue;
+		if (!picked?.memory_sentence) continue;
 		if (
 			isNoiseSession({
 				project: sessionProject(group),

--- a/platform/daemon/src/obsidian-source-embeddings.test.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, getVectorRuntimeStatus, initDbAccessor } from "./db-accessor";
 import { type EmbeddingConfig, loadMemoryConfig } from "./memory-config";
 import { hybridRecall } from "./memory-search";
-import { resetEmbeddingCircuitBreakers } from "./embedding-circuit-breaker";
+import { awaitEmbeddingProviderAvailable, resetEmbeddingCircuitBreakers } from "./embedding-circuit-breaker";
 import {
 	buildObsidianSourceChunks,
 	indexObsidianSourceEmbeddings,
@@ -178,6 +178,8 @@ describe("Obsidian source embeddings", () => {
 		});
 
 		expect(first.providerUnavailable).toBe(true);
+		const sharedCircuit = await awaitEmbeddingProviderAvailable("native:nomic-embed-text-v1.5:", undefined, 1000);
+		expect(sharedCircuit.available).toBe(false);
 		expect(first.status).toBe("embeddings pending - provider down");
 		expect(first.skipped).toBe(first.chunks);
 		expect(second.providerUnavailable).toBe(true);

--- a/platform/daemon/src/obsidian-source-embeddings.test.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, getVectorRuntimeStatus, initDbAccessor } from "./db-accessor";
 import { type EmbeddingConfig, loadMemoryConfig } from "./memory-config";
 import { hybridRecall } from "./memory-search";
+import { resetEmbeddingCircuitBreakers } from "./embedding-circuit-breaker";
 import {
 	buildObsidianSourceChunks,
 	indexObsidianSourceEmbeddings,
@@ -43,6 +44,7 @@ describe("Obsidian source embeddings", () => {
 	});
 
 	afterEach(() => {
+		resetEmbeddingCircuitBreakers();
 		closeDbAccessor();
 		if (prevSignetPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
 		else process.env.SIGNET_PATH = prevSignetPath;

--- a/platform/daemon/src/obsidian-source-embeddings.test.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.test.ts
@@ -6,6 +6,7 @@ import { closeDbAccessor, getDbAccessor, getVectorRuntimeStatus, initDbAccessor 
 import { type EmbeddingConfig, loadMemoryConfig } from "./memory-config";
 import { hybridRecall } from "./memory-search";
 import { awaitEmbeddingProviderAvailable, resetEmbeddingCircuitBreakers } from "./embedding-circuit-breaker";
+import { logger } from "./logger";
 import {
 	buildObsidianSourceChunks,
 	indexObsidianSourceEmbeddings,
@@ -185,6 +186,34 @@ describe("Obsidian source embeddings", () => {
 		expect(second.providerUnavailable).toBe(true);
 		expect(second.status).toBe("embeddings pending - provider down");
 		expect(fetches).toBe(1);
+	});
+
+	it("emits one consolidated notice while sweeping many provider-failing files", async () => {
+		const notices: string[] = [];
+		const originalWarn = logger.warn;
+		logger.warn = ((_category: unknown, message: unknown) => {
+			if (String(message).includes("Embedding provider unavailable")) notices.push(String(message));
+		}) as typeof logger.warn;
+		try {
+			const fetchEmbedding: SourceEmbeddingFetch = async (_text, _cfg, _role, opts) => {
+				opts?.onFailure?.("provider_unavailable");
+				return null;
+			};
+			for (let index = 0; index < 5; index++) {
+				await indexObsidianSourceEmbeddings({
+					agentId: "obsidian-embedding-agent",
+					sourceId: "obsidian:test-vault",
+					root: vault,
+					filePath: join(vault, "literature", `provider-down-${index}.md`),
+					content: `# Provider Down ${index}\n\nThis source note is representative of a failing many-file provider sweep.`,
+					embeddingConfig,
+					fetchEmbedding,
+				});
+			}
+			expect(notices).toHaveLength(1);
+		} finally {
+			logger.warn = originalWarn;
+		}
 	});
 
 	it("removes legacy Obsidian chunk rows once generic chunks are refreshed", async () => {

--- a/platform/daemon/src/obsidian-source-embeddings.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.ts
@@ -18,7 +18,11 @@ import { dbOwnerBatch, dbOwnerQuery, ownerStatement } from "./db-owner-runtime";
 import type { EmbeddingRole } from "./embedding-profile";
 import type { EmbeddingConfig } from "./memory-config";
 import { upsertMemoryContentSafetyInTx } from "./memory-content-safety";
-import { awaitEmbeddingProviderAvailable, recordEmbeddingProviderFailure } from "./embedding-circuit-breaker";
+import {
+	awaitEmbeddingProviderAvailable,
+	recordEmbeddingProviderFailure,
+	shouldEmitEmbeddingProviderNotice,
+} from "./embedding-circuit-breaker";
 import { logger } from "./logger";
 
 export const OBSIDIAN_CHUNK_SOURCE_TYPE = SOURCE_CHUNK_SOURCE_TYPE;
@@ -352,6 +356,8 @@ export async function indexObsidianSourceEmbeddingsViaOwner(
 		if (!vector || vector.length === 0) {
 			if (providerUnavailableCause(failureCause)) {
 				recordEmbeddingProviderFailure(providerKey, SOURCE_EMBEDDING_POLL_MS);
+				if (shouldEmitEmbeddingProviderNotice(providerKey))
+					logger.warn("embedding", `Embedding provider unavailable; retrying source indexing (${providerKey})`);
 				const attempts = (failureState?.attempts ?? 0) + 1;
 				retryAfterMs = computeRetryBackoffMs(attempts, SOURCE_EMBEDDING_POLL_MS);
 				sourceEmbeddingFailures.set(failureKey, { attempts, retryAt: Date.now() + retryAfterMs });
@@ -575,7 +581,6 @@ export async function indexObsidianSourceEmbeddings(
 	if (embeddingConfig.provider === "none") return { chunks: 0, embedded: 0, skipped: 0, providerUnavailable: false };
 	const chunks = buildObsidianSourceChunks(input);
 	const failureKey = sourceEmbeddingFailureKey(input, embeddingConfig.model);
-	const providerKey = `${embeddingConfig.provider}:${embeddingConfig.model}:${embeddingConfig.base_url ?? ""}`;
 	const failureState = sourceEmbeddingFailures.get(failureKey);
 	if (failureState && failureState.retryAt > Date.now()) {
 		return {
@@ -633,6 +638,8 @@ export async function indexObsidianSourceEmbeddings(
 			if (providerUnavailableCause(failureCause)) {
 				const activeProviderKey = `${writeConfig.provider}:${writeConfig.model}:${writeConfig.base_url ?? ""}`;
 				recordEmbeddingProviderFailure(activeProviderKey, SOURCE_EMBEDDING_POLL_MS);
+				if (shouldEmitEmbeddingProviderNotice(activeProviderKey))
+					logger.warn("embedding", `Embedding provider unavailable; retrying source indexing (${activeProviderKey})`);
 				const attempts = (failureState?.attempts ?? 0) + 1;
 				retryAfterMs = computeRetryBackoffMs(attempts, SOURCE_EMBEDDING_POLL_MS);
 				sourceEmbeddingFailures.set(failureKey, { attempts, retryAt: Date.now() + retryAfterMs });

--- a/platform/daemon/src/obsidian-source-embeddings.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.ts
@@ -278,7 +278,14 @@ export async function indexObsidianSourceEmbeddingsViaOwner(
 	const providerKey = `${configured.provider}:${configured.model}:${configured.base_url ?? ""}`;
 	const gate = await awaitEmbeddingProviderAvailable(providerKey, async () => true, SOURCE_EMBEDDING_POLL_MS);
 	if (!gate.available)
-		return { chunks: chunks.length, embedded: 0, skipped: chunks.length, status: EMBEDDINGS_PENDING_PROVIDER_DOWN, providerUnavailable: true, retryAfterMs: gate.retryAfterMs };
+		return {
+			chunks: chunks.length,
+			embedded: 0,
+			skipped: chunks.length,
+			status: EMBEDDINGS_PENDING_PROVIDER_DOWN,
+			providerUnavailable: true,
+			retryAfterMs: gate.retryAfterMs,
+		};
 	const failureState = sourceEmbeddingFailures.get(failureKey);
 	if (failureState && failureState.retryAt > Date.now())
 		return {
@@ -329,6 +336,7 @@ export async function indexObsidianSourceEmbeddingsViaOwner(
 		});
 		if (!vector || vector.length === 0) {
 			if (providerUnavailableCause(failureCause)) {
+				recordEmbeddingProviderFailure(providerKey, SOURCE_EMBEDDING_POLL_MS);
 				const attempts = (failureState?.attempts ?? 0) + 1;
 				retryAfterMs = computeRetryBackoffMs(attempts, SOURCE_EMBEDDING_POLL_MS);
 				sourceEmbeddingFailures.set(failureKey, { attempts, retryAt: Date.now() + retryAfterMs });

--- a/platform/daemon/src/obsidian-source-embeddings.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.ts
@@ -18,6 +18,7 @@ import { dbOwnerBatch, dbOwnerQuery, ownerStatement } from "./db-owner-runtime";
 import type { EmbeddingRole } from "./embedding-profile";
 import type { EmbeddingConfig } from "./memory-config";
 import { upsertMemoryContentSafetyInTx } from "./memory-content-safety";
+import { awaitEmbeddingProviderAvailable, recordEmbeddingProviderFailure } from "./embedding-circuit-breaker";
 
 export const OBSIDIAN_CHUNK_SOURCE_TYPE = SOURCE_CHUNK_SOURCE_TYPE;
 const OBSIDIAN_SOURCE_CHUNK_DELAY_MS = 100;
@@ -274,6 +275,10 @@ export async function indexObsidianSourceEmbeddingsViaOwner(
 	const configured = await ownerEmbeddingConfig(input.embeddingConfig);
 	if (configured.provider === "none") return { chunks: 0, embedded: 0, skipped: 0, providerUnavailable: false };
 	const failureKey = sourceEmbeddingFailureKey(input, configured.model);
+	const providerKey = `${configured.provider}:${configured.model}:${configured.base_url ?? ""}`;
+	const gate = await awaitEmbeddingProviderAvailable(providerKey, async () => true, SOURCE_EMBEDDING_POLL_MS);
+	if (!gate.available)
+		return { chunks: chunks.length, embedded: 0, skipped: chunks.length, status: EMBEDDINGS_PENDING_PROVIDER_DOWN, providerUnavailable: true, retryAfterMs: gate.retryAfterMs };
 	const failureState = sourceEmbeddingFailures.get(failureKey);
 	if (failureState && failureState.retryAt > Date.now())
 		return {

--- a/platform/daemon/src/obsidian-source-embeddings.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.ts
@@ -19,6 +19,7 @@ import type { EmbeddingRole } from "./embedding-profile";
 import type { EmbeddingConfig } from "./memory-config";
 import { upsertMemoryContentSafetyInTx } from "./memory-content-safety";
 import { awaitEmbeddingProviderAvailable, recordEmbeddingProviderFailure } from "./embedding-circuit-breaker";
+import { logger } from "./logger";
 
 export const OBSIDIAN_CHUNK_SOURCE_TYPE = SOURCE_CHUNK_SOURCE_TYPE;
 const OBSIDIAN_SOURCE_CHUNK_DELAY_MS = 100;
@@ -276,7 +277,21 @@ export async function indexObsidianSourceEmbeddingsViaOwner(
 	if (configured.provider === "none") return { chunks: 0, embedded: 0, skipped: 0, providerUnavailable: false };
 	const failureKey = sourceEmbeddingFailureKey(input, configured.model);
 	const providerKey = `${configured.provider}:${configured.model}:${configured.base_url ?? ""}`;
-	const gate = await awaitEmbeddingProviderAvailable(providerKey, async () => true, SOURCE_EMBEDDING_POLL_MS);
+	let probeCause: PipelineCauseFamily = "provider_unavailable";
+	const gate = await awaitEmbeddingProviderAvailable(
+		providerKey,
+		async () => {
+			const probe = await input.fetchEmbedding("", configured, "document", {
+				usage: { source: "artifact-index", agentId: input.agentId },
+				onFailure: (cause) => {
+					probeCause = cause;
+				},
+			});
+			return Boolean(probe?.length) && !providerUnavailableCause(probeCause);
+		},
+		SOURCE_EMBEDDING_POLL_MS,
+		() => logger.warn("embedding", `Embedding provider unavailable; retrying source indexing (${providerKey})`),
+	);
 	if (!gate.available)
 		return {
 			chunks: chunks.length,
@@ -560,6 +575,7 @@ export async function indexObsidianSourceEmbeddings(
 	if (embeddingConfig.provider === "none") return { chunks: 0, embedded: 0, skipped: 0, providerUnavailable: false };
 	const chunks = buildObsidianSourceChunks(input);
 	const failureKey = sourceEmbeddingFailureKey(input, embeddingConfig.model);
+	const providerKey = `${embeddingConfig.provider}:${embeddingConfig.model}:${embeddingConfig.base_url ?? ""}`;
 	const failureState = sourceEmbeddingFailures.get(failureKey);
 	if (failureState && failureState.retryAt > Date.now()) {
 		return {
@@ -615,6 +631,8 @@ export async function indexObsidianSourceEmbeddings(
 		});
 		if (!vector || vector.length === 0) {
 			if (providerUnavailableCause(failureCause)) {
+				const activeProviderKey = `${writeConfig.provider}:${writeConfig.model}:${writeConfig.base_url ?? ""}`;
+				recordEmbeddingProviderFailure(activeProviderKey, SOURCE_EMBEDDING_POLL_MS);
 				const attempts = (failureState?.attempts ?? 0) + 1;
 				retryAfterMs = computeRetryBackoffMs(attempts, SOURCE_EMBEDDING_POLL_MS);
 				sourceEmbeddingFailures.set(failureKey, { attempts, retryAt: Date.now() + retryAfterMs });


### PR DESCRIPTION
## Summary

Fixes #1665. A provider outage previously caused independent embedding consumers to keep issuing calls, creating per-file error bursts and starving the event loop.

## Changes

- Add a process-shared embedding circuit breaker using the existing retry-backoff policy and migration limits.
- Gate embedding index migration and embedding tracker provider checks through the shared breaker.
- Gate native Obsidian source embedding work and preserve the pending state while the provider is unavailable.
- Make memory-artifact reindexing honor system pressure between batches.
- Keep the API small and compatible with the #1664 durable failed-state lane.

## Testing

- `git diff --check` passed.
- Daemon TypeScript diagnostics for changed files passed; repository typecheck still reports pre-existing missing `@signet/lifecycle-proof` and dashboard type errors.
- Focused migration and memory-lineage tests were run; the suite exposed unrelated existing fixture/process-pressure failures and did not pass cleanly.

## AI disclosure

Implementation assisted by AI.
