### PR TITLE
fix(daemon): isolate database initialization from event loop

### DIFF
--- a/platform/daemon/src/daemon-status.test.ts
+++ b/platform/daemon/src/daemon-status.test.ts
@@ -709,5 +709,5 @@ describe.skip("structural worker retirement under Dreaming (#946) [retired confi
 		} finally {
 			await second.close();
 		}
-	});
+	}, 15000);
 });

--- a/platform/daemon/src/daemon-status.test.ts
+++ b/platform/daemon/src/daemon-status.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Hono } from "hono";
 import { cleanupTestTempDir, createTestTempDir } from "./test-temp-dir";
+import { createDbOwnerClient } from "./db-owner-client";
 
 let app: Hono;
 let dir = "";
@@ -645,5 +646,60 @@ describe.skip("structural worker retirement under Dreaming (#946) [retired confi
 		// The retired worker's exclusive side-effect (markSynthesized) must
 		// never fire — proving no dependency-synthesis tick ran.
 		expect(synthesized.last_synthesized_at).toBeNull();
+	});
+
+	it("keeps the real HTTP surface responsive during owner initialization", async () => {
+		const dbPath = join(dir, "memory", "memories.db");
+		const owner = createDbOwnerClient({ dbPath });
+		try {
+			await owner.start();
+			const initialization = owner.submit(
+				{ kind: "initialize", agentsDir: dir },
+				{ operation: "db.initialize.liveness-regression", lane: "maintenance", deadlineMs: 60_000 },
+			);
+			const started = performance.now();
+			const responses = await Promise.all([
+				app.request("http://localhost/health/live"),
+				app.request("http://localhost/api/status"),
+			]);
+			const elapsed = performance.now() - started;
+			expect(responses[0]?.status).toBe(200);
+			expect(responses[1]?.status).toBe(200);
+			expect(elapsed).toBeLessThan(500);
+			await owner.awaitResult(initialization, 60_000);
+		} finally {
+			await owner.close();
+		}
+	});
+
+	it("can safely re-enter initialization after an owner dies", async () => {
+		const dbPath = join(dir, "memory", "memories.db");
+		const first = createDbOwnerClient({ dbPath });
+		await first.start();
+		const pid = first.health().pid;
+		if (pid === null) throw new Error("owner did not publish a pid");
+		const pending = first.submit(
+			{ kind: "initialize", agentsDir: dir },
+			{ operation: "db.initialize.kill-reentry", lane: "maintenance", deadlineMs: 5_000 },
+		);
+		process.kill(pid, "SIGKILL");
+		await expect(pending.result).rejects.toBeDefined();
+		await first.close();
+
+		const second = createDbOwnerClient({ dbPath });
+		try {
+			await second.start();
+			await second.submit(
+				{ kind: "initialize", agentsDir: dir },
+				{ operation: "db.initialize.reentry", lane: "maintenance", deadlineMs: 60_000 },
+			).result;
+			const integrity = await second.submit<{ integrity_check: string }[]>(
+				{ kind: "query", statement: { sql: "PRAGMA integrity_check", result: "all" } },
+				{ operation: "db.initialize.integrity-after-reentry", lane: "read", deadlineMs: 5_000 },
+			).result;
+			expect(integrity).toEqual([{ integrity_check: "ok" }]);
+		} finally {
+			await second.close();
+		}
 	});
 });

--- a/platform/daemon/src/daemon-status.test.ts
+++ b/platform/daemon/src/daemon-status.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Hono } from "hono";
 import { cleanupTestTempDir, createTestTempDir } from "./test-temp-dir";
@@ -11,6 +11,12 @@ let prev: string | undefined;
 let countConnectorsActive: (connectors: readonly { readonly status: string }[]) => number;
 const originalSpawn = Bun.spawn;
 const originalWhich = Bun.which;
+
+async function waitForMarker(path: string): Promise<void> {
+	const deadline = Date.now() + 5_000;
+	while (!existsSync(path) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 5));
+	expect(existsSync(path)).toBe(true);
+}
 
 describe("daemon status contract", () => {
 	beforeAll(async () => {
@@ -230,11 +236,6 @@ describe("daemon status contract", () => {
 				`memory:
   pipelineV2:
     enabled: true
-    extraction:
-      provider: ollama
-      model: qwen3:4b
-    synthesis:
-      enabled: false
 `,
 			);
 			expect(state.restartPipelineRuntimeRef).toBeDefined();
@@ -276,9 +277,6 @@ describe("daemon status contract", () => {
 			`memory:
   pipelineV2:
     enabled: true
-    extraction:
-      provider: ollama
-      model: qwen3:4b
     worker:
       maxLlmConcurrency: 1
 `,
@@ -325,9 +323,6 @@ describe.skip("legacy extraction cutover sweep (#946) [retired config fixtures p
 	const DREAMING_ENABLED_CONFIG = `memory:
   pipelineV2:
     enabled: true
-    extraction:
-      provider: ollama
-      model: qwen3:4b
 `;
 
 	function writeConfig(cfg: string): void {
@@ -475,9 +470,6 @@ describe.skip("structural worker retirement under Dreaming (#946) [retired confi
 	const DREAMING_ENABLED_STRUCTURAL_CONFIG = `memory:
   pipelineV2:
     enabled: true
-    extraction:
-      provider: ollama
-      model: qwen3:4b
     graph:
       enabled: true
     structural:
@@ -650,13 +642,18 @@ describe.skip("structural worker retirement under Dreaming (#946) [retired confi
 
 	it("keeps the real HTTP surface responsive during owner initialization", async () => {
 		const dbPath = join(dir, "memory", "memories.db");
-		const owner = createDbOwnerClient({ dbPath });
+		const startedMarker = join(dir, "init-started");
+		const releaseMarker = join(dir, "init-release");
+		process.env.SIGNET_DB_OWNER_TEST_INIT_STARTED = startedMarker;
+		process.env.SIGNET_DB_OWNER_TEST_INIT_RELEASE = releaseMarker;
+		const owner = createDbOwnerClient({ dbPath, workerPath: join(import.meta.dir, "db-owner-worker.ts") });
 		try {
 			await owner.start();
 			const initialization = owner.submit(
 				{ kind: "initialize", agentsDir: dir },
 				{ operation: "db.initialize.liveness-regression", lane: "maintenance", deadlineMs: 60_000 },
 			);
+			await waitForMarker(startedMarker);
 			const started = performance.now();
 			const responses = await Promise.all([
 				app.request("http://localhost/health/live"),
@@ -666,6 +663,7 @@ describe.skip("structural worker retirement under Dreaming (#946) [retired confi
 			expect(responses[0]?.status).toBe(200);
 			expect(responses[1]?.status).toBe(200);
 			expect(elapsed).toBeLessThan(500);
+			writeFileSync(releaseMarker, "release\n");
 			await owner.awaitResult(initialization, 60_000);
 		} finally {
 			await owner.close();
@@ -674,7 +672,11 @@ describe.skip("structural worker retirement under Dreaming (#946) [retired confi
 
 	it("can safely re-enter initialization after an owner dies", async () => {
 		const dbPath = join(dir, "memory", "memories.db");
-		const first = createDbOwnerClient({ dbPath });
+		const startedMarker = join(dir, "kill-init-started");
+		const releaseMarker = join(dir, "kill-init-release");
+		process.env.SIGNET_DB_OWNER_TEST_INIT_STARTED = startedMarker;
+		process.env.SIGNET_DB_OWNER_TEST_INIT_RELEASE = releaseMarker;
+		const first = createDbOwnerClient({ dbPath, workerPath: join(import.meta.dir, "db-owner-worker.ts") });
 		await first.start();
 		const pid = first.health().pid;
 		if (pid === null) throw new Error("owner did not publish a pid");
@@ -682,9 +684,15 @@ describe.skip("structural worker retirement under Dreaming (#946) [retired confi
 			{ kind: "initialize", agentsDir: dir },
 			{ operation: "db.initialize.kill-reentry", lane: "maintenance", deadlineMs: 5_000 },
 		);
+		await waitForMarker(startedMarker);
 		process.kill(pid, "SIGKILL");
 		await expect(pending.result).rejects.toBeDefined();
+		writeFileSync(releaseMarker, "release\n");
+		Reflect.deleteProperty(process.env, "SIGNET_DB_OWNER_TEST_INIT_STARTED");
+		Reflect.deleteProperty(process.env, "SIGNET_DB_OWNER_TEST_INIT_RELEASE");
 		await first.close();
+		Reflect.deleteProperty(process.env, "SIGNET_DB_OWNER_TEST_INIT_STARTED");
+		Reflect.deleteProperty(process.env, "SIGNET_DB_OWNER_TEST_INIT_RELEASE");
 
 		const second = createDbOwnerClient({ dbPath });
 		try {

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -53,7 +53,7 @@ import {
 	closeDbAccessor,
 	getDbAccessor,
 	getVectorRuntimeStatus,
-	initDbAccessorAsync,
+	initDbAccessorLite,
 	type WriteDb,
 } from "./db-accessor";
 import { type VacuumConversionHandle, startVacuumConversionWorker } from "./db-vacuum";
@@ -2045,8 +2045,17 @@ async function main() {
 		});
 	}
 
-	await initDbAccessorAsync(MEMORY_DB, { agentsDir: AGENTS_DIR });
+	// Expensive schema/FTS/vector initialization must execute in the killable
+	// owner process, not merely behind an async function on this isolate.
 	dbOwnerClient = createDbOwnerClient({ dbPath: MEMORY_DB });
+	await dbOwnerClient.start();
+	const initialization = dbOwnerClient.submit(
+		{ kind: "initialize", agentsDir: AGENTS_DIR },
+		{ operation: "db.initialize", lane: "maintenance", deadlineMs: 60_000, estimatedWorkUnits: 10_000 },
+	);
+	await dbOwnerClient.awaitResult(initialization, 60_000);
+	const { extensionPath: initExtensionPath } = getVectorRuntimeStatus();
+	initDbAccessorLite(MEMORY_DB, initExtensionPath ?? "");
 	setSessionClaimStore(createSessionClaimStore(getDbAccessor()));
 	startSessionCleanup();
 	// Formal TTL lifecycle (#902): when stale-session cleanup evicts a claim
@@ -2067,7 +2076,6 @@ async function main() {
 	startEventLoopMonitor();
 	startFdPollMonitor();
 
-	dbOwnerClient = createDbOwnerClient({ dbPath: MEMORY_DB });
 	dbOwnerMaintenanceHandle = createDbOwnerMaintenance({ dbPath: MEMORY_DB, owner: dbOwnerClient });
 	registerDbOwnerMaintenance(dbOwnerMaintenanceHandle);
 	// Clean accumulated crash-loop damage through the owner. This remains a

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -123,6 +123,7 @@ export interface DbOwnerSourceArtifactUpsert {
 }
 
 export type DbOwnerRequest =
+	| { readonly kind: "initialize"; readonly agentsDir?: string }
 	| { readonly kind: "query"; readonly statement: DbOwnerStatement }
 	| { readonly kind: "transaction"; readonly transaction: DbOwnerTransaction }
 	| {

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -345,7 +345,14 @@ export function runDbOwnerWorker(): void {
 		);
 	}
 
+	async function executeInitialization(agentsDir: string | undefined): Promise<unknown> {
+		const { initDbAccessorAsync } = await import("./db-accessor");
+		await initDbAccessorAsync(ownerDbPath, { agentsDir });
+		return { initialized: true };
+	}
+
 	async function execute(job: DbOwnerJob): Promise<unknown> {
+		if (job.request.kind === "initialize") return await executeInitialization(job.request.agentsDir);
 		if (job.request.kind === "query") return executeStatement(job.request.statement);
 		if (job.request.kind === "transaction") return executeTransaction(job.request.transaction.statements);
 		if (job.request.kind === "batch") return executeBatch(job.request.statements, job.request.requireChanges === true);

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import { existsSync, writeFileSync } from "node:fs";
 import type { Database as BunDatabase } from "bun:sqlite";
 import { findSqliteVecExtension } from "@signet/core";
 import {
@@ -346,6 +347,12 @@ export function runDbOwnerWorker(): void {
 	}
 
 	async function executeInitialization(agentsDir: string | undefined): Promise<unknown> {
+		const startedMarker = process.env.SIGNET_DB_OWNER_TEST_INIT_STARTED;
+		const releaseMarker = process.env.SIGNET_DB_OWNER_TEST_INIT_RELEASE;
+		if (startedMarker !== undefined && releaseMarker !== undefined) {
+			writeFileSync(startedMarker, "started\n");
+			while (!existsSync(releaseMarker)) await new Promise((resolve) => setTimeout(resolve, 5));
+		}
 		const { initDbAccessorAsync } = await import("./db-accessor");
 		await initDbAccessorAsync(ownerDbPath, { agentsDir });
 		return { initialized: true };


### PR DESCRIPTION
## Summary

Fixes #1670 by moving collection-size-dependent SQLite initialization behind the existing killable DB-owner child-process boundary. The parent daemon now starts the owner, submits a bounded `db.initialize` job, and only creates its lightweight accessor after the owner completes initialization.

## Reproduction method

The production incident was reproduced by observing readiness followed by `/health/live` and `/api/status` starvation during synchronous SQLite reads on a 102,853-memory, 7.6 GiB database, with `strace` showing repeated SQLite `pread64` calls and `gdb` placing the parent thread in native `pread64`. This checkout cannot honestly reproduce that production scale. The mechanism is represented by the owner boundary: expensive initialization now executes in the child process rather than the HTTP isolate.

## Before / after evidence

Before: `initDbAccessorAsync` still called `finishDbAccessorInit` in the parent isolate; the Promise did not move native SQLite work off the event loop.

After: `db.initialize` is submitted to the maintenance DB-owner lane with a 60-second hard owner deadline. The parent calls only `initDbAccessorLite` after completion, so the initialization SQL runs in the child process and can be killed at the process boundary.

## Init reads moved async

The initialization path containing migrations, FTS state inspection/repair, embedding-index state inspection, sqlite-vec setup, vector backfill, and orphan reconciliation is now invoked by the DB-owner worker through `initDbAccessorAsync`. The daemon-side accessor is lightweight and does not rerun those scans.

## Verification

- `git diff --check`: pass
- `bun test platform/daemon/src/db-owner-client.test.ts platform/daemon/src/db-accessor.test.ts`: 50 passed, 1 pre-existing timing failure in `recall lane completes while maintenance lane is saturated` (238.6ms vs 200ms)
- `bun run --filter '@signet/daemon' build`: blocked by missing workspace package `@signet/lifecycle-proof` in this fresh worktree
- `bun run --filter '@signet/daemon' typecheck`: blocked by the same missing package plus unrelated existing type errors
- Biome: changed files report no new diagnostics; existing daemon unused-import/type warnings remain

## AI disclosure

Assisted-by: Hermes-Agent:gpt-5.6-luna

## Checklist exception

This is an architecture/outage fix with scaled production reproduction evidence unavailable in the checkout; the issue's mechanism and boundary are directly addressed and the limitation is documented above.
