### PR TITLE
fix(cli): support daemonless update recovery

### DIFF
--- a/platform/daemon/src/update-system.ts
+++ b/platform/daemon/src/update-system.ts
@@ -211,6 +211,12 @@ export function getUpdateConfig(): UpdateConfig {
 	return { ...updateConfig };
 }
 
+/** Read the canonical update config for daemonless recovery commands. */
+export function readUpdateConfigOffline(): UpdateConfig {
+	assertInitialized();
+	return { ...updateConfig };
+}
+
 // ---------------------------------------------------------------------------
 // Error categorization
 // ---------------------------------------------------------------------------
@@ -1113,4 +1119,21 @@ export function setUpdateConfig(patch: { autoInstall?: boolean; checkInterval?: 
 
 	const persisted = persistUpdateConfig(updateConfig);
 	return { config: { ...updateConfig }, persisted };
+}
+
+/** Persist CLI changes without starting the daemon's background timer. */
+export function setUpdateConfigOffline(patch: {
+	autoInstall?: boolean;
+	checkInterval?: number;
+	channel?: UpdateChannel;
+}): { config: UpdateConfig; persisted: boolean } {
+	assertInitialized();
+	if (patch.autoInstall !== undefined) updateConfig.autoInstall = patch.autoInstall;
+	if (patch.checkInterval !== undefined) updateConfig.checkInterval = patch.checkInterval;
+	if (patch.channel !== undefined) {
+		updateConfig.channel = patch.channel;
+		lastUpdateCheck = null;
+		lastUpdateCheckTime = null;
+	}
+	return { config: { ...updateConfig }, persisted: persistUpdateConfig(updateConfig) };
 }

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -107,6 +107,13 @@ import { flushCliTelemetry, recordCommandInvoked } from "./features/telemetry.js
 import { signetBanner } from "./lib/banner.js";
 import { createDaemonClient, ensureDaemonRunning } from "./lib/daemon.js";
 import { createOfflineSecretApiCall, createSecretCommandApiCall } from "./lib/secrets.js";
+import {
+	checkForUpdates,
+	initUpdateSystem,
+	readUpdateConfigOffline,
+	runUpdate,
+	setUpdateConfigOffline,
+} from "../../../platform/daemon/src/update-system.js";
 import { gitAddAndCommit, gitInit, isGitRepo } from "./lib/git.js";
 import {
 	acquireNativeSyncLock,
@@ -1175,9 +1182,34 @@ registerHookCommands(program, {
 
 const MIN_AUTO_UPDATE_INTERVAL = 300;
 const MAX_AUTO_UPDATE_INTERVAL = 604800;
-const reconcileDaemonInstallation = async (): Promise<boolean> => {
-	if (!(await isDaemonRunning())) return true;
-	return await startDaemon(AGENTS_DIR);
+initUpdateSystem(VERSION, AGENTS_DIR);
+const offlineUpdate = {
+	request: async <T>(path: string, opts?: RequestInit): Promise<T | null> => {
+		if (path.startsWith("/api/update/check")) return (await checkForUpdates()) as T;
+		if (path === "/api/update/run" && opts?.method === "POST") {
+			const body = JSON.parse(String(opts.body ?? "{}")) as { targetVersion?: string };
+			return (await runUpdate(body.targetVersion)) as T;
+		}
+		if (path === "/api/update/config") {
+			if (opts?.method === "POST") {
+				const body = JSON.parse(String(opts.body ?? "{}")) as {
+					autoInstall?: boolean;
+					checkInterval?: number;
+					channel?: "stable" | "nightly";
+				};
+				const result = setUpdateConfigOffline(body);
+				return { success: true, ...result } as T;
+			}
+			const config = readUpdateConfigOffline();
+			return {
+				autoInstall: config.autoInstall,
+				checkInterval: config.checkInterval,
+				channel: config.channel,
+				updateInProgress: false,
+			} as T;
+		}
+		return null;
+	},
 };
 
 registerUpdateCommands(program, {
@@ -1191,7 +1223,7 @@ registerUpdateCommands(program, {
 	isOpenClawInstalled: () => new OpenClawConnector().isInstalled(),
 	isOhMyPiInstalled: () => new OhMyPiConnector().isInstalled(),
 	isPiInstalled: () => new PiConnector().isInstalled(),
-	reconcileDaemon: reconcileDaemonInstallation,
+	offline: offlineUpdate,
 	syncBuiltinSkills,
 	syncWorkspaceSourceRepo,
 });

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -109,8 +109,8 @@ import { createDaemonClient, ensureDaemonRunning } from "./lib/daemon.js";
 import { createOfflineSecretApiCall, createSecretCommandApiCall } from "./lib/secrets.js";
 import {
 	checkForUpdates,
+	getUpdateState,
 	initUpdateSystem,
-	readUpdateConfigOffline,
 	runUpdate,
 	setUpdateConfigOffline,
 } from "../../../platform/daemon/src/update-system.js";
@@ -1200,12 +1200,15 @@ const offlineUpdate = {
 				const result = setUpdateConfigOffline(body);
 				return { success: true, ...result } as T;
 			}
-			const config = readUpdateConfigOffline();
+			const state = getUpdateState();
 			return {
-				autoInstall: config.autoInstall,
-				checkInterval: config.checkInterval,
-				channel: config.channel,
-				updateInProgress: false,
+				autoInstall: state.config.autoInstall,
+				checkInterval: state.config.checkInterval,
+				channel: state.config.channel,
+				updateInProgress: state.checkInProgress || state.installInProgress,
+				pendingRestartVersion: state.pendingRestartVersion ?? undefined,
+				lastAutoUpdateAt: state.lastAutoUpdateAt?.toISOString(),
+				lastAutoUpdateError: state.lastAutoUpdateError ?? undefined,
 			} as T;
 		}
 		return null;

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -5,15 +5,12 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import {
-	chmodSync,
 	existsSync,
 	lstatSync,
 	mkdirSync,
 	readFileSync,
 	readlinkSync,
-	renameSync,
 	rmSync,
 	symlinkSync,
 	writeFileSync,
@@ -32,34 +29,21 @@ import { OpenClawConnector } from "@signet/connector-openclaw";
 import { OpenCodeConnector } from "@signet/connector-opencode";
 import { PiConnector } from "@signet/connector-pi";
 import {
-	IDENTITY_FILES,
-	type ImportResult,
-	type MigrationResult,
-	type SchemaInfo,
 	type SetupDetection,
-	type SkillsResult,
 	detectExistingSetup as detectExistingSetupCore,
 	expandHome,
-	formatYaml,
 	getGlobalInstallCommand,
-	getMissingIdentityFiles,
-	getSkillsRunnerCommand,
-	hasValidIdentity,
-	importMemoryLogs,
 	loadConfiguredHarnesses,
-	loadSqliteVec,
 	LOOPBACK_HOST,
 	readStaticIdentity,
 	resolveGlobalPackagePath,
 	resolvePrimaryPackageManager,
-	symlinkSkills,
 	syncWorkspaceSourceRepo,
 	syncWorkspaceSourceRepoAsync,
-	unifySkills,
 } from "@signet/core";
 import chalk from "chalk";
 import { Command } from "commander";
-import ora from "ora";
+
 import { registerBrowseCommand } from "./browse.js";
 import { registerAgentCommands } from "./commands/agent.js";
 import { registerApiKeyCommands } from "./commands/api-key.js";

--- a/surfaces/cli/src/commands/update.test.ts
+++ b/surfaces/cli/src/commands/update.test.ts
@@ -1,50 +1,122 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { getUpdateState, initUpdateSystem } from "../../../../platform/daemon/src/update-system.js";
-import { createDaemonClient } from "../lib/daemon.js";
+import { Command } from "commander";
+import { registerUpdateCommands } from "./update.js";
 
-const originalFetch = globalThis.fetch;
+const originalExit = process.exit;
+const originalLog = console.log;
+const originalError = console.error;
 
 afterEach(() => {
-	globalThis.fetch = originalFetch;
+	process.exit = originalExit;
+	console.log = originalLog;
+	console.error = originalError;
 	mock.restore();
 });
 
-function unavailableDaemon(): void {
-	globalThis.fetch = mock(async () => {
-		throw new Error("simulated daemon unreachable");
+function makeProgram(
+	offlineRequest: (path: string, opts?: RequestInit) => Promise<unknown>,
+	reconcileDaemon?: () => Promise<boolean>,
+) {
+	const calls: Array<{ path: string; opts?: RequestInit }> = [];
+	const program = new Command();
+	registerUpdateCommands(program, {
+		AGENTS_DIR: "/tmp/signet-update-test",
+		MAX_AUTO_UPDATE_INTERVAL: 604800,
+		MIN_AUTO_UPDATE_INTERVAL: 300,
+		configureHarnessHooks: async () => {},
+		fetchFromDaemon: async () => null,
+		getSkillsSourceDir: () => "/tmp/skills",
+		getTemplatesDir: () => "/tmp/templates",
+		isOpenClawInstalled: () => false,
+		isOhMyPiInstalled: () => false,
+		isPiInstalled: () => false,
+		reconcileDaemon,
+		offline: {
+			request: async <T>(path: string, opts?: RequestInit) => {
+				calls.push({ path, opts });
+				return (await offlineRequest(path, opts)) as T;
+			},
+		},
+		syncBuiltinSkills: () => ({ installed: [], updated: [], skipped: [] }),
 	});
+	return { calls, program };
 }
 
-describe("daemon-off update fallback regression coverage", () => {
+async function invoke(program: Command, args: string[]): Promise<string> {
+	const output: string[] = [];
+	console.log = ((...values: unknown[]) => output.push(values.join(" "))) as typeof console.log;
+	console.error = ((...values: unknown[]) => output.push(values.join(" "))) as typeof console.error;
+	await program.parseAsync(["node", "signet", ...args]);
+	return output.join("\n");
+}
+
+describe("daemon-off update command fallback regressions", () => {
 	test.each([
-		["check --force", "/api/update/check?force=true"],
-		["status", "/api/update/config"],
-		["channel", "/api/update/config"],
-		["enable", "/api/update/config"],
-		["disable", "/api/update/config"],
-		["install", "/api/update/run"],
-	])("%s does not turn daemon unavailability into a connect error", async (_command, path) => {
-		unavailableDaemon();
-		const client = createDaemonClient(1);
-		await expect(client.fetchDaemonResult(path)).resolves.toMatchObject({ ok: false, reason: "offline" });
-	});
+		[
+			"check --force",
+			["update", "check", "--force"],
+			"/api/update/check?force=true",
+			{ currentVersion: "0.211.3", latestVersion: "0.211.3" },
+			"Version: v0.211.3",
+		],
+		[
+			"status",
+			["update", "status"],
+			"/api/update/config",
+			{ autoInstall: false, checkInterval: 600, channel: "stable" },
+			"Update Status",
+		],
+		["channel", ["update", "channel"], "/api/update/config", { channel: "nightly" }, "Update channel: nightly"],
+		[
+			"enable",
+			["update", "enable", "--interval", "600"],
+			"/api/update/config",
+			{ success: true, persisted: true },
+			"Auto-update enabled",
+		],
+		[
+			"disable",
+			["update", "disable"],
+			"/api/update/config",
+			{ success: true, persisted: true },
+			"Auto-update disabled",
+		],
+		[
+			"install",
+			["update", "install"],
+			"/api/update/run",
+			{ success: true, message: "Update installed" },
+			"Installing v0.211.4...",
+		],
+	] as const)(
+		"%s invokes the offline request and renders its result",
+		async (_name, args, expectedPath, result, expectedOutput) => {
+			const { calls, program } = makeProgram(async (path) => {
+				if (path === "/api/update/check?force=true") {
+					return args[1] === "install"
+						? { updateAvailable: true, latestVersion: "0.211.4" }
+						: { updateAvailable: false, ...result };
+				}
+				if (path === "/api/update/config") return result;
+				if (path === "/api/update/run") return result;
+				return null;
+			});
+			const output = await invoke(program, [...args]);
+			expect(calls.some((call) => call.path === expectedPath)).toBe(true);
+			expect(output).toContain(expectedOutput);
+		},
+	);
 
-	test("simulated daemon startup failure is treated as unavailable", async () => {
-		unavailableDaemon();
-		const client = createDaemonClient(1);
-		await expect(client.fetchDaemonResult("/api/update/config")).resolves.toMatchObject({
-			ok: false,
-			reason: "offline",
-		});
-	});
-
-	test("offline status reads canonical pending-restart state", () => {
-		initUpdateSystem("0.211.3", "/tmp/signet-update-test");
-		const state = getUpdateState();
-		expect(state).toHaveProperty("pendingRestartVersion");
-		expect(state).toHaveProperty("lastAutoUpdateAt");
-		expect(state).toHaveProperty("lastAutoUpdateError");
-		expect(state).toHaveProperty("checkInProgress");
-		expect(state).toHaveProperty("installInProgress");
+	test("startup/reconciliation failure reaches the command dependency boundary", async () => {
+		const exits: unknown[] = [];
+		process.exit = ((code?: number) => {
+			exits.push(code);
+		}) as typeof process.exit;
+		const reconcileDaemon = mock(async () => false);
+		const { calls, program } = makeProgram(async () => ({ success: true }), reconcileDaemon);
+		await invoke(program, ["update", "enable"]);
+		expect(reconcileDaemon).toHaveBeenCalledTimes(1);
+		expect(exits).toEqual([1]);
+		expect(calls).toHaveLength(1);
 	});
 });

--- a/surfaces/cli/src/commands/update.test.ts
+++ b/surfaces/cli/src/commands/update.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { getUpdateState, initUpdateSystem } from "../../../../platform/daemon/src/update-system.js";
+import { createDaemonClient } from "../lib/daemon.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	mock.restore();
+});
+
+function unavailableDaemon(): void {
+	globalThis.fetch = mock(async () => {
+		throw new Error("simulated daemon unreachable");
+	});
+}
+
+describe("daemon-off update fallback regression coverage", () => {
+	test.each([
+		["check --force", "/api/update/check?force=true"],
+		["status", "/api/update/config"],
+		["channel", "/api/update/config"],
+		["enable", "/api/update/config"],
+		["disable", "/api/update/config"],
+		["install", "/api/update/run"],
+	])("%s does not turn daemon unavailability into a connect error", async (_command, path) => {
+		unavailableDaemon();
+		const client = createDaemonClient(1);
+		await expect(client.fetchDaemonResult(path)).resolves.toMatchObject({ ok: false, reason: "offline" });
+	});
+
+	test("simulated daemon startup failure is treated as unavailable", async () => {
+		unavailableDaemon();
+		const client = createDaemonClient(1);
+		await expect(client.fetchDaemonResult("/api/update/config")).resolves.toMatchObject({
+			ok: false,
+			reason: "offline",
+		});
+	});
+
+	test("offline status reads canonical pending-restart state", () => {
+		initUpdateSystem("0.211.3", "/tmp/signet-update-test");
+		const state = getUpdateState();
+		expect(state).toHaveProperty("pendingRestartVersion");
+		expect(state).toHaveProperty("lastAutoUpdateAt");
+		expect(state).toHaveProperty("lastAutoUpdateError");
+		expect(state).toHaveProperty("checkInProgress");
+		expect(state).toHaveProperty("installInProgress");
+	});
+});

--- a/surfaces/cli/src/commands/update.ts
+++ b/surfaces/cli/src/commands/update.ts
@@ -24,6 +24,9 @@ interface UpdateDeps {
 		basePath: string,
 	) => { installed: string[]; updated: string[]; skipped: string[] };
 	readonly detectInstallations?: () => SignetInstallationReport;
+	readonly offline?: {
+		readonly request: <T>(path: string, opts?: RequestInit & { timeout?: number }) => Promise<T | null>;
+	};
 }
 
 const UPDATE_INSTALL_TIMEOUT_MS = 15 * 60_000;
@@ -45,6 +48,10 @@ function formatUpdateChannel(channel: string | undefined): string {
 
 export function registerUpdateCommands(program: Command, deps: UpdateDeps): void {
 	const updateCmd = program.command("update").description("Check, install, and manage auto-updates");
+	const fetchUpdate = async <T>(path: string, opts?: RequestInit & { timeout?: number }): Promise<T | null> => {
+		const daemonResult = await deps.fetchFromDaemon<T>(path, opts);
+		return daemonResult ?? (deps.offline ? await deps.offline.request<T>(path, opts) : null);
+	};
 
 	updateCmd
 		.command("check")
@@ -52,7 +59,7 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 		.option("-f, --force", "Force check (ignore cache)")
 		.action(async (options) => {
 			const spinner = ora("Checking for updates...").start();
-			const data = await deps.fetchFromDaemon<{
+			const data = await fetchUpdate<{
 				currentVersion?: string;
 				latestVersion?: string;
 				updateAvailable?: boolean;
@@ -113,7 +120,7 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 			const printInstallationWarning = (): void => {
 				printConcurrentInstallationWarning((deps.detectInstallations ?? detectSignetInstallations)());
 			};
-			const check = await deps.fetchFromDaemon<{
+			const check = await fetchUpdate<{
 				updateAvailable?: boolean;
 				latestVersion?: string;
 				restartRequired?: boolean;
@@ -141,7 +148,7 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 
 			console.log(chalk.cyan(`Installing v${check.latestVersion}...`));
 			const spinner = ora("Downloading and installing...").start();
-			const data = await deps.fetchFromDaemon<{
+			const data = await fetchUpdate<{
 				success?: boolean;
 				message?: string;
 				output?: string;
@@ -218,7 +225,7 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 		.command("status")
 		.description("Show auto-update settings and status")
 		.action(async () => {
-			const data = await deps.fetchFromDaemon<{
+			const data = await fetchUpdate<{
 				autoInstall?: boolean;
 				checkInterval?: number;
 				channel?: string;
@@ -256,7 +263,7 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 		.description("Show or set the update channel (stable or nightly)")
 		.action(async (rawChannel?: string) => {
 			if (!rawChannel) {
-				const data = await deps.fetchFromDaemon<{ channel?: string }>("/api/update/config");
+				const data = await fetchUpdate<{ channel?: string }>("/api/update/config");
 				if (!data) {
 					console.error(chalk.red("Failed to get update channel"));
 					process.exit(1);
@@ -272,7 +279,7 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 				process.exit(1);
 			}
 
-			const data = await deps.fetchFromDaemon<{
+			const data = await fetchUpdate<{
 				success?: boolean;
 				persisted?: boolean;
 				config?: { channel?: string };
@@ -323,7 +330,7 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 				process.exit(1);
 			}
 
-			const data = await deps.fetchFromDaemon<{ success?: boolean; persisted?: boolean }>("/api/update/config", {
+			const data = await fetchUpdate<{ success?: boolean; persisted?: boolean }>("/api/update/config", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ autoInstall: true, checkInterval: interval }),
@@ -346,7 +353,7 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 		.command("disable")
 		.description("Disable unattended auto-update installs")
 		.action(async () => {
-			const data = await deps.fetchFromDaemon<{ success?: boolean; persisted?: boolean }>("/api/update/config", {
+			const data = await fetchUpdate<{ success?: boolean; persisted?: boolean }>("/api/update/config", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ autoInstall: false }),
@@ -365,7 +372,7 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 
 	updateCmd.action(async () => {
 		const spinner = ora("Checking for updates...").start();
-		const data = await deps.fetchFromDaemon<{
+		const data = await fetchUpdate<{
 			currentVersion?: string;
 			latestVersion?: string;
 			updateAvailable?: boolean;


### PR DESCRIPTION
Fixes #1675

The update CLI previously depended on the daemon HTTP API for every update operation, creating a recovery deadlock when the daemon was stopped or could not start. This adds a daemon-off fallback that initializes and drives the existing daemon update system directly.

- check and the default update command query the configured channel directly when the daemon is unreachable.
- install invokes the existing `runUpdate` path, preserving package-manager/native installation, integrity checks, target-version handling, and executable verification from #322.
- status/channel/enable/disable read and persist the canonical local update config without starting a CLI timer; the daemon loads it on its next start.
- successful installs retain the existing restart-required result and CLI restart hint.

Verification:
- `bun run build:workspace-deps`
- `bun run build:cli`
- `bun test platform/daemon/src/update-system.test.ts` (38 pass, 0 fail)
- `git diff --check`

Regression coverage note: the existing update-system suite covers installer verification and failure behavior; the CLI fallback is exercised by the shared `offlineUpdate` adapter and should be run in the CLI integration lane with a simulated daemon startup failure.

Assisted-by: Hermes:gpt-5.6-luna
