### PR TITLE
fix(daemon): unblock DB-owner startup handshake

### DIFF
--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -89,6 +89,15 @@ describe("auth guard co-location", () => {
 		return new Hono();
 	}
 
+	it("passes the resolved SQLite runtime to the recall owner", async () => {
+		const { createRecallDbOwnerOptions } = await import("./daemon");
+		expect(createRecallDbOwnerOptions("/tmp/custom-libsqlite3.dylib")).toEqual({
+			dbPath: join(tmpDir, "memory", "memories.db"),
+			sqlitePath: "/tmp/custom-libsqlite3.dylib",
+			workerRole: "recall",
+		});
+	});
+
 	async function status(app: InstanceType<typeof import("hono").Hono>, method: string, path: string): Promise<number> {
 		const res = await app.request(path, { method });
 		return res.status;

--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -117,6 +117,7 @@ describe("auth guard co-location", () => {
 		function rejectingRecallOwner(error: Error): DbOwnerClient {
 			return {
 				start: async () => {},
+				initialize: async () => {},
 				submit<Result>(request: DbOwnerRequest, options: DbOwnerSubmitOptions): DbOwnerJobHandle<Result> {
 					return {
 						job: {
@@ -139,6 +140,8 @@ describe("auth guard co-location", () => {
 				cancel: () => {},
 				health: () => ({
 					state: "ready",
+					initialization: "ready",
+					databaseReady: true,
 					pid: null,
 					generation: 1,
 					queuedJobs: 0,

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -54,6 +54,7 @@ import {
 	getDbAccessor,
 	getVectorRuntimeStatus,
 	initDbAccessorLite,
+	resolveSqliteRuntimeConfig,
 	type WriteDb,
 } from "./db-accessor";
 import { type VacuumConversionHandle, startVacuumConversionWorker } from "./db-vacuum";
@@ -2044,13 +2045,10 @@ async function main() {
 
 	// Expensive schema/FTS/vector initialization must execute in the killable
 	// owner process, not merely behind an async function on this isolate.
-	dbOwnerClient = createDbOwnerClient({ dbPath: MEMORY_DB });
+	const sqliteRuntime = resolveSqliteRuntimeConfig({ agentsDir: AGENTS_DIR });
+	dbOwnerClient = createDbOwnerClient({ dbPath: MEMORY_DB, sqlitePath: sqliteRuntime.choice?.path });
 	await dbOwnerClient.start();
-	const initialization = dbOwnerClient.submit(
-		{ kind: "initialize", agentsDir: AGENTS_DIR },
-		{ operation: "db.initialize", lane: "maintenance", deadlineMs: 60_000, estimatedWorkUnits: 10_000 },
-	);
-	await dbOwnerClient.awaitResult(initialization, 60_000);
+	await dbOwnerClient.initialize(AGENTS_DIR);
 	const { extensionPath: initExtensionPath } = getVectorRuntimeStatus();
 	initDbAccessorLite(MEMORY_DB, initExtensionPath ?? "");
 	setSessionClaimStore(createSessionClaimStore(getDbAccessor()));

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -58,7 +58,7 @@ import {
 	type WriteDb,
 } from "./db-accessor";
 import { type VacuumConversionHandle, startVacuumConversionWorker } from "./db-vacuum";
-import { createDbOwnerClient, type DbOwnerClient } from "./db-owner-client";
+import { createDbOwnerClient, type DbOwnerClient, type DbOwnerClientOptions } from "./db-owner-client";
 import {
 	type DbOwnerMaintenance,
 	createDbOwnerMaintenance,
@@ -302,9 +302,17 @@ export function countConnectorsActive(connectors: readonly { readonly status: st
 
 export const app = new Hono();
 
+// Resolve the custom SQLite runtime once so both owner lanes use the same
+// runtime selected for this daemon instance.
+const sqliteRuntime = resolveSqliteRuntimeConfig({ agentsDir: AGENTS_DIR });
+
+export function createRecallDbOwnerOptions(sqlitePath: string | undefined): DbOwnerClientOptions {
+	return { dbPath: MEMORY_DB, sqlitePath, workerRole: "recall" };
+}
+
 // Recall uses its own child-process lane so request reads never wait behind
 // maintenance or write work in the generic owner.
-const recallDbOwner = createDbOwnerClient({ dbPath: MEMORY_DB, workerRole: "recall" });
+const recallDbOwner = createDbOwnerClient(createRecallDbOwnerOptions(sqliteRuntime.choice?.path));
 
 registerGlobalMiddleware(app);
 getOrCreateInferenceRouter(resolveDefaultBasePath());
@@ -2045,7 +2053,6 @@ async function main() {
 
 	// Expensive schema/FTS/vector initialization must execute in the killable
 	// owner process, not merely behind an async function on this isolate.
-	const sqliteRuntime = resolveSqliteRuntimeConfig({ agentsDir: AGENTS_DIR });
 	dbOwnerClient = createDbOwnerClient({ dbPath: MEMORY_DB, sqlitePath: sqliteRuntime.choice?.path });
 	await dbOwnerClient.start();
 	await dbOwnerClient.initialize(AGENTS_DIR);

--- a/platform/daemon/src/db-owner-client.test.ts
+++ b/platform/daemon/src/db-owner-client.test.ts
@@ -132,7 +132,7 @@ describe("DB owner client", () => {
 		}
 	});
 
-	test("allows the DB owner startup deadline to be overridden by environment", async () => {
+	test("rejects when an overridden DB owner startup deadline expires", async () => {
 		const database = makeDb();
 		directory = database.directory;
 		const workerPath = join(database.directory, "delayed-ready-worker.js");
@@ -141,10 +141,24 @@ describe("DB owner client", () => {
 			'setTimeout(() => process.stdout.write(JSON.stringify({ type: "ready", pid: process.pid }) + "\\n"), 100);',
 		);
 		const previousTimeout = process.env.SIGNET_DB_OWNER_START_TIMEOUT_MS;
-		process.env.SIGNET_DB_OWNER_START_TIMEOUT_MS = "250";
+		process.env.SIGNET_DB_OWNER_START_TIMEOUT_MS = "50";
 		try {
 			client = createDbOwnerClient({ dbPath: database.path, workerPath });
-			await expect(client.start()).resolves.toBeUndefined();
+			await expect(client.start()).rejects.toMatchObject({ code: "DB_OWNER_START_TIMEOUT" });
+		} finally {
+			if (previousTimeout === undefined) Reflect.deleteProperty(process.env, "SIGNET_DB_OWNER_START_TIMEOUT_MS");
+			else process.env.SIGNET_DB_OWNER_START_TIMEOUT_MS = previousTimeout;
+		}
+	});
+
+	test("rejects garbage DB owner startup timeout configuration", async () => {
+		const database = makeDb();
+		directory = database.directory;
+		const previousTimeout = process.env.SIGNET_DB_OWNER_START_TIMEOUT_MS;
+		process.env.SIGNET_DB_OWNER_START_TIMEOUT_MS = "abc";
+		try {
+			client = createDbOwnerClient({ dbPath: database.path });
+			await expect(client.start()).rejects.toMatchObject({ code: "DB_OWNER_START_TIMEOUT_INVALID" });
 		} finally {
 			if (previousTimeout === undefined) Reflect.deleteProperty(process.env, "SIGNET_DB_OWNER_START_TIMEOUT_MS");
 			else process.env.SIGNET_DB_OWNER_START_TIMEOUT_MS = previousTimeout;

--- a/platform/daemon/src/db-owner-client.test.ts
+++ b/platform/daemon/src/db-owner-client.test.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -16,7 +16,6 @@ import {
 import { findSqliteVecExtension } from "@signet/core";
 import { closeDbAccessor, initDbAccessor } from "./db-accessor";
 import { recallThroughDbOwner } from "./db-owner-recall";
-import { loadSqliteVecIfAvailable } from "./db-owner-worker";
 
 function makeDb(): { readonly directory: string; readonly path: string } {
 	const directory = mkdtempSync(join(tmpdir(), "signet-db-owner-"));
@@ -101,6 +100,65 @@ describe("DB owner client", () => {
 			if (previousVecPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_VEC_PATH");
 			else process.env.SIGNET_VEC_PATH = previousVecPath;
 		}
+	});
+
+	test("publishes protocol readiness before synchronous database startup", async () => {
+		const database = makeDb();
+		directory = database.directory;
+		const startupStarted = join(database.directory, "startup-started");
+		const startupRelease = join(database.directory, "startup-release");
+		const previousStarted = process.env.SIGNET_DB_OWNER_TEST_STARTUP_STARTED;
+		const previousRelease = process.env.SIGNET_DB_OWNER_TEST_STARTUP_RELEASE;
+		process.env.SIGNET_DB_OWNER_TEST_STARTUP_STARTED = startupStarted;
+		process.env.SIGNET_DB_OWNER_TEST_STARTUP_RELEASE = startupRelease;
+		try {
+			client = createDbOwnerClient({ dbPath: database.path });
+			const start = client.start();
+			await waitFor(() => existsSync(startupStarted));
+			await expect(start).resolves.toBeUndefined();
+			writeFileSync(startupRelease, "release\n");
+			await expect(
+				client.submit<readonly { readonly value: number }[]>(
+					{ kind: "query", statement: { sql: "SELECT 1 AS value", result: "all" } },
+					{ operation: "startup-ready-query", lane: "read", deadlineMs: 1_000 },
+				).result,
+			).resolves.toEqual([{ value: 1 }]);
+		} finally {
+			writeFileSync(startupRelease, "release\n");
+			if (previousStarted === undefined) Reflect.deleteProperty(process.env, "SIGNET_DB_OWNER_TEST_STARTUP_STARTED");
+			else process.env.SIGNET_DB_OWNER_TEST_STARTUP_STARTED = previousStarted;
+			if (previousRelease === undefined) Reflect.deleteProperty(process.env, "SIGNET_DB_OWNER_TEST_STARTUP_RELEASE");
+			else process.env.SIGNET_DB_OWNER_TEST_STARTUP_RELEASE = previousRelease;
+		}
+	});
+
+	test("allows the DB owner startup deadline to be overridden by environment", async () => {
+		const database = makeDb();
+		directory = database.directory;
+		const workerPath = join(database.directory, "delayed-ready-worker.js");
+		await Bun.write(
+			workerPath,
+			'setTimeout(() => process.stdout.write(JSON.stringify({ type: "ready", pid: process.pid }) + "\\n"), 100);',
+		);
+		const previousTimeout = process.env.SIGNET_DB_OWNER_START_TIMEOUT_MS;
+		process.env.SIGNET_DB_OWNER_START_TIMEOUT_MS = "250";
+		try {
+			client = createDbOwnerClient({ dbPath: database.path, workerPath });
+			await expect(client.start()).resolves.toBeUndefined();
+		} finally {
+			if (previousTimeout === undefined) Reflect.deleteProperty(process.env, "SIGNET_DB_OWNER_START_TIMEOUT_MS");
+			else process.env.SIGNET_DB_OWNER_START_TIMEOUT_MS = previousTimeout;
+		}
+	});
+
+	test("keeps transport readiness distinct from database initialization", async () => {
+		const database = makeMigratedDb();
+		directory = database.directory;
+		client = createDbOwnerClient({ dbPath: database.path });
+		await client.start();
+		expect(client.health()).toMatchObject({ state: "ready", initialization: "not_started", databaseReady: false });
+		await client.initialize(database.directory);
+		expect(client.health()).toMatchObject({ state: "ready", initialization: "ready", databaseReady: true });
 	});
 
 	test("detects an owner survivor when harness teardown is skipped", async () => {

--- a/platform/daemon/src/db-owner-client.ts
+++ b/platform/daemon/src/db-owner-client.ts
@@ -23,6 +23,7 @@ import {
 export type { DbOwnerLane, DbOwnerRequest } from "./db-owner-protocol";
 
 export type DbOwnerHealthState = "starting" | "ready" | "dead" | "failed" | "closed";
+export type DbOwnerInitializationState = "not_started" | "running" | "ready" | "failed";
 
 /** Keep owner admission bounded like the Phase B async database queues. */
 export const MAX_DB_OWNER_PENDING_JOBS = DB_OWNER_MAX_QUEUE_DEPTH;
@@ -31,7 +32,11 @@ export const MAX_DB_OWNER_DEADLINE_MS = DB_OWNER_MAX_DEADLINE_MS;
 export const MAX_DB_OWNER_RESULT_BYTES = DB_OWNER_MAX_RESULT_BYTES;
 
 export interface DbOwnerHealth {
+	/** Process/IPC state. `ready` means transport is usable, not schema-ready. */
 	readonly state: DbOwnerHealthState;
+	/** State of the explicit database initialization job. */
+	readonly initialization: DbOwnerInitializationState;
+	readonly databaseReady: boolean;
 	readonly pid: number | null;
 	readonly generation: number;
 	readonly queuedJobs: number;
@@ -56,6 +61,7 @@ export interface DbOwnerJobHandle<Result> {
 
 export interface DbOwnerClient {
 	start(): Promise<void>;
+	initialize(agentsDir?: string): Promise<void>;
 	submit<Result>(request: DbOwnerRequest, options: DbOwnerSubmitOptions): DbOwnerJobHandle<Result>;
 	awaitResult<Result>(handle: DbOwnerJobHandle<Result>, timeoutMs?: number): Promise<Result>;
 	cancel(jobId: string): void;
@@ -115,8 +121,24 @@ interface PendingJob<Result> {
 export interface DbOwnerClientOptions {
 	readonly dbPath: string;
 	readonly workerPath?: string;
+	/** SQLite runtime library to activate before the worker opens the database. */
+	readonly sqlitePath?: string;
 	readonly startupTimeoutMs?: number;
 	readonly workerRole?: "generic" | "recall";
+}
+
+const DEFAULT_DB_OWNER_START_TIMEOUT_MS = 5_000;
+
+function resolveStartupTimeoutMs(options: DbOwnerClientOptions): number {
+	const configured = options.startupTimeoutMs ?? process.env.SIGNET_DB_OWNER_START_TIMEOUT_MS;
+	const timeoutMs = configured === undefined ? DEFAULT_DB_OWNER_START_TIMEOUT_MS : Number(configured);
+	if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+		throw new DbOwnerError(
+			"DB_OWNER_START_TIMEOUT_INVALID",
+			"DB owner startup timeout must be a positive integer in milliseconds",
+		);
+	}
+	return timeoutMs;
 }
 
 function workerArguments(workerPath: string | undefined): readonly string[] {
@@ -161,6 +183,7 @@ function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient
 	let activeJobId: string | null = null;
 	let lastError: string | null = null;
 	let deadlineKills = 0;
+	let initialization: DbOwnerInitializationState = "not_started";
 	let sequence = 0;
 	let input = "";
 	let stderr = "";
@@ -173,6 +196,8 @@ function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient
 	function currentHealth(): DbOwnerHealth {
 		return {
 			state,
+			initialization,
+			databaseReady: initialization === "ready",
 			pid,
 			generation,
 			queuedJobs: pending.size,
@@ -242,6 +267,7 @@ function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient
 		startPromise = null;
 		state = closed ? "closed" : nextState;
 		lastError = error.message;
+		if (initialization === "running") initialization = "failed";
 		const rejectStartup = startupReject;
 		startupResolve = null;
 		startupReject = null;
@@ -269,10 +295,15 @@ function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient
 		if (event.type === "fatal") {
 			lastError = event.error.message;
 			state = "failed";
+			if (initialization === "running") initialization = "failed";
 			startupReject?.(messageFromError(event.error));
 			startupReject = null;
 			startupResolve = null;
 			return;
+		}
+		const pendingJob = pending.get(event.jobId);
+		if (pendingJob?.job.request.kind === "initialize") {
+			initialization = event.outcome === "completed" ? "ready" : "failed";
 		}
 		settle(event.jobId, (job) => {
 			if (job.settled) return;
@@ -360,7 +391,7 @@ function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient
 			return;
 		}
 		if (startPromise !== null) return await startPromise;
-		const timeoutMs = options.startupTimeoutMs ?? 5_000;
+		const timeoutMs = resolveStartupTimeoutMs(options);
 		state = "starting";
 		lastError = null;
 		stderr = "";
@@ -372,6 +403,7 @@ function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient
 				...process.env,
 				SIGNET_DB_OWNER_DB_PATH: options.dbPath,
 				SIGNET_DB_OWNER_WORKER: "1",
+				...(options.sqlitePath === undefined ? {} : { SIGNET_DB_OWNER_SQLITE_PATH: options.sqlitePath }),
 				...(options.workerRole === "recall" ? { SIGNET_DB_OWNER_RECALL_WORKER: "1" } : {}),
 			};
 			// A compiled daemon sets this marker so the native entrypoint dispatches
@@ -522,6 +554,7 @@ function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient
 			}, submitOptions.deadlineMs);
 			pendingJob = { job, resolve, reject, timer, settled: false, dispatched: false };
 			pending.set(job.id, pendingJob as PendingJob<unknown>);
+			if (request.kind === "initialize") initialization = "running";
 			activeJobId ??= job.id;
 			dispatch(job.id);
 		});
@@ -585,7 +618,15 @@ function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient
 		rejectAll(new DbOwnerDiedError("DB owner client closed"));
 	}
 
-	return { start, submit, awaitResult, cancel, health: currentHealth, close };
+	async function initialize(agentsDir?: string): Promise<void> {
+		const handle = submit(
+			{ kind: "initialize", agentsDir },
+			{ operation: "db.initialize", lane: "maintenance", deadlineMs: 60_000, estimatedWorkUnits: 10_000 },
+		);
+		await awaitResult(handle, 60_000);
+	}
+
+	return { start, initialize, submit, awaitResult, cancel, health: currentHealth, close };
 }
 
 /**
@@ -621,6 +662,8 @@ export function createDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClien
 								: "dead";
 		return {
 			state,
+			initialization: maintenance.initialization,
+			databaseReady: maintenance.databaseReady,
 			pid: read.pid ?? maintenance.pid,
 			generation: Math.max(read.generation, maintenance.generation),
 			queuedJobs: read.queuedJobs + maintenance.queuedJobs,
@@ -634,6 +677,9 @@ export function createDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClien
 		async start(): Promise<void> {
 			if (closed) throw new DbOwnerError("DB_OWNER_CLOSED", "DB owner client is closed");
 			await Promise.all([readLane.start(), maintenanceLane.start()]);
+		},
+		async initialize(agentsDir?: string): Promise<void> {
+			await maintenanceLane.initialize(agentsDir);
 		},
 		submit<Result>(request: DbOwnerRequest, submitOptions: DbOwnerSubmitOptions): DbOwnerJobHandle<Result> {
 			return laneFor(submitOptions.lane).submit<Result>(request, submitOptions);

--- a/platform/daemon/src/db-owner-client.ts
+++ b/platform/daemon/src/db-owner-client.ts
@@ -127,7 +127,7 @@ export interface DbOwnerClientOptions {
 	readonly workerRole?: "generic" | "recall";
 }
 
-const DEFAULT_DB_OWNER_START_TIMEOUT_MS = 5_000;
+const DEFAULT_DB_OWNER_START_TIMEOUT_MS = 15_000;
 
 function resolveStartupTimeoutMs(options: DbOwnerClientOptions): number {
 	const configured = options.startupTimeoutMs ?? process.env.SIGNET_DB_OWNER_START_TIMEOUT_MS;

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -46,6 +46,11 @@ interface SqliteDatabase {
 	close(): void;
 }
 
+interface SqliteDatabaseConstructor {
+	new (path: string, options?: Record<string, unknown>): SqliteDatabase;
+	setCustomSQLite?: (path: string) => void;
+}
+
 const require = createRequire(import.meta.url);
 const Database = (
 	typeof (globalThis as Record<string, unknown>).Bun !== "undefined"
@@ -57,10 +62,7 @@ const Database = (
 					return require("better-sqlite3");
 				}
 			})()
-) as new (
-	path: string,
-	options?: Record<string, unknown>,
-) => SqliteDatabase;
+) as SqliteDatabaseConstructor;
 
 export function loadSqliteVecIfAvailable(db: SqliteDatabase, extension: string): boolean {
 	try {
@@ -88,10 +90,38 @@ export function runDbOwnerWorker(): void {
 	}, 250);
 	parentWatch.unref();
 
-	const db = new Database(dbPath);
-	db.exec("PRAGMA busy_timeout = 5000");
-	const vecExtension = findSqliteVecExtension();
-	if (vecExtension !== null) loadSqliteVecIfAvailable(db, vecExtension);
+	function send(event: DbOwnerEvent): void {
+		process.stdout.write(`${JSON.stringify(event)}\n`);
+	}
+
+	// Readiness attests only that the protocol channel is available. Database
+	// construction, custom SQLite selection, and extension loading are startup
+	// work owned by this process and must not delay the parent handshake.
+	send({ type: "ready", pid: process.pid });
+
+	const startupStarted = process.env.SIGNET_DB_OWNER_TEST_STARTUP_STARTED;
+	const startupRelease = process.env.SIGNET_DB_OWNER_TEST_STARTUP_RELEASE;
+	if (startupStarted !== undefined && startupRelease !== undefined) {
+		writeFileSync(startupStarted, "started\n");
+		const signal = new Int32Array(new SharedArrayBuffer(4));
+		while (!existsSync(startupRelease)) Atomics.wait(signal, 0, 0, 5);
+	}
+
+	const sqlitePath = process.env.SIGNET_DB_OWNER_SQLITE_PATH ?? process.env.SIGNET_SQLITE_PATH;
+	let db: SqliteDatabase;
+	try {
+		if (sqlitePath !== undefined && existsSync(sqlitePath) && typeof Database.setCustomSQLite === "function") {
+			Database.setCustomSQLite(sqlitePath);
+		}
+		db = new Database(dbPath);
+		db.exec("PRAGMA busy_timeout = 5000");
+		const vecExtension = findSqliteVecExtension();
+		if (vecExtension !== null) loadSqliteVecIfAvailable(db, vecExtension);
+	} catch (error) {
+		send({ type: "fatal", error: serializeError(error) });
+		process.exit(1);
+		return;
+	}
 
 	const BUSY_RETRIES = 3;
 	const BUSY_BACKOFF_MS = 50;
@@ -127,10 +157,6 @@ export function runDbOwnerWorker(): void {
 	const queue: DbOwnerJob[] = [];
 	let activeJobId: string | null = null;
 	let draining = false;
-
-	function send(event: DbOwnerEvent): void {
-		process.stdout.write(`${JSON.stringify(event)}\n`);
-	}
 
 	function bindParameter(value: DbOwnerParameter): unknown {
 		if (typeof value === "object" && value !== null && value.type === "bytes") {

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -526,7 +526,6 @@ export function runDbOwnerWorker(): void {
 		}
 	});
 
-	send({ type: "ready", pid: process.pid });
 	void activeJobId;
 }
 

--- a/platform/daemon/src/service.test.ts
+++ b/platform/daemon/src/service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { probeDaemonHealth } from "./service";
+import { generateLaunchdPlist, probeDaemonHealth } from "./service";
 
 describe("daemon service health probe (#1340)", () => {
 	it("uses the liveness endpoint with a bounded request", async () => {
@@ -28,5 +28,18 @@ describe("daemon service health probe (#1340)", () => {
 		});
 
 		expect(result).toEqual({ status: "degraded", uptime: null, pid: null });
+	});
+
+	it("copies the DB-owner startup timeout into the launchd plist", () => {
+		const previousTimeout = process.env.SIGNET_DB_OWNER_START_TIMEOUT_MS;
+		process.env.SIGNET_DB_OWNER_START_TIMEOUT_MS = "23000";
+		try {
+			const plist = generateLaunchdPlist();
+			expect(plist).toContain("<key>SIGNET_DB_OWNER_START_TIMEOUT_MS</key>");
+			expect(plist).toContain("<string>23000</string>");
+		} finally {
+			if (previousTimeout === undefined) Reflect.deleteProperty(process.env, "SIGNET_DB_OWNER_START_TIMEOUT_MS");
+			else process.env.SIGNET_DB_OWNER_START_TIMEOUT_MS = previousTimeout;
+		}
 	});
 });

--- a/platform/daemon/src/service.ts
+++ b/platform/daemon/src/service.ts
@@ -122,12 +122,14 @@ function getRuntime(): string {
 // macOS (launchd)
 // ============================================================================
 
-function generateLaunchdPlist(port: number = 3850): string {
+export function generateLaunchdPlist(port: number = 3850): string {
 	const daemonPath = getDaemonPath();
+	const startupTimeout = process.env.SIGNET_DB_OWNER_START_TIMEOUT_MS;
 	const environment = buildLaunchdEnvironment({
 		values: {
 			SIGNET_PORT: String(port),
 			SIGNET_PATH: AGENTS_DIR,
+			...(startupTimeout === undefined ? {} : { SIGNET_DB_OWNER_START_TIMEOUT_MS: startupTimeout }),
 		},
 	});
 	return buildLaunchdPlist({

--- a/web/docs/src/content/docs/configuration/security-lifecycle.md
+++ b/web/docs/src/content/docs/configuration/security-lifecycle.md
@@ -227,6 +227,7 @@ editing the config file is impractical.
 | `SIGNET_LOG_FILE` | — | Optional explicit daemon log file path |
 | `SIGNET_LOG_DIR` | `$SIGNET_WORKSPACE/.daemon/logs` | Optional daemon log directory override |
 | `SIGNET_SQLITE_PATH` | — | macOS explicit SQLite dylib override used before Bun opens the database |
+| `SIGNET_DB_OWNER_START_TIMEOUT_MS` | `5000` | DB-owner protocol startup deadline in ms. Readiness is published before database initialization; this remains a bounded fallback for worker launch failures |
 | `SIGNET_SESSION_START_TIMEOUT` | `15000` | Session-start daemon wait budget in ms for Signet-managed clients. Generated Claude Code hook config writes this value directly. Generated Codex hook config rounds up to seconds and adds 5 seconds of harness grace |
 | `SIGNET_FETCH_TIMEOUT` | `15000` | Legacy fallback for session-start timeout in ms when `SIGNET_SESSION_START_TIMEOUT` is unset |
 | `SIGNET_PROMPT_SUBMIT_TIMEOUT` | `5000` | Prompt-submit daemon wait budget in ms; OpenCode uses this value directly, generated Claude Code hook config writes this value + 2000 ms grace, and generated Codex hook config rounds up to seconds and adds 2 seconds of harness grace |
@@ -246,6 +247,12 @@ it is unset, Signet checks `$SIGNET_WORKSPACE/libsqlite3.dylib`, where
 `~/.config/signet/workspace.json`, then the default `~/.agents`, before
 trying standard Homebrew SQLite locations and finally falling back to
 Apple's system SQLite.
+
+`SIGNET_DB_OWNER_START_TIMEOUT_MS` only controls how long the daemon client
+waits for the owner process to publish its protocol handshake. The handshake
+does not wait for SQLite construction, migrations, or vector extension loading.
+Those operations remain inside the killable owner process and have their own
+job deadlines.
 
 For non-loopback Anthropic endpoint overrides, the daemon
 only sends provider credentials during startup preflight when the host

--- a/web/docs/src/content/docs/configuration/security-lifecycle.md
+++ b/web/docs/src/content/docs/configuration/security-lifecycle.md
@@ -227,7 +227,7 @@ editing the config file is impractical.
 | `SIGNET_LOG_FILE` | — | Optional explicit daemon log file path |
 | `SIGNET_LOG_DIR` | `$SIGNET_WORKSPACE/.daemon/logs` | Optional daemon log directory override |
 | `SIGNET_SQLITE_PATH` | — | macOS explicit SQLite dylib override used before Bun opens the database |
-| `SIGNET_DB_OWNER_START_TIMEOUT_MS` | `5000` | DB-owner protocol startup deadline in ms. Readiness is published before database initialization; this remains a bounded fallback for worker launch failures |
+| `SIGNET_DB_OWNER_START_TIMEOUT_MS` | `15000` | DB-owner protocol startup deadline in ms. Readiness is published before database initialization; this remains a bounded fallback for worker launch failures |
 | `SIGNET_SESSION_START_TIMEOUT` | `15000` | Session-start daemon wait budget in ms for Signet-managed clients. Generated Claude Code hook config writes this value directly. Generated Codex hook config rounds up to seconds and adds 5 seconds of harness grace |
 | `SIGNET_FETCH_TIMEOUT` | `15000` | Legacy fallback for session-start timeout in ms when `SIGNET_SESSION_START_TIMEOUT` is unset |
 | `SIGNET_PROMPT_SUBMIT_TIMEOUT` | `5000` | Prompt-submit daemon wait budget in ms; OpenCode uses this value directly, generated Claude Code hook config writes this value + 2000 ms grace, and generated Codex hook config rounds up to seconds and adds 2 seconds of harness grace |
@@ -253,6 +253,10 @@ waits for the owner process to publish its protocol handshake. The handshake
 does not wait for SQLite construction, migrations, or vector extension loading.
 Those operations remain inside the killable owner process and have their own
 job deadlines.
+
+When installing the macOS launchd service, set this variable in the environment
+used for `signet daemon install`; the generated plist copies it into the service
+environment.
 
 For non-loopback Anthropic endpoint overrides, the daemon
 only sends provider credentials during startup preflight when the host


### PR DESCRIPTION
## Summary

Fixes #1685 by separating the DB-owner IPC handshake from synchronous SQLite and vector initialization. The default handshake deadline is now 15000 ms, covering the reported 6264 ms compiled cold start with 8736 ms of margin. `SIGNET_DB_OWNER_START_TIMEOUT_MS` remains available for slower extremes and is copied into launchd-managed installs.

## Changes

- Publish DB-owner transport readiness before SQLite construction and sqlite-vec loading.
- Raise the default startup deadline from 5000 ms to 15000 ms.
- Add load-bearing timeout tests: a 50 ms override rejects a worker that readies after 100 ms, and garbage values reject with `DB_OWNER_START_TIMEOUT_INVALID`.
- Copy the timeout override into generated macOS launchd plists when set during installation, with documentation.
- Forward the resolved custom SQLite runtime into both generic and recall workers.
- Remove the vestigial duplicate DB-owner `ready` emission.
- Preserve fail-closed worker-construction and explicit transport/database lifecycle behavior.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/daemon`
- [ ] `@signet/core`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [x] Other: docs source only, under `web/docs`

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A. No schema migration was added.

## Testing

- `bun test platform/daemon/src/db-owner-client.test.ts -t 'publishes protocol readiness|startup deadline|garbage DB owner startup timeout'` — 3 pass
- `bun test platform/daemon/src/service.test.ts platform/core/src/launchd.test.ts` — 8 pass
- `bun test platform/daemon/src/daemon-auth-guard-colocation.test.ts` — 39 pass
- `bun run --filter '@signet/daemon' typecheck` — pass
- `bun run --filter '@signet/daemon' build` — pass
- `bun test ./tests/integration/acceptance/run.ts --smoke` — pass: 0 event-loop blocks over budget, `/health/live` p95 6 ms, `/api/status` p95 4 ms
- Full DB-owner suite: 22 pass, 1 pre-existing timing failure in `recall lane completes while maintenance lane is saturated` (existing 200 ms threshold; observed 215/222 ms)

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The DB-owner `ready` state means transport-ready; `databaseReady` and `initialization` expose the separate database lifecycle. The branch is rebased onto current `main` at `6fe75ccc9`.