### PR TITLE
fix: bound status and diagnostics projections

### DIFF
--- a/platform/core/src/migrations/138-bounded-status-projections.ts
+++ b/platform/core/src/migrations/138-bounded-status-projections.ts
@@ -1,0 +1,334 @@
+import type { MigrationDb } from "./index";
+
+function hasColumn(db: MigrationDb, table: string, column: string): boolean {
+	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<{ name?: unknown }>;
+	return rows.some((row) => row.name === column);
+}
+
+function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
+	if (!hasColumn(db, table, column)) db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+}
+
+/**
+ * Migration 138: bounded status projections for /api/status and diagnostics.
+ *
+ * The HTTP-serving isolate previously grouped transcript_capture_jobs and
+ * memories directly to calculate compact health fields. Those payload tables
+ * can be very large. This migration installs incrementally maintained
+ * projections, backfills them once in the migration/owner lane, and adds
+ * covering indexes for the remaining maintenance lookups.
+ */
+export function up(db: MigrationDb): void {
+	// A legitimate v1 database can reach this migration without the column
+	// that the baseline schema normally creates. Make this upgrade path safe
+	// before creating the partial index or triggers below.
+	addColumnIfMissing(db, "memories", "manual_override", "INTEGER DEFAULT 0");
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS transcript_capture_status (
+			agent_id TEXT PRIMARY KEY,
+			pending INTEGER NOT NULL DEFAULT 0,
+			processing INTEGER NOT NULL DEFAULT 0,
+			completed INTEGER NOT NULL DEFAULT 0,
+			failed INTEGER NOT NULL DEFAULT 0,
+			dead INTEGER NOT NULL DEFAULT 0,
+			oldest_pending_at TEXT,
+			last_error TEXT,
+			last_error_at TEXT
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_transcript_capture_jobs_agent_status_created_at
+			ON transcript_capture_jobs(agent_id, status, created_at);
+
+		CREATE INDEX IF NOT EXISTS idx_transcript_capture_jobs_error_updated_at
+			ON transcript_capture_jobs(agent_id, updated_at DESC)
+			WHERE error IS NOT NULL;
+
+		CREATE TABLE IF NOT EXISTS memories_duplicate_hash_counts (
+			content_hash TEXT PRIMARY KEY,
+			dup_count INTEGER NOT NULL
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_memories_dup_counts_active
+			ON memories_duplicate_hash_counts(dup_count)
+			WHERE dup_count > 1;
+
+		CREATE TABLE IF NOT EXISTS memories_diagnostics_state (
+			id INTEGER PRIMARY KEY CHECK (id = 1),
+			total_active INTEGER NOT NULL DEFAULT 0,
+			exact_duplicates INTEGER NOT NULL DEFAULT 0,
+			exact_clusters INTEGER NOT NULL DEFAULT 0
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_memories_active_hash_diagnostics
+			ON memories(content_hash)
+			WHERE is_deleted = 0
+			  AND content_hash IS NOT NULL
+			  AND pinned = 0
+			  AND manual_override = 0;
+	`);
+
+	db.exec(`
+		CREATE TRIGGER IF NOT EXISTS transcript_capture_status_ai
+		AFTER INSERT ON transcript_capture_jobs
+		BEGIN
+			INSERT INTO transcript_capture_status (agent_id)
+			VALUES (NEW.agent_id)
+			ON CONFLICT(agent_id) DO NOTHING;
+
+			UPDATE transcript_capture_status
+			 SET pending = pending + (NEW.status = 'pending'),
+			     processing = processing + (NEW.status = 'processing'),
+			     completed = completed + (NEW.status = 'completed'),
+			     failed = failed + (NEW.status = 'failed'),
+			     dead = dead + (NEW.status = 'dead')
+			 WHERE agent_id = NEW.agent_id;
+
+			UPDATE transcript_capture_status
+			 SET oldest_pending_at = (
+			     SELECT MIN(created_at) FROM transcript_capture_jobs
+			     WHERE agent_id = NEW.agent_id AND status = 'pending'
+			 )
+			 WHERE agent_id = NEW.agent_id;
+
+			UPDATE transcript_capture_status
+			 SET last_error = (
+			     SELECT error FROM transcript_capture_jobs
+			     WHERE agent_id = NEW.agent_id AND error IS NOT NULL
+			     ORDER BY updated_at DESC LIMIT 1
+			 ),
+			     last_error_at = (
+			     SELECT updated_at FROM transcript_capture_jobs
+			     WHERE agent_id = NEW.agent_id AND error IS NOT NULL
+			     ORDER BY updated_at DESC LIMIT 1
+			 )
+			 WHERE agent_id = NEW.agent_id
+			   AND NEW.error IS NOT NULL;
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS transcript_capture_status_au
+		AFTER UPDATE OF status, error, updated_at, created_at ON transcript_capture_jobs
+		BEGIN
+			UPDATE transcript_capture_status
+			 SET pending = pending + (NEW.status = 'pending') - (OLD.status = 'pending'),
+			     processing = processing + (NEW.status = 'processing') - (OLD.status = 'processing'),
+			     completed = completed + (NEW.status = 'completed') - (OLD.status = 'completed'),
+			     failed = failed + (NEW.status = 'failed') - (OLD.status = 'failed'),
+			     dead = dead + (NEW.status = 'dead') - (OLD.status = 'dead')
+			 WHERE agent_id = NEW.agent_id;
+
+			UPDATE transcript_capture_status
+			 SET oldest_pending_at = (
+			     SELECT MIN(created_at) FROM transcript_capture_jobs
+			     WHERE agent_id = NEW.agent_id AND status = 'pending'
+			 )
+			 WHERE agent_id = NEW.agent_id;
+
+			UPDATE transcript_capture_status
+			 SET last_error = (
+			     SELECT error FROM transcript_capture_jobs
+			     WHERE agent_id = NEW.agent_id AND error IS NOT NULL
+			     ORDER BY updated_at DESC LIMIT 1
+			 ),
+			     last_error_at = (
+			     SELECT updated_at FROM transcript_capture_jobs
+			     WHERE agent_id = NEW.agent_id AND error IS NOT NULL
+			     ORDER BY updated_at DESC LIMIT 1
+			 )
+			 WHERE agent_id = NEW.agent_id
+			   AND (NEW.error IS NOT NULL OR OLD.error IS NOT NULL);
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS transcript_capture_status_ad
+		AFTER DELETE ON transcript_capture_jobs
+		BEGIN
+			UPDATE transcript_capture_status
+			 SET pending = pending - (OLD.status = 'pending'),
+			     processing = processing - (OLD.status = 'processing'),
+			     completed = completed - (OLD.status = 'completed'),
+			     failed = failed - (OLD.status = 'failed'),
+			     dead = dead - (OLD.status = 'dead')
+			 WHERE agent_id = OLD.agent_id;
+
+			UPDATE transcript_capture_status
+			 SET oldest_pending_at = (
+			     SELECT MIN(created_at) FROM transcript_capture_jobs
+			     WHERE agent_id = OLD.agent_id AND status = 'pending'
+			 )
+			 WHERE agent_id = OLD.agent_id;
+
+			UPDATE transcript_capture_status
+			 SET last_error = (
+			     SELECT error FROM transcript_capture_jobs
+			     WHERE agent_id = OLD.agent_id AND error IS NOT NULL
+			     ORDER BY updated_at DESC LIMIT 1
+			 ),
+			     last_error_at = (
+			     SELECT updated_at FROM transcript_capture_jobs
+			     WHERE agent_id = OLD.agent_id AND error IS NOT NULL
+			     ORDER BY updated_at DESC LIMIT 1
+			 )
+			 WHERE agent_id = OLD.agent_id
+			   AND OLD.error IS NOT NULL;
+		END;
+	`);
+
+	db.exec(`
+		CREATE TRIGGER IF NOT EXISTS memories_dup_projection_ai
+		AFTER INSERT ON memories
+		BEGIN
+			UPDATE memories_diagnostics_state
+			 SET total_active = total_active + CASE WHEN NEW.is_deleted = 0 THEN 1 ELSE 0 END,
+			     exact_duplicates = exact_duplicates + CASE
+			       WHEN NEW.is_deleted = 0 AND NEW.content_hash IS NOT NULL
+			        AND NEW.pinned = 0 AND NEW.manual_override = 0
+			        AND COALESCE((SELECT dup_count FROM memories_duplicate_hash_counts WHERE content_hash = NEW.content_hash), 0) >= 1
+			       THEN 1 ELSE 0 END,
+			     exact_clusters = exact_clusters + CASE
+			       WHEN NEW.is_deleted = 0 AND NEW.content_hash IS NOT NULL
+			        AND NEW.pinned = 0 AND NEW.manual_override = 0
+			        AND COALESCE((SELECT dup_count FROM memories_duplicate_hash_counts WHERE content_hash = NEW.content_hash), 0) = 1
+			       THEN 1 ELSE 0 END
+			 WHERE id = 1;
+
+			INSERT INTO memories_duplicate_hash_counts (content_hash, dup_count)
+			 SELECT NEW.content_hash, 1
+			 WHERE NEW.is_deleted = 0
+			   AND NEW.content_hash IS NOT NULL
+			   AND NEW.pinned = 0
+			   AND NEW.manual_override = 0
+			 ON CONFLICT(content_hash) DO UPDATE SET dup_count = dup_count + 1;
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS memories_dup_projection_au
+		AFTER UPDATE OF is_deleted, content_hash, pinned, manual_override ON memories
+		BEGIN
+			UPDATE memories_diagnostics_state
+			 SET total_active = total_active
+			       + CASE WHEN NEW.is_deleted = 0 THEN 1 ELSE 0 END
+			       - CASE WHEN OLD.is_deleted = 0 THEN 1 ELSE 0 END,
+			     exact_duplicates = exact_duplicates - CASE
+			       WHEN OLD.is_deleted = 0 AND OLD.content_hash IS NOT NULL
+			        AND OLD.pinned = 0 AND OLD.manual_override = 0
+			        AND COALESCE((SELECT dup_count FROM memories_duplicate_hash_counts WHERE content_hash = OLD.content_hash), 0) > 1
+			       THEN 1 ELSE 0 END,
+			     exact_clusters = exact_clusters - CASE
+			       WHEN OLD.is_deleted = 0 AND OLD.content_hash IS NOT NULL
+			        AND OLD.pinned = 0 AND OLD.manual_override = 0
+			        AND COALESCE((SELECT dup_count FROM memories_duplicate_hash_counts WHERE content_hash = OLD.content_hash), 0) = 2
+			       THEN 1 ELSE 0 END
+			 WHERE id = 1;
+
+			UPDATE memories_duplicate_hash_counts
+			 SET dup_count = dup_count - 1
+			 WHERE OLD.is_deleted = 0
+			   AND OLD.content_hash IS NOT NULL
+			   AND OLD.pinned = 0
+			   AND OLD.manual_override = 0
+			   AND content_hash = OLD.content_hash;
+
+			DELETE FROM memories_duplicate_hash_counts
+			 WHERE content_hash = OLD.content_hash
+			   AND dup_count <= 0;
+
+			UPDATE memories_diagnostics_state
+			 SET exact_duplicates = exact_duplicates + CASE
+			       WHEN NEW.is_deleted = 0 AND NEW.content_hash IS NOT NULL
+			        AND NEW.pinned = 0 AND NEW.manual_override = 0
+			        AND COALESCE((SELECT dup_count FROM memories_duplicate_hash_counts WHERE content_hash = NEW.content_hash), 0) >= 1
+			       THEN 1 ELSE 0 END,
+			     exact_clusters = exact_clusters + CASE
+			       WHEN NEW.is_deleted = 0 AND NEW.content_hash IS NOT NULL
+			        AND NEW.pinned = 0 AND NEW.manual_override = 0
+			        AND COALESCE((SELECT dup_count FROM memories_duplicate_hash_counts WHERE content_hash = NEW.content_hash), 0) = 1
+			       THEN 1 ELSE 0 END
+			 WHERE id = 1;
+
+			INSERT INTO memories_duplicate_hash_counts (content_hash, dup_count)
+			 SELECT NEW.content_hash, 1
+			 WHERE NEW.is_deleted = 0
+			   AND NEW.content_hash IS NOT NULL
+			   AND NEW.pinned = 0
+			   AND NEW.manual_override = 0
+			 ON CONFLICT(content_hash) DO UPDATE SET dup_count = dup_count + 1;
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS memories_dup_projection_ad
+		AFTER DELETE ON memories
+		BEGIN
+			UPDATE memories_diagnostics_state
+			 SET total_active = total_active - CASE WHEN OLD.is_deleted = 0 THEN 1 ELSE 0 END,
+			     exact_duplicates = exact_duplicates - CASE
+			       WHEN OLD.is_deleted = 0 AND OLD.content_hash IS NOT NULL
+			        AND OLD.pinned = 0 AND OLD.manual_override = 0
+			        AND COALESCE((SELECT dup_count FROM memories_duplicate_hash_counts WHERE content_hash = OLD.content_hash), 0) > 1
+			       THEN 1 ELSE 0 END,
+			     exact_clusters = exact_clusters - CASE
+			       WHEN OLD.is_deleted = 0 AND OLD.content_hash IS NOT NULL
+			        AND OLD.pinned = 0 AND OLD.manual_override = 0
+			        AND COALESCE((SELECT dup_count FROM memories_duplicate_hash_counts WHERE content_hash = OLD.content_hash), 0) = 2
+			       THEN 1 ELSE 0 END
+			 WHERE id = 1;
+
+			UPDATE memories_duplicate_hash_counts
+			 SET dup_count = dup_count - 1
+			 WHERE OLD.is_deleted = 0
+			   AND OLD.content_hash IS NOT NULL
+			   AND OLD.pinned = 0
+			   AND OLD.manual_override = 0
+			   AND content_hash = OLD.content_hash;
+
+			DELETE FROM memories_duplicate_hash_counts
+			 WHERE content_hash = OLD.content_hash
+			   AND dup_count <= 0;
+		END;
+	`);
+
+	// Rebuild projections on every migration invocation so a repaired or
+	// partially-created projection cannot retain stale hashes or counters.
+	db.exec(`
+		DELETE FROM transcript_capture_status;
+		DELETE FROM memories_duplicate_hash_counts;
+		INSERT INTO memories_duplicate_hash_counts (content_hash, dup_count)
+		SELECT content_hash, COUNT(*)
+		 FROM memories
+		 WHERE is_deleted = 0
+		   AND content_hash IS NOT NULL
+		   AND pinned = 0
+		   AND manual_override = 0
+		 GROUP BY content_hash;
+
+		INSERT INTO memories_diagnostics_state (id, total_active, exact_duplicates, exact_clusters)
+		VALUES (
+			1,
+			(SELECT COUNT(*) FROM memories WHERE is_deleted = 0),
+			COALESCE((SELECT SUM(dup_count - 1) FROM memories_duplicate_hash_counts WHERE dup_count > 1), 0),
+			(SELECT COUNT(*) FROM memories_duplicate_hash_counts WHERE dup_count > 1)
+		)
+		ON CONFLICT(id) DO UPDATE SET
+			total_active = excluded.total_active,
+			exact_duplicates = excluded.exact_duplicates,
+			exact_clusters = excluded.exact_clusters;
+
+		INSERT INTO transcript_capture_status (
+			agent_id, pending, processing, completed, failed, dead,
+			oldest_pending_at, last_error, last_error_at
+		)
+		SELECT
+			j.agent_id,
+			SUM(j.status = 'pending'),
+			SUM(j.status = 'processing'),
+			SUM(j.status = 'completed'),
+			SUM(j.status = 'failed'),
+			SUM(j.status = 'dead'),
+			MIN(CASE WHEN j.status = 'pending' THEN j.created_at END),
+			(SELECT e2.error FROM transcript_capture_jobs e2
+			 WHERE e2.agent_id = j.agent_id AND e2.error IS NOT NULL
+			 ORDER BY e2.updated_at DESC LIMIT 1),
+			(SELECT e3.updated_at FROM transcript_capture_jobs e3
+			 WHERE e3.agent_id = j.agent_id AND e3.error IS NOT NULL
+			 ORDER BY e3.updated_at DESC LIMIT 1)
+		FROM transcript_capture_jobs j
+		GROUP BY j.agent_id;
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -143,6 +143,7 @@ import { up as scopeMemoryHeadEntries } from "./134-scope-memory-head-entries";
 import { up as memoryHeadPublication } from "./135-memory-head-publication";
 import { up as memoryHeadRevisions } from "./136-memory-head-revisions";
 import { up as dreamingHeadManifest } from "./137-dreaming-head-manifest";
+import { up as boundedStatusProjections } from "./138-bounded-status-projections";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1264,6 +1265,14 @@ export const MIGRATIONS: readonly Migration[] = [
 				{ table: "dreaming_passes", column: "head_revision" },
 				{ table: "dreaming_passes", column: "head_hash" },
 			],
+		},
+	},
+	{
+		version: 138,
+		name: "bounded-status-projections",
+		up: boundedStatusProjections,
+		artifacts: {
+			tables: ["transcript_capture_status", "memories_duplicate_hash_counts", "memories_diagnostics_state"],
 		},
 	},
 ];

--- a/platform/daemon/src/diagnostics.ts
+++ b/platform/daemon/src/diagnostics.ts
@@ -440,27 +440,30 @@ export function getMutationHealth(db: ReadDb): MutationHealth {
 }
 
 export function getDuplicateHealth(db: ReadDb): DuplicateHealth {
-	const dupRow = db
+	// Read the maintained one-row aggregate (migration 138) instead of
+	// grouping every active memory by content_hash on the HTTP-serving isolate
+	// (#1670). The hash-count table is only the mutation-side read model; this
+	// route performs one primary-key lookup and never scans either payload table
+	// or the distinct-hash projection.
+	const row = db
 		.prepare(
-			`SELECT
-				COALESCE(SUM(excess), 0) AS exact_dupes,
-				COUNT(*) AS exact_clusters
-			 FROM (
-				SELECT content_hash, COUNT(*) - 1 AS excess
-				FROM memories
-				WHERE is_deleted = 0 AND content_hash IS NOT NULL
-				  AND pinned = 0 AND manual_override = 0
-				GROUP BY content_hash
-				HAVING COUNT(*) > 1
-			 )`,
+			`SELECT total_active AS totalActive,
+			        exact_duplicates AS exactDuplicates,
+			        exact_clusters AS exactClusters
+			 FROM memories_diagnostics_state
+			 WHERE id = 1`,
 		)
-		.get() as { exact_dupes: number; exact_clusters: number } | undefined;
+		.get() as
+		| {
+				totalActive: number;
+				exactDuplicates: number;
+				exactClusters: number;
+		  }
+		| undefined;
 
-	const totalRow = db.prepare("SELECT COUNT(*) AS n FROM memories WHERE is_deleted = 0").get() as { n: number };
-
-	const totalActive = totalRow.n;
-	const exactDuplicates = dupRow?.exact_dupes ?? 0;
-	const exactClusters = dupRow?.exact_clusters ?? 0;
+	const totalActive = row?.totalActive ?? 0;
+	const exactDuplicates = row?.exactDuplicates ?? 0;
+	const exactClusters = row?.exactClusters ?? 0;
 	const duplicateRatio = totalActive > 0 ? exactDuplicates / totalActive : 0;
 
 	let score = 1.0;

--- a/platform/daemon/src/status-projection.test.ts
+++ b/platform/daemon/src/status-projection.test.ts
@@ -276,12 +276,17 @@ describe("transcript capture status projection (#1670)", () => {
 	it("reads no payload column on the status path", async () => {
 		await enqueue("agent-a", "s1", "2026-08-19T10:00:00.000Z");
 		// Proxy the ReadDb so every executed SQL string is observable. The
-		// bounded path must never touch transcript_capture_jobs.
+		// bounded path must never touch transcript_capture_jobs. Implement both
+		// get() and all() so the reverted implementation fails the intentional
+		// table-access assertion rather than a mock-shape TypeError.
 		let touchedJobsTable = false;
 		const sqlRecorder = {
-			prepare(sql: string): { get(...args: unknown[]): unknown } {
+			prepare(sql: string): {
+				get(...args: unknown[]): unknown;
+				all(...args: unknown[]): unknown[];
+			} {
 				if (sql.includes("transcript_capture_jobs")) touchedJobsTable = true;
-				return { get: () => ({}) };
+				return { get: () => null, all: () => [] };
 			},
 		};
 		const accessor = getDbAccessor();
@@ -340,17 +345,36 @@ describe("bounded status and diagnostics scale (#1670)", () => {
 			}
 		});
 
+		const median = (values: readonly number[]): number => {
+			const sorted = [...values].sort((left, right) => left - right);
+			return sorted[Math.floor(sorted.length / 2)] ?? Number.POSITIVE_INFINITY;
+		};
+		const measure = async <T>(operation: () => Promise<T>): Promise<{ value: T; elapsed: number }> => {
+			const started = performance.now();
+			const value = await operation();
+			return { value, elapsed: performance.now() - started };
+		};
+
+		// Keep a calibrated copy of the pre-#1670 aggregate in this same
+		// payload-heavy database. A timing-only assertion is too weak on a warm
+		// CI runner: the legacy scan can happen to finish under 50ms at this
+		// scale. The ratio assertion below makes the red/green discriminator
+		// explicit while the hard budget still protects the route contract.
+		const legacyStatusLatencies: number[] = [];
 		const statusLatencies: number[] = [];
 		let status = await getTranscriptCaptureStatus(accessor, "scale-agent");
-		for (let attempt = 0; attempt < 3; attempt += 1) {
-			const started = performance.now();
-			status = await getTranscriptCaptureStatus(accessor, "scale-agent");
-			statusLatencies.push(performance.now() - started);
+		for (let attempt = 0; attempt < 6; attempt += 1) {
+			const legacy = await measure(() => legacyStatusOracle("scale-agent"));
+			const projected = await measure(() => getTranscriptCaptureStatus(accessor, "scale-agent"));
+			legacyStatusLatencies.push(legacy.elapsed);
+			statusLatencies.push(projected.elapsed);
+			status = projected.value;
 		}
 		expect(status.pending).toBe(1_500);
 		expect(status.completed).toBe(500);
 		expect(status.failed).toBe(500);
 		expect(Math.max(...statusLatencies)).toBeLessThan(50);
+		expect(median(legacyStatusLatencies)).toBeGreaterThan(median(statusLatencies) * 2);
 
 		const { Hono } = await import("hono");
 		const { registerPipelineRoutes } = await import("./routes/pipeline-routes");
@@ -364,6 +388,16 @@ describe("bounded status and diagnostics scale (#1670)", () => {
 			httpStatusLatencies.push(performance.now() - started);
 		}
 		expect(Math.max(...httpStatusLatencies)).toBeLessThan(50);
+
+		const legacyDuplicateLatencies: number[] = [];
+		const duplicateLatencies: number[] = [];
+		for (let attempt = 0; attempt < 6; attempt += 1) {
+			const legacy = await measure(legacyDuplicateOracle);
+			const projected = await measure(() => accessor.withReadDbAsync((db) => getDuplicateHealth(db)));
+			legacyDuplicateLatencies.push(legacy.elapsed);
+			duplicateLatencies.push(projected.elapsed);
+		}
+		expect(median(legacyDuplicateLatencies)).toBeGreaterThan(median(duplicateLatencies) * 2);
 
 		const diagnosticsLatencies: number[] = [];
 		let diagnostics = await accessor.withReadDbAsync((db) =>
@@ -450,11 +484,16 @@ describe("duplicate health projection (#1670)", () => {
 		]);
 		let touchedMemoriesTable = false;
 		const sqlRecorder = {
-			prepare(sql: string): { get(...args: unknown[]): unknown } {
+			prepare(sql: string): {
+				get(...args: unknown[]): unknown;
+				all(...args: unknown[]): unknown[];
+			} {
 				if (/FROM\s+memories\b/.test(sql) && !sql.includes("memories_")) {
 					touchedMemoriesTable = true;
 				}
-				return { get: () => ({ exact_dupes: 0, exact_clusters: 0, n: 0 }) };
+				// Keep both statement methods implemented so reverting the fix
+				// reports the forbidden payload-table read, not a fake TypeError.
+				return { get: () => ({ totalActive: 0, exactDuplicates: 0, exactClusters: 0 }), all: () => [] };
 			},
 		};
 		getDuplicateHealth(sqlRecorder as unknown as Parameters<typeof getDuplicateHealth>[0]);

--- a/platform/daemon/src/status-projection.test.ts
+++ b/platform/daemon/src/status-projection.test.ts
@@ -1,0 +1,463 @@
+/**
+ * Regression coverage for #1670 (wedge 1): /api/status transcript capture
+ * status and diagnostics duplicate health must read bounded projections
+ * (migration 138), never aggregate the payload tables on the HTTP isolate.
+ *
+ * Each test compares the projection-backed readers against the exact legacy
+ * SQL so the response shape and values are provably unchanged, and one test
+ * asserts the read path never touches the payload table at all.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { createProviderTracker, getDiagnostics, getDuplicateHealth } from "./diagnostics";
+import {
+	enqueueTranscriptCaptureJob,
+	getTranscriptCaptureStatus,
+	runTranscriptCaptureOnce,
+	type TranscriptCaptureStatusSummary,
+} from "./transcript-capture-worker";
+
+let dir = "";
+let prevSignetPath: string | undefined;
+
+/** The exact pre-#1670 status derivation, kept as the oracle for the projection. */
+async function legacyStatusOracle(agentId: string | null): Promise<TranscriptCaptureStatusSummary> {
+	return getDbAccessor().withReadDbAsync((db) => {
+		const where = agentId ? "WHERE agent_id = ?" : "";
+		const params = agentId ? [agentId] : [];
+		const rows = db
+			.prepare(
+				`SELECT status, COUNT(*) AS count, MIN(CASE WHEN status = 'pending' THEN created_at END) AS oldest_pending
+				 FROM transcript_capture_jobs ${where}
+				 GROUP BY status`,
+			)
+			.all(...params) as Array<{ status: string; count: number; oldest_pending?: string | null }>;
+		const latestError = db
+			.prepare(
+				`SELECT error FROM transcript_capture_jobs ${where}${where ? " AND" : "WHERE"} error IS NOT NULL
+				 ORDER BY updated_at DESC LIMIT 1`,
+			)
+			.get(...params) as { error?: string | null } | undefined;
+		const summary = {
+			pending: 0,
+			processing: 0,
+			completed: 0,
+			failed: 0,
+			dead: 0,
+			oldestPendingAt: null as string | null,
+			lastError: latestError?.error ?? null,
+		};
+		for (const row of rows) {
+			const key = row.status as keyof Pick<
+				TranscriptCaptureStatusSummary,
+				"pending" | "processing" | "completed" | "failed" | "dead"
+			>;
+			if (key in summary) summary[key] = row.count;
+			if (row.oldest_pending) summary.oldestPendingAt = row.oldest_pending;
+		}
+		return summary;
+	});
+}
+
+/** The exact pre-#1670 duplicate derivation. */
+async function legacyDuplicateOracle(): Promise<{
+	exactDuplicates: number;
+	exactClusters: number;
+	totalActive: number;
+	duplicateRatio: number;
+}> {
+	return getDbAccessor().withReadDbAsync((db) => {
+		const dupRow = db
+			.prepare(
+				`SELECT
+					COALESCE(SUM(excess), 0) AS exact_dupes,
+					COUNT(*) AS exact_clusters
+				 FROM (
+					SELECT content_hash, COUNT(*) - 1 AS excess
+					FROM memories
+					WHERE is_deleted = 0 AND content_hash IS NOT NULL
+					  AND pinned = 0 AND manual_override = 0
+					GROUP BY content_hash
+					HAVING COUNT(*) > 1
+				 )`,
+			)
+			.get() as { exact_dupes: number; exact_clusters: number } | undefined;
+		const totalRow = db.prepare("SELECT COUNT(*) AS n FROM memories WHERE is_deleted = 0").get() as {
+			n: number;
+		};
+		const totalActive = totalRow.n;
+		const exactDuplicates = dupRow?.exact_dupes ?? 0;
+		const exactClusters = dupRow?.exact_clusters ?? 0;
+		return {
+			exactDuplicates,
+			exactClusters,
+			totalActive,
+			duplicateRatio: totalActive > 0 ? exactDuplicates / totalActive : 0,
+		};
+	});
+}
+
+interface MemorySeed {
+	readonly id: string;
+	readonly contentHash: string | null;
+	readonly pinned?: number;
+	readonly manualOverride?: number;
+	readonly isDeleted?: number;
+	readonly project?: string;
+}
+
+async function seedMemories(seeds: readonly MemorySeed[]): Promise<void> {
+	await getDbAccessor().withWriteTxAsync((db) => {
+		const insert = db.prepare(
+			`INSERT INTO memories
+				(id, content, content_hash, pinned, manual_override, is_deleted, type, agent_id,
+				 project, scope, visibility, created_at, updated_at, updated_by)
+			 VALUES (?, ?, ?, ?, ?, ?, 'fact', 'default', ?, 'global', 'global', ?, ?, 'test')`,
+		);
+		const now = new Date().toISOString();
+		for (const seed of seeds) {
+			insert.run(
+				seed.id,
+				`content ${seed.id}`,
+				seed.contentHash,
+				seed.pinned ?? 0,
+				seed.manualOverride ?? 0,
+				seed.isDeleted ?? 0,
+				seed.project ?? null,
+				now,
+				now,
+			);
+		}
+	});
+}
+
+function enqueue(
+	agentId: string,
+	sessionId: string,
+	capturedAt: string,
+	transcript = "User: turn\nAssistant: reply",
+): Promise<string | null> {
+	return enqueueTranscriptCaptureJob(getDbAccessor(), {
+		agentId,
+		harness: "pi",
+		sessionKey: `session-${sessionId}`,
+		sessionId: `snapshot-${sessionId}`,
+		project: "/repo",
+		transcript,
+		rawTranscript: transcript,
+		capturedAt,
+		endedAt: capturedAt,
+	});
+}
+
+beforeEach(() => {
+	prevSignetPath = process.env.SIGNET_PATH;
+	dir = mkdtempSync(join(tmpdir(), "signet-status-projection-"));
+	process.env.SIGNET_PATH = dir;
+	initDbAccessor(join(dir, "memory", "memories.db"));
+});
+
+afterEach(() => {
+	closeDbAccessor();
+	if (prevSignetPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
+	else process.env.SIGNET_PATH = prevSignetPath;
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("transcript capture status projection (#1670)", () => {
+	it("returns an all-zero summary for an agent with no projection row", async () => {
+		expect(await getTranscriptCaptureStatus(getDbAccessor(), "agent-none")).toEqual({
+			pending: 0,
+			processing: 0,
+			completed: 0,
+			failed: 0,
+			dead: 0,
+			oldestPendingAt: null,
+			lastError: null,
+		});
+	});
+
+	it("matches the legacy aggregate across a real enqueue/complete/fail workload", async () => {
+		await enqueue("agent-a", "s1", "2026-08-19T10:00:00.000Z");
+		await enqueue("agent-a", "s2", "2026-08-19T10:01:00.000Z");
+		await enqueue("agent-b", "s3", "2026-08-19T10:02:00.000Z");
+		expect(await runTranscriptCaptureOnce(getDbAccessor(), dir)).toBe(true);
+		expect(await runTranscriptCaptureOnce(getDbAccessor(), dir)).toBe(true);
+		expect(await runTranscriptCaptureOnce(getDbAccessor(), dir)).toBe(true);
+
+		// Terminal transition: agent-b's job exhausts its attempts.
+		await getDbAccessor().withWriteTxAsync((db) => {
+			db.prepare(
+				"UPDATE transcript_capture_jobs SET status = 'failed', attempts = max_attempts, error = 'boom' WHERE agent_id = 'agent-b'",
+			).run();
+		});
+
+		for (const agentId of ["agent-a", "agent-b", null]) {
+			expect(await getTranscriptCaptureStatus(getDbAccessor(), agentId)).toEqual(await legacyStatusOracle(agentId));
+		}
+		expect(await getTranscriptCaptureStatus(getDbAccessor(), "agent-a")).toMatchObject({
+			completed: 2,
+			pending: 0,
+			lastError: null,
+		});
+	});
+
+	it("keeps oldest pending and latest error aligned with the legacy query through state churn", async () => {
+		await enqueue("agent-a", "older", "2026-08-19T09:00:00.000Z");
+		await enqueue("agent-a", "newer", "2026-08-19T11:00:00.000Z");
+		await getDbAccessor().withWriteTxAsync((db) => {
+			db.prepare(
+				"UPDATE transcript_capture_jobs SET status = 'failed', error = 'later failure', updated_at = '2026-08-19T12:00:00.000Z' WHERE session_key = 'session-newer'",
+			).run();
+			db.prepare(
+				"UPDATE transcript_capture_jobs SET status = 'failed', error = 'earlier failure', updated_at = '2026-08-19T08:00:00.000Z' WHERE session_key = 'session-older'",
+			).run();
+		});
+
+		const projected = await getTranscriptCaptureStatus(getDbAccessor(), "agent-a");
+		expect(projected).toEqual(await legacyStatusOracle("agent-a"));
+		expect(projected.lastError).toBe("later failure");
+		expect(projected.oldestPendingAt).toBeNull();
+
+		// Retention-style purge of terminal rows must decrement the projection.
+		await getDbAccessor().withWriteTxAsync((db) => {
+			db.prepare("DELETE FROM transcript_capture_jobs WHERE status = 'failed'").run();
+		});
+		const afterPurge = await getTranscriptCaptureStatus(getDbAccessor(), "agent-a");
+		expect(afterPurge).toEqual(await legacyStatusOracle("agent-a"));
+		expect(afterPurge).toMatchObject({ failed: 0, lastError: null });
+	});
+
+	it("aggregates across agents for the daemon-wide summary", async () => {
+		await enqueue("agent-a", "s1", "2026-08-19T10:00:00.000Z");
+		await enqueue("agent-b", "s2", "2026-08-19T09:30:00.000Z");
+		const projected = await getTranscriptCaptureStatus(getDbAccessor());
+		expect(projected).toEqual(await legacyStatusOracle(null));
+		expect(projected.pending).toBe(2);
+		// enqueue stamps created_at at delivery time; the daemon-wide summary
+		// must surface the earliest of those per-agent projection values.
+		const earliest = await getDbAccessor().withReadDbAsync((db) =>
+			db.prepare("SELECT MIN(created_at) AS oldest FROM transcript_capture_jobs WHERE status = 'pending'").get(),
+		);
+		expect(projected.oldestPendingAt).toBe((earliest as { oldest: string | null }).oldest);
+	});
+
+	it("revives dead jobs through the enqueue upsert without corrupting counters", async () => {
+		const input = {
+			agentId: "agent-a",
+			harness: "pi",
+			sessionKey: "session-revive",
+			sessionId: "snapshot-revive",
+			project: "/repo",
+			transcript: "User: revive",
+			rawTranscript: "revive",
+			capturedAt: "2026-08-19T10:00:00.000Z",
+			endedAt: "2026-08-19T10:00:00.000Z",
+		} as const;
+		const id = await enqueueTranscriptCaptureJob(getDbAccessor(), input);
+		expect(id).toBeTruthy();
+		await getDbAccessor().withWriteTxAsync((db) => {
+			db.prepare(
+				"UPDATE transcript_capture_jobs SET status = 'dead', attempts = max_attempts, error = 'gave up' WHERE id = ?",
+			).run(id);
+		});
+		expect((await getTranscriptCaptureStatus(getDbAccessor(), "agent-a")).dead).toBe(1);
+		// The production revive path reuses the same INSERT ... ON CONFLICT.
+		expect(await enqueueTranscriptCaptureJob(getDbAccessor(), input)).toBe(id);
+		const revived = await getTranscriptCaptureStatus(getDbAccessor(), "agent-a");
+		expect(revived).toEqual(await legacyStatusOracle("agent-a"));
+		expect(revived).toMatchObject({ dead: 0, pending: 1, lastError: null });
+	});
+
+	it("reads no payload column on the status path", async () => {
+		await enqueue("agent-a", "s1", "2026-08-19T10:00:00.000Z");
+		// Proxy the ReadDb so every executed SQL string is observable. The
+		// bounded path must never touch transcript_capture_jobs.
+		let touchedJobsTable = false;
+		const sqlRecorder = {
+			prepare(sql: string): { get(...args: unknown[]): unknown } {
+				if (sql.includes("transcript_capture_jobs")) touchedJobsTable = true;
+				return { get: () => ({}) };
+			},
+		};
+		const accessor = getDbAccessor();
+		const recordingAccessor = {
+			...accessor,
+			withReadDbAsync: (fn: (db: unknown) => unknown): Promise<unknown> => Promise.resolve(fn(sqlRecorder)),
+		} as unknown as Parameters<typeof getTranscriptCaptureStatus>[0];
+		await getTranscriptCaptureStatus(recordingAccessor, "agent-a");
+		expect(touchedJobsTable).toBe(false);
+	});
+});
+
+describe("bounded status and diagnostics scale (#1670)", () => {
+	it("keeps the route readers under 50ms with large inline payloads", async () => {
+		const accessor = getDbAccessor();
+		const rowCount = 2_500;
+		const transcriptPayload = "transcript payload ".repeat(512);
+		const memoryPayload = "memory payload ".repeat(512);
+		await accessor.withWriteTxAsync((db) => {
+			const insertJob = db.prepare(
+				`INSERT INTO transcript_capture_jobs
+					(id, agent_id, harness, session_key, session_id, project, transcript, raw_transcript,
+					 captured_at, ended_at, summary_status, status, attempts, max_attempts, created_at, updated_at, error)
+				 VALUES (?, 'scale-agent', 'pi', ?, ?, '/scale', ?, ?, ?, ?, 'not_requested', ?, 0, 5, ?, ?, ?)`,
+			);
+			const insertMemory = db.prepare(
+				`INSERT INTO memories
+					(id, content, content_hash, pinned, manual_override, is_deleted, type, agent_id,
+					 project, scope, visibility, created_at, updated_at, updated_by)
+				 VALUES (?, ?, ?, 0, 0, 0, 'fact', 'scale-agent', ?, 'global', 'global', ?, ?, 'test')`,
+			);
+			for (let index = 0; index < rowCount; index += 1) {
+				const timestamp = `2026-08-19T00:${String(index % 60).padStart(2, "0")}:00.000Z`;
+				const status = index % 5 === 0 ? "failed" : index % 5 === 1 ? "completed" : "pending";
+				insertJob.run(
+					`scale-job-${index}`,
+					`scale-session-${index}`,
+					`scale-snapshot-${index}`,
+					transcriptPayload,
+					transcriptPayload,
+					timestamp,
+					timestamp,
+					status,
+					timestamp,
+					timestamp,
+					status === "failed" ? `failure-${index}` : null,
+				);
+				insertMemory.run(
+					`scale-memory-${index}`,
+					memoryPayload,
+					`scale-hash-${index}`,
+					`/scale/${index}`,
+					timestamp,
+					timestamp,
+				);
+			}
+		});
+
+		const statusLatencies: number[] = [];
+		let status = await getTranscriptCaptureStatus(accessor, "scale-agent");
+		for (let attempt = 0; attempt < 3; attempt += 1) {
+			const started = performance.now();
+			status = await getTranscriptCaptureStatus(accessor, "scale-agent");
+			statusLatencies.push(performance.now() - started);
+		}
+		expect(status.pending).toBe(1_500);
+		expect(status.completed).toBe(500);
+		expect(status.failed).toBe(500);
+		expect(Math.max(...statusLatencies)).toBeLessThan(50);
+
+		const { Hono } = await import("hono");
+		const { registerPipelineRoutes } = await import("./routes/pipeline-routes");
+		const app = new Hono();
+		registerPipelineRoutes(app);
+		expect((await app.request("http://localhost/api/status")).status).toBe(200);
+		const httpStatusLatencies: number[] = [];
+		for (let attempt = 0; attempt < 3; attempt += 1) {
+			const started = performance.now();
+			expect((await app.request("http://localhost/api/status")).status).toBe(200);
+			httpStatusLatencies.push(performance.now() - started);
+		}
+		expect(Math.max(...httpStatusLatencies)).toBeLessThan(50);
+
+		const diagnosticsLatencies: number[] = [];
+		let diagnostics = await accessor.withReadDbAsync((db) =>
+			getDiagnostics(db, createProviderTracker(), undefined, undefined, { graphEnabled: false }),
+		);
+		for (let attempt = 0; attempt < 3; attempt += 1) {
+			const started = performance.now();
+			diagnostics = await accessor.withReadDbAsync((db) =>
+				getDiagnostics(db, createProviderTracker(), undefined, undefined, { graphEnabled: false }),
+			);
+			diagnosticsLatencies.push(performance.now() - started);
+		}
+		expect(diagnostics.duplicate.totalActive).toBe(rowCount);
+		expect(diagnostics.duplicate.exactDuplicates).toBe(0);
+		expect(diagnostics.duplicate.exactClusters).toBe(0);
+		expect(Math.max(...diagnosticsLatencies)).toBeLessThan(50);
+	});
+});
+
+describe("duplicate health projection (#1670)", () => {
+	it("matches the legacy duplicate aggregate across pin/delete/rehash churn", async () => {
+		// Distinct (agent, scope, project) tuples so the unique content-hash
+		// index permits duplicate hashes across scope boundaries.
+		await seedMemories([
+			{ id: "m1", contentHash: "h1", project: "p1" },
+			{ id: "m2", contentHash: "h1", project: "p2" },
+			{ id: "m3", contentHash: "h1", project: "p3" },
+			{ id: "m4", contentHash: "h2", project: "p1" },
+			{ id: "m5", contentHash: null, project: "p1" },
+			{ id: "m6", contentHash: "h3", pinned: 1, project: "p1" },
+			{ id: "m7", contentHash: "h3", project: "p2" },
+			{ id: "m8", contentHash: "h4", isDeleted: 1, project: "p1" },
+			{ id: "m9", contentHash: "h4", manualOverride: 1, project: "p1" },
+			{ id: "m10", contentHash: "h4", project: "p2" },
+		]);
+		const accessor = getDbAccessor();
+		const read = async (): Promise<ReturnType<typeof getDuplicateHealth>> =>
+			await accessor.withReadDbAsync((db) => getDuplicateHealth(db));
+
+		const baseline = await read();
+		expect(baseline).toMatchObject(await legacyDuplicateOracle());
+
+		// Pin one duplicate: h1 drops from 3 eligible to 2.
+		await accessor.withWriteTxAsync((db) => {
+			db.prepare("UPDATE memories SET pinned = 1 WHERE id = 'm2'").run();
+		});
+		expect(await read()).toMatchObject(await legacyDuplicateOracle());
+
+		// Soft-delete another: h1 leaves the duplicate set entirely.
+		await accessor.withWriteTxAsync((db) => {
+			db.prepare("UPDATE memories SET is_deleted = 1 WHERE id = 'm3'").run();
+		});
+		expect(await read()).toMatchObject(await legacyDuplicateOracle());
+
+		// Rehash: m1 moves from h1 to h9.
+		await accessor.withWriteTxAsync((db) => {
+			db.prepare("UPDATE memories SET content_hash = 'h9' WHERE id = 'm1'").run();
+		});
+		expect(await read()).toMatchObject(await legacyDuplicateOracle());
+
+		// Hard delete (retention purge).
+		await accessor.withWriteTxAsync((db) => {
+			db.prepare("DELETE FROM memories WHERE id = 'm4'").run();
+		});
+		expect(await read()).toMatchObject(await legacyDuplicateOracle());
+
+		// New duplicate pair on h5.
+		await seedMemories([
+			{ id: "m11", contentHash: "h5", project: "p1" },
+			{ id: "m12", contentHash: "h5", project: "p2" },
+		]);
+		const finalHealth = await read();
+		const oracle = await legacyDuplicateOracle();
+		expect(finalHealth.exactDuplicates).toBe(oracle.exactDuplicates);
+		expect(finalHealth.exactClusters).toBe(oracle.exactClusters);
+		expect(finalHealth.totalActive).toBe(oracle.totalActive);
+		expect(finalHealth.duplicateRatio).toBe(oracle.duplicateRatio);
+	});
+
+	it("reads no memories payload row on the duplicate-health path", async () => {
+		await seedMemories([
+			{ id: "m1", contentHash: "h1", project: "p1" },
+			{ id: "m2", contentHash: "h1", project: "p2" },
+		]);
+		let touchedMemoriesTable = false;
+		const sqlRecorder = {
+			prepare(sql: string): { get(...args: unknown[]): unknown } {
+				if (/FROM\s+memories\b/.test(sql) && !sql.includes("memories_")) {
+					touchedMemoriesTable = true;
+				}
+				return { get: () => ({ exact_dupes: 0, exact_clusters: 0, n: 0 }) };
+			},
+		};
+		getDuplicateHealth(sqlRecorder as unknown as Parameters<typeof getDuplicateHealth>[0]);
+		expect(touchedMemoriesTable).toBe(false);
+	});
+});

--- a/platform/daemon/src/transcript-capture-worker.ts
+++ b/platform/daemon/src/transcript-capture-worker.ts
@@ -408,44 +408,81 @@ export async function startTranscriptCaptureWorker(
 	};
 }
 
+interface TranscriptStatusProjectionRow {
+	readonly pending: number;
+	readonly processing: number;
+	readonly completed: number;
+	readonly failed: number;
+	readonly dead: number;
+	readonly oldestPendingAt: string | null;
+	readonly lastError: string | null;
+}
+
+const EMPTY_TRANSCRIPT_STATUS: TranscriptCaptureStatusSummary = {
+	pending: 0,
+	processing: 0,
+	completed: 0,
+	failed: 0,
+	dead: 0,
+	oldestPendingAt: null,
+	lastError: null,
+};
+
+function projectionRowToSummary(row: TranscriptStatusProjectionRow): TranscriptCaptureStatusSummary {
+	return {
+		pending: row.pending,
+		processing: row.processing,
+		completed: row.completed,
+		failed: row.failed,
+		dead: row.dead,
+		oldestPendingAt: row.oldestPendingAt ?? null,
+		lastError: row.lastError ?? null,
+	};
+}
+
+/**
+ * Bounded capture status for /api/status and health surfaces.
+ *
+ * Reads the `transcript_capture_status` projection (migration 138), which
+ * triggers maintain on every job mutation. The previous implementation
+ * grouped `transcript_capture_jobs` — whose rows carry full transcript
+ * payloads inline — directly on the HTTP-serving isolate, which wedged the
+ * parent event loop on production-scale databases (#1670). Both reads here
+ * are bounded: one projection row by primary key, or a SUM over the tiny
+ * one-row-per-agent projection table. Same fields, same values, cheap source.
+ */
 export async function getTranscriptCaptureStatus(
 	dbAccessor: DbAccessor,
 	agentId?: string | null,
 ): Promise<TranscriptCaptureStatusSummary> {
 	return await dbAccessor.withReadDbAsync(async (db) => {
-		const where = agentId ? "WHERE agent_id = ?" : "";
-		const params = agentId ? [agentId] : [];
-		const rows = db
-			.prepare(
-				`SELECT status, COUNT(*) AS count, MIN(CASE WHEN status = 'pending' THEN created_at END) AS oldest_pending
-				 FROM transcript_capture_jobs ${where}
-				 GROUP BY status`,
-			)
-			.all(...params) as Array<{ status: string; count: number; oldest_pending?: string | null }>;
-		const latestError = db
-			.prepare(
-				`SELECT error FROM transcript_capture_jobs ${where}${where ? " AND" : "WHERE"} error IS NOT NULL
-				 ORDER BY updated_at DESC LIMIT 1`,
-			)
-			.get(...params) as { error?: string | null } | undefined;
-		const summary = {
-			pending: 0,
-			processing: 0,
-			completed: 0,
-			failed: 0,
-			dead: 0,
-			oldestPendingAt: null as string | null,
-			lastError: latestError?.error ?? null,
-		};
-		for (const row of rows) {
-			const key = row.status as keyof Pick<
-				TranscriptCaptureStatusSummary,
-				"pending" | "processing" | "completed" | "failed" | "dead"
-			>;
-			if (key in summary) summary[key] = row.count;
-			if (row.oldest_pending) summary.oldestPendingAt = row.oldest_pending;
+		if (agentId) {
+			const row = db
+				.prepare(
+					`SELECT pending, processing, completed, failed, dead,
+					        oldest_pending_at AS oldestPendingAt, last_error AS lastError
+					 FROM transcript_capture_status
+					 WHERE agent_id = ?`,
+				)
+				.get(agentId) as TranscriptStatusProjectionRow | undefined;
+			// bun:sqlite returns null (not undefined) for a missing row.
+			return row == null ? EMPTY_TRANSCRIPT_STATUS : projectionRowToSummary(row);
 		}
-		return summary;
+		const row = db
+			.prepare(
+				`SELECT COALESCE(SUM(pending), 0) AS pending,
+				        COALESCE(SUM(processing), 0) AS processing,
+				        COALESCE(SUM(completed), 0) AS completed,
+				        COALESCE(SUM(failed), 0) AS failed,
+				        COALESCE(SUM(dead), 0) AS dead,
+				        MIN(oldest_pending_at) AS oldestPendingAt,
+				        (SELECT last_error FROM transcript_capture_status
+				         WHERE last_error_at IS NOT NULL
+				         ORDER BY last_error_at DESC LIMIT 1) AS lastError
+				 FROM transcript_capture_status`,
+			)
+			.get() as TranscriptStatusProjectionRow | undefined;
+		return row == null ? EMPTY_TRANSCRIPT_STATUS : projectionRowToSummary(row);
 	});
 }
 


### PR DESCRIPTION
## Summary

- add migration 138 with maintained transcript-capture and duplicate-health projections
- switch `/api/status` and duplicate diagnostics reads to bounded projection queries
- add migration compatibility/backfill coverage and a payload-scale regression test for #1670

## Changes

- `@signet/core`: migration 138 creates and backfills the projection tables, indexes, and maintenance triggers
- `@signet/daemon`: `/api/status` transcript status and duplicate diagnostics use bounded read-model queries
- Added red-on-parent/green-on-fix regression coverage with large inline transcript and memory payloads

## Type

- [x] `fix` — bug fix
- [x] `perf` — performance improvement
- [x] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`

## Screenshots

N/A: no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

The error/fallback check is covered by migration backfill/idempotence tests and zero-value fallback assertions when a projection row is absent. Security and input/config checks are not applicable to these read-only, internally maintained projections; no admin or mutation endpoint was changed. The API response shape is unchanged and the implementation comments document the status projection contract.

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Rollback / compatibility note included in PR description

Migration 138 is append-only and rebuilds its projections from existing source tables on each migration invocation. It adds the legacy `memories.manual_override` column when absent before creating dependent indexes/triggers, supports fresh and upgraded databases, and backfills existing transcript jobs and memories. The projections can be rebuilt from `transcript_capture_jobs` and `memories`; the source tables and API response shapes remain unchanged.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Verified locally with:

- `bun test platform/core/src/migrations/migrations.test.ts` (69 pass, 0 fail)
- `bun test platform/daemon/src/status-projection.test.ts` (9 pass, 0 fail)
- `bun test platform/daemon/src/transcript-capture-worker.test.ts platform/daemon/src/diagnostics.test.ts platform/daemon/src/daemon-status.test.ts` (46 pass, 12 skipped, 0 fail)
- `bun run --filter "@signet/core" build`
- `bun run --filter "@signet/daemon" build`
- Biome check and `git diff --check`

The scale test inserts 2,500 transcript jobs and 2,500 memory rows with large inline payloads, exercises the direct readers and real `/api/status`, and enforces a 50ms per-call budget. The restored parent implementation fails the payload-table access assertion.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- No API version or response-shape changes.
- No new synchronous DB access sites were added.
- Fixes #1670