### PR TITLE
fix: preserve semantic recall without sqlite-vec

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,16 +4,16 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 1000 sites
+- Exact ledger inventory: 1002 sites
 - Synchronous `withWriteTx()` sites: 66
 - Synchronous `withReadDb()` sites: 109
-- Async-named parent DB sites: 309
+- Async-named parent DB sites: 311
 - Synchronous filesystem/process sites: 516
 - Compile-visible legacy DB sites remaining: 175
   - `withWriteTx`: 66
   - `withReadDb`: 109
 
-The 1,000-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named parent DB callbacks. The 66 synchronous writes, 109 synchronous reads, and 309 async-named parent DB sites are the complete database-call inventory; 175 compatibility DB operations remain transitional callers for the later migration phase. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 1,002-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named parent DB callbacks. The 66 synchronous writes, 109 synchronous reads, and 311 async-named parent DB sites are the complete database-call inventory; 175 compatibility DB operations remain transitional callers for the later migration phase. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## A3 Slice 2 migration notes
 

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -221,6 +221,7 @@ export {
 export {
 	search,
 	vectorSearch,
+	vectorSearchWithMetadata,
 	keywordSearch,
 	hybridSearch,
 	cosineSimilarity,
@@ -228,6 +229,8 @@ export {
 	type SearchOptions,
 	type SearchResult,
 	type VectorSearchOptions,
+	type VectorSearchCompleteness,
+	type VectorSearchResponse,
 	type HybridSearchOptions,
 } from "./search";
 export {

--- a/platform/core/src/search.test.ts
+++ b/platform/core/src/search.test.ts
@@ -6,6 +6,36 @@ import { join } from "node:path";
 import { findSqliteVecExtension } from "./database";
 import { vectorSearch } from "./search";
 
+describe("vector search fallback", () => {
+	it("returns bounded cosine matches when sqlite-vec is unavailable", () => {
+		const raw = new Database(":memory:");
+		raw.exec(`
+			CREATE TABLE memories (id TEXT PRIMARY KEY, type TEXT, source_type TEXT);
+			CREATE TABLE embeddings (
+				id TEXT PRIMARY KEY,
+				source_id TEXT NOT NULL,
+				dimensions INTEGER NOT NULL,
+				vector BLOB
+			);
+			INSERT INTO memories VALUES ('memory-fact', 'fact', NULL), ('memory-other', 'other', NULL), ('memory-aggregate', 'fact', 'aggregate-recall');
+		`);
+		const insert = raw.prepare("INSERT INTO embeddings VALUES (?, ?, ?, ?)");
+		insert.run("embedding-fact", "memory-fact", 3, new Float32Array([1, 0, 0]));
+		insert.run("embedding-other", "memory-other", 3, new Float32Array([0, 1, 0]));
+		insert.run("embedding-aggregate", "memory-aggregate", 3, new Float32Array([1, 0, 0]));
+
+		expect(
+			vectorSearch(raw, new Float32Array([1, 0, 0]), {
+				limit: 2,
+				type: "fact",
+				excludeAggregateRecall: true,
+				maxScanRows: 10,
+			}),
+		).toEqual([{ id: "memory-fact", score: 1 }]);
+		raw.close();
+	});
+});
+
 describe("vector search during embedding projection cutover", () => {
 	it("joins the consistent old view during rebuild and the new view after completion", () => {
 		const extension = findSqliteVecExtension();

--- a/platform/core/src/search.test.ts
+++ b/platform/core/src/search.test.ts
@@ -33,8 +33,37 @@ describe("vector search fallback", () => {
 			}),
 		).toEqual([{ id: "memory-fact", score: 1 }]);
 		const metadata = vectorSearchWithMetadata(raw, new Float32Array([1, 0, 0]), { maxScanRows: 10 });
-		expect(metadata.completeness).toBe("recent-window");
-		expect(metadata.searchedWindow).toBe(10);
+		expect(metadata.completeness).toBe("complete");
+		expect(metadata.searchedWindow).toBeUndefined();
+		raw.close();
+	});
+
+	it("reports a bounded window only when an extra row proves truncation", () => {
+		const raw = new Database(":memory:");
+		raw.exec(`
+			CREATE TABLE memories (id TEXT PRIMARY KEY, type TEXT, source_type TEXT);
+			CREATE TABLE embeddings (
+				id TEXT PRIMARY KEY,
+				source_id TEXT NOT NULL,
+				dimensions INTEGER NOT NULL,
+				vector BLOB
+			);
+			INSERT INTO memories VALUES ('memory-old', 'fact', NULL), ('memory-new', 'fact', NULL);
+		`);
+		const insert = raw.prepare("INSERT INTO embeddings VALUES (?, ?, ?, ?)");
+		insert.run("embedding-old", "memory-old", 3, new Float32Array([1, 0, 0]));
+		insert.run("embedding-new", "memory-new", 3, new Float32Array([1, 0, 0]));
+
+		const exactCap = vectorSearchWithMetadata(raw, new Float32Array([1, 0, 0]), { maxScanRows: 2 });
+		expect(exactCap.completeness).toBe("complete");
+		expect(exactCap.searchedWindow).toBeUndefined();
+
+		raw.exec("INSERT INTO memories VALUES ('memory-latest', 'fact', NULL)");
+		insert.run("embedding-latest", "memory-latest", 3, new Float32Array([1, 0, 0]));
+		const truncated = vectorSearchWithMetadata(raw, new Float32Array([1, 0, 0]), { maxScanRows: 2 });
+		expect(truncated.completeness).toBe("recent-window");
+		expect(truncated.searchedWindow).toBe(2);
+		expect(truncated.results.map((row) => row.id)).toEqual(["memory-latest", "memory-new"]);
 		raw.close();
 	});
 

--- a/platform/core/src/search.test.ts
+++ b/platform/core/src/search.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { findSqliteVecExtension } from "./database";
-import { vectorSearch } from "./search";
+import { vectorSearch, vectorSearchWithMetadata } from "./search";
 
 describe("vector search fallback", () => {
 	it("returns bounded cosine matches when sqlite-vec is unavailable", () => {
@@ -32,6 +32,29 @@ describe("vector search fallback", () => {
 				maxScanRows: 10,
 			}),
 		).toEqual([{ id: "memory-fact", score: 1 }]);
+		const metadata = vectorSearchWithMetadata(raw, new Float32Array([1, 0, 0]), { maxScanRows: 10 });
+		expect(metadata.completeness).toBe("recent-window");
+		expect(metadata.searchedWindow).toBe(10);
+		raw.close();
+	});
+
+	it("skips a truncated vector blob instead of scoring its prefix", () => {
+		const raw = new Database(":memory:");
+		raw.exec(`
+			CREATE TABLE memories (id TEXT PRIMARY KEY, type TEXT, source_type TEXT);
+			CREATE TABLE embeddings (
+				id TEXT PRIMARY KEY,
+				source_id TEXT NOT NULL,
+				dimensions INTEGER NOT NULL,
+				vector BLOB
+			);
+			INSERT INTO memories VALUES ('memory-truncated', 'fact', NULL);
+		`);
+		raw
+			.prepare("INSERT INTO embeddings VALUES (?, ?, ?, ?)")
+			.run("embedding-truncated", "memory-truncated", 3, new Float32Array([1]));
+
+		expect(vectorSearch(raw, new Float32Array([1, 0, 0]), { limit: 1, maxScanRows: 10 })).toEqual([]);
 		raw.close();
 	});
 });

--- a/platform/core/src/search.ts
+++ b/platform/core/src/search.ts
@@ -200,7 +200,8 @@ function boundedCosineFallback(
 		predicates.push("COALESCE(m.source_type, '') != 'aggregate-recall'");
 	}
 	// Fetch one sentinel row so an exact-cap result is distinguishable from a
-	// truncated recent window without a second count query.
+	// truncated recent window without a second count query. This keeps the
+	// completeness metadata accurate when the eligible set fits the cap.
 	params.push(maxScanRows + 1);
 
 	const rows = db

--- a/platform/core/src/search.ts
+++ b/platform/core/src/search.ts
@@ -34,6 +34,8 @@ export interface VectorSearchOptions {
 	limit?: number;
 	type?: string;
 	excludeAggregateRecall?: boolean;
+	/** Maximum canonical embedding rows to inspect when sqlite-vec is unavailable. */
+	maxScanRows?: number;
 }
 
 export interface HybridSearchOptions {
@@ -172,12 +174,54 @@ function activeVectorSearchTables(db: SQLiteDatabase): VectorSearchTables {
 	}
 }
 
+function boundedCosineFallback(
+	db: SQLiteDatabase,
+	queryVector: Float32Array,
+	searchTables: VectorSearchTables,
+	options: VectorSearchOptions,
+): Array<{ id: string; score: number }> {
+	const limit = options.limit ?? 20;
+	const maxScanRows = Math.max(1, Math.min(options.maxScanRows ?? 10_000, 10_000));
+	const params: unknown[] = [queryVector.length];
+	const predicates = ["e.vector IS NOT NULL", "e.dimensions = ?"];
+	if (options.type) {
+		predicates.push("m.type = ?");
+		params.push(options.type);
+	}
+	if (options.excludeAggregateRecall) {
+		predicates.push("COALESCE(m.source_type, '') != 'aggregate-recall'");
+	}
+	params.push(maxScanRows);
+
+	const rows = db
+		.prepare(
+			`SELECT e.source_id, e.vector
+			 FROM ${searchTables.embeddings} e
+			 JOIN memories m ON e.source_id = m.id
+			 WHERE ${predicates.join(" AND ")}
+			 ORDER BY e.rowid DESC
+			 LIMIT ?`,
+		)
+		.all(...params) as Array<{ source_id: string; vector: Buffer | null }>;
+
+	return rows
+		.flatMap((row) => {
+			if (!row.vector || row.vector.byteLength === 0 || row.vector.byteLength % 4 !== 0) return [];
+			const memory = new Float32Array(row.vector.buffer, row.vector.byteOffset, row.vector.byteLength / 4);
+			const score = Math.max(0, Math.min(1, cosineSimilarity(queryVector, memory)));
+			return score > 0 ? [{ id: row.source_id, score }] : [];
+		})
+		.sort((a, b) => b.score - a.score)
+		.slice(0, limit);
+}
+
 export function vectorSearch(
 	db: SQLiteDatabase,
 	queryVector: Float32Array,
 	options?: VectorSearchOptions,
 ): Array<{ id: string; score: number }> {
-	const limit = options?.limit ?? 20;
+	const effectiveOptions = options ?? {};
+	const limit = effectiveOptions.limit ?? 20;
 	const results: Array<{ id: string; score: number }> = [];
 
 	try {
@@ -186,7 +230,7 @@ export function vectorSearch(
 			// sqlite-vec uses MATCH syntax for vector search
 			// The query vector must be serialized as a blob
 			const queryBlob = new Float32Array(queryVector);
-			const maxK = options?.excludeAggregateRecall ? Math.max(limit, Math.min(limit * 8, 1000)) : limit;
+			const maxK = effectiveOptions.excludeAggregateRecall ? Math.max(limit, Math.min(limit * 8, 1000)) : limit;
 			let k = limit;
 
 			while (true) {
@@ -195,11 +239,11 @@ export function vectorSearch(
 
 				// Build type filter if specified
 				let typeFilter = "";
-				if (options?.type) {
+				if (effectiveOptions.type) {
 					typeFilter = " AND m.type = ?";
-					params.push(options.type);
+					params.push(effectiveOptions.type);
 				}
-				if (options?.excludeAggregateRecall) {
+				if (effectiveOptions.excludeAggregateRecall) {
 					typeFilter += " AND COALESCE(m.source_type, '') != 'aggregate-recall'";
 				}
 
@@ -225,13 +269,21 @@ export function vectorSearch(
 					const similarity = 1 - row.distance;
 					results.push({ id: row.source_id, score: Math.max(0, similarity) });
 				}
-				if (results.length >= limit || k >= maxK || (!options?.excludeAggregateRecall && rows.length < k)) break;
+				if (results.length >= limit || k >= maxK || (!effectiveOptions.excludeAggregateRecall && rows.length < k))
+					break;
 				k = Math.min(k * 2, maxK);
 			}
 		});
 	} catch (e) {
-		// Vector search may fail if no embeddings exist or vec table unavailable
-		console.warn("Vector search failed:", e);
+		// macOS Bun may use Apple's SQLite build, which omits loadExtension().
+		// Keep semantic recall functional by scanning a bounded canonical-vector
+		// window instead of silently reducing the request to keyword-only recall.
+		try {
+			const searchTables = activeVectorSearchTables(db);
+			return boundedCosineFallback(db, queryVector, searchTables, effectiveOptions);
+		} catch (fallbackError) {
+			console.warn("Vector search failed, including bounded cosine fallback:", fallbackError, e);
+		}
 	}
 
 	return results;

--- a/platform/core/src/search.ts
+++ b/platform/core/src/search.ts
@@ -132,6 +132,14 @@ interface VectorSearchTables {
 	readonly embeddings: "embeddings" | "embeddings_staging";
 }
 
+export type VectorSearchCompleteness = "complete" | "recent-window" | "unavailable";
+
+export interface VectorSearchResponse {
+	readonly results: Array<{ id: string; score: number }>;
+	readonly completeness: VectorSearchCompleteness;
+	readonly searchedWindow?: number;
+}
+
 function withReadTransaction(db: SQLiteDatabase, read: () => void): void {
 	if (db.exec === undefined) {
 		read();
@@ -206,8 +214,8 @@ function boundedCosineFallback(
 
 	return rows
 		.flatMap((row) => {
-			if (!row.vector || row.vector.byteLength === 0 || row.vector.byteLength % 4 !== 0) return [];
-			const memory = new Float32Array(row.vector.buffer, row.vector.byteOffset, row.vector.byteLength / 4);
+			if (!row.vector || row.vector.byteLength !== queryVector.length * 4) return [];
+			const memory = blobToVector(row.vector);
 			const score = Math.max(0, Math.min(1, cosineSimilarity(queryVector, memory)));
 			return score > 0 ? [{ id: row.source_id, score }] : [];
 		})
@@ -215,11 +223,11 @@ function boundedCosineFallback(
 		.slice(0, limit);
 }
 
-export function vectorSearch(
+export function vectorSearchWithMetadata(
 	db: SQLiteDatabase,
 	queryVector: Float32Array,
 	options?: VectorSearchOptions,
-): Array<{ id: string; score: number }> {
+): VectorSearchResponse {
 	const effectiveOptions = options ?? {};
 	const limit = effectiveOptions.limit ?? 20;
 	const results: Array<{ id: string; score: number }> = [];
@@ -279,14 +287,31 @@ export function vectorSearch(
 		// Keep semantic recall functional by scanning a bounded canonical-vector
 		// window instead of silently reducing the request to keyword-only recall.
 		try {
-			const searchTables = activeVectorSearchTables(db);
-			return boundedCosineFallback(db, queryVector, searchTables, effectiveOptions);
+			let fallbackResults: Array<{ id: string; score: number }> = [];
+			withReadTransaction(db, () => {
+				const searchTables = activeVectorSearchTables(db);
+				fallbackResults = boundedCosineFallback(db, queryVector, searchTables, effectiveOptions);
+			});
+			return {
+				results: fallbackResults,
+				completeness: "recent-window",
+				searchedWindow: Math.max(1, Math.min(effectiveOptions.maxScanRows ?? 10_000, 10_000)),
+			};
 		} catch (fallbackError) {
 			console.warn("Vector search failed, including bounded cosine fallback:", fallbackError, e);
+			return { results: [], completeness: "unavailable" };
 		}
 	}
 
-	return results;
+	return { results, completeness: "complete" };
+}
+
+export function vectorSearch(
+	db: SQLiteDatabase,
+	queryVector: Float32Array,
+	options?: VectorSearchOptions,
+): Array<{ id: string; score: number }> {
+	return vectorSearchWithMetadata(db, queryVector, options).results;
 }
 
 /**

--- a/platform/core/src/search.ts
+++ b/platform/core/src/search.ts
@@ -187,7 +187,7 @@ function boundedCosineFallback(
 	queryVector: Float32Array,
 	searchTables: VectorSearchTables,
 	options: VectorSearchOptions,
-): Array<{ id: string; score: number }> {
+): VectorSearchResponse {
 	const limit = options.limit ?? 20;
 	const maxScanRows = Math.max(1, Math.min(options.maxScanRows ?? 10_000, 10_000));
 	const params: unknown[] = [queryVector.length];
@@ -199,7 +199,9 @@ function boundedCosineFallback(
 	if (options.excludeAggregateRecall) {
 		predicates.push("COALESCE(m.source_type, '') != 'aggregate-recall'");
 	}
-	params.push(maxScanRows);
+	// Fetch one sentinel row so an exact-cap result is distinguishable from a
+	// truncated recent window without a second count query.
+	params.push(maxScanRows + 1);
 
 	const rows = db
 		.prepare(
@@ -211,8 +213,9 @@ function boundedCosineFallback(
 			 LIMIT ?`,
 		)
 		.all(...params) as Array<{ source_id: string; vector: Buffer | null }>;
-
-	return rows
+	const truncated = rows.length > maxScanRows;
+	const scannedRows = truncated ? rows.slice(0, maxScanRows) : rows;
+	const results = scannedRows
 		.flatMap((row) => {
 			if (!row.vector || row.vector.byteLength !== queryVector.length * 4) return [];
 			const memory = blobToVector(row.vector);
@@ -221,6 +224,12 @@ function boundedCosineFallback(
 		})
 		.sort((a, b) => b.score - a.score)
 		.slice(0, limit);
+
+	return {
+		results,
+		completeness: truncated ? "recent-window" : "complete",
+		...(truncated ? { searchedWindow: maxScanRows } : {}),
+	};
 }
 
 export function vectorSearchWithMetadata(
@@ -287,16 +296,12 @@ export function vectorSearchWithMetadata(
 		// Keep semantic recall functional by scanning a bounded canonical-vector
 		// window instead of silently reducing the request to keyword-only recall.
 		try {
-			let fallbackResults: Array<{ id: string; score: number }> = [];
+			let fallbackResponse: VectorSearchResponse | undefined;
 			withReadTransaction(db, () => {
 				const searchTables = activeVectorSearchTables(db);
-				fallbackResults = boundedCosineFallback(db, queryVector, searchTables, effectiveOptions);
+				fallbackResponse = boundedCosineFallback(db, queryVector, searchTables, effectiveOptions);
 			});
-			return {
-				results: fallbackResults,
-				completeness: "recent-window",
-				searchedWindow: Math.max(1, Math.min(effectiveOptions.maxScanRows ?? 10_000, 10_000)),
-			};
+			return fallbackResponse ?? { results: [], completeness: "unavailable" };
 		} catch (fallbackError) {
 			console.warn("Vector search failed, including bounded cosine fallback:", fallbackError, e);
 			return { results: [], completeness: "unavailable" };

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -678,7 +678,7 @@ function loadVecExtension(db: SqliteDatabase): void {
 		if (!vecExtPath) {
 			vecLoaded = false;
 			vecLoadError = "sqlite-vec extension not found";
-			console.warn("[db-accessor] sqlite-vec extension not found — vector search disabled");
+			console.warn("[db-accessor] sqlite-vec extension not found — using bounded canonical-vector fallback");
 		}
 	}
 	if (vecExtPath) {

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -222,6 +222,11 @@ export type DbOwnerRequest =
 			/** Serialized recall inputs. The owner reconstructs no daemon callbacks. */
 			readonly payload: DbOwnerRecallPayload;
 	  }
+	| {
+			readonly kind: "vector_search";
+			/** The owner performs the potentially expensive cosine scan. */
+			readonly payload: DbOwnerVectorSearchPayload;
+	  }
 	| { readonly kind: "source_snapshot_import"; readonly input: DbOwnerSourceSnapshotImport }
 	| { readonly kind: "source_graph_index"; readonly input: DbOwnerSourceGraphIndex }
 	| { readonly kind: "source_graph_file_purge"; readonly input: DbOwnerSourceGraphFilePurge }
@@ -244,6 +249,16 @@ export interface DbOwnerRecallPayload {
 	readonly query?: string;
 	/** Precomputed embedding for callers that already own the embedding boundary. */
 	readonly queryEmbedding?: readonly number[] | null;
+}
+
+export interface DbOwnerVectorSearchPayload {
+	readonly queryEmbedding: readonly number[];
+	readonly options?: {
+		readonly limit?: number;
+		readonly type?: string;
+		readonly excludeAggregateRecall?: boolean;
+		readonly maxScanRows?: number;
+	};
 }
 
 export interface DbOwnerJob {

--- a/platform/daemon/src/db-owner-recall.test.ts
+++ b/platform/daemon/src/db-owner-recall.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { createDbOwnerClient } from "./db-owner-client";
-import { hybridRecallThroughDbOwner } from "./db-owner-recall";
+import { vectorSearchThroughDbOwner, hybridRecallThroughDbOwner } from "./db-owner-recall";
 import { type ResolvedMemoryConfig, loadMemoryConfig } from "./memory-config";
 import { hybridRecall, type RecallResponse } from "./memory-search";
 
@@ -97,6 +97,35 @@ describe("DB owner recall lane", () => {
 			const routed = await hybridRecallThroughDbOwner(client, params, cfg, { queryEmbedding: null });
 			expect(comparable(routed)).toEqual(comparable(direct));
 			expect(routed.results.map((result) => result.id)).not.toContain("owner-fact-other-agent");
+		} finally {
+			await client.close();
+		}
+	});
+
+	test("executes vector scoring in the recall owner lane", async () => {
+		directory = mkdtempSync(join(tmpdir(), "signet-db-owner-vector-search-"));
+		previousSignetPath = process.env.SIGNET_PATH;
+		mkdirSync(join(directory, "memory"), { recursive: true });
+		writeFileSync(join(directory, "agent.yaml"), "name: DbOwnerVectorSearchTest\n");
+		process.env.SIGNET_PATH = directory;
+		const databasePath = join(directory, "memory", "memories.db");
+		initDbAccessor(databasePath);
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories (id, content, type, agent_id, visibility, created_at, updated_at, updated_by)
+				 VALUES (?, ?, 'fact', 'agent-a', 'global', datetime('now'), datetime('now'), 'test')`,
+			).run("owner-vector-fact", "owner vector fixture");
+			db.prepare(
+				"INSERT INTO embeddings (content_hash, source_id, source_type, vector, dimensions, chunk_text, created_at) VALUES (?, ?, 'memory', ?, ?, '', datetime('now'))",
+			).run("owner-vector-hash", "owner-vector-fact", new Float32Array([1, 0, 0]), 3);
+		});
+		closeDbAccessor();
+
+		const client = createDbOwnerClient({ dbPath: databasePath, workerRole: "recall" });
+		try {
+			const result = await vectorSearchThroughDbOwner(client, [1, 0, 0], { limit: 1, maxScanRows: 10 });
+			expect(result.results).toEqual([{ id: "owner-vector-fact", score: 1 }]);
+			expect(["complete", "recent-window"]).toContain(result.completeness);
 		} finally {
 			await client.close();
 		}

--- a/platform/daemon/src/db-owner-recall.ts
+++ b/platform/daemon/src/db-owner-recall.ts
@@ -1,5 +1,7 @@
 import type { DbOwnerClient } from "./db-owner-client";
 import type { DbOwnerParameter } from "./db-owner-protocol";
+import { DB_OWNER_MAX_WORK_UNITS } from "./db-owner-protocol";
+import type { VectorSearchOptions, VectorSearchResponse } from "@signet/core";
 import type { RecallParams, RecallResponse } from "./memory-search";
 import type { ResolvedMemoryConfig } from "./memory-config";
 
@@ -44,6 +46,31 @@ export async function hybridRecallThroughDbOwner(
 			lane: "read",
 			deadlineMs: options.deadlineMs ?? 30_000,
 			estimatedWorkUnits: Math.max(1, Math.min(10_000, (params.limit ?? 10) * 100)),
+		},
+	);
+	return await client.awaitResult(handle);
+}
+
+/** Execute vector scoring, including the bounded fallback scan, in the owner. */
+export async function vectorSearchThroughDbOwner(
+	client: DbOwnerClient,
+	queryEmbedding: readonly number[],
+	options: VectorSearchOptions = {},
+): Promise<VectorSearchResponse> {
+	const maxScanRows = Math.max(1, Math.min(options.maxScanRows ?? DB_OWNER_MAX_WORK_UNITS, DB_OWNER_MAX_WORK_UNITS));
+	const handle = client.submit<VectorSearchResponse>(
+		{
+			kind: "vector_search",
+			payload: {
+				queryEmbedding,
+				options: { ...options, maxScanRows },
+			},
+		},
+		{
+			operation: "recall.vector-search",
+			lane: "read",
+			deadlineMs: 30_000,
+			estimatedWorkUnits: maxScanRows,
 		},
 	);
 	return await client.awaitResult(handle);

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import type { Database as BunDatabase } from "bun:sqlite";
-import { findSqliteVecExtension } from "@signet/core";
+import { findSqliteVecExtension, vectorSearchWithMetadata } from "@signet/core";
 import {
 	applyObsidianSourceStructureInTx,
 	applyObsidianSourceStructurePurgeInTx,
@@ -22,6 +22,7 @@ import type {
 	DbOwnerRecallPayload,
 	DbOwnerStatement,
 	DbOwnerNativeMemoryIndex,
+	DbOwnerVectorSearchPayload,
 } from "./db-owner-protocol";
 import type { EmbeddingConfig } from "./memory-config";
 import { vectorToBlob } from "./db-helpers";
@@ -736,6 +737,21 @@ export function runDbOwnerWorker(): void {
 		);
 	}
 
+	async function executeVectorSearch(payload: DbOwnerVectorSearchPayload): Promise<unknown> {
+		if (process.env.SIGNET_DB_OWNER_RECALL_WORKER !== "1") {
+			throw new Error("DB owner vector-search jobs require a recall worker");
+		}
+		if (!recallAccessorReady) {
+			const { initDbAccessorAsync } = await import("./db-accessor");
+			await initDbAccessorAsync(ownerDbPath);
+			recallAccessorReady = true;
+		}
+		const { getDbAccessor } = await import("./db-accessor");
+		return await getDbAccessor().withReadDbAsync((db) =>
+			vectorSearchWithMetadata(db, new Float32Array(payload.queryEmbedding), payload.options),
+		);
+	}
+
 	async function executeInitialization(agentsDir: string | undefined, context?: JobExecutionContext): Promise<unknown> {
 		const startedMarker = process.env.SIGNET_DB_OWNER_TEST_INIT_STARTED;
 		const releaseMarker = process.env.SIGNET_DB_OWNER_TEST_INIT_RELEASE;
@@ -767,6 +783,7 @@ export function runDbOwnerWorker(): void {
 		if (job.request.kind === "source_snapshot_import") return executeSourceSnapshotImport(job.request, context);
 		if (job.request.kind === "source_artifact_upsert" || job.request.kind === "source_artifact_upsert_batch")
 			return executeSourceArtifactUpsert(job.request, context);
+		if (job.request.kind === "vector_search") return await executeVectorSearch(job.request.payload);
 		if (
 			job.request.kind === "source_graph_index" ||
 			job.request.kind === "source_graph_file_purge" ||

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -92,7 +92,7 @@ export function loadSqliteVecIfAvailable(db: SqliteDatabase, extension: string):
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		console.warn(
-			`sqlite-vec extension could not be loaded on ${process.platform}: ${message}; continuing without vec, KNN recall is degraded`,
+			`sqlite-vec extension could not be loaded on ${process.platform}: ${message}; continuing with bounded canonical-vector fallback, KNN throughput is degraded`,
 		);
 		return false;
 	}

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -716,7 +716,7 @@ export function runDbOwnerWorker(): void {
 		}
 		const embedding = await getDbAccessor().withReadDbAsync(
 			async (db) => resolveActiveEmbeddingConfig(db, config.embedding),
-			{ siteToken: "db-owner-worker.ts:716" },
+			{ siteToken: "db-owner-worker.ts:717" },
 		);
 		const query = payload.query;
 		const queryEmbedding =
@@ -747,8 +747,9 @@ export function runDbOwnerWorker(): void {
 			recallAccessorReady = true;
 		}
 		const { getDbAccessor } = await import("./db-accessor");
-		return await getDbAccessor().withReadDbAsync((db) =>
-			vectorSearchWithMetadata(db, new Float32Array(payload.queryEmbedding), payload.options),
+		return await getDbAccessor().withReadDbAsync(
+			(db) => vectorSearchWithMetadata(db, new Float32Array(payload.queryEmbedding), payload.options),
+			{ siteToken: "db-owner-worker.ts:750" },
 		);
 	}
 

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -23,7 +23,8 @@ import {
 	type RecallTemporalMeta,
 	SOURCE_CHUNK_SOURCE_TYPE,
 	scanMemoryContent,
-	vectorSearch,
+	vectorSearchWithMetadata,
+	type VectorSearchCompleteness,
 } from "@signet/core";
 import { normalizeAndHashContent } from "./content-normalization";
 import { type ReadDb, getDbAccessor, runWriteTxAsync, prepareTypedStatement } from "./db-accessor";
@@ -141,6 +142,10 @@ export interface RecallResponse {
 		totalReturned: number;
 		hasSupplementary: boolean;
 		noHits: boolean;
+		/** Completeness of the semantic vector channel, when it ran. */
+		vectorCompleteness?: VectorSearchCompleteness;
+		/** Maximum canonical rows inspected by a bounded fallback scan. */
+		searchedWindow?: number;
 		/**
 		 * True when lexical coverage is known incomplete because FTS rows are
 		 * missing. The response remains successful and may contain bounded bridge
@@ -1718,6 +1723,8 @@ export async function hybridRecall(
 	// This keeps constrained queries eligible for vector similarity when graph
 	// traversal yields no focal entities.
 	const vectorMap = new Map<string, number>();
+	let vectorCompleteness: VectorSearchCompleteness | undefined;
+	let searchedWindow: number | undefined;
 	if (queryVecF32) {
 		const queryVector = queryVecF32;
 		const excludeAggregateRecall = params.aggregate === true || params.excludeAggregateRecallMemories === true;
@@ -1726,13 +1733,15 @@ export async function hybridRecall(
 			timings.timeAsync("vector_search", async () => {
 				await getDbAccessor().withReadDbAsync(
 					async (db) => {
-						const vecResults = vectorSearch(db, queryVector, {
+						const vectorResult = vectorSearchWithMetadata(db, queryVector, {
 							limit: vecLimit,
 							type: params.type,
 							excludeAggregateRecall,
 							maxScanRows: DB_OWNER_MAX_WORK_UNITS,
 						});
-						for (const r of vecResults) {
+						vectorCompleteness = vectorResult.completeness;
+						searchedWindow = vectorResult.searchedWindow;
+						for (const r of vectorResult.results) {
 							vectorMap.set(r.id, r.score);
 						}
 					},
@@ -2631,6 +2640,8 @@ export async function hybridRecall(
 				totalReturned: results.length,
 				hasSupplementary: results.some((row) => row.supplementary === true),
 				noHits: results.length === 0,
+				...(vectorCompleteness === undefined ? {} : { vectorCompleteness }),
+				...(searchedWindow === undefined ? {} : { searchedWindow }),
 			},
 		});
 	}
@@ -3130,6 +3141,8 @@ export async function hybridRecall(
 			totalReturned: results.length,
 			hasSupplementary: results.some((row) => row.supplementary === true),
 			noHits: results.length === 0,
+			...(vectorCompleteness === undefined ? {} : { vectorCompleteness }),
+			...(searchedWindow === undefined ? {} : { searchedWindow }),
 			...(temporal.meta ? { temporal: temporal.meta } : {}),
 		},
 		entities: entityContext && entityContext.length > 0 ? entityContext : undefined,

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -635,7 +635,7 @@ async function applyRehearsalBoost(
 					last_accessed: string | null;
 					created_at: string;
 				}>,
-			{ siteToken: "memory-search.ts:619" },
+			{ siteToken: "memory-search.ts:624" },
 		);
 
 		const accessMap = new Map(accessRows.map((r) => [r.id, r]));
@@ -811,7 +811,7 @@ async function authorizeScoredCandidates(
 			}
 			return allowed;
 		},
-		{ siteToken: "memory-search.ts:769" },
+		{ siteToken: "memory-search.ts:774" },
 	);
 	return scored.filter((row) => allowed.has(row.id));
 }
@@ -833,7 +833,7 @@ async function loadObservedScores(ids: readonly string[], agentId: string): Prom
 				.all(agentId, ...ids) as Array<{ memory_id: string; score: number }>;
 			return new Map(rows.map((row) => [row.memory_id, row.score]));
 		},
-		{ siteToken: "memory-search.ts:817" },
+		{ siteToken: "memory-search.ts:822" },
 	);
 }
 
@@ -883,7 +883,7 @@ async function loadCurrentnessInfo(ids: readonly string[], agentId: string): Pro
 					(row.replacement_content === null || scanMemoryContent(row.replacement_content).contextEligible),
 			);
 		},
-		{ siteToken: "memory-search.ts:851" },
+		{ siteToken: "memory-search.ts:856" },
 	);
 
 	const mutable = new Map<
@@ -1091,7 +1091,7 @@ async function buildSourceChunkVectorHits(
 					.sort((a, b) => b.score - a.score)
 					.slice(0, limit);
 			},
-			{ siteToken: "memory-search.ts:1035" },
+			{ siteToken: "memory-search.ts:1040" },
 		);
 	} catch (e) {
 		logger.warn("memory", "Source chunk vector recall failed (non-fatal)", {
@@ -1331,7 +1331,7 @@ async function buildNativeArtifactRecallHits(
 					}))
 					.filter((row) => row.content.length > 0 && !existingSourceIds.has(nativeArtifactPublicId(row)));
 			},
-			{ siteToken: "memory-search.ts:1209" },
+			{ siteToken: "memory-search.ts:1214" },
 		);
 	} catch (e) {
 		logger.warn("memory", "Native artifact recall failed (non-fatal)", {
@@ -1573,7 +1573,7 @@ export async function hybridRecall(
 					queryTokens: getGraphQueryTokens(),
 					includePinned: false,
 				}),
-			{ siteToken: "memory-search.ts:1565" },
+			{ siteToken: "memory-search.ts:1570" },
 		);
 		focalCache = { agentId, value };
 		return value;
@@ -1642,7 +1642,7 @@ export async function hybridRecall(
 					// Min-max normalize BM25 scores to [0,1] within the batch
 					addFtsScores(ftsRows);
 				},
-				{ siteToken: "memory-search.ts:1585" },
+				{ siteToken: "memory-search.ts:1590" },
 			);
 		});
 	} catch (e) {
@@ -1693,7 +1693,7 @@ export async function hybridRecall(
 							hintMap.set(row.id, Math.max(hintMap.get(row.id) ?? 0, hint));
 						}
 					},
-					{ siteToken: "memory-search.ts:1664" },
+					{ siteToken: "memory-search.ts:1669" },
 				);
 			});
 		} catch (e) {
@@ -1745,7 +1745,7 @@ export async function hybridRecall(
 							vectorMap.set(r.id, r.score);
 						}
 					},
-					{ siteToken: "memory-search.ts:1727" },
+					{ siteToken: "memory-search.ts:1734" },
 				);
 			});
 		} catch (e) {
@@ -1777,7 +1777,7 @@ export async function hybridRecall(
 								filterSql: filter.sql,
 								filterArgs: filter.args,
 							}),
-						{ siteToken: "memory-search.ts:1762" },
+						{ siteToken: "memory-search.ts:1772" },
 					),
 			);
 			for (const [id, score] of candidates) structuredCandidateMap.set(id, score);
@@ -1798,7 +1798,7 @@ export async function hybridRecall(
 									limit: cfg.search.top_k,
 									minScore,
 								}),
-							{ siteToken: "memory-search.ts:1785" },
+							{ siteToken: "memory-search.ts:1795" },
 						),
 				);
 			} catch (e) {
@@ -1894,7 +1894,7 @@ export async function hybridRecall(
 								focal.entityIds,
 								(readFn) =>
 									getDbAccessor().withReadDbAsync(readFn, {
-										siteToken: "memory-search.ts:1886",
+										siteToken: "memory-search.ts:1896",
 										operation: "memory.graph-traversal",
 									}),
 								agentId,
@@ -1931,7 +1931,7 @@ export async function hybridRecall(
 											source_id: string;
 											vector: Buffer | null;
 										}>,
-									{ siteToken: "memory-search.ts:1913" },
+									{ siteToken: "memory-search.ts:1923" },
 								);
 								const qv = queryVecF32;
 								for (const row of embRows) {
@@ -2010,7 +2010,7 @@ export async function hybridRecall(
 					async () =>
 						await getDbAccessor().withReadDbAsync(
 							async (db) => getGraphBoostIds(query, db, cfg.pipelineV2.graph.boostTimeoutMs, params.agentId),
-							{ siteToken: "memory-search.ts:2001" },
+							{ siteToken: "memory-search.ts:2011" },
 						),
 				);
 				if (graphResult.graphLinkedIds.size > 0) {
@@ -2045,7 +2045,7 @@ export async function hybridRecall(
 								focal.entityIds,
 								(readFn) =>
 									getDbAccessor().withReadDbAsync(readFn, {
-										siteToken: "memory-search.ts:2037",
+										siteToken: "memory-search.ts:2047",
 										operation: "memory.graph-traversal",
 									}),
 								agentId,
@@ -2099,7 +2099,7 @@ export async function hybridRecall(
 											id: string;
 											traversal_score: number;
 										}>,
-									{ siteToken: "memory-search.ts:2070" },
+									{ siteToken: "memory-search.ts:2080" },
 								);
 
 								for (const row of baseRows) {
@@ -2167,7 +2167,7 @@ export async function hybridRecall(
 								 WHERE id IN (${placeholders})`,
 							)
 							.all(...candidateIds) as Array<{ id: string; content: string }>,
-					{ siteToken: "memory-search.ts:2152" },
+					{ siteToken: "memory-search.ts:2162" },
 				);
 				for (const row of contentRows) {
 					const score = scoreTemporalTopicEvidence(query, row.content);
@@ -2213,7 +2213,7 @@ export async function hybridRecall(
 							query,
 							agentId,
 						),
-					{ siteToken: "memory-search.ts:2198" },
+					{ siteToken: "memory-search.ts:2208" },
 				);
 				for (const [id, score] of structured) {
 					structuredEvidenceMap.set(id, score);
@@ -2249,7 +2249,7 @@ export async function hybridRecall(
 									 WHERE id IN (${placeholders})`,
 								)
 								.all(...coverageIds) as Array<{ id: string; content: string }>,
-						{ siteToken: "memory-search.ts:2234" },
+						{ siteToken: "memory-search.ts:2244" },
 					);
 					contentMap = new Map(contentRows.map((row) => [row.id, row.content]));
 				}
@@ -2299,7 +2299,7 @@ export async function hybridRecall(
 						id: string;
 						content: string;
 					}>,
-				{ siteToken: "memory-search.ts:2281" },
+				{ siteToken: "memory-search.ts:2291" },
 			);
 			const contentMap = new Map(contentRows.map((r) => [r.id, r.content]));
 
@@ -2379,7 +2379,7 @@ export async function hybridRecall(
 						content: string;
 						type: string;
 					}>,
-				{ siteToken: "memory-search.ts:2360" },
+				{ siteToken: "memory-search.ts:2370" },
 			);
 			const meta = new Map(dampenRows.map((r) => [r.id, r]));
 
@@ -2399,7 +2399,7 @@ export async function hybridRecall(
 							memory_id: string;
 							entity_id: string;
 						}>,
-					{ siteToken: "memory-search.ts:2381" },
+					{ siteToken: "memory-search.ts:2391" },
 				);
 
 				const entityIds = new Set<string>();
@@ -2430,7 +2430,7 @@ export async function hybridRecall(
 								entity_id: string;
 								cnt: number;
 							}>,
-						{ siteToken: "memory-search.ts:2410" },
+						{ siteToken: "memory-search.ts:2420" },
 					);
 					for (const row of degreeRows) {
 						degrees.set(row.entity_id, row.cnt);
@@ -2677,7 +2677,7 @@ export async function hybridRecall(
 						scope: string | null;
 						agent_id: string | null;
 					}>,
-				{ siteToken: "memory-search.ts:2645" },
+				{ siteToken: "memory-search.ts:2657" },
 			),
 	);
 
@@ -2691,7 +2691,7 @@ export async function hybridRecall(
 					content: row.content,
 				}),
 			),
-		{ siteToken: "memory-search.ts:2672" },
+		{ siteToken: "memory-search.ts:2684" },
 	);
 	const rowMap = new Map(safeRows.map((r) => [r.id, r]));
 	// No pre-decrement: always fetch `limit` memories. The summary card is
@@ -2932,7 +2932,7 @@ export async function hybridRecall(
 						}),
 					);
 				},
-				{ siteToken: "memory-search.ts:2870" },
+				{ siteToken: "memory-search.ts:2882" },
 			);
 
 			for (const r of supplementary) {
@@ -3061,7 +3061,7 @@ export async function hybridRecall(
 
 						return { eids, structured };
 					},
-					{ siteToken: "memory-search.ts:2970" },
+					{ siteToken: "memory-search.ts:2982" },
 				);
 
 				if (ctx) {
@@ -3090,7 +3090,7 @@ export async function hybridRecall(
 			const cap = Math.max(3, Math.ceil(limit * 0.3));
 			const blocks = await getDbAccessor().withReadDbAsync(
 				async (db) => constructContextBlocks(db, agentId, focalEids, cap),
-				{ siteToken: "memory-search.ts:3079" },
+				{ siteToken: "memory-search.ts:3091" },
 			);
 			const now = new Date().toISOString();
 			const minReal = results.length > 0 ? Math.min(...results.map((r) => r.score)) : 0.5;

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -1730,6 +1730,7 @@ export async function hybridRecall(
 							limit: vecLimit,
 							type: params.type,
 							excludeAggregateRecall,
+							maxScanRows: DB_OWNER_MAX_WORK_UNITS,
 						});
 						for (const r of vecResults) {
 							vectorMap.set(r.id, r.score);

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -9,6 +9,7 @@ import { aggregateRecall, parseAggregateRecallBudget, readAggregateRecallBudgetI
 import { checkScope, requirePermission, requireRateLimit } from "../auth";
 import { type ConcurrencyAdmission, createConcurrencyAdmission } from "../concurrency-admission";
 import type { DbOwnerClient } from "../db-owner-client";
+import { DB_OWNER_MAX_WORK_UNITS } from "../db-owner-protocol";
 import { hybridRecallThroughDbOwner } from "../db-owner-recall";
 import { normalizeAndHashContent } from "../content-normalization";
 import { type ReadDb, type WriteDb, getDbAccessor, runWriteTxAsync, prepareTypedStatement } from "../db-accessor";
@@ -3677,6 +3678,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						limit: k + 1,
 						type,
 						excludeAggregateRecall: true,
+						maxScanRows: DB_OWNER_MAX_WORK_UNITS,
 					});
 				},
 				{ siteToken: "routes/memory-routes.ts:3653" },

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { applyRecallScoreThreshold, scanMemoryContent, vectorSearch } from "@signet/core";
+import { applyRecallScoreThreshold, scanMemoryContent, vectorSearchWithMetadata } from "@signet/core";
 import type { Context, Hono, MiddlewareHandler } from "hono";
 import { ensureAgentRegistered, getAgentScope, resolveAgentId } from "../agent-id";
 import { aggregateRecall, parseAggregateRecallBudget, readAggregateRecallBudgetInput } from "../aggregate-recall";
@@ -10,7 +10,7 @@ import { checkScope, requirePermission, requireRateLimit } from "../auth";
 import { type ConcurrencyAdmission, createConcurrencyAdmission } from "../concurrency-admission";
 import type { DbOwnerClient } from "../db-owner-client";
 import { DB_OWNER_MAX_WORK_UNITS } from "../db-owner-protocol";
-import { hybridRecallThroughDbOwner } from "../db-owner-recall";
+import { hybridRecallThroughDbOwner, vectorSearchThroughDbOwner } from "../db-owner-recall";
 import { normalizeAndHashContent } from "../content-normalization";
 import { type ReadDb, type WriteDb, getDbAccessor, runWriteTxAsync, prepareTypedStatement } from "../db-accessor";
 import { syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "../db-helpers";
@@ -3651,9 +3651,9 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const type = c.req.query("type");
 
 		try {
-			const searchData = await getDbAccessor().withReadDbAsync(
-				async (db) => {
-					const embeddingRow = db
+			const embeddingRow = await getDbAccessor().withReadDbAsync(
+				async (db) =>
+					db
 						.prepare(`
         SELECT e.vector
         FROM embeddings e
@@ -3663,35 +3663,39 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
         ${memoryLifecycleSql(db)}
         LIMIT 1
       `)
-						.get(id) as { vector: Buffer } | undefined;
-
-					if (!embeddingRow) return null;
-
-					const queryVector = new Float32Array(
-						embeddingRow.vector.buffer.slice(
-							embeddingRow.vector.byteOffset,
-							embeddingRow.vector.byteOffset + embeddingRow.vector.byteLength,
-						),
-					);
-
-					return vectorSearch(db, queryVector, {
-						limit: k + 1,
-						type,
-						excludeAggregateRecall: true,
-						maxScanRows: DB_OWNER_MAX_WORK_UNITS,
-					});
-				},
+						.get(id) as { vector: Buffer } | undefined,
 				{ siteToken: "routes/memory-routes.ts:3653" },
 			);
 
-			if (!searchData) {
+			if (!embeddingRow) {
 				return c.json({ error: "No embedding found for this memory", results: [] }, 404);
 			}
 
-			const filteredResults = searchData.filter((r) => r.id !== id).slice(0, k);
+			const queryVector = new Float32Array(
+				embeddingRow.vector.buffer.slice(
+					embeddingRow.vector.byteOffset,
+					embeddingRow.vector.byteOffset + embeddingRow.vector.byteLength,
+				),
+			);
+			const searchOptions = {
+				limit: k + 1,
+				type,
+				excludeAggregateRecall: true,
+				maxScanRows: DB_OWNER_MAX_WORK_UNITS,
+			};
+			const searchData =
+				recallOwner === undefined
+					? await getDbAccessor().withReadDbAsync((db) => vectorSearchWithMetadata(db, queryVector, searchOptions))
+					: await vectorSearchThroughDbOwner(recallOwner, [...queryVector], searchOptions);
+
+			const filteredResults = searchData.results.filter((r) => r.id !== id).slice(0, k);
 
 			if (filteredResults.length === 0) {
-				return c.json({ results: [] });
+				return c.json({
+					results: [],
+					completeness: searchData.completeness,
+					...(searchData.searchedWindow === undefined ? {} : { searchedWindow: searchData.searchedWindow }),
+				});
 			}
 
 			const ids = filteredResults.map((r) => r.id);
@@ -3744,7 +3748,11 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				})
 				.filter((r): r is NonNullable<typeof r> => r !== null);
 
-			return c.json({ results });
+			return c.json({
+				results,
+				completeness: searchData.completeness,
+				...(searchData.searchedWindow === undefined ? {} : { searchedWindow: searchData.searchedWindow }),
+			});
 		} catch (e) {
 			logger.error("memory", "Similarity search failed", e as Error);
 			return c.json({ error: "Similarity search failed", results: [] }, 500);

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -118,7 +118,7 @@ async function withActiveEmbeddingConfig(cfg: ResolvedMemoryConfig): Promise<Res
 	return {
 		...cfg,
 		embedding: await getDbAccessor().withReadDbAsync(async (db) => resolveActiveEmbeddingConfig(db, cfg.embedding), {
-			siteToken: "routes/memory-routes.ts:119",
+			siteToken: "routes/memory-routes.ts:120",
 		}),
 	};
 }
@@ -632,7 +632,7 @@ async function authorizeMemoryMutationScope(c: Context, memoryIds: readonly stri
 				(id) => stmt.get(id) as { id: string; agent_id: string | null; project: string | null } | undefined,
 			);
 		},
-		{ siteToken: "routes/memory-routes.ts:627" },
+		{ siteToken: "routes/memory-routes.ts:628" },
 	);
 	const claims = c.get("auth")?.claims ?? null;
 	for (const row of rows) {
@@ -983,7 +983,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						db.prepare("SELECT project FROM memories WHERE id = ?").get(memoryId) as
 							| { project: string | null }
 							| undefined,
-					{ siteToken: "routes/memory-routes.ts:980" },
+					{ siteToken: "routes/memory-routes.ts:981" },
 				);
 				if (row) {
 					const decision = checkScope(auth.claims, { project: row.project ?? undefined }, authConfig.mode);
@@ -1081,7 +1081,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						},
 					};
 				},
-				{ siteToken: "routes/memory-routes.ts:1024" },
+				{ siteToken: "routes/memory-routes.ts:1025" },
 			);
 
 			return c.json(result);
@@ -1126,7 +1126,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						)
 						.map(({ agent_id: _agentId, ...row }) => row);
 				},
-				{ siteToken: "routes/memory-routes.ts:1104" },
+				{ siteToken: "routes/memory-routes.ts:1105" },
 			);
 			return c.json({ memories });
 		} catch (e) {
@@ -1236,7 +1236,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						highUsed: filterSafe(highUsed).map(({ agent_id: _agentId, ...row }) => row),
 					};
 				},
-				{ siteToken: "routes/memory-routes.ts:1159" },
+				{ siteToken: "routes/memory-routes.ts:1160" },
 			);
 			return c.json({ agentId, minSessions, limit, ...slices });
 		} catch (e) {
@@ -1266,7 +1266,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						readPolicy: agentScope.readPolicy,
 						policyGroup: agentScope.policyGroup ?? undefined,
 					}),
-				{ siteToken: "routes/memory-routes.ts:1260" },
+				{ siteToken: "routes/memory-routes.ts:1261" },
 			);
 			return c.json(timeline);
 		} catch (e) {
@@ -1323,7 +1323,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						)
 						.all(...(shouldEnforceAuthScope(c) ? scopeArgs : []));
 				},
-				{ siteToken: "routes/memory-routes.ts:1307" },
+				{ siteToken: "routes/memory-routes.ts:1308" },
 			);
 			return c.json({ items: rows });
 		} catch (e) {
@@ -1350,7 +1350,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						}[];
 						return rows.map((r) => r.who);
 					},
-					{ siteToken: "routes/memory-routes.ts:1345" },
+					{ siteToken: "routes/memory-routes.ts:1346" },
 				);
 				return c.json({ values });
 			} catch {
@@ -1444,7 +1444,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 							return publicRow;
 						});
 				},
-				{ siteToken: "routes/memory-routes.ts:1376" },
+				{ siteToken: "routes/memory-routes.ts:1377" },
 			);
 
 			recordRecallOutcome({
@@ -1678,7 +1678,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 			const baseIdempotencyMemory = await getDbAccessor().withReadDbAsync(
 				async (db) => getScopedIdempotencyMemoryId(db, rowProvenance.idempotencyKey, dedupeScope),
-				{ siteToken: "routes/memory-routes.ts:1678" },
+				{ siteToken: "routes/memory-routes.ts:1679" },
 			);
 			if (baseIdempotencyMemory) {
 				return c.json({ error: "idempotencyKey already used for non-chunk content" }, 409);
@@ -1686,7 +1686,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 			const existingChunks = await getDbAccessor().withReadDbAsync(
 				async (db) => getScopedChunkIdempotencyRows(db, rowProvenance.idempotencyKey, dedupeScope),
-				{ siteToken: "routes/memory-routes.ts:1686" },
+				{ siteToken: "routes/memory-routes.ts:1687" },
 			);
 			if (existingChunks.length > 0) {
 				const groupIds = new Set(existingChunks.map((row) => row.sourceId).filter((id): id is string => !!id));
@@ -1720,7 +1720,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				contentHashes.add(plan.normalized.contentHash);
 				const byHash = await getDbAccessor().withReadDbAsync(
 					async (db) => getScopedContentHashMemoryId(db, plan.normalized.contentHash, dedupeScope),
-					{ siteToken: "routes/memory-routes.ts:1720" },
+					{ siteToken: "routes/memory-routes.ts:1721" },
 				);
 				if (byHash) {
 					return c.json({ error: "chunk content already exists for this agent and scope" }, 409);
@@ -1927,7 +1927,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				? []
 				: await getDbAccessor().withReadDbAsync(
 						async (db) => getScopedChunkIdempotencyRows(db, rowProvenance.idempotencyKey, dedupeScope),
-						{ siteToken: "routes/memory-routes.ts:1927" },
+						{ siteToken: "routes/memory-routes.ts:1928" },
 					);
 		if (chunkedIdempotencyMemory.length > 0) {
 			return c.json({ error: "idempotencyKey already used for chunked content" }, 409);
@@ -2056,7 +2056,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						if (byIdempotencyKey) return byIdempotencyKey;
 						return getScopedContentHashDedupeRow(db, contentHash, dedupeScope);
 					},
-					{ siteToken: "routes/memory-routes.ts:2052" },
+					{ siteToken: "routes/memory-routes.ts:2053" },
 				);
 				if (existing) {
 					c.header("x-signet-operation-skipped", "1");
@@ -2300,7 +2300,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					: null;
 				return { row, safety };
 			},
-			{ siteToken: "routes/memory-routes.ts:2271" },
+			{ siteToken: "routes/memory-routes.ts:2272" },
 		);
 		const row = memoryRead.row;
 
@@ -2343,7 +2343,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			async (db) => {
 				return db.prepare("SELECT id FROM memories WHERE id = ?").get(memoryId) as { id: string } | undefined;
 			},
-			{ siteToken: "routes/memory-routes.ts:2341" },
+			{ siteToken: "routes/memory-routes.ts:2342" },
 		);
 		if (!exists) {
 			return c.json({ error: "Not found", memoryId }, 404);
@@ -2374,7 +2374,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					request_id: string | null;
 				}>;
 			},
-			{ siteToken: "routes/memory-routes.ts:2351" },
+			{ siteToken: "routes/memory-routes.ts:2352" },
 		);
 
 		return c.json({
@@ -2495,7 +2495,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				// order — creation time is.
 				return [...byId.values()].sort((a, b) => a.created_at.localeCompare(b.created_at) || a.version - b.version);
 			},
-			{ siteToken: "routes/memory-routes.ts:2452" },
+			{ siteToken: "routes/memory-routes.ts:2453" },
 		);
 
 		return c.json({
@@ -2538,7 +2538,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					)
 					.get(jobId) as unknown;
 			},
-			{ siteToken: "routes/memory-routes.ts:2527" },
+			{ siteToken: "routes/memory-routes.ts:2528" },
 		);
 
 		type JobRow = {
@@ -3664,7 +3664,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
         LIMIT 1
       `)
 						.get(id) as { vector: Buffer } | undefined,
-				{ siteToken: "routes/memory-routes.ts:3653" },
+				{ siteToken: "routes/memory-routes.ts:3654" },
 			);
 
 			if (!embeddingRow) {
@@ -3685,7 +3685,9 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			};
 			const searchData =
 				recallOwner === undefined
-					? await getDbAccessor().withReadDbAsync((db) => vectorSearchWithMetadata(db, queryVector, searchOptions))
+					? await getDbAccessor().withReadDbAsync((db) => vectorSearchWithMetadata(db, queryVector, searchOptions), {
+							siteToken: "routes/memory-routes.ts:3688",
+						})
 					: await vectorSearchThroughDbOwner(recallOwner, [...queryVector], searchOptions);
 
 			const filteredResults = searchData.results.filter((r) => r.id !== id).slice(0, k);
@@ -3727,7 +3729,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						}),
 					);
 				},
-				{ siteToken: "routes/memory-routes.ts:3698" },
+				{ siteToken: "routes/memory-routes.ts:3706" },
 			);
 
 			const rowMap = new Map(rows.map((r) => [r.id, r]));
@@ -3822,7 +3824,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 					return { total: totalRow?.count ?? 0, rows: rowData };
 				},
-				{ siteToken: "routes/memory-routes.ts:3775" },
+				{ siteToken: "routes/memory-routes.ts:3787" },
 			);
 
 			const embeddings = rows.map((row) => ({
@@ -3874,7 +3876,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					? { ...state, coverage: stagingCoverage(db, state.staging.dimensions, state.staging.fingerprint) }
 					: state;
 			},
-			{ siteToken: "routes/memory-routes.ts:3860" },
+			{ siteToken: "routes/memory-routes.ts:3872" },
 		);
 		return c.json({ ...status, tracker, index });
 	});
@@ -3887,7 +3889,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const providerStatus = await checkEmbeddingProvider(cfg.embedding);
 		const report = await getDbAccessor().withReadDbAsync(
 			async (db) => buildEmbeddingHealth(db, cfg.embedding, providerStatus),
-			{ siteToken: "routes/memory-routes.ts:3878" },
+			{ siteToken: "routes/memory-routes.ts:3890" },
 		);
 		return c.json(report);
 	});
@@ -3968,7 +3970,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 									}
 								: undefined,
 						}),
-					{ siteToken: "routes/memory-routes.ts:3941" },
+					{ siteToken: "routes/memory-routes.ts:3953" },
 				);
 
 				return c.json({
@@ -3998,7 +4000,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						: 0;
 				return { cached: cachedResult, total: count };
 			},
-			{ siteToken: "routes/memory-routes.ts:3981" },
+			{ siteToken: "routes/memory-routes.ts:3993" },
 		);
 
 		if (cached !== null && cached.embeddingCount === total) {
@@ -4030,7 +4032,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			const computation = (async () => {
 				try {
 					const result = await getDbAccessor().withReadDbAsync(async (db) => computeProjection(db, nComponents), {
-						siteToken: "routes/memory-routes.ts:4022",
+						siteToken: "routes/memory-routes.ts:4034",
 					});
 					const count = await getDbAccessor().withReadDbAsync(
 						async (db) => {
@@ -4039,7 +4041,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 								? row.count
 								: 0;
 						},
-						{ siteToken: "routes/memory-routes.ts:4025" },
+						{ siteToken: "routes/memory-routes.ts:4037" },
 					);
 					await runWriteTxAsync(getDbAccessor(), (db) => cacheProjection(db, nComponents, result, count));
 				} catch (err) {
@@ -4207,7 +4209,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 					return { documents, total };
 				},
-				{ siteToken: "routes/memory-routes.ts:4179" },
+				{ siteToken: "routes/memory-routes.ts:4191" },
 			);
 
 			return c.json({ ...result, limit, offset });
@@ -4231,7 +4233,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				async (db) => {
 					return db.prepare("SELECT * FROM documents WHERE id = ?").get(id);
 				},
-				{ siteToken: "routes/memory-routes.ts:4220" },
+				{ siteToken: "routes/memory-routes.ts:4232" },
 			);
 			if (!doc) return c.json({ error: "Document not found" }, 404);
 			return c.json(doc);
@@ -4277,7 +4279,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						)
 						.all(id, ...(shouldEnforceAuthScope(c) ? scopeArgs : []));
 				},
-				{ siteToken: "routes/memory-routes.ts:4255" },
+				{ siteToken: "routes/memory-routes.ts:4267" },
 			);
 			return c.json({ chunks, count: chunks.length });
 		} catch (e) {
@@ -4303,7 +4305,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					| ({ id: string } & DocumentScopeRow)
 					| undefined;
 			},
-			{ siteToken: "routes/memory-routes.ts:4290" },
+			{ siteToken: "routes/memory-routes.ts:4302" },
 		);
 		if (!doc) return c.json({ error: "Document not found" }, 404);
 

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,12 +16,12 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(1000);
+	expect(baseline).toHaveLength(1002);
 	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(66);
 	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(109);
 	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(68);
 	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(3);
-	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(235);
+	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(237);
 });
 
 test("the event-loop ledger exactly equals the current source inventory", () => {
@@ -327,8 +327,8 @@ test("the production TypeScript project cannot import the compatibility module",
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const report = renderReport(baseline, { total: 175, withWriteTx: 66, withReadDb: 109 });
-	expect(report).toContain("Exact ledger inventory: 1000 sites");
-	expect(report).toContain("66 synchronous writes, 109 synchronous reads, and 309 async-named parent DB sites");
+	expect(report).toContain("Exact ledger inventory: 1002 sites");
+	expect(report).toContain("66 synchronous writes, 109 synchronous reads, and 311 async-named parent DB sites");
 	expect(report).toContain("type boundary");
 	expect(report).not.toContain("1061");
 });

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -949,63 +949,70 @@
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 119,
+      "line": 120,
       "api": "readFileSync",
       "source": "return readFileSync(cancellationRegistryPath, \"utf8\").includes(`${jobId}\\n`);",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 144,
+      "line": 145,
       "api": "writeFileSync",
       "source": "writeFileSync(startupStarted, \"started\\n\");",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 146,
+      "line": 147,
       "api": "existsSync",
       "source": "while (!existsSync(startupRelease)) Atomics.wait(signal, 0, 0, 5);",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 152,
+      "line": 153,
       "api": "existsSync",
       "source": "if (sqlitePath !== undefined && existsSync(sqlitePath) && typeof Database.setCustomSQLite === \"function\") {",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 181,
+      "line": 182,
       "api": "writeFileSync",
       "source": "if (commitMarker !== undefined) writeFileSync(commitMarker, \"started\\n\");",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 716,
+      "line": 717,
       "api": "withReadDbAsync",
       "source": "const embedding = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 743,
+      "line": 750,
+      "api": "withReadDbAsync",
+      "source": "return await getDbAccessor().withReadDbAsync(",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-owner-worker.ts",
+      "line": 760,
       "api": "writeFileSync",
       "source": "writeFileSync(startedMarker, \"started\\n\");",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 744,
+      "line": 761,
       "api": "existsSync",
       "source": "while (!existsSync(releaseMarker)) await new Promise((resolve) => setTimeout(resolve, 5));",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 787,
+      "line": 805,
       "api": "writeFileSync",
       "source": "if (activeFile) writeFileSync(activeFile, `${Date.now()}\\n`);",
       "category": "hot-path"
@@ -2433,203 +2440,203 @@
     },
     {
       "path": "memory-search.ts",
-      "line": 619,
+      "line": 624,
       "api": "withReadDbAsync",
       "source": "const accessRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 769,
+      "line": 774,
       "api": "withReadDbAsync",
       "source": "const allowed = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 817,
+      "line": 822,
       "api": "withReadDbAsync",
       "source": "return await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 851,
+      "line": 856,
       "api": "withReadDbAsync",
       "source": "const rows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 1035,
+      "line": 1040,
       "api": "withReadDbAsync",
       "source": "return await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 1209,
+      "line": 1214,
       "api": "withReadDbAsync",
       "source": "return await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 1565,
+      "line": 1570,
       "api": "withReadDbAsync",
       "source": "const value = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 1585,
+      "line": 1590,
       "api": "withReadDbAsync",
       "source": "await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 1664,
+      "line": 1669,
       "api": "withReadDbAsync",
       "source": "await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 1727,
+      "line": 1734,
       "api": "withReadDbAsync",
       "source": "await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 1762,
+      "line": 1772,
       "api": "withReadDbAsync",
       "source": "await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 1785,
+      "line": 1795,
       "api": "withReadDbAsync",
       "source": "await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 1886,
+      "line": 1896,
       "api": "withReadDbAsync",
       "source": "getDbAccessor().withReadDbAsync(readFn, {",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 1913,
+      "line": 1923,
       "api": "withReadDbAsync",
       "source": "const embRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2001,
+      "line": 2011,
       "api": "withReadDbAsync",
       "source": "await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2037,
+      "line": 2047,
       "api": "withReadDbAsync",
       "source": "getDbAccessor().withReadDbAsync(readFn, {",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2070,
+      "line": 2080,
       "api": "withReadDbAsync",
       "source": "const baseRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2152,
+      "line": 2162,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2198,
+      "line": 2208,
       "api": "withReadDbAsync",
       "source": "const structured = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2234,
+      "line": 2244,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2281,
+      "line": 2291,
       "api": "withReadDbAsync",
       "source": "const contentRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2360,
+      "line": 2370,
       "api": "withReadDbAsync",
       "source": "const dampenRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2381,
+      "line": 2391,
       "api": "withReadDbAsync",
       "source": "const links = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2410,
+      "line": 2420,
       "api": "withReadDbAsync",
       "source": "const degreeRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2645,
+      "line": 2657,
       "api": "withReadDbAsync",
       "source": "await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2672,
+      "line": 2684,
       "api": "withReadDbAsync",
       "source": "const safeRows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2870,
+      "line": 2882,
       "api": "withReadDbAsync",
       "source": "const supplementary = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 2970,
+      "line": 2982,
       "api": "withReadDbAsync",
       "source": "const ctx = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "memory-search.ts",
-      "line": 3079,
+      "line": 3091,
       "api": "withReadDbAsync",
       "source": "const blocks = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
@@ -4456,245 +4463,252 @@
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 119,
+      "line": 120,
       "api": "withReadDbAsync",
       "source": "embedding: await getDbAccessor().withReadDbAsync(async (db) => resolveActiveEmbeddingConfig(db, cfg.embedding), {",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 288,
+      "line": 289,
       "api": "mkdirSync",
       "source": "mkdirSync(dir, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 304,
+      "line": 305,
       "api": "writeFileSync",
       "source": "writeFileSync(path, noteContent, { encoding: \"utf-8\", flag: \"wx\" });",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 627,
+      "line": 628,
       "api": "withReadDbAsync",
       "source": "const rows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 980,
+      "line": 981,
       "api": "withReadDbAsync",
       "source": "const row = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1024,
+      "line": 1025,
       "api": "withReadDbAsync",
       "source": "const result = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1104,
+      "line": 1105,
       "api": "withReadDbAsync",
       "source": "const memories = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1159,
+      "line": 1160,
       "api": "withReadDbAsync",
       "source": "const slices = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1260,
+      "line": 1261,
       "api": "withReadDbAsync",
       "source": "const timeline = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1307,
+      "line": 1308,
       "api": "withReadDbAsync",
       "source": "const rows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1345,
+      "line": 1346,
       "api": "withReadDbAsync",
       "source": "const values = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1376,
+      "line": 1377,
       "api": "withReadDbAsync",
       "source": "const results = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1678,
+      "line": 1679,
       "api": "withReadDbAsync",
       "source": "const baseIdempotencyMemory = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1686,
+      "line": 1687,
       "api": "withReadDbAsync",
       "source": "const existingChunks = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1720,
+      "line": 1721,
       "api": "withReadDbAsync",
       "source": "const byHash = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 1927,
+      "line": 1928,
       "api": "withReadDbAsync",
       "source": ": await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 2052,
+      "line": 2053,
       "api": "withReadDbAsync",
       "source": "const existing = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 2271,
+      "line": 2272,
       "api": "withReadDbAsync",
       "source": "const memoryRead = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 2341,
+      "line": 2342,
       "api": "withReadDbAsync",
       "source": "const exists = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 2351,
+      "line": 2352,
       "api": "withReadDbAsync",
       "source": "const history = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 2452,
+      "line": 2453,
       "api": "withReadDbAsync",
       "source": "const rows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 2527,
+      "line": 2528,
       "api": "withReadDbAsync",
       "source": "const maybeRow = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3653,
+      "line": 3654,
       "api": "withReadDbAsync",
-      "source": "const searchData = await getDbAccessor().withReadDbAsync(",
+      "source": "const embeddingRow = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3698,
+      "line": 3688,
+      "api": "withReadDbAsync",
+      "source": "? await getDbAccessor().withReadDbAsync((db) => vectorSearchWithMetadata(db, queryVector, searchOptions), {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/memory-routes.ts",
+      "line": 3706,
       "api": "withReadDbAsync",
       "source": "const rows = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3775,
+      "line": 3787,
       "api": "withReadDbAsync",
       "source": "const { total, rows } = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3860,
+      "line": 3872,
       "api": "withReadDbAsync",
       "source": "const index = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3878,
+      "line": 3890,
       "api": "withReadDbAsync",
       "source": "const report = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3941,
+      "line": 3953,
       "api": "withReadDbAsync",
       "source": "const projection = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 3981,
+      "line": 3993,
       "api": "withReadDbAsync",
       "source": "const { cached, total } = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 4022,
+      "line": 4034,
       "api": "withReadDbAsync",
       "source": "const result = await getDbAccessor().withReadDbAsync(async (db) => computeProjection(db, nComponents), {",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 4025,
+      "line": 4037,
       "api": "withReadDbAsync",
       "source": "const count = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 4179,
+      "line": 4191,
       "api": "withReadDbAsync",
       "source": "const result = await accessor.withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 4220,
+      "line": 4232,
       "api": "withReadDbAsync",
       "source": "const doc = await accessor.withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 4255,
+      "line": 4267,
       "api": "withReadDbAsync",
       "source": "const chunks = await accessor.withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "routes/memory-routes.ts",
-      "line": 4290,
+      "line": 4302,
       "api": "withReadDbAsync",
       "source": "const doc = await accessor.withReadDbAsync(",
       "category": "hot-path"

--- a/web/docs/src/content/docs/architecture/pipeline-storage.md
+++ b/web/docs/src/content/docs/architecture/pipeline-storage.md
@@ -197,8 +197,11 @@ hashed; an identical chunk already linked to the same document is skipped.
 Canonical vectors are stored in `embeddings`, with the sqlite-vec table serving
 as a derived ANN mirror when the extension is available. If sqlite-vec cannot
 load, including Bun's system SQLite on macOS, semantic recall uses a bounded
-cosine scan over canonical vectors instead; recall remains functional with
-degraded throughput.
+cosine scan over the newest canonical vectors instead. This fallback is
+explicitly partial: recall responses identify `vectorCompleteness` as
+`"recent-window"` and report the `searchedWindow` size (10,000 rows by default).
+It preserves a useful semantic channel without claiming complete workspace
+coverage, and the scan runs in the dedicated recall owner process.
 
 A failed document updates the document row with an error and follows the same
 retry budget as its queue job. Deleting a document while work is in flight

--- a/web/docs/src/content/docs/architecture/pipeline-storage.md
+++ b/web/docs/src/content/docs/architecture/pipeline-storage.md
@@ -195,7 +195,10 @@ source through `document_memories(document_id, memory_id, chunk_index)`.
 Embedding calls happen before the write transaction. Chunks are normalized and
 hashed; an identical chunk already linked to the same document is skipped.
 Canonical vectors are stored in `embeddings`, with the sqlite-vec table serving
-as a derived ANN mirror when the extension is available.
+as a derived ANN mirror when the extension is available. If sqlite-vec cannot
+load, including Bun's system SQLite on macOS, semantic recall uses a bounded
+cosine scan over canonical vectors instead; recall remains functional with
+degraded throughput.
 
 A failed document updates the document row with an error and follows the same
 retry budget as its queue job. Deleting a document while work is in flight

--- a/web/docs/src/content/docs/memory.md
+++ b/web/docs/src/content/docs/memory.md
@@ -124,9 +124,12 @@ Candidate collection uses several independent channels:
   the same words as the current query.
 - **Vector search** embeds the original query and searches `vec_embeddings`
   through `sqlite-vec`. When that extension is unavailable, it uses a bounded
-  cosine scan over canonical vectors instead. Vector search cannot pre-filter
-  every recall scope, so constrained searches over-fetch and rely on
-  authorization after merge.
+  cosine scan over the newest canonical vectors instead. The fallback is an
+  explicitly partial `recent-window` channel: responses expose
+  `meta.vectorCompleteness: "recent-window"` and `meta.searchedWindow` (the
+  default is 10,000 rows), so it must not be read as complete workspace recall.
+  Vector search cannot pre-filter every recall scope, so constrained searches
+  over-fetch and rely on authorization after merge.
 - **Structured path candidates** search entity/aspect/group/claim paths so
   structured knowledge can surface even when its prose is sparse.
 - **Graph traversal** resolves focal entities and walks the knowledge graph.

--- a/web/docs/src/content/docs/memory.md
+++ b/web/docs/src/content/docs/memory.md
@@ -123,8 +123,10 @@ Candidate collection uses several independent channels:
   alternate phrasings. They can rescue a memory whose content does not use
   the same words as the current query.
 - **Vector search** embeds the original query and searches `vec_embeddings`
-  through `sqlite-vec`. Vector search cannot pre-filter every recall scope,
-  so constrained searches over-fetch and rely on authorization after merge.
+  through `sqlite-vec`. When that extension is unavailable, it uses a bounded
+  cosine scan over canonical vectors instead. Vector search cannot pre-filter
+  every recall scope, so constrained searches over-fetch and rely on
+  authorization after merge.
 - **Structured path candidates** search entity/aspect/group/claim paths so
   structured knowledge can surface even when its prose is sparse.
 - **Graph traversal** resolves focal entities and walks the knowledge graph.


### PR DESCRIPTION
## Summary

- Preserve semantic vector recall for the newest bounded window when sqlite-vec cannot load, including Bun's system SQLite on macOS, and report when older eligible rows fall outside that window.
- Route potentially expensive fallback vector scoring through the dedicated recall DB-owner process for `/memory/similar` and owner-backed recall.
- Expose an explicit completeness contract (`complete`, `recent-window`, or `unavailable`), reject truncated vector BLOBs, and select projection/embedding tables inside one read transaction.

## Type

- [ ] `feat` - new user-facing feature (bumps minor)
- [x] `fix` - bug fix
- [ ] `refactor` - restructure without behavior change
- [ ] `chore` - build, deps, config, docs
- [ ] `perf` - performance improvement
- [ ] `test` - test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [x] Other: documentation only under `web/docs`

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Testing

- [x] `bun test platform/core/src/search.test.ts`: 5 pass
- [x] `bun test platform/daemon/src/db-owner-recall.test.ts`: 4 pass
- [x] `bun test --max-concurrency=1 --reporter=dots platform/daemon/src/routes/memory-routes.test.ts`: 1 pass
- [x] `bun test --max-concurrency=1 --test-name-pattern='keeps the owner alive when sqlite-vec cannot be loaded|routes a recall read through a separate owner process' platform/daemon/src/db-owner-client.test.ts`: 2 pass
- [x] `bun run --filter '@signet/core' build`: pass
- [x] `bun run --filter '@signet/daemon' build`: pass
- [x] Changed-file Biome check: pass with 2 pre-existing warnings
- [x] `bun scripts/audit-event-loop-contract.ts`: pass
- [x] Changed-package typechecks: core and daemon pass

The full workspace typecheck is currently blocked by pre-existing connector package export and generated-bundle errors outside this change.

## Migration Notes

No migrations. No schema changes. The canonical embeddings table is read only by the fallback.

## AI disclosure

- [x] AI tools were used (Kanban task `t_0b1ac1ac`)


