### PR TITLE
fix(daemon): reserve interactive DB-owner capacity

### DIFF
--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -161,7 +161,6 @@ describe("auth guard co-location", () => {
 					foregroundOldestAgeMs: null,
 					maintenanceOldestAgeMs: null,
 					lastError: null,
-					deadlineKills: 0,
 				}),
 				close: async () => {},
 			};

--- a/platform/daemon/src/database-integrity.test.ts
+++ b/platform/daemon/src/database-integrity.test.ts
@@ -117,7 +117,6 @@ describe("telemetry database integrity recovery (#1360)", () => {
 			expect(result.telemetryCheck.ok).toBe(true);
 			expect(result.ownerState).toBe("ready");
 			expect(result.ownerGeneration).toBe(1);
-			expect(result.deadlineKills).toBe(0);
 		} finally {
 			await owner.close();
 			rmSync(dir, { recursive: true, force: true });

--- a/platform/daemon/src/database-integrity.ts
+++ b/platform/daemon/src/database-integrity.ts
@@ -53,7 +53,6 @@ export interface DatabaseIntegrityStatus {
 	readonly repairGuidance: string | null;
 	readonly ownerState: string | null;
 	readonly ownerGeneration: number | null;
-	readonly deadlineKills: number;
 	readonly incrementalProgress: DatabaseIntegrityProgress | null;
 }
 
@@ -87,7 +86,6 @@ let latestStatus: DatabaseIntegrityStatus = {
 	repairGuidance: null,
 	ownerState: null,
 	ownerGeneration: null,
-	deadlineKills: 0,
 	incrementalProgress: null,
 };
 
@@ -135,7 +133,6 @@ function statusWith(
 		repairGuidance,
 		ownerState: health?.state ?? null,
 		ownerGeneration: health?.generation ?? null,
-		deadlineKills: health?.deadlineKills ?? 0,
 		incrementalProgress: null,
 	};
 }
@@ -172,7 +169,6 @@ export function updateDatabaseIntegrityStatus(
 		repairGuidance: state === "corrupt" || state === "unavailable" ? REPAIR_GUIDANCE : null,
 		ownerState: health?.state ?? latestStatus.ownerState,
 		ownerGeneration: health?.generation ?? latestStatus.ownerGeneration,
-		deadlineKills: health?.deadlineKills ?? latestStatus.deadlineKills,
 		incrementalProgress: progress,
 	};
 }
@@ -498,7 +494,6 @@ async function runOwnerDeferredIntegrityCheck(
 			budgetMs: ownerTimeoutMs,
 			ownerState: health.state,
 			ownerGeneration: health.generation,
-			deadlineKills: health.deadlineKills,
 		});
 	}, 1_000);
 	try {
@@ -515,7 +510,6 @@ async function runOwnerDeferredIntegrityCheck(
 			durationMs: latestStatus.durationMs,
 			ownerState: latestStatus.ownerState,
 			ownerGeneration: latestStatus.ownerGeneration,
-			deadlineKills: latestStatus.deadlineKills,
 		});
 		return latestStatus;
 	} catch (error) {
@@ -535,7 +529,6 @@ async function runOwnerDeferredIntegrityCheck(
 			error: message,
 			ownerState: latestStatus.ownerState,
 			ownerGeneration: latestStatus.ownerGeneration,
-			deadlineKills: latestStatus.deadlineKills,
 		});
 		return latestStatus;
 	} finally {

--- a/platform/daemon/src/db-owner-client.test.ts
+++ b/platform/daemon/src/db-owner-client.test.ts
@@ -305,33 +305,62 @@ describe("DB owner client", () => {
 		expect(recallDurationMs).toBeLessThan(200);
 	});
 
-	test("prioritizes foreground writes over queued maintenance work", async () => {
+	test("reserves interactive write capacity while maintenance is saturated", async () => {
 		const database = makeDb();
 		directory = database.directory;
 		client = createDbOwnerClient({ dbPath: database.path });
-		const first = client.submit(
-			{ kind: "sleep", durationMs: 180 },
-			{ operation: "maintenance.first", lane: "maintenance", deadlineMs: 2_000 },
+		const maintenance = client.submit(
+			{ kind: "sleep", durationMs: 300 },
+			{ operation: "maintenance.saturation", lane: "maintenance", deadlineMs: 2_000 },
 		);
-		const second = client.submit(
-			{ kind: "sleep", durationMs: 180 },
-			{ operation: "maintenance.second", lane: "maintenance", deadlineMs: 2_000 },
-		);
-		await waitFor(() => client?.health().activeJobId === first.job.id);
+		await waitFor(() => client?.health().lanes?.maintenance.activeJobId === maintenance.job.id);
+		const startedAt = Date.now();
 		const foreground = client.submit<unknown[]>(
 			{ kind: "query", statement: { sql: "SELECT 1 AS value", result: "all" } },
-			{ operation: "memory.foreground-priority", lane: "write", deadlineMs: 2_000 },
+			{ operation: "memory.interactive-write", lane: "write", deadlineMs: 1_000 },
 		);
-		expect(client.health().foregroundQueuedJobs).toBe(1);
-		expect(client.health().maintenanceQueuedJobs).toBe(1);
-		expect(client.health().queuedJobs).toBe(2);
-		expect(client.health().lanes?.maintenance.queuedJobs).toBe(2);
-		expect(client.health().lanes?.maintenance.activeJobId).toBe(first.job.id);
-		expect(client.health().activeWorkloadClass).toBe("maintenance");
-		const startedAt = Date.now();
 		expect(await foreground.result).toEqual([{ value: 1 }]);
-		expect(Date.now() - startedAt).toBeLessThan(320);
-		await Promise.all([first.result, second.result]);
+		expect(Date.now() - startedAt).toBeLessThan(250);
+		expect(client.health().lanes?.maintenance.activeJobId).toBe(maintenance.job.id);
+		expect(client.health().lanes?.write.activeJobId).toBeNull();
+		await maintenance.result;
+	});
+
+	test("serves health, dashboard, recall, and writes during maintenance saturation", async () => {
+		const database = makeDb();
+		directory = database.directory;
+		client = createDbOwnerClient({ dbPath: database.path });
+		await client.start();
+		const maintenance = client.submit(
+			{ kind: "sleep", durationMs: 350 },
+			{ operation: "sources.native-sync", lane: "maintenance", deadlineMs: 2_000 },
+		);
+		await waitFor(() => client?.health().lanes?.maintenance.activeJobId === maintenance.job.id);
+		const startedAt = Date.now();
+		const health = client.submit<unknown[]>(
+			{ kind: "query", statement: { sql: "SELECT 1 AS health", result: "all" } },
+			{ operation: "health", lane: "read", deadlineMs: 1_000 },
+		);
+		const dashboard = client.submit<unknown[]>(
+			{ kind: "query", statement: { sql: "SELECT 1 AS dashboard", result: "all" } },
+			{ operation: "dashboard", lane: "read", deadlineMs: 1_000 },
+		);
+		const recall = client.submit<unknown[]>(
+			{ kind: "query", statement: { sql: "SELECT 1 AS recall", result: "all" } },
+			{ operation: "recall", lane: "read", deadlineMs: 1_000 },
+		);
+		const write = client.submit<unknown[]>(
+			{ kind: "query", statement: { sql: "SELECT 1 AS write", result: "all" } },
+			{ operation: "memory.interactive-write", lane: "write", deadlineMs: 1_000 },
+		);
+		expect(await Promise.all([health.result, dashboard.result, recall.result, write.result])).toEqual([
+			[{ health: 1 }],
+			[{ dashboard: 1 }],
+			[{ recall: 1 }],
+			[{ write: 1 }],
+		]);
+		expect(Date.now() - startedAt).toBeLessThan(500);
+		await maintenance.result;
 	});
 
 	test("keeps recall reads independent from maintenance work", async () => {
@@ -357,7 +386,7 @@ describe("DB owner client", () => {
 		}
 	});
 
-	test("applies a hard deadline to a slow recall read and recovers", async () => {
+	test("abandons a slow recall read without replacing its owner", async () => {
 		const database = makeDb();
 		directory = database.directory;
 		client = createDbOwnerClient({ dbPath: database.path, workerRole: "recall" });
@@ -370,7 +399,7 @@ describe("DB owner client", () => {
 			deadlineMs: 1_000,
 		});
 		expect(await fast).toEqual([{ id: "m1" }]);
-		expect(client.health().generation).toBe(2);
+		expect(client.health().generation).toBe(1);
 	});
 
 	test("executes a transactional write on the owner before a read lane job", async () => {
@@ -479,25 +508,28 @@ describe("DB owner client", () => {
 		expect(client.health().generation).toBe(2);
 	});
 
-	test("kills the owner at a hard deadline and leaves the daemon responsive", async () => {
+	test("abandons a timed-out maintenance job without killing the owner", async () => {
 		const database = makeDb();
 		directory = database.directory;
 		client = createDbOwnerClient({ dbPath: database.path });
+		await client.start();
 		const slow = client.submit(
 			{ kind: "sleep", durationMs: 250 },
 			{ operation: "maintenance.deadline-test", lane: "maintenance", deadlineMs: 40 },
 		);
 		await expect(slow.result).rejects.toBeInstanceOf(DbOwnerDeadlineError);
-		await waitFor(() => client?.health().state === "dead");
-		expect(client.health().deadlineKills).toBe(1);
+		expect(client.health().deadlineKills).toBe(0);
+		expect(client.health().lanes?.maintenance.pid).not.toBeNull();
 		const fast = client.submit<unknown[]>(
 			{ kind: "query", statement: { sql: "SELECT 1 AS value", result: "all" } },
-			{ operation: "recall.read", lane: "read", deadlineMs: 1_000 },
+			{ operation: "memory.interactive-after-maintenance-timeout", lane: "write", deadlineMs: 1_000 },
 		);
 		expect(await fast.result).toEqual([{ value: 1 }]);
+		expect(client.health().state).toBe("ready");
+		await waitFor(() => client?.health().lanes?.maintenance.activeJobId === null);
 	});
 
-	test("recovers immediately after a deadline kills the owner", async () => {
+	test("recovers immediately after a maintenance deadline is abandoned", async () => {
 		const database = makeDb();
 		directory = database.directory;
 		client = createDbOwnerClient({ dbPath: database.path });

--- a/platform/daemon/src/db-owner-client.test.ts
+++ b/platform/daemon/src/db-owner-client.test.ts
@@ -13,9 +13,12 @@ import {
 	MAX_DB_OWNER_PENDING_JOBS,
 	MAX_DB_OWNER_WORK_UNITS,
 } from "./db-owner-client";
+import { shouldRecordDbOwnerCancellation } from "./db-owner-worker";
 import { findSqliteVecExtension } from "@signet/core";
 import { closeDbAccessor, initDbAccessor } from "./db-accessor";
+import { createDbOwnerMaintenance, registerDbOwnerMaintenance } from "./db-owner-maintenance";
 import { recallThroughDbOwner } from "./db-owner-recall";
+import { dbOwnerQuery } from "./db-owner-runtime";
 
 function makeDb(): { readonly directory: string; readonly path: string } {
 	const directory = mkdtempSync(join(tmpdir(), "signet-db-owner-"));
@@ -54,6 +57,7 @@ describe("DB owner client", () => {
 	let directory: string | null = null;
 
 	afterEach(async () => {
+		registerDbOwnerMaintenance(null);
 		await client?.close();
 		client = null;
 		if (directory !== null) rmSync(directory, { recursive: true, force: true });
@@ -518,7 +522,6 @@ describe("DB owner client", () => {
 			{ operation: "maintenance.deadline-test", lane: "maintenance", deadlineMs: 40 },
 		);
 		await expect(slow.result).rejects.toBeInstanceOf(DbOwnerDeadlineError);
-		expect(client.health().deadlineKills).toBe(0);
 		expect(client.health().lanes?.maintenance.pid).not.toBeNull();
 		const fast = client.submit<unknown[]>(
 			{ kind: "query", statement: { sql: "SELECT 1 AS value", result: "all" } },
@@ -594,6 +597,43 @@ describe("DB owner client", () => {
 		await first.result;
 		expect(client.health().queuedJobs).toBe(0);
 		expect(client.health().activeJobId).toBeNull();
+	});
+
+	test("does not retain cancellation IDs for completed or active jobs", () => {
+		const completedJobs = Array.from({ length: 1_000 }, (_, index) => ({ id: `completed-${index}` }));
+		const activeJob = { id: "active" };
+
+		for (const job of completedJobs) {
+			expect(shouldRecordDbOwnerCancellation(job.id, null, [], [])).toBe(false);
+		}
+		expect(shouldRecordDbOwnerCancellation(activeJob.id, activeJob.id, [], [])).toBe(false);
+		expect(shouldRecordDbOwnerCancellation("queued", null, [{ ...activeJob, id: "queued" }], [])).toBe(true);
+	});
+
+	test("classifies a sources operation as maintenance despite a foreground override", async () => {
+		const database = makeDb();
+		directory = database.directory;
+		client = createDbOwnerClient({ dbPath: database.path });
+		registerDbOwnerMaintenance(createDbOwnerMaintenance({ dbPath: database.path, owner: client }));
+		const slow = client.submit(
+			{ kind: "sleep", durationMs: 250 },
+			{ operation: "maintenance.classifier-saturation", lane: "maintenance", deadlineMs: 1_000 },
+		);
+		await waitFor(() => client?.health().lanes?.maintenance.activeJobId === slow.job.id);
+
+		const query = dbOwnerQuery<readonly { readonly value: number }[]>(
+			{ sql: "SELECT 1 AS value", result: "all" },
+			{
+				operation: "sources.foreground-override",
+				lane: "write",
+				workloadClass: "foreground",
+				deadlineMs: 1_000,
+			},
+		);
+		await waitFor(() => client?.health().lanes?.maintenance.queuedJobs === 1);
+		expect(client.health().lanes?.write.queuedJobs).toBe(0);
+		await expect(query).resolves.toEqual([{ value: 1 }]);
+		await slow.result;
 	});
 
 	test("rejects owner work beyond the bounded queue admission cap", async () => {

--- a/platform/daemon/src/db-owner-client.ts
+++ b/platform/daemon/src/db-owner-client.ts
@@ -69,10 +69,11 @@ export interface DbOwnerHealth {
 	/** Per-owner-lane snapshot; present on the aggregate client health surface. */
 	readonly lanes?: {
 		readonly read: DbOwnerLaneHealth;
+		readonly write: DbOwnerLaneHealth;
 		readonly maintenance: DbOwnerLaneHealth;
 	};
 	readonly lastError: string | null;
-	/** Number of owner processes SIGKILLed by a hard job deadline. */
+	/** Number of owner processes killed by supervised shutdown or transport recovery. */
 	readonly deadlineKills: number;
 }
 
@@ -223,7 +224,7 @@ function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient
 	let pid: number | null = null;
 	let activeJobId: string | null = null;
 	let lastError: string | null = null;
-	let deadlineKills = 0;
+	const deadlineKills = 0;
 	let initialization: DbOwnerInitializationState = "not_started";
 	let sequence = 0;
 	let input = "";
@@ -615,14 +616,24 @@ function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient
 				const entry = pending.get(job.id);
 				if (entry === undefined || entry.settled) return;
 				lastError = `deadline exceeded for ${job.id}`;
-				deadlineKills++;
+				const owner = child;
+				const dispatched = entry.dispatched;
 				settle(job.id, (settledJob) => {
 					if (!settledJob.settled) {
 						settledJob.settled = true;
 						settledJob.reject(new DbOwnerDeadlineError(job.id));
 					}
 				});
-				retireOwner(new DbOwnerDiedError(`DB owner killed after deadline for ${job.id}`));
+				// A job deadline abandons the work; it is not authority to kill the
+				// owner. The owner may still be finishing a synchronous operation,
+				// but interactive work is admitted through a separate owner below.
+				// This preserves the owner process and lets the worker consume the
+				// cancellation when the job is still queued.
+				if (dispatched && owner !== null && state === "ready") {
+					void write(owner, { type: "cancel", jobId: job.id }).catch(() => {
+						// A transport failure is handled by the owner exit path.
+					});
+				}
 			}, submitOptions.deadlineMs);
 			pendingJob = { job, resolve, reject, timer, resolveMetrics, settled: false, dispatched: false };
 			pending.set(job.id, pendingJob as PendingJob<unknown>);
@@ -708,11 +719,16 @@ function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient
  */
 export function createDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient {
 	const readLane = createSingleDbOwnerClient(options);
-	const maintenanceLane = createSingleDbOwnerClient(options);
+	// Interactive writes must never share the maintenance owner. Queue priority
+	// inside one saturated child is not capacity reservation: a synchronous
+	// maintenance job can still hold that child and its SQLite connection.
+	const writeLane = options.workerRole === "recall" ? readLane : createSingleDbOwnerClient(options);
+	const maintenanceLane = options.workerRole === "recall" ? readLane : createSingleDbOwnerClient(options);
 	let closed = false;
 
-	function laneFor(requestLane: DbOwnerLane): DbOwnerClient {
-		return requestLane === "read" ? readLane : maintenanceLane;
+	function laneFor(requestLane: DbOwnerLane, workloadClass?: DbOwnerWorkloadClass): DbOwnerClient {
+		if (workloadClass === "maintenance" || requestLane === "maintenance") return maintenanceLane;
+		return requestLane === "read" ? readLane : writeLane;
 	}
 
 	function toLaneHealth(lane: DbOwnerHealth): DbOwnerLaneHealth {
@@ -734,65 +750,76 @@ export function createDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClien
 
 	function health(): DbOwnerHealth {
 		const read = readLane.health();
+		const write = writeLane.health();
 		const maintenance = maintenanceLane.health();
 		const state: DbOwnerHealthState =
-			read.state === "closed" && maintenance.state === "closed"
+			read.state === "closed" && write.state === "closed" && maintenance.state === "closed"
 				? "closed"
-				: read.state === "failed" || maintenance.state === "failed"
+				: read.state === "failed" || write.state === "failed" || maintenance.state === "failed"
 					? "failed"
 					: (read.state === "dead" && read.generation > 0) ||
+							(write.state === "dead" && write.generation > 0) ||
 							(maintenance.state === "dead" && maintenance.generation > 0)
 						? "dead"
-						: read.state === "starting" || maintenance.state === "starting"
+						: read.state === "starting" || write.state === "starting" || maintenance.state === "starting"
 							? "starting"
-							: read.state === "ready" || maintenance.state === "ready"
+							: read.state === "ready" || write.state === "ready" || maintenance.state === "ready"
 								? "ready"
 								: "dead";
 		return {
 			state,
 			initialization: maintenance.initialization,
 			databaseReady: maintenance.databaseReady,
-			pid: read.pid ?? maintenance.pid,
-			generation: Math.max(read.generation, maintenance.generation),
-			queuedJobs: read.queuedJobs + maintenance.queuedJobs,
-			foregroundQueuedJobs: read.foregroundQueuedJobs + maintenance.foregroundQueuedJobs,
-			maintenanceQueuedJobs: read.maintenanceQueuedJobs + maintenance.maintenanceQueuedJobs,
-			activeJobId: read.activeJobId ?? maintenance.activeJobId,
-			activeWorkloadClass: read.activeWorkloadClass ?? maintenance.activeWorkloadClass,
-			foregroundOldestAgeMs: oldestAge(read.foregroundOldestAgeMs, maintenance.foregroundOldestAgeMs),
+			pid: read.pid ?? write.pid ?? maintenance.pid,
+			generation: Math.max(read.generation, write.generation, maintenance.generation),
+			queuedJobs: read.queuedJobs + write.queuedJobs + maintenance.queuedJobs,
+			foregroundQueuedJobs: read.foregroundQueuedJobs + write.foregroundQueuedJobs + maintenance.foregroundQueuedJobs,
+			maintenanceQueuedJobs:
+				read.maintenanceQueuedJobs + write.maintenanceQueuedJobs + maintenance.maintenanceQueuedJobs,
+			activeJobId: read.activeJobId ?? write.activeJobId ?? maintenance.activeJobId,
+			activeWorkloadClass: read.activeWorkloadClass ?? write.activeWorkloadClass ?? maintenance.activeWorkloadClass,
+			foregroundOldestAgeMs: oldestAge(
+				oldestAge(read.foregroundOldestAgeMs, write.foregroundOldestAgeMs),
+				maintenance.foregroundOldestAgeMs,
+			),
 			maintenanceOldestAgeMs: oldestAge(read.maintenanceOldestAgeMs, maintenance.maintenanceOldestAgeMs),
 			lanes: {
 				read: toLaneHealth(read),
+				write: toLaneHealth(write),
 				maintenance: toLaneHealth(maintenance),
 			},
-			lastError: read.lastError ?? maintenance.lastError,
-			deadlineKills: read.deadlineKills + maintenance.deadlineKills,
+			lastError: read.lastError ?? write.lastError ?? maintenance.lastError,
+			deadlineKills: read.deadlineKills + write.deadlineKills + maintenance.deadlineKills,
 		};
 	}
 
 	return {
 		async start(): Promise<void> {
 			if (closed) throw new DbOwnerError("DB_OWNER_CLOSED", "DB owner client is closed");
-			await Promise.all([readLane.start(), maintenanceLane.start()]);
+			await Promise.all([readLane.start(), writeLane.start(), maintenanceLane.start()]);
 		},
 		async initialize(agentsDir?: string): Promise<void> {
 			await maintenanceLane.initialize(agentsDir);
 		},
 		submit<Result>(request: DbOwnerRequest, submitOptions: DbOwnerSubmitOptions): DbOwnerJobHandle<Result> {
-			return laneFor(submitOptions.lane).submit<Result>(request, submitOptions);
+			return laneFor(submitOptions.lane, submitOptions.workloadClass).submit<Result>(request, submitOptions);
 		},
 		awaitResult<Result>(handle: DbOwnerJobHandle<Result>, timeoutMs?: number): Promise<Result> {
-			return laneFor(handle.job.lane).awaitResult(handle, timeoutMs);
+			return laneFor(handle.job.lane, handle.job.workloadClass).awaitResult(handle, timeoutMs);
 		},
 		cancel(jobId) {
 			readLane.cancel(jobId);
+			writeLane.cancel(jobId);
 			maintenanceLane.cancel(jobId);
 		},
 		health,
 		async close(): Promise<void> {
 			if (closed) return;
 			closed = true;
-			await Promise.all([readLane.close(), maintenanceLane.close()]);
+			const lanes = [readLane];
+			if (writeLane !== readLane) lanes.push(writeLane);
+			if (maintenanceLane !== readLane && maintenanceLane !== writeLane) lanes.push(maintenanceLane);
+			await Promise.all(lanes.map((lane) => lane.close()));
 		},
 	};
 }

--- a/platform/daemon/src/db-owner-client.ts
+++ b/platform/daemon/src/db-owner-client.ts
@@ -48,7 +48,6 @@ export interface DbOwnerLaneHealth {
 	readonly foregroundOldestAgeMs: number | null;
 	readonly maintenanceOldestAgeMs: number | null;
 	readonly lastError: string | null;
-	readonly deadlineKills: number;
 }
 
 export interface DbOwnerHealth {
@@ -73,8 +72,6 @@ export interface DbOwnerHealth {
 		readonly maintenance: DbOwnerLaneHealth;
 	};
 	readonly lastError: string | null;
-	/** Number of owner processes killed by supervised shutdown or transport recovery. */
-	readonly deadlineKills: number;
 }
 
 export interface DbOwnerSubmitOptions {
@@ -224,7 +221,6 @@ function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient
 	let pid: number | null = null;
 	let activeJobId: string | null = null;
 	let lastError: string | null = null;
-	const deadlineKills = 0;
 	let initialization: DbOwnerInitializationState = "not_started";
 	let sequence = 0;
 	let input = "";
@@ -263,7 +259,6 @@ function createSingleDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClient
 			foregroundOldestAgeMs: oldestAge("foreground"),
 			maintenanceOldestAgeMs: oldestAge("maintenance"),
 			lastError,
-			deadlineKills,
 		};
 	}
 
@@ -744,7 +739,6 @@ export function createDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClien
 			foregroundOldestAgeMs: lane.foregroundOldestAgeMs,
 			maintenanceOldestAgeMs: lane.maintenanceOldestAgeMs,
 			lastError: lane.lastError,
-			deadlineKills: lane.deadlineKills,
 		};
 	}
 
@@ -789,7 +783,6 @@ export function createDbOwnerClient(options: DbOwnerClientOptions): DbOwnerClien
 				maintenance: toLaneHealth(maintenance),
 			},
 			lastError: read.lastError ?? write.lastError ?? maintenance.lastError,
-			deadlineKills: read.deadlineKills + write.deadlineKills + maintenance.deadlineKills,
 		};
 	}
 

--- a/platform/daemon/src/db-owner-protocol.md
+++ b/platform/daemon/src/db-owner-protocol.md
@@ -93,9 +93,9 @@ transaction request wraps all of its statements atomically. A `batch` contains
 only `run` statements and also rolls back on failure; `requireChanges` is a
 fail-closed zero-change precondition.
 
-A queued cancellation is removed from the client pending map, clears its deadline timer, and is removed from the owner's queue before execution. A cancellation received while synchronous native SQLite work is running is best effort because the owner cannot observe stdin until that call returns. A deadline is different: the client kills the entire child with `SIGKILL` at the absolute deadline. The subsequent owner death fails all other in-flight and queued jobs closed.
+A queued cancellation is removed from the client pending map, clears its deadline timer, and is removed from the owner's queue before execution. A cancellation received while synchronous native SQLite work is running is best effort because the owner cannot observe stdin until that call returns. A deadline abandons the job rather than killing the owner: the client rejects the handle, removes the job from its pending map, and sends a cancel message when the job was dispatched. The owner drops a still-queued job; an already-running synchronous operation may finish, but its abandoned result is ignored. Other jobs continue on the surviving owner.
 
-Construction failure, malformed protocol input, owner exit, deadline kill, and job failure are all observable through the health state or the rejected handle. A dead owner is recoverable without a daemon restart, but no job is silently replayed because writes may have reached SQLite before a process crash.
+Construction failure, malformed protocol input, owner exit, deadline abandonment, and job failure are observable through the health state or the rejected handle. Deadline expiry does not kill the owner or fail unrelated jobs. Supervised shutdown and transport recovery are the only owner-kill authorities; no job is silently replayed because writes may have reached SQLite before a process crash.
 
 ## Client surface
 
@@ -105,8 +105,7 @@ Construction failure, malformed protocol input, owner exit, deadline kill, and j
 - `submit(request, options)` returns a serializable job envelope and a typed result handle.
 - `awaitResult(handle, timeoutMs?)` awaits a result and cancels on the optional caller timeout.
 - `cancel(jobId)` requests cancellation.
-- `health()` returns owner state, PID, generation, total and per-class queue counts, active job/class, oldest pending ages, and last error without touching SQLite.
-- `health()` also reports hard-deadline kills, so maintenance pressure is visible without touching SQLite.
+- `health()` returns owner state, PID, generation, total and per-class queue counts, active job/class, oldest pending ages, and last error without touching SQLite. Deadline expiry is represented by the rejected job handle, not a hard-deadline-kill metric: it abandons the job, sends cancellation to the owner when dispatched, and leaves the owner alive.
 - `close()` sends shutdown and is idempotent.
 
 No callback receives a database handle. No synchronous SQLite symbol is exported by the client or the recall seam. The owner module is the sanctioned synchronous site.

--- a/platform/daemon/src/db-owner-runtime.ts
+++ b/platform/daemon/src/db-owner-runtime.ts
@@ -92,10 +92,12 @@ export interface DbOwnerSqlOptions {
 }
 
 function submitOptions(options: DbOwnerSqlOptions): DbOwnerSubmitOptions {
+	const workloadClass =
+		options.workloadClass ?? (/^(?:sources|maintenance|vacuum)\./.test(options.operation) ? "maintenance" : undefined);
 	return {
 		operation: options.operation,
 		lane: options.lane ?? "write",
-		workloadClass: options.workloadClass,
+		workloadClass,
 		deadlineMs: options.deadlineMs ?? 5_000,
 		estimatedWorkUnits: options.estimatedWorkUnits,
 	};

--- a/platform/daemon/src/db-owner-runtime.ts
+++ b/platform/daemon/src/db-owner-runtime.ts
@@ -92,8 +92,9 @@ export interface DbOwnerSqlOptions {
 }
 
 function submitOptions(options: DbOwnerSqlOptions): DbOwnerSubmitOptions {
-	const workloadClass =
-		options.workloadClass ?? (/^(?:sources|maintenance|vacuum)\./.test(options.operation) ? "maintenance" : undefined);
+	const workloadClass = /^(?:sources|maintenance|vacuum)\./.test(options.operation)
+		? "maintenance"
+		: options.workloadClass;
 	return {
 		operation: options.operation,
 		lane: options.lane ?? "write",

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -79,6 +79,16 @@ export function loadSqliteVecIfAvailable(db: SqliteDatabase, extension: string):
 	}
 }
 
+export function shouldRecordDbOwnerCancellation(
+	jobId: string,
+	activeJobId: string | null,
+	foregroundJobs: readonly Pick<DbOwnerJob, "id">[],
+	maintenanceJobs: readonly Pick<DbOwnerJob, "id">[],
+): boolean {
+	if (jobId === activeJobId) return false;
+	return foregroundJobs.some((job) => job.id === jobId) || maintenanceJobs.some((job) => job.id === jobId);
+}
+
 export function runDbOwnerWorker(): void {
 	const dbPath = process.env.SIGNET_DB_OWNER_DB_PATH;
 	if (dbPath === undefined) throw new Error("DB owner requires SIGNET_DB_OWNER_DB_PATH");
@@ -177,6 +187,7 @@ export function runDbOwnerWorker(): void {
 		}
 		return undefined;
 	}
+
 	function bindParameter(value: DbOwnerParameter): unknown {
 		if (typeof value === "object" && value !== null && value.type === "bytes") {
 			return Buffer.from(value.base64, "base64");
@@ -525,6 +536,7 @@ export function runDbOwnerWorker(): void {
 			process.exit(0);
 		}
 		if (command.type === "cancel") {
+			if (!shouldRecordDbOwnerCancellation(command.jobId, activeJobId, foregroundQueue, maintenanceQueue)) return;
 			cancelled.add(command.jobId);
 			return;
 		}

--- a/platform/daemon/src/routes/health.test.ts
+++ b/platform/daemon/src/routes/health.test.ts
@@ -78,7 +78,6 @@ describe("GET /health owner diagnostics", () => {
 			foregroundOldestAgeMs: 12,
 			maintenanceOldestAgeMs: 34,
 			lastError: null,
-			deadlineKills: 0,
 		} as const;
 		const ownerHealth = {
 			...lane,

--- a/platform/daemon/src/startup-recovery.ts
+++ b/platform/daemon/src/startup-recovery.ts
@@ -40,7 +40,6 @@ export interface StartupRecoveryProgress {
 	readonly operation: string;
 	readonly processed: number;
 	readonly batches: number;
-	readonly deadlineKills: number;
 	readonly ownerState: string | null;
 	readonly ownerGeneration: number | null;
 	readonly updatedAt: string;
@@ -63,7 +62,6 @@ const PENDING_INTEGRITY: DatabaseIntegrityStatus = {
 	repairGuidance: null,
 	ownerState: null,
 	ownerGeneration: null,
-	deadlineKills: 0,
 	incrementalProgress: null,
 };
 
@@ -149,7 +147,6 @@ async function runOwnerStartupRecovery(owner: DbOwnerClient): Promise<StartupRec
 			processed,
 			ownerState: health.state,
 			ownerGeneration: health.generation,
-			deadlineKills: health.deadlineKills,
 		});
 	};
 


### PR DESCRIPTION
## Summary

- split the daemon DB-owner client into independent read, interactive-write, and maintenance owner lanes so queue priority is backed by reserved process/connection capacity
- classify `sources.*`, `maintenance.*`, and `vacuum.*` runtime operations authoritatively as maintenance, including callers that request foreground workload class
- change per-job deadline handling to abandon and cancel work without killing the DB owner; supervised shutdown and transport recovery remain the only owner-kill paths
- aggregate per-lane health and retain durable maintenance checkpoint/reschedule behavior

## Repair notes

- [x] Finding 1: `platform/daemon/src/db-owner-worker.ts:82-90,539-541` now records cancellation IDs only for jobs still present in a queue; active, completed, and unknown job IDs are ignored, preventing late-cancel set growth. `platform/daemon/src/db-owner-client.test.ts:603-610` covers 1,000 completed-job cancels plus active and queued cases.
- [x] Finding 2: `platform/daemon/src/db-owner-runtime.ts:95-98` makes the `sources.*`, `maintenance.*`, and `vacuum.*` operation classifier override explicit foreground workload class. `platform/daemon/src/db-owner-client.test.ts:613-642` verifies a `sources.*` foreground override queues on maintenance while that lane is saturated.
- [x] Finding 3: removed the dead always-zero `deadlineKills` field from DB-owner lane/aggregate health and its database-integrity/startup-recovery status and logging surfaces. The existing deadline tests retain the no-kill owner behavior without a misleading metric.

## Evidence

- `bun test platform/daemon/src/db-owner-client.test.ts` - 27 pass, 0 fail
- `bun test platform/daemon/src/db-owner-maintenance.test.ts` - 13 pass, 0 fail
- `bun test platform/daemon/src/incremental-database-integrity.test.ts` - 6 pass, 0 fail
- `bun test platform/daemon/src/database-integrity.test.ts` - 17 pass, 0 fail
- `bun test platform/daemon/src/routes/health.test.ts` - 15 pass, 0 fail
- `bun test platform/daemon/src/native-memory-sources.test.ts` - 57 pass, 0 fail
- `bun test platform/daemon/src/obsidian-source-embeddings.test.ts` - 11 pass, 0 fail
- `bun test platform/daemon/src/daemon-production-wiring.test.ts` - 2 pass, 0 fail
- `bun test platform/daemon/src/deferred-runtime-gate.test.ts` - 2 pass, 0 fail
- aggregate: 150 pass, 0 fail across 9 files
- `bunx biome check platform/daemon/src/daemon-auth-guard-colocation.test.ts platform/daemon/src/database-integrity.test.ts platform/daemon/src/database-integrity.ts platform/daemon/src/db-owner-client.test.ts platform/daemon/src/db-owner-client.ts platform/daemon/src/db-owner-runtime.ts platform/daemon/src/db-owner-worker.ts platform/daemon/src/routes/health.test.ts platform/daemon/src/startup-recovery.ts`
- `bun run --filter '@signet/core' build`
- `bun run --filter '@signet/daemon' build` (includes daemon typecheck)

The saturation tests prove interactive health/dashboard/recall/write submissions complete while a maintenance owner is busy, and deadline tests prove timed-out maintenance work does not replace or kill the owner.

Refs #1696

## AI disclosure

- [x] AI tools were used (kanban worker t_57ba96b2, orchestrator-verified)

## Type

- [ ] `feat` - new user-facing feature (bumps minor)
- [x] `fix` - bug fix
- [ ] `refactor` - restructure without behavior change
- [ ] `chore` - build, deps, config, docs
- [ ] `perf` - performance improvement
- [ ] `test` - test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally
