### PR TITLE
fix(daemon): pause source sync on provider outage

### DIFF
--- a/platform/core/src/migrations/139-native-source-sync-state.ts
+++ b/platform/core/src/migrations/139-native-source-sync-state.ts
@@ -1,0 +1,19 @@
+import type { MigrationDb } from "./index";
+
+/** Durable source-level pause and frontier for provider-gated native sync. */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS native_source_sync_state (
+			agent_id TEXT NOT NULL,
+			source_key TEXT NOT NULL,
+			source_root TEXT NOT NULL,
+			status TEXT NOT NULL CHECK(status IN ('running', 'paused')),
+			checkpoint_path TEXT,
+			pause_reason TEXT,
+			updated_at TEXT NOT NULL,
+			PRIMARY KEY (agent_id, source_key)
+		);
+		CREATE INDEX IF NOT EXISTS idx_native_source_sync_state_status
+			ON native_source_sync_state(agent_id, status);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -144,6 +144,7 @@ import { up as memoryHeadPublication } from "./135-memory-head-publication";
 import { up as memoryHeadRevisions } from "./136-memory-head-revisions";
 import { up as dreamingHeadManifest } from "./137-dreaming-head-manifest";
 import { up as boundedStatusProjections } from "./138-bounded-status-projections";
+import { up as nativeSourceSyncState } from "./139-native-source-sync-state";
 
 // -- Public interface consumed by Database.init() --
 
@@ -1274,6 +1275,12 @@ export const MIGRATIONS: readonly Migration[] = [
 		artifacts: {
 			tables: ["transcript_capture_status", "memories_duplicate_hash_counts", "memories_diagnostics_state"],
 		},
+	},
+	{
+		version: 139,
+		name: "native-source-sync-state",
+		up: nativeSourceSyncState,
+		artifacts: { tables: ["native_source_sync_state"] },
 	},
 ];
 

--- a/platform/daemon/src/daemon-production-wiring.test.ts
+++ b/platform/daemon/src/daemon-production-wiring.test.ts
@@ -36,6 +36,8 @@ describe("daemon production DB owner wiring", () => {
 
 		expect(source).toContain("const syncResult = nativeMemoryBridge?.getLastSyncResult?.();");
 		expect(source).toContain("pauseSourceIndexJob(sourceId, jobId, {");
+		expect(source).toContain("scanned: paused.scanned,");
+		expect(source).toContain("indexed: paused.indexed,");
 		expect(source).toContain('outcome: syncResult?.status === "paused" && paused ? "partial" : "success",');
 		expect(source).toContain('updateFreshness: syncResult?.status === "paused" && paused ? false : undefined,');
 	});

--- a/platform/daemon/src/daemon-production-wiring.test.ts
+++ b/platform/daemon/src/daemon-production-wiring.test.ts
@@ -30,4 +30,13 @@ describe("daemon production DB owner wiring", () => {
 		expect(source).toContain("INCREMENTAL_INTEGRITY_TABLES_PER_RUN");
 		expect(source).not.toContain("runDeferredIntegrityCheck");
 	});
+
+	it("keeps a paused startup source partial instead of reporting success", async () => {
+		const source = await Bun.file(daemonSourceUrl).text();
+
+		expect(source).toContain("const syncResult = nativeMemoryBridge?.getLastSyncResult?.();");
+		expect(source).toContain("pauseSourceIndexJob(sourceId, jobId, {");
+		expect(source).toContain('outcome: syncResult?.status === "paused" && paused ? "partial" : "success",');
+		expect(source).toContain('updateFreshness: syncResult?.status === "paused" && paused ? false : undefined,');
+	});
 });

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -178,6 +178,7 @@ import {
 	getSourceIndexJob,
 	markSourceIndexInFlight,
 	markSourceIndexJobRunning,
+	pauseSourceIndexJob,
 	updateSourceIndexJobProgress,
 } from "./source-index-progress";
 import {
@@ -2593,8 +2594,17 @@ async function main() {
 					nativeMemoryBridge
 						.syncExisting()
 						.then(() => {
+							const syncResult = nativeMemoryBridge?.getLastSyncResult?.();
 							for (const [sourceId, jobId] of startupSourceJobs) {
-								completeSourceIndexJobFromProgress(sourceId, jobId);
+								const paused = syncResult?.pausedSources.find((result) => result.sourceId === sourceId);
+								if (syncResult?.status === "paused" && paused) {
+									pauseSourceIndexJob(sourceId, jobId, {
+										pauseReason: paused.pauseReason ?? "provider_unavailable",
+										resumeFrontier: paused.resumeFrontier,
+									});
+								} else {
+									completeSourceIndexJobFromProgress(sourceId, jobId);
+								}
 								const source = loadSourcesConfig(AGENTS_DIR).sources.find((entry) => entry.id === sourceId);
 								const job = getSourceIndexJob(sourceId);
 								if (source) {
@@ -2609,7 +2619,13 @@ async function main() {
 												job?.startedAt && job.finishedAt
 													? Math.max(0, Date.parse(job.finishedAt) - Date.parse(job.startedAt))
 													: 0,
-											outcome: "success",
+											outcome: syncResult?.status === "paused" && paused ? "partial" : "success",
+											failureClass:
+												syncResult?.status === "paused" && paused
+													? sourceFailureClass(new Error("network provider unavailable"))
+													: undefined,
+											updateFreshness: syncResult?.status === "paused" && paused ? false : undefined,
+											searchable: syncResult?.status === "paused" && paused ? (job?.indexed ?? 0) > 0 : undefined,
 										}),
 									);
 								}

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -2601,6 +2601,8 @@ async function main() {
 									pauseSourceIndexJob(sourceId, jobId, {
 										pauseReason: paused.pauseReason ?? "provider_unavailable",
 										resumeFrontier: paused.resumeFrontier,
+										scanned: paused.scanned,
+										indexed: paused.indexed,
 									});
 								} else {
 									completeSourceIndexJobFromProgress(sourceId, jobId);

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { addObsidianSource, loadSourcesConfig } from "@signet/core";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { resetEmbeddingCircuitBreakers } from "./embedding-circuit-breaker";
+import { resetObsidianSourceEmbeddingBackoff } from "./obsidian-source-embeddings";
 import { indexExternalMemoryArtifact } from "./memory-lineage";
 import {
 	claudeCodeNativeMemorySource,
@@ -1000,7 +1001,7 @@ describe("native memory sources", () => {
 		).toBe(true);
 		expect(
 			await indexNativeMemoryFile(source, file, "agent-native", {
-				embeddingConfig: { provider: "native", model: "test", dimensions: 3, base_url: "" },
+				embeddingConfig: { provider: "native", model: "test", dimensions: 3, base_url: "", profile: "test" },
 				fetchEmbedding: async () => [1, 2, 3],
 			}),
 		).toBe(true);
@@ -1190,7 +1191,7 @@ describe("native memory sources", () => {
 				file,
 				"agent-native",
 				{
-					embeddingConfig: { provider: "native", model: "test", dimensions: 3, base_url: "" },
+					embeddingConfig: { provider: "native", model: "test", dimensions: 3, base_url: "", profile: "test" },
 					fetchEmbedding: async () => [1, 2, 3],
 				},
 			),
@@ -1208,71 +1209,152 @@ describe("native memory sources", () => {
 		expect(rows.some((row) => row.chunk_text.includes("heading: Signet Sources"))).toBe(true);
 	});
 
-	it("completes source artifact sync and backoffs embeddings when the provider is down", async () => {
+	it("pauses a source before scanning when its embedding provider is unavailable", async () => {
 		const root = join(dir, "provider-down-vault");
 		const file = join(root, "permanent", "Pending.md");
 		mkdirSync(join(root, "permanent"), { recursive: true });
-		writeFileSync(
-			file,
-			"# Pending Embeddings\n\nThe source artifact remains searchable as canonical evidence while its provider-down embedding work waits for retry.\n",
-		);
+		writeFileSync(file, "# Pending Embeddings\n\nProvider availability must gate all source work.\n");
 		let fetches = 0;
-		let heartbeats = 0;
-		const statuses: string[] = [];
-		const heartbeat = setInterval(() => {
-			heartbeats++;
-		}, 5);
+		const indexed: string[] = [];
 		const source = obsidianNativeMemorySource(root, "Provider Down Vault", "obsidian:provider-down");
-		const handle = startNativeMemoryBridge([source], {
-			agentId: "agent-native",
-			pollIntervalMs: 0,
-			sourceGraphEnabled: true,
-			embeddingConfig: { provider: "native", model: "down-model", dimensions: 3, base_url: "" },
-			fetchEmbedding: async (_text, _cfg, _role, options) => {
-				fetches++;
-				await new Promise((resolve) => setTimeout(resolve, 25));
-				options?.onFailure?.("provider_unavailable");
-				return null;
-			},
-			onFileIndexed: (event) => {
-				if (event.status) statuses.push(event.status);
-			},
-		});
+		const makeHandle = () =>
+			startNativeMemoryBridge([source], {
+				agentId: "agent-native",
+				pollIntervalMs: 0,
+				sourceGraphEnabled: false,
+				embeddingConfig: { provider: "native", model: "down-model", dimensions: 3, base_url: "", profile: "down" },
+				fetchEmbedding: async (_text, _cfg, _role, options) => {
+					fetches++;
+					options?.onFailure?.("provider_unavailable");
+					return null;
+				},
+				onFileIndexed: (event) => indexed.push(event.filePath),
+			});
+		const handle = makeHandle();
 		try {
-			expect(await handle.syncExisting()).toBe(1);
 			expect(await handle.syncExisting()).toBe(0);
 			expect(fetches).toBe(1);
-			expect(heartbeats).toBeGreaterThan(0);
-			expect(statuses).toEqual(["embeddings pending - provider down", "embeddings pending - provider down"]);
-
-			const semanticRows = getDbAccessor().withReadDb(
-				(db) =>
-					db
-						.prepare(
-							`SELECT
-							(SELECT COUNT(*) FROM entities WHERE agent_id = ? AND source_id = ? AND source_path = ?) AS graph_count,
-							(SELECT COUNT(*) FROM embeddings WHERE agent_id = ? AND source_type = 'source_chunk') AS embedding_count`,
-						)
-						.get("agent-native", "obsidian:provider-down", file, "agent-native") as {
-						graph_count: number;
-						embedding_count: number;
-					},
-			);
-			expect(semanticRows.graph_count).toBe(0);
-			expect(semanticRows.embedding_count).toBe(0);
-
-			const artifact = getDbAccessor().withReadDb(
-				(db) =>
-					db.prepare("SELECT source_path, content FROM memory_artifacts WHERE source_path = ?").get(file) as {
-						source_path: string;
-						content: string;
-					},
-			);
-			expect(artifact.source_path).toBe(file);
-			expect(artifact.content).toContain("canonical evidence");
+			expect(indexed).toEqual([]);
+			expect(
+				await getDbAccessor().withReadDbAsync(
+					(db) =>
+						db
+							.prepare(
+								"SELECT status, checkpoint_path, pause_reason FROM native_source_sync_state WHERE agent_id = ? AND source_key = ?",
+							)
+							.get("agent-native", "obsidian:provider-down") as {
+							status: string;
+							checkpoint_path: string | null;
+							pause_reason: string | null;
+						},
+				),
+			).toEqual({ status: "paused", checkpoint_path: null, pause_reason: "provider_unavailable" });
 		} finally {
-			clearInterval(heartbeat);
 			await handle.close();
+		}
+
+		// A new bridge must honor the durable pause without rescanning, owner
+		// churn, or a legacy artifact fallback.
+		const restarted = makeHandle();
+		try {
+			expect(await restarted.syncExisting()).toBe(0);
+			expect(fetches).toBe(1);
+			expect(indexed).toEqual([]);
+		} finally {
+			await restarted.close();
+		}
+	});
+
+	it("resumes a paused source from its durable checkpoint after provider recovery", async () => {
+		const root = join(dir, "checkpoint-vault");
+		const first = join(root, "permanent", "A.md");
+		const second = join(root, "permanent", "B.md");
+		mkdirSync(join(root, "permanent"), { recursive: true });
+		writeFileSync(first, "# Checkpoint A\n\nThe first note completes before the provider fails.\n");
+		writeFileSync(
+			second,
+			"# Checkpoint B\n\nThe second note resumes after recovery and contains enough durable source text to require an embedding checkpoint.\n",
+		);
+		let failSecond = true;
+		let chunkCalls = 0;
+		const calls: string[] = [];
+		const indexed: string[] = [];
+		const source = obsidianNativeMemorySource(root, "Checkpoint Vault", "obsidian:checkpoint");
+		const makeHandle = () =>
+			startNativeMemoryBridge([source], {
+				agentId: "agent-native",
+				pollIntervalMs: 0,
+				sourceGraphEnabled: false,
+				embeddingConfig: {
+					provider: "native",
+					model: "checkpoint-model",
+					dimensions: 3,
+					base_url: "",
+					profile: "checkpoint",
+				},
+				fetchEmbedding: async (text, _cfg, _role, options) => {
+					calls.push(text);
+					if (text.trim().length > 0) {
+						chunkCalls++;
+						if (failSecond && chunkCalls === 2) {
+							options?.onFailure?.("provider_unavailable");
+							return null;
+						}
+					}
+					return [1, 2, 3];
+				},
+				onFileIndexed: (event) => indexed.push(event.filePath),
+			});
+		const firstHandle = makeHandle();
+		try {
+			expect(await firstHandle.syncExisting()).toBe(2);
+			expect(indexed).toContain(first);
+			expect(indexed).toContain(second);
+			expect(
+				await getDbAccessor().withReadDbAsync(
+					(db) =>
+						db
+							.prepare(
+								"SELECT status, checkpoint_path, pause_reason FROM native_source_sync_state WHERE agent_id = ? AND source_key = ?",
+							)
+							.get("agent-native", "obsidian:checkpoint") as {
+							status: string;
+							checkpoint_path: string | null;
+							pause_reason: string | null;
+						},
+				),
+			).toEqual({ status: "paused", checkpoint_path: first, pause_reason: "provider_unavailable" });
+		} finally {
+			await firstHandle.close();
+		}
+
+		failSecond = false;
+		resetEmbeddingCircuitBreakers();
+		resetObsidianSourceEmbeddingBackoff();
+		const callsBeforeRecovery = calls.length;
+		const indexedBeforeRecovery = indexed.length;
+		const recovered = makeHandle();
+		try {
+			expect(await recovered.syncExisting()).toBe(1);
+			expect(indexed.slice(indexedBeforeRecovery)).toEqual([second]);
+			expect(calls.slice(callsBeforeRecovery).some((text) => text.includes("Checkpoint A"))).toBe(false);
+			expect(calls.slice(callsBeforeRecovery).some((text) => text.includes("Checkpoint B"))).toBe(true);
+			expect(
+				await getDbAccessor().withReadDbAsync(
+					(db) =>
+						db
+							.prepare(
+								"SELECT status, checkpoint_path, pause_reason FROM native_source_sync_state WHERE agent_id = ? AND source_key = ?",
+							)
+							.get("agent-native", "obsidian:checkpoint") as {
+							status: string;
+							checkpoint_path: string | null;
+							pause_reason: string | null;
+						},
+				),
+			).toEqual({ status: "running", checkpoint_path: null, pause_reason: null });
+		} finally {
+			await recovered.close();
 		}
 	});
 
@@ -1377,7 +1459,7 @@ describe("native memory sources", () => {
 
 		expect(
 			await indexNativeMemoryFile(initialSource, privateFile, "agent-native", {
-				embeddingConfig: { provider: "native", model: "test", dimensions: 3, base_url: "" },
+				embeddingConfig: { provider: "native", model: "test", dimensions: 3, base_url: "", profile: "test" },
 				fetchEmbedding: async () => [1, 2, 3],
 			}),
 		).toBe(true);
@@ -1612,7 +1694,7 @@ describe("native memory sources", () => {
 		handle = startNativeMemoryBridge([source], {
 			agentId: "agent-native",
 			pollIntervalMs: 0,
-			embeddingConfig: { provider: "native", model: "test", dimensions: 3, base_url: "" },
+			embeddingConfig: { provider: "native", model: "test", dimensions: 3, base_url: "", profile: "test" },
 			fetchEmbedding: async () => {
 				embeddingCalls++;
 				if (embeddingCalls === 1) {
@@ -1649,7 +1731,7 @@ describe("native memory sources", () => {
 		const handle = startNativeMemoryBridge([obsidianNativeMemorySource(root, "Slow Vault", "obsidian:slow-vault")], {
 			agentId: "agent-native",
 			pollIntervalMs: 1,
-			embeddingConfig: { provider: "native", model: "test", dimensions: 3, base_url: "" },
+			embeddingConfig: { provider: "native", model: "test", dimensions: 3, base_url: "", profile: "test" },
 			fetchEmbedding: async () => {
 				await Bun.sleep(20);
 				return [1, 2, 3];

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -7,6 +7,7 @@ import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { resetEmbeddingCircuitBreakers } from "./embedding-circuit-breaker";
 import { resetObsidianSourceEmbeddingBackoff } from "./obsidian-source-embeddings";
 import { indexExternalMemoryArtifact } from "./memory-lineage";
+import type { NativeMemoryBridgeOptions } from "./native-memory-sources";
 import {
 	claudeCodeNativeMemorySource,
 	codexNativeMemorySource,
@@ -1235,6 +1236,13 @@ describe("native memory sources", () => {
 			expect(await handle.syncExisting()).toBe(0);
 			expect(fetches).toBe(1);
 			expect(indexed).toEqual([]);
+			expect(handle.getLastSyncResult?.()).toMatchObject({
+				status: "paused",
+				indexed: 0,
+				pausedSources: [
+					{ sourceId: "obsidian:provider-down", resumeFrontier: null, pauseReason: "provider_unavailable" },
+				],
+			});
 			expect(
 				await getDbAccessor().withReadDbAsync(
 					(db) =>
@@ -1262,6 +1270,64 @@ describe("native memory sources", () => {
 			expect(indexed).toEqual([]);
 		} finally {
 			await restarted.close();
+		}
+	});
+
+	it("joins a polling bridge scan from a manual bridge without duplicating provider calls", async () => {
+		const root = join(dir, "cross-instance-vault");
+		const file = join(root, "permanent", "Shared.md");
+		mkdirSync(join(root, "permanent"), { recursive: true });
+		writeFileSync(file, "# Shared\n\nOne provider call must serve both the polling and manual bridge instances.\n");
+		const source = obsidianNativeMemorySource(root, "Cross Instance Vault", "obsidian:cross-instance");
+		let releaseEmbedding = () => {};
+		const embeddingGate = new Promise<void>((resolve) => {
+			releaseEmbedding = resolve;
+		});
+		let embeddingStarted = false;
+		let providerCalls = 0;
+		let probeCalls = 0;
+		let embeddingCalls = 0;
+		const embeddingOptions: Pick<NativeMemoryBridgeOptions, "embeddingConfig" | "fetchEmbedding"> = {
+			embeddingConfig: { provider: "native", model: "cross-instance", dimensions: 3, base_url: "", profile: "cross" },
+			fetchEmbedding: async (text: string) => {
+				providerCalls++;
+				if (text.trim().length > 0) {
+					embeddingCalls++;
+					embeddingStarted = true;
+					await embeddingGate;
+				} else {
+					probeCalls++;
+				}
+				return [1, 2, 3];
+			},
+		};
+		const pollingBridge = startNativeMemoryBridge([source], {
+			agentId: "agent-native",
+			pollIntervalMs: 0,
+			...embeddingOptions,
+		});
+		const manualBridge = startNativeMemoryBridge([source], {
+			agentId: "agent-native",
+			pollIntervalMs: 0,
+			...embeddingOptions,
+		});
+		try {
+			const pollingRun = pollingBridge.syncExisting();
+			for (let attempt = 0; attempt < 200 && !embeddingStarted; attempt++) await Bun.sleep(10);
+			expect(embeddingStarted).toBe(true);
+			const manualRun = manualBridge.syncExisting();
+			await Bun.sleep(20);
+			expect(providerCalls).toBe(3); // two availability probes and one file embedding from the polling scan
+			expect(probeCalls).toBe(2);
+			expect(embeddingCalls).toBe(1);
+			releaseEmbedding();
+			expect(await pollingRun).toBe(1);
+			expect(await manualRun).toBe(1);
+			expect(providerCalls).toBe(3);
+		} finally {
+			releaseEmbedding();
+			await pollingBridge.close();
+			await manualBridge.close();
 		}
 	});
 

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -66,7 +66,25 @@ export interface NativeMemoryFilePattern {
 
 export interface NativeMemoryBridgeHandle {
 	readonly syncExisting: (options?: NativeMemoryBridgeSyncOptions) => Promise<number>;
+	readonly getLastSyncResult?: () => NativeMemorySyncResult;
 	readonly close: () => Promise<void>;
+}
+
+export interface NativeMemorySyncSourceResult {
+	readonly sourceKey: string;
+	readonly sourceId?: string;
+	readonly status: "complete" | "paused";
+	readonly scanned: number;
+	readonly indexed: number;
+	readonly resumeFrontier: string | null;
+	readonly pauseReason?: string;
+}
+
+export interface NativeMemorySyncResult {
+	readonly status: "complete" | "paused";
+	readonly scanned: number;
+	readonly indexed: number;
+	readonly pausedSources: readonly NativeMemorySyncSourceResult[];
 }
 
 export interface NativeMemoryBridgeSyncOptions {
@@ -120,6 +138,14 @@ interface IndexedNativeMemory {
 }
 
 const indexed = new Map<string, IndexedNativeMemory>();
+
+interface SharedNativeMemorySourceFlight {
+	readonly promise: Promise<NativeMemorySyncSourceResult>;
+	readonly resolve: (result: NativeMemorySyncSourceResult) => void;
+	readonly reject: (error: unknown) => void;
+}
+
+const sharedNativeMemorySourceFlights = new Map<string, SharedNativeMemorySourceFlight>();
 
 /** Test-only: drop the in-process content-hash cache so scans behave like a fresh daemon. */
 export interface NativeMemorySourcePermissionIssue {
@@ -492,6 +518,10 @@ function fingerprintKey(source: Pick<NativeMemorySource, "harness">, filePath: s
 
 function sourceStateKey(source: NativeMemorySource, agentId: string): string {
 	return `${agentId}:${source.harness}:${source.root.replace(/\\/g, "/").replace(/\/$/, "")}`;
+}
+
+function sourceFlightKey(source: NativeMemorySource, agentId: string): string {
+	return `${agentId}:${nativeSourceSyncKey(source)}:${normalizedRoot(source.root)}`;
 }
 
 function contentFingerprint(content: string): string {
@@ -1157,180 +1187,247 @@ export function startNativeMemoryBridge(
 	const known = new Map<string, Set<string>>();
 	const syncStates = new Map<string, NativeSourceSyncState | null>();
 
-	const runScan = async (): Promise<number> => {
+	const runScan = async (): Promise<NativeMemorySyncResult> => {
 		let count = 0;
+		const sourceResults: NativeMemorySyncSourceResult[] = [];
 		const yielder = yieldEvery(options.yieldEveryFiles ?? 20);
 		for (const source of activeBridgeSources(sources, options)) {
 			if (options.shouldContinue && !options.shouldContinue(source)) continue;
-			let changedCount = 0;
-			let scanned = 0;
-			const key = sourceStateKey(source, agentId);
-			const durableKey = nativeSourceSyncKey(source);
-			if (!syncStates.has(durableKey)) syncStates.set(durableKey, await readNativeSourceSyncState(agentId, source));
-			let syncState = syncStates.get(durableKey) ?? null;
-			if (sourceNeedsProvider(source, options)) {
-				const provider = await sourceProviderGate(agentId, options);
-				if (!provider.available) {
-					if (syncState?.status !== "paused") {
-						await persistNativeSourceSyncState({
-							agentId,
-							source,
+			const flightKey = sourceFlightKey(source, agentId);
+			const existingFlight = sharedNativeMemorySourceFlights.get(flightKey);
+			if (existingFlight) {
+				const joined = await existingFlight.promise;
+				sourceResults.push(joined);
+				count += joined.indexed;
+				syncStates.delete(nativeSourceSyncKey(source));
+				continue;
+			}
+			let resolveFlight!: (result: NativeMemorySyncSourceResult) => void;
+			let rejectFlight!: (error: unknown) => void;
+			const flightPromise = new Promise<NativeMemorySyncSourceResult>((resolve, reject) => {
+				resolveFlight = resolve;
+				rejectFlight = reject;
+			});
+			sharedNativeMemorySourceFlights.set(flightKey, {
+				promise: flightPromise,
+				resolve: resolveFlight,
+				reject: rejectFlight,
+			});
+			let sourceResult: NativeMemorySyncSourceResult | undefined;
+			let sourceFailure: unknown;
+			try {
+				let changedCount = 0;
+				let scanned = 0;
+				const key = sourceStateKey(source, agentId);
+				const durableKey = nativeSourceSyncKey(source);
+				let sourcePausedReason: string | undefined;
+				if (!syncStates.has(durableKey)) syncStates.set(durableKey, await readNativeSourceSyncState(agentId, source));
+				let syncState = syncStates.get(durableKey) ?? null;
+				if (sourceNeedsProvider(source, options)) {
+					const provider = await sourceProviderGate(agentId, options);
+					if (!provider.available) {
+						if (syncState?.status !== "paused") {
+							await persistNativeSourceSyncState({
+								agentId,
+								source,
+								status: "paused",
+								pauseReason: "provider_unavailable",
+							});
+							syncState = await readNativeSourceSyncState(agentId, source);
+							syncStates.set(durableKey, syncState);
+						}
+						sourcePausedReason = "provider_unavailable";
+						sourceResult = {
+							sourceKey: durableKey,
+							sourceId: source.sourceId,
 							status: "paused",
-							pauseReason: "provider_unavailable",
-						});
+							scanned,
+							indexed: changedCount,
+							resumeFrontier: syncState?.checkpointPath ?? null,
+							pauseReason: sourcePausedReason,
+						};
+						sourceResults.push(sourceResult);
+						continue;
+					}
+					if (syncState?.status === "paused") {
+						await persistNativeSourceSyncState({ agentId, source, status: "running" });
 						syncState = await readNativeSourceSyncState(agentId, source);
 						syncStates.set(durableKey, syncState);
 					}
-					continue;
 				}
-				if (syncState?.status === "paused") {
-					await persistNativeSourceSyncState({ agentId, source, status: "running" });
-					syncState = await readNativeSourceSyncState(agentId, source);
-					syncStates.set(durableKey, syncState);
-				}
-			}
-			let checkpointPath = syncState?.checkpointPath ?? null;
-			const current = new Set<string>();
-			const rootExists = await pathExists(source.root, source, agentId);
-			const maxFilesPerScan = options.maxFilesPerScan ?? NATIVE_MEMORY_MAX_FILES_PER_SCAN;
-			let scanComplete = true;
-			let scanTruncated = false;
-			if (rootExists) {
-				const fileDelayMs = sourceFileDelayMs(source, options);
-				let total = 0;
-				const markdownPathIndex =
-					source.harness === "obsidian" && (options.sourceGraphEnabled ?? true)
-						? buildObsidianMarkdownPathIndex(source.root, [])
-						: undefined;
-				for await (const file of walkNativeMemoryFiles(source.root, source, agentId)) {
-					if (!matchesPattern(source, file)) continue;
-					total++;
-					if (total > maxFilesPerScan) {
-						scanComplete = false;
-						scanTruncated = true;
-						break;
+				let checkpointPath = syncState?.checkpointPath ?? null;
+				const current = new Set<string>();
+				const rootExists = await pathExists(source.root, source, agentId);
+				const maxFilesPerScan = options.maxFilesPerScan ?? NATIVE_MEMORY_MAX_FILES_PER_SCAN;
+				let scanComplete = true;
+				let scanTruncated = false;
+				if (rootExists) {
+					const fileDelayMs = sourceFileDelayMs(source, options);
+					let total = 0;
+					const markdownPathIndex =
+						source.harness === "obsidian" && (options.sourceGraphEnabled ?? true)
+							? buildObsidianMarkdownPathIndex(source.root, [])
+							: undefined;
+					for await (const file of walkNativeMemoryFiles(source.root, source, agentId)) {
+						if (!matchesPattern(source, file)) continue;
+						total++;
+						if (total > maxFilesPerScan) {
+							scanComplete = false;
+							scanTruncated = true;
+							break;
+						}
+						current.add(file);
+						if (markdownPathIndex) addObsidianMarkdownPathIndex(markdownPathIndex, source.root, file);
+						await yielder();
 					}
-					current.add(file);
-					if (markdownPathIndex) addObsidianMarkdownPathIndex(markdownPathIndex, source.root, file);
-					await yielder();
-				}
-				// The generator plus awaited indexing below is a one-item bounded work queue.
-				for await (const file of walkNativeMemoryFiles(source.root, source, agentId)) {
-					if (scanned >= maxFilesPerScan) break;
-					if (!matchesPattern(source, file)) continue;
-					if (checkpointPath !== null && file.replace(/\\/g, "/") <= checkpointPath) continue;
-					if (options.shouldContinue && !options.shouldContinue(source)) {
-						scanComplete = false;
-						break;
-					}
-					scanned++;
-					let embeddingStatus: string | undefined;
-					const changed = await indexNativeMemoryFile(source, file, agentId, {
-						...options,
-						markdownPathIndex,
-						onEmbeddingStatus: (status) => {
-							embeddingStatus = status;
-							options.onEmbeddingStatus?.(status);
-						},
-					});
-					if (changed) {
-						count++;
-						changedCount++;
-					}
-					current.add(file);
-					options.onFileIndexed?.({
-						source,
-						filePath: file,
-						indexed: changed,
-						scanned,
-						total,
-						changed: changedCount,
-						...(embeddingStatus ? { status: embeddingStatus } : {}),
-					});
-					if (embeddingStatus === "embeddings pending - provider down") {
-						scanComplete = false;
+					// The generator plus awaited indexing below is a one-item bounded work queue.
+					for await (const file of walkNativeMemoryFiles(source.root, source, agentId)) {
+						if (scanned >= maxFilesPerScan) break;
+						if (!matchesPattern(source, file)) continue;
+						if (checkpointPath !== null && file.replace(/\\/g, "/") <= checkpointPath) continue;
+						if (options.shouldContinue && !options.shouldContinue(source)) {
+							scanComplete = false;
+							break;
+						}
+						scanned++;
+						let embeddingStatus: string | undefined;
+						const changed = await indexNativeMemoryFile(source, file, agentId, {
+							...options,
+							markdownPathIndex,
+							onEmbeddingStatus: (status) => {
+								embeddingStatus = status;
+								options.onEmbeddingStatus?.(status);
+							},
+						});
+						if (changed) {
+							count++;
+							changedCount++;
+						}
+						current.add(file);
+						options.onFileIndexed?.({
+							source,
+							filePath: file,
+							indexed: changed,
+							scanned,
+							total,
+							changed: changedCount,
+							...(embeddingStatus ? { status: embeddingStatus } : {}),
+						});
+						if (embeddingStatus === "embeddings pending - provider down") {
+							scanComplete = false;
+							sourcePausedReason = "provider_unavailable";
+							await persistNativeSourceSyncState({
+								agentId,
+								source,
+								status: "paused",
+								pauseReason: "provider_unavailable",
+							});
+							syncStates.set(durableKey, {
+								agentId,
+								sourceKey: durableKey,
+								sourceRoot: source.root,
+								status: "paused",
+								checkpointPath,
+								pauseReason: "provider_unavailable",
+							});
+							break;
+						}
 						await persistNativeSourceSyncState({
 							agentId,
 							source,
-							status: "paused",
-							pauseReason: "provider_unavailable",
+							status: "running",
+							checkpointPath: file.replace(/\\/g, "/"),
 						});
-						syncStates.set(durableKey, {
+						checkpointPath = file.replace(/\\/g, "/");
+						syncState = {
 							agentId,
 							sourceKey: durableKey,
 							sourceRoot: source.root,
-							status: "paused",
-							checkpointPath,
-							pauseReason: "provider_unavailable",
-						});
-						break;
+							status: "running",
+							checkpointPath: file.replace(/\\/g, "/"),
+							pauseReason: null,
+						};
+						syncStates.set(durableKey, syncState);
+						await yielder();
+						await sleep(fileDelayMs);
 					}
-					await persistNativeSourceSyncState({
-						agentId,
-						source,
-						status: "running",
-						checkpointPath: file.replace(/\\/g, "/"),
-					});
-					checkpointPath = file.replace(/\\/g, "/");
-					syncState = {
+					if (scanTruncated) {
+						logger.warn("watcher", "Native memory scan reached its file budget", {
+							harness: source.harness,
+							root: source.root,
+							cap: maxFilesPerScan,
+						});
+					}
+				}
+				const cleanupAllowed = sourceCleanupEnabledFor(source, options) && (!rootExists || scanComplete);
+				if (cleanupAllowed) {
+					const currentPaths = new Set([...current].map((file) => file.replace(/\\/g, "/")));
+					for (const file of await activeNativeArtifactPaths(source, agentId)) {
+						if (!currentPaths.has(file.replace(/\\/g, "/"))) await removeNativeMemoryFile(source, file, agentId);
+					}
+				}
+				const previous = known.get(key);
+				if (previous && cleanupAllowed) {
+					for (const file of previous) {
+						if (!current.has(file)) await removeNativeMemoryFile(source, file, agentId);
+					}
+				}
+				known.set(key, current);
+				if (
+					rootExists &&
+					scanComplete &&
+					source.sourceId &&
+					(!options.shouldContinue || options.shouldContinue(source))
+				) {
+					markSourceIndexed(source.sourceId, undefined, options.agentsDir);
+				}
+				if (scanComplete && syncStates.get(durableKey) !== null && syncStates.has(durableKey)) {
+					await clearNativeSourceSyncCheckpoint({ agentId, source });
+					syncStates.set(durableKey, {
 						agentId,
 						sourceKey: durableKey,
 						sourceRoot: source.root,
 						status: "running",
-						checkpointPath: file.replace(/\\/g, "/"),
+						checkpointPath: null,
 						pauseReason: null,
-					};
-					syncStates.set(durableKey, syncState);
-					await yielder();
-					await sleep(fileDelayMs);
-				}
-				if (scanTruncated) {
-					logger.warn("watcher", "Native memory scan reached its file budget", {
-						harness: source.harness,
-						root: source.root,
-						cap: maxFilesPerScan,
 					});
 				}
-			}
-			const cleanupAllowed = sourceCleanupEnabledFor(source, options) && (!rootExists || scanComplete);
-			if (cleanupAllowed) {
-				const currentPaths = new Set([...current].map((file) => file.replace(/\\/g, "/")));
-				for (const file of await activeNativeArtifactPaths(source, agentId)) {
-					if (!currentPaths.has(file.replace(/\\/g, "/"))) await removeNativeMemoryFile(source, file, agentId);
-				}
-			}
-			const previous = known.get(key);
-			if (previous && cleanupAllowed) {
-				for (const file of previous) {
-					if (!current.has(file)) await removeNativeMemoryFile(source, file, agentId);
-				}
-			}
-			known.set(key, current);
-			if (
-				rootExists &&
-				scanComplete &&
-				source.sourceId &&
-				(!options.shouldContinue || options.shouldContinue(source))
-			) {
-				markSourceIndexed(source.sourceId, undefined, options.agentsDir);
-			}
-			if (scanComplete && syncStates.get(durableKey) !== null && syncStates.has(durableKey)) {
-				await clearNativeSourceSyncCheckpoint({ agentId, source });
-				syncStates.set(durableKey, {
-					agentId,
+				sourceResult = {
 					sourceKey: durableKey,
-					sourceRoot: source.root,
-					status: "running",
-					checkpointPath: null,
-					pauseReason: null,
-				});
+					sourceId: source.sourceId,
+					status: sourcePausedReason === undefined ? "complete" : "paused",
+					scanned,
+					indexed: changedCount,
+					resumeFrontier: checkpointPath,
+					...(sourcePausedReason === undefined ? {} : { pauseReason: sourcePausedReason }),
+				};
+				sourceResults.push(sourceResult);
+			} catch (error) {
+				sourceFailure = error;
+				throw error;
+			} finally {
+				sharedNativeMemorySourceFlights.delete(flightKey);
+				if (sourceFailure !== undefined) rejectFlight(sourceFailure);
+				else if (sourceResult !== undefined) resolveFlight(sourceResult);
 			}
 		}
-		return count;
+		const pausedSources = sourceResults.filter((result) => result.status === "paused");
+		return {
+			status: pausedSources.length > 0 ? "paused" : "complete",
+			scanned: sourceResults.reduce((total, result) => total + result.scanned, 0),
+			indexed: count,
+			pausedSources,
+		};
 	};
 
 	let syncInFlight: Promise<number> | null = null;
 	let resyncRequested = false;
+	let lastSyncResult: NativeMemorySyncResult = {
+		status: "complete",
+		scanned: 0,
+		indexed: 0,
+		pausedSources: [],
+	};
 	const syncExisting = async (syncOptions: NativeMemoryBridgeSyncOptions = {}): Promise<number> => {
 		if (syncInFlight) {
 			if (syncOptions.requestResyncIfBusy ?? true) resyncRequested = true;
@@ -1341,7 +1438,9 @@ export function startNativeMemoryBridge(
 				let total = 0;
 				do {
 					resyncRequested = false;
-					total += await runScan();
+					const result = await runScan();
+					total += result.indexed;
+					lastSyncResult = result;
 				} while (resyncRequested);
 				return total;
 			})
@@ -1365,6 +1464,7 @@ export function startNativeMemoryBridge(
 
 	return {
 		syncExisting,
+		getLastSyncResult: () => lastSyncResult,
 		async close(): Promise<void> {
 			if (pollTimer) clearInterval(pollTimer);
 			if (syncInFlight) await syncInFlight.catch(() => 0);

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -33,6 +33,14 @@ import {
 	purgeObsidianSourceFileEmbeddingsViaOwner,
 	resetObsidianSourceEmbeddingBackoff,
 } from "./obsidian-source-embeddings";
+import { awaitEmbeddingProviderAvailable } from "./embedding-circuit-breaker";
+import {
+	clearNativeSourceSyncCheckpoint,
+	nativeSourceSyncKey,
+	persistNativeSourceSyncState,
+	readNativeSourceSyncState,
+	type NativeSourceSyncState,
+} from "./native-source-sync-state";
 import {
 	type ObsidianMarkdownPathIndex,
 	addObsidianMarkdownPathIndex,
@@ -394,7 +402,10 @@ async function* walkNativeMemoryFiles(
 	}
 	let entries = 0;
 	try {
-		for await (const entry of directory) {
+		const dirEntries: Array<{ readonly name: string; isDirectory: () => boolean; isFile: () => boolean }> = [];
+		for await (const entry of directory) dirEntries.push(entry);
+		dirEntries.sort((a, b) => a.name.localeCompare(b.name));
+		for (const entry of dirEntries) {
 			entries++;
 			if (entries % NATIVE_MEMORY_DIRECTORY_YIELD_EVERY === 0)
 				await new Promise<void>((resolve) => setImmediate(resolve));
@@ -1100,6 +1111,40 @@ function sourceCleanupEnabledFor(source: NativeMemorySource, options: NativeMemo
 	return (options.sourceCleanupEnabled ?? true) && (options.shouldCleanupSource?.(source) ?? true);
 }
 
+function sourceNeedsProvider(source: NativeMemorySource, options: NativeMemoryBridgeOptions): boolean {
+	return (
+		source.harness === "obsidian" &&
+		options.embeddingConfig !== undefined &&
+		options.embeddingConfig.provider !== "none" &&
+		options.fetchEmbedding !== undefined
+	);
+}
+
+async function sourceProviderGate(
+	agentId: string,
+	options: Pick<NativeMemoryBridgeOptions, "embeddingConfig" | "fetchEmbedding">,
+): Promise<{ readonly available: boolean; readonly retryAfterMs?: number }> {
+	const embeddingConfig = options.embeddingConfig;
+	const fetchEmbedding = options.fetchEmbedding;
+	if (!embeddingConfig || !fetchEmbedding || embeddingConfig.provider === "none") return { available: true };
+	const providerKey = `${embeddingConfig.provider}:${embeddingConfig.model}:${embeddingConfig.base_url ?? ""}`;
+	let providerFailed = false;
+	return await awaitEmbeddingProviderAvailable(
+		providerKey,
+		async () => {
+			providerFailed = false;
+			const probe = await fetchEmbedding("", embeddingConfig, "document", {
+				usage: { source: "artifact-index", agentId },
+				onFailure: (cause) => {
+					providerFailed = cause === "provider_unavailable" || cause === "timeout";
+				},
+			});
+			return Boolean(probe?.length) && !providerFailed;
+		},
+		10_000,
+	);
+}
+
 export function startNativeMemoryBridge(
 	sources: readonly NativeMemorySource[] = [
 		codexNativeMemorySource(),
@@ -1110,6 +1155,7 @@ export function startNativeMemoryBridge(
 ): NativeMemoryBridgeHandle {
 	const agentId = resolveBridgeAgentId(options.agentId);
 	const known = new Map<string, Set<string>>();
+	const syncStates = new Map<string, NativeSourceSyncState | null>();
 
 	const runScan = async (): Promise<number> => {
 		let count = 0;
@@ -1119,6 +1165,31 @@ export function startNativeMemoryBridge(
 			let changedCount = 0;
 			let scanned = 0;
 			const key = sourceStateKey(source, agentId);
+			const durableKey = nativeSourceSyncKey(source);
+			if (!syncStates.has(durableKey)) syncStates.set(durableKey, await readNativeSourceSyncState(agentId, source));
+			let syncState = syncStates.get(durableKey) ?? null;
+			if (sourceNeedsProvider(source, options)) {
+				const provider = await sourceProviderGate(agentId, options);
+				if (!provider.available) {
+					if (syncState?.status !== "paused") {
+						await persistNativeSourceSyncState({
+							agentId,
+							source,
+							status: "paused",
+							pauseReason: "provider_unavailable",
+						});
+						syncState = await readNativeSourceSyncState(agentId, source);
+						syncStates.set(durableKey, syncState);
+					}
+					continue;
+				}
+				if (syncState?.status === "paused") {
+					await persistNativeSourceSyncState({ agentId, source, status: "running" });
+					syncState = await readNativeSourceSyncState(agentId, source);
+					syncStates.set(durableKey, syncState);
+				}
+			}
+			let checkpointPath = syncState?.checkpointPath ?? null;
 			const current = new Set<string>();
 			const rootExists = await pathExists(source.root, source, agentId);
 			const maxFilesPerScan = options.maxFilesPerScan ?? NATIVE_MEMORY_MAX_FILES_PER_SCAN;
@@ -1139,6 +1210,7 @@ export function startNativeMemoryBridge(
 						scanTruncated = true;
 						break;
 					}
+					current.add(file);
 					if (markdownPathIndex) addObsidianMarkdownPathIndex(markdownPathIndex, source.root, file);
 					await yielder();
 				}
@@ -1146,6 +1218,7 @@ export function startNativeMemoryBridge(
 				for await (const file of walkNativeMemoryFiles(source.root, source, agentId)) {
 					if (scanned >= maxFilesPerScan) break;
 					if (!matchesPattern(source, file)) continue;
+					if (checkpointPath !== null && file.replace(/\\/g, "/") <= checkpointPath) continue;
 					if (options.shouldContinue && !options.shouldContinue(source)) {
 						scanComplete = false;
 						break;
@@ -1174,6 +1247,40 @@ export function startNativeMemoryBridge(
 						changed: changedCount,
 						...(embeddingStatus ? { status: embeddingStatus } : {}),
 					});
+					if (embeddingStatus === "embeddings pending - provider down") {
+						scanComplete = false;
+						await persistNativeSourceSyncState({
+							agentId,
+							source,
+							status: "paused",
+							pauseReason: "provider_unavailable",
+						});
+						syncStates.set(durableKey, {
+							agentId,
+							sourceKey: durableKey,
+							sourceRoot: source.root,
+							status: "paused",
+							checkpointPath,
+							pauseReason: "provider_unavailable",
+						});
+						break;
+					}
+					await persistNativeSourceSyncState({
+						agentId,
+						source,
+						status: "running",
+						checkpointPath: file.replace(/\\/g, "/"),
+					});
+					checkpointPath = file.replace(/\\/g, "/");
+					syncState = {
+						agentId,
+						sourceKey: durableKey,
+						sourceRoot: source.root,
+						status: "running",
+						checkpointPath: file.replace(/\\/g, "/"),
+						pauseReason: null,
+					};
+					syncStates.set(durableKey, syncState);
 					await yielder();
 					await sleep(fileDelayMs);
 				}
@@ -1206,6 +1313,17 @@ export function startNativeMemoryBridge(
 				(!options.shouldContinue || options.shouldContinue(source))
 			) {
 				markSourceIndexed(source.sourceId, undefined, options.agentsDir);
+			}
+			if (scanComplete && syncStates.get(durableKey) !== null && syncStates.has(durableKey)) {
+				await clearNativeSourceSyncCheckpoint({ agentId, source });
+				syncStates.set(durableKey, {
+					agentId,
+					sourceKey: durableKey,
+					sourceRoot: source.root,
+					status: "running",
+					checkpointPath: null,
+					pauseReason: null,
+				});
 			}
 		}
 		return count;

--- a/platform/daemon/src/native-source-sync-state.ts
+++ b/platform/daemon/src/native-source-sync-state.ts
@@ -1,0 +1,110 @@
+import { dbOwnerBatch, dbOwnerQuery, ownerStatement } from "./db-owner-runtime";
+import type { NativeMemorySource } from "./native-memory-sources";
+
+export type NativeSourceSyncStatus = "running" | "paused";
+
+export interface NativeSourceSyncState {
+	readonly agentId: string;
+	readonly sourceKey: string;
+	readonly sourceRoot: string;
+	readonly status: NativeSourceSyncStatus;
+	readonly checkpointPath: string | null;
+	readonly pauseReason: string | null;
+}
+
+interface NativeSourceSyncStateRow {
+	readonly agent_id: string;
+	readonly source_key: string;
+	readonly source_root: string;
+	readonly status: NativeSourceSyncStatus;
+	readonly checkpoint_path: string | null;
+	readonly pause_reason: string | null;
+}
+
+export function nativeSourceSyncKey(source: Pick<NativeMemorySource, "harness" | "root" | "sourceId">): string {
+	return source.sourceId ?? `${source.harness}:${source.root.replace(/\\/g, "/").replace(/\/$/, "")}`;
+}
+
+function normalizedSourceRoot(root: string): string {
+	return root.replace(/\\/g, "/").replace(/\/$/, "");
+}
+
+export async function readNativeSourceSyncState(
+	agentId: string,
+	source: Pick<NativeMemorySource, "harness" | "root" | "sourceId">,
+): Promise<NativeSourceSyncState | null> {
+	const sourceKey = nativeSourceSyncKey(source);
+	const row = await dbOwnerQuery<NativeSourceSyncStateRow | null>(
+		ownerStatement(
+			`SELECT agent_id, source_key, source_root, status, checkpoint_path, pause_reason
+			 FROM native_source_sync_state
+			 WHERE agent_id = ? AND source_key = ?`,
+			[agentId, sourceKey],
+			"get",
+		),
+		{ operation: "sources.sync-state.read", lane: "read" },
+	);
+	if (row === null || normalizedSourceRoot(row.source_root) !== normalizedSourceRoot(source.root)) return null;
+	return {
+		agentId: row.agent_id,
+		sourceKey: row.source_key,
+		sourceRoot: row.source_root,
+		status: row.status,
+		checkpointPath: row.checkpoint_path,
+		pauseReason: row.pause_reason,
+	};
+}
+
+export async function persistNativeSourceSyncState(input: {
+	readonly agentId: string;
+	readonly source: Pick<NativeMemorySource, "harness" | "root" | "sourceId">;
+	readonly status: NativeSourceSyncStatus;
+	readonly checkpointPath?: string;
+	readonly pauseReason?: string | null;
+}): Promise<void> {
+	const sourceKey = nativeSourceSyncKey(input.source);
+	const now = new Date().toISOString();
+	await dbOwnerBatch(
+		[
+			ownerStatement(
+				`INSERT INTO native_source_sync_state
+				 (agent_id, source_key, source_root, status, checkpoint_path, pause_reason, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)
+				 ON CONFLICT(agent_id, source_key) DO UPDATE SET
+				   source_root = excluded.source_root,
+				   status = excluded.status,
+				   checkpoint_path = COALESCE(excluded.checkpoint_path, native_source_sync_state.checkpoint_path),
+				   pause_reason = excluded.pause_reason,
+				   updated_at = excluded.updated_at`,
+				[
+					input.agentId,
+					sourceKey,
+					input.source.root,
+					input.status,
+					input.checkpointPath ?? null,
+					input.pauseReason ?? null,
+					now,
+				],
+			),
+		],
+		{ operation: "sources.sync-state.persist", lane: "write", estimatedWorkUnits: 1 },
+	);
+}
+
+export async function clearNativeSourceSyncCheckpoint(input: {
+	readonly agentId: string;
+	readonly source: Pick<NativeMemorySource, "harness" | "root" | "sourceId">;
+}): Promise<void> {
+	const sourceKey = nativeSourceSyncKey(input.source);
+	await dbOwnerBatch(
+		[
+			ownerStatement(
+				`UPDATE native_source_sync_state
+				 SET status = 'running', checkpoint_path = NULL, pause_reason = NULL, updated_at = ?
+				 WHERE agent_id = ? AND source_key = ?`,
+				[new Date().toISOString(), input.agentId, sourceKey],
+			),
+		],
+		{ operation: "sources.sync-state.complete", lane: "write", estimatedWorkUnits: 1 },
+	);
+}

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -77,6 +77,7 @@ describe("Sources routes", () => {
 			syncGate?: Promise<void>;
 			syncError?: unknown;
 			pausedSync?: boolean;
+			pausedBeforeScan?: boolean;
 			recordIndexOperation?: (input: SourceIndexTelemetryInput) => Promise<void>;
 			onPurge?: () => void;
 			onSyncStart?: () => void;
@@ -103,16 +104,16 @@ describe("Sources routes", () => {
 				const syncResult: NativeMemorySyncResult = options.pausedSync
 					? {
 							status: "paused",
-							scanned: 2,
-							indexed: 1,
+							scanned: options.pausedBeforeScan ? 0 : 2,
+							indexed: options.pausedBeforeScan ? 0 : 1,
 							pausedSources: [
 								{
 									sourceKey: sources[0]?.sourceId ?? "obsidian:test",
 									sourceId: sources[0]?.sourceId,
 									status: "paused",
-									scanned: 2,
-									indexed: 1,
-									resumeFrontier: join(vault, "permanent", "Note.md"),
+									scanned: options.pausedBeforeScan ? 0 : 2,
+									indexed: options.pausedBeforeScan ? 0 : 1,
+									resumeFrontier: options.pausedBeforeScan ? null : join(vault, "permanent", "Note.md"),
 									pauseReason: "provider_unavailable",
 								},
 							],
@@ -123,14 +124,18 @@ describe("Sources routes", () => {
 						options.onSyncStart?.();
 						if (options.syncGate) await options.syncGate;
 						if (options.syncError !== undefined) throw options.syncError;
-						bridgeOptions.onFileIndexed?.({
-							source: sources[0] as NativeMemorySource,
-							filePath: join(vault, "permanent", "Note.md"),
-							indexed: true,
-							scanned: 1,
-							total: 1,
-							changed: options.indexed ?? 1,
-						});
+						if (!options.pausedSync) {
+							if (!options.pausedBeforeScan) {
+								bridgeOptions.onFileIndexed?.({
+									source: sources[0] as NativeMemorySource,
+									filePath: join(vault, "permanent", "Note.md"),
+									indexed: true,
+									scanned: 1,
+									total: 1,
+									changed: options.indexed ?? 1,
+								});
+							}
+						}
 						return options.indexed ?? 1;
 					},
 					getLastSyncResult: () => syncResult,
@@ -461,10 +466,31 @@ describe("Sources routes", () => {
 		expect(getSourceIndexJob(body.source.id)).toMatchObject({
 			status: "paused",
 			partial: true,
+			scanned: 2,
 			indexed: 1,
 			pauseReason: "provider_unavailable",
 			resumeFrontier: join(vault, "permanent", "Note.md"),
 		});
+	});
+
+	it("reports zero partial counts when the provider is down before the first file", async () => {
+		const app = makeApp({ pausedSync: true, pausedBeforeScan: true });
+		const response = await app.request("/api/sources/obsidian", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ path: vault, name: "Paused Before Scan Vault" }),
+		});
+		expect(response.status).toBe(202);
+		const body = (await response.json()) as { source: { id: string } };
+		await waitFor(() => getSourceIndexJob(body.source.id)?.status === "paused");
+		expect(getSourceIndexJob(body.source.id)).toMatchObject({
+			status: "paused",
+			partial: true,
+			scanned: 0,
+			indexed: 0,
+			pauseReason: "provider_unavailable",
+		});
+		expect(loadSourcesConfig(dir).sources[0]?.lastIndexedAt).toBeUndefined();
 	});
 
 	it("finalizes a failed index job before lifecycle telemetry failure can reject the job", async () => {

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -13,7 +13,12 @@ import { Hono } from "hono";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 import { dbOwnerBatch, ownerStatement } from "../db-owner-runtime";
 import { hashNormalizedBody } from "../memory-lineage";
-import type { NativeMemoryBridgeHandle, NativeMemoryBridgeOptions, NativeMemorySource } from "../native-memory-sources";
+import type {
+	NativeMemoryBridgeHandle,
+	NativeMemoryBridgeOptions,
+	NativeMemorySource,
+	NativeMemorySyncResult,
+} from "../native-memory-sources";
 import { indexSourceArtifactStructure } from "../source-artifact-graph";
 import {
 	beginSourceIndexJob,
@@ -71,6 +76,7 @@ describe("Sources routes", () => {
 			purged?: number;
 			syncGate?: Promise<void>;
 			syncError?: unknown;
+			pausedSync?: boolean;
 			recordIndexOperation?: (input: SourceIndexTelemetryInput) => Promise<void>;
 			onPurge?: () => void;
 			onSyncStart?: () => void;
@@ -94,6 +100,24 @@ describe("Sources routes", () => {
 				expect(bridgeOptions.fetchEmbedding).toBeDefined();
 				expect(bridgeOptions.sourceCleanupEnabled).toBe(false);
 				expect(bridgeOptions.sourceGraphEnabled).toBe(true);
+				const syncResult: NativeMemorySyncResult = options.pausedSync
+					? {
+							status: "paused",
+							scanned: 2,
+							indexed: 1,
+							pausedSources: [
+								{
+									sourceKey: sources[0]?.sourceId ?? "obsidian:test",
+									sourceId: sources[0]?.sourceId,
+									status: "paused",
+									scanned: 2,
+									indexed: 1,
+									resumeFrontier: join(vault, "permanent", "Note.md"),
+									pauseReason: "provider_unavailable",
+								},
+							],
+						}
+					: { status: "complete", scanned: 1, indexed: options.indexed ?? 1, pausedSources: [] };
 				return {
 					syncExisting: async () => {
 						options.onSyncStart?.();
@@ -109,6 +133,7 @@ describe("Sources routes", () => {
 						});
 						return options.indexed ?? 1;
 					},
+					getLastSyncResult: () => syncResult,
 					close: async () => {},
 				} satisfies NativeMemoryBridgeHandle;
 			},
@@ -420,6 +445,26 @@ describe("Sources routes", () => {
 
 		await waitFor(() => !!loadSourcesConfig(dir).sources[0]?.lastIndexedAt);
 		expect(loadSourcesConfig(dir).sources[0]?.id).toBe(body.source.id);
+	});
+
+	it("reports a provider outage as paused partial progress without stamping freshness", async () => {
+		const app = makeApp({ pausedSync: true });
+		const response = await app.request("/api/sources/obsidian", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ path: vault, name: "Paused Vault" }),
+		});
+		expect(response.status).toBe(202);
+		const body = (await response.json()) as { source: { id: string } };
+		await waitFor(() => getSourceIndexJob(body.source.id)?.status === "paused");
+		expect(loadSourcesConfig(dir).sources[0]?.lastIndexedAt).toBeUndefined();
+		expect(getSourceIndexJob(body.source.id)).toMatchObject({
+			status: "paused",
+			partial: true,
+			indexed: 1,
+			pauseReason: "provider_unavailable",
+			resumeFrontier: join(vault, "permanent", "Note.md"),
+		});
 	});
 
 	it("finalizes a failed index job before lifecycle telemetry failure can reject the job", async () => {

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -660,6 +660,8 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 			pauseSourceIndexJob(input.source.id, job.id, {
 				pauseReason: paused.pauseReason ?? "provider_unavailable",
 				resumeFrontier: paused.resumeFrontier,
+				scanned: paused.scanned,
+				indexed: paused.indexed,
 			});
 			await recordSourceIndexTelemetryBestEffort(input.recordIndexOperation, {
 				source: input.source,

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -46,6 +46,7 @@ import {
 	isSourceIndexInFlight,
 	markSourceIndexInFlight,
 	markSourceIndexJobRunning,
+	pauseSourceIndexJob,
 	updateSourceIndexJobProgress,
 } from "../source-index-progress";
 import {
@@ -653,6 +654,26 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 		});
 		const indexed = await bridge.syncExisting();
 		if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
+		const syncResult = bridge.getLastSyncResult?.();
+		const paused = syncResult?.pausedSources.find((result) => result.sourceId === input.source.id);
+		if (syncResult?.status === "paused" && paused) {
+			pauseSourceIndexJob(input.source.id, job.id, {
+				pauseReason: paused.pauseReason ?? "provider_unavailable",
+				resumeFrontier: paused.resumeFrontier,
+			});
+			await recordSourceIndexTelemetryBestEffort(input.recordIndexOperation, {
+				source: input.source,
+				agentId,
+				discovered: syncResult.scanned,
+				accepted: syncResult.indexed,
+				durationMs: Date.now() - startedAt,
+				outcome: "partial",
+				failureClass: sourceFailureClass(new Error("network provider unavailable")),
+				searchable: syncResult.indexed > 0,
+				updateFreshness: false,
+			});
+			return;
+		}
 		markSourceIndexed(input.source.id, undefined, input.agentsDir);
 		const progress = getSourceIndexJob(input.source.id);
 		completeSourceIndexJob(input.source.id, job.id, indexed);

--- a/platform/daemon/src/source-index-progress.test.ts
+++ b/platform/daemon/src/source-index-progress.test.ts
@@ -5,6 +5,7 @@ import {
 	completeSourceIndexJob,
 	getSourceIndexJob,
 	markSourceIndexJobRunning,
+	pauseSourceIndexJob,
 	updateSourceIndexJobProgress,
 } from "./source-index-progress";
 
@@ -51,5 +52,25 @@ describe("source index progress", () => {
 
 		expect(markSourceIndexJobRunning("source-1", job.id)).toBeUndefined();
 		expect(getSourceIndexJob("source-1")?.status).toBe("complete");
+	});
+
+	test("persists counts when a provider pauses before any progress event", () => {
+		clearSourceIndexProgressForTests();
+		const job = beginSourceIndexJob("source-paused");
+		pauseSourceIndexJob("source-paused", job.id, {
+			pauseReason: "provider_unavailable",
+			resumeFrontier: "/vault/permanent/First.md",
+			scanned: 2,
+			indexed: 1,
+		});
+
+		expect(getSourceIndexJob("source-paused")).toMatchObject({
+			status: "paused",
+			partial: true,
+			scanned: 2,
+			indexed: 1,
+			pauseReason: "provider_unavailable",
+			resumeFrontier: "/vault/permanent/First.md",
+		});
 	});
 });

--- a/platform/daemon/src/source-index-progress.ts
+++ b/platform/daemon/src/source-index-progress.ts
@@ -1,4 +1,4 @@
-export type SourceIndexJobStatus = "queued" | "running" | "complete" | "error";
+export type SourceIndexJobStatus = "queued" | "running" | "complete" | "paused" | "error";
 
 export interface SourceIndexJob {
 	readonly id: string;
@@ -12,6 +12,9 @@ export interface SourceIndexJob {
 	readonly indexed?: number;
 	readonly currentPath?: string;
 	readonly statusMessage?: string;
+	readonly partial?: boolean;
+	readonly pauseReason?: string;
+	readonly resumeFrontier?: string | null;
 	readonly error?: string;
 }
 
@@ -88,6 +91,24 @@ export function completeSourceIndexJob(sourceId: string, jobId: string, indexed:
 
 export function completeSourceIndexJobFromProgress(sourceId: string, jobId: string): void {
 	completeSourceIndexJob(sourceId, jobId, sourceIndexJobs.get(sourceId)?.indexed ?? 0);
+}
+
+export function pauseSourceIndexJob(
+	sourceId: string,
+	jobId: string,
+	input: { readonly pauseReason: string; readonly resumeFrontier: string | null },
+): void {
+	if (!isCurrentSourceIndexJob(sourceId, jobId)) return;
+	const current = sourceIndexJobs.get(sourceId);
+	if (!current) return;
+	sourceIndexJobs.set(sourceId, {
+		...current,
+		status: "paused",
+		finishedAt: new Date().toISOString(),
+		partial: true,
+		pauseReason: input.pauseReason,
+		resumeFrontier: input.resumeFrontier,
+	});
 }
 
 export function failSourceIndexJob(sourceId: string, jobId: string, error: unknown): void {

--- a/platform/daemon/src/source-index-progress.ts
+++ b/platform/daemon/src/source-index-progress.ts
@@ -96,7 +96,12 @@ export function completeSourceIndexJobFromProgress(sourceId: string, jobId: stri
 export function pauseSourceIndexJob(
 	sourceId: string,
 	jobId: string,
-	input: { readonly pauseReason: string; readonly resumeFrontier: string | null },
+	input: {
+		readonly pauseReason: string;
+		readonly resumeFrontier: string | null;
+		readonly scanned: number;
+		readonly indexed: number;
+	},
 ): void {
 	if (!isCurrentSourceIndexJob(sourceId, jobId)) return;
 	const current = sourceIndexJobs.get(sourceId);
@@ -106,6 +111,8 @@ export function pauseSourceIndexJob(
 		status: "paused",
 		finishedAt: new Date().toISOString(),
 		partial: true,
+		scanned: input.scanned,
+		indexed: input.indexed,
 		pauseReason: input.pauseReason,
 		resumeFrontier: input.resumeFrontier,
 	});

--- a/web/docs/src/content/docs/api/documents-sources.md
+++ b/web/docs/src/content/docs/api/documents-sources.md
@@ -314,6 +314,28 @@ When a source artifact is indexed but its embedding provider is unavailable,
 `"embeddings pending - provider down"` while embeddings wait for a bounded
 retry window.
 
+Each source may also expose an `indexJob` while its source scan is queued,
+running, complete, paused, or failed. A paused job is a partial scan stopped
+because the provider is unavailable. Its `partial` field is `true`, and
+`scanned` and `indexed` report the counts reached before the pause, including
+zero when the provider was unavailable before the first file. `pauseReason`
+identifies the cause, and `resumeFrontier` is the file path from which the next
+scan resumes, or `null` when no file was checkpointed. A paused scan does not
+update the source's `lastIndexedAt`.
+
+```json
+{
+  "indexJob": {
+    "status": "paused",
+    "partial": true,
+    "scanned": 2,
+    "indexed": 1,
+    "pauseReason": "provider_unavailable",
+    "resumeFrontier": "/home/user/ObsidianVault/permanent/Next.md"
+  }
+}
+```
+
 <a id="post-api-sources-discord"></a>
 
 ### POST /api/sources/discord


### PR DESCRIPTION
## Summary

Provider-down native source synchronization now pauses durably at the source boundary and resumes from a persisted per-source checkpoint after recovery. Paused scans are reported as partial rather than successful, and manual resyncs join an in-flight polling scan for the same agent/source instead of duplicating provider and DB-owner work.

Closes #1696

## Changes

- Add migration 139 and owner-routed helpers for per-agent, per-source sync state.
- Gate Obsidian source scans through the existing embedding provider circuit before filesystem work.
- Persist `paused` / `running` state, pause reason, and a normalized file frontier.
- Resume after recovery by skipping files at or before the durable checkpoint.
- Return per-source sync status, scanned/indexed counts, and resume frontier from the native bridge.
- Mark manual and startup source jobs `paused` / `partial` on provider outage, skip `lastIndexedAt` freshness stamping, and retain searchable partial results when present.
- Serialize manual and polling bridges through a module-level agent/source flight registry.
- Add provider-down, provider-down-before-first-file, restart-during-pause, recovery-from-checkpoint, startup partial-status, and cross-instance single-flight regression coverage.
- Document the paused/partial `GET /api/sources` index-job status, counts, pause reason, resume frontier, and freshness behavior.
- Keep the upstream migration 138 (`bounded-status-projections`) intact after rebasing onto current `origin/main`.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`

## Screenshots

N/A: no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
  - Validated against `docs/specs/INDEX.md` and `docs/specs/dependencies.yaml`; this internal source-sync reliability fix adds no new public spec.
- [x] Agent scoping verified on all new/changed data queries.
- [x] Input/config validation and bounds checks added.
  - Uses the existing resolved embedding configuration, normalized agent/source flight key, and bounded provider circuit timing; no new unbounded input surface is introduced.
- [x] Error handling and fallback paths tested (no silent swallow).
  - Provider-down exits before filesystem scanning, persists the pause frontier, and does not enter legacy fallback work.
- [x] Security checks applied to admin/mutation endpoints.
  - N/A: no endpoint or authorization change.
- [x] Docs updated for API/spec/status changes.
  - Updated `web/docs/src/content/docs/api/documents-sources.md` with the paused/partial `indexJob` response fields, zero-count behavior before the first file, resume frontier, and the `lastIndexedAt` freshness rule.
- [x] Regression tests added for each bug fix.
- [x] Lint/typecheck/tests pass locally.
  - Daemon typecheck/build, core build, focused source/migration suites, production-wiring regression coverage, and changed-file Biome checks pass. Root typecheck still reports unrelated existing connector-package failures; full root `bun test` had the pre-existing 420-second timeout.

## Migration Notes

- [x] Migration is idempotent.
- [x] Rollback / compatibility note included in PR description.
  - Migration 139 appends `native_source_sync_state`; existing migration 138 remains unchanged. Older databases create the table on normal migration, and repeated migration runs are safe. No rollback migration is required; removing the feature requires dropping only this derived control-plane table after source work is stopped.

## Testing

- [x] `bun test platform/daemon/src/native-memory-sources.test.ts` — 59 pass, 0 fail, 220 expect calls.
- [x] `bun test platform/daemon/src/routes/sources-routes.test.ts` — 46 pass, 0 fail, 293 expect calls, including provider-down-before-first-file counts.
- [x] `bun test platform/daemon/src/daemon-production-wiring.test.ts platform/daemon/src/source-index-progress.test.ts` — 7 pass, 0 fail.
- [x] `bun test platform/core/src/migrations/migrations.test.ts` — 69 pass, 0 fail, 649 expect calls.
- [x] `bun run --filter '@signet/core' build` — pass.
- [x] `bun run --filter '@signet/daemon' build` — pass, including daemon `tsc --noEmit` and dashboard build.
- [x] `bun run --filter '@signet/daemon' typecheck` — pass.
- [x] `bunx biome check --write` on all changed files — pass.
- [ ] `bun test` — pre-existing root-suite timeout after 420 seconds; focused affected-suite coverage passes.
- [ ] `bun run typecheck` — current root run fails in unrelated connector packages (`connector-oh-my-pi`, `connector-gemini`, `connector-forge`, `connector-opencode`, `connector-pi`, `connector-openclaw`, `connector-codex`); core and daemon typechecks pass.
- [x] `bun run lint` — exits 0; reports existing repository warnings outside this diff.
- [ ] Tested against running daemon — not run; bridge/database boundary coverage passed and no live daemon instance was available in the bounded verification window.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by: Hermes-Agent:gpt-5.6-luna` commit tag)

## Per-finding resolution

- Finding 1, partial pause success lie: `platform/daemon/src/routes/sources-routes.ts:657-677` now consumes the bridge result, pauses the job with the bridge's scanned/indexed counts and frontier, records `partial`, disables freshness updates, and returns before `markSourceIndexed` at line 679. Startup uses the same count-aware treatment at `platform/daemon/src/daemon.ts:2597-2632`; the production-wiring regression is in `platform/daemon/src/daemon-production-wiring.test.ts`, and route coverage includes both partial progress and provider-down-before-first-file with zero counts.
- Finding 2, cross-instance single-flight: `platform/daemon/src/native-memory-sources.ts:148,523,1196-1215,1409` uses a module-level agent/source/root flight registry; a manual bridge joins the polling promise. The regression at `platform/daemon/src/native-memory-sources.test.ts:1276-1327` observes two provider probes and one embedding call total, with both bridge calls returning the same indexed count.

## Notes

The source-pause state machine remains in `platform/daemon/src/native-memory-sources.ts`: provider gating occurs before `pathExists` / source walking; provider-down status from embedding indexing persists `paused` and stops the current scan; successful completion clears the frontier. The durable state schema and owner-routed accessors are in `platform/core/src/migrations/139-native-source-sync-state.ts` and `platform/daemon/src/native-source-sync-state.ts`.


