### PR TITLE
fix(daemon): kill incremental integrity FTS frontier loop

### DIFF
--- a/platform/daemon/src/database-integrity.ts
+++ b/platform/daemon/src/database-integrity.ts
@@ -20,11 +20,11 @@ import type { DbOwnerStatement } from "./db-owner-protocol";
 import { logger } from "./logger";
 import { resolveEmbeddedWorkerPath } from "./native-runtime-assets";
 
-export type DatabaseIntegrityState = "unknown" | "healthy" | "repaired" | "corrupt" | "unavailable";
+export type DatabaseIntegrityState = "unknown" | "healthy" | "repaired" | "corrupt" | "unavailable" | "degraded";
 
 export interface DatabaseIntegrityProgress {
 	readonly checkpointKey: string;
-	readonly phase: "running" | "complete" | "cancelled" | "timed_out" | "unavailable";
+	readonly phase: "running" | "complete" | "cancelled" | "timed_out" | "unavailable" | "degraded";
 	readonly checkedObjects: number;
 	readonly failedObjects: number;
 	readonly remainingObjects: number;
@@ -35,6 +35,7 @@ export interface DatabaseIntegrityProgress {
 	readonly ownerQueueAdmissionMs: number;
 	readonly ownerExecutionMs: number;
 	readonly cancellationReason: string | null;
+	readonly degradationReason: string | null;
 }
 
 export interface IntegrityCheckStatus {
@@ -45,7 +46,8 @@ export interface IntegrityCheckStatus {
 export interface DatabaseIntegrityStatus {
 	readonly checkedAt: string;
 	readonly state: DatabaseIntegrityState;
-	readonly phase: "pending" | "running" | "complete" | "timed_out";
+	readonly phase: "pending" | "running" | "complete" | "timed_out" | "degraded";
+	readonly integrity: string | null;
 	readonly quickCheck: IntegrityCheckStatus;
 	readonly telemetryCheck: IntegrityCheckStatus;
 	readonly rebuiltIndexes: readonly string[];
@@ -79,6 +81,7 @@ let latestStatus: DatabaseIntegrityStatus = {
 	checkedAt: "",
 	state: "unknown",
 	phase: "pending",
+	integrity: null,
 	quickCheck: UNKNOWN_CHECK,
 	telemetryCheck: UNKNOWN_CHECK,
 	rebuiltIndexes: [],
@@ -126,6 +129,7 @@ function statusWith(
 		checkedAt: new Date().toISOString(),
 		state,
 		phase,
+		integrity: null,
 		quickCheck,
 		telemetryCheck,
 		rebuiltIndexes,
@@ -146,20 +150,30 @@ export function updateDatabaseIntegrityStatus(
 	const health = owner?.health();
 	const failed = progress.failedObjects > 0 || errors.length > 0;
 	const operationalFailure = progress.phase === "unavailable" || progress.phase === "timed_out";
+	const degraded = progress.phase === "degraded" || progress.degradationReason !== null;
 	const state: DatabaseIntegrityState = operationalFailure
 		? "unavailable"
-		: failed
-			? "corrupt"
-			: progress.phase === "complete"
-				? "healthy"
-				: "unknown";
+		: degraded
+			? "degraded"
+			: failed
+				? "corrupt"
+				: progress.phase === "complete"
+					? "healthy"
+					: "unknown";
 	const phase: DatabaseIntegrityStatus["phase"] =
-		progress.phase === "timed_out" ? "timed_out" : progress.phase === "running" ? "running" : "complete";
+		progress.phase === "timed_out"
+			? "timed_out"
+			: progress.phase === "running"
+				? "running"
+				: progress.phase === "degraded"
+					? "degraded"
+					: "complete";
 	latestStatus = {
 		...latestStatus,
 		checkedAt: new Date().toISOString(),
 		state,
 		phase,
+		integrity: degraded ? progress.degradationReason : null,
 		quickCheck: failed
 			? { ok: false, messages: errors.length > 0 ? errors : ["incremental integrity check failed"] }
 			: progress.phase === "complete"

--- a/platform/daemon/src/incremental-database-integrity.test.ts
+++ b/platform/daemon/src/incremental-database-integrity.test.ts
@@ -35,6 +35,72 @@ function makeDatabase(): {
 }
 
 describe("incremental database integrity maintenance (#1683)", () => {
+	it("does not multiply the database-wide page count by the object frontier", async () => {
+		const database = makeDatabase();
+		await database.owner.start();
+
+		const result = await runIncrementalDatabaseIntegrityCheck({
+			owner: database.owner,
+			checkpointKey: "test.integrity.database-page-count-math",
+			tablesPerRun: 3,
+			maxWorkUnits: 3,
+			runBudgetMs: 5_000,
+		});
+		const verification = new Database(database.path, { readonly: true });
+		const pageCount = (verification.prepare("PRAGMA page_count").get() as { page_count: number }).page_count;
+		const pageSize = (verification.prepare("PRAGMA page_size").get() as { page_size: number }).page_size;
+		verification.close();
+
+		expect(result.phase).toBe("complete");
+		expect(result.databasePagesObserved).toBe(pageCount);
+		expect(result.databaseBytesObserved).toBe(pageCount * pageSize);
+	});
+
+	it("parks the stuck-frontier-on-FTS-object class in a named degraded state", async () => {
+		const database = makeDatabase();
+		const db = new Database(database.path);
+		db.exec(`
+			CREATE TABLE session_transcripts (content TEXT NOT NULL);
+			CREATE VIRTUAL TABLE session_transcripts_fts USING fts5(content, content='session_transcripts', content_rowid='rowid');
+		`);
+		db.close();
+		await database.owner.start();
+		const scans: string[] = [];
+
+		const first = await runIncrementalDatabaseIntegrityCheck({
+			owner: database.owner,
+			checkpointKey: "test.integrity.stuck-frontier-fts-object",
+			tablesPerRun: 64,
+			maxWorkUnits: 64,
+			runBudgetMs: 5_000,
+			onObjectScan: (object) => {
+				scans.push(`${object.type}:${object.name}`);
+			},
+		});
+
+		expect(first.phase).toBe("degraded");
+		expect(first.degradationReason).toBe("degraded:fts-unverifiable");
+		expect(first.remainingObjects).toBe(0);
+		expect(getDatabaseIntegrityStatus()).toMatchObject({
+			state: "degraded",
+			phase: "degraded",
+			integrity: "degraded:fts-unverifiable",
+		});
+
+		const second = await runIncrementalDatabaseIntegrityCheck({
+			owner: database.owner,
+			checkpointKey: "test.integrity.stuck-frontier-fts-object",
+			tablesPerRun: 64,
+			maxWorkUnits: 64,
+			runBudgetMs: 5_000,
+			onObjectScan: (object) => {
+				scans.push(`${object.type}:${object.name}`);
+			},
+		});
+		expect(second.phase).toBe("degraded");
+		expect(scans.filter((object) => object === "table:session_transcripts_fts")).toHaveLength(1);
+	});
+
 	it("commits one table frontier per bounded slice and resumes", async () => {
 		const database = makeDatabase();
 		await database.owner.start();

--- a/platform/daemon/src/incremental-database-integrity.ts
+++ b/platform/daemon/src/incremental-database-integrity.ts
@@ -31,8 +31,9 @@ const DEFAULT_RUN_BUDGET_MS = 5_000;
 const MAX_RUN_BUDGET_MS = 60_000;
 const DEFAULT_WORK_UNITS = 8;
 const MAX_WORK_UNITS = 64;
+const FTS_UNVERIFIABLE_STATUS = "degraded:fts-unverifiable" as const;
 
-export type IncrementalIntegrityPhase = "running" | "complete" | "cancelled" | "timed_out" | "unavailable";
+export type IncrementalIntegrityPhase = "running" | "complete" | "cancelled" | "timed_out" | "unavailable" | "degraded";
 
 export interface IncrementalIntegrityProgress extends DatabaseIntegrityProgress {
 	readonly checkpointKey: string;
@@ -67,13 +68,14 @@ interface Checkpoint {
 	readonly failedTables: number;
 	readonly pagesChecked: number;
 	readonly bytesChecked: number;
-	readonly status: "running" | "complete";
+	readonly status: "running" | "complete" | typeof FTS_UNVERIFIABLE_STATUS;
 }
 
 interface TableRow {
 	readonly name: string;
 	readonly type: "table" | "index" | "view" | "trigger";
 	readonly cursor: string;
+	readonly sql?: string;
 }
 
 interface NumberRow {
@@ -125,6 +127,10 @@ function boundedWorkUnits(value: number | undefined): number {
 
 function escapeIdentifier(value: string): string {
 	return `"${value.replaceAll('"', '""')}"`;
+}
+
+function isUnchunkableFts(object: TableRow): boolean {
+	return object.type === "table" && typeof object.sql === "string" && /\bUSING\s+fts5\s*\(/i.test(object.sql);
 }
 
 function scalar(value: unknown): number {
@@ -187,7 +193,11 @@ async function readCheckpoint(
 		[key],
 		{ deadlineMs, onOwnerMetrics },
 	);
-	if (row === undefined || (row.status !== "running" && row.status !== "complete") || typeof row.cursor !== "string") {
+	if (
+		row === undefined ||
+		(row.status !== "running" && row.status !== "complete" && row.status !== FTS_UNVERIFIABLE_STATUS) ||
+		typeof row.cursor !== "string"
+	) {
 		throw new Error(`integrity checkpoint ${key} is missing or invalid`);
 	}
 	return row;
@@ -241,7 +251,7 @@ async function nextObject(
 	const object = await ownerQueryOne<TableRow>(
 		owner,
 		"integrity.objects.next",
-		`SELECT name, type, name || ':' || type AS cursor FROM sqlite_schema
+		`SELECT name, type, sql, name || ':' || type AS cursor FROM sqlite_schema
 		 WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%'
 		   AND name <> ? AND (name || ':' || type) > ?
 		   AND type IN ('table', 'index', 'view', 'trigger')
@@ -296,8 +306,11 @@ async function persistTable(
 		cursor: object,
 		checkedTables: checkpoint.checkedTables + 1,
 		failedTables: checkpoint.failedTables + (failed ? 1 : 0),
-		pagesChecked: checkpoint.pagesChecked + metrics.pages,
-		bytesChecked: checkpoint.bytesChecked + metrics.bytes,
+		// PRAGMA page_count is a database-wide snapshot, not per-object work.
+		// Adding it for every table multiplies the database size by the object
+		// count (the 765M-page integrity report was this exact bug).
+		pagesChecked: metrics.pages,
+		bytesChecked: metrics.bytes,
 		status: "running",
 	};
 	await ownerTransaction(
@@ -345,6 +358,31 @@ async function markComplete(
 	);
 }
 
+async function markDegraded(
+	owner: DbOwnerClient,
+	key: string,
+	object: string,
+	checkpoint: Checkpoint,
+	deadlineMs: number,
+	onOwnerMetrics?: OwnerMetricsCallback,
+): Promise<Checkpoint> {
+	const next: Checkpoint = { ...checkpoint, cursor: object, status: FTS_UNVERIFIABLE_STATUS };
+	await ownerTransaction(
+		owner,
+		"integrity.checkpoint.degraded",
+		[
+			ownerRunStatement(
+				`UPDATE ${CHECKPOINT_TABLE}
+				 SET cursor = ?, status = ?, updated_at = ?
+				 WHERE checkpoint_key = ? AND cursor = ? AND status = 'running'`,
+				[next.cursor, next.status, new Date().toISOString(), key, checkpoint.cursor],
+			),
+		],
+		{ deadlineMs, estimatedWorkUnits: 1, onOwnerMetrics },
+	);
+	return next;
+}
+
 function progressFrom(
 	key: string,
 	phase: IncrementalIntegrityPhase,
@@ -355,6 +393,7 @@ function progressFrom(
 	ownerQueueAdmissionMs: number,
 	ownerExecutionMs: number,
 	cancellationReason: string | null,
+	degradationReason: string | null,
 ): IncrementalIntegrityProgress {
 	return {
 		checkpointKey: key,
@@ -369,6 +408,7 @@ function progressFrom(
 		ownerQueueAdmissionMs,
 		ownerExecutionMs,
 		cancellationReason,
+		degradationReason,
 	};
 }
 
@@ -399,6 +439,7 @@ export async function runIncrementalDatabaseIntegrityCheck(
 	};
 	let phase: IncrementalIntegrityPhase = "running";
 	let cancellationReason: string | null = null;
+	let degradationReason: string | null = null;
 	let checkpoint: Checkpoint = {
 		cursor: "",
 		checkedTables: 0,
@@ -421,12 +462,12 @@ export async function runIncrementalDatabaseIntegrityCheck(
 		return Math.min(ownerDeadlineMs, Math.floor(remaining));
 	};
 	const emit = async (phase: IncrementalIntegrityPhase, reason: string | null): Promise<void> => {
-		const remaining = await remainingObjects(
-			options.owner,
-			checkpoint.cursor,
-			remainingBudget(),
-			recordOwnerMetrics,
-		).catch(() => 0);
+		const remaining =
+			phase === "degraded"
+				? 0
+				: await remainingObjects(options.owner, checkpoint.cursor, remainingBudget(), recordOwnerMetrics).catch(
+						() => 0,
+					);
 		const progress = progressFrom(
 			key,
 			phase,
@@ -437,17 +478,18 @@ export async function runIncrementalDatabaseIntegrityCheck(
 			ownerQueueAdmissionMs,
 			ownerExecutionMs,
 			reason,
+			degradationReason,
 		);
 		updateDatabaseIntegrityStatus(progress, errors, options.owner);
 		await options.onProgress?.(progress);
 	};
 	const progressSnapshot = async (): Promise<IncrementalIntegrityProgress> => {
-		const remaining = await remainingObjects(
-			options.owner,
-			checkpoint.cursor,
-			remainingBudget(),
-			recordOwnerMetrics,
-		).catch(() => 0);
+		const remaining =
+			phase === "degraded"
+				? 0
+				: await remainingObjects(options.owner, checkpoint.cursor, remainingBudget(), recordOwnerMetrics).catch(
+						() => 0,
+					);
 		return progressFrom(
 			key,
 			phase,
@@ -458,6 +500,7 @@ export async function runIncrementalDatabaseIntegrityCheck(
 			ownerQueueAdmissionMs,
 			ownerExecutionMs,
 			cancellationReason,
+			degradationReason,
 		);
 	};
 
@@ -465,6 +508,12 @@ export async function runIncrementalDatabaseIntegrityCheck(
 		await ensureCheckpoint(options.owner, key, remainingBudget(), recordOwnerMetrics);
 		checkpoint = await readCheckpoint(options.owner, key, remainingBudget(), recordOwnerMetrics);
 		lastTable = checkpointCursorToLastObject(checkpoint.cursor);
+		if (checkpoint.status === FTS_UNVERIFIABLE_STATUS) {
+			phase = "degraded";
+			degradationReason = FTS_UNVERIFIABLE_STATUS;
+			await emit("degraded", FTS_UNVERIFIABLE_STATUS);
+			return { ...(await progressSnapshot()), errors };
+		}
 		if (checkpoint.status === "complete") {
 			await resetCompleteCheckpoint(options.owner, key, remainingBudget(), recordOwnerMetrics);
 			checkpoint = await readCheckpoint(options.owner, key, remainingBudget(), recordOwnerMetrics);
@@ -494,8 +543,26 @@ export async function runIncrementalDatabaseIntegrityCheck(
 				await emit("complete", null);
 				return { ...(await progressSnapshot()), errors };
 			}
-			await options.onObjectScan?.(table);
 			lastTable = `${table.type}:${table.name}`;
+			if (isUnchunkableFts(table)) {
+				// SQLite's FTS5 integrity-check is one monolithic native operation;
+				// it has no segment/rowid-range cursor. Persist the named park state
+				// instead of re-entering the same virtual table on every slice.
+				await options.onObjectScan?.(table);
+				checkpoint = await markDegraded(
+					options.owner,
+					key,
+					table.cursor,
+					checkpoint,
+					remainingBudget(),
+					recordOwnerMetrics,
+				);
+				phase = "degraded";
+				degradationReason = FTS_UNVERIFIABLE_STATUS;
+				await emit("degraded", FTS_UNVERIFIABLE_STATUS);
+				return { ...(await progressSnapshot()), errors };
+			}
+			await options.onObjectScan?.(table);
 			const row =
 				table.type === "table"
 					? await ownerQueryOne<QuickCheckRow>(
@@ -593,6 +660,7 @@ export async function runIncrementalDatabaseIntegrityCheck(
 				ownerQueueAdmissionMs,
 				ownerExecutionMs,
 				reason,
+				degradationReason,
 			);
 			updateDatabaseIntegrityStatus(progress, [...errors, reason], options.owner);
 			return { ...progress, errors: [...errors, reason] };

--- a/platform/daemon/src/routes/health.ts
+++ b/platform/daemon/src/routes/health.ts
@@ -212,7 +212,9 @@ export function mountHealthRoutes(app: Hono): void {
 		return c.json({
 			status: shuttingDown
 				? "shutting_down"
-				: databaseIntegrity.state === "corrupt" || databaseIntegrity.state === "unavailable"
+				: databaseIntegrity.state === "corrupt" ||
+						databaseIntegrity.state === "unavailable" ||
+						databaseIntegrity.state === "degraded"
 					? "degraded"
 					: "healthy",
 			uptime: process.uptime(),

--- a/platform/daemon/src/startup-recovery.ts
+++ b/platform/daemon/src/startup-recovery.ts
@@ -55,6 +55,7 @@ const PENDING_INTEGRITY: DatabaseIntegrityStatus = {
 	checkedAt: "",
 	state: "unknown",
 	phase: "pending",
+	integrity: null,
 	quickCheck: { ok: false, messages: ["not checked"] },
 	telemetryCheck: { ok: false, messages: ["not checked"] },
 	rebuiltIndexes: [],

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -473,7 +473,7 @@
     },
     {
       "path": "database-integrity.ts",
-      "line": 371,
+      "line": 385,
       "api": "existsSync",
       "source": "if (existsSync(bundled)) return bundled;",
       "category": "hot-path"


### PR DESCRIPTION
## Summary

- Fix the integrity math bug: `PRAGMA page_count` is database-wide, but the old checkpoint code added the same snapshot once per schema object. The 765M-page / ~3.1TB report was the resulting object-count multiplication. Checkpoints now store the current database-wide observation.
- Prevent the FTS5 frontier re-entry loop: external-content FTS5 integrity verification is a monolithic SQLite operation with no segment/rowid-range cursor. The checkpoint now atomically parks at `degraded:fts-unverifiable` instead of retrying the same object.
- Expose the named degradation through `databaseIntegrity.integrity` and set the `/health` top-level status to `degraded` without marking the database corrupt.

Root cause and implementation:
- `platform/daemon/src/incremental-database-integrity.ts:306-313`: page/byte observations are snapshots, not per-object work; replace cumulative addition with assignment.
- `platform/daemon/src/incremental-database-integrity.ts:132-134,358-383,508-525`: detect FTS5 virtual tables, persist the exact degraded checkpoint status, and return a durable zero-remaining frontier on subsequent slices.
- `platform/daemon/src/database-integrity.ts:23-58,150-184`: carry the degraded phase/reason into health status.

## Verification

- `bun test platform/daemon/src/incremental-database-integrity.test.ts`: 8 pass, 0 fail.
- `bun test platform/daemon/src/database-integrity.test.ts`: 17 pass, 0 fail.
- `bun run --filter '@signet/core' build`: pass.
- `bun run --filter '@signet/daemon' typecheck`: pass.
- `bun run --filter '@signet/daemon' build:types`: pass.
- `bun run build.ts` from `platform/daemon`: pass for all 9 daemon bundles.
- Scoped Biome check: pass.
- Fresh-copy acceptance harness against `/mnt/work/hermes-scratch/w35a-repro-agents-2/memory/memories.db`: settled in 10 slices / 18.6s in `degraded:fts-unverifiable`; no repeated FTS scan; final observation was 2,023,947 pages / 8,290,086,912 bytes, matching the real database size. Final owner maintenance admission was 12ms with no sustained post-settle 100ms+ waits. Full output: `/mnt/work/hermes-scratch/w35a-acceptance.log`.

Regression tests explicitly name both the database-page-count math bug and the `stuck-frontier-on-FTS-object` class.

### Spec alignment

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — change is internal to daemon integrity accounting; no spec surface touched.
- [x] Agent scoping verified on all new/changed data queries — integrity state rows are daemon-owned, no agent-scoped queries changed.

### Hardening

- [x] Input/config validation and bounds checks added — integrity page/byte observations now derive from PRAGMA values directly, bounded by DB size.
- [x] Error handling and fallback paths tested (no silent swallow) — unverifiable FTS integrity surfaces as named degraded state via health.
- [x] Security checks applied to admin/mutation endpoints — no endpoints changed beyond health read surface.
- [x] Docs updated for API/spec/status changes — health degraded-state surfaced in PR description; no API schema change.
- [x] Regression tests added for each bug fix — stuck-frontier + accounting regression tests included (see file list).
- [x] Lint/typecheck/tests pass locally — verified per worker run.
