### PR TITLE
fix(daemon): amputate parent-side native-memory indexing

### DIFF
--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -2587,6 +2587,7 @@ async function main() {
 						sourceCleanupEnabled: true,
 						shouldCleanupSource: (source) => source.harness !== "obsidian",
 						sourceGraphEnabled: true,
+						workerOwnedIndexing: true,
 						...resolveEmbeddingBridgeOptions(memoryCfg.embedding, fetchEmbedding),
 						onFileIndexed: (event) => {
 							const sourceId = event.source.sourceId;

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -109,6 +109,37 @@ export interface DbOwnerSourceArtifactIndex {
 	readonly content: string;
 }
 
+/**
+ * The source/index owner receives a descriptor produced by the killable source
+ * worker. The parent never reads, hashes, or normalizes the file; this owner
+ * performs the artifact upsert and optional graph projection in one boundary.
+ */
+export interface DbOwnerNativeMemoryIndex {
+	readonly agentId: string;
+	readonly sourcePath: string;
+	readonly sourceHash: string;
+	readonly sourceKind: string;
+	readonly harness: string;
+	readonly content: string;
+	readonly sourceMtimeMs: number;
+	readonly sourceId: string | null;
+	readonly sourceRoot: string | null;
+	readonly sourceExternalId: string | null;
+	readonly sourceParentPath: string | null;
+	readonly sourceMetaJson: string | null;
+	readonly displayName: string;
+	/** Durable per-file frontier update committed with the artifact transaction. */
+	readonly checkpoint?: {
+		readonly sourceKey: string;
+		readonly scanned: number;
+	};
+	readonly graph?: {
+		readonly sourceId: string;
+		readonly sourceName: string;
+		readonly root: string;
+	};
+}
+
 export interface DbOwnerSourceArtifactFields {
 	readonly agentId: string;
 	readonly sourcePath: string;
@@ -161,6 +192,7 @@ export type DbOwnerRequest =
 	| { readonly kind: "source_graph_file_purge"; readonly input: DbOwnerSourceGraphFilePurge }
 	| { readonly kind: "source_graph_purge"; readonly input: DbOwnerSourceGraphPurge }
 	| { readonly kind: "source_artifact_index"; readonly input: DbOwnerSourceArtifactIndex }
+	| { readonly kind: "source_native_memory_index"; readonly input: DbOwnerNativeMemoryIndex }
 	| { readonly kind: "source_artifact_purge"; readonly input: DbOwnerSourceArtifactPurge }
 	| { readonly kind: "source_artifact_upsert"; readonly input: DbOwnerSourceArtifactUpsert }
 	| { readonly kind: "source_artifact_upsert_batch"; readonly input: readonly DbOwnerSourceArtifactUpsert[] }

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -128,6 +128,25 @@ export interface DbOwnerNativeMemoryIndex {
 	readonly sourceParentPath: string | null;
 	readonly sourceMetaJson: string | null;
 	readonly displayName: string;
+	/** Source-worker prepared chunks and configuration for owner-side embedding. */
+	readonly embedding?: {
+		readonly config: {
+			readonly provider: string;
+			readonly model: string;
+			readonly dimensions: number;
+			readonly base_url: string;
+			readonly api_key?: string;
+			readonly profile?: string;
+			readonly warmNative?: boolean;
+			readonly indexGeneration?: string;
+			readonly llamaCppMaxInputTokens?: number;
+			readonly costRates?: readonly unknown[];
+		};
+		readonly chunks: readonly {
+			readonly id: string;
+			readonly chunkText: string;
+		}[];
+	};
 	/** Durable per-file frontier update committed with the artifact transaction. */
 	readonly checkpoint?: {
 		readonly sourceKey: string;

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -132,6 +132,10 @@ export interface DbOwnerNativeMemoryIndex {
 	readonly checkpoint?: {
 		readonly sourceKey: string;
 		readonly scanned: number;
+		/** Traversal state immediately after this descriptor's file. */
+		readonly cursor: string | null;
+		readonly frontier: readonly string[] | null;
+		readonly complete: boolean;
 	};
 	readonly graph?: {
 		readonly sourceId: string;

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -140,7 +140,6 @@ export interface DbOwnerNativeMemoryIndex {
 			readonly warmNative?: boolean;
 			readonly indexGeneration?: string;
 			readonly llamaCppMaxInputTokens?: number;
-			readonly costRates?: readonly unknown[];
 		};
 		readonly chunks: readonly {
 			readonly id: string;

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -155,6 +155,17 @@ export interface DbOwnerNativeMemoryIndex {
 		readonly frontier: readonly string[] | null;
 		readonly complete: boolean;
 	};
+	/**
+	 * Retry frontier selected atomically when owner-side embedding reports that
+	 * the provider is unavailable partway through this descriptor.
+	 */
+	readonly checkpointOnProviderFailure?: {
+		readonly sourceKey: string;
+		readonly scanned: number;
+		readonly cursor: string | null;
+		readonly frontier: readonly string[] | null;
+		readonly complete: boolean;
+	};
 	readonly graph?: {
 		readonly sourceId: string;
 		readonly sourceName: string;

--- a/platform/daemon/src/db-owner-runtime.ts
+++ b/platform/daemon/src/db-owner-runtime.ts
@@ -304,13 +304,17 @@ export async function dbOwnerSourceArtifactIndex(
 export async function dbOwnerSourceNativeMemoryIndex(
 	input: DbOwnerNativeMemoryIndex,
 	options: DbOwnerSqlOptions,
-): Promise<{ readonly artifactChanged: boolean; readonly graphIndexed: boolean }> {
+): Promise<{
+	readonly artifactChanged: boolean;
+	readonly graphIndexed: boolean;
+	readonly embeddingProviderUnavailable: boolean;
+}> {
 	const owner = await getDbOwner();
-	return await submitWithAdmission<{ readonly artifactChanged: boolean; readonly graphIndexed: boolean }>(
-		owner,
-		{ kind: "source_native_memory_index", input },
-		{ ...options, lane: options.lane ?? "write" },
-	);
+	return await submitWithAdmission<{
+		readonly artifactChanged: boolean;
+		readonly graphIndexed: boolean;
+		readonly embeddingProviderUnavailable: boolean;
+	}>(owner, { kind: "source_native_memory_index", input }, { ...options, lane: options.lane ?? "write" });
 }
 
 export async function dbOwnerSourceArtifactPurge(

--- a/platform/daemon/src/db-owner-runtime.ts
+++ b/platform/daemon/src/db-owner-runtime.ts
@@ -15,6 +15,7 @@ import type {
 	DbOwnerSourceGraphPurge,
 	DbOwnerSourceSnapshotImport,
 	DbOwnerSourceArtifactIndex,
+	DbOwnerNativeMemoryIndex,
 	DbOwnerSourceArtifactPurge,
 	DbOwnerSourceArtifactUpsert,
 	DbOwnerStatement,
@@ -296,6 +297,18 @@ export async function dbOwnerSourceArtifactIndex(
 	return await submitWithAdmission<unknown>(
 		owner,
 		{ kind: "source_artifact_index", input },
+		{ ...options, lane: options.lane ?? "write" },
+	);
+}
+
+export async function dbOwnerSourceNativeMemoryIndex(
+	input: DbOwnerNativeMemoryIndex,
+	options: DbOwnerSqlOptions,
+): Promise<{ readonly artifactChanged: boolean; readonly graphIndexed: boolean }> {
+	const owner = await getDbOwner();
+	return await submitWithAdmission<{ readonly artifactChanged: boolean; readonly graphIndexed: boolean }>(
+		owner,
+		{ kind: "source_native_memory_index", input },
 		{ ...options, lane: options.lane ?? "write" },
 	);
 }

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import type { Database as BunDatabase } from "bun:sqlite";
@@ -9,6 +10,7 @@ import {
 } from "./obsidian-source-graph";
 import { indexSourceArtifactStructureInTx, purgeSourceArtifactStructureInTx } from "./source-artifact-graph";
 import { upsertMemoryArtifactInTx, type MemoryArtifactUpsertFields } from "./memory-lineage";
+import { upsertMemoryContentSafetyInTx } from "./memory-content-safety";
 import { NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID } from "./native-memory-constants";
 import { applySourceSnapshotImportInTx } from "./source-snapshots";
 import type {
@@ -21,6 +23,8 @@ import type {
 	DbOwnerStatement,
 	DbOwnerNativeMemoryIndex,
 } from "./db-owner-protocol";
+import type { EmbeddingConfig } from "./memory-config";
+import { vectorToBlob } from "./db-helpers";
 import {
 	DB_OWNER_MAX_DEADLINE_MS,
 	DB_OWNER_MAX_MAINTENANCE_DEADLINE_MS,
@@ -424,12 +428,135 @@ export function runDbOwnerWorker(): void {
 		};
 	}
 
-	function executeNativeMemoryIndex(
+	interface NativeMemoryEmbeddingResult {
+		readonly embedded: number;
+		readonly skipped: number;
+		readonly providerUnavailable: boolean;
+	}
+
+	async function executeNativeMemoryEmbeddings(
+		input: DbOwnerNativeMemoryIndex,
+		database: SqliteDatabase,
+	): Promise<NativeMemoryEmbeddingResult> {
+		const embedding = input.embedding;
+		if (embedding === undefined || input.sourceId === null || embedding.config.provider === "none")
+			return { embedded: 0, skipped: 0, providerUnavailable: false };
+		const { fetchEmbedding } = await import("./embedding-fetch");
+		const vecSchema = database
+			.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'vec_embeddings'")
+			.get() as { sql?: string } | null;
+		const vecAvailable = vecSchema !== null;
+		const vecDimensions = vecSchema?.sql?.match(/float\\s*\\[\\s*(\\d+)\\s*\\]/i)?.[1];
+		const currentHashes = new Set<string>();
+		let embedded = 0;
+		let skipped = 0;
+		for (const chunk of embedding.chunks) {
+			const contentHash = createHash("sha256")
+				.update(`${input.agentId}\n${chunk.id}\n${chunk.chunkText}`)
+				.digest("hex");
+			const embeddingId = createHash("sha256")
+				.update(`source_chunk:${input.agentId}:${chunk.id}`)
+				.digest("hex")
+				.slice(0, 32);
+			currentHashes.add(contentHash);
+			const existing = database
+				.prepare(
+					"SELECT id, content_hash FROM embeddings WHERE source_type IN (?, ?) AND source_id = ? AND agent_id = ? LIMIT 1",
+				)
+				.get("source_chunk", "obsidian_chunk", chunk.id, input.agentId) as { id: string; content_hash: string } | null;
+			if (existing?.content_hash === contentHash) {
+				upsertMemoryContentSafetyInTx(database as unknown as import("./db-accessor").WriteDb, {
+					agentId: input.agentId,
+					sourceKind: "source_chunk",
+					sourceId: embeddingId,
+					content: chunk.chunkText,
+				});
+				skipped++;
+				continue;
+			}
+			let failureCause = "provider_unavailable";
+			const vector = await fetchEmbedding(chunk.chunkText, embedding.config as EmbeddingConfig, "document", {
+				usage: { source: "artifact-index", agentId: input.agentId },
+				onFailure: (cause) => {
+					failureCause = cause;
+				},
+			});
+			if (vector === null || vector.length === 0) {
+				if (failureCause === "provider_unavailable" || failureCause === "timeout")
+					return {
+						embedded,
+						skipped: embedding.chunks.length - embedded,
+						providerUnavailable: true,
+					};
+				skipped++;
+				continue;
+			}
+			if (existing !== null) {
+				if (vecAvailable) database.prepare("DELETE FROM vec_embeddings WHERE id = ?").run(existing.id);
+				database.prepare("DELETE FROM embeddings WHERE id = ?").run(existing.id);
+			}
+			database
+				.prepare(
+					`INSERT INTO embeddings
+					 (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+					 ON CONFLICT(content_hash) DO UPDATE SET vector = excluded.vector, dimensions = excluded.dimensions,
+					 source_type = excluded.source_type, source_id = excluded.source_id, chunk_text = excluded.chunk_text,
+					 created_at = excluded.created_at, agent_id = excluded.agent_id`,
+				)
+				.run(
+					embeddingId,
+					contentHash,
+					vectorToBlob(vector),
+					vector.length,
+					"source_chunk",
+					chunk.id,
+					chunk.chunkText,
+					new Date().toISOString(),
+					input.agentId,
+				);
+			upsertMemoryContentSafetyInTx(database as unknown as import("./db-accessor").WriteDb, {
+				agentId: input.agentId,
+				sourceKind: "source_chunk",
+				sourceId: embeddingId,
+				content: chunk.chunkText,
+			});
+			if (vecAvailable && vecDimensions === String(vector.length))
+				database
+					.prepare("INSERT OR REPLACE INTO vec_embeddings (id, embedding) VALUES (?, ?)")
+					.run(embeddingId, vectorToBlob(vector));
+			embedded++;
+		}
+		const prefix = `${input.sourceId}:${input.sourceExternalId ?? input.sourcePath}#`;
+		const stale = database
+			.prepare(
+				"SELECT id, content_hash, source_type FROM embeddings WHERE source_type IN (?, ?) AND source_id LIKE ? AND agent_id = ?",
+			)
+			.all("source_chunk", "obsidian_chunk", `${prefix}%`, input.agentId) as Array<{
+			id: string;
+			content_hash: string;
+			source_type: string;
+		}>;
+		for (const row of stale) {
+			if (row.source_type === "obsidian_chunk" || currentHashes.has(row.content_hash)) continue;
+			if (vecAvailable) database.prepare("DELETE FROM vec_embeddings WHERE id = ?").run(row.id);
+			database.prepare("DELETE FROM embeddings WHERE id = ?").run(row.id);
+		}
+		return { embedded, skipped, providerUnavailable: false };
+	}
+
+	async function executeNativeMemoryIndex(
 		request: Extract<DbOwnerJob["request"], { readonly kind: "source_native_memory_index" }>,
 		context?: JobExecutionContext,
-	): { readonly artifactChanged: boolean; readonly graphIndexed: boolean } {
+	): Promise<{
+		readonly artifactChanged: boolean;
+		readonly graphIndexed: boolean;
+		readonly embeddingProviderUnavailable: boolean;
+	}> {
 		const input = request.input;
 		const sourcePath = input.sourcePath.replace(/\\/g, "/");
+		const embeddingResult = await executeNativeMemoryEmbeddings(input, db);
+
 		const existing = db
 			.prepare(
 				"SELECT source_sha256 FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0 LIMIT 1",
@@ -472,6 +599,7 @@ export function runDbOwnerWorker(): void {
 			return {
 				artifactChanged: existing?.source_sha256 !== input.sourceHash,
 				graphIndexed: input.graph !== undefined,
+				embeddingProviderUnavailable: embeddingResult.providerUnavailable,
 			};
 		} catch (error) {
 			try {

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -557,6 +557,9 @@ export function runDbOwnerWorker(): void {
 		const sourcePath = input.sourcePath.replace(/\\/g, "/");
 		const embeddingResult = await executeNativeMemoryEmbeddings(input, db);
 
+		const checkpoint = embeddingResult.providerUnavailable
+			? (input.checkpointOnProviderFailure ?? input.checkpoint)
+			: input.checkpoint;
 		const existing = db
 			.prepare(
 				"SELECT source_sha256 FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0 LIMIT 1",
@@ -575,7 +578,7 @@ export function runDbOwnerWorker(): void {
 					content: input.content,
 				});
 			}
-			if (input.checkpoint !== undefined) {
+			if (checkpoint !== undefined) {
 				db.prepare(
 					`INSERT INTO source_sync_checkpoints
 					 (agent_id, source_key, phase, cursor, frontier, scanned, complete, updated_at)
@@ -588,11 +591,11 @@ export function runDbOwnerWorker(): void {
 					 updated_at = excluded.updated_at`,
 				).run(
 					input.agentId,
-					input.checkpoint.sourceKey,
-					sourcePath,
-					input.checkpoint.frontier === null ? null : JSON.stringify(input.checkpoint.frontier),
-					input.checkpoint.scanned,
-					input.checkpoint.complete ? 1 : 0,
+					checkpoint.sourceKey,
+					checkpoint.cursor,
+					checkpoint.frontier === null ? null : JSON.stringify(checkpoint.frontier),
+					checkpoint.scanned,
+					checkpoint.complete ? 1 : 0,
 				);
 			}
 			commit(context);

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -452,14 +452,21 @@ export function runDbOwnerWorker(): void {
 				db.prepare(
 					`INSERT INTO source_sync_checkpoints
 					 (agent_id, source_key, phase, cursor, frontier, scanned, complete, updated_at)
-					 VALUES (?, ?, 'content', ?, NULL, ?, 0, datetime('now'))
+					 VALUES (?, ?, 'content', ?, ?, ?, ?, datetime('now'))
 					 ON CONFLICT(agent_id, source_key, phase) DO UPDATE SET
 					 cursor = excluded.cursor,
 					 frontier = excluded.frontier,
 					 scanned = excluded.scanned,
 					 complete = excluded.complete,
 					 updated_at = excluded.updated_at`,
-				).run(input.agentId, input.checkpoint.sourceKey, sourcePath, input.checkpoint.scanned);
+				).run(
+					input.agentId,
+					input.checkpoint.sourceKey,
+					sourcePath,
+					input.checkpoint.frontier === null ? null : JSON.stringify(input.checkpoint.frontier),
+					input.checkpoint.scanned,
+					input.checkpoint.complete ? 1 : 0,
+				);
 			}
 			commit(context);
 			return {

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -8,7 +8,8 @@ import {
 	purgeObsidianSourceFileStructureInTx,
 } from "./obsidian-source-graph";
 import { indexSourceArtifactStructureInTx, purgeSourceArtifactStructureInTx } from "./source-artifact-graph";
-import { upsertMemoryArtifactInTx } from "./memory-lineage";
+import { upsertMemoryArtifactInTx, type MemoryArtifactUpsertFields } from "./memory-lineage";
+import { NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID } from "./native-memory-constants";
 import { applySourceSnapshotImportInTx } from "./source-snapshots";
 import type {
 	DbOwnerCommand,
@@ -18,6 +19,7 @@ import type {
 	DbOwnerParameter,
 	DbOwnerRecallPayload,
 	DbOwnerStatement,
+	DbOwnerNativeMemoryIndex,
 } from "./db-owner-protocol";
 import {
 	DB_OWNER_MAX_DEADLINE_MS,
@@ -389,6 +391,91 @@ export function runDbOwnerWorker(): void {
 		}
 	}
 
+	function nativeMemoryArtifactFields(input: DbOwnerNativeMemoryIndex): MemoryArtifactUpsertFields {
+		const sourcePath = input.sourcePath.replace(/\\/g, "/");
+		const capturedAt = Number.isFinite(input.sourceMtimeMs)
+			? new Date(input.sourceMtimeMs).toISOString()
+			: new Date().toISOString();
+		return {
+			agentId: input.agentId,
+			sourcePath,
+			sourceSha256: input.sourceHash,
+			sourceKind: input.sourceKind,
+			sessionId: `native:${input.harness}:${sourcePath}`,
+			sessionKey: `native:${input.harness}`,
+			sessionToken: `native:${input.harness}`,
+			project: null,
+			harness: input.harness,
+			capturedAt,
+			startedAt: capturedAt,
+			endedAt: capturedAt,
+			manifestPath: null,
+			sourceNodeId: NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID,
+			memorySentence: `Indexed ${input.harness} native memory from ${sourcePath.split("/").at(-1) ?? sourcePath}.`,
+			memorySentenceQuality: "fallback",
+			content: input.content,
+			updatedAt: new Date().toISOString(),
+			sourceMtimeMs: input.sourceMtimeMs,
+			sourceId: input.sourceId,
+			sourceRoot: input.sourceRoot,
+			sourceExternalId: input.sourceExternalId,
+			sourceParentPath: input.sourceParentPath,
+			sourceMetaJson: input.sourceMetaJson,
+		};
+	}
+
+	function executeNativeMemoryIndex(
+		request: Extract<DbOwnerJob["request"], { readonly kind: "source_native_memory_index" }>,
+		context?: JobExecutionContext,
+	): { readonly artifactChanged: boolean; readonly graphIndexed: boolean } {
+		const input = request.input;
+		const sourcePath = input.sourcePath.replace(/\\/g, "/");
+		const existing = db
+			.prepare(
+				"SELECT source_sha256 FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0 LIMIT 1",
+			)
+			.get(input.agentId, sourcePath) as { source_sha256: string } | null | undefined;
+		db.exec("BEGIN IMMEDIATE");
+		try {
+			upsertMemoryArtifactInTx(db as unknown as BunDatabase, nativeMemoryArtifactFields(input));
+			if (input.graph !== undefined) {
+				applyObsidianSourceStructureInTx(db as unknown as import("./db-accessor").WriteDb, {
+					agentId: input.agentId,
+					sourceId: input.graph.sourceId,
+					sourceName: input.graph.sourceName,
+					root: input.graph.root,
+					filePath: sourcePath,
+					content: input.content,
+				});
+			}
+			if (input.checkpoint !== undefined) {
+				db.prepare(
+					`INSERT INTO source_sync_checkpoints
+					 (agent_id, source_key, phase, cursor, frontier, scanned, complete, updated_at)
+					 VALUES (?, ?, 'content', ?, NULL, ?, 0, datetime('now'))
+					 ON CONFLICT(agent_id, source_key, phase) DO UPDATE SET
+					 cursor = excluded.cursor,
+					 frontier = excluded.frontier,
+					 scanned = excluded.scanned,
+					 complete = excluded.complete,
+					 updated_at = excluded.updated_at`,
+				).run(input.agentId, input.checkpoint.sourceKey, sourcePath, input.checkpoint.scanned);
+			}
+			commit(context);
+			return {
+				artifactChanged: existing?.source_sha256 !== input.sourceHash,
+				graphIndexed: input.graph !== undefined,
+			};
+		} catch (error) {
+			try {
+				db.exec("ROLLBACK");
+			} catch {
+				// Preserve the original error.
+			}
+			throw error;
+		}
+	}
+
 	function executeSourceArtifactIndex(
 		request: Extract<DbOwnerJob["request"], { readonly kind: "source_artifact_index" }>,
 		context?: JobExecutionContext,
@@ -518,6 +605,7 @@ export function runDbOwnerWorker(): void {
 		)
 			return executeSourceGraph(job.request, context);
 		if (job.request.kind === "source_artifact_index") return executeSourceArtifactIndex(job.request, context);
+		if (job.request.kind === "source_native_memory_index") return executeNativeMemoryIndex(job.request, context);
 		if (job.request.kind === "source_artifact_purge") return executeSourceArtifactPurge(job.request, context);
 		if (job.request.kind === "vacuum_conversion") {
 			const { convertToIncrementalVacuum } = await import("./db-vacuum");

--- a/platform/daemon/src/native-memory-source-worker.test.ts
+++ b/platform/daemon/src/native-memory-source-worker.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "bun:test";
-import { createNativeSourceWorker } from "./native-memory-source-worker";
+import { createNativeSourceWorker, NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES } from "./native-memory-source-worker";
 
 async function fixture(): Promise<{
 	readonly root: string;
@@ -75,5 +75,31 @@ describe("native source worker", () => {
 		});
 		await worker.close();
 		expect(page.files[0]?.chunks?.length).toBe(1);
+	});
+
+	it("derives Codex source IDs in the isolated worker", async () => {
+		const { root } = await fixture();
+		const worker = createNativeSourceWorker();
+		const page = await worker.scan({
+			source: { root, harness: "codex", files: [{ glob: "**/*.md", kind: "markdown" }] },
+			cursor: null,
+			pageSize: 1,
+		});
+		await worker.close();
+		expect(page.files[0]?.sourceId).toMatch(/^codex_native_memory:[0-9a-f]{16}$/);
+	});
+
+	it(`rejects a descriptor larger than the ${NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES}-byte IPC bound`, async () => {
+		const root = await mkdtemp(join(tmpdir(), "signet-native-source-worker-bound-"));
+		await writeFile(join(root, "huge.md"), "x".repeat(NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES + 1024));
+		const worker = createNativeSourceWorker();
+		await expect(
+			worker.scan({
+				source: { root, files: [{ glob: "**/*.md", kind: "markdown" }] },
+				cursor: null,
+				pageSize: 1,
+			}),
+		).rejects.toThrow(/IPC limit/);
+		await worker.close();
 	});
 });

--- a/platform/daemon/src/native-memory-source-worker.test.ts
+++ b/platform/daemon/src/native-memory-source-worker.test.ts
@@ -1,5 +1,6 @@
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
+import { Writable } from "node:stream";
 import { join } from "node:path";
 import { EventEmitter } from "node:events";
 import { describe, expect, it } from "bun:test";
@@ -24,26 +25,30 @@ async function fixture(): Promise<{
 }
 
 describe("native source worker", () => {
-	it("does not complete a delayed drain early", async () => {
-		const stdin = new EventEmitter() as unknown as NodeJS.WritableStream;
-		let settled = false;
-		const drain = waitForNativeSourceWorkerDrain(stdin).then(() => {
-			settled = true;
+	it("does not complete a scan before a real backpressured command drains", async () => {
+		const { root } = await fixture();
+		const source = {
+			root,
+			files: [
+				{ glob: "**/*.md", kind: "markdown" },
+				...Array.from({ length: 4096 }, (_, index) => ({
+					glob: `never-match-${index}-${"x".repeat(64)}`,
+					kind: "markdown",
+				})),
+			],
+		};
+		type TestStdin = NodeJS.WritableStream & {
+			readonly writableHighWaterMark: number;
+			write: (...args: unknown[]) => boolean;
+		};
+		let stdin!: TestStdin;
+		let commandWritten!: () => void;
+		const command = new Promise<void>((resolve) => {
+			commandWritten = resolve;
 		});
-
-		await Bun.sleep(0);
-		expect(settled).toBe(false);
-		stdin.emit("drain");
-		await drain;
-		expect(settled).toBe(true);
-	});
-
-	it("does not complete a scan before its command drain resolves", async () => {
-		const { source } = await fixture();
-		let release!: () => void;
-		const drain = new Promise<void>((resolve) => {
-			release = resolve;
-		});
+		let commandBytes = 0;
+		let commandWriteReturnedFalse = false;
+		let releaseWrite!: () => void;
 		let scanStarted!: () => void;
 		const started = new Promise<void>((resolve) => {
 			scanStarted = resolve;
@@ -53,12 +58,30 @@ describe("native source worker", () => {
 			resultDelivered = resolve;
 		});
 		const worker = createNativeSourceWorker({
+			wrapStdin: (rawStdin) => {
+				const backpressuredStdin = new Writable({
+					highWaterMark: 1024,
+					write(chunk, _encoding, callback) {
+						rawStdin.write(chunk as string);
+						releaseWrite = callback;
+					},
+				}) as TestStdin;
+				stdin = backpressuredStdin;
+				const write = stdin.write.bind(stdin);
+				stdin.write = ((...args: unknown[]) => {
+					const result = write(...args);
+					const chunk = args[0];
+					if (typeof chunk === "string" && chunk.includes('"type":"scan"')) {
+						commandBytes = Buffer.byteLength(chunk, "utf8");
+						commandWriteReturnedFalse = result === false;
+						commandWritten();
+					}
+					return result;
+				}) as TestStdin["write"];
+				return stdin;
+			},
 			onScanStarted: scanStarted,
 			onScanResult: resultDelivered,
-			writeCommand: async (stdin, command) => {
-				stdin.write(command);
-				await drain;
-			},
 		});
 		let settled = false;
 		try {
@@ -66,15 +89,17 @@ describe("native source worker", () => {
 				settled = true;
 				return page;
 			});
+			await command;
+			expect(commandBytes).toBeGreaterThan(stdin.writableHighWaterMark);
+			expect(commandWriteReturnedFalse).toBe(true);
 			await started;
 			await result;
 			await new Promise<void>((resolve) => setImmediate(resolve));
 			expect(settled).toBe(false);
-			release();
+			releaseWrite();
 			await scan;
 			expect(settled).toBe(true);
 		} finally {
-			release();
 			await worker.close();
 		}
 	});

--- a/platform/daemon/src/native-memory-source-worker.test.ts
+++ b/platform/daemon/src/native-memory-source-worker.test.ts
@@ -1,8 +1,13 @@
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { EventEmitter } from "node:events";
 import { describe, expect, it } from "bun:test";
-import { createNativeSourceWorker, NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES } from "./native-memory-source-worker";
+import {
+	createNativeSourceWorker,
+	NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES,
+	waitForNativeSourceWorkerDrain,
+} from "./native-memory-source-worker";
 
 async function fixture(): Promise<{
 	readonly root: string;
@@ -19,6 +24,76 @@ async function fixture(): Promise<{
 }
 
 describe("native source worker", () => {
+	it("does not complete a delayed drain early", async () => {
+		const stdin = new EventEmitter() as unknown as NodeJS.WritableStream;
+		let settled = false;
+		const drain = waitForNativeSourceWorkerDrain(stdin).then(() => {
+			settled = true;
+		});
+
+		await Bun.sleep(0);
+		expect(settled).toBe(false);
+		stdin.emit("drain");
+		await drain;
+		expect(settled).toBe(true);
+	});
+
+	it("does not complete a scan before its command drain resolves", async () => {
+		const { source } = await fixture();
+		let release!: () => void;
+		const drain = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		let scanStarted!: () => void;
+		const started = new Promise<void>((resolve) => {
+			scanStarted = resolve;
+		});
+		let resultDelivered!: () => void;
+		const result = new Promise<void>((resolve) => {
+			resultDelivered = resolve;
+		});
+		const worker = createNativeSourceWorker({
+			onScanStarted: scanStarted,
+			onScanResult: resultDelivered,
+			writeCommand: async (stdin, command) => {
+				stdin.write(command);
+				await drain;
+			},
+		});
+		let settled = false;
+		try {
+			const scan = worker.scan({ source, cursor: null, pageSize: 1 }).then((page) => {
+				settled = true;
+				return page;
+			});
+			await started;
+			await result;
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			expect(settled).toBe(false);
+			release();
+			await scan;
+			expect(settled).toBe(true);
+		} finally {
+			release();
+			await worker.close();
+		}
+	});
+
+	it("propagates a worker stream error while waiting for drain", async () => {
+		const stdin = new EventEmitter() as unknown as NodeJS.WritableStream;
+		const streamError = new Error("worker stdin failed");
+		const drain = waitForNativeSourceWorkerDrain(stdin);
+		stdin.emit("error", streamError);
+		await expect(drain).rejects.toBe(streamError);
+	});
+
+	it("propagates a worker stream close while waiting for drain", async () => {
+		const stdin = new EventEmitter() as unknown as NodeJS.WritableStream;
+		const drain = waitForNativeSourceWorkerDrain(stdin);
+		stdin.emit("close");
+		await expect(drain).rejects.toThrow("closed before drain");
+	});
+
 	it("pages source content and resumes from a durable cursor after worker restart", async () => {
 		const { source } = await fixture();
 		const firstWorker = createNativeSourceWorker();

--- a/platform/daemon/src/native-memory-source-worker.ts
+++ b/platform/daemon/src/native-memory-source-worker.ts
@@ -16,6 +16,7 @@ export interface NativeSourceWorkerPattern {
 
 export interface NativeSourceWorkerSource {
 	readonly root: string;
+	readonly sourceRoot?: string;
 	readonly files: readonly NativeSourceWorkerPattern[];
 	readonly harness?: string;
 	readonly sourceId?: string;
@@ -27,6 +28,8 @@ export interface NativeSourceWorkerFile {
 	readonly mtimeMs: number;
 	readonly kind: string;
 	readonly contentHash: string;
+	/** Source identity is derived in the isolated worker, never in the parent. */
+	readonly sourceId?: string;
 	readonly lineCount: number;
 	readonly rolloutId?: string;
 	readonly chunks?: readonly ObsidianSourceChunk[];
@@ -55,6 +58,7 @@ type WorkerCommand = ScanCommand | { readonly type: "cancel"; readonly id: strin
 
 type WorkerEvent =
 	| { readonly type: "ready"; readonly pid: number }
+	| { readonly type: "scan_started"; readonly id: string }
 	| {
 			readonly type: "result";
 			readonly id: string;
@@ -69,6 +73,20 @@ interface PendingScan {
 }
 
 const NATIVE_SOURCE_WORKER_SCAN_DEADLINE_MS = 30_000;
+/** Maximum UTF-8 JSON size for either side of the worker IPC channel. */
+export const NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES = 4 * 1024 * 1024;
+
+function nativeSourceId(source: NativeSourceWorkerSource): string | undefined {
+	if (source.sourceId !== undefined) return source.sourceId;
+	if (source.harness === "codex")
+		return `codex_native_memory:${createHash("sha256").update(source.root.replace(/\\/g, "/")).digest("hex").slice(0, 16)}`;
+	if (source.harness === "hermes-agent")
+		return `hermes_native_memory:${createHash("sha256")
+			.update((source.sourceRoot ?? source.root).replace(/\\/g, "/"))
+			.digest("hex")
+			.slice(0, 16)}`;
+	return undefined;
+}
 
 function matchSegment(glob: string, value: string): boolean {
 	if (glob === "*") return value.length > 0;
@@ -155,15 +173,36 @@ async function scan(command: ScanCommand): Promise<NativeSourceWorkerPage> {
 							content,
 						})
 					: undefined;
-			files.push({
+			const descriptor: NativeSourceWorkerFile = {
 				path,
 				content,
 				mtimeMs: info.mtimeMs,
 				kind,
 				...contentMetadata(content),
+				...(nativeSourceId(command.source) === undefined ? {} : { sourceId: nativeSourceId(command.source) }),
 				...(chunks === undefined ? {} : { chunks }),
-			});
+			};
+			const candidate = {
+				files: [...files, descriptor],
+				nextCursor: descriptor.path,
+				scanned: files.length + 1,
+				total: files.length + 1,
+				complete: frontier.length === 0,
+				frontier,
+				permissionDeniedPaths,
+			};
+			const candidateBytes = Buffer.byteLength(JSON.stringify(candidate), "utf8");
+			if (files.length > 0 && candidateBytes > NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES) {
+				frontier.push(path);
+				break;
+			}
+			if (candidateBytes > NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES)
+				throw new Error(
+					`native source worker descriptor exceeds the ${NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES}-byte IPC limit`,
+				);
+			files.push(descriptor);
 		} catch (error) {
+			if (error instanceof Error && error.message.includes("IPC limit")) throw error;
 			if (
 				typeof error === "object" &&
 				error !== null &&
@@ -194,7 +233,12 @@ export function runNativeSourceWorker(): void {
 	const canceled = new Set<string>();
 	let input = "";
 	const send = (event: WorkerEvent): void => {
-		process.stdout.write(`${JSON.stringify(event)}\n`);
+		const serialized = JSON.stringify(event);
+		if (Buffer.byteLength(serialized, "utf8") > NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES)
+			throw new Error(
+				`native source worker message exceeds the ${NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES}-byte IPC limit`,
+			);
+		process.stdout.write(`${serialized}\n`);
 	};
 	send({ type: "ready", pid: process.pid });
 	process.stdin.setEncoding("utf8");
@@ -205,6 +249,7 @@ export function runNativeSourceWorker(): void {
 		for (const line of lines) {
 			if (!line) continue;
 			const command = JSON.parse(line) as WorkerCommand;
+			if (command.type === "scan") send({ type: "scan_started", id: command.id });
 			if (command.type === "shutdown") {
 				clearInterval(parentWatch);
 				process.exit(0);
@@ -247,7 +292,9 @@ export interface NativeSourceWorkerHandle {
 	readonly close: () => Promise<void>;
 }
 
-export function createNativeSourceWorker(): NativeSourceWorkerHandle {
+export function createNativeSourceWorker(
+	options: { readonly onScanStarted?: () => void } = {},
+): NativeSourceWorkerHandle {
 	let child: ChildProcess | null = null;
 	let startPromise: Promise<void> | null = null;
 	let sequence = 0;
@@ -273,6 +320,7 @@ export function createNativeSourceWorker(): NativeSourceWorkerHandle {
 					if (!line) continue;
 					const event = JSON.parse(line) as WorkerEvent;
 					if (event.type === "ready") resolve();
+					if (event.type === "scan_started") options.onScanStarted?.();
 					if (event.type === "result" || event.type === "error") {
 						const job = pending.get(event.id);
 						if (!job) continue;
@@ -329,9 +377,44 @@ export function createNativeSourceWorker(): NativeSourceWorkerHandle {
 				reject(new Error(`native source worker scan exceeded ${NATIVE_SOURCE_WORKER_SCAN_DEADLINE_MS}ms`));
 			}, NATIVE_SOURCE_WORKER_SCAN_DEADLINE_MS);
 			pending.set(id, { resolve, reject, timer });
-			stdin.write(
-				`${JSON.stringify({ type: "scan", id, ...inputValue, frontier: inputValue.frontier ?? undefined })}\n`,
-			);
+			const command = `${JSON.stringify({ type: "scan", id, ...inputValue, frontier: inputValue.frontier ?? undefined })}\n`;
+			if (Buffer.byteLength(command, "utf8") > NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES) {
+				pending.delete(id);
+				activeId = null;
+				clearTimeout(timer);
+				reject(
+					new Error(
+						`native source worker command exceeds the ${NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES}-byte IPC limit`,
+					),
+				);
+				return;
+			}
+			try {
+				if (stdin.write(command)) return;
+			} catch (error) {
+				pending.delete(id);
+				activeId = null;
+				clearTimeout(timer);
+				reject(error);
+				return;
+			}
+			void new Promise<void>((resolve, reject) => {
+				const onDrain = (): void => {
+					stdin.off("error", onError);
+					resolve();
+				};
+				const onError = (error: Error): void => {
+					stdin.off("drain", onDrain);
+					reject(error);
+				};
+				stdin.once("drain", onDrain);
+				stdin.once("error", onError);
+			}).catch((error: unknown) => {
+				if (!pending.delete(id)) return;
+				activeId = null;
+				clearTimeout(timer);
+				reject(error);
+			});
 		});
 	};
 	return {

--- a/platform/daemon/src/native-memory-source-worker.ts
+++ b/platform/daemon/src/native-memory-source-worker.ts
@@ -76,6 +76,31 @@ const NATIVE_SOURCE_WORKER_SCAN_DEADLINE_MS = 30_000;
 /** Maximum UTF-8 JSON size for either side of the worker IPC channel. */
 export const NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES = 4 * 1024 * 1024;
 
+export function waitForNativeSourceWorkerDrain(stdin: NodeJS.WritableStream): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		const cleanup = (): void => {
+			stdin.off("drain", onDrain);
+			stdin.off("error", onError);
+			stdin.off("close", onClose);
+		};
+		const onDrain = (): void => {
+			cleanup();
+			resolve();
+		};
+		const onError = (error: Error): void => {
+			cleanup();
+			reject(error);
+		};
+		const onClose = (): void => {
+			cleanup();
+			reject(new Error("native source worker stdin closed before drain"));
+		};
+		stdin.once("drain", onDrain);
+		stdin.once("error", onError);
+		stdin.once("close", onClose);
+	});
+}
+
 function nativeSourceId(source: NativeSourceWorkerSource): string | undefined {
 	if (source.sourceId !== undefined) return source.sourceId;
 	if (source.harness === "codex")
@@ -293,7 +318,13 @@ export interface NativeSourceWorkerHandle {
 }
 
 export function createNativeSourceWorker(
-	options: { readonly onScanStarted?: () => void } = {},
+	options: {
+		readonly onScanStarted?: () => void;
+		/** Test-only hook fired when the child has delivered a scan result. */
+		readonly onScanResult?: () => void;
+		/** Test-only seam for exercising command backpressure. */
+		readonly writeCommand?: (stdin: NodeJS.WritableStream, command: string) => Promise<void>;
+	} = {},
 ): NativeSourceWorkerHandle {
 	let child: ChildProcess | null = null;
 	let startPromise: Promise<void> | null = null;
@@ -327,8 +358,10 @@ export function createNativeSourceWorker(
 						pending.delete(event.id);
 						activeId = null;
 						if (job.timer) clearTimeout(job.timer);
-						if (event.type === "result") job.resolve(event.result);
-						else job.reject(new Error(event.message));
+						if (event.type === "result") {
+							options.onScanResult?.();
+							job.resolve(event.result);
+						} else job.reject(new Error(event.message));
 					}
 				}
 			});
@@ -369,53 +402,39 @@ export function createNativeSourceWorker(
 			throw new Error("native source worker is unavailable");
 		const id = `source-scan-${process.pid}-${++sequence}`;
 		activeId = id;
-		return await new Promise<NativeSourceWorkerPage>((resolve, reject) => {
-			const timer = setTimeout(() => {
+		let rejectResult!: (error: Error) => void;
+		let timer!: ReturnType<typeof setTimeout>;
+		const result = new Promise<NativeSourceWorkerPage>((resolve, reject) => {
+			rejectResult = reject;
+			timer = setTimeout(() => {
 				if (!pending.delete(id)) return;
 				activeId = null;
 				worker.kill("SIGKILL");
 				reject(new Error(`native source worker scan exceeded ${NATIVE_SOURCE_WORKER_SCAN_DEADLINE_MS}ms`));
 			}, NATIVE_SOURCE_WORKER_SCAN_DEADLINE_MS);
 			pending.set(id, { resolve, reject, timer });
-			const command = `${JSON.stringify({ type: "scan", id, ...inputValue, frontier: inputValue.frontier ?? undefined })}\n`;
-			if (Buffer.byteLength(command, "utf8") > NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES) {
-				pending.delete(id);
-				activeId = null;
-				clearTimeout(timer);
-				reject(
-					new Error(
-						`native source worker command exceeds the ${NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES}-byte IPC limit`,
-					),
-				);
-				return;
-			}
-			try {
-				if (stdin.write(command)) return;
-			} catch (error) {
-				pending.delete(id);
-				activeId = null;
-				clearTimeout(timer);
-				reject(error);
-				return;
-			}
-			void new Promise<void>((resolve, reject) => {
-				const onDrain = (): void => {
-					stdin.off("error", onError);
-					resolve();
-				};
-				const onError = (error: Error): void => {
-					stdin.off("drain", onDrain);
-					reject(error);
-				};
-				stdin.once("drain", onDrain);
-				stdin.once("error", onError);
-			}).catch((error: unknown) => {
-				if (!pending.delete(id)) return;
-				activeId = null;
-				clearTimeout(timer);
-				reject(error);
-			});
 		});
+		const command = `${JSON.stringify({ type: "scan", id, ...inputValue, frontier: inputValue.frontier ?? undefined })}\n`;
+		if (Buffer.byteLength(command, "utf8") > NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES) {
+			pending.delete(id);
+			clearTimeout(timer);
+			activeId = null;
+			rejectResult(
+				new Error(`native source worker command exceeds the ${NATIVE_SOURCE_WORKER_MAX_MESSAGE_BYTES}-byte IPC limit`),
+			);
+			return await result;
+		}
+		try {
+			if (options.writeCommand) await options.writeCommand(stdin, command);
+			else if (!stdin.write(command)) await waitForNativeSourceWorkerDrain(stdin);
+		} catch (error: unknown) {
+			if (pending.delete(id)) {
+				clearTimeout(timer);
+				activeId = null;
+				rejectResult(error instanceof Error ? error : new Error(String(error)));
+			}
+		}
+		return await result;
 	};
 	return {
 		scan,

--- a/platform/daemon/src/native-memory-source-worker.ts
+++ b/platform/daemon/src/native-memory-source-worker.ts
@@ -39,6 +39,7 @@ export interface NativeSourceWorkerPage {
 	readonly total: number;
 	readonly complete: boolean;
 	readonly frontier: readonly string[];
+	readonly permissionDeniedPaths: readonly string[];
 }
 
 interface ScanCommand {
@@ -122,6 +123,7 @@ async function scan(command: ScanCommand): Promise<NativeSourceWorkerPage> {
 	const pageSize = Math.max(1, Math.min(100, Math.trunc(command.pageSize)));
 	const frontier = [...(command.frontier ?? [command.source.root])];
 	const files: NativeSourceWorkerFile[] = [];
+	const permissionDeniedPaths: string[] = [];
 	while (frontier.length > 0 && files.length < pageSize) {
 		const path = frontier.pop();
 		if (path === undefined) break;
@@ -141,6 +143,7 @@ async function scan(command: ScanCommand): Promise<NativeSourceWorkerPage> {
 			const kind = matchesPattern(command.source, path);
 			if (kind === null) continue;
 			const content = await readFile(path, "utf8");
+			if (!content.trim()) continue;
 			const chunks =
 				command.source.harness === "obsidian" &&
 				command.source.sourceId !== undefined &&
@@ -160,7 +163,14 @@ async function scan(command: ScanCommand): Promise<NativeSourceWorkerPage> {
 				...contentMetadata(content),
 				...(chunks === undefined ? {} : { chunks }),
 			});
-		} catch {
+		} catch (error) {
+			if (
+				typeof error === "object" &&
+				error !== null &&
+				((error as NodeJS.ErrnoException).code === "EACCES" || (error as NodeJS.ErrnoException).code === "EPERM")
+			) {
+				permissionDeniedPaths.push(path);
+			}
 			// Files and directories can disappear while a source is being edited.
 		}
 	}
@@ -171,6 +181,7 @@ async function scan(command: ScanCommand): Promise<NativeSourceWorkerPage> {
 		total: files.length,
 		complete: frontier.length === 0,
 		frontier,
+		permissionDeniedPaths,
 	};
 }
 

--- a/platform/daemon/src/native-memory-source-worker.ts
+++ b/platform/daemon/src/native-memory-source-worker.ts
@@ -319,6 +319,8 @@ export interface NativeSourceWorkerHandle {
 
 export function createNativeSourceWorker(
 	options: {
+		/** Test-only seam for exercising backpressure with a real Writable implementation. */
+		readonly wrapStdin?: (stdin: NodeJS.WritableStream) => NodeJS.WritableStream;
 		readonly onScanStarted?: () => void;
 		/** Test-only hook fired when the child has delivered a scan result. */
 		readonly onScanResult?: () => void;
@@ -397,9 +399,10 @@ export function createNativeSourceWorker(
 	}): Promise<NativeSourceWorkerPage> => {
 		await start();
 		const worker = child;
-		const stdin = worker?.stdin;
-		if (worker === null || stdin === null || stdin === undefined)
+		const rawStdin = worker?.stdin;
+		if (worker === null || rawStdin === null || rawStdin === undefined)
 			throw new Error("native source worker is unavailable");
+		const stdin = options.wrapStdin?.(rawStdin) ?? rawStdin;
 		const id = `source-scan-${process.pid}-${++sequence}`;
 		activeId = id;
 		let rejectResult!: (error: Error) => void;

--- a/platform/daemon/src/native-memory-sources-dataless.test.ts
+++ b/platform/daemon/src/native-memory-sources-dataless.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -175,7 +175,8 @@ describe("dataless / EDEADLK native artifact reads (#1161)", () => {
 
 			resetNativeMemoryIndexCache();
 			statError = () => null;
-			readdirError = (path) => (path === dir ? permissionError() : null);
+			readdirError = () => null;
+			chmodSync(dir, 0o000);
 			const readdirBridge = startNativeMemoryBridge([source], { agentId: "agent-readdir", pollIntervalMs: 0 });
 			await readdirBridge.syncExisting();
 			await readdirBridge.syncExisting();
@@ -188,6 +189,7 @@ describe("dataless / EDEADLK native artifact reads (#1161)", () => {
 		} finally {
 			logger.warn = originalWarn;
 			Object.defineProperty(process, "platform", { value: originalPlatform });
+			chmodSync(dir, 0o700);
 			rmSync(dir, { recursive: true, force: true });
 		}
 	});

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -1879,6 +1879,123 @@ describe("native memory sources", () => {
 		}
 	}, 5_000);
 
+	it("resumes from the committed per-file worker frontier after a capped scan", async () => {
+		const root = join(dir, "resume-frontier-source");
+		mkdirSync(root, { recursive: true });
+		for (let index = 0; index < 3; index += 1) {
+			writeFileSync(join(root, `note-${index}.md`), `# Resume ${index}\n\nfrontier ${index}\n`);
+		}
+		const source = obsidianNativeMemorySource(root, "Resume source", "obsidian:resume-frontier");
+		const first = startNativeMemoryBridge([source], {
+			agentId: "agent-resume-frontier",
+			pollIntervalMs: 0,
+			maxFilesPerScan: 1,
+			sourceGraphEnabled: false,
+		});
+		try {
+			expect(await first.syncExisting()).toBe(1);
+		} finally {
+			await first.close();
+		}
+
+		const checkpointRows = await dbOwnerQuery<
+			readonly { readonly cursor: string | null; readonly frontier: string | null; readonly complete: number }[]
+		>(
+			ownerStatement(
+				"SELECT cursor, frontier, complete FROM source_sync_checkpoints WHERE agent_id = ? AND source_key = ? AND phase = 'content'",
+				["agent-resume-frontier", `agent-resume-frontier:obsidian:${root}`],
+				"all",
+			),
+			{ operation: "test.resume-frontier.checkpoint", lane: "read" },
+		);
+		const checkpoint = checkpointRows[0] ?? null;
+		expect(checkpoint?.cursor).toContain("note-");
+		expect(JSON.parse(checkpoint?.frontier ?? "[]")).not.toContain(root);
+		expect(checkpoint?.complete).toBe(0);
+
+		const second = startNativeMemoryBridge([source], {
+			agentId: "agent-resume-frontier",
+			pollIntervalMs: 0,
+			maxFilesPerScan: 1,
+			sourceGraphEnabled: false,
+		});
+		try {
+			expect(await second.syncExisting()).toBe(1);
+		} finally {
+			await second.close();
+		}
+		const artifactRows = await dbOwnerQuery<readonly { readonly count: number }[]>(
+			ownerStatement(
+				"SELECT COUNT(*) AS count FROM memory_artifacts WHERE agent_id = ?",
+				["agent-resume-frontier"],
+				"all",
+			),
+			{ operation: "test.resume-frontier.artifacts", lane: "read" },
+		);
+		const artifactCount = artifactRows[0]?.count ?? 0;
+		expect(artifactCount).toBe(2);
+	});
+
+	it("resumes from the durable frontier after the source worker is killed", async () => {
+		const root = join(dir, "killed-resume-source");
+		mkdirSync(root, { recursive: true });
+		for (let index = 0; index < 3; index += 1) {
+			writeFileSync(join(root, `note-${index}.md`), `# Killed ${index}\n\nworker resume ${index}\n`);
+		}
+		const source = obsidianNativeMemorySource(root, "Killed resume source", "obsidian:killed-resume");
+		const firstIndexed: string[] = [];
+		const first = startNativeMemoryBridge([source], {
+			agentId: "agent-killed-resume",
+			pollIntervalMs: 0,
+			maxFilesPerScan: 3,
+			sourceGraphEnabled: false,
+			onFileIndexed: ({ filePath }) => {
+				firstIndexed.push(filePath);
+				if (firstIndexed.length === 1) first.cancel();
+			},
+		});
+		await expect(first.syncExisting()).rejects.toThrow(/native source sync cancelled|native source worker/);
+		await first.close();
+		expect(firstIndexed).toHaveLength(1);
+
+		const checkpointRows = await dbOwnerQuery<
+			readonly { readonly frontier: string | null; readonly complete: number }[]
+		>(
+			ownerStatement(
+				"SELECT frontier, complete FROM source_sync_checkpoints WHERE agent_id = ? AND source_key = ? AND phase = 'content'",
+				["agent-killed-resume", `agent-killed-resume:obsidian:${root}`],
+				"all",
+			),
+			{
+				operation: "test.native-memory-resume-checkpoint",
+				lane: "read",
+			},
+		);
+		const checkpoint = checkpointRows[0] ?? null;
+		expect(checkpoint).not.toBeNull();
+		const frontier: unknown = JSON.parse(checkpoint?.frontier ?? "null");
+		expect(Array.isArray(frontier)).toBe(true);
+		expect(frontier).toHaveLength(2);
+		expect(frontier).not.toContain(root);
+		expect(checkpoint?.complete).toBe(0);
+
+		const restartedIndexed: string[] = [];
+		const restarted = startNativeMemoryBridge([source], {
+			agentId: "agent-killed-resume",
+			pollIntervalMs: 0,
+			maxFilesPerScan: 1,
+			sourceGraphEnabled: false,
+			onFileIndexed: ({ filePath }) => restartedIndexed.push(filePath),
+		});
+		try {
+			expect(await restarted.syncExisting()).toBe(1);
+		} finally {
+			await restarted.close();
+		}
+		expect(restartedIndexed).toHaveLength(1);
+		expect(restartedIndexed[0]).not.toBe(firstIndexed[0]);
+	});
+
 	it("kills only the source worker and leaves the DB owner usable", async () => {
 		const root = join(dir, "killable-source");
 		mkdirSync(root, { recursive: true });

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -1867,7 +1867,8 @@ describe("native memory sources", () => {
 				implementation.indexOf("export async function indexNativeMemoryFile"),
 				implementation.indexOf("export async function removeNativeMemoryFile"),
 			);
-			expect(indexingPath).not.toMatch(/\b(?:readFileSync|statSync|lstatSync)\b/);
+			expect(indexingPath).not.toMatch(/\b(?:readFileSync|statSync|lstatSync|createHash)\b/);
+			expect(implementation).not.toContain('from "node:crypto"');
 			// This is the runtime attribution shim: warnings are inspected by
 			// category/message rather than inferred from elapsed wall-clock time.
 			expect(criticalWarnings).toEqual([]);
@@ -1937,7 +1938,7 @@ describe("native memory sources", () => {
 		expect(artifactCount).toBe(2);
 	});
 
-	it("resumes from the durable frontier after the source worker is killed", async () => {
+	it("resumes from the durable frontier after the source worker is killed during traversal", async () => {
 		const root = join(dir, "killed-resume-source");
 		mkdirSync(root, { recursive: true });
 		for (let index = 0; index < 3; index += 1) {
@@ -1945,16 +1946,21 @@ describe("native memory sources", () => {
 		}
 		const source = obsidianNativeMemorySource(root, "Killed resume source", "obsidian:killed-resume");
 		const firstIndexed: string[] = [];
+		let scanStarts = 0;
 		const first = startNativeMemoryBridge([source], {
 			agentId: "agent-killed-resume",
 			pollIntervalMs: 0,
-			maxFilesPerScan: 3,
+			maxFilesPerScan: 1,
 			sourceGraphEnabled: false,
-			onFileIndexed: ({ filePath }) => {
-				firstIndexed.push(filePath);
-				if (firstIndexed.length === 1) first.cancel();
+			onSourceWorkerScanStarted: () => {
+				scanStarts += 1;
+				// The first scan commits note-0. The second scan is killed from
+				// the worker-start event, before its descriptor is returned.
+				if (scanStarts === 2) first.cancel();
 			},
+			onFileIndexed: ({ filePath }) => firstIndexed.push(filePath),
 		});
+		expect(await first.syncExisting()).toBe(1);
 		await expect(first.syncExisting()).rejects.toThrow(/native source sync cancelled|native source worker/);
 		await first.close();
 		expect(firstIndexed).toHaveLength(1);
@@ -1967,10 +1973,7 @@ describe("native memory sources", () => {
 				["agent-killed-resume", `agent-killed-resume:obsidian:${root}`],
 				"all",
 			),
-			{
-				operation: "test.native-memory-resume-checkpoint",
-				lane: "read",
-			},
+			{ operation: "test.native-memory-resume-checkpoint", lane: "read" },
 		);
 		const checkpoint = checkpointRows[0] ?? null;
 		expect(checkpoint).not.toBeNull();
@@ -1995,6 +1998,70 @@ describe("native memory sources", () => {
 		}
 		expect(restartedIndexed).toHaveLength(1);
 		expect(restartedIndexed[0]).not.toBe(firstIndexed[0]);
+	});
+
+	it("keeps the provider-enabled frontier resumable when traversal is killed", async () => {
+		const root = join(dir, "provider-frontier-source");
+		mkdirSync(root, { recursive: true });
+		const firstPath = join(root, "note-a.md");
+		const secondPath = join(root, "note-b.md");
+		writeFileSync(firstPath, "# Provider A\n\nProvider frontier first descriptor.\n");
+		writeFileSync(secondPath, "# Provider B\n\nProvider frontier next descriptor.\n");
+		const provider = Bun.serve({
+			port: 0,
+			fetch: () => Response.json({ data: [{ embedding: [1, 2, 3] }] }),
+		});
+		const embeddingConfig = {
+			provider: "openai" as const,
+			model: "provider-frontier-test",
+			dimensions: 3,
+			base_url: `http://127.0.0.1:${provider.port}/v1`,
+			api_key: "test",
+			indexGeneration: "staging" as const,
+		};
+		const source = obsidianNativeMemorySource(root, "Provider frontier source", "obsidian:provider-frontier");
+		let scanStarts = 0;
+		const firstIndexed: string[] = [];
+		const first = startNativeMemoryBridge([source], {
+			agentId: "agent-provider-frontier",
+			pollIntervalMs: 0,
+			maxFilesPerScan: 1,
+			sourceGraphEnabled: false,
+			workerOwnedIndexing: false,
+			embeddingConfig,
+			fetchEmbedding: async () => [9, 9, 9],
+			onSourceWorkerScanStarted: () => {
+				scanStarts += 1;
+				if (scanStarts === 2) first.cancel();
+			},
+			onFileIndexed: ({ filePath }) => firstIndexed.push(filePath),
+		});
+		try {
+			expect(await first.syncExisting()).toBe(1);
+			await expect(first.syncExisting()).rejects.toThrow(/native source sync cancelled|native source worker/);
+		} finally {
+			await first.close();
+		}
+		expect(firstIndexed).toEqual([firstPath]);
+
+		const restartedIndexed: string[] = [];
+		const restarted = startNativeMemoryBridge([source], {
+			agentId: "agent-provider-frontier",
+			pollIntervalMs: 0,
+			maxFilesPerScan: 1,
+			sourceGraphEnabled: false,
+			workerOwnedIndexing: false,
+			embeddingConfig,
+			fetchEmbedding: async () => [9, 9, 9],
+			onFileIndexed: ({ filePath }) => restartedIndexed.push(filePath),
+		});
+		try {
+			expect(await restarted.syncExisting()).toBe(1);
+		} finally {
+			await restarted.close();
+			provider.stop();
+		}
+		expect(restartedIndexed).toEqual([secondPath]);
 	});
 
 	it("keeps embedding work and the crash-window frontier in the owner process", async () => {

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -6,6 +6,7 @@ import { addObsidianSource, loadSourcesConfig } from "@signet/core";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { dbOwnerQuery, ownerStatement } from "./db-owner-runtime";
 import { resetEmbeddingCircuitBreakers } from "./embedding-circuit-breaker";
+import { logger } from "./logger";
 import { resetObsidianSourceEmbeddingBackoff } from "./obsidian-source-embeddings";
 import { indexExternalMemoryArtifact } from "./memory-lineage";
 import type { NativeMemoryBridgeOptions } from "./native-memory-sources";
@@ -1815,14 +1816,17 @@ describe("native memory sources", () => {
 		}
 	});
 
-	it("keeps the source scan off the parent synchronous SQLite surface", async () => {
+	it("keeps a 200-file mixed-size source scan off parent sync surfaces", async () => {
 		const root = join(dir, "large-source");
 		mkdirSync(root, { recursive: true });
-		for (let index = 0; index < 5; index += 1) {
-			writeFileSync(
-				join(root, `note-${index}.md`),
-				`# Note ${index}\n\nParent-side SQLite must not run during this source scan.\n`,
-			);
+		for (let index = 0; index < 200; index += 1) {
+			const content =
+				index % 3 === 0
+					? `# Small ${index}\n\nSmall native memory note ${index}.\n`
+					: index % 3 === 1
+						? `# Medium ${index}\n\n${"Medium native memory content. ".repeat(5)}\n`
+						: `# Large ${index}\n\n${"Large native memory content. ".repeat(15)}\n`;
+			writeFileSync(join(root, `note-${index}.md`), content);
 		}
 		const accessor = getDbAccessor() as typeof getDbAccessor extends () => infer T
 			? T & Record<string, unknown>
@@ -1838,23 +1842,42 @@ describe("native memory sources", () => {
 			parentCrossings += 1;
 			throw new Error("parent synchronous SQLite crossed during native source sync");
 		};
+		const criticalWarnings: string[] = [];
+		const originalWarn = logger.warn;
+		const originalInfo = logger.info;
+		logger.warn = ((_category: unknown, message: unknown) => {
+			if (/critical|event.?loop|block/i.test(String(message))) criticalWarnings.push(String(message));
+		}) as typeof logger.warn;
+		logger.info = (() => {}) as typeof logger.info;
 		const handle = startNativeMemoryBridge(
 			[obsidianNativeMemorySource(root, "Large source", "obsidian:large-source")],
 			{
 				agentId: "agent-native",
 				pollIntervalMs: 0,
+				sourceFileDelayMs: 0,
 				sourceGraphEnabled: false,
 			},
 		);
 		try {
-			expect(await handle.syncExisting()).toBe(5);
+			expect(await handle.syncExisting()).toBe(200);
 			expect(parentCrossings).toBe(0);
+			const implementation = readFileSync(new URL("./native-memory-sources.ts", import.meta.url), "utf8");
+			const indexingPath = implementation.slice(
+				implementation.indexOf("export async function indexNativeMemoryFile"),
+				implementation.indexOf("export async function removeNativeMemoryFile"),
+			);
+			expect(indexingPath).not.toMatch(/\b(?:readFileSync|statSync|lstatSync)\b/);
+			// This is the runtime attribution shim: warnings are inspected by
+			// category/message rather than inferred from elapsed wall-clock time.
+			expect(criticalWarnings).toEqual([]);
 		} finally {
+			logger.warn = originalWarn;
+			logger.info = originalInfo;
 			(accessor as Record<string, unknown>).withReadDb = originalRead;
 			(accessor as Record<string, unknown>).withWriteTx = originalWrite;
 			await handle.close();
 		}
-	});
+	}, 5_000);
 
 	it("kills only the source worker and leaves the DB owner usable", async () => {
 		const root = join(dir, "killable-source");

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -7,7 +7,7 @@ import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { dbOwnerQuery, ownerStatement } from "./db-owner-runtime";
 import { resetEmbeddingCircuitBreakers } from "./embedding-circuit-breaker";
 import { logger } from "./logger";
-import { resetObsidianSourceEmbeddingBackoff } from "./obsidian-source-embeddings";
+import { buildObsidianSourceChunks, resetObsidianSourceEmbeddingBackoff } from "./obsidian-source-embeddings";
 import { indexExternalMemoryArtifact } from "./memory-lineage";
 import type { NativeMemoryBridgeOptions } from "./native-memory-sources";
 import {
@@ -1424,6 +1424,87 @@ describe("native memory sources", () => {
 		} finally {
 			await recovered.close();
 		}
+	});
+
+	it("leaves a provider-failed descriptor pending for restart after a mid-batch failure", async () => {
+		const root = join(dir, "mid-batch-provider-vault");
+		const file = join(root, "permanent", "Pending.md");
+		mkdirSync(join(root, "permanent"), { recursive: true });
+		const content =
+			"# First section\n\nThe first chunk completes before the provider fails. It contains enough source text to be embedded independently.\n\n" +
+			"## Second section\n\nThe second chunk fails during the same descriptor and must remain pending for the next daemon run.\n";
+		writeFileSync(file, content);
+		const source = obsidianNativeMemorySource(root, "Mid-batch Provider Vault", "obsidian:mid-batch-provider");
+		const chunks = buildObsidianSourceChunks({ sourceId: source.sourceId ?? "", root, filePath: file, content });
+		expect(chunks.length).toBeGreaterThan(1);
+		let failSecondChunk = true;
+		const calls: string[] = [];
+		const provider = Bun.serve({
+			port: 0,
+			fetch: async (request) => {
+				const body = (await request.json()) as { readonly input?: string | readonly string[] };
+				const text = typeof body.input === "string" ? body.input : (body.input?.join("\n") ?? "");
+				calls.push(text);
+				if (failSecondChunk && text.includes("Second section"))
+					return new Response("provider unavailable", { status: 503 });
+				return Response.json({ data: [{ embedding: [1, 2, 3] }] });
+			},
+		});
+		const makeHandle = () =>
+			startNativeMemoryBridge([source], {
+				agentId: "agent-mid-batch-provider",
+				pollIntervalMs: 0,
+				maxFilesPerScan: 1,
+				sourceGraphEnabled: false,
+				workerOwnedIndexing: true,
+				embeddingConfig: {
+					provider: "openai",
+					model: "mid-batch",
+					dimensions: 3,
+					base_url: `http://127.0.0.1:${provider.port}/v1`,
+					api_key: "test",
+				},
+				fetchEmbedding: async (text) => {
+					calls.push(`parent:${text}`);
+					return [9, 9, 9];
+				},
+			});
+
+		const first = makeHandle();
+		try {
+			expect(await first.syncExisting()).toBe(1);
+		} finally {
+			await first.close();
+		}
+
+		const checkpointRows = await dbOwnerQuery<
+			readonly { readonly cursor: string | null; readonly frontier: string | null; readonly complete: number }[]
+		>(
+			ownerStatement(
+				"SELECT cursor, frontier, complete FROM source_sync_checkpoints WHERE agent_id = ? AND source_key = ? AND phase = 'content'",
+				["agent-mid-batch-provider", `agent-mid-batch-provider:obsidian:${root}`],
+				"all",
+			),
+			{ operation: "test.mid-batch-provider.checkpoint", lane: "read" },
+		);
+		const checkpoint = checkpointRows[0] ?? null;
+		expect(checkpoint).not.toBeNull();
+		expect(checkpoint?.cursor).toBeNull();
+		expect(JSON.parse(checkpoint?.frontier ?? "[]")).toContain(file);
+		expect(checkpoint?.complete).toBe(0);
+
+		failSecondChunk = false;
+		resetEmbeddingCircuitBreakers();
+		resetObsidianSourceEmbeddingBackoff();
+		const callsBeforeRecovery = calls.length;
+		const recovered = makeHandle();
+		try {
+			expect(await recovered.syncExisting()).toBe(0);
+		} finally {
+			await recovered.close();
+		}
+		expect(calls.slice(callsBeforeRecovery).some((text) => text.includes("Second section"))).toBe(true);
+		provider.stop();
 	});
 
 	it("purges all artifacts below a disconnected Obsidian source root", async () => {

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -1856,6 +1856,7 @@ describe("native memory sources", () => {
 				pollIntervalMs: 0,
 				sourceFileDelayMs: 0,
 				sourceGraphEnabled: false,
+				workerOwnedIndexing: true,
 			},
 		);
 		try {
@@ -1994,6 +1995,92 @@ describe("native memory sources", () => {
 		}
 		expect(restartedIndexed).toHaveLength(1);
 		expect(restartedIndexed[0]).not.toBe(firstIndexed[0]);
+	});
+
+	it("keeps embedding work and the crash-window frontier in the owner process", async () => {
+		const root = join(dir, "owner-embedding-resume-source");
+		mkdirSync(root, { recursive: true });
+		const firstPath = join(root, "note-a.md");
+		const secondPath = join(root, "note-b.md");
+		writeFileSync(
+			firstPath,
+			"# Owner A\n\nThe first owner-indexed source note has enough content for a durable chunk.\n",
+		);
+		writeFileSync(
+			secondPath,
+			"# Owner B\n\nThe second owner-indexed source note proves restart resumes at the next frontier.\n",
+		);
+		const provider = Bun.serve({
+			port: 0,
+			fetch: () => Response.json({ data: [{ embedding: [1, 2, 3] }] }),
+		});
+		let parentEmbeddingCalls = 0;
+		const source = obsidianNativeMemorySource(root, "Owner embedding source", "obsidian:owner-embedding");
+		const embeddingConfig = {
+			provider: "openai" as const,
+			model: "owner-test",
+			dimensions: 3,
+			base_url: `http://127.0.0.1:${provider.port}/v1`,
+			api_key: "test",
+			indexGeneration: "staging" as const,
+		};
+		const firstIndexed: string[] = [];
+		const first = startNativeMemoryBridge([source], {
+			agentId: "agent-owner-embedding",
+			pollIntervalMs: 0,
+			maxFilesPerScan: 2,
+			sourceGraphEnabled: false,
+			workerOwnedIndexing: true,
+			embeddingConfig,
+			fetchEmbedding: async () => {
+				parentEmbeddingCalls++;
+				return [9, 9, 9];
+			},
+			onFileIndexed: ({ filePath }) => {
+				firstIndexed.push(filePath);
+				if (firstIndexed.length === 1) first.cancel();
+			},
+		});
+		try {
+			await expect(first.syncExisting()).rejects.toThrow(/native source sync cancelled|native source worker/);
+		} finally {
+			await first.close();
+		}
+		expect(parentEmbeddingCalls).toBe(0);
+		expect(firstIndexed).toHaveLength(1);
+		const checkpoint = await dbOwnerQuery<readonly { readonly frontier: string | null; readonly complete: number }[]>(
+			ownerStatement(
+				"SELECT frontier, complete FROM source_sync_checkpoints WHERE agent_id = ? AND source_key = ? AND phase = 'content'",
+				["agent-owner-embedding", `agent-owner-embedding:obsidian:${root}`],
+				"all",
+			),
+			{ operation: "test.owner-embedding.frontier", lane: "read" },
+		);
+		expect(JSON.parse(checkpoint[0]?.frontier ?? "[]")).toHaveLength(1);
+		expect(checkpoint[0]?.complete).toBe(0);
+
+		const restartedIndexed: string[] = [];
+		const restarted = startNativeMemoryBridge([source], {
+			agentId: "agent-owner-embedding",
+			pollIntervalMs: 0,
+			maxFilesPerScan: 1,
+			sourceGraphEnabled: false,
+			workerOwnedIndexing: true,
+			embeddingConfig,
+			fetchEmbedding: async () => {
+				parentEmbeddingCalls++;
+				return [9, 9, 9];
+			},
+			onFileIndexed: ({ filePath }) => restartedIndexed.push(filePath),
+		});
+		try {
+			expect(await restarted.syncExisting()).toBe(1);
+		} finally {
+			await restarted.close();
+			provider.stop();
+		}
+		expect(restartedIndexed).toEqual([secondPath]);
+		expect(parentEmbeddingCalls).toBe(0);
 	});
 
 	it("kills only the source worker and leaves the DB owner usable", async () => {

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -17,11 +17,12 @@ import {
 	dbOwnerBatch,
 	dbOwnerQuery,
 	dbOwnerSourceGraphFilePurge,
-	dbOwnerSourceGraphIndex,
 	dbOwnerSourceGraphPurge,
+	dbOwnerSourceNativeMemoryIndex,
 	ownerStatement,
 } from "./db-owner-runtime";
 import { EPISODIC_CAPTURED_AT_FLOOR, timestampMillis } from "./episodic-sources";
+import { hasDbAccessor } from "./db-accessor";
 import { logger } from "./logger";
 import { awaitEmbeddingProviderAvailable } from "./embedding-circuit-breaker";
 import {
@@ -31,7 +32,7 @@ import {
 	clearNativeSourceSyncCheckpoint,
 } from "./native-source-sync-state";
 import type { EmbeddingConfig } from "./memory-config";
-import { hashNormalizedBody, indexExternalMemoryArtifact, softDeleteArtifactRowsForPath } from "./memory-lineage";
+import { hashNormalizedBody, softDeleteArtifactRowsForPath } from "./memory-lineage";
 import {
 	type SourceEmbeddingFetch,
 	type ObsidianSourceChunk,
@@ -881,6 +882,7 @@ export async function indexNativeMemoryFile(
 		readonly lineCount?: number;
 		readonly rolloutId?: string;
 		readonly chunks?: readonly ObsidianSourceChunk[];
+		readonly syncCheckpoint?: { readonly sourceKey: string; readonly scanned: number };
 		readonly signal?: AbortSignal;
 	} = {},
 ): Promise<boolean> {
@@ -888,6 +890,10 @@ export async function indexNativeMemoryFile(
 	if (!safeRelativePath(source.root, filePath)) return false;
 	const pattern = matchesPattern(source, filePath);
 	if (!pattern) return false;
+	// Source-worker pages carry the complete descriptor. This fast path is the
+	// production bridge boundary: the parent forwards content/hash/mtime to the
+	// owner and does not perform file reads or preflight indexing queries.
+	const workerDescriptor = options.content !== undefined && options.contentHash !== undefined;
 
 	const key = fingerprintKey(source, filePath, agentId);
 	const cooldownUntil = readFailureBackoffUntil.get(key);
@@ -965,23 +971,27 @@ export async function indexNativeMemoryFile(
 	}
 	readFailureBackoffUntil.delete(key);
 	permissionDeniedPaths.delete(key);
-	if (!content.trim()) {
+	if (!workerDescriptor && !content.trim()) {
 		await removeNativeMemoryFile(source, filePath, agentId);
 		return false;
 	}
 
 	const hash = options.contentHash ?? contentFingerprint(content);
 	let persistedHash: string | null;
-	try {
-		persistedHash = await nativeArtifactContentHash(filePath, agentId, options.signal);
-	} catch (error) {
-		logger.error(
-			"watcher",
-			"Cannot read native memory artifact persistence state",
-			error instanceof Error ? error : new Error(String(error)),
-			{ path: filePath },
-		);
-		return false;
+	if (workerDescriptor) {
+		persistedHash = null;
+	} else {
+		try {
+			persistedHash = await nativeArtifactContentHash(filePath, agentId, options.signal);
+		} catch (error) {
+			logger.error(
+				"watcher",
+				"Cannot read native memory artifact persistence state",
+				error instanceof Error ? error : new Error(String(error)),
+				{ path: filePath },
+			);
+			return false;
+		}
 	}
 	const obsidian = source.harness === "obsidian" && pattern.kind === "source_obsidian_markdown";
 	const hermes = source.harness === "hermes-agent";
@@ -993,7 +1003,7 @@ export async function indexNativeMemoryFile(
 		options.embeddingConfig !== undefined &&
 		options.fetchEmbedding !== undefined;
 	let semanticComplete = true;
-	if (obsidian) {
+	if (obsidian && !workerDescriptor) {
 		const graphExists =
 			!graphRequested || (await obsidianGraphExists(agentId, sourceId ?? "", filePath, options.signal));
 		const embeddingsExist =
@@ -1010,11 +1020,11 @@ export async function indexNativeMemoryFile(
 		semanticComplete = graphExists && embeddingsExist;
 	}
 	const cached = indexed.get(key);
-	if (cached?.contentHash === hash) {
+	if (!workerDescriptor && cached?.contentHash === hash) {
 		if (persistedHash === hash && semanticComplete) return false;
 		indexed.delete(key);
 	}
-	if (persistedHash === hash && semanticComplete) {
+	if (!workerDescriptor && persistedHash === hash && semanticComplete) {
 		// One-shot heal for legacy rows with a corrupt pre-epoch captured_at:
 		// they stay permanently pending otherwise (no watermark can reach
 		// 1980), keeping content passes from ever early-exiting (#1149).
@@ -1027,14 +1037,27 @@ export async function indexNativeMemoryFile(
 	}
 
 	try {
-		const artifactChanged = persistedHash !== hash;
-		if (artifactChanged) {
-			const provenanceRoot = source.sourceRoot ?? source.root;
-			const externalId =
-				obsidian || source.harness === "codex" || hermes ? sourceRelativePath(provenanceRoot, filePath) : null;
-			await indexExternalMemoryArtifact({
+		const provenanceRoot = source.sourceRoot ?? source.root;
+		const externalId =
+			obsidian || source.harness === "codex" || hermes ? sourceRelativePath(provenanceRoot, filePath) : null;
+		const sourceMeta = obsidian
+			? {
+					provider: "obsidian",
+					displayName: source.displayName,
+				}
+			: (codexSourceMeta(source, filePath, {
+					lineCount: options.lineCount ?? sourceLineCount(content),
+					rolloutId: options.rolloutId,
+				}) ??
+				hermesSourceMeta(source, filePath, {
+					lineCount: options.lineCount ?? sourceLineCount(content),
+					contentHash: hash,
+				}));
+		const ownerResult = await dbOwnerSourceNativeMemoryIndex(
+			{
 				agentId,
 				sourcePath: filePath,
+				sourceHash: hash,
 				sourceKind: pattern.kind,
 				harness: source.harness,
 				content,
@@ -1043,23 +1066,28 @@ export async function indexNativeMemoryFile(
 				sourceRoot: obsidian || source.harness === "codex" || hermes ? normalizedRoot(provenanceRoot) : null,
 				sourceExternalId: externalId,
 				sourceParentPath: externalId ? dirname(externalId).replace(/^\.$/, "") : null,
-				sourceMeta: obsidian
+				sourceMetaJson: sourceMeta === undefined ? null : JSON.stringify(sourceMeta),
+				displayName: source.displayName,
+				...(options.syncCheckpoint && !embeddingRequested ? { checkpoint: options.syncCheckpoint } : {}),
+				...(obsidian && sourceId && graphRequested
 					? {
-							provider: "obsidian",
-							displayName: source.displayName,
+							graph: {
+								sourceId,
+								sourceName: source.displayName,
+								root: source.root,
+							},
 						}
-					: (codexSourceMeta(source, filePath, {
-							lineCount: options.lineCount ?? sourceLineCount(content),
-							rolloutId: options.rolloutId,
-						}) ??
-						hermesSourceMeta(source, filePath, {
-							lineCount: options.lineCount ?? sourceLineCount(content),
-							contentHash: hash,
-						})),
+					: {}),
+			},
+			{
+				operation: "sources.native-memory.owner.index",
+				lane: "write",
+				workloadClass: "maintenance",
+				estimatedWorkUnits: Math.max(1, Math.ceil(content.length / 1024)),
 				signal: options.signal,
-			});
-		}
-		let semanticIndexed = false;
+			},
+		);
+		let semanticIndexed = ownerResult.graphIndexed;
 		let embeddingProviderUnavailable = false;
 		if (obsidian && sourceId) {
 			if (options.embeddingConfig && options.fetchEmbedding) {
@@ -1092,39 +1120,16 @@ export async function indexNativeMemoryFile(
 				}
 				semanticIndexed = !embeddingProviderUnavailable;
 			}
-			// A provider outage is source-scoped: persist the artifact, but do not
-			// submit graph work that would amplify every retry before the embedding
-			// gate's source-level backoff expires.
-			if (!embeddingProviderUnavailable && (options.sourceGraphEnabled ?? true)) {
-				await dbOwnerSourceGraphIndex(
-					{
-						agentId,
-						sourceId,
-						sourceName: source.displayName,
-						root: source.root,
-						filePath,
-						content,
-					},
-					{
-						operation: "sources.graph.owner.index",
-						lane: "write",
-						workloadClass: "maintenance",
-						estimatedWorkUnits: 10,
-						signal: options.signal,
-					},
-				);
-				semanticIndexed = true;
-			}
 		}
 		indexed.set(key, { contentHash: hash });
-		if (artifactChanged) {
+		if (ownerResult.artifactChanged) {
 			logger.info("watcher", "Indexed native memory artifact", {
 				harness: source.harness,
 				kind: pattern.kind,
 				path: filePath,
 			});
 		}
-		return artifactChanged || semanticIndexed;
+		return ownerResult.artifactChanged || semanticIndexed;
 	} catch (err) {
 		logger.error(
 			"watcher",
@@ -1337,7 +1342,9 @@ export function startNativeMemoryBridge(
 				let scanned = 0;
 				const key = sourceStateKey(source, agentId);
 				const durableKey = nativeSourceSyncKey(source);
-				const syncState = await readNativeSourceSyncState(agentId, source, signal);
+				const rootExists = await pathExists(source.root, source, agentId);
+				const dbAvailable = hasDbAccessor();
+				const syncState = rootExists && dbAvailable ? await readNativeSourceSyncState(agentId, source, signal) : null;
 				if (sourceNeedsProvider(source, options)) {
 					const provider = await sourceProviderGate(agentId, options, signal);
 					if (!provider.available) {
@@ -1367,13 +1374,14 @@ export function startNativeMemoryBridge(
 				const current = new Set<string>();
 				const resumePath = syncState?.status === "paused" ? syncState.checkpointPath : null;
 				let resumeCheckpointPath = resumePath;
-				const rootExists = await pathExists(source.root, source, agentId);
 				const maxFilesPerScan = options.maxFilesPerScan ?? NATIVE_MEMORY_MAX_FILES_PER_SCAN;
 				let scanComplete = true;
 				let sourcePaused = false;
 				if (rootExists) {
 					const fileDelayMs = sourceFileDelayMs(source, options);
-					const checkpoint = await readNativeSourceSyncCheckpoint(agentId, key, "content", signal);
+					const checkpoint = dbAvailable
+						? await readNativeSourceSyncCheckpoint(agentId, key, "content", signal)
+						: { cursor: null, frontier: null, complete: true };
 					let cursor = checkpoint.complete ? null : checkpoint.cursor;
 					let frontier = checkpoint.complete ? null : checkpoint.frontier;
 					let pageComplete = false;
@@ -1384,18 +1392,23 @@ export function startNativeMemoryBridge(
 							frontier,
 							pageSize: Math.min(100, maxFilesPerScan - scanned),
 						});
+						for (const path of page.permissionDeniedPaths) {
+							recordNativeMemoryPermissionDenied(source, path, agentId);
+						}
 						if (cancelRequested) throw new Error("native source sync cancelled");
 						if (page.files.length === 0 && page.complete) {
 							pageComplete = true;
 							cursor = null;
-							await writeNativeSourceSyncCheckpoint(
-								agentId,
-								key,
-								"content",
-								{ cursor: null, frontier: null, complete: true },
-								scanned,
-								signal,
-							);
+							if (dbAvailable) {
+								await writeNativeSourceSyncCheckpoint(
+									agentId,
+									key,
+									"content",
+									{ cursor: null, frontier: null, complete: true },
+									scanned,
+									signal,
+								);
+							}
 							break;
 						}
 						for (const file of page.files) {
@@ -1416,6 +1429,7 @@ export function startNativeMemoryBridge(
 								contentHash: file.contentHash,
 								lineCount: file.lineCount,
 								rolloutId: file.rolloutId,
+								syncCheckpoint: { sourceKey: key, scanned },
 								onEmbeddingStatus: (status) => {
 									embeddingStatus = status;
 									options.onEmbeddingStatus?.(status);
@@ -1448,6 +1462,16 @@ export function startNativeMemoryBridge(
 								});
 								break;
 							}
+							if (dbAvailable && sourceNeedsProvider(source, options)) {
+								await writeNativeSourceSyncCheckpoint(
+									agentId,
+									key,
+									"content",
+									{ cursor: file.path.replace(/\\/g, "/"), frontier: null, complete: false },
+									scanned,
+									signal,
+								);
+							}
 							resumeCheckpointPath = file.path.replace(/\\/g, "/");
 							await yielder();
 							await sleep(fileDelayMs);
@@ -1456,18 +1480,20 @@ export function startNativeMemoryBridge(
 						cursor = page.nextCursor;
 						frontier = page.frontier;
 						pageComplete = page.complete;
-						await writeNativeSourceSyncCheckpoint(
-							agentId,
-							key,
-							"content",
-							{
-								cursor: pageComplete ? null : cursor,
-								frontier: pageComplete ? null : frontier,
-								complete: pageComplete,
-							},
-							scanned,
-							signal,
-						);
+						if (dbAvailable) {
+							await writeNativeSourceSyncCheckpoint(
+								agentId,
+								key,
+								"content",
+								{
+									cursor: pageComplete ? null : cursor,
+									frontier: pageComplete ? null : frontier,
+									complete: pageComplete,
+								},
+								scanned,
+								signal,
+							);
+						}
 					}
 					scanComplete = pageComplete;
 					if (!pageComplete && scanned >= maxFilesPerScan) {
@@ -1504,7 +1530,10 @@ export function startNativeMemoryBridge(
 						resumeFrontier: null,
 					};
 				}
-				const cleanupAllowed = sourceCleanupEnabledFor(source, options) && (!rootExists || scanComplete);
+				const cleanupAllowed =
+					sourceCleanupEnabledFor(source, options) &&
+					(!rootExists || scanComplete) &&
+					nativeMemorySourcePermissionHealth(source, agentId).status !== "denied";
 				if (cleanupAllowed) {
 					const currentPaths = new Set([...current].map((file) => file.replace(/\\/g, "/")));
 					for (const file of await activeNativeArtifactPaths(source, agentId, signal)) {

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -111,6 +111,8 @@ export interface NativeMemoryBridgeOptions {
 	readonly sourceGraphEnabled?: boolean;
 	/** Test and bounded-scan override. Production scans use the 50,000-file cap. */
 	readonly maxFilesPerScan?: number;
+	/** Production native scans route descriptors through the killable DB owner. */
+	readonly workerOwnedIndexing?: boolean;
 	readonly shouldContinue?: (source: NativeMemorySource) => boolean;
 	readonly onEmbeddingStatus?: (status: string | undefined) => void;
 	readonly onFileIndexed?: (event: NativeMemoryFileIndexEvent) => void;
@@ -882,6 +884,7 @@ export async function indexNativeMemoryFile(
 		readonly lineCount?: number;
 		readonly rolloutId?: string;
 		readonly chunks?: readonly ObsidianSourceChunk[];
+		readonly workerOwnedIndexing?: boolean;
 		readonly syncCheckpoint?: {
 			readonly sourceKey: string;
 			readonly scanned: number;
@@ -1074,7 +1077,10 @@ export async function indexNativeMemoryFile(
 				sourceParentPath: externalId ? dirname(externalId).replace(/^\.$/, "") : null,
 				sourceMetaJson: sourceMeta === undefined ? null : JSON.stringify(sourceMeta),
 				displayName: source.displayName,
-				...(options.syncCheckpoint && !embeddingRequested ? { checkpoint: options.syncCheckpoint } : {}),
+				...(options.syncCheckpoint ? { checkpoint: options.syncCheckpoint } : {}),
+				...(options.workerOwnedIndexing && obsidian && sourceId && options.embeddingConfig && options.chunks
+					? { embedding: { config: options.embeddingConfig, chunks: options.chunks } }
+					: {}),
 				...(obsidian && sourceId && graphRequested
 					? {
 							graph: {
@@ -1094,8 +1100,10 @@ export async function indexNativeMemoryFile(
 			},
 		);
 		let semanticIndexed = ownerResult.graphIndexed;
-		let embeddingProviderUnavailable = false;
-		if (obsidian && sourceId) {
+		let embeddingProviderUnavailable = ownerResult.embeddingProviderUnavailable;
+		if (options.workerOwnedIndexing && embeddingProviderUnavailable)
+			options.onEmbeddingStatus?.("embeddings pending - provider down");
+		if (obsidian && sourceId && !options.workerOwnedIndexing) {
 			if (options.embeddingConfig && options.fetchEmbedding) {
 				const embeddingResult = await indexObsidianSourceEmbeddingsViaOwner({
 					agentId,
@@ -1351,7 +1359,7 @@ export function startNativeMemoryBridge(
 				const rootExists = await pathExists(source.root, source, agentId);
 				const dbAvailable = hasDbAccessor();
 				const syncState = rootExists && dbAvailable ? await readNativeSourceSyncState(agentId, source, signal) : null;
-				if (sourceNeedsProvider(source, options)) {
+				if (sourceNeedsProvider(source, options) && !options.workerOwnedIndexing) {
 					const provider = await sourceProviderGate(agentId, options, signal);
 					if (!provider.available) {
 						await persistNativeSourceSyncState({
@@ -1479,16 +1487,6 @@ export function startNativeMemoryBridge(
 									signal,
 								});
 								break;
-							}
-							if (dbAvailable && sourceNeedsProvider(source, options)) {
-								await writeNativeSourceSyncCheckpoint(
-									agentId,
-									key,
-									"content",
-									{ cursor: file.path.replace(/\\/g, "/"), frontier: null, complete: false },
-									scanned,
-									signal,
-								);
 							}
 							resumeCheckpointPath = file.path.replace(/\\/g, "/");
 							await yielder();

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { lstat, readFile, stat } from "node:fs/promises";
 
 import { homedir } from "node:os";
@@ -113,6 +112,8 @@ export interface NativeMemoryBridgeOptions {
 	readonly maxFilesPerScan?: number;
 	/** Production native scans route descriptors through the killable DB owner. */
 	readonly workerOwnedIndexing?: boolean;
+	/** Test-only event hook used to kill a source worker during traversal. */
+	readonly onSourceWorkerScanStarted?: () => void;
 	readonly shouldContinue?: (source: NativeMemorySource) => boolean;
 	readonly onEmbeddingStatus?: (status: string | undefined) => void;
 	readonly onFileIndexed?: (event: NativeMemoryFileIndexEvent) => void;
@@ -308,7 +309,11 @@ function claudeCodeRoot(): string {
 }
 
 function sourceIdForCodexRoot(root: string): string {
-	return `codex_native_memory:${createHash("sha256").update(normalizedRoot(root)).digest("hex").slice(0, 16)}`;
+	return `codex_native_memory:${normalizedRoot(root)}`;
+}
+
+function sourceIdForHermesRoot(root: string): string {
+	return `hermes_native_memory:${normalizedRoot(root)}`;
 }
 
 function hermesProfileRoot(root: string): string {
@@ -325,10 +330,6 @@ function hermesProfileId(root: string): string {
 		if (profile.length > 0 && !profile.includes("/")) return profile;
 	}
 	return basename(normalized) === ".hermes" ? "default" : basename(normalized);
-}
-
-function sourceIdForHermesRoot(root: string): string {
-	return `hermes_native_memory:${createHash("sha256").update(normalizedRoot(root)).digest("hex").slice(0, 16)}`;
 }
 
 export function codexNativeMemorySource(root = codexRoot()): NativeMemorySource {
@@ -743,6 +744,7 @@ async function obsidianEmbeddingsExist(input: {
 function workerSource(source: NativeMemorySource): NativeSourceWorkerSource {
 	return {
 		root: source.root,
+		sourceRoot: source.sourceRoot,
 		harness: source.harness,
 		sourceId: source.sourceId,
 		files: source.files.map((pattern) => ({
@@ -884,6 +886,7 @@ export async function indexNativeMemoryFile(
 		readonly lineCount?: number;
 		readonly rolloutId?: string;
 		readonly chunks?: readonly ObsidianSourceChunk[];
+		readonly sourceId?: string;
 		readonly workerOwnedIndexing?: boolean;
 		readonly syncCheckpoint?: {
 			readonly sourceKey: string;
@@ -1004,7 +1007,9 @@ export async function indexNativeMemoryFile(
 	}
 	const obsidian = source.harness === "obsidian" && pattern.kind === "source_obsidian_markdown";
 	const hermes = source.harness === "hermes-agent";
-	const sourceId = obsidian ? (source.sourceId ?? sourceIdForObsidianRoot(source.root)) : (source.sourceId ?? null);
+	const sourceId = obsidian
+		? (options.sourceId ?? source.sourceId ?? sourceIdForObsidianRoot(source.root))
+		: (options.sourceId ?? source.sourceId ?? null);
 	const graphRequested = obsidian && (options.sourceGraphEnabled ?? true);
 	const embeddingRequested =
 		obsidian &&
@@ -1077,7 +1082,9 @@ export async function indexNativeMemoryFile(
 				sourceParentPath: externalId ? dirname(externalId).replace(/^\.$/, "") : null,
 				sourceMetaJson: sourceMeta === undefined ? null : JSON.stringify(sourceMeta),
 				displayName: source.displayName,
-				...(options.syncCheckpoint ? { checkpoint: options.syncCheckpoint } : {}),
+				...(options.syncCheckpoint && !(workerDescriptor && embeddingRequested && !options.workerOwnedIndexing)
+					? { checkpoint: options.syncCheckpoint }
+					: {}),
 				...(options.workerOwnedIndexing && obsidian && sourceId && options.embeddingConfig && options.chunks
 					? { embedding: { config: options.embeddingConfig, chunks: options.chunks } }
 					: {}),
@@ -1112,6 +1119,7 @@ export async function indexNativeMemoryFile(
 					filePath,
 					content,
 					chunks: options.chunks,
+					checkpoint: options.syncCheckpoint,
 					embeddingConfig: options.embeddingConfig,
 					fetchEmbedding: options.fetchEmbedding,
 					signal: options.signal,
@@ -1314,7 +1322,9 @@ export function startNativeMemoryBridge(
 ): NativeMemoryBridgeHandle {
 	const agentId = resolveBridgeAgentId(options.agentId);
 	const known = new Map<string, Set<string>>();
-	const sourceWorker = createNativeSourceWorker();
+	const sourceWorker = createNativeSourceWorker({
+		onScanStarted: () => options.onSourceWorkerScanStarted?.(),
+	});
 	let cancelRequested = false;
 	let lastSyncResult: NativeMemorySyncResult = { status: "complete", scanned: 0, indexed: 0, pausedSources: [] };
 
@@ -1425,6 +1435,7 @@ export function startNativeMemoryBridge(
 							}
 							break;
 						}
+						const pageScannedBefore = scanned;
 						for (const [fileIndex, file] of page.files.entries()) {
 							if (cancelRequested) throw new Error("native source sync cancelled");
 							if (resumePath && file.path.replace(/\\/g, "/") <= resumePath.replace(/\\/g, "/")) {
@@ -1441,6 +1452,7 @@ export function startNativeMemoryBridge(
 								chunks: file.chunks,
 								mtimeMs: file.mtimeMs,
 								contentHash: file.contentHash,
+								sourceId: file.sourceId,
 								lineCount: file.lineCount,
 								rolloutId: file.rolloutId,
 								syncCheckpoint: {
@@ -1496,7 +1508,7 @@ export function startNativeMemoryBridge(
 						cursor = page.nextCursor;
 						frontier = page.frontier;
 						pageComplete = page.complete;
-						if (dbAvailable) {
+						if (dbAvailable && scanned === pageScannedBefore) {
 							await writeNativeSourceSyncCheckpoint(
 								agentId,
 								key,

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -895,6 +895,7 @@ export async function indexNativeMemoryFile(
 			readonly frontier: readonly string[] | null;
 			readonly complete: boolean;
 		};
+		readonly syncCheckpointOnProviderFailure?: NativeSourceSyncCheckpoint;
 		readonly signal?: AbortSignal;
 	} = {},
 ): Promise<boolean> {
@@ -1084,6 +1085,17 @@ export async function indexNativeMemoryFile(
 				displayName: source.displayName,
 				...(options.syncCheckpoint && !(workerDescriptor && embeddingRequested && !options.workerOwnedIndexing)
 					? { checkpoint: options.syncCheckpoint }
+					: {}),
+				...(options.syncCheckpoint && options.syncCheckpointOnProviderFailure && options.workerOwnedIndexing
+					? {
+							checkpointOnProviderFailure: {
+								sourceKey: options.syncCheckpoint.sourceKey,
+								scanned: options.syncCheckpoint.scanned,
+								cursor: options.syncCheckpointOnProviderFailure.cursor,
+								frontier: options.syncCheckpointOnProviderFailure.frontier,
+								complete: options.syncCheckpointOnProviderFailure.complete,
+							},
+						}
 					: {}),
 				...(options.workerOwnedIndexing && obsidian && sourceId && options.embeddingConfig && options.chunks
 					? { embedding: { config: options.embeddingConfig, chunks: options.chunks } }
@@ -1445,6 +1457,17 @@ export function startNativeMemoryBridge(
 							if (scanned >= maxFilesPerScan) break;
 							scanned++;
 							let embeddingStatus: string | undefined;
+							const retryCheckpoint: NativeSourceSyncCheckpoint = {
+								cursor,
+								frontier: [
+									...page.frontier,
+									...page.files
+										.slice(fileIndex)
+										.map((next) => next.path)
+										.reverse(),
+								],
+								complete: false,
+							};
 							const changed = await indexNativeMemoryFile(source, file.path, agentId, {
 								...options,
 								signal,
@@ -1468,6 +1491,7 @@ export function startNativeMemoryBridge(
 									],
 									complete: page.complete && fileIndex === page.files.length - 1,
 								},
+								syncCheckpointOnProviderFailure: retryCheckpoint,
 								onEmbeddingStatus: (status) => {
 									embeddingStatus = status;
 									options.onEmbeddingStatus?.(status);
@@ -1490,11 +1514,21 @@ export function startNativeMemoryBridge(
 							if (embeddingStatus === "embeddings pending - provider down") {
 								sourcePaused = true;
 								scanComplete = false;
+								if (dbAvailable && !options.workerOwnedIndexing) {
+									await writeNativeSourceSyncCheckpoint(
+										agentId,
+										key,
+										"content",
+										retryCheckpoint,
+										Math.max(0, scanned - 1),
+										signal,
+									);
+								}
 								await persistNativeSourceSyncState({
 									agentId,
 									source,
 									status: "paused",
-									checkpointPath: resumeCheckpointPath ?? file.path,
+									...(resumeCheckpointPath === null ? {} : { checkpointPath: resumeCheckpointPath }),
 									pauseReason: "provider_unavailable",
 									signal,
 								});

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -882,7 +882,13 @@ export async function indexNativeMemoryFile(
 		readonly lineCount?: number;
 		readonly rolloutId?: string;
 		readonly chunks?: readonly ObsidianSourceChunk[];
-		readonly syncCheckpoint?: { readonly sourceKey: string; readonly scanned: number };
+		readonly syncCheckpoint?: {
+			readonly sourceKey: string;
+			readonly scanned: number;
+			readonly cursor: string | null;
+			readonly frontier: readonly string[] | null;
+			readonly complete: boolean;
+		};
 		readonly signal?: AbortSignal;
 	} = {},
 ): Promise<boolean> {
@@ -1411,7 +1417,7 @@ export function startNativeMemoryBridge(
 							}
 							break;
 						}
-						for (const file of page.files) {
+						for (const [fileIndex, file] of page.files.entries()) {
 							if (cancelRequested) throw new Error("native source sync cancelled");
 							if (resumePath && file.path.replace(/\\/g, "/") <= resumePath.replace(/\\/g, "/")) {
 								current.add(file.path);
@@ -1429,7 +1435,19 @@ export function startNativeMemoryBridge(
 								contentHash: file.contentHash,
 								lineCount: file.lineCount,
 								rolloutId: file.rolloutId,
-								syncCheckpoint: { sourceKey: key, scanned },
+								syncCheckpoint: {
+									sourceKey: key,
+									scanned,
+									cursor: file.path.replace(/\\/g, "/"),
+									frontier: [
+										...page.frontier,
+										...page.files
+											.slice(fileIndex + 1)
+											.map((next) => next.path)
+											.reverse(),
+									],
+									complete: page.complete && fileIndex === page.files.length - 1,
+								},
 								onEmbeddingStatus: (status) => {
 									embeddingStatus = status;
 									options.onEmbeddingStatus?.(status);

--- a/platform/daemon/src/obsidian-source-embeddings.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.ts
@@ -56,6 +56,13 @@ export interface IndexObsidianSourceEmbeddingsInput {
 	readonly chunks?: readonly ObsidianSourceChunk[];
 	readonly embeddingConfig: EmbeddingConfig;
 	readonly fetchEmbedding: SourceEmbeddingFetch;
+	readonly checkpoint?: {
+		readonly sourceKey: string;
+		readonly scanned: number;
+		readonly cursor: string | null;
+		readonly frontier: readonly string[] | null;
+		readonly complete: boolean;
+	};
 	readonly signal?: AbortSignal;
 }
 
@@ -439,12 +446,37 @@ export async function indexObsidianSourceEmbeddingsViaOwner(
 		const staleIds = stale
 			.filter((row) => row.source_type === LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE || !currentHashes.has(row.content_hash))
 			.map((row) => row.id);
-		if (staleIds.length > 0) {
+		const checkpointStatement =
+			input.checkpoint === undefined
+				? null
+				: ownerStatement(
+						`INSERT INTO source_sync_checkpoints
+						 (agent_id, source_key, phase, cursor, frontier, scanned, complete, updated_at)
+						 VALUES (?, ?, 'content', ?, ?, ?, ?, datetime('now'))
+						 ON CONFLICT(agent_id, source_key, phase) DO UPDATE SET
+						 cursor = excluded.cursor,
+						 frontier = excluded.frontier,
+						 scanned = excluded.scanned,
+						 complete = excluded.complete,
+						 updated_at = excluded.updated_at`,
+						[
+							input.agentId,
+							input.checkpoint.sourceKey,
+							input.checkpoint.cursor,
+							input.checkpoint.frontier === null ? null : JSON.stringify(input.checkpoint.frontier),
+							input.checkpoint.scanned,
+							input.checkpoint.complete ? 1 : 0,
+						],
+					);
+		if (staleIds.length > 0 || checkpointStatement !== null) {
 			const statements = [
 				...(vecAvailable
 					? [ownerStatement(`DELETE FROM vec_embeddings WHERE id IN (${staleIds.map(() => "?").join(", ")})`, staleIds)]
 					: []),
-				ownerStatement(`DELETE FROM embeddings WHERE id IN (${staleIds.map(() => "?").join(", ")})`, staleIds),
+				...(staleIds.length > 0
+					? [ownerStatement(`DELETE FROM embeddings WHERE id IN (${staleIds.map(() => "?").join(", ")})`, staleIds)]
+					: []),
+				...(checkpointStatement === null ? [] : [checkpointStatement]),
 			];
 			await dbOwnerBatch(statements, {
 				operation: "sources.embeddings.owner.stale.delete",
@@ -596,7 +628,7 @@ export async function indexObsidianSourceEmbeddings(
 	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
 	const embeddingConfig = getDbAccessor().withReadDb(
 		(db: import("./db-accessor").ReadDb) => resolveActiveEmbeddingConfig(db, input.embeddingConfig),
-		"obsidian-source-embeddings.ts:597",
+		"obsidian-source-embeddings.ts:629",
 	);
 	if (embeddingConfig.provider === "none") return { chunks: 0, embedded: 0, skipped: 0, providerUnavailable: false };
 	const chunks = buildObsidianSourceChunks(input);
@@ -638,7 +670,7 @@ export async function indexObsidianSourceEmbeddings(
 						sourceId: existingChunk.id,
 						content: chunk.chunkText,
 					}),
-				"obsidian-source-embeddings.ts:633",
+				"obsidian-source-embeddings.ts:665",
 			);
 			skipped++;
 			await yielder();
@@ -648,7 +680,7 @@ export async function indexObsidianSourceEmbeddings(
 		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
 		const writeConfig = getDbAccessor().withReadDb(
 			(db: import("./db-accessor").ReadDb) => resolveActiveEmbeddingConfig(db, input.embeddingConfig),
-			"obsidian-source-embeddings.ts:649",
+			"obsidian-source-embeddings.ts:681",
 		);
 		let failureCause: PipelineCauseFamily = "provider_unavailable";
 		const vector = await input.fetchEmbedding(chunk.chunkText, writeConfig, "document", {
@@ -727,7 +759,7 @@ export async function indexObsidianSourceEmbeddings(
 				| undefined;
 			syncVecInsert(db, stored?.id ?? embId, vector);
 			return true;
-		}, "obsidian-source-embeddings.ts:683");
+		}, "obsidian-source-embeddings.ts:715");
 		if (!stored) {
 			skipped++;
 			await yielder();
@@ -765,7 +797,7 @@ export async function indexObsidianSourceEmbeddings(
 				const stmt = db.prepare("DELETE FROM embeddings WHERE id = ?");
 				for (const id of staleIds) stmt.run(id);
 			}
-		}, "obsidian-source-embeddings.ts:744");
+		}, "obsidian-source-embeddings.ts:776");
 
 	return {
 		chunks: chunks.length,
@@ -794,7 +826,7 @@ function existingChunkEmbedding(agentId: string, chunkId: string): { id: string;
 					"SELECT id, content_hash FROM embeddings WHERE source_type IN (?, ?) AND source_id = ? AND agent_id = ? LIMIT 1",
 				)
 				.get(SOURCE_CHUNK_SOURCE_TYPE, LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE, chunkId, agentId),
-		"obsidian-source-embeddings.ts:790",
+		"obsidian-source-embeddings.ts:822",
 	) as { id: string; content_hash: string } | undefined;
 	return row ?? null;
 }
@@ -835,7 +867,7 @@ function purgeEmbeddingsBySourceIdPrefix(prefix: string, agentId?: string): numb
 			changes += result.changes;
 		}
 		return changes;
-	}, "obsidian-source-embeddings.ts:813");
+	}, "obsidian-source-embeddings.ts:845");
 }
 
 function prefixUpperBound(prefix: string): string {

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -662,56 +662,56 @@
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 114,
+      "line": 118,
       "api": "readFileSync",
       "source": "return readFileSync(cancellationRegistryPath, \"utf8\").includes(`${jobId}\\n`);",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 139,
+      "line": 143,
       "api": "writeFileSync",
       "source": "writeFileSync(startupStarted, \"started\\n\");",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 141,
+      "line": 145,
       "api": "existsSync",
       "source": "while (!existsSync(startupRelease)) Atomics.wait(signal, 0, 0, 5);",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 147,
+      "line": 151,
       "api": "existsSync",
       "source": "if (sqlitePath !== undefined && existsSync(sqlitePath) && typeof Database.setCustomSQLite === \"function\") {",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 176,
+      "line": 180,
       "api": "writeFileSync",
       "source": "if (commitMarker !== undefined) writeFileSync(commitMarker, \"started\\n\");",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 590,
+      "line": 718,
       "api": "writeFileSync",
       "source": "writeFileSync(startedMarker, \"started\\n\");",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 591,
+      "line": 719,
       "api": "existsSync",
       "source": "while (!existsSync(releaseMarker)) await new Promise((resolve) => setTimeout(resolve, 5));",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 625,
+      "line": 753,
       "api": "writeFileSync",
       "source": "if (activeFile) writeFileSync(activeFile, `${Date.now()}\\n`);",
       "category": "hot-path"

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -697,21 +697,21 @@
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 583,
+      "line": 590,
       "api": "writeFileSync",
       "source": "writeFileSync(startedMarker, \"started\\n\");",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 584,
+      "line": 591,
       "api": "existsSync",
       "source": "while (!existsSync(releaseMarker)) await new Promise((resolve) => setTimeout(resolve, 5));",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 618,
+      "line": 625,
       "api": "writeFileSync",
       "source": "if (activeFile) writeFileSync(activeFile, `${Date.now()}\\n`);",
       "category": "hot-path"
@@ -1642,7 +1642,7 @@
     },
     {
       "path": "native-memory-source-worker.ts",
-      "line": 226,
+      "line": 236,
       "api": "existsSync",
       "source": "return [existsSync(bundled) ? bundled : join(directory, \"native-memory-source-worker.ts\")];",
       "category": "hot-path"

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -1642,7 +1642,7 @@
     },
     {
       "path": "native-memory-source-worker.ts",
-      "line": 236,
+      "line": 281,
       "api": "existsSync",
       "source": "return [existsSync(bundled) ? bundled : join(directory, \"native-memory-source-worker.ts\")];",
       "category": "hot-path"
@@ -1796,49 +1796,49 @@
     },
     {
       "path": "obsidian-source-embeddings.ts",
-      "line": 597,
+      "line": 629,
       "api": "withReadDb",
       "source": "const embeddingConfig = getDbAccessor().withReadDb(",
       "category": "hot-path"
     },
     {
       "path": "obsidian-source-embeddings.ts",
-      "line": 633,
+      "line": 665,
       "api": "withWriteTx",
       "source": "getDbAccessor().withWriteTx(",
       "category": "hot-path"
     },
     {
       "path": "obsidian-source-embeddings.ts",
-      "line": 649,
+      "line": 681,
       "api": "withReadDb",
       "source": "const writeConfig = getDbAccessor().withReadDb(",
       "category": "hot-path"
     },
     {
       "path": "obsidian-source-embeddings.ts",
-      "line": 683,
+      "line": 715,
       "api": "withWriteTx",
       "source": "const stored = getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
       "path": "obsidian-source-embeddings.ts",
-      "line": 744,
+      "line": 776,
       "api": "withWriteTx",
       "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
       "path": "obsidian-source-embeddings.ts",
-      "line": 790,
+      "line": 822,
       "api": "withReadDb",
       "source": "const row = getDbAccessor().withReadDb(",
       "category": "hot-path"
     },
     {
       "path": "obsidian-source-embeddings.ts",
-      "line": 813,
+      "line": 845,
       "api": "withWriteTx",
       "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -697,21 +697,21 @@
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 718,
+      "line": 721,
       "api": "writeFileSync",
       "source": "writeFileSync(startedMarker, \"started\\n\");",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 719,
+      "line": 722,
       "api": "existsSync",
       "source": "while (!existsSync(releaseMarker)) await new Promise((resolve) => setTimeout(resolve, 5));",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 753,
+      "line": 756,
       "api": "writeFileSync",
       "source": "if (activeFile) writeFileSync(activeFile, `${Date.now()}\\n`);",
       "category": "hot-path"
@@ -1642,7 +1642,7 @@
     },
     {
       "path": "native-memory-source-worker.ts",
-      "line": 281,
+      "line": 306,
       "api": "existsSync",
       "source": "return [existsSync(bundled) ? bundled : join(directory, \"native-memory-source-worker.ts\")];",
       "category": "hot-path"

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -662,56 +662,56 @@
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 112,
+      "line": 114,
       "api": "readFileSync",
       "source": "return readFileSync(cancellationRegistryPath, \"utf8\").includes(`${jobId}\\n`);",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 137,
+      "line": 139,
       "api": "writeFileSync",
       "source": "writeFileSync(startupStarted, \"started\\n\");",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 139,
+      "line": 141,
       "api": "existsSync",
       "source": "while (!existsSync(startupRelease)) Atomics.wait(signal, 0, 0, 5);",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 145,
+      "line": 147,
       "api": "existsSync",
       "source": "if (sqlitePath !== undefined && existsSync(sqlitePath) && typeof Database.setCustomSQLite === \"function\") {",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 174,
+      "line": 176,
       "api": "writeFileSync",
       "source": "if (commitMarker !== undefined) writeFileSync(commitMarker, \"started\\n\");",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 496,
+      "line": 583,
       "api": "writeFileSync",
       "source": "writeFileSync(startedMarker, \"started\\n\");",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 497,
+      "line": 584,
       "api": "existsSync",
       "source": "while (!existsSync(releaseMarker)) await new Promise((resolve) => setTimeout(resolve, 5));",
       "category": "hot-path"
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 530,
+      "line": 618,
       "api": "writeFileSync",
       "source": "if (activeFile) writeFileSync(activeFile, `${Date.now()}\\n`);",
       "category": "hot-path"
@@ -1642,7 +1642,7 @@
     },
     {
       "path": "native-memory-source-worker.ts",
-      "line": 225,
+      "line": 226,
       "api": "existsSync",
       "source": "return [existsSync(bundled) ? bundled : join(directory, \"native-memory-source-worker.ts\")];",
       "category": "hot-path"


### PR DESCRIPTION
## Summary

Move native-memory source-file reads, hashing, normalization, artifact upserts, Obsidian graph projection, and provider-enabled embedding work off the daemon parent path. Source workers now send bounded complete descriptors to the database owner, which commits artifact, graph, embedding, and resumable checkpoint state without a provider crash-window gap.

## Changes

- Added a `source_native_memory_index` DB-owner request and transaction boundary for native artifact and optional Obsidian graph indexing.
- Kept source discovery, content hashing, line metadata, empty-content filtering, and Obsidian chunk preparation in the isolated source worker.
- Persisted the actual per-file worker traversal frontier, cursor, and completion state with the owner transaction; processed worker descriptors no longer rely on a later parent-side checkpoint write.
- Selected a provider-failure retry frontier inside the DB-owner transaction, so a provider failure after earlier chunks leaves the current descriptor pending atomically with artifact/embedding state; the parent-provider path persists the same pending frontier before pausing.
- Preserved permission diagnostics by returning permission-denied paths from the source worker to the parent health tracker.
- Removed parent-side `createHash` source-ID work; Codex and Hermes production source IDs are hash-free parent values, while the isolated worker derives a fallback ID when a descriptor has no supplied source ID.
- Added a 4,194,304-byte UTF-8 JSON IPC bound on commands, pages, and worker events. Pages split before the bound, oversized single descriptors fail explicitly, and parent writes await `drain` with stream error/close propagation.
- Added deterministic kill/resume regressions for traversal and provider-enabled traversal, plus a 200-file attribution regression that rejects parent reads/stats/hash calls.
- Regenerated the sanctioned event-loop contract baseline without adding sync sites.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: none

## Screenshots

N/A: no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — N/A: no spec or dependency contract changed.
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints — N/A: no admin or mutation endpoints were added or changed.
- [x] Docs updated for API/spec/status changes — N/A: internal daemon checkpoint/IPC protocol only; no public API, spec, or status contract changed.
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally for the changed package and focused suites

## Migration Notes (if applicable)

N/A: no migrations touched.

## Testing

- [ ] `bun test` passes — root full gate is blocked before tests by the missing optional `platform/core/node_modules/better-sqlite3` artifact.
- [ ] `bun run typecheck` passes — root typecheck is blocked by the pre-existing `@signet/connector-opencode` missing `src/plugin-bundle.js`; daemon typecheck passes.
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A for the unavailable full-gate items below

Focused verification:

- `bun run --filter '@signet/core' build` passed.
- `bun run --filter '@signet/daemon' build` passed, including daemon `tsc --noEmit`.
- `bun test platform/daemon/src/native-memory-sources.test.ts` passed: 66 tests, including traversal-kill, provider-enabled frontier, owner-embedding, 200-file attribution, and provider-failed mid-descriptor restart regressions.
- `bun test platform/daemon/src/native-memory-source-worker.test.ts` passed: 9 tests, including delayed drain, stream error/close propagation, fallback source-ID derivation, and the 4,194,304-byte IPC bound.
- `bun test scripts/audit-event-loop-contract.test.ts` passed: 21 tests.
- `bun scripts/audit-event-loop-contract.ts` passed: 706 inventory entries, 198 legacy markers, ratchet held.
- `bunx biome check --write` passed for all six changed files.
- Adapted `/tmp/t_09104c1a-embedding-frontier.test.ts` passed: provider-enabled worker kill resumes the next descriptor.
- Mutation verification: removing atomic provider-failure checkpoint selection made the production-path restart regression fail because the current descriptor was checkpointed as completed; removing the awaited command write made the delayed-drain regression fail because the scan completed early.

The canonical root full gate could not start its test suites because `platform/core/node_modules/better-sqlite3` is missing. Root typecheck also reports the unchanged `@signet/connector-opencode` missing generated `src/plugin-bundle.js`; the changed daemon package typecheck and build pass. No unavailable full-gate result is represented as green.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Branch `w36a-native-index` was reset to the verified live PR head before repair and pushed without force. In production mode, the parent forwards only source-worker descriptors and owner results: file acquisition, hashing, normalization, artifact persistence, graph projection, embedding work, and resumable source traversal state do not run through the parent indexing path. The worker IPC payload bound is 4,194,304 UTF-8 JSON bytes.