### PR TITLE
fix(daemon): remove secondary sync paths

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,15 +4,15 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 706 sites
-- Synchronous `withWriteTx()` sites: 78
-- Synchronous `withReadDb()` sites: 120
-- Synchronous filesystem/process sites: 508
-- Compile-visible legacy DB sites remaining: 198
-  - `withWriteTx`: 78
-  - `withReadDb`: 120
+- Exact ledger inventory: 683 sites
+- Synchronous `withWriteTx()` sites: 73
+- Synchronous `withReadDb()` sites: 115
+- Synchronous filesystem/process sites: 495
+- Compile-visible legacy DB sites remaining: 188
+  - `withWriteTx`: 73
+  - `withReadDb`: 115
 
-The 706-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call. The 78 synchronous writes and 120 synchronous reads are the complete database-call inventory; 198 compatibility DB operations remain transitional callers for the later migration phase. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 683-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call. The 73 synchronous writes and 115 synchronous reads are the complete database-call inventory; 188 compatibility DB operations remain transitional callers for the later migration phase. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## A3 Slice 2 migration notes
 
@@ -29,4 +29,4 @@ The converted async sites are distributed as follows: document-worker (18), drea
 
 The structural boundary makes statically-resolved imports from the production source tree impossible: TypeScript reports TS6059 before aliases or computed member calls can use the compatibility type. The production bundle also only starts from source entrypoints, so this compatibility module is not a shipped production artifact.
 
-A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 198 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 78 write and 120 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.
+A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 188 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 73 write and 115 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.

--- a/platform/daemon/src/cross-agent.test.ts
+++ b/platform/daemon/src/cross-agent.test.ts
@@ -320,7 +320,7 @@ describe("cross-agent messages", () => {
 });
 
 describe("ACP delivery reconciliation", () => {
-	it("marks a committed ACP row indeterminate if the process dies before claiming it", () => {
+	it("marks a committed ACP row indeterminate if the process dies before claiming it", async () => {
 		const message = createAgentMessage({
 			fromAgentId: "alpha",
 			content: "queued before crash",
@@ -330,13 +330,13 @@ describe("ACP delivery reconciliation", () => {
 			acpTargetAgentName: "helper",
 		});
 
-		expect(reconcileAcpDeliveries(undefined, Date.parse(message.createdAt) + 31_000)).toBe(1);
+		expect(await reconcileAcpDeliveries(undefined, Date.parse(message.createdAt) + 31_000)).toBe(1);
 		const recovered = listAgentMessages({ agentId: "alpha", includeSent: true })[0];
 		expect(recovered?.deliveryState).toBe("indeterminate");
 		expect(recovered?.deliveryError).toBe("ACP relay was queued but never started");
 	});
 
-	it("uses a lease so a second daemon cannot reconcile an active relay", () => {
+	it("uses a lease so a second daemon cannot reconcile an active relay", async () => {
 		const message = createAgentMessage({
 			fromAgentId: "alpha",
 			content: "lease me",
@@ -346,7 +346,7 @@ describe("ACP delivery reconciliation", () => {
 			acpTargetAgentName: "helper",
 		});
 		const first = claimAcpMessageDelivery({ messageId: message.id, agentId: "alpha", nowMs: 1_000 });
-		expect(() => reconcileAcpDeliveries(undefined, 80_000)).not.toThrow();
+		expect(await reconcileAcpDeliveries(undefined, 80_000)).toBe(0);
 		expect(() => claimAcpMessageDelivery({ messageId: message.id, agentId: "alpha", nowMs: 20_000 })).toThrow(
 			"already active",
 		);
@@ -356,7 +356,7 @@ describe("ACP delivery reconciliation", () => {
 		);
 	});
 
-	it("marks a fetch-complete but locally-uncommitted relay indeterminate and retries with the same idempotency key", () => {
+	it("marks a fetch-complete but locally-uncommitted relay indeterminate and retries with the same idempotency key", async () => {
 		const message = createAgentMessage({
 			fromAgentId: "alpha",
 			content: "recover me",
@@ -366,7 +366,7 @@ describe("ACP delivery reconciliation", () => {
 			acpTargetAgentName: "helper",
 		});
 		const first = claimAcpMessageDelivery({ messageId: message.id, agentId: "alpha", nowMs: 1_000 });
-		expect(reconcileAcpDeliveries(undefined, 200_000)).toBe(1);
+		expect(await reconcileAcpDeliveries(undefined, 200_000)).toBe(1);
 		const indeterminate = listAgentMessages({ agentId: "alpha", includeSent: true })[0];
 		expect(indeterminate?.deliveryState).toBe("indeterminate");
 		expect(indeterminate?.deliveryStatus).toBe("queued");

--- a/platform/daemon/src/cross-agent.ts
+++ b/platform/daemon/src/cross-agent.ts
@@ -877,14 +877,17 @@ export function updateAgentMessageDelivery(
 	return updated;
 }
 
-export function reconcileAcpDeliveries(accessor: DbAccessor = getDbAccessor(), nowMs = Date.now()): number {
+export async function reconcileAcpDeliveries(
+	accessor: DbAccessor = getDbAccessor(),
+	nowMs = Date.now(),
+): Promise<number> {
 	const now = new Date(nowMs).toISOString();
 	const pendingCutoff = new Date(nowMs - ACP_PENDING_GRACE_MS).toISOString();
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	return accessor.withWriteTx((db: import("./db-accessor").WriteDb) => {
-		const result = db
-			.prepare(
-				`UPDATE cross_agent_messages
+	return await accessor.withWriteTxAsync(
+		(db: import("./db-accessor").WriteDb) => {
+			const result = db
+				.prepare(
+					`UPDATE cross_agent_messages
 				 SET delivery_state = 'indeterminate', delivery_status = 'queued',
 				     delivery_error = CASE
 				       WHEN delivery_state = 'in_flight' THEN 'ACP relay interrupted; remote outcome is unknown'
@@ -895,10 +898,12 @@ export function reconcileAcpDeliveries(accessor: DbAccessor = getDbAccessor(), n
 				 WHERE delivery_path = 'acp'
 				   AND ((delivery_state = 'in_flight' AND delivery_lease_expires_at <= ?)
 				     OR (delivery_state = 'pending' AND delivery_updated_at <= ?))`,
-			)
-			.run(now, now, pendingCutoff);
-		return result.changes;
-	}, "cross-agent.ts:884");
+				)
+				.run(now, now, pendingCutoff);
+			return result.changes;
+		},
+		{ operation: "cross-agent.reconcile-acp-deliveries" },
+	);
 }
 
 export function listAgentMessagePage(options: ListAgentMessageOptions = {}): AgentMessagePage {
@@ -935,7 +940,7 @@ export function listAgentMessagePage(options: ListAgentMessageOptions = {}): Age
 			offset,
 			hasMore: offset + items.length < total,
 		};
-	}, "cross-agent.ts:914");
+	}, "cross-agent.ts:919");
 }
 
 export function listAgentMessages(options: ListAgentMessageOptions = {}): AgentMessage[] {
@@ -992,7 +997,7 @@ export function acknowledgeAgentMessage(input: AcknowledgeAgentMessageInput): Ac
 		const acknowledgedAt = receipt?.acknowledged_at;
 		if (!acknowledgedAt) throw new Error("Failed to persist cross-agent acknowledgement");
 		return { messageId, agentId, acknowledgedAt, alreadyAcknowledged: false };
-	}, "cross-agent.ts:953");
+	}, "cross-agent.ts:958");
 }
 
 export function subscribeCrossAgentEvents(subscriber: (event: CrossAgentEvent) => void): () => void {
@@ -1028,5 +1033,5 @@ export function resetCrossAgentStateForTest(): void {
 	getDbAccessor().withWriteTx((db: import("./db-accessor").WriteDb) => {
 		db.prepare("DELETE FROM cross_agent_message_receipts").run();
 		db.prepare("DELETE FROM cross_agent_messages").run();
-	}, "cross-agent.ts:1028");
+	}, "cross-agent.ts:1033");
 }

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1159,14 +1159,15 @@ function stopStaleSessionSweeper(): void {
 function startAcpDeliveryReconciliation(): void {
 	if (acpDeliveryReconciliationTimer !== null) return;
 	acpDeliveryReconciliationTimer = setInterval(() => {
-		try {
-			const reconciled = reconcileAcpDeliveries();
-			if (reconciled > 0) logger.info("daemon", "Reconciled abandoned ACP delivery attempts", { reconciled });
-		} catch (error) {
-			logger.warn("daemon", "ACP delivery reconciliation failed", {
-				error: error instanceof Error ? error.message : String(error),
+		void reconcileAcpDeliveries()
+			.then((reconciled) => {
+				if (reconciled > 0) logger.info("daemon", "Reconciled abandoned ACP delivery attempts", { reconciled });
+			})
+			.catch((error) => {
+				logger.warn("daemon", "ACP delivery reconciliation failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
 			});
-		}
 	}, ACP_DELIVERY_RECONCILIATION_INTERVAL_MS);
 	acpDeliveryReconciliationTimer.unref?.();
 	logger.debug("watcher", "Started ACP delivery reconciliation", {

--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -2239,8 +2239,8 @@ memory:
 		expect(audit).toContain("README.md");
 	});
 
-	test.serial("sanitizes transcript audit filenames to stay within the audit directory", () => {
-		const result = writeTranscriptAudit({
+	test.serial("sanitizes transcript audit filenames to stay within the audit directory", async () => {
+		const result = await writeTranscriptAudit({
 			basePath: TEST_DIR,
 			agentId: "default",
 			sessionId: "sess-audit-safe",
@@ -2259,9 +2259,9 @@ memory:
 		expect(finalPath).not.toContain("/tmp/evil");
 	});
 
-	test.serial("uses the full raw transcript hash when audit ids are missing", () => {
+	test.serial("uses the full raw transcript hash when audit ids are missing", async () => {
 		const rawTranscript = "User: audit me\nAssistant: on it";
-		const result = writeTranscriptAudit({
+		const result = await writeTranscriptAudit({
 			basePath: TEST_DIR,
 			agentId: "agent-a",
 			sessionId: "",

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -152,7 +152,6 @@ import { assembleInheritedContextBlock, resolveParentSession } from "./subagent-
 import { awaitPressureClear, isSystemPressureHigh } from "./system-pressure";
 import { getActiveTelemetry } from "./telemetry";
 import { searchTemporalFallback } from "./temporal-fallback";
-import { writeTranscriptAudit } from "./transcript-audit";
 import * as transcriptCapture from "./transcript-capture";
 import {
 	enqueueTranscriptCaptureJob,
@@ -1718,23 +1717,6 @@ export async function handleUserPromptSubmit(
 				});
 			} catch (error) {
 				deps.logger.warn("hooks", "Prompt JSONL transcript append failed", {
-					error: error instanceof Error ? error.message : String(error),
-					sessionKey: req.sessionKey,
-				});
-			}
-		}
-
-		if (rawTranscript) {
-			try {
-				writeTranscriptAudit({
-					basePath: getAgentsDir(),
-					agentId,
-					sessionId: req.sessionKey,
-					sessionKey: req.sessionKey,
-					rawTranscript,
-				});
-			} catch (error) {
-				deps.logger.warn("hooks", "Prompt transcript audit write failed", {
 					error: error instanceof Error ? error.message : String(error),
 					sessionKey: req.sessionKey,
 				});

--- a/platform/daemon/src/pipeline/skill-graph.ts
+++ b/platform/daemon/src/pipeline/skill-graph.ts
@@ -72,29 +72,31 @@ function skillEntityId(agentId: string, name: string): string {
 	return `skill:${agentId}:${name}`;
 }
 
-function findSkillEntityId(input: SkillUninstallInput, accessor: DbAccessor): string | null {
+async function findSkillEntityId(input: SkillUninstallInput, accessor: DbAccessor): Promise<string | null> {
 	const agentId = input.agentId ?? "default";
 	const canonicalId = skillEntityId(agentId, input.skillName);
 
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	return accessor.withReadDb((db: import("../db-accessor").ReadDb) => {
-		if (input.entityId) {
-			const explicit = db
-				.prepare("SELECT id FROM entities WHERE id = ? AND agent_id = ?")
-				.get(input.entityId, agentId) as { id: string } | undefined;
-			if (explicit) return explicit.id;
-		}
+	return await accessor.withReadDbAsync(
+		(db: import("../db-accessor").ReadDb) => {
+			if (input.entityId) {
+				const explicit = db
+					.prepare("SELECT id FROM entities WHERE id = ? AND agent_id = ?")
+					.get(input.entityId, agentId) as { id: string } | undefined;
+				if (explicit) return explicit.id;
+			}
 
-		const canonical = db.prepare("SELECT id FROM entities WHERE id = ? AND agent_id = ?").get(canonicalId, agentId) as
-			| { id: string }
-			| undefined;
-		if (canonical) return canonical.id;
+			const canonical = db.prepare("SELECT id FROM entities WHERE id = ? AND agent_id = ?").get(canonicalId, agentId) as
+				| { id: string }
+				| undefined;
+			if (canonical) return canonical.id;
 
-		const adopted = db
-			.prepare("SELECT id FROM entities WHERE name = ? AND agent_id = ? AND entity_type = 'skill' LIMIT 1")
-			.get(input.skillName, agentId) as { id: string } | undefined;
-		return adopted?.id ?? null;
-	}, "pipeline/skill-graph.ts:80");
+			const adopted = db
+				.prepare("SELECT id FROM entities WHERE name = ? AND agent_id = ? AND entity_type = 'skill' LIMIT 1")
+				.get(input.skillName, agentId) as { id: string } | undefined;
+			return adopted?.id ?? null;
+		},
+		{ operation: "pipeline.skill-graph.find" },
+	);
 }
 
 function skillMetaIds(input: SkillUninstallInput): readonly string[] {
@@ -170,89 +172,27 @@ export async function installSkillNode(
 	const fm = input.frontmatter;
 
 	// Step 1: Create entity + skill_meta in a write transaction
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	accessor.withWriteTx((db: import("../db-accessor").WriteDb) => {
-		// Check if entity already exists by id or name (idempotent)
-		const existing = db
-			.prepare("SELECT id FROM entities WHERE id = ? OR (name = ? AND agent_id = ?)")
-			.get(entityId, fm.name, agentId) as { id: string } | undefined;
+	await accessor.withWriteTxAsync(
+		(db: import("../db-accessor").WriteDb) => {
+			const existing = db
+				.prepare("SELECT id FROM entities WHERE id = ? OR (name = ? AND agent_id = ?)")
+				.get(entityId, fm.name, agentId) as { id: string } | undefined;
 
-		if (existing) {
-			// If matched by name (collision), adopt that entity's id
-			if (existing.id !== entityId) {
-				entityId = existing.id;
-			}
-			// Update existing entity
-			db.prepare(`UPDATE entities SET entity_type = 'skill', description = ?, updated_at = ? WHERE id = ?`).run(
-				fm.description,
-				now,
-				entityId,
-			);
-
-			// Upsert skill_meta (may not exist if entity was from extraction)
-			db.prepare(
-				`INSERT INTO skill_meta
-				 (entity_id, agent_id, version, author, license, source,
-				  role, triggers, tags, permissions, enriched,
-				  installed_at, importance, decay_rate, fs_path)
-				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-				 ON CONFLICT(entity_id) DO UPDATE SET
-					version = excluded.version, author = excluded.author,
-					license = excluded.license, source = excluded.source,
-					role = excluded.role, triggers = excluded.triggers,
-					tags = excluded.tags, permissions = excluded.permissions,
-					enriched = excluded.enriched, fs_path = excluded.fs_path,
-					uninstalled_at = NULL, updated_at = ?`,
-			).run(
-				entityId,
-				agentId,
-				fm.version ?? null,
-				fm.author ?? null,
-				fm.license ?? null,
-				input.source,
-				fm.role ?? "utility",
-				fm.triggers ? JSON.stringify(fm.triggers) : null,
-				fm.tags ? JSON.stringify(fm.tags) : null,
-				fm.permissions ? JSON.stringify(fm.permissions) : null,
-				0,
-				now,
-				procCfg.importanceOnInstall,
-				procCfg.decayRate,
-				input.fsPath,
-				now,
-			);
-		} else {
-			// Insert new entity (catch name UNIQUE collision from extraction pipeline)
-			try {
-				db.prepare(
-					`INSERT INTO entities
-					 (id, name, canonical_name, entity_type, agent_id, description, mentions, created_at, updated_at)
-					 VALUES (?, ?, ?, 'skill', ?, ?, 0, ?, ?)`,
-				).run(entityId, fm.name, fm.name.toLowerCase(), agentId, fm.description, now, now);
-			} catch (e) {
-				const msg = e instanceof Error ? e.message : String(e);
-				if (!msg.includes("UNIQUE constraint")) throw e;
-
-				// Name collision — an extracted entity already owns this name.
-				// Claim it as a skill entity and reuse its id.
-				const collision = db
-					.prepare("SELECT id FROM entities WHERE name = ? AND agent_id = ? LIMIT 1")
-					.get(fm.name, agentId) as { id: string } | undefined;
-
-				if (!collision) throw e;
-
+			if (existing) {
+				// If matched by name (collision), adopt that entity's id
+				if (existing.id !== entityId) {
+					entityId = existing.id;
+				}
+				// Update existing entity
 				db.prepare(`UPDATE entities SET entity_type = 'skill', description = ?, updated_at = ? WHERE id = ?`).run(
 					fm.description,
 					now,
-					collision.id,
+					entityId,
 				);
-				entityId = collision.id;
-			}
 
-			// Upsert skill_meta. Reconciler startup, periodic passes, and watcher
-			// can overlap; avoid UNIQUE(entity_id) races under concurrent installs.
-			db.prepare(
-				`INSERT INTO skill_meta
+				// Upsert skill_meta (may not exist if entity was from extraction)
+				db.prepare(
+					`INSERT INTO skill_meta
 				 (entity_id, agent_id, version, author, license, source,
 				  role, triggers, tags, permissions, enriched,
 				  installed_at, importance, decay_rate, fs_path)
@@ -264,34 +204,96 @@ export async function installSkillNode(
 					tags = excluded.tags, permissions = excluded.permissions,
 					enriched = excluded.enriched, fs_path = excluded.fs_path,
 					uninstalled_at = NULL, updated_at = ?`,
-			).run(
-				entityId,
-				agentId,
-				fm.version ?? null,
-				fm.author ?? null,
-				fm.license ?? null,
-				input.source,
-				fm.role ?? "utility",
-				fm.triggers ? JSON.stringify(fm.triggers) : null,
-				fm.tags ? JSON.stringify(fm.tags) : null,
-				fm.permissions ? JSON.stringify(fm.permissions) : null,
-				0,
-				now,
-				procCfg.importanceOnInstall,
-				procCfg.decayRate,
-				input.fsPath,
-				now,
-			);
-		}
-	}, "pipeline/skill-graph.ts:174");
+				).run(
+					entityId,
+					agentId,
+					fm.version ?? null,
+					fm.author ?? null,
+					fm.license ?? null,
+					input.source,
+					fm.role ?? "utility",
+					fm.triggers ? JSON.stringify(fm.triggers) : null,
+					fm.tags ? JSON.stringify(fm.tags) : null,
+					fm.permissions ? JSON.stringify(fm.permissions) : null,
+					0,
+					now,
+					procCfg.importanceOnInstall,
+					procCfg.decayRate,
+					input.fsPath,
+					now,
+				);
+			} else {
+				// Insert new entity (catch name UNIQUE collision from extraction pipeline)
+				try {
+					db.prepare(
+						`INSERT INTO entities
+					 (id, name, canonical_name, entity_type, agent_id, description, mentions, created_at, updated_at)
+					 VALUES (?, ?, ?, 'skill', ?, ?, 0, ?, ?)`,
+					).run(entityId, fm.name, fm.name.toLowerCase(), agentId, fm.description, now, now);
+				} catch (e) {
+					const msg = e instanceof Error ? e.message : String(e);
+					if (!msg.includes("UNIQUE constraint")) throw e;
+
+					// Name collision — an extracted entity already owns this name.
+					// Claim it as a skill entity and reuse its id.
+					const collision = db
+						.prepare("SELECT id FROM entities WHERE name = ? AND agent_id = ? LIMIT 1")
+						.get(fm.name, agentId) as { id: string } | undefined;
+
+					if (!collision) throw e;
+
+					db.prepare(`UPDATE entities SET entity_type = 'skill', description = ?, updated_at = ? WHERE id = ?`).run(
+						fm.description,
+						now,
+						collision.id,
+					);
+					entityId = collision.id;
+				}
+
+				// Upsert skill_meta. Reconciler startup, periodic passes, and watcher
+				// can overlap; avoid UNIQUE(entity_id) races under concurrent installs.
+				db.prepare(
+					`INSERT INTO skill_meta
+				 (entity_id, agent_id, version, author, license, source,
+				  role, triggers, tags, permissions, enriched,
+				  installed_at, importance, decay_rate, fs_path)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				 ON CONFLICT(entity_id) DO UPDATE SET
+					version = excluded.version, author = excluded.author,
+					license = excluded.license, source = excluded.source,
+					role = excluded.role, triggers = excluded.triggers,
+					tags = excluded.tags, permissions = excluded.permissions,
+					enriched = excluded.enriched, fs_path = excluded.fs_path,
+					uninstalled_at = NULL, updated_at = ?`,
+				).run(
+					entityId,
+					agentId,
+					fm.version ?? null,
+					fm.author ?? null,
+					fm.license ?? null,
+					input.source,
+					fm.role ?? "utility",
+					fm.triggers ? JSON.stringify(fm.triggers) : null,
+					fm.tags ? JSON.stringify(fm.tags) : null,
+					fm.permissions ? JSON.stringify(fm.permissions) : null,
+					0,
+					now,
+					procCfg.importanceOnInstall,
+					procCfg.decayRate,
+					input.fsPath,
+					now,
+				);
+			}
+		},
+		{ operation: "pipeline.skill-graph.install-metadata" },
+	);
 
 	// Step 2: Generate embedding from the authored frontmatter
 	let embeddingCreated = false;
 	const embeddingText = buildEmbeddingText(fm);
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	const writeConfig = accessor.withReadDb(
+	const writeConfig = await accessor.withReadDbAsync(
 		(db: import("../db-accessor").ReadDb) => resolveActiveEmbeddingConfig(db, embeddingCfg),
-		"pipeline/skill-graph.ts:292",
+		{ operation: "pipeline.skill-graph.install-embedding-config" },
 	);
 	const embVec = await fetchEmbedding(embeddingText, writeConfig, "document", {
 		usage: { source: "artifact-index", agentId },
@@ -302,29 +304,29 @@ export async function installSkillNode(
 		const blob = vectorToBlob(embVec);
 		const embHash = skillEmbeddingHash(entityId, input.frontmatter);
 
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		embeddingCreated = accessor.withWriteTx((db: import("../db-accessor").WriteDb) => {
-			if (!isActiveEmbeddingConfig(db, writeConfig)) return false;
-			// Remove any old skill embeddings
-			const oldEmbs = db
-				.prepare(`SELECT id FROM embeddings WHERE source_type = 'skill' AND source_id = ?`)
-				.all(entityId) as Array<{ id: string }>;
+		embeddingCreated = await accessor.withWriteTxAsync(
+			(db: import("../db-accessor").WriteDb) => {
+				if (!isActiveEmbeddingConfig(db, writeConfig)) return false;
+				// Remove any old skill embeddings
+				const oldEmbs = db
+					.prepare(`SELECT id FROM embeddings WHERE source_type = 'skill' AND source_id = ?`)
+					.all(entityId) as Array<{ id: string }>;
 
-			if (oldEmbs.length > 0) {
-				if (
-					!syncVecDeleteByEmbeddingIds(
-						db,
-						oldEmbs.map((e) => e.id),
-					)
-				) {
-					throw new Error("failed to reconcile vec_embeddings before replacing skill embedding");
+				if (oldEmbs.length > 0) {
+					if (
+						!syncVecDeleteByEmbeddingIds(
+							db,
+							oldEmbs.map((e) => e.id),
+						)
+					) {
+						throw new Error("failed to reconcile vec_embeddings before replacing skill embedding");
+					}
+					db.prepare(`DELETE FROM embeddings WHERE source_type = 'skill' AND source_id = ?`).run(entityId);
 				}
-				db.prepare(`DELETE FROM embeddings WHERE source_type = 'skill' AND source_id = ?`).run(entityId);
-			}
 
-			// Insert new embedding (ON CONFLICT may keep the existing row id)
-			db.prepare(
-				`INSERT INTO embeddings
+				// Insert new embedding (ON CONFLICT may keep the existing row id)
+				db.prepare(
+					`INSERT INTO embeddings
 				 (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at)
 				 VALUES (?, ?, ?, ?, 'skill', ?, ?, ?)
 				 ON CONFLICT(content_hash) DO UPDATE SET
@@ -332,14 +334,16 @@ export async function installSkillNode(
 				   dimensions = excluded.dimensions,
 				   source_id = excluded.source_id,
 				   chunk_text = excluded.chunk_text`,
-			).run(embId, embHash, blob, embVec.length, entityId, embeddingText, now);
+				).run(embId, embHash, blob, embVec.length, entityId, embeddingText, now);
 
-			// Query back the actual row id — on conflict SQLite keeps the
-			// existing id, not the one we generated above.
-			const actualRow = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(embHash) as { id: string };
-			syncVecInsert(db, actualRow.id, embVec);
-			return true;
-		}, "pipeline/skill-graph.ts:306");
+				// Query back the actual row id — on conflict SQLite keeps the
+				// existing id, not the one we generated above.
+				const actualRow = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(embHash) as { id: string };
+				syncVecInsert(db, actualRow.id, embVec);
+				return true;
+			},
+			{ operation: "pipeline.skill-graph.install-embedding" },
+		);
 	}
 
 	logger.info("pipeline", "Skill node installed", {
@@ -355,58 +359,65 @@ export async function installSkillNode(
 // Uninstall: remove entity + skill_meta + embeddings + relations
 // ---------------------------------------------------------------------------
 
-export function uninstallSkillNode(input: SkillUninstallInput, accessor: DbAccessor): SkillUninstallResult {
+export async function uninstallSkillNode(
+	input: SkillUninstallInput,
+	accessor: DbAccessor,
+): Promise<SkillUninstallResult> {
 	const agentId = input.agentId ?? "default";
-	const entityId = findSkillEntityId(input, accessor);
+	const entityId = await findSkillEntityId(input, accessor);
 	const metaIds = skillMetaIds(input);
 
 	if (!entityId) {
 		const now = new Date().toISOString();
-		// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-		accessor.withWriteTx((db: import("../db-accessor").WriteDb) => {
-			for (const metaId of metaIds) {
-				db.prepare(
-					"UPDATE skill_meta SET uninstalled_at = ?, updated_at = ? WHERE entity_id = ? AND agent_id = ? AND uninstalled_at IS NULL",
-				).run(now, now, metaId, agentId);
-			}
-		}, "pipeline/skill-graph.ts:366");
+		await accessor.withWriteTxAsync(
+			(db: import("../db-accessor").WriteDb) => {
+				for (const metaId of metaIds) {
+					db.prepare(
+						"UPDATE skill_meta SET uninstalled_at = ?, updated_at = ? WHERE entity_id = ? AND agent_id = ? AND uninstalled_at IS NULL",
+					).run(now, now, metaId, agentId);
+				}
+			},
+			{ operation: "pipeline.skill-graph.uninstall-metadata" },
+		);
 		return { removed: false, entityId: null };
 	}
 
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withWriteTx migration site
-	accessor.withWriteTx((db: import("../db-accessor").WriteDb) => {
-		// 1. Remove skill relation edges
-		db.prepare(
-			`DELETE FROM relations
+	await accessor.withWriteTxAsync(
+		(db: import("../db-accessor").WriteDb) => {
+			// 1. Remove skill relation edges
+			db.prepare(
+				`DELETE FROM relations
 			 WHERE source_entity_id = ? OR target_entity_id = ?`,
-		).run(entityId, entityId);
+			).run(entityId, entityId);
 
-		// 2. Remove skill mention links
-		db.prepare("DELETE FROM memory_entity_mentions WHERE entity_id = ?").run(entityId);
+			// 2. Remove skill mention links
+			db.prepare("DELETE FROM memory_entity_mentions WHERE entity_id = ?").run(entityId);
 
-		// 3. Remove embeddings + vec sync
-		const embRows = db
-			.prepare(`SELECT id FROM embeddings WHERE source_type = 'skill' AND source_id = ?`)
-			.all(entityId) as Array<{ id: string }>;
+			// 3. Remove embeddings + vec sync
+			const embRows = db
+				.prepare(`SELECT id FROM embeddings WHERE source_type = 'skill' AND source_id = ?`)
+				.all(entityId) as Array<{ id: string }>;
 
-		if (embRows.length > 0) {
-			if (
-				!syncVecDeleteByEmbeddingIds(
-					db,
-					embRows.map((e) => e.id),
-				)
-			) {
-				throw new Error("failed to reconcile vec_embeddings before uninstalling skill");
+			if (embRows.length > 0) {
+				if (
+					!syncVecDeleteByEmbeddingIds(
+						db,
+						embRows.map((e) => e.id),
+					)
+				) {
+					throw new Error("failed to reconcile vec_embeddings before uninstalling skill");
+				}
+				db.prepare(`DELETE FROM embeddings WHERE source_type = 'skill' AND source_id = ?`).run(entityId);
 			}
-			db.prepare(`DELETE FROM embeddings WHERE source_type = 'skill' AND source_id = ?`).run(entityId);
-		}
 
-		// 4. Hard-delete skill_meta + entity in same transaction
-		for (const metaId of metaIds) {
-			db.prepare("DELETE FROM skill_meta WHERE entity_id = ? AND agent_id = ?").run(metaId, agentId);
-		}
-		db.prepare("DELETE FROM entities WHERE id = ?").run(entityId);
-	}, "pipeline/skill-graph.ts:377");
+			// 4. Hard-delete skill_meta + entity in same transaction
+			for (const metaId of metaIds) {
+				db.prepare("DELETE FROM skill_meta WHERE entity_id = ? AND agent_id = ?").run(metaId, agentId);
+			}
+			db.prepare("DELETE FROM entities WHERE id = ?").run(entityId);
+		},
+		{ operation: "pipeline.skill-graph.uninstall" },
+	);
 
 	logger.info("pipeline", "Skill node uninstalled", {
 		skill: input.skillName,

--- a/platform/daemon/src/pipeline/skill-reconciler.test.ts
+++ b/platform/daemon/src/pipeline/skill-reconciler.test.ts
@@ -716,7 +716,8 @@ describe("single-flight trigger overlap (#1354)", () => {
 			expect(calls).toBe(1);
 
 			releaseEmbedding?.();
-			await waitFor(() => calls === 2);
+			await waitFor(() => embeddingCount("alpha-skill") === 1 && embeddingCount("beta-skill") === 1);
+			expect(calls).toBe(2);
 
 			expect(entityCount("alpha-skill")).toBe(1);
 			expect(entityCount("beta-skill")).toBe(1);

--- a/platform/daemon/src/pipeline/skill-reconciler.ts
+++ b/platform/daemon/src/pipeline/skill-reconciler.ts
@@ -10,7 +10,7 @@
  * Idempotent — matched by canonical name + frontmatter content hash.
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { access, readFile, readdir, stat } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { watch } from "chokidar";
 import type { DbAccessor } from "../db-accessor.js";
@@ -68,6 +68,15 @@ export function withSkillReconciliationLock<T>(
 
 function skillsDir(agentsDir: string): string {
 	return join(agentsDir, "skills");
+}
+
+async function pathExists(path: string): Promise<boolean> {
+	try {
+		await access(path);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -133,12 +142,12 @@ export async function reconcileOnce(
 
 	// 1. Scan filesystem
 	const diskSkills = new Map<string, string>(); // name → SKILL.md path
-	if (options.scanFilesystem !== false && existsSync(dir)) {
-		const entries = readdirSync(dir, { withFileTypes: true });
+	if (options.scanFilesystem !== false && (await pathExists(dir))) {
+		const entries = await readdir(dir, { withFileTypes: true });
 		for (const entry of entries) {
 			if (!entry.isDirectory()) continue;
 			const skillMdPath = join(dir, entry.name, "SKILL.md");
-			if (existsSync(skillMdPath)) {
+			if (await pathExists(skillMdPath)) {
 				diskSkills.set(entry.name, skillMdPath);
 			}
 		}
@@ -159,17 +168,16 @@ export async function reconcileOnce(
 	}
 
 	// 3. Check for orphaned graph nodes (file removed from disk)
-	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-	const graphSkills = deps.accessor.withReadDb(
+	const graphSkills = await deps.accessor.withReadDbAsync(
 		(db: import("../db-accessor").ReadDb) =>
 			db
 				.prepare("SELECT entity_id, fs_path FROM skill_meta WHERE agent_id = 'default' AND uninstalled_at IS NULL")
 				.all() as Array<{ entity_id: string; fs_path: string }>,
-		"pipeline/skill-reconciler.ts:163",
+		{ operation: "pipeline.skill-reconciler.list-graph-skills" },
 	);
 
 	for (const row of graphSkills) {
-		if (!existsSync(row.fs_path)) {
+		if (!(await pathExists(row.fs_path))) {
 			// Prefer the namespace id, but retain the filesystem name for legacy
 			// rows whose entity_id does not use the skill namespace.
 			const parts = row.entity_id.split(":");
@@ -227,34 +235,32 @@ export async function reconcileSkillFile(
 		}
 
 		try {
-			if (!existsSync(mdPath)) {
-				const result = uninstallSkillNode({ skillName }, deps.accessor);
+			if (!(await pathExists(mdPath))) {
+				const result = await uninstallSkillNode({ skillName }, deps.accessor);
 				resetSkillFailureState(skillName);
 				return result.removed ? "removed" : "unchanged";
 			}
 
-			const content = readFileSync(mdPath, "utf-8");
+			const content = await readFile(mdPath, "utf-8");
 			const parsed = parseSkillFile(content);
 			if (!parsed) return "skipped";
 
 			const entityId = `skill:default:${skillName}`;
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const existing = deps.accessor.withReadDb(
+			const existing = await deps.accessor.withReadDbAsync(
 				(db: import("../db-accessor").ReadDb) =>
 					db
 						.prepare("SELECT id FROM entities WHERE id = ? OR (name = ? AND agent_id = 'default')")
 						.get(entityId, skillName) as { id: string } | undefined,
-				"pipeline/skill-reconciler.ts:242",
+				{ operation: "pipeline.skill-reconciler.find-entity" },
 			);
 			const actualId = existing?.id ?? entityId;
 			const rawHash = skillEmbeddingHash(actualId, parsed.frontmatter);
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const storedEmb = deps.accessor.withReadDb(
+			const storedEmb = await deps.accessor.withReadDbAsync(
 				(db: import("../db-accessor").ReadDb) =>
 					db
 						.prepare("SELECT content_hash FROM embeddings WHERE source_type = 'skill' AND source_id = ?")
 						.get(actualId) as { content_hash: string } | undefined,
-				"pipeline/skill-reconciler.ts:252",
+				{ operation: "pipeline.skill-reconciler.find-embedding" },
 			);
 
 			const shouldInstall =
@@ -308,8 +314,8 @@ export async function reconcileSkillFile(
  * unlink path and must use the workspace key, not the skills directory path.
  */
 export function reconcileUnlinkedSkill(skillName: string, deps: ReconcilerDeps): Promise<ReconcileSkillResult> {
-	return withSkillReconciliationLock(deps.agentsDir, skillName, () => {
-		const result = uninstallSkillNode({ skillName }, deps.accessor);
+	return withSkillReconciliationLock(deps.agentsDir, skillName, async () => {
+		const result = await uninstallSkillNode({ skillName }, deps.accessor);
 		resetSkillFailureState(skillName);
 		return result.removed ? "removed" : "unchanged";
 	});
@@ -332,9 +338,9 @@ export function startReconciler(deps: ReconcilerDeps): ReconcilerHandle {
 	let activePass: Promise<void> | null = null;
 	let stopped = false;
 
-	const directoryMtimeMs = (): number | null => {
+	const directoryMtimeMs = async (): Promise<number | null> => {
 		try {
-			return statSync(dir).mtimeMs;
+			return (await stat(dir)).mtimeMs;
 		} catch {
 			return null;
 		}
@@ -345,7 +351,7 @@ export function startReconciler(deps: ReconcilerDeps): ReconcilerHandle {
 		if (activePass) return activePass;
 
 		const pass = (async () => {
-			const currentMtimeMs = directoryMtimeMs();
+			const currentMtimeMs = await directoryMtimeMs();
 			const scanFilesystem = currentMtimeMs !== lastScannedDirMtimeMs;
 			await reconcileOnce(deps, { scanFilesystem });
 			lastScannedDirMtimeMs = currentMtimeMs;
@@ -376,45 +382,43 @@ export function startReconciler(deps: ReconcilerDeps): ReconcilerHandle {
 	// File watcher for low-latency reconciliation
 	let watcher: ReturnType<typeof watch> | null = null;
 
-	if (existsSync(dir)) {
-		watcher = watch(join(dir, "*", "SKILL.md"), {
-			ignoreInitial: true,
-			awaitWriteFinish: { stabilityThreshold: 500 },
-		});
+	watcher = watch(join(dir, "*", "SKILL.md"), {
+		ignoreInitial: true,
+		awaitWriteFinish: { stabilityThreshold: 500 },
+	});
 
-		watcher.on("add", (filePath) => {
-			const skillName = basename(dirname(filePath));
-			logger.info("reconciler", "SKILL.md added", { skill: skillName });
-			reconcileSkillFile(skillName, filePath, deps, { forceInstall: true }).catch((e) => {
-				logger.error("reconciler", "Watcher reconciliation failed", e instanceof Error ? e : undefined, {
-					skill: skillName,
-					error: String(e),
-				});
+	watcher.on("add", (filePath) => {
+		const skillName = basename(dirname(filePath));
+		logger.info("reconciler", "SKILL.md added", { skill: skillName });
+		reconcileSkillFile(skillName, filePath, deps, { forceInstall: true }).catch((e) => {
+			logger.error("reconciler", "Watcher reconciliation failed", e instanceof Error ? e : undefined, {
+				skill: skillName,
+				error: String(e),
 			});
 		});
+	});
 
-		watcher.on("change", (filePath) => {
-			const skillName = basename(dirname(filePath));
-			logger.info("reconciler", "SKILL.md changed", { skill: skillName });
-			reconcileSkillFile(skillName, filePath, deps, { forceInstall: true }).catch((e) => {
-				logger.error("reconciler", "Watcher reconciliation failed", e instanceof Error ? e : undefined, {
-					skill: skillName,
-					error: String(e),
-				});
+	watcher.on("change", (filePath) => {
+		const skillName = basename(dirname(filePath));
+		logger.info("reconciler", "SKILL.md changed", { skill: skillName });
+		reconcileSkillFile(skillName, filePath, deps, { forceInstall: true }).catch((e) => {
+			logger.error("reconciler", "Watcher reconciliation failed", e instanceof Error ? e : undefined, {
+				skill: skillName,
+				error: String(e),
 			});
 		});
+	});
 
-		watcher.on("unlink", (filePath) => {
-			const skillName = basename(dirname(filePath));
-			logger.info("reconciler", "SKILL.md removed", { skill: skillName });
-			reconcileUnlinkedSkill(skillName, deps).catch((e) => {
-				logger.error("reconciler", "Watcher uninstall failed", e instanceof Error ? e : undefined, {
-					skill: skillName,
-					error: String(e),
-				});
+	watcher.on("unlink", (filePath) => {
+		const skillName = basename(dirname(filePath));
+		logger.info("reconciler", "SKILL.md removed", { skill: skillName });
+		reconcileUnlinkedSkill(skillName, deps).catch((e) => {
+			logger.error("reconciler", "Watcher uninstall failed", e instanceof Error ? e : undefined, {
+				skill: skillName,
+				error: String(e),
 			});
 		});
-	}
+	});
 
 	logger.info("reconciler", "Skill reconciler started", {
 		intervalMs,

--- a/platform/daemon/src/routes/skills.ts
+++ b/platform/daemon/src/routes/skills.ts
@@ -17,7 +17,6 @@ import {
 	readdirSync,
 	renameSync,
 	rmSync,
-	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
@@ -29,7 +28,7 @@ import * as yauzl from "yauzl";
 import type { AuthMode } from "../auth/index.js";
 import { type DbAccessor, getDbAccessor } from "../db-accessor.js";
 import { logger } from "../logger.js";
-import { type EmbeddingConfig, type PipelineV2Config, loadMemoryConfig } from "../memory-config.js";
+import { type EmbeddingConfig, loadMemoryConfig } from "../memory-config.js";
 import { uninstallSkillNode } from "../pipeline/skill-graph.js";
 import { type ReconcilerDeps, reconcileSkillFile, withSkillReconciliationLock } from "../pipeline/skill-reconciler.js";
 
@@ -818,8 +817,8 @@ async function onSkillUninstalling(skillName: string): Promise<void> {
 	const accessor = getAccessorSafe();
 	if (!accessor) return;
 
-	await withSkillReconciliationLock(getAgentsDir(), skillName, () => {
-		const result = uninstallSkillNode({ skillName }, accessor);
+	await withSkillReconciliationLock(getAgentsDir(), skillName, async () => {
+		const result = await uninstallSkillNode({ skillName }, accessor);
 		if (result.removed) {
 			logger.info("skills", "Graph node removed for skill", {
 				skill: skillName,

--- a/platform/daemon/src/transcript-audit.test.ts
+++ b/platform/daemon/src/transcript-audit.test.ts
@@ -14,13 +14,13 @@ describe("transcript audit sizing (#1163)", () => {
 		expect(capTranscriptAuditContent("small transcript")).toBe("small transcript");
 	});
 
-	it("archives by renaming the latest instead of writing the content twice", () => {
+	it("archives by renaming the latest instead of writing the content twice", async () => {
 		const root = mkdtempSync(join(tmpdir(), "signet-audit-"));
 		try {
 			// 10MB raw — well over the 8MB cap — so a duplicated write would
 			// leave ~20MB of audit files for one session.
 			const big = "y".repeat(10 * 1024 * 1024);
-			const result = writeTranscriptAudit({
+			const result = await writeTranscriptAudit({
 				basePath: root,
 				agentId: "default",
 				sessionId: "sess-1",
@@ -46,10 +46,10 @@ describe("transcript audit sizing (#1163)", () => {
 		}
 	});
 
-	it("keeps the rolling latest file when no archive timestamp is supplied", () => {
+	it("keeps the rolling latest file when no archive timestamp is supplied", async () => {
 		const root = mkdtempSync(join(tmpdir(), "signet-audit-"));
 		try {
-			const result = writeTranscriptAudit({
+			const result = await writeTranscriptAudit({
 				basePath: root,
 				agentId: "default",
 				sessionId: "sess-2",

--- a/platform/daemon/src/transcript-audit.ts
+++ b/platform/daemon/src/transcript-audit.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { mkdir, rename, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { resolveDefaultBasePath } from "@signet/core";
 
@@ -44,25 +44,23 @@ export interface TranscriptAuditWrite {
 	readonly finalPath?: string;
 }
 
-export function writeTranscriptAudit(params: {
+export async function writeTranscriptAudit(params: {
 	readonly basePath?: string;
 	readonly agentId: string;
 	readonly sessionId: string;
 	readonly sessionKey: string | null;
 	readonly rawTranscript: string;
 	readonly capturedAt?: string;
-}): TranscriptAuditWrite | null {
+}): Promise<TranscriptAuditWrite | null> {
 	if (params.rawTranscript.trim().length === 0) return null;
 
 	const dir = getTranscriptAuditDir(params.basePath ?? process.env.SIGNET_PATH ?? resolveDefaultBasePath());
-	if (!existsSync(dir)) {
-		mkdirSync(dir, { recursive: true });
-	}
+	await mkdir(dir, { recursive: true });
 
 	const token = resolveAuditToken(params.agentId, params.sessionId, params.sessionKey, params.rawTranscript);
 	const content = capTranscriptAuditContent(params.rawTranscript);
 	const latestPath = buildAuditPath(dir, `${token}--latest.log`);
-	writeFileSync(latestPath, content, "utf8");
+	await writeFile(latestPath, content, "utf8");
 
 	if (!params.capturedAt) {
 		return { latestPath };
@@ -72,11 +70,11 @@ export function writeTranscriptAudit(params: {
 	// Archive the latest by renaming it — the content is never written twice;
 	// the next capture recreates the rolling latest file.
 	try {
-		renameSync(latestPath, finalPath);
+		await rename(latestPath, finalPath);
 	} catch {
 		// The archive matters more than avoiding the copy; fall back to a
 		// direct write of the (already capped) content.
-		writeFileSync(finalPath, content, "utf8");
+		await writeFile(finalPath, content, "utf8");
 	}
 	return { latestPath, finalPath };
 }

--- a/platform/daemon/src/transcript-capture-worker.ts
+++ b/platform/daemon/src/transcript-capture-worker.ts
@@ -227,7 +227,7 @@ async function leaseJob(dbAccessor: DbAccessor): Promise<TranscriptCaptureJobRow
 
 async function processTranscriptCaptureJob(basePath: string, job: TranscriptCaptureJobRow): Promise<void> {
 	if (job.rawTranscript) {
-		writeTranscriptAudit({
+		await writeTranscriptAudit({
 			basePath,
 			agentId: job.agentId,
 			sessionId: job.sessionId,

--- a/platform/daemon/src/transcript-recovery-worker.test.ts
+++ b/platform/daemon/src/transcript-recovery-worker.test.ts
@@ -8,7 +8,11 @@ import { deriveSessionEndFallbackId } from "./session-end-recovery";
 import { markSessionTranscriptCompleted, upsertSessionTranscript } from "./session-transcripts";
 import { enqueueTranscriptCaptureJob, runTranscriptCaptureOnce } from "./transcript-capture-worker";
 import { normalizeSessionTranscript } from "./transcript-normalization";
-import { runTranscriptRecoveryScan, startTranscriptRecoveryWorker } from "./transcript-recovery-worker";
+import {
+	runTranscriptRecoveryScan,
+	parseTranscriptRecoveryResult,
+	startTranscriptRecoveryWorker,
+} from "./transcript-recovery-worker";
 
 let dir = "";
 let claudeRoot = "";
@@ -31,6 +35,22 @@ async function scan(nowMs = Date.now()) {
 }
 
 describe("transcript recovery worker", () => {
+	it("parses a buffered child result after the child has closed", () => {
+		const result = {
+			discovered: 1,
+			examined: 1,
+			enqueued: 1,
+			deduplicated: 0,
+			skippedRecent: 0,
+			skippedOversized: 0,
+			skippedUnchanged: 0,
+			skippedInvalid: 0,
+		};
+		expect(parseTranscriptRecoveryResult(`logger output\n${JSON.stringify({ type: "result", result })}\n`)).toEqual(
+			result,
+		);
+	});
+
 	beforeEach(() => {
 		previousSignetPath = process.env.SIGNET_PATH;
 		previousRecoveryHoldFile = process.env.SIGNET_TRANSCRIPT_RECOVERY_TEST_HOLD_FILE;
@@ -479,6 +499,31 @@ describe("transcript recovery worker", () => {
 		});
 		await handle.stop();
 		expect(handle.running).toBe(false);
+	});
+
+	it("accepts a result written immediately before the recovery child exits", async () => {
+		const transcriptPath = join(claudeRoot, "-repo", "immediate-exit.jsonl");
+		writeSettled(
+			transcriptPath,
+			JSON.stringify({ sessionId: "immediate-exit", message: { role: "user", content: "child result" } }),
+		);
+
+		const handle = startTranscriptRecoveryWorker(getDbAccessor(), dir, "agent-a", {
+			roots: { claudeCode: claudeRoot, codex: codexRoot },
+			intervalMs: 60_000,
+		});
+		try {
+			for (let attempt = 0; attempt < 200; attempt++) {
+				const job = getDbAccessor().withReadDb((db) =>
+					db.prepare("SELECT id FROM transcript_capture_jobs WHERE transcript_path = ?").get(transcriptPath),
+				);
+				if (job) return;
+				await new Promise((resolve) => setTimeout(resolve, 5));
+			}
+			throw new Error("recovery child result was not accepted before the test deadline");
+		} finally {
+			await handle.stop();
+		}
 	});
 
 	it("cancels a scan waiting for DB admission", async () => {

--- a/platform/daemon/src/transcript-recovery-worker.test.ts
+++ b/platform/daemon/src/transcript-recovery-worker.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { DbOwnerDiedError } from "./db-owner-client";
 import { deriveSessionEndFallbackId } from "./session-end-recovery";
+import { logger } from "./logger";
 import { markSessionTranscriptCompleted, upsertSessionTranscript } from "./session-transcripts";
 import { enqueueTranscriptCaptureJob, runTranscriptCaptureOnce } from "./transcript-capture-worker";
 import { normalizeSessionTranscript } from "./transcript-normalization";
@@ -502,27 +503,48 @@ describe("transcript recovery worker", () => {
 	});
 
 	it("accepts a result written immediately before the recovery child exits", async () => {
-		const transcriptPath = join(claudeRoot, "-repo", "immediate-exit.jsonl");
-		writeSettled(
-			transcriptPath,
-			JSON.stringify({ sessionId: "immediate-exit", message: { role: "user", content: "child result" } }),
+		const childPath = join(dir, "immediate-exit-child.js");
+		const result = {
+			discovered: 1,
+			examined: 1,
+			enqueued: 1,
+			deduplicated: 0,
+			skippedRecent: 0,
+			skippedOversized: 0,
+			skippedUnchanged: 0,
+			skippedInvalid: 0,
+		};
+		writeFileSync(
+			childPath,
+			`process.stdout.write(${JSON.stringify(`${JSON.stringify({ type: "result", result })}\n`)}); process.exit(0);`,
 		);
+		const infoMessages: string[] = [];
+		const warnMessages: string[] = [];
+		const originalInfo = logger.info;
+		const originalWarn = logger.warn;
+		logger.info = ((category, message) => {
+			infoMessages.push(`${category}:${message}`);
+		}) as typeof logger.info;
+		logger.warn = ((category, message) => {
+			warnMessages.push(`${category}:${message}`);
+		}) as typeof logger.warn;
 
 		const handle = startTranscriptRecoveryWorker(getDbAccessor(), dir, "agent-a", {
 			roots: { claudeCode: claudeRoot, codex: codexRoot },
 			intervalMs: 60_000,
+			childPath,
 		});
 		try {
 			for (let attempt = 0; attempt < 200; attempt++) {
-				const job = getDbAccessor().withReadDb((db) =>
-					db.prepare("SELECT id FROM transcript_capture_jobs WHERE transcript_path = ?").get(transcriptPath),
-				);
-				if (job) return;
-				await new Promise((resolve) => setTimeout(resolve, 5));
+				if (infoMessages.includes("transcripts:Transcript recovery scan complete")) break;
+				await Bun.sleep(5);
 			}
-			throw new Error("recovery child result was not accepted before the test deadline");
+			expect(infoMessages).toContain("transcripts:Transcript recovery scan complete");
+			expect(warnMessages).toEqual([]);
 		} finally {
 			await handle.stop();
+			logger.info = originalInfo;
+			logger.warn = originalWarn;
 		}
 	});
 

--- a/platform/daemon/src/transcript-recovery-worker.ts
+++ b/platform/daemon/src/transcript-recovery-worker.ts
@@ -61,6 +61,18 @@ export interface TranscriptRecoveryScanResult {
 	readonly skippedInvalid: number;
 }
 
+export function parseTranscriptRecoveryResult(output: string): TranscriptRecoveryScanResult | null {
+	for (const line of output.split("\n")) {
+		try {
+			const event = JSON.parse(line) as { type?: string; result?: TranscriptRecoveryScanResult };
+			if (event.type === "result" && event.result !== undefined) return event.result;
+		} catch {
+			// Logger output is not part of the child protocol.
+		}
+	}
+	return null;
+}
+
 export interface TranscriptRecoveryWorkerHandle {
 	stop(): Promise<void>;
 	nudge(): void;
@@ -564,24 +576,20 @@ export function startTranscriptRecoveryWorker(
 			};
 			child.stdout?.setEncoding("utf8");
 			child.stdout?.on("data", (chunk: string) => {
+				// Buffer the complete protocol until the stdio streams close. The
+				// child may write its result and exit in the same turn; resolving from
+				// `data` or rejecting from `exit` races the final stdout delivery.
 				output += chunk;
-				for (const line of output.split("\\n").slice(0, -1)) {
-					try {
-						const event = JSON.parse(line) as { type?: string; result?: TranscriptRecoveryScanResult };
-						if (event.type === "result" && event.result !== undefined)
-							settle(() => resolve(event.result as TranscriptRecoveryScanResult));
-					} catch {
-						// Logger output is not part of the child protocol.
-					}
-				}
-				output = output.slice(output.lastIndexOf("\\n") + 1);
 			});
 			child.on("error", (error) => settle(() => reject(error)));
-			child.on("exit", (code, signal) => {
-				if (!settled) {
-					const detail = signal === null ? `exit code ${code ?? "unknown"}` : `signal ${signal}`;
-					settle(() => reject(new Error(`Transcript recovery child exited with ${detail}`)));
+			child.on("close", (code, signal) => {
+				const result = parseTranscriptRecoveryResult(output);
+				if (result !== null) {
+					settle(() => resolve(result));
+					return;
 				}
+				const detail = signal === null ? `exit code ${code ?? "unknown"}` : `signal ${signal}`;
+				settle(() => reject(new Error(`Transcript recovery child exited with ${detail}`)));
 			});
 		});
 	};

--- a/platform/daemon/src/transcript-recovery-worker.ts
+++ b/platform/daemon/src/transcript-recovery-worker.ts
@@ -81,6 +81,12 @@ export interface TranscriptRecoveryWorkerHandle {
 	readonly childPid: number | null;
 }
 
+type TranscriptRecoveryWorkerOptions = TranscriptRecoveryScanOptions & {
+	readonly intervalMs?: number;
+	/** Test-only child entrypoint used to exercise the stdio/close protocol deterministically. */
+	readonly childPath?: string;
+};
+
 function defaultRoots(): TranscriptRecoveryRoots {
 	const home = homedir();
 	return {
@@ -534,7 +540,7 @@ export function startTranscriptRecoveryWorker(
 	dbAccessor: DbAccessor,
 	basePath: string,
 	agentId: string,
-	options: TranscriptRecoveryScanOptions & { readonly intervalMs?: number } = {},
+	options: TranscriptRecoveryWorkerOptions = {},
 ): TranscriptRecoveryWorkerHandle {
 	let stopped = false;
 	let running = false;
@@ -556,8 +562,14 @@ export function startTranscriptRecoveryWorker(
 		const childName = fileURLToPath(import.meta.url).endsWith(".ts")
 			? "transcript-recovery-child.ts"
 			: "transcript-recovery-child.js";
-		const childPath = join(dirname(fileURLToPath(import.meta.url)), childName);
-		const { intervalMs: _intervalMs, signal: _signal, execution: _execution, ...scanOptions } = options;
+		const childPath = options.childPath ?? join(dirname(fileURLToPath(import.meta.url)), childName);
+		const {
+			intervalMs: _intervalMs,
+			signal: _signal,
+			execution: _execution,
+			childPath: _childPath,
+			...scanOptions
+		} = options;
 		const child = spawn(process.execPath, [childPath], {
 			env: {
 				...process.env,

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,9 +16,9 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(706);
-	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(78);
-	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(120);
+	expect(baseline).toHaveLength(683);
+	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(73);
+	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(115);
 });
 
 test("the event-loop ledger exactly equals the current source inventory", () => {
@@ -309,9 +309,9 @@ test("the production TypeScript project cannot import the compatibility module",
 
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	const report = renderReport(baseline, { total: 198, withWriteTx: 78, withReadDb: 120 });
-	expect(report).toContain("Exact ledger inventory: 706 sites");
-	expect(report).toContain("78 synchronous writes and 120 synchronous reads");
+	const report = renderReport(baseline, { total: 188, withWriteTx: 73, withReadDb: 115 });
+	expect(report).toContain("Exact ledger inventory: 683 sites");
+	expect(report).toContain("73 synchronous writes and 115 synchronous reads");
 	expect(report).toContain("type boundary");
 	expect(report).not.toContain("1061");
 });

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -277,28 +277,21 @@
     },
     {
       "path": "cross-agent.ts",
-      "line": 884,
-      "api": "withWriteTx",
-      "source": "return accessor.withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "cross-agent.ts",
-      "line": 914,
+      "line": 919,
       "api": "withReadDb",
       "source": "return getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
       "path": "cross-agent.ts",
-      "line": 953,
+      "line": 958,
       "api": "withWriteTx",
       "source": "return getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
     },
     {
       "path": "cross-agent.ts",
-      "line": 1028,
+      "line": 1033,
       "api": "withWriteTx",
       "source": "getDbAccessor().withWriteTx((db: import(\"./db-accessor\").WriteDb) => {",
       "category": "hot-path"
@@ -375,98 +368,98 @@
     },
     {
       "path": "daemon.ts",
-      "line": 1440,
+      "line": 1441,
       "api": "existsSync",
       "source": "if (!existsSync(p)) continue;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1442,
+      "line": 1443,
       "api": "readFileSync",
       "source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\")) as Record<string, unknown>;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1482,
+      "line": 1483,
       "api": "existsSync",
       "source": "if (!existsSync(path)) continue;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1484,
+      "line": 1485,
       "api": "readFileSync",
       "source": "const routing = parseRoutingConfig(parseSimpleYaml(readFileSync(path, \"utf-8\")));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1871,
+      "line": 1872,
       "api": "existsSync",
       "source": "if (existsSync(PID_FILE)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1873,
+      "line": 1874,
       "api": "unlinkSync",
       "source": "unlinkSync(PID_FILE);",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2014,
+      "line": 2015,
       "api": "mkdirSync",
       "source": "mkdirSync(DAEMON_DIR, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2015,
+      "line": 2016,
       "api": "mkdirSync",
       "source": "mkdirSync(LOG_DIR, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2016,
+      "line": 2017,
       "api": "mkdirSync",
       "source": "mkdirSync(dirname(MEMORY_DB), { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2093,
+      "line": 2094,
       "api": "existsSync",
       "source": "const workerPath = existsSync(bundled)",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2163,
+      "line": 2164,
       "api": "writeFileSync",
       "source": "writeFileSync(PID_FILE, process.pid.toString());",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2539,
+      "line": 2540,
       "api": "existsSync",
       "source": "if (existsSync(healthStampPath)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2540,
+      "line": 2541,
       "api": "readFileSync",
       "source": "const prev = JSON.parse(readFileSync(healthStampPath, \"utf-8\"));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2543,
+      "line": 2544,
       "api": "writeFileSync",
       "source": "writeFileSync(",
       "category": "hot-path"
@@ -893,63 +886,63 @@
     },
     {
       "path": "hooks.ts",
-      "line": 500,
+      "line": 499,
       "api": "existsSync",
       "source": "if (!existsSync(getMemoryDbPath())) return undefined;",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 600,
+      "line": 599,
       "api": "existsSync",
       "source": "if (!existsSync(getMemoryDbPath())) return [];",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 808,
+      "line": 807,
       "api": "existsSync",
       "source": "if (req.sessionKey && existsSync(getMemoryDbPath())) {",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 1662,
+      "line": 1661,
       "api": "existsSync",
       "source": "if (req.transcriptPath && existsSync(req.transcriptPath)) {",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 1664,
+      "line": 1663,
       "api": "readFileSync",
       "source": "rawTranscript = readFileSync(req.transcriptPath, \"utf-8\");",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 2089,
+      "line": 2071,
       "api": "existsSync",
       "source": "if (req.transcriptPath && existsSync(req.transcriptPath)) {",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 2091,
+      "line": 2073,
       "api": "readFileSync",
       "source": "rawTranscript = readFileSync(req.transcriptPath, \"utf-8\");",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 2353,
+      "line": 2335,
       "api": "existsSync",
       "source": "} else if (req.transcriptPath && existsSync(req.transcriptPath)) {",
       "category": "hot-path"
     },
     {
       "path": "hooks.ts",
-      "line": 2355,
+      "line": 2337,
       "api": "readFileSync",
       "source": "const raw = readFileSync(req.transcriptPath, \"utf-8\");",
       "category": "hot-path"
@@ -2285,125 +2278,6 @@
       "category": "hot-path"
     },
     {
-      "path": "pipeline/skill-graph.ts",
-      "line": 80,
-      "api": "withReadDb",
-      "source": "return accessor.withReadDb((db: import(\"../db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 174,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 292,
-      "api": "withReadDb",
-      "source": "const writeConfig = accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 306,
-      "api": "withWriteTx",
-      "source": "embeddingCreated = accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 366,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-graph.ts",
-      "line": 377,
-      "api": "withWriteTx",
-      "source": "accessor.withWriteTx((db: import(\"../db-accessor\").WriteDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 136,
-      "api": "existsSync",
-      "source": "if (options.scanFilesystem !== false && existsSync(dir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 137,
-      "api": "readdirSync",
-      "source": "const entries = readdirSync(dir, { withFileTypes: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 141,
-      "api": "existsSync",
-      "source": "if (existsSync(skillMdPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 163,
-      "api": "withReadDb",
-      "source": "const graphSkills = deps.accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 172,
-      "api": "existsSync",
-      "source": "if (!existsSync(row.fs_path)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 230,
-      "api": "existsSync",
-      "source": "if (!existsSync(mdPath)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 236,
-      "api": "readFileSync",
-      "source": "const content = readFileSync(mdPath, \"utf-8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 242,
-      "api": "withReadDb",
-      "source": "const existing = deps.accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 252,
-      "api": "withReadDb",
-      "source": "const storedEmb = deps.accessor.withReadDb(",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 337,
-      "api": "statSync",
-      "source": "return statSync(dir).mtimeMs;",
-      "category": "hot-path"
-    },
-    {
-      "path": "pipeline/skill-reconciler.ts",
-      "line": 379,
-      "api": "existsSync",
-      "source": "if (existsSync(dir)) {",
-      "category": "hot-path"
-    },
-    {
       "path": "pipeline/synthesis-worker.ts",
       "line": 72,
       "api": "existsSync",
@@ -3245,175 +3119,182 @@
     },
     {
       "path": "routes/skills.ts",
-      "line": 221,
+      "line": 220,
       "api": "existsSync",
       "source": "if (!existsSync(getSkillsDir())) return [];",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 223,
+      "line": 222,
       "api": "readdirSync",
       "source": "return readdirSync(getSkillsDir(), { withFileTypes: true })",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 227,
+      "line": 226,
       "api": "existsSync",
       "source": "if (!existsSync(skillMdPath)) return [];",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 229,
+      "line": 228,
       "api": "readFileSync",
       "source": "const content = readFileSync(skillMdPath, \"utf-8\");",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 364,
+      "line": 363,
       "api": "existsSync",
       "source": "if (process.env.SIGNET_SKILLS_SOURCE && existsSync(process.env.SIGNET_SKILLS_SOURCE)) {",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 369,
+      "line": 368,
       "api": "existsSync",
       "source": "if (existsSync(devPath)) return devPath;",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 372,
+      "line": 371,
       "api": "existsSync",
       "source": "if (existsSync(distPath)) return distPath;",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 374,
+      "line": 373,
       "api": "existsSync",
       "source": "if (existsSync(distPath2)) return distPath2;",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 380,
+      "line": 379,
       "api": "existsSync",
       "source": "if (!sourceDir || !existsSync(sourceDir)) return [];",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 384,
+      "line": 383,
       "api": "readdirSync",
       "source": "return readdirSync(sourceDir, { withFileTypes: true })",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 388,
+      "line": 387,
       "api": "existsSync",
       "source": "if (!existsSync(skillMdPath)) return [];",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 390,
+      "line": 389,
       "api": "readFileSync",
       "source": "const content = readFileSync(skillMdPath, \"utf-8\");",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 510,
+      "line": 509,
       "api": "existsSync",
       "source": "if (!existsSync(skillMd)) {",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 513,
+      "line": 512,
       "api": "lstatSync",
       "source": "if (!lstatSync(skillMd).isFile()) {",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 521,
+      "line": 520,
       "api": "readdirSync",
       "source": "for (const entry of readdirSync(dir, { withFileTypes: true })) {",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 636,
+      "line": 635,
       "api": "mkdirSync",
       "source": "mkdirSync(target, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 641,
+      "line": 640,
       "api": "mkdirSync",
       "source": "mkdirSync(dirname(target), { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 715,
+      "line": 714,
       "api": "rmSync",
       "source": "rmSync(stagingDir, { recursive: true, force: true });",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 716,
+      "line": 715,
       "api": "rmSync",
       "source": "rmSync(backupDir, { recursive: true, force: true });",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 718,
+      "line": 717,
       "api": "existsSync",
       "source": "if (existsSync(targetDir)) {",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 719,
+      "line": 718,
       "api": "renameSync",
       "source": "renameSync(targetDir, backupDir);",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 722,
+      "line": 721,
       "api": "renameSync",
       "source": "renameSync(stagingDir, targetDir);",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 723,
+      "line": 722,
       "api": "rmSync",
       "source": "rmSync(backupDir, { recursive: true, force: true });",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 725,
+      "line": 724,
       "api": "rmSync",
       "source": "rmSync(stagingDir, { recursive: true, force: true });",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 726,
+      "line": 725,
+      "api": "existsSync",
+      "source": "if (movedTarget && existsSync(backupDir) && !existsSync(targetDir)) {",
+      "category": "hot-path"
+    },
+    {
+      "path": "routes/skills.ts",
+      "line": 725,
       "api": "existsSync",
       "source": "if (movedTarget && existsSync(backupDir) && !existsSync(targetDir)) {",
       "category": "hot-path"
@@ -3421,83 +3302,76 @@
     {
       "path": "routes/skills.ts",
       "line": 726,
-      "api": "existsSync",
-      "source": "if (movedTarget && existsSync(backupDir) && !existsSync(targetDir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "routes/skills.ts",
-      "line": 727,
       "api": "renameSync",
       "source": "renameSync(backupDir, targetDir);",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 729,
+      "line": 728,
       "api": "rmSync",
       "source": "rmSync(backupDir, { recursive: true, force: true });",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 759,
+      "line": 758,
       "api": "mkdirSync",
       "source": "mkdirSync(extractDir, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 770,
+      "line": 769,
       "api": "mkdirSync",
       "source": "mkdirSync(getSkillsDir(), { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 783,
+      "line": 782,
       "api": "rmSync",
       "source": "rmSync(tempRoot, { recursive: true, force: true });",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 1011,
+      "line": 1010,
       "api": "existsSync",
       "source": "if (existsSync(skillMdPath)) {",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 1013,
+      "line": 1012,
       "api": "readFileSync",
       "source": "const content = readFileSync(skillMdPath, \"utf-8\");",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 1031,
+      "line": 1030,
       "api": "existsSync",
       "source": "if (existsSync(signetSkillPath)) {",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 1033,
+      "line": 1032,
       "api": "readFileSync",
       "source": "const content = readFileSync(signetSkillPath, \"utf-8\");",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 1188,
+      "line": 1187,
       "api": "existsSync",
       "source": "if (!existsSync(skillDir)) {",
       "category": "hot-path"
     },
     {
       "path": "routes/skills.ts",
-      "line": 1195,
+      "line": 1194,
       "api": "rmSync",
       "source": "rmSync(skillDir, { recursive: true, force: true });",
       "category": "hot-path"
@@ -4466,41 +4340,6 @@
       "line": 59,
       "api": "rmSync",
       "source": "rmSync(dir, { recursive: true, force: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-audit.ts",
-      "line": 58,
-      "api": "existsSync",
-      "source": "if (!existsSync(dir)) {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-audit.ts",
-      "line": 59,
-      "api": "mkdirSync",
-      "source": "mkdirSync(dir, { recursive: true });",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-audit.ts",
-      "line": 65,
-      "api": "writeFileSync",
-      "source": "writeFileSync(latestPath, content, \"utf8\");",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-audit.ts",
-      "line": 75,
-      "api": "renameSync",
-      "source": "renameSync(latestPath, finalPath);",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-audit.ts",
-      "line": 79,
-      "api": "writeFileSync",
-      "source": "writeFileSync(finalPath, content, \"utf8\");",
       "category": "hot-path"
     },
     {

--- a/scripts/legacy-sync-db-baseline.json
+++ b/scripts/legacy-sync-db-baseline.json
@@ -2,8 +2,8 @@
 	"version": 1,
 	"generatedFrom": "bun scripts/legacy-sync-db-baseline.ts",
 	"markedCallsites": {
-		"total": 198,
-		"withReadDb": 120,
-		"withWriteTx": 78
+		"total": 188,
+		"withReadDb": 115,
+		"withWriteTx": 73
 	}
 }


### PR DESCRIPTION
## Summary

- Fix transcript recovery child completion so buffered results are parsed after stdio closes before exit failures are reported.
- Convert skill reconciliation, skill graph install/uninstall, ACP reconciliation, and transcript audit writes to owner-admitted async filesystem/DB operations.
- Remove the duplicate synchronous prompt-side transcript audit write; transcript capture owns the audit write.
- Add regression coverage and refresh the event-loop audit/count ledgers.

## Verification

- Focused suites: `bun test platform/daemon/src/transcript-recovery-worker.test.ts platform/daemon/src/transcript-audit.test.ts platform/daemon/src/cross-agent.test.ts platform/daemon/src/pipeline/skill-reconciler.test.ts platform/daemon/src/pipeline/skill-graph.test.ts scripts/audit-event-loop-contract.test.ts` (83 pass, 0 fail).
- `bun scripts/audit-event-loop-contract.ts` (683 inventory entries; 188 legacy DB markers; ratchet holds).
- `bunx biome check platform/daemon/src/transcript-recovery-worker.ts platform/daemon/src/transcript-recovery-worker.test.ts`.
- `bun run --filter '@signet/daemon' typecheck`.
- `bun run --filter '@signet/daemon' build`.
- Mutation check: the load-bearing immediate-exit regression passes with the fixed close/result handler; restoring the pre-fix data/exit handler fails the NEW test (16 pass, 1 fail: `accepts a result written immediately before the recovery child exits`). The test now drives a deterministic fake child that writes the result line and calls `process.exit(0)` in the same turn, and observes parent completion rather than only the database side effect.

The broader `hooks.test.ts` file retains three unrelated existing failures in MEMORY.md/reindex behavior; the changed transcript-audit tests pass.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Refs #1696

Assisted-by: Hermes Agent:gpt-5.6-luna