### PR TITLE
fix(daemon): allow unknown migration backup free space

### DIFF
--- a/platform/daemon/src/db-accessor.test.ts
+++ b/platform/daemon/src/db-accessor.test.ts
@@ -886,7 +886,7 @@ describe("DbAccessor", () => {
 		expect(operations).toContain(`unlink:${staleName}`);
 		expect(operations).not.toContain(`unlink:${currentName}`);
 	});
-	test("refuses a migration backup when statfs is degenerate instead of copy-probing", () => {
+	test("proceeds when statfs reports zero-sized blocks", () => {
 		const dbPath = tmpDbPath();
 		cleanupDirs.push(join(dbPath, ".."));
 		const dbDir = join(dbPath, "..");
@@ -895,73 +895,74 @@ describe("DbAccessor", () => {
 		const files = new Map<string, number>();
 		const operations: string[] = [];
 
-		expect(() =>
-			backupBeforeMigration({ exec: () => {} }, dbPath, 64, {
-				copyFileSync: () => {
-					operations.push("copy");
-				},
-				readdirSync: () => Array.from(files.keys()),
-				statSync: (path) => ({ mtimeMs: files.get(String(path).slice(dbDir.length + 1)) ?? 0, size: 8 }),
-				statfsSync: () => ({ bavail: 0, bsize: 0 }),
-				unlinkSync: () => {
-					operations.push("unlink");
-				},
-				now: () => 6000,
-				log: () => {},
-			}),
-		).toThrow(DbSpacePreflightError);
-		// Admission never falls back to an unbounded copy probe: it refuses
-		// with the metrics it has and writes nothing.
-		expect(operations).toEqual([]);
-		expect(files.has("test.db.bak-v64-6000")).toBe(false);
+		const backupPath = backupBeforeMigration({ exec: () => {} }, dbPath, 64, {
+			copyFileSync: (_source, destination) => {
+				operations.push("copy");
+				files.set(String(destination).slice(dbDir.length + 1), 1);
+			},
+			readdirSync: () => Array.from(files.keys()),
+			statSync: (path) => ({ mtimeMs: files.get(String(path).slice(dbDir.length + 1)) ?? 0, size: 8 }),
+			statfsSync: () => ({ bavail: 0, bsize: 0 }),
+			unlinkSync: (path) => {
+				operations.push("unlink");
+				files.delete(String(path).slice(dbDir.length + 1));
+			},
+			now: () => 6000,
+			log: () => {},
+		});
+		expect(backupPath).toBe(`${dbPath}.bak-v64-6000`);
+		expect(operations).toEqual(["copy"]);
+		expect(files.has("test.db.bak-v64-6000")).toBe(true);
 	});
 
-	test("refuses when statfs returns a degenerate block size instead of write-probing", () => {
+	test("proceeds when statfs returns a degenerate block size", () => {
 		const dbPath = tmpDbPath();
 		cleanupDirs.push(join(dbPath, ".."));
 		writeFileSync(dbPath, "database");
 		const operations: string[] = [];
 
-		expect(() =>
-			backupBeforeMigration({ exec: () => {} }, dbPath, 65, {
-				copyFileSync: () => {
-					operations.push("copy");
-				},
-				readdirSync: () => [],
-				statSync: () => ({ mtimeMs: 0, size: 1024 * 1024 + 1 }),
-				statfsSync: () => ({ bavail: 244199454, bsize: 0 }),
-				unlinkSync: () => {
-					operations.push("unlink");
-				},
-				now: () => 7000,
-				log: () => {},
-			}),
-		).toThrow(DbSpacePreflightError);
-		expect(operations).toEqual([]);
+		const backupPath = backupBeforeMigration({ exec: () => {} }, dbPath, 65, {
+			copyFileSync: () => {
+				operations.push("copy");
+			},
+			readdirSync: () => [],
+			statSync: () => ({ mtimeMs: 0, size: 1024 * 1024 + 1 }),
+			statfsSync: () => ({ bavail: 244199454, bsize: 0 }),
+			unlinkSync: () => {
+				operations.push("unlink");
+			},
+			now: () => 7000,
+			log: () => {},
+		});
+		expect(backupPath).toBe(`${dbPath}.bak-v65-7000`);
+		expect(operations).toEqual(["copy"]);
 	});
 
-	test("does not fabricate free space when statfs is degenerate", () => {
+	test("proceeds with a warning when statfs free space is unknown", () => {
 		const dbPath = tmpDbPath();
 		cleanupDirs.push(join(dbPath, ".."));
+		const dbDir = join(dbPath, "..");
 		writeFileSync(dbPath, "database");
+		const files = new Map<string, number>();
+		const warnings: string[] = [];
 
-		let error: DbSpacePreflightError | undefined;
-		try {
-			backupBeforeMigration({ exec: () => {} }, dbPath, 65, {
-				copyFileSync: () => {},
-				readdirSync: () => [],
-				statSync: () => ({ mtimeMs: 0, size: 8 }),
-				statfsSync: () => ({ bavail: 0, bsize: 0 }),
-				unlinkSync: () => {},
-				now: () => 7000,
-				log: () => {},
-			});
-		} catch (err) {
-			error = err as DbSpacePreflightError;
-		}
-		expect(error).toBeInstanceOf(DbSpacePreflightError);
-		if (!error) throw new Error("expected DbSpacePreflightError");
-		expect((error.metrics as unknown as { freeBytes: number | null }).freeBytes).toBeNull();
+		const backupPath = backupBeforeMigration({ exec: () => {} }, dbPath, 65, {
+			copyFileSync: (_source, destination) => {
+				files.set(String(destination).slice(dbDir.length + 1), 1);
+			},
+			readdirSync: () => Array.from(files.keys()),
+			statSync: (path) => ({ mtimeMs: 0, size: files.get(String(path).slice(dbDir.length + 1)) ?? 8 }),
+			statfsSync: () => ({ bavail: 0, bsize: 0 }),
+			unlinkSync: (path) => {
+				files.delete(String(path).slice(dbDir.length + 1));
+			},
+			now: () => 7000,
+			log: (message) => warnings.push(message),
+		});
+
+		expect(backupPath).toBe(`${dbPath}.bak-v65-7000`);
+		expect(files.has("test.db.bak-v65-7000")).toBe(true);
+		expect(warnings.some((message) => message.includes("free space is unknown"))).toBe(true);
 	});
 
 	test("still blocks a genuinely verified-full migration backup", () => {

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -783,6 +783,7 @@ export interface MigrationBackupDeps {
 	readonly unlinkSync: (path: string) => void;
 	readonly now: () => number;
 	readonly log: (message: string) => void;
+	readonly warn?: (message: string) => void;
 	/** Test seam and optional alternate checkpoint source for backup admission. */
 	readonly readVerificationCheckpoint?: (backupPath: string) => string | undefined;
 }
@@ -796,6 +797,7 @@ const migrationBackupDeps: MigrationBackupDeps = {
 	unlinkSync,
 	now: Date.now,
 	log: console.log,
+	warn: console.warn,
 };
 
 function readErrorMessage(err: unknown): string {
@@ -1137,13 +1139,15 @@ function preflightMigrationBackupSpace(dbPath: string, deps: MigrationBackupDeps
 		dbBytes,
 		freeBytes,
 		requiredBytes: dbBytes + MIGRATION_BACKUP_SPACE_MARGIN_BYTES,
-	} as DbSpaceMetrics;
+	} satisfies DbSpaceMetrics;
 	if (freeBytes === null) {
-		// A degenerate statfs reading is not a license to proceed. Unbounded
-		// copy-probing inside admission would violate the startup deadline, and
-		// an unknown free-space figure cannot satisfy the space margin, so the
-		// honest outcome is refusal with the metrics we do have.
-		throw new DbSpacePreflightError("migration_backup", metrics);
+		// statfs is unavailable or returned an unusable value on some filesystems.
+		// Do not turn an unknown measurement into a false zero and brick startup;
+		// the copy itself remains the authoritative write check.
+		(deps.warn ?? deps.log)(
+			"[db-accessor] Migration backup free space is unknown; proceeding without the space preflight.",
+		);
+		return metrics;
 	}
 	if (freeBytes < metrics.requiredBytes) throw new DbSpacePreflightError("migration_backup", metrics);
 	return metrics;
@@ -1576,8 +1580,8 @@ function prepareMigrationBackup(
  * Resume admission: the remaining bytes still need headroom on this disk,
  * now, after the partial copy already consumed `offset` bytes. The
  * in-progress backup itself is the current attempt's rollback point, so it
- * is not pruned; only its remaining growth must fit. Degenerate statfs
- * readings refuse, exactly like the fresh-copy preflight.
+ * is not pruned; only its remaining growth must fit. Unknown statfs readings
+ * warn and proceed, exactly like the fresh-copy preflight.
  */
 function preflightResumedMigrationBackupSpace(
 	dbPath: string,
@@ -1592,8 +1596,13 @@ function preflightResumedMigrationBackupSpace(
 		dbBytes: sourceSize,
 		freeBytes,
 		requiredBytes: remaining + MIGRATION_BACKUP_SPACE_MARGIN_BYTES,
-	} as DbSpaceMetrics;
-	if (freeBytes === null) throw new DbSpacePreflightError("migration_backup", metrics);
+	} satisfies DbSpaceMetrics;
+	if (freeBytes === null) {
+		(deps.warn ?? deps.log)(
+			"[db-accessor] Migration backup resume free space is unknown; proceeding without the space preflight.",
+		);
+		return;
+	}
 	if (freeBytes < metrics.requiredBytes) throw new DbSpacePreflightError("migration_backup", metrics);
 }
 

--- a/platform/daemon/src/db-vacuum.ts
+++ b/platform/daemon/src/db-vacuum.ts
@@ -26,7 +26,7 @@ export type DbSpaceOperation = "migration_backup" | "vacuum";
 
 export interface DbSpaceMetrics {
 	readonly dbBytes: number;
-	readonly freeBytes: number;
+	readonly freeBytes: number | null;
 	readonly requiredBytes: number;
 }
 
@@ -91,7 +91,9 @@ function measureDbSpace(dbPath: string, deps: DbSpaceDeps): DbSpaceMetrics | nul
 
 function assertDbSpace(operation: DbSpaceOperation, dbPath: string, deps: DbSpaceDeps): DbSpaceMetrics | null {
 	const metrics = measureDbSpace(dbPath, deps);
-	if (metrics && metrics.freeBytes < metrics.requiredBytes) throw new DbSpacePreflightError(operation, metrics);
+	if (metrics && metrics.freeBytes !== null && metrics.freeBytes < metrics.requiredBytes) {
+		throw new DbSpacePreflightError(operation, metrics);
+	}
 	return metrics;
 }
 

--- a/platform/daemon/src/db-vacuum.ts
+++ b/platform/daemon/src/db-vacuum.ts
@@ -336,14 +336,14 @@ export function getVacuumConversionStatus(accessor: DbAccessor): VacuumConversio
 	// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
 	return accessor.withReadDb(
 		(db: import("./db-accessor").ReadDb) => readStatusFromDb(toPragmaReadDb(db)),
-		"db-vacuum.ts:335",
+		"db-vacuum.ts:337",
 	);
 }
 
 /** Async durable conversion-state lookup for background workers. */
 export async function getVacuumConversionStatusAsync(accessor: DbAccessor): Promise<VacuumConversionStatus> {
 	return await accessor.withReadDbAsync((db) => readStatusFromDb(toPragmaReadDb(db)), {
-		siteToken: "db-vacuum.ts:343",
+		siteToken: "db-vacuum.ts:345",
 		operation: "maintenance.vacuum.status",
 	});
 }
@@ -451,7 +451,7 @@ export async function reclaimIncrementalVacuum(
 		if (opts.owner) remaining = await dbOwnerIncrementalVacuum(opts.owner, batchPages);
 		else {
 			if (!accessor.incrementalVacuumAsync) throw new Error("incremental vacuum operation is unavailable");
-			remaining = await accessor.incrementalVacuumAsync({ siteToken: "db-vacuum.ts:452" });
+			remaining = await accessor.incrementalVacuumAsync({ siteToken: "db-vacuum.ts:454" });
 		}
 		const progressed = before === null ? Math.max(0, batchPages) : Math.max(0, before - remaining);
 		reclaimed += progressed;
@@ -504,7 +504,7 @@ export function startVacuumConversionWorker(
 						lastError: null,
 					});
 				},
-				{ siteToken: "db-vacuum.ts:490", operation: "maintenance.vacuum.mark-running" },
+				{ siteToken: "db-vacuum.ts:492", operation: "maintenance.vacuum.mark-running" },
 			);
 
 			const running = await getVacuumConversionStatusAsync(accessor);
@@ -519,7 +519,7 @@ export function startVacuumConversionWorker(
 					await dbOwnerVacuumConversion(opts.owner);
 				} else {
 					if (!accessor.vacuumConversionAsync) throw new Error("VACUUM conversion operation is unavailable");
-					await accessor.vacuumConversionAsync({ siteToken: "db-vacuum.ts:520" });
+					await accessor.vacuumConversionAsync({ siteToken: "db-vacuum.ts:522" });
 				}
 				await accessor.withWriteTxAsync(
 					(db) => {
@@ -534,7 +534,7 @@ export function startVacuumConversionWorker(
 							lastError: null,
 						});
 					},
-					{ siteToken: "db-vacuum.ts:522", operation: "maintenance.vacuum.mark-completed" },
+					{ siteToken: "db-vacuum.ts:524", operation: "maintenance.vacuum.mark-completed" },
 				);
 				logger.info("db-vacuum", "Post-ready conversion worker completed");
 			} catch (error) {
@@ -552,7 +552,7 @@ export function startVacuumConversionWorker(
 							lastError: message.slice(0, 500),
 						});
 					},
-					{ siteToken: "db-vacuum.ts:540", operation: "maintenance.vacuum.mark-failed" },
+					{ siteToken: "db-vacuum.ts:542", operation: "maintenance.vacuum.mark-failed" },
 				);
 				logger.error(
 					"db-vacuum",

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -641,245 +641,245 @@
     },
     {
       "path": "db-accessor.ts",
-      "line": 816,
+      "line": 818,
       "api": "readdirSync",
       "source": ".readdirSync(dir)",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 828,
+      "line": 830,
       "api": "lstatSync",
       "source": "const stat = deps.lstatSync(path);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 835,
+      "line": 837,
       "api": "statSync",
       "source": "const stat = deps.statSync(path);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 848,
+      "line": 850,
       "api": "readFileSync",
       "source": "const parsed = JSON.parse(readFileSync(`${backupPath}.verdict.json`, \"utf8\")) as { status?: unknown };",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 890,
+      "line": 892,
       "api": "readFileSync",
       "source": "const parsed = JSON.parse(readFileSync(`${backupPath}.cursor.json`, \"utf8\")) as Partial<MigrationBackupCursor>;",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 916,
+      "line": 918,
       "api": "existsSync",
       "source": "return cursor === undefined && !existsSync(`${backupPath}.cursor.json`);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 944,
+      "line": 946,
       "api": "unlinkSync",
       "source": "deps.unlinkSync(backupPath);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 950,
+      "line": 952,
       "api": "unlinkSync",
       "source": "deps.unlinkSync(`${backupPath}.verdict.json`);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 955,
+      "line": 957,
       "api": "unlinkSync",
       "source": "deps.unlinkSync(`${backupPath}.cursor.json`);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 998,
+      "line": 1000,
       "api": "existsSync",
       "source": "if (!existsSync(dbPath) || !hasPendingMigrations(db as never)) return false;",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 999,
+      "line": 1001,
       "api": "statSync",
       "source": "const source = deps.statSync(dbPath);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1072,
+      "line": 1074,
       "api": "unlinkSync",
       "source": "deps.unlinkSync(backupPath);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1080,
+      "line": 1082,
       "api": "unlinkSync",
       "source": "deps.unlinkSync(`${backupPath}.cursor.json`);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1085,
+      "line": 1087,
       "api": "unlinkSync",
       "source": "deps.unlinkSync(`${backupPath}.verdict.json`);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1100,
+      "line": 1102,
       "api": "statfsSync",
       "source": "const stat = deps.statfsSync(path);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1112,
+      "line": 1114,
       "api": "statSync",
       "source": "const size = deps.statSync(path).size;",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1177,
+      "line": 1181,
       "api": "copyFileSync",
       "source": "deps.copyFileSync(dbPath, backupDest);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1201,
+      "line": 1205,
       "api": "copyFileSync",
       "source": "deps.copyFileSync(dbPath, backupDest);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1227,
+      "line": 1231,
       "api": "statSync",
       "source": "const sourceStat = statSync(dbPath);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1267,
+      "line": 1271,
       "api": "readdirSync",
       "source": "for (const name of readdirSync(dir).filter(",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1285,
+      "line": 1289,
       "api": "lstatSync",
       "source": "destinationStat = lstatSync(destination);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1314,
+      "line": 1318,
       "api": "unlinkSync",
       "source": "unlinkSync(destination);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1321,
+      "line": 1325,
       "api": "unlinkSync",
       "source": "unlinkSync(cursorPath);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1521,
+      "line": 1525,
       "api": "readdirSync",
       "source": "entries = deps.readdirSync(dir);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1539,
+      "line": 1543,
       "api": "unlinkSync",
       "source": "deps.unlinkSync(path);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1561,
+      "line": 1565,
       "api": "statSync",
       "source": "const source = deps.statSync(dbPath);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1606,
+      "line": 1615,
       "api": "unlinkSync",
       "source": "deps.unlinkSync(backupDest);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1615,
+      "line": 1624,
       "api": "unlinkSync",
       "source": "else deps.unlinkSync(backupDest);",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1659,
+      "line": 1668,
       "api": "readdirSync",
       "source": ".readdirSync(dir)",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1667,
+      "line": 1676,
       "api": "unlinkSync",
       "source": "deps.unlinkSync(join(dir, name));",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1793,
+      "line": 1802,
       "api": "existsSync",
       "source": "if (!existsSync(dir)) {",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1794,
+      "line": 1803,
       "api": "mkdirSync",
       "source": "mkdirSync(dir, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1815,
+      "line": 1824,
       "api": "existsSync",
       "source": "if (existsSync(path) && hasPendingMigrations(toMigrationDb(writeConn))) {",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 1826,
+      "line": 1835,
       "api": "existsSync",
       "source": "if (existsSync(path) && hasPendingMigrations(toMigrationDb(writeConn))) {",
       "category": "hot-path"
     },
     {
       "path": "db-accessor.ts",
-      "line": 3001,
+      "line": 3010,
       "api": "withWriteTxAsync",
       "source": "return await accessor.withWriteTxAsync(fn, siteToken === undefined ? options : { ...options, siteToken });",
       "category": "hot-path"
@@ -1019,49 +1019,49 @@
     },
     {
       "path": "db-vacuum.ts",
-      "line": 335,
+      "line": 337,
       "api": "withReadDb",
       "source": "return accessor.withReadDb(",
       "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
-      "line": 343,
+      "line": 345,
       "api": "withReadDbAsync",
       "source": "return await accessor.withReadDbAsync((db) => readStatusFromDb(toPragmaReadDb(db)), {",
       "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
-      "line": 452,
+      "line": 454,
       "api": "incrementalVacuumAsync",
-      "source": "remaining = await accessor.incrementalVacuumAsync({ siteToken: \"db-vacuum.ts:452\" });",
+      "source": "remaining = await accessor.incrementalVacuumAsync({ siteToken: \"db-vacuum.ts:454\" });",
       "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
-      "line": 490,
+      "line": 492,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "db-vacuum.ts",
-      "line": 520,
-      "api": "vacuumConversionAsync",
-      "source": "await accessor.vacuumConversionAsync({ siteToken: \"db-vacuum.ts:520\" });",
       "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
       "line": 522,
+      "api": "vacuumConversionAsync",
+      "source": "await accessor.vacuumConversionAsync({ siteToken: \"db-vacuum.ts:522\" });",
+      "category": "hot-path"
+    },
+    {
+      "path": "db-vacuum.ts",
+      "line": 524,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
       "category": "hot-path"
     },
     {
       "path": "db-vacuum.ts",
-      "line": 540,
+      "line": 542,
       "api": "withWriteTxAsync",
       "source": "await accessor.withWriteTxAsync(",
       "category": "hot-path"


### PR DESCRIPTION
## Summary

Releases 0.214.9 (blocked draft): the macos-15-intel native job fails at daemon startup with
`DbOwnerError: [migration_backup] admission refused (space): ... Database size: 20480 bytes; free: null bytes; required: 134238208 bytes.`
The W3.8 migration-backup disk-space preflight treats a null/unknown statfs free-space value as 0 and fatal-blocks startup — including on real Intel macOS filesystems where the stat cannot produce a number.

## Changes

- Unknown free space (null/undefined/NaN from statfs) is now UNKNOWN, not zero: warn with the raw value and proceed with the migration backup without a space verdict. The preflight guards against filling the disk; it is not an integrity invariant, so unknown must not be fatal.
- A verified low free-space number still fails closed exactly as before.
- Fresh and resumed backup paths both covered; db-vacuum shares the same guard semantics.
- Follow-up c1541ee39: rebase line-derived site tokens in db-vacuum.ts after the space-guard edit and regenerate the event-loop ledger (7 tokens, count unchanged 993, ratchet holds 188).

## Type

- [ ] `feat`
- [x] `fix` — bug fix
- [ ] `refactor`
- [ ] `chore`
- [ ] `perf`
- [ ] `test`

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: daemon-internal preflight

## Screenshots

None — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes

No schema migrations. Startup behavior change: unknown free space no longer blocks migration backup; documented in Summary.