### PR TITLE
fix(daemon): honor paused memory-sidecar boundary

### DIFF
--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -89,14 +89,6 @@ describe("auth guard co-location", () => {
 		return new Hono();
 	}
 
-	it("passes the resolved SQLite runtime to the recall owner", async () => {
-		const { createRecallDbOwnerOptions } = await import("./daemon");
-		expect(createRecallDbOwnerOptions("/tmp/custom-libsqlite3.dylib")).toEqual({
-			dbPath: join(tmpDir, "memory", "memories.db"),
-			sqlitePath: "/tmp/custom-libsqlite3.dylib",
-			workerRole: "recall",
-		});
-	});
 
 	async function status(app: InstanceType<typeof import("hono").Hono>, method: string, path: string): Promise<number> {
 		const res = await app.request(path, { method });
@@ -237,7 +229,7 @@ inference:
 			}
 		});
 
-		it("keeps generic recall failures at HTTP 500", async () => {
+		it("uses the shared dynamic recall owner for generic failures", async () => {
 			const state = await import("./routes/state.js");
 			const { Hono } = await import("hono");
 			const { createAuthMiddleware, createToken } = await import("./auth");
@@ -246,8 +238,15 @@ inference:
 			if (!secret) throw new Error("expected auth secret for team-mode recall test");
 			const token = createToken(secret, { sub: "internal-recall", role: "readonly", scope: {} }, 60);
 			const app = new Hono();
+			const owner = rejectingRecallOwner(new Error("database read failed"));
+			let ownerResolutions = 0;
 			app.use("*", createAuthMiddleware(state.authConfig, secret));
-			registerMemoryRoutes(app, { recallOwner: rejectingRecallOwner(new Error("database read failed")) });
+			registerMemoryRoutes(app, {
+				getRecallOwner: () => {
+					ownerResolutions++;
+					return owner;
+				},
+			});
 			const response = await app.request("/api/memory/recall", {
 				method: "POST",
 				headers: {
@@ -259,7 +258,9 @@ inference:
 
 			expect(response.status).toBe(500);
 			expect(await response.json()).toEqual({ error: "Recall failed", results: [] });
+			expect(ownerResolutions).toBe(1);
 		});
+
 
 		it("records the FTS cause for a partial direct recall", async () => {
 			const state = await import("./routes/state.js");

--- a/platform/daemon/src/daemon-production-wiring.test.ts
+++ b/platform/daemon/src/daemon-production-wiring.test.ts
@@ -31,6 +31,31 @@ describe("daemon production DB owner wiring", () => {
 		expect(source).not.toContain("recallDbOwner");
 	});
 
+	it("does not retain the synthesis worker while the pipeline is paused", async () => {
+		const source = await Bun.file(daemonSourceUrl).text();
+
+		expect(source).toContain("let synthWorker: Worker | null = null;\n\tif (!memoryCfg.pipelineV2.paused) {");
+		expect(source).toContain("new Worker(workerPath);");
+	});
+
+	it("keeps background imports and source indexing dormant while paused", async () => {
+		const source = await Bun.file(daemonSourceUrl).text();
+
+		expect(source).toContain("if (loadMemoryConfig(AGENTS_DIR).pipelineV2.paused) return 0;");
+		expect(source).toContain("nativeMemoryBridgeStartTimer = setTimeout(() => {");
+		expect(source).toContain("clearTimeout(nativeMemoryBridgeStartTimer);");
+		expect(source).not.toContain("ingestedMemoryFiles");
+		expect(source).toContain('if (!startupCfg.pipelineV2.paused && startupCfg.embedding.provider !== "none")');
+		expect(source).toContain(
+			"if (!loadMemoryConfig(AGENTS_DIR).pipelineV2.paused)\n\t\t\t\tvacuumConversionHandle",
+		);
+		expect(source).toContain("const liveMemoryCfg = loadMemoryConfig(AGENTS_DIR);");
+		expect(source).toContain("await startPipelineRuntime(liveMemoryCfg, telemetryCollector);");
+		expect(source).toContain(
+			"if (loadMemoryConfig(AGENTS_DIR).pipelineV2.paused) return;\n\t\ttry {\n\t\t\tawait cleanupSourceDeletionTombstones",
+		);
+	});
+
 	it("keeps post-ready integrity maintenance incremental and checkpointed", async () => {
 		const source = await Bun.file(daemonSourceUrl).text();
 

--- a/platform/daemon/src/daemon-production-wiring.test.ts
+++ b/platform/daemon/src/daemon-production-wiring.test.ts
@@ -81,6 +81,7 @@ describe("daemon production DB owner wiring", () => {
 		expect(source).toContain(
 			"if (!deferredMemoryCfg.pipelineV2.paused)\n\t\t\t\tnativeMemoryBridgeStartTimer = setTimeout",
 		);
+		expect(source).toContain("if (!memoryCfg.pipelineV2.paused) syncAgentRoster(AGENTS_DIR);");
 	});
 
 	it("keeps post-ready integrity maintenance incremental and checkpointed", async () => {

--- a/platform/daemon/src/daemon-production-wiring.test.ts
+++ b/platform/daemon/src/daemon-production-wiring.test.ts
@@ -38,7 +38,7 @@ describe("daemon production DB owner wiring", () => {
 		expect(source).toContain("new Worker(workerPath);");
 	});
 
-	it("keeps background imports and source indexing dormant while paused", async () => {
+	it("keeps autonomous background work dormant while paused", async () => {
 		const source = await Bun.file(daemonSourceUrl).text();
 
 		expect(source).toContain("if (loadMemoryConfig(AGENTS_DIR).pipelineV2.paused) return 0;");
@@ -56,6 +56,13 @@ describe("daemon production DB owner wiring", () => {
 		);
 		expect(source).toContain("const deferredMemoryCfg = loadMemoryConfig(AGENTS_DIR);");
 		expect(source).toContain("resolveEmbeddingBridgeOptions(deferredMemoryCfg.embedding, fetchEmbedding)");
+		expect(source).toContain(
+			"if (!liveMemoryCfg.pipelineV2.paused) {\n\t\t\tschedulerHandle = startSchedulerWorker",
+		);
+		expect(source).toContain("transcriptRecoveryWorkerHandle = startTranscriptRecoveryWorker");
+		expect(source).toContain(
+			"} else if (!pipelinePaused) {\n\t\tensureRetentionWorker(getDbAccessor(), DEFAULT_RETENTION, dbOwnerMaintenanceHandle ?? undefined);",
+		);
 	});
 
 	it("keeps post-ready integrity maintenance incremental and checkpointed", async () => {

--- a/platform/daemon/src/daemon-production-wiring.test.ts
+++ b/platform/daemon/src/daemon-production-wiring.test.ts
@@ -63,6 +63,14 @@ describe("daemon production DB owner wiring", () => {
 		expect(source).toContain(
 			"} else if (!pipelinePaused) {\n\t\tensureRetentionWorker(getDbAccessor(), DEFAULT_RETENTION, dbOwnerMaintenanceHandle ?? undefined);",
 		);
+		expect(source).toContain("if (!pipelinePaused && !transcriptCaptureWorkerHandle)");
+		expect(source).toContain("if (!memoryCfg.pipelineV2.paused) {\n\t\tstartSessionCleanup();");
+		expect(source).toContain(
+			"if (!liveMemoryCfg.pipelineV2.paused) {\n\t\t\tcheckpointPruneTimer = setInterval",
+		);
+		expect(source).toContain(
+			"if (!deferredMemoryCfg.pipelineV2.paused) {\n\t\t\t\tstartStaleSessionSweeper();",
+		);
 	});
 
 	it("keeps post-ready integrity maintenance incremental and checkpointed", async () => {

--- a/platform/daemon/src/daemon-production-wiring.test.ts
+++ b/platform/daemon/src/daemon-production-wiring.test.ts
@@ -54,6 +54,8 @@ describe("daemon production DB owner wiring", () => {
 		expect(source).toContain(
 			"if (loadMemoryConfig(AGENTS_DIR).pipelineV2.paused) return;\n\t\ttry {\n\t\t\tawait cleanupSourceDeletionTombstones",
 		);
+		expect(source).toContain("const deferredMemoryCfg = loadMemoryConfig(AGENTS_DIR);");
+		expect(source).toContain("resolveEmbeddingBridgeOptions(deferredMemoryCfg.embedding, fetchEmbedding)");
 	});
 
 	it("keeps post-ready integrity maintenance incremental and checkpointed", async () => {

--- a/platform/daemon/src/daemon-production-wiring.test.ts
+++ b/platform/daemon/src/daemon-production-wiring.test.ts
@@ -71,6 +71,9 @@ describe("daemon production DB owner wiring", () => {
 		expect(source).toContain(
 			"if (!deferredMemoryCfg.pipelineV2.paused) {\n\t\t\t\tstartStaleSessionSweeper();",
 		);
+		expect(source).toContain(
+			"if (!memoryCfg.pipelineV2.paused) {\n\t\t// Clean accumulated crash-loop damage through the owner.",
+		);
 	});
 
 	it("keeps post-ready integrity maintenance incremental and checkpointed", async () => {

--- a/platform/daemon/src/daemon-production-wiring.test.ts
+++ b/platform/daemon/src/daemon-production-wiring.test.ts
@@ -74,6 +74,13 @@ describe("daemon production DB owner wiring", () => {
 		expect(source).toContain(
 			"if (!memoryCfg.pipelineV2.paused) {\n\t\t// Clean accumulated crash-loop damage through the owner.",
 		);
+		expect(source).toContain("const restoredSessions = restorePersistedSessions();");
+		expect(source).toContain(
+			"if (!memoryCfg.pipelineV2.paused) {\n\t\t\tfor (const source of loadSourcesConfig(AGENTS_DIR).sources)",
+		);
+		expect(source).toContain(
+			"if (!deferredMemoryCfg.pipelineV2.paused)\n\t\t\t\tnativeMemoryBridgeStartTimer = setTimeout",
+		);
 	});
 
 	it("keeps post-ready integrity maintenance incremental and checkpointed", async () => {

--- a/platform/daemon/src/daemon-production-wiring.test.ts
+++ b/platform/daemon/src/daemon-production-wiring.test.ts
@@ -22,6 +22,15 @@ describe("daemon production DB owner wiring", () => {
 		expect(source).toContain("ownerMaintenance: dbOwnerMaintenanceHandle ?? undefined,");
 	});
 
+	it("shares the generic read lane with recall and leaves unused lanes unstarted", async () => {
+		const source = await Bun.file(daemonSourceUrl).text();
+
+		expect(source).toContain("registerMemoryRoutes(app, { getRecallOwner: () => dbOwnerClient ?? undefined });");
+		expect(source).toContain("await dbOwnerClient.initialize(AGENTS_DIR);");
+		expect(source).not.toContain("await dbOwnerClient.start();");
+		expect(source).not.toContain("recallDbOwner");
+	});
+
 	it("keeps post-ready integrity maintenance incremental and checkpointed", async () => {
 		const source = await Bun.file(daemonSourceUrl).text();
 

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -2550,7 +2550,8 @@ async function main() {
 				}
 			} catch {}
 
-			if (!memoryCfg.pipelineV2.paused) {
+			const deferredMemoryCfg = loadMemoryConfig(AGENTS_DIR);
+			if (!deferredMemoryCfg.pipelineV2.paused) {
 				void importExistingMemoryFiles().catch((e) => {
 					const errDetails = e instanceof Error ? { message: e.message, stack: e.stack } : { error: String(e) };
 					logger.error("daemon", "Failed to import existing memory files", undefined, errDetails);
@@ -2562,7 +2563,8 @@ async function main() {
 
 			nativeMemoryBridgeStartTimer = setTimeout(() => {
 				nativeMemoryBridgeStartTimer = null;
-				if (shuttingDown || loadMemoryConfig(AGENTS_DIR).pipelineV2.paused) return;
+				const deferredMemoryCfg = loadMemoryConfig(AGENTS_DIR);
+				if (shuttingDown || deferredMemoryCfg.pipelineV2.paused) return;
 				if (!nativeMemoryBridge) {
 					const startupSourceJobs = new Map<string, string>();
 					for (const source of loadSourcesConfig(AGENTS_DIR).sources) {
@@ -2581,7 +2583,7 @@ async function main() {
 						sourceCleanupEnabled: true,
 						shouldCleanupSource: (source) => source.harness !== "obsidian",
 						sourceGraphEnabled: true,
-						...resolveEmbeddingBridgeOptions(memoryCfg.embedding, fetchEmbedding),
+						...resolveEmbeddingBridgeOptions(deferredMemoryCfg.embedding, fetchEmbedding),
 						onFileIndexed: (event) => {
 							const sourceId = event.source.sourceId;
 							if (!sourceId) return;

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1645,7 +1645,7 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 				transformersRuntimeAssetPath: resolveEmbeddedWorkerPath("embedding-worker-transformers-runtime"),
 			});
 		}
-	} else {
+	} else if (!pipelinePaused) {
 		ensureRetentionWorker(getDbAccessor(), DEFAULT_RETENTION, dbOwnerMaintenanceHandle ?? undefined);
 	}
 
@@ -2333,16 +2333,18 @@ async function main() {
 
 		initCheckpointFlush(getDbAccessor());
 
-		schedulerHandle = startSchedulerWorker(getDbAccessor());
-		if (!transcriptCaptureWorkerHandle) {
-			transcriptCaptureWorkerHandle = await startTranscriptCaptureWorker(getDbAccessor(), AGENTS_DIR);
-		}
-		if (!transcriptRecoveryWorkerHandle) {
-			transcriptRecoveryWorkerHandle = startTranscriptRecoveryWorker(
-				getDbAccessor(),
-				AGENTS_DIR,
-				resolveDaemonAgentId(),
-			);
+		if (!liveMemoryCfg.pipelineV2.paused) {
+			schedulerHandle = startSchedulerWorker(getDbAccessor());
+			if (!transcriptCaptureWorkerHandle) {
+				transcriptCaptureWorkerHandle = await startTranscriptCaptureWorker(getDbAccessor(), AGENTS_DIR);
+			}
+			if (!transcriptRecoveryWorkerHandle) {
+				transcriptRecoveryWorkerHandle = startTranscriptRecoveryWorker(
+					getDbAccessor(),
+					AGENTS_DIR,
+					resolveDaemonAgentId(),
+				);
+			}
 		}
 
 		checkpointPruneTimer = setInterval(() => {

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -2063,10 +2063,10 @@ async function main() {
 				maxCheckpointsPerSession: memoryCfg.pipelineV2.continuity.maxCheckpointsPerSession,
 			}),
 		);
-	}
-	const restoredSessions = restorePersistedSessions();
-	if (restoredSessions.active > 0 || restoredSessions.expired > 0 || restoredSessions.ended > 0) {
-		logger.info("session-tracker", "Restored durable session lifecycle state", restoredSessions);
+		const restoredSessions = restorePersistedSessions();
+		if (restoredSessions.active > 0 || restoredSessions.expired > 0 || restoredSessions.ended > 0) {
+			logger.info("session-tracker", "Restored durable session lifecycle state", restoredSessions);
+		}
 	}
 	logFdSnapshot("post-db-init");
 	startEventLoopMonitor();
@@ -2224,10 +2224,12 @@ async function main() {
 				});
 			}
 		});
-		for (const source of loadSourcesConfig(AGENTS_DIR).sources) {
-			if (source.enabled) {
-				// Server readiness must not wait on best-effort telemetry, but shutdown must drain it.
-				void trackSourceLifecycleWrite(recordSourceConnected(source, resolveDaemonAgentId()));
+		if (!memoryCfg.pipelineV2.paused) {
+			for (const source of loadSourcesConfig(AGENTS_DIR).sources) {
+				if (source.enabled) {
+					// Server readiness must not wait on best-effort telemetry, but shutdown must drain it.
+					void trackSourceLifecycleWrite(recordSourceConnected(source, resolveDaemonAgentId()));
+				}
 			}
 		}
 
@@ -2573,7 +2575,8 @@ async function main() {
 				startAcpDeliveryReconciliation();
 			}
 
-			nativeMemoryBridgeStartTimer = setTimeout(() => {
+			if (!deferredMemoryCfg.pipelineV2.paused)
+				nativeMemoryBridgeStartTimer = setTimeout(() => {
 				nativeMemoryBridgeStartTimer = null;
 				const deferredMemoryCfg = loadMemoryConfig(AGENTS_DIR);
 				if (shuttingDown || deferredMemoryCfg.pipelineV2.paused) return;
@@ -2682,7 +2685,7 @@ async function main() {
 						});
 				}
 			}, 30_000);
-			nativeMemoryBridgeStartTimer.unref?.();
+			nativeMemoryBridgeStartTimer?.unref?.();
 
 			const startupCfg = loadMemoryConfig(AGENTS_DIR);
 			if (!startupCfg.pipelineV2.paused && startupCfg.embedding.provider !== "none") {

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -2074,9 +2074,11 @@ async function main() {
 
 	dbOwnerMaintenanceHandle = createDbOwnerMaintenance({ dbPath: MEMORY_DB, owner: dbOwnerClient });
 	registerDbOwnerMaintenance(dbOwnerMaintenanceHandle);
-	// Clean accumulated crash-loop damage through the owner. This remains a
-	// deferred call, so owner startup and the bounded drain never delay readiness.
-	runStartupRecovery(getDbAccessor(), { owner: dbOwnerClient });
+	if (!memoryCfg.pipelineV2.paused) {
+		// Clean accumulated crash-loop damage through the owner. This remains a
+		// deferred call, so owner startup and the bounded drain never delay readiness.
+		runStartupRecovery(getDbAccessor(), { owner: dbOwnerClient });
+	}
 
 	// Source-deletion cleanup runs in the post-ready deferred lane below. Do not
 	// put it before binding the HTTP server: its lifecycle-state delete uses the

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -367,11 +367,7 @@ setupDashboardRoutes(app);
 
 let watcher: ReturnType<typeof watch> | null = null;
 let nativeMemoryBridge: NativeMemoryBridgeHandle | null = null;
-
-// Fast in-process cache layered on top of the persistent legacy_markdown_imports
-// manifest. The DB manifest is the authoritative restart-safe skip state;
-// this map only avoids duplicate work within a single daemon lifetime.
-const ingestedMemoryFiles = new Map<string, string>();
+let nativeMemoryBridgeStartTimer: NodeJS.Timeout | null = null;
 const LEGACY_MARKDOWN_IMPORTER_VERSION = 1;
 const MEMORY_IMPORT_POLL_MS = 30_000;
 
@@ -877,6 +873,7 @@ function memoryIdFromRememberResponse(value: unknown): string | null {
 }
 
 async function ingestMemoryMarkdown(filePath: string): Promise<number> {
+	if (loadMemoryConfig(AGENTS_DIR).pipelineV2.paused) return 0;
 	if (filePath.endsWith("MEMORY.md")) return 0;
 
 	const filenameWithExt = basename(filePath);
@@ -1017,7 +1014,6 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 	}
 
 	if (transientFailures > 0) {
-		ingestedMemoryFiles.delete(filePath);
 		await writeLegacyMarkdownImportState({
 			filePath,
 			state: fileState,
@@ -1027,7 +1023,6 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 			error: `${transientFailures} transient chunk import failure(s)`,
 		});
 	} else {
-		ingestedMemoryFiles.set(filePath, hash);
 		await writeLegacyMarkdownImportState({
 			filePath,
 			state: fileState,
@@ -1102,6 +1097,7 @@ function sleep(ms: number): Promise<void> {
 function startMemoryImportPoller(): void {
 	if (memoryImportTimer !== null) return;
 	memoryImportTimer = setInterval(() => {
+		if (loadMemoryConfig(AGENTS_DIR).pipelineV2.paused) return;
 		if (memoryImportInFlight) return;
 		memoryImportInFlight = true;
 		importExistingMemoryFiles()
@@ -1776,6 +1772,10 @@ async function cleanup() {
 		clearTimeout(syncTimer);
 		syncTimer = null;
 	}
+	if (nativeMemoryBridgeStartTimer !== null) {
+		clearTimeout(nativeMemoryBridgeStartTimer);
+		nativeMemoryBridgeStartTimer = null;
+	}
 	stopMemoryImportPoller();
 	stopStaleSessionSweeper();
 	stopAcpDeliveryReconciliation();
@@ -2077,20 +2077,23 @@ async function main() {
 	// put it before binding the HTTP server: its lifecycle-state delete uses the
 	// bounded async writer and must not make readiness depend on that queue.
 
+	const memoryCfg = loadMemoryConfig(AGENTS_DIR);
 	const { extensionPath } = getVectorRuntimeStatus();
 	const bundled = join(__dirname, "synthesis-render-worker.js");
 	const workerPath = existsSync(bundled)
 		? bundled
 		: (resolveEmbeddedWorkerPath("synthesis-render-worker") ?? join(__dirname, "synthesis-render-worker.ts"));
 	let synthWorker: Worker | null = null;
-	try {
-		synthWorker = new Worker(workerPath);
-	} catch (err) {
-		logger.warn(
-			"daemon",
-			"synthesis worker creation failed — using sync rendering",
-			err instanceof Error ? err : undefined,
-		);
+	if (!memoryCfg.pipelineV2.paused) {
+		try {
+			synthWorker = new Worker(workerPath);
+		} catch (err) {
+			logger.warn(
+				"daemon",
+				"synthesis worker creation failed — using sync rendering",
+				err instanceof Error ? err : undefined,
+			);
+		}
 	}
 	let synthWorkerReady = false;
 	if (synthWorker) {
@@ -2162,7 +2165,6 @@ async function main() {
 
 	await ensureArchitectureDoc();
 
-	const memoryCfg = loadMemoryConfig(AGENTS_DIR);
 	let telemetryCollector: TelemetryCollector | undefined;
 	if (memoryCfg.pipelineV2.telemetryEnabled && !telemetryDisabledByEnv()) {
 		const posthogApiKey = memoryCfg.pipelineV2.telemetry.posthogApiKey;
@@ -2325,7 +2327,8 @@ async function main() {
 	const startPostReadyRuntime = async (): Promise<void> => {
 		await deferredRuntimeGate.waitForIntegrity();
 		reportStartupGrace();
-		await startPipelineRuntime(memoryCfg, telemetryCollector);
+		const liveMemoryCfg = loadMemoryConfig(AGENTS_DIR);
+		await startPipelineRuntime(liveMemoryCfg, telemetryCollector);
 		logFdSnapshot("post-pipeline");
 
 		initCheckpointFlush(getDbAccessor());
@@ -2407,6 +2410,7 @@ async function main() {
 	// Cleanup is retryable maintenance. It must not hold up pipeline startup if
 	// the async writer is blocked or unavailable.
 	deferredRuntimeScheduler.scheduleMaintenance(async (): Promise<void> => {
+		if (loadMemoryConfig(AGENTS_DIR).pipelineV2.paused) return;
 		try {
 			await cleanupSourceDeletionTombstones(AGENTS_DIR);
 		} catch (error) {
@@ -2457,6 +2461,7 @@ async function main() {
 		});
 		logger.info("daemon", "Daemon ready");
 		deferredRuntimeScheduler.scheduleMaintenance(async (): Promise<void> => {
+			if (loadMemoryConfig(AGENTS_DIR).pipelineV2.paused) return;
 			const maintenance = dbOwnerMaintenanceHandle;
 			if (maintenance === null) throw new Error("DB owner maintenance is unavailable for FTS startup recovery");
 			const result = await completeFtsStartupRecovery({
@@ -2472,10 +2477,12 @@ async function main() {
 		deferredRuntimeScheduler.scheduleIntegrity(async (): Promise<void> => {
 			logFdSnapshot("server-ready");
 			writeDaemonLifecycle(AGENTS_DIR, buildLifecycleRecord("running"));
-			vacuumConversionHandle = startVacuumConversionWorker(getDbAccessor(), { owner: dbOwnerClient ?? undefined });
+			if (!loadMemoryConfig(AGENTS_DIR).pipelineV2.paused)
+				vacuumConversionHandle = startVacuumConversionWorker(getDbAccessor(), { owner: dbOwnerClient ?? undefined });
 			const owner = dbOwnerClient;
 			if (owner === null) throw new Error("DB owner is unavailable for incremental integrity maintenance");
 			const runIntegritySlice = async (): Promise<void> => {
+				if (loadMemoryConfig(AGENTS_DIR).pipelineV2.paused) return;
 				const result = await runIncrementalDatabaseIntegrityCheck({
 					owner,
 					checkpointKey: "database.quick-check",
@@ -2494,7 +2501,10 @@ async function main() {
 						lastObject: result.lastObject,
 					});
 				}
-				if (result.phase === "running" || result.phase === "timed_out" || result.phase === "unavailable") {
+				if (
+					!loadMemoryConfig(AGENTS_DIR).pipelineV2.paused &&
+					(result.phase === "running" || result.phase === "timed_out" || result.phase === "unavailable")
+				) {
 					const timer = setTimeout(
 						() => {
 							void runIntegritySlice().catch((error) => {
@@ -2540,15 +2550,19 @@ async function main() {
 				}
 			} catch {}
 
-			importExistingMemoryFiles().catch((e) => {
-				const errDetails = e instanceof Error ? { message: e.message, stack: e.stack } : { error: String(e) };
-				logger.error("daemon", "Failed to import existing memory files", undefined, errDetails);
-			});
-			startMemoryImportPoller();
+			if (!memoryCfg.pipelineV2.paused) {
+				void importExistingMemoryFiles().catch((e) => {
+					const errDetails = e instanceof Error ? { message: e.message, stack: e.stack } : { error: String(e) };
+					logger.error("daemon", "Failed to import existing memory files", undefined, errDetails);
+				});
+				startMemoryImportPoller();
+			}
 			startStaleSessionSweeper();
 			startAcpDeliveryReconciliation();
 
-			setTimeout(() => {
+			nativeMemoryBridgeStartTimer = setTimeout(() => {
+				nativeMemoryBridgeStartTimer = null;
+				if (shuttingDown || loadMemoryConfig(AGENTS_DIR).pipelineV2.paused) return;
 				if (!nativeMemoryBridge) {
 					const startupSourceJobs = new Map<string, string>();
 					for (const source of loadSourcesConfig(AGENTS_DIR).sources) {
@@ -2654,9 +2668,10 @@ async function main() {
 						});
 				}
 			}, 30_000);
+			nativeMemoryBridgeStartTimer.unref?.();
 
 			const startupCfg = loadMemoryConfig(AGENTS_DIR);
-			if (startupCfg.embedding.provider !== "none") {
+			if (!startupCfg.pipelineV2.paused && startupCfg.embedding.provider !== "none") {
 				checkEmbeddingProvider(startupCfg.embedding)
 					.then((embeddingStatus) => {
 						if (!embeddingStatus.available) {

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -2154,7 +2154,7 @@ async function main() {
 		});
 	}
 
-	syncAgentRoster(AGENTS_DIR);
+	if (!memoryCfg.pipelineV2.paused) syncAgentRoster(AGENTS_DIR);
 
 	invalidateTraversalCache();
 

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1123,6 +1123,7 @@ function stopMemoryImportPoller(): void {
 function startStaleSessionSweeper(): void {
 	if (staleSessionSweepTimer !== null) return;
 	staleSessionSweepTimer = setInterval(() => {
+		if (loadMemoryConfig(AGENTS_DIR).pipelineV2.paused) return;
 		// Keep each timer tick small. The sweep is single-flight and yields
 		// between finalizations, so a large abandoned-session backlog cannot
 		// monopolize the daemon or fan out downstream capture work.
@@ -1148,6 +1149,7 @@ function stopStaleSessionSweeper(): void {
 function startAcpDeliveryReconciliation(): void {
 	if (acpDeliveryReconciliationTimer !== null) return;
 	acpDeliveryReconciliationTimer = setInterval(() => {
+		if (loadMemoryConfig(AGENTS_DIR).pipelineV2.paused) return;
 		try {
 			const reconciled = reconcileAcpDeliveries();
 			if (reconciled > 0) logger.info("daemon", "Reconciled abandoned ACP delivery attempts", { reconciled });
@@ -1534,7 +1536,7 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 	});
 
 	reloadAuthState(AGENTS_DIR);
-	if (!transcriptCaptureWorkerHandle) {
+	if (!pipelinePaused && !transcriptCaptureWorkerHandle) {
 		transcriptCaptureWorkerHandle = await startTranscriptCaptureWorker(getDbAccessor(), AGENTS_DIR);
 	}
 
@@ -2045,20 +2047,23 @@ async function main() {
 	// owner process, not merely behind an async function on this isolate.
 	dbOwnerClient = createDbOwnerClient({ dbPath: MEMORY_DB, sqlitePath: sqliteRuntime.choice?.path });
 	await dbOwnerClient.initialize(AGENTS_DIR);
+	const memoryCfg = loadMemoryConfig(AGENTS_DIR);
 	const { extensionPath: initExtensionPath } = getVectorRuntimeStatus();
 	initDbAccessorLite(MEMORY_DB, initExtensionPath ?? "");
 	setSessionClaimStore(createSessionClaimStore(getDbAccessor()));
-	startSessionCleanup();
-	// Formal TTL lifecycle (#902): when stale-session cleanup evicts a claim
-	// whose harness never sent session-end, checkpoint the residual continuity
-	// state and mark the retained transcript complete instead of silently
-	// dropping the in-memory lifecycle state.
-	setSessionEvictionHandler(
-		createTtlEvictionHandler({
-			accessor: getDbAccessor(),
-			maxCheckpointsPerSession: loadMemoryConfig(AGENTS_DIR).pipelineV2.continuity.maxCheckpointsPerSession,
-		}),
-	);
+	if (!memoryCfg.pipelineV2.paused) {
+		startSessionCleanup();
+		// Formal TTL lifecycle (#902): when stale-session cleanup evicts a claim
+		// whose harness never sent session-end, checkpoint the residual continuity
+		// state and mark the retained transcript complete instead of silently
+		// dropping the in-memory lifecycle state.
+		setSessionEvictionHandler(
+			createTtlEvictionHandler({
+				accessor: getDbAccessor(),
+				maxCheckpointsPerSession: memoryCfg.pipelineV2.continuity.maxCheckpointsPerSession,
+			}),
+		);
+	}
 	const restoredSessions = restorePersistedSessions();
 	if (restoredSessions.active > 0 || restoredSessions.expired > 0 || restoredSessions.ended > 0) {
 		logger.info("session-tracker", "Restored durable session lifecycle state", restoredSessions);
@@ -2077,7 +2082,6 @@ async function main() {
 	// put it before binding the HTTP server: its lifecycle-state delete uses the
 	// bounded async writer and must not make readiness depend on that queue.
 
-	const memoryCfg = loadMemoryConfig(AGENTS_DIR);
 	const { extensionPath } = getVectorRuntimeStatus();
 	const bundled = join(__dirname, "synthesis-render-worker.js");
 	const workerPath = existsSync(bundled)
@@ -2347,19 +2351,21 @@ async function main() {
 			}
 		}
 
-		checkpointPruneTimer = setInterval(() => {
-			try {
-				const cfg = loadMemoryConfig(AGENTS_DIR).pipelineV2.continuity;
-				if (cfg.enabled) {
-					pruneCheckpoints(getDbAccessor(), cfg.retentionDays);
+		if (!liveMemoryCfg.pipelineV2.paused) {
+			checkpointPruneTimer = setInterval(() => {
+				try {
+					const pipelineCfg = loadMemoryConfig(AGENTS_DIR).pipelineV2;
+					if (!pipelineCfg.paused && pipelineCfg.continuity.enabled) {
+						pruneCheckpoints(getDbAccessor(), pipelineCfg.continuity.retentionDays);
+					}
+				} catch (err) {
+					logger.warn("daemon", "Checkpoint pruning failed", {
+						error: err instanceof Error ? err.message : String(err),
+					});
 				}
-			} catch (err) {
-				logger.warn("daemon", "Checkpoint pruning failed", {
-					error: err instanceof Error ? err.message : String(err),
-				});
-			}
-		}, 3600_000);
-		setCheckpointPruneTimer(checkpointPruneTimer);
+			}, 3600_000);
+			setCheckpointPruneTimer(checkpointPruneTimer);
+		}
 
 		startGitSyncTimer();
 		initUpdateSystem(CURRENT_VERSION, AGENTS_DIR, (preferredExecutablePath) => {
@@ -2560,8 +2566,10 @@ async function main() {
 				});
 				startMemoryImportPoller();
 			}
-			startStaleSessionSweeper();
-			startAcpDeliveryReconciliation();
+			if (!deferredMemoryCfg.pipelineV2.paused) {
+				startStaleSessionSweeper();
+				startAcpDeliveryReconciliation();
+			}
 
 			nativeMemoryBridgeStartTimer = setTimeout(() => {
 				nativeMemoryBridgeStartTimer = null;

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -59,7 +59,7 @@ import {
 	type WriteDb,
 } from "./db-accessor";
 import { type VacuumConversionHandle, startVacuumConversionWorker } from "./db-vacuum";
-import { createDbOwnerClient, type DbOwnerClient, type DbOwnerClientOptions } from "./db-owner-client";
+import { createDbOwnerClient, type DbOwnerClient } from "./db-owner-client";
 import { type DbOwnerMaintenance, createDbOwnerMaintenance, registerDbOwnerMaintenance } from "./db-owner-maintenance";
 import { createDeferredRuntimeGate, createDeferredRuntimeScheduler } from "./deferred-runtime-gate";
 import { getQueuePressureSnapshot } from "./diagnostics-queue";
@@ -302,13 +302,6 @@ export const app = new Hono();
 // runtime selected for this daemon instance.
 const sqliteRuntime = resolveSqliteRuntimeConfig({ agentsDir: AGENTS_DIR });
 
-export function createRecallDbOwnerOptions(sqlitePath: string | undefined): DbOwnerClientOptions {
-	return { dbPath: MEMORY_DB, sqlitePath, workerRole: "recall" };
-}
-
-// Recall uses its own child-process lane so request reads never wait behind
-// maintenance or write work in the generic owner.
-const recallDbOwner = createDbOwnerClient(createRecallDbOwnerOptions(sqliteRuntime.choice?.path));
 
 registerGlobalMiddleware(app);
 getOrCreateInferenceRouter(resolveDefaultBasePath());
@@ -317,7 +310,7 @@ mountHealthRoutes(app);
 mountMcpRoute(app);
 registerAuthRoutes(app);
 
-registerMemoryRoutes(app, { recallOwner: recallDbOwner });
+registerMemoryRoutes(app, { getRecallOwner: () => dbOwnerClient ?? undefined });
 registerHooksRoutes(app);
 registerKnowledgeRoutes(app);
 registerOntologyRoutes(app);
@@ -1857,7 +1850,6 @@ async function cleanup() {
 		await dbOwnerClient.close();
 		dbOwnerClient = null;
 	}
-	await recallDbOwner.close();
 	closeDbAccessor();
 
 	if (watcher) {
@@ -2052,7 +2044,6 @@ async function main() {
 	// Expensive schema/FTS/vector initialization must execute in the killable
 	// owner process, not merely behind an async function on this isolate.
 	dbOwnerClient = createDbOwnerClient({ dbPath: MEMORY_DB, sqlitePath: sqliteRuntime.choice?.path });
-	await dbOwnerClient.start();
 	await dbOwnerClient.initialize(AGENTS_DIR);
 	const { extensionPath: initExtensionPath } = getVectorRuntimeStatus();
 	initDbAccessorLite(MEMORY_DB, initExtensionPath ?? "");

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -131,8 +131,10 @@ export interface MemoryRoutesDeps {
 	readonly fetchEmbedding?: typeof fetchEmbedding;
 	readonly getInferenceRouterOrNull?: typeof getInferenceRouterOrNull;
 	readonly memoryCaptureAdmission?: ConcurrencyAdmission;
-	/** Dedicated owner read lane. When set, recall never touches daemon SQLite. */
+	/** Owner read lane. When set, recall never touches daemon SQLite. */
 	readonly recallOwner?: DbOwnerClient;
+	/** Resolves the daemon's shared owner after startup. */
+	readonly getRecallOwner?: () => DbOwnerClient | undefined;
 }
 
 function contentSafetyForInspection(db: ReadDb, agentId: string, memoryId: string, content: unknown) {
@@ -758,11 +760,12 @@ export function createMemoryCaptureAdmissionMiddleware(
 export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): void {
 	const aggregateRecallFn = deps.aggregateRecall ?? aggregateRecall;
 	const hybridRecallFn = deps.hybridRecall ?? hybridRecall;
-	const recallOwner = deps.recallOwner;
+	const resolveRecallOwner = (): DbOwnerClient | undefined => deps.getRecallOwner?.() ?? deps.recallOwner;
 	const routeRecall = async (
 		params: RecallParams,
 		config: ResolvedMemoryConfig,
 		embedFn: Parameters<typeof hybridRecall>[2],
+		recallOwner = resolveRecallOwner(),
 	): Promise<RecallResponse> => {
 		if (recallOwner !== undefined) return await hybridRecallThroughDbOwner(recallOwner, params, config);
 		return await hybridRecallFn(params, config, embedFn);
@@ -3363,6 +3366,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			const denied = await requirePermission("remember", authConfig)(c, () => Promise.resolve());
 			if (denied) return denied;
 		}
+		const recallOwner = resolveRecallOwner();
 
 		const configuredCfg = loadMemoryConfig(AGENTS_DIR);
 		const cfg =
@@ -3440,6 +3444,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 							params,
 							cfg,
 							recallAttributedEmbedFn(fetchEmbeddingFn, agentId, recordRouteOperationFailure(c)),
+							recallOwner,
 						);
 			const requestedMinScore = (body as { readonly minScore?: unknown }).minScore;
 			const returnedResult = applyRecallScoreThreshold(
@@ -3494,6 +3499,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const project = c.req.query("project");
 		const includeRecalled = c.req.query("includeRecalled") ?? c.req.query("include_recalled");
 
+		const recallOwner = resolveRecallOwner();
 		const configuredCfg = loadMemoryConfig(AGENTS_DIR);
 		const cfg = recallOwner !== undefined ? configuredCfg : await withActiveEmbeddingConfig(configuredCfg);
 		const scopeProject = c.get("auth")?.claims?.scope?.project;
@@ -3534,6 +3540,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				params,
 				cfg,
 				recallAttributedEmbedFn(fetchEmbedding, agentId, recordRouteOperationFailure(c)),
+				recallOwner,
 			);
 			recordRecallQaTelemetry({
 				route: "GET /api/memory/search",

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -12,6 +12,7 @@ import {
 import { Hono } from "hono";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 import { dbOwnerBatch, ownerStatement } from "../db-owner-runtime";
+import { loadMemoryConfig } from "../memory-config";
 import { hashNormalizedBody } from "../memory-lineage";
 import type {
 	NativeMemoryBridgeHandle,
@@ -450,6 +451,36 @@ describe("Sources routes", () => {
 
 		await waitFor(() => !!loadSourcesConfig(dir).sources[0]?.lastIndexedAt);
 		expect(loadSourcesConfig(dir).sources[0]?.id).toBe(body.source.id);
+	});
+
+	it("pauses source indexing before bridge startup when the pipeline is paused", async () => {
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			`memory:
+  pipelineV2:
+    paused: true
+`,
+		);
+		expect(loadMemoryConfig(dir).pipelineV2.paused).toBe(true);
+		let syncStarted = false;
+		const res = await makeApp({ onSyncStart: () => (syncStarted = true) }).request("/api/sources/obsidian", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ path: vault, name: "Paused Route Vault" }),
+		});
+
+		expect(res.status).toBe(202);
+		const body = (await res.json()) as { queued: boolean; source: { id: string } };
+		expect(body.queued).toBe(false);
+		await waitFor(() => getSourceIndexJob(body.source.id)?.status === "paused");
+		expect(syncStarted).toBe(false);
+		expect(getSourceIndexJob(body.source.id)).toMatchObject({
+			status: "paused",
+			partial: true,
+			scanned: 0,
+			indexed: 0,
+			pauseReason: "pipeline_paused",
+		});
 	});
 
 	it("reports a provider outage as paused partial progress without stamping freshness", async () => {

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -260,7 +260,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 			recordIndexOperation,
 		});
 
-		return c.json({ source: result.source, created: result.created, indexed: 0, queued: true, job }, 202);
+		return c.json({ source: result.source, created: result.created, indexed: 0, queued: job.status === "queued", job }, 202);
 	});
 
 	app.post("/api/sources/discord", async (c) => {
@@ -320,7 +320,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 			recordIndexOperation,
 		});
 
-		return c.json({ source: result.source, created: result.created, indexed: 0, queued: true, job }, 202);
+		return c.json({ source: result.source, created: result.created, indexed: 0, queued: job.status === "queued", job }, 202);
 	});
 
 	app.get("/api/sources/:sourceId/snapshot", (c) => {
@@ -459,7 +459,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 			recordIndexOperation,
 		});
 
-		return c.json({ source: result.source, created: result.created, indexed: 0, queued: true, job }, 202);
+		return c.json({ source: result.source, created: result.created, indexed: 0, queued: job.status === "queued", job }, 202);
 	});
 
 	app.delete("/api/sources/:sourceId", async (c) => {
@@ -529,6 +529,15 @@ function isSourceImportBlocked(sourceId: string): boolean {
 function enqueueSourceIndexJob(input: SourceIndexJobInput): SourceIndexJob {
 	const job = beginSourceIndexJob(input.source.id);
 	if (job.id.startsWith("source-index:")) routeSourceJobs.set(input.source.id, { job, input });
+	if (loadMemoryConfig(input.agentsDir).pipelineV2.paused) {
+		pauseSourceIndexJob(input.source.id, job.id, {
+			pauseReason: "pipeline_paused",
+			resumeFrontier: null,
+			scanned: job.scanned ?? 0,
+			indexed: job.indexed ?? 0,
+		});
+		return getSourceIndexJob(input.source.id) ?? job;
+	}
 	scheduleSourceIndexJob(input, job, 0);
 	return job;
 }
@@ -561,6 +570,15 @@ async function recordSourceIndexTelemetryBestEffort(
 async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob): Promise<void> {
 	const startedAt = Date.now();
 	const agentId = resolveDaemonAgentId();
+	if (loadMemoryConfig(input.agentsDir).pipelineV2.paused) {
+		pauseSourceIndexJob(input.source.id, job.id, {
+			pauseReason: "pipeline_paused",
+			resumeFrontier: null,
+			scanned: job.scanned ?? 0,
+			indexed: job.indexed ?? 0,
+		});
+		return;
+	}
 	if (isSourceIndexInFlight(input.source.id)) {
 		scheduleSourceIndexJob(input, job, 50);
 		return;
@@ -582,7 +600,8 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 				source: input.source,
 				agentsDir: input.agentsDir,
 				agentId,
-				shouldContinue: () => isCurrentSourceIndexJob(input.source.id, job.id),
+				shouldContinue: () =>
+					!loadMemoryConfig(input.agentsDir).pipelineV2.paused && isCurrentSourceIndexJob(input.source.id, job.id),
 				onProgress: (event) => {
 					if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
 					updateSourceIndexJobProgress(input.source.id, job.id, event);
@@ -596,6 +615,15 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 					}
 				},
 			});
+			if (loadMemoryConfig(input.agentsDir).pipelineV2.paused) {
+				pauseSourceIndexJob(input.source.id, job.id, {
+					pauseReason: "pipeline_paused",
+					resumeFrontier: null,
+					scanned: result.scanned,
+					indexed: result.indexed,
+				});
+				return;
+			}
 			if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
 			if (result.failures.length > 0) {
 				const accepted = Math.max(0, result.indexed - result.failures.length);
@@ -650,11 +678,21 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 					statusMessage: event.status,
 				});
 			},
-			shouldContinue: () => isCurrentSourceIndexJob(input.source.id, job.id),
+			shouldContinue: () =>
+				!loadMemoryConfig(input.agentsDir).pipelineV2.paused && isCurrentSourceIndexJob(input.source.id, job.id),
 		});
 		const indexed = await bridge.syncExisting();
-		if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
 		const syncResult = bridge.getLastSyncResult?.();
+		if (loadMemoryConfig(input.agentsDir).pipelineV2.paused) {
+			pauseSourceIndexJob(input.source.id, job.id, {
+				pauseReason: "pipeline_paused",
+				resumeFrontier: null,
+				scanned: syncResult?.scanned ?? 0,
+				indexed: syncResult?.indexed ?? indexed,
+			});
+			return;
+		}
+		if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
 		const paused = syncResult?.pausedSources.find((result) => result.sourceId === input.source.id);
 		if (syncResult?.status === "paused" && paused) {
 			pauseSourceIndexJob(input.source.id, job.id, {


### PR DESCRIPTION
## Product boundary
Signet is treated here as a **memory sidecar**: one central daemon serves health and explicit memory/session APIs. Indexing, embeddings, synthesis, recovery scans, roster/lifecycle writes, and maintenance are bounded jobs—not boot side effects while the pipeline is paused.

## Change
- Reuse the generic DB read lane for recall and avoid eager generic-lane startup.
- Make `pipelineV2.paused` an admission boundary for startup recovery, persisted-session restoration, agent-roster writes, source lifecycle telemetry, synthesis-worker creation, scheduler, transcript capture/recovery, retention, session TTL cleanup/finalization, checkpoint pruning, legacy Markdown import/polling, delayed native source-bridge timer/sync, embedding health checks, FTS recovery, vacuum, integrity scans, and deferred tombstone purges.
- Reload live memory configuration at deferred pipeline/source admissions and use it for delayed bridge embedding options.
- Cancel pending native-source startup during shutdown.
- Source-add requests while paused persist configuration but return an immediately paused job; no bridge/sync starts. Running jobs re-check pause state.
- Remove an unused process-lifetime legacy-import map.

## Verification
- `bun test src/routes/sources-routes.test.ts --test-name-pattern "pauses source indexing before bridge"`
- `bun test src/daemon-production-wiring.test.ts src/daemon-auth-guard-colocation.test.ts`
- `bun run typecheck` in `platform/daemon`
- `bun run build` in `platform/daemon`
- Isolated paused daemon smoke: `/health/live` was healthy; startup emitted no recovery work; adding an Obsidian source returned `queued:false` and `status:"paused"`; through the 30-second deferred window there was no source indexing, FTS, vacuum, integrity, embedding health, scheduler, transcript capture/recovery, retention, checkpoint pruning, session sweep, roster/lifecycle write, source bridge timer, or startup recovery; graceful stop left no child process.

## Scope
This does not deploy the source daemon or add idle-worker retirement. The observed two DB-owner worker children remain unproven and are not misrepresented as fixed. ACPX child cleanup stays separate in #1716.

## Known unrelated test state
The full `src/routes/sources-routes.test.ts` suite currently has two standalone snapshot-import failures (`expected 200`, received `400`) outside this diff; this PR adds no behavior on those routes.