### PR TITLE
fix(daemon): bound transcript recovery retries

### DIFF
--- a/platform/daemon/build.ts
+++ b/platform/daemon/build.ts
@@ -32,6 +32,7 @@ const targets: Array<{
 	{ entrypoint: "./src/native-memory-source-worker.ts", outfile: "./dist/native-memory-source-worker.js" },
 	{ entrypoint: "./src/pipeline/dreaming-token-worker.ts", outfile: "./dist/dreaming-token-worker.js" },
 	{ entrypoint: "./src/transcript-recovery-child.ts", outfile: "./dist/transcript-recovery-child.js" },
+	{ entrypoint: "./src/transcript-recovery-supervisor.ts", outfile: "./dist/transcript-recovery-supervisor.js" },
 ];
 
 const forceNodeBuild = process.env.FORCE_NODE_BUILD === "1";

--- a/platform/daemon/src/transcript-recovery-supervisor.ts
+++ b/platform/daemon/src/transcript-recovery-supervisor.ts
@@ -1,0 +1,39 @@
+import { spawn } from "node:child_process";
+
+async function main(): Promise<void> {
+	const childPath = process.env.SIGNET_TRANSCRIPT_RECOVERY_CHILD_PATH;
+	if (childPath === undefined) throw new Error("Transcript recovery supervisor child path is missing");
+
+	const child = spawn(process.execPath, [childPath], {
+		env: process.env,
+		stdio: ["ignore", "pipe", "pipe"],
+		detached: process.platform !== "win32",
+	});
+	child.stdout?.pipe(process.stdout);
+	child.stderr?.pipe(process.stderr);
+	if (child.pid !== undefined) process.stdout.write(`${JSON.stringify({ type: "started", pid: child.pid })}\n`);
+	const forward = (signal: NodeJS.Signals): void => {
+		if (process.platform !== "win32" && child.pid !== undefined) {
+			try {
+				process.kill(-child.pid, signal);
+				return;
+			} catch {
+				// The child may have exited between the check and the signal.
+			}
+		}
+		child.kill(signal);
+	};
+	process.once("SIGTERM", () => forward("SIGTERM"));
+	process.once("SIGINT", () => forward("SIGINT"));
+
+	const [code, signal] = await new Promise<[number | null, NodeJS.Signals | null]>((resolve, reject) => {
+		child.once("error", reject);
+		child.once("close", (exitCode, exitSignal) => resolve([exitCode, exitSignal]));
+	});
+	if (signal !== null || code !== 0) process.exitCode = code ?? 1;
+}
+
+void main().catch((error: unknown) => {
+	process.stderr.write(`${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`);
+	process.exitCode = 1;
+});

--- a/platform/daemon/src/transcript-recovery-supervisor.ts
+++ b/platform/daemon/src/transcript-recovery-supervisor.ts
@@ -1,5 +1,7 @@
 import { spawn } from "node:child_process";
 
+const TRANSCRIPT_RECOVERY_CHILD_GRACE_MS = 4_000;
+
 async function main(): Promise<void> {
 	const childPath = process.env.SIGNET_TRANSCRIPT_RECOVERY_CHILD_PATH;
 	if (childPath === undefined) throw new Error("Transcript recovery supervisor child path is missing");
@@ -12,16 +14,37 @@ async function main(): Promise<void> {
 	child.stdout?.pipe(process.stdout);
 	child.stderr?.pipe(process.stderr);
 	if (child.pid !== undefined) process.stdout.write(`${JSON.stringify({ type: "started", pid: child.pid })}\n`);
+
+	let killTimer: ReturnType<typeof setTimeout> | undefined;
+	const killTarget = (): void => {
+		if (child.pid === undefined) return;
+		try {
+			if (process.platform !== "win32") process.kill(-child.pid, "SIGKILL");
+			else child.kill("SIGKILL");
+		} catch {
+			try {
+				child.kill("SIGKILL");
+			} catch {
+				// The target may have exited between the check and escalation.
+			}
+		}
+	};
 	const forward = (signal: NodeJS.Signals): void => {
 		if (process.platform !== "win32" && child.pid !== undefined) {
 			try {
 				process.kill(-child.pid, signal);
-				return;
 			} catch {
-				// The child may have exited between the check and the signal.
+				// The target may have exited between the check and signal.
 			}
 		}
-		child.kill(signal);
+		try {
+			child.kill(signal);
+		} catch {
+			// The target may have exited between the check and signal.
+		}
+		if (killTimer === undefined && (signal === "SIGTERM" || signal === "SIGINT")) {
+			killTimer = setTimeout(killTarget, TRANSCRIPT_RECOVERY_CHILD_GRACE_MS);
+		}
 	};
 	process.once("SIGTERM", () => forward("SIGTERM"));
 	process.once("SIGINT", () => forward("SIGINT"));
@@ -30,6 +53,7 @@ async function main(): Promise<void> {
 		child.once("error", reject);
 		child.once("close", (exitCode, exitSignal) => resolve([exitCode, exitSignal]));
 	});
+	if (killTimer !== undefined) clearTimeout(killTimer);
 	if (signal !== null || code !== 0) process.exitCode = code ?? 1;
 }
 

--- a/platform/daemon/src/transcript-recovery-worker.test.ts
+++ b/platform/daemon/src/transcript-recovery-worker.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { DbOwnerDiedError } from "./db-owner-client";
 import { deriveSessionEndFallbackId } from "./session-end-recovery";
@@ -13,7 +14,6 @@ import {
 	runTranscriptRecoveryScan,
 	parseTranscriptRecoveryResult,
 	startTranscriptRecoveryWorker,
-	TRANSCRIPT_RECOVERY_STOP_GRACE_MS,
 } from "./transcript-recovery-worker";
 
 let dir = "";
@@ -546,9 +546,7 @@ describe("transcript recovery worker", () => {
 		expect(existsSync(pidPath)).toBe(true);
 		const targetPid = Number(readFileSync(pidPath, "utf8"));
 		expect(Number.isInteger(targetPid)).toBe(true);
-		const startedAt = Date.now();
 		await handle.stop();
-		expect(Date.now() - startedAt).toBeGreaterThanOrEqual(TRANSCRIPT_RECOVERY_STOP_GRACE_MS);
 		expect(handle.running).toBe(false);
 		let targetAlive = true;
 		for (let attempt = 0; attempt < 100 && targetAlive; attempt++) {
@@ -561,6 +559,55 @@ describe("transcript recovery worker", () => {
 		}
 		expect(targetAlive).toBe(false);
 	}, 10_000);
+
+	it("kills the recovery target when its PID handshake is delayed", async () => {
+		const childPath = join(dir, "delayed-pid-child.js");
+		const supervisorPath = join(dir, "delayed-pid-supervisor.js");
+		const pidPath = join(dir, "delayed-pid-child.pid");
+		const productionSupervisorPath = join(dirname(fileURLToPath(import.meta.url)), "transcript-recovery-supervisor.ts");
+		writeFileSync(
+			childPath,
+			`require("node:fs").writeFileSync(${JSON.stringify(pidPath)}, String(process.pid)); process.on("SIGTERM", () => {}); setInterval(() => {}, 1_000);`,
+		);
+		writeFileSync(
+			supervisorPath,
+			`const realSupervisorPath = ${JSON.stringify(productionSupervisorPath)}; const originalWrite = process.stdout.write.bind(process.stdout); let delayedStarted = true; process.stdout.write = (chunk) => { if (delayedStarted && String(chunk).includes('"type":"started"')) { delayedStarted = false; setTimeout(() => originalWrite(chunk), 10_000); return true; } return originalWrite(chunk); }; require(realSupervisorPath);`,
+		);
+		const handle = startTranscriptRecoveryWorker(getDbAccessor(), dir, "agent-a", {
+			roots: { claudeCode: claudeRoot, codex: codexRoot },
+			intervalMs: 60_000,
+			childPath,
+			supervisorPath,
+		});
+		let targetPid = 0;
+		for (let attempt = 0; attempt < 100 && targetPid === 0; attempt++) {
+			if (existsSync(pidPath)) targetPid = Number(readFileSync(pidPath, "utf8"));
+			if (targetPid === 0) await Bun.sleep(5);
+		}
+		expect(Number.isInteger(targetPid)).toBe(true);
+		expect(targetPid).toBeGreaterThan(0);
+		try {
+			await handle.stop();
+			let targetAlive = false;
+			for (let attempt = 0; attempt < 100; attempt++) {
+				targetAlive = true;
+				try {
+					process.kill(targetPid, 0);
+				} catch {
+					targetAlive = false;
+					break;
+				}
+				await Bun.sleep(5);
+			}
+			expect(targetAlive).toBe(false);
+		} finally {
+			try {
+				process.kill(targetPid, "SIGKILL");
+			} catch {
+				// The target should already be gone; keep cleanup idempotent.
+			}
+		}
+	}, 20_000);
 
 	it("accepts a result written immediately before the recovery child exits", async () => {
 		const childPath = join(dir, "immediate-exit-child.js");

--- a/platform/daemon/src/transcript-recovery-worker.test.ts
+++ b/platform/daemon/src/transcript-recovery-worker.test.ts
@@ -389,6 +389,33 @@ describe("transcript recovery worker", () => {
 		expect(second.examined).toBe(0);
 	});
 
+	it("bounds fingerprint preload to discovered files despite large history", async () => {
+		const path = join(claudeRoot, "-repo", "bounded-history.jsonl");
+		writeSettled(path, JSON.stringify({ sessionId: "bounded-history", message: { role: "user", content: "bounded" } }));
+		expect((await scan()).enqueued).toBe(1);
+		getDbAccessor().withWriteTx((db) => {
+			const insert = db.prepare(
+				`INSERT INTO transcript_recovery_files (
+					agent_id, source_path, harness, size_bytes, mtime_ms, content_sha256, session_id, last_scanned_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			);
+			for (let index = 0; index < 5_000; index++) {
+				insert.run(
+					"agent-a",
+					`/historical/${index}.jsonl`,
+					"claude-code",
+					1,
+					1,
+					`sha-${index}`,
+					`session-${index}`,
+					"2026-01-01",
+				);
+			}
+		});
+		const result = await scan();
+		expect(result.skippedUnchanged).toBe(1);
+		expect(result.examined).toBe(0);
+	});
 	it("resumes a bounded scan from its durable frontier", async () => {
 		const firstPath = join(claudeRoot, "-repo", "a-frontier.jsonl");
 		const secondPath = join(claudeRoot, "-repo", "b-frontier.jsonl");
@@ -548,6 +575,53 @@ describe("transcript recovery worker", () => {
 		}
 	});
 
+	it("does not reschedule after a successful child scan", async () => {
+		const childPath = join(dir, "counted-child.js");
+		const counterPath = join(dir, "child-runs.txt");
+		const result = {
+			discovered: 0,
+			examined: 0,
+			enqueued: 0,
+			deduplicated: 0,
+			skippedRecent: 0,
+			skippedOversized: 0,
+			skippedUnchanged: 0,
+			skippedInvalid: 0,
+		};
+		writeFileSync(
+			childPath,
+			`require("node:fs").appendFileSync(${JSON.stringify(counterPath)}, "x"); process.stdout.write(${JSON.stringify(`${JSON.stringify({ type: "result", result })}\\n`)}); process.exit(0);`,
+		);
+		const handle = startTranscriptRecoveryWorker(getDbAccessor(), dir, "agent-a", {
+			roots: { claudeCode: claudeRoot, codex: codexRoot },
+			intervalMs: 10,
+			childPath,
+		});
+		await Bun.sleep(100);
+		await handle.stop();
+		expect(readFileSync(counterPath, "utf8")).toBe("x");
+	});
+	it("treats a clean exit without a protocol payload as a terminal success", async () => {
+		const childPath = join(dir, "empty-success-child.js");
+		writeFileSync(childPath, "process.exit(0);");
+		const warnings: string[] = [];
+		const originalWarn = logger.warn;
+		logger.warn = ((category, message) => {
+			warnings.push(`${category}:${message}`);
+		}) as typeof logger.warn;
+		const handle = startTranscriptRecoveryWorker(getDbAccessor(), dir, "agent-a", {
+			roots: { claudeCode: claudeRoot, codex: codexRoot },
+			intervalMs: 10,
+			childPath,
+		});
+		try {
+			await Bun.sleep(100);
+			expect(warnings).toEqual([]);
+		} finally {
+			await handle.stop();
+			logger.warn = originalWarn;
+		}
+	});
 	it("cancels a scan waiting for DB admission", async () => {
 		let admittedResolve!: () => void;
 		const admitted = new Promise<void>((resolve) => {

--- a/platform/daemon/src/transcript-recovery-worker.test.ts
+++ b/platform/daemon/src/transcript-recovery-worker.test.ts
@@ -13,6 +13,7 @@ import {
 	runTranscriptRecoveryScan,
 	parseTranscriptRecoveryResult,
 	startTranscriptRecoveryWorker,
+	TRANSCRIPT_RECOVERY_STOP_GRACE_MS,
 } from "./transcript-recovery-worker";
 
 let dir = "";
@@ -528,6 +529,38 @@ describe("transcript recovery worker", () => {
 		await handle.stop();
 		expect(handle.running).toBe(false);
 	});
+
+	it("escalates to SIGKILL for a SIGTERM-resistant recovery target", async () => {
+		const childPath = join(dir, "sigterm-resistant-child.js");
+		const pidPath = join(dir, "sigterm-resistant-child.pid");
+		writeFileSync(
+			childPath,
+			`require("node:fs").writeFileSync(${JSON.stringify(pidPath)}, String(process.pid)); process.on("SIGTERM", () => {}); setInterval(() => {}, 1_000);`,
+		);
+		const handle = startTranscriptRecoveryWorker(getDbAccessor(), dir, "agent-a", {
+			roots: { claudeCode: claudeRoot, codex: codexRoot },
+			intervalMs: 60_000,
+			childPath,
+		});
+		for (let attempt = 0; attempt < 100 && !existsSync(pidPath); attempt++) await Bun.sleep(5);
+		expect(existsSync(pidPath)).toBe(true);
+		const targetPid = Number(readFileSync(pidPath, "utf8"));
+		expect(Number.isInteger(targetPid)).toBe(true);
+		const startedAt = Date.now();
+		await handle.stop();
+		expect(Date.now() - startedAt).toBeGreaterThanOrEqual(TRANSCRIPT_RECOVERY_STOP_GRACE_MS);
+		expect(handle.running).toBe(false);
+		let targetAlive = true;
+		for (let attempt = 0; attempt < 100 && targetAlive; attempt++) {
+			try {
+				process.kill(targetPid, 0);
+			} catch {
+				targetAlive = false;
+			}
+			if (targetAlive) await Bun.sleep(5);
+		}
+		expect(targetAlive).toBe(false);
+	}, 10_000);
 
 	it("accepts a result written immediately before the recovery child exits", async () => {
 		const childPath = join(dir, "immediate-exit-child.js");

--- a/platform/daemon/src/transcript-recovery-worker.ts
+++ b/platform/daemon/src/transcript-recovery-worker.ts
@@ -235,7 +235,7 @@ async function loadRecoveryFingerprints(
 					has_dead_capture_job?: unknown;
 				}>,
 			{
-				siteToken: "transcript-recovery-worker.ts:193",
+				siteToken: "transcript-recovery-worker.ts:219",
 				operation: "transcript-recovery.load-fingerprints",
 				signal,
 			},
@@ -332,7 +332,7 @@ async function loadFrontiers(
 				.all(agentId) as Array<{ harness: string; root_path: string; cursor_path?: string | null }>;
 			return new Map(rows.map((row) => [`${row.harness}\\0${row.root_path}`, row.cursor_path ?? null]));
 		},
-		{ siteToken: "transcript-recovery-worker.ts:269", operation: "transcript-recovery.load-frontiers", signal },
+		{ siteToken: "transcript-recovery-worker.ts:328", operation: "transcript-recovery.load-frontiers", signal },
 	);
 }
 
@@ -353,7 +353,7 @@ async function saveFrontier(
 					updated_at = excluded.updated_at`,
 			).run(agentId, candidate.harness, candidate.rootPath, cursorPath, new Date().toISOString());
 		},
-		{ siteToken: "transcript-recovery-worker.ts:287", operation: "transcript-recovery.save-frontier", signal },
+		{ siteToken: "transcript-recovery-worker.ts:346", operation: "transcript-recovery.save-frontier", signal },
 	);
 }
 
@@ -371,7 +371,7 @@ async function clearFrontiers(
 				roots.codex,
 			);
 		},
-		{ siteToken: "transcript-recovery-worker.ts:307", operation: "transcript-recovery.clear-frontiers", signal },
+		{ siteToken: "transcript-recovery-worker.ts:366", operation: "transcript-recovery.clear-frontiers", signal },
 	);
 }
 
@@ -489,7 +489,7 @@ export async function runTranscriptRecoveryScan(
 			await dbAccessor.withWriteTxAsync(
 				(db) => markScanned(db, agentId, candidate, contentSha256, skippedSessionId, new Date(nowMs).toISOString()),
 				{
-					siteToken: "transcript-recovery-worker.ts:422",
+					siteToken: "transcript-recovery-worker.ts:489",
 					operation: "transcript-recovery.mark-scanned",
 					signal: options.signal,
 				},
@@ -503,7 +503,7 @@ export async function runTranscriptRecoveryScan(
 		const alreadyCaptured = await dbAccessor.withReadDbAsync(
 			(db) => snapshotAlreadyCaptured(db, agentId, candidate, sessionId, transcript),
 			{
-				siteToken: "transcript-recovery-worker.ts:436",
+				siteToken: "transcript-recovery-worker.ts:503",
 				operation: "transcript-recovery.snapshot-check",
 				signal: options.signal,
 			},
@@ -512,7 +512,7 @@ export async function runTranscriptRecoveryScan(
 			await dbAccessor.withWriteTxAsync(
 				(db) => markScanned(db, agentId, candidate, contentSha256, sessionId, new Date(nowMs).toISOString()),
 				{
-					siteToken: "transcript-recovery-worker.ts:445",
+					siteToken: "transcript-recovery-worker.ts:512",
 					operation: "transcript-recovery.mark-scanned",
 					signal: options.signal,
 				},
@@ -542,7 +542,7 @@ export async function runTranscriptRecoveryScan(
 			await dbAccessor.withWriteTxAsync(
 				(db) => markScanned(db, agentId, candidate, contentSha256, sessionId, new Date(nowMs).toISOString()),
 				{
-					siteToken: "transcript-recovery-worker.ts:475",
+					siteToken: "transcript-recovery-worker.ts:542",
 					operation: "transcript-recovery.mark-scanned",
 					signal: options.signal,
 				},
@@ -600,7 +600,7 @@ export async function runTranscriptRecoveryScan(
 		await dbAccessor.withWriteTxAsync(
 			(db) => markScanned(db, agentId, candidate, contentSha256, sessionId, new Date(nowMs).toISOString()),
 			{
-				siteToken: "transcript-recovery-worker.ts:533",
+				siteToken: "transcript-recovery-worker.ts:600",
 				operation: "transcript-recovery.mark-scanned",
 				signal: options.signal,
 			},

--- a/platform/daemon/src/transcript-recovery-worker.ts
+++ b/platform/daemon/src/transcript-recovery-worker.ts
@@ -18,6 +18,8 @@ export const TRANSCRIPT_RECOVERY_SETTLE_MS = 60_000;
 export const TRANSCRIPT_RECOVERY_MAX_BYTES = 50 * 1024 * 1024;
 export const TRANSCRIPT_RECOVERY_MAX_FILES_PER_SCAN = 50;
 export const TRANSCRIPT_RECOVERY_MAX_DISCOVERED_FILES = 50_000;
+export const TRANSCRIPT_RECOVERY_MAX_RETRY_DELAY_MS = 30 * 60_000;
+export const TRANSCRIPT_RECOVERY_STOP_GRACE_MS = 5_000;
 
 interface RecoveryCandidate {
 	readonly harness: "claude-code" | "codex";
@@ -235,7 +237,7 @@ async function loadRecoveryFingerprints(
 					has_dead_capture_job?: unknown;
 				}>,
 			{
-				siteToken: "transcript-recovery-worker.ts:219",
+				siteToken: "transcript-recovery-worker.ts:221",
 				operation: "transcript-recovery.load-fingerprints",
 				signal,
 			},
@@ -332,7 +334,7 @@ async function loadFrontiers(
 				.all(agentId) as Array<{ harness: string; root_path: string; cursor_path?: string | null }>;
 			return new Map(rows.map((row) => [`${row.harness}\\0${row.root_path}`, row.cursor_path ?? null]));
 		},
-		{ siteToken: "transcript-recovery-worker.ts:328", operation: "transcript-recovery.load-frontiers", signal },
+		{ siteToken: "transcript-recovery-worker.ts:330", operation: "transcript-recovery.load-frontiers", signal },
 	);
 }
 
@@ -353,7 +355,7 @@ async function saveFrontier(
 					updated_at = excluded.updated_at`,
 			).run(agentId, candidate.harness, candidate.rootPath, cursorPath, new Date().toISOString());
 		},
-		{ siteToken: "transcript-recovery-worker.ts:346", operation: "transcript-recovery.save-frontier", signal },
+		{ siteToken: "transcript-recovery-worker.ts:348", operation: "transcript-recovery.save-frontier", signal },
 	);
 }
 
@@ -371,7 +373,7 @@ async function clearFrontiers(
 				roots.codex,
 			);
 		},
-		{ siteToken: "transcript-recovery-worker.ts:366", operation: "transcript-recovery.clear-frontiers", signal },
+		{ siteToken: "transcript-recovery-worker.ts:368", operation: "transcript-recovery.clear-frontiers", signal },
 	);
 }
 
@@ -489,7 +491,7 @@ export async function runTranscriptRecoveryScan(
 			await dbAccessor.withWriteTxAsync(
 				(db) => markScanned(db, agentId, candidate, contentSha256, skippedSessionId, new Date(nowMs).toISOString()),
 				{
-					siteToken: "transcript-recovery-worker.ts:489",
+					siteToken: "transcript-recovery-worker.ts:491",
 					operation: "transcript-recovery.mark-scanned",
 					signal: options.signal,
 				},
@@ -503,7 +505,7 @@ export async function runTranscriptRecoveryScan(
 		const alreadyCaptured = await dbAccessor.withReadDbAsync(
 			(db) => snapshotAlreadyCaptured(db, agentId, candidate, sessionId, transcript),
 			{
-				siteToken: "transcript-recovery-worker.ts:503",
+				siteToken: "transcript-recovery-worker.ts:505",
 				operation: "transcript-recovery.snapshot-check",
 				signal: options.signal,
 			},
@@ -512,7 +514,7 @@ export async function runTranscriptRecoveryScan(
 			await dbAccessor.withWriteTxAsync(
 				(db) => markScanned(db, agentId, candidate, contentSha256, sessionId, new Date(nowMs).toISOString()),
 				{
-					siteToken: "transcript-recovery-worker.ts:512",
+					siteToken: "transcript-recovery-worker.ts:514",
 					operation: "transcript-recovery.mark-scanned",
 					signal: options.signal,
 				},
@@ -542,7 +544,7 @@ export async function runTranscriptRecoveryScan(
 			await dbAccessor.withWriteTxAsync(
 				(db) => markScanned(db, agentId, candidate, contentSha256, sessionId, new Date(nowMs).toISOString()),
 				{
-					siteToken: "transcript-recovery-worker.ts:542",
+					siteToken: "transcript-recovery-worker.ts:544",
 					operation: "transcript-recovery.mark-scanned",
 					signal: options.signal,
 				},
@@ -600,7 +602,7 @@ export async function runTranscriptRecoveryScan(
 		await dbAccessor.withWriteTxAsync(
 			(db) => markScanned(db, agentId, candidate, contentSha256, sessionId, new Date(nowMs).toISOString()),
 			{
-				siteToken: "transcript-recovery-worker.ts:600",
+				siteToken: "transcript-recovery-worker.ts:602",
 				operation: "transcript-recovery.mark-scanned",
 				signal: options.signal,
 			},
@@ -647,7 +649,29 @@ export function startTranscriptRecoveryWorker(
 			timer = null;
 			void scan();
 		}, retryDelayMs);
-		retryDelayMs = Math.min(retryDelayMs * 2, TRANSCRIPT_RECOVERY_INTERVAL_MS);
+		retryDelayMs = Math.min(retryDelayMs * 2, TRANSCRIPT_RECOVERY_MAX_RETRY_DELAY_MS);
+	};
+
+	const signalActiveProcesses = (signal: NodeJS.Signals): void => {
+		if (activeTargetPid !== null) {
+			try {
+				if (process.platform !== "win32") process.kill(-activeTargetPid, signal);
+			} catch {
+				// The target may have exited between the check and kill.
+			}
+			try {
+				process.kill(activeTargetPid, signal);
+			} catch {
+				// The target may have exited between the group and direct kills.
+			}
+		}
+		if (activeChild !== null) {
+			try {
+				activeChild.kill(signal);
+			} catch {
+				// The supervisor may have exited between the check and kill.
+			}
+		}
 	};
 
 	const runChild = async (): Promise<TranscriptRecoveryScanResult> => {
@@ -759,22 +783,23 @@ export function startTranscriptRecoveryWorker(
 			cancellation.abort();
 			if (timer) clearTimeout(timer);
 			timer = null;
-			if (activeTargetPid !== null && process.platform !== "win32") {
-				try {
-					process.kill(-activeTargetPid, "SIGTERM");
-				} catch {
-					// The target may have exited between the check and kill.
-				}
-			}
-			if (activeChild !== null) {
-				try {
-					activeChild.kill("SIGTERM");
-				} catch {
-					// The child may have exited between the check and kill.
-				}
-			}
-			if (activeScan !== null) {
-				await Promise.race([activeScan, new Promise<void>((resolve) => setTimeout(resolve, 5_000))]);
+			const scanToStop = activeScan;
+			if (scanToStop === null) return;
+			signalActiveProcesses("SIGTERM");
+			let graceTimer: ReturnType<typeof setTimeout> | undefined;
+			const stoppedGracefully = await Promise.race([
+				scanToStop.then(
+					() => true,
+					() => true,
+				),
+				new Promise<boolean>((resolve) => {
+					graceTimer = setTimeout(() => resolve(false), TRANSCRIPT_RECOVERY_STOP_GRACE_MS);
+				}),
+			]);
+			if (graceTimer !== undefined) clearTimeout(graceTimer);
+			if (!stoppedGracefully) {
+				signalActiveProcesses("SIGKILL");
+				await scanToStop;
 			}
 		},
 		nudge(): void {

--- a/platform/daemon/src/transcript-recovery-worker.ts
+++ b/platform/daemon/src/transcript-recovery-worker.ts
@@ -73,6 +73,18 @@ export function parseTranscriptRecoveryResult(output: string): TranscriptRecover
 	return null;
 }
 
+function parseTranscriptRecoveryChildPid(output: string): number | null {
+	for (const line of output.split("\n")) {
+		try {
+			const event = JSON.parse(line) as { type?: string; pid?: unknown };
+			if (event.type === "started" && typeof event.pid === "number" && Number.isInteger(event.pid)) return event.pid;
+		} catch {
+			// Logger output is not part of the child protocol.
+		}
+	}
+	return null;
+}
+
 export interface TranscriptRecoveryWorkerHandle {
 	stop(): Promise<void>;
 	nudge(): void;
@@ -85,6 +97,8 @@ type TranscriptRecoveryWorkerOptions = TranscriptRecoveryScanOptions & {
 	readonly intervalMs?: number;
 	/** Test-only child entrypoint used to exercise the stdio/close protocol deterministically. */
 	readonly childPath?: string;
+	/** Test-only supervisor entrypoint; production uses the bundled supervisor. */
+	readonly supervisorPath?: string;
 };
 
 function defaultRoots(): TranscriptRecoveryRoots {
@@ -183,15 +197,60 @@ function readMetadata(candidate: RecoveryCandidate, raw: string): TranscriptMeta
 	};
 }
 
-function unchanged(db: ReadDb, agentId: string, candidate: RecoveryCandidate): boolean {
-	const row = db
-		.prepare(
-			`SELECT size_bytes, mtime_ms
-			 FROM transcript_recovery_files
-			 WHERE agent_id = ? AND source_path = ?`,
-		)
-		.get(agentId, candidate.path) as { size_bytes?: unknown; mtime_ms?: unknown } | undefined;
-	return row?.size_bytes === candidate.size && row.mtime_ms === Math.trunc(candidate.mtimeMs);
+const RECOVERY_FINGERPRINT_BATCH_SIZE = 400;
+
+interface RecoveryFingerprint {
+	readonly sizeBytes: number;
+	readonly mtimeMs: number;
+	readonly hasDeadCaptureJob: boolean;
+}
+
+async function loadRecoveryFingerprints(
+	dbAccessor: DbAccessor,
+	agentId: string,
+	candidates: readonly RecoveryCandidate[],
+	signal?: AbortSignal,
+): Promise<Map<string, RecoveryFingerprint>> {
+	const fingerprints = new Map<string, RecoveryFingerprint>();
+	for (let offset = 0; offset < candidates.length; offset += RECOVERY_FINGERPRINT_BATCH_SIZE) {
+		throwIfAborted(signal);
+		const paths = candidates.slice(offset, offset + RECOVERY_FINGERPRINT_BATCH_SIZE).map((candidate) => candidate.path);
+		const placeholders = paths.map(() => "?").join(", ");
+		const rows = await dbAccessor.withReadDbAsync(
+			(db) =>
+				db
+					.prepare(
+						`SELECT f.source_path, f.size_bytes, f.mtime_ms,
+								EXISTS(
+									SELECT 1 FROM transcript_capture_jobs AS j
+									 WHERE j.agent_id = f.agent_id AND j.session_id = f.session_id AND j.status = 'dead'
+								) AS has_dead_capture_job
+						 FROM transcript_recovery_files AS f
+						 WHERE f.agent_id = ? AND f.source_path IN (${placeholders})`,
+					)
+					.all(agentId, ...paths) as Array<{
+					source_path?: unknown;
+					size_bytes?: unknown;
+					mtime_ms?: unknown;
+					has_dead_capture_job?: unknown;
+				}>,
+			{
+				siteToken: "transcript-recovery-worker.ts:193",
+				operation: "transcript-recovery.load-fingerprints",
+				signal,
+			},
+		);
+		for (const row of rows) {
+			if (typeof row.source_path !== "string" || typeof row.size_bytes !== "number" || typeof row.mtime_ms !== "number")
+				continue;
+			fingerprints.set(row.source_path, {
+				sizeBytes: row.size_bytes,
+				mtimeMs: row.mtime_ms,
+				hasDeadCaptureJob: row.has_dead_capture_job === 1 || row.has_dead_capture_job === true,
+			});
+		}
+	}
+	return fingerprints;
 }
 
 function snapshotAlreadyCaptured(
@@ -357,9 +416,17 @@ export async function runTranscriptRecoveryScan(
 	const discoveryComplete = claudeDiscoveryComplete && codexDiscoveryComplete;
 	candidates.sort((a, b) => a.path.localeCompare(b.path));
 	const frontiers = await loadFrontiers(dbAccessor, agentId, options.signal);
+	const fingerprints = await loadRecoveryFingerprints(dbAccessor, agentId, candidates, options.signal);
 	const resumableCandidates = candidates.filter((candidate) => {
 		const cursor = frontiers.get(frontierKey(candidate));
-		return cursor === undefined || cursor === null || candidate.path > cursor;
+		if (cursor === undefined || cursor === null || candidate.path > cursor) return true;
+		const fingerprint = fingerprints.get(candidate.path);
+		return (
+			fingerprint === undefined ||
+			fingerprint.hasDeadCaptureJob ||
+			fingerprint.sizeBytes !== candidate.size ||
+			fingerprint.mtimeMs !== Math.trunc(candidate.mtimeMs)
+		);
 	});
 
 	let examined = 0;
@@ -382,12 +449,12 @@ export async function runTranscriptRecoveryScan(
 			await saveFrontier(dbAccessor, agentId, candidate, candidate.path, options.signal);
 			continue;
 		}
+		const fingerprint = fingerprints.get(candidate.path);
 		if (
-			await dbAccessor.withReadDbAsync((db) => unchanged(db, agentId, candidate), {
-				siteToken: "transcript-recovery-worker.ts:386",
-				operation: "transcript-recovery.unchanged",
-				signal: options.signal,
-			})
+			fingerprint !== undefined &&
+			!fingerprint.hasDeadCaptureJob &&
+			fingerprint.sizeBytes === candidate.size &&
+			fingerprint.mtimeMs === Math.trunc(candidate.mtimeMs)
 		) {
 			skippedUnchanged++;
 			await saveFrontier(dbAccessor, agentId, candidate, candidate.path, options.signal);
@@ -471,7 +538,7 @@ export async function runTranscriptRecoveryScan(
 			existingTranscript?.completedAt !== undefined &&
 			transcript.length > existingTranscript.content.length &&
 			transcript.includes(existingTranscript.content);
-		if (existingTranscript?.completedAt && !completedSnapshotExtendsCanonical) {
+		if (existingTranscript?.completedAt && !completedSnapshotExtendsCanonical && !fingerprint?.hasDeadCaptureJob) {
 			await dbAccessor.withWriteTxAsync(
 				(db) => markScanned(db, agentId, candidate, contentSha256, sessionId, new Date(nowMs).toISOString()),
 				{
@@ -565,35 +632,45 @@ export function startTranscriptRecoveryWorker(
 ): TranscriptRecoveryWorkerHandle {
 	let stopped = false;
 	let running = false;
+	let completed = false;
 	let timer: ReturnType<typeof setTimeout> | null = null;
 	let activeScan: Promise<void> | null = null;
 	let activeChild: ChildProcess | null = null;
+	let activeTargetPid: number | null = null;
 	const cancellation = new AbortController();
 	const execution = options.execution ?? "child";
+	let retryDelayMs = options.intervalMs ?? TRANSCRIPT_RECOVERY_INTERVAL_MS;
 
-	const schedule = (delayMs: number): void => {
-		if (stopped || timer) return;
+	const scheduleRetry = (): void => {
+		if (stopped || completed || timer) return;
 		timer = setTimeout(() => {
 			timer = null;
 			void scan();
-		}, delayMs);
+		}, retryDelayMs);
+		retryDelayMs = Math.min(retryDelayMs * 2, TRANSCRIPT_RECOVERY_INTERVAL_MS);
 	};
 
 	const runChild = async (): Promise<TranscriptRecoveryScanResult> => {
 		const childName = fileURLToPath(import.meta.url).endsWith(".ts")
 			? "transcript-recovery-child.ts"
 			: "transcript-recovery-child.js";
+		const supervisorName = fileURLToPath(import.meta.url).endsWith(".ts")
+			? "transcript-recovery-supervisor.ts"
+			: "transcript-recovery-supervisor.js";
 		const childPath = options.childPath ?? join(dirname(fileURLToPath(import.meta.url)), childName);
+		const supervisorPath = options.supervisorPath ?? join(dirname(fileURLToPath(import.meta.url)), supervisorName);
 		const {
 			intervalMs: _intervalMs,
 			signal: _signal,
 			execution: _execution,
 			childPath: _childPath,
+			supervisorPath: _supervisorPath,
 			...scanOptions
 		} = options;
-		const child = spawn(process.execPath, [childPath], {
+		const child = spawn(process.execPath, [supervisorPath], {
 			env: {
 				...process.env,
+				SIGNET_TRANSCRIPT_RECOVERY_CHILD_PATH: childPath,
 				SIGNET_TRANSCRIPT_RECOVERY_INPUT: JSON.stringify({ basePath, agentId, options: scanOptions }),
 			},
 			stdio: ["ignore", "pipe", "pipe"],
@@ -613,12 +690,26 @@ export function startTranscriptRecoveryWorker(
 				// child may write its result and exit in the same turn; resolving from
 				// `data` or rejecting from `exit` races the final stdout delivery.
 				output += chunk;
+				activeTargetPid = parseTranscriptRecoveryChildPid(output) ?? activeTargetPid;
 			});
 			child.on("error", (error) => settle(() => reject(error)));
 			child.on("close", (code, signal) => {
 				const result = parseTranscriptRecoveryResult(output);
-				if (result !== null) {
-					settle(() => resolve(result));
+				if (code === 0 && signal === null) {
+					settle(() =>
+						resolve(
+							result ?? {
+								discovered: 0,
+								examined: 0,
+								enqueued: 0,
+								deduplicated: 0,
+								skippedRecent: 0,
+								skippedOversized: 0,
+								skippedUnchanged: 0,
+								skippedInvalid: 0,
+							},
+						),
+					);
 					return;
 				}
 				const detail = signal === null ? `exit code ${code ?? "unknown"}` : `signal ${signal}`;
@@ -642,6 +733,7 @@ export function startTranscriptRecoveryWorker(
 				if (result.enqueued > 0 || result.deduplicated > 0) {
 					logger.info("transcripts", "Transcript recovery scan complete", { ...result });
 				}
+				completed = true;
 			} catch (error) {
 				if (cancellation.signal.aborted || stopped) return;
 				logger.warn("transcripts", "Transcript recovery scan failed", {
@@ -654,8 +746,9 @@ export function startTranscriptRecoveryWorker(
 		} finally {
 			activeScan = null;
 			activeChild = null;
+			activeTargetPid = null;
 			running = false;
-			schedule(options.intervalMs ?? TRANSCRIPT_RECOVERY_INTERVAL_MS);
+			if (!completed) scheduleRetry();
 		}
 	};
 
@@ -666,16 +759,27 @@ export function startTranscriptRecoveryWorker(
 			cancellation.abort();
 			if (timer) clearTimeout(timer);
 			timer = null;
+			if (activeTargetPid !== null && process.platform !== "win32") {
+				try {
+					process.kill(-activeTargetPid, "SIGTERM");
+				} catch {
+					// The target may have exited between the check and kill.
+				}
+			}
 			if (activeChild !== null) {
 				try {
-					activeChild.kill("SIGKILL");
+					activeChild.kill("SIGTERM");
 				} catch {
 					// The child may have exited between the check and kill.
 				}
 			}
-			await activeScan;
+			if (activeScan !== null) {
+				await Promise.race([activeScan, new Promise<void>((resolve) => setTimeout(resolve, 5_000))]);
+			}
 		},
 		nudge(): void {
+			completed = false;
+			retryDelayMs = options.intervalMs ?? TRANSCRIPT_RECOVERY_INTERVAL_MS;
 			if (timer) clearTimeout(timer);
 			timer = null;
 			queueMicrotask(() => void scan());
@@ -684,7 +788,7 @@ export function startTranscriptRecoveryWorker(
 			return !stopped;
 		},
 		get childPid(): number | null {
-			return activeChild?.pid ?? null;
+			return activeTargetPid ?? activeChild?.pid ?? null;
 		},
 	};
 }

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -6682,63 +6682,63 @@
     },
     {
       "path": "transcript-recovery-worker.ts",
-      "line": 269,
+      "line": 221,
+      "api": "withReadDbAsync",
+      "source": "const rows = await dbAccessor.withReadDbAsync(",
+      "category": "hot-path"
+    },
+    {
+      "path": "transcript-recovery-worker.ts",
+      "line": 330,
       "api": "withReadDbAsync",
       "source": "return dbAccessor.withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "transcript-recovery-worker.ts",
-      "line": 287,
+      "line": 348,
       "api": "withWriteTxAsync",
       "source": "await dbAccessor.withWriteTxAsync(",
       "category": "hot-path"
     },
     {
       "path": "transcript-recovery-worker.ts",
-      "line": 307,
+      "line": 368,
       "api": "withWriteTxAsync",
       "source": "await dbAccessor.withWriteTxAsync(",
       "category": "hot-path"
     },
     {
       "path": "transcript-recovery-worker.ts",
-      "line": 386,
-      "api": "withReadDbAsync",
-      "source": "await dbAccessor.withReadDbAsync((db) => unchanged(db, agentId, candidate), {",
-      "category": "hot-path"
-    },
-    {
-      "path": "transcript-recovery-worker.ts",
-      "line": 422,
+      "line": 491,
       "api": "withWriteTxAsync",
       "source": "await dbAccessor.withWriteTxAsync(",
       "category": "hot-path"
     },
     {
       "path": "transcript-recovery-worker.ts",
-      "line": 436,
+      "line": 505,
       "api": "withReadDbAsync",
       "source": "const alreadyCaptured = await dbAccessor.withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "transcript-recovery-worker.ts",
-      "line": 445,
+      "line": 514,
       "api": "withWriteTxAsync",
       "source": "await dbAccessor.withWriteTxAsync(",
       "category": "hot-path"
     },
     {
       "path": "transcript-recovery-worker.ts",
-      "line": 475,
+      "line": 544,
       "api": "withWriteTxAsync",
       "source": "await dbAccessor.withWriteTxAsync(",
       "category": "hot-path"
     },
     {
       "path": "transcript-recovery-worker.ts",
-      "line": 533,
+      "line": 602,
       "api": "withWriteTxAsync",
       "source": "await dbAccessor.withWriteTxAsync(",
       "category": "hot-path"


### PR DESCRIPTION
## Summary

- Treat a clean transcript-recovery child exit as success, including the exit-0/stdout protocol race, and stop retrying after a successful pass.
- Add an isolated supervisor that owns and reaps the scan child, forwards termination to its process group, and exposes the target PID for lifecycle cleanup.
- Bound fingerprint lookup to discovered paths in 400-row batches while preserving changed-file and dead-job retries.

Closes the transcript-recovery exit-0 misclassification, zombie accumulation, repeated successful rescans, and unbounded historical fingerprint preload described in W3.4x-FIX (root cause of the 0.214.1-.11 live wedges; evidence: /mnt/work/hermes-scratch/w34-regate5-forensics/).

## Changes

- transcript-recovery-worker.ts: exit-0 success classification, candidate-scoped batched fingerprint preload (400 rows), terminal state after successful pass, backoff on the reschedule path.
- transcript-recovery-supervisor.ts: child ownership + guaranteed reap, process-group termination forwarding.
- Site tokens rebased after the retry-bounding edit (a02548aa8) so the Event-loop Contract Audit passes at head.

## Type

- [ ] `feat`
- [x] `fix` — bug fix
- [ ] `refactor`
- [ ] `chore`
- [ ] `perf`
- [ ] `test`

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: daemon-internal recovery lifecycle

## Screenshots

None — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Verification

- `bun test platform/daemon/src/transcript-recovery-worker.test.ts` (20 pass)
- `bun run --filter '@signet/daemon' typecheck`
- `bun run --filter '@signet/daemon' build`
- `bunx biome check` on changed files
- `git diff --check`
- Event-loop Contract Audit green at head a02548aa8 (site tokens rebased)

## Migration Notes

No schema migrations.