### PR TITLE
fix(daemon): reap ACPX workers before re-admission (supersedes #1716)

### DIFF
--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -22,6 +22,7 @@ import {
 	configureLlmConcurrency,
 	createAcpxProvider,
 	getLlmConcurrencyStatus,
+	waitForAcpxCleanup,
 	withLlmConcurrency,
 } from "./provider";
 import { logger } from "../logger";
@@ -143,14 +144,14 @@ printf '  acpx answer  \\n'
 			expect(readFileSync(promptPath, "utf-8")).toBe("hello acpx");
 			expect(readFileSync(hooksPath, "utf-8")).toBe("1|false");
 			expect(readFileSync(cwdPath, "utf-8")).toBe(realpathSync(join(root, ".daemon", "acpx-background")));
-			await expect(createAcpxProvider({ agent: "codex", bin, terminal: "disabled" }).generate("hello", { timeoutMs: 1000 })).resolves.toBe(
-				"acpx answer",
-			);
+			await expect(
+				createAcpxProvider({ agent: "codex", bin, terminal: "disabled" }).generate("hello", { timeoutMs: 1000 }),
+			).resolves.toBe("acpx answer");
 			expect(readFileSync(argsPath, "utf-8").trim().split("\n")).toContain("--no-terminal");
 			for (const terminal of [true, "inherit"] as const) {
-				await expect(createAcpxProvider({ agent: "codex", bin, terminal }).generate("hello", { timeoutMs: 1000 })).resolves.toBe(
-					"acpx answer",
-				);
+				await expect(
+					createAcpxProvider({ agent: "codex", bin, terminal }).generate("hello", { timeoutMs: 1000 }),
+				).resolves.toBe("acpx answer");
 				expect(readFileSync(argsPath, "utf-8").trim().split("\n")).not.toContain("--no-terminal");
 			}
 		} finally {
@@ -828,6 +829,42 @@ printf 'ok\\n'
 		}
 	});
 
+	it("regression: same-agent admission serializes spawn before the global permit", async () => {
+		const root = join(tmpdir(), `signet-acpx-admission-toctou-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		const bin = join(root, "fake-acpx.sh");
+		const startsPath = join(root, "starts.txt");
+		mkdirSync(root, { recursive: true });
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+prompt=$(cat)
+printf '%s\\n' "$prompt" >> ${JSON.stringify(startsPath)}
+if [[ "$prompt" == "first" ]]; then sleep 0.3; fi
+printf '%s\\n' "$prompt"
+`,
+		);
+		chmodSync(bin, 0o755);
+		const previousConcurrencyLimit = getLlmConcurrencyStatus().limit;
+		let first: Promise<string> | undefined;
+		let second: Promise<string> | undefined;
+		try {
+			configureLlmConcurrency(2);
+			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
+			first = provider.generate("first", { timeoutMs: 3_000 });
+			await waitForPath(startsPath);
+			second = provider.generate("second", { timeoutMs: 3_000 });
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			expect(readFileSync(startsPath, "utf-8").trim().split("\n")).toEqual(["first"]);
+			await expect(first).resolves.toBe("first");
+			await expect(second).resolves.toBe("second");
+			expect(readFileSync(startsPath, "utf-8").trim().split("\n")).toEqual(["first", "second"]);
+		} finally {
+			await Promise.allSettled([first, second]);
+			configureLlmConcurrency(previousConcurrencyLimit);
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("regression: same-agent cleanup re-admission does not hold the only global permit", async () => {
 		const root = join(tmpdir(), `signet-acpx-cleanup-readmit-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		const procRoot = join(root, "proc");
@@ -881,9 +918,6 @@ printf '%s\\n' "$prompt"
 			first = codex.generate("first", { timeoutMs: 3_000 });
 			sameAgent = codex.generate("same-agent", { timeoutMs: 3_000 });
 			unrelated = claude.generate("unrelated", { timeoutMs: 3_000 });
-			await waitForLlmConcurrencyStatus(1, 3);
-			expect(getLlmConcurrencyStatus().pending).toBe(3);
-
 			releaseBlocker.resolve();
 			await blocker;
 			await waitForPath(join(escapedProc, "cmdline"));
@@ -1092,6 +1126,7 @@ printf 'ok\\n'
 		try {
 			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
 			await expect(provider.generate("hello", { timeoutMs: 1000 })).resolves.toBe("ok");
+			await waitForAcpxCleanup("codex");
 		} finally {
 			process.kill = previousKill;
 			logger.warn = previousWarn;
@@ -1150,6 +1185,7 @@ printf 'ok\\n'
 		try {
 			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
 			await expect(provider.generate("hello", { timeoutMs: 1000 })).resolves.toBe("ok");
+			await waitForAcpxCleanup("codex");
 		} finally {
 			process.kill = previousKill;
 			logger.warn = previousWarn;
@@ -1228,6 +1264,7 @@ printf 'ok\\n'
 		try {
 			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
 			await expect(provider.generate("hello", { timeoutMs: 5000 })).resolves.toBe("ok");
+			await waitForAcpxCleanup("codex");
 			psCallCount = Number(readFileSync(psCalls, "utf-8").trim());
 		} finally {
 			process.kill = previousKill;
@@ -1300,6 +1337,7 @@ printf 'ok\\n'
 		try {
 			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
 			await expect(provider.generate("hello", { timeoutMs: 5_000 })).resolves.toBe("ok");
+			await waitForAcpxCleanup("codex");
 			elapsedMs = performance.now() - startedAt;
 			spawnedPids = readSpawnedPids();
 		} finally {
@@ -1366,7 +1404,9 @@ sleep 30
 		chmodSync(bin, 0o755);
 		const writer = nodeSpawn("bash", ["-c", `sleep 0.25; printf 'not-codex\\0' > ${JSON.stringify(cmdlinePath)}`]);
 		const writerClosed =
-			writer.exitCode === null ? new Promise<void>((resolve) => writer.once("close", () => resolve())) : Promise.resolve();
+			writer.exitCode === null
+				? new Promise<void>((resolve) => writer.once("close", () => resolve()))
+				: Promise.resolve();
 		const previousProcRoot = process.env.SIGNET_ACPX_PROC_ROOT;
 		const previousPlatform = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
 		process.env.SIGNET_ACPX_PROC_ROOT = procRoot;
@@ -1592,7 +1632,6 @@ printf 'ok\n'
 		}
 	});
 
-
 	it("regression: timeout starts escaped-stdio cleanup but releases its permit after a bounded termination wait", async () => {
 		const root = join(tmpdir(), `signet-acpx-escaped-stdio-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		const procRoot = join(root, "proc");
@@ -1681,7 +1720,9 @@ touch ${JSON.stringify(holderReadyPath)}
 
 			await cleanupStarted.promise;
 			retry = provider.generate("retry", { timeoutMs: 5_000 });
-			unrelated = createAcpxProvider({ agent: "claude-code", bin, hooks: "disabled" }).generate("unrelated", { timeoutMs: 5_000 });
+			unrelated = createAcpxProvider({ agent: "claude-code", bin, hooks: "disabled" }).generate("unrelated", {
+				timeoutMs: 5_000,
+			});
 			await expect(unrelated).resolves.toBe("unrelated answer");
 			// The run-id barrier is active even if the bounded child wait has already released the permit.
 			expect(existsSync(retryRanPath)).toBe(false);

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -70,6 +70,18 @@ async function waitForPath(path: string): Promise<void> {
 	throw new Error(`path was not created: ${path}`);
 }
 
+async function waitForLlmConcurrencyStatus(running: number, pending: number): Promise<void> {
+	for (let i = 0; i < 100; i += 1) {
+		const status = getLlmConcurrencyStatus();
+		if (status.running === running && status.pending === pending) return;
+		const { promise, resolve } = Promise.withResolvers<void>();
+		setImmediate(resolve);
+		await promise;
+	}
+	const status = getLlmConcurrencyStatus();
+	throw new Error(`LLM concurrency did not reach running=${running}, pending=${pending}: ${JSON.stringify(status)}`);
+}
+
 // ---------------------------------------------------------------------------
 // ACPX harness-subprocess provider
 // ---------------------------------------------------------------------------
@@ -82,7 +94,7 @@ describe("createAcpxProvider", () => {
 		expect(calculateAcpxRetryDelayMs(20, () => 1)).toBe(2_000);
 	});
 
-	it("runs ACPX one-shot exec with pinned version-compatible args and sterile hook env", async () => {
+	it("regression: boolean terminal false passes --no-terminal", async () => {
 		const root = join(tmpdir(), `signet-acpx-provider-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		mkdirSync(root, { recursive: true });
 		const bin = join(root, "fake-acpx.sh");
@@ -110,7 +122,7 @@ printf '  acpx answer  \\n'
 				bin,
 				permissions: "deny-all",
 				hooks: "disabled",
-				terminal: "disabled",
+				terminal: false,
 				mode: "session",
 				session: "background",
 				allowedTools: ["read_file"],
@@ -131,6 +143,16 @@ printf '  acpx answer  \\n'
 			expect(readFileSync(promptPath, "utf-8")).toBe("hello acpx");
 			expect(readFileSync(hooksPath, "utf-8")).toBe("1|false");
 			expect(readFileSync(cwdPath, "utf-8")).toBe(realpathSync(join(root, ".daemon", "acpx-background")));
+			await expect(createAcpxProvider({ agent: "codex", bin, terminal: "disabled" }).generate("hello", { timeoutMs: 1000 })).resolves.toBe(
+				"acpx answer",
+			);
+			expect(readFileSync(argsPath, "utf-8").trim().split("\n")).toContain("--no-terminal");
+			for (const terminal of [true, "inherit"] as const) {
+				await expect(createAcpxProvider({ agent: "codex", bin, terminal }).generate("hello", { timeoutMs: 1000 })).resolves.toBe(
+					"acpx answer",
+				);
+				expect(readFileSync(argsPath, "utf-8").trim().split("\n")).not.toContain("--no-terminal");
+			}
 		} finally {
 			if (previousSignetPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
 			else process.env.SIGNET_PATH = previousSignetPath;
@@ -682,6 +704,278 @@ printf 'ok\\n'
 		}
 	});
 
+	it("regression: cleanup barriers resolve when a target exits after SIGTERM", async () => {
+		const root = join(tmpdir(), `signet-acpx-immediate-cleanup-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		const procRoot = join(root, "proc");
+		const escapedPid = 12348;
+		const escapedProc = join(procRoot, String(escapedPid));
+		const bin = join(root, "fake-acpx.sh");
+		mkdirSync(procRoot, { recursive: true });
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+prompt=$(cat)
+if [[ "$prompt" == "next" ]]; then
+printf 'next\\n'
+exit 0
+fi
+mkdir -p ${JSON.stringify(escapedProc)}
+printf 'codex-acp\\0' > ${JSON.stringify(join(escapedProc, "cmdline"))}
+printf 'SIGNET_ACPX_RUN_ID=%s\\0' "$SIGNET_ACPX_RUN_ID" > ${JSON.stringify(join(escapedProc, "environ"))}
+printf 'first\\n'
+`,
+		);
+		chmodSync(bin, 0o755);
+		const previousProcRoot = process.env.SIGNET_ACPX_PROC_ROOT;
+		const previousPlatform = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
+		const previousKill = process.kill;
+		const terminated = Promise.withResolvers<void>();
+		let killed = false;
+		try {
+			process.env.SIGNET_ACPX_CLEANUP_PLATFORM = "linux";
+			process.env.SIGNET_ACPX_PROC_ROOT = procRoot;
+			process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+				if (pid !== escapedPid) return true;
+				if (signal === "SIGTERM") {
+					rmSync(escapedProc, { recursive: true, force: true });
+					terminated.resolve();
+					return true;
+				}
+				if (signal === 0) {
+					const error = Object.assign(new Error("process exited"), { code: "ESRCH" });
+					throw error;
+				}
+				if (signal === "SIGKILL") killed = true;
+				return true;
+			}) as typeof process.kill;
+			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
+			const first = provider.generate("first", { timeoutMs: 3_000 });
+			await terminated.promise;
+			await expect(first).resolves.toBe("first");
+			await expect(provider.generate("next", { timeoutMs: 3_000 })).resolves.toBe("next");
+			expect(killed).toBe(false);
+		} finally {
+			process.kill = previousKill;
+			if (previousProcRoot === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PROC_ROOT");
+			else process.env.SIGNET_ACPX_PROC_ROOT = previousProcRoot;
+			if (previousPlatform === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_CLEANUP_PLATFORM");
+			else process.env.SIGNET_ACPX_CLEANUP_PLATFORM = previousPlatform;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("regression: normal completion returns before escaped-child reaping while the next same-agent attempt waits", async () => {
+		const root = join(tmpdir(), `signet-acpx-success-cleanup-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		const procRoot = join(root, "proc");
+		const escapedPid = 12345;
+		const escapedProc = join(procRoot, String(escapedPid));
+		const bin = join(root, "fake-acpx.sh");
+		const nextRanPath = join(root, "next-ran");
+		mkdirSync(procRoot, { recursive: true });
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+prompt=$(cat)
+if [[ "$prompt" == "next" ]]; then
+touch ${JSON.stringify(nextRanPath)}
+printf 'next\\n'
+exit 0
+fi
+mkdir -p ${JSON.stringify(escapedProc)}
+printf 'codex-acp\\0' > ${JSON.stringify(join(escapedProc, "cmdline"))}
+printf 'SIGNET_ACPX_RUN_ID=%s\\0' "$SIGNET_ACPX_RUN_ID" > ${JSON.stringify(join(escapedProc, "environ"))}
+printf 'ok\\n'
+`,
+		);
+		chmodSync(bin, 0o755);
+		const previousProcRoot = process.env.SIGNET_ACPX_PROC_ROOT;
+		const previousPlatform = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
+		const previousConcurrencyLimit = getLlmConcurrencyStatus().limit;
+		const previousKill = process.kill;
+		const cleanupStarted = Promise.withResolvers<void>();
+		let cleanupFinished = false;
+		try {
+			configureLlmConcurrency(2);
+			process.env.SIGNET_ACPX_CLEANUP_PLATFORM = "linux";
+			process.env.SIGNET_ACPX_PROC_ROOT = procRoot;
+			process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+				if (pid === escapedPid && signal === "SIGTERM") cleanupStarted.resolve();
+				if (pid === escapedPid && signal === "SIGKILL") cleanupFinished = true;
+				return true;
+			}) as typeof process.kill;
+			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
+			const first = provider.generate("first", { timeoutMs: 3_000 });
+			await waitForPath(join(escapedProc, "cmdline"));
+			await cleanupStarted.promise;
+			await expect(first).resolves.toBe("ok");
+			expect(cleanupFinished).toBe(false);
+
+			const next = provider.generate("next", { timeoutMs: 3_000 });
+			for (let i = 0; i < 4; i += 1) await Promise.resolve();
+			expect(getLlmConcurrencyStatus().running).toBe(0);
+			expect(existsSync(nextRanPath)).toBe(false);
+			await expect(next).resolves.toBe("next");
+			expect(cleanupFinished).toBe(true);
+			expect(existsSync(nextRanPath)).toBe(true);
+		} finally {
+			process.kill = previousKill;
+			configureLlmConcurrency(previousConcurrencyLimit);
+			if (previousProcRoot === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PROC_ROOT");
+			else process.env.SIGNET_ACPX_PROC_ROOT = previousProcRoot;
+			if (previousPlatform === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_CLEANUP_PLATFORM");
+			else process.env.SIGNET_ACPX_CLEANUP_PLATFORM = previousPlatform;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("regression: same-agent cleanup re-admission does not hold the only global permit", async () => {
+		const root = join(tmpdir(), `signet-acpx-cleanup-readmit-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		const procRoot = join(root, "proc");
+		const escapedPid = 12347;
+		const escapedProc = join(procRoot, String(escapedPid));
+		const bin = join(root, "fake-acpx.sh");
+		const unrelatedRanPath = join(root, "unrelated-ran");
+		mkdirSync(procRoot, { recursive: true });
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+prompt=$(cat)
+if [[ "$prompt" == "first" ]]; then
+  mkdir -p ${JSON.stringify(escapedProc)}
+  printf 'codex-acp\\0' > ${JSON.stringify(join(escapedProc, "cmdline"))}
+  printf 'SIGNET_ACPX_RUN_ID=%s\\0' "$SIGNET_ACPX_RUN_ID" > ${JSON.stringify(join(escapedProc, "environ"))}
+fi
+if [[ "$prompt" == "unrelated" ]]; then touch ${JSON.stringify(unrelatedRanPath)}; fi
+printf '%s\\n' "$prompt"
+`,
+		);
+		chmodSync(bin, 0o755);
+		const previousProcRoot = process.env.SIGNET_ACPX_PROC_ROOT;
+		const previousPlatform = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
+		const previousConcurrencyLimit = getLlmConcurrencyStatus().limit;
+		const previousKill = process.kill;
+		const blockerEntered = Promise.withResolvers<void>();
+		const releaseBlocker = Promise.withResolvers<void>();
+		const cleanupStarted = Promise.withResolvers<void>();
+		let cleanupFinished = false;
+		let blocker: Promise<void> | undefined;
+		let first: Promise<string> | undefined;
+		let sameAgent: Promise<string> | undefined;
+		let unrelated: Promise<string> | undefined;
+		try {
+			configureLlmConcurrency(1);
+			process.env.SIGNET_ACPX_CLEANUP_PLATFORM = "linux";
+			process.env.SIGNET_ACPX_PROC_ROOT = procRoot;
+			process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+				if (pid === escapedPid && signal === "SIGTERM") cleanupStarted.resolve();
+				if (pid === escapedPid && signal === "SIGKILL") cleanupFinished = true;
+				return true;
+			}) as typeof process.kill;
+			const codex = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
+			const claude = createAcpxProvider({ agent: "claude", bin, hooks: "disabled" });
+			blocker = withLlmConcurrency(async () => {
+				blockerEntered.resolve();
+				await releaseBlocker.promise;
+			});
+			await blockerEntered.promise;
+			first = codex.generate("first", { timeoutMs: 3_000 });
+			sameAgent = codex.generate("same-agent", { timeoutMs: 3_000 });
+			unrelated = claude.generate("unrelated", { timeoutMs: 3_000 });
+			await waitForLlmConcurrencyStatus(1, 3);
+			expect(getLlmConcurrencyStatus().pending).toBe(3);
+
+			releaseBlocker.resolve();
+			await blocker;
+			await waitForPath(join(escapedProc, "cmdline"));
+			await cleanupStarted.promise;
+			await expect(first).resolves.toBe("first");
+			await waitForPath(unrelatedRanPath);
+			expect(cleanupFinished).toBe(false);
+			await expect(unrelated).resolves.toBe("unrelated");
+			await expect(sameAgent).resolves.toBe("same-agent");
+			expect(cleanupFinished).toBe(true);
+		} finally {
+			releaseBlocker.resolve();
+			await Promise.allSettled([blocker, first, sameAgent, unrelated]);
+			process.kill = previousKill;
+			configureLlmConcurrency(previousConcurrencyLimit);
+			if (previousProcRoot === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PROC_ROOT");
+			else process.env.SIGNET_ACPX_PROC_ROOT = previousProcRoot;
+			if (previousPlatform === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_CLEANUP_PLATFORM");
+			else process.env.SIGNET_ACPX_CLEANUP_PLATFORM = previousPlatform;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("regression: cleanup-barrier waits honor caller abort and deadline", async () => {
+		const root = join(tmpdir(), `signet-acpx-cleanup-wait-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		const procRoot = join(root, "proc");
+		const escapedPid = 12346;
+		const escapedProc = join(procRoot, String(escapedPid));
+		const bin = join(root, "fake-acpx.sh");
+		const spawnedPath = join(root, "spawned");
+		mkdirSync(procRoot, { recursive: true });
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+prompt=$(cat)
+if [[ "$prompt" != "first" ]]; then
+touch ${JSON.stringify(spawnedPath)}
+printf 'unexpected\\n'
+exit 0
+fi
+mkdir -p ${JSON.stringify(escapedProc)}
+printf 'codex-acp\\0' > ${JSON.stringify(join(escapedProc, "cmdline"))}
+printf 'SIGNET_ACPX_RUN_ID=%s\\0' "$SIGNET_ACPX_RUN_ID" > ${JSON.stringify(join(escapedProc, "environ"))}
+printf 'ok\\n'
+`,
+		);
+		chmodSync(bin, 0o755);
+		const previousProcRoot = process.env.SIGNET_ACPX_PROC_ROOT;
+		const previousPlatform = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
+		const previousKill = process.kill;
+		const cleanupStarted = Promise.withResolvers<void>();
+		try {
+			process.env.SIGNET_ACPX_CLEANUP_PLATFORM = "linux";
+			process.env.SIGNET_ACPX_PROC_ROOT = procRoot;
+			process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+				if (pid === escapedPid && signal === "SIGTERM") cleanupStarted.resolve();
+				return true;
+			}) as typeof process.kill;
+			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
+			const first = provider.generate("first", { timeoutMs: 3_000 });
+			await waitForPath(join(escapedProc, "cmdline"));
+			await cleanupStarted.promise;
+
+			const controller = new AbortController();
+			const abortStartedAt = performance.now();
+			const aborted = provider.generate("aborted", { timeoutMs: 3_000, signal: controller.signal });
+			controller.abort(new Error("cleanup caller cancelled"));
+			await expect(aborted).rejects.toThrow("cleanup caller cancelled");
+			expect(performance.now() - abortStartedAt).toBeLessThan(250);
+			expect(existsSync(spawnedPath)).toBe(false);
+
+			const deadlineStartedAt = performance.now();
+			await expect(provider.generate("timed-out", { timeoutMs: 100 })).rejects.toThrow(
+				/codex via ACPX timeout after 100ms/,
+			);
+			const deadlineElapsedMs = performance.now() - deadlineStartedAt;
+			expect(deadlineElapsedMs).toBeGreaterThanOrEqual(60);
+			expect(deadlineElapsedMs).toBeLessThan(400);
+			expect(existsSync(spawnedPath)).toBe(false);
+
+			await expect(first).resolves.toBe("ok");
+			expect(existsSync(spawnedPath)).toBe(false);
+		} finally {
+			process.kill = previousKill;
+			if (previousProcRoot === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PROC_ROOT");
+			else process.env.SIGNET_ACPX_PROC_ROOT = previousProcRoot;
+			if (previousPlatform === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_CLEANUP_PLATFORM");
+			else process.env.SIGNET_ACPX_CLEANUP_PLATFORM = previousPlatform;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("reaps escaped Codex ACP children on darwin via a bounded ps sweep (#1459)", async () => {
 		const root = join(tmpdir(), `signet-acpx-darwin-sweep-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		mkdirSync(root, { recursive: true });
@@ -1055,7 +1349,6 @@ printf 'ok\\n'
 	});
 
 	it("keeps the event loop responsive while ACPX cleanup waits on proc I/O (#1328)", async () => {
-		if (process.platform !== "linux") return;
 		const root = join(tmpdir(), `signet-acpx-async-cleanup-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		const procRoot = join(root, "proc");
 		const procPid = join(procRoot, "12345");
@@ -1072,8 +1365,12 @@ sleep 30
 		);
 		chmodSync(bin, 0o755);
 		const writer = nodeSpawn("bash", ["-c", `sleep 0.25; printf 'not-codex\\0' > ${JSON.stringify(cmdlinePath)}`]);
+		const writerClosed =
+			writer.exitCode === null ? new Promise<void>((resolve) => writer.once("close", () => resolve())) : Promise.resolve();
 		const previousProcRoot = process.env.SIGNET_ACPX_PROC_ROOT;
+		const previousPlatform = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
 		process.env.SIGNET_ACPX_PROC_ROOT = procRoot;
+		process.env.SIGNET_ACPX_CLEANUP_PLATFORM = "linux";
 		let heartbeats = 0;
 		const heartbeat = setInterval(() => {
 			heartbeats += 1;
@@ -1088,7 +1385,10 @@ sleep 30
 			clearInterval(heartbeat);
 			if (previousProcRoot === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PROC_ROOT");
 			else process.env.SIGNET_ACPX_PROC_ROOT = previousProcRoot;
-			writer.kill();
+			if (previousPlatform === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_CLEANUP_PLATFORM");
+			else process.env.SIGNET_ACPX_CLEANUP_PLATFORM = previousPlatform;
+			await writerClosed;
+			await new Promise<void>((resolve) => setImmediate(resolve));
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
@@ -1288,6 +1588,221 @@ printf 'ok\n'
 			expect(readFileSync(pwdPath, "utf-8").trim()).toBe(join(root, "workspace"));
 		} finally {
 			process.chdir(previousCwd);
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+
+	it("regression: timeout starts escaped-stdio cleanup but releases its permit after a bounded termination wait", async () => {
+		const root = join(tmpdir(), `signet-acpx-escaped-stdio-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		const procRoot = join(root, "proc");
+		const bin = join(root, "fake-acpx.sh");
+		const childSpawner = join(root, "spawn-escaped-child.mjs");
+		const childPidPath = join(root, "escaped-child.pid");
+		const holderReadyPath = join(root, "holder-ready");
+		const retryRanPath = join(root, "retry-ran");
+		const unrelatedRanPath = join(root, "unrelated-ran");
+		mkdirSync(procRoot, { recursive: true });
+		writeFileSync(
+			childSpawner,
+			`import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+const child = spawn(process.execPath, ["-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1_000);"], {
+	detached: true,
+	stdio: "inherit",
+});
+writeFileSync(process.argv[2], String(child.pid));
+child.unref();
+`,
+		);
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+prompt=$(cat)
+if [[ "$prompt" == "barrier-settle" ]]; then
+  printf 'ready\\n'
+  exit 0
+fi
+if [[ "$prompt" == "retry" ]]; then
+  touch ${JSON.stringify(retryRanPath)}
+  printf 'retry answer\\n'
+  exit 0
+fi
+if [[ "$prompt" == "unrelated" ]]; then
+  touch ${JSON.stringify(unrelatedRanPath)}
+  printf 'unrelated answer\\n'
+  exit 0
+fi
+${JSON.stringify(process.execPath)} ${JSON.stringify(childSpawner)} ${JSON.stringify(childPidPath)}
+escaped_pid="$(cat ${JSON.stringify(childPidPath)})"
+mkdir -p ${JSON.stringify(procRoot)}/"$escaped_pid"
+printf 'codex-acp\\0' > ${JSON.stringify(procRoot)}/"$escaped_pid"/cmdline
+printf 'SIGNET_ACPX_RUN_ID=%s\\0' "$SIGNET_ACPX_RUN_ID" > ${JSON.stringify(procRoot)}/"$escaped_pid"/environ
+touch ${JSON.stringify(holderReadyPath)}
+`,
+		);
+		chmodSync(bin, 0o755);
+		const previousProcRoot = process.env.SIGNET_ACPX_PROC_ROOT;
+		const previousPlatform = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
+		const previousConcurrencyLimit = getLlmConcurrencyStatus().limit;
+		const previousKill = process.kill;
+		const cleanupStarted = Promise.withResolvers<void>();
+		let escapedPid: number | undefined;
+		let cleanupSignals = 0;
+		let cleanupKillSignals = 0;
+		let cleanupStartedAt = 0;
+		let barrierSettled: Promise<string> | undefined;
+		let holder: Promise<string> | undefined;
+		let retry: Promise<string> | undefined;
+		let unrelated: Promise<string> | undefined;
+		try {
+			configureLlmConcurrency(16);
+			process.env.SIGNET_ACPX_CLEANUP_PLATFORM = "linux";
+			process.env.SIGNET_ACPX_PROC_ROOT = procRoot;
+			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
+			barrierSettled = provider.generate("barrier-settle", { timeoutMs: 3_000 });
+			await expect(barrierSettled).resolves.toBe("ready");
+			holder = provider.generate("holder", { timeoutMs: 500 });
+			void holder.catch(() => undefined);
+			await waitForPath(holderReadyPath);
+			escapedPid = await waitForPidFile(childPidPath);
+			process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+				if (pid === escapedPid) {
+					if (signal === "SIGTERM") {
+						cleanupSignals += 1;
+						cleanupStartedAt = performance.now();
+						cleanupStarted.resolve();
+					}
+					if (signal === "SIGKILL") cleanupKillSignals += 1;
+					return true;
+				}
+				return previousKill(pid, signal as NodeJS.Signals);
+			}) as typeof process.kill;
+
+			await cleanupStarted.promise;
+			retry = provider.generate("retry", { timeoutMs: 5_000 });
+			unrelated = createAcpxProvider({ agent: "claude-code", bin, hooks: "disabled" }).generate("unrelated", { timeoutMs: 5_000 });
+			await expect(unrelated).resolves.toBe("unrelated answer");
+			// The run-id barrier is active even if the bounded child wait has already released the permit.
+			expect(existsSync(retryRanPath)).toBe(false);
+
+			await expect(holder).rejects.toThrow(/codex via ACPX timeout after \d+ms/);
+			const cleanupElapsedMs = performance.now() - cleanupStartedAt;
+			expect(cleanupElapsedMs).toBeLessThan(300);
+			expect(getLlmConcurrencyStatus()).toMatchObject({ running: 0, pending: 0 });
+			expect(cleanupSignals).toBe(1);
+			expect(cleanupKillSignals).toBe(0);
+			expect(() => previousKill(escapedPid, 0)).not.toThrow();
+
+			rmSync(join(procRoot, String(escapedPid)), { recursive: true, force: true });
+			await expect(retry).resolves.toBe("retry answer");
+			previousKill(escapedPid, "SIGKILL");
+			await waitForProcessExit(escapedPid);
+			const { promise: closeTurn, resolve: advanceCloseTurn } = Promise.withResolvers<void>();
+			setImmediate(advanceCloseTurn);
+			await closeTurn;
+			expect(cleanupSignals).toBe(1);
+			expect(cleanupKillSignals).toBe(1);
+		} finally {
+			if (escapedPid !== undefined) {
+				try {
+					previousKill(escapedPid, "SIGKILL");
+				} catch {
+					// Already exited.
+				}
+			}
+			await Promise.allSettled([barrierSettled, holder, retry, unrelated]);
+			configureLlmConcurrency(previousConcurrencyLimit);
+			process.kill = previousKill;
+			if (previousProcRoot === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PROC_ROOT");
+			else process.env.SIGNET_ACPX_PROC_ROOT = previousProcRoot;
+			if (previousPlatform === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_CLEANUP_PLATFORM");
+			else process.env.SIGNET_ACPX_CLEANUP_PLATFORM = previousPlatform;
+			rmSync(root, { recursive: true, force: true });
+		}
+	}, 4_000);
+
+	it("does not launch a same-agent request aborted during ACPX cleanup", async () => {
+		const root = join(tmpdir(), `signet-acpx-aborted-cleanup-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		const procRoot = join(root, "proc");
+		const bin = join(root, "fake-acpx.sh");
+		const holderReadyPath = join(root, "holder-ready");
+		const queuedRanPath = join(root, "queued-ran");
+		mkdirSync(root, { recursive: true });
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+prompt=$(cat)
+if [[ "$prompt" == "barrier-settle" ]]; then
+  printf 'ready\\n'
+  exit 0
+fi
+if [[ "$prompt" == "holder" ]]; then
+  mkdir -p ${JSON.stringify(join(procRoot, "12345"))}
+  printf 'codex-acp\\0' > ${JSON.stringify(join(procRoot, "12345", "cmdline"))}
+  printf 'SIGNET_ACPX_RUN_ID=%s\\0' "$SIGNET_ACPX_RUN_ID" > ${JSON.stringify(join(procRoot, "12345", "environ"))}
+  touch ${JSON.stringify(holderReadyPath)}
+  sleep 30
+else
+  touch ${JSON.stringify(queuedRanPath)}
+  printf 'queued answer\\n'
+fi
+`,
+		);
+		chmodSync(bin, 0o755);
+		const previousProcRoot = process.env.SIGNET_ACPX_PROC_ROOT;
+		const previousPlatform = process.env.SIGNET_ACPX_CLEANUP_PLATFORM;
+		const previousKill = process.kill;
+		const previousConcurrencyLimit = getLlmConcurrencyStatus().limit;
+		const cleanupStarted = Promise.withResolvers<void>();
+		const cleanupFinished = Promise.withResolvers<void>();
+		let cleanupInFlight = false;
+		let holderController: AbortController | undefined;
+		let queuedController: AbortController | undefined;
+		let barrierSettled: Promise<string> | undefined;
+		let holder: Promise<string> | undefined;
+		let queued: Promise<string> | undefined;
+		try {
+			process.env.SIGNET_ACPX_CLEANUP_PLATFORM = "linux";
+			configureLlmConcurrency(16);
+			process.env.SIGNET_ACPX_PROC_ROOT = procRoot;
+			process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+				if (pid !== 12345) return previousKill(pid, signal as NodeJS.Signals);
+				if (signal === "SIGTERM") {
+					cleanupInFlight = true;
+					cleanupStarted.resolve();
+				}
+				if (signal === "SIGKILL") cleanupFinished.resolve();
+				return true;
+			}) as typeof process.kill;
+			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
+			barrierSettled = provider.generate("barrier-settle", { timeoutMs: 3_000 });
+			await expect(barrierSettled).resolves.toBe("ready");
+			holderController = new AbortController();
+			holder = provider.generate("holder", { signal: holderController.signal, timeoutMs: 5_000 });
+			await waitForPath(holderReadyPath);
+			holderController.abort();
+			const holderAborted = expect(holder).rejects.toThrow("codex via ACPX aborted");
+			await cleanupStarted.promise;
+			await holderAborted;
+
+			queuedController = new AbortController();
+			queued = provider.generate("queued", { signal: queuedController.signal, timeoutMs: 5_000 });
+			await waitForLlmConcurrencyStatus(0, 0);
+			queuedController.abort(new Error("queued caller cancelled"));
+			await expect(queued).rejects.toThrow("queued caller cancelled");
+			expect(existsSync(queuedRanPath)).toBe(false);
+		} finally {
+			holderController?.abort();
+			queuedController?.abort();
+			await Promise.allSettled([barrierSettled, holder, queued]);
+			if (cleanupInFlight) await cleanupFinished.promise;
+			configureLlmConcurrency(previousConcurrencyLimit);
+			process.kill = previousKill;
+			if (previousProcRoot === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PROC_ROOT");
+			else process.env.SIGNET_ACPX_PROC_ROOT = previousProcRoot;
+			if (previousPlatform === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_CLEANUP_PLATFORM");
+			else process.env.SIGNET_ACPX_CLEANUP_PLATFORM = previousPlatform;
 			rmSync(root, { recursive: true, force: true });
 		}
 	});

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -732,20 +732,14 @@ const DEFAULT_ACPX_EMPTY_RESPONSE_RETRY_DELAY_MS = 100;
 const MAX_ACPX_EMPTY_RESPONSE_RETRY_DELAY_MS = 2_000;
 
 const acpxCleanupBarriers = new Map<string, Promise<void>>();
-const acpxCleanupGenerations = new Map<string, number>();
-const ACPX_RETRY_ADMISSION = Symbol("acpx retry admission");
+const acpxAdmissionBarriers = new Map<string, Promise<void>>();
 
 function acpxCleanupKey(agent: string): string {
 	return normalizeAcpxAgent(agent).toLowerCase();
 }
 
-function acpxCleanupGeneration(agent: string): number {
-	return acpxCleanupGenerations.get(acpxCleanupKey(agent)) ?? 0;
-}
-
 function trackAcpxCleanupBarrier(agent: string, cleanup: Promise<void>): Promise<void> {
 	const key = acpxCleanupKey(agent);
-	acpxCleanupGenerations.set(key, acpxCleanupGeneration(agent) + 1);
 	const settledCleanup = cleanup.catch(() => undefined);
 	const predecessor = acpxCleanupBarriers.get(key);
 	const barrier = predecessor ? Promise.all([predecessor, settledCleanup]).then(() => undefined) : settledCleanup;
@@ -756,21 +750,54 @@ function trackAcpxCleanupBarrier(agent: string, cleanup: Promise<void>): Promise
 	return barrier;
 }
 
-async function waitForAcpxCleanupBarrier(
+interface AcpxAdmissionLease {
+	readonly ready: Promise<void>;
+	release(): void;
+}
+
+function reserveAcpxAdmission(agent: string): AcpxAdmissionLease {
+	const key = acpxCleanupKey(agent);
+	const predecessors = [acpxAdmissionBarriers.get(key), acpxCleanupBarriers.get(key)].filter(
+		(value): value is Promise<void> => value !== undefined,
+	);
+	const ready = predecessors.length === 0 ? Promise.resolve() : Promise.all(predecessors).then(() => undefined);
+	let resolveOwn!: () => void;
+	let released = false;
+	const own = new Promise<void>((resolve) => {
+		resolveOwn = resolve;
+	});
+	const barrier = ready.then(() => own);
+	acpxAdmissionBarriers.set(key, barrier);
+	void barrier.then(() => {
+		if (acpxAdmissionBarriers.get(key) === barrier) acpxAdmissionBarriers.delete(key);
+	});
+	return {
+		ready,
+		release: () => {
+			if (released) return;
+			released = true;
+			resolveOwn();
+		},
+	};
+}
+
+async function waitForAcpxAdmission(
+	lease: AcpxAdmissionLease,
 	agent: string,
 	deadline: number,
 	timeoutMs: number,
 	signal: AbortSignal | undefined,
-): Promise<number> {
-	const key = acpxCleanupKey(agent);
-	while (true) {
-		const barrier = acpxCleanupBarriers.get(key);
-		if (!barrier) return acpxCleanupGeneration(agent);
-		signal?.throwIfAborted();
-		const remainingMs = deadline - performance.now();
-		if (remainingMs <= 1) {
-			throw new Error(`${agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`);
-		}
+): Promise<void> {
+	if (signal?.aborted) {
+		lease.release();
+		signal.throwIfAborted();
+	}
+	const remainingMs = deadline - performance.now();
+	if (remainingMs <= 1) {
+		lease.release();
+		throw new Error(`${agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`);
+	}
+	try {
 		await new Promise<void>((resolve, reject) => {
 			let settled = false;
 			const finish = (fn: () => void): void => {
@@ -784,15 +811,29 @@ async function waitForAcpxCleanupBarrier(
 			const timer = setTimeout(
 				() =>
 					finish(() =>
-						reject(new Error(`${agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`)),
+						reject(
+							new Error(`${agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`),
+						),
 					),
 				remainingMs,
 			);
 			timer.unref?.();
 			signal?.addEventListener("abort", onAbort, { once: true });
-			void barrier.then(() => finish(resolve));
+			void lease.ready.then(() => finish(resolve));
 		});
-		if (acpxCleanupBarriers.get(key) === barrier) return acpxCleanupGeneration(agent);
+	} catch (error) {
+		lease.release();
+		throw error;
+	}
+}
+
+/** Wait for the currently tracked orphan cleanup for an ACPX agent. */
+export async function waitForAcpxCleanup(agent: string): Promise<void> {
+	while (true) {
+		const barrier = acpxCleanupBarriers.get(acpxCleanupKey(agent));
+		if (!barrier) return;
+		await barrier;
+		if (acpxCleanupBarriers.get(acpxCleanupKey(agent)) === barrier) return;
 	}
 }
 
@@ -1503,6 +1544,7 @@ function runAcpxAttempt(
 	prompt: string,
 	remainingMs: number,
 	signal: AbortSignal | undefined,
+	onCleanup?: (cleanup: Promise<void>) => void,
 ): Promise<string> {
 	const { bin, args, cwd } = buildAcpxCommand(config, remainingMs);
 	const outputFormat = resolveAcpxFormat(config);
@@ -1527,10 +1569,8 @@ function runAcpxAttempt(
 			settled = true;
 			clearTimeout(timer);
 			signal?.removeEventListener("abort", onAbort);
-			cleanup ??= trackAcpxCleanupBarrier(
-				config.agent,
-				cleanupAcpxAgentProcesses(config.agent, runId),
-			);
+			cleanup ??= trackAcpxCleanupBarrier(config.agent, cleanupAcpxAgentProcesses(config.agent, runId));
+			onCleanup?.(cleanup);
 			if (cleanupWait === "all") await cleanup;
 			if (cleanupWait === "termination") await waitForAcpxChildTermination(child);
 			fn();
@@ -1564,53 +1604,50 @@ function runAcpxAttempt(
 		child.on(
 			"close",
 			(code) =>
-				void finish(
-					() => {
-						if (terminationError) {
-							reject(terminationError);
+				void finish(() => {
+					if (terminationError) {
+						reject(terminationError);
+						return;
+					}
+					if (code !== 0) {
+						reject(new Error(`${config.agent} via ACPX exited ${code}: ${stderr.slice(0, 300)}`));
+						return;
+					}
+					let text: string | undefined;
+					let parsed: AcpxParsedJsonOutput | undefined;
+					try {
+						if (outputFormat === "json") {
+							parsed = parseAcpxJsonOutput(stdout, config);
+							text = parsed.text;
+						} else {
+							text = stdout.trim();
+						}
+					} catch (error) {
+						reject(error);
+						return;
+					}
+					if (!text) {
+						if (parsed && (!parsed.finalSeen || parsed.sideEffects)) {
+							reject(new Error(`${config.agent} via ACPX JSON output did not include a final response`));
 							return;
 						}
-						if (code !== 0) {
-							reject(new Error(`${config.agent} via ACPX exited ${code}: ${stderr.slice(0, 300)}`));
-							return;
-						}
-						let text: string | undefined;
-						let parsed: AcpxParsedJsonOutput | undefined;
-						try {
-							if (outputFormat === "json") {
-								parsed = parseAcpxJsonOutput(stdout, config);
-								text = parsed.text;
-							} else {
-								text = stdout.trim();
-							}
-						} catch (error) {
-							reject(error);
-							return;
-						}
-						if (!text) {
-							if (parsed && (!parsed.finalSeen || parsed.sideEffects)) {
-								reject(new Error(`${config.agent} via ACPX JSON output did not include a final response`));
-								return;
-							}
-							reject(
-								new AcpxEmptyResponseError(config.agent, {
-									exitCode: 0,
-									stdoutBytes: Buffer.byteLength(stdout),
-									stderrBytes: Buffer.byteLength(stderr),
-									format: outputFormat,
-									durationMs: performance.now() - startedAt,
-									sideEffects: parsed?.sideEffects ?? false,
-									...(parsed?.sessionId ? { sessionId: parsed.sessionId } : {}),
-									...(parsed?.stopReason ? { stopReason: parsed.stopReason } : {}),
-									...(parsed?.usage || quietUsage(stderr) ? { usage: parsed?.usage ?? quietUsage(stderr) } : {}),
-								}),
-							);
-							return;
-						}
-						resolve(text);
-					},
-					"none",
-				),
+						reject(
+							new AcpxEmptyResponseError(config.agent, {
+								exitCode: 0,
+								stdoutBytes: Buffer.byteLength(stdout),
+								stderrBytes: Buffer.byteLength(stderr),
+								format: outputFormat,
+								durationMs: performance.now() - startedAt,
+								sideEffects: parsed?.sideEffects ?? false,
+								...(parsed?.sessionId ? { sessionId: parsed.sessionId } : {}),
+								...(parsed?.stopReason ? { stopReason: parsed.stopReason } : {}),
+								...(parsed?.usage || quietUsage(stderr) ? { usage: parsed?.usage ?? quietUsage(stderr) } : {}),
+							}),
+						);
+						return;
+					}
+					resolve(text);
+				}, "none"),
 		);
 		if (!terminationError) child.stdin?.end(prompt);
 	});
@@ -1642,74 +1679,59 @@ export function createAcpxProvider(config: AcpxProviderConfig): LlmProvider {
 					);
 				}
 				const attemptConfig = attempt === 0 ? config : { ...config, mode: "exec" as const, session: undefined };
-				while (true) {
-					try {
-						const cleanupGeneration = await waitForAcpxCleanupBarrier(
-							attemptConfig.agent,
-							deadline,
-							timeoutMs,
-							signal,
+				const admission = reserveAcpxAdmission(attemptConfig.agent);
+				let cleanup: Promise<void> | undefined;
+				try {
+					await waitForAcpxAdmission(admission, attemptConfig.agent, deadline, timeoutMs, signal);
+					signal?.throwIfAborted();
+					const postAdmissionRemainingMs = deadline - performance.now();
+					if (postAdmissionRemainingMs <= 1) {
+						throw new Error(
+							`${config.agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`,
 						);
-						signal?.throwIfAborted();
-						const postCleanupRemainingMs = deadline - performance.now();
-						if (postCleanupRemainingMs <= 1) {
-							if (lastEmpty) {
-								throw formatEmptyResponseError(
-									config.agent,
-									lastEmpty.diagnostics,
-									attempt - 1,
-									performance.now() - startedAt,
+					}
+					const result = await withLlmConcurrency(
+						async () => {
+							signal?.throwIfAborted();
+							const acquiredRemainingMs = deadline - performance.now();
+							if (acquiredRemainingMs <= 1) {
+								throw new Error(
+									`${config.agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`,
 								);
 							}
-							throw new Error(
-								`${config.agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`,
-							);
-						}
-						return await withLlmConcurrency(
-							async () => {
-								signal?.throwIfAborted();
-								const acquiredRemainingMs = deadline - performance.now();
-								if (acquiredRemainingMs <= 1) {
-									if (lastEmpty) {
-										throw formatEmptyResponseError(
-											config.agent,
-											lastEmpty.diagnostics,
-											attempt - 1,
-											performance.now() - startedAt,
-										);
-									}
-									throw new Error(
-										`${config.agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`,
-									);
-								}
-								if (acpxCleanupGeneration(attemptConfig.agent) !== cleanupGeneration) {
-									throw ACPX_RETRY_ADMISSION;
-								}
-								return runAcpxAttempt(attemptConfig, prompt, acquiredRemainingMs, signal);
-							},
-							postCleanupRemainingMs,
-							"acpx",
-							signal,
-						);
-					} catch (error) {
-						if (error === ACPX_RETRY_ADMISSION) continue;
-						if (!(error instanceof AcpxEmptyResponseError)) throw error;
-						lastEmpty = error;
-						if (attempt >= retries) {
-							throw formatEmptyResponseError(config.agent, error.diagnostics, attempt, performance.now() - startedAt);
-						}
-						const delayMs = calculateAcpxRetryDelayMs(attempt);
-						logger.warn("inference", "Retrying sterile ACPX empty response", {
-							agent: config.agent,
-							attempt: attempt + 1,
-							delayMs,
-							format: error.diagnostics.format,
-							sessionId: error.diagnostics.sessionId ?? "unknown",
-							stopReason: error.diagnostics.stopReason ?? "unknown",
-						});
-						await waitForAcpxRetry(config.agent, delayMs, deadline, signal);
-						break;
+							return runAcpxAttempt(attemptConfig, prompt, acquiredRemainingMs, signal, (barrier) => {
+								cleanup = barrier;
+							});
+						},
+						postAdmissionRemainingMs,
+						"acpx",
+						signal,
+					);
+					if (cleanup) void cleanup.then(admission.release, admission.release);
+					else admission.release();
+					return result;
+				} catch (error) {
+					if (!(error instanceof AcpxEmptyResponseError)) {
+						if (cleanup) void cleanup.then(admission.release, admission.release);
+						else admission.release();
+						throw error;
 					}
+					await cleanup?.catch(() => undefined);
+					admission.release();
+					lastEmpty = error;
+					if (attempt >= retries) {
+						throw formatEmptyResponseError(config.agent, error.diagnostics, attempt, performance.now() - startedAt);
+					}
+					const delayMs = calculateAcpxRetryDelayMs(attempt);
+					logger.warn("inference", "Retrying sterile ACPX empty response", {
+						agent: config.agent,
+						attempt: attempt + 1,
+						delayMs,
+						format: error.diagnostics.format,
+						sessionId: error.diagnostics.sessionId ?? "unknown",
+						stopReason: error.diagnostics.stopReason ?? "unknown",
+					});
+					await waitForAcpxRetry(config.agent, delayMs, deadline, signal);
 				}
 			}
 			throw new Error(`${config.agent} via ACPX retry loop exhausted`);

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -17,7 +17,7 @@
  */
 // On Windows, use node:child_process spawn with windowsHide to prevent
 // console window flashing. Bun.spawn doesn't support windowsHide.
-import { spawn as nodeSpawn } from "node:child_process";
+import { spawn as nodeSpawn, type ChildProcess } from "node:child_process";
 import { mkdirSync } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";
 import { isAbsolute, join, resolve as resolvePath } from "node:path";
@@ -696,7 +696,7 @@ export async function awaitSubprocessWithDeadline<T>(
 
 export type AcpxPermissionMode = "inherit" | "deny-all" | "approve-reads" | "approve-all";
 export type AcpxHooksMode = "inherit" | "disabled" | "enabled";
-export type AcpxTerminalMode = "inherit" | "disabled" | "enabled";
+export type AcpxTerminalMode = "inherit" | "disabled" | "enabled" | boolean;
 export type AcpxSessionMode = "exec" | "session";
 export type AcpxOutputFormat = "quiet" | "json";
 
@@ -730,6 +730,71 @@ const DEFAULT_ACPX_EMPTY_RESPONSE_RETRIES = 1;
 const MAX_ACPX_EMPTY_RESPONSE_RETRIES = 3;
 const DEFAULT_ACPX_EMPTY_RESPONSE_RETRY_DELAY_MS = 100;
 const MAX_ACPX_EMPTY_RESPONSE_RETRY_DELAY_MS = 2_000;
+
+const acpxCleanupBarriers = new Map<string, Promise<void>>();
+const acpxCleanupGenerations = new Map<string, number>();
+const ACPX_RETRY_ADMISSION = Symbol("acpx retry admission");
+
+function acpxCleanupKey(agent: string): string {
+	return normalizeAcpxAgent(agent).toLowerCase();
+}
+
+function acpxCleanupGeneration(agent: string): number {
+	return acpxCleanupGenerations.get(acpxCleanupKey(agent)) ?? 0;
+}
+
+function trackAcpxCleanupBarrier(agent: string, cleanup: Promise<void>): Promise<void> {
+	const key = acpxCleanupKey(agent);
+	acpxCleanupGenerations.set(key, acpxCleanupGeneration(agent) + 1);
+	const settledCleanup = cleanup.catch(() => undefined);
+	const predecessor = acpxCleanupBarriers.get(key);
+	const barrier = predecessor ? Promise.all([predecessor, settledCleanup]).then(() => undefined) : settledCleanup;
+	acpxCleanupBarriers.set(key, barrier);
+	void barrier.then(() => {
+		if (acpxCleanupBarriers.get(key) === barrier) acpxCleanupBarriers.delete(key);
+	});
+	return barrier;
+}
+
+async function waitForAcpxCleanupBarrier(
+	agent: string,
+	deadline: number,
+	timeoutMs: number,
+	signal: AbortSignal | undefined,
+): Promise<number> {
+	const key = acpxCleanupKey(agent);
+	while (true) {
+		const barrier = acpxCleanupBarriers.get(key);
+		if (!barrier) return acpxCleanupGeneration(agent);
+		signal?.throwIfAborted();
+		const remainingMs = deadline - performance.now();
+		if (remainingMs <= 1) {
+			throw new Error(`${agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`);
+		}
+		await new Promise<void>((resolve, reject) => {
+			let settled = false;
+			const finish = (fn: () => void): void => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				signal?.removeEventListener("abort", onAbort);
+				fn();
+			};
+			const onAbort = (): void => finish(() => reject(signal?.reason ?? new Error(`${agent} via ACPX aborted`)));
+			const timer = setTimeout(
+				() =>
+					finish(() =>
+						reject(new Error(`${agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`)),
+					),
+				remainingMs,
+			);
+			timer.unref?.();
+			signal?.addEventListener("abort", onAbort, { once: true });
+			void barrier.then(() => finish(resolve));
+		});
+		if (acpxCleanupBarriers.get(key) === barrier) return acpxCleanupGeneration(agent);
+	}
+}
 
 function normalizeAcpxAgent(agent: string): string {
 	return agent === "claude-code" ? "claude" : agent;
@@ -862,7 +927,7 @@ function buildAcpxCommand(
 		args.push("--model", config.model);
 	}
 	args.push(...acpxPermissionArgs(config.permissions));
-	if (config.terminal === "disabled") args.push("--no-terminal");
+	if (config.terminal === false || config.terminal === "disabled") args.push("--no-terminal");
 	if (allowedTools) args.push("--allowed-tools", allowedTools.join(","));
 	args.push(...(config.extraArgs ?? []));
 	args.push(normalizeAcpxAgent(config.agent));
@@ -937,11 +1002,30 @@ function terminateChildProcessTree(child: ReturnType<typeof nodeSpawn>, signal: 
 	child.kill(signal);
 }
 
+const ACPX_TERMINATION_WAIT_MS = 100;
+
 function terminateChildProcessTreeWithEscalation(child: ReturnType<typeof nodeSpawn>): void {
 	terminateChildProcessTree(child, "SIGTERM");
 	const escalation = setTimeout(() => terminateChildProcessTree(child, "SIGKILL"), 1000);
 	escalation.unref?.();
 	child.once("close", () => clearTimeout(escalation));
+}
+
+function waitForAcpxChildTermination(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+	const { promise, resolve } = Promise.withResolvers<void>();
+	let settled = false;
+	const finish = (): void => {
+		if (settled) return;
+		settled = true;
+		clearTimeout(timer);
+		child.off("close", finish);
+		resolve();
+	};
+	const timer = setTimeout(finish, ACPX_TERMINATION_WAIT_MS);
+	timer.unref?.();
+	child.once("close", finish);
+	return promise;
 }
 
 function acpxAgentProcessBasenames(agent: string): string[] {
@@ -1135,6 +1219,45 @@ async function procCommandMatchesAgent(
 	}
 }
 
+const ACPX_CLEANUP_GRACE_MS = 1000;
+const ACPX_CLEANUP_POLL_MS = 25;
+
+function acpxCleanupProcessExists(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (
+			error instanceof Error &&
+			"code" in error &&
+			(error as NodeJS.ErrnoException).code !== undefined &&
+			(error as NodeJS.ErrnoException).code !== "ESRCH"
+		);
+	}
+}
+
+async function terminateAcpxAgentProcess(pid: number): Promise<void> {
+	try {
+		process.kill(pid, "SIGTERM");
+	} catch {
+		return;
+	}
+	const deadline = performance.now() + ACPX_CLEANUP_GRACE_MS;
+	while (acpxCleanupProcessExists(pid)) {
+		const remainingMs = deadline - performance.now();
+		if (remainingMs <= 0) break;
+		const { promise, resolve } = Promise.withResolvers<void>();
+		setTimeout(resolve, Math.min(ACPX_CLEANUP_POLL_MS, remainingMs));
+		await promise;
+	}
+	if (!acpxCleanupProcessExists(pid)) return;
+	try {
+		process.kill(pid, "SIGKILL");
+	} catch {
+		// Already exited.
+	}
+}
+
 async function cleanupAcpxAgentProcesses(agent: string, runId: string): Promise<void> {
 	const basenames = new Set(acpxAgentProcessBasenames(agent));
 	if (basenames.size === 0) return;
@@ -1168,21 +1291,7 @@ async function cleanupAcpxAgentProcesses(agent: string, runId: string): Promise<
 		});
 		return;
 	}
-	for (const pid of pids) {
-		try {
-			process.kill(pid, "SIGTERM");
-		} catch {
-			// Already gone or not ours to signal.
-		}
-		const escalation = setTimeout(() => {
-			try {
-				process.kill(pid, "SIGKILL");
-			} catch {
-				// Already exited.
-			}
-		}, 1000);
-		escalation.unref?.();
-	}
+	await Promise.all(pids.map(terminateAcpxAgentProcess));
 }
 
 interface AcpxParsedJsonOutput {
@@ -1403,7 +1512,9 @@ function runAcpxAttempt(
 		let stdout = "";
 		let stderr = "";
 		let settled = false;
-		let aborted = false;
+		let timer: NodeJS.Timeout | undefined;
+		let cleanup: Promise<void> | undefined;
+		let terminationError: Error | undefined;
 		const child = nodeSpawn(bin, args, {
 			cwd,
 			env: acpxEnv(config, runId),
@@ -1411,26 +1522,34 @@ function runAcpxAttempt(
 			detached: process.platform !== "win32",
 			windowsHide: true,
 		});
-		const finish = async (fn: () => void, waitForCleanup = true): Promise<void> => {
+		const finish = async (fn: () => void, cleanupWait: "all" | "termination" | "none" = "all"): Promise<void> => {
 			if (settled) return;
 			settled = true;
 			clearTimeout(timer);
 			signal?.removeEventListener("abort", onAbort);
-			const cleanup = cleanupAcpxAgentProcesses(config.agent, runId).catch(() => undefined);
-			if (waitForCleanup) await cleanup;
-			else void cleanup;
+			cleanup ??= trackAcpxCleanupBarrier(
+				config.agent,
+				cleanupAcpxAgentProcesses(config.agent, runId),
+			);
+			if (cleanupWait === "all") await cleanup;
+			if (cleanupWait === "termination") await waitForAcpxChildTermination(child);
 			fn();
 		};
-		const onAbort = (): void => {
-			aborted = true;
+		const terminate = (error: Error): void => {
+			if (settled || terminationError) return;
+			terminationError = error;
 			terminateChildProcessTreeWithEscalation(child);
+			void finish(() => reject(error), "termination");
 		};
+		const onAbort = (): void => terminate(new Error(`${config.agent} via ACPX aborted`));
 		if (signal?.aborted) onAbort();
 		else signal?.addEventListener("abort", onAbort, { once: true });
-		const timer = setTimeout(() => {
-			terminateChildProcessTreeWithEscalation(child);
-			void finish(() => reject(new Error(`${config.agent} via ACPX timeout after ${Math.ceil(remainingMs)}ms`)), false);
-		}, remainingMs);
+		if (!terminationError) {
+			timer = setTimeout(
+				() => terminate(new Error(`${config.agent} via ACPX timeout after ${Math.ceil(remainingMs)}ms`)),
+				remainingMs,
+			);
+		}
 		child.stdout?.setEncoding("utf8");
 		child.stderr?.setEncoding("utf8");
 		child.stdout?.on("data", (chunk) => {
@@ -1440,57 +1559,60 @@ function runAcpxAttempt(
 			stderr += String(chunk);
 		});
 		child.on("error", (error) => {
-			void finish(() => reject(error));
+			if (!terminationError) void finish(() => reject(error));
 		});
 		child.on(
 			"close",
 			(code) =>
-				void finish(() => {
-					if (aborted) {
-						reject(new Error(`${config.agent} via ACPX aborted`));
-						return;
-					}
-					if (code !== 0) {
-						reject(new Error(`${config.agent} via ACPX exited ${code}: ${stderr.slice(0, 300)}`));
-						return;
-					}
-					let text: string | undefined;
-					let parsed: AcpxParsedJsonOutput | undefined;
-					try {
-						if (outputFormat === "json") {
-							parsed = parseAcpxJsonOutput(stdout, config);
-							text = parsed.text;
-						} else {
-							text = stdout.trim();
-						}
-					} catch (error) {
-						reject(error);
-						return;
-					}
-					if (!text) {
-						if (parsed && (!parsed.finalSeen || parsed.sideEffects)) {
-							reject(new Error(`${config.agent} via ACPX JSON output did not include a final response`));
+				void finish(
+					() => {
+						if (terminationError) {
+							reject(terminationError);
 							return;
 						}
-						reject(
-							new AcpxEmptyResponseError(config.agent, {
-								exitCode: 0,
-								stdoutBytes: Buffer.byteLength(stdout),
-								stderrBytes: Buffer.byteLength(stderr),
-								format: outputFormat,
-								durationMs: performance.now() - startedAt,
-								sideEffects: parsed?.sideEffects ?? false,
-								...(parsed?.sessionId ? { sessionId: parsed.sessionId } : {}),
-								...(parsed?.stopReason ? { stopReason: parsed.stopReason } : {}),
-								...(parsed?.usage || quietUsage(stderr) ? { usage: parsed?.usage ?? quietUsage(stderr) } : {}),
-							}),
-						);
-						return;
-					}
-					resolve(text);
-				}),
+						if (code !== 0) {
+							reject(new Error(`${config.agent} via ACPX exited ${code}: ${stderr.slice(0, 300)}`));
+							return;
+						}
+						let text: string | undefined;
+						let parsed: AcpxParsedJsonOutput | undefined;
+						try {
+							if (outputFormat === "json") {
+								parsed = parseAcpxJsonOutput(stdout, config);
+								text = parsed.text;
+							} else {
+								text = stdout.trim();
+							}
+						} catch (error) {
+							reject(error);
+							return;
+						}
+						if (!text) {
+							if (parsed && (!parsed.finalSeen || parsed.sideEffects)) {
+								reject(new Error(`${config.agent} via ACPX JSON output did not include a final response`));
+								return;
+							}
+							reject(
+								new AcpxEmptyResponseError(config.agent, {
+									exitCode: 0,
+									stdoutBytes: Buffer.byteLength(stdout),
+									stderrBytes: Buffer.byteLength(stderr),
+									format: outputFormat,
+									durationMs: performance.now() - startedAt,
+									sideEffects: parsed?.sideEffects ?? false,
+									...(parsed?.sessionId ? { sessionId: parsed.sessionId } : {}),
+									...(parsed?.stopReason ? { stopReason: parsed.stopReason } : {}),
+									...(parsed?.usage || quietUsage(stderr) ? { usage: parsed?.usage ?? quietUsage(stderr) } : {}),
+								}),
+							);
+							return;
+						}
+						resolve(text);
+					},
+					"none",
+				),
 		);
-		child.stdin?.end(prompt);
+		if (!terminationError) child.stdin?.end(prompt);
 	});
 }
 
@@ -1520,45 +1642,74 @@ export function createAcpxProvider(config: AcpxProviderConfig): LlmProvider {
 					);
 				}
 				const attemptConfig = attempt === 0 ? config : { ...config, mode: "exec" as const, session: undefined };
-				try {
-					return await withLlmConcurrency(
-						() => {
-							const acquiredRemainingMs = deadline - performance.now();
-							if (acquiredRemainingMs <= 1) {
-								if (lastEmpty) {
-									throw formatEmptyResponseError(
-										config.agent,
-										lastEmpty.diagnostics,
-										attempt - 1,
-										performance.now() - startedAt,
-									);
-								}
-								throw new Error(
-									`${config.agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`,
+				while (true) {
+					try {
+						const cleanupGeneration = await waitForAcpxCleanupBarrier(
+							attemptConfig.agent,
+							deadline,
+							timeoutMs,
+							signal,
+						);
+						signal?.throwIfAborted();
+						const postCleanupRemainingMs = deadline - performance.now();
+						if (postCleanupRemainingMs <= 1) {
+							if (lastEmpty) {
+								throw formatEmptyResponseError(
+									config.agent,
+									lastEmpty.diagnostics,
+									attempt - 1,
+									performance.now() - startedAt,
 								);
 							}
-							return runAcpxAttempt(attemptConfig, prompt, acquiredRemainingMs, signal);
-						},
-						remainingMs,
-						"acpx",
-						signal,
-					);
-				} catch (error) {
-					if (!(error instanceof AcpxEmptyResponseError)) throw error;
-					lastEmpty = error;
-					if (attempt >= retries) {
-						throw formatEmptyResponseError(config.agent, error.diagnostics, attempt, performance.now() - startedAt);
+							throw new Error(
+								`${config.agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`,
+							);
+						}
+						return await withLlmConcurrency(
+							async () => {
+								signal?.throwIfAborted();
+								const acquiredRemainingMs = deadline - performance.now();
+								if (acquiredRemainingMs <= 1) {
+									if (lastEmpty) {
+										throw formatEmptyResponseError(
+											config.agent,
+											lastEmpty.diagnostics,
+											attempt - 1,
+											performance.now() - startedAt,
+										);
+									}
+									throw new Error(
+										`${config.agent} via ACPX timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`,
+									);
+								}
+								if (acpxCleanupGeneration(attemptConfig.agent) !== cleanupGeneration) {
+									throw ACPX_RETRY_ADMISSION;
+								}
+								return runAcpxAttempt(attemptConfig, prompt, acquiredRemainingMs, signal);
+							},
+							postCleanupRemainingMs,
+							"acpx",
+							signal,
+						);
+					} catch (error) {
+						if (error === ACPX_RETRY_ADMISSION) continue;
+						if (!(error instanceof AcpxEmptyResponseError)) throw error;
+						lastEmpty = error;
+						if (attempt >= retries) {
+							throw formatEmptyResponseError(config.agent, error.diagnostics, attempt, performance.now() - startedAt);
+						}
+						const delayMs = calculateAcpxRetryDelayMs(attempt);
+						logger.warn("inference", "Retrying sterile ACPX empty response", {
+							agent: config.agent,
+							attempt: attempt + 1,
+							delayMs,
+							format: error.diagnostics.format,
+							sessionId: error.diagnostics.sessionId ?? "unknown",
+							stopReason: error.diagnostics.stopReason ?? "unknown",
+						});
+						await waitForAcpxRetry(config.agent, delayMs, deadline, signal);
+						break;
 					}
-					const delayMs = calculateAcpxRetryDelayMs(attempt);
-					logger.warn("inference", "Retrying sterile ACPX empty response", {
-						agent: config.agent,
-						attempt: attempt + 1,
-						delayMs,
-						format: error.diagnostics.format,
-						sessionId: error.diagnostics.sessionId ?? "unknown",
-						stopReason: error.diagnostics.stopReason ?? "unknown",
-					});
-					await waitForAcpxRetry(config.agent, delayMs, deadline, signal);
 				}
 			}
 			throw new Error(`${config.agent} via ACPX retry loop exhausted`);

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -3504,7 +3504,7 @@
     },
     {
       "path": "pipeline/provider.ts",
-      "line": 824,
+      "line": 930,
       "api": "mkdirSync",
       "source": "mkdirSync(isolatedCwd, { recursive: true });",
       "category": "hot-path"


### PR DESCRIPTION
Supersedes #1716 (same-repo branch; contributor glen-tl's commits preserved — rebased + repaired per the review thread there).

## Summary

Prevent detached ACPX/Codex descendants from overlapping same-agent re-admission after normal completion, timeout, or abort, addressing orphaned hook/worker accumulation.

## Changes

- Original work (glen-tl): track cleanup by normalized ACPX agent, gate same-agent re-admission until prior run-scoped cleanup settles, keep unrelated agents eligible for global capacity, start escaped-descendant cleanup at termination, bound cleanup waits, restore Linux detached-child coverage.
- Repair (717fa8014, rebased on main): same-agent admission serialized BEFORE global semaphore acquisition and held through cleanup — closes the TOCTOU where a concurrent second call observed no barrier and launched 39ms behind the first; Darwin tests synchronize on the deferred cleanup barrier; Biome clean; event-loop ledger regenerated for the rebased line numbers.

## Type

- [ ] `feat`
- [x] `fix` — bug fix
- [ ] `refactor`
- [ ] `chore`
- [ ] `perf`
- [ ] `test`

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

None — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Verification

- Focused provider suite 52/52 at head (base 45/45 — includes the four repaired Darwin tests)
- Concurrent-launch TOCTOU regression (serialized starts asserted, unrelated agents still parallel)
- daemon typecheck + build + biome clean; audit test 22/22 at rebased head

## Migration Notes

No schema migrations.