### PR TITLE
fix(daemon): route vector backfill through db owner

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,16 +4,16 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 998 sites
+- Exact ledger inventory: 997 sites
 - Synchronous `withWriteTx()` sites: 66
 - Synchronous `withReadDb()` sites: 109
-- Async-named parent DB sites: 307
+- Async-named parent DB sites: 306
 - Synchronous filesystem/process sites: 516
 - Compile-visible legacy DB sites remaining: 175
   - `withWriteTx`: 66
   - `withReadDb`: 109
 
-The 998-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named parent DB callbacks. The 66 synchronous writes, 109 synchronous reads, and 307 async-named parent DB sites are the complete database-call inventory; 175 compatibility DB operations remain transitional callers for the later migration phase. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 997-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named parent DB callbacks. The 66 synchronous writes, 109 synchronous reads, and 306 async-named parent DB sites are the complete database-call inventory; 175 compatibility DB operations remain transitional callers for the later migration phase. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## A3 Slice 2 migration notes
 

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -68,7 +68,6 @@ import {
 } from "./database-integrity";
 import {
 	closeDbAccessor,
-	backfillVecEmbeddings,
 	DatabaseIntegrityCorruptError,
 	getDbAccessor,
 	getVectorRuntimeStatus,
@@ -2605,16 +2604,30 @@ async function main() {
 								budgetExpired = true;
 								return;
 							}
-							await getDbAccessor().withWriteDbAsync(
-								(db) =>
-									backfillVecEmbeddings(db, activeEmbedding.dimensions, deadlineAt, {
-										maxBatches: 1,
-										batchSize: 500,
-									}),
-								{ siteToken: "daemon.ts:2608", operation: "maintenance.vec-backfill" },
+							const remainingMs = Math.max(1, Math.floor(deadlineAt - Date.now()));
+							if (remainingMs <= 5_000) {
+								budgetExpired = true;
+								return;
+							}
+							const vectorBackfillOwner = dbOwnerClient;
+							if (vectorBackfillOwner === null) return;
+							const backfill = vectorBackfillOwner.submit<{ readonly completed: boolean }>(
+								{
+									kind: "vector_backfill",
+									expectedDimensions: activeEmbedding.dimensions,
+									maxBatches: 1,
+									batchSize: 500,
+								},
+								{
+									operation: "maintenance.vec-backfill",
+									lane: "maintenance",
+									deadlineMs: remainingMs,
+									estimatedWorkUnits: 1,
+								},
 							);
-							// The writer callback is synchronous on this isolate. Yield after
-							// every bounded batch so health and ready can run between slices.
+							await vectorBackfillOwner.awaitResult(backfill, remainingMs);
+							// Yield after every bounded owner batch so health and ready can run
+							// between slices without this isolate executing SQLite writes.
 							await new Promise<void>((resolve) => setImmediate(resolve));
 							if (!(await probePendingVecBackfillWithRetry())) return;
 						}

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -848,7 +848,7 @@ interface LegacyMarkdownFileState {
 async function withWriteTxAsync<T>(fn: (db: WriteDb) => T): Promise<T> {
 	const accessor = getDbAccessor();
 	if (!accessor.withWriteTxAsync) throw new Error("Async database writer is unavailable");
-	return accessor.withWriteTxAsync(fn, { siteToken: "daemon.ts:852" });
+	return accessor.withWriteTxAsync(fn, { siteToken: "daemon.ts:851" });
 }
 
 async function legacyMarkdownFileState(filePath: string): Promise<LegacyMarkdownFileState | null> {
@@ -891,7 +891,7 @@ async function readLegacyMarkdownImportState(filePath: string): Promise<{
 					| undefined;
 				return row ?? null;
 			},
-			{ siteToken: "daemon.ts:874" },
+			{ siteToken: "daemon.ts:873" },
 		);
 	} catch {
 		// Older/unmigrated DBs fall back to the legacy importer behavior.
@@ -968,7 +968,7 @@ async function legacyMarkdownChunkKnown(filePath: string, chunkHash: string): Pr
 					.get(filePath, chunkHash);
 				return row != null;
 			},
-			{ siteToken: "daemon.ts:965" },
+			{ siteToken: "daemon.ts:964" },
 		);
 	} catch {
 		return false;
@@ -1592,7 +1592,7 @@ async function syncAgentRoster(agentsDir: string): Promise<void> {
 				stmt.run(normalized.name, normalized.name, normalized.readPolicy, normalized.policyGroup, now, now);
 			}
 		},
-		{ siteToken: "daemon.ts:1579", operation: "startup.sync-agent-roster", estimatedWorkUnits: roster.length },
+		{ siteToken: "daemon.ts:1578", operation: "startup.sync-agent-roster", estimatedWorkUnits: roster.length },
 	);
 	logger.info("daemon", "Agent roster synced", { count: roster.length });
 }
@@ -1660,7 +1660,7 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 
 	const activeEmbeddingCfg = await getDbAccessor().withReadDbAsync(
 		(db) => resolveActiveEmbeddingConfig(db, memoryCfg.embedding),
-		{ siteToken: "daemon.ts:1662", operation: "startup.resolve-active-embedding" },
+		{ siteToken: "daemon.ts:1661", operation: "startup.resolve-active-embedding" },
 	);
 	configureLlmConcurrency(memoryCfg.pipelineV2.worker.maxLlmConcurrency);
 	logger.info("config", "Resolved embedding config", {
@@ -2459,11 +2459,11 @@ async function main() {
 										.get() as { cnt: number } | undefined;
 									return row?.cnt ?? 0;
 								},
-								{ siteToken: "daemon.ts:2456", operation: "heartbeat.memory-count" },
+								{ siteToken: "daemon.ts:2455", operation: "heartbeat.memory-count" },
 							),
 							listConnectorsAsync(accessor),
 							accessor.withReadDbAsync((db) => getQueuePressureSnapshot(db), {
-								siteToken: "daemon.ts:2466",
+								siteToken: "daemon.ts:2465",
 								operation: "heartbeat.queue-pressure",
 							}),
 						]);
@@ -2558,7 +2558,7 @@ async function main() {
 		if (migrationIntegrityWritesBlocked) return false;
 		const activeEmbedding = await getDbAccessor().withReadDbAsync(
 			(db) => resolveActiveEmbeddingConfig(db, memoryCfg.embedding),
-			{ siteToken: "daemon.ts:2560", operation: "maintenance.vec-backfill-config" },
+			{ siteToken: "daemon.ts:2559", operation: "maintenance.vec-backfill-config" },
 		);
 		return await ownerHasPendingVecBackfill(owner, activeEmbedding.dimensions);
 	};
@@ -2590,7 +2590,7 @@ async function main() {
 					try {
 						const activeEmbedding = await getDbAccessor().withReadDbAsync(
 							(db) => resolveActiveEmbeddingConfig(db, memoryCfg.embedding),
-							{ siteToken: "daemon.ts:2592", operation: "maintenance.vec-backfill-config" },
+							{ siteToken: "daemon.ts:2591", operation: "maintenance.vec-backfill-config" },
 						);
 						if (migrationIntegrityWritesBlocked) return;
 						if (!isVectorRuntimeUsable()) {

--- a/platform/daemon/src/db-owner-client.test.ts
+++ b/platform/daemon/src/db-owner-client.test.ts
@@ -93,6 +93,45 @@ describe("DB owner client", () => {
 		}
 	}
 
+	test("runs vector backfill in bounded owner slices and reaches a terminal iteration", async () => {
+		const database = makeDb();
+		directory = database.directory;
+		const fixture = new Database(database.path);
+		fixture.exec(
+			"CREATE TABLE embeddings (id TEXT PRIMARY KEY, dimensions INTEGER NOT NULL, vector BLOB); CREATE TABLE vec_embeddings (id TEXT PRIMARY KEY, embedding BLOB NOT NULL); CREATE TABLE vec_embeddings_rowids (id TEXT PRIMARY KEY); CREATE TRIGGER vec_embeddings_rowids_after_insert AFTER INSERT ON vec_embeddings BEGIN INSERT OR REPLACE INTO vec_embeddings_rowids (id) VALUES (NEW.id); END",
+		);
+		const vector = Buffer.from(new Float32Array([1, 2]).buffer);
+		const insert = fixture.prepare("INSERT INTO embeddings (id, dimensions, vector) VALUES (?, 2, ?)");
+		for (let index = 0; index < 1_201; index += 1) {
+			insert.run(`embedding-${String(index).padStart(4, "0")}`, index === 600 ? Buffer.from([1]) : vector);
+		}
+		fixture.close();
+
+		client = createDbOwnerClient({ dbPath: database.path });
+		await client.start();
+		for (let iteration = 0; iteration < 4; iteration += 1) {
+			await expect(
+				client.submit<{ readonly completed: boolean }>(
+					{ kind: "vector_backfill", expectedDimensions: 2, maxBatches: 1, batchSize: 500 },
+					{ operation: "maintenance.vector-backfill-regression", lane: "maintenance", deadlineMs: 10_000 },
+				).result,
+			).resolves.toEqual({ completed: true });
+		}
+		const counts = await client.submit<
+			readonly { readonly embeddings: number; readonly vectors: number; readonly quarantined: number }[]
+		>(
+			{
+				kind: "query",
+				statement: {
+					sql: "SELECT (SELECT COUNT(*) FROM embeddings) AS embeddings, (SELECT COUNT(*) FROM vec_embeddings) AS vectors, (SELECT COUNT(*) FROM vec_embeddings_quarantine) AS quarantined",
+					result: "all",
+				},
+			},
+			{ operation: "maintenance.vector-backfill-regression-verify", lane: "read", deadlineMs: 5_000 },
+		).result;
+		expect(counts).toEqual([{ embeddings: 1_201, vectors: 1_200, quarantined: 1 }]);
+	});
+
 	test("keeps the owner alive when sqlite-vec cannot be loaded", async () => {
 		const database = makeDb();
 		directory = database.directory;

--- a/platform/daemon/src/db-owner-protocol.ts
+++ b/platform/daemon/src/db-owner-protocol.ts
@@ -231,6 +231,12 @@ export type DbOwnerRequest =
 	| { readonly kind: "source_artifact_purge"; readonly input: DbOwnerSourceArtifactPurge }
 	| { readonly kind: "source_artifact_upsert"; readonly input: DbOwnerSourceArtifactUpsert }
 	| { readonly kind: "source_artifact_upsert_batch"; readonly input: readonly DbOwnerSourceArtifactUpsert[] }
+	| {
+			readonly kind: "vector_backfill";
+			readonly expectedDimensions: number;
+			readonly maxBatches?: number;
+			readonly batchSize?: number;
+	  }
 	| { readonly kind: "vacuum_conversion" }
 	| { readonly kind: "incremental_vacuum"; readonly pages: number }
 	| { readonly kind: "sleep"; readonly durationMs: number };

--- a/platform/daemon/src/db-owner-worker.ts
+++ b/platform/daemon/src/db-owner-worker.ts
@@ -776,6 +776,18 @@ export function runDbOwnerWorker(): void {
 		if (job.request.kind === "source_artifact_index") return executeSourceArtifactIndex(job.request, context);
 		if (job.request.kind === "source_native_memory_index") return executeNativeMemoryIndex(job.request, context);
 		if (job.request.kind === "source_artifact_purge") return executeSourceArtifactPurge(job.request, context);
+		if (job.request.kind === "vector_backfill") {
+			if (!Number.isInteger(job.request.expectedDimensions) || job.request.expectedDimensions <= 0) {
+				throw new RangeError("DB owner vector backfill dimensions must be a positive integer");
+			}
+			const { backfillVecEmbeddings } = await import("./db-accessor");
+			backfillVecEmbeddings(db as never, job.request.expectedDimensions, context.deadlineAt, {
+				maxBatches: job.request.maxBatches,
+				batchSize: job.request.batchSize,
+			});
+			if (context !== undefined) context.committed = true;
+			return { completed: true };
+		}
 		if (job.request.kind === "vacuum_conversion") {
 			const { convertToIncrementalVacuum } = await import("./db-vacuum");
 			const pauseMs = Number.parseInt(process.env.SIGNET_TEST_DB_OWNER_VACUUM_PAUSE_MS ?? "0", 10);

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,11 +16,11 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(998);
+	expect(baseline).toHaveLength(997);
 	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(66);
 	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(109);
 	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(68);
-	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(3);
+	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(2);
 	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(233);
 });
 
@@ -327,8 +327,8 @@ test("the production TypeScript project cannot import the compatibility module",
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const report = renderReport(baseline, { total: 175, withWriteTx: 66, withReadDb: 109 });
-	expect(report).toContain("Exact ledger inventory: 998 sites");
-	expect(report).toContain("66 synchronous writes, 109 synchronous reads, and 307 async-named parent DB sites");
+	expect(report).toContain("Exact ledger inventory: 997 sites");
+	expect(report).toContain("66 synchronous writes, 109 synchronous reads, and 306 async-named parent DB sites");
 	expect(report).toContain("type boundary");
 	expect(report).not.toContain("1061");
 });

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -354,252 +354,245 @@
     },
     {
       "path": "daemon.ts",
-      "line": 526,
+      "line": 525,
       "api": "existsSync",
       "source": "if (!existsSync(agentsMdPath)) return;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 543,
+      "line": 542,
       "api": "existsSync",
       "source": "const existingFiles = files.filter((f) => existsSync(join(AGENTS_DIR, f.name)));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 571,
+      "line": 570,
       "api": "existsSync",
       "source": "if (!existsSync(identityPath)) return \"\";",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 590,
+      "line": 589,
       "api": "existsSync",
       "source": "if (activeHarnesses.has(\"opencode\") && existsSync(opencodeDir)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 622,
+      "line": 621,
       "api": "existsSync",
       "source": "if (activeHarnesses.has(\"opencode\") && existsSync(opencodeDir)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 629,
+      "line": 628,
       "api": "existsSync",
       "source": "if (existsSync(geminiDir)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 634,
+      "line": 633,
       "api": "existsSync",
       "source": "if (existsSync(settingsPath)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 635,
+      "line": 634,
       "api": "readFileSync",
       "source": "const parsed = JSON.parse(readFileSync(settingsPath, \"utf8\"));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 655,
+      "line": 654,
       "api": "existsSync",
       "source": "if (!existsSync(targetPath)) continue;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 852,
+      "line": 851,
       "api": "withWriteTxAsync",
-      "source": "return accessor.withWriteTxAsync(fn, { siteToken: \"daemon.ts:852\" });",
+      "source": "return accessor.withWriteTxAsync(fn, { siteToken: \"daemon.ts:851\" });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 874,
+      "line": 873,
       "api": "withReadDbAsync",
       "source": "return await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 927,
+      "line": 926,
       "api": "withWriteTxAsync",
       "source": "await withWriteTxAsync((db) => {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 965,
+      "line": 964,
       "api": "withReadDbAsync",
       "source": "return await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 987,
+      "line": 986,
       "api": "withWriteTxAsync",
       "source": "await withWriteTxAsync((db) => {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1199,
+      "line": 1198,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDir)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1564,
+      "line": 1563,
       "api": "existsSync",
       "source": "if (!existsSync(p)) continue;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1566,
+      "line": 1565,
       "api": "readFileSync",
       "source": "const yaml = parseSimpleYaml(readFileSync(p, \"utf-8\")) as Record<string, unknown>;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1579,
+      "line": 1578,
       "api": "withWriteTxAsync",
       "source": "await db.withWriteTxAsync(",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1606,
+      "line": 1605,
       "api": "existsSync",
       "source": "if (!existsSync(path)) continue;",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1608,
+      "line": 1607,
       "api": "readFileSync",
       "source": "const routing = parseRoutingConfig(parseSimpleYaml(readFileSync(path, \"utf-8\")));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1662,
+      "line": 1661,
       "api": "withReadDbAsync",
       "source": "const activeEmbeddingCfg = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1996,
+      "line": 1995,
       "api": "existsSync",
       "source": "if (existsSync(PID_FILE)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 1998,
+      "line": 1997,
       "api": "unlinkSync",
       "source": "unlinkSync(PID_FILE);",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2139,
+      "line": 2138,
       "api": "mkdirSync",
       "source": "mkdirSync(DAEMON_DIR, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2140,
+      "line": 2139,
       "api": "mkdirSync",
       "source": "mkdirSync(LOG_DIR, { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2141,
+      "line": 2140,
       "api": "mkdirSync",
       "source": "mkdirSync(dirname(MEMORY_DB), { recursive: true });",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2298,
+      "line": 2297,
       "api": "existsSync",
       "source": "const workerPath = existsSync(bundled)",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2373,
+      "line": 2372,
       "api": "writeFileSync",
       "source": "writeFileSync(PID_FILE, process.pid.toString());",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2456,
+      "line": 2455,
       "api": "withReadDbAsync",
       "source": "accessor.withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2466,
+      "line": 2465,
       "api": "withReadDbAsync",
       "source": "accessor.withReadDbAsync((db) => getQueuePressureSnapshot(db), {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2560,
+      "line": 2559,
       "api": "withReadDbAsync",
       "source": "const activeEmbedding = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2592,
+      "line": 2591,
       "api": "withReadDbAsync",
       "source": "const activeEmbedding = await getDbAccessor().withReadDbAsync(",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 2608,
-      "api": "withWriteDbAsync",
-      "source": "await getDbAccessor().withWriteDbAsync(",
-      "category": "hot-path"
-    },
-    {
-      "path": "daemon.ts",
-      "line": 3090,
+      "line": 3103,
       "api": "existsSync",
       "source": "if (existsSync(healthStampPath)) {",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3091,
+      "line": 3104,
       "api": "readFileSync",
       "source": "const prev = JSON.parse(readFileSync(healthStampPath, \"utf-8\"));",
       "category": "hot-path"
     },
     {
       "path": "daemon.ts",
-      "line": 3094,
+      "line": 3107,
       "api": "writeFileSync",
       "source": "writeFileSync(",
       "category": "hot-path"
@@ -1005,7 +998,7 @@
     },
     {
       "path": "db-owner-worker.ts",
-      "line": 787,
+      "line": 799,
       "api": "writeFileSync",
       "source": "if (activeFile) writeFileSync(activeFile, `${Date.now()}\\n`);",
       "category": "hot-path"


### PR DESCRIPTION
## Summary
- Route post-ready vector embedding backfill through the DB-owner maintenance lane instead of running synchronous SQLite writes in the daemon isolate.
- Keep each owner operation bounded to one batch and preserve the existing deadline reserve so health and ready work can run between slices.
- Add a 1,201-row regression fixture with one malformed vector, four terminal iterations, and exact vector/quarantine counts.

## Diagnosis
The isolated inspector reproduction showed the allocation/GC wedge in backfillVecEmbeddings, reached through daemon.ts:2608 and the parent write queue. Concurrent native-source indexing then amplified SQLite lock contention and owner deadline failures. Bun 1.4.0 does not expose the HeapProfiler CDP domain, so the CPU profile was the available runtime allocation evidence.

## Verification
- bun test src/db-owner-client.test.ts --timeout 30000 (37 pass)
- bun test src/db-owner-client.test.ts -t "runs vector backfill" --timeout 30000 (1 pass)
- bun test src/db-accessor.test.ts -t "vec_embeddings schema repair" --timeout 30000 (8 pass)
- bun test src/native-memory-sources.test.ts --timeout 30000 (66 pass)
- bunx biome check on all four changed files
- bun run --filter @signet/daemon typecheck
- bun run --filter @signet/daemon build
- bun scripts/audit-event-loop-contract.ts (pass)
- Mutation run with the owner vector-backfill branch removed: the new regression test failed at the owner result assertion; fixed code then passed.

## Readiness checklist
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) (internal maintenance routing; no spec or dependency changes)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints (not applicable; no endpoint changes)
- [x] Docs updated for API/spec/status changes (not applicable; internal daemon routing only)
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Scope
No live daemon, user database, or real source roots were modified. The isolated reproduction used a copied database and read-only source roots.