### PR TITLE
fix(daemon): owner-route traversal candidate hydration

### DIFF
--- a/docs/event-loop-contract-audit.md
+++ b/docs/event-loop-contract-audit.md
@@ -4,16 +4,16 @@ This report is generated from the deterministic migration ledger in `scripts/eve
 
 ## Current inventory
 
-- Exact ledger inventory: 1000 sites
+- Exact ledger inventory: 999 sites
 - Synchronous `withWriteTx()` sites: 66
-- Synchronous `withReadDb()` sites: 108
+- Synchronous `withReadDb()` sites: 107
 - Async-named parent DB sites: 310
 - Synchronous filesystem/process sites: 516
-- Compile-visible legacy DB sites remaining: 174
+- Compile-visible legacy DB sites remaining: 173
   - `withWriteTx`: 66
-  - `withReadDb`: 108
+  - `withReadDb`: 107
 
-The 1,000-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named parent DB callbacks. The 66 synchronous writes, 108 synchronous reads, and 310 async-named parent DB sites are the complete database-call inventory; 174 compatibility DB operations remain transitional callers for the later migration phase. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
+The 999-site inventory excludes test, benchmark, generated, and `__tests__` fixtures and includes every synchronous filesystem, process, and database call, including async-named parent DB callbacks. The 66 synchronous writes, 107 synchronous reads, and 310 async-named parent DB sites are the complete database-call inventory; 173 compatibility DB operations remain transitional callers for the later migration phase. Those compatibility calls are marked with `@ts-expect-error LEGACY_SYNC_DB_ACCESS`, so the compiler reports every remaining site without forcing this phase to migrate them.
 
 ## A3 Slice 2 migration notes
 
@@ -30,4 +30,4 @@ The converted async sites are distributed as follows: document-worker (18), drea
 
 The structural boundary makes statically-resolved imports from the production source tree impossible: TypeScript reports TS6059 before aliases or computed member calls can use the compatibility type. The production bundle also only starts from source entrypoints, so this compatibility module is not a shipped production artifact.
 
-A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 174 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 66 write and 108 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.
+A runtime-computed require() or import() can still reach a source-tree file when a development process deliberately constructs the path. TypeScript cannot prove an unresolved runtime string, and the AST audit remains the supplementary guard for that source-execution residual. This Phase A boundary intentionally leaves the synchronous methods on the runtime accessor so the 173 transitional callers keep working. The deferred final cleanup is explicit: first land the six A3 caller-migration slices that convert all 66 write and 107 read markers to async, then remove the runtime synchronous methods and compatibility module in a follow-up.

--- a/platform/daemon/src/memory-candidates.test.ts
+++ b/platform/daemon/src/memory-candidates.test.ts
@@ -112,6 +112,29 @@ describe("fetchTraversalCandidates (#1250)", () => {
 		expect(loopBreaths).toBeGreaterThan(0);
 	});
 
+	test("routes traversal hydration through the DB owner, not the parent DB seams", async () => {
+		insertMemory("memory-traversal-owner", "agent-a", 0.9);
+		const accessor = getDbAccessor() as unknown as {
+			withReadDb: (...args: never[]) => unknown;
+			withReadDbAsync: (...args: never[]) => Promise<unknown>;
+		};
+		const originalWithReadDb = accessor.withReadDb;
+		const originalWithReadDbAsync = accessor.withReadDbAsync;
+		accessor.withReadDb = () => {
+			throw new Error("traversal hydration crossed the parent sync DB seam");
+		};
+		accessor.withReadDbAsync = async () => {
+			throw new Error("traversal hydration crossed the parent async DB seam");
+		};
+		try {
+			const rows = await fetchTraversalCandidates(dbPath, ["memory-traversal-owner"], "agent-a");
+			expect(rows.map((row) => row.id)).toEqual(["memory-traversal-owner"]);
+		} finally {
+			accessor.withReadDb = originalWithReadDb;
+			accessor.withReadDbAsync = originalWithReadDbAsync;
+		}
+	});
+
 	test("routes the candidate pool through the DB owner, not the parent DB seams", async () => {
 		insertMemory("memory-owner", "agent-a", 0.9);
 		const accessor = getDbAccessor() as unknown as {

--- a/platform/daemon/src/memory-candidates.ts
+++ b/platform/daemon/src/memory-candidates.ts
@@ -142,50 +142,77 @@ export async function fetchTraversalCandidates(
 	}
 
 	try {
+		const owner = await getDbOwner(memoryDbPath);
+		const safetyTable = await ownerReadOne<{ readonly name: string }>(
+			owner,
+			"SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+			["memory_content_safety"],
+			{
+				operation: "session-start.traversal-candidate-safety-table",
+				lane: "read",
+				deadlineMs: 5_000,
+				estimatedWorkUnits: 1,
+			},
+		);
+		const hasSafetyTable = safetyTable !== null;
+		const safetyJoin = hasSafetyTable
+			? " LEFT JOIN memory_content_safety safety ON safety.agent_id = ? AND safety.source_kind = 'memory' AND safety.source_id = m.id"
+			: "";
+		const safetySelect = hasSafetyTable
+			? ", safety.status AS safety_status, safety.context_eligible AS safety_context_eligible"
+			: ", NULL AS safety_status, NULL AS safety_context_eligible";
 		const rows: ScoredMemory[] = [];
 		const yieldBetweenBatches = yieldEvery(1);
 
 		for (let offset = 0; offset < boundedMemoryIds.length; offset += TRAVERSAL_CANDIDATE_BATCH_SIZE) {
 			const batch = boundedMemoryIds.slice(offset, offset + TRAVERSAL_CANDIDATE_BATCH_SIZE);
 			const placeholders = batch.map(() => "?").join(", ");
-			// @ts-expect-error LEGACY_SYNC_DB_ACCESS: withReadDb migration site
-			const batchRows: ScoredMemory[] = getDbAccessor().withReadDb((db: import("./db-accessor").ReadDb) => {
-				const queried = db
-					.prepare(
-						`SELECT
-						 m.id,
-						 m.content,
-						 m.type,
+			const batchRows = await ownerReadAll<
+				ScoredMemory & {
+					readonly safety_status: string | null;
+					readonly safety_context_eligible: number | null;
+				}
+			>(
+				owner,
+				`SELECT
+					 m.id,
+					 m.content,
+					 m.type,
+					 m.importance,
+					 m.tags,
+					 m.pinned,
+					 m.project,
+					 m.created_at,
+					 COALESCE(m.access_count, 0) AS access_count,
+					 COALESCE(
+						 (SELECT MAX(ea.importance)
+						  FROM entity_attributes ea
+						  WHERE ea.memory_id = m.id
+						    AND ea.agent_id = ?
+						    AND ea.status = 'active'),
 						 m.importance,
-						 m.tags,
-						 m.pinned,
-						 m.project,
-						 m.created_at,
-						 COALESCE(m.access_count, 0) AS access_count,
-						 COALESCE(
-							(SELECT MAX(ea.importance)
-							 FROM entity_attributes ea
-							 WHERE ea.memory_id = m.id
-							   AND ea.agent_id = ?
-							   AND ea.status = 'active'),
-							 m.importance,
-							 0.5
-						 ) AS effScore
-					 FROM memories m
-					 WHERE m.id IN (${placeholders})
-					   AND m.is_deleted = 0`,
-					)
-					.all(agentId, ...batch) as unknown as ScoredMemory[];
-				return queried.filter((row) =>
-					isMemoryContentContextEligible(db, {
-						agentId,
-						sourceKind: "memory",
-						sourceId: row.id,
-						content: row.content,
-					}),
-				);
-			}, "memory-candidates.ts:152");
-			rows.push(...batchRows);
+						 0.5
+					 ) AS effScore${safetySelect}
+				 FROM memories m${safetyJoin}
+				 WHERE m.id IN (${placeholders})
+				   AND m.is_deleted = 0`,
+				hasSafetyTable ? [agentId, agentId, ...batch] : [agentId, ...batch],
+				{
+					operation: "session-start.traversal-candidate-hydration",
+					lane: "read",
+					deadlineMs: 5_000,
+					estimatedWorkUnits: Math.max(1, Math.min(150, batch.length * 3)),
+				},
+			);
+			rows.push(
+				...batchRows.filter(
+					(row) =>
+						scanMemoryContent(row.content).contextEligible &&
+						(!hasSafetyTable ||
+							row.safety_status === null ||
+							(row.safety_status === "clean" && row.safety_context_eligible === 1)),
+				),
+			);
 			await yieldBetweenBatches();
 		}
 

--- a/platform/daemon/src/memory-candidates.ts
+++ b/platform/daemon/src/memory-candidates.ts
@@ -351,7 +351,7 @@ export function getPredictedContextMemories(
 						content: row.transcript,
 					}),
 				);
-			}, "memory-candidates.ts:310");
+			}, "memory-candidates.ts:337");
 
 		if (transcriptRows.length === 0) return [];
 
@@ -432,7 +432,7 @@ export function getPredictedContextMemories(
 							content: row.content,
 						}),
 					),
-				"memory-candidates.ts:372",
+				"memory-candidates.ts:399",
 			);
 
 		const selected: ScoredMemory[] = [];
@@ -479,7 +479,7 @@ export function getRecentMemories(memoryDbPath: string, limit: number, recencyBi
 			return (db.prepare(query).all(limit) as unknown as Array<SimpleMemory>).filter(
 				(row) => scanMemoryContent(row.content).contextEligible,
 			);
-		}, "memory-candidates.ts:438");
+		}, "memory-candidates.ts:465");
 
 		return rows.map((r) => ({
 			id: r.id,
@@ -514,7 +514,7 @@ export function getMemoriesSince(memoryDbPath: string, sinceMs: number, limit: n
 			`)
 				.all(sinceIso, limit) as unknown as Array<SimpleMemory>;
 			return rows.filter((row) => scanMemoryContent(row.content).contextEligible);
-		}, "memory-candidates.ts:479");
+		}, "memory-candidates.ts:506");
 
 		return rows.map((r) => ({
 			id: r.id,

--- a/scripts/audit-event-loop-contract.test.ts
+++ b/scripts/audit-event-loop-contract.test.ts
@@ -16,9 +16,9 @@ import {
 
 test("the deterministic ledger retains the exact current source inventory", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
-	expect(baseline).toHaveLength(1000);
+	expect(baseline).toHaveLength(999);
 	expect(baseline.filter((site) => site.api === "withWriteTx")).toHaveLength(66);
-	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(108);
+	expect(baseline.filter((site) => site.api === "withReadDb")).toHaveLength(107);
 	expect(baseline.filter((site) => site.api === "withWriteTxAsync")).toHaveLength(68);
 	expect(baseline.filter((site) => site.api === "withWriteDbAsync")).toHaveLength(2);
 	expect(baseline.filter((site) => site.api === "withReadDbAsync")).toHaveLength(237);
@@ -327,8 +327,8 @@ test("the production TypeScript project cannot import the compatibility module",
 test("the generated report describes the type boundary and transitional counts", () => {
 	const baseline = loadBaseline(resolve("scripts/event-loop-contract-baseline.json"));
 	const report = renderReport(baseline, { total: 175, withWriteTx: 66, withReadDb: 109 });
-	expect(report).toContain("Exact ledger inventory: 1000 sites");
-	expect(report).toContain("66 synchronous writes, 108 synchronous reads, and 310 async-named parent DB sites");
+	expect(report).toContain("Exact ledger inventory: 999 sites");
+	expect(report).toContain("66 synchronous writes, 107 synchronous reads, and 310 async-named parent DB sites");
 	expect(report).toContain("type boundary");
 	expect(report).not.toContain("1061");
 });

--- a/scripts/event-loop-contract-baseline.json
+++ b/scripts/event-loop-contract-baseline.json
@@ -1964,63 +1964,56 @@
     },
     {
       "path": "memory-candidates.ts",
-      "line": 152,
-      "api": "withReadDb",
-      "source": "const batchRows: ScoredMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
-      "category": "hot-path"
-    },
-    {
-      "path": "memory-candidates.ts",
-      "line": 214,
+      "line": 241,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return [];",
       "category": "hot-path"
     },
     {
       "path": "memory-candidates.ts",
-      "line": 302,
+      "line": 329,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return [];",
       "category": "hot-path"
     },
     {
       "path": "memory-candidates.ts",
-      "line": 310,
+      "line": 337,
       "api": "withReadDb",
       "source": "getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
       "path": "memory-candidates.ts",
-      "line": 372,
+      "line": 399,
       "api": "withReadDb",
       "source": "getDbAccessor().withReadDb(",
       "category": "hot-path"
     },
     {
       "path": "memory-candidates.ts",
-      "line": 434,
+      "line": 461,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return [];",
       "category": "hot-path"
     },
     {
       "path": "memory-candidates.ts",
-      "line": 438,
+      "line": 465,
       "api": "withReadDb",
       "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"
     },
     {
       "path": "memory-candidates.ts",
-      "line": 474,
+      "line": 501,
       "api": "existsSync",
       "source": "if (!existsSync(memoryDbPath)) return [];",
       "category": "hot-path"
     },
     {
       "path": "memory-candidates.ts",
-      "line": 479,
+      "line": 506,
       "api": "withReadDb",
       "source": "const rows: SimpleMemory[] = getDbAccessor().withReadDb((db: import(\"./db-accessor\").ReadDb) => {",
       "category": "hot-path"

--- a/scripts/legacy-sync-db-baseline.json
+++ b/scripts/legacy-sync-db-baseline.json
@@ -2,8 +2,8 @@
 	"version": 1,
 	"generatedFrom": "bun scripts/legacy-sync-db-baseline.ts",
 	"markedCallsites": {
-		"total": 174,
-		"withReadDb": 108,
+		"total": 173,
+		"withReadDb": 107,
 		"withWriteTx": 66
 	}
 }


### PR DESCRIPTION
## Summary

Owner-routes traversal candidate hydration (loop-3 fix): the session-start hook path no longer runs synchronous candidate queries on the parent. Loops 1 (backfillVecEmbeddings, #1726) and 2 (getAllScoredCandidates, #1727) are dead; this removes the remaining sync hydration sibling in the same path.

## Changes

- memory-candidates.ts: traversal candidate hydration through the DB owner (read lane, bounded, site-tokened); handleSessionStart awaits the boundary.
- Legacy site tokens realigned to current call lines (337/399/465/506); both contract baselines regenerated; ratchet 174 -> 173.

## Type

- [ ] `feat`
- [x] `fix` — bug fix
- [ ] `refactor`
- [ ] `chore`
- [ ] `perf`
- [ ] `test`

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

None — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Verification

- Focused traversal tests green; audit suite 22/22; daemon tsc clean; Biome clean
- Ratchet: 174 -> 173 (one sync site eliminated)

## Migration Notes

No schema migrations.